### PR TITLE
[Feat] 즐겨찾기 탭에서 목록 바로 표시

### DIFF
--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -337,6 +337,27 @@ class FavoriteFacilityListScreen extends StatefulWidget {
 
 class _FavoriteFacilityListScreenState
     extends State<FavoriteFacilityListScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('즐겨찾기 시설')),
+      body: FavoriteFacilityListContent(repository: widget.repository),
+    );
+  }
+}
+
+class FavoriteFacilityListContent extends StatefulWidget {
+  const FavoriteFacilityListContent({required this.repository, super.key});
+
+  final FavoriteFacilityRepository repository;
+
+  @override
+  State<FavoriteFacilityListContent> createState() =>
+      _FavoriteFacilityListContentState();
+}
+
+class _FavoriteFacilityListContentState
+    extends State<FavoriteFacilityListContent> {
   late final FavoriteFacilityListController _controller;
 
   @override
@@ -354,18 +375,15 @@ class _FavoriteFacilityListScreenState
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('즐겨찾기 시설')),
-      body: SafeArea(
-        child: AnimatedBuilder(
-          animation: _controller,
-          builder: (context, _) {
-            return _FavoriteFacilityListBody(
-              state: _controller.state,
-              onRetry: _controller.load,
-            );
-          },
-        ),
+    return SafeArea(
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, _) {
+          return _FavoriteFacilityListBody(
+            state: _controller.state,
+            onRetry: _controller.load,
+          );
+        },
       ),
     );
   }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -984,10 +984,7 @@ class FavoriteHomeScreen extends StatelessWidget {
           bottom: TabBar(tabs: [for (final section in sections) section.tab]),
         ),
         body: TabBarView(
-          children: [
-            for (final section in sections)
-              _FavoriteSectionEntry(section: section),
-          ],
+          children: [for (final section in sections) section.content],
         ),
       ),
     );
@@ -1002,18 +999,9 @@ class FavoriteHomeScreen extends StatelessWidget {
       sections.add(
         _FavoriteSection(
           tab: const Tab(key: Key('favoriteRoutesTabButton'), text: '경로'),
-          icon: Icons.route,
-          buttonLabel: '즐겨찾기 경로 보기',
-          buttonKey: const Key('favoriteRoutesButton'),
-          open: () {
-            Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (_) => FavoriteRouteListScreen(
-                  repository: favoriteRouteRepository,
-                ),
-              ),
-            );
-          },
+          content: FavoriteRouteListContent(
+            repository: favoriteRouteRepository,
+          ),
         ),
       );
     }
@@ -1021,23 +1009,13 @@ class FavoriteHomeScreen extends StatelessWidget {
       sections.add(
         _FavoriteSection(
           tab: const Tab(key: Key('favoriteStationsTabButton'), text: '역'),
-          icon: Icons.train,
-          buttonLabel: '즐겨찾기 역 보기',
-          buttonKey: const Key('favoriteStationsButton'),
-          open: () {
-            Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (_) => FavoriteStationListScreen(
-                  repository: favoriteRepository,
-                  stationRepository: stationRepository,
-                  reportRepository: reportRepository,
-                  locationProvider: locationProvider,
-                  facilityReportDraftTargetStore:
-                      facilityReportDraftTargetStore,
-                ),
-              ),
-            );
-          },
+          content: FavoriteStationListContent(
+            repository: favoriteRepository,
+            stationRepository: stationRepository,
+            reportRepository: reportRepository,
+            locationProvider: locationProvider,
+            facilityReportDraftTargetStore: facilityReportDraftTargetStore,
+          ),
         ),
       );
     }
@@ -1045,18 +1023,9 @@ class FavoriteHomeScreen extends StatelessWidget {
       sections.add(
         _FavoriteSection(
           tab: const Tab(key: Key('favoriteFacilitiesTabButton'), text: '시설'),
-          icon: Icons.elevator_outlined,
-          buttonLabel: '즐겨찾기 시설 보기',
-          buttonKey: const Key('favoriteFacilitiesButton'),
-          open: () {
-            Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (_) => FavoriteFacilityListScreen(
-                  repository: favoriteFacilityRepository,
-                ),
-              ),
-            );
-          },
+          content: FavoriteFacilityListContent(
+            repository: favoriteFacilityRepository,
+          ),
         ),
       );
     }
