### PR TITLE
[Feat] 관리자 신고 상세 조회 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
@@ -51,6 +51,11 @@ class FacilityReportController {
 		return ApiResponse.ok(reports);
 	}
 
+	@GetMapping("/admin/reports/{reportId}")
+	ApiResponse<FacilityReportResponse> adminReport(@PathVariable String reportId) {
+		return ApiResponse.ok(FacilityReportResponse.from(facilityReportUseCase.getReport(reportId)));
+	}
+
 	@PostMapping("/admin/reports/{reportId}/review")
 	ApiResponse<FacilityReportResponse> reviewReport(
 		@PathVariable String reportId,

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -290,6 +290,65 @@ class FacilityReportControllerTest {
 			.andExpect(jsonPath("$.message").value("요청 값을 확인해야 합니다."));
 	}
 
+	@Test
+	@DisplayName("관리자는 신고 상세에서 사진과 위치 정보를 확인한다")
+	void adminReadsReportDetailWithPhotoAndLocation() throws Exception {
+		String response = mockMvc.perform(post("/api/v1/reports")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-admin-detail",
+					  "stationId": "station-sangnoksu",
+					  "facilityId": "facility-sangnoksu-elevator-1",
+					  "reportType": "BROKEN",
+					  "description": "엘리베이터 앞 안내문이 떨어져 있습니다.",
+					  "photoUrl": "https://cdn.example.test/reports/elevator-notice.jpg",
+					  "latitude": 37.302421,
+					  "longitude": 126.866221
+					}
+					"""))
+			.andExpect(status().isCreated())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		String reportId = JsonPath.read(response, "$.data.id");
+
+		mockMvc.perform(get("/admin/reports/{reportId}", reportId)
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.id").value(reportId))
+			.andExpect(jsonPath("$.data.userId").value("anonymous-user-admin-detail"))
+			.andExpect(jsonPath("$.data.description").value("엘리베이터 앞 안내문이 떨어져 있습니다."))
+			.andExpect(jsonPath("$.data.photoUrl").value("https://cdn.example.test/reports/elevator-notice.jpg"))
+			.andExpect(jsonPath("$.data.latitude").value(37.302421))
+			.andExpect(jsonPath("$.data.longitude").value(126.866221))
+			.andExpect(jsonPath("$.data.status").value("SUBMITTED"));
+	}
+
+	@Test
+	@DisplayName("관리자 신고 상세는 관리자만 사용할 수 있다")
+	void adminReportDetailRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/reports/report-1"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/reports/report-1")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 관리자 신고 상세는 공통 404 응답을 반환한다")
+	void adminReportDetailReturnsCommonErrorForMissingReport() throws Exception {
+		mockMvc.perform(get("/admin/reports/missing-report")
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("신고 정보를 찾을 수 없습니다."));
+	}
+
 	private String createReport(String userId, String description) throws Exception {
 		String response = mockMvc.perform(post("/api/v1/reports")
 				.contentType(MediaType.APPLICATION_JSON)

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -340,6 +340,7 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(controller, /@PostMapping\("\/api\/v1\/reports"\)/);
   assert.match(controller, /@GetMapping\("\/api\/v1\/reports\/\{reportId\}"\)/);
   assert.match(controller, /@GetMapping\("\/admin\/reports"\)/);
+  assert.match(controller, /@GetMapping\("\/admin\/reports\/\{reportId\}"\)/);
   assert.match(controller, /@RequestParam\(required = false\) FacilityReportStatus status/);
   assert.match(controller, /@PostMapping\("\/admin\/reports\/\{reportId\}\/review"\)/);
   assert.match(controller, /Principal principal/);


### PR DESCRIPTION
## 관련 이슈
close #68

## 요약
관리자가 신고 목록에서 항목을 선택했을 때 상세 내용을 확인할 수 있도록 `GET /admin/reports/{reportId}` API를 추가했습니다. 사진 URL, 위치, 설명, 상태, 검수 정보는 기존 신고 응답 모델로 그대로 내려줍니다.

## 변경 사항
- 관리자 신고 상세 조회 API 추가
- 관리자 상세 조회 인증/인가 테스트 추가
- 존재하지 않는 신고 상세 조회의 공통 404 응답 테스트 추가
- 저장소 계약 테스트에 관리자 상세 조회 경로 추가

## 검증
- `./gradlew test --tests "com.easysubway.report.adapter.in.web.FacilityReportControllerTest"`
- `node --test tools/ci/*.test.mjs`
- `./gradlew test`
- `git diff --check`
- `git ls-files '*.md'`
- `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md docs/agent/2026-06-14-admin-report-detail.md .codex/issue-admin-report-detail.local.md`

## 리스크
- 현재 사진은 업로드 파일이 아니라 `photoUrl` 문자열만 응답합니다. 파일 저장소 연동과 서명 URL 정책은 사진 업로드 작업에서 별도로 다뤄야 합니다.

## 체크리스트
- [x] 관리자 API는 `/admin/**` 보안 체인 아래에 있다.
- [x] 일반 사용자와 무인증 사용자는 상세 API에 접근할 수 없다.
- [x] README 외 Markdown 문서는 tracked 대상에 추가하지 않았다.
