### PR TITLE
[Feat] 모바일 경로 결과 피드백 추가

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -20,6 +20,7 @@ class EasySubwayApp extends StatelessWidget {
     StationSearchRepository? repository,
     FacilityReportRepository? reportRepository,
     RouteSearchRepository? routeRepository,
+    RouteFeedbackRepository? routeFeedbackRepository,
     FavoriteStationRepository? favoriteRepository,
     FavoriteFacilityRepository? favoriteFacilityRepository,
     FavoriteRouteRepository? favoriteRouteRepository,
@@ -35,6 +36,7 @@ class EasySubwayApp extends StatelessWidget {
            repository: repository,
            reportRepository: reportRepository,
            routeRepository: routeRepository,
+           routeFeedbackRepository: routeFeedbackRepository,
            favoriteRepository: favoriteRepository,
            favoriteFacilityRepository: favoriteFacilityRepository,
            favoriteRouteRepository: favoriteRouteRepository,
@@ -56,6 +58,7 @@ class EasySubwayApp extends StatelessWidget {
   }) : repository = dependencies.repository,
        reportRepository = dependencies.reportRepository,
        routeRepository = dependencies.routeRepository,
+       routeFeedbackRepository = dependencies.routeFeedbackRepository,
        favoriteRepository = dependencies.favoriteRepository,
        favoriteFacilityRepository = dependencies.favoriteFacilityRepository,
        favoriteRouteRepository = dependencies.favoriteRouteRepository,
@@ -65,6 +68,7 @@ class EasySubwayApp extends StatelessWidget {
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
+  final RouteFeedbackRepository? routeFeedbackRepository;
   final FavoriteStationRepository? favoriteRepository;
   final FavoriteFacilityRepository? favoriteFacilityRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
@@ -120,6 +124,7 @@ class EasySubwayApp extends StatelessWidget {
         repository: repository,
         reportRepository: reportRepository,
         routeRepository: routeRepository,
+        routeFeedbackRepository: routeFeedbackRepository,
         favoriteRepository: favoriteRepository,
         favoriteFacilityRepository: favoriteFacilityRepository,
         favoriteRouteRepository: favoriteRouteRepository,
@@ -137,6 +142,7 @@ class _EasySubwayHome extends StatefulWidget {
     required this.repository,
     required this.reportRepository,
     required this.routeRepository,
+    required this.routeFeedbackRepository,
     required this.favoriteRepository,
     required this.favoriteFacilityRepository,
     required this.favoriteRouteRepository,
@@ -149,6 +155,7 @@ class _EasySubwayHome extends StatefulWidget {
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
+  final RouteFeedbackRepository? routeFeedbackRepository;
   final FavoriteStationRepository? favoriteRepository;
   final FavoriteFacilityRepository? favoriteFacilityRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
@@ -206,6 +213,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         repository: widget.repository,
         reportRepository: widget.reportRepository,
         routeRepository: widget.routeRepository,
+        routeFeedbackRepository: widget.routeFeedbackRepository,
         favoriteRepository: widget.favoriteRepository,
         favoriteFacilityRepository: widget.favoriteFacilityRepository,
         favoriteRouteRepository: widget.favoriteRouteRepository,
@@ -321,6 +329,7 @@ class _EasySubwayAppDependencies {
     required this.repository,
     required this.reportRepository,
     required this.routeRepository,
+    required this.routeFeedbackRepository,
     required this.favoriteRepository,
     required this.favoriteFacilityRepository,
     required this.favoriteRouteRepository,
@@ -332,6 +341,7 @@ class _EasySubwayAppDependencies {
     StationSearchRepository? repository,
     FacilityReportRepository? reportRepository,
     RouteSearchRepository? routeRepository,
+    RouteFeedbackRepository? routeFeedbackRepository,
     FavoriteStationRepository? favoriteRepository,
     FavoriteFacilityRepository? favoriteFacilityRepository,
     FavoriteRouteRepository? favoriteRouteRepository,
@@ -357,6 +367,12 @@ class _EasySubwayAppDependencies {
           ),
       routeRepository:
           routeRepository ?? RouteSearchApiRepository(baseUri: baseUri),
+      routeFeedbackRepository:
+          routeFeedbackRepository ??
+          _defaultRouteFeedbackRepository(
+            baseUri: baseUri,
+            authProvider: sharedAuthProvider,
+          ),
       favoriteRepository:
           favoriteRepository ??
           _defaultFavoriteStationRepository(
@@ -389,6 +405,7 @@ class _EasySubwayAppDependencies {
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
+  final RouteFeedbackRepository? routeFeedbackRepository;
   final FavoriteStationRepository? favoriteRepository;
   final FavoriteFacilityRepository? favoriteFacilityRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
@@ -449,6 +466,19 @@ FavoriteRouteRepository? _defaultFavoriteRouteRepository({
   );
 }
 
+RouteFeedbackRepository? _defaultRouteFeedbackRepository({
+  required Uri baseUri,
+  required AuthorizationHeaderProvider? authProvider,
+}) {
+  if (authProvider == null) {
+    return null;
+  }
+  return RouteFeedbackApiRepository(
+    baseUri: baseUri,
+    authProvider: authProvider,
+  );
+}
+
 NotificationSettingsRepository? _defaultNotificationSettingsRepository({
   required Uri baseUri,
   required AuthorizationHeaderProvider? authProvider,
@@ -467,6 +497,7 @@ class HomeScreen extends StatelessWidget {
     required this.repository,
     required this.reportRepository,
     required this.routeRepository,
+    required this.routeFeedbackRepository,
     required this.favoriteRepository,
     required this.favoriteFacilityRepository,
     required this.favoriteRouteRepository,
@@ -481,6 +512,7 @@ class HomeScreen extends StatelessWidget {
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
   final RouteSearchRepository routeRepository;
+  final RouteFeedbackRepository? routeFeedbackRepository;
   final FavoriteStationRepository? favoriteRepository;
   final FavoriteFacilityRepository? favoriteFacilityRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
@@ -495,6 +527,7 @@ class HomeScreen extends StatelessWidget {
     final favoriteRepository = this.favoriteRepository;
     final favoriteFacilityRepository = this.favoriteFacilityRepository;
     final favoriteRouteRepository = this.favoriteRouteRepository;
+    final routeFeedbackRepository = this.routeFeedbackRepository;
     final notificationRepository = this.notificationRepository;
 
     return Scaffold(
@@ -541,6 +574,7 @@ class HomeScreen extends StatelessWidget {
                     builder: (_) => RouteSearchScreen(
                       repository: routeRepository,
                       stationRepository: repository,
+                      routeFeedbackRepository: routeFeedbackRepository,
                       favoriteRouteRepository: favoriteRouteRepository,
                       initialMobilityType: initialMobilityType,
                     ),

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -11,6 +11,7 @@ import 'station_search.dart';
 
 const _routeSearchTimeout = Duration(seconds: 8);
 const _routeSearchErrorMessage = '경로 정보를 불러오지 못했습니다.';
+const _routeFeedbackErrorMessage = '의견을 보내지 못했습니다.';
 const _favoriteRouteErrorMessage = '즐겨찾기 경로를 처리하지 못했습니다.';
 const _favoriteRouteLoadErrorMessage = '즐겨찾기 경로를 불러오지 못했습니다.';
 
@@ -25,6 +26,49 @@ String _mobilityLabelFor(String mobilityType) {
 
 abstract class RouteSearchRepository {
   Future<RouteSearchResult> searchRoute(RouteSearchRequest request);
+}
+
+abstract class RouteFeedbackRepository {
+  Future<void> submitRouteFeedback(RouteFeedbackRequest request);
+}
+
+enum RouteFeedbackRating {
+  helpful('HELPFUL'),
+  notHelpful('NOT_HELPFUL'),
+  blockedByRealWorld('BLOCKED_BY_REAL_WORLD');
+
+  const RouteFeedbackRating(this.serverValue);
+
+  final String serverValue;
+}
+
+class RouteFeedbackRequest {
+  const RouteFeedbackRequest({
+    required this.routeSearchId,
+    required this.rating,
+    required this.comment,
+  });
+
+  final String routeSearchId;
+  final RouteFeedbackRating rating;
+  final String comment;
+
+  RouteFeedbackRequest trimmed() {
+    return RouteFeedbackRequest(
+      routeSearchId: routeSearchId.trim(),
+      rating: rating,
+      comment: comment.trim(),
+    );
+  }
+
+  Map<String, Object?> toJson({required String userId}) {
+    final trimmedRequest = trimmed();
+    return {
+      'userId': userId.trim(),
+      'rating': trimmedRequest.rating.serverValue,
+      'comment': trimmedRequest.comment,
+    };
+  }
 }
 
 class RouteSearchApiRepository implements RouteSearchRepository {
@@ -76,6 +120,122 @@ class RouteSearchApiRepository implements RouteSearchRepository {
       throw const RouteSearchException(_routeSearchErrorMessage);
     }
   }
+}
+
+class RouteFeedbackApiRepository implements RouteFeedbackRepository {
+  RouteFeedbackApiRepository({
+    required this.baseUri,
+    required this.authProvider,
+    HttpClient? httpClient,
+  }) : _httpClient = httpClient ?? HttpClient();
+
+  final Uri baseUri;
+  final AuthorizationHeaderProvider authProvider;
+  final HttpClient _httpClient;
+
+  @override
+  Future<void> submitRouteFeedback(RouteFeedbackRequest feedbackRequest) async {
+    final trimmedRequest = feedbackRequest.trimmed();
+    if (trimmedRequest.routeSearchId.isEmpty) {
+      throw const RouteFeedbackException(_routeFeedbackErrorMessage);
+    }
+
+    final uri = baseUri.resolve(
+      '/api/v1/routes/${Uri.encodeComponent(trimmedRequest.routeSearchId)}/feedback',
+    );
+
+    for (var attempt = 0; attempt < 2; attempt++) {
+      try {
+        final authorizationHeader = await authProvider
+            .authorizationHeader()
+            .timeout(_routeSearchTimeout);
+        // 익명 인증 API는 Basic 인증의 username을 사용자 식별자로 사용한다.
+        final userId = _userIdFromAuthorizationHeader(authorizationHeader);
+        if (userId == null) {
+          throw const RouteFeedbackException(_routeFeedbackErrorMessage);
+        }
+
+        final request = await _httpClient
+            .postUrl(uri)
+            .timeout(_routeSearchTimeout);
+        request.headers.contentType = ContentType.json;
+        request.headers.set(
+          HttpHeaders.authorizationHeader,
+          authorizationHeader!,
+        );
+        request.write(jsonEncode(trimmedRequest.toJson(userId: userId)));
+
+        final response = await request.close().timeout(_routeSearchTimeout);
+        final body = await utf8
+            .decodeStream(response)
+            .timeout(_routeSearchTimeout);
+
+        // 저장된 익명 인증이 만료된 경우 새 인증을 발급받아 한 번만 재시도한다.
+        if (response.statusCode == HttpStatus.unauthorized && attempt == 0) {
+          await authProvider.invalidateAuthorization().timeout(
+            _routeSearchTimeout,
+          );
+          continue;
+        }
+
+        if (response.statusCode != HttpStatus.ok) {
+          throw const RouteFeedbackException(_routeFeedbackErrorMessage);
+        }
+
+        final decoded = jsonDecode(body);
+        if (decoded is! Map<String, Object?> || decoded['success'] != true) {
+          throw const RouteFeedbackException(_routeFeedbackErrorMessage);
+        }
+        return;
+      } on RouteFeedbackException {
+        rethrow;
+      } catch (error, stackTrace) {
+        reportMobileError(
+          error,
+          stackTrace,
+          context: '경로 피드백 API 요청 처리 중 예외가 발생했습니다.',
+        );
+        throw const RouteFeedbackException(_routeFeedbackErrorMessage);
+      }
+    }
+    throw const RouteFeedbackException(_routeFeedbackErrorMessage);
+  }
+
+  String? _userIdFromAuthorizationHeader(String? authorizationHeader) {
+    const prefix = 'Basic ';
+    if (authorizationHeader == null ||
+        !authorizationHeader.startsWith(prefix)) {
+      return null;
+    }
+
+    try {
+      final decoded = utf8.decode(
+        base64Decode(authorizationHeader.substring(prefix.length)),
+      );
+      final separatorIndex = decoded.indexOf(':');
+      if (separatorIndex <= 0) {
+        return null;
+      }
+      final userId = decoded.substring(0, separatorIndex).trim();
+      return userId.isEmpty ? null : userId;
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '경로 피드백 사용자 식별자 처리 중 예외가 발생했습니다.',
+      );
+      return null;
+    }
+  }
+}
+
+class RouteFeedbackException implements Exception {
+  const RouteFeedbackException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
 }
 
 abstract class FavoriteRouteRepository {
@@ -689,6 +849,7 @@ class RouteSearchScreen extends StatefulWidget {
   RouteSearchScreen({
     required this.repository,
     required this.stationRepository,
+    this.routeFeedbackRepository,
     this.favoriteRouteRepository,
     String? initialMobilityType,
     super.key,
@@ -696,6 +857,7 @@ class RouteSearchScreen extends StatefulWidget {
 
   final RouteSearchRepository repository;
   final StationSearchRepository stationRepository;
+  final RouteFeedbackRepository? routeFeedbackRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
   final String initialMobilityType;
 
@@ -822,6 +984,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
               animation: _controller,
               builder: (context, _) => _RouteSearchBody(
                 state: _controller.state,
+                routeFeedbackRepository: widget.routeFeedbackRepository,
                 favoriteRouteRepository: widget.favoriteRouteRepository,
               ),
             ),
@@ -1211,10 +1374,12 @@ class _RouteStationOptionTile extends StatelessWidget {
 class _RouteSearchBody extends StatelessWidget {
   const _RouteSearchBody({
     required this.state,
+    required this.routeFeedbackRepository,
     required this.favoriteRouteRepository,
   });
 
   final RouteSearchState state;
+  final RouteFeedbackRepository? routeFeedbackRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
 
   @override
@@ -1237,6 +1402,7 @@ class _RouteSearchBody extends StatelessWidget {
       ),
       RouteSearchViewStatus.success => _RouteSearchResultCard(
         result: state.result!,
+        routeFeedbackRepository: routeFeedbackRepository,
         favoriteRouteRepository: favoriteRouteRepository,
       ),
     };
@@ -1268,10 +1434,12 @@ class _RouteSearchMessage extends StatelessWidget {
 class _RouteSearchResultCard extends StatelessWidget {
   const _RouteSearchResultCard({
     required this.result,
+    required this.routeFeedbackRepository,
     required this.favoriteRouteRepository,
   });
 
   final RouteSearchResult result;
+  final RouteFeedbackRepository? routeFeedbackRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
 
   @override
@@ -1282,6 +1450,13 @@ class _RouteSearchResultCard extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _RouteSearchResultSummaryCard(result: result),
+        if (routeFeedbackRepository != null) ...[
+          const SizedBox(height: 12),
+          _RouteFeedbackButtons(
+            result: result,
+            repository: routeFeedbackRepository!,
+          ),
+        ],
         if (canSaveRoute) ...[
           const SizedBox(height: 12),
           _RouteFavoriteSaveButton(
@@ -1621,6 +1796,131 @@ class _RouteStepTile extends StatelessWidget {
         ],
       ),
     );
+  }
+}
+
+class _RouteFeedbackButtons extends StatefulWidget {
+  const _RouteFeedbackButtons({required this.result, required this.repository});
+
+  final RouteSearchResult result;
+  final RouteFeedbackRepository repository;
+
+  @override
+  State<_RouteFeedbackButtons> createState() => _RouteFeedbackButtonsState();
+}
+
+class _RouteFeedbackButtonsState extends State<_RouteFeedbackButtons> {
+  bool _submitting = false;
+  bool _submitted = false;
+  String _message = '';
+
+  @override
+  void didUpdateWidget(_RouteFeedbackButtons oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.result.routeSearchId != widget.result.routeSearchId) {
+      _submitting = false;
+      _submitted = false;
+      _message = '';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: FilledButton.icon(
+                key: const Key('routeFeedbackHelpfulButton'),
+                onPressed: _canSubmit
+                    ? () => _submit(RouteFeedbackRating.helpful, '추천이 도움이 됐어요')
+                    : null,
+                icon: const Icon(Icons.thumb_up_alt_outlined),
+                label: Text(_submitting ? '보내는 중' : '도움 됐어요'),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: OutlinedButton.icon(
+                key: const Key('routeFeedbackNotHelpfulButton'),
+                onPressed: _canSubmit
+                    ? () => _submit(
+                        RouteFeedbackRating.notHelpful,
+                        '경로가 실제 이동과 맞지 않아요',
+                      )
+                    : null,
+                icon: const Icon(Icons.report_problem_outlined),
+                label: const Text('맞지 않아요'),
+              ),
+            ),
+          ],
+        ),
+        if (_message.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          Semantics(
+            liveRegion: true,
+            child: Text(
+              _message,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: const Color(0xFF29484B),
+                fontWeight: FontWeight.w800,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  bool get _canSubmit => !_submitting && !_submitted;
+
+  Future<void> _submit(RouteFeedbackRating rating, String comment) async {
+    setState(() {
+      _submitting = true;
+      _message = '';
+    });
+
+    try {
+      await widget.repository.submitRouteFeedback(
+        RouteFeedbackRequest(
+          routeSearchId: widget.result.routeSearchId,
+          rating: rating,
+          comment: comment,
+        ),
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _submitting = false;
+        _submitted = true;
+        _message = '의견을 보냈습니다.';
+      });
+    } on RouteFeedbackException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _submitting = false;
+        _message = error.message;
+      });
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '경로 피드백 화면 처리 중 예외가 발생했습니다.',
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _submitting = false;
+        _message = _routeFeedbackErrorMessage;
+      });
+    }
   }
 }
 

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -250,6 +250,64 @@ void main() {
     expect(saved.mobilityLabel, '고령자');
     expect(saved.scoreLabel, '이동 점수 92점');
   });
+
+  test('경로 피드백 API 저장소는 익명 사용자 식별자와 평가를 전송한다', () async {
+    late Uri requestedUri;
+    late String requestedBody;
+    late String? requestedAuthorization;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) async {
+      requestedUri = request.uri;
+      requestedAuthorization = request.headers.value(
+        HttpHeaders.authorizationHeader,
+      );
+      requestedBody = await utf8.decoder.bind(request).join();
+
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {
+              'feedbackId': 'route-feedback-1',
+              'routeSearchId': 'route-1',
+              'userId': 'anonymous-user-1',
+              'rating': 'HELPFUL',
+              'comment': '추천이 도움이 됐어요',
+              'createdAt': '2026-06-15T12:00:00',
+            },
+          }),
+        )
+        ..close();
+    });
+
+    final repository = RouteFeedbackApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: const BasicAuthorizationHeaderProvider(
+        username: 'anonymous-user-1',
+        password: 'password',
+      ),
+    );
+
+    await repository.submitRouteFeedback(
+      const RouteFeedbackRequest(
+        routeSearchId: 'route-1',
+        rating: RouteFeedbackRating.helpful,
+        comment: '추천이 도움이 됐어요',
+      ),
+    );
+
+    expect(requestedUri.path, '/api/v1/routes/route-1/feedback');
+    expect(requestedAuthorization, startsWith('Basic '));
+    expect(jsonDecode(requestedBody), {
+      'userId': 'anonymous-user-1',
+      'rating': 'HELPFUL',
+      'comment': '추천이 도움이 됐어요',
+    });
+  });
 }
 
 class FakeRouteSearchRepository implements RouteSearchRepository {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1555,6 +1555,147 @@ void main() {
     expect(find.text('자주 쓰는 경로에 저장했습니다.'), findsOneWidget);
   });
 
+  testWidgets('경로 검색 결과는 큰 버튼으로 추천 피드백을 보낸다', (tester) async {
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '사당': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
+    final routeFeedbackRepository = FakeRouteFeedbackRepository();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        routeFeedbackRepository: routeFeedbackRepository,
+        favoriteRepository: FakeFavoriteStationRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchButton')));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeOriginStationInput')),
+      '상록수',
+    );
+    await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeDestinationStationInput')),
+      '사당',
+    );
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationSearchButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationOption-station-sadang')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(ListView), const Offset(0, -360));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(
+      find.byKey(const Key('routeFeedbackHelpfulButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeFeedbackHelpfulButton')));
+    await tester.pumpAndSettle();
+
+    expect(routeFeedbackRepository.requests, hasLength(1));
+    expect(routeFeedbackRepository.requests.single.routeSearchId, 'route-1');
+    expect(
+      routeFeedbackRepository.requests.single.rating,
+      RouteFeedbackRating.helpful,
+    );
+    expect(routeFeedbackRepository.requests.single.comment, '추천이 도움이 됐어요');
+    expect(find.text('의견을 보냈습니다.'), findsOneWidget);
+
+    final helpfulButton = tester.widget<FilledButton>(
+      find.byKey(const Key('routeFeedbackHelpfulButton')),
+    );
+    expect(helpfulButton.onPressed, isNull);
+  });
+
+  testWidgets('경로 피드백 실패는 짧은 오류 문구로 알린다', (tester) async {
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '사당': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
+    final routeFeedbackRepository = FakeRouteFeedbackRepository()
+      ..error = const RouteFeedbackException('의견을 보내지 못했습니다.');
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        routeFeedbackRepository: routeFeedbackRepository,
+        favoriteRepository: FakeFavoriteStationRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchButton')));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeOriginStationInput')),
+      '상록수',
+    );
+    await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeDestinationStationInput')),
+      '사당',
+    );
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationSearchButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationOption-station-sadang')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(ListView), const Offset(0, -360));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(
+      find.byKey(const Key('routeFeedbackNotHelpfulButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeFeedbackNotHelpfulButton')));
+    await tester.pumpAndSettle();
+
+    expect(
+      routeFeedbackRepository.requests.single.rating,
+      RouteFeedbackRating.notHelpful,
+    );
+    expect(find.text('의견을 보내지 못했습니다.'), findsOneWidget);
+  });
+
   testWidgets('경로 안내 칩은 좁은 화면과 큰 글자에서도 넘치지 않는다', (tester) async {
     tester.view.physicalSize = const Size(320, 1200);
     tester.view.devicePixelRatio = 1;
@@ -2112,6 +2253,20 @@ class FakeRouteSearchRepository implements RouteSearchRepository {
   Future<RouteSearchResult> searchRoute(RouteSearchRequest request) async {
     requests.add(request);
     return result;
+  }
+}
+
+class FakeRouteFeedbackRepository implements RouteFeedbackRepository {
+  final requests = <RouteFeedbackRequest>[];
+  Object? error;
+
+  @override
+  Future<void> submitRouteFeedback(RouteFeedbackRequest request) async {
+    requests.add(request);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

close #138

## 배경

경로 검색 결과가 실제 이동에 도움이 됐는지 확인할 수 있는 사용자 피드백 경로가 필요합니다. 교통약자 이동 경로는 엘리베이터, 환승 동선, 현장 상황 차이가 커서 검색 결과 이후의 짧은 평가가 추천 품질 개선에 직접 연결됩니다.

## 변경 사항

- 경로 검색 결과 화면에 `도움 됐어요`, `맞지 않아요` 피드백 버튼을 추가했습니다.
- 익명 인증 세션의 Basic username을 사용자 식별자로 사용해 `/api/v1/routes/{routeSearchId}/feedback` API로 평가를 전송합니다.
- 저장된 익명 인증이 만료되어 401이 내려오면 인증을 지우고 한 번 재시도합니다.
- 피드백 성공 후 중복 제출을 막고, 실패 시 짧은 오류 문구만 표시합니다.

## 검증

- `dart format lib/main.dart lib/route_search.dart test/route_search_test.dart test/widget_test.dart`
- `flutter analyze`
- `flutter test test/route_search_test.dart`
- `flutter test test/widget_test.dart`
- `flutter test`
- `node --test tools/ci/repository-contract.test.mjs`
- `flutter build apk --debug`
- Android 에뮬레이터에서 상록수 -> 사당 경로 검색 결과의 피드백 버튼 노출과 터치 영역을 확인했습니다.

## 리뷰 포인트

- `RouteFeedbackApiRepository`가 익명 인증 username을 `userId`로 보내는 방식이 현재 백엔드 계약과 맞는지 확인해 주세요.
- 피드백 버튼 문구와 위치가 경로 저장 버튼보다 먼저 보여도 사용 흐름에 무리가 없는지 확인해 주세요.
- 401 재시도는 인증 갱신 1회로 제한했습니다.

## 리스크

- 백엔드가 추후 인증 principal 기반으로 `userId`를 결정하게 되면 모바일 요청 body의 `userId`는 제거하는 편이 낫습니다.
- 현재 화면은 간단한 이분 피드백만 받습니다. 현장 차단, 엘리베이터 고장 같은 세부 사유는 별도 입력 흐름을 붙일 수 있습니다.

## 체크리스트

- [x] 테스트 display name을 한글로 작성했습니다.
- [x] 새 로직 중 의도가 바로 드러나지 않는 부분에 짧은 한글 주석을 추가했습니다.
- [x] Android 에뮬레이터에서 실제 화면을 확인했습니다.
- [ ] CI 통과 확인
- [ ] CodeRabbit 또는 Codex CLI 리뷰 확인
- [ ] merge 후 CD 상태 확인
