### PR TITLE
[Feat] 시설 신고 현재 위치 첨부 추가

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -254,6 +254,8 @@ class FacilityReportRequest {
     required this.reportType,
     required this.description,
     this.photoUrl,
+    this.latitude,
+    this.longitude,
   });
 
   final String userId;
@@ -262,6 +264,8 @@ class FacilityReportRequest {
   final String reportType;
   final String description;
   final String? photoUrl;
+  final double? latitude;
+  final double? longitude;
 
   FacilityReportRequest trimmed() {
     return FacilityReportRequest(
@@ -271,6 +275,8 @@ class FacilityReportRequest {
       reportType: reportType.trim(),
       description: description.trim(),
       photoUrl: photoUrl?.trim(),
+      latitude: latitude,
+      longitude: longitude,
     );
   }
 
@@ -286,9 +292,27 @@ class FacilityReportRequest {
     if (request.photoUrl != null && request.photoUrl!.isNotEmpty) {
       json['photoUrl'] = request.photoUrl;
     }
+    // 좌표 한쪽만 저장되면 현장 위치를 잘못 해석할 수 있어 한 쌍일 때만 보낸다.
+    if (request.latitude != null && request.longitude != null) {
+      json['latitude'] = request.latitude;
+      json['longitude'] = request.longitude;
+    }
     return json;
   }
 }
+
+class FacilityReportLocation {
+  const FacilityReportLocation({
+    required this.latitude,
+    required this.longitude,
+  });
+
+  final double latitude;
+  final double longitude;
+}
+
+typedef FacilityReportLocationLoader =
+    Future<FacilityReportLocation> Function();
 
 class FacilityReportResult {
   const FacilityReportResult({
@@ -442,6 +466,8 @@ class FacilityReportController extends ChangeNotifier {
     required FacilityReportTypeOption selectedType,
     required String description,
     String? photoUrl,
+    double? latitude,
+    double? longitude,
   }) async {
     if (_disposed || _state.status == FacilityReportViewStatus.loading) {
       return;
@@ -463,6 +489,8 @@ class FacilityReportController extends ChangeNotifier {
           reportType: selectedType.reportType,
           description: description,
           photoUrl: photoUrl,
+          latitude: latitude,
+          longitude: longitude,
         ),
       );
       _emitState(
@@ -564,11 +592,13 @@ class FacilityReportScreen extends StatefulWidget {
   const FacilityReportScreen({
     required this.repository,
     required this.target,
+    this.locationLoader,
     super.key,
   });
 
   final FacilityReportRepository repository;
   final FacilityReportTarget target;
+  final FacilityReportLocationLoader? locationLoader;
 
   @override
   State<FacilityReportScreen> createState() => _FacilityReportScreenState();
@@ -832,6 +862,10 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
   final TextEditingController _descriptionController = TextEditingController();
   final TextEditingController _photoUrlController = TextEditingController();
   FacilityReportTypeOption _selectedType = FacilityReportTypeOption.broken;
+  FacilityReportLocation? _attachedLocation;
+  String _locationMessage = '';
+  bool _isLoadingLocation = false;
+  bool _isLocationFailure = false;
 
   @override
   void initState() {
@@ -923,6 +957,32 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
                 ),
               ),
             ),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              key: const Key('facilityReportAttachLocationButton'),
+              onPressed:
+                  isLoading ||
+                      hasSubmittedReport ||
+                      _isLoadingLocation ||
+                      widget.locationLoader == null
+                  ? null
+                  : _attachLocation,
+              icon: _isLoadingLocation
+                  ? const SizedBox(
+                      width: 22,
+                      height: 22,
+                      child: CircularProgressIndicator(strokeWidth: 2.5),
+                    )
+                  : const Icon(Icons.my_location),
+              label: Text(_attachedLocation == null ? '현재 위치 첨부' : '현재 위치 첨부됨'),
+            ),
+            if (_locationMessage.isNotEmpty) ...[
+              const SizedBox(height: 10),
+              _FacilityReportLocationMessage(
+                message: _locationMessage,
+                isFailure: _isLocationFailure,
+              ),
+            ],
             const SizedBox(height: 16),
             if (state.message.isNotEmpty) _FacilityReportMessage(state: state),
             const SizedBox(height: 16),
@@ -964,7 +1024,51 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       selectedType: _selectedType,
       description: _descriptionController.text,
       photoUrl: _photoUrlController.text,
+      latitude: _attachedLocation?.latitude,
+      longitude: _attachedLocation?.longitude,
     );
+  }
+
+  Future<void> _attachLocation() async {
+    final locationLoader = widget.locationLoader;
+    if (locationLoader == null || _isLoadingLocation) {
+      return;
+    }
+    setState(() {
+      _isLoadingLocation = true;
+      _locationMessage = '';
+      _isLocationFailure = false;
+    });
+
+    try {
+      final location = await locationLoader();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _attachedLocation = location;
+        _locationMessage = '현재 위치가 첨부되었습니다.';
+        _isLocationFailure = false;
+      });
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '시설 신고 현재 위치 첨부 중 예외가 발생했습니다.',
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _attachedLocation = null;
+        _locationMessage = '현재 위치를 확인하지 못했습니다.';
+        _isLocationFailure = true;
+      });
+    } finally {
+      if (mounted) {
+        setState(() => _isLoadingLocation = false);
+      }
+    }
   }
 }
 
