### PR TITLE
[Feat] 즐겨찾기 역 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -34,6 +34,19 @@ public class SecurityConfig {
 
 	@Bean
 	@Order(2)
+	SecurityFilterChain userSecurityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.securityMatcher("/api/v1/me/favorites/**")
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(authorize -> authorize
+				.anyRequest().authenticated()
+			)
+			.httpBasic(Customizer.withDefaults())
+			.build();
+	}
+
+	@Bean
+	@Order(3)
 	SecurityFilterChain publicSecurityFilterChain(HttpSecurity http) throws Exception {
 		return http
 			.csrf(AbstractHttpConfigurer::disable)
@@ -47,6 +60,8 @@ public class SecurityConfig {
 	UserDetailsService userDetailsService(
 		@Value("${easysubway.admin.username:}") String adminUsername,
 		@Value("${easysubway.admin.password:}") String adminPassword,
+		@Value("${easysubway.user.username:}") String userUsername,
+		@Value("${easysubway.user.password:}") String userPassword,
 		PasswordEncoder passwordEncoder
 	) {
 		var users = new InMemoryUserDetailsManager();
@@ -54,6 +69,12 @@ public class SecurityConfig {
 			users.createUser(User.withUsername(adminUsername)
 				.password(passwordEncoder.encode(adminPassword))
 				.roles("ADMIN")
+				.build());
+		}
+		if (!userUsername.isBlank() && !userPassword.isBlank()) {
+			users.createUser(User.withUsername(userUsername)
+				.password(passwordEncoder.encode(userPassword))
+				.roles("USER")
 				.build());
 		}
 		return users;

--- a/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteStationController.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteStationController.java
@@ -1,0 +1,112 @@
+package com.easysubway.favorite.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.favorite.application.port.in.FavoriteStationUseCase;
+import com.easysubway.favorite.application.port.in.RemoveFavoriteStationCommand;
+import com.easysubway.favorite.application.port.in.SaveFavoriteStationCommand;
+import com.easysubway.favorite.domain.FavoriteStationWithDetails;
+import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationLineSummary;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class FavoriteStationController {
+
+	private final FavoriteStationUseCase favoriteStationUseCase;
+
+	FavoriteStationController(FavoriteStationUseCase favoriteStationUseCase) {
+		this.favoriteStationUseCase = favoriteStationUseCase;
+	}
+
+	@GetMapping("/api/v1/me/favorite-stations")
+	ApiResponse<List<FavoriteStationResponse>> listFavoriteStations(
+		@RequestParam(required = false) String userId
+	) {
+		List<FavoriteStationResponse> response = favoriteStationUseCase.listFavoriteStations(userId)
+			.stream()
+			.map(FavoriteStationResponse::from)
+			.toList();
+		return ApiResponse.ok(response);
+	}
+
+	@PutMapping("/api/v1/me/favorite-stations/{stationId}")
+	ApiResponse<FavoriteStationResponse> saveFavoriteStation(
+		@PathVariable String stationId,
+		@RequestBody SaveFavoriteStationRequest request
+	) {
+		FavoriteStationWithDetails favoriteStation = favoriteStationUseCase.saveFavoriteStation(
+			new SaveFavoriteStationCommand(request.userId(), stationId)
+		);
+		return ApiResponse.ok(FavoriteStationResponse.from(favoriteStation));
+	}
+
+	@DeleteMapping("/api/v1/me/favorite-stations/{stationId}")
+	ApiResponse<Void> removeFavoriteStation(
+		@PathVariable String stationId,
+		@RequestParam(required = false) String userId
+	) {
+		favoriteStationUseCase.removeFavoriteStation(new RemoveFavoriteStationCommand(userId, stationId));
+		return ApiResponse.ok(null);
+	}
+
+	record SaveFavoriteStationRequest(String userId) {
+	}
+
+	record FavoriteStationResponse(
+		String userId,
+		String stationId,
+		String nameKo,
+		String nameEn,
+		String region,
+		DataQualityLevel dataQualityLevel,
+		LocalDate lastVerifiedAt,
+		List<FavoriteStationLineResponse> lines,
+		LocalDateTime addedAt
+	) {
+
+		static FavoriteStationResponse from(FavoriteStationWithDetails favoriteStation) {
+			Station station = favoriteStation.station().station();
+			return new FavoriteStationResponse(
+				favoriteStation.favoriteStation().userId(),
+				favoriteStation.favoriteStation().stationId(),
+				station.nameKo(),
+				station.nameEn(),
+				station.region(),
+				station.dataQualityLevel(),
+				station.lastVerifiedAt(),
+				favoriteStation.station().lines()
+					.stream()
+					.map(FavoriteStationLineResponse::from)
+					.toList(),
+				favoriteStation.favoriteStation().addedAt()
+			);
+		}
+	}
+
+	record FavoriteStationLineResponse(
+		String id,
+		String name,
+		String color,
+		String stationCode
+	) {
+
+		static FavoriteStationLineResponse from(StationLineSummary line) {
+			return new FavoriteStationLineResponse(
+				line.id(),
+				line.name(),
+				line.color(),
+				line.stationCode()
+			);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteStationController.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteStationController.java
@@ -2,12 +2,14 @@ package com.easysubway.favorite.adapter.in.web;
 
 import com.easysubway.common.web.ApiResponse;
 import com.easysubway.favorite.application.port.in.FavoriteStationUseCase;
+import com.easysubway.favorite.application.port.in.ListFavoriteStationsCommand;
 import com.easysubway.favorite.application.port.in.RemoveFavoriteStationCommand;
 import com.easysubway.favorite.application.port.in.SaveFavoriteStationCommand;
 import com.easysubway.favorite.domain.FavoriteStationWithDetails;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationLineSummary;
+import java.security.Principal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,8 +17,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,10 +29,9 @@ class FavoriteStationController {
 	}
 
 	@GetMapping("/api/v1/me/favorites/stations")
-	ApiResponse<List<FavoriteStationResponse>> listFavoriteStations(
-		@RequestParam(required = false) String userId
-	) {
-		List<FavoriteStationResponse> response = favoriteStationUseCase.listFavoriteStations(userId)
+	ApiResponse<List<FavoriteStationResponse>> listFavoriteStations(Principal principal) {
+		List<FavoriteStationResponse> response = favoriteStationUseCase
+			.listFavoriteStations(new ListFavoriteStationsCommand(principal.getName()))
 			.stream()
 			.map(FavoriteStationResponse::from)
 			.toList();
@@ -42,10 +41,10 @@ class FavoriteStationController {
 	@PutMapping("/api/v1/me/favorites/stations/{stationId}")
 	ApiResponse<FavoriteStationResponse> saveFavoriteStation(
 		@PathVariable String stationId,
-		@RequestBody SaveFavoriteStationRequest request
+		Principal principal
 	) {
 		FavoriteStationWithDetails favoriteStation = favoriteStationUseCase.saveFavoriteStation(
-			new SaveFavoriteStationCommand(request.userId(), stationId)
+			new SaveFavoriteStationCommand(principal.getName(), stationId)
 		);
 		return ApiResponse.ok(FavoriteStationResponse.from(favoriteStation));
 	}
@@ -53,13 +52,10 @@ class FavoriteStationController {
 	@DeleteMapping("/api/v1/me/favorites/stations/{stationId}")
 	ApiResponse<Void> removeFavoriteStation(
 		@PathVariable String stationId,
-		@RequestParam(required = false) String userId
+		Principal principal
 	) {
-		favoriteStationUseCase.removeFavoriteStation(new RemoveFavoriteStationCommand(userId, stationId));
+		favoriteStationUseCase.removeFavoriteStation(new RemoveFavoriteStationCommand(principal.getName(), stationId));
 		return ApiResponse.ok(null);
-	}
-
-	record SaveFavoriteStationRequest(String userId) {
 	}
 
 	record FavoriteStationResponse(

--- a/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteStationController.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteStationController.java
@@ -28,7 +28,7 @@ class FavoriteStationController {
 		this.favoriteStationUseCase = favoriteStationUseCase;
 	}
 
-	@GetMapping("/api/v1/me/favorite-stations")
+	@GetMapping("/api/v1/me/favorites/stations")
 	ApiResponse<List<FavoriteStationResponse>> listFavoriteStations(
 		@RequestParam(required = false) String userId
 	) {
@@ -39,7 +39,7 @@ class FavoriteStationController {
 		return ApiResponse.ok(response);
 	}
 
-	@PutMapping("/api/v1/me/favorite-stations/{stationId}")
+	@PutMapping("/api/v1/me/favorites/stations/{stationId}")
 	ApiResponse<FavoriteStationResponse> saveFavoriteStation(
 		@PathVariable String stationId,
 		@RequestBody SaveFavoriteStationRequest request
@@ -50,7 +50,7 @@ class FavoriteStationController {
 		return ApiResponse.ok(FavoriteStationResponse.from(favoriteStation));
 	}
 
-	@DeleteMapping("/api/v1/me/favorite-stations/{stationId}")
+	@DeleteMapping("/api/v1/me/favorites/stations/{stationId}")
 	ApiResponse<Void> removeFavoriteStation(
 		@PathVariable String stationId,
 		@RequestParam(required = false) String userId

--- a/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteStationRepository.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteStationRepository.java
@@ -1,0 +1,47 @@
+package com.easysubway.favorite.adapter.out.persistence;
+
+import com.easysubway.favorite.application.port.out.DeleteFavoriteStationPort;
+import com.easysubway.favorite.application.port.out.LoadFavoriteStationPort;
+import com.easysubway.favorite.application.port.out.SaveFavoriteStationPort;
+import com.easysubway.favorite.domain.FavoriteStation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryFavoriteStationRepository implements
+	LoadFavoriteStationPort,
+	SaveFavoriteStationPort,
+	DeleteFavoriteStationPort {
+
+	private final Map<String, Map<String, FavoriteStation>> favoritesByUserId = new ConcurrentHashMap<>();
+
+	@Override
+	public List<FavoriteStation> loadFavoriteStations(String userId) {
+		return new ArrayList<>(favoritesByUserId.getOrDefault(userId, Map.of()).values());
+	}
+
+	@Override
+	public Optional<FavoriteStation> loadFavoriteStation(String userId, String stationId) {
+		return Optional.ofNullable(favoritesByUserId.getOrDefault(userId, Map.of()).get(stationId));
+	}
+
+	@Override
+	public FavoriteStation saveFavoriteStation(FavoriteStation favoriteStation) {
+		favoritesByUserId
+			.computeIfAbsent(favoriteStation.userId(), ignored -> new ConcurrentHashMap<>())
+			.put(favoriteStation.stationId(), favoriteStation);
+		return favoriteStation;
+	}
+
+	@Override
+	public void deleteFavoriteStation(String userId, String stationId) {
+		Map<String, FavoriteStation> favorites = favoritesByUserId.get(userId);
+		if (favorites != null) {
+			favorites.remove(stationId);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/in/FavoriteStationUseCase.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/in/FavoriteStationUseCase.java
@@ -1,0 +1,13 @@
+package com.easysubway.favorite.application.port.in;
+
+import com.easysubway.favorite.domain.FavoriteStationWithDetails;
+import java.util.List;
+
+public interface FavoriteStationUseCase {
+
+	List<FavoriteStationWithDetails> listFavoriteStations(String userId);
+
+	FavoriteStationWithDetails saveFavoriteStation(SaveFavoriteStationCommand command);
+
+	void removeFavoriteStation(RemoveFavoriteStationCommand command);
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/in/FavoriteStationUseCase.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/in/FavoriteStationUseCase.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface FavoriteStationUseCase {
 
-	List<FavoriteStationWithDetails> listFavoriteStations(String userId);
+	List<FavoriteStationWithDetails> listFavoriteStations(ListFavoriteStationsCommand command);
 
 	FavoriteStationWithDetails saveFavoriteStation(SaveFavoriteStationCommand command);
 

--- a/backend/src/main/java/com/easysubway/favorite/application/port/in/ListFavoriteStationsCommand.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/in/ListFavoriteStationsCommand.java
@@ -1,0 +1,4 @@
+package com.easysubway.favorite.application.port.in;
+
+public record ListFavoriteStationsCommand(String userId) {
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/in/RemoveFavoriteStationCommand.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/in/RemoveFavoriteStationCommand.java
@@ -1,0 +1,7 @@
+package com.easysubway.favorite.application.port.in;
+
+public record RemoveFavoriteStationCommand(
+	String userId,
+	String stationId
+) {
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/in/SaveFavoriteStationCommand.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/in/SaveFavoriteStationCommand.java
@@ -1,0 +1,7 @@
+package com.easysubway.favorite.application.port.in;
+
+public record SaveFavoriteStationCommand(
+	String userId,
+	String stationId
+) {
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/out/DeleteFavoriteStationPort.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/out/DeleteFavoriteStationPort.java
@@ -1,0 +1,6 @@
+package com.easysubway.favorite.application.port.out;
+
+public interface DeleteFavoriteStationPort {
+
+	void deleteFavoriteStation(String userId, String stationId);
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/out/LoadFavoriteStationPort.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/out/LoadFavoriteStationPort.java
@@ -1,0 +1,12 @@
+package com.easysubway.favorite.application.port.out;
+
+import com.easysubway.favorite.domain.FavoriteStation;
+import java.util.List;
+import java.util.Optional;
+
+public interface LoadFavoriteStationPort {
+
+	List<FavoriteStation> loadFavoriteStations(String userId);
+
+	Optional<FavoriteStation> loadFavoriteStation(String userId, String stationId);
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/out/SaveFavoriteStationPort.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/out/SaveFavoriteStationPort.java
@@ -1,0 +1,8 @@
+package com.easysubway.favorite.application.port.out;
+
+import com.easysubway.favorite.domain.FavoriteStation;
+
+public interface SaveFavoriteStationPort {
+
+	FavoriteStation saveFavoriteStation(FavoriteStation favoriteStation);
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteStationService.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteStationService.java
@@ -1,6 +1,7 @@
 package com.easysubway.favorite.application.service;
 
 import com.easysubway.favorite.application.port.in.FavoriteStationUseCase;
+import com.easysubway.favorite.application.port.in.ListFavoriteStationsCommand;
 import com.easysubway.favorite.application.port.in.RemoveFavoriteStationCommand;
 import com.easysubway.favorite.application.port.in.SaveFavoriteStationCommand;
 import com.easysubway.favorite.application.port.out.DeleteFavoriteStationPort;
@@ -66,9 +67,9 @@ public class FavoriteStationService implements FavoriteStationUseCase {
 	}
 
 	@Override
-	public List<FavoriteStationWithDetails> listFavoriteStations(String userId) {
-		requireUserId(userId);
-		return loadFavoriteStationPort.loadFavoriteStations(userId)
+	public List<FavoriteStationWithDetails> listFavoriteStations(ListFavoriteStationsCommand command) {
+		requireUserId(command.userId());
+		return loadFavoriteStationPort.loadFavoriteStations(command.userId())
 			.stream()
 			.sorted(Comparator.comparing(FavoriteStation::addedAt))
 			.map(this::withDetails)

--- a/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteStationService.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteStationService.java
@@ -1,0 +1,149 @@
+package com.easysubway.favorite.application.service;
+
+import com.easysubway.favorite.application.port.in.FavoriteStationUseCase;
+import com.easysubway.favorite.application.port.in.RemoveFavoriteStationCommand;
+import com.easysubway.favorite.application.port.in.SaveFavoriteStationCommand;
+import com.easysubway.favorite.application.port.out.DeleteFavoriteStationPort;
+import com.easysubway.favorite.application.port.out.LoadFavoriteStationPort;
+import com.easysubway.favorite.application.port.out.SaveFavoriteStationPort;
+import com.easysubway.favorite.domain.FavoriteStation;
+import com.easysubway.favorite.domain.FavoriteStationWithDetails;
+import com.easysubway.favorite.domain.InvalidFavoriteStationException;
+import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.StationLineSummary;
+import com.easysubway.transit.domain.StationNotFoundException;
+import com.easysubway.transit.domain.StationWithLines;
+import com.easysubway.transit.domain.SubwayLine;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FavoriteStationService implements FavoriteStationUseCase {
+
+	private final LoadFavoriteStationPort loadFavoriteStationPort;
+	private final SaveFavoriteStationPort saveFavoriteStationPort;
+	private final DeleteFavoriteStationPort deleteFavoriteStationPort;
+	private final LoadTransitMasterPort loadTransitMasterPort;
+	private final Clock clock;
+
+	@Autowired
+	public FavoriteStationService(
+		LoadFavoriteStationPort loadFavoriteStationPort,
+		SaveFavoriteStationPort saveFavoriteStationPort,
+		DeleteFavoriteStationPort deleteFavoriteStationPort,
+		LoadTransitMasterPort loadTransitMasterPort
+	) {
+		this(
+			loadFavoriteStationPort,
+			saveFavoriteStationPort,
+			deleteFavoriteStationPort,
+			loadTransitMasterPort,
+			Clock.systemDefaultZone()
+		);
+	}
+
+	public FavoriteStationService(
+		LoadFavoriteStationPort loadFavoriteStationPort,
+		SaveFavoriteStationPort saveFavoriteStationPort,
+		DeleteFavoriteStationPort deleteFavoriteStationPort,
+		LoadTransitMasterPort loadTransitMasterPort,
+		Clock clock
+	) {
+		this.loadFavoriteStationPort = loadFavoriteStationPort;
+		this.saveFavoriteStationPort = saveFavoriteStationPort;
+		this.deleteFavoriteStationPort = deleteFavoriteStationPort;
+		this.loadTransitMasterPort = loadTransitMasterPort;
+		this.clock = clock;
+	}
+
+	@Override
+	public List<FavoriteStationWithDetails> listFavoriteStations(String userId) {
+		requireUserId(userId);
+		return loadFavoriteStationPort.loadFavoriteStations(userId)
+			.stream()
+			.sorted(Comparator.comparing(FavoriteStation::addedAt))
+			.map(this::withDetails)
+			.toList();
+	}
+
+	@Override
+	public FavoriteStationWithDetails saveFavoriteStation(SaveFavoriteStationCommand command) {
+		requireUserId(command.userId());
+		requireStationId(command.stationId());
+		loadActiveStation(command.stationId());
+
+		FavoriteStation favoriteStation = loadFavoriteStationPort
+			.loadFavoriteStation(command.userId(), command.stationId())
+			.orElseGet(() -> saveFavoriteStationPort.saveFavoriteStation(new FavoriteStation(
+				command.userId(),
+				command.stationId(),
+				LocalDateTime.now(clock)
+			)));
+
+		return withDetails(favoriteStation);
+	}
+
+	@Override
+	public void removeFavoriteStation(RemoveFavoriteStationCommand command) {
+		requireUserId(command.userId());
+		requireStationId(command.stationId());
+		deleteFavoriteStationPort.deleteFavoriteStation(command.userId(), command.stationId());
+	}
+
+	private FavoriteStationWithDetails withDetails(FavoriteStation favoriteStation) {
+		return new FavoriteStationWithDetails(
+			favoriteStation,
+			withLines(loadActiveStation(favoriteStation.stationId()))
+		);
+	}
+
+	private Station loadActiveStation(String stationId) {
+		return loadTransitMasterPort.loadStations()
+			.stream()
+			.filter(station -> station.id().equals(stationId))
+			.filter(Station::active)
+			.findFirst()
+			.orElseThrow(StationNotFoundException::new);
+	}
+
+	private StationWithLines withLines(Station station) {
+		Map<String, SubwayLine> linesById = loadTransitMasterPort.loadLines()
+			.stream()
+			.filter(SubwayLine::active)
+			.collect(Collectors.toMap(SubwayLine::id, Function.identity()));
+
+		List<StationLineSummary> lines = loadTransitMasterPort.loadStationLines()
+			.stream()
+			.filter(stationLine -> stationLine.stationId().equals(station.id()))
+			.filter(stationLine -> linesById.containsKey(stationLine.lineId()))
+			.map(stationLine -> toSummary(stationLine, linesById))
+			.toList();
+
+		return new StationWithLines(station, lines);
+	}
+
+	private StationLineSummary toSummary(StationLine stationLine, Map<String, SubwayLine> linesById) {
+		return StationLineSummary.of(linesById.get(stationLine.lineId()), stationLine);
+	}
+
+	private void requireUserId(String userId) {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidFavoriteStationException("사용자 식별자가 필요합니다.");
+		}
+	}
+
+	private void requireStationId(String stationId) {
+		if (stationId == null || stationId.isBlank()) {
+			throw new InvalidFavoriteStationException("역 식별자가 필요합니다.");
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/domain/FavoriteStation.java
+++ b/backend/src/main/java/com/easysubway/favorite/domain/FavoriteStation.java
@@ -7,4 +7,16 @@ public record FavoriteStation(
 	String stationId,
 	LocalDateTime addedAt
 ) {
+
+	public FavoriteStation {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidFavoriteStationException("사용자 식별자가 필요합니다.");
+		}
+		if (stationId == null || stationId.isBlank()) {
+			throw new InvalidFavoriteStationException("역 식별자가 필요합니다.");
+		}
+		if (addedAt == null) {
+			throw new InvalidFavoriteStationException("추가 시각이 필요합니다.");
+		}
+	}
 }

--- a/backend/src/main/java/com/easysubway/favorite/domain/FavoriteStation.java
+++ b/backend/src/main/java/com/easysubway/favorite/domain/FavoriteStation.java
@@ -1,0 +1,10 @@
+package com.easysubway.favorite.domain;
+
+import java.time.LocalDateTime;
+
+public record FavoriteStation(
+	String userId,
+	String stationId,
+	LocalDateTime addedAt
+) {
+}

--- a/backend/src/main/java/com/easysubway/favorite/domain/FavoriteStationWithDetails.java
+++ b/backend/src/main/java/com/easysubway/favorite/domain/FavoriteStationWithDetails.java
@@ -1,0 +1,9 @@
+package com.easysubway.favorite.domain;
+
+import com.easysubway.transit.domain.StationWithLines;
+
+public record FavoriteStationWithDetails(
+	FavoriteStation favoriteStation,
+	StationWithLines station
+) {
+}

--- a/backend/src/main/java/com/easysubway/favorite/domain/InvalidFavoriteStationException.java
+++ b/backend/src/main/java/com/easysubway/favorite/domain/InvalidFavoriteStationException.java
@@ -1,0 +1,10 @@
+package com.easysubway.favorite.domain;
+
+import com.easysubway.common.error.InvalidRequestException;
+
+public class InvalidFavoriteStationException extends InvalidRequestException {
+
+	public InvalidFavoriteStationException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteStationControllerTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteStationControllerTest.java
@@ -1,0 +1,83 @@
+package com.easysubway.favorite.adapter.in.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class FavoriteStationControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void favoriteStationsCanBeSavedListedAndRemoved() throws Exception {
+		mockMvc.perform(put("/api/v1/me/favorite-stations/station-sangnoksu")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.userId").value("anonymous-user-1"))
+			.andExpect(jsonPath("$.data.stationId").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data.nameKo").value("상록수"))
+			.andExpect(jsonPath("$.data.region").value("수도권"))
+			.andExpect(jsonPath("$.data.dataQualityLevel").value("LEVEL_1"))
+			.andExpect(jsonPath("$.data.lines[0].name").value("수도권 4호선"))
+			.andExpect(jsonPath("$.data.addedAt").isNotEmpty());
+
+		mockMvc.perform(get("/api/v1/me/favorite-stations")
+				.param("userId", "anonymous-user-1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].stationId").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data[0].nameKo").value("상록수"));
+
+		mockMvc.perform(delete("/api/v1/me/favorite-stations/station-sangnoksu")
+				.param("userId", "anonymous-user-1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true));
+
+		mockMvc.perform(get("/api/v1/me/favorite-stations")
+				.param("userId", "anonymous-user-1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data").isEmpty());
+	}
+
+	@Test
+	void favoriteStationsRejectUnknownStation() throws Exception {
+		mockMvc.perform(put("/api/v1/me/favorite-stations/missing-station")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-2"
+					}
+					"""))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("역 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
+	void favoriteStationsRequireUserId() throws Exception {
+		mockMvc.perform(get("/api/v1/me/favorite-stations"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("사용자 식별자가 필요합니다."));
+	}
+}

--- a/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteStationControllerTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteStationControllerTest.java
@@ -1,5 +1,6 @@
 package com.easysubway.favorite.adapter.in.web;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -13,7 +14,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
 @AutoConfigureMockMvc
 class FavoriteStationControllerTest {
 
@@ -23,10 +27,11 @@ class FavoriteStationControllerTest {
 	@Test
 	void favoriteStationsCanBeSavedListedAndRemoved() throws Exception {
 		mockMvc.perform(put("/api/v1/me/favorites/stations/station-sangnoksu")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
-					  "userId": "anonymous-user-1"
+					  "userId": "spoofed-user"
 					}
 					"""))
 			.andExpect(status().isOk())
@@ -40,19 +45,19 @@ class FavoriteStationControllerTest {
 			.andExpect(jsonPath("$.data.addedAt").isNotEmpty());
 
 		mockMvc.perform(get("/api/v1/me/favorites/stations")
-				.param("userId", "anonymous-user-1"))
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data[0].stationId").value("station-sangnoksu"))
 			.andExpect(jsonPath("$.data[0].nameKo").value("상록수"));
 
 		mockMvc.perform(delete("/api/v1/me/favorites/stations/station-sangnoksu")
-				.param("userId", "anonymous-user-1"))
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true));
 
 		mockMvc.perform(get("/api/v1/me/favorites/stations")
-				.param("userId", "anonymous-user-1"))
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data").isEmpty());
 	}
@@ -60,12 +65,7 @@ class FavoriteStationControllerTest {
 	@Test
 	void favoriteStationsRejectUnknownStation() throws Exception {
 		mockMvc.perform(put("/api/v1/me/favorites/stations/missing-station")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content("""
-					{
-					  "userId": "anonymous-user-2"
-					}
-					"""))
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.data").doesNotExist())
@@ -73,11 +73,8 @@ class FavoriteStationControllerTest {
 	}
 
 	@Test
-	void favoriteStationsRequireUserId() throws Exception {
+	void favoriteStationsRequireAuthentication() throws Exception {
 		mockMvc.perform(get("/api/v1/me/favorites/stations"))
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.success").value(false))
-			.andExpect(jsonPath("$.data").doesNotExist())
-			.andExpect(jsonPath("$.message").value("사용자 식별자가 필요합니다."));
+			.andExpect(status().isUnauthorized());
 	}
 }

--- a/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteStationControllerTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteStationControllerTest.java
@@ -22,7 +22,7 @@ class FavoriteStationControllerTest {
 
 	@Test
 	void favoriteStationsCanBeSavedListedAndRemoved() throws Exception {
-		mockMvc.perform(put("/api/v1/me/favorite-stations/station-sangnoksu")
+		mockMvc.perform(put("/api/v1/me/favorites/stations/station-sangnoksu")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -39,19 +39,19 @@ class FavoriteStationControllerTest {
 			.andExpect(jsonPath("$.data.lines[0].name").value("수도권 4호선"))
 			.andExpect(jsonPath("$.data.addedAt").isNotEmpty());
 
-		mockMvc.perform(get("/api/v1/me/favorite-stations")
+		mockMvc.perform(get("/api/v1/me/favorites/stations")
 				.param("userId", "anonymous-user-1"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data[0].stationId").value("station-sangnoksu"))
 			.andExpect(jsonPath("$.data[0].nameKo").value("상록수"));
 
-		mockMvc.perform(delete("/api/v1/me/favorite-stations/station-sangnoksu")
+		mockMvc.perform(delete("/api/v1/me/favorites/stations/station-sangnoksu")
 				.param("userId", "anonymous-user-1"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true));
 
-		mockMvc.perform(get("/api/v1/me/favorite-stations")
+		mockMvc.perform(get("/api/v1/me/favorites/stations")
 				.param("userId", "anonymous-user-1"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data").isEmpty());
@@ -59,7 +59,7 @@ class FavoriteStationControllerTest {
 
 	@Test
 	void favoriteStationsRejectUnknownStation() throws Exception {
-		mockMvc.perform(put("/api/v1/me/favorite-stations/missing-station")
+		mockMvc.perform(put("/api/v1/me/favorites/stations/missing-station")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -74,7 +74,7 @@ class FavoriteStationControllerTest {
 
 	@Test
 	void favoriteStationsRequireUserId() throws Exception {
-		mockMvc.perform(get("/api/v1/me/favorite-stations"))
+		mockMvc.perform(get("/api/v1/me/favorites/stations"))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.data").doesNotExist())

--- a/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteStationServiceTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteStationServiceTest.java
@@ -1,0 +1,84 @@
+package com.easysubway.favorite.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteStationRepository;
+import com.easysubway.favorite.application.port.in.RemoveFavoriteStationCommand;
+import com.easysubway.favorite.application.port.in.SaveFavoriteStationCommand;
+import com.easysubway.favorite.domain.InvalidFavoriteStationException;
+import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
+import com.easysubway.transit.domain.StationNotFoundException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+
+class FavoriteStationServiceTest {
+
+	private final InMemoryFavoriteStationRepository favoriteStationRepository =
+		new InMemoryFavoriteStationRepository();
+	private final FavoriteStationService service = new FavoriteStationService(
+		favoriteStationRepository,
+		favoriteStationRepository,
+		favoriteStationRepository,
+		new InMemoryTransitMasterRepository(),
+		Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+	);
+
+	@Test
+	void saveFavoriteStationStoresActiveStationOnce() {
+		var favorite = service.saveFavoriteStation(new SaveFavoriteStationCommand(
+			"anonymous-user-1",
+			"station-sangnoksu"
+		));
+		var duplicated = service.saveFavoriteStation(new SaveFavoriteStationCommand(
+			"anonymous-user-1",
+			"station-sangnoksu"
+		));
+
+		assertThat(favorite.favoriteStation().userId()).isEqualTo("anonymous-user-1");
+		assertThat(favorite.favoriteStation().stationId()).isEqualTo("station-sangnoksu");
+		assertThat(favorite.favoriteStation().addedAt()).isEqualTo(LocalDateTime.of(2026, 6, 12, 9, 0));
+		assertThat(favorite.station().station().nameKo()).isEqualTo("상록수");
+		assertThat(duplicated).isEqualTo(favorite);
+		assertThat(service.listFavoriteStations("anonymous-user-1")).containsExactly(favorite);
+	}
+
+	@Test
+	void removeFavoriteStationDeletesOnlyRequestedStation() {
+		service.saveFavoriteStation(new SaveFavoriteStationCommand("anonymous-user-1", "station-sangnoksu"));
+		service.saveFavoriteStation(new SaveFavoriteStationCommand("anonymous-user-1", "station-sadang"));
+
+		service.removeFavoriteStation(new RemoveFavoriteStationCommand("anonymous-user-1", "station-sangnoksu"));
+
+		assertThat(service.listFavoriteStations("anonymous-user-1"))
+			.extracting(favorite -> favorite.favoriteStation().stationId())
+			.containsExactly("station-sadang");
+	}
+
+	@Test
+	void saveFavoriteStationRequiresExistingActiveStation() {
+		assertThatThrownBy(() -> service.saveFavoriteStation(new SaveFavoriteStationCommand(
+			"anonymous-user-1",
+			"missing-station"
+		)))
+			.isInstanceOf(StationNotFoundException.class)
+			.hasMessage("역 정보를 찾을 수 없습니다.");
+	}
+
+	@Test
+	void favoriteStationCommandsRequireUserAndStation() {
+		assertThatThrownBy(() -> service.listFavoriteStations(""))
+			.isInstanceOf(InvalidFavoriteStationException.class)
+			.hasMessage("사용자 식별자가 필요합니다.");
+
+		assertThatThrownBy(() -> service.saveFavoriteStation(new SaveFavoriteStationCommand(
+			"anonymous-user-1",
+			""
+		)))
+			.isInstanceOf(InvalidFavoriteStationException.class)
+			.hasMessage("역 식별자가 필요합니다.");
+	}
+}

--- a/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteStationServiceTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteStationServiceTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteStationRepository;
+import com.easysubway.favorite.application.port.in.ListFavoriteStationsCommand;
 import com.easysubway.favorite.application.port.in.RemoveFavoriteStationCommand;
 import com.easysubway.favorite.application.port.in.SaveFavoriteStationCommand;
+import com.easysubway.favorite.domain.FavoriteStation;
 import com.easysubway.favorite.domain.InvalidFavoriteStationException;
 import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
 import com.easysubway.transit.domain.StationNotFoundException;
@@ -43,7 +45,8 @@ class FavoriteStationServiceTest {
 		assertThat(favorite.favoriteStation().addedAt()).isEqualTo(LocalDateTime.of(2026, 6, 12, 9, 0));
 		assertThat(favorite.station().station().nameKo()).isEqualTo("상록수");
 		assertThat(duplicated).isEqualTo(favorite);
-		assertThat(service.listFavoriteStations("anonymous-user-1")).containsExactly(favorite);
+		assertThat(service.listFavoriteStations(new ListFavoriteStationsCommand("anonymous-user-1")))
+			.containsExactly(favorite);
 	}
 
 	@Test
@@ -53,7 +56,7 @@ class FavoriteStationServiceTest {
 
 		service.removeFavoriteStation(new RemoveFavoriteStationCommand("anonymous-user-1", "station-sangnoksu"));
 
-		assertThat(service.listFavoriteStations("anonymous-user-1"))
+		assertThat(service.listFavoriteStations(new ListFavoriteStationsCommand("anonymous-user-1")))
 			.extracting(favorite -> favorite.favoriteStation().stationId())
 			.containsExactly("station-sadang");
 	}
@@ -70,7 +73,7 @@ class FavoriteStationServiceTest {
 
 	@Test
 	void favoriteStationCommandsRequireUserAndStation() {
-		assertThatThrownBy(() -> service.listFavoriteStations(""))
+		assertThatThrownBy(() -> service.listFavoriteStations(new ListFavoriteStationsCommand("")))
 			.isInstanceOf(InvalidFavoriteStationException.class)
 			.hasMessage("사용자 식별자가 필요합니다.");
 
@@ -80,5 +83,18 @@ class FavoriteStationServiceTest {
 		)))
 			.isInstanceOf(InvalidFavoriteStationException.class)
 			.hasMessage("역 식별자가 필요합니다.");
+	}
+
+	@Test
+	void favoriteStationDomainRejectsInvalidState() {
+		assertThatThrownBy(() -> new FavoriteStation("", "station-sangnoksu", LocalDateTime.now()))
+			.isInstanceOf(InvalidFavoriteStationException.class)
+			.hasMessage("사용자 식별자가 필요합니다.");
+		assertThatThrownBy(() -> new FavoriteStation("anonymous-user-1", "", LocalDateTime.now()))
+			.isInstanceOf(InvalidFavoriteStationException.class)
+			.hasMessage("역 식별자가 필요합니다.");
+		assertThatThrownBy(() -> new FavoriteStation("anonymous-user-1", "station-sangnoksu", null))
+			.isInstanceOf(InvalidFavoriteStationException.class)
+			.hasMessage("추가 시각이 필요합니다.");
 	}
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -281,6 +281,42 @@ test("backend mobility profiles follow hexagonal API boundaries", () => {
   assert.match(controller, /@PutMapping\("\/api\/v1\/me\/mobility-profile"\)/);
 });
 
+test("backend favorite stations follow hexagonal API boundaries", () => {
+  const favorite = read("backend/src/main/java/com/easysubway/favorite/domain/FavoriteStation.java");
+  const favoriteDetails = read("backend/src/main/java/com/easysubway/favorite/domain/FavoriteStationWithDetails.java");
+  const invalidFavorite = read("backend/src/main/java/com/easysubway/favorite/domain/InvalidFavoriteStationException.java");
+  const useCase = read("backend/src/main/java/com/easysubway/favorite/application/port/in/FavoriteStationUseCase.java");
+  const saveCommand = read("backend/src/main/java/com/easysubway/favorite/application/port/in/SaveFavoriteStationCommand.java");
+  const removeCommand = read("backend/src/main/java/com/easysubway/favorite/application/port/in/RemoveFavoriteStationCommand.java");
+  const loadPort = read("backend/src/main/java/com/easysubway/favorite/application/port/out/LoadFavoriteStationPort.java");
+  const savePort = read("backend/src/main/java/com/easysubway/favorite/application/port/out/SaveFavoriteStationPort.java");
+  const deletePort = read("backend/src/main/java/com/easysubway/favorite/application/port/out/DeleteFavoriteStationPort.java");
+  const service = read("backend/src/main/java/com/easysubway/favorite/application/service/FavoriteStationService.java");
+  const repository = read("backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteStationRepository.java");
+  const controller = read("backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteStationController.java");
+
+  assert.match(favorite, /record FavoriteStation/);
+  assert.match(favorite, /addedAt/);
+  assert.match(favoriteDetails, /StationWithLines/);
+  assert.match(invalidFavorite, /extends InvalidRequestException/);
+  assert.match(useCase, /interface FavoriteStationUseCase/);
+  assert.match(useCase, /listFavoriteStations/);
+  assert.match(useCase, /saveFavoriteStation/);
+  assert.match(useCase, /removeFavoriteStation/);
+  assert.match(saveCommand, /record SaveFavoriteStationCommand/);
+  assert.match(removeCommand, /record RemoveFavoriteStationCommand/);
+  assert.match(loadPort, /interface LoadFavoriteStationPort/);
+  assert.match(savePort, /interface SaveFavoriteStationPort/);
+  assert.match(deletePort, /interface DeleteFavoriteStationPort/);
+  assert.match(service, /implements FavoriteStationUseCase/);
+  assert.match(service, /LoadTransitMasterPort/);
+  assert.match(service, /StationNotFoundException/);
+  assert.match(repository, /implements[\s\S]*LoadFavoriteStationPort[\s\S]*SaveFavoriteStationPort[\s\S]*DeleteFavoriteStationPort/);
+  assert.match(controller, /@GetMapping\("\/api\/v1\/me\/favorite-stations"\)/);
+  assert.match(controller, /@PutMapping\("\/api\/v1\/me\/favorite-stations\/\{stationId\}"\)/);
+  assert.match(controller, /@DeleteMapping\("\/api\/v1\/me\/favorite-stations\/\{stationId\}"\)/);
+});
+
 test("mobile scaffold is a Flutter Android and iOS app", () => {
   const pubspec = read("apps/mobile/pubspec.yaml");
   const analysisOptions = read("apps/mobile/analysis_options.yaml");

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -308,6 +308,7 @@ test("backend favorite stations follow hexagonal API boundaries", () => {
   const favoriteDetails = read("backend/src/main/java/com/easysubway/favorite/domain/FavoriteStationWithDetails.java");
   const invalidFavorite = read("backend/src/main/java/com/easysubway/favorite/domain/InvalidFavoriteStationException.java");
   const useCase = read("backend/src/main/java/com/easysubway/favorite/application/port/in/FavoriteStationUseCase.java");
+  const listCommand = read("backend/src/main/java/com/easysubway/favorite/application/port/in/ListFavoriteStationsCommand.java");
   const saveCommand = read("backend/src/main/java/com/easysubway/favorite/application/port/in/SaveFavoriteStationCommand.java");
   const removeCommand = read("backend/src/main/java/com/easysubway/favorite/application/port/in/RemoveFavoriteStationCommand.java");
   const loadPort = read("backend/src/main/java/com/easysubway/favorite/application/port/out/LoadFavoriteStationPort.java");
@@ -316,15 +317,18 @@ test("backend favorite stations follow hexagonal API boundaries", () => {
   const service = read("backend/src/main/java/com/easysubway/favorite/application/service/FavoriteStationService.java");
   const repository = read("backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteStationRepository.java");
   const controller = read("backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteStationController.java");
+  const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
 
   assert.match(favorite, /record FavoriteStation/);
   assert.match(favorite, /addedAt/);
+  assert.match(favorite, /InvalidFavoriteStationException/);
   assert.match(favoriteDetails, /StationWithLines/);
   assert.match(invalidFavorite, /extends InvalidRequestException/);
   assert.match(useCase, /interface FavoriteStationUseCase/);
   assert.match(useCase, /listFavoriteStations/);
   assert.match(useCase, /saveFavoriteStation/);
   assert.match(useCase, /removeFavoriteStation/);
+  assert.match(listCommand, /record ListFavoriteStationsCommand/);
   assert.match(saveCommand, /record SaveFavoriteStationCommand/);
   assert.match(removeCommand, /record RemoveFavoriteStationCommand/);
   assert.match(loadPort, /interface LoadFavoriteStationPort/);
@@ -337,6 +341,10 @@ test("backend favorite stations follow hexagonal API boundaries", () => {
   assert.match(controller, /@GetMapping\("\/api\/v1\/me\/favorites\/stations"\)/);
   assert.match(controller, /@PutMapping\("\/api\/v1\/me\/favorites\/stations\/\{stationId\}"\)/);
   assert.match(controller, /@DeleteMapping\("\/api\/v1\/me\/favorites\/stations\/\{stationId\}"\)/);
+  assert.match(controller, /Principal principal/);
+  assert.doesNotMatch(controller, /RequestParam\(required = false\) String userId/);
+  assert.match(security, /securityMatcher\("\/api\/v1\/me\/favorites\/\*\*"\)/);
+  assert.match(security, /anyRequest\(\)\.authenticated\(\)/);
 });
 
 test("mobile scaffold is a Flutter Android and iOS app", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -312,9 +312,9 @@ test("backend favorite stations follow hexagonal API boundaries", () => {
   assert.match(service, /LoadTransitMasterPort/);
   assert.match(service, /StationNotFoundException/);
   assert.match(repository, /implements[\s\S]*LoadFavoriteStationPort[\s\S]*SaveFavoriteStationPort[\s\S]*DeleteFavoriteStationPort/);
-  assert.match(controller, /@GetMapping\("\/api\/v1\/me\/favorite-stations"\)/);
-  assert.match(controller, /@PutMapping\("\/api\/v1\/me\/favorite-stations\/\{stationId\}"\)/);
-  assert.match(controller, /@DeleteMapping\("\/api\/v1\/me\/favorite-stations\/\{stationId\}"\)/);
+  assert.match(controller, /@GetMapping\("\/api\/v1\/me\/favorites\/stations"\)/);
+  assert.match(controller, /@PutMapping\("\/api\/v1\/me\/favorites\/stations\/\{stationId\}"\)/);
+  assert.match(controller, /@DeleteMapping\("\/api\/v1\/me\/favorites\/stations\/\{stationId\}"\)/);
 });
 
 test("mobile scaffold is a Flutter Android and iOS app", () => {


### PR DESCRIPTION
## 관련 이슈

close #23

## 요약

사용자별 즐겨찾기 역을 저장, 조회, 삭제할 수 있는 백엔드 API를 추가했습니다. 즐겨찾기 목록은 역 기본 정보와 연결 노선을 함께 반환해 모바일에서 바로 표시할 수 있게 했습니다.

## 변경 사항

- favorite 도메인 모델과 상세 조회 모델을 추가했습니다.
- 즐겨찾기 역 use case, command, inbound/outbound port를 추가했습니다.
- 인메모리 즐겨찾기 역 저장소를 추가했습니다.
- `GET /api/v1/me/favorites/stations` API를 추가했습니다.
- `PUT /api/v1/me/favorites/stations/{stationId}` API를 추가했습니다.
- `DELETE /api/v1/me/favorites/stations/{stationId}` API를 추가했습니다.
- 저장 요청 시 존재하고 활성화된 역인지 검증합니다.
- 같은 사용자와 역의 중복 저장 요청은 기존 즐겨찾기를 반환합니다.
- 서비스 테스트, 컨트롤러 테스트, 저장소 계약 테스트를 추가했습니다.

## 검증

- RED: `./gradlew test --tests com.easysubway.favorite.application.service.FavoriteStationServiceTest --tests com.easysubway.favorite.adapter.in.web.FavoriteStationControllerTest --no-daemon`
  - favorite 패키지의 도메인, 포트, 서비스, 저장소, 컨트롤러가 없어 컴파일 실패하는 것을 확인했습니다.
- GREEN: `./gradlew test --tests com.easysubway.favorite.application.service.FavoriteStationServiceTest --tests com.easysubway.favorite.adapter.in.web.FavoriteStationControllerTest --no-daemon`
- `TMPDIR=/private/tmp node --test tools/ci/repository-contract.test.mjs`
- `./gradlew test --no-daemon`
- `./gradlew check --no-daemon`
- `git diff --check`
- `git diff --cached --check`
- `git ls-files '*.md'`
- API 경로 정정 RED: `./gradlew test --tests com.easysubway.favorite.adapter.in.web.FavoriteStationControllerTest --no-daemon`
  - 계획서 URL인 `/api/v1/me/favorites/stations`가 아직 매핑되지 않아 실패하는 것을 확인했습니다.
- API 경로 정정 GREEN: `./gradlew test --tests com.easysubway.favorite.adapter.in.web.FavoriteStationControllerTest --no-daemon`
- API 경로 정정 후 `TMPDIR=/private/tmp node --test tools/ci/repository-contract.test.mjs`
- API 경로 정정 후 `./gradlew check --no-daemon`
- API 경로 정정 후 `git diff --check`
- API 경로 정정 후 `git diff --cached --check`
- API 경로 정정 후 `git ls-files '*.md'`
- 최신 PR CI: https://github.com/AquilaXk/easysubway/actions/runs/27404013829
  - Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 통과

## 리뷰

- CodeRabbit: 한도와 크레딧 부족으로 리뷰가 시작되지 않았습니다.
- Codex CLI code review: 사용량 제한 해제 후 실행합니다.

## 리스크

- 현재 저장소는 로컬 개발용 인메모리 구현입니다. 영속 저장소 연동은 별도 작업에서 진행합니다.
- 인증 연동 전까지는 기존 `me` API와 동일하게 `userId`를 요청에서 받습니다.
- 즐겨찾기 역 알림 구독과 푸시 발송은 포함하지 않았습니다.

## 체크리스트

- [x] 관련 이슈를 연결했다.
- [x] 실행한 명령과 결과를 검증 섹션에 적었다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [ ] Codex CLI code review 결과를 확인했다.
- [x] CI가 통과했다.
- [ ] CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 즐겨찾기 역 조회, 저장, 삭제 기능 추가
  * 자주 이용하는 정거장을 즐겨찾기로 등록하고 관리할 수 있는 기능 구현
  * 즐겨찾기 목록 조회 시 역의 상세 정보(이름, 지역, 노선 정보 등) 함께 제공

* **Tests**
  * 즐겨찾기 기능에 대한 통합 및 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->