### PR TITLE
[Feat] 관리자 데이터 수집 배치 화면 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageController.java
@@ -1,0 +1,113 @@
+package com.easysubway.collection.adapter.in.web;
+
+import com.easysubway.collection.application.port.in.DataCollectionUseCase;
+import com.easysubway.collection.application.port.in.RunDataCollectionCommand;
+import com.easysubway.collection.domain.DataCollectionRun;
+import com.easysubway.collection.domain.DataCollectionSource;
+import com.easysubway.collection.domain.DataCollectionStatus;
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+class DataCollectionAdminPageController {
+
+	private static final int DEFAULT_RECENT_RUN_LIMIT = 20;
+
+	private final DataCollectionUseCase dataCollectionUseCase;
+
+	DataCollectionAdminPageController(DataCollectionUseCase dataCollectionUseCase) {
+		this.dataCollectionUseCase = dataCollectionUseCase;
+	}
+
+	@GetMapping("/admin/data-collections/page")
+	String dataCollectionPage(Model model) {
+		model.addAttribute("sourceOptions", sourceOptions());
+		model.addAttribute("runs", recentRunRows());
+		return "admin/collections/list";
+	}
+
+	@PostMapping("/admin/data-collections/page/run")
+	String runCollectionFromPage(
+		@RequestParam DataCollectionSource source,
+		Principal principal
+	) {
+		dataCollectionUseCase.runCollection(new RunDataCollectionCommand(source, principal.getName()));
+		return "redirect:/admin/data-collections/page";
+	}
+
+	private List<DataCollectionRunRow> recentRunRows() {
+		return dataCollectionUseCase.listRecentRuns(DEFAULT_RECENT_RUN_LIMIT)
+			.stream()
+			.map(DataCollectionRunRow::from)
+			.toList();
+	}
+
+	private static List<DataCollectionSourceOption> sourceOptions() {
+		return Arrays.stream(DataCollectionSource.values())
+			.map(source -> new DataCollectionSourceOption(source, sourceLabel(source)))
+			.toList();
+	}
+
+	private static String sourceLabel(DataCollectionSource source) {
+		return switch (source) {
+			case TRANSIT_MASTER -> "도시철도 마스터";
+		};
+	}
+
+	private static String statusLabel(DataCollectionStatus status) {
+		return switch (status) {
+			case RUNNING -> "실행 중";
+			case COMPLETED -> "완료";
+			case FAILED -> "실패";
+		};
+	}
+
+	record DataCollectionRunRow(
+		String runId,
+		String sourceLabel,
+		String statusLabel,
+		String requestedBy,
+		LocalDateTime startedAt,
+		LocalDateTime completedAt,
+		int collectedCount,
+		String failureMessage
+	) {
+
+		static DataCollectionRunRow from(DataCollectionRun run) {
+			return new DataCollectionRunRow(
+				run.runId(),
+				DataCollectionAdminPageController.sourceLabel(run.source()),
+				DataCollectionAdminPageController.statusLabel(run.status()),
+				run.requestedBy(),
+				run.startedAt(),
+				run.completedAt(),
+				run.collectedCount(),
+				run.failureMessage()
+			);
+		}
+
+		public String failureLabel() {
+			if (failureMessage == null || failureMessage.isBlank()) {
+				return "-";
+			}
+			return failureMessage;
+		}
+
+		public String completedAtLabel() {
+			if (completedAt == null) {
+				return "-";
+			}
+			return completedAt.toString();
+		}
+	}
+
+	record DataCollectionSourceOption(DataCollectionSource value, String label) {
+	}
+}