@@ -1065,47 +1034,10 @@ class FavoriteHomeScreen extends StatelessWidget {
 }
 
 class _FavoriteSection {
-  const _FavoriteSection({
-    required this.tab,
-    required this.icon,
-    required this.buttonLabel,
-    required this.buttonKey,
-    required this.open,
-  });
+  const _FavoriteSection({required this.tab, required this.content});
 
   final Tab tab;
-  final IconData icon;
-  final String buttonLabel;
-  final Key buttonKey;
-  final VoidCallback open;
-}
-
-class _FavoriteSectionEntry extends StatelessWidget {
-  const _FavoriteSectionEntry({required this.section});
-
-  final _FavoriteSection section;
-
-  @override
-  Widget build(BuildContext context) {
-    return SafeArea(
-      child: ListView(
-        padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
-        children: [
-          OutlinedButton.icon(
-            key: section.buttonKey,
-            onPressed: section.open,
-            style: OutlinedButton.styleFrom(
-              minimumSize: const Size.fromHeight(72),
-              backgroundColor: Colors.white,
-              side: BorderSide(color: Theme.of(context).colorScheme.outline),
-            ),
-            icon: Icon(section.icon),
-            label: Text(section.buttonLabel),
-          ),
-        ],
-      ),
-    );
-  }
+  final Widget content;
 }
 
 class SupportAccessScreen extends StatelessWidget {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2185,6 +2185,26 @@ class FavoriteRouteListScreen extends StatefulWidget {
 }
 
 class _FavoriteRouteListScreenState extends State<FavoriteRouteListScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('즐겨찾기 경로')),
+      body: FavoriteRouteListContent(repository: widget.repository),
+    );
+  }
+}
+
+class FavoriteRouteListContent extends StatefulWidget {
+  const FavoriteRouteListContent({required this.repository, super.key});
+
+  final FavoriteRouteRepository repository;
+
+  @override
+  State<FavoriteRouteListContent> createState() =>
+      _FavoriteRouteListContentState();
+}
+
+class _FavoriteRouteListContentState extends State<FavoriteRouteListContent> {
   late final FavoriteRouteListController _controller;
 
   @override
@@ -2202,16 +2222,13 @@ class _FavoriteRouteListScreenState extends State<FavoriteRouteListScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('즐겨찾기 경로')),
-      body: SafeArea(
-        child: AnimatedBuilder(
-          animation: _controller,
-          builder: (context, _) => _FavoriteRouteListBody(
-            state: _controller.state,
-            onRetry: _controller.load,
-            onRemove: _controller.remove,
-          ),
+    return SafeArea(
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, _) => _FavoriteRouteListBody(
+          state: _controller.state,
+          onRetry: _controller.load,
+          onRemove: _controller.remove,
         ),
       ),
     );

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2447,6 +2447,44 @@ class FavoriteStationListScreen extends StatefulWidget {
 }
 
 class _FavoriteStationListScreenState extends State<FavoriteStationListScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('즐겨찾기 역')),
+      body: FavoriteStationListContent(
+        repository: widget.repository,
+        stationRepository: widget.stationRepository,
+        reportRepository: widget.reportRepository,
+        locationProvider: widget.locationProvider,
+        facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
+      ),
+    );
+  }
+}
+
+class FavoriteStationListContent extends StatefulWidget {
+  const FavoriteStationListContent({
+    required this.repository,
+    required this.stationRepository,
+    required this.reportRepository,
+    this.locationProvider,
+    this.facilityReportDraftTargetStore,
+    super.key,
+  });
+
+  final FavoriteStationRepository repository;
+  final StationSearchRepository stationRepository;
+  final FacilityReportRepository reportRepository;
+  final CurrentLocationProvider? locationProvider;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
+
+  @override
+  State<FavoriteStationListContent> createState() =>
+      _FavoriteStationListContentState();
+}
+
+class _FavoriteStationListContentState
+    extends State<FavoriteStationListContent> {
   late final FavoriteStationListController _controller;
 
   @override
@@ -2464,19 +2502,16 @@ class _FavoriteStationListScreenState extends State<FavoriteStationListScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('즐겨찾기 역')),
-      body: SafeArea(
-        child: AnimatedBuilder(
-          animation: _controller,
-          builder: (context, _) {
-            return _FavoriteStationListBody(
-              state: _controller.state,
-              onRetry: _controller.load,
-              onFavoriteTap: _openStationDetail,
-            );
-          },
-        ),
+    return SafeArea(
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, _) {
+          return _FavoriteStationListBody(
+            state: _controller.state,
+            onRetry: _controller.load,
+            onFavoriteTap: _openStationDetail,
+          );
+        },
       ),
     );
   }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -39,19 +39,13 @@ OnboardingState _completedOnboardingStateWithPreferences({
   );
 }
 
