### PR TITLE
[Fix] 시설 신고 사진 복구와 위치 안내 개선

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:image_picker/image_picker.dart';
 
 import 'auth_headers.dart';
@@ -16,6 +17,8 @@ const _anonymousReportUserId = 'anonymous-mobile-user';
 const _facilityReportPhotoTooLargeMessage = '사진이 너무 큽니다. 다른 사진을 선택해 주세요.';
 const _facilityReportLocationDisabledMessage =
     '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.';
+const _facilityReportDraftTargetStorageKey =
+    'easysubway.facilityReport.draftTarget';
 
 abstract class FacilityReportRepository {
   Future<FacilityReportResult> createReport(FacilityReportRequest request);
@@ -509,12 +512,93 @@ class FacilityReportTarget {
     required this.facilityStatusLabel,
   });
 
+  factory FacilityReportTarget.fromJson(Map<String, Object?> json) {
+    return FacilityReportTarget(
+      stationId: _requiredReportString(json, 'stationId'),
+      stationName: _requiredReportString(json, 'stationName'),
+      facilityId: _requiredReportString(json, 'facilityId'),
+      facilityName: _requiredReportString(json, 'facilityName'),
+      facilityTypeLabel: _requiredReportString(json, 'facilityTypeLabel'),
+      facilityStatusLabel: _requiredReportString(json, 'facilityStatusLabel'),
+    );
+  }
+
+  factory FacilityReportTarget.decode(String value) {
+    final decoded = jsonDecode(value);
+    if (decoded is! Map<String, Object?>) {
+      throw const FormatException('Invalid facility report target payload');
+    }
+    return FacilityReportTarget.fromJson(decoded);
+  }
+
   final String stationId;
   final String stationName;
   final String facilityId;
   final String facilityName;
   final String facilityTypeLabel;
   final String facilityStatusLabel;
+
+  Map<String, Object?> toJson() {
+    return {
+      'stationId': stationId,
+      'stationName': stationName,
+      'facilityId': facilityId,
+      'facilityName': facilityName,
+      'facilityTypeLabel': facilityTypeLabel,
+      'facilityStatusLabel': facilityStatusLabel,
+    };
+  }
+
+  String encode() => jsonEncode(toJson());
+}
+
+abstract class FacilityReportDraftTargetStore {
+  Future<FacilityReportTarget?> readTarget();
+
+  Future<void> saveTarget(FacilityReportTarget target);
+
+  Future<void> clearTarget();
+}
+
+class SecureFacilityReportDraftTargetStore
+    implements FacilityReportDraftTargetStore {
+  const SecureFacilityReportDraftTargetStore({
+    this.storage = const FlutterSecureStorage(),
+  });
+
+  final FlutterSecureStorage storage;
+
+  @override
+  Future<FacilityReportTarget?> readTarget() async {
+    final value = await storage.read(key: _facilityReportDraftTargetStorageKey);
+    if (value == null) {
+      return null;
+    }
+    try {
+      return FacilityReportTarget.decode(value);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '저장된 시설 신고 대상을 읽는 중 예외가 발생했습니다.',
+      );
+      await clearTarget();
+      return null;
+    }
+  }
+
+  @override
+  Future<void> saveTarget(FacilityReportTarget target) async {
+    await storage.write(
+      key: _facilityReportDraftTargetStorageKey,
+      value: target.encode(),
+    );
+  }
+
+  @override
+  Future<void> clearTarget() async {
+    await storage.delete(key: _facilityReportDraftTargetStorageKey);
+  }
 }
 
 enum FacilityReportTypeOption {
@@ -728,6 +812,8 @@ class FacilityReportScreen extends StatefulWidget {
     this.openLocationSettings,
     this.photoPicker,
     this.lostPhotoRestorer,
+    this.draftTargetStore,
+    this.initialPhotoAttachment,
     super.key,
   });
 
@@ -739,6 +825,8 @@ class FacilityReportScreen extends StatefulWidget {
   final FacilityReportLocationSettingsOpener? openLocationSettings;
   final FacilityReportPhotoPicker? photoPicker;
   final FacilityReportLostPhotoRestorer? lostPhotoRestorer;
+  final FacilityReportDraftTargetStore? draftTargetStore;
+  final FacilityReportPhotoAttachment? initialPhotoAttachment;
 
   @override
   State<FacilityReportScreen> createState() => _FacilityReportScreenState();
@@ -1019,6 +1107,10 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     _controller = FacilityReportController(repository: widget.repository)
       ..addListener(_onReportStateChanged);
     _defaultPhotoPicker = ImagePickerFacilityReportPhotoPicker();
+    _photoAttachment = widget.initialPhotoAttachment;
+    if (_photoAttachment != null) {
+      _photoMessage = '사진 1장 추가됨';
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         unawaited(_restoreLostPhoto());
@@ -1329,6 +1421,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       _isPhotoFailure = false;
     });
     try {
+      await _saveDraftTargetForPhotoPicker();
       final picker = widget.photoPicker ?? _pickPhotoWithDevicePicker;
       final photo = await picker();
       if (!mounted || photo == null) {
@@ -1361,6 +1454,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
         });
       }
     } finally {
+      await _clearDraftTargetForPhotoPicker();
       if (mounted) {
         setState(() => _isPickingPhoto = false);
       }
@@ -1372,11 +1466,11 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       return;
     }
     final restorer = widget.lostPhotoRestorer;
-    if (restorer == null && !Platform.isAndroid) {
+    if (restorer == null) {
       return;
     }
     try {
-      final photo = await (restorer ?? _defaultPhotoPicker.retrieveLostPhoto)();
+      final photo = await restorer();
       if (!mounted || photo == null || _photoAttachment != null) {
         return;
       }
@@ -1404,6 +1498,30 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
           _isPhotoFailure = true;
         });
       }
