### PR TITLE
[Feat] 알림 설정 API 기반 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
 	SecurityFilterChain userSecurityFilterChain(HttpSecurity http) throws Exception {
 		// 사용자별 데이터는 URL이나 본문 userId가 아니라 인증 계정을 기준으로 다룬다.
 		return http
-			.securityMatcher("/api/v1/me/favorites/**")
+			.securityMatcher("/api/v1/me/favorites/**", "/api/v1/devices", "/api/v1/me/notification-settings")
 			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(authorize -> authorize
 				.anyRequest().authenticated()

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/NotificationPreferenceController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/NotificationPreferenceController.java
@@ -1,0 +1,116 @@
+package com.easysubway.notification.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.notification.application.port.in.NotificationPreferenceUseCase;
+import com.easysubway.notification.application.port.in.RegisterDeviceCommand;
+import com.easysubway.notification.application.port.in.SaveNotificationSettingsCommand;
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.NotificationSettings;
+import com.easysubway.notification.domain.RegisteredDevice;
+import java.security.Principal;
+import java.time.LocalDateTime;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class NotificationPreferenceController {
+
+	private final NotificationPreferenceUseCase notificationPreferenceUseCase;
+
+	NotificationPreferenceController(NotificationPreferenceUseCase notificationPreferenceUseCase) {
+		this.notificationPreferenceUseCase = notificationPreferenceUseCase;
+	}
+
+	@PostMapping("/api/v1/devices")
+	ApiResponse<RegisteredDeviceResponse> registerDevice(
+		@RequestBody RegisterDeviceRequest request,
+		Principal principal
+	) {
+		RegisteredDevice device = notificationPreferenceUseCase.registerDevice(new RegisterDeviceCommand(
+			principal.getName(),
+			request.platform(),
+			request.deviceToken()
+		));
+		return ApiResponse.ok(RegisteredDeviceResponse.from(device));
+	}
+
+	@GetMapping("/api/v1/me/notification-settings")
+	ApiResponse<NotificationSettingsResponse> getNotificationSettings(Principal principal) {
+		NotificationSettings settings = notificationPreferenceUseCase.getNotificationSettings(principal.getName());
+		return ApiResponse.ok(NotificationSettingsResponse.from(settings));
+	}
+
+	@PutMapping("/api/v1/me/notification-settings")
+	ApiResponse<NotificationSettingsResponse> saveNotificationSettings(
+		@RequestBody SaveNotificationSettingsRequest request,
+		Principal principal
+	) {
+		NotificationSettings settings = notificationPreferenceUseCase.saveNotificationSettings(
+			new SaveNotificationSettingsCommand(
+				principal.getName(),
+				request.favoriteStationFacilityAlerts(),
+				request.favoriteRouteFacilityAlerts(),
+				request.reportStatusAlerts(),
+				request.dataQualityAlerts()
+			)
+		);
+		return ApiResponse.ok(NotificationSettingsResponse.from(settings));
+	}
+
+	record RegisterDeviceRequest(
+		String userId,
+		DevicePlatform platform,
+		String deviceToken
+	) {
+	}
+
+	record RegisteredDeviceResponse(
+		String userId,
+		DevicePlatform platform,
+		String deviceToken,
+		LocalDateTime registeredAt
+	) {
+
+		static RegisteredDeviceResponse from(RegisteredDevice device) {
+			return new RegisteredDeviceResponse(
+				device.userId(),
+				device.platform(),
+				device.deviceToken(),
+				device.registeredAt()
+			);
+		}
+	}
+
+	record SaveNotificationSettingsRequest(
+		String userId,
+		boolean favoriteStationFacilityAlerts,
+		boolean favoriteRouteFacilityAlerts,
+		boolean reportStatusAlerts,
+		boolean dataQualityAlerts
+	) {
+	}
+
+	record NotificationSettingsResponse(
+		String userId,
+		boolean favoriteStationFacilityAlerts,
+		boolean favoriteRouteFacilityAlerts,
+		boolean reportStatusAlerts,
+		boolean dataQualityAlerts,
+		LocalDateTime updatedAt
+	) {
+
+		static NotificationSettingsResponse from(NotificationSettings settings) {
+			return new NotificationSettingsResponse(
+				settings.userId(),
+				settings.favoriteStationFacilityAlerts(),
+				settings.favoriteRouteFacilityAlerts(),
+				settings.reportStatusAlerts(),
+				settings.dataQualityAlerts(),
+				settings.updatedAt()
+			);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryNotificationPreferenceRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryNotificationPreferenceRepository.java
@@ -1,0 +1,57 @@
+package com.easysubway.notification.adapter.out.persistence;
+
+import com.easysubway.notification.application.port.out.LoadNotificationPreferencePort;
+import com.easysubway.notification.application.port.out.SaveNotificationSettingsPort;
+import com.easysubway.notification.application.port.out.SaveRegisteredDevicePort;
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.NotificationSettings;
+import com.easysubway.notification.domain.RegisteredDevice;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryNotificationPreferenceRepository implements
+	LoadNotificationPreferencePort,
+	SaveRegisteredDevicePort,
+	SaveNotificationSettingsPort {
+
+	private final Map<String, NotificationSettings> settingsByUserId = new ConcurrentHashMap<>();
+	private final Map<String, Map<DeviceKey, RegisteredDevice>> devicesByUserId = new ConcurrentHashMap<>();
+
+	@Override
+	public Optional<NotificationSettings> loadNotificationSettings(String userId) {
+		return Optional.ofNullable(settingsByUserId.get(userId));
+	}
+
+	@Override
+	public List<RegisteredDevice> loadDevices(String userId) {
+		return devicesByUserId.getOrDefault(userId, Map.of())
+			.values()
+			.stream()
+			.sorted(Comparator
+				.comparing(RegisteredDevice::registeredAt)
+				.thenComparing(RegisteredDevice::deviceToken))
+			.toList();
+	}
+
+	@Override
+	public RegisteredDevice saveRegisteredDevice(RegisteredDevice device) {
+		devicesByUserId
+			.computeIfAbsent(device.userId(), ignored -> new ConcurrentHashMap<>())
+			.put(new DeviceKey(device.platform(), device.deviceToken()), device);
+		return device;
+	}
+
+	@Override
+	public NotificationSettings saveNotificationSettings(NotificationSettings settings) {
+		settingsByUserId.put(settings.userId(), settings);
+		return settings;
+	}
+
+	private record DeviceKey(DevicePlatform platform, String deviceToken) {
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryNotificationPreferenceRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryNotificationPreferenceRepository.java
@@ -40,9 +40,12 @@ public class InMemoryNotificationPreferenceRepository implements
 
 	@Override
 	public RegisteredDevice saveRegisteredDevice(RegisteredDevice device) {
+		var deviceKey = new DeviceKey(device.platform(), device.deviceToken());
+		// 한 물리 기기는 한 사용자에게만 알림이 가야 하므로 재등록 시 이전 소유자 버킷에서 제거한다.
+		devicesByUserId.values().forEach(devices -> devices.remove(deviceKey));
 		devicesByUserId
 			.computeIfAbsent(device.userId(), ignored -> new ConcurrentHashMap<>())
-			.put(new DeviceKey(device.platform(), device.deviceToken()), device);
+			.put(deviceKey, device);
 		return device;
 	}
 

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/NotificationPreferenceUseCase.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/NotificationPreferenceUseCase.java
@@ -1,0 +1,13 @@
+package com.easysubway.notification.application.port.in;
+
+import com.easysubway.notification.domain.NotificationSettings;
+import com.easysubway.notification.domain.RegisteredDevice;
+
+public interface NotificationPreferenceUseCase {
+
+	RegisteredDevice registerDevice(RegisterDeviceCommand command);
+
+	NotificationSettings getNotificationSettings(String userId);
+
+	NotificationSettings saveNotificationSettings(SaveNotificationSettingsCommand command);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/RegisterDeviceCommand.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/RegisterDeviceCommand.java
@@ -1,0 +1,25 @@
+package com.easysubway.notification.application.port.in;
+
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.InvalidNotificationPreferenceException;
+
+public record RegisterDeviceCommand(
+	String userId,
+	DevicePlatform platform,
+	String deviceToken
+) {
+
+	public RegisterDeviceCommand {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidNotificationPreferenceException("사용자 식별자가 필요합니다.");
+		}
+		if (platform == null) {
+			throw new InvalidNotificationPreferenceException("기기 플랫폼을 선택해야 합니다.");
+		}
+		if (deviceToken == null || deviceToken.isBlank()) {
+			throw new InvalidNotificationPreferenceException("기기 토큰이 필요합니다.");
+		}
+		userId = userId.trim();
+		deviceToken = deviceToken.trim();
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/SaveNotificationSettingsCommand.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/SaveNotificationSettingsCommand.java
@@ -1,0 +1,19 @@
+package com.easysubway.notification.application.port.in;
+
+import com.easysubway.notification.domain.InvalidNotificationPreferenceException;
+
+public record SaveNotificationSettingsCommand(
+	String userId,
+	boolean favoriteStationFacilityAlerts,
+	boolean favoriteRouteFacilityAlerts,
+	boolean reportStatusAlerts,
+	boolean dataQualityAlerts
+) {
+
+	public SaveNotificationSettingsCommand {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidNotificationPreferenceException("사용자 식별자가 필요합니다.");
+		}
+		userId = userId.trim();
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/LoadNotificationPreferencePort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/LoadNotificationPreferencePort.java
@@ -1,0 +1,13 @@
+package com.easysubway.notification.application.port.out;
+
+import com.easysubway.notification.domain.NotificationSettings;
+import com.easysubway.notification.domain.RegisteredDevice;
+import java.util.List;
+import java.util.Optional;
+
+public interface LoadNotificationPreferencePort {
+
+	Optional<NotificationSettings> loadNotificationSettings(String userId);
+
+	List<RegisteredDevice> loadDevices(String userId);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/SaveNotificationSettingsPort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/SaveNotificationSettingsPort.java
@@ -1,0 +1,8 @@
+package com.easysubway.notification.application.port.out;
+
+import com.easysubway.notification.domain.NotificationSettings;
+
+public interface SaveNotificationSettingsPort {
+
+	NotificationSettings saveNotificationSettings(NotificationSettings settings);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/SaveRegisteredDevicePort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/SaveRegisteredDevicePort.java
@@ -1,0 +1,8 @@
+package com.easysubway.notification.application.port.out;
+
+import com.easysubway.notification.domain.RegisteredDevice;
+
+public interface SaveRegisteredDevicePort {
+
+	RegisteredDevice saveRegisteredDevice(RegisteredDevice device);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/service/NotificationPreferenceService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/NotificationPreferenceService.java
@@ -1,0 +1,100 @@
+package com.easysubway.notification.application.service;
+
+import com.easysubway.notification.application.port.in.NotificationPreferenceUseCase;
+import com.easysubway.notification.application.port.in.RegisterDeviceCommand;
+import com.easysubway.notification.application.port.in.SaveNotificationSettingsCommand;
+import com.easysubway.notification.application.port.out.LoadNotificationPreferencePort;
+import com.easysubway.notification.application.port.out.SaveNotificationSettingsPort;
+import com.easysubway.notification.application.port.out.SaveRegisteredDevicePort;
+import com.easysubway.notification.domain.InvalidNotificationPreferenceException;
+import com.easysubway.notification.domain.NotificationSettings;
+import com.easysubway.notification.domain.RegisteredDevice;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationPreferenceService implements NotificationPreferenceUseCase {
+
+	private final LoadNotificationPreferencePort loadNotificationPreferencePort;
+	private final SaveRegisteredDevicePort saveRegisteredDevicePort;
+	private final SaveNotificationSettingsPort saveNotificationSettingsPort;
+	private final Clock clock;
+
+	@Autowired
+	public NotificationPreferenceService(
+		LoadNotificationPreferencePort loadNotificationPreferencePort,
+		SaveRegisteredDevicePort saveRegisteredDevicePort,
+		SaveNotificationSettingsPort saveNotificationSettingsPort
+	) {
+		this(
+			loadNotificationPreferencePort,
+			saveRegisteredDevicePort,
+			saveNotificationSettingsPort,
+			Clock.systemDefaultZone()
+		);
+	}
+
+	public NotificationPreferenceService(
+		LoadNotificationPreferencePort loadNotificationPreferencePort,
+		SaveRegisteredDevicePort saveRegisteredDevicePort,
+		SaveNotificationSettingsPort saveNotificationSettingsPort,
+		Clock clock
+	) {
+		this.loadNotificationPreferencePort = loadNotificationPreferencePort;
+		this.saveRegisteredDevicePort = saveRegisteredDevicePort;
+		this.saveNotificationSettingsPort = saveNotificationSettingsPort;
+		this.clock = clock;
+	}
+
+	@Override
+	public RegisteredDevice registerDevice(RegisterDeviceCommand command) {
+		var device = new RegisteredDevice(
+			command.userId(),
+			command.platform(),
+			command.deviceToken(),
+			LocalDateTime.now(clock)
+		);
+		return saveRegisteredDevicePort.saveRegisteredDevice(device);
+	}
+
+	@Override
+	public NotificationSettings getNotificationSettings(String userId) {
+		String normalizedUserId = requireUserId(userId);
+		return loadNotificationPreferencePort.loadNotificationSettings(normalizedUserId)
+			.orElseGet(() -> defaultSettings(normalizedUserId));
+	}
+
+	@Override
+	public NotificationSettings saveNotificationSettings(SaveNotificationSettingsCommand command) {
+		var settings = new NotificationSettings(
+			command.userId(),
+			command.favoriteStationFacilityAlerts(),
+			command.favoriteRouteFacilityAlerts(),
+			command.reportStatusAlerts(),
+			command.dataQualityAlerts(),
+			LocalDateTime.now(clock)
+		);
+		return saveNotificationSettingsPort.saveNotificationSettings(settings);
+	}
+
+	private NotificationSettings defaultSettings(String userId) {
+		// 주요 이동 안전 알림은 기본 수신으로 두고, 데이터 품질 알림만 사용자가 켜도록 둔다.
+		return new NotificationSettings(
+			userId,
+			true,
+			true,
+			true,
+			false,
+			LocalDateTime.now(clock)
+		);
+	}
+
+	private String requireUserId(String userId) {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidNotificationPreferenceException("사용자 식별자가 필요합니다.");
+		}
+		return userId.trim();
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/DevicePlatform.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/DevicePlatform.java
@@ -1,0 +1,6 @@
+package com.easysubway.notification.domain;
+
+public enum DevicePlatform {
+	ANDROID,
+	IOS
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/InvalidNotificationPreferenceException.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/InvalidNotificationPreferenceException.java
@@ -1,0 +1,10 @@
+package com.easysubway.notification.domain;
+
+import com.easysubway.common.error.InvalidRequestException;
+
+public class InvalidNotificationPreferenceException extends InvalidRequestException {
+
+	public InvalidNotificationPreferenceException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/NotificationSettings.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/NotificationSettings.java
@@ -1,0 +1,23 @@
+package com.easysubway.notification.domain;
+
+import java.time.LocalDateTime;
+
+public record NotificationSettings(
+	String userId,
+	boolean favoriteStationFacilityAlerts,
+	boolean favoriteRouteFacilityAlerts,
+	boolean reportStatusAlerts,
+	boolean dataQualityAlerts,
+	LocalDateTime updatedAt
+) {
+
+	public NotificationSettings {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidNotificationPreferenceException("사용자 식별자가 필요합니다.");
+		}
+		if (updatedAt == null) {
+			throw new InvalidNotificationPreferenceException("알림 설정 시간이 필요합니다.");
+		}
+		userId = userId.trim();
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/RegisteredDevice.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/RegisteredDevice.java
@@ -1,0 +1,28 @@
+package com.easysubway.notification.domain;
+
+import java.time.LocalDateTime;
+
+public record RegisteredDevice(
+	String userId,
+	DevicePlatform platform,
+	String deviceToken,
+	LocalDateTime registeredAt
+) {
+
+	public RegisteredDevice {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidNotificationPreferenceException("사용자 식별자가 필요합니다.");
+		}
+		if (platform == null) {
+			throw new InvalidNotificationPreferenceException("기기 플랫폼을 선택해야 합니다.");
+		}
+		if (deviceToken == null || deviceToken.isBlank()) {
+			throw new InvalidNotificationPreferenceException("기기 토큰이 필요합니다.");
+		}
+		if (registeredAt == null) {
+			throw new InvalidNotificationPreferenceException("기기 등록 시간이 필요합니다.");
+		}
+		userId = userId.trim();
+		deviceToken = deviceToken.trim();
+	}
+}

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/web/NotificationPreferenceControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/web/NotificationPreferenceControllerTest.java
@@ -1,0 +1,133 @@
+package com.easysubway.notification.adapter.in.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("알림 설정 API")
+class NotificationPreferenceControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("인증 사용자 기준으로 기기 토큰을 등록한다")
+	void registerDeviceUsesAuthenticatedUser() throws Exception {
+		mockMvc.perform(post("/api/v1/devices")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "spoofed-user",
+					  "platform": "ANDROID",
+					  "deviceToken": "device-token-1"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.userId").value("anonymous-user-1"))
+			.andExpect(jsonPath("$.data.platform").value("ANDROID"))
+			.andExpect(jsonPath("$.data.deviceToken").value("device-token-1"))
+			.andExpect(jsonPath("$.data.registeredAt").isNotEmpty());
+	}
+
+	@Test
+	@DisplayName("인증 사용자 기준으로 알림 설정을 저장하고 조회한다")
+	void notificationSettingsCanBeSavedAndRead() throws Exception {
+		mockMvc.perform(put("/api/v1/me/notification-settings")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "spoofed-user",
+					  "favoriteStationFacilityAlerts": true,
+					  "favoriteRouteFacilityAlerts": false,
+					  "reportStatusAlerts": true,
+					  "dataQualityAlerts": true
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.userId").value("anonymous-user-1"))
+			.andExpect(jsonPath("$.data.favoriteStationFacilityAlerts").value(true))
+			.andExpect(jsonPath("$.data.favoriteRouteFacilityAlerts").value(false))
+			.andExpect(jsonPath("$.data.reportStatusAlerts").value(true))
+			.andExpect(jsonPath("$.data.dataQualityAlerts").value(true));
+
+		mockMvc.perform(get("/api/v1/me/notification-settings")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.favoriteRouteFacilityAlerts").value(false))
+			.andExpect(jsonPath("$.data.dataQualityAlerts").value(true));
+	}
+
+	@Test
+	@DisplayName("알림 API는 인증된 사용자만 사용할 수 있다")
+	void notificationApisRequireAuthentication() throws Exception {
+		mockMvc.perform(get("/api/v1/me/notification-settings"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(post("/api/v1/devices")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "platform": "IOS",
+					  "deviceToken": "device-token-1"
+					}
+					"""))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("알 수 없는 기기 플랫폼은 공통 400 응답으로 거부한다")
+	void registerDeviceRejectsUnknownPlatform() throws Exception {
+		mockMvc.perform(post("/api/v1/devices")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "platform": "WATCH",
+					  "deviceToken": "device-token-1"
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("요청 본문을 확인해야 합니다."));
+	}
+
+	@Test
+	@DisplayName("빈 기기 토큰은 공통 400 응답으로 거부한다")
+	void registerDeviceRejectsBlankToken() throws Exception {
+		mockMvc.perform(post("/api/v1/devices")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "platform": "IOS",
+					  "deviceToken": ""
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("기기 토큰이 필요합니다."));
+	}
+}

--- a/backend/src/test/java/com/easysubway/notification/application/service/NotificationPreferenceServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notification/application/service/NotificationPreferenceServiceTest.java
@@ -1,0 +1,106 @@
+package com.easysubway.notification.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.notification.adapter.out.persistence.InMemoryNotificationPreferenceRepository;
+import com.easysubway.notification.application.port.in.RegisterDeviceCommand;
+import com.easysubway.notification.application.port.in.SaveNotificationSettingsCommand;
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.InvalidNotificationPreferenceException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("알림 설정 서비스")
+class NotificationPreferenceServiceTest {
+
+	private final InMemoryNotificationPreferenceRepository repository = new InMemoryNotificationPreferenceRepository();
+	private final NotificationPreferenceService service = new NotificationPreferenceService(
+		repository,
+		repository,
+		repository,
+		Clock.fixed(Instant.parse("2026-06-13T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+	);
+
+	@Test
+	@DisplayName("새 사용자는 이동 안전에 필요한 기본 알림을 켠 상태로 조회한다")
+	void getSettingsReturnsDefaultEnabledSettings() {
+		var settings = service.getNotificationSettings("anonymous-user-1");
+
+		assertThat(settings.userId()).isEqualTo("anonymous-user-1");
+		assertThat(settings.favoriteStationFacilityAlerts()).isTrue();
+		assertThat(settings.favoriteRouteFacilityAlerts()).isTrue();
+		assertThat(settings.reportStatusAlerts()).isTrue();
+		assertThat(settings.dataQualityAlerts()).isFalse();
+		assertThat(settings.updatedAt()).isEqualTo(LocalDateTime.of(2026, 6, 13, 9, 0));
+	}
+
+	@Test
+	@DisplayName("사용자는 알림 종류별 수신 여부를 저장할 수 있다")
+	void saveSettingsStoresChannelPreferences() {
+		var settings = service.saveNotificationSettings(new SaveNotificationSettingsCommand(
+			"anonymous-user-1",
+			true,
+			false,
+			true,
+			true
+		));
+
+		assertThat(settings.favoriteStationFacilityAlerts()).isTrue();
+		assertThat(settings.favoriteRouteFacilityAlerts()).isFalse();
+		assertThat(settings.reportStatusAlerts()).isTrue();
+		assertThat(settings.dataQualityAlerts()).isTrue();
+		assertThat(settings.updatedAt()).isEqualTo(LocalDateTime.of(2026, 6, 13, 9, 0));
+		assertThat(service.getNotificationSettings("anonymous-user-1")).isEqualTo(settings);
+	}
+
+	@Test
+	@DisplayName("기기 토큰은 사용자와 플랫폼 기준으로 저장하고 같은 토큰은 갱신한다")
+	void registerDeviceStoresAndUpdatesDeviceToken() {
+		var device = service.registerDevice(new RegisterDeviceCommand(
+			"anonymous-user-1",
+			DevicePlatform.ANDROID,
+			"device-token-1"
+		));
+		var updated = service.registerDevice(new RegisterDeviceCommand(
+			"anonymous-user-1",
+			DevicePlatform.ANDROID,
+			"device-token-1"
+		));
+
+		assertThat(device.userId()).isEqualTo("anonymous-user-1");
+		assertThat(device.platform()).isEqualTo(DevicePlatform.ANDROID);
+		assertThat(device.deviceToken()).isEqualTo("device-token-1");
+		assertThat(device.registeredAt()).isEqualTo(LocalDateTime.of(2026, 6, 13, 9, 0));
+		assertThat(updated).isEqualTo(device);
+		assertThat(repository.loadDevices("anonymous-user-1")).containsExactly(device);
+	}
+
+	@Test
+	@DisplayName("알림 명령은 사용자, 플랫폼, 기기 토큰을 요구한다")
+	void notificationCommandsRequireUserPlatformAndToken() {
+		assertThatThrownBy(() -> service.getNotificationSettings(""))
+			.isInstanceOf(InvalidNotificationPreferenceException.class)
+			.hasMessage("사용자 식별자가 필요합니다.");
+
+		assertThatThrownBy(() -> service.registerDevice(new RegisterDeviceCommand(
+			"anonymous-user-1",
+			null,
+			"device-token-1"
+		)))
+			.isInstanceOf(InvalidNotificationPreferenceException.class)
+			.hasMessage("기기 플랫폼을 선택해야 합니다.");
+
+		assertThatThrownBy(() -> service.registerDevice(new RegisterDeviceCommand(
+			"anonymous-user-1",
+			DevicePlatform.IOS,
+			""
+		)))
+			.isInstanceOf(InvalidNotificationPreferenceException.class)
+			.hasMessage("기기 토큰이 필요합니다.");
+	}
+}

--- a/backend/src/test/java/com/easysubway/notification/application/service/NotificationPreferenceServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notification/application/service/NotificationPreferenceServiceTest.java
@@ -81,6 +81,26 @@ class NotificationPreferenceServiceTest {
 	}
 
 	@Test
+	@DisplayName("같은 기기 토큰은 새 사용자 등록 시 이전 사용자 목록에서 제거한다")
+	void registerDeviceMovesTokenOwnershipToLatestUser() {
+		var oldOwnerDevice = service.registerDevice(new RegisterDeviceCommand(
+			"anonymous-user-1",
+			DevicePlatform.IOS,
+			"shared-device-token"
+		));
+		var newOwnerDevice = service.registerDevice(new RegisterDeviceCommand(
+			"anonymous-user-2",
+			DevicePlatform.IOS,
+			"shared-device-token"
+		));
+
+		assertThat(oldOwnerDevice.userId()).isEqualTo("anonymous-user-1");
+		assertThat(newOwnerDevice.userId()).isEqualTo("anonymous-user-2");
+		assertThat(repository.loadDevices("anonymous-user-1")).isEmpty();
+		assertThat(repository.loadDevices("anonymous-user-2")).containsExactly(newOwnerDevice);
+	}
+
+	@Test
 	@DisplayName("알림 명령은 사용자, 플랫폼, 기기 토큰을 요구한다")
 	void notificationCommandsRequireUserPlatformAndToken() {
 		assertThatThrownBy(() -> service.getNotificationSettings(""))

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -372,8 +372,53 @@ test("백엔드 즐겨찾기 역은 헥사고날 API 경계를 따른다", () =>
   assert.match(controller, /@DeleteMapping\("\/api\/v1\/me\/favorites\/stations\/\{stationId\}"\)/);
   assert.match(controller, /Principal principal/);
   assert.doesNotMatch(controller, /RequestParam\(required = false\) String userId/);
-  assert.match(security, /securityMatcher\("\/api\/v1\/me\/favorites\/\*\*"\)/);
+  assert.match(security, /securityMatcher\("\/api\/v1\/me\/favorites\/\*\*"/);
   assert.match(security, /anyRequest\(\)\.authenticated\(\)/);
+});
+
+test("백엔드 알림 설정은 인증 사용자 기준 헥사고날 API 경계를 따른다", () => {
+  const device = read("backend/src/main/java/com/easysubway/notification/domain/RegisteredDevice.java");
+  const settings = read("backend/src/main/java/com/easysubway/notification/domain/NotificationSettings.java");
+  const platform = read("backend/src/main/java/com/easysubway/notification/domain/DevicePlatform.java");
+  const invalidNotification = read("backend/src/main/java/com/easysubway/notification/domain/InvalidNotificationPreferenceException.java");
+  const useCase = read("backend/src/main/java/com/easysubway/notification/application/port/in/NotificationPreferenceUseCase.java");
+  const registerCommand = read("backend/src/main/java/com/easysubway/notification/application/port/in/RegisterDeviceCommand.java");
+  const saveCommand = read("backend/src/main/java/com/easysubway/notification/application/port/in/SaveNotificationSettingsCommand.java");
+  const loadPort = read("backend/src/main/java/com/easysubway/notification/application/port/out/LoadNotificationPreferencePort.java");
+  const saveDevicePort = read("backend/src/main/java/com/easysubway/notification/application/port/out/SaveRegisteredDevicePort.java");
+  const saveSettingsPort = read("backend/src/main/java/com/easysubway/notification/application/port/out/SaveNotificationSettingsPort.java");
+  const service = read("backend/src/main/java/com/easysubway/notification/application/service/NotificationPreferenceService.java");
+  const repository = read("backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryNotificationPreferenceRepository.java");
+  const controller = read("backend/src/main/java/com/easysubway/notification/adapter/in/web/NotificationPreferenceController.java");
+  const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
+
+  assert.match(device, /record RegisteredDevice/);
+  assert.match(device, /registeredAt/);
+  assert.match(settings, /record NotificationSettings/);
+  assert.match(settings, /favoriteStationFacilityAlerts/);
+  assert.match(settings, /favoriteRouteFacilityAlerts/);
+  assert.match(settings, /reportStatusAlerts/);
+  assert.match(settings, /dataQualityAlerts/);
+  assert.match(platform, /ANDROID/);
+  assert.match(platform, /IOS/);
+  assert.match(invalidNotification, /extends InvalidRequestException/);
+  assert.match(useCase, /interface NotificationPreferenceUseCase/);
+  assert.match(useCase, /registerDevice/);
+  assert.match(useCase, /getNotificationSettings/);
+  assert.match(useCase, /saveNotificationSettings/);
+  assert.match(registerCommand, /record RegisterDeviceCommand/);
+  assert.match(saveCommand, /record SaveNotificationSettingsCommand/);
+  assert.match(loadPort, /interface LoadNotificationPreferencePort/);
+  assert.match(saveDevicePort, /interface SaveRegisteredDevicePort/);
+  assert.match(saveSettingsPort, /interface SaveNotificationSettingsPort/);
+  assert.match(service, /implements NotificationPreferenceUseCase/);
+  assert.match(repository, /implements[\s\S]*LoadNotificationPreferencePort[\s\S]*SaveRegisteredDevicePort[\s\S]*SaveNotificationSettingsPort/);
+  assert.match(controller, /@PostMapping\("\/api\/v1\/devices"\)/);
+  assert.match(controller, /@GetMapping\("\/api\/v1\/me\/notification-settings"\)/);
+  assert.match(controller, /@PutMapping\("\/api\/v1\/me\/notification-settings"\)/);
+  assert.match(controller, /Principal principal/);
+  assert.doesNotMatch(controller, /RequestParam\(required = false\) String userId/);
+  assert.match(security, /securityMatcher\("\/api\/v1\/me\/favorites\/\*\*", "\/api\/v1\/devices", "\/api\/v1\/me\/notification-settings"\)/);
 });
 
 test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {


### PR DESCRIPTION
## 관련 이슈

Closes #42

## 배경

즐겨찾기 역과 시설 신고 흐름이 들어오면서, 사용자가 관심 있는 역/노선의 편의시설 변경과 신고 처리 상태를 받을 수 있는 백엔드 계약이 필요해졌습니다. 이번 변경은 실제 푸시 발송이 아니라 인증 사용자 기준의 기기 등록과 알림 설정 저장 API를 먼저 고정합니다.

## 변경 사항

- Android/iOS 기기 토큰 등록 API를 추가했습니다.
- 인증 사용자 기준 알림 설정 조회/저장 API를 추가했습니다.
- 알림 설정 도메인, use case, command, output port, in-memory adapter를 헥사고날 구조로 나눴습니다.
- 사용자 보안 필터에 기기 등록과 알림 설정 경로를 포함했습니다.
- 알림 설정 API/서비스 테스트와 저장소 계약 테스트를 추가했습니다.

## 검증

- `./gradlew test --no-daemon --console=plain`
- `node --test tools/ci/*.test.mjs`
- `git diff --check --cached`
- `git ls-files '*.md'`
- 보안 검토: staged notification API diff에서 reportable finding 0건

## 리스크

- 현재 저장소 adapter는 bootstrap용 in-memory 구현입니다. 실제 푸시 발송, 영속 저장소, 요청 쿼터, provider secret 처리는 별도 작업에서 검토해야 합니다.
