### PR TITLE
[Style] 홈 화면 주요 기능 위계 개선

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -776,18 +776,27 @@ class HomeScreen extends StatelessWidget {
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
           children: [
+            Text(
+              '안녕하세요',
+              style: textTheme.titleLarge?.copyWith(
+                color: const Color(0xFF466467),
+                fontWeight: FontWeight.w800,
+                height: 1.25,
+              ),
+            ),
+            const SizedBox(height: 6),
             Semantics(
               header: true,
               child: Text(
                 '어디로 가시나요?',
-                style: textTheme.headlineSmall?.copyWith(
+                style: textTheme.headlineMedium?.copyWith(
                   color: const Color(0xFF102A2C),
                   fontWeight: FontWeight.w800,
                   height: 1.25,
                 ),
               ),
             ),
-            const SizedBox(height: 20),
+            const SizedBox(height: 22),
             _HomePrimaryActionButton(
               key: const Key('stationSearchButton'),
               onPressed: () {
@@ -827,18 +836,21 @@ class HomeScreen extends StatelessWidget {
               icon: const Icon(Icons.route),
               label: '길찾기',
             ),
-            const SizedBox(height: 20),
+            const SizedBox(height: 22),
+            const Divider(height: 1),
+            const SizedBox(height: 14),
             LayoutBuilder(
               builder: (context, constraints) {
                 const spacing = 10.0;
                 final itemWidth = (constraints.maxWidth - spacing) / 2;
                 return Wrap(
+                  key: const Key('homeSecondaryActionsGroup'),
                   spacing: spacing,
                   runSpacing: spacing,
                   children: [
                     SizedBox(
                       width: itemWidth,
-                      height: 64,
+                      height: 56,
                       child: _HomeSecondaryActionButton(
                         key: const Key('mobilityProfileButton'),
                         onPressed: () {
@@ -855,7 +867,7 @@ class HomeScreen extends StatelessWidget {
                     if (hasFavorites)
                       SizedBox(
                         width: itemWidth,
-                        height: 64,
+                        height: 56,
                         child: _HomeSecondaryActionButton(
                           key: const Key('favoritesButton'),
                           onPressed: () {
@@ -882,7 +894,7 @@ class HomeScreen extends StatelessWidget {
                       ),
                     SizedBox(
                       width: itemWidth,
-                      height: 64,
+                      height: 56,
                       child: _HomeSecondaryActionButton(
                         key: const Key('myReportsButton'),
                         onPressed: () {
@@ -901,7 +913,7 @@ class HomeScreen extends StatelessWidget {
                     if (notificationRepository != null)
                       SizedBox(
                         width: itemWidth,
-                        height: 64,
+                        height: 56,
                         child: _HomeSecondaryActionButton(
                           key: const Key('notificationSettingsButton'),
                           onPressed: () {
@@ -947,11 +959,13 @@ class _HomePrimaryActionButton extends StatelessWidget {
     return FilledButton.icon(
       onPressed: onPressed,
       style: FilledButton.styleFrom(
-        minimumSize: const Size.fromHeight(82),
-        textStyle: const TextStyle(fontSize: 22, fontWeight: FontWeight.w800),
+        alignment: Alignment.centerLeft,
+        minimumSize: const Size.fromHeight(92),
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        textStyle: const TextStyle(fontSize: 24, fontWeight: FontWeight.w800),
       ),
-      icon: icon,
-      label: Text(label),
+      icon: IconTheme.merge(data: const IconThemeData(size: 30), child: icon),
+      label: Text(label, maxLines: 1),
     );
   }
 }
@@ -978,10 +992,10 @@ class _HomeSecondaryActionButton extends StatelessWidget {
         backgroundColor: Colors.white,
         foregroundColor: const Color(0xFF006D77),
         side: BorderSide(color: colorScheme.outlineVariant),
-        textStyle: const TextStyle(fontSize: 17, fontWeight: FontWeight.w700),
-        padding: const EdgeInsets.symmetric(horizontal: 10),
+        textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+        padding: const EdgeInsets.symmetric(horizontal: 8),
       ),
-      icon: icon,
+      icon: IconTheme.merge(data: const IconThemeData(size: 22), child: icon),
       label: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
     );
   }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -515,7 +515,12 @@ void main() {
         ),
       );
 
+      expect(find.text('안녕하세요'), findsOneWidget);
       expect(find.text('어디로 가시나요?'), findsOneWidget);
+      expect(
+        find.byKey(const Key('homeSecondaryActionsGroup')),
+        findsOneWidget,
+      );
       expect(find.widgetWithText(FilledButton, '역 검색'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsOneWidget);
@@ -550,8 +555,11 @@ void main() {
         find.byKey(const Key('notificationSettingsButton')),
       );
 
-      expect(stationButtonSize.height, greaterThanOrEqualTo(76));
-      expect(routeButtonSize.height, greaterThanOrEqualTo(76));
+      expect(stationButtonSize.height, greaterThanOrEqualTo(88));
+      expect(routeButtonSize.height, greaterThanOrEqualTo(88));
+      expect(profileButtonSize.height, lessThanOrEqualTo(58));
+      expect(myReportsButtonSize.height, lessThanOrEqualTo(58));
+      expect(notificationButtonSize.height, lessThanOrEqualTo(58));
       expect(profileButtonSize.height, lessThan(stationButtonSize.height));
       expect(myReportsButtonSize.height, lessThan(stationButtonSize.height));
       expect(notificationButtonSize.height, lessThan(stationButtonSize.height));


### PR DESCRIPTION
## 관련 이슈

close #234

## 작업 배경

- 홈 화면은 사용자가 앱을 열자마자 `역 검색`과 `길찾기`를 바로 선택할 수 있어야 합니다.
- 기존 홈은 이미 즐겨찾기 진입점 통합은 되어 있었지만, 보조 메뉴와 핵심 기능의 시각적 차이가 아직 약했습니다.
- 고령자, 임산부, 장애인 사용자가 처음 보더라도 어디를 눌러야 하는지 바로 알 수 있도록 첫 화면의 행동 우선순위를 더 분명히 했습니다.

## 작업 내용

- 홈 상단에 짧은 인사와 목적 질문을 분리해 첫 화면의 맥락을 정리했습니다.
- `역 검색`, `길찾기` 버튼을 더 크고 왼쪽 정렬된 주요 행동으로 조정했습니다.
- `이동 조건`, `즐겨찾기`, `내 신고`, `알림 설정`은 구분선 아래 낮은 보조 카드로 묶었습니다.
- 홈 화면 위젯 테스트가 주요 행동 높이와 보조 행동 그룹을 직접 검증하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --plain-name "홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다"` 실패 확인 후 통과
  - `dart format apps/mobile/lib/main.dart apps/mobile/test/widget_test.dart` 성공
  - `flutter test test/widget_test.dart` 성공, 80개 테스트 통과
  - `flutter analyze` 성공
  - `git diff --check` 성공
  - `git ls-files '*.md'` 결과가 `README.md`, `.github/pull_request_template.md`만 포함함
  - `flutter build apk --debug --dart-define=EASYSUBWAY_API_BASE_URL=https://api.easysubway.example` 성공
  - Android 에뮬레이터 `maum_on_api36`에서 홈 화면 확인, 스크린샷 저장: `/tmp/easysubway-home-ux-before-nav.png`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 새 설명문을 길게 추가하지 않고, 버튼 크기와 그룹 위계 중심으로 홈 화면을 단순화했습니다.
  - 즐겨찾기는 계속 하나의 홈 진입점으로 유지하고 내부 탭에서 경로/역/시설을 나눕니다.

## 리스크

- 홈 첫 화면의 버튼 높이가 달라졌으므로 작은 화면과 큰 글자 설정에서 실제 표시 균형을 계속 확인해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI code review 대체 실행이 필요 없음을 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
