### PR TITLE
[Chore] 환경 설정 YAML 전환

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,0 +1,3 @@
+logging:
+  level:
+    com.easysubway: DEBUG

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,3 @@
+logging:
+  level:
+    com.easysubway: INFO

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-spring.application.name=easysubway-backend
-management.endpoints.web.exposure.include=health,info

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  application:
+    name: easysubway-backend
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,info"

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -133,7 +133,9 @@ test("backend scaffold is an eGovFrame 5.0 Spring Boot Java 21 hexagonal project
   const service = read("backend/src/main/java/com/easysubway/health/application/service/HealthCheckService.java");
   const controller = read("backend/src/main/java/com/easysubway/health/adapter/in/web/HealthCheckController.java");
   const apiResponse = read("backend/src/main/java/com/easysubway/common/web/ApiResponse.java");
-  const properties = read("backend/src/main/resources/application.properties");
+  const applicationYml = read("backend/src/main/resources/application.yml");
+  const applicationDevYml = read("backend/src/main/resources/application-dev.yml");
+  const applicationProdYml = read("backend/src/main/resources/application-prod.yml");
 
   assert.ok(existsSync(path.join(root, "backend/gradlew")));
   assert.ok(existsSync(path.join(root, "backend/gradle/wrapper/gradle-wrapper.jar")));
@@ -158,8 +160,13 @@ test("backend scaffold is an eGovFrame 5.0 Spring Boot Java 21 hexagonal project
   assert.match(controller, /@GetMapping\("\/api\/health"\)/);
   assert.match(controller, /CheckHealthUseCase/);
   assert.match(apiResponse, /record ApiResponse/);
-  assert.match(properties, /spring\.application\.name=easysubway-backend/);
-  assert.match(properties, /management\.endpoints\.web\.exposure\.include=health,info/);
+  assert.equal(existsSync(path.join(root, "backend/src/main/resources/application.properties")), false);
+  assert.match(applicationYml, /spring:\n  application:\n    name: easysubway-backend/);
+  assert.match(applicationYml, /management:\n  endpoints:\n    web:\n      exposure:\n        include: "health,info"/);
+  assert.match(applicationDevYml, /logging:\n  level:\n    com\.easysubway: DEBUG/);
+  assert.match(applicationProdYml, /logging:\n  level:\n    com\.easysubway: INFO/);
+  assert.doesNotMatch(applicationDevYml, /spring\.profiles\.active|on-profile/);
+  assert.doesNotMatch(applicationProdYml, /spring\.profiles\.active|on-profile/);
 });
 
 test("backend transit master follows hexagonal API boundaries", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -161,10 +161,10 @@ test("backend scaffold is an eGovFrame 5.0 Spring Boot Java 21 hexagonal project
   assert.match(controller, /CheckHealthUseCase/);
   assert.match(apiResponse, /record ApiResponse/);
   assert.equal(existsSync(path.join(root, "backend/src/main/resources/application.properties")), false);
-  assert.match(applicationYml, /spring:\n  application:\n    name: easysubway-backend/);
-  assert.match(applicationYml, /management:\n  endpoints:\n    web:\n      exposure:\n        include: "health,info"/);
-  assert.match(applicationDevYml, /logging:\n  level:\n    com\.easysubway: DEBUG/);
-  assert.match(applicationProdYml, /logging:\n  level:\n    com\.easysubway: INFO/);
+  assert.match(applicationYml, /spring:\s*\n\s*application:\s*\n\s*name:\s*["']?easysubway-backend["']?/);
+  assert.match(applicationYml, /management:\s*\n\s*endpoints:\s*\n\s*web:\s*\n\s*exposure:\s*\n\s*include:\s*["']?health\s*,\s*info["']?/);
+  assert.match(applicationDevYml, /logging:\s*\n\s*level:\s*\n\s*com\.easysubway:\s*["']?DEBUG["']?/);
+  assert.match(applicationProdYml, /logging:\s*\n\s*level:\s*\n\s*com\.easysubway:\s*["']?INFO["']?/);
   assert.doesNotMatch(applicationDevYml, /spring\.profiles\.active|on-profile/);
   assert.doesNotMatch(applicationProdYml, /spring\.profiles\.active|on-profile/);
 });


### PR DESCRIPTION
## 관련 이슈

Closes #25

## 요약

백엔드 설정 파일을 properties에서 YAML 구조로 전환했습니다. 공통 설정은 `application.yml`에 두고, 개발/운영 환경에서 달라질 수 있는 설정은 `application-dev.yml`, `application-prod.yml`로 분리했습니다.

## 변경 사항

- `application.properties`를 제거하고 `application.yml`로 공통 설정을 이전했습니다.
- `application-dev.yml`, `application-prod.yml`을 추가해 profile별 설정 파일을 준비했습니다.
- 저장소 계약 테스트가 YAML 설정 파일 구조와 properties 파일 제거 여부를 검증하도록 갱신했습니다.

## 검증

- `./gradlew test --no-daemon --console=plain` 통과
- `env TMPDIR=/Volumes/MACSSD/Projects/GitProjects/swieun-jihacheol/.codex/tmp node --test tools/ci/repository-contract.test.mjs` 통과
- `git diff --check` 통과
- `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`

## 리뷰어가 먼저 봐야 할 지점

- Spring Boot profile별 파일명 규칙에 맞춰 `application-dev.yml`, `application-prod.yml` 내부에는 profile 활성화 값을 별도로 넣지 않았습니다.
- 기존 `spring.application.name`과 actuator 노출 설정은 `application.yml`에 그대로 유지했습니다.

## 체크리스트

- [x] 관련 이슈를 연결했다.
- [x] 실행한 명령과 결과를 검증 섹션에 적었다.
- [x] CodeRabbit 리뷰를 확인할 예정이다.
- [x] CI 통과 후 merge하고 main CI/CD 상태를 확인할 예정이다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 백엔드 설정 파일 구조 개선: properties 파일 기반 설정에서 YAML 파일 기반 설정으로 마이그레이션
* 개발(DEBUG) 및 프로덕션(INFO) 환경별 로깅 레벨 설정 추가

## Tests
* 백엔드 설정 파일 검증 테스트 업데이트: 새로운 YAML 설정 방식에 맞도록 테스트 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->