### PR TITLE
[Feat] 경로 검색 단순 보기 적용

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -768,6 +768,7 @@ class HomeScreen extends StatelessWidget {
                       routeFeedbackRepository: routeFeedbackRepository,
                       favoriteRouteRepository: favoriteRouteRepository,
                       initialMobilityType: initialMobilityType,
+                      simpleViewEnabled: simpleViewEnabled,
                     ),
                   ),
                 );

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -930,9 +930,12 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
               onSelected: _updateDestinationStation,
             ),
             const SizedBox(height: 12),
-            // 단순 보기에서는 온보딩에서 고른 이동 조건을 그대로 적용해 선택 부담을 줄인다.
+            // 단순 보기에서는 드롭다운 대신 현재 조건을 크게 보여주고, 필요할 때만 바꿀 수 있게 한다.
             if (widget.simpleViewEnabled)
-              _RouteMobilityTypeSummary(mobilityType: _selectedMobilityType)
+              _RouteMobilityTypeSummary(
+                mobilityType: _selectedMobilityType,
+                onChangeRequested: _showMobilityTypePicker,
+              )
             else
               InputDecorator(
                 key: const Key('routeMobilityTypeInput'),
@@ -1040,64 +1043,173 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
     });
     _controller.reset();
   }
+
+  Future<void> _showMobilityTypePicker() async {
+    final selectedMobilityType = await showModalBottomSheet<String>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) {
+        return SafeArea(
+          child: ListView(
+            shrinkWrap: true,
+            padding: const EdgeInsets.fromLTRB(20, 8, 20, 24),
+            children: [
+              Text(
+                '이동 조건',
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: const Color(0xFF102A2C),
+                  fontWeight: FontWeight.w900,
+                  height: 1.25,
+                ),
+              ),
+              const SizedBox(height: 12),
+              for (final option in mobilityProfileOptions)
+                _RouteMobilityTypeOptionButton(
+                  key: Key('routeMobilityOption-${option.mobilityType}'),
+                  option: option,
+                  selected: option.mobilityType == _selectedMobilityType,
+                  onSelected: () =>
+                      Navigator.of(context).pop(option.mobilityType),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+
+    if (!mounted || selectedMobilityType == null) {
+      return;
+    }
+    setState(() {
+      _selectedMobilityType = selectedMobilityType;
+    });
+    _controller.reset();
+  }
 }
 
 class _RouteMobilityTypeSummary extends StatelessWidget {
-  const _RouteMobilityTypeSummary({required this.mobilityType});
+  const _RouteMobilityTypeSummary({
+    required this.mobilityType,
+    required this.onChangeRequested,
+  });
 
   final String mobilityType;
+  final VoidCallback onChangeRequested;
 
   @override
   Widget build(BuildContext context) {
     final option = _mobilityOptionFor(mobilityType);
-    return MergeSemantics(
-      child: Semantics(
-        label: '적용 중인 이동 조건, ${option.title}',
-        liveRegion: true,
-        child: ExcludeSemantics(
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: const Color(0xFFE9F5F6),
-              border: Border.all(color: const Color(0xFFB9D4D8)),
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-              child: Row(
-                children: [
-                  Icon(option.icon, color: const Color(0xFF006D77), size: 26),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          '적용 중인 이동 조건',
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(
-                                color: const Color(0xFF29484B),
-                                fontWeight: FontWeight.w700,
-                                height: 1.25,
-                              ),
-                        ),
-                        const SizedBox(height: 3),
-                        Text(
-                          option.title,
-                          style: Theme.of(context).textTheme.titleMedium
-                              ?.copyWith(
-                                color: const Color(0xFF102A2C),
-                                fontWeight: FontWeight.w900,
-                                height: 1.25,
-                              ),
-                        ),
-                      ],
+    return Semantics(
+      button: true,
+      label: '이동 조건 바꾸기, 현재 ${option.title}',
+      liveRegion: true,
+      child: ExcludeSemantics(
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            key: const Key('routeSimpleMobilityTypeButton'),
+            onTap: onChangeRequested,
+            borderRadius: BorderRadius.circular(8),
+            child: Ink(
+              decoration: BoxDecoration(
+                color: const Color(0xFFE9F5F6),
+                border: Border.all(color: const Color(0xFFB9D4D8)),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 12,
+                ),
+                child: Row(
+                  children: [
+                    Icon(option.icon, color: const Color(0xFF006D77), size: 26),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '적용 중인 이동 조건',
+                            style: Theme.of(context).textTheme.bodyMedium
+                                ?.copyWith(
+                                  color: const Color(0xFF29484B),
+                                  fontWeight: FontWeight.w700,
+                                  height: 1.25,
+                                ),
+                          ),
+                          const SizedBox(height: 3),
+                          Text(
+                            option.title,
+                            style: Theme.of(context).textTheme.titleMedium
+                                ?.copyWith(
+                                  color: const Color(0xFF102A2C),
+                                  fontWeight: FontWeight.w900,
+                                  height: 1.25,
+                                ),
+                          ),
+                        ],
+                      ),
                     ),
-                  ),
-                ],
+                    Text(
+                      '바꾸기',
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        color: const Color(0xFF006D77),
+                        fontWeight: FontWeight.w900,
+                        height: 1.25,
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _RouteMobilityTypeOptionButton extends StatelessWidget {
+  const _RouteMobilityTypeOptionButton({
+    required this.option,
+    required this.selected,
+    required this.onSelected,
+    super.key,
+  });
+
+  final MobilityProfileOption option;
+  final bool selected;
+  final VoidCallback onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = selected
+        ? FilledButton.styleFrom(minimumSize: const Size.fromHeight(64))
+        : OutlinedButton.styleFrom(minimumSize: const Size.fromHeight(64));
+    final label = Row(
+      children: [
+        Icon(option.icon),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Text(
+            option.title,
+            style: const TextStyle(fontWeight: FontWeight.w800),
+          ),
+        ),
+        if (selected) const Icon(Icons.check_circle),
+      ],
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Semantics(
+        label: option.semanticsLabel(selected),
+        button: true,
+        selected: selected,
+        child: selected
+            ? FilledButton(onPressed: onSelected, style: style, child: label)
+            : OutlinedButton(onPressed: onSelected, style: style, child: label),
       ),
     );
   }

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1103,6 +1103,7 @@ class _RouteMobilityTypeSummary extends StatelessWidget {
       button: true,
       label: '이동 조건 바꾸기, 현재 ${option.title}',
       liveRegion: true,
+      onTap: onChangeRequested,
       child: ExcludeSemantics(
         child: Material(
           color: Colors.transparent,

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -851,6 +851,7 @@ class RouteSearchScreen extends StatefulWidget {
     required this.stationRepository,
     this.routeFeedbackRepository,
     this.favoriteRouteRepository,
+    this.simpleViewEnabled = true,
     String? initialMobilityType,
     super.key,
   }) : initialMobilityType = _resolveInitialMobilityType(initialMobilityType);
@@ -860,6 +861,7 @@ class RouteSearchScreen extends StatefulWidget {
   final RouteFeedbackRepository? routeFeedbackRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
   final String initialMobilityType;
+  final bool simpleViewEnabled;
 
   @override
   State<RouteSearchScreen> createState() => _RouteSearchScreenState();
@@ -928,36 +930,40 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
               onSelected: _updateDestinationStation,
             ),
             const SizedBox(height: 12),
-            InputDecorator(
-              key: const Key('routeMobilityTypeInput'),
-              decoration: const InputDecoration(
-                labelText: '이동 조건',
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.all(Radius.circular(8)),
+            // 단순 보기에서는 온보딩에서 고른 이동 조건을 그대로 적용해 선택 부담을 줄인다.
+            if (widget.simpleViewEnabled)
+              _RouteMobilityTypeSummary(mobilityType: _selectedMobilityType)
+            else
+              InputDecorator(
+                key: const Key('routeMobilityTypeInput'),
+                decoration: const InputDecoration(
+                  labelText: '이동 조건',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(8)),
+                  ),
+                ),
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<String>(
+                    value: _selectedMobilityType,
+                    isExpanded: true,
+                    items: [
+                      for (final option in mobilityProfileOptions)
+                        DropdownMenuItem<String>(
+                          value: option.mobilityType,
+                          child: Text(option.title),
+                        ),
+                    ],
+                    onChanged: (value) {
+                      if (value == null) {
+                        return;
+                      }
+                      setState(() {
+                        _selectedMobilityType = value;
+                      });
+                    },
+                  ),
                 ),
               ),
-              child: DropdownButtonHideUnderline(
-                child: DropdownButton<String>(
-                  value: _selectedMobilityType,
-                  isExpanded: true,
-                  items: [
-                    for (final option in mobilityProfileOptions)
-                      DropdownMenuItem<String>(
-                        value: option.mobilityType,
-                        child: Text(option.title),
-                      ),
-                  ],
-                  onChanged: (value) {
-                    if (value == null) {
-                      return;
-                    }
-                    setState(() {
-                      _selectedMobilityType = value;
-                    });
-                  },
-                ),
-              ),
-            ),
             const SizedBox(height: 12),
             AnimatedBuilder(
               animation: _controller,
@@ -1034,6 +1040,74 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
     });
     _controller.reset();
   }
+}
+
+class _RouteMobilityTypeSummary extends StatelessWidget {
+  const _RouteMobilityTypeSummary({required this.mobilityType});
+
+  final String mobilityType;
+
+  @override
+  Widget build(BuildContext context) {
+    final option = _mobilityOptionFor(mobilityType);
+    return MergeSemantics(
+      child: Semantics(
+        label: '적용 중인 이동 조건, ${option.title}',
+        liveRegion: true,
+        child: ExcludeSemantics(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: const Color(0xFFE9F5F6),
+              border: Border.all(color: const Color(0xFFB9D4D8)),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+              child: Row(
+                children: [
+                  Icon(option.icon, color: const Color(0xFF006D77), size: 26),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '적용 중인 이동 조건',
+                          style: Theme.of(context).textTheme.bodyMedium
+                              ?.copyWith(
+                                color: const Color(0xFF29484B),
+                                fontWeight: FontWeight.w700,
+                                height: 1.25,
+                              ),
+                        ),
+                        const SizedBox(height: 3),
+                        Text(
+                          option.title,
+                          style: Theme.of(context).textTheme.titleMedium
+                              ?.copyWith(
+                                color: const Color(0xFF102A2C),
+                                fontWeight: FontWeight.w900,
+                                height: 1.25,
+                              ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+MobilityProfileOption _mobilityOptionFor(String mobilityType) {
+  return mobilityProfileOptions.firstWhere(
+    (option) => option.mobilityType == mobilityType,
+    orElse: () => mobilityProfileOptions.first,
+  );
 }
 
 class _RouteStationPicker extends StatefulWidget {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2469,6 +2469,70 @@ void main() {
     expect(routeRepository.requests.single.mobilityType, 'WHEELCHAIR');
   });
 
+  testWidgets('경로 검색 단순 보기에서도 이동 조건을 바꿀 수 있다', (tester) async {
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '사당': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
+    final routeRepository = FakeRouteSearchRepository();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: routeRepository,
+        favoriteRepository: FakeFavoriteStationRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DropdownButton<String>), findsNothing);
+    expect(find.text('고령자'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('routeSimpleMobilityTypeButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeMobilityOption-WHEELCHAIR')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('휠체어'), findsOneWidget);
+
+    await tester.enterText(
+      find.byKey(const Key('routeOriginStationInput')),
+      '상록수',
+    );
+    await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeDestinationStationInput')),
+      '사당',
+    );
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationSearchButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationOption-station-sadang')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(ListView), const Offset(0, -360));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(routeRepository.requests.single.mobilityType, 'WHEELCHAIR');
+  });
+
   testWidgets('경로 검색 결과는 이동 가능한 경로만 즐겨찾기에 저장한다', (tester) async {
     final stationRepository = FakeStationSearchRepository(
       queryResults: {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2533,6 +2533,36 @@ void main() {
     expect(routeRepository.requests.single.mobilityType, 'WHEELCHAIR');
   });
 
+  testWidgets('경로 검색 단순 보기 이동 조건은 스크린리더로도 바꿀 수 있다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('routeSearchButton')));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getSemantics(find.bySemanticsLabel('이동 조건 바꾸기, 현재 고령자')),
+        isSemantics(
+          label: '이동 조건 바꾸기, 현재 고령자',
+          isButton: true,
+          hasTapAction: true,
+        ),
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('경로 검색 결과는 이동 가능한 경로만 즐겨찾기에 저장한다', (tester) async {
     final stationRepository = FakeStationSearchRepository(
       queryResults: {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2300,7 +2300,9 @@ void main() {
       expect(find.text('도착역'), findsOneWidget);
       expect(find.text('출발역 ID'), findsNothing);
       expect(find.text('도착역 ID'), findsNothing);
-      expect(find.text('이동 조건'), findsOneWidget);
+      expect(find.text('적용 중인 이동 조건'), findsOneWidget);
+      expect(find.text('고령자'), findsOneWidget);
+      expect(find.byType(DropdownButton<String>), findsNothing);
 
       final originInput = tester.widget<TextField>(
         find.byKey(const Key('routeOriginStationInput')),
@@ -2397,6 +2399,74 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('경로 검색 단순 보기를 끄면 화면에서 이동 조건을 바꿀 수 있다', (tester) async {
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '사당': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
+    final routeRepository = FakeRouteSearchRepository();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: routeRepository,
+        favoriteRepository: FakeFavoriteStationRepository(),
+        initialOnboardingState: _completedOnboardingStateWithPreferences(
+          preferences: const OnboardingViewPreferences(
+            largeTextEnabled: true,
+            highContrastEnabled: false,
+            simpleViewEnabled: false,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('이동 조건'), findsOneWidget);
+    expect(find.byType(DropdownButton<String>), findsOneWidget);
+
+    await tester.tap(find.byType(DropdownButton<String>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('휠체어').last);
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeOriginStationInput')),
+      '상록수',
+    );
+    await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeDestinationStationInput')),
+      '사당',
+    );
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationSearchButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationOption-station-sadang')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(ListView), const Offset(0, -360));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(routeRepository.requests.single.mobilityType, 'WHEELCHAIR');
   });
 
   testWidgets('경로 검색 결과는 이동 가능한 경로만 즐겨찾기에 저장한다', (tester) async {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1424,6 +1424,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(main, /highContrast:[\s\S]*preferences\.highContrastEnabled \|\| mediaQuery\.highContrast/);
   assert.match(main, /_themeForPreferences/);
   assert.match(main, /simpleViewEnabled: preferences\.simpleViewEnabled/);
+  assert.match(main, /RouteSearchScreen\([\s\S]*simpleViewEnabled: simpleViewEnabled/);
   assert.match(main, /label: '즐겨찾기'/);
   assert.match(main, /FavoriteHomeScreen/);
   assert.match(main, /FavoriteRouteListContent/);
@@ -1441,8 +1442,10 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(onboarding, /단순 보기/);
   assert.match(onboarding, /onTap: \(\) => onChanged\(!value\)/);
   assert.match(routeSearch, /final String initialMobilityType/);
+  assert.match(routeSearch, /final bool simpleViewEnabled/);
   assert.match(routeSearch, /_resolveInitialMobilityType/);
   assert.match(routeSearch, /_selectedMobilityType = widget\.initialMobilityType/);
+  assert.match(routeSearch, /_RouteMobilityTypeSummary\(mobilityType: _selectedMobilityType\)/);
   assert.match(widgetTest, /첫 실행 앱은 온보딩을 완료한 뒤 홈으로 이동한다/);
   assert.match(widgetTest, /온보딩 이동 조건은 경로 검색 기본값으로 이어진다/);
   assert.match(widgetTest, /온보딩 보기 설정은 완료 뒤 홈 UI에 적용된다/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1445,7 +1445,9 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(routeSearch, /final bool simpleViewEnabled/);
   assert.match(routeSearch, /_resolveInitialMobilityType/);
   assert.match(routeSearch, /_selectedMobilityType = widget\.initialMobilityType/);
-  assert.match(routeSearch, /_RouteMobilityTypeSummary\(mobilityType: _selectedMobilityType\)/);
+  assert.match(routeSearch, /_RouteMobilityTypeSummary\([\s\S]*mobilityType: _selectedMobilityType[\s\S]*onChangeRequested: _showMobilityTypePicker/);
+  assert.match(routeSearch, /routeSimpleMobilityTypeButton/);
+  assert.match(routeSearch, /routeMobilityOption-\$\{option\.mobilityType\}/);
   assert.match(widgetTest, /첫 실행 앱은 온보딩을 완료한 뒤 홈으로 이동한다/);
   assert.match(widgetTest, /온보딩 이동 조건은 경로 검색 기본값으로 이어진다/);
   assert.match(widgetTest, /온보딩 보기 설정은 완료 뒤 홈 UI에 적용된다/);


### PR DESCRIPTION
## 관련 이슈

Closes #222

## 배경

온보딩에서 단순 보기를 선택한 사용자는 경로 검색에서도 같은 단순 흐름을 기대한다. 기존 화면은 단순 보기 여부와 관계없이 이동 조건 드롭다운을 보여줘 출발역과 도착역 선택보다 보조 설정이 먼저 눈에 들어올 수 있었다.

## 변경 사항

- 홈에서 경로 검색 화면으로 `simpleViewEnabled` 설정을 전달했다.
- 단순 보기에서는 이동 조건 드롭다운을 숨기고 현재 적용 중인 이동 조건만 요약으로 보여준다.
- 단순 보기를 끈 사용자는 기존처럼 경로 검색 화면에서 이동 조건을 바꿀 수 있게 유지했다.
- 경로 검색 위젯 테스트와 repository contract에 단순 보기 전달/표시 조건을 추가했다.

## 검증

- `flutter analyze`
- `flutter test`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- Android emulator `emulator-5554`에서 경로 검색 화면 확인
  - 스크린샷: `/tmp/easysubway-route-search-simple-view.png`

## 리스크

- 단순 보기에서는 경로 검색 화면 안에서 이동 조건을 직접 바꾸지 않는다. 사용자가 조건을 바꾸려면 홈의 이동 조건 화면을 사용해야 한다.
