### PR TITLE
[Feat] 관리자 시설 상태 수정 화면 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
@@ -1,0 +1,137 @@
+package com.easysubway.transit.adapter.in.web;
+
+import com.easysubway.transit.application.port.in.StationSearchCommand;
+import com.easysubway.transit.application.port.in.TransitMasterAdminUseCase;
+import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
+import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilityStatusCommand;
+import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import com.easysubway.transit.domain.AccessibilityFacilityType;
+import com.easysubway.transit.domain.DataConfidenceLevel;
+import com.easysubway.transit.domain.StationWithLines;
+import java.security.Principal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+class TransitFacilityAdminPageController {
+
+	private final TransitMasterQueryUseCase transitMasterQueryUseCase;
+	private final TransitMasterAdminUseCase transitMasterAdminUseCase;
+
+	TransitFacilityAdminPageController(
+		TransitMasterQueryUseCase transitMasterQueryUseCase,
+		TransitMasterAdminUseCase transitMasterAdminUseCase
+	) {
+		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
+		this.transitMasterAdminUseCase = transitMasterAdminUseCase;
+	}
+
+	@GetMapping("/admin/facilities/page")
+	String facilitiesPage(Model model) {
+		model.addAttribute("facilities", facilityRows());
+		model.addAttribute("statusOptions", statusOptions());
+		return "admin/facilities/list";
+	}
+
+	@PostMapping("/admin/facilities/{facilityId}/page/status")
+	String updateFacilityStatusFromPage(
+		@PathVariable String facilityId,
+		@RequestParam AccessibilityFacilityStatus status,
+		Principal principal
+	) {
+		transitMasterAdminUseCase.updateFacilityStatus(new UpdateAccessibilityFacilityStatusCommand(
+			facilityId,
+			status,
+			principal.getName()
+		));
+		return "redirect:/admin/facilities/page";
+	}
+
+	private List<FacilityStatusRow> facilityRows() {
+		// 관리자 화면은 역별 시설 상태를 한눈에 보도록 역 목록을 먼저 펼친 뒤 시설 행으로 변환한다.
+		return transitMasterQueryUseCase.searchStations(new StationSearchCommand(null, null))
+			.stream()
+			.flatMap(station -> transitMasterQueryUseCase.listStationFacilities(station.station().id())
+				.stream()
+				.map(facility -> FacilityStatusRow.from(station, facility)))
+			.toList();
+	}
+
+	private static List<FacilityStatusOption> statusOptions() {
+		return Arrays.stream(AccessibilityFacilityStatus.values())
+			.map(status -> new FacilityStatusOption(status, statusLabel(status)))
+			.toList();
+	}
+
+	private static String typeLabel(AccessibilityFacilityType type) {
+		return switch (type) {
+			case ELEVATOR -> "엘리베이터";
+			case ESCALATOR -> "에스컬레이터";
+			case WHEELCHAIR_LIFT -> "휠체어 리프트";
+			case RAMP -> "경사로";
+			case ACCESSIBLE_TOILET -> "장애인 화장실";
+			case TOILET -> "화장실";
+			case NURSING_ROOM -> "수유실";
+			case CUSTOMER_CENTER -> "고객센터";
+		};
+	}
+
+	private static String statusLabel(AccessibilityFacilityStatus status) {
+		return switch (status) {
+			case NORMAL -> "정상";
+			case BROKEN -> "고장";
+			case UNDER_CONSTRUCTION -> "공사 중";
+			case CLOSED -> "폐쇄";
+			case UNKNOWN -> "확인 필요";
+			case USER_REPORTED -> "사용자 제보";
+			case ADMIN_VERIFIED -> "관리자 확인";
+		};
+	}
+
+	private static String confidenceLabel(DataConfidenceLevel confidence) {
+		return switch (confidence) {
+			case HIGH -> "정보 신뢰도 높음";
+			case MEDIUM -> "정보 신뢰도 보통";
+			case LOW -> "정보 신뢰도 낮음";
+			case NEEDS_VERIFICATION -> "정보 확인 필요";
+		};
+	}
+
+	record FacilityStatusRow(
+		String facilityId,
+		String stationId,
+		String stationName,
+		String facilityName,
+		String typeLabel,
+		AccessibilityFacilityStatus status,
+		String statusLabel,
+		String confidenceLabel,
+		LocalDate lastUpdatedAt
+	) {
+
+		static FacilityStatusRow from(StationWithLines station, AccessibilityFacility facility) {
+			return new FacilityStatusRow(
+				facility.id(),
+				station.station().id(),
+				station.station().nameKo(),
+				facility.name(),
+				TransitFacilityAdminPageController.typeLabel(facility.type()),
+				facility.status(),
+				TransitFacilityAdminPageController.statusLabel(facility.status()),
+				TransitFacilityAdminPageController.confidenceLabel(facility.dataConfidence()),
+				facility.lastUpdatedAt()
+			);
+		}
+	}
+
+	record FacilityStatusOption(AccessibilityFacilityStatus value, String label) {
+	}
+}