@@ -1216,6 +1320,45 @@ class _FacilityReportMessage extends StatelessWidget {
             Expanded(
               child: Text(
                 state.message,
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: const Color(0xFF102A2C),
+                  fontWeight: FontWeight.w800,
+                  height: 1.3,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FacilityReportLocationMessage extends StatelessWidget {
+  const _FacilityReportLocationMessage({
+    required this.message,
+    required this.isFailure,
+  });
+
+  final String message;
+  final bool isFailure;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isFailure ? const Color(0xFF8A4B00) : const Color(0xFF006D77);
+    final icon = isFailure ? Icons.error_outline : Icons.check_circle_outline;
+
+    return Semantics(
+      label: message,
+      liveRegion: true,
+      child: ExcludeSemantics(
+        child: Row(
+          children: [
+            Icon(icon, color: color, size: 24),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                message,
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                   color: const Color(0xFF102A2C),
                   fontWeight: FontWeight.w800,

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -311,6 +311,15 @@ class FacilityReportLocation {
   final double longitude;
 }
 
+class FacilityReportLocationException implements Exception {
+  const FacilityReportLocationException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
 typedef FacilityReportLocationLoader =
     Future<FacilityReportLocation> Function();
 
@@ -889,6 +898,8 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     final isLoading = state.status == FacilityReportViewStatus.loading;
     final reportResult = state.result;
     final hasSubmittedReport = reportResult != null;
+    final isSubmitDisabled =
+        isLoading || hasSubmittedReport || _isLoadingLocation;
 
     return Scaffold(
       appBar: AppBar(title: const Text('시설 신고')),
@@ -996,7 +1007,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
             ],
             FilledButton.icon(
               key: const Key('facilityReportSubmitButton'),
-              onPressed: isLoading || hasSubmittedReport ? null : _submit,
+              onPressed: isSubmitDisabled ? null : _submit,
               icon: isLoading
                   ? const SizedBox(
                       width: 22,
@@ -1049,6 +1060,15 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
         _attachedLocation = location;
         _locationMessage = '현재 위치가 첨부되었습니다.';
         _isLocationFailure = false;
+      });
+    } on FacilityReportLocationException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _attachedLocation = null;
+        _locationMessage = error.message;
+        _isLocationFailure = true;
       });
     } catch (error, stackTrace) {
       reportMobileError(

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -640,6 +640,7 @@ class HomeScreen extends StatelessWidget {
                         repository: favoriteRepository,
                         stationRepository: repository,
                         reportRepository: reportRepository,
+                        locationProvider: locationProvider,
                       ),
                     ),
                   );

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1682,6 +1682,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
           repository: widget.repository,
           reportRepository: widget.reportRepository,
           favoriteRepository: widget.favoriteRepository,
+          locationProvider: widget.locationProvider,
           stationId: result.id,
         ),
       ),
@@ -1847,12 +1848,14 @@ class FavoriteStationListScreen extends StatefulWidget {
     required this.repository,
     required this.stationRepository,
     required this.reportRepository,
+    this.locationProvider,
     super.key,
   });
 
   final FavoriteStationRepository repository;
   final StationSearchRepository stationRepository;
   final FacilityReportRepository reportRepository;
+  final CurrentLocationProvider? locationProvider;
 
   @override
   State<FavoriteStationListScreen> createState() =>
@@ -1901,6 +1904,7 @@ class _FavoriteStationListScreenState extends State<FavoriteStationListScreen> {
           repository: widget.stationRepository,
           reportRepository: widget.reportRepository,
           favoriteRepository: widget.repository,
+          locationProvider: widget.locationProvider,
           stationId: favorite.stationId,
           // 목록에서 들어온 역은 이미 저장된 상태로 보여 해제 동작을 바로 할 수 있게 한다.
           initiallyFavorite: true,
@@ -2065,6 +2069,7 @@ class StationDetailScreen extends StatefulWidget {
     required this.reportRepository,
     required this.stationId,
     this.favoriteRepository,
+    this.locationProvider,
     this.initiallyFavorite,
     super.key,
   });
@@ -2072,6 +2077,7 @@ class StationDetailScreen extends StatefulWidget {
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
   final FavoriteStationRepository? favoriteRepository;
+  final CurrentLocationProvider? locationProvider;
   final String stationId;
   final bool? initiallyFavorite;
 
@@ -2122,6 +2128,7 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
               state: _controller.state,
               reportRepository: widget.reportRepository,
               favoriteController: _favoriteController,
+              locationProvider: widget.locationProvider,
             );
           },
         ),
