### PR TITLE
[Fix] 모바일 원본 예외 로깅 경계 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,16 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Mobile App CI / Set up Node.js for mobile contracts
+        if: ${{ needs.changes.outputs.mobile == 'true' && steps.scaffold.outputs.present == 'true' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Mobile App CI / Run mobile catch contract
+        if: ${{ needs.changes.outputs.mobile == 'true' && steps.scaffold.outputs.present == 'true' }}
+        run: node --test --test-name-pattern "모바일 generic catch" tools/ci/repository-contract.test.mjs
+
       - name: Mobile App CI / Run Flutter analyzer and tests
         if: ${{ needs.changes.outputs.mobile == 'true' && steps.scaffold.outputs.present == 'true' }}
         working-directory: apps/mobile

--- a/apps/mobile/lib/anonymous_auth.dart
+++ b/apps/mobile/lib/anonymous_auth.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'auth_headers.dart';
+import 'mobile_error_reporter.dart';
 
 const _anonymousAuthTimeout = Duration(seconds: 8);
 const _anonymousAuthErrorMessage = '인증을 준비하지 못했습니다. 잠시 후 다시 시도해 주세요.';
@@ -46,7 +47,12 @@ class SecureAnonymousAuthCredentialStore
         throw const FormatException('Invalid anonymous auth storage payload');
       }
       return AnonymousAuthCredentials.fromJson(decoded);
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '저장된 익명 인증 정보를 읽는 중 예외가 발생했습니다.',
+      );
       await clearCredentials();
       return null;
     }
@@ -125,7 +131,12 @@ class AnonymousAuthApiRepository implements AnonymousAuthRepository {
       return AnonymousAuthCredentials.fromJson(data);
     } on AnonymousAuthException {
       rethrow;
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '익명 인증 API 응답 처리 중 예외가 발생했습니다.',
+      );
       throw const AnonymousAuthException(_anonymousAuthErrorMessage);
     }
   }

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+import 'mobile_error_reporter.dart';
+
 const _facilityReportTimeout = Duration(seconds: 8);
 const _facilityReportErrorMessage = '신고를 보내지 못했습니다.';
 const _facilityReportStatusErrorMessage = '처리 상태를 확인하지 못했습니다.';
@@ -48,7 +50,12 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       );
     } on FacilityReportException {
       rethrow;
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '시설 신고 접수 응답 처리 중 예외가 발생했습니다.',
+      );
       throw const FacilityReportException(_facilityReportErrorMessage);
     }
   }
@@ -81,7 +88,12 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       );
     } on FacilityReportException {
       rethrow;
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '시설 신고 처리 상태 응답 처리 중 예외가 발생했습니다.',
+      );
       throw const FacilityReportException(_facilityReportStatusErrorMessage);
     }
   }
@@ -328,7 +340,12 @@ class FacilityReportController extends ChangeNotifier {
           message: error.message,
         ),
       );
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '시설 신고 화면 제출 처리 중 예외가 발생했습니다.',
+      );
       _emitState(
         const FacilityReportState(
           status: FacilityReportViewStatus.failure,
@@ -372,7 +389,12 @@ class FacilityReportController extends ChangeNotifier {
           result: currentResult,
         ),
       );
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '시설 신고 처리 상태 새로고침 중 예외가 발생했습니다.',
+      );
       // 알 수 없는 오류도 같은 화면에서 다시 확인할 수 있게 접수 결과를 보존한다.
       _emitState(
         FacilityReportState(

--- a/apps/mobile/lib/mobile_error_reporter.dart
+++ b/apps/mobile/lib/mobile_error_reporter.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+typedef MobileErrorReporter = void Function(FlutterErrorDetails details);
+
+const _mobileErrorReporterZoneKey = #easysubwayMobileErrorReporter;
+
+void reportMobileError(
+  Object error,
+  StackTrace stackTrace, {
+  required String context,
+}) {
+  final details = FlutterErrorDetails(
+    exception: error,
+    stack: stackTrace,
+    library: 'easysubway mobile',
+    context: ErrorDescription(context),
+  );
+
+  final zoneReporter = Zone.current[_mobileErrorReporterZoneKey];
+  if (zoneReporter is MobileErrorReporter) {
+    zoneReporter(details);
+    return;
+  }
+
+  FlutterError.reportError(details);
+}
+
+Future<T> runWithMobileErrorReporter<T>(
+  MobileErrorReporter reporter,
+  Future<T> Function() body,
+) {
+  return runZoned(body, zoneValues: {_mobileErrorReporterZoneKey: reporter});
+}

--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import 'auth_headers.dart';
+import 'mobile_error_reporter.dart';
 
 const _notificationSettingsTimeout = Duration(seconds: 8);
 const _notificationSettingsLoadErrorMessage = '알림 설정을 불러오지 못했습니다.';
@@ -45,7 +46,12 @@ class NotificationSettingsApiRepository
 
     try {
       return NotificationSettings.fromJson(data);
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '알림 설정 조회 응답 처리 중 예외가 발생했습니다.',
+      );
       throw const NotificationSettingsException(
         _notificationSettingsLoadErrorMessage,
       );
@@ -70,7 +76,12 @@ class NotificationSettingsApiRepository
 
     try {
       return NotificationSettings.fromJson(data);
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '알림 설정 저장 응답 처리 중 예외가 발생했습니다.',
+      );
       throw const NotificationSettingsException(
         _notificationSettingsSaveErrorMessage,
       );
@@ -131,7 +142,12 @@ class NotificationSettingsApiRepository
         return decoded['data'];
       } on NotificationSettingsException {
         rethrow;
-      } catch (_) {
+      } catch (error, stackTrace) {
+        reportMobileError(
+          error,
+          stackTrace,
+          context: '알림 설정 API 요청 처리 중 예외가 발생했습니다.',
+        );
         throw NotificationSettingsException(errorMessage);
       }
     }
