### PR TITLE
[Feat] 즐겨찾기 데이터 출처 표시

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -358,6 +358,7 @@ class FavoriteStation {
     required this.nameEn,
     required this.region,
     required this.dataQualityLevel,
+    this.dataSourceType = '',
     required this.lastVerifiedAt,
     required this.lines,
     required this.addedAt,
@@ -376,6 +377,7 @@ class FavoriteStation {
       nameEn: _requiredString(json, 'nameEn'),
       region: _requiredString(json, 'region'),
       dataQualityLevel: _requiredString(json, 'dataQualityLevel'),
+      dataSourceType: _stringOrEmpty(json, 'dataSourceType'),
       lastVerifiedAt: _requiredString(json, 'lastVerifiedAt'),
       lines: rawLines
           .map((item) {
@@ -397,11 +399,14 @@ class FavoriteStation {
   final String nameEn;
   final String region;
   final String dataQualityLevel;
+  final String dataSourceType;
   final String lastVerifiedAt;
   final List<StationSearchLine> lines;
   final String addedAt;
 
   String get dataQualityLabel => _dataQualityLabel(dataQualityLevel);
+
+  String get dataSourceLabel => _dataSourceLabel(dataSourceType);
 
   String get lineLabel {
     if (lines.isEmpty) {
@@ -411,7 +416,7 @@ class FavoriteStation {
   }
 
   String get semanticLabel {
-    return '즐겨찾기 역, $nameKo, $lineLabel, $region, $dataQualityLabel';
+    return '즐겨찾기 역, $nameKo, $lineLabel, $region, $dataQualityLabel, $dataSourceLabel';
   }
 }
 
@@ -1707,6 +1712,14 @@ class _FavoriteStationTile extends StatelessWidget {
                     const SizedBox(height: 4),
                     Text(
                       favorite.dataQualityLabel,
+                      style: textTheme.bodyMedium?.copyWith(
+                        color: const Color(0xFF405A5D),
+                        height: 1.3,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      favorite.dataSourceLabel,
                       style: textTheme.bodyMedium?.copyWith(
                         color: const Color(0xFF405A5D),
                         height: 1.3,

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -222,6 +222,7 @@ void main() {
                 'nameEn': 'Sangnoksu',
                 'region': '수도권',
                 'dataQualityLevel': 'LEVEL_1',
+                'dataSourceType': 'OFFICIAL_FILE',
                 'lastVerifiedAt': '2026-06-12',
                 'lines': [
                   {
@@ -259,6 +260,7 @@ void main() {
     expect(favorites.single.nameKo, '상록수');
     expect(favorites.single.lineLabel, '수도권 4호선');
     expect(favorites.single.dataQualityLabel, '기본 정보만 확인됨');
+    expect(favorites.single.dataSourceLabel, '출처 공식 파일');
   });
 
   test('즐겨찾기 역 API 저장소는 인증 제공자가 없으면 인증 헤더를 보내지 않는다', () async {
@@ -322,6 +324,7 @@ void main() {
                 'nameEn': 'Sangnoksu',
                 'region': '수도권',
                 'dataQualityLevel': 'LEVEL_1',
+                'dataSourceType': 'OFFICIAL_FILE',
                 'lastVerifiedAt': '2026-06-12',
                 'lines': [
                   {
@@ -377,6 +380,7 @@ void main() {
               'nameEn': 'Sangnoksu',
               'region': '수도권',
               'dataQualityLevel': 'LEVEL_1',
+              'dataSourceType': 'OFFICIAL_FILE',
               'lastVerifiedAt': '2026-06-12',
               'lines': const [],
               'addedAt': '2026-06-13T10:00:00',

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -432,9 +432,12 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.bySemanticsLabel('즐겨찾기 역, 상록수, 수도권 4호선, 수도권, 기본 정보만 확인됨'),
+        find.bySemanticsLabel(
+          '즐겨찾기 역, 상록수, 수도권 4호선, 수도권, 기본 정보만 확인됨, 출처 공식 파일',
+        ),
         findsOneWidget,
       );
+      expect(find.text('출처 공식 파일'), findsOneWidget);
 
       final tileSize = tester.getSize(
         find.byKey(const Key('favoriteStationTile-station-sangnoksu')),
@@ -1366,6 +1369,7 @@ FavoriteStation _favoriteStation({required String id, required String name}) {
     nameEn: id,
     region: '수도권',
     dataQualityLevel: 'LEVEL_1',
+    dataSourceType: 'OFFICIAL_FILE',
     lastVerifiedAt: '2026-06-13',
     lines: const [
       StationSearchLine(

--- a/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteFacilityController.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteFacilityController.java
@@ -10,6 +10,7 @@ import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.AccessibilityFacilityType;
 import com.easysubway.transit.domain.DataConfidenceLevel;
+import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.Station;
 import java.security.Principal;
 import java.time.LocalDate;
@@ -77,6 +78,7 @@ class FavoriteFacilityController {
 		String description,
 		AccessibilityFacilityStatus status,
 		DataConfidenceLevel dataConfidence,
+		DataSourceType dataSourceType,
 		LocalDate lastUpdatedAt,
 		LocalDateTime addedAt
 	) {
@@ -98,6 +100,7 @@ class FavoriteFacilityController {
 				facility.description(),
 				facility.status(),
 				facility.dataConfidence(),
+				facility.dataSourceType(),
 				facility.lastUpdatedAt(),
 				favoriteFacility.favoriteFacility().addedAt()
 			);

--- a/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteStationController.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteStationController.java
@@ -7,6 +7,7 @@ import com.easysubway.favorite.application.port.in.RemoveFavoriteStationCommand;
 import com.easysubway.favorite.application.port.in.SaveFavoriteStationCommand;
 import com.easysubway.favorite.domain.FavoriteStationWithDetails;
 import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationLineSummary;
 import java.security.Principal;
@@ -65,6 +66,7 @@ class FavoriteStationController {
 		String nameEn,
 		String region,
 		DataQualityLevel dataQualityLevel,
+		DataSourceType dataSourceType,
 		LocalDate lastVerifiedAt,
 		List<FavoriteStationLineResponse> lines,
 		LocalDateTime addedAt
@@ -79,6 +81,7 @@ class FavoriteStationController {
 				station.nameEn(),
 				station.region(),
 				station.dataQualityLevel(),
+				station.dataSourceType(),
 				station.lastVerifiedAt(),
 				favoriteStation.station().lines()
 					.stream()

--- a/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteFacilityControllerTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteFacilityControllerTest.java
@@ -27,7 +27,7 @@ class FavoriteFacilityControllerTest {
 	private MockMvc mockMvc;
 
 	@Test
-	@DisplayName("인증 사용자 기준으로 시설을 저장하고 목록 조회와 삭제를 처리한다")
+	@DisplayName("인증 사용자 기준으로 시설을 저장하고 데이터 출처와 함께 목록 조회와 삭제를 처리한다")
 	void favoriteFacilitiesCanBeSavedListedAndRemoved() throws Exception {
 		mockMvc.perform(put("/api/v1/me/favorites/facilities/facility-sangnoksu-elevator-1")
 				.with(httpBasic("anonymous-user-1", "user-test-password"))
@@ -47,6 +47,7 @@ class FavoriteFacilityControllerTest {
 			.andExpect(jsonPath("$.data.type").value("ELEVATOR"))
 			.andExpect(jsonPath("$.data.status").value("NORMAL"))
 			.andExpect(jsonPath("$.data.dataConfidence").value("HIGH"))
+			.andExpect(jsonPath("$.data.dataSourceType").value("OFFICIAL_FILE"))
 			.andExpect(jsonPath("$.data.lastUpdatedAt").value("2026-06-12"))
 			.andExpect(jsonPath("$.data.addedAt").isNotEmpty());
 
@@ -56,7 +57,8 @@ class FavoriteFacilityControllerTest {
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data[0].facilityId").value("facility-sangnoksu-elevator-1"))
 			.andExpect(jsonPath("$.data[0].stationNameKo").value("상록수"))
-			.andExpect(jsonPath("$.data[0].name").value("1번 출구 엘리베이터"));
+			.andExpect(jsonPath("$.data[0].name").value("1번 출구 엘리베이터"))
+			.andExpect(jsonPath("$.data[0].dataSourceType").value("OFFICIAL_FILE"));
 
 		mockMvc.perform(delete("/api/v1/me/favorites/facilities/facility-sangnoksu-elevator-1")
 				.with(httpBasic("anonymous-user-1", "user-test-password")))

--- a/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteStationControllerTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/in/web/FavoriteStationControllerTest.java
@@ -27,7 +27,7 @@ class FavoriteStationControllerTest {
 	private MockMvc mockMvc;
 
 	@Test
-	@DisplayName("인증 사용자 기준으로 역을 저장하고 목록 조회와 삭제를 처리한다")
+	@DisplayName("인증 사용자 기준으로 역을 저장하고 데이터 출처와 함께 목록 조회와 삭제를 처리한다")
 	void favoriteStationsCanBeSavedListedAndRemoved() throws Exception {
 		mockMvc.perform(put("/api/v1/me/favorites/stations/station-sangnoksu")
 				.with(httpBasic("anonymous-user-1", "user-test-password"))
@@ -44,6 +44,7 @@ class FavoriteStationControllerTest {
 			.andExpect(jsonPath("$.data.nameKo").value("상록수"))
 			.andExpect(jsonPath("$.data.region").value("수도권"))
 			.andExpect(jsonPath("$.data.dataQualityLevel").value("LEVEL_1"))
+			.andExpect(jsonPath("$.data.dataSourceType").value("OFFICIAL_FILE"))
 			.andExpect(jsonPath("$.data.lines[0].name").value("수도권 4호선"))
 			.andExpect(jsonPath("$.data.addedAt").isNotEmpty());
 
@@ -52,7 +53,8 @@ class FavoriteStationControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data[0].stationId").value("station-sangnoksu"))
-			.andExpect(jsonPath("$.data[0].nameKo").value("상록수"));
+			.andExpect(jsonPath("$.data[0].nameKo").value("상록수"))
+			.andExpect(jsonPath("$.data[0].dataSourceType").value("OFFICIAL_FILE"));
 
 		mockMvc.perform(delete("/api/v1/me/favorites/stations/station-sangnoksu")
 				.with(httpBasic("anonymous-user-1", "user-test-password")))


### PR DESCRIPTION
Closes #94

## 배경
즐겨찾기 화면은 사용자가 자주 다시 확인하는 이동 정보 진입점입니다. 검색 결과에서는 데이터 출처를 확인할 수 있지만 즐겨찾기 목록에서는 출처가 보이지 않아, 저장한 역 정보가 어떤 기준 데이터에서 온 것인지 바로 판단하기 어려웠습니다.

## 변경 사항
- 즐겨찾기 역 응답에 `dataSourceType`을 포함했습니다.
- 즐겨찾기 시설 응답에 `dataSourceType`을 포함했습니다.
- 모바일 즐겨찾기 역 카드에 한국어 데이터 출처 라벨을 표시했습니다.
- 스크린리더 의미 라벨에도 데이터 출처를 포함했습니다.
- 출처 값이 없거나 알 수 없는 경우 기존 공통 라벨 규칙에 따라 `출처 확인 필요`로 표시되도록 파싱 경로를 연결했습니다.

## 검증
- `./gradlew test --tests '*FavoriteStationControllerTest' --tests '*FavoriteFacilityControllerTest'`
- `./gradlew test --tests '*Favorite*'`
- `./gradlew test`
- `flutter test test/widget_test.dart --plain-name "홈 즐겨찾기는 저장한 역을 큰 목록으로 보여준다"`
- `flutter test test/station_search_test.dart --plain-name "즐겨찾기 역 API 저장소는 인증 헤더와 함께 목록을 요청하고 결과를 파싱한다"`
- `flutter test test/station_search_test.dart test/widget_test.dart`
- `flutter test`
- `flutter analyze`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`

## 리스크
- 응답 필드 추가만 포함하며 기존 필드를 제거하지 않았습니다.
- 모바일에는 현재 즐겨찾기 역 목록 화면만 있어 역 카드 출처 표시를 먼저 반영했습니다. 즐겨찾기 시설 목록 화면이 추가될 때 동일 필드를 바로 사용할 수 있도록 백엔드 응답 계약은 함께 고정했습니다.
