### PR TITLE
[Feat] 역 상세 쉬운 이동 구조 표시

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -835,6 +835,43 @@ class StationFacilityInfo {
     };
   }
 
+  bool get isLayoutSummaryTarget {
+    return switch (type) {
+      'ELEVATOR' ||
+      'WHEELCHAIR_LIFT' ||
+      'RAMP' ||
+      'ACCESSIBLE_TOILET' ||
+      'NURSING_ROOM' ||
+      'CUSTOMER_CENTER' ||
+      'STATION_OFFICE' => true,
+      _ => false,
+    };
+  }
+
+  IconData get layoutSummaryIcon {
+    return switch (type) {
+      'ELEVATOR' => Icons.elevator,
+      'WHEELCHAIR_LIFT' => Icons.accessible_forward,
+      'RAMP' => Icons.accessible,
+      'ACCESSIBLE_TOILET' => Icons.wc,
+      'NURSING_ROOM' => Icons.child_care,
+      'CUSTOMER_CENTER' || 'STATION_OFFICE' => Icons.support_agent,
+      _ => Icons.place,
+    };
+  }
+
+  int get layoutSummaryPriority {
+    return switch (type) {
+      'ELEVATOR' => 10,
+      'WHEELCHAIR_LIFT' => 20,
+      'RAMP' => 30,
+      'ACCESSIBLE_TOILET' => 40,
+      'NURSING_ROOM' => 50,
+      'CUSTOMER_CENTER' || 'STATION_OFFICE' => 60,
+      _ => 90,
+    };
+  }
+
   String get statusLabel {
     return switch (status) {
       'NORMAL' => '정상',
@@ -882,6 +919,13 @@ class StationFacilityInfo {
   String get semanticLabel {
     return '$name, $typeLabel, $statusLabel, $locationLabel, $updatedLabel, $confidenceLabel, $dataSourceLabel';
   }
+}
+
+class StationLayoutSummaryItem {
+  const StationLayoutSummaryItem({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
 }
 
 class StationSearchLine {
@@ -1262,6 +1306,81 @@ class StationDetailState {
       return '확인이 필요한 시설 없음';
     }
     return '확인이 필요한 시설 $count개';
+  }
+
+  List<StationLayoutSummaryItem> get layoutSummaryItems {
+    final items = <StationLayoutSummaryItem>[];
+    // 역 전체 구조를 짧게 보여주기 위해 엘리베이터 연결 출구를 우선 시작점으로 삼는다.
+    final accessibleExit = exits
+        .where((exit) => exit.hasElevatorConnection)
+        .cast<StationExitInfo?>()
+        .firstWhere((exit) => exit != null, orElse: () => null);
+    final firstExit = exits.isNotEmpty ? exits.first : null;
+    final exit = accessibleExit ?? firstExit;
+    if (exit != null) {
+      items.add(
+        StationLayoutSummaryItem(icon: Icons.exit_to_app, text: exit.name),
+      );
+    }
+
+    for (final facility in _layoutSummaryFacilities()) {
+      items.add(
+        StationLayoutSummaryItem(
+          icon: facility.layoutSummaryIcon,
+          text: facility.typeLabel,
+        ),
+      );
+    }
+
+    if (items.isNotEmpty) {
+      items.add(const StationLayoutSummaryItem(icon: Icons.train, text: '승강장'));
+    }
+    return List.unmodifiable(items);
+  }
+
+  String get layoutSummarySemanticLabel {
+    final items = layoutSummaryItems;
+    if (items.isEmpty) {
+      return '이동 구조 정보 없음';
+    }
+    return '이동 구조, ${items.map((item) => item.text).join(', ')}';
+  }
+
+  List<StationFacilityInfo> _layoutSummaryFacilities() {
+    final seenTypes = <String>{};
+    final summaryFacilities = <StationFacilityInfo>[];
+    final candidates = facilities
+        .where((facility) => facility.isLayoutSummaryTarget)
+        .toList();
+    candidates.sort((left, right) {
+      // 고장 여부보다 시설 유형 순서를 먼저 고정해 이동 흐름이 매번 같은 순서로 보이게 한다.
+      final typePriority = left.layoutSummaryPriority.compareTo(
+        right.layoutSummaryPriority,
+      );
+      if (typePriority != 0) {
+        return typePriority;
+      }
+      final statusPriority = left.statusPriority.compareTo(
+        right.statusPriority,
+      );
+      if (statusPriority != 0) {
+        return statusPriority;
+      }
+      return left.name.compareTo(right.name);
+    });
+
+    for (final facility in candidates) {
+      if (!facility.isLayoutSummaryTarget ||
+          seenTypes.contains(facility.type)) {
+        continue;
+      }
+      seenTypes.add(facility.type);
+      summaryFacilities.add(facility);
+      if (summaryFacilities.length == 3) {
+        break;
+      }
+    }
+    return summaryFacilities;
   }
 }
 
@@ -2233,6 +2352,8 @@ class _StationDetailBody extends StatelessWidget {
         facilities: state.prioritizedFacilities,
         facilityAttentionSummary: state.facilityAttentionSummary,
         facilityAttentionSemanticLabel: state.facilityAttentionSemanticLabel,
+        layoutSummaryItems: state.layoutSummaryItems,
+        layoutSummarySemanticLabel: state.layoutSummarySemanticLabel,
         reportRepository: reportRepository,
         favoriteController: favoriteController,
         locationProvider: locationProvider,
@@ -2248,6 +2369,8 @@ class _StationDetailContent extends StatelessWidget {
     required this.facilities,
     required this.facilityAttentionSummary,
     required this.facilityAttentionSemanticLabel,
+    required this.layoutSummaryItems,
+    required this.layoutSummarySemanticLabel,
     required this.reportRepository,
     required this.favoriteController,
     required this.locationProvider,
@@ -2258,6 +2381,8 @@ class _StationDetailContent extends StatelessWidget {
   final List<StationFacilityInfo> facilities;
   final String facilityAttentionSummary;
   final String facilityAttentionSemanticLabel;
+  final List<StationLayoutSummaryItem> layoutSummaryItems;
+  final String layoutSummarySemanticLabel;
   final FacilityReportRepository reportRepository;
   final StationFavoriteToggleController? favoriteController;
   final CurrentLocationProvider? locationProvider;
@@ -2276,6 +2401,15 @@ class _StationDetailContent extends StatelessWidget {
           ),
         ],
         const SizedBox(height: 24),
+        if (layoutSummaryItems.isNotEmpty) ...[
+          const _StationDetailSectionTitle(title: '이동 구조'),
+          const SizedBox(height: 12),
+          _StationLayoutSummary(
+            items: layoutSummaryItems,
+            semanticLabel: layoutSummarySemanticLabel,
+          ),
+          const SizedBox(height: 24),
+        ],
         const _StationDetailSectionTitle(title: '출구'),
         const SizedBox(height: 12),
         if (exits.isEmpty)
@@ -2349,6 +2483,87 @@ class _StationDetailContent extends StatelessWidget {
       return null;
     }
     return provider.needsLocationPermissionRequest;
+  }
+}
+
+class _StationLayoutSummary extends StatelessWidget {
+  const _StationLayoutSummary({
+    required this.items,
+    required this.semanticLabel,
+  });
+
+  final List<StationLayoutSummaryItem> items;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Semantics(
+      label: semanticLabel,
+      child: ExcludeSemantics(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final itemWidth = (constraints.maxWidth - 12) / 2;
+            return Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                for (final item in items)
+                  _StationLayoutStep(
+                    item: item,
+                    textTheme: textTheme,
+                    width: itemWidth,
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _StationLayoutStep extends StatelessWidget {
+  const _StationLayoutStep({
+    required this.item,
+    required this.textTheme,
+    required this.width,
+  });
+
+  final StationLayoutSummaryItem item;
+  final TextTheme textTheme;
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      constraints: const BoxConstraints(minHeight: 82),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFEAF6F4),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: const Color(0xFFB9D7D2)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(item.icon, color: const Color(0xFF006D77), size: 26),
+          const SizedBox(height: 8),
+          Text(
+            item.text,
+            textAlign: TextAlign.center,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: textTheme.bodyLarge?.copyWith(
+              color: const Color(0xFF102A2C),
+              fontWeight: FontWeight.w900,
+              height: 1.2,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1313,8 +1313,7 @@ class StationDetailState {
     // 역 전체 구조를 짧게 보여주기 위해 엘리베이터 연결 출구를 우선 시작점으로 삼는다.
     final accessibleExit = exits
         .where((exit) => exit.hasElevatorConnection)
-        .cast<StationExitInfo?>()
-        .firstWhere((exit) => exit != null, orElse: () => null);
+        .firstOrNull;
     final firstExit = exits.isNotEmpty ? exits.first : null;
     final exit = accessibleExit ?? firstExit;
     if (exit != null) {
@@ -1370,8 +1369,7 @@ class StationDetailState {
     });
 
     for (final facility in candidates) {
-      if (!facility.isLayoutSummaryTarget ||
-          seenTypes.contains(facility.type)) {
+      if (seenTypes.contains(facility.type)) {
         continue;
       }
       seenTypes.add(facility.type);

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -819,6 +819,52 @@ void main() {
     expect(state.facilityAttentionSemanticLabel, '확인이 필요한 시설 3개');
   });
 
+  test('역 상세 상태는 쉬운 이동 구조 요약을 만든다', () {
+    final state = StationDetailState(
+      status: StationDetailStatus.success,
+      detail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      exits: [
+        _stationExit(
+          id: 'exit-sangnoksu-1',
+          name: '1번 출구',
+          hasElevatorConnection: true,
+        ),
+        _stationExit(
+          id: 'exit-sangnoksu-2',
+          name: '2번 출구',
+          hasElevatorConnection: false,
+          hasStairOnlyPath: true,
+        ),
+      ],
+      facilities: [
+        _stationFacility(
+          id: 'facility-sangnoksu-elevator-1',
+          name: '1번 출구 엘리베이터',
+          type: 'ELEVATOR',
+          exitId: 'exit-sangnoksu-1',
+        ),
+        _stationFacility(
+          id: 'facility-sangnoksu-toilet-1',
+          name: '장애인 화장실',
+          type: 'ACCESSIBLE_TOILET',
+          exitId: '',
+          status: 'BROKEN',
+        ),
+      ],
+    );
+
+    expect(state.layoutSummaryItems.map((item) => item.text), [
+      '1번 출구',
+      '엘리베이터',
+      '장애인 화장실',
+      '승강장',
+    ]);
+    expect(
+      state.layoutSummarySemanticLabel,
+      '이동 구조, 1번 출구, 엘리베이터, 장애인 화장실, 승강장',
+    );
+  });
+
   test('즐겨찾기 역 목록 컨트롤러는 목록과 빈 목록과 실패 상태를 구분한다', () async {
     final repository = FakeFavoriteStationRepository();
     final controller = FavoriteStationListController(repository: repository);
@@ -973,14 +1019,19 @@ StationDetail _stationDetail({required String id, required String name}) {
   );
 }
 
-StationExitInfo _stationExit() {
-  return const StationExitInfo(
-    id: 'exit-sangnoksu-1',
+StationExitInfo _stationExit({
+  String id = 'exit-sangnoksu-1',
+  String name = '1번 출구',
+  bool hasElevatorConnection = true,
+  bool hasStairOnlyPath = false,
+}) {
+  return StationExitInfo(
+    id: id,
     stationId: 'station-sangnoksu',
     exitNumber: '1',
-    name: '1번 출구',
-    hasElevatorConnection: true,
-    hasStairOnlyPath: false,
+    name: name,
+    hasElevatorConnection: hasElevatorConnection,
+    hasStairOnlyPath: hasStairOnlyPath,
     dataConfidence: 'HIGH',
   );
 }
@@ -988,13 +1039,15 @@ StationExitInfo _stationExit() {
 StationFacilityInfo _stationFacility({
   String id = 'facility-sangnoksu-elevator-1',
   String name = '1번 출구 엘리베이터',
+  String type = 'ELEVATOR',
+  String exitId = 'exit-sangnoksu-1',
   String status = 'NORMAL',
 }) {
   return StationFacilityInfo(
     id: id,
     stationId: 'station-sangnoksu',
-    exitId: 'exit-sangnoksu-1',
-    type: 'ELEVATOR',
+    exitId: exitId,
+    type: type,
     name: name,
     floorFrom: '지상',
     floorTo: '대합실',

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1062,29 +1062,34 @@ void main() {
       expect(find.text('기본 정보만 확인됨'), findsOneWidget);
       expect(find.text('출처 공식 파일'), findsWidgets);
       expect(find.text('마지막 확인 2026-06-13'), findsOneWidget);
-      expect(find.text('출구'), findsOneWidget);
-      expect(find.text('1번 출구'), findsOneWidget);
-      expect(find.text('엘리베이터 연결'), findsOneWidget);
-      expect(find.text('계단 없는 이동 가능'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
           '상록수역 상세 정보, 수도권 2호선, 기본 정보만 확인됨, 출처 공식 파일, 마지막 확인 2026-06-13',
         ),
         findsOneWidget,
       );
+      expect(find.text('이동 구조'), findsOneWidget);
+      expect(find.text('승강장'), findsOneWidget);
+      expect(find.bySemanticsLabel('이동 구조, 1번 출구, 엘리베이터, 승강장'), findsOneWidget);
+      await tester.drag(find.byType(ListView), const Offset(0, -260));
+      await tester.pumpAndSettle();
+      expect(find.text('출구'), findsOneWidget);
+      expect(find.text('1번 출구'), findsWidgets);
+      expect(find.text('엘리베이터 연결'), findsOneWidget);
+      expect(find.text('계단 없는 이동 가능'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
           '1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 정보 신뢰도 높음, 출처 공식 파일',
         ),
         findsOneWidget,
       );
-      await tester.drag(find.byType(ListView), const Offset(0, -260));
+      await tester.drag(find.byType(ListView), const Offset(0, -520));
       await tester.pumpAndSettle();
       expect(find.text('시설'), findsOneWidget);
       expect(find.text('확인 필요 1개'), findsOneWidget);
       expect(find.bySemanticsLabel('확인이 필요한 시설 1개'), findsOneWidget);
       expect(find.text('2번 출구 엘리베이터'), findsOneWidget);
-      expect(find.text('엘리베이터'), findsOneWidget);
+      expect(find.text('엘리베이터'), findsWidgets);
       expect(find.text('고장'), findsOneWidget);
       await tester.scrollUntilVisible(
         find.byKey(
@@ -2087,6 +2092,8 @@ void main() {
         find.byKey(const Key('stationSearchResult-station-sangnoksu')),
       );
       await tester.pumpAndSettle();
+      await tester.drag(find.byType(ListView), const Offset(0, -520));
+      await tester.pumpAndSettle();
       await tester.ensureVisible(
         find.byKey(
           const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
@@ -2574,6 +2581,8 @@ void main() {
       find.byKey(const Key('stationSearchResult-station-sangnoksu')),
     );
     await tester.pumpAndSettle();
+    await tester.drag(find.byType(ListView), const Offset(0, -520));
+    await tester.pumpAndSettle();
     await tester.ensureVisible(
       find.byKey(
         const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
@@ -2701,6 +2710,8 @@ void main() {
     await tester.tap(
       find.byKey(const Key('stationSearchResult-station-sangnoksu')),
     );
+    await tester.pumpAndSettle();
+    await tester.drag(find.byType(ListView), const Offset(0, -520));
     await tester.pumpAndSettle();
     await tester.ensureVisible(
       find.byKey(


### PR DESCRIPTION
## 관련 이슈
Closes #152

## 요약
- 역 상세 화면에 이동 구조 요약 섹션을 추가했습니다.
- 출구/시설 데이터를 바탕으로 엘리베이터 연결 출구와 주요 접근성 시설을 2열 아이콘 요약으로 보여주도록 했습니다.
- 스크린리더용 의미 라벨과 회귀 테스트를 추가했습니다.

## 검증
- [x] `flutter test test/station_search_test.dart --plain-name "역 상세 상태는 쉬운 이동 구조 요약을 만든다"`
- [x] `flutter test test/widget_test.dart --plain-name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다"`
- [x] `flutter test test/station_search_test.dart`
- [x] `flutter test test/widget_test.dart`
- [x] `flutter test`
- [x] `flutter analyze`
- [x] `flutter build apk --debug`
- [x] `flutter build ios --simulator --debug`
- [x] `node --test tools/ci/*.test.mjs`
- [x] `git diff --check`
- [x] Android emulator actual screen check
- [ ] GitHub CI
- [ ] CodeRabbit review 또는 Codex CLI code review
- [ ] main CD

## 리스크
- 실제 역 내부 동선 그래프가 아직 없으므로 이번 변경은 확정 경로 안내가 아니라 출구/시설 데이터 기반의 요약 표시입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 역 상세 화면에 주요 시설을 요약하는 "이동 구조" 섹션 추가
  * 우선순위 기반으로 최대 3개의 시설 정보를 한눈에 확인 가능
  * 접근성(시맨틱 레이블) 개선으로 음성 안내 기능 강화

* **테스트**
  * 이동 구조 레이아웃 요약 검증 테스트 추가
  * 역 상세 정보 UI 테스트 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->