### PR TITLE
[Feat] 모바일 경로 검색 화면 추가

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'mobility_profile.dart';
+import 'route_search.dart';
 import 'station_search.dart';
 
 void main() {
@@ -8,12 +9,19 @@ void main() {
 }
 
 class EasySubwayApp extends StatelessWidget {
-  EasySubwayApp({StationSearchRepository? repository, super.key})
-    : repository =
-          repository ??
-          StationSearchApiRepository(baseUri: defaultStationApiBaseUri());
+  EasySubwayApp({
+    StationSearchRepository? repository,
+    RouteSearchRepository? routeRepository,
+    super.key,
+  }) : repository =
+           repository ??
+           StationSearchApiRepository(baseUri: defaultStationApiBaseUri()),
+       routeRepository =
+           routeRepository ??
+           RouteSearchApiRepository(baseUri: defaultStationApiBaseUri());
 
   final StationSearchRepository repository;
+  final RouteSearchRepository routeRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -58,15 +66,23 @@ class EasySubwayApp extends StatelessWidget {
         ),
         useMaterial3: true,
       ),
-      home: HomeScreen(repository: repository),
+      home: HomeScreen(
+        repository: repository,
+        routeRepository: routeRepository,
+      ),
     );
   }
 }
 
 class HomeScreen extends StatelessWidget {
-  const HomeScreen({required this.repository, super.key});
+  const HomeScreen({
+    required this.repository,
+    required this.routeRepository,
+    super.key,
+  });
 
   final StationSearchRepository repository;
+  final RouteSearchRepository routeRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -101,6 +117,20 @@ class HomeScreen extends StatelessWidget {
               },
               icon: const Icon(Icons.search),
               label: const Text('역 검색'),
+            ),
+            const SizedBox(height: 12),
+            FilledButton.icon(
+              key: const Key('routeSearchButton'),
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) =>
+                        RouteSearchScreen(repository: routeRepository),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.route),
+              label: const Text('경로 검색'),
             ),
             const SizedBox(height: 12),
             OutlinedButton.icon(

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -274,52 +274,74 @@ class RouteSearchController extends ChangeNotifier {
 
   RouteSearchState _state = const RouteSearchState.idle();
   int _searchRequestId = 0;
+  bool _disposed = false;
 
   RouteSearchState get state => _state;
 
   Future<void> search(RouteSearchRequest request) async {
+    if (_disposed) {
+      return;
+    }
+
     final requestId = ++_searchRequestId;
     final trimmedRequest = request.trimmed();
     if (trimmedRequest.originStationId.isEmpty ||
         trimmedRequest.destinationStationId.isEmpty) {
-      _state = const RouteSearchState(
-        status: RouteSearchViewStatus.failure,
-        message: '출발역과 도착역을 입력해 주세요.',
+      _emitState(
+        const RouteSearchState(
+          status: RouteSearchViewStatus.failure,
+          message: '출발역과 도착역을 입력해 주세요.',
+        ),
       );
-      notifyListeners();
       return;
     }
 
-    _state = const RouteSearchState(status: RouteSearchViewStatus.loading);
-    notifyListeners();
+    _emitState(const RouteSearchState(status: RouteSearchViewStatus.loading));
 
     try {
       final result = await repository.searchRoute(trimmedRequest);
-      if (requestId != _searchRequestId) {
+      if (_disposed || requestId != _searchRequestId) {
         return;
       }
-      _state = RouteSearchState(
-        status: RouteSearchViewStatus.success,
-        result: result,
+      _emitState(
+        RouteSearchState(status: RouteSearchViewStatus.success, result: result),
       );
     } on RouteSearchException catch (error) {
-      if (requestId != _searchRequestId) {
+      if (_disposed || requestId != _searchRequestId) {
         return;
       }
-      _state = RouteSearchState(
-        status: RouteSearchViewStatus.failure,
-        message: error.message,
+      _emitState(
+        RouteSearchState(
+          status: RouteSearchViewStatus.failure,
+          message: error.message,
+        ),
       );
     } catch (_) {
-      if (requestId != _searchRequestId) {
+      if (_disposed || requestId != _searchRequestId) {
         return;
       }
-      _state = const RouteSearchState(
-        status: RouteSearchViewStatus.failure,
-        message: _routeSearchErrorMessage,
+      _emitState(
+        const RouteSearchState(
+          status: RouteSearchViewStatus.failure,
+          message: _routeSearchErrorMessage,
+        ),
       );
     }
+  }
+
+  void _emitState(RouteSearchState nextState) {
+    if (_disposed) {
+      return;
+    }
+    _state = nextState;
     notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    // 화면을 떠난 뒤 도착한 네트워크 응답이 dispose된 리스너를 깨우지 않게 막는다.
+    _disposed = true;
+    super.dispose();
   }
 }
 
@@ -377,30 +399,35 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
               onSubmitted: (_) => _submit(),
             ),
             const SizedBox(height: 12),
-            DropdownButtonFormField<String>(
+            InputDecorator(
               key: const Key('routeMobilityTypeInput'),
-              initialValue: _selectedMobilityType,
               decoration: const InputDecoration(
                 labelText: '이동 조건',
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.all(Radius.circular(8)),
                 ),
               ),
-              items: [
-                for (final option in mobilityProfileOptions)
-                  DropdownMenuItem<String>(
-                    value: option.mobilityType,
-                    child: Text(option.title),
-                  ),
-              ],
-              onChanged: (value) {
-                if (value == null) {
-                  return;
-                }
-                setState(() {
-                  _selectedMobilityType = value;
-                });
-              },
+              child: DropdownButtonHideUnderline(
+                child: DropdownButton<String>(
+                  value: _selectedMobilityType,
+                  isExpanded: true,
+                  items: [
+                    for (final option in mobilityProfileOptions)
+                      DropdownMenuItem<String>(
+                        value: option.mobilityType,
+                        child: Text(option.title),
+                      ),
+                  ],
+                  onChanged: (value) {
+                    if (value == null) {
+                      return;
+                    }
+                    setState(() {
+                      _selectedMobilityType = value;
+                    });
+                  },
+                ),
+              ),
             ),
             const SizedBox(height: 12),
             AnimatedBuilder(

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1,0 +1,728 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import 'mobility_profile.dart';
+
+const _routeSearchTimeout = Duration(seconds: 8);
+const _routeSearchErrorMessage = '경로 정보를 불러오지 못했습니다.';
+
+abstract class RouteSearchRepository {
+  Future<RouteSearchResult> searchRoute(RouteSearchRequest request);
+}
+
+class RouteSearchApiRepository implements RouteSearchRepository {
+  RouteSearchApiRepository({required this.baseUri, HttpClient? httpClient})
+    : _httpClient = httpClient ?? HttpClient();
+
+  final Uri baseUri;
+  final HttpClient _httpClient;
+
+  @override
+  Future<RouteSearchResult> searchRoute(RouteSearchRequest routeRequest) async {
+    final uri = baseUri.resolve('/api/v1/routes/search');
+
+    try {
+      final request = await _httpClient
+          .postUrl(uri)
+          .timeout(_routeSearchTimeout);
+      request.headers.contentType = ContentType.json;
+      request.write(jsonEncode(routeRequest.toJson()));
+
+      final response = await request.close().timeout(_routeSearchTimeout);
+      final body = await utf8
+          .decodeStream(response)
+          .timeout(_routeSearchTimeout);
+
+      if (response.statusCode != HttpStatus.ok) {
+        throw const RouteSearchException(_routeSearchErrorMessage);
+      }
+
+      final decoded = jsonDecode(body);
+      if (decoded is! Map<String, Object?> || decoded['success'] != true) {
+        throw const RouteSearchException(_routeSearchErrorMessage);
+      }
+
+      final data = decoded['data'];
+      if (data is! Map<String, Object?>) {
+        throw const RouteSearchException(_routeSearchErrorMessage);
+      }
+
+      return RouteSearchResult.fromJson(data);
+    } on RouteSearchException {
+      rethrow;
+    } catch (_) {
+      throw const RouteSearchException(_routeSearchErrorMessage);
+    }
+  }
+}
+
+class RouteSearchException implements Exception {
+  const RouteSearchException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class RouteSearchRequest {
+  const RouteSearchRequest({
+    required this.originStationId,
+    required this.destinationStationId,
+    required this.mobilityType,
+  });
+
+  final String originStationId;
+  final String destinationStationId;
+  final String mobilityType;
+
+  RouteSearchRequest trimmed() {
+    return RouteSearchRequest(
+      originStationId: originStationId.trim(),
+      destinationStationId: destinationStationId.trim(),
+      mobilityType: mobilityType,
+    );
+  }
+
+  Map<String, Object?> toJson() {
+    final trimmedRequest = trimmed();
+    return {
+      'originStationId': trimmedRequest.originStationId,
+      'destinationStationId': trimmedRequest.destinationStationId,
+      'mobilityType': trimmedRequest.mobilityType,
+    };
+  }
+}
+
+class RouteSearchResult {
+  const RouteSearchResult({
+    required this.routeSearchId,
+    required this.originStationId,
+    required this.originStationName,
+    required this.destinationStationId,
+    required this.destinationStationName,
+    required this.mobilityType,
+    required this.status,
+    required this.lineId,
+    required this.lineName,
+    required this.score,
+    required this.steps,
+    required this.warnings,
+    required this.blockedReasons,
+    required this.createdAt,
+  });
+
+  factory RouteSearchResult.fromJson(Map<String, Object?> json) {
+    final rawSteps = json['steps'];
+    final rawWarnings = json['warnings'];
+    final rawBlockedReasons = json['blockedReasons'];
+    if (rawSteps is! List ||
+        rawWarnings is! List ||
+        rawBlockedReasons is! List) {
+      throw const FormatException('Invalid route payload');
+    }
+
+    return RouteSearchResult(
+      routeSearchId: _requiredRouteString(json, 'routeSearchId'),
+      originStationId: _requiredRouteString(json, 'originStationId'),
+      originStationName: _requiredRouteString(json, 'originStationName'),
+      destinationStationId: _requiredRouteString(json, 'destinationStationId'),
+      destinationStationName: _requiredRouteString(
+        json,
+        'destinationStationName',
+      ),
+      mobilityType: _requiredRouteString(json, 'mobilityType'),
+      status: _requiredRouteString(json, 'status'),
+      lineId: _optionalRouteString(json, 'lineId'),
+      lineName: _optionalRouteString(json, 'lineName'),
+      score: _requiredRouteInt(json, 'score'),
+      steps: rawSteps
+          .map((item) {
+            if (item is! Map<String, Object?>) {
+              throw const FormatException('Invalid route step payload');
+            }
+            return RouteSearchStep.fromJson(item);
+          })
+          .toList(growable: false),
+      warnings: rawWarnings
+          .map((item) {
+            if (item is! Map<String, Object?>) {
+              throw const FormatException('Invalid route warning payload');
+            }
+            return RouteSearchWarning.fromJson(item);
+          })
+          .toList(growable: false),
+      blockedReasons: rawBlockedReasons
+          .map((item) {
+            if (item is! String || item.trim().isEmpty) {
+              throw const FormatException('Invalid blocked reason payload');
+            }
+            return item;
+          })
+          .toList(growable: false),
+      createdAt: _requiredRouteString(json, 'createdAt'),
+    );
+  }
+
+  final String routeSearchId;
+  final String originStationId;
+  final String originStationName;
+  final String destinationStationId;
+  final String destinationStationName;
+  final String mobilityType;
+  final String status;
+  final String lineId;
+  final String lineName;
+  final int score;
+  final List<RouteSearchStep> steps;
+  final List<RouteSearchWarning> warnings;
+  final List<String> blockedReasons;
+  final String createdAt;
+
+  String get summaryTitle => '$originStationName에서 $destinationStationName까지';
+
+  String get statusLabel {
+    return switch (status) {
+      'FOUND' => '경로를 찾았습니다',
+      'BLOCKED' => '안내할 수 있는 경로가 없습니다',
+      _ => '확인이 필요합니다',
+    };
+  }
+
+  String get scoreLabel => '이동 점수 $score점';
+
+  String get lineLabel => lineName.isEmpty ? '노선 확인 필요' : lineName;
+
+  bool get isBlocked => status == 'BLOCKED' || blockedReasons.isNotEmpty;
+
+  String get semanticLabel =>
+      '경로 검색 결과, $summaryTitle, $lineLabel, $scoreLabel';
+}
+
+class RouteSearchStep {
+  const RouteSearchStep({
+    required this.sequence,
+    required this.title,
+    required this.description,
+    required this.lineId,
+    required this.lineName,
+    required this.fromStationId,
+    required this.toStationId,
+  });
+
+  factory RouteSearchStep.fromJson(Map<String, Object?> json) {
+    return RouteSearchStep(
+      sequence: _requiredRouteInt(json, 'sequence'),
+      title: _requiredRouteString(json, 'title'),
+      description: _requiredRouteString(json, 'description'),
+      lineId: _optionalRouteString(json, 'lineId'),
+      lineName: _optionalRouteString(json, 'lineName'),
+      fromStationId: _optionalRouteString(json, 'fromStationId'),
+      toStationId: _optionalRouteString(json, 'toStationId'),
+    );
+  }
+
+  final int sequence;
+  final String title;
+  final String description;
+  final String lineId;
+  final String lineName;
+  final String fromStationId;
+  final String toStationId;
+}
+
+class RouteSearchWarning {
+  const RouteSearchWarning({required this.code, required this.message});
+
+  factory RouteSearchWarning.fromJson(Map<String, Object?> json) {
+    return RouteSearchWarning(
+      code: _requiredRouteString(json, 'code'),
+      message: _requiredRouteString(json, 'message'),
+    );
+  }
+
+  final String code;
+  final String message;
+}
+
+enum RouteSearchViewStatus { idle, loading, success, failure }
+
+class RouteSearchState {
+  const RouteSearchState({
+    required this.status,
+    this.result,
+    this.message = '',
+  });
+
+  const RouteSearchState.idle()
+    : status = RouteSearchViewStatus.idle,
+      result = null,
+      message = '';
+
+  final RouteSearchViewStatus status;
+  final RouteSearchResult? result;
+  final String message;
+}
+
+class RouteSearchController extends ChangeNotifier {
+  RouteSearchController({required this.repository});
+
+  final RouteSearchRepository repository;
+
+  RouteSearchState _state = const RouteSearchState.idle();
+  int _searchRequestId = 0;
+
+  RouteSearchState get state => _state;
+
+  Future<void> search(RouteSearchRequest request) async {
+    final requestId = ++_searchRequestId;
+    final trimmedRequest = request.trimmed();
+    if (trimmedRequest.originStationId.isEmpty ||
+        trimmedRequest.destinationStationId.isEmpty) {
+      _state = const RouteSearchState(
+        status: RouteSearchViewStatus.failure,
+        message: '출발역과 도착역을 입력해 주세요.',
+      );
+      notifyListeners();
+      return;
+    }
+
+    _state = const RouteSearchState(status: RouteSearchViewStatus.loading);
+    notifyListeners();
+
+    try {
+      final result = await repository.searchRoute(trimmedRequest);
+      if (requestId != _searchRequestId) {
+        return;
+      }
+      _state = RouteSearchState(
+        status: RouteSearchViewStatus.success,
+        result: result,
+      );
+    } on RouteSearchException catch (error) {
+      if (requestId != _searchRequestId) {
+        return;
+      }
+      _state = RouteSearchState(
+        status: RouteSearchViewStatus.failure,
+        message: error.message,
+      );
+    } catch (_) {
+      if (requestId != _searchRequestId) {
+        return;
+      }
+      _state = const RouteSearchState(
+        status: RouteSearchViewStatus.failure,
+        message: _routeSearchErrorMessage,
+      );
+    }
+    notifyListeners();
+  }
+}
+
+class RouteSearchScreen extends StatefulWidget {
+  const RouteSearchScreen({required this.repository, super.key});
+
+  final RouteSearchRepository repository;
+
+  @override
+  State<RouteSearchScreen> createState() => _RouteSearchScreenState();
+}
+
+class _RouteSearchScreenState extends State<RouteSearchScreen> {
+  late final RouteSearchController _controller;
+  final TextEditingController _originController = TextEditingController();
+  final TextEditingController _destinationController = TextEditingController();
+  String _selectedMobilityType = mobilityProfileOptions.first.mobilityType;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = RouteSearchController(repository: widget.repository);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _originController.dispose();
+    _destinationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('경로 검색')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          children: [
+            _RouteTextField(
+              key: const Key('routeOriginStationInput'),
+              controller: _originController,
+              labelText: '출발역 ID',
+              hintText: '출발역 ID를 입력해 주세요',
+              textInputAction: TextInputAction.next,
+            ),
+            const SizedBox(height: 12),
+            _RouteTextField(
+              key: const Key('routeDestinationStationInput'),
+              controller: _destinationController,
+              labelText: '도착역 ID',
+              hintText: '도착역 ID를 입력해 주세요',
+              textInputAction: TextInputAction.done,
+              onSubmitted: (_) => _submit(),
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              key: const Key('routeMobilityTypeInput'),
+              initialValue: _selectedMobilityType,
+              decoration: const InputDecoration(
+                labelText: '이동 조건',
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(8)),
+                ),
+              ),
+              items: [
+                for (final option in mobilityProfileOptions)
+                  DropdownMenuItem<String>(
+                    value: option.mobilityType,
+                    child: Text(option.title),
+                  ),
+              ],
+              onChanged: (value) {
+                if (value == null) {
+                  return;
+                }
+                setState(() {
+                  _selectedMobilityType = value;
+                });
+              },
+            ),
+            const SizedBox(height: 12),
+            AnimatedBuilder(
+              animation: _controller,
+              builder: (context, _) {
+                final isLoading =
+                    _controller.state.status == RouteSearchViewStatus.loading;
+                return FilledButton.icon(
+                  key: const Key('routeSearchSubmitButton'),
+                  onPressed: isLoading ? null : _submit,
+                  icon: const Icon(Icons.route),
+                  label: const Text('경로 찾기'),
+                );
+              },
+            ),
+            const SizedBox(height: 20),
+            AnimatedBuilder(
+              animation: _controller,
+              builder: (context, _) =>
+                  _RouteSearchBody(state: _controller.state),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _submit() {
+    if (_controller.state.status == RouteSearchViewStatus.loading) {
+      return;
+    }
+    _controller.search(
+      RouteSearchRequest(
+        originStationId: _originController.text,
+        destinationStationId: _destinationController.text,
+        mobilityType: _selectedMobilityType,
+      ),
+    );
+  }
+}
+
+class _RouteTextField extends StatelessWidget {
+  const _RouteTextField({
+    required this.controller,
+    required this.labelText,
+    required this.hintText,
+    required this.textInputAction,
+    this.onSubmitted,
+    super.key,
+  });
+
+  final TextEditingController controller;
+  final String labelText;
+  final String hintText;
+  final TextInputAction textInputAction;
+  final ValueChanged<String>? onSubmitted;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      minLines: 1,
+      textInputAction: textInputAction,
+      style: const TextStyle(fontSize: 20, height: 1.35),
+      decoration: InputDecoration(
+        labelText: labelText,
+        hintText: hintText,
+        floatingLabelBehavior: FloatingLabelBehavior.always,
+        border: const OutlineInputBorder(
+          borderRadius: BorderRadius.all(Radius.circular(8)),
+        ),
+      ),
+      onSubmitted: onSubmitted,
+    );
+  }
+}
+
+class _RouteSearchBody extends StatelessWidget {
+  const _RouteSearchBody({required this.state});
+
+  final RouteSearchState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (state.status) {
+      RouteSearchViewStatus.idle => const SizedBox.shrink(),
+      RouteSearchViewStatus.loading => Semantics(
+        label: '경로 검색 중',
+        liveRegion: true,
+        child: const Center(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: CircularProgressIndicator(),
+          ),
+        ),
+      ),
+      RouteSearchViewStatus.failure => _RouteSearchMessage(
+        message: state.message,
+        liveRegion: true,
+      ),
+      RouteSearchViewStatus.success => _RouteSearchResultCard(
+        result: state.result!,
+      ),
+    };
+  }
+}
+
+class _RouteSearchMessage extends StatelessWidget {
+  const _RouteSearchMessage({required this.message, this.liveRegion = false});
+
+  final String message;
+  final bool liveRegion;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      liveRegion: liveRegion,
+      child: Text(
+        message,
+        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+          color: const Color(0xFF405A5D),
+          fontWeight: FontWeight.w700,
+          height: 1.35,
+        ),
+      ),
+    );
+  }
+}
+
+class _RouteSearchResultCard extends StatelessWidget {
+  const _RouteSearchResultCard({required this.result});
+
+  final RouteSearchResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return MergeSemantics(
+      child: Semantics(
+        label: result.semanticLabel,
+        liveRegion: true,
+        child: ExcludeSemantics(
+          child: Card(
+            color: Colors.white,
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: const BorderSide(color: Color(0xFFD5E2E4)),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    result.statusLabel,
+                    style: textTheme.titleMedium?.copyWith(
+                      color: const Color(0xFF102A2C),
+                      fontWeight: FontWeight.w900,
+                      height: 1.25,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    result.summaryTitle,
+                    style: textTheme.titleLarge?.copyWith(
+                      color: const Color(0xFF102A2C),
+                      fontWeight: FontWeight.w900,
+                      height: 1.25,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    result.lineLabel,
+                    style: textTheme.bodyLarge?.copyWith(
+                      color: const Color(0xFF29484B),
+                      fontWeight: FontWeight.w800,
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    result.scoreLabel,
+                    style: textTheme.bodyLarge?.copyWith(
+                      color: const Color(0xFF29484B),
+                      fontWeight: FontWeight.w800,
+                      height: 1.3,
+                    ),
+                  ),
+                  if (result.blockedReasons.isNotEmpty) ...[
+                    const SizedBox(height: 12),
+                    for (final reason in result.blockedReasons)
+                      _RouteNotice(text: reason, icon: Icons.block),
+                  ],
+                  if (result.warnings.isNotEmpty) ...[
+                    const SizedBox(height: 12),
+                    for (final warning in result.warnings)
+                      _RouteNotice(
+                        text: warning.message,
+                        icon: Icons.warning_amber,
+                      ),
+                  ],
+                  if (result.steps.isNotEmpty) ...[
+                    const SizedBox(height: 16),
+                    for (final step in result.steps) _RouteStepTile(step: step),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RouteNotice extends StatelessWidget {
+  const _RouteNotice({required this.text, required this.icon});
+
+  final String text;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: const Color(0xFF8A5A00), size: 24),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              text,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: const Color(0xFF3C2F00),
+                fontWeight: FontWeight.w700,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RouteStepTile extends StatelessWidget {
+  const _RouteStepTile({required this.step});
+
+  final RouteSearchStep step;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          CircleAvatar(
+            radius: 16,
+            backgroundColor: const Color(0xFF006D77),
+            child: Text(
+              '${step.sequence}',
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 16,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  step.title,
+                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: const Color(0xFF102A2C),
+                    fontWeight: FontWeight.w900,
+                    height: 1.3,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  step.description,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: const Color(0xFF405A5D),
+                    height: 1.35,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _requiredRouteString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is String && value.trim().isNotEmpty) {
+    return value;
+  }
+  throw FormatException('Missing required route field: $key');
+}
+
+String _optionalRouteString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is String) {
+    return value.trim();
+  }
+  return '';
+}
+
+int _requiredRouteInt(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is int) {
+    return value;
+  }
+  throw FormatException('Missing required route field: $key');
+}

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -198,8 +198,27 @@ class RouteSearchResult {
 
   bool get isBlocked => status == 'BLOCKED' || blockedReasons.isNotEmpty;
 
-  String get semanticLabel =>
-      '경로 검색 결과, $summaryTitle, $lineLabel, $scoreLabel';
+  String get semanticLabel {
+    final parts = <String>[
+      '경로 검색 결과',
+      statusLabel,
+      summaryTitle,
+      lineLabel,
+      scoreLabel,
+    ];
+    if (blockedReasons.isNotEmpty) {
+      parts.add('안내 불가 이유 ${blockedReasons.join(', ')}');
+    }
+    if (warnings.isNotEmpty) {
+      parts.add('주의 ${warnings.map((warning) => warning.message).join(', ')}');
+    }
+    if (steps.isNotEmpty) {
+      parts.add(
+        '이동 안내 ${steps.map((step) => '${step.sequence}번 ${step.title}, ${step.description}').join(', ')}',
+      );
+    }
+    return parts.join(', ');
+  }
 }
 
 class RouteSearchStep {

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -1,0 +1,164 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:easysubway_mobile/route_search.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('경로 API 저장소는 백엔드 경로 검색을 요청하고 결과를 파싱한다', () async {
+    late Uri requestedUri;
+    late String requestedBody;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) async {
+      requestedUri = request.uri;
+      requestedBody = await utf8.decoder.bind(request).join();
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {
+              'routeSearchId': 'route-1',
+              'originStationId': 'station-sangnoksu',
+              'originStationName': '상록수',
+              'destinationStationId': 'station-sadang',
+              'destinationStationName': '사당',
+              'mobilityType': 'WHEELCHAIR',
+              'status': 'FOUND',
+              'lineId': 'seoul-4',
+              'lineName': '수도권 4호선',
+              'score': 92,
+              'steps': [
+                {
+                  'sequence': 1,
+                  'title': '상록수역에서 4호선 승강장으로 이동',
+                  'description': '엘리베이터를 이용해 승강장으로 이동합니다.',
+                  'lineId': 'seoul-4',
+                  'lineName': '수도권 4호선',
+                  'fromStationId': 'station-sangnoksu',
+                  'toStationId': 'station-sadang',
+                },
+              ],
+              'warnings': [
+                {
+                  'code': 'LOW_DATA_CONFIDENCE',
+                  'message': '일부 시설 정보는 확인이 필요합니다.',
+                },
+              ],
+              'blockedReasons': [],
+              'createdAt': '2026-06-13T04:20:00',
+            },
+          }),
+        )
+        ..close();
+    });
+
+    final repository = RouteSearchApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(requestedUri.path, '/api/v1/routes/search');
+    expect(jsonDecode(requestedBody), {
+      'originStationId': 'station-sangnoksu',
+      'destinationStationId': 'station-sadang',
+      'mobilityType': 'WHEELCHAIR',
+    });
+    expect(result.routeSearchId, 'route-1');
+    expect(result.summaryTitle, '상록수에서 사당까지');
+    expect(result.lineName, '수도권 4호선');
+    expect(result.statusLabel, '경로를 찾았습니다');
+    expect(result.scoreLabel, '이동 점수 92점');
+    expect(result.steps.single.title, '상록수역에서 4호선 승강장으로 이동');
+    expect(result.warnings.single.message, '일부 시설 정보는 확인이 필요합니다.');
+  });
+
+  test('경로 검색 컨트롤러는 빈 입력과 실패 상태를 쉬운 문구로 표시한다', () async {
+    final repository = FakeRouteSearchRepository();
+    final controller = RouteSearchController(repository: repository);
+
+    await controller.search(
+      const RouteSearchRequest(
+        originStationId: '  ',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'SENIOR',
+      ),
+    );
+
+    expect(repository.requests, isEmpty);
+    expect(controller.state.status, RouteSearchViewStatus.failure);
+    expect(controller.state.message, '출발역과 도착역을 입력해 주세요.');
+
+    repository.error = const RouteSearchException('경로 정보를 불러오지 못했습니다.');
+
+    await controller.search(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'SENIOR',
+      ),
+    );
+
+    expect(controller.state.status, RouteSearchViewStatus.failure);
+    expect(controller.state.message, '경로 정보를 불러오지 못했습니다.');
+  });
+}
+
+class FakeRouteSearchRepository implements RouteSearchRepository {
+  final requests = <RouteSearchRequest>[];
+  Object? error;
+
+  @override
+  Future<RouteSearchResult> searchRoute(RouteSearchRequest request) async {
+    requests.add(request);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return _sampleRouteSearchResult();
+  }
+}
+
+RouteSearchResult _sampleRouteSearchResult() {
+  return const RouteSearchResult(
+    routeSearchId: 'route-1',
+    originStationId: 'station-sangnoksu',
+    originStationName: '상록수',
+    destinationStationId: 'station-sadang',
+    destinationStationName: '사당',
+    mobilityType: 'SENIOR',
+    status: 'FOUND',
+    lineId: 'seoul-4',
+    lineName: '수도권 4호선',
+    score: 92,
+    steps: [
+      RouteSearchStep(
+        sequence: 1,
+        title: '상록수역에서 4호선 승강장으로 이동',
+        description: '엘리베이터를 이용해 승강장으로 이동합니다.',
+        lineId: 'seoul-4',
+        lineName: '수도권 4호선',
+        fromStationId: 'station-sangnoksu',
+        toStationId: 'station-sadang',
+      ),
+    ],
+    warnings: [
+      RouteSearchWarning(
+        code: 'LOW_DATA_CONFIDENCE',
+        message: '일부 시설 정보는 확인이 필요합니다.',
+      ),
+    ],
+    blockedReasons: [],
+    createdAt: '2026-06-13T04:20:00',
+  );
+}

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -12,6 +13,11 @@ void main() {
     addTearDown(server.close);
 
     server.listen((request) async {
+      expect(request.method, 'POST');
+      expect(
+        request.headers.value(HttpHeaders.contentTypeHeader),
+        contains(ContentType.json.mimeType),
+      );
       requestedUri = request.uri;
       requestedBody = await utf8.decoder.bind(request).join();
       request.response
@@ -109,8 +115,39 @@ void main() {
       ),
     );
 
+    expect(repository.requests, hasLength(1));
+    expect(repository.requests.single.originStationId, 'station-sangnoksu');
+    expect(repository.requests.single.destinationStationId, 'station-sadang');
+    expect(repository.requests.single.mobilityType, 'SENIOR');
     expect(controller.state.status, RouteSearchViewStatus.failure);
     expect(controller.state.message, '경로 정보를 불러오지 못했습니다.');
+  });
+
+  test('경로 검색 컨트롤러는 화면 종료 후 비동기 결과를 알리지 않는다', () async {
+    final repository = PendingRouteSearchRepository();
+    final controller = RouteSearchController(repository: repository);
+    var notificationCount = 0;
+    controller.addListener(() {
+      notificationCount += 1;
+    });
+
+    final searchFuture = controller.search(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'SENIOR',
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(controller.state.status, RouteSearchViewStatus.loading);
+    expect(notificationCount, 1);
+
+    controller.dispose();
+    repository.complete(_sampleRouteSearchResult());
+    await searchFuture;
+
+    expect(notificationCount, 1);
   });
 }
 
@@ -126,6 +163,18 @@ class FakeRouteSearchRepository implements RouteSearchRepository {
       throw currentError;
     }
     return _sampleRouteSearchResult();
+  }
+}
+
+class PendingRouteSearchRepository implements RouteSearchRepository {
+  final _completer = Completer<RouteSearchResult>();
+
+  @override
+  Future<RouteSearchResult> searchRoute(RouteSearchRequest request) =>
+      _completer.future;
+
+  void complete(RouteSearchResult result) {
+    _completer.complete(result);
   }
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -282,7 +282,11 @@ void main() {
       expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
       expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('경로 검색 결과, 상록수에서 사당까지, 수도권 4호선, 이동 점수 92점'),
+        find.bySemanticsLabel(
+          '경로 검색 결과, 경로를 찾았습니다, 상록수에서 사당까지, 수도권 4호선, 이동 점수 92점, '
+          '주의 일부 시설 정보는 확인이 필요합니다., '
+          '이동 안내 1번 상록수역에서 4호선 승강장으로 이동, 엘리베이터를 이용해 승강장으로 이동합니다.',
+        ),
         findsOneWidget,
       );
 
@@ -332,6 +336,13 @@ void main() {
 
       expect(find.text('안내할 수 있는 경로가 없습니다'), findsOneWidget);
       expect(find.text('휠체어로 이동 가능한 엘리베이터가 없습니다.'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel(
+          '경로 검색 결과, 안내할 수 있는 경로가 없습니다, 상록수에서 없는역까지, 노선 확인 필요, 이동 점수 0점, '
+          '안내 불가 이유 휠체어로 이동 가능한 엘리베이터가 없습니다.',
+        ),
+        findsOneWidget,
+      );
       final completedButton = tester.widget<FilledButton>(
         find.byKey(const Key('routeSearchSubmitButton')),
       );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:easysubway_mobile/main.dart';
+import 'package:easysubway_mobile/route_search.dart';
 import 'package:easysubway_mobile/station_search.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -11,11 +12,15 @@ void main() {
 
     try {
       await tester.pumpWidget(
-        EasySubwayApp(repository: FakeStationSearchRepository()),
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+        ),
       );
 
       expect(find.text('역 찾기'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '역 검색'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '경로 검색'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsOneWidget);
       expect(find.text('이동 프로필'), findsOneWidget);
       expect(find.text('시설 정보'), findsOneWidget);
@@ -30,11 +35,15 @@ void main() {
       final stationButtonSize = tester.getSize(
         find.byKey(const Key('stationSearchButton')),
       );
+      final routeButtonSize = tester.getSize(
+        find.byKey(const Key('routeSearchButton')),
+      );
       final profileButtonSize = tester.getSize(
         find.byKey(const Key('mobilityProfileButton')),
       );
 
       expect(stationButtonSize.height, greaterThanOrEqualTo(60));
+      expect(routeButtonSize.height, greaterThanOrEqualTo(60));
       expect(profileButtonSize.height, greaterThanOrEqualTo(60));
     } finally {
       semanticsHandle.dispose();
@@ -71,7 +80,12 @@ void main() {
     );
 
     try {
-      await tester.pumpWidget(EasySubwayApp(repository: repository));
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: repository,
+          routeRepository: FakeRouteSearchRepository(),
+        ),
+      );
 
       await tester.tap(find.byKey(const Key('stationSearchButton')));
       await tester.pumpAndSettle();
@@ -137,7 +151,12 @@ void main() {
   testWidgets('검색 요청 중에는 검색 버튼을 비활성화한다', (tester) async {
     final repository = ControlledStationSearchRepository();
 
-    await tester.pumpWidget(EasySubwayApp(repository: repository));
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        routeRepository: FakeRouteSearchRepository(),
+      ),
+    );
 
     await tester.tap(find.byKey(const Key('stationSearchButton')));
     await tester.pumpAndSettle();
@@ -166,7 +185,10 @@ void main() {
 
     try {
       await tester.pumpWidget(
-        EasySubwayApp(repository: FakeStationSearchRepository()),
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+        ),
       );
 
       await tester.tap(find.byKey(const Key('mobilityProfileButton')));
@@ -212,6 +234,107 @@ void main() {
       semanticsHandle.dispose();
     }
   });
+
+  testWidgets('경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final routeRepository = FakeRouteSearchRepository();
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          routeRepository: routeRepository,
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('routeSearchButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('경로 검색'), findsOneWidget);
+      expect(find.text('출발역 ID'), findsOneWidget);
+      expect(find.text('도착역 ID'), findsOneWidget);
+      expect(find.text('이동 조건'), findsOneWidget);
+
+      await tester.enterText(
+        find.byKey(const Key('routeOriginStationInput')),
+        'station-sangnoksu',
+      );
+      await tester.enterText(
+        find.byKey(const Key('routeDestinationStationInput')),
+        'station-sadang',
+      );
+      await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+      await tester.pumpAndSettle();
+
+      expect(routeRepository.requests, hasLength(1));
+      expect(
+        routeRepository.requests.single.originStationId,
+        'station-sangnoksu',
+      );
+      expect(
+        routeRepository.requests.single.destinationStationId,
+        'station-sadang',
+      );
+      expect(routeRepository.requests.single.mobilityType, 'SENIOR');
+      expect(find.text('상록수에서 사당까지'), findsOneWidget);
+      expect(find.text('수도권 4호선'), findsOneWidget);
+      expect(find.text('이동 점수 92점'), findsOneWidget);
+      expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
+      expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('경로 검색 결과, 상록수에서 사당까지, 수도권 4호선, 이동 점수 92점'),
+        findsOneWidget,
+      );
+
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
+  testWidgets('경로 검색 중에는 버튼을 비활성화하고 안내 불가 이유를 보여준다', (tester) async {
+    final routeRepository = ControlledRouteSearchRepository();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        routeRepository: routeRepository,
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchButton')));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeOriginStationInput')),
+      'station-sangnoksu',
+    );
+    await tester.enterText(
+      find.byKey(const Key('routeDestinationStationInput')),
+      'station-nowhere',
+    );
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pump();
+
+    expect(routeRepository.requests, hasLength(1));
+    expect(find.bySemanticsLabel('경로 검색 중'), findsOneWidget);
+    final loadingButton = tester.widget<FilledButton>(
+      find.byKey(const Key('routeSearchSubmitButton')),
+    );
+    expect(loadingButton.onPressed, isNull);
+
+    routeRepository.complete(_blockedRouteSearchResult());
+    await tester.pumpAndSettle();
+
+    expect(find.text('안내할 수 있는 경로가 없습니다'), findsOneWidget);
+    expect(find.text('휠체어로 이동 가능한 엘리베이터가 없습니다.'), findsOneWidget);
+    final completedButton = tester.widget<FilledButton>(
+      find.byKey(const Key('routeSearchSubmitButton')),
+    );
+    expect(completedButton.onPressed, isNotNull);
+  });
 }
 
 class FakeStationSearchRepository implements StationSearchRepository {
@@ -240,4 +363,82 @@ class ControlledStationSearchRepository implements StationSearchRepository {
   void complete(List<StationSearchResult> results) {
     _completer.complete(results);
   }
+}
+
+class FakeRouteSearchRepository implements RouteSearchRepository {
+  final requests = <RouteSearchRequest>[];
+
+  @override
+  Future<RouteSearchResult> searchRoute(RouteSearchRequest request) async {
+    requests.add(request);
+    return _sampleRouteSearchResult();
+  }
+}
+
+class ControlledRouteSearchRepository implements RouteSearchRepository {
+  final requests = <RouteSearchRequest>[];
+  final _completer = Completer<RouteSearchResult>();
+
+  @override
+  Future<RouteSearchResult> searchRoute(RouteSearchRequest request) {
+    requests.add(request);
+    return _completer.future;
+  }
+
+  void complete(RouteSearchResult result) {
+    _completer.complete(result);
+  }
+}
+
+RouteSearchResult _sampleRouteSearchResult() {
+  return const RouteSearchResult(
+    routeSearchId: 'route-1',
+    originStationId: 'station-sangnoksu',
+    originStationName: '상록수',
+    destinationStationId: 'station-sadang',
+    destinationStationName: '사당',
+    mobilityType: 'SENIOR',
+    status: 'FOUND',
+    lineId: 'seoul-4',
+    lineName: '수도권 4호선',
+    score: 92,
+    steps: [
+      RouteSearchStep(
+        sequence: 1,
+        title: '상록수역에서 4호선 승강장으로 이동',
+        description: '엘리베이터를 이용해 승강장으로 이동합니다.',
+        lineId: 'seoul-4',
+        lineName: '수도권 4호선',
+        fromStationId: 'station-sangnoksu',
+        toStationId: 'station-sadang',
+      ),
+    ],
+    warnings: [
+      RouteSearchWarning(
+        code: 'LOW_DATA_CONFIDENCE',
+        message: '일부 시설 정보는 확인이 필요합니다.',
+      ),
+    ],
+    blockedReasons: [],
+    createdAt: '2026-06-13T04:20:00',
+  );
+}
+
+RouteSearchResult _blockedRouteSearchResult() {
+  return const RouteSearchResult(
+    routeSearchId: 'route-blocked',
+    originStationId: 'station-sangnoksu',
+    originStationName: '상록수',
+    destinationStationId: 'station-nowhere',
+    destinationStationName: '없는역',
+    mobilityType: 'WHEELCHAIR',
+    status: 'BLOCKED',
+    lineId: '',
+    lineName: '',
+    score: 0,
+    steps: [],
+    warnings: [],
+    blockedReasons: ['휠체어로 이동 가능한 엘리베이터가 없습니다.'],
+    createdAt: '2026-06-13T04:25:00',
+  );
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -295,45 +295,50 @@ void main() {
   });
 
   testWidgets('경로 검색 중에는 버튼을 비활성화하고 안내 불가 이유를 보여준다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
     final routeRepository = ControlledRouteSearchRepository();
 
-    await tester.pumpWidget(
-      EasySubwayApp(
-        repository: FakeStationSearchRepository(),
-        routeRepository: routeRepository,
-      ),
-    );
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          routeRepository: routeRepository,
+        ),
+      );
 
-    await tester.tap(find.byKey(const Key('routeSearchButton')));
-    await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('routeSearchButton')));
+      await tester.pumpAndSettle();
 
