### PR TITLE
[Feat] 신고 검수 처리 API 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,8 +37,10 @@ dependencies {
 	implementation 'org.egovframe.rte:egovframe-rte-ptl-mvc'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.easysubway.common.security;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -19,14 +20,26 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
 	@Bean
-	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+	@Order(1)
+	SecurityFilterChain adminSecurityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.securityMatcher("/admin/**")
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(authorize -> authorize
+				.anyRequest().hasRole("ADMIN")
+			)
+			.httpBasic(Customizer.withDefaults())
+			.build();
+	}
+
+	@Bean
+	@Order(2)
+	SecurityFilterChain publicSecurityFilterChain(HttpSecurity http) throws Exception {
 		return http
 			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(authorize -> authorize
-				.requestMatchers("/admin/**").hasRole("ADMIN")
 				.anyRequest().permitAll()
 			)
-			.httpBasic(Customizer.withDefaults())
 			.build();
 	}
 

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -1,0 +1,53 @@
+package com.easysubway.common.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+	@Bean
+	SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(authorize -> authorize
+				.requestMatchers("/admin/**").hasRole("ADMIN")
+				.anyRequest().permitAll()
+			)
+			.httpBasic(Customizer.withDefaults())
+			.build();
+	}
+
+	@Bean
+	UserDetailsService userDetailsService(
+		@Value("${easysubway.admin.username:}") String adminUsername,
+		@Value("${easysubway.admin.password:}") String adminPassword,
+		PasswordEncoder passwordEncoder
+	) {
+		var users = new InMemoryUserDetailsManager();
+		if (!adminUsername.isBlank() && !adminPassword.isBlank()) {
+			users.createUser(User.withUsername(adminUsername)
+				.password(passwordEncoder.encode(adminPassword))
+				.roles("ADMIN")
+				.build());
+		}
+		return users;
+	}
+
+	@Bean
+	PasswordEncoder passwordEncoder() {
+		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+	}
+}

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
@@ -3,10 +3,13 @@ package com.easysubway.report.adapter.in.web;
 import com.easysubway.common.web.ApiResponse;
 import com.easysubway.report.application.port.in.CreateFacilityReportCommand;
 import com.easysubway.report.application.port.in.FacilityReportUseCase;
+import com.easysubway.report.application.port.in.ReviewFacilityReportCommand;
 import com.easysubway.report.domain.FacilityReport;
+import com.easysubway.report.domain.FacilityReportReviewDecision;
 import com.easysubway.report.domain.FacilityReportStatus;
 import com.easysubway.report.domain.FacilityReportType;
 import java.math.BigDecimal;
+import java.security.Principal;
 import java.time.LocalDateTime;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,6 +40,16 @@ class FacilityReportController {
 		return ApiResponse.ok(FacilityReportResponse.from(facilityReportUseCase.getReport(reportId)));
 	}
 
