### PR TITLE
[CI] GitHub Actions 환경값 단일 dotenv secret 계약 강화

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 `.env.example`은 로컬 실행과 배포에 필요한 dotenv 양식입니다. 실제 값은 git에 올리지 않는 로컬 `.env`에만 둡니다.
 
-GitHub Actions에는 개별 환경변수를 여러 개 만들지 않고, 로컬 `.env` 파일 전체를 `EASYSUBWAY_ENV` secret 하나로 저장합니다.
+GitHub Actions에는 개별 환경변수를 여러 개 만들지 않고, 로컬 `.env` 파일 전체를 `EASYSUBWAY_ENV` secret 하나로 저장합니다. GitHub Actions secret 이름은 반드시 `EASYSUBWAY_ENV`만 사용합니다.
 
 ```bash
 scripts/github/sync-actions-env-secret.sh .env

--- a/scripts/github/sync-actions-env-secret.sh
+++ b/scripts/github/sync-actions-env-secret.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ENV_FILE="${1:-.env}"
-REPO="${GITHUB_REPOSITORY:-AquilaXk/easysubway}"
-SECRET_NAME="${EASYSUBWAY_ACTIONS_ENV_SECRET_NAME:-EASYSUBWAY_ENV}"
+readonly ENV_FILE="${1:-.env}"
+readonly REPO="${GITHUB_REPOSITORY:-AquilaXk/easysubway}"
+readonly SECRET_NAME="EASYSUBWAY_ENV"
 
 if [[ ! -f "${ENV_FILE}" ]]; then
 	printf 'Local env file not found: %s\n' "${ENV_FILE}" >&2

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -21,6 +21,13 @@ function jobBlock(workflow, startJob, nextJob) {
   return match[0];
 }
 
+function workflowFiles() {
+  return execFileSync("git", ["ls-files", ".github/workflows/*.yml", ".github/workflows/*.yaml"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim().split("\n").filter(Boolean);
+}
+
 function assertMobileCatchPolicy(file, source) {
   const catchPattern = /catch\s*\(([^)]*)\)/g;
   for (const match of source.matchAll(catchPattern)) {
@@ -162,18 +169,22 @@ test("환경 예시는 비밀값 없는 로컬 데이터 인프라 기본값을 
 test("GitHub Actions 환경값은 dotenv secret 하나로 관리한다", () => {
   const readme = read("README.md");
   const script = read("scripts/github/sync-actions-env-secret.sh");
-  const workflow = read(".github/workflows/ci.yml");
-  const cdWorkflow = read(".github/workflows/cd.yml");
 
   assert.match(readme, /`EASYSUBWAY_ENV` secret 하나/);
+  assert.match(readme, /GitHub Actions secret 이름은 반드시 `EASYSUBWAY_ENV`만 사용합니다/);
   assert.match(readme, /scripts\/github\/sync-actions-env-secret\.sh \.env/);
   assert.match(readme, /secrets\.EASYSUBWAY_ENV/);
   assert.match(readme, /CD workflow는 `EASYSUBWAY_ENV` secret이 있으면 배포 dotenv 계약을 검증/);
-  assert.match(script, /SECRET_NAME="\$\{EASYSUBWAY_ACTIONS_ENV_SECRET_NAME:-EASYSUBWAY_ENV\}"/);
+  assert.match(script, /readonly SECRET_NAME="EASYSUBWAY_ENV"/);
+  assert.doesNotMatch(script, /EASYSUBWAY_ACTIONS_ENV_SECRET_NAME/);
   assert.match(script, /gh secret set "\$\{SECRET_NAME\}" --repo "\$\{REPO\}" < "\$\{ENV_FILE\}"/);
   assert.match(script, /\.env\.example is a template/);
-  assert.doesNotMatch(workflow, /secrets\.EASYSUBWAY_(DATASOURCE|REDIS|TRUSTED_PROXY|POSTGRES)/);
-  assert.doesNotMatch(cdWorkflow, /secrets\.EASYSUBWAY_(DATASOURCE|REDIS|TRUSTED_PROXY|POSTGRES)/);
+
+  for (const file of workflowFiles()) {
+    const source = read(file);
+    assert.doesNotMatch(source, /secrets\.EASYSUBWAY_(?!ENV\b)[A-Z0-9_]+/, `${file} must use only secrets.EASYSUBWAY_ENV`);
+    assert.doesNotMatch(source, /vars\.EASYSUBWAY_[A-Z0-9_]+/, `${file} must not use GitHub Actions vars for app env`);
+  }
 });
 
 test("모바일 generic catch는 원본 예외와 스택을 버리지 않는다", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -28,6 +28,14 @@ function workflowFiles() {
   }).trim().split("\n").filter(Boolean);
 }
 
+function assertActionsEnvSecretPolicy(file, source) {
+  const disallowedSecretAccess = /secrets(?:\.EASYSUBWAY_(?!ENV\b)[A-Z0-9_]+|\[['"]EASYSUBWAY_(?!ENV['"]?\])[A-Z0-9_]+['"]\])/;
+  const disallowedVarsAccess = /vars(?:\.EASYSUBWAY_[A-Z0-9_]+|\[['"]EASYSUBWAY_[A-Z0-9_]+['"]\])/;
+
+  assert.doesNotMatch(source, disallowedSecretAccess, `${file} must use only secrets.EASYSUBWAY_ENV`);
+  assert.doesNotMatch(source, disallowedVarsAccess, `${file} must not use GitHub Actions vars for app env`);
+}
+
 function assertMobileCatchPolicy(file, source) {
   const catchPattern = /catch\s*\(([^)]*)\)/g;
   for (const match of source.matchAll(catchPattern)) {
@@ -182,9 +190,19 @@ test("GitHub Actions 환경값은 dotenv secret 하나로 관리한다", () => {
 
   for (const file of workflowFiles()) {
     const source = read(file);
-    assert.doesNotMatch(source, /secrets\.EASYSUBWAY_(?!ENV\b)[A-Z0-9_]+/, `${file} must use only secrets.EASYSUBWAY_ENV`);
-    assert.doesNotMatch(source, /vars\.EASYSUBWAY_[A-Z0-9_]+/, `${file} must not use GitHub Actions vars for app env`);
+    assertActionsEnvSecretPolicy(file, source);
   }
+});
+
+test("GitHub Actions 환경값 계약은 bracket notation 우회를 차단한다", () => {
+  assert.throws(
+    () => assertActionsEnvSecretPolicy("example.yml", "env:\n  DB: ${{ secrets['EASYSUBWAY_DATABASE_URL'] }}"),
+    /example\.yml must use only secrets\.EASYSUBWAY_ENV/,
+  );
+  assert.throws(
+    () => assertActionsEnvSecretPolicy("example.yml", "env:\n  DB: ${{ vars['EASYSUBWAY_DATABASE_URL'] }}"),
+    /example\.yml must not use GitHub Actions vars for app env/,
+  );
 });
 
 test("모바일 generic catch는 원본 예외와 스택을 버리지 않는다", () => {


### PR DESCRIPTION
## 관련 이슈

Closes #88

## 요약

GitHub Actions 환경값 관리 방식을 `EASYSUBWAY_ENV` 단일 dotenv secret으로 고정했습니다. 로컬 `.env`를 다른 secret 이름으로 올릴 수 있던 우회 경로를 제거하고, workflow 전체에서 개별 앱 환경값 secret이나 GitHub Actions vars를 쓰지 못하도록 계약 테스트를 넓혔습니다.

## 변경 사항

- README에 GitHub Actions secret 이름은 반드시 `EASYSUBWAY_ENV`만 사용한다고 명시
- `scripts/github/sync-actions-env-secret.sh`에서 secret 이름 override 제거
- repository contract 테스트가 `.github/workflows/*.yml`, `.yaml` 전체를 스캔해 `secrets.EASYSUBWAY_ENV` 외 개별 앱 secret과 `vars.EASYSUBWAY_*` 사용을 차단

## 검증

- `node --test --test-name-pattern "GitHub Actions 환경값" tools/ci/repository-contract.test.mjs`
  - RED: README 고정 문구와 스크립트 secret 이름 고정이 없어 실패
  - GREEN: 정책 반영 후 통과
- `node --test tools/ci/*.test.mjs`
  - 33개 통과
- `scripts/github/sync-actions-env-secret.sh .env.example`
  - `.env.example`은 양식 파일이라 거부되는 동작 확인
- `git diff --check`
- `git ls-files '*.md'`
  - `.github/pull_request_template.md`, `README.md`만 추적

## 리뷰어가 먼저 봐야 할 지점

- `scripts/github/sync-actions-env-secret.sh`에서 `EASYSUBWAY_ACTIONS_ENV_SECRET_NAME` override를 제거한 것이 운영 정책과 맞는지 확인이 필요합니다.
- `tools/ci/repository-contract.test.mjs`의 workflow 전체 스캔 정규식이 새 workflow 추가 시에도 의도대로 동작하는지 봐주세요.

## 체크리스트

- [x] 관련 issue를 연결했다.
- [x] 실행한 명령과 결과를 검증 항목에 적었다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] Codex CLI code review 결과를 확인했다.
- [ ] CI 상태를 확인했다.
- [ ] CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * GitHub Actions 배포 시 환경 변수를 단일 secret으로 관리하는 방식에 대한 설명을 명확히 강화하였습니다.

* **Refactor**
  * 환경 변수 관리 설정을 단순화하여 단일 secret 이름으로 고정하였습니다.

* **Tests**
  * 배포 환경 변수 관리 계약 검증 범위를 확대하고 더욱 구체적으로 강화하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->