### PR TITLE
[Fix] 시설 신고 위치 안내 문구 정리

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1445,8 +1445,8 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('사진 확인'),
-        content: const Text('사진과 위치를 함께 보냅니다.'),
+        title: const Text('사진 보내기'),
+        content: const Text('이 사진을 함께 보낼까요?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3273,7 +3273,7 @@ void main() {
     expect(find.text('사진 1장 추가됨'), findsOneWidget);
   });
 
-  testWidgets('시설 신고 화면은 사진과 위치를 보내기 전에 확인한다', (tester) async {
+  testWidgets('시설 신고 화면은 사진을 보내기 전에 쉬운 문구로 확인한다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
 
     await tester.pumpWidget(
@@ -3329,8 +3329,10 @@ void main() {
     await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('사진 확인'), findsOneWidget);
-    expect(find.text('사진과 위치를 함께 보냅니다.'), findsOneWidget);
+    expect(find.text('사진 보내기'), findsOneWidget);
+    expect(find.text('이 사진을 함께 보낼까요?'), findsOneWidget);
+    expect(find.text('사진 확인'), findsNothing);
+    expect(find.text('사진과 위치를 함께 보냅니다.'), findsNothing);
     expect(find.text('사진·위치 확인'), findsNothing);
     expect(find.text('사진과 신고 위치를 함께 보냅니다.'), findsNothing);
     expect(reportRepository.requests, isEmpty);


### PR DESCRIPTION
## 관련 이슈
Closes #214

## 배경
시설 신고는 가까운 역 판단을 위해 앱 사용 중 위치를 자동 확인한다. 사진 전송 확인 팝업에서 위치 첨부를 직접 말하면 사용자가 별도 작업을 해야 하는 것처럼 보일 수 있어, 사진 전송 여부만 묻도록 문구를 정리했다.

## 변경 사항
- 사진 첨부 신고 확인 팝업 제목을 `사진 보내기`로 변경했다.
- 확인 문구에서 위치 첨부 표현을 제거하고 `이 사진을 함께 보낼까요?`로 줄였다.
- 위치 자동 확인, GPS 꺼짐 안내, 제출 차단, 좌표 포함 전송 동작은 유지했다.
- 관련 위젯 테스트를 사용자에게 보이는 문구 기준으로 갱신했다.

## 검증
- `flutter test test/widget_test.dart --plain-name "시설 신고 화면은 사진을 보내기 전에 쉬운 문구로 확인한다"`
- `flutter test test/widget_test.dart --plain-name "시설 신고 화면은"`
- `flutter test`
- Android 에뮬레이터에서 시설 신고 화면을 띄워 사진 확인 팝업이 `사진 보내기`, `이 사진을 함께 보낼까요?`로 표시되고 위치 첨부 문구가 없는 것을 확인했다.

## 리스크
- 문구 변경만 포함하므로 API 요청 형식과 위치 수집 타이밍에는 영향이 없다.