### PR TITLE
[Feat] 모바일 알림 권한 요청 흐름 연결

### DIFF
--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -77,3 +77,7 @@ kotlin {
 flutter {
     source = "../.."
 }
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.18.0")
+}

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:label="쉬운 지하철"

--- a/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
@@ -17,10 +17,13 @@ import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
     private val locationChannelName = "com.easysubway.easysubway_mobile/location"
+    private val notificationChannelName = "com.easysubway.easysubway_mobile/notifications"
     private val locationPermissionRequestCode = 2401
+    private val notificationPermissionRequestCode = 2402
     private val locationTimeoutMillis = 10_000L
 
     private var pendingLocationResult: MethodChannel.Result? = null
+    private var pendingNotificationPermissionResult: MethodChannel.Result? = null
     private var pendingLocationListener: LocationListener? = null
     private val mainHandler = Handler(Looper.getMainLooper())
 
@@ -32,6 +35,13 @@ class MainActivity : FlutterActivity() {
                     "currentLocation" -> handleCurrentLocation(result)
                     "needsLocationPermissionRequest" -> result.success(!hasLocationPermission())
                     "openLocationSettings" -> openLocationSettings(result)
+                    else -> result.notImplemented()
+                }
+            }
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, notificationChannelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "requestNotificationPermission" -> requestNotificationPermission(result)
                     else -> result.notImplemented()
                 }
             }
@@ -84,6 +94,12 @@ class MainActivity : FlutterActivity() {
         grantResults: IntArray,
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == notificationPermissionRequestCode) {
+            val result = pendingNotificationPermissionResult ?: return
+            pendingNotificationPermissionResult = null
+            result.success(grantResults.any { it == PackageManager.PERMISSION_GRANTED })
+            return
+        }
         if (requestCode != locationPermissionRequestCode) {
             return
         }
@@ -204,6 +220,35 @@ class MainActivity : FlutterActivity() {
             return true
         }
         return checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun requestNotificationPermission(result: MethodChannel.Result) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            result.success(true)
