### PR TITLE
[Style] 홈 도움말 진입 위치 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -730,12 +730,18 @@ class HomeScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('쉬운 지하철'),
         actions: [
-          IconButton(
+          TextButton.icon(
             key: const Key('homeHelpActionButton'),
-            tooltip: '도움말',
             onPressed: openSupportAccess,
             icon: const Icon(Icons.help_outline),
+            label: const Text('도움말'),
+            style: TextButton.styleFrom(
+              foregroundColor: Theme.of(context).colorScheme.primary,
+              minimumSize: const Size(96, 48),
+              textStyle: const TextStyle(fontWeight: FontWeight.w800),
+            ),
           ),
+          const SizedBox(width: 8),
         ],
       ),
       body: SafeArea(

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -718,9 +718,26 @@ class HomeScreen extends StatelessWidget {
         favoriteRepository != null ||
         favoriteFacilityRepository != null ||
         favoriteRouteRepository != null;
+    void openSupportAccess() {
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => SupportAccessScreen(accessInfo: supportAccessInfo),
+        ),
+      );
+    }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('쉬운 지하철')),
+      appBar: AppBar(
+        title: const Text('쉬운 지하철'),
+        actions: [
+          IconButton(
+            key: const Key('homeHelpActionButton'),
+            tooltip: '도움말',
+            onPressed: openSupportAccess,
+            icon: const Icon(Icons.help_outline),
+          ),
+        ],
+      ),
       body: SafeArea(
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
@@ -868,24 +885,6 @@ class HomeScreen extends StatelessWidget {
                           label: '알림 설정',
                         ),
                       ),
-                    SizedBox(
-                      width: itemWidth,
-                      height: 64,
-                      child: _HomeSecondaryActionButton(
-                        key: const Key('helpButton'),
-                        onPressed: () {
-                          Navigator.of(context).push(
-                            MaterialPageRoute<void>(
-                              builder: (_) => SupportAccessScreen(
-                                accessInfo: supportAccessInfo,
-                              ),
-                            ),
-                          );
-                        },
-                        icon: const Icon(Icons.help_outline),
-                        label: '도움말',
-                      ),
-                    ),
                   ],
                 );
               },

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -524,6 +524,7 @@ void main() {
       expect(find.widgetWithText(OutlinedButton, '알림 설정'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '도움말'), findsNothing);
       expect(find.byKey(const Key('homeHelpActionButton')), findsOneWidget);
+      expect(find.widgetWithText(TextButton, '도움말'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '내 신고'), findsNothing);
       expect(find.widgetWithText(FilledButton, '알림 설정'), findsNothing);
       expect(find.text('즐겨찾기 경로'), findsNothing);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -522,6 +522,8 @@ void main() {
       expect(find.widgetWithText(OutlinedButton, '즐겨찾기'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '내 신고'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '알림 설정'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '도움말'), findsNothing);
+      expect(find.byKey(const Key('homeHelpActionButton')), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '내 신고'), findsNothing);
       expect(find.widgetWithText(FilledButton, '알림 설정'), findsNothing);
       expect(find.text('즐겨찾기 경로'), findsNothing);
@@ -616,9 +618,7 @@ void main() {
         ),
       );
 
-      await tester.scrollUntilVisible(find.byKey(const Key('helpButton')), 120);
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('helpButton')));
+      await tester.tap(find.byKey(const Key('homeHelpActionButton')));
       await tester.pumpAndSettle();
 
       expect(find.text('도움말'), findsOneWidget);


### PR DESCRIPTION
Closes #224

## 요약
- 홈 본문 보조 버튼 목록에서 `도움말`을 제거했습니다.
- 도움말 기능은 상단 AppBar 액션으로 이동해 개인정보처리방침, 고객지원, 데이터 삭제 요청 경로는 그대로 접근할 수 있게 했습니다.
- 홈 위젯 테스트가 본문 보조 버튼 구성과 상단 도움말 진입을 함께 검증하도록 갱신했습니다.

## 검증
- `flutter test test/widget_test.dart --name '홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다'`
- `flutter test test/widget_test.dart --name '홈은 도움말에서 개인정보와 삭제 요청 경로를 보여준다'`
- `dart format apps/mobile/lib/main.dart apps/mobile/test/widget_test.dart`
- `git diff --check`
- `node --test tools/ci/*.test.mjs`
- `flutter analyze`
- `flutter test`
- Android emulator: 홈 화면에서 본문 보조 버튼 4개와 상단 도움말 액션 확인
- Android emulator: 상단 도움말 액션으로 도움말 화면 진입 확인

## 리스크
- 도움말 진입 위치가 본문에서 상단으로 바뀌므로 기존 위치를 기대하던 사용자는 버튼 위치가 달라졌다고 느낄 수 있습니다. 다만 첫 화면의 핵심 선택지를 줄이는 목적에 맞춰 기능은 유지했습니다.
