### PR TITLE
[Feat] 역 상세 시설 상태 우선순위 표시

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -832,6 +832,17 @@ class StationFacilityInfo {
     };
   }
 
+  bool get needsAttention => statusPriority < 40;
+
+  int get statusPriority {
+    return switch (status) {
+      'BROKEN' || 'CLOSED' => 10,
+      'UNDER_CONSTRUCTION' || 'CONSTRUCTION' => 20,
+      'USER_REPORTED' || 'UNKNOWN' || 'NEEDS_REPORT' || 'NEEDS_CHECK' => 30,
+      _ => 40,
+    };
+  }
+
   String get confidenceLabel => _dataConfidenceLabel(dataConfidence);
 
   String get dataSourceLabel => _dataSourceLabel(dataSourceType);
@@ -1199,6 +1210,39 @@ class StationDetailState {
   final List<StationExitInfo> exits;
   final List<StationFacilityInfo> facilities;
   final String message;
+
+  List<StationFacilityInfo> get prioritizedFacilities {
+    final sorted = List<StationFacilityInfo>.of(facilities);
+    sorted.sort((left, right) {
+      // 이동에 영향을 주는 시설 상태를 먼저 보여 사용자가 우회 여부를 빨리 판단하게 한다.
+      final priority = left.statusPriority.compareTo(right.statusPriority);
+      if (priority != 0) {
+        return priority;
+      }
+      return left.name.compareTo(right.name);
+    });
+    return List.unmodifiable(sorted);
+  }
+
+  int get attentionFacilityCount {
+    return facilities.where((facility) => facility.needsAttention).length;
+  }
+
+  String get facilityAttentionSummary {
+    final count = attentionFacilityCount;
+    if (count == 0) {
+      return '확인 필요 없음';
+    }
+    return '확인 필요 $count개';
+  }
+
+  String get facilityAttentionSemanticLabel {
+    final count = attentionFacilityCount;
+    if (count == 0) {
+      return '확인이 필요한 시설 없음';
+    }
+    return '확인이 필요한 시설 $count개';
+  }
 }
 
 class StationDetailController extends ChangeNotifier {
@@ -2111,7 +2155,9 @@ class _StationDetailBody extends StatelessWidget {
       StationDetailStatus.success => _StationDetailContent(
         detail: state.detail!,
         exits: state.exits,
-        facilities: state.facilities,
+        facilities: state.prioritizedFacilities,
+        facilityAttentionSummary: state.facilityAttentionSummary,
+        facilityAttentionSemanticLabel: state.facilityAttentionSemanticLabel,
         reportRepository: reportRepository,
         favoriteController: favoriteController,
       ),
@@ -2124,6 +2170,8 @@ class _StationDetailContent extends StatelessWidget {
     required this.detail,
     required this.exits,
     required this.facilities,
+    required this.facilityAttentionSummary,
+    required this.facilityAttentionSemanticLabel,
     required this.reportRepository,
     required this.favoriteController,
   });
@@ -2131,6 +2179,8 @@ class _StationDetailContent extends StatelessWidget {
   final StationDetail detail;
   final List<StationExitInfo> exits;
   final List<StationFacilityInfo> facilities;
+  final String facilityAttentionSummary;
+  final String facilityAttentionSemanticLabel;
   final FacilityReportRepository reportRepository;
   final StationFavoriteToggleController? favoriteController;
 
@@ -2156,6 +2206,11 @@ class _StationDetailContent extends StatelessWidget {
           for (final exit in exits) _StationExitCard(exit: exit),
         const SizedBox(height: 24),
         const _StationDetailSectionTitle(title: '시설'),
+        const SizedBox(height: 12),
+        _StationFacilityStatusSummary(
+          text: facilityAttentionSummary,
+          semanticLabel: facilityAttentionSemanticLabel,
+        ),
         const SizedBox(height: 12),
         if (facilities.isEmpty)
           const _StationDetailEmptyMessage(message: '시설 정보가 아직 없습니다.')
@@ -2183,6 +2238,26 @@ class _StationDetailContent extends StatelessWidget {
             facilityStatusLabel: facility.statusLabel,
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _StationFacilityStatusSummary extends StatelessWidget {
+  const _StationFacilityStatusSummary({
+    required this.text,
+    required this.semanticLabel,
+  });
+
+  final String text;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: semanticLabel,
+      child: ExcludeSemantics(
+        child: _StationDetailInfoRow(icon: Icons.priority_high, text: text),
       ),
     );
   }

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -839,7 +839,8 @@ class StationFacilityInfo {
       'BROKEN' || 'CLOSED' => 10,
       'UNDER_CONSTRUCTION' || 'CONSTRUCTION' => 20,
       'USER_REPORTED' || 'UNKNOWN' || 'NEEDS_REPORT' || 'NEEDS_CHECK' => 30,
-      _ => 40,
+      'NORMAL' || 'ADMIN_VERIFIED' => 40,
+      _ => 30,
     };
   }
 
@@ -2207,19 +2208,20 @@ class _StationDetailContent extends StatelessWidget {
         const SizedBox(height: 24),
         const _StationDetailSectionTitle(title: '시설'),
         const SizedBox(height: 12),
-        _StationFacilityStatusSummary(
-          text: facilityAttentionSummary,
-          semanticLabel: facilityAttentionSemanticLabel,
-        ),
-        const SizedBox(height: 12),
         if (facilities.isEmpty)
           const _StationDetailEmptyMessage(message: '시설 정보가 아직 없습니다.')
-        else
+        else ...[
+          _StationFacilityStatusSummary(
+            text: facilityAttentionSummary,
+            semanticLabel: facilityAttentionSemanticLabel,
+          ),
+          const SizedBox(height: 12),
           for (final facility in facilities)
             _StationFacilityCard(
               facility: facility,
               onReportTap: () => _openFacilityReport(context, facility),
             ),
+        ],
       ],
     );
   }

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -734,6 +734,34 @@ void main() {
     expect(controller.state.message, '역 상세 정보를 불러오지 못했습니다.');
   });
 
