### PR TITLE
[Fix] 시설 신고 위치 설정 이동 추가

### DIFF
--- a/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.easysubway.easysubway_mobile
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationListener
@@ -9,6 +10,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.provider.Settings
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.plugin.common.MethodChannel
@@ -29,9 +31,25 @@ class MainActivity : FlutterActivity() {
                 when (call.method) {
                     "currentLocation" -> handleCurrentLocation(result)
                     "needsLocationPermissionRequest" -> result.success(!hasLocationPermission())
+                    "openLocationSettings" -> openLocationSettings(result)
                     else -> result.notImplemented()
                 }
             }
+    }
+
+    private fun openLocationSettings(result: MethodChannel.Result) {
+        val intent = Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
+        if (intent.resolveActivity(packageManager) == null) {
+            result.success(false)
+            return
+        }
+
+        try {
+            startActivity(intent)
+            result.success(true)
+        } catch (exception: RuntimeException) {
+            result.success(false)
+        }
     }
 
     private fun handleCurrentLocation(result: MethodChannel.Result) {

--- a/apps/mobile/ios/Runner/AppDelegate.swift
+++ b/apps/mobile/ios/Runner/AppDelegate.swift
@@ -28,6 +28,10 @@ import UIKit
         result(self?.needsLocationPermissionRequest() ?? true)
         return
       }
+      if call.method == "openLocationSettings" {
+        self?.openLocationSettings(result)
+        return
+      }
       guard call.method == "currentLocation" else {
         result(FlutterMethodNotImplemented)
         return
@@ -117,6 +121,16 @@ import UIKit
       return true
     @unknown default:
       return true
+    }
+  }
+
+  private func openLocationSettings(_ result: @escaping FlutterResult) {
+    guard let url = URL(string: UIApplication.openSettingsURLString) else {
+      result(false)
+      return
+    }
+    UIApplication.shared.open(url, options: [:]) { success in
+      result(success)
     }
   }
 

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -14,6 +14,7 @@ const _facilityReportStatusErrorMessage = '처리 상태를 확인하지 못했�
 const _facilityReportListErrorMessage = '신고 내역을 불러오지 못했습니다.';
 const _anonymousReportUserId = 'anonymous-mobile-user';
 const _facilityReportPhotoTooLargeMessage = '사진이 너무 큽니다. 다른 사진을 선택해 주세요.';
+const _facilityReportLocationDisabledMessage = '기기 위치를 켜고 다시 확인해 주세요.';
 
 abstract class FacilityReportRepository {
   Future<FacilityReportResult> createReport(FacilityReportRequest request);
@@ -362,6 +363,8 @@ typedef FacilityReportLocationLoader =
 typedef FacilityReportLocationPermissionRequestChecker =
     Future<bool> Function();
 
+typedef FacilityReportLocationSettingsOpener = Future<bool> Function();
+
 typedef FacilityReportPhotoPicker =
     Future<FacilityReportPhotoAttachment?> Function();
 
@@ -700,6 +703,7 @@ class FacilityReportScreen extends StatefulWidget {
     required this.target,
     this.locationLoader,
     this.needsLocationPermissionRequest,
+    this.openLocationSettings,
     this.photoPicker,
     super.key,
   });
@@ -709,6 +713,7 @@ class FacilityReportScreen extends StatefulWidget {
   final FacilityReportLocationLoader? locationLoader;
   final FacilityReportLocationPermissionRequestChecker?
   needsLocationPermissionRequest;
+  final FacilityReportLocationSettingsOpener? openLocationSettings;
   final FacilityReportPhotoPicker? photoPicker;
 
   @override
@@ -980,6 +985,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
   bool _isLoadingLocation = false;
   bool _isLocationPreflightRunning = false;
   bool _isLocationFailure = false;
+  bool _isOpeningLocationSettings = false;
   bool _isPhotoFailure = false;
   bool _isPickingPhoto = false;
 
@@ -1099,6 +1105,27 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
               ),
               if (_isLocationFailure && !hasSubmittedReport) ...[
                 const SizedBox(height: 10),
+                if (_canOpenLocationSettings) ...[
+                  OutlinedButton.icon(
+                    key: const Key('facilityReportOpenLocationSettingsButton'),
+                    onPressed:
+                        isLoading ||
+                            _isOpeningLocationSettings ||
+                            _isLoadingLocation ||
+                            _isLocationPreflightRunning
+                        ? null
+                        : _openLocationSettings,
+                    icon: _isOpeningLocationSettings
+                        ? const SizedBox(
+                            width: 22,
+                            height: 22,
+                            child: CircularProgressIndicator(strokeWidth: 2.5),
+                          )
+                        : const Icon(Icons.settings),
+                    label: const Text('위치 설정 열기'),
+                  ),
+                  const SizedBox(height: 10),
+                ],
                 OutlinedButton.icon(
                   key: const Key('facilityReportRetryLocationButton'),
                   onPressed:
@@ -1152,6 +1179,10 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       setState(() {});
     }
   }