+    }
+  }
+
+  Future<void> _saveDraftTargetForPhotoPicker() async {
+    try {
+      await widget.draftTargetStore?.saveTarget(widget.target);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '시설 신고 사진 선택 대상 저장 중 예외가 발생했습니다.',
+      );
+    }
+  }
+
+  Future<void> _clearDraftTargetForPhotoPicker() async {
+    try {
+      await widget.draftTargetStore?.clearTarget();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '시설 신고 사진 선택 대상 정리 중 예외가 발생했습니다.',
+      );
     }
   }
 

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -14,7 +14,8 @@ const _facilityReportStatusErrorMessage = '처리 상태를 확인하지 못했�
 const _facilityReportListErrorMessage = '신고 내역을 불러오지 못했습니다.';
 const _anonymousReportUserId = 'anonymous-mobile-user';
 const _facilityReportPhotoTooLargeMessage = '사진이 너무 큽니다. 다른 사진을 선택해 주세요.';
-const _facilityReportLocationDisabledMessage = '기기 위치를 켜고 다시 확인해 주세요.';
+const _facilityReportLocationDisabledMessage =
+    '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.';
 
 abstract class FacilityReportRepository {
   Future<FacilityReportResult> createReport(FacilityReportRequest request);
@@ -368,6 +369,9 @@ typedef FacilityReportLocationSettingsOpener = Future<bool> Function();
 typedef FacilityReportPhotoPicker =
     Future<FacilityReportPhotoAttachment?> Function();
 
+typedef FacilityReportLostPhotoRestorer =
+    Future<FacilityReportPhotoAttachment?> Function();
+
 class ImagePickerFacilityReportPhotoPicker {
   ImagePickerFacilityReportPhotoPicker({ImagePicker? imagePicker})
     : _imagePicker = imagePicker ?? ImagePicker();
@@ -386,6 +390,20 @@ class ImagePickerFacilityReportPhotoPicker {
     return _pick(ImageSource.camera);
   }
 
+  Future<FacilityReportPhotoAttachment?> retrieveLostPhoto() async {
+    final response = await _imagePicker.retrieveLostData();
+    if (response.isEmpty) {
+      return null;
+    }
+    if (response.exception != null) {
+      throw const FacilityReportPhotoException('사진을 다시 선택해 주세요.');
+    }
+    if (response.type != RetrieveType.image || response.file == null) {
+      return null;
+    }
+    return _attachmentFromFile(response.file!);
+  }
+
   Future<FacilityReportPhotoAttachment?> _pick(ImageSource source) async {
     final image = await _imagePicker.pickImage(
       source: source,
@@ -396,6 +414,10 @@ class ImagePickerFacilityReportPhotoPicker {
     if (image == null) {
       return null;
     }
+    return _attachmentFromFile(image);
+  }
+
+  Future<FacilityReportPhotoAttachment> _attachmentFromFile(XFile image) async {
     final bytes = await image.readAsBytes();
     if (bytes.lengthInBytes > _maxPhotoBytes) {
       throw const FacilityReportPhotoException(
@@ -705,6 +727,7 @@ class FacilityReportScreen extends StatefulWidget {
     this.needsLocationPermissionRequest,
     this.openLocationSettings,
     this.photoPicker,
+    this.lostPhotoRestorer,
     super.key,
   });
 
@@ -715,6 +738,7 @@ class FacilityReportScreen extends StatefulWidget {
   needsLocationPermissionRequest;
   final FacilityReportLocationSettingsOpener? openLocationSettings;
   final FacilityReportPhotoPicker? photoPicker;
+  final FacilityReportLostPhotoRestorer? lostPhotoRestorer;
 
   @override
   State<FacilityReportScreen> createState() => _FacilityReportScreenState();
@@ -997,6 +1021,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     _defaultPhotoPicker = ImagePickerFacilityReportPhotoPicker();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
+        unawaited(_restoreLostPhoto());
         unawaited(_requestCurrentLocation());
       }
     });
@@ -1227,7 +1252,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('현재 위치 사용'),
-        content: const Text('신고 위치를 확인하는 데 사용합니다.'),
+        content: const Text('현재 위치로 신고할 역을 확인합니다.'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
@@ -1338,6 +1363,46 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     } finally {
       if (mounted) {
         setState(() => _isPickingPhoto = false);
+      }
+    }
+  }
+
+  Future<void> _restoreLostPhoto() async {
+    if (_photoAttachment != null) {
+      return;
+    }
+    final restorer = widget.lostPhotoRestorer;
+    if (restorer == null && !Platform.isAndroid) {
+      return;
+    }
+    try {
+      final photo = await (restorer ?? _defaultPhotoPicker.retrieveLostPhoto)();
+      if (!mounted || photo == null || _photoAttachment != null) {
+        return;
+      }
+      setState(() {
+        _photoAttachment = photo;
+        _photoMessage = '사진 1장 추가됨';
+        _isPhotoFailure = false;
+      });
+    } on FacilityReportPhotoException catch (error) {
+      if (mounted) {
+        setState(() {
+          _photoMessage = error.message;
+          _isPhotoFailure = true;
+        });
+      }
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '시설 신고 사진 선택 복구 중 예외가 발생했습니다.',
+      );
+      if (mounted) {
+        setState(() {
+          _photoMessage = '사진을 다시 선택해 주세요.';
+          _isPhotoFailure = true;
+        });
       }
     }
   }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -14,7 +14,15 @@ import 'station_search.dart';
 import 'mobile_error_reporter.dart';
 
 void main() {
-  runApp(EasySubwayApp(onboardingStore: const SecureOnboardingResultStore()));
+  final photoPicker = ImagePickerFacilityReportPhotoPicker();
+  runApp(
+    EasySubwayApp(
+      onboardingStore: const SecureOnboardingResultStore(),
+      facilityReportDraftTargetStore:
+          const SecureFacilityReportDraftTargetStore(),
+      facilityReportLostPhotoRestorer: photoPicker.retrieveLostPhoto,
+    ),
+  );
 }
 
 class EasySubwayApp extends StatelessWidget {
@@ -51,12 +59,8 @@ class EasySubwayApp extends StatelessWidget {
          ),
          initialOnboardingState: initialOnboardingState,
          onboardingStore: onboardingStore,
-         facilityReportDraftTargetStore:
-             facilityReportDraftTargetStore ??
-             const SecureFacilityReportDraftTargetStore(),
-         facilityReportLostPhotoRestorer:
-             facilityReportLostPhotoRestorer ??
-             ImagePickerFacilityReportPhotoPicker().retrieveLostPhoto,
+         facilityReportDraftTargetStore: facilityReportDraftTargetStore,
+         facilityReportLostPhotoRestorer: facilityReportLostPhotoRestorer,
          key: key,
        );
 
@@ -89,7 +93,7 @@ class EasySubwayApp extends StatelessWidget {
   final OnboardingState initialOnboardingState;
   final OnboardingResultStore? onboardingStore;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
-  final FacilityReportLostPhotoRestorer facilityReportLostPhotoRestorer;
+  final FacilityReportLostPhotoRestorer? facilityReportLostPhotoRestorer;
 
   @override
   Widget build(BuildContext context) {
@@ -182,7 +186,7 @@ class _EasySubwayHome extends StatefulWidget {
   final OnboardingState initialOnboardingState;
   final OnboardingResultStore? onboardingStore;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
-  final FacilityReportLostPhotoRestorer facilityReportLostPhotoRestorer;
+  final FacilityReportLostPhotoRestorer? facilityReportLostPhotoRestorer;
 
   @override
   State<_EasySubwayHome> createState() => _EasySubwayHomeState();
@@ -244,6 +248,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         locationProvider: widget.locationProvider,
         initialMobilityType: onboardingResult?.profile.mobilityType,
         simpleViewEnabled: preferences.simpleViewEnabled,
+        facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
       ),
     );
   }
@@ -303,7 +308,8 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
     }
 
     final draftTargetStore = widget.facilityReportDraftTargetStore;
-    if (draftTargetStore == null) {
+    final lostPhotoRestorer = widget.facilityReportLostPhotoRestorer;
+    if (draftTargetStore == null || lostPhotoRestorer == null) {
       return;
     }
     _pendingFacilityReportPhotoRecoveryStarted = true;
@@ -316,7 +322,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         return;
       }
 
-      photoAttachment = await widget.facilityReportLostPhotoRestorer();
+      photoAttachment = await lostPhotoRestorer();
       await draftTargetStore.clearTarget();
     } catch (error, stackTrace) {
       reportMobileError(
@@ -624,6 +630,7 @@ class HomeScreen extends StatelessWidget {
     required this.notificationRepository,
     required this.locationProvider,
     this.simpleViewEnabled = true,
+    this.facilityReportDraftTargetStore,
     String? initialMobilityType,
     super.key,
   }) : initialMobilityType =
@@ -640,6 +647,7 @@ class HomeScreen extends StatelessWidget {
   final CurrentLocationProvider locationProvider;
   final String initialMobilityType;
   final bool simpleViewEnabled;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
 
   @override
   Widget build(BuildContext context) {
@@ -678,6 +686,8 @@ class HomeScreen extends StatelessWidget {
                       reportRepository: reportRepository,
                       favoriteRepository: favoriteRepository,
                       locationProvider: locationProvider,
+                      facilityReportDraftTargetStore:
+                          facilityReportDraftTargetStore,
                     ),
                   ),
                 );
@@ -761,6 +771,8 @@ class HomeScreen extends StatelessWidget {
                         stationRepository: repository,
                         reportRepository: reportRepository,
                         locationProvider: locationProvider,
+                        facilityReportDraftTargetStore:
+                            facilityReportDraftTargetStore,
                       ),
                     ),
                   );

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'anonymous_auth.dart';
@@ -28,6 +30,8 @@ class EasySubwayApp extends StatelessWidget {
     CurrentLocationProvider? locationProvider,
     AnonymousAuthRepository? anonymousAuthRepository,
     OnboardingResultStore? onboardingStore,
+    FacilityReportDraftTargetStore? facilityReportDraftTargetStore,
+    FacilityReportLostPhotoRestorer? facilityReportLostPhotoRestorer,
     OnboardingState initialOnboardingState = const OnboardingState.initial(),
     bool enableAnonymousAuth = true,
     Key? key,
@@ -47,6 +51,12 @@ class EasySubwayApp extends StatelessWidget {
          ),
          initialOnboardingState: initialOnboardingState,
          onboardingStore: onboardingStore,
+         facilityReportDraftTargetStore:
+             facilityReportDraftTargetStore ??
+             const SecureFacilityReportDraftTargetStore(),
+         facilityReportLostPhotoRestorer:
+             facilityReportLostPhotoRestorer ??
+             ImagePickerFacilityReportPhotoPicker().retrieveLostPhoto,
          key: key,
        );
 
