### PR TITLE
[Feat] 도시철도 데이터 출처 표시

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -422,6 +422,7 @@ class StationSearchResult {
     required this.nameEn,
     required this.region,
     required this.dataQualityLevel,
+    this.dataSourceType = '',
     required this.lastVerifiedAt,
     required this.lines,
   });
@@ -438,6 +439,7 @@ class StationSearchResult {
       nameEn: _requiredString(json, 'nameEn'),
       region: _requiredString(json, 'region'),
       dataQualityLevel: _requiredString(json, 'dataQualityLevel'),
+      dataSourceType: _stringOrEmpty(json, 'dataSourceType'),
       lastVerifiedAt: _requiredString(json, 'lastVerifiedAt'),
       lines: rawLines
           .map((item) {
@@ -455,12 +457,15 @@ class StationSearchResult {
   final String nameEn;
   final String region;
   final String dataQualityLevel;
+  final String dataSourceType;
   final String lastVerifiedAt;
   final List<StationSearchLine> lines;
 
   String get dataQualityLabel {
     return _dataQualityLabel(dataQualityLevel);
   }
+
+  String get dataSourceLabel => _dataSourceLabel(dataSourceType);
 
   String get lineLabel {
     if (lines.isEmpty) {
@@ -481,6 +486,7 @@ class StationDetail {
     this.latitude,
     this.longitude,
     required this.dataQualityLevel,
+    this.dataSourceType = '',
     required this.lastVerifiedAt,
     required this.lines,
   });
@@ -499,6 +505,7 @@ class StationDetail {
       latitude: _optionalDouble(json, 'latitude'),
       longitude: _optionalDouble(json, 'longitude'),
       dataQualityLevel: _requiredString(json, 'dataQualityLevel'),
+      dataSourceType: _stringOrEmpty(json, 'dataSourceType'),
       lastVerifiedAt: _requiredString(json, 'lastVerifiedAt'),
       lines: rawLines
           .map((item) {
@@ -520,10 +527,13 @@ class StationDetail {
   final double? latitude;
   final double? longitude;
   final String dataQualityLevel;
+  final String dataSourceType;
   final String lastVerifiedAt;
   final List<StationSearchLine> lines;
 
   String get dataQualityLabel => _dataQualityLabel(dataQualityLevel);
+
+  String get dataSourceLabel => _dataSourceLabel(dataSourceType);
 
   String get lineLabel {
     if (lines.isEmpty) {
@@ -533,7 +543,7 @@ class StationDetail {
   }
 
   String get semanticLabel {
-    return '$nameKo역 상세 정보, $lineLabel, $dataQualityLabel, 마지막 확인 $lastVerifiedAt';
+    return '$nameKo역 상세 정보, $lineLabel, $dataQualityLabel, $dataSourceLabel, 마지막 확인 $lastVerifiedAt';
   }
 }
 
@@ -548,6 +558,7 @@ class StationExitInfo {
     required this.hasElevatorConnection,
     required this.hasStairOnlyPath,
     required this.dataConfidence,
+    this.dataSourceType = '',
   });
 
   factory StationExitInfo.fromJson(Map<String, Object?> json) {
@@ -561,6 +572,7 @@ class StationExitInfo {
       hasElevatorConnection: _requiredBool(json, 'hasElevatorConnection'),
       hasStairOnlyPath: _requiredBool(json, 'hasStairOnlyPath'),
       dataConfidence: _requiredString(json, 'dataConfidence'),
+      dataSourceType: _stringOrEmpty(json, 'dataSourceType'),
     );
   }
 
@@ -573,6 +585,7 @@ class StationExitInfo {
   final bool hasElevatorConnection;
   final bool hasStairOnlyPath;
   final String dataConfidence;
+  final String dataSourceType;
 
   String get elevatorConnectionLabel {
     return hasElevatorConnection ? '엘리베이터 연결' : '엘리베이터 연결 확인 필요';
@@ -584,8 +597,10 @@ class StationExitInfo {
 
   String get confidenceLabel => _dataConfidenceLabel(dataConfidence);
 
+  String get dataSourceLabel => _dataSourceLabel(dataSourceType);
+
   String get semanticLabel {
-    return '$name, $elevatorConnectionLabel, $stairPathLabel, $confidenceLabel';
+    return '$name, $elevatorConnectionLabel, $stairPathLabel, $confidenceLabel, $dataSourceLabel';
   }
 }
 
@@ -603,6 +618,7 @@ class StationFacilityInfo {
     required this.description,
     required this.status,
     required this.dataConfidence,
+    this.dataSourceType = '',
     required this.lastUpdatedAt,
   });
 
@@ -620,6 +636,7 @@ class StationFacilityInfo {
       description: _stringOrEmpty(json, 'description'),
       status: _requiredString(json, 'status'),
       dataConfidence: _requiredString(json, 'dataConfidence'),
+      dataSourceType: _stringOrEmpty(json, 'dataSourceType'),
       lastUpdatedAt: _requiredString(json, 'lastUpdatedAt'),
     );
   }
@@ -636,6 +653,7 @@ class StationFacilityInfo {
   final String description;
   final String status;
   final String dataConfidence;
+  final String dataSourceType;
   final String lastUpdatedAt;
 
   String get typeLabel {
@@ -671,6 +689,8 @@ class StationFacilityInfo {
 
   String get confidenceLabel => _dataConfidenceLabel(dataConfidence);
 
+  String get dataSourceLabel => _dataSourceLabel(dataSourceType);
+
   String get locationLabel {
     if (description.trim().isNotEmpty) {
       return description;
@@ -684,7 +704,7 @@ class StationFacilityInfo {
   String get updatedLabel => '최근 확인 $lastUpdatedAt';
 
   String get semanticLabel {
-    return '$name, $typeLabel, $statusLabel, $locationLabel, $updatedLabel, $confidenceLabel';
+    return '$name, $typeLabel, $statusLabel, $locationLabel, $updatedLabel, $confidenceLabel, $dataSourceLabel';
   }
 }
 
@@ -807,6 +827,18 @@ String _dataConfidenceLabel(String dataConfidence) {
     'MEDIUM' => '정보 신뢰도 보통',
     'LOW' => '정보 확인 필요',
     _ => '정보 확인 필요',
+  };
+}
+
+String _dataSourceLabel(String dataSourceType) {
+  return switch (dataSourceType) {
+    'OFFICIAL_API' => '출처 공공 API',
+    'OFFICIAL_FILE' => '출처 공식 파일',
+    'OPERATOR_PAGE' => '출처 운영기관 페이지',
+    'USER_REPORT' => '출처 사용자 제보',
+    'ADMIN_VERIFIED' => '출처 관리자 검수',
+    'PARTNER_FEED' => '출처 제휴 데이터',
+    _ => '출처 확인 필요',
   };
 }
 
@@ -1907,6 +1939,11 @@ class _StationDetailHeader extends StatelessWidget {
             ),
             const SizedBox(height: 6),
             _StationDetailInfoRow(
+              icon: Icons.source_outlined,
+              text: detail.dataSourceLabel,
+            ),
+            const SizedBox(height: 6),
+            _StationDetailInfoRow(
               icon: Icons.event_available,
               text: '마지막 확인 ${detail.lastVerifiedAt}',
             ),
@@ -2116,6 +2153,15 @@ class _StationExitCard extends StatelessWidget {
                       height: 1.3,
                     ),
                   ),
+                  const SizedBox(height: 6),
+                  Text(
+                    exit.dataSourceLabel,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: const Color(0xFF405A5D),
+                      fontWeight: FontWeight.w700,
+                      height: 1.3,
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -2186,6 +2232,15 @@ class _StationFacilityCard extends StatelessWidget {
               const SizedBox(height: 6),
               Text(
                 facility.confidenceLabel,
+                style: textTheme.bodyMedium?.copyWith(
+                  color: const Color(0xFF405A5D),
+                  fontWeight: FontWeight.w700,
+                  height: 1.3,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                facility.dataSourceLabel,
                 style: textTheme.bodyMedium?.copyWith(
                   color: const Color(0xFF405A5D),
                   fontWeight: FontWeight.w700,

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -28,6 +28,7 @@ void main() {
                 'nameEn': 'Sangnoksu',
                 'region': '수도권',
                 'dataQualityLevel': 'LEVEL_1',
+                'dataSourceType': 'OFFICIAL_FILE',
                 'lastVerifiedAt': '2026-06-12',
                 'lines': [
                   {
@@ -60,6 +61,7 @@ void main() {
     expect(results.single.nameKo, '상록수');
     expect(results.single.region, '수도권');
     expect(results.single.dataQualityLabel, '기본 정보만 확인됨');
+    expect(results.single.dataSourceLabel, '출처 공식 파일');
     expect(results.single.lines.single.name, '수도권 4호선');
   });
 
@@ -87,6 +89,7 @@ void main() {
                 'latitude': 37.302795,
                 'longitude': 126.866489,
                 'dataQualityLevel': 'LEVEL_1',
+                'dataSourceType': 'OFFICIAL_FILE',
                 'lastVerifiedAt': '2026-06-12',
                 'lines': [
                   {
@@ -118,6 +121,7 @@ void main() {
                   'hasElevatorConnection': true,
                   'hasStairOnlyPath': false,
                   'dataConfidence': 'HIGH',
+                  'dataSourceType': 'OFFICIAL_FILE',
                 },
               ],
             }),
@@ -141,6 +145,7 @@ void main() {
                   'description': '1번 출구 앞',
                   'status': 'NORMAL',
                   'dataConfidence': 'HIGH',
+                  'dataSourceType': 'OFFICIAL_FILE',
                   'lastUpdatedAt': '2026-06-12',
                 },
               ],
@@ -176,17 +181,20 @@ void main() {
     expect(detail.latitude, 37.302795);
     expect(detail.longitude, 126.866489);
     expect(detail.dataQualityLabel, '기본 정보만 확인됨');
+    expect(detail.dataSourceLabel, '출처 공식 파일');
     expect(detail.lines.single.stationCode, '448');
     expect(exits.single.name, '1번 출구');
     expect(exits.single.latitude, 37.302795);
     expect(exits.single.longitude, 126.866489);
     expect(exits.single.elevatorConnectionLabel, '엘리베이터 연결');
     expect(exits.single.stairPathLabel, '계단 없는 이동 가능');
+    expect(exits.single.dataSourceLabel, '출처 공식 파일');
     expect(facilities.single.typeLabel, '엘리베이터');
     expect(facilities.single.latitude, 37.302795);
     expect(facilities.single.longitude, 126.866489);
     expect(facilities.single.statusLabel, '정상');
     expect(facilities.single.confidenceLabel, '정보 신뢰도 높음');
+    expect(facilities.single.dataSourceLabel, '출처 공식 파일');
   });
 
   test('즐겨찾기 역 API 저장소는 인증 헤더와 함께 목록을 요청하고 결과를 파싱한다', () async {
@@ -624,7 +632,7 @@ void main() {
     expect(ramp.confidenceLabel, '정보 확인 필요');
     expect(
       ramp.semanticLabel,
-      '1번 출구 경사로, 경사로, 공사 중, 1F-B1, 최근 확인 2026-06-13, 정보 확인 필요',
+      '1번 출구 경사로, 경사로, 공사 중, 1F-B1, 최근 확인 2026-06-13, 정보 확인 필요, 출처 확인 필요',
     );
     expect(customerCenter.typeLabel, '고객센터');
     expect(customerCenter.statusLabel, '검수 완료');

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -567,6 +567,7 @@ void main() {
           hasElevatorConnection: true,
           hasStairOnlyPath: false,
           dataConfidence: 'HIGH',
+          dataSourceType: 'OFFICIAL_FILE',
         ),
       ],
       stationFacilities: const [
@@ -581,6 +582,7 @@ void main() {
           description: '1번 출구 앞',
           status: 'NORMAL',
           dataConfidence: 'HIGH',
+          dataSourceType: 'OFFICIAL_FILE',
           lastUpdatedAt: '2026-06-12',
         ),
       ],
@@ -616,24 +618,27 @@ void main() {
       expect(find.text('상록수역'), findsOneWidget);
       expect(find.text('수도권 2호선'), findsOneWidget);
       expect(find.text('기본 정보만 확인됨'), findsOneWidget);
+      expect(find.text('출처 공식 파일'), findsWidgets);
       expect(find.text('마지막 확인 2026-06-13'), findsOneWidget);
       expect(find.text('출구'), findsOneWidget);
       expect(find.text('1번 출구'), findsOneWidget);
       expect(find.text('엘리베이터 연결'), findsOneWidget);
       expect(find.text('계단 없는 이동 가능'), findsOneWidget);
-      expect(find.text('시설'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
-          '상록수역 상세 정보, 수도권 2호선, 기본 정보만 확인됨, 마지막 확인 2026-06-13',
+          '상록수역 상세 정보, 수도권 2호선, 기본 정보만 확인됨, 출처 공식 파일, 마지막 확인 2026-06-13',
         ),
         findsOneWidget,
       );
       expect(
-        find.bySemanticsLabel('1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 정보 신뢰도 높음'),
+        find.bySemanticsLabel(
+          '1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 정보 신뢰도 높음, 출처 공식 파일',
+        ),
         findsOneWidget,
       );
       await tester.drag(find.byType(ListView), const Offset(0, -260));
       await tester.pumpAndSettle();
+      expect(find.text('시설'), findsOneWidget);
       expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
       expect(find.text('엘리베이터'), findsOneWidget);
       expect(find.text('정상'), findsOneWidget);
@@ -641,7 +646,7 @@ void main() {
       expect(find.text('최근 확인 2026-06-12'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
-          '1번 출구 엘리베이터, 엘리베이터, 정상, 1번 출구 앞, 최근 확인 2026-06-12, 정보 신뢰도 높음',
+          '1번 출구 엘리베이터, 엘리베이터, 정상, 1번 출구 앞, 최근 확인 2026-06-12, 정보 신뢰도 높음, 출처 공식 파일',
         ),
         findsOneWidget,
       );
@@ -1678,6 +1683,7 @@ StationSearchResult _stationResult({required String id, required String name}) {
     nameEn: id,
     region: '수도권',
     dataQualityLevel: 'LEVEL_1',
+    dataSourceType: 'OFFICIAL_FILE',
     lastVerifiedAt: '2026-06-13',
     lines: const [
       StationSearchLine(
@@ -1697,6 +1703,7 @@ StationDetail _stationDetail({required String id, required String name}) {
     nameEn: id,
     region: '수도권',
     dataQualityLevel: 'LEVEL_1',
+    dataSourceType: 'OFFICIAL_FILE',
     lastVerifiedAt: '2026-06-13',
     lines: const [
       StationSearchLine(

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
@@ -167,6 +167,7 @@ class TransitMasterController {
 		String nameEn,
 		String region,
 		DataQualityLevel dataQualityLevel,
+		DataSourceType dataSourceType,
 		LocalDate lastVerifiedAt,
 		List<StationLineResponse> lines
 	) {
@@ -179,6 +180,7 @@ class TransitMasterController {
 				station.nameEn(),
 				station.region(),
 				station.dataQualityLevel(),
+				station.dataSourceType(),
 				station.lastVerifiedAt(),
 				stationWithLines.lines()
 					.stream()
@@ -196,6 +198,7 @@ class TransitMasterController {
 		BigDecimal latitude,
 		BigDecimal longitude,
 		DataQualityLevel dataQualityLevel,
+		DataSourceType dataSourceType,
 		LocalDate lastVerifiedAt,
 		List<StationLineResponse> lines
 	) {
@@ -210,6 +213,7 @@ class TransitMasterController {
 				station.latitude(),
 				station.longitude(),
 				station.dataQualityLevel(),
+				station.dataSourceType(),
 				station.lastVerifiedAt(),
 				stationWithLines.lines()
 					.stream()
@@ -251,7 +255,8 @@ class TransitMasterController {
 		BigDecimal longitude,
 		boolean hasElevatorConnection,
 		boolean hasStairOnlyPath,
-		DataConfidenceLevel dataConfidence
+		DataConfidenceLevel dataConfidence,
+		DataSourceType dataSourceType
 	) {
 
 		static StationExitResponse from(StationExit exit) {
@@ -264,7 +269,8 @@ class TransitMasterController {
 				exit.longitude(),
 				exit.hasElevatorConnection(),
 				exit.hasStairOnlyPath(),
-				exit.dataConfidence()
+				exit.dataConfidence(),
+				exit.dataSourceType()
 			);
 		}
 	}
@@ -282,6 +288,7 @@ class TransitMasterController {
 		String description,
 		AccessibilityFacilityStatus status,
 		DataConfidenceLevel dataConfidence,
+		DataSourceType dataSourceType,
 		LocalDate lastUpdatedAt
 	) {
 
@@ -299,6 +306,7 @@ class TransitMasterController {
 				facility.description(),
 				facility.status(),
 				facility.dataConfidence(),
+				facility.dataSourceType(),
 				facility.lastUpdatedAt()
 			);
 		}

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -58,6 +58,7 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 			new BigDecimal("37.302795"),
 			new BigDecimal("126.866489"),
 			DataQualityLevel.LEVEL_1,
+			DataSourceType.OFFICIAL_FILE,
 			LocalDate.of(2026, 6, 12),
 			true
 		),
@@ -69,6 +70,7 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 			new BigDecimal("37.476530"),
 			new BigDecimal("126.981685"),
 			DataQualityLevel.LEVEL_1,
+			DataSourceType.OFFICIAL_FILE,
 			LocalDate.of(2026, 6, 12),
 			true
 		)
@@ -89,7 +91,8 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 			new BigDecimal("126.866221"),
 			true,
 			false,
-			DataConfidenceLevel.HIGH
+			DataConfidenceLevel.HIGH,
+			DataSourceType.OFFICIAL_FILE
 		),
 		new StationExit(
 			"exit-sangnoksu-2",
@@ -100,7 +103,8 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 			new BigDecimal("126.866768"),
 			false,
 			true,
-			DataConfidenceLevel.MEDIUM
+			DataConfidenceLevel.MEDIUM,
+			DataSourceType.OFFICIAL_FILE
 		)
 	);
 
@@ -161,6 +165,7 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 			facility.description(),
 			status,
 			facility.dataConfidence(),
+			facility.dataSourceType(),
 			updatedAt
 		));
 	}
@@ -179,6 +184,7 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 			"1번 출구와 대합실을 연결합니다.",
 			AccessibilityFacilityStatus.NORMAL,
 			DataConfidenceLevel.HIGH,
+			DataSourceType.OFFICIAL_FILE,
 			LocalDate.of(2026, 6, 12)
 		));
 		saveSeedFacility(new AccessibilityFacility(
@@ -194,6 +200,7 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 			"1번 출구 방향 상행 에스컬레이터입니다.",
 			AccessibilityFacilityStatus.NORMAL,
 			DataConfidenceLevel.MEDIUM,
+			DataSourceType.OFFICIAL_FILE,
 			LocalDate.of(2026, 6, 12)
 		));
 		saveSeedFacility(new AccessibilityFacility(
@@ -209,6 +216,7 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 			"개찰구 안쪽 대합실에 있습니다.",
 			AccessibilityFacilityStatus.UNKNOWN,
 			DataConfidenceLevel.NEEDS_VERIFICATION,
+			DataSourceType.OFFICIAL_FILE,
 			LocalDate.of(2026, 6, 12)
 		));
 	}

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -225,6 +225,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 			facility.description(),
 			status,
 			facility.dataConfidence(),
+			facility.dataSourceType(),
 			updatedAt
 		);
 	}

--- a/backend/src/main/java/com/easysubway/transit/domain/AccessibilityFacility.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/AccessibilityFacility.java
@@ -16,6 +16,7 @@ public record AccessibilityFacility(
 	String description,
 	AccessibilityFacilityStatus status,
 	DataConfidenceLevel dataConfidence,
+	DataSourceType dataSourceType,
 	LocalDate lastUpdatedAt
 ) {
 }

--- a/backend/src/main/java/com/easysubway/transit/domain/Station.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/Station.java
@@ -11,6 +11,7 @@ public record Station(
 	BigDecimal latitude,
 	BigDecimal longitude,
 	DataQualityLevel dataQualityLevel,
+	DataSourceType dataSourceType,
 	LocalDate lastVerifiedAt,
 	boolean active
 ) {

--- a/backend/src/main/java/com/easysubway/transit/domain/StationExit.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/StationExit.java
@@ -11,6 +11,7 @@ public record StationExit(
 	BigDecimal longitude,
 	boolean hasElevatorConnection,
 	boolean hasStairOnlyPath,
-	DataConfidenceLevel dataConfidence
+	DataConfidenceLevel dataConfidence,
+	DataSourceType dataSourceType
 ) {
 }

--- a/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteFacilityServiceTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteFacilityServiceTest.java
@@ -16,6 +16,7 @@ import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.AccessibilityFacilityType;
 import com.easysubway.transit.domain.DataConfidenceLevel;
+import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLine;
@@ -197,6 +198,7 @@ class FavoriteFacilityServiceTest {
 				"연결 역 데이터가 없는 테스트 시설입니다.",
 				AccessibilityFacilityStatus.NORMAL,
 				DataConfidenceLevel.HIGH,
+				DataSourceType.OFFICIAL_FILE,
 				LocalDate.of(2026, 6, 12)
 			));
 		}

--- a/backend/src/test/java/com/easysubway/notification/application/service/FacilityStatusAlertServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notification/application/service/FacilityStatusAlertServiceTest.java
@@ -235,6 +235,7 @@ class FacilityStatusAlertServiceTest {
 				new BigDecimal("37.000000"),
 				new BigDecimal("127.000000"),
 				DataQualityLevel.LEVEL_1,
+				DataSourceType.OFFICIAL_FILE,
 				LocalDate.of(2026, 6, 12),
 				false
 			));
@@ -265,6 +266,7 @@ class FacilityStatusAlertServiceTest {
 				"운영 종료 역에 남아 있는 시설 데이터입니다.",
 				AccessibilityFacilityStatus.NORMAL,
 				DataConfidenceLevel.HIGH,
+				DataSourceType.OFFICIAL_FILE,
 				LocalDate.of(2026, 6, 12)
 			));
 		}

--- a/backend/src/test/java/com/easysubway/quality/application/service/DataQualityServiceTest.java
+++ b/backend/src/test/java/com/easysubway/quality/application/service/DataQualityServiceTest.java
@@ -8,6 +8,7 @@ import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.AccessibilityFacilityType;
 import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLine;
@@ -76,6 +77,7 @@ class DataQualityServiceTest {
 			new BigDecimal("37.302795"),
 			new BigDecimal("126.866489"),
 			qualityLevel,
+			DataSourceType.OFFICIAL_FILE,
 			LocalDate.of(2026, 6, 12),
 			true
 		);
@@ -91,7 +93,8 @@ class DataQualityServiceTest {
 			new BigDecimal("126.866100"),
 			true,
 			false,
-			confidenceLevel
+			confidenceLevel,
+			DataSourceType.OFFICIAL_FILE
 		);
 	}
 
@@ -109,6 +112,7 @@ class DataQualityServiceTest {
 			"교통약자 승강 편의시설",
 			AccessibilityFacilityStatus.NORMAL,
 			confidenceLevel,
+			DataSourceType.OFFICIAL_FILE,
 			LocalDate.of(2026, 6, 12)
 		);
 	}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -451,8 +451,8 @@ class RouteSearchServiceTest {
 		@Override
 		public List<StationExit> loadStationExits() {
 			return List.of(
-				new StationExit("exit-a-1", "station-a", "1", "1번 출구", BigDecimal.ONE, BigDecimal.ONE, false, true, DataConfidenceLevel.HIGH),
-				new StationExit("exit-b-1", "station-b", "1", "1번 출구", BigDecimal.ONE, BigDecimal.ONE, false, true, DataConfidenceLevel.HIGH)
+				new StationExit("exit-a-1", "station-a", "1", "1번 출구", BigDecimal.ONE, BigDecimal.ONE, false, true, DataConfidenceLevel.HIGH, DataSourceType.OFFICIAL_FILE),
+				new StationExit("exit-b-1", "station-b", "1", "1번 출구", BigDecimal.ONE, BigDecimal.ONE, false, true, DataConfidenceLevel.HIGH, DataSourceType.OFFICIAL_FILE)
 			);
 		}
 
@@ -483,8 +483,8 @@ class RouteSearchServiceTest {
 		@Override
 		public List<StationExit> loadStationExits() {
 			return List.of(
-				new StationExit("exit-a-1", "station-a", "1", "1번 출구", BigDecimal.ONE, BigDecimal.ONE, false, true, DataConfidenceLevel.LOW),
-				new StationExit("exit-b-1", "station-b", "1", "1번 출구", BigDecimal.ONE, BigDecimal.ONE, false, true, DataConfidenceLevel.LOW)
+				new StationExit("exit-a-1", "station-a", "1", "1번 출구", BigDecimal.ONE, BigDecimal.ONE, false, true, DataConfidenceLevel.LOW, DataSourceType.OFFICIAL_FILE),
+				new StationExit("exit-b-1", "station-b", "1", "1번 출구", BigDecimal.ONE, BigDecimal.ONE, false, true, DataConfidenceLevel.LOW, DataSourceType.OFFICIAL_FILE)
 			);
 		}
 	}
@@ -677,6 +677,7 @@ class RouteSearchServiceTest {
 			"테스트용 접근성 시설입니다.",
 			status,
 			dataConfidence,
+			DataSourceType.OFFICIAL_FILE,
 			LocalDate.of(2026, 6, 13)
 		);
 	}
@@ -703,6 +704,7 @@ class RouteSearchServiceTest {
 			BigDecimal.ONE,
 			BigDecimal.ONE,
 			DataQualityLevel.LEVEL_1,
+			DataSourceType.OFFICIAL_FILE,
 			LocalDate.of(2026, 6, 13),
 			true
 		);
@@ -718,7 +720,8 @@ class RouteSearchServiceTest {
 			BigDecimal.ONE,
 			false,
 			true,
-			DataConfidenceLevel.HIGH
+			DataConfidenceLevel.HIGH,
+			DataSourceType.OFFICIAL_FILE
 		);
 	}
 
@@ -732,7 +735,8 @@ class RouteSearchServiceTest {
 			BigDecimal.ONE,
 			true,
 			false,
-			DataConfidenceLevel.HIGH
+			DataConfidenceLevel.HIGH,
+			DataSourceType.OFFICIAL_FILE
 		);
 	}
 }

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -54,7 +54,7 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
-	@DisplayName("역 검색은 한글 역명으로 조회할 수 있다")
+	@DisplayName("역 검색은 한글 역명과 데이터 출처로 조회할 수 있다")
 	void stationsCanBeSearchedByKoreanName() throws Exception {
 		mockMvc.perform(get("/api/v1/stations").param("query", "상록수"))
 			.andExpect(status().isOk())
@@ -62,6 +62,7 @@ class TransitMasterControllerTest {
 			.andExpect(jsonPath("$.data[0].id").value("station-sangnoksu"))
 			.andExpect(jsonPath("$.data[0].nameKo").value("상록수"))
 			.andExpect(jsonPath("$.data[0].dataQualityLevel").value("LEVEL_1"))
+			.andExpect(jsonPath("$.data[0].dataSourceType").value("OFFICIAL_FILE"))
 			.andExpect(jsonPath("$.data[0].lines[0].id").value("seoul-4"));
 	}
 
@@ -77,7 +78,7 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
-	@DisplayName("역 상세는 연결 노선과 데이터 품질을 포함한다")
+	@DisplayName("역 상세는 연결 노선과 데이터 품질과 출처를 포함한다")
 	void stationDetailIncludesConnectedLinesAndQuality() throws Exception {
 		mockMvc.perform(get("/api/v1/stations/station-sangnoksu"))
 			.andExpect(status().isOk())
@@ -87,11 +88,12 @@ class TransitMasterControllerTest {
 			.andExpect(jsonPath("$.data.latitude").value(37.302795))
 			.andExpect(jsonPath("$.data.longitude").value(126.866489))
 			.andExpect(jsonPath("$.data.dataQualityLevel").value("LEVEL_1"))
+			.andExpect(jsonPath("$.data.dataSourceType").value("OFFICIAL_FILE"))
 			.andExpect(jsonPath("$.data.lines[0].stationCode").value("448"));
 	}
 
 	@Test
-	@DisplayName("역 출구 목록은 접근성 신호를 포함한다")
+	@DisplayName("역 출구 목록은 접근성 신호와 데이터 출처를 포함한다")
 	void stationExitsIncludeAccessibilitySignals() throws Exception {
 		mockMvc.perform(get("/api/v1/stations/station-sangnoksu/exits"))
 			.andExpect(status().isOk())
@@ -101,11 +103,12 @@ class TransitMasterControllerTest {
 			.andExpect(jsonPath("$.data[0].name").value("1번 출구"))
 			.andExpect(jsonPath("$.data[0].hasElevatorConnection").value(true))
 			.andExpect(jsonPath("$.data[0].hasStairOnlyPath").value(false))
+			.andExpect(jsonPath("$.data[0].dataSourceType").value("OFFICIAL_FILE"))
 			.andExpect(jsonPath("$.data[0].dataConfidence").value("HIGH"));
 	}
 
 	@Test
-	@DisplayName("역 시설 목록은 시설 유형과 상태와 신뢰도를 포함한다")
+	@DisplayName("역 시설 목록은 시설 유형과 상태와 신뢰도와 출처를 포함한다")
 	void stationFacilitiesIncludeTypeStatusAndConfidence() throws Exception {
 		mockMvc.perform(get("/api/v1/stations/station-sangnoksu/facilities"))
 			.andExpect(status().isOk())
@@ -116,6 +119,7 @@ class TransitMasterControllerTest {
 			.andExpect(jsonPath("$.data[0].exitId").value("exit-sangnoksu-1"))
 			.andExpect(jsonPath("$.data[0].status").value("NORMAL"))
 			.andExpect(jsonPath("$.data[0].dataConfidence").value("HIGH"))
+			.andExpect(jsonPath("$.data[0].dataSourceType").value("OFFICIAL_FILE"))
 			.andExpect(jsonPath("$.data[0].lastUpdatedAt").value("2026-06-12"));
 	}
 

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -286,6 +286,7 @@ class TransitMasterServiceTest {
 					new BigDecimal("37.302795"),
 					new BigDecimal("126.866489"),
 					DataQualityLevel.LEVEL_1,
+					DataSourceType.OFFICIAL_FILE,
 					LocalDate.of(2026, 6, 12),
 					true
 				)


### PR DESCRIPTION
Closes #92

## 배경

역 상세 화면은 데이터 품질과 최근 확인일은 보여주지만, 해당 정보가 어떤 출처에서 온 것인지는 사용자에게 드러나지 않았습니다. 이동에 제약이 있는 사용자는 엘리베이터, 출구, 시설 정보를 보고 바로 이동 결정을 해야 하므로 정보 출처를 숨기지 않고 짧은 문구로 확인할 수 있어야 합니다.

## 변경 사항

- 역 검색, 역 상세, 출구, 시설 API 응답에 `dataSourceType`을 추가했습니다.
- 인메모리 도시철도 마스터 데이터와 상태 갱신 경로에서 기존 공식 파일 출처를 유지하도록 연결했습니다.
- 모바일 역 상세 화면에서 역, 출구, 시설의 출처를 `출처 공식 파일`처럼 쉬운 한국어 라벨로 표시했습니다.
- 스크린리더 라벨에도 출처 문구를 포함해 화면을 보지 않고도 정보 출처를 알 수 있게 했습니다.
- 출처 값이 없거나 모르는 값이면 `출처 확인 필요`로 안내하도록 fallback을 추가했습니다.

## 검증

- `./gradlew test --tests '*TransitMasterControllerTest'`
- `./gradlew test --tests '*TransitMaster*'`
- `./gradlew test`
- `flutter test test/station_search_test.dart --plain-name "역 API 저장소는 백엔드 역 목록을 요청하고 결과를 파싱한다"`
- `flutter test test/widget_test.dart --plain-name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다"`
- `flutter test test/station_search_test.dart test/widget_test.dart`
- `flutter test`
- `flutter analyze`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`

## 리스크

- 응답 필드가 추가되지만 기존 필드는 제거하지 않아 기존 클라이언트 호환성 영향은 낮습니다.
- 실제 수집기나 데이터베이스 영속화 구조는 아직 없어서, 이번 변경은 현재 마스터 데이터 모델과 API/모바일 표시 계약을 먼저 고정합니다.
