### PR TITLE
[Feat] 관리자 신고 검수 화면 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'com.h2database:h2'

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -20,10 +20,9 @@ public class SecurityConfig {
 	@Bean
 	@Order(1)
 	SecurityFilterChain adminSecurityFilterChain(HttpSecurity http) throws Exception {
-		// 관리자 검수 API는 다른 공개 API보다 먼저 매칭해야 잘못된 인증 우회를 막을 수 있다.
+		// 관리자 검수 화면에는 상태 변경 form이 있으므로 CSRF 보호를 유지한다.
 		return http
 			.securityMatcher("/admin/**")
-			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(authorize -> authorize
 				.anyRequest().hasRole("ADMIN")
 			)

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -1,0 +1,179 @@
+package com.easysubway.report.adapter.in.web;
+
+import com.easysubway.report.application.port.in.FacilityReportUseCase;
+import com.easysubway.report.application.port.in.ReviewFacilityReportCommand;
+import com.easysubway.report.domain.FacilityReport;
+import com.easysubway.report.domain.FacilityReportReviewDecision;
+import com.easysubway.report.domain.FacilityReportStatus;
+import com.easysubway.report.domain.FacilityReportType;
+import java.math.BigDecimal;
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+class FacilityReportAdminPageController {
+
+	private final FacilityReportUseCase facilityReportUseCase;
+
+	FacilityReportAdminPageController(FacilityReportUseCase facilityReportUseCase) {
+		this.facilityReportUseCase = facilityReportUseCase;
+	}
+
+	@GetMapping("/admin/reports/page")
+	String reportListPage(
+		@RequestParam(required = false) FacilityReportStatus status,
+		Model model
+	) {
+		List<FacilityReportListPageRow> reports = facilityReportUseCase.listReports(status)
+			.stream()
+			.map(FacilityReportListPageRow::from)
+			.toList();
+
+		model.addAttribute("reports", reports);
+		model.addAttribute("selectedStatus", status);
+		model.addAttribute("statusOptions", statusOptions());
+		return "admin/reports/list";
+	}
+
+	@GetMapping("/admin/reports/{reportId}/page")
+	String reportDetailPage(@PathVariable String reportId, Model model) {
+		model.addAttribute("report", FacilityReportDetailPageView.from(facilityReportUseCase.getReport(reportId)));
+		model.addAttribute("reviewActions", reviewActions());
+		return "admin/reports/detail";
+	}
+
+	@PostMapping("/admin/reports/{reportId}/page/review")
+	String reviewReportFromPage(
+		@PathVariable String reportId,
+		@RequestParam FacilityReportReviewDecision decision,
+		Principal principal
+	) {
+		facilityReportUseCase.reviewReport(new ReviewFacilityReportCommand(reportId, decision, principal.getName()));
+		return "redirect:/admin/reports/%s/page".formatted(reportId);
+	}
+
+	private static List<StatusOption> statusOptions() {
+		return Arrays.stream(FacilityReportStatus.values())
+			.map(status -> new StatusOption(status, statusLabel(status)))
+			.toList();
+	}
+
+	private static List<ReviewAction> reviewActions() {
+		return List.of(
+			new ReviewAction(FacilityReportReviewDecision.ACCEPT, "승인"),
+			new ReviewAction(FacilityReportReviewDecision.REJECT, "반려"),
+			new ReviewAction(FacilityReportReviewDecision.MARK_DUPLICATE, "중복 처리")
+		);
+	}
+
+	private static String reportTypeLabel(FacilityReportType reportType) {
+		return switch (reportType) {
+			case BROKEN -> "고장";
+			case UNDER_CONSTRUCTION -> "공사 중";
+			case CLOSED -> "폐쇄";
+			case LOCATION_WRONG -> "위치가 달라요";
+			case INFORMATION_WRONG -> "정보가 달라요";
+			case RECOVERED -> "다시 정상";
+		};
+	}
+
+	private static String statusLabel(FacilityReportStatus status) {
+		return switch (status) {
+			case SUBMITTED -> "접수됨";
+			case UNDER_REVIEW -> "검수 중";
+			case ACCEPTED -> "반영됨";
+			case REJECTED -> "반려됨";
+			case DUPLICATE -> "중복";
+			case RESOLVED -> "완료";
+		};
+	}
+
+	private static String coordinateLabel(BigDecimal latitude, BigDecimal longitude) {
+		if (latitude == null || longitude == null) {
+			return "위치 없음";
+		}
+		return "%s, %s".formatted(latitude.toPlainString(), longitude.toPlainString());
+	}
+
+	record FacilityReportListPageRow(
+		String id,
+		String stationId,
+		String facilityId,
+		String reportTypeLabel,
+		String description,
+		String statusLabel,
+		LocalDateTime createdAt,
+		boolean hasPhoto,
+		String coordinateLabel
+	) {
+
+		static FacilityReportListPageRow from(FacilityReport report) {
+			return new FacilityReportListPageRow(
+				report.id(),
+				report.stationId(),
+				report.facilityId(),
+				FacilityReportAdminPageController.reportTypeLabel(report.reportType()),
+				report.description(),
+				FacilityReportAdminPageController.statusLabel(report.status()),
+				report.createdAt(),
+				report.photoFileName() != null && !report.photoFileName().isBlank(),
+				FacilityReportAdminPageController.coordinateLabel(report.latitude(), report.longitude())
+			);
+		}
+	}
+
+	record FacilityReportDetailPageView(
+		String id,
+		String userId,
+		String stationId,
+		String facilityId,
+		String reportTypeLabel,
+		String description,
+		String statusLabel,
+		LocalDateTime createdAt,
+		LocalDateTime reviewedAt,
+		String reviewedBy,
+		String photoFileName,
+		String photoContentType,
+		String photoDataBase64,
+		String coordinateLabel
+	) {
+
+		static FacilityReportDetailPageView from(FacilityReport report) {
+			return new FacilityReportDetailPageView(
+				report.id(),
+				report.userId(),
+				report.stationId(),
+				report.facilityId(),
+				FacilityReportAdminPageController.reportTypeLabel(report.reportType()),
+				report.description(),
+				FacilityReportAdminPageController.statusLabel(report.status()),
+				report.createdAt(),
+				report.reviewedAt(),
+				report.reviewedBy(),
+				report.photoFileName(),
+				report.photoContentType(),
+				report.photoDataBase64(),
+				FacilityReportAdminPageController.coordinateLabel(report.latitude(), report.longitude())
+			);
+		}
+
+		public boolean hasPhoto() {
+			return photoFileName != null && !photoFileName.isBlank();
+		}
+	}
+
+	record StatusOption(FacilityReportStatus value, String label) {
+	}
+
+	record ReviewAction(FacilityReportReviewDecision value, String label) {
+	}
+}

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -103,6 +103,16 @@ class FacilityReportAdminPageController {
 		return "%s, %s".formatted(latitude.toPlainString(), longitude.toPlainString());
 	}
 
+	private static boolean hasCompletePhoto(FacilityReport report) {
+		return hasText(report.photoFileName())
+			&& hasText(report.photoContentType())
+			&& hasText(report.photoDataBase64());
+	}
+
+	private static boolean hasText(String value) {
+		return value != null && !value.isBlank();
+	}
+
 	record FacilityReportListPageRow(
 		String id,
 		String stationId,
@@ -124,7 +134,7 @@ class FacilityReportAdminPageController {
 				report.description(),
 				FacilityReportAdminPageController.statusLabel(report.status()),
 				report.createdAt(),
-				report.photoFileName() != null && !report.photoFileName().isBlank(),
+				FacilityReportAdminPageController.hasCompletePhoto(report),
 				FacilityReportAdminPageController.coordinateLabel(report.latitude(), report.longitude())
 			);
 		}
@@ -167,7 +177,9 @@ class FacilityReportAdminPageController {
 		}
 
 		public boolean hasPhoto() {
-			return photoFileName != null && !photoFileName.isBlank();
+			return FacilityReportAdminPageController.hasText(photoFileName)
+				&& FacilityReportAdminPageController.hasText(photoContentType)
+				&& FacilityReportAdminPageController.hasText(photoDataBase64);
 		}
 	}
 

--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -1,0 +1,171 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>신고 상세</title>
+	<style>
+		body {
+			margin: 0;
+			background: #f6f8f8;
+			color: #102a2c;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+		}
+
+		main {
+			max-width: 920px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}
+
+		h1 {
+			margin: 0 0 20px;
+			font-size: 32px;
+			line-height: 1.2;
+		}
+
+		.back-link {
+			display: inline-block;
+			margin-bottom: 24px;
+			color: #005e68;
+			font-weight: 800;
+		}
+
+		section {
+			margin-bottom: 24px;
+			background: #fff;
+			border: 1px solid #d8e0e0;
+		}
+
+		h2 {
+			margin: 0;
+			padding: 16px 18px;
+			background: #eaf0f0;
+			font-size: 20px;
+		}
+
+		dl {
+			display: grid;
+			grid-template-columns: minmax(120px, 180px) 1fr;
+			margin: 0;
+		}
+
+		dt,
+		dd {
+			margin: 0;
+			padding: 14px 18px;
+			border-top: 1px solid #d8e0e0;
+			line-height: 1.5;
+		}
+
+		dt {
+			font-weight: 800;
+			background: #f8fbfb;
+		}
+
+		dd {
+			font-weight: 600;
+		}
+
+		.photo-preview {
+			max-width: 100%;
+			max-height: 420px;
+			margin-top: 10px;
+			border: 1px solid #d8e0e0;
+		}
+
+		.review-form {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 10px;
+			padding: 18px;
+			background: #fff;
+			border: 1px solid #d8e0e0;
+		}
+
+		button {
+			min-height: 44px;
+			padding: 0 16px;
+			border: 0;
+			border-radius: 6px;
+			background: #003d40;
+			color: #fff;
+			font-size: 16px;
+			font-weight: 800;
+			cursor: pointer;
+		}
+
+		button.secondary {
+			background: #6b4b00;
+		}
+
+		button.danger {
+			background: #8a1d1d;
+		}
+	</style>
+</head>
+<body>
+<main>
+	<a class="back-link" th:href="@{/admin/reports/page}">목록으로</a>
+	<h1>신고 상세</h1>
+
+	<section>
+		<h2>신고 내용</h2>
+		<dl>
+			<dt>신고 번호</dt>
+			<dd th:text="${report.id}">report-id</dd>
+			<dt>상태</dt>
+			<dd th:text="${report.statusLabel}">접수됨</dd>
+			<dt>유형</dt>
+			<dd th:text="${report.reportTypeLabel}">고장</dd>
+			<dt>내용</dt>
+			<dd th:text="${report.description}">신고 내용</dd>
+			<dt>역 ID</dt>
+			<dd th:text="${report.stationId}">station-id</dd>
+			<dt>시설 ID</dt>
+			<dd th:text="${report.facilityId}">facility-id</dd>
+			<dt>신고자</dt>
+			<dd th:text="${report.userId}">user-id</dd>
+			<dt>좌표</dt>
+			<dd th:text="${report.coordinateLabel}">위치 없음</dd>
+			<dt>접수일</dt>
+			<dd th:text="${report.createdAt}">2026-06-15T10:00:00</dd>
+		</dl>
+	</section>
+
+	<section>
+		<h2>사진</h2>
+		<dl>
+			<dt>파일명</dt>
+			<dd th:text="${report.hasPhoto() ? report.photoFileName : '없음'}">없음</dd>
+			<dt>미리보기</dt>
+			<dd>
+				<span th:if="${!report.hasPhoto()}">없음</span>
+				<img th:if="${report.hasPhoto()}"
+				     class="photo-preview"
+				     th:src="'data:' + ${report.photoContentType} + ';base64,' + ${report.photoDataBase64}"
+				     alt="첨부 사진">
+			</dd>
+		</dl>
+	</section>
+
+	<section>
+		<h2>검수 기록</h2>
+		<dl>
+			<dt>검수자</dt>
+			<dd th:text="${report.reviewedBy != null ? report.reviewedBy : '없음'}">없음</dd>
+			<dt>검수일</dt>
+			<dd th:text="${report.reviewedAt != null ? report.reviewedAt : '없음'}">없음</dd>
+		</dl>
+	</section>
+
+	<form class="review-form"
+	      th:action="@{/admin/reports/{reportId}/page/review(reportId=${report.id})}"
+	      method="post">
+		<button type="submit" name="decision" value="ACCEPT">승인</button>
+		<button class="danger" type="submit" name="decision" value="REJECT">반려</button>
+		<button class="secondary" type="submit" name="decision" value="MARK_DUPLICATE">중복 처리</button>
+	</form>
+</main>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -162,6 +162,7 @@
 	<form class="review-form"
 	      th:action="@{/admin/reports/{reportId}/page/review(reportId=${report.id})}"
 	      method="post">
+		<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
 		<button type="submit" name="decision" value="ACCEPT">승인</button>
 		<button class="danger" type="submit" name="decision" value="REJECT">반려</button>
 		<button class="secondary" type="submit" name="decision" value="MARK_DUPLICATE">중복 처리</button>

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>시설 신고 검수</title>
+	<style>
+		body {
+			margin: 0;
+			background: #f6f8f8;
+			color: #102a2c;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+		}
+
+		main {
+			max-width: 1120px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}
+
+		h1 {
+			margin: 0 0 24px;
+			font-size: 32px;
+			line-height: 1.2;
+		}
+
+		.status-filter {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 8px;
+			margin-bottom: 20px;
+		}
+
+		.status-filter a {
+			display: inline-flex;
+			align-items: center;
+			min-height: 40px;
+			padding: 0 14px;
+			border: 1px solid #7b9294;
+			border-radius: 6px;
+			background: #fff;
+			color: #102a2c;
+			font-weight: 700;
+			text-decoration: none;
+		}
+
+		.status-filter a[aria-current="page"] {
+			background: #003d40;
+			color: #fff;
+			border-color: #003d40;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+			background: #fff;
+			border: 1px solid #d8e0e0;
+		}
+
+		th,
+		td {
+			padding: 14px 12px;
+			border-bottom: 1px solid #d8e0e0;
+			text-align: left;
+			vertical-align: top;
+			font-size: 15px;
+			line-height: 1.45;
+		}
+
+		th {
+			background: #eaf0f0;
+			font-weight: 800;
+		}
+
+		.empty {
+			padding: 40px 12px;
+			text-align: center;
+			color: #536b6d;
+			font-weight: 700;
+		}
+
+		.detail-link {
+			color: #005e68;
+			font-weight: 800;
+		}
+	</style>
+</head>
+<body>
+<main>
+	<h1>시설 신고 검수</h1>
+
+	<nav class="status-filter" aria-label="신고 상태 필터">
+		<a th:href="@{/admin/reports/page}" th:attr="aria-current=${selectedStatus == null ? 'page' : null}">전체</a>
+		<a th:each="statusOption : ${statusOptions}"
+		   th:href="@{/admin/reports/page(status=${statusOption.value})}"
+		   th:attr="aria-current=${selectedStatus == statusOption.value ? 'page' : null}"
+		   th:text="${statusOption.label}">접수됨</a>
+	</nav>
+
+	<table>
+		<thead>
+		<tr>
+			<th scope="col">상태</th>
+			<th scope="col">유형</th>
+			<th scope="col">신고 내용</th>
+			<th scope="col">역 ID</th>
+			<th scope="col">시설 ID</th>
+			<th scope="col">좌표</th>
+			<th scope="col">사진</th>
+			<th scope="col">상세</th>
+		</tr>
+		</thead>
+		<tbody>
+		<tr th:if="${reports.isEmpty()}">
+			<td class="empty" colspan="8">확인할 신고가 없습니다.</td>
+		</tr>
+		<tr th:each="report : ${reports}">
+			<td th:text="${report.statusLabel}">접수됨</td>
+			<td th:text="${report.reportTypeLabel}">고장</td>
+			<td th:text="${report.description}">신고 내용</td>
+			<td th:text="${report.stationId}">station-id</td>
+			<td th:text="${report.facilityId}">facility-id</td>
+			<td th:text="${report.coordinateLabel}">위치 없음</td>
+			<td th:text="${report.hasPhoto ? '있음' : '없음'}">없음</td>
+			<td>
+				<a class="detail-link"
+				   th:href="@{/admin/reports/{reportId}/page(reportId=${report.id})}">상세 보기</a>
+			</td>
+		</tr>
+		</tbody>
+	</table>
+</main>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionControllerTest.java
+++ b/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionControllerTest.java
@@ -1,5 +1,6 @@
 package com.easysubway.collection.adapter.in.web;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -32,6 +33,7 @@ class DataCollectionControllerTest {
 	void adminRunsTransitMasterCollectionAndListsRuns() throws Exception {
 		mockMvc.perform(post("/admin/data-collections/runs")
 				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -59,6 +61,7 @@ class DataCollectionControllerTest {
 	@DisplayName("데이터 수집 배치 API는 관리자만 사용할 수 있다")
 	void dataCollectionApisRequireAdminAuthentication() throws Exception {
 		mockMvc.perform(post("/admin/data-collections/runs")
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -72,6 +75,7 @@ class DataCollectionControllerTest {
 
 		mockMvc.perform(post("/admin/data-collections/runs")
 				.with(httpBasic("basic-user", "user-test-password"))
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -90,6 +94,7 @@ class DataCollectionControllerTest {
 	void dataCollectionRunRequestRequiresSource() throws Exception {
 		mockMvc.perform(post("/admin/data-collections/runs")
 				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("{}"))
 			.andExpect(status().isBadRequest())

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationControllerTest.java
@@ -1,5 +1,6 @@
 package com.easysubway.notification.adapter.in.web;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -42,6 +43,7 @@ class PushNotificationControllerTest {
 
 		mockMvc.perform(post("/admin/notifications/push")
 				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -66,6 +68,7 @@ class PushNotificationControllerTest {
 	@DisplayName("푸시 알림 발송 API는 관리자만 사용할 수 있다")
 	void pushNotificationDispatchRequiresAdminAuthentication() throws Exception {
 		mockMvc.perform(post("/admin/notifications/push")
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -1,0 +1,146 @@
+package com.easysubway.report.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-test",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("관리자 시설 신고 화면")
+class FacilityReportAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("관리자는 신고 목록 화면에서 접수 상태와 상세 링크를 확인한다")
+	void adminReportListPageShowsReportsAndDetailLinks() throws Exception {
+		String reportId = createReport("관리자 목록에서 볼 신고");
+
+		String html = mockMvc.perform(get("/admin/reports/page")
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("시설 신고 검수")
+			.contains("접수됨")
+			.contains("관리자 목록에서 볼 신고")
+			.contains("/admin/reports/%s/page".formatted(reportId))
+			.contains("status=SUBMITTED");
+	}
+
+	@Test
+	@DisplayName("관리자는 신고 상세 화면에서 사진과 위치와 검수 버튼을 확인한다")
+	void adminReportDetailPageShowsPhotoLocationAndReviewActions() throws Exception {
+		String reportId = createReportWithPhotoAndLocation("상세에서 확인할 신고");
+
+		String html = mockMvc.perform(get("/admin/reports/{reportId}/page", reportId)
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("신고 상세")
+			.contains("상세에서 확인할 신고")
+			.contains("elevator-notice.jpg")
+			.contains("37.302421")
+			.contains("126.866221")
+			.contains("name=\"decision\" value=\"ACCEPT\"")
+			.contains("name=\"decision\" value=\"REJECT\"")
+			.contains("name=\"decision\" value=\"MARK_DUPLICATE\"");
+	}
+
+	@Test
+	@DisplayName("관리자는 상세 화면에서 승인한 뒤 상세 화면으로 돌아온다")
+	void adminReportDetailPageReviewsReportAndRedirectsToDetail() throws Exception {
+		String reportId = createReport("승인할 신고");
+
+		mockMvc.perform(post("/admin/reports/{reportId}/page/review", reportId)
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("decision", "ACCEPT"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(header().string("Location", "/admin/reports/%s/page".formatted(reportId)));
+
+		String html = mockMvc.perform(get("/admin/reports/{reportId}/page", reportId)
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("반영됨")
+			.contains("admin-test");
+	}
+
+	@Test
+	@DisplayName("관리자 신고 화면은 관리자 인증을 요구한다")
+	void adminReportPagesRequireAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/reports/page"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/reports/page")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private String createReport(String description) throws Exception {
+		return createReport(description, "");
+	}
+
+	private String createReportWithPhotoAndLocation(String description) throws Exception {
+		return createReport(
+			description,
+			"""
+				,
+					  "photoFileName": "elevator-notice.jpg",
+					  "photoContentType": "image/jpeg",
+					  "photoDataBase64": "aW1hZ2UtYnl0ZXM=",
+					  "latitude": 37.302421,
+					  "longitude": 126.866221
+				"""
+		);
+	}
+
+	private String createReport(String description, String optionalJson) throws Exception {
+		String response = mockMvc.perform(post("/api/v1/reports")
+				.with(httpBasic("basic-user", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "stationId": "station-sangnoksu",
+					  "facilityId": "facility-sangnoksu-elevator-1",
+					  "reportType": "BROKEN",
+					  "description": "%s"%s
+					}
+					""".formatted(description, optionalJson)))
+			.andExpect(status().isCreated())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		return JsonPath.read(response, "$.data.id");
+	}
+}

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -1,6 +1,7 @@
 package com.easysubway.report.adapter.in.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -79,6 +80,7 @@ class FacilityReportAdminPageControllerTest {
 
 		mockMvc.perform(post("/admin/reports/{reportId}/page/review", reportId)
 				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("decision", "ACCEPT"))
 			.andExpect(status().is3xxRedirection())
@@ -99,11 +101,33 @@ class FacilityReportAdminPageControllerTest {
 	@Test
 	@DisplayName("관리자 신고 화면은 관리자 인증을 요구한다")
 	void adminReportPagesRequireAdminAuthentication() throws Exception {
+		String reportId = createReport("인증 검증용 신고");
+
 		mockMvc.perform(get("/admin/reports/page"))
 			.andExpect(status().isUnauthorized());
 
 		mockMvc.perform(get("/admin/reports/page")
 				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/admin/reports/{reportId}/page", reportId))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/reports/{reportId}/page", reportId)
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(post("/admin/reports/{reportId}/page/review", reportId)
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("decision", "ACCEPT"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(post("/admin/reports/{reportId}/page/review", reportId)
+				.with(httpBasic("basic-user", "user-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("decision", "ACCEPT"))
 			.andExpect(status().isForbidden());
 	}
 

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -1,8 +1,9 @@
 package com.easysubway.report.adapter.in.web;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -246,6 +247,7 @@ class FacilityReportControllerTest {
 
 		mockMvc.perform(post("/admin/reports/{reportId}/review", reportId)
 				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -274,6 +276,7 @@ class FacilityReportControllerTest {
 	@DisplayName("신고 검수는 관리자 인증을 요구한다")
 	void reviewReportRequiresAdminAuthentication() throws Exception {
 		mockMvc.perform(post("/admin/reports/report-1/review")
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -288,6 +291,7 @@ class FacilityReportControllerTest {
 	void reviewReportRejectsInvalidDecisionRequest() throws Exception {
 		mockMvc.perform(post("/admin/reports/report-1/review")
 				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{}
@@ -303,6 +307,7 @@ class FacilityReportControllerTest {
 	void reviewReportReturnsCommonErrorForMissingReport() throws Exception {
 		mockMvc.perform(post("/admin/reports/missing-report/review")
 				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -323,6 +328,7 @@ class FacilityReportControllerTest {
 
 		mockMvc.perform(post("/admin/reports/{reportId}/review", acceptedReportId)
 				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -1,5 +1,6 @@
 package com.easysubway.transit.adapter.in.web;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -234,6 +235,7 @@ class TransitMasterControllerTest {
 	void adminUpdatesFacilityStatusAndPublicListReflectsIt() throws Exception {
 		mockMvc.perform(patch("/admin/facilities/facility-sangnoksu-elevator-1/status")
 				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -255,6 +257,7 @@ class TransitMasterControllerTest {
 	@DisplayName("시설 상태 수정 API는 관리자 인증을 요구한다")
 	void updateFacilityStatusRequiresAdminAuthentication() throws Exception {
 		mockMvc.perform(patch("/admin/facilities/facility-sangnoksu-elevator-1/status")
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -265,6 +268,7 @@ class TransitMasterControllerTest {
 
 		mockMvc.perform(patch("/admin/facilities/facility-sangnoksu-elevator-1/status")
 				.with(httpBasic("basic-user", "user-test-password"))
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -279,6 +283,7 @@ class TransitMasterControllerTest {
 	void updateFacilityStatusRequiresStatus() throws Exception {
 		mockMvc.perform(patch("/admin/facilities/facility-sangnoksu-elevator-1/status")
 				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("{}"))
 			.andExpect(status().isBadRequest())
@@ -292,6 +297,7 @@ class TransitMasterControllerTest {
 	void updateFacilityStatusReturnsCommonErrorForMissingFacility() throws Exception {
 		mockMvc.perform(patch("/admin/facilities/missing-facility/status")
 				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{


### PR DESCRIPTION
Closes #156

## 배경
관리자 신고 검수는 JSON API로만 처리할 수 있어 운영자가 접수 목록, 사진, 좌표, 검수 결과를 한 화면에서 확인하기 어렵습니다. 신고가 들어왔을 때 바로 목록을 훑고 상세에서 승인/반려/중복 처리를 할 수 있는 최소 관리자 화면이 필요합니다.

## 변경 사항
- `/admin/reports/page` 신고 목록 화면을 추가했습니다.
- 상태별 필터와 상세 화면 링크를 추가했습니다.
- `/admin/reports/{reportId}/page` 신고 상세 화면을 추가했습니다.
- 상세 화면에서 신고 내용, 사진 파일/미리보기, 좌표, 검수 기록을 확인할 수 있게 했습니다.
- 상세 화면에서 승인, 반려, 중복 처리를 form POST로 실행하고 상세 화면으로 돌아오게 했습니다.
- 관리자 화면 렌더링을 위해 Thymeleaf 의존성을 추가했습니다.

## 검증
- `./gradlew test --tests '*FacilityReportAdminPageControllerTest*'`
- `./gradlew test --tests '*FacilityReportControllerTest*'`
- `./gradlew check`
- `node --test tools/ci/*.test.mjs`

## 리스크
- 관리자 화면은 기존 `/admin/**` Basic 인증 정책을 그대로 사용합니다.
- 기존 JSON API 경로와 요청/응답 형식은 변경하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added admin facility report review interface with list and detail views
  * Enabled admins to process reports with approval, rejection, and duplicate status decisions
  * Added photo and location viewing for reported facilities

* **Tests**
  * Added comprehensive test coverage for admin report pages and review functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->