### PR TITLE
[Feat] 이동 조건 선택 화면 추가

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'mobility_profile.dart';
 import 'station_search.dart';
 
 void main() {
@@ -104,7 +105,13 @@ class HomeScreen extends StatelessWidget {
             const SizedBox(height: 12),
             OutlinedButton.icon(
               key: const Key('mobilityProfileButton'),
-              onPressed: () {},
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<MobilityProfileOption>(
+                    builder: (_) => const MobilityProfileScreen(),
+                  ),
+                );
+              },
               icon: const Icon(Icons.accessibility_new),
               label: const Text('이동 조건'),
             ),

--- a/apps/mobile/lib/mobility_profile.dart
+++ b/apps/mobile/lib/mobility_profile.dart
@@ -1,0 +1,270 @@
+import 'package:flutter/material.dart';
+
+class MobilityProfileOption {
+  const MobilityProfileOption({
+    required this.id,
+    required this.title,
+    required this.summary,
+    required this.icon,
+    required this.mobilityType,
+    required this.avoidStairs,
+    required this.requireElevator,
+    required this.allowEscalator,
+    required this.minimizeTransfers,
+    required this.avoidLongWalks,
+  });
+
+  final String id;
+  final String title;
+  final String summary;
+  final IconData icon;
+  final String mobilityType;
+  final bool avoidStairs;
+  final bool requireElevator;
+  final bool allowEscalator;
+  final bool minimizeTransfers;
+  final bool avoidLongWalks;
+
+  String semanticsLabel(bool isSelected) {
+    final state = isSelected ? '선택됨' : '선택 가능';
+    return '$title $state, $summary';
+  }
+}
+
+// 서버 저장 API와 연결할 때 같은 기본값을 재사용하기 위해 화면 선택지를 데이터로 둔다.
+const mobilityProfileOptions = <MobilityProfileOption>[
+  MobilityProfileOption(
+    id: 'elderly',
+    title: '고령자',
+    summary: '계단을 피하고 쉬운 환승을 우선해요',
+    icon: Icons.elderly,
+    mobilityType: 'SENIOR',
+    avoidStairs: true,
+    requireElevator: false,
+    allowEscalator: true,
+    minimizeTransfers: true,
+    avoidLongWalks: true,
+  ),
+  MobilityProfileOption(
+    id: 'stroller',
+    title: '유모차',
+    summary: '엘리베이터와 넓은 길을 우선해요',
+    icon: Icons.child_friendly,
+    mobilityType: 'STROLLER',
+    avoidStairs: true,
+    requireElevator: true,
+    allowEscalator: false,
+    minimizeTransfers: false,
+    avoidLongWalks: true,
+  ),
+  MobilityProfileOption(
+    id: 'wheelchair',
+    title: '휠체어',
+    summary: '계단 없는 길만 안내해요',
+    icon: Icons.accessible_forward,
+    mobilityType: 'WHEELCHAIR',
+    avoidStairs: true,
+    requireElevator: true,
+    allowEscalator: false,
+    minimizeTransfers: true,
+    avoidLongWalks: true,
+  ),
+  MobilityProfileOption(
+    id: 'pregnant',
+    title: '임산부',
+    summary: '짧게 걷고 적게 갈아타요',
+    icon: Icons.pregnant_woman,
+    mobilityType: 'PREGNANT',
+    avoidStairs: true,
+    requireElevator: false,
+    allowEscalator: true,
+    minimizeTransfers: true,
+    avoidLongWalks: true,
+  ),
+  MobilityProfileOption(
+    id: 'injured',
+    title: '일시 부상',
+    summary: '계단과 긴 보행을 줄여요',
+    icon: Icons.healing,
+    mobilityType: 'TEMPORARY_INJURY',
+    avoidStairs: true,
+    requireElevator: false,
+    allowEscalator: true,
+    minimizeTransfers: false,
+    avoidLongWalks: true,
+  ),
+  MobilityProfileOption(
+    id: 'luggage',
+    title: '큰 짐',
+    summary: '짐을 들고 이동하기 쉬운 길을 우선해요',
+    icon: Icons.luggage,
+    mobilityType: 'LUGGAGE',
+    avoidStairs: true,
+    requireElevator: false,
+    allowEscalator: true,
+    minimizeTransfers: false,
+    avoidLongWalks: true,
+  ),
+];
+
+class MobilityProfileScreen extends StatefulWidget {
+  const MobilityProfileScreen({super.key});
+
+  @override
+  State<MobilityProfileScreen> createState() => _MobilityProfileScreenState();
+}
+
+class _MobilityProfileScreenState extends State<MobilityProfileScreen> {
+  MobilityProfileOption? _selectedOption;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('이동 조건')),
+      bottomNavigationBar: SafeArea(
+        minimum: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+        child: FilledButton.icon(
+          key: const Key('mobilityProfileDoneButton'),
+          onPressed: _selectedOption == null
+              ? null
+              : () => Navigator.of(context).pop(_selectedOption),
+          icon: const Icon(Icons.check),
+          label: const Text('선택 완료'),
+        ),
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _SelectionStatus(option: _selectedOption),
+              if (_selectedOption != null) const SizedBox(height: 12),
+              for (final option in mobilityProfileOptions)
+                _MobilityProfileCard(
+                  option: option,
+                  selected: option.id == _selectedOption?.id,
+                  onTap: () {
+                    setState(() {
+                      _selectedOption = option;
+                    });
+                  },
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MobilityProfileCard extends StatelessWidget {
+  const _MobilityProfileCard({
+    required this.option,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final MobilityProfileOption option;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final borderColor = selected
+        ? colorScheme.primary
+        : const Color(0xFFD5E2E4);
+    final backgroundColor = selected ? const Color(0xFFE6F2F0) : Colors.white;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Semantics(
+        label: option.semanticsLabel(selected),
+        selected: selected,
+        button: true,
+        child: ExcludeSemantics(
+          child: Material(
+            color: backgroundColor,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: BorderSide(color: borderColor, width: selected ? 2 : 1),
+            ),
+            child: InkWell(
+              key: Key('mobilityProfileCard-${option.id}'),
+              borderRadius: BorderRadius.circular(8),
+              onTap: onTap,
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 76),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      Icon(option.icon, color: colorScheme.primary, size: 34),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Text(
+                              option.title,
+                              style: Theme.of(context).textTheme.titleMedium
+                                  ?.copyWith(
+                                    color: const Color(0xFF102A2C),
+                                    fontWeight: FontWeight.w900,
+                                    height: 1.25,
+                                  ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              option.summary,
+                              style: Theme.of(context).textTheme.bodyLarge
+                                  ?.copyWith(
+                                    color: const Color(0xFF29484B),
+                                    fontWeight: FontWeight.w700,
+                                    height: 1.3,
+                                  ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      if (selected)
+                        Icon(Icons.check_circle, color: colorScheme.primary),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SelectionStatus extends StatelessWidget {
+  const _SelectionStatus({required this.option});
+
+  final MobilityProfileOption? option;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedOption = option;
+    if (selectedOption == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Semantics(
+      liveRegion: true,
+      child: Text(
+        '${selectedOption.title} 조건을 선택했습니다',
+        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+          color: const Color(0xFF102A2C),
+          fontWeight: FontWeight.w800,
+          height: 1.35,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/mobility_profile.dart
+++ b/apps/mobile/lib/mobility_profile.dart
@@ -183,6 +183,7 @@ class _MobilityProfileCard extends StatelessWidget {
         label: option.semanticsLabel(selected),
         selected: selected,
         button: true,
+        onTap: onTap,
         child: ExcludeSemantics(
           child: Material(
             color: backgroundColor,

--- a/apps/mobile/test/mobility_profile_test.dart
+++ b/apps/mobile/test/mobility_profile_test.dart
@@ -1,0 +1,18 @@
+import 'package:easysubway_mobile/mobility_profile.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('이동 조건 선택지는 백엔드 이동 유형 값과 일치한다', () {
+    final mobilityTypesById = {
+      for (final option in mobilityProfileOptions)
+        option.id: option.mobilityType,
+    };
+
+    expect(mobilityTypesById['elderly'], 'SENIOR');
+    expect(mobilityTypesById['stroller'], 'STROLLER');
+    expect(mobilityTypesById['wheelchair'], 'WHEELCHAIR');
+    expect(mobilityTypesById['pregnant'], 'PREGNANT');
+    expect(mobilityTypesById['injured'], 'TEMPORARY_INJURY');
+    expect(mobilityTypesById['luggage'], 'LUGGAGE');
+  });
+}

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -183,6 +183,15 @@ void main() {
       expect(find.text('엘리베이터와 넓은 길을 우선해요'), findsOneWidget);
       expect(find.text('계단 없는 길만 안내해요'), findsOneWidget);
 
+      expect(
+        tester.getSemantics(find.bySemanticsLabel('휠체어 선택 가능, 계단 없는 길만 안내해요')),
+        isSemantics(
+          label: '휠체어 선택 가능, 계단 없는 길만 안내해요',
+          isButton: true,
+          hasTapAction: true,
+        ),
+      );
+
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -160,6 +160,49 @@ void main() {
     );
     expect(completedButton.onPressed, isNotNull);
   });
+
+  testWidgets('이동 조건 화면은 큰 선택 카드로 사용자 상황을 고를 수 있다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(repository: FakeStationSearchRepository()),
+      );
+
+      await tester.tap(find.byKey(const Key('mobilityProfileButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('이동 조건'), findsOneWidget);
+      expect(find.text('고령자'), findsOneWidget);
+      expect(find.text('유모차'), findsOneWidget);
+      expect(find.text('휠체어'), findsOneWidget);
+      expect(find.text('임산부'), findsOneWidget);
+      expect(find.text('일시 부상'), findsOneWidget);
+      expect(find.text('큰 짐'), findsOneWidget);
+      expect(find.text('계단을 피하고 쉬운 환승을 우선해요'), findsOneWidget);
+      expect(find.text('엘리베이터와 넓은 길을 우선해요'), findsOneWidget);
+      expect(find.text('계단 없는 길만 안내해요'), findsOneWidget);
+
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+
+      final wheelchairCard = find.byKey(
+        const Key('mobilityProfileCard-wheelchair'),
+      );
+      expect(wheelchairCard, findsOneWidget);
+      expect(tester.getSize(wheelchairCard).height, greaterThanOrEqualTo(76));
+
+      await tester.tap(wheelchairCard);
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel('휠체어 선택됨, 계단 없는 길만 안내해요'), findsOneWidget);
+      expect(find.text('휠체어 조건을 선택했습니다'), findsOneWidget);
+      expect(find.bySemanticsLabel('선택 완료'), findsOneWidget);
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
 }
 
 class FakeStationSearchRepository implements StationSearchRepository {


### PR DESCRIPTION
## 관련 이슈

close #30

## 작업 배경

홈 화면의 `이동 조건` 버튼이 아직 동작하지 않아 사용자가 자신의 이동 상황을 앱에 알려줄 수 없었습니다. 경로 검색에서 계단 회피, 엘리베이터 우선, 쉬운 환승 같은 조건을 쓰려면 모바일에서 먼저 선택 흐름과 값 계약이 필요합니다.

## 작업 내용

- 홈 화면의 `이동 조건` 버튼을 이동 조건 선택 화면으로 연결했습니다.
- 고령자, 유모차, 휠체어, 임산부, 일시 부상, 큰 짐 프로필을 큰 카드 형태로 선택할 수 있게 했습니다.
- 각 프로필은 쉬운 문구와 아이콘으로 핵심 이동 조건을 보여주고, 선택 상태와 탭 액션을 스크린리더에 제공합니다.
- 하단 `선택 완료` 버튼을 고정해 선택 후 다음 행동이 화면 아래에서 항상 보이게 했습니다.
- 모바일 선택지의 `mobilityType` 값을 백엔드 enum과 맞추는 테스트를 추가했습니다.

## 검증

- `flutter analyze` 통과
- `flutter test` 통과
- `node --test tools/ci/*.test.mjs` 통과
- `git diff --check` 통과
- `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`\n- GitHub Actions: `Changes`, `Mobile App CI`, `Android CI`, `iOS CI` 통과\n- CodeRabbit: actionable comment 없이 통과\n\n## 리뷰어 메모\n\n- `apps/mobile/lib/mobility_profile.dart`의 프로필 기본값이 이후 서버 저장 API와 맞물릴 계약입니다.\n- 접근성 테스트는 Android/iOS 터치 영역, 라벨이 있는 터치 대상, 스크린리더 tap action을 같이 확인합니다.\n- 추가 검토에서 카드 semantics tap action 누락을 확인해 같은 PR에서 수정했습니다.\n\n## 리스크\n\n- 서버 저장 API 호출은 아직 연결하지 않았으므로 앱 재시작 후 선택값 보존은 다음 작업 범위입니다.\n- 경로 검색 점수에 선택 조건을 반영하는 작업은 별도 API 연동 작업에서 진행해야 합니다.\n\n## 체크리스트\n\n- [x] 로컬 검증을 통과했다.\n- [x] CI 결과를 확인했다.\n- [x] CodeRabbit 리뷰를 확인했다.\n- [x] CodeRabbit 실행이 가능해 Codex CLI 대체 리뷰는 필요하지 않다.\n- [x] 배포 환경 변경이 없어 별도 CD 확인 대상이 아니다.