### PR TITLE
[Feat] 경로 단계별 이동 부담 요약 추가

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -485,7 +485,7 @@ class RouteSearchResult {
     }
     if (steps.isNotEmpty) {
       parts.add(
-        '이동 안내 ${steps.map((step) => '${step.sequence}번 ${step.title}, ${step.description}').join(', ')}',
+        '이동 안내 ${steps.map((step) => '${step.sequence}번 ${step.title}, ${step.burdenLabel}, ${step.description}').join(', ')}',
       );
     }
     return parts.join(', ');
@@ -501,6 +501,10 @@ class RouteSearchStep {
     required this.lineName,
     required this.fromStationId,
     required this.toStationId,
+    required this.estimatedMinutes,
+    required this.distanceMeters,
+    required this.includesStairs,
+    required this.requiresAccessibilityCheck,
   });
 
   factory RouteSearchStep.fromJson(Map<String, Object?> json) {
@@ -512,6 +516,13 @@ class RouteSearchStep {
       lineName: _optionalRouteString(json, 'lineName'),
       fromStationId: _optionalRouteString(json, 'fromStationId'),
       toStationId: _optionalRouteString(json, 'toStationId'),
+      estimatedMinutes: _requiredRouteInt(json, 'estimatedMinutes'),
+      distanceMeters: _requiredRouteInt(json, 'distanceMeters'),
+      includesStairs: _requiredRouteBool(json, 'includesStairs'),
+      requiresAccessibilityCheck: _requiredRouteBool(
+        json,
+        'requiresAccessibilityCheck',
+      ),
     );
   }
 
