### PR TITLE
[Feat] 경로 검색 역 선택 UX 개선

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -124,8 +124,10 @@ class HomeScreen extends StatelessWidget {
               onPressed: () {
                 Navigator.of(context).push(
                   MaterialPageRoute<void>(
-                    builder: (_) =>
-                        RouteSearchScreen(repository: routeRepository),
+                    builder: (_) => RouteSearchScreen(
+                      repository: routeRepository,
+                      stationRepository: repository,
+                    ),
                   ),
                 );
               },

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import 'mobility_profile.dart';
+import 'station_search.dart';
 
 const _routeSearchTimeout = Duration(seconds: 8);
 const _routeSearchErrorMessage = '경로 정보를 불러오지 못했습니다.';
@@ -365,9 +366,14 @@ class RouteSearchController extends ChangeNotifier {
 }
 
 class RouteSearchScreen extends StatefulWidget {
-  const RouteSearchScreen({required this.repository, super.key});
+  const RouteSearchScreen({
+    required this.repository,
+    required this.stationRepository,
+    super.key,
+  });
 
   final RouteSearchRepository repository;
+  final StationSearchRepository stationRepository;
 
   @override
   State<RouteSearchScreen> createState() => _RouteSearchScreenState();
@@ -375,9 +381,10 @@ class RouteSearchScreen extends StatefulWidget {
 
 class _RouteSearchScreenState extends State<RouteSearchScreen> {
   late final RouteSearchController _controller;
-  final TextEditingController _originController = TextEditingController();
-  final TextEditingController _destinationController = TextEditingController();
+  StationSearchResult? _originStation;
+  StationSearchResult? _destinationStation;
   String _selectedMobilityType = mobilityProfileOptions.first.mobilityType;
+  String _validationMessage = '';
 
   @override
   void initState() {
@@ -388,8 +395,6 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
   @override
   void dispose() {
     _controller.dispose();
-    _originController.dispose();
-    _destinationController.dispose();
     super.dispose();
   }
 
@@ -401,21 +406,34 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
           children: [
-            _RouteTextField(
-              key: const Key('routeOriginStationInput'),
-              controller: _originController,
-              labelText: '출발역 ID',
-              hintText: '출발역 ID를 입력해 주세요',
-              textInputAction: TextInputAction.next,
+            _RouteStationPicker(
+              labelText: '출발역',
+              inputKey: const Key('routeOriginStationInput'),
+              searchButtonKey: const Key('routeOriginStationSearchButton'),
+              optionKeyPrefix: 'routeOriginStationOption',
+              selectedStation: _originStation,
+              repository: widget.stationRepository,
+              onSelected: (station) {
+                setState(() {
+                  _originStation = station;
+                  _validationMessage = '';
+                });
+              },
             ),
-            const SizedBox(height: 12),
-            _RouteTextField(
-              key: const Key('routeDestinationStationInput'),
-              controller: _destinationController,
-              labelText: '도착역 ID',
-              hintText: '도착역 ID를 입력해 주세요',
-              textInputAction: TextInputAction.done,
-              onSubmitted: (_) => _submit(),
+            const SizedBox(height: 16),
+            _RouteStationPicker(
+              labelText: '도착역',
+              inputKey: const Key('routeDestinationStationInput'),
+              searchButtonKey: const Key('routeDestinationStationSearchButton'),
+              optionKeyPrefix: 'routeDestinationStationOption',
+              selectedStation: _destinationStation,
+              repository: widget.stationRepository,
+              onSelected: (station) {
+                setState(() {
+                  _destinationStation = station;
+                  _validationMessage = '';
+                });
+              },
             ),
             const SizedBox(height: 12),
             InputDecorator(
@@ -463,6 +481,13 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
               },
             ),
             const SizedBox(height: 20),
+            if (_validationMessage.isNotEmpty) ...[
+              _RouteSearchMessage(
+                message: _validationMessage,
+                liveRegion: true,
+              ),
+              const SizedBox(height: 16),
+            ],
             AnimatedBuilder(
               animation: _controller,
               builder: (context, _) =>
@@ -478,48 +503,357 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
     if (_controller.state.status == RouteSearchViewStatus.loading) {
       return;
     }
+    if (_originStation == null || _destinationStation == null) {
+      setState(() {
+        _validationMessage = '출발역과 도착역을 검색 결과에서 선택해 주세요.';
+      });
+      return;
+    }
+    setState(() {
+      _validationMessage = '';
+    });
+
+    // 화면에는 역 이름을 보여주지만 API에는 안정적인 station id만 전달한다.
     _controller.search(
       RouteSearchRequest(
-        originStationId: _originController.text,
-        destinationStationId: _destinationController.text,
+        originStationId: _originStation!.id,
+        destinationStationId: _destinationStation!.id,
         mobilityType: _selectedMobilityType,
       ),
     );
   }
 }
 
-class _RouteTextField extends StatelessWidget {
-  const _RouteTextField({
-    required this.controller,
+class _RouteStationPicker extends StatefulWidget {
+  const _RouteStationPicker({
     required this.labelText,
-    required this.hintText,
-    required this.textInputAction,
-    this.onSubmitted,
-    super.key,
+    required this.inputKey,
+    required this.searchButtonKey,
+    required this.optionKeyPrefix,
+    required this.selectedStation,
+    required this.repository,
+    required this.onSelected,
   });
 
-  final TextEditingController controller;
   final String labelText;
-  final String hintText;
-  final TextInputAction textInputAction;
-  final ValueChanged<String>? onSubmitted;
+  final Key inputKey;
+  final Key searchButtonKey;
+  final String optionKeyPrefix;
+  final StationSearchResult? selectedStation;
+  final StationSearchRepository repository;
+  final ValueChanged<StationSearchResult?> onSelected;
+
+  @override
+  State<_RouteStationPicker> createState() => _RouteStationPickerState();
+}
+
+class _RouteStationPickerState extends State<_RouteStationPicker> {
+  late final StationSearchController _controller;
+  final TextEditingController _textController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = StationSearchController(repository: widget.repository);
+    _textController.addListener(_clearSelectedStationIfNeeded);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _textController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      controller: controller,
-      minLines: 1,
-      textInputAction: textInputAction,
-      style: const TextStyle(fontSize: 20, height: 1.35),
-      decoration: InputDecoration(
-        labelText: labelText,
-        hintText: hintText,
-        floatingLabelBehavior: FloatingLabelBehavior.always,
-        border: const OutlineInputBorder(
-          borderRadius: BorderRadius.all(Radius.circular(8)),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Semantics(
+          label: '${widget.labelText} 입력',
+          textField: true,
+          child: TextField(
+            key: widget.inputKey,
+            controller: _textController,
+            minLines: 1,
+            textInputAction: TextInputAction.search,
+            style: const TextStyle(fontSize: 20, height: 1.35),
+            decoration: InputDecoration(
+              labelText: widget.labelText,
+              hintText: '역 이름을 입력해 주세요',
+              floatingLabelBehavior: FloatingLabelBehavior.always,
+              border: const OutlineInputBorder(
+                borderRadius: BorderRadius.all(Radius.circular(8)),
+              ),
+            ),
+            onSubmitted: (_) => _search(),
+          ),
+        ),
+        const SizedBox(height: 8),
+        AnimatedBuilder(
+          animation: _controller,
+          builder: (context, _) {
+            final isLoading =
+                _controller.state.status == StationSearchStatus.loading;
+            return OutlinedButton.icon(
+              key: widget.searchButtonKey,
+              onPressed: isLoading ? null : _search,
+              icon: const Icon(Icons.search),
+              label: Text('${widget.labelText} 검색'),
+            );
+          },
+        ),
+        if (widget.selectedStation case final selectedStation?) ...[
+          const SizedBox(height: 8),
+          _RouteSelectedStationSummary(
+            labelText: widget.labelText,
+            station: selectedStation,
+          ),
+        ],
+        const SizedBox(height: 8),
+        AnimatedBuilder(
+          animation: _controller,
+          builder: (context, _) {
+            return _RouteStationSearchBody(
+              labelText: widget.labelText,
+              optionKeyPrefix: widget.optionKeyPrefix,
+              state: _controller.state,
+              onSelected: _selectStation,
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  void _search() {
+    if (_controller.state.status == StationSearchStatus.loading) {
+      return;
+    }
+    _controller.search(_textController.text);
+  }
+
+  void _selectStation(StationSearchResult station) {
+    widget.onSelected(station);
+    _textController.text = station.nameKo;
+    // 선택 후 후보 목록을 접어 다음 입력을 바로 찾을 수 있게 한다.
+    unawaited(_controller.search(''));
+  }
+
+  void _clearSelectedStationIfNeeded() {
+    final selectedStation = widget.selectedStation;
+    if (selectedStation == null) {
+      return;
+    }
+    if (_textController.text.trim() == selectedStation.nameKo) {
+      return;
+    }
+    widget.onSelected(null);
+  }
+}
+
+class _RouteSelectedStationSummary extends StatelessWidget {
+  const _RouteSelectedStationSummary({
+    required this.labelText,
+    required this.station,
+  });
+
+  final String labelText;
+  final StationSearchResult station;
+
+  @override
+  Widget build(BuildContext context) {
+    return MergeSemantics(
+      child: Semantics(
+        label: '$labelText 선택됨, ${station.semanticLabel}',
+        liveRegion: true,
+        child: ExcludeSemantics(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: const Color(0xFFE9F5F6),
+              border: Border.all(color: const Color(0xFFB9D4D8)),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(Icons.check_circle, color: Color(0xFF006D77)),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '$labelText ${station.nameKo}',
+                          style: Theme.of(context).textTheme.bodyLarge
+                              ?.copyWith(
+                                color: const Color(0xFF102A2C),
+                                fontWeight: FontWeight.w900,
+                                height: 1.3,
+                              ),
+                        ),
+                        const SizedBox(height: 6),
+                        StationLineBadges(lines: station.lines),
+                        const SizedBox(height: 6),
+                        Text(
+                          station.lineLabel,
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: const Color(0xFF29484B),
+                                fontWeight: FontWeight.w700,
+                                height: 1.3,
+                              ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
         ),
       ),
-      onSubmitted: onSubmitted,
+    );
+  }
+}
+
+class _RouteStationSearchBody extends StatelessWidget {
+  const _RouteStationSearchBody({
+    required this.labelText,
+    required this.optionKeyPrefix,
+    required this.state,
+    required this.onSelected,
+  });
+
+  final String labelText;
+  final String optionKeyPrefix;
+  final StationSearchState state;
+  final ValueChanged<StationSearchResult> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (state.status) {
+      StationSearchStatus.idle => const SizedBox.shrink(),
+      StationSearchStatus.loading => Semantics(
+        label: '$labelText 검색 중',
+        liveRegion: true,
+        child: const Center(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 16),
+            child: CircularProgressIndicator(),
+          ),
+        ),
+      ),
+      StationSearchStatus.empty || StationSearchStatus.failure =>
+        _RouteSearchMessage(message: state.message, liveRegion: true),
+      StationSearchStatus.success => Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Semantics(
+            label: '$labelText 검색 결과 ${state.results.length}개',
+            liveRegion: true,
+            child: const SizedBox.shrink(),
+          ),
+          for (final result in state.results)
+            _RouteStationOptionTile(
+              key: Key('$optionKeyPrefix-${result.id}'),
+              labelText: labelText,
+              result: result,
+              onSelected: onSelected,
+            ),
+        ],
+      ),
+    };
+  }
+}
+
+class _RouteStationOptionTile extends StatelessWidget {
+  const _RouteStationOptionTile({
+    required this.labelText,
+    required this.result,
+    required this.onSelected,
+    super.key,
+  });
+
+  final String labelText;
+  final StationSearchResult result;
+  final ValueChanged<StationSearchResult> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return MergeSemantics(
+      child: Semantics(
+        label: '$labelText 선택, ${result.semanticLabel}',
+        button: true,
+        child: ExcludeSemantics(
+          child: Card(
+            margin: const EdgeInsets.only(bottom: 8),
+            color: Colors.white,
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: const BorderSide(color: Color(0xFFD5E2E4)),
+            ),
+            child: InkWell(
+              onTap: () => onSelected(result),
+              borderRadius: BorderRadius.circular(8),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            result.nameKo,
+                            style: textTheme.titleMedium?.copyWith(
+                              color: const Color(0xFF102A2C),
+                              fontWeight: FontWeight.w900,
+                              height: 1.25,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          StationLineBadges(lines: result.lines),
+                          const SizedBox(height: 8),
+                          Text(
+                            result.lineLabel,
+                            style: textTheme.bodyLarge?.copyWith(
+                              color: const Color(0xFF29484B),
+                              fontWeight: FontWeight.w700,
+                              height: 1.3,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            result.dataQualityLabel,
+                            style: textTheme.bodyMedium?.copyWith(
+                              color: const Color(0xFF405A5D),
+                              height: 1.3,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    const Icon(
+                      Icons.chevron_right,
+                      color: Color(0xFF006D77),
+                      size: 32,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -349,6 +349,14 @@ class RouteSearchController extends ChangeNotifier {
     }
   }
 
+  void reset() {
+    if (_disposed) {
+      return;
+    }
+    _searchRequestId += 1;
+    _emitState(const RouteSearchState.idle());
+  }
+
   void _emitState(RouteSearchState nextState) {
     if (_disposed) {
       return;
@@ -413,12 +421,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
               optionKeyPrefix: 'routeOriginStationOption',
               selectedStation: _originStation,
               repository: widget.stationRepository,
-              onSelected: (station) {
-                setState(() {
-                  _originStation = station;
-                  _validationMessage = '';
-                });
-              },
+              onSelected: _updateOriginStation,
             ),
             const SizedBox(height: 16),
             _RouteStationPicker(
@@ -428,12 +431,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
               optionKeyPrefix: 'routeDestinationStationOption',
               selectedStation: _destinationStation,
               repository: widget.stationRepository,
-              onSelected: (station) {
-                setState(() {
-                  _destinationStation = station;
-                  _validationMessage = '';
-                });
-              },
+              onSelected: _updateDestinationStation,
             ),
             const SizedBox(height: 12),
             InputDecorator(
@@ -504,6 +502,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
       return;
     }
     if (_originStation == null || _destinationStation == null) {
+      _controller.reset();
       setState(() {
         _validationMessage = '출발역과 도착역을 검색 결과에서 선택해 주세요.';
       });
@@ -521,6 +520,22 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
         mobilityType: _selectedMobilityType,
       ),
     );
+  }
+
+  void _updateOriginStation(StationSearchResult? station) {
+    setState(() {
+      _originStation = station;
+      _validationMessage = '';
+    });
+    _controller.reset();
+  }
+
+  void _updateDestinationStation(StationSearchResult? station) {
+    setState(() {
+      _destinationStation = station;
+      _validationMessage = '';
+    });
+    _controller.reset();
   }
 }
 
@@ -790,6 +805,7 @@ class _RouteStationOptionTile extends StatelessWidget {
       child: Semantics(
         label: '$labelText 선택, ${result.semanticLabel}',
         button: true,
+        onTap: () => onSelected(result),
         child: ExcludeSemantics(
           child: Card(
             margin: const EdgeInsets.only(bottom: 8),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -477,7 +477,7 @@ class _StationSearchResultTile extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: 10),
-                  _StationSearchLineBadges(lines: result.lines),
+                  StationLineBadges(lines: result.lines),
                   const SizedBox(height: 8),
                   Text(
                     result.lineLabel,
@@ -513,8 +513,8 @@ class _StationSearchResultTile extends StatelessWidget {
   }
 }
 
-class _StationSearchLineBadges extends StatelessWidget {
-  const _StationSearchLineBadges({required this.lines});
+class StationLineBadges extends StatelessWidget {
+  const StationLineBadges({required this.lines, super.key});
 
   final List<StationSearchLine> lines;
 
@@ -527,13 +527,13 @@ class _StationSearchLineBadges extends StatelessWidget {
     return Wrap(
       spacing: 8,
       runSpacing: 8,
-      children: [for (final line in lines) _StationSearchLineBadge(line: line)],
+      children: [for (final line in lines) StationLineBadge(line: line)],
     );
   }
 }
 
-class _StationSearchLineBadge extends StatelessWidget {
-  const _StationSearchLineBadge({required this.line});
+class StationLineBadge extends StatelessWidget {
+  const StationLineBadge({required this.line, super.key});
 
   final StationSearchLine line;
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -237,12 +237,18 @@ void main() {
 
   testWidgets('경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '사당': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
     final routeRepository = FakeRouteSearchRepository();
 
     try {
       await tester.pumpWidget(
         EasySubwayApp(
-          repository: FakeStationSearchRepository(),
+          repository: stationRepository,
           routeRepository: routeRepository,
         ),
       );
@@ -251,21 +257,47 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('경로 검색'), findsOneWidget);
-      expect(find.text('출발역 ID'), findsOneWidget);
-      expect(find.text('도착역 ID'), findsOneWidget);
+      expect(find.text('출발역'), findsOneWidget);
+      expect(find.text('도착역'), findsOneWidget);
+      expect(find.text('출발역 ID'), findsNothing);
+      expect(find.text('도착역 ID'), findsNothing);
       expect(find.text('이동 조건'), findsOneWidget);
+
+      final originInput = tester.widget<TextField>(
+        find.byKey(const Key('routeOriginStationInput')),
+      );
+      expect(originInput.decoration?.hintText, '역 이름을 입력해 주세요');
 
       await tester.enterText(
         find.byKey(const Key('routeOriginStationInput')),
-        'station-sangnoksu',
+        '상록수',
       );
+      await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+      );
+      await tester.pumpAndSettle();
+
       await tester.enterText(
         find.byKey(const Key('routeDestinationStationInput')),
-        'station-sadang',
+        '사당',
       );
+      await tester.tap(
+        find.byKey(const Key('routeDestinationStationSearchButton')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('routeDestinationStationOption-station-sadang')),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.drag(find.byType(ListView), const Offset(0, -360));
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
       await tester.pumpAndSettle();
 
+      expect(stationRepository.requestedQueries, ['상록수', '사당']);
       expect(routeRepository.requests, hasLength(1));
       expect(
         routeRepository.requests.single.originStationId,
@@ -281,6 +313,14 @@ void main() {
       expect(find.text('이동 점수 92점'), findsOneWidget);
       expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
       expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('출발역 선택됨, 상록수, 수도권 2호선, 수도권, 기본 정보만 확인됨'),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel('도착역 선택됨, 사당, 수도권 2호선, 수도권, 기본 정보만 확인됨'),
+        findsOneWidget,
+      );
       expect(
         find.bySemanticsLabel(
           '경로 검색 결과, 경로를 찾았습니다, 상록수에서 사당까지, 수도권 4호선, 이동 점수 92점, '
@@ -298,14 +338,48 @@ void main() {
     }
   });
 
+  testWidgets('경로 검색은 입력만 하고 선택하지 않은 역을 쉬운 문구로 안내한다', (tester) async {
+    final routeRepository = FakeRouteSearchRepository();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        routeRepository: routeRepository,
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchButton')));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeOriginStationInput')),
+      '상록수',
+    );
+    await tester.enterText(
+      find.byKey(const Key('routeDestinationStationInput')),
+      '사당',
+    );
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(routeRepository.requests, isEmpty);
+    expect(find.text('출발역과 도착역을 검색 결과에서 선택해 주세요.'), findsOneWidget);
+  });
+
   testWidgets('경로 검색 중에는 버튼을 비활성화하고 안내 불가 이유를 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '없는역': [_stationResult(id: 'station-nowhere', name: '없는역')],
+      },
+    );
     final routeRepository = ControlledRouteSearchRepository();
 
     try {
       await tester.pumpWidget(
         EasySubwayApp(
-          repository: FakeStationSearchRepository(),
+          repository: stationRepository,
           routeRepository: routeRepository,
         ),
       );
@@ -315,12 +389,30 @@ void main() {
 
       await tester.enterText(
         find.byKey(const Key('routeOriginStationInput')),
-        'station-sangnoksu',
+        '상록수',
       );
+      await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+      );
+      await tester.pumpAndSettle();
+
       await tester.enterText(
         find.byKey(const Key('routeDestinationStationInput')),
-        'station-nowhere',
+        '없는역',
       );
+      await tester.tap(
+        find.byKey(const Key('routeDestinationStationSearchButton')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('routeDestinationStationOption-station-nowhere')),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.drag(find.byType(ListView), const Offset(0, -360));
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
       await tester.pump();
 
@@ -354,15 +446,19 @@ void main() {
 }
 
 class FakeStationSearchRepository implements StationSearchRepository {
-  FakeStationSearchRepository({this.nextResults = const []});
+  FakeStationSearchRepository({
+    this.nextResults = const [],
+    this.queryResults = const {},
+  });
 
   final List<StationSearchResult> nextResults;
+  final Map<String, List<StationSearchResult>> queryResults;
   final requestedQueries = <String>[];
 
   @override
   Future<List<StationSearchResult>> searchStations(String query) async {
     requestedQueries.add(query);
-    return nextResults;
+    return queryResults[query] ?? nextResults;
   }
 }
 
@@ -404,6 +500,25 @@ class ControlledRouteSearchRepository implements RouteSearchRepository {
   void complete(RouteSearchResult result) {
     _completer.complete(result);
   }
+}
+
+StationSearchResult _stationResult({required String id, required String name}) {
+  return StationSearchResult(
+    id: id,
+    nameKo: name,
+    nameEn: id,
+    region: '수도권',
+    dataQualityLevel: 'LEVEL_1',
+    lastVerifiedAt: '2026-06-13',
+    lines: const [
+      StationSearchLine(
+        id: 'seoul-2',
+        name: '수도권 2호선',
+        color: '#00A84D',
+        stationCode: '222',
+      ),
+    ],
+  );
 }
 
 RouteSearchResult _sampleRouteSearchResult() {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -274,6 +274,16 @@ void main() {
       );
       await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
       await tester.pumpAndSettle();
+      expect(
+        tester.getSemantics(
+          find.bySemanticsLabel('출발역 선택, 상록수, 수도권 2호선, 수도권, 기본 정보만 확인됨'),
+        ),
+        isSemantics(
+          label: '출발역 선택, 상록수, 수도권 2호선, 수도권, 기본 정보만 확인됨',
+          isButton: true,
+          hasTapAction: true,
+        ),
+      );
       await tester.tap(
         find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
       );
@@ -364,6 +374,81 @@ void main() {
 
     expect(routeRepository.requests, isEmpty);
     expect(find.text('출발역과 도착역을 검색 결과에서 선택해 주세요.'), findsOneWidget);
+  });
+
+  testWidgets('경로 검색은 역 선택이 바뀌면 이전 결과를 숨긴다', (tester) async {
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '사당': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
+    final routeRepository = FakeRouteSearchRepository();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        routeRepository: routeRepository,
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchButton')));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeOriginStationInput')),
+      '상록수',
+    );
+    await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeDestinationStationInput')),
+      '사당',
+    );
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationSearchButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationOption-station-sadang')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(ListView), const Offset(0, -360));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('상록수에서 사당까지'), findsOneWidget);
+
+    await tester.drag(find.byType(ListView), const Offset(0, 700));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('routeOriginStationInput')),
+      '상록',
+    );
+    await tester.drag(find.byType(ListView), const Offset(0, -360));
+    await tester.pumpAndSettle();
+    final submitButton = tester.widget<FilledButton>(
+      find.byKey(const Key('routeSearchSubmitButton')),
+    );
+    submitButton.onPressed!();
+    await tester.pumpAndSettle();
+    await tester.drag(find.byType(ListView), const Offset(0, -240));
+    await tester.pumpAndSettle();
+
+    expect(routeRepository.requests, hasLength(1));
+    expect(find.text('출발역과 도착역을 검색 결과에서 선택해 주세요.'), findsOneWidget);
+
+    await tester.drag(find.byType(ListView), const Offset(0, -500));
+    await tester.pumpAndSettle();
+
+    expect(find.text('상록수에서 사당까지'), findsNothing);
   });
 
   testWidgets('경로 검색 중에는 버튼을 비활성화하고 안내 불가 이유를 보여준다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

Closes #34

## 요약

경로 검색 화면에서 사용자가 station id를 직접 입력하지 않고 출발역과 도착역을 역 이름으로 검색해 선택하도록 변경했습니다. 선택된 역은 화면에 이름과 노선 배지로 표시하고, 경로 검색 API에는 기존 station id를 그대로 전달합니다.

## 변경 사항

- 경로 검색 화면에 출발역/도착역별 역 이름 검색과 선택 목록을 추가했습니다.
- 역 선택 목록과 선택 완료 영역에 노선 배지, 노선명, 데이터 수준을 표시했습니다.
- 역 이름을 입력만 하고 선택하지 않은 경우 경로 요청을 보내지 않고 선택 필요 안내를 표시했습니다.
- 기존 역 검색 노선 배지를 경로 검색에서도 재사용할 수 있도록 공용 위젯으로 정리했습니다.
- 위젯 테스트를 역 이름 검색/선택 흐름과 선택 누락 검증으로 갱신했습니다.

## 검증

- `cd apps/mobile && flutter analyze` 통과
- `cd apps/mobile && flutter test` 통과
- `node --test tools/ci/*.test.mjs` 통과
- `git diff --check` 통과
- `git ls-files '*.md'` 결과: `README.md`, `.github/pull_request_template.md`
- `cd apps/mobile && flutter build apk --debug` 통과
- `cd apps/mobile && flutter build ios --simulator --no-codesign` 통과
- CodeRabbit은 한도/크레딧 부족으로 실제 리뷰가 시작되지 않아 Codex CLI code review로 대체 확인
- Codex CLI code review 1차 지적 2건 수정 후 재검토에서 추가 수정 필요 없음
- main 머지 후 CI run `27453354326` 통과

## 리뷰어가 먼저 봐야 할 지점

- 역 선택 후 후보 목록을 접는 동작이 출발역에서 도착역으로 이동하는 흐름을 방해하지 않는지 확인해 주세요.
- `RouteSearchScreen`이 기존 경로 API 계약을 바꾸지 않고 선택된 station id만 전달하는지 확인해 주세요.
- 경로 검색 화면의 문구가 불필요하게 길지 않고 실제 사용자가 이해하기 쉬운지 확인해 주세요.

## 체크리스트

- [x] 관련 이슈를 연결했다.
- [x] 실행한 명령과 결과를 검증에 적었다.
- [x] 사용자 또는 운영 영향이 있는 변경 사항을 요약했다.
- [x] CodeRabbit 상태를 확인했다.
- [x] Codex CLI code review 결과를 확인했다.
- [x] CD 상태를 확인했다.