@@ -54,6 +64,8 @@ class EasySubwayApp extends StatelessWidget {
     required _EasySubwayAppDependencies dependencies,
     required this.initialOnboardingState,
     required this.onboardingStore,
+    required this.facilityReportDraftTargetStore,
+    required this.facilityReportLostPhotoRestorer,
     super.key,
   }) : repository = dependencies.repository,
        reportRepository = dependencies.reportRepository,
@@ -76,6 +88,8 @@ class EasySubwayApp extends StatelessWidget {
   final CurrentLocationProvider locationProvider;
   final OnboardingState initialOnboardingState;
   final OnboardingResultStore? onboardingStore;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
+  final FacilityReportLostPhotoRestorer facilityReportLostPhotoRestorer;
 
   @override
   Widget build(BuildContext context) {
@@ -132,6 +146,8 @@ class EasySubwayApp extends StatelessWidget {
         locationProvider: locationProvider,
         initialOnboardingState: initialOnboardingState,
         onboardingStore: onboardingStore,
+        facilityReportDraftTargetStore: facilityReportDraftTargetStore,
+        facilityReportLostPhotoRestorer: facilityReportLostPhotoRestorer,
       ),
     );
   }
@@ -150,6 +166,8 @@ class _EasySubwayHome extends StatefulWidget {
     required this.locationProvider,
     required this.initialOnboardingState,
     required this.onboardingStore,
+    required this.facilityReportDraftTargetStore,
+    required this.facilityReportLostPhotoRestorer,
   });
 
   final StationSearchRepository repository;
