### PR TITLE
[Feat] 홈 화면 핵심 기능 중심으로 단순화

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -714,6 +714,10 @@ class HomeScreen extends StatelessWidget {
     final routeFeedbackRepository = this.routeFeedbackRepository;
     final notificationRepository = this.notificationRepository;
     final notificationPermissionProvider = this.notificationPermissionProvider;
+    final hasFavorites =
+        favoriteRepository != null ||
+        favoriteFacilityRepository != null ||
+        favoriteRouteRepository != null;
 
     return Scaffold(
       appBar: AppBar(title: const Text('쉬운 지하철')),
@@ -724,7 +728,7 @@ class HomeScreen extends StatelessWidget {
             Semantics(
               header: true,
               child: Text(
-                '역 찾기',
+                '어디로 가시나요?',
                 style: textTheme.headlineSmall?.copyWith(
                   color: const Color(0xFF102A2C),
                   fontWeight: FontWeight.w800,
@@ -732,8 +736,8 @@ class HomeScreen extends StatelessWidget {
                 ),
               ),
             ),
-            const SizedBox(height: 24),
-            FilledButton.icon(
+            const SizedBox(height: 20),
+            _HomePrimaryActionButton(
               key: const Key('stationSearchButton'),
               onPressed: () {
                 Navigator.of(context).push(
@@ -750,10 +754,10 @@ class HomeScreen extends StatelessWidget {
                 );
               },
               icon: const Icon(Icons.search),
-              label: const Text('역 검색'),
+              label: '역 검색',
             ),
             const SizedBox(height: 12),
-            FilledButton.icon(
+            _HomePrimaryActionButton(
               key: const Key('routeSearchButton'),
               onPressed: () {
                 Navigator.of(context).push(
@@ -769,146 +773,336 @@ class HomeScreen extends StatelessWidget {
                 );
               },
               icon: const Icon(Icons.route),
-              label: const Text('경로 검색'),
+              label: '길찾기',
             ),
-            const SizedBox(height: 12),
-            OutlinedButton.icon(
-              key: const Key('mobilityProfileButton'),
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute<MobilityProfileOption>(
-                    builder: (_) => const MobilityProfileScreen(),
-                  ),
+            const SizedBox(height: 20),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                const spacing = 10.0;
+                final itemWidth = (constraints.maxWidth - spacing) / 2;
+                return Wrap(
+                  spacing: spacing,
+                  runSpacing: spacing,
+                  children: [
+                    SizedBox(
+                      width: itemWidth,
+                      height: 64,
+                      child: _HomeSecondaryActionButton(
+                        key: const Key('mobilityProfileButton'),
+                        onPressed: () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute<MobilityProfileOption>(
+                              builder: (_) => const MobilityProfileScreen(),
+                            ),
+                          );
+                        },
+                        icon: const Icon(Icons.accessibility_new),
+                        label: '이동 조건',
+                      ),
+                    ),
+                    if (hasFavorites)
+                      SizedBox(
+                        width: itemWidth,
+                        height: 64,
+                        child: _HomeSecondaryActionButton(
+                          key: const Key('favoritesButton'),
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute<void>(
+                                builder: (_) => FavoriteHomeScreen(
+                                  favoriteRepository: favoriteRepository,
+                                  favoriteFacilityRepository:
+                                      favoriteFacilityRepository,
+                                  favoriteRouteRepository:
+                                      favoriteRouteRepository,
+                                  stationRepository: repository,
+                                  reportRepository: reportRepository,
+                                  locationProvider: locationProvider,
+                                  facilityReportDraftTargetStore:
+                                      facilityReportDraftTargetStore,
+                                ),
+                              ),
+                            );
+                          },
+                          icon: const Icon(Icons.star_outline),
+                          label: '즐겨찾기',
+                        ),
+                      ),
+                    SizedBox(
+                      width: itemWidth,
+                      height: 64,
+                      child: _HomeSecondaryActionButton(
+                        key: const Key('myReportsButton'),
+                        onPressed: () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute<void>(
+                              builder: (_) => MyFacilityReportListScreen(
+                                repository: reportRepository,
+                              ),
+                            ),
+                          );
+                        },
+                        icon: const Icon(Icons.receipt_long_outlined),
+                        label: '내 신고',
+                      ),
+                    ),
+                    if (notificationRepository != null)
+                      SizedBox(
+                        width: itemWidth,
+                        height: 64,
+                        child: _HomeSecondaryActionButton(
+                          key: const Key('notificationSettingsButton'),
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute<void>(
+                                builder: (_) => NotificationSettingsScreen(
+                                  repository: notificationRepository,
+                                  notificationPermissionProvider:
+                                      notificationPermissionProvider,
+                                ),
+                              ),
+                            );
+                          },
+                          icon: const Icon(Icons.notifications_active_outlined),
+                          label: '알림 설정',
+                        ),
+                      ),
+                    SizedBox(
+                      width: itemWidth,
+                      height: 64,
+                      child: _HomeSecondaryActionButton(
+                        key: const Key('helpButton'),
+                        onPressed: () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute<void>(
+                              builder: (_) => SupportAccessScreen(
+                                accessInfo: supportAccessInfo,
+                              ),
+                            ),
+                          );
+                        },
+                        icon: const Icon(Icons.help_outline),
+                        label: '도움말',
+                      ),
+                    ),
+                  ],
                 );
               },
