### PR TITLE
[Feat] 경로 검색 기초 API 추가

### DIFF
--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -6,65 +6,62 @@ import 'package:easysubway_mobile/station_search.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test(
-    'station API repository requests backend stations and parses results',
-    () async {
-      late Uri requestedUri;
-      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-      addTearDown(server.close);
+  test('역 API 저장소는 백엔드 역 목록을 요청하고 결과를 파싱한다', () async {
+    late Uri requestedUri;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
 
-      server.listen((request) {
-        requestedUri = request.uri;
-        request.response
-          ..statusCode = HttpStatus.ok
-          ..headers.contentType = ContentType.json
-          ..write(
-            jsonEncode({
-              'success': true,
-              'data': [
-                {
-                  'id': 'station-sangnoksu',
-                  'nameKo': '상록수',
-                  'nameEn': 'Sangnoksu',
-                  'region': '수도권',
-                  'dataQualityLevel': 'LEVEL_1',
-                  'lastVerifiedAt': '2026-06-12',
-                  'lines': [
-                    {
-                      'id': 'seoul-4',
-                      'operatorId': 'seoul-metro',
-                      'name': '수도권 4호선',
-                      'color': '#00A5DE',
-                      'stationCode': '448',
-                      'sequence': 48,
-                      'platformInfo': '당고개 방면 / 오이도 방면',
-                    },
-                  ],
-                },
-              ],
-            }),
-          )
-          ..close();
-      });
+    server.listen((request) {
+      requestedUri = request.uri;
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': [
+              {
+                'id': 'station-sangnoksu',
+                'nameKo': '상록수',
+                'nameEn': 'Sangnoksu',
+                'region': '수도권',
+                'dataQualityLevel': 'LEVEL_1',
+                'lastVerifiedAt': '2026-06-12',
+                'lines': [
+                  {
+                    'id': 'seoul-4',
+                    'operatorId': 'seoul-metro',
+                    'name': '수도권 4호선',
+                    'color': '#00A5DE',
+                    'stationCode': '448',
+                    'sequence': 48,
+                    'platformInfo': '당고개 방면 / 오이도 방면',
+                  },
+                ],
+              },
+            ],
+          }),
+        )
+        ..close();
+    });
 
-      final repository = StationSearchApiRepository(
-        baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
-      );
+    final repository = StationSearchApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
 
-      final results = await repository.searchStations('상록수');
+    final results = await repository.searchStations('상록수');
 
-      expect(requestedUri.path, '/api/v1/stations');
-      expect(requestedUri.queryParameters['query'], '상록수');
-      expect(results, hasLength(1));
-      expect(results.single.id, 'station-sangnoksu');
-      expect(results.single.nameKo, '상록수');
-      expect(results.single.region, '수도권');
-      expect(results.single.dataQualityLabel, '기본 정보만 확인됨');
-      expect(results.single.lines.single.name, '수도권 4호선');
-    },
-  );
+    expect(requestedUri.path, '/api/v1/stations');
+    expect(requestedUri.queryParameters['query'], '상록수');
+    expect(results, hasLength(1));
+    expect(results.single.id, 'station-sangnoksu');
+    expect(results.single.nameKo, '상록수');
+    expect(results.single.region, '수도권');
+    expect(results.single.dataQualityLabel, '기본 정보만 확인됨');
+    expect(results.single.lines.single.name, '수도권 4호선');
+  });
 
