### PR TITLE
[Feat] 위치 권한 요청 전 안내 추가

### DIFF
--- a/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
@@ -26,10 +26,10 @@ class MainActivity : FlutterActivity() {
         super.configureFlutterEngine(flutterEngine)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, locationChannelName)
             .setMethodCallHandler { call, result ->
-                if (call.method == "currentLocation") {
-                    handleCurrentLocation(result)
-                } else {
-                    result.notImplemented()
+                when (call.method) {
+                    "currentLocation" -> handleCurrentLocation(result)
+                    "needsLocationPermissionRequest" -> result.success(!hasLocationPermission())
+                    else -> result.notImplemented()
                 }
             }
     }

--- a/apps/mobile/ios/Runner/AppDelegate.swift
+++ b/apps/mobile/ios/Runner/AppDelegate.swift
@@ -24,6 +24,10 @@ import UIKit
       binaryMessenger: engineBridge.applicationRegistrar.messenger()
     )
     channel.setMethodCallHandler { [weak self] call, result in
+      if call.method == "needsLocationPermissionRequest" {
+        result(self?.needsLocationPermissionRequest() ?? true)
+        return
+      }
       guard call.method == "currentLocation" else {
         result(FlutterMethodNotImplemented)
         return
@@ -103,6 +107,17 @@ import UIKit
       return manager.authorizationStatus
     }
     return CLLocationManager.authorizationStatus()
+  }
+
+  private func needsLocationPermissionRequest() -> Bool {
+    switch currentAuthorizationStatus(for: locationManager) {
+    case .authorizedAlways, .authorizedWhenInUse:
+      return false
+    case .notDetermined, .restricted, .denied:
+      return true
+    @unknown default:
+      return true
+    }
   }
 
   private func finishLocationRequest(value: Any? = nil, errorCode: String? = nil) {

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -978,6 +978,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
   String _photoMessage = '';
   String _locationMessage = '';
   bool _isLoadingLocation = false;
+  bool _isLocationPreflightRunning = false;
   bool _isLocationFailure = false;
   bool _isPhotoFailure = false;
   bool _isPickingPhoto = false;
@@ -1013,6 +1014,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
         isLoading ||
         hasSubmittedReport ||
         _isLoadingLocation ||
+        _isLocationPreflightRunning ||
         _isLocationFailure ||
         (widget.locationLoader != null && _attachedLocation == null);
 
@@ -1098,10 +1100,13 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
                 const SizedBox(height: 10),
                 OutlinedButton.icon(
                   key: const Key('facilityReportRetryLocationButton'),
-                  onPressed: isLoading || _isLoadingLocation
+                  onPressed:
+                      isLoading ||
+                          _isLoadingLocation ||
+                          _isLocationPreflightRunning
                       ? null
                       : _requestCurrentLocation,
-                  icon: _isLoadingLocation
+                  icon: _isLoadingLocation || _isLocationPreflightRunning
                       ? const SizedBox(
                           width: 22,
                           height: 22,
@@ -1207,22 +1212,31 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
   }
 
   Future<void> _requestCurrentLocation() async {
-    if (widget.locationLoader == null || _isLoadingLocation) {
+    if (widget.locationLoader == null ||
+        _isLoadingLocation ||
+        _isLocationPreflightRunning) {
       return;
     }
-    final needsPermissionRequest = await _needsLocationPermissionRequest();
-    if (!mounted) {
-      return;
+    setState(() => _isLocationPreflightRunning = true);
+    try {
+      final needsPermissionRequest = await _needsLocationPermissionRequest();
+      if (!mounted) {
+        return;
+      }
+      if (needsPermissionRequest && !await _confirmLocationUse()) {
+        setState(() {
+          _attachedLocation = null;
+          _locationMessage = '현재 위치 확인이 필요합니다.';
+          _isLocationFailure = true;
+        });
+        return;
+      }
+      await _loadCurrentLocation();
+    } finally {
+      if (mounted) {
+        setState(() => _isLocationPreflightRunning = false);
+      }
     }
-    if (needsPermissionRequest && !await _confirmLocationUse()) {
-      setState(() {
-        _attachedLocation = null;
-        _locationMessage = '현재 위치 확인이 필요합니다.';
-        _isLocationFailure = true;
-      });
-      return;
-    }
-    await _loadCurrentLocation();
   }
 
   Future<bool> _needsLocationPermissionRequest() async {

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -359,6 +359,9 @@ class FacilityReportLocationException implements Exception {
 typedef FacilityReportLocationLoader =
     Future<FacilityReportLocation> Function();
 
+typedef FacilityReportLocationPermissionRequestChecker =
+    Future<bool> Function();
+
 typedef FacilityReportPhotoPicker =
     Future<FacilityReportPhotoAttachment?> Function();
 
@@ -696,6 +699,7 @@ class FacilityReportScreen extends StatefulWidget {
     required this.repository,
     required this.target,
     this.locationLoader,
+    this.needsLocationPermissionRequest,
     this.photoPicker,
     super.key,
   });
@@ -703,6 +707,8 @@ class FacilityReportScreen extends StatefulWidget {
   final FacilityReportRepository repository;
   final FacilityReportTarget target;
   final FacilityReportLocationLoader? locationLoader;
+  final FacilityReportLocationPermissionRequestChecker?
+  needsLocationPermissionRequest;
   final FacilityReportPhotoPicker? photoPicker;
 
   @override
@@ -982,7 +988,11 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     _controller = FacilityReportController(repository: widget.repository)
       ..addListener(_onReportStateChanged);
     _defaultPhotoPicker = ImagePickerFacilityReportPhotoPicker();
-    unawaited(_loadCurrentLocation());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        unawaited(_requestCurrentLocation());
+      }
+    });
   }
 
   @override
@@ -1090,7 +1100,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
                   key: const Key('facilityReportRetryLocationButton'),
                   onPressed: isLoading || _isLoadingLocation
                       ? null
-                      : _loadCurrentLocation,
+                      : _requestCurrentLocation,
                   icon: _isLoadingLocation
                       ? const SizedBox(
                           width: 22,
@@ -1173,6 +1183,54 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       ),
     );
     return confirmed ?? false;
+  }
+
+  Future<bool> _confirmLocationUse() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('현재 위치 사용'),
+        content: const Text('신고 위치를 확인하는 데 사용합니다.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('취소'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('위치 사용'),
+          ),
+        ],
+      ),
+    );
+    return confirmed ?? false;
+  }
+
+  Future<void> _requestCurrentLocation() async {
+    if (widget.locationLoader == null || _isLoadingLocation) {
+      return;
+    }
+    final needsPermissionRequest = await _needsLocationPermissionRequest();
+    if (!mounted) {
+      return;
+    }
+    if (needsPermissionRequest && !await _confirmLocationUse()) {
+      setState(() {
+        _attachedLocation = null;
+        _locationMessage = '현재 위치 확인이 필요합니다.';
+        _isLocationFailure = true;
+      });
+      return;
+    }
+    await _loadCurrentLocation();
+  }
+
+  Future<bool> _needsLocationPermissionRequest() async {
+    final checker = widget.needsLocationPermissionRequest;
+    if (checker == null) {
+      return true;
+    }
+    return checker();
   }
 
   Future<void> _pickPhoto() async {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1592,6 +1592,7 @@ class StationSearchScreen extends StatefulWidget {
 class _StationSearchScreenState extends State<StationSearchScreen> {
   late final StationSearchController _controller;
   final TextEditingController _queryController = TextEditingController();
+  bool _isLocationPreflightRunning = false;
 
   @override
   void initState() {
@@ -1655,7 +1656,8 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
               animation: _controller,
               builder: (context, _) {
                 final isLoading =
-                    _controller.state.status == StationSearchStatus.loading;
+                    _controller.state.status == StationSearchStatus.loading ||
+                    _isLocationPreflightRunning;
                 return OutlinedButton.icon(
                   key: const Key('nearbyStationSearchButton'),
                   onPressed: isLoading ? null : _searchNearby,
@@ -1688,19 +1690,30 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   }
 
   Future<void> _searchNearby() async {
-    if (_controller.state.status == StationSearchStatus.loading) {
+    if (_controller.state.status == StationSearchStatus.loading ||
+        _isLocationPreflightRunning) {
       return;
     }
-    final needsPermissionRequest = await widget.locationProvider
-        .needsLocationPermissionRequest();
-    if (!mounted) {
-      return;
+    setState(() => _isLocationPreflightRunning = true);
+    try {
+      final needsPermissionRequest = await widget.locationProvider
+          .needsLocationPermissionRequest();
+      if (!mounted) {
+        return;
+      }
+      if (needsPermissionRequest &&
+          !await _confirmLocationUse(context, message: '가까운 역을 찾는 데 사용합니다.')) {
+        return;
+      }
+      if (!mounted) {
+        return;
+      }
+      await _controller.searchNearby(widget.locationProvider);
+    } finally {
+      if (mounted) {
+        setState(() => _isLocationPreflightRunning = false);
+      }
     }
-    if (needsPermissionRequest &&
-        !await _confirmLocationUse(context, message: '가까운 역을 찾는 데 사용합니다.')) {
-      return;
-    }
-    _controller.searchNearby(widget.locationProvider);
   }
 
   void _openStationDetail(StationSearchResult result) {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -40,6 +40,8 @@ class CurrentLocation {
 }
 
 abstract class CurrentLocationProvider {
+  Future<bool> needsLocationPermissionRequest();
+
   Future<CurrentLocation> currentLocation();
 }
 
@@ -59,6 +61,23 @@ class MethodChannelCurrentLocationProvider implements CurrentLocationProvider {
           const MethodChannel('com.easysubway.easysubway_mobile/location');
 
   final MethodChannel _channel;
+
+  @override
+  Future<bool> needsLocationPermissionRequest() async {
+    try {
+      return await _channel.invokeMethod<bool>(
+            'needsLocationPermissionRequest',
+          ) ??
+          true;
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '현재 위치 권한 상태 확인 중 예외가 발생했습니다.',
+      );
+      return true;
+    }
+  }
 
   @override
   Future<CurrentLocation> currentLocation() async {
@@ -1668,8 +1687,17 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     _controller.search(query);
   }
 
-  void _searchNearby() {
+  Future<void> _searchNearby() async {
     if (_controller.state.status == StationSearchStatus.loading) {
+      return;
+    }
+    final needsPermissionRequest = await widget.locationProvider
+        .needsLocationPermissionRequest();
+    if (!mounted) {
+      return;
+    }
+    if (needsPermissionRequest &&
+        !await _confirmLocationUse(context, message: '가까운 역을 찾는 데 사용합니다.')) {
       return;
     }
     _controller.searchNearby(widget.locationProvider);
@@ -1688,6 +1716,30 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       ),
     );
   }
+}
+
+Future<bool> _confirmLocationUse(
+  BuildContext context, {
+  required String message,
+}) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('현재 위치 사용'),
+      content: Text(message),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('취소'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('위치 사용'),
+        ),
+      ],
+    ),
+  );
+  return confirmed ?? false;
 }
 
 class _StationSearchBody extends StatelessWidget {
@@ -2244,6 +2296,7 @@ class _StationDetailContent extends StatelessWidget {
         builder: (_) => FacilityReportScreen(
           repository: reportRepository,
           locationLoader: _locationLoader(),
+          needsLocationPermissionRequest: _locationPermissionRequestChecker(),
           target: FacilityReportTarget(
             stationId: detail.id,
             stationName: detail.nameKo,
@@ -2274,6 +2327,15 @@ class _StationDetailContent extends StatelessWidget {
         longitude: location.longitude,
       );
     };
+  }
+
+  FacilityReportLocationPermissionRequestChecker?
+  _locationPermissionRequestChecker() {
+    final provider = locationProvider;
+    if (provider == null) {
+      return null;
+    }
+    return provider.needsLocationPermissionRequest;
   }
 }
 

--- a/apps/mobile/test/current_location_provider_test.dart
+++ b/apps/mobile/test/current_location_provider_test.dart
@@ -1,0 +1,23 @@
+import 'package:easysubway_mobile/station_search.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('현재 위치 제공자는 권한 요청 필요 여부를 네이티브 채널로 확인한다', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    const channel = MethodChannel('test/current-location');
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    final requestedMethods = <String>[];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      requestedMethods.add(call.method);
+      return false;
+    });
+    addTearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+    final provider = MethodChannelCurrentLocationProvider(channel: channel);
+
+    expect(await provider.needsLocationPermissionRequest(), isFalse);
+    expect(requestedMethods, ['needsLocationPermissionRequest']);
+  });
+}

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -1220,11 +1220,21 @@ class FailingStationDetailRepository implements StationSearchRepository {
 }
 
 class FakeCurrentLocationProvider implements CurrentLocationProvider {
-  FakeCurrentLocationProvider({this.location, this.error});
+  FakeCurrentLocationProvider({
+    this.location,
+    this.error,
+    this.needsPermissionRequest = true,
+  });
 
   final CurrentLocation? location;
   final Object? error;
+  final bool needsPermissionRequest;
   int requestCount = 0;
+
+  @override
+  Future<bool> needsLocationPermissionRequest() async {
+    return needsPermissionRequest;
+  }
 
   @override
   Future<CurrentLocation> currentLocation() async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -899,6 +899,49 @@ void main() {
     expect(find.text('현재 위치 사용'), findsNothing);
   });
 
