### PR TITLE
[Feat] 모바일 온보딩 설정 로컬 저장

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -8,9 +8,10 @@ import 'notification_settings.dart';
 import 'onboarding.dart';
 import 'route_search.dart';
 import 'station_search.dart';
+import 'mobile_error_reporter.dart';
 
 void main() {
-  runApp(EasySubwayApp());
+  runApp(EasySubwayApp(onboardingStore: const SecureOnboardingResultStore()));
 }
 
 class EasySubwayApp extends StatelessWidget {
@@ -21,6 +22,7 @@ class EasySubwayApp extends StatelessWidget {
     FavoriteStationRepository? favoriteRepository,
     NotificationSettingsRepository? notificationRepository,
     AnonymousAuthRepository? anonymousAuthRepository,
+    OnboardingResultStore? onboardingStore,
     OnboardingState initialOnboardingState = const OnboardingState.initial(),
     bool enableAnonymousAuth = true,
     Key? key,
@@ -35,12 +37,14 @@ class EasySubwayApp extends StatelessWidget {
            enableAnonymousAuth: enableAnonymousAuth,
          ),
          initialOnboardingState: initialOnboardingState,
+         onboardingStore: onboardingStore,
          key: key,
        );
 
   EasySubwayApp._({
     required _EasySubwayAppDependencies dependencies,
     required this.initialOnboardingState,
+    required this.onboardingStore,
     super.key,
   }) : repository = dependencies.repository,
        reportRepository = dependencies.reportRepository,
@@ -54,6 +58,7 @@ class EasySubwayApp extends StatelessWidget {
   final FavoriteStationRepository? favoriteRepository;
   final NotificationSettingsRepository? notificationRepository;
   final OnboardingState initialOnboardingState;
+  final OnboardingResultStore? onboardingStore;
 
   @override
   Widget build(BuildContext context) {
@@ -105,6 +110,7 @@ class EasySubwayApp extends StatelessWidget {
         favoriteRepository: favoriteRepository,
         notificationRepository: notificationRepository,
         initialOnboardingState: initialOnboardingState,
+        onboardingStore: onboardingStore,
       ),
     );
   }
@@ -118,6 +124,7 @@ class _EasySubwayHome extends StatefulWidget {
     required this.favoriteRepository,
     required this.notificationRepository,
     required this.initialOnboardingState,
+    required this.onboardingStore,
   });
 
   final StationSearchRepository repository;