-  test('station API repository rejects malformed station payloads', () async {
+  test('역 API 저장소는 형식이 잘못된 역 응답을 거부한다', () async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(server.close);
 
@@ -113,21 +110,18 @@ void main() {
     );
   });
 
-  test(
-    'station search controller keeps blank input idle without API calls',
-    () async {
-      final repository = FakeStationSearchRepository();
-      final controller = StationSearchController(repository: repository);
+  test('역 검색 컨트롤러는 빈 입력을 API 호출 없이 대기 상태로 둔다', () async {
+    final repository = FakeStationSearchRepository();
+    final controller = StationSearchController(repository: repository);
 
-      await controller.search('   ');
+    await controller.search('   ');
 
-      expect(repository.requestedQueries, isEmpty);
-      expect(controller.state.status, StationSearchStatus.idle);
-      expect(controller.state.results, isEmpty);
-    },
-  );
+    expect(repository.requestedQueries, isEmpty);
+    expect(controller.state.status, StationSearchStatus.idle);
+    expect(controller.state.results, isEmpty);
+  });
 
-  test('station search controller ignores stale responses', () async {
+  test('역 검색 컨트롤러는 늦게 도착한 이전 응답을 무시한다', () async {
     final repository = ControlledStationSearchRepository();
     final controller = StationSearchController(repository: repository);
 
@@ -153,7 +147,7 @@ void main() {
     expect(controller.state.results.single.nameKo, '강남');
   });
 
-  test('station search controller exposes empty and failure states', () async {
+  test('역 검색 컨트롤러는 빈 결과와 실패 상태를 표시한다', () async {
     final repository = FakeStationSearchRepository();
     final controller = StationSearchController(repository: repository);
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('renders concise home screen actions', (tester) async {
+  testWidgets('홈 화면은 핵심 행동만 간결하게 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
 
     try {
@@ -41,9 +41,7 @@ void main() {
     }
   });
 
-  testWidgets('searches stations and shows accessible backend results', (
-    tester,
-  ) async {
+  testWidgets('역 검색은 접근성 표시가 포함된 백엔드 결과를 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final repository = FakeStationSearchRepository(
       nextResults: [
@@ -136,9 +134,7 @@ void main() {
     }
   });
 
-  testWidgets('disables search button while request is loading', (
-    tester,
-  ) async {
+  testWidgets('검색 요청 중에는 검색 버튼을 비활성화한다', (tester) async {
     final repository = ControlledStationSearchRepository();
 
     await tester.pumpWidget(EasySubwayApp(repository: repository));

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
 	@Bean
 	@Order(3)
 	SecurityFilterChain publicSecurityFilterChain(HttpSecurity http) throws Exception {
+		// 역 검색과 경로 검색은 로그인 전 이동 계획에 필요한 공개 조회 기능이다.
 		return http
 			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(authorize -> authorize

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig {
 	@Bean
 	@Order(1)
 	SecurityFilterChain adminSecurityFilterChain(HttpSecurity http) throws Exception {
+		// 관리자 검수 API는 다른 공개 API보다 먼저 매칭해야 잘못된 인증 우회를 막을 수 있다.
 		return http
 			.securityMatcher("/admin/**")
 			.csrf(AbstractHttpConfigurer::disable)
@@ -35,6 +36,7 @@ public class SecurityConfig {
 	@Bean
 	@Order(2)
 	SecurityFilterChain userSecurityFilterChain(HttpSecurity http) throws Exception {
+		// 사용자별 데이터는 URL이나 본문 userId가 아니라 인증 계정을 기준으로 다룬다.
 		return http
 			.securityMatcher("/api/v1/me/favorites/**")
 			.csrf(AbstractHttpConfigurer::disable)

--- a/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteStationService.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteStationService.java
@@ -80,6 +80,7 @@ public class FavoriteStationService implements FavoriteStationUseCase {
 	public FavoriteStationWithDetails saveFavoriteStation(SaveFavoriteStationCommand command) {
 		requireUserId(command.userId());
 		requireStationId(command.stationId());
+		// 즐겨찾기는 운영 중인 역만 허용해 폐역 또는 잘못된 역 식별자가 사용자 목록에 남지 않게 한다.
 		loadActiveStation(command.stationId());
 
 		FavoriteStation favoriteStation = loadFavoriteStationPort
@@ -117,6 +118,7 @@ public class FavoriteStationService implements FavoriteStationUseCase {
 	}
 
 	private StationWithLines withLines(Station station) {
+		// 응답 노선은 현재 활성 노선만 노출해 검색/즐겨찾기 화면의 혼동을 줄인다.
 		Map<String, SubwayLine> linesById = loadTransitMasterPort.loadLines()
 			.stream()
 			.filter(SubwayLine::active)

--- a/backend/src/main/java/com/easysubway/profile/application/service/MobilityProfileService.java
+++ b/backend/src/main/java/com/easysubway/profile/application/service/MobilityProfileService.java
@@ -66,6 +66,7 @@ public class MobilityProfileService implements MobilityProfileUseCase {
 	}
 
 	private MobilityProfile defaultProfile(String userId) {
+		// 새 사용자는 디지털 소외계층을 기본 사용자로 보고 계단과 긴 이동을 피하는 값으로 시작한다.
 		return new MobilityProfile(
 			userId,
 			MobilityType.SENIOR,
@@ -94,6 +95,7 @@ public class MobilityProfileService implements MobilityProfileUseCase {
 	}
 
 	private void requireWheelchairRules(SaveMobilityProfileCommand command) {
+		// 휠체어 사용자는 계단 허용 여부가 경로 안전성과 직결되므로 저장 단계에서 차단한다.
 		if (command.mobilityType() == MobilityType.WHEELCHAIR && !command.avoidStairs()) {
 			throw new InvalidMobilityProfileException("휠체어 프로필은 계단 없는 경로만 저장할 수 있습니다.");
 		}

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -53,6 +53,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 	public FacilityReport createReport(CreateFacilityReportCommand command) {
 		requireReportType(command);
 		requireActiveStation(command.stationId());
+		// 신고 대상 시설이 요청한 역에 속해야 다른 역 시설 상태가 잘못 갱신되는 일을 막을 수 있다.
 		requireFacilityInStation(command.stationId(), command.facilityId());
 
 		FacilityReport report = new FacilityReport(
@@ -143,6 +144,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 	}
 
 	private FacilityReportStatus toStatus(FacilityReportReviewDecision decision) {
+		// 외부 요청의 검수 결정값을 내부 신고 상태로 한 곳에서만 변환한다.
 		return switch (decision) {
 			case ACCEPT -> FacilityReportStatus.ACCEPTED;
 			case REJECT -> FacilityReportStatus.REJECTED;

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+// 경로 검색은 사용자별 저장 데이터 없이 역과 이동 조건만 계산하므로 로그인 전 탐색 화면에서도 호출한다.
 class RouteSearchController {
 
 	private final RouteSearchUseCase routeSearchUseCase;

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -1,0 +1,43 @@
+package com.easysubway.route.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.application.port.in.RouteSearchUseCase;
+import com.easysubway.route.application.port.in.SearchRouteCommand;
+import com.easysubway.route.domain.RouteSearchResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class RouteSearchController {
+
+	private final RouteSearchUseCase routeSearchUseCase;
+
+	RouteSearchController(RouteSearchUseCase routeSearchUseCase) {
+		this.routeSearchUseCase = routeSearchUseCase;
+	}
+
+	@PostMapping("/api/v1/routes/search")
+	ApiResponse<RouteSearchResult> searchRoute(@RequestBody SearchRouteRequest request) {
+		return ApiResponse.ok(routeSearchUseCase.searchRoute(request.toCommand()));
+	}
+
+	@GetMapping("/api/v1/routes/{routeSearchId}")
+	ApiResponse<RouteSearchResult> getRouteSearch(@PathVariable String routeSearchId) {
+		return ApiResponse.ok(routeSearchUseCase.getRouteSearch(routeSearchId));
+	}
+
+	record SearchRouteRequest(
+		String originStationId,
+		String destinationStationId,
+		MobilityType mobilityType
+	) {
+
+		SearchRouteCommand toCommand() {
+			return new SearchRouteCommand(originStationId, destinationStationId, mobilityType);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
@@ -1,0 +1,26 @@
+package com.easysubway.route.adapter.out.persistence;
+
+import com.easysubway.route.application.port.out.LoadRouteSearchPort;
+import com.easysubway.route.application.port.out.SaveRouteSearchPort;
+import com.easysubway.route.domain.RouteSearchResult;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryRouteSearchRepository implements LoadRouteSearchPort, SaveRouteSearchPort {
+
+	private final Map<String, RouteSearchResult> routeSearches = new ConcurrentHashMap<>();
+
+	@Override
+	public Optional<RouteSearchResult> loadRouteSearch(String routeSearchId) {
+		return Optional.ofNullable(routeSearches.get(routeSearchId));
+	}
+
+	@Override
+	public RouteSearchResult saveRouteSearch(RouteSearchResult routeSearchResult) {
+		routeSearches.put(routeSearchResult.routeSearchId(), routeSearchResult);
+		return routeSearchResult;
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
@@ -3,24 +3,39 @@ package com.easysubway.route.adapter.out.persistence;
 import com.easysubway.route.application.port.out.LoadRouteSearchPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
 import com.easysubway.route.domain.RouteSearchResult;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class InMemoryRouteSearchRepository implements LoadRouteSearchPort, SaveRouteSearchPort {
 
-	private final Map<String, RouteSearchResult> routeSearches = new ConcurrentHashMap<>();
+	static final int MAX_STORED_ROUTE_SEARCHES = 1_000;
+
+	private final Map<String, RouteSearchResult> routeSearches = new LinkedHashMap<>();
 
 	@Override
 	public Optional<RouteSearchResult> loadRouteSearch(String routeSearchId) {
-		return Optional.ofNullable(routeSearches.get(routeSearchId));
+		synchronized (routeSearches) {
+			return Optional.ofNullable(routeSearches.get(routeSearchId));
+		}
 	}
 
 	@Override
 	public RouteSearchResult saveRouteSearch(RouteSearchResult routeSearchResult) {
-		routeSearches.put(routeSearchResult.routeSearchId(), routeSearchResult);
-		return routeSearchResult;
+		synchronized (routeSearches) {
+			routeSearches.put(routeSearchResult.routeSearchId(), routeSearchResult);
+			evictOldestRouteSearches();
+			return routeSearchResult;
+		}
+	}
+
+	private void evictOldestRouteSearches() {
+		// 공개 API 요청으로 생성되는 임시 결과가 프로세스 메모리에 무한히 쌓이지 않게 한다.
+		while (routeSearches.size() > MAX_STORED_ROUTE_SEARCHES) {
+			String oldestRouteSearchId = routeSearches.keySet().iterator().next();
+			routeSearches.remove(oldestRouteSearchId);
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
@@ -1,0 +1,10 @@
+package com.easysubway.route.application.port.in;
+
+import com.easysubway.route.domain.RouteSearchResult;
+
+public interface RouteSearchUseCase {
+
+	RouteSearchResult searchRoute(SearchRouteCommand command);
+
+	RouteSearchResult getRouteSearch(String routeSearchId);
+}

--- a/backend/src/main/java/com/easysubway/route/application/port/in/SearchRouteCommand.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/SearchRouteCommand.java
@@ -1,0 +1,10 @@
+package com.easysubway.route.application.port.in;
+
+import com.easysubway.profile.domain.MobilityType;
+
+public record SearchRouteCommand(
+	String originStationId,
+	String destinationStationId,
+	MobilityType mobilityType
+) {
+}

--- a/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteSearchPort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteSearchPort.java
@@ -1,0 +1,9 @@
+package com.easysubway.route.application.port.out;
+
+import com.easysubway.route.domain.RouteSearchResult;
+import java.util.Optional;
+
+public interface LoadRouteSearchPort {
+
+	Optional<RouteSearchResult> loadRouteSearch(String routeSearchId);
+}

--- a/backend/src/main/java/com/easysubway/route/application/port/out/SaveRouteSearchPort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/SaveRouteSearchPort.java
@@ -1,0 +1,8 @@
+package com.easysubway.route.application.port.out;
+
+import com.easysubway.route.domain.RouteSearchResult;
+
+public interface SaveRouteSearchPort {
+
+	RouteSearchResult saveRouteSearch(RouteSearchResult routeSearchResult);
+}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -303,7 +303,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 
 	private String displayLineName(SubwayLine line) {
 		String lineCode = line.lineCode();
-		if (lineCode != null && lineCode.chars().allMatch(Character::isDigit)) {
+		if (lineCode != null && !lineCode.isBlank() && lineCode.chars().allMatch(Character::isDigit)) {
 			return lineCode + "호선";
 		}
 		return line.name();

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -1,0 +1,299 @@
+package com.easysubway.route.application.service;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.application.port.in.RouteSearchUseCase;
+import com.easysubway.route.application.port.in.SearchRouteCommand;
+import com.easysubway.route.application.port.out.LoadRouteSearchPort;
+import com.easysubway.route.application.port.out.SaveRouteSearchPort;
+import com.easysubway.route.domain.InvalidRouteSearchException;
+import com.easysubway.route.domain.RouteNotFoundException;
+import com.easysubway.route.domain.RouteSearchNotFoundException;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.route.domain.RouteStep;
+import com.easysubway.route.domain.RouteWarning;
+import com.easysubway.route.domain.RouteWarningCode;
+import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import com.easysubway.transit.domain.AccessibilityFacilityType;
+import com.easysubway.transit.domain.DataConfidenceLevel;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationExit;
+import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.StationNotFoundException;
+import com.easysubway.transit.domain.SubwayLine;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RouteSearchService implements RouteSearchUseCase {
+
+	private final LoadRouteSearchPort loadRouteSearchPort;
+	private final SaveRouteSearchPort saveRouteSearchPort;
+	private final LoadTransitMasterPort loadTransitMasterPort;
+	private final Clock clock;
+
+	@Autowired
+	public RouteSearchService(
+		LoadRouteSearchPort loadRouteSearchPort,
+		SaveRouteSearchPort saveRouteSearchPort,
+		LoadTransitMasterPort loadTransitMasterPort
+	) {
+		this(loadRouteSearchPort, saveRouteSearchPort, loadTransitMasterPort, Clock.systemDefaultZone());
+	}
+
+	public RouteSearchService(
+		LoadRouteSearchPort loadRouteSearchPort,
+		SaveRouteSearchPort saveRouteSearchPort,
+		LoadTransitMasterPort loadTransitMasterPort,
+		Clock clock
+	) {
+		this.loadRouteSearchPort = loadRouteSearchPort;
+		this.saveRouteSearchPort = saveRouteSearchPort;
+		this.loadTransitMasterPort = loadTransitMasterPort;
+		this.clock = clock;
+	}
+
+	@Override
+	public RouteSearchResult searchRoute(SearchRouteCommand command) {
+		requireCommand(command);
+		Station origin = loadActiveStation(command.originStationId());
+		Station destination = loadActiveStation(command.destinationStationId());
+		if (origin.id().equals(destination.id())) {
+			throw new InvalidRouteSearchException("출발역과 도착역이 달라야 합니다.");
+		}
+
+		DirectLine directLine = findDirectLine(origin.id(), destination.id());
+		List<RouteWarning> warnings = routeWarnings(origin.id(), destination.id());
+
+		if (command.mobilityType() == MobilityType.WHEELCHAIR && hasStairOnlyAccess(origin.id(), destination.id())) {
+			return saveRouteSearchPort.saveRouteSearch(new RouteSearchResult(
+				newRouteSearchId(),
+				origin.id(),
+				origin.nameKo(),
+				destination.id(),
+				destination.nameKo(),
+				command.mobilityType(),
+				RouteSearchStatus.BLOCKED,
+				directLine.line().id(),
+				directLine.line().name(),
+				0,
+				List.of(),
+				warnings,
+				List.of("계단 없는 역 접근 경로를 확인할 수 없습니다."),
+				LocalDateTime.now(clock)
+			));
+		}
+
+		List<RouteStep> steps = directLineSteps(origin, destination, directLine);
+		return saveRouteSearchPort.saveRouteSearch(new RouteSearchResult(
+			newRouteSearchId(),
+			origin.id(),
+			origin.nameKo(),
+			destination.id(),
+			destination.nameKo(),
+			command.mobilityType(),
+			RouteSearchStatus.FOUND,
+			directLine.line().id(),
+			directLine.line().name(),
+			routeScore(command.mobilityType(), directLine, warnings),
+			steps,
+			warnings,
+			List.of(),
+			LocalDateTime.now(clock)
+		));
+	}
+
+	@Override
+	public RouteSearchResult getRouteSearch(String routeSearchId) {
+		if (routeSearchId == null || routeSearchId.isBlank()) {
+			throw new RouteSearchNotFoundException();
+		}
+		return loadRouteSearchPort.loadRouteSearch(routeSearchId)
+			.orElseThrow(RouteSearchNotFoundException::new);
+	}
+
+	private void requireCommand(SearchRouteCommand command) {
+		if (command.originStationId() == null || command.originStationId().isBlank()) {
+			throw new InvalidRouteSearchException("출발역을 선택해야 합니다.");
+		}
+		if (command.destinationStationId() == null || command.destinationStationId().isBlank()) {
+			throw new InvalidRouteSearchException("도착역을 선택해야 합니다.");
+		}
+		if (command.mobilityType() == null) {
+			throw new InvalidRouteSearchException("이동 유형을 선택해야 합니다.");
+		}
+	}
+
+	private Station loadActiveStation(String stationId) {
+		return loadTransitMasterPort.loadStations()
+			.stream()
+			.filter(Station::active)
+			.filter(station -> station.id().equals(stationId))
+			.findFirst()
+			.orElseThrow(StationNotFoundException::new);
+	}
+
+	private DirectLine findDirectLine(String originStationId, String destinationStationId) {
+		// 현재 기준선은 환승 없이 같은 활성 노선에 속한 두 역만 직접 경로로 계산한다.
+		Map<String, SubwayLine> activeLinesById = loadTransitMasterPort.loadLines()
+			.stream()
+			.filter(SubwayLine::active)
+			.collect(Collectors.toMap(SubwayLine::id, Function.identity()));
+
+		Map<String, StationLine> originLinesByLineId = loadTransitMasterPort.loadStationLines()
+			.stream()
+			.filter(stationLine -> stationLine.stationId().equals(originStationId))
+			.filter(stationLine -> activeLinesById.containsKey(stationLine.lineId()))
+			.collect(Collectors.toMap(StationLine::lineId, Function.identity()));
+
+		return loadTransitMasterPort.loadStationLines()
+			.stream()
+			.filter(stationLine -> stationLine.stationId().equals(destinationStationId))
+			.filter(stationLine -> originLinesByLineId.containsKey(stationLine.lineId()))
+			.filter(stationLine -> activeLinesById.containsKey(stationLine.lineId()))
+			.map(destinationLine -> new DirectLine(
+				activeLinesById.get(destinationLine.lineId()),
+				originLinesByLineId.get(destinationLine.lineId()),
+				destinationLine
+			))
+			.min(Comparator.comparingInt(DirectLine::stopCount))
+			.orElseThrow(RouteNotFoundException::new);
+	}
+
+	private List<RouteWarning> routeWarnings(String originStationId, String destinationStationId) {
+		// 출구 데이터가 없거나 신뢰도가 낮으면 사용자가 이동 전 확인할 수 있게 경고를 남긴다.
+		if (hasLowAccessibilityData(originStationId) || hasLowAccessibilityData(destinationStationId)) {
+			return List.of(new RouteWarning(
+				RouteWarningCode.LOW_DATA_CONFIDENCE,
+				"출발역 또는 도착역 접근성 정보가 부족합니다. 이동 전 역 상세 정보를 확인하세요."
+			));
+		}
+		return List.of();
+	}
+
+	private boolean hasLowAccessibilityData(String stationId) {
+		List<StationExit> exits = stationExits(stationId);
+		if (exits.isEmpty()) {
+			return true;
+		}
+		return exits.stream()
+			.anyMatch(exit -> exit.dataConfidence() != DataConfidenceLevel.HIGH);
+	}
+
+	private boolean hasStairOnlyAccess(String originStationId, String destinationStationId) {
+		return hasStairOnlyAccess(originStationId) || hasStairOnlyAccess(destinationStationId);
+	}
+
+	private boolean hasStairOnlyAccess(String stationId) {
+		List<StationExit> exits = stationExits(stationId);
+		if (exits.isEmpty()) {
+			return false;
+		}
+		// 휠체어 프로필은 계단만 확인되는 역 접근을 추천하지 않는다.
+		boolean hasStepFreeExit = exits.stream()
+			.anyMatch(exit -> exit.hasElevatorConnection() && !exit.hasStairOnlyPath());
+		boolean hasNormalElevator = stationFacilities(stationId).stream()
+			.anyMatch(this::isNormalElevator);
+		boolean hasStairOnlyExit = exits.stream().anyMatch(StationExit::hasStairOnlyPath);
+		return hasStairOnlyExit && !hasStepFreeExit && !hasNormalElevator;
+	}
+
+	private boolean isNormalElevator(AccessibilityFacility facility) {
+		return facility.type() == AccessibilityFacilityType.ELEVATOR
+			&& (facility.status() == AccessibilityFacilityStatus.NORMAL
+				|| facility.status() == AccessibilityFacilityStatus.ADMIN_VERIFIED);
+	}
+
+	private List<StationExit> stationExits(String stationId) {
+		return loadTransitMasterPort.loadStationExits()
+			.stream()
+			.filter(exit -> exit.stationId().equals(stationId))
+			.toList();
+	}
+
+	private List<AccessibilityFacility> stationFacilities(String stationId) {
+		return loadTransitMasterPort.loadAccessibilityFacilities()
+			.stream()
+			.filter(facility -> facility.stationId().equals(stationId))
+			.toList();
+	}
+
+	private int routeScore(MobilityType mobilityType, DirectLine directLine, List<RouteWarning> warnings) {
+		// 점수는 시간이 아니라 상대 비용이다. 낮을수록 쉬운 경로에 가깝다.
+		int trainTime = directLine.stopCount() * 3;
+		int walkingTime = 8;
+		int profilePenalty = switch (mobilityType) {
+			case SENIOR -> 12;
+			case STROLLER, PREGNANT, LUGGAGE -> 10;
+			case TEMPORARY_INJURY -> 14;
+			case WHEELCHAIR -> 18;
+		};
+		int lowDataPenalty = warnings.isEmpty() ? 0 : 20;
+		return trainTime + walkingTime + profilePenalty + lowDataPenalty;
+	}
+
+	private List<RouteStep> directLineSteps(Station origin, Station destination, DirectLine directLine) {
+		String displayLine = displayLineName(directLine.line());
+		return List.of(
+			new RouteStep(
+				1,
+				origin.nameKo() + "역에서 " + displayLine + " 승강장으로 이동",
+				"엘리베이터와 넓은 통로가 있는 출구를 먼저 확인한 뒤 승강장으로 이동합니다.",
+				directLine.line().id(),
+				directLine.line().name(),
+				origin.id(),
+				origin.id()
+			),
+			new RouteStep(
+				2,
+				directLine.line().name() + "으로 " + destination.nameKo() + "역까지 이동",
+				directLine.stopCount() + "개 역을 이동합니다. 환승은 없습니다.",
+				directLine.line().id(),
+				directLine.line().name(),
+				origin.id(),
+				destination.id()
+			),
+			new RouteStep(
+				3,
+				destination.nameKo() + "역에서 출구 접근성 정보를 확인",
+				"도착역 출구와 엘리베이터 상태를 확인한 뒤 이동합니다.",
+				directLine.line().id(),
+				directLine.line().name(),
+				destination.id(),
+				destination.id()
+			)
+		);
+	}
+
+	private String displayLineName(SubwayLine line) {
+		if (line.lineCode().chars().allMatch(Character::isDigit)) {
+			return line.lineCode() + "호선";
+		}
+		return line.name();
+	}
+
+	private String newRouteSearchId() {
+		return "route-" + UUID.randomUUID();
+	}
+
+	private record DirectLine(
+		SubwayLine line,
+		StationLine origin,
+		StationLine destination
+	) {
+
+		int stopCount() {
+			return Math.abs(origin.sequence() - destination.sequence());
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -214,8 +214,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.anyMatch(this::hasUsableStatus);
 		boolean hasUsableStepFreeExit = highConfidenceExits.stream()
 			.anyMatch(exit -> isUsableStepFreeExit(exit, highConfidenceStepFreeFacilities));
-		boolean hasStairOnlyExit = highConfidenceExits.stream().anyMatch(StationExit::hasStairOnlyPath);
-		return hasStairOnlyExit && !hasUsableStepFreeFacility && !hasUsableStepFreeExit;
+		return !hasUsableStepFreeFacility && !hasUsableStepFreeExit;
 	}
 
 	private boolean isStepFreeFacility(AccessibilityFacility facility) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -206,20 +206,39 @@ public class RouteSearchService implements RouteSearchUseCase {
 			return false;
 		}
 		// 차단 판단은 신뢰도 높은 실제 무단차 시설만 사용하고, 낮은 신뢰도 데이터는 경고로만 노출한다.
-		boolean hasUsableStepFreeFacility = stationFacilities(stationId).stream()
+		List<AccessibilityFacility> highConfidenceStepFreeFacilities = stationFacilities(stationId).stream()
 			.filter(facility -> facility.dataConfidence() == DataConfidenceLevel.HIGH)
-			.anyMatch(this::isUsableStepFreeFacility);
+			.filter(this::isStepFreeFacility)
+			.toList();
+		boolean hasUsableStepFreeFacility = highConfidenceStepFreeFacilities.stream()
+			.anyMatch(this::hasUsableStatus);
+		boolean hasUsableStepFreeExit = highConfidenceExits.stream()
+			.anyMatch(exit -> isUsableStepFreeExit(exit, highConfidenceStepFreeFacilities));
 		boolean hasStairOnlyExit = highConfidenceExits.stream().anyMatch(StationExit::hasStairOnlyPath);
-		return hasStairOnlyExit && !hasUsableStepFreeFacility;
+		return hasStairOnlyExit && !hasUsableStepFreeFacility && !hasUsableStepFreeExit;
 	}
 
-	private boolean isUsableStepFreeFacility(AccessibilityFacility facility) {
-		boolean usableStatus = facility.status() == AccessibilityFacilityStatus.NORMAL
-			|| facility.status() == AccessibilityFacilityStatus.ADMIN_VERIFIED;
-		return usableStatus && switch (facility.type()) {
+	private boolean isStepFreeFacility(AccessibilityFacility facility) {
+		return switch (facility.type()) {
 			case ELEVATOR, WHEELCHAIR_LIFT, RAMP -> true;
 			default -> false;
 		};
+	}
+
+	private boolean hasUsableStatus(AccessibilityFacility facility) {
+		return facility.status() == AccessibilityFacilityStatus.NORMAL
+			|| facility.status() == AccessibilityFacilityStatus.ADMIN_VERIFIED;
+	}
+
+	private boolean isUsableStepFreeExit(
+		StationExit exit,
+		List<AccessibilityFacility> highConfidenceStepFreeFacilities
+	) {
+		if (!exit.hasElevatorConnection() || exit.hasStairOnlyPath()) {
+			return false;
+		}
+		return highConfidenceStepFreeFacilities.stream()
+			.noneMatch(facility -> exit.id().equals(facility.exitId()) && !hasUsableStatus(facility));
 	}
 
 	private List<StationExit> stationExits(String stationId) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -199,12 +199,19 @@ public class RouteSearchService implements RouteSearchUseCase {
 		if (exits.isEmpty()) {
 			return false;
 		}
-		// 휠체어 프로필은 계단만 확인되는 역 접근을 추천하지 않는다.
-		boolean hasStepFreeExit = exits.stream()
+		List<StationExit> highConfidenceExits = exits.stream()
+			.filter(exit -> exit.dataConfidence() == DataConfidenceLevel.HIGH)
+			.toList();
+		if (highConfidenceExits.isEmpty()) {
+			return false;
+		}
+		// 차단 판단은 신뢰도 높은 데이터만 사용하고, 낮은 신뢰도 데이터는 경고로만 노출한다.
+		boolean hasStepFreeExit = highConfidenceExits.stream()
 			.anyMatch(exit -> exit.hasElevatorConnection() && !exit.hasStairOnlyPath());
 		boolean hasNormalElevator = stationFacilities(stationId).stream()
+			.filter(facility -> facility.dataConfidence() == DataConfidenceLevel.HIGH)
 			.anyMatch(this::isNormalElevator);
-		boolean hasStairOnlyExit = exits.stream().anyMatch(StationExit::hasStairOnlyPath);
+		boolean hasStairOnlyExit = highConfidenceExits.stream().anyMatch(StationExit::hasStairOnlyPath);
 		return hasStairOnlyExit && !hasStepFreeExit && !hasNormalElevator;
 	}
 

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -205,20 +205,21 @@ public class RouteSearchService implements RouteSearchUseCase {
 		if (highConfidenceExits.isEmpty()) {
 			return false;
 		}
-		// 차단 판단은 신뢰도 높은 데이터만 사용하고, 낮은 신뢰도 데이터는 경고로만 노출한다.
-		boolean hasStepFreeExit = highConfidenceExits.stream()
-			.anyMatch(exit -> exit.hasElevatorConnection() && !exit.hasStairOnlyPath());
-		boolean hasNormalElevator = stationFacilities(stationId).stream()
+		// 차단 판단은 신뢰도 높은 실제 무단차 시설만 사용하고, 낮은 신뢰도 데이터는 경고로만 노출한다.
+		boolean hasUsableStepFreeFacility = stationFacilities(stationId).stream()
 			.filter(facility -> facility.dataConfidence() == DataConfidenceLevel.HIGH)
-			.anyMatch(this::isNormalElevator);
+			.anyMatch(this::isUsableStepFreeFacility);
 		boolean hasStairOnlyExit = highConfidenceExits.stream().anyMatch(StationExit::hasStairOnlyPath);
-		return hasStairOnlyExit && !hasStepFreeExit && !hasNormalElevator;
+		return hasStairOnlyExit && !hasUsableStepFreeFacility;
 	}
 
-	private boolean isNormalElevator(AccessibilityFacility facility) {
-		return facility.type() == AccessibilityFacilityType.ELEVATOR
-			&& (facility.status() == AccessibilityFacilityStatus.NORMAL
-				|| facility.status() == AccessibilityFacilityStatus.ADMIN_VERIFIED);
+	private boolean isUsableStepFreeFacility(AccessibilityFacility facility) {
+		boolean usableStatus = facility.status() == AccessibilityFacilityStatus.NORMAL
+			|| facility.status() == AccessibilityFacilityStatus.ADMIN_VERIFIED;
+		return usableStatus && switch (facility.type()) {
+			case ELEVATOR, WHEELCHAIR_LIFT, RAMP -> true;
+			default -> false;
+		};
 	}
 
 	private List<StationExit> stationExits(String stationId) {
@@ -283,8 +284,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 	}
 
 	private String displayLineName(SubwayLine line) {
-		if (line.lineCode().chars().allMatch(Character::isDigit)) {
-			return line.lineCode() + "호선";
+		String lineCode = line.lineCode();
+		if (lineCode != null && lineCode.chars().allMatch(Character::isDigit)) {
+			return lineCode + "호선";
 		}
 		return line.name();
 	}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -25,6 +25,7 @@ import com.easysubway.transit.domain.StationNotFoundException;
 import com.easysubway.transit.domain.SubwayLine;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -73,9 +74,10 @@ public class RouteSearchService implements RouteSearchUseCase {
 		}
 
 		DirectLine directLine = findDirectLine(origin.id(), destination.id());
-		List<RouteWarning> warnings = routeWarnings(origin.id(), destination.id());
+		boolean stairOnlyAccess = hasStairOnlyAccess(origin.id(), destination.id());
+		List<RouteWarning> warnings = routeWarnings(origin.id(), destination.id(), stairOnlyAccess);
 
-		if (command.mobilityType() == MobilityType.WHEELCHAIR && hasStairOnlyAccess(origin.id(), destination.id())) {
+		if (command.mobilityType() == MobilityType.WHEELCHAIR && stairOnlyAccess) {
 			return saveRouteSearchPort.saveRouteSearch(new RouteSearchResult(
 				newRouteSearchId(),
 				origin.id(),
@@ -170,15 +172,22 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.orElseThrow(RouteNotFoundException::new);
 	}
 
-	private List<RouteWarning> routeWarnings(String originStationId, String destinationStationId) {
+	private List<RouteWarning> routeWarnings(String originStationId, String destinationStationId, boolean stairOnlyAccess) {
 		// 출구 데이터가 없거나 신뢰도가 낮으면 사용자가 이동 전 확인할 수 있게 경고를 남긴다.
+		List<RouteWarning> warnings = new ArrayList<>();
 		if (hasLowAccessibilityData(originStationId) || hasLowAccessibilityData(destinationStationId)) {
-			return List.of(new RouteWarning(
+			warnings.add(new RouteWarning(
 				RouteWarningCode.LOW_DATA_CONFIDENCE,
 				"출발역 또는 도착역 접근성 정보가 부족합니다. 이동 전 역 상세 정보를 확인하세요."
 			));
 		}
-		return List.of();
+		if (stairOnlyAccess) {
+			warnings.add(new RouteWarning(
+				RouteWarningCode.STAIR_ONLY_ACCESS,
+				"출발역 또는 도착역에 계단 없는 접근 경로가 확인되지 않았습니다."
+			));
+		}
+		return List.copyOf(warnings);
 	}
 
 	private boolean hasLowAccessibilityData(String stationId) {
@@ -186,8 +195,12 @@ public class RouteSearchService implements RouteSearchUseCase {
 		if (exits.isEmpty()) {
 			return true;
 		}
-		return exits.stream()
+		boolean hasLowConfidenceExit = exits.stream()
 			.anyMatch(exit -> exit.dataConfidence() != DataConfidenceLevel.HIGH);
+		boolean hasLowConfidenceStepFreeFacility = stationFacilities(stationId).stream()
+			.filter(this::isStepFreeFacility)
+			.anyMatch(facility -> facility.dataConfidence() != DataConfidenceLevel.HIGH);
+		return hasLowConfidenceExit || hasLowConfidenceStepFreeFacility;
 	}
 
 	private boolean hasStairOnlyAccess(String originStationId, String destinationStationId) {
@@ -264,8 +277,11 @@ public class RouteSearchService implements RouteSearchUseCase {
 			case TEMPORARY_INJURY -> 14;
 			case WHEELCHAIR -> 18;
 		};
-		int lowDataPenalty = warnings.isEmpty() ? 0 : 20;
-		return trainTime + walkingTime + profilePenalty + lowDataPenalty;
+		int lowDataPenalty = warnings.stream()
+			.anyMatch(warning -> warning.code() == RouteWarningCode.LOW_DATA_CONFIDENCE) ? 20 : 0;
+		int stairOnlyPenalty = warnings.stream()
+			.anyMatch(warning -> warning.code() == RouteWarningCode.STAIR_ONLY_ACCESS) ? 30 : 0;
+		return trainTime + walkingTime + profilePenalty + lowDataPenalty + stairOnlyPenalty;
 	}
 
 	private List<RouteStep> directLineSteps(Station origin, Station destination, DirectLine directLine) {

--- a/backend/src/main/java/com/easysubway/route/domain/InvalidRouteSearchException.java
+++ b/backend/src/main/java/com/easysubway/route/domain/InvalidRouteSearchException.java
@@ -1,0 +1,10 @@
+package com.easysubway.route.domain;
+
+import com.easysubway.common.error.InvalidRequestException;
+
+public class InvalidRouteSearchException extends InvalidRequestException {
+
+	public InvalidRouteSearchException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteNotFoundException.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteNotFoundException.java
@@ -1,0 +1,10 @@
+package com.easysubway.route.domain;
+
+import com.easysubway.common.error.ResourceNotFoundException;
+
+public class RouteNotFoundException extends ResourceNotFoundException {
+
+	public RouteNotFoundException() {
+		super("연결 가능한 경로를 찾을 수 없습니다.");
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteSearchNotFoundException.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteSearchNotFoundException.java
@@ -1,0 +1,10 @@
+package com.easysubway.route.domain;
+
+import com.easysubway.common.error.ResourceNotFoundException;
+
+public class RouteSearchNotFoundException extends ResourceNotFoundException {
+
+	public RouteSearchNotFoundException() {
+		super("경로 검색 결과를 찾을 수 없습니다.");
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java
@@ -1,0 +1,23 @@
+package com.easysubway.route.domain;
+
+import com.easysubway.profile.domain.MobilityType;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record RouteSearchResult(
+	String routeSearchId,
+	String originStationId,
+	String originStationName,
+	String destinationStationId,
+	String destinationStationName,
+	MobilityType mobilityType,
+	RouteSearchStatus status,
+	String lineId,
+	String lineName,
+	int score,
+	List<RouteStep> steps,
+	List<RouteWarning> warnings,
+	List<String> blockedReasons,
+	LocalDateTime createdAt
+) {
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteSearchStatus.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteSearchStatus.java
@@ -1,0 +1,6 @@
+package com.easysubway.route.domain;
+
+public enum RouteSearchStatus {
+	FOUND,
+	BLOCKED
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteStep.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteStep.java
@@ -1,0 +1,12 @@
+package com.easysubway.route.domain;
+
+public record RouteStep(
+	int sequence,
+	String title,
+	String description,
+	String lineId,
+	String lineName,
+	String fromStationId,
+	String toStationId
+) {
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteWarning.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteWarning.java
@@ -1,0 +1,7 @@
+package com.easysubway.route.domain;
+
+public record RouteWarning(
+	RouteWarningCode code,
+	String message
+) {
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteWarningCode.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteWarningCode.java
@@ -1,5 +1,6 @@
 package com.easysubway.route.domain;
 
 public enum RouteWarningCode {
-	LOW_DATA_CONFIDENCE
+	LOW_DATA_CONFIDENCE,
+	STAIR_ONLY_ACCESS
 }

--- a/backend/src/main/java/com/easysubway/route/domain/RouteWarningCode.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteWarningCode.java
@@ -1,0 +1,5 @@
+package com.easysubway.route.domain;
+
+public enum RouteWarningCode {
+	LOW_DATA_CONFIDENCE
+}

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -46,6 +46,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase {
 
 	@Override
 	public List<StationWithLines> searchStations(StationSearchCommand command) {
+		// 역 검색 결과에는 운영 중인 역과 노선만 포함해 사용자에게 닫힌 노선 선택지를 노출하지 않는다.
 		return loadTransitMasterPort.loadStations()
 			.stream()
 			.filter(Station::active)
@@ -88,6 +89,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase {
 	}
 
 	private StationWithLines withLines(Station station) {
+		// 역-노선 연결 데이터가 있어도 노선 자체가 비활성이면 응답에서 제외한다.
 		Map<String, SubwayLine> linesById = loadTransitMasterPort.loadLines()
 			.stream()
 			.filter(SubwayLine::active)

--- a/backend/src/test/java/com/easysubway/EasySubwayBackendApplicationTests.java
+++ b/backend/src/test/java/com/easysubway/EasySubwayBackendApplicationTests.java
@@ -1,12 +1,15 @@
 package com.easysubway;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@DisplayName("백엔드 애플리케이션 컨텍스트")
 class EasySubwayBackendApplicationTests {
 
 	@Test
+	@DisplayName("스프링 부트 애플리케이션 컨텍스트가 정상 로드된다")
 	void contextLoads() {
 	}
 

--- a/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteStationControllerTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteStationControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -19,12 +20,14 @@ import org.springframework.test.web.servlet.MockMvc;
 	"easysubway.user.password=user-test-password"
 })
 @AutoConfigureMockMvc
+@DisplayName("즐겨찾기 역 API")
 class FavoriteStationControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
 
 	@Test
+	@DisplayName("인증 사용자 기준으로 역을 저장하고 목록 조회와 삭제를 처리한다")
 	void favoriteStationsCanBeSavedListedAndRemoved() throws Exception {
 		mockMvc.perform(put("/api/v1/me/favorites/stations/station-sangnoksu")
 				.with(httpBasic("anonymous-user-1", "user-test-password"))
@@ -63,6 +66,7 @@ class FavoriteStationControllerTest {
 	}
 
 	@Test
+	@DisplayName("존재하지 않는 역은 공통 404 응답으로 거부한다")
 	void favoriteStationsRejectUnknownStation() throws Exception {
 		mockMvc.perform(put("/api/v1/me/favorites/stations/missing-station")
 				.with(httpBasic("anonymous-user-1", "user-test-password")))
@@ -73,6 +77,7 @@ class FavoriteStationControllerTest {
 	}
 
 	@Test
+	@DisplayName("즐겨찾기 목록은 인증된 사용자만 조회할 수 있다")
 	void favoriteStationsRequireAuthentication() throws Exception {
 		mockMvc.perform(get("/api/v1/me/favorites/stations"))
 			.andExpect(status().isUnauthorized());

--- a/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteStationServiceTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteStationServiceTest.java
@@ -15,8 +15,10 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("즐겨찾기 역 서비스")
 class FavoriteStationServiceTest {
 
 	private final InMemoryFavoriteStationRepository favoriteStationRepository =
@@ -30,6 +32,7 @@ class FavoriteStationServiceTest {
 	);
 
 	@Test
+	@DisplayName("활성 역은 사용자별 즐겨찾기에 한 번만 저장된다")
 	void saveFavoriteStationStoresActiveStationOnce() {
 		var favorite = service.saveFavoriteStation(new SaveFavoriteStationCommand(
 			"anonymous-user-1",
@@ -50,6 +53,7 @@ class FavoriteStationServiceTest {
 	}
 
 	@Test
+	@DisplayName("삭제 요청은 같은 사용자와 같은 역의 즐겨찾기만 제거한다")
 	void removeFavoriteStationDeletesOnlyRequestedStation() {
 		service.saveFavoriteStation(new SaveFavoriteStationCommand("anonymous-user-1", "station-sangnoksu"));
 		service.saveFavoriteStation(new SaveFavoriteStationCommand("anonymous-user-1", "station-sadang"));
@@ -62,6 +66,7 @@ class FavoriteStationServiceTest {
 	}
 
 	@Test
+	@DisplayName("즐겨찾기 저장은 존재하는 활성 역을 요구한다")
 	void saveFavoriteStationRequiresExistingActiveStation() {
 		assertThatThrownBy(() -> service.saveFavoriteStation(new SaveFavoriteStationCommand(
 			"anonymous-user-1",
@@ -72,6 +77,7 @@ class FavoriteStationServiceTest {
 	}
 
 	@Test
+	@DisplayName("즐겨찾기 명령은 사용자와 역 식별자를 요구한다")
 	void favoriteStationCommandsRequireUserAndStation() {
 		assertThatThrownBy(() -> service.listFavoriteStations(new ListFavoriteStationsCommand("")))
 			.isInstanceOf(InvalidFavoriteStationException.class)
@@ -86,6 +92,7 @@ class FavoriteStationServiceTest {
 	}
 
 	@Test
+	@DisplayName("즐겨찾기 도메인은 비어 있는 사용자와 역 정보를 허용하지 않는다")
 	void favoriteStationDomainRejectsInvalidState() {
 		assertThatThrownBy(() -> new FavoriteStation("", "station-sangnoksu", LocalDateTime.now()))
 			.isInstanceOf(InvalidFavoriteStationException.class)

--- a/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
+++ b/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
@@ -4,6 +4,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -12,12 +13,14 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("헬스체크 API")
 class HealthCheckControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
 
 	@Test
+	@DisplayName("공통 응답 형식으로 API 헬스체크를 반환한다")
 	void apiHealthReturnsCommonResponse() throws Exception {
 		mockMvc.perform(get("/api/health"))
 			.andExpect(status().isOk())
@@ -27,6 +30,7 @@ class HealthCheckControllerTest {
 	}
 
 	@Test
+	@DisplayName("액추에이터 헬스체크 엔드포인트가 UP 상태를 반환한다")
 	void actuatorHealthIsAvailable() throws Exception {
 		mockMvc.perform(get("/actuator/health"))
 			.andExpect(status().isOk())

--- a/backend/src/test/java/com/easysubway/health/application/service/HealthCheckServiceTest.java
+++ b/backend/src/test/java/com/easysubway/health/application/service/HealthCheckServiceTest.java
@@ -3,11 +3,14 @@ package com.easysubway.health.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.easysubway.health.domain.HealthStatus;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("헬스체크 서비스")
 class HealthCheckServiceTest {
 
 	@Test
+	@DisplayName("백엔드 상태와 서비스 이름을 반환한다")
 	void checkHealthReturnsBackendStatus() {
 		HealthStatus status = new HealthCheckService().checkHealth();
 

--- a/backend/src/test/java/com/easysubway/profile/adapter/in/web/MobilityProfileControllerTest.java
+++ b/backend/src/test/java/com/easysubway/profile/adapter/in/web/MobilityProfileControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -14,12 +15,14 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("이동 프로필 API")
 class MobilityProfileControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
 
 	@Test
+	@DisplayName("익명 사용자의 기본 이동 프로필을 조회한다")
 	void getProfileReturnsDefaultProfileForAnonymousUser() throws Exception {
 		mockMvc.perform(get("/api/v1/me/mobility-profile")
 				.param("userId", "anonymous-user-1"))
@@ -38,6 +41,7 @@ class MobilityProfileControllerTest {
 	}
 
 	@Test
+	@DisplayName("이동 프로필을 저장하고 다시 조회할 수 있다")
 	void putProfileStoresAndReturnsMobilityProfile() throws Exception {
 		mockMvc.perform(put("/api/v1/me/mobility-profile")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -71,6 +75,7 @@ class MobilityProfileControllerTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 프로필의 계단 허용 요청은 공통 400 응답으로 거부한다")
 	void putProfileRejectsWheelchairProfileThatAllowsStairs() throws Exception {
 		mockMvc.perform(put("/api/v1/me/mobility-profile")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -95,6 +100,7 @@ class MobilityProfileControllerTest {
 	}
 
 	@Test
+	@DisplayName("알 수 없는 이동 유형은 공통 400 응답으로 거부한다")
 	void putProfileReturnsCommonErrorForInvalidMobilityType() throws Exception {
 		mockMvc.perform(put("/api/v1/me/mobility-profile")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -119,6 +125,7 @@ class MobilityProfileControllerTest {
 	}
 
 	@Test
+	@DisplayName("프로필 조회는 사용자 식별자를 요구한다")
 	void getProfileRequiresUserId() throws Exception {
 		mockMvc.perform(get("/api/v1/me/mobility-profile"))
 			.andExpect(status().isBadRequest())

--- a/backend/src/test/java/com/easysubway/profile/application/service/MobilityProfileServiceTest.java
+++ b/backend/src/test/java/com/easysubway/profile/application/service/MobilityProfileServiceTest.java
@@ -11,8 +11,10 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("이동 프로필 서비스")
 class MobilityProfileServiceTest {
 
 	private final InMemoryMobilityProfileRepository repository = new InMemoryMobilityProfileRepository();
@@ -23,6 +25,7 @@ class MobilityProfileServiceTest {
 	);
 
 	@Test
+	@DisplayName("새 익명 사용자는 고령자 기본 이동 프로필을 받는다")
 	void getProfileReturnsDefaultProfileForNewAnonymousUser() {
 		var profile = service.getProfile("anonymous-user-1");
 
@@ -40,6 +43,7 @@ class MobilityProfileServiceTest {
 	}
 
 	@Test
+	@DisplayName("이동 유형과 접근성 선호 설정을 저장한다")
 	void saveProfileStoresMobilityAndAccessibilityPreferences() {
 		var profile = service.saveProfile(new SaveMobilityProfileCommand(
 			"anonymous-user-1",
@@ -64,6 +68,7 @@ class MobilityProfileServiceTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 프로필은 계단 허용 설정으로 저장할 수 없다")
 	void saveProfileRejectsWheelchairProfileThatAllowsStairs() {
 		assertThatThrownBy(() -> service.saveProfile(new SaveMobilityProfileCommand(
 			"anonymous-user-1",
@@ -82,6 +87,7 @@ class MobilityProfileServiceTest {
 	}
 
 	@Test
+	@DisplayName("프로필 저장은 사용자 식별자와 이동 유형을 요구한다")
 	void saveProfileRequiresUserIdAndMobilityType() {
 		assertThatThrownBy(() -> service.saveProfile(new SaveMobilityProfileCommand(
 			"",

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -19,12 +20,14 @@ import org.springframework.test.web.servlet.MockMvc;
 	"easysubway.admin.password=admin-test-password"
 })
 @AutoConfigureMockMvc
+@DisplayName("시설 신고 API")
 class FacilityReportControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
 
 	@Test
+	@DisplayName("시설 신고를 생성하고 같은 식별자로 조회한다")
 	void createReportReturnsSubmittedReportAndCanBeRead() throws Exception {
 		String response = mockMvc.perform(post("/api/v1/reports")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -60,6 +63,7 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("존재하지 않는 시설 신고 요청은 공통 404 응답을 반환한다")
 	void createReportReturnsCommonErrorForUnknownFacility() throws Exception {
 		mockMvc.perform(post("/api/v1/reports")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -79,6 +83,7 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("신고 유형이 없는 요청은 공통 400 응답을 반환한다")
 	void createReportReturnsCommonErrorForMissingReportType() throws Exception {
 		mockMvc.perform(post("/api/v1/reports")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -97,6 +102,7 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("알 수 없는 신고 유형은 공통 400 응답을 반환한다")
 	void createReportReturnsCommonErrorForInvalidReportType() throws Exception {
 		mockMvc.perform(post("/api/v1/reports")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -116,6 +122,7 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("존재하지 않는 신고 조회는 공통 404 응답을 반환한다")
 	void missingReportReturnsCommonErrorResponse() throws Exception {
 		mockMvc.perform(get("/api/v1/reports/missing-report"))
 			.andExpect(status().isNotFound())
@@ -125,6 +132,7 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 신고를 승인하고 조회 결과에서 검수 상태를 확인할 수 있다")
 	void reviewReportStoresAcceptedStatusAndCanBeRead() throws Exception {
 		String response = mockMvc.perform(post("/api/v1/reports")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -166,6 +174,7 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("신고 검수는 관리자 인증을 요구한다")
 	void reviewReportRequiresAdminAuthentication() throws Exception {
 		mockMvc.perform(post("/admin/reports/report-1/review")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -178,6 +187,7 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("검수 결정값이 없는 요청은 공통 400 응답을 반환한다")
 	void reviewReportRejectsInvalidDecisionRequest() throws Exception {
 		mockMvc.perform(post("/admin/reports/report-1/review")
 				.with(httpBasic("admin-test", "admin-test-password"))
@@ -192,6 +202,7 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("존재하지 않는 신고 검수는 공통 404 응답을 반환한다")
 	void reviewReportReturnsCommonErrorForMissingReport() throws Exception {
 		mockMvc.perform(post("/admin/reports/missing-report/review")
 				.with(httpBasic("admin-test", "admin-test-password"))

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -19,8 +19,10 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("시설 신고 서비스")
 class FacilityReportServiceTest {
 
 	private final InMemoryFacilityReportRepository reportRepository = new InMemoryFacilityReportRepository();
@@ -32,6 +34,7 @@ class FacilityReportServiceTest {
 	);
 
 	@Test
+	@DisplayName("시설 신고는 제출 상태로 저장되고 다시 조회된다")
 	void createReportStoresSubmittedFacilityReport() {
 		var report = service.createReport(new CreateFacilityReportCommand(
 			"anonymous-user-1",
@@ -54,6 +57,7 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
+	@DisplayName("시설 신고는 존재하는 역을 요구한다")
 	void createReportRequiresExistingStation() {
 		assertThatThrownBy(() -> service.createReport(new CreateFacilityReportCommand(
 			"anonymous-user-1",
@@ -70,6 +74,7 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
+	@DisplayName("시설 신고는 해당 역에 속한 시설을 요구한다")
 	void createReportRequiresFacilityInStation() {
 		assertThatThrownBy(() -> service.createReport(new CreateFacilityReportCommand(
 			"anonymous-user-1",
@@ -86,6 +91,7 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
+	@DisplayName("시설 신고는 신고 유형을 요구한다")
 	void createReportRequiresReportType() {
 		assertThatThrownBy(() -> service.createReport(new CreateFacilityReportCommand(
 			"anonymous-user-1",
@@ -102,6 +108,7 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
+	@DisplayName("존재하지 않는 신고는 조회할 수 없다")
 	void getReportRequiresExistingReport() {
 		assertThatThrownBy(() -> service.getReport("missing-report"))
 			.isInstanceOf(FacilityReportNotFoundException.class)
@@ -109,6 +116,7 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
+	@DisplayName("신고 검수 승인 결과와 검수자를 저장한다")
 	void reviewReportStoresAcceptedDecisionAndReviewer() {
 		var report = service.createReport(new CreateFacilityReportCommand(
 			"anonymous-user-1",
@@ -134,6 +142,7 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
+	@DisplayName("신고 검수는 반려와 중복 처리 상태를 저장한다")
 	void reviewReportCanRejectOrMarkDuplicate() {
 		var rejected = service.createReport(new CreateFacilityReportCommand(
 			"anonymous-user-1",
@@ -169,6 +178,7 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
+	@DisplayName("신고 검수는 결정값과 검수자 식별자를 요구한다")
 	void reviewReportRequiresDecisionAndReviewer() {
 		var report = service.createReport(new CreateFacilityReportCommand(
 			"anonymous-user-1",
@@ -198,6 +208,7 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
+	@DisplayName("존재하지 않는 신고는 검수할 수 없다")
 	void reviewReportRequiresExistingReport() {
 		assertThatThrownBy(() -> service.reviewReport(new ReviewFacilityReportCommand(
 			"missing-report",

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
@@ -1,0 +1,80 @@
+package com.easysubway.route.adapter.in.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("경로 검색 API")
+class RouteSearchControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("경로 검색을 생성하고 같은 식별자로 다시 조회한다")
+	void postRouteSearchCreatesRouteAndGetReturnsStoredResult() throws Exception {
+		var result = mockMvc.perform(post("/api/v1/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "mobilityType": "STROLLER"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.status").value("FOUND"))
+			.andExpect(jsonPath("$.data.originStationName").value("상록수"))
+			.andExpect(jsonPath("$.data.destinationStationName").value("사당"))
+			.andExpect(jsonPath("$.data.lineName").value("수도권 4호선"))
+			.andExpect(jsonPath("$.data.steps[0].title").value("상록수역에서 4호선 승강장으로 이동"))
+			.andReturn();
+
+		String routeSearchId = JsonPath.read(result.getResponse().getContentAsString(), "$.data.routeSearchId");
+
+		mockMvc.perform(get("/api/v1/routes/{routeSearchId}", routeSearchId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.routeSearchId").value(routeSearchId))
+			.andExpect(jsonPath("$.data.status").value("FOUND"));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 역으로 경로 검색을 요청하면 공통 404 응답을 반환한다")
+	void postRouteSearchRejectsUnknownStation() throws Exception {
+		mockMvc.perform(post("/api/v1/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "missing",
+					  "destinationStationId": "station-sadang",
+					  "mobilityType": "SENIOR"
+					}
+					"""))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").value("역 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("알 수 없는 경로 검색 식별자는 공통 404 응답을 반환한다")
+	void getRouteSearchRejectsUnknownRouteSearchId() throws Exception {
+		mockMvc.perform(get("/api/v1/routes/route-missing"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").value("경로 검색 결과를 찾을 수 없습니다."));
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
@@ -2,6 +2,7 @@ package com.easysubway.route.adapter.in.web;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -49,6 +50,24 @@ class RouteSearchControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.routeSearchId").value(routeSearchId))
+			.andExpect(jsonPath("$.data.status").value("FOUND"));
+	}
+
+	@Test
+	@DisplayName("공개 경로 검색은 잘못된 Basic 인증 헤더가 있어도 허용한다")
+	void publicRouteSearchIgnoresInvalidBasicAuthentication() throws Exception {
+		mockMvc.perform(post("/api/v1/routes/search")
+				.with(httpBasic("wrong-user", "wrong-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "mobilityType": "SENIOR"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.status").value("FOUND"));
 	}
 

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.easysubway.route.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("인메모리 경로 검색 저장소")
+class InMemoryRouteSearchRepositoryTest {
+
+	@Test
+	@DisplayName("공개 경로 검색 결과는 최대 보관 개수를 넘으면 오래된 항목부터 제거한다")
+	void saveRouteSearchEvictsOldestResultWhenLimitIsExceeded() {
+		var repository = new InMemoryRouteSearchRepository();
+
+		for (int index = 0; index <= InMemoryRouteSearchRepository.MAX_STORED_ROUTE_SEARCHES; index++) {
+			repository.saveRouteSearch(routeSearchResult("route-" + index));
+		}
+
+		assertThat(repository.loadRouteSearch("route-0")).isEmpty();
+		assertThat(repository.loadRouteSearch("route-" + InMemoryRouteSearchRepository.MAX_STORED_ROUTE_SEARCHES))
+			.isPresent();
+	}
+
+	private RouteSearchResult routeSearchResult(String routeSearchId) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-a",
+			"출발역",
+			"station-b",
+			"도착역",
+			MobilityType.SENIOR,
+			RouteSearchStatus.FOUND,
+			"line-a",
+			"테스트 노선",
+			10,
+			List.of(),
+			List.of(),
+			List.of(),
+			LocalDateTime.of(2026, 6, 13, 9, 0)
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -112,6 +112,42 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("유모차 이동 유형은 계단만 있는 역 접근 경로를 경고하고 점수를 높인다")
+	void strollerRouteWarnsStairOnlyStationAccess() {
+		var stairOnlyRepository = new InMemoryRouteSearchRepository();
+		var stairOnlyService = new RouteSearchService(
+			stairOnlyRepository,
+			stairOnlyRepository,
+			new StairOnlyTransitMasterPort(),
+			CLOCK
+		);
+		var accessibleRepository = new InMemoryRouteSearchRepository();
+		var accessibleService = new RouteSearchService(
+			accessibleRepository,
+			accessibleRepository,
+			new RampAccessibleTransitMasterPort(),
+			CLOCK
+		);
+
+		var stairOnlyResult = stairOnlyService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.STROLLER
+		));
+		var accessibleResult = accessibleService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.STROLLER
+		));
+
+		assertThat(stairOnlyResult.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(stairOnlyResult.warnings())
+			.extracting("code")
+			.contains(RouteWarningCode.STAIR_ONLY_ACCESS);
+		assertThat(stairOnlyResult.score()).isGreaterThan(accessibleResult.score());
+	}
+
+	@Test
 	@DisplayName("휠체어 이동 유형은 신뢰도 낮은 계단 정보만으로 경로를 차단하지 않는다")
 	void wheelchairRouteDoesNotBlockWithLowConfidenceStairOnlyData() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -175,6 +211,29 @@ class RouteSearchServiceTest {
 
 		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
 		assertThat(result.blockedReasons()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("출구 신뢰도가 높아도 무단차 시설 신뢰도가 낮으면 경고한다")
+	void routeWarnsWhenStepFreeFacilityConfidenceIsLow() {
+		var repository = new InMemoryRouteSearchRepository();
+		var lowConfidenceFacilityService = new RouteSearchService(
+			repository,
+			repository,
+			new LowConfidenceStepFreeFacilityTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = lowConfidenceFacilityService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.STROLLER
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.warnings())
+			.extracting("code")
+			.contains(RouteWarningCode.LOW_DATA_CONFIDENCE);
 	}
 
 	@Test
@@ -428,6 +487,31 @@ class RouteSearchServiceTest {
 		}
 	}
 
+	private static class LowConfidenceStepFreeFacilityTransitMasterPort extends ExitSummaryAccessibleTransitMasterPort {
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility(
+					"facility-a-elevator",
+					"station-a",
+					"exit-a-2",
+					AccessibilityFacilityType.ELEVATOR,
+					AccessibilityFacilityStatus.NORMAL,
+					DataConfidenceLevel.MEDIUM
+				),
+				facility(
+					"facility-b-elevator",
+					"station-b",
+					"exit-b-1",
+					AccessibilityFacilityType.ELEVATOR,
+					AccessibilityFacilityStatus.NORMAL,
+					DataConfidenceLevel.MEDIUM
+				)
+			);
+		}
+	}
+
 	private static class BrokenElevatorTransitMasterPort extends StairOnlyTransitMasterPort {
 
 		@Override
@@ -510,6 +594,17 @@ class RouteSearchServiceTest {
 		AccessibilityFacilityType type,
 		AccessibilityFacilityStatus status
 	) {
+		return facility(id, stationId, exitId, type, status, DataConfidenceLevel.HIGH);
+	}
+
+	private static AccessibilityFacility facility(
+		String id,
+		String stationId,
+		String exitId,
+		AccessibilityFacilityType type,
+		AccessibilityFacilityStatus status,
+		DataConfidenceLevel dataConfidence
+	) {
 		return new AccessibilityFacility(
 			id,
 			stationId,
@@ -522,7 +617,7 @@ class RouteSearchServiceTest {
 			BigDecimal.ONE,
 			"테스트용 접근성 시설입니다.",
 			status,
-			DataConfidenceLevel.HIGH,
+			dataConfidence,
 			LocalDate.of(2026, 6, 13)
 		);
 	}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -110,6 +110,30 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 이동 유형은 신뢰도 낮은 계단 정보만으로 경로를 차단하지 않는다")
+	void wheelchairRouteDoesNotBlockWithLowConfidenceStairOnlyData() {
+		var repository = new InMemoryRouteSearchRepository();
+		var lowConfidenceService = new RouteSearchService(
+			repository,
+			repository,
+			new LowConfidenceStairOnlyTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = lowConfidenceService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.blockedReasons()).isEmpty();
+		assertThat(result.warnings())
+			.extracting("code")
+			.contains(RouteWarningCode.LOW_DATA_CONFIDENCE);
+	}
+
+	@Test
 	@DisplayName("경로 검색은 존재하는 역과 공통 노선을 요구한다")
 	void searchRouteRequiresExistingStationsAndSharedLine() {
 		assertThatThrownBy(() -> service.searchRoute(new SearchRouteCommand(
@@ -196,6 +220,17 @@ class RouteSearchServiceTest {
 			return List.of(
 				new StationLine("station-a", "line-a", "101", 1, "상행 / 하행"),
 				new StationLine("station-b", "line-b", "202", 2, "상행 / 하행")
+			);
+		}
+	}
+
+	private static class LowConfidenceStairOnlyTransitMasterPort extends StairOnlyTransitMasterPort {
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				new StationExit("exit-a-1", "station-a", "1", "1번 출구", BigDecimal.ONE, BigDecimal.ONE, false, true, DataConfidenceLevel.LOW),
+				new StationExit("exit-b-1", "station-b", "1", "1번 출구", BigDecimal.ONE, BigDecimal.ONE, false, true, DataConfidenceLevel.LOW)
 			);
 		}
 	}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -157,6 +157,27 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 이동 유형은 출구 요약에 엘리베이터 연결이 있으면 별도 시설 행이 없어도 경로를 제공한다")
+	void wheelchairRouteAllowsElevatorConnectedExitWithoutFacilityRow() {
+		var repository = new InMemoryRouteSearchRepository();
+		var exitSummaryService = new RouteSearchService(
+			repository,
+			repository,
+			new ExitSummaryAccessibleTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = exitSummaryService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.blockedReasons()).isEmpty();
+	}
+
+	@Test
 	@DisplayName("휠체어 이동 유형은 고장난 엘리베이터만 있으면 계단 없는 경로로 보지 않는다")
 	void wheelchairRouteBlocksBrokenElevatorAsStepFreeAccess() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -341,6 +362,18 @@ class RouteSearchServiceTest {
 		}
 	}
 
+	private static class ExitSummaryAccessibleTransitMasterPort extends StairOnlyTransitMasterPort {
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				stairOnlyExit("exit-a-1", "station-a"),
+				stepFreeExit("exit-a-2", "station-a"),
+				stepFreeExit("exit-b-1", "station-b")
+			);
+		}
+	}
+
 	private static class BrokenElevatorTransitMasterPort extends StairOnlyTransitMasterPort {
 
 		@Override
@@ -358,12 +391,14 @@ class RouteSearchServiceTest {
 				facility(
 					"facility-a-elevator",
 					"station-a",
+					"exit-a-2",
 					AccessibilityFacilityType.ELEVATOR,
 					AccessibilityFacilityStatus.BROKEN
 				),
 				facility(
 					"facility-b-elevator",
 					"station-b",
+					"exit-b-1",
 					AccessibilityFacilityType.ELEVATOR,
 					AccessibilityFacilityStatus.NORMAL
 				)
@@ -386,13 +421,14 @@ class RouteSearchServiceTest {
 	private static AccessibilityFacility facility(
 		String id,
 		String stationId,
+		String exitId,
 		AccessibilityFacilityType type,
 		AccessibilityFacilityStatus status
 	) {
 		return new AccessibilityFacility(
 			id,
 			stationId,
-			null,
+			exitId,
 			type,
 			"테스트 접근성 시설",
 			"지상",
@@ -404,6 +440,15 @@ class RouteSearchServiceTest {
 			DataConfidenceLevel.HIGH,
 			LocalDate.of(2026, 6, 13)
 		);
+	}
+
+	private static AccessibilityFacility facility(
+		String id,
+		String stationId,
+		AccessibilityFacilityType type,
+		AccessibilityFacilityStatus status
+	) {
+		return facility(id, stationId, null, type, status);
 	}
 
 	private static SubwayLine line(String id) {

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -1,0 +1,232 @@
+package com.easysubway.route.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
+import com.easysubway.route.application.port.in.SearchRouteCommand;
+import com.easysubway.route.domain.RouteNotFoundException;
+import com.easysubway.route.domain.RouteSearchNotFoundException;
+import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.route.domain.RouteWarningCode;
+import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
+import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.DataConfidenceLevel;
+import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationExit;
+import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.StationNotFoundException;
+import com.easysubway.transit.domain.SubwayLine;
+import com.easysubway.transit.domain.TransitOperator;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("경로 검색 서비스")
+class RouteSearchServiceTest {
+
+	private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-13T09:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+	private final InMemoryRouteSearchRepository routeSearchRepository = new InMemoryRouteSearchRepository();
+	private final RouteSearchService service = new RouteSearchService(
+		routeSearchRepository,
+		routeSearchRepository,
+		new InMemoryTransitMasterRepository(),
+		CLOCK
+	);
+
+	@Test
+	@DisplayName("유모차 이동 유형은 같은 노선 직접 경로와 접근성 경고를 반환한다")
+	void searchRouteReturnsDirectLineRecommendationForStroller() {
+		var result = service.searchRoute(new SearchRouteCommand(
+			"station-sangnoksu",
+			"station-sadang",
+			MobilityType.STROLLER
+		));
+
+		assertThat(result.routeSearchId()).startsWith("route-");
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.mobilityType()).isEqualTo(MobilityType.STROLLER);
+		assertThat(result.originStationName()).isEqualTo("상록수");
+		assertThat(result.destinationStationName()).isEqualTo("사당");
+		assertThat(result.lineName()).isEqualTo("수도권 4호선");
+		assertThat(result.score()).isGreaterThan(0);
+		assertThat(result.steps())
+			.extracting("title")
+			.containsExactly(
+				"상록수역에서 4호선 승강장으로 이동",
+				"수도권 4호선으로 사당역까지 이동",
+				"사당역에서 출구 접근성 정보를 확인"
+			);
+		assertThat(result.warnings())
+			.extracting("code")
+			.contains(RouteWarningCode.LOW_DATA_CONFIDENCE);
+	}
+
+	@Test
+	@DisplayName("생성된 경로 검색 결과는 식별자로 다시 조회할 수 있다")
+	void getRouteSearchReturnsStoredResult() {
+		var created = service.searchRoute(new SearchRouteCommand(
+			"station-sangnoksu",
+			"station-sadang",
+			MobilityType.SENIOR
+		));
+
+		var loaded = service.getRouteSearch(created.routeSearchId());
+
+		assertThat(loaded).isEqualTo(created);
+	}
+
+	@Test
+	@DisplayName("휠체어 이동 유형은 계단만 있는 역 접근 경로를 차단한다")
+	void wheelchairRouteBlocksStairOnlyStationAccess() {
+		var repository = new InMemoryRouteSearchRepository();
+		var stairOnlyService = new RouteSearchService(
+			repository,
+			repository,
+			new StairOnlyTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = stairOnlyService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
+		assertThat(result.steps()).isEmpty();
+		assertThat(result.blockedReasons())
+			.containsExactly("계단 없는 역 접근 경로를 확인할 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("경로 검색은 존재하는 역과 공통 노선을 요구한다")
+	void searchRouteRequiresExistingStationsAndSharedLine() {
+		assertThatThrownBy(() -> service.searchRoute(new SearchRouteCommand(
+			"missing",
+			"station-sadang",
+			MobilityType.SENIOR
+		)))
+			.isInstanceOf(StationNotFoundException.class)
+			.hasMessage("역 정보를 찾을 수 없습니다.");
+
+		var repository = new InMemoryRouteSearchRepository();
+		var disconnectedService = new RouteSearchService(
+			repository,
+			repository,
+			new DisconnectedTransitMasterPort(),
+			CLOCK
+		);
+
+		assertThatThrownBy(() -> disconnectedService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.SENIOR
+		)))
+			.isInstanceOf(RouteNotFoundException.class)
+			.hasMessage("연결 가능한 경로를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("알 수 없는 경로 검색 식별자는 조회할 수 없다")
+	void getRouteSearchRequiresKnownRouteSearchId() {
+		assertThatThrownBy(() -> service.getRouteSearch("route-missing"))
+			.isInstanceOf(RouteSearchNotFoundException.class)
+			.hasMessage("경로 검색 결과를 찾을 수 없습니다.");
+	}
+
+	private static class StairOnlyTransitMasterPort implements LoadTransitMasterPort {
+
+		@Override
+		public List<TransitOperator> loadOperators() {
+			return List.of(operator());
+		}
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of(line("line-a"));
+		}
+
+		@Override
+		public List<Station> loadStations() {
+			return List.of(station("station-a", "출발역"), station("station-b", "도착역"));
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of(
+				new StationLine("station-a", "line-a", "101", 1, "상행 / 하행"),
+				new StationLine("station-b", "line-a", "102", 2, "상행 / 하행")
+			);
+		}
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				new StationExit("exit-a-1", "station-a", "1", "1번 출구", BigDecimal.ONE, BigDecimal.ONE, false, true, DataConfidenceLevel.HIGH),
+				new StationExit("exit-b-1", "station-b", "1", "1번 출구", BigDecimal.ONE, BigDecimal.ONE, false, true, DataConfidenceLevel.HIGH)
+			);
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of();
+		}
+	}
+
+	private static class DisconnectedTransitMasterPort extends StairOnlyTransitMasterPort {
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of(line("line-a"), line("line-b"));
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of(
+				new StationLine("station-a", "line-a", "101", 1, "상행 / 하행"),
+				new StationLine("station-b", "line-b", "202", 2, "상행 / 하행")
+			);
+		}
+	}
+
+	private static TransitOperator operator() {
+		return new TransitOperator(
+			"operator-a",
+			"운영사",
+			"수도권",
+			"https://example.com",
+			"https://example.com/contact",
+			DataSourceType.OFFICIAL_FILE,
+			true
+		);
+	}
+
+	private static SubwayLine line(String id) {
+		return new SubwayLine(id, "operator-a", "테스트 노선", "#0052A4", "수도권", "T", true);
+	}
+
+	private static Station station(String id, String name) {
+		return new Station(
+			id,
+			name,
+			name,
+			"수도권",
+			BigDecimal.ONE,
+			BigDecimal.ONE,
+			DataQualityLevel.LEVEL_1,
+			LocalDate.of(2026, 6, 13),
+			true
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -13,6 +13,8 @@ import com.easysubway.route.domain.RouteWarningCode;
 import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import com.easysubway.transit.domain.AccessibilityFacilityType;
 import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
@@ -134,6 +136,50 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 이동 유형은 정상 램프가 있으면 계단 출구가 있어도 경로를 제공한다")
+	void wheelchairRouteAllowsNormalRampAsStepFreeAccess() {
+		var repository = new InMemoryRouteSearchRepository();
+		var rampService = new RouteSearchService(
+			repository,
+			repository,
+			new RampAccessibleTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = rampService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.blockedReasons()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("휠체어 이동 유형은 고장난 엘리베이터만 있으면 계단 없는 경로로 보지 않는다")
+	void wheelchairRouteBlocksBrokenElevatorAsStepFreeAccess() {
+		var repository = new InMemoryRouteSearchRepository();
+		var brokenElevatorService = new RouteSearchService(
+			repository,
+			repository,
+			new BrokenElevatorTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = brokenElevatorService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
+		assertThat(result.steps()).isEmpty();
+		assertThat(result.blockedReasons())
+			.containsExactly("계단 없는 역 접근 경로를 확인할 수 없습니다.");
+	}
+
+	@Test
 	@DisplayName("경로 검색은 존재하는 역과 공통 노선을 요구한다")
 	void searchRouteRequiresExistingStationsAndSharedLine() {
 		assertThatThrownBy(() -> service.searchRoute(new SearchRouteCommand(
@@ -159,6 +205,29 @@ class RouteSearchServiceTest {
 		)))
 			.isInstanceOf(RouteNotFoundException.class)
 			.hasMessage("연결 가능한 경로를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("노선 코드가 없으면 노선명을 경로 단계 제목에 사용한다")
+	void searchRouteUsesLineNameWhenLineCodeIsMissing() {
+		var repository = new InMemoryRouteSearchRepository();
+		var missingLineCodeService = new RouteSearchService(
+			repository,
+			repository,
+			new MissingLineCodeTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = missingLineCodeService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.SENIOR
+		));
+
+		assertThat(result.steps())
+			.extracting("title")
+			.first()
+			.isEqualTo("출발역역에서 테스트 노선 승강장으로 이동");
 	}
 
 	@Test
@@ -235,6 +304,73 @@ class RouteSearchServiceTest {
 		}
 	}
 
+	private static class MissingLineCodeTransitMasterPort extends StairOnlyTransitMasterPort {
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of(new SubwayLine("line-a", "operator-a", "테스트 노선", "#0052A4", "수도권", null, true));
+		}
+	}
+
+	private static class RampAccessibleTransitMasterPort extends StairOnlyTransitMasterPort {
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				stairOnlyExit("exit-a-1", "station-a"),
+				stepFreeExit("exit-b-1", "station-b")
+			);
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility(
+					"facility-a-ramp",
+					"station-a",
+					AccessibilityFacilityType.RAMP,
+					AccessibilityFacilityStatus.NORMAL
+				),
+				facility(
+					"facility-b-elevator",
+					"station-b",
+					AccessibilityFacilityType.ELEVATOR,
+					AccessibilityFacilityStatus.NORMAL
+				)
+			);
+		}
+	}
+
+	private static class BrokenElevatorTransitMasterPort extends StairOnlyTransitMasterPort {
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				stairOnlyExit("exit-a-1", "station-a"),
+				stepFreeExit("exit-a-2", "station-a"),
+				stepFreeExit("exit-b-1", "station-b")
+			);
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility(
+					"facility-a-elevator",
+					"station-a",
+					AccessibilityFacilityType.ELEVATOR,
+					AccessibilityFacilityStatus.BROKEN
+				),
+				facility(
+					"facility-b-elevator",
+					"station-b",
+					AccessibilityFacilityType.ELEVATOR,
+					AccessibilityFacilityStatus.NORMAL
+				)
+			);
+		}
+	}
+
 	private static TransitOperator operator() {
 		return new TransitOperator(
 			"operator-a",
@@ -244,6 +380,29 @@ class RouteSearchServiceTest {
 			"https://example.com/contact",
 			DataSourceType.OFFICIAL_FILE,
 			true
+		);
+	}
+
+	private static AccessibilityFacility facility(
+		String id,
+		String stationId,
+		AccessibilityFacilityType type,
+		AccessibilityFacilityStatus status
+	) {
+		return new AccessibilityFacility(
+			id,
+			stationId,
+			null,
+			type,
+			"테스트 접근성 시설",
+			"지상",
+			"대합실",
+			BigDecimal.ONE,
+			BigDecimal.ONE,
+			"테스트용 접근성 시설입니다.",
+			status,
+			DataConfidenceLevel.HIGH,
+			LocalDate.of(2026, 6, 13)
 		);
 	}
 
@@ -262,6 +421,34 @@ class RouteSearchServiceTest {
 			DataQualityLevel.LEVEL_1,
 			LocalDate.of(2026, 6, 13),
 			true
+		);
+	}
+
+	private static StationExit stairOnlyExit(String id, String stationId) {
+		return new StationExit(
+			id,
+			stationId,
+			"1",
+			"1번 출구",
+			BigDecimal.ONE,
+			BigDecimal.ONE,
+			false,
+			true,
+			DataConfidenceLevel.HIGH
+		);
+	}
+
+	private static StationExit stepFreeExit(String id, String stationId) {
+		return new StationExit(
+			id,
+			stationId,
+			"2",
+			"2번 출구",
+			BigDecimal.ONE,
+			BigDecimal.ONE,
+			true,
+			false,
+			DataConfidenceLevel.HIGH
 		);
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -201,6 +201,29 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 이동 유형은 고장난 엘리베이터 출구만 있는 역을 차단한다")
+	void wheelchairRouteBlocksBrokenElevatorOnlyExit() {
+		var repository = new InMemoryRouteSearchRepository();
+		var brokenElevatorOnlyService = new RouteSearchService(
+			repository,
+			repository,
+			new BrokenElevatorOnlyTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = brokenElevatorOnlyService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
+		assertThat(result.steps()).isEmpty();
+		assertThat(result.blockedReasons())
+			.containsExactly("계단 없는 역 접근 경로를 확인할 수 없습니다.");
+	}
+
+	@Test
 	@DisplayName("경로 검색은 존재하는 역과 공통 노선을 요구한다")
 	void searchRouteRequiresExistingStationsAndSharedLine() {
 		assertThatThrownBy(() -> service.searchRoute(new SearchRouteCommand(
@@ -392,6 +415,37 @@ class RouteSearchServiceTest {
 					"facility-a-elevator",
 					"station-a",
 					"exit-a-2",
+					AccessibilityFacilityType.ELEVATOR,
+					AccessibilityFacilityStatus.BROKEN
+				),
+				facility(
+					"facility-b-elevator",
+					"station-b",
+					"exit-b-1",
+					AccessibilityFacilityType.ELEVATOR,
+					AccessibilityFacilityStatus.NORMAL
+				)
+			);
+		}
+	}
+
+	private static class BrokenElevatorOnlyTransitMasterPort extends StairOnlyTransitMasterPort {
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				stepFreeExit("exit-a-1", "station-a"),
+				stepFreeExit("exit-b-1", "station-b")
+			);
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility(
+					"facility-a-elevator",
+					"station-a",
+					"exit-a-1",
 					AccessibilityFacilityType.ELEVATOR,
 					AccessibilityFacilityStatus.BROKEN
 				),

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -275,6 +275,29 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("노선 코드가 빈 값이면 노선명을 경로 단계 제목에 사용한다")
+	void searchRouteUsesLineNameWhenLineCodeIsBlank() {
+		var repository = new InMemoryRouteSearchRepository();
+		var blankLineCodeService = new RouteSearchService(
+			repository,
+			repository,
+			new BlankLineCodeTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = blankLineCodeService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.SENIOR
+		));
+
+		assertThat(result.steps())
+			.extracting("title")
+			.first()
+			.isEqualTo("출발역역에서 테스트 노선 승강장으로 이동");
+	}
+
+	@Test
 	@DisplayName("알 수 없는 경로 검색 식별자는 조회할 수 없다")
 	void getRouteSearchRequiresKnownRouteSearchId() {
 		assertThatThrownBy(() -> service.getRouteSearch("route-missing"))
@@ -353,6 +376,14 @@ class RouteSearchServiceTest {
 		@Override
 		public List<SubwayLine> loadLines() {
 			return List.of(new SubwayLine("line-a", "operator-a", "테스트 노선", "#0052A4", "수도권", null, true));
+		}
+	}
+
+	private static class BlankLineCodeTransitMasterPort extends StairOnlyTransitMasterPort {
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of(new SubwayLine("line-a", "operator-a", "테스트 노선", "#0052A4", "수도권", "", true));
 		}
 	}
 

--- a/backend/src/test/java/com/easysubway/support/EgovFrameRuntimeTest.java
+++ b/backend/src/test/java/com/easysubway/support/EgovFrameRuntimeTest.java
@@ -2,11 +2,14 @@ package com.easysubway.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("전자정부프레임워크 런타임")
 class EgovFrameRuntimeTest {
 
 	@Test
+	@DisplayName("전자정부프레임워크 MVC PaginationInfo가 클래스패스에 존재한다")
 	void egovFrameMvcRuntimeIsOnClasspath() throws ClassNotFoundException {
 		Class<?> paginationInfo = Class.forName("org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo");
 

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -13,12 +14,14 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@DisplayName("도시철도 마스터데이터 API")
 class TransitMasterControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
 
 	@Test
+	@DisplayName("운영기관 목록은 시드된 활성 기관을 반환한다")
 	void operatorsReturnsSeededTransitOperators() throws Exception {
 		mockMvc.perform(get("/api/v1/operators"))
 			.andExpect(status().isOk())
@@ -31,6 +34,7 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("노선 목록은 운영기관으로 필터링할 수 있다")
 	void linesCanBeFilteredByOperator() throws Exception {
 		mockMvc.perform(get("/api/v1/lines").param("operatorId", "seoul-metro"))
 			.andExpect(status().isOk())
@@ -42,6 +46,7 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("역 검색은 한글 역명으로 조회할 수 있다")
 	void stationsCanBeSearchedByKoreanName() throws Exception {
 		mockMvc.perform(get("/api/v1/stations").param("query", "상록수"))
 			.andExpect(status().isOk())
@@ -53,6 +58,7 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("공개 역 검색은 잘못된 Basic 인증 헤더가 있어도 허용한다")
 	void publicStationSearchIgnoresInvalidBasicAuthentication() throws Exception {
 		mockMvc.perform(get("/api/v1/stations")
 				.param("query", "상록수")
@@ -63,6 +69,7 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("역 상세는 연결 노선과 데이터 품질을 포함한다")
 	void stationDetailIncludesConnectedLinesAndQuality() throws Exception {
 		mockMvc.perform(get("/api/v1/stations/station-sangnoksu"))
 			.andExpect(status().isOk())
@@ -76,6 +83,7 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("역 출구 목록은 접근성 신호를 포함한다")
 	void stationExitsIncludeAccessibilitySignals() throws Exception {
 		mockMvc.perform(get("/api/v1/stations/station-sangnoksu/exits"))
 			.andExpect(status().isOk())
@@ -89,6 +97,7 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("역 시설 목록은 시설 유형과 상태와 신뢰도를 포함한다")
 	void stationFacilitiesIncludeTypeStatusAndConfidence() throws Exception {
 		mockMvc.perform(get("/api/v1/stations/station-sangnoksu/facilities"))
 			.andExpect(status().isOk())
@@ -103,6 +112,7 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("존재하지 않는 역 상세는 공통 404 응답을 반환한다")
 	void missingStationReturnsCommonErrorResponse() throws Exception {
 		mockMvc.perform(get("/api/v1/stations/unknown-station"))
 			.andExpect(status().isNotFound())
@@ -112,6 +122,7 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("존재하지 않는 역 출구 목록은 공통 404 응답을 반환한다")
 	void missingStationExitsReturnCommonErrorResponse() throws Exception {
 		mockMvc.perform(get("/api/v1/stations/unknown-station/exits"))
 			.andExpect(status().isNotFound())
@@ -121,6 +132,7 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("존재하지 않는 역 시설 목록은 공통 404 응답을 반환한다")
 	void missingStationFacilitiesReturnCommonErrorResponse() throws Exception {
 		mockMvc.perform(get("/api/v1/stations/unknown-station/facilities"))
 			.andExpect(status().isNotFound())

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -21,13 +21,16 @@ import com.easysubway.transit.domain.TransitOperator;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+@DisplayName("도시철도 마스터데이터 서비스")
 class TransitMasterServiceTest {
 
 	private final TransitMasterService service = new TransitMasterService(new InMemoryTransitMasterRepository());
 
 	@Test
+	@DisplayName("활성 운영기관 마스터데이터를 반환한다")
 	void listOperatorsReturnsActiveMasterData() {
 		var operators = service.listOperators();
 
@@ -37,6 +40,7 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
+	@DisplayName("운영기관 식별자로 노선을 필터링한다")
 	void listLinesCanFilterByOperatorId() {
 		var lines = service.listLines("korail");
 
@@ -46,6 +50,7 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
+	@DisplayName("역 검색은 한글 이름과 영문 이름을 모두 찾는다")
 	void searchStationsMatchesKoreanAndEnglishNames() {
 		var koreanMatches = service.searchStations(new StationSearchCommand("상록수", null));
 		var englishMatches = service.searchStations(new StationSearchCommand("sang", null));
@@ -56,6 +61,7 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
+	@DisplayName("역 검색 응답에서 비활성 노선은 제외한다")
 	void searchStationsExcludesInactiveLinesFromStationResponses() {
 		var serviceWithInactiveLine = new TransitMasterService(new TransitMasterPortWithInactiveLine());
 
@@ -70,6 +76,7 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
+	@DisplayName("존재하지 않는 역 상세 조회는 도메인 예외를 던진다")
 	void getStationThrowsDomainExceptionForUnknownStation() {
 		assertThatThrownBy(() -> service.getStation("missing"))
 			.isInstanceOf(StationNotFoundException.class)
@@ -77,6 +84,7 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
+	@DisplayName("역 출구 목록은 접근성 신호를 함께 반환한다")
 	void listStationExitsReturnsExitAccessibilitySignals() {
 		var exits = service.listStationExits("station-sangnoksu");
 
@@ -90,6 +98,7 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
+	@DisplayName("역 시설 목록은 상태와 데이터 신뢰도를 함께 반환한다")
 	void listStationFacilitiesReturnsStatusAndConfidence() {
 		var facilities = service.listStationFacilities("station-sangnoksu");
 
@@ -103,6 +112,7 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
+	@DisplayName("역 출구와 시설 목록은 존재하는 역을 요구한다")
 	void stationExitsAndFacilitiesRequireExistingStation() {
 		assertThatThrownBy(() -> service.listStationExits("missing"))
 			.isInstanceOf(StationNotFoundException.class)

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -14,7 +14,7 @@ function read(relativePath) {
   return readFileSync(path.join(root, relativePath), "utf8");
 }
 
-test("gitignore keeps local agent docs and non-README markdown out of git", () => {
+test("로컬 에이전트 문서와 README 외 Markdown은 gitignore로 추적되지 않는다", () => {
   const gitignore = read(".gitignore");
 
   assert.match(gitignore, /^\*\.md$/m);
@@ -25,7 +25,7 @@ test("gitignore keeps local agent docs and non-README markdown out of git", () =
   assert.match(gitignore, /^\.codex\/$/m);
 });
 
-test("ci enforces README-only markdown and local agent file policy", () => {
+test("지속적 통합은 README 외 Markdown과 로컬 에이전트 문서 추적 금지를 검사한다", () => {
   const workflow = read(".github/workflows/ci.yml");
 
   assert.match(workflow, /git ls-files '\*\.md' ':!:README\.md' ':!:\.github\/pull_request_template\.md'/);
@@ -34,7 +34,7 @@ test("ci enforces README-only markdown and local agent file policy", () => {
   assert.match(workflow, /Unexpected tracked local agent file/);
 });
 
-test("ci job and step names identify failure areas clearly", () => {
+test("지속적 통합 작업과 스텝 이름은 실패 영역을 구분할 수 있게 표시된다", () => {
   const workflow = read(".github/workflows/ci.yml");
 
   assert.match(workflow, /name: Changes/);
@@ -50,7 +50,7 @@ test("ci job and step names identify failure areas clearly", () => {
   assert.match(workflow, /iOS CI \/ Build Flutter iOS simulator app/);
 });
 
-test("pull request template is tracked with review and CD gates", () => {
+test("풀 리퀘스트 템플릿은 리뷰와 배포 확인 게이트를 포함한다", () => {
   const template = read(".github/pull_request_template.md");
 
   assert.match(template, /## 관련 이슈/);
@@ -62,7 +62,7 @@ test("pull request template is tracked with review and CD gates", () => {
   assert.match(template, /CD 상태를 확인했다/);
 });
 
-test("issue templates collect developer-style context without agent narration", () => {
+test("이슈 템플릿은 에이전트 서술 없이 개발자 판단 정보를 수집한다", () => {
   const templates = [
     read(".github/ISSUE_TEMPLATE/bug_report.yml"),
     read(".github/ISSUE_TEMPLATE/feature_request.yml"),
@@ -75,7 +75,7 @@ test("issue templates collect developer-style context without agent narration", 
   assert.doesNotMatch(templates, /AI 에이전트|자동 생성|제가 작업/);
 });
 
-test("coderabbit is configured for Korean repository reviews", () => {
+test("한국어 저장소 리뷰 기준으로 CodeRabbit이 설정된다", () => {
   const config = read(".coderabbit.yaml");
 
   assert.match(config, /language: "ko-KR"/);
@@ -85,7 +85,7 @@ test("coderabbit is configured for Korean repository reviews", () => {
   assert.match(config, /auto_review:/);
 });
 
-test("env example provides non-secret local data infrastructure defaults", () => {
+test("환경 예시는 비밀값 없는 로컬 데이터 인프라 기본값을 제공한다", () => {
   const envExample = read(".env.example");
 
   assert.match(envExample, /^EASYSUBWAY_POSTGRES_DB=easysubway$/m);
@@ -96,7 +96,7 @@ test("env example provides non-secret local data infrastructure defaults", () =>
   assert.doesNotMatch(envExample, /prod|production|secret|token|key/i);
 });
 
-test("docker compose defines local PostGIS and Redis services", () => {
+test("로컬 PostGIS와 Redis 서비스가 Docker Compose에 정의된다", () => {
   const compose = read("infra/docker-compose.yml");
 
   assert.match(compose, /postgres:\n/);
@@ -117,14 +117,14 @@ test("docker compose defines local PostGIS and Redis services", () => {
   assert.match(compose, /^volumes:\n  postgres-data:\n  redis-data:/m);
 });
 
-test("repository ci validates docker compose configuration", () => {
+test("저장소 지속적 통합은 Docker Compose 설정을 검증한다", () => {
   const workflow = read(".github/workflows/ci.yml");
 
   assert.match(workflow, /Repository CI \/ Validate Docker Compose config/);
   assert.match(workflow, /docker compose --env-file \.env\.example -f infra\/docker-compose\.yml config --quiet/);
 });
 
-test("backend scaffold is an eGovFrame 5.0 Spring Boot Java 21 hexagonal project", () => {
+test("백엔드 스캐폴드는 eGovFrame 5.0 Spring Boot Java 21 헥사고날 프로젝트다", () => {
   const build = read("backend/build.gradle");
   const wrapper = read("backend/gradle/wrapper/gradle-wrapper.properties");
   const application = read("backend/src/main/java/com/easysubway/EasySubwayBackendApplication.java");
@@ -169,7 +169,7 @@ test("backend scaffold is an eGovFrame 5.0 Spring Boot Java 21 hexagonal project
   assert.doesNotMatch(applicationProdYml, /spring\.profiles\.active|on-profile/);
 });
 
-test("backend transit master follows hexagonal API boundaries", () => {
+test("백엔드 도시철도 마스터데이터는 헥사고날 API 경계를 따른다", () => {
   const operator = read("backend/src/main/java/com/easysubway/transit/domain/TransitOperator.java");
   const line = read("backend/src/main/java/com/easysubway/transit/domain/SubwayLine.java");
   const station = read("backend/src/main/java/com/easysubway/transit/domain/Station.java");
@@ -218,7 +218,7 @@ test("backend transit master follows hexagonal API boundaries", () => {
   assert.match(exceptionHandler, /@ExceptionHandler\(ResourceNotFoundException\.class\)/);
 });
 
-test("backend facility reports follow hexagonal API boundaries", () => {
+test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   const report = read("backend/src/main/java/com/easysubway/report/domain/FacilityReport.java");
   const reportReviewDecision = read("backend/src/main/java/com/easysubway/report/domain/FacilityReportReviewDecision.java");
   const reportType = read("backend/src/main/java/com/easysubway/report/domain/FacilityReportType.java");
@@ -273,7 +273,7 @@ test("backend facility reports follow hexagonal API boundaries", () => {
   assert.match(security, /passwordEncoder\.encode\(adminPassword\)/);
 });
 
-test("backend mobility profiles follow hexagonal API boundaries", () => {
+test("백엔드 이동 프로필은 헥사고날 API 경계를 따른다", () => {
   const profile = read("backend/src/main/java/com/easysubway/profile/domain/MobilityProfile.java");
   const mobilityType = read("backend/src/main/java/com/easysubway/profile/domain/MobilityType.java");
   const invalidProfile = read("backend/src/main/java/com/easysubway/profile/domain/InvalidMobilityProfileException.java");
@@ -310,7 +310,7 @@ test("backend mobility profiles follow hexagonal API boundaries", () => {
   assert.match(controller, /@PutMapping\("\/api\/v1\/me\/mobility-profile"\)/);
 });
 
-test("backend favorite stations follow hexagonal API boundaries", () => {
+test("백엔드 즐겨찾기 역은 헥사고날 API 경계를 따른다", () => {
   const favorite = read("backend/src/main/java/com/easysubway/favorite/domain/FavoriteStation.java");
   const favoriteDetails = read("backend/src/main/java/com/easysubway/favorite/domain/FavoriteStationWithDetails.java");
   const invalidFavorite = read("backend/src/main/java/com/easysubway/favorite/domain/InvalidFavoriteStationException.java");
@@ -354,7 +354,52 @@ test("backend favorite stations follow hexagonal API boundaries", () => {
   assert.match(security, /anyRequest\(\)\.authenticated\(\)/);
 });
 
-test("mobile scaffold is a Flutter Android and iOS app", () => {
+test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
+  const result = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java");
+  const status = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchStatus.java");
+  const warning = read("backend/src/main/java/com/easysubway/route/domain/RouteWarning.java");
+  const warningCode = read("backend/src/main/java/com/easysubway/route/domain/RouteWarningCode.java");
+  const step = read("backend/src/main/java/com/easysubway/route/domain/RouteStep.java");
+  const invalidSearch = read("backend/src/main/java/com/easysubway/route/domain/InvalidRouteSearchException.java");
+  const routeNotFound = read("backend/src/main/java/com/easysubway/route/domain/RouteNotFoundException.java");
+  const searchNotFound = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchNotFoundException.java");
+  const useCase = read("backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java");
+  const command = read("backend/src/main/java/com/easysubway/route/application/port/in/SearchRouteCommand.java");
+  const loadPort = read("backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteSearchPort.java");
+  const savePort = read("backend/src/main/java/com/easysubway/route/application/port/out/SaveRouteSearchPort.java");
+  const service = read("backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java");
+  const repository = read("backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java");
+  const controller = read("backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java");
+
+  assert.match(result, /record RouteSearchResult/);
+  assert.match(result, /mobilityType/);
+  assert.match(result, /blockedReasons/);
+  assert.match(status, /FOUND/);
+  assert.match(status, /BLOCKED/);
+  assert.match(warning, /record RouteWarning/);
+  assert.match(warningCode, /LOW_DATA_CONFIDENCE/);
+  assert.match(step, /record RouteStep/);
+  assert.match(invalidSearch, /extends InvalidRequestException/);
+  assert.match(routeNotFound, /extends ResourceNotFoundException/);
+  assert.match(searchNotFound, /extends ResourceNotFoundException/);
+  assert.match(useCase, /interface RouteSearchUseCase/);
+  assert.match(useCase, /searchRoute/);
+  assert.match(useCase, /getRouteSearch/);
+  assert.match(command, /record SearchRouteCommand/);
+  assert.match(loadPort, /interface LoadRouteSearchPort/);
+  assert.match(savePort, /interface SaveRouteSearchPort/);
+  assert.match(service, /implements RouteSearchUseCase/);
+  assert.match(service, /LoadTransitMasterPort/);
+  assert.match(service, /MobilityType\.WHEELCHAIR/);
+  assert.match(service, /RouteSearchStatus\.BLOCKED/);
+  assert.match(service, /hasStairOnlyAccess/);
+  assert.match(service, /routeScore/);
+  assert.match(repository, /implements LoadRouteSearchPort, SaveRouteSearchPort/);
+  assert.match(controller, /@PostMapping\("\/api\/v1\/routes\/search"\)/);
+  assert.match(controller, /@GetMapping\("\/api\/v1\/routes\/\{routeSearchId\}"\)/);
+});
+
+test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다", () => {
   const pubspec = read("apps/mobile/pubspec.yaml");
   const analysisOptions = read("apps/mobile/analysis_options.yaml");
   const androidManifest = read("apps/mobile/android/app/src/main/AndroidManifest.xml");
@@ -385,12 +430,12 @@ test("mobile scaffold is a Flutter Android and iOS app", () => {
   assert.match(stationSearch, /request\.close\(\)\.timeout\(_stationSearchTimeout\)/);
   assert.doesNotMatch(main, /빠른 길보다, 갈 수 있는 길을 먼저 안내합니다|고령자, 임산부, 장애인도 편하게 이동할 수 있도록|현장에서 발견한 불편 정보를 신고하고 검수할 수 있게/);
   assert.match(widgetTest, /EasySubwayApp/);
-  assert.match(widgetTest, /renders concise home screen actions/);
+  assert.match(widgetTest, /홈 화면은 핵심 행동만 간결하게 보여준다/);
   assert.match(widgetTest, /bySemanticsLabel/);
   assert.match(widgetTest, /greaterThanOrEqualTo\(60\)/);
 });
 
-test("path classifier treats README as docs-only", async () => {
+test("경로 분류기는 README를 문서 전용 변경으로 처리한다", async () => {
   const outputs = await classifyChangedFiles(["README.md"]);
 
   assert.equal(outputs.docs_only, "true");
@@ -403,7 +448,7 @@ test("path classifier treats README as docs-only", async () => {
   assert.equal(outputs.deploy, "false");
 });
 
-test("path classifier maps repository, backend, mobile, Android, and iOS changes", async () => {
+test("경로 분류기는 저장소, 백엔드, 모바일, Android, iOS 변경을 구분한다", async () => {
   const repository = await classifyChangedFiles([".github/ISSUE_TEMPLATE/task_request.yml"]);
   assert.equal(repository.repository, "true");
   assert.equal(repository.docs_only, "false");
@@ -434,7 +479,7 @@ test("path classifier maps repository, backend, mobile, Android, and iOS changes
   assert.equal(infra.deploy, "true");
 });
 
-test("path classifier tests are stable when GITHUB_OUTPUT is inherited from CI", async () => {
+test("경로 분류기 테스트는 CI의 GITHUB_OUTPUT을 물려받아도 안정적이다", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "easysubway-gh-output-"));
   const previousGithubOutput = process.env.GITHUB_OUTPUT;
   process.env.GITHUB_OUTPUT = path.join(dir, "github-output.txt");


### PR DESCRIPTION
## 관련 이슈

Closes #27

## 요약

교통약자 이동 조건을 반영할 수 있는 경로 검색 기초 API를 추가했습니다. 현재 범위는 같은 활성 노선에 속한 출발역/도착역의 직접 이동 경로를 계산하고, 휠체어 사용자가 계단만 확인되는 역 접근 경로를 요청하면 추천하지 않고 차단 상태를 반환하는 기준선입니다.

## 변경 사항

- `POST /api/v1/routes/search`로 출발역, 도착역, 이동 유형을 받아 경로 검색 결과를 생성합니다.
- `GET /api/v1/routes/{routeSearchId}`로 생성된 경로 검색 결과를 다시 조회할 수 있게 했습니다.
- 경로 검색 도메인, 유스케이스, 입출력 포트, 인메모리 저장소를 헥사고날 구조로 분리했습니다.
- 접근성 출구 데이터 신뢰도가 낮거나 부족한 경우 경로 결과에 확인 경고를 포함합니다.
- 기존 백엔드/모바일 테스트와 저장소 계약 테스트의 표시명을 한글로 정리해 CI 실패 지점을 읽기 쉽게 했습니다.
- 이동약자 정책, 인증 사용자 기준 데이터 처리, 비활성 노선 제외처럼 유지보수자가 놓치기 쉬운 분기에 짧은 주석을 추가했습니다.

## 검증

- `./gradlew test --tests 'com.easysubway.route.*' --no-daemon --console=plain`
- `./gradlew test --no-daemon --console=plain`
- `node --test tools/ci/repository-contract.test.mjs`
- `flutter test`
- `git diff --check`
- `git ls-files '*.md'`

## 리뷰 포인트

- 같은 노선 직접 경로만 계산하는 현재 기준선이 후속 환승 경로 확장에 무리가 없는지
- 휠체어 이동 유형에서 계단만 확인되는 접근 경로를 `BLOCKED`로 반환하는 정책이 적절한지
- 경로 검색 결과의 안내 문구가 고령자와 디지털 소외계층에게 충분히 직관적인지

## 체크리스트

- [x] issue를 기준으로 작업했다.
- [x] `main` 직접 push 없이 작업 브랜치에서 변경했다.
- [x] 백엔드 테스트를 통과했다.
- [x] 모바일 테스트를 통과했다.
- [x] 저장소 계약 테스트를 통과했다.
- [ ] GitHub Actions CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰 또는 대체 코드리뷰 결과를 확인했다.
- [ ] merge 후 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 경로 검색 API 추가: 출발지와 목적지를 지정하여 최적의 이동 경로 조회 기능 구현

* **Tests**
  * 테스트 케이스 설명을 한국어로 통일
  * 테스트 표시 이름 개선으로 가독성 향상
  * 경로 검색 관련 통합 및 단위 테스트 추가

* **Documentation**
  * 서비스 계층 로직 설명을 위한 주석 보강
  * 보안 및 데이터 처리 정책 관련 주석 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->