### PR TITLE
[Feat] 가까운 역 조회 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
@@ -82,8 +82,8 @@ class TransitMasterController {
 
 	@GetMapping("/api/v1/stations/nearby")
 	ApiResponse<List<NearbyStationResponse>> nearbyStations(
-		@RequestParam BigDecimal lat,
-		@RequestParam BigDecimal lng,
+		@RequestParam(required = false) BigDecimal lat,
+		@RequestParam(required = false) BigDecimal lng,
 		@RequestParam(required = false) Integer radiusMeters,
 		@RequestParam(required = false) Integer limit
 	) {

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
@@ -1,6 +1,7 @@
 package com.easysubway.transit.adapter.in.web;
 
 import com.easysubway.common.web.ApiResponse;
+import com.easysubway.transit.application.port.in.NearbyStationSearchCommand;
 import com.easysubway.transit.application.port.in.StationSearchCommand;
 import com.easysubway.transit.application.port.in.TransitMasterAdminUseCase;
 import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
@@ -11,6 +12,7 @@ import com.easysubway.transit.domain.AccessibilityFacilityType;
 import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.NearbyStation;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLineSummary;
@@ -73,6 +75,22 @@ class TransitMasterController {
 			.searchStations(new StationSearchCommand(query, lineId))
 			.stream()
 			.map(StationSummaryResponse::from)
+			.toList();
+
+		return ApiResponse.ok(response);
+	}
+
+	@GetMapping("/api/v1/stations/nearby")
+	ApiResponse<List<NearbyStationResponse>> nearbyStations(
+		@RequestParam BigDecimal lat,
+		@RequestParam BigDecimal lng,
+		@RequestParam(required = false) Integer radiusMeters,
+		@RequestParam(required = false) Integer limit
+	) {
+		List<NearbyStationResponse> response = transitMasterQueryUseCase
+			.searchNearbyStations(NearbyStationSearchCommand.of(lat, lng, radiusMeters, limit))
+			.stream()
+			.map(NearbyStationResponse::from)
 			.toList();
 
 		return ApiResponse.ok(response);
@@ -182,6 +200,38 @@ class TransitMasterController {
 				station.dataQualityLevel(),
 				station.dataSourceType(),
 				station.lastVerifiedAt(),
+				stationWithLines.lines()
+					.stream()
+					.map(StationLineResponse::from)
+					.toList()
+			);
+		}
+	}
+
+	record NearbyStationResponse(
+		String id,
+		String nameKo,
+		String nameEn,
+		String region,
+		DataQualityLevel dataQualityLevel,
+		DataSourceType dataSourceType,
+		LocalDate lastVerifiedAt,
+		int distanceMeters,
+		List<StationLineResponse> lines
+	) {
+
+		static NearbyStationResponse from(NearbyStation nearbyStation) {
+			StationWithLines stationWithLines = nearbyStation.stationWithLines();
+			Station station = stationWithLines.station();
+			return new NearbyStationResponse(
+				station.id(),
+				station.nameKo(),
+				station.nameEn(),
+				station.region(),
+				station.dataQualityLevel(),
+				station.dataSourceType(),
+				station.lastVerifiedAt(),
+				nearbyStation.distanceMeters(),
 				stationWithLines.lines()
 					.stream()
 					.map(StationLineResponse::from)

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/NearbyStationSearchCommand.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/NearbyStationSearchCommand.java
@@ -1,0 +1,68 @@
+package com.easysubway.transit.application.port.in;
+
+import com.easysubway.transit.domain.InvalidStationSearchException;
+import java.math.BigDecimal;
+
+public record NearbyStationSearchCommand(
+	BigDecimal latitude,
+	BigDecimal longitude,
+	int radiusMeters,
+	int limit
+) {
+
+	private static final int DEFAULT_RADIUS_METERS = 2_000;
+	private static final int DEFAULT_LIMIT = 10;
+	private static final int MAX_RADIUS_METERS = 50_000;
+	private static final int MAX_LIMIT = 50;
+
+	public static NearbyStationSearchCommand of(
+		BigDecimal latitude,
+		BigDecimal longitude,
+		Integer radiusMeters,
+		Integer limit
+	) {
+		return new NearbyStationSearchCommand(
+			latitude,
+			longitude,
+			radiusMeters == null ? DEFAULT_RADIUS_METERS : radiusMeters,
+			limit == null ? DEFAULT_LIMIT : limit
+		);
+	}
+
+	public NearbyStationSearchCommand {
+		validateLatitude(latitude);
+		validateLongitude(longitude);
+		validateRadius(radiusMeters);
+		validateLimit(limit);
+	}
+
+	private static void validateLatitude(BigDecimal latitude) {
+		if (latitude == null) {
+			throw new InvalidStationSearchException("위도가 필요합니다.");
+		}
+		if (latitude.compareTo(BigDecimal.valueOf(-90)) < 0 || latitude.compareTo(BigDecimal.valueOf(90)) > 0) {
+			throw new InvalidStationSearchException("위도는 -90부터 90 사이여야 합니다.");
+		}
+	}
+
+	private static void validateLongitude(BigDecimal longitude) {
+		if (longitude == null) {
+			throw new InvalidStationSearchException("경도가 필요합니다.");
+		}
+		if (longitude.compareTo(BigDecimal.valueOf(-180)) < 0 || longitude.compareTo(BigDecimal.valueOf(180)) > 0) {
+			throw new InvalidStationSearchException("경도는 -180부터 180 사이여야 합니다.");
+		}
+	}
+
+	private static void validateRadius(int radiusMeters) {
+		if (radiusMeters <= 0 || radiusMeters > MAX_RADIUS_METERS) {
+			throw new InvalidStationSearchException("조회 반경은 1m부터 50000m 사이여야 합니다.");
+		}
+	}
+
+	private static void validateLimit(int limit) {
+		if (limit <= 0 || limit > MAX_LIMIT) {
+			throw new InvalidStationSearchException("조회 개수는 1개부터 50개 사이여야 합니다.");
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
@@ -1,6 +1,7 @@
 package com.easysubway.transit.application.port.in;
 
 import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.NearbyStation;
 import com.easysubway.transit.domain.StationWithLines;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.SubwayLine;
@@ -14,6 +15,8 @@ public interface TransitMasterQueryUseCase {
 	List<SubwayLine> listLines(String operatorId);
 
 	List<StationWithLines> searchStations(StationSearchCommand command);
+
+	List<NearbyStation> searchNearbyStations(NearbyStationSearchCommand command);
 
 	StationWithLines getStation(String stationId);
 

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -101,11 +101,12 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 	public List<StationWithLines> searchStations(StationSearchCommand command) {
 		// 역 검색 결과에는 운영 중인 역과 노선만 포함해 사용자에게 닫힌 노선 선택지를 노출하지 않는다.
 		Map<String, SubwayLine> linesById = activeLinesById();
+		Map<String, List<StationLine>> stationLinesByStationId = activeStationLinesByStationId(linesById);
 		return loadTransitMasterPort.loadStations()
 			.stream()
 			.filter(Station::active)
 			.filter(station -> station.matches(command.query()))
-			.map(station -> withLines(station, linesById))
+			.map(station -> withLines(station, linesById, stationLinesByStationId))
 			.filter(station -> hasLine(station, command.lineId()))
 			.toList();
 	}
@@ -113,10 +114,14 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 	@Override
 	public List<NearbyStation> searchNearbyStations(NearbyStationSearchCommand command) {
 		Map<String, SubwayLine> linesById = activeLinesById();
+		Map<String, List<StationLine>> stationLinesByStationId = activeStationLinesByStationId(linesById);
 		return loadTransitMasterPort.loadStations()
 			.stream()
 			.filter(Station::active)
-			.map(station -> new NearbyStation(withLines(station, linesById), distanceMeters(command, station)))
+			.map(station -> new NearbyStation(
+				withLines(station, linesById, stationLinesByStationId),
+				distanceMeters(command, station)
+			))
 			.filter(nearbyStation -> nearbyStation.distanceMeters() <= command.radiusMeters())
 			.sorted(Comparator.comparingInt(NearbyStation::distanceMeters))
 			.limit(command.limit())
@@ -185,10 +190,23 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 	}
 
 	private StationWithLines withLines(Station station, Map<String, SubwayLine> linesById) {
-		List<StationLineSummary> lines = loadTransitMasterPort.loadStationLines()
+		return withLines(station, linesById, activeStationLinesByStationId(linesById));
+	}
+
+	private Map<String, List<StationLine>> activeStationLinesByStationId(Map<String, SubwayLine> linesById) {
+		return loadTransitMasterPort.loadStationLines()
 			.stream()
-			.filter(stationLine -> stationLine.stationId().equals(station.id()))
 			.filter(stationLine -> linesById.containsKey(stationLine.lineId()))
+			.collect(Collectors.groupingBy(StationLine::stationId));
+	}
+
+	private StationWithLines withLines(
+		Station station,
+		Map<String, SubwayLine> linesById,
+		Map<String, List<StationLine>> stationLinesByStationId
+	) {
+		List<StationLineSummary> lines = stationLinesByStationId.getOrDefault(station.id(), List.of())
+			.stream()
 			.map(stationLine -> toSummary(stationLine, linesById))
 			.toList();
 

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -1,5 +1,6 @@
 package com.easysubway.transit.application.service;
 
+import com.easysubway.transit.application.port.in.NearbyStationSearchCommand;
 import com.easysubway.transit.application.port.in.StationSearchCommand;
 import com.easysubway.transit.application.port.in.TransitMasterAdminUseCase;
 import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
@@ -12,6 +13,7 @@ import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.AccessibilityFacilityNotFoundException;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.InvalidAccessibilityFacilityException;
+import com.easysubway.transit.domain.NearbyStation;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLine;
@@ -22,6 +24,7 @@ import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -31,6 +34,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class TransitMasterService implements TransitMasterQueryUseCase, TransitMasterAdminUseCase {
+
+	private static final double EARTH_RADIUS_METERS = 6_371_000.0;
 
 	private final LoadTransitMasterPort loadTransitMasterPort;
 	private final SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort;
@@ -95,12 +100,26 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 	@Override
 	public List<StationWithLines> searchStations(StationSearchCommand command) {
 		// 역 검색 결과에는 운영 중인 역과 노선만 포함해 사용자에게 닫힌 노선 선택지를 노출하지 않는다.
+		Map<String, SubwayLine> linesById = activeLinesById();
 		return loadTransitMasterPort.loadStations()
 			.stream()
 			.filter(Station::active)
 			.filter(station -> station.matches(command.query()))
-			.map(this::withLines)
+			.map(station -> withLines(station, linesById))
 			.filter(station -> hasLine(station, command.lineId()))
+			.toList();
+	}
+
+	@Override
+	public List<NearbyStation> searchNearbyStations(NearbyStationSearchCommand command) {
+		Map<String, SubwayLine> linesById = activeLinesById();
+		return loadTransitMasterPort.loadStations()
+			.stream()
+			.filter(Station::active)
+			.map(station -> new NearbyStation(withLines(station, linesById), distanceMeters(command, station)))
+			.filter(nearbyStation -> nearbyStation.distanceMeters() <= command.radiusMeters())
+			.sorted(Comparator.comparingInt(NearbyStation::distanceMeters))
+			.limit(command.limit())
 			.toList();
 	}
 
@@ -155,11 +174,17 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 
 	private StationWithLines withLines(Station station) {
 		// 역-노선 연결 데이터가 있어도 노선 자체가 비활성이면 응답에서 제외한다.
-		Map<String, SubwayLine> linesById = loadTransitMasterPort.loadLines()
+		return withLines(station, activeLinesById());
+	}
+
+	private Map<String, SubwayLine> activeLinesById() {
+		return loadTransitMasterPort.loadLines()
 			.stream()
 			.filter(SubwayLine::active)
 			.collect(Collectors.toMap(SubwayLine::id, Function.identity()));
+	}
 
+	private StationWithLines withLines(Station station, Map<String, SubwayLine> linesById) {
 		List<StationLineSummary> lines = loadTransitMasterPort.loadStationLines()
 			.stream()
 			.filter(stationLine -> stationLine.stationId().equals(station.id()))
@@ -185,6 +210,19 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		return station.lines()
 			.stream()
 			.anyMatch(line -> line.id().equals(lineId));
+	}
+
+	private int distanceMeters(NearbyStationSearchCommand command, Station station) {
+		double latitude1 = Math.toRadians(command.latitude().doubleValue());
+		double latitude2 = Math.toRadians(station.latitude().doubleValue());
+		double deltaLatitude = Math.toRadians(station.latitude().doubleValue() - command.latitude().doubleValue());
+		double deltaLongitude = Math.toRadians(station.longitude().doubleValue() - command.longitude().doubleValue());
+
+		double haversine = Math.sin(deltaLatitude / 2) * Math.sin(deltaLatitude / 2)
+			+ Math.cos(latitude1) * Math.cos(latitude2)
+			* Math.sin(deltaLongitude / 2) * Math.sin(deltaLongitude / 2);
+		double centralAngle = 2 * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine));
+		return (int) Math.round(EARTH_RADIUS_METERS * centralAngle);
 	}
 
 	private void requireFacilityStatus(UpdateAccessibilityFacilityStatusCommand command) {

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -221,7 +221,8 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		double haversine = Math.sin(deltaLatitude / 2) * Math.sin(deltaLatitude / 2)
 			+ Math.cos(latitude1) * Math.cos(latitude2)
 			* Math.sin(deltaLongitude / 2) * Math.sin(deltaLongitude / 2);
-		double centralAngle = 2 * Math.atan2(Math.sqrt(haversine), Math.sqrt(1 - haversine));
+		double boundedHaversine = Math.min(1.0, Math.max(0.0, haversine));
+		double centralAngle = 2 * Math.atan2(Math.sqrt(boundedHaversine), Math.sqrt(1 - boundedHaversine));
 		return (int) Math.round(EARTH_RADIUS_METERS * centralAngle);
 	}
 

--- a/backend/src/main/java/com/easysubway/transit/domain/InvalidStationSearchException.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/InvalidStationSearchException.java
@@ -1,0 +1,10 @@
+package com.easysubway.transit.domain;
+
+import com.easysubway.common.error.InvalidRequestException;
+
+public class InvalidStationSearchException extends InvalidRequestException {
+
+	public InvalidStationSearchException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/NearbyStation.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/NearbyStation.java
@@ -1,0 +1,7 @@
+package com.easysubway.transit.domain;
+
+public record NearbyStation(
+	StationWithLines stationWithLines,
+	int distanceMeters
+) {
+}

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -134,6 +134,17 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("가까운 역 조회는 좌표 누락도 공통 오류 응답으로 반환한다")
+	void nearbyStationsReturnCommonErrorWhenCoordinatesAreMissing() throws Exception {
+		mockMvc.perform(get("/api/v1/stations/nearby")
+				.param("lng", "126.866500"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("위도가 필요합니다."));
+	}
+
+	@Test
 	@DisplayName("역 출구 목록은 접근성 신호와 데이터 출처를 포함한다")
 	void stationExitsIncludeAccessibilitySignals() throws Exception {
 		mockMvc.perform(get("/api/v1/stations/station-sangnoksu/exits"))

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -93,6 +93,47 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("가까운 역 조회는 현재 위치 기준으로 역을 거리순 반환한다")
+	void nearbyStationsReturnStationsOrderedByDistance() throws Exception {
+		mockMvc.perform(get("/api/v1/stations/nearby")
+				.param("lat", "37.302800")
+				.param("lng", "126.866500")
+				.param("radiusMeters", "30000"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].id").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data[0].nameKo").value("상록수"))
+			.andExpect(jsonPath("$.data[0].distanceMeters").isNumber())
+			.andExpect(jsonPath("$.data[0].lines[0].id").value("seoul-4"))
+			.andExpect(jsonPath("$.data[1].id").value("station-sadang"));
+	}
+
+	@Test
+	@DisplayName("가까운 역 조회는 반경 밖 역을 제외한다")
+	void nearbyStationsExcludeStationsOutsideRadius() throws Exception {
+		mockMvc.perform(get("/api/v1/stations/nearby")
+				.param("lat", "37.302800")
+				.param("lng", "126.866500")
+				.param("radiusMeters", "500"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.length()").value(1))
+			.andExpect(jsonPath("$.data[0].id").value("station-sangnoksu"));
+	}
+
+	@Test
+	@DisplayName("가까운 역 조회는 올바른 좌표를 요구한다")
+	void nearbyStationsRequireValidCoordinates() throws Exception {
+		mockMvc.perform(get("/api/v1/stations/nearby")
+				.param("lat", "91.0")
+				.param("lng", "126.866500"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("위도는 -90부터 90 사이여야 합니다."));
+	}
+
+	@Test
 	@DisplayName("역 출구 목록은 접근성 신호와 데이터 출처를 포함한다")
 	void stationExitsIncludeAccessibilitySignals() throws Exception {
 		mockMvc.perform(get("/api/v1/stations/station-sangnoksu/exits"))

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -103,6 +103,22 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
+	@DisplayName("가까운 역 조회는 역-노선 연결을 한 번만 불러온다")
+	void searchNearbyStationsLoadsStationLinesOnce() {
+		var repository = new CountingTransitMasterRepository();
+		var service = new TransitMasterService(repository, repository);
+
+		service.searchNearbyStations(NearbyStationSearchCommand.of(
+			new BigDecimal("37.302795"),
+			new BigDecimal("126.866489"),
+			50_000,
+			10
+		));
+
+		assertThat(repository.stationLineLoadCount).isEqualTo(1);
+	}
+
+	@Test
 	@DisplayName("존재하지 않는 역 상세 조회는 도메인 예외를 던진다")
 	void getStationThrowsDomainExceptionForUnknownStation() {
 		assertThatThrownBy(() -> service.getStation("missing"))
@@ -333,6 +349,17 @@ class TransitMasterServiceTest {
 		@Override
 		public void alertFacilityStatusChanged(FacilityStatusChangedAlertCommand command) {
 			commands.add(command);
+		}
+	}
+
+	private static class CountingTransitMasterRepository extends InMemoryTransitMasterRepository {
+
+		private int stationLineLoadCount;
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			stationLineLoadCount++;
+			return super.loadStationLines();
 		}
 	}
 }

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
+import com.easysubway.transit.application.port.in.NearbyStationSearchCommand;
 import com.easysubway.transit.application.port.in.StationSearchCommand;
 import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilityStatusCommand;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
@@ -86,6 +87,19 @@ class TransitMasterServiceTest {
 			.extracting("id")
 			.containsExactly("seoul-4");
 		assertThat(inactiveLineMatches).isEmpty();
+	}
+
+	@Test
+	@DisplayName("가까운 역 조회는 대척점 부동소수점 오차로 먼 역을 포함하지 않는다")
+	void searchNearbyStationsDoesNotIncludeAntipodalStationAsZeroDistance() {
+		var nearbyStations = service.searchNearbyStations(NearbyStationSearchCommand.of(
+			new BigDecimal("-37.302795319689004"),
+			new BigDecimal("-53.13351073508813"),
+			500,
+			10
+		));
+
+		assertThat(nearbyStations).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

close #104

## 요약

- 현재 위치 기준 가까운 역 조회 API를 추가했습니다.
- 기존 역 요약 응답에 `distanceMeters`를 더해 모바일에서 가까운 역 후보를 바로 표시할 수 있게 했습니다.
- 좌표, 반경, 조회 개수 입력값을 검증해 잘못된 요청은 공통 400 응답으로 처리합니다.

## 변경 사항

- `GET /api/v1/stations/nearby` 엔드포인트 추가
- 가까운 역 조회용 입력 커맨드와 도메인 결과 모델 추가
- 활성 역만 대상으로 거리 계산, 반경 필터링, 거리순 정렬, 개수 제한 적용
- 가까운 역 조회 컨트롤러 테스트 추가

## 검증

- `./gradlew test --tests '*TransitMasterControllerTest.nearbyStations*'`
- `./gradlew test --tests '*TransitMaster*'`
- `./gradlew test`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`

## 리스크

- 현재는 인메모리 시드 역 기준의 거리 계산입니다. 운영 DB/PostGIS 연동 시에는 동일 응답 계약을 유지하면서 DB 거리 검색으로 교체할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 현재 위치 주변 역 검색 기능 추가
  - 위도, 경도를 입력하여 인근 역 조회 가능
  - 검색 범위와 결과 개수 설정 가능
  - 검색된 역들을 거리순으로 정렬 제공
  - 각 역까지의 거리 정보 포함

## 테스트
- 주변 역 검색 기능 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->