### PR TITLE
[Fix] 시설 신고 위치 확인 안내 개선

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -16,7 +16,7 @@ const _facilityReportListErrorMessage = '신고 내역을 불러오지 못했습
 const _anonymousReportUserId = 'anonymous-mobile-user';
 const _facilityReportPhotoTooLargeMessage = '사진이 너무 큽니다. 다른 사진을 선택해 주세요.';
 const _facilityReportLocationDisabledMessage =
-    '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.';
+    '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.';
 const _facilityReportDraftTargetStorageKey =
     'easysubway.facilityReport.draftTarget';
 
@@ -1323,7 +1323,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('사진·위치 확인'),
-        content: const Text('사진과 현재 위치를 함께 보냅니다.'),
+        content: const Text('사진과 신고 위치를 함께 보냅니다.'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
@@ -1344,7 +1344,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('현재 위치 사용'),
-        content: const Text('신고할 역을 확인하는 데 필요합니다.'),
+        content: const Text('현재 위치로 가까운 역을 찾습니다.'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -11,7 +11,8 @@ import 'mobile_error_reporter.dart';
 
 const _stationSearchTimeout = Duration(seconds: 8);
 const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
-const _currentLocationDisabledMessage = '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.';
+const _currentLocationDisabledMessage =
+    '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.';
 const _favoriteStationTimeout = Duration(seconds: 8);
 const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했습니다.';
 const _favoriteStationStatusErrorMessage = '즐겨찾기를 확인하지 못했습니다.';
@@ -1983,7 +1984,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
         return;
       }
       if (needsPermissionRequest &&
-          !await _confirmLocationUse(context, message: '가까운 역을 찾는 데 사용합니다.')) {
+          !await _confirmLocationUse(context, message: '현재 위치로 가까운 역을 찾습니다.')) {
         return;
       }
       if (!mounted) {

--- a/apps/mobile/test/current_location_provider_test.dart
+++ b/apps/mobile/test/current_location_provider_test.dart
@@ -39,7 +39,7 @@ void main() {
         isA<CurrentLocationException>().having(
           (error) => error.message,
           'message',
-          '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.',
+          '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.',
         ),
       ),
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1259,7 +1259,7 @@ void main() {
   testWidgets('역 검색은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다', (tester) async {
     final locationProvider = FakeCurrentLocationProvider(
       error: const CurrentLocationException(
-        '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.',
+        '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.',
       ),
       needsPermissionRequest: false,
     );
@@ -1281,7 +1281,10 @@ void main() {
     await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.'), findsOneWidget);
+    expect(
+      find.text('기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.'),
+      findsOneWidget,
+    );
     expect(
       find.byKey(const Key('stationSearchOpenLocationSettingsButton')),
       findsOneWidget,
@@ -2957,7 +2960,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('사진·위치 확인'), findsOneWidget);
-    expect(find.text('사진과 현재 위치를 함께 보냅니다.'), findsOneWidget);
+    expect(find.text('사진과 신고 위치를 함께 보냅니다.'), findsOneWidget);
     expect(reportRepository.requests, isEmpty);
 
     await tester.tap(find.text('취소'));
@@ -3005,7 +3008,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('현재 위치 사용'), findsOneWidget);
-    expect(find.text('신고할 역을 확인하는 데 필요합니다.'), findsOneWidget);
+    expect(find.text('현재 위치로 가까운 역을 찾습니다.'), findsOneWidget);
     expect(requestCount, 0);
 
     await tester.tap(find.text('취소'));
@@ -3112,7 +3115,7 @@ void main() {
       requestCount++;
       if (requestCount == 1) {
         throw const FacilityReportLocationException(
-          '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.',
+          '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.',
         );
       }
       return const FacilityReportLocation(
@@ -3146,7 +3149,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.'), findsOneWidget);
+    expect(
+      find.text('기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.'),
+      findsOneWidget,
+    );
     final failedLocationSubmitButton = tester.widget<FilledButton>(
       find.byKey(const Key('facilityReportSubmitButton')),
     );
@@ -3176,7 +3182,7 @@ void main() {
     final reportRepository = FakeFacilityReportRepository();
     final locationProvider = FakeCurrentLocationProvider(
       error: const CurrentLocationException(
-        '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.',
+        '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.',
       ),
       needsPermissionRequest: false,
     );
@@ -3243,7 +3249,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.'), findsOneWidget);
+    expect(
+      find.text('기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.'),
+      findsOneWidget,
+    );
     expect(find.text('현재 위치 첨부됨'), findsNothing);
     expect(find.text('현재 위치가 첨부되었습니다.'), findsNothing);
     expect(find.text('위치 확인됨'), findsNothing);
@@ -3270,7 +3279,7 @@ void main() {
     final reportRepository = FakeFacilityReportRepository();
     final locationProvider = FakeCurrentLocationProvider(
       error: const CurrentLocationException(
-        '기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.',
+        '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.',
       ),
       needsPermissionRequest: false,
     );
@@ -3335,7 +3344,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('기기 위치를 켜 주세요. 위치가 없으면 역 확인이 어렵습니다.'), findsOneWidget);
+    expect(
+      find.text('기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.'),
+      findsOneWidget,
+    );
     expect(
       find.byKey(const Key('facilityReportOpenLocationSettingsButton')),
       findsOneWidget,


### PR DESCRIPTION
## 관련 이슈

close #170

## 작업 배경

시설 신고와 주변 역 찾기는 현재 위치를 이용해 가까운 역을 판단합니다. GPS가 꺼져 있으면 사용자가 왜 다음 단계로 갈 수 없는지 바로 이해해야 하고, 화면에는 사용자가 판단할 필요 없는 내부 상태 표현을 남기지 않아야 합니다.

이번 변경은 위치가 없을 때의 안내를 더 짧고 행동 중심으로 정리하고, 신고 제출 확인 문구도 사용자가 이해하기 쉬운 표현으로 바꿉니다.

## 작업 내용

- GPS가 꺼져 있을 때 안내 문구를 `기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.`로 통일했습니다.
- 시설 신고의 위치 권한 안내를 `현재 위치로 가까운 역을 찾습니다.`로 정리했습니다.
- 사진과 위치를 함께 보내기 전 확인 문구를 `사진과 신고 위치를 함께 보냅니다.`로 바꿨습니다.
- 위치 성공 상태에서 `현재 위치 첨부됨`, `현재 위치가 첨부되었습니다.`, `위치 확인됨` 같은 별도 문구를 노출하지 않는 테스트를 유지했습니다.

## 검증

- `flutter test test/current_location_provider_test.dart` 통과
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다'` 통과
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 GPS가 꺼져 있으면 위치 확인을 요청하고 제출을 막는다'` 통과
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 사진과 위치를 보내기 전에 확인한다'` 통과
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 현재 위치를 함께 보낸다'` 통과
- `flutter analyze` 통과
- `flutter test` 통과
- `node --test tools/ci/*.test.mjs` 통과
- `git diff --check` 통과
- `flutter build apk --debug` 통과
- `flutter build ios --simulator --no-codesign` 통과
- Android 에뮬레이터에서 기기 위치를 끈 상태로 `내 주변 역 찾기` 안내와 `위치 설정 열기` 버튼 확인

## 리뷰어 메모

- 이번 변경은 위치 조회 로직이나 권한 요청 타이밍을 바꾸지 않고, GPS 꺼짐/위치 사용/제출 확인 문구를 사용자 행동 중심으로 정리하는 범위입니다.
- Android 실제 화면은 `/private/tmp/easysubway-gps-disabled-guidance.png`에서 확인했습니다.

## 리스크

- 문구 변경이므로 API 요청 형식이나 네이티브 위치 채널 계약에는 영향이 없습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