--- a/backend/src/main/resources/templates/admin/facilities/list.html
+++ b/backend/src/main/resources/templates/admin/facilities/list.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>시설 상태 관리</title>
+	<style>
+		body {
+			margin: 0;
+			background: #f6f8f8;
+			color: #102a2c;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+		}
+
+		main {
+			max-width: 1120px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}
+
+		h1 {
+			margin: 0 0 20px;
+			font-size: 32px;
+			line-height: 1.2;
+		}
+
+		.summary {
+			margin: 0 0 20px;
+			color: #29484b;
+			font-size: 17px;
+			font-weight: 700;
+			line-height: 1.45;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+			background: #fff;
+			border: 1px solid #d8e0e0;
+		}
+
+		th,
+		td {
+			padding: 14px 12px;
+			border-top: 1px solid #d8e0e0;
+			text-align: left;
+			vertical-align: top;
+			line-height: 1.45;
+		}
+
+		th {
+			background: #eaf0f0;
+			font-weight: 900;
+		}
+
+		td {
+			font-weight: 650;
+		}
+
+		.meta {
+			display: block;
+			margin-top: 4px;
+			color: #406164;
+			font-size: 14px;
+			font-weight: 700;
+		}
+
+		form {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 8px;
+			align-items: center;
+		}
+
+		select {
+			min-height: 44px;
+			min-width: 136px;
+			padding: 0 10px;
+			border: 1px solid #8aa0a3;
+			border-radius: 6px;
+			background: #fff;
+			color: #102a2c;
+			font-size: 16px;
+			font-weight: 800;
+		}
+
+		button {
+			min-height: 44px;
+			padding: 0 16px;
+			border: 0;
+			border-radius: 6px;
+			background: #003d40;
+			color: #fff;
+			font-size: 16px;
+			font-weight: 900;
+			cursor: pointer;
+		}
+
+		.empty {
+			padding: 24px;
+			background: #fff;
+			border: 1px solid #d8e0e0;
+			font-weight: 800;
+		}
+	</style>
+</head>
+<body>
+<main>
+	<h1>시설 상태 관리</h1>
+	<p class="summary">역 상세와 경로 안내에 쓰는 시설 상태를 확인하고 수정합니다.</p>
+
+	<p class="empty" th:if="${facilities.isEmpty()}">등록된 시설이 없습니다.</p>
+	<table th:if="${!facilities.isEmpty()}">
+		<thead>
+		<tr>
+			<th scope="col">시설</th>
+			<th scope="col">역</th>
+			<th scope="col">현재 상태</th>
+			<th scope="col">신뢰도</th>
+			<th scope="col">갱신일</th>
+			<th scope="col">상태 변경</th>
+		</tr>
+		</thead>
+		<tbody>
+		<tr th:each="facility : ${facilities}">
+			<td>
+				<span th:text="${facility.facilityName}">1번 출구 엘리베이터</span>
+				<span class="meta" th:text="${facility.typeLabel}">엘리베이터</span>
+				<span class="meta" th:text="${facility.facilityId}">facility-id</span>
+			</td>
+			<td>
+				<span th:text="${facility.stationName}">상록수</span>
+				<span class="meta" th:text="${facility.stationId}">station-id</span>
+			</td>
+			<td th:text="${facility.statusLabel}">정상</td>
+			<td th:text="${facility.confidenceLabel}">정보 신뢰도 높음</td>
+			<td th:text="${facility.lastUpdatedAt}">2026-06-12</td>
+			<td>
+				<form th:action="@{/admin/facilities/{facilityId}/page/status(facilityId=${facility.facilityId})}"
+				      method="post">
+					<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+					<label>
+						<span class="meta">변경할 상태</span>
+						<select name="status">
+							<option th:each="option : ${statusOptions}"
+							        th:value="${option.value}"
+							        th:selected="${option.value == facility.status}"
+							        th:text="${option.label}">정상</option>
+						</select>
+					</label>
+					<button type="submit">저장</button>
+				</form>
+			</td>
+		</tr>
+		</tbody>
+	</table>
+</main>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageControllerTest.java
@@ -1,0 +1,103 @@
+package com.easysubway.transit.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("관리자 시설 상태 화면")
+class TransitFacilityAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("관리자는 시설 상태 화면에서 시설과 현재 상태를 확인한다")
+	void adminGetsFacilityStatusPage() throws Exception {
+		String html = mockMvc.perform(get("/admin/facilities/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("시설 상태 관리")
+			.contains("상록수")
+			.contains("1번 출구 엘리베이터")
+			.contains("엘리베이터")
+			.contains("정상")
+			.contains("장애인 화장실")
+			.contains("확인 필요")
+			.contains("정보 신뢰도 높음")
+			.contains("name=\"status\"")
+			.contains("name=\"_csrf\"");
+	}
+
+	@Test
+	@DisplayName("관리자는 시설 상태 화면에서 상태를 변경한 뒤 목록으로 돌아온다")
+	@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+	void adminUpdatesFacilityStatusFromPageAndRedirectsToList() throws Exception {
+		mockMvc.perform(post("/admin/facilities/facility-sangnoksu-elevator-1/page/status")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("status", "BROKEN"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(header().string("Location", "/admin/facilities/page"));
+
+		String html = mockMvc.perform(get("/admin/facilities/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("1번 출구 엘리베이터")
+			.contains("고장");
+	}
+
+	@Test
+	@DisplayName("관리자 시설 상태 화면은 관리자 인증을 요구한다")
+	void facilityStatusPagesRequireAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/facilities/page"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/facilities/page")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(post("/admin/facilities/facility-sangnoksu-elevator-1/page/status")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("status", "BROKEN"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(post("/admin/facilities/facility-sangnoksu-elevator-1/page/status")
+				.with(httpBasic("basic-user", "user-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("status", "BROKEN"))
+			.andExpect(status().isForbidden());
+	}
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #198

## 요약
- 관리자용 시설 상태 목록 화면을 추가했습니다.
- 목록 화면에서 시설 상태를 바로 변경할 수 있게 기존 관리자 유스케이스를 연결했습니다.
- 관리자 인증, CSRF, 상태 변경 후 목록 복귀 흐름을 테스트로 고정했습니다.

## 변경 사항
- `GET /admin/facilities/page`에서 역별 시설 상태 목록을 렌더링합니다.
- `POST /admin/facilities/{facilityId}/page/status`에서 선택한 상태로 시설 상태를 변경합니다.
- 시설 유형, 상태, 신뢰도 값을 관리자 화면에서 바로 읽을 수 있는 한국어 라벨로 표시합니다.
- 관리자와 일반 사용자 접근 권한 차이를 MockMvc 테스트로 확인합니다.

## 검증
- `./gradlew test --tests "*TransitFacilityAdminPageControllerTest"`
- `./gradlew test`
- `node --test tools/ci/*.test.mjs`
- `flutter test test/widget_test.dart --plain-name "시설 신고 화면은 GPS가 꺼져 있으면 위치 확인을 요청하고 제출을 막는다"`
- `flutter test test/widget_test.dart --plain-name "시설 신고 화면은 현재 위치를 함께 보낸다"`

## 리스크
- 현재 목록은 등록된 역과 시설을 한 화면에 보여주는 구조입니다. 시설 데이터가 크게 늘어나면 검색이나 페이지네이션을 별도 작업으로 추가해야 합니다.