### PR TITLE
[Feat] 내 신고 상세 상태 화면 추가

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -980,60 +980,177 @@ class _MyReportListItem extends StatelessWidget {
     return Semantics(
       label:
           '내 신고, ${report.reportTypeLabel}, 접수번호 ${report.id}, ${report.statusLabel}, $description, 접수일 $createdAtLabel',
-      button: false,
+      button: true,
       child: ExcludeSemantics(
-        child: DecoratedBox(
-          key: Key('myReport-${report.id}'),
-          decoration: BoxDecoration(
-            color: Colors.white,
+        child: Material(
+          color: Colors.white,
+          shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(8),
-            border: Border.all(color: const Color(0xFFD5E2E4)),
+            side: const BorderSide(color: Color(0xFFD5E2E4)),
           ),
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Expanded(
-                      child: Text(
-                        report.reportTypeLabel,
-                        style: textTheme.titleMedium?.copyWith(
-                          color: const Color(0xFF102A2C),
-                          fontWeight: FontWeight.w900,
-                          height: 1.25,
+          child: InkWell(
+            key: Key('myReport-${report.id}'),
+            borderRadius: BorderRadius.circular(8),
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => MyFacilityReportDetailScreen(report: report),
+              ),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          report.reportTypeLabel,
+                          style: textTheme.titleMedium?.copyWith(
+                            color: const Color(0xFF102A2C),
+                            fontWeight: FontWeight.w900,
+                            height: 1.25,
+                          ),
                         ),
                       ),
-                    ),
-                    const SizedBox(width: 12),
-                    _MyReportStatusPill(label: report.statusLabel),
-                  ],
-                ),
-                const SizedBox(height: 10),
-                Text(
-                  description,
-                  style: textTheme.bodyLarge?.copyWith(
-                    color: const Color(0xFF102A2C),
-                    fontWeight: FontWeight.w700,
-                    height: 1.35,
+                      const SizedBox(width: 12),
+                      _MyReportStatusPill(label: report.statusLabel),
+                    ],
                   ),
-                ),
-                const SizedBox(height: 12),
-                Wrap(
-                  spacing: 12,
-                  runSpacing: 6,
-                  children: [
-                    _MyReportMetaText(label: '접수번호', value: report.id),
-                    _MyReportMetaText(label: '접수일', value: createdAtLabel),
-                  ],
-                ),
-              ],
+                  const SizedBox(height: 10),
+                  Text(
+                    description,
+                    style: textTheme.bodyLarge?.copyWith(
+                      color: const Color(0xFF102A2C),
+                      fontWeight: FontWeight.w700,
+                      height: 1.35,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 6,
+                    children: [
+                      _MyReportMetaText(label: '접수번호', value: report.id),
+                      _MyReportMetaText(label: '접수일', value: createdAtLabel),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+class MyFacilityReportDetailScreen extends StatelessWidget {
+  const MyFacilityReportDetailScreen({required this.report, super.key});
+
+  final FacilityReportResult report;
+
+  @override
+  Widget build(BuildContext context) {
+    final description = report.description.isEmpty
+        ? report.reportTypeLabel
+        : report.description;
+    final createdAtLabel = _reportDateLabel(report.createdAt);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('신고 상세')),
+      body: SafeArea(
+        child: Semantics(
+          label:
+              '내 신고 상세, ${report.reportTypeLabel}, 현재 상태 ${report.statusLabel}, 접수번호 ${report.id}',
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+            children: [
+              Text(
+                report.reportTypeLabel,
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                  color: const Color(0xFF102A2C),
+                  fontWeight: FontWeight.w900,
+                  height: 1.25,
+                ),
+              ),
+              const SizedBox(height: 12),
+              _MyReportDetailStatus(label: report.statusLabel),
+              const SizedBox(height: 24),
+              _MyReportDetailRow(label: '접수번호', value: report.id),
+              const Divider(height: 32),
+              _MyReportDetailRow(label: '접수일', value: createdAtLabel),
+              const Divider(height: 32),
+              _MyReportDetailRow(label: '신고 내용', value: description),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MyReportDetailStatus extends StatelessWidget {
+  const _MyReportDetailStatus({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: const Color(0xFFE6F2F0),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: const Color(0xFF93C7C2)),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          child: Text(
+            label,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              color: const Color(0xFF102A2C),
+              fontWeight: FontWeight.w900,
+              height: 1.2,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MyReportDetailRow extends StatelessWidget {
+  const _MyReportDetailRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: Theme.of(context).textTheme.labelLarge?.copyWith(
+            color: const Color(0xFF29484B),
+            fontWeight: FontWeight.w900,
+            height: 1.2,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          value,
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+            color: const Color(0xFF102A2C),
+            fontWeight: FontWeight.w800,
+            height: 1.3,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -976,11 +976,19 @@ class _MyReportListItem extends StatelessWidget {
         ? report.reportTypeLabel
         : report.description;
     final createdAtLabel = _reportDateLabel(report.createdAt);
+    void openReportDetail() {
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => MyFacilityReportDetailScreen(report: report),
+        ),
+      );
+    }
 
     return Semantics(
       label:
           '내 신고, ${report.reportTypeLabel}, 접수번호 ${report.id}, ${report.statusLabel}, $description, 접수일 $createdAtLabel',
       button: true,
+      onTap: openReportDetail,
       child: ExcludeSemantics(
         child: Material(
           color: Colors.white,
@@ -991,11 +999,7 @@ class _MyReportListItem extends StatelessWidget {
           child: InkWell(
             key: Key('myReport-${report.id}'),
             borderRadius: BorderRadius.circular(8),
-            onTap: () => Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (_) => MyFacilityReportDetailScreen(report: report),
-              ),
-            ),
+            onTap: openReportDetail,
             child: Padding(
               padding: const EdgeInsets.all(16),
               child: Column(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -148,6 +148,52 @@ void main() {
     expect(reportRepository.listMyReportsCount, 1);
   });
 
+  testWidgets('내 신고 항목을 누르면 상세 상태 화면으로 이동한다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository(
+      reports: [
+        const FacilityReportResult(
+          id: 'report-2',
+          stationId: 'station-sangnoksu',
+          facilityId: 'facility-sangnoksu-elevator-1',
+          reportType: 'CLOSED',
+          description: '출입문이 막혀 있습니다.',
+          status: 'ACCEPTED',
+          createdAt: '2026-06-15T09:00:00',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: reportRepository,
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('myReportsButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('myReport-report-2')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('신고 상세'), findsOneWidget);
+    expect(find.text('폐쇄'), findsOneWidget);
+    expect(find.text('반영됨'), findsOneWidget);
+    expect(find.text('접수번호'), findsOneWidget);
+    expect(find.text('report-2'), findsOneWidget);
+    expect(find.text('접수일'), findsOneWidget);
+    expect(find.text('2026.06.15'), findsOneWidget);
+    expect(find.text('출입문이 막혀 있습니다.'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel('내 신고 상세, 폐쇄, 현재 상태 반영됨, 접수번호 report-2'),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('내 신고 화면은 접수한 신고가 없으면 짧은 빈 상태를 보여준다', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -1279,10 +1325,7 @@ void main() {
     await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
     await tester.pumpAndSettle();
 
-    expect(
-      find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'),
-      findsOneWidget,
-    );
+    expect(find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
     expect(
       find.byKey(const Key('stationSearchOpenLocationSettingsButton')),
       findsOneWidget,
@@ -3298,10 +3341,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(
-      find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'),
-      findsOneWidget,
-    );
+    expect(find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
     final failedLocationSubmitButton = tester.widget<FilledButton>(
       find.byKey(const Key('facilityReportSubmitButton')),
     );
@@ -3395,10 +3435,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(
-      find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'),
-      findsOneWidget,
-    );
+    expect(find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
     expect(find.text('현재 위치 첨부됨'), findsNothing);
     expect(find.text('현재 위치가 첨부되었습니다.'), findsNothing);
     expect(find.text('위치 확인됨'), findsNothing);
@@ -3490,10 +3527,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(
-      find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'),
-      findsOneWidget,
-    );
+    expect(find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
     expect(
       find.byKey(const Key('facilityReportOpenLocationSettingsButton')),
       findsOneWidget,
@@ -3551,7 +3585,9 @@ void main() {
     await tester.ensureVisible(
       find.byKey(const Key('facilityReportRetryLocationButton')),
     );
-    await tester.tap(find.byKey(const Key('facilityReportRetryLocationButton')));
+    await tester.tap(
+      find.byKey(const Key('facilityReportRetryLocationButton')),
+    );
     await tester.pump();
 
     expect(requestCount, 1);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -177,6 +177,16 @@ void main() {
 
     await tester.tap(find.byKey(const Key('myReportsButton')));
     await tester.pumpAndSettle();
+    final reportSemantics = tester.getSemantics(
+      find.bySemanticsLabel(
+        '내 신고, 폐쇄, 접수번호 report-2, 반영됨, 출입문이 막혀 있습니다., 접수일 2026.06.15',
+      ),
+    );
+    expect(
+      reportSemantics.getSemanticsData().hasAction(SemanticsAction.tap),
+      isTrue,
+    );
+
     await tester.tap(find.byKey(const Key('myReport-report-2')));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## 관련 이슈
- Closes #190

## 배경
내 신고 목록에서 신고 상태를 확인할 수는 있지만, 사용자가 접수번호와 처리 상태를 다시 확인하려면 목록 안의 짧은 정보에 의존해야 했습니다. 신고를 다시 문의하거나 처리 상태를 확인하는 흐름에서 목록 항목을 눌러 상세 내용을 볼 수 있게 보강합니다.

## 변경 사항
- 내 신고 목록 항목을 터치 가능한 카드로 변경했습니다.
- 신고 유형, 현재 상태, 접수번호, 접수일, 신고 내용을 보여주는 상세 화면을 추가했습니다.
- 스크린리더가 목록 항목을 버튼으로 인식하고 상세 화면의 핵심 상태를 읽을 수 있게 접근성 라벨을 정리했습니다.
- 내 신고 항목 탭 시 상세 화면으로 이동하는 위젯 테스트를 추가했습니다.

## 검증
- `flutter test --plain-name "내 신고 항목을 누르면 상세 상태 화면으로 이동한다" test/widget_test.dart`
- `flutter test`
- `flutter analyze`
- `node --test tools/ci/*.test.mjs`
- Android 에뮬레이터에서 신고 접수 후 내 신고 목록 진입, 신고 상세 화면 표시 확인

## 리스크
- 새 API 계약은 추가하지 않고 기존 내 신고 응답을 화면 전환에 재사용합니다.
- 목록 카드가 터치 가능해지므로 기존 스크린리더 라벨을 유지하면서 버튼 의미만 추가했습니다.