### PR TITLE
[Feat] 시설 상태 신고 화면 추가

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1,0 +1,623 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+const _facilityReportTimeout = Duration(seconds: 8);
+const _facilityReportErrorMessage = '신고를 보내지 못했습니다.';
+const _anonymousReportUserId = 'anonymous-mobile-user';
+
+abstract class FacilityReportRepository {
+  Future<FacilityReportResult> createReport(FacilityReportRequest request);
+}
+
+class FacilityReportApiRepository implements FacilityReportRepository {
+  FacilityReportApiRepository({required this.baseUri, HttpClient? httpClient})
+    : _httpClient = httpClient ?? HttpClient();
+
+  final Uri baseUri;
+  final HttpClient _httpClient;
+
+  @override
+  Future<FacilityReportResult> createReport(
+    FacilityReportRequest reportRequest,
+  ) async {
+    final uri = baseUri.resolve('/api/v1/reports');
+
+    try {
+      final request = await _httpClient
+          .postUrl(uri)
+          .timeout(_facilityReportTimeout);
+      request.headers.contentType = ContentType.json;
+      request.write(jsonEncode(reportRequest.toJson()));
+
+      final response = await request.close().timeout(_facilityReportTimeout);
+      final body = await utf8
+          .decodeStream(response)
+          .timeout(_facilityReportTimeout);
+
+      if (response.statusCode != HttpStatus.created &&
+          response.statusCode != HttpStatus.ok) {
+        throw const FacilityReportException(_facilityReportErrorMessage);
+      }
+
+      final decoded = jsonDecode(body);
+      if (decoded is! Map<String, Object?> || decoded['success'] != true) {
+        throw const FacilityReportException(_facilityReportErrorMessage);
+      }
+
+      final data = decoded['data'];
+      if (data is! Map<String, Object?>) {
+        throw const FacilityReportException(_facilityReportErrorMessage);
+      }
+
+      return FacilityReportResult.fromJson(data);
+    } on FacilityReportException {
+      rethrow;
+    } catch (_) {
+      throw const FacilityReportException(_facilityReportErrorMessage);
+    }
+  }
+}
+
+class FacilityReportException implements Exception {
+  const FacilityReportException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class FacilityReportRequest {
+  const FacilityReportRequest({
+    required this.userId,
+    required this.stationId,
+    required this.facilityId,
+    required this.reportType,
+    required this.description,
+  });
+
+  final String userId;
+  final String stationId;
+  final String facilityId;
+  final String reportType;
+  final String description;
+
+  FacilityReportRequest trimmed() {
+    return FacilityReportRequest(
+      userId: userId.trim(),
+      stationId: stationId.trim(),
+      facilityId: facilityId.trim(),
+      reportType: reportType.trim(),
+      description: description.trim(),
+    );
+  }
+
+  Map<String, Object?> toJson() {
+    final request = trimmed();
+    return {
+      'userId': request.userId,
+      'stationId': request.stationId,
+      'facilityId': request.facilityId,
+      'reportType': request.reportType,
+      'description': request.description,
+    };
+  }
+}
+
+class FacilityReportResult {
+  const FacilityReportResult({
+    required this.id,
+    required this.stationId,
+    required this.facilityId,
+    required this.reportType,
+    required this.description,
+    required this.status,
+    required this.createdAt,
+  });
+
+  factory FacilityReportResult.fromJson(Map<String, Object?> json) {
+    return FacilityReportResult(
+      id: _requiredReportString(json, 'id'),
+      stationId: _requiredReportString(json, 'stationId'),
+      facilityId: _requiredReportString(json, 'facilityId'),
+      reportType: _requiredReportString(json, 'reportType'),
+      description: _optionalReportString(json, 'description'),
+      status: _requiredReportString(json, 'status'),
+      createdAt: _requiredReportString(json, 'createdAt'),
+    );
+  }
+
+  final String id;
+  final String stationId;
+  final String facilityId;
+  final String reportType;
+  final String description;
+  final String status;
+  final String createdAt;
+
+  String get statusLabel {
+    return switch (status) {
+      'SUBMITTED' => '접수됨',
+      'UNDER_REVIEW' => '확인 중',
+      'ACCEPTED' => '반영됨',
+      'REJECTED' => '반려됨',
+      'DUPLICATE' => '중복 신고',
+      'RESOLVED' => '처리 완료',
+      _ => '접수 상태 확인 필요',
+    };
+  }
+}
+
+class FacilityReportTarget {
+  const FacilityReportTarget({
+    required this.stationId,
+    required this.stationName,
+    required this.facilityId,
+    required this.facilityName,
+    required this.facilityTypeLabel,
+    required this.facilityStatusLabel,
+  });
+
+  final String stationId;
+  final String stationName;
+  final String facilityId;
+  final String facilityName;
+  final String facilityTypeLabel;
+  final String facilityStatusLabel;
+}
+
+enum FacilityReportTypeOption {
+  broken,
+  underConstruction,
+  closed,
+  locationWrong,
+  informationWrong,
+  recovered,
+}
+
+extension FacilityReportTypeOptionLabel on FacilityReportTypeOption {
+  String get reportType {
+    return switch (this) {
+      FacilityReportTypeOption.broken => 'BROKEN',
+      FacilityReportTypeOption.underConstruction => 'UNDER_CONSTRUCTION',
+      FacilityReportTypeOption.closed => 'CLOSED',
+      FacilityReportTypeOption.locationWrong => 'LOCATION_WRONG',
+      FacilityReportTypeOption.informationWrong => 'INFORMATION_WRONG',
+      FacilityReportTypeOption.recovered => 'RECOVERED',
+    };
+  }
+
+  String get label {
+    return switch (this) {
+      FacilityReportTypeOption.broken => '고장',
+      FacilityReportTypeOption.underConstruction => '공사 중',
+      FacilityReportTypeOption.closed => '폐쇄',
+      FacilityReportTypeOption.locationWrong => '위치가 달라요',
+      FacilityReportTypeOption.informationWrong => '정보가 달라요',
+      FacilityReportTypeOption.recovered => '다시 정상',
+    };
+  }
+
+  IconData get icon {
+    return switch (this) {
+      FacilityReportTypeOption.broken => Icons.warning_amber_rounded,
+      FacilityReportTypeOption.underConstruction => Icons.construction,
+      FacilityReportTypeOption.closed => Icons.block,
+      FacilityReportTypeOption.locationWrong => Icons.wrong_location_outlined,
+      FacilityReportTypeOption.informationWrong => Icons.edit_note,
+      FacilityReportTypeOption.recovered => Icons.check_circle_outline,
+    };
+  }
+}
+
+enum FacilityReportViewStatus { idle, loading, success, failure }
+
+class FacilityReportState {
+  const FacilityReportState({
+    required this.status,
+    this.message = '',
+    this.result,
+  });
+
+  const FacilityReportState.idle()
+    : status = FacilityReportViewStatus.idle,
+      message = '',
+      result = null;
+
+  final FacilityReportViewStatus status;
+  final String message;
+  final FacilityReportResult? result;
+}
+
+class FacilityReportController extends ChangeNotifier {
+  FacilityReportController({required this.repository});
+
+  final FacilityReportRepository repository;
+
+  FacilityReportState _state = const FacilityReportState.idle();
+  bool _disposed = false;
+
+  FacilityReportState get state => _state;
+
+  Future<void> submit({
+    required FacilityReportTarget target,
+    required FacilityReportTypeOption selectedType,
+    required String description,
+  }) async {
+    if (_disposed || _state.status == FacilityReportViewStatus.loading) {
+      return;
+    }
+
+    _emitState(
+      const FacilityReportState(
+        status: FacilityReportViewStatus.loading,
+        message: '신고 보내는 중',
+      ),
+    );
+
+    try {
+      final result = await repository.createReport(
+        FacilityReportRequest(
+          userId: _anonymousReportUserId,
+          stationId: target.stationId,
+          facilityId: target.facilityId,
+          reportType: selectedType.reportType,
+          description: description,
+        ),
+      );
+      _emitState(
+        FacilityReportState(
+          status: FacilityReportViewStatus.success,
+          message: '신고가 접수되었습니다.',
+          result: result,
+        ),
+      );
+    } on FacilityReportException catch (error) {
+      _emitState(
+        FacilityReportState(
+          status: FacilityReportViewStatus.failure,
+          message: error.message,
+        ),
+      );
+    } catch (_) {
+      _emitState(
+        const FacilityReportState(
+          status: FacilityReportViewStatus.failure,
+          message: _facilityReportErrorMessage,
+        ),
+      );
+    }
+  }
+
+  void _emitState(FacilityReportState nextState) {
+    if (_disposed) {
+      return;
+    }
+    _state = nextState;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+}
+
+class FacilityReportScreen extends StatefulWidget {
+  const FacilityReportScreen({
+    required this.repository,
+    required this.target,
+    super.key,
+  });
+
+  final FacilityReportRepository repository;
+  final FacilityReportTarget target;
+
+  @override
+  State<FacilityReportScreen> createState() => _FacilityReportScreenState();
+}
+
+class _FacilityReportScreenState extends State<FacilityReportScreen> {
+  late final FacilityReportController _controller;
+  final TextEditingController _descriptionController = TextEditingController();
+  FacilityReportTypeOption _selectedType = FacilityReportTypeOption.broken;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = FacilityReportController(repository: widget.repository)
+      ..addListener(_onReportStateChanged);
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_onReportStateChanged);
+    _controller.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = _controller.state;
+    final isLoading = state.status == FacilityReportViewStatus.loading;
+    final isSuccess = state.status == FacilityReportViewStatus.success;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('시설 신고')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          children: [
+            _FacilityReportHeader(target: widget.target),
+            const SizedBox(height: 24),
+            const _FacilityReportSectionTitle(title: '무엇을 알려드릴까요?'),
+            const SizedBox(height: 12),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final cardWidth = (constraints.maxWidth - 10) / 2;
+                return Wrap(
+                  spacing: 10,
+                  runSpacing: 10,
+                  children: [
+                    for (final option in FacilityReportTypeOption.values)
+                      SizedBox(
+                        width: cardWidth,
+                        child: _FacilityReportTypeCard(
+                          option: option,
+                          selected: option == _selectedType,
+                          onTap: isLoading || isSuccess
+                              ? null
+                              : () => setState(() => _selectedType = option),
+                        ),
+                      ),
+                  ],
+                );
+              },
+            ),
+            const SizedBox(height: 20),
+            TextField(
+              key: const Key('facilityReportDescriptionInput'),
+              controller: _descriptionController,
+              enabled: !isLoading && !isSuccess,
+              minLines: 3,
+              maxLines: 5,
+              textInputAction: TextInputAction.newline,
+              style: const TextStyle(fontSize: 18, height: 1.35),
+              decoration: const InputDecoration(
+                labelText: '내용',
+                hintText: '상황을 짧게 적어 주세요',
+                floatingLabelBehavior: FloatingLabelBehavior.always,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(8)),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            if (state.message.isNotEmpty) _FacilityReportMessage(state: state),
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              key: const Key('facilityReportSubmitButton'),
+              onPressed: isLoading || isSuccess ? null : _submit,
+              icon: isLoading
+                  ? const SizedBox(
+                      width: 22,
+                      height: 22,
+                      child: CircularProgressIndicator(strokeWidth: 2.5),
+                    )
+                  : const Icon(Icons.send),
+              label: Text(isSuccess ? '접수 완료' : '신고 보내기'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _onReportStateChanged() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  void _submit() {
+    _controller.submit(
+      target: widget.target,
+      selectedType: _selectedType,
+      description: _descriptionController.text,
+    );
+  }
+}
+
+class _FacilityReportHeader extends StatelessWidget {
+  const _FacilityReportHeader({required this.target});
+
+  final FacilityReportTarget target;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Semantics(
+      label:
+          '${target.stationName}역, ${target.facilityName}, ${target.facilityTypeLabel}, 현재 ${target.facilityStatusLabel}',
+      header: true,
+      child: ExcludeSemantics(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '${target.stationName}역',
+              style: textTheme.headlineSmall?.copyWith(
+                color: const Color(0xFF102A2C),
+                fontWeight: FontWeight.w900,
+                height: 1.2,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              target.facilityName,
+              style: textTheme.titleLarge?.copyWith(
+                color: const Color(0xFF102A2C),
+                fontWeight: FontWeight.w800,
+                height: 1.25,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '${target.facilityTypeLabel} · ${target.facilityStatusLabel}',
+              style: textTheme.bodyLarge?.copyWith(
+                color: const Color(0xFF29484B),
+                fontWeight: FontWeight.w700,
+                height: 1.3,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FacilityReportSectionTitle extends StatelessWidget {
+  const _FacilityReportSectionTitle({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      header: true,
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+          color: const Color(0xFF102A2C),
+          fontWeight: FontWeight.w900,
+          height: 1.25,
+        ),
+      ),
+    );
+  }
+}
+
+class _FacilityReportTypeCard extends StatelessWidget {
+  const _FacilityReportTypeCard({
+    required this.option,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final FacilityReportTypeOption option;
+  final bool selected;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = selected ? const Color(0xFF006D77) : const Color(0xFFD5E2E4);
+    final textColor = selected ? Colors.white : const Color(0xFF102A2C);
+    final semanticsLabel = '${option.label} ${selected ? '선택됨' : '선택 가능'}';
+
+    return Semantics(
+      label: semanticsLabel,
+      button: true,
+      selected: selected,
+      onTap: onTap,
+      child: ExcludeSemantics(
+        child: Material(
+          color: selected ? color : Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+            side: BorderSide(color: color, width: 1.5),
+          ),
+          child: InkWell(
+            key: Key('facilityReportType-${option.reportType}'),
+            borderRadius: BorderRadius.circular(8),
+            onTap: onTap,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 72),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 12,
+                ),
+                child: Row(
+                  children: [
+                    Icon(option.icon, color: textColor, size: 28),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        option.label,
+                        style: Theme.of(context).textTheme.titleMedium
+                            ?.copyWith(
+                              color: textColor,
+                              fontWeight: FontWeight.w900,
+                              height: 1.25,
+                            ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FacilityReportMessage extends StatelessWidget {
+  const _FacilityReportMessage({required this.state});
+
+  final FacilityReportState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final isFailure = state.status == FacilityReportViewStatus.failure;
+    final color = isFailure ? const Color(0xFF8A4B00) : const Color(0xFF006D77);
+    final icon = isFailure ? Icons.error_outline : Icons.check_circle_outline;
+
+    return Semantics(
+      label: state.message,
+      liveRegion: true,
+      child: ExcludeSemantics(
+        child: Row(
+          children: [
+            Icon(icon, color: color, size: 26),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                state.message,
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: const Color(0xFF102A2C),
+                  fontWeight: FontWeight.w800,
+                  height: 1.3,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+String _requiredReportString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is String && value.trim().isNotEmpty) {
+    return value;
+  }
+  throw FormatException('Missing required report field: $key');
+}
+
+String _optionalReportString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is String) {
+    return value;
+  }
+  return '';
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'facility_report.dart';
 import 'mobility_profile.dart';
 import 'route_search.dart';
 import 'station_search.dart';
@@ -11,16 +12,21 @@ void main() {
 class EasySubwayApp extends StatelessWidget {
   EasySubwayApp({
     StationSearchRepository? repository,
+    FacilityReportRepository? reportRepository,
     RouteSearchRepository? routeRepository,
     super.key,
   }) : repository =
            repository ??
            StationSearchApiRepository(baseUri: defaultStationApiBaseUri()),
+       reportRepository =
+           reportRepository ??
+           FacilityReportApiRepository(baseUri: defaultStationApiBaseUri()),
        routeRepository =
            routeRepository ??
            RouteSearchApiRepository(baseUri: defaultStationApiBaseUri());
 
   final StationSearchRepository repository;
+  final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
 
   @override
@@ -68,6 +74,7 @@ class EasySubwayApp extends StatelessWidget {
       ),
       home: HomeScreen(
         repository: repository,
+        reportRepository: reportRepository,
         routeRepository: routeRepository,
       ),
     );
@@ -77,11 +84,13 @@ class EasySubwayApp extends StatelessWidget {
 class HomeScreen extends StatelessWidget {
   const HomeScreen({
     required this.repository,
+    required this.reportRepository,
     required this.routeRepository,
     super.key,
   });
 
   final StationSearchRepository repository;
+  final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
 
   @override
@@ -111,7 +120,10 @@ class HomeScreen extends StatelessWidget {
               onPressed: () {
                 Navigator.of(context).push(
                   MaterialPageRoute<void>(
-                    builder: (_) => StationSearchScreen(repository: repository),
+                    builder: (_) => StationSearchScreen(
+                      repository: repository,
+                      reportRepository: reportRepository,
+                    ),
                   ),
                 );
               },

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+import 'facility_report.dart';
+
 const _stationSearchTimeout = Duration(seconds: 8);
 const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
 
@@ -674,9 +676,14 @@ class StationDetailController extends ChangeNotifier {
 }
 
 class StationSearchScreen extends StatefulWidget {
-  const StationSearchScreen({required this.repository, super.key});
+  const StationSearchScreen({
+    required this.repository,
+    required this.reportRepository,
+    super.key,
+  });
 
   final StationSearchRepository repository;
+  final FacilityReportRepository reportRepository;
 
   @override
   State<StationSearchScreen> createState() => _StationSearchScreenState();
@@ -771,6 +778,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       MaterialPageRoute<void>(
         builder: (_) => StationDetailScreen(
           repository: widget.repository,
+          reportRepository: widget.reportRepository,
           stationId: result.id,
         ),
       ),
@@ -923,11 +931,13 @@ class _StationSearchResultTile extends StatelessWidget {
 class StationDetailScreen extends StatefulWidget {
   const StationDetailScreen({
     required this.repository,
+    required this.reportRepository,
     required this.stationId,
     super.key,
   });
 
   final StationSearchRepository repository;
+  final FacilityReportRepository reportRepository;
   final String stationId;
 
   @override
@@ -958,7 +968,10 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
         child: AnimatedBuilder(
           animation: _controller,
           builder: (context, _) {
-            return _StationDetailBody(state: _controller.state);
+            return _StationDetailBody(
+              state: _controller.state,
+              reportRepository: widget.reportRepository,
+            );
           },
         ),
       ),
@@ -967,9 +980,13 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
 }
 
 class _StationDetailBody extends StatelessWidget {
-  const _StationDetailBody({required this.state});
+  const _StationDetailBody({
+    required this.state,
+    required this.reportRepository,
+  });
 
   final StationDetailState state;
+  final FacilityReportRepository reportRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -987,6 +1004,7 @@ class _StationDetailBody extends StatelessWidget {
         detail: state.detail!,
         exits: state.exits,
         facilities: state.facilities,
+        reportRepository: reportRepository,
       ),
     };
   }
@@ -997,11 +1015,13 @@ class _StationDetailContent extends StatelessWidget {
     required this.detail,
     required this.exits,
     required this.facilities,
+    required this.reportRepository,
   });
 
   final StationDetail detail;
   final List<StationExitInfo> exits;
   final List<StationFacilityInfo> facilities;
+  final FacilityReportRepository reportRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -1023,8 +1043,29 @@ class _StationDetailContent extends StatelessWidget {
           const _StationDetailEmptyMessage(message: '시설 정보가 아직 없습니다.')
         else
           for (final facility in facilities)
-            _StationFacilityCard(facility: facility),
+            _StationFacilityCard(
+              facility: facility,
+              onReportTap: () => _openFacilityReport(context, facility),
+            ),
       ],
+    );
+  }
+
+  void _openFacilityReport(BuildContext context, StationFacilityInfo facility) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => FacilityReportScreen(
+          repository: reportRepository,
+          target: FacilityReportTarget(
+            stationId: detail.id,
+            stationName: detail.nameKo,
+            facilityId: facility.id,
+            facilityName: facility.name,
+            facilityTypeLabel: facility.typeLabel,
+            facilityStatusLabel: facility.statusLabel,
+          ),
+        ),
+      ),
     );
   }
 }
@@ -1213,70 +1254,87 @@ class _StationExitCard extends StatelessWidget {
 }
 
 class _StationFacilityCard extends StatelessWidget {
-  const _StationFacilityCard({required this.facility});
+  const _StationFacilityCard({
+    required this.facility,
+    required this.onReportTap,
+  });
 
   final StationFacilityInfo facility;
+  final VoidCallback onReportTap;
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
 
-    return MergeSemantics(
-      child: Semantics(
-        label: facility.semanticLabel,
-        child: ExcludeSemantics(
-          child: Card(
-            margin: const EdgeInsets.only(bottom: 12),
-            color: Colors.white,
-            elevation: 0,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-              side: const BorderSide(color: Color(0xFFD5E2E4)),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+    return Semantics(
+      container: true,
+      explicitChildNodes: true,
+      label: facility.semanticLabel,
+      child: Card(
+        margin: const EdgeInsets.only(bottom: 12),
+        color: Colors.white,
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+          side: const BorderSide(color: Color(0xFFD5E2E4)),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                facility.name,
+                style: textTheme.titleMedium?.copyWith(
+                  color: const Color(0xFF102A2C),
+                  fontWeight: FontWeight.w900,
+                  height: 1.25,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
                 children: [
-                  Text(
-                    facility.name,
-                    style: textTheme.titleMedium?.copyWith(
-                      color: const Color(0xFF102A2C),
-                      fontWeight: FontWeight.w900,
-                      height: 1.25,
-                    ),
-                  ),
-                  const SizedBox(height: 10),
-                  Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    children: [
-                      _StationDetailTextPill(text: facility.typeLabel),
-                      _StationDetailTextPill(text: facility.statusLabel),
-                    ],
-                  ),
-                  const SizedBox(height: 12),
-                  _StationDetailInfoRow(
-                    icon: Icons.place_outlined,
-                    text: facility.locationLabel,
-                  ),
-                  const SizedBox(height: 6),
-                  _StationDetailInfoRow(
-                    icon: Icons.event_available,
-                    text: facility.updatedLabel,
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    facility.confidenceLabel,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: const Color(0xFF405A5D),
-                      fontWeight: FontWeight.w700,
-                      height: 1.3,
-                    ),
-                  ),
+                  _StationDetailTextPill(text: facility.typeLabel),
+                  _StationDetailTextPill(text: facility.statusLabel),
                 ],
               ),
-            ),
+              const SizedBox(height: 12),
+              _StationDetailInfoRow(
+                icon: Icons.place_outlined,
+                text: facility.locationLabel,
+              ),
+              const SizedBox(height: 6),
+              _StationDetailInfoRow(
+                icon: Icons.event_available,
+                text: facility.updatedLabel,
+              ),
+              const SizedBox(height: 6),
+              Text(
+                facility.confidenceLabel,
+                style: textTheme.bodyMedium?.copyWith(
+                  color: const Color(0xFF405A5D),
+                  fontWeight: FontWeight.w700,
+                  height: 1.3,
+                ),
+              ),
+              const SizedBox(height: 14),
+              Semantics(
+                container: true,
+                label: '${facility.name} 상태 신고',
+                button: true,
+                onTap: onReportTap,
+                child: ExcludeSemantics(
+                  child: OutlinedButton.icon(
+                    key: Key('facilityReportButton-${facility.id}'),
+                    onPressed: onReportTap,
+                    icon: const Icon(Icons.report_outlined),
+                    label: const Text('상태 신고'),
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -1,0 +1,123 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:easysubway_mobile/facility_report.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('시설 신고 API 저장소는 백엔드 계약에 맞춰 신고를 전송한다', () async {
+    late Map<String, Object?> requestBody;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) async {
+      requestBody =
+          jsonDecode(await utf8.decodeStream(request)) as Map<String, Object?>;
+      request.response
+        ..statusCode = HttpStatus.created
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {
+              'id': 'report-1',
+              'stationId': 'station-sangnoksu',
+              'facilityId': 'facility-sangnoksu-elevator-1',
+              'reportType': 'BROKEN',
+              'description': '문이 열리지 않습니다.',
+              'status': 'SUBMITTED',
+              'createdAt': '2026-06-13T10:00:00',
+            },
+          }),
+        )
+        ..close();
+    });
+
+    final repository = FacilityReportApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    final result = await repository.createReport(
+      const FacilityReportRequest(
+        userId: 'anonymous-mobile-user',
+        stationId: 'station-sangnoksu',
+        facilityId: 'facility-sangnoksu-elevator-1',
+        reportType: 'BROKEN',
+        description: ' 문이 열리지 않습니다. ',
+      ),
+    );
+
+    expect(requestBody['stationId'], 'station-sangnoksu');
+    expect(requestBody['facilityId'], 'facility-sangnoksu-elevator-1');
+    expect(requestBody['reportType'], 'BROKEN');
+    expect(requestBody['description'], '문이 열리지 않습니다.');
+    expect(result.id, 'report-1');
+    expect(result.statusLabel, '접수됨');
+  });
+
+  test('시설 신고 컨트롤러는 전송 중 중복 제출을 막고 성공 상태를 알린다', () async {
+    final repository = PendingFacilityReportRepository();
+    final controller = FacilityReportController(repository: repository);
+    addTearDown(controller.dispose);
+
+    final target = _reportTarget();
+    final firstSubmit = controller.submit(
+      target: target,
+      selectedType: FacilityReportTypeOption.broken,
+      description: '문이 열리지 않습니다.',
+    );
+    final secondSubmit = controller.submit(
+      target: target,
+      selectedType: FacilityReportTypeOption.closed,
+      description: '다시 누른 요청',
+    );
+
+    expect(repository.requests, hasLength(1));
+    expect(controller.state.status, FacilityReportViewStatus.loading);
+
+    repository.complete();
+    await firstSubmit;
+    await secondSubmit;
+
+    expect(repository.requests, hasLength(1));
+    expect(controller.state.status, FacilityReportViewStatus.success);
+    expect(controller.state.message, '신고가 접수되었습니다.');
+  });
+}
+
+FacilityReportTarget _reportTarget() {
+  return const FacilityReportTarget(
+    stationId: 'station-sangnoksu',
+    stationName: '상록수',
+    facilityId: 'facility-sangnoksu-elevator-1',
+    facilityName: '1번 출구 엘리베이터',
+    facilityTypeLabel: '엘리베이터',
+    facilityStatusLabel: '정상',
+  );
+}
+
+class PendingFacilityReportRepository implements FacilityReportRepository {
+  final requests = <FacilityReportRequest>[];
+  final _completer = Completer<FacilityReportResult>();
+
+  @override
+  Future<FacilityReportResult> createReport(FacilityReportRequest request) {
+    requests.add(request);
+    return _completer.future;
+  }
+
+  void complete() {
+    _completer.complete(
+      const FacilityReportResult(
+        id: 'report-1',
+        stationId: 'station-sangnoksu',
+        facilityId: 'facility-sangnoksu-elevator-1',
+        reportType: 'BROKEN',
+        description: '문이 열리지 않습니다.',
+        status: 'SUBMITTED',
+        createdAt: '2026-06-13T10:00:00',
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:easysubway_mobile/main.dart';
+import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/route_search.dart';
 import 'package:easysubway_mobile/station_search.dart';
 import 'package:flutter/material.dart';
@@ -14,6 +15,7 @@ void main() {
       await tester.pumpWidget(
         EasySubwayApp(
           repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
           routeRepository: FakeRouteSearchRepository(),
         ),
       );
@@ -83,6 +85,7 @@ void main() {
       await tester.pumpWidget(
         EasySubwayApp(
           repository: repository,
+          reportRepository: FakeFacilityReportRepository(),
           routeRepository: FakeRouteSearchRepository(),
         ),
       );
@@ -188,6 +191,7 @@ void main() {
       await tester.pumpWidget(
         EasySubwayApp(
           repository: repository,
+          reportRepository: FakeFacilityReportRepository(),
           routeRepository: FakeRouteSearchRepository(),
         ),
       );
@@ -238,6 +242,14 @@ void main() {
         ),
         findsOneWidget,
       );
+      await tester.ensureVisible(
+        find.byKey(
+          const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.widgetWithText(OutlinedButton, '상태 신고'), findsOneWidget);
+      expect(find.bySemanticsLabel('1번 출구 엘리베이터 상태 신고'), findsOneWidget);
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
@@ -253,6 +265,7 @@ void main() {
     await tester.pumpWidget(
       EasySubwayApp(
         repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
         routeRepository: FakeRouteSearchRepository(),
       ),
     );
@@ -286,6 +299,7 @@ void main() {
       await tester.pumpWidget(
         EasySubwayApp(
           repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
           routeRepository: FakeRouteSearchRepository(),
         ),
       );
@@ -348,6 +362,7 @@ void main() {
       await tester.pumpWidget(
         EasySubwayApp(
           repository: stationRepository,
+          reportRepository: FakeFacilityReportRepository(),
           routeRepository: routeRepository,
         ),
       );
@@ -453,6 +468,7 @@ void main() {
     await tester.pumpWidget(
       EasySubwayApp(
         repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
         routeRepository: routeRepository,
       ),
     );
@@ -487,6 +503,7 @@ void main() {
     await tester.pumpWidget(
       EasySubwayApp(
         repository: stationRepository,
+        reportRepository: FakeFacilityReportRepository(),
         routeRepository: routeRepository,
       ),
     );
@@ -564,6 +581,7 @@ void main() {
       await tester.pumpWidget(
         EasySubwayApp(
           repository: stationRepository,
+          reportRepository: FakeFacilityReportRepository(),
           routeRepository: routeRepository,
         ),
       );
@@ -623,6 +641,101 @@ void main() {
         find.byKey(const Key('routeSearchSubmitButton')),
       );
       expect(completedButton.onPressed, isNotNull);
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
+  testWidgets('시설 신고 화면은 신고 유형과 내용을 보내고 접수 결과를 보여준다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final reportRepository = FakeFacilityReportRepository();
+    final stationRepository = FakeStationSearchRepository(
+      nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      stationFacilities: const [
+        StationFacilityInfo(
+          id: 'facility-sangnoksu-elevator-1',
+          stationId: 'station-sangnoksu',
+          exitId: 'exit-sangnoksu-1',
+          type: 'ELEVATOR',
+          name: '1번 출구 엘리베이터',
+          floorFrom: 'B1',
+          floorTo: '1F',
+          description: '1번 출구 앞',
+          status: 'NORMAL',
+          dataConfidence: 'HIGH',
+          lastUpdatedAt: '2026-06-12',
+        ),
+      ],
+    );
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: stationRepository,
+          reportRepository: reportRepository,
+          routeRepository: FakeRouteSearchRepository(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('stationSearchButton')));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('stationSearchInput')),
+        '상록수',
+      );
+      await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+      );
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(
+        find.byKey(
+          const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(
+          const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('시설 신고'), findsOneWidget);
+      expect(find.text('상록수역'), findsOneWidget);
+      expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
+      expect(find.text('무엇을 알려드릴까요?'), findsOneWidget);
+      expect(find.bySemanticsLabel('고장 선택됨'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('facilityReportType-CLOSED')));
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(
+        find.byKey(const Key('facilityReportDescriptionInput')),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('facilityReportDescriptionInput')),
+        '출입문이 막혀 있습니다.',
+      );
+      await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
+      await tester.pumpAndSettle();
+
+      expect(reportRepository.requests, hasLength(1));
+      expect(reportRepository.requests.single.stationId, 'station-sangnoksu');
+      expect(
+        reportRepository.requests.single.facilityId,
+        'facility-sangnoksu-elevator-1',
+      );
+      expect(reportRepository.requests.single.reportType, 'CLOSED');
+      expect(reportRepository.requests.single.description, '출입문이 막혀 있습니다.');
+      expect(find.text('신고가 접수되었습니다.'), findsOneWidget);
+      expect(find.bySemanticsLabel('신고가 접수되었습니다.'), findsOneWidget);
+
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
     } finally {
       semanticsHandle.dispose();
     }
@@ -714,6 +827,31 @@ class FakeRouteSearchRepository implements RouteSearchRepository {
   Future<RouteSearchResult> searchRoute(RouteSearchRequest request) async {
     requests.add(request);
     return _sampleRouteSearchResult();
+  }
+}
+
+class FakeFacilityReportRepository implements FacilityReportRepository {
+  final requests = <FacilityReportRequest>[];
+  Object? error;
+
+  @override
+  Future<FacilityReportResult> createReport(
+    FacilityReportRequest request,
+  ) async {
+    requests.add(request);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return FacilityReportResult(
+      id: 'report-${requests.length}',
+      stationId: request.stationId,
+      facilityId: request.facilityId,
+      reportType: request.reportType,
+      description: request.description,
+      status: 'SUBMITTED',
+      createdAt: '2026-06-13T10:00:00',
+    );
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

close #38

## 배경

역 상세 화면에서 시설 상태를 볼 수 있지만 현장 상태가 다를 때 사용자가 바로 신고할 방법이 없었다. 엘리베이터 고장, 공사, 폐쇄는 이동 가능 여부에 직접 영향을 주므로 시설 카드에서 신고 접수까지 이어지는 모바일 흐름을 추가한다.

## 변경 사항

- 시설 신고 API 저장소와 신고 요청/응답 모델을 추가했다.
- 역 상세 시설 카드에 `상태 신고` 버튼을 추가했다.
- 시설 신고 화면을 추가해 신고 유형 선택, 내용 입력, 전송, 성공/실패 상태를 처리한다.
- 신고 유형 선택 카드는 두 열로 배치해 작은 화면에서도 입력칸까지 접근하기 쉽게 구성했다.
- 전송 중에는 중복 제출을 막고, 실패 시 같은 화면에서 다시 시도할 수 있게 했다.
- TalkBack/VoiceOver가 시설 신고 버튼, 신고 유형 선택, 접수 결과를 읽을 수 있도록 semantics를 추가했다.

## 검증

- `flutter analyze`
- `flutter test`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`
- Android debug build: `flutter build apk --debug`
- Android emulator: APK 설치, 앱 실행, 홈 UI 트리 및 스크린샷 확인
- iOS simulator build: `flutter build ios --simulator --no-codesign`
- iOS simulator: 앱 설치, 실행, 홈 스크린샷 확인

## 리스크

- 사진 첨부와 현재 위치 첨부는 포함하지 않았다.
- 실제 신고 접수는 백엔드 `/api/v1/reports` 응답에 의존한다.
