### PR TITLE
[Feat] 내 신고 화면 추가

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -10,12 +10,15 @@ import 'mobile_error_reporter.dart';
 const _facilityReportTimeout = Duration(seconds: 8);
 const _facilityReportErrorMessage = '신고를 보내지 못했습니다.';
 const _facilityReportStatusErrorMessage = '처리 상태를 확인하지 못했습니다.';
+const _facilityReportListErrorMessage = '신고 내역을 불러오지 못했습니다.';
 const _anonymousReportUserId = 'anonymous-mobile-user';
 
 abstract class FacilityReportRepository {
   Future<FacilityReportResult> createReport(FacilityReportRequest request);
 
   Future<FacilityReportResult> getReport(String reportId);
+
+  Future<List<FacilityReportResult>> listMyReports();
 }
 
 class FacilityReportApiRepository implements FacilityReportRepository {
@@ -134,6 +137,65 @@ class FacilityReportApiRepository implements FacilityReportRepository {
     }
   }
 
+  @override
+  Future<List<FacilityReportResult>> listMyReports() async {
+    try {
+      return await _getMyReportsWithAuthorizationRetry();
+    } on FacilityReportException {
+      rethrow;
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '내 시설 신고 목록 응답 처리 중 예외가 발생했습니다.',
+      );
+      throw const FacilityReportException(_facilityReportListErrorMessage);
+    }
+  }
+
+  Future<List<FacilityReportResult>>
+  _getMyReportsWithAuthorizationRetry() async {
+    for (var attempt = 0; attempt < 2; attempt++) {
+      final request = await _httpClient
+          .getUrl(baseUri.resolve('/api/v1/me/reports'))
+          .timeout(_facilityReportTimeout);
+      final authorizationHeader = await authProvider
+          ?.authorizationHeader()
+          .timeout(_facilityReportTimeout);
+      if (authorizationHeader != null) {
+        request.headers.set(
+          HttpHeaders.authorizationHeader,
+          authorizationHeader,
+        );
+      }
+
+      final response = await request.close().timeout(_facilityReportTimeout);
+      final body = await utf8
+          .decodeStream(response)
+          .timeout(_facilityReportTimeout);
+
+      if (response.statusCode == HttpStatus.unauthorized &&
+          authorizationHeader != null &&
+          attempt == 0) {
+        // 목록 조회도 접수와 같은 익명 인증을 쓰므로 만료 시 한 번만 갱신한다.
+        await authProvider!.invalidateAuthorization().timeout(
+          _facilityReportTimeout,
+        );
+        continue;
+      }
+
+      if (response.statusCode != HttpStatus.ok) {
+        throw const FacilityReportException(_facilityReportListErrorMessage);
+      }
+
+      return _reportListFromBody(
+        body,
+        errorMessage: _facilityReportListErrorMessage,
+      );
+    }
+    throw const FacilityReportException(_facilityReportListErrorMessage);
+  }
+
   FacilityReportResult _reportResultFromBody(
     String body, {
     required String errorMessage,
@@ -149,6 +211,29 @@ class FacilityReportApiRepository implements FacilityReportRepository {
     }
 
     return FacilityReportResult.fromJson(data);
+  }
+
+  List<FacilityReportResult> _reportListFromBody(
+    String body, {
+    required String errorMessage,
+  }) {
+    final decoded = jsonDecode(body);
+    if (decoded is! Map<String, Object?> || decoded['success'] != true) {
+      throw FacilityReportException(errorMessage);
+    }
+
+    final data = decoded['data'];
+    if (data is! List<Object?>) {
+      throw FacilityReportException(errorMessage);
+    }
+
+    return [
+      for (final item in data)
+        if (item is Map<String, Object?>)
+          FacilityReportResult.fromJson(item)
+        else
+          throw FacilityReportException(errorMessage),
+    ];
   }
 }
 
@@ -238,6 +323,18 @@ class FacilityReportResult {
       'DUPLICATE' => '중복 신고',
       'RESOLVED' => '처리 완료',
       _ => '접수 상태 확인 필요',
+    };
+  }
+
+  String get reportTypeLabel {
+    return switch (reportType) {
+      'BROKEN' => '고장',
+      'UNDER_CONSTRUCTION' => '공사 중',
+      'CLOSED' => '폐쇄',
+      'LOCATION_WRONG' => '위치가 달라요',
+      'INFORMATION_WRONG' => '정보가 달라요',
+      'RECOVERED' => '다시 정상',
+      _ => '시설 신고',
     };
   }
 }
