### PR TITLE
[Feat] 역 검색 초성 입력 지원

### DIFF
--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -65,6 +65,57 @@ void main() {
     expect(results.single.lines.single.name, '수도권 4호선');
   });
 
+  test('역 API 저장소는 초성 검색어를 그대로 요청한다', () async {
+    late Uri requestedUri;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestedUri = request.uri;
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': [
+              {
+                'id': 'station-sangnoksu',
+                'nameKo': '상록수',
+                'nameEn': 'Sangnoksu',
+                'region': '수도권',
+                'dataQualityLevel': 'LEVEL_1',
+                'dataSourceType': 'OFFICIAL_FILE',
+                'lastVerifiedAt': '2026-06-12',
+                'lines': [
+                  {
+                    'id': 'seoul-4',
+                    'operatorId': 'seoul-metro',
+                    'name': '수도권 4호선',
+                    'color': '#00A5DE',
+                    'stationCode': '448',
+                    'sequence': 48,
+                    'platformInfo': '당고개 방면 / 오이도 방면',
+                  },
+                ],
+              },
+            ],
+          }),
+        )
+        ..close();
+    });
+
+    final repository = StationSearchApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    final results = await repository.searchStations('ㅅㄹㅅ');
+
+    expect(requestedUri.path, '/api/v1/stations');
+    expect(requestedUri.queryParameters['query'], 'ㅅㄹㅅ');
+    expect(results.single.nameKo, '상록수');
+  });
+
   test('역 API 저장소는 현재 위치 기준 가까운 역을 요청하고 거리를 파싱한다', () async {
     late Uri requestedUri;
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);

--- a/backend/src/main/java/com/easysubway/transit/domain/Station.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/Station.java
@@ -3,6 +3,8 @@ package com.easysubway.transit.domain;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import java.util.Locale;
+
 public record Station(
 	String id,
 	String nameKo,
@@ -16,11 +18,41 @@ public record Station(
 	boolean active
 ) {
 
+	private static final char[] KOREAN_INITIAL_CONSONANTS = {
+		'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ',
+		'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+	};
+	private static final int HANGUL_SYLLABLE_START = 0xAC00;
+	private static final int HANGUL_SYLLABLE_END = 0xD7A3;
+	private static final int HANGUL_JUNG_JONG_COUNT = 21 * 28;
+
 	public boolean matches(String keyword) {
 		if (keyword == null || keyword.isBlank()) {
 			return true;
 		}
-		String normalizedKeyword = keyword.trim().toLowerCase();
-		return nameKo.contains(keyword.trim()) || nameEn.toLowerCase().contains(normalizedKeyword);
+		String trimmedKeyword = keyword.trim();
+		String normalizedKeyword = trimmedKeyword.toLowerCase(Locale.ROOT);
+		return nameKo.contains(trimmedKeyword)
+			|| nameEn.toLowerCase(Locale.ROOT).contains(normalizedKeyword)
+			|| initialConsonantsOf(nameKo).contains(trimmedKeyword);
+	}
+
+	private static String initialConsonantsOf(String value) {
+		StringBuilder initials = new StringBuilder();
+		for (int index = 0; index < value.length(); index++) {
+			char character = value.charAt(index);
+			if (isHangulSyllable(character)) {
+				// 한글 완성형 음절은 유니코드 순서로 초성 인덱스를 계산할 수 있다.
+				int initialIndex = (character - HANGUL_SYLLABLE_START) / HANGUL_JUNG_JONG_COUNT;
+				initials.append(KOREAN_INITIAL_CONSONANTS[initialIndex]);
+			} else {
+				initials.append(character);
+			}
+		}
+		return initials.toString();
+	}
+
+	private static boolean isHangulSyllable(char character) {
+		return character >= HANGUL_SYLLABLE_START && character <= HANGUL_SYLLABLE_END;
 	}
 }

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -67,6 +67,16 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("역 검색은 한글 초성만 입력해도 조회할 수 있다")
+	void stationsCanBeSearchedByKoreanInitialConsonants() throws Exception {
+		mockMvc.perform(get("/api/v1/stations").param("query", "ㅅㄹㅅ"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].id").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data[0].nameKo").value("상록수"));
+	}
+
+	@Test
 	@DisplayName("공개 역 검색은 잘못된 Basic 인증 헤더가 있어도 허용한다")
 	void publicStationSearchIgnoresInvalidBasicAuthentication() throws Exception {
 		mockMvc.perform(get("/api/v1/stations")

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -71,6 +71,16 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
+	@DisplayName("역 검색은 한글 초성만 입력해도 역을 찾는다")
+	void searchStationsMatchesKoreanInitialConsonants() {
+		var stations = service.searchStations(new StationSearchCommand("ㅅㄹㅅ", null));
+
+		assertThat(stations)
+			.extracting(station -> station.station().id())
+			.containsExactly("station-sangnoksu");
+	}
+
+	@Test
 	@DisplayName("역 검색 응답에서 비활성 노선은 제외한다")
 	void searchStationsExcludesInactiveLinesFromStationResponses() {
 		var serviceWithInactiveLine = new TransitMasterService(


### PR DESCRIPTION
Closes #124

## 배경
역 이름을 정확히 끝까지 입력하기 어려운 사용자가 `ㅅㄹㅅ`처럼 한글 초성만 입력해도 원하는 역을 찾을 수 있어야 합니다. 고령자나 한 손 조작 사용자는 긴 역명을 입력하는 부담이 커서, 초성 검색은 역 찾기 진입 장벽을 낮추는 기본 검색 경험입니다.

## 변경 사항
- 역 이름의 한글 완성형 음절에서 초성을 계산해 검색어와 매칭하도록 역 도메인 검색 조건을 확장했습니다.
- `/api/v1/stations?query=ㅅㄹㅅ` 요청이 `상록수`를 반환하는 서비스/컨트롤러 테스트를 추가했습니다.
- 모바일 역 검색 저장소가 초성 검색어를 변형하지 않고 API query로 전달하는 테스트를 추가했습니다.

## 검증
- `backend`: `./gradlew test`
- `backend`: `./gradlew test --tests com.easysubway.transit.application.service.TransitMasterServiceTest --tests com.easysubway.transit.adapter.in.web.TransitMasterControllerTest`
- `apps/mobile`: `flutter analyze`
- `apps/mobile`: `flutter test`
- `apps/mobile`: `flutter test test/station_search_test.dart`
- `apps/mobile`: `flutter build apk --debug`
- `apps/mobile`: `flutter build ios --simulator --no-codesign`
- `repo`: `git diff --check`
- `repo`: `git ls-files '*.md'`
- Android 에뮬레이터에서 홈 진입, 역 검색 화면, `상록수` 결과 카드 표시를 확인했습니다. 에뮬레이터 ADB 한글 자모 입력 제한으로 화면 렌더링은 `sangnoksu` 입력으로 확인했고, `ㅅㄹㅅ` 검색 경로는 백엔드 API 응답과 모바일 저장소 테스트로 검증했습니다.

## 리스크
- 초성 문자열은 역의 한국어 이름 기준으로만 매칭합니다. 영문명 검색은 기존 소문자 포함 검색을 유지합니다.
