### PR TITLE
[Feat] 도움말 외부 연결 동작 추가

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'anonymous_auth.dart';
 import 'auth_headers.dart';
@@ -43,6 +44,8 @@ class EasySubwayApp extends StatelessWidget {
     FacilityReportLostPhotoRestorer? facilityReportLostPhotoRestorer,
     SupportAccessInfo supportAccessInfo =
         const SupportAccessInfo.fromEnvironment(),
+    SupportAccessLauncher supportAccessLauncher =
+        const UrlLauncherSupportAccessLauncher(),
     OnboardingState initialOnboardingState = const OnboardingState.initial(),
     bool enableAnonymousAuth = true,
     Key? key,
@@ -66,6 +69,7 @@ class EasySubwayApp extends StatelessWidget {
          facilityReportDraftTargetStore: facilityReportDraftTargetStore,
          facilityReportLostPhotoRestorer: facilityReportLostPhotoRestorer,
          supportAccessInfo: supportAccessInfo,
+         supportAccessLauncher: supportAccessLauncher,
          key: key,
        );
 
@@ -76,6 +80,7 @@ class EasySubwayApp extends StatelessWidget {
     required this.facilityReportDraftTargetStore,
     required this.facilityReportLostPhotoRestorer,
     required this.supportAccessInfo,
+    required this.supportAccessLauncher,
     super.key,
   }) : repository = dependencies.repository,
        reportRepository = dependencies.reportRepository,
@@ -104,6 +109,7 @@ class EasySubwayApp extends StatelessWidget {
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
   final FacilityReportLostPhotoRestorer? facilityReportLostPhotoRestorer;
   final SupportAccessInfo supportAccessInfo;
+  final SupportAccessLauncher supportAccessLauncher;
 
   @override
   Widget build(BuildContext context) {
@@ -164,8 +170,22 @@ class EasySubwayApp extends StatelessWidget {
         facilityReportDraftTargetStore: facilityReportDraftTargetStore,
         facilityReportLostPhotoRestorer: facilityReportLostPhotoRestorer,
         supportAccessInfo: supportAccessInfo,
+        supportAccessLauncher: supportAccessLauncher,
       ),
     );
+  }
+}
+
+abstract interface class SupportAccessLauncher {
+  Future<bool> open(Uri uri);
+}
+
+class UrlLauncherSupportAccessLauncher implements SupportAccessLauncher {
+  const UrlLauncherSupportAccessLauncher();
+
+  @override
+  Future<bool> open(Uri uri) {
+    return launchUrl(uri, mode: LaunchMode.externalApplication);
   }
 }
 
@@ -207,6 +227,7 @@ class _EasySubwayHome extends StatefulWidget {
     required this.facilityReportDraftTargetStore,
     required this.facilityReportLostPhotoRestorer,
     required this.supportAccessInfo,
+    required this.supportAccessLauncher,
   });
 
   final StationSearchRepository repository;
@@ -224,6 +245,7 @@ class _EasySubwayHome extends StatefulWidget {
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
   final FacilityReportLostPhotoRestorer? facilityReportLostPhotoRestorer;
   final SupportAccessInfo supportAccessInfo;
+  final SupportAccessLauncher supportAccessLauncher;
 
   @override
   State<_EasySubwayHome> createState() => _EasySubwayHomeState();
@@ -290,6 +312,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         simpleViewEnabled: preferences.simpleViewEnabled,
         facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
         supportAccessInfo: widget.supportAccessInfo,
+        supportAccessLauncher: widget.supportAccessLauncher,
       ),
     );
   }