+  test('역 상세 상태는 확인이 필요한 시설을 먼저 보여 주고 짧은 요약을 만든다', () {
+    final state = StationDetailState(
+      status: StationDetailStatus.success,
+      detail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      facilities: [
+        _stationFacility(),
+        _stationFacility(
+          id: 'facility-sangnoksu-ramp-1',
+          name: '1번 출구 경사로',
+          status: 'UNDER_CONSTRUCTION',
+        ),
+        _stationFacility(
+          id: 'facility-sangnoksu-elevator-2',
+          name: '2번 출구 엘리베이터',
+          status: 'BROKEN',
+        ),
+      ],
+    );
+
+    expect(state.prioritizedFacilities.map((facility) => facility.name), [
+      '2번 출구 엘리베이터',
+      '1번 출구 경사로',
+      '1번 출구 엘리베이터',
+    ]);
+    expect(state.facilityAttentionSummary, '확인 필요 2개');
+    expect(state.facilityAttentionSemanticLabel, '확인이 필요한 시설 2개');
+  });
+
   test('즐겨찾기 역 목록 컨트롤러는 목록과 빈 목록과 실패 상태를 구분한다', () async {
     final repository = FakeFavoriteStationRepository();
     final controller = FavoriteStationListController(repository: repository);
@@ -900,17 +928,21 @@ StationExitInfo _stationExit() {
   );
 }
 
-StationFacilityInfo _stationFacility() {
-  return const StationFacilityInfo(
-    id: 'facility-sangnoksu-elevator-1',
+StationFacilityInfo _stationFacility({
+  String id = 'facility-sangnoksu-elevator-1',
+  String name = '1번 출구 엘리베이터',
+  String status = 'NORMAL',
+}) {
+  return StationFacilityInfo(
+    id: id,
     stationId: 'station-sangnoksu',
     exitId: 'exit-sangnoksu-1',
     type: 'ELEVATOR',
-    name: '1번 출구 엘리베이터',
+    name: name,
     floorFrom: '지상',
     floorTo: '대합실',
     description: '1번 출구와 대합실을 연결합니다.',
-    status: 'NORMAL',
+    status: status,
     dataConfidence: 'HIGH',
     lastUpdatedAt: '2026-06-12',
   );

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -746,6 +746,11 @@ void main() {
           status: 'UNDER_CONSTRUCTION',
         ),
         _stationFacility(
+          id: 'facility-sangnoksu-call-bell-1',
+          name: '비상벨',
+          status: 'NEW_BACKEND_STATUS',
+        ),
+        _stationFacility(
           id: 'facility-sangnoksu-elevator-2',
           name: '2번 출구 엘리베이터',
           status: 'BROKEN',
@@ -756,10 +761,11 @@ void main() {
     expect(state.prioritizedFacilities.map((facility) => facility.name), [
       '2번 출구 엘리베이터',
       '1번 출구 경사로',
+      '비상벨',
       '1번 출구 엘리베이터',
     ]);
-    expect(state.facilityAttentionSummary, '확인 필요 2개');
-    expect(state.facilityAttentionSemanticLabel, '확인이 필요한 시설 2개');
+    expect(state.facilityAttentionSummary, '확인 필요 3개');
+    expect(state.facilityAttentionSemanticLabel, '확인이 필요한 시설 3개');
   });
 
   test('즐겨찾기 역 목록 컨트롤러는 목록과 빈 목록과 실패 상태를 구분한다', () async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -858,6 +858,20 @@ void main() {
           dataSourceType: 'OFFICIAL_FILE',
           lastUpdatedAt: '2026-06-12',
         ),
+        StationFacilityInfo(
+          id: 'facility-sangnoksu-elevator-2',
+          stationId: 'station-sangnoksu',
+          exitId: 'exit-sangnoksu-2',
+          type: 'ELEVATOR',
+          name: '2번 출구 엘리베이터',
+          floorFrom: 'B1',
+          floorTo: '1F',
+          description: '2번 출구 앞',
+          status: 'BROKEN',
+          dataConfidence: 'HIGH',
+          dataSourceType: 'OFFICIAL_FILE',
+          lastUpdatedAt: '2026-06-14',
+        ),
       ],
     );
 
@@ -912,8 +926,20 @@ void main() {
       await tester.drag(find.byType(ListView), const Offset(0, -260));
       await tester.pumpAndSettle();
       expect(find.text('시설'), findsOneWidget);
-      expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
+      expect(find.text('확인 필요 1개'), findsOneWidget);
+      expect(find.bySemanticsLabel('확인이 필요한 시설 1개'), findsOneWidget);
+      expect(find.text('2번 출구 엘리베이터'), findsOneWidget);
       expect(find.text('엘리베이터'), findsOneWidget);
+      expect(find.text('고장'), findsOneWidget);
+      await tester.scrollUntilVisible(
+        find.byKey(
+          const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+        ),
+        120,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
       expect(find.text('정상'), findsOneWidget);
       expect(find.text('1번 출구 앞'), findsOneWidget);
       expect(find.text('최근 확인 2026-06-12'), findsOneWidget);
@@ -923,13 +949,12 @@ void main() {
         ),
         findsOneWidget,
       );
-      await tester.ensureVisible(
+      expect(
         find.byKey(
           const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
         ),
+        findsOneWidget,
       );
-      await tester.pumpAndSettle();
-      expect(find.widgetWithText(OutlinedButton, '상태 신고'), findsOneWidget);
       expect(find.bySemanticsLabel('1번 출구 엘리베이터 상태 신고'), findsOneWidget);
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -965,6 +965,62 @@ void main() {
     }
   });
 
+  testWidgets('역 상세는 시설 목록이 없으면 확인 필요 요약을 숨긴다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final repository = FakeStationSearchRepository(
+      nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      stationExits: const [
+        StationExitInfo(
+          id: 'exit-sangnoksu-1',
+          stationId: 'station-sangnoksu',
+          exitNumber: '1',
+          name: '1번 출구',
+          hasElevatorConnection: true,
+          hasStairOnlyPath: false,
+          dataConfidence: 'HIGH',
+          dataSourceType: 'OFFICIAL_FILE',
+        ),
+      ],
+      stationFacilities: const [],
+    );
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: repository,
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('stationSearchButton')));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('stationSearchInput')),
+        '상록수',
+      );
+      await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.drag(find.byType(ListView), const Offset(0, -520));
+      await tester.pumpAndSettle();
+
+      expect(find.text('시설'), findsOneWidget);
+      expect(find.text('시설 정보가 아직 없습니다.'), findsOneWidget);
+      expect(find.text('확인 필요 없음'), findsNothing);
+      expect(find.bySemanticsLabel('확인이 필요한 시설 없음'), findsNothing);
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('역 상세는 현재 역을 즐겨찾기에 저장하고 해제한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final favoriteRepository = FakeFavoriteStationRepository();


### PR DESCRIPTION
## 관련 이슈
Closes #120

## 배경
역 상세 화면에서 엘리베이터, 에스컬레이터, 장애인 화장실 상태가 같은 순서로만 표시되면 이동 전에 확인이 필요한 시설을 늦게 발견할 수 있다. 특히 보행 보조기, 휠체어, 유아차를 쓰는 사용자는 고장, 공사, 확인 필요 상태를 먼저 확인해야 우회 여부를 빠르게 판단할 수 있다.

## 변경 사항
- 역 상세 시설 목록을 상태 우선순위 기준으로 정렬했다.
- 고장/운영 중단, 공사 중, 확인 필요 상태를 정상 시설보다 먼저 보여 주도록 했다.
- 시설 섹션 상단에 `확인 필요 N개` 요약을 추가하고 스크린리더 라벨은 `확인이 필요한 시설 N개`로 제공했다.
- 정렬 기준과 요약 문구를 단위 테스트와 위젯 테스트로 고정했다.

## 검증
- `flutter analyze`
- `flutter test test/station_search_test.dart`
- `flutter test test/widget_test.dart`
- `flutter test`
- `flutter build apk --debug`
- `flutter build ios --simulator --no-codesign`
- Android Emulator에서 `sang` 검색 -> 상록수역 상세 -> 시설 섹션 진입 확인
  - `확인 필요 1개` 표시 확인
  - 접근성 라벨 `확인이 필요한 시설 1개` 확인
  - `장애인 화장실`이 정상 시설보다 먼저 표시되는지 확인

## 리스크
- 서버가 내려주는 상태 enum이 늘어나면 우선순위 기본값은 정상 시설과 같은 그룹으로 처리된다. 새 장애 상태가 추가될 때 모바일 매핑도 함께 확장해야 한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 역 상세 화면에서 시설 목록을 우선순위에 따라 자동 정렬합니다.
  * "확인 필요 시설" 요약 정보를 시설 섹션 상단에 표시합니다.
  * 접근성 라벨을 추가하여 스크린 리더 지원을 개선합니다.

* **Tests**
  * 시설 우선순위 정렬 및 요약 기능에 대한 단위 테스트를 추가합니다.
  * UI 및 접근성 검증 테스트를 업데이트합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->