+            return
+        }
+        if (hasNotificationPermission()) {
+            result.success(true)
+            return
+        }
+        if (pendingNotificationPermissionResult != null) {
+            result.error("notificationUnavailable", "notification request already running", null)
+            return
+        }
+
+        // Android 13 이상은 알림도 런타임 권한이라 사용자가 누른 직후에만 요청한다.
+        pendingNotificationPermissionResult = result
+        requestPermissions(
+            arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+            notificationPermissionRequestCode,
+        )
+    }
+
+    private fun hasNotificationPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return true
+        }
+        return checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
     }
 
     private fun LocationManager.safeLastKnownLocation(provider: String): Location? {

--- a/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.easysubway.easysubway_mobile
 
 import android.Manifest
-import android.app.NotificationManager
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.location.Location
@@ -12,6 +11,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
+import androidx.core.app.NotificationManagerCompat
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.plugin.common.MethodChannel
@@ -98,7 +98,10 @@ class MainActivity : FlutterActivity() {
         if (requestCode == notificationPermissionRequestCode) {
             val result = pendingNotificationPermissionResult ?: return
             pendingNotificationPermissionResult = null
-            result.success(grantResults.any { it == PackageManager.PERMISSION_GRANTED })
+            result.success(
+                grantResults.any { it == PackageManager.PERMISSION_GRANTED } &&
+                    areAppNotificationsEnabled(),
+            )
             return
         }
         if (requestCode != locationPermissionRequestCode) {
@@ -253,12 +256,8 @@ class MainActivity : FlutterActivity() {
     }
 
     private fun areAppNotificationsEnabled(): Boolean {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            return true
-        }
         // Android 12 이하에서도 사용자가 앱 알림을 꺼두면 실제 푸시가 표시되지 않는다.
-        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-        return notificationManager.areNotificationsEnabled()
+        return NotificationManagerCompat.from(this).areNotificationsEnabled()
     }
 
     private fun LocationManager.safeLastKnownLocation(provider: String): Location? {

--- a/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.easysubway.easysubway_mobile
 
 import android.Manifest
+import android.app.NotificationManager
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.location.Location
@@ -224,10 +225,10 @@ class MainActivity : FlutterActivity() {
 
     private fun requestNotificationPermission(result: MethodChannel.Result) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            result.success(true)
+            result.success(areAppNotificationsEnabled())
             return
         }
-        if (hasNotificationPermission()) {
+        if (hasNotificationPermission() && areAppNotificationsEnabled()) {
             result.success(true)
             return
         }
@@ -249,6 +250,15 @@ class MainActivity : FlutterActivity() {
             return true
         }
         return checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun areAppNotificationsEnabled(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            return true
+        }
+        // Android 12 이하에서도 사용자가 앱 알림을 꺼두면 실제 푸시가 표시되지 않는다.
+        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        return notificationManager.areNotificationsEnabled()
     }
 
     private fun LocationManager.safeLastKnownLocation(provider: String): Location? {

--- a/apps/mobile/ios/Runner/AppDelegate.swift
+++ b/apps/mobile/ios/Runner/AppDelegate.swift
@@ -1,10 +1,12 @@
 import CoreLocation
 import Flutter
 import UIKit
+import UserNotifications
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate, CLLocationManagerDelegate {
   private let locationChannelName = "com.easysubway.easysubway_mobile/location"
+  private let notificationChannelName = "com.easysubway.easysubway_mobile/notifications"
   private let locationManager = CLLocationManager()
   private var pendingLocationResult: FlutterResult?
 
@@ -37,6 +39,18 @@ import UIKit
         return
       }
       self?.handleCurrentLocation(result)
+    }
+
+    let notificationChannel = FlutterMethodChannel(
+      name: notificationChannelName,
+      binaryMessenger: engineBridge.applicationRegistrar.messenger()
+    )
+    notificationChannel.setMethodCallHandler { [weak self] call, result in
+      guard call.method == "requestNotificationPermission" else {
+        result(FlutterMethodNotImplemented)
+        return
+      }
+      self?.requestNotificationPermission(result)
     }
   }
 
@@ -131,6 +145,21 @@ import UIKit
     }
     UIApplication.shared.open(url, options: [:]) { success in
       result(success)
+    }
+  }
+
+  private func requestNotificationPermission(_ result: @escaping FlutterResult) {
+    // iOS 권한 팝업은 사용자가 알림 켜기를 누른 뒤에만 띄운다.
+    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) {
+      granted,
+      error in
+      DispatchQueue.main.async {
+        if error != nil {
+          result(FlutterError(code: "notificationUnavailable", message: nil, details: nil))
+          return
+        }
+        result(granted)
+      }
     }
   }
 

