### PR TITLE
[Feat] 신고 검수 승인 시설 상태 반영

### DIFF
--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -10,14 +10,19 @@ import com.easysubway.report.domain.FacilityReportNotFoundException;
 import com.easysubway.report.domain.FacilityReportReviewDecision;
 import com.easysubway.report.domain.FacilityReportStatus;
 import com.easysubway.report.domain.FacilityReportTargetNotFoundException;
+import com.easysubway.report.domain.FacilityReportType;
 import com.easysubway.report.domain.InvalidFacilityReportException;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.application.port.out.SaveAccessibilityFacilityStatusPort;
+import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationNotFoundException;
 import java.time.Clock;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -26,6 +31,7 @@ import org.springframework.stereotype.Service;
 public class FacilityReportService implements FacilityReportUseCase {
 
 	private final LoadTransitMasterPort loadTransitMasterPort;
+	private final SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort;
 	private final LoadFacilityReportPort loadFacilityReportPort;
 	private final SaveFacilityReportPort saveFacilityReportPort;
 	private final Clock clock;
@@ -33,19 +39,28 @@ public class FacilityReportService implements FacilityReportUseCase {
 	@Autowired
 	public FacilityReportService(
 		LoadTransitMasterPort loadTransitMasterPort,
+		SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort,
 		LoadFacilityReportPort loadFacilityReportPort,
 		SaveFacilityReportPort saveFacilityReportPort
 	) {
-		this(loadTransitMasterPort, loadFacilityReportPort, saveFacilityReportPort, Clock.systemDefaultZone());
+		this(
+			loadTransitMasterPort,
+			saveAccessibilityFacilityStatusPort,
+			loadFacilityReportPort,
+			saveFacilityReportPort,
+			Clock.systemDefaultZone()
+		);
 	}
 
 	public FacilityReportService(
 		LoadTransitMasterPort loadTransitMasterPort,
+		SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort,
 		LoadFacilityReportPort loadFacilityReportPort,
 		SaveFacilityReportPort saveFacilityReportPort,
 		Clock clock
 	) {
 		this.loadTransitMasterPort = loadTransitMasterPort;
+		this.saveAccessibilityFacilityStatusPort = saveAccessibilityFacilityStatusPort;
 		this.loadFacilityReportPort = loadFacilityReportPort;
 		this.saveFacilityReportPort = saveFacilityReportPort;
 		this.clock = clock;
@@ -114,7 +129,10 @@ public class FacilityReportService implements FacilityReportUseCase {
 			command.reviewedBy()
 		);
 
-		return saveFacilityReportPort.saveReport(reviewed);
+		FacilityReport saved = saveFacilityReportPort.saveReport(reviewed);
+		// 승인된 상태 신고만 실제 시설 운영 상태에 반영한다.
+		applyAcceptedReportToFacilityStatus(report, command.decision());
+		return saved;
 	}
 
 	private void requireReportType(CreateFacilityReportCommand command) {
@@ -160,6 +178,28 @@ public class FacilityReportService implements FacilityReportUseCase {
 			case ACCEPT -> FacilityReportStatus.ACCEPTED;
 			case REJECT -> FacilityReportStatus.REJECTED;
 			case MARK_DUPLICATE -> FacilityReportStatus.DUPLICATE;
+		};
+	}
+
+	private void applyAcceptedReportToFacilityStatus(FacilityReport report, FacilityReportReviewDecision decision) {
+		if (decision != FacilityReportReviewDecision.ACCEPT) {
+			return;
+		}
+
+		toFacilityStatus(report.reportType()).ifPresent(status -> saveAccessibilityFacilityStatusPort.saveFacilityStatus(
+			report.facilityId(),
+			status,
+			LocalDate.now(clock)
+		));
+	}
+
+	private Optional<AccessibilityFacilityStatus> toFacilityStatus(FacilityReportType reportType) {
+		return switch (reportType) {
+			case BROKEN -> Optional.of(AccessibilityFacilityStatus.BROKEN);
+			case UNDER_CONSTRUCTION -> Optional.of(AccessibilityFacilityStatus.UNDER_CONSTRUCTION);
+			case CLOSED -> Optional.of(AccessibilityFacilityStatus.CLOSED);
+			case RECOVERED -> Optional.of(AccessibilityFacilityStatus.NORMAL);
+			case LOCATION_WRONG, INFORMATION_WRONG -> Optional.empty();
 		};
 	}
 }

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -1,6 +1,7 @@
 package com.easysubway.transit.adapter.out.persistence;
 
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.application.port.out.SaveAccessibilityFacilityStatusPort;
 import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.AccessibilityFacilityType;
@@ -14,11 +15,13 @@ import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class InMemoryTransitMasterRepository implements LoadTransitMasterPort {
+public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, SaveAccessibilityFacilityStatusPort {
 
 	private static final List<TransitOperator> OPERATORS = List.of(
 		new TransitOperator(
@@ -101,53 +104,11 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort {
 		)
 	);
 
-	private static final List<AccessibilityFacility> ACCESSIBILITY_FACILITIES = List.of(
-		new AccessibilityFacility(
-			"facility-sangnoksu-elevator-1",
-			"station-sangnoksu",
-			"exit-sangnoksu-1",
-			AccessibilityFacilityType.ELEVATOR,
-			"1번 출구 엘리베이터",
-			"지상",
-			"대합실",
-			new BigDecimal("37.302421"),
-			new BigDecimal("126.866221"),
-			"1번 출구와 대합실을 연결합니다.",
-			AccessibilityFacilityStatus.NORMAL,
-			DataConfidenceLevel.HIGH,
-			LocalDate.of(2026, 6, 12)
-		),
-		new AccessibilityFacility(
-			"facility-sangnoksu-escalator-1",
-			"station-sangnoksu",
-			"exit-sangnoksu-1",
-			AccessibilityFacilityType.ESCALATOR,
-			"1번 출구 에스컬레이터",
-			"지상",
-			"대합실",
-			new BigDecimal("37.302444"),
-			new BigDecimal("126.866250"),
-			"1번 출구 방향 상행 에스컬레이터입니다.",
-			AccessibilityFacilityStatus.NORMAL,
-			DataConfidenceLevel.MEDIUM,
-			LocalDate.of(2026, 6, 12)
-		),
-		new AccessibilityFacility(
-			"facility-sangnoksu-accessible-toilet",
-			"station-sangnoksu",
-			null,
-			AccessibilityFacilityType.ACCESSIBLE_TOILET,
-			"장애인 화장실",
-			"대합실",
-			"대합실",
-			new BigDecimal("37.302820"),
-			new BigDecimal("126.866401"),
-			"개찰구 안쪽 대합실에 있습니다.",
-			AccessibilityFacilityStatus.UNKNOWN,
-			DataConfidenceLevel.NEEDS_VERIFICATION,
-			LocalDate.of(2026, 6, 12)
-		)
-	);
+	private final Map<String, AccessibilityFacility> accessibilityFacilities = new LinkedHashMap<>();
+
+	public InMemoryTransitMasterRepository() {
+		seedAccessibilityFacilities();
+	}
 
 	@Override
 	public List<TransitOperator> loadOperators() {
@@ -176,6 +137,83 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort {
 
 	@Override
 	public List<AccessibilityFacility> loadAccessibilityFacilities() {
-		return ACCESSIBILITY_FACILITIES;
+		return List.copyOf(accessibilityFacilities.values());
+	}
+
+	@Override
+	public void saveFacilityStatus(String facilityId, AccessibilityFacilityStatus status, LocalDate updatedAt) {
+		AccessibilityFacility facility = accessibilityFacilities.get(facilityId);
+		if (facility == null) {
+			// 신고 생성 단계에서 시설 존재 여부를 검증하므로 저장 어댑터는 알 수 없는 식별자를 무시한다.
+			return;
+		}
+
+		accessibilityFacilities.put(facilityId, new AccessibilityFacility(
+			facility.id(),
+			facility.stationId(),
+			facility.exitId(),
+			facility.type(),
+			facility.name(),
+			facility.floorFrom(),
+			facility.floorTo(),
+			facility.latitude(),
+			facility.longitude(),
+			facility.description(),
+			status,
+			facility.dataConfidence(),
+			updatedAt
+		));
+	}
+
+	private void seedAccessibilityFacilities() {
+		saveSeedFacility(new AccessibilityFacility(
+			"facility-sangnoksu-elevator-1",
+			"station-sangnoksu",
+			"exit-sangnoksu-1",
+			AccessibilityFacilityType.ELEVATOR,
+			"1번 출구 엘리베이터",
+			"지상",
+			"대합실",
+			new BigDecimal("37.302421"),
+			new BigDecimal("126.866221"),
+			"1번 출구와 대합실을 연결합니다.",
+			AccessibilityFacilityStatus.NORMAL,
+			DataConfidenceLevel.HIGH,
+			LocalDate.of(2026, 6, 12)
+		));
+		saveSeedFacility(new AccessibilityFacility(
+			"facility-sangnoksu-escalator-1",
+			"station-sangnoksu",
+			"exit-sangnoksu-1",
+			AccessibilityFacilityType.ESCALATOR,
+			"1번 출구 에스컬레이터",
+			"지상",
+			"대합실",
+			new BigDecimal("37.302444"),
+			new BigDecimal("126.866250"),
+			"1번 출구 방향 상행 에스컬레이터입니다.",
+			AccessibilityFacilityStatus.NORMAL,
+			DataConfidenceLevel.MEDIUM,
+			LocalDate.of(2026, 6, 12)
+		));
+		saveSeedFacility(new AccessibilityFacility(
+			"facility-sangnoksu-accessible-toilet",
+			"station-sangnoksu",
+			null,
+			AccessibilityFacilityType.ACCESSIBLE_TOILET,
+			"장애인 화장실",
+			"대합실",
+			"대합실",
+			new BigDecimal("37.302820"),
+			new BigDecimal("126.866401"),
+			"개찰구 안쪽 대합실에 있습니다.",
+			AccessibilityFacilityStatus.UNKNOWN,
+			DataConfidenceLevel.NEEDS_VERIFICATION,
+			LocalDate.of(2026, 6, 12)
+		));
+	}
+
+	private void saveSeedFacility(AccessibilityFacility facility) {
+		accessibilityFacilities.put(facility.id(), facility);
 	}
 }

--- a/backend/src/main/java/com/easysubway/transit/application/port/out/SaveAccessibilityFacilityStatusPort.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/out/SaveAccessibilityFacilityStatusPort.java
@@ -1,0 +1,9 @@
+package com.easysubway.transit.application.port.out;
+
+import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import java.time.LocalDate;
+
+public interface SaveAccessibilityFacilityStatusPort {
+
+	void saveFacilityStatus(String facilityId, AccessibilityFacilityStatus status, LocalDate updatedAt);
+}

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -175,6 +175,11 @@ class FacilityReportControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.status").value("ACCEPTED"))
 			.andExpect(jsonPath("$.data.reviewedBy").value("admin-test"));
+
+		mockMvc.perform(get("/api/v1/stations/station-sangnoksu/facilities"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data[0].id").value("facility-sangnoksu-elevator-1"))
+			.andExpect(jsonPath("$.data[0].status").value("BROKEN"));
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -13,6 +13,7 @@ import com.easysubway.report.domain.FacilityReportTargetNotFoundException;
 import com.easysubway.report.domain.FacilityReportType;
 import com.easysubway.report.domain.InvalidFacilityReportException;
 import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
+import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.StationNotFoundException;
 import java.math.BigDecimal;
 import java.time.Clock;
@@ -26,8 +27,10 @@ import org.junit.jupiter.api.Test;
 class FacilityReportServiceTest {
 
 	private final InMemoryFacilityReportRepository reportRepository = new InMemoryFacilityReportRepository();
+	private final InMemoryTransitMasterRepository transitRepository = new InMemoryTransitMasterRepository();
 	private final FacilityReportService service = new FacilityReportService(
-		new InMemoryTransitMasterRepository(),
+		transitRepository,
+		transitRepository,
 		reportRepository,
 		reportRepository,
 		Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
@@ -179,6 +182,74 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
+	@DisplayName("승인된 시설 신고는 신고 유형에 맞춰 시설 상태를 바꾼다")
+	void acceptedReportUpdatesFacilityStatusByReportType() {
+		var transitRepository = new InMemoryTransitMasterRepository();
+		var serviceWithFacilityStatus = serviceWithTransitRepository(transitRepository);
+
+		var broken = serviceWithFacilityStatus.createReport(reportCommand(
+			"anonymous-user-broken",
+			FacilityReportType.BROKEN,
+			"엘리베이터가 멈춰 있습니다."
+		));
+		serviceWithFacilityStatus.reviewReport(reviewCommand(broken.id(), FacilityReportReviewDecision.ACCEPT));
+		assertThat(facilityStatus(transitRepository, "facility-sangnoksu-elevator-1"))
+			.isEqualTo(AccessibilityFacilityStatus.BROKEN);
+
+		var underConstruction = serviceWithFacilityStatus.createReport(reportCommand(
+			"anonymous-user-construction",
+			FacilityReportType.UNDER_CONSTRUCTION,
+			"시설 앞 공사가 진행 중입니다."
+		));
+		serviceWithFacilityStatus.reviewReport(reviewCommand(underConstruction.id(), FacilityReportReviewDecision.ACCEPT));
+		assertThat(facilityStatus(transitRepository, "facility-sangnoksu-elevator-1"))
+			.isEqualTo(AccessibilityFacilityStatus.UNDER_CONSTRUCTION);
+
+		var closed = serviceWithFacilityStatus.createReport(reportCommand(
+			"anonymous-user-closed",
+			FacilityReportType.CLOSED,
+			"출입이 막혀 있습니다."
+		));
+		serviceWithFacilityStatus.reviewReport(reviewCommand(closed.id(), FacilityReportReviewDecision.ACCEPT));
+		assertThat(facilityStatus(transitRepository, "facility-sangnoksu-elevator-1"))
+			.isEqualTo(AccessibilityFacilityStatus.CLOSED);
+
+		var recovered = serviceWithFacilityStatus.createReport(reportCommand(
+			"anonymous-user-recovered",
+			FacilityReportType.RECOVERED,
+			"다시 정상 이용 가능합니다."
+		));
+		serviceWithFacilityStatus.reviewReport(reviewCommand(recovered.id(), FacilityReportReviewDecision.ACCEPT));
+		assertThat(facilityStatus(transitRepository, "facility-sangnoksu-elevator-1"))
+			.isEqualTo(AccessibilityFacilityStatus.NORMAL);
+	}
+
+	@Test
+	@DisplayName("반려와 중복 처리된 시설 신고는 시설 상태를 바꾸지 않는다")
+	void rejectedOrDuplicateReportDoesNotUpdateFacilityStatus() {
+		var transitRepository = new InMemoryTransitMasterRepository();
+		var serviceWithFacilityStatus = serviceWithTransitRepository(transitRepository);
+
+		var rejected = serviceWithFacilityStatus.createReport(reportCommand(
+			"anonymous-user-rejected-status",
+			FacilityReportType.BROKEN,
+			"반려할 고장 신고입니다."
+		));
+		serviceWithFacilityStatus.reviewReport(reviewCommand(rejected.id(), FacilityReportReviewDecision.REJECT));
+		assertThat(facilityStatus(transitRepository, "facility-sangnoksu-elevator-1"))
+			.isEqualTo(AccessibilityFacilityStatus.NORMAL);
+
+		var duplicated = serviceWithFacilityStatus.createReport(reportCommand(
+			"anonymous-user-duplicate-status",
+			FacilityReportType.CLOSED,
+			"중복 처리할 폐쇄 신고입니다."
+		));
+		serviceWithFacilityStatus.reviewReport(reviewCommand(duplicated.id(), FacilityReportReviewDecision.MARK_DUPLICATE));
+		assertThat(facilityStatus(transitRepository, "facility-sangnoksu-elevator-1"))
+			.isEqualTo(AccessibilityFacilityStatus.NORMAL);
+	}
+
+	@Test
 	@DisplayName("신고 검수는 반려와 중복 처리 상태를 저장한다")
 	void reviewReportCanRejectOrMarkDuplicate() {
 		var rejected = service.createReport(new CreateFacilityReportCommand(
@@ -257,11 +328,19 @@ class FacilityReportServiceTest {
 	}
 
 	private CreateFacilityReportCommand reportCommand(String userId, String description) {
+		return reportCommand(userId, FacilityReportType.BROKEN, description);
+	}
+
+	private CreateFacilityReportCommand reportCommand(
+		String userId,
+		FacilityReportType reportType,
+		String description
+	) {
 		return new CreateFacilityReportCommand(
 			userId,
 			"station-sangnoksu",
 			"facility-sangnoksu-elevator-1",
-			FacilityReportType.BROKEN,
+			reportType,
 			description,
 			null,
 			null,
@@ -270,13 +349,44 @@ class FacilityReportServiceTest {
 	}
 
 	private FacilityReportService serviceWithClock(Clock clock) {
+		return serviceWithClockAndTransitRepository(clock, new InMemoryTransitMasterRepository());
+	}
+
+	private FacilityReportService serviceWithTransitRepository(InMemoryTransitMasterRepository transitRepository) {
+		return serviceWithClockAndTransitRepository(
+			Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul")),
+			transitRepository
+		);
+	}
+
+	private FacilityReportService serviceWithClockAndTransitRepository(
+		Clock clock,
+		InMemoryTransitMasterRepository transitRepository
+	) {
 		var repository = new InMemoryFacilityReportRepository();
 		return new FacilityReportService(
-			new InMemoryTransitMasterRepository(),
+			transitRepository,
+			transitRepository,
 			repository,
 			repository,
 			clock
 		);
+	}
+
+	private ReviewFacilityReportCommand reviewCommand(String reportId, FacilityReportReviewDecision decision) {
+		return new ReviewFacilityReportCommand(reportId, decision, "admin-1");
+	}
+
+	private AccessibilityFacilityStatus facilityStatus(
+		InMemoryTransitMasterRepository transitRepository,
+		String facilityId
+	) {
+		return transitRepository.loadAccessibilityFacilities()
+			.stream()
+			.filter(facility -> facility.id().equals(facilityId))
+			.findFirst()
+			.orElseThrow()
+			.status();
 	}
 
 	private static class TickingClock extends Clock {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -302,8 +302,14 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   const reviewCommand = read("backend/src/main/java/com/easysubway/report/application/port/in/ReviewFacilityReportCommand.java");
   const loadPort = read("backend/src/main/java/com/easysubway/report/application/port/out/LoadFacilityReportPort.java");
   const savePort = read("backend/src/main/java/com/easysubway/report/application/port/out/SaveFacilityReportPort.java");
+  const saveFacilityStatusPort = read(
+    "backend/src/main/java/com/easysubway/transit/application/port/out/SaveAccessibilityFacilityStatusPort.java",
+  );
   const service = read("backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java");
   const repository = read("backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java");
+  const transitRepository = read(
+    "backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java",
+  );
   const controller = read("backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java");
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
 
@@ -327,8 +333,14 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(loadPort, /interface LoadFacilityReportPort/);
   assert.match(loadPort, /loadReports/);
   assert.match(savePort, /interface SaveFacilityReportPort/);
+  assert.match(saveFacilityStatusPort, /interface SaveAccessibilityFacilityStatusPort/);
+  assert.match(saveFacilityStatusPort, /saveFacilityStatus/);
   assert.match(service, /implements FacilityReportUseCase/);
   assert.match(service, /LoadTransitMasterPort/);
+  assert.match(service, /SaveAccessibilityFacilityStatusPort/);
+  assert.match(service, /applyAcceptedReportToFacilityStatus/);
+  assert.match(service, /case BROKEN -> Optional\.of\(AccessibilityFacilityStatus\.BROKEN\)/);
+  assert.match(service, /case RECOVERED -> Optional\.of\(AccessibilityFacilityStatus\.NORMAL\)/);
   assert.match(service, /listReports\(FacilityReportStatus status\)/);
   assert.match(service, /Comparator\.comparing\(FacilityReport::createdAt\)\.reversed\(\)/);
   assert.match(service, /FacilityReportStatus\.SUBMITTED/);
@@ -337,6 +349,8 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(service, /FacilityReportStatus\.DUPLICATE/);
   assert.match(repository, /implements LoadFacilityReportPort, SaveFacilityReportPort/);
   assert.match(repository, /List<FacilityReport> loadReports\(\)/);
+  assert.match(transitRepository, /implements LoadTransitMasterPort, SaveAccessibilityFacilityStatusPort/);
+  assert.match(transitRepository, /saveFacilityStatus\(String facilityId, AccessibilityFacilityStatus status, LocalDate updatedAt\)/);
   assert.match(controller, /@PostMapping\("\/api\/v1\/reports"\)/);
   assert.match(controller, /@GetMapping\("\/api\/v1\/reports\/\{reportId\}"\)/);
   assert.match(controller, /@GetMapping\("\/admin\/reports"\)/);


### PR DESCRIPTION
## 관련 이슈
- Closes #70

## 요약
- 관리자 검수에서 시설 신고를 승인하면 신고 유형에 맞춰 시설 운영 상태가 갱신되도록 연결했습니다.
- 시설 상태 저장을 transit outbound port로 분리해 신고 서비스가 저장 구현에 직접 의존하지 않도록 유지했습니다.
- 승인, 반려, 중복 처리별 상태 반영 범위를 서비스 테스트와 웹 계층 테스트로 고정했습니다.

## 변경 사항
- `BROKEN`, `UNDER_CONSTRUCTION`, `CLOSED`, `RECOVERED` 신고 승인 시 시설 상태를 각각 고장, 공사중, 폐쇄, 정상으로 반영합니다.
- `LOCATION_WRONG`, `INFORMATION_WRONG` 신고 승인은 시설 운영 상태를 변경하지 않습니다.
- 반려와 중복 처리된 신고는 시설 상태를 변경하지 않습니다.
- 인메모리 도시철도 저장소에 시설 상태 저장 포트를 추가했습니다.

## 검증
- `./gradlew test --tests "com.easysubway.report.application.service.FacilityReportServiceTest"`
- `./gradlew test --tests "com.easysubway.report.adapter.in.web.FacilityReportControllerTest"`
- `./gradlew test`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`
- `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md docs/agent/2026-06-14-report-review-updates-facility-status.md .codex/issue-report-review-updates-facility-status.local.md`

## 리스크
- 현재 저장소가 인메모리라 승인 신고와 시설 상태 반영은 같은 프로세스 내에서만 유지됩니다. 영속 저장소 도입 시 신고 검수 저장과 시설 상태 갱신을 하나의 트랜잭션으로 묶어야 합니다.

## 체크리스트
- [x] 승인 신고만 시설 운영 상태에 반영했습니다.
- [x] 반려와 중복 처리 신고가 시설 상태를 바꾸지 않도록 검증했습니다.
- [x] 헥사고날 outbound port 경계를 유지했습니다.
- [x] README 외 Markdown 문서가 git에 추적되지 않는지 확인했습니다.
