### PR TITLE
[Feat] 신고 처리 결과 알림 발송

### DIFF
--- a/backend/src/main/java/com/easysubway/notification/application/port/in/ReportStatusAlertUseCase.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/ReportStatusAlertUseCase.java
@@ -1,0 +1,6 @@
+package com.easysubway.notification.application.port.in;
+
+public interface ReportStatusAlertUseCase {
+
+	void alertReportStatusChanged(ReportStatusChangedAlertCommand command);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/ReportStatusChangedAlertCommand.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/ReportStatusChangedAlertCommand.java
@@ -1,0 +1,25 @@
+package com.easysubway.notification.application.port.in;
+
+import com.easysubway.notification.domain.InvalidPushNotificationException;
+import com.easysubway.report.domain.FacilityReportStatus;
+
+public record ReportStatusChangedAlertCommand(
+	String userId,
+	String reportId,
+	FacilityReportStatus status
+) {
+
+	public ReportStatusChangedAlertCommand {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidPushNotificationException("사용자 식별자가 필요합니다.");
+		}
+		if (reportId == null || reportId.isBlank()) {
+			throw new InvalidPushNotificationException("신고 식별자가 필요합니다.");
+		}
+		if (status == null) {
+			throw new InvalidPushNotificationException("신고 상태를 선택해야 합니다.");
+		}
+		userId = userId.trim();
+		reportId = reportId.trim();
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/application/service/ReportStatusAlertService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/ReportStatusAlertService.java
@@ -1,0 +1,40 @@
+package com.easysubway.notification.application.service;
+
+import com.easysubway.notification.application.port.in.DispatchPushNotificationCommand;
+import com.easysubway.notification.application.port.in.PushNotificationDispatchUseCase;
+import com.easysubway.notification.application.port.in.ReportStatusAlertUseCase;
+import com.easysubway.notification.application.port.in.ReportStatusChangedAlertCommand;
+import com.easysubway.notification.domain.PushNotificationType;
+import com.easysubway.report.domain.FacilityReportStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReportStatusAlertService implements ReportStatusAlertUseCase {
+
+	private final PushNotificationDispatchUseCase pushNotificationDispatchUseCase;
+
+	public ReportStatusAlertService(PushNotificationDispatchUseCase pushNotificationDispatchUseCase) {
+		this.pushNotificationDispatchUseCase = pushNotificationDispatchUseCase;
+	}
+
+	@Override
+	public void alertReportStatusChanged(ReportStatusChangedAlertCommand command) {
+		pushNotificationDispatchUseCase.dispatch(new DispatchPushNotificationCommand(
+			command.userId(),
+			PushNotificationType.REPORT_STATUS,
+			"신고 처리 결과",
+			body(command.status())
+		));
+	}
+
+	private String body(FacilityReportStatus status) {
+		return switch (status) {
+			case ACCEPTED -> "제보해 주신 신고가 확인되어 시설 정보에 반영되었습니다.";
+			case REJECTED -> "제보해 주신 신고를 검토했지만 이번에는 반영되지 않았습니다.";
+			case DUPLICATE -> "제보해 주신 신고는 이미 접수된 내용과 같아 중복으로 정리되었습니다.";
+			case UNDER_REVIEW -> "제보해 주신 신고를 검토하고 있습니다.";
+			case RESOLVED -> "제보해 주신 신고 처리가 완료되었습니다.";
+			case SUBMITTED -> "제보해 주신 신고가 접수되어 검수를 기다리고 있습니다.";
+		};
+	}
+}

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -14,6 +14,8 @@ import com.easysubway.report.domain.FacilityReportType;
 import com.easysubway.report.domain.InvalidFacilityReportException;
 import com.easysubway.notification.application.port.in.FacilityStatusAlertUseCase;
 import com.easysubway.notification.application.port.in.FacilityStatusChangedAlertCommand;
+import com.easysubway.notification.application.port.in.ReportStatusAlertUseCase;
+import com.easysubway.notification.application.port.in.ReportStatusChangedAlertCommand;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.transit.application.port.out.SaveAccessibilityFacilityStatusPort;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
@@ -37,9 +39,29 @@ public class FacilityReportService implements FacilityReportUseCase {
 	private final LoadFacilityReportPort loadFacilityReportPort;
 	private final SaveFacilityReportPort saveFacilityReportPort;
 	private final FacilityStatusAlertUseCase facilityStatusAlertUseCase;
+	private final ReportStatusAlertUseCase reportStatusAlertUseCase;
 	private final Clock clock;
 
 	@Autowired
+	public FacilityReportService(
+		LoadTransitMasterPort loadTransitMasterPort,
+		SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort,
+		LoadFacilityReportPort loadFacilityReportPort,
+		SaveFacilityReportPort saveFacilityReportPort,
+		FacilityStatusAlertUseCase facilityStatusAlertUseCase,
+		ReportStatusAlertUseCase reportStatusAlertUseCase
+	) {
+		this(
+			loadTransitMasterPort,
+			saveAccessibilityFacilityStatusPort,
+			loadFacilityReportPort,
+			saveFacilityReportPort,
+			facilityStatusAlertUseCase,
+			reportStatusAlertUseCase,
+			Clock.systemDefaultZone()
+		);
+	}
+
 	public FacilityReportService(
 		LoadTransitMasterPort loadTransitMasterPort,
 		SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort,
@@ -53,6 +75,8 @@ public class FacilityReportService implements FacilityReportUseCase {
 			loadFacilityReportPort,
 			saveFacilityReportPort,
 			facilityStatusAlertUseCase,
+			command -> {
+			},
 			Clock.systemDefaultZone()
 		);
 	}
@@ -71,6 +95,8 @@ public class FacilityReportService implements FacilityReportUseCase {
 			saveFacilityReportPort,
 			command -> {
 			},
+			command -> {
+			},
 			clock
 		);
 	}
@@ -83,11 +109,33 @@ public class FacilityReportService implements FacilityReportUseCase {
 		FacilityStatusAlertUseCase facilityStatusAlertUseCase,
 		Clock clock
 	) {
+		this(
+			loadTransitMasterPort,
+			saveAccessibilityFacilityStatusPort,
+			loadFacilityReportPort,
+			saveFacilityReportPort,
+			facilityStatusAlertUseCase,
+			command -> {
+			},
+			clock
+		);
+	}
+
+	public FacilityReportService(
+		LoadTransitMasterPort loadTransitMasterPort,
+		SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort,
+		LoadFacilityReportPort loadFacilityReportPort,
+		SaveFacilityReportPort saveFacilityReportPort,
+		FacilityStatusAlertUseCase facilityStatusAlertUseCase,
+		ReportStatusAlertUseCase reportStatusAlertUseCase,
+		Clock clock
+	) {
 		this.loadTransitMasterPort = loadTransitMasterPort;
 		this.saveAccessibilityFacilityStatusPort = saveAccessibilityFacilityStatusPort;
 		this.loadFacilityReportPort = loadFacilityReportPort;
 		this.saveFacilityReportPort = saveFacilityReportPort;
 		this.facilityStatusAlertUseCase = facilityStatusAlertUseCase;
+		this.reportStatusAlertUseCase = reportStatusAlertUseCase;
 		this.clock = clock;
 	}
 
@@ -155,6 +203,12 @@ public class FacilityReportService implements FacilityReportUseCase {
 		);
 
 		FacilityReport saved = saveFacilityReportPort.saveReport(reviewed);
+		// 같은 결과로 재검수한 경우 사용자가 중복 처리 알림을 받지 않도록 상태 변경만 알린다.
+		if (report.status() != saved.status()) {
+			reportStatusAlertUseCase.alertReportStatusChanged(
+				new ReportStatusChangedAlertCommand(saved.userId(), saved.id(), saved.status())
+			);
+		}
 		// 승인된 상태 신고만 실제 시설 운영 상태에 반영한다.
 		applyAcceptedReportToFacilityStatus(report, command.decision());
 		return saved;

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -28,11 +28,15 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class FacilityReportService implements FacilityReportUseCase {
+
+	private static final Logger log = LoggerFactory.getLogger(FacilityReportService.class);
 
 	private final LoadTransitMasterPort loadTransitMasterPort;
 	private final SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort;
@@ -205,13 +209,28 @@ public class FacilityReportService implements FacilityReportUseCase {
 		FacilityReport saved = saveFacilityReportPort.saveReport(reviewed);
 		// 같은 결과로 재검수한 경우 사용자가 중복 처리 알림을 받지 않도록 상태 변경만 알린다.
 		if (report.status() != saved.status()) {
-			reportStatusAlertUseCase.alertReportStatusChanged(
-				new ReportStatusChangedAlertCommand(saved.userId(), saved.id(), saved.status())
-			);
+			alertReportStatusChanged(saved);
 		}
 		// 승인된 상태 신고만 실제 시설 운영 상태에 반영한다.
 		applyAcceptedReportToFacilityStatus(report, command.decision());
 		return saved;
+	}
+
+	private void alertReportStatusChanged(FacilityReport saved) {
+		try {
+			reportStatusAlertUseCase.alertReportStatusChanged(
+				new ReportStatusChangedAlertCommand(saved.userId(), saved.id(), saved.status())
+			);
+		} catch (RuntimeException exception) {
+			// 알림은 저장 이후 부수 효과이므로 실패해도 검수 결과 응답과 시설 상태 반영을 막지 않는다.
+			log.warn(
+				"신고 처리 결과 알림 발송에 실패했습니다. reportId={}, userId={}, status={}",
+				saved.id(),
+				saved.userId(),
+				saved.status(),
+				exception
+			);
+		}
 	}
 
 	private void requireReportType(CreateFacilityReportCommand command) {

--- a/backend/src/test/java/com/easysubway/notification/application/service/ReportStatusAlertServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notification/application/service/ReportStatusAlertServiceTest.java
@@ -1,0 +1,140 @@
+package com.easysubway.notification.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.notification.adapter.out.persistence.InMemoryNotificationPreferenceRepository;
+import com.easysubway.notification.adapter.out.persistence.InMemoryPushNotificationOutboxRepository;
+import com.easysubway.notification.application.port.in.RegisterDeviceCommand;
+import com.easysubway.notification.application.port.in.ReportStatusChangedAlertCommand;
+import com.easysubway.notification.application.port.in.SaveNotificationSettingsCommand;
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.InvalidPushNotificationException;
+import com.easysubway.notification.domain.PushNotificationType;
+import com.easysubway.report.domain.FacilityReportStatus;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("신고 처리 결과 알림 서비스")
+class ReportStatusAlertServiceTest {
+
+	private static final Clock CLOCK = Clock.fixed(
+		Instant.parse("2026-06-14T05:00:00Z"),
+		ZoneId.of("Asia/Seoul")
+	);
+
+	private final InMemoryNotificationPreferenceRepository notificationPreferenceRepository =
+		new InMemoryNotificationPreferenceRepository();
+	private final InMemoryPushNotificationOutboxRepository outboxRepository =
+		new InMemoryPushNotificationOutboxRepository();
+	private final NotificationPreferenceService preferenceService = new NotificationPreferenceService(
+		notificationPreferenceRepository,
+		notificationPreferenceRepository,
+		notificationPreferenceRepository,
+		CLOCK
+	);
+	private final PushNotificationDispatchService dispatchService = new PushNotificationDispatchService(
+		notificationPreferenceRepository,
+		outboxRepository,
+		CLOCK
+	);
+	private final ReportStatusAlertService service = new ReportStatusAlertService(dispatchService);
+
+	@Test
+	@DisplayName("승인된 신고는 작성자에게 확인 완료 알림 후보를 만든다")
+	void acceptedReportCreatesReportStatusPushCandidate() {
+		registerDevice("anonymous-user-accepted", DevicePlatform.ANDROID, "accepted-token");
+
+		service.alertReportStatusChanged(new ReportStatusChangedAlertCommand(
+			"anonymous-user-accepted",
+			"report-accepted",
+			FacilityReportStatus.ACCEPTED
+		));
+
+		assertThat(outboxRepository.loadPushNotifications("anonymous-user-accepted"))
+			.extracting("type")
+			.containsExactly(PushNotificationType.REPORT_STATUS);
+		assertThat(outboxRepository.loadPushNotifications("anonymous-user-accepted"))
+			.extracting("body")
+			.containsExactly("제보해 주신 신고가 확인되어 시설 정보에 반영되었습니다.");
+	}
+
+	@Test
+	@DisplayName("반려와 중복 처리된 신고는 작성자에게 결과 알림 후보를 만든다")
+	void rejectedAndDuplicateReportsCreateReportStatusPushCandidate() {
+		registerDevice("anonymous-user-rejected", DevicePlatform.IOS, "rejected-token");
+		registerDevice("anonymous-user-duplicate", DevicePlatform.ANDROID, "duplicate-token");
+
+		service.alertReportStatusChanged(new ReportStatusChangedAlertCommand(
+			"anonymous-user-rejected",
+			"report-rejected",
+			FacilityReportStatus.REJECTED
+		));
+		service.alertReportStatusChanged(new ReportStatusChangedAlertCommand(
+			"anonymous-user-duplicate",
+			"report-duplicate",
+			FacilityReportStatus.DUPLICATE
+		));
+
+		assertThat(outboxRepository.loadPushNotifications("anonymous-user-rejected"))
+			.extracting("body")
+			.containsExactly("제보해 주신 신고를 검토했지만 이번에는 반영되지 않았습니다.");
+		assertThat(outboxRepository.loadPushNotifications("anonymous-user-duplicate"))
+			.extracting("body")
+			.containsExactly("제보해 주신 신고는 이미 접수된 내용과 같아 중복으로 정리되었습니다.");
+	}
+
+	@Test
+	@DisplayName("사용자가 꺼둔 신고 처리 알림은 outbox 후보를 만들지 않는다")
+	void disabledReportStatusAlertDoesNotCreateOutboxCandidate() {
+		registerDevice("anonymous-user-disabled", DevicePlatform.ANDROID, "disabled-token");
+		preferenceService.saveNotificationSettings(new SaveNotificationSettingsCommand(
+			"anonymous-user-disabled",
+			true,
+			true,
+			false,
+			false
+		));
+
+		service.alertReportStatusChanged(new ReportStatusChangedAlertCommand(
+			"anonymous-user-disabled",
+			"report-disabled",
+			FacilityReportStatus.ACCEPTED
+		));
+
+		assertThat(outboxRepository.loadPushNotifications("anonymous-user-disabled")).isEmpty();
+	}
+
+	@Test
+	@DisplayName("신고 처리 알림 명령은 사용자와 신고와 상태를 요구한다")
+	void reportStatusAlertCommandRequiresUserReportAndStatus() {
+		assertThatThrownBy(() -> new ReportStatusChangedAlertCommand(
+			"",
+			"report-1",
+			FacilityReportStatus.ACCEPTED
+		))
+			.isInstanceOf(InvalidPushNotificationException.class)
+			.hasMessage("사용자 식별자가 필요합니다.");
+		assertThatThrownBy(() -> new ReportStatusChangedAlertCommand(
+			"anonymous-user-1",
+			"",
+			FacilityReportStatus.ACCEPTED
+		))
+			.isInstanceOf(InvalidPushNotificationException.class)
+			.hasMessage("신고 식별자가 필요합니다.");
+		assertThatThrownBy(() -> new ReportStatusChangedAlertCommand(
+			"anonymous-user-1",
+			"report-1",
+			null
+		))
+			.isInstanceOf(InvalidPushNotificationException.class)
+			.hasMessage("신고 상태를 선택해야 합니다.");
+	}
+
+	private void registerDevice(String userId, DevicePlatform platform, String token) {
+		preferenceService.registerDevice(new RegisterDeviceCommand(userId, platform, token));
+	}
+}

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -14,6 +14,8 @@ import com.easysubway.report.domain.FacilityReportType;
 import com.easysubway.report.domain.InvalidFacilityReportException;
 import com.easysubway.notification.application.port.in.FacilityStatusAlertUseCase;
 import com.easysubway.notification.application.port.in.FacilityStatusChangedAlertCommand;
+import com.easysubway.notification.application.port.in.ReportStatusAlertUseCase;
+import com.easysubway.notification.application.port.in.ReportStatusChangedAlertCommand;
 import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.StationNotFoundException;
@@ -181,6 +183,69 @@ class FacilityReportServiceTest {
 		assertThat(reviewed.reviewedAt()).isEqualTo(LocalDateTime.of(2026, 6, 12, 9, 0));
 		assertThat(reviewed.reviewedBy()).isEqualTo("admin-1");
 		assertThat(service.getReport(report.id())).isEqualTo(reviewed);
+	}
+
+	@Test
+	@DisplayName("신고 검수 결과는 신고 작성자에게 처리 알림을 요청한다")
+	void reviewedReportRequestsReportStatusAlertForReporter() {
+		var reportStatusAlertUseCase = new RecordingReportStatusAlertUseCase();
+		var repository = new InMemoryFacilityReportRepository();
+		var service = new FacilityReportService(
+			new InMemoryTransitMasterRepository(),
+			new InMemoryTransitMasterRepository(),
+			repository,
+			repository,
+			command -> {
+			},
+			reportStatusAlertUseCase,
+			Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+		);
+		var report = service.createReport(reportCommand(
+			"anonymous-user-report-alert",
+			FacilityReportType.INFORMATION_WRONG,
+			"신고 처리 결과 알림을 받을 신고입니다."
+		));
+
+		service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT));
+
+		assertThat(reportStatusAlertUseCase.commands)
+			.extracting(ReportStatusChangedAlertCommand::userId)
+			.containsExactly("anonymous-user-report-alert");
+		assertThat(reportStatusAlertUseCase.commands)
+			.extracting(ReportStatusChangedAlertCommand::reportId)
+			.containsExactly(report.id());
+		assertThat(reportStatusAlertUseCase.commands)
+			.extracting(ReportStatusChangedAlertCommand::status)
+			.containsExactly(FacilityReportStatus.REJECTED);
+	}
+
+	@Test
+	@DisplayName("이미 같은 상태인 신고 재검수는 처리 알림을 다시 요청하지 않는다")
+	void repeatedSameReportReviewDoesNotRequestReportStatusAlertAgain() {
+		var reportStatusAlertUseCase = new RecordingReportStatusAlertUseCase();
+		var repository = new InMemoryFacilityReportRepository();
+		var service = new FacilityReportService(
+			new InMemoryTransitMasterRepository(),
+			new InMemoryTransitMasterRepository(),
+			repository,
+			repository,
+			command -> {
+			},
+			reportStatusAlertUseCase,
+			Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+		);
+		var report = service.createReport(reportCommand(
+			"anonymous-user-repeat-alert",
+			FacilityReportType.INFORMATION_WRONG,
+			"같은 결과로 다시 검수할 신고입니다."
+		));
+
+		service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT));
+		service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT));
+
+		assertThat(reportStatusAlertUseCase.commands)
+			.extracting(ReportStatusChangedAlertCommand::status)
+			.containsExactly(FacilityReportStatus.REJECTED);
 	}
 
 	@Test
