### PR TITLE
[Fix] 데이터 품질 안내 문구 개선

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1176,11 +1176,11 @@ int? _optionalInt(Map<String, Object?> json, String key) {
 
 String _dataQualityLabel(String dataQualityLevel) {
   return switch (dataQualityLevel) {
-    'LEVEL_1' => '기본 정보만 확인됨',
-    'LEVEL_2' => '접근성 시설 확인됨',
-    'LEVEL_3' => '쉬운 경로 안내 가능',
-    'LEVEL_4' => '실시간 상태 반영됨',
-    _ => '확인 정보 부족',
+    'LEVEL_1' => '기본 정보만 있음',
+    'LEVEL_2' => '시설 정보 확인됨',
+    'LEVEL_3' => '쉬운 길 안내 가능',
+    'LEVEL_4' => '고장·공사 반영됨',
+    _ => '정보 확인 필요',
   };
 }
 

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -8,6 +8,30 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('역 데이터 품질은 내부 레벨을 쉬운 안내 문구로 바꾼다', () {
+    final labels = ['LEVEL_1', 'LEVEL_2', 'LEVEL_3', 'LEVEL_4', 'UNKNOWN']
+        .map(
+          (level) => StationSearchResult(
+            id: 'station-$level',
+            nameKo: '상록수',
+            nameEn: 'Sangnoksu',
+            region: '수도권',
+            dataQualityLevel: level,
+            lastVerifiedAt: '2026-06-12',
+            lines: const [],
+          ).dataQualityLabel,
+        )
+        .toList(growable: false);
+
+    expect(labels, [
+      '기본 정보만 있음',
+      '시설 정보 확인됨',
+      '쉬운 길 안내 가능',
+      '고장·공사 반영됨',
+      '정보 확인 필요',
+    ]);
+  });
+
   test('역 API 저장소는 백엔드 역 목록을 요청하고 결과를 파싱한다', () async {
     late Uri requestedUri;
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
@@ -60,7 +84,7 @@ void main() {
     expect(results.single.id, 'station-sangnoksu');
     expect(results.single.nameKo, '상록수');
     expect(results.single.region, '수도권');
-    expect(results.single.dataQualityLabel, '기본 정보만 확인됨');
+    expect(results.single.dataQualityLabel, '기본 정보만 있음');
     expect(results.single.dataSourceLabel, '출처 공식 파일');
     expect(results.single.lines.single.name, '수도권 4호선');
   });
@@ -451,7 +475,7 @@ void main() {
     expect(detail.nameKo, '상록수');
     expect(detail.latitude, 37.302795);
     expect(detail.longitude, 126.866489);
-    expect(detail.dataQualityLabel, '기본 정보만 확인됨');
+    expect(detail.dataQualityLabel, '기본 정보만 있음');
     expect(detail.dataSourceLabel, '출처 공식 파일');
     expect(detail.lines.single.stationCode, '448');
     expect(exits.single.name, '1번 출구');
@@ -530,7 +554,7 @@ void main() {
     expect(favorites.single.stationId, 'station-sangnoksu');
     expect(favorites.single.nameKo, '상록수');
     expect(favorites.single.lineLabel, '수도권 4호선');
-    expect(favorites.single.dataQualityLabel, '기본 정보만 확인됨');
+    expect(favorites.single.dataQualityLabel, '기본 정보만 있음');
     expect(favorites.single.dataSourceLabel, '출처 공식 파일');
   });
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -608,15 +608,13 @@ void main() {
       expect(find.text('즐겨찾기 역'), findsOneWidget);
       expect(find.text('상록수'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
-      expect(find.text('기본 정보만 확인됨'), findsOneWidget);
+      expect(find.text('기본 정보만 있음'), findsOneWidget);
       expect(
         find.byKey(const Key('favoriteStationTile-station-sangnoksu')),
         findsOneWidget,
       );
       expect(
-        find.bySemanticsLabel(
-          '즐겨찾기 역, 상록수, 수도권 4호선, 수도권, 기본 정보만 확인됨, 출처 공식 파일',
-        ),
+        find.bySemanticsLabel('즐겨찾기 역, 상록수, 수도권 4호선, 수도권, 기본 정보만 있음, 출처 공식 파일'),
         findsOneWidget,
       );
       expect(find.text('출처 공식 파일'), findsOneWidget);
@@ -854,18 +852,18 @@ void main() {
       );
       expect(find.text('경의중앙'), findsOneWidget);
       expect(find.text('수도권 4호선, 경의중앙선'), findsOneWidget);
-      expect(find.text('기본 정보만 확인됨'), findsOneWidget);
+      expect(find.text('기본 정보만 있음'), findsOneWidget);
       expect(find.bySemanticsLabel('검색 결과 1개'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 확인됨'),
+        find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
         findsOneWidget,
       );
       expect(
         tester.getSemantics(
-          find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 확인됨'),
+          find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
         ),
         isSemantics(
-          label: '상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 확인됨',
+          label: '상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음',
           isButton: true,
           hasTapAction: true,
         ),
@@ -1127,7 +1125,7 @@ void main() {
       expect(find.text('상록수'), findsOneWidget);
       expect(find.text('230m 거리'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('상록수, 230m 거리, 수도권 2호선, 수도권, 기본 정보만 확인됨'),
+        find.bySemanticsLabel('상록수, 230m 거리, 수도권 2호선, 수도권, 기본 정보만 있음'),
         findsOneWidget,
       );
 
@@ -1377,12 +1375,12 @@ void main() {
       expect(repository.requestedFacilityStationIds, ['station-sangnoksu']);
       expect(find.text('상록수역'), findsOneWidget);
       expect(find.text('수도권 2호선'), findsOneWidget);
-      expect(find.text('기본 정보만 확인됨'), findsOneWidget);
+      expect(find.text('기본 정보만 있음'), findsOneWidget);
       expect(find.text('출처 공식 파일'), findsWidgets);
       expect(find.text('마지막 확인 2026-06-13'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
-          '상록수역 상세 정보, 수도권 2호선, 기본 정보만 확인됨, 출처 공식 파일, 마지막 확인 2026-06-13',
+          '상록수역 상세 정보, 수도권 2호선, 기본 정보만 있음, 출처 공식 파일, 마지막 확인 2026-06-13',
         ),
         findsOneWidget,
       );
@@ -1880,10 +1878,10 @@ void main() {
       await tester.pumpAndSettle();
       expect(
         tester.getSemantics(
-          find.bySemanticsLabel('출발역 선택, 상록수, 수도권 2호선, 수도권, 기본 정보만 확인됨'),
+          find.bySemanticsLabel('출발역 선택, 상록수, 수도권 2호선, 수도권, 기본 정보만 있음'),
         ),
         isSemantics(
-          label: '출발역 선택, 상록수, 수도권 2호선, 수도권, 기본 정보만 확인됨',
+          label: '출발역 선택, 상록수, 수도권 2호선, 수도권, 기본 정보만 있음',
           isButton: true,
           hasTapAction: true,
         ),
@@ -1940,11 +1938,11 @@ void main() {
       expect(find.text('약 4분 · 180m · 접근성 확인'), findsOneWidget);
       expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('출발역 선택됨, 상록수, 수도권 2호선, 수도권, 기본 정보만 확인됨'),
+        find.bySemanticsLabel('출발역 선택됨, 상록수, 수도권 2호선, 수도권, 기본 정보만 있음'),
         findsOneWidget,
       );
       expect(
-        find.bySemanticsLabel('도착역 선택됨, 사당, 수도권 2호선, 수도권, 기본 정보만 확인됨'),
+        find.bySemanticsLabel('도착역 선택됨, 사당, 수도권 2호선, 수도권, 기본 정보만 있음'),
         findsOneWidget,
       );
       expect(


### PR DESCRIPTION
## 관련 이슈

Closes #174

## 배경

역 검색과 역 상세에서 데이터 품질을 보여줄 때 내부 레벨 값의 의미가 사용자에게 바로 전달되어야 합니다. 특히 정보가 부족한 역은 사용자가 앱 안내를 어디까지 믿어도 되는지 빠르게 판단할 수 있어야 하므로, 라벨을 더 짧고 행동 판단이 쉬운 문구로 정리했습니다.

## 변경 사항

- 모바일 앱의 데이터 품질 라벨을 쉬운 문구로 변경했습니다.
  - `LEVEL_1`: `기본 정보만 있음`
  - `LEVEL_2`: `시설 정보 확인됨`
  - `LEVEL_3`: `쉬운 길 안내 가능`
  - `LEVEL_4`: `고장·공사 반영됨`
  - 알 수 없는 값: `정보 확인 필요`
- 역 검색 결과, 역 상세, 즐겨찾기 역의 스크린리더 문구가 같은 라벨을 쓰도록 테스트 기대값을 갱신했습니다.
- 내부 레벨 값과 사용자 표시 문구의 매핑을 고정하는 단위 테스트를 추가했습니다.

## 검증

- RED 확인
  - `flutter test test/station_search_test.dart --plain-name '역 데이터 품질은 내부 레벨을 쉬운 안내 문구로 바꾼다'`
  - `flutter test test/widget_test.dart --plain-name '역 검색은 접근성 표시가 포함된 백엔드 결과를 보여준다'`
- GREEN 확인
  - `flutter test test/station_search_test.dart`
  - `flutter test test/widget_test.dart`
  - `flutter analyze`
  - `flutter test`
  - `node --test tools/ci/*.test.mjs`
  - `git diff --check`
  - `git ls-files '*.md'`
  - `flutter build apk --debug`
  - `flutter build ios --simulator --no-codesign`
- Android 에뮬레이터 실제 화면 확인
  - 검색 결과 스크린리더 문구: `상록수, 수도권 4호선, 수도권, 기본 정보만 있음`
  - 역 상세 스크린리더 문구: `상록수역 상세 정보, 수도권 4호선, 기본 정보만 있음, 출처 공식 파일, 마지막 확인 2026-06-12`
  - 스크린샷: `/tmp/easysubway-data-quality-current.png`

## 리스크

- API 계약 값은 그대로 유지하고 앱 표시 문구만 바꿨습니다.
- 기존 사용자에게는 같은 데이터 상태가 조금 다른 문구로 보입니다.

## 체크리스트

- [x] 사용자 화면에 내부 레벨 값이 노출되지 않음
- [x] 스크린리더 문구가 새 라벨을 사용함
- [x] Android 실제 화면 확인
- [x] iOS 시뮬레이터 빌드 확인
- [x] CI 통과 확인
- [x] 코드 리뷰 확인
- [x] merge 후 CD 확인
