### PR TITLE
[Feat] 관리자 데이터 품질 대시보드 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageController.java
@@ -1,0 +1,103 @@
+package com.easysubway.quality.adapter.in.web;
+
+import com.easysubway.quality.application.port.in.DataQualityUseCase;
+import com.easysubway.quality.domain.DataQualitySummary;
+import com.easysubway.transit.domain.DataConfidenceLevel;
+import com.easysubway.transit.domain.DataQualityLevel;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class DataQualityAdminPageController {
+
+	private final DataQualityUseCase dataQualityUseCase;
+
+	DataQualityAdminPageController(DataQualityUseCase dataQualityUseCase) {
+		this.dataQualityUseCase = dataQualityUseCase;
+	}
+
+	@GetMapping("/admin/data-quality/page")
+	String dataQualityDashboardPage(Model model) {
+		DataQualitySummary summary = dataQualityUseCase.summarizeDataQuality();
+		model.addAttribute("summary", DataQualityDashboardView.from(summary));
+		return "admin/quality/dashboard";
+	}
+
+	private static String qualityLabel(DataQualityLevel level) {
+		return switch (level) {
+			case LEVEL_1 -> "Level 1";
+			case LEVEL_2 -> "Level 2";
+			case LEVEL_3 -> "Level 3";
+			case LEVEL_4 -> "Level 4";
+		};
+	}
+
+	private static String qualityDescription(DataQualityLevel level) {
+		return switch (level) {
+			case LEVEL_1 -> "기본 정보 확인";
+			case LEVEL_2 -> "일부 정보 확인";
+			case LEVEL_3 -> "정보 보강 필요";
+			case LEVEL_4 -> "제보 필요";
+		};
+	}
+
+	private static String confidenceLabel(DataConfidenceLevel level) {
+		return switch (level) {
+			case HIGH -> "높음";
+			case MEDIUM -> "보통";
+			case LOW -> "낮음";
+			case NEEDS_VERIFICATION -> "확인 필요";
+		};
+	}
+
+	record DataQualityDashboardView(
+		int totalStations,
+		int totalExits,
+		int totalFacilities,
+		long needsVerificationFacilityCount,
+		long missingStationVerificationDateCount,
+		List<QualityCountRow> stationQualityRows,
+		List<ConfidenceCountRow> exitConfidenceRows,
+		List<ConfidenceCountRow> facilityConfidenceRows
+	) {
+
+		static DataQualityDashboardView from(DataQualitySummary summary) {
+			return new DataQualityDashboardView(
+				summary.totalStations(),
+				summary.totalExits(),
+				summary.totalFacilities(),
+				summary.needsVerificationFacilityCount(),
+				summary.missingStationVerificationDateCount(),
+				qualityRows(summary.stationQualityCounts()),
+				confidenceRows(summary.exitConfidenceCounts()),
+				confidenceRows(summary.facilityConfidenceCounts())
+			);
+		}
+
+		private static List<QualityCountRow> qualityRows(Map<DataQualityLevel, Long> counts) {
+			return Arrays.stream(DataQualityLevel.values())
+				.map(level -> new QualityCountRow(
+					qualityLabel(level),
+					qualityDescription(level),
+					counts.getOrDefault(level, 0L)
+				))
+				.toList();
+		}
+
+		private static List<ConfidenceCountRow> confidenceRows(Map<DataConfidenceLevel, Long> counts) {
+			return Arrays.stream(DataConfidenceLevel.values())
+				.map(level -> new ConfidenceCountRow(confidenceLabel(level), counts.getOrDefault(level, 0L)))
+				.toList();
+		}
+	}
+
+	record QualityCountRow(String label, String description, long count) {
+	}
+
+	record ConfidenceCountRow(String label, long count) {
+	}
+}

