### PR TITLE
[Fix] 위치 기반 신고와 주변 역 확인 흐름 정리

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1445,8 +1445,8 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('사진·위치 확인'),
-        content: const Text('사진과 신고 위치를 함께 보냅니다.'),
+        title: const Text('사진 확인'),
+        content: const Text('사진을 함께 보냅니다.'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1446,7 +1446,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('사진 확인'),
-        content: const Text('사진을 함께 보냅니다.'),
+        content: const Text('사진과 위치를 함께 보냅니다.'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1839,7 +1839,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   final TextEditingController _queryController = TextEditingController();
   Future<List<SubwayLineOption>>? _lineOptionsFuture;
   SubwayLineOption? _selectedLine;
-  bool _isLocationPreflightRunning = false;
+  bool _isNearbySearchRunning = false;
   bool _isOpeningLocationSettings = false;
 
   @override
@@ -1876,7 +1876,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
                   return _StationLineFilterSection(
                     linesFuture: _lineOptionsFuture!,
                     selectedLine: _selectedLine,
-                    enabled: !isSearching && !_isLocationPreflightRunning,
+                    enabled: !isSearching && !_isNearbySearchRunning,
                     onLineSelected: _selectLine,
                   );
                 },
@@ -1925,7 +1925,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
               builder: (context, _) {
                 final isLoading =
                     _controller.state.status == StationSearchStatus.loading ||
-                    _isLocationPreflightRunning;
+                    _isNearbySearchRunning;
                 return OutlinedButton.icon(
                   key: const Key('nearbyStationSearchButton'),
                   onPressed: isLoading ? null : _searchNearby,
@@ -1973,27 +1973,17 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
 
   Future<void> _searchNearby() async {
     if (_controller.state.status == StationSearchStatus.loading ||
-        _isLocationPreflightRunning) {
+        _isNearbySearchRunning) {
       return;
     }
-    setState(() => _isLocationPreflightRunning = true);
+    setState(() => _isNearbySearchRunning = true);
+    // OS 권한 요청과 GPS 상태 확인은 네이티브 위치 조회에 맡기고,
+    // 사용자가 누른 즉시 가까운 역을 찾는 흐름으로 유지한다.
     try {
-      final needsPermissionRequest = await widget.locationProvider
-          .needsLocationPermissionRequest();
-      if (!mounted) {
-        return;
-      }
-      if (needsPermissionRequest &&
-          !await _confirmLocationUse(context, message: '현재 위치로 가까운 역을 찾습니다.')) {
-        return;
-      }
-      if (!mounted) {
-        return;
-      }
       await _controller.searchNearby(widget.locationProvider);
     } finally {
       if (mounted) {
-        setState(() => _isLocationPreflightRunning = false);
+        setState(() => _isNearbySearchRunning = false);
       }
     }
   }
@@ -2026,30 +2016,6 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       ),
     );
   }
-}
-
-Future<bool> _confirmLocationUse(
-  BuildContext context, {
-  required String message,
-}) async {
-  final confirmed = await showDialog<bool>(
-    context: context,
-    builder: (context) => AlertDialog(
-      title: const Text('현재 위치 사용'),
-      content: Text(message),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(false),
-          child: const Text('취소'),
-        ),
-        FilledButton(
-          onPressed: () => Navigator.of(context).pop(true),
-          child: const Text('위치 사용'),
-        ),
-      ],
-    ),
-  );
-  return confirmed ?? false;
 }
 
 class _StationLineFilterSection extends StatelessWidget {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3210,8 +3210,10 @@ void main() {
     await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('사진·위치 확인'), findsOneWidget);
-    expect(find.text('사진과 신고 위치를 함께 보냅니다.'), findsOneWidget);
+    expect(find.text('사진 확인'), findsOneWidget);
+    expect(find.text('사진을 함께 보냅니다.'), findsOneWidget);
+    expect(find.text('사진·위치 확인'), findsNothing);
+    expect(find.text('사진과 신고 위치를 함께 보냅니다.'), findsNothing);
     expect(reportRepository.requests, isEmpty);
 
     await tester.tap(find.text('취소'));

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1274,11 +1274,19 @@ void main() {
     }
   });
 