+  testWidgets('역 검색은 위치 권한 확인 중 중복 탭을 무시한다', (tester) async {
+    final permissionCompleter = Completer<bool>();
+    final locationProvider = FakeCurrentLocationProvider(
+      location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
+      needsPermissionRequestLoader: () => permissionCompleter.future,
+    );
+    final repository = FakeStationSearchRepository(
+      nearbyResults: [
+        _stationResult(
+          id: 'station-sangnoksu',
+          name: '상록수',
+          distanceMeters: 230,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        locationProvider: locationProvider,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
+    await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
+    await tester.pump();
+
+    expect(locationProvider.permissionCheckCount, 1);
+    expect(locationProvider.requestCount, 0);
+
+    permissionCompleter.complete(false);
+    await tester.pumpAndSettle();
+
+    expect(locationProvider.requestCount, 1);
+    expect(repository.requestedNearbyLocations, hasLength(1));
+  });
+
   testWidgets('역 검색은 현재 위치를 확인하지 못하면 짧은 안내를 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final locationProvider = FakeCurrentLocationProvider(
@@ -2339,12 +2382,81 @@ void main() {
     await tester.tap(
       find.byKey(const Key('facilityReportRetryLocationButton')),
     );
-    await tester.pumpAndSettle();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
     await tester.tap(find.text('위치 사용'));
     await tester.pumpAndSettle();
 
     expect(requestCount, 1);
     expect(find.text('현재 위치 확인이 필요합니다.'), findsNothing);
+  });
+
+  testWidgets('시설 신고 화면은 위치 재확인 중 중복 탭을 무시한다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    final permissionChecks = <Completer<bool>>[
+      Completer<bool>(),
+      Completer<bool>(),
+    ];
+    var permissionCheckCount = 0;
+    var requestCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FacilityReportScreen(
+          repository: reportRepository,
+          target: const FacilityReportTarget(
+            stationId: 'station-sangnoksu',
+            stationName: '상록수',
+            facilityId: 'facility-sangnoksu-elevator-1',
+            facilityName: '1번 출구 엘리베이터',
+            facilityTypeLabel: '엘리베이터',
+            facilityStatusLabel: '정상',
+          ),
+          needsLocationPermissionRequest: () {
+            final check = permissionChecks[permissionCheckCount];
+            permissionCheckCount++;
+            return check.future;
+          },
+          locationLoader: () async {
+            requestCount++;
+            return const FacilityReportLocation(
+              latitude: 37.302421,
+              longitude: 126.866221,
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(permissionCheckCount, 1);
+
+    permissionChecks.first.complete(true);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('취소'));
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('facilityReportRetryLocationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('facilityReportRetryLocationButton')),
+    );
+    await tester.tap(
+      find.byKey(const Key('facilityReportRetryLocationButton')),
+    );
+    await tester.pump();
+
+    expect(permissionCheckCount, 2);
+    expect(requestCount, 0);
+
+    permissionChecks.last.complete(false);
+    await tester.pumpAndSettle();
+
+    expect(permissionCheckCount, 2);
+    expect(requestCount, 1);
   });
 
   testWidgets('시설 신고 화면은 위치 실패 후 다시 확인할 수 있다', (tester) async {
@@ -2400,7 +2512,8 @@ void main() {
     await tester.tap(
       find.byKey(const Key('facilityReportRetryLocationButton')),
     );
-    await tester.pumpAndSettle();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 250));
     await tester.tap(find.text('위치 사용'));
     await tester.pumpAndSettle();
 
@@ -3135,15 +3248,23 @@ class FakeCurrentLocationProvider implements CurrentLocationProvider {
     this.location,
     this.error,
     this.needsPermissionRequest = true,
+    this.needsPermissionRequestLoader,
   });
 
   final CurrentLocation? location;
   final Object? error;
   final bool needsPermissionRequest;
+  final Future<bool> Function()? needsPermissionRequestLoader;
+  int permissionCheckCount = 0;
   int requestCount = 0;
 
   @override
   Future<bool> needsLocationPermissionRequest() async {
+    permissionCheckCount++;
+    final loader = needsPermissionRequestLoader;
+    if (loader != null) {
+      return loader();
+    }
     return needsPermissionRequest;
   }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -816,6 +816,7 @@ void main() {
     final semanticsHandle = tester.ensureSemantics();
     final locationProvider = FakeCurrentLocationProvider(
       location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
+      needsPermissionRequest: false,
     );
     final repository = FakeStationSearchRepository(
       nearbyResults: [
@@ -844,6 +845,7 @@ void main() {
       await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
       await tester.pumpAndSettle();
 
+      expect(find.text('현재 위치 사용'), findsNothing);
       expect(locationProvider.requestCount, 1);
       expect(repository.requestedNearbyLocations.single.latitude, 37.3028);
       expect(repository.requestedNearbyLocations.single.longitude, 126.8665);
@@ -865,6 +867,36 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('역 검색은 현재 위치 안내를 취소하면 위치를 요청하지 않는다', (tester) async {
+    final locationProvider = FakeCurrentLocationProvider(
+      location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
+    );
+    final repository = FakeStationSearchRepository();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        locationProvider: locationProvider,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('취소'));
+    await tester.pumpAndSettle();
+
+    expect(locationProvider.requestCount, 0);
+    expect(repository.requestedNearbyLocations, isEmpty);
+    expect(find.text('현재 위치 사용'), findsNothing);
   });
 
   testWidgets('역 검색은 현재 위치를 확인하지 못하면 짧은 안내를 보여준다', (tester) async {
@@ -889,6 +921,8 @@ void main() {
       await tester.tap(find.byKey(const Key('stationSearchButton')));
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('위치 사용'));
       await tester.pumpAndSettle();
 
       expect(locationProvider.requestCount, 1);
@@ -2022,6 +2056,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
+      await _acceptLocationUse(tester);
 
       expect(find.text('시설 신고'), findsOneWidget);
       expect(find.text('상록수역'), findsOneWidget);
@@ -2126,6 +2161,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
+      await _acceptLocationUse(tester);
 
       expect(
         find.byKey(const Key('facilityReportPhotoUrlInput')),
@@ -2205,6 +2241,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
+    await _acceptLocationUse(tester);
 
     await tester.dragUntilVisible(
       find.byKey(const Key('facilityReportAddPhotoButton')),
@@ -2251,6 +2288,65 @@ void main() {
     expect(reportRepository.requests.single.longitude, 126.866221);
   });
 
+  testWidgets('시설 신고 화면은 위치 안내를 수락하기 전에는 위치를 요청하지 않는다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    var requestCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FacilityReportScreen(
+          repository: reportRepository,
+          target: const FacilityReportTarget(
+            stationId: 'station-sangnoksu',
+            stationName: '상록수',
+            facilityId: 'facility-sangnoksu-elevator-1',
+            facilityName: '1번 출구 엘리베이터',
+            facilityTypeLabel: '엘리베이터',
+            facilityStatusLabel: '정상',
+          ),
+          locationLoader: () async {
+            requestCount++;
+            return const FacilityReportLocation(
+              latitude: 37.302421,
+              longitude: 126.866221,
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('현재 위치 사용'), findsOneWidget);
+    expect(find.text('신고 위치를 확인하는 데 사용합니다.'), findsOneWidget);
+    expect(requestCount, 0);
+
+    await tester.tap(find.text('취소'));
+    await tester.pumpAndSettle();
+
+    expect(requestCount, 0);
+    await tester.dragUntilVisible(
+      find.byKey(const Key('facilityReportRetryLocationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('현재 위치 확인이 필요합니다.'), findsOneWidget);
+    expect(
+      find.byKey(const Key('facilityReportRetryLocationButton')),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.byKey(const Key('facilityReportRetryLocationButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('위치 사용'));
+    await tester.pumpAndSettle();
+
+    expect(requestCount, 1);
+    expect(find.text('현재 위치 확인이 필요합니다.'), findsNothing);
+  });
+
   testWidgets('시설 신고 화면은 위치 실패 후 다시 확인할 수 있다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
     var requestCount = 0;
@@ -2283,6 +2379,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
+    await _acceptLocationUse(tester);
     await tester.dragUntilVisible(
       find.byKey(const Key('facilityReportSubmitButton')),
       find.byType(Scrollable).first,
@@ -2304,6 +2401,8 @@ void main() {
       find.byKey(const Key('facilityReportRetryLocationButton')),
     );
     await tester.pumpAndSettle();
+    await tester.tap(find.text('위치 사용'));
+    await tester.pumpAndSettle();
 
     expect(requestCount, 2);
     expect(find.text('위치 확인됨'), findsNothing);
@@ -2320,6 +2419,7 @@ void main() {
         latitude: 37.302421,
         longitude: 126.866221,
       ),
+      needsPermissionRequest: false,
     );
     final stationRepository = FakeStationSearchRepository(
       nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
@@ -2418,6 +2518,8 @@ void main() {
       ),
     );
     await tester.pump();
+    await tester.tap(find.text('위치 사용'));
+    await tester.pump();
 
     await tester.ensureVisible(
       find.byKey(const Key('facilityReportDescriptionInput')),
@@ -2499,6 +2601,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
+    await _acceptLocationUse(tester);
     await tester.ensureVisible(
       find.byKey(const Key('facilityReportDescriptionInput')),
     );
@@ -2515,6 +2618,12 @@ void main() {
     await tester.pump();
     expect(reportRepository.requests, isEmpty);
   });
+}
+
+Future<void> _acceptLocationUse(WidgetTester tester) async {
+  expect(find.text('현재 위치 사용'), findsOneWidget);
+  await tester.tap(find.text('위치 사용'));
+  await tester.pumpAndSettle();
 }
 
 FavoriteStation _favoriteStation({required String id, required String name}) {
@@ -3022,11 +3131,21 @@ StationSearchResult _stationResult({
 }
 
 class FakeCurrentLocationProvider implements CurrentLocationProvider {
-  FakeCurrentLocationProvider({this.location, this.error});
+  FakeCurrentLocationProvider({
+    this.location,
+    this.error,
+    this.needsPermissionRequest = true,
+  });
 
   final CurrentLocation? location;
   final Object? error;
+  final bool needsPermissionRequest;
   int requestCount = 0;
+
+  @override
+  Future<bool> needsLocationPermissionRequest() async {
+    return needsPermissionRequest;
+  }
 
   @override
   Future<CurrentLocation> currentLocation() async {


### PR DESCRIPTION
## 관련 이슈
- Closes #150

## 배경
위치 권한이 없는 상태에서 주변 역 찾기나 시설 신고를 누르면 OS 권한 팝업이 바로 뜨기 때문에 사용자가 왜 위치가 필요한지 판단하기 어렵습니다. 반대로 이미 위치 권한이 있는 사용자는 추가 확인 없이 현재 위치를 사용해 가까운 역과 신고 위치를 판단해야 합니다.

## 변경 사항
- Android/iOS 위치 채널에 권한 요청 필요 여부 조회를 추가했습니다.
- 역 검색은 권한 요청이 필요한 경우에만 짧은 안내를 보여주고, 취소하면 위치 요청을 시작하지 않습니다.
- 시설 신고도 권한 요청 전 안내를 거치며, GPS가 꺼져 있거나 위치를 확인하지 못하면 기존 실패 문구와 재시도 버튼으로 복구할 수 있게 유지했습니다.
- 사진 신고는 URL 입력 없이 실제 사진 첨부 흐름을 유지하고, 현재 위치 첨부 완료 같은 불필요한 상태 문구를 노출하지 않습니다.

## 검증
- `flutter test`
- `flutter analyze`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `flutter build apk --debug`
- `flutter build ios --simulator --debug`
- Android 에뮬레이터에서 주변 역 찾기 위치 안내, 취소 시 OS 권한 미요청, 권한 허용 후 GPS 꺼짐 안내를 확인했습니다.

## 리스크
- 위치 권한 상태 조회 채널이 실패하면 안전하게 안내를 먼저 보여주는 쪽으로 처리합니다.
- 백엔드가 없는 로컬 앱 실행에서는 위치 수집 뒤 주변 역 API 호출이 실패할 수 있으며, 이번 변경 범위는 권한/위치 안내 흐름입니다.