### PR TITLE
[Feat] 환승 1회 경로 추천 기준선 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepository.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepository.java
@@ -5,6 +5,8 @@ import com.easysubway.favorite.application.port.out.LoadFavoriteRouteAlertTarget
 import com.easysubway.favorite.application.port.out.LoadFavoriteRoutePort;
 import com.easysubway.favorite.application.port.out.SaveFavoriteRoutePort;
 import com.easysubway.favorite.domain.FavoriteRoute;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteStep;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -73,7 +75,20 @@ public class InMemoryFavoriteRouteRepository implements
 	private boolean hasRouteTouchingStation(Map<String, FavoriteRoute> favorites, String stationId) {
 		return favorites.values()
 			.stream()
-			.anyMatch(favorite -> stationId.equals(favorite.route().originStationId())
-				|| stationId.equals(favorite.route().destinationStationId()));
+			.anyMatch(favorite -> routeTouchesStation(favorite.route(), stationId));
+	}
+
+	private boolean routeTouchesStation(RouteSearchResult route, String stationId) {
+		if (stationId.equals(route.originStationId()) || stationId.equals(route.destinationStationId())) {
+			return true;
+		}
+		// 환승 경로는 중간 단계에 장애 알림 대상 역이 포함될 수 있어 모든 이동 구간을 확인한다.
+		return route.steps()
+			.stream()
+			.anyMatch(step -> stepTouchesStation(step, stationId));
+	}
+
+	private boolean stepTouchesStation(RouteStep step, String stationId) {
+		return stationId.equals(step.fromStationId()) || stationId.equals(step.toStationId());
 	}
 }

--- a/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteRouteService.java
+++ b/backend/src/main/java/com/easysubway/favorite/application/service/FavoriteRouteService.java
@@ -13,6 +13,7 @@ import com.easysubway.favorite.domain.InvalidFavoriteRouteException;
 import com.easysubway.route.application.port.out.LoadRouteSearchPort;
 import com.easysubway.route.domain.RouteSearchNotFoundException;
 import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Comparator;
@@ -81,6 +82,7 @@ public class FavoriteRouteService implements FavoriteRouteUseCase {
 		}
 
 		RouteSearchResult route = loadRouteSearch(command.routeSearchId());
