### PR TITLE
[Feat] 시설 상태 신고 접수 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/common/error/InvalidRequestException.java
+++ b/backend/src/main/java/com/easysubway/common/error/InvalidRequestException.java
@@ -1,0 +1,8 @@
+package com.easysubway.common.error;
+
+public class InvalidRequestException extends RuntimeException {
+
+	public InvalidRequestException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/easysubway/common/web/CommonExceptionHandler.java
+++ b/backend/src/main/java/com/easysubway/common/web/CommonExceptionHandler.java
@@ -1,13 +1,27 @@
 package com.easysubway.common.web;
 
+import com.easysubway.common.error.InvalidRequestException;
 import com.easysubway.common.error.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 class CommonExceptionHandler {
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	ApiResponse<Void> handleUnreadableMessage() {
+		return ApiResponse.fail("요청 본문을 확인해야 합니다.");
+	}
+
+	@ExceptionHandler(InvalidRequestException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	ApiResponse<Void> handleInvalidRequest(InvalidRequestException exception) {
+		return ApiResponse.fail(exception.getMessage());
+	}
 
 	@ExceptionHandler(ResourceNotFoundException.class)
 	@ResponseStatus(HttpStatus.NOT_FOUND)

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
@@ -1,0 +1,99 @@
+package com.easysubway.report.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.report.application.port.in.CreateFacilityReportCommand;
+import com.easysubway.report.application.port.in.FacilityReportUseCase;
+import com.easysubway.report.domain.FacilityReport;
+import com.easysubway.report.domain.FacilityReportStatus;
+import com.easysubway.report.domain.FacilityReportType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class FacilityReportController {
+
+	private final FacilityReportUseCase facilityReportUseCase;
+
+	FacilityReportController(FacilityReportUseCase facilityReportUseCase) {
+		this.facilityReportUseCase = facilityReportUseCase;
+	}
+
+	@PostMapping("/api/v1/reports")
+	@ResponseStatus(HttpStatus.CREATED)
+	ApiResponse<FacilityReportResponse> createReport(@RequestBody CreateFacilityReportRequest request) {
+		FacilityReport report = facilityReportUseCase.createReport(request.toCommand());
+		return ApiResponse.ok(FacilityReportResponse.from(report));
+	}
+
+	@GetMapping("/api/v1/reports/{reportId}")
+	ApiResponse<FacilityReportResponse> report(@PathVariable String reportId) {
+		return ApiResponse.ok(FacilityReportResponse.from(facilityReportUseCase.getReport(reportId)));
+	}
+
+	record CreateFacilityReportRequest(
+		String userId,
+		String stationId,
+		String facilityId,
+		FacilityReportType reportType,
+		String description,
+		String photoUrl,
+		BigDecimal latitude,
+		BigDecimal longitude
+	) {
+
+		CreateFacilityReportCommand toCommand() {
+			return new CreateFacilityReportCommand(
+				userId,
+				stationId,
+				facilityId,
+				reportType,
+				description,
+				photoUrl,
+				latitude,
+				longitude
+			);
+		}
+	}
+
+	record FacilityReportResponse(
+		String id,
+		String userId,
+		String stationId,
+		String facilityId,
+		FacilityReportType reportType,
+		String description,
+		String photoUrl,
+		BigDecimal latitude,
+		BigDecimal longitude,
+		FacilityReportStatus status,
+		LocalDateTime createdAt,
+		LocalDateTime reviewedAt,
+		String reviewedBy
+	) {
+
+		static FacilityReportResponse from(FacilityReport report) {
+			return new FacilityReportResponse(
+				report.id(),
+				report.userId(),
+				report.stationId(),
+				report.facilityId(),
+				report.reportType(),
+				report.description(),
+				report.photoUrl(),
+				report.latitude(),
+				report.longitude(),
+				report.status(),
+				report.createdAt(),
+				report.reviewedAt(),
+				report.reviewedBy()
+			);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
@@ -1,0 +1,26 @@
+package com.easysubway.report.adapter.out.persistence;
+
+import com.easysubway.report.application.port.out.LoadFacilityReportPort;
+import com.easysubway.report.application.port.out.SaveFacilityReportPort;
+import com.easysubway.report.domain.FacilityReport;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryFacilityReportRepository implements LoadFacilityReportPort, SaveFacilityReportPort {
+
+	private final Map<String, FacilityReport> reports = new ConcurrentHashMap<>();
+
+	@Override
+	public Optional<FacilityReport> loadReport(String reportId) {
+		return Optional.ofNullable(reports.get(reportId));
+	}
+
+	@Override
+	public FacilityReport saveReport(FacilityReport report) {
+		reports.put(report.id(), report);
+		return report;
+	}
+}

--- a/backend/src/main/java/com/easysubway/report/application/port/in/CreateFacilityReportCommand.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/in/CreateFacilityReportCommand.java
@@ -1,0 +1,16 @@
+package com.easysubway.report.application.port.in;
+
+import com.easysubway.report.domain.FacilityReportType;
+import java.math.BigDecimal;
+
+public record CreateFacilityReportCommand(
+	String userId,
+	String stationId,
+	String facilityId,
+	FacilityReportType reportType,
+	String description,
+	String photoUrl,
+	BigDecimal latitude,
+	BigDecimal longitude
+) {
+}

--- a/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
@@ -1,0 +1,10 @@
+package com.easysubway.report.application.port.in;
+
+import com.easysubway.report.domain.FacilityReport;
+
+public interface FacilityReportUseCase {
+
+	FacilityReport createReport(CreateFacilityReportCommand command);
+
+	FacilityReport getReport(String reportId);
+}

--- a/backend/src/main/java/com/easysubway/report/application/port/out/LoadFacilityReportPort.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/out/LoadFacilityReportPort.java
@@ -1,0 +1,9 @@
+package com.easysubway.report.application.port.out;
+
+import com.easysubway.report.domain.FacilityReport;
+import java.util.Optional;
+
+public interface LoadFacilityReportPort {
+
+	Optional<FacilityReport> loadReport(String reportId);
+}

--- a/backend/src/main/java/com/easysubway/report/application/port/out/SaveFacilityReportPort.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/out/SaveFacilityReportPort.java
@@ -1,0 +1,8 @@
+package com.easysubway.report.application.port.out;
+
+import com.easysubway.report.domain.FacilityReport;
+
+public interface SaveFacilityReportPort {
+
+	FacilityReport saveReport(FacilityReport report);
+}

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -1,0 +1,105 @@
+package com.easysubway.report.application.service;
+
+import com.easysubway.report.application.port.in.CreateFacilityReportCommand;
+import com.easysubway.report.application.port.in.FacilityReportUseCase;
+import com.easysubway.report.application.port.out.LoadFacilityReportPort;
+import com.easysubway.report.application.port.out.SaveFacilityReportPort;
+import com.easysubway.report.domain.FacilityReport;
+import com.easysubway.report.domain.FacilityReportNotFoundException;
+import com.easysubway.report.domain.FacilityReportStatus;
+import com.easysubway.report.domain.FacilityReportTargetNotFoundException;
+import com.easysubway.report.domain.InvalidFacilityReportException;
+import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationNotFoundException;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FacilityReportService implements FacilityReportUseCase {
+
+	private final LoadTransitMasterPort loadTransitMasterPort;
+	private final LoadFacilityReportPort loadFacilityReportPort;
+	private final SaveFacilityReportPort saveFacilityReportPort;
+	private final Clock clock;
+
+	@Autowired
+	public FacilityReportService(
+		LoadTransitMasterPort loadTransitMasterPort,
+		LoadFacilityReportPort loadFacilityReportPort,
+		SaveFacilityReportPort saveFacilityReportPort
+	) {
+		this(loadTransitMasterPort, loadFacilityReportPort, saveFacilityReportPort, Clock.systemDefaultZone());
+	}
+
+	public FacilityReportService(
+		LoadTransitMasterPort loadTransitMasterPort,
+		LoadFacilityReportPort loadFacilityReportPort,
+		SaveFacilityReportPort saveFacilityReportPort,
+		Clock clock
+	) {
+		this.loadTransitMasterPort = loadTransitMasterPort;
+		this.loadFacilityReportPort = loadFacilityReportPort;
+		this.saveFacilityReportPort = saveFacilityReportPort;
+		this.clock = clock;
+	}
+
+	@Override
+	public FacilityReport createReport(CreateFacilityReportCommand command) {
+		requireReportType(command);
+		requireActiveStation(command.stationId());
+		requireFacilityInStation(command.stationId(), command.facilityId());
+
+		FacilityReport report = new FacilityReport(
+			"report-" + UUID.randomUUID(),
+			command.userId(),
+			command.stationId(),
+			command.facilityId(),
+			command.reportType(),
+			command.description(),
+			command.photoUrl(),
+			command.latitude(),
+			command.longitude(),
+			FacilityReportStatus.SUBMITTED,
+			LocalDateTime.now(clock),
+			null,
+			null
+		);
+
+		return saveFacilityReportPort.saveReport(report);
+	}
+
+	@Override
+	public FacilityReport getReport(String reportId) {
+		return loadFacilityReportPort.loadReport(reportId)
+			.orElseThrow(FacilityReportNotFoundException::new);
+	}
+
+	private void requireReportType(CreateFacilityReportCommand command) {
+		if (command.reportType() == null) {
+			throw new InvalidFacilityReportException("신고 유형을 선택해야 합니다.");
+		}
+	}
+
+	private void requireActiveStation(String stationId) {
+		loadTransitMasterPort.loadStations()
+			.stream()
+			.filter(Station::active)
+			.filter(station -> station.id().equals(stationId))
+			.findFirst()
+			.orElseThrow(StationNotFoundException::new);
+	}
+
+	private void requireFacilityInStation(String stationId, String facilityId) {
+		boolean exists = loadTransitMasterPort.loadAccessibilityFacilities()
+			.stream()
+			.anyMatch(facility -> facility.id().equals(facilityId) && facility.stationId().equals(stationId));
+
+		if (!exists) {
+			throw new FacilityReportTargetNotFoundException();
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/report/domain/FacilityReport.java
+++ b/backend/src/main/java/com/easysubway/report/domain/FacilityReport.java
@@ -1,0 +1,21 @@
+package com.easysubway.report.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record FacilityReport(
+	String id,
+	String userId,
+	String stationId,
+	String facilityId,
+	FacilityReportType reportType,
+	String description,
+	String photoUrl,
+	BigDecimal latitude,
+	BigDecimal longitude,
+	FacilityReportStatus status,
+	LocalDateTime createdAt,
+	LocalDateTime reviewedAt,
+	String reviewedBy
+) {
+}

--- a/backend/src/main/java/com/easysubway/report/domain/FacilityReportNotFoundException.java
+++ b/backend/src/main/java/com/easysubway/report/domain/FacilityReportNotFoundException.java
@@ -1,0 +1,10 @@
+package com.easysubway.report.domain;
+
+import com.easysubway.common.error.ResourceNotFoundException;
+
+public class FacilityReportNotFoundException extends ResourceNotFoundException {
+
+	public FacilityReportNotFoundException() {
+		super("신고 정보를 찾을 수 없습니다.");
+	}
+}

--- a/backend/src/main/java/com/easysubway/report/domain/FacilityReportStatus.java
+++ b/backend/src/main/java/com/easysubway/report/domain/FacilityReportStatus.java
@@ -1,0 +1,10 @@
+package com.easysubway.report.domain;
+
+public enum FacilityReportStatus {
+	SUBMITTED,
+	DUPLICATE,
+	UNDER_REVIEW,
+	ACCEPTED,
+	REJECTED,
+	RESOLVED
+}

--- a/backend/src/main/java/com/easysubway/report/domain/FacilityReportTargetNotFoundException.java
+++ b/backend/src/main/java/com/easysubway/report/domain/FacilityReportTargetNotFoundException.java
@@ -1,0 +1,10 @@
+package com.easysubway.report.domain;
+
+import com.easysubway.common.error.ResourceNotFoundException;
+
+public class FacilityReportTargetNotFoundException extends ResourceNotFoundException {
+
+	public FacilityReportTargetNotFoundException() {
+		super("시설 정보를 찾을 수 없습니다.");
+	}
+}

--- a/backend/src/main/java/com/easysubway/report/domain/FacilityReportType.java
+++ b/backend/src/main/java/com/easysubway/report/domain/FacilityReportType.java
@@ -1,0 +1,10 @@
+package com.easysubway.report.domain;
+
+public enum FacilityReportType {
+	BROKEN,
+	UNDER_CONSTRUCTION,
+	CLOSED,
+	LOCATION_WRONG,
+	INFORMATION_WRONG,
+	RECOVERED
+}

--- a/backend/src/main/java/com/easysubway/report/domain/InvalidFacilityReportException.java
+++ b/backend/src/main/java/com/easysubway/report/domain/InvalidFacilityReportException.java
@@ -1,0 +1,10 @@
+package com.easysubway.report.domain;
+
+import com.easysubway.common.error.InvalidRequestException;
+
+public class InvalidFacilityReportException extends InvalidRequestException {
+
+	public InvalidFacilityReportException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -1,0 +1,122 @@
+package com.easysubway.report.adapter.in.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class FacilityReportControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void createReportReturnsSubmittedReportAndCanBeRead() throws Exception {
+		String response = mockMvc.perform(post("/api/v1/reports")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "stationId": "station-sangnoksu",
+					  "facilityId": "facility-sangnoksu-elevator-1",
+					  "reportType": "BROKEN",
+					  "description": "엘리베이터 문이 열리지 않습니다.",
+					  "latitude": 37.302421,
+					  "longitude": 126.866221
+					}
+					"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.id").isNotEmpty())
+			.andExpect(jsonPath("$.data.stationId").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data.facilityId").value("facility-sangnoksu-elevator-1"))
+			.andExpect(jsonPath("$.data.reportType").value("BROKEN"))
+			.andExpect(jsonPath("$.data.status").value("SUBMITTED"))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		String reportId = JsonPath.read(response, "$.data.id");
+
+		mockMvc.perform(get("/api/v1/reports/{reportId}", reportId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.id").value(reportId))
+			.andExpect(jsonPath("$.data.description").value("엘리베이터 문이 열리지 않습니다."));
+	}
+
+	@Test
+	void createReportReturnsCommonErrorForUnknownFacility() throws Exception {
+		mockMvc.perform(post("/api/v1/reports")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "stationId": "station-sangnoksu",
+					  "facilityId": "missing-facility",
+					  "reportType": "BROKEN",
+					  "description": "엘리베이터가 멈춰 있습니다."
+					}
+					"""))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("시설 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
+	void createReportReturnsCommonErrorForMissingReportType() throws Exception {
+		mockMvc.perform(post("/api/v1/reports")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "stationId": "station-sangnoksu",
+					  "facilityId": "facility-sangnoksu-elevator-1",
+					  "description": "신고 유형이 없는 요청입니다."
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("신고 유형을 선택해야 합니다."));
+	}
+
+	@Test
+	void createReportReturnsCommonErrorForInvalidReportType() throws Exception {
+		mockMvc.perform(post("/api/v1/reports")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "stationId": "station-sangnoksu",
+					  "facilityId": "facility-sangnoksu-elevator-1",
+					  "reportType": "BROKNN",
+					  "description": "잘못된 신고 유형입니다."
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("요청 본문을 확인해야 합니다."));
+	}
+
+	@Test
+	void missingReportReturnsCommonErrorResponse() throws Exception {
+		mockMvc.perform(get("/api/v1/reports/missing-report"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("신고 정보를 찾을 수 없습니다."));
+	}
+}

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -1,0 +1,108 @@
+package com.easysubway.report.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.report.adapter.out.persistence.InMemoryFacilityReportRepository;
+import com.easysubway.report.application.port.in.CreateFacilityReportCommand;
+import com.easysubway.report.domain.FacilityReportNotFoundException;
+import com.easysubway.report.domain.FacilityReportStatus;
+import com.easysubway.report.domain.FacilityReportTargetNotFoundException;
+import com.easysubway.report.domain.FacilityReportType;
+import com.easysubway.report.domain.InvalidFacilityReportException;
+import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
+import com.easysubway.transit.domain.StationNotFoundException;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+
+class FacilityReportServiceTest {
+
+	private final InMemoryFacilityReportRepository reportRepository = new InMemoryFacilityReportRepository();
+	private final FacilityReportService service = new FacilityReportService(
+		new InMemoryTransitMasterRepository(),
+		reportRepository,
+		reportRepository,
+		Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+	);
+
+	@Test
+	void createReportStoresSubmittedFacilityReport() {
+		var report = service.createReport(new CreateFacilityReportCommand(
+			"anonymous-user-1",
+			"station-sangnoksu",
+			"facility-sangnoksu-elevator-1",
+			FacilityReportType.BROKEN,
+			"엘리베이터 문이 열리지 않습니다.",
+			null,
+			new BigDecimal("37.302421"),
+			new BigDecimal("126.866221")
+		));
+
+		assertThat(report.id()).isNotBlank();
+		assertThat(report.stationId()).isEqualTo("station-sangnoksu");
+		assertThat(report.facilityId()).isEqualTo("facility-sangnoksu-elevator-1");
+		assertThat(report.reportType()).isEqualTo(FacilityReportType.BROKEN);
+		assertThat(report.status()).isEqualTo(FacilityReportStatus.SUBMITTED);
+		assertThat(report.createdAt()).isEqualTo(LocalDateTime.of(2026, 6, 12, 9, 0));
+		assertThat(service.getReport(report.id())).isEqualTo(report);
+	}
+
+	@Test
+	void createReportRequiresExistingStation() {
+		assertThatThrownBy(() -> service.createReport(new CreateFacilityReportCommand(
+			"anonymous-user-1",
+			"missing-station",
+			"facility-sangnoksu-elevator-1",
+			FacilityReportType.BROKEN,
+			"엘리베이터가 멈춰 있습니다.",
+			null,
+			null,
+			null
+		)))
+			.isInstanceOf(StationNotFoundException.class)
+			.hasMessage("역 정보를 찾을 수 없습니다.");
+	}
+
+	@Test
+	void createReportRequiresFacilityInStation() {
+		assertThatThrownBy(() -> service.createReport(new CreateFacilityReportCommand(
+			"anonymous-user-1",
+			"station-sadang",
+			"facility-sangnoksu-elevator-1",
+			FacilityReportType.BROKEN,
+			"다른 역 시설로 신고할 수 없습니다.",
+			null,
+			null,
+			null
+		)))
+			.isInstanceOf(FacilityReportTargetNotFoundException.class)
+			.hasMessage("시설 정보를 찾을 수 없습니다.");
+	}
+
+	@Test
+	void createReportRequiresReportType() {
+		assertThatThrownBy(() -> service.createReport(new CreateFacilityReportCommand(
+			"anonymous-user-1",
+			"station-sangnoksu",
+			"facility-sangnoksu-elevator-1",
+			null,
+			"신고 유형이 없는 요청입니다.",
+			null,
+			null,
+			null
+		)))
+			.isInstanceOf(InvalidFacilityReportException.class)
+			.hasMessage("신고 유형을 선택해야 합니다.");
+	}
+
+	@Test
+	void getReportRequiresExistingReport() {
+		assertThatThrownBy(() -> service.getReport("missing-report"))
+			.isInstanceOf(FacilityReportNotFoundException.class)
+			.hasMessage("신고 정보를 찾을 수 없습니다.");
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -204,7 +204,44 @@ test("backend transit master follows hexagonal API boundaries", () => {
   assert.match(controller, /@GetMapping\("\/api\/v1\/stations\/\{stationId\}"\)/);
   assert.match(controller, /@GetMapping\("\/api\/v1\/stations\/\{stationId\}\/exits"\)/);
   assert.match(controller, /@GetMapping\("\/api\/v1\/stations\/\{stationId\}\/facilities"\)/);
+  assert.match(exceptionHandler, /@ExceptionHandler\(HttpMessageNotReadableException\.class\)/);
+  assert.match(exceptionHandler, /@ExceptionHandler\(InvalidRequestException\.class\)/);
   assert.match(exceptionHandler, /@ExceptionHandler\(ResourceNotFoundException\.class\)/);
+});
+
+test("backend facility reports follow hexagonal API boundaries", () => {
+  const report = read("backend/src/main/java/com/easysubway/report/domain/FacilityReport.java");
+  const reportType = read("backend/src/main/java/com/easysubway/report/domain/FacilityReportType.java");
+  const reportStatus = read("backend/src/main/java/com/easysubway/report/domain/FacilityReportStatus.java");
+  const invalidReport = read("backend/src/main/java/com/easysubway/report/domain/InvalidFacilityReportException.java");
+  const useCase = read("backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java");
+  const command = read("backend/src/main/java/com/easysubway/report/application/port/in/CreateFacilityReportCommand.java");
+  const loadPort = read("backend/src/main/java/com/easysubway/report/application/port/out/LoadFacilityReportPort.java");
+  const savePort = read("backend/src/main/java/com/easysubway/report/application/port/out/SaveFacilityReportPort.java");
+  const service = read("backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java");
+  const repository = read("backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java");
+  const controller = read("backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java");
+
+  assert.match(report, /record FacilityReport/);
+  assert.match(report, /reviewedAt/);
+  assert.match(reportType, /BROKEN/);
+  assert.match(reportType, /LOCATION_WRONG/);
+  assert.match(reportStatus, /SUBMITTED/);
+  assert.match(reportStatus, /RESOLVED/);
+  assert.match(invalidReport, /extends InvalidRequestException/);
+  assert.match(useCase, /interface FacilityReportUseCase/);
+  assert.match(useCase, /createReport/);
+  assert.match(useCase, /getReport/);
+  assert.match(command, /record CreateFacilityReportCommand/);
+  assert.match(loadPort, /interface LoadFacilityReportPort/);
+  assert.match(savePort, /interface SaveFacilityReportPort/);
+  assert.match(service, /implements FacilityReportUseCase/);
+  assert.match(service, /LoadTransitMasterPort/);
+  assert.match(service, /FacilityReportStatus\.SUBMITTED/);
+  assert.match(repository, /implements LoadFacilityReportPort, SaveFacilityReportPort/);
+  assert.match(controller, /@PostMapping\("\/api\/v1\/reports"\)/);
+  assert.match(controller, /@GetMapping\("\/api\/v1\/reports\/\{reportId\}"\)/);
+  assert.match(controller, /@ResponseStatus\(HttpStatus\.CREATED\)/);
 });
 
 test("mobile scaffold is a Flutter Android and iOS app", () => {


### PR DESCRIPTION
## 관련 이슈

close #15

## 요약

역 시설의 고장, 공사, 폐쇄 같은 현장 상태를 사용자 신고로 접수할 수 있도록 백엔드 API 기준선을 추가했습니다. 신고는 별도 report 패키지의 헥사고날 경계로 분리했고, 접수 시 transit 마스터 데이터의 역과 시설을 검증합니다.

## 변경 사항

- `FacilityReport` 도메인 모델과 신고 유형/상태 enum을 추가했습니다.
- 신고 접수와 상세 조회 input port, 저장/조회 output port, 서비스를 추가했습니다.
- in-memory 신고 저장소를 추가했습니다.
- `POST /api/v1/reports`를 추가했습니다.
- `GET /api/v1/reports/{reportId}`를 추가했습니다.
- 없는 역, 없는 시설, 역과 맞지 않는 시설은 공통 오류 응답을 반환합니다.
- 요청 본문 형식 오류와 필수 신고 유형 누락을 공통 오류 응답으로 처리합니다.
- 서비스 테스트, 컨트롤러 테스트, 저장소 계약 테스트를 추가했습니다.

## 검증

- `./gradlew test --tests com.easysubway.report.application.service.FacilityReportServiceTest --tests com.easysubway.report.adapter.in.web.FacilityReportControllerTest --no-daemon`
- `node --test tools/ci/*.test.mjs`
- `./gradlew test --no-daemon`
- `./gradlew check --no-daemon`
- `git diff --check`
- `git diff --cached --check`
- `git ls-files '*.md'`
- PR CI: https://github.com/AquilaXk/easysubway/actions/runs/27399300608
- main CI: https://github.com/AquilaXk/easysubway/actions/runs/27399578222
- Codex CLI code review: 최종 재검토 기준 추가 이슈 없음
- CD 확인: 별도 배포 workflow는 아직 없으며 main CI 빌드 게이트 통과까지 확인

## 리스크

- 현재 신고 저장소는 in-memory 기준선입니다. 실제 운영 저장은 DB/JPA 작업에서 분리해 연결해야 합니다.
- 사진 업로드, 관리자 검수, 시설 상태 자동 반영은 포함하지 않았습니다.
- 인증이 아직 없으므로 `userId`는 클라이언트가 전달하는 익명 식별자 형태로만 보관합니다.

## 체크리스트

- [x] 관련 이슈를 연결했다.
- [x] 실행한 명령과 결과를 검증 섹션에 적었다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [x] Codex CLI code review 결과를 확인했다.
- [x] CI가 통과했다.
- [x] CD 상태를 확인했다.