-    await tester.enterText(
-      find.byKey(const Key('routeOriginStationInput')),
-      'station-sangnoksu',
-    );
-    await tester.enterText(
-      find.byKey(const Key('routeDestinationStationInput')),
-      'station-nowhere',
-    );
-    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
-    await tester.pump();
+      await tester.enterText(
+        find.byKey(const Key('routeOriginStationInput')),
+        'station-sangnoksu',
+      );
+      await tester.enterText(
+        find.byKey(const Key('routeDestinationStationInput')),
+        'station-nowhere',
+      );
+      await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+      await tester.pump();
 
-    expect(routeRepository.requests, hasLength(1));
-    expect(find.bySemanticsLabel('경로 검색 중'), findsOneWidget);
-    final loadingButton = tester.widget<FilledButton>(
-      find.byKey(const Key('routeSearchSubmitButton')),
-    );
-    expect(loadingButton.onPressed, isNull);
+      expect(routeRepository.requests, hasLength(1));
+      expect(find.bySemanticsLabel('경로 검색 중'), findsOneWidget);
+      final loadingButton = tester.widget<FilledButton>(
+        find.byKey(const Key('routeSearchSubmitButton')),
+      );
+      expect(loadingButton.onPressed, isNull);
 
-    routeRepository.complete(_blockedRouteSearchResult());
-    await tester.pumpAndSettle();
+      routeRepository.complete(_blockedRouteSearchResult());
+      await tester.pumpAndSettle();
 