@@ -163,6 +181,8 @@ class _EasySubwayHome extends StatefulWidget {
   final CurrentLocationProvider locationProvider;
   final OnboardingState initialOnboardingState;
   final OnboardingResultStore? onboardingStore;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
+  final FacilityReportLostPhotoRestorer facilityReportLostPhotoRestorer;
 
   @override
   State<_EasySubwayHome> createState() => _EasySubwayHomeState();
@@ -174,6 +194,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
   late bool _loadingOnboardingState =
       widget.onboardingStore != null &&
       !widget.initialOnboardingState.isCompleted;
+  bool _pendingFacilityReportPhotoRecoveryStarted = false;
 
   @override
   void initState() {
@@ -181,6 +202,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
     if (_loadingOnboardingState) {
       _restoreOnboardingState();
     }
+    _schedulePendingFacilityReportPhotoRecovery();
   }
 
   @override
@@ -198,6 +220,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
           setState(() {
             _onboardingState = OnboardingState.completed(result: result);
           });
+          _schedulePendingFacilityReportPhotoRecovery();
         },
       );
     }
@@ -247,6 +270,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
           : OnboardingState.completed(result: storedResult);
       _loadingOnboardingState = false;
     });
+    _schedulePendingFacilityReportPhotoRecovery();
   }
 
   Future<void> _saveOnboardingResult(OnboardingResult result) async {
@@ -260,6 +284,102 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
       );
     }
   }
+
+  void _schedulePendingFacilityReportPhotoRecovery() {
+    if (_pendingFacilityReportPhotoRecoveryStarted) {
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_recoverPendingFacilityReportPhoto());
+    });
+  }
+
+  Future<void> _recoverPendingFacilityReportPhoto() async {
+    if (!mounted ||
+        _pendingFacilityReportPhotoRecoveryStarted ||
+        _loadingOnboardingState ||
+        !_onboardingState.isCompleted) {
+      return;
+    }
+
+    final draftTargetStore = widget.facilityReportDraftTargetStore;
+    if (draftTargetStore == null) {
+      return;
+    }
+    _pendingFacilityReportPhotoRecoveryStarted = true;
+
+    FacilityReportTarget? target;
+    FacilityReportPhotoAttachment? photoAttachment;
+    try {
+      target = await draftTargetStore.readTarget();
+      if (target == null) {
+        return;
+      }
+
+      photoAttachment = await widget.facilityReportLostPhotoRestorer();
+      await draftTargetStore.clearTarget();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '앱 시작 시 시설 신고 사진 복구 중 예외가 발생했습니다.',
+      );
+      await _clearFacilityReportDraftTargetQuietly(draftTargetStore);
+      return;
+    }
+
+    if (!mounted || photoAttachment == null) {
+      return;
+    }
+
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => FacilityReportScreen(
+          repository: widget.reportRepository,
+          target: target!,
+          locationLoader: _facilityReportLocationLoader(
+            widget.locationProvider,
+          ),
+          needsLocationPermissionRequest:
+              widget.locationProvider.needsLocationPermissionRequest,
+          openLocationSettings: widget.locationProvider.openLocationSettings,
+          draftTargetStore: draftTargetStore,
+          initialPhotoAttachment: photoAttachment,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _clearFacilityReportDraftTargetQuietly(
+    FacilityReportDraftTargetStore draftTargetStore,
+  ) async {
+    try {
+      await draftTargetStore.clearTarget();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '시설 신고 사진 복구 대상 정리 중 예외가 발생했습니다.',
+      );
+    }
+  }
+}
+
+FacilityReportLocationLoader _facilityReportLocationLoader(
+  CurrentLocationProvider provider,
+) {
+  return () async {
+    final CurrentLocation location;
+    try {
+      location = await provider.currentLocation();
+    } on CurrentLocationException catch (error) {
+      throw FacilityReportLocationException(error.message);
+    }
+    return FacilityReportLocation(
+      latitude: location.latitude,
+      longitude: location.longitude,
+    );
+  };
 }
 
 class _OnboardingPreferenceScope extends StatelessWidget {

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -323,7 +323,6 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
       }
 
       photoAttachment = await lostPhotoRestorer();
-      await draftTargetStore.clearTarget();
     } catch (error, stackTrace) {
       reportMobileError(
         error,
@@ -333,6 +332,8 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
       await _clearFacilityReportDraftTargetQuietly(draftTargetStore);
       return;
     }
+
+    await _clearFacilityReportDraftTargetQuietly(draftTargetStore);
 
     if (!mounted || photoAttachment == null) {
       return;

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -132,7 +132,7 @@ class MethodChannelCurrentLocationProvider implements CurrentLocationProvider {
   String _locationErrorMessage(String code) {
     return switch (code) {
       'permissionDenied' => '위치 권한을 확인해 주세요.',
-      'locationDisabled' => '기기 위치를 켜고 다시 확인해 주세요.',
+      'locationDisabled' => '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.',
       'locationUnavailable' => '현재 위치를 확인하지 못했습니다.',
       _ => '현재 위치를 확인하지 못했습니다.',
     };

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1710,6 +1710,7 @@ class StationSearchScreen extends StatefulWidget {
     required this.reportRepository,
     required this.locationProvider,
     this.favoriteRepository,
+    this.facilityReportDraftTargetStore,
     super.key,
   });
 
@@ -1717,6 +1718,7 @@ class StationSearchScreen extends StatefulWidget {
   final FacilityReportRepository reportRepository;
   final CurrentLocationProvider locationProvider;
   final FavoriteStationRepository? favoriteRepository;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
 
   @override
   State<StationSearchScreen> createState() => _StationSearchScreenState();
@@ -1858,6 +1860,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
           favoriteRepository: widget.favoriteRepository,
           locationProvider: widget.locationProvider,
           stationId: result.id,
+          facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
         ),
       ),
     );
@@ -2047,6 +2050,7 @@ class FavoriteStationListScreen extends StatefulWidget {
     required this.stationRepository,
     required this.reportRepository,
     this.locationProvider,
+    this.facilityReportDraftTargetStore,
     super.key,
   });
 
