### PR TITLE
[Feat] 즐겨찾기 시설 목록 화면 연결

### DIFF
--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -1,0 +1,570 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import 'auth_headers.dart';
+import 'mobile_error_reporter.dart';
+
+const _favoriteFacilityTimeout = Duration(seconds: 8);
+const _favoriteFacilityLoadErrorMessage = '즐겨찾기 시설을 불러오지 못했습니다.';
+
+abstract class FavoriteFacilityRepository {
+  Future<List<FavoriteFacility>> listFavoriteFacilities();
+}
+
+class FavoriteFacilityApiRepository implements FavoriteFacilityRepository {
+  FavoriteFacilityApiRepository({
+    required this.baseUri,
+    required this.authProvider,
+    HttpClient? httpClient,
+  }) : _httpClient = httpClient ?? HttpClient();
+
+  final Uri baseUri;
+  final AuthorizationHeaderProvider authProvider;
+  final HttpClient _httpClient;
+
+  @override
+  Future<List<FavoriteFacility>> listFavoriteFacilities() async {
+    final data = await _requestData(
+      'GET',
+      baseUri.resolve('/api/v1/me/favorites/facilities'),
+      errorMessage: _favoriteFacilityLoadErrorMessage,
+    );
+    if (data is! List) {
+      throw const FavoriteFacilityException(_favoriteFacilityLoadErrorMessage);
+    }
+
+    try {
+      return data
+          .map((item) {
+            if (item is! Map<String, Object?>) {
+              throw const FormatException('Invalid favorite facility payload');
+            }
+            return FavoriteFacility.fromJson(item);
+          })
+          .toList(growable: false);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '즐겨찾기 시설 목록 응답 처리 중 예외가 발생했습니다.',
+      );
+      throw const FavoriteFacilityException(_favoriteFacilityLoadErrorMessage);
+    }
+  }
+
+  Future<Object?> _requestData(
+    String method,
+    Uri uri, {
+    required String errorMessage,
+  }) async {
+    for (var attempt = 0; attempt < 2; attempt++) {
+      try {
+        final request = await _httpClient
+            .openUrl(method, uri)
+            .timeout(_favoriteFacilityTimeout);
+        final authorizationHeader = await authProvider
+            .authorizationHeader()
+            .timeout(_favoriteFacilityTimeout);
+        if (authorizationHeader != null) {
+          request.headers.set(
+            HttpHeaders.authorizationHeader,
+            authorizationHeader,
+          );
+        }
+
+        final response = await request.close().timeout(
+          _favoriteFacilityTimeout,
+        );
+        final body = await utf8
+            .decodeStream(response)
+            .timeout(_favoriteFacilityTimeout);
+
+        if (response.statusCode == HttpStatus.unauthorized &&
+            authorizationHeader != null &&
+            attempt == 0) {
+          // 저장된 익명 인증이 만료된 경우 비우고 새 인증으로 한 번만 다시 시도한다.
+          await authProvider.invalidateAuthorization().timeout(
+            _favoriteFacilityTimeout,
+          );
+          continue;
+        }
+
+        if (response.statusCode < HttpStatus.ok ||
+            response.statusCode >= HttpStatus.multipleChoices) {
+          throw FavoriteFacilityException(errorMessage);
+        }
+
+        final decoded = jsonDecode(body);
+        if (decoded is! Map<String, Object?> || decoded['success'] != true) {
+          throw FavoriteFacilityException(errorMessage);
+        }
+        return decoded['data'];
+      } on FavoriteFacilityException {
+        rethrow;
+      } catch (error, stackTrace) {
+        reportMobileError(
+          error,
+          stackTrace,
+          context: '즐겨찾기 시설 API 요청 처리 중 예외가 발생했습니다.',
+        );
+        throw FavoriteFacilityException(errorMessage);
+      }
+    }
+    throw FavoriteFacilityException(errorMessage);
+  }
+}
+
+class FavoriteFacilityException implements Exception {
+  const FavoriteFacilityException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class FavoriteFacility {
+  const FavoriteFacility({
+    required this.userId,
+    required this.facilityId,
+    required this.stationId,
+    required this.stationNameKo,
+    required this.stationNameEn,
+    required this.exitId,
+    required this.type,
+    required this.name,
+    required this.floorFrom,
+    required this.floorTo,
+    required this.description,
+    required this.status,
+    required this.dataConfidence,
+    this.dataSourceType = '',
+    required this.lastUpdatedAt,
+    required this.addedAt,
+  });
+
+  factory FavoriteFacility.fromJson(Map<String, Object?> json) {
+    return FavoriteFacility(
+      userId: _requiredString(json, 'userId'),
+      facilityId: _requiredString(json, 'facilityId'),
+      stationId: _requiredString(json, 'stationId'),
+      stationNameKo: _requiredString(json, 'stationNameKo'),
+      stationNameEn: _requiredString(json, 'stationNameEn'),
+      exitId: _stringOrEmpty(json, 'exitId'),
+      type: _requiredString(json, 'type'),
+      name: _requiredString(json, 'name'),
+      floorFrom: _stringOrEmpty(json, 'floorFrom'),
+      floorTo: _stringOrEmpty(json, 'floorTo'),
+      description: _stringOrEmpty(json, 'description'),
+      status: _requiredString(json, 'status'),
+      dataConfidence: _requiredString(json, 'dataConfidence'),
+      dataSourceType: _stringOrEmpty(json, 'dataSourceType'),
+      lastUpdatedAt: _requiredString(json, 'lastUpdatedAt'),
+      addedAt: _requiredString(json, 'addedAt'),
+    );
+  }
+
+  final String userId;
+  final String facilityId;
+  final String stationId;
+  final String stationNameKo;
+  final String stationNameEn;
+  final String exitId;
+  final String type;
+  final String name;
+  final String floorFrom;
+  final String floorTo;
+  final String description;
+  final String status;
+  final String dataConfidence;
+  final String dataSourceType;
+  final String lastUpdatedAt;
+  final String addedAt;
+
+  String get stationLabel => '$stationNameKo역';
+
+  String get typeLabel {
+    return switch (type) {
+      'ELEVATOR' => '엘리베이터',
+      'ESCALATOR' => '에스컬레이터',
+      'WHEELCHAIR_LIFT' => '휠체어 리프트',
+      'RAMP' => '경사로',
+      'ACCESSIBLE_TOILET' => '장애인 화장실',
+      'TOILET' => '화장실',
+      'NURSING_ROOM' => '수유실',
+      'CUSTOMER_CENTER' => '고객센터',
+      'STATION_OFFICE' => '역무실',
+      _ => '시설',
+    };
+  }
+
+  String get statusLabel {
+    return switch (status) {
+      'NORMAL' => '정상',
+      'BROKEN' => '고장',
+      'UNDER_CONSTRUCTION' => '공사 중',
+      'CONSTRUCTION' => '공사 중',
+      'CLOSED' => '폐쇄',
+      'UNKNOWN' => '확인 필요',
+      'USER_REPORTED' => '제보됨',
+      'ADMIN_VERIFIED' => '검수 완료',
+      'NEEDS_REPORT' => '제보 필요',
+      'NEEDS_CHECK' => '확인 필요',
+      _ => '상태 확인 필요',
+    };
+  }
+
+  String get confidenceLabel => _dataConfidenceLabel(dataConfidence);
+
+  String get dataSourceLabel => _dataSourceLabel(dataSourceType);
+
+  String get locationLabel {
+    if (description.trim().isNotEmpty) {
+      return description;
+    }
+    if (floorFrom.trim().isNotEmpty && floorTo.trim().isNotEmpty) {
+      return '$floorFrom-$floorTo';
+    }
+    return '위치 확인 필요';
+  }
+
+  String get semanticLabel {
+    return '즐겨찾기 시설, $name, $stationLabel, $typeLabel, $statusLabel, $locationLabel, $confidenceLabel, $dataSourceLabel';
+  }
+}
+
+enum FavoriteFacilityListStatus { loading, success, empty, failure }
+
+class FavoriteFacilityListState {
+  const FavoriteFacilityListState({
+    required this.status,
+    required this.favorites,
+    this.message = '',
+  });
+
+  const FavoriteFacilityListState.loading()
+    : status = FavoriteFacilityListStatus.loading,
+      favorites = const [],
+      message = '';
+
+  final FavoriteFacilityListStatus status;
+  final List<FavoriteFacility> favorites;
+  final String message;
+}
+
+class FavoriteFacilityListController extends ChangeNotifier {
+  FavoriteFacilityListController({required this.repository});
+
+  final FavoriteFacilityRepository repository;
+
+  FavoriteFacilityListState _state = const FavoriteFacilityListState.loading();
+  bool _isDisposed = false;
+
+  FavoriteFacilityListState get state => _state;
+
+  Future<void> load() async {
+    _emitState(const FavoriteFacilityListState.loading());
+
+    try {
+      final favorites = await repository.listFavoriteFacilities();
+      if (favorites.isEmpty) {
+        _emitState(
+          const FavoriteFacilityListState(
+            status: FavoriteFacilityListStatus.empty,
+            favorites: [],
+            message: '저장한 시설이 없습니다.',
+          ),
+        );
+        return;
+      }
+      _emitState(
+        FavoriteFacilityListState(
+          status: FavoriteFacilityListStatus.success,
+          favorites: favorites,
+        ),
+      );
+    } on FavoriteFacilityException catch (error) {
+      _emitState(
+        FavoriteFacilityListState(
+          status: FavoriteFacilityListStatus.failure,
+          favorites: const [],
+          message: error.message,
+        ),
+      );
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '즐겨찾기 시설 화면 처리 중 예외가 발생했습니다.',
+      );
+      _emitState(
+        const FavoriteFacilityListState(
+          status: FavoriteFacilityListStatus.failure,
+          favorites: [],
+          message: _favoriteFacilityLoadErrorMessage,
+        ),
+      );
+    }
+  }
+
+  void _emitState(FavoriteFacilityListState nextState) {
+    if (_isDisposed) {
+      return;
+    }
+    _state = nextState;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
+  }
+}
+
+class FavoriteFacilityListScreen extends StatefulWidget {
+  const FavoriteFacilityListScreen({required this.repository, super.key});
+
+  final FavoriteFacilityRepository repository;
+
+  @override
+  State<FavoriteFacilityListScreen> createState() =>
+      _FavoriteFacilityListScreenState();
+}
+
+class _FavoriteFacilityListScreenState
+    extends State<FavoriteFacilityListScreen> {
+  late final FavoriteFacilityListController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = FavoriteFacilityListController(repository: widget.repository);
+    unawaited(_controller.load());
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('즐겨찾기 시설')),
+      body: SafeArea(
+        child: AnimatedBuilder(
+          animation: _controller,
+          builder: (context, _) {
+            return _FavoriteFacilityListBody(
+              state: _controller.state,
+              onRetry: _controller.load,
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _FavoriteFacilityListBody extends StatelessWidget {
+  const _FavoriteFacilityListBody({required this.state, required this.onRetry});
+
+  final FavoriteFacilityListState state;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (state.status) {
+      FavoriteFacilityListStatus.loading => Semantics(
+        label: '즐겨찾기 시설 불러오는 중',
+        liveRegion: true,
+        child: const Center(child: CircularProgressIndicator()),
+      ),
+      FavoriteFacilityListStatus.empty => Padding(
+        padding: const EdgeInsets.all(20),
+        child: _FavoriteFacilityMessage(
+          message: state.message,
+          liveRegion: true,
+        ),
+      ),
+      FavoriteFacilityListStatus.failure => Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _FavoriteFacilityMessage(message: state.message, liveRegion: true),
+            const SizedBox(height: 16),
+            OutlinedButton.icon(
+              key: const Key('favoriteFacilitiesRetryButton'),
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('다시 불러오기'),
+            ),
+          ],
+        ),
+      ),
+      FavoriteFacilityListStatus.success => ListView(
+        padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+        children: [
+          Semantics(
+            label: '즐겨찾기 시설 ${state.favorites.length}개',
+            liveRegion: true,
+            child: const SizedBox.shrink(),
+          ),
+          for (final favorite in state.favorites)
+            _FavoriteFacilityTile(favorite: favorite),
+        ],
+      ),
+    };
+  }
+}
+
+class _FavoriteFacilityTile extends StatelessWidget {
+  const _FavoriteFacilityTile({required this.favorite});
+
+  final FavoriteFacility favorite;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return MergeSemantics(
+      child: Semantics(
+        label: favorite.semanticLabel,
+        child: ExcludeSemantics(
+          child: Card(
+            key: Key('favoriteFacilityTile-${favorite.facilityId}'),
+            margin: const EdgeInsets.only(bottom: 12),
+            color: Colors.white,
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: const BorderSide(color: Color(0xFFD5E2E4)),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    favorite.name,
+                    style: textTheme.titleLarge?.copyWith(
+                      color: const Color(0xFF102A2C),
+                      fontWeight: FontWeight.w900,
+                      height: 1.25,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    favorite.stationLabel,
+                    style: textTheme.bodyLarge?.copyWith(
+                      color: const Color(0xFF29484B),
+                      fontWeight: FontWeight.w800,
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    favorite.statusLabel,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: const Color(0xFF405A5D),
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    favorite.locationLabel,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: const Color(0xFF405A5D),
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    favorite.confidenceLabel,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: const Color(0xFF405A5D),
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    favorite.dataSourceLabel,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: const Color(0xFF405A5D),
+                      height: 1.3,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FavoriteFacilityMessage extends StatelessWidget {
+  const _FavoriteFacilityMessage({
+    required this.message,
+    required this.liveRegion,
+  });
+
+  final String message;
+  final bool liveRegion;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      liveRegion: liveRegion,
+      child: Text(
+        message,
+        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+          color: const Color(0xFF102A2C),
+          fontWeight: FontWeight.w800,
+          height: 1.35,
+        ),
+      ),
+    );
+  }
+}
+
+String _requiredString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is String && value.trim().isNotEmpty) {
+    return value;
+  }
+  throw FormatException('Missing required favorite facility field: $key');
+}
+
+String _stringOrEmpty(Map<String, Object?> json, String key) {
+  final value = json[key];
+  return value is String ? value : '';
+}
+
+String _dataConfidenceLabel(String dataConfidence) {
+  return switch (dataConfidence) {
+    'HIGH' => '정보 신뢰도 높음',
+    'MEDIUM' => '정보 신뢰도 보통',
+    'LOW' => '정보 확인 필요',
+    _ => '정보 확인 필요',
+  };
+}
+
+String _dataSourceLabel(String dataSourceType) {
+  return switch (dataSourceType) {
+    'OFFICIAL_API' => '출처 공공 API',
+    'OFFICIAL_FILE' => '출처 공식 파일',
+    'OPERATOR_PAGE' => '출처 운영기관 페이지',
+    'USER_REPORT' => '출처 사용자 제보',
+    'ADMIN_VERIFIED' => '출처 관리자 검수',
+    'PARTNER_FEED' => '출처 제휴 데이터',
+    _ => '출처 확인 필요',
+  };
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'anonymous_auth.dart';
 import 'auth_headers.dart';
 import 'facility_report.dart';
+import 'favorite_facility.dart';
 import 'mobility_profile.dart';
 import 'notification_settings.dart';
 import 'onboarding.dart';
@@ -20,6 +21,7 @@ class EasySubwayApp extends StatelessWidget {
     FacilityReportRepository? reportRepository,
     RouteSearchRepository? routeRepository,
     FavoriteStationRepository? favoriteRepository,
+    FavoriteFacilityRepository? favoriteFacilityRepository,
     NotificationSettingsRepository? notificationRepository,
     AnonymousAuthRepository? anonymousAuthRepository,
     OnboardingResultStore? onboardingStore,
@@ -32,6 +34,7 @@ class EasySubwayApp extends StatelessWidget {
            reportRepository: reportRepository,
            routeRepository: routeRepository,
            favoriteRepository: favoriteRepository,
+           favoriteFacilityRepository: favoriteFacilityRepository,
            notificationRepository: notificationRepository,
            anonymousAuthRepository: anonymousAuthRepository,
            enableAnonymousAuth: enableAnonymousAuth,
@@ -50,12 +53,14 @@ class EasySubwayApp extends StatelessWidget {
        reportRepository = dependencies.reportRepository,
        routeRepository = dependencies.routeRepository,
        favoriteRepository = dependencies.favoriteRepository,
+       favoriteFacilityRepository = dependencies.favoriteFacilityRepository,
        notificationRepository = dependencies.notificationRepository;
 
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
   final FavoriteStationRepository? favoriteRepository;
+  final FavoriteFacilityRepository? favoriteFacilityRepository;
   final NotificationSettingsRepository? notificationRepository;
   final OnboardingState initialOnboardingState;
   final OnboardingResultStore? onboardingStore;
@@ -108,6 +113,7 @@ class EasySubwayApp extends StatelessWidget {
         reportRepository: reportRepository,
         routeRepository: routeRepository,
         favoriteRepository: favoriteRepository,
+        favoriteFacilityRepository: favoriteFacilityRepository,
         notificationRepository: notificationRepository,
         initialOnboardingState: initialOnboardingState,
         onboardingStore: onboardingStore,
@@ -122,6 +128,7 @@ class _EasySubwayHome extends StatefulWidget {
     required this.reportRepository,
     required this.routeRepository,
     required this.favoriteRepository,
+    required this.favoriteFacilityRepository,
     required this.notificationRepository,
     required this.initialOnboardingState,
     required this.onboardingStore,
@@ -131,6 +138,7 @@ class _EasySubwayHome extends StatefulWidget {
   final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
   final FavoriteStationRepository? favoriteRepository;
+  final FavoriteFacilityRepository? favoriteFacilityRepository;
   final NotificationSettingsRepository? notificationRepository;
   final OnboardingState initialOnboardingState;
   final OnboardingResultStore? onboardingStore;
@@ -185,6 +193,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         reportRepository: widget.reportRepository,
         routeRepository: widget.routeRepository,
         favoriteRepository: widget.favoriteRepository,
+        favoriteFacilityRepository: widget.favoriteFacilityRepository,
         notificationRepository: widget.notificationRepository,
         initialMobilityType: onboardingResult?.profile.mobilityType,
         simpleViewEnabled: preferences.simpleViewEnabled,
@@ -297,6 +306,7 @@ class _EasySubwayAppDependencies {
     required this.reportRepository,
     required this.routeRepository,
     required this.favoriteRepository,
+    required this.favoriteFacilityRepository,
     required this.notificationRepository,
   });
 
@@ -305,6 +315,7 @@ class _EasySubwayAppDependencies {
     FacilityReportRepository? reportRepository,
     RouteSearchRepository? routeRepository,
     FavoriteStationRepository? favoriteRepository,
+    FavoriteFacilityRepository? favoriteFacilityRepository,
     NotificationSettingsRepository? notificationRepository,
     AnonymousAuthRepository? anonymousAuthRepository,
     required bool enableAnonymousAuth,
@@ -328,6 +339,12 @@ class _EasySubwayAppDependencies {
             baseUri: baseUri,
             authProvider: sharedAuthProvider,
           ),
+      favoriteFacilityRepository:
+          favoriteFacilityRepository ??
+          _defaultFavoriteFacilityRepository(
+            baseUri: baseUri,
+            authProvider: sharedAuthProvider,
+          ),
       notificationRepository:
           notificationRepository ??
           _defaultNotificationSettingsRepository(
@@ -341,6 +358,7 @@ class _EasySubwayAppDependencies {
   final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
   final FavoriteStationRepository? favoriteRepository;
+  final FavoriteFacilityRepository? favoriteFacilityRepository;
   final NotificationSettingsRepository? notificationRepository;
 }
 
@@ -371,6 +389,19 @@ FavoriteStationRepository? _defaultFavoriteStationRepository({
   );
 }
 
+FavoriteFacilityRepository? _defaultFavoriteFacilityRepository({
+  required Uri baseUri,
+  required AuthorizationHeaderProvider? authProvider,
+}) {
+  if (authProvider == null) {
+    return null;
+  }
+  return FavoriteFacilityApiRepository(
+    baseUri: baseUri,
+    authProvider: authProvider,
+  );
+}
+
 NotificationSettingsRepository? _defaultNotificationSettingsRepository({
   required Uri baseUri,
   required AuthorizationHeaderProvider? authProvider,
@@ -390,6 +421,7 @@ class HomeScreen extends StatelessWidget {
     required this.reportRepository,
     required this.routeRepository,
     required this.favoriteRepository,
+    required this.favoriteFacilityRepository,
     required this.notificationRepository,
     this.simpleViewEnabled = true,
     String? initialMobilityType,
@@ -401,6 +433,7 @@ class HomeScreen extends StatelessWidget {
   final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
   final FavoriteStationRepository? favoriteRepository;
+  final FavoriteFacilityRepository? favoriteFacilityRepository;
   final NotificationSettingsRepository? notificationRepository;
   final String initialMobilityType;
   final bool simpleViewEnabled;
@@ -409,6 +442,7 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     final favoriteRepository = this.favoriteRepository;
+    final favoriteFacilityRepository = this.favoriteFacilityRepository;
     final notificationRepository = this.notificationRepository;
 
     return Scaffold(
@@ -478,7 +512,24 @@ class HomeScreen extends StatelessWidget {
                   );
                 },
                 icon: const Icon(Icons.star),
-                label: const Text('즐겨찾기'),
+                label: const Text('즐겨찾기 역'),
+              ),
+              const SizedBox(height: 12),
+            ],
+            if (favoriteFacilityRepository != null) ...[
+              FilledButton.icon(
+                key: const Key('favoriteFacilitiesButton'),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => FavoriteFacilityListScreen(
+                        repository: favoriteFacilityRepository,
+                      ),
+                    ),
+                  );
+                },
+                icon: const Icon(Icons.elevator_outlined),
+                label: const Text('즐겨찾기 시설'),
               ),
               const SizedBox(height: 12),
             ],

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1555,7 +1555,7 @@ class _FavoriteStationListScreenState extends State<FavoriteStationListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('즐겨찾기')),
+      appBar: AppBar(title: const Text('즐겨찾기 역')),
       body: SafeArea(
         child: AnimatedBuilder(
           animation: _controller,

--- a/apps/mobile/test/favorite_facility_test.dart
+++ b/apps/mobile/test/favorite_facility_test.dart
@@ -1,0 +1,195 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:easysubway_mobile/auth_headers.dart';
+import 'package:easysubway_mobile/favorite_facility.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('즐겨찾기 시설 API 저장소는 인증 헤더와 함께 목록을 요청하고 결과를 파싱한다', () async {
+    late String? authorizationHeader;
+    late Uri requestedUri;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestedUri = request.uri;
+      authorizationHeader = request.headers.value(
+        HttpHeaders.authorizationHeader,
+      );
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': [
+              {
+                'userId': 'anonymous-user-1',
+                'facilityId': 'facility-sangnoksu-elevator-1',
+                'stationId': 'station-sangnoksu',
+                'stationNameKo': '상록수',
+                'stationNameEn': 'Sangnoksu',
+                'exitId': 'exit-sangnoksu-1',
+                'type': 'ELEVATOR',
+                'name': '1번 출구 엘리베이터',
+                'floorFrom': '1F',
+                'floorTo': 'B1',
+                'description': '1번 출구 앞',
+                'status': 'NORMAL',
+                'dataConfidence': 'HIGH',
+                'dataSourceType': 'OFFICIAL_FILE',
+                'lastUpdatedAt': '2026-06-12',
+                'addedAt': '2026-06-14T10:00:00',
+              },
+            ],
+          }),
+        )
+        ..close();
+    });
+
+    final repository = FavoriteFacilityApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: const BasicAuthorizationHeaderProvider(
+        username: 'anonymous-user-1',
+        password: 'user-test-password',
+      ),
+    );
+
+    final favorites = await repository.listFavoriteFacilities();
+
+    expect(requestedUri.path, '/api/v1/me/favorites/facilities');
+    expect(
+      authorizationHeader,
+      'Basic ${base64Encode(utf8.encode('anonymous-user-1:user-test-password'))}',
+    );
+    expect(favorites.single.facilityId, 'facility-sangnoksu-elevator-1');
+    expect(favorites.single.stationNameKo, '상록수');
+    expect(favorites.single.typeLabel, '엘리베이터');
+    expect(favorites.single.statusLabel, '정상');
+    expect(favorites.single.confidenceLabel, '정보 신뢰도 높음');
+    expect(favorites.single.dataSourceLabel, '출처 공식 파일');
+    expect(
+      favorites.single.semanticLabel,
+      '즐겨찾기 시설, 1번 출구 엘리베이터, 상록수역, 엘리베이터, 정상, 1번 출구 앞, 정보 신뢰도 높음, 출처 공식 파일',
+    );
+  });
+
+  test('즐겨찾기 시설 API 저장소는 인증 실패 시 인증을 지우고 한 번 재시도한다', () async {
+    final authorizationHeaders = <String?>[];
+    var requestCount = 0;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestCount++;
+      authorizationHeaders.add(
+        request.headers.value(HttpHeaders.authorizationHeader),
+      );
+      request.response.headers.contentType = ContentType.json;
+
+      if (requestCount == 1) {
+        request.response
+          ..statusCode = HttpStatus.unauthorized
+          ..write(jsonEncode({'success': false}))
+          ..close();
+        return;
+      }
+
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..write(jsonEncode({'success': true, 'data': []}))
+        ..close();
+    });
+
+    final authProvider = RetryAuthorizationHeaderProvider();
+    final repository = FavoriteFacilityApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: authProvider,
+    );
+
+    final favorites = await repository.listFavoriteFacilities();
+
+    expect(favorites, isEmpty);
+    expect(authorizationHeaders, ['Basic stale-token', 'Basic fresh-token']);
+    expect(authProvider.authorizationCount, 2);
+    expect(authProvider.invalidateCount, 1);
+  });
+
+  test('즐겨찾기 시설 목록 컨트롤러는 목록과 빈 목록과 실패 상태를 구분한다', () async {
+    final repository = FakeFavoriteFacilityRepository();
+    final controller = FavoriteFacilityListController(repository: repository);
+    addTearDown(controller.dispose);
+
+    repository.favorites = [_favoriteFacility()];
+    await controller.load();
+
+    expect(controller.state.status, FavoriteFacilityListStatus.success);
+    expect(controller.state.favorites.single.name, '1번 출구 엘리베이터');
+
+    repository.favorites = const [];
+    await controller.load();
+
+    expect(controller.state.status, FavoriteFacilityListStatus.empty);
+    expect(controller.state.message, '저장한 시설이 없습니다.');
+
+    repository.error = const FavoriteFacilityException('즐겨찾기 시설을 불러오지 못했습니다.');
+    await controller.load();
+
+    expect(controller.state.status, FavoriteFacilityListStatus.failure);
+    expect(controller.state.message, '즐겨찾기 시설을 불러오지 못했습니다.');
+  });
+}
+
+class RetryAuthorizationHeaderProvider implements AuthorizationHeaderProvider {
+  var authorizationCount = 0;
+  var invalidateCount = 0;
+  var _invalidated = false;
+
+  @override
+  Future<String?> authorizationHeader() async {
+    authorizationCount++;
+    return _invalidated ? 'Basic fresh-token' : 'Basic stale-token';
+  }
+
+  @override
+  Future<void> invalidateAuthorization() async {
+    invalidateCount++;
+    _invalidated = true;
+  }
+}
+
+class FakeFavoriteFacilityRepository implements FavoriteFacilityRepository {
+  List<FavoriteFacility> favorites = const [];
+  Object? error;
+
+  @override
+  Future<List<FavoriteFacility>> listFavoriteFacilities() async {
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return favorites;
+  }
+}
+
+FavoriteFacility _favoriteFacility() {
+  return const FavoriteFacility(
+    userId: 'anonymous-user-1',
+    facilityId: 'facility-sangnoksu-elevator-1',
+    stationId: 'station-sangnoksu',
+    stationNameKo: '상록수',
+    stationNameEn: 'Sangnoksu',
+    exitId: 'exit-sangnoksu-1',
+    type: 'ELEVATOR',
+    name: '1번 출구 엘리베이터',
+    floorFrom: '1F',
+    floorTo: 'B1',
+    description: '1번 출구 앞',
+    status: 'NORMAL',
+    dataConfidence: 'HIGH',
+    dataSourceType: 'OFFICIAL_FILE',
+    lastUpdatedAt: '2026-06-12',
+    addedAt: '2026-06-14T10:00:00',
+  );
+}

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:easysubway_mobile/anonymous_auth.dart';
 import 'package:easysubway_mobile/main.dart';
 import 'package:easysubway_mobile/facility_report.dart';
