### PR TITLE
[Fix] 시설 신고 GPS 확인 흐름 개선

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1010,6 +1010,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     final isLoading = state.status == FacilityReportViewStatus.loading;
     final reportResult = state.result;
     final hasSubmittedReport = reportResult != null;
+    // 현장 좌표가 없으면 역·시설 판단이 흔들릴 수 있어 위치 확인 전 제출을 막는다.
     final isSubmitDisabled =
         isLoading ||
         hasSubmittedReport ||

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -116,7 +116,7 @@ class MethodChannelCurrentLocationProvider implements CurrentLocationProvider {
   String _locationErrorMessage(String code) {
     return switch (code) {
       'permissionDenied' => '위치 권한을 확인해 주세요.',
-      'locationDisabled' => '기기 위치를 켜 주세요.',
+      'locationDisabled' => '기기 위치를 켜고 다시 확인해 주세요.',
       'locationUnavailable' => '현재 위치를 확인하지 못했습니다.',
       _ => '현재 위치를 확인하지 못했습니다.',
     };

--- a/apps/mobile/test/current_location_provider_test.dart
+++ b/apps/mobile/test/current_location_provider_test.dart
@@ -20,4 +20,28 @@ void main() {
     expect(await provider.needsLocationPermissionRequest(), isFalse);
     expect(requestedMethods, ['needsLocationPermissionRequest']);
   });
+
+  test('현재 위치 제공자는 GPS 꺼짐 오류를 쉬운 안내 문구로 바꾼다', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    const channel = MethodChannel('test/current-location-disabled');
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      throw PlatformException(code: 'locationDisabled');
+    });
+    addTearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+    final provider = MethodChannelCurrentLocationProvider(channel: channel);
+
+    await expectLater(
+      provider.currentLocation(),
+      throwsA(
+        isA<CurrentLocationException>().having(
+          (error) => error.message,
+          'message',
+          '기기 위치를 켜고 다시 확인해 주세요.',
+        ),
+      ),
+    );
+  });
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2473,7 +2473,7 @@ void main() {
     Future<FacilityReportLocation> locationLoader() async {
       requestCount++;
       if (requestCount == 1) {
-        throw const FacilityReportLocationException('기기 위치를 켜 주세요.');
+        throw const FacilityReportLocationException('기기 위치를 켜고 다시 확인해 주세요.');
       }
       return const FacilityReportLocation(
         latitude: 37.302421,
@@ -2506,7 +2506,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('기기 위치를 켜 주세요.'), findsOneWidget);
+    expect(find.text('기기 위치를 켜고 다시 확인해 주세요.'), findsOneWidget);
     final failedLocationSubmitButton = tester.widget<FilledButton>(
       find.byKey(const Key('facilityReportSubmitButton')),
     );
@@ -2530,6 +2530,98 @@ void main() {
       find.byKey(const Key('facilityReportSubmitButton')),
     );
     expect(readySubmitButton.onPressed, isNotNull);
+  });
+
+  testWidgets('시설 신고 화면은 GPS가 꺼져 있으면 위치 확인을 요청하고 제출을 막는다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    final locationProvider = FakeCurrentLocationProvider(
+      error: const CurrentLocationException('기기 위치를 켜고 다시 확인해 주세요.'),
+      needsPermissionRequest: false,
+    );
+    final stationRepository = FakeStationSearchRepository(
+      nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      stationFacilities: const [
+        StationFacilityInfo(
+          id: 'facility-sangnoksu-elevator-1',
+          stationId: 'station-sangnoksu',
+          exitId: 'exit-sangnoksu-1',
+          type: 'ELEVATOR',
+          name: '1번 출구 엘리베이터',
+          floorFrom: 'B1',
+          floorTo: '1F',
+          description: '1번 출구 앞',
+          status: 'NORMAL',
+          dataConfidence: 'HIGH',
+          lastUpdatedAt: '2026-06-12',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: reportRepository,
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        locationProvider: locationProvider,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+    await tester.drag(find.byType(ListView), const Offset(0, -520));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(
+        const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(
+        const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(locationProvider.requestCount, 1);
+    await tester.dragUntilVisible(
+      find.byKey(const Key('facilityReportRetryLocationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('기기 위치를 켜고 다시 확인해 주세요.'), findsOneWidget);
+    expect(find.text('현재 위치 첨부됨'), findsNothing);
+    expect(find.text('현재 위치가 첨부되었습니다.'), findsNothing);
+    expect(find.text('위치 확인됨'), findsNothing);
+
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+      '위치가 다르게 표시됩니다.',
+    );
+    final failedLocationSubmitButton = tester.widget<FilledButton>(
+      find.byKey(const Key('facilityReportSubmitButton')),
+    );
+    expect(failedLocationSubmitButton.onPressed, isNull);
+    await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
+    await tester.pump();
+
+    expect(reportRepository.requests, isEmpty);
   });
 
   testWidgets('시설 신고 화면은 현재 위치를 함께 보낸다', (tester) async {


### PR DESCRIPTION
Closes #154

## 배경
시설 신고는 현장 위치가 있어야 역과 시설을 더 정확히 판단할 수 있습니다. GPS가 꺼진 상태에서는 위치를 얻지 못하므로 신고 제출을 막고, 사용자가 바로 조치할 수 있는 문구와 재확인 버튼을 보여주도록 정리했습니다.

## 변경 사항
- 네이티브 위치 조회에서 `locationDisabled`가 오면 `기기 위치를 켜고 다시 확인해 주세요.`로 안내합니다.
- 시설 신고 화면의 위치 확인 전 제출 차단 의도를 주석으로 명확히 남겼습니다.
- GPS 꺼짐 상태에서 제출이 막히고 재확인 버튼이 보이는 위젯 테스트를 추가했습니다.
- 위치 확인 성공 시 `현재 위치 첨부됨` 같은 별도 성공 문구가 나오지 않는 회귀 조건을 유지했습니다.

## 검증
- `flutter test test/current_location_provider_test.dart`
- `flutter test test/widget_test.dart --plain-name "시설 신고 화면은 GPS가 꺼져 있으면 위치 확인을 요청하고 제출을 막는다"`
- `flutter test test/widget_test.dart --plain-name "시설 신고 화면은 현재 위치를 함께 보낸다"`
- `flutter test`
- `flutter analyze`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `flutter build apk --debug`
- `flutter build ios --simulator --debug`
- Android 에뮬레이터 실제 화면 확인: `/private/tmp/easysubway-gps-disabled.png`

## 리스크
- Android/iOS 네이티브 위치 서비스가 꺼진 상태의 오류 코드가 `locationDisabled`로 유지되어야 합니다. 해당 매핑은 단위 테스트로 고정했습니다.
