### PR TITLE
[Fix] 시설 신고 위치 확인 흐름 개선

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1095,7 +1095,6 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
   String _photoMessage = '';
   String _locationMessage = '';
   bool _isLoadingLocation = false;
-  bool _isLocationPreflightRunning = false;
   bool _isLocationFailure = false;
   bool _isOpeningLocationSettings = false;
   bool _isPhotoFailure = false;
@@ -1139,7 +1138,6 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
         isLoading ||
         hasSubmittedReport ||
         _isLoadingLocation ||
-        _isLocationPreflightRunning ||
         _isLocationFailure ||
         (widget.locationLoader != null && _attachedLocation == null);
 
@@ -1233,8 +1231,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
                     onPressed:
                         isLoading ||
                             _isOpeningLocationSettings ||
-                            _isLoadingLocation ||
-                            _isLocationPreflightRunning
+                            _isLoadingLocation
                         ? null
                         : _openLocationSettings,
                     icon: _isOpeningLocationSettings
@@ -1250,13 +1247,10 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
                 ],
                 OutlinedButton.icon(
                   key: const Key('facilityReportRetryLocationButton'),
-                  onPressed:
-                      isLoading ||
-                          _isLoadingLocation ||
-                          _isLocationPreflightRunning
+                  onPressed: isLoading || _isLoadingLocation
                       ? null
                       : _requestCurrentLocation,
-                  icon: _isLoadingLocation || _isLocationPreflightRunning
+                  icon: _isLoadingLocation
                       ? const SizedBox(
                           width: 22,
                           height: 22,
@@ -1344,27 +1338,6 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     return confirmed ?? false;
   }
 
-  Future<bool> _confirmLocationPermissionUse() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('위치 확인'),
-        content: const Text('가까운 역과 신고 위치를 확인합니다.'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('나중에'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('계속'),
-          ),
-        ],
-      ),
-    );
-    return confirmed ?? false;
-  }
-
   Future<bool> _confirmPhotoUse() async {
     final confirmed = await showDialog<bool>(
       context: context,
@@ -1395,32 +1368,11 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
   }
 
   Future<void> _requestCurrentLocation() async {
-    if (widget.locationLoader == null ||
-        _isLoadingLocation ||
-        _isLocationPreflightRunning) {
+    if (widget.locationLoader == null || _isLoadingLocation) {
       return;
     }
-    setState(() => _isLocationPreflightRunning = true);
-    try {
-      final needsPermissionRequest = await _needsLocationPermissionRequest();
-      if (!mounted) {
-        return;
-      }
-      if (needsPermissionRequest && !await _confirmLocationPermissionUse()) {
-        setState(() {
-          _attachedLocation = null;
-          _locationMessage = '위치 권한을 확인해 주세요.';
-          _isLocationFailure = true;
-        });
-        return;
-      }
-      // 권한 요청과 GPS 상태 확인은 네이티브 채널이 맡고, 화면은 실패 안내만 보여준다.
-      await _loadCurrentLocation();
-    } finally {
-      if (mounted) {
-        setState(() => _isLocationPreflightRunning = false);
-      }
-    }
+    // 권한 요청과 GPS 상태 확인은 네이티브 채널이 맡고, 화면은 실패 안내만 보여준다.
+    await _loadCurrentLocation();
   }
 
   Future<void> _openLocationSettings() async {
@@ -1436,14 +1388,6 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
         setState(() => _isOpeningLocationSettings = false);
       }
     }
-  }
-
-  Future<bool> _needsLocationPermissionRequest() async {
-    final checker = widget.needsLocationPermissionRequest;
-    if (checker == null) {
-      return true;
-    }
-    return checker();
   }
 
   Future<void> _pickPhoto() async {

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1247,7 +1247,10 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
                 ],
                 OutlinedButton.icon(
                   key: const Key('facilityReportRetryLocationButton'),
-                  onPressed: isLoading || _isLoadingLocation
+                  onPressed:
+                      isLoading ||
+                          _isOpeningLocationSettings ||
+                          _isLoadingLocation
                       ? null
                       : _requestCurrentLocation,
                   icon: _isLoadingLocation

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3155,7 +3155,11 @@ void main() {
             facilityTypeLabel: '엘리베이터',
             facilityStatusLabel: '정상',
           ),
-          needsLocationPermissionRequest: () async => true,
+          needsLocationPermissionRequest: () async {
+            throw AssertionError(
+              '시설 신고 화면은 위치 preflight checker를 호출하지 않아야 합니다.',
+            );
+          },
           locationLoader: () async {
             requestCount++;
             return const FacilityReportLocation(
@@ -3502,6 +3506,58 @@ void main() {
 
     expect(locationProvider.openSettingsCount, 1);
     expect(reportRepository.requests, isEmpty);
+  });
+
+  testWidgets('시설 신고 화면은 위치 설정을 여는 중 위치 재확인을 막는다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    final openSettingsCompleter = Completer<bool>();
+    var requestCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FacilityReportScreen(
+          repository: reportRepository,
+          target: const FacilityReportTarget(
+            stationId: 'station-sangnoksu',
+            stationName: '상록수',
+            facilityId: 'facility-sangnoksu-elevator-1',
+            facilityName: '1번 출구 엘리베이터',
+            facilityTypeLabel: '엘리베이터',
+            facilityStatusLabel: '정상',
+          ),
+          locationLoader: () async {
+            requestCount++;
+            throw const FacilityReportLocationException(
+              '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
+            );
+          },
+          needsLocationPermissionRequest: () async => false,
+          openLocationSettings: () => openSettingsCompleter.future,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.dragUntilVisible(
+      find.byKey(const Key('facilityReportOpenLocationSettingsButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const Key('facilityReportOpenLocationSettingsButton')),
+    );
+    await tester.pump();
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportRetryLocationButton')),
+    );
+    await tester.tap(find.byKey(const Key('facilityReportRetryLocationButton')));
+    await tester.pump();
+
+    expect(requestCount, 1);
+
+    openSettingsCompleter.complete(true);
+    await tester.pumpAndSettle();
   });
 
   testWidgets('시설 신고 화면은 현재 위치를 함께 보낸다', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3139,7 +3139,7 @@ void main() {
     );
   });
 
-  testWidgets('시설 신고 화면은 첫 위치 권한 요청 전에 짧은 목적 안내를 보여준다', (tester) async {
+  testWidgets('시설 신고 화면은 첫 위치 권한 요청도 화면 진입 시 자동으로 진행한다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
     var requestCount = 0;
 
@@ -3168,15 +3168,25 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('위치 확인'), findsOneWidget);
-    expect(find.text('가까운 역과 신고 위치를 확인합니다.'), findsOneWidget);
-    expect(requestCount, 0);
-
-    await tester.tap(find.text('계속'));
-    await tester.pumpAndSettle();
-
     expect(requestCount, 1);
     expect(find.text('위치 확인'), findsNothing);
+    expect(find.text('가까운 역과 신고 위치를 확인합니다.'), findsNothing);
+    expect(find.text('현재 위치 첨부됨'), findsNothing);
+
+    await tester.ensureVisible(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('facilityReportDescriptionInput')),
+      '권한 요청 후 바로 확인된 위치입니다.',
+    );
+    await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(reportRepository.requests, hasLength(1));
+    expect(reportRepository.requests.single.latitude, 37.302421);
+    expect(reportRepository.requests.single.longitude, 126.866221);
   });
 
   testWidgets('시설 신고 화면은 위치 재확인 중 중복 탭을 무시한다', (tester) async {


### PR DESCRIPTION
## 관련 이슈
Closes #188

## 요약
시설 신고 화면에서 위치 권한 요청 전 별도 확인 팝업을 띄우던 흐름을 제거했습니다. 화면 진입 시 네이티브 위치 요청으로 바로 이어지며, 위치 확인이 성공하면 별도 첨부 문구 없이 신고 요청에 좌표만 포함됩니다.

GPS가 꺼져 있거나 위치 확인에 실패한 경우에는 기존처럼 신고 제출을 막고, 사용자가 바로 조치할 수 있도록 GPS 안내와 위치 설정/재시도 버튼을 보여줍니다.

## 변경 사항
- 시설 신고 화면의 위치 사전 확인 다이얼로그 제거
- 위치 로딩 중복 방지 상태를 실제 위치 요청 상태로 단순화
- 첫 위치 권한 요청이 필요한 경우에도 자동 위치 확인과 좌표 전송이 이어지는 위젯 테스트 갱신

## 검증
- `flutter test --plain-name "시설 신고 화면은 첫 위치 권한 요청도 화면 진입 시 자동으로 진행한다"`
- `flutter test`
- `flutter analyze`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`
- Android 에뮬레이터 확인
  - GPS 켜짐: 상록수역 시설 신고 화면에서 별도 위치 첨부 문구 없이 신고 버튼 활성화 확인
  - GPS 꺼짐: GPS 안내, 위치 설정 열기, 위치 다시 확인 버튼 노출 확인

## 리스크
- 위치 권한 요청의 사전 설명은 제거되지만, 실제 권한 요청과 GPS 상태 확인은 기존 네이티브 채널이 처리합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 시설 신고 화면의 위치 정보 처리 흐름을 단순화했습니다.
  * 위치 권한 요청 절차가 더욱 간결하고 직관적으로 작동합니다.
  * 사용자 인터페이스가 개선되어 신고 절차가 보다 신속하게 진행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->