### PR TITLE
[Fix] 모바일 릴리즈 API 기본 주소 보안 강화

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -3548,6 +3548,9 @@ Uri stationApiBaseUriForEnvironment({
     if (isReleaseMode && baseUri.scheme != 'https') {
       throw StateError('Release API base URL must use HTTPS.');
     }
+    if (isReleaseMode && baseUri.host.isEmpty) {
+      throw StateError('Release API base URL must include a host.');
+    }
     return baseUri;
   }
   if (isReleaseMode) {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'auth_headers.dart';
@@ -11,8 +12,7 @@ import 'mobile_error_reporter.dart';
 
 const _stationSearchTimeout = Duration(seconds: 8);
 const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
-const _currentLocationDisabledMessage =
-    '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
+const _currentLocationDisabledMessage = '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
 const _favoriteStationTimeout = Duration(seconds: 8);
 const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했습니다.';
 const _favoriteStationStatusErrorMessage = '즐겨찾기를 확인하지 못했습니다.';
@@ -3530,10 +3530,31 @@ double _contrastRatio(Color first, Color second) {
 
 Uri defaultStationApiBaseUri() {
   const configuredBaseUrl = String.fromEnvironment('EASYSUBWAY_API_BASE_URL');
-  if (configuredBaseUrl.isNotEmpty) {
-    return Uri.parse(configuredBaseUrl);
+  return stationApiBaseUriForEnvironment(
+    configuredBaseUrl: configuredBaseUrl,
+    isAndroid: Platform.isAndroid,
+    isReleaseMode: kReleaseMode,
+  );
+}
+
+Uri stationApiBaseUriForEnvironment({
+  required String configuredBaseUrl,
+  required bool isAndroid,
+  required bool isReleaseMode,
+}) {
+  final trimmedBaseUrl = configuredBaseUrl.trim();
+  if (trimmedBaseUrl.isNotEmpty) {
+    final baseUri = Uri.parse(trimmedBaseUrl);
+    if (isReleaseMode && baseUri.scheme != 'https') {
+      throw StateError('Release API base URL must use HTTPS.');
+    }
+    return baseUri;
   }
-  if (Platform.isAndroid) {
+  if (isReleaseMode) {
+    // 운영 빌드는 로컬 개발 주소로 조용히 떨어지지 않게 빌드 설정 누락을 즉시 드러낸다.
+    throw StateError('Release API base URL must be configured.');
+  }
+  if (isAndroid) {
     return Uri.parse('http://10.0.2.2:8080');
   }
   return Uri.parse('http://127.0.0.1:8080');

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -8,6 +8,58 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('릴리즈 빌드는 API 기본 주소를 반드시 설정해야 한다', () {
+    expect(
+      () => stationApiBaseUriForEnvironment(
+        configuredBaseUrl: '',
+        isAndroid: true,
+        isReleaseMode: true,
+      ),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'Release API base URL must be configured.',
+        ),
+      ),
+    );
+  });
+
+  test('릴리즈 빌드는 HTTPS API 주소만 사용한다', () {
+    expect(
+      () => stationApiBaseUriForEnvironment(
+        configuredBaseUrl: 'http://api.easysubway.example',
+        isAndroid: false,
+        isReleaseMode: true,
+      ),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'Release API base URL must use HTTPS.',
+        ),
+      ),
+    );
+
+    final baseUri = stationApiBaseUriForEnvironment(
+      configuredBaseUrl: 'https://api.easysubway.example',
+      isAndroid: false,
+      isReleaseMode: true,
+    );
+
+    expect(baseUri, Uri.parse('https://api.easysubway.example'));
+  });
+
+  test('개발 빌드는 Android 에뮬레이터 로컬 API 주소를 유지한다', () {
+    final baseUri = stationApiBaseUriForEnvironment(
+      configuredBaseUrl: '',
+      isAndroid: true,
+      isReleaseMode: false,
+    );
+
+    expect(baseUri, Uri.parse('http://10.0.2.2:8080'));
+  });
+
   test('역 데이터 품질은 내부 레벨을 쉬운 안내 문구로 바꾼다', () {
     final labels = ['LEVEL_1', 'LEVEL_2', 'LEVEL_3', 'LEVEL_4', 'UNKNOWN']
         .map(

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -50,6 +50,23 @@ void main() {
     expect(baseUri, Uri.parse('https://api.easysubway.example'));
   });
 
+  test('릴리즈 빌드는 호스트가 없는 API 주소를 거부한다', () {
+    expect(
+      () => stationApiBaseUriForEnvironment(
+        configuredBaseUrl: 'https://',
+        isAndroid: false,
+        isReleaseMode: true,
+      ),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'Release API base URL must include a host.',
+        ),
+      ),
+    );
+  });
+
   test('개발 빌드는 Android 에뮬레이터 로컬 API 주소를 유지한다', () {
     final baseUri = stationApiBaseUriForEnvironment(
       configuredBaseUrl: '',

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1438,7 +1438,16 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(stationSearch, /request\.close\(\)\.timeout\(_stationSearchTimeout\)/);
   assert.match(stationSearch, /HttpStatus\.unauthorized/);
   assert.match(stationSearch, /invalidateAuthorization\(\)/);
+  assert.match(stationSearch, /package:flutter\/foundation\.dart/);
+  assert.match(stationSearch, /const configuredBaseUrl = String\.fromEnvironment\('EASYSUBWAY_API_BASE_URL'\)/);
+  assert.match(stationSearch, /isReleaseMode: kReleaseMode/);
+  assert.match(stationSearch, /Uri stationApiBaseUriForEnvironment\(/);
+  assert.match(stationSearch, /Release API base URL must be configured\./);
+  assert.match(stationSearch, /Release API base URL must use HTTPS\./);
   assert.match(read("apps/mobile/test/station_search_test.dart"), /인증 실패 시 인증을 지우고 한 번 재시도한다/);
+  assert.match(read("apps/mobile/test/station_search_test.dart"), /릴리즈 빌드는 API 기본 주소를 반드시 설정해야 한다/);
+  assert.match(read("apps/mobile/test/station_search_test.dart"), /릴리즈 빌드는 HTTPS API 주소만 사용한다/);
+  assert.match(read("apps/mobile/test/station_search_test.dart"), /개발 빌드는 Android 에뮬레이터 로컬 API 주소를 유지한다/);
   assert.match(mapAdapter, /enum MapProviderType/);
   assert.match(mapAdapter, /MapProviderType\.naver => '네이버 지도'/);
   assert.match(mapAdapter, /MapProviderType\.kakao => '카카오 지도'/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1444,9 +1444,12 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(stationSearch, /Uri stationApiBaseUriForEnvironment\(/);
   assert.match(stationSearch, /Release API base URL must be configured\./);
   assert.match(stationSearch, /Release API base URL must use HTTPS\./);
+  assert.match(stationSearch, /baseUri\.host\.isEmpty/);
+  assert.match(stationSearch, /Release API base URL must include a host\./);
   assert.match(read("apps/mobile/test/station_search_test.dart"), /인증 실패 시 인증을 지우고 한 번 재시도한다/);
   assert.match(read("apps/mobile/test/station_search_test.dart"), /릴리즈 빌드는 API 기본 주소를 반드시 설정해야 한다/);
   assert.match(read("apps/mobile/test/station_search_test.dart"), /릴리즈 빌드는 HTTPS API 주소만 사용한다/);
+  assert.match(read("apps/mobile/test/station_search_test.dart"), /릴리즈 빌드는 호스트가 없는 API 주소를 거부한다/);
   assert.match(read("apps/mobile/test/station_search_test.dart"), /개발 빌드는 Android 에뮬레이터 로컬 API 주소를 유지한다/);
   assert.match(mapAdapter, /enum MapProviderType/);
   assert.match(mapAdapter, /MapProviderType\.naver => '네이버 지도'/);


### PR DESCRIPTION
## 관련 이슈
Closes #202

## 요약
모바일 앱의 API 기본 주소 정책을 release 빌드 기준으로 분리했습니다. `EASYSUBWAY_API_BASE_URL`이 비어 있거나 HTTPS가 아닌 값이면 release mode에서 즉시 오류를 내고, debug/profile에서는 기존 Android 에뮬레이터 로컬 API fallback을 유지합니다.

## 변경 사항
- API base URL 결정 로직을 테스트 가능한 정책 함수로 분리
- release mode에서 API base URL 누락을 오류로 처리
- release mode에서 HTTP API base URL을 오류로 처리
- release mode에서 호스트가 없는 HTTPS API base URL을 오류로 처리
- debug/profile Android 에뮬레이터 `http://10.0.2.2:8080` fallback 유지
- 모바일 단위 테스트와 repository contract에 릴리즈 API 주소 보안 정책 추가

## 검증
- `flutter test test/station_search_test.dart` 성공: 31개 통과
- `flutter test` 성공: 154개 통과
- `flutter analyze` 성공
- `node --test tools/ci/*.test.mjs` 성공: 37개 통과
- `git diff --check` 성공
- `git ls-files *.md` 확인: `.github/pull_request_template.md`, `README.md`만 추적
- local-only 브리프 ignore 확인: `docs/agent/2026-06-16-mobile-release-api-base-url.md`
- PR CI 성공: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI
- CodeRabbit 리뷰 확인: 호스트 없는 HTTPS 주소 검증 누락 지적 반영 후 스레드 resolved
- main CI 성공: run `27585677535`
- main CD 성공: run `27585677540`

## 리뷰어가 먼저 봐야 할 지점
- release mode에서 설정 누락을 조용히 로컬 HTTP 주소로 대체하지 않습니다.
- debug/profile 로컬 개발 흐름은 유지했습니다.
- 실제 운영 API 주소는 빌드 시 `--dart-define=EASYSUBWAY_API_BASE_URL=https://...`로 주입해야 합니다.

## 체크리스트
- [x] CodeRabbit 리뷰를 확인했다
- [ ] Codex CLI code review 결과를 확인했다 (CodeRabbit 리뷰가 정상 완료되어 대체 실행하지 않음)
- [x] CI 상태를 확인했다
- [x] CD 상태를 확인했다
