### PR TITLE
[Style] 앱 전체 안내 문구 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -71,7 +71,7 @@ class HomeScreen extends StatelessWidget {
             Semantics(
               header: true,
               child: Text(
-                '접근성 이동 안내',
+                '역 찾기',
                 style: textTheme.headlineSmall?.copyWith(
                   color: const Color(0xFF102A2C),
                   fontWeight: FontWeight.w800,
@@ -79,52 +79,35 @@ class HomeScreen extends StatelessWidget {
                 ),
               ),
             ),
-            const SizedBox(height: 8),
-            Text(
-              '빠른 길보다, 갈 수 있는 길을 먼저 안내합니다.',
-              style: textTheme.titleMedium?.copyWith(
-                color: const Color(0xFF284D50),
-                fontWeight: FontWeight.w700,
-                height: 1.45,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              '고령자, 임산부, 장애인도 편하게 이동할 수 있도록 큰 글자와 명확한 선택지를 우선합니다.',
-              style: textTheme.bodyLarge?.copyWith(
-                color: const Color(0xFF345C60),
-                height: 1.55,
-              ),
-            ),
             const SizedBox(height: 24),
             FilledButton.icon(
               key: const Key('stationSearchButton'),
               onPressed: () {},
               icon: const Icon(Icons.search),
-              label: const Text('가까운 역 찾기'),
+              label: const Text('가까운 역'),
             ),
             const SizedBox(height: 12),
             OutlinedButton.icon(
               key: const Key('mobilityProfileButton'),
               onPressed: () {},
               icon: const Icon(Icons.accessibility_new),
-              label: const Text('이동 조건 선택'),
+              label: const Text('이동 조건'),
             ),
             const SizedBox(height: 24),
             const FeatureTile(
               icon: Icons.accessible_forward,
               title: '이동 프로필',
-              description: '휠체어, 유모차, 큰 짐처럼 이동 조건을 먼저 반영합니다.',
+              semanticLabel: '이동 프로필, 이동 조건 저장',
             ),
             const FeatureTile(
               icon: Icons.elevator,
               title: '시설 정보',
-              description: '엘리베이터, 경사로, 넓은 개찰구 상태를 확인합니다.',
+              semanticLabel: '시설 정보, 엘리베이터와 경사로',
             ),
             const FeatureTile(
               icon: Icons.report_outlined,
-              title: '신고와 검수',
-              description: '현장에서 발견한 불편 정보를 신고하고 검수할 수 있게 준비합니다.',
+              title: '신고',
+              semanticLabel: '신고, 불편 신고',
             ),
           ],
         ),
@@ -137,39 +120,39 @@ class FeatureTile extends StatelessWidget {
   const FeatureTile({
     required this.icon,
     required this.title,
-    required this.description,
+    required this.semanticLabel,
     super.key,
   });
 
   final IconData icon;
   final String title;
-  final String description;
+  final String semanticLabel;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
     return MergeSemantics(
-      child: Card(
-        margin: const EdgeInsets.only(bottom: 12),
-        color: Colors.white,
-        elevation: 0,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(8),
-          side: const BorderSide(color: Color(0xFFD5E2E4)),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Icon(icon, color: colorScheme.primary, size: 32),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
+      child: Semantics(
+        label: semanticLabel,
+        child: ExcludeSemantics(
+          child: Card(
+            margin: const EdgeInsets.only(bottom: 12),
+            color: Colors.white,
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: const BorderSide(color: Color(0xFFD5E2E4)),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Icon(icon, color: colorScheme.primary, size: 32),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Text(
                       title,
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
                         color: const Color(0xFF102A2C),
@@ -177,18 +160,10 @@ class FeatureTile extends StatelessWidget {
                         height: 1.35,
                       ),
                     ),
-                    const SizedBox(height: 6),
-                    Text(
-                      description,
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: const Color(0xFF345C60),
-                        height: 1.5,
-                      ),
-                    ),
-                  ],
-                ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
       ),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3,26 +3,36 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('renders accessibility guidance home screen', (tester) async {
-    await tester.pumpWidget(const EasySubwayApp());
+  testWidgets('renders concise home screen actions', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
 
-    expect(find.text('접근성 이동 안내'), findsOneWidget);
-    expect(find.text('빠른 길보다, 갈 수 있는 길을 먼저 안내합니다.'), findsOneWidget);
-    expect(find.textContaining('고령자, 임산부, 장애인'), findsOneWidget);
-    expect(find.widgetWithText(FilledButton, '가까운 역 찾기'), findsOneWidget);
-    expect(find.widgetWithText(OutlinedButton, '이동 조건 선택'), findsOneWidget);
-    expect(find.text('이동 프로필'), findsOneWidget);
-    expect(find.text('시설 정보'), findsOneWidget);
-    expect(find.text('신고와 검수'), findsOneWidget);
+    try {
+      await tester.pumpWidget(const EasySubwayApp());
 
-    final stationButtonSize = tester.getSize(
-      find.byKey(const Key('stationSearchButton')),
-    );
-    final profileButtonSize = tester.getSize(
-      find.byKey(const Key('mobilityProfileButton')),
-    );
+      expect(find.text('역 찾기'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '가까운 역'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsOneWidget);
+      expect(find.text('이동 프로필'), findsOneWidget);
+      expect(find.text('시설 정보'), findsOneWidget);
+      expect(find.text('신고'), findsOneWidget);
+      expect(find.textContaining('빠른 길보다'), findsNothing);
+      expect(find.textContaining('고령자'), findsNothing);
+      expect(find.textContaining('휠체어'), findsNothing);
+      expect(find.bySemanticsLabel('이동 프로필, 이동 조건 저장'), findsOneWidget);
+      expect(find.bySemanticsLabel('시설 정보, 엘리베이터와 경사로'), findsOneWidget);
+      expect(find.bySemanticsLabel('신고, 불편 신고'), findsOneWidget);
 
-    expect(stationButtonSize.height, greaterThanOrEqualTo(60));
-    expect(profileButtonSize.height, greaterThanOrEqualTo(60));
+      final stationButtonSize = tester.getSize(
+        find.byKey(const Key('stationSearchButton')),
+      );
+      final profileButtonSize = tester.getSize(
+        find.byKey(const Key('mobilityProfileButton')),
+      );
+
+      expect(stationButtonSize.height, greaterThanOrEqualTo(60));
+      expect(profileButtonSize.height, greaterThanOrEqualTo(60));
+    } finally {
+      semanticsHandle.dispose();
+    }
   });
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -209,11 +209,14 @@ test("mobile scaffold is a Flutter Android and iOS app", () => {
   assert.match(androidManifest, /android:label="쉬운 지하철"/);
   assert.match(iosInfoPlist, /CFBundleDisplayName[\s\S]*?<string>쉬운 지하철<\/string>/);
   assert.match(main, /class EasySubwayApp extends StatelessWidget/);
-  assert.match(main, /갈 수 있는 길을 먼저 안내합니다/);
-  assert.match(main, /고령자, 임산부, 장애인/);
-  assert.match(main, /이동 조건 선택/);
+  assert.match(main, /역 찾기/);
+  assert.match(main, /가까운 역/);
+  assert.match(main, /이동 조건/);
+  assert.match(main, /semanticLabel: '시설 정보, 엘리베이터와 경사로'/);
+  assert.doesNotMatch(main, /빠른 길보다, 갈 수 있는 길을 먼저 안내합니다|고령자, 임산부, 장애인도 편하게 이동할 수 있도록|현장에서 발견한 불편 정보를 신고하고 검수할 수 있게/);
   assert.match(widgetTest, /EasySubwayApp/);
-  assert.match(widgetTest, /접근성 이동 안내/);
+  assert.match(widgetTest, /renders concise home screen actions/);
+  assert.match(widgetTest, /bySemanticsLabel/);
   assert.match(widgetTest, /greaterThanOrEqualTo\(60\)/);
 });
 


### PR DESCRIPTION
## 배경

초기 홈 화면에 있던 소개/설명형 문구가 실제 앱 화면에서는 과하게 느껴질 수 있습니다. 사용자는 앱을 열자마자 역을 찾거나 이동 조건을 설정해야 하므로, 화면을 기능명과 행동 버튼 중심으로 정리했습니다.

## 변경 사항

- 홈 화면의 긴 서브카피와 feature card 설명 문장을 제거했습니다.
- 주요 화면 라벨을 `역 찾기`, `가까운 역`, `이동 조건`, `이동 프로필`, `시설 정보`, `신고`로 간결하게 정리했습니다.
- widget test를 간결한 화면 구조와 설명문 미노출 기준으로 갱신했습니다.
- 레포 계약 테스트도 설명형 문구가 다시 들어오면 실패하도록 갱신했습니다.

## 검증

- `flutter analyze` (`apps/mobile`)
- `flutter test` (`apps/mobile`)
- `node --test tools/ci/*.test.mjs`
- `flutter build apk --debug` (`apps/mobile`)
- `flutter build ios --simulator --debug` (`apps/mobile`)
- iOS simulator 실행 및 UI snapshot 확인
- Android emulator 설치/실행 및 UI dump 확인
- `git diff --check`
- `git ls-files '*.md'`

## 리뷰 포인트

- 앱 화면에 남은 문구가 기능 수행에 필요한 수준인지
- 버튼 라벨과 feature 라벨이 고령자/임산부/장애인 사용자에게 충분히 직접적인지
- 설명문 제거 후에도 터치 영역과 접근성 라벨이 유지되는지

## 제외 범위

- 실제 역 검색 기능 구현
- 신규 화면 추가
- 디자인 시스템 전면 개편
- 문서 변경

Closes #11