@@ -257,7 +273,12 @@ class NotificationSettingsController extends ChangeNotifier {
       );
     } on NotificationSettingsException catch (error) {
       _emitFailure(error.message);
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '알림 설정 화면 조회 처리 중 예외가 발생했습니다.',
+      );
       _emitFailure(_notificationSettingsLoadErrorMessage);
     }
   }
@@ -312,7 +333,12 @@ class NotificationSettingsController extends ChangeNotifier {
           message: error.message,
         ),
       );
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '알림 설정 화면 저장 처리 중 예외가 발생했습니다.',
+      );
       _emitState(
         NotificationSettingsState(
           status: NotificationSettingsStatus.ready,

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+import 'mobile_error_reporter.dart';
 import 'mobility_profile.dart';
 import 'station_search.dart';
 
@@ -54,7 +55,12 @@ class RouteSearchApiRepository implements RouteSearchRepository {
       return RouteSearchResult.fromJson(data);
     } on RouteSearchException {
       rethrow;
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '경로 검색 API 응답 처리 중 예외가 발생했습니다.',
+      );
       throw const RouteSearchException(_routeSearchErrorMessage);
     }
   }
@@ -336,7 +342,12 @@ class RouteSearchController extends ChangeNotifier {
           message: error.message,
         ),
       );
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '경로 검색 화면 처리 중 예외가 발생했습니다.',
+      );
       if (_disposed || requestId != _searchRequestId) {
         return;
       }

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 
 import 'auth_headers.dart';
 import 'facility_report.dart';
+import 'mobile_error_reporter.dart';
 
 const _stationSearchTimeout = Duration(seconds: 8);
 const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
@@ -51,7 +52,12 @@ class StationSearchApiRepository implements StationSearchRepository {
             return StationSearchResult.fromJson(item);
           })
           .toList(growable: false);
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '역 검색 목록 응답 처리 중 예외가 발생했습니다.',
+      );
       throw const StationSearchException(_stationSearchErrorMessage);
     }
   }
@@ -67,7 +73,8 @@ class StationSearchApiRepository implements StationSearchRepository {
     }
     try {
       return StationDetail.fromJson(data);
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '역 상세 응답 처리 중 예외가 발생했습니다.');
       throw const StationSearchException(_stationSearchErrorMessage);
     }
   }
@@ -90,7 +97,12 @@ class StationSearchApiRepository implements StationSearchRepository {
             return StationExitInfo.fromJson(item);
           })
           .toList(growable: false);
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '역 출구 목록 응답 처리 중 예외가 발생했습니다.',
+      );
       throw const StationSearchException(_stationSearchErrorMessage);
     }
   }
@@ -115,7 +127,12 @@ class StationSearchApiRepository implements StationSearchRepository {
             return StationFacilityInfo.fromJson(item);
           })
           .toList(growable: false);
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '역 시설 목록 응답 처리 중 예외가 발생했습니다.',
+      );
       throw const StationSearchException(_stationSearchErrorMessage);
     }
   }
