### PR TITLE
[Feat] 관리자 신고 검수 감사 로그 기록

### DIFF
--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -3,6 +3,7 @@ package com.easysubway.report.adapter.in.web;
 import com.easysubway.report.application.port.in.FacilityReportUseCase;
 import com.easysubway.report.application.port.in.ReviewFacilityReportCommand;
 import com.easysubway.report.domain.FacilityReport;
+import com.easysubway.report.domain.FacilityReportReviewAudit;
 import com.easysubway.report.domain.FacilityReportReviewDecision;
 import com.easysubway.report.domain.FacilityReportStatus;
 import com.easysubway.report.domain.FacilityReportType;
@@ -46,6 +47,13 @@ class FacilityReportAdminPageController {
 	@GetMapping("/admin/reports/{reportId}/page")
 	String reportDetailPage(@PathVariable String reportId, Model model) {
 		model.addAttribute("report", FacilityReportDetailPageView.from(facilityReportUseCase.getReport(reportId)));
+		model.addAttribute(
+			"reviewAudits",
+			facilityReportUseCase.listReviewAudits(reportId)
+				.stream()
+				.map(FacilityReportReviewAuditPageRow::from)
+				.toList()
+		);
 		model.addAttribute("reviewActions", reviewActions());
 		return "admin/reports/detail";
 	}
@@ -96,6 +104,14 @@ class FacilityReportAdminPageController {
 			case REJECTED -> "반려됨";
 			case DUPLICATE -> "중복";
 			case RESOLVED -> "완료";
+		};
+	}
+
+	private static String reviewDecisionLabel(FacilityReportReviewDecision decision) {
+		return switch (decision) {
+			case ACCEPT -> "승인";
+			case REJECT -> "반려";
+			case MARK_DUPLICATE -> "중복 처리";
 		};
 	}
 
