### PR TITLE
[Feat] 내 신고 이력 API 추가

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+import 'auth_headers.dart';
 import 'mobile_error_reporter.dart';
 
 const _facilityReportTimeout = Duration(seconds: 8);
@@ -18,36 +19,22 @@ abstract class FacilityReportRepository {
 }
 
 class FacilityReportApiRepository implements FacilityReportRepository {
-  FacilityReportApiRepository({required this.baseUri, HttpClient? httpClient})
-    : _httpClient = httpClient ?? HttpClient();
+  FacilityReportApiRepository({
+    required this.baseUri,
+    this.authProvider,
+    HttpClient? httpClient,
+  }) : _httpClient = httpClient ?? HttpClient();
 
   final Uri baseUri;
+  final AuthorizationHeaderProvider? authProvider;
   final HttpClient _httpClient;
 
   @override
   Future<FacilityReportResult> createReport(
     FacilityReportRequest reportRequest,
   ) async {
-    final uri = baseUri.resolve('/api/v1/reports');
-
     try {
-      final request = await _httpClient
-          .postUrl(uri)
-          .timeout(_facilityReportTimeout);
-      request.headers.contentType = ContentType.json;
-      request.write(jsonEncode(reportRequest.toJson()));
-
-      final response = await request.close().timeout(_facilityReportTimeout);
-      if (response.statusCode != HttpStatus.created &&
-          response.statusCode != HttpStatus.ok) {
-        throw const FacilityReportException(_facilityReportErrorMessage);
-      }
-
-      // 응답 파싱 실패도 repository 예외 문구로 통일되도록 try 블록 안에서 완료한다.
-      return await _readReportResult(
-        response,
-        errorMessage: _facilityReportErrorMessage,
-      );
+      return await _postReportWithAuthorizationRetry(reportRequest);
     } on FacilityReportException {
       rethrow;
     } catch (error, stackTrace) {
@@ -58,6 +45,53 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       );
       throw const FacilityReportException(_facilityReportErrorMessage);
     }
+  }
+
+  Future<FacilityReportResult> _postReportWithAuthorizationRetry(
+    FacilityReportRequest reportRequest,
+  ) async {
+    for (var attempt = 0; attempt < 2; attempt++) {
+      final request = await _httpClient
+          .postUrl(baseUri.resolve('/api/v1/reports'))
+          .timeout(_facilityReportTimeout);
+      final authorizationHeader = await authProvider
+          ?.authorizationHeader()
+          .timeout(_facilityReportTimeout);
+      if (authorizationHeader != null) {
+        request.headers.set(
+          HttpHeaders.authorizationHeader,
+          authorizationHeader,
+        );
+      }
+      request.headers.contentType = ContentType.json;
+      request.write(jsonEncode(reportRequest.toJson()));
+
+      final response = await request.close().timeout(_facilityReportTimeout);
+      final body = await utf8
+          .decodeStream(response)
+          .timeout(_facilityReportTimeout);
+
+      if (response.statusCode == HttpStatus.unauthorized &&
+          authorizationHeader != null &&
+          attempt == 0) {
+        // 만료된 익명 인증은 비우고 새 인증으로 한 번만 다시 시도한다.
+        await authProvider!.invalidateAuthorization().timeout(
+          _facilityReportTimeout,
+        );
+        continue;
+      }
+
+      if (response.statusCode != HttpStatus.created &&
+          response.statusCode != HttpStatus.ok) {
+        throw const FacilityReportException(_facilityReportErrorMessage);
+      }
+
+      return _reportResultFromBody(
+        body,
+        errorMessage: _facilityReportErrorMessage,
+      );
+    }
+    throw const FacilityReportException(_facilityReportErrorMessage);
   }
 
   @override
@@ -81,9 +115,11 @@ class FacilityReportApiRepository implements FacilityReportRepository {
         throw const FacilityReportException(_facilityReportStatusErrorMessage);
       }
 
-      // 상태 확인 응답도 파싱 오류까지 사용자가 이해할 수 있는 문구로 바꾼다.
-      return await _readReportResult(
-        response,
+      final body = await utf8
+          .decodeStream(response)
+          .timeout(_facilityReportTimeout);
+      return _reportResultFromBody(
+        body,
         errorMessage: _facilityReportStatusErrorMessage,
       );
     } on FacilityReportException {
@@ -98,13 +134,10 @@ class FacilityReportApiRepository implements FacilityReportRepository {
     }
   }
 
