### PR TITLE
[Style] 역 검색 결과 목록 밀도 개선

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2339,10 +2339,12 @@ class _StationSearchResultTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final stationName = _stationResultDisplayName(result.nameKo);
+    final semanticLabel = _stationResultSemanticLabel(result);
 
     return MergeSemantics(
       child: Semantics(
-        label: result.semanticLabel,
+        label: semanticLabel,
         button: true,
         onTap: onTap,
         child: ExcludeSemantics(
@@ -2383,7 +2385,7 @@ class _StationSearchResultTile extends StatelessWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              result.nameKo,
+                              stationName,
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                               style: textTheme.headlineSmall?.copyWith(
@@ -2424,6 +2426,24 @@ class _StationSearchResultTile extends StatelessWidget {
       ),
     );
   }
+}
+
+String _stationResultDisplayName(String name) {
+  final trimmedName = name.trim();
+  // 백엔드 역 이름은 접미사 없이 내려올 수 있어 검색 결과 화면에서만 보정한다.
+  if (trimmedName.endsWith('역')) {
+    return trimmedName;
+  }
+  return '$trimmedName역';
+}
+
+String _stationResultSemanticLabel(StationSearchResult result) {
+  final stationName = _stationResultDisplayName(result.nameKo);
+  final distance = result.distanceLabel;
+  if (distance.isEmpty) {
+    return '$stationName, ${result.lineLabel}, ${result.region}, ${result.dataQualityLabel}';
+  }
+  return '$stationName, $distance, ${result.lineLabel}, ${result.region}, ${result.dataQualityLabel}';
 }
 
 class FavoriteStationListScreen extends StatefulWidget {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1272,15 +1272,15 @@ void main() {
       expect(find.text('기본 정보만 있음'), findsNothing);
       expect(find.bySemanticsLabel('검색 결과 1개'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
+        find.bySemanticsLabel('상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
         findsOneWidget,
       );
       expect(
         tester.getSemantics(
-          find.bySemanticsLabel('상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
+          find.bySemanticsLabel('상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
         ),
         isSemantics(
-          label: '상록수, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음',
+          label: '상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음',
           isButton: true,
           hasTapAction: true,
         ),
@@ -1627,10 +1627,10 @@ void main() {
       expect(locationProvider.requestCount, 1);
       expect(repository.requestedNearbyLocations.single.latitude, 37.3028);
       expect(repository.requestedNearbyLocations.single.longitude, 126.8665);
-      expect(find.text('상록수'), findsOneWidget);
+      expect(find.text('상록수역'), findsOneWidget);
       expect(find.text('230m 거리 · 수도권 2호선'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('상록수, 230m 거리, 수도권 2호선, 수도권, 기본 정보만 있음'),
+        find.bySemanticsLabel('상록수역, 230m 거리, 수도권 2호선, 수도권, 기본 정보만 있음'),
         findsOneWidget,
       );
 
@@ -1681,7 +1681,7 @@ void main() {
     expect(locationProvider.requestCount, 1);
     expect(repository.requestedNearbyLocations, hasLength(1));
     expect(find.text('현재 위치 사용'), findsNothing);
-    expect(find.text('상록수'), findsOneWidget);
+    expect(find.text('상록수역'), findsOneWidget);
   });
 
   testWidgets('역 검색은 주변 역 확인 중 중복 탭을 무시한다', (tester) async {
@@ -1769,7 +1769,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(repository.requestedNearbyLocations, hasLength(1));
-    expect(find.text('상록수'), findsOneWidget);
+    expect(find.text('상록수역'), findsOneWidget);
     expect(find.text('230m 거리 · 수도권 2호선'), findsOneWidget);
   });
 
@@ -2257,7 +2257,12 @@ void main() {
     await tester.pump(const Duration(milliseconds: 350));
     await tester.pump();
 
-    expect(find.text('상록수역'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel(
+        '상록수역 상세 정보, 수도권 2호선, 기본 정보만 있음, 출처 공식 파일, 마지막 확인 2026-06-13',
+      ),
+      findsOneWidget,
+    );
     expect(find.widgetWithText(OutlinedButton, '확인 중'), findsOneWidget);
 
     favoriteRepository.complete([


### PR DESCRIPTION
## 관련 이슈

close #230

## 작업 배경

- 역 검색 결과 카드가 실제 선택에 필요한 정보보다 큰 영역을 차지하면 한 화면에서 확인 가능한 역 수가 줄어듭니다.
- 교통약자 사용자는 역 이름과 노선만 빠르게 보고 선택하는 흐름이 중요하므로, 결과 카드의 시각 정보는 줄이고 스크린리더 문맥은 유지합니다.

## 작업 내용

- 역 검색 결과와 주변 역 결과에서 `상록수`처럼 접미사가 없는 역 이름을 화면 표시용으로 `상록수역` 형태로 보정했습니다.
- 검색 결과 카드의 접근성 라벨도 화면 표시명과 같은 역 이름을 사용하도록 맞췄습니다.
- 화면에는 역 이름과 노선만 보이게 유지하고, 지역과 데이터 품질 정보는 스크린리더 문맥에만 남겼습니다.
- 역 검색 및 주변 역 위젯 테스트의 한국어 display name 기대값을 새 화면 표시 기준에 맞췄습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/station_search.dart apps/mobile/test/widget_test.dart` 성공
  - `flutter test` 성공, 176개 테스트 통과
  - `flutter analyze` 성공, 이슈 없음
  - `flutter build apk --debug --target-platform android-arm64 --dart-define=EASYSUBWAY_API_BASE_URL=http://10.0.2.2:8080` 성공
  - `flutter build ios --simulator --no-codesign --dart-define=EASYSUBWAY_API_BASE_URL=https://api.easysubway.example` 성공
  - `node --test tools/ci/*.test.mjs` 성공, 39개 테스트 통과
  - `git diff --check` 성공
  - `git ls-files '*.md'` 결과가 `README.md`, `.github/pull_request_template.md`만 포함함
  - Android 에뮬레이터에서 `sang` 검색 후 `상록수역`, `수도권 4호선`만 노출되는 결과 카드를 확인함

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `StationSearchResult.nameKo` 원본 데이터는 그대로 두고, 검색 결과 타일에서만 화면 표시명을 보정합니다.
  - 지역과 데이터 품질 문구는 결과 카드에서 숨기되, 스크린리더 라벨에는 남깁니다.

## 리스크

- 검색 결과 화면에서는 역 접미사가 붙어 보이지만, 상세 화면과 즐겨찾기 원본 데이터 표시 정책은 그대로 유지됩니다.
- 검색 API 응답에 이미 `역` 접미사가 포함된 경우에는 중복으로 붙이지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