--- a/apps/mobile/ios/Runner/AppDelegate.swift
+++ b/apps/mobile/ios/Runner/AppDelegate.swift
@@ -18,6 +18,10 @@ import UserNotifications
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
+  deinit {
+    locationManager.delegate = nil
+  }
+
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     // Flutter 화면은 공통 로직을 유지하고, iOS 권한과 센서 접근만 네이티브에서 처리한다.

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -35,6 +35,7 @@ class EasySubwayApp extends StatelessWidget {
     FavoriteFacilityRepository? favoriteFacilityRepository,
     FavoriteRouteRepository? favoriteRouteRepository,
     NotificationSettingsRepository? notificationRepository,
+    NotificationPermissionProvider? notificationPermissionProvider,
     CurrentLocationProvider? locationProvider,
     AnonymousAuthRepository? anonymousAuthRepository,
     OnboardingResultStore? onboardingStore,
@@ -55,6 +56,7 @@ class EasySubwayApp extends StatelessWidget {
            favoriteFacilityRepository: favoriteFacilityRepository,
            favoriteRouteRepository: favoriteRouteRepository,
            notificationRepository: notificationRepository,
+           notificationPermissionProvider: notificationPermissionProvider,
            locationProvider: locationProvider,
            anonymousAuthRepository: anonymousAuthRepository,
            enableAnonymousAuth: enableAnonymousAuth,
@@ -83,6 +85,8 @@ class EasySubwayApp extends StatelessWidget {
        favoriteFacilityRepository = dependencies.favoriteFacilityRepository,
        favoriteRouteRepository = dependencies.favoriteRouteRepository,
        notificationRepository = dependencies.notificationRepository,
+       notificationPermissionProvider =
+           dependencies.notificationPermissionProvider,
        locationProvider = dependencies.locationProvider;
 
   final StationSearchRepository repository;
@@ -93,6 +97,7 @@ class EasySubwayApp extends StatelessWidget {
   final FavoriteFacilityRepository? favoriteFacilityRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
   final NotificationSettingsRepository? notificationRepository;
+  final NotificationPermissionProvider? notificationPermissionProvider;
   final CurrentLocationProvider locationProvider;
   final OnboardingState initialOnboardingState;
   final OnboardingResultStore? onboardingStore;
@@ -152,6 +157,7 @@ class EasySubwayApp extends StatelessWidget {
         favoriteFacilityRepository: favoriteFacilityRepository,
         favoriteRouteRepository: favoriteRouteRepository,
         notificationRepository: notificationRepository,
+        notificationPermissionProvider: notificationPermissionProvider,
         locationProvider: locationProvider,
         initialOnboardingState: initialOnboardingState,
         onboardingStore: onboardingStore,
@@ -194,6 +200,7 @@ class _EasySubwayHome extends StatefulWidget {
     required this.favoriteFacilityRepository,
     required this.favoriteRouteRepository,
     required this.notificationRepository,
+    required this.notificationPermissionProvider,
     required this.locationProvider,
     required this.initialOnboardingState,
     required this.onboardingStore,
@@ -210,6 +217,7 @@ class _EasySubwayHome extends StatefulWidget {
   final FavoriteFacilityRepository? favoriteFacilityRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
   final NotificationSettingsRepository? notificationRepository;
+  final NotificationPermissionProvider? notificationPermissionProvider;
   final CurrentLocationProvider locationProvider;
   final OnboardingState initialOnboardingState;
   final OnboardingResultStore? onboardingStore;
@@ -274,6 +282,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         favoriteFacilityRepository: widget.favoriteFacilityRepository,
         favoriteRouteRepository: widget.favoriteRouteRepository,
         notificationRepository: widget.notificationRepository,
+        notificationPermissionProvider: widget.notificationPermissionProvider,
         locationProvider: widget.locationProvider,
         initialMobilityType: onboardingResult?.profile.mobilityType,
         simpleViewEnabled: preferences.simpleViewEnabled,
@@ -491,6 +500,7 @@ class _EasySubwayAppDependencies {
     required this.favoriteFacilityRepository,
     required this.favoriteRouteRepository,
     required this.notificationRepository,
+    required this.notificationPermissionProvider,
     required this.locationProvider,
   });
 
@@ -503,6 +513,7 @@ class _EasySubwayAppDependencies {
     FavoriteFacilityRepository? favoriteFacilityRepository,
     FavoriteRouteRepository? favoriteRouteRepository,
     NotificationSettingsRepository? notificationRepository,
+    NotificationPermissionProvider? notificationPermissionProvider,
     CurrentLocationProvider? locationProvider,
     AnonymousAuthRepository? anonymousAuthRepository,
     required bool enableAnonymousAuth,
@@ -554,6 +565,9 @@ class _EasySubwayAppDependencies {
             baseUri: baseUri,
             authProvider: sharedAuthProvider,
           ),
+      notificationPermissionProvider:
+          notificationPermissionProvider ??
+          MethodChannelNotificationPermissionProvider(),
       locationProvider:
           locationProvider ?? MethodChannelCurrentLocationProvider(),
     );
@@ -567,6 +581,7 @@ class _EasySubwayAppDependencies {
   final FavoriteFacilityRepository? favoriteFacilityRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
   final NotificationSettingsRepository? notificationRepository;
+  final NotificationPermissionProvider? notificationPermissionProvider;
   final CurrentLocationProvider locationProvider;
 }
 
@@ -659,6 +674,7 @@ class HomeScreen extends StatelessWidget {
     required this.favoriteFacilityRepository,
     required this.favoriteRouteRepository,
     required this.notificationRepository,
+    required this.notificationPermissionProvider,
     required this.locationProvider,
     required this.supportAccessInfo,
     this.simpleViewEnabled = true,
@@ -676,6 +692,7 @@ class HomeScreen extends StatelessWidget {
   final FavoriteFacilityRepository? favoriteFacilityRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
   final NotificationSettingsRepository? notificationRepository;
+  final NotificationPermissionProvider? notificationPermissionProvider;
   final CurrentLocationProvider locationProvider;
   final SupportAccessInfo supportAccessInfo;
   final String initialMobilityType;
@@ -690,6 +707,7 @@ class HomeScreen extends StatelessWidget {
     final favoriteRouteRepository = this.favoriteRouteRepository;
     final routeFeedbackRepository = this.routeFeedbackRepository;
     final notificationRepository = this.notificationRepository;
+    final notificationPermissionProvider = this.notificationPermissionProvider;
 
     return Scaffold(
       appBar: AppBar(title: const Text('쉬운 지하철')),
@@ -840,6 +858,8 @@ class HomeScreen extends StatelessWidget {
                     MaterialPageRoute<void>(
                       builder: (_) => NotificationSettingsScreen(
                         repository: notificationRepository,
+                        notificationPermissionProvider:
+                            notificationPermissionProvider,
                       ),
                     ),
                   );

--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'auth_headers.dart';
 import 'mobile_error_reporter.dart';
@@ -11,6 +12,7 @@ const _notificationSettingsTimeout = Duration(seconds: 8);
 const _notificationSettingsLoadErrorMessage = '알림 설정을 불러오지 못했습니다.';
 const _notificationSettingsSaveErrorMessage = '알림 설정을 저장하지 못했습니다.';
 const _deviceRegistrationErrorMessage = '기기 알림 등록을 마치지 못했습니다.';
+const _notificationPermissionErrorMessage = '알림 권한을 확인하지 못했습니다.';
 
 abstract class NotificationSettingsRepository {
   Future<NotificationSettings> getNotificationSettings();
@@ -22,6 +24,39 @@ abstract class NotificationSettingsRepository {
 
 abstract class DeviceRegistrationRepository {
   Future<RegisteredDevice> registerDevice(DeviceRegistrationRequest request);
+}
+
+abstract class NotificationPermissionProvider {
+  Future<NotificationPermissionStatus> requestNotificationPermission();
+}
+
+enum NotificationPermissionStatus { granted, denied }
+
+class MethodChannelNotificationPermissionProvider
+    implements NotificationPermissionProvider {
+  MethodChannelNotificationPermissionProvider({MethodChannel? channel})
+    : _channel =
+          channel ??
+          const MethodChannel('com.easysubway.easysubway_mobile/notifications');
+
+  final MethodChannel _channel;
+
+  @override
+  Future<NotificationPermissionStatus> requestNotificationPermission() async {
+    try {
+      final granted =
+          await _channel.invokeMethod<bool>('requestNotificationPermission') ??
+          false;
+      return granted
+          ? NotificationPermissionStatus.granted
+          : NotificationPermissionStatus.denied;
+    } on PlatformException catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '알림 권한 요청 중 예외가 발생했습니다.');
+      throw const NotificationSettingsException(
+        _notificationPermissionErrorMessage,
+      );
+    }
+  }
 }
 
 class NotificationSettingsApiRepository
@@ -309,10 +344,7 @@ class DeviceRegistrationRequest {
   final String deviceToken;
 
   Map<String, Object?> toJson() {
-    return {
-      'platform': platform.apiValue,
-      'deviceToken': deviceToken.trim(),
-    };
+    return {'platform': platform.apiValue, 'deviceToken': deviceToken.trim()};
   }
 }
 
@@ -564,9 +596,14 @@ class NotificationSettingsController extends ChangeNotifier {
 }
 
 class NotificationSettingsScreen extends StatefulWidget {
-  const NotificationSettingsScreen({required this.repository, super.key});
+  const NotificationSettingsScreen({
+    required this.repository,
+    this.notificationPermissionProvider,
+    super.key,
+  });
 
   final NotificationSettingsRepository repository;
+  final NotificationPermissionProvider? notificationPermissionProvider;
 
   @override
   State<NotificationSettingsScreen> createState() =>
@@ -576,6 +613,8 @@ class NotificationSettingsScreen extends StatefulWidget {
 class _NotificationSettingsScreenState
     extends State<NotificationSettingsScreen> {
   late final NotificationSettingsController _controller;
+  bool _isRequestingNotificationPermission = false;
+  String _notificationPermissionMessage = '';
 
   @override
   void initState() {
@@ -612,6 +651,12 @@ class _NotificationSettingsScreenState
             }
             return _NotificationSettingsContent(
               state: state,
+              notificationPermissionProvider:
+                  widget.notificationPermissionProvider,
+              isRequestingNotificationPermission:
+                  _isRequestingNotificationPermission,
+              notificationPermissionMessage: _notificationPermissionMessage,
+              onRequestNotificationPermission: _requestNotificationPermission,
               onFavoriteStationFacilityAlertsChanged:
                   _controller.updateFavoriteStationFacilityAlerts,
               onFavoriteRouteFacilityAlertsChanged:
@@ -625,11 +670,86 @@ class _NotificationSettingsScreenState
       ),
     );
   }
+
+  Future<void> _requestNotificationPermission() async {
+    final provider = widget.notificationPermissionProvider;
+    if (provider == null || _isRequestingNotificationPermission) {
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('알림 받기'),
+        content: const Text('시설 상태와 신고 결과를 알려드립니다.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('나중에'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('켜기'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted || confirmed != true) {
+      return;
+    }
+
+    setState(() {
+      _isRequestingNotificationPermission = true;
+      _notificationPermissionMessage = '';
+    });
+
+    try {
+      final status = await provider.requestNotificationPermission();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _notificationPermissionMessage =
+            status == NotificationPermissionStatus.granted
+            ? '기기 알림이 켜졌습니다.'
+            : '기기 알림 권한을 켜 주세요.';
+      });
+    } on NotificationSettingsException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _notificationPermissionMessage = error.message;
+      });
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '알림 권한 요청 화면 처리 중 예외가 발생했습니다.',
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _notificationPermissionMessage = _notificationPermissionErrorMessage;
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isRequestingNotificationPermission = false;
+        });
+      }
+    }
+  }
 }
 
 class _NotificationSettingsContent extends StatelessWidget {
   const _NotificationSettingsContent({
     required this.state,
+    required this.notificationPermissionProvider,
+    required this.isRequestingNotificationPermission,
+    required this.notificationPermissionMessage,
+    required this.onRequestNotificationPermission,
     required this.onFavoriteStationFacilityAlertsChanged,
     required this.onFavoriteRouteFacilityAlertsChanged,
     required this.onReportStatusAlertsChanged,
@@ -638,6 +758,10 @@ class _NotificationSettingsContent extends StatelessWidget {
   });
 
   final NotificationSettingsState state;
+  final NotificationPermissionProvider? notificationPermissionProvider;
+  final bool isRequestingNotificationPermission;
+  final String notificationPermissionMessage;
+  final VoidCallback onRequestNotificationPermission;
   final ValueChanged<bool> onFavoriteStationFacilityAlertsChanged;
   final ValueChanged<bool> onFavoriteRouteFacilityAlertsChanged;
   final ValueChanged<bool> onReportStatusAlertsChanged;
@@ -652,6 +776,40 @@ class _NotificationSettingsContent extends StatelessWidget {
     return ListView(
       padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
       children: [
+        if (notificationPermissionProvider != null) ...[
+          Semantics(
+            label: isRequestingNotificationPermission
+                ? '기기 알림 권한 확인 중'
+                : '기기 알림 켜기',
+            child: OutlinedButton.icon(
+              key: const Key('notificationPermissionButton'),
+              onPressed: isRequestingNotificationPermission
+                  ? null
+                  : onRequestNotificationPermission,
+              icon: isRequestingNotificationPermission
+                  ? const SizedBox(
+                      width: 22,
+                      height: 22,
+                      child: CircularProgressIndicator(strokeWidth: 3),
+                    )
+                  : const Icon(Icons.notifications_active_outlined),
+              label: Text(
+                isRequestingNotificationPermission ? '확인 중' : '기기 알림 켜기',
+              ),
+            ),
+          ),
+          if (notificationPermissionMessage.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            _NotificationSettingsMessage(
+              message: notificationPermissionMessage,
+            ),
+          ],
+          const SizedBox(height: 12),
+        ],
+        if (state.message.isNotEmpty) ...[
+          _NotificationSettingsMessage(message: state.message),
+          const SizedBox(height: 12),
+        ],
         _NotificationSwitchTile(
           key: const Key('notificationSwitch-favoriteStationFacilityAlerts'),
           title: '역 시설 알림',
@@ -696,25 +854,32 @@ class _NotificationSettingsContent extends StatelessWidget {
             label: Text(isSaving ? '저장 중' : '저장'),
           ),
         ),
-        if (state.message.isNotEmpty) ...[
-          const SizedBox(height: 16),
-          Semantics(
-            container: true,
-            excludeSemantics: true,
-            liveRegion: true,
-            label: state.message,
-            child: Text(
-              state.message,
-              key: const Key('notificationSettingsMessage'),
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: const Color(0xFF102A2C),
-                fontWeight: FontWeight.w700,
-                height: 1.35,
-              ),
-            ),
-          ),
-        ],
       ],
+    );
+  }
+}
+
+class _NotificationSettingsMessage extends StatelessWidget {
+  const _NotificationSettingsMessage({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      container: true,
+      excludeSemantics: true,
+      liveRegion: true,
+      label: message,
+      child: Text(
+        message,
+        key: const Key('notificationSettingsMessage'),
+        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+          color: const Color(0xFF102A2C),
+          fontWeight: FontWeight.w700,
+          height: 1.35,
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile/test/notification_permission_provider_test.dart
+++ b/apps/mobile/test/notification_permission_provider_test.dart
@@ -1,0 +1,72 @@
+import 'package:easysubway_mobile/notification_settings.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('알림 권한 제공자는 네이티브 채널로 권한 요청을 보낸다', () async {
+    const channel = MethodChannel('test/notification-permission');
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return true;
+        });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null),
+    );
+    final provider = MethodChannelNotificationPermissionProvider(
+      channel: channel,
+    );
+
+    final result = await provider.requestNotificationPermission();
+
+    expect(result, NotificationPermissionStatus.granted);
+    expect(calls.single.method, 'requestNotificationPermission');
+  });
+
+  test('알림 권한 제공자는 권한 거부를 쉬운 상태로 바꾼다', () async {
+    const channel = MethodChannel('test/notification-permission-denied');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (_) async => false);
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null),
+    );
+    final provider = MethodChannelNotificationPermissionProvider(
+      channel: channel,
+    );
+
+    final result = await provider.requestNotificationPermission();
+
+    expect(result, NotificationPermissionStatus.denied);
+  });
+
+  test('알림 권한 제공자는 네이티브 오류를 쉬운 안내로 바꾼다', () async {
+    const channel = MethodChannel('test/notification-permission-error');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (_) async {
+          throw PlatformException(code: 'notificationUnavailable');
+        });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null),
+    );
+    final provider = MethodChannelNotificationPermissionProvider(
+      channel: channel,
+    );
+
+    await expectLater(
+      provider.requestNotificationPermission(),
+      throwsA(
+        isA<NotificationSettingsException>().having(
+          (error) => error.message,
+          'message',
+          '알림 권한을 확인하지 못했습니다.',
+        ),
+      ),
+    );
+  });
+}

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -641,6 +641,80 @@ void main() {
     }
   });
 
