### PR TITLE
[Feat] 운영사·노선·역 마스터 조회 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/common/error/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/easysubway/common/error/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.easysubway.common.error;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+	public ResourceNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/easysubway/common/web/ApiResponse.java
+++ b/backend/src/main/java/com/easysubway/common/web/ApiResponse.java
@@ -1,8 +1,15 @@
 package com.easysubway.common.web;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ApiResponse<T>(boolean success, T data, String message) {
 
 	public static <T> ApiResponse<T> ok(T data) {
 		return new ApiResponse<>(true, data, null);
+	}
+
+	public static <T> ApiResponse<T> fail(String message) {
+		return new ApiResponse<>(false, null, message);
 	}
 }

--- a/backend/src/main/java/com/easysubway/common/web/CommonExceptionHandler.java
+++ b/backend/src/main/java/com/easysubway/common/web/CommonExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.easysubway.common.web;
+
+import com.easysubway.common.error.ResourceNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+class CommonExceptionHandler {
+
+	@ExceptionHandler(ResourceNotFoundException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	ApiResponse<Void> handleResourceNotFound(ResourceNotFoundException exception) {
+		return ApiResponse.fail(exception.getMessage());
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
@@ -1,0 +1,197 @@
+package com.easysubway.transit.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.transit.application.port.in.StationSearchCommand;
+import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
+import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationLineSummary;
+import com.easysubway.transit.domain.StationWithLines;
+import com.easysubway.transit.domain.SubwayLine;
+import com.easysubway.transit.domain.TransitOperator;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class TransitMasterController {
+
+	private final TransitMasterQueryUseCase transitMasterQueryUseCase;
+
+	TransitMasterController(TransitMasterQueryUseCase transitMasterQueryUseCase) {
+		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
+	}
+
+	@GetMapping("/api/v1/operators")
+	ApiResponse<List<TransitOperatorResponse>> operators() {
+		List<TransitOperatorResponse> response = transitMasterQueryUseCase.listOperators()
+			.stream()
+			.map(TransitOperatorResponse::from)
+			.toList();
+
+		return ApiResponse.ok(response);
+	}
+
+	@GetMapping("/api/v1/lines")
+	ApiResponse<List<SubwayLineResponse>> lines(
+		@RequestParam(required = false) String operatorId
+	) {
+		List<SubwayLineResponse> response = transitMasterQueryUseCase.listLines(operatorId)
+			.stream()
+			.map(SubwayLineResponse::from)
+			.toList();
+
+		return ApiResponse.ok(response);
+	}
+
+	@GetMapping("/api/v1/stations")
+	ApiResponse<List<StationSummaryResponse>> stations(
+		@RequestParam(required = false) String query,
+		@RequestParam(required = false) String lineId
+	) {
+		List<StationSummaryResponse> response = transitMasterQueryUseCase
+			.searchStations(new StationSearchCommand(query, lineId))
+			.stream()
+			.map(StationSummaryResponse::from)
+			.toList();
+
+		return ApiResponse.ok(response);
+	}
+
+	@GetMapping("/api/v1/stations/{stationId}")
+	ApiResponse<StationDetailResponse> station(@PathVariable String stationId) {
+		return ApiResponse.ok(StationDetailResponse.from(transitMasterQueryUseCase.getStation(stationId)));
+	}
+
+	record TransitOperatorResponse(
+		String id,
+		String name,
+		String region,
+		String websiteUrl,
+		String contactUrl,
+		DataSourceType dataSourceType,
+		boolean active
+	) {
+
+		static TransitOperatorResponse from(TransitOperator operator) {
+			return new TransitOperatorResponse(
+				operator.id(),
+				operator.name(),
+				operator.region(),
+				operator.websiteUrl(),
+				operator.contactUrl(),
+				operator.dataSourceType(),
+				operator.active()
+			);
+		}
+	}
+
+	record SubwayLineResponse(
+		String id,
+		String operatorId,
+		String name,
+		String color,
+		String region,
+		String lineCode,
+		boolean active
+	) {
+
+		static SubwayLineResponse from(SubwayLine line) {
+			return new SubwayLineResponse(
+				line.id(),
+				line.operatorId(),
+				line.name(),
+				line.color(),
+				line.region(),
+				line.lineCode(),
+				line.active()
+			);
+		}
+	}
+
+	record StationSummaryResponse(
+		String id,
+		String nameKo,
+		String nameEn,
+		String region,
+		DataQualityLevel dataQualityLevel,
+		LocalDate lastVerifiedAt,
+		List<StationLineResponse> lines
+	) {
+
+		static StationSummaryResponse from(StationWithLines stationWithLines) {
+			Station station = stationWithLines.station();
+			return new StationSummaryResponse(
+				station.id(),
+				station.nameKo(),
+				station.nameEn(),
+				station.region(),
+				station.dataQualityLevel(),
+				station.lastVerifiedAt(),
+				stationWithLines.lines()
+					.stream()
+					.map(StationLineResponse::from)
+					.toList()
+			);
+		}
+	}
+
+	record StationDetailResponse(
+		String id,
+		String nameKo,
+		String nameEn,
+		String region,
+		BigDecimal latitude,
+		BigDecimal longitude,
+		DataQualityLevel dataQualityLevel,
+		LocalDate lastVerifiedAt,
+		List<StationLineResponse> lines
+	) {
+
+		static StationDetailResponse from(StationWithLines stationWithLines) {
+			Station station = stationWithLines.station();
+			return new StationDetailResponse(
+				station.id(),
+				station.nameKo(),
+				station.nameEn(),
+				station.region(),
+				station.latitude(),
+				station.longitude(),
+				station.dataQualityLevel(),
+				station.lastVerifiedAt(),
+				stationWithLines.lines()
+					.stream()
+					.map(StationLineResponse::from)
+					.toList()
+			);
+		}
+	}
+
+	record StationLineResponse(
+		String id,
+		String operatorId,
+		String name,
+		String color,
+		String stationCode,
+		int sequence,
+		String platformInfo
+	) {
+
+		static StationLineResponse from(StationLineSummary line) {
+			return new StationLineResponse(
+				line.id(),
+				line.operatorId(),
+				line.name(),
+				line.color(),
+				line.stationCode(),
+				line.sequence(),
+				line.platformInfo()
+			);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -1,0 +1,93 @@
+package com.easysubway.transit.adapter.out.persistence;
+
+import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.SubwayLine;
+import com.easysubway.transit.domain.TransitOperator;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryTransitMasterRepository implements LoadTransitMasterPort {
+
+	private static final List<TransitOperator> OPERATORS = List.of(
+		new TransitOperator(
+			"seoul-metro",
+			"서울교통공사",
+			"수도권",
+			"https://www.seoulmetro.co.kr",
+			"https://www.seoulmetro.co.kr/kr/customerMain.do",
+			DataSourceType.OFFICIAL_FILE,
+			true
+		),
+		new TransitOperator(
+			"korail",
+			"한국철도공사",
+			"수도권",
+			"https://www.letskorail.com",
+			"https://info.korail.com",
+			DataSourceType.OFFICIAL_FILE,
+			true
+		)
+	);
+
+	private static final List<SubwayLine> LINES = List.of(
+		new SubwayLine("seoul-4", "seoul-metro", "수도권 4호선", "#00A5DE", "수도권", "4", true),
+		new SubwayLine("suin-bundang", "korail", "수인분당선", "#F5A200", "수도권", "K1", true)
+	);
+
+	private static final List<Station> STATIONS = List.of(
+		new Station(
+			"station-sangnoksu",
+			"상록수",
+			"Sangnoksu",
+			"수도권",
+			new BigDecimal("37.302795"),
+			new BigDecimal("126.866489"),
+			DataQualityLevel.LEVEL_1,
+			LocalDate.of(2026, 6, 12),
+			true
+		),
+		new Station(
+			"station-sadang",
+			"사당",
+			"Sadang",
+			"수도권",
+			new BigDecimal("37.476530"),
+			new BigDecimal("126.981685"),
+			DataQualityLevel.LEVEL_1,
+			LocalDate.of(2026, 6, 12),
+			true
+		)
+	);
+
+	private static final List<StationLine> STATION_LINES = List.of(
+		new StationLine("station-sangnoksu", "seoul-4", "448", 48, "당고개 방면 / 오이도 방면"),
+		new StationLine("station-sadang", "seoul-4", "433", 33, "당고개 방면 / 오이도 방면")
+	);
+
+	@Override
+	public List<TransitOperator> loadOperators() {
+		return OPERATORS;
+	}
+
+	@Override
+	public List<SubwayLine> loadLines() {
+		return LINES;
+	}
+
+	@Override
+	public List<Station> loadStations() {
+		return STATIONS;
+	}
+
+	@Override
+	public List<StationLine> loadStationLines() {
+		return STATION_LINES;
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/StationSearchCommand.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/StationSearchCommand.java
@@ -1,0 +1,4 @@
+package com.easysubway.transit.application.port.in;
+
+public record StationSearchCommand(String query, String lineId) {
+}

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
@@ -1,0 +1,17 @@
+package com.easysubway.transit.application.port.in;
+
+import com.easysubway.transit.domain.StationWithLines;
+import com.easysubway.transit.domain.SubwayLine;
+import com.easysubway.transit.domain.TransitOperator;
+import java.util.List;
+
+public interface TransitMasterQueryUseCase {
+
+	List<TransitOperator> listOperators();
+
+	List<SubwayLine> listLines(String operatorId);
+
+	List<StationWithLines> searchStations(StationSearchCommand command);
+
+	StationWithLines getStation(String stationId);
+}

--- a/backend/src/main/java/com/easysubway/transit/application/port/out/LoadTransitMasterPort.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/out/LoadTransitMasterPort.java
@@ -1,0 +1,18 @@
+package com.easysubway.transit.application.port.out;
+
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.SubwayLine;
+import com.easysubway.transit.domain.TransitOperator;
+import java.util.List;
+
+public interface LoadTransitMasterPort {
+
+	List<TransitOperator> loadOperators();
+
+	List<SubwayLine> loadLines();
+
+	List<Station> loadStations();
+
+	List<StationLine> loadStationLines();
+}

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -1,0 +1,97 @@
+package com.easysubway.transit.application.service;
+
+import com.easysubway.transit.application.port.in.StationSearchCommand;
+import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
+import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.StationLineSummary;
+import com.easysubway.transit.domain.StationNotFoundException;
+import com.easysubway.transit.domain.StationWithLines;
+import com.easysubway.transit.domain.SubwayLine;
+import com.easysubway.transit.domain.TransitOperator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TransitMasterService implements TransitMasterQueryUseCase {
+
+	private final LoadTransitMasterPort loadTransitMasterPort;
+
+	public TransitMasterService(LoadTransitMasterPort loadTransitMasterPort) {
+		this.loadTransitMasterPort = loadTransitMasterPort;
+	}
+
+	@Override
+	public List<TransitOperator> listOperators() {
+		return loadTransitMasterPort.loadOperators()
+			.stream()
+			.filter(TransitOperator::active)
+			.toList();
+	}
+
+	@Override
+	public List<SubwayLine> listLines(String operatorId) {
+		return loadTransitMasterPort.loadLines()
+			.stream()
+			.filter(SubwayLine::active)
+			.filter(line -> operatorId == null || operatorId.isBlank() || line.operatorId().equals(operatorId))
+			.toList();
+	}
+
+	@Override
+	public List<StationWithLines> searchStations(StationSearchCommand command) {
+		return loadTransitMasterPort.loadStations()
+			.stream()
+			.filter(Station::active)
+			.filter(station -> station.matches(command.query()))
+			.map(this::withLines)
+			.filter(station -> hasLine(station, command.lineId()))
+			.toList();
+	}
+
+	@Override
+	public StationWithLines getStation(String stationId) {
+		return loadTransitMasterPort.loadStations()
+			.stream()
+			.filter(Station::active)
+			.filter(station -> station.id().equals(stationId))
+			.findFirst()
+			.map(this::withLines)
+			.orElseThrow(StationNotFoundException::new);
+	}
+
+	private StationWithLines withLines(Station station) {
+		Map<String, SubwayLine> linesById = loadTransitMasterPort.loadLines()
+			.stream()
+			.collect(Collectors.toMap(SubwayLine::id, Function.identity()));
+
+		List<StationLineSummary> lines = loadTransitMasterPort.loadStationLines()
+			.stream()
+			.filter(stationLine -> stationLine.stationId().equals(station.id()))
+			.map(stationLine -> toSummary(stationLine, linesById))
+			.toList();
+
+		return new StationWithLines(station, lines);
+	}
+
+	private StationLineSummary toSummary(StationLine stationLine, Map<String, SubwayLine> linesById) {
+		SubwayLine line = linesById.get(stationLine.lineId());
+		if (line == null) {
+			throw new IllegalStateException("Station line references missing line: " + stationLine.lineId());
+		}
+		return StationLineSummary.of(line, stationLine);
+	}
+
+	private boolean hasLine(StationWithLines station, String lineId) {
+		if (lineId == null || lineId.isBlank()) {
+			return true;
+		}
+		return station.lines()
+			.stream()
+			.anyMatch(line -> line.id().equals(lineId));
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -67,11 +67,13 @@ public class TransitMasterService implements TransitMasterQueryUseCase {
 	private StationWithLines withLines(Station station) {
 		Map<String, SubwayLine> linesById = loadTransitMasterPort.loadLines()
 			.stream()
+			.filter(SubwayLine::active)
 			.collect(Collectors.toMap(SubwayLine::id, Function.identity()));
 
 		List<StationLineSummary> lines = loadTransitMasterPort.loadStationLines()
 			.stream()
 			.filter(stationLine -> stationLine.stationId().equals(station.id()))
+			.filter(stationLine -> linesById.containsKey(stationLine.lineId()))
 			.map(stationLine -> toSummary(stationLine, linesById))
 			.toList();
 

--- a/backend/src/main/java/com/easysubway/transit/domain/DataQualityLevel.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/DataQualityLevel.java
@@ -1,0 +1,8 @@
+package com.easysubway.transit.domain;
+
+public enum DataQualityLevel {
+	LEVEL_1,
+	LEVEL_2,
+	LEVEL_3,
+	LEVEL_4
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/DataSourceType.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/DataSourceType.java
@@ -1,0 +1,10 @@
+package com.easysubway.transit.domain;
+
+public enum DataSourceType {
+	OFFICIAL_API,
+	OFFICIAL_FILE,
+	OPERATOR_PAGE,
+	USER_REPORT,
+	ADMIN_VERIFIED,
+	PARTNER_FEED
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/Station.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/Station.java
@@ -1,0 +1,25 @@
+package com.easysubway.transit.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record Station(
+	String id,
+	String nameKo,
+	String nameEn,
+	String region,
+	BigDecimal latitude,
+	BigDecimal longitude,
+	DataQualityLevel dataQualityLevel,
+	LocalDate lastVerifiedAt,
+	boolean active
+) {
+
+	public boolean matches(String keyword) {
+		if (keyword == null || keyword.isBlank()) {
+			return true;
+		}
+		String normalizedKeyword = keyword.trim().toLowerCase();
+		return nameKo.contains(keyword.trim()) || nameEn.toLowerCase().contains(normalizedKeyword);
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/StationLine.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/StationLine.java
@@ -1,0 +1,10 @@
+package com.easysubway.transit.domain;
+
+public record StationLine(
+	String stationId,
+	String lineId,
+	String stationCode,
+	int sequence,
+	String platformInfo
+) {
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/StationLineSummary.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/StationLineSummary.java
@@ -1,0 +1,24 @@
+package com.easysubway.transit.domain;
+
+public record StationLineSummary(
+	String id,
+	String operatorId,
+	String name,
+	String color,
+	String stationCode,
+	int sequence,
+	String platformInfo
+) {
+
+	public static StationLineSummary of(SubwayLine line, StationLine stationLine) {
+		return new StationLineSummary(
+			line.id(),
+			line.operatorId(),
+			line.name(),
+			line.color(),
+			stationLine.stationCode(),
+			stationLine.sequence(),
+			stationLine.platformInfo()
+		);
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/StationNotFoundException.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/StationNotFoundException.java
@@ -1,0 +1,12 @@
+package com.easysubway.transit.domain;
+
+import com.easysubway.common.error.ResourceNotFoundException;
+
+public class StationNotFoundException extends ResourceNotFoundException {
+
+	private static final String MESSAGE = "역 정보를 찾을 수 없습니다.";
+
+	public StationNotFoundException() {
+		super(MESSAGE);
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/StationWithLines.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/StationWithLines.java
@@ -1,0 +1,6 @@
+package com.easysubway.transit.domain;
+
+import java.util.List;
+
+public record StationWithLines(Station station, List<StationLineSummary> lines) {
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/SubwayLine.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/SubwayLine.java
@@ -1,0 +1,12 @@
+package com.easysubway.transit.domain;
+
+public record SubwayLine(
+	String id,
+	String operatorId,
+	String name,
+	String color,
+	String region,
+	String lineCode,
+	boolean active
+) {
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/TransitOperator.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/TransitOperator.java
@@ -1,0 +1,12 @@
+package com.easysubway.transit.domain;
+
+public record TransitOperator(
+	String id,
+	String name,
+	String region,
+	String websiteUrl,
+	String contactUrl,
+	DataSourceType dataSourceType,
+	boolean active
+) {
+}

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -1,0 +1,75 @@
+package com.easysubway.transit.adapter.in.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class TransitMasterControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void operatorsReturnsSeededTransitOperators() throws Exception {
+		mockMvc.perform(get("/api/v1/operators"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].id").value("seoul-metro"))
+			.andExpect(jsonPath("$.data[0].name").value("서울교통공사"))
+			.andExpect(jsonPath("$.data[0].region").value("수도권"))
+			.andExpect(jsonPath("$.data[0].dataSourceType").value("OFFICIAL_FILE"))
+			.andExpect(jsonPath("$.data[0].active").value(true));
+	}
+
+	@Test
+	void linesCanBeFilteredByOperator() throws Exception {
+		mockMvc.perform(get("/api/v1/lines").param("operatorId", "seoul-metro"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].id").value("seoul-4"))
+			.andExpect(jsonPath("$.data[0].operatorId").value("seoul-metro"))
+			.andExpect(jsonPath("$.data[0].name").value("수도권 4호선"))
+			.andExpect(jsonPath("$.data[0].color").value("#00A5DE"));
+	}
+
+	@Test
+	void stationsCanBeSearchedByKoreanName() throws Exception {
+		mockMvc.perform(get("/api/v1/stations").param("query", "상록수"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].id").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data[0].nameKo").value("상록수"))
+			.andExpect(jsonPath("$.data[0].dataQualityLevel").value("LEVEL_1"))
+			.andExpect(jsonPath("$.data[0].lines[0].id").value("seoul-4"));
+	}
+
+	@Test
+	void stationDetailIncludesConnectedLinesAndQuality() throws Exception {
+		mockMvc.perform(get("/api/v1/stations/station-sangnoksu"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.id").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data.nameEn").value("Sangnoksu"))
+			.andExpect(jsonPath("$.data.latitude").value(37.302795))
+			.andExpect(jsonPath("$.data.longitude").value(126.866489))
+			.andExpect(jsonPath("$.data.dataQualityLevel").value("LEVEL_1"))
+			.andExpect(jsonPath("$.data.lines[0].stationCode").value("448"));
+	}
+
+	@Test
+	void missingStationReturnsCommonErrorResponse() throws Exception {
+		mockMvc.perform(get("/api/v1/stations/unknown-station"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("역 정보를 찾을 수 없습니다."));
+	}
+}

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -5,8 +5,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
 import com.easysubway.transit.application.port.in.StationSearchCommand;
+import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationLine;
 import com.easysubway.transit.domain.StationNotFoundException;
+import com.easysubway.transit.domain.SubwayLine;
+import com.easysubway.transit.domain.TransitOperator;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class TransitMasterServiceTest {
@@ -42,9 +51,74 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
+	void searchStationsExcludesInactiveLinesFromStationResponses() {
+		var serviceWithInactiveLine = new TransitMasterService(new TransitMasterPortWithInactiveLine());
+
+		var stations = serviceWithInactiveLine.searchStations(new StationSearchCommand("상록수", null));
+		var inactiveLineMatches = serviceWithInactiveLine.searchStations(new StationSearchCommand("상록수", "closed-line"));
+
+		assertThat(stations).hasSize(1);
+		assertThat(stations.getFirst().lines())
+			.extracting("id")
+			.containsExactly("seoul-4");
+		assertThat(inactiveLineMatches).isEmpty();
+	}
+
+	@Test
 	void getStationThrowsDomainExceptionForUnknownStation() {
 		assertThatThrownBy(() -> service.getStation("missing"))
 			.isInstanceOf(StationNotFoundException.class)
 			.hasMessage("역 정보를 찾을 수 없습니다.");
+	}
+
+	private static class TransitMasterPortWithInactiveLine implements LoadTransitMasterPort {
+
+		@Override
+		public List<TransitOperator> loadOperators() {
+			return List.of(
+				new TransitOperator(
+					"seoul-metro",
+					"서울교통공사",
+					"수도권",
+					"https://www.seoulmetro.co.kr",
+					"https://www.seoulmetro.co.kr/kr/customerMain.do",
+					DataSourceType.OFFICIAL_FILE,
+					true
+				)
+			);
+		}
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of(
+				new SubwayLine("seoul-4", "seoul-metro", "수도권 4호선", "#00A5DE", "수도권", "4", true),
+				new SubwayLine("closed-line", "seoul-metro", "운영 종료 노선", "#999999", "수도권", "C", false)
+			);
+		}
+
+		@Override
+		public List<Station> loadStations() {
+			return List.of(
+				new Station(
+					"station-sangnoksu",
+					"상록수",
+					"Sangnoksu",
+					"수도권",
+					new BigDecimal("37.302795"),
+					new BigDecimal("126.866489"),
+					DataQualityLevel.LEVEL_1,
+					LocalDate.of(2026, 6, 12),
+					true
+				)
+			);
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of(
+				new StationLine("station-sangnoksu", "seoul-4", "448", 48, "당고개 방면 / 오이도 방면"),
+				new StationLine("station-sangnoksu", "closed-line", "999", 99, "운영 종료")
+			);
+		}
 	}
 }

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -1,0 +1,50 @@
+package com.easysubway.transit.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
+import com.easysubway.transit.application.port.in.StationSearchCommand;
+import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.StationNotFoundException;
+import org.junit.jupiter.api.Test;
+
+class TransitMasterServiceTest {
+
+	private final TransitMasterService service = new TransitMasterService(new InMemoryTransitMasterRepository());
+
+	@Test
+	void listOperatorsReturnsActiveMasterData() {
+		var operators = service.listOperators();
+
+		assertThat(operators)
+			.extracting("id")
+			.contains("seoul-metro", "korail");
+	}
+
+	@Test
+	void listLinesCanFilterByOperatorId() {
+		var lines = service.listLines("korail");
+
+		assertThat(lines)
+			.extracting("id")
+			.containsExactly("suin-bundang");
+	}
+
+	@Test
+	void searchStationsMatchesKoreanAndEnglishNames() {
+		var koreanMatches = service.searchStations(new StationSearchCommand("상록수", null));
+		var englishMatches = service.searchStations(new StationSearchCommand("sang", null));
+
+		assertThat(koreanMatches).hasSize(1);
+		assertThat(englishMatches).hasSize(1);
+		assertThat(koreanMatches.getFirst().station().dataQualityLevel()).isEqualTo(DataQualityLevel.LEVEL_1);
+	}
+
+	@Test
+	void getStationThrowsDomainExceptionForUnknownStation() {
+		assertThatThrownBy(() -> service.getStation("missing"))
+			.isInstanceOf(StationNotFoundException.class)
+			.hasMessage("역 정보를 찾을 수 없습니다.");
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -160,6 +160,35 @@ test("backend scaffold is an eGovFrame 5.0 Spring Boot Java 21 hexagonal project
   assert.match(properties, /management\.endpoints\.web\.exposure\.include=health,info/);
 });
 
+test("backend transit master follows hexagonal API boundaries", () => {
+  const operator = read("backend/src/main/java/com/easysubway/transit/domain/TransitOperator.java");
+  const line = read("backend/src/main/java/com/easysubway/transit/domain/SubwayLine.java");
+  const station = read("backend/src/main/java/com/easysubway/transit/domain/Station.java");
+  const quality = read("backend/src/main/java/com/easysubway/transit/domain/DataQualityLevel.java");
+  const source = read("backend/src/main/java/com/easysubway/transit/domain/DataSourceType.java");
+  const useCase = read("backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java");
+  const outboundPort = read("backend/src/main/java/com/easysubway/transit/application/port/out/LoadTransitMasterPort.java");
+  const service = read("backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java");
+  const repository = read("backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java");
+  const controller = read("backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java");
+  const exceptionHandler = read("backend/src/main/java/com/easysubway/common/web/CommonExceptionHandler.java");
+
+  assert.match(operator, /record TransitOperator/);
+  assert.match(line, /record SubwayLine/);
+  assert.match(station, /record Station/);
+  assert.match(quality, /LEVEL_1/);
+  assert.match(source, /OFFICIAL_FILE/);
+  assert.match(useCase, /interface TransitMasterQueryUseCase/);
+  assert.match(outboundPort, /interface LoadTransitMasterPort/);
+  assert.match(service, /implements TransitMasterQueryUseCase/);
+  assert.match(repository, /implements LoadTransitMasterPort/);
+  assert.match(controller, /@GetMapping\("\/api\/v1\/operators"\)/);
+  assert.match(controller, /@GetMapping\("\/api\/v1\/lines"\)/);
+  assert.match(controller, /@GetMapping\("\/api\/v1\/stations"\)/);
+  assert.match(controller, /@GetMapping\("\/api\/v1\/stations\/\{stationId\}"\)/);
+  assert.match(exceptionHandler, /@ExceptionHandler\(ResourceNotFoundException\.class\)/);
+});
+
 test("mobile scaffold is a Flutter Android and iOS app", () => {
   const pubspec = read("apps/mobile/pubspec.yaml");
   const analysisOptions = read("apps/mobile/analysis_options.yaml");


### PR DESCRIPTION
## 배경

역 검색과 역 상세 화면에서 운영사, 노선, 역의 신뢰 가능한 기준 데이터가 필요합니다. 시설/경로 안내를 붙이기 전 백엔드에서 읽기 전용 마스터 API와 데이터 품질 표시 값을 먼저 제공합니다.

## 변경 사항

- 운영사, 노선, 역, 역-노선 연결, 데이터 품질/출처 도메인 모델을 추가했습니다.
- `TransitMasterQueryUseCase`와 `LoadTransitMasterPort`를 중심으로 헥사고날 경계를 구성했습니다.
- 인메모리 마스터 저장소에 서울교통공사, 한국철도공사, 수도권 4호선, 수인분당선, 상록수역/사당역 seed 데이터를 추가했습니다.
- `/api/v1/operators`, `/api/v1/lines`, `/api/v1/stations`, `/api/v1/stations/{stationId}` 조회 API를 추가했습니다.
- 찾을 수 없는 역은 공통 404 오류 응답으로 반환하도록 예외 처리기를 추가했습니다.
- API 계약 테스트, 서비스 테스트, 레포지토리 계약 테스트를 추가했습니다.

## 검증

- `./gradlew check --no-daemon` (`backend`)
- `node --test tools/ci/*.test.mjs`
- `docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/ISSUE_TEMPLATE/*.yml`
- `git diff --check`
- `git ls-files '*.md'`

## 리뷰 포인트

- 백엔드 패키지 구조가 domain/application/adapter 경계를 유지하는지
- API 응답 필드가 모바일 역 검색/상세 화면에서 바로 쓰기 충분한지
- 인메모리 seed 범위가 실제 데이터 연동 전 최소 기준으로 적절한지
- 404 오류 응답이 공통 응답 규격과 맞는지

## 제외 범위

- 실제 전국 도시철도 데이터 수집/동기화
- DB/JPA 마이그레이션
- 모바일 화면 연동
- 시설 정보, 경로 탐색, 관리자 검수 기능

Closes #9