@@ -126,20 +133,39 @@ class _EasySubwayHome extends StatefulWidget {
   final FavoriteStationRepository? favoriteRepository;
   final NotificationSettingsRepository? notificationRepository;
   final OnboardingState initialOnboardingState;
+  final OnboardingResultStore? onboardingStore;
 
   @override
   State<_EasySubwayHome> createState() => _EasySubwayHomeState();
 }
 
 class _EasySubwayHomeState extends State<_EasySubwayHome> {
-  // 영구 저장을 연결하기 전까지는 같은 앱 세션에서 온보딩 완료 상태를 유지한다.
+  // 저장소가 없는 테스트/프리뷰에서도 같은 앱 세션에서는 온보딩 완료 상태를 유지한다.
   late OnboardingState _onboardingState = widget.initialOnboardingState;
+  late bool _loadingOnboardingState =
+      widget.onboardingStore != null &&
+      !widget.initialOnboardingState.isCompleted;
+
+  @override
+  void initState() {
+    super.initState();
+    if (_loadingOnboardingState) {
+      _restoreOnboardingState();
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
+    if (_loadingOnboardingState) {
+      return const Scaffold(
+        body: SafeArea(child: Center(child: CircularProgressIndicator())),
+      );
+    }
+
     if (!_onboardingState.isCompleted) {
       return OnboardingScreen(
-        onCompleted: (result) {
+        onCompleted: (result) async {
+          await _saveOnboardingResult(result);
           setState(() {
             _onboardingState = OnboardingState.completed(result: result);
           });
@@ -164,6 +190,42 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         simpleViewEnabled: preferences.simpleViewEnabled,
       ),
     );
+  }
+
+  Future<void> _restoreOnboardingState() async {
+    OnboardingResult? storedResult;
+    try {
+      storedResult = await widget.onboardingStore?.readResult();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '온보딩 설정을 불러오는 중 예외가 발생했습니다.',
+      );
+    }
+
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _onboardingState = storedResult == null
+          ? const OnboardingState.initial()
+          : OnboardingState.completed(result: storedResult);
+      _loadingOnboardingState = false;
+    });
+  }
+
+  Future<void> _saveOnboardingResult(OnboardingResult result) async {
+    try {
+      await widget.onboardingStore?.saveResult(result);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '온보딩 설정을 저장하는 중 예외가 발생했습니다.',
+      );
+    }
   }
 }
 

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -1,6 +1,61 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'mobility_profile.dart';
+import 'mobile_error_reporter.dart';
+
+const _onboardingResultStorageKey = 'easysubway.onboarding.result';
+
+abstract class OnboardingResultStore {
+  Future<OnboardingResult?> readResult();
+
+  Future<void> saveResult(OnboardingResult result);
+
+  Future<void> clearResult();
+}
+
+class SecureOnboardingResultStore implements OnboardingResultStore {
+  const SecureOnboardingResultStore({
+    this.storage = const FlutterSecureStorage(),
+  });
+
+  final FlutterSecureStorage storage;
+
+  @override
+  Future<OnboardingResult?> readResult() async {
+    final value = await storage.read(key: _onboardingResultStorageKey);
+    if (value == null) {
+      return null;
+    }
+
+    try {
+      return OnboardingResult.decode(value);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '저장된 온보딩 설정을 읽는 중 예외가 발생했습니다.',
+      );
+      await clearResult();
+      return null;
+    }
+  }
+
+  @override
+  Future<void> saveResult(OnboardingResult result) async {
+    await storage.write(
+      key: _onboardingResultStorageKey,
+      value: result.encode(),
+    );
+  }
+
+  @override
+  Future<void> clearResult() async {
+    await storage.delete(key: _onboardingResultStorageKey);
+  }
+}
 
 class OnboardingViewPreferences {
   const OnboardingViewPreferences({
@@ -13,6 +68,14 @@ class OnboardingViewPreferences {
     : largeTextEnabled = true,
       highContrastEnabled = false,
       simpleViewEnabled = true;
+
+  factory OnboardingViewPreferences.fromJson(Map<String, Object?> json) {
+    return OnboardingViewPreferences(
+      largeTextEnabled: json['largeTextEnabled'] == true,
+      highContrastEnabled: json['highContrastEnabled'] == true,
+      simpleViewEnabled: json['simpleViewEnabled'] == true,
+    );
+  }
 
   final bool largeTextEnabled;
   final bool highContrastEnabled;
@@ -29,13 +92,55 @@ class OnboardingViewPreferences {
       simpleViewEnabled: simpleViewEnabled ?? this.simpleViewEnabled,
     );
   }
+
+  Map<String, Object?> toJson() {
+    return {
+      'largeTextEnabled': largeTextEnabled,
+      'highContrastEnabled': highContrastEnabled,
+      'simpleViewEnabled': simpleViewEnabled,
+    };
+  }
 }
 
 class OnboardingResult {
   const OnboardingResult({required this.profile, required this.preferences});
 
+  factory OnboardingResult.fromJson(Map<String, Object?> json) {
+    final profileId = json['profileId'];
+    final preferences = json['preferences'];
+    if (profileId is! String || preferences is! Map<String, Object?>) {
+      throw const FormatException('Invalid onboarding storage payload');
+    }
+
+    final profile = mobilityProfileOptions.firstWhere(
+      (option) => option.id == profileId,
+      orElse: () => throw const FormatException('Invalid onboarding profile'),
+    );
+
+    return OnboardingResult(
+      profile: profile,
+      preferences: OnboardingViewPreferences.fromJson(preferences),
+    );
+  }
+
+  factory OnboardingResult.decode(String value) {
+    final decoded = jsonDecode(value);
+    if (decoded is! Map<String, Object?>) {
+      throw const FormatException('Invalid onboarding storage payload');
+    }
+    return OnboardingResult.fromJson(decoded);
+  }
+
   final MobilityProfileOption profile;
   final OnboardingViewPreferences preferences;
+
+  Map<String, Object?> toJson() {
+    return {'profileId': profile.id, 'preferences': preferences.toJson()};
+  }
+
+  String encode() {
+    return jsonEncode(toJson());
+  }
 }
 
 class OnboardingState {

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -70,10 +70,20 @@ class OnboardingViewPreferences {
       simpleViewEnabled = true;
 
   factory OnboardingViewPreferences.fromJson(Map<String, Object?> json) {
+    final largeTextEnabled = json['largeTextEnabled'];
+    final highContrastEnabled = json['highContrastEnabled'];
+    final simpleViewEnabled = json['simpleViewEnabled'];
+    // 손상된 저장값이 접근성 기본값을 조용히 끄지 않도록 타입을 엄격히 확인한다.
+    if (largeTextEnabled is! bool ||
+        highContrastEnabled is! bool ||
+        simpleViewEnabled is! bool) {
+      throw const FormatException('Invalid onboarding preferences payload');
+    }
+
     return OnboardingViewPreferences(
-      largeTextEnabled: json['largeTextEnabled'] == true,
-      highContrastEnabled: json['highContrastEnabled'] == true,
-      simpleViewEnabled: json['simpleViewEnabled'] == true,
+      largeTextEnabled: largeTextEnabled,
+      highContrastEnabled: highContrastEnabled,
+      simpleViewEnabled: simpleViewEnabled,
     );
   }
 

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -123,4 +123,18 @@ void main() {
       throwsA(isA<FormatException>()),
     );
   });
+
+  test('온보딩 완료 결과는 손상된 보기 설정 저장값을 거부한다', () {
+    expect(
+      () => OnboardingResult.decode(
+        '{"profileId":"elderly","preferences":{"largeTextEnabled":"yes","highContrastEnabled":false,"simpleViewEnabled":true}}',
+      ),
+      throwsA(isA<FormatException>()),
+    );
+
+    expect(
+      () => OnboardingResult.decode('{"profileId":"elderly","preferences":{}}'),
+      throwsA(isA<FormatException>()),
+    );
+  });
 }

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -93,4 +93,34 @@ void main() {
     expect(result.preferences.highContrastEnabled, isTrue);
     expect(result.preferences.simpleViewEnabled, isFalse);
   });