@@ -143,7 +160,12 @@ class StationSearchApiRepository implements StationSearchRepository {
       return data;
     } on StationSearchException {
       rethrow;
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '역 정보 API 요청 처리 중 예외가 발생했습니다.',
+      );
       throw const StationSearchException(_stationSearchErrorMessage);
     }
   }
@@ -211,7 +233,12 @@ class FavoriteStationApiRepository implements FavoriteStationRepository {
             return FavoriteStation.fromJson(item);
           })
           .toList(growable: false);
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '즐겨찾기 역 목록 응답 처리 중 예외가 발생했습니다.',
+      );
       throw const FavoriteStationException(_favoriteStationLoadErrorMessage);
     }
   }
@@ -232,7 +259,12 @@ class FavoriteStationApiRepository implements FavoriteStationRepository {
 
     try {
       return FavoriteStation.fromJson(data);
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '즐겨찾기 역 저장 응답 처리 중 예외가 발생했습니다.',
+      );
       throw const FavoriteStationException(_favoriteStationChangeErrorMessage);
     }
   }
@@ -296,7 +328,12 @@ class FavoriteStationApiRepository implements FavoriteStationRepository {
         return decoded['data'];
       } on FavoriteStationException {
         rethrow;
-      } catch (_) {
+      } catch (error, stackTrace) {
+        reportMobileError(
+          error,
+          stackTrace,
+          context: '즐겨찾기 역 API 요청 처리 중 예외가 발생했습니다.',
+        );
         throw FavoriteStationException(errorMessage);
       }
     }
@@ -843,7 +880,8 @@ class StationSearchController extends ChangeNotifier {
         results: const [],
         message: error.message,
       );
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '역 검색 화면 처리 중 예외가 발생했습니다.');
       if (requestId != _searchRequestId) {
         return;
       }
@@ -912,7 +950,8 @@ class StationDetailController extends ChangeNotifier {
         exits: responses[1] as List<StationExitInfo>,
         facilities: responses[2] as List<StationFacilityInfo>,
       );
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '역 상세 화면 로드 중 예외가 발생했습니다.');
       if (_isDisposed) {
         return;
       }
@@ -988,7 +1027,12 @@ class FavoriteStationListController extends ChangeNotifier {
           message: error.message,
         ),
       );
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '즐겨찾기 역 목록 화면 로드 중 예외가 발생했습니다.',
+      );
       _emitState(
         const FavoriteStationListState(
           status: FavoriteStationListStatus.failure,
@@ -1081,7 +1125,12 @@ class StationFavoriteToggleController extends ChangeNotifier {
       _emitState(StationFavoriteToggleState.ready(isFavorite: isFavorite));
     } on FavoriteStationException catch (error) {
       _emitFailure(error.message);
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '역 즐겨찾기 상태 확인 중 예외가 발생했습니다.',
+      );
       _emitFailure(_favoriteStationStatusErrorMessage);
     }
   }
@@ -1109,7 +1158,8 @@ class StationFavoriteToggleController extends ChangeNotifier {
       );
     } on FavoriteStationException catch (error) {
       _emitFailure(error.message);
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '역 즐겨찾기 저장 중 예외가 발생했습니다.');
       _emitFailure(_favoriteStationChangeErrorMessage);
     }
   }
@@ -1137,7 +1187,8 @@ class StationFavoriteToggleController extends ChangeNotifier {
       );
     } on FavoriteStationException catch (error) {
       _emitFailure(error.message);
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '역 즐겨찾기 해제 중 예외가 발생했습니다.');
       _emitFailure(_favoriteStationChangeErrorMessage);
     }
   }

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -950,6 +950,14 @@ class StationDetailController extends ChangeNotifier {
         exits: responses[1] as List<StationExitInfo>,
         facilities: responses[2] as List<StationFacilityInfo>,
       );