-              icon: const Icon(Icons.accessibility_new),
-              label: const Text('이동 조건'),
             ),
-            const SizedBox(height: 12),
-            FilledButton.icon(
-              key: const Key('myReportsButton'),
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => MyFacilityReportListScreen(
-                      repository: reportRepository,
-                    ),
-                  ),
-                );
-              },
-              icon: const Icon(Icons.receipt_long_outlined),
-              label: const Text('내 신고'),
-            ),
-            const SizedBox(height: 12),
-            if (favoriteRouteRepository != null) ...[
-              FilledButton.icon(
-                key: const Key('favoriteRoutesButton'),
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute<void>(
-                      builder: (_) => FavoriteRouteListScreen(
-                        repository: favoriteRouteRepository,
-                      ),
-                    ),
-                  );
-                },
-                icon: const Icon(Icons.bookmarks_outlined),
-                label: const Text('즐겨찾기 경로'),
-              ),
-              const SizedBox(height: 12),
-            ],
-            if (favoriteRepository != null) ...[
-              FilledButton.icon(
-                key: const Key('favoriteStationsButton'),
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute<void>(
-                      builder: (_) => FavoriteStationListScreen(
-                        repository: favoriteRepository,
-                        stationRepository: repository,
-                        reportRepository: reportRepository,
-                        locationProvider: locationProvider,
-                        facilityReportDraftTargetStore:
-                            facilityReportDraftTargetStore,
-                      ),
-                    ),
-                  );
-                },
-                icon: const Icon(Icons.star),
-                label: const Text('즐겨찾기 역'),
-              ),
-              const SizedBox(height: 12),
-            ],
-            if (favoriteFacilityRepository != null) ...[
-              FilledButton.icon(
-                key: const Key('favoriteFacilitiesButton'),
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute<void>(
-                      builder: (_) => FavoriteFacilityListScreen(
-                        repository: favoriteFacilityRepository,
-                      ),
-                    ),
-                  );
-                },
-                icon: const Icon(Icons.elevator_outlined),
-                label: const Text('즐겨찾기 시설'),
-              ),
-              const SizedBox(height: 12),
-            ],
-            if (notificationRepository != null) ...[
-              FilledButton.icon(
-                key: const Key('notificationSettingsButton'),
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute<void>(
-                      builder: (_) => NotificationSettingsScreen(
-                        repository: notificationRepository,
-                        notificationPermissionProvider:
-                            notificationPermissionProvider,
-                      ),
-                    ),
-                  );
-                },
-                icon: const Icon(Icons.notifications_active_outlined),
-                label: const Text('알림 설정'),
-              ),
-              const SizedBox(height: 12),
-            ],
-            OutlinedButton.icon(
-              key: const Key('helpButton'),
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) =>
-                        SupportAccessScreen(accessInfo: supportAccessInfo),
-                  ),
-                );
-              },
-              icon: const Icon(Icons.help_outline),
-              label: const Text('도움말'),
-            ),
-            const SizedBox(height: 12),
-            if (!simpleViewEnabled) ...[
-              const SizedBox(height: 24),
-              const FeatureTile(
-                icon: Icons.accessible_forward,
-                title: '이동 프로필',
-                semanticLabel: '이동 프로필, 이동 조건 저장',
-              ),
-              const FeatureTile(
-                icon: Icons.elevator,
-                title: '시설 정보',
-                semanticLabel: '시설 정보, 엘리베이터와 경사로',
-              ),
-              const FeatureTile(
-                icon: Icons.report_outlined,
-                title: '신고',
-                semanticLabel: '신고, 불편 신고',
-              ),
-            ],
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _HomePrimaryActionButton extends StatelessWidget {
+  const _HomePrimaryActionButton({
+    required this.onPressed,
+    required this.icon,
+    required this.label,
+    super.key,
+  });
+
+  final VoidCallback onPressed;
+  final Widget icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.icon(
+      onPressed: onPressed,
+      style: FilledButton.styleFrom(
+        minimumSize: const Size.fromHeight(82),
+        textStyle: const TextStyle(fontSize: 22, fontWeight: FontWeight.w800),
+      ),
+      icon: icon,
+      label: Text(label),
+    );
+  }
+}
+
+class _HomeSecondaryActionButton extends StatelessWidget {
+  const _HomeSecondaryActionButton({
+    required this.onPressed,
+    required this.icon,
+    required this.label,
+    super.key,
+  });
+
+  final VoidCallback onPressed;
+  final Widget icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return OutlinedButton.icon(
+      onPressed: onPressed,
+      style: OutlinedButton.styleFrom(
+        alignment: Alignment.center,
+        backgroundColor: Colors.white,
+        foregroundColor: const Color(0xFF006D77),
+        side: BorderSide(color: colorScheme.outlineVariant),
+        textStyle: const TextStyle(fontSize: 17, fontWeight: FontWeight.w700),
+        padding: const EdgeInsets.symmetric(horizontal: 10),
+      ),
+      icon: icon,
+      label: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
+    );
+  }
+}
+
+class FavoriteHomeScreen extends StatelessWidget {
+  const FavoriteHomeScreen({
+    required this.favoriteRepository,
+    required this.favoriteFacilityRepository,
+    required this.favoriteRouteRepository,
+    required this.stationRepository,
+    required this.reportRepository,
+    required this.locationProvider,
+    required this.facilityReportDraftTargetStore,
+    super.key,
+  });
+
+  final FavoriteStationRepository? favoriteRepository;
+  final FavoriteFacilityRepository? favoriteFacilityRepository;
+  final FavoriteRouteRepository? favoriteRouteRepository;
+  final StationSearchRepository stationRepository;
+  final FacilityReportRepository reportRepository;
+  final CurrentLocationProvider locationProvider;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
+
+  @override
+  Widget build(BuildContext context) {
+    final sections = _favoriteSections(context);
+    return DefaultTabController(
+      length: sections.length,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('즐겨찾기'),
+          bottom: TabBar(tabs: [for (final section in sections) section.tab]),
+        ),
+        body: TabBarView(
+          children: [
+            for (final section in sections)
+              _FavoriteSectionEntry(section: section),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<_FavoriteSection> _favoriteSections(BuildContext context) {
+    final sections = <_FavoriteSection>[];
+    final favoriteRouteRepository = this.favoriteRouteRepository;
+    final favoriteRepository = this.favoriteRepository;
+    final favoriteFacilityRepository = this.favoriteFacilityRepository;
+    if (favoriteRouteRepository != null) {
+      sections.add(
+        _FavoriteSection(
+          tab: const Tab(key: Key('favoriteRoutesTabButton'), text: '경로'),
+          icon: Icons.route,
+          buttonLabel: '즐겨찾기 경로 보기',
+          buttonKey: const Key('favoriteRoutesButton'),
+          open: () {
+            Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => FavoriteRouteListScreen(
+                  repository: favoriteRouteRepository,
+                ),
+              ),
+            );
+          },
+        ),
+      );
+    }
+    if (favoriteRepository != null) {
+      sections.add(
+        _FavoriteSection(
+          tab: const Tab(key: Key('favoriteStationsTabButton'), text: '역'),
+          icon: Icons.train,
+          buttonLabel: '즐겨찾기 역 보기',
+          buttonKey: const Key('favoriteStationsButton'),
+          open: () {
+            Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => FavoriteStationListScreen(
+                  repository: favoriteRepository,
+                  stationRepository: stationRepository,
+                  reportRepository: reportRepository,
+                  locationProvider: locationProvider,
+                  facilityReportDraftTargetStore:
+                      facilityReportDraftTargetStore,
+                ),
+              ),
+            );
+          },
+        ),
+      );
+    }
+    if (favoriteFacilityRepository != null) {
+      sections.add(
+        _FavoriteSection(
+          tab: const Tab(key: Key('favoriteFacilitiesTabButton'), text: '시설'),
+          icon: Icons.elevator_outlined,
+          buttonLabel: '즐겨찾기 시설 보기',
+          buttonKey: const Key('favoriteFacilitiesButton'),
+          open: () {
+            Navigator.of(context).push(
+              MaterialPageRoute<void>(
+                builder: (_) => FavoriteFacilityListScreen(
+                  repository: favoriteFacilityRepository,
+                ),
+              ),
+            );
+          },
+        ),
+      );
+    }
+    return sections;
+  }
+}
+
+class _FavoriteSection {
+  const _FavoriteSection({
+    required this.tab,
+    required this.icon,
+    required this.buttonLabel,
+    required this.buttonKey,
+    required this.open,
+  });
+
+  final Tab tab;
+  final IconData icon;
+  final String buttonLabel;
+  final Key buttonKey;
+  final VoidCallback open;
+}
+
+class _FavoriteSectionEntry extends StatelessWidget {
+  const _FavoriteSectionEntry({required this.section});
+
+  final _FavoriteSection section;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: ListView(
+        padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+        children: [
+          OutlinedButton.icon(
+            key: section.buttonKey,
+            onPressed: section.open,
+            style: OutlinedButton.styleFrom(
+              minimumSize: const Size.fromHeight(72),
+              backgroundColor: Colors.white,
+              side: BorderSide(color: Theme.of(context).colorScheme.outline),
+            ),
+            icon: Icon(section.icon),
+            label: Text(section.buttonLabel),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -39,6 +39,21 @@ OnboardingState _completedOnboardingStateWithPreferences({
   );
 }
 
+Future<void> _openFavoriteList(
+  WidgetTester tester, {
+  required Key listButtonKey,
+  Key? tabKey,
+}) async {
+  await tester.tap(find.byKey(const Key('favoritesButton')));
+  await tester.pumpAndSettle();
+  if (tabKey != null) {
+    await tester.tap(find.byKey(tabKey));
+    await tester.pumpAndSettle();
+  }
+  await tester.tap(find.byKey(listButtonKey));
+  await tester.pumpAndSettle();
+}
+
 void main() {
   testWidgets('첫 실행 앱은 온보딩을 완료한 뒤 홈으로 이동한다', (tester) async {
     final onboardingStore = MemoryOnboardingResultStore();
@@ -64,7 +79,7 @@ void main() {
     await tester.tap(find.byKey(const Key('onboardingDoneButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('역 찾기'), findsOneWidget);
+    expect(find.text('어디로 가시나요?'), findsOneWidget);
     expect(find.byKey(const Key('stationSearchButton')), findsOneWidget);
     expect(find.text('먼저 이동 조건을 골라 주세요'), findsNothing);
     expect(onboardingStore.savedResult?.profile.id, 'elderly');
@@ -483,7 +498,7 @@ void main() {
     expect(find.text('신고'), findsNothing);
   });
 
-  testWidgets('홈 화면은 핵심 행동만 간결하게 보여준다', (tester) async {
+  testWidgets('홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
 
     try {
@@ -493,6 +508,9 @@ void main() {
           reportRepository: FakeFacilityReportRepository(),
           routeRepository: FakeRouteSearchRepository(),
           favoriteRepository: FakeFavoriteStationRepository(),
+          favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+          favoriteRouteRepository: FakeFavoriteRouteRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
           initialOnboardingState: _completedOnboardingStateWithPreferences(
             preferences: const OnboardingViewPreferences(
               largeTextEnabled: true,
@@ -503,12 +521,18 @@ void main() {
         ),
       );
 
-      expect(find.text('역 찾기'), findsOneWidget);
+      expect(find.text('어디로 가시나요?'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '역 검색'), findsOneWidget);
-      expect(find.widgetWithText(FilledButton, '경로 검색'), findsOneWidget);
-      expect(find.widgetWithText(FilledButton, '내 신고'), findsOneWidget);
-      expect(find.widgetWithText(FilledButton, '즐겨찾기 역'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '즐겨찾기'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '내 신고'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '알림 설정'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '내 신고'), findsNothing);
+      expect(find.widgetWithText(FilledButton, '알림 설정'), findsNothing);
+      expect(find.text('즐겨찾기 경로'), findsNothing);
+      expect(find.text('즐겨찾기 역'), findsNothing);
+      expect(find.text('즐겨찾기 시설'), findsNothing);
       expect(find.textContaining('빠른 길보다'), findsNothing);
       expect(find.textContaining('고령자'), findsNothing);
       expect(find.textContaining('휠체어'), findsNothing);
@@ -525,35 +549,55 @@ void main() {
       final myReportsButtonSize = tester.getSize(
         find.byKey(const Key('myReportsButton')),
       );
-
-      await tester.scrollUntilVisible(
-        find.byKey(const Key('notificationSettingsButton')),
-        120,
-      );
-      await tester.pumpAndSettle();
-      expect(find.widgetWithText(FilledButton, '알림 설정'), findsOneWidget);
       final notificationButtonSize = tester.getSize(
         find.byKey(const Key('notificationSettingsButton')),
       );
 
-      expect(stationButtonSize.height, greaterThanOrEqualTo(60));
-      expect(routeButtonSize.height, greaterThanOrEqualTo(60));
-      expect(notificationButtonSize.height, greaterThanOrEqualTo(60));
-      expect(profileButtonSize.height, greaterThanOrEqualTo(60));
-      expect(myReportsButtonSize.height, greaterThanOrEqualTo(60));
+      expect(stationButtonSize.height, greaterThanOrEqualTo(76));
+      expect(routeButtonSize.height, greaterThanOrEqualTo(76));
+      expect(profileButtonSize.height, lessThan(stationButtonSize.height));
+      expect(myReportsButtonSize.height, lessThan(stationButtonSize.height));
+      expect(notificationButtonSize.height, lessThan(stationButtonSize.height));
 
       await tester.drag(find.byType(ListView), const Offset(0, -620));
       await tester.pumpAndSettle();
 
-      expect(find.text('이동 프로필'), findsOneWidget);
-      expect(find.text('시설 정보'), findsOneWidget);
-      expect(find.text('신고'), findsOneWidget);
-      expect(find.bySemanticsLabel('이동 프로필, 이동 조건 저장'), findsOneWidget);
-      expect(find.bySemanticsLabel('시설 정보, 엘리베이터와 경사로'), findsOneWidget);
-      expect(find.bySemanticsLabel('신고, 불편 신고'), findsOneWidget);
+      expect(find.text('이동 프로필'), findsNothing);
+      expect(find.text('시설 정보'), findsNothing);
+      expect(find.text('신고'), findsNothing);
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('홈 즐겨찾기는 하나의 진입점에서 종류를 고르게 한다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    expect(find.byKey(const Key('favoritesButton')), findsOneWidget);
+    expect(find.byKey(const Key('favoriteRoutesButton')), findsNothing);
+    expect(find.byKey(const Key('favoriteStationsButton')), findsNothing);
+    expect(find.byKey(const Key('favoriteFacilitiesButton')), findsNothing);
+
+    await tester.tap(find.byKey(const Key('favoritesButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('즐겨찾기'), findsOneWidget);
+    expect(find.byKey(const Key('favoriteRoutesTabButton')), findsOneWidget);
+    expect(find.byKey(const Key('favoriteStationsTabButton')), findsOneWidget);
+    expect(
+      find.byKey(const Key('favoriteFacilitiesTabButton')),
+      findsOneWidget,
+    );
   });
 
   testWidgets('홈은 도움말에서 개인정보와 삭제 요청 경로를 보여준다', (tester) async {
@@ -621,12 +665,10 @@ void main() {
       ),
     );
 
-    expect(find.byKey(const Key('favoriteStationsButton')), findsNothing);
-    expect(find.widgetWithText(FilledButton, '즐겨찾기 역'), findsNothing);
-    expect(find.byKey(const Key('favoriteRoutesButton')), findsNothing);
-    expect(find.widgetWithText(FilledButton, '즐겨찾기 경로'), findsNothing);
+    expect(find.byKey(const Key('favoritesButton')), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, '즐겨찾기'), findsNothing);
     expect(find.byKey(const Key('notificationSettingsButton')), findsNothing);
-    expect(find.widgetWithText(FilledButton, '알림 설정'), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, '알림 설정'), findsNothing);
   });
 
   testWidgets('기본 홈 화면은 익명 인증으로 즐겨찾기를 노출한다', (tester) async {
@@ -640,17 +682,10 @@ void main() {
       ),
     );
 
-    expect(find.byKey(const Key('favoriteRoutesButton')), findsOneWidget);
-    expect(find.widgetWithText(FilledButton, '즐겨찾기 경로'), findsOneWidget);
-    expect(find.byKey(const Key('favoriteStationsButton')), findsOneWidget);
-    expect(find.widgetWithText(FilledButton, '즐겨찾기 역'), findsOneWidget);
-    await tester.scrollUntilVisible(
-      find.byKey(const Key('notificationSettingsButton')),
-      120,
-    );
-    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('favoritesButton')), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, '즐겨찾기'), findsOneWidget);
     expect(find.byKey(const Key('notificationSettingsButton')), findsOneWidget);
-    expect(find.widgetWithText(FilledButton, '알림 설정'), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, '알림 설정'), findsOneWidget);
   });
 
   test('기본 앱은 즐겨찾기와 알림 설정에 같은 익명 인증 세션을 주입한다', () {
@@ -846,8 +881,11 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byKey(const Key('favoriteStationsButton')));
-      await tester.pumpAndSettle();
+      await _openFavoriteList(
+        tester,
+        listButtonKey: const Key('favoriteStationsButton'),
+        tabKey: const Key('favoriteStationsTabButton'),
+      );
 
       expect(find.text('즐겨찾기 역'), findsOneWidget);
       expect(find.text('상록수'), findsOneWidget);
@@ -894,13 +932,11 @@ void main() {
         ),
       );
 
-      await tester.scrollUntilVisible(
-        find.byKey(const Key('favoriteFacilitiesButton')),
-        120,
+      await _openFavoriteList(
+        tester,
+        listButtonKey: const Key('favoriteFacilitiesButton'),
+        tabKey: const Key('favoriteFacilitiesTabButton'),
       );
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('favoriteFacilitiesButton')));
-      await tester.pumpAndSettle();
 
       expect(find.text('즐겨찾기 시설'), findsOneWidget);
       expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
@@ -956,8 +992,10 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byKey(const Key('favoriteRoutesButton')));
-      await tester.pumpAndSettle();
+      await _openFavoriteList(
+        tester,
+        listButtonKey: const Key('favoriteRoutesButton'),
+      );
 
       expect(find.text('즐겨찾기 경로'), findsOneWidget);
       expect(find.text('상록수에서 사당까지'), findsOneWidget);
@@ -1004,8 +1042,10 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byKey(const Key('favoriteRoutesButton')));
-    await tester.pumpAndSettle();
+    await _openFavoriteList(
+      tester,
+      listButtonKey: const Key('favoriteRoutesButton'),
+    );
 
     final removeButton = find.byKey(const Key('favoriteRouteRemove-route-1'));
     await tester.tap(removeButton);
@@ -2120,8 +2160,11 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byKey(const Key('favoriteStationsButton')));
-    await tester.pumpAndSettle();
+    await _openFavoriteList(
+      tester,
+      listButtonKey: const Key('favoriteStationsButton'),
+      tabKey: const Key('favoriteStationsTabButton'),
+    );
     await tester.tap(
       find.byKey(const Key('favoriteStationTile-station-sangnoksu')),
     );


### PR DESCRIPTION
## 관련 이슈
- Closes #217

## 배경
홈 화면의 모든 메뉴가 같은 색과 크기로 나열되어 처음 사용하는 사용자가 가장 먼저 눌러야 할 행동을 고르기 어려웠다. 교통약자 사용자가 앱을 열자마자 역 검색과 길찾기를 바로 찾을 수 있도록 핵심 기능과 보조 기능의 시각적 위계를 분리했다.

## 변경 사항
- 홈 상단 문구를 `어디로 가시나요?`로 바꾸고 `역 검색`, `길찾기`를 큰 핵심 버튼으로 배치했다.
- `이동 조건`, `즐겨찾기`, `내 신고`, `알림 설정`, `도움말`은 흰색 보조 카드 버튼으로 낮은 비중에 배치했다.
- 홈의 `즐겨찾기 경로`, `즐겨찾기 역`, `즐겨찾기 시설` 진입점을 하나의 `즐겨찾기`로 합쳤다.
- `즐겨찾기` 화면에서 `경로`, `역`, `시설` 탭을 고르고 기존 목록 화면으로 이동할 수 있게 했다.
- 홈 화면과 즐겨찾기 진입 흐름 테스트를 새 구조에 맞춰 보강했다.

## 검증
- `flutter test test/widget_test.dart`
- `flutter analyze`
- `git diff --check`
- Android 에뮬레이터 실제 화면 확인
  - 홈 화면: `/tmp/easysubway-home-redesign-current.png`
  - 즐겨찾기 화면: `/tmp/easysubway-favorites-hub.png`

## 리스크
- 즐겨찾기 목록은 홈에서 바로 열리지 않고 통합 즐겨찾기 화면을 한 번 거친다. 대신 홈 메뉴 수를 줄이고 경로/역/시설을 탭으로 구분해 첫 화면의 복잡도를 낮췄다.
