### PR TITLE
[Feat] 시설 신고 업로드 전 사진·위치 확인 추가

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1137,7 +1137,13 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     }
   }
 
-  void _submit() {
+  Future<void> _submit() async {
+    if (_photoAttachment != null && _attachedLocation != null) {
+      final confirmed = await _confirmReportUpload();
+      if (!confirmed) {
+        return;
+      }
+    }
     _controller.submit(
       target: widget.target,
       selectedType: _selectedType,
@@ -1146,6 +1152,27 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       latitude: _attachedLocation?.latitude,
       longitude: _attachedLocation?.longitude,
     );
+  }
+
+  Future<bool> _confirmReportUpload() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('사진·위치 확인'),
+        content: const Text('사진과 현재 위치를 함께 보냅니다.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('취소'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('보내기'),
+          ),
+        ],
+      ),
+    );
+    return confirmed ?? false;
   }
 
   Future<void> _pickPhoto() async {
@@ -1242,7 +1269,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       }
       setState(() {
         _attachedLocation = location;
-        _locationMessage = '위치 확인됨';
+        _locationMessage = '';
         _isLocationFailure = false;
       });
     } on FacilityReportLocationException catch (error) {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2159,6 +2159,8 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
       await tester.pumpAndSettle();
+      await tester.tap(find.text('보내기'));
+      await tester.pumpAndSettle();
 
       expect(reportRepository.requests, hasLength(1));
       expect(
@@ -2173,6 +2175,80 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('시설 신고 화면은 사진과 위치를 보내기 전에 확인한다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FacilityReportScreen(
+          repository: reportRepository,
+          target: const FacilityReportTarget(
+            stationId: 'station-sangnoksu',
+            stationName: '상록수',
+            facilityId: 'facility-sangnoksu-elevator-1',
+            facilityName: '1번 출구 엘리베이터',
+            facilityTypeLabel: '엘리베이터',
+            facilityStatusLabel: '정상',
+          ),
+          locationLoader: () async => const FacilityReportLocation(
+            latitude: 37.302421,
+            longitude: 126.866221,
+          ),
+          photoPicker: () async => const FacilityReportPhotoAttachment(
+            fileName: 'elevator-door.jpg',
+            contentType: 'image/jpeg',
+            dataBase64: 'aW1hZ2UtYnl0ZXM=',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('facilityReportAddPhotoButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('facilityReportAddPhotoButton')));
+    await tester.pumpAndSettle();
+
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+      '문 앞에 안내문이 붙어 있습니다.',
+    );
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportSubmitButton')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('사진·위치 확인'), findsOneWidget);
+    expect(find.text('사진과 현재 위치를 함께 보냅니다.'), findsOneWidget);
+    expect(reportRepository.requests, isEmpty);
+
+    await tester.tap(find.text('취소'));
+    await tester.pumpAndSettle();
+
+    expect(reportRepository.requests, isEmpty);
+
+    await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('보내기'));
+    await tester.pumpAndSettle();
+
+    expect(reportRepository.requests, hasLength(1));
+    expect(reportRepository.requests.single.photoFileName, 'elevator-door.jpg');
+    expect(reportRepository.requests.single.latitude, 37.302421);
+    expect(reportRepository.requests.single.longitude, 126.866221);
   });
 
   testWidgets('시설 신고 화면은 위치 실패 후 다시 확인할 수 있다', (tester) async {
@@ -2230,7 +2306,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(requestCount, 2);
-    expect(find.text('위치 확인됨'), findsOneWidget);
+    expect(find.text('위치 확인됨'), findsNothing);
     final readySubmitButton = tester.widget<FilledButton>(
       find.byKey(const Key('facilityReportSubmitButton')),
     );
@@ -2306,7 +2382,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('현재 위치 첨부됨'), findsNothing);
     expect(find.text('현재 위치가 첨부되었습니다.'), findsNothing);
-    expect(find.text('위치 확인됨'), findsOneWidget);
+    expect(find.text('위치 확인됨'), findsNothing);
     expect(locationProvider.requestCount, 1);
 
     await tester.enterText(


### PR DESCRIPTION
## 관련 이슈
- Closes #148

## 배경
시설 신고에서 사진과 위치 좌표가 함께 전송될 수 있는데, 사용자가 보내기 직전에 그 사실을 한 번 더 확인할 수 있는 장치가 필요했습니다. 동시에 위치가 정상 수집된 경우에는 불필요한 상태 문구를 줄이고, 위치를 확인하지 못한 경우에만 사용자가 바로 조치할 수 있는 안내를 남기도록 정리했습니다.

## 변경 사항
- 사진과 현재 위치가 모두 준비된 상태에서 신고를 보내면 `사진·위치 확인` 팝업을 먼저 보여줍니다.
- 확인 팝업에서 `취소`를 누르면 신고 요청을 보내지 않고, `보내기`를 누른 경우에만 사진과 좌표를 전송합니다.
- 위치 수집 성공 시 화면에는 별도 성공 문구를 표시하지 않고 내부 좌표만 유지합니다.
- 위치 수집 실패 시 제출을 막고 기존 `기기 위치를 켜 주세요.` / 권한 안내와 재시도 버튼 흐름을 유지합니다.
- 사진·위치 확인, 위치 실패 후 재시도, 위치 성공 문구 미노출을 위젯 테스트로 고정했습니다.

## 검증
- `flutter test`
- `flutter analyze`
- `flutter build apk --debug`
- `flutter build ios --simulator --debug`
- `node --test tools/ci/*.test.mjs`
- Android Emulator에서 확인
  - 시설 신고 화면 진입 시 위치 성공 문구가 보이지 않고 신고 버튼이 활성화됨
  - 앨범에서 실제 사진을 선택한 뒤 `신고 보내기`를 누르면 `사진·위치 확인` 팝업 표시
  - GPS를 끈 상태에서 `내 주변 역 찾기`를 누르면 `기기 위치를 켜 주세요.` 안내 표시

## 리스크
- 사진 선택기는 Android 시스템 UI를 사용하므로 기기 OS 버전에 따라 선택기 문구나 레이아웃은 달라질 수 있습니다.
- 이번 변경은 업로드 직전 확인 UX만 다루며, 서버의 사진/좌표 저장 계약은 변경하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시설 신고 제출 시 사진과 위치가 모두 있을 경우 확인 대화상자 표시 추가

* **개선 사항**
  * 위치 확인 후 메시지 UI 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->