### PR TITLE
[CI] 배포 준비 상태 확인 워크플로우 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,9 +18,6 @@ jobs:
     name: CD Readiness
     runs-on: ubuntu-latest
 
-    env:
-      EASYSUBWAY_ENV_SECRET: ${{ secrets.EASYSUBWAY_ENV }}
-
     steps:
       - name: CD Readiness / Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -30,6 +27,8 @@ jobs:
       - name: CD Readiness / Restore GitHub Actions dotenv secret
         id: dotenv
         shell: bash
+        env:
+          EASYSUBWAY_ENV_SECRET: ${{ secrets.EASYSUBWAY_ENV }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,86 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  readiness:
+    name: CD Readiness
+    runs-on: ubuntu-latest
+
+    env:
+      EASYSUBWAY_ENV_SECRET: ${{ secrets.EASYSUBWAY_ENV }}
+
+    steps:
+      - name: CD Readiness / Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: CD Readiness / Restore GitHub Actions dotenv secret
+        id: dotenv
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          env_file="${RUNNER_TEMP}/easysubway.env"
+          if [[ -n "${EASYSUBWAY_ENV_SECRET}" ]]; then
+            printf '%s\n' "${EASYSUBWAY_ENV_SECRET}" > "${env_file}"
+            echo "source=secret" >> "${GITHUB_OUTPUT}"
+          else
+            cp .env.example "${env_file}"
+            echo "source=example" >> "${GITHUB_OUTPUT}"
+            echo "::notice title=CD env secret::EASYSUBWAY_ENV secret is not configured; validating template only."
+          fi
+
+          chmod 600 "${env_file}"
+          echo "EASYSUBWAY_ENV_FILE=${env_file}" >> "${GITHUB_ENV}"
+
+      - name: CD Readiness / Validate deployment dotenv contract
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing_names=()
+          while IFS= read -r name; do
+            if [[ -n "${name}" ]] && ! grep -Eq "^${name}=" "${EASYSUBWAY_ENV_FILE}"; then
+              missing_names+=("${name}")
+            fi
+          done < <(sed -nE 's/^([A-Z0-9_]+)=.*/\1/p' .env.example)
+
+          if (( ${#missing_names[@]} > 0 )); then
+            printf 'Missing required deployment env names:\n' >&2
+            printf ' - %s\n' "${missing_names[@]}" >&2
+            exit 1
+          fi
+
+      - name: CD Readiness / Validate Docker Compose deployment config
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker compose --env-file "${EASYSUBWAY_ENV_FILE}" -f infra/docker-compose.yml config --quiet
+
+      - name: CD Readiness / Summarize deployment readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "### CD Readiness"
+            echo "- dotenv source: ${{ steps.dotenv.outputs.source }}"
+            echo "- compose config: valid"
+            if [[ "${{ steps.dotenv.outputs.source }}" == "example" ]]; then
+              echo "- deployment secret: EASYSUBWAY_ENV secret is not configured"
+            else
+              echo "- deployment secret: EASYSUBWAY_ENV"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
 
           env_file="${RUNNER_TEMP}/easysubway.env"
           if [[ -n "${EASYSUBWAY_ENV_SECRET}" ]]; then
-            printf '%s\n' "${EASYSUBWAY_ENV_SECRET}" > "${env_file}"
+            printf '%s' "${EASYSUBWAY_ENV_SECRET}" > "${env_file}"
             echo "source=secret" >> "${GITHUB_OUTPUT}"
           else
             cp .env.example "${env_file}"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ scripts/github/sync-actions-env-secret.sh .env
 
 워크플로에서 실제 배포 값을 사용할 때는 `secrets.EASYSUBWAY_ENV`를 파일로 복원한 뒤 그 파일을 `docker compose --env-file` 또는 애플리케이션 실행 환경에 넘깁니다. PR CI는 민감값이 필요하지 않으므로 `.env.example`로 양식만 검증합니다.
 
+CD workflow는 `EASYSUBWAY_ENV` secret이 있으면 배포 dotenv 계약을 검증하고, 아직 secret이 없으면 `.env.example`로 배포 설정 양식만 확인합니다.
+
 `EASYSUBWAY_TRUSTED_PROXY_CIDRS`는 ALB, Nginx, API Gateway처럼 애플리케이션 앞단에 있는 신뢰 가능한 프록시 IP 또는 CIDR 목록입니다. 예: `10.0.0.0/8,192.168.0.10`. 운영에서는 누락 시 시작 단계에서 설정 오류가 드러나도록 기본값을 두지 않습니다. 개발 환경은 프록시 없이도 로컬 실행할 수 있도록 빈 기본값을 허용하며, 이 경우 전달 헤더를 익명 인증 발급 제한 키로 사용하지 않습니다.
 
 ## Workspace

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -72,6 +72,23 @@ test("필수 지속적 통합 작업은 변경 없는 영역도 성공 상태로
   assert.doesNotMatch(jobBlock(workflow, "android", "ios"), /\n    if:/);
 });
 
+test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을 검증한다", () => {
+  const workflow = read(".github/workflows/cd.yml");
+
+  assert.match(workflow, /name: CD/);
+  assert.match(workflow, /push:\s*\n\s*branches:\s*\n\s*-\s*main/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /permissions:\s*\n\s*contents:\s*read/);
+  assert.match(workflow, /name: CD Readiness/);
+  assert.match(workflow, /secrets\.EASYSUBWAY_ENV/);
+  assert.match(workflow, /CD Readiness \/ Restore GitHub Actions dotenv secret/);
+  assert.match(workflow, /CD Readiness \/ Validate deployment dotenv contract/);
+  assert.match(workflow, /CD Readiness \/ Validate Docker Compose deployment config/);
+  assert.match(workflow, /docker compose --env-file "\$\{EASYSUBWAY_ENV_FILE\}" -f infra\/docker-compose\.yml config --quiet/);
+  assert.match(workflow, /EASYSUBWAY_ENV secret is not configured/);
+  assert.doesNotMatch(workflow, /secrets\.EASYSUBWAY_(DATASOURCE|REDIS|TRUSTED_PROXY|POSTGRES)/);
+});
+
 test("풀 리퀘스트 템플릿은 리뷰와 배포 확인 게이트를 포함한다", () => {
   const template = read(".github/pull_request_template.md");
 
@@ -127,14 +144,17 @@ test("GitHub Actions 환경값은 dotenv secret 하나로 관리한다", () => {
   const readme = read("README.md");
   const script = read("scripts/github/sync-actions-env-secret.sh");
   const workflow = read(".github/workflows/ci.yml");
+  const cdWorkflow = read(".github/workflows/cd.yml");
 
   assert.match(readme, /`EASYSUBWAY_ENV` secret 하나/);
   assert.match(readme, /scripts\/github\/sync-actions-env-secret\.sh \.env/);
   assert.match(readme, /secrets\.EASYSUBWAY_ENV/);
+  assert.match(readme, /CD workflow는 `EASYSUBWAY_ENV` secret이 있으면 배포 dotenv 계약을 검증/);
   assert.match(script, /SECRET_NAME="\$\{EASYSUBWAY_ACTIONS_ENV_SECRET_NAME:-EASYSUBWAY_ENV\}"/);
   assert.match(script, /gh secret set "\$\{SECRET_NAME\}" --repo "\$\{REPO\}" < "\$\{ENV_FILE\}"/);
   assert.match(script, /\.env\.example is a template/);
   assert.doesNotMatch(workflow, /secrets\.EASYSUBWAY_(DATASOURCE|REDIS|TRUSTED_PROXY|POSTGRES)/);
+  assert.doesNotMatch(cdWorkflow, /secrets\.EASYSUBWAY_(DATASOURCE|REDIS|TRUSTED_PROXY|POSTGRES)/);
 });
 
 test("로컬 PostGIS와 Redis 서비스가 Docker Compose에 정의된다", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -82,10 +82,12 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
   assert.match(workflow, /name: CD Readiness/);
   assert.match(workflow, /secrets\.EASYSUBWAY_ENV/);
   assert.match(workflow, /CD Readiness \/ Restore GitHub Actions dotenv secret/);
+  assert.match(workflow, /CD Readiness \/ Restore GitHub Actions dotenv secret[\s\S]*?env:\s*\n\s*EASYSUBWAY_ENV_SECRET: \$\{\{ secrets\.EASYSUBWAY_ENV \}\}/);
   assert.match(workflow, /CD Readiness \/ Validate deployment dotenv contract/);
   assert.match(workflow, /CD Readiness \/ Validate Docker Compose deployment config/);
   assert.match(workflow, /docker compose --env-file "\$\{EASYSUBWAY_ENV_FILE\}" -f infra\/docker-compose\.yml config --quiet/);
   assert.match(workflow, /EASYSUBWAY_ENV secret is not configured/);
+  assert.doesNotMatch(workflow, /runs-on: ubuntu-latest\s*\n\s*env:\s*\n\s*EASYSUBWAY_ENV_SECRET/);
   assert.doesNotMatch(workflow, /secrets\.EASYSUBWAY_(DATASOURCE|REDIS|TRUSTED_PROXY|POSTGRES)/);
 });
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -83,6 +83,8 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
   assert.match(workflow, /secrets\.EASYSUBWAY_ENV/);
   assert.match(workflow, /CD Readiness \/ Restore GitHub Actions dotenv secret/);
   assert.match(workflow, /CD Readiness \/ Restore GitHub Actions dotenv secret[\s\S]*?env:\s*\n\s*EASYSUBWAY_ENV_SECRET: \$\{\{ secrets\.EASYSUBWAY_ENV \}\}/);
+  assert.match(workflow, /printf '%s' "\$\{EASYSUBWAY_ENV_SECRET\}" > "\$\{env_file\}"/);
+  assert.doesNotMatch(workflow, /printf '%s\\n' "\$\{EASYSUBWAY_ENV_SECRET\}"/);
   assert.match(workflow, /CD Readiness \/ Validate deployment dotenv contract/);
   assert.match(workflow, /CD Readiness \/ Validate Docker Compose deployment config/);
   assert.match(workflow, /docker compose --env-file "\$\{EASYSUBWAY_ENV_FILE\}" -f infra\/docker-compose\.yml config --quiet/);


### PR DESCRIPTION
## 관련 이슈
Closes #84

## 요약
- main push와 수동 실행에서 동작하는 CD 준비 상태 워크플로우를 추가했습니다.
- `EASYSUBWAY_ENV` secret이 있으면 임시 dotenv 파일로 복원해 배포 환경 양식과 Docker Compose 설정을 검증합니다.
- secret이 아직 없으면 `.env.example`로 배포 설정 양식만 확인하고 summary에 미설정 상태를 남깁니다.

## 변경 사항
- `.github/workflows/cd.yml` 추가
- CD workflow 계약을 `tools/ci/repository-contract.test.mjs`에 고정
- README에 CD workflow와 단일 dotenv secret 동작을 짧게 정리

## 검증
- `node --test tools/ci/*.test.mjs` 통과
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/cd.yml .github/workflows/ci.yml` 통과
- `docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet` 통과
- `git diff --check` 통과
- `git ls-files '*.md'` 결과가 `.github/pull_request_template.md`, `README.md`만 포함하는 것 확인

## 리뷰어가 먼저 봐야 할 지점
- `EASYSUBWAY_ENV`가 없는 public 저장소 상태에서도 CD readiness가 실패하지 않고, 미설정 상태를 명확히 남기는 조건이 적절한지 확인이 필요합니다.
- 실제 배포 대상이 생기면 이 workflow에 배포 job을 이어 붙이는 방식으로 확장할 수 있습니다.

## 리스크
- 현재 CD는 실제 외부 배포가 아니라 배포 준비 상태 확인입니다.
- 로컬 `.env`가 없어 이번 작업에서는 GitHub secret 업데이트를 수행하지 않았습니다.

## 체크리스트
- [x] 관련 issue를 연결했다.
- [x] 실행한 명령과 결과를 검증에 기록했다.
- [x] CodeRabbit 리뷰를 확인한다.
- [x] CodeRabbit이 실행되지 않으면 Codex CLI code review 결과를 확인한다.
- [x] merge 후 CD 상태를 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * main 브랜치 푸시 또는 수동 트리거 시 필수 환경 변수 및 배포 구성을 자동으로 검증하는 지속적 배포 워크플로우 추가

* **Documentation**
  * 자동 배포 검증 프로세스 및 환경 설정 요구사항 문서화

* **Tests**
  * 배포 워크플로우 및 환경 설정 계약 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->