-    expect(find.text('안내할 수 있는 경로가 없습니다'), findsOneWidget);
-    expect(find.text('휠체어로 이동 가능한 엘리베이터가 없습니다.'), findsOneWidget);
-    final completedButton = tester.widget<FilledButton>(
-      find.byKey(const Key('routeSearchSubmitButton')),
-    );
-    expect(completedButton.onPressed, isNotNull);
+      expect(find.text('안내할 수 있는 경로가 없습니다'), findsOneWidget);
+      expect(find.text('휠체어로 이동 가능한 엘리베이터가 없습니다.'), findsOneWidget);
+      final completedButton = tester.widget<FilledButton>(
+        find.byKey(const Key('routeSearchSubmitButton')),
+      );
+      expect(completedButton.onPressed, isNotNull);
+    } finally {
+      semanticsHandle.dispose();
+    }
   });
 }
 


### PR DESCRIPTION
## 관련 이슈

close #32

## 작업 배경

백엔드 경로 검색 API는 준비되어 있지만 모바일 앱에서는 아직 출발역, 도착역, 이동 조건으로 경로를 검색할 수 없었습니다. 쉬운 지하철의 핵심 흐름인 “갈 수 있는 길” 안내를 앱에서 시작할 수 있도록 모바일 경로 검색 화면을 연결했습니다.