@@ -466,6 +563,260 @@ class FacilityReportScreen extends StatefulWidget {
 
   @override
   State<FacilityReportScreen> createState() => _FacilityReportScreenState();
+}
+
+class MyFacilityReportListScreen extends StatefulWidget {
+  const MyFacilityReportListScreen({required this.repository, super.key});
+
+  final FacilityReportRepository repository;
+
+  @override
+  State<MyFacilityReportListScreen> createState() =>
+      _MyFacilityReportListScreenState();
+}
+
+class _MyFacilityReportListScreenState
+    extends State<MyFacilityReportListScreen> {
+  late Future<List<FacilityReportResult>> _reportsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _reportsFuture = widget.repository.listMyReports();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('내 신고')),
+      body: SafeArea(
+        child: FutureBuilder<List<FacilityReportResult>>(
+          future: _reportsFuture,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState != ConnectionState.done) {
+              return const _MyReportLoading();
+            }
+            if (snapshot.hasError) {
+              return _MyReportError(onRetry: _retry);
+            }
+
+            final reports = snapshot.data ?? const <FacilityReportResult>[];
+            if (reports.isEmpty) {
+              return const _MyReportEmpty();
+            }
+
+            return ListView.separated(
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+              itemCount: reports.length,
+              separatorBuilder: (_, _) => const SizedBox(height: 12),
+              itemBuilder: (context, index) {
+                return _MyReportListItem(report: reports[index]);
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  void _retry() {
+    setState(() {
+      _reportsFuture = widget.repository.listMyReports();
+    });
+  }
+}
+
+class _MyReportLoading extends StatelessWidget {
+  const _MyReportLoading();
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: '신고 내역 불러오는 중',
+      liveRegion: true,
+      child: const Center(child: CircularProgressIndicator()),
+    );
+  }
+}
+
+class _MyReportEmpty extends StatelessWidget {
+  const _MyReportEmpty();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          '접수한 신고가 없습니다.',
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+            color: const Color(0xFF102A2C),
+            fontWeight: FontWeight.w900,
+            height: 1.3,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MyReportError extends StatelessWidget {
+  const _MyReportError({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              _facilityReportListErrorMessage,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                color: const Color(0xFF102A2C),
+                fontWeight: FontWeight.w900,
+                height: 1.3,
+              ),
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton.icon(
+              key: const Key('myReportsRetryButton'),
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('다시 시도'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MyReportListItem extends StatelessWidget {
+  const _MyReportListItem({required this.report});
+
+  final FacilityReportResult report;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final description = report.description.isEmpty
+        ? report.reportTypeLabel
+        : report.description;
+
+    return Semantics(
+      label: '내 신고, 접수번호 ${report.id}, ${report.statusLabel}, $description',
+      button: false,
+      child: ExcludeSemantics(
+        child: DecoratedBox(
+          key: Key('myReport-${report.id}'),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: const Color(0xFFD5E2E4)),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        report.reportTypeLabel,
+                        style: textTheme.titleMedium?.copyWith(
+                          color: const Color(0xFF102A2C),
+                          fontWeight: FontWeight.w900,
+                          height: 1.25,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    _MyReportStatusPill(label: report.statusLabel),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                Text(
+                  description,
+                  style: textTheme.bodyLarge?.copyWith(
+                    color: const Color(0xFF102A2C),
+                    fontWeight: FontWeight.w700,
+                    height: 1.35,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 6,
+                  children: [
+                    _MyReportMetaText(label: '접수번호', value: report.id),
+                    _MyReportMetaText(
+                      label: '접수일',
+                      value: _reportDateLabel(report.createdAt),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MyReportStatusPill extends StatelessWidget {
+  const _MyReportStatusPill({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: const Color(0xFFE6F2F0),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: const Color(0xFF93C7C2)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        child: Text(
+          label,
+          style: Theme.of(context).textTheme.labelLarge?.copyWith(
+            color: const Color(0xFF102A2C),
+            fontWeight: FontWeight.w900,
+            height: 1.2,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MyReportMetaText extends StatelessWidget {
+  const _MyReportMetaText({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      '$label $value',
+      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+        color: const Color(0xFF29484B),
+        fontWeight: FontWeight.w700,
+        height: 1.3,
+      ),
+    );
+  }
 }
 
 class _FacilityReportScreenState extends State<FacilityReportScreen> {
@@ -865,4 +1216,14 @@ String _optionalReportString(Map<String, Object?> json, String key) {
     return value;
   }
   return '';
+}
+
+String _reportDateLabel(String createdAt) {
+  final parsed = DateTime.tryParse(createdAt);
+  if (parsed == null) {
+    return createdAt;
+  }
+  final month = parsed.month.toString().padLeft(2, '0');
+  final day = parsed.day.toString().padLeft(2, '0');
+  return '${parsed.year}.$month.$day';
 }

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -708,9 +708,11 @@ class _MyReportListItem extends StatelessWidget {
     final description = report.description.isEmpty
         ? report.reportTypeLabel
         : report.description;
+    final createdAtLabel = _reportDateLabel(report.createdAt);
 
     return Semantics(
-      label: '내 신고, 접수번호 ${report.id}, ${report.statusLabel}, $description',
+      label:
+          '내 신고, ${report.reportTypeLabel}, 접수번호 ${report.id}, ${report.statusLabel}, $description, 접수일 $createdAtLabel',
       button: false,
       child: ExcludeSemantics(
         child: DecoratedBox(
@@ -757,10 +759,7 @@ class _MyReportListItem extends StatelessWidget {
                   runSpacing: 6,
                   children: [
                     _MyReportMetaText(label: '접수번호', value: report.id),
-                    _MyReportMetaText(
-                      label: '접수일',
-                      value: _reportDateLabel(report.createdAt),
-                    ),
+                    _MyReportMetaText(label: '접수일', value: createdAtLabel),
                   ],
                 ),
               ],

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -564,6 +564,21 @@ class HomeScreen extends StatelessWidget {
               label: const Text('이동 조건'),
             ),
             const SizedBox(height: 12),
+            FilledButton.icon(
+              key: const Key('myReportsButton'),
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => MyFacilityReportListScreen(
+                      repository: reportRepository,
+                    ),
+                  ),
+                );
+              },
+              icon: const Icon(Icons.receipt_long_outlined),
+              label: const Text('내 신고'),
+            ),
+            const SizedBox(height: 12),
             if (favoriteRouteRepository != null) ...[
               FilledButton.icon(
                 key: const Key('favoriteRoutesButton'),

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -264,6 +264,128 @@ void main() {
     expect(result.statusLabel, '반영됨');
   });
 
+  test('내 신고 API 저장소는 백엔드 계약에 맞춰 신고 목록을 조회한다', () async {
+    late String requestMethod;
+    late String requestPath;
+    late String? authorizationHeader;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestMethod = request.method;
+      requestPath = request.uri.path;
+      authorizationHeader = request.headers.value(
+        HttpHeaders.authorizationHeader,
+      );
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': [
+              {
+                'id': 'report-2',
+                'stationId': 'station-sangnoksu',
+                'facilityId': 'facility-sangnoksu-elevator-1',
+                'reportType': 'CLOSED',
+                'description': '출입문이 막혀 있습니다.',
+                'status': 'ACCEPTED',
+                'createdAt': '2026-06-15T09:00:00',
+              },
+              {
+                'id': 'report-1',
+                'stationId': 'station-sangnoksu',
+                'facilityId': 'facility-sangnoksu-elevator-2',
+                'reportType': 'BROKEN',
+                'description': '버튼이 눌리지 않습니다.',
+                'status': 'SUBMITTED',
+                'createdAt': '2026-06-14T09:00:00',
+              },
+            ],
+          }),
+        )
+        ..close();
+    });
+
+    final repository = FacilityReportApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: const BasicAuthorizationHeaderProvider(
+        username: 'anonymous-user-1',
+        password: 'user-test-password',
+      ),
+    );
+
+    final reports = await repository.listMyReports();
+
+    expect(requestMethod, 'GET');
+    expect(requestPath, '/api/v1/me/reports');
+    expect(
+      authorizationHeader,
+      'Basic ${base64Encode(utf8.encode('anonymous-user-1:user-test-password'))}',
+    );
+    expect(reports, hasLength(2));
+    expect(reports.first.id, 'report-2');
+    expect(reports.first.statusLabel, '반영됨');
+    expect(reports.last.statusLabel, '접수됨');
+  });
+
+  test('내 신고 API 저장소는 인증 실패 시 인증을 지우고 한 번 재시도한다', () async {
+    final authorizationHeaders = <String?>[];
+    var requestCount = 0;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestCount++;
+      authorizationHeaders.add(
+        request.headers.value(HttpHeaders.authorizationHeader),
+      );
+      request.response.headers.contentType = ContentType.json;
+
+      if (requestCount == 1) {
+        request.response
+          ..statusCode = HttpStatus.unauthorized
+          ..write(jsonEncode({'success': false}))
+          ..close();
+        return;
+      }
+
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': [
+              {
+                'id': 'report-1',
+                'stationId': 'station-sangnoksu',
+                'facilityId': 'facility-sangnoksu-elevator-1',
+                'reportType': 'BROKEN',
+                'description': '문이 열리지 않습니다.',
+                'status': 'SUBMITTED',
+                'createdAt': '2026-06-13T10:00:00',
+              },
+            ],
+          }),
+        )
+        ..close();
+    });
+
+    final authProvider = RetryAuthorizationHeaderProvider();
+    final repository = FacilityReportApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: authProvider,
+    );
+
+    final reports = await repository.listMyReports();
+
+    expect(reports.single.id, 'report-1');
+    expect(authorizationHeaders, ['Basic stale-token', 'Basic fresh-token']);
+    expect(authProvider.authorizationCount, 2);
+    expect(authProvider.invalidateCount, 1);
+  });
+
   test('시설 신고 API 저장소는 상태 조회 실패를 전용 안내 문구로 바꾼다', () async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(server.close);
@@ -400,6 +522,11 @@ class PendingFacilityReportRepository implements FacilityReportRepository {
     throw UnimplementedError();
   }
 
+  @override
+  Future<List<FacilityReportResult>> listMyReports() {
+    throw UnimplementedError();
+  }
+
   void complete() {
     _completer.complete(
       const FacilityReportResult(
@@ -443,6 +570,11 @@ class RefreshableFacilityReportRepository implements FacilityReportRepository {
     return _refreshCompleter!.future;
   }
 
+  @override
+  Future<List<FacilityReportResult>> listMyReports() {
+    throw UnimplementedError();
+  }
+
   void completeRefresh() {
     _refreshCompleter!.complete(
       const FacilityReportResult(
@@ -481,6 +613,11 @@ class FailingRefreshFacilityReportRepository
   Future<FacilityReportResult> getReport(String reportId) {
     loadedReportIds.add(reportId);
     return Future.error(const FacilityReportException('처리 상태를 확인하지 못했습니다.'));
+  }
+
+  @override
+  Future<List<FacilityReportResult>> listMyReports() {
+    throw UnimplementedError();
   }
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -105,6 +105,56 @@ void main() {
     expect(Theme.of(homeContext).colorScheme.primary, const Color(0xFF003D40));
   });
 
+  testWidgets('홈에서 내 신고 화면으로 이동한다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository(
+      reports: [
+        const FacilityReportResult(
+          id: 'report-2',
+          stationId: 'station-sangnoksu',
+          facilityId: 'facility-sangnoksu-elevator-1',
+          reportType: 'CLOSED',
+          description: '출입문이 막혀 있습니다.',
+          status: 'ACCEPTED',
+          createdAt: '2026-06-15T09:00:00',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: reportRepository,
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('myReportsButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('내 신고'), findsOneWidget);
+    expect(find.text('반영됨'), findsOneWidget);
+    expect(find.text('출입문이 막혀 있습니다.'), findsOneWidget);
+    expect(reportRepository.listMyReportsCount, 1);
+  });
+
+  testWidgets('내 신고 화면은 접수한 신고가 없으면 짧은 빈 상태를 보여준다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MyFacilityReportListScreen(
+          repository: FakeFacilityReportRepository(reports: const []),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('접수한 신고가 없습니다.'), findsOneWidget);
+    expect(find.byKey(const Key('myReportsRetryButton')), findsNothing);
+  });
+
   testWidgets('앱은 온보딩 저장소를 읽지 못하면 다시 설정을 고르게 한다', (tester) async {
     final reportedErrors = <FlutterErrorDetails>[];
 
@@ -258,8 +308,8 @@ void main() {
       expect(find.text('역 찾기'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '역 검색'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '경로 검색'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '내 신고'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '즐겨찾기 역'), findsOneWidget);
-      expect(find.widgetWithText(FilledButton, '알림 설정'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsOneWidget);
       expect(find.textContaining('빠른 길보다'), findsNothing);
       expect(find.textContaining('고령자'), findsNothing);
@@ -274,6 +324,16 @@ void main() {
       final profileButtonSize = tester.getSize(
         find.byKey(const Key('mobilityProfileButton')),
       );
+      final myReportsButtonSize = tester.getSize(
+        find.byKey(const Key('myReportsButton')),
+      );
+
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('notificationSettingsButton')),
+        120,
+      );
+      await tester.pumpAndSettle();
+      expect(find.widgetWithText(FilledButton, '알림 설정'), findsOneWidget);
       final notificationButtonSize = tester.getSize(
         find.byKey(const Key('notificationSettingsButton')),
       );
@@ -282,6 +342,7 @@ void main() {
       expect(routeButtonSize.height, greaterThanOrEqualTo(60));
       expect(notificationButtonSize.height, greaterThanOrEqualTo(60));
       expect(profileButtonSize.height, greaterThanOrEqualTo(60));
+      expect(myReportsButtonSize.height, greaterThanOrEqualTo(60));
 
       await tester.drag(find.byType(ListView), const Offset(0, -620));
       await tester.pumpAndSettle();
@@ -331,6 +392,11 @@ void main() {
     expect(find.widgetWithText(FilledButton, '즐겨찾기 경로'), findsOneWidget);
     expect(find.byKey(const Key('favoriteStationsButton')), findsOneWidget);
     expect(find.widgetWithText(FilledButton, '즐겨찾기 역'), findsOneWidget);
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('notificationSettingsButton')),
+      120,
+    );
+    await tester.pumpAndSettle();
     expect(find.byKey(const Key('notificationSettingsButton')), findsOneWidget);
     expect(find.widgetWithText(FilledButton, '알림 설정'), findsOneWidget);
   });
@@ -392,8 +458,9 @@ void main() {
         ),
       );
 
-      await tester.ensureVisible(
+      await tester.scrollUntilVisible(
         find.byKey(const Key('notificationSettingsButton')),
+        120,
       );
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('notificationSettingsButton')));
@@ -503,6 +570,11 @@ void main() {
         ),
       );
 
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('favoriteFacilitiesButton')),
+        120,
+      );
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('favoriteFacilitiesButton')));
       await tester.pumpAndSettle();
 
@@ -2038,9 +2110,13 @@ class FakeRouteSearchRepository implements RouteSearchRepository {
 }
 
 class FakeFacilityReportRepository implements FacilityReportRepository {
+  FakeFacilityReportRepository({this.reports = const []});
+
   final requests = <FacilityReportRequest>[];
   final loadedReportIds = <String>[];
+  final List<FacilityReportResult> reports;
   String nextReportStatus = 'SUBMITTED';
+  int listMyReportsCount = 0;
   Object? error;
 
   @override
@@ -2079,6 +2155,16 @@ class FakeFacilityReportRepository implements FacilityReportRepository {
       status: nextReportStatus,
       createdAt: '2026-06-13T10:00:00',
     );
+  }
+
+  @override
+  Future<List<FacilityReportResult>> listMyReports() async {
+    listMyReportsCount++;
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return reports;
   }
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -138,6 +138,12 @@ void main() {
     expect(find.text('내 신고'), findsOneWidget);
     expect(find.text('반영됨'), findsOneWidget);
     expect(find.text('출입문이 막혀 있습니다.'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel(
+        '내 신고, 폐쇄, 접수번호 report-2, 반영됨, 출입문이 막혀 있습니다., 접수일 2026.06.15',
+      ),
+      findsOneWidget,
+    );
     expect(reportRepository.listMyReportsCount, 1);
   });
 


### PR DESCRIPTION
## 관련 이슈
- Closes #134

## 요약
- 홈 화면에 `내 신고` 진입 버튼을 추가했습니다.
- 모바일 신고 저장소에서 `GET /api/v1/me/reports`를 호출해 내 신고 목록을 조회하도록 연결했습니다.
- 내 신고 화면에 로딩, 빈 목록, 실패, 목록 표시 상태를 추가했습니다.
- 인증 만료 시 기존 익명 인증 흐름과 같이 인증 정보를 지우고 한 번 재시도합니다.

## 변경 사항
- `FacilityReportRepository`에 내 신고 목록 조회 계약을 추가했습니다.
- 신고 목록 응답 파싱, 상태 라벨, 신고 유형 라벨을 모바일 표시용으로 정리했습니다.
- 홈 위젯 테스트는 버튼이 늘어난 스크롤형 홈 레이아웃을 반영하도록 수정했습니다.

## 검증
- `flutter test test/facility_report_test.dart`
- `flutter test test/widget_test.dart`
- `flutter analyze`
- `flutter test`
- `flutter build apk --debug`
- Android 에뮬레이터 `maum_on_api36`에서 홈 `내 신고` 버튼과 내 신고 화면 진입을 확인했습니다.
  - 홈 스크린샷: `/private/tmp/easysubway-home-my-reports-button.png`
  - 내 신고 화면 스크린샷: `/private/tmp/easysubway-my-reports-error.png`

## 리스크
- 로컬 백엔드가 실행 중이 아닐 때는 내 신고 화면이 실패 상태를 보여줍니다. 실패 상태에는 짧은 오류 문구와 `다시 시도` 버튼을 제공합니다.