+
+  test('온보딩 완료 결과는 로컬 저장용 문자열로 변환하고 다시 읽는다', () {
+    final result = OnboardingResult(
+      profile: mobilityProfileOptions.firstWhere(
+        (option) => option.id == 'wheelchair',
+      ),
+      preferences: const OnboardingViewPreferences(
+        largeTextEnabled: true,
+        highContrastEnabled: true,
+        simpleViewEnabled: false,
+      ),
+    );
+
+    final decoded = OnboardingResult.decode(result.encode());
+
+    expect(decoded.profile.id, 'wheelchair');
+    expect(decoded.profile.mobilityType, 'WHEELCHAIR');
+    expect(decoded.preferences.largeTextEnabled, isTrue);
+    expect(decoded.preferences.highContrastEnabled, isTrue);
+    expect(decoded.preferences.simpleViewEnabled, isFalse);
+  });
+
+  test('온보딩 완료 결과는 알 수 없는 이동 조건 저장값을 거부한다', () {
+    expect(
+      () => OnboardingResult.decode(
+        '{"profileId":"unknown","preferences":{"largeTextEnabled":true,"highContrastEnabled":false,"simpleViewEnabled":true}}',
+      ),
+      throwsA(isA<FormatException>()),
+    );
+  });
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -4,6 +4,7 @@ import 'package:easysubway_mobile/anonymous_auth.dart';
 import 'package:easysubway_mobile/main.dart';
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/mobility_profile.dart';
+import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:easysubway_mobile/notification_settings.dart';
 import 'package:easysubway_mobile/onboarding.dart';
 import 'package:easysubway_mobile/route_search.dart';