+
+  bool get _canOpenLocationSettings =>
+      widget.openLocationSettings != null &&
+      _locationMessage == _facilityReportLocationDisabledMessage;
 
   Future<void> _submit() async {
     if (_photoAttachment != null && _attachedLocation != null) {
@@ -1236,6 +1267,21 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     } finally {
       if (mounted) {
         setState(() => _isLocationPreflightRunning = false);
+      }
+    }
+  }
+
+  Future<void> _openLocationSettings() async {
+    final openLocationSettings = widget.openLocationSettings;
+    if (openLocationSettings == null || _isOpeningLocationSettings) {
+      return;
+    }
+    setState(() => _isOpeningLocationSettings = true);
+    try {
+      await openLocationSettings();
+    } finally {
+      if (mounted) {
+        setState(() => _isOpeningLocationSettings = false);
       }
     }
   }

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -43,6 +43,8 @@ abstract class CurrentLocationProvider {
   Future<bool> needsLocationPermissionRequest();
 
   Future<CurrentLocation> currentLocation();
+
+  Future<bool> openLocationSettings();
 }
 
 class CurrentLocationException implements Exception {
@@ -99,6 +101,20 @@ class MethodChannelCurrentLocationProvider implements CurrentLocationProvider {
     } catch (error, stackTrace) {
       reportMobileError(error, stackTrace, context: '현재 위치 조회 중 예외가 발생했습니다.');
       throw const CurrentLocationException('현재 위치를 확인하지 못했습니다.');
+    }
+  }
+
+  @override
+  Future<bool> openLocationSettings() async {
+    try {
+      return await _channel.invokeMethod<bool>('openLocationSettings') ?? false;
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '위치 설정 화면 이동 중 예외가 발생했습니다.',
+      );
+      return false;
     }
   }
 
@@ -2442,6 +2458,7 @@ class _StationDetailContent extends StatelessWidget {
           repository: reportRepository,
           locationLoader: _locationLoader(),
           needsLocationPermissionRequest: _locationPermissionRequestChecker(),
+          openLocationSettings: _locationSettingsOpener(),
           target: FacilityReportTarget(
             stationId: detail.id,
             stationName: detail.nameKo,
@@ -2481,6 +2498,14 @@ class _StationDetailContent extends StatelessWidget {
       return null;
     }
     return provider.needsLocationPermissionRequest;
+  }
+
+  FacilityReportLocationSettingsOpener? _locationSettingsOpener() {
+    final provider = locationProvider;
+    if (provider == null) {
+      return null;
+    }
+    return provider.openLocationSettings;
   }
 }
 

--- a/apps/mobile/test/current_location_provider_test.dart
+++ b/apps/mobile/test/current_location_provider_test.dart
@@ -44,4 +44,22 @@ void main() {
       ),
     );
   });
+
+  test('현재 위치 제공자는 위치 설정 열기를 네이티브 채널에 요청한다', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    const channel = MethodChannel('test/current-location-settings');
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    final requestedMethods = <String>[];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      requestedMethods.add(call.method);
+      return true;
+    });
+    addTearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+    final provider = MethodChannelCurrentLocationProvider(channel: channel);
+
+    expect(await provider.openLocationSettings(), isTrue);
+    expect(requestedMethods, ['openLocationSettings']);
+  });
 }

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -1299,6 +1299,11 @@ class FakeCurrentLocationProvider implements CurrentLocationProvider {
     return location ??
         const CurrentLocation(latitude: 37.3028, longitude: 126.8665);
   }
