### PR TITLE
[Feat] 온보딩 위치 권한 준비 흐름 추가

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -256,6 +256,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
 
     if (!_onboardingState.isCompleted) {
       return OnboardingScreen(
+        locationProvider: widget.locationProvider,
         onCompleted: (result) async {
           await _saveOnboardingResult(result);
           setState(() {

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -5,6 +5,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'mobility_profile.dart';
 import 'mobile_error_reporter.dart';
+import 'station_search.dart';
 
 const _onboardingResultStorageKey = 'easysubway.onboarding.result';
 
@@ -164,9 +165,14 @@ class OnboardingState {
 }
 
 class OnboardingScreen extends StatefulWidget {
-  const OnboardingScreen({required this.onCompleted, super.key});
+  const OnboardingScreen({
+    required this.onCompleted,
+    this.locationProvider,
+    super.key,
+  });
 
   final ValueChanged<OnboardingResult> onCompleted;
+  final CurrentLocationProvider? locationProvider;
 
   @override
   State<OnboardingScreen> createState() => _OnboardingScreenState();
@@ -176,6 +182,10 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   MobilityProfileOption? _selectedProfile;
   OnboardingViewPreferences _preferences =
       const OnboardingViewPreferences.defaults();
+  String _locationMessage = '';
+  bool _isLocationFailure = false;
+  bool _isCheckingLocation = false;
+  bool _isOpeningLocationSettings = false;
 
   @override
   Widget build(BuildContext context) {
@@ -242,6 +252,25 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                   });
                 },
               ),
+            if (widget.locationProvider != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                '현재 위치',
+                style: textTheme.titleLarge?.copyWith(
+                  color: const Color(0xFF102A2C),
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 12),
+              _OnboardingLocationSection(
+                message: _locationMessage,
+                isFailure: _isLocationFailure,
+                isChecking: _isCheckingLocation,
+                isOpeningSettings: _isOpeningLocationSettings,
+                onPrepareLocation: _prepareLocation,
+                onOpenSettings: _openLocationSettings,
+              ),
+            ],
             const SizedBox(height: 12),
             Text(
               '보기 설정',
@@ -284,6 +313,187 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                   );
                 });
               },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _prepareLocation() async {
+    final locationProvider = widget.locationProvider;
+    if (locationProvider == null || _isCheckingLocation) {
+      return;
+    }
+    setState(() {
+      _isCheckingLocation = true;
+      _locationMessage = '';
+      _isLocationFailure = false;
+    });
+    try {
+      // 온보딩에서는 좌표를 저장하지 않고, 이후 주변 역 찾기에서 바로 쓸 권한과 GPS 상태만 준비한다.
+      await locationProvider.currentLocation();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _locationMessage = '위치 준비 완료';
+        _isLocationFailure = false;
+      });
+    } on CurrentLocationException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _locationMessage = error.message;
+        _isLocationFailure = true;
+      });
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '온보딩 현재 위치 준비 중 예외가 발생했습니다.',
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _locationMessage = '현재 위치를 확인하지 못했습니다.';
+        _isLocationFailure = true;
+      });
+    } finally {
+      if (mounted) {
+        setState(() => _isCheckingLocation = false);
+      }
+    }
+  }
+
+  Future<void> _openLocationSettings() async {
+    final locationProvider = widget.locationProvider;
+    if (locationProvider == null || _isOpeningLocationSettings) {
+      return;
+    }
+    setState(() => _isOpeningLocationSettings = true);
+    try {
+      await locationProvider.openLocationSettings();
+    } finally {
+      if (mounted) {
+        setState(() => _isOpeningLocationSettings = false);
+      }
+    }
+  }
+}
+
+class _OnboardingLocationSection extends StatelessWidget {
+  const _OnboardingLocationSection({
+    required this.message,
+    required this.isFailure,
+    required this.isChecking,
+    required this.isOpeningSettings,
+    required this.onPrepareLocation,
+    required this.onOpenSettings,
+  });
+
+  final String message;
+  final bool isFailure;
+  final bool isChecking;
+  final bool isOpeningSettings;
+  final VoidCallback onPrepareLocation;
+  final VoidCallback onOpenSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          '가까운 역을 자동으로 찾으려면 GPS가 필요합니다.',
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+            color: const Color(0xFF29484B),
+            fontWeight: FontWeight.w700,
+            height: 1.3,
+          ),
+        ),
+        const SizedBox(height: 12),
+        OutlinedButton.icon(
+          key: const Key('onboardingLocationButton'),
+          onPressed: isChecking ? null : onPrepareLocation,
+          icon: isChecking
+              ? const SizedBox(
+                  width: 22,
+                  height: 22,
+                  child: CircularProgressIndicator(strokeWidth: 2.5),
+                )
+              : const Icon(Icons.my_location),
+          label: const Text('위치 켜기'),
+          style: OutlinedButton.styleFrom(
+            minimumSize: const Size.fromHeight(60),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+        ),
+        if (message.isNotEmpty) ...[
+          const SizedBox(height: 10),
+          _OnboardingLocationMessage(message: message, isFailure: isFailure),
+        ],
+        if (isFailure) ...[
+          const SizedBox(height: 10),
+          OutlinedButton.icon(
+            key: const Key('onboardingOpenLocationSettingsButton'),
+            onPressed: isOpeningSettings ? null : onOpenSettings,
+            icon: isOpeningSettings
+                ? const SizedBox(
+                    width: 22,
+                    height: 22,
+                    child: CircularProgressIndicator(strokeWidth: 2.5),
+                  )
+                : const Icon(Icons.settings),
+            label: const Text('위치 설정 열기'),
+            style: OutlinedButton.styleFrom(
+              minimumSize: const Size.fromHeight(60),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _OnboardingLocationMessage extends StatelessWidget {
+  const _OnboardingLocationMessage({
+    required this.message,
+    required this.isFailure,
+  });
+
+  final String message;
+  final bool isFailure;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isFailure ? const Color(0xFF8A4B00) : const Color(0xFF006D77);
+    final icon = isFailure ? Icons.error_outline : Icons.check_circle_outline;
+
+    return Semantics(
+      label: message,
+      liveRegion: true,
+      child: ExcludeSemantics(
+        child: Row(
+          children: [
+            Icon(icon, color: color, size: 24),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                message,
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: const Color(0xFF102A2C),
+                  fontWeight: FontWeight.w800,
+                  height: 1.3,
+                ),
+              ),
             ),
           ],
         ),

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -322,7 +322,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
 
   Future<void> _prepareLocation() async {
     final locationProvider = widget.locationProvider;
-    if (locationProvider == null || _isCheckingLocation) {
+    if (locationProvider == null ||
+        _isCheckingLocation ||
+        _isOpeningLocationSettings) {
       return;
     }
     setState(() {
@@ -370,7 +372,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
 
   Future<void> _openLocationSettings() async {
     final locationProvider = widget.locationProvider;
-    if (locationProvider == null || _isOpeningLocationSettings) {
+    if (locationProvider == null ||
+        _isOpeningLocationSettings ||
+        _isCheckingLocation) {
       return;
     }
     setState(() => _isOpeningLocationSettings = true);
@@ -417,7 +421,7 @@ class _OnboardingLocationSection extends StatelessWidget {
         const SizedBox(height: 12),
         OutlinedButton.icon(
           key: const Key('onboardingLocationButton'),
-          onPressed: isChecking ? null : onPrepareLocation,
+          onPressed: isChecking || isOpeningSettings ? null : onPrepareLocation,
           icon: isChecking
               ? const SizedBox(
                   width: 22,
@@ -441,7 +445,7 @@ class _OnboardingLocationSection extends StatelessWidget {
           const SizedBox(height: 10),
           OutlinedButton.icon(
             key: const Key('onboardingOpenLocationSettingsButton'),
-            onPressed: isOpeningSettings ? null : onOpenSettings,
+            onPressed: isOpeningSettings || isChecking ? null : onOpenSettings,
             icon: isOpeningSettings
                 ? const SizedBox(
                     width: 22,

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:easysubway_mobile/mobility_profile.dart';
 import 'package:easysubway_mobile/onboarding.dart';
 import 'package:easysubway_mobile/station_search.dart';
@@ -147,6 +149,48 @@ void main() {
     expect(locationProvider.openSettingsCount, 1);
   });
 
+  testWidgets('온보딩은 위치 설정을 여는 동안 위치 확인을 다시 시작하지 않는다', (tester) async {
+    final openSettingsCompleter = Completer<bool>();
+    final locationProvider = FakeCurrentLocationProvider(
+      error: const CurrentLocationException(
+        '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
+      ),
+      openSettingsLoader: () => openSettingsCompleter.future,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OnboardingScreen(
+          locationProvider: locationProvider,
+          onCompleted: (_) {},
+        ),
+      ),
+    );
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('onboardingLocationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('onboardingLocationButton')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const Key('onboardingOpenLocationSettingsButton')),
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('onboardingLocationButton')));
+    await tester.pump();
+
+    expect(locationProvider.requestCount, 1);
+    expect(locationProvider.openSettingsCount, 1);
+
+    openSettingsCompleter.complete(true);
+    await tester.pumpAndSettle();
+  });
+
   test('온보딩 완료 결과는 선택한 이동 조건과 보기 설정을 함께 담는다', () {
     final result = OnboardingResult(
       profile: mobilityProfileOptions.firstWhere(
@@ -211,10 +255,15 @@ void main() {
 }
 
 class FakeCurrentLocationProvider implements CurrentLocationProvider {
-  FakeCurrentLocationProvider({this.location, this.error});
+  FakeCurrentLocationProvider({
+    this.location,
+    this.error,
+    this.openSettingsLoader,
+  });
 
   final CurrentLocation? location;
   final Object? error;
+  final Future<bool> Function()? openSettingsLoader;
   int requestCount = 0;
   int openSettingsCount = 0;
 
@@ -235,6 +284,10 @@ class FakeCurrentLocationProvider implements CurrentLocationProvider {
   @override
   Future<bool> openLocationSettings() async {
     openSettingsCount++;
+    final loader = openSettingsLoader;
+    if (loader != null) {
+      return loader();
+    }
     return true;
   }
 }

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -1,5 +1,6 @@
 import 'package:easysubway_mobile/mobility_profile.dart';
 import 'package:easysubway_mobile/onboarding.dart';
+import 'package:easysubway_mobile/station_search.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -76,6 +77,76 @@ void main() {
     }
   });
 
+  testWidgets('온보딩은 사용자가 누르면 위치 권한 준비를 시작한다', (tester) async {
+    final locationProvider = FakeCurrentLocationProvider(
+      location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OnboardingScreen(
+          locationProvider: locationProvider,
+          onCompleted: (_) {},
+        ),
+      ),
+    );
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('onboardingLocationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('가까운 역을 자동으로 찾으려면 GPS가 필요합니다.'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('onboardingLocationButton')));
+    await tester.pumpAndSettle();
+
+    expect(locationProvider.requestCount, 1);
+    expect(find.text('위치 준비 완료'), findsOneWidget);
+  });
+
+  testWidgets('온보딩은 GPS가 꺼져 있으면 위치 설정을 열 수 있다', (tester) async {
+    final locationProvider = FakeCurrentLocationProvider(
+      error: const CurrentLocationException(
+        '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
+      ),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OnboardingScreen(
+          locationProvider: locationProvider,
+          onCompleted: (_) {},
+        ),
+      ),
+    );
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('onboardingLocationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('onboardingLocationButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
+    expect(
+      find.byKey(const Key('onboardingOpenLocationSettingsButton')),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.byKey(const Key('onboardingOpenLocationSettingsButton')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(locationProvider.openSettingsCount, 1);
+  });
+
   test('온보딩 완료 결과는 선택한 이동 조건과 보기 설정을 함께 담는다', () {
     final result = OnboardingResult(
       profile: mobilityProfileOptions.firstWhere(
@@ -137,4 +208,33 @@ void main() {
       throwsA(isA<FormatException>()),
     );
   });
+}
+
+class FakeCurrentLocationProvider implements CurrentLocationProvider {
+  FakeCurrentLocationProvider({this.location, this.error});
+
+  final CurrentLocation? location;
+  final Object? error;
+  int requestCount = 0;
+  int openSettingsCount = 0;
+
+  @override
+  Future<bool> needsLocationPermissionRequest() async => true;
+
+  @override
+  Future<CurrentLocation> currentLocation() async {
+    requestCount++;
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return location ??
+        const CurrentLocation(latitude: 37.3028, longitude: 126.8665);
+  }
+
+  @override
+  Future<bool> openLocationSettings() async {
+    openSettingsCount++;
+    return true;
+  }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -71,6 +71,38 @@ void main() {
     expect(onboardingStore.saveCount, 1);
   });
 
+  testWidgets('첫 실행 앱은 온보딩에서 위치 권한을 준비할 수 있다', (tester) async {
+    final locationProvider = FakeCurrentLocationProvider(
+      location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        onboardingStore: MemoryOnboardingResultStore(),
+        locationProvider: locationProvider,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('onboardingLocationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('onboardingLocationButton')));
+    await tester.pumpAndSettle();
+
+    expect(locationProvider.requestCount, 1);
+    expect(find.text('위치 준비 완료'), findsOneWidget);
+  });
+
   testWidgets('앱은 저장된 온보딩 설정으로 홈을 바로 보여준다', (tester) async {
     final onboardingStore = MemoryOnboardingResultStore(
       initialResult: OnboardingResult(


### PR DESCRIPTION
Closes #206

## 배경
첫 사용자는 주변 역 찾기나 시설 신고를 누른 뒤에야 위치 권한과 GPS 상태를 마주칩니다. 가까운 역을 자동으로 판단하려면 위치가 필요하므로, 온보딩에서 짧게 위치 사용을 준비할 수 있도록 했습니다.

## 변경 사항
- 온보딩 화면에 `현재 위치` 영역을 추가하고 `위치 켜기` 버튼을 연결했습니다.
- 버튼을 누르면 앱 자체 확인창 없이 네이티브 위치 요청으로 이어지게 했습니다.
- GPS가 꺼져 있거나 위치를 확인하지 못하면 쉬운 안내 문구와 `위치 설정 열기` 버튼을 보여줍니다.
- 위치 준비는 온보딩 완료를 막지 않으며, 성공 시 `위치 준비 완료`만 짧게 표시합니다.
- 온보딩 통합 테스트와 GPS 꺼짐 테스트를 추가했습니다.

## 검증
- `flutter analyze`
- `flutter test --reporter expanded`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `git ls-files '*.md'`
- Android emulator: 첫 실행 온보딩에서 `현재 위치` 영역, `위치 켜기`, OS 위치 권한 다이얼로그, `위치 준비 완료` 상태 확인

## 리뷰 포인트
- 온보딩 문구가 과하게 설명적이지 않고 위치 사용 목적을 충분히 전달하는지
- 위치 권한 준비 실패가 온보딩 완료 흐름을 막지 않는지
- 기존 주변 역 찾기와 시설 신고 위치 흐름에 회귀가 없는지

## 체크리스트
- [x] 위치 권한 준비는 사용자 액션 뒤에만 시작한다.
- [x] GPS 꺼짐 상태는 설정 이동 버튼으로 복구할 수 있다.
- [x] README 외 Markdown 문서는 추가 추적하지 않았다.
- [x] Android 에뮬레이터에서 실제 화면을 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 온보딩 흐름에 현재 위치 확인 단계 추가
  * 위치 권한 요청 및 위치 설정 오픈 기능 제공
  * 위치 준비 상태 표시 및 오류 메시지 UI 추가

* **테스트**
  * 위치 권한 및 설정 플로우 검증 테스트 추가
  * 온보딩 위치 기능 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->