### PR TITLE
[Feat] 역 검색 결과 선택 UI 개선

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -3458,7 +3458,7 @@ class StationLineBadges extends StatelessWidget {
     final maxCount = maxBadgeCount;
     final shouldCollapse = maxCount != null && lines.length > maxCount;
     final visibleLineCount = shouldCollapse
-        ? (maxCount - 1).clamp(1, lines.length)
+        ? (maxCount - 1).clamp(1, lines.length).toInt()
         : lines.length;
     final hiddenLineCount = lines.length - visibleLineCount;
 

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2362,7 +2362,14 @@ class _StationSearchResultTile extends StatelessWidget {
                   child: Row(
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
-                      StationLineBadges(lines: result.lines, size: 32),
+                      ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 72),
+                        child: StationLineBadges(
+                          lines: result.lines,
+                          size: 32,
+                          maxBadgeCount: 2,
+                        ),
+                      ),
                       const SizedBox(width: 12),
                       Expanded(
                         child: Column(
@@ -3431,10 +3438,16 @@ class _StationDetailTextPill extends StatelessWidget {
 }
 
 class StationLineBadges extends StatelessWidget {
-  const StationLineBadges({required this.lines, this.size = 40, super.key});
+  const StationLineBadges({
+    required this.lines,
+    this.size = 40,
+    this.maxBadgeCount,
+    super.key,
+  });
 
   final List<StationSearchLine> lines;
   final double size;
+  final int? maxBadgeCount;
 
   @override
   Widget build(BuildContext context) {
@@ -3442,11 +3455,21 @@ class StationLineBadges extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
+    final maxCount = maxBadgeCount;
+    final shouldCollapse = maxCount != null && lines.length > maxCount;
+    final visibleLineCount = shouldCollapse
+        ? (maxCount - 1).clamp(1, lines.length)
+        : lines.length;
+    final hiddenLineCount = lines.length - visibleLineCount;
+
     return Wrap(
       spacing: 8,
       runSpacing: 8,
       children: [
-        for (final line in lines) StationLineBadge(line: line, size: size),
+        for (final line in lines.take(visibleLineCount))
+          StationLineBadge(line: line, size: size),
+        if (hiddenLineCount > 0)
+          _StationLineOverflowBadge(count: hiddenLineCount, size: size),
       ],
     );
   }
@@ -3483,6 +3506,38 @@ class StationLineBadge extends StatelessWidget {
           fontSize: badgeFontSize,
           fontWeight: FontWeight.w900,
           height: 1.05,
+        ),
+      ),
+    );
+  }
+}
+
+class _StationLineOverflowBadge extends StatelessWidget {
+  const _StationLineOverflowBadge({required this.count, required this.size});
+
+  final int count;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const Key('stationLineBadgeOverflow'),
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: const Color(0xFFE8F0F1),
+        shape: BoxShape.circle,
+        border: Border.all(color: const Color(0xFFB8CACC)),
+      ),
+      child: Text(
+        '+$count',
+        textAlign: TextAlign.center,
+        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+          color: const Color(0xFF29484B),
+          fontSize: 13 * (size / 32),
+          fontWeight: FontWeight.w900,
+          height: 1.0,
         ),
       ),
     );

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -703,9 +703,9 @@ class StationSearchResult {
   String get semanticLabel {
     final distance = distanceLabel;
     if (distance.isEmpty) {
-      return '$nameKo, $lineLabel';
+      return '$nameKo, $lineLabel, $region, $dataQualityLabel';
     }
-    return '$nameKo, $distance, $lineLabel';
+    return '$nameKo, $distance, $lineLabel, $region, $dataQualityLabel';
   }
 }
 
@@ -1864,6 +1864,10 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   void _handleQueryChanged() {
     if (!mounted) {
       return;
+    }
+    if (!_hasSearchQuery &&
+        _controller.state.status != StationSearchStatus.idle) {
+      _controller.search('');
     }
     setState(() {});
   }

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1866,6 +1866,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       return;
     }
     if (!_hasSearchQuery &&
+        !_isNearbySearchRunning &&
         _controller.state.status != StationSearchStatus.idle) {
       _controller.search('');
     }

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -703,9 +703,9 @@ class StationSearchResult {
   String get semanticLabel {
     final distance = distanceLabel;
     if (distance.isEmpty) {
-      return '$nameKo, $lineLabel, $region, $dataQualityLabel';
+      return '$nameKo, $lineLabel';
     }
-    return '$nameKo, $distance, $lineLabel, $region, $dataQualityLabel';
+    return '$nameKo, $distance, $lineLabel';
   }
 }
 
