### PR TITLE
[Feat] 즐겨찾기 시설 영속 저장소 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteFacilityRepository.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteFacilityRepository.java
@@ -90,15 +90,23 @@ public class JdbcFavoriteFacilityRepository implements
 	@Override
 	@Transactional
 	public FavoriteFacility saveFavoriteFacility(FavoriteFacility favoriteFacility) {
-		if (updateFavoriteFacility(favoriteFacility) == 0) {
+		DuplicateKeyException lastDuplicateKeyException = null;
+		for (int attempt = 0; attempt < 2; attempt++) {
+			if (updateFavoriteFacility(favoriteFacility) > 0) {
+				return favoriteFacility;
+			}
 			try {
 				insertFavoriteFacility(favoriteFacility);
+				return favoriteFacility;
 			} catch (DuplicateKeyException exception) {
-				// 같은 사용자가 같은 시설을 동시에 저장하면 삽입 충돌 후 최신 추가 시각으로 맞춘다.
-				updateFavoriteFacility(favoriteFacility);
+				lastDuplicateKeyException = exception;
+				// 같은 시설 저장과 삭제가 교차하면 재갱신이 빗나갈 수 있어 삽입 경로를 한 번 더 시도한다.
+				if (updateFavoriteFacility(favoriteFacility) > 0) {
+					return favoriteFacility;
+				}
 			}
 		}
-		return favoriteFacility;
+		throw new IllegalStateException("즐겨찾기 시설 저장 중 동시 변경이 반복되었습니다.", lastDuplicateKeyException);
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteFacilityRepository.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteFacilityRepository.java
@@ -1,0 +1,163 @@
+package com.easysubway.favorite.adapter.out.persistence;
+
+import com.easysubway.favorite.application.port.out.DeleteFavoriteFacilityPort;
+import com.easysubway.favorite.application.port.out.LoadFavoriteFacilityAlertTargetPort;
+import com.easysubway.favorite.application.port.out.LoadFavoriteFacilityPort;
+import com.easysubway.favorite.application.port.out.SaveFavoriteFacilityPort;
+import com.easysubway.favorite.domain.FavoriteFacility;
+import com.easysubway.favorite.domain.InvalidFavoriteFacilityException;
+import com.easysubway.user.application.port.out.DeleteUserFavoriteFacilityPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Profile("prod")
+public class JdbcFavoriteFacilityRepository implements
+	LoadFavoriteFacilityPort,
+	LoadFavoriteFacilityAlertTargetPort,
+	SaveFavoriteFacilityPort,
+	DeleteFavoriteFacilityPort,
+	DeleteUserFavoriteFacilityPort {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public JdbcFavoriteFacilityRepository(DataSource dataSource) {
+		this(new JdbcTemplate(dataSource));
+	}
+
+	JdbcFavoriteFacilityRepository(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public List<FavoriteFacility> loadFavoriteFacilities(String userId) {
+		return jdbcTemplate.query(
+			"""
+				SELECT user_id, facility_id, added_at
+				FROM favorite_facilities
+				WHERE user_id = ?
+				ORDER BY added_at ASC, facility_id ASC
+				""",
+			this::mapFavoriteFacility,
+			userId
+		);
+	}
+
+	@Override
+	public Optional<FavoriteFacility> loadFavoriteFacility(String userId, String facilityId) {
+		try {
+			return Optional.ofNullable(jdbcTemplate.queryForObject(
+				"""
+					SELECT user_id, facility_id, added_at
+					FROM favorite_facilities
+					WHERE user_id = ? AND facility_id = ?
+					""",
+				this::mapFavoriteFacility,
+				userId,
+				facilityId
+			));
+		} catch (EmptyResultDataAccessException exception) {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public List<String> loadUserIdsByFavoriteFacilityId(String facilityId) {
+		if (facilityId == null || facilityId.isBlank()) {
+			throw new InvalidFavoriteFacilityException("시설 식별자가 필요합니다.");
+		}
+		return jdbcTemplate.queryForList(
+			"""
+				SELECT user_id
+				FROM favorite_facilities
+				WHERE facility_id = ?
+				ORDER BY user_id ASC
+				""",
+			String.class,
+			facilityId
+		);
+	}
+
+	@Override
+	@Transactional
+	public FavoriteFacility saveFavoriteFacility(FavoriteFacility favoriteFacility) {
+		if (updateFavoriteFacility(favoriteFacility) == 0) {
+			try {
+				insertFavoriteFacility(favoriteFacility);
+			} catch (DuplicateKeyException exception) {
+				// 같은 사용자가 같은 시설을 동시에 저장하면 삽입 충돌 후 최신 추가 시각으로 맞춘다.
+				updateFavoriteFacility(favoriteFacility);
+			}
+		}
+		return favoriteFacility;
+	}
+
+	@Override
+	public void deleteFavoriteFacility(String userId, String facilityId) {
+		jdbcTemplate.update(
+			"""
+				DELETE FROM favorite_facilities
+				WHERE user_id = ? AND facility_id = ?
+				""",
+			userId,
+			facilityId
+		);
+	}
+
+	@Override
+	public int deleteFavoriteFacilitiesByUserId(String userId) {
+		return jdbcTemplate.update(
+			"""
+				DELETE FROM favorite_facilities
+				WHERE user_id = ?
+				""",
+			userId
+		);
+	}
+
+	private int updateFavoriteFacility(FavoriteFacility favoriteFacility) {
+		return jdbcTemplate.update(
+			"""
+				UPDATE favorite_facilities
+				SET added_at = ?
+				WHERE user_id = ? AND facility_id = ?
+				""",
+			favoriteFacility.addedAt(),
+			favoriteFacility.userId(),
+			favoriteFacility.facilityId()
+		);
+	}
+
+	private void insertFavoriteFacility(FavoriteFacility favoriteFacility) {
+		jdbcTemplate.update(
+			"""
+				INSERT INTO favorite_facilities (
+					user_id,
+					facility_id,
+					added_at
+				)
+				VALUES (?, ?, ?)
+				""",
+			favoriteFacility.userId(),
+			favoriteFacility.facilityId(),
+			favoriteFacility.addedAt()
+		);
+	}
+
+	private FavoriteFacility mapFavoriteFacility(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new FavoriteFacility(
+			resultSet.getString("user_id"),
+			resultSet.getString("facility_id"),
+			resultSet.getTimestamp("added_at").toLocalDateTime()
+		);
+	}
+}

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -121,3 +121,16 @@ CREATE INDEX IF NOT EXISTS idx_favorite_stations_station_user
 
 CREATE INDEX IF NOT EXISTS idx_favorite_stations_user_added
 	ON favorite_stations (user_id, added_at ASC, station_id ASC);
+
+CREATE TABLE IF NOT EXISTS favorite_facilities (
+	user_id VARCHAR(120) NOT NULL,
+	facility_id VARCHAR(120) NOT NULL,
+	added_at TIMESTAMP NOT NULL,
+	PRIMARY KEY (user_id, facility_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_favorite_facilities_facility_user
+	ON favorite_facilities (facility_id, user_id);
+
+CREATE INDEX IF NOT EXISTS idx_favorite_facilities_user_added
+	ON favorite_facilities (user_id, added_at ASC, facility_id ASC);

--- a/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteFacilityRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteFacilityRepositoryTest.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
@@ -57,6 +58,18 @@ class JdbcFavoriteFacilityRepositoryTest {
 		repository.saveFavoriteFacility(updatedFavorite);
 
 		assertThat(repository.loadFavoriteFacilities("anonymous-user-1")).containsExactly(updatedFavorite);
+	}
+
+	@Test
+	@DisplayName("동시 저장 충돌 후 행이 사라지면 다시 삽입한다")
+	void saveFavoriteFacilityRetriesInsertWhenDuplicateRetryUpdateMissesRow() {
+		var jdbcTemplate = new DuplicateOnceJdbcTemplate(repositoryJdbcTemplate());
+		var retryRepository = new JdbcFavoriteFacilityRepository(jdbcTemplate);
+		var favorite = favorite("anonymous-user-1", "facility-elevator-1", 9);
+
+		retryRepository.saveFavoriteFacility(favorite);
+
+		assertThat(retryRepository.loadFavoriteFacility("anonymous-user-1", "facility-elevator-1")).contains(favorite);
 	}
 
 	@Test
@@ -116,5 +129,42 @@ class JdbcFavoriteFacilityRepositoryTest {
 			facilityId,
 			LocalDateTime.of(2026, 6, 17, hour, 0)
 		);
+	}
+
+	private JdbcTemplate repositoryJdbcTemplate() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:favorite-facilities-retry;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS favorite_facilities");
+		jdbcTemplate.execute("""
+			CREATE TABLE favorite_facilities (
+				user_id VARCHAR(120) NOT NULL,
+				facility_id VARCHAR(120) NOT NULL,
+				added_at TIMESTAMP NOT NULL,
+				PRIMARY KEY (user_id, facility_id)
+			)
+			""");
+		return jdbcTemplate;
+	}
+
+	private static final class DuplicateOnceJdbcTemplate extends JdbcTemplate {
+
+		private boolean duplicateRaised;
+
+		private DuplicateOnceJdbcTemplate(JdbcTemplate delegate) {
+			super(delegate.getDataSource());
+		}
+
+		@Override
+		public int update(String sql, Object... args) {
+			if (!duplicateRaised && sql.contains("INSERT INTO favorite_facilities")) {
+				duplicateRaised = true;
+				throw new DuplicateKeyException("stale duplicate");
+			}
+			return super.update(sql, args);
+		}
 	}
 }

--- a/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteFacilityRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteFacilityRepositoryTest.java
@@ -1,0 +1,120 @@
+package com.easysubway.favorite.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.favorite.domain.FavoriteFacility;
+import com.easysubway.favorite.domain.InvalidFavoriteFacilityException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("JDBC 즐겨찾기 시설 저장소")
+class JdbcFavoriteFacilityRepositoryTest {
+
+	private JdbcFavoriteFacilityRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:favorite-facilities;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS favorite_facilities");
+		jdbcTemplate.execute("""
+			CREATE TABLE favorite_facilities (
+				user_id VARCHAR(120) NOT NULL,
+				facility_id VARCHAR(120) NOT NULL,
+				added_at TIMESTAMP NOT NULL,
+				PRIMARY KEY (user_id, facility_id)
+			)
+			""");
+		repository = new JdbcFavoriteFacilityRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("즐겨찾기 시설을 저장하고 사용자 식별자와 시설 식별자로 조회한다")
+	void saveFavoriteFacilityAndLoadByUserIdAndFacilityId() {
+		var favorite = favorite("anonymous-user-1", "facility-elevator-1", 9);
+
+		repository.saveFavoriteFacility(favorite);
+
+		assertThat(repository.loadFavoriteFacility("anonymous-user-1", "facility-elevator-1")).contains(favorite);
+		assertThat(repository.loadFavoriteFacilities("anonymous-user-1")).containsExactly(favorite);
+	}
+
+	@Test
+	@DisplayName("같은 사용자와 시설 즐겨찾기는 마지막 저장 값으로 갱신한다")
+	void saveFavoriteFacilityUpdatesExistingFavorite() {
+		repository.saveFavoriteFacility(favorite("anonymous-user-1", "facility-elevator-1", 9));
+		var updatedFavorite = favorite("anonymous-user-1", "facility-elevator-1", 10);
+
+		repository.saveFavoriteFacility(updatedFavorite);
+
+		assertThat(repository.loadFavoriteFacilities("anonymous-user-1")).containsExactly(updatedFavorite);
+	}
+
+	@Test
+	@DisplayName("사용자별 즐겨찾기 시설 목록은 추가 시각과 시설 식별자 순서로 조회한다")
+	void loadFavoriteFacilitiesOrdersByAddedAtAndFacilityId() {
+		var laterFavorite = favorite("anonymous-user-1", "facility-escalator-2", 10);
+		var firstFavorite = favorite("anonymous-user-1", "facility-elevator-2", 9);
+		var secondFavorite = favorite("anonymous-user-1", "facility-elevator-1", 9);
+		repository.saveFavoriteFacility(laterFavorite);
+		repository.saveFavoriteFacility(firstFavorite);
+		repository.saveFavoriteFacility(secondFavorite);
+		repository.saveFavoriteFacility(favorite("anonymous-user-2", "facility-elevator-1", 8));
+
+		assertThat(repository.loadFavoriteFacilities("anonymous-user-1"))
+			.containsExactly(secondFavorite, firstFavorite, laterFavorite);
+	}
+
+	@Test
+	@DisplayName("시설 상태 알림 대상 사용자는 사용자 식별자 순서로 조회한다")
+	void loadUserIdsByFavoriteFacilityIdReturnsSortedUserIds() {
+		repository.saveFavoriteFacility(favorite("anonymous-user-2", "facility-elevator-1", 9));
+		repository.saveFavoriteFacility(favorite("anonymous-user-1", "facility-elevator-1", 9));
+		repository.saveFavoriteFacility(favorite("anonymous-user-3", "facility-escalator-2", 9));
+
+		assertThat(repository.loadUserIdsByFavoriteFacilityId("facility-elevator-1"))
+			.containsExactly("anonymous-user-1", "anonymous-user-2");
+	}
+
+	@Test
+	@DisplayName("시설 상태 알림 대상 조회는 빈 시설 식별자를 거부한다")
+	void loadUserIdsByFavoriteFacilityIdRejectsBlankFacilityId() {
+		assertThatThrownBy(() -> repository.loadUserIdsByFavoriteFacilityId(""))
+			.isInstanceOf(InvalidFavoriteFacilityException.class)
+			.hasMessage("시설 식별자가 필요합니다.");
+	}
+
+	@Test
+	@DisplayName("사용자 데이터 삭제 요청은 해당 사용자의 즐겨찾기 시설 개수를 반환한다")
+	void deleteFavoriteFacilitiesByUserIdReturnsDeletedCount() {
+		repository.saveFavoriteFacility(favorite("anonymous-user-1", "facility-elevator-1", 9));
+		repository.saveFavoriteFacility(favorite("anonymous-user-1", "facility-escalator-2", 10));
+		repository.saveFavoriteFacility(favorite("anonymous-user-2", "facility-elevator-1", 9));
+
+		int deletedCount = repository.deleteFavoriteFacilitiesByUserId("anonymous-user-1");
+		int deletedAgainCount = repository.deleteFavoriteFacilitiesByUserId("anonymous-user-1");
+
+		assertThat(deletedCount).isEqualTo(2);
+		assertThat(deletedAgainCount).isZero();
+		assertThat(repository.loadFavoriteFacilities("anonymous-user-1")).isEmpty();
+		assertThat(repository.loadFavoriteFacilities("anonymous-user-2"))
+			.containsExactly(favorite("anonymous-user-2", "facility-elevator-1", 9));
+	}
+
+	private FavoriteFacility favorite(String userId, String facilityId, int hour) {
+		return new FavoriteFacility(
+			userId,
+			facilityId,
+			LocalDateTime.of(2026, 6, 17, hour, 0)
+		);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1018,6 +1018,10 @@ test("백엔드 즐겨찾기 시설은 시설 마스터 기반 헥사고날 API 
   const deletePort = read("backend/src/main/java/com/easysubway/favorite/application/port/out/DeleteFavoriteFacilityPort.java");
   const service = read("backend/src/main/java/com/easysubway/favorite/application/service/FavoriteFacilityService.java");
   const repository = read("backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteFacilityRepository.java");
+  const jdbcRepository = read(
+    "backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteFacilityRepository.java",
+  );
+  const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
   const controller = read("backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteFacilityController.java");
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
 
@@ -1048,6 +1052,18 @@ test("백엔드 즐겨찾기 시설은 시설 마스터 기반 헥사고날 API 
   assert.match(service, /FavoriteFacilityNotFoundException/);
   assert.match(repository, /implements[\s\S]*LoadFavoriteFacilityPort[\s\S]*LoadFavoriteFacilityAlertTargetPort[\s\S]*SaveFavoriteFacilityPort[\s\S]*DeleteFavoriteFacilityPort/);
   assert.match(repository, /loadUserIdsByFavoriteFacilityId/);
+  assert.match(jdbcRepository, /@Profile\("prod"\)/);
+  assert.match(jdbcRepository, /implements[\s\S]*LoadFavoriteFacilityPort[\s\S]*LoadFavoriteFacilityAlertTargetPort[\s\S]*SaveFavoriteFacilityPort[\s\S]*DeleteFavoriteFacilityPort[\s\S]*DeleteUserFavoriteFacilityPort/);
+  assert.match(jdbcRepository, /List<FavoriteFacility> loadFavoriteFacilities\(String userId\)/);
+  assert.match(jdbcRepository, /Optional<FavoriteFacility> loadFavoriteFacility\(String userId, String facilityId\)/);
+  assert.match(jdbcRepository, /List<String> loadUserIdsByFavoriteFacilityId\(String facilityId\)/);
+  assert.match(jdbcRepository, /FavoriteFacility saveFavoriteFacility\(FavoriteFacility favoriteFacility\)/);
+  assert.match(jdbcRepository, /int deleteFavoriteFacilitiesByUserId\(String userId\)/);
+  assert.match(jdbcRepository, /favorite_facilities/);
+  assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS favorite_facilities/);
+  assert.match(batchPostgresSchema, /PRIMARY KEY \(user_id, facility_id\)/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_favorite_facilities_facility_user/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_favorite_facilities_user_added/);
   assert.match(controller, /@GetMapping\("\/api\/v1\/me\/favorites\/facilities"\)/);
   assert.match(controller, /@PutMapping\("\/api\/v1\/me\/favorites\/facilities\/\{facilityId\}"\)/);
   assert.match(controller, /@DeleteMapping\("\/api\/v1\/me\/favorites\/facilities\/\{facilityId\}"\)/);


### PR DESCRIPTION
## 관련 이슈

close #248

## 작업 배경

- 즐겨찾기 시설은 사용자가 자주 확인하는 엘리베이터, 에스컬레이터, 출구 같은 시설 상태를 다시 찾는 기준 데이터입니다.
- 시설 상태 변경 알림은 즐겨찾기 시설 사용자 목록을 기준으로 대상자를 찾으므로, 운영 환경에서 서버 재시작이나 배포 이후에도 데이터가 유지되어야 합니다.

## 작업 내용

- `prod` 프로필 전용 `JdbcFavoriteFacilityRepository`를 추가했습니다.
- 사용자별 즐겨찾기 시설 목록 조회, 단건 조회, 저장, 삭제, 사용자 데이터 삭제, 시설 상태 알림 대상 조회를 JDBC 기반으로 처리했습니다.
- 같은 사용자와 시설 조합은 복합 기본키로 중복 저장을 막고, 저장 시 기존 행은 `added_at`을 갱신하도록 했습니다.
- 운영 PostgreSQL 스키마에 `favorite_facilities` 테이블과 사용자/시설 조회용 인덱스를 추가했습니다.
- 저장소 계약 테스트에 즐겨찾기 시설 JDBC 어댑터와 운영 스키마 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "*JdbcFavoriteFacilityRepositoryTest"`: RED 확인 후 성공
  - `node --test tools/ci/repository-contract.test.mjs`: RED 확인 후 성공, 41개 테스트 통과
  - `./gradlew test`: 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `README.md`, `.github/pull_request_template.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - GitHub Actions PR CI run `27632614549`: 성공
  - CodeRabbit review: 중복 키 경합 후 재갱신 결과 미확인 지적 1건 확인
  - `./gradlew test --tests "*JdbcFavoriteFacilityRepositoryTest"`: CodeRabbit 지적 수정 후 성공
  - `./gradlew test`: CodeRabbit 지적 수정 후 성공
  - `node --test tools/ci/repository-contract.test.mjs`: CodeRabbit 지적 수정 후 성공, 41개 테스트 통과
  - GitHub Actions PR CI run `27633206532`: 수정 커밋 반영 후 성공
  - CodeRabbit review thread: 수정 반영 확인 및 resolved
  - GitHub Actions main CI run `27633581569`: merge 후 성공
  - GitHub Actions main CD run `27633581624`: merge 후 CD Readiness 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `JdbcFavoriteFacilityRepository.saveFavoriteFacility`의 갱신/삽입/중복 키 재시도 흐름
  - `favorite_facilities`의 복합 기본키와 알림 대상 조회 인덱스 구성이 서비스 조회 패턴과 맞는지 여부

## 리스크

- 이번 PR은 즐겨찾기 시설 저장소만 운영 DB로 전환합니다. 즐겨찾기 경로 영속 저장소는 별도 작업으로 남아 있습니다.
- 기존 API 응답 형식은 변경하지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
