### PR TITLE
[Feat] 즐겨찾기 역 영속 저장소 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteStationRepository.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteStationRepository.java
@@ -1,0 +1,163 @@
+package com.easysubway.favorite.adapter.out.persistence;
+
+import com.easysubway.favorite.application.port.out.DeleteFavoriteStationPort;
+import com.easysubway.favorite.application.port.out.LoadFavoriteStationAlertTargetPort;
+import com.easysubway.favorite.application.port.out.LoadFavoriteStationPort;
+import com.easysubway.favorite.application.port.out.SaveFavoriteStationPort;
+import com.easysubway.favorite.domain.FavoriteStation;
+import com.easysubway.favorite.domain.InvalidFavoriteStationException;
+import com.easysubway.user.application.port.out.DeleteUserFavoriteStationPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Profile("prod")
+public class JdbcFavoriteStationRepository implements
+	LoadFavoriteStationPort,
+	LoadFavoriteStationAlertTargetPort,
+	SaveFavoriteStationPort,
+	DeleteFavoriteStationPort,
+	DeleteUserFavoriteStationPort {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public JdbcFavoriteStationRepository(DataSource dataSource) {
+		this(new JdbcTemplate(dataSource));
+	}
+
+	JdbcFavoriteStationRepository(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public List<FavoriteStation> loadFavoriteStations(String userId) {
+		return jdbcTemplate.query(
+			"""
+				SELECT user_id, station_id, added_at
+				FROM favorite_stations
+				WHERE user_id = ?
+				ORDER BY added_at ASC, station_id ASC
+				""",
+			this::mapFavoriteStation,
+			userId
+		);
+	}
+
+	@Override
+	public Optional<FavoriteStation> loadFavoriteStation(String userId, String stationId) {
+		try {
+			return Optional.ofNullable(jdbcTemplate.queryForObject(
+				"""
+					SELECT user_id, station_id, added_at
+					FROM favorite_stations
+					WHERE user_id = ? AND station_id = ?
+					""",
+				this::mapFavoriteStation,
+				userId,
+				stationId
+			));
+		} catch (EmptyResultDataAccessException exception) {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public List<String> loadUserIdsByFavoriteStationId(String stationId) {
+		if (stationId == null || stationId.isBlank()) {
+			throw new InvalidFavoriteStationException("역 식별자가 필요합니다.");
+		}
+		return jdbcTemplate.queryForList(
+			"""
+				SELECT user_id
+				FROM favorite_stations
+				WHERE station_id = ?
+				ORDER BY user_id ASC
+				""",
+			String.class,
+			stationId
+		);
+	}
+
+	@Override
+	@Transactional
+	public FavoriteStation saveFavoriteStation(FavoriteStation favoriteStation) {
+		if (updateFavoriteStation(favoriteStation) == 0) {
+			try {
+				insertFavoriteStation(favoriteStation);
+			} catch (DuplicateKeyException exception) {
+				// 같은 사용자가 같은 역을 동시에 저장하면 삽입 충돌 후 최신 추가 시각으로 맞춘다.
+				updateFavoriteStation(favoriteStation);
+			}
+		}
+		return favoriteStation;
+	}
+
+	@Override
+	public void deleteFavoriteStation(String userId, String stationId) {
+		jdbcTemplate.update(
+			"""
+				DELETE FROM favorite_stations
+				WHERE user_id = ? AND station_id = ?
+				""",
+			userId,
+			stationId
+		);
+	}
+
+	@Override
+	public int deleteFavoriteStationsByUserId(String userId) {
+		return jdbcTemplate.update(
+			"""
+				DELETE FROM favorite_stations
+				WHERE user_id = ?
+				""",
+			userId
+		);
+	}
+
+	private int updateFavoriteStation(FavoriteStation favoriteStation) {
+		return jdbcTemplate.update(
+			"""
+				UPDATE favorite_stations
+				SET added_at = ?
+				WHERE user_id = ? AND station_id = ?
+				""",
+			favoriteStation.addedAt(),
+			favoriteStation.userId(),
+			favoriteStation.stationId()
+		);
+	}
+
+	private void insertFavoriteStation(FavoriteStation favoriteStation) {
+		jdbcTemplate.update(
+			"""
+				INSERT INTO favorite_stations (
+					user_id,
+					station_id,
+					added_at
+				)
+				VALUES (?, ?, ?)
+				""",
+			favoriteStation.userId(),
+			favoriteStation.stationId(),
+			favoriteStation.addedAt()
+		);
+	}
+
+	private FavoriteStation mapFavoriteStation(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new FavoriteStation(
+			resultSet.getString("user_id"),
+			resultSet.getString("station_id"),
+			resultSet.getTimestamp("added_at").toLocalDateTime()
+		);
+	}
+}

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -108,3 +108,16 @@ CREATE TABLE IF NOT EXISTS mobility_profiles (
 
 CREATE INDEX IF NOT EXISTS idx_mobility_profiles_updated_at
 	ON mobility_profiles (updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS favorite_stations (
+	user_id VARCHAR(120) NOT NULL,
+	station_id VARCHAR(120) NOT NULL,
+	added_at TIMESTAMP NOT NULL,
+	PRIMARY KEY (user_id, station_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_favorite_stations_station_user
+	ON favorite_stations (station_id, user_id);
+
+CREATE INDEX IF NOT EXISTS idx_favorite_stations_user_added
+	ON favorite_stations (user_id, added_at ASC, station_id ASC);

--- a/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteStationRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteStationRepositoryTest.java
@@ -1,0 +1,120 @@
+package com.easysubway.favorite.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.favorite.domain.FavoriteStation;
+import com.easysubway.favorite.domain.InvalidFavoriteStationException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("JDBC 즐겨찾기 역 저장소")
+class JdbcFavoriteStationRepositoryTest {
+
+	private JdbcFavoriteStationRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:favorite-stations;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS favorite_stations");
+		jdbcTemplate.execute("""
+			CREATE TABLE favorite_stations (
+				user_id VARCHAR(120) NOT NULL,
+				station_id VARCHAR(120) NOT NULL,
+				added_at TIMESTAMP NOT NULL,
+				PRIMARY KEY (user_id, station_id)
+			)
+			""");
+		repository = new JdbcFavoriteStationRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("즐겨찾기 역을 저장하고 사용자 식별자와 역 식별자로 조회한다")
+	void saveFavoriteStationAndLoadByUserIdAndStationId() {
+		var favorite = favorite("anonymous-user-1", "station-sangnoksu", 9);
+
+		repository.saveFavoriteStation(favorite);
+
+		assertThat(repository.loadFavoriteStation("anonymous-user-1", "station-sangnoksu")).contains(favorite);
+		assertThat(repository.loadFavoriteStations("anonymous-user-1")).containsExactly(favorite);
+	}
+
+	@Test
+	@DisplayName("같은 사용자와 역 즐겨찾기는 마지막 저장 값으로 갱신한다")
+	void saveFavoriteStationUpdatesExistingFavorite() {
+		repository.saveFavoriteStation(favorite("anonymous-user-1", "station-sangnoksu", 9));
+		var updatedFavorite = favorite("anonymous-user-1", "station-sangnoksu", 10);
+
+		repository.saveFavoriteStation(updatedFavorite);
+
+		assertThat(repository.loadFavoriteStations("anonymous-user-1")).containsExactly(updatedFavorite);
+	}
+
+	@Test
+	@DisplayName("사용자별 즐겨찾기 역 목록은 추가 시각과 역 식별자 순서로 조회한다")
+	void loadFavoriteStationsOrdersByAddedAtAndStationId() {
+		var laterFavorite = favorite("anonymous-user-1", "station-sadang", 10);
+		var firstFavorite = favorite("anonymous-user-1", "station-sangnoksu", 9);
+		var secondFavorite = favorite("anonymous-user-1", "station-banwol", 9);
+		repository.saveFavoriteStation(laterFavorite);
+		repository.saveFavoriteStation(firstFavorite);
+		repository.saveFavoriteStation(secondFavorite);
+		repository.saveFavoriteStation(favorite("anonymous-user-2", "station-sangnoksu", 8));
+
+		assertThat(repository.loadFavoriteStations("anonymous-user-1"))
+			.containsExactly(secondFavorite, firstFavorite, laterFavorite);
+	}
+
+	@Test
+	@DisplayName("역 시설 알림 대상 사용자는 사용자 식별자 순서로 조회한다")
+	void loadUserIdsByFavoriteStationIdReturnsSortedUserIds() {
+		repository.saveFavoriteStation(favorite("anonymous-user-2", "station-sangnoksu", 9));
+		repository.saveFavoriteStation(favorite("anonymous-user-1", "station-sangnoksu", 9));
+		repository.saveFavoriteStation(favorite("anonymous-user-3", "station-sadang", 9));
+
+		assertThat(repository.loadUserIdsByFavoriteStationId("station-sangnoksu"))
+			.containsExactly("anonymous-user-1", "anonymous-user-2");
+	}
+
+	@Test
+	@DisplayName("역 시설 알림 대상 조회는 빈 역 식별자를 거부한다")
+	void loadUserIdsByFavoriteStationIdRejectsBlankStationId() {
+		assertThatThrownBy(() -> repository.loadUserIdsByFavoriteStationId(""))
+			.isInstanceOf(InvalidFavoriteStationException.class)
+			.hasMessage("역 식별자가 필요합니다.");
+	}
+
+	@Test
+	@DisplayName("사용자 데이터 삭제 요청은 해당 사용자의 즐겨찾기 역 개수를 반환한다")
+	void deleteFavoriteStationsByUserIdReturnsDeletedCount() {
+		repository.saveFavoriteStation(favorite("anonymous-user-1", "station-sangnoksu", 9));
+		repository.saveFavoriteStation(favorite("anonymous-user-1", "station-sadang", 10));
+		repository.saveFavoriteStation(favorite("anonymous-user-2", "station-sangnoksu", 9));
+
+		int deletedCount = repository.deleteFavoriteStationsByUserId("anonymous-user-1");
+		int deletedAgainCount = repository.deleteFavoriteStationsByUserId("anonymous-user-1");
+
+		assertThat(deletedCount).isEqualTo(2);
+		assertThat(deletedAgainCount).isZero();
+		assertThat(repository.loadFavoriteStations("anonymous-user-1")).isEmpty();
+		assertThat(repository.loadFavoriteStations("anonymous-user-2"))
+			.containsExactly(favorite("anonymous-user-2", "station-sangnoksu", 9));
+	}
+
+	private FavoriteStation favorite(String userId, String stationId, int hour) {
+		return new FavoriteStation(
+			userId,
+			stationId,
+			LocalDateTime.of(2026, 6, 17, hour, 0)
+		);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -951,6 +951,10 @@ test("백엔드 즐겨찾기 역은 헥사고날 API 경계를 따른다", () =>
   const deletePort = read("backend/src/main/java/com/easysubway/favorite/application/port/out/DeleteFavoriteStationPort.java");
   const service = read("backend/src/main/java/com/easysubway/favorite/application/service/FavoriteStationService.java");
   const repository = read("backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteStationRepository.java");
+  const jdbcRepository = read(
+    "backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteStationRepository.java",
+  );
+  const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
   const controller = read("backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteStationController.java");
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
 
@@ -976,6 +980,18 @@ test("백엔드 즐겨찾기 역은 헥사고날 API 경계를 따른다", () =>
   assert.match(service, /StationNotFoundException/);
   assert.match(repository, /implements[\s\S]*LoadFavoriteStationPort[\s\S]*LoadFavoriteStationAlertTargetPort[\s\S]*SaveFavoriteStationPort[\s\S]*DeleteFavoriteStationPort/);
   assert.match(repository, /loadUserIdsByFavoriteStationId/);
+  assert.match(jdbcRepository, /@Profile\("prod"\)/);
+  assert.match(jdbcRepository, /implements[\s\S]*LoadFavoriteStationPort[\s\S]*LoadFavoriteStationAlertTargetPort[\s\S]*SaveFavoriteStationPort[\s\S]*DeleteFavoriteStationPort[\s\S]*DeleteUserFavoriteStationPort/);
+  assert.match(jdbcRepository, /List<FavoriteStation> loadFavoriteStations\(String userId\)/);
+  assert.match(jdbcRepository, /Optional<FavoriteStation> loadFavoriteStation\(String userId, String stationId\)/);
+  assert.match(jdbcRepository, /List<String> loadUserIdsByFavoriteStationId\(String stationId\)/);
+  assert.match(jdbcRepository, /FavoriteStation saveFavoriteStation\(FavoriteStation favoriteStation\)/);
+  assert.match(jdbcRepository, /int deleteFavoriteStationsByUserId\(String userId\)/);
+  assert.match(jdbcRepository, /favorite_stations/);
+  assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS favorite_stations/);
+  assert.match(batchPostgresSchema, /PRIMARY KEY \(user_id, station_id\)/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_favorite_stations_station_user/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_favorite_stations_user_added/);
   assert.match(controller, /@GetMapping\("\/api\/v1\/me\/favorites\/stations"\)/);
   assert.match(controller, /@PutMapping\("\/api\/v1\/me\/favorites\/stations\/\{stationId\}"\)/);
   assert.match(controller, /@DeleteMapping\("\/api\/v1\/me\/favorites\/stations\/\{stationId\}"\)/);


### PR DESCRIPTION
## 관련 이슈

close #246

## 작업 배경

- 즐겨찾기 역은 사용자가 자주 확인하는 역 목록이면서 시설 상태 변경 알림 대상자를 찾는 기준 데이터입니다.
- 운영 프로필에서 인메모리 저장소가 제외되므로 서버 재시작이나 배포 이후에도 즐겨찾기 역이 유지되는 JDBC 저장소가 필요합니다.

## 작업 내용

- `prod` 프로필 전용 `JdbcFavoriteStationRepository`를 추가했습니다.
- 사용자별 즐겨찾기 역 목록 조회, 단건 조회, 저장, 삭제, 사용자 데이터 삭제, 역 시설 알림 대상 조회를 JDBC 기반으로 처리했습니다.
- 같은 사용자와 역 조합은 복합 기본키로 중복 저장을 막고, 저장 시 기존 행은 `added_at`을 갱신하도록 했습니다.
- 운영 PostgreSQL 스키마에 `favorite_stations` 테이블과 사용자/역 조회용 인덱스를 추가했습니다.
- 저장소 계약 테스트에 즐겨찾기 역 JDBC 어댑터와 운영 스키마 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "*JdbcFavoriteStationRepositoryTest"`: 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 성공, 41개 테스트 통과
  - `./gradlew test`: 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `README.md`, `.github/pull_request_template.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - GitHub Actions PR CI run `27631331108`: 성공
  - CodeRabbit: rate limit으로 실제 리뷰 미시작
  - `codex review --base origin/main --title "[Feat] 즐겨찾기 역 영속 저장소 추가"`: actionable issue 0건
  - GitHub Actions main CI run `27631915945`: 성공
  - GitHub Actions main CD run `27631916576`: 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `JdbcFavoriteStationRepository.saveFavoriteStation`의 갱신/삽입/중복 키 재시도 흐름
  - `favorite_stations`의 복합 기본키와 알림 대상 조회 인덱스 구성이 서비스 조회 패턴과 맞는지 여부

## 리스크

- 이번 PR은 즐겨찾기 역 저장소만 운영 DB로 전환합니다. 즐겨찾기 시설과 즐겨찾기 경로 영속 저장소는 별도 작업으로 남아 있습니다.
- 기존 API 응답 형식은 변경하지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