+		requireSavableRoute(route);
 
 		FavoriteRoute favoriteRoute = saveFavoriteRoutePort.saveFavoriteRoute(new FavoriteRoute(
 			command.userId(),
@@ -106,6 +108,13 @@ public class FavoriteRouteService implements FavoriteRouteUseCase {
 		// 즐겨찾기 경로는 사용자가 방금 확인한 경로 검색 결과만 저장해 오래된 임의 ID 저장을 막는다.
 		return loadRouteSearchPort.loadRouteSearch(routeSearchId)
 			.orElseThrow(RouteSearchNotFoundException::new);
+	}
+
+	private void requireSavableRoute(RouteSearchResult route) {
+		// 실제 이동 후보가 아닌 차단 경로는 즐겨찾기와 시설 알림 대상에서 제외한다.
+		if (route.status() != RouteSearchStatus.FOUND) {
+			throw new InvalidFavoriteRouteException("이동 가능한 경로만 즐겨찾기에 저장할 수 있습니다.");
+		}
 	}
 
 	private void requireUserId(String userId) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -75,8 +75,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 		}
 
 		RoutePlan routePlan = findRoutePlan(origin.id(), destination.id());
-		boolean stairOnlyAccess = hasStairOnlyAccess(origin.id(), destination.id());
-		List<RouteWarning> warnings = routeWarnings(origin.id(), destination.id(), stairOnlyAccess);
+		List<String> accessibilityStationIds = routePlan.accessibilityStationIds(origin.id(), destination.id());
+		boolean stairOnlyAccess = hasStairOnlyAccess(accessibilityStationIds);
+		List<RouteWarning> warnings = routeWarnings(accessibilityStationIds, stairOnlyAccess);
 		RouteProfileWeight profileWeight = RouteProfileWeight.from(command.mobilityType());
 
 		if (profileWeight.blocksStairOnlyAccess() && stairOnlyAccess) {
@@ -265,19 +266,19 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.findFirst();
 	}
 
-	private List<RouteWarning> routeWarnings(String originStationId, String destinationStationId, boolean stairOnlyAccess) {
+	private List<RouteWarning> routeWarnings(List<String> stationIds, boolean stairOnlyAccess) {
 		// 출구 데이터가 없거나 신뢰도가 낮으면 사용자가 이동 전 확인할 수 있게 경고를 남긴다.
 		List<RouteWarning> warnings = new ArrayList<>();
-		if (hasLowAccessibilityData(originStationId) || hasLowAccessibilityData(destinationStationId)) {
+		if (stationIds.stream().anyMatch(this::hasLowAccessibilityData)) {
 			warnings.add(new RouteWarning(
 				RouteWarningCode.LOW_DATA_CONFIDENCE,
-				"출발역 또는 도착역 접근성 정보가 부족합니다. 이동 전 역 상세 정보를 확인하세요."
+				"이동 경로 중 일부 역의 접근성 정보가 부족합니다. 이동 전 역 상세 정보를 확인하세요."
 			));
 		}
 		if (stairOnlyAccess) {
 			warnings.add(new RouteWarning(
 				RouteWarningCode.STAIR_ONLY_ACCESS,
-				"출발역 또는 도착역에 계단 없는 접근 경로가 확인되지 않았습니다."
+				"이동 경로 중 일부 역에 계단 없는 접근 경로가 확인되지 않았습니다."
 			));
 		}
 		return List.copyOf(warnings);
@@ -296,8 +297,8 @@ public class RouteSearchService implements RouteSearchUseCase {
 		return hasLowConfidenceExit || hasLowConfidenceStepFreeFacility;
 	}
 
-	private boolean hasStairOnlyAccess(String originStationId, String destinationStationId) {
-		return hasStairOnlyAccess(originStationId) || hasStairOnlyAccess(destinationStationId);
+	private boolean hasStairOnlyAccess(List<String> stationIds) {
+		return stationIds.stream().anyMatch(this::hasStairOnlyAccess);
 	}
 
 	private boolean hasStairOnlyAccess(String stationId) {
@@ -565,6 +566,12 @@ public class RouteSearchService implements RouteSearchUseCase {
 
 		int transferCount() {
 			return transferRoute.isPresent() ? 1 : 0;
+		}
+
+		List<String> accessibilityStationIds(String originStationId, String destinationStationId) {
+			return transferRoute
+				.map(route -> List.of(originStationId, route.transferStation().id(), destinationStationId))
+				.orElseGet(() -> List.of(originStationId, destinationStationId));
 		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -73,7 +74,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			throw new InvalidRouteSearchException("출발역과 도착역이 달라야 합니다.");
 		}
 
-		DirectLine directLine = findDirectLine(origin.id(), destination.id());
+		RoutePlan routePlan = findRoutePlan(origin.id(), destination.id());
 		boolean stairOnlyAccess = hasStairOnlyAccess(origin.id(), destination.id());
 		List<RouteWarning> warnings = routeWarnings(origin.id(), destination.id(), stairOnlyAccess);
 		RouteProfileWeight profileWeight = RouteProfileWeight.from(command.mobilityType());
@@ -87,8 +88,8 @@ public class RouteSearchService implements RouteSearchUseCase {
 				destination.nameKo(),
 				command.mobilityType(),
 				RouteSearchStatus.BLOCKED,
-				directLine.line().id(),
-				directLine.line().name(),
+				routePlan.lineId(),
+				routePlan.lineName(),
 				0,
 				List.of(),
 				warnings,
@@ -97,7 +98,6 @@ public class RouteSearchService implements RouteSearchUseCase {
 			));
 		}
 
-		List<RouteStep> steps = directLineSteps(origin, destination, directLine, profileWeight);
 		return saveRouteSearchPort.saveRouteSearch(new RouteSearchResult(
 			newRouteSearchId(),
 			origin.id(),
@@ -106,10 +106,10 @@ public class RouteSearchService implements RouteSearchUseCase {
 			destination.nameKo(),
 			command.mobilityType(),
 			RouteSearchStatus.FOUND,
-			directLine.line().id(),
-			directLine.line().name(),
-			routeScore(profileWeight, directLine, warnings),
-			steps,
+			routePlan.lineId(),
+			routePlan.lineName(),
+			routeScore(profileWeight, routePlan, warnings),
+			routeSteps(origin, destination, routePlan, profileWeight),
 			warnings,
 			List.of(),
 			LocalDateTime.now(clock)
@@ -146,8 +146,14 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.orElseThrow(StationNotFoundException::new);
 	}
 
-	private DirectLine findDirectLine(String originStationId, String destinationStationId) {
-		// 현재 기준선은 환승 없이 같은 활성 노선에 속한 두 역만 직접 경로로 계산한다.
+	private RoutePlan findRoutePlan(String originStationId, String destinationStationId) {
+		return findDirectLine(originStationId, destinationStationId)
+			.map(RoutePlan::direct)
+			.or(() -> findOneTransferRoute(originStationId, destinationStationId).map(RoutePlan::transfer))
+			.orElseThrow(RouteNotFoundException::new);
+	}
+
+	private Optional<DirectLine> findDirectLine(String originStationId, String destinationStationId) {
 		Map<String, SubwayLine> activeLinesById = loadTransitMasterPort.loadLines()
 			.stream()
 			.filter(SubwayLine::active)
@@ -169,8 +175,94 @@ public class RouteSearchService implements RouteSearchUseCase {
 				originLinesByLineId.get(destinationLine.lineId()),
 				destinationLine
 			))
-			.min(Comparator.comparingInt(DirectLine::stopCount))
-			.orElseThrow(RouteNotFoundException::new);
+			.min(Comparator.comparingInt(DirectLine::stopCount));
+	}
+
+	private Optional<TransferRoute> findOneTransferRoute(String originStationId, String destinationStationId) {
+		Map<String, SubwayLine> activeLinesById = loadTransitMasterPort.loadLines()
+			.stream()
+			.filter(SubwayLine::active)
+			.collect(Collectors.toMap(SubwayLine::id, Function.identity()));
+		Map<String, Station> activeStationsById = loadTransitMasterPort.loadStations()
+			.stream()
+			.filter(Station::active)
+			.collect(Collectors.toMap(Station::id, Function.identity()));
+		List<StationLine> activeStationLines = loadTransitMasterPort.loadStationLines()
+			.stream()
+			.filter(stationLine -> activeLinesById.containsKey(stationLine.lineId()))
+			.filter(stationLine -> activeStationsById.containsKey(stationLine.stationId()))
+			.toList();
+		List<StationLine> originLines = stationLines(activeStationLines, originStationId);
+		List<StationLine> destinationLines = stationLines(activeStationLines, destinationStationId);
+		Map<String, List<StationLine>> stationLinesByStationId = activeStationLines.stream()
+			.collect(Collectors.groupingBy(StationLine::stationId));
+
+		// 한 번 환승 기준선은 두 노선이 만나는 활성 역을 찾아 총 이동 역 수가 가장 짧은 후보를 고른다.
+		List<TransferRoute> candidates = new ArrayList<>();
+		for (StationLine originLine : originLines) {
+			for (StationLine destinationLine : destinationLines) {
+				if (originLine.lineId().equals(destinationLine.lineId())) {
+					continue;
+				}
+				stationLinesByStationId.forEach((stationId, linesAtStation) -> addTransferCandidate(
+					candidates,
+					activeLinesById,
+					activeStationsById,
+					originStationId,
+					destinationStationId,
+					originLine,
+					destinationLine,
+					stationId,
+					linesAtStation
+				));
+			}
+		}
+
+		return candidates.stream()
+			.min(Comparator.comparingInt(TransferRoute::stopCount)
+				.thenComparing(route -> route.transferStation().nameKo()));
+	}
+
+	private void addTransferCandidate(
+		List<TransferRoute> candidates,
+		Map<String, SubwayLine> activeLinesById,
+		Map<String, Station> activeStationsById,
+		String originStationId,
+		String destinationStationId,
+		StationLine originLine,
+		StationLine destinationLine,
+		String stationId,
+		List<StationLine> linesAtStation
+	) {
+		if (stationId.equals(originStationId) || stationId.equals(destinationStationId)) {
+			return;
+		}
+		Optional<StationLine> transferOriginLine = stationLineFor(linesAtStation, originLine.lineId());
+		Optional<StationLine> transferDestinationLine = stationLineFor(linesAtStation, destinationLine.lineId());
+		if (transferOriginLine.isEmpty() || transferDestinationLine.isEmpty()) {
+			return;
+		}
+		candidates.add(new TransferRoute(
+			activeLinesById.get(originLine.lineId()),
+			originLine,
+			transferOriginLine.get(),
+			activeLinesById.get(destinationLine.lineId()),
+			transferDestinationLine.get(),
+			destinationLine,
+			activeStationsById.get(stationId)
+		));
+	}
+
+	private List<StationLine> stationLines(List<StationLine> stationLines, String stationId) {
+		return stationLines.stream()
+			.filter(stationLine -> stationLine.stationId().equals(stationId))
+			.toList();
+	}
+
+	private Optional<StationLine> stationLineFor(List<StationLine> stationLines, String lineId) {
+		return stationLines.stream()
+			.filter(stationLine -> stationLine.lineId().equals(lineId))
+			.findFirst();
 	}
 
 	private List<RouteWarning> routeWarnings(String originStationId, String destinationStationId, boolean stairOnlyAccess) {
@@ -268,9 +360,10 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.toList();
 	}
 
-	private int routeScore(RouteProfileWeight profileWeight, DirectLine directLine, List<RouteWarning> warnings) {
+	private int routeScore(RouteProfileWeight profileWeight, RoutePlan routePlan, List<RouteWarning> warnings) {
 		// 점수는 시간이 아니라 상대 비용이다. 낮을수록 쉬운 경로에 가깝다.
-		int trainTime = directLine.stopCount() * 3;
+		int trainTime = routePlan.stopCount() * 3;
+		int transferPenalty = routePlan.transferCount() * profileWeight.transferPenalty();
 		int lowDataPenalty = warnings.stream()
 			.anyMatch(warning -> warning.code() == RouteWarningCode.LOW_DATA_CONFIDENCE)
 			? profileWeight.lowDataConfidencePenalty()
@@ -279,7 +372,19 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.anyMatch(warning -> warning.code() == RouteWarningCode.STAIR_ONLY_ACCESS)
 			? profileWeight.stairOnlyAccessPenalty()
 			: 0;
-		return trainTime + profileWeight.baseAccessCost() + lowDataPenalty + stairOnlyPenalty;
+		return trainTime + transferPenalty + profileWeight.baseAccessCost() + lowDataPenalty + stairOnlyPenalty;
+	}
+
+	private List<RouteStep> routeSteps(
+		Station origin,
+		Station destination,
+		RoutePlan routePlan,
+		RouteProfileWeight profileWeight
+	) {
+		if (routePlan.transferRoute().isPresent()) {
+			return transferSteps(origin, destination, routePlan.transferRoute().get(), profileWeight);
+		}
+		return directLineSteps(origin, destination, routePlan.directLine().orElseThrow(), profileWeight);
 	}
 
 	private List<RouteStep> directLineSteps(
@@ -320,6 +425,63 @@ public class RouteSearchService implements RouteSearchUseCase {
 		);
 	}
 
+	private List<RouteStep> transferSteps(
+		Station origin,
+		Station destination,
+		TransferRoute route,
+		RouteProfileWeight profileWeight
+	) {
+		String firstDisplayLine = displayLineName(route.firstLine());
+		String secondDisplayLine = displayLineName(route.secondLine());
+		return List.of(
+			new RouteStep(
+				1,
+				origin.nameKo() + "역에서 " + firstDisplayLine + " 승강장으로 이동",
+				profileWeight.entryGuidance(),
+				route.firstLine().id(),
+				route.firstLine().name(),
+				origin.id(),
+				origin.id()
+			),
+			new RouteStep(
+				2,
+				route.firstLine().name() + "으로 " + route.transferStation().nameKo() + "역까지 이동",
+				route.firstSegmentStopCount() + "개 역을 이동한 뒤 환승합니다.",
+				route.firstLine().id(),
+				route.firstLine().name(),
+				origin.id(),
+				route.transferStation().id()
+			),
+			new RouteStep(
+				3,
+				route.transferStation().nameKo() + "역에서 " + secondDisplayLine + " 승강장으로 환승",
+				route.transferStation().nameKo() + "의 엘리베이터와 계단 없는 연결 동선을 먼저 확인합니다.",
+				route.secondLine().id(),
+				route.secondLine().name(),
+				route.transferStation().id(),
+				route.transferStation().id()
+			),
+			new RouteStep(
+				4,
+				route.secondLine().name() + "으로 " + destination.nameKo() + "역까지 이동",
+				route.secondSegmentStopCount() + "개 역을 이동합니다.",
+				route.secondLine().id(),
+				route.secondLine().name(),
+				route.transferStation().id(),
+				destination.id()
+			),
+			new RouteStep(
+				5,
+				destination.nameKo() + "역에서 출구 접근성 정보를 확인",
+				profileWeight.exitGuidance(),
+				route.secondLine().id(),
+				route.secondLine().name(),
+				destination.id(),
+				destination.id()
+			)
+		);
+	}
+
 	private String displayLineName(SubwayLine line) {
 		String lineCode = line.lineCode();
 		if (lineCode != null && !lineCode.isBlank() && lineCode.chars().allMatch(Character::isDigit)) {
@@ -340,6 +502,69 @@ public class RouteSearchService implements RouteSearchUseCase {
 
 		int stopCount() {
 			return Math.abs(origin.sequence() - destination.sequence());
+		}
+	}
+
+	private record TransferRoute(
+		SubwayLine firstLine,
+		StationLine origin,
+		StationLine transferOriginLine,
+		SubwayLine secondLine,
+		StationLine transferDestinationLine,
+		StationLine destination,
+		Station transferStation
+	) {
+
+		int firstSegmentStopCount() {
+			return Math.abs(origin.sequence() - transferOriginLine.sequence());
+		}
+
+		int secondSegmentStopCount() {
+			return Math.abs(transferDestinationLine.sequence() - destination.sequence());
+		}
+
+		int stopCount() {
+			return firstSegmentStopCount() + secondSegmentStopCount();
+		}
+	}
+
+	private record RoutePlan(
+		Optional<DirectLine> directLine,
+		Optional<TransferRoute> transferRoute
+	) {
+
+		static RoutePlan direct(DirectLine directLine) {
+			return new RoutePlan(Optional.of(directLine), Optional.empty());
+		}
+
+		static RoutePlan transfer(TransferRoute transferRoute) {
+			return new RoutePlan(Optional.empty(), Optional.of(transferRoute));
+		}
+
+		String lineId() {
+			return directLine
+				.map(direct -> direct.line().id())
+				.orElseGet(() -> transferRoute
+					.map(route -> route.firstLine().id() + "/" + route.secondLine().id())
+					.orElseThrow());
+		}
+
+		String lineName() {
+			return directLine
+				.map(direct -> direct.line().name())
+				.orElseGet(() -> transferRoute
+					.map(route -> route.firstLine().name() + " / " + route.secondLine().name())
+					.orElseThrow());
+		}
+
+		int stopCount() {
+			return directLine
+				.map(DirectLine::stopCount)
+				.orElseGet(() -> transferRoute.map(TransferRoute::stopCount).orElseThrow());
+		}
+
+		int transferCount() {
+			return transferRoute.isPresent() ? 1 : 0;
 		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -74,11 +74,11 @@ public class RouteSearchService implements RouteSearchUseCase {
 			throw new InvalidRouteSearchException("출발역과 도착역이 달라야 합니다.");
 		}
 
-		RoutePlan routePlan = findRoutePlan(origin.id(), destination.id());
+		RouteProfileWeight profileWeight = RouteProfileWeight.from(command.mobilityType());
+		RoutePlan routePlan = findRoutePlan(origin.id(), destination.id(), profileWeight);
 		List<String> accessibilityStationIds = routePlan.accessibilityStationIds(origin.id(), destination.id());
 		boolean stairOnlyAccess = hasStairOnlyAccess(accessibilityStationIds);
 		List<RouteWarning> warnings = routeWarnings(accessibilityStationIds, stairOnlyAccess);
-		RouteProfileWeight profileWeight = RouteProfileWeight.from(command.mobilityType());
 
 		if (profileWeight.blocksStairOnlyAccess() && stairOnlyAccess) {
 			return saveRouteSearchPort.saveRouteSearch(new RouteSearchResult(
@@ -147,10 +147,14 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.orElseThrow(StationNotFoundException::new);
 	}
 
-	private RoutePlan findRoutePlan(String originStationId, String destinationStationId) {
+	private RoutePlan findRoutePlan(
+		String originStationId,
+		String destinationStationId,
+		RouteProfileWeight profileWeight
+	) {
 		return findDirectLine(originStationId, destinationStationId)
 			.map(RoutePlan::direct)
-			.or(() -> findOneTransferRoute(originStationId, destinationStationId).map(RoutePlan::transfer))
+			.or(() -> findOneTransferRoute(originStationId, destinationStationId, profileWeight).map(RoutePlan::transfer))
 			.orElseThrow(RouteNotFoundException::new);
 	}
 
@@ -179,7 +183,11 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.min(Comparator.comparingInt(DirectLine::stopCount));
 	}
 
-	private Optional<TransferRoute> findOneTransferRoute(String originStationId, String destinationStationId) {
+	private Optional<TransferRoute> findOneTransferRoute(
+		String originStationId,
+		String destinationStationId,
+		RouteProfileWeight profileWeight
+	) {
 		Map<String, SubwayLine> activeLinesById = loadTransitMasterPort.loadLines()
 			.stream()
 			.filter(SubwayLine::active)
@@ -220,8 +228,22 @@ public class RouteSearchService implements RouteSearchUseCase {
 		}
 
 		return candidates.stream()
-			.min(Comparator.comparingInt(TransferRoute::stopCount)
+			.min(Comparator.comparingInt((TransferRoute route) -> transferCandidateCost(route, profileWeight))
 				.thenComparing(route -> route.transferStation().nameKo()));
+	}
+
+	private int transferCandidateCost(TransferRoute route, RouteProfileWeight profileWeight) {
+		String transferStationId = route.transferStation().id();
+		int stairOnlyCost = hasStairOnlyAccess(transferStationId)
+			? profileWeight.stairOnlyAccessPenalty()
+			: 0;
+		int lowDataCost = hasLowAccessibilityData(transferStationId)
+			? profileWeight.lowDataConfidencePenalty()
+			: 0;
+		int blockedTransferCost = profileWeight.blocksStairOnlyAccess() && hasStairOnlyAccess(transferStationId)
+			? 10_000
+			: 0;
+		return route.stopCount() * 3 + profileWeight.transferPenalty() + stairOnlyCost + lowDataCost + blockedTransferCost;
 	}
 
 	private void addTransferCandidate(

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -228,8 +228,16 @@ public class RouteSearchService implements RouteSearchUseCase {
 		}
 
 		return candidates.stream()
-			.min(Comparator.comparingInt((TransferRoute route) -> transferCandidateCost(route, profileWeight))
+			.min(Comparator.comparingInt((TransferRoute route) -> transferAccessibilityRank(route, profileWeight))
+				.thenComparingInt(route -> transferCandidateCost(route, profileWeight))
 				.thenComparing(route -> route.transferStation().nameKo()));
+	}
+
+	private int transferAccessibilityRank(TransferRoute route, RouteProfileWeight profileWeight) {
+		if (profileWeight.blocksStairOnlyAccess() && hasStairOnlyAccess(route.transferStation().id())) {
+			return 1;
+		}
+		return 0;
 	}
 
 	private int transferCandidateCost(TransferRoute route, RouteProfileWeight profileWeight) {
@@ -240,10 +248,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 		int lowDataCost = hasLowAccessibilityData(transferStationId)
 			? profileWeight.lowDataConfidencePenalty()
 			: 0;
-		int blockedTransferCost = profileWeight.blocksStairOnlyAccess() && hasStairOnlyAccess(transferStationId)
-			? 10_000
-			: 0;
-		return route.stopCount() * 3 + profileWeight.transferPenalty() + stairOnlyCost + lowDataCost + blockedTransferCost;
+		return route.stopCount() * 3 + profileWeight.transferPenalty() + stairOnlyCost + lowDataCost;
 	}
 
 	private void addTransferCandidate(

--- a/backend/src/main/java/com/easysubway/route/domain/RouteProfileWeight.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteProfileWeight.java
@@ -6,6 +6,7 @@ public record RouteProfileWeight(
 	int baseAccessCost,
 	int lowDataConfidencePenalty,
 	int stairOnlyAccessPenalty,
+	int transferPenalty,
 	boolean blocksStairOnlyAccess,
 	String entryGuidance,
 	String exitGuidance
@@ -18,6 +19,7 @@ public record RouteProfileWeight(
 				18,
 				24,
 				38,
+				12,
 				false,
 				"계단을 피하고 이동 거리가 짧은 출구를 먼저 확인합니다.",
 				"도착역에서 계단을 피할 수 있는 출구와 짧은 동선을 확인합니다."
@@ -26,6 +28,7 @@ public record RouteProfileWeight(
 				20,
 				28,
 				48,
+				15,
 				false,
 				"엘리베이터와 넓은 통로가 있는 출구를 먼저 확인합니다.",
 				"도착역에서 엘리베이터와 넓은 통로가 있는 출구를 확인합니다."
@@ -34,6 +37,7 @@ public record RouteProfileWeight(
 				24,
 				36,
 				100,
+				18,
 				true,
 				"엘리베이터, 리프트, 경사로 연결을 먼저 확인합니다.",
 				"도착역에서 엘리베이터, 리프트, 경사로 연결 출구를 확인합니다."
@@ -42,6 +46,7 @@ public record RouteProfileWeight(
 				17,
 				26,
 				42,
+				14,
 				false,
 				"엘리베이터와 짧은 이동 동선을 먼저 확인합니다.",
 				"도착역에서 짧게 걸을 수 있는 엘리베이터 출구를 확인합니다."
@@ -50,6 +55,7 @@ public record RouteProfileWeight(
 				22,
 				30,
 				52,
+				17,
 				false,
 				"계단을 피하고 쉬어 갈 수 있는 동선을 먼저 확인합니다.",
 				"도착역에서 계단을 피하고 천천히 이동할 수 있는 출구를 확인합니다."
@@ -58,6 +64,7 @@ public record RouteProfileWeight(
 				16,
 				22,
 				34,
+				10,
 				false,
 				"엘리베이터와 넓은 출구 동선을 먼저 확인합니다.",
 				"도착역에서 큰 짐을 들고 지나가기 쉬운 출구를 확인합니다."

--- a/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepositoryTest.java
@@ -6,6 +6,7 @@ import com.easysubway.favorite.domain.FavoriteRoute;
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.route.domain.RouteStep;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -34,6 +35,20 @@ class InMemoryFavoriteRouteRepositoryTest {
 			.contains("route-search-1", "route-search-" + InMemoryFavoriteRouteRepository.MAX_FAVORITE_ROUTES_PER_USER);
 	}
 
+	@Test
+	@DisplayName("경로 알림 대상 조회는 환승 단계에 포함된 역도 매칭한다")
+	void loadUserIdsByRouteStationIdMatchesTransferStepStation() {
+		var repository = new InMemoryFavoriteRouteRepository();
+		repository.saveFavoriteRoute(new FavoriteRoute(
+			"route-user",
+			transferRouteSearch(),
+			LocalDateTime.of(2026, 6, 13, 9, 0)
+		));
+
+		assertThat(repository.loadUserIdsByRouteStationId("station-transfer"))
+			.containsExactly("route-user");
+	}
+
 	private RouteSearchResult routeSearch(String routeSearchId) {
 		return new RouteSearchResult(
 			routeSearchId,
@@ -47,6 +62,30 @@ class InMemoryFavoriteRouteRepositoryTest {
 			"수도권 4호선",
 			90,
 			List.of(),
+			List.of(),
+			List.of(),
+			LocalDateTime.of(2026, 6, 13, 9, 0)
+		);
+	}
+
+	private RouteSearchResult transferRouteSearch() {
+		return new RouteSearchResult(
+			"route-search-transfer",
+			"station-origin",
+			"출발역",
+			"station-destination",
+			"도착역",
+			MobilityType.WHEELCHAIR,
+			RouteSearchStatus.FOUND,
+			"line-a/line-b",
+			"A 노선 / B 노선",
+			45,
+			List.of(
+				new RouteStep(1, "출발역에서 A 노선 승강장으로 이동", "엘리베이터를 확인합니다.", "line-a", "A 노선", "station-origin", "station-origin"),
+				new RouteStep(2, "A 노선으로 환승역까지 이동", "2개 역을 이동한 뒤 환승합니다.", "line-a", "A 노선", "station-origin", "station-transfer"),
+				new RouteStep(3, "환승역에서 B 노선 승강장으로 환승", "환승역의 엘리베이터를 확인합니다.", "line-b", "B 노선", "station-transfer", "station-transfer"),
+				new RouteStep(4, "B 노선으로 도착역까지 이동", "2개 역을 이동합니다.", "line-b", "B 노선", "station-transfer", "station-destination")
+			),
 			List.of(),
 			List.of(),
 			LocalDateTime.of(2026, 6, 13, 9, 0)

--- a/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteRouteServiceTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/application/service/FavoriteRouteServiceTest.java
@@ -141,6 +141,19 @@ class FavoriteRouteServiceTest {
 	}
 
 	@Test
+	@DisplayName("차단된 경로 검색 결과는 즐겨찾기에 저장할 수 없다")
+	void saveFavoriteRouteRejectsBlockedRouteSearchResult() {
+		routeSearchRepository.saveRouteSearch(blockedRouteSearch("route-search-blocked"));
+
+		assertThatThrownBy(() -> service.saveFavoriteRoute(new SaveFavoriteRouteCommand(
+			"anonymous-user-1",
+			"route-search-blocked"
+		)))
+			.isInstanceOf(InvalidFavoriteRouteException.class)
+			.hasMessage("이동 가능한 경로만 즐겨찾기에 저장할 수 있습니다.");
+	}
+
+	@Test
 	@DisplayName("즐겨찾기 경로 명령은 사용자와 경로 식별자를 요구한다")
 	void favoriteRouteCommandsRequireUserAndRouteSearchId() {
 		assertThatThrownBy(() -> service.listFavoriteRoutes(new ListFavoriteRoutesCommand("")))
@@ -191,6 +204,25 @@ class FavoriteRouteServiceTest {
 			List.of(),
 			List.of(),
 			List.of(),
+			LocalDateTime.of(2026, 6, 13, 9, 0)
+		);
+	}
+
+	private RouteSearchResult blockedRouteSearch(String routeSearchId) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-sangnoksu",
+			"상록수",
+			"station-sadang",
+			"사당",
+			MobilityType.WHEELCHAIR,
+			RouteSearchStatus.BLOCKED,
+			"line-4",
+			"수도권 4호선",
+			0,
+			List.of(),
+			List.of(),
+			List.of("계단 없는 역 접근 경로를 확인할 수 없습니다."),
 			LocalDateTime.of(2026, 6, 13, 9, 0)
 		);
 	}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -206,6 +206,31 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 이동 유형은 우회 거리가 길어도 무단차 환승역을 우선한다")
+	void wheelchairRoutePrefersStepFreeTransferStationEvenWhenDetourIsLong() {
+		var repository = new InMemoryRouteSearchRepository();
+		var transferService = new RouteSearchService(
+			repository,
+			repository,
+			new LongDetourTransferAccessibilityTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = transferService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.steps())
+			.extracting("title")
+			.contains(
+				"무단차환승역역에서 B 노선 승강장으로 환승"
+			);
+	}
+
+	@Test
 	@DisplayName("유모차 이동 유형은 계단만 있는 역 접근 경로를 경고하고 점수를 높인다")
 	void strollerRouteWarnsStairOnlyStationAccess() {
 		var stairOnlyRepository = new InMemoryRouteSearchRepository();
@@ -716,6 +741,21 @@ class RouteSearchServiceTest {
 				facility("facility-a-elevator", "station-a", "exit-a-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
 				facility("facility-step-free-transfer-elevator", "station-step-free-transfer", "exit-step-free-transfer-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
 				facility("facility-b-elevator", "station-b", "exit-b-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL)
+			);
+		}
+	}
+
+	private static class LongDetourTransferAccessibilityTransitMasterPort extends MixedTransferAccessibilityTransitMasterPort {
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of(
+				new StationLine("station-a", "line-a", "101", 1, "상행 / 하행"),
+				new StationLine("station-stair-transfer", "line-a", "102", 2, "상행 / 하행"),
+				new StationLine("station-stair-transfer", "line-b", "201", 1, "상행 / 하행"),
+				new StationLine("station-step-free-transfer", "line-a", "6000", 6_000, "상행 / 하행"),
+				new StationLine("station-step-free-transfer", "line-b", "7000", 7_000, "상행 / 하행"),
+				new StationLine("station-b", "line-b", "13000", 13_000, "상행 / 하행")
 			);
 		}
 	}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -113,6 +113,47 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("공통 노선이 없으면 한 번 환승 가능한 역을 경로로 반환한다")
+	void searchRouteReturnsOneTransferRecommendation() {
+		var repository = new InMemoryRouteSearchRepository();
+		var transferService = new RouteSearchService(
+			repository,
+			repository,
+			new OneTransferTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = transferService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.SENIOR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.lineName()).isEqualTo("A 노선 / B 노선");
+		assertThat(result.steps())
+			.extracting("title")
+			.containsExactly(
+				"출발역역에서 A 노선 승강장으로 이동",
+				"A 노선으로 환승역역까지 이동",
+				"환승역역에서 B 노선 승강장으로 환승",
+				"B 노선으로 도착역역까지 이동",
+				"도착역역에서 출구 접근성 정보를 확인"
+			);
+		assertThat(result.steps().get(2).description())
+			.isEqualTo("환승역의 엘리베이터와 계단 없는 연결 동선을 먼저 확인합니다.");
+	}
+
+	@Test
+	@DisplayName("환승 경로는 같은 이동 거리의 직접 경로보다 점수가 높다")
+	void transferRouteScoreIncludesTransferCost() {
+		int transferScore = scoreFor(MobilityType.SENIOR, new OneTransferTransitMasterPort());
+		int directScore = scoreFor(MobilityType.SENIOR, new DirectComparableTransitMasterPort());
+
+		assertThat(transferScore).isGreaterThan(directScore);
+	}
+
+	@Test
 	@DisplayName("유모차 이동 유형은 계단만 있는 역 접근 경로를 경고하고 점수를 높인다")
 	void strollerRouteWarnsStairOnlyStationAccess() {
 		var stairOnlyRepository = new InMemoryRouteSearchRepository();
@@ -474,6 +515,91 @@ class RouteSearchServiceTest {
 			return List.of(
 				new StationLine("station-a", "line-a", "101", 1, "상행 / 하행"),
 				new StationLine("station-b", "line-b", "202", 2, "상행 / 하행")
+			);
+		}
+	}
+
+	private static class OneTransferTransitMasterPort extends StairOnlyTransitMasterPort {
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of(
+				new SubwayLine("line-a", "operator-a", "A 노선", "#0052A4", "수도권", null, true),
+				new SubwayLine("line-b", "operator-a", "B 노선", "#00A84D", "수도권", null, true)
+			);
+		}
+
+		@Override
+		public List<Station> loadStations() {
+			return List.of(
+				station("station-a", "출발역"),
+				station("station-transfer", "환승역"),
+				station("station-b", "도착역")
+			);
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of(
+				new StationLine("station-a", "line-a", "101", 1, "상행 / 하행"),
+				new StationLine("station-transfer", "line-a", "103", 3, "상행 / 하행"),
+				new StationLine("station-transfer", "line-b", "201", 1, "상행 / 하행"),
+				new StationLine("station-b", "line-b", "203", 3, "상행 / 하행")
+			);
+		}
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				stepFreeExit("exit-a-1", "station-a"),
+				stepFreeExit("exit-transfer-1", "station-transfer"),
+				stepFreeExit("exit-b-1", "station-b")
+			);
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility("facility-a-elevator", "station-a", "exit-a-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-transfer-elevator", "station-transfer", "exit-transfer-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-b-elevator", "station-b", "exit-b-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL)
+			);
+		}
+	}
+
+	private static class DirectComparableTransitMasterPort extends OneTransferTransitMasterPort {
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of(new SubwayLine("line-direct", "operator-a", "테스트 직통", "#0052A4", "수도권", null, true));
+		}
+
+		@Override
+		public List<Station> loadStations() {
+			return List.of(station("station-a", "출발역"), station("station-b", "도착역"));
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of(
+				new StationLine("station-a", "line-direct", "101", 1, "상행 / 하행"),
+				new StationLine("station-b", "line-direct", "105", 5, "상행 / 하행")
+			);
+		}
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				stepFreeExit("exit-a-1", "station-a"),
+				stepFreeExit("exit-b-1", "station-b")
+			);
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility("facility-a-elevator", "station-a", "exit-a-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-b-elevator", "station-b", "exit-b-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL)
 			);
 		}
 	}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -154,6 +154,30 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 이동 유형은 환승역이 계단 전용이면 경로를 차단한다")
+	void wheelchairRouteBlocksStairOnlyTransferStation() {
+		var repository = new InMemoryRouteSearchRepository();
+		var transferService = new RouteSearchService(
+			repository,
+			repository,
+			new StairOnlyTransferTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = transferService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
+		assertThat(result.steps()).isEmpty();
+		assertThat(result.warnings())
+			.extracting("code")
+			.contains(RouteWarningCode.STAIR_ONLY_ACCESS);
+	}
+
+	@Test
 	@DisplayName("유모차 이동 유형은 계단만 있는 역 접근 경로를 경고하고 점수를 높인다")
 	void strollerRouteWarnsStairOnlyStationAccess() {
 		var stairOnlyRepository = new InMemoryRouteSearchRepository();
@@ -591,6 +615,26 @@ class RouteSearchServiceTest {
 		public List<StationExit> loadStationExits() {
 			return List.of(
 				stepFreeExit("exit-a-1", "station-a"),
+				stepFreeExit("exit-b-1", "station-b")
+			);
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility("facility-a-elevator", "station-a", "exit-a-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-b-elevator", "station-b", "exit-b-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL)
+			);
+		}
+	}
+
+	private static class StairOnlyTransferTransitMasterPort extends OneTransferTransitMasterPort {
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				stepFreeExit("exit-a-1", "station-a"),
+				stairOnlyExit("exit-transfer-1", "station-transfer"),
 				stepFreeExit("exit-b-1", "station-b")
 			);
 		}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -178,6 +178,34 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 이동 유형은 계단 전용 환승역보다 무단차 환승역을 우선한다")
+	void wheelchairRoutePrefersStepFreeTransferStation() {
+		var repository = new InMemoryRouteSearchRepository();
+		var transferService = new RouteSearchService(
+			repository,
+			repository,
+			new MixedTransferAccessibilityTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = transferService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.steps())
+			.extracting("title")
+			.contains(
+				"무단차환승역역에서 B 노선 승강장으로 환승"
+			);
+		assertThat(result.warnings())
+			.extracting("code")
+			.doesNotContain(RouteWarningCode.STAIR_ONLY_ACCESS);
+	}
+
+	@Test
 	@DisplayName("유모차 이동 유형은 계단만 있는 역 접근 경로를 경고하고 점수를 높인다")
 	void strollerRouteWarnsStairOnlyStationAccess() {
 		var stairOnlyRepository = new InMemoryRouteSearchRepository();
@@ -643,6 +671,50 @@ class RouteSearchServiceTest {
 		public List<AccessibilityFacility> loadAccessibilityFacilities() {
 			return List.of(
 				facility("facility-a-elevator", "station-a", "exit-a-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-b-elevator", "station-b", "exit-b-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL)
+			);
+		}
+	}
+
+	private static class MixedTransferAccessibilityTransitMasterPort extends OneTransferTransitMasterPort {
+
+		@Override
+		public List<Station> loadStations() {
+			return List.of(
+				station("station-a", "출발역"),
+				station("station-stair-transfer", "계단환승역"),
+				station("station-step-free-transfer", "무단차환승역"),
+				station("station-b", "도착역")
+			);
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of(
+				new StationLine("station-a", "line-a", "101", 1, "상행 / 하행"),
+				new StationLine("station-stair-transfer", "line-a", "102", 2, "상행 / 하행"),
+				new StationLine("station-step-free-transfer", "line-a", "103", 3, "상행 / 하행"),
+				new StationLine("station-stair-transfer", "line-b", "201", 1, "상행 / 하행"),
+				new StationLine("station-step-free-transfer", "line-b", "202", 2, "상행 / 하행"),
+				new StationLine("station-b", "line-b", "204", 4, "상행 / 하행")
+			);
+		}
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				stepFreeExit("exit-a-1", "station-a"),
+				stairOnlyExit("exit-stair-transfer-1", "station-stair-transfer"),
+				stepFreeExit("exit-step-free-transfer-1", "station-step-free-transfer"),
+				stepFreeExit("exit-b-1", "station-b")
+			);
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility("facility-a-elevator", "station-a", "exit-a-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-step-free-transfer-elevator", "station-step-free-transfer", "exit-step-free-transfer-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
 				facility("facility-b-elevator", "station-b", "exit-b-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL)
 			);
 		}


### PR DESCRIPTION
## 관련 이슈
- Closes #100

## 배경
경로 검색이 같은 노선 직접 이동만 지원하면 한 번 갈아타면 도달 가능한 역도 경로 없음으로 처리됩니다. 교통약자에게는 환승 가능 여부와 환승역의 접근성 확인 지점이 중요하므로, 보유 중인 역-노선 순서 데이터만으로 한 번 환승 가능한 경로를 계산하는 기준선을 추가했습니다.

## 변경 사항
- 직접 경로를 먼저 찾고, 없으면 한 번 환승 가능한 후보를 계산하도록 경로 검색 서비스를 확장했습니다.
- 환승 경로 결과에 출발역 접근, 첫 노선 이동, 환승, 두 번째 노선 이동, 도착역 접근성 확인 단계를 포함했습니다.
- 이동 유형별 가중치에 환승 부담 비용을 추가해 같은 이동 거리의 직접 경로보다 환승 경로 점수가 높게 계산되도록 했습니다.
- 환승 경로와 점수 회귀 테스트를 한글 display name으로 추가했습니다.

## 검증
- `./gradlew test --tests "com.easysubway.route.application.service.RouteSearchServiceTest"`
- `./gradlew test`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files "*.md"`
- 보안 diff 검토: 신규 인증/권한, 파일, 네트워크, SQL, secret 처리 변경 없음

## 리스크
- 현재는 한 번 환승까지만 계산합니다. 두 번 이상 환승과 환승역 내부 이동 난이도는 별도 작업에서 확장해야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 1회 환승이 필요한 경로 추천 기능 추가
  * 접근성 기반 경로 경고 기능 추가 (계단 전용 환승역 차단 등)
  * 환승 페널티를 고려한 경로 점수 계산 개선

* **Tests**
  * 1회 환승 경로 추천 시나리오에 대한 테스트 케이스 3개 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->