### PR TITLE
[Refactor] 환승 경로 탐색 구조 분리

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -31,11 +31,13 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -271,6 +273,13 @@ public class RouteSearchService implements RouteSearchUseCase {
 		String destinationStationId,
 		RouteProfileWeight profileWeight
 	) {
+		Map<String, Boolean> stairOnlyAccessCache = new HashMap<>();
+		Map<String, Boolean> lowAccessibilityDataCache = new HashMap<>();
+		Predicate<String> stairOnlyAccess = stationId ->
+			stairOnlyAccessCache.computeIfAbsent(stationId, this::hasStairOnlyAccess);
+		Predicate<String> lowAccessibilityData = stationId ->
+			lowAccessibilityDataCache.computeIfAbsent(stationId, this::hasLowAccessibilityData);
+
 		return new TransferRouteGraph(
 			loadTransitMasterPort.loadLines(),
 			loadTransitMasterPort.loadStations(),
@@ -279,8 +288,8 @@ public class RouteSearchService implements RouteSearchUseCase {
 			originStationId,
 			destinationStationId,
 			profileWeight,
-			this::hasStairOnlyAccess,
-			this::hasLowAccessibilityData
+			stairOnlyAccess,
+			lowAccessibilityData
 		);
 	}
 

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -271,109 +271,17 @@ public class RouteSearchService implements RouteSearchUseCase {
 		String destinationStationId,
 		RouteProfileWeight profileWeight
 	) {
-		Map<String, SubwayLine> activeLinesById = loadTransitMasterPort.loadLines()
-			.stream()
-			.filter(SubwayLine::active)
-			.collect(Collectors.toMap(SubwayLine::id, Function.identity()));
-		Map<String, Station> activeStationsById = loadTransitMasterPort.loadStations()
-			.stream()
-			.filter(Station::active)
-			.collect(Collectors.toMap(Station::id, Function.identity()));
-		List<StationLine> activeStationLines = loadTransitMasterPort.loadStationLines()
-			.stream()
-			.filter(stationLine -> activeLinesById.containsKey(stationLine.lineId()))
-			.filter(stationLine -> activeStationsById.containsKey(stationLine.stationId()))
-			.toList();
-		List<StationLine> originLines = stationLines(activeStationLines, originStationId);
-		List<StationLine> destinationLines = stationLines(activeStationLines, destinationStationId);
-		Map<String, List<StationLine>> stationLinesByStationId = activeStationLines.stream()
-			.collect(Collectors.groupingBy(StationLine::stationId));
-
-		// 한 번 환승 기준선은 두 노선이 만나는 활성 역을 찾아 총 이동 역 수가 가장 짧은 후보를 고른다.
-		List<TransferRoute> candidates = new ArrayList<>();
-		for (StationLine originLine : originLines) {
-			for (StationLine destinationLine : destinationLines) {
-				if (originLine.lineId().equals(destinationLine.lineId())) {
-					continue;
-				}
-				stationLinesByStationId.forEach((stationId, linesAtStation) -> addTransferCandidate(
-					candidates,
-					activeLinesById,
-					activeStationsById,
-					originStationId,
-					destinationStationId,
-					originLine,
-					destinationLine,
-					stationId,
-					linesAtStation
-				));
-			}
-		}
-
-		return candidates.stream()
-			.min(Comparator.comparingInt((TransferRoute route) -> transferAccessibilityRank(route, profileWeight))
-				.thenComparingInt(route -> transferCandidateCost(route, profileWeight))
-				.thenComparing(route -> route.transferStation().nameKo()));
-	}
-
-	private int transferAccessibilityRank(TransferRoute route, RouteProfileWeight profileWeight) {
-		if (profileWeight.blocksStairOnlyAccess() && hasStairOnlyAccess(route.transferStation().id())) {
-			return 1;
-		}
-		return 0;
-	}
-
-	private int transferCandidateCost(TransferRoute route, RouteProfileWeight profileWeight) {
-		String transferStationId = route.transferStation().id();
-		int stairOnlyCost = hasStairOnlyAccess(transferStationId)
-			? profileWeight.stairOnlyAccessPenalty()
-			: 0;
-		int lowDataCost = hasLowAccessibilityData(transferStationId)
-			? profileWeight.lowDataConfidencePenalty()
-			: 0;
-		return route.stopCount() * 3 + profileWeight.transferPenalty() + stairOnlyCost + lowDataCost;
-	}
-
-	private void addTransferCandidate(
-		List<TransferRoute> candidates,
-		Map<String, SubwayLine> activeLinesById,
-		Map<String, Station> activeStationsById,
-		String originStationId,
-		String destinationStationId,
-		StationLine originLine,
-		StationLine destinationLine,
-		String stationId,
-		List<StationLine> linesAtStation
-	) {
-		if (stationId.equals(originStationId) || stationId.equals(destinationStationId)) {
-			return;
-		}
-		Optional<StationLine> transferOriginLine = stationLineFor(linesAtStation, originLine.lineId());
-		Optional<StationLine> transferDestinationLine = stationLineFor(linesAtStation, destinationLine.lineId());
-		if (transferOriginLine.isEmpty() || transferDestinationLine.isEmpty()) {
-			return;
-		}
-		candidates.add(new TransferRoute(
-			activeLinesById.get(originLine.lineId()),
-			originLine,
-			transferOriginLine.get(),
-			activeLinesById.get(destinationLine.lineId()),
-			transferDestinationLine.get(),
-			destinationLine,
-			activeStationsById.get(stationId)
-		));
-	}
-
-	private List<StationLine> stationLines(List<StationLine> stationLines, String stationId) {
-		return stationLines.stream()
-			.filter(stationLine -> stationLine.stationId().equals(stationId))
-			.toList();
-	}
-
-	private Optional<StationLine> stationLineFor(List<StationLine> stationLines, String lineId) {
-		return stationLines.stream()
-			.filter(stationLine -> stationLine.lineId().equals(lineId))
-			.findFirst();
+		return new TransferRouteGraph(
+			loadTransitMasterPort.loadLines(),
+			loadTransitMasterPort.loadStations(),
+			loadTransitMasterPort.loadStationLines()
+		).findBestOneTransferRoute(
+			originStationId,
+			destinationStationId,
+			profileWeight,
+			this::hasStairOnlyAccess,
+			this::hasLowAccessibilityData
+		);
 	}
 
 	private List<RouteWarning> routeWarnings(List<String> stationIds, boolean stairOnlyAccess) {
@@ -662,29 +570,6 @@ public class RouteSearchService implements RouteSearchUseCase {
 
 		int stopCount() {
 			return Math.abs(origin.sequence() - destination.sequence());
-		}
-	}
-
-	private record TransferRoute(
-		SubwayLine firstLine,
-		StationLine origin,
-		StationLine transferOriginLine,
-		SubwayLine secondLine,
-		StationLine transferDestinationLine,
-		StationLine destination,
-		Station transferStation
-	) {
-
-		int firstSegmentStopCount() {
-			return Math.abs(origin.sequence() - transferOriginLine.sequence());
-		}
-
-		int secondSegmentStopCount() {
-			return Math.abs(transferDestinationLine.sequence() - destination.sequence());
-		}
-
-		int stopCount() {
-			return firstSegmentStopCount() + secondSegmentStopCount();
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/route/application/service/TransferRoute.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/TransferRoute.java
@@ -1,0 +1,28 @@
+package com.easysubway.route.application.service;
+
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.SubwayLine;
+
+record TransferRoute(
+	SubwayLine firstLine,
+	StationLine origin,
+	StationLine transferOriginLine,
+	SubwayLine secondLine,
+	StationLine transferDestinationLine,
+	StationLine destination,
+	Station transferStation
+) {
+
+	int firstSegmentStopCount() {
+		return Math.abs(origin.sequence() - transferOriginLine.sequence());
+	}
+
+	int secondSegmentStopCount() {
+		return Math.abs(transferDestinationLine.sequence() - destination.sequence());
+	}
+
+	int stopCount() {
+		return firstSegmentStopCount() + secondSegmentStopCount();
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/application/service/TransferRouteGraph.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/TransferRouteGraph.java
@@ -1,0 +1,152 @@
+package com.easysubway.route.application.service;
+
+import com.easysubway.route.domain.RouteProfileWeight;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.SubwayLine;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+class TransferRouteGraph {
+
+	private final Map<String, SubwayLine> activeLinesById;
+	private final Map<String, Station> activeStationsById;
+	private final List<StationLine> activeStationLines;
+	private final Map<String, List<StationLine>> stationLinesByStationId;
+
+	TransferRouteGraph(
+		List<SubwayLine> lines,
+		List<Station> stations,
+		List<StationLine> stationLines
+	) {
+		this.activeLinesById = lines.stream()
+			.filter(SubwayLine::active)
+			.collect(Collectors.toMap(SubwayLine::id, Function.identity()));
+		this.activeStationsById = stations.stream()
+			.filter(Station::active)
+			.collect(Collectors.toMap(Station::id, Function.identity()));
+		this.activeStationLines = stationLines.stream()
+			.filter(stationLine -> activeLinesById.containsKey(stationLine.lineId()))
+			.filter(stationLine -> activeStationsById.containsKey(stationLine.stationId()))
+			.toList();
+		this.stationLinesByStationId = activeStationLines.stream()
+			.collect(Collectors.groupingBy(StationLine::stationId));
+	}
+
+	Optional<TransferRoute> findBestOneTransferRoute(
+		String originStationId,
+		String destinationStationId,
+		RouteProfileWeight profileWeight,
+		Predicate<String> stairOnlyAccess,
+		Predicate<String> lowAccessibilityData
+	) {
+		List<StationLine> originLines = stationLines(originStationId);
+		List<StationLine> destinationLines = stationLines(destinationStationId);
+
+		List<TransferRoute> candidates = new ArrayList<>();
+		for (StationLine originLine : originLines) {
+			for (StationLine destinationLine : destinationLines) {
+				if (!originLine.lineId().equals(destinationLine.lineId())) {
+					addTransferCandidates(candidates, originStationId, destinationStationId, originLine, destinationLine);
+				}
+			}
+		}
+
+		return candidates.stream()
+			.min(Comparator.comparingInt((TransferRoute route) -> transferAccessibilityRank(route, profileWeight, stairOnlyAccess))
+				.thenComparingInt(route -> transferCandidateCost(route, profileWeight, stairOnlyAccess, lowAccessibilityData))
+				.thenComparing(route -> route.transferStation().nameKo()));
+	}
+
+	private void addTransferCandidates(
+		List<TransferRoute> candidates,
+		String originStationId,
+		String destinationStationId,
+		StationLine originLine,
+		StationLine destinationLine
+	) {
+		// 그래프의 한 간선은 출발 노선과 도착 노선이 같은 활성 역에서 만나는 환승 연결을 뜻한다.
+		stationLinesByStationId.forEach((stationId, linesAtStation) -> addTransferCandidate(
+			candidates,
+			originStationId,
+			destinationStationId,
+			originLine,
+			destinationLine,
+			stationId,
+			linesAtStation
+		));
+	}
+
+	private void addTransferCandidate(
+		List<TransferRoute> candidates,
+		String originStationId,
+		String destinationStationId,
+		StationLine originLine,
+		StationLine destinationLine,
+		String stationId,
+		List<StationLine> linesAtStation
+	) {
+		if (stationId.equals(originStationId) || stationId.equals(destinationStationId)) {
+			return;
+		}
+		Optional<StationLine> transferOriginLine = stationLineFor(linesAtStation, originLine.lineId());
+		Optional<StationLine> transferDestinationLine = stationLineFor(linesAtStation, destinationLine.lineId());
+		if (transferOriginLine.isEmpty() || transferDestinationLine.isEmpty()) {
+			return;
+		}
+		candidates.add(new TransferRoute(
+			activeLinesById.get(originLine.lineId()),
+			originLine,
+			transferOriginLine.get(),
+			activeLinesById.get(destinationLine.lineId()),
+			transferDestinationLine.get(),
+			destinationLine,
+			activeStationsById.get(stationId)
+		));
+	}
+
+	private int transferAccessibilityRank(
+		TransferRoute route,
+		RouteProfileWeight profileWeight,
+		Predicate<String> stairOnlyAccess
+	) {
+		if (profileWeight.blocksStairOnlyAccess() && stairOnlyAccess.test(route.transferStation().id())) {
+			return 1;
+		}
+		return 0;
+	}
+
+	private int transferCandidateCost(
+		TransferRoute route,
+		RouteProfileWeight profileWeight,
+		Predicate<String> stairOnlyAccess,
+		Predicate<String> lowAccessibilityData
+	) {
+		String transferStationId = route.transferStation().id();
+		int stairOnlyCost = stairOnlyAccess.test(transferStationId)
+			? profileWeight.stairOnlyAccessPenalty()
+			: 0;
+		int lowDataCost = lowAccessibilityData.test(transferStationId)
+			? profileWeight.lowDataConfidencePenalty()
+			: 0;
+		return route.stopCount() * 3 + profileWeight.transferPenalty() + stairOnlyCost + lowDataCost;
+	}
+
+	private List<StationLine> stationLines(String stationId) {
+		return activeStationLines.stream()
+			.filter(stationLine -> stationLine.stationId().equals(stationId))
+			.toList();
+	}
+
+	private Optional<StationLine> stationLineFor(List<StationLine> stationLines, String lineId) {
+		return stationLines.stream()
+			.filter(stationLine -> stationLine.lineId().equals(lineId))
+			.findFirst();
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/application/service/TransferRouteGraphTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/TransferRouteGraphTest.java
@@ -1,0 +1,107 @@
+package com.easysubway.route.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.domain.RouteProfileWeight;
+import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.SubwayLine;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("환승 경로 그래프")
+class TransferRouteGraphTest {
+
+	@Test
+	@DisplayName("공통 환승역을 찾아 한 번 환승 후보를 만든다")
+	void findBestOneTransferRouteBuildsCandidateFromSharedTransferStation() {
+		var graph = new TransferRouteGraph(
+			List.of(line("line-a", "A 노선"), line("line-b", "B 노선")),
+			List.of(station("origin", "출발"), station("transfer", "환승"), station("destination", "도착")),
+			List.of(
+				stationLine("origin", "line-a", 1),
+				stationLine("transfer", "line-a", 3),
+				stationLine("transfer", "line-b", 1),
+				stationLine("destination", "line-b", 4)
+			)
+		);
+
+		var route = graph.findBestOneTransferRoute(
+			"origin",
+			"destination",
+			RouteProfileWeight.from(MobilityType.SENIOR),
+			stationId -> false,
+			stationId -> false
+		);
+
+		assertThat(route).isPresent();
+		assertThat(route.get().transferStation().id()).isEqualTo("transfer");
+		assertThat(route.get().firstSegmentStopCount()).isEqualTo(2);
+		assertThat(route.get().secondSegmentStopCount()).isEqualTo(3);
+		assertThat(route.get().stopCount()).isEqualTo(5);
+		assertThat(route.get().firstLine().name()).isEqualTo("A 노선");
+		assertThat(route.get().secondLine().name()).isEqualTo("B 노선");
+	}
+
+	@Test
+	@DisplayName("휠체어 이동은 이동 거리가 길어도 계단 없는 환승역을 먼저 고른다")
+	void findBestOneTransferRoutePrefersStepFreeTransferForWheelchair() {
+		var graph = new TransferRouteGraph(
+			List.of(line("line-a", "A 노선"), line("line-b", "B 노선")),
+			List.of(
+				station("origin", "출발"),
+				station("stair-transfer", "계단환승"),
+				station("step-free-transfer", "무단차환승"),
+				station("destination", "도착")
+			),
+			List.of(
+				stationLine("origin", "line-a", 1),
+				stationLine("stair-transfer", "line-a", 2),
+				stationLine("step-free-transfer", "line-a", 30),
+				stationLine("stair-transfer", "line-b", 1),
+				stationLine("step-free-transfer", "line-b", 30),
+				stationLine("destination", "line-b", 3)
+			)
+		);
+
+		var route = graph.findBestOneTransferRoute(
+			"origin",
+			"destination",
+			RouteProfileWeight.from(MobilityType.WHEELCHAIR),
+			stationId -> stationId.equals("stair-transfer"),
+			stationId -> false
+		);
+
+		assertThat(route).isPresent();
+		assertThat(route.get().transferStation().id()).isEqualTo("step-free-transfer");
+	}
+
+	private SubwayLine line(String id, String name) {
+		return new SubwayLine(id, "operator", name, "#111111", "수도권", id, true);
+	}
+
+	private Station station(String id, String nameKo) {
+		return new Station(
+			id,
+			nameKo,
+			id,
+			"수도권",
+			BigDecimal.ZERO,
+			BigDecimal.ZERO,
+			DataQualityLevel.LEVEL_3,
+			DataSourceType.OFFICIAL_FILE,
+			LocalDate.of(2026, 6, 16),
+			true
+		);
+	}
+
+	private StationLine stationLine(String stationId, String lineId, int sequence) {
+		return new StationLine(stationId, lineId, stationId + "-" + lineId, sequence, "상행 / 하행");
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/application/service/TransferRouteGraphTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/TransferRouteGraphTest.java
@@ -82,6 +82,39 @@ class TransferRouteGraphTest {
 		assertThat(route.get().transferStation().id()).isEqualTo("step-free-transfer");
 	}
 
+	@Test
+	@DisplayName("접근성 데이터 신뢰도가 낮은 환승역은 비용 패널티를 반영한다")
+	void findBestOneTransferRouteAppliesLowAccessibilityPenalty() {
+		var graph = new TransferRouteGraph(
+			List.of(line("line-a", "A 노선"), line("line-b", "B 노선")),
+			List.of(
+				station("origin", "출발"),
+				station("low-data-transfer", "저신뢰환승"),
+				station("high-data-transfer", "고신뢰환승"),
+				station("destination", "도착")
+			),
+			List.of(
+				stationLine("origin", "line-a", 1),
+				stationLine("low-data-transfer", "line-a", 2),
+				stationLine("low-data-transfer", "line-b", 4),
+				stationLine("high-data-transfer", "line-a", 3),
+				stationLine("high-data-transfer", "line-b", 3),
+				stationLine("destination", "line-b", 5)
+			)
+		);
+
+		var route = graph.findBestOneTransferRoute(
+			"origin",
+			"destination",
+			RouteProfileWeight.from(MobilityType.SENIOR),
+			stationId -> false,
+			stationId -> stationId.equals("low-data-transfer")
+		);
+
+		assertThat(route).isPresent();
+		assertThat(route.get().transferStation().id()).isEqualTo("high-data-transfer");
+	}
+
 	private SubwayLine line(String id, String name) {
 		return new SubwayLine(id, "operator", name, "#111111", "수도권", id, true);
 	}


### PR DESCRIPTION
## 관련 이슈

close #238

## 작업 배경

- 경로 검색은 직접 경로가 없을 때 한 번 환승 후보를 찾고 접근성 조건에 맞는 환승역을 선택합니다.
- 기존 구현은 환승 후보 생성과 정렬 기준이 `RouteSearchService` 내부에 모여 있어 이후 환승 동선 그래프, 다중 환승, 이동 조건별 가중치 확장 시 변경 범위가 커집니다.
- 이번 작업은 API 응답을 유지하면서 환승 후보 탐색 책임을 별도 컴포넌트로 분리해 확장 기준선을 마련합니다.

## 작업 내용

- `TransferRouteGraph`를 추가해 활성 노선, 활성 역, 역-노선 연결을 기반으로 한 번 환승 후보를 생성하게 했습니다.
- `TransferRoute` 후보 모델을 서비스 내부 record에서 별도 package-private record로 분리했습니다.
- `RouteSearchService`는 직접 경로 탐색과 결과 생성 책임을 유지하고, 환승 후보 선택은 `TransferRouteGraph`에 위임하도록 정리했습니다.
- 공통 환승역 후보 생성과 휠체어 이동 유형의 무단차 환승 우선 기준을 새 단위 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "*TransferRouteGraphTest"` 컴파일 실패 확인 후 성공
  - `./gradlew test --tests "*RouteSearchServiceTest"` 성공
  - `./gradlew test --tests "*TransferRouteGraphTest" --tests "*RouteSearchServiceTest"` 성공
  - `git diff --check` 성공
  - `./gradlew test` 성공
  - `node --test tools/ci/*.test.mjs` 성공, 40개 테스트 통과
  - `git ls-files '*.md'` 결과가 `README.md`, `.github/pull_request_template.md`만 포함함
  - CodeRabbit 지적 반영 후 `./gradlew test --tests "*TransferRouteGraphTest" --tests "*RouteSearchServiceTest"` 성공
  - CodeRabbit 지적 반영 후 `git diff --check` 성공
  - CodeRabbit 지적 반영 후 `./gradlew test` 성공
  - CodeRabbit 지적 반영 후 `node --test tools/ci/*.test.mjs` 성공, 40개 테스트 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - API 응답 record와 컨트롤러 계약은 바꾸지 않고, 환승 후보 생성 책임만 분리했습니다.
  - 접근성 판단은 기존 `RouteSearchService`의 `hasStairOnlyAccess`, `hasLowAccessibilityData` 기준을 predicate로 넘겨 기존 점수 산정 기준을 유지했습니다.
  - CodeRabbit nitpick 2건은 같은 PR의 후속 커밋 `1c21ff8`에서 반영했고, thread는 CodeRabbit 확인 후 resolved 상태입니다.

## 리스크

- 기능 동작 변경을 의도하지 않은 구조 분리 작업입니다. 기존 경로 검색 테스트로 직접/환승/차단 경로 동작을 다시 확인했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 지연 중 Codex CLI code review fallback 결과도 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