+    } on StationSearchException {
+      if (_isDisposed) {
+        return;
+      }
+      _state = const StationDetailState(
+        status: StationDetailStatus.failure,
+        message: '역 상세 정보를 불러오지 못했습니다.',
+      );
     } catch (error, stackTrace) {
       reportMobileError(error, stackTrace, context: '역 상세 화면 로드 중 예외가 발생했습니다.');
       if (_isDisposed) {

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:easysubway_mobile/facility_report.dart';
+import 'package:easysubway_mobile/mobile_error_reporter.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -57,6 +59,7 @@ void main() {
   });
 
   test('시설 신고 API 저장소는 잘못된 접수 응답도 쉬운 실패 문구로 바꾼다', () async {
+    final reportedErrors = _captureReportedErrors();
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(server.close);
 
@@ -77,24 +80,70 @@ void main() {
       baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
     );
 
-    await expectLater(
-      repository.createReport(
-        const FacilityReportRequest(
-          userId: 'anonymous-mobile-user',
-          stationId: 'station-sangnoksu',
-          facilityId: 'facility-sangnoksu-elevator-1',
-          reportType: 'BROKEN',
-          description: '문이 열리지 않습니다.',
+    await runWithMobileErrorReporter(reportedErrors.add, () async {
+      await expectLater(
+        repository.createReport(
+          const FacilityReportRequest(
+            userId: 'anonymous-mobile-user',
+            stationId: 'station-sangnoksu',
+            facilityId: 'facility-sangnoksu-elevator-1',
+            reportType: 'BROKEN',
+            description: '문이 열리지 않습니다.',
+          ),
         ),
-      ),
-      throwsA(
-        isA<FacilityReportException>().having(
-          (error) => error.message,
-          'message',
-          '신고를 보내지 못했습니다.',
+        throwsA(
+          isA<FacilityReportException>().having(
+            (error) => error.message,
+            'message',
+            '신고를 보내지 못했습니다.',
+          ),
         ),
-      ),
+      );
+    });
+    expect(reportedErrors, hasLength(1));
+  });
+
+  test('시설 신고 API 저장소는 파싱 실패 원인과 스택을 오류 경계에 보고한다', () async {
+    final reportedErrors = _captureReportedErrors();
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      request.response
+        ..statusCode = HttpStatus.created
+        ..headers.contentType = ContentType.json
+        ..write('{broken-json')
+        ..close();
+    });
+
+    final repository = FacilityReportApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
     );
+
+    await runWithMobileErrorReporter(reportedErrors.add, () async {
+      await expectLater(
+        repository.createReport(
+          const FacilityReportRequest(
+            userId: 'anonymous-mobile-user',
+            stationId: 'station-sangnoksu',
+            facilityId: 'facility-sangnoksu-elevator-1',
+            reportType: 'BROKEN',
+            description: '문이 열리지 않습니다.',
+          ),
+        ),
+        throwsA(
+          isA<FacilityReportException>().having(
+            (error) => error.message,
+            'message',
+            '신고를 보내지 못했습니다.',
+          ),
+        ),
+      );
+    });
+
+    expect(reportedErrors, hasLength(1));
+    expect(reportedErrors.single.exception, isA<FormatException>());
+    expect(reportedErrors.single.stack, isNotNull);
   });
 
   test('시설 신고 API 저장소는 접수번호로 처리 상태를 조회한다', () async {
@@ -245,6 +294,10 @@ void main() {
   });
 }
 
+List<FlutterErrorDetails> _captureReportedErrors() {
+  return <FlutterErrorDetails>[];
+}
+
 FacilityReportTarget _reportTarget() {
   return const FacilityReportTarget(
     stationId: 'station-sangnoksu',
@@ -351,8 +404,6 @@ class FailingRefreshFacilityReportRepository
   @override
   Future<FacilityReportResult> getReport(String reportId) {
     loadedReportIds.add(reportId);
-    return Future.error(
-      const FacilityReportException('처리 상태를 확인하지 못했습니다.'),
-    );
+    return Future.error(const FacilityReportException('처리 상태를 확인하지 못했습니다.'));
   }
 }

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -531,6 +531,21 @@ void main() {
     expect(controller.state.facilities.single.name, '1번 출구 엘리베이터');
   });
 
