### PR TITLE
[Feat] 지역 목록 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
@@ -19,10 +19,12 @@ import com.easysubway.transit.domain.StationLineSummary;
 import com.easysubway.transit.domain.StationWithLines;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
+import com.easysubway.transit.domain.TransitRegionSummary;
 import java.math.BigDecimal;
 import java.security.Principal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,6 +44,16 @@ class TransitMasterController {
 	) {
 		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
 		this.transitMasterAdminUseCase = transitMasterAdminUseCase;
+	}
+
+	@GetMapping("/api/v1/regions")
+	ApiResponse<List<TransitRegionResponse>> regions() {
+		List<TransitRegionResponse> response = transitMasterQueryUseCase.listRegions()
+			.stream()
+			.map(TransitRegionResponse::from)
+			.toList();
+
+		return ApiResponse.ok(response);
 	}
 
 	@GetMapping("/api/v1/operators")
@@ -131,6 +143,25 @@ class TransitMasterController {
 			request.toCommand(facilityId, principal.getName())
 		);
 		return ApiResponse.ok(AccessibilityFacilityResponse.from(facility));
+	}
+
+	record TransitRegionResponse(
+		String name,
+		int operatorCount,
+		int lineCount,
+		int stationCount,
+		Map<DataQualityLevel, Long> dataQualityCounts
+	) {
+
+		static TransitRegionResponse from(TransitRegionSummary region) {
+			return new TransitRegionResponse(
+				region.name(),
+				region.operatorCount(),
+				region.lineCount(),
+				region.stationCount(),
+				region.dataQualityCounts()
+			);
+		}
 	}
 
 	record TransitOperatorResponse(

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
@@ -6,9 +6,12 @@ import com.easysubway.transit.domain.StationWithLines;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
+import com.easysubway.transit.domain.TransitRegionSummary;
 import java.util.List;
 
 public interface TransitMasterQueryUseCase {
+
+	List<TransitRegionSummary> listRegions();
 
 	List<TransitOperator> listOperators();
 

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -12,6 +12,7 @@ import com.easysubway.transit.application.port.out.SaveAccessibilityFacilityStat
 import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.AccessibilityFacilityNotFoundException;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.InvalidAccessibilityFacilityException;
 import com.easysubway.transit.domain.NearbyStation;
 import com.easysubway.transit.domain.Station;
@@ -22,13 +23,16 @@ import com.easysubway.transit.domain.StationNotFoundException;
 import com.easysubway.transit.domain.StationWithLines;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
+import com.easysubway.transit.domain.TransitRegionSummary;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -81,18 +85,31 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 	}
 
 	@Override
-	public List<TransitOperator> listOperators() {
-		return loadTransitMasterPort.loadOperators()
-			.stream()
-			.filter(TransitOperator::active)
+	public List<TransitRegionSummary> listRegions() {
+		List<TransitOperator> operators = activeOperators();
+		List<SubwayLine> lines = activeLines();
+		List<Station> stations = activeStations();
+
+		return Stream.concat(
+				Stream.concat(operators.stream().map(TransitOperator::region), lines.stream().map(SubwayLine::region)),
+				stations.stream().map(Station::region)
+			)
+			.filter(region -> region != null && !region.isBlank())
+			.distinct()
+			.sorted()
+			.map(region -> summarizeRegion(region, operators, lines, stations))
 			.toList();
 	}
 
 	@Override
+	public List<TransitOperator> listOperators() {
+		return activeOperators();
+	}
+
+	@Override
 	public List<SubwayLine> listLines(String operatorId) {
-		return loadTransitMasterPort.loadLines()
+		return activeLines()
 			.stream()
-			.filter(SubwayLine::active)
 			.filter(line -> operatorId == null || operatorId.isBlank() || line.operatorId().equals(operatorId))
 			.toList();
 	}
@@ -168,10 +185,57 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		return withStatus(facility, command.status(), updatedAt);
 	}
 
-	private Station loadActiveStation(String stationId) {
+	private TransitRegionSummary summarizeRegion(
+		String region,
+		List<TransitOperator> operators,
+		List<SubwayLine> lines,
+		List<Station> stations
+	) {
+		List<Station> stationsInRegion = stations.stream()
+			.filter(station -> region.equals(station.region()))
+			.toList();
+		return new TransitRegionSummary(
+			region,
+			(int) operators.stream().filter(operator -> region.equals(operator.region())).count(),
+			(int) lines.stream().filter(line -> region.equals(line.region())).count(),
+			stationsInRegion.size(),
+			dataQualityCounts(stationsInRegion)
+		);
+	}
+
+	private Map<DataQualityLevel, Long> dataQualityCounts(List<Station> stations) {
+		// 응답 키 순서를 데이터 품질 단계 순서와 맞춰 화면에서 안정적으로 표시할 수 있게 한다.
+		Map<DataQualityLevel, Long> counts = new EnumMap<>(DataQualityLevel.class);
+		for (Station station : stations) {
+			counts.merge(station.dataQualityLevel(), 1L, Long::sum);
+		}
+		return counts;
+	}
+
+	private List<TransitOperator> activeOperators() {
+		return loadTransitMasterPort.loadOperators()
+			.stream()
+			.filter(TransitOperator::active)
+			.toList();
+	}
+
+	private List<SubwayLine> activeLines() {
+		return loadTransitMasterPort.loadLines()
+			.stream()
+			.filter(SubwayLine::active)
+			.toList();
+	}
+
+	private List<Station> activeStations() {
 		return loadTransitMasterPort.loadStations()
 			.stream()
 			.filter(Station::active)
+			.toList();
+	}
+
+	private Station loadActiveStation(String stationId) {
+		return activeStations()
+			.stream()
 			.filter(station -> station.id().equals(stationId))
 			.findFirst()
 			.orElseThrow(StationNotFoundException::new);
@@ -183,9 +247,8 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 	}
 
 	private Map<String, SubwayLine> activeLinesById() {
-		return loadTransitMasterPort.loadLines()
+		return activeLines()
 			.stream()
-			.filter(SubwayLine::active)
 			.collect(Collectors.toMap(SubwayLine::id, Function.identity()));
 	}
 

--- a/backend/src/main/java/com/easysubway/transit/domain/TransitRegionSummary.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/TransitRegionSummary.java
@@ -1,0 +1,22 @@
+package com.easysubway.transit.domain;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+public record TransitRegionSummary(
+	String name,
+	int operatorCount,
+	int lineCount,
+	int stationCount,
+	Map<DataQualityLevel, Long> dataQualityCounts
+) {
+
+	public TransitRegionSummary {
+		if (dataQualityCounts == null || dataQualityCounts.isEmpty()) {
+			dataQualityCounts = Map.of();
+		} else {
+			dataQualityCounts = Collections.unmodifiableMap(new EnumMap<>(dataQualityCounts));
+		}
+	}
+}

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -29,6 +29,19 @@ class TransitMasterControllerTest {
 	private MockMvc mockMvc;
 
 	@Test
+	@DisplayName("지역 목록은 활성 마스터데이터 수와 데이터 품질 분포를 반환한다")
+	void regionsReturnActiveMasterDataCountsAndQualityCounts() throws Exception {
+		mockMvc.perform(get("/api/v1/regions"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].name").value("수도권"))
+			.andExpect(jsonPath("$.data[0].operatorCount").value(2))
+			.andExpect(jsonPath("$.data[0].lineCount").value(2))
+			.andExpect(jsonPath("$.data[0].stationCount").value(2))
+			.andExpect(jsonPath("$.data[0].dataQualityCounts.LEVEL_1").value(2));
+	}
+
+	@Test
 	@DisplayName("운영기관 목록은 시드된 활성 기관을 반환한다")
 	void operatorsReturnsSeededTransitOperators() throws Exception {
 		mockMvc.perform(get("/api/v1/operators"))

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -50,6 +50,22 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
+	@DisplayName("지역 목록은 활성 운영기관과 노선과 역 수를 집계한다")
+	void listRegionsSummarizesActiveMasterDataCounts() {
+		var regions = service.listRegions();
+
+		assertThat(regions)
+			.extracting("name")
+			.containsExactly("수도권");
+		var region = regions.getFirst();
+		assertThat(region.operatorCount()).isEqualTo(2);
+		assertThat(region.lineCount()).isEqualTo(2);
+		assertThat(region.stationCount()).isEqualTo(2);
+		assertThat(region.dataQualityCounts())
+			.containsEntry(DataQualityLevel.LEVEL_1, 2L);
+	}
+
+	@Test
 	@DisplayName("운영기관 식별자로 노선을 필터링한다")
 	void listLinesCanFilterByOperatorId() {
 		var lines = service.listLines("korail");


### PR DESCRIPTION
## 관련 이슈
close #128

## 배경
모바일에서 전국 도시철도 데이터를 지역 단위로 탐색하려면 클라이언트가 운영기관, 노선, 역 목록을 모두 내려받아 지역을 추론하지 않아도 되는 API 계약이 필요합니다. 지역별 데이터 규모와 품질 분포를 함께 내려주면 사용자가 현재 제공 수준을 이해하기 쉽습니다.

## 변경 사항
- `GET /api/v1/regions`를 추가했습니다.
- 활성 운영기관, 노선, 역 기준으로 지역별 운영기관 수, 노선 수, 역 수를 집계합니다.
- 역 데이터 품질 분포를 `dataQualityCounts`로 반환합니다.
- 기존 운영기관, 노선, 역 조회 API는 기존 계약을 유지했습니다.

## 검증
- `./gradlew test --tests "*TransitMaster*"`
- `./gradlew test`
- `git diff --check`
- `git ls-files "*.md"`

## 리스크
- 현재는 인메모리 마스터데이터 기준 집계입니다. DB 전환 시 같은 유스케이스 계약을 유지하면서 쿼리 어댑터로 교체해야 합니다.