### PR TITLE
[Feat] 관리자 중복 신고 기준 기록

### DIFF
--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -54,9 +54,12 @@ class FacilityReportAdminPageController {
 	String reviewReportFromPage(
 		@PathVariable String reportId,
 		@RequestParam FacilityReportReviewDecision decision,
+		@RequestParam(required = false) String duplicateOfReportId,
 		Principal principal
 	) {
-		facilityReportUseCase.reviewReport(new ReviewFacilityReportCommand(reportId, decision, principal.getName()));
+		facilityReportUseCase.reviewReport(
+			new ReviewFacilityReportCommand(reportId, decision, principal.getName(), duplicateOfReportId)
+		);
 		return "redirect:/admin/reports/%s/page".formatted(reportId);
 	}
 
@@ -154,6 +157,7 @@ class FacilityReportAdminPageController {
 		String photoFileName,
 		String photoContentType,
 		String photoDataBase64,
+		String duplicateOfReportId,
 		String coordinateLabel
 	) {
 
@@ -172,6 +176,7 @@ class FacilityReportAdminPageController {
 				report.photoFileName(),
 				report.photoContentType(),
 				report.photoDataBase64(),
+				report.duplicateOfReportId(),
 				FacilityReportAdminPageController.coordinateLabel(report.latitude(), report.longitude())
 			);
 		}

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
@@ -108,11 +108,12 @@ class FacilityReportController {
 	}
 
 	record ReviewFacilityReportRequest(
-		FacilityReportReviewDecision decision
+		FacilityReportReviewDecision decision,
+		String duplicateOfReportId
 	) {
 
 		ReviewFacilityReportCommand toCommand(String reportId, String reviewedBy) {
-			return new ReviewFacilityReportCommand(reportId, decision, reviewedBy);
+			return new ReviewFacilityReportCommand(reportId, decision, reviewedBy, duplicateOfReportId);
 		}
 	}
 
@@ -127,6 +128,7 @@ class FacilityReportController {
 		String photoContentType,
 		BigDecimal latitude,
 		BigDecimal longitude,
+		String duplicateOfReportId,
 		FacilityReportStatus status,
 		LocalDateTime createdAt,
 		LocalDateTime reviewedAt,
@@ -145,6 +147,7 @@ class FacilityReportController {
 				report.photoContentType(),
 				report.latitude(),
 				report.longitude(),
+				report.duplicateOfReportId(),
 				report.status(),
 				report.createdAt(),
 				report.reviewedAt(),
@@ -164,6 +167,7 @@ class FacilityReportController {
 		String photoContentType,
 		BigDecimal latitude,
 		BigDecimal longitude,
+		String duplicateOfReportId,
 		FacilityReportStatus status,
 		LocalDateTime createdAt,
 		LocalDateTime reviewedAt,
@@ -183,6 +187,7 @@ class FacilityReportController {
 				report.photoContentType(),
 				report.latitude(),
 				report.longitude(),
+				report.duplicateOfReportId(),
 				report.status(),
 				report.createdAt(),
 				report.reviewedAt(),
@@ -203,6 +208,7 @@ class FacilityReportController {
 		String photoDataBase64,
 		BigDecimal latitude,
 		BigDecimal longitude,
+		String duplicateOfReportId,
 		FacilityReportStatus status,
 		LocalDateTime createdAt,
 		LocalDateTime reviewedAt,
@@ -222,6 +228,7 @@ class FacilityReportController {
 				report.photoDataBase64(),
 				report.latitude(),
 				report.longitude(),
+				report.duplicateOfReportId(),
 				report.status(),
 				report.createdAt(),
 				report.reviewedAt(),

--- a/backend/src/main/java/com/easysubway/report/application/port/in/ReviewFacilityReportCommand.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/in/ReviewFacilityReportCommand.java
@@ -5,6 +5,15 @@ import com.easysubway.report.domain.FacilityReportReviewDecision;
 public record ReviewFacilityReportCommand(
 	String reportId,
 	FacilityReportReviewDecision decision,
-	String reviewedBy
+	String reviewedBy,
+	String duplicateOfReportId
 ) {
+
+	public ReviewFacilityReportCommand(
+		String reportId,
+		FacilityReportReviewDecision decision,
+		String reviewedBy
+	) {
+		this(reportId, decision, reviewedBy, null);
+	}
 }

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -176,6 +176,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 			photoDataBase64,
 			command.latitude(),
 			command.longitude(),
+			null,
 			FacilityReportStatus.SUBMITTED,
 			LocalDateTime.now(clock),
 			null,
@@ -213,6 +214,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 		requireReviewer(command);
 
 		FacilityReport report = getReport(command.reportId());
+		String duplicateOfReportId = resolveDuplicateOfReportId(command, report);
 		FacilityReport reviewed = new FacilityReport(
 			report.id(),
 			report.userId(),
@@ -225,6 +227,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 			report.photoDataBase64(),
 			report.latitude(),
 			report.longitude(),
+			duplicateOfReportId,
 			toStatus(command.decision()),
 			report.createdAt(),
 			LocalDateTime.now(clock),
@@ -336,6 +339,22 @@ public class FacilityReportService implements FacilityReportUseCase {
 		if (command.reviewedBy() == null || command.reviewedBy().isBlank()) {
 			throw new InvalidFacilityReportException("검수자 식별자가 필요합니다.");
 		}
+	}
+
+	private String resolveDuplicateOfReportId(ReviewFacilityReportCommand command, FacilityReport report) {
+		if (command.decision() != FacilityReportReviewDecision.MARK_DUPLICATE) {
+			return null;
+		}
+		String duplicateOfReportId = normalizeDuplicateOfReportId(command.duplicateOfReportId());
+		if (duplicateOfReportId == null || duplicateOfReportId.equals(report.id())) {
+			throw new InvalidFacilityReportException("기준 신고를 확인해야 합니다.");
+		}
+		getReport(duplicateOfReportId);
+		return duplicateOfReportId;
+	}
+
+	private String normalizeDuplicateOfReportId(String duplicateOfReportId) {
+		return hasText(duplicateOfReportId) ? duplicateOfReportId.trim() : null;
 	}
 
 	private void requireActiveStation(String stationId) {

--- a/backend/src/main/java/com/easysubway/report/domain/FacilityReport.java
+++ b/backend/src/main/java/com/easysubway/report/domain/FacilityReport.java
@@ -15,6 +15,7 @@ public record FacilityReport(
 	String photoDataBase64,
 	BigDecimal latitude,
 	BigDecimal longitude,
+	String duplicateOfReportId,
 	FacilityReportStatus status,
 	LocalDateTime createdAt,
 	LocalDateTime reviewedAt,

--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -156,6 +156,8 @@
 			<dd th:text="${report.reviewedBy != null ? report.reviewedBy : '없음'}">없음</dd>
 			<dt>검수일</dt>
 			<dd th:text="${report.reviewedAt != null ? report.reviewedAt : '없음'}">없음</dd>
+			<dt>기준 신고</dt>
+			<dd th:text="${report.duplicateOfReportId != null ? report.duplicateOfReportId : '없음'}">없음</dd>
 		</dl>
 	</section>
 
@@ -163,6 +165,10 @@
 	      th:action="@{/admin/reports/{reportId}/page/review(reportId=${report.id})}"
 	      method="post">
 		<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+		<label>
+			기준 신고 ID
+			<input name="duplicateOfReportId" type="text" autocomplete="off" placeholder="중복 처리할 때 입력">
+		</label>
 		<button type="submit" name="decision" value="ACCEPT">승인</button>
 		<button class="danger" type="submit" name="decision" value="REJECT">반려</button>
 		<button class="secondary" type="submit" name="decision" value="MARK_DUPLICATE">중복 처리</button>

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -99,6 +99,34 @@ class FacilityReportAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 상세 화면에서 중복 처리 기준 신고를 확인한다")
+	void adminReportDetailPageShowsDuplicateOriginalReport() throws Exception {
+		String originalReportId = createReport("먼저 접수된 고장 신고");
+		String duplicatedReportId = createReport("같은 시설에 대해 다시 들어온 신고");
+
+		mockMvc.perform(post("/admin/reports/{reportId}/page/review", duplicatedReportId)
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("decision", "MARK_DUPLICATE")
+				.param("duplicateOfReportId", originalReportId))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(header().string("Location", "/admin/reports/%s/page".formatted(duplicatedReportId)));
+
+		String html = mockMvc.perform(get("/admin/reports/{reportId}/page", duplicatedReportId)
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("중복")
+			.contains("기준 신고")
+			.contains(originalReportId);
+	}
+
+	@Test
 	@DisplayName("관리자 신고 화면은 관리자 인증을 요구한다")
 	void adminReportPagesRequireAdminAuthentication() throws Exception {
 		String reportId = createReport("인증 검증용 신고");

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -303,6 +303,54 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 중복 신고를 기준 신고와 함께 처리한다")
+	void reviewReportMarksDuplicateWithOriginalReport() throws Exception {
+		String originalReportId = createReport("anonymous-user-original", "먼저 접수된 고장 신고");
+		String duplicatedReportId = createReport("anonymous-user-duplicated", "같은 시설에 대해 다시 들어온 신고");
+
+		mockMvc.perform(post("/admin/reports/{reportId}/review", duplicatedReportId)
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "decision": "MARK_DUPLICATE",
+					  "duplicateOfReportId": "%s"
+					}
+					""".formatted(originalReportId)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.id").value(duplicatedReportId))
+			.andExpect(jsonPath("$.data.status").value("DUPLICATE"))
+			.andExpect(jsonPath("$.data.duplicateOfReportId").value(originalReportId));
+
+		mockMvc.perform(get("/admin/reports/{reportId}", duplicatedReportId)
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.duplicateOfReportId").value(originalReportId));
+	}
+
+	@Test
+	@DisplayName("중복 신고 검수는 기준 신고 식별자를 요구한다")
+	void duplicateReviewRequiresOriginalReportId() throws Exception {
+		String duplicatedReportId = createReport("anonymous-user-duplicated", "기준 신고 없이 중복 처리할 신고");
+
+		mockMvc.perform(post("/admin/reports/{reportId}/review", duplicatedReportId)
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "decision": "MARK_DUPLICATE"
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("기준 신고를 확인해야 합니다."));
+	}
+
+	@Test
 	@DisplayName("존재하지 않는 신고 검수는 공통 404 응답을 반환한다")
 	void reviewReportReturnsCommonErrorForMissingReport() throws Exception {
 		mockMvc.perform(post("/admin/reports/missing-report/review")

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -249,6 +249,7 @@ class FacilityReportServiceTest {
 			null,
 			null,
 			null,
+			null,
 			FacilityReportStatus.SUBMITTED,
 			LocalDateTime.of(2026, 6, 12, 9, 0),
 			null,
@@ -553,7 +554,12 @@ class FacilityReportServiceTest {
 			FacilityReportType.CLOSED,
 			"중복 처리할 폐쇄 신고입니다."
 		));
-		serviceWithFacilityStatus.reviewReport(reviewCommand(duplicated.id(), FacilityReportReviewDecision.MARK_DUPLICATE));
+		serviceWithFacilityStatus.reviewReport(new ReviewFacilityReportCommand(
+			duplicated.id(),
+			FacilityReportReviewDecision.MARK_DUPLICATE,
+			"admin-1",
+			rejected.id()
+		));
 		assertThat(facilityStatus(transitRepository, "facility-sangnoksu-elevator-1"))
 			.isEqualTo(AccessibilityFacilityStatus.NORMAL);
 	}
@@ -594,8 +600,62 @@ class FacilityReportServiceTest {
 		assertThat(service.reviewReport(new ReviewFacilityReportCommand(
 			duplicated.id(),
 			FacilityReportReviewDecision.MARK_DUPLICATE,
-			"admin-1"
+			"admin-1",
+			rejected.id()
 		)).status()).isEqualTo(FacilityReportStatus.DUPLICATE);
+	}
+
+	@Test
+	@DisplayName("중복 처리된 신고는 기준 신고 식별자를 함께 저장한다")
+	void duplicateReportStoresMergedReportId() {
+		var original = service.createReport(reportCommand(
+			"anonymous-user-original",
+			FacilityReportType.BROKEN,
+			"먼저 접수된 고장 신고입니다."
+		));
+		var duplicated = service.createReport(reportCommand(
+			"anonymous-user-duplicated",
+			FacilityReportType.BROKEN,
+			"같은 시설에 대해 다시 들어온 신고입니다."
+		));
+
+		var reviewed = service.reviewReport(new ReviewFacilityReportCommand(
+			duplicated.id(),
+			FacilityReportReviewDecision.MARK_DUPLICATE,
+			"admin-1",
+			original.id()
+		));
+
+		assertThat(reviewed.status()).isEqualTo(FacilityReportStatus.DUPLICATE);
+		assertThat(reviewed.duplicateOfReportId()).isEqualTo(original.id());
+		assertThat(service.getReport(duplicated.id()).duplicateOfReportId()).isEqualTo(original.id());
+	}
+
+	@Test
+	@DisplayName("중복 처리는 존재하는 다른 신고를 기준으로 요구한다")
+	void duplicateReviewRequiresExistingDifferentReport() {
+		var report = service.createReport(reportCommand(
+			"anonymous-user-duplicated",
+			FacilityReportType.BROKEN,
+			"중복 처리할 신고입니다."
+		));
+
+		assertThatThrownBy(() -> service.reviewReport(new ReviewFacilityReportCommand(
+			report.id(),
+			FacilityReportReviewDecision.MARK_DUPLICATE,
+			"admin-1",
+			"missing-report"
+		)))
+			.isInstanceOf(FacilityReportNotFoundException.class)
+			.hasMessage("신고 정보를 찾을 수 없습니다.");
+		assertThatThrownBy(() -> service.reviewReport(new ReviewFacilityReportCommand(
+			report.id(),
+			FacilityReportReviewDecision.MARK_DUPLICATE,
+			"admin-1",
+			report.id()
+		)))
+			.isInstanceOf(InvalidFacilityReportException.class)
+			.hasMessage("기준 신고를 확인해야 합니다.");
 	}
 
 	@Test
@@ -710,7 +770,7 @@ class FacilityReportServiceTest {
 	}
 
 	private ReviewFacilityReportCommand reviewCommand(String reportId, FacilityReportReviewDecision decision) {
-		return new ReviewFacilityReportCommand(reportId, decision, "admin-1");
+		return new ReviewFacilityReportCommand(reportId, decision, "admin-1", null);
 	}
 
 	private AccessibilityFacilityStatus facilityStatus(


### PR DESCRIPTION
## 관련 이슈

close #178

## 작업 배경

시설 신고 검수에서 중복 상태는 남길 수 있지만, 어떤 신고를 기준으로 중복 처리했는지 기록할 수 없었습니다. 같은 시설 신고가 반복 접수되는 운영 상황에서는 기준 신고 ID가 남아야 후속 처리와 문의 대응이 가능합니다.

## 작업 내용

- 중복 처리 검수 요청에 기준 신고 ID를 포함하도록 관리자 API 계약을 확장했습니다.
- 중복 처리된 신고에 기준 신고 ID를 저장하고 관리자 상세 화면에서 확인할 수 있게 했습니다.
- 존재하지 않는 기준 신고나 자기 자신을 기준으로 지정한 요청은 공통 오류로 막았습니다.
- 승인/반려 흐름과 기존 시설 상태 반영 흐름은 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests '*FacilityReport*'`
  - `node --test tools/ci/*.test.mjs`
  - `git diff --check`
  - `git ls-files '*.md'`

## 리뷰어 메모

- `MARK_DUPLICATE`일 때만 기준 신고 ID를 요구하고, `ACCEPT`/`REJECT`에서는 기존 요청 본문이 그대로 동작하는지 확인해 주세요.
- 공개 모바일 상태 조회에는 기준 신고 ID가 상태 추적 정보로 포함되지만 사진 본문 노출 정책은 바뀌지 않습니다.

## 리스크

- 현재 저장소가 인메모리라 실제 DB 컬럼 추가는 별도 영구 저장소 작업에서 필요합니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