+import 'package:easysubway_mobile/favorite_facility.dart';
 import 'package:easysubway_mobile/mobility_profile.dart';
 import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:easysubway_mobile/notification_settings.dart';
@@ -251,7 +252,7 @@ void main() {
       expect(find.text('역 찾기'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '역 검색'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '경로 검색'), findsOneWidget);
-      expect(find.widgetWithText(FilledButton, '즐겨찾기'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '즐겨찾기 역'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '알림 설정'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsOneWidget);
       expect(find.textContaining('빠른 길보다'), findsNothing);
@@ -302,7 +303,7 @@ void main() {
     );
 
     expect(find.byKey(const Key('favoriteStationsButton')), findsNothing);
-    expect(find.widgetWithText(FilledButton, '즐겨찾기'), findsNothing);
+    expect(find.widgetWithText(FilledButton, '즐겨찾기 역'), findsNothing);
     expect(find.byKey(const Key('notificationSettingsButton')), findsNothing);
     expect(find.widgetWithText(FilledButton, '알림 설정'), findsNothing);
   });
@@ -319,7 +320,7 @@ void main() {
     );
 
     expect(find.byKey(const Key('favoriteStationsButton')), findsOneWidget);
-    expect(find.widgetWithText(FilledButton, '즐겨찾기'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, '즐겨찾기 역'), findsOneWidget);
     expect(find.byKey(const Key('notificationSettingsButton')), findsOneWidget);
     expect(find.widgetWithText(FilledButton, '알림 설정'), findsOneWidget);
   });
