### PR TITLE
[Feat] 신고 처리 상태 확인 연결

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -10,6 +10,8 @@ const _anonymousReportUserId = 'anonymous-mobile-user';
 
 abstract class FacilityReportRepository {
   Future<FacilityReportResult> createReport(FacilityReportRequest request);
+
+  Future<FacilityReportResult> getReport(String reportId);
 }
 
 class FacilityReportApiRepository implements FacilityReportRepository {
@@ -33,31 +35,65 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       request.write(jsonEncode(reportRequest.toJson()));
 
       final response = await request.close().timeout(_facilityReportTimeout);
-      final body = await utf8
-          .decodeStream(response)
-          .timeout(_facilityReportTimeout);
-
       if (response.statusCode != HttpStatus.created &&
           response.statusCode != HttpStatus.ok) {
         throw const FacilityReportException(_facilityReportErrorMessage);
       }
 
-      final decoded = jsonDecode(body);
-      if (decoded is! Map<String, Object?> || decoded['success'] != true) {
-        throw const FacilityReportException(_facilityReportErrorMessage);
-      }
-
-      final data = decoded['data'];
-      if (data is! Map<String, Object?>) {
-        throw const FacilityReportException(_facilityReportErrorMessage);
-      }
-
-      return FacilityReportResult.fromJson(data);
+      return _readReportResult(response);
     } on FacilityReportException {
       rethrow;
     } catch (_) {
       throw const FacilityReportException(_facilityReportErrorMessage);
     }
+  }
+
+  @override
+  Future<FacilityReportResult> getReport(String reportId) async {
+    final trimmedReportId = reportId.trim();
+    if (trimmedReportId.isEmpty) {
+      throw const FacilityReportException(_facilityReportErrorMessage);
+    }
+
+    final uri = baseUri.resolve(
+      '/api/v1/reports/${Uri.encodeComponent(trimmedReportId)}',
+    );
+
+    try {
+      final request = await _httpClient
+          .getUrl(uri)
+          .timeout(_facilityReportTimeout);
+      final response = await request.close().timeout(_facilityReportTimeout);
+
+      if (response.statusCode != HttpStatus.ok) {
+        throw const FacilityReportException(_facilityReportErrorMessage);
+      }
+
+      return _readReportResult(response);
+    } on FacilityReportException {
+      rethrow;
+    } catch (_) {
+      throw const FacilityReportException(_facilityReportErrorMessage);
+    }
+  }
+
+  Future<FacilityReportResult> _readReportResult(
+    HttpClientResponse response,
+  ) async {
+    final body = await utf8
+        .decodeStream(response)
+        .timeout(_facilityReportTimeout);
+    final decoded = jsonDecode(body);
+    if (decoded is! Map<String, Object?> || decoded['success'] != true) {
+      throw const FacilityReportException(_facilityReportErrorMessage);
+    }
+
+    final data = decoded['data'];
+    if (data is! Map<String, Object?>) {
+      throw const FacilityReportException(_facilityReportErrorMessage);
+    }
+
+    return FacilityReportResult.fromJson(data);
   }
 }
 
@@ -292,6 +328,52 @@ class FacilityReportController extends ChangeNotifier {
     }
   }
 