--- a/backend/src/main/resources/templates/admin/quality/dashboard.html
+++ b/backend/src/main/resources/templates/admin/quality/dashboard.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>데이터 품질 대시보드</title>
+	<style>
+		body {
+			margin: 0;
+			background: #f6f8f8;
+			color: #102a2c;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+		}
+
+		main {
+			max-width: 1120px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}
+
+		h1 {
+			margin: 0 0 24px;
+			font-size: 32px;
+			line-height: 1.2;
+		}
+
+		h2 {
+			margin: 0;
+			padding: 16px 18px;
+			background: #eaf0f0;
+			font-size: 20px;
+		}
+
+		.metric-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+			gap: 12px;
+			margin-bottom: 24px;
+		}
+
+		.metric {
+			background: #fff;
+			border: 1px solid #d8e0e0;
+			padding: 18px;
+		}
+
+		.metric span {
+			display: block;
+			color: #536b6d;
+			font-weight: 800;
+			line-height: 1.4;
+		}
+
+		.metric strong {
+			display: block;
+			margin-top: 8px;
+			font-size: 30px;
+			line-height: 1.15;
+		}
+
+		section {
+			margin-bottom: 24px;
+			background: #fff;
+			border: 1px solid #d8e0e0;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		th,
+		td {
+			padding: 14px 18px;
+			border-top: 1px solid #d8e0e0;
+			text-align: left;
+			vertical-align: top;
+			font-size: 15px;
+			line-height: 1.45;
+		}
+
+		th {
+			background: #f8fbfb;
+			font-weight: 800;
+		}
+
+		td:last-child,
+		th:last-child {
+			text-align: right;
+			font-weight: 800;
+		}
+	</style>
+</head>
+<body>
+<main>
+	<h1>데이터 품질 대시보드</h1>
+
+	<div class="metric-grid" aria-label="전체 데이터 품질 요약">
+		<div class="metric">
+			<span>전체 역</span>
+			<strong th:text="${summary.totalStations}">0</strong>
+		</div>
+		<div class="metric">
+			<span>전체 출구</span>
+			<strong th:text="${summary.totalExits}">0</strong>
+		</div>
+		<div class="metric">
+			<span>전체 시설</span>
+			<strong th:text="${summary.totalFacilities}">0</strong>
+		</div>
+		<div class="metric">
+			<span>확인 필요한 시설</span>
+			<strong th:text="${summary.needsVerificationFacilityCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>검수일 없는 역</span>
+			<strong th:text="${summary.missingStationVerificationDateCount}">0</strong>
+		</div>
+	</div>
+
+	<section>
+		<h2>역 품질 등급</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">등급</th>
+				<th scope="col">상태</th>
+				<th scope="col">역 수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.stationQualityRows}">
+				<td th:text="${row.label}">Level 1</td>
+				<td th:text="${row.description}">기본 정보 확인</td>
+				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>출구 신뢰도</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">신뢰도</th>
+				<th scope="col">출구 수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.exitConfidenceRows}">
+				<td th:text="${row.label}">높음</td>
+				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>시설 신뢰도</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">신뢰도</th>
+				<th scope="col">시설 수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.facilityConfidenceRows}">
+				<td th:text="${row.label}">높음</td>
+				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageControllerTest.java
@@ -1,0 +1,64 @@
+package com.easysubway.quality.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("관리자 데이터 품질 대시보드")
+class DataQualityAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("관리자는 데이터 품질 대시보드에서 주요 집계와 보강 대상을 확인한다")
+	void adminGetsDataQualityDashboardPage() throws Exception {
+		String html = mockMvc.perform(get("/admin/data-quality/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("데이터 품질 대시보드")
+			.contains("전체 역")
+			.contains(">2<")
+			.contains("전체 출구")
+			.contains("전체 시설")
+			.contains(">3<")
+			.contains("확인 필요한 시설")
+			.contains("검수일 없는 역")
+			.contains("Level 1")
+			.contains("기본 정보 확인")
+			.contains("높음")
+			.contains("보통")
+			.contains("확인 필요");
+	}
+
+	@Test
+	@DisplayName("데이터 품질 대시보드는 관리자 인증을 요구한다")
+	void dataQualityDashboardRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/data-quality/page"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/data-quality/page")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #158

## 요약
- 관리자용 `/admin/data-quality/page` 화면을 추가했습니다.
- 기존 데이터 품질 요약 use case를 재사용해 전체 역/출구/시설 수, 확인 필요 시설 수, 검수일 없는 역 수를 보여줍니다.
- 역 품질 등급과 출구/시설 신뢰도 분포를 운영자가 바로 볼 수 있는 표로 정리했습니다.

## 변경 사항
- `DataQualityAdminPageController` 추가
- `admin/quality/dashboard.html` Thymeleaf 템플릿 추가
- 관리자 인증/권한과 HTML 응답 내용을 확인하는 테스트 추가

## 검증
- `./gradlew test --tests '*DataQualityAdminPageControllerTest*'`
- `./gradlew test --tests '*DataQualityControllerTest*'`
- `./gradlew check`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`

## 리스크
- 기존 JSON API는 변경하지 않았습니다.
- 새 화면은 조회 전용 GET 화면이라 CSRF 토큰 처리는 필요하지 않습니다.
