### PR TITLE
[Feat] 이동 프로필별 경로 가중치 적용

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -1,12 +1,12 @@
 package com.easysubway.route.application.service;
 
-import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.application.port.out.LoadRouteSearchPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
 import com.easysubway.route.domain.InvalidRouteSearchException;
 import com.easysubway.route.domain.RouteNotFoundException;
+import com.easysubway.route.domain.RouteProfileWeight;
 import com.easysubway.route.domain.RouteSearchNotFoundException;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
@@ -76,8 +76,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 		DirectLine directLine = findDirectLine(origin.id(), destination.id());
 		boolean stairOnlyAccess = hasStairOnlyAccess(origin.id(), destination.id());
 		List<RouteWarning> warnings = routeWarnings(origin.id(), destination.id(), stairOnlyAccess);
+		RouteProfileWeight profileWeight = RouteProfileWeight.from(command.mobilityType());
 
-		if (command.mobilityType() == MobilityType.WHEELCHAIR && stairOnlyAccess) {
+		if (profileWeight.blocksStairOnlyAccess() && stairOnlyAccess) {
 			return saveRouteSearchPort.saveRouteSearch(new RouteSearchResult(
 				newRouteSearchId(),
 				origin.id(),
@@ -96,7 +97,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			));
 		}
 
-		List<RouteStep> steps = directLineSteps(origin, destination, directLine);
+		List<RouteStep> steps = directLineSteps(origin, destination, directLine, profileWeight);
 		return saveRouteSearchPort.saveRouteSearch(new RouteSearchResult(
 			newRouteSearchId(),
 			origin.id(),
@@ -107,7 +108,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			RouteSearchStatus.FOUND,
 			directLine.line().id(),
 			directLine.line().name(),
-			routeScore(command.mobilityType(), directLine, warnings),
+			routeScore(profileWeight, directLine, warnings),
 			steps,
 			warnings,
 			List.of(),
@@ -267,30 +268,32 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.toList();
 	}
 
-	private int routeScore(MobilityType mobilityType, DirectLine directLine, List<RouteWarning> warnings) {
+	private int routeScore(RouteProfileWeight profileWeight, DirectLine directLine, List<RouteWarning> warnings) {
 		// 점수는 시간이 아니라 상대 비용이다. 낮을수록 쉬운 경로에 가깝다.
 		int trainTime = directLine.stopCount() * 3;
-		int walkingTime = 8;
-		int profilePenalty = switch (mobilityType) {
-			case SENIOR -> 12;
-			case STROLLER, PREGNANT, LUGGAGE -> 10;
-			case TEMPORARY_INJURY -> 14;
-			case WHEELCHAIR -> 18;
-		};
 		int lowDataPenalty = warnings.stream()
-			.anyMatch(warning -> warning.code() == RouteWarningCode.LOW_DATA_CONFIDENCE) ? 20 : 0;
+			.anyMatch(warning -> warning.code() == RouteWarningCode.LOW_DATA_CONFIDENCE)
+			? profileWeight.lowDataConfidencePenalty()
+			: 0;
 		int stairOnlyPenalty = warnings.stream()
-			.anyMatch(warning -> warning.code() == RouteWarningCode.STAIR_ONLY_ACCESS) ? 30 : 0;
-		return trainTime + walkingTime + profilePenalty + lowDataPenalty + stairOnlyPenalty;
+			.anyMatch(warning -> warning.code() == RouteWarningCode.STAIR_ONLY_ACCESS)
+			? profileWeight.stairOnlyAccessPenalty()
+			: 0;
+		return trainTime + profileWeight.baseAccessCost() + lowDataPenalty + stairOnlyPenalty;
 	}
 
-	private List<RouteStep> directLineSteps(Station origin, Station destination, DirectLine directLine) {
+	private List<RouteStep> directLineSteps(
+		Station origin,
+		Station destination,
+		DirectLine directLine,
+		RouteProfileWeight profileWeight
+	) {
 		String displayLine = displayLineName(directLine.line());
 		return List.of(
 			new RouteStep(
 				1,
 				origin.nameKo() + "역에서 " + displayLine + " 승강장으로 이동",
-				"엘리베이터와 넓은 통로가 있는 출구를 먼저 확인한 뒤 승강장으로 이동합니다.",
+				profileWeight.entryGuidance(),
 				directLine.line().id(),
 				directLine.line().name(),
 				origin.id(),
@@ -308,7 +311,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			new RouteStep(
 				3,
 				destination.nameKo() + "역에서 출구 접근성 정보를 확인",
-				"도착역 출구와 엘리베이터 상태를 확인한 뒤 이동합니다.",
+				profileWeight.exitGuidance(),
 				directLine.line().id(),
 				directLine.line().name(),
 				destination.id(),

--- a/backend/src/main/java/com/easysubway/route/domain/RouteProfileWeight.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteProfileWeight.java
@@ -1,0 +1,67 @@
+package com.easysubway.route.domain;
+
+import com.easysubway.profile.domain.MobilityType;
+
+public record RouteProfileWeight(
+	int baseAccessCost,
+	int lowDataConfidencePenalty,
+	int stairOnlyAccessPenalty,
+	boolean blocksStairOnlyAccess,
+	String entryGuidance,
+	String exitGuidance
+) {
+
+	public static RouteProfileWeight from(MobilityType mobilityType) {
+		// 점수는 시간 예측이 아니라 같은 경로 후보를 비교하기 위한 접근 부담 비용이다.
+		return switch (mobilityType) {
+			case SENIOR -> new RouteProfileWeight(
+				18,
+				24,
+				38,
+				false,
+				"계단을 피하고 이동 거리가 짧은 출구를 먼저 확인합니다.",
+				"도착역에서 계단을 피할 수 있는 출구와 짧은 동선을 확인합니다."
+			);
+			case STROLLER -> new RouteProfileWeight(
+				20,
+				28,
+				48,
+				false,
+				"엘리베이터와 넓은 통로가 있는 출구를 먼저 확인합니다.",
+				"도착역에서 엘리베이터와 넓은 통로가 있는 출구를 확인합니다."
+			);
+			case WHEELCHAIR -> new RouteProfileWeight(
+				24,
+				36,
+				100,
+				true,
+				"엘리베이터, 리프트, 경사로 연결을 먼저 확인합니다.",
+				"도착역에서 엘리베이터, 리프트, 경사로 연결 출구를 확인합니다."
+			);
+			case PREGNANT -> new RouteProfileWeight(
+				17,
+				26,
+				42,
+				false,
+				"엘리베이터와 짧은 이동 동선을 먼저 확인합니다.",
+				"도착역에서 짧게 걸을 수 있는 엘리베이터 출구를 확인합니다."
+			);
+			case TEMPORARY_INJURY -> new RouteProfileWeight(
+				22,
+				30,
+				52,
+				false,
+				"계단을 피하고 쉬어 갈 수 있는 동선을 먼저 확인합니다.",
+				"도착역에서 계단을 피하고 천천히 이동할 수 있는 출구를 확인합니다."
+			);
+			case LUGGAGE -> new RouteProfileWeight(
+				16,
+				22,
+				34,
+				false,
+				"엘리베이터와 넓은 출구 동선을 먼저 확인합니다.",
+				"도착역에서 큰 짐을 들고 지나가기 쉬운 출구를 확인합니다."
+			);
+		};
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -30,6 +30,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -145,6 +146,34 @@ class RouteSearchServiceTest {
 			.extracting("code")
 			.contains(RouteWarningCode.STAIR_ONLY_ACCESS);
 		assertThat(stairOnlyResult.score()).isGreaterThan(accessibleResult.score());
+	}
+
+	@Test
+	@DisplayName("계단 접근 경고 점수는 이동 유형별 이동 부담을 다르게 반영한다")
+	void stairOnlyWarningScoreReflectsMobilityProfileCost() {
+		assertThat(stairOnlyScoreByMobilityType())
+			.containsEntry(MobilityType.TEMPORARY_INJURY, 77)
+			.containsEntry(MobilityType.STROLLER, 71)
+			.containsEntry(MobilityType.PREGNANT, 62)
+			.containsEntry(MobilityType.SENIOR, 59)
+			.containsEntry(MobilityType.LUGGAGE, 53);
+	}
+
+	@Test
+	@DisplayName("경로 단계 설명은 이동 유형별로 필요한 접근 조건을 안내한다")
+	void routeStepDescriptionReflectsMobilityProfile() {
+		assertThat(firstStepDescription(MobilityType.SENIOR))
+			.isEqualTo("계단을 피하고 이동 거리가 짧은 출구를 먼저 확인합니다.");
+		assertThat(firstStepDescription(MobilityType.STROLLER))
+			.isEqualTo("엘리베이터와 넓은 통로가 있는 출구를 먼저 확인합니다.");
+		assertThat(firstStepDescription(MobilityType.WHEELCHAIR))
+			.isEqualTo("엘리베이터, 리프트, 경사로 연결을 먼저 확인합니다.");
+		assertThat(firstStepDescription(MobilityType.PREGNANT))
+			.isEqualTo("엘리베이터와 짧은 이동 동선을 먼저 확인합니다.");
+		assertThat(firstStepDescription(MobilityType.TEMPORARY_INJURY))
+			.isEqualTo("계단을 피하고 쉬어 갈 수 있는 동선을 먼저 확인합니다.");
+		assertThat(firstStepDescription(MobilityType.LUGGAGE))
+			.isEqualTo("엘리베이터와 넓은 출구 동선을 먼저 확인합니다.");
 	}
 
 	@Test
@@ -362,6 +391,36 @@ class RouteSearchServiceTest {
 		assertThatThrownBy(() -> service.getRouteSearch("route-missing"))
 			.isInstanceOf(RouteSearchNotFoundException.class)
 			.hasMessage("경로 검색 결과를 찾을 수 없습니다.");
+	}
+
+	private static Map<MobilityType, Integer> stairOnlyScoreByMobilityType() {
+		return Map.of(
+			MobilityType.SENIOR, scoreFor(MobilityType.SENIOR, new StairOnlyTransitMasterPort()),
+			MobilityType.STROLLER, scoreFor(MobilityType.STROLLER, new StairOnlyTransitMasterPort()),
+			MobilityType.PREGNANT, scoreFor(MobilityType.PREGNANT, new StairOnlyTransitMasterPort()),
+			MobilityType.TEMPORARY_INJURY, scoreFor(MobilityType.TEMPORARY_INJURY, new StairOnlyTransitMasterPort()),
+			MobilityType.LUGGAGE, scoreFor(MobilityType.LUGGAGE, new StairOnlyTransitMasterPort())
+		);
+	}
+
+	private static int scoreFor(MobilityType mobilityType, LoadTransitMasterPort transitMasterPort) {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeSearchService = new RouteSearchService(repository, repository, transitMasterPort, CLOCK);
+		return routeSearchService.searchRoute(new SearchRouteCommand("station-a", "station-b", mobilityType)).score();
+	}
+
+	private static String firstStepDescription(MobilityType mobilityType) {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeSearchService = new RouteSearchService(
+			repository,
+			repository,
+			new RampAccessibleTransitMasterPort(),
+			CLOCK
+		);
+		return routeSearchService.searchRoute(new SearchRouteCommand("station-a", "station-b", mobilityType))
+			.steps()
+			.getFirst()
+			.description();
 	}
 
 	private static class StairOnlyTransitMasterPort implements LoadTransitMasterPort {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -572,6 +572,7 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   const status = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchStatus.java");
   const warning = read("backend/src/main/java/com/easysubway/route/domain/RouteWarning.java");
   const warningCode = read("backend/src/main/java/com/easysubway/route/domain/RouteWarningCode.java");
+  const profileWeight = read("backend/src/main/java/com/easysubway/route/domain/RouteProfileWeight.java");
   const step = read("backend/src/main/java/com/easysubway/route/domain/RouteStep.java");
   const invalidSearch = read("backend/src/main/java/com/easysubway/route/domain/InvalidRouteSearchException.java");
   const routeNotFound = read("backend/src/main/java/com/easysubway/route/domain/RouteNotFoundException.java");
@@ -591,6 +592,10 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(status, /BLOCKED/);
   assert.match(warning, /record RouteWarning/);
   assert.match(warningCode, /LOW_DATA_CONFIDENCE/);
+  assert.match(profileWeight, /record RouteProfileWeight/);
+  assert.match(profileWeight, /MobilityType/);
+  assert.match(profileWeight, /blocksStairOnlyAccess/);
+  assert.match(profileWeight, /entryGuidance/);
   assert.match(step, /record RouteStep/);
   assert.match(invalidSearch, /extends InvalidRequestException/);
   assert.match(routeNotFound, /extends ResourceNotFoundException/);
@@ -603,7 +608,7 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(savePort, /interface SaveRouteSearchPort/);
   assert.match(service, /implements RouteSearchUseCase/);
   assert.match(service, /LoadTransitMasterPort/);
-  assert.match(service, /MobilityType\.WHEELCHAIR/);
+  assert.match(service, /RouteProfileWeight\.from/);
   assert.match(service, /RouteSearchStatus\.BLOCKED/);
   assert.match(service, /hasStairOnlyAccess/);
   assert.match(service, /routeScore/);


### PR DESCRIPTION
## 관련 이슈

Closes #58

## 요약

- 이동 유형별 경로 비용 정책을 분리했습니다.
- 계단 접근, 낮은 데이터 신뢰도에 대한 점수 반영을 이동 유형별로 조정했습니다.
- 경로 단계 설명을 고령자, 유모차, 휠체어, 임산부, 일시 부상, 큰 짐 사용자에게 맞게 정리했습니다.

## 변경 사항

- `RouteProfileWeight`로 이동 유형별 기본 비용과 경고 비용을 관리
- 휠체어 계단 접근 차단 기준 유지
- 경로 검색 서비스 테스트에 프로필별 점수와 안내 문구 검증 추가

## 검증

- [x] `./gradlew test --tests "com.easysubway.route.*"`
- [x] `./gradlew test`
- [x] `node --test tools/ci/*.test.mjs`
- [x] `git diff --check`
- [x] `git ls-files '*.md'`
- [x] GitHub PR CI 통과
- [x] CodeRabbit 리뷰 확인 또는 Codex CLI code review 대체 확인
- [x] Codex Security diff scan 확인
- [x] merge 후 main CI와 후속 workflow 확인

## 리스크

- 기존 경로 응답의 `score` 값이 이동 유형별로 달라집니다.
- 경로 단계 설명 문구가 변경되므로 모바일 화면에서 표시되는 안내 문구가 함께 바뀝니다.
