### PR TITLE
[Feat] 시설 신고 사진 링크 입력 추가

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -253,6 +253,7 @@ class FacilityReportRequest {
     required this.facilityId,
     required this.reportType,
     required this.description,
+    this.photoUrl,
   });
 
   final String userId;
@@ -260,6 +261,7 @@ class FacilityReportRequest {
   final String facilityId;
   final String reportType;
   final String description;
+  final String? photoUrl;
 
   FacilityReportRequest trimmed() {
     return FacilityReportRequest(
@@ -268,18 +270,23 @@ class FacilityReportRequest {
       facilityId: facilityId.trim(),
       reportType: reportType.trim(),
       description: description.trim(),
+      photoUrl: photoUrl?.trim(),
     );
   }
 
   Map<String, Object?> toJson() {
     final request = trimmed();
-    return {
+    final json = <String, Object?>{
       'userId': request.userId,
       'stationId': request.stationId,
       'facilityId': request.facilityId,
       'reportType': request.reportType,
       'description': request.description,
     };
+    if (request.photoUrl != null && request.photoUrl!.isNotEmpty) {
+      json['photoUrl'] = request.photoUrl;
+    }
+    return json;
   }
 }
 
@@ -434,6 +441,7 @@ class FacilityReportController extends ChangeNotifier {
     required FacilityReportTarget target,
     required FacilityReportTypeOption selectedType,
     required String description,
+    String? photoUrl,
   }) async {
     if (_disposed || _state.status == FacilityReportViewStatus.loading) {
       return;
@@ -454,6 +462,7 @@ class FacilityReportController extends ChangeNotifier {
           facilityId: target.facilityId,
           reportType: selectedType.reportType,
           description: description,
+          photoUrl: photoUrl,
         ),
       );
       _emitState(
@@ -821,6 +830,7 @@ class _MyReportMetaText extends StatelessWidget {
 class _FacilityReportScreenState extends State<FacilityReportScreen> {
   late final FacilityReportController _controller;
   final TextEditingController _descriptionController = TextEditingController();
+  final TextEditingController _photoUrlController = TextEditingController();
   FacilityReportTypeOption _selectedType = FacilityReportTypeOption.broken;
 
   @override
@@ -835,6 +845,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     _controller.removeListener(_onReportStateChanged);
     _controller.dispose();
     _descriptionController.dispose();
+    _photoUrlController.dispose();
     super.dispose();
   }
 
@@ -896,6 +907,23 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
               ),
             ),
             const SizedBox(height: 16),
+            TextField(
+              key: const Key('facilityReportPhotoUrlInput'),
+              controller: _photoUrlController,
+              enabled: !isLoading && !hasSubmittedReport,
+              keyboardType: TextInputType.url,
+              textInputAction: TextInputAction.done,
+              style: const TextStyle(fontSize: 18, height: 1.35),
+              decoration: const InputDecoration(
+                labelText: '사진 링크',
+                hintText: '사진 주소를 붙여 넣어 주세요',
+                floatingLabelBehavior: FloatingLabelBehavior.always,
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(8)),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
             if (state.message.isNotEmpty) _FacilityReportMessage(state: state),
             const SizedBox(height: 16),
             if (reportResult != null) ...[
@@ -935,6 +963,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       target: widget.target,
       selectedType: _selectedType,
       description: _descriptionController.text,
+      photoUrl: _photoUrlController.text,
     );
   }
 }

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -56,6 +56,7 @@ void main() {
         facilityId: 'facility-sangnoksu-elevator-1',
         reportType: 'BROKEN',
         description: ' 문이 열리지 않습니다. ',
+        photoUrl: ' https://cdn.example.test/reports/elevator-door.jpg ',
       ),
     );
 
