### PR TITLE
[Feat] 즐겨찾기 시설 API 기반 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteFacilityController.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteFacilityController.java
@@ -1,0 +1,106 @@
+package com.easysubway.favorite.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.favorite.application.port.in.FavoriteFacilityUseCase;
+import com.easysubway.favorite.application.port.in.ListFavoriteFacilitiesCommand;
+import com.easysubway.favorite.application.port.in.RemoveFavoriteFacilityCommand;
+import com.easysubway.favorite.application.port.in.SaveFavoriteFacilityCommand;
+import com.easysubway.favorite.domain.FavoriteFacilityWithDetails;
+import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import com.easysubway.transit.domain.AccessibilityFacilityType;
+import com.easysubway.transit.domain.DataConfidenceLevel;
+import com.easysubway.transit.domain.Station;
+import java.security.Principal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class FavoriteFacilityController {
+
+	private final FavoriteFacilityUseCase favoriteFacilityUseCase;
+
+	FavoriteFacilityController(FavoriteFacilityUseCase favoriteFacilityUseCase) {
+		this.favoriteFacilityUseCase = favoriteFacilityUseCase;
+	}
+
+	@GetMapping("/api/v1/me/favorites/facilities")
+	ApiResponse<List<FavoriteFacilityResponse>> listFavoriteFacilities(Principal principal) {
+		List<FavoriteFacilityResponse> response = favoriteFacilityUseCase
+			.listFavoriteFacilities(new ListFavoriteFacilitiesCommand(principal.getName()))
+			.stream()
+			.map(FavoriteFacilityResponse::from)
+			.toList();
+		return ApiResponse.ok(response);
+	}
+
+	@PutMapping("/api/v1/me/favorites/facilities/{facilityId}")
+	ApiResponse<FavoriteFacilityResponse> saveFavoriteFacility(
+		@PathVariable String facilityId,
+		Principal principal
+	) {
+		FavoriteFacilityWithDetails favoriteFacility = favoriteFacilityUseCase.saveFavoriteFacility(
+			new SaveFavoriteFacilityCommand(principal.getName(), facilityId)
+		);
+		return ApiResponse.ok(FavoriteFacilityResponse.from(favoriteFacility));
+	}
+
+	@DeleteMapping("/api/v1/me/favorites/facilities/{facilityId}")
+	ApiResponse<Void> removeFavoriteFacility(
+		@PathVariable String facilityId,
+		Principal principal
+	) {
+		favoriteFacilityUseCase.removeFavoriteFacility(new RemoveFavoriteFacilityCommand(
+			principal.getName(),
+			facilityId
+		));
+		return ApiResponse.ok(null);
+	}
+
+	record FavoriteFacilityResponse(
+		String userId,
+		String facilityId,
+		String stationId,
+		String stationNameKo,
+		String stationNameEn,
+		String exitId,
+		AccessibilityFacilityType type,
+		String name,
+		String floorFrom,
+		String floorTo,
+		String description,
+		AccessibilityFacilityStatus status,
+		DataConfidenceLevel dataConfidence,
+		LocalDate lastUpdatedAt,
+		LocalDateTime addedAt
+	) {
+
+		static FavoriteFacilityResponse from(FavoriteFacilityWithDetails favoriteFacility) {
+			AccessibilityFacility facility = favoriteFacility.facility();
+			Station station = favoriteFacility.station();
+			return new FavoriteFacilityResponse(
+				favoriteFacility.favoriteFacility().userId(),
+				favoriteFacility.favoriteFacility().facilityId(),
+				facility.stationId(),
+				station.nameKo(),
+				station.nameEn(),
+				facility.exitId(),
+				facility.type(),
+				facility.name(),
+				facility.floorFrom(),
+				facility.floorTo(),
+				facility.description(),
+				facility.status(),
+				facility.dataConfidence(),
+				facility.lastUpdatedAt(),
+				favoriteFacility.favoriteFacility().addedAt()
+			);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteFacilityRepository.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteFacilityRepository.java
@@ -1,0 +1,47 @@
+package com.easysubway.favorite.adapter.out.persistence;
+
+import com.easysubway.favorite.application.port.out.DeleteFavoriteFacilityPort;
+import com.easysubway.favorite.application.port.out.LoadFavoriteFacilityPort;
+import com.easysubway.favorite.application.port.out.SaveFavoriteFacilityPort;
+import com.easysubway.favorite.domain.FavoriteFacility;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryFavoriteFacilityRepository implements
+	LoadFavoriteFacilityPort,
+	SaveFavoriteFacilityPort,
+	DeleteFavoriteFacilityPort {
+
+	private final Map<String, Map<String, FavoriteFacility>> favoritesByUserId = new ConcurrentHashMap<>();
+
+	@Override
+	public List<FavoriteFacility> loadFavoriteFacilities(String userId) {
+		return new ArrayList<>(favoritesByUserId.getOrDefault(userId, Map.of()).values());
+	}
+
+	@Override
+	public Optional<FavoriteFacility> loadFavoriteFacility(String userId, String facilityId) {
+		return Optional.ofNullable(favoritesByUserId.getOrDefault(userId, Map.of()).get(facilityId));
+	}
+
+	@Override
+	public FavoriteFacility saveFavoriteFacility(FavoriteFacility favoriteFacility) {
+		favoritesByUserId
+			.computeIfAbsent(favoriteFacility.userId(), ignored -> new ConcurrentHashMap<>())
+			.put(favoriteFacility.facilityId(), favoriteFacility);
+		return favoriteFacility;
+	}
+
+	@Override
+	public void deleteFavoriteFacility(String userId, String facilityId) {
+		Map<String, FavoriteFacility> favorites = favoritesByUserId.get(userId);
+		if (favorites != null) {
+			favorites.remove(facilityId);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/in/FavoriteFacilityUseCase.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/in/FavoriteFacilityUseCase.java
@@ -1,0 +1,13 @@
+package com.easysubway.favorite.application.port.in;
+
+import com.easysubway.favorite.domain.FavoriteFacilityWithDetails;
+import java.util.List;
+
+public interface FavoriteFacilityUseCase {
+
+	List<FavoriteFacilityWithDetails> listFavoriteFacilities(ListFavoriteFacilitiesCommand command);
+
+	FavoriteFacilityWithDetails saveFavoriteFacility(SaveFavoriteFacilityCommand command);
+
+	void removeFavoriteFacility(RemoveFavoriteFacilityCommand command);
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/in/ListFavoriteFacilitiesCommand.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/in/ListFavoriteFacilitiesCommand.java
@@ -1,0 +1,4 @@
+package com.easysubway.favorite.application.port.in;
+
+public record ListFavoriteFacilitiesCommand(String userId) {
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/in/RemoveFavoriteFacilityCommand.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/in/RemoveFavoriteFacilityCommand.java
@@ -1,0 +1,4 @@
+package com.easysubway.favorite.application.port.in;
+
+public record RemoveFavoriteFacilityCommand(String userId, String facilityId) {
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/in/SaveFavoriteFacilityCommand.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/in/SaveFavoriteFacilityCommand.java
@@ -1,0 +1,4 @@
+package com.easysubway.favorite.application.port.in;
+
+public record SaveFavoriteFacilityCommand(String userId, String facilityId) {
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/out/DeleteFavoriteFacilityPort.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/out/DeleteFavoriteFacilityPort.java
@@ -1,0 +1,6 @@
+package com.easysubway.favorite.application.port.out;
+
+public interface DeleteFavoriteFacilityPort {
+
+	void deleteFavoriteFacility(String userId, String facilityId);
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/out/LoadFavoriteFacilityPort.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/out/LoadFavoriteFacilityPort.java
@@ -1,0 +1,12 @@
+package com.easysubway.favorite.application.port.out;
+
+import com.easysubway.favorite.domain.FavoriteFacility;
+import java.util.List;
+import java.util.Optional;
+
+public interface LoadFavoriteFacilityPort {
+
+	List<FavoriteFacility> loadFavoriteFacilities(String userId);
+
+	Optional<FavoriteFacility> loadFavoriteFacility(String userId, String facilityId);
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/port/out/SaveFavoriteFacilityPort.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/port/out/SaveFavoriteFacilityPort.java
@@ -1,0 +1,8 @@
+package com.easysubway.favorite.application.port.out;
+
+import com.easysubway.favorite.domain.FavoriteFacility;
+
+public interface SaveFavoriteFacilityPort {
+
+	FavoriteFacility saveFavoriteFacility(FavoriteFacility favoriteFacility);
+}

--- a/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteFacilityService.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteFacilityService.java
@@ -76,7 +76,8 @@ public class FavoriteFacilityService implements FavoriteFacilityUseCase {
 		requireUserId(command.userId());
 		requireFacilityId(command.facilityId());
 		// 고장 또는 확인 필요 시설도 추적 대상이므로 상태값은 저장 가능 여부에 쓰지 않는다.
-		loadFacility(command.facilityId());
+		AccessibilityFacility facility = loadFacility(command.facilityId());
+		Station station = loadActiveStation(facility.stationId());
 
 		FavoriteFacility favoriteFacility = loadFavoriteFacilityPort
 			.loadFavoriteFacility(command.userId(), command.facilityId())
@@ -86,7 +87,7 @@ public class FavoriteFacilityService implements FavoriteFacilityUseCase {
 				LocalDateTime.now(clock)
 			)));
 
-		return withDetails(favoriteFacility);
+		return new FavoriteFacilityWithDetails(favoriteFacility, facility, station);
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteFacilityService.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteFacilityService.java
@@ -1,0 +1,136 @@
+package com.easysubway.favorite.application.service;
+
+import com.easysubway.favorite.application.port.in.FavoriteFacilityUseCase;
+import com.easysubway.favorite.application.port.in.ListFavoriteFacilitiesCommand;
+import com.easysubway.favorite.application.port.in.RemoveFavoriteFacilityCommand;
+import com.easysubway.favorite.application.port.in.SaveFavoriteFacilityCommand;
+import com.easysubway.favorite.application.port.out.DeleteFavoriteFacilityPort;
+import com.easysubway.favorite.application.port.out.LoadFavoriteFacilityPort;
+import com.easysubway.favorite.application.port.out.SaveFavoriteFacilityPort;
+import com.easysubway.favorite.domain.FavoriteFacility;
+import com.easysubway.favorite.domain.FavoriteFacilityNotFoundException;
+import com.easysubway.favorite.domain.FavoriteFacilityWithDetails;
+import com.easysubway.favorite.domain.InvalidFavoriteFacilityException;
+import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationNotFoundException;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FavoriteFacilityService implements FavoriteFacilityUseCase {
+
+	private final LoadFavoriteFacilityPort loadFavoriteFacilityPort;
+	private final SaveFavoriteFacilityPort saveFavoriteFacilityPort;
+	private final DeleteFavoriteFacilityPort deleteFavoriteFacilityPort;
+	private final LoadTransitMasterPort loadTransitMasterPort;
+	private final Clock clock;
+
+	@Autowired
+	public FavoriteFacilityService(
+		LoadFavoriteFacilityPort loadFavoriteFacilityPort,
+		SaveFavoriteFacilityPort saveFavoriteFacilityPort,
+		DeleteFavoriteFacilityPort deleteFavoriteFacilityPort,
+		LoadTransitMasterPort loadTransitMasterPort
+	) {
+		this(
+			loadFavoriteFacilityPort,
+			saveFavoriteFacilityPort,
+			deleteFavoriteFacilityPort,
+			loadTransitMasterPort,
+			Clock.systemDefaultZone()
+		);
+	}
+
+	public FavoriteFacilityService(
+		LoadFavoriteFacilityPort loadFavoriteFacilityPort,
+		SaveFavoriteFacilityPort saveFavoriteFacilityPort,
+		DeleteFavoriteFacilityPort deleteFavoriteFacilityPort,
+		LoadTransitMasterPort loadTransitMasterPort,
+		Clock clock
+	) {
+		this.loadFavoriteFacilityPort = loadFavoriteFacilityPort;
+		this.saveFavoriteFacilityPort = saveFavoriteFacilityPort;
+		this.deleteFavoriteFacilityPort = deleteFavoriteFacilityPort;
+		this.loadTransitMasterPort = loadTransitMasterPort;
+		this.clock = clock;
+	}
+
+	@Override
+	public List<FavoriteFacilityWithDetails> listFavoriteFacilities(ListFavoriteFacilitiesCommand command) {
+		requireUserId(command.userId());
+		return loadFavoriteFacilityPort.loadFavoriteFacilities(command.userId())
+			.stream()
+			.sorted(Comparator.comparing(FavoriteFacility::addedAt))
+			.map(this::withDetails)
+			.toList();
+	}
+
+	@Override
+	public FavoriteFacilityWithDetails saveFavoriteFacility(SaveFavoriteFacilityCommand command) {
+		requireUserId(command.userId());
+		requireFacilityId(command.facilityId());
+		// 고장 또는 확인 필요 시설도 추적 대상이므로 상태값은 저장 가능 여부에 쓰지 않는다.
+		loadFacility(command.facilityId());
+
+		FavoriteFacility favoriteFacility = loadFavoriteFacilityPort
+			.loadFavoriteFacility(command.userId(), command.facilityId())
+			.orElseGet(() -> saveFavoriteFacilityPort.saveFavoriteFacility(new FavoriteFacility(
+				command.userId(),
+				command.facilityId(),
+				LocalDateTime.now(clock)
+			)));
+
+		return withDetails(favoriteFacility);
+	}
+
+	@Override
+	public void removeFavoriteFacility(RemoveFavoriteFacilityCommand command) {
+		requireUserId(command.userId());
+		requireFacilityId(command.facilityId());
+		deleteFavoriteFacilityPort.deleteFavoriteFacility(command.userId(), command.facilityId());
+	}
+
+	private FavoriteFacilityWithDetails withDetails(FavoriteFacility favoriteFacility) {
+		AccessibilityFacility facility = loadFacility(favoriteFacility.facilityId());
+		return new FavoriteFacilityWithDetails(
+			favoriteFacility,
+			facility,
+			loadActiveStation(facility.stationId())
+		);
+	}
+
+	private AccessibilityFacility loadFacility(String facilityId) {
+		return loadTransitMasterPort.loadAccessibilityFacilities()
+			.stream()
+			.filter(facility -> facility.id().equals(facilityId))
+			.findFirst()
+			.orElseThrow(FavoriteFacilityNotFoundException::new);
+	}
+
+	private Station loadActiveStation(String stationId) {
+		return loadTransitMasterPort.loadStations()
+			.stream()
+			.filter(station -> station.id().equals(stationId))
+			.filter(Station::active)
+			.findFirst()
+			.orElseThrow(StationNotFoundException::new);
+	}
+
+	private void requireUserId(String userId) {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidFavoriteFacilityException("사용자 식별자가 필요합니다.");
+		}
+	}
+
+	private void requireFacilityId(String facilityId) {
+		if (facilityId == null || facilityId.isBlank()) {
+			throw new InvalidFavoriteFacilityException("시설 식별자가 필요합니다.");
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/domain/FavoriteFacility.java
+++ b/backend/src/main/java/com/easysubway/favorite/domain/FavoriteFacility.java
@@ -1,0 +1,22 @@
+package com.easysubway.favorite.domain;
+
+import java.time.LocalDateTime;
+
+public record FavoriteFacility(
+	String userId,
+	String facilityId,
+	LocalDateTime addedAt
+) {
+
+	public FavoriteFacility {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidFavoriteFacilityException("사용자 식별자가 필요합니다.");
+		}
+		if (facilityId == null || facilityId.isBlank()) {
+			throw new InvalidFavoriteFacilityException("시설 식별자가 필요합니다.");
+		}
+		if (addedAt == null) {
+			throw new InvalidFavoriteFacilityException("추가 시각이 필요합니다.");
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/domain/FavoriteFacilityNotFoundException.java
+++ b/backend/src/main/java/com/easysubway/favorite/domain/FavoriteFacilityNotFoundException.java
@@ -1,0 +1,12 @@
+package com.easysubway.favorite.domain;
+
+import com.easysubway.common.error.ResourceNotFoundException;
+
+public class FavoriteFacilityNotFoundException extends ResourceNotFoundException {
+
+	private static final String MESSAGE = "시설 정보를 찾을 수 없습니다.";
+
+	public FavoriteFacilityNotFoundException() {
+		super(MESSAGE);
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/domain/FavoriteFacilityWithDetails.java
+++ b/backend/src/main/java/com/easysubway/favorite/domain/FavoriteFacilityWithDetails.java
@@ -1,0 +1,11 @@
+package com.easysubway.favorite.domain;
+
+import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.Station;
+
+public record FavoriteFacilityWithDetails(
+	FavoriteFacility favoriteFacility,
+	AccessibilityFacility facility,
+	Station station
+) {
+}

--- a/backend/src/main/java/com/easysubway/favorite/domain/InvalidFavoriteFacilityException.java
+++ b/backend/src/main/java/com/easysubway/favorite/domain/InvalidFavoriteFacilityException.java
@@ -1,0 +1,10 @@
+package com.easysubway.favorite.domain;
+
+import com.easysubway.common.error.InvalidRequestException;
+
+public class InvalidFavoriteFacilityException extends InvalidRequestException {
+
+	public InvalidFavoriteFacilityException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteFacilityControllerTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteFacilityControllerTest.java
@@ -1,0 +1,89 @@
+package com.easysubway.favorite.adapter.in.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("즐겨찾기 시설 API")
+class FavoriteFacilityControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("인증 사용자 기준으로 시설을 저장하고 목록 조회와 삭제를 처리한다")
+	void favoriteFacilitiesCanBeSavedListedAndRemoved() throws Exception {
+		mockMvc.perform(put("/api/v1/me/favorites/facilities/facility-sangnoksu-elevator-1")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "spoofed-user"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.userId").value("anonymous-user-1"))
+			.andExpect(jsonPath("$.data.facilityId").value("facility-sangnoksu-elevator-1"))
+			.andExpect(jsonPath("$.data.stationId").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data.stationNameKo").value("상록수"))
+			.andExpect(jsonPath("$.data.name").value("1번 출구 엘리베이터"))
+			.andExpect(jsonPath("$.data.type").value("ELEVATOR"))
+			.andExpect(jsonPath("$.data.status").value("NORMAL"))
+			.andExpect(jsonPath("$.data.dataConfidence").value("HIGH"))
+			.andExpect(jsonPath("$.data.lastUpdatedAt").value("2026-06-12"))
+			.andExpect(jsonPath("$.data.addedAt").isNotEmpty());
+
+		mockMvc.perform(get("/api/v1/me/favorites/facilities")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].facilityId").value("facility-sangnoksu-elevator-1"))
+			.andExpect(jsonPath("$.data[0].stationNameKo").value("상록수"))
+			.andExpect(jsonPath("$.data[0].name").value("1번 출구 엘리베이터"));
+
+		mockMvc.perform(delete("/api/v1/me/favorites/facilities/facility-sangnoksu-elevator-1")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true));
+
+		mockMvc.perform(get("/api/v1/me/favorites/facilities")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data").isEmpty());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 시설은 공통 404 응답으로 거부한다")
+	void favoriteFacilitiesRejectUnknownFacility() throws Exception {
+		mockMvc.perform(put("/api/v1/me/favorites/facilities/missing-facility")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("시설 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("즐겨찾기 시설 목록은 인증된 사용자만 조회할 수 있다")
+	void favoriteFacilitiesRequireAuthentication() throws Exception {
+		mockMvc.perform(get("/api/v1/me/favorites/facilities"))
+			.andExpect(status().isUnauthorized());
+	}
+}

--- a/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteFacilityRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteFacilityRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.easysubway.favorite.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.favorite.domain.FavoriteFacility;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("즐겨찾기 시설 인메모리 저장소")
+class InMemoryFavoriteFacilityRepositoryTest {
+
+	@Test
+	@DisplayName("사용자별 시설 즐겨찾기는 시설 식별자를 기준으로 저장하고 삭제한다")
+	void favoriteFacilityRepositoryStoresAndDeletesByUserAndFacility() {
+		var repository = new InMemoryFavoriteFacilityRepository();
+		var favorite = new FavoriteFacility(
+			"anonymous-user-1",
+			"facility-sangnoksu-elevator-1",
+			LocalDateTime.of(2026, 6, 12, 9, 0)
+		);
+
+		repository.saveFavoriteFacility(favorite);
+
+		assertThat(repository.loadFavoriteFacility("anonymous-user-1", "facility-sangnoksu-elevator-1"))
+			.contains(favorite);
+		assertThat(repository.loadFavoriteFacilities("anonymous-user-1"))
+			.containsExactly(favorite);
+
+		repository.deleteFavoriteFacility("anonymous-user-1", "facility-sangnoksu-elevator-1");
+
+		assertThat(repository.loadFavoriteFacilities("anonymous-user-1")).isEmpty();
+	}
+}

--- a/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteFacilityServiceTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteFacilityServiceTest.java
@@ -10,11 +10,25 @@ import com.easysubway.favorite.application.port.in.SaveFavoriteFacilityCommand;
 import com.easysubway.favorite.domain.FavoriteFacility;
 import com.easysubway.favorite.domain.FavoriteFacilityNotFoundException;
 import com.easysubway.favorite.domain.InvalidFavoriteFacilityException;
+import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
+import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import com.easysubway.transit.domain.AccessibilityFacilityType;
+import com.easysubway.transit.domain.DataConfidenceLevel;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationExit;
+import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.StationNotFoundException;
+import com.easysubway.transit.domain.SubwayLine;
+import com.easysubway.transit.domain.TransitOperator;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -87,6 +101,28 @@ class FavoriteFacilityServiceTest {
 	}
 
 	@Test
+	@DisplayName("시설의 연결 역이 없으면 즐겨찾기를 저장하지 않는다")
+	void saveFavoriteFacilityRejectsFacilityWithoutActiveStationBeforePersisting() {
+		var repository = new InMemoryFavoriteFacilityRepository();
+		var serviceWithBrokenTransitData = new FavoriteFacilityService(
+			repository,
+			repository,
+			repository,
+			new BrokenFacilityTransitMasterPort(),
+			Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+		);
+
+		assertThatThrownBy(() -> serviceWithBrokenTransitData.saveFavoriteFacility(new SaveFavoriteFacilityCommand(
+			"anonymous-user-1",
+			"facility-broken-station"
+		)))
+			.isInstanceOf(StationNotFoundException.class)
+			.hasMessage("역 정보를 찾을 수 없습니다.");
+
+		assertThat(repository.loadFavoriteFacilities("anonymous-user-1")).isEmpty();
+	}
+
+	@Test
 	@DisplayName("시설 즐겨찾기 명령은 사용자와 시설 식별자를 요구한다")
 	void favoriteFacilityCommandsRequireUserAndFacility() {
 		assertThatThrownBy(() -> service.listFavoriteFacilities(new ListFavoriteFacilitiesCommand("")))
@@ -117,5 +153,52 @@ class FavoriteFacilityServiceTest {
 		))
 			.isInstanceOf(InvalidFavoriteFacilityException.class)
 			.hasMessage("추가 시각이 필요합니다.");
+	}
+
+	private static final class BrokenFacilityTransitMasterPort implements LoadTransitMasterPort {
+
+		@Override
+		public List<TransitOperator> loadOperators() {
+			return List.of();
+		}
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of();
+		}
+
+		@Override
+		public List<Station> loadStations() {
+			return List.of();
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of();
+		}
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of();
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(new AccessibilityFacility(
+				"facility-broken-station",
+				"station-missing",
+				null,
+				AccessibilityFacilityType.ELEVATOR,
+				"연결 역 누락 엘리베이터",
+				"지상",
+				"대합실",
+				new BigDecimal("37.300000"),
+				new BigDecimal("126.800000"),
+				"연결 역 데이터가 없는 테스트 시설입니다.",
+				AccessibilityFacilityStatus.NORMAL,
+				DataConfidenceLevel.HIGH,
+				LocalDate.of(2026, 6, 12)
+			));
+		}
 	}
 }

--- a/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteFacilityServiceTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteFacilityServiceTest.java
@@ -1,0 +1,121 @@
+package com.easysubway.favorite.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteFacilityRepository;
+import com.easysubway.favorite.application.port.in.ListFavoriteFacilitiesCommand;
+import com.easysubway.favorite.application.port.in.RemoveFavoriteFacilityCommand;
+import com.easysubway.favorite.application.port.in.SaveFavoriteFacilityCommand;
+import com.easysubway.favorite.domain.FavoriteFacility;
+import com.easysubway.favorite.domain.FavoriteFacilityNotFoundException;
+import com.easysubway.favorite.domain.InvalidFavoriteFacilityException;
+import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("즐겨찾기 시설 서비스")
+class FavoriteFacilityServiceTest {
+
+	private final InMemoryFavoriteFacilityRepository favoriteFacilityRepository =
+		new InMemoryFavoriteFacilityRepository();
+	private final FavoriteFacilityService service = new FavoriteFacilityService(
+		favoriteFacilityRepository,
+		favoriteFacilityRepository,
+		favoriteFacilityRepository,
+		new InMemoryTransitMasterRepository(),
+		Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+	);
+
+	@Test
+	@DisplayName("시설 즐겨찾기는 사용자별로 한 번만 저장되고 역 정보와 함께 조회된다")
+	void saveFavoriteFacilityStoresFacilityOnceWithStationDetails() {
+		var favorite = service.saveFavoriteFacility(new SaveFavoriteFacilityCommand(
+			"anonymous-user-1",
+			"facility-sangnoksu-elevator-1"
+		));
+		var duplicated = service.saveFavoriteFacility(new SaveFavoriteFacilityCommand(
+			"anonymous-user-1",
+			"facility-sangnoksu-elevator-1"
+		));
+
+		assertThat(favorite.favoriteFacility().userId()).isEqualTo("anonymous-user-1");
+		assertThat(favorite.favoriteFacility().facilityId()).isEqualTo("facility-sangnoksu-elevator-1");
+		assertThat(favorite.favoriteFacility().addedAt()).isEqualTo(LocalDateTime.of(2026, 6, 12, 9, 0));
+		assertThat(favorite.facility().name()).isEqualTo("1번 출구 엘리베이터");
+		assertThat(favorite.station().nameKo()).isEqualTo("상록수");
+		assertThat(duplicated).isEqualTo(favorite);
+		assertThat(service.listFavoriteFacilities(new ListFavoriteFacilitiesCommand("anonymous-user-1")))
+			.containsExactly(favorite);
+	}
+
+	@Test
+	@DisplayName("시설 즐겨찾기 삭제는 같은 사용자와 같은 시설만 제거한다")
+	void removeFavoriteFacilityDeletesOnlyRequestedFacility() {
+		service.saveFavoriteFacility(new SaveFavoriteFacilityCommand(
+			"anonymous-user-1",
+			"facility-sangnoksu-elevator-1"
+		));
+		service.saveFavoriteFacility(new SaveFavoriteFacilityCommand(
+			"anonymous-user-1",
+			"facility-sangnoksu-escalator-1"
+		));
+
+		service.removeFavoriteFacility(new RemoveFavoriteFacilityCommand(
+			"anonymous-user-1",
+			"facility-sangnoksu-elevator-1"
+		));
+
+		assertThat(service.listFavoriteFacilities(new ListFavoriteFacilitiesCommand("anonymous-user-1")))
+			.extracting(favorite -> favorite.favoriteFacility().facilityId())
+			.containsExactly("facility-sangnoksu-escalator-1");
+	}
+
+	@Test
+	@DisplayName("시설 즐겨찾기 저장은 존재하는 시설을 요구한다")
+	void saveFavoriteFacilityRequiresExistingFacility() {
+		assertThatThrownBy(() -> service.saveFavoriteFacility(new SaveFavoriteFacilityCommand(
+			"anonymous-user-1",
+			"missing-facility"
+		)))
+			.isInstanceOf(FavoriteFacilityNotFoundException.class)
+			.hasMessage("시설 정보를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("시설 즐겨찾기 명령은 사용자와 시설 식별자를 요구한다")
+	void favoriteFacilityCommandsRequireUserAndFacility() {
+		assertThatThrownBy(() -> service.listFavoriteFacilities(new ListFavoriteFacilitiesCommand("")))
+			.isInstanceOf(InvalidFavoriteFacilityException.class)
+			.hasMessage("사용자 식별자가 필요합니다.");
+
+		assertThatThrownBy(() -> service.saveFavoriteFacility(new SaveFavoriteFacilityCommand(
+			"anonymous-user-1",
+			""
+		)))
+			.isInstanceOf(InvalidFavoriteFacilityException.class)
+			.hasMessage("시설 식별자가 필요합니다.");
+	}
+
+	@Test
+	@DisplayName("시설 즐겨찾기 도메인은 비어 있는 사용자와 시설 정보를 허용하지 않는다")
+	void favoriteFacilityDomainRejectsInvalidState() {
+		assertThatThrownBy(() -> new FavoriteFacility("", "facility-sangnoksu-elevator-1", LocalDateTime.now()))
+			.isInstanceOf(InvalidFavoriteFacilityException.class)
+			.hasMessage("사용자 식별자가 필요합니다.");
+		assertThatThrownBy(() -> new FavoriteFacility("anonymous-user-1", "", LocalDateTime.now()))
+			.isInstanceOf(InvalidFavoriteFacilityException.class)
+			.hasMessage("시설 식별자가 필요합니다.");
+		assertThatThrownBy(() -> new FavoriteFacility(
+			"anonymous-user-1",
+			"facility-sangnoksu-elevator-1",
+			null
+		))
+			.isInstanceOf(InvalidFavoriteFacilityException.class)
+			.hasMessage("추가 시각이 필요합니다.");
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -424,6 +424,58 @@ test("백엔드 즐겨찾기 역은 헥사고날 API 경계를 따른다", () =>
   assert.match(security, /anyRequest\(\)\.authenticated\(\)/);
 });
 
+test("백엔드 즐겨찾기 시설은 시설 마스터 기반 헥사고날 API 경계를 따른다", () => {
+  const favorite = read("backend/src/main/java/com/easysubway/favorite/domain/FavoriteFacility.java");
+  const favoriteDetails = read("backend/src/main/java/com/easysubway/favorite/domain/FavoriteFacilityWithDetails.java");
+  const invalidFavorite = read("backend/src/main/java/com/easysubway/favorite/domain/InvalidFavoriteFacilityException.java");
+  const notFound = read("backend/src/main/java/com/easysubway/favorite/domain/FavoriteFacilityNotFoundException.java");
+  const useCase = read("backend/src/main/java/com/easysubway/favorite/application/port/in/FavoriteFacilityUseCase.java");
+  const listCommand = read("backend/src/main/java/com/easysubway/favorite/application/port/in/ListFavoriteFacilitiesCommand.java");
+  const saveCommand = read("backend/src/main/java/com/easysubway/favorite/application/port/in/SaveFavoriteFacilityCommand.java");
+  const removeCommand = read("backend/src/main/java/com/easysubway/favorite/application/port/in/RemoveFavoriteFacilityCommand.java");
+  const loadPort = read("backend/src/main/java/com/easysubway/favorite/application/port/out/LoadFavoriteFacilityPort.java");
+  const savePort = read("backend/src/main/java/com/easysubway/favorite/application/port/out/SaveFavoriteFacilityPort.java");
+  const deletePort = read("backend/src/main/java/com/easysubway/favorite/application/port/out/DeleteFavoriteFacilityPort.java");
+  const service = read("backend/src/main/java/com/easysubway/favorite/application/service/FavoriteFacilityService.java");
+  const repository = read("backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteFacilityRepository.java");
+  const controller = read("backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteFacilityController.java");
+  const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
+
+  assert.match(favorite, /record FavoriteFacility/);
+  assert.match(favorite, /facilityId/);
+  assert.match(favorite, /addedAt/);
+  assert.match(favorite, /InvalidFavoriteFacilityException/);
+  assert.match(favoriteDetails, /AccessibilityFacility/);
+  assert.match(favoriteDetails, /Station/);
+  assert.match(invalidFavorite, /extends InvalidRequestException/);
+  assert.match(notFound, /extends ResourceNotFoundException/);
+  assert.match(notFound, /시설 정보를 찾을 수 없습니다\./);
+  assert.match(useCase, /interface FavoriteFacilityUseCase/);
+  assert.match(useCase, /listFavoriteFacilities/);
+  assert.match(useCase, /saveFavoriteFacility/);
+  assert.match(useCase, /removeFavoriteFacility/);
+  assert.match(listCommand, /record ListFavoriteFacilitiesCommand/);
+  assert.match(saveCommand, /record SaveFavoriteFacilityCommand/);
+  assert.match(removeCommand, /record RemoveFavoriteFacilityCommand/);
+  assert.match(loadPort, /interface LoadFavoriteFacilityPort/);
+  assert.match(savePort, /interface SaveFavoriteFacilityPort/);
+  assert.match(deletePort, /interface DeleteFavoriteFacilityPort/);
+  assert.match(service, /implements FavoriteFacilityUseCase/);
+  assert.match(service, /LoadTransitMasterPort/);
+  assert.match(service, /loadAccessibilityFacilities/);
+  assert.match(service, /FavoriteFacilityNotFoundException/);
+  assert.match(repository, /implements[\s\S]*LoadFavoriteFacilityPort[\s\S]*SaveFavoriteFacilityPort[\s\S]*DeleteFavoriteFacilityPort/);
+  assert.match(controller, /@GetMapping\("\/api\/v1\/me\/favorites\/facilities"\)/);
+  assert.match(controller, /@PutMapping\("\/api\/v1\/me\/favorites\/facilities\/\{facilityId\}"\)/);
+  assert.match(controller, /@DeleteMapping\("\/api\/v1\/me\/favorites\/facilities\/\{facilityId\}"\)/);
+  assert.match(controller, /Principal principal/);
+  assert.match(controller, /AccessibilityFacilityStatus/);
+  assert.match(controller, /DataConfidenceLevel/);
+  assert.doesNotMatch(controller, /RequestParam\(required = false\) String userId/);
+  assert.match(security, /securityMatcher\([\s\S]*"\/api\/v1\/me\/favorites\/\*\*"/);
+  assert.match(security, /anyRequest\(\)\.authenticated\(\)/);
+});
+
 test("백엔드 즐겨찾기 경로는 경로 검색 결과 기반 헥사고날 API 경계를 따른다", () => {
   const favorite = read("backend/src/main/java/com/easysubway/favorite/domain/FavoriteRoute.java");
   const favoriteDetails = read("backend/src/main/java/com/easysubway/favorite/domain/FavoriteRouteWithDetails.java");


### PR DESCRIPTION
## 관련 이슈
- Closes #56

## 요약
- 인증 사용자 기준 시설 즐겨찾기 조회/저장/삭제 API를 추가했습니다.
- 즐겨찾기 응답에 시설 상태, 데이터 신뢰도, 마지막 갱신일, 연결 역 정보를 포함했습니다.
- 존재하지 않는 시설과 미인증 요청을 테스트로 고정했습니다.

## 변경 사항
- `FavoriteFacility` 도메인과 입출력 포트를 추가했습니다.
- 시설 마스터 데이터를 조회해 즐겨찾기 상세 응답을 구성하는 서비스를 추가했습니다.
- 인메모리 저장소와 컨트롤러를 추가했습니다.
- 컨트롤러, 서비스, 저장소 테스트를 추가했습니다.

## 검증
- [x] `./gradlew test --tests "com.easysubway.favorite.*"` 통과
- [x] `./gradlew test --rerun-tasks` 통과
- [x] `node --test tools/ci/*.test.mjs` 통과
- [x] `git diff --cached --check` 통과
- [x] `git ls-files '*.md'` 결과: `README.md`, `.github/pull_request_template.md`
- [x] Codex Security diff scan 결과: reportable finding 0건

## 리스크
- 현재 저장소는 인메모리 구현이므로 서버 재시작 시 즐겨찾기 데이터가 유지되지 않습니다. 영속 저장소 전환 시 동일 포트 계약을 유지해야 합니다.

## 체크리스트
- [x] PR 본문에 템플릿 안내 문구가 남아 있지 않음
- [x] CodeRabbit 또는 Codex CLI code review 결과를 확인함
- [x] 필수 CI 통과 확인
