### PR TITLE
[Feat] 역 검색 API 연동 추가

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:label="쉬운 지하철"
         android:name="${applicationName}"

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,11 +1,18 @@
 import 'package:flutter/material.dart';
 
+import 'station_search.dart';
+
 void main() {
-  runApp(const EasySubwayApp());
+  runApp(EasySubwayApp());
 }
 
 class EasySubwayApp extends StatelessWidget {
-  const EasySubwayApp({super.key});
+  EasySubwayApp({StationSearchRepository? repository, super.key})
+    : repository =
+          repository ??
+          StationSearchApiRepository(baseUri: defaultStationApiBaseUri());
+
+  final StationSearchRepository repository;
 
   @override
   Widget build(BuildContext context) {
@@ -50,13 +57,15 @@ class EasySubwayApp extends StatelessWidget {
         ),
         useMaterial3: true,
       ),
-      home: const HomeScreen(),
+      home: HomeScreen(repository: repository),
     );
   }
 }
 
 class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+  const HomeScreen({required this.repository, super.key});
+
+  final StationSearchRepository repository;
 
   @override
   Widget build(BuildContext context) {
@@ -82,9 +91,15 @@ class HomeScreen extends StatelessWidget {
             const SizedBox(height: 24),
             FilledButton.icon(
               key: const Key('stationSearchButton'),
-              onPressed: () {},
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => StationSearchScreen(repository: repository),
+                  ),
+                );
+              },
               icon: const Icon(Icons.search),
-              label: const Text('가까운 역'),
+              label: const Text('역 검색'),
             ),
             const SizedBox(height: 12),
             OutlinedButton.icon(

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -4,6 +4,9 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+const _stationSearchTimeout = Duration(seconds: 8);
+const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
+
 abstract class StationSearchRepository {
   Future<List<StationSearchResult>> searchStations(String query);
 }
@@ -22,34 +25,40 @@ class StationSearchApiRepository implements StationSearchRepository {
         .replace(queryParameters: {'query': query});
 
     try {
-      final request = await _httpClient.getUrl(uri);
-      final response = await request.close().timeout(
-        const Duration(seconds: 8),
-      );
-      final body = await utf8.decodeStream(response);
+      final request = await _httpClient
+          .getUrl(uri)
+          .timeout(_stationSearchTimeout);
+      final response = await request.close().timeout(_stationSearchTimeout);
+      final body = await utf8
+          .decodeStream(response)
+          .timeout(_stationSearchTimeout);
 
       if (response.statusCode != HttpStatus.ok) {
-        throw const StationSearchException('역 정보를 불러오지 못했습니다.');
+        throw const StationSearchException(_stationSearchErrorMessage);
       }
 
       final decoded = jsonDecode(body);
       if (decoded is! Map<String, Object?> || decoded['success'] != true) {
-        throw const StationSearchException('역 정보를 불러오지 못했습니다.');
+        throw const StationSearchException(_stationSearchErrorMessage);
       }
 
       final data = decoded['data'];
       if (data is! List) {
-        throw const StationSearchException('역 정보를 불러오지 못했습니다.');
+        throw const StationSearchException(_stationSearchErrorMessage);
       }
 
       return data
-          .whereType<Map<String, Object?>>()
-          .map(StationSearchResult.fromJson)
-          .toList();
+          .map((item) {
+            if (item is! Map<String, Object?>) {
+              throw const FormatException('Invalid station payload');
+            }
+            return StationSearchResult.fromJson(item);
+          })
+          .toList(growable: false);
     } on StationSearchException {
       rethrow;
     } catch (_) {
-      throw const StationSearchException('역 정보를 불러오지 못했습니다.');
+      throw const StationSearchException(_stationSearchErrorMessage);
     }
   }
 }
@@ -75,20 +84,26 @@ class StationSearchResult {
   });
 
   factory StationSearchResult.fromJson(Map<String, Object?> json) {
-    final lines = json['lines'];
+    final rawLines = json['lines'];
+    if (rawLines is! List) {
+      throw const FormatException('Invalid station lines payload');
+    }
+
     return StationSearchResult(
-      id: json['id'] as String? ?? '',
-      nameKo: json['nameKo'] as String? ?? '',
-      nameEn: json['nameEn'] as String? ?? '',
-      region: json['region'] as String? ?? '',
-      dataQualityLevel: json['dataQualityLevel'] as String? ?? '',
-      lastVerifiedAt: json['lastVerifiedAt'] as String? ?? '',
-      lines: lines is List
-          ? lines
-                .whereType<Map<String, Object?>>()
-                .map(StationSearchLine.fromJson)
-                .toList()
-          : const [],
+      id: _requiredString(json, 'id'),
+      nameKo: _requiredString(json, 'nameKo'),
+      nameEn: _requiredString(json, 'nameEn'),
+      region: _requiredString(json, 'region'),
+      dataQualityLevel: _requiredString(json, 'dataQualityLevel'),
+      lastVerifiedAt: _requiredString(json, 'lastVerifiedAt'),
+      lines: rawLines
+          .map((item) {
+            if (item is! Map<String, Object?>) {
+              throw const FormatException('Invalid station line payload');
+            }
+            return StationSearchLine.fromJson(item);
+          })
+          .toList(growable: false),
     );
   }
 
@@ -130,12 +145,20 @@ class StationSearchLine {
 
   factory StationSearchLine.fromJson(Map<String, Object?> json) {
     return StationSearchLine(
-      id: json['id'] as String? ?? '',
-      name: json['name'] as String? ?? '',
-      color: json['color'] as String? ?? '',
-      stationCode: json['stationCode'] as String? ?? '',
+      id: _requiredString(json, 'id'),
+      name: _requiredString(json, 'name'),
+      color: _requiredString(json, 'color'),
+      stationCode: _requiredString(json, 'stationCode'),
     );
   }
+
+  static const _knownBadgeLabels = <String, String>{
+    '경의중앙': '경의중앙',
+    '수인분당': '수인분당',
+    '신분당': '신분당',
+    '인천1': '인천1',
+    '인천2': '인천2',
+  };
 
   final String id;
   final String name;
@@ -143,25 +166,22 @@ class StationSearchLine {
   final String stationCode;
 
   String get badgeText {
+    for (final entry in _knownBadgeLabels.entries) {
+      if (name.contains(entry.key)) {
+        return entry.value;
+      }
+    }
+
     final numberedLine = RegExp(r'(\d+)\s*호선').firstMatch(name);
     if (numberedLine != null) {
       return numberedLine.group(1) ?? name;
     }
 
-    if (name.contains('경의중앙')) {
-      return '경의\n중앙';
-    }
-    if (name.contains('수인분당')) {
-      return '수인\n분당';
-    }
-    if (name.contains('인천') && name.contains('1')) {
-      return '인천1';
-    }
-    if (name.contains('인천') && name.contains('2')) {
-      return '인천2';
-    }
-
-    final compactName = name.replaceAll('수도권 ', '').replaceAll('선', '');
+    final compactName = name
+        .replaceAll('수도권 ', '')
+        .replaceAll('광역 ', '')
+        .replaceAll('선', '')
+        .trim();
     if (compactName.length <= 4) {
       return compactName;
     }
@@ -178,6 +198,14 @@ class StationSearchLine {
     }
     return const Color(0xFF006D77);
   }
+}
+
+String _requiredString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is String && value.trim().isNotEmpty) {
+    return value;
+  }
+  throw FormatException('Missing required station field: $key');
 }
 
 enum StationSearchStatus { idle, loading, success, empty, failure }
