### PR TITLE
[Feat] 즐겨찾기 역 화면 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,21 +67,27 @@ jobs:
     name: Repository CI
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
 
     steps:
+      - name: Repository CI / Skip unchanged area
+        if: ${{ needs.changes.outputs.repository != 'true' && needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.ci != 'true' }}
+        run: echo "No repository, docs-only, or CI changes; skipping repository checks."
+
       - name: Repository CI / Checkout repository
+        if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Repository CI / Set up Node.js
+        if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
 
       - name: Repository CI / Validate whitespace
+        if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -92,15 +98,19 @@ jobs:
           fi
 
       - name: Repository CI / Run contract tests
+        if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         run: node --test tools/ci/*.test.mjs
 
       - name: Repository CI / Validate Docker Compose config
+        if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         run: docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet
 
       - name: Repository CI / Validate issue forms
+        if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         run: ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/ISSUE_TEMPLATE/*.yml
 
       - name: Repository CI / Validate tracked Markdown policy
+        if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -112,6 +122,7 @@ jobs:
           fi
 
       - name: Repository CI / Validate local agent docs are not tracked
+        if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -126,15 +137,20 @@ jobs:
     name: Backend CI
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.backend == 'true' }}
 
     steps:
+      - name: Backend CI / Skip unchanged area
+        if: ${{ needs.changes.outputs.backend != 'true' }}
+        run: echo "No backend changes; skipping backend checks."
+
       - name: Backend CI / Checkout repository
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: Backend CI / Detect backend scaffold
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         id: scaffold
         shell: bash
         run: |
@@ -148,7 +164,7 @@ jobs:
           fi
 
       - name: Backend CI / Set up Java
-        if: ${{ steps.scaffold.outputs.present == 'true' }}
+        if: ${{ needs.changes.outputs.backend == 'true' && steps.scaffold.outputs.present == 'true' }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: temurin
@@ -156,7 +172,7 @@ jobs:
           cache: gradle
 
       - name: Backend CI / Run Gradle checks
-        if: ${{ steps.scaffold.outputs.present == 'true' }}
+        if: ${{ needs.changes.outputs.backend == 'true' && steps.scaffold.outputs.present == 'true' }}
         working-directory: backend
         run: ./gradlew check --no-daemon
 
@@ -164,15 +180,20 @@ jobs:
     name: Mobile App CI
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.mobile == 'true' }}
 
     steps:
+      - name: Mobile App CI / Skip unchanged area
+        if: ${{ needs.changes.outputs.mobile != 'true' }}
+        run: echo "No mobile app changes; skipping mobile checks."
+
       - name: Mobile App CI / Checkout repository
+        if: ${{ needs.changes.outputs.mobile == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: Mobile App CI / Detect Flutter scaffold
+        if: ${{ needs.changes.outputs.mobile == 'true' }}
         id: scaffold
         shell: bash
         run: |
@@ -185,14 +206,14 @@ jobs:
           fi
 
       - name: Mobile App CI / Set up Flutter
-        if: ${{ steps.scaffold.outputs.present == 'true' }}
+        if: ${{ needs.changes.outputs.mobile == 'true' && steps.scaffold.outputs.present == 'true' }}
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
           cache: true
 
       - name: Mobile App CI / Run Flutter analyzer and tests
-        if: ${{ steps.scaffold.outputs.present == 'true' }}
+        if: ${{ needs.changes.outputs.mobile == 'true' && steps.scaffold.outputs.present == 'true' }}
         working-directory: apps/mobile
         shell: bash
         run: |
@@ -205,15 +226,20 @@ jobs:
     name: Android CI
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.android == 'true' }}
 
     steps:
+      - name: Android CI / Skip unchanged area
+        if: ${{ needs.changes.outputs.android != 'true' }}
+        run: echo "No Android changes; skipping Android checks."
+
       - name: Android CI / Checkout repository
+        if: ${{ needs.changes.outputs.android == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: Android CI / Detect Android scaffold
+        if: ${{ needs.changes.outputs.android == 'true' }}
         id: scaffold
         shell: bash
         run: |
@@ -226,7 +252,7 @@ jobs:
           fi
 
       - name: Android CI / Set up Java
-        if: ${{ steps.scaffold.outputs.present == 'true' }}
+        if: ${{ needs.changes.outputs.android == 'true' && steps.scaffold.outputs.present == 'true' }}
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: temurin
@@ -234,14 +260,14 @@ jobs:
           cache: gradle
 
       - name: Android CI / Set up Flutter
-        if: ${{ steps.scaffold.outputs.present == 'true' }}
+        if: ${{ needs.changes.outputs.android == 'true' && steps.scaffold.outputs.present == 'true' }}
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
           cache: true
 
       - name: Android CI / Build Flutter Android debug APK
-        if: ${{ steps.scaffold.outputs.present == 'true' }}
+        if: ${{ needs.changes.outputs.android == 'true' && steps.scaffold.outputs.present == 'true' }}
         working-directory: apps/mobile
         shell: bash
         run: |
@@ -253,15 +279,20 @@ jobs:
     name: iOS CI
     runs-on: macos-latest
     needs: changes
-    if: ${{ needs.changes.outputs.ios == 'true' }}
 
     steps:
+      - name: iOS CI / Skip unchanged area
+        if: ${{ needs.changes.outputs.ios != 'true' }}
+        run: echo "No iOS changes; skipping iOS checks."
+
       - name: iOS CI / Checkout repository
+        if: ${{ needs.changes.outputs.ios == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: iOS CI / Detect iOS scaffold
+        if: ${{ needs.changes.outputs.ios == 'true' }}
         id: scaffold
         shell: bash
         run: |
@@ -274,14 +305,14 @@ jobs:
           fi
 
       - name: iOS CI / Set up Flutter
-        if: ${{ steps.scaffold.outputs.present == 'true' }}
+        if: ${{ needs.changes.outputs.ios == 'true' && steps.scaffold.outputs.present == 'true' }}
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
           cache: true
 
       - name: iOS CI / Build Flutter iOS simulator app
-        if: ${{ steps.scaffold.outputs.present == 'true' }}
+        if: ${{ needs.changes.outputs.ios == 'true' && steps.scaffold.outputs.present == 'true' }}
         working-directory: apps/mobile
         shell: bash
         run: |

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -29,7 +29,7 @@ class EasySubwayApp extends StatelessWidget {
            favoriteRepository ??
            FavoriteStationApiRepository(
              baseUri: defaultStationApiBaseUri(),
-             credentials: const FavoriteStationCredentials.fromEnvironment(),
+             authProvider: const NoFavoriteStationAuthProvider(),
            );
 
   final StationSearchRepository repository;

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -14,6 +14,7 @@ class EasySubwayApp extends StatelessWidget {
     StationSearchRepository? repository,
     FacilityReportRepository? reportRepository,
     RouteSearchRepository? routeRepository,
+    FavoriteStationRepository? favoriteRepository,
     super.key,
   }) : repository =
            repository ??
@@ -23,11 +24,18 @@ class EasySubwayApp extends StatelessWidget {
            FacilityReportApiRepository(baseUri: defaultStationApiBaseUri()),
        routeRepository =
            routeRepository ??
-           RouteSearchApiRepository(baseUri: defaultStationApiBaseUri());
+           RouteSearchApiRepository(baseUri: defaultStationApiBaseUri()),
+       favoriteRepository =
+           favoriteRepository ??
+           FavoriteStationApiRepository(
+             baseUri: defaultStationApiBaseUri(),
+             credentials: const FavoriteStationCredentials.fromEnvironment(),
+           );
 
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
+  final FavoriteStationRepository favoriteRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -76,6 +84,7 @@ class EasySubwayApp extends StatelessWidget {
         repository: repository,
         reportRepository: reportRepository,
         routeRepository: routeRepository,
+        favoriteRepository: favoriteRepository,
       ),
     );
   }
@@ -86,12 +95,14 @@ class HomeScreen extends StatelessWidget {
     required this.repository,
     required this.reportRepository,
     required this.routeRepository,
+    required this.favoriteRepository,
     super.key,
   });
 
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
+  final FavoriteStationRepository favoriteRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -123,6 +134,7 @@ class HomeScreen extends StatelessWidget {
                     builder: (_) => StationSearchScreen(
                       repository: repository,
                       reportRepository: reportRepository,
+                      favoriteRepository: favoriteRepository,
                     ),
                   ),
                 );
@@ -145,6 +157,23 @@ class HomeScreen extends StatelessWidget {
               },
               icon: const Icon(Icons.route),
               label: const Text('경로 검색'),
+            ),
+            const SizedBox(height: 12),
+            FilledButton.icon(
+              key: const Key('favoriteStationsButton'),
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => FavoriteStationListScreen(
+                      repository: favoriteRepository,
+                      stationRepository: repository,
+                      reportRepository: reportRepository,
+                    ),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.star),
+              label: const Text('즐겨찾기'),
             ),
             const SizedBox(height: 12),
             OutlinedButton.icon(

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -14,7 +14,7 @@ class EasySubwayApp extends StatelessWidget {
     StationSearchRepository? repository,
     FacilityReportRepository? reportRepository,
     RouteSearchRepository? routeRepository,
-    FavoriteStationRepository? favoriteRepository,
+    this.favoriteRepository,
     super.key,
   }) : repository =
            repository ??
@@ -24,18 +24,12 @@ class EasySubwayApp extends StatelessWidget {
            FacilityReportApiRepository(baseUri: defaultStationApiBaseUri()),
        routeRepository =
            routeRepository ??
-           RouteSearchApiRepository(baseUri: defaultStationApiBaseUri()),
-       favoriteRepository =
-           favoriteRepository ??
-           FavoriteStationApiRepository(
-             baseUri: defaultStationApiBaseUri(),
-             authProvider: const NoFavoriteStationAuthProvider(),
-           );
+           RouteSearchApiRepository(baseUri: defaultStationApiBaseUri());
 
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
-  final FavoriteStationRepository favoriteRepository;
+  final FavoriteStationRepository? favoriteRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -102,11 +96,12 @@ class HomeScreen extends StatelessWidget {
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
-  final FavoriteStationRepository favoriteRepository;
+  final FavoriteStationRepository? favoriteRepository;
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final favoriteRepository = this.favoriteRepository;
 
     return Scaffold(
       appBar: AppBar(title: const Text('쉬운 지하철')),
@@ -159,23 +154,25 @@ class HomeScreen extends StatelessWidget {
               label: const Text('경로 검색'),
             ),
             const SizedBox(height: 12),
-            FilledButton.icon(
-              key: const Key('favoriteStationsButton'),
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => FavoriteStationListScreen(
-                      repository: favoriteRepository,
-                      stationRepository: repository,
-                      reportRepository: reportRepository,
+            if (favoriteRepository != null) ...[
+              FilledButton.icon(
+                key: const Key('favoriteStationsButton'),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => FavoriteStationListScreen(
+                        repository: favoriteRepository,
+                        stationRepository: repository,
+                        reportRepository: reportRepository,
+                      ),
                     ),
-                  ),
-                );
-              },
-              icon: const Icon(Icons.star),
-              label: const Text('즐겨찾기'),
-            ),
-            const SizedBox(height: 12),
+                  );
+                },
+                icon: const Icon(Icons.star),
+                label: const Text('즐겨찾기'),
+              ),
+              const SizedBox(height: 12),
+            ],
             OutlinedButton.icon(
               key: const Key('mobilityProfileButton'),
               onPressed: () {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -10,6 +10,7 @@ const _stationSearchTimeout = Duration(seconds: 8);
 const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
 const _favoriteStationTimeout = Duration(seconds: 8);
 const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했습니다.';
+const _favoriteStationStatusErrorMessage = '즐겨찾기를 확인하지 못했습니다.';
 const _favoriteStationChangeErrorMessage = '즐겨찾기를 바꾸지 못했습니다.';
 
 abstract class StationSearchRepository {
@@ -983,7 +984,7 @@ class FavoriteStationListController extends ChangeNotifier {
   }
 }
 
-enum StationFavoriteToggleStatus { ready, saving, removing, failure }
+enum StationFavoriteToggleStatus { checking, ready, saving, removing, failure }
 
 class StationFavoriteToggleState {
   const StationFavoriteToggleState({
@@ -996,11 +997,21 @@ class StationFavoriteToggleState {
     : status = StationFavoriteToggleStatus.ready,
       message = '';
 
+  const StationFavoriteToggleState.checking({required this.isFavorite})
+    : status = StationFavoriteToggleStatus.checking,
+      message = '';
+
   final StationFavoriteToggleStatus status;
   final bool isFavorite;
   final String message;
 
   bool get isBusy {
+    return status == StationFavoriteToggleStatus.checking ||
+        status == StationFavoriteToggleStatus.saving ||
+        status == StationFavoriteToggleStatus.removing;
+  }
+
+  bool get isChanging {
     return status == StationFavoriteToggleStatus.saving ||
         status == StationFavoriteToggleStatus.removing;
   }
@@ -1011,7 +1022,10 @@ class StationFavoriteToggleController extends ChangeNotifier {
     required this.repository,
     required this.stationId,
     bool initiallyFavorite = false,
-  }) : _state = StationFavoriteToggleState.ready(isFavorite: initiallyFavorite);
+    bool initiallyChecking = false,
+  }) : _state = initiallyChecking
+           ? StationFavoriteToggleState.checking(isFavorite: initiallyFavorite)
+           : StationFavoriteToggleState.ready(isFavorite: initiallyFavorite);
 
   final FavoriteStationRepository repository;
   final String stationId;
@@ -1020,6 +1034,28 @@ class StationFavoriteToggleController extends ChangeNotifier {
   bool _isDisposed = false;
 
   StationFavoriteToggleState get state => _state;
+
+  Future<void> load() async {
+    if (_state.isChanging) {
+      return;
+    }
+
+    _emitState(
+      StationFavoriteToggleState.checking(isFavorite: _state.isFavorite),
+    );
+
+    try {
+      final favorites = await repository.listFavoriteStations();
+      final isFavorite = favorites.any(
+        (favorite) => favorite.stationId == stationId,
+      );
+      _emitState(StationFavoriteToggleState.ready(isFavorite: isFavorite));
+    } on FavoriteStationException catch (error) {
+      _emitFailure(error.message);
+    } catch (_) {
+      _emitFailure(_favoriteStationStatusErrorMessage);
+    }
+  }
 
   Future<void> save() async {
     if (_state.isBusy) {
@@ -1106,13 +1142,13 @@ class StationSearchScreen extends StatefulWidget {
   const StationSearchScreen({
     required this.repository,
     required this.reportRepository,
-    required this.favoriteRepository,
+    this.favoriteRepository,
     super.key,
   });
 
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
-  final FavoriteStationRepository favoriteRepository;
+  final FavoriteStationRepository? favoriteRepository;
 
   @override
   State<StationSearchScreen> createState() => _StationSearchScreenState();
@@ -1202,11 +1238,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     _controller.search(query);
   }
 
-  Future<void> _openStationDetail(StationSearchResult result) async {
-    final initiallyFavorite = await _isFavoriteStation(result.id);
-    if (!mounted) {
-      return;
-    }
+  void _openStationDetail(StationSearchResult result) {
     Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (_) => StationDetailScreen(
@@ -1214,19 +1246,9 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
           reportRepository: widget.reportRepository,
           favoriteRepository: widget.favoriteRepository,
           stationId: result.id,
-          initiallyFavorite: initiallyFavorite,
         ),
       ),
     );
-  }
-
-  Future<bool> _isFavoriteStation(String stationId) async {
-    try {
-      final favorites = await widget.favoriteRepository.listFavoriteStations();
-      return favorites.any((favorite) => favorite.stationId == stationId);
-    } catch (_) {
-      return false;
-    }
   }
 }
 
@@ -1585,17 +1607,17 @@ class StationDetailScreen extends StatefulWidget {
   const StationDetailScreen({
     required this.repository,
     required this.reportRepository,
-    required this.favoriteRepository,
     required this.stationId,
-    this.initiallyFavorite = false,
+    this.favoriteRepository,
+    this.initiallyFavorite,
     super.key,
   });
 
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
-  final FavoriteStationRepository favoriteRepository;
+  final FavoriteStationRepository? favoriteRepository;
   final String stationId;
-  final bool initiallyFavorite;
+  final bool? initiallyFavorite;
 
   @override
   State<StationDetailScreen> createState() => _StationDetailScreenState();
@@ -1603,24 +1625,32 @@ class StationDetailScreen extends StatefulWidget {
 
 class _StationDetailScreenState extends State<StationDetailScreen> {
   late final StationDetailController _controller;
-  late final StationFavoriteToggleController _favoriteController;
+  StationFavoriteToggleController? _favoriteController;
 
   @override
   void initState() {
     super.initState();
     _controller = StationDetailController(repository: widget.repository);
-    _favoriteController = StationFavoriteToggleController(
-      repository: widget.favoriteRepository,
-      stationId: widget.stationId,
-      initiallyFavorite: widget.initiallyFavorite,
-    );
+    final favoriteRepository = widget.favoriteRepository;
+    if (favoriteRepository != null) {
+      final initiallyFavorite = widget.initiallyFavorite;
+      _favoriteController = StationFavoriteToggleController(
+        repository: favoriteRepository,
+        stationId: widget.stationId,
+        initiallyFavorite: initiallyFavorite ?? false,
+        initiallyChecking: initiallyFavorite == null,
+      );
+      if (initiallyFavorite == null) {
+        _favoriteController!.load();
+      }
+    }
     _controller.load(widget.stationId);
   }
 
   @override
   void dispose() {
     _controller.dispose();
-    _favoriteController.dispose();
+    _favoriteController?.dispose();
     super.dispose();
   }
 
@@ -1653,7 +1683,7 @@ class _StationDetailBody extends StatelessWidget {
 
   final StationDetailState state;
   final FacilityReportRepository reportRepository;
-  final StationFavoriteToggleController favoriteController;
+  final StationFavoriteToggleController? favoriteController;
 
   @override
   Widget build(BuildContext context) {
@@ -1691,7 +1721,7 @@ class _StationDetailContent extends StatelessWidget {
   final List<StationExitInfo> exits;
   final List<StationFacilityInfo> facilities;
   final FacilityReportRepository reportRepository;
-  final StationFavoriteToggleController favoriteController;
+  final StationFavoriteToggleController? favoriteController;
 
   @override
   Widget build(BuildContext context) {
@@ -1699,8 +1729,13 @@ class _StationDetailContent extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
       children: [
         _StationDetailHeader(detail: detail),
-        const SizedBox(height: 16),
-        _StationFavoriteControl(detail: detail, controller: favoriteController),
+        if (favoriteController != null) ...[
+          const SizedBox(height: 16),
+          _StationFavoriteControl(
+            detail: detail,
+            controller: favoriteController!,
+          ),
+        ],
         const SizedBox(height: 24),
         const _StationDetailSectionTitle(title: '출구'),
         const SizedBox(height: 12),
@@ -1811,7 +1846,11 @@ class _StationFavoriteControl extends StatelessWidget {
         final state = controller.state;
         final isFavorite = state.isFavorite;
         final label = _favoriteButtonLabel(state);
-        final actionLabel = isFavorite ? '즐겨찾기 해제' : '즐겨찾기 저장';
+        final actionLabel = state.status == StationFavoriteToggleStatus.checking
+            ? '즐겨찾기 확인 중'
+            : isFavorite
+            ? '즐겨찾기 해제'
+            : '즐겨찾기 저장';
         final onPressed = state.isBusy
             ? null
             : isFavorite
@@ -1858,6 +1897,7 @@ class _StationFavoriteControl extends StatelessWidget {
 
   String _favoriteButtonLabel(StationFavoriteToggleState state) {
     return switch (state.status) {
+      StationFavoriteToggleStatus.checking => '확인 중',
       StationFavoriteToggleStatus.saving => '저장 중',
       StationFavoriteToggleStatus.removing => '해제 중',
       StationFavoriteToggleStatus.ready ||

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -8,6 +8,9 @@ import 'facility_report.dart';
 
 const _stationSearchTimeout = Duration(seconds: 8);
 const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
+const _favoriteStationTimeout = Duration(seconds: 8);
+const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했습니다.';
+const _favoriteStationChangeErrorMessage = '즐겨찾기를 바꾸지 못했습니다.';
 
 abstract class StationSearchRepository {
   Future<List<StationSearchResult>> searchStations(String query);
@@ -151,6 +154,220 @@ class StationSearchException implements Exception {
 
   @override
   String toString() => message;
+}
+
+abstract class FavoriteStationRepository {
+  Future<List<FavoriteStation>> listFavoriteStations();
+
+  Future<FavoriteStation> saveFavoriteStation(String stationId);
+
+  Future<void> removeFavoriteStation(String stationId);
+}
+
+class FavoriteStationCredentials {
+  const FavoriteStationCredentials({
+    required this.username,
+    required this.password,
+  });
+
+  const FavoriteStationCredentials.fromEnvironment()
+    : username = const String.fromEnvironment('EASYSUBWAY_FAVORITE_USERNAME'),
+      password = const String.fromEnvironment('EASYSUBWAY_FAVORITE_PASSWORD');
+
+  final String username;
+  final String password;
+
+  String? get authorizationHeader {
+    // 즐겨찾기는 사용자별 데이터라 Basic 인증값을 빌드 환경에서 주입받아 요청에만 붙인다.
+    if (username.trim().isEmpty || password.isEmpty) {
+      return null;
+    }
+    final token = base64Encode(utf8.encode('${username.trim()}:$password'));
+    return 'Basic $token';
+  }
+}
+
+class FavoriteStationApiRepository implements FavoriteStationRepository {
+  FavoriteStationApiRepository({
+    required this.baseUri,
+    required this.credentials,
+    HttpClient? httpClient,
+  }) : _httpClient = httpClient ?? HttpClient();
+
+  final Uri baseUri;
+  final FavoriteStationCredentials credentials;
+  final HttpClient _httpClient;
+
+  @override
+  Future<List<FavoriteStation>> listFavoriteStations() async {
+    final data = await _requestData(
+      'GET',
+      baseUri.resolve('/api/v1/me/favorites/stations'),
+      errorMessage: _favoriteStationLoadErrorMessage,
+    );
+    if (data is! List) {
+      throw const FavoriteStationException(_favoriteStationLoadErrorMessage);
+    }
+
+    try {
+      return data
+          .map((item) {
+            if (item is! Map<String, Object?>) {
+              throw const FormatException('Invalid favorite station payload');
+            }
+            return FavoriteStation.fromJson(item);
+          })
+          .toList(growable: false);
+    } catch (_) {
+      throw const FavoriteStationException(_favoriteStationLoadErrorMessage);
+    }
+  }
+
+  @override
+  Future<FavoriteStation> saveFavoriteStation(String stationId) async {
+    final uri = baseUri.resolve(
+      '/api/v1/me/favorites/stations/${Uri.encodeComponent(stationId)}',
+    );
+    final data = await _requestData(
+      'PUT',
+      uri,
+      errorMessage: _favoriteStationChangeErrorMessage,
+    );
+    if (data is! Map<String, Object?>) {
+      throw const FavoriteStationException(_favoriteStationChangeErrorMessage);
+    }
+
+    try {
+      return FavoriteStation.fromJson(data);
+    } catch (_) {
+      throw const FavoriteStationException(_favoriteStationChangeErrorMessage);
+    }
+  }
+
+  @override
+  Future<void> removeFavoriteStation(String stationId) async {
+    final uri = baseUri.resolve(
+      '/api/v1/me/favorites/stations/${Uri.encodeComponent(stationId)}',
+    );
+    await _requestData(
+      'DELETE',
+      uri,
+      errorMessage: _favoriteStationChangeErrorMessage,
+    );
+  }
+
+  Future<Object?> _requestData(
+    String method,
+    Uri uri, {
+    required String errorMessage,
+  }) async {
+    try {
+      final request = await _httpClient
+          .openUrl(method, uri)
+          .timeout(_favoriteStationTimeout);
+      final authorizationHeader = credentials.authorizationHeader;
+      if (authorizationHeader != null) {
+        request.headers.set(
+          HttpHeaders.authorizationHeader,
+          authorizationHeader,
+        );
+      }
+
+      final response = await request.close().timeout(_favoriteStationTimeout);
+      final body = await utf8
+          .decodeStream(response)
+          .timeout(_favoriteStationTimeout);
+
+      if (response.statusCode < HttpStatus.ok ||
+          response.statusCode >= HttpStatus.multipleChoices) {
+        throw FavoriteStationException(errorMessage);
+      }
+
+      final decoded = jsonDecode(body);
+      if (decoded is! Map<String, Object?> || decoded['success'] != true) {
+        throw FavoriteStationException(errorMessage);
+      }
+      return decoded['data'];
+    } on FavoriteStationException {
+      rethrow;
+    } catch (_) {
+      throw FavoriteStationException(errorMessage);
+    }
+  }
+}
+
+class FavoriteStationException implements Exception {
+  const FavoriteStationException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class FavoriteStation {
+  const FavoriteStation({
+    required this.userId,
+    required this.stationId,
+    required this.nameKo,
+    required this.nameEn,
+    required this.region,
+    required this.dataQualityLevel,
+    required this.lastVerifiedAt,
+    required this.lines,
+    required this.addedAt,
+  });
+
+  factory FavoriteStation.fromJson(Map<String, Object?> json) {
+    final rawLines = json['lines'];
+    if (rawLines is! List) {
+      throw const FormatException('Invalid favorite station lines payload');
+    }
+
+    return FavoriteStation(
+      userId: _requiredString(json, 'userId'),
+      stationId: _requiredString(json, 'stationId'),
+      nameKo: _requiredString(json, 'nameKo'),
+      nameEn: _requiredString(json, 'nameEn'),
+      region: _requiredString(json, 'region'),
+      dataQualityLevel: _requiredString(json, 'dataQualityLevel'),
+      lastVerifiedAt: _requiredString(json, 'lastVerifiedAt'),
+      lines: rawLines
+          .map((item) {
+            if (item is! Map<String, Object?>) {
+              throw const FormatException(
+                'Invalid favorite station line payload',
+              );
+            }
+            return StationSearchLine.fromJson(item);
+          })
+          .toList(growable: false),
+      addedAt: _requiredString(json, 'addedAt'),
+    );
+  }
+
+  final String userId;
+  final String stationId;
+  final String nameKo;
+  final String nameEn;
+  final String region;
+  final String dataQualityLevel;
+  final String lastVerifiedAt;
+  final List<StationSearchLine> lines;
+  final String addedAt;
+
+  String get dataQualityLabel => _dataQualityLabel(dataQualityLevel);
+
+  String get lineLabel {
+    if (lines.isEmpty) {
+      return '노선 정보 없음';
+    }
+    return lines.map((line) => line.name).join(', ');
+  }
+
+  String get semanticLabel {
+    return '즐겨찾기 역, $nameKo, $lineLabel, $region, $dataQualityLabel';
+  }
 }
 
 class StationSearchResult {
@@ -675,15 +892,217 @@ class StationDetailController extends ChangeNotifier {
   }
 }
 
+enum FavoriteStationListStatus { loading, success, empty, failure }
+
+class FavoriteStationListState {
+  const FavoriteStationListState({
+    required this.status,
+    this.favorites = const [],
+    this.message = '',
+  });
+
+  const FavoriteStationListState.loading()
+    : status = FavoriteStationListStatus.loading,
+      favorites = const [],
+      message = '';
+
+  final FavoriteStationListStatus status;
+  final List<FavoriteStation> favorites;
+  final String message;
+}
+
+class FavoriteStationListController extends ChangeNotifier {
+  FavoriteStationListController({required this.repository});
+
+  final FavoriteStationRepository repository;
+
+  FavoriteStationListState _state = const FavoriteStationListState.loading();
+  bool _isDisposed = false;
+
+  FavoriteStationListState get state => _state;
+
+  Future<void> load() async {
+    _emitState(const FavoriteStationListState.loading());
+
+    try {
+      final favorites = await repository.listFavoriteStations();
+      if (favorites.isEmpty) {
+        _emitState(
+          const FavoriteStationListState(
+            status: FavoriteStationListStatus.empty,
+            message: '저장한 역이 없습니다.',
+          ),
+        );
+      } else {
+        _emitState(
+          FavoriteStationListState(
+            status: FavoriteStationListStatus.success,
+            favorites: favorites,
+          ),
+        );
+      }
+    } on FavoriteStationException catch (error) {
+      _emitState(
+        FavoriteStationListState(
+          status: FavoriteStationListStatus.failure,
+          message: error.message,
+        ),
+      );
+    } catch (_) {
+      _emitState(
+        const FavoriteStationListState(
+          status: FavoriteStationListStatus.failure,
+          message: _favoriteStationLoadErrorMessage,
+        ),
+      );
+    }
+  }
+
+  void _emitState(FavoriteStationListState nextState) {
+    if (_isDisposed) {
+      return;
+    }
+    _state = nextState;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
+  }
+}
+
+enum StationFavoriteToggleStatus { ready, saving, removing, failure }
+
+class StationFavoriteToggleState {
+  const StationFavoriteToggleState({
+    required this.status,
+    required this.isFavorite,
+    this.message = '',
+  });
+
+  const StationFavoriteToggleState.ready({required this.isFavorite})
+    : status = StationFavoriteToggleStatus.ready,
+      message = '';
+
+  final StationFavoriteToggleStatus status;
+  final bool isFavorite;
+  final String message;
+
+  bool get isBusy {
+    return status == StationFavoriteToggleStatus.saving ||
+        status == StationFavoriteToggleStatus.removing;
+  }
+}
+
+class StationFavoriteToggleController extends ChangeNotifier {
+  StationFavoriteToggleController({
+    required this.repository,
+    required this.stationId,
+    bool initiallyFavorite = false,
+  }) : _state = StationFavoriteToggleState.ready(isFavorite: initiallyFavorite);
+
+  final FavoriteStationRepository repository;
+  final String stationId;
+
+  StationFavoriteToggleState _state;
+  bool _isDisposed = false;
+
+  StationFavoriteToggleState get state => _state;
+
+  Future<void> save() async {
+    if (_state.isBusy) {
+      return;
+    }
+
+    _emitState(
+      StationFavoriteToggleState(
+        status: StationFavoriteToggleStatus.saving,
+        isFavorite: _state.isFavorite,
+      ),
+    );
+
+    try {
+      await repository.saveFavoriteStation(stationId);
+      _emitState(
+        const StationFavoriteToggleState(
+          status: StationFavoriteToggleStatus.ready,
+          isFavorite: true,
+          message: '즐겨찾기에 저장했습니다.',
+        ),
+      );
+    } on FavoriteStationException catch (error) {
+      _emitFailure(error.message);
+    } catch (_) {
+      _emitFailure(_favoriteStationChangeErrorMessage);
+    }
+  }
+
+  Future<void> remove() async {
+    if (_state.isBusy) {
+      return;
+    }
+
+    _emitState(
+      StationFavoriteToggleState(
+        status: StationFavoriteToggleStatus.removing,
+        isFavorite: _state.isFavorite,
+      ),
+    );
+
+    try {
+      await repository.removeFavoriteStation(stationId);
+      _emitState(
+        const StationFavoriteToggleState(
+          status: StationFavoriteToggleStatus.ready,
+          isFavorite: false,
+          message: '즐겨찾기에서 해제했습니다.',
+        ),
+      );
+    } on FavoriteStationException catch (error) {
+      _emitFailure(error.message);
+    } catch (_) {
+      _emitFailure(_favoriteStationChangeErrorMessage);
+    }
+  }
+
+  void _emitFailure(String message) {
+    _emitState(
+      StationFavoriteToggleState(
+        status: StationFavoriteToggleStatus.failure,
+        isFavorite: _state.isFavorite,
+        message: message,
+      ),
+    );
+  }
+
+  void _emitState(StationFavoriteToggleState nextState) {
+    if (_isDisposed) {
+      return;
+    }
+    _state = nextState;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
+  }
+}
+
 class StationSearchScreen extends StatefulWidget {
   const StationSearchScreen({
     required this.repository,
     required this.reportRepository,
+    required this.favoriteRepository,
     super.key,
   });
 
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
+  final FavoriteStationRepository favoriteRepository;
 
   @override
   State<StationSearchScreen> createState() => _StationSearchScreenState();
@@ -779,6 +1198,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
         builder: (_) => StationDetailScreen(
           repository: widget.repository,
           reportRepository: widget.reportRepository,
+          favoriteRepository: widget.favoriteRepository,
           stationId: result.id,
         ),
       ),
@@ -928,17 +1348,226 @@ class _StationSearchResultTile extends StatelessWidget {
   }
 }
 
+class FavoriteStationListScreen extends StatefulWidget {
+  const FavoriteStationListScreen({
+    required this.repository,
+    required this.stationRepository,
+    required this.reportRepository,
+    super.key,
+  });
+
+  final FavoriteStationRepository repository;
+  final StationSearchRepository stationRepository;
+  final FacilityReportRepository reportRepository;
+
+  @override
+  State<FavoriteStationListScreen> createState() =>
+      _FavoriteStationListScreenState();
+}
+
+class _FavoriteStationListScreenState extends State<FavoriteStationListScreen> {
+  late final FavoriteStationListController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = FavoriteStationListController(repository: widget.repository);
+    _controller.load();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('즐겨찾기')),
+      body: SafeArea(
+        child: AnimatedBuilder(
+          animation: _controller,
+          builder: (context, _) {
+            return _FavoriteStationListBody(
+              state: _controller.state,
+              onRetry: _controller.load,
+              onFavoriteTap: _openStationDetail,
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  void _openStationDetail(FavoriteStation favorite) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => StationDetailScreen(
+          repository: widget.stationRepository,
+          reportRepository: widget.reportRepository,
+          favoriteRepository: widget.repository,
+          stationId: favorite.stationId,
+          // 목록에서 들어온 역은 이미 저장된 상태로 보여 해제 동작을 바로 할 수 있게 한다.
+          initiallyFavorite: true,
+        ),
+      ),
+    );
+  }
+}
+
+class _FavoriteStationListBody extends StatelessWidget {
+  const _FavoriteStationListBody({
+    required this.state,
+    required this.onRetry,
+    required this.onFavoriteTap,
+  });
+
+  final FavoriteStationListState state;
+  final VoidCallback onRetry;
+  final ValueChanged<FavoriteStation> onFavoriteTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (state.status) {
+      FavoriteStationListStatus.loading => Semantics(
+        label: '즐겨찾기 불러오는 중',
+        liveRegion: true,
+        child: const Center(child: CircularProgressIndicator()),
+      ),
+      FavoriteStationListStatus.empty => Padding(
+        padding: const EdgeInsets.all(20),
+        child: _StationSearchMessage(message: state.message, liveRegion: true),
+      ),
+      FavoriteStationListStatus.failure => Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _StationSearchMessage(message: state.message, liveRegion: true),
+            const SizedBox(height: 16),
+            OutlinedButton.icon(
+              key: const Key('favoriteStationsRetryButton'),
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('다시 불러오기'),
+            ),
+          ],
+        ),
+      ),
+      FavoriteStationListStatus.success => ListView(
+        padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+        children: [
+          Semantics(
+            label: '즐겨찾기 역 ${state.favorites.length}개',
+            liveRegion: true,
+            child: const SizedBox.shrink(),
+          ),
+          for (final favorite in state.favorites)
+            _FavoriteStationTile(
+              favorite: favorite,
+              onTap: () => onFavoriteTap(favorite),
+            ),
+        ],
+      ),
+    };
+  }
+}
+
+class _FavoriteStationTile extends StatelessWidget {
+  const _FavoriteStationTile({required this.favorite, required this.onTap});
+
+  final FavoriteStation favorite;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return MergeSemantics(
+      child: Semantics(
+        label: favorite.semanticLabel,
+        button: true,
+        onTap: onTap,
+        child: ExcludeSemantics(
+          child: Card(
+            margin: const EdgeInsets.only(bottom: 12),
+            color: Colors.white,
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: const BorderSide(color: Color(0xFFD5E2E4)),
+            ),
+            child: InkWell(
+              key: Key('favoriteStationTile-${favorite.stationId}'),
+              borderRadius: BorderRadius.circular(8),
+              onTap: onTap,
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      favorite.nameKo,
+                      style: textTheme.titleLarge?.copyWith(
+                        color: const Color(0xFF102A2C),
+                        fontWeight: FontWeight.w900,
+                        height: 1.25,
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    StationLineBadges(lines: favorite.lines),
+                    const SizedBox(height: 8),
+                    Text(
+                      favorite.lineLabel,
+                      style: textTheme.bodyLarge?.copyWith(
+                        color: const Color(0xFF29484B),
+                        fontWeight: FontWeight.w800,
+                        height: 1.3,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      favorite.region,
+                      style: textTheme.bodyMedium?.copyWith(
+                        color: const Color(0xFF405A5D),
+                        height: 1.3,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      favorite.dataQualityLabel,
+                      style: textTheme.bodyMedium?.copyWith(
+                        color: const Color(0xFF405A5D),
+                        height: 1.3,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class StationDetailScreen extends StatefulWidget {
   const StationDetailScreen({
     required this.repository,
     required this.reportRepository,
+    required this.favoriteRepository,
     required this.stationId,
+    this.initiallyFavorite = false,
     super.key,
   });
 
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
+  final FavoriteStationRepository favoriteRepository;
   final String stationId;
+  final bool initiallyFavorite;
 
   @override
   State<StationDetailScreen> createState() => _StationDetailScreenState();
@@ -946,17 +1575,24 @@ class StationDetailScreen extends StatefulWidget {
 
 class _StationDetailScreenState extends State<StationDetailScreen> {
   late final StationDetailController _controller;
+  late final StationFavoriteToggleController _favoriteController;
 
   @override
   void initState() {
     super.initState();
     _controller = StationDetailController(repository: widget.repository);
+    _favoriteController = StationFavoriteToggleController(
+      repository: widget.favoriteRepository,
+      stationId: widget.stationId,
+      initiallyFavorite: widget.initiallyFavorite,
+    );
     _controller.load(widget.stationId);
   }
 
   @override
   void dispose() {
     _controller.dispose();
+    _favoriteController.dispose();
     super.dispose();
   }
 
@@ -971,6 +1607,7 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
             return _StationDetailBody(
               state: _controller.state,
               reportRepository: widget.reportRepository,
+              favoriteController: _favoriteController,
             );
           },
         ),
@@ -983,10 +1620,12 @@ class _StationDetailBody extends StatelessWidget {
   const _StationDetailBody({
     required this.state,
     required this.reportRepository,
+    required this.favoriteController,
   });
 
   final StationDetailState state;
   final FacilityReportRepository reportRepository;
+  final StationFavoriteToggleController favoriteController;
 
   @override
   Widget build(BuildContext context) {
@@ -1005,6 +1644,7 @@ class _StationDetailBody extends StatelessWidget {
         exits: state.exits,
         facilities: state.facilities,
         reportRepository: reportRepository,
+        favoriteController: favoriteController,
       ),
     };
   }
@@ -1016,12 +1656,14 @@ class _StationDetailContent extends StatelessWidget {
     required this.exits,
     required this.facilities,
     required this.reportRepository,
+    required this.favoriteController,
   });
 
   final StationDetail detail;
   final List<StationExitInfo> exits;
   final List<StationFacilityInfo> facilities;
   final FacilityReportRepository reportRepository;
+  final StationFavoriteToggleController favoriteController;
 
   @override
   Widget build(BuildContext context) {
@@ -1029,6 +1671,8 @@ class _StationDetailContent extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
       children: [
         _StationDetailHeader(detail: detail),
+        const SizedBox(height: 16),
+        _StationFavoriteControl(detail: detail, controller: favoriteController),
         const SizedBox(height: 24),
         const _StationDetailSectionTitle(title: '출구'),
         const SizedBox(height: 12),
@@ -1119,6 +1763,79 @@ class _StationDetailHeader extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+class _StationFavoriteControl extends StatelessWidget {
+  const _StationFavoriteControl({
+    required this.detail,
+    required this.controller,
+  });
+
+  final StationDetail detail;
+  final StationFavoriteToggleController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, _) {
+        final state = controller.state;
+        final isFavorite = state.isFavorite;
+        final label = _favoriteButtonLabel(state);
+        final actionLabel = isFavorite ? '즐겨찾기 해제' : '즐겨찾기 저장';
+        final onPressed = state.isBusy
+            ? null
+            : isFavorite
+            ? controller.remove
+            : controller.save;
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Semantics(
+              container: true,
+              label: '${detail.nameKo}역 $actionLabel',
+              button: true,
+              onTap: onPressed,
+              child: ExcludeSemantics(
+                child: OutlinedButton.icon(
+                  key: const Key('stationFavoriteToggleButton'),
+                  onPressed: onPressed,
+                  icon: Icon(isFavorite ? Icons.star : Icons.star_border),
+                  label: Text(label),
+                ),
+              ),
+            ),
+            if (state.message.isNotEmpty) ...[
+              const SizedBox(height: 10),
+              Semantics(
+                label: state.message,
+                liveRegion: true,
+                child: Text(
+                  state.message,
+                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: const Color(0xFF102A2C),
+                    fontWeight: FontWeight.w800,
+                    height: 1.3,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        );
+      },
+    );
+  }
+
+  String _favoriteButtonLabel(StationFavoriteToggleState state) {
+    return switch (state.status) {
+      StationFavoriteToggleStatus.saving => '저장 중',
+      StationFavoriteToggleStatus.removing => '해제 중',
+      StationFavoriteToggleStatus.ready ||
+      StationFavoriteToggleStatus.failure =>
+        state.isFavorite ? '즐겨찾기 해제' : '즐겨찾기 저장',
+    };
   }
 }
 

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -164,21 +164,29 @@ abstract class FavoriteStationRepository {
   Future<void> removeFavoriteStation(String stationId);
 }
 
-class FavoriteStationCredentials {
-  const FavoriteStationCredentials({
+abstract class FavoriteStationAuthProvider {
+  Future<String?> authorizationHeader();
+}
+
+class NoFavoriteStationAuthProvider implements FavoriteStationAuthProvider {
+  const NoFavoriteStationAuthProvider();
+
+  @override
+  Future<String?> authorizationHeader() async => null;
+}
+
+class BasicFavoriteStationAuthProvider implements FavoriteStationAuthProvider {
+  const BasicFavoriteStationAuthProvider({
     required this.username,
     required this.password,
   });
 
-  const FavoriteStationCredentials.fromEnvironment()
-    : username = const String.fromEnvironment('EASYSUBWAY_FAVORITE_USERNAME'),
-      password = const String.fromEnvironment('EASYSUBWAY_FAVORITE_PASSWORD');
-
   final String username;
   final String password;
 
-  String? get authorizationHeader {
-    // 즐겨찾기는 사용자별 데이터라 Basic 인증값을 빌드 환경에서 주입받아 요청에만 붙인다.
+  @override
+  Future<String?> authorizationHeader() async {
+    // 실제 앱은 로그인 세션에서 인증값을 주입해야 하며, 빌드 타임 공용 인증값은 사용하지 않는다.
     if (username.trim().isEmpty || password.isEmpty) {
       return null;
     }
@@ -190,12 +198,12 @@ class FavoriteStationCredentials {
 class FavoriteStationApiRepository implements FavoriteStationRepository {
   FavoriteStationApiRepository({
     required this.baseUri,
-    required this.credentials,
+    required this.authProvider,
     HttpClient? httpClient,
   }) : _httpClient = httpClient ?? HttpClient();
 
   final Uri baseUri;
-  final FavoriteStationCredentials credentials;
+  final FavoriteStationAuthProvider authProvider;
   final HttpClient _httpClient;
 
   @override
@@ -265,7 +273,9 @@ class FavoriteStationApiRepository implements FavoriteStationRepository {
       final request = await _httpClient
           .openUrl(method, uri)
           .timeout(_favoriteStationTimeout);
-      final authorizationHeader = credentials.authorizationHeader;
+      final authorizationHeader = await authProvider
+          .authorizationHeader()
+          .timeout(_favoriteStationTimeout);
       if (authorizationHeader != null) {
         request.headers.set(
           HttpHeaders.authorizationHeader,
@@ -1192,7 +1202,11 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     _controller.search(query);
   }
 
-  void _openStationDetail(StationSearchResult result) {
+  Future<void> _openStationDetail(StationSearchResult result) async {
+    final initiallyFavorite = await _isFavoriteStation(result.id);
+    if (!mounted) {
+      return;
+    }
     Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (_) => StationDetailScreen(
@@ -1200,9 +1214,19 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
           reportRepository: widget.reportRepository,
           favoriteRepository: widget.favoriteRepository,
           stationId: result.id,
+          initiallyFavorite: initiallyFavorite,
         ),
       ),
     );
+  }
+
+  Future<bool> _isFavoriteStation(String stationId) async {
+    try {
+      final favorites = await widget.favoriteRepository.listFavoriteStations();
+      return favorites.any((favorite) => favorite.stationId == stationId);
+    } catch (_) {
+      return false;
+    }
   }
 }
 
@@ -1400,8 +1424,8 @@ class _FavoriteStationListScreenState extends State<FavoriteStationListScreen> {
     );
   }
 
-  void _openStationDetail(FavoriteStation favorite) {
-    Navigator.of(context).push(
+  Future<void> _openStationDetail(FavoriteStation favorite) async {
+    await Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (_) => StationDetailScreen(
           repository: widget.stationRepository,
@@ -1413,6 +1437,10 @@ class _FavoriteStationListScreenState extends State<FavoriteStationListScreen> {
         ),
       ),
     );
+    if (!mounted) {
+      return;
+    }
+    _controller.load();
   }
 }
 

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -225,7 +225,7 @@ void main() {
 
     final repository = FavoriteStationApiRepository(
       baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
-      credentials: const FavoriteStationCredentials(
+      authProvider: const BasicFavoriteStationAuthProvider(
         username: 'anonymous-user-1',
         password: 'user-test-password',
       ),
@@ -243,6 +243,33 @@ void main() {
     expect(favorites.single.nameKo, '상록수');
     expect(favorites.single.lineLabel, '수도권 4호선');
     expect(favorites.single.dataQualityLabel, '기본 정보만 확인됨');
+  });
+
+  test('즐겨찾기 역 API 저장소는 인증 제공자가 없으면 인증 헤더를 보내지 않는다', () async {
+    late String? authorizationHeader;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      authorizationHeader = request.headers.value(
+        HttpHeaders.authorizationHeader,
+      );
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(jsonEncode({'success': true, 'data': []}))
+        ..close();
+    });
+
+    final repository = FavoriteStationApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: const NoFavoriteStationAuthProvider(),
+    );
+
+    final favorites = await repository.listFavoriteStations();
+
+    expect(favorites, isEmpty);
+    expect(authorizationHeader, isNull);
   });
 
   test('즐겨찾기 역 API 저장소는 역 저장과 해제를 요청한다', () async {
@@ -284,7 +311,7 @@ void main() {
 
     final repository = FavoriteStationApiRepository(
       baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
-      credentials: const FavoriteStationCredentials(
+      authProvider: const BasicFavoriteStationAuthProvider(
         username: 'anonymous-user-1',
         password: 'user-test-password',
       ),

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -181,6 +181,126 @@ void main() {
     expect(facilities.single.confidenceLabel, '정보 신뢰도 높음');
   });
 
+  test('즐겨찾기 역 API 저장소는 인증 헤더와 함께 목록을 요청하고 결과를 파싱한다', () async {
+    late String? authorizationHeader;
+    late Uri requestedUri;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestedUri = request.uri;
+      authorizationHeader = request.headers.value(
+        HttpHeaders.authorizationHeader,
+      );
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': [
+              {
+                'userId': 'anonymous-user-1',
+                'stationId': 'station-sangnoksu',
+                'nameKo': '상록수',
+                'nameEn': 'Sangnoksu',
+                'region': '수도권',
+                'dataQualityLevel': 'LEVEL_1',
+                'lastVerifiedAt': '2026-06-12',
+                'lines': [
+                  {
+                    'id': 'seoul-4',
+                    'name': '수도권 4호선',
+                    'color': '#00A5DE',
+                    'stationCode': '448',
+                  },
+                ],
+                'addedAt': '2026-06-13T10:00:00',
+              },
+            ],
+          }),
+        )
+        ..close();
+    });
+
+    final repository = FavoriteStationApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      credentials: const FavoriteStationCredentials(
+        username: 'anonymous-user-1',
+        password: 'user-test-password',
+      ),
+    );
+
+    final favorites = await repository.listFavoriteStations();
+
+    expect(requestedUri.path, '/api/v1/me/favorites/stations');
+    expect(
+      authorizationHeader,
+      'Basic ${base64Encode(utf8.encode('anonymous-user-1:user-test-password'))}',
+    );
+    expect(favorites, hasLength(1));
+    expect(favorites.single.stationId, 'station-sangnoksu');
+    expect(favorites.single.nameKo, '상록수');
+    expect(favorites.single.lineLabel, '수도권 4호선');
+    expect(favorites.single.dataQualityLabel, '기본 정보만 확인됨');
+  });
+
+  test('즐겨찾기 역 API 저장소는 역 저장과 해제를 요청한다', () async {
+    final requestedMethods = <String>[];
+    final requestedPaths = <String>[];
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestedMethods.add(request.method);
+      requestedPaths.add(request.uri.path);
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json;
+
+      if (request.method == 'PUT') {
+        request.response.write(
+          jsonEncode({
+            'success': true,
+            'data': {
+              'userId': 'anonymous-user-1',
+              'stationId': 'station-sangnoksu',
+              'nameKo': '상록수',
+              'nameEn': 'Sangnoksu',
+              'region': '수도권',
+              'dataQualityLevel': 'LEVEL_1',
+              'lastVerifiedAt': '2026-06-12',
+              'lines': const [],
+              'addedAt': '2026-06-13T10:00:00',
+            },
+          }),
+        );
+      } else {
+        request.response.write(jsonEncode({'success': true, 'data': null}));
+      }
+
+      request.response.close();
+    });
+
+    final repository = FavoriteStationApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      credentials: const FavoriteStationCredentials(
+        username: 'anonymous-user-1',
+        password: 'user-test-password',
+      ),
+    );
+
+    final favorite = await repository.saveFavoriteStation('station-sangnoksu');
+    await repository.removeFavoriteStation('station-sangnoksu');
+
+    expect(favorite.nameKo, '상록수');
+    expect(requestedMethods, ['PUT', 'DELETE']);
+    expect(requestedPaths, [
+      '/api/v1/me/favorites/stations/station-sangnoksu',
+      '/api/v1/me/favorites/stations/station-sangnoksu',
+    ]);
+  });
+
   test('역 API 저장소는 형식이 잘못된 역 응답을 거부한다', () async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(server.close);
@@ -305,6 +425,51 @@ void main() {
     expect(controller.state.facilities.single.name, '1번 출구 엘리베이터');
   });
 
+  test('즐겨찾기 역 목록 컨트롤러는 목록과 빈 목록과 실패 상태를 구분한다', () async {
+    final repository = FakeFavoriteStationRepository();
+    final controller = FavoriteStationListController(repository: repository);
+
+    repository.favorites = [
+      _favoriteStation(id: 'station-sangnoksu', name: '상록수'),
+    ];
+    await controller.load();
+
+    expect(controller.state.status, FavoriteStationListStatus.success);
+    expect(controller.state.favorites.single.nameKo, '상록수');
+
+    repository.favorites = const [];
+    await controller.load();
+
+    expect(controller.state.status, FavoriteStationListStatus.empty);
+    expect(controller.state.message, '저장한 역이 없습니다.');
+
+    repository.error = const FavoriteStationException('즐겨찾기를 불러오지 못했습니다.');
+    await controller.load();
+
+    expect(controller.state.status, FavoriteStationListStatus.failure);
+    expect(controller.state.message, '즐겨찾기를 불러오지 못했습니다.');
+  });
+
+  test('역 상세 즐겨찾기 컨트롤러는 저장과 해제를 순서대로 처리한다', () async {
+    final repository = FakeFavoriteStationRepository();
+    final controller = StationFavoriteToggleController(
+      repository: repository,
+      stationId: 'station-sangnoksu',
+    );
+
+    await controller.save();
+
+    expect(repository.savedStationIds, ['station-sangnoksu']);
+    expect(controller.state.isFavorite, isTrue);
+    expect(controller.state.message, '즐겨찾기에 저장했습니다.');
+
+    await controller.remove();
+
+    expect(repository.removedStationIds, ['station-sangnoksu']);
+    expect(controller.state.isFavorite, isFalse);
+    expect(controller.state.message, '즐겨찾기에서 해제했습니다.');
+  });
+
   test('시설 정보는 백엔드 enum 값을 쉬운 라벨과 스크린리더 문구로 바꾼다', () {
     const ramp = StationFacilityInfo(
       id: 'facility-ramp-1',
@@ -344,6 +509,27 @@ void main() {
     expect(customerCenter.statusLabel, '검수 완료');
     expect(customerCenter.semanticLabel, contains('정보 신뢰도 높음'));
   });
+}
+
+FavoriteStation _favoriteStation({required String id, required String name}) {
+  return FavoriteStation(
+    userId: 'anonymous-user-1',
+    stationId: id,
+    nameKo: name,
+    nameEn: id,
+    region: '수도권',
+    dataQualityLevel: 'LEVEL_1',
+    lastVerifiedAt: '2026-06-12',
+    lines: const [
+      StationSearchLine(
+        id: 'seoul-4',
+        name: '수도권 4호선',
+        color: '#00A5DE',
+        stationCode: '448',
+      ),
+    ],
+    addedAt: '2026-06-13T10:00:00',
+  );
 }
 
 StationSearchResult _stationResult({required String id, required String name}) {
@@ -516,5 +702,45 @@ class ControlledStationDetailRepository implements StationSearchRepository {
     );
     _exitsCompleter.complete([_stationExit()]);
     _facilitiesCompleter.complete([_stationFacility()]);
+  }
+}
+
+class FakeFavoriteStationRepository implements FavoriteStationRepository {
+  List<FavoriteStation> favorites = const [];
+  final savedStationIds = <String>[];
+  final removedStationIds = <String>[];
+  Object? error;
+
+  @override
+  Future<List<FavoriteStation>> listFavoriteStations() async {
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return favorites;
+  }
+
+  @override
+  Future<FavoriteStation> saveFavoriteStation(String stationId) async {
+    savedStationIds.add(stationId);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    final favorite = _favoriteStation(id: stationId, name: '상록수');
+    favorites = [favorite];
+    return favorite;
+  }
+
+  @override
+  Future<void> removeFavoriteStation(String stationId) async {
+    removedStationIds.add(stationId);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    favorites = favorites
+        .where((favorite) => favorite.stationId != stationId)
+        .toList(growable: false);
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -54,6 +54,19 @@ void main() {
     }
   });
 
+  testWidgets('인증 저장소가 없으면 홈 즐겨찾기를 노출하지 않는다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+      ),
+    );
+
+    expect(find.byKey(const Key('favoriteStationsButton')), findsNothing);
+    expect(find.widgetWithText(FilledButton, '즐겨찾기'), findsNothing);
+  });
+
   testWidgets('홈 즐겨찾기는 저장한 역을 큰 목록으로 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final favoriteRepository = FakeFavoriteStationRepository(
@@ -397,6 +410,45 @@ void main() {
 
     expect(find.widgetWithText(OutlinedButton, '즐겨찾기 해제'), findsOneWidget);
     expect(find.bySemanticsLabel('상록수역 즐겨찾기 해제'), findsOneWidget);
+  });
+
+  testWidgets('역 상세는 즐겨찾기 확인을 기다리지 않고 열린다', (tester) async {
+    final favoriteRepository = ControlledFavoriteStationRepository();
+    final stationRepository = FakeStationSearchRepository(
+      nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: favoriteRepository,
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+    await tester.pump();
+
+    expect(find.text('상록수역'), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, '확인 중'), findsOneWidget);
+
+    favoriteRepository.complete([
+      _favoriteStation(id: 'station-sangnoksu', name: '상록수'),
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(OutlinedButton, '즐겨찾기 해제'), findsOneWidget);
   });
 
   testWidgets('즐겨찾기 목록은 상세에서 해제하고 돌아오면 다시 불러온다', (tester) async {
@@ -1100,6 +1152,29 @@ class FakeFavoriteStationRepository implements FavoriteStationRepository {
     favorites = favorites
         .where((favorite) => favorite.stationId != stationId)
         .toList(growable: false);
+  }
+}
+
+class ControlledFavoriteStationRepository implements FavoriteStationRepository {
+  final _favoritesCompleter = Completer<List<FavoriteStation>>();
+
+  @override
+  Future<List<FavoriteStation>> listFavoriteStations() {
+    return _favoritesCompleter.future;
+  }
+
+  @override
+  Future<FavoriteStation> saveFavoriteStation(String stationId) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> removeFavoriteStation(String stationId) {
+    throw UnimplementedError();
+  }
+
+  void complete(List<FavoriteStation> favorites) {
+    _favoritesCompleter.complete(favorites);
   }
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -17,12 +17,14 @@ void main() {
           repository: FakeStationSearchRepository(),
           reportRepository: FakeFacilityReportRepository(),
           routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
         ),
       );
 
       expect(find.text('역 찾기'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '역 검색'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '경로 검색'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '즐겨찾기'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsOneWidget);
       expect(find.text('이동 프로필'), findsOneWidget);
       expect(find.text('시설 정보'), findsOneWidget);
@@ -47,6 +49,51 @@ void main() {
       expect(stationButtonSize.height, greaterThanOrEqualTo(60));
       expect(routeButtonSize.height, greaterThanOrEqualTo(60));
       expect(profileButtonSize.height, greaterThanOrEqualTo(60));
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
+  testWidgets('홈 즐겨찾기는 저장한 역을 큰 목록으로 보여준다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final favoriteRepository = FakeFavoriteStationRepository(
+      favorites: [_favoriteStation(id: 'station-sangnoksu', name: '상록수')],
+    );
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: favoriteRepository,
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('favoriteStationsButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('즐겨찾기'), findsOneWidget);
+      expect(find.text('상록수'), findsOneWidget);
+      expect(find.text('수도권 4호선'), findsOneWidget);
+      expect(find.text('기본 정보만 확인됨'), findsOneWidget);
+      expect(
+        find.byKey(const Key('favoriteStationTile-station-sangnoksu')),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel('즐겨찾기 역, 상록수, 수도권 4호선, 수도권, 기본 정보만 확인됨'),
+        findsOneWidget,
+      );
+
+      final tileSize = tester.getSize(
+        find.byKey(const Key('favoriteStationTile-station-sangnoksu')),
+      );
+      expect(tileSize.height, greaterThanOrEqualTo(72));
+
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
     } finally {
       semanticsHandle.dispose();
     }
@@ -87,6 +134,7 @@ void main() {
           repository: repository,
           reportRepository: FakeFacilityReportRepository(),
           routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
         ),
       );
 
@@ -193,6 +241,7 @@ void main() {
           repository: repository,
           reportRepository: FakeFacilityReportRepository(),
           routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
         ),
       );
 
@@ -221,11 +270,6 @@ void main() {
       expect(find.text('엘리베이터 연결'), findsOneWidget);
       expect(find.text('계단 없는 이동 가능'), findsOneWidget);
       expect(find.text('시설'), findsOneWidget);
-      expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
-      expect(find.text('엘리베이터'), findsOneWidget);
-      expect(find.text('정상'), findsOneWidget);
-      expect(find.text('1번 출구 앞'), findsOneWidget);
-      expect(find.text('최근 확인 2026-06-12'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
           '상록수역 상세 정보, 수도권 2호선, 기본 정보만 확인됨, 마지막 확인 2026-06-13',
@@ -236,6 +280,13 @@ void main() {
         find.bySemanticsLabel('1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 정보 신뢰도 높음'),
         findsOneWidget,
       );
+      await tester.drag(find.byType(ListView), const Offset(0, -260));
+      await tester.pumpAndSettle();
+      expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
+      expect(find.text('엘리베이터'), findsOneWidget);
+      expect(find.text('정상'), findsOneWidget);
+      expect(find.text('1번 출구 앞'), findsOneWidget);
+      expect(find.text('최근 확인 2026-06-12'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
           '1번 출구 엘리베이터, 엘리베이터, 정상, 1번 출구 앞, 최근 확인 2026-06-12, 정보 신뢰도 높음',
@@ -259,6 +310,63 @@ void main() {
     }
   });
 
+  testWidgets('역 상세는 현재 역을 즐겨찾기에 저장하고 해제한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final favoriteRepository = FakeFavoriteStationRepository();
+    final stationRepository = FakeStationSearchRepository(
+      nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+    );
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: stationRepository,
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: favoriteRepository,
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('stationSearchButton')));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('stationSearchInput')),
+        '상록수',
+      );
+      await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(OutlinedButton, '즐겨찾기 저장'), findsOneWidget);
+      expect(find.bySemanticsLabel('상록수역 즐겨찾기 저장'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('stationFavoriteToggleButton')));
+      await tester.pumpAndSettle();
+
+      expect(favoriteRepository.savedStationIds, ['station-sangnoksu']);
+      expect(find.text('즐겨찾기에 저장했습니다.'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '즐겨찾기 해제'), findsOneWidget);
+      expect(find.bySemanticsLabel('상록수역 즐겨찾기 해제'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('stationFavoriteToggleButton')));
+      await tester.pumpAndSettle();
+
+      expect(favoriteRepository.removedStationIds, ['station-sangnoksu']);
+      expect(find.text('즐겨찾기에서 해제했습니다.'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '즐겨찾기 저장'), findsOneWidget);
+
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('검색 요청 중에는 검색 버튼을 비활성화한다', (tester) async {
     final repository = ControlledStationSearchRepository();
 
@@ -267,6 +375,7 @@ void main() {
         repository: repository,
         reportRepository: FakeFacilityReportRepository(),
         routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
       ),
     );
 
@@ -301,6 +410,7 @@ void main() {
           repository: FakeStationSearchRepository(),
           reportRepository: FakeFacilityReportRepository(),
           routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
         ),
       );
 
@@ -364,6 +474,7 @@ void main() {
           repository: stationRepository,
           reportRepository: FakeFacilityReportRepository(),
           routeRepository: routeRepository,
+          favoriteRepository: FakeFavoriteStationRepository(),
         ),
       );
 
@@ -470,6 +581,7 @@ void main() {
         repository: FakeStationSearchRepository(),
         reportRepository: FakeFacilityReportRepository(),
         routeRepository: routeRepository,
+        favoriteRepository: FakeFavoriteStationRepository(),
       ),
     );
 
@@ -505,6 +617,7 @@ void main() {
         repository: stationRepository,
         reportRepository: FakeFacilityReportRepository(),
         routeRepository: routeRepository,
+        favoriteRepository: FakeFavoriteStationRepository(),
       ),
     );
 
@@ -583,6 +696,7 @@ void main() {
           repository: stationRepository,
           reportRepository: FakeFacilityReportRepository(),
           routeRepository: routeRepository,
+          favoriteRepository: FakeFavoriteStationRepository(),
         ),
       );
 
@@ -675,6 +789,7 @@ void main() {
           repository: stationRepository,
           reportRepository: reportRepository,
           routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
         ),
       );
 
@@ -740,6 +855,27 @@ void main() {
       semanticsHandle.dispose();
     }
   });
+}
+
+FavoriteStation _favoriteStation({required String id, required String name}) {
+  return FavoriteStation(
+    userId: 'anonymous-user-1',
+    stationId: id,
+    nameKo: name,
+    nameEn: id,
+    region: '수도권',
+    dataQualityLevel: 'LEVEL_1',
+    lastVerifiedAt: '2026-06-13',
+    lines: const [
+      StationSearchLine(
+        id: 'seoul-4',
+        name: '수도권 4호선',
+        color: '#00A5DE',
+        stationCode: '448',
+      ),
+    ],
+    addedAt: '2026-06-13T10:00:00',
+  );
 }
 
 class FakeStationSearchRepository implements StationSearchRepository {
@@ -852,6 +988,48 @@ class FakeFacilityReportRepository implements FacilityReportRepository {
       status: 'SUBMITTED',
       createdAt: '2026-06-13T10:00:00',
     );
+  }
+}
+
+class FakeFavoriteStationRepository implements FavoriteStationRepository {
+  FakeFavoriteStationRepository({this.favorites = const []});
+
+  List<FavoriteStation> favorites;
+  final savedStationIds = <String>[];
+  final removedStationIds = <String>[];
+  Object? error;
+
+  @override
+  Future<List<FavoriteStation>> listFavoriteStations() async {
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return favorites;
+  }
+
+  @override
+  Future<FavoriteStation> saveFavoriteStation(String stationId) async {
+    savedStationIds.add(stationId);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    final favorite = _favoriteStation(id: stationId, name: '상록수');
+    favorites = [favorite];
+    return favorite;
+  }
+
+  @override
+  Future<void> removeFavoriteStation(String stationId) async {
+    removedStationIds.add(stationId);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    favorites = favorites
+        .where((favorite) => favorite.stationId != stationId)
+        .toList(growable: false);
   }
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -367,6 +367,76 @@ void main() {
     }
   });
 
+  testWidgets('검색 결과의 저장된 역은 상세에서 해제 버튼으로 시작한다', (tester) async {
+    final favoriteRepository = FakeFavoriteStationRepository(
+      favorites: [_favoriteStation(id: 'station-sangnoksu', name: '상록수')],
+    );
+    final stationRepository = FakeStationSearchRepository(
+      nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: favoriteRepository,
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(OutlinedButton, '즐겨찾기 해제'), findsOneWidget);
+    expect(find.bySemanticsLabel('상록수역 즐겨찾기 해제'), findsOneWidget);
+  });
+
+  testWidgets('즐겨찾기 목록은 상세에서 해제하고 돌아오면 다시 불러온다', (tester) async {
+    final favoriteRepository = FakeFavoriteStationRepository(
+      favorites: [_favoriteStation(id: 'station-sangnoksu', name: '상록수')],
+    );
+    final stationRepository = FakeStationSearchRepository(
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: favoriteRepository,
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('favoriteStationsButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('favoriteStationTile-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('stationFavoriteToggleButton')));
+    await tester.pumpAndSettle();
+
+    expect(favoriteRepository.removedStationIds, ['station-sangnoksu']);
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    expect(find.text('저장한 역이 없습니다.'), findsOneWidget);
+    expect(
+      find.byKey(const Key('favoriteStationTile-station-sangnoksu')),
+      findsNothing,
+    );
+  });
+
   testWidgets('검색 요청 중에는 검색 버튼을 비활성화한다', (tester) async {
     final repository = ControlledStationSearchRepository();
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -14,6 +14,13 @@ function read(relativePath) {
   return readFileSync(path.join(root, relativePath), "utf8");
 }
 
+function jobBlock(workflow, startJob, nextJob) {
+  const pattern = new RegExp(`  ${startJob}:[\\s\\S]*?\\n  ${nextJob}:`);
+  const match = workflow.match(pattern);
+  assert.ok(match, `${startJob} job block not found`);
+  return match[0];
+}
+
 test("로컬 에이전트 문서와 README 외 Markdown은 gitignore로 추적되지 않는다", () => {
   const gitignore = read(".gitignore");
 
@@ -48,6 +55,21 @@ test("지속적 통합 작업과 스텝 이름은 실패 영역을 구분할 수
   assert.match(workflow, /Mobile App CI \/ Run Flutter analyzer and tests/);
   assert.match(workflow, /Android CI \/ Build Flutter Android debug APK/);
   assert.match(workflow, /iOS CI \/ Build Flutter iOS simulator app/);
+});
+
+test("필수 지속적 통합 작업은 변경 없는 영역도 성공 상태로 종료한다", () => {
+  const workflow = read(".github/workflows/ci.yml");
+
+  assert.match(workflow, /Repository CI \/ Skip unchanged area/);
+  assert.match(workflow, /Backend CI \/ Skip unchanged area/);
+  assert.match(workflow, /Mobile App CI \/ Skip unchanged area/);
+  assert.match(workflow, /Android CI \/ Skip unchanged area/);
+  assert.match(workflow, /iOS CI \/ Skip unchanged area/);
+
+  assert.doesNotMatch(jobBlock(workflow, "repository-contracts", "backend"), /\n    if:/);
+  assert.doesNotMatch(jobBlock(workflow, "backend", "mobile-app"), /\n    if:/);
+  assert.doesNotMatch(jobBlock(workflow, "mobile-app", "android"), /\n    if:/);
+  assert.doesNotMatch(jobBlock(workflow, "android", "ios"), /\n    if:/);
 });
 
 test("풀 리퀘스트 템플릿은 리뷰와 배포 확인 게이트를 포함한다", () => {


### PR DESCRIPTION
## 관련 이슈
Closes #40

## 배경
자주 확인하는 역을 매번 검색해야 하면 조작 횟수가 늘어납니다. 홈에서 바로 즐겨찾기 목록으로 들어가고, 역 상세에서 현재 역을 저장하거나 해제할 수 있게 해 반복 탐색 부담을 줄입니다.

## 변경 사항
- 런타임 사용자 인증 저장소가 주입된 홈 화면에 큰 터치 영역의 `즐겨찾기` 진입점을 추가했습니다.
- 즐겨찾기 역 목록 화면을 추가하고 역 이름, 노선 배지, 지역, 데이터 수준을 표시했습니다.
- 즐겨찾기 목록 로딩, 빈 목록, 실패 상태를 쉬운 문구로 표시했습니다.
- 역 상세 화면에서 현재 역을 즐겨찾기에 저장하거나 해제할 수 있게 했습니다.
- 즐겨찾기 API 인증 헤더는 런타임 인증 제공자에서만 붙이도록 하고, 기본 앱 빌드에는 공용 인증값과 인증 없는 즐겨찾기 진입점을 포함하지 않았습니다.
- 검색 결과에서 상세 화면은 즉시 열고, 즐겨찾기 상태는 상세 화면 내부에서 비동기로 확인하도록 했습니다.
- 검색 결과에서 이미 저장된 역을 열면 상세 화면이 해제 상태로 갱신되고, 즐겨찾기 목록에서 상세를 닫으면 목록을 다시 불러오도록 했습니다.
- TalkBack/VoiceOver가 즐겨찾기 버튼, 목록 항목, 저장/해제 상태, 결과 메시지를 읽을 수 있도록 semantics를 추가했습니다.
- 조건부 CI job이 변경 없는 영역에서도 required check를 성공 상태로 남기고 내부 검증 step만 skip하도록 조정했습니다.

## 검증
- `flutter test`
- `flutter analyze`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`
- `flutter build apk --debug`
- Android emulator install/launch/UI tree/screenshot
- `flutter build ios --simulator --no-codesign`
- iOS simulator install/launch/screenshot

## 리스크
- 즐겨찾기 API는 사용자별 데이터라 로그인/세션 인증 연동이 필요합니다. 인증 저장소가 주입되지 않은 기본 앱 실행 경로에서는 즐겨찾기 진입과 토글을 노출하지 않습니다.
- 로그인 화면과 세션 저장소 구현은 이번 범위에 포함하지 않았습니다.
