### PR TITLE
[Feat] 온보딩 알림 권한 준비 흐름 추가

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -533,10 +533,10 @@ class _EasySubwayAppDependencies {
           authProvider: sharedAuthProvider,
         );
     final resolvedNotificationPermissionProvider =
-        resolvedNotificationRepository == null
-        ? null
-        : notificationPermissionProvider ??
-              MethodChannelNotificationPermissionProvider();
+        notificationPermissionProvider ??
+        (resolvedNotificationRepository == null
+            ? null
+            : MethodChannelNotificationPermissionProvider());
 
     return _EasySubwayAppDependencies(
       repository: repository ?? StationSearchApiRepository(baseUri: baseUri),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -526,6 +526,17 @@ class _EasySubwayAppDependencies {
       anonymousAuthRepository: anonymousAuthRepository,
       enableAnonymousAuth: enableAnonymousAuth,
     );
+    final resolvedNotificationRepository =
+        notificationRepository ??
+        _defaultNotificationSettingsRepository(
+          baseUri: baseUri,
+          authProvider: sharedAuthProvider,
+        );
+    final resolvedNotificationPermissionProvider =
+        resolvedNotificationRepository == null
+        ? null
+        : notificationPermissionProvider ??
+              MethodChannelNotificationPermissionProvider();
 
     return _EasySubwayAppDependencies(
       repository: repository ?? StationSearchApiRepository(baseUri: baseUri),
@@ -561,15 +572,8 @@ class _EasySubwayAppDependencies {
             baseUri: baseUri,
             authProvider: sharedAuthProvider,
           ),
-      notificationRepository:
-          notificationRepository ??
-          _defaultNotificationSettingsRepository(
-            baseUri: baseUri,
-            authProvider: sharedAuthProvider,
-          ),
-      notificationPermissionProvider:
-          notificationPermissionProvider ??
-          MethodChannelNotificationPermissionProvider(),
+      notificationRepository: resolvedNotificationRepository,
+      notificationPermissionProvider: resolvedNotificationPermissionProvider,
       locationProvider:
           locationProvider ?? MethodChannelCurrentLocationProvider(),
     );

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -257,6 +257,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
     if (!_onboardingState.isCompleted) {
       return OnboardingScreen(
         locationProvider: widget.locationProvider,
+        notificationPermissionProvider: widget.notificationPermissionProvider,
         onCompleted: (result) async {
           await _saveOnboardingResult(result);
           setState(() {

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -5,6 +5,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'mobility_profile.dart';
 import 'mobile_error_reporter.dart';
+import 'notification_settings.dart';
 import 'station_search.dart';
 
 const _onboardingResultStorageKey = 'easysubway.onboarding.result';
@@ -168,11 +169,13 @@ class OnboardingScreen extends StatefulWidget {
   const OnboardingScreen({
     required this.onCompleted,
     this.locationProvider,
+    this.notificationPermissionProvider,
     super.key,
   });
 
   final ValueChanged<OnboardingResult> onCompleted;
   final CurrentLocationProvider? locationProvider;
+  final NotificationPermissionProvider? notificationPermissionProvider;
 
   @override
   State<OnboardingScreen> createState() => _OnboardingScreenState();
@@ -186,6 +189,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   bool _isLocationFailure = false;
   bool _isCheckingLocation = false;
   bool _isOpeningLocationSettings = false;
+  String _notificationMessage = '';
+  bool _isNotificationFailure = false;
+  bool _isRequestingNotificationPermission = false;
 
   @override
   Widget build(BuildContext context) {
@@ -267,8 +273,27 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                 isFailure: _isLocationFailure,
                 isChecking: _isCheckingLocation,
                 isOpeningSettings: _isOpeningLocationSettings,
+                isBlocked: _isRequestingNotificationPermission,
                 onPrepareLocation: _prepareLocation,
                 onOpenSettings: _openLocationSettings,
+              ),
+            ],
+            if (widget.notificationPermissionProvider != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                '알림',
+                style: textTheme.titleLarge?.copyWith(
+                  color: const Color(0xFF102A2C),
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 12),
+              _OnboardingNotificationSection(
+                message: _notificationMessage,
+                isFailure: _isNotificationFailure,
+                isRequesting: _isRequestingNotificationPermission,
+                isBlocked: _isCheckingLocation || _isOpeningLocationSettings,
+                onPrepareNotification: _prepareNotification,
               ),
             ],
             const SizedBox(height: 12),
@@ -324,7 +349,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     final locationProvider = widget.locationProvider;
     if (locationProvider == null ||
         _isCheckingLocation ||
-        _isOpeningLocationSettings) {
+        _isOpeningLocationSettings ||
+        _isRequestingNotificationPermission) {
       return;
     }
     setState(() {
@@ -374,7 +400,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     final locationProvider = widget.locationProvider;
     if (locationProvider == null ||
         _isOpeningLocationSettings ||
-        _isCheckingLocation) {
+        _isCheckingLocation ||
+        _isRequestingNotificationPermission) {
       return;
     }
     setState(() => _isOpeningLocationSettings = true);
@@ -386,6 +413,61 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       }
     }
   }
+
+  Future<void> _prepareNotification() async {
+    final notificationPermissionProvider =
+        widget.notificationPermissionProvider;
+    if (notificationPermissionProvider == null ||
+        _isRequestingNotificationPermission ||
+        _isCheckingLocation ||
+        _isOpeningLocationSettings) {
+      return;
+    }
+    setState(() {
+      _isRequestingNotificationPermission = true;
+      _notificationMessage = '';
+      _isNotificationFailure = false;
+    });
+    try {
+      // 온보딩에서는 토큰을 등록하지 않고, 이후 알림 설정에서 쓸 기기 권한만 준비한다.
+      final status = await notificationPermissionProvider
+          .requestNotificationPermission();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _notificationMessage = status == NotificationPermissionStatus.granted
+            ? '알림 준비 완료'
+            : '알림 권한을 켜 주세요.';
+        _isNotificationFailure = status != NotificationPermissionStatus.granted;
+      });
+    } on NotificationSettingsException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _notificationMessage = error.message;
+        _isNotificationFailure = true;
+      });
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '온보딩 알림 권한 준비 중 예외가 발생했습니다.',
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _notificationMessage = '알림 권한을 확인하지 못했습니다.';
+        _isNotificationFailure = true;
+      });
+    } finally {
+      if (mounted) {
+        setState(() => _isRequestingNotificationPermission = false);
+      }
+    }
+  }
 }
 
 class _OnboardingLocationSection extends StatelessWidget {
@@ -394,6 +476,7 @@ class _OnboardingLocationSection extends StatelessWidget {
     required this.isFailure,
     required this.isChecking,
     required this.isOpeningSettings,
+    required this.isBlocked,
     required this.onPrepareLocation,
     required this.onOpenSettings,
   });
