### PR TITLE
[Feat] 이동 프로필 저장 조회 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/profile/adapter/in/web/MobilityProfileController.java
+++ b/backend/src/main/java/com/easysubway/profile/adapter/in/web/MobilityProfileController.java
@@ -1,0 +1,98 @@
+package com.easysubway.profile.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.profile.application.port.in.MobilityProfileUseCase;
+import com.easysubway.profile.application.port.in.SaveMobilityProfileCommand;
+import com.easysubway.profile.domain.MobilityProfile;
+import com.easysubway.profile.domain.MobilityType;
+import java.time.LocalDateTime;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class MobilityProfileController {
+
+	private final MobilityProfileUseCase mobilityProfileUseCase;
+
+	MobilityProfileController(MobilityProfileUseCase mobilityProfileUseCase) {
+		this.mobilityProfileUseCase = mobilityProfileUseCase;
+	}
+
+	@GetMapping("/api/v1/me/mobility-profile")
+	ApiResponse<MobilityProfileResponse> getProfile(
+		@RequestParam(required = false) String userId
+	) {
+		return ApiResponse.ok(MobilityProfileResponse.from(mobilityProfileUseCase.getProfile(userId)));
+	}
+
+	@PutMapping("/api/v1/me/mobility-profile")
+	ApiResponse<MobilityProfileResponse> saveProfile(
+		@RequestBody SaveMobilityProfileRequest request
+	) {
+		MobilityProfile profile = mobilityProfileUseCase.saveProfile(request.toCommand());
+		return ApiResponse.ok(MobilityProfileResponse.from(profile));
+	}
+
+	record SaveMobilityProfileRequest(
+		String userId,
+		MobilityType mobilityType,
+		boolean avoidStairs,
+		boolean requireElevator,
+		boolean allowEscalator,
+		boolean minimizeTransfers,
+		boolean avoidLongWalks,
+		boolean largeText,
+		boolean highContrast,
+		boolean simpleView
+	) {
+
+		SaveMobilityProfileCommand toCommand() {
+			return new SaveMobilityProfileCommand(
+				userId,
+				mobilityType,
+				avoidStairs,
+				requireElevator,
+				allowEscalator,
+				minimizeTransfers,
+				avoidLongWalks,
+				largeText,
+				highContrast,
+				simpleView
+			);
+		}
+	}
+
+	record MobilityProfileResponse(
+		String userId,
+		MobilityType mobilityType,
+		boolean avoidStairs,
+		boolean requireElevator,
+		boolean allowEscalator,
+		boolean minimizeTransfers,
+		boolean avoidLongWalks,
+		boolean largeText,
+		boolean highContrast,
+		boolean simpleView,
+		LocalDateTime updatedAt
+	) {
+
+		static MobilityProfileResponse from(MobilityProfile profile) {
+			return new MobilityProfileResponse(
+				profile.userId(),
+				profile.mobilityType(),
+				profile.avoidStairs(),
+				profile.requireElevator(),
+				profile.allowEscalator(),
+				profile.minimizeTransfers(),
+				profile.avoidLongWalks(),
+				profile.largeText(),
+				profile.highContrast(),
+				profile.simpleView(),
+				profile.updatedAt()
+			);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/profile/adapter/out/persistence/InMemoryMobilityProfileRepository.java
+++ b/backend/src/main/java/com/easysubway/profile/adapter/out/persistence/InMemoryMobilityProfileRepository.java
@@ -1,0 +1,26 @@
+package com.easysubway.profile.adapter.out.persistence;
+
+import com.easysubway.profile.application.port.out.LoadMobilityProfilePort;
+import com.easysubway.profile.application.port.out.SaveMobilityProfilePort;
+import com.easysubway.profile.domain.MobilityProfile;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryMobilityProfileRepository implements LoadMobilityProfilePort, SaveMobilityProfilePort {
+
+	private final ConcurrentMap<String, MobilityProfile> profiles = new ConcurrentHashMap<>();
+
+	@Override
+	public Optional<MobilityProfile> loadProfile(String userId) {
+		return Optional.ofNullable(profiles.get(userId));
+	}
+
+	@Override
+	public MobilityProfile saveProfile(MobilityProfile profile) {
+		profiles.put(profile.userId(), profile);
+		return profile;
+	}
+}

--- a/backend/src/main/java/com/easysubway/profile/application/port/in/MobilityProfileUseCase.java
+++ b/backend/src/main/java/com/easysubway/profile/application/port/in/MobilityProfileUseCase.java
@@ -1,0 +1,10 @@
+package com.easysubway.profile.application.port.in;
+
+import com.easysubway.profile.domain.MobilityProfile;
+
+public interface MobilityProfileUseCase {
+
+	MobilityProfile getProfile(String userId);
+
+	MobilityProfile saveProfile(SaveMobilityProfileCommand command);
+}

--- a/backend/src/main/java/com/easysubway/profile/application/port/in/SaveMobilityProfileCommand.java
+++ b/backend/src/main/java/com/easysubway/profile/application/port/in/SaveMobilityProfileCommand.java
@@ -1,0 +1,17 @@
+package com.easysubway.profile.application.port.in;
+
+import com.easysubway.profile.domain.MobilityType;
+
+public record SaveMobilityProfileCommand(
+	String userId,
+	MobilityType mobilityType,
+	boolean avoidStairs,
+	boolean requireElevator,
+	boolean allowEscalator,
+	boolean minimizeTransfers,
+	boolean avoidLongWalks,
+	boolean largeText,
+	boolean highContrast,
+	boolean simpleView
+) {
+}

--- a/backend/src/main/java/com/easysubway/profile/application/port/out/LoadMobilityProfilePort.java
+++ b/backend/src/main/java/com/easysubway/profile/application/port/out/LoadMobilityProfilePort.java
@@ -1,0 +1,9 @@
+package com.easysubway.profile.application.port.out;
+
+import com.easysubway.profile.domain.MobilityProfile;
+import java.util.Optional;
+
+public interface LoadMobilityProfilePort {
+
+	Optional<MobilityProfile> loadProfile(String userId);
+}

--- a/backend/src/main/java/com/easysubway/profile/application/port/out/SaveMobilityProfilePort.java
+++ b/backend/src/main/java/com/easysubway/profile/application/port/out/SaveMobilityProfilePort.java
@@ -1,0 +1,8 @@
+package com.easysubway.profile.application.port.out;
+
+import com.easysubway.profile.domain.MobilityProfile;
+
+public interface SaveMobilityProfilePort {
+
+	MobilityProfile saveProfile(MobilityProfile profile);
+}

--- a/backend/src/main/java/com/easysubway/profile/application/service/MobilityProfileService.java
+++ b/backend/src/main/java/com/easysubway/profile/application/service/MobilityProfileService.java
@@ -1,0 +1,101 @@
+package com.easysubway.profile.application.service;
+
+import com.easysubway.profile.application.port.in.MobilityProfileUseCase;
+import com.easysubway.profile.application.port.in.SaveMobilityProfileCommand;
+import com.easysubway.profile.application.port.out.LoadMobilityProfilePort;
+import com.easysubway.profile.application.port.out.SaveMobilityProfilePort;
+import com.easysubway.profile.domain.InvalidMobilityProfileException;
+import com.easysubway.profile.domain.MobilityProfile;
+import com.easysubway.profile.domain.MobilityType;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MobilityProfileService implements MobilityProfileUseCase {
+
+	private final LoadMobilityProfilePort loadMobilityProfilePort;
+	private final SaveMobilityProfilePort saveMobilityProfilePort;
+	private final Clock clock;
+
+	@Autowired
+	public MobilityProfileService(
+		LoadMobilityProfilePort loadMobilityProfilePort,
+		SaveMobilityProfilePort saveMobilityProfilePort
+	) {
+		this(loadMobilityProfilePort, saveMobilityProfilePort, Clock.systemDefaultZone());
+	}
+
+	public MobilityProfileService(
+		LoadMobilityProfilePort loadMobilityProfilePort,
+		SaveMobilityProfilePort saveMobilityProfilePort,
+		Clock clock
+	) {
+		this.loadMobilityProfilePort = loadMobilityProfilePort;
+		this.saveMobilityProfilePort = saveMobilityProfilePort;
+		this.clock = clock;
+	}
+
+	@Override
+	public MobilityProfile getProfile(String userId) {
+		requireUserId(userId);
+		return loadMobilityProfilePort.loadProfile(userId)
+			.orElseGet(() -> defaultProfile(userId));
+	}
+
+	@Override
+	public MobilityProfile saveProfile(SaveMobilityProfileCommand command) {
+		requireUserId(command.userId());
+		requireMobilityType(command.mobilityType());
+		requireWheelchairRules(command);
+
+		return saveMobilityProfilePort.saveProfile(new MobilityProfile(
+			command.userId(),
+			command.mobilityType(),
+			command.avoidStairs(),
+			command.requireElevator(),
+			command.allowEscalator(),
+			command.minimizeTransfers(),
+			command.avoidLongWalks(),
+			command.largeText(),
+			command.highContrast(),
+			command.simpleView(),
+			LocalDateTime.now(clock)
+		));
+	}
+
+	private MobilityProfile defaultProfile(String userId) {
+		return new MobilityProfile(
+			userId,
+			MobilityType.SENIOR,
+			true,
+			false,
+			true,
+			true,
+			true,
+			false,
+			false,
+			false,
+			LocalDateTime.now(clock)
+		);
+	}
+
+	private void requireUserId(String userId) {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidMobilityProfileException("사용자 식별자가 필요합니다.");
+		}
+	}
+
+	private void requireMobilityType(MobilityType mobilityType) {
+		if (mobilityType == null) {
+			throw new InvalidMobilityProfileException("이동 유형을 선택해야 합니다.");
+		}
+	}
+
+	private void requireWheelchairRules(SaveMobilityProfileCommand command) {
+		if (command.mobilityType() == MobilityType.WHEELCHAIR && !command.avoidStairs()) {
+			throw new InvalidMobilityProfileException("휠체어 프로필은 계단 없는 경로만 저장할 수 있습니다.");
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/profile/domain/InvalidMobilityProfileException.java
+++ b/backend/src/main/java/com/easysubway/profile/domain/InvalidMobilityProfileException.java
@@ -1,0 +1,10 @@
+package com.easysubway.profile.domain;
+
+import com.easysubway.common.error.InvalidRequestException;
+
+public class InvalidMobilityProfileException extends InvalidRequestException {
+
+	public InvalidMobilityProfileException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/easysubway/profile/domain/MobilityProfile.java
+++ b/backend/src/main/java/com/easysubway/profile/domain/MobilityProfile.java
@@ -1,0 +1,18 @@
+package com.easysubway.profile.domain;
+
+import java.time.LocalDateTime;
+
+public record MobilityProfile(
+	String userId,
+	MobilityType mobilityType,
+	boolean avoidStairs,
+	boolean requireElevator,
+	boolean allowEscalator,
+	boolean minimizeTransfers,
+	boolean avoidLongWalks,
+	boolean largeText,
+	boolean highContrast,
+	boolean simpleView,
+	LocalDateTime updatedAt
+) {
+}

--- a/backend/src/main/java/com/easysubway/profile/domain/MobilityType.java
+++ b/backend/src/main/java/com/easysubway/profile/domain/MobilityType.java
@@ -1,0 +1,10 @@
+package com.easysubway.profile.domain;
+
+public enum MobilityType {
+	SENIOR,
+	STROLLER,
+	WHEELCHAIR,
+	PREGNANT,
+	TEMPORARY_INJURY,
+	LUGGAGE
+}

--- a/backend/src/test/java/com/easysubway/profile/adapter/in/web/MobilityProfileControllerTest.java
+++ b/backend/src/test/java/com/easysubway/profile/adapter/in/web/MobilityProfileControllerTest.java
@@ -1,0 +1,129 @@
+package com.easysubway.profile.adapter.in.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MobilityProfileControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void getProfileReturnsDefaultProfileForAnonymousUser() throws Exception {
+		mockMvc.perform(get("/api/v1/me/mobility-profile")
+				.param("userId", "anonymous-user-1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.userId").value("anonymous-user-1"))
+			.andExpect(jsonPath("$.data.mobilityType").value("SENIOR"))
+			.andExpect(jsonPath("$.data.avoidStairs").value(true))
+			.andExpect(jsonPath("$.data.requireElevator").value(false))
+			.andExpect(jsonPath("$.data.allowEscalator").value(true))
+			.andExpect(jsonPath("$.data.minimizeTransfers").value(true))
+			.andExpect(jsonPath("$.data.avoidLongWalks").value(true))
+			.andExpect(jsonPath("$.data.largeText").value(false))
+			.andExpect(jsonPath("$.data.highContrast").value(false))
+			.andExpect(jsonPath("$.data.simpleView").value(false));
+	}
+
+	@Test
+	void putProfileStoresAndReturnsMobilityProfile() throws Exception {
+		mockMvc.perform(put("/api/v1/me/mobility-profile")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-2",
+					  "mobilityType": "PREGNANT",
+					  "avoidStairs": true,
+					  "requireElevator": false,
+					  "allowEscalator": true,
+					  "minimizeTransfers": true,
+					  "avoidLongWalks": true,
+					  "largeText": true,
+					  "highContrast": false,
+					  "simpleView": true
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.userId").value("anonymous-user-2"))
+			.andExpect(jsonPath("$.data.mobilityType").value("PREGNANT"))
+			.andExpect(jsonPath("$.data.largeText").value(true))
+			.andExpect(jsonPath("$.data.simpleView").value(true));
+
+		mockMvc.perform(get("/api/v1/me/mobility-profile")
+				.param("userId", "anonymous-user-2"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.mobilityType").value("PREGNANT"))
+			.andExpect(jsonPath("$.data.largeText").value(true))
+			.andExpect(jsonPath("$.data.simpleView").value(true));
+	}
+
+	@Test
+	void putProfileRejectsWheelchairProfileThatAllowsStairs() throws Exception {
+		mockMvc.perform(put("/api/v1/me/mobility-profile")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-3",
+					  "mobilityType": "WHEELCHAIR",
+					  "avoidStairs": false,
+					  "requireElevator": true,
+					  "allowEscalator": false,
+					  "minimizeTransfers": true,
+					  "avoidLongWalks": true,
+					  "largeText": false,
+					  "highContrast": false,
+					  "simpleView": true
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("휠체어 프로필은 계단 없는 경로만 저장할 수 있습니다."));
+	}
+
+	@Test
+	void putProfileReturnsCommonErrorForInvalidMobilityType() throws Exception {
+		mockMvc.perform(put("/api/v1/me/mobility-profile")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-4",
+					  "mobilityType": "UNKNOWN",
+					  "avoidStairs": true,
+					  "requireElevator": false,
+					  "allowEscalator": true,
+					  "minimizeTransfers": true,
+					  "avoidLongWalks": true,
+					  "largeText": false,
+					  "highContrast": false,
+					  "simpleView": false
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("요청 본문을 확인해야 합니다."));
+	}
+
+	@Test
+	void getProfileRequiresUserId() throws Exception {
+		mockMvc.perform(get("/api/v1/me/mobility-profile"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("사용자 식별자가 필요합니다."));
+	}
+}

--- a/backend/src/test/java/com/easysubway/profile/application/service/MobilityProfileServiceTest.java
+++ b/backend/src/test/java/com/easysubway/profile/application/service/MobilityProfileServiceTest.java
@@ -1,0 +1,116 @@
+package com.easysubway.profile.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.profile.adapter.out.persistence.InMemoryMobilityProfileRepository;
+import com.easysubway.profile.application.port.in.SaveMobilityProfileCommand;
+import com.easysubway.profile.domain.InvalidMobilityProfileException;
+import com.easysubway.profile.domain.MobilityType;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+
+class MobilityProfileServiceTest {
+
+	private final InMemoryMobilityProfileRepository repository = new InMemoryMobilityProfileRepository();
+	private final MobilityProfileService service = new MobilityProfileService(
+		repository,
+		repository,
+		Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+	);
+
+	@Test
+	void getProfileReturnsDefaultProfileForNewAnonymousUser() {
+		var profile = service.getProfile("anonymous-user-1");
+
+		assertThat(profile.userId()).isEqualTo("anonymous-user-1");
+		assertThat(profile.mobilityType()).isEqualTo(MobilityType.SENIOR);
+		assertThat(profile.avoidStairs()).isTrue();
+		assertThat(profile.requireElevator()).isFalse();
+		assertThat(profile.allowEscalator()).isTrue();
+		assertThat(profile.minimizeTransfers()).isTrue();
+		assertThat(profile.avoidLongWalks()).isTrue();
+		assertThat(profile.largeText()).isFalse();
+		assertThat(profile.highContrast()).isFalse();
+		assertThat(profile.simpleView()).isFalse();
+		assertThat(profile.updatedAt()).isEqualTo(LocalDateTime.of(2026, 6, 12, 9, 0));
+	}
+
+	@Test
+	void saveProfileStoresMobilityAndAccessibilityPreferences() {
+		var profile = service.saveProfile(new SaveMobilityProfileCommand(
+			"anonymous-user-1",
+			MobilityType.STROLLER,
+			true,
+			true,
+			true,
+			false,
+			true,
+			true,
+			true,
+			false
+		));
+
+		assertThat(profile.mobilityType()).isEqualTo(MobilityType.STROLLER);
+		assertThat(profile.requireElevator()).isTrue();
+		assertThat(profile.largeText()).isTrue();
+		assertThat(profile.highContrast()).isTrue();
+		assertThat(profile.simpleView()).isFalse();
+		assertThat(profile.updatedAt()).isEqualTo(LocalDateTime.of(2026, 6, 12, 9, 0));
+		assertThat(service.getProfile("anonymous-user-1")).isEqualTo(profile);
+	}
+
+	@Test
+	void saveProfileRejectsWheelchairProfileThatAllowsStairs() {
+		assertThatThrownBy(() -> service.saveProfile(new SaveMobilityProfileCommand(
+			"anonymous-user-1",
+			MobilityType.WHEELCHAIR,
+			false,
+			true,
+			false,
+			true,
+			true,
+			false,
+			false,
+			true
+		)))
+			.isInstanceOf(InvalidMobilityProfileException.class)
+			.hasMessage("휠체어 프로필은 계단 없는 경로만 저장할 수 있습니다.");
+	}
+
+	@Test
+	void saveProfileRequiresUserIdAndMobilityType() {
+		assertThatThrownBy(() -> service.saveProfile(new SaveMobilityProfileCommand(
+			"",
+			MobilityType.SENIOR,
+			true,
+			false,
+			true,
+			true,
+			true,
+			false,
+			false,
+			false
+		)))
+			.isInstanceOf(InvalidMobilityProfileException.class)
+			.hasMessage("사용자 식별자가 필요합니다.");
+
+		assertThatThrownBy(() -> service.saveProfile(new SaveMobilityProfileCommand(
+			"anonymous-user-1",
+			null,
+			true,
+			false,
+			true,
+			true,
+			true,
+			false,
+			false,
+			false
+		)))
+			.isInstanceOf(InvalidMobilityProfileException.class)
+			.hasMessage("이동 유형을 선택해야 합니다.");
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -244,6 +244,43 @@ test("backend facility reports follow hexagonal API boundaries", () => {
   assert.match(controller, /@ResponseStatus\(HttpStatus\.CREATED\)/);
 });
 
+test("backend mobility profiles follow hexagonal API boundaries", () => {
+  const profile = read("backend/src/main/java/com/easysubway/profile/domain/MobilityProfile.java");
+  const mobilityType = read("backend/src/main/java/com/easysubway/profile/domain/MobilityType.java");
+  const invalidProfile = read("backend/src/main/java/com/easysubway/profile/domain/InvalidMobilityProfileException.java");
+  const useCase = read("backend/src/main/java/com/easysubway/profile/application/port/in/MobilityProfileUseCase.java");
+  const command = read("backend/src/main/java/com/easysubway/profile/application/port/in/SaveMobilityProfileCommand.java");
+  const loadPort = read("backend/src/main/java/com/easysubway/profile/application/port/out/LoadMobilityProfilePort.java");
+  const savePort = read("backend/src/main/java/com/easysubway/profile/application/port/out/SaveMobilityProfilePort.java");
+  const service = read("backend/src/main/java/com/easysubway/profile/application/service/MobilityProfileService.java");
+  const repository = read("backend/src/main/java/com/easysubway/profile/adapter/out/persistence/InMemoryMobilityProfileRepository.java");
+  const controller = read("backend/src/main/java/com/easysubway/profile/adapter/in/web/MobilityProfileController.java");
+
+  assert.match(profile, /record MobilityProfile/);
+  assert.match(profile, /largeText/);
+  assert.match(profile, /highContrast/);
+  assert.match(profile, /simpleView/);
+  assert.match(mobilityType, /SENIOR/);
+  assert.match(mobilityType, /STROLLER/);
+  assert.match(mobilityType, /WHEELCHAIR/);
+  assert.match(mobilityType, /PREGNANT/);
+  assert.match(mobilityType, /TEMPORARY_INJURY/);
+  assert.match(mobilityType, /LUGGAGE/);
+  assert.match(invalidProfile, /extends InvalidRequestException/);
+  assert.match(useCase, /interface MobilityProfileUseCase/);
+  assert.match(useCase, /getProfile/);
+  assert.match(useCase, /saveProfile/);
+  assert.match(command, /record SaveMobilityProfileCommand/);
+  assert.match(loadPort, /interface LoadMobilityProfilePort/);
+  assert.match(savePort, /interface SaveMobilityProfilePort/);
+  assert.match(service, /implements MobilityProfileUseCase/);
+  assert.match(service, /defaultProfile/);
+  assert.match(service, /MobilityType\.WHEELCHAIR/);
+  assert.match(repository, /implements LoadMobilityProfilePort, SaveMobilityProfilePort/);
+  assert.match(controller, /@GetMapping\("\/api\/v1\/me\/mobility-profile"\)/);
+  assert.match(controller, /@PutMapping\("\/api\/v1\/me\/mobility-profile"\)/);
+});
+
 test("mobile scaffold is a Flutter Android and iOS app", () => {
   const pubspec = read("apps/mobile/pubspec.yaml");
   const analysisOptions = read("apps/mobile/analysis_options.yaml");


### PR DESCRIPTION
## 관련 이슈

close #17

## 요약

사용자별 이동 조건과 접근성 화면 설정을 저장하고 조회할 수 있는 백엔드 API 기준선을 추가했습니다. 초기 서비스 흐름에 맞춰 로그인 없이 익명 사용자 ID로 동작하며, 이후 역 검색 우선순위와 경로 추천에서 같은 이동 프로필을 사용할 수 있도록 profile 패키지를 헥사고날 경계로 분리했습니다.

## 변경 사항

- `MobilityProfile` 도메인 모델과 `MobilityType` enum을 추가했습니다.
- 고령자, 유모차, 휠체어, 임산부, 일시 부상, 큰 짐 이동 유형을 지원합니다.
- 계단 회피, 엘리베이터 필요, 에스컬레이터 허용, 환승 최소화, 긴 보행 회피 조건을 저장합니다.
- 큰 글씨, 고대비, 단순 보기 설정을 함께 저장합니다.
- `GET /api/v1/me/mobility-profile?userId={userId}` API를 추가했습니다.
- `PUT /api/v1/me/mobility-profile` API를 추가했습니다.
- 없는 사용자에게는 기본 이동 프로필을 반환합니다.
- 휠체어 프로필에서 계단 허용 요청은 공통 400 오류로 거부합니다.
- 서비스 테스트, 컨트롤러 테스트, 저장소 계약 테스트를 추가했습니다.

## 검증

- RED: `./gradlew test --tests com.easysubway.profile.application.service.MobilityProfileServiceTest --tests com.easysubway.profile.adapter.in.web.MobilityProfileControllerTest --no-daemon`
  - profile 패키지가 없어 컴파일 실패하는 것을 확인했습니다.
- GREEN: `./gradlew test --tests com.easysubway.profile.application.service.MobilityProfileServiceTest --tests com.easysubway.profile.adapter.in.web.MobilityProfileControllerTest --no-daemon`
- `node --test tools/ci/*.test.mjs`
- `./gradlew test --no-daemon`
- `./gradlew check --no-daemon`
- `git diff --check`
- `git diff --cached --check`
- `git ls-files '*.md'`
- PR CI: https://github.com/AquilaXk/easysubway/actions/runs/27399990917
- main CI: https://github.com/AquilaXk/easysubway/actions/runs/27400326765
- CodeRabbit: actionable comment 없음
- Codex CLI code review: CodeRabbit 실제 리뷰 완료로 미실행
- CD 확인: 별도 배포 workflow는 아직 없으며 main CI 빌드 게이트 통과까지 확인

## 리스크

- 현재 저장소는 in-memory 기준선입니다. 실제 사용자 설정 보존은 DB/JPA 작업에서 분리해 연결해야 합니다.
- 인증이 아직 없으므로 `userId`는 클라이언트가 전달하는 익명 식별자 형태로만 사용합니다.
- 이동 프로필은 저장까지만 담당하며, 경로 추천 가중치 적용은 별도 작업에서 연결해야 합니다.

## 체크리스트

- [x] 관련 이슈를 연결했다.
- [x] 실행한 명령과 결과를 검증 섹션에 적었다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [x] Codex CLI code review 필요 여부를 확인했다.
- [x] CI가 통과했다.
- [x] CD 상태를 확인했다.
