### PR TITLE
[CI] CI 실패 지점 가독성 개선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,13 @@ jobs:
       deploy: ${{ steps.filter.outputs.deploy }}
 
     steps:
-      - name: Checkout
+      - name: Changes / Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Detect changed paths
+      - name: Changes / Detect changed paths and CI areas
         id: filter
         shell: bash
         env:
@@ -64,24 +64,24 @@ jobs:
           bash tools/ci/detect-changed-paths.sh changed-files.txt
 
   repository-contracts:
-    name: Repository Contracts
+    name: Repository CI
     runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
 
     steps:
-      - name: Checkout
+      - name: Repository CI / Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Set up Node.js
+      - name: Repository CI / Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
 
-      - name: Validate whitespace
+      - name: Repository CI / Validate whitespace
         shell: bash
         run: |
           set -euo pipefail
@@ -91,13 +91,13 @@ jobs:
             git diff-tree --check --root HEAD
           fi
 
-      - name: Validate repository contracts
+      - name: Repository CI / Run contract tests
         run: node --test tools/ci/*.test.mjs
 
-      - name: Validate issue forms
+      - name: Repository CI / Validate issue forms
         run: ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/ISSUE_TEMPLATE/*.yml
 
-      - name: Validate tracked Markdown policy
+      - name: Repository CI / Validate tracked Markdown policy
         shell: bash
         run: |
           set -euo pipefail
@@ -108,7 +108,7 @@ jobs:
             exit 1
           fi
 
-      - name: Validate local agent docs are not tracked
+      - name: Repository CI / Validate local agent docs are not tracked
         shell: bash
         run: |
           set -euo pipefail
@@ -120,18 +120,18 @@ jobs:
           fi
 
   backend:
-    name: Backend
+    name: Backend CI
     runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.backend == 'true' }}
 
     steps:
-      - name: Checkout
+      - name: Backend CI / Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
-      - name: Detect backend scaffold
+      - name: Backend CI / Detect backend scaffold
         id: scaffold
         shell: bash
         run: |
@@ -144,7 +144,7 @@ jobs:
             echo "Backend scaffold not found; skipping backend checks."
           fi
 
-      - name: Set up Java
+      - name: Backend CI / Set up Java
         if: ${{ steps.scaffold.outputs.present == 'true' }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
@@ -152,24 +152,24 @@ jobs:
           java-version: "21"
           cache: gradle
 
-      - name: Run backend checks
+      - name: Backend CI / Run Gradle checks
         if: ${{ steps.scaffold.outputs.present == 'true' }}
         working-directory: backend
         run: ./gradlew check --no-daemon
 
-  mobile:
-    name: Mobile
+  mobile-app:
+    name: Mobile App CI
     runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.mobile == 'true' }}
 
     steps:
-      - name: Checkout
+      - name: Mobile App CI / Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
-      - name: Detect Flutter mobile scaffold
+      - name: Mobile App CI / Detect Flutter scaffold
         id: scaffold
         shell: bash
         run: |
@@ -181,14 +181,14 @@ jobs:
             echo "Flutter mobile scaffold not found; skipping mobile checks."
           fi
 
-      - name: Set up Flutter
+      - name: Mobile App CI / Set up Flutter
         if: ${{ steps.scaffold.outputs.present == 'true' }}
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
           cache: true
 
-      - name: Run Flutter checks
+      - name: Mobile App CI / Run Flutter analyzer and tests
         if: ${{ steps.scaffold.outputs.present == 'true' }}
         working-directory: apps/mobile
         shell: bash
@@ -199,18 +199,18 @@ jobs:
           flutter test
 
   android:
-    name: Android
+    name: Android CI
     runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.android == 'true' }}
 
     steps:
-      - name: Checkout
+      - name: Android CI / Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
-      - name: Detect Android scaffold
+      - name: Android CI / Detect Android scaffold
         id: scaffold
         shell: bash
         run: |
@@ -222,7 +222,7 @@ jobs:
             echo "Android scaffold not found; skipping Android checks."
           fi
 
-      - name: Set up Java
+      - name: Android CI / Set up Java
         if: ${{ steps.scaffold.outputs.present == 'true' }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
@@ -230,14 +230,14 @@ jobs:
           java-version: "21"
           cache: gradle
 
-      - name: Set up Flutter
+      - name: Android CI / Set up Flutter
         if: ${{ steps.scaffold.outputs.present == 'true' }}
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
           cache: true
 
-      - name: Build Flutter Android debug app
+      - name: Android CI / Build Flutter Android debug APK
         if: ${{ steps.scaffold.outputs.present == 'true' }}
         working-directory: apps/mobile
         shell: bash
@@ -247,18 +247,18 @@ jobs:
           flutter build apk --debug
 
   ios:
-    name: iOS
+    name: iOS CI
     runs-on: macos-latest
     needs: changes
     if: ${{ needs.changes.outputs.ios == 'true' }}
 
     steps:
-      - name: Checkout
+      - name: iOS CI / Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
-      - name: Detect iOS scaffold
+      - name: iOS CI / Detect iOS scaffold
         id: scaffold
         shell: bash
         run: |
@@ -270,14 +270,14 @@ jobs:
             echo "iOS scaffold not found; skipping iOS checks."
           fi
 
-      - name: Set up Flutter
+      - name: iOS CI / Set up Flutter
         if: ${{ steps.scaffold.outputs.present == 'true' }}
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
           cache: true
 
-      - name: Build Flutter iOS simulator app
+      - name: iOS CI / Build Flutter iOS simulator app
         if: ${{ steps.scaffold.outputs.present == 'true' }}
         working-directory: apps/mobile
         shell: bash

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -34,6 +34,22 @@ test("ci enforces README-only markdown and local agent file policy", () => {
   assert.match(workflow, /Unexpected tracked local agent file/);
 });
 
+test("ci job and step names identify failure areas clearly", () => {
+  const workflow = read(".github/workflows/ci.yml");
+
+  assert.match(workflow, /name: Changes/);
+  assert.match(workflow, /name: Repository CI/);
+  assert.match(workflow, /name: Backend CI/);
+  assert.match(workflow, /name: Mobile App CI/);
+  assert.match(workflow, /name: Android CI/);
+  assert.match(workflow, /name: iOS CI/);
+  assert.match(workflow, /Repository CI \/ Run contract tests/);
+  assert.match(workflow, /Backend CI \/ Detect backend scaffold/);
+  assert.match(workflow, /Mobile App CI \/ Run Flutter analyzer and tests/);
+  assert.match(workflow, /Android CI \/ Build Flutter Android debug APK/);
+  assert.match(workflow, /iOS CI \/ Build Flutter iOS simulator app/);
+});
+
 test("pull request template is tracked with review and CD gates", () => {
   const template = read(".github/pull_request_template.md");
 


### PR DESCRIPTION
## 관련 이슈

close #1

## 작업 배경

CI 실패가 발생했을 때 GitHub Actions 화면에서 실패 영역을 바로 읽을 수 있도록 job과 step 이름을 정리했습니다. 앞으로 backend, Flutter 공통 앱 코드, Android 빌드, iOS 빌드가 늘어날수록 실패 위치를 빠르게 좁히는 게 중요합니다.

## 작업 내용

- repository 정책 검증 job 이름을 `Repository CI`로 정리했습니다.
- Flutter 공통 앱 코드 검증 job을 `Mobile App CI`로 명확히 표시했습니다.
- backend, Android, iOS job 이름을 각각 `Backend CI`, `Android CI`, `iOS CI`로 정리했습니다.
- 주요 step 이름에 영역 prefix를 붙여 실패 단계가 Actions 화면에서 바로 보이게 했습니다.
- CI 계약 테스트에 job/step 이름 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/*.test.mjs`: 9개 테스트 통과
  - `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/ISSUE_TEMPLATE/*.yml`: 모든 이슈 템플릿 파싱 통과
  - `git diff --check HEAD`: whitespace 문제 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `.github/workflows/ci.yml`의 job 이름이 GitHub ruleset required check 이름과 일치해야 합니다.
  - `Mobile App CI`는 Flutter 공통 코드 검증이고, `Android CI`/`iOS CI`는 플랫폼 빌드 검증입니다.

## 리스크

- GitHub required status check 이름이 바뀌므로 ruleset도 같은 이름으로 맞춰야 합니다. 현재 ruleset은 `Repository CI`, `Backend CI`, `Mobile App CI`, `Android CI`, `iOS CI`로 갱신했습니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