-  testWidgets('역 검색은 현재 위치 안내를 취소하면 위치를 요청하지 않는다', (tester) async {
+  testWidgets('역 검색은 현재 위치 확인창 없이 바로 주변 역을 찾는다', (tester) async {
     final locationProvider = FakeCurrentLocationProvider(
       location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
     );
-    final repository = FakeStationSearchRepository();
+    final repository = FakeStationSearchRepository(
+      nearbyResults: [
+        _stationResult(
+          id: 'station-sangnoksu',
+          name: '상록수',
+          distanceMeters: 230,
+        ),
+      ],
+    );
 
     await tester.pumpWidget(
       EasySubwayApp(
@@ -1296,19 +1304,17 @@ void main() {
     await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('취소'));
-    await tester.pumpAndSettle();
-
-    expect(locationProvider.requestCount, 0);
-    expect(repository.requestedNearbyLocations, isEmpty);
+    expect(locationProvider.permissionCheckCount, 0);
+    expect(locationProvider.requestCount, 1);
+    expect(repository.requestedNearbyLocations, hasLength(1));
     expect(find.text('현재 위치 사용'), findsNothing);
+    expect(find.text('상록수'), findsOneWidget);
   });
 
-  testWidgets('역 검색은 위치 권한 확인 중 중복 탭을 무시한다', (tester) async {
-    final permissionCompleter = Completer<bool>();
+  testWidgets('역 검색은 주변 역 확인 중 중복 탭을 무시한다', (tester) async {
+    final locationCompleter = Completer<CurrentLocation>();
     final locationProvider = FakeCurrentLocationProvider(
-      location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
-      needsPermissionRequestLoader: () => permissionCompleter.future,
+      locationLoader: () => locationCompleter.future,
     );
     final repository = FakeStationSearchRepository(
       nearbyResults: [
@@ -1337,13 +1343,14 @@ void main() {
     await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
     await tester.pump();
 
-    expect(locationProvider.permissionCheckCount, 1);
-    expect(locationProvider.requestCount, 0);
+    expect(locationProvider.permissionCheckCount, 0);
+    expect(locationProvider.requestCount, 1);
 
-    permissionCompleter.complete(false);
+    locationCompleter.complete(
+      const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
+    );
     await tester.pumpAndSettle();
 
-    expect(locationProvider.requestCount, 1);
     expect(repository.requestedNearbyLocations, hasLength(1));
   });
 
@@ -1369,8 +1376,6 @@ void main() {
       await tester.tap(find.byKey(const Key('stationSearchButton')));
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('위치 사용'));
       await tester.pumpAndSettle();
 
       expect(locationProvider.requestCount, 1);
@@ -3211,7 +3216,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('사진 확인'), findsOneWidget);
-    expect(find.text('사진을 함께 보냅니다.'), findsOneWidget);
+    expect(find.text('사진과 위치를 함께 보냅니다.'), findsOneWidget);
     expect(find.text('사진·위치 확인'), findsNothing);
     expect(find.text('사진과 신고 위치를 함께 보냅니다.'), findsNothing);
     expect(reportRepository.requests, isEmpty);
@@ -4494,12 +4499,14 @@ class FakeCurrentLocationProvider implements CurrentLocationProvider {
   FakeCurrentLocationProvider({
     this.location,
     this.error,
+    this.locationLoader,
     this.needsPermissionRequest = true,
     this.needsPermissionRequestLoader,
   });
 
   final CurrentLocation? location;
   final Object? error;
+  final Future<CurrentLocation> Function()? locationLoader;
   final bool needsPermissionRequest;
   final Future<bool> Function()? needsPermissionRequestLoader;
   int permissionCheckCount = 0;
@@ -4519,6 +4526,10 @@ class FakeCurrentLocationProvider implements CurrentLocationProvider {
   @override
   Future<CurrentLocation> currentLocation() async {
     requestCount++;
+    final loader = locationLoader;
+    if (loader != null) {
+      return loader();
+    }
     final currentError = error;
     if (currentError != null) {
       throw currentError;


### PR DESCRIPTION
## 관련 이슈
Closes #204

## 요약
시설 신고에서 사진을 첨부한 뒤 보내기 전에 뜨는 확인 다이얼로그를 짧게 정리하되, 사진과 위치가 함께 전송된다는 사실은 숨기지 않도록 조정했습니다. 주변 역 찾기는 앱 자체 확인창 없이 바로 네이티브 위치 조회로 이어지게 바꿔, GPS가 켜져 있으면 바로 역 판단에 쓰고 GPS가 꺼져 있으면 기존 안내와 위치 설정 흐름을 보여줍니다.

## 변경 사항
- 사진 첨부 후 제출 확인 다이얼로그 제목을 `사진 확인`으로 유지
- 확인 다이얼로그 본문을 `사진과 위치를 함께 보냅니다.`로 변경
- 주변 역 찾기에서 앱 자체 `현재 위치 사용` 확인 다이얼로그 제거
- 주변 역 조회 중 빠른 중복 탭을 막는 화면 잠금 상태 추가
- GPS 꺼짐 안내, 위치 설정 열기, 위치 다시 확인, 제출 차단 테스트 보강

## 검증
- `flutter test test/widget_test.dart --plain-name '역 검색은 현재 위치 확인창 없이 바로 주변 역을 찾는다'` 성공
- `flutter test test/widget_test.dart --plain-name '역 검색은 주변 역 확인 중 중복 탭을 무시한다'` 성공
- `flutter test test/widget_test.dart --plain-name '역 검색은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다'` 성공
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 사진과 위치를 보내기 전에 확인한다'` 성공
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 GPS가 꺼져 있으면 위치 확인을 요청하고 제출을 막는다'` 성공
- `flutter analyze` 성공
- `flutter test` 성공: 155개 통과
- `node --test tools/ci/*.test.mjs` 성공: 37개 통과
- `git diff --check` 성공
- `git ls-files '*.md'` 확인: `.github/pull_request_template.md`, `README.md`만 추적
- Android 에뮬레이터 실제 화면 확인: 주변 역 찾기는 앱 자체 위치 확인창 없이 OS 위치 권한 요청으로 이어짐
- Android 에뮬레이터 실제 화면 확인: 사진 첨부 후 확인창에 `사진 확인` / `사진과 위치를 함께 보냅니다.` 표시

## 리뷰어가 먼저 봐야 할 지점
- 사진 확인 다이얼로그는 짧게 유지하지만 위치 전송 사실은 명시합니다.
- 주변 역 찾기는 별도 확인창 없이 OS 위치 권한 요청과 GPS 상태 안내에 맡깁니다.
- 위치가 확인된 신고 요청에는 기존처럼 좌표가 포함됩니다.

## 체크리스트
- [x] CodeRabbit 상태를 확인했다 (rate limit 및 prepaid credit 부족으로 실제 리뷰 미시작)
- [x] Codex CLI code review 결과를 확인했다
- [x] CI 상태를 확인했다
- [x] CD 상태를 확인했다
