### PR TITLE
[Fix] 운영 인메모리 저장소 차단

### DIFF
--- a/backend/src/main/java/com/easysubway/common/persistence/ProductionPersistenceReadinessConfiguration.java
+++ b/backend/src/main/java/com/easysubway/common/persistence/ProductionPersistenceReadinessConfiguration.java
@@ -1,0 +1,22 @@
+package com.easysubway.common.persistence;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration(proxyBeanMethods = false)
+@Profile("prod")
+class ProductionPersistenceReadinessConfiguration {
+
+	private static final String MESSAGE = "운영 영속 저장소 구현이 필요합니다.";
+
+	@Bean
+	static BeanFactoryPostProcessor productionPersistenceReadinessGate() {
+		// 운영에서는 사용자 데이터 유실 가능성이 있는 인메모리 저장소 fallback보다 명시적 실패를 우선한다.
+		return beanFactory -> {
+			throw new BeanCreationException(MESSAGE);
+		};
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteFacilityRepository.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteFacilityRepository.java
@@ -12,9 +12,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Profile("!prod")
 public class InMemoryFavoriteFacilityRepository implements
 	LoadFavoriteFacilityPort,
 	LoadFavoriteFacilityAlertTargetPort,

--- a/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepository.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepository.java
@@ -14,9 +14,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Profile("!prod")
 public class InMemoryFavoriteRouteRepository implements
 	LoadFavoriteRoutePort,
 	LoadFavoriteRouteAlertTargetPort,

--- a/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteStationRepository.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteStationRepository.java
@@ -12,9 +12,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Profile("!prod")
 public class InMemoryFavoriteStationRepository implements
 	LoadFavoriteStationPort,
 	LoadFavoriteStationAlertTargetPort,

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryNotificationPreferenceRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryNotificationPreferenceRepository.java
@@ -12,9 +12,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Profile("!prod")
 public class InMemoryNotificationPreferenceRepository implements
 	LoadNotificationPreferencePort,
 	SaveRegisteredDevicePort,

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
@@ -8,9 +8,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Profile("!prod")
 public class InMemoryPushNotificationOutboxRepository implements
 	LoadPushNotificationOutboxPort,
 	SavePushNotificationOutboxPort,

--- a/backend/src/main/java/com/easysubway/profile/adapter/out/persistence/InMemoryMobilityProfileRepository.java
+++ b/backend/src/main/java/com/easysubway/profile/adapter/out/persistence/InMemoryMobilityProfileRepository.java
@@ -7,9 +7,11 @@ import com.easysubway.user.application.port.out.DeleteUserMobilityProfilePort;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Profile("!prod")
 public class InMemoryMobilityProfileRepository implements
 	LoadMobilityProfilePort,
 	SaveMobilityProfilePort,

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
@@ -8,9 +8,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Profile("!prod")
 public class InMemoryFacilityReportRepository implements
 	LoadFacilityReportPort,
 	SaveFacilityReportPort,

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportReviewAuditRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportReviewAuditRepository.java
@@ -6,9 +6,11 @@ import com.easysubway.report.domain.FacilityReportReviewAudit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Profile("!prod")
 public class InMemoryFacilityReportReviewAuditRepository implements
 	LoadFacilityReportReviewAuditPort,
 	SaveFacilityReportReviewAuditPort {

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
@@ -9,9 +9,11 @@ import com.easysubway.user.application.port.out.AnonymizeUserRouteFeedbackPort;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Profile("!prod")
 public class InMemoryRouteSearchRepository
 	implements LoadRouteSearchPort, SaveRouteSearchPort, SaveRouteFeedbackPort, AnonymizeUserRouteFeedbackPort {
 

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -18,9 +18,11 @@ import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Profile("!prod")
 public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, SaveAccessibilityFacilityStatusPort {
 
 	private static final List<TransitOperator> OPERATORS = List.of(

--- a/backend/src/test/java/com/easysubway/common/persistence/InMemoryRepositoryProfileTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/InMemoryRepositoryProfileTest.java
@@ -1,0 +1,59 @@
+package com.easysubway.common.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.collection.adapter.out.persistence.InMemoryDataCollectionRunRepository;
+import com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteFacilityRepository;
+import com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteRouteRepository;
+import com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteStationRepository;
+import com.easysubway.notification.adapter.out.persistence.InMemoryNotificationPreferenceRepository;
+import com.easysubway.notification.adapter.out.persistence.InMemoryPushNotificationOutboxRepository;
+import com.easysubway.profile.adapter.out.persistence.InMemoryMobilityProfileRepository;
+import com.easysubway.report.adapter.out.persistence.InMemoryFacilityReportRepository;
+import com.easysubway.report.adapter.out.persistence.InMemoryFacilityReportReviewAuditRepository;
+import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
+import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.context.annotation.Profile;
+
+@DisplayName("인메모리 저장소 프로필 설정")
+class InMemoryRepositoryProfileTest {
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("inMemoryRepositories")
+	@DisplayName("인메모리 저장소는 운영 프로필에서 빈으로 등록하지 않는다")
+	void inMemoryRepositoriesAreDisabledOnProd(Class<?> repositoryType) {
+		Profile profile = repositoryType.getAnnotation(Profile.class);
+
+		assertThat(profile)
+			.as("%s 클래스는 @Profile(\"!prod\")가 필요합니다.", repositoryType.getSimpleName())
+			.isNotNull();
+		assertThat(profile.value()).containsExactly("!prod");
+	}
+
+	@Test
+	@DisplayName("검증 대상에는 운영 데이터가 유실될 수 있는 인메모리 저장소를 모두 포함한다")
+	void allStatefulInMemoryRepositoriesAreCovered() {
+		assertThat(inMemoryRepositories()).hasSize(11);
+	}
+
+	static Stream<Class<?>> inMemoryRepositories() {
+		return Stream.of(
+			InMemoryDataCollectionRunRepository.class,
+			InMemoryFavoriteFacilityRepository.class,
+			InMemoryFavoriteRouteRepository.class,
+			InMemoryFavoriteStationRepository.class,
+			InMemoryFacilityReportRepository.class,
+			InMemoryFacilityReportReviewAuditRepository.class,
+			InMemoryMobilityProfileRepository.class,
+			InMemoryNotificationPreferenceRepository.class,
+			InMemoryPushNotificationOutboxRepository.class,
+			InMemoryRouteSearchRepository.class,
+			InMemoryTransitMasterRepository.class
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/common/persistence/ProductionPersistenceReadinessConfigurationTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/ProductionPersistenceReadinessConfigurationTest.java
@@ -1,0 +1,34 @@
+package com.easysubway.common.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+@DisplayName("운영 영속 저장소 준비 상태")
+class ProductionPersistenceReadinessConfigurationTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(ProductionPersistenceReadinessConfiguration.class);
+
+	@Test
+	@DisplayName("운영 프로필은 영속 저장소 구현 전까지 명확한 오류로 시작을 막는다")
+	void prodProfileFailsWithPersistenceReadinessMessage() {
+		contextRunner
+			.withPropertyValues("spring.profiles.active=prod")
+			.run(context -> {
+				assertThat(context).hasFailed();
+				assertThat(context.getStartupFailure())
+					.hasMessageContaining("운영 영속 저장소 구현이 필요합니다.");
+			});
+	}
+
+	@Test
+	@DisplayName("개발 프로필은 영속 저장소 준비 상태 검사 없이 시작한다")
+	void devProfileDoesNotRunPersistenceReadinessGate() {
+		contextRunner
+			.withPropertyValues("spring.profiles.active=dev")
+			.run(context -> assertThat(context).hasNotFailed());
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -76,6 +76,13 @@ function assertMobileCatchPolicy(file, source) {
   }
 }
 
+function inMemoryRepositoryFiles() {
+  return execFileSync("git", ["ls-files", "backend/src/main/java/**/InMemory*Repository.java"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim().split("\n").filter(Boolean);
+}
+
 function readPngPixelBounds(relativePath) {
   const png = readFileSync(path.join(root, relativePath));
   const signature = png.subarray(0, 8);
@@ -589,6 +596,17 @@ test("백엔드 익명 사용자 인증은 헥사고날 API 경계를 따른다"
   assert.match(applicationProd, /redis:[\s\S]*host: \$\{EASYSUBWAY_REDIS_HOST\}/);
   assert.match(applicationProd, /redis:[\s\S]*port: \$\{EASYSUBWAY_REDIS_PORT:6379\}/);
   assert.match(applicationProd, /trusted-proxies: \$\{EASYSUBWAY_TRUSTED_PROXY_CIDRS\}/);
+});
+
+test("백엔드 인메모리 저장소는 운영 프로필에서 제외된다", () => {
+  const files = inMemoryRepositoryFiles();
+
+  assert.ok(files.length >= 1, "InMemory repository files must be discovered");
+  for (const file of files) {
+    const source = read(file);
+    assert.match(source, /import org\.springframework\.context\.annotation\.Profile;/, `${file} must import Profile`);
+    assert.match(source, /@Repository\s+@Profile\("!prod"\)/, `${file} must be disabled on prod profile`);
+  }
 });
 
 test("백엔드 사용자 데이터 삭제는 헥사고날 API 경계를 따른다", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -600,6 +600,9 @@ test("백엔드 익명 사용자 인증은 헥사고날 API 경계를 따른다"
 
 test("백엔드 인메모리 저장소는 운영 프로필에서 제외된다", () => {
   const files = inMemoryRepositoryFiles();
+  const readinessConfiguration = read(
+    "backend/src/main/java/com/easysubway/common/persistence/ProductionPersistenceReadinessConfiguration.java",
+  );
 
   assert.ok(files.length >= 1, "InMemory repository files must be discovered");
   for (const file of files) {
@@ -607,6 +610,9 @@ test("백엔드 인메모리 저장소는 운영 프로필에서 제외된다", 
     assert.match(source, /import org\.springframework\.context\.annotation\.Profile;/, `${file} must import Profile`);
     assert.match(source, /@Repository\s+@Profile\("!prod"\)/, `${file} must be disabled on prod profile`);
   }
+  assert.match(readinessConfiguration, /@Profile\("prod"\)/);
+  assert.match(readinessConfiguration, /BeanFactoryPostProcessor/);
+  assert.match(readinessConfiguration, /운영 영속 저장소 구현이 필요합니다\./);
 });
 
 test("백엔드 사용자 데이터 삭제는 헥사고날 API 경계를 따른다", () => {


### PR DESCRIPTION
## 관련 이슈

close #242

## 작업 배경

신고, 즐겨찾기, 경로 검색, 알림 설정 같은 사용자 데이터 저장소가 인메모리 구현으로 운영 프로필에 등록되면 재시작이나 scale-out 시 데이터가 유실되거나 노드별 상태가 달라질 수 있습니다. 실제 영속 저장소 구현이 준비되기 전까지 운영 프로필에서는 인메모리 저장소가 조용히 기동되지 않도록 막습니다.

## 작업 내용

- 사용자/운영 데이터가 남는 `InMemory*Repository` 빈을 `@Profile("!prod")`로 제한했습니다.
- 영속 저장소 구현이 아직 없는 운영 프로필은 missing bean 오류 대신 `운영 영속 저장소 구현이 필요합니다.` 메시지로 먼저 실패하도록 readiness gate를 추가했습니다.
- 인메모리 저장소가 운영 프로필에서 제외되는지, prod readiness gate가 동작하는지 검증하는 backend 테스트를 추가했습니다.
- 새 인메모리 저장소가 추가될 때 운영 프로필 차단 누락을 잡도록 repository contract를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "*InMemoryRepositoryProfileTest"`: 실패 확인 후 구현, 이후 통과
  - `./gradlew test --tests "*ProductionPersistenceReadinessConfigurationTest"`: 실패 확인 후 구현, 이후 통과
  - `./gradlew test`: 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과
  - `git diff --check`: 통과
  - `git ls-files "*.md"`: `.github/pull_request_template.md`, `README.md`만 추적됨
  - PR CI: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 통과
  - merge 후 main CI/CD: 통과

## 리뷰어 메모

- 운영 프로필에서 아직 영속 구현이 없는 포트는 애플리케이션이 명확한 readiness 오류로 기동 실패하는 것이 의도입니다. 데이터 유실 가능성이 있는 인메모리 fallback으로 운영하는 상황을 막기 위한 변경입니다.
- CodeRabbit은 rate limit으로 실제 리뷰가 시작되지 않아 Codex CLI code review를 대체 실행했습니다. Codex CLI 지적 1건은 inline review로 남긴 뒤 `c89c064`에서 수정하고 thread를 resolve했습니다.

## 리스크

- prod 프로필 로컬 실행이나 배포 검증은 영속 저장소 구현이 붙기 전까지 readiness 오류로 실패합니다. 이는 운영 데이터 유실보다 안전한 실패로 보는 변경입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.