### PR TITLE
[Feat] 경로 피드백 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -4,6 +4,9 @@ import com.easysubway.common.web.ApiResponse;
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
+import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
+import com.easysubway.route.domain.RouteFeedback;
+import com.easysubway.route.domain.RouteFeedbackRating;
 import com.easysubway.route.domain.RouteSearchResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,6 +34,14 @@ class RouteSearchController {
 		return ApiResponse.ok(routeSearchUseCase.getRouteSearch(routeSearchId));
 	}
 
+	@PostMapping("/api/v1/routes/{routeSearchId}/feedback")
+	ApiResponse<RouteFeedback> submitRouteFeedback(
+		@PathVariable String routeSearchId,
+		@RequestBody SubmitRouteFeedbackRequest request
+	) {
+		return ApiResponse.ok(routeSearchUseCase.submitRouteFeedback(request.toCommand(routeSearchId)));
+	}
+
 	record SearchRouteRequest(
 		String originStationId,
 		String destinationStationId,
@@ -39,6 +50,17 @@ class RouteSearchController {
 
 		SearchRouteCommand toCommand() {
 			return new SearchRouteCommand(originStationId, destinationStationId, mobilityType);
+		}
+	}
+
+	record SubmitRouteFeedbackRequest(
+		String userId,
+		RouteFeedbackRating rating,
+		String comment
+	) {
+
+		SubmitRouteFeedbackCommand toCommand(String routeSearchId) {
+			return new SubmitRouteFeedbackCommand(routeSearchId, userId, rating, comment);
 		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
@@ -1,7 +1,9 @@
 package com.easysubway.route.adapter.out.persistence;
 
 import com.easysubway.route.application.port.out.LoadRouteSearchPort;
+import com.easysubway.route.application.port.out.SaveRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
+import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteSearchResult;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -9,11 +11,14 @@ import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class InMemoryRouteSearchRepository implements LoadRouteSearchPort, SaveRouteSearchPort {
+public class InMemoryRouteSearchRepository
+	implements LoadRouteSearchPort, SaveRouteSearchPort, SaveRouteFeedbackPort {
 
 	static final int MAX_STORED_ROUTE_SEARCHES = 1_000;
+	static final int MAX_STORED_ROUTE_FEEDBACKS = 5_000;
 
 	private final Map<String, RouteSearchResult> routeSearches = new LinkedHashMap<>();
+	private final Map<String, RouteFeedback> routeFeedbacks = new LinkedHashMap<>();
 
 	@Override
 	public Optional<RouteSearchResult> loadRouteSearch(String routeSearchId) {
@@ -31,11 +36,28 @@ public class InMemoryRouteSearchRepository implements LoadRouteSearchPort, SaveR
 		}
 	}
 
+	@Override
+	public RouteFeedback saveRouteFeedback(RouteFeedback feedback) {
+		synchronized (routeFeedbacks) {
+			routeFeedbacks.put(feedback.feedbackId(), feedback);
+			evictOldestRouteFeedbacks();
+			return feedback;
+		}
+	}
+
 	private void evictOldestRouteSearches() {
 		// 공개 API 요청으로 생성되는 임시 결과가 프로세스 메모리에 무한히 쌓이지 않게 한다.
 		while (routeSearches.size() > MAX_STORED_ROUTE_SEARCHES) {
 			String oldestRouteSearchId = routeSearches.keySet().iterator().next();
 			routeSearches.remove(oldestRouteSearchId);
+		}
+	}
+
+	private void evictOldestRouteFeedbacks() {
+		// 피드백은 운영 DB 전환 전까지 임시 보관하되 공개 요청으로 메모리가 무한 증가하지 않게 한다.
+		while (routeFeedbacks.size() > MAX_STORED_ROUTE_FEEDBACKS) {
+			String oldestFeedbackId = routeFeedbacks.keySet().iterator().next();
+			routeFeedbacks.remove(oldestFeedbackId);
 		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
@@ -1,5 +1,6 @@
 package com.easysubway.route.application.port.in;
 
+import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteSearchResult;
 
 public interface RouteSearchUseCase {
@@ -7,4 +8,6 @@ public interface RouteSearchUseCase {
 	RouteSearchResult searchRoute(SearchRouteCommand command);
 
 	RouteSearchResult getRouteSearch(String routeSearchId);
+
+	RouteFeedback submitRouteFeedback(SubmitRouteFeedbackCommand command);
 }

--- a/backend/src/main/java/com/easysubway/route/application/port/in/SubmitRouteFeedbackCommand.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/SubmitRouteFeedbackCommand.java
@@ -1,0 +1,11 @@
+package com.easysubway.route.application.port.in;
+
+import com.easysubway.route.domain.RouteFeedbackRating;
+
+public record SubmitRouteFeedbackCommand(
+	String routeSearchId,
+	String userId,
+	RouteFeedbackRating rating,
+	String comment
+) {
+}

--- a/backend/src/main/java/com/easysubway/route/application/port/out/SaveRouteFeedbackPort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/SaveRouteFeedbackPort.java
@@ -1,0 +1,8 @@
+package com.easysubway.route.application.port.out;
+
+import com.easysubway.route.domain.RouteFeedback;
+
+public interface SaveRouteFeedbackPort {
+
+	RouteFeedback saveRouteFeedback(RouteFeedback feedback);
+}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -2,9 +2,13 @@ package com.easysubway.route.application.service;
 
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
+import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
 import com.easysubway.route.application.port.out.LoadRouteSearchPort;
+import com.easysubway.route.application.port.out.SaveRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
+import com.easysubway.route.domain.InvalidRouteFeedbackException;
 import com.easysubway.route.domain.InvalidRouteSearchException;
+import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteProfileWeight;
 import com.easysubway.route.domain.RouteSearchNotFoundException;
@@ -50,6 +54,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 
 	private final LoadRouteSearchPort loadRouteSearchPort;
 	private final SaveRouteSearchPort saveRouteSearchPort;
+	private final SaveRouteFeedbackPort saveRouteFeedbackPort;
 	private final LoadTransitMasterPort loadTransitMasterPort;
 	private final Clock clock;
 
@@ -57,9 +62,38 @@ public class RouteSearchService implements RouteSearchUseCase {
 	public RouteSearchService(
 		LoadRouteSearchPort loadRouteSearchPort,
 		SaveRouteSearchPort saveRouteSearchPort,
+		SaveRouteFeedbackPort saveRouteFeedbackPort,
 		LoadTransitMasterPort loadTransitMasterPort
 	) {
-		this(loadRouteSearchPort, saveRouteSearchPort, loadTransitMasterPort, Clock.systemDefaultZone());
+		this(loadRouteSearchPort, saveRouteSearchPort, saveRouteFeedbackPort, loadTransitMasterPort, Clock.systemDefaultZone());
+	}
+
+	public RouteSearchService(
+		LoadRouteSearchPort loadRouteSearchPort,
+		SaveRouteSearchPort saveRouteSearchPort,
+		LoadTransitMasterPort loadTransitMasterPort
+	) {
+		this(
+			loadRouteSearchPort,
+			saveRouteSearchPort,
+			requireFeedbackPort(saveRouteSearchPort),
+			loadTransitMasterPort,
+			Clock.systemDefaultZone()
+		);
+	}
+
+	public RouteSearchService(
+		LoadRouteSearchPort loadRouteSearchPort,
+		SaveRouteSearchPort saveRouteSearchPort,
+		SaveRouteFeedbackPort saveRouteFeedbackPort,
+		LoadTransitMasterPort loadTransitMasterPort,
+		Clock clock
+	) {
+		this.loadRouteSearchPort = loadRouteSearchPort;
+		this.saveRouteSearchPort = saveRouteSearchPort;
+		this.saveRouteFeedbackPort = saveRouteFeedbackPort;
+		this.loadTransitMasterPort = loadTransitMasterPort;
+		this.clock = clock;
 	}
 
 	public RouteSearchService(
@@ -68,10 +102,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 		LoadTransitMasterPort loadTransitMasterPort,
 		Clock clock
 	) {
-		this.loadRouteSearchPort = loadRouteSearchPort;
-		this.saveRouteSearchPort = saveRouteSearchPort;
-		this.loadTransitMasterPort = loadTransitMasterPort;
-		this.clock = clock;
+		this(loadRouteSearchPort, saveRouteSearchPort, requireFeedbackPort(saveRouteSearchPort), loadTransitMasterPort, clock);
 	}
 
 	@Override
@@ -135,6 +166,23 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.orElseThrow(RouteSearchNotFoundException::new);
 	}
 
+	@Override
+	public RouteFeedback submitRouteFeedback(SubmitRouteFeedbackCommand command) {
+		requireFeedbackCommand(command);
+		String routeSearchId = command.routeSearchId().trim();
+		if (loadRouteSearchPort.loadRouteSearch(routeSearchId).isEmpty()) {
+			throw new RouteSearchNotFoundException();
+		}
+		return saveRouteFeedbackPort.saveRouteFeedback(new RouteFeedback(
+			newRouteFeedbackId(),
+			routeSearchId,
+			command.userId().trim(),
+			command.rating(),
+			normalizeFeedbackComment(command.comment()),
+			LocalDateTime.now(clock)
+		));
+	}
+
 	private void requireCommand(SearchRouteCommand command) {
 		if (command.originStationId() == null || command.originStationId().isBlank()) {
 			throw new InvalidRouteSearchException("출발역을 선택해야 합니다.");
@@ -145,6 +193,32 @@ public class RouteSearchService implements RouteSearchUseCase {
 		if (command.mobilityType() == null) {
 			throw new InvalidRouteSearchException("이동 유형을 선택해야 합니다.");
 		}
+	}
+
+	private void requireFeedbackCommand(SubmitRouteFeedbackCommand command) {
+		if (command == null || command.routeSearchId() == null || command.routeSearchId().isBlank()) {
+			throw new RouteSearchNotFoundException();
+		}
+		if (command.userId() == null || command.userId().isBlank()) {
+			throw new InvalidRouteFeedbackException("피드백 작성자를 확인해야 합니다.");
+		}
+		if (command.rating() == null) {
+			throw new InvalidRouteFeedbackException("피드백 평가를 선택해야 합니다.");
+		}
+	}
+
+	private String normalizeFeedbackComment(String comment) {
+		if (comment == null) {
+			return "";
+		}
+		return comment.trim();
+	}
+
+	private static SaveRouteFeedbackPort requireFeedbackPort(SaveRouteSearchPort saveRouteSearchPort) {
+		if (saveRouteSearchPort instanceof SaveRouteFeedbackPort saveRouteFeedbackPort) {
+			return saveRouteFeedbackPort;
+		}
+		throw new IllegalArgumentException("경로 피드백 저장 포트가 필요합니다.");
 	}
 
 	private Station loadActiveStation(String stationId) {
@@ -574,6 +648,10 @@ public class RouteSearchService implements RouteSearchUseCase {
 
 	private String newRouteSearchId() {
 		return "route-" + UUID.randomUUID();
+	}
+
+	private String newRouteFeedbackId() {
+		return "route-feedback-" + UUID.randomUUID();
 	}
 
 	private record DirectLine(

--- a/backend/src/main/java/com/easysubway/route/domain/InvalidRouteFeedbackException.java
+++ b/backend/src/main/java/com/easysubway/route/domain/InvalidRouteFeedbackException.java
@@ -1,0 +1,10 @@
+package com.easysubway.route.domain;
+
+import com.easysubway.common.error.InvalidRequestException;
+
+public class InvalidRouteFeedbackException extends InvalidRequestException {
+
+	public InvalidRouteFeedbackException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteFeedback.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteFeedback.java
@@ -1,0 +1,13 @@
+package com.easysubway.route.domain;
+
+import java.time.LocalDateTime;
+
+public record RouteFeedback(
+	String feedbackId,
+	String routeSearchId,
+	String userId,
+	RouteFeedbackRating rating,
+	String comment,
+	LocalDateTime createdAt
+) {
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteFeedbackRating.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteFeedbackRating.java
@@ -1,0 +1,7 @@
+package com.easysubway.route.domain;
+
+public enum RouteFeedbackRating {
+	HELPFUL,
+	NOT_HELPFUL,
+	BLOCKED_BY_REAL_WORLD
+}

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
@@ -100,4 +100,98 @@ class RouteSearchControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.message").value("경로 검색 결과를 찾을 수 없습니다."));
 	}
+
+	@Test
+	@DisplayName("경로 피드백은 생성된 경로 검색 결과에 연결해 저장한다")
+	void postRouteFeedbackSavesFeedbackForStoredRouteSearch() throws Exception {
+		var result = mockMvc.perform(post("/api/v1/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "mobilityType": "SENIOR"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andReturn();
+		String routeSearchId = JsonPath.read(result.getResponse().getContentAsString(), "$.data.routeSearchId");
+
+		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "rating": "HELPFUL",
+					  "comment": "엘리베이터 안내가 실제 이동에 맞았어요"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.feedbackId").exists())
+			.andExpect(jsonPath("$.data.routeSearchId").value(routeSearchId))
+			.andExpect(jsonPath("$.data.userId").value("anonymous-user-1"))
+			.andExpect(jsonPath("$.data.rating").value("HELPFUL"))
+			.andExpect(jsonPath("$.data.comment").value("엘리베이터 안내가 실제 이동에 맞았어요"));
+	}
+
+	@Test
+	@DisplayName("알 수 없는 경로 검색 결과에는 피드백을 저장하지 않는다")
+	void postRouteFeedbackRejectsUnknownRouteSearchId() throws Exception {
+		mockMvc.perform(post("/api/v1/routes/route-missing/feedback")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "rating": "HELPFUL",
+					  "comment": "안내가 도움이 됐어요"
+					}
+					"""))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").value("경로 검색 결과를 찾을 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("경로 피드백은 사용자 식별자와 평가가 필요하다")
+	void postRouteFeedbackRequiresUserIdAndRating() throws Exception {
+		var result = mockMvc.perform(post("/api/v1/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "mobilityType": "SENIOR"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andReturn();
+		String routeSearchId = JsonPath.read(result.getResponse().getContentAsString(), "$.data.routeSearchId");
+
+		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": " ",
+					  "rating": null,
+					  "comment": " "
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").value("피드백 작성자를 확인해야 합니다."));
+
+		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "rating": null,
+					  "comment": "안내 확인이 필요했어요"
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").value("피드백 평가를 선택해야 합니다."));
+	}
 }

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -6,7 +6,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
+import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
+import com.easysubway.route.domain.InvalidRouteFeedbackException;
 import com.easysubway.route.domain.RouteNotFoundException;
+import com.easysubway.route.domain.RouteFeedbackRating;
 import com.easysubway.route.domain.RouteSearchNotFoundException;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteWarningCode;
@@ -93,6 +96,71 @@ class RouteSearchServiceTest {
 		var loaded = service.getRouteSearch(created.routeSearchId());
 
 		assertThat(loaded).isEqualTo(created);
+	}
+
+	@Test
+	@DisplayName("경로 피드백은 생성된 경로 검색 결과에 연결해 저장한다")
+	void submitRouteFeedbackStoresFeedbackForRouteSearch() {
+		var routeSearch = service.searchRoute(new SearchRouteCommand(
+			"station-sangnoksu",
+			"station-sadang",
+			MobilityType.SENIOR
+		));
+
+		var feedback = service.submitRouteFeedback(new SubmitRouteFeedbackCommand(
+			routeSearch.routeSearchId(),
+			"anonymous-user-1",
+			RouteFeedbackRating.HELPFUL,
+			"엘리베이터 안내가 실제 이동에 맞았어요"
+		));
+
+		assertThat(feedback.feedbackId()).startsWith("route-feedback-");
+		assertThat(feedback.routeSearchId()).isEqualTo(routeSearch.routeSearchId());
+		assertThat(feedback.userId()).isEqualTo("anonymous-user-1");
+		assertThat(feedback.rating()).isEqualTo(RouteFeedbackRating.HELPFUL);
+		assertThat(feedback.comment()).isEqualTo("엘리베이터 안내가 실제 이동에 맞았어요");
+		assertThat(feedback.createdAt()).isEqualTo(LocalDate.of(2026, 6, 13).atTime(18, 0));
+	}
+
+	@Test
+	@DisplayName("경로 피드백은 알 수 없는 경로 검색 식별자를 거부한다")
+	void submitRouteFeedbackRejectsUnknownRouteSearchId() {
+		assertThatThrownBy(() -> service.submitRouteFeedback(new SubmitRouteFeedbackCommand(
+			"route-missing",
+			"anonymous-user-1",
+			RouteFeedbackRating.HELPFUL,
+			"안내가 도움이 됐어요"
+		)))
+			.isInstanceOf(RouteSearchNotFoundException.class)
+			.hasMessage("경로 검색 결과를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("경로 피드백은 작성자와 평가가 필요하다")
+	void submitRouteFeedbackRequiresUserIdAndRating() {
+		var routeSearch = service.searchRoute(new SearchRouteCommand(
+			"station-sangnoksu",
+			"station-sadang",
+			MobilityType.SENIOR
+		));
+
+		assertThatThrownBy(() -> service.submitRouteFeedback(new SubmitRouteFeedbackCommand(
+			routeSearch.routeSearchId(),
+			" ",
+			null,
+			" "
+		)))
+			.isInstanceOf(InvalidRouteFeedbackException.class)
+			.hasMessage("피드백 작성자를 확인해야 합니다.");
+
+		assertThatThrownBy(() -> service.submitRouteFeedback(new SubmitRouteFeedbackCommand(
+			routeSearch.routeSearchId(),
+			"anonymous-user-1",
+			null,
+			"안내 확인이 필요했어요"
+		)))
+			.isInstanceOf(InvalidRouteFeedbackException.class)
+			.hasMessage("피드백 평가를 선택해야 합니다.");
 	}
 
 	@Test


### PR DESCRIPTION
Closes #126

## 배경
경로 추천 결과가 실제 이동에 도움이 됐는지 수집할 수 있어야 추천 품질을 개선할 수 있습니다. 현재는 경로 검색 결과를 만들고 조회할 수 있지만, 사용자가 안내 적합성이나 실제 이동 중 막힌 지점을 남길 API가 없습니다.

## 변경 사항
- `POST /api/v1/routes/{routeSearchId}/feedback` API를 추가했습니다.
- 경로 검색 결과가 존재하는 경우에만 피드백을 저장하도록 서비스 계층을 확장했습니다.
- 피드백 도메인에 작성자, 평가, 내용, 생성 시각을 저장합니다.
- 알 수 없는 경로 검색 식별자, 빈 작성자, 평가 누락을 공통 오류 응답으로 처리합니다.
- 인메모리 피드백 저장소가 공개 요청으로 무한 증가하지 않도록 상한을 뒀습니다.

## 검증
- `backend`: `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest --tests com.easysubway.route.adapter.in.web.RouteSearchControllerTest`
- `backend`: `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest --tests com.easysubway.route.adapter.in.web.RouteSearchControllerTest --tests com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepositoryTest`
- `backend`: `./gradlew test`
- `repo`: `git diff --check`
- `repo`: `git ls-files '*.md'`

## 리스크
- 현재 피드백 저장소는 로컬 인메모리 기준선입니다. 운영 저장소로 전환할 때는 사용자별 조회, 중복 제출 제한, 분석용 집계 쿼리를 별도 설계해야 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 경로 검색 결과에 대한 피드백 제출 기능 추가
  * 피드백에 도움됨/도움 안됨/실제 상황 차단 등 3가지 평가 옵션 제공
  * 피드백 작성자, 평가, 코멘트 입력 지원

* **Bug Fixes**
  * 유효하지 않은 경로 검색 ID로 피드백 제출 시 적절한 오류 메시지 반환
  * 필수 필드(작성자, 평가) 누락 시 유효성 검사 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->