@@ -2054,6 +2058,7 @@ class FavoriteStationListScreen extends StatefulWidget {
   final StationSearchRepository stationRepository;
   final FacilityReportRepository reportRepository;
   final CurrentLocationProvider? locationProvider;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
 
   @override
   State<FavoriteStationListScreen> createState() =>
@@ -2104,6 +2109,7 @@ class _FavoriteStationListScreenState extends State<FavoriteStationListScreen> {
           favoriteRepository: widget.repository,
           locationProvider: widget.locationProvider,
           stationId: favorite.stationId,
+          facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
           // 목록에서 들어온 역은 이미 저장된 상태로 보여 해제 동작을 바로 할 수 있게 한다.
           initiallyFavorite: true,
         ),
@@ -2269,6 +2275,7 @@ class StationDetailScreen extends StatefulWidget {
     this.favoriteRepository,
     this.locationProvider,
     this.initiallyFavorite,
+    this.facilityReportDraftTargetStore,
     super.key,
   });
 
@@ -2278,6 +2285,7 @@ class StationDetailScreen extends StatefulWidget {
   final CurrentLocationProvider? locationProvider;
   final String stationId;
   final bool? initiallyFavorite;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
 
   @override
   State<StationDetailScreen> createState() => _StationDetailScreenState();
@@ -2327,6 +2335,8 @@ class _StationDetailScreenState extends State<StationDetailScreen> {
               reportRepository: widget.reportRepository,
               favoriteController: _favoriteController,
               locationProvider: widget.locationProvider,
+              facilityReportDraftTargetStore:
+                  widget.facilityReportDraftTargetStore,
             );
           },
         ),
@@ -2341,12 +2351,14 @@ class _StationDetailBody extends StatelessWidget {
     required this.reportRepository,
     required this.favoriteController,
     required this.locationProvider,
+    required this.facilityReportDraftTargetStore,
   });
 
   final StationDetailState state;
   final FacilityReportRepository reportRepository;
   final StationFavoriteToggleController? favoriteController;
   final CurrentLocationProvider? locationProvider;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
 
   @override
   Widget build(BuildContext context) {
@@ -2371,6 +2383,7 @@ class _StationDetailBody extends StatelessWidget {
         reportRepository: reportRepository,
         favoriteController: favoriteController,
         locationProvider: locationProvider,
+        facilityReportDraftTargetStore: facilityReportDraftTargetStore,
       ),
     };
   }
@@ -2388,6 +2401,7 @@ class _StationDetailContent extends StatelessWidget {
     required this.reportRepository,
     required this.favoriteController,
     required this.locationProvider,
+    required this.facilityReportDraftTargetStore,
   });
 
   final StationDetail detail;
