### PR TITLE
[Feat] 역 검색 노선 필터 추가

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1344,7 +1344,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('현재 위치 사용'),
-        content: const Text('현재 위치로 신고할 역을 확인합니다.'),
+        content: const Text('신고할 역을 확인하는 데 필요합니다.'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -11,6 +11,7 @@ import 'mobile_error_reporter.dart';
 
 const _stationSearchTimeout = Duration(seconds: 8);
 const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
+const _currentLocationDisabledMessage = '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.';
 const _favoriteStationTimeout = Duration(seconds: 8);
 const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했습니다.';
 const _favoriteStationStatusErrorMessage = '즐겨찾기를 확인하지 못했습니다.';
@@ -30,6 +31,15 @@ abstract class StationSearchRepository {
   Future<List<StationExitInfo>> listStationExits(String stationId);
 
   Future<List<StationFacilityInfo>> listStationFacilities(String stationId);
+}
+
+abstract class StationLineFilterRepository {
+  Future<List<SubwayLineOption>> listLines();
+
+  Future<List<StationSearchResult>> searchStationsOnLine(
+    String query,
+    String lineId,
+  );
 }
 
 class CurrentLocation {
@@ -132,14 +142,15 @@ class MethodChannelCurrentLocationProvider implements CurrentLocationProvider {
   String _locationErrorMessage(String code) {
     return switch (code) {
       'permissionDenied' => '위치 권한을 확인해 주세요.',
-      'locationDisabled' => '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.',
+      'locationDisabled' => _currentLocationDisabledMessage,
       'locationUnavailable' => '현재 위치를 확인하지 못했습니다.',
       _ => '현재 위치를 확인하지 못했습니다.',
     };
   }
 }
 
-class StationSearchApiRepository implements StationSearchRepository {
+class StationSearchApiRepository
+    implements StationSearchRepository, StationLineFilterRepository {
   StationSearchApiRepository({required this.baseUri, HttpClient? httpClient})
     : _httpClient = httpClient ?? HttpClient();
 
@@ -148,9 +159,23 @@ class StationSearchApiRepository implements StationSearchRepository {
 
   @override
   Future<List<StationSearchResult>> searchStations(String query) async {
+    return _searchStations({'query': query});
+  }
+
+  @override
+  Future<List<StationSearchResult>> searchStationsOnLine(
+    String query,
+    String lineId,
+  ) {
+    return _searchStations({'query': query, 'lineId': lineId});
+  }
+
+  Future<List<StationSearchResult>> _searchStations(
+    Map<String, String> queryParameters,
+  ) async {
     final uri = baseUri
         .resolve('/api/v1/stations')
-        .replace(queryParameters: {'query': query});
+        .replace(queryParameters: queryParameters);
 
     final data = await _getData(uri);
     if (data is! List) {
@@ -171,6 +196,32 @@ class StationSearchApiRepository implements StationSearchRepository {
         error,
         stackTrace,
         context: '역 검색 목록 응답 처리 중 예외가 발생했습니다.',
+      );
+      throw const StationSearchException(_stationSearchErrorMessage);
+    }
+  }
+
+  @override
+  Future<List<SubwayLineOption>> listLines() async {
+    final data = await _getData(baseUri.resolve('/api/v1/lines'));
+    if (data is! List) {
+      throw const StationSearchException(_stationSearchErrorMessage);
+    }
+
+    try {
+      return data
+          .map((item) {
+            if (item is! Map<String, Object?>) {
+              throw const FormatException('Invalid line payload');
+            }
+            return SubwayLineOption.fromJson(item);
+          })
+          .toList(growable: false);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '노선 목록 응답 처리 중 예외가 발생했습니다.',
       );
       throw const StationSearchException(_stationSearchErrorMessage);
     }
@@ -974,28 +1025,7 @@ class StationSearchLine {
   final String color;
   final String stationCode;
 
-  String get badgeText {
-    for (final entry in _knownBadgeLabels.entries) {
-      if (name.contains(entry.key)) {
-        return entry.value;
-      }
-    }
-
-    final numberedLine = RegExp(r'(\d+)\s*호선').firstMatch(name);
-    if (numberedLine != null) {
-      return numberedLine.group(1) ?? name;
-    }
-
-    final compactName = name
-        .replaceAll('수도권 ', '')
-        .replaceAll('광역 ', '')
-        .replaceAll('선', '')
-        .trim();
-    if (compactName.length <= 4) {
-      return compactName;
-    }
-    return compactName.substring(0, 4);
-  }
+  String get badgeText => _lineBadgeText(name);
 
   Color get badgeColor {
     final normalized = color.trim().replaceFirst('#', '');
@@ -1007,6 +1037,78 @@ class StationSearchLine {
     }
     return const Color(0xFF006D77);
   }
+}
+
+class SubwayLineOption {
+  const SubwayLineOption({
+    required this.id,
+    required this.name,
+    required this.color,
+    required this.region,
+    required this.lineCode,
+    required this.active,
+  });
+
+  factory SubwayLineOption.fromJson(Map<String, Object?> json) {
+    return SubwayLineOption(
+      id: _requiredString(json, 'id'),
+      name: _requiredString(json, 'name'),
+      color: _requiredString(json, 'color'),
+      region: _requiredString(json, 'region'),
+      lineCode: _stringOrEmpty(json, 'lineCode'),
+      active: _requiredBool(json, 'active'),
+    );
+  }
+
+  final String id;
+  final String name;
+  final String color;
+  final String region;
+  final String lineCode;
+  final bool active;
+
+  String get shortLabel {
+    if (lineCode.trim().isNotEmpty) {
+      return lineCode.trim();
+    }
+    return _lineBadgeText(name);
+  }
+
+  String get semanticLabel => name;
+
+  Color get badgeColor {
+    final normalized = color.trim().replaceFirst('#', '');
+    if (normalized.length == 6) {
+      final parsed = int.tryParse(normalized, radix: 16);
+      if (parsed != null) {
+        return Color(0xFF000000 | parsed);
+      }
+    }
+    return const Color(0xFF006D77);
+  }
+}
+
+String _lineBadgeText(String name) {
+  for (final entry in StationSearchLine._knownBadgeLabels.entries) {
+    if (name.contains(entry.key)) {
+      return entry.value;
+    }
+  }
+
+  final numberedLine = RegExp(r'(\d+)\s*호선').firstMatch(name);
+  if (numberedLine != null) {
+    return numberedLine.group(1) ?? name;
+  }
+
+  final compactName = name
+      .replaceAll('수도권 ', '')
+      .replaceAll('광역 ', '')
+      .replaceAll('선', '')
+      .trim();
+  if (compactName.length <= 4) {
+    return compactName;
+  }
+  return compactName.substring(0, 4);
 }
 
 String _requiredString(Map<String, Object?> json, String key) {
@@ -1132,7 +1234,7 @@ class StationSearchController extends ChangeNotifier {
 
   StationSearchState get state => _state;
 
-  Future<void> search(String query) async {
+  Future<void> search(String query, {String? lineId}) async {
     final requestId = ++_searchRequestId;
     final trimmedQuery = query.trim();
     if (trimmedQuery.isEmpty) {
@@ -1148,7 +1250,14 @@ class StationSearchController extends ChangeNotifier {
     _notifyIfActive(requestId);
 
     try {
-      final results = await repository.searchStations(trimmedQuery);
+      final selectedLineId = lineId?.trim();
+      final results =
+          selectedLineId != null &&
+              selectedLineId.isNotEmpty &&
+              repository is StationLineFilterRepository
+          ? await (repository as StationLineFilterRepository)
+                .searchStationsOnLine(trimmedQuery, selectedLineId)
+          : await repository.searchStations(trimmedQuery);
       if (!_isActiveRequest(requestId)) {
         return;
       }
@@ -1727,12 +1836,19 @@ class StationSearchScreen extends StatefulWidget {
 class _StationSearchScreenState extends State<StationSearchScreen> {
   late final StationSearchController _controller;
   final TextEditingController _queryController = TextEditingController();
+  Future<List<SubwayLineOption>>? _lineOptionsFuture;
+  SubwayLineOption? _selectedLine;
   bool _isLocationPreflightRunning = false;
+  bool _isOpeningLocationSettings = false;
 
   @override
   void initState() {
     super.initState();
     _controller = StationSearchController(repository: widget.repository);
+    final lineRepository = _lineFilterRepository;
+    if (lineRepository != null) {
+      _lineOptionsFuture = lineRepository.listLines();
+    }
   }
 
   @override
@@ -1750,6 +1866,14 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
           children: [
+            if (_lineOptionsFuture != null) ...[
+              _StationLineFilterSection(
+                linesFuture: _lineOptionsFuture!,
+                selectedLine: _selectedLine,
+                onLineSelected: _selectLine,
+              ),
+              const SizedBox(height: 16),
+            ],
             Semantics(
               label: '역 이름 입력',
               textField: true,
@@ -1808,6 +1932,8 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
                 return _StationSearchBody(
                   state: _controller.state,
                   onResultTap: _openStationDetail,
+                  isOpeningLocationSettings: _isOpeningLocationSettings,
+                  onOpenLocationSettings: _openLocationSettings,
                 );
               },
             ),
@@ -1821,7 +1947,19 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     if (_controller.state.status == StationSearchStatus.loading) {
       return;
     }
-    _controller.search(query);
+    _controller.search(query, lineId: _selectedLine?.id);
+  }
+
+  StationLineFilterRepository? get _lineFilterRepository {
+    final Object repository = widget.repository;
+    if (repository is StationLineFilterRepository) {
+      return repository;
+    }
+    return null;
+  }
+
+  void _selectLine(SubwayLineOption? line) {
+    setState(() => _selectedLine = line);
   }
 
   Future<void> _searchNearby() async {
@@ -1847,6 +1985,20 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     } finally {
       if (mounted) {
         setState(() => _isLocationPreflightRunning = false);
+      }
+    }
+  }
+
+  Future<void> _openLocationSettings() async {
+    if (_isOpeningLocationSettings) {
+      return;
+    }
+    setState(() => _isOpeningLocationSettings = true);
+    try {
+      await widget.locationProvider.openLocationSettings();
+    } finally {
+      if (mounted) {
+        setState(() => _isOpeningLocationSettings = false);
       }
     }
   }
@@ -1891,11 +2043,199 @@ Future<bool> _confirmLocationUse(
   return confirmed ?? false;
 }
 
+class _StationLineFilterSection extends StatelessWidget {
+  const _StationLineFilterSection({
+    required this.linesFuture,
+    required this.selectedLine,
+    required this.onLineSelected,
+  });
+
+  final Future<List<SubwayLineOption>> linesFuture;
+  final SubwayLineOption? selectedLine;
+  final ValueChanged<SubwayLineOption?> onLineSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<SubwayLineOption>>(
+      future: linesFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const SizedBox(
+            height: 56,
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: CircularProgressIndicator(strokeWidth: 2.5),
+            ),
+          );
+        }
+
+        if (snapshot.hasError) {
+          return Text(
+            '노선을 불러오지 못했습니다.',
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: const Color(0xFF29484B),
+              fontWeight: FontWeight.w700,
+              height: 1.3,
+            ),
+          );
+        }
+
+        final lines = (snapshot.data ?? const <SubwayLineOption>[])
+            .where((line) => line.active)
+            .toList(growable: false);
+        if (lines.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '노선',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                color: const Color(0xFF102A2C),
+                fontWeight: FontWeight.w900,
+                height: 1.25,
+              ),
+            ),
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: [
+                _StationLineFilterButton(
+                  key: const Key('stationLineFilter-all'),
+                  label: '전체',
+                  semanticLabel: '전체 노선',
+                  selected: selectedLine == null,
+                  onPressed: () => onLineSelected(null),
+                ),
+                for (final line in lines)
+                  _StationLineFilterButton(
+                    key: Key('stationLineFilter-${line.id}'),
+                    label: line.name,
+                    semanticLabel: line.semanticLabel,
+                    selected: selectedLine?.id == line.id,
+                    badgeText: line.shortLabel,
+                    badgeColor: line.badgeColor,
+                    onPressed: () => onLineSelected(line),
+                  ),
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _StationLineFilterButton extends StatelessWidget {
+  const _StationLineFilterButton({
+    required this.label,
+    required this.semanticLabel,
+    required this.selected,
+    required this.onPressed,
+    this.badgeText,
+    this.badgeColor,
+    super.key,
+  });
+
+  final String label;
+  final String semanticLabel;
+  final bool selected;
+  final VoidCallback onPressed;
+  final String? badgeText;
+  final Color? badgeColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final backgroundColor = selected ? const Color(0xFF007A80) : Colors.white;
+    final foregroundColor = selected ? Colors.white : const Color(0xFF102A2C);
+    final borderColor = selected
+        ? const Color(0xFF007A80)
+        : const Color(0xFF93C7C2);
+
+    return Semantics(
+      label: '$semanticLabel ${selected ? '선택됨' : '선택 안 됨'}',
+      button: true,
+      selected: selected,
+      child: ExcludeSemantics(
+        child: OutlinedButton(
+          onPressed: onPressed,
+          style: OutlinedButton.styleFrom(
+            minimumSize: const Size(96, 56),
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+            backgroundColor: backgroundColor,
+            foregroundColor: foregroundColor,
+            side: BorderSide(color: borderColor, width: selected ? 2 : 1.5),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+            textStyle: const TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w900,
+              height: 1.2,
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (badgeText != null && badgeColor != null) ...[
+                _LineFilterBadge(text: badgeText!, color: badgeColor!),
+                const SizedBox(width: 8),
+              ],
+              Text(label),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LineFilterBadge extends StatelessWidget {
+  const _LineFilterBadge({required this.text, required this.color});
+
+  final String text;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final textColor = _higherContrastTextColor(color);
+    final fontSize = RegExp(r'^\d+$').hasMatch(text) ? 20.0 : 12.0;
+
+    return Container(
+      width: 32,
+      height: 32,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+      child: Text(
+        text,
+        maxLines: 2,
+        textAlign: TextAlign.center,
+        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+          color: textColor,
+          fontSize: fontSize,
+          fontWeight: FontWeight.w900,
+          height: 1.0,
+        ),
+      ),
+    );
+  }
+}
+
 class _StationSearchBody extends StatelessWidget {
-  const _StationSearchBody({required this.state, required this.onResultTap});
+  const _StationSearchBody({
+    required this.state,
+    required this.onResultTap,
+    required this.isOpeningLocationSettings,
+    required this.onOpenLocationSettings,
+  });
 
   final StationSearchState state;
   final ValueChanged<StationSearchResult> onResultTap;
+  final bool isOpeningLocationSettings;
+  final VoidCallback onOpenLocationSettings;
 
   @override
   Widget build(BuildContext context) {
@@ -1911,8 +2251,12 @@ class _StationSearchBody extends StatelessWidget {
           ),
         ),
       ),
-      StationSearchStatus.empty || StationSearchStatus.failure =>
-        _StationSearchMessage(message: state.message, liveRegion: true),
+      StationSearchStatus.empty ||
+      StationSearchStatus.failure => _StationSearchFailureMessage(
+        message: state.message,
+        isOpeningLocationSettings: isOpeningLocationSettings,
+        onOpenLocationSettings: onOpenLocationSettings,
+      ),
       StationSearchStatus.success => Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
@@ -1929,6 +2273,48 @@ class _StationSearchBody extends StatelessWidget {
         ],
       ),
     };
+  }
+}
+
+class _StationSearchFailureMessage extends StatelessWidget {
+  const _StationSearchFailureMessage({
+    required this.message,
+    required this.isOpeningLocationSettings,
+    required this.onOpenLocationSettings,
+  });
+
+  final String message;
+  final bool isOpeningLocationSettings;
+  final VoidCallback onOpenLocationSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    final shouldShowLocationSettings =
+        message == _currentLocationDisabledMessage;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _StationSearchMessage(message: message, liveRegion: true),
+        if (shouldShowLocationSettings) ...[
+          const SizedBox(height: 12),
+          OutlinedButton.icon(
+            key: const Key('stationSearchOpenLocationSettingsButton'),
+            onPressed: isOpeningLocationSettings
+                ? null
+                : onOpenLocationSettings,
+            icon: isOpeningLocationSettings
+                ? const SizedBox(
+                    width: 22,
+                    height: 22,
+                    child: CircularProgressIndicator(strokeWidth: 2.5),
+                  )
+                : const Icon(Icons.settings),
+            label: const Text('위치 설정 열기'),
+          ),
+        ],
+      ],
+    );
   }
 }
 

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1867,10 +1867,18 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
           children: [
             if (_lineOptionsFuture != null) ...[
-              _StationLineFilterSection(
-                linesFuture: _lineOptionsFuture!,
-                selectedLine: _selectedLine,
-                onLineSelected: _selectLine,
+              AnimatedBuilder(
+                animation: _controller,
+                builder: (context, _) {
+                  final isSearching =
+                      _controller.state.status == StationSearchStatus.loading;
+                  return _StationLineFilterSection(
+                    linesFuture: _lineOptionsFuture!,
+                    selectedLine: _selectedLine,
+                    enabled: !isSearching && !_isLocationPreflightRunning,
+                    onLineSelected: _selectLine,
+                  );
+                },
               ),
               const SizedBox(height: 16),
             ],
@@ -2047,11 +2055,13 @@ class _StationLineFilterSection extends StatelessWidget {
   const _StationLineFilterSection({
     required this.linesFuture,
     required this.selectedLine,
+    required this.enabled,
     required this.onLineSelected,
   });
 
   final Future<List<SubwayLineOption>> linesFuture;
   final SubwayLineOption? selectedLine;
+  final bool enabled;
   final ValueChanged<SubwayLineOption?> onLineSelected;
 
   @override
@@ -2108,7 +2118,7 @@ class _StationLineFilterSection extends StatelessWidget {
                   label: '전체',
                   semanticLabel: '전체 노선',
                   selected: selectedLine == null,
-                  onPressed: () => onLineSelected(null),
+                  onPressed: enabled ? () => onLineSelected(null) : null,
                 ),
                 for (final line in lines)
                   _StationLineFilterButton(
@@ -2118,7 +2128,7 @@ class _StationLineFilterSection extends StatelessWidget {
                     selected: selectedLine?.id == line.id,
                     badgeText: line.shortLabel,
                     badgeColor: line.badgeColor,
-                    onPressed: () => onLineSelected(line),
+                    onPressed: enabled ? () => onLineSelected(line) : null,
                   ),
               ],
             ),
@@ -2143,7 +2153,7 @@ class _StationLineFilterButton extends StatelessWidget {
   final String label;
   final String semanticLabel;
   final bool selected;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
   final String? badgeText;
   final Color? badgeColor;
 
@@ -2159,6 +2169,7 @@ class _StationLineFilterButton extends StatelessWidget {
       label: '$semanticLabel ${selected ? '선택됨' : '선택 안 됨'}',
       button: true,
       selected: selected,
+      onTap: onPressed,
       child: ExcludeSemantics(
         child: OutlinedButton(
           onPressed: onPressed,

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2169,6 +2169,7 @@ class _StationLineFilterButton extends StatelessWidget {
       label: '$semanticLabel ${selected ? '선택됨' : '선택 안 됨'}',
       button: true,
       selected: selected,
+      enabled: onPressed != null,
       onTap: onPressed,
       child: ExcludeSemantics(
         child: OutlinedButton(

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -116,6 +116,107 @@ void main() {
     expect(results.single.nameKo, '상록수');
   });
 
+  test('역 API 저장소는 선택한 노선으로 역 검색을 좁힌다', () async {
+    late Uri requestedUri;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestedUri = request.uri;
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': [
+              {
+                'id': 'station-sangnoksu',
+                'nameKo': '상록수',
+                'nameEn': 'Sangnoksu',
+                'region': '수도권',
+                'dataQualityLevel': 'LEVEL_1',
+                'dataSourceType': 'OFFICIAL_FILE',
+                'lastVerifiedAt': '2026-06-12',
+                'lines': [
+                  {
+                    'id': 'seoul-4',
+                    'operatorId': 'seoul-metro',
+                    'name': '수도권 4호선',
+                    'color': '#00A5DE',
+                    'stationCode': '448',
+                    'sequence': 48,
+                    'platformInfo': '당고개 방면 / 오이도 방면',
+                  },
+                ],
+              },
+            ],
+          }),
+        )
+        ..close();
+    });
+
+    final repository = StationSearchApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    final results = await repository.searchStationsOnLine('상록수', 'seoul-4');
+
+    expect(requestedUri.path, '/api/v1/stations');
+    expect(requestedUri.queryParameters['query'], '상록수');
+    expect(requestedUri.queryParameters['lineId'], 'seoul-4');
+    expect(results.single.nameKo, '상록수');
+  });
+
+  test('역 API 저장소는 노선 목록을 요청하고 쉬운 라벨로 파싱한다', () async {
+    late Uri requestedUri;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestedUri = request.uri;
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': [
+              {
+                'id': 'seoul-4',
+                'operatorId': 'seoul-metro',
+                'name': '수도권 4호선',
+                'color': '#00A5DE',
+                'region': '수도권',
+                'lineCode': '4',
+                'active': true,
+              },
+              {
+                'id': 'korail-gyeongui-jungang',
+                'operatorId': 'korail',
+                'name': '경의중앙선',
+                'color': '#75C5A1',
+                'region': '수도권',
+                'lineCode': '경의중앙',
+                'active': true,
+              },
+            ],
+          }),
+        )
+        ..close();
+    });
+
+    final repository = StationSearchApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    final lines = await repository.listLines();
+
+    expect(requestedUri.path, '/api/v1/lines');
+    expect(lines.map((line) => line.shortLabel), ['4', '경의중앙']);
+    expect(lines.first.semanticLabel, '수도권 4호선');
+  });
+
   test('역 API 저장소는 현재 위치 기준 가까운 역을 요청하고 거리를 파싱한다', () async {
     late Uri requestedUri;
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
@@ -649,6 +750,18 @@ void main() {
     expect(controller.state.results, isEmpty);
   });
 
+  test('역 검색 컨트롤러는 선택한 노선으로 결과를 요청한다', () async {
+    final repository = FakeStationSearchRepository()
+      ..nextResults = [_stationResult(id: 'station-sangnoksu', name: '상록수')];
+    final controller = StationSearchController(repository: repository);
+
+    await controller.search('상록수', lineId: 'seoul-4');
+
+    expect(repository.requestedQueries, ['상록수']);
+    expect(repository.requestedLineIds, ['seoul-4']);
+    expect(controller.state.status, StationSearchStatus.success);
+  });
+
   test('역 검색 컨트롤러는 늦게 도착한 이전 응답을 무시한다', () async {
     final repository = ControlledStationSearchRepository();
     final controller = StationSearchController(repository: repository);
@@ -1058,9 +1171,12 @@ StationFacilityInfo _stationFacility({
   );
 }
 
-class FakeStationSearchRepository implements StationSearchRepository {
+class FakeStationSearchRepository
+    implements StationSearchRepository, StationLineFilterRepository {
   final requestedQueries = <String>[];
+  final requestedLineIds = <String?>[];
   final requestedNearbyLocations = <CurrentLocation>[];
+  List<SubwayLineOption> lineOptions = const [];
   Object? error;
   List<StationSearchResult> nextResults = const [];
   List<StationSearchResult> nextNearbyResults = const [];
@@ -1068,11 +1184,35 @@ class FakeStationSearchRepository implements StationSearchRepository {
   @override
   Future<List<StationSearchResult>> searchStations(String query) async {
     requestedQueries.add(query);
+    requestedLineIds.add(null);
     final currentError = error;
     if (currentError != null) {
       throw currentError;
     }
     return nextResults;
+  }
+
+  @override
+  Future<List<StationSearchResult>> searchStationsOnLine(
+    String query,
+    String lineId,
+  ) async {
+    requestedQueries.add(query);
+    requestedLineIds.add(lineId);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return nextResults;
+  }
+
+  @override
+  Future<List<SubwayLineOption>> listLines() async {
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return lineOptions;
   }
 
   @override

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -927,6 +927,83 @@ void main() {
     }
   });
 
+  testWidgets('역 검색은 검색 중 노선 선택을 바꾸지 않는다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final searchCompleter = Completer<List<StationSearchResult>>();
+    final repository = FakeStationSearchRepository(
+      lineOptions: const [
+        SubwayLineOption(
+          id: 'seoul-4',
+          name: '수도권 4호선',
+          color: '#00A5DE',
+          region: '수도권',
+          lineCode: '4',
+          active: true,
+        ),
+        SubwayLineOption(
+          id: 'korail-gyeongui-jungang',
+          name: '경의중앙선',
+          color: '#75C5A1',
+          region: '수도권',
+          lineCode: '경의중앙',
+          active: true,
+        ),
+      ],
+      searchCompleter: searchCompleter,
+    );
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: repository,
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('stationSearchButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('stationLineFilter-seoul-4')));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getSemantics(find.bySemanticsLabel('수도권 4호선 선택됨')),
+        isSemantics(
+          label: '수도권 4호선 선택됨',
+          isButton: true,
+          isSelected: true,
+          hasTapAction: true,
+        ),
+      );
+
+      await tester.enterText(
+        find.byKey(const Key('stationSearchInput')),
+        '상록수',
+      );
+      await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+      await tester.pump();
+
+      await tester.tap(
+        find.byKey(const Key('stationLineFilter-korail-gyeongui-jungang')),
+      );
+      await tester.pump();
+
+      expect(find.bySemanticsLabel('수도권 4호선 선택됨'), findsOneWidget);
+      expect(find.bySemanticsLabel('경의중앙선 선택 안 됨'), findsOneWidget);
+
+      searchCompleter.complete([
+        _stationResult(id: 'station-sangnoksu', name: '상록수'),
+      ]);
+      await tester.pumpAndSettle();
+
+      expect(repository.requestedLineIds, ['seoul-4']);
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('역 검색은 현재 위치 주변 역을 큰 버튼으로 찾고 거리를 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final locationProvider = FakeCurrentLocationProvider(
@@ -3477,6 +3554,7 @@ class FakeStationSearchRepository
     this.nearbyResults = const [],
     this.queryResults = const {},
     this.lineOptions = const [],
+    this.searchCompleter,
     StationDetail? stationDetail,
     this.stationExits = const [],
     this.stationFacilities = const [],
@@ -3488,6 +3566,7 @@ class FakeStationSearchRepository
   final List<StationSearchResult> nearbyResults;
   final Map<String, List<StationSearchResult>> queryResults;
   final List<SubwayLineOption> lineOptions;
+  final Completer<List<StationSearchResult>>? searchCompleter;
   final StationDetail stationDetail;
   final List<StationExitInfo> stationExits;
   final List<StationFacilityInfo> stationFacilities;
@@ -3502,6 +3581,10 @@ class FakeStationSearchRepository
   Future<List<StationSearchResult>> searchStations(String query) async {
     requestedQueries.add(query);
     requestedLineIds.add(null);
+    final delayedResults = searchCompleter;
+    if (delayedResults != null) {
+      return delayedResults.future;
+    }
     return queryResults[query] ?? nextResults;
   }
 
@@ -3512,6 +3595,10 @@ class FakeStationSearchRepository
   ) async {
     requestedQueries.add(query);
     requestedLineIds.add(lineId);
+    final delayedResults = searchCompleter;
+    if (delayedResults != null) {
+      return delayedResults.future;
+    }
     return queryResults[query] ?? nextResults;
   }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -833,6 +833,100 @@ void main() {
     }
   });
 
+  testWidgets('역 검색은 노선을 선택해 결과를 좁힌다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final repository = FakeStationSearchRepository(
+      lineOptions: const [
+        SubwayLineOption(
+          id: 'seoul-4',
+          name: '수도권 4호선',
+          color: '#00A5DE',
+          region: '수도권',
+          lineCode: '4',
+          active: true,
+        ),
+        SubwayLineOption(
+          id: 'korail-gyeongui-jungang',
+          name: '경의중앙선',
+          color: '#75C5A1',
+          region: '수도권',
+          lineCode: '경의중앙',
+          active: true,
+        ),
+      ],
+      nextResults: [
+        const StationSearchResult(
+          id: 'station-sangnoksu',
+          nameKo: '상록수',
+          nameEn: 'Sangnoksu',
+          region: '수도권',
+          dataQualityLevel: 'LEVEL_1',
+          lastVerifiedAt: '2026-06-12',
+          lines: [
+            StationSearchLine(
+              id: 'seoul-4',
+              name: '수도권 4호선',
+              color: '#00A5DE',
+              stationCode: '448',
+            ),
+          ],
+        ),
+      ],
+    );
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: repository,
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('stationSearchButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('stationLineFilter-all')), findsOneWidget);
+      expect(
+        find.byKey(const Key('stationLineFilter-seoul-4')),
+        findsOneWidget,
+      );
+      expect(find.text('4'), findsOneWidget);
+      expect(find.bySemanticsLabel('수도권 4호선 선택 안 됨'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('stationLineFilter-seoul-4')));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel('수도권 4호선 선택됨'), findsOneWidget);
+
+      await tester.enterText(
+        find.byKey(const Key('stationSearchInput')),
+        '상록수',
+      );
+      await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+      await tester.pumpAndSettle();
+
+      expect(repository.requestedQueries, ['상록수']);
+      expect(repository.requestedLineIds, ['seoul-4']);
+      expect(
+        find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.byKey(const Key('stationLineFilter-all')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+      await tester.pumpAndSettle();
+
+      expect(repository.requestedQueries, ['상록수', '상록수']);
+      expect(repository.requestedLineIds, ['seoul-4', null]);
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('역 검색은 현재 위치 주변 역을 큰 버튼으로 찾고 거리를 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final locationProvider = FakeCurrentLocationProvider(
@@ -1000,6 +1094,46 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('역 검색은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다', (tester) async {
+    final locationProvider = FakeCurrentLocationProvider(
+      error: const CurrentLocationException(
+        '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.',
+      ),
+      needsPermissionRequest: false,
+    );
+    final repository = FakeStationSearchRepository();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        locationProvider: locationProvider,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.'), findsOneWidget);
+    expect(
+      find.byKey(const Key('stationSearchOpenLocationSettingsButton')),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.byKey(const Key('stationSearchOpenLocationSettingsButton')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(locationProvider.openSettingsCount, 1);
+    expect(repository.requestedNearbyLocations, isEmpty);
   });
 
   testWidgets('역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다', (tester) async {
@@ -3336,11 +3470,13 @@ FavoriteRoute _favoriteRoute() {
   );
 }
 
-class FakeStationSearchRepository implements StationSearchRepository {
+class FakeStationSearchRepository
+    implements StationSearchRepository, StationLineFilterRepository {
   FakeStationSearchRepository({
     this.nextResults = const [],
     this.nearbyResults = const [],
     this.queryResults = const {},
+    this.lineOptions = const [],
     StationDetail? stationDetail,
     this.stationExits = const [],
     this.stationFacilities = const [],
@@ -3351,10 +3487,12 @@ class FakeStationSearchRepository implements StationSearchRepository {
   final List<StationSearchResult> nextResults;
   final List<StationSearchResult> nearbyResults;
   final Map<String, List<StationSearchResult>> queryResults;
+  final List<SubwayLineOption> lineOptions;
   final StationDetail stationDetail;
   final List<StationExitInfo> stationExits;
   final List<StationFacilityInfo> stationFacilities;
   final requestedQueries = <String>[];
+  final requestedLineIds = <String?>[];
   final requestedNearbyLocations = <CurrentLocation>[];
   final requestedDetailStationIds = <String>[];
   final requestedExitStationIds = <String>[];
@@ -3363,7 +3501,23 @@ class FakeStationSearchRepository implements StationSearchRepository {
   @override
   Future<List<StationSearchResult>> searchStations(String query) async {
     requestedQueries.add(query);
+    requestedLineIds.add(null);
     return queryResults[query] ?? nextResults;
+  }
+
+  @override
+  Future<List<StationSearchResult>> searchStationsOnLine(
+    String query,
+    String lineId,
+  ) async {
+    requestedQueries.add(query);
+    requestedLineIds.add(lineId);
+    return queryResults[query] ?? nextResults;
+  }
+
+  @override
+  Future<List<SubwayLineOption>> listLines() async {
+    return lineOptions;
   }
 
   @override

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -853,6 +853,14 @@ void main() {
           lineCode: '경의중앙',
           active: true,
         ),
+        SubwayLineOption(
+          id: 'inactive-line',
+          name: '운행 중지 노선',
+          color: '#777777',
+          region: '수도권',
+          lineCode: '중지',
+          active: false,
+        ),
       ],
       nextResults: [
         const StationSearchResult(
@@ -893,6 +901,11 @@ void main() {
         find.byKey(const Key('stationLineFilter-seoul-4')),
         findsOneWidget,
       );
+      expect(
+        find.byKey(const Key('stationLineFilter-inactive-line')),
+        findsNothing,
+      );
+      expect(find.text('운행 중지 노선'), findsNothing);
       expect(find.text('4'), findsOneWidget);
       expect(find.bySemanticsLabel('수도권 4호선 선택 안 됨'), findsOneWidget);
 
@@ -948,6 +961,14 @@ void main() {
           lineCode: '경의중앙',
           active: true,
         ),
+        SubwayLineOption(
+          id: 'inactive-line',
+          name: '운행 중지 노선',
+          color: '#777777',
+          region: '수도권',
+          lineCode: '중지',
+          active: false,
+        ),
       ],
       searchCompleter: searchCompleter,
     );
@@ -965,6 +986,13 @@ void main() {
 
       await tester.tap(find.byKey(const Key('stationSearchButton')));
       await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('stationLineFilter-inactive-line')),
+        findsNothing,
+      );
+      expect(find.text('운행 중지 노선'), findsNothing);
+
       await tester.tap(find.byKey(const Key('stationLineFilter-seoul-4')));
       await tester.pumpAndSettle();
 
@@ -2922,7 +2950,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('현재 위치 사용'), findsOneWidget);
-    expect(find.text('현재 위치로 신고할 역을 확인합니다.'), findsOneWidget);
+    expect(find.text('신고할 역을 확인하는 데 필요합니다.'), findsOneWidget);
     expect(requestCount, 0);
 
     await tester.tap(find.text('취소'));


### PR DESCRIPTION
Closes #166

## 배경
역 이름만 입력하는 검색은 같은 이름이 여러 노선에 걸쳐 있거나 사용자가 노선명을 정확히 기억하지 못하는 경우 결과를 좁히기 어렵습니다. 고령자와 이동약자가 빠르게 알아볼 수 있도록 노선 색상과 번호 배지를 함께 제공하고, 선택한 노선으로 검색 API를 호출하도록 개선합니다.

주변 역 찾기에서는 GPS가 켜져 있으면 현재 위치를 바로 사용하고, GPS가 꺼진 경우에는 역 추정이 흔들리지 않도록 위치 설정으로 이동할 수 있게 했습니다.

## 변경 사항
- 역 검색 화면 상단에 노선 필터를 추가했습니다.
- `/api/v1/lines` 노선 목록을 불러와 활성 노선만 큰 버튼으로 표시합니다.
- 선택한 노선이 있으면 역 검색 요청에 `lineId`를 함께 보냅니다.
- 노선 배지는 기존 검색 결과 카드와 같은 색상/라벨 규칙을 사용합니다.
- GPS 꺼짐 안내가 표시될 때 역 검색 화면에서도 `위치 설정 열기` 버튼을 제공합니다.
- 노선 필터, 노선 검색 요청, GPS 꺼짐 회복 흐름을 테스트로 고정했습니다.

## 검증
- `flutter test test/station_search_test.dart`
- `flutter test test/widget_test.dart --plain-name '역 검색은 노선을 선택해 결과를 좁힌다'`
- `flutter test test/widget_test.dart --plain-name '역 검색은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다'`
- `flutter analyze`
- `flutter test`
- `flutter build apk --debug`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`
- Android emulator-5554에서 역 검색 화면 노선 필터와 GPS on 주변 역 자동 검색 화면 확인

## 리스크
- 백엔드 `/api/v1/lines` 응답이 실패하면 노선 필터는 숨기지 않고 짧은 실패 문구를 보여 줍니다. 역 이름 검색과 주변 역 검색은 계속 사용할 수 있습니다.
- 노선 라벨은 `lineCode`를 우선 사용하고, 없으면 노선명에서 짧은 배지를 계산합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 역 검색 시 특정 노선으로 검색 결과를 필터링할 수 있는 노선 필터 기능 추가
  * 위치 설정이 비활성화된 경우 검색 실패 메시지와 함께 위치 설정 열기 버튼 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->