### PR TITLE
[Feat] 이동 프로필 영속 저장소 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/profile/adapter/out/persistence/JdbcMobilityProfileRepository.java
+++ b/backend/src/main/java/com/easysubway/profile/adapter/out/persistence/JdbcMobilityProfileRepository.java
@@ -1,0 +1,154 @@
+package com.easysubway.profile.adapter.out.persistence;
+
+import com.easysubway.profile.application.port.out.LoadMobilityProfilePort;
+import com.easysubway.profile.application.port.out.SaveMobilityProfilePort;
+import com.easysubway.profile.domain.MobilityProfile;
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.user.application.port.out.DeleteUserMobilityProfilePort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Profile("prod")
+public class JdbcMobilityProfileRepository implements
+	LoadMobilityProfilePort,
+	SaveMobilityProfilePort,
+	DeleteUserMobilityProfilePort {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public JdbcMobilityProfileRepository(DataSource dataSource) {
+		this(new JdbcTemplate(dataSource));
+	}
+
+	JdbcMobilityProfileRepository(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public Optional<MobilityProfile> loadProfile(String userId) {
+		try {
+			return Optional.ofNullable(jdbcTemplate.queryForObject(
+				"""
+					SELECT user_id, mobility_type, avoid_stairs, require_elevator, allow_escalator,
+					       minimize_transfers, avoid_long_walks, large_text, high_contrast, simple_view, updated_at
+					FROM mobility_profiles
+					WHERE user_id = ?
+					""",
+				this::mapProfile,
+				userId
+			));
+		} catch (EmptyResultDataAccessException exception) {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	@Transactional
+	public MobilityProfile saveProfile(MobilityProfile profile) {
+		if (updateProfile(profile) == 0) {
+			try {
+				insertProfile(profile);
+			} catch (DuplicateKeyException exception) {
+				// 같은 사용자의 최초 저장이 동시에 들어오면 삽입 충돌 후 최신 값으로 수렴시킨다.
+				updateProfile(profile);
+			}
+		}
+		return profile;
+	}
+
+	private int updateProfile(MobilityProfile profile) {
+		return jdbcTemplate.update("""
+			UPDATE mobility_profiles
+			SET mobility_type = ?,
+			    avoid_stairs = ?,
+			    require_elevator = ?,
+			    allow_escalator = ?,
+			    minimize_transfers = ?,
+			    avoid_long_walks = ?,
+			    large_text = ?,
+			    high_contrast = ?,
+			    simple_view = ?,
+			    updated_at = ?
+			WHERE user_id = ?
+			""",
+			profile.mobilityType().name(),
+			profile.avoidStairs(),
+			profile.requireElevator(),
+			profile.allowEscalator(),
+			profile.minimizeTransfers(),
+			profile.avoidLongWalks(),
+			profile.largeText(),
+			profile.highContrast(),
+			profile.simpleView(),
+			profile.updatedAt(),
+			profile.userId()
+		);
+	}
+
+	private void insertProfile(MobilityProfile profile) {
+		jdbcTemplate.update("""
+			INSERT INTO mobility_profiles (
+				user_id,
+				mobility_type,
+				avoid_stairs,
+				require_elevator,
+				allow_escalator,
+				minimize_transfers,
+				avoid_long_walks,
+				large_text,
+				high_contrast,
+				simple_view,
+				updated_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			""",
+			profile.userId(),
+			profile.mobilityType().name(),
+			profile.avoidStairs(),
+			profile.requireElevator(),
+			profile.allowEscalator(),
+			profile.minimizeTransfers(),
+			profile.avoidLongWalks(),
+			profile.largeText(),
+			profile.highContrast(),
+			profile.simpleView(),
+			profile.updatedAt()
+		);
+	}
+
+	@Override
+	public boolean deleteMobilityProfile(String userId) {
+		return jdbcTemplate.update(
+			"""
+				DELETE FROM mobility_profiles
+				WHERE user_id = ?
+				""",
+			userId
+		) > 0;
+	}
+
+	private MobilityProfile mapProfile(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new MobilityProfile(
+			resultSet.getString("user_id"),
+			MobilityType.valueOf(resultSet.getString("mobility_type")),
+			resultSet.getBoolean("avoid_stairs"),
+			resultSet.getBoolean("require_elevator"),
+			resultSet.getBoolean("allow_escalator"),
+			resultSet.getBoolean("minimize_transfers"),
+			resultSet.getBoolean("avoid_long_walks"),
+			resultSet.getBoolean("large_text"),
+			resultSet.getBoolean("high_contrast"),
+			resultSet.getBoolean("simple_view"),
+			resultSet.getTimestamp("updated_at").toLocalDateTime()
+		);
+	}
+}

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -91,3 +91,20 @@ CREATE TABLE IF NOT EXISTS data_collection_runs (
 
 CREATE INDEX IF NOT EXISTS idx_data_collection_runs_started_at
 	ON data_collection_runs (started_at DESC);
+
+CREATE TABLE IF NOT EXISTS mobility_profiles (
+	user_id VARCHAR(120) NOT NULL PRIMARY KEY,
+	mobility_type VARCHAR(40) NOT NULL,
+	avoid_stairs BOOLEAN NOT NULL,
+	require_elevator BOOLEAN NOT NULL,
+	allow_escalator BOOLEAN NOT NULL,
+	minimize_transfers BOOLEAN NOT NULL,
+	avoid_long_walks BOOLEAN NOT NULL,
+	large_text BOOLEAN NOT NULL,
+	high_contrast BOOLEAN NOT NULL,
+	simple_view BOOLEAN NOT NULL,
+	updated_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_mobility_profiles_updated_at
+	ON mobility_profiles (updated_at DESC);

--- a/backend/src/test/java/com/easysubway/profile/adapter/out/persistence/JdbcMobilityProfileRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/profile/adapter/out/persistence/JdbcMobilityProfileRepositoryTest.java
@@ -1,0 +1,106 @@
+package com.easysubway.profile.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.profile.domain.MobilityProfile;
+import com.easysubway.profile.domain.MobilityType;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("JDBC 이동 프로필 저장소")
+class JdbcMobilityProfileRepositoryTest {
+
+	private JdbcMobilityProfileRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:mobility-profile;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS mobility_profiles");
+		jdbcTemplate.execute("""
+			CREATE TABLE mobility_profiles (
+				user_id VARCHAR(120) PRIMARY KEY,
+				mobility_type VARCHAR(40) NOT NULL,
+				avoid_stairs BOOLEAN NOT NULL,
+				require_elevator BOOLEAN NOT NULL,
+				allow_escalator BOOLEAN NOT NULL,
+				minimize_transfers BOOLEAN NOT NULL,
+				avoid_long_walks BOOLEAN NOT NULL,
+				large_text BOOLEAN NOT NULL,
+				high_contrast BOOLEAN NOT NULL,
+				simple_view BOOLEAN NOT NULL,
+				updated_at TIMESTAMP NOT NULL
+			)
+			""");
+		repository = new JdbcMobilityProfileRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("이동 프로필을 저장하고 사용자 식별자로 조회한다")
+	void saveProfileAndLoadProfileByUserId() {
+		var profile = profile("anonymous-user-1", MobilityType.SENIOR, true, false);
+
+		repository.saveProfile(profile);
+
+		assertThat(repository.loadProfile("anonymous-user-1")).contains(profile);
+	}
+
+	@Test
+	@DisplayName("같은 사용자 이동 프로필은 마지막 저장 값으로 갱신한다")
+	void saveProfileUpdatesExistingProfileForSameUser() {
+		repository.saveProfile(profile("anonymous-user-1", MobilityType.SENIOR, true, false));
+		var updatedProfile = profile("anonymous-user-1", MobilityType.WHEELCHAIR, true, true);
+
+		repository.saveProfile(updatedProfile);
+
+		assertThat(repository.loadProfile("anonymous-user-1")).contains(updatedProfile);
+	}
+
+	@Test
+	@DisplayName("없는 사용자 이동 프로필은 빈 결과로 조회한다")
+	void loadProfileReturnsEmptyWhenProfileDoesNotExist() {
+		assertThat(repository.loadProfile("missing-user")).isEmpty();
+	}
+
+	@Test
+	@DisplayName("사용자 데이터 삭제 요청은 이동 프로필을 제거한다")
+	void deleteMobilityProfileRemovesProfileByUserId() {
+		repository.saveProfile(profile("anonymous-user-1", MobilityType.STROLLER, true, true));
+
+		boolean deleted = repository.deleteMobilityProfile("anonymous-user-1");
+		boolean deletedAgain = repository.deleteMobilityProfile("anonymous-user-1");
+
+		assertThat(deleted).isTrue();
+		assertThat(deletedAgain).isFalse();
+		assertThat(repository.loadProfile("anonymous-user-1")).isEmpty();
+	}
+
+	private MobilityProfile profile(
+		String userId,
+		MobilityType mobilityType,
+		boolean avoidStairs,
+		boolean requireElevator
+	) {
+		return new MobilityProfile(
+			userId,
+			mobilityType,
+			avoidStairs,
+			requireElevator,
+			true,
+			true,
+			true,
+			false,
+			true,
+			false,
+			LocalDateTime.of(2026, 6, 17, 9, 30)
+		);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -894,6 +894,10 @@ test("백엔드 이동 프로필은 헥사고날 API 경계를 따른다", () =>
   const savePort = read("backend/src/main/java/com/easysubway/profile/application/port/out/SaveMobilityProfilePort.java");
   const service = read("backend/src/main/java/com/easysubway/profile/application/service/MobilityProfileService.java");
   const repository = read("backend/src/main/java/com/easysubway/profile/adapter/out/persistence/InMemoryMobilityProfileRepository.java");
+  const jdbcRepository = read(
+    "backend/src/main/java/com/easysubway/profile/adapter/out/persistence/JdbcMobilityProfileRepository.java",
+  );
+  const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
   const controller = read("backend/src/main/java/com/easysubway/profile/adapter/in/web/MobilityProfileController.java");
 
   assert.match(profile, /record MobilityProfile/);
@@ -917,6 +921,16 @@ test("백엔드 이동 프로필은 헥사고날 API 경계를 따른다", () =>
   assert.match(service, /defaultProfile/);
   assert.match(service, /MobilityType\.WHEELCHAIR/);
   assert.match(repository, /implements[\s\S]*LoadMobilityProfilePort[\s\S]*SaveMobilityProfilePort/);
+  assert.match(jdbcRepository, /@Profile\("prod"\)/);
+  assert.match(jdbcRepository, /implements[\s\S]*LoadMobilityProfilePort[\s\S]*SaveMobilityProfilePort[\s\S]*DeleteUserMobilityProfilePort/);
+  assert.match(jdbcRepository, /Optional<MobilityProfile> loadProfile\(String userId\)/);
+  assert.match(jdbcRepository, /MobilityProfile saveProfile\(MobilityProfile profile\)/);
+  assert.match(jdbcRepository, /boolean deleteMobilityProfile\(String userId\)/);
+  assert.match(jdbcRepository, /mobility_profiles/);
+  assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS mobility_profiles/);
+  assert.match(batchPostgresSchema, /user_id VARCHAR\(120\) NOT NULL PRIMARY KEY/);
+  assert.match(batchPostgresSchema, /mobility_type VARCHAR\(40\) NOT NULL/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_mobility_profiles_updated_at/);
   assert.match(controller, /@GetMapping\("\/api\/v1\/me\/mobility-profile"\)/);
   assert.match(controller, /@PutMapping\("\/api\/v1\/me\/mobility-profile"\)/);
 });


### PR DESCRIPTION
## 관련 이슈

close #244

## 작업 배경

- 운영 프로필에서 인메모리 저장소가 제외되면서 이동 프로필도 실제 데이터베이스에 저장할 어댑터가 필요합니다.
- 이동 조건은 경로 탐색 접근성 판단에 직접 영향을 주므로, 앱 재시작과 서버 재배포 후에도 사용자별 설정이 유지되어야 합니다.

## 작업 내용

- `prod` 프로필 전용 `JdbcMobilityProfileRepository`를 추가해 이동 프로필 조회, 저장, 사용자 데이터 삭제를 JDBC 기반으로 처리했습니다.
- 저장은 기존 행 갱신 후 신규 삽입을 시도하고, 최초 저장 경쟁으로 중복 키가 발생하면 다시 갱신하도록 구성했습니다.
- 운영 PostgreSQL 스키마에 `mobility_profiles` 테이블과 갱신 시각 인덱스를 추가했습니다.
- 저장소 계약 테스트에 이동 프로필 JDBC 어댑터와 운영 스키마 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "*JdbcMobilityProfileRepositoryTest"`: 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 성공, 41개 테스트 통과
  - `./gradlew test`: 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `README.md`, `.github/pull_request_template.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `JdbcMobilityProfileRepository.saveProfile`의 갱신/삽입/중복 키 재시도 흐름
  - `schema-postgresql.sql`의 `mobility_profiles` 컬럼 구성이 도메인 필드와 일치하는지 여부

## 리스크

- 이번 PR은 이동 프로필 저장소 1개만 운영 DB로 전환합니다. 다른 인메모리 저장소의 운영 구현은 별도 작업으로 남아 있습니다.
- 기존 API 응답 형식은 변경하지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