+  testWidgets('알림 설정 화면은 기기 알림 권한을 사용자 확인 뒤 요청한다', (tester) async {
+    final notificationPermissionProvider = FakeNotificationPermissionProvider(
+      nextStatus: NotificationPermissionStatus.granted,
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        notificationPermissionProvider: notificationPermissionProvider,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('notificationSettingsButton')),
+      120,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('notificationSettingsButton')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('notificationPermissionButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('알림 받기'), findsOneWidget);
+    expect(find.text('시설 상태와 신고 결과를 알려드립니다.'), findsOneWidget);
+    expect(notificationPermissionProvider.requestCount, 0);
+
+    await tester.tap(find.text('켜기'));
+    await tester.pumpAndSettle();
+
+    expect(notificationPermissionProvider.requestCount, 1);
+    expect(find.text('기기 알림이 켜졌습니다.'), findsOneWidget);
+    expect(find.bySemanticsLabel('기기 알림이 켜졌습니다.'), findsOneWidget);
+  });
+
+  testWidgets('알림 설정 화면은 기기 알림 권한 거부를 짧게 안내한다', (tester) async {
+    final notificationPermissionProvider = FakeNotificationPermissionProvider(
+      nextStatus: NotificationPermissionStatus.denied,
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        notificationPermissionProvider: notificationPermissionProvider,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('notificationSettingsButton')),
+      120,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('notificationSettingsButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('notificationPermissionButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('켜기'));
+    await tester.pumpAndSettle();
+
+    expect(notificationPermissionProvider.requestCount, 1);
+    expect(find.text('기기 알림 권한을 켜 주세요.'), findsOneWidget);
+    expect(find.bySemanticsLabel('기기 알림 권한을 켜 주세요.'), findsOneWidget);
+  });
+
   testWidgets('홈 즐겨찾기는 저장한 역을 큰 목록으로 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final favoriteRepository = FakeFavoriteStationRepository(
@@ -4186,6 +4260,20 @@ class FakeNotificationSettingsRepository
     }
     this.settings = settings.copyWith(updatedAt: '2026-06-14T09:05:00');
     return this.settings;
+  }
+}
+
+class FakeNotificationPermissionProvider
+    implements NotificationPermissionProvider {
+  FakeNotificationPermissionProvider({required this.nextStatus});
+
+  final NotificationPermissionStatus nextStatus;
+  int requestCount = 0;
+
+  @override
+  Future<NotificationPermissionStatus> requestNotificationPermission() async {
+    requestCount++;
+    return nextStatus;
   }
 }
 