+  Future<void> refreshCurrentReport() async {
+    final currentResult = _state.result;
+    if (_disposed ||
+        _state.status == FacilityReportViewStatus.loading ||
+        currentResult == null) {
+      return;
+    }
+
+    _emitState(
+      FacilityReportState(
+        status: FacilityReportViewStatus.loading,
+        message: '처리 상태 확인 중',
+        result: currentResult,
+      ),
+    );
+
+    try {
+      final result = await repository.getReport(currentResult.id);
+      _emitState(
+        FacilityReportState(
+          status: FacilityReportViewStatus.success,
+          message: '처리 상태를 확인했습니다.',
+          result: result,
+        ),
+      );
+    } on FacilityReportException catch (error) {
+      // 상태 확인이 실패해도 사용자가 접수번호를 잃지 않도록 직전 결과는 유지한다.
+      _emitState(
+        FacilityReportState(
+          status: FacilityReportViewStatus.failure,
+          message: error.message,
+          result: currentResult,
+        ),
+      );
+    } catch (_) {
+      // 알 수 없는 오류도 같은 화면에서 다시 확인할 수 있게 접수 결과를 보존한다.
+      _emitState(
+        FacilityReportState(
+          status: FacilityReportViewStatus.failure,
+          message: '처리 상태를 확인하지 못했습니다.',
+          result: currentResult,
+        ),
+      );
+    }
+  }
+
   void _emitState(FacilityReportState nextState) {
     if (_disposed) {
       return;
@@ -345,7 +427,8 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
   Widget build(BuildContext context) {
     final state = _controller.state;
     final isLoading = state.status == FacilityReportViewStatus.loading;
-    final isSuccess = state.status == FacilityReportViewStatus.success;
+    final reportResult = state.result;
+    final hasSubmittedReport = reportResult != null;
 
     return Scaffold(
       appBar: AppBar(title: const Text('시설 신고')),
@@ -370,7 +453,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
                         child: _FacilityReportTypeCard(
                           option: option,
                           selected: option == _selectedType,
-                          onTap: isLoading || isSuccess
+                          onTap: isLoading || hasSubmittedReport
                               ? null
                               : () => setState(() => _selectedType = option),
                         ),
@@ -383,7 +466,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
             TextField(
               key: const Key('facilityReportDescriptionInput'),
               controller: _descriptionController,
-              enabled: !isLoading && !isSuccess,
+              enabled: !isLoading && !hasSubmittedReport,
               minLines: 3,
               maxLines: 5,
               textInputAction: TextInputAction.newline,
@@ -400,9 +483,17 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
             const SizedBox(height: 16),
             if (state.message.isNotEmpty) _FacilityReportMessage(state: state),
             const SizedBox(height: 16),
+            if (reportResult != null) ...[
+              _FacilityReportStatusPanel(
+                result: reportResult,
+                isLoading: isLoading,
+                onRefresh: _controller.refreshCurrentReport,
+              ),
+              const SizedBox(height: 16),
+            ],
             FilledButton.icon(
               key: const Key('facilityReportSubmitButton'),
-              onPressed: isLoading || isSuccess ? null : _submit,
+              onPressed: isLoading || hasSubmittedReport ? null : _submit,
               icon: isLoading
                   ? const SizedBox(
                       width: 22,
@@ -410,7 +501,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
                       child: CircularProgressIndicator(strokeWidth: 2.5),
                     )
                   : const Icon(Icons.send),
-              label: Text(isSuccess ? '접수 완료' : '신고 보내기'),
+              label: Text(hasSubmittedReport ? '접수 완료' : '신고 보내기'),
             ),
           ],
         ),
@@ -429,6 +520,95 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       target: widget.target,
       selectedType: _selectedType,
       description: _descriptionController.text,
+    );
+  }
+}
+
+class _FacilityReportStatusPanel extends StatelessWidget {
+  const _FacilityReportStatusPanel({
+    required this.result,
+    required this.isLoading,
+    required this.onRefresh,
+  });
+
+  final FacilityReportResult result;
+  final bool isLoading;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: const Color(0xFFE6F2F0),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: const Color(0xFF93C7C2)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Semantics(
+              // 접수번호와 상태를 한 문장으로 묶어 스크린리더가 상태 변화를 읽게 한다.
+              label: '신고 접수번호 ${result.id}, 현재 상태 ${result.statusLabel}',
+              liveRegion: true,
+              child: ExcludeSemantics(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _FacilityReportStatusRow(label: '접수번호', value: result.id),
+                    const SizedBox(height: 10),
+                    _FacilityReportStatusRow(
+                      label: '처리 상태',
+                      value: result.statusLabel,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 14),
+            OutlinedButton.icon(
+              key: const Key('facilityReportRefreshButton'),
+              onPressed: isLoading ? null : onRefresh,
+              icon: const Icon(Icons.refresh),
+              label: Text(isLoading ? '확인 중' : '처리 상태 확인'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FacilityReportStatusRow extends StatelessWidget {
+  const _FacilityReportStatusRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: textTheme.labelLarge?.copyWith(
+            color: const Color(0xFF29484B),
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          value,
+          style: textTheme.titleMedium?.copyWith(
+            color: const Color(0xFF102A2C),
+            fontWeight: FontWeight.w900,
+            height: 1.25,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 
 const _facilityReportTimeout = Duration(seconds: 8);
 const _facilityReportErrorMessage = '신고를 보내지 못했습니다.';
+const _facilityReportStatusErrorMessage = '처리 상태를 확인하지 못했습니다.';
 const _anonymousReportUserId = 'anonymous-mobile-user';
 
 abstract class FacilityReportRepository {
@@ -40,7 +41,11 @@ class FacilityReportApiRepository implements FacilityReportRepository {
         throw const FacilityReportException(_facilityReportErrorMessage);
       }
 
-      return _readReportResult(response);
+      // 응답 파싱 실패도 repository 예외 문구로 통일되도록 try 블록 안에서 완료한다.
+      return await _readReportResult(
+        response,
+        errorMessage: _facilityReportErrorMessage,
+      );
     } on FacilityReportException {
       rethrow;
     } catch (_) {
@@ -52,7 +57,7 @@ class FacilityReportApiRepository implements FacilityReportRepository {
   Future<FacilityReportResult> getReport(String reportId) async {
     final trimmedReportId = reportId.trim();
     if (trimmedReportId.isEmpty) {
-      throw const FacilityReportException(_facilityReportErrorMessage);
+      throw const FacilityReportException(_facilityReportStatusErrorMessage);
     }
 
     final uri = baseUri.resolve(
@@ -66,31 +71,36 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       final response = await request.close().timeout(_facilityReportTimeout);
 
       if (response.statusCode != HttpStatus.ok) {
-        throw const FacilityReportException(_facilityReportErrorMessage);
+        throw const FacilityReportException(_facilityReportStatusErrorMessage);
       }
 
-      return _readReportResult(response);
+      // 상태 확인 응답도 파싱 오류까지 사용자가 이해할 수 있는 문구로 바꾼다.
+      return await _readReportResult(
+        response,
+        errorMessage: _facilityReportStatusErrorMessage,
+      );
     } on FacilityReportException {
       rethrow;
     } catch (_) {
-      throw const FacilityReportException(_facilityReportErrorMessage);
+      throw const FacilityReportException(_facilityReportStatusErrorMessage);
     }
   }
 
   Future<FacilityReportResult> _readReportResult(
-    HttpClientResponse response,
-  ) async {
+    HttpClientResponse response, {
+    required String errorMessage,
+  }) async {
     final body = await utf8
         .decodeStream(response)
         .timeout(_facilityReportTimeout);
     final decoded = jsonDecode(body);
     if (decoded is! Map<String, Object?> || decoded['success'] != true) {
-      throw const FacilityReportException(_facilityReportErrorMessage);
+      throw FacilityReportException(errorMessage);
     }
 
     final data = decoded['data'];
     if (data is! Map<String, Object?>) {
-      throw const FacilityReportException(_facilityReportErrorMessage);
+      throw FacilityReportException(errorMessage);
     }
 
     return FacilityReportResult.fromJson(data);

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -56,6 +56,48 @@ void main() {
     expect(result.statusLabel, '접수됨');
   });
 
+  test('시설 신고 API 저장소는 접수번호로 처리 상태를 조회한다', () async {
+    late String requestMethod;
+    late String requestPath;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestMethod = request.method;
+      requestPath = request.uri.path;
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {
+              'id': 'report-1',
+              'stationId': 'station-sangnoksu',
+              'facilityId': 'facility-sangnoksu-elevator-1',
+              'reportType': 'BROKEN',
+              'description': '문이 열리지 않습니다.',
+              'status': 'ACCEPTED',
+              'createdAt': '2026-06-13T10:00:00',
+            },
+          }),
+        )
+        ..close();
+    });
+
+    final repository = FacilityReportApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    final result = await repository.getReport('report-1');
+
+    expect(requestMethod, 'GET');
+    expect(requestPath, '/api/v1/reports/report-1');
+    expect(result.id, 'report-1');
+    expect(result.status, 'ACCEPTED');
+    expect(result.statusLabel, '반영됨');
+  });
+
   test('시설 신고 컨트롤러는 전송 중 중복 제출을 막고 성공 상태를 알린다', () async {
     final repository = PendingFacilityReportRepository();
     final controller = FacilityReportController(repository: repository);
@@ -84,6 +126,34 @@ void main() {
     expect(controller.state.status, FacilityReportViewStatus.success);
     expect(controller.state.message, '신고가 접수되었습니다.');
   });
+
+  test('시설 신고 컨트롤러는 접수 후 처리 상태를 다시 확인한다', () async {
+    final repository = RefreshableFacilityReportRepository();
+    final controller = FacilityReportController(repository: repository);
+    addTearDown(controller.dispose);
+
+    await controller.submit(
+      target: _reportTarget(),
+      selectedType: FacilityReportTypeOption.broken,
+      description: '문이 열리지 않습니다.',
+    );
+
+    expect(controller.state.result?.statusLabel, '접수됨');
+
+    final refresh = controller.refreshCurrentReport();
+
+    expect(repository.loadedReportIds, ['report-1']);
+    expect(controller.state.status, FacilityReportViewStatus.loading);
+    expect(controller.state.message, '처리 상태 확인 중');
+    expect(controller.state.result?.statusLabel, '접수됨');
+
+    repository.completeRefresh();
+    await refresh;
+
+    expect(controller.state.status, FacilityReportViewStatus.success);
+    expect(controller.state.message, '처리 상태를 확인했습니다.');
+    expect(controller.state.result?.statusLabel, '반영됨');
+  });
 }
 
 FacilityReportTarget _reportTarget() {
@@ -107,6 +177,11 @@ class PendingFacilityReportRepository implements FacilityReportRepository {
     return _completer.future;
   }
 
+  @override
+  Future<FacilityReportResult> getReport(String reportId) {
+    throw UnimplementedError();
+  }
+
   void complete() {
     _completer.complete(
       const FacilityReportResult(
@@ -116,6 +191,49 @@ class PendingFacilityReportRepository implements FacilityReportRepository {
         reportType: 'BROKEN',
         description: '문이 열리지 않습니다.',
         status: 'SUBMITTED',
+        createdAt: '2026-06-13T10:00:00',
+      ),
+    );
+  }
+}
+
+class RefreshableFacilityReportRepository implements FacilityReportRepository {
+  final requests = <FacilityReportRequest>[];
+  final loadedReportIds = <String>[];
+  Completer<FacilityReportResult>? _refreshCompleter;
+
+  @override
+  Future<FacilityReportResult> createReport(FacilityReportRequest request) {
+    requests.add(request);
+    return Future.value(
+      const FacilityReportResult(
+        id: 'report-1',
+        stationId: 'station-sangnoksu',
+        facilityId: 'facility-sangnoksu-elevator-1',
+        reportType: 'BROKEN',
+        description: '문이 열리지 않습니다.',
+        status: 'SUBMITTED',
+        createdAt: '2026-06-13T10:00:00',
+      ),
+    );
+  }
+
+  @override
+  Future<FacilityReportResult> getReport(String reportId) {
+    loadedReportIds.add(reportId);
+    _refreshCompleter = Completer<FacilityReportResult>();
+    return _refreshCompleter!.future;
+  }
+
+  void completeRefresh() {
+    _refreshCompleter!.complete(
+      const FacilityReportResult(
+        id: 'report-1',
+        stationId: 'station-sangnoksu',
+        facilityId: 'facility-sangnoksu-elevator-1',
+        reportType: 'BROKEN',
+        description: '문이 열리지 않습니다.',
+        status: 'ACCEPTED',
         createdAt: '2026-06-13T10:00:00',
       ),
     );

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -56,6 +56,47 @@ void main() {
     expect(result.statusLabel, '접수됨');
   });
 
+  test('시설 신고 API 저장소는 잘못된 접수 응답도 쉬운 실패 문구로 바꾼다', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      request.response
+        ..statusCode = HttpStatus.created
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {'id': 'report-1'},
+          }),
+        )
+        ..close();
+    });
+
+    final repository = FacilityReportApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    await expectLater(
+      repository.createReport(
+        const FacilityReportRequest(
+          userId: 'anonymous-mobile-user',
+          stationId: 'station-sangnoksu',
+          facilityId: 'facility-sangnoksu-elevator-1',
+          reportType: 'BROKEN',
+          description: '문이 열리지 않습니다.',
+        ),
+      ),
+      throwsA(
+        isA<FacilityReportException>().having(
+          (error) => error.message,
+          'message',
+          '신고를 보내지 못했습니다.',
+        ),
+      ),
+    );
+  });
+
   test('시설 신고 API 저장소는 접수번호로 처리 상태를 조회한다', () async {
     late String requestMethod;
     late String requestPath;
@@ -96,6 +137,34 @@ void main() {
     expect(result.id, 'report-1');
     expect(result.status, 'ACCEPTED');
     expect(result.statusLabel, '반영됨');
+  });
+
+  test('시설 신고 API 저장소는 상태 조회 실패를 전용 안내 문구로 바꾼다', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      request.response
+        ..statusCode = HttpStatus.internalServerError
+        ..headers.contentType = ContentType.json
+        ..write(jsonEncode({'success': false}))
+        ..close();
+    });
+
+    final repository = FacilityReportApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    await expectLater(
+      repository.getReport('report-1'),
+      throwsA(
+        isA<FacilityReportException>().having(
+          (error) => error.message,
+          'message',
+          '처리 상태를 확인하지 못했습니다.',
+        ),
+      ),
+    );
   });
 
   test('시설 신고 컨트롤러는 전송 중 중복 제출을 막고 성공 상태를 알린다', () async {
@@ -153,6 +222,26 @@ void main() {
     expect(controller.state.status, FacilityReportViewStatus.success);
     expect(controller.state.message, '처리 상태를 확인했습니다.');
     expect(controller.state.result?.statusLabel, '반영됨');
+  });
+
+  test('시설 신고 컨트롤러는 상태 확인 실패에도 접수 결과를 유지한다', () async {
+    final repository = FailingRefreshFacilityReportRepository();
+    final controller = FacilityReportController(repository: repository);
+    addTearDown(controller.dispose);
+
+    await controller.submit(
+      target: _reportTarget(),
+      selectedType: FacilityReportTypeOption.broken,
+      description: '문이 열리지 않습니다.',
+    );
+
+    await controller.refreshCurrentReport();
+
+    expect(repository.loadedReportIds, ['report-1']);
+    expect(controller.state.status, FacilityReportViewStatus.failure);
+    expect(controller.state.message, '처리 상태를 확인하지 못했습니다.');
+    expect(controller.state.result?.id, 'report-1');
+    expect(controller.state.result?.statusLabel, '접수됨');
   });
 }
 
