### PR TITLE
[Style] 역 검색 입력 안내 문구 정렬

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1884,7 +1884,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
               const SizedBox(height: 16),
             ],
             Semantics(
-              label: '역 이름 입력',
+              label: '역 이름을 입력해 주세요',
               textField: true,
               child: TextField(
                 key: const Key('stationSearchInput'),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -887,6 +887,8 @@ void main() {
       expect(searchInput.decoration?.hintText, '역 이름을 입력해 주세요');
       expect(searchInput.decoration?.hintText, isNot('예: 상록수'));
       expect(find.text('역 이름을 입력해 주세요.'), findsNothing);
+      expect(find.bySemanticsLabel('역 이름을 입력해 주세요'), findsOneWidget);
+      expect(find.bySemanticsLabel('역 이름 입력'), findsNothing);
       expect(
         searchInput.decoration?.floatingLabelBehavior,
         FloatingLabelBehavior.always,


### PR DESCRIPTION
## 관련 이슈
Closes #192

## 요약
- 역 검색 입력칸의 접근성 라벨을 표시 힌트와 같은 '역 이름을 입력해 주세요'로 맞췄습니다.
- 기존 표시 힌트와 검색 동작은 유지했습니다.
- 회귀 테스트로 이전 라벨인 '역 이름 입력'이 다시 노출되지 않도록 고정했습니다.

## 검증
- RED: `flutter test test/widget_test.dart --name "역 검색은 접근성 표시가 포함된 백엔드 결과를 보여준다"` 실패 확인
- GREEN: `flutter test test/widget_test.dart --name "역 검색은 접근성 표시가 포함된 백엔드 결과를 보여준다"`
- `flutter test`
- `flutter analyze`
- `node --test tools/ci/*.test.mjs`
- `flutter build apk --debug --dart-define=EASYSUBWAY_API_BASE_URL=http://10.0.2.2:8080`
- Android 에뮬레이터 UI tree에서 입력칸 hint가 '역 이름을 입력해 주세요'로 노출되는 것 확인

## 리스크
- 화면 동작 변경 없이 입력칸 semantics 라벨만 맞춘 변경입니다.
- Android/iOS 공통 Flutter 위젯 변경이므로 플랫폼별 네이티브 권한이나 API 계약 영향은 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 역 검색 입력 필드의 접근성 안내 문구를 사용자 친화적으로 개선하여 화면 읽기 기능 사용자의 경험을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->