### PR TITLE
[Feat] 즐겨찾기 경로 API 기반 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteRouteController.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteRouteController.java
@@ -1,0 +1,103 @@
+package com.easysubway.favorite.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.favorite.application.port.in.FavoriteRouteUseCase;
+import com.easysubway.favorite.application.port.in.ListFavoriteRoutesCommand;
+import com.easysubway.favorite.application.port.in.RemoveFavoriteRouteCommand;
+import com.easysubway.favorite.application.port.in.SaveFavoriteRouteCommand;
+import com.easysubway.favorite.domain.FavoriteRouteWithDetails;
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.domain.RouteSearchStatus;
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class FavoriteRouteController {
+
+	private final FavoriteRouteUseCase favoriteRouteUseCase;
+
+	FavoriteRouteController(FavoriteRouteUseCase favoriteRouteUseCase) {
+		this.favoriteRouteUseCase = favoriteRouteUseCase;
+	}
+
+	@GetMapping("/api/v1/me/favorites/routes")
+	ApiResponse<List<FavoriteRouteResponse>> listFavoriteRoutes(Principal principal) {
+		List<FavoriteRouteResponse> response = favoriteRouteUseCase
+			.listFavoriteRoutes(new ListFavoriteRoutesCommand(principal.getName()))
+			.stream()
+			.map(FavoriteRouteResponse::from)
+			.toList();
+		return ApiResponse.ok(response);
+	}
+
+	@PostMapping("/api/v1/me/favorites/routes")
+	ApiResponse<FavoriteRouteResponse> saveFavoriteRoute(
+		@RequestBody SaveFavoriteRouteRequest request,
+		Principal principal
+	) {
+		FavoriteRouteWithDetails favoriteRoute = favoriteRouteUseCase.saveFavoriteRoute(
+			new SaveFavoriteRouteCommand(principal.getName(), request.routeSearchId())
+		);
+		return ApiResponse.ok(FavoriteRouteResponse.from(favoriteRoute));
+	}
+
+	@DeleteMapping("/api/v1/me/favorites/routes/{favoriteRouteId}")
+	ApiResponse<Void> removeFavoriteRoute(
+		@PathVariable String favoriteRouteId,
+		Principal principal
+	) {
+		favoriteRouteUseCase.removeFavoriteRoute(new RemoveFavoriteRouteCommand(principal.getName(), favoriteRouteId));
+		return ApiResponse.ok(null);
+	}
+
+	record SaveFavoriteRouteRequest(
+		String userId,
+		String routeSearchId
+	) {
+	}
+
+	record FavoriteRouteResponse(
+		String userId,
+		String favoriteRouteId,
+		String routeSearchId,
+		String originStationId,
+		String originStationName,
+		String destinationStationId,
+		String destinationStationName,
+		MobilityType mobilityType,
+		RouteSearchStatus status,
+		String lineId,
+		String lineName,
+		int score,
+		LocalDateTime routeCreatedAt,
+		LocalDateTime addedAt
+	) {
+
+		static FavoriteRouteResponse from(FavoriteRouteWithDetails favoriteRoute) {
+			var route = favoriteRoute.route();
+			return new FavoriteRouteResponse(
+				favoriteRoute.favoriteRoute().userId(),
+				favoriteRoute.favoriteRoute().routeSearchId(),
+				route.routeSearchId(),
+				route.originStationId(),
+				route.originStationName(),
+				route.destinationStationId(),
+				route.destinationStationName(),
+				route.mobilityType(),
+				route.status(),
+				route.lineId(),
+				route.lineName(),
+				route.score(),
+				route.createdAt(),
+				favoriteRoute.favoriteRoute().addedAt()
+			);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepository.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepository.java
@@ -1,0 +1,58 @@
+package com.easysubway.favorite.adapter.out.persistence;
+
+import com.easysubway.favorite.application.port.out.DeleteFavoriteRoutePort;
+import com.easysubway.favorite.application.port.out.LoadFavoriteRoutePort;
+import com.easysubway.favorite.application.port.out.SaveFavoriteRoutePort;
+import com.easysubway.favorite.domain.FavoriteRoute;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryFavoriteRouteRepository implements
+	LoadFavoriteRoutePort,
+	SaveFavoriteRoutePort,
+	DeleteFavoriteRoutePort {
+
+	static final int MAX_FAVORITE_ROUTES_PER_USER = 100;
+
+	private final Map<String, Map<String, FavoriteRoute>> favoritesByUserId = new LinkedHashMap<>();
+
+	@Override
+	public synchronized List<FavoriteRoute> loadFavoriteRoutes(String userId) {
+		return new ArrayList<>(favoritesByUserId.getOrDefault(userId, Map.of()).values());
+	}
+
+	@Override
+	public synchronized Optional<FavoriteRoute> loadFavoriteRoute(String userId, String routeSearchId) {
+		return Optional.ofNullable(favoritesByUserId.getOrDefault(userId, Map.of()).get(routeSearchId));
+	}
+
+	@Override
+	public synchronized FavoriteRoute saveFavoriteRoute(FavoriteRoute favoriteRoute) {
+		Map<String, FavoriteRoute> favorites = favoritesByUserId
+			.computeIfAbsent(favoriteRoute.userId(), ignored -> new LinkedHashMap<>());
+		favorites.put(favoriteRoute.routeSearchId(), favoriteRoute);
+		evictOldestFavoriteRoutes(favorites);
+		return favoriteRoute;
+	}
+
+	@Override
+	public synchronized void deleteFavoriteRoute(String userId, String routeSearchId) {
+		Map<String, FavoriteRoute> favorites = favoritesByUserId.get(userId);
+		if (favorites != null) {
+			favorites.remove(routeSearchId);
+		}
+	}
+
+	private void evictOldestFavoriteRoutes(Map<String, FavoriteRoute> favorites) {
+		// 경로 즐겨찾기는 검색할 때마다 새 ID가 생기므로 사용자별 인메모리 보관량을 제한한다.
+		while (favorites.size() > MAX_FAVORITE_ROUTES_PER_USER) {
+			String oldestRouteSearchId = favorites.keySet().iterator().next();
+			favorites.remove(oldestRouteSearchId);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/in/FavoriteRouteUseCase.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/in/FavoriteRouteUseCase.java
@@ -1,0 +1,13 @@
+package com.easysubway.favorite.application.port.in;
+
+import com.easysubway.favorite.domain.FavoriteRouteWithDetails;
+import java.util.List;
+
+public interface FavoriteRouteUseCase {
+
+	List<FavoriteRouteWithDetails> listFavoriteRoutes(ListFavoriteRoutesCommand command);
+
+	FavoriteRouteWithDetails saveFavoriteRoute(SaveFavoriteRouteCommand command);
+
+	void removeFavoriteRoute(RemoveFavoriteRouteCommand command);
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/in/ListFavoriteRoutesCommand.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/in/ListFavoriteRoutesCommand.java
@@ -1,0 +1,4 @@
+package com.easysubway.favorite.application.port.in;
+
+public record ListFavoriteRoutesCommand(String userId) {
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/in/RemoveFavoriteRouteCommand.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/in/RemoveFavoriteRouteCommand.java
@@ -1,0 +1,7 @@
+package com.easysubway.favorite.application.port.in;
+
+public record RemoveFavoriteRouteCommand(
+	String userId,
+	String favoriteRouteId
+) {
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/in/SaveFavoriteRouteCommand.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/in/SaveFavoriteRouteCommand.java
@@ -1,0 +1,7 @@
+package com.easysubway.favorite.application.port.in;
+
+public record SaveFavoriteRouteCommand(
+	String userId,
+	String routeSearchId
+) {
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/out/DeleteFavoriteRoutePort.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/out/DeleteFavoriteRoutePort.java
@@ -1,0 +1,6 @@
+package com.easysubway.favorite.application.port.out;
+
+public interface DeleteFavoriteRoutePort {
+
+	void deleteFavoriteRoute(String userId, String routeSearchId);
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/out/LoadFavoriteRoutePort.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/out/LoadFavoriteRoutePort.java
@@ -1,0 +1,12 @@
+package com.easysubway.favorite.application.port.out;
+
+import com.easysubway.favorite.domain.FavoriteRoute;
+import java.util.List;
+import java.util.Optional;
+
+public interface LoadFavoriteRoutePort {
+
+	List<FavoriteRoute> loadFavoriteRoutes(String userId);
+
+	Optional<FavoriteRoute> loadFavoriteRoute(String userId, String routeSearchId);
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/out/SaveFavoriteRoutePort.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/out/SaveFavoriteRoutePort.java
@@ -1,0 +1,8 @@
+package com.easysubway.favorite.application.port.out;
+
+import com.easysubway.favorite.domain.FavoriteRoute;
+
+public interface SaveFavoriteRoutePort {
+
+	FavoriteRoute saveFavoriteRoute(FavoriteRoute favoriteRoute);
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteRouteService.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteRouteService.java
@@ -79,7 +79,7 @@ public class FavoriteRouteService implements FavoriteRouteUseCase {
 			.loadFavoriteRoute(command.userId(), command.routeSearchId())
 			.orElseGet(() -> saveFavoriteRoutePort.saveFavoriteRoute(new FavoriteRoute(
 				command.userId(),
-				command.routeSearchId(),
+				route,
 				LocalDateTime.now(clock)
 			)));
 
@@ -94,7 +94,7 @@ public class FavoriteRouteService implements FavoriteRouteUseCase {
 	}
 
 	private FavoriteRouteWithDetails withDetails(FavoriteRoute favoriteRoute) {
-		return new FavoriteRouteWithDetails(favoriteRoute, loadRouteSearch(favoriteRoute.routeSearchId()));
+		return new FavoriteRouteWithDetails(favoriteRoute, favoriteRoute.route());
 	}
 
 	private RouteSearchResult loadRouteSearch(String routeSearchId) {

--- a/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteRouteService.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteRouteService.java
@@ -73,15 +73,20 @@ public class FavoriteRouteService implements FavoriteRouteUseCase {
 	public FavoriteRouteWithDetails saveFavoriteRoute(SaveFavoriteRouteCommand command) {
 		requireUserId(command.userId());
 		requireRouteSearchId(command.routeSearchId());
+		FavoriteRoute existingFavoriteRoute = loadFavoriteRoutePort
+			.loadFavoriteRoute(command.userId(), command.routeSearchId())
+			.orElse(null);
+		if (existingFavoriteRoute != null) {
+			return withDetails(existingFavoriteRoute);
+		}
+
 		RouteSearchResult route = loadRouteSearch(command.routeSearchId());
 
-		FavoriteRoute favoriteRoute = loadFavoriteRoutePort
-			.loadFavoriteRoute(command.userId(), command.routeSearchId())
-			.orElseGet(() -> saveFavoriteRoutePort.saveFavoriteRoute(new FavoriteRoute(
-				command.userId(),
-				route,
-				LocalDateTime.now(clock)
-			)));
+		FavoriteRoute favoriteRoute = saveFavoriteRoutePort.saveFavoriteRoute(new FavoriteRoute(
+			command.userId(),
+			route,
+			LocalDateTime.now(clock)
+		));
 
 		return new FavoriteRouteWithDetails(favoriteRoute, route);
 	}

--- a/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteRouteService.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteRouteService.java
@@ -1,0 +1,117 @@
+package com.easysubway.favorite.application.service;
+
+import com.easysubway.favorite.application.port.in.FavoriteRouteUseCase;
+import com.easysubway.favorite.application.port.in.ListFavoriteRoutesCommand;
+import com.easysubway.favorite.application.port.in.RemoveFavoriteRouteCommand;
+import com.easysubway.favorite.application.port.in.SaveFavoriteRouteCommand;
+import com.easysubway.favorite.application.port.out.DeleteFavoriteRoutePort;
+import com.easysubway.favorite.application.port.out.LoadFavoriteRoutePort;
+import com.easysubway.favorite.application.port.out.SaveFavoriteRoutePort;
+import com.easysubway.favorite.domain.FavoriteRoute;
+import com.easysubway.favorite.domain.FavoriteRouteWithDetails;
+import com.easysubway.favorite.domain.InvalidFavoriteRouteException;
+import com.easysubway.route.application.port.out.LoadRouteSearchPort;
+import com.easysubway.route.domain.RouteSearchNotFoundException;
+import com.easysubway.route.domain.RouteSearchResult;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FavoriteRouteService implements FavoriteRouteUseCase {
+
+	private final LoadFavoriteRoutePort loadFavoriteRoutePort;
+	private final SaveFavoriteRoutePort saveFavoriteRoutePort;
+	private final DeleteFavoriteRoutePort deleteFavoriteRoutePort;
+	private final LoadRouteSearchPort loadRouteSearchPort;
+	private final Clock clock;
+
+	@Autowired
+	public FavoriteRouteService(
+		LoadFavoriteRoutePort loadFavoriteRoutePort,
+		SaveFavoriteRoutePort saveFavoriteRoutePort,
+		DeleteFavoriteRoutePort deleteFavoriteRoutePort,
+		LoadRouteSearchPort loadRouteSearchPort
+	) {
+		this(
+			loadFavoriteRoutePort,
+			saveFavoriteRoutePort,
+			deleteFavoriteRoutePort,
+			loadRouteSearchPort,
+			Clock.systemDefaultZone()
+		);
+	}
+
+	public FavoriteRouteService(
+		LoadFavoriteRoutePort loadFavoriteRoutePort,
+		SaveFavoriteRoutePort saveFavoriteRoutePort,
+		DeleteFavoriteRoutePort deleteFavoriteRoutePort,
+		LoadRouteSearchPort loadRouteSearchPort,
+		Clock clock
+	) {
+		this.loadFavoriteRoutePort = loadFavoriteRoutePort;
+		this.saveFavoriteRoutePort = saveFavoriteRoutePort;
+		this.deleteFavoriteRoutePort = deleteFavoriteRoutePort;
+		this.loadRouteSearchPort = loadRouteSearchPort;
+		this.clock = clock;
+	}
+
+	@Override
+	public List<FavoriteRouteWithDetails> listFavoriteRoutes(ListFavoriteRoutesCommand command) {
+		requireUserId(command.userId());
+		return loadFavoriteRoutePort.loadFavoriteRoutes(command.userId())
+			.stream()
+			.sorted(Comparator.comparing(FavoriteRoute::addedAt))
+			.map(this::withDetails)
+			.toList();
+	}
+
+	@Override
+	public FavoriteRouteWithDetails saveFavoriteRoute(SaveFavoriteRouteCommand command) {
+		requireUserId(command.userId());
+		requireRouteSearchId(command.routeSearchId());
+		RouteSearchResult route = loadRouteSearch(command.routeSearchId());
+
+		FavoriteRoute favoriteRoute = loadFavoriteRoutePort
+			.loadFavoriteRoute(command.userId(), command.routeSearchId())
+			.orElseGet(() -> saveFavoriteRoutePort.saveFavoriteRoute(new FavoriteRoute(
+				command.userId(),
+				command.routeSearchId(),
+				LocalDateTime.now(clock)
+			)));
+
+		return new FavoriteRouteWithDetails(favoriteRoute, route);
+	}
+
+	@Override
+	public void removeFavoriteRoute(RemoveFavoriteRouteCommand command) {
+		requireUserId(command.userId());
+		requireRouteSearchId(command.favoriteRouteId());
+		deleteFavoriteRoutePort.deleteFavoriteRoute(command.userId(), command.favoriteRouteId());
+	}
+
+	private FavoriteRouteWithDetails withDetails(FavoriteRoute favoriteRoute) {
+		return new FavoriteRouteWithDetails(favoriteRoute, loadRouteSearch(favoriteRoute.routeSearchId()));
+	}
+
+	private RouteSearchResult loadRouteSearch(String routeSearchId) {
+		// 즐겨찾기 경로는 사용자가 방금 확인한 경로 검색 결과만 저장해 오래된 임의 ID 저장을 막는다.
+		return loadRouteSearchPort.loadRouteSearch(routeSearchId)
+			.orElseThrow(RouteSearchNotFoundException::new);
+	}
+
+	private void requireUserId(String userId) {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidFavoriteRouteException("사용자 식별자가 필요합니다.");
+		}
+	}
+
+	private void requireRouteSearchId(String routeSearchId) {
+		if (routeSearchId == null || routeSearchId.isBlank()) {
+			throw new InvalidFavoriteRouteException("경로 검색 식별자가 필요합니다.");
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/domain/FavoriteRoute.java
+++ b/backend/src/main/java/com/easysubway/favorite/domain/FavoriteRoute.java
@@ -1,0 +1,22 @@
+package com.easysubway.favorite.domain;
+
+import java.time.LocalDateTime;
+
+public record FavoriteRoute(
+	String userId,
+	String routeSearchId,
+	LocalDateTime addedAt
+) {
+
+	public FavoriteRoute {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidFavoriteRouteException("사용자 식별자가 필요합니다.");
+		}
+		if (routeSearchId == null || routeSearchId.isBlank()) {
+			throw new InvalidFavoriteRouteException("경로 검색 식별자가 필요합니다.");
+		}
+		if (addedAt == null) {
+			throw new InvalidFavoriteRouteException("추가 시각이 필요합니다.");
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/domain/FavoriteRoute.java
+++ b/backend/src/main/java/com/easysubway/favorite/domain/FavoriteRoute.java
@@ -1,10 +1,11 @@
 package com.easysubway.favorite.domain;
 
+import com.easysubway.route.domain.RouteSearchResult;
 import java.time.LocalDateTime;
 
 public record FavoriteRoute(
 	String userId,
-	String routeSearchId,
+	RouteSearchResult route,
 	LocalDateTime addedAt
 ) {
 
@@ -12,11 +13,18 @@ public record FavoriteRoute(
 		if (userId == null || userId.isBlank()) {
 			throw new InvalidFavoriteRouteException("사용자 식별자가 필요합니다.");
 		}
-		if (routeSearchId == null || routeSearchId.isBlank()) {
+		if (route == null) {
+			throw new InvalidFavoriteRouteException("경로 검색 결과가 필요합니다.");
+		}
+		if (route.routeSearchId() == null || route.routeSearchId().isBlank()) {
 			throw new InvalidFavoriteRouteException("경로 검색 식별자가 필요합니다.");
 		}
 		if (addedAt == null) {
 			throw new InvalidFavoriteRouteException("추가 시각이 필요합니다.");
 		}
+	}
+
+	public String routeSearchId() {
+		return route.routeSearchId();
 	}
 }

--- a/backend/src/main/java/com/easysubway/favorite/domain/FavoriteRouteWithDetails.java
+++ b/backend/src/main/java/com/easysubway/favorite/domain/FavoriteRouteWithDetails.java
@@ -1,0 +1,9 @@
+package com.easysubway.favorite.domain;
+
+import com.easysubway.route.domain.RouteSearchResult;
+
+public record FavoriteRouteWithDetails(
+	FavoriteRoute favoriteRoute,
+	RouteSearchResult route
+) {
+}

--- a/backend/src/main/java/com/easysubway/favorite/domain/InvalidFavoriteRouteException.java
+++ b/backend/src/main/java/com/easysubway/favorite/domain/InvalidFavoriteRouteException.java
@@ -1,0 +1,10 @@
+package com.easysubway.favorite.domain;
+
+import com.easysubway.common.error.InvalidRequestException;
+
+public class InvalidFavoriteRouteException extends InvalidRequestException {
+
+	public InvalidFavoriteRouteException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteRouteControllerTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteRouteControllerTest.java
@@ -1,0 +1,138 @@
+package com.easysubway.favorite.adapter.in.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("즐겨찾기 경로 API")
+class FavoriteRouteControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private InMemoryRouteSearchRepository routeSearchRepository;
+
+	@Test
+	@DisplayName("인증 사용자 기준으로 경로를 저장하고 목록 조회와 삭제를 처리한다")
+	void favoriteRoutesCanBeSavedListedAndRemoved() throws Exception {
+		routeSearchRepository.saveRouteSearch(routeSearch("route-search-controller-1"));
+
+		mockMvc.perform(post("/api/v1/me/favorites/routes")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "spoofed-user",
+					  "routeSearchId": "route-search-controller-1"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.userId").value("anonymous-user-1"))
+			.andExpect(jsonPath("$.data.favoriteRouteId").value("route-search-controller-1"))
+			.andExpect(jsonPath("$.data.routeSearchId").value("route-search-controller-1"))
+			.andExpect(jsonPath("$.data.originStationName").value("상록수"))
+			.andExpect(jsonPath("$.data.destinationStationName").value("사당"))
+			.andExpect(jsonPath("$.data.lineName").value("수도권 4호선"))
+			.andExpect(jsonPath("$.data.addedAt").isNotEmpty());
+
+		mockMvc.perform(get("/api/v1/me/favorites/routes")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].routeSearchId").value("route-search-controller-1"))
+			.andExpect(jsonPath("$.data[0].originStationName").value("상록수"));
+
+		mockMvc.perform(delete("/api/v1/me/favorites/routes/route-search-controller-1")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true));
+
+		mockMvc.perform(get("/api/v1/me/favorites/routes")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data").isEmpty());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 경로 검색 결과는 공통 404 응답으로 거부한다")
+	void favoriteRoutesRejectUnknownRouteSearch() throws Exception {
+		mockMvc.perform(post("/api/v1/me/favorites/routes")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "routeSearchId": "missing-route-search"
+					}
+					"""))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("경로 검색 결과를 찾을 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("빈 경로 검색 식별자는 공통 400 응답으로 거부한다")
+	void favoriteRoutesRejectBlankRouteSearchId() throws Exception {
+		mockMvc.perform(post("/api/v1/me/favorites/routes")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "routeSearchId": ""
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").value("경로 검색 식별자가 필요합니다."));
+	}
+
+	@Test
+	@DisplayName("즐겨찾기 경로 목록은 인증된 사용자만 조회할 수 있다")
+	void favoriteRoutesRequireAuthentication() throws Exception {
+		mockMvc.perform(get("/api/v1/me/favorites/routes"))
+			.andExpect(status().isUnauthorized());
+	}
+
+	private RouteSearchResult routeSearch(String routeSearchId) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-sangnoksu",
+			"상록수",
+			"station-sadang",
+			"사당",
+			MobilityType.SENIOR,
+			RouteSearchStatus.FOUND,
+			"line-4",
+			"수도권 4호선",
+			90,
+			List.of(),
+			List.of(),
+			List.of(),
+			LocalDateTime.of(2026, 6, 13, 9, 0)
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepositoryTest.java
@@ -1,0 +1,32 @@
+package com.easysubway.favorite.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.favorite.domain.FavoriteRoute;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("즐겨찾기 경로 인메모리 저장소")
+class InMemoryFavoriteRouteRepositoryTest {
+
+	@Test
+	@DisplayName("사용자별 즐겨찾기 경로는 보관 한도를 넘기면 가장 오래된 항목부터 정리한다")
+	void saveFavoriteRouteEvictsOldestRouteWhenLimitExceeded() {
+		var repository = new InMemoryFavoriteRouteRepository();
+
+		for (int index = 0; index <= InMemoryFavoriteRouteRepository.MAX_FAVORITE_ROUTES_PER_USER; index++) {
+			repository.saveFavoriteRoute(new FavoriteRoute(
+				"anonymous-user-1",
+				"route-search-" + index,
+				LocalDateTime.of(2026, 6, 13, 9, 0).plusMinutes(index)
+			));
+		}
+
+		assertThat(repository.loadFavoriteRoutes("anonymous-user-1"))
+			.hasSize(InMemoryFavoriteRouteRepository.MAX_FAVORITE_ROUTES_PER_USER)
+			.extracting(FavoriteRoute::routeSearchId)
+			.doesNotContain("route-search-0")
+			.contains("route-search-1", "route-search-" + InMemoryFavoriteRouteRepository.MAX_FAVORITE_ROUTES_PER_USER);
+	}
+}

--- a/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepositoryTest.java
@@ -3,7 +3,11 @@ package com.easysubway.favorite.adapter.out.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.easysubway.favorite.domain.FavoriteRoute;
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +22,7 @@ class InMemoryFavoriteRouteRepositoryTest {
 		for (int index = 0; index <= InMemoryFavoriteRouteRepository.MAX_FAVORITE_ROUTES_PER_USER; index++) {
 			repository.saveFavoriteRoute(new FavoriteRoute(
 				"anonymous-user-1",
-				"route-search-" + index,
+				routeSearch("route-search-" + index),
 				LocalDateTime.of(2026, 6, 13, 9, 0).plusMinutes(index)
 			));
 		}
@@ -28,5 +32,24 @@ class InMemoryFavoriteRouteRepositoryTest {
 			.extracting(FavoriteRoute::routeSearchId)
 			.doesNotContain("route-search-0")
 			.contains("route-search-1", "route-search-" + InMemoryFavoriteRouteRepository.MAX_FAVORITE_ROUTES_PER_USER);
+	}
+
+	private RouteSearchResult routeSearch(String routeSearchId) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-sangnoksu",
+			"상록수",
+			"station-sadang",
+			"사당",
+			MobilityType.SENIOR,
+			RouteSearchStatus.FOUND,
+			"line-4",
+			"수도권 4호선",
+			90,
+			List.of(),
+			List.of(),
+			List.of(),
+			LocalDateTime.of(2026, 6, 13, 9, 0)
+		);
 	}
 }

--- a/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteRouteServiceTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteRouteServiceTest.java
@@ -74,6 +74,25 @@ class FavoriteRouteServiceTest {
 	}
 
 	@Test
+	@DisplayName("즐겨찾기 경로 목록은 임시 경로 검색 캐시가 정리돼도 저장한 요약을 보여준다")
+	void listFavoriteRoutesKeepsSavedRouteAfterRouteSearchEviction() {
+		routeSearchRepository.saveRouteSearch(routeSearch("route-search-saved", "상록수", "사당"));
+		service.saveFavoriteRoute(new SaveFavoriteRouteCommand("anonymous-user-1", "route-search-saved"));
+
+		for (int index = 0; index <= 1_000; index++) {
+			routeSearchRepository.saveRouteSearch(routeSearch("route-search-evict-" + index, "사당", "상록수"));
+		}
+
+		assertThat(service.listFavoriteRoutes(new ListFavoriteRoutesCommand("anonymous-user-1")))
+			.singleElement()
+			.satisfies(favorite -> {
+				assertThat(favorite.favoriteRoute().routeSearchId()).isEqualTo("route-search-saved");
+				assertThat(favorite.route().originStationName()).isEqualTo("상록수");
+				assertThat(favorite.route().destinationStationName()).isEqualTo("사당");
+			});
+	}
+
+	@Test
 	@DisplayName("삭제 요청은 같은 사용자와 같은 경로의 즐겨찾기만 제거한다")
 	void removeFavoriteRouteDeletesOnlyRequestedRoute() {
 		routeSearchRepository.saveRouteSearch(routeSearch("route-search-4", "상록수", "사당"));
@@ -117,13 +136,20 @@ class FavoriteRouteServiceTest {
 	@Test
 	@DisplayName("즐겨찾기 경로 도메인은 비어 있는 사용자와 경로 정보를 허용하지 않는다")
 	void favoriteRouteDomainRejectsInvalidState() {
-		assertThatThrownBy(() -> new FavoriteRoute("", "route-search-1", LocalDateTime.now()))
+		assertThatThrownBy(() -> new FavoriteRoute("", routeSearch("route-search-1", "상록수", "사당"), LocalDateTime.now()))
 			.isInstanceOf(InvalidFavoriteRouteException.class)
 			.hasMessage("사용자 식별자가 필요합니다.");
-		assertThatThrownBy(() -> new FavoriteRoute("anonymous-user-1", "", LocalDateTime.now()))
+		assertThatThrownBy(() -> new FavoriteRoute("anonymous-user-1", null, LocalDateTime.now()))
+			.isInstanceOf(InvalidFavoriteRouteException.class)
+			.hasMessage("경로 검색 결과가 필요합니다.");
+		assertThatThrownBy(() -> new FavoriteRoute("anonymous-user-1", routeSearch("", "상록수", "사당"), LocalDateTime.now()))
 			.isInstanceOf(InvalidFavoriteRouteException.class)
 			.hasMessage("경로 검색 식별자가 필요합니다.");
-		assertThatThrownBy(() -> new FavoriteRoute("anonymous-user-1", "route-search-1", null))
+		assertThatThrownBy(() -> new FavoriteRoute(
+			"anonymous-user-1",
+			routeSearch("route-search-1", "상록수", "사당"),
+			null
+		))
 			.isInstanceOf(InvalidFavoriteRouteException.class)
 			.hasMessage("추가 시각이 필요합니다.");
 	}

--- a/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteRouteServiceTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteRouteServiceTest.java
@@ -1,0 +1,149 @@
+package com.easysubway.favorite.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteRouteRepository;
+import com.easysubway.favorite.application.port.in.ListFavoriteRoutesCommand;
+import com.easysubway.favorite.application.port.in.RemoveFavoriteRouteCommand;
+import com.easysubway.favorite.application.port.in.SaveFavoriteRouteCommand;
+import com.easysubway.favorite.domain.FavoriteRoute;
+import com.easysubway.favorite.domain.InvalidFavoriteRouteException;
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
+import com.easysubway.route.domain.RouteSearchNotFoundException;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("즐겨찾기 경로 서비스")
+class FavoriteRouteServiceTest {
+
+	private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-13T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+	private final InMemoryFavoriteRouteRepository favoriteRouteRepository = new InMemoryFavoriteRouteRepository();
+	private final InMemoryRouteSearchRepository routeSearchRepository = new InMemoryRouteSearchRepository();
+	private final FavoriteRouteService service = new FavoriteRouteService(
+		favoriteRouteRepository,
+		favoriteRouteRepository,
+		favoriteRouteRepository,
+		routeSearchRepository,
+		CLOCK
+	);
+
+	@Test
+	@DisplayName("경로 검색 결과를 즐겨찾기 경로로 저장하고 중복 저장은 기존 항목을 반환한다")
+	void saveFavoriteRouteStoresRouteSearchResultOnce() {
+		routeSearchRepository.saveRouteSearch(routeSearch("route-search-1", "상록수", "사당"));
+
+		var favorite = service.saveFavoriteRoute(new SaveFavoriteRouteCommand(
+			"anonymous-user-1",
+			"route-search-1"
+		));
+		var duplicated = service.saveFavoriteRoute(new SaveFavoriteRouteCommand(
+			"anonymous-user-1",
+			"route-search-1"
+		));
+
+		assertThat(favorite.favoriteRoute().userId()).isEqualTo("anonymous-user-1");
+		assertThat(favorite.favoriteRoute().routeSearchId()).isEqualTo("route-search-1");
+		assertThat(favorite.favoriteRoute().addedAt()).isEqualTo(LocalDateTime.of(2026, 6, 13, 9, 0));
+		assertThat(favorite.route().originStationName()).isEqualTo("상록수");
+		assertThat(favorite.route().destinationStationName()).isEqualTo("사당");
+		assertThat(duplicated).isEqualTo(favorite);
+	}
+
+	@Test
+	@DisplayName("즐겨찾기 경로 목록은 저장한 순서대로 조회한다")
+	void listFavoriteRoutesReturnsSavedOrder() {
+		routeSearchRepository.saveRouteSearch(routeSearch("route-search-2", "상록수", "사당"));
+		routeSearchRepository.saveRouteSearch(routeSearch("route-search-3", "사당", "상록수"));
+
+		service.saveFavoriteRoute(new SaveFavoriteRouteCommand("anonymous-user-1", "route-search-2"));
+		service.saveFavoriteRoute(new SaveFavoriteRouteCommand("anonymous-user-1", "route-search-3"));
+
+		assertThat(service.listFavoriteRoutes(new ListFavoriteRoutesCommand("anonymous-user-1")))
+			.extracting(favorite -> favorite.favoriteRoute().routeSearchId())
+			.containsExactly("route-search-2", "route-search-3");
+	}
+
+	@Test
+	@DisplayName("삭제 요청은 같은 사용자와 같은 경로의 즐겨찾기만 제거한다")
+	void removeFavoriteRouteDeletesOnlyRequestedRoute() {
+		routeSearchRepository.saveRouteSearch(routeSearch("route-search-4", "상록수", "사당"));
+		routeSearchRepository.saveRouteSearch(routeSearch("route-search-5", "사당", "상록수"));
+		service.saveFavoriteRoute(new SaveFavoriteRouteCommand("anonymous-user-1", "route-search-4"));
+		service.saveFavoriteRoute(new SaveFavoriteRouteCommand("anonymous-user-1", "route-search-5"));
+
+		service.removeFavoriteRoute(new RemoveFavoriteRouteCommand("anonymous-user-1", "route-search-4"));
+
+		assertThat(service.listFavoriteRoutes(new ListFavoriteRoutesCommand("anonymous-user-1")))
+			.extracting(favorite -> favorite.favoriteRoute().routeSearchId())
+			.containsExactly("route-search-5");
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 경로 검색 결과는 즐겨찾기에 저장할 수 없다")
+	void saveFavoriteRouteRequiresExistingRouteSearchResult() {
+		assertThatThrownBy(() -> service.saveFavoriteRoute(new SaveFavoriteRouteCommand(
+			"anonymous-user-1",
+			"missing-route-search"
+		)))
+			.isInstanceOf(RouteSearchNotFoundException.class)
+			.hasMessage("경로 검색 결과를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("즐겨찾기 경로 명령은 사용자와 경로 식별자를 요구한다")
+	void favoriteRouteCommandsRequireUserAndRouteSearchId() {
+		assertThatThrownBy(() -> service.listFavoriteRoutes(new ListFavoriteRoutesCommand("")))
+			.isInstanceOf(InvalidFavoriteRouteException.class)
+			.hasMessage("사용자 식별자가 필요합니다.");
+
+		assertThatThrownBy(() -> service.saveFavoriteRoute(new SaveFavoriteRouteCommand(
+			"anonymous-user-1",
+			""
+		)))
+			.isInstanceOf(InvalidFavoriteRouteException.class)
+			.hasMessage("경로 검색 식별자가 필요합니다.");
+	}
+
+	@Test
+	@DisplayName("즐겨찾기 경로 도메인은 비어 있는 사용자와 경로 정보를 허용하지 않는다")
+	void favoriteRouteDomainRejectsInvalidState() {
+		assertThatThrownBy(() -> new FavoriteRoute("", "route-search-1", LocalDateTime.now()))
+			.isInstanceOf(InvalidFavoriteRouteException.class)
+			.hasMessage("사용자 식별자가 필요합니다.");
+		assertThatThrownBy(() -> new FavoriteRoute("anonymous-user-1", "", LocalDateTime.now()))
+			.isInstanceOf(InvalidFavoriteRouteException.class)
+			.hasMessage("경로 검색 식별자가 필요합니다.");
+		assertThatThrownBy(() -> new FavoriteRoute("anonymous-user-1", "route-search-1", null))
+			.isInstanceOf(InvalidFavoriteRouteException.class)
+			.hasMessage("추가 시각이 필요합니다.");
+	}
+
+	private RouteSearchResult routeSearch(String routeSearchId, String originStationName, String destinationStationName) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-sangnoksu",
+			originStationName,
+			"station-sadang",
+			destinationStationName,
+			MobilityType.SENIOR,
+			RouteSearchStatus.FOUND,
+			"line-4",
+			"수도권 4호선",
+			90,
+			List.of(),
+			List.of(),
+			List.of(),
+			LocalDateTime.of(2026, 6, 13, 9, 0)
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteRouteServiceTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteRouteServiceTest.java
@@ -93,6 +93,28 @@ class FavoriteRouteServiceTest {
 	}
 
 	@Test
+	@DisplayName("중복 저장은 임시 경로 검색 캐시가 정리돼도 기존 즐겨찾기를 반환한다")
+	void duplicateSaveReturnsExistingFavoriteAfterRouteSearchEviction() {
+		routeSearchRepository.saveRouteSearch(routeSearch("route-search-duplicate", "상록수", "사당"));
+		var saved = service.saveFavoriteRoute(new SaveFavoriteRouteCommand(
+			"anonymous-user-1",
+			"route-search-duplicate"
+		));
+
+		for (int index = 0; index <= 1_000; index++) {
+			routeSearchRepository.saveRouteSearch(routeSearch("route-search-overflow-" + index, "사당", "상록수"));
+		}
+
+		var duplicated = service.saveFavoriteRoute(new SaveFavoriteRouteCommand(
+			"anonymous-user-1",
+			"route-search-duplicate"
+		));
+
+		assertThat(duplicated).isEqualTo(saved);
+		assertThat(duplicated.route().originStationName()).isEqualTo("상록수");
+	}
+
+	@Test
 	@DisplayName("삭제 요청은 같은 사용자와 같은 경로의 즐겨찾기만 제거한다")
 	void removeFavoriteRouteDeletesOnlyRequestedRoute() {
 		routeSearchRepository.saveRouteSearch(routeSearch("route-search-4", "상록수", "사당"));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -393,6 +393,7 @@ test("백엔드 즐겨찾기 경로는 경로 검색 결과 기반 헥사고날 
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
 
   assert.match(favorite, /record FavoriteRoute/);
+  assert.match(favorite, /RouteSearchResult/);
   assert.match(favorite, /routeSearchId/);
   assert.match(favorite, /addedAt/);
   assert.match(favorite, /InvalidFavoriteRouteException/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -376,6 +376,51 @@ test("백엔드 즐겨찾기 역은 헥사고날 API 경계를 따른다", () =>
   assert.match(security, /anyRequest\(\)\.authenticated\(\)/);
 });
 
+test("백엔드 즐겨찾기 경로는 경로 검색 결과 기반 헥사고날 API 경계를 따른다", () => {
+  const favorite = read("backend/src/main/java/com/easysubway/favorite/domain/FavoriteRoute.java");
+  const favoriteDetails = read("backend/src/main/java/com/easysubway/favorite/domain/FavoriteRouteWithDetails.java");
+  const invalidFavorite = read("backend/src/main/java/com/easysubway/favorite/domain/InvalidFavoriteRouteException.java");
+  const useCase = read("backend/src/main/java/com/easysubway/favorite/application/port/in/FavoriteRouteUseCase.java");
+  const listCommand = read("backend/src/main/java/com/easysubway/favorite/application/port/in/ListFavoriteRoutesCommand.java");
+  const saveCommand = read("backend/src/main/java/com/easysubway/favorite/application/port/in/SaveFavoriteRouteCommand.java");
+  const removeCommand = read("backend/src/main/java/com/easysubway/favorite/application/port/in/RemoveFavoriteRouteCommand.java");
+  const loadPort = read("backend/src/main/java/com/easysubway/favorite/application/port/out/LoadFavoriteRoutePort.java");
+  const savePort = read("backend/src/main/java/com/easysubway/favorite/application/port/out/SaveFavoriteRoutePort.java");
+  const deletePort = read("backend/src/main/java/com/easysubway/favorite/application/port/out/DeleteFavoriteRoutePort.java");
+  const service = read("backend/src/main/java/com/easysubway/favorite/application/service/FavoriteRouteService.java");
+  const repository = read("backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepository.java");
+  const controller = read("backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteRouteController.java");
+  const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
+
+  assert.match(favorite, /record FavoriteRoute/);
+  assert.match(favorite, /routeSearchId/);
+  assert.match(favorite, /addedAt/);
+  assert.match(favorite, /InvalidFavoriteRouteException/);
+  assert.match(favoriteDetails, /RouteSearchResult/);
+  assert.match(invalidFavorite, /extends InvalidRequestException/);
+  assert.match(useCase, /interface FavoriteRouteUseCase/);
+  assert.match(useCase, /listFavoriteRoutes/);
+  assert.match(useCase, /saveFavoriteRoute/);
+  assert.match(useCase, /removeFavoriteRoute/);
+  assert.match(listCommand, /record ListFavoriteRoutesCommand/);
+  assert.match(saveCommand, /record SaveFavoriteRouteCommand/);
+  assert.match(removeCommand, /record RemoveFavoriteRouteCommand/);
+  assert.match(loadPort, /interface LoadFavoriteRoutePort/);
+  assert.match(savePort, /interface SaveFavoriteRoutePort/);
+  assert.match(deletePort, /interface DeleteFavoriteRoutePort/);
+  assert.match(service, /implements FavoriteRouteUseCase/);
+  assert.match(service, /LoadRouteSearchPort/);
+  assert.match(service, /RouteSearchNotFoundException/);
+  assert.match(repository, /implements[\s\S]*LoadFavoriteRoutePort[\s\S]*SaveFavoriteRoutePort[\s\S]*DeleteFavoriteRoutePort/);
+  assert.match(controller, /@GetMapping\("\/api\/v1\/me\/favorites\/routes"\)/);
+  assert.match(controller, /@PostMapping\("\/api\/v1\/me\/favorites\/routes"\)/);
+  assert.match(controller, /@DeleteMapping\("\/api\/v1\/me\/favorites\/routes\/\{favoriteRouteId\}"\)/);
+  assert.match(controller, /Principal principal/);
+  assert.doesNotMatch(controller, /RequestParam\(required = false\) String userId/);
+  assert.match(security, /securityMatcher\("\/api\/v1\/me\/favorites\/\*\*"/);
+  assert.match(security, /anyRequest\(\)\.authenticated\(\)/);
+});
+
 test("백엔드 알림 설정은 인증 사용자 기준 헥사고날 API 경계를 따른다", () => {
   const device = read("backend/src/main/java/com/easysubway/notification/domain/RegisteredDevice.java");
   const settings = read("backend/src/main/java/com/easysubway/notification/domain/NotificationSettings.java");


### PR DESCRIPTION
## 관련 이슈

Closes #44

## 배경

즐겨찾기 역은 저장할 수 있지만, 사용자가 자주 이동하는 경로 자체를 저장하는 API가 없었다. 반복 이동 사용자는 같은 출발역/도착역 조합을 다시 찾는 일이 많고, 이후 경로 기반 시설 알림을 붙이려면 사용자별 즐겨찾기 경로 기준선이 필요하다.

## 변경 사항

- `GET /api/v1/me/favorites/routes`로 인증 사용자의 즐겨찾기 경로 목록을 조회한다.
- `POST /api/v1/me/favorites/routes`로 기존 경로 검색 결과를 즐겨찾기에 저장한다.
- `DELETE /api/v1/me/favorites/routes/{favoriteRouteId}`로 인증 사용자의 즐겨찾기 경로를 삭제한다.
- 요청 본문 `userId`는 사용하지 않고 `Principal.getName()` 기준으로 사용자 데이터를 처리한다.
- 즐겨찾기 경로 도메인, 유스케이스, 입출력 포트, 인메모리 저장소를 기존 헥사고날 구조에 맞춰 추가했다.
- 경로 검색 결과가 없으면 404, 빈 경로 식별자는 400 공통 응답으로 내려가도록 고정했다.
- 경로 검색 ID가 계속 늘어날 수 있어 인메모리 저장소는 사용자별 즐겨찾기 경로를 100개로 제한하고 오래된 항목부터 정리한다.

## 검증

- `./gradlew test --tests 'com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteRouteRepositoryTest' --tests 'com.easysubway.favorite.*Route*' --no-daemon --console=plain`
- `./gradlew test --no-daemon --console=plain`
- `node --test tools/ci/*.test.mjs`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/ISSUE_TEMPLATE/*.yml`
- `git diff --check HEAD`
- `git ls-files '*.md'`
- Codex Security diff scan: reportable finding 0건
  - Markdown: `/tmp/codex-security-scans/swieun-jihacheol/local-patch_20260613T125125Z/report.md`
  - HTML: `/tmp/codex-security-scans/swieun-jihacheol/local-patch_20260613T125125Z/report.html`

## 리뷰어가 먼저 봐야 할 지점

- 즐겨찾기 경로 저장이 `routeSearchId`를 기준으로 기존 검색 결과만 허용하는지
- 사용자 식별이 요청 본문이 아니라 인증 principal 기준으로만 처리되는지
- 인메모리 저장소 보관 한도와 오래된 항목 정리 방식이 현재 백엔드 기준선에 적절한지

## 리스크

- 현재 저장소는 인메모리 어댑터라 프로세스 재시작 시 즐겨찾기 경로가 초기화된다. 영속 저장소 전환은 별도 작업에서 처리해야 한다.
- 즐겨찾기 경로는 기존 경로 검색 결과를 참조하므로, 경로 재계산이나 장기 보관용 경로 스냅샷 정책은 별도 설계가 필요하다.

## 체크리스트

- [x] 관련 이슈를 연결했다.
- [x] 로컬 검증을 실행했다.
- [x] 사용자별 데이터가 인증 principal 기준으로 처리되는지 확인했다.
- [x] 루트 README와 GitHub 템플릿 외 Markdown 문서가 추가로 추적되지 않는지 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **새로운 기능**
  * 자주 이용하는 지하철 노선을 즐겨찾기로 저장할 수 있습니다.
  * 저장한 즐겨찾기 노선 목록을 언제든 확인할 수 있습니다.
  * 더 이상 필요 없는 즐겨찾기 노선을 삭제할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->