@@ -236,6 +325,34 @@ class RefreshableFacilityReportRepository implements FacilityReportRepository {
         status: 'ACCEPTED',
         createdAt: '2026-06-13T10:00:00',
       ),
+    );
+  }
+}
+
+class FailingRefreshFacilityReportRepository
+    implements FacilityReportRepository {
+  final loadedReportIds = <String>[];
+
+  @override
+  Future<FacilityReportResult> createReport(FacilityReportRequest request) {
+    return Future.value(
+      const FacilityReportResult(
+        id: 'report-1',
+        stationId: 'station-sangnoksu',
+        facilityId: 'facility-sangnoksu-elevator-1',
+        reportType: 'BROKEN',
+        description: '문이 열리지 않습니다.',
+        status: 'SUBMITTED',
+        createdAt: '2026-06-13T10:00:00',
+      ),
+    );
+  }
+
+  @override
+  Future<FacilityReportResult> getReport(String reportId) {
+    loadedReportIds.add(reportId);
+    return Future.error(
+      const FacilityReportException('처리 상태를 확인하지 못했습니다.'),
     );
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1254,6 +1254,30 @@ void main() {
       expect(reportRepository.requests.single.description, '출입문이 막혀 있습니다.');
       expect(find.text('신고가 접수되었습니다.'), findsOneWidget);
       expect(find.bySemanticsLabel('신고가 접수되었습니다.'), findsOneWidget);
+      expect(find.text('접수번호'), findsOneWidget);
+      expect(find.text('report-1'), findsOneWidget);
+      expect(find.text('처리 상태'), findsOneWidget);
+      expect(find.text('접수됨'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('신고 접수번호 report-1, 현재 상태 접수됨'),
+        findsOneWidget,
+      );
+
+      reportRepository.nextReportStatus = 'ACCEPTED';
+      await tester.ensureVisible(
+        find.byKey(const Key('facilityReportRefreshButton')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('facilityReportRefreshButton')));
+      await tester.pumpAndSettle();
+
+      expect(reportRepository.loadedReportIds, ['report-1']);
+      expect(find.text('처리 상태를 확인했습니다.'), findsOneWidget);
+      expect(find.text('반영됨'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('신고 접수번호 report-1, 현재 상태 반영됨'),
+        findsOneWidget,
+      );
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
@@ -1375,6 +1399,8 @@ class FakeRouteSearchRepository implements RouteSearchRepository {
 
 class FakeFacilityReportRepository implements FacilityReportRepository {
   final requests = <FacilityReportRequest>[];
+  final loadedReportIds = <String>[];
+  String nextReportStatus = 'SUBMITTED';
   Object? error;
 
   @override
@@ -1393,6 +1419,24 @@ class FakeFacilityReportRepository implements FacilityReportRepository {
       reportType: request.reportType,
       description: request.description,
       status: 'SUBMITTED',
+      createdAt: '2026-06-13T10:00:00',
+    );
+  }
+
+  @override
+  Future<FacilityReportResult> getReport(String reportId) async {
+    loadedReportIds.add(reportId);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return FacilityReportResult(
+      id: reportId,
+      stationId: 'station-sangnoksu',
+      facilityId: 'facility-sangnoksu-elevator-1',
+      reportType: 'CLOSED',
+      description: '출입문이 막혀 있습니다.',
+      status: nextReportStatus,
       createdAt: '2026-06-13T10:00:00',
     );
   }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -573,6 +573,8 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   const onboardingTest = read("apps/mobile/test/onboarding_test.dart");
   const routeSearch = read("apps/mobile/lib/route_search.dart");
   const stationSearch = read("apps/mobile/lib/station_search.dart");
+  const facilityReport = read("apps/mobile/lib/facility_report.dart");
+  const facilityReportTest = read("apps/mobile/test/facility_report_test.dart");
   const notificationSettings = read("apps/mobile/lib/notification_settings.dart");
   const notificationSettingsTest = read("apps/mobile/test/notification_settings_test.dart");
   const widgetTest = read("apps/mobile/test/widget_test.dart");
@@ -669,6 +671,15 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(stationSearch, /HttpStatus\.unauthorized/);
   assert.match(stationSearch, /invalidateAuthorization\(\)/);
   assert.match(read("apps/mobile/test/station_search_test.dart"), /인증 실패 시 인증을 지우고 한 번 재시도한다/);
+  assert.match(facilityReport, /Future<FacilityReportResult> getReport\(String reportId\)/);
+  assert.match(facilityReport, /\/api\/v1\/reports\/\$\{Uri\.encodeComponent\(trimmedReportId\)\}/);
+  assert.match(facilityReport, /refreshCurrentReport/);
+  assert.match(facilityReport, /처리 상태 확인 중/);
+  assert.match(facilityReport, /접수번호/);
+  assert.match(facilityReport, /facilityReportRefreshButton/);
+  assert.match(facilityReportTest, /접수번호로 처리 상태를 조회한다/);
+  assert.match(facilityReportTest, /접수 후 처리 상태를 다시 확인한다/);
+  assert.match(widgetTest, /신고 접수번호 report-1, 현재 상태 반영됨/);
   assert.match(notificationSettings, /class NotificationSettingsApiRepository/);
   assert.match(notificationSettings, /\/api\/v1\/me\/notification-settings/);
   assert.match(notificationSettings, /AuthorizationHeaderProvider/);


### PR DESCRIPTION
## 관련 이슈

close #54

## 작업 배경

시설 신고를 접수한 사용자는 접수 직후 신고가 정상적으로 저장됐는지와 현재 처리 상태를 알고 싶어 한다. 기존 모바일 화면은 성공 메시지만 보여줘 접수번호와 상태를 다시 확인하기 어렵다.

교통약자 사용자가 같은 화면에서 처리 상태를 다시 확인할 수 있도록 신고 단건 조회 API를 모바일 저장소에 연결하고, 접수 후 상태 확인 UI를 추가한다.

## 작업 내용

- 모바일 시설 신고 저장소에 `/api/v1/reports/{reportId}` 조회 기능을 추가했다.
- 신고 접수 후 접수번호와 처리 상태를 쉬운 문구로 표시하는 상태 패널을 추가했다.
- 같은 화면에서 처리 상태를 다시 확인하는 버튼을 연결했다.
- 상태 확인 실패 시에도 접수번호를 잃지 않도록 직전 신고 결과를 유지했다.
- 저장소 계약 테스트와 Flutter 테스트가 상태 조회 흐름을 검증하도록 갱신했다.

## 검증

- `flutter test test/facility_report_test.dart` 통과
- `flutter test test/widget_test.dart` 통과
- `flutter test` 통과
- `flutter analyze` 통과
- `node --test tools/ci/*.test.mjs` 통과
- `git diff --check` 통과
- `flutter build apk --debug` 통과
- `flutter build ios --simulator --no-codesign` 통과
- `/opt/homebrew/share/android-commandlinetools/platform-tools/adb devices` 확인: 연결된 Android 기기 없음
- `git ls-files '*.md'` 확인: `README.md`, `.github/pull_request_template.md`만 추적
- PR CI run `27483206353` 통과
- CodeRabbit 한도 초과로 실제 리뷰 미시작 확인
- Codex CLI code review 최초 지적 2건을 수정 커밋 `2aad2abf86157ee0e8823c8c3b001fc1a2bbc9a0`에 반영하고 재검토에서 추가 수정 필요 없음 확인
- merge 후 main CI run `27483651323` 통과
- 별도 CD 워크플로우 없음 확인, Actions Storage Cleanup run `27483651339` 통과

## 리뷰어 메모

- 백엔드 신고 조회 API 계약은 이미 존재하므로 서버 계약은 바꾸지 않았다.
- 사진 첨부, 위치 권한, 푸시 알림은 이번 범위에 포함하지 않았다.
- 상태 확인 실패 시 접수번호와 이전 상태를 유지해 사용자가 신고 결과를 잃지 않게 했다.

## 리스크

- 앱 세션 안에서 접수한 신고 상태만 바로 확인한다. 신고 이력 목록은 별도 작업 범위다.
- 관리자 검수 결과가 바뀌어도 사용자가 버튼을 눌러야 최신 상태를 확인한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
