### PR TITLE
[Feat] 이동 안내 안전 고지 추가

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -14,6 +14,7 @@ const _routeSearchErrorMessage = '경로 정보를 불러오지 못했습니다.
 const _routeFeedbackErrorMessage = '의견을 보내지 못했습니다.';
 const _favoriteRouteErrorMessage = '즐겨찾기 경로를 처리하지 못했습니다.';
 const _favoriteRouteLoadErrorMessage = '즐겨찾기 경로를 불러오지 못했습니다.';
+const _routeSafetyGuidanceNotice = '이동 전 현장 안내와 역무원 안내를 확인해 주세요.';
 
 String _mobilityLabelFor(String mobilityType) {
   for (final option in mobilityProfileOptions) {
@@ -648,6 +649,7 @@ class RouteSearchResult {
         '이동 안내 ${steps.map((step) => '${step.sequence}번 ${step.title}, ${step.burdenLabel}, ${step.description}').join(', ')}',
       );
     }
+    parts.add('안전 안내 $_routeSafetyGuidanceNotice');
     return parts.join(', ');
   }
 }
@@ -1719,8 +1721,13 @@ class _RouteSearchResultSummaryCard extends StatelessWidget {
                       height: 1.3,
                     ),
                   ),
+                  const SizedBox(height: 16),
+                  const _RouteNotice(
+                    title: '안전 안내',
+                    text: _routeSafetyGuidanceNotice,
+                    icon: Icons.info_outline,
+                  ),
                   if (result.blockedReasons.isNotEmpty) ...[
-                    const SizedBox(height: 16),
                     for (final reason in result.blockedReasons)
                       _RouteNotice(
                         title: '안내 불가 이유',

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -13,6 +13,7 @@ import 'mobile_error_reporter.dart';
 const _stationSearchTimeout = Duration(seconds: 8);
 const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
 const _currentLocationDisabledMessage = '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
+const _stationSafetyGuidanceNotice = '이동 전 현장 안내와 역무원 안내를 확인해 주세요.';
 const _favoriteStationTimeout = Duration(seconds: 8);
 const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했습니다.';
 const _favoriteStationStatusErrorMessage = '즐겨찾기를 확인하지 못했습니다.';
@@ -2838,6 +2839,8 @@ class _StationDetailContent extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
       children: [
         _StationDetailHeader(detail: detail),
+        const SizedBox(height: 12),
+        const _StationSafetyGuidanceNotice(),
         if (favoriteController != null) ...[
           const SizedBox(height: 16),
           _StationFavoriteControl(
@@ -3093,6 +3096,23 @@ class _StationDetailHeader extends StatelessWidget {
               text: '마지막 확인 ${detail.lastVerifiedAt}',
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StationSafetyGuidanceNotice extends StatelessWidget {
+  const _StationSafetyGuidanceNotice();
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: '안전 안내, $_stationSafetyGuidanceNotice',
+      child: const ExcludeSemantics(
+        child: _StationDetailInfoRow(
+          icon: Icons.info_outline,
+          text: _stationSafetyGuidanceNotice,
         ),
       ),
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1932,6 +1932,11 @@ void main() {
       expect(find.text('기본 정보만 있음'), findsOneWidget);
       expect(find.text('출처 공식 파일'), findsWidgets);
       expect(find.text('마지막 확인 2026-06-13'), findsOneWidget);
+      expect(find.text('이동 전 현장 안내와 역무원 안내를 확인해 주세요.'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('안전 안내, 이동 전 현장 안내와 역무원 안내를 확인해 주세요.'),
+        findsOneWidget,
+      );
       expect(
         find.bySemanticsLabel(
           '상록수역 상세 정보, 수도권 2호선, 기본 정보만 있음, 출처 공식 파일, 마지막 확인 2026-06-13',
@@ -2504,6 +2509,7 @@ void main() {
       expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
       expect(find.text('약 4분 · 180m · 접근성 확인'), findsOneWidget);
       expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
+      expect(find.text('이동 전 현장 안내와 역무원 안내를 확인해 주세요.'), findsOneWidget);
       expect(
         find.bySemanticsLabel('출발역 선택됨, 상록수, 수도권 2호선, 수도권, 기본 정보만 있음'),
         findsOneWidget,
@@ -2516,7 +2522,8 @@ void main() {
         find.bySemanticsLabel(
           '경로 검색 결과, 이동할 수 있는 경로, 고령자, 상록수에서 사당까지, 수도권 4호선, 이동 점수 92점, 주의 확인, '
           '주의 일부 시설 정보는 확인이 필요합니다., '
-          '이동 안내 1번 상록수역에서 4호선 승강장으로 이동, 약 4분 · 180m · 접근성 확인, 엘리베이터를 이용해 승강장으로 이동합니다.',
+          '이동 안내 1번 상록수역에서 4호선 승강장으로 이동, 약 4분 · 180m · 접근성 확인, 엘리베이터를 이용해 승강장으로 이동합니다., '
+          '안전 안내 이동 전 현장 안내와 역무원 안내를 확인해 주세요.',
         ),
         findsOneWidget,
       );
@@ -3143,10 +3150,12 @@ void main() {
       );
       expect(find.text('안내할 수 있는 경로가 없습니다'), findsOneWidget);
       expect(find.text('휠체어로 이동 가능한 엘리베이터가 없습니다.'), findsOneWidget);
+      expect(find.text('이동 전 현장 안내와 역무원 안내를 확인해 주세요.'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
           '경로 검색 결과, 다른 경로가 필요합니다, 휠체어, 상록수에서 없는역까지, 노선 확인 필요, 이동 점수 0점, '
-          '안내 불가 이유 휠체어로 이동 가능한 엘리베이터가 없습니다.',
+          '안내 불가 이유 휠체어로 이동 가능한 엘리베이터가 없습니다., '
+          '안전 안내 이동 전 현장 안내와 역무원 안내를 확인해 주세요.',
         ),
         findsOneWidget,
       );


### PR DESCRIPTION
## 관련 이슈

close #228

## 작업 배경

- 역 상세와 경로 검색 결과는 이동 가능 여부를 보여 주지만, 실제 현장 상황이 바뀔 수 있다는 안전 확인 안내가 부족했습니다.
- 고령자, 임산부, 장애인 사용자가 안내 결과를 그대로 확정 정보로 오해하지 않도록 짧고 반복 가능한 안전 고지를 추가했습니다.

## 작업 내용

- 역 상세 상단에 현장 안내와 역무원 안내를 확인하라는 안전 고지를 추가했습니다.
- 경로 검색 결과 카드와 스크린리더 설명에 같은 안전 고지를 포함했습니다.
- 역 상세와 경로 검색 위젯 테스트에 안전 고지 노출과 접근성 라벨 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test`: 176개 테스트 통과
  - `flutter analyze`: No issues found
  - `flutter build apk --debug --dart-define=EASYSUBWAY_API_BASE_URL=http://10.0.2.2:8080`: debug APK 빌드 성공
  - `flutter build ios --simulator --no-codesign --dart-define=EASYSUBWAY_API_BASE_URL=https://api.easysubway.example`: iOS simulator 앱 빌드 성공
  - `node --test tools/ci/*.test.mjs`: 39개 테스트 통과
  - `git diff --check`: 공백 오류 없음
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적
- Android 에뮬레이터에서 상록수역 상세 화면과 상록수-사당 경로 검색 결과를 직접 열어 안전 고지 접근성 라벨을 확인했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 역 상세 안전 고지가 기존 즐겨찾기/시설 정보 흐름을 밀어내지 않는지 확인해 주세요.
  - 경로 검색 결과의 스크린리더 문장이 안내 불가 이유와 안전 고지를 함께 읽을 때 자연스러운지 확인해 주세요.

## 리스크

- 새 API 호출이나 저장 데이터 변경은 없습니다.
- 경로 결과 카드에 안내 문구가 한 줄 추가되어 작은 화면에서는 결과 하단 스크롤 길이가 조금 늘어납니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
