### PR TITLE
[Feat] 자주 쓰는 경로 즐겨찾기 연결

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -22,6 +22,7 @@ class EasySubwayApp extends StatelessWidget {
     RouteSearchRepository? routeRepository,
     FavoriteStationRepository? favoriteRepository,
     FavoriteFacilityRepository? favoriteFacilityRepository,
+    FavoriteRouteRepository? favoriteRouteRepository,
     NotificationSettingsRepository? notificationRepository,
     CurrentLocationProvider? locationProvider,
     AnonymousAuthRepository? anonymousAuthRepository,
@@ -36,6 +37,7 @@ class EasySubwayApp extends StatelessWidget {
            routeRepository: routeRepository,
            favoriteRepository: favoriteRepository,
            favoriteFacilityRepository: favoriteFacilityRepository,
+           favoriteRouteRepository: favoriteRouteRepository,
            notificationRepository: notificationRepository,
            locationProvider: locationProvider,
            anonymousAuthRepository: anonymousAuthRepository,
@@ -56,6 +58,7 @@ class EasySubwayApp extends StatelessWidget {
        routeRepository = dependencies.routeRepository,
        favoriteRepository = dependencies.favoriteRepository,
        favoriteFacilityRepository = dependencies.favoriteFacilityRepository,
+       favoriteRouteRepository = dependencies.favoriteRouteRepository,
        notificationRepository = dependencies.notificationRepository,
        locationProvider = dependencies.locationProvider;
 
@@ -64,6 +67,7 @@ class EasySubwayApp extends StatelessWidget {
   final RouteSearchRepository routeRepository;
   final FavoriteStationRepository? favoriteRepository;
   final FavoriteFacilityRepository? favoriteFacilityRepository;
+  final FavoriteRouteRepository? favoriteRouteRepository;
   final NotificationSettingsRepository? notificationRepository;
   final CurrentLocationProvider locationProvider;
   final OnboardingState initialOnboardingState;
@@ -118,6 +122,7 @@ class EasySubwayApp extends StatelessWidget {
         routeRepository: routeRepository,
         favoriteRepository: favoriteRepository,
         favoriteFacilityRepository: favoriteFacilityRepository,
+        favoriteRouteRepository: favoriteRouteRepository,
         notificationRepository: notificationRepository,
         locationProvider: locationProvider,
         initialOnboardingState: initialOnboardingState,
@@ -134,6 +139,7 @@ class _EasySubwayHome extends StatefulWidget {
     required this.routeRepository,
     required this.favoriteRepository,
     required this.favoriteFacilityRepository,
+    required this.favoriteRouteRepository,
     required this.notificationRepository,
     required this.locationProvider,
     required this.initialOnboardingState,
@@ -145,6 +151,7 @@ class _EasySubwayHome extends StatefulWidget {
   final RouteSearchRepository routeRepository;
   final FavoriteStationRepository? favoriteRepository;
   final FavoriteFacilityRepository? favoriteFacilityRepository;
+  final FavoriteRouteRepository? favoriteRouteRepository;
   final NotificationSettingsRepository? notificationRepository;
   final CurrentLocationProvider locationProvider;
   final OnboardingState initialOnboardingState;
@@ -201,6 +208,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         routeRepository: widget.routeRepository,
         favoriteRepository: widget.favoriteRepository,
         favoriteFacilityRepository: widget.favoriteFacilityRepository,
+        favoriteRouteRepository: widget.favoriteRouteRepository,
         notificationRepository: widget.notificationRepository,
         locationProvider: widget.locationProvider,
         initialMobilityType: onboardingResult?.profile.mobilityType,
@@ -315,6 +323,7 @@ class _EasySubwayAppDependencies {
     required this.routeRepository,
     required this.favoriteRepository,
     required this.favoriteFacilityRepository,
+    required this.favoriteRouteRepository,
     required this.notificationRepository,
     required this.locationProvider,
   });
@@ -325,6 +334,7 @@ class _EasySubwayAppDependencies {
     RouteSearchRepository? routeRepository,
     FavoriteStationRepository? favoriteRepository,
     FavoriteFacilityRepository? favoriteFacilityRepository,
+    FavoriteRouteRepository? favoriteRouteRepository,
     NotificationSettingsRepository? notificationRepository,
     CurrentLocationProvider? locationProvider,
     AnonymousAuthRepository? anonymousAuthRepository,
@@ -355,6 +365,12 @@ class _EasySubwayAppDependencies {
             baseUri: baseUri,
             authProvider: sharedAuthProvider,
           ),
+      favoriteRouteRepository:
+          favoriteRouteRepository ??
+          _defaultFavoriteRouteRepository(
+            baseUri: baseUri,
+            authProvider: sharedAuthProvider,
+          ),
       notificationRepository:
           notificationRepository ??
           _defaultNotificationSettingsRepository(
@@ -371,6 +387,7 @@ class _EasySubwayAppDependencies {
   final RouteSearchRepository routeRepository;
   final FavoriteStationRepository? favoriteRepository;
   final FavoriteFacilityRepository? favoriteFacilityRepository;
+  final FavoriteRouteRepository? favoriteRouteRepository;
   final NotificationSettingsRepository? notificationRepository;
   final CurrentLocationProvider locationProvider;
 }
@@ -415,6 +432,19 @@ FavoriteFacilityRepository? _defaultFavoriteFacilityRepository({
   );
 }
 
+FavoriteRouteRepository? _defaultFavoriteRouteRepository({
+  required Uri baseUri,
+  required AuthorizationHeaderProvider? authProvider,
+}) {
+  if (authProvider == null) {
+    return null;
+  }
+  return FavoriteRouteApiRepository(
+    baseUri: baseUri,
+    authProvider: authProvider,
+  );
+}
+
 NotificationSettingsRepository? _defaultNotificationSettingsRepository({
   required Uri baseUri,
   required AuthorizationHeaderProvider? authProvider,
@@ -435,6 +465,7 @@ class HomeScreen extends StatelessWidget {
     required this.routeRepository,
     required this.favoriteRepository,
     required this.favoriteFacilityRepository,
+    required this.favoriteRouteRepository,
     required this.notificationRepository,
     required this.locationProvider,
     this.simpleViewEnabled = true,
@@ -448,6 +479,7 @@ class HomeScreen extends StatelessWidget {
   final RouteSearchRepository routeRepository;
   final FavoriteStationRepository? favoriteRepository;
   final FavoriteFacilityRepository? favoriteFacilityRepository;
+  final FavoriteRouteRepository? favoriteRouteRepository;
   final NotificationSettingsRepository? notificationRepository;
   final CurrentLocationProvider locationProvider;
   final String initialMobilityType;
@@ -458,6 +490,7 @@ class HomeScreen extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
     final favoriteRepository = this.favoriteRepository;
     final favoriteFacilityRepository = this.favoriteFacilityRepository;
+    final favoriteRouteRepository = this.favoriteRouteRepository;
     final notificationRepository = this.notificationRepository;
 
     return Scaffold(
@@ -504,6 +537,7 @@ class HomeScreen extends StatelessWidget {
                     builder: (_) => RouteSearchScreen(
                       repository: routeRepository,
                       stationRepository: repository,
+                      favoriteRouteRepository: favoriteRouteRepository,
                       initialMobilityType: initialMobilityType,
                     ),
                   ),
@@ -513,6 +547,36 @@ class HomeScreen extends StatelessWidget {
               label: const Text('경로 검색'),
             ),
             const SizedBox(height: 12),
+            OutlinedButton.icon(
+              key: const Key('mobilityProfileButton'),
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<MobilityProfileOption>(
+                    builder: (_) => const MobilityProfileScreen(),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.accessibility_new),
+              label: const Text('이동 조건'),
+            ),
+            const SizedBox(height: 12),
+            if (favoriteRouteRepository != null) ...[
+              FilledButton.icon(
+                key: const Key('favoriteRoutesButton'),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => FavoriteRouteListScreen(
+                        repository: favoriteRouteRepository,
+                      ),
+                    ),
+                  );
+                },
+                icon: const Icon(Icons.bookmarks_outlined),
+                label: const Text('즐겨찾기 경로'),
+              ),
+              const SizedBox(height: 12),
+            ],
             if (favoriteRepository != null) ...[
               FilledButton.icon(
                 key: const Key('favoriteStationsButton'),
@@ -566,18 +630,6 @@ class HomeScreen extends StatelessWidget {
               ),
               const SizedBox(height: 12),
             ],
-            OutlinedButton.icon(
-              key: const Key('mobilityProfileButton'),
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute<MobilityProfileOption>(
-                    builder: (_) => const MobilityProfileScreen(),
-                  ),
-                );
-              },
-              icon: const Icon(Icons.accessibility_new),
-              label: const Text('이동 조건'),
-            ),
             if (!simpleViewEnabled) ...[
               const SizedBox(height: 24),
               const FeatureTile(

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -4,12 +4,15 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+import 'auth_headers.dart';
 import 'mobile_error_reporter.dart';
 import 'mobility_profile.dart';
 import 'station_search.dart';
 
 const _routeSearchTimeout = Duration(seconds: 8);
 const _routeSearchErrorMessage = '경로 정보를 불러오지 못했습니다.';
+const _favoriteRouteErrorMessage = '즐겨찾기 경로를 처리하지 못했습니다.';
+const _favoriteRouteLoadErrorMessage = '즐겨찾기 경로를 불러오지 못했습니다.';
 
 abstract class RouteSearchRepository {
   Future<RouteSearchResult> searchRoute(RouteSearchRequest request);
@@ -63,6 +66,237 @@ class RouteSearchApiRepository implements RouteSearchRepository {
       );
       throw const RouteSearchException(_routeSearchErrorMessage);
     }
+  }
+}
+
+abstract class FavoriteRouteRepository {
+  Future<List<FavoriteRoute>> listFavoriteRoutes();
+
+  Future<FavoriteRoute> saveFavoriteRoute(String routeSearchId);
+
+  Future<void> removeFavoriteRoute(String favoriteRouteId);
+}
+
+class FavoriteRouteApiRepository implements FavoriteRouteRepository {
+  FavoriteRouteApiRepository({
+    required this.baseUri,
+    required this.authProvider,
+    HttpClient? httpClient,
+  }) : _httpClient = httpClient ?? HttpClient();
+
+  final Uri baseUri;
+  final AuthorizationHeaderProvider authProvider;
+  final HttpClient _httpClient;
+
+  @override
+  Future<List<FavoriteRoute>> listFavoriteRoutes() async {
+    final data = await _requestData(
+      'GET',
+      baseUri.resolve('/api/v1/me/favorites/routes'),
+      errorMessage: _favoriteRouteLoadErrorMessage,
+    );
+    if (data is! List) {
+      throw const FavoriteRouteException(_favoriteRouteLoadErrorMessage);
+    }
+
+    try {
+      return data
+          .map((item) {
+            if (item is! Map<String, Object?>) {
+              throw const FormatException('Invalid favorite route payload');
+            }
+            return FavoriteRoute.fromJson(item);
+          })
+          .toList(growable: false);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '즐겨찾기 경로 목록 응답 처리 중 예외가 발생했습니다.',
+      );
+      throw const FavoriteRouteException(_favoriteRouteLoadErrorMessage);
+    }
+  }
+
+  @override
+  Future<FavoriteRoute> saveFavoriteRoute(String routeSearchId) async {
+    final data = await _requestData(
+      'POST',
+      baseUri.resolve('/api/v1/me/favorites/routes'),
+      body: {'routeSearchId': routeSearchId},
+      errorMessage: _favoriteRouteErrorMessage,
+    );
+    if (data is! Map<String, Object?>) {
+      throw const FavoriteRouteException(_favoriteRouteErrorMessage);
+    }
+
+    try {
+      return FavoriteRoute.fromJson(data);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '즐겨찾기 경로 저장 응답 처리 중 예외가 발생했습니다.',
+      );
+      throw const FavoriteRouteException(_favoriteRouteErrorMessage);
+    }
+  }
+
+  @override
+  Future<void> removeFavoriteRoute(String favoriteRouteId) async {
+    await _requestData(
+      'DELETE',
+      baseUri.resolve('/api/v1/me/favorites/routes/$favoriteRouteId'),
+      errorMessage: _favoriteRouteErrorMessage,
+    );
+  }
+
+  Future<Object?> _requestData(
+    String method,
+    Uri uri, {
+    Map<String, Object?>? body,
+    required String errorMessage,
+  }) async {
+    for (var attempt = 0; attempt < 2; attempt++) {
+      try {
+        final request = await _httpClient
+            .openUrl(method, uri)
+            .timeout(_routeSearchTimeout);
+        final authorizationHeader = await authProvider
+            .authorizationHeader()
+            .timeout(_routeSearchTimeout);
+        if (authorizationHeader != null) {
+          request.headers.set(
+            HttpHeaders.authorizationHeader,
+            authorizationHeader,
+          );
+        }
+        if (body != null) {
+          request.headers.contentType = ContentType.json;
+          request.write(jsonEncode(body));
+        }
+
+        final response = await request.close().timeout(_routeSearchTimeout);
+        final responseBody = await utf8
+            .decodeStream(response)
+            .timeout(_routeSearchTimeout);
+
+        if (response.statusCode == HttpStatus.unauthorized &&
+            authorizationHeader != null &&
+            attempt == 0) {
+          // 만료된 익명 인증은 비우고 새 인증으로 한 번만 다시 시도한다.
+          await authProvider.invalidateAuthorization().timeout(
+            _routeSearchTimeout,
+          );
+          continue;
+        }
+
+        if (response.statusCode < HttpStatus.ok ||
+            response.statusCode >= HttpStatus.multipleChoices) {
+          throw FavoriteRouteException(errorMessage);
+        }
+
+        final decoded = jsonDecode(responseBody);
+        if (decoded is! Map<String, Object?> || decoded['success'] != true) {
+          throw FavoriteRouteException(errorMessage);
+        }
+        return decoded['data'];
+      } on FavoriteRouteException {
+        rethrow;
+      } catch (error, stackTrace) {
+        reportMobileError(
+          error,
+          stackTrace,
+          context: '즐겨찾기 경로 API 요청 처리 중 예외가 발생했습니다.',
+        );
+        throw FavoriteRouteException(errorMessage);
+      }
+    }
+    throw FavoriteRouteException(errorMessage);
+  }
+}
+
+class FavoriteRouteException implements Exception {
+  const FavoriteRouteException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class FavoriteRoute {
+  const FavoriteRoute({
+    required this.userId,
+    required this.favoriteRouteId,
+    required this.routeSearchId,
+    required this.originStationId,
+    required this.originStationName,
+    required this.destinationStationId,
+    required this.destinationStationName,
+    required this.mobilityType,
+    required this.status,
+    required this.lineId,
+    required this.lineName,
+    required this.score,
+    required this.routeCreatedAt,
+    required this.addedAt,
+  });
+
+  factory FavoriteRoute.fromJson(Map<String, Object?> json) {
+    return FavoriteRoute(
+      userId: _requiredRouteString(json, 'userId'),
+      favoriteRouteId: _requiredRouteString(json, 'favoriteRouteId'),
+      routeSearchId: _requiredRouteString(json, 'routeSearchId'),
+      originStationId: _requiredRouteString(json, 'originStationId'),
+      originStationName: _requiredRouteString(json, 'originStationName'),
+      destinationStationId: _requiredRouteString(json, 'destinationStationId'),
+      destinationStationName: _requiredRouteString(
+        json,
+        'destinationStationName',
+      ),
+      mobilityType: _requiredRouteString(json, 'mobilityType'),
+      status: _requiredRouteString(json, 'status'),
+      lineId: _optionalRouteString(json, 'lineId'),
+      lineName: _optionalRouteString(json, 'lineName'),
+      score: _requiredRouteInt(json, 'score'),
+      routeCreatedAt: _requiredRouteString(json, 'routeCreatedAt'),
+      addedAt: _requiredRouteString(json, 'addedAt'),
+    );
+  }
+
+  final String userId;
+  final String favoriteRouteId;
+  final String routeSearchId;
+  final String originStationId;
+  final String originStationName;
+  final String destinationStationId;
+  final String destinationStationName;
+  final String mobilityType;
+  final String status;
+  final String lineId;
+  final String lineName;
+  final int score;
+  final String routeCreatedAt;
+  final String addedAt;
+
+  String get summaryTitle => '$originStationName에서 $destinationStationName까지';
+
+  String get lineLabel => lineName.isEmpty ? '노선 확인 필요' : lineName;
+
+  String get scoreLabel => '이동 점수 $score점';
+
+  String get mobilityLabel {
+    for (final option in mobilityProfileOptions) {
+      if (option.mobilityType == mobilityType) {
+        return option.title;
+      }
+    }
+    return '이동 조건 확인 필요';
+  }
+
+  String get semanticLabel {
+    return '즐겨찾기 경로, $summaryTitle, $lineLabel, $mobilityLabel, $scoreLabel';
   }
 }
 
@@ -388,12 +622,14 @@ class RouteSearchScreen extends StatefulWidget {
   RouteSearchScreen({
     required this.repository,
     required this.stationRepository,
+    this.favoriteRouteRepository,
     String? initialMobilityType,
     super.key,
   }) : initialMobilityType = _resolveInitialMobilityType(initialMobilityType);
 
   final RouteSearchRepository repository;
   final StationSearchRepository stationRepository;
+  final FavoriteRouteRepository? favoriteRouteRepository;
   final String initialMobilityType;
 
   @override
@@ -517,8 +753,10 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
             ],
             AnimatedBuilder(
               animation: _controller,
-              builder: (context, _) =>
-                  _RouteSearchBody(state: _controller.state),
+              builder: (context, _) => _RouteSearchBody(
+                state: _controller.state,
+                favoriteRouteRepository: widget.favoriteRouteRepository,
+              ),
             ),
           ],
         ),
@@ -904,9 +1142,13 @@ class _RouteStationOptionTile extends StatelessWidget {
 }
 
 class _RouteSearchBody extends StatelessWidget {
-  const _RouteSearchBody({required this.state});
+  const _RouteSearchBody({
+    required this.state,
+    required this.favoriteRouteRepository,
+  });
 
   final RouteSearchState state;
+  final FavoriteRouteRepository? favoriteRouteRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -928,6 +1170,7 @@ class _RouteSearchBody extends StatelessWidget {
       ),
       RouteSearchViewStatus.success => _RouteSearchResultCard(
         result: state.result!,
+        favoriteRouteRepository: favoriteRouteRepository,
       ),
     };
   }
@@ -956,7 +1199,36 @@ class _RouteSearchMessage extends StatelessWidget {
 }
 
 class _RouteSearchResultCard extends StatelessWidget {
-  const _RouteSearchResultCard({required this.result});
+  const _RouteSearchResultCard({
+    required this.result,
+    required this.favoriteRouteRepository,
+  });
+
+  final RouteSearchResult result;
+  final FavoriteRouteRepository? favoriteRouteRepository;
+
+  @override
+  Widget build(BuildContext context) {
+    final canSaveRoute = favoriteRouteRepository != null && !result.isBlocked;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _RouteSearchResultSummaryCard(result: result),
+        if (canSaveRoute) ...[
+          const SizedBox(height: 12),
+          _RouteFavoriteSaveButton(
+            result: result,
+            repository: favoriteRouteRepository!,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _RouteSearchResultSummaryCard extends StatelessWidget {
+  const _RouteSearchResultSummaryCard({required this.result});
 
   final RouteSearchResult result;
 
@@ -1123,6 +1395,421 @@ class _RouteStepTile extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _RouteFavoriteSaveButton extends StatefulWidget {
+  const _RouteFavoriteSaveButton({
+    required this.result,
+    required this.repository,
+  });
+
+  final RouteSearchResult result;
+  final FavoriteRouteRepository repository;
+
+  @override
+  State<_RouteFavoriteSaveButton> createState() =>
+      _RouteFavoriteSaveButtonState();
+}
+
+class _RouteFavoriteSaveButtonState extends State<_RouteFavoriteSaveButton> {
+  bool _saving = false;
+  String _message = '';
+
+  @override
+  void didUpdateWidget(_RouteFavoriteSaveButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.result.routeSearchId != widget.result.routeSearchId) {
+      _saving = false;
+      _message = '';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        FilledButton.icon(
+          key: const Key('routeFavoriteSaveButton'),
+          onPressed: _saving ? null : _save,
+          icon: const Icon(Icons.bookmark_add_outlined),
+          label: Text(_saving ? '저장 중' : '자주 쓰는 경로 저장'),
+        ),
+        if (_message.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          Semantics(
+            liveRegion: true,
+            child: Text(
+              _message,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: const Color(0xFF29484B),
+                fontWeight: FontWeight.w800,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Future<void> _save() async {
+    setState(() {
+      _saving = true;
+      _message = '';
+    });
+
+    try {
+      await widget.repository.saveFavoriteRoute(widget.result.routeSearchId);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _saving = false;
+        _message = '자주 쓰는 경로에 저장했습니다.';
+      });
+    } on FavoriteRouteException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _saving = false;
+        _message = error.message;
+      });
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '경로 즐겨찾기 저장 화면 처리 중 예외가 발생했습니다.',
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _saving = false;
+        _message = _favoriteRouteErrorMessage;
+      });
+    }
+  }
+}
+
+enum FavoriteRouteListStatus { loading, success, empty, failure }
+
+class FavoriteRouteListState {
+  const FavoriteRouteListState({
+    required this.status,
+    required this.favorites,
+    this.message = '',
+  });
+
+  const FavoriteRouteListState.loading()
+    : status = FavoriteRouteListStatus.loading,
+      favorites = const [],
+      message = '';
+
+  final FavoriteRouteListStatus status;
+  final List<FavoriteRoute> favorites;
+  final String message;
+}
+
+class FavoriteRouteListController extends ChangeNotifier {
+  FavoriteRouteListController({required this.repository});
+
+  final FavoriteRouteRepository repository;
+  FavoriteRouteListState _state = const FavoriteRouteListState.loading();
+  bool _disposed = false;
+
+  FavoriteRouteListState get state => _state;
+
+  Future<void> load() async {
+    _emitState(const FavoriteRouteListState.loading());
+    try {
+      final favorites = await repository.listFavoriteRoutes();
+      if (_disposed) {
+        return;
+      }
+      _emitState(
+        favorites.isEmpty
+            ? const FavoriteRouteListState(
+                status: FavoriteRouteListStatus.empty,
+                favorites: [],
+                message: '저장한 경로가 없습니다.',
+              )
+            : FavoriteRouteListState(
+                status: FavoriteRouteListStatus.success,
+                favorites: favorites,
+              ),
+      );
+    } on FavoriteRouteException catch (error) {
+      _emitFailure(error.message);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '즐겨찾기 경로 목록 화면 처리 중 예외가 발생했습니다.',
+      );
+      _emitFailure(_favoriteRouteLoadErrorMessage);
+    }
+  }
+
+  Future<void> remove(FavoriteRoute favorite) async {
+    try {
+      await repository.removeFavoriteRoute(favorite.favoriteRouteId);
+      if (_disposed) {
+        return;
+      }
+      final nextFavorites = _state.favorites
+          .where((item) => item.favoriteRouteId != favorite.favoriteRouteId)
+          .toList(growable: false);
+      _emitState(
+        nextFavorites.isEmpty
+            ? const FavoriteRouteListState(
+                status: FavoriteRouteListStatus.empty,
+                favorites: [],
+                message: '저장한 경로가 없습니다.',
+              )
+            : FavoriteRouteListState(
+                status: FavoriteRouteListStatus.success,
+                favorites: nextFavorites,
+              ),
+      );
+    } on FavoriteRouteException catch (error) {
+      _emitFailure(error.message);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '즐겨찾기 경로 삭제 처리 중 예외가 발생했습니다.',
+      );
+      _emitFailure(_favoriteRouteErrorMessage);
+    }
+  }
+
+  void _emitFailure(String message) {
+    _emitState(
+      FavoriteRouteListState(
+        status: FavoriteRouteListStatus.failure,
+        favorites: _state.favorites,
+        message: message,
+      ),
+    );
+  }
+
+  void _emitState(FavoriteRouteListState nextState) {
+    if (_disposed) {
+      return;
+    }
+    _state = nextState;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+}
+
+class FavoriteRouteListScreen extends StatefulWidget {
+  const FavoriteRouteListScreen({required this.repository, super.key});
+
+  final FavoriteRouteRepository repository;
+
+  @override
+  State<FavoriteRouteListScreen> createState() =>
+      _FavoriteRouteListScreenState();
+}
+
+class _FavoriteRouteListScreenState extends State<FavoriteRouteListScreen> {
+  late final FavoriteRouteListController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = FavoriteRouteListController(repository: widget.repository);
+    unawaited(_controller.load());
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('즐겨찾기 경로')),
+      body: SafeArea(
+        child: AnimatedBuilder(
+          animation: _controller,
+          builder: (context, _) => _FavoriteRouteListBody(
+            state: _controller.state,
+            onRetry: _controller.load,
+            onRemove: _controller.remove,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FavoriteRouteListBody extends StatelessWidget {
+  const _FavoriteRouteListBody({
+    required this.state,
+    required this.onRetry,
+    required this.onRemove,
+  });
+
+  final FavoriteRouteListState state;
+  final VoidCallback onRetry;
+  final ValueChanged<FavoriteRoute> onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+      children: [
+        switch (state.status) {
+          FavoriteRouteListStatus.loading => Semantics(
+            label: '즐겨찾기 경로 불러오는 중',
+            liveRegion: true,
+            child: const Center(
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: 24),
+                child: CircularProgressIndicator(),
+              ),
+            ),
+          ),
+          FavoriteRouteListStatus.empty => _RouteSearchMessage(
+            message: state.message,
+            liveRegion: true,
+          ),
+          FavoriteRouteListStatus.failure => Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _RouteSearchMessage(message: state.message, liveRegion: true),
+              const SizedBox(height: 12),
+              OutlinedButton.icon(
+                key: const Key('favoriteRoutesRetryButton'),
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh),
+                label: const Text('다시 불러오기'),
+              ),
+            ],
+          ),
+          FavoriteRouteListStatus.success => Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Semantics(
+                label: '즐겨찾기 경로 ${state.favorites.length}개',
+                liveRegion: true,
+                child: const SizedBox.shrink(),
+              ),
+              for (final favorite in state.favorites)
+                _FavoriteRouteTile(favorite: favorite, onRemove: onRemove),
+            ],
+          ),
+        },
+      ],
+    );
+  }
+}
+
+class _FavoriteRouteTile extends StatelessWidget {
+  const _FavoriteRouteTile({required this.favorite, required this.onRemove});
+
+  final FavoriteRoute favorite;
+  final ValueChanged<FavoriteRoute> onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _FavoriteRouteSummaryCard(favorite: favorite),
+        const SizedBox(height: 12),
+        OutlinedButton.icon(
+          key: Key('favoriteRouteRemove-${favorite.favoriteRouteId}'),
+          onPressed: () => onRemove(favorite),
+          icon: const Icon(Icons.delete_outline),
+          label: const Text('삭제'),
+        ),
+        const SizedBox(height: 12),
+      ],
+    );
+  }
+}
+
+class _FavoriteRouteSummaryCard extends StatelessWidget {
+  const _FavoriteRouteSummaryCard({required this.favorite});
+
+  final FavoriteRoute favorite;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return MergeSemantics(
+      child: Semantics(
+        label: favorite.semanticLabel,
+        child: ExcludeSemantics(
+          child: Card(
+            margin: const EdgeInsets.only(bottom: 12),
+            color: Colors.white,
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: const BorderSide(color: Color(0xFFD5E2E4)),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    favorite.summaryTitle,
+                    style: textTheme.titleLarge?.copyWith(
+                      color: const Color(0xFF102A2C),
+                      fontWeight: FontWeight.w900,
+                      height: 1.25,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    favorite.lineLabel,
+                    style: textTheme.bodyLarge?.copyWith(
+                      color: const Color(0xFF29484B),
+                      fontWeight: FontWeight.w800,
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    favorite.mobilityLabel,
+                    style: textTheme.bodyLarge?.copyWith(
+                      color: const Color(0xFF29484B),
+                      fontWeight: FontWeight.w800,
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    favorite.scoreLabel,
+                    style: textTheme.bodyLarge?.copyWith(
+                      color: const Color(0xFF29484B),
+                      fontWeight: FontWeight.w800,
+                      height: 1.3,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1503,16 +1503,33 @@ class FavoriteRouteListState {
     required this.status,
     required this.favorites,
     this.message = '',
+    this.removingIds = const {},
   });
 
   const FavoriteRouteListState.loading()
     : status = FavoriteRouteListStatus.loading,
       favorites = const [],
-      message = '';
+      message = '',
+      removingIds = const {};
 
   final FavoriteRouteListStatus status;
   final List<FavoriteRoute> favorites;
   final String message;
+  final Set<String> removingIds;
+
+  FavoriteRouteListState copyWith({
+    FavoriteRouteListStatus? status,
+    List<FavoriteRoute>? favorites,
+    String? message,
+    Set<String>? removingIds,
+  }) {
+    return FavoriteRouteListState(
+      status: status ?? this.status,
+      favorites: favorites ?? this.favorites,
+      message: message ?? this.message,
+      removingIds: removingIds ?? this.removingIds,
+    );
+  }
 }
 
 class FavoriteRouteListController extends ChangeNotifier {
@@ -1556,44 +1573,64 @@ class FavoriteRouteListController extends ChangeNotifier {
   }
 
   Future<void> remove(FavoriteRoute favorite) async {
+    final favoriteRouteId = favorite.favoriteRouteId;
+    if (_state.removingIds.contains(favoriteRouteId)) {
+      return;
+    }
+
+    _emitState(
+      _state.copyWith(removingIds: {..._state.removingIds, favoriteRouteId}),
+    );
+
     try {
-      await repository.removeFavoriteRoute(favorite.favoriteRouteId);
+      await repository.removeFavoriteRoute(favoriteRouteId);
       if (_disposed) {
         return;
       }
       final nextFavorites = _state.favorites
-          .where((item) => item.favoriteRouteId != favorite.favoriteRouteId)
+          .where((item) => item.favoriteRouteId != favoriteRouteId)
           .toList(growable: false);
+      final nextRemovingIds = {..._state.removingIds}..remove(favoriteRouteId);
       _emitState(
         nextFavorites.isEmpty
-            ? const FavoriteRouteListState(
+            ? FavoriteRouteListState(
                 status: FavoriteRouteListStatus.empty,
-                favorites: [],
+                favorites: const [],
                 message: '저장한 경로가 없습니다.',
+                removingIds: nextRemovingIds,
               )
             : FavoriteRouteListState(
                 status: FavoriteRouteListStatus.success,
                 favorites: nextFavorites,
+                removingIds: nextRemovingIds,
               ),
       );
     } on FavoriteRouteException catch (error) {
-      _emitFailure(error.message);
+      _emitFailure(error.message, removingIdToClear: favoriteRouteId);
     } catch (error, stackTrace) {
       reportMobileError(
         error,
         stackTrace,
         context: '즐겨찾기 경로 삭제 처리 중 예외가 발생했습니다.',
       );
-      _emitFailure(_favoriteRouteErrorMessage);
+      _emitFailure(
+        _favoriteRouteErrorMessage,
+        removingIdToClear: favoriteRouteId,
+      );
     }
   }
 
-  void _emitFailure(String message) {
+  void _emitFailure(String message, {String? removingIdToClear}) {
+    final nextRemovingIds = {..._state.removingIds};
+    if (removingIdToClear != null) {
+      nextRemovingIds.remove(removingIdToClear);
+    }
     _emitState(
       FavoriteRouteListState(
         status: FavoriteRouteListStatus.failure,
         favorites: _state.favorites,
         message: message,
+        removingIds: nextRemovingIds,
       ),
     );
   }
@@ -1710,7 +1747,13 @@ class _FavoriteRouteListBody extends StatelessWidget {
                 child: const SizedBox.shrink(),
               ),
               for (final favorite in state.favorites)
-                _FavoriteRouteTile(favorite: favorite, onRemove: onRemove),
+                _FavoriteRouteTile(
+                  favorite: favorite,
+                  isRemoving: state.removingIds.contains(
+                    favorite.favoriteRouteId,
+                  ),
+                  onRemove: onRemove,
+                ),
             ],
           ),
         },
@@ -1720,23 +1763,45 @@ class _FavoriteRouteListBody extends StatelessWidget {
 }
 
 class _FavoriteRouteTile extends StatelessWidget {
-  const _FavoriteRouteTile({required this.favorite, required this.onRemove});
+  const _FavoriteRouteTile({
+    required this.favorite,
+    required this.isRemoving,
+    required this.onRemove,
+  });
 
   final FavoriteRoute favorite;
+  final bool isRemoving;
   final ValueChanged<FavoriteRoute> onRemove;
 
   @override
   Widget build(BuildContext context) {
+    final removeSemanticLabel =
+        '${favorite.summaryTitle} ${isRemoving ? '삭제 중' : '삭제'}';
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _FavoriteRouteSummaryCard(favorite: favorite),
         const SizedBox(height: 12),
-        OutlinedButton.icon(
-          key: Key('favoriteRouteRemove-${favorite.favoriteRouteId}'),
-          onPressed: () => onRemove(favorite),
-          icon: const Icon(Icons.delete_outline),
-          label: const Text('삭제'),
+        Semantics(
+          container: true,
+          label: removeSemanticLabel,
+          button: true,
+          enabled: !isRemoving,
+          onTap: isRemoving ? null : () => onRemove(favorite),
+          child: ExcludeSemantics(
+            child: OutlinedButton.icon(
+              key: Key('favoriteRouteRemove-${favorite.favoriteRouteId}'),
+              onPressed: isRemoving ? null : () => onRemove(favorite),
+              icon: isRemoving
+                  ? const SizedBox.square(
+                      dimension: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.delete_outline),
+              label: Text(isRemoving ? '삭제 중' : '삭제'),
+            ),
+          ),
         ),
         const SizedBox(height: 12),
       ],

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:easysubway_mobile/auth_headers.dart';
 import 'package:easysubway_mobile/route_search.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -149,6 +150,69 @@ void main() {
 
     expect(notificationCount, 1);
   });
+
+  test('즐겨찾기 경로 API 저장소는 인증 헤더로 저장과 목록과 삭제를 요청한다', () async {
+    final requestedMethods = <String>[];
+    final requestedPaths = <String>[];
+    final requestedBodies = <String>[];
+    final requestedAuthorizations = <String?>[];
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) async {
+      requestedMethods.add(request.method);
+      requestedPaths.add(request.uri.path);
+      requestedAuthorizations.add(
+        request.headers.value(HttpHeaders.authorizationHeader),
+      );
+      requestedBodies.add(await utf8.decoder.bind(request).join());
+
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json;
+
+      if (request.method == 'GET') {
+        request.response.write(
+          jsonEncode({
+            'success': true,
+            'data': [_favoriteRouteJson()],
+          }),
+        );
+      } else if (request.method == 'POST') {
+        request.response.write(
+          jsonEncode({'success': true, 'data': _favoriteRouteJson()}),
+        );
+      } else {
+        request.response.write(jsonEncode({'success': true, 'data': null}));
+      }
+      await request.response.close();
+    });
+
+    final repository = FavoriteRouteApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: const BasicAuthorizationHeaderProvider(
+        username: 'anonymous-user-1',
+        password: 'password',
+      ),
+    );
+
+    final favorites = await repository.listFavoriteRoutes();
+    final saved = await repository.saveFavoriteRoute('route-1');
+    await repository.removeFavoriteRoute('route-1');
+
+    expect(requestedMethods, ['GET', 'POST', 'DELETE']);
+    expect(requestedPaths, [
+      '/api/v1/me/favorites/routes',
+      '/api/v1/me/favorites/routes',
+      '/api/v1/me/favorites/routes/route-1',
+    ]);
+    expect(jsonDecode(requestedBodies[1]), {'routeSearchId': 'route-1'});
+    expect(requestedAuthorizations, everyElement(startsWith('Basic ')));
+    expect(favorites.single.summaryTitle, '상록수에서 사당까지');
+    expect(saved.favoriteRouteId, 'route-1');
+    expect(saved.mobilityLabel, '고령자');
+    expect(saved.scoreLabel, '이동 점수 92점');
+  });
 }
 
 class FakeRouteSearchRepository implements RouteSearchRepository {
@@ -210,4 +274,23 @@ RouteSearchResult _sampleRouteSearchResult() {
     blockedReasons: [],
     createdAt: '2026-06-13T04:20:00',
   );
+}
+
+Map<String, Object?> _favoriteRouteJson() {
+  return {
+    'userId': 'anonymous-user-1',
+    'favoriteRouteId': 'route-1',
+    'routeSearchId': 'route-1',
+    'originStationId': 'station-sangnoksu',
+    'originStationName': '상록수',
+    'destinationStationId': 'station-sadang',
+    'destinationStationName': '사당',
+    'mobilityType': 'SENIOR',
+    'status': 'FOUND',
+    'lineId': 'seoul-4',
+    'lineName': '수도권 4호선',
+    'score': 92,
+    'routeCreatedAt': '2026-06-13T04:20:00',
+    'addedAt': '2026-06-14T10:00:00',
+  };
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -277,7 +277,7 @@ void main() {
       expect(notificationButtonSize.height, greaterThanOrEqualTo(60));
       expect(profileButtonSize.height, greaterThanOrEqualTo(60));
 
-      await tester.drag(find.byType(ListView), const Offset(0, -220));
+      await tester.drag(find.byType(ListView), const Offset(0, -620));
       await tester.pumpAndSettle();
 
       expect(find.text('이동 프로필'), findsOneWidget);
@@ -304,6 +304,8 @@ void main() {
 
     expect(find.byKey(const Key('favoriteStationsButton')), findsNothing);
     expect(find.widgetWithText(FilledButton, '즐겨찾기 역'), findsNothing);
+    expect(find.byKey(const Key('favoriteRoutesButton')), findsNothing);
+    expect(find.widgetWithText(FilledButton, '즐겨찾기 경로'), findsNothing);
     expect(find.byKey(const Key('notificationSettingsButton')), findsNothing);
     expect(find.widgetWithText(FilledButton, '알림 설정'), findsNothing);
   });
@@ -319,6 +321,8 @@ void main() {
       ),
     );
 
+    expect(find.byKey(const Key('favoriteRoutesButton')), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, '즐겨찾기 경로'), findsOneWidget);
     expect(find.byKey(const Key('favoriteStationsButton')), findsOneWidget);
     expect(find.widgetWithText(FilledButton, '즐겨찾기 역'), findsOneWidget);
     expect(find.byKey(const Key('notificationSettingsButton')), findsOneWidget);
@@ -338,6 +342,8 @@ void main() {
         app.favoriteRepository as FavoriteStationApiRepository;
     final favoriteFacilityRepository =
         app.favoriteFacilityRepository as FavoriteFacilityApiRepository;
+    final favoriteRouteRepository =
+        app.favoriteRouteRepository as FavoriteRouteApiRepository;
     final notificationRepository =
         app.notificationRepository as NotificationSettingsApiRepository;
 
@@ -351,6 +357,13 @@ void main() {
     expect(
       identical(
         favoriteFacilityRepository.authProvider,
+        favoriteRouteRepository.authProvider,
+      ),
+      isTrue,
+    );
+    expect(
+      identical(
+        favoriteRouteRepository.authProvider,
         notificationRepository.authProvider,
       ),
       isTrue,
@@ -373,6 +386,10 @@ void main() {
         ),
       );
 
+      await tester.ensureVisible(
+        find.byKey(const Key('notificationSettingsButton')),
+      );
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('notificationSettingsButton')));
       await tester.pumpAndSettle();
 
@@ -508,6 +525,54 @@ void main() {
         ),
       );
       expect(tileSize.height, greaterThanOrEqualTo(72));
+
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
+  testWidgets('홈 즐겨찾기 경로는 저장한 경로를 큰 목록으로 보여주고 삭제한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final favoriteRouteRepository = FakeFavoriteRouteRepository(
+      favorites: [_favoriteRoute()],
+    );
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+          favoriteRouteRepository: favoriteRouteRepository,
+          notificationRepository: FakeNotificationSettingsRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('favoriteRoutesButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('즐겨찾기 경로'), findsOneWidget);
+      expect(find.text('상록수에서 사당까지'), findsOneWidget);
+      expect(find.text('수도권 4호선'), findsOneWidget);
+      expect(find.text('고령자'), findsOneWidget);
+      expect(find.text('이동 점수 92점'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('즐겨찾기 경로, 상록수에서 사당까지, 수도권 4호선, 고령자, 이동 점수 92점'),
+        findsOneWidget,
+      );
+      expect(find.bySemanticsLabel('삭제'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('favoriteRouteRemove-route-1')));
+      await tester.pumpAndSettle();
+
+      expect(favoriteRouteRepository.removedFavoriteRouteIds, ['route-1']);
+      expect(find.text('저장한 경로가 없습니다.'), findsOneWidget);
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
@@ -1206,6 +1271,71 @@ void main() {
     }
   });
 
+  testWidgets('경로 검색 결과는 이동 가능한 경로만 즐겨찾기에 저장한다', (tester) async {
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '사당': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
+    final favoriteRouteRepository = FakeFavoriteRouteRepository();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteRouteRepository: favoriteRouteRepository,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchButton')));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeOriginStationInput')),
+      '상록수',
+    );
+    await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeDestinationStationInput')),
+      '사당',
+    );
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationSearchButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationOption-station-sadang')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(ListView), const Offset(0, -360));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('자주 쓰는 경로 저장'), findsOneWidget);
+
+    await tester.ensureVisible(
+      find.byKey(const Key('routeFavoriteSaveButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeFavoriteSaveButton')));
+    await tester.pumpAndSettle();
+
+    expect(favoriteRouteRepository.savedRouteSearchIds, ['route-1']);
+    expect(find.text('자주 쓰는 경로에 저장했습니다.'), findsOneWidget);
+  });
+
   testWidgets('경로 검색은 입력만 하고 선택하지 않은 역을 쉬운 문구로 안내한다', (tester) async {
     final routeRepository = FakeRouteSearchRepository();
 
@@ -1561,6 +1691,25 @@ FavoriteFacility _favoriteFacility() {
   );
 }
 
+FavoriteRoute _favoriteRoute() {
+  return const FavoriteRoute(
+    userId: 'anonymous-user-1',
+    favoriteRouteId: 'route-1',
+    routeSearchId: 'route-1',
+    originStationId: 'station-sangnoksu',
+    originStationName: '상록수',
+    destinationStationId: 'station-sadang',
+    destinationStationName: '사당',
+    mobilityType: 'SENIOR',
+    status: 'FOUND',
+    lineId: 'seoul-4',
+    lineName: '수도권 4호선',
+    score: 92,
+    routeCreatedAt: '2026-06-13T04:20:00',
+    addedAt: '2026-06-14T10:00:00',
+  );
+}
+
 class FakeStationSearchRepository implements StationSearchRepository {
   FakeStationSearchRepository({
     this.nextResults = const [],
@@ -1807,6 +1956,48 @@ class FakeFavoriteFacilityRepository implements FavoriteFacilityRepository {
       throw currentError;
     }
     return favorites;
+  }
+}
+
+class FakeFavoriteRouteRepository implements FavoriteRouteRepository {
+  FakeFavoriteRouteRepository({this.favorites = const []});
+
+  List<FavoriteRoute> favorites;
+  final savedRouteSearchIds = <String>[];
+  final removedFavoriteRouteIds = <String>[];
+  Object? error;
+
+  @override
+  Future<List<FavoriteRoute>> listFavoriteRoutes() async {
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return favorites;
+  }
+
+  @override
+  Future<FavoriteRoute> saveFavoriteRoute(String routeSearchId) async {
+    savedRouteSearchIds.add(routeSearchId);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    final favorite = _favoriteRoute();
+    favorites = [favorite];
+    return favorite;
+  }
+
+  @override
+  Future<void> removeFavoriteRoute(String favoriteRouteId) async {
+    removedFavoriteRouteIds.add(favoriteRouteId);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    favorites = favorites
+        .where((favorite) => favorite.favoriteRouteId != favoriteRouteId)
+        .toList(growable: false);
   }
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -566,7 +566,7 @@ void main() {
         find.bySemanticsLabel('즐겨찾기 경로, 상록수에서 사당까지, 수도권 4호선, 고령자, 이동 점수 92점'),
         findsOneWidget,
       );
-      expect(find.bySemanticsLabel('삭제'), findsOneWidget);
+      expect(find.bySemanticsLabel('상록수에서 사당까지 삭제'), findsOneWidget);
 
       await tester.tap(find.byKey(const Key('favoriteRouteRemove-route-1')));
       await tester.pumpAndSettle();
@@ -580,6 +580,48 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('홈 즐겨찾기 경로 삭제 중에는 같은 항목을 다시 누를 수 없다', (tester) async {
+    final removeCompleter = Completer<void>();
+    final favoriteRouteRepository = FakeFavoriteRouteRepository(
+      favorites: [_favoriteRoute()],
+      removeCompleter: removeCompleter,
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: favoriteRouteRepository,
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('favoriteRoutesButton')));
+    await tester.pumpAndSettle();
+
+    final removeButton = find.byKey(const Key('favoriteRouteRemove-route-1'));
+    await tester.tap(removeButton);
+    await tester.pump();
+
+    expect(favoriteRouteRepository.removedFavoriteRouteIds, ['route-1']);
+    expect(find.text('삭제 중'), findsOneWidget);
+    expect(find.bySemanticsLabel('상록수에서 사당까지 삭제 중'), findsOneWidget);
+
+    await tester.tap(removeButton);
+    await tester.pump();
+
+    expect(favoriteRouteRepository.removedFavoriteRouteIds, ['route-1']);
+
+    removeCompleter.complete();
+    await tester.pumpAndSettle();
+
+    expect(find.text('저장한 경로가 없습니다.'), findsOneWidget);
   });
 
   testWidgets('역 검색은 접근성 표시가 포함된 백엔드 결과를 보여준다', (tester) async {
@@ -1960,9 +2002,13 @@ class FakeFavoriteFacilityRepository implements FavoriteFacilityRepository {
 }
 
 class FakeFavoriteRouteRepository implements FavoriteRouteRepository {
-  FakeFavoriteRouteRepository({this.favorites = const []});
+  FakeFavoriteRouteRepository({
+    this.favorites = const [],
+    this.removeCompleter,
+  });
 
   List<FavoriteRoute> favorites;
+  final Completer<void>? removeCompleter;
   final savedRouteSearchIds = <String>[];
   final removedFavoriteRouteIds = <String>[];
   Object? error;
@@ -1994,6 +2040,10 @@ class FakeFavoriteRouteRepository implements FavoriteRouteRepository {
     final currentError = error;
     if (currentError != null) {
       throw currentError;
+    }
+    final currentRemoveCompleter = removeCompleter;
+    if (currentRemoveCompleter != null) {
+      await currentRemoveCompleter.future;
     }
     favorites = favorites
         .where((favorite) => favorite.favoriteRouteId != favoriteRouteId)


### PR DESCRIPTION
## 관련 이슈
- close #112

## 배경
경로 검색에서 확인한 이동 경로를 다시 쓰려면 매번 출발역과 도착역을 다시 입력해야 했다. 자주 이동하는 사용자가 같은 경로를 빠르게 다시 확인할 수 있도록 경로 검색 결과 저장과 홈 진입 목록을 연결한다.

## 변경 사항
- 경로 검색 결과에서 이동 가능한 경로를 `자주 쓰는 경로`로 저장하는 액션을 추가했다.
- 홈 화면에 `즐겨찾기 경로` 진입 버튼을 추가하고, 저장한 경로 목록과 삭제 흐름을 연결했다.
- 즐겨찾기 경로 API 저장소를 추가해 목록 조회, 저장, 삭제 요청에 익명 인증 헤더를 함께 보낸다.
- 결과 요약과 저장/삭제 버튼의 접근성 의미를 분리해 스크린리더에서 카드 설명과 버튼 액션이 각각 잡히게 했다.
- 즐겨찾기 경로 저장/목록/삭제 위젯 테스트와 API 계약 테스트를 추가했다.

## 검증
- `flutter test`
- `flutter build apk --debug`
- `flutter build ios --simulator --no-codesign`
- `node --test tools/ci/*.test.mjs`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/ISSUE_TEMPLATE/*.yml`
- Android 에뮬레이터에서 온보딩 완료 후 `상록수 -> 사당` 경로 검색, 경로 저장, 즐겨찾기 경로 목록 조회, 삭제 후 빈 목록 복귀를 확인했다.

## 리스크
- dev 환경에서 즐겨찾기 경로 저장은 익명 인증을 거치므로 Redis가 떠 있지 않으면 요청이 실패한다. 로컬 검증에서는 Redis 기동 후 저장/조회/삭제 흐름을 확인했다.

## 체크리스트
- [x] 사용자에게 보이는 문구가 과도한 설명 없이 짧고 직접적인지 확인
- [x] 저장/삭제 버튼이 큰 터치 영역과 접근성 라벨을 가진지 확인
- [x] README 외 Markdown 문서가 새로 추적되지 않는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **즐겨찾기 경로 기능** - 자주 이용하는 경로를 저장하고 관리할 수 있습니다
* **즐겨찾기 경로 목록 화면** - 저장된 경로를 확인하고 필요에 따라 삭제할 수 있습니다
* **경로 검색 결과에서 즐겨찾기 저장** - 검색한 경로를 빠르게 저장할 수 있습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->