+  test('역 상세 컨트롤러는 처리된 역 정보 실패를 오류 경계에 다시 보고하지 않는다', () async {
+    final reportedErrors = _captureReportedErrors();
+    final repository = FailingStationDetailRepository();
+    final controller = StationDetailController(repository: repository);
+    addTearDown(controller.dispose);
+
+    await runWithMobileErrorReporter(reportedErrors.add, () async {
+      await controller.load('station-sangnoksu');
+    });
+
+    expect(reportedErrors, isEmpty);
+    expect(controller.state.status, StationDetailStatus.failure);
+    expect(controller.state.message, '역 상세 정보를 불러오지 못했습니다.');
+  });
+
   test('즐겨찾기 역 목록 컨트롤러는 목록과 빈 목록과 실패 상태를 구분한다', () async {
     final repository = FakeFavoriteStationRepository();
     final controller = FavoriteStationListController(repository: repository);
@@ -812,6 +827,30 @@ class ControlledStationDetailRepository implements StationSearchRepository {
     );
     _exitsCompleter.complete([_stationExit()]);
     _facilitiesCompleter.complete([_stationFacility()]);
+  }
+}
+
+class FailingStationDetailRepository implements StationSearchRepository {
+  @override
+  Future<List<StationSearchResult>> searchStations(String query) async {
+    return const [];
+  }
+
+  @override
+  Future<StationDetail> getStationDetail(String stationId) async {
+    throw const StationSearchException('역 정보를 불러오지 못했습니다.');
+  }
+
+  @override
+  Future<List<StationExitInfo>> listStationExits(String stationId) async {
+    return const [];
+  }
+
+  @override
+  Future<List<StationFacilityInfo>> listStationFacilities(
+    String stationId,
+  ) async {
+    return const [];
   }
 }
 

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:easysubway_mobile/station_search.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -400,6 +402,7 @@ void main() {
   });
 
   test('역 API 저장소는 형식이 잘못된 역 응답을 거부한다', () async {
+    final reportedErrors = _captureReportedErrors();
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(server.close);
 
@@ -436,16 +439,21 @@ void main() {
       baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
     );
 
-    expect(
-      () => repository.searchStations('상록수'),
-      throwsA(
-        isA<StationSearchException>().having(
-          (error) => error.message,
-          'message',
-          '역 정보를 불러오지 못했습니다.',
+    await runWithMobileErrorReporter(reportedErrors.add, () async {
+      await expectLater(
+        repository.searchStations('상록수'),
+        throwsA(
+          isA<StationSearchException>().having(
+            (error) => error.message,
+            'message',
+            '역 정보를 불러오지 못했습니다.',
+          ),
         ),
-      ),
-    );
+      );
+    });
+    expect(reportedErrors, hasLength(1));
+    expect(reportedErrors.single.exception, isA<FormatException>());
+    expect(reportedErrors.single.stack, isNotNull);
   });
 
   test('역 검색 컨트롤러는 빈 입력을 API 호출 없이 대기 상태로 둔다', () async {
@@ -607,6 +615,10 @@ void main() {
     expect(customerCenter.statusLabel, '검수 완료');
     expect(customerCenter.semanticLabel, contains('정보 신뢰도 높음'));
   });
+}
+
+List<FlutterErrorDetails> _captureReportedErrors() {
+  return <FlutterErrorDetails>[];
 }
 
 FavoriteStation _favoriteStation({required String id, required String name}) {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -159,6 +159,18 @@ test("GitHub Actions 환경값은 dotenv secret 하나로 관리한다", () => {
   assert.match(script, /\.env\.example is a template/);
   assert.doesNotMatch(workflow, /secrets\.EASYSUBWAY_(DATASOURCE|REDIS|TRUSTED_PROXY|POSTGRES)/);
   assert.doesNotMatch(cdWorkflow, /secrets\.EASYSUBWAY_(DATASOURCE|REDIS|TRUSTED_PROXY|POSTGRES)/);
+});
+
+test("모바일 generic catch는 원본 예외와 스택을 버리지 않는다", () => {
+  const mobileFiles = execFileSync("git", ["ls-files", "apps/mobile/lib/*.dart"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim().split("\n").filter(Boolean);
+
+  assert.ok(mobileFiles.length > 0, "mobile Dart files not found");
+  for (const file of mobileFiles) {
+    assert.doesNotMatch(read(file), /catch\s*\(_\)/, `${file} has catch (_)`);
+  }
 });
 
 test("로컬 PostGIS와 Redis 서비스가 Docker Compose에 정의된다", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -21,6 +21,20 @@ function jobBlock(workflow, startJob, nextJob) {
   return match[0];
 }
 
+function assertMobileCatchPolicy(file, source) {
+  const catchPattern = /catch\s*\(([^)]*)\)/g;
+  for (const match of source.matchAll(catchPattern)) {
+    const lineStart = source.lastIndexOf("\n", match.index) + 1;
+    const linePrefix = source.slice(lineStart, match.index);
+    if (/\bon\s+\w+/.test(linePrefix)) {
+      continue;
+    }
+
+    const names = match[1].split(",").map((name) => name.trim());
+    assert.deepEqual(names, ["error", "stackTrace"], `${file} has catch without named error and stackTrace`);
+  }
+}
+
 test("로컬 에이전트 문서와 README 외 Markdown은 gitignore로 추적되지 않는다", () => {
   const gitignore = read(".gitignore");
 
@@ -53,6 +67,7 @@ test("지속적 통합 작업과 스텝 이름은 실패 영역을 구분할 수
   assert.match(workflow, /Repository CI \/ Run contract tests/);
   assert.match(workflow, /Backend CI \/ Detect backend scaffold/);
   assert.match(workflow, /Mobile App CI \/ Run Flutter analyzer and tests/);
+  assert.match(workflow, /Mobile App CI \/ Run mobile catch contract/);
   assert.match(workflow, /Android CI \/ Build Flutter Android debug APK/);
   assert.match(workflow, /iOS CI \/ Build Flutter iOS simulator app/);
 });
@@ -169,8 +184,20 @@ test("모바일 generic catch는 원본 예외와 스택을 버리지 않는다"
 
   assert.ok(mobileFiles.length > 0, "mobile Dart files not found");
   for (const file of mobileFiles) {
-    assert.doesNotMatch(read(file), /catch\s*\(_\)/, `${file} has catch (_)`);
+    assertMobileCatchPolicy(file, read(file));
   }
+});
+
+test("모바일 변경 CI는 원본 예외 catch 계약을 실행한다", () => {
+  const workflow = read(".github/workflows/ci.yml");
+  const mobileJob = jobBlock(workflow, "mobile-app", "android");
+
+  assert.match(mobileJob, /Mobile App CI \/ Set up Node\.js for mobile contracts/);
+  assert.match(mobileJob, /Mobile App CI \/ Run mobile catch contract/);
+  assert.match(
+    mobileJob,
+    /node --test --test-name-pattern "모바일 generic catch" tools\/ci\/repository-contract\.test\.mjs/,
+  );
 });
 
 test("로컬 PostGIS와 Redis 서비스가 Docker Compose에 정의된다", () => {


### PR DESCRIPTION
## 관련 이슈
Closes #86

## 배경
모바일 API 저장소와 화면 컨트롤러의 일부 generic catch가 원본 예외와 스택 트레이스를 잃고 사용자용 문구만 남기고 있었습니다. 사용자는 짧고 쉬운 실패 문구를 유지해야 하지만, 운영 중에는 네트워크 실패, JSON 파싱 실패, 화면 상태 처리 오류를 구분할 수 있어야 합니다.

## 변경 사항
- Flutter 기본 오류 경계로 원본 예외와 스택을 전달하는 모바일 오류 보고 경계를 추가했습니다.
- 익명 인증, 역 검색, 경로 검색, 시설 신고, 알림 설정의 generic catch에서 `error`와 `stackTrace`를 보고한 뒤 기존 사용자 문구를 유지하도록 바꿨습니다.
- 테스트 간 전역 오류 훅 충돌이 없도록 zone 기반 오류 reporter 주입을 지원했습니다.
- 모바일 lib에 `catch (_)`가 다시 들어오지 않도록 저장소 계약 테스트를 추가했습니다.

## 검증
- `flutter test test/facility_report_test.dart test/notification_settings_test.dart test/route_search_test.dart test/station_search_test.dart test/anonymous_auth_test.dart` 통과
- `flutter test` 통과
- `flutter analyze` 통과
- `node --test tools/ci/*.test.mjs` 통과
- `git diff --check` 통과
- `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`

## 리뷰어가 먼저 봐야 할 지점
- `apps/mobile/lib/mobile_error_reporter.dart`의 zone 기반 reporter 주입 방식
- 사용자 오류 문구가 기존과 동일하게 유지되는지
- `tools/ci/repository-contract.test.mjs`의 `catch (_)` 재발 방지 계약

## 리스크
- 외부 오류 수집 SDK는 추가하지 않았습니다. 이후 Sentry 같은 도구를 붙일 때는 이 오류 보고 경계를 연결 지점으로 사용할 수 있습니다.