@@ -683,6 +706,7 @@ class HomeScreen extends StatelessWidget {
     required this.notificationPermissionProvider,
     required this.locationProvider,
     required this.supportAccessInfo,
+    required this.supportAccessLauncher,
     this.simpleViewEnabled = true,
     this.facilityReportDraftTargetStore,
     String? initialMobilityType,
@@ -701,6 +725,7 @@ class HomeScreen extends StatelessWidget {
   final NotificationPermissionProvider? notificationPermissionProvider;
   final CurrentLocationProvider locationProvider;
   final SupportAccessInfo supportAccessInfo;
+  final SupportAccessLauncher supportAccessLauncher;
   final String initialMobilityType;
   final bool simpleViewEnabled;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
@@ -721,7 +746,10 @@ class HomeScreen extends StatelessWidget {
     void openSupportAccess() {
       Navigator.of(context).push(
         MaterialPageRoute<void>(
-          builder: (_) => SupportAccessScreen(accessInfo: supportAccessInfo),
+          builder: (_) => SupportAccessScreen(
+            accessInfo: supportAccessInfo,
+            launcher: supportAccessLauncher,
+          ),
         ),
       );
     }
@@ -1047,9 +1075,14 @@ class _FavoriteSection {
 }
 
 class SupportAccessScreen extends StatelessWidget {
-  const SupportAccessScreen({required this.accessInfo, super.key});
+  const SupportAccessScreen({
+    required this.accessInfo,
+    required this.launcher,
+    super.key,
+  });
 
   final SupportAccessInfo accessInfo;
+  final SupportAccessLauncher launcher;
 
   @override
   Widget build(BuildContext context) {
@@ -1064,6 +1097,8 @@ class SupportAccessScreen extends StatelessWidget {
               icon: Icons.privacy_tip_outlined,
               title: '개인정보처리방침',
               value: accessInfo.privacyPolicyUrl,
+              uri: _httpsUri(accessInfo.privacyPolicyUrl),
+              launcher: launcher,
             ),
             const SizedBox(height: 12),
             _SupportAccessItem(
@@ -1071,6 +1106,8 @@ class SupportAccessScreen extends StatelessWidget {
               icon: Icons.support_agent,
               title: '고객지원',
               value: accessInfo.supportEmail,
+              uri: _mailtoUri(accessInfo.supportEmail, '쉬운 지하철 고객지원 문의'),
+              launcher: launcher,
             ),
             const SizedBox(height: 12),
             _SupportAccessItem(
@@ -1078,6 +1115,8 @@ class SupportAccessScreen extends StatelessWidget {
               icon: Icons.delete_outline,
               title: '데이터 삭제 요청',
               value: accessInfo.dataDeletionEmail,
+              uri: _mailtoUri(accessInfo.dataDeletionEmail, '쉬운 지하철 데이터 삭제 요청'),
+              launcher: launcher,
             ),
           ],
         ),
@@ -1091,23 +1130,33 @@ class _SupportAccessItem extends StatelessWidget {
     required this.icon,
     required this.title,
     required this.value,
+    required this.uri,
+    required this.launcher,
     super.key,
   });
 
   final IconData icon;
   final String title;
   final String value;
+  final Uri? uri;
+  final SupportAccessLauncher launcher;
 
   @override
   Widget build(BuildContext context) {
-    final displayValue = value.trim().isEmpty ? '앱 출시 전 연결됩니다.' : value;
+    final displayValue = value.trim().isEmpty ? '준비 중입니다.' : value.trim();
+    final targetUri = uri;
     return Semantics(
       button: true,
+      enabled: targetUri != null,
       label: '$title, $displayValue',
-      onTap: () => unawaited(_showDetail(context, displayValue)),
+      onTap: targetUri == null
+          ? null
+          : () => unawaited(_openTarget(context, targetUri)),
       child: ExcludeSemantics(
         child: OutlinedButton.icon(
-          onPressed: () => _showDetail(context, displayValue),
+          onPressed: targetUri == null
+              ? null
+              : () => unawaited(_openTarget(context, targetUri)),
           icon: Icon(icon),
           label: Align(
             alignment: Alignment.centerLeft,
@@ -1135,21 +1184,46 @@ class _SupportAccessItem extends StatelessWidget {
     );
   }
 
-  Future<void> _showDetail(BuildContext context, String displayValue) {
-    return showDialog<void>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(title),
-        content: SelectableText(displayValue),
-        actions: [
-          FilledButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('확인'),
-          ),
-        ],
-      ),
+  Future<void> _openTarget(BuildContext context, Uri uri) async {
+    bool opened = false;
+    try {
+      opened = await launcher.open(uri);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '도움말 외부 연결 실행 중 예외가 발생했습니다.',
+      );
+    }
+
+    if (!context.mounted || opened) {
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('연결할 수 없습니다. 잠시 후 다시 시도해 주세요.')),
     );
   }
+}
+
+Uri? _httpsUri(String value) {
+  final uri = Uri.tryParse(value.trim());
+  if (uri == null || uri.scheme != 'https' || uri.host.isEmpty) {
+    return null;
+  }
+  return uri;
+}
+
+Uri? _mailtoUri(String value, String subject) {
+  final email = value.trim();
+  if (email.isEmpty) {
+    return null;
+  }
+  return Uri(
+    scheme: 'mailto',
+    path: email,
+    queryParameters: {'subject': subject},
+  );
 }
 
 class FeatureTile extends StatelessWidget {

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -557,6 +557,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.32"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   flutter_secure_storage: ^10.3.1
   image_picker: ^1.2.2
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -652,6 +652,133 @@ void main() {
     }
   });
 
+  testWidgets('도움말은 개인정보 링크를 값 복사 화면이 아니라 외부 연결로 처리한다', (tester) async {
+    final launcher = RecordingSupportAccessLauncher();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        supportAccessLauncher: launcher,
+        supportAccessInfo: const SupportAccessInfo(
+          privacyPolicyUrl: 'https://easysubway.example/privacy',
+          supportEmail: 'support@easysubway.example',
+          dataDeletionEmail: 'privacy@easysubway.example',
+        ),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('homeHelpActionButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('privacyPolicyAccessItem')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsNothing);
+    expect(
+      launcher.openedUris.single.toString(),
+      'https://easysubway.example/privacy',
+    );
+  });
+
+  testWidgets('도움말은 고객지원과 데이터 삭제 요청을 메일 앱으로 연결한다', (tester) async {
+    final launcher = RecordingSupportAccessLauncher();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        supportAccessLauncher: launcher,
+        supportAccessInfo: const SupportAccessInfo(
+          privacyPolicyUrl: 'https://easysubway.example/privacy',
+          supportEmail: 'support@easysubway.example',
+          dataDeletionEmail: 'privacy@easysubway.example',
+        ),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('homeHelpActionButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('supportAccessItem')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
+    await tester.pumpAndSettle();
+
+    expect(launcher.openedUris, hasLength(2));
+    expect(launcher.openedUris.first.scheme, 'mailto');
+    expect(launcher.openedUris.first.path, 'support@easysubway.example');
+    expect(launcher.openedUris.last.scheme, 'mailto');
+    expect(launcher.openedUris.last.path, 'privacy@easysubway.example');
+  });
+
+  testWidgets('도움말은 연결값이 비어 있으면 준비 중으로 보여주고 실행하지 않는다', (tester) async {
+    final launcher = RecordingSupportAccessLauncher();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        supportAccessLauncher: launcher,
+        supportAccessInfo: const SupportAccessInfo(
+          privacyPolicyUrl: '',
+          supportEmail: '',
+          dataDeletionEmail: '',
+        ),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('homeHelpActionButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('준비 중입니다.'), findsNWidgets(3));
+
+    await tester.tap(find.byKey(const Key('privacyPolicyAccessItem')));
+    await tester.tap(find.byKey(const Key('supportAccessItem')));
+    await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
+    await tester.pumpAndSettle();
+
+    expect(launcher.openedUris, isEmpty);
+  });
+
+  testWidgets('도움말은 외부 연결 실패를 짧게 안내한다', (tester) async {
+    final launcher = RecordingSupportAccessLauncher(openResult: false);
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        supportAccessLauncher: launcher,
+        supportAccessInfo: const SupportAccessInfo(
+          privacyPolicyUrl: 'https://easysubway.example/privacy',
+          supportEmail: 'support@easysubway.example',
+          dataDeletionEmail: 'privacy@easysubway.example',
+        ),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('homeHelpActionButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('privacyPolicyAccessItem')));
+    await tester.pump();
+
+    expect(find.text('연결할 수 없습니다. 잠시 후 다시 시도해 주세요.'), findsOneWidget);
+  });
+
   testWidgets('인증 저장소가 없으면 홈 즐겨찾기를 노출하지 않는다', (tester) async {
     await tester.pumpWidget(
       EasySubwayApp(
@@ -4927,6 +5054,19 @@ class MemoryFacilityReportDraftTargetStore
       throw StateError('draft target clear failed');
     }
     target = null;
+  }
+}
+
+class RecordingSupportAccessLauncher implements SupportAccessLauncher {
+  RecordingSupportAccessLauncher({this.openResult = true});
+
+  final bool openResult;
+  final openedUris = <Uri>[];
+
+  @override
+  Future<bool> open(Uri uri) async {
+    openedUris.add(uri);
+    return openResult;
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

Closes #226

## 배경

도움말 화면의 개인정보처리방침, 고객지원, 데이터 삭제 요청 항목이 값 표시 다이얼로그로만 동작하고 있었습니다. 출시 전 개인정보/삭제 요청 경로는 사용자가 앱 안에서 바로 접근할 수 있어야 하므로, 별도 복사나 직접 입력 없이 기본 브라우저와 메일 앱으로 이어지게 정리했습니다.

## 변경 사항

- `url_launcher`를 추가해 도움말의 HTTPS URL과 `mailto:` 링크를 외부 앱으로 실행합니다.
- 테스트에서 링크 실행을 검증할 수 있도록 `SupportAccessLauncher` 경계를 분리했습니다.
- 개인정보처리방침은 외부 브라우저, 고객지원/데이터 삭제 요청은 메일 앱 작성 화면으로 연결합니다.
- 연결값이 비어 있으면 `준비 중입니다.`로 표시하고 버튼을 비활성화합니다.
- 외부 실행 실패 시 짧은 안내 문구를 보여줍니다.

## 검증

- `flutter test test/widget_test.dart --plain-name '도움말'`
- `flutter analyze`
- `flutter test`
- `node --test tools/ci/*.test.mjs`
- `git diff --check`
- `flutter build apk --debug --dart-define=EASYSUBWAY_PRIVACY_POLICY_URL=https://easysubway.example/privacy --dart-define=EASYSUBWAY_SUPPORT_EMAIL=support@easysubway.example --dart-define=EASYSUBWAY_DATA_DELETION_EMAIL=privacy@easysubway.example`
- `flutter build ios --simulator --no-codesign --dart-define=EASYSUBWAY_PRIVACY_POLICY_URL=https://easysubway.example/privacy --dart-define=EASYSUBWAY_SUPPORT_EMAIL=support@easysubway.example --dart-define=EASYSUBWAY_DATA_DELETION_EMAIL=privacy@easysubway.example`
- Android 에뮬레이터에서 도움말 화면과 개인정보처리방침 외부 브라우저 전환 확인

## 리스크

- 이메일 앱이 없는 환경에서는 `mailto:` 실행이 실패할 수 있습니다. 이 경우 앱 안에서는 짧은 실패 안내를 보여줍니다.
- 실제 운영 URL과 메일 주소는 빌드 환경값으로 주입되어야 합니다.

## 체크리스트

- [x] README 외 문서 추적 없음
- [x] Android 실제 화면 확인
- [x] iOS simulator build 확인
- [x] CI 통과 후 merge 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 도움말 화면에서 개인정보보호정책 링크 및 지원 메일을 외부 앱으로 직접 열 수 있도록 개선
  * 유효하지 않은 링크는 버튼을 비활성화하여 사용자 경험 향상
  * 연결 실패 시 친화적인 안내 메시지 제공

* **테스트**
  * 도움말 화면의 링크 오픈 및 오류 처리 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->