### PR TITLE
[Fix] 시설 신고 사진 및 위치 안내 개선

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1099,6 +1099,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
   bool _isLocationFailure = false;
   bool _isOpeningLocationSettings = false;
   bool _isPhotoFailure = false;
+  bool _isConfirmingPhotoUse = false;
   bool _isPickingPhoto = false;
 
   @override
@@ -1195,7 +1196,11 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
             const SizedBox(height: 16),
             OutlinedButton.icon(
               key: const Key('facilityReportAddPhotoButton'),
-              onPressed: isLoading || hasSubmittedReport || _isPickingPhoto
+              onPressed:
+                  isLoading ||
+                      hasSubmittedReport ||
+                      _isConfirmingPhotoUse ||
+                      _isPickingPhoto
                   ? null
                   : _pickPhoto,
               icon: _isPickingPhoto
@@ -1441,16 +1446,20 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
   }
 
   Future<void> _pickPhoto() async {
-    if (_isPickingPhoto) {
+    if (_isConfirmingPhotoUse || _isPickingPhoto) {
       return;
     }
-    if (!await _confirmPhotoUse()) {
-      return;
-    }
+    setState(() => _isConfirmingPhotoUse = true);
+    final confirmed = await _confirmPhotoUse();
     if (!mounted) {
       return;
     }
+    if (!confirmed) {
+      setState(() => _isConfirmingPhotoUse = false);
+      return;
+    }
     setState(() {
+      _isConfirmingPhotoUse = false;
       _isPickingPhoto = true;
       _photoMessage = '';
       _isPhotoFailure = false;

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1360,6 +1360,35 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     return confirmed ?? false;
   }
 
+  Future<bool> _confirmPhotoUse() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('사진 확인'),
+        content: const Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('사진은 신고 확인에만 사용됩니다.'),
+            SizedBox(height: 8),
+            Text('얼굴이나 전화번호가 보이면 가려 주세요.'),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('취소'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('계속'),
+          ),
+        ],
+      ),
+    );
+    return confirmed ?? false;
+  }
+
   Future<void> _requestCurrentLocation() async {
     if (widget.locationLoader == null ||
         _isLoadingLocation ||
@@ -1413,6 +1442,12 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
 
   Future<void> _pickPhoto() async {
     if (_isPickingPhoto) {
+      return;
+    }
+    if (!await _confirmPhotoUse()) {
+      return;
+    }
+    if (!mounted) {
       return;
     }
     setState(() {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2636,6 +2636,63 @@ void main() {
     expect(find.text('사진 1장 추가됨'), findsOneWidget);
   });
 
+  testWidgets('시설 신고 화면은 사진 확인 중 빠른 중복 탭을 무시한다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    var pickerCallCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FacilityReportScreen(
+          repository: reportRepository,
+          target: const FacilityReportTarget(
+            stationId: 'station-sangnoksu',
+            stationName: '상록수',
+            facilityId: 'facility-sangnoksu-elevator-1',
+            facilityName: '1번 출구 엘리베이터',
+            facilityTypeLabel: '엘리베이터',
+            facilityStatusLabel: '정상',
+          ),
+          locationLoader: () async => const FacilityReportLocation(
+            latitude: 37.302421,
+            longitude: 126.866221,
+          ),
+          needsLocationPermissionRequest: () async => false,
+          photoPicker: () async {
+            pickerCallCount++;
+            return const FacilityReportPhotoAttachment(
+              fileName: 'elevator-door.jpg',
+              contentType: 'image/jpeg',
+              dataBase64: 'aW1hZ2UtYnl0ZXM=',
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('facilityReportAddPhotoButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+    final addPhotoButton = tester.widget<OutlinedButton>(
+      find.byKey(const Key('facilityReportAddPhotoButton')),
+    );
+    addPhotoButton.onPressed!();
+    addPhotoButton.onPressed!();
+    await tester.pumpAndSettle();
+
+    expect(find.text('사진 확인'), findsOneWidget);
+
+    await tester.tap(find.text('계속'));
+    await tester.pumpAndSettle();
+
+    expect(pickerCallCount, 1);
+    expect(find.text('사진 확인'), findsNothing);
+    expect(find.text('사진 1장 추가됨'), findsOneWidget);
+  });
+
   testWidgets('시설 신고 화면은 사진을 직접 추가해서 보낸다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final reportRepository = FakeFacilityReportRepository();

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1508,6 +1508,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('facilityReportAddPhotoButton')));
     await tester.pump();
+    await _continuePhotoUse(tester, settle: false);
 
     expect(draftTargetStore.saveCount, 1);
     expect(
@@ -2572,6 +2573,69 @@ void main() {
     }
   });
 
+  testWidgets('시설 신고 화면은 사진 선택 전에 짧은 개인정보 안내를 보여준다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    var pickerCallCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FacilityReportScreen(
+          repository: reportRepository,
+          target: const FacilityReportTarget(
+            stationId: 'station-sangnoksu',
+            stationName: '상록수',
+            facilityId: 'facility-sangnoksu-elevator-1',
+            facilityName: '1번 출구 엘리베이터',
+            facilityTypeLabel: '엘리베이터',
+            facilityStatusLabel: '정상',
+          ),
+          locationLoader: () async => const FacilityReportLocation(
+            latitude: 37.302421,
+            longitude: 126.866221,
+          ),
+          needsLocationPermissionRequest: () async => false,
+          photoPicker: () async {
+            pickerCallCount++;
+            return const FacilityReportPhotoAttachment(
+              fileName: 'elevator-door.jpg',
+              contentType: 'image/jpeg',
+              dataBase64: 'aW1hZ2UtYnl0ZXM=',
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('facilityReportAddPhotoButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('facilityReportAddPhotoButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('사진 확인'), findsOneWidget);
+    expect(find.text('사진은 신고 확인에만 사용됩니다.'), findsOneWidget);
+    expect(find.text('얼굴이나 전화번호가 보이면 가려 주세요.'), findsOneWidget);
+    expect(pickerCallCount, 0);
+
+    await tester.tap(find.text('취소'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('사진 1장 추가됨'), findsNothing);
+    expect(pickerCallCount, 0);
+
+    await tester.tap(find.byKey(const Key('facilityReportAddPhotoButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('계속'));
+    await tester.pumpAndSettle();
+
+    expect(pickerCallCount, 1);
+    expect(find.text('사진 1장 추가됨'), findsOneWidget);
+  });
+
   testWidgets('시설 신고 화면은 사진을 직접 추가해서 보낸다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final reportRepository = FakeFacilityReportRepository();
@@ -2619,6 +2683,7 @@ void main() {
 
       await tester.tap(find.byKey(const Key('facilityReportAddPhotoButton')));
       await tester.pumpAndSettle();
+      await _continuePhotoUse(tester);
 
       expect(find.text('사진 1장 추가됨'), findsOneWidget);
 
@@ -2751,6 +2816,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('facilityReportAddPhotoButton')));
     await tester.pumpAndSettle();
+    await _continuePhotoUse(tester);
 
     expect(draftTargetStore.saveCount, 1);
     expect(draftTargetStore.clearCount, 1);
@@ -2942,6 +3008,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('facilityReportAddPhotoButton')));
     await tester.pumpAndSettle();
+    await _continuePhotoUse(tester);
 
     await tester.ensureVisible(
       find.byKey(const Key('facilityReportDescriptionInput')),
@@ -3578,6 +3645,19 @@ Future<void> _acceptLocationUse(WidgetTester tester) async {
   expect(find.text('현재 위치 사용'), findsOneWidget);
   await tester.tap(find.text('위치 사용'));
   await tester.pumpAndSettle();
+}
+
+Future<void> _continuePhotoUse(
+  WidgetTester tester, {
+  bool settle = true,
+}) async {
+  expect(find.text('사진 확인'), findsOneWidget);
+  await tester.tap(find.text('계속'));
+  if (settle) {
+    await tester.pumpAndSettle();
+  } else {
+    await tester.pump();
+  }
 }
 
 FavoriteStation _favoriteStation({required String id, required String name}) {


### PR DESCRIPTION
## 관련 이슈

Closes #172

## 배경

시설 신고에서 사진을 바로 열면 사용자가 주변 사람의 얼굴이나 전화번호가 찍힌 사진을 그대로 올릴 수 있습니다. 사진을 첨부하기 전에 신고 확인에 쓰인다는 점과 개인정보가 보이면 가려야 한다는 점을 짧게 알려 사용자가 다음 행동을 바로 판단할 수 있게 했습니다.

같은 화면의 위치 흐름도 다시 확인했습니다. GPS가 꺼져 있으면 위치 설정을 열도록 안내하고, GPS가 켜져 있으면 위치 성공 문구를 추가로 띄우지 않고 자동 수집된 좌표를 신고에 포함합니다.

## 변경 사항

- 시설 신고 화면에서 `사진 추가` 또는 `사진 바꾸기`를 누르면 사진 선택 전 안내 다이얼로그를 표시합니다.
- 안내에서 `취소`를 누르면 사진 picker와 임시 신고 대상 저장을 실행하지 않습니다.
- 안내에서 `계속`을 누른 경우에만 기존 카메라/앨범 선택 흐름을 진행합니다.
- 사진 확인 다이얼로그가 열린 동안 빠른 중복 탭으로 picker가 여러 번 실행되지 않도록 막았습니다.
- 기존 사진 첨부 테스트를 새 확인 단계에 맞게 갱신하고, 사진 선택 전 안내 테스트를 추가했습니다.
- GPS 꺼짐/켜짐 시설 신고 흐름은 기존 테스트와 Android 에뮬레이터에서 함께 확인했습니다.

## 검증

- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 GPS가 꺼져 있으면 위치 확인을 요청하고 제출을 막는다'`
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 현재 위치를 함께 보낸다'`
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다'`
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 사진 선택 전에 짧은 개인정보 안내를 보여준다'`
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 사진 확인 중 빠른 중복 탭을 무시한다'`
- `flutter analyze`
- `flutter test`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`
- `flutter build apk --debug`
- Android 에뮬레이터 실제 화면 확인
  - GPS 꺼짐 상태에서 `위치 설정 열기`와 `위치 다시 확인` 표시 확인
  - 사진 선택 전 `사진 확인` 안내 다이얼로그 표시 확인
  - GPS 켠 뒤 위치 경고가 사라지고 `신고 보내기`가 활성화되는 것 확인
- `flutter build ios --simulator --no-codesign`

## 리스크

- 사진 선택 전에 한 번 더 확인 단계가 생기므로 첨부까지 탭이 1회 늘어납니다. 대신 취소 시 picker를 열지 않아 불필요한 권한/앨범 진입을 줄입니다.

## 체크리스트

- [x] 사진 첨부 전 안내가 짧고 행동 중심인지 확인
- [x] GPS 꺼짐/켜짐 시설 신고 흐름 확인
- [x] Android 실제 화면 확인
- [x] iOS 시뮬레이터 빌드 확인
- [x] CI 통과 확인
- [x] 코드 리뷰 확인
- [x] merge 후 CD 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시설 신고 시 사진 첨부 전에 사진 사용 안내 및 확인 단계 추가

* **개선사항**
  * 사진 첨부 중 중복 선택 방지

* **테스트**
  * 사진 첨부 플로우 관련 테스트 케이스 업데이트 및 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