@@ -522,6 +533,32 @@ class RouteSearchStep {
   final String lineName;
   final String fromStationId;
   final String toStationId;
+  final int estimatedMinutes;
+  final int distanceMeters;
+  final bool includesStairs;
+  final bool requiresAccessibilityCheck;
+
+  String get burdenLabel {
+    final labels = <String>[
+      '약 $estimatedMinutes분',
+      _routeDistanceLabel(distanceMeters),
+      if (includesStairs) '계단 포함',
+      if (requiresAccessibilityCheck) '접근성 확인',
+    ];
+    return labels.join(' · ');
+  }
+}
+
+String _routeDistanceLabel(int distanceMeters) {
+  if (distanceMeters < 1000) {
+    return '${distanceMeters}m';
+  }
+
+  final kilometers = distanceMeters / 1000;
+  if (distanceMeters % 1000 == 0) {
+    return '${kilometers.toStringAsFixed(0)}km';
+  }
+  return '${kilometers.toStringAsFixed(1)}km';
 }
 
 class RouteSearchWarning {
@@ -1562,6 +1599,15 @@ class _RouteStepTile extends StatelessWidget {
                 ),
                 const SizedBox(height: 4),
                 Text(
+                  step.burdenLabel,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: const Color(0xFF29484B),
+                    fontWeight: FontWeight.w800,
+                    height: 1.3,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
                   step.description,
                   style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                     color: const Color(0xFF405A5D),
@@ -2077,6 +2123,14 @@ String _optionalRouteString(Map<String, Object?> json, String key) {
 int _requiredRouteInt(Map<String, Object?> json, String key) {
   final value = json[key];
   if (value is int) {
+    return value;
+  }
+  throw FormatException('Missing required route field: $key');
+}
+
+bool _requiredRouteBool(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is bool) {
     return value;
   }
   throw FormatException('Missing required route field: $key');

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -48,6 +48,10 @@ void main() {
                   'lineName': '수도권 4호선',
                   'fromStationId': 'station-sangnoksu',
                   'toStationId': 'station-sadang',
+                  'estimatedMinutes': 4,
+                  'distanceMeters': 180,
+                  'includesStairs': false,
+                  'requiresAccessibilityCheck': true,
                 },
               ],
               'warnings': [
@@ -88,6 +92,11 @@ void main() {
     expect(result.statusLabel, '경로를 찾았습니다');
     expect(result.scoreLabel, '이동 점수 92점');
     expect(result.steps.single.title, '상록수역에서 4호선 승강장으로 이동');
+    expect(result.steps.single.estimatedMinutes, 4);
+    expect(result.steps.single.distanceMeters, 180);
+    expect(result.steps.single.includesStairs, isFalse);
+    expect(result.steps.single.requiresAccessibilityCheck, isTrue);
+    expect(result.steps.single.burdenLabel, '약 4분 · 180m · 접근성 확인');
     expect(result.warnings.single.message, '일부 시설 정보는 확인이 필요합니다.');
   });
 
@@ -159,6 +168,24 @@ void main() {
     expect(result.guidanceLabel, '확인이 필요합니다');
     expect(result.guidanceIcon, Icons.warning_amber);
     expect(result.semanticLabel, isNot(contains('이동할 수 있는 경로')));
+  });
+
+  test('경로 단계 이동 부담은 긴 거리를 킬로미터로 표시한다', () {
+    const step = RouteSearchStep(
+      sequence: 2,
+      title: '수도권 4호선으로 사당역까지 이동',
+      description: '15개 역을 이동합니다. 환승은 없습니다.',
+      lineId: 'seoul-4',
+      lineName: '수도권 4호선',
+      fromStationId: 'station-sangnoksu',
+      toStationId: 'station-sadang',
+      estimatedMinutes: 30,
+      distanceMeters: 13500,
+      includesStairs: false,
+      requiresAccessibilityCheck: false,
+    );
+
+    expect(step.burdenLabel, '약 30분 · 13.5km');
   });
 
   test('즐겨찾기 경로 API 저장소는 인증 헤더로 저장과 목록과 삭제를 요청한다', () async {
@@ -273,6 +300,10 @@ RouteSearchResult _sampleRouteSearchResult({String status = 'FOUND'}) {
         lineName: '수도권 4호선',
         fromStationId: 'station-sangnoksu',
         toStationId: 'station-sadang',
+        estimatedMinutes: 4,
+        distanceMeters: 180,
+        includesStairs: false,
+        requiresAccessibilityCheck: true,
       ),
     ],
     warnings: const [

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1304,6 +1304,7 @@ void main() {
       expect(find.text('이동 순서'), findsOneWidget);
       expect(find.byKey(const Key('routeStepNumber-1')), findsOneWidget);
       expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
+      expect(find.text('약 4분 · 180m · 접근성 확인'), findsOneWidget);
       expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
       expect(
         find.bySemanticsLabel('출발역 선택됨, 상록수, 수도권 2호선, 수도권, 기본 정보만 확인됨'),
@@ -1317,7 +1318,7 @@ void main() {
         find.bySemanticsLabel(
           '경로 검색 결과, 이동할 수 있는 경로, 고령자, 상록수에서 사당까지, 수도권 4호선, 이동 점수 92점, 주의 확인, '
           '주의 일부 시설 정보는 확인이 필요합니다., '
-          '이동 안내 1번 상록수역에서 4호선 승강장으로 이동, 엘리베이터를 이용해 승강장으로 이동합니다.',
+          '이동 안내 1번 상록수역에서 4호선 승강장으로 이동, 약 4분 · 180m · 접근성 확인, 엘리베이터를 이용해 승강장으로 이동합니다.',
         ),
         findsOneWidget,
       );
@@ -2318,6 +2319,10 @@ RouteSearchResult _sampleRouteSearchResult({
         lineName: '수도권 4호선',
         fromStationId: 'station-sangnoksu',
         toStationId: 'station-sadang',
+        estimatedMinutes: 4,
+        distanceMeters: 180,
+        includesStairs: false,
+        requiresAccessibilityCheck: true,
       ),
     ],
     warnings: const [

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -431,6 +431,8 @@ public class RouteSearchService implements RouteSearchUseCase {
 		RouteProfileWeight profileWeight
 	) {
 		String displayLine = displayLineName(directLine.line());
+		boolean originIncludesStairs = hasStairOnlyAccess(origin.id());
+		boolean destinationIncludesStairs = hasStairOnlyAccess(destination.id());
 		return List.of(
 			new RouteStep(
 				1,
@@ -442,7 +444,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 				origin.id(),
 				ENTRY_ESTIMATED_MINUTES,
 				ENTRY_DISTANCE_METERS,
-				false,
+				originIncludesStairs,
 				true
 			),
 			new RouteStep(
@@ -468,7 +470,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 				destination.id(),
 				EXIT_ESTIMATED_MINUTES,
 				EXIT_DISTANCE_METERS,
-				false,
+				destinationIncludesStairs,
 				true
 			)
 		);
@@ -482,6 +484,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 	) {
 		String firstDisplayLine = displayLineName(route.firstLine());
 		String secondDisplayLine = displayLineName(route.secondLine());
+		boolean originIncludesStairs = hasStairOnlyAccess(origin.id());
+		boolean transferIncludesStairs = hasStairOnlyAccess(route.transferStation().id());
+		boolean destinationIncludesStairs = hasStairOnlyAccess(destination.id());
 		return List.of(
 			new RouteStep(
 				1,
@@ -493,7 +498,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 				origin.id(),
 				ENTRY_ESTIMATED_MINUTES,
 				ENTRY_DISTANCE_METERS,
-				false,
+				originIncludesStairs,
 				true
 			),
 			new RouteStep(
@@ -519,7 +524,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 				route.transferStation().id(),
 				TRANSFER_ESTIMATED_MINUTES,
 				TRANSFER_DISTANCE_METERS,
-				false,
+				transferIncludesStairs,
 				true
 			),
 			new RouteStep(
@@ -545,7 +550,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 				destination.id(),
 				EXIT_ESTIMATED_MINUTES,
 				EXIT_DISTANCE_METERS,
-				false,
+				destinationIncludesStairs,
 				true
 			)
 		);

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -39,6 +39,15 @@ import org.springframework.stereotype.Service;
 @Service
 public class RouteSearchService implements RouteSearchUseCase {
 
+	private static final int ENTRY_ESTIMATED_MINUTES = 4;
+	private static final int ENTRY_DISTANCE_METERS = 180;
+	private static final int EXIT_ESTIMATED_MINUTES = 3;
+	private static final int EXIT_DISTANCE_METERS = 120;
+	private static final int TRANSFER_ESTIMATED_MINUTES = 6;
+	private static final int TRANSFER_DISTANCE_METERS = 260;
+	private static final int MINUTES_PER_STATION = 2;
+	private static final int METERS_PER_STATION = 900;
+
 	private final LoadRouteSearchPort loadRouteSearchPort;
 	private final SaveRouteSearchPort saveRouteSearchPort;
 	private final LoadTransitMasterPort loadTransitMasterPort;
@@ -430,7 +439,11 @@ public class RouteSearchService implements RouteSearchUseCase {
 				directLine.line().id(),
 				directLine.line().name(),
 				origin.id(),
-				origin.id()
+				origin.id(),
+				ENTRY_ESTIMATED_MINUTES,
+				ENTRY_DISTANCE_METERS,
+				false,
+				true
 			),
 			new RouteStep(
 				2,
@@ -439,7 +452,11 @@ public class RouteSearchService implements RouteSearchUseCase {
 				directLine.line().id(),
 				directLine.line().name(),
 				origin.id(),
-				destination.id()
+				destination.id(),
+				trainEstimatedMinutes(directLine.stopCount()),
+				trainDistanceMeters(directLine.stopCount()),
+				false,
+				false
 			),
 			new RouteStep(
 				3,
@@ -448,7 +465,11 @@ public class RouteSearchService implements RouteSearchUseCase {
 				directLine.line().id(),
 				directLine.line().name(),
 				destination.id(),
-				destination.id()
+				destination.id(),
+				EXIT_ESTIMATED_MINUTES,
+				EXIT_DISTANCE_METERS,
+				false,
+				true
 			)
 		);
 	}
@@ -469,7 +490,11 @@ public class RouteSearchService implements RouteSearchUseCase {
 				route.firstLine().id(),
 				route.firstLine().name(),
 				origin.id(),
-				origin.id()
+				origin.id(),
+				ENTRY_ESTIMATED_MINUTES,
+				ENTRY_DISTANCE_METERS,
+				false,
+				true
 			),
 			new RouteStep(
 				2,
@@ -478,7 +503,11 @@ public class RouteSearchService implements RouteSearchUseCase {
 				route.firstLine().id(),
 				route.firstLine().name(),
 				origin.id(),
-				route.transferStation().id()
+				route.transferStation().id(),
+				trainEstimatedMinutes(route.firstSegmentStopCount()),
+				trainDistanceMeters(route.firstSegmentStopCount()),
+				false,
+				false
 			),
 			new RouteStep(
 				3,
@@ -487,7 +516,11 @@ public class RouteSearchService implements RouteSearchUseCase {
 				route.secondLine().id(),
 				route.secondLine().name(),
 				route.transferStation().id(),
-				route.transferStation().id()
+				route.transferStation().id(),
+				TRANSFER_ESTIMATED_MINUTES,
+				TRANSFER_DISTANCE_METERS,
+				false,
+				true
 			),
 			new RouteStep(
 				4,
@@ -496,7 +529,11 @@ public class RouteSearchService implements RouteSearchUseCase {
 				route.secondLine().id(),
 				route.secondLine().name(),
 				route.transferStation().id(),
-				destination.id()
+				destination.id(),
+				trainEstimatedMinutes(route.secondSegmentStopCount()),
+				trainDistanceMeters(route.secondSegmentStopCount()),
+				false,
+				false
 			),
 			new RouteStep(
 				5,
@@ -505,9 +542,21 @@ public class RouteSearchService implements RouteSearchUseCase {
 				route.secondLine().id(),
 				route.secondLine().name(),
 				destination.id(),
-				destination.id()
+				destination.id(),
+				EXIT_ESTIMATED_MINUTES,
+				EXIT_DISTANCE_METERS,
+				false,
+				true
 			)
 		);
+	}
+
+	private int trainEstimatedMinutes(int stopCount) {
+		return Math.max(1, stopCount) * MINUTES_PER_STATION;
+	}
+
+	private int trainDistanceMeters(int stopCount) {
+		return Math.max(1, stopCount) * METERS_PER_STATION;
 	}
 
 	private String displayLineName(SubwayLine line) {

--- a/backend/src/main/java/com/easysubway/route/domain/RouteStep.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteStep.java
@@ -7,6 +7,10 @@ public record RouteStep(
 	String lineId,
 	String lineName,
 	String fromStationId,
-	String toStationId
+	String toStationId,
+	int estimatedMinutes,
+	int distanceMeters,
+	boolean includesStairs,
+	boolean requiresAccessibilityCheck
 ) {
 }

--- a/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepositoryTest.java
@@ -81,10 +81,10 @@ class InMemoryFavoriteRouteRepositoryTest {
 			"A 노선 / B 노선",
 			45,
 			List.of(
-				new RouteStep(1, "출발역에서 A 노선 승강장으로 이동", "엘리베이터를 확인합니다.", "line-a", "A 노선", "station-origin", "station-origin"),
-				new RouteStep(2, "A 노선으로 환승역까지 이동", "2개 역을 이동한 뒤 환승합니다.", "line-a", "A 노선", "station-origin", "station-transfer"),
-				new RouteStep(3, "환승역에서 B 노선 승강장으로 환승", "환승역의 엘리베이터를 확인합니다.", "line-b", "B 노선", "station-transfer", "station-transfer"),
-				new RouteStep(4, "B 노선으로 도착역까지 이동", "2개 역을 이동합니다.", "line-b", "B 노선", "station-transfer", "station-destination")
+				new RouteStep(1, "출발역에서 A 노선 승강장으로 이동", "엘리베이터를 확인합니다.", "line-a", "A 노선", "station-origin", "station-origin", 4, 180, false, true),
+				new RouteStep(2, "A 노선으로 환승역까지 이동", "2개 역을 이동한 뒤 환승합니다.", "line-a", "A 노선", "station-origin", "station-transfer", 4, 1800, false, false),
+				new RouteStep(3, "환승역에서 B 노선 승강장으로 환승", "환승역의 엘리베이터를 확인합니다.", "line-b", "B 노선", "station-transfer", "station-transfer", 6, 260, false, true),
+				new RouteStep(4, "B 노선으로 도착역까지 이동", "2개 역을 이동합니다.", "line-b", "B 노선", "station-transfer", "station-destination", 4, 1800, false, false)
 			),
 			List.of(),
 			List.of(),

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
@@ -42,6 +42,10 @@ class RouteSearchControllerTest {
 			.andExpect(jsonPath("$.data.destinationStationName").value("사당"))
 			.andExpect(jsonPath("$.data.lineName").value("수도권 4호선"))
 			.andExpect(jsonPath("$.data.steps[0].title").value("상록수역에서 4호선 승강장으로 이동"))
+			.andExpect(jsonPath("$.data.steps[0].estimatedMinutes").value(4))
+			.andExpect(jsonPath("$.data.steps[0].distanceMeters").value(180))
+			.andExpect(jsonPath("$.data.steps[0].includesStairs").value(false))
+			.andExpect(jsonPath("$.data.steps[0].requiresAccessibilityCheck").value(true))
 			.andReturn();
 
 		String routeSearchId = JsonPath.read(result.getResponse().getContentAsString(), "$.data.routeSearchId");

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -272,7 +272,33 @@ class RouteSearchServiceTest {
 		assertThat(stairOnlyResult.warnings())
 			.extracting("code")
 			.contains(RouteWarningCode.STAIR_ONLY_ACCESS);
+		assertThat(stairOnlyResult.steps().get(0).includesStairs()).isTrue();
+		assertThat(stairOnlyResult.steps().get(1).includesStairs()).isFalse();
+		assertThat(stairOnlyResult.steps().get(2).includesStairs()).isTrue();
 		assertThat(stairOnlyResult.score()).isGreaterThan(accessibleResult.score());
+	}
+
+	@Test
+	@DisplayName("계단 전용 환승역은 환승 단계에 계단 포함으로 표시한다")
+	void routeStepMarksStairOnlyTransferAccess() {
+		var repository = new InMemoryRouteSearchRepository();
+		var transferService = new RouteSearchService(
+			repository,
+			repository,
+			new StairOnlyTransferTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = transferService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.STROLLER
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.steps())
+			.extracting("includesStairs")
+			.containsExactly(false, false, true, false, false);
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -70,6 +70,12 @@ class RouteSearchServiceTest {
 				"수도권 4호선으로 사당역까지 이동",
 				"사당역에서 출구 접근성 정보를 확인"
 			);
+		assertThat(result.steps().get(0).estimatedMinutes()).isEqualTo(4);
+		assertThat(result.steps().get(0).distanceMeters()).isEqualTo(180);
+		assertThat(result.steps().get(0).includesStairs()).isFalse();
+		assertThat(result.steps().get(0).requiresAccessibilityCheck()).isTrue();
+		assertThat(result.steps().get(1).estimatedMinutes()).isGreaterThan(0);
+		assertThat(result.steps().get(1).requiresAccessibilityCheck()).isFalse();
 		assertThat(result.warnings())
 			.extracting("code")
 			.contains(RouteWarningCode.LOW_DATA_CONFIDENCE);
@@ -142,6 +148,9 @@ class RouteSearchServiceTest {
 			);
 		assertThat(result.steps().get(2).description())
 			.isEqualTo("환승역의 엘리베이터와 계단 없는 연결 동선을 먼저 확인합니다.");
+		assertThat(result.steps().get(2).estimatedMinutes()).isEqualTo(6);
+		assertThat(result.steps().get(2).distanceMeters()).isEqualTo(260);
+		assertThat(result.steps().get(2).requiresAccessibilityCheck()).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

Closes #118

## 작업 배경

경로 결과에서 단계별 이동 시간과 거리, 접근성 확인 필요 여부가 바로 보이지 않아 사용자가 각 이동 구간의 부담을 판단하기 어렵다. 고령자와 이동 보조가 필요한 사용자가 출발 전 이동 부담을 빠르게 비교할 수 있도록 백엔드 응답과 모바일 표시를 함께 확장한다.

## 작업 내용

- 경로 단계 모델에 예상 소요 시간, 이동 거리, 계단 포함 여부, 접근성 확인 필요 여부를 추가했다.
- 직접 이동, 환승 이동, 승강장 진입, 출구 접근 단계별 기본 이동 부담 값을 백엔드에서 내려주도록 구성했다.
- 모바일 경로 결과의 이동 순서에 `약 n분 · 거리 · 접근성 확인` 형식의 짧은 요약을 표시했다.
- 긴 이동 거리는 `13500m` 대신 `13.5km`처럼 읽기 쉬운 단위로 표시한다.
- 경로 결과 스크린리더 문구에도 단계별 이동 부담을 포함했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test` 성공
  - `node --test tools/ci/*.test.mjs` 성공
  - `git diff --check` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - `flutter test` 성공
  - `flutter analyze` 성공
  - `flutter build apk --debug` 성공
  - `flutter build ios --simulator --no-codesign` 성공
  - Android 에뮬레이터에서 상록수 -> 사당 경로 검색 결과 확인: `약 4분 · 180m · 접근성 확인`, `약 30분 · 13.5km`, `약 3분 · 120m · 접근성 확인` 노출 확인

## 리뷰어 메모

- `RouteStep` 응답 필드가 모바일 파서의 필수 계약으로 추가됐다.
- 현재 이동 시간과 거리는 경로 계산 고도화 전 기본 추정값이다. 사용자가 긴 거리 숫자를 바로 이해할 수 있도록 모바일에서는 km 단위 변환을 적용했다.

## 리스크

- 기존 API 소비자가 있다면 `RouteStep` 응답 필드가 추가된다. 필드 제거는 없으며 모바일은 새 필드를 필수로 파싱한다.
- 실제 역 내부 이동 시간은 아직 정밀 데이터가 아니므로, 출구/승강장 접근성 데이터가 보강되면 계산 기준을 다시 조정해야 한다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 경로 검색 결과에 각 단계의 소요 시간, 거리, 계단 유무, 접근성 정보를 표시하는 기능 추가

* **Tests**
  * 경로 검색 단계 정보 및 접근성 관련 검증 테스트 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->