## 작업 내용

- 홈 화면에 `경로 검색` 버튼을 추가하고 경로 검색 화면으로 연결했습니다.
- 출발역 ID, 도착역 ID, 이동 조건을 입력해 `POST /api/v1/routes/search`를 호출하는 모바일 저장소를 추가했습니다.
- 경로 검색 결과의 출발/도착역, 노선, 이동 점수, 단계별 안내, 경고, 안내 불가 이유를 큰 글씨와 스크린리더 라벨로 표시합니다.
- 검색 중 버튼 비활성화와 진행 상태 안내를 추가했습니다.
- 백엔드 응답 계약 파싱 테스트와 접근성 위젯 테스트를 추가했습니다.

## 검증

- `flutter analyze apps/mobile` 통과
- `flutter test` 통과
- `node --test tools/ci/*.test.mjs` 통과
- `git diff --check` 통과
- `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
- GitHub CI 통과: Changes, Mobile App CI, Android CI, iOS CI
- 변경 범위 없음으로 스킵 확인: Repository CI, Backend CI
- merge 후 main CI/CD 확인 통과: run `27452332777`

## 리뷰어 메모

- 역 이름 자동완성은 아직 붙이지 않고, 백엔드 API 계약을 먼저 모바일에 연결했습니다.
- 화면 문구는 앱 사용 설명이 아니라 실제 입력/결과 이해에 필요한 문구만 남겼습니다.
- `RouteSearchApiRepository`는 기존 역 검색 저장소와 같은 방식으로 `HttpClient`와 공통 `ApiResponse` JSON을 파싱합니다.
- CodeRabbit 초기 리뷰 지적은 같은 PR에서 반영했습니다.
- 최신 커밋 재검토는 CodeRabbit 한도/크레딧 부족으로 시작되지 않아 Codex CLI code review로 확인했습니다.

## 리스크

- 현재 입력은 역 ID 기준입니다. 역 이름 검색과 선택 모달은 다음 작업에서 붙여야 실제 사용자 입력 부담이 줄어듭니다.
- 지도 표시와 현재 위치 연동은 이번 범위에서 제외했습니다.

## 체크리스트

- [x] 로컬 검증을 통과했다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