### PR DESCRIPTION
Closes #196

## 배경
모바일 알림 설정 화면에서 서버 알림 항목은 켜고 끌 수 있지만, 기기 알림 권한을 요청하는 흐름은 연결되어 있지 않았다. 사용자가 시설 상태와 신고 처리 결과 알림을 실제로 받으려면 Android/iOS OS 권한 요청이 같은 화면에서 이어져야 한다.

## 변경 사항
- 알림 설정 화면에 `기기 알림 켜기` 버튼을 추가하고, 사용자가 확인한 뒤 OS 알림 권한을 요청하도록 연결했다.
- Android 13 이상 `POST_NOTIFICATIONS` 권한과 iOS `UNUserNotificationCenter` 권한 요청을 MethodChannel로 연결했다.
- 권한 승인/거부/플랫폼 오류를 짧은 화면 문구와 스크린리더 live region으로 안내하도록 했다.
- 권한 제공자 단위 테스트와 알림 설정 화면 위젯 테스트를 추가했다.

## 검증
- `flutter test`
- `flutter analyze`
- `flutter build apk --debug --dart-define=EASYSUBWAY_API_BASE_URL=http://10.0.2.2:8080`
- `flutter build ios --simulator --no-codesign --dart-define=EASYSUBWAY_API_BASE_URL=http://127.0.0.1:8080`
- `node --test tools/ci/*.test.mjs`
- Android Emulator에서 알림 설정 화면, 앱 내부 확인 다이얼로그, Android 알림 권한 팝업, 허용 후 결과 문구를 확인했다.

## 리스크
- Android OS 권한 팝업 문구는 시스템 언어와 Android 버전에 따라 달라진다.
- 현재 작업은 OS 권한 요청까지 연결하며, FCM 토큰 발급/갱신 자동 등록 흐름은 별도 작업에서 다룬다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 모바일 앱의 알림 설정 화면에서 기기 알림 권한을 직접 요청하고 관리할 수 있는 기능 추가
  * Android 및 iOS 플랫폼에서 런타임 알림 권한 요청 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->