@@ -2400,6 +2414,7 @@ class _StationDetailContent extends StatelessWidget {
   final FacilityReportRepository reportRepository;
   final StationFavoriteToggleController? favoriteController;
   final CurrentLocationProvider? locationProvider;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
 
   @override
   Widget build(BuildContext context) {
@@ -2459,7 +2474,7 @@ class _StationDetailContent extends StatelessWidget {
           locationLoader: _locationLoader(),
           needsLocationPermissionRequest: _locationPermissionRequestChecker(),
           openLocationSettings: _locationSettingsOpener(),
-          draftTargetStore: const SecureFacilityReportDraftTargetStore(),
+          draftTargetStore: facilityReportDraftTargetStore,
           target: FacilityReportTarget(
             stationId: detail.id,
             stationName: detail.nameKo,

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2459,6 +2459,7 @@ class _StationDetailContent extends StatelessWidget {
           locationLoader: _locationLoader(),
           needsLocationPermissionRequest: _locationPermissionRequestChecker(),
           openLocationSettings: _locationSettingsOpener(),
+          draftTargetStore: const SecureFacilityReportDraftTargetStore(),
           target: FacilityReportTarget(
             stationId: detail.id,
             stationName: detail.nameKo,

--- a/apps/mobile/test/current_location_provider_test.dart
+++ b/apps/mobile/test/current_location_provider_test.dart
@@ -39,7 +39,7 @@ void main() {
         isA<CurrentLocationException>().having(
           (error) => error.message,
           'message',
-          '기기 위치를 켜고 다시 확인해 주세요.',
+          '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.',
         ),
       ),
     );

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -6,9 +6,68 @@ import 'package:easysubway_mobile/auth_headers.dart';
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
 
 void main() {
+  test('시설 신고 사진 선택기는 복구된 사진을 첨부 데이터로 바꾼다', () async {
+    final tempDir = await Directory.systemTemp.createTemp(
+      'facility-report-photo-',
+    );
+    addTearDown(() => tempDir.delete(recursive: true));
+    final photoFile = File('${tempDir.path}/restored-photo.png');
+    await photoFile.writeAsBytes([1, 2, 3, 4]);
+
+    final picker = ImagePickerFacilityReportPhotoPicker(
+      imagePicker: FakeLostDataImagePicker(
+        LostDataResponse(
+          file: XFile(photoFile.path, name: 'restored-photo.png'),
+          type: RetrieveType.image,
+        ),
+      ),
+    );
+
+    final attachment = await picker.retrieveLostPhoto();
+
+    expect(attachment, isNotNull);
+    expect(attachment!.fileName, 'restored-photo.png');
+    expect(attachment.contentType, 'image/png');
+    expect(attachment.dataBase64, 'AQIDBA==');
+  });
+
+  test('시설 신고 사진 선택기는 복구할 사진이 없으면 첨부하지 않는다', () async {
+    final picker = ImagePickerFacilityReportPhotoPicker(
+      imagePicker: FakeLostDataImagePicker(LostDataResponse.empty()),
+    );
+
+    final attachment = await picker.retrieveLostPhoto();
+
+    expect(attachment, isNull);
+  });
+
+  test('시설 신고 사진 선택기는 복구 오류를 쉬운 안내로 바꾼다', () async {
+    final picker = ImagePickerFacilityReportPhotoPicker(
+      imagePicker: FakeLostDataImagePicker(
+        LostDataResponse(
+          exception: PlatformException(code: 'lost_data_error'),
+          type: RetrieveType.image,
+        ),
+      ),
+    );
+
+    await expectLater(
+      picker.retrieveLostPhoto(),
+      throwsA(
+        isA<FacilityReportPhotoException>().having(
+          (error) => error.message,
+          'message',
+          '사진을 다시 선택해 주세요.',
+        ),
+      ),
+    );
+  });
+
   test('시설 신고 API 저장소는 백엔드 계약에 맞춰 신고를 전송한다', () async {
     late String? authorizationHeader;
     late Map<String, Object?> requestBody;
@@ -529,6 +588,15 @@ void main() {
     expect(controller.state.result?.id, 'report-1');
     expect(controller.state.result?.statusLabel, '접수됨');
   });
+}
+
+class FakeLostDataImagePicker extends ImagePicker {
+  FakeLostDataImagePicker(this.response);
+
+  final LostDataResponse response;
+
+  @override
+  Future<LostDataResponse> retrieveLostData() async => response;
 }
 
 List<FlutterErrorDetails> _captureReportedErrors() {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2552,6 +2552,61 @@ void main() {
     );
   });
 
+  testWidgets('앱은 사진 복구 대상 정리에 실패해도 복구 화면을 연다', (tester) async {
+    final reportedErrors = <FlutterErrorDetails>[];
+    final draftTargetStore = MemoryFacilityReportDraftTargetStore(
+      const FacilityReportTarget(
+        stationId: 'station-sangnoksu',
+        stationName: '상록수',
+        facilityId: 'facility-sangnoksu-toilet-1',
+        facilityName: '장애인 화장실',
+        facilityTypeLabel: '장애인 화장실',
+        facilityStatusLabel: '확인 필요',
+      ),
+    )..throwOnClear = true;
+
+    await runWithMobileErrorReporter(reportedErrors.add, () async {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
+          locationProvider: FakeCurrentLocationProvider(
+            location: const CurrentLocation(
+              latitude: 37.302421,
+              longitude: 126.866221,
+            ),
+            needsPermissionRequest: false,
+          ),
+          facilityReportDraftTargetStore: draftTargetStore,
+          facilityReportLostPhotoRestorer: () async {
+            return const FacilityReportPhotoAttachment(
+              fileName: 'restored-toilet.webp',
+              contentType: 'image/webp',
+              dataBase64: 'cmVzdG9yZWQ=',
+            );
+          },
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+      await tester.pumpAndSettle();
+    });
+
+    expect(reportedErrors, hasLength(1));
+    expect(reportedErrors.single.exception, isA<StateError>());
+    expect(draftTargetStore.clearCount, 1);
+    expect(find.text('시설 신고'), findsOneWidget);
+    await tester.dragUntilVisible(
+      find.bySemanticsLabel('사진 1장 추가됨'),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('사진 1장 추가됨'), findsOneWidget);
+  });
+
   testWidgets('시설 신고 화면은 사진과 위치를 보내기 전에 확인한다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
 
@@ -3692,6 +3747,7 @@ class MemoryFacilityReportDraftTargetStore
   int readCount = 0;
   int saveCount = 0;
   int clearCount = 0;
+  bool throwOnClear = false;
 
   @override
   Future<FacilityReportTarget?> readTarget() async {
@@ -3709,6 +3765,9 @@ class MemoryFacilityReportDraftTargetStore
   @override
   Future<void> clearTarget() async {
     clearCount++;
+    if (throwOnClear) {
+      throw StateError('draft target clear failed');
+    }
     target = null;
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -200,6 +200,27 @@ void main() {
     expect(find.text('먼저 이동 조건을 골라 주세요'), findsNothing);
   });
 
+  testWidgets('기본 앱은 사진 복구 저장소가 없어도 플랫폼 오류 없이 홈을 보여준다', (tester) async {
+    final reportedErrors = <FlutterErrorDetails>[];
+
+    await runWithMobileErrorReporter(reportedErrors.add, () async {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+      await tester.pumpAndSettle();
+    });
+
+    expect(reportedErrors, isEmpty);
+    expect(find.byKey(const Key('stationSearchButton')), findsOneWidget);
+  });
+
   testWidgets('온보딩 이동 조건은 경로 검색 기본값으로 이어진다', (tester) async {
     final stationRepository = FakeStationSearchRepository(
       queryResults: {
@@ -1123,6 +1144,79 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('역 상세에서 연 시설 신고는 앱에 주입한 사진 복구 대상을 저장한다', (tester) async {
+    final repository = FakeStationSearchRepository(
+      nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      stationFacilities: const [
+        StationFacilityInfo(
+          id: 'facility-sangnoksu-elevator-1',
+          stationId: 'station-sangnoksu',
+          exitId: 'exit-sangnoksu-1',
+          type: 'ELEVATOR',
+          name: '1번 출구 엘리베이터',
+          floorFrom: 'B1',
+          floorTo: '1F',
+          description: '1번 출구 앞',
+          status: 'BROKEN',
+          dataConfidence: 'HIGH',
+          dataSourceType: 'OFFICIAL_FILE',
+          lastUpdatedAt: '2026-06-14',
+        ),
+      ],
+    );
+    final draftTargetStore = MemoryFacilityReportDraftTargetStore();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        facilityReportDraftTargetStore: draftTargetStore,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(
+        const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+      ),
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(
+        const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.dragUntilVisible(
+      find.byKey(const Key('facilityReportAddPhotoButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('facilityReportAddPhotoButton')));
+    await tester.pump();
+
+    expect(draftTargetStore.saveCount, 1);
+    expect(
+      draftTargetStore.savedTargets.single.facilityId,
+      'facility-sangnoksu-elevator-1',
+    );
   });
 
   testWidgets('역 상세는 시설 목록이 없으면 확인 필요 요약을 숨긴다', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2325,6 +2325,139 @@ void main() {
     expect(reportRepository.requests.single.photoDataBase64, 'cmVzdG9yZWQ=');
   });
 
+  testWidgets('시설 신고 화면은 사진 선택 전 대상 정보를 저장하고 정상 복귀하면 지운다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    final draftTargetStore = MemoryFacilityReportDraftTargetStore();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FacilityReportScreen(
+          repository: reportRepository,
+          target: const FacilityReportTarget(
+            stationId: 'station-sangnoksu',
+            stationName: '상록수',
+            facilityId: 'facility-sangnoksu-toilet-1',
+            facilityName: '장애인 화장실',
+            facilityTypeLabel: '장애인 화장실',
+            facilityStatusLabel: '확인 필요',
+          ),
+          draftTargetStore: draftTargetStore,
+          photoPicker: () async => const FacilityReportPhotoAttachment(
+            fileName: 'toilet-door.jpg',
+            contentType: 'image/jpeg',
+            dataBase64: 'cGhvdG8=',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('facilityReportAddPhotoButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('facilityReportAddPhotoButton')));
+    await tester.pumpAndSettle();
+
+    expect(draftTargetStore.saveCount, 1);
+    expect(draftTargetStore.clearCount, 1);
+    expect(
+      draftTargetStore.savedTargets.single.facilityId,
+      'facility-sangnoksu-toilet-1',
+    );
+    expect(draftTargetStore.target, isNull);
+    expect(find.text('사진 1장 추가됨'), findsOneWidget);
+  });
+
+  testWidgets('앱은 재시작 후 복구된 사진을 저장된 시설 신고 화면에 연결한다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    final draftTargetStore = MemoryFacilityReportDraftTargetStore(
+      const FacilityReportTarget(
+        stationId: 'station-sangnoksu',
+        stationName: '상록수',
+        facilityId: 'facility-sangnoksu-toilet-1',
+        facilityName: '장애인 화장실',
+        facilityTypeLabel: '장애인 화장실',
+        facilityStatusLabel: '확인 필요',
+      ),
+    );
+    var restoreCount = 0;
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: reportRepository,
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        locationProvider: FakeCurrentLocationProvider(
+          location: const CurrentLocation(
+            latitude: 37.302421,
+            longitude: 126.866221,
+          ),
+          needsPermissionRequest: false,
+        ),
+        facilityReportDraftTargetStore: draftTargetStore,
+        facilityReportLostPhotoRestorer: () async {
+          restoreCount++;
+          return const FacilityReportPhotoAttachment(
+            fileName: 'restored-toilet.webp',
+            contentType: 'image/webp',
+            dataBase64: 'cmVzdG9yZWQ=',
+          );
+        },
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(restoreCount, 1);
+    expect(draftTargetStore.clearCount, 1);
+    expect(find.text('시설 신고'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel('상록수역, 장애인 화장실, 장애인 화장실, 현재 확인 필요'),
+      findsOneWidget,
+    );
+
+    await tester.dragUntilVisible(
+      find.bySemanticsLabel('사진 1장 추가됨'),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('사진 1장 추가됨'), findsOneWidget);
+
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+      '앱 재시작 후 복구된 사진입니다.',
+    );
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportSubmitButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('보내기'));
+    await tester.pumpAndSettle();
+
+    expect(reportRepository.requests, hasLength(1));
+    expect(reportRepository.requests.single.stationId, 'station-sangnoksu');
+    expect(
+      reportRepository.requests.single.facilityId,
+      'facility-sangnoksu-toilet-1',
+    );
+    expect(
+      reportRepository.requests.single.photoFileName,
+      'restored-toilet.webp',
+    );
+  });
+
   testWidgets('시설 신고 화면은 사진과 위치를 보내기 전에 확인한다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
 
@@ -3453,6 +3586,36 @@ class MemoryOnboardingResultStore implements OnboardingResultStore {
   @override
   Future<void> clearResult() async {
     savedResult = null;
+  }
+}
+
+class MemoryFacilityReportDraftTargetStore
+    implements FacilityReportDraftTargetStore {
+  MemoryFacilityReportDraftTargetStore([this.target]);
+
+  FacilityReportTarget? target;
+  final savedTargets = <FacilityReportTarget>[];
+  int readCount = 0;
+  int saveCount = 0;
+  int clearCount = 0;
+
+  @override
+  Future<FacilityReportTarget?> readTarget() async {
+    readCount++;
+    return target;
+  }
+
+  @override
+  Future<void> saveTarget(FacilityReportTarget target) async {
+    saveCount++;
+    savedTargets.add(target);
+    this.target = target;
+  }
+
+  @override
+  Future<void> clearTarget() async {
+    clearCount++;
+    target = null;
   }
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2263,6 +2263,68 @@ void main() {
     }
   });
 
+  testWidgets('시설 신고 화면은 복구된 사진을 첨부 상태로 보여준다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    var restoreCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FacilityReportScreen(
+          repository: reportRepository,
+          target: const FacilityReportTarget(
+            stationId: 'station-sangnoksu',
+            stationName: '상록수',
+            facilityId: 'facility-sangnoksu-elevator-1',
+            facilityName: '1번 출구 엘리베이터',
+            facilityTypeLabel: '엘리베이터',
+            facilityStatusLabel: '정상',
+          ),
+          lostPhotoRestorer: () async {
+            restoreCount++;
+            return const FacilityReportPhotoAttachment(
+              fileName: 'restored-photo.webp',
+              contentType: 'image/webp',
+              dataBase64: 'cmVzdG9yZWQ=',
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(restoreCount, 1);
+    await tester.dragUntilVisible(
+      find.bySemanticsLabel('사진 1장 추가됨'),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('사진 1장 추가됨'), findsOneWidget);
+
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+      '선택했던 사진입니다.',
+    );
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportSubmitButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(reportRepository.requests, hasLength(1));
+    expect(
+      reportRepository.requests.single.photoFileName,
+      'restored-photo.webp',
+    );
+    expect(reportRepository.requests.single.photoContentType, 'image/webp');
+    expect(reportRepository.requests.single.photoDataBase64, 'cmVzdG9yZWQ=');
+  });
+
   testWidgets('시설 신고 화면은 사진과 위치를 보내기 전에 확인한다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
 
@@ -2367,7 +2429,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('현재 위치 사용'), findsOneWidget);
-    expect(find.text('신고 위치를 확인하는 데 사용합니다.'), findsOneWidget);
+    expect(find.text('현재 위치로 신고할 역을 확인합니다.'), findsOneWidget);
     expect(requestCount, 0);
 
     await tester.tap(find.text('취소'));
@@ -2473,7 +2535,9 @@ void main() {
     Future<FacilityReportLocation> locationLoader() async {
       requestCount++;
       if (requestCount == 1) {
-        throw const FacilityReportLocationException('기기 위치를 켜고 다시 확인해 주세요.');
+        throw const FacilityReportLocationException(
+          '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.',
+        );
       }
       return const FacilityReportLocation(
         latitude: 37.302421,
@@ -2506,7 +2570,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('기기 위치를 켜고 다시 확인해 주세요.'), findsOneWidget);
+    expect(find.text('기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.'), findsOneWidget);
     final failedLocationSubmitButton = tester.widget<FilledButton>(
       find.byKey(const Key('facilityReportSubmitButton')),
     );
@@ -2535,7 +2599,9 @@ void main() {
   testWidgets('시설 신고 화면은 GPS가 꺼져 있으면 위치 확인을 요청하고 제출을 막는다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
     final locationProvider = FakeCurrentLocationProvider(
-      error: const CurrentLocationException('기기 위치를 켜고 다시 확인해 주세요.'),
+      error: const CurrentLocationException(
+        '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.',
+      ),
       needsPermissionRequest: false,
     );
     final stationRepository = FakeStationSearchRepository(
@@ -2601,7 +2667,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('기기 위치를 켜고 다시 확인해 주세요.'), findsOneWidget);
+    expect(find.text('기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.'), findsOneWidget);
     expect(find.text('현재 위치 첨부됨'), findsNothing);
     expect(find.text('현재 위치가 첨부되었습니다.'), findsNothing);
     expect(find.text('위치 확인됨'), findsNothing);
@@ -2627,7 +2693,9 @@ void main() {
   testWidgets('시설 신고 화면은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
     final locationProvider = FakeCurrentLocationProvider(
-      error: const CurrentLocationException('기기 위치를 켜고 다시 확인해 주세요.'),
+      error: const CurrentLocationException(
+        '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.',
+      ),
       needsPermissionRequest: false,
     );
     final stationRepository = FakeStationSearchRepository(
@@ -2691,7 +2759,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('기기 위치를 켜고 다시 확인해 주세요.'), findsOneWidget);
+    expect(find.text('기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.'), findsOneWidget);
     expect(
       find.byKey(const Key('facilityReportOpenLocationSettingsButton')),
       findsOneWidget,


### PR DESCRIPTION
Closes #164

## 요약

- Android 사진 선택 중 앱이 재시작된 경우 `image_picker` lost data를 시설 신고 사진 첨부로 복구합니다.
- 복구된 사진은 기존 사진 첨부와 동일하게 파일명, content type, base64 데이터로 신고 요청에 포함됩니다.
- 복구 데이터가 없거나 복구 실패가 발생해도 신고 화면의 기본 입력 흐름은 유지합니다.
- 위치 권한 안내는 신고할 역 확인 목적이 바로 보이도록 줄이고, GPS가 꺼져 있으면 위치 설정을 켜도록 안내합니다.
- GPS가 정상 동작하면 현재 위치는 자동으로 요청에 포함하되 성공 안내 문구는 화면에 노출하지 않습니다.

## 변경 사항

- `ImagePickerFacilityReportPhotoPicker`에 lost data 복구 메서드를 추가했습니다.
- 시설 신고 화면 진입 후 복구 가능한 사진을 한 번 확인하도록 연결했습니다.
- 복구 성공/실패/데이터 없음 경로를 테스트로 고정했습니다.
- 시설 신고 위치 동의 문구를 `현재 위치로 신고할 역을 확인합니다.`로 정리했습니다.
- GPS 꺼짐 안내를 `기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.`로 바꾸고, 위치 성공 상태의 불필요한 안내 문구가 다시 나오지 않도록 테스트로 고정했습니다.

## 검증

- `flutter test test/facility_report_test.dart`
- `flutter test test/widget_test.dart --plain-name "시설 신고 화면은 복구된 사진을 첨부 상태로 보여준다"`
- `flutter test test/current_location_provider_test.dart --plain-name "현재 위치 제공자는 GPS 꺼짐 오류를 쉬운 안내 문구로 바꾼다"`
- `flutter test test/widget_test.dart --plain-name "시설 신고 화면은 GPS가 꺼져 있으면 위치 확인을 요청하고 제출을 막는다"`
- `flutter test`
- `flutter analyze`
- `flutter build apk --debug`
- Android 에뮬레이터 실제 화면 확인: 위치 권한 안내, 위치 성공 후 신고 화면, 사진 선택 바텀시트
- iOS Simulator build/run 확인

## 리스크

- lost data 복구는 Android 저메모리 또는 Activity 재시작 상황에서만 의미가 있어 실제 재현이 제한적입니다. 변환 로직은 단위/위젯 테스트로 고정하고, 기본 사진 첨부 화면은 에뮬레이터에서 확인합니다.
- 위치 권한 창은 OS가 관리하므로 앱 내부 문구와 권한 허용 후 화면 상태를 실제 에뮬레이터에서 확인했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 시설 신고 시 분실된 사진을 자동으로 복구하는 기능 추가
  * 사진 선택 중 진행 상황을 임시 저장하고 복구하는 기능 추가
  * 앱 시작 시 저장된 신고 정보를 자동으로 복구하는 기능 추가

* **Bug Fixes**
  * 위치 서비스 비활성화 시 사용자 안내 메시지 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->