### PR TITLE
[Feat] 푸시 알림 outbox 기반 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationController.java
@@ -1,0 +1,90 @@
+package com.easysubway.notification.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.notification.application.port.in.DispatchPushNotificationCommand;
+import com.easysubway.notification.application.port.in.PushNotificationDispatchUseCase;
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationDispatchResult;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import com.easysubway.notification.domain.PushNotificationType;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class PushNotificationController {
+
+	private final PushNotificationDispatchUseCase pushNotificationDispatchUseCase;
+
+	PushNotificationController(PushNotificationDispatchUseCase pushNotificationDispatchUseCase) {
+		this.pushNotificationDispatchUseCase = pushNotificationDispatchUseCase;
+	}
+
+	@PostMapping("/admin/notifications/push")
+	ApiResponse<PushNotificationDispatchResponse> dispatch(@RequestBody PushNotificationDispatchRequest request) {
+		PushNotificationDispatchResult result = pushNotificationDispatchUseCase.dispatch(
+			new DispatchPushNotificationCommand(
+				request.userId(),
+				request.type(),
+				request.title(),
+				request.body()
+			)
+		);
+		return ApiResponse.ok(PushNotificationDispatchResponse.from(result));
+	}
+
+	record PushNotificationDispatchRequest(
+		String userId,
+		PushNotificationType type,
+		String title,
+		String body
+	) {
+	}
+
+	record PushNotificationDispatchResponse(
+		String requestedUserId,
+		PushNotificationType type,
+		int createdCount,
+		List<PushNotificationResponse> notifications
+	) {
+
+		static PushNotificationDispatchResponse from(PushNotificationDispatchResult result) {
+			return new PushNotificationDispatchResponse(
+				result.requestedUserId(),
+				result.type(),
+				result.createdCount(),
+				result.notifications().stream()
+					.map(PushNotificationResponse::from)
+					.toList()
+			);
+		}
+	}
+
+	record PushNotificationResponse(
+		String notificationId,
+		String userId,
+		DevicePlatform platform,
+		PushNotificationType type,
+		String title,
+		String body,
+		PushNotificationStatus status,
+		LocalDateTime createdAt
+	) {
+
+		static PushNotificationResponse from(PushNotification notification) {
+			return new PushNotificationResponse(
+				notification.notificationId(),
+				notification.userId(),
+				notification.platform(),
+				notification.type(),
+				notification.title(),
+				notification.body(),
+				notification.status(),
+				notification.createdAt()
+			);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
@@ -1,0 +1,32 @@
+package com.easysubway.notification.adapter.out.persistence;
+
+import com.easysubway.notification.application.port.out.LoadPushNotificationOutboxPort;
+import com.easysubway.notification.application.port.out.SavePushNotificationOutboxPort;
+import com.easysubway.notification.domain.PushNotification;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryPushNotificationOutboxRepository implements
+	LoadPushNotificationOutboxPort,
+	SavePushNotificationOutboxPort {
+
+	private final Map<String, List<PushNotification>> notificationsByUserId = new ConcurrentHashMap<>();
+
+	@Override
+	public PushNotification savePushNotification(PushNotification notification) {
+		// outbox는 실제 발송 어댑터가 붙기 전까지 생성 순서를 보존해 운영자가 대기열을 확인할 수 있게 둔다.
+		notificationsByUserId
+			.computeIfAbsent(notification.userId(), ignored -> new CopyOnWriteArrayList<>())
+			.add(notification);
+		return notification;
+	}
+
+	@Override
+	public List<PushNotification> loadPushNotifications(String userId) {
+		return List.copyOf(notificationsByUserId.getOrDefault(userId, List.of()));
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/DispatchPushNotificationCommand.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/DispatchPushNotificationCommand.java
@@ -1,0 +1,30 @@
+package com.easysubway.notification.application.port.in;
+
+import com.easysubway.notification.domain.InvalidPushNotificationException;
+import com.easysubway.notification.domain.PushNotificationType;
+
+public record DispatchPushNotificationCommand(
+	String userId,
+	PushNotificationType type,
+	String title,
+	String body
+) {
+
+	public DispatchPushNotificationCommand {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidPushNotificationException("사용자 식별자가 필요합니다.");
+		}
+		if (type == null) {
+			throw new InvalidPushNotificationException("알림 종류를 선택해야 합니다.");
+		}
+		if (title == null || title.isBlank()) {
+			throw new InvalidPushNotificationException("알림 제목이 필요합니다.");
+		}
+		if (body == null || body.isBlank()) {
+			throw new InvalidPushNotificationException("알림 본문이 필요합니다.");
+		}
+		userId = userId.trim();
+		title = title.trim();
+		body = body.trim();
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationDispatchUseCase.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationDispatchUseCase.java
@@ -1,0 +1,8 @@
+package com.easysubway.notification.application.port.in;
+
+import com.easysubway.notification.domain.PushNotificationDispatchResult;
+
+public interface PushNotificationDispatchUseCase {
+
+	PushNotificationDispatchResult dispatch(DispatchPushNotificationCommand command);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/LoadPushNotificationOutboxPort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/LoadPushNotificationOutboxPort.java
@@ -1,0 +1,9 @@
+package com.easysubway.notification.application.port.out;
+
+import com.easysubway.notification.domain.PushNotification;
+import java.util.List;
+
+public interface LoadPushNotificationOutboxPort {
+
+	List<PushNotification> loadPushNotifications(String userId);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/SavePushNotificationOutboxPort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/SavePushNotificationOutboxPort.java
@@ -1,0 +1,8 @@
+package com.easysubway.notification.application.port.out;
+
+import com.easysubway.notification.domain.PushNotification;
+
+public interface SavePushNotificationOutboxPort {
+
+	PushNotification savePushNotification(PushNotification notification);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDispatchService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDispatchService.java
@@ -1,0 +1,101 @@
+package com.easysubway.notification.application.service;
+
+import com.easysubway.notification.application.port.in.DispatchPushNotificationCommand;
+import com.easysubway.notification.application.port.in.PushNotificationDispatchUseCase;
+import com.easysubway.notification.application.port.out.LoadNotificationPreferencePort;
+import com.easysubway.notification.application.port.out.SavePushNotificationOutboxPort;
+import com.easysubway.notification.domain.NotificationSettings;
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationDispatchResult;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import com.easysubway.notification.domain.PushNotificationType;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PushNotificationDispatchService implements PushNotificationDispatchUseCase {
+
+	private final LoadNotificationPreferencePort loadNotificationPreferencePort;
+	private final SavePushNotificationOutboxPort savePushNotificationOutboxPort;
+	private final Clock clock;
+
+	@Autowired
+	public PushNotificationDispatchService(
+		LoadNotificationPreferencePort loadNotificationPreferencePort,
+		SavePushNotificationOutboxPort savePushNotificationOutboxPort
+	) {
+		this(loadNotificationPreferencePort, savePushNotificationOutboxPort, Clock.systemDefaultZone());
+	}
+
+	public PushNotificationDispatchService(
+		LoadNotificationPreferencePort loadNotificationPreferencePort,
+		SavePushNotificationOutboxPort savePushNotificationOutboxPort,
+		Clock clock
+	) {
+		this.loadNotificationPreferencePort = loadNotificationPreferencePort;
+		this.savePushNotificationOutboxPort = savePushNotificationOutboxPort;
+		this.clock = clock;
+	}
+
+	@Override
+	public PushNotificationDispatchResult dispatch(DispatchPushNotificationCommand command) {
+		NotificationSettings settings = loadNotificationPreferencePort.loadNotificationSettings(command.userId())
+			.orElseGet(() -> defaultSettings(command.userId()));
+		if (!isEnabled(settings, command.type())) {
+			return emptyResult(command);
+		}
+
+		List<PushNotification> savedNotifications = new ArrayList<>();
+		for (var device : loadNotificationPreferencePort.loadDevices(command.userId())) {
+			var notification = new PushNotification(
+				"push-" + UUID.randomUUID(),
+				command.userId(),
+				device.platform(),
+				device.deviceToken(),
+				command.type(),
+				command.title(),
+				command.body(),
+				PushNotificationStatus.PENDING,
+				LocalDateTime.now(clock)
+			);
+			savedNotifications.add(savePushNotificationOutboxPort.savePushNotification(notification));
+		}
+
+		return new PushNotificationDispatchResult(
+			command.userId(),
+			command.type(),
+			savedNotifications.size(),
+			savedNotifications
+		);
+	}
+
+	private PushNotificationDispatchResult emptyResult(DispatchPushNotificationCommand command) {
+		return new PushNotificationDispatchResult(command.userId(), command.type(), 0, List.of());
+	}
+
+	private NotificationSettings defaultSettings(String userId) {
+		// 사용자가 설정을 열기 전에도 핵심 이동 안전 알림은 받을 수 있게 기존 기본값과 동일하게 맞춘다.
+		return new NotificationSettings(
+			userId,
+			true,
+			true,
+			true,
+			false,
+			LocalDateTime.now(clock)
+		);
+	}
+
+	private boolean isEnabled(NotificationSettings settings, PushNotificationType type) {
+		return switch (type) {
+			case FAVORITE_STATION_FACILITY -> settings.favoriteStationFacilityAlerts();
+			case FAVORITE_ROUTE_FACILITY -> settings.favoriteRouteFacilityAlerts();
+			case REPORT_STATUS -> settings.reportStatusAlerts();
+			case DATA_QUALITY -> settings.dataQualityAlerts();
+		};
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/InvalidPushNotificationException.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/InvalidPushNotificationException.java
@@ -1,0 +1,10 @@
+package com.easysubway.notification.domain;
+
+import com.easysubway.common.error.InvalidRequestException;
+
+public class InvalidPushNotificationException extends InvalidRequestException {
+
+	public InvalidPushNotificationException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotification.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotification.java
@@ -1,0 +1,51 @@
+package com.easysubway.notification.domain;
+
+import java.time.LocalDateTime;
+
+public record PushNotification(
+	String notificationId,
+	String userId,
+	DevicePlatform platform,
+	String deviceToken,
+	PushNotificationType type,
+	String title,
+	String body,
+	PushNotificationStatus status,
+	LocalDateTime createdAt
+) {
+
+	public PushNotification {
+		if (notificationId == null || notificationId.isBlank()) {
+			throw new InvalidPushNotificationException("알림 식별자가 필요합니다.");
+		}
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidPushNotificationException("사용자 식별자가 필요합니다.");
+		}
+		if (platform == null) {
+			throw new InvalidPushNotificationException("기기 플랫폼을 선택해야 합니다.");
+		}
+		if (deviceToken == null || deviceToken.isBlank()) {
+			throw new InvalidPushNotificationException("기기 토큰이 필요합니다.");
+		}
+		if (type == null) {
+			throw new InvalidPushNotificationException("알림 종류를 선택해야 합니다.");
+		}
+		if (title == null || title.isBlank()) {
+			throw new InvalidPushNotificationException("알림 제목이 필요합니다.");
+		}
+		if (body == null || body.isBlank()) {
+			throw new InvalidPushNotificationException("알림 본문이 필요합니다.");
+		}
+		if (status == null) {
+			throw new InvalidPushNotificationException("알림 상태가 필요합니다.");
+		}
+		if (createdAt == null) {
+			throw new InvalidPushNotificationException("알림 생성 시간이 필요합니다.");
+		}
+		notificationId = notificationId.trim();
+		userId = userId.trim();
+		deviceToken = deviceToken.trim();
+		title = title.trim();
+		body = body.trim();
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotificationDispatchResult.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotificationDispatchResult.java
@@ -1,0 +1,28 @@
+package com.easysubway.notification.domain;
+
+import java.util.List;
+
+public record PushNotificationDispatchResult(
+	String requestedUserId,
+	PushNotificationType type,
+	int createdCount,
+	List<PushNotification> notifications
+) {
+
+	public PushNotificationDispatchResult {
+		if (requestedUserId == null || requestedUserId.isBlank()) {
+			throw new InvalidPushNotificationException("사용자 식별자가 필요합니다.");
+		}
+		if (type == null) {
+			throw new InvalidPushNotificationException("알림 종류를 선택해야 합니다.");
+		}
+		if (createdCount < 0) {
+			throw new InvalidPushNotificationException("생성된 알림 수는 0 이상이어야 합니다.");
+		}
+		if (notifications == null) {
+			throw new InvalidPushNotificationException("알림 목록이 필요합니다.");
+		}
+		requestedUserId = requestedUserId.trim();
+		notifications = List.copyOf(notifications);
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotificationStatus.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotificationStatus.java
@@ -1,0 +1,5 @@
+package com.easysubway.notification.domain;
+
+public enum PushNotificationStatus {
+	PENDING
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotificationType.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotificationType.java
@@ -1,0 +1,8 @@
+package com.easysubway.notification.domain;
+
+public enum PushNotificationType {
+	FAVORITE_STATION_FACILITY,
+	FAVORITE_ROUTE_FACILITY,
+	REPORT_STATUS,
+	DATA_QUALITY
+}

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationControllerTest.java
@@ -1,0 +1,80 @@
+package com.easysubway.notification.adapter.in.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("푸시 알림 발송 API")
+class PushNotificationControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("관리자는 사용자 기기에 푸시 알림 발송 후보를 만들고 토큰은 응답하지 않는다")
+	void adminDispatchesPushNotificationWithoutExposingDeviceToken() throws Exception {
+		mockMvc.perform(post("/api/v1/devices")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "platform": "ANDROID",
+					  "deviceToken": "secret-device-token"
+					}
+					"""))
+			.andExpect(status().isOk());
+
+		mockMvc.perform(post("/admin/notifications/push")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "type": "FAVORITE_STATION_FACILITY",
+					  "title": "엘리베이터 운행 변경",
+					  "body": "상록수역 엘리베이터 상태를 확인하세요."
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.requestedUserId").value("anonymous-user-1"))
+			.andExpect(jsonPath("$.data.type").value("FAVORITE_STATION_FACILITY"))
+			.andExpect(jsonPath("$.data.createdCount").value(1))
+			.andExpect(jsonPath("$.data.notifications[0].notificationId").isNotEmpty())
+			.andExpect(jsonPath("$.data.notifications[0].platform").value("ANDROID"))
+			.andExpect(jsonPath("$.data.notifications[0].status").value("PENDING"))
+			.andExpect(jsonPath("$.data.notifications[0].deviceToken").doesNotExist());
+	}
+
+	@Test
+	@DisplayName("푸시 알림 발송 API는 관리자만 사용할 수 있다")
+	void pushNotificationDispatchRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(post("/admin/notifications/push")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "type": "REPORT_STATUS",
+					  "title": "신고 처리 알림",
+					  "body": "제보한 내용이 확인되었습니다."
+					}
+					"""))
+			.andExpect(status().isUnauthorized());
+	}
+}

--- a/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDispatchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDispatchServiceTest.java
@@ -1,0 +1,151 @@
+package com.easysubway.notification.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.notification.adapter.out.persistence.InMemoryNotificationPreferenceRepository;
+import com.easysubway.notification.adapter.out.persistence.InMemoryPushNotificationOutboxRepository;
+import com.easysubway.notification.application.port.in.DispatchPushNotificationCommand;
+import com.easysubway.notification.application.port.in.RegisterDeviceCommand;
+import com.easysubway.notification.application.port.in.SaveNotificationSettingsCommand;
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.InvalidPushNotificationException;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import com.easysubway.notification.domain.PushNotificationType;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("푸시 알림 발송 서비스")
+class PushNotificationDispatchServiceTest {
+
+	private static final Clock CLOCK = Clock.fixed(
+		Instant.parse("2026-06-14T01:00:00Z"),
+		ZoneId.of("Asia/Seoul")
+	);
+
+	private final InMemoryNotificationPreferenceRepository preferenceRepository =
+		new InMemoryNotificationPreferenceRepository();
+	private final InMemoryPushNotificationOutboxRepository outboxRepository =
+		new InMemoryPushNotificationOutboxRepository();
+	private final NotificationPreferenceService preferenceService = new NotificationPreferenceService(
+		preferenceRepository,
+		preferenceRepository,
+		preferenceRepository,
+		CLOCK
+	);
+	private final PushNotificationDispatchService dispatchService = new PushNotificationDispatchService(
+		preferenceRepository,
+		outboxRepository,
+		CLOCK
+	);
+
+	@Test
+	@DisplayName("수신 설정이 켜진 사용자의 등록 기기마다 발송 후보를 만든다")
+	void dispatchCreatesOutboxMessagesForEveryRegisteredDevice() {
+		registerDevice("anonymous-user-1", DevicePlatform.ANDROID, "android-token-1");
+		registerDevice("anonymous-user-1", DevicePlatform.IOS, "ios-token-1");
+
+		var result = dispatchService.dispatch(new DispatchPushNotificationCommand(
+			"anonymous-user-1",
+			PushNotificationType.FAVORITE_STATION_FACILITY,
+			"엘리베이터 운행 변경",
+			"상록수역 엘리베이터 상태를 확인하세요."
+		));
+
+		assertThat(result.requestedUserId()).isEqualTo("anonymous-user-1");
+		assertThat(result.type()).isEqualTo(PushNotificationType.FAVORITE_STATION_FACILITY);
+		assertThat(result.createdCount()).isEqualTo(2);
+		assertThat(result.notifications())
+			.extracting("platform")
+			.containsExactly(DevicePlatform.ANDROID, DevicePlatform.IOS);
+		assertThat(outboxRepository.loadPushNotifications("anonymous-user-1"))
+			.extracting("status")
+			.containsExactly(PushNotificationStatus.PENDING, PushNotificationStatus.PENDING);
+	}
+
+	@Test
+	@DisplayName("사용자가 꺼둔 알림 종류는 발송 후보를 만들지 않는다")
+	void dispatchSkipsDisabledNotificationType() {
+		registerDevice("anonymous-user-2", DevicePlatform.ANDROID, "android-token-2");
+		preferenceService.saveNotificationSettings(new SaveNotificationSettingsCommand(
+			"anonymous-user-2",
+			false,
+			true,
+			true,
+			true
+		));
+
+		var result = dispatchService.dispatch(new DispatchPushNotificationCommand(
+			"anonymous-user-2",
+			PushNotificationType.FAVORITE_STATION_FACILITY,
+			"엘리베이터 운행 변경",
+			"상록수역 엘리베이터 상태를 확인하세요."
+		));
+
+		assertThat(result.createdCount()).isZero();
+		assertThat(result.notifications()).isEmpty();
+		assertThat(outboxRepository.loadPushNotifications("anonymous-user-2")).isEmpty();
+	}
+
+	@Test
+	@DisplayName("등록된 기기가 없으면 빈 발송 결과를 반환한다")
+	void dispatchReturnsEmptyResultWhenUserHasNoDevice() {
+		var result = dispatchService.dispatch(new DispatchPushNotificationCommand(
+			"anonymous-user-3",
+			PushNotificationType.REPORT_STATUS,
+			"신고 처리 알림",
+			"제보한 내용이 확인되었습니다."
+		));
+
+		assertThat(result.createdCount()).isZero();
+		assertThat(result.notifications()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("발송 명령은 사용자, 알림 종류, 제목, 본문을 요구한다")
+	void dispatchCommandRequiresUserTypeTitleAndBody() {
+		assertThatThrownBy(() -> new DispatchPushNotificationCommand(
+			"",
+			PushNotificationType.DATA_QUALITY,
+			"정보 갱신",
+			"역 정보가 갱신되었습니다."
+		))
+			.isInstanceOf(InvalidPushNotificationException.class)
+			.hasMessage("사용자 식별자가 필요합니다.");
+
+		assertThatThrownBy(() -> new DispatchPushNotificationCommand(
+			"anonymous-user-1",
+			null,
+			"정보 갱신",
+			"역 정보가 갱신되었습니다."
+		))
+			.isInstanceOf(InvalidPushNotificationException.class)
+			.hasMessage("알림 종류를 선택해야 합니다.");
+
+		assertThatThrownBy(() -> new DispatchPushNotificationCommand(
+			"anonymous-user-1",
+			PushNotificationType.DATA_QUALITY,
+			"",
+			"역 정보가 갱신되었습니다."
+		))
+			.isInstanceOf(InvalidPushNotificationException.class)
+			.hasMessage("알림 제목이 필요합니다.");
+
+		assertThatThrownBy(() -> new DispatchPushNotificationCommand(
+			"anonymous-user-1",
+			PushNotificationType.DATA_QUALITY,
+			"정보 갱신",
+			""
+		))
+			.isInstanceOf(InvalidPushNotificationException.class)
+			.hasMessage("알림 본문이 필요합니다.");
+	}
+
+	private void registerDevice(String userId, DevicePlatform platform, String deviceToken) {
+		preferenceService.registerDevice(new RegisterDeviceCommand(userId, platform, deviceToken));
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -567,6 +567,46 @@ test("백엔드 알림 설정은 인증 사용자 기준 헥사고날 API 경계
   assert.match(security, /securityMatcher\([\s\S]*"\/api\/v1\/me\/favorites\/\*\*"[\s\S]*"\/api\/v1\/devices"[\s\S]*"\/api\/v1\/me\/notification-settings"[\s\S]*\)/);
 });
 
+test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 따른다", () => {
+  const notification = read("backend/src/main/java/com/easysubway/notification/domain/PushNotification.java");
+  const result = read("backend/src/main/java/com/easysubway/notification/domain/PushNotificationDispatchResult.java");
+  const type = read("backend/src/main/java/com/easysubway/notification/domain/PushNotificationType.java");
+  const status = read("backend/src/main/java/com/easysubway/notification/domain/PushNotificationStatus.java");
+  const invalidPush = read("backend/src/main/java/com/easysubway/notification/domain/InvalidPushNotificationException.java");
+  const useCase = read("backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationDispatchUseCase.java");
+  const command = read("backend/src/main/java/com/easysubway/notification/application/port/in/DispatchPushNotificationCommand.java");
+  const loadOutboxPort = read("backend/src/main/java/com/easysubway/notification/application/port/out/LoadPushNotificationOutboxPort.java");
+  const saveOutboxPort = read("backend/src/main/java/com/easysubway/notification/application/port/out/SavePushNotificationOutboxPort.java");
+  const service = read("backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDispatchService.java");
+  const repository = read("backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java");
+  const controller = read("backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationController.java");
+  const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
+
+  assert.match(notification, /record PushNotification/);
+  assert.match(notification, /deviceToken/);
+  assert.match(notification, /PushNotificationStatus/);
+  assert.match(result, /record PushNotificationDispatchResult/);
+  assert.match(type, /FAVORITE_STATION_FACILITY/);
+  assert.match(type, /FAVORITE_ROUTE_FACILITY/);
+  assert.match(type, /REPORT_STATUS/);
+  assert.match(type, /DATA_QUALITY/);
+  assert.match(status, /PENDING/);
+  assert.match(invalidPush, /extends InvalidRequestException/);
+  assert.match(useCase, /interface PushNotificationDispatchUseCase/);
+  assert.match(useCase, /dispatch/);
+  assert.match(command, /record DispatchPushNotificationCommand/);
+  assert.match(loadOutboxPort, /interface LoadPushNotificationOutboxPort/);
+  assert.match(saveOutboxPort, /interface SavePushNotificationOutboxPort/);
+  assert.match(service, /implements PushNotificationDispatchUseCase/);
+  assert.match(service, /LoadNotificationPreferencePort/);
+  assert.match(service, /SavePushNotificationOutboxPort/);
+  assert.match(repository, /implements[\s\S]*LoadPushNotificationOutboxPort[\s\S]*SavePushNotificationOutboxPort/);
+  assert.match(controller, /@PostMapping\("\/admin\/notifications\/push"\)/);
+  assert.match(controller, /PushNotificationDispatchUseCase/);
+  assert.doesNotMatch(controller, /deviceToken/);
+  assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
+});
+
 test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   const result = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java");
   const status = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchStatus.java");


### PR DESCRIPTION
## 관련 이슈

Closes #60

## 요약

- 관리자 보호 API에서 푸시 알림 발송 후보를 생성할 수 있게 했습니다.
- 사용자 알림 설정과 등록 기기를 기준으로 기기별 outbox 레코드를 만듭니다.
- 관리자 응답에는 기기 토큰을 노출하지 않습니다.

## 변경 사항

- 푸시 알림 유형, 상태, outbox 레코드 도메인 추가
- 발송 요청 use case와 outbox 저장 포트 추가
- 인메모리 outbox 어댑터와 관리자 API 추가
- 알림 설정 비활성, 기기 없음, 토큰 비노출 테스트 추가
- 저장소 계약 테스트에 알림 outbox 경계 추가

## 검증

- [x] `./gradlew test --tests "com.easysubway.notification.*"`
- [x] `./gradlew test`
- [x] `node --test tools/ci/*.test.mjs`
- [x] `git diff --check`
- [x] `git ls-files '*.md'`
- [x] GitHub PR CI 통과
- [x] CodeRabbit 리뷰 확인 또는 Codex CLI code review 대체 확인
- [x] Codex Security diff scan 확인
- [x] merge 후 main CI와 후속 workflow 확인

## 리스크

- 실제 FCM/APNs 전송은 포함하지 않았습니다.
- 이번 변경은 관리자 API와 서버 내부 outbox 기반이며, 모바일 화면 동작은 바뀌지 않습니다.