@@ -192,5 +208,24 @@ class FacilityReportAdminPageController {
 	}
 
 	record ReviewAction(FacilityReportReviewDecision value, String label) {
+	}
+
+	record FacilityReportReviewAuditPageRow(
+		String reviewerId,
+		String decisionLabel,
+		String previousStatusLabel,
+		String nextStatusLabel,
+		LocalDateTime createdAt
+	) {
+
+		static FacilityReportReviewAuditPageRow from(FacilityReportReviewAudit audit) {
+			return new FacilityReportReviewAuditPageRow(
+				audit.reviewerId(),
+				FacilityReportAdminPageController.reviewDecisionLabel(audit.decision()),
+				FacilityReportAdminPageController.statusLabel(audit.previousStatus()),
+				FacilityReportAdminPageController.statusLabel(audit.nextStatus()),
+				audit.createdAt()
+			);
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportReviewAuditRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportReviewAuditRepository.java
@@ -1,0 +1,32 @@
+package com.easysubway.report.adapter.out.persistence;
+
+import com.easysubway.report.application.port.out.LoadFacilityReportReviewAuditPort;
+import com.easysubway.report.application.port.out.SaveFacilityReportReviewAuditPort;
+import com.easysubway.report.domain.FacilityReportReviewAudit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryFacilityReportReviewAuditRepository implements
+	LoadFacilityReportReviewAuditPort,
+	SaveFacilityReportReviewAuditPort {
+
+	private final List<FacilityReportReviewAudit> audits = Collections.synchronizedList(new ArrayList<>());
+
+	@Override
+	public FacilityReportReviewAudit saveAudit(FacilityReportReviewAudit audit) {
+		audits.add(audit);
+		return audit;
+	}
+
+	@Override
+	public List<FacilityReportReviewAudit> loadAuditsByReportId(String reportId) {
+		synchronized (audits) {
+			return audits.stream()
+				.filter(audit -> audit.reportId().equals(reportId))
+				.toList();
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
@@ -1,6 +1,7 @@
 package com.easysubway.report.application.port.in;
 
 import com.easysubway.report.domain.FacilityReport;
+import com.easysubway.report.domain.FacilityReportReviewAudit;
 import com.easysubway.report.domain.FacilityReportStatus;
 import java.util.List;
 
@@ -15,4 +16,6 @@ public interface FacilityReportUseCase {
 	List<FacilityReport> listReports(FacilityReportStatus status);
 
 	FacilityReport reviewReport(ReviewFacilityReportCommand command);
+
+	List<FacilityReportReviewAudit> listReviewAudits(String reportId);
 }

--- a/backend/src/main/java/com/easysubway/report/application/port/out/LoadFacilityReportReviewAuditPort.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/out/LoadFacilityReportReviewAuditPort.java
@@ -1,0 +1,9 @@
+package com.easysubway.report.application.port.out;
+
+import com.easysubway.report.domain.FacilityReportReviewAudit;
+import java.util.List;
+
+public interface LoadFacilityReportReviewAuditPort {
+
+	List<FacilityReportReviewAudit> loadAuditsByReportId(String reportId);
+}

--- a/backend/src/main/java/com/easysubway/report/application/port/out/SaveFacilityReportReviewAuditPort.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/out/SaveFacilityReportReviewAuditPort.java
@@ -1,0 +1,8 @@
+package com.easysubway.report.application.port.out;
+
+import com.easysubway.report.domain.FacilityReportReviewAudit;
+
+public interface SaveFacilityReportReviewAuditPort {
+
+	FacilityReportReviewAudit saveAudit(FacilityReportReviewAudit audit);
+}

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -4,9 +4,12 @@ import com.easysubway.report.application.port.in.CreateFacilityReportCommand;
 import com.easysubway.report.application.port.in.FacilityReportUseCase;
 import com.easysubway.report.application.port.in.ReviewFacilityReportCommand;
 import com.easysubway.report.application.port.out.LoadFacilityReportPort;
+import com.easysubway.report.application.port.out.LoadFacilityReportReviewAuditPort;
 import com.easysubway.report.application.port.out.SaveFacilityReportPort;
+import com.easysubway.report.application.port.out.SaveFacilityReportReviewAuditPort;
 import com.easysubway.report.domain.FacilityReport;
 import com.easysubway.report.domain.FacilityReportNotFoundException;
+import com.easysubway.report.domain.FacilityReportReviewAudit;
 import com.easysubway.report.domain.FacilityReportReviewDecision;
 import com.easysubway.report.domain.FacilityReportStatus;
 import com.easysubway.report.domain.FacilityReportTargetNotFoundException;
@@ -51,8 +54,10 @@ public class FacilityReportService implements FacilityReportUseCase {
 	private final SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort;
 	private final LoadFacilityReportPort loadFacilityReportPort;
 	private final SaveFacilityReportPort saveFacilityReportPort;
+	private final LoadFacilityReportReviewAuditPort loadFacilityReportReviewAuditPort;
 	private final FacilityStatusAlertUseCase facilityStatusAlertUseCase;
 	private final ReportStatusAlertUseCase reportStatusAlertUseCase;
+	private final SaveFacilityReportReviewAuditPort saveFacilityReportReviewAuditPort;
 	private final Clock clock;
 
 	@Autowired
@@ -62,7 +67,9 @@ public class FacilityReportService implements FacilityReportUseCase {
 		LoadFacilityReportPort loadFacilityReportPort,
 		SaveFacilityReportPort saveFacilityReportPort,
 		FacilityStatusAlertUseCase facilityStatusAlertUseCase,
-		ReportStatusAlertUseCase reportStatusAlertUseCase
+		ReportStatusAlertUseCase reportStatusAlertUseCase,
+		SaveFacilityReportReviewAuditPort saveFacilityReportReviewAuditPort,
+		LoadFacilityReportReviewAuditPort loadFacilityReportReviewAuditPort
 	) {
 		this(
 			loadTransitMasterPort,
@@ -71,6 +78,8 @@ public class FacilityReportService implements FacilityReportUseCase {
 			saveFacilityReportPort,
 			facilityStatusAlertUseCase,
 			reportStatusAlertUseCase,
+			saveFacilityReportReviewAuditPort,
+			loadFacilityReportReviewAuditPort,
 			Clock.systemDefaultZone()
 		);
 	}
@@ -90,6 +99,8 @@ public class FacilityReportService implements FacilityReportUseCase {
 			facilityStatusAlertUseCase,
 			command -> {
 			},
+			audit -> audit,
+			reportId -> List.of(),
 			Clock.systemDefaultZone()
 		);
 	}
@@ -110,6 +121,8 @@ public class FacilityReportService implements FacilityReportUseCase {
 			},
 			command -> {
 			},
+			audit -> audit,
+			reportId -> List.of(),
 			clock
 		);
 	}
@@ -130,6 +143,8 @@ public class FacilityReportService implements FacilityReportUseCase {
 			facilityStatusAlertUseCase,
 			command -> {
 			},
+			audit -> audit,
+			reportId -> List.of(),
 			clock
 		);
 	}
@@ -143,12 +158,61 @@ public class FacilityReportService implements FacilityReportUseCase {
 		ReportStatusAlertUseCase reportStatusAlertUseCase,
 		Clock clock
 	) {
+		this(
+			loadTransitMasterPort,
+			saveAccessibilityFacilityStatusPort,
+			loadFacilityReportPort,
+			saveFacilityReportPort,
+			facilityStatusAlertUseCase,
+			reportStatusAlertUseCase,
+			audit -> audit,
+			reportId -> List.of(),
+			clock
+		);
+	}
+
+	public FacilityReportService(
+		LoadTransitMasterPort loadTransitMasterPort,
+		SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort,
+		LoadFacilityReportPort loadFacilityReportPort,
+		SaveFacilityReportPort saveFacilityReportPort,
+		FacilityStatusAlertUseCase facilityStatusAlertUseCase,
+		ReportStatusAlertUseCase reportStatusAlertUseCase,
+		SaveFacilityReportReviewAuditPort saveFacilityReportReviewAuditPort,
+		Clock clock
+	) {
+		this(
+			loadTransitMasterPort,
+			saveAccessibilityFacilityStatusPort,
+			loadFacilityReportPort,
+			saveFacilityReportPort,
+			facilityStatusAlertUseCase,
+			reportStatusAlertUseCase,
+			saveFacilityReportReviewAuditPort,
+			reportId -> List.of(),
+			clock
+		);
+	}
+
+	public FacilityReportService(
+		LoadTransitMasterPort loadTransitMasterPort,
+		SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort,
+		LoadFacilityReportPort loadFacilityReportPort,
+		SaveFacilityReportPort saveFacilityReportPort,
+		FacilityStatusAlertUseCase facilityStatusAlertUseCase,
+		ReportStatusAlertUseCase reportStatusAlertUseCase,
+		SaveFacilityReportReviewAuditPort saveFacilityReportReviewAuditPort,
+		LoadFacilityReportReviewAuditPort loadFacilityReportReviewAuditPort,
+		Clock clock
+	) {
 		this.loadTransitMasterPort = loadTransitMasterPort;
 		this.saveAccessibilityFacilityStatusPort = saveAccessibilityFacilityStatusPort;
 		this.loadFacilityReportPort = loadFacilityReportPort;
 		this.saveFacilityReportPort = saveFacilityReportPort;
+		this.loadFacilityReportReviewAuditPort = loadFacilityReportReviewAuditPort;
 		this.facilityStatusAlertUseCase = facilityStatusAlertUseCase;
 		this.reportStatusAlertUseCase = reportStatusAlertUseCase;
+		this.saveFacilityReportReviewAuditPort = saveFacilityReportReviewAuditPort;
 		this.clock = clock;
 	}
 
@@ -235,6 +299,16 @@ public class FacilityReportService implements FacilityReportUseCase {
 		);
 
 		FacilityReport saved = saveFacilityReportPort.saveReport(reviewed);
+		// 신고 상태 변경과 별개로 관리자 검수 행동 자체를 추적할 수 있게 별도 감사 로그를 남긴다.
+		saveFacilityReportReviewAuditPort.saveAudit(new FacilityReportReviewAudit(
+			"audit-" + UUID.randomUUID(),
+			saved.id(),
+			command.reviewedBy(),
+			command.decision(),
+			report.status(),
+			saved.status(),
+			saved.reviewedAt()
+		));
 		// 같은 결과로 재검수한 경우 사용자가 중복 처리 알림을 받지 않도록 상태 변경만 알린다.
 		if (report.status() != saved.status()) {
 			alertReportStatusChanged(saved);
@@ -242,6 +316,15 @@ public class FacilityReportService implements FacilityReportUseCase {
 		// 승인된 상태 신고만 실제 시설 운영 상태에 반영한다.
 		applyAcceptedReportToFacilityStatus(report, command.decision());
 		return saved;
+	}
+
+	@Override
+	public List<FacilityReportReviewAudit> listReviewAudits(String reportId) {
+		getReport(reportId);
+		return loadFacilityReportReviewAuditPort.loadAuditsByReportId(reportId)
+			.stream()
+			.sorted(Comparator.comparing(FacilityReportReviewAudit::createdAt))
+			.toList();
 	}
 
 	private void requireReporter(CreateFacilityReportCommand command) {

--- a/backend/src/main/java/com/easysubway/report/domain/FacilityReportReviewAudit.java
+++ b/backend/src/main/java/com/easysubway/report/domain/FacilityReportReviewAudit.java
@@ -1,0 +1,14 @@
+package com.easysubway.report.domain;
+
+import java.time.LocalDateTime;
+
+public record FacilityReportReviewAudit(
+	String id,
+	String reportId,
+	String reviewerId,
+	FacilityReportReviewDecision decision,
+	FacilityReportStatus previousStatus,
+	FacilityReportStatus nextStatus,
+	LocalDateTime createdAt
+) {
+}

--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -161,6 +161,31 @@
 		</dl>
 	</section>
 
+	<section>
+		<h2>감사 이력</h2>
+		<p th:if="${reviewAudits.isEmpty()}">없음</p>
+		<table th:if="${!reviewAudits.isEmpty()}">
+			<thead>
+			<tr>
+				<th>검수자</th>
+				<th>결정</th>
+				<th>이전 상태</th>
+				<th>이후 상태</th>
+				<th>기록일</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="audit : ${reviewAudits}">
+				<td th:text="${audit.reviewerId}">admin</td>
+				<td th:text="${audit.decisionLabel}">승인</td>
+				<td th:text="${audit.previousStatusLabel}">접수됨</td>
+				<td th:text="${audit.nextStatusLabel}">반영됨</td>
+				<td th:text="${audit.createdAt}">2026-06-15T10:00:00</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
 	<form class="review-form"
 	      th:action="@{/admin/reports/{reportId}/page/review(reportId=${report.id})}"
 	      method="post">

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -99,6 +99,33 @@ class FacilityReportAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 신고 상세 화면에서 검수 감사 이력을 확인한다")
+	void adminReportDetailPageShowsReviewAuditHistory() throws Exception {
+		String reportId = createReport("감사 이력을 확인할 신고");
+
+		mockMvc.perform(post("/admin/reports/{reportId}/page/review", reportId)
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("decision", "REJECT"))
+			.andExpect(status().is3xxRedirection());
+
+		String html = mockMvc.perform(get("/admin/reports/{reportId}/page", reportId)
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("감사 이력")
+			.contains("admin-test")
+			.contains("반려")
+			.contains("접수됨")
+			.contains("반려됨");
+	}
+
+	@Test
 	@DisplayName("관리자는 상세 화면에서 중복 처리 기준 신고를 확인한다")
 	void adminReportDetailPageShowsDuplicateOriginalReport() throws Exception {
 		String originalReportId = createReport("먼저 접수된 고장 신고");

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -7,8 +7,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.easysubway.report.adapter.out.persistence.InMemoryFacilityReportRepository;
 import com.easysubway.report.application.port.in.CreateFacilityReportCommand;
 import com.easysubway.report.application.port.in.ReviewFacilityReportCommand;
+import com.easysubway.report.application.port.out.LoadFacilityReportReviewAuditPort;
+import com.easysubway.report.application.port.out.SaveFacilityReportReviewAuditPort;
 import com.easysubway.report.domain.FacilityReport;
 import com.easysubway.report.domain.FacilityReportNotFoundException;
+import com.easysubway.report.domain.FacilityReportReviewAudit;
 import com.easysubway.report.domain.FacilityReportReviewDecision;
 import com.easysubway.report.domain.FacilityReportStatus;
 import com.easysubway.report.domain.FacilityReportTargetNotFoundException;
@@ -310,6 +313,116 @@ class FacilityReportServiceTest {
 		assertThat(reviewed.reviewedAt()).isEqualTo(LocalDateTime.of(2026, 6, 12, 9, 0));
 		assertThat(reviewed.reviewedBy()).isEqualTo("admin-1");
 		assertThat(service.getReport(report.id())).isEqualTo(reviewed);
+	}
+
+	@Test
+	@DisplayName("신고 검수는 관리자 행동을 감사 로그로 기록한다")
+	void reviewReportStoresAuditLogForReviewerDecision() {
+		var auditPort = new RecordingFacilityReportReviewAuditPort();
+		var repository = new InMemoryFacilityReportRepository();
+		var service = new FacilityReportService(
+			new InMemoryTransitMasterRepository(),
+			new InMemoryTransitMasterRepository(),
+			repository,
+			repository,
+			command -> {
+			},
+			command -> {
+			},
+			auditPort,
+			Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+		);
+		var report = service.createReport(reportCommand(
+			"anonymous-user-audit",
+			FacilityReportType.INFORMATION_WRONG,
+			"감사 로그를 남길 신고입니다."
+		));
+
+		service.reviewReport(new ReviewFacilityReportCommand(
+			report.id(),
+			FacilityReportReviewDecision.REJECT,
+			"admin-auditor"
+		));
+
+		assertThat(auditPort.savedAudits).hasSize(1);
+		FacilityReportReviewAudit audit = auditPort.savedAudits.getFirst();
+		assertThat(audit.reportId()).isEqualTo(report.id());
+		assertThat(audit.reviewerId()).isEqualTo("admin-auditor");
+		assertThat(audit.decision()).isEqualTo(FacilityReportReviewDecision.REJECT);
+		assertThat(audit.previousStatus()).isEqualTo(FacilityReportStatus.SUBMITTED);
+		assertThat(audit.nextStatus()).isEqualTo(FacilityReportStatus.REJECTED);
+		assertThat(audit.createdAt()).isEqualTo(LocalDateTime.of(2026, 6, 12, 9, 0));
+	}
+
+	@Test
+	@DisplayName("같은 신고를 다시 검수해도 관리자 행동은 감사 로그로 남긴다")
+	void repeatedReviewStoresAuditLogForEachReviewerAction() {
+		var auditPort = new RecordingFacilityReportReviewAuditPort();
+		var repository = new InMemoryFacilityReportRepository();
+		var service = new FacilityReportService(
+			new InMemoryTransitMasterRepository(),
+			new InMemoryTransitMasterRepository(),
+			repository,
+			repository,
+			command -> {
+			},
+			command -> {
+			},
+			auditPort,
+			Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+		);
+		var report = service.createReport(reportCommand(
+			"anonymous-user-repeat-audit",
+			FacilityReportType.INFORMATION_WRONG,
+			"반복 검수 감사 로그를 남길 신고입니다."
+		));
+
+		service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT));
+		service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT));
+
+		assertThat(auditPort.savedAudits)
+			.extracting(FacilityReportReviewAudit::previousStatus)
+			.containsExactly(FacilityReportStatus.SUBMITTED, FacilityReportStatus.REJECTED);
+		assertThat(auditPort.savedAudits)
+			.extracting(FacilityReportReviewAudit::nextStatus)
+			.containsExactly(FacilityReportStatus.REJECTED, FacilityReportStatus.REJECTED);
+	}
+
+	@Test
+	@DisplayName("신고 검수 감사 로그는 신고별로 조회한다")
+	void listReportReviewAuditsReturnsOnlyRequestedReportAudits() {
+		var auditPort = new RecordingFacilityReportReviewAuditPort();
+		var repository = new InMemoryFacilityReportRepository();
+		var service = new FacilityReportService(
+			new InMemoryTransitMasterRepository(),
+			new InMemoryTransitMasterRepository(),
+			repository,
+			repository,
+			command -> {
+			},
+			command -> {
+			},
+			auditPort,
+			auditPort,
+			Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+		);
+		var targetReport = service.createReport(reportCommand(
+			"anonymous-user-audit-target",
+			FacilityReportType.INFORMATION_WRONG,
+			"조회할 감사 로그를 남길 신고입니다."
+		));
+		var otherReport = service.createReport(reportCommand(
+			"anonymous-user-audit-other",
+			FacilityReportType.INFORMATION_WRONG,
+			"다른 신고입니다."
+		));
+
+		service.reviewReport(reviewCommand(targetReport.id(), FacilityReportReviewDecision.REJECT));
+		service.reviewReport(reviewCommand(otherReport.id(), FacilityReportReviewDecision.REJECT));
+
+		assertThat(service.listReviewAudits(targetReport.id()))
+			.extracting(FacilityReportReviewAudit::reportId)
+			.containsExactly(targetReport.id());
 	}
 
 	@Test
@@ -815,6 +928,25 @@ class FacilityReportServiceTest {
 		@Override
 		public void alertFacilityStatusChanged(FacilityStatusChangedAlertCommand command) {
 			commands.add(command);
+		}
+	}
+
+	private static class RecordingFacilityReportReviewAuditPort
+		implements SaveFacilityReportReviewAuditPort, LoadFacilityReportReviewAuditPort {
+
+		private final java.util.List<FacilityReportReviewAudit> savedAudits = new java.util.ArrayList<>();
+
+		@Override
+		public FacilityReportReviewAudit saveAudit(FacilityReportReviewAudit audit) {
+			savedAudits.add(audit);
+			return audit;
+		}
+
+		@Override
+		public java.util.List<FacilityReportReviewAudit> loadAuditsByReportId(String reportId) {
+			return savedAudits.stream()
+				.filter(audit -> audit.reportId().equals(reportId))
+				.toList();
 		}
 	}
 


### PR DESCRIPTION
close #182

## 요약
- 관리자 신고 검수 시 검수자, 결정, 이전/이후 상태, 기록 시각을 감사 로그로 저장합니다.
- 관리자 신고 상세 화면에서 신고별 검수 감사 이력을 확인할 수 있게 했습니다.
- 감사 로그 저장/조회 포트를 분리해 신고 도메인의 헥사고날 경계를 유지했습니다.

## 변경 사항
- `FacilityReportReviewAudit` 도메인 모델과 저장/조회 포트를 추가했습니다.
- 신고 검수 서비스가 상태 저장 직후 관리자 검수 행동을 감사 로그로 기록하도록 변경했습니다.
- 인메모리 감사 로그 저장소를 추가해 현재 개발/테스트 환경에서 신고별 감사 이력을 조회할 수 있게 했습니다.
- 관리자 신고 상세 화면에 감사 이력 표를 추가했습니다.
- 서비스 테스트와 관리자 화면 테스트에 감사 로그 저장/조회/표시 검증을 추가했습니다.

## 검증
- `./gradlew test`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`

## 리스크
- 현재 감사 로그 저장소는 인메모리 구현입니다. 운영 영속화는 DB 어댑터가 추가될 때 같은 포트를 구현하는 방식으로 확장해야 합니다.