--- a/backend/src/main/resources/templates/admin/collections/list.html
+++ b/backend/src/main/resources/templates/admin/collections/list.html
@@ -1,0 +1,145 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>데이터 수집 배치</title>
+	<style>
+		body {
+			margin: 0;
+			background: #f6f8f8;
+			color: #102a2c;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+		}
+
+		main {
+			max-width: 1120px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}
+
+		h1 {
+			margin: 0 0 24px;
+			font-size: 32px;
+			line-height: 1.2;
+		}
+
+		.run-form {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 10px;
+			margin-bottom: 24px;
+			padding: 18px;
+			background: #fff;
+			border: 1px solid #d8e0e0;
+		}
+
+		.run-form label {
+			display: flex;
+			align-items: center;
+			min-height: 44px;
+			gap: 8px;
+			font-weight: 800;
+		}
+
+		button {
+			min-height: 44px;
+			padding: 0 16px;
+			border: 0;
+			border-radius: 6px;
+			background: #003d40;
+			color: #fff;
+			font-size: 16px;
+			font-weight: 800;
+			cursor: pointer;
+		}
+
+		section {
+			background: #fff;
+			border: 1px solid #d8e0e0;
+		}
+
+		h2 {
+			margin: 0;
+			padding: 16px 18px;
+			background: #eaf0f0;
+			font-size: 20px;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		th,
+		td {
+			padding: 14px 12px;
+			border-top: 1px solid #d8e0e0;
+			text-align: left;
+			vertical-align: top;
+			font-size: 15px;
+			line-height: 1.45;
+		}
+
+		th {
+			background: #f8fbfb;
+			font-weight: 800;
+		}
+
+		.empty {
+			padding: 40px 12px;
+			text-align: center;
+			color: #536b6d;
+			font-weight: 700;
+		}
+	</style>
+</head>
+<body>
+<main>
+	<h1>데이터 수집 배치</h1>
+
+	<form class="run-form" th:action="@{/admin/data-collections/page/run}" method="post">
+		<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+		<label th:each="sourceOption : ${sourceOptions}">
+			<input type="radio"
+			       name="source"
+			       th:value="${sourceOption.value}"
+			       th:checked="${sourceOptionStat.first}">
+			<span th:text="${sourceOption.label + ' 데이터 수집'}">도시철도 마스터 데이터 수집</span>
+		</label>
+		<button type="submit">수집 실행</button>
+	</form>
+
+	<section>
+		<h2>최근 실행 기록</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">수집 대상</th>
+				<th scope="col">상태</th>
+				<th scope="col">요청자</th>
+				<th scope="col">시작</th>
+				<th scope="col">완료</th>
+				<th scope="col">수집 건수</th>
+				<th scope="col">실패 사유</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:if="${runs.isEmpty()}">
+				<td class="empty" colspan="7">최근 실행 기록이 없습니다.</td>
+			</tr>
+			<tr th:each="run : ${runs}">
+				<td th:text="${run.sourceLabel}">도시철도 마스터</td>
+				<td th:text="${run.statusLabel}">완료</td>
+				<td th:text="${run.requestedBy}">admin-user</td>
+				<td th:text="${run.startedAt}">2026-06-15T10:00:00</td>
+				<td th:text="${run.completedAtLabel()}">2026-06-15T10:01:00</td>
+				<td th:text="${run.collectedCount}">13</td>
+				<td th:text="${run.failureLabel()}">-</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageControllerTest.java
@@ -1,0 +1,117 @@
+package com.easysubway.collection.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("관리자 데이터 수집 배치 화면")
+class DataCollectionAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("관리자는 데이터 수집 화면에서 실행 버튼과 최근 실행 기록을 확인한다")
+	void adminGetsDataCollectionPageWithRunFormAndRecentRuns() throws Exception {
+		runTransitMasterCollection();
+
+		String html = mockMvc.perform(get("/admin/data-collections/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("데이터 수집 배치")
+			.contains("도시철도 마스터 데이터 수집")
+			.contains("수집 실행")
+			.contains("최근 실행 기록")
+			.contains("완료")
+			.contains("admin-user")
+			.contains(">13<")
+			.contains("name=\"source\"")
+			.contains("value=\"TRANSIT_MASTER\"")
+			.contains("name=\"_csrf\"");
+	}
+
+	@Test
+	@DisplayName("관리자는 데이터 수집 화면에서 배치를 실행한 뒤 목록으로 돌아온다")
+	void adminRunsDataCollectionFromPageAndRedirectsToList() throws Exception {
+		mockMvc.perform(post("/admin/data-collections/page/run")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("source", "TRANSIT_MASTER"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(header().string("Location", "/admin/data-collections/page"));
+
+		String html = mockMvc.perform(get("/admin/data-collections/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("도시철도 마스터")
+			.contains("완료")
+			.contains("admin-user");
+	}
+
+	@Test
+	@DisplayName("관리자 데이터 수집 화면은 관리자 인증을 요구한다")
+	void dataCollectionPagesRequireAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/data-collections/page"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/data-collections/page")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(post("/admin/data-collections/page/run")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("source", "TRANSIT_MASTER"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(post("/admin/data-collections/page/run")
+				.with(httpBasic("basic-user", "user-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("source", "TRANSIT_MASTER"))
+			.andExpect(status().isForbidden());
+	}
+
+	private void runTransitMasterCollection() throws Exception {
+		mockMvc.perform(post("/admin/data-collections/runs")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "source": "TRANSIT_MASTER"
+					}
+					"""))
+			.andExpect(status().isOk());
+	}
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #160

## 요약
- 관리자용 `/admin/data-collections/page` 화면을 추가했습니다.
- 최근 데이터 수집 실행 기록을 표로 확인할 수 있게 했습니다.
- 화면 form에서 도시철도 마스터 데이터 수집 배치를 실행하고 목록 화면으로 돌아오게 했습니다.

## 변경 사항
- `DataCollectionAdminPageController` 추가
- `admin/collections/list.html` Thymeleaf 템플릿 추가
- 관리자 화면 접근 제어, CSRF form, 실행 후 redirect, 최근 실행 기록 표시 테스트 추가

## 검증
- `./gradlew test --tests '*DataCollectionAdminPageControllerTest*'`
- `./gradlew test --tests '*DataCollectionControllerTest*'`
- `./gradlew check`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`

## 리스크
- 기존 JSON API는 변경하지 않았습니다.
- 화면의 실행 form은 관리자 보안 체인의 CSRF 보호를 그대로 사용합니다.