@@ -38,6 +39,8 @@ OnboardingState _completedOnboardingStateWithPreferences({
 
 void main() {
   testWidgets('첫 실행 앱은 온보딩을 완료한 뒤 홈으로 이동한다', (tester) async {
+    final onboardingStore = MemoryOnboardingResultStore();
+
     await tester.pumpWidget(
       EasySubwayApp(
         repository: FakeStationSearchRepository(),
@@ -45,8 +48,10 @@ void main() {
         routeRepository: FakeRouteSearchRepository(),
         favoriteRepository: FakeFavoriteStationRepository(),
         notificationRepository: FakeNotificationSettingsRepository(),
+        onboardingStore: onboardingStore,
       ),
     );
+    await tester.pumpAndSettle();
 
     expect(find.text('쉬운 지하철'), findsOneWidget);
     expect(find.text('먼저 이동 조건을 골라 주세요'), findsOneWidget);
@@ -60,6 +65,66 @@ void main() {
     expect(find.text('역 찾기'), findsOneWidget);
     expect(find.byKey(const Key('stationSearchButton')), findsOneWidget);
     expect(find.text('먼저 이동 조건을 골라 주세요'), findsNothing);
+    expect(onboardingStore.savedResult?.profile.id, 'elderly');
+    expect(onboardingStore.saveCount, 1);
+  });
+
+  testWidgets('앱은 저장된 온보딩 설정으로 홈을 바로 보여준다', (tester) async {
+    final onboardingStore = MemoryOnboardingResultStore(
+      initialResult: OnboardingResult(
+        profile: mobilityProfileOptions.firstWhere(
+          (option) => option.id == 'wheelchair',
+        ),
+        preferences: const OnboardingViewPreferences(
+          largeTextEnabled: true,
+          highContrastEnabled: true,
+          simpleViewEnabled: true,
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        onboardingStore: onboardingStore,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final homeContext = tester.element(find.byType(HomeScreen));
+
+    expect(onboardingStore.readCount, 1);
+    expect(find.byKey(const Key('stationSearchButton')), findsOneWidget);
+    expect(find.text('먼저 이동 조건을 골라 주세요'), findsNothing);
+    expect(MediaQuery.textScalerOf(homeContext).scale(20), closeTo(23.6, 0.01));
+    expect(Theme.of(homeContext).colorScheme.primary, const Color(0xFF003D40));
+  });
+
+  testWidgets('앱은 온보딩 저장소를 읽지 못하면 다시 설정을 고르게 한다', (tester) async {
+    final reportedErrors = <FlutterErrorDetails>[];
+
+    await runWithMobileErrorReporter(reportedErrors.add, () async {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
+          onboardingStore: MemoryOnboardingResultStore(throwOnRead: true),
+        ),
+      );
+      await tester.pumpAndSettle();
+    });
+
+    expect(reportedErrors, hasLength(1));
+    expect(reportedErrors.single.exception, isA<FormatException>());
+    expect(find.text('먼저 이동 조건을 골라 주세요'), findsOneWidget);
+    expect(find.byKey(const Key('stationSearchButton')), findsNothing);
   });
 
   testWidgets('온보딩을 마친 앱 세션은 홈을 바로 보여준다', (tester) async {
@@ -1556,6 +1621,38 @@ class FakeAnonymousAuthRepository implements AnonymousAuthRepository {
       userId: 'anonymous-user-1',
       password: 'user-test-password',
     );
+  }
+}
+
+class MemoryOnboardingResultStore implements OnboardingResultStore {
+  MemoryOnboardingResultStore({
+    OnboardingResult? initialResult,
+    this.throwOnRead = false,
+  }) : savedResult = initialResult;
+
+  OnboardingResult? savedResult;
+  final bool throwOnRead;
+  int readCount = 0;
+  int saveCount = 0;
+
+  @override
+  Future<OnboardingResult?> readResult() async {
+    readCount++;
+    if (throwOnRead) {
+      throw const FormatException('broken onboarding result');
+    }
+    return savedResult;
+  }
+
+  @override
+  Future<void> saveResult(OnboardingResult result) async {
+    saveCount++;
+    savedResult = result;
+  }
+
+  @override
+  Future<void> clearResult() async {
+    savedResult = null;
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

Closes #90

## 요약

온보딩에서 고른 이동 조건과 보기 설정을 로컬 저장소에 저장하고, 앱을 다시 열 때 같은 설정으로 홈 화면을 바로 보여주도록 연결했습니다. 저장소를 읽지 못하는 경우에는 오류를 보고하고 초기 온보딩으로 돌아가 사용자가 다시 설정할 수 있게 했습니다.

## 변경 사항

- `OnboardingResultStore`와 `SecureOnboardingResultStore` 추가
- 온보딩 완료 결과를 JSON 문자열로 저장/복원하는 변환 로직 추가
- 앱 시작 시 저장된 온보딩 결과를 읽어 홈 화면과 보기 설정에 적용
- 저장소 읽기 실패 시 오류 경계에 보고하고 초기 온보딩으로 복구
- 저장/복원/실패 복구 테스트 추가

## 검증

- `flutter test test/widget_test.dart`
  - RED: 온보딩 저장소 주입점이 없어 실패
  - GREEN: 저장/복원 구현 후 통과
- `flutter test test/widget_test.dart --plain-name "앱은 온보딩 저장소를 읽지 못하면 다시 설정을 고르게 한다"`
  - RED: 저장소 읽기 실패가 테스트 실패와 로딩 정지로 이어짐
  - GREEN: 오류 보고 후 초기 온보딩 복구로 통과
- `flutter test test/onboarding_test.dart test/widget_test.dart`
- `flutter test`
  - 73개 통과
- `flutter analyze`
- `node --test tools/ci/*.test.mjs`
  - 34개 통과
- `git diff --check`
- `git ls-files '*.md'`
  - `.github/pull_request_template.md`, `README.md`만 추적

## 리뷰어가 먼저 봐야 할 지점

- 실제 앱 진입점에서만 `SecureOnboardingResultStore`를 주입하고, 테스트/프리뷰는 저장소 없이 기존 세션 동작을 유지하도록 둔 구조가 적절한지 확인이 필요합니다.
- 저장소 읽기 실패를 사용자 차단 오류로 만들지 않고 초기 온보딩으로 복구하는 처리가 접근성 사용자 흐름에 맞는지 봐주세요.

## 체크리스트

- [x] 관련 issue를 연결했다.
- [x] 실행한 명령과 결과를 검증 항목에 적었다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] Codex CLI code review 결과를 확인했다.
- [ ] CI 상태를 확인했다.
- [ ] CD 상태를 확인했다.