@@ -319,11 +347,20 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
               ),
             ),
             const SizedBox(height: 12),
-            FilledButton.icon(
-              key: const Key('stationSearchSubmitButton'),
-              onPressed: () => _submit(_queryController.text),
-              icon: const Icon(Icons.search),
-              label: const Text('검색'),
+            AnimatedBuilder(
+              animation: _controller,
+              builder: (context, _) {
+                final isLoading =
+                    _controller.state.status == StationSearchStatus.loading;
+                return FilledButton.icon(
+                  key: const Key('stationSearchSubmitButton'),
+                  onPressed: isLoading
+                      ? null
+                      : () => _submit(_queryController.text),
+                  icon: const Icon(Icons.search),
+                  label: const Text('검색'),
+                );
+              },
             ),
             const SizedBox(height: 20),
             AnimatedBuilder(
@@ -339,6 +376,9 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   }
 
   void _submit(String query) {
+    if (_controller.state.status == StationSearchStatus.loading) {
+      return;
+    }
     _controller.search(query);
   }
 }
@@ -365,7 +405,13 @@ class _StationSearchBody extends StatelessWidget {
       StationSearchStatus.empty || StationSearchStatus.failure =>
         _StationSearchMessage(message: state.message, liveRegion: true),
       StationSearchStatus.success => Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
+          Semantics(
+            label: '검색 결과 ${state.results.length}개',
+            liveRegion: true,
+            child: const SizedBox.shrink(),
+          ),
           for (final result in state.results)
             _StationSearchResultTile(result: result),
         ],