@@ -509,6 +574,16 @@ class FacilityReportServiceTest {
 
 		@Override
 		public void alertFacilityStatusChanged(FacilityStatusChangedAlertCommand command) {
+			commands.add(command);
+		}
+	}
+
+	private static class RecordingReportStatusAlertUseCase implements ReportStatusAlertUseCase {
+
+		private final java.util.List<ReportStatusChangedAlertCommand> commands = new java.util.ArrayList<>();
+
+		@Override
+		public void alertReportStatusChanged(ReportStatusChangedAlertCommand command) {
 			commands.add(command);
 		}
 	}

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -1,6 +1,7 @@
 package com.easysubway.report.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.easysubway.report.adapter.out.persistence.InMemoryFacilityReportRepository;
@@ -246,6 +247,33 @@ class FacilityReportServiceTest {
 		assertThat(reportStatusAlertUseCase.commands)
 			.extracting(ReportStatusChangedAlertCommand::status)
 			.containsExactly(FacilityReportStatus.REJECTED);
+	}
+
+	@Test
+	@DisplayName("신고 처리 결과 알림 실패는 검수 저장 결과를 실패시키지 않는다")
+	void reportStatusAlertFailureDoesNotFailReviewResult() {
+		var repository = new InMemoryFacilityReportRepository();
+		var service = new FacilityReportService(
+			new InMemoryTransitMasterRepository(),
+			new InMemoryTransitMasterRepository(),
+			repository,
+			repository,
+			command -> {
+			},
+			command -> {
+				throw new IllegalStateException("푸시 알림 발송 실패");
+			},
+			Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+		);
+		var report = service.createReport(reportCommand(
+			"anonymous-user-alert-failure",
+			FacilityReportType.INFORMATION_WRONG,
+			"알림 실패와 별개로 저장되어야 하는 신고입니다."
+		));
+
+		assertThatNoException()
+			.isThrownBy(() -> service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT)));
+		assertThat(service.getReport(report.id()).status()).isEqualTo(FacilityReportStatus.REJECTED);
 	}
 
 	@Test

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -721,6 +721,30 @@ test("백엔드 시설 상태 변경 알림은 즐겨찾기와 푸시 outbox 경
   assert.match(transitService, /alertFacilityStatusChanged/);
 });
 
