### PR TITLE
[Feat] 모바일 기기 토큰 등록 API 연결

### DIFF
--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -10,6 +10,7 @@ import 'mobile_error_reporter.dart';
 const _notificationSettingsTimeout = Duration(seconds: 8);
 const _notificationSettingsLoadErrorMessage = '알림 설정을 불러오지 못했습니다.';
 const _notificationSettingsSaveErrorMessage = '알림 설정을 저장하지 못했습니다.';
+const _deviceRegistrationErrorMessage = '기기 알림 등록을 마치지 못했습니다.';
 
 abstract class NotificationSettingsRepository {
   Future<NotificationSettings> getNotificationSettings();
@@ -17,6 +18,10 @@ abstract class NotificationSettingsRepository {
   Future<NotificationSettings> saveNotificationSettings(
     NotificationSettings settings,
   );
+}
+
+abstract class DeviceRegistrationRepository {
+  Future<RegisteredDevice> registerDevice(DeviceRegistrationRequest request);
 }
 
 class NotificationSettingsApiRepository
@@ -155,6 +160,117 @@ class NotificationSettingsApiRepository
   }
 }
 
+class DeviceRegistrationApiRepository implements DeviceRegistrationRepository {
+  DeviceRegistrationApiRepository({
+    required this.baseUri,
+    required this.authProvider,
+    HttpClient? httpClient,
+  }) : _httpClient = httpClient ?? HttpClient();
+
+  final Uri baseUri;
+  final AuthorizationHeaderProvider authProvider;
+  final HttpClient _httpClient;
+
+  @override
+  Future<RegisteredDevice> registerDevice(
+    DeviceRegistrationRequest registrationRequest,
+  ) async {
+    try {
+      return await _postDeviceWithAuthorizationRetry(registrationRequest);
+    } on NotificationSettingsException {
+      rethrow;
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '기기 알림 등록 응답 처리 중 예외가 발생했습니다.',
+      );
+      throw const NotificationSettingsException(
+        _deviceRegistrationErrorMessage,
+      );
+    }
+  }
+
+  Future<RegisteredDevice> _postDeviceWithAuthorizationRetry(
+    DeviceRegistrationRequest registrationRequest,
+  ) async {
+    for (var attempt = 0; attempt < 2; attempt++) {
+      final request = await _httpClient
+          .postUrl(baseUri.resolve('/api/v1/devices'))
+          .timeout(_notificationSettingsTimeout);
+      final authorizationHeader = await authProvider
+          .authorizationHeader()
+          .timeout(_notificationSettingsTimeout);
+      if (authorizationHeader != null) {
+        request.headers.set(
+          HttpHeaders.authorizationHeader,
+          authorizationHeader,
+        );
+      }
+      request.headers.contentType = ContentType.json;
+      request.write(jsonEncode(registrationRequest.toJson()));
+
+      final response = await request.close().timeout(
+        _notificationSettingsTimeout,
+      );
+      final body = await utf8
+          .decodeStream(response)
+          .timeout(_notificationSettingsTimeout);
+
+      if (response.statusCode == HttpStatus.unauthorized &&
+          authorizationHeader != null &&
+          attempt == 0) {
+        // 기기 등록도 익명 인증 사용자에 묶이므로 만료 시 한 번만 새 인증으로 재시도한다.
+        await authProvider.invalidateAuthorization().timeout(
+          _notificationSettingsTimeout,
+        );
+        continue;
+      }
+
+      if (response.statusCode < HttpStatus.ok ||
+          response.statusCode >= HttpStatus.multipleChoices) {
+        throw const NotificationSettingsException(
+          _deviceRegistrationErrorMessage,
+        );
+      }
+
+      return _registeredDeviceFromBody(body);
+    }
+    throw const NotificationSettingsException(_deviceRegistrationErrorMessage);
+  }
+
+  RegisteredDevice _registeredDeviceFromBody(String body) {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is! Map<String, Object?> || decoded['success'] != true) {
+        throw const NotificationSettingsException(
+          _deviceRegistrationErrorMessage,
+        );
+      }
+
+      final data = decoded['data'];
+      if (data is! Map<String, Object?>) {
+        throw const NotificationSettingsException(
+          _deviceRegistrationErrorMessage,
+        );
+      }
+
+      return RegisteredDevice.fromJson(data);
+    } on NotificationSettingsException {
+      rethrow;
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '기기 알림 등록 응답 파싱 중 예외가 발생했습니다.',
+      );
+      throw const NotificationSettingsException(
+        _deviceRegistrationErrorMessage,
+      );
+    }
+  }
+}
+
 class NotificationSettingsException implements Exception {
   const NotificationSettingsException(this.message);
 
@@ -162,6 +278,65 @@ class NotificationSettingsException implements Exception {
 
   @override
   String toString() => message;
+}
+
+enum DevicePlatform {
+  android('ANDROID'),
+  ios('IOS');
+
+  const DevicePlatform(this.apiValue);
+
+  factory DevicePlatform.fromJson(String value) {
+    return switch (value) {
+      'ANDROID' => DevicePlatform.android,
+      'IOS' => DevicePlatform.ios,
+      _ => throw const NotificationSettingsException(
+        _deviceRegistrationErrorMessage,
+      ),
+    };
+  }
+
+  final String apiValue;
+}
+
+class DeviceRegistrationRequest {
+  const DeviceRegistrationRequest({
+    required this.platform,
+    required this.deviceToken,
+  });
+
+  final DevicePlatform platform;
+  final String deviceToken;
+
+  Map<String, Object?> toJson() {
+    return {
+      'platform': platform.apiValue,
+      'deviceToken': deviceToken.trim(),
+    };
+  }
+}
+
+class RegisteredDevice {
+  const RegisteredDevice({
+    required this.userId,
+    required this.platform,
+    required this.deviceToken,
+    required this.registeredAt,
+  });
+
+  factory RegisteredDevice.fromJson(Map<String, Object?> json) {
+    return RegisteredDevice(
+      userId: _requiredString(json, 'userId'),
+      platform: DevicePlatform.fromJson(_requiredString(json, 'platform')),
+      deviceToken: _requiredString(json, 'deviceToken'),
+      registeredAt: _requiredString(json, 'registeredAt'),
+    );
+  }
+
+  final String userId;
+  final DevicePlatform platform;
+  final String deviceToken;
+  final String registeredAt;
 }
 
 class NotificationSettings {

--- a/apps/mobile/test/notification_settings_test.dart
+++ b/apps/mobile/test/notification_settings_test.dart
@@ -6,6 +6,162 @@ import 'package:easysubway_mobile/notification_settings.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('기기 등록 API 저장소는 인증 헤더와 함께 플랫폼과 토큰을 보낸다', () async {
+    late String requestedMethod;
+    late Uri requestedUri;
+    late String? authorizationHeader;
+    late Map<String, Object?> requestBody;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) async {
+      requestedMethod = request.method;
+      requestedUri = request.uri;
+      authorizationHeader = request.headers.value(
+        HttpHeaders.authorizationHeader,
+      );
+      requestBody =
+          jsonDecode(await utf8.decodeStream(request)) as Map<String, Object?>;
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {
+              'userId': 'anonymous-user-1',
+              'platform': 'ANDROID',
+              'deviceToken': 'android-device-token-1',
+              'registeredAt': '2026-06-15T09:00:00',
+            },
+          }),
+        )
+        ..close();
+    });
+
+    final repository = DeviceRegistrationApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: const BasicAuthorizationHeaderProvider(
+        username: 'anonymous-user-1',
+        password: 'user-test-password',
+      ),
+    );
+
+    final registeredDevice = await repository.registerDevice(
+      const DeviceRegistrationRequest(
+        platform: DevicePlatform.android,
+        deviceToken: ' android-device-token-1 ',
+      ),
+    );
+
+    expect(requestedMethod, 'POST');
+    expect(requestedUri.path, '/api/v1/devices');
+    expect(
+      authorizationHeader,
+      'Basic ${base64Encode(utf8.encode('anonymous-user-1:user-test-password'))}',
+    );
+    expect(requestBody, {
+      'platform': 'ANDROID',
+      'deviceToken': 'android-device-token-1',
+    });
+    expect(registeredDevice.userId, 'anonymous-user-1');
+    expect(registeredDevice.platform, DevicePlatform.android);
+    expect(registeredDevice.deviceToken, 'android-device-token-1');
+    expect(registeredDevice.registeredAt, '2026-06-15T09:00:00');
+  });
+
+  test('기기 등록 API 저장소는 인증 실패 시 인증을 지우고 한 번 재시도한다', () async {
+    final authorizationHeaders = <String?>[];
+    var requestCount = 0;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) async {
+      requestCount++;
+      authorizationHeaders.add(
+        request.headers.value(HttpHeaders.authorizationHeader),
+      );
+      await utf8.decodeStream(request);
+      request.response.headers.contentType = ContentType.json;
+
+      if (requestCount == 1) {
+        request.response
+          ..statusCode = HttpStatus.unauthorized
+          ..write(jsonEncode({'success': false}))
+          ..close();
+        return;
+      }
+
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {
+              'userId': 'anonymous-user-1',
+              'platform': 'IOS',
+              'deviceToken': 'ios-device-token-1',
+              'registeredAt': '2026-06-15T09:05:00',
+            },
+          }),
+        )
+        ..close();
+    });
+
+    final authProvider = RetryAuthorizationHeaderProvider();
+    final repository = DeviceRegistrationApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: authProvider,
+    );
+
+    final registeredDevice = await repository.registerDevice(
+      const DeviceRegistrationRequest(
+        platform: DevicePlatform.ios,
+        deviceToken: 'ios-device-token-1',
+      ),
+    );
+
+    expect(registeredDevice.platform, DevicePlatform.ios);
+    expect(authorizationHeaders, ['Basic stale-token', 'Basic fresh-token']);
+    expect(authProvider.authorizationCount, 2);
+    expect(authProvider.invalidateCount, 1);
+  });
+
+  test('기기 등록 API 저장소는 실패 응답을 쉬운 안내로 바꾼다', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) async {
+      await utf8.decodeStream(request);
+      request.response
+        ..statusCode = HttpStatus.badRequest
+        ..headers.contentType = ContentType.json
+        ..write(jsonEncode({'success': false}))
+        ..close();
+    });
+
+    final repository = DeviceRegistrationApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: const NoAuthorizationHeaderProvider(),
+    );
+
+    await expectLater(
+      repository.registerDevice(
+        const DeviceRegistrationRequest(
+          platform: DevicePlatform.android,
+          deviceToken: 'android-device-token-1',
+        ),
+      ),
+      throwsA(
+        isA<NotificationSettingsException>().having(
+          (error) => error.message,
+          'message',
+          '기기 알림 등록을 마치지 못했습니다.',
+        ),
+      ),
+    );
+  });
+
   test('알림 설정 API 저장소는 인증 헤더와 함께 현재 설정을 요청한다', () async {
     late String? authorizationHeader;
     late Uri requestedUri;


### PR DESCRIPTION
## 관련 이슈
Closes #194

## 요약
- 모바일 알림 API 계층에 기기 토큰 등록 저장소를 추가했습니다.
- Android/iOS 플랫폼 값을 백엔드 계약인 `ANDROID`, `IOS`로 변환해 `/api/v1/devices`에 전송합니다.
- 알림 설정 API와 같은 방식으로 인증 실패 시 저장된 인증을 지우고 한 번 재시도합니다.
- 실패 응답은 사용자에게 노출 가능한 짧은 안내 문구로 바꿉니다.

## 검증
- RED: `flutter test test/notification_settings_test.dart` 컴파일 실패 확인
- GREEN: `flutter test test/notification_settings_test.dart`
- `flutter test`
- `flutter analyze`
- `node --test tools/ci/*.test.mjs`
- `flutter build apk --debug --dart-define=EASYSUBWAY_API_BASE_URL=http://10.0.2.2:8080`
- Android 에뮬레이터 설치와 앱 실행 smoke 확인

## 리스크
- 실제 FCM/APNs 토큰 수집과 OS 알림 권한 요청은 아직 연결하지 않았습니다.
- 이번 변경은 모바일 API 경계만 추가하며, 화면 UI와 백엔드 API 계약은 바꾸지 않습니다.