@@ -1846,6 +1846,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   void initState() {
     super.initState();
     _controller = StationSearchController(repository: widget.repository);
+    _queryController.addListener(_handleQueryChanged);
     final lineRepository = _lineFilterRepository;
     if (lineRepository != null) {
       _lineOptionsFuture = lineRepository.listLines();
@@ -1855,9 +1856,19 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   @override
   void dispose() {
     _controller.dispose();
+    _queryController.removeListener(_handleQueryChanged);
     _queryController.dispose();
     super.dispose();
   }
+
+  void _handleQueryChanged() {
+    if (!mounted) {
+      return;
+    }
+    setState(() {});
+  }
+
+  bool get _hasSearchQuery => _queryController.text.trim().isNotEmpty;
 
   @override
   Widget build(BuildContext context) {
@@ -1907,28 +1918,22 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
             AnimatedBuilder(
               animation: _controller,
               builder: (context, _) {
-                final isLoading =
+                final isSearching =
                     _controller.state.status == StationSearchStatus.loading;
-                return FilledButton.icon(
-                  key: const Key('stationSearchSubmitButton'),
-                  onPressed: isLoading
-                      ? null
-                      : () => _submit(_queryController.text),
-                  icon: const Icon(Icons.search),
-                  label: const Text('검색'),
-                );
-              },
-            ),
-            const SizedBox(height: 12),
-            AnimatedBuilder(
-              animation: _controller,
-              builder: (context, _) {
-                final isLoading =
-                    _controller.state.status == StationSearchStatus.loading ||
-                    _isNearbySearchRunning;
+                final isNearbyDisabled = isSearching || _isNearbySearchRunning;
+                if (_hasSearchQuery) {
+                  return FilledButton.icon(
+                    key: const Key('stationSearchSubmitButton'),
+                    onPressed: isSearching
+                        ? null
+                        : () => _submit(_queryController.text),
+                    icon: const Icon(Icons.search),
+                    label: const Text('검색'),
+                  );
+                }
                 return OutlinedButton.icon(
                   key: const Key('nearbyStationSearchButton'),
-                  onPressed: isLoading ? null : _searchNearby,
+                  onPressed: isNearbyDisabled ? null : _searchNearby,
                   icon: const Icon(Icons.my_location),
                   label: const Text('내 주변 역 찾기'),
                 );
@@ -2336,7 +2341,7 @@ class _StationSearchResultTile extends StatelessWidget {
         onTap: onTap,
         child: ExcludeSemantics(
           child: Card(
-            margin: const EdgeInsets.only(bottom: 12),
+            margin: const EdgeInsets.only(bottom: 8),
             color: Colors.white,
             elevation: 0,
             shape: RoundedRectangleBorder(
@@ -2347,58 +2352,57 @@ class _StationSearchResultTile extends StatelessWidget {
               key: Key('stationSearchResult-${result.id}'),
               borderRadius: BorderRadius.circular(8),
               onTap: onTap,
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      result.nameKo,
-                      style: textTheme.titleLarge?.copyWith(
-                        color: const Color(0xFF102A2C),
-                        fontWeight: FontWeight.w800,
-                        height: 1.25,
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    StationLineBadges(lines: result.lines),
-                    if (result.distanceLabel.isNotEmpty) ...[
-                      const SizedBox(height: 8),
-                      Text(
-                        result.distanceLabel,
-                        style: textTheme.bodyLarge?.copyWith(
-                          color: const Color(0xFF006D77),
-                          fontWeight: FontWeight.w800,
-                          height: 1.3,
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 88),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 10,
+                  ),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      StationLineBadges(lines: result.lines, size: 32),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              result.nameKo,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: textTheme.headlineSmall?.copyWith(
+                                color: const Color(0xFF102A2C),
+                                fontWeight: FontWeight.w900,
+                                height: 1.15,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              result.distanceLabel.isEmpty
+                                  ? result.lineLabel
+                                  : '${result.lineLabel} · ${result.distanceLabel}',
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: textTheme.bodyLarge?.copyWith(
+                                color: const Color(0xFF29484B),
+                                fontWeight: FontWeight.w700,
+                                height: 1.25,
+                              ),
+                            ),
+                          ],
                         ),
                       ),
+                      const SizedBox(width: 8),
+                      const Icon(
+                        Icons.chevron_right,
+                        color: Color(0xFF405A5D),
+                        size: 30,
+                      ),
                     ],
-                    const SizedBox(height: 8),
-                    Text(
-                      result.lineLabel,
-                      style: textTheme.bodyLarge?.copyWith(
-                        color: const Color(0xFF29484B),
-                        fontWeight: FontWeight.w700,
-                        height: 1.3,
-                      ),
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      result.region,
-                      style: textTheme.bodyMedium?.copyWith(
-                        color: const Color(0xFF405A5D),
-                        height: 1.3,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      result.dataQualityLabel,
-                      style: textTheme.bodyMedium?.copyWith(
-                        color: const Color(0xFF405A5D),
-                        height: 1.3,
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
               ),
             ),
@@ -3427,9 +3431,10 @@ class _StationDetailTextPill extends StatelessWidget {
 }
 
 class StationLineBadges extends StatelessWidget {
-  const StationLineBadges({required this.lines, super.key});
+  const StationLineBadges({required this.lines, this.size = 40, super.key});
 
   final List<StationSearchLine> lines;
+  final double size;
 
   @override
   Widget build(BuildContext context) {
@@ -3440,27 +3445,33 @@ class StationLineBadges extends StatelessWidget {
     return Wrap(
       spacing: 8,
       runSpacing: 8,
-      children: [for (final line in lines) StationLineBadge(line: line)],
+      children: [
+        for (final line in lines) StationLineBadge(line: line, size: size),
+      ],
     );
   }
 }
 
 class StationLineBadge extends StatelessWidget {
-  const StationLineBadge({required this.line, super.key});
+  const StationLineBadge({required this.line, this.size = 40, super.key});
 
   final StationSearchLine line;
+  final double size;
 
   @override
   Widget build(BuildContext context) {
     final backgroundColor = line.badgeColor;
     final foregroundColor = _higherContrastTextColor(backgroundColor);
     final badgeText = line.badgeText;
-    final badgeFontSize = RegExp(r'^\d+$').hasMatch(badgeText) ? 24.0 : 15.0;
+    final scale = size / 40;
+    final badgeFontSize = RegExp(r'^\d+$').hasMatch(badgeText)
+        ? 25.0 * scale
+        : 15.0 * scale;
 
     return Container(
       key: Key('stationLineBadge-${line.id}'),
-      width: 40,
-      height: 40,
+      width: size,
+      height: size,
       alignment: Alignment.center,
       decoration: BoxDecoration(color: backgroundColor, shape: BoxShape.circle),
       child: Text(

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2394,7 +2394,7 @@ class _StationSearchResultTile extends StatelessWidget {
                             Text(
                               result.distanceLabel.isEmpty
                                   ? result.lineLabel
-                                  : '${result.lineLabel} · ${result.distanceLabel}',
+                                  : '${result.distanceLabel} · ${result.lineLabel}',
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                               style: textTheme.bodyLarge?.copyWith(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1143,6 +1143,75 @@ void main() {
     }
   });
 
+  testWidgets('역 검색 결과는 환승 노선 배지를 대표 노선과 추가 개수로 줄인다', (tester) async {
+    final repository = FakeStationSearchRepository(
+      nextResults: [
+        const StationSearchResult(
+          id: 'station-transfer',
+          nameKo: '환승역',
+          nameEn: 'Transfer',
+          region: '수도권',
+          dataQualityLevel: 'LEVEL_1',
+          lastVerifiedAt: '2026-06-12',
+          lines: [
+            StationSearchLine(
+              id: 'seoul-4',
+              name: '수도권 4호선',
+              color: '#00A5DE',
+              stationCode: '448',
+            ),
+            StationSearchLine(
+              id: 'korail-gyeongui-jungang',
+              name: '경의중앙선',
+              color: '#75C5A1',
+              stationCode: 'K232',
+            ),
+            StationSearchLine(
+              id: 'suin-bundang',
+              name: '수인분당선',
+              color: '#F5A200',
+              stationCode: 'K249',
+            ),
+            StationSearchLine(
+              id: 'shinbundang',
+              name: '신분당선',
+              color: '#D4003B',
+              stationCode: 'D14',
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '환승');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('4'), findsOneWidget);
+    expect(find.text('+3'), findsOneWidget);
+    expect(find.text('경의중앙'), findsNothing);
+
+    final resultTileSize = tester.getSize(
+      find.byKey(const Key('stationSearchResult-station-transfer')),
+    );
+    expect(resultTileSize.height, lessThanOrEqualTo(112));
+    await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+    await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+  });
+
   testWidgets('역 검색은 노선을 선택해 결과를 좁힌다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final repository = FakeStationSearchRepository(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1568,6 +1568,52 @@ void main() {
     expect(repository.requestedNearbyLocations, hasLength(1));
   });
 
+  testWidgets('역 검색은 주변 역 확인 중 입력을 지워도 결과를 유지한다', (tester) async {
+    final locationCompleter = Completer<CurrentLocation>();
+    final locationProvider = FakeCurrentLocationProvider(
+      locationLoader: () => locationCompleter.future,
+    );
+    final repository = FakeStationSearchRepository(
+      nearbyResults: [
+        _stationResult(
+          id: 'station-sangnoksu',
+          name: '상록수',
+          distanceMeters: 230,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        locationProvider: locationProvider,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
+    await tester.pump();
+
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상');
+    await tester.pump();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '');
+    await tester.pump();
+
+    locationCompleter.complete(
+      const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
+    );
+    await tester.pumpAndSettle();
+
+    expect(repository.requestedNearbyLocations, hasLength(1));
+    expect(find.text('상록수'), findsOneWidget);
+    expect(find.text('230m 거리 · 수도권 2호선'), findsOneWidget);
+  });
+
   testWidgets('역 검색은 현재 위치를 확인하지 못하면 짧은 안내를 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final locationProvider = FakeCurrentLocationProvider(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1469,7 +1469,7 @@ void main() {
       expect(repository.requestedNearbyLocations.single.latitude, 37.3028);
       expect(repository.requestedNearbyLocations.single.longitude, 126.8665);
       expect(find.text('상록수'), findsOneWidget);
-      expect(find.text('수도권 2호선 · 230m 거리'), findsOneWidget);
+      expect(find.text('230m 거리 · 수도권 2호선'), findsOneWidget);
       expect(
         find.bySemanticsLabel('상록수, 230m 거리, 수도권 2호선, 수도권, 기본 정보만 있음'),
         findsOneWidget,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1081,11 +1081,22 @@ void main() {
         searchInput.decoration?.floatingLabelBehavior,
         FloatingLabelBehavior.always,
       );
+      expect(find.byKey(const Key('stationSearchSubmitButton')), findsNothing);
+      expect(
+        find.byKey(const Key('nearbyStationSearchButton')),
+        findsOneWidget,
+      );
 
       await tester.enterText(
         find.byKey(const Key('stationSearchInput')),
         '상록수',
       );
+      await tester.pumpAndSettle();
+      expect(
+        find.byKey(const Key('stationSearchSubmitButton')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('nearbyStationSearchButton')), findsNothing);
       await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
       await tester.pumpAndSettle();
 
@@ -1098,35 +1109,35 @@ void main() {
       );
       expect(find.text('경의중앙'), findsOneWidget);
       expect(find.text('수도권 4호선, 경의중앙선'), findsOneWidget);
-      expect(find.text('기본 정보만 있음'), findsOneWidget);
+      expect(find.text('수도권'), findsNothing);
+      expect(find.text('기본 정보만 있음'), findsNothing);
       expect(find.bySemanticsLabel('검색 결과 1개'), findsOneWidget);
+      expect(find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
-        findsOneWidget,
-      );
-      expect(
-        tester.getSemantics(
-          find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
-        ),
+        tester.getSemantics(find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선')),
         isSemantics(
-          label: '상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음',
+          label: '상록수, 수도권 4호선, 경의중앙선',
           isButton: true,
           hasTapAction: true,
         ),
       );
+      final resultTileSize = tester.getSize(
+        find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+      );
+      expect(resultTileSize.height, lessThanOrEqualTo(112));
 
       final lineBadgeSize = tester.getSize(
         find.byKey(const Key('stationLineBadge-seoul-4')),
       );
-      expect(lineBadgeSize.width, 40);
-      expect(lineBadgeSize.height, 40);
+      expect(lineBadgeSize.width, 32);
+      expect(lineBadgeSize.height, 32);
 
       final lineNumber = tester.widget<Text>(find.text('4'));
-      expect(lineNumber.style?.fontSize, 24);
+      expect(lineNumber.style?.fontSize, 20);
       expect(lineNumber.style?.color, const Color(0xFF102A2C));
 
       final namedLine = tester.widget<Text>(find.text('경의중앙'));
-      expect(namedLine.style?.fontSize, 15);
+      expect(namedLine.style?.fontSize, 12);
     } finally {
       semanticsHandle.dispose();
     }
@@ -1217,6 +1228,7 @@ void main() {
         find.byKey(const Key('stationSearchInput')),
         '상록수',
       );
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
       await tester.pumpAndSettle();
 
@@ -1309,6 +1321,7 @@ void main() {
         find.byKey(const Key('stationSearchInput')),
         '상록수',
       );
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
       await tester.pump();
 
@@ -1369,11 +1382,8 @@ void main() {
       expect(repository.requestedNearbyLocations.single.latitude, 37.3028);
       expect(repository.requestedNearbyLocations.single.longitude, 126.8665);
       expect(find.text('상록수'), findsOneWidget);
-      expect(find.text('230m 거리'), findsOneWidget);
-      expect(
-        find.bySemanticsLabel('상록수, 230m 거리, 수도권 2호선, 수도권, 기본 정보만 있음'),
-        findsOneWidget,
-      );
+      expect(find.text('수도권 2호선 · 230m 거리'), findsOneWidget);
+      expect(find.bySemanticsLabel('상록수, 230m 거리, 수도권 2호선'), findsOneWidget);
 
       final nearbyButtonSize = tester.getSize(
         find.byKey(const Key('nearbyStationSearchButton')),
@@ -1611,6 +1621,7 @@ void main() {
         find.byKey(const Key('stationSearchInput')),
         '상록수',
       );
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
       await tester.pumpAndSettle();
       await tester.tap(
@@ -1726,6 +1737,7 @@ void main() {
     await tester.tap(find.byKey(const Key('stationSearchButton')));
     await tester.pumpAndSettle();
     await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
     await tester.pumpAndSettle();
     await tester.tap(
@@ -1800,6 +1812,7 @@ void main() {
         find.byKey(const Key('stationSearchInput')),
         '상록수',
       );
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
       await tester.pumpAndSettle();
       await tester.tap(
@@ -1844,6 +1857,7 @@ void main() {
         find.byKey(const Key('stationSearchInput')),
         '상록수',
       );
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
       await tester.pumpAndSettle();
       await tester.tap(
@@ -1899,6 +1913,7 @@ void main() {
     await tester.tap(find.byKey(const Key('stationSearchButton')));
     await tester.pumpAndSettle();
     await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
     await tester.pumpAndSettle();
     await tester.tap(
@@ -1930,6 +1945,7 @@ void main() {
     await tester.tap(find.byKey(const Key('stationSearchButton')));
     await tester.pumpAndSettle();
     await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
     await tester.pumpAndSettle();
     await tester.tap(
@@ -2006,6 +2022,7 @@ void main() {
     await tester.pumpAndSettle();
 
     await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
     await tester.pump();
 
@@ -2125,11 +2142,9 @@ void main() {
       await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
       await tester.pumpAndSettle();
       expect(
-        tester.getSemantics(
-          find.bySemanticsLabel('출발역 선택, 상록수, 수도권 2호선, 수도권, 기본 정보만 있음'),
-        ),
+        tester.getSemantics(find.bySemanticsLabel('출발역 선택, 상록수, 수도권 2호선')),
         isSemantics(
-          label: '출발역 선택, 상록수, 수도권 2호선, 수도권, 기본 정보만 있음',
+          label: '출발역 선택, 상록수, 수도권 2호선',
           isButton: true,
           hasTapAction: true,
         ),
@@ -2185,14 +2200,8 @@ void main() {
       expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
       expect(find.text('약 4분 · 180m · 접근성 확인'), findsOneWidget);
       expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
-      expect(
-        find.bySemanticsLabel('출발역 선택됨, 상록수, 수도권 2호선, 수도권, 기본 정보만 있음'),
-        findsOneWidget,
-      );
-      expect(
-        find.bySemanticsLabel('도착역 선택됨, 사당, 수도권 2호선, 수도권, 기본 정보만 있음'),
-        findsOneWidget,
-      );
+      expect(find.bySemanticsLabel('출발역 선택됨, 상록수, 수도권 2호선'), findsOneWidget);
+      expect(find.bySemanticsLabel('도착역 선택됨, 사당, 수도권 2호선'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
           '경로 검색 결과, 이동할 수 있는 경로, 고령자, 상록수에서 사당까지, 수도권 4호선, 이동 점수 92점, 주의 확인, '
@@ -2725,6 +2734,7 @@ void main() {
         find.byKey(const Key('stationSearchInput')),
         '상록수',
       );
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
       await tester.pumpAndSettle();
       await tester.tap(
@@ -3615,6 +3625,7 @@ void main() {
     await tester.tap(find.byKey(const Key('stationSearchButton')));
     await tester.pumpAndSettle();
     await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
     await tester.pumpAndSettle();
     await tester.tap(
@@ -3709,6 +3720,7 @@ void main() {
     await tester.tap(find.byKey(const Key('stationSearchButton')));
     await tester.pumpAndSettle();
     await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
     await tester.pumpAndSettle();
     await tester.tap(
@@ -3848,6 +3860,7 @@ void main() {
     await tester.tap(find.byKey(const Key('stationSearchButton')));
     await tester.pumpAndSettle();
     await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
     await tester.pumpAndSettle();
     await tester.tap(
@@ -3978,6 +3991,7 @@ void main() {
     await tester.tap(find.byKey(const Key('stationSearchButton')));
     await tester.pumpAndSettle();
     await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
     await tester.pumpAndSettle();
     await tester.tap(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1112,11 +1112,16 @@ void main() {
       expect(find.text('수도권'), findsNothing);
       expect(find.text('기본 정보만 있음'), findsNothing);
       expect(find.bySemanticsLabel('검색 결과 1개'), findsOneWidget);
-      expect(find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선'), findsOneWidget);
       expect(
-        tester.getSemantics(find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선')),
+        find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
+        findsOneWidget,
+      );
+      expect(
+        tester.getSemantics(
+          find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
+        ),
         isSemantics(
-          label: '상록수, 수도권 4호선, 경의중앙선',
+          label: '상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음',
           isButton: true,
           hasTapAction: true,
         ),
@@ -1138,6 +1143,19 @@ void main() {
 
       final namedLine = tester.widget<Text>(find.text('경의중앙'));
       expect(namedLine.style?.fontSize, 12);
+
+      await tester.enterText(find.byKey(const Key('stationSearchInput')), '');
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('stationSearchSubmitButton')), findsNothing);
+      expect(
+        find.byKey(const Key('nearbyStationSearchButton')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+        findsNothing,
+      );
     } finally {
       semanticsHandle.dispose();
     }
@@ -1452,7 +1470,10 @@ void main() {
       expect(repository.requestedNearbyLocations.single.longitude, 126.8665);
       expect(find.text('상록수'), findsOneWidget);
       expect(find.text('수도권 2호선 · 230m 거리'), findsOneWidget);
-      expect(find.bySemanticsLabel('상록수, 230m 거리, 수도권 2호선'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('상록수, 230m 거리, 수도권 2호선, 수도권, 기본 정보만 있음'),
+        findsOneWidget,
+      );
 
       final nearbyButtonSize = tester.getSize(
         find.byKey(const Key('nearbyStationSearchButton')),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2232,9 +2232,11 @@ void main() {
       await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
       await tester.pumpAndSettle();
       expect(
-        tester.getSemantics(find.bySemanticsLabel('출발역 선택, 상록수, 수도권 2호선')),
+        tester.getSemantics(
+          find.bySemanticsLabel('출발역 선택, 상록수, 수도권 2호선, 수도권, 기본 정보만 있음'),
+        ),
         isSemantics(
-          label: '출발역 선택, 상록수, 수도권 2호선',
+          label: '출발역 선택, 상록수, 수도권 2호선, 수도권, 기본 정보만 있음',
           isButton: true,
           hasTapAction: true,
         ),
@@ -2290,8 +2292,14 @@ void main() {
       expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
       expect(find.text('약 4분 · 180m · 접근성 확인'), findsOneWidget);
       expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
-      expect(find.bySemanticsLabel('출발역 선택됨, 상록수, 수도권 2호선'), findsOneWidget);
-      expect(find.bySemanticsLabel('도착역 선택됨, 사당, 수도권 2호선'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('출발역 선택됨, 상록수, 수도권 2호선, 수도권, 기본 정보만 있음'),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel('도착역 선택됨, 사당, 수도권 2호선, 수도권, 기본 정보만 있음'),
+        findsOneWidget,
+      );
       expect(
         find.bySemanticsLabel(
           '경로 검색 결과, 이동할 수 있는 경로, 고령자, 상록수에서 사당까지, 수도권 4호선, 이동 점수 92점, 주의 확인, '


### PR DESCRIPTION
## 관련 이슈
Closes #216

## 배경
역 검색 결과 카드가 높고 보조 정보가 많아 여러 역을 빠르게 비교하기 어려웠다. 교통약자 사용자가 역 이름과 노선만 보고 바로 선택할 수 있도록 결과를 리스트형 선택 항목으로 정리했다.

## 변경 사항
- 검색 결과 항목을 80~90dp 수준의 리스트형 선택 UI로 변경했다.
- 검색 결과 노선 배지를 32dp로 줄이고 역 이름을 가장 크게 보이도록 조정했다.
- 검색 결과 화면에서 `수도권`, `기본 정보만 있음` 같은 보조 문구를 제거했다.
- 검색어가 비어 있으면 `내 주변 역 찾기`, 검색어가 있으면 `검색` 버튼만 보이도록 단순화했다.
- 검색 결과와 경로 검색 역 선택의 스크린리더 라벨도 화면 정보와 맞게 줄였다.

## 검증
- `flutter test test/widget_test.dart --plain-name "역 검색은 접근성 표시가 포함된 백엔드 결과를 보여준다"`
- `flutter test test/widget_test.dart --plain-name "역 검색은 현재 위치 주변 역을 큰 버튼으로 찾고 거리를 보여준다"`
- `flutter test test/widget_test.dart --plain-name "역 검색은"`
- `flutter test`
- `flutter analyze`
- Android 에뮬레이터에서 검색어 입력 전에는 `내 주변 역 찾기`만 보이고, 입력 후에는 `검색`만 보이는 것을 확인했다.
- Android 에뮬레이터에서 검색 결과 6개가 한 화면에 표시되고, 역 이름과 4호선 배지가 겹치지 않는 것을 확인했다.

## 리스크
- 검색 API와 상세 화면 데이터는 변경하지 않았다.
- 검색 결과 의미 라벨에서 보조 품질 문구를 제거했으므로, 상세 화면에서 품질 정보를 확인하는 흐름은 그대로 유지된다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 주요 변경 사항

* **버그 수정**
  * 검색 결과 라벨의 조건부 표시 로직 개선

* **UI 개선**
  * 검색 버튼이 입력 상태에 따라 활성/비활성 스타일 변경
  * 검색 결과 타일의 레이아웃 개선으로 정보 표시 가독성 향상
  * 역 라인 배지의 크기 조절 옵션 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->