+test("백엔드 신고 처리 결과 알림은 신고 서비스와 푸시 outbox 경계를 따른다", () => {
+  const useCase = read("backend/src/main/java/com/easysubway/notification/application/port/in/ReportStatusAlertUseCase.java");
+  const command = read("backend/src/main/java/com/easysubway/notification/application/port/in/ReportStatusChangedAlertCommand.java");
+  const service = read("backend/src/main/java/com/easysubway/notification/application/service/ReportStatusAlertService.java");
+  const reportService = read("backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java");
+
+  assert.match(useCase, /interface ReportStatusAlertUseCase/);
+  assert.match(useCase, /alertReportStatusChanged/);
+  assert.match(command, /record ReportStatusChangedAlertCommand/);
+  assert.match(command, /String userId/);
+  assert.match(command, /String reportId/);
+  assert.match(command, /FacilityReportStatus status/);
+  assert.match(service, /implements ReportStatusAlertUseCase/);
+  assert.match(service, /PushNotificationDispatchUseCase/);
+  assert.match(service, /PushNotificationType\.REPORT_STATUS/);
+  assert.match(service, /case ACCEPTED/);
+  assert.match(service, /case REJECTED/);
+  assert.match(service, /case DUPLICATE/);
+  assert.match(reportService, /ReportStatusAlertUseCase/);
+  assert.match(reportService, /ReportStatusChangedAlertCommand/);
+  assert.match(reportService, /report\.status\(\) != saved\.status\(\)/);
+  assert.match(reportService, /alertReportStatusChanged/);
+});
+
 test("백엔드 데이터 수집 배치는 관리자 API와 Spring Batch 경계를 따른다", () => {
   const buildGradle = read("backend/build.gradle");
   const application = read("backend/src/main/resources/application.yml");

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -739,9 +739,13 @@ test("백엔드 신고 처리 결과 알림은 신고 서비스와 푸시 outbox
   assert.match(service, /case ACCEPTED/);
   assert.match(service, /case REJECTED/);
   assert.match(service, /case DUPLICATE/);
+  assert.match(service, /case UNDER_REVIEW/);
+  assert.match(service, /case RESOLVED/);
+  assert.match(service, /case SUBMITTED/);
   assert.match(reportService, /ReportStatusAlertUseCase/);
   assert.match(reportService, /ReportStatusChangedAlertCommand/);
   assert.match(reportService, /report\.status\(\) != saved\.status\(\)/);
+  assert.match(reportService, /catch \(RuntimeException exception\)/);
   assert.match(reportService, /alertReportStatusChanged/);
 });
 


### PR DESCRIPTION
Closes #76

## 요약
- 신고 검수 결과를 신고 작성자에게 `REPORT_STATUS` 알림으로 전달하는 use case를 추가했습니다.
- `FacilityReportService`가 검수 상태가 실제로 바뀐 경우에만 신고 처리 알림을 요청하도록 연결했습니다.
- 신고 처리 알림은 기존 `PushNotificationDispatchUseCase`를 사용해 알림 설정과 outbox 저장 정책을 그대로 따릅니다.

## 변경 사항
- `ReportStatusAlertUseCase`, `ReportStatusChangedAlertCommand`, `ReportStatusAlertService` 추가
- 승인, 반려, 중복, 검토 중, 완료, 접수 상태별 신고 처리 알림 문구 추가
- 같은 상태로 재검수한 신고는 중복 알림을 만들지 않도록 분기 추가
- 서비스 테스트와 repository contract 테스트로 신고 처리 알림 경계 고정

## 검증
- `./gradlew test --tests "com.easysubway.notification.application.service.ReportStatusAlertServiceTest" --tests "com.easysubway.report.application.service.FacilityReportServiceTest"`
- `./gradlew test`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`

## 리스크
- 실제 FCM/APNs 발송은 기존 범위와 동일하게 포함하지 않았습니다.
- 알림 수신 여부는 기존 사용자 알림 설정과 등록 기기 상태에 따릅니다.

## 체크리스트
- [x] 신고 처리 결과 알림이 기존 push outbox 경계를 사용함
- [x] 중복 재검수 알림을 방지함
- [x] 한글 DisplayName 테스트를 추가함
- [x] README 외 Markdown 추적 정책을 확인함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 신고 처리 결과 알림 기능을 추가했습니다. 신고가 검수 완료될 때 신고 작성자에게 처리 결과(승인, 반려, 중복 등)를 알림으로 자동 전송합니다. 사용자는 신고 처리 현황을 실시간으로 파악할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->