@@ -2135,11 +2142,13 @@ class _StationDetailBody extends StatelessWidget {
     required this.state,
     required this.reportRepository,
     required this.favoriteController,
+    required this.locationProvider,
   });
 
   final StationDetailState state;
   final FacilityReportRepository reportRepository;
   final StationFavoriteToggleController? favoriteController;
+  final CurrentLocationProvider? locationProvider;
 
   @override
   Widget build(BuildContext context) {
@@ -2161,6 +2170,7 @@ class _StationDetailBody extends StatelessWidget {
         facilityAttentionSemanticLabel: state.facilityAttentionSemanticLabel,
         reportRepository: reportRepository,
         favoriteController: favoriteController,
+        locationProvider: locationProvider,
       ),
     };
   }
@@ -2175,6 +2185,7 @@ class _StationDetailContent extends StatelessWidget {
     required this.facilityAttentionSemanticLabel,
     required this.reportRepository,
     required this.favoriteController,
+    required this.locationProvider,
   });
 
   final StationDetail detail;
@@ -2184,6 +2195,7 @@ class _StationDetailContent extends StatelessWidget {
   final String facilityAttentionSemanticLabel;
   final FacilityReportRepository reportRepository;
   final StationFavoriteToggleController? favoriteController;
+  final CurrentLocationProvider? locationProvider;
 
   @override
   Widget build(BuildContext context) {
@@ -2231,6 +2243,7 @@ class _StationDetailContent extends StatelessWidget {
       MaterialPageRoute<void>(
         builder: (_) => FacilityReportScreen(
           repository: reportRepository,
+          locationLoader: _locationLoader(),
           target: FacilityReportTarget(
             stationId: detail.id,
             stationName: detail.nameKo,
@@ -2242,6 +2255,20 @@ class _StationDetailContent extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  FacilityReportLocationLoader? _locationLoader() {
+    final provider = locationProvider;
+    if (provider == null) {
+      return null;
+    }
+    return () async {
+      final location = await provider.currentLocation();
+      return FacilityReportLocation(
+        latitude: location.latitude,
+        longitude: location.longitude,
+      );
+    };
   }
 }
 

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2263,7 +2263,12 @@ class _StationDetailContent extends StatelessWidget {
       return null;
     }
     return () async {
-      final location = await provider.currentLocation();
+      final CurrentLocation location;
+      try {
+        location = await provider.currentLocation();
+      } on CurrentLocationException catch (error) {
+        throw FacilityReportLocationException(error.message);
+      }
       return FacilityReportLocation(
         latitude: location.latitude,
         longitude: location.longitude,

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -57,6 +57,8 @@ void main() {
         reportType: 'BROKEN',
         description: ' 문이 열리지 않습니다. ',
         photoUrl: ' https://cdn.example.test/reports/elevator-door.jpg ',
+        latitude: 37.302421,
+        longitude: 126.866221,
       ),
     );
 
@@ -68,6 +70,8 @@ void main() {
       requestBody['photoUrl'],
       'https://cdn.example.test/reports/elevator-door.jpg',
     );
+    expect(requestBody['latitude'], 37.302421);
+    expect(requestBody['longitude'], 126.866221);
     expect(
       authorizationHeader,
       'Basic ${base64Encode(utf8.encode('anonymous-user-1:user-test-password'))}',
@@ -87,6 +91,19 @@ void main() {
     );
 
     expect(request.toJson(), isNot(contains('photoUrl')));
+  });
+
+  test('시설 신고 요청은 현재 위치가 없으면 좌표를 전송하지 않는다', () {
+    final request = const FacilityReportRequest(
+      userId: 'anonymous-mobile-user',
+      stationId: 'station-sangnoksu',
+      facilityId: 'facility-sangnoksu-elevator-1',
+      reportType: 'BROKEN',
+      description: '문이 열리지 않습니다.',
+    );
+
+    expect(request.toJson(), isNot(contains('latitude')));
+    expect(request.toJson(), isNot(contains('longitude')));
   });
 
   test('시설 신고 API 저장소는 인증 실패 시 인증을 지우고 한 번 재시도한다', () async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2094,6 +2094,99 @@ void main() {
       semanticsHandle.dispose();
     }
   });
+
+  testWidgets('시설 신고 화면은 현재 위치를 함께 보낸다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    final locationProvider = FakeCurrentLocationProvider(
+      location: const CurrentLocation(
+        latitude: 37.302421,
+        longitude: 126.866221,
+      ),
+    );
+    final stationRepository = FakeStationSearchRepository(
+      nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      stationFacilities: const [
+        StationFacilityInfo(
+          id: 'facility-sangnoksu-elevator-1',
+          stationId: 'station-sangnoksu',
+          exitId: 'exit-sangnoksu-1',
+          type: 'ELEVATOR',
+          name: '1번 출구 엘리베이터',
+          floorFrom: 'B1',
+          floorTo: '1F',
+          description: '1번 출구 앞',
+          status: 'NORMAL',
+          dataConfidence: 'HIGH',
+          lastUpdatedAt: '2026-06-12',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: reportRepository,
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        locationProvider: locationProvider,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(
+        const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(
+        const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('시설 신고'), findsOneWidget);
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+    );
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportPhotoUrlInput')),
+    );
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportAttachLocationButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('facilityReportAttachLocationButton')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('현재 위치가 첨부되었습니다.'), findsOneWidget);
+    expect(locationProvider.requestCount, 1);
+
+    await tester.enterText(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+      '승강기 앞에서 확인했습니다.',
+    );
+    await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(reportRepository.requests, hasLength(1));
+    expect(reportRepository.requests.single.latitude, 37.302421);
+    expect(reportRepository.requests.single.longitude, 126.866221);
+  });
 }
 
 FavoriteStation _favoriteStation({required String id, required String name}) {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2187,6 +2187,141 @@ void main() {
     expect(reportRepository.requests.single.latitude, 37.302421);
     expect(reportRepository.requests.single.longitude, 126.866221);
   });
+
+  testWidgets('시설 신고 화면은 현재 위치 첨부 중 제출을 막는다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    final locationCompleter = Completer<FacilityReportLocation>();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FacilityReportScreen(
+          repository: reportRepository,
+          target: const FacilityReportTarget(
+            stationId: 'station-sangnoksu',
+            stationName: '상록수',
+            facilityId: 'facility-sangnoksu-elevator-1',
+            facilityName: '1번 출구 엘리베이터',
+            facilityTypeLabel: '엘리베이터',
+            facilityStatusLabel: '정상',
+          ),
+          locationLoader: () => locationCompleter.future,
+        ),
+      ),
+    );
+
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+    );
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportPhotoUrlInput')),
+    );
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportAttachLocationButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('facilityReportAttachLocationButton')),
+    );
+    await tester.pump();
+
+    final loadingSubmitButton = tester.widget<FilledButton>(
+      find.byKey(const Key('facilityReportSubmitButton')),
+    );
+    expect(loadingSubmitButton.onPressed, isNull);
+    await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
+    await tester.pump();
+    expect(reportRepository.requests, isEmpty);
+
+    locationCompleter.complete(
+      const FacilityReportLocation(latitude: 37.302421, longitude: 126.866221),
+    );
+    await tester.pumpAndSettle();
+
+    final readySubmitButton = tester.widget<FilledButton>(
+      find.byKey(const Key('facilityReportSubmitButton')),
+    );
+    expect(readySubmitButton.onPressed, isNotNull);
+  });
+
+  testWidgets('시설 신고 화면은 현재 위치 실패 안내를 그대로 보여준다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    final stationRepository = FakeStationSearchRepository(
+      nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      stationFacilities: const [
+        StationFacilityInfo(
+          id: 'facility-sangnoksu-elevator-1',
+          stationId: 'station-sangnoksu',
+          exitId: 'exit-sangnoksu-1',
+          type: 'ELEVATOR',
+          name: '1번 출구 엘리베이터',
+          floorFrom: 'B1',
+          floorTo: '1F',
+          description: '1번 출구 앞',
+          status: 'NORMAL',
+          dataConfidence: 'HIGH',
+          lastUpdatedAt: '2026-06-12',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: reportRepository,
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        locationProvider: FakeCurrentLocationProvider(
+          error: const CurrentLocationException('위치 권한을 허용해 주세요.'),
+        ),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(
+        const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(
+        const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+    );
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportPhotoUrlInput')),
+    );
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportAttachLocationButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('facilityReportAttachLocationButton')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('위치 권한을 허용해 주세요.'), findsOneWidget);
+    expect(find.text('현재 위치를 확인하지 못했습니다.'), findsNothing);
+    expect(reportRepository.requests, isEmpty);
+  });
 }
 
 FavoriteStation _favoriteStation({required String id, required String name}) {


### PR DESCRIPTION
Closes #144

## 요약
- 시설 신고 요청에 선택 좌표(latitude/longitude)를 포함하도록 모바일 요청 모델을 확장했습니다.
- 역 상세에서 쓰는 현재 위치 제공자를 시설 신고 화면까지 전달했습니다.
- 신고 화면에 `현재 위치 첨부` 버튼을 추가하고, 첨부 성공 시 `현재 위치가 첨부되었습니다.` 상태를 보여줍니다.

## 검증
- `flutter test`
- `flutter analyze`
- `node --test tools/ci/*.test.mjs`
- Android emulator: 상록수역 > 장애인 화장실 > 시설 신고에서 위치 권한 허용 후 `현재 위치 첨부됨`과 완료 메시지를 확인했습니다.

## 리스크
- 위치 권한 거부나 위치 조회 실패 시 좌표 없이 기존 신고 흐름을 유지합니다.