-Future<void> _openFavoriteList(
-  WidgetTester tester, {
-  required Key listButtonKey,
-  Key? tabKey,
-}) async {
+Future<void> _openFavoriteList(WidgetTester tester, {Key? tabKey}) async {
   await tester.tap(find.byKey(const Key('favoritesButton')));
   await tester.pumpAndSettle();
   if (tabKey != null) {
     await tester.tap(find.byKey(tabKey));
     await tester.pumpAndSettle();
   }
-  await tester.tap(find.byKey(listButtonKey));
-  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -570,7 +564,7 @@ void main() {
     }
   });
 
-  testWidgets('홈 즐겨찾기는 하나의 진입점에서 종류를 고르게 한다', (tester) async {
+  testWidgets('홈 즐겨찾기는 하나의 진입점에서 탭 목록을 바로 보여준다', (tester) async {
     await tester.pumpWidget(
       EasySubwayApp(
         repository: FakeStationSearchRepository(),
@@ -598,6 +592,9 @@ void main() {
       find.byKey(const Key('favoriteFacilitiesTabButton')),
       findsOneWidget,
     );
+    expect(find.byKey(const Key('favoriteRoutesButton')), findsNothing);
+    expect(find.byKey(const Key('favoriteStationsButton')), findsNothing);
+    expect(find.byKey(const Key('favoriteFacilitiesButton')), findsNothing);
   });
 
   testWidgets('홈은 도움말에서 개인정보와 삭제 요청 경로를 보여준다', (tester) async {
@@ -877,17 +874,17 @@ void main() {
           reportRepository: FakeFacilityReportRepository(),
           routeRepository: FakeRouteSearchRepository(),
           favoriteRepository: favoriteRepository,
+          favoriteRouteRepository: FakeFavoriteRouteRepository(),
           initialOnboardingState: _completedOnboardingState(),
         ),
       );
 
       await _openFavoriteList(
         tester,
-        listButtonKey: const Key('favoriteStationsButton'),
         tabKey: const Key('favoriteStationsTabButton'),
       );
 
-      expect(find.text('즐겨찾기 역'), findsOneWidget);
+      expect(find.text('역'), findsOneWidget);
       expect(find.text('상록수'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
       expect(find.text('기본 정보만 있음'), findsOneWidget);
@@ -928,17 +925,17 @@ void main() {
           routeRepository: FakeRouteSearchRepository(),
           favoriteRepository: FakeFavoriteStationRepository(),
           favoriteFacilityRepository: favoriteFacilityRepository,
+          favoriteRouteRepository: FakeFavoriteRouteRepository(),
           initialOnboardingState: _completedOnboardingState(),
         ),
       );
 
       await _openFavoriteList(
         tester,
-        listButtonKey: const Key('favoriteFacilitiesButton'),
         tabKey: const Key('favoriteFacilitiesTabButton'),
       );
 
-      expect(find.text('즐겨찾기 시설'), findsOneWidget);
+      expect(find.text('시설'), findsOneWidget);
       expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
       expect(find.text('상록수역'), findsOneWidget);
       expect(find.text('정상'), findsOneWidget);
@@ -992,12 +989,9 @@ void main() {
         ),
       );
 
-      await _openFavoriteList(
-        tester,
-        listButtonKey: const Key('favoriteRoutesButton'),
-      );
+      await _openFavoriteList(tester);
 
-      expect(find.text('즐겨찾기 경로'), findsOneWidget);
+      expect(find.text('경로'), findsOneWidget);
       expect(find.text('상록수에서 사당까지'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
       expect(find.text('고령자'), findsOneWidget);
@@ -1042,10 +1036,7 @@ void main() {
       ),
     );
 
-    await _openFavoriteList(
-      tester,
-      listButtonKey: const Key('favoriteRoutesButton'),
-    );
+    await _openFavoriteList(tester);
 
     final removeButton = find.byKey(const Key('favoriteRouteRemove-route-1'));
     await tester.tap(removeButton);
@@ -2082,6 +2073,7 @@ void main() {
         reportRepository: FakeFacilityReportRepository(),
         routeRepository: FakeRouteSearchRepository(),
         favoriteRepository: favoriteRepository,
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
         initialOnboardingState: _completedOnboardingState(),
       ),
     );
@@ -2114,6 +2106,7 @@ void main() {
         reportRepository: FakeFacilityReportRepository(),
         routeRepository: FakeRouteSearchRepository(),
         favoriteRepository: favoriteRepository,
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
         initialOnboardingState: _completedOnboardingState(),
       ),
     );
@@ -2156,13 +2149,13 @@ void main() {
         reportRepository: FakeFacilityReportRepository(),
         routeRepository: FakeRouteSearchRepository(),
         favoriteRepository: favoriteRepository,
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
         initialOnboardingState: _completedOnboardingState(),
       ),
     );
 
     await _openFavoriteList(
       tester,
-      listButtonKey: const Key('favoriteStationsButton'),
       tabKey: const Key('favoriteStationsTabButton'),
     );
     await tester.tap(

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1408,8 +1408,8 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(envExample, /^EASYSUBWAY_ANDROID_KEY_PASSWORD=$/m);
   assert.match(iosInfoPlist, /CFBundleDisplayName[\s\S]*?<string>쉬운 지하철<\/string>/);
   assert.match(main, /class EasySubwayApp extends StatelessWidget/);
-  assert.match(main, /역 찾기/);
   assert.match(main, /역 검색/);
+  assert.match(main, /길찾기/);
   assert.match(main, /이동 조건/);
   assert.match(main, /알림 설정/);
   assert.match(main, /AnonymousAuthSession/);
@@ -1424,8 +1424,11 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(main, /highContrast:[\s\S]*preferences\.highContrastEnabled \|\| mediaQuery\.highContrast/);
   assert.match(main, /_themeForPreferences/);
   assert.match(main, /simpleViewEnabled: preferences\.simpleViewEnabled/);
-  assert.match(main, /if \(!simpleViewEnabled\)/);
-  assert.match(main, /semanticLabel: '시설 정보, 엘리베이터와 경사로'/);
+  assert.match(main, /label: '즐겨찾기'/);
+  assert.match(main, /FavoriteHomeScreen/);
+  assert.match(main, /FavoriteRouteListContent/);
+  assert.match(main, /FavoriteStationListContent/);
+  assert.match(main, /FavoriteFacilityListContent/);
   assert.match(onboarding, /class OnboardingViewPreferences/);
   assert.match(onboarding, /const OnboardingViewPreferences\.defaults/);
   assert.match(onboarding, /class OnboardingResult/);
@@ -1537,7 +1540,8 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(notificationSettingsTest, /알림 설정 컨트롤러는 조회와 저장 상태를 구분한다/);
   assert.doesNotMatch(main, /빠른 길보다, 갈 수 있는 길을 먼저 안내합니다|고령자, 임산부, 장애인도 편하게 이동할 수 있도록|현장에서 발견한 불편 정보를 신고하고 검수할 수 있게/);
   assert.match(widgetTest, /EasySubwayApp/);
-  assert.match(widgetTest, /홈 화면은 핵심 행동만 간결하게 보여준다/);
+  assert.match(widgetTest, /홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다/);
+  assert.match(widgetTest, /홈 즐겨찾기는 하나의 진입점에서 탭 목록을 바로 보여준다/);
   assert.match(widgetTest, /알림 설정 화면은 현재 설정을 불러오고 바꾼 값을 저장한다/);
   assert.match(widgetTest, /bySemanticsLabel/);
   assert.match(widgetTest, /greaterThanOrEqualTo\(60\)/);


### PR DESCRIPTION
## 관련 이슈
Closes #220

## 요약
- 즐겨찾기 화면의 경로/역/시설 탭에서 목록을 바로 보여주도록 정리합니다.
- 탭 안의 중복 "보기" 버튼을 제거하고 기존 목록 UI와 접근성 라벨을 유지합니다.
- 경로 삭제, 역 상세 진입, 시설 목록 표시 테스트를 탭 화면 기준으로 갱신합니다.

## 변경 사항
- 홈의 즐겨찾기 진입점은 하나만 유지합니다.
- 즐겨찾기 탭 콘텐츠가 기존 목록 화면 본문을 직접 재사용하도록 구조를 정리합니다.
- 기존 개별 목록 화면은 외부 진입이 필요한 경우를 위해 유지합니다.

## 검증
- `flutter test test/widget_test.dart`
- `flutter analyze`
- `node --test tools/ci/*.test.mjs`
- Android emulator 화면 확인
  - `/tmp/easysubway-favorite-tabs-direct-list-routes.png`
  - `/tmp/easysubway-favorite-tabs-direct-list-stations.png`
  - `/tmp/easysubway-favorite-tabs-direct-list-facilities.png`

## 리스크
- 개별 즐겨찾기 목록 화면과 통합 탭 화면이 같은 본문 위젯을 공유하므로, 향후 목록 레이아웃 변경 시 두 진입점이 함께 영향을 받습니다.