+
+  @override
+  Future<bool> openLocationSettings() async {
+    return true;
+  }
 }
 
 class FakeFavoriteStationRepository implements FavoriteStationRepository {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2624,6 +2624,88 @@ void main() {
     expect(reportRepository.requests, isEmpty);
   });
 
+  testWidgets('시설 신고 화면은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    final locationProvider = FakeCurrentLocationProvider(
+      error: const CurrentLocationException('기기 위치를 켜고 다시 확인해 주세요.'),
+      needsPermissionRequest: false,
+    );
+    final stationRepository = FakeStationSearchRepository(
+      nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      stationFacilities: const [
+        StationFacilityInfo(
+          id: 'facility-sangnoksu-elevator-1',
+          stationId: 'station-sangnoksu',
+          exitId: 'exit-sangnoksu-1',
+          type: 'ELEVATOR',
+          name: '1번 출구 엘리베이터',
+          floorFrom: 'B1',
+          floorTo: '1F',
+          description: '1번 출구 앞',
+          status: 'NORMAL',
+          dataConfidence: 'HIGH',
+          lastUpdatedAt: '2026-06-12',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: reportRepository,
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        locationProvider: locationProvider,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+    await tester.drag(find.byType(ListView), const Offset(0, -520));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(
+        const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(
+        const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.dragUntilVisible(
+      find.byKey(const Key('facilityReportOpenLocationSettingsButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('기기 위치를 켜고 다시 확인해 주세요.'), findsOneWidget);
+    expect(
+      find.byKey(const Key('facilityReportOpenLocationSettingsButton')),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.byKey(const Key('facilityReportOpenLocationSettingsButton')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(locationProvider.openSettingsCount, 1);
+    expect(reportRepository.requests, isEmpty);
+  });
+
   testWidgets('시설 신고 화면은 현재 위치를 함께 보낸다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
     final locationProvider = FakeCurrentLocationProvider(
@@ -3360,6 +3442,7 @@ class FakeCurrentLocationProvider implements CurrentLocationProvider {
   final Future<bool> Function()? needsPermissionRequestLoader;
   int permissionCheckCount = 0;
   int requestCount = 0;
+  int openSettingsCount = 0;
 
   @override
   Future<bool> needsLocationPermissionRequest() async {
@@ -3380,6 +3463,12 @@ class FakeCurrentLocationProvider implements CurrentLocationProvider {
     }
     return location ??
         const CurrentLocation(latitude: 37.3028, longitude: 126.8665);
+  }
+
+  @override
+  Future<bool> openLocationSettings() async {
+    openSettingsCount++;
+    return true;
   }
 }
 


### PR DESCRIPTION
Closes #162

## 요약
- 시설 신고 화면에서 GPS가 꺼져 있을 때 위치 설정으로 바로 이동할 수 있게 했습니다.
- Android/iOS 위치 MethodChannel에 설정 이동 메서드를 추가했습니다.
- 현재 위치가 없으면 신고 제출을 막는 기존 보호 흐름은 유지했습니다.

## 변경 사항
- `CurrentLocationProvider.openLocationSettings()`를 추가하고 Android/iOS 네이티브 채널로 연결했습니다.
- GPS 꺼짐 안내 문구가 표시된 경우에만 `위치 설정 열기` 버튼을 보여줍니다.
- 위치 설정 이동 버튼과 MethodChannel 호출을 테스트로 고정했습니다.

## 검증
- `flutter test test/current_location_provider_test.dart`
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다'`
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 GPS가 꺼져 있으면 위치 확인을 요청하고 제출을 막는다'`
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 현재 위치를 함께 보낸다'`
- `flutter test`
- `flutter analyze`
- `flutter build apk --debug`
- XcodeBuildMCP `build_run_sim`
- Android 에뮬레이터에서 GPS 꺼짐 상태의 시설 신고 화면과 Android 위치 설정 이동 확인
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`

## 리스크
- iOS는 시스템 전체 위치 설정이 아니라 앱 설정 화면으로 이동합니다. iOS 정책상 앱에서 안정적으로 열 수 있는 설정 진입점이라, 권한/위치 관련 설정을 사용자가 확인하는 보조 흐름으로 사용합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시설 신고 화면에서 기기 위치 사용이 비활성화된 경우, "위치 설정 열기" 버튼을 통해 기기의 위치 설정 화면으로 바로 이동할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->