-  Future<FacilityReportResult> _readReportResult(
-    HttpClientResponse response, {
+  FacilityReportResult _reportResultFromBody(
+    String body, {
     required String errorMessage,
-  }) async {
-    final body = await utf8
-        .decodeStream(response)
-        .timeout(_facilityReportTimeout);
+  }) {
     final decoded = jsonDecode(body);
     if (decoded is! Map<String, Object?> || decoded['success'] != true) {
       throw FacilityReportException(errorMessage);

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -350,7 +350,11 @@ class _EasySubwayAppDependencies {
     return _EasySubwayAppDependencies(
       repository: repository ?? StationSearchApiRepository(baseUri: baseUri),
       reportRepository:
-          reportRepository ?? FacilityReportApiRepository(baseUri: baseUri),
+          reportRepository ??
+          FacilityReportApiRepository(
+            baseUri: baseUri,
+            authProvider: sharedAuthProvider,
+          ),
       routeRepository:
           routeRepository ?? RouteSearchApiRepository(baseUri: baseUri),
       favoriteRepository:

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:easysubway_mobile/auth_headers.dart';
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:flutter/foundation.dart';
@@ -9,11 +10,15 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('시설 신고 API 저장소는 백엔드 계약에 맞춰 신고를 전송한다', () async {
+    late String? authorizationHeader;
     late Map<String, Object?> requestBody;
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(server.close);
 
     server.listen((request) async {
+      authorizationHeader = request.headers.value(
+        HttpHeaders.authorizationHeader,
+      );
       requestBody =
           jsonDecode(await utf8.decodeStream(request)) as Map<String, Object?>;
       request.response
@@ -38,6 +43,10 @@ void main() {
 
     final repository = FacilityReportApiRepository(
       baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: const BasicAuthorizationHeaderProvider(
+        username: 'anonymous-user-1',
+        password: 'user-test-password',
+      ),
     );
 
     final result = await repository.createReport(
@@ -54,8 +63,75 @@ void main() {
     expect(requestBody['facilityId'], 'facility-sangnoksu-elevator-1');
     expect(requestBody['reportType'], 'BROKEN');
     expect(requestBody['description'], '문이 열리지 않습니다.');
+    expect(
+      authorizationHeader,
+      'Basic ${base64Encode(utf8.encode('anonymous-user-1:user-test-password'))}',
+    );
     expect(result.id, 'report-1');
     expect(result.statusLabel, '접수됨');
+  });
+
+  test('시설 신고 API 저장소는 인증 실패 시 인증을 지우고 한 번 재시도한다', () async {
+    final authorizationHeaders = <String?>[];
+    var requestCount = 0;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) async {
+      requestCount++;
+      authorizationHeaders.add(
+        request.headers.value(HttpHeaders.authorizationHeader),
+      );
+      await utf8.decodeStream(request);
+      request.response.headers.contentType = ContentType.json;
+
+      if (requestCount == 1) {
+        request.response
+          ..statusCode = HttpStatus.unauthorized
+          ..write(jsonEncode({'success': false}))
+          ..close();
+        return;
+      }
+
+      request.response
+        ..statusCode = HttpStatus.created
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {
+              'id': 'report-1',
+              'stationId': 'station-sangnoksu',
+              'facilityId': 'facility-sangnoksu-elevator-1',
+              'reportType': 'BROKEN',
+              'description': '문이 열리지 않습니다.',
+              'status': 'SUBMITTED',
+              'createdAt': '2026-06-13T10:00:00',
+            },
+          }),
+        )
+        ..close();
+    });
+
+    final authProvider = RetryAuthorizationHeaderProvider();
+    final repository = FacilityReportApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: authProvider,
+    );
+
+    final result = await repository.createReport(
+      const FacilityReportRequest(
+        userId: 'anonymous-mobile-user',
+        stationId: 'station-sangnoksu',
+        facilityId: 'facility-sangnoksu-elevator-1',
+        reportType: 'BROKEN',
+        description: '문이 열리지 않습니다.',
+      ),
+    );
+
+    expect(result.id, 'report-1');
+    expect(authorizationHeaders, ['Basic stale-token', 'Basic fresh-token']);
+    expect(authProvider.authorizationCount, 2);
+    expect(authProvider.invalidateCount, 1);
   });
 
   test('시설 신고 API 저장소는 잘못된 접수 응답도 쉬운 실패 문구로 바꾼다', () async {
@@ -405,5 +481,24 @@ class FailingRefreshFacilityReportRepository
   Future<FacilityReportResult> getReport(String reportId) {
     loadedReportIds.add(reportId);
     return Future.error(const FacilityReportException('처리 상태를 확인하지 못했습니다.'));
+  }
+}
+
+class RetryAuthorizationHeaderProvider implements AuthorizationHeaderProvider {
+  int authorizationCount = 0;
+  int invalidateCount = 0;
+
+  @override
+  Future<String?> authorizationHeader() async {
+    authorizationCount++;
+    if (authorizationCount == 1) {
+      return 'Basic stale-token';
+    }
+    return 'Basic fresh-token';
+  }
+
+  @override
+  Future<void> invalidateAuthorization() async {
+    invalidateCount++;
   }
 }

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
 		return http
 			.securityMatcher(
 				"/api/v1/me",
+				"/api/v1/me/reports",
 				"/api/v1/me/favorites/**",
 				"/api/v1/devices",
 				"/api/v1/me/notification-settings"

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
 				"/api/v1/me",
 				"/api/v1/me/reports",
 				"/api/v1/me/favorites/**",
+				"/api/v1/reports",
 				"/api/v1/devices",
 				"/api/v1/me/notification-settings"
 			)

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
@@ -42,6 +42,15 @@ class FacilityReportController {
 		return ApiResponse.ok(FacilityReportResponse.from(facilityReportUseCase.getReport(reportId)));
 	}
 
+	@GetMapping("/api/v1/me/reports")
+	ApiResponse<List<FacilityReportResponse>> myReports(Principal principal) {
+		List<FacilityReportResponse> reports = facilityReportUseCase.listUserReports(principal.getName())
+			.stream()
+			.map(FacilityReportResponse::from)
+			.toList();
+		return ApiResponse.ok(reports);
+	}
+
 	@GetMapping("/admin/reports")
 	ApiResponse<List<FacilityReportResponse>> adminReports(@RequestParam(required = false) FacilityReportStatus status) {
 		List<FacilityReportResponse> reports = facilityReportUseCase.listReports(status)

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
@@ -32,8 +32,11 @@ class FacilityReportController {
 
 	@PostMapping("/api/v1/reports")
 	@ResponseStatus(HttpStatus.CREATED)
-	ApiResponse<FacilityReportResponse> createReport(@RequestBody CreateFacilityReportRequest request) {
-		FacilityReport report = facilityReportUseCase.createReport(request.toCommand());
+	ApiResponse<FacilityReportResponse> createReport(
+		@RequestBody CreateFacilityReportRequest request,
+		Principal principal
+	) {
+		FacilityReport report = facilityReportUseCase.createReport(request.toCommand(principal.getName()));
 		return ApiResponse.ok(FacilityReportResponse.from(report));
 	}
 
@@ -86,9 +89,9 @@ class FacilityReportController {
 		BigDecimal longitude
 	) {
 
-		CreateFacilityReportCommand toCommand() {
+		CreateFacilityReportCommand toCommand(String authenticatedUserId) {
 			return new CreateFacilityReportCommand(
-				userId,
+				authenticatedUserId,
 				stationId,
 				facilityId,
 				reportType,

--- a/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
@@ -10,6 +10,8 @@ public interface FacilityReportUseCase {
 
 	FacilityReport getReport(String reportId);
 
+	List<FacilityReport> listUserReports(String userId);
+
 	List<FacilityReport> listReports(FacilityReportStatus status);
 
 	FacilityReport reviewReport(ReviewFacilityReportCommand command);

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -145,6 +145,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 
 	@Override
 	public FacilityReport createReport(CreateFacilityReportCommand command) {
+		requireReporter(command);
 		requireReportType(command);
 		requireActiveStation(command.stationId());
 		// 신고 대상 시설이 요청한 역에 속해야 다른 역 시설 상태가 잘못 갱신되는 일을 막을 수 있다.
@@ -179,7 +180,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 	public List<FacilityReport> listUserReports(String userId) {
 		return sortedReports()
 			.stream()
-			.filter(report -> report.userId().equals(userId))
+			.filter(report -> userId.equals(report.userId()))
 			.toList();
 	}
 
@@ -221,6 +222,12 @@ public class FacilityReportService implements FacilityReportUseCase {
 		// 승인된 상태 신고만 실제 시설 운영 상태에 반영한다.
 		applyAcceptedReportToFacilityStatus(report, command.decision());
 		return saved;
+	}
+
+	private void requireReporter(CreateFacilityReportCommand command) {
+		if (command.userId() == null || command.userId().isBlank()) {
+			throw new InvalidFacilityReportException("사용자 식별자가 필요합니다.");
+		}
 	}
 
 	private List<FacilityReport> sortedReports() {

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -176,11 +176,18 @@ public class FacilityReportService implements FacilityReportUseCase {
 	}
 
 	@Override
+	public List<FacilityReport> listUserReports(String userId) {
+		return sortedReports()
+			.stream()
+			.filter(report -> report.userId().equals(userId))
+			.toList();
+	}
+
+	@Override
 	public List<FacilityReport> listReports(FacilityReportStatus status) {
-		return loadFacilityReportPort.loadReports()
+		return sortedReports()
 			.stream()
 			.filter(report -> status == null || report.status() == status)
-			.sorted(Comparator.comparing(FacilityReport::createdAt).reversed())
 			.toList();
 	}
 
@@ -214,6 +221,14 @@ public class FacilityReportService implements FacilityReportUseCase {
 		// 승인된 상태 신고만 실제 시설 운영 상태에 반영한다.
 		applyAcceptedReportToFacilityStatus(report, command.decision());
 		return saved;
+	}
+
+	private List<FacilityReport> sortedReports() {
+		// 사용자 화면과 관리자 화면 모두 최신 처리 상태를 먼저 보도록 같은 정렬 기준을 쓴다.
+		return loadFacilityReportPort.loadReports()
+			.stream()
+			.sorted(Comparator.comparing(FacilityReport::createdAt).reversed())
+			.toList();
 	}
 
 	private void alertReportStatusChanged(FacilityReport saved) {

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -136,6 +136,37 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("내 신고 이력은 인증 사용자 신고만 최신순으로 반환한다")
+	void myReportListReturnsOnlyAuthenticatedUserReportsByNewestFirst() throws Exception {
+		String olderReportId = createReport("basic-user", "먼저 접수한 내 신고");
+		String otherUserReportId = createReport("other-user", "다른 사용자의 신고");
+		String newerReportId = createReport("basic-user", "나중에 접수한 내 신고");
+
+		String response = mockMvc.perform(get("/api/v1/me/reports")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data").isArray())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		List<String> reportIds = JsonPath.read(response, "$.data[*].id");
+		Assertions.assertThat(reportIds)
+			.contains(newerReportId, olderReportId)
+			.doesNotContain(otherUserReportId);
+		Assertions.assertThat(reportIds.indexOf(newerReportId))
+			.isLessThan(reportIds.indexOf(olderReportId));
+	}
+
+	@Test
+	@DisplayName("내 신고 이력은 인증된 사용자만 조회할 수 있다")
+	void myReportListRequiresAuthentication() throws Exception {
+		mockMvc.perform(get("/api/v1/me/reports"))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
 	@DisplayName("관리자는 신고를 승인하고 조회 결과에서 검수 상태를 확인할 수 있다")
 	void reviewReportStoresAcceptedStatusAndCanBeRead() throws Exception {
 		String response = mockMvc.perform(post("/api/v1/reports")

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -31,13 +31,14 @@ class FacilityReportControllerTest {
 	private MockMvc mockMvc;
 
 	@Test
-	@DisplayName("시설 신고를 생성하고 같은 식별자로 조회한다")
+	@DisplayName("시설 신고는 인증 사용자 기준으로 생성되고 같은 식별자로 조회한다")
 	void createReportReturnsSubmittedReportAndCanBeRead() throws Exception {
 		String response = mockMvc.perform(post("/api/v1/reports")
+				.with(httpBasic("basic-user", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
-					  "userId": "anonymous-user-1",
+					  "userId": "spoofed-user",
 					  "stationId": "station-sangnoksu",
 					  "facilityId": "facility-sangnoksu-elevator-1",
 					  "reportType": "BROKEN",
@@ -53,6 +54,7 @@ class FacilityReportControllerTest {
 			.andExpect(jsonPath("$.data.facilityId").value("facility-sangnoksu-elevator-1"))
 			.andExpect(jsonPath("$.data.reportType").value("BROKEN"))
 			.andExpect(jsonPath("$.data.status").value("SUBMITTED"))
+			.andExpect(jsonPath("$.data.userId").value("basic-user"))
 			.andReturn()
 			.getResponse()
 			.getContentAsString();
@@ -67,9 +69,27 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("시설 신고 생성은 인증된 사용자만 사용할 수 있다")
+	void createReportRequiresAuthentication() throws Exception {
+		mockMvc.perform(post("/api/v1/reports")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "stationId": "station-sangnoksu",
+					  "facilityId": "facility-sangnoksu-elevator-1",
+					  "reportType": "BROKEN",
+					  "description": "엘리베이터가 멈춰 있습니다."
+					}
+					"""))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
 	@DisplayName("존재하지 않는 시설 신고 요청은 공통 404 응답을 반환한다")
 	void createReportReturnsCommonErrorForUnknownFacility() throws Exception {
 		mockMvc.perform(post("/api/v1/reports")
+				.with(httpBasic("basic-user", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -90,6 +110,7 @@ class FacilityReportControllerTest {
 	@DisplayName("신고 유형이 없는 요청은 공통 400 응답을 반환한다")
 	void createReportReturnsCommonErrorForMissingReportType() throws Exception {
 		mockMvc.perform(post("/api/v1/reports")
+				.with(httpBasic("basic-user", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -109,6 +130,7 @@ class FacilityReportControllerTest {
 	@DisplayName("알 수 없는 신고 유형은 공통 400 응답을 반환한다")
 	void createReportReturnsCommonErrorForInvalidReportType() throws Exception {
 		mockMvc.perform(post("/api/v1/reports")
+				.with(httpBasic("basic-user", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -138,9 +160,9 @@ class FacilityReportControllerTest {
 	@Test
 	@DisplayName("내 신고 이력은 인증 사용자 신고만 최신순으로 반환한다")
 	void myReportListReturnsOnlyAuthenticatedUserReportsByNewestFirst() throws Exception {
-		String olderReportId = createReport("basic-user", "먼저 접수한 내 신고");
-		String otherUserReportId = createReport("other-user", "다른 사용자의 신고");
-		String newerReportId = createReport("basic-user", "나중에 접수한 내 신고");
+		String olderReportId = createReport("basic-user", "user-test-password", "spoofed-user", "먼저 접수한 내 신고");
+		String otherUserReportId = createReport("admin-test", "admin-test-password", "basic-user", "다른 사용자의 신고");
+		String newerReportId = createReport("basic-user", "user-test-password", "spoofed-user", "나중에 접수한 내 신고");
 
 		String response = mockMvc.perform(get("/api/v1/me/reports")
 				.with(httpBasic("basic-user", "user-test-password")))
@@ -170,6 +192,7 @@ class FacilityReportControllerTest {
 	@DisplayName("관리자는 신고를 승인하고 조회 결과에서 검수 상태를 확인할 수 있다")
 	void reviewReportStoresAcceptedStatusAndCanBeRead() throws Exception {
 		String response = mockMvc.perform(post("/api/v1/reports")
+				.with(httpBasic("basic-user", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -330,6 +353,7 @@ class FacilityReportControllerTest {
 	@DisplayName("관리자는 신고 상세에서 사진과 위치 정보를 확인한다")
 	void adminReadsReportDetailWithPhotoAndLocation() throws Exception {
 		String response = mockMvc.perform(post("/api/v1/reports")
+				.with(httpBasic("basic-user", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -355,7 +379,7 @@ class FacilityReportControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.id").value(reportId))
-			.andExpect(jsonPath("$.data.userId").value("anonymous-user-admin-detail"))
+			.andExpect(jsonPath("$.data.userId").value("basic-user"))
 			.andExpect(jsonPath("$.data.description").value("엘리베이터 앞 안내문이 떨어져 있습니다."))
 			.andExpect(jsonPath("$.data.photoUrl").value("https://cdn.example.test/reports/elevator-notice.jpg"))
 			.andExpect(jsonPath("$.data.latitude").value(37.302421))
@@ -386,7 +410,17 @@ class FacilityReportControllerTest {
 	}
 
 	private String createReport(String userId, String description) throws Exception {
+		return createReport("basic-user", "user-test-password", userId, description);
+	}
+
+	private String createReport(
+		String username,
+		String password,
+		String userId,
+		String description
+	) throws Exception {
 		String response = mockMvc.perform(post("/api/v1/reports")
+				.with(httpBasic(username, password))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -137,6 +137,23 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
+	@DisplayName("내 신고 목록은 요청 사용자 신고만 최신순으로 반환한다")
+	void listUserReportsReturnsOnlyUserReportsByNewestFirst() {
+		FacilityReportService serviceWithTickingClock = serviceWithClock(new TickingClock());
+
+		var older = serviceWithTickingClock.createReport(reportCommand("report-owner", "먼저 접수한 내 신고"));
+		var otherUserReport = serviceWithTickingClock.createReport(reportCommand("other-user", "다른 사용자의 신고"));
+		var newer = serviceWithTickingClock.createReport(reportCommand("report-owner", "나중에 접수한 내 신고"));
+
+		assertThat(serviceWithTickingClock.listUserReports("report-owner"))
+			.extracting("id")
+			.containsExactly(newer.id(), older.id());
+		assertThat(serviceWithTickingClock.listUserReports("report-owner"))
+			.extracting("id")
+			.doesNotContain(otherUserReport.id());
+	}
+
+	@Test
 	@DisplayName("신고 목록은 상태별로 필터링한다")
 	void listReportsCanFilterByStatus() {
 		FacilityReportService serviceWithTickingClock = serviceWithClock(new TickingClock());

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.easysubway.report.adapter.out.persistence.InMemoryFacilityReportRepository;
 import com.easysubway.report.application.port.in.CreateFacilityReportCommand;
 import com.easysubway.report.application.port.in.ReviewFacilityReportCommand;
+import com.easysubway.report.domain.FacilityReport;
 import com.easysubway.report.domain.FacilityReportNotFoundException;
 import com.easysubway.report.domain.FacilityReportReviewDecision;
 import com.easysubway.report.domain.FacilityReportStatus;
@@ -116,6 +117,23 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
+	@DisplayName("시설 신고는 사용자 식별자를 요구한다")
+	void createReportRequiresUserId() {
+		assertThatThrownBy(() -> service.createReport(new CreateFacilityReportCommand(
+			"",
+			"station-sangnoksu",
+			"facility-sangnoksu-elevator-1",
+			FacilityReportType.BROKEN,
+			"신고 작성자 식별자가 없는 요청입니다.",
+			null,
+			null,
+			null
+		)))
+			.isInstanceOf(InvalidFacilityReportException.class)
+			.hasMessage("사용자 식별자가 필요합니다.");
+	}
+
+	@Test
 	@DisplayName("존재하지 않는 신고는 조회할 수 없다")
 	void getReportRequiresExistingReport() {
 		assertThatThrownBy(() -> service.getReport("missing-report"))
@@ -151,6 +169,29 @@ class FacilityReportServiceTest {
 		assertThat(serviceWithTickingClock.listUserReports("report-owner"))
 			.extracting("id")
 			.doesNotContain(otherUserReport.id());
+	}
+
+	@Test
+	@DisplayName("내 신고 목록은 소유자 없는 신고가 있어도 실패하지 않는다")
+	void listUserReportsIgnoresReportsWithoutOwner() {
+		reportRepository.saveReport(new FacilityReport(
+			"report-without-owner",
+			null,
+			"station-sangnoksu",
+			"facility-sangnoksu-elevator-1",
+			FacilityReportType.BROKEN,
+			"소유자 없는 기존 신고입니다.",
+			null,
+			null,
+			null,
+			FacilityReportStatus.SUBMITTED,
+			LocalDateTime.of(2026, 6, 12, 9, 0),
+			null,
+			null
+		));
+
+		assertThatNoException().isThrownBy(() -> service.listUserReports("anonymous-user-1"));
+		assertThat(service.listUserReports("anonymous-user-1")).isEmpty();
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

Closes #130

## 배경

사용자가 신고를 접수한 뒤 처리 상태를 확인하려면 앱에서 본인이 제출한 신고만 모아 보여줄 수 있어야 합니다. 기존에는 공개 신고 생성과 단건 조회, 관리자 목록만 있어 사용자 신고 이력 화면을 구성할 API가 부족했습니다.

## 변경 사항

- `GET /api/v1/me/reports` API를 추가했습니다.
- 인증 사용자 식별자를 기준으로 본인 신고만 최신순으로 반환합니다.
- `/api/v1/me/reports`를 인증 보호 경로에 포함했습니다.
- 서비스와 API 테스트로 사용자 격리, 최신순 정렬, 인증 필요 조건을 고정했습니다.

## 검증

- `./gradlew test --tests '*FacilityReport*'`\n- `./gradlew test`\n- `git diff --check`\n- `git ls-files '*.md'`\n\n## 리스크\n\n- 기존 공개 신고 생성 API의 요청/응답 형식은 변경하지 않았습니다.\n- 신규 API는 인증 사용자 기준 목록만 추가하므로 관리자 신고 목록과 단건 조회 흐름에는 영향이 없습니다.