### PR TITLE
[Fix] 위치 비활성 안내 문구 개선

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -16,7 +16,7 @@ const _facilityReportListErrorMessage = '신고 내역을 불러오지 못했습
 const _anonymousReportUserId = 'anonymous-mobile-user';
 const _facilityReportPhotoTooLargeMessage = '사진이 너무 큽니다. 다른 사진을 선택해 주세요.';
 const _facilityReportLocationDisabledMessage =
-    '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.';
+    '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
 const _facilityReportDraftTargetStorageKey =
     'easysubway.facilityReport.draftTarget';
 

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -12,7 +12,7 @@ import 'mobile_error_reporter.dart';
 const _stationSearchTimeout = Duration(seconds: 8);
 const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
 const _currentLocationDisabledMessage =
-    '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.';
+    '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
 const _favoriteStationTimeout = Duration(seconds: 8);
 const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했습니다.';
 const _favoriteStationStatusErrorMessage = '즐겨찾기를 확인하지 못했습니다.';

--- a/apps/mobile/test/current_location_provider_test.dart
+++ b/apps/mobile/test/current_location_provider_test.dart
@@ -39,7 +39,7 @@ void main() {
         isA<CurrentLocationException>().having(
           (error) => error.message,
           'message',
-          '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.',
+          '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
         ),
       ),
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1257,7 +1257,7 @@ void main() {
   testWidgets('역 검색은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다', (tester) async {
     final locationProvider = FakeCurrentLocationProvider(
       error: const CurrentLocationException(
-        '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.',
+        '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
       ),
       needsPermissionRequest: false,
     );
@@ -1280,7 +1280,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text('기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.'),
+      find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'),
       findsOneWidget,
     );
     expect(
@@ -3200,7 +3200,7 @@ void main() {
             requestCount++;
             if (requestCount == 1) {
               throw const FacilityReportLocationException(
-                '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.',
+                '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
               );
             }
             if (requestCount == 2) {
@@ -3250,7 +3250,7 @@ void main() {
       requestCount++;
       if (requestCount == 1) {
         throw const FacilityReportLocationException(
-          '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.',
+          '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
         );
       }
       return const FacilityReportLocation(
@@ -3285,7 +3285,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text('기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.'),
+      find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'),
       findsOneWidget,
     );
     final failedLocationSubmitButton = tester.widget<FilledButton>(
@@ -3314,7 +3314,7 @@ void main() {
     final reportRepository = FakeFacilityReportRepository();
     final locationProvider = FakeCurrentLocationProvider(
       error: const CurrentLocationException(
-        '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.',
+        '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
       ),
       needsPermissionRequest: false,
     );
@@ -3382,7 +3382,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text('기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.'),
+      find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'),
       findsOneWidget,
     );
     expect(find.text('현재 위치 첨부됨'), findsNothing);
@@ -3411,7 +3411,7 @@ void main() {
     final reportRepository = FakeFacilityReportRepository();
     final locationProvider = FakeCurrentLocationProvider(
       error: const CurrentLocationException(
-        '기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.',
+        '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
       ),
       needsPermissionRequest: false,
     );
@@ -3477,7 +3477,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text('기기 위치를 켜고 다시 확인해 주세요. 위치가 없으면 가까운 역을 찾기 어렵습니다.'),
+      find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'),
       findsOneWidget,
     );
     expect(


### PR DESCRIPTION
## 관련 이슈
close #180

## 요약
- GPS가 꺼진 상태의 위치 안내 문구를 행동이 먼저 보이도록 정리했습니다.
- 역 검색과 시설 신고에서 같은 안내 문구를 사용하도록 맞췄습니다.
- 시설 신고 화면의 자동 위치 수집, GPS 비활성 시 제출 차단, 위치 설정 이동 동작은 유지했습니다.

## 변경 사항
- 위치 비활성 안내 문구를 `기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.`로 변경
- 현재 위치 제공자, 역 검색, 시설 신고 위젯 테스트 기대값 갱신
- `현재 위치 첨부됨`류 상태 문구가 노출되지 않는 기존 검증 유지

## 검증
- `flutter test test/current_location_provider_test.dart test/widget_test.dart --plain-name "GPS가 꺼져 있으면"`
- `flutter test`
- `flutter analyze`
- `git diff --check`
- Android Emulator: `emulator-5554`에서 위치 서비스를 끈 뒤 역 검색 화면의 GPS 안내 문구와 `위치 설정 열기` 버튼 노출 확인

## 리스크
- 문구 변경만 포함되어 API 계약과 저장 데이터에는 영향이 없습니다.