@@ -335,12 +336,21 @@ void main() {
 
     final favoriteRepository =
         app.favoriteRepository as FavoriteStationApiRepository;
+    final favoriteFacilityRepository =
+        app.favoriteFacilityRepository as FavoriteFacilityApiRepository;
     final notificationRepository =
         app.notificationRepository as NotificationSettingsApiRepository;
 
     expect(
       identical(
         favoriteRepository.authProvider,
+        favoriteFacilityRepository.authProvider,
+      ),
+      isTrue,
+    );
+    expect(
+      identical(
+        favoriteFacilityRepository.authProvider,
         notificationRepository.authProvider,
       ),
       isTrue,
@@ -423,7 +433,7 @@ void main() {
       await tester.tap(find.byKey(const Key('favoriteStationsButton')));
       await tester.pumpAndSettle();
 
-      expect(find.text('즐겨찾기'), findsOneWidget);
+      expect(find.text('즐겨찾기 역'), findsOneWidget);
       expect(find.text('상록수'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
       expect(find.text('기본 정보만 확인됨'), findsOneWidget);
@@ -441,6 +451,61 @@ void main() {
 
       final tileSize = tester.getSize(
         find.byKey(const Key('favoriteStationTile-station-sangnoksu')),
+      );
+      expect(tileSize.height, greaterThanOrEqualTo(72));
+
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
+  testWidgets('홈 즐겨찾기 시설은 저장한 시설을 큰 목록으로 보여준다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final favoriteFacilityRepository = FakeFavoriteFacilityRepository(
+      favorites: [_favoriteFacility()],
+    );
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          favoriteFacilityRepository: favoriteFacilityRepository,
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('favoriteFacilitiesButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('즐겨찾기 시설'), findsOneWidget);
+      expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
+      expect(find.text('상록수역'), findsOneWidget);
+      expect(find.text('정상'), findsOneWidget);
+      expect(find.text('정보 신뢰도 높음'), findsOneWidget);
+      expect(find.text('출처 공식 파일'), findsOneWidget);
+      expect(
+        find.byKey(
+          const Key('favoriteFacilityTile-facility-sangnoksu-elevator-1'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel(
+          '즐겨찾기 시설, 1번 출구 엘리베이터, 상록수역, 엘리베이터, 정상, 1번 출구 앞, 정보 신뢰도 높음, 출처 공식 파일',
+        ),
+        findsOneWidget,
+      );
+
+      final tileSize = tester.getSize(
+        find.byKey(
+          const Key('favoriteFacilityTile-facility-sangnoksu-elevator-1'),
+        ),
       );
       expect(tileSize.height, greaterThanOrEqualTo(72));
 
@@ -1383,6 +1448,27 @@ FavoriteStation _favoriteStation({required String id, required String name}) {
   );
 }
 
+FavoriteFacility _favoriteFacility() {
+  return const FavoriteFacility(
+    userId: 'anonymous-user-1',
+    facilityId: 'facility-sangnoksu-elevator-1',
+    stationId: 'station-sangnoksu',
+    stationNameKo: '상록수',
+    stationNameEn: 'Sangnoksu',
+    exitId: 'exit-sangnoksu-1',
+    type: 'ELEVATOR',
+    name: '1번 출구 엘리베이터',
+    floorFrom: '1F',
+    floorTo: 'B1',
+    description: '1번 출구 앞',
+    status: 'NORMAL',
+    dataConfidence: 'HIGH',
+    dataSourceType: 'OFFICIAL_FILE',
+    lastUpdatedAt: '2026-06-12',
+    addedAt: '2026-06-14T10:00:00',
+  );
+}
+
 class FakeStationSearchRepository implements StationSearchRepository {
   FakeStationSearchRepository({
     this.nextResults = const [],
@@ -1591,6 +1677,22 @@ class FakeNotificationSettingsRepository
     }
     this.settings = settings.copyWith(updatedAt: '2026-06-14T09:05:00');
     return this.settings;
+  }
+}
+
+class FakeFavoriteFacilityRepository implements FavoriteFacilityRepository {
+  FakeFavoriteFacilityRepository({this.favorites = const []});
+
+  List<FavoriteFacility> favorites;
+  Object? error;
+
+  @override
+  Future<List<FavoriteFacility>> listFavoriteFacilities() async {
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return favorites;
   }
 }
 


### PR DESCRIPTION
Closes #96

## 배경
저장한 교통약자 편의시설을 홈에서 바로 확인할 수 있는 진입점이 필요합니다. 역 즐겨찾기와 시설 즐겨찾기가 같은 이름으로 보이면 사용자가 어떤 목록인지 구분하기 어려워, 홈 버튼과 화면 제목을 분리했습니다.

## 변경 사항
- 홈에 `즐겨찾기 시설` 진입 버튼을 추가했습니다.
- `/api/v1/me/favorites/facilities` 응답을 읽는 모바일 저장소와 목록 컨트롤러를 추가했습니다.
- 저장한 시설을 역명, 시설명, 상태, 위치, 신뢰도, 출처 중심으로 간결하게 보여주는 목록 화면을 추가했습니다.
- 기존 역 즐겨찾기 버튼과 화면 제목을 `즐겨찾기 역`으로 바꿔 시설 목록과 구분했습니다.
- 인증 만료 시 저장된 익명 인증을 지우고 한 번 재시도하도록 시설 즐겨찾기 API 저장소를 구성했습니다.

## 검증
- `flutter analyze`
- `flutter test`
- `flutter build apk --debug`
- `flutter build ios --simulator --debug`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`
- Android 에뮬레이터에서 홈 화면의 `즐겨찾기 시설` 버튼과 시설 목록 화면을 실제로 열어 화면 구성과 접근성 라벨을 확인했습니다.

## 리스크
- 백엔드 시설 즐겨찾기 API가 비어 있으면 빈 목록 문구가 표시됩니다.
- 현재 화면은 저장된 시설을 확인하는 범위이며, 시설 추가/해제 동작은 별도 화면에서 다룹니다.

## 체크리스트
- [x] 직접 `main`에 push하지 않고 작업 브랜치에서 PR을 열었습니다.
- [x] 관련 테스트와 Android/iOS debug build를 확인했습니다.
- [x] README 외 Markdown 문서가 추가로 추적되지 않는지 확인했습니다.
- [x] 실제 Android 화면을 열어 UI를 확인했습니다.