@@ -496,7 +542,7 @@ class _StationSearchLineBadge extends StatelessWidget {
     final backgroundColor = line.badgeColor;
     final foregroundColor = _higherContrastTextColor(backgroundColor);
     final badgeText = line.badgeText;
-    final badgeFontSize = RegExp(r'^\d+$').hasMatch(badgeText) ? 24.0 : 13.0;
+    final badgeFontSize = RegExp(r'^\d+$').hasMatch(badgeText) ? 24.0 : 15.0;
 
     return Container(
       key: Key('stationLineBadge-${line.id}'),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -205,10 +205,12 @@ class StationSearchController extends ChangeNotifier {
   final StationSearchRepository repository;
 
   StationSearchState _state = const StationSearchState.idle();
+  int _searchRequestId = 0;
 
   StationSearchState get state => _state;
 
   Future<void> search(String query) async {
+    final requestId = ++_searchRequestId;
     final trimmedQuery = query.trim();
     if (trimmedQuery.isEmpty) {
       _state = const StationSearchState.idle();
@@ -224,6 +226,9 @@ class StationSearchController extends ChangeNotifier {
 
     try {
       final results = await repository.searchStations(trimmedQuery);
+      if (requestId != _searchRequestId) {
+        return;
+      }
       if (results.isEmpty) {
         _state = const StationSearchState(
           status: StationSearchStatus.empty,
@@ -237,12 +242,18 @@ class StationSearchController extends ChangeNotifier {
         );
       }
     } on StationSearchException catch (error) {
+      if (requestId != _searchRequestId) {
+        return;
+      }
       _state = StationSearchState(
         status: StationSearchStatus.failure,
         results: const [],
         message: error.message,
       );
     } catch (_) {
+      if (requestId != _searchRequestId) {
+        return;
+      }
       _state = const StationSearchState(
         status: StationSearchStatus.failure,
         results: [],
@@ -397,7 +408,6 @@ class _StationSearchResultTile extends StatelessWidget {
     return MergeSemantics(
       child: Semantics(
         label: result.semanticLabel,
-        button: true,
         child: ExcludeSemantics(
           child: Card(
             margin: const EdgeInsets.only(bottom: 12),
@@ -484,9 +494,7 @@ class _StationSearchLineBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final backgroundColor = line.badgeColor;
-    final foregroundColor = backgroundColor.computeLuminance() > 0.55
-        ? const Color(0xFF102A2C)
-        : Colors.white;
+    final foregroundColor = _higherContrastTextColor(backgroundColor);
     final badgeText = line.badgeText;
     final badgeFontSize = RegExp(r'^\d+$').hasMatch(badgeText) ? 24.0 : 13.0;
 
@@ -509,6 +517,22 @@ class _StationSearchLineBadge extends StatelessWidget {
       ),
     );
   }
+}
+
+Color _higherContrastTextColor(Color backgroundColor) {
+  const darkText = Color(0xFF102A2C);
+  final darkContrast = _contrastRatio(backgroundColor, darkText);
+  final lightContrast = _contrastRatio(backgroundColor, Colors.white);
+  return darkContrast >= lightContrast ? darkText : Colors.white;
+}
+
+double _contrastRatio(Color first, Color second) {
+  final firstLuminance = first.computeLuminance() + 0.05;
+  final secondLuminance = second.computeLuminance() + 0.05;
+  if (firstLuminance > secondLuminance) {
+    return firstLuminance / secondLuminance;
+  }
+  return secondLuminance / firstLuminance;
 }
 
 Uri defaultStationApiBaseUri() {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -141,6 +141,43 @@ class StationSearchLine {
   final String name;
   final String color;
   final String stationCode;
+
+  String get badgeText {
+    final numberedLine = RegExp(r'(\d+)\s*호선').firstMatch(name);
+    if (numberedLine != null) {
+      return numberedLine.group(1) ?? name;
+    }
+
+    if (name.contains('경의중앙')) {
+      return '경의\n중앙';
+    }
+    if (name.contains('수인분당')) {
+      return '수인\n분당';
+    }
+    if (name.contains('인천') && name.contains('1')) {
+      return '인천1';
+    }
+    if (name.contains('인천') && name.contains('2')) {
+      return '인천2';
+    }
+
+    final compactName = name.replaceAll('수도권 ', '').replaceAll('선', '');
+    if (compactName.length <= 4) {
+      return compactName;
+    }
+    return compactName.substring(0, 4);
+  }
+
+  Color get badgeColor {
+    final normalized = color.trim().replaceFirst('#', '');
+    if (normalized.length == 6) {
+      final parsed = int.tryParse(normalized, radix: 16);
+      if (parsed != null) {
+        return Color(0xFF000000 | parsed);
+      }
+    }
+    return const Color(0xFF006D77);
+  }
 }
 
 enum StationSearchStatus { idle, loading, success, empty, failure }
@@ -261,7 +298,8 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
                 style: const TextStyle(fontSize: 20, height: 1.35),
                 decoration: const InputDecoration(
                   labelText: '역 이름',
-                  hintText: '예: 상록수',
+                  hintText: '역 이름을 입력해 주세요',
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.all(Radius.circular(8)),
                   ),
@@ -302,9 +340,7 @@ class _StationSearchBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return switch (state.status) {
-      StationSearchStatus.idle => const _StationSearchMessage(
-        message: '역 이름을 입력해 주세요.',
-      ),
+      StationSearchStatus.idle => const SizedBox.shrink(),
       StationSearchStatus.loading => Semantics(
         label: '역 검색 중',
         liveRegion: true,
@@ -356,6 +392,8 @@ class _StationSearchResultTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
     return MergeSemantics(
       child: Semantics(
         label: result.semanticLabel,
@@ -371,59 +409,102 @@ class _StationSearchResultTile extends StatelessWidget {
             ),
             child: Padding(
               padding: const EdgeInsets.all(16),
-              child: Row(
+              child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Icon(Icons.train, color: Color(0xFF006D77), size: 32),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          result.nameKo,
-                          style: Theme.of(context).textTheme.titleLarge
-                              ?.copyWith(
-                                color: const Color(0xFF102A2C),
-                                fontWeight: FontWeight.w800,
-                                height: 1.25,
-                              ),
-                        ),
-                        const SizedBox(height: 6),
-                        Text(
-                          result.lineLabel,
-                          style: Theme.of(context).textTheme.bodyLarge
-                              ?.copyWith(
-                                color: const Color(0xFF29484B),
-                                fontWeight: FontWeight.w700,
-                                height: 1.3,
-                              ),
-                        ),
-                        const SizedBox(height: 6),
-                        Text(
-                          result.region,
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(
-                                color: const Color(0xFF405A5D),
-                                height: 1.3,
-                              ),
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          result.dataQualityLabel,
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(
-                                color: const Color(0xFF405A5D),
-                                height: 1.3,
-                              ),
-                        ),
-                      ],
+                  Text(
+                    result.nameKo,
+                    style: textTheme.titleLarge?.copyWith(
+                      color: const Color(0xFF102A2C),
+                      fontWeight: FontWeight.w800,
+                      height: 1.25,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  _StationSearchLineBadges(lines: result.lines),
+                  const SizedBox(height: 8),
+                  Text(
+                    result.lineLabel,
+                    style: textTheme.bodyLarge?.copyWith(
+                      color: const Color(0xFF29484B),
+                      fontWeight: FontWeight.w700,
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    result.region,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: const Color(0xFF405A5D),
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    result.dataQualityLabel,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: const Color(0xFF405A5D),
+                      height: 1.3,
                     ),
                   ),
                 ],
               ),
             ),
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StationSearchLineBadges extends StatelessWidget {
+  const _StationSearchLineBadges({required this.lines});
+
+  final List<StationSearchLine> lines;
+
+  @override
+  Widget build(BuildContext context) {
+    if (lines.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [for (final line in lines) _StationSearchLineBadge(line: line)],
+    );
+  }
+}
+
+class _StationSearchLineBadge extends StatelessWidget {
+  const _StationSearchLineBadge({required this.line});
+
+  final StationSearchLine line;
+
+  @override
+  Widget build(BuildContext context) {
+    final backgroundColor = line.badgeColor;
+    final foregroundColor = backgroundColor.computeLuminance() > 0.55
+        ? const Color(0xFF102A2C)
+        : Colors.white;
+    final badgeText = line.badgeText;
+    final badgeFontSize = RegExp(r'^\d+$').hasMatch(badgeText) ? 24.0 : 13.0;
+
+    return Container(
+      key: Key('stationLineBadge-${line.id}'),
+      width: 40,
+      height: 40,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(color: backgroundColor, shape: BoxShape.circle),
+      child: Text(
+        badgeText,
+        textAlign: TextAlign.center,
+        maxLines: 2,
+        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+          color: foregroundColor,
+          fontSize: badgeFontSize,
+          fontWeight: FontWeight.w900,
+          height: 1.05,
         ),
       ),
     );

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -102,11 +102,11 @@ class StationSearchResult {
 
   String get dataQualityLabel {
     return switch (dataQualityLevel) {
-      'LEVEL_1' => '데이터 수준 1',
-      'LEVEL_2' => '데이터 수준 2',
-      'LEVEL_3' => '데이터 수준 3',
-      'LEVEL_4' => '데이터 수준 4',
-      _ => '데이터 수준 미확인',
+      'LEVEL_1' => '기본 정보만 확인됨',
+      'LEVEL_2' => '접근성 시설 확인됨',
+      'LEVEL_3' => '쉬운 경로 안내 가능',
+      'LEVEL_4' => '실시간 상태 반영됨',
+      _ => '확인 정보 부족',
     };
   }
 

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1,0 +1,442 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+abstract class StationSearchRepository {
+  Future<List<StationSearchResult>> searchStations(String query);
+}
+
+class StationSearchApiRepository implements StationSearchRepository {
+  StationSearchApiRepository({required this.baseUri, HttpClient? httpClient})
+    : _httpClient = httpClient ?? HttpClient();
+
+  final Uri baseUri;
+  final HttpClient _httpClient;
+
+  @override
+  Future<List<StationSearchResult>> searchStations(String query) async {
+    final uri = baseUri
+        .resolve('/api/v1/stations')
+        .replace(queryParameters: {'query': query});
+
+    try {
+      final request = await _httpClient.getUrl(uri);
+      final response = await request.close().timeout(
+        const Duration(seconds: 8),
+      );
+      final body = await utf8.decodeStream(response);
+
+      if (response.statusCode != HttpStatus.ok) {
+        throw const StationSearchException('역 정보를 불러오지 못했습니다.');
+      }
+
+      final decoded = jsonDecode(body);
+      if (decoded is! Map<String, Object?> || decoded['success'] != true) {
+        throw const StationSearchException('역 정보를 불러오지 못했습니다.');
+      }
+
+      final data = decoded['data'];
+      if (data is! List) {
+        throw const StationSearchException('역 정보를 불러오지 못했습니다.');
+      }
+
+      return data
+          .whereType<Map<String, Object?>>()
+          .map(StationSearchResult.fromJson)
+          .toList();
+    } on StationSearchException {
+      rethrow;
+    } catch (_) {
+      throw const StationSearchException('역 정보를 불러오지 못했습니다.');
+    }
+  }
+}
+
+class StationSearchException implements Exception {
+  const StationSearchException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class StationSearchResult {
+  const StationSearchResult({
+    required this.id,
+    required this.nameKo,
+    required this.nameEn,
+    required this.region,
+    required this.dataQualityLevel,
+    required this.lastVerifiedAt,
+    required this.lines,
+  });
+
+  factory StationSearchResult.fromJson(Map<String, Object?> json) {
+    final lines = json['lines'];
+    return StationSearchResult(
+      id: json['id'] as String? ?? '',
+      nameKo: json['nameKo'] as String? ?? '',
+      nameEn: json['nameEn'] as String? ?? '',
+      region: json['region'] as String? ?? '',
+      dataQualityLevel: json['dataQualityLevel'] as String? ?? '',
+      lastVerifiedAt: json['lastVerifiedAt'] as String? ?? '',
+      lines: lines is List
+          ? lines
+                .whereType<Map<String, Object?>>()
+                .map(StationSearchLine.fromJson)
+                .toList()
+          : const [],
+    );
+  }
+
+  final String id;
+  final String nameKo;
+  final String nameEn;
+  final String region;
+  final String dataQualityLevel;
+  final String lastVerifiedAt;
+  final List<StationSearchLine> lines;
+
+  String get dataQualityLabel {
+    return switch (dataQualityLevel) {
+      'LEVEL_1' => '데이터 수준 1',
+      'LEVEL_2' => '데이터 수준 2',
+      'LEVEL_3' => '데이터 수준 3',
+      'LEVEL_4' => '데이터 수준 4',
+      _ => '데이터 수준 미확인',
+    };
+  }
+
+  String get lineLabel {
+    if (lines.isEmpty) {
+      return '노선 정보 없음';
+    }
+    return lines.map((line) => line.name).join(', ');
+  }
+
+  String get semanticLabel => '$nameKo, $lineLabel, $region, $dataQualityLabel';
+}
+
+class StationSearchLine {
+  const StationSearchLine({
+    required this.id,
+    required this.name,
+    required this.color,
+    required this.stationCode,
+  });
+
+  factory StationSearchLine.fromJson(Map<String, Object?> json) {
+    return StationSearchLine(
+      id: json['id'] as String? ?? '',
+      name: json['name'] as String? ?? '',
+      color: json['color'] as String? ?? '',
+      stationCode: json['stationCode'] as String? ?? '',
+    );
+  }
+
+  final String id;
+  final String name;
+  final String color;
+  final String stationCode;
+}
+
+enum StationSearchStatus { idle, loading, success, empty, failure }
+
+class StationSearchState {
+  const StationSearchState({
+    required this.status,
+    required this.results,
+    this.message = '',
+  });
+
+  const StationSearchState.idle()
+    : status = StationSearchStatus.idle,
+      results = const [],
+      message = '';
+
+  final StationSearchStatus status;
+  final List<StationSearchResult> results;
+  final String message;
+}
+
+class StationSearchController extends ChangeNotifier {
+  StationSearchController({required this.repository});
+
+  final StationSearchRepository repository;
+
+  StationSearchState _state = const StationSearchState.idle();
+
+  StationSearchState get state => _state;
+
+  Future<void> search(String query) async {
+    final trimmedQuery = query.trim();
+    if (trimmedQuery.isEmpty) {
+      _state = const StationSearchState.idle();
+      notifyListeners();
+      return;
+    }
+
+    _state = const StationSearchState(
+      status: StationSearchStatus.loading,
+      results: [],
+    );
+    notifyListeners();
+
+    try {
+      final results = await repository.searchStations(trimmedQuery);
+      if (results.isEmpty) {
+        _state = const StationSearchState(
+          status: StationSearchStatus.empty,
+          results: [],
+          message: '검색 결과가 없습니다.',
+        );
+      } else {
+        _state = StationSearchState(
+          status: StationSearchStatus.success,
+          results: results,
+        );
+      }
+    } on StationSearchException catch (error) {
+      _state = StationSearchState(
+        status: StationSearchStatus.failure,
+        results: const [],
+        message: error.message,
+      );
+    } catch (_) {
+      _state = const StationSearchState(
+        status: StationSearchStatus.failure,
+        results: [],
+        message: '역 정보를 불러오지 못했습니다.',
+      );
+    }
+    notifyListeners();
+  }
+}
+
+class StationSearchScreen extends StatefulWidget {
+  const StationSearchScreen({required this.repository, super.key});
+
+  final StationSearchRepository repository;
+
+  @override
+  State<StationSearchScreen> createState() => _StationSearchScreenState();
+}
+
+class _StationSearchScreenState extends State<StationSearchScreen> {
+  late final StationSearchController _controller;
+  final TextEditingController _queryController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = StationSearchController(repository: widget.repository);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _queryController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('역 검색')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          children: [
+            Semantics(
+              label: '역 이름 입력',
+              textField: true,
+              child: TextField(
+                key: const Key('stationSearchInput'),
+                controller: _queryController,
+                minLines: 1,
+                textInputAction: TextInputAction.search,
+                style: const TextStyle(fontSize: 20, height: 1.35),
+                decoration: const InputDecoration(
+                  labelText: '역 이름',
+                  hintText: '예: 상록수',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(8)),
+                  ),
+                ),
+                onSubmitted: _submit,
+              ),
+            ),
+            const SizedBox(height: 12),
+            FilledButton.icon(
+              key: const Key('stationSearchSubmitButton'),
+              onPressed: () => _submit(_queryController.text),
+              icon: const Icon(Icons.search),
+              label: const Text('검색'),
+            ),
+            const SizedBox(height: 20),
+            AnimatedBuilder(
+              animation: _controller,
+              builder: (context, _) {
+                return _StationSearchBody(state: _controller.state);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _submit(String query) {
+    _controller.search(query);
+  }
+}
+
+class _StationSearchBody extends StatelessWidget {
+  const _StationSearchBody({required this.state});
+
+  final StationSearchState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (state.status) {
+      StationSearchStatus.idle => const _StationSearchMessage(
+        message: '역 이름을 입력해 주세요.',
+      ),
+      StationSearchStatus.loading => Semantics(
+        label: '역 검색 중',
+        liveRegion: true,
+        child: const Center(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: CircularProgressIndicator(),
+          ),
+        ),
+      ),
+      StationSearchStatus.empty || StationSearchStatus.failure =>
+        _StationSearchMessage(message: state.message, liveRegion: true),
+      StationSearchStatus.success => Column(
+        children: [
+          for (final result in state.results)
+            _StationSearchResultTile(result: result),
+        ],
+      ),
+    };
+  }
+}
+
+class _StationSearchMessage extends StatelessWidget {
+  const _StationSearchMessage({required this.message, this.liveRegion = false});
+
+  final String message;
+  final bool liveRegion;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      liveRegion: liveRegion,
+      child: Text(
+        message,
+        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+          color: const Color(0xFF405A5D),
+          fontWeight: FontWeight.w700,
+          height: 1.35,
+        ),
+      ),
+    );
+  }
+}
+
+class _StationSearchResultTile extends StatelessWidget {
+  const _StationSearchResultTile({required this.result});
+
+  final StationSearchResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    return MergeSemantics(
+      child: Semantics(
+        label: result.semanticLabel,
+        button: true,
+        child: ExcludeSemantics(
+          child: Card(
+            margin: const EdgeInsets.only(bottom: 12),
+            color: Colors.white,
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: const BorderSide(color: Color(0xFFD5E2E4)),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(Icons.train, color: Color(0xFF006D77), size: 32),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          result.nameKo,
+                          style: Theme.of(context).textTheme.titleLarge
+                              ?.copyWith(
+                                color: const Color(0xFF102A2C),
+                                fontWeight: FontWeight.w800,
+                                height: 1.25,
+                              ),
+                        ),
+                        const SizedBox(height: 6),
+                        Text(
+                          result.lineLabel,
+                          style: Theme.of(context).textTheme.bodyLarge
+                              ?.copyWith(
+                                color: const Color(0xFF29484B),
+                                fontWeight: FontWeight.w700,
+                                height: 1.3,
+                              ),
+                        ),
+                        const SizedBox(height: 6),
+                        Text(
+                          result.region,
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: const Color(0xFF405A5D),
+                                height: 1.3,
+                              ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          result.dataQualityLabel,
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: const Color(0xFF405A5D),
+                                height: 1.3,
+                              ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Uri defaultStationApiBaseUri() {
+  const configuredBaseUrl = String.fromEnvironment('EASYSUBWAY_API_BASE_URL');
+  if (configuredBaseUrl.isNotEmpty) {
+    return Uri.parse(configuredBaseUrl);
+  }
+  if (Platform.isAndroid) {
+    return Uri.parse('http://10.0.2.2:8080');
+  }
+  return Uri.parse('http://127.0.0.1:8080');
+}

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -77,6 +78,32 @@ void main() {
     },
   );
 
+  test('station search controller ignores stale responses', () async {
+    final repository = ControlledStationSearchRepository();
+    final controller = StationSearchController(repository: repository);
+
+    final firstSearch = controller.search('상록수');
+    final secondSearch = controller.search('강남');
+
+    expect(repository.requestedQueries, ['상록수', '강남']);
+
+    repository.complete('강남', [
+      _stationResult(id: 'station-gangnam', name: '강남'),
+    ]);
+    await secondSearch;
+
+    expect(controller.state.status, StationSearchStatus.success);
+    expect(controller.state.results.single.nameKo, '강남');
+
+    repository.complete('상록수', [
+      _stationResult(id: 'station-sangnoksu', name: '상록수'),
+    ]);
+    await firstSearch;
+
+    expect(controller.state.status, StationSearchStatus.success);
+    expect(controller.state.results.single.nameKo, '강남');
+  });
+
   test('station search controller exposes empty and failure states', () async {
     final repository = FakeStationSearchRepository();
     final controller = StationSearchController(repository: repository);
@@ -95,6 +122,25 @@ void main() {
   });
 }
 
+StationSearchResult _stationResult({required String id, required String name}) {
+  return StationSearchResult(
+    id: id,
+    nameKo: name,
+    nameEn: id,
+    region: '수도권',
+    dataQualityLevel: 'LEVEL_1',
+    lastVerifiedAt: '2026-06-12',
+    lines: const [
+      StationSearchLine(
+        id: 'seoul-2',
+        name: '수도권 2호선',
+        color: '#00A84D',
+        stationCode: '222',
+      ),
+    ],
+  );
+}
+
 class FakeStationSearchRepository implements StationSearchRepository {
   final requestedQueries = <String>[];
   Object? error;
@@ -108,5 +154,26 @@ class FakeStationSearchRepository implements StationSearchRepository {
       throw currentError;
     }
     return nextResults;
+  }
+}
+
+class ControlledStationSearchRepository implements StationSearchRepository {
+  final requestedQueries = <String>[];
+  final _pending = <String, Completer<List<StationSearchResult>>>{};
+
+  @override
+  Future<List<StationSearchResult>> searchStations(String query) {
+    requestedQueries.add(query);
+    final completer = Completer<List<StationSearchResult>>();
+    _pending[query] = completer;
+    return completer.future;
+  }
+
+  void complete(String query, List<StationSearchResult> results) {
+    final completer = _pending.remove(query);
+    if (completer == null) {
+      throw StateError('Pending search not found: $query');
+    }
+    completer.complete(results);
   }
 }

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -64,6 +64,55 @@ void main() {
     },
   );
 
+  test('station API repository rejects malformed station payloads', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': [
+              {
+                'nameKo': '상록수',
+                'nameEn': 'Sangnoksu',
+                'region': '수도권',
+                'dataQualityLevel': 'LEVEL_1',
+                'lastVerifiedAt': '2026-06-12',
+                'lines': [
+                  {
+                    'id': 'seoul-4',
+                    'name': '수도권 4호선',
+                    'color': '#00A5DE',
+                    'stationCode': '448',
+                  },
+                ],
+              },
+            ],
+          }),
+        )
+        ..close();
+    });
+
+    final repository = StationSearchApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    expect(
+      () => repository.searchStations('상록수'),
+      throwsA(
+        isA<StationSearchException>().having(
+          (error) => error.message,
+          'message',
+          '역 정보를 불러오지 못했습니다.',
+        ),
+      ),
+    );
+  });
+
   test(
     'station search controller keeps blank input idle without API calls',
     () async {

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:easysubway_mobile/station_search.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'station API repository requests backend stations and parses results',
+    () async {
+      late Uri requestedUri;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+
+      server.listen((request) {
+        requestedUri = request.uri;
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(
+            jsonEncode({
+              'success': true,
+              'data': [
+                {
+                  'id': 'station-sangnoksu',
+                  'nameKo': '상록수',
+                  'nameEn': 'Sangnoksu',
+                  'region': '수도권',
+                  'dataQualityLevel': 'LEVEL_1',
+                  'lastVerifiedAt': '2026-06-12',
+                  'lines': [
+                    {
+                      'id': 'seoul-4',
+                      'operatorId': 'seoul-metro',
+                      'name': '수도권 4호선',
+                      'color': '#00A5DE',
+                      'stationCode': '448',
+                      'sequence': 48,
+                      'platformInfo': '당고개 방면 / 오이도 방면',
+                    },
+                  ],
+                },
+              ],
+            }),
+          )
+          ..close();
+      });
+
+      final repository = StationSearchApiRepository(
+        baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      );
+
+      final results = await repository.searchStations('상록수');
+
+      expect(requestedUri.path, '/api/v1/stations');
+      expect(requestedUri.queryParameters['query'], '상록수');
+      expect(results, hasLength(1));
+      expect(results.single.id, 'station-sangnoksu');
+      expect(results.single.nameKo, '상록수');
+      expect(results.single.region, '수도권');
+      expect(results.single.dataQualityLabel, '데이터 수준 1');
+      expect(results.single.lines.single.name, '수도권 4호선');
+    },
+  );
+
+  test(
+    'station search controller keeps blank input idle without API calls',
+    () async {
+      final repository = FakeStationSearchRepository();
+      final controller = StationSearchController(repository: repository);
+
+      await controller.search('   ');
+
+      expect(repository.requestedQueries, isEmpty);
+      expect(controller.state.status, StationSearchStatus.idle);
+      expect(controller.state.results, isEmpty);
+    },
+  );
+
+  test('station search controller exposes empty and failure states', () async {
+    final repository = FakeStationSearchRepository();
+    final controller = StationSearchController(repository: repository);
+
+    await controller.search('없는역');
+
+    expect(controller.state.status, StationSearchStatus.empty);
+    expect(controller.state.message, '검색 결과가 없습니다.');
+
+    repository.error = const StationSearchException('역 정보를 불러오지 못했습니다.');
+
+    await controller.search('상록수');
+
+    expect(controller.state.status, StationSearchStatus.failure);
+    expect(controller.state.message, '역 정보를 불러오지 못했습니다.');
+  });
+}
+
+class FakeStationSearchRepository implements StationSearchRepository {
+  final requestedQueries = <String>[];
+  Object? error;
+  List<StationSearchResult> nextResults = const [];
+
+  @override
+  Future<List<StationSearchResult>> searchStations(String query) async {
+    requestedQueries.add(query);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return nextResults;
+  }
+}

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -58,7 +58,7 @@ void main() {
       expect(results.single.id, 'station-sangnoksu');
       expect(results.single.nameKo, '상록수');
       expect(results.single.region, '수도권');
-      expect(results.single.dataQualityLabel, '데이터 수준 1');
+      expect(results.single.dataQualityLabel, '기본 정보만 확인됨');
       expect(results.single.lines.single.name, '수도권 4호선');
     },
   );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1,4 +1,5 @@
 import 'package:easysubway_mobile/main.dart';
+import 'package:easysubway_mobile/station_search.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -7,10 +8,12 @@ void main() {
     final semanticsHandle = tester.ensureSemantics();
 
     try {
-      await tester.pumpWidget(const EasySubwayApp());
+      await tester.pumpWidget(
+        EasySubwayApp(repository: FakeStationSearchRepository()),
+      );
 
       expect(find.text('역 찾기'), findsOneWidget);
-      expect(find.widgetWithText(FilledButton, '가까운 역'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '역 검색'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsOneWidget);
       expect(find.text('이동 프로필'), findsOneWidget);
       expect(find.text('시설 정보'), findsOneWidget);
@@ -35,4 +38,66 @@ void main() {
       semanticsHandle.dispose();
     }
   });
+
+  testWidgets('searches stations and shows accessible backend results', (
+    tester,
+  ) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final repository = FakeStationSearchRepository(
+      nextResults: [
+        const StationSearchResult(
+          id: 'station-sangnoksu',
+          nameKo: '상록수',
+          nameEn: 'Sangnoksu',
+          region: '수도권',
+          dataQualityLevel: 'LEVEL_1',
+          lastVerifiedAt: '2026-06-12',
+          lines: [
+            StationSearchLine(
+              id: 'seoul-4',
+              name: '수도권 4호선',
+              color: '#00A5DE',
+              stationCode: '448',
+            ),
+          ],
+        ),
+      ],
+    );
+
+    try {
+      await tester.pumpWidget(EasySubwayApp(repository: repository));
+
+      await tester.tap(find.byKey(const Key('stationSearchButton')));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('stationSearchInput')),
+        '상록수',
+      );
+      await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+      await tester.pumpAndSettle();
+
+      expect(repository.requestedQueries, ['상록수']);
+      expect(find.text('수도권 4호선'), findsOneWidget);
+      expect(find.text('데이터 수준 1'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('상록수, 수도권 4호선, 수도권, 데이터 수준 1'),
+        findsOneWidget,
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+}
+
+class FakeStationSearchRepository implements StationSearchRepository {
+  FakeStationSearchRepository({this.nextResults = const []});
+
+  final List<StationSearchResult> nextResults;
+  final requestedQueries = <String>[];
+
+  @override
+  Future<List<StationSearchResult>> searchStations(String query) async {
+    requestedQueries.add(query);
+    return nextResults;
+  }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -69,6 +69,18 @@ void main() {
 
       await tester.tap(find.byKey(const Key('stationSearchButton')));
       await tester.pumpAndSettle();
+
+      final searchInput = tester.widget<TextField>(
+        find.byKey(const Key('stationSearchInput')),
+      );
+      expect(searchInput.decoration?.hintText, '역 이름을 입력해 주세요');
+      expect(searchInput.decoration?.hintText, isNot('예: 상록수'));
+      expect(find.text('역 이름을 입력해 주세요.'), findsNothing);
+      expect(
+        searchInput.decoration?.floatingLabelBehavior,
+        FloatingLabelBehavior.always,
+      );
+
       await tester.enterText(
         find.byKey(const Key('stationSearchInput')),
         '상록수',
@@ -77,12 +89,23 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(repository.requestedQueries, ['상록수']);
+      expect(find.byKey(const Key('stationLineBadge-seoul-4')), findsOneWidget);
+      expect(find.text('4'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
       expect(find.text('기본 정보만 확인됨'), findsOneWidget);
       expect(
         find.bySemanticsLabel('상록수, 수도권 4호선, 수도권, 기본 정보만 확인됨'),
         findsOneWidget,
       );
+
+      final lineBadgeSize = tester.getSize(
+        find.byKey(const Key('stationLineBadge-seoul-4')),
+      );
+      expect(lineBadgeSize.width, 40);
+      expect(lineBadgeSize.height, 40);
+
+      final lineNumber = tester.widget<Text>(find.text('4'));
+      expect(lineNumber.style?.fontSize, 24);
     } finally {
       semanticsHandle.dispose();
     }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:easysubway_mobile/main.dart';
 import 'package:easysubway_mobile/station_search.dart';
 import 'package:flutter/material.dart';
@@ -59,6 +61,12 @@ void main() {
               color: '#00A5DE',
               stationCode: '448',
             ),
+            StationSearchLine(
+              id: 'korail-gyeongui-jungang',
+              name: '경의중앙선',
+              color: '#75C5A1',
+              stationCode: 'K232',
+            ),
           ],
         ),
       ],
@@ -91,14 +99,20 @@ void main() {
       expect(repository.requestedQueries, ['상록수']);
       expect(find.byKey(const Key('stationLineBadge-seoul-4')), findsOneWidget);
       expect(find.text('4'), findsOneWidget);
-      expect(find.text('수도권 4호선'), findsOneWidget);
-      expect(find.text('기본 정보만 확인됨'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('상록수, 수도권 4호선, 수도권, 기본 정보만 확인됨'),
+        find.byKey(const Key('stationLineBadge-korail-gyeongui-jungang')),
+        findsOneWidget,
+      );
+      expect(find.text('경의중앙'), findsOneWidget);
+      expect(find.text('수도권 4호선, 경의중앙선'), findsOneWidget);
+      expect(find.text('기본 정보만 확인됨'), findsOneWidget);
+      expect(find.bySemanticsLabel('검색 결과 1개'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 확인됨'),
         findsOneWidget,
       );
       final resultSemantics = tester.getSemantics(
-        find.bySemanticsLabel('상록수, 수도권 4호선, 수도권, 기본 정보만 확인됨'),
+        find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 확인됨'),
       );
       expect(
         resultSemantics.getSemanticsData().flagsCollection.isButton,
@@ -114,9 +128,41 @@ void main() {
       final lineNumber = tester.widget<Text>(find.text('4'));
       expect(lineNumber.style?.fontSize, 24);
       expect(lineNumber.style?.color, const Color(0xFF102A2C));
+
+      final namedLine = tester.widget<Text>(find.text('경의중앙'));
+      expect(namedLine.style?.fontSize, 15);
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('disables search button while request is loading', (
+    tester,
+  ) async {
+    final repository = ControlledStationSearchRepository();
+
+    await tester.pumpWidget(EasySubwayApp(repository: repository));
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pump();
+
+    expect(repository.requestedQueries, ['상록수']);
+    final loadingButton = tester.widget<FilledButton>(
+      find.byKey(const Key('stationSearchSubmitButton')),
+    );
+    expect(loadingButton.onPressed, isNull);
+
+    repository.complete(const []);
+    await tester.pumpAndSettle();
+
+    final completedButton = tester.widget<FilledButton>(
+      find.byKey(const Key('stationSearchSubmitButton')),
+    );
+    expect(completedButton.onPressed, isNotNull);
   });
 }
 
@@ -130,5 +176,20 @@ class FakeStationSearchRepository implements StationSearchRepository {
   Future<List<StationSearchResult>> searchStations(String query) async {
     requestedQueries.add(query);
     return nextResults;
+  }
+}
+
+class ControlledStationSearchRepository implements StationSearchRepository {
+  final requestedQueries = <String>[];
+  final _completer = Completer<List<StationSearchResult>>();
+
+  @override
+  Future<List<StationSearchResult>> searchStations(String query) {
+    requestedQueries.add(query);
+    return _completer.future;
+  }
+
+  void complete(List<StationSearchResult> results) {
+    _completer.complete(results);
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -78,9 +78,9 @@ void main() {
 
       expect(repository.requestedQueries, ['상록수']);
       expect(find.text('수도권 4호선'), findsOneWidget);
-      expect(find.text('데이터 수준 1'), findsOneWidget);
+      expect(find.text('기본 정보만 확인됨'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('상록수, 수도권 4호선, 수도권, 데이터 수준 1'),
+        find.bySemanticsLabel('상록수, 수도권 4호선, 수도권, 기본 정보만 확인됨'),
         findsOneWidget,
       );
     } finally {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -97,6 +97,13 @@ void main() {
         find.bySemanticsLabel('상록수, 수도권 4호선, 수도권, 기본 정보만 확인됨'),
         findsOneWidget,
       );
+      final resultSemantics = tester.getSemantics(
+        find.bySemanticsLabel('상록수, 수도권 4호선, 수도권, 기본 정보만 확인됨'),
+      );
+      expect(
+        resultSemantics.getSemanticsData().flagsCollection.isButton,
+        isFalse,
+      );
 
       final lineBadgeSize = tester.getSize(
         find.byKey(const Key('stationLineBadge-seoul-4')),
@@ -106,6 +113,7 @@ void main() {
 
       final lineNumber = tester.widget<Text>(find.text('4'));
       expect(lineNumber.style?.fontSize, 24);
+      expect(lineNumber.style?.color, const Color(0xFF102A2C));
     } finally {
       semanticsHandle.dispose();
     }

--- a/tools/ci/detect-changed-paths.sh
+++ b/tools/ci/detect-changed-paths.sh
@@ -59,6 +59,8 @@ while IFS= read -r file; do
   case "${file}" in
     apps/mobile/**)
       mobile=true
+      android=true
+      ios=true
       ;;
   esac
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -302,9 +302,10 @@ test("mobile scaffold is a Flutter Android and iOS app", () => {
   assert.match(iosInfoPlist, /CFBundleDisplayName[\s\S]*?<string>쉬운 지하철<\/string>/);
   assert.match(main, /class EasySubwayApp extends StatelessWidget/);
   assert.match(main, /역 찾기/);
-  assert.match(main, /가까운 역/);
+  assert.match(main, /역 검색/);
   assert.match(main, /이동 조건/);
   assert.match(main, /semanticLabel: '시설 정보, 엘리베이터와 경사로'/);
+  assert.ok(existsSync(path.join(root, "apps/mobile/lib/station_search.dart")));
   assert.doesNotMatch(main, /빠른 길보다, 갈 수 있는 길을 먼저 안내합니다|고령자, 임산부, 장애인도 편하게 이동할 수 있도록|현장에서 발견한 불편 정보를 신고하고 검수할 수 있게/);
   assert.match(widgetTest, /EasySubwayApp/);
   assert.match(widgetTest, /renders concise home screen actions/);
@@ -336,8 +337,8 @@ test("path classifier maps repository, backend, mobile, Android, and iOS changes
 
   const mobile = await classifyChangedFiles(["apps/mobile/lib/main.dart"]);
   assert.equal(mobile.mobile, "true");
-  assert.equal(mobile.android, "false");
-  assert.equal(mobile.ios, "false");
+  assert.equal(mobile.android, "true");
+  assert.equal(mobile.ios, "true");
 
   const android = await classifyChangedFiles(["apps/mobile/android/app/build.gradle.kts"]);
   assert.equal(android.mobile, "true");

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -287,6 +287,7 @@ test("mobile scaffold is a Flutter Android and iOS app", () => {
   const androidManifest = read("apps/mobile/android/app/src/main/AndroidManifest.xml");
   const iosInfoPlist = read("apps/mobile/ios/Runner/Info.plist");
   const main = read("apps/mobile/lib/main.dart");
+  const stationSearch = read("apps/mobile/lib/station_search.dart");
   const widgetTest = read("apps/mobile/test/widget_test.dart");
 
   assert.ok(existsSync(path.join(root, "apps/mobile/android")));
@@ -307,6 +308,8 @@ test("mobile scaffold is a Flutter Android and iOS app", () => {
   assert.match(main, /이동 조건/);
   assert.match(main, /semanticLabel: '시설 정보, 엘리베이터와 경사로'/);
   assert.ok(existsSync(path.join(root, "apps/mobile/lib/station_search.dart")));
+  assert.match(stationSearch, /_httpClient\s*\.\s*getUrl\(uri\)\s*\.\s*timeout\(_stationSearchTimeout\)/);
+  assert.match(stationSearch, /request\.close\(\)\.timeout\(_stationSearchTimeout\)/);
   assert.doesNotMatch(main, /빠른 길보다, 갈 수 있는 길을 먼저 안내합니다|고령자, 임산부, 장애인도 편하게 이동할 수 있도록|현장에서 발견한 불편 정보를 신고하고 검수할 수 있게/);
   assert.match(widgetTest, /EasySubwayApp/);
   assert.match(widgetTest, /renders concise home screen actions/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -299,6 +299,7 @@ test("mobile scaffold is a Flutter Android and iOS app", () => {
   assert.match(pubspec, /uses-material-design: true/);
   assert.match(analysisOptions, /package:flutter_lints\/flutter\.yaml/);
   assert.match(androidManifest, /android:label="쉬운 지하철"/);
+  assert.match(androidManifest, /<uses-permission android:name="android\.permission\.INTERNET"\/>/);
   assert.match(iosInfoPlist, /CFBundleDisplayName[\s\S]*?<string>쉬운 지하철<\/string>/);
   assert.match(main, /class EasySubwayApp extends StatelessWidget/);
   assert.match(main, /역 찾기/);


### PR DESCRIPTION
## 관련 이슈

close #21

## 요약

모바일 앱의 역 검색 진입점을 백엔드 역 조회 API와 연결했습니다. 사용자가 역 이름을 입력하고 검색하면 API 응답을 파싱해 역 이름, 노선, 지역, 확인된 정보 수준을 표시합니다.

검색 화면은 빈 입력, 로딩, 빈 결과, 오류 상태를 구분하고, 검색 입력과 결과 항목에 스크린리더 라벨을 제공합니다. 노선은 색상 배지와 텍스트를 함께 표시해 사용자가 4호선 같은 노선 상징을 더 빠르게 알아볼 수 있게 했습니다.

## 변경 사항

- 홈 화면의 역 찾기 버튼을 역 검색 화면으로 연결했습니다.
- `GET /api/v1/stations?query=...` 응답을 읽는 모바일 API repository를 추가했습니다.
- 역 검색 상태 controller를 추가했습니다.
- 검색 화면에 입력, 검색 버튼, 상태 메시지, 결과 목록을 추가했습니다.
- 검색 입력칸 힌트를 `역 이름을 입력해 주세요`로 바꾸고, 검색 전 중복 안내 문구를 제거했습니다.
- 결과 항목에 역 이름, 노선 배지, 노선명, 지역, 확인 정보 수준을 분리해 표시했습니다.
- `데이터 수준 1` 같은 내부값 노출을 `기본 정보만 확인됨` 같은 사용자 문구로 바꿨습니다.
- Android release 빌드에서도 역 검색 API를 호출할 수 있도록 main manifest에 `INTERNET` 권한을 추가했습니다.
- 배지 글자색을 배경색 대비가 더 높은 색으로 선택하고, 비활성 결과 카드를 button으로 읽지 않게 조정했습니다.
- 오래된 검색 응답이 최신 검색 결과를 덮어쓰지 않도록 요청 번호 기반 stale response 방어를 추가했습니다.
- 모바일 공통 코드 변경 시 Android CI와 iOS CI도 함께 실행되도록 경로 분류를 보강했습니다.
- Flutter unit/widget test와 repository contract test를 추가·갱신했습니다.

## 검증

- RED: `flutter test`
  - 역 검색 repository와 화면 연결이 없어 컴파일 실패하는 것을 확인했습니다.
- RED: `flutter test`
  - `LEVEL_1` 응답이 사용자 문구가 아닌 `데이터 수준 1`로 표시되는 것을 확인했습니다.
- RED: `flutter test test/widget_test.dart`
  - 노선 배지 key가 없어 실패하는 것을 확인했습니다.
  - 입력칸 힌트가 `예: 상록수`로 남아 있어 실패하는 것을 확인했습니다.
  - 검색 버튼 아래 중복 안내 문구가 남아 있어 실패하는 것을 확인했습니다.
- RED: `flutter test test/station_search_test.dart test/widget_test.dart`
  - 오래된 검색 응답이 최신 결과를 덮어쓰는 것을 확인했습니다.
  - 결과 카드가 실제 동작 없이 button semantics로 노출되는 것을 확인했습니다.
- RED: `TMPDIR=/private/tmp node --test tools/ci/*.test.mjs`
  - Android main manifest의 `INTERNET` 권한 누락을 확인했습니다.
- GREEN: `flutter test test/station_search_test.dart test/widget_test.dart`
- `dart format lib test`
- `flutter analyze`
- `flutter test`
- `TMPDIR=/private/tmp node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git diff --cached --check`
- `git ls-files '*.md'`
- Backend API smoke
  - `GET /api/health` 응답 확인
  - `GET /api/v1/stations?query=상록수` 응답 확인
  - `GET /api/v1/stations?query=Sangnoksu` 응답 확인
- Android emulator QA
  - `./gradlew :app:installDebug --no-daemon --console=plain`
  - `com.easysubway.easysubway_mobile/.MainActivity` 실행
  - UI tree에서 홈 화면 `역 검색`, `이동 조건`, `이동 프로필, 이동 조건 저장`, `시설 정보, 엘리베이터와 경사로`, `신고, 불편 신고` 라벨 확인
  - 검색 화면에서 입력칸 안내만 남고 검색 버튼 아래 중복 안내가 없는 것 확인
  - 검색 화면에서 `Sangnoksu` 입력 후 `상록수, 수도권 4호선, 수도권, 기본 정보만 확인됨` 결과 라벨 확인
  - 결과 카드에서 4호선 색상 배지와 노선명 텍스트가 함께 표시되는 것 확인
  - Android crash buffer에서 앱 crash 없음 확인
- iOS Simulator QA
  - Runner Debug build/install/launch 성공
  - UI snapshot에서 홈 화면 `역 검색`, `이동 조건`, `이동 프로필, 이동 조건 저장`, `시설 정보, 엘리베이터와 경사로`, `신고, 불편 신고` 라벨 확인
  - 검색 화면에서 입력 target과 빈 상태 문구 변경 확인
  - 앱 crash는 확인되지 않았고, iOS runtime accessibility bundle 중복 class 경고만 확인했습니다.
- PR CI: https://github.com/AquilaXk/easysubway/actions/runs/27418080619
- CodeRabbit: Review completed, pre-merge checks 5개 통과

## 리스크

- 실제 백엔드 주소는 `--dart-define=EASYSUBWAY_API_BASE_URL=...`로 주입할 수 있습니다.
- Android 에뮬레이터 기본값은 `http://10.0.2.2:8080`, iOS 시뮬레이터와 로컬 기본값은 `http://127.0.0.1:8080`입니다.
- 역 상세 화면 연결은 별도 작업으로 분리했습니다.

## 체크리스트

- [x] 관련 이슈를 연결했다.
- [x] 실행한 명령과 결과를 검증 섹션에 적었다.
- [x] CodeRabbit 또는 Codex CLI code review 결과를 확인했다.
- [x] CI가 통과했다.
- [ ] CD 상태를 확인했다.