+	@PostMapping("/admin/reports/{reportId}/review")
+	ApiResponse<FacilityReportResponse> reviewReport(
+		@PathVariable String reportId,
+		@RequestBody ReviewFacilityReportRequest request,
+		Principal principal
+	) {
+		FacilityReport report = facilityReportUseCase.reviewReport(request.toCommand(reportId, principal.getName()));
+		return ApiResponse.ok(FacilityReportResponse.from(report));
+	}
+
 	record CreateFacilityReportRequest(
 		String userId,
 		String stationId,
@@ -59,6 +72,15 @@ class FacilityReportController {
 				latitude,
 				longitude
 			);
+		}
+	}
+
+	record ReviewFacilityReportRequest(
+		FacilityReportReviewDecision decision
+	) {
+
+		ReviewFacilityReportCommand toCommand(String reportId, String reviewedBy) {
+			return new ReviewFacilityReportCommand(reportId, decision, reviewedBy);
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
@@ -7,4 +7,6 @@ public interface FacilityReportUseCase {
 	FacilityReport createReport(CreateFacilityReportCommand command);
 
 	FacilityReport getReport(String reportId);
+
+	FacilityReport reviewReport(ReviewFacilityReportCommand command);
 }

--- a/backend/src/main/java/com/easysubway/report/application/port/in/ReviewFacilityReportCommand.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/in/ReviewFacilityReportCommand.java
@@ -1,0 +1,10 @@
+package com.easysubway.report.application.port.in;
+
+import com.easysubway.report.domain.FacilityReportReviewDecision;
+
+public record ReviewFacilityReportCommand(
+	String reportId,
+	FacilityReportReviewDecision decision,
+	String reviewedBy
+) {
+}

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -2,10 +2,12 @@ package com.easysubway.report.application.service;
 
 import com.easysubway.report.application.port.in.CreateFacilityReportCommand;
 import com.easysubway.report.application.port.in.FacilityReportUseCase;
+import com.easysubway.report.application.port.in.ReviewFacilityReportCommand;
 import com.easysubway.report.application.port.out.LoadFacilityReportPort;
 import com.easysubway.report.application.port.out.SaveFacilityReportPort;
 import com.easysubway.report.domain.FacilityReport;
 import com.easysubway.report.domain.FacilityReportNotFoundException;
+import com.easysubway.report.domain.FacilityReportReviewDecision;
 import com.easysubway.report.domain.FacilityReportStatus;
 import com.easysubway.report.domain.FacilityReportTargetNotFoundException;
 import com.easysubway.report.domain.InvalidFacilityReportException;
@@ -78,9 +80,46 @@ public class FacilityReportService implements FacilityReportUseCase {
 			.orElseThrow(FacilityReportNotFoundException::new);
 	}
 
+	@Override
+	public FacilityReport reviewReport(ReviewFacilityReportCommand command) {
+		requireReviewDecision(command);
+		requireReviewer(command);
+
+		FacilityReport report = getReport(command.reportId());
+		FacilityReport reviewed = new FacilityReport(
+			report.id(),
+			report.userId(),
+			report.stationId(),
+			report.facilityId(),
+			report.reportType(),
+			report.description(),
+			report.photoUrl(),
+			report.latitude(),
+			report.longitude(),
+			toStatus(command.decision()),
+			report.createdAt(),
+			LocalDateTime.now(clock),
+			command.reviewedBy()
+		);
+
+		return saveFacilityReportPort.saveReport(reviewed);
+	}
+
 	private void requireReportType(CreateFacilityReportCommand command) {
 		if (command.reportType() == null) {
 			throw new InvalidFacilityReportException("신고 유형을 선택해야 합니다.");
+		}
+	}
+
+	private void requireReviewDecision(ReviewFacilityReportCommand command) {
+		if (command.decision() == null) {
+			throw new InvalidFacilityReportException("검수 결과를 선택해야 합니다.");
+		}
+	}
+
+	private void requireReviewer(ReviewFacilityReportCommand command) {
+		if (command.reviewedBy() == null || command.reviewedBy().isBlank()) {
+			throw new InvalidFacilityReportException("검수자 식별자가 필요합니다.");
 		}
 	}
 
@@ -101,5 +140,13 @@ public class FacilityReportService implements FacilityReportUseCase {
 		if (!exists) {
 			throw new FacilityReportTargetNotFoundException();
 		}
+	}
+
+	private FacilityReportStatus toStatus(FacilityReportReviewDecision decision) {
+		return switch (decision) {
+			case ACCEPT -> FacilityReportStatus.ACCEPTED;
+			case REJECT -> FacilityReportStatus.REJECTED;
+			case MARK_DUPLICATE -> FacilityReportStatus.DUPLICATE;
+		};
 	}
 }

--- a/backend/src/main/java/com/easysubway/report/domain/FacilityReportReviewDecision.java
+++ b/backend/src/main/java/com/easysubway/report/domain/FacilityReportReviewDecision.java
@@ -1,0 +1,7 @@
+package com.easysubway.report.domain;
+
+public enum FacilityReportReviewDecision {
+	ACCEPT,
+	REJECT,
+	MARK_DUPLICATE
+}

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -2,6 +2,7 @@ package com.easysubway.report.adapter.in.web;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -13,7 +14,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-test",
+	"easysubway.admin.password=admin-test-password"
+})
 @AutoConfigureMockMvc
 class FacilityReportControllerTest {
 
@@ -114,6 +118,89 @@ class FacilityReportControllerTest {
 	@Test
 	void missingReportReturnsCommonErrorResponse() throws Exception {
 		mockMvc.perform(get("/api/v1/reports/missing-report"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("신고 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
+	void reviewReportStoresAcceptedStatusAndCanBeRead() throws Exception {
+		String response = mockMvc.perform(post("/api/v1/reports")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-review",
+					  "stationId": "station-sangnoksu",
+					  "facilityId": "facility-sangnoksu-elevator-1",
+					  "reportType": "BROKEN",
+					  "description": "엘리베이터 문이 열리지 않습니다."
+					}
+					"""))
+			.andExpect(status().isCreated())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		String reportId = JsonPath.read(response, "$.data.id");
+
+		mockMvc.perform(post("/admin/reports/{reportId}/review", reportId)
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "decision": "ACCEPT"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.id").value(reportId))
+			.andExpect(jsonPath("$.data.status").value("ACCEPTED"))
+			.andExpect(jsonPath("$.data.reviewedAt").isNotEmpty())
+			.andExpect(jsonPath("$.data.reviewedBy").value("admin-test"));
+
+		mockMvc.perform(get("/api/v1/reports/{reportId}", reportId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.status").value("ACCEPTED"))
+			.andExpect(jsonPath("$.data.reviewedBy").value("admin-test"));
+	}
+
+	@Test
+	void reviewReportRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(post("/admin/reports/report-1/review")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "decision": "ACCEPT"
+					}
+					"""))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	void reviewReportRejectsInvalidDecisionRequest() throws Exception {
+		mockMvc.perform(post("/admin/reports/report-1/review")
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("검수 결과를 선택해야 합니다."));
+	}
+
+	@Test
+	void reviewReportReturnsCommonErrorForMissingReport() throws Exception {
+		mockMvc.perform(post("/admin/reports/missing-report/review")
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "decision": "REJECT"
+					}
+					"""))
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.data").doesNotExist())

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.easysubway.report.adapter.out.persistence.InMemoryFacilityReportRepository;
 import com.easysubway.report.application.port.in.CreateFacilityReportCommand;
+import com.easysubway.report.application.port.in.ReviewFacilityReportCommand;
 import com.easysubway.report.domain.FacilityReportNotFoundException;
+import com.easysubway.report.domain.FacilityReportReviewDecision;
 import com.easysubway.report.domain.FacilityReportStatus;
 import com.easysubway.report.domain.FacilityReportTargetNotFoundException;
 import com.easysubway.report.domain.FacilityReportType;
@@ -102,6 +104,106 @@ class FacilityReportServiceTest {
 	@Test
 	void getReportRequiresExistingReport() {
 		assertThatThrownBy(() -> service.getReport("missing-report"))
+			.isInstanceOf(FacilityReportNotFoundException.class)
+			.hasMessage("신고 정보를 찾을 수 없습니다.");
+	}
+
+	@Test
+	void reviewReportStoresAcceptedDecisionAndReviewer() {
+		var report = service.createReport(new CreateFacilityReportCommand(
+			"anonymous-user-1",
+			"station-sangnoksu",
+			"facility-sangnoksu-elevator-1",
+			FacilityReportType.BROKEN,
+			"엘리베이터 문이 열리지 않습니다.",
+			null,
+			null,
+			null
+		));
+
+		var reviewed = service.reviewReport(new ReviewFacilityReportCommand(
+			report.id(),
+			FacilityReportReviewDecision.ACCEPT,
+			"admin-1"
+		));
+
+		assertThat(reviewed.status()).isEqualTo(FacilityReportStatus.ACCEPTED);
+		assertThat(reviewed.reviewedAt()).isEqualTo(LocalDateTime.of(2026, 6, 12, 9, 0));
+		assertThat(reviewed.reviewedBy()).isEqualTo("admin-1");
+		assertThat(service.getReport(report.id())).isEqualTo(reviewed);
+	}
+
+	@Test
+	void reviewReportCanRejectOrMarkDuplicate() {
+		var rejected = service.createReport(new CreateFacilityReportCommand(
+			"anonymous-user-1",
+			"station-sangnoksu",
+			"facility-sangnoksu-elevator-1",
+			FacilityReportType.INFORMATION_WRONG,
+			"기존 정보가 맞습니다.",
+			null,
+			null,
+			null
+		));
+		var duplicated = service.createReport(new CreateFacilityReportCommand(
+			"anonymous-user-2",
+			"station-sangnoksu",
+			"facility-sangnoksu-elevator-1",
+			FacilityReportType.BROKEN,
+			"이미 접수된 신고입니다.",
+			null,
+			null,
+			null
+		));
+
+		assertThat(service.reviewReport(new ReviewFacilityReportCommand(
+			rejected.id(),
+			FacilityReportReviewDecision.REJECT,
+			"admin-1"
+		)).status()).isEqualTo(FacilityReportStatus.REJECTED);
+		assertThat(service.reviewReport(new ReviewFacilityReportCommand(
+			duplicated.id(),
+			FacilityReportReviewDecision.MARK_DUPLICATE,
+			"admin-1"
+		)).status()).isEqualTo(FacilityReportStatus.DUPLICATE);
+	}
+
+	@Test
+	void reviewReportRequiresDecisionAndReviewer() {
+		var report = service.createReport(new CreateFacilityReportCommand(
+			"anonymous-user-1",
+			"station-sangnoksu",
+			"facility-sangnoksu-elevator-1",
+			FacilityReportType.BROKEN,
+			"검수 대상 신고입니다.",
+			null,
+			null,
+			null
+		));
+
+		assertThatThrownBy(() -> service.reviewReport(new ReviewFacilityReportCommand(
+			report.id(),
+			null,
+			"admin-1"
+		)))
+			.isInstanceOf(InvalidFacilityReportException.class)
+			.hasMessage("검수 결과를 선택해야 합니다.");
+		assertThatThrownBy(() -> service.reviewReport(new ReviewFacilityReportCommand(
+			report.id(),
+			FacilityReportReviewDecision.ACCEPT,
+			""
+		)))
+			.isInstanceOf(InvalidFacilityReportException.class)
+			.hasMessage("검수자 식별자가 필요합니다.");
+	}
+
+	@Test
+	void reviewReportRequiresExistingReport() {
+		assertThatThrownBy(() -> service.reviewReport(new ReviewFacilityReportCommand(
+			"missing-report",
+			FacilityReportReviewDecision.ACCEPT,
+			"admin-1"
+		)))
 			.isInstanceOf(FacilityReportNotFoundException.class)
 			.hasMessage("신고 정보를 찾을 수 없습니다.");
 	}

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -1,5 +1,6 @@
 package com.easysubway.transit.adapter.in.web;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -49,6 +50,16 @@ class TransitMasterControllerTest {
 			.andExpect(jsonPath("$.data[0].nameKo").value("상록수"))
 			.andExpect(jsonPath("$.data[0].dataQualityLevel").value("LEVEL_1"))
 			.andExpect(jsonPath("$.data[0].lines[0].id").value("seoul-4"));
+	}
+
+	@Test
+	void publicStationSearchIgnoresInvalidBasicAuthentication() throws Exception {
+		mockMvc.perform(get("/api/v1/stations")
+				.param("query", "상록수")
+				.with(httpBasic("wrong-admin", "wrong-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].id").value("station-sangnoksu"));
 	}
 
 	@Test

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -258,7 +258,9 @@ test("backend facility reports follow hexagonal API boundaries", () => {
   assert.match(controller, /Principal principal/);
   assert.match(controller, /principal\.getName\(\)/);
   assert.match(controller, /@ResponseStatus\(HttpStatus\.CREATED\)/);
-  assert.match(security, /requestMatchers\("\/admin\/\*\*"\)\.hasRole\("ADMIN"\)/);
+  assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
+  assert.match(security, /anyRequest\(\)\.hasRole\("ADMIN"\)/);
+  assert.match(security, /anyRequest\(\)\.permitAll\(\)/);
   assert.match(security, /httpBasic/);
   assert.match(security, /PasswordEncoder/);
   assert.match(security, /passwordEncoder\.encode\(adminPassword\)/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -145,8 +145,10 @@ test("backend scaffold is an eGovFrame 5.0 Spring Boot Java 21 hexagonal project
   assert.match(build, /mavenBom 'org\.egovframe\.boot:egovframe-boot-starter-parent:5\.0\.0'/);
   assert.match(build, /implementation 'org\.egovframe\.rte:egovframe-rte-ptl-mvc'/);
   assert.match(build, /implementation 'org\.springframework\.boot:spring-boot-starter-web'/);
+  assert.match(build, /implementation 'org\.springframework\.boot:spring-boot-starter-security'/);
   assert.match(build, /implementation 'org\.springframework\.boot:spring-boot-starter-actuator'/);
   assert.match(build, /testImplementation 'org\.springframework\.boot:spring-boot-starter-test'/);
+  assert.match(build, /testImplementation 'org\.springframework\.security:spring-security-test'/);
 
   assert.match(application, /@SpringBootApplication/);
   assert.match(domain, /record HealthStatus/);
@@ -211,19 +213,25 @@ test("backend transit master follows hexagonal API boundaries", () => {
 
 test("backend facility reports follow hexagonal API boundaries", () => {
   const report = read("backend/src/main/java/com/easysubway/report/domain/FacilityReport.java");
+  const reportReviewDecision = read("backend/src/main/java/com/easysubway/report/domain/FacilityReportReviewDecision.java");
   const reportType = read("backend/src/main/java/com/easysubway/report/domain/FacilityReportType.java");
   const reportStatus = read("backend/src/main/java/com/easysubway/report/domain/FacilityReportStatus.java");
   const invalidReport = read("backend/src/main/java/com/easysubway/report/domain/InvalidFacilityReportException.java");
   const useCase = read("backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java");
   const command = read("backend/src/main/java/com/easysubway/report/application/port/in/CreateFacilityReportCommand.java");
+  const reviewCommand = read("backend/src/main/java/com/easysubway/report/application/port/in/ReviewFacilityReportCommand.java");
   const loadPort = read("backend/src/main/java/com/easysubway/report/application/port/out/LoadFacilityReportPort.java");
   const savePort = read("backend/src/main/java/com/easysubway/report/application/port/out/SaveFacilityReportPort.java");
   const service = read("backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java");
   const repository = read("backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java");
   const controller = read("backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java");
+  const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
 
   assert.match(report, /record FacilityReport/);
   assert.match(report, /reviewedAt/);
+  assert.match(reportReviewDecision, /ACCEPT/);
+  assert.match(reportReviewDecision, /REJECT/);
+  assert.match(reportReviewDecision, /MARK_DUPLICATE/);
   assert.match(reportType, /BROKEN/);
   assert.match(reportType, /LOCATION_WRONG/);
   assert.match(reportStatus, /SUBMITTED/);
@@ -232,16 +240,28 @@ test("backend facility reports follow hexagonal API boundaries", () => {
   assert.match(useCase, /interface FacilityReportUseCase/);
   assert.match(useCase, /createReport/);
   assert.match(useCase, /getReport/);
+  assert.match(useCase, /reviewReport/);
   assert.match(command, /record CreateFacilityReportCommand/);
+  assert.match(reviewCommand, /record ReviewFacilityReportCommand/);
   assert.match(loadPort, /interface LoadFacilityReportPort/);
   assert.match(savePort, /interface SaveFacilityReportPort/);
   assert.match(service, /implements FacilityReportUseCase/);
   assert.match(service, /LoadTransitMasterPort/);
   assert.match(service, /FacilityReportStatus\.SUBMITTED/);
+  assert.match(service, /FacilityReportStatus\.ACCEPTED/);
+  assert.match(service, /FacilityReportStatus\.REJECTED/);
+  assert.match(service, /FacilityReportStatus\.DUPLICATE/);
   assert.match(repository, /implements LoadFacilityReportPort, SaveFacilityReportPort/);
   assert.match(controller, /@PostMapping\("\/api\/v1\/reports"\)/);
   assert.match(controller, /@GetMapping\("\/api\/v1\/reports\/\{reportId\}"\)/);
+  assert.match(controller, /@PostMapping\("\/admin\/reports\/\{reportId\}\/review"\)/);
+  assert.match(controller, /Principal principal/);
+  assert.match(controller, /principal\.getName\(\)/);
   assert.match(controller, /@ResponseStatus\(HttpStatus\.CREATED\)/);
+  assert.match(security, /requestMatchers\("\/admin\/\*\*"\)\.hasRole\("ADMIN"\)/);
+  assert.match(security, /httpBasic/);
+  assert.match(security, /PasswordEncoder/);
+  assert.match(security, /passwordEncoder\.encode\(adminPassword\)/);
 });
 
 test("backend mobility profiles follow hexagonal API boundaries", () => {


### PR DESCRIPTION
## 관련 이슈

close #19

## 요약

접수된 시설 신고를 관리자가 승인, 거절, 중복으로 검수할 수 있는 백엔드 API 기준선을 추가했습니다. 검수 결과는 신고 상태로 저장되고, 검수 시각과 검수자 식별자는 함께 기록됩니다.

관리자 검수 API는 Basic 인증이 있는 ADMIN 권한에서만 호출할 수 있고, 검수자 식별자는 요청 본문이 아니라 인증 주체에서 가져옵니다.

## 변경 사항

- 신고 검수 결과 enum을 추가했습니다.
- 신고 검수 command와 use case method를 추가했습니다.
- `POST /admin/reports/{reportId}/review` API를 추가했습니다.
- `/admin/**` 요청을 ADMIN 권한으로 제한하는 Spring Security 설정을 추가했습니다.
- 관리자 비밀번호 설정값은 `PasswordEncoder`로 인코딩해 저장합니다.
- 승인은 `ACCEPTED`, 거절은 `REJECTED`, 중복은 `DUPLICATE` 상태로 저장합니다.
- 검수 시각과 인증된 검수자 식별자를 신고에 기록합니다.
- 없는 신고는 공통 404 오류로 반환합니다.
- 검수 결과가 없는 요청은 공통 400 오류로 반환합니다.
- 서비스 테스트, 컨트롤러 테스트, 저장소 계약 테스트를 추가했습니다.

## 검증

- RED: `./gradlew test --tests com.easysubway.report.application.service.FacilityReportServiceTest --tests com.easysubway.report.adapter.in.web.FacilityReportControllerTest --no-daemon`
  - 검수 command와 decision이 없어 컴파일 실패하는 것을 확인했습니다.
- GREEN: `./gradlew test --tests com.easysubway.report.application.service.FacilityReportServiceTest --tests com.easysubway.report.adapter.in.web.FacilityReportControllerTest --no-daemon`
- RED: `./gradlew test --tests com.easysubway.report.adapter.in.web.FacilityReportControllerTest --no-daemon`
  - 관리자 비밀번호를 평문 설정값으로 두면 인증이 실패하는 것을 확인했습니다.
- GREEN: `./gradlew test --tests com.easysubway.report.adapter.in.web.FacilityReportControllerTest --no-daemon`
- `node --test tools/ci/*.test.mjs`
- `./gradlew test --no-daemon`
- `./gradlew check --no-daemon`
- `git diff --check`
- `git diff --cached --check`
- `git ls-files *.md`
- PR CI: https://github.com/AquilaXk/easysubway/actions/runs/27401248900
- CodeRabbit: 한도와 크레딧 부족으로 실제 리뷰가 시작되지 않았습니다.
- Codex CLI code review: P1, P2 지적을 확인했고 같은 PR에서 수정했습니다. 최종 재실행은 Codex CLI 사용량 제한으로 중단되었습니다.

## 리스크

- 승인된 신고를 실제 시설 상태에 반영하는 처리는 별도 작업으로 분리했습니다.
- 알림 발송과 신고 목록 화면은 포함하지 않았습니다.
- 최종 Codex CLI 재검토는 사용량 제한 해제 후 다시 실행해야 합니다.

## 체크리스트

- [x] 관련 이슈를 연결했다.
- [x] 실행한 명령과 결과를 검증 섹션에 적었다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [x] Codex CLI code review 필요 여부를 확인했다.
- [x] CI가 통과했다.
- [ ] 최종 Codex CLI 재검토를 완료했다.
- [ ] CD 상태를 확인했다.