@@ -64,11 +65,28 @@ void main() {
     expect(requestBody['reportType'], 'BROKEN');
     expect(requestBody['description'], '문이 열리지 않습니다.');
     expect(
+      requestBody['photoUrl'],
+      'https://cdn.example.test/reports/elevator-door.jpg',
+    );
+    expect(
       authorizationHeader,
       'Basic ${base64Encode(utf8.encode('anonymous-user-1:user-test-password'))}',
     );
     expect(result.id, 'report-1');
     expect(result.statusLabel, '접수됨');
+  });
+
+  test('시설 신고 요청은 사진 링크가 비어 있으면 전송하지 않는다', () {
+    final request = const FacilityReportRequest(
+      userId: 'anonymous-mobile-user',
+      stationId: 'station-sangnoksu',
+      facilityId: 'facility-sangnoksu-elevator-1',
+      reportType: 'BROKEN',
+      description: '문이 열리지 않습니다.',
+      photoUrl: '   ',
+    );
+
+    expect(request.toJson(), isNot(contains('photoUrl')));
   });
 
   test('시설 신고 API 저장소는 인증 실패 시 인증을 지우고 한 번 재시도한다', () async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2033,6 +2033,14 @@ void main() {
         find.byKey(const Key('facilityReportDescriptionInput')),
         '출입문이 막혀 있습니다.',
       );
+      await tester.ensureVisible(
+        find.byKey(const Key('facilityReportPhotoUrlInput')),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('facilityReportPhotoUrlInput')),
+        'https://cdn.example.test/reports/closed-door.jpg',
+      );
       await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
       await tester.pumpAndSettle();
 
@@ -2044,6 +2052,10 @@ void main() {
       );
       expect(reportRepository.requests.single.reportType, 'CLOSED');
       expect(reportRepository.requests.single.description, '출입문이 막혀 있습니다.');
+      expect(
+        reportRepository.requests.single.photoUrl,
+        'https://cdn.example.test/reports/closed-door.jpg',
+      );
       expect(find.text('신고가 접수되었습니다.'), findsOneWidget);
       expect(find.bySemanticsLabel('신고가 접수되었습니다.'), findsOneWidget);
       expect(find.text('접수번호'), findsOneWidget);
@@ -2054,6 +2066,10 @@ void main() {
         find.bySemanticsLabel('신고 접수번호 report-1, 현재 상태 접수됨'),
         findsOneWidget,
       );
+      final submittedPhotoUrlInput = tester.widget<TextField>(
+        find.byKey(const Key('facilityReportPhotoUrlInput')),
+      );
+      expect(submittedPhotoUrlInput.enabled, isFalse);
 
       reportRepository.nextReportStatus = 'ACCEPTED';
       await tester.ensureVisible(


### PR DESCRIPTION
## 관련 이슈
- Closes #142

## 배경
시설 신고 백엔드 계약은 사진 증거 링크를 받을 수 있지만, 모바일 신고 화면에서는 사용자가 사진 주소를 함께 전달할 입력 경로가 없었습니다. 현장에서 시설 상태를 설명할 때 사진 링크를 같이 남길 수 있도록 신고 요청과 화면을 맞춥니다.

## 변경 사항
- 시설 신고 요청 모델에 선택 입력값 `photoUrl`을 추가했습니다.
- 사진 링크는 앞뒤 공백을 제거하고, 비어 있으면 요청 JSON에서 제외하도록 처리했습니다.
- 시설 신고 화면에 `사진 링크` 입력 칸을 추가하고, 접수 완료 후에는 기존 입력처럼 수정할 수 없게 했습니다.
- API 요청과 위젯 흐름 테스트에 사진 링크 전송/제외 케이스를 추가했습니다.

## 검증
- `dart format lib/facility_report.dart test/facility_report_test.dart test/widget_test.dart`
- `flutter test test/facility_report_test.dart`
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 신고 유형과 내용을 보내고 접수 결과를 보여준다'`
- `flutter test`
- `flutter analyze`
- `node --test tools/ci/*.test.mjs`
- Android Emulator `maum_on_api36`에서 상록수역 시설 신고 화면의 `사진 링크` 입력 칸 배치 확인

## 리스크
- 실제 이미지 파일 업로드나 카메라/앨범 권한 처리는 포함하지 않았습니다. 현재 범위는 이미 업로드된 사진 주소를 신고 요청에 포함하는 입력 경로입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 시설 신고 시 사진 URL을 입력할 수 있는 기능이 추가되었습니다. 입력값의 공백이 자동으로 제거되며, 빈 입력값은 전송되지 않습니다.

* **Tests**
  * 사진 URL 입력 및 처리 관련 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->