@@ -402,6 +485,7 @@ class _OnboardingLocationSection extends StatelessWidget {
   final bool isFailure;
   final bool isChecking;
   final bool isOpeningSettings;
+  final bool isBlocked;
   final VoidCallback onPrepareLocation;
   final VoidCallback onOpenSettings;
 
@@ -421,7 +505,9 @@ class _OnboardingLocationSection extends StatelessWidget {
         const SizedBox(height: 12),
         OutlinedButton.icon(
           key: const Key('onboardingLocationButton'),
-          onPressed: isChecking || isOpeningSettings ? null : onPrepareLocation,
+          onPressed: isChecking || isOpeningSettings || isBlocked
+              ? null
+              : onPrepareLocation,
           icon: isChecking
               ? const SizedBox(
                   width: 22,
@@ -439,13 +525,15 @@ class _OnboardingLocationSection extends StatelessWidget {
         ),
         if (message.isNotEmpty) ...[
           const SizedBox(height: 10),
-          _OnboardingLocationMessage(message: message, isFailure: isFailure),
+          _OnboardingStatusMessage(message: message, isFailure: isFailure),
         ],
         if (isFailure) ...[
           const SizedBox(height: 10),
           OutlinedButton.icon(
             key: const Key('onboardingOpenLocationSettingsButton'),
-            onPressed: isOpeningSettings || isChecking ? null : onOpenSettings,
+            onPressed: isOpeningSettings || isChecking || isBlocked
+                ? null
+                : onOpenSettings,
             icon: isOpeningSettings
                 ? const SizedBox(
                     width: 22,
@@ -467,8 +555,64 @@ class _OnboardingLocationSection extends StatelessWidget {
   }
 }
 
-class _OnboardingLocationMessage extends StatelessWidget {
-  const _OnboardingLocationMessage({
+class _OnboardingNotificationSection extends StatelessWidget {
+  const _OnboardingNotificationSection({
+    required this.message,
+    required this.isFailure,
+    required this.isRequesting,
+    required this.isBlocked,
+    required this.onPrepareNotification,
+  });
+
+  final String message;
+  final bool isFailure;
+  final bool isRequesting;
+  final bool isBlocked;
+  final VoidCallback onPrepareNotification;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          '시설 고장과 신고 결과를 알려드려요.',
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+            color: const Color(0xFF29484B),
+            fontWeight: FontWeight.w700,
+            height: 1.3,
+          ),
+        ),
+        const SizedBox(height: 12),
+        OutlinedButton.icon(
+          key: const Key('onboardingNotificationButton'),
+          onPressed: isRequesting || isBlocked ? null : onPrepareNotification,
+          icon: isRequesting
+              ? const SizedBox(
+                  width: 22,
+                  height: 22,
+                  child: CircularProgressIndicator(strokeWidth: 2.5),
+                )
+              : const Icon(Icons.notifications_active_outlined),
+          label: const Text('알림 켜기'),
+          style: OutlinedButton.styleFrom(
+            minimumSize: const Size.fromHeight(60),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+        ),
+        if (message.isNotEmpty) ...[
+          const SizedBox(height: 10),
+          _OnboardingStatusMessage(message: message, isFailure: isFailure),
+        ],
+      ],
+    );
+  }
+}
+
+class _OnboardingStatusMessage extends StatelessWidget {
+  const _OnboardingStatusMessage({
     required this.message,
     required this.isFailure,
   });

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -438,7 +438,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       setState(() {
         _notificationMessage = status == NotificationPermissionStatus.granted
             ? '알림 준비 완료'
-            : '알림 권한을 켜 주세요.';
+            : '설정에서 알림 권한을 켜 주세요.';
         _isNotificationFailure = status != NotificationPermissionStatus.granted;
       });
     } on NotificationSettingsException catch (error) {
@@ -576,7 +576,7 @@ class _OnboardingNotificationSection extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(
-          '시설 고장과 신고 결과를 알려드려요.',
+          '시설 고장, 신고 결과, 공사 안내를 알려드려요.',
           style: Theme.of(context).textTheme.bodyLarge?.copyWith(
             color: const Color(0xFF29484B),
             fontWeight: FontWeight.w700,

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -213,7 +213,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('시설 고장과 신고 결과를 알려드려요.'), findsOneWidget);
+    expect(find.text('시설 고장, 신고 결과, 공사 안내를 알려드려요.'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
     await tester.pumpAndSettle();
@@ -247,7 +247,71 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(notificationPermissionProvider.requestCount, 1);
-    expect(find.text('알림 권한을 켜 주세요.'), findsOneWidget);
+    expect(find.text('설정에서 알림 권한을 켜 주세요.'), findsOneWidget);
+  });
+
+  testWidgets('온보딩은 알림 권한 요청 실패를 짧게 안내한다', (tester) async {
+    final notificationPermissionProvider = FakeNotificationPermissionProvider(
+      error: const NotificationSettingsException('알림 권한을 확인하지 못했습니다.'),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OnboardingScreen(
+          notificationPermissionProvider: notificationPermissionProvider,
+          onCompleted: (_) {},
+        ),
+      ),
+    );
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('onboardingNotificationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
+    await tester.pumpAndSettle();
+
+    expect(notificationPermissionProvider.requestCount, 1);
+    expect(find.text('알림 권한을 확인하지 못했습니다.'), findsOneWidget);
+  });
+
+  testWidgets('온보딩은 알림 권한 요청 실패가 있어도 완료를 막지 않는다', (tester) async {
+    OnboardingResult? completedResult;
+    final notificationPermissionProvider = FakeNotificationPermissionProvider(
+      error: const NotificationSettingsException('알림 권한을 확인하지 못했습니다.'),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OnboardingScreen(
+          notificationPermissionProvider: notificationPermissionProvider,
+          onCompleted: (result) => completedResult = result,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('onboardingProfileCard-elderly')));
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('onboardingNotificationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
+    await tester.pumpAndSettle();
+    expect(find.text('알림 권한을 확인하지 못했습니다.'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+
+    expect(completedResult, isNotNull);
+    expect(completedResult?.profile.id, 'elderly');
   });
 
   test('온보딩 완료 결과는 선택한 이동 조건과 보기 설정을 함께 담는다', () {
@@ -353,14 +417,22 @@ class FakeCurrentLocationProvider implements CurrentLocationProvider {
 
 class FakeNotificationPermissionProvider
     implements NotificationPermissionProvider {
-  FakeNotificationPermissionProvider({required this.status});
+  FakeNotificationPermissionProvider({
+    this.status = NotificationPermissionStatus.granted,
+    this.error,
+  });
 
   final NotificationPermissionStatus status;
+  final Object? error;
   int requestCount = 0;
 
   @override
   Future<NotificationPermissionStatus> requestNotificationPermission() async {
     requestCount++;
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
     return status;
   }
 }

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:easysubway_mobile/mobility_profile.dart';
+import 'package:easysubway_mobile/notification_settings.dart';
 import 'package:easysubway_mobile/onboarding.dart';
 import 'package:easysubway_mobile/station_search.dart';
 import 'package:flutter/material.dart';
@@ -191,6 +192,64 @@ void main() {
     await tester.pumpAndSettle();
   });
 
+  testWidgets('온보딩은 사용자가 누르면 알림 권한 준비를 시작한다', (tester) async {
+    final notificationPermissionProvider = FakeNotificationPermissionProvider(
+      status: NotificationPermissionStatus.granted,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OnboardingScreen(
+          notificationPermissionProvider: notificationPermissionProvider,
+          onCompleted: (_) {},
+        ),
+      ),
+    );
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('onboardingNotificationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('시설 고장과 신고 결과를 알려드려요.'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
+    await tester.pumpAndSettle();
+
+    expect(notificationPermissionProvider.requestCount, 1);
+    expect(find.text('알림 준비 완료'), findsOneWidget);
+  });
+
+  testWidgets('온보딩은 알림 권한을 거부하면 짧게 안내한다', (tester) async {
+    final notificationPermissionProvider = FakeNotificationPermissionProvider(
+      status: NotificationPermissionStatus.denied,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OnboardingScreen(
+          notificationPermissionProvider: notificationPermissionProvider,
+          onCompleted: (_) {},
+        ),
+      ),
+    );
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('onboardingNotificationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
+    await tester.pumpAndSettle();
+
+    expect(notificationPermissionProvider.requestCount, 1);
+    expect(find.text('알림 권한을 켜 주세요.'), findsOneWidget);
+  });
+
   test('온보딩 완료 결과는 선택한 이동 조건과 보기 설정을 함께 담는다', () {
     final result = OnboardingResult(
       profile: mobilityProfileOptions.firstWhere(
@@ -289,5 +348,19 @@ class FakeCurrentLocationProvider implements CurrentLocationProvider {
       return loader();
     }
     return true;
+  }
+}
+
+class FakeNotificationPermissionProvider
+    implements NotificationPermissionProvider {
+  FakeNotificationPermissionProvider({required this.status});
+
+  final NotificationPermissionStatus status;
+  int requestCount = 0;
+
+  @override
+  Future<NotificationPermissionStatus> requestNotificationPermission() async {
+    requestCount++;
+    return status;
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -154,6 +154,37 @@ void main() {
     expect(find.widgetWithText(OutlinedButton, '알림 켜기'), findsNothing);
   });
 
+  testWidgets('첫 실행 앱은 알림 권한 제공자가 직접 주입되면 온보딩 알림 권한을 요청한다', (tester) async {
+    final notificationPermissionProvider = FakeNotificationPermissionProvider(
+      nextStatus: NotificationPermissionStatus.granted,
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        notificationPermissionProvider: notificationPermissionProvider,
+        onboardingStore: MemoryOnboardingResultStore(),
+        enableAnonymousAuth: false,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('onboardingNotificationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
+    await tester.pumpAndSettle();
+
+    expect(notificationPermissionProvider.requestCount, 1);
+    expect(find.text('알림 준비 완료'), findsOneWidget);
+  });
+
   testWidgets('앱은 저장된 온보딩 설정으로 홈을 바로 보여준다', (tester) async {
     final onboardingStore = MemoryOnboardingResultStore(
       initialResult: OnboardingResult(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -103,6 +103,38 @@ void main() {
     expect(find.text('위치 준비 완료'), findsOneWidget);
   });
 
+  testWidgets('첫 실행 앱은 온보딩에서 알림 권한을 준비할 수 있다', (tester) async {
+    final notificationPermissionProvider = FakeNotificationPermissionProvider(
+      nextStatus: NotificationPermissionStatus.granted,
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        notificationPermissionProvider: notificationPermissionProvider,
+        onboardingStore: MemoryOnboardingResultStore(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('onboardingNotificationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
+    await tester.pumpAndSettle();
+
+    expect(notificationPermissionProvider.requestCount, 1);
+    expect(find.text('알림 준비 완료'), findsOneWidget);
+  });
+
   testWidgets('앱은 저장된 온보딩 설정으로 홈을 바로 보여준다', (tester) async {
     final onboardingStore = MemoryOnboardingResultStore(
       initialResult: OnboardingResult(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -135,6 +135,25 @@ void main() {
     expect(find.text('알림 준비 완료'), findsOneWidget);
   });
 
+  testWidgets('첫 실행 앱은 알림 설정이 꺼진 구성에서 온보딩 알림 권한을 요청하지 않는다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        onboardingStore: MemoryOnboardingResultStore(),
+        enableAnonymousAuth: false,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(Scrollable).first, const Offset(0, -1300));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('onboardingNotificationButton')), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, '알림 켜기'), findsNothing);
+  });
+
   testWidgets('앱은 저장된 온보딩 설정으로 홈을 바로 보여준다', (tester) async {
     final onboardingStore = MemoryOnboardingResultStore(
       initialResult: OnboardingResult(


### PR DESCRIPTION
Closes #208

## 배경
첫 실행 온보딩에서 현재 위치는 준비할 수 있지만, 시설 고장이나 신고 처리 결과를 받기 위한 기기 알림 권한은 설정 화면까지 들어가야만 켤 수 있었습니다. 교통약자가 처음 앱을 설정할 때 필요한 권한을 한 화면에서 준비할 수 있도록 온보딩에 알림 권한 준비 흐름을 추가합니다.

## 변경 사항
- 온보딩에 알림 섹션과 `알림 켜기` 버튼을 추가했습니다.
- 버튼을 누르면 OS 알림 권한 요청만 수행하고, 토큰 등록이나 서버 설정 변경은 기존 알림 설정 화면 범위로 남겼습니다.
- 알림 권한 허용, 거부, 예외 상황을 짧은 문구로 안내합니다.
- 위치 권한 준비와 알림 권한 요청이 동시에 실행되지 않도록 버튼 상태를 조정했습니다.
- 첫 실행 앱에서 온보딩 알림 권한 준비가 실제 앱 주입 경로로 동작하는지 위젯 테스트를 추가했습니다.

## 위치/GPS 확인
- 신고 화면은 `현재 위치 첨부됨` 같은 성공 문구를 노출하지 않고, 진입 시 자동으로 좌표를 확인합니다.
- GPS가 꺼져 있으면 `기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.` 안내와 위치 설정 버튼을 보여 주며 제출을 막는 회귀 테스트를 확인했습니다.
- GPS가 켜져 위치를 받을 수 있으면 신고 요청에 위도/경도를 포함하는 회귀 테스트를 확인했습니다.

## 검증
- `flutter test test/onboarding_test.dart --plain-name '온보딩은 사용자가 누르면 알림 권한 준비를 시작한다'` RED 확인 후 구현
- `flutter test test/onboarding_test.dart --plain-name '온보딩은 사용자가 누르면 알림 권한 준비를 시작한다'`
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 GPS가 꺼져 있으면 위치 확인을 요청하고 제출을 막는다'`
- `flutter test test/widget_test.dart --plain-name '시설 신고 화면은 현재 위치를 함께 보낸다'`
- `flutter analyze`
- `flutter test --reporter expanded`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `flutter build apk --debug`
- Android 에뮬레이터에서 온보딩 위치/알림 섹션 실제 화면 확인
- Android crash buffer 확인

## 리뷰 포인트
- 온보딩 알림 문구가 과하게 설명적이지 않고 처음 사용하는 사용자에게 충분히 직관적인지 봐 주세요.
- 알림 권한 준비가 토큰 등록이나 서버 설정 변경까지 확장되지 않는 현재 범위가 맞는지 확인해 주세요.
- 위치/GPS 안내와 알림 준비 버튼이 큰 글씨 화면에서 서로 겹치지 않는지 확인해 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 온보딩 화면에 알림 권한 요청 기능 추가
  * 알림 권한 설정 상태를 실시간으로 표시
  * 위치 및 알림 권한 설정 플로우 개선

* **테스트**
  * 알림 권한 요청 플로우 검증 테스트 추가
  * 다양한 알림 권한 시나리오에 대한 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->