### PR TITLE
[Feat] 즐겨찾기 경로 영속 저장소 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteRouteRepository.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteRouteRepository.java
@@ -1,0 +1,383 @@
+package com.easysubway.favorite.adapter.out.persistence;
+
+import com.easysubway.favorite.application.port.out.DeleteFavoriteRoutePort;
+import com.easysubway.favorite.application.port.out.LoadFavoriteRouteAlertTargetPort;
+import com.easysubway.favorite.application.port.out.LoadFavoriteRoutePort;
+import com.easysubway.favorite.application.port.out.SaveFavoriteRoutePort;
+import com.easysubway.favorite.domain.FavoriteRoute;
+import com.easysubway.favorite.domain.InvalidFavoriteRouteException;
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.route.domain.RouteStep;
+import com.easysubway.route.domain.RouteWarning;
+import com.easysubway.user.application.port.out.DeleteUserFavoriteRoutePort;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Profile("prod")
+public class JdbcFavoriteRouteRepository implements
+	LoadFavoriteRoutePort,
+	LoadFavoriteRouteAlertTargetPort,
+	SaveFavoriteRoutePort,
+	DeleteFavoriteRoutePort,
+	DeleteUserFavoriteRoutePort {
+
+	private static final TypeReference<List<RouteStep>> ROUTE_STEPS_TYPE = new TypeReference<>() {
+	};
+	private static final TypeReference<List<RouteWarning>> ROUTE_WARNINGS_TYPE = new TypeReference<>() {
+	};
+	private static final TypeReference<List<String>> STRING_LIST_TYPE = new TypeReference<>() {
+	};
+
+	private final JdbcTemplate jdbcTemplate;
+	private final ObjectMapper objectMapper;
+
+	@Autowired
+	public JdbcFavoriteRouteRepository(DataSource dataSource, ObjectMapper objectMapper) {
+		this(new JdbcTemplate(dataSource), objectMapper);
+	}
+
+	JdbcFavoriteRouteRepository(JdbcTemplate jdbcTemplate) {
+		this(jdbcTemplate, new ObjectMapper().findAndRegisterModules());
+	}
+
+	JdbcFavoriteRouteRepository(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
+		this.jdbcTemplate = jdbcTemplate;
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public List<FavoriteRoute> loadFavoriteRoutes(String userId) {
+		return jdbcTemplate.query(
+			"""
+				SELECT user_id,
+					route_search_id,
+					origin_station_id,
+					origin_station_name,
+					destination_station_id,
+					destination_station_name,
+					mobility_type,
+					status,
+					line_id,
+					line_name,
+					score,
+					steps_json,
+					warnings_json,
+					blocked_reasons_json,
+					route_created_at,
+					added_at
+				FROM favorite_routes
+				WHERE user_id = ?
+				ORDER BY added_at ASC, route_search_id ASC
+				""",
+			this::mapFavoriteRoute,
+			userId
+		);
+	}
+
+	@Override
+	public Optional<FavoriteRoute> loadFavoriteRoute(String userId, String routeSearchId) {
+		try {
+			return Optional.ofNullable(jdbcTemplate.queryForObject(
+				"""
+					SELECT user_id,
+						route_search_id,
+						origin_station_id,
+						origin_station_name,
+						destination_station_id,
+						destination_station_name,
+						mobility_type,
+						status,
+						line_id,
+						line_name,
+						score,
+						steps_json,
+						warnings_json,
+						blocked_reasons_json,
+						route_created_at,
+						added_at
+					FROM favorite_routes
+					WHERE user_id = ? AND route_search_id = ?
+					""",
+				this::mapFavoriteRoute,
+				userId,
+				routeSearchId
+			));
+		} catch (EmptyResultDataAccessException exception) {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public List<String> loadUserIdsByRouteStationId(String stationId) {
+		if (stationId == null || stationId.isBlank()) {
+			throw new InvalidFavoriteRouteException("역 식별자가 필요합니다.");
+		}
+		return jdbcTemplate.queryForList(
+			"""
+				SELECT DISTINCT user_id
+				FROM favorite_route_stations
+				WHERE station_id = ?
+				ORDER BY user_id ASC
+				""",
+			String.class,
+			stationId
+		);
+	}
+
+	@Override
+	@Transactional
+	public FavoriteRoute saveFavoriteRoute(FavoriteRoute favoriteRoute) {
+		DuplicateKeyException lastDuplicateKeyException = null;
+		for (int attempt = 0; attempt < 2; attempt++) {
+			if (updateFavoriteRoute(favoriteRoute) > 0) {
+				replaceRouteStations(favoriteRoute);
+				return favoriteRoute;
+			}
+			try {
+				insertFavoriteRoute(favoriteRoute);
+				replaceRouteStations(favoriteRoute);
+				return favoriteRoute;
+			} catch (DuplicateKeyException exception) {
+				lastDuplicateKeyException = exception;
+				// 저장과 삭제가 동시에 교차하면 재갱신이 빗나갈 수 있어 삽입 경로를 한 번 더 시도한다.
+				if (updateFavoriteRoute(favoriteRoute) > 0) {
+					replaceRouteStations(favoriteRoute);
+					return favoriteRoute;
+				}
+			}
+		}
+		throw new IllegalStateException("즐겨찾기 경로 저장 중 동시 변경이 반복되었습니다.", lastDuplicateKeyException);
+	}
+
+	@Override
+	@Transactional
+	public void deleteFavoriteRoute(String userId, String routeSearchId) {
+		deleteRouteStations(userId, routeSearchId);
+		jdbcTemplate.update(
+			"""
+				DELETE FROM favorite_routes
+				WHERE user_id = ? AND route_search_id = ?
+				""",
+			userId,
+			routeSearchId
+		);
+	}
+
+	@Override
+	@Transactional
+	public int deleteFavoriteRoutesByUserId(String userId) {
+		Integer favoriteRouteCount = jdbcTemplate.queryForObject(
+			"""
+				SELECT COUNT(*)
+				FROM favorite_routes
+				WHERE user_id = ?
+				""",
+			Integer.class,
+			userId
+		);
+		jdbcTemplate.update(
+			"""
+				DELETE FROM favorite_route_stations
+				WHERE user_id = ?
+				""",
+			userId
+		);
+		jdbcTemplate.update(
+			"""
+				DELETE FROM favorite_routes
+				WHERE user_id = ?
+				""",
+			userId
+		);
+		return favoriteRouteCount == null ? 0 : favoriteRouteCount;
+	}
+
+	private int updateFavoriteRoute(FavoriteRoute favoriteRoute) {
+		RouteSearchResult route = favoriteRoute.route();
+		return jdbcTemplate.update(
+			"""
+				UPDATE favorite_routes
+				SET origin_station_id = ?,
+					origin_station_name = ?,
+					destination_station_id = ?,
+					destination_station_name = ?,
+					mobility_type = ?,
+					status = ?,
+					line_id = ?,
+					line_name = ?,
+					score = ?,
+					steps_json = ?,
+					warnings_json = ?,
+					blocked_reasons_json = ?,
+					route_created_at = ?,
+					added_at = ?
+				WHERE user_id = ? AND route_search_id = ?
+				""",
+			route.originStationId(),
+			route.originStationName(),
+			route.destinationStationId(),
+			route.destinationStationName(),
+			route.mobilityType().name(),
+			route.status().name(),
+			route.lineId(),
+			route.lineName(),
+			route.score(),
+			writeJson(route.steps()),
+			writeJson(route.warnings()),
+			writeJson(route.blockedReasons()),
+			route.createdAt(),
+			favoriteRoute.addedAt(),
+			favoriteRoute.userId(),
+			favoriteRoute.routeSearchId()
+		);
+	}
+
+	private void insertFavoriteRoute(FavoriteRoute favoriteRoute) {
+		RouteSearchResult route = favoriteRoute.route();
+		jdbcTemplate.update(
+			"""
+				INSERT INTO favorite_routes (
+					user_id,
+					route_search_id,
+					origin_station_id,
+					origin_station_name,
+					destination_station_id,
+					destination_station_name,
+					mobility_type,
+					status,
+					line_id,
+					line_name,
+					score,
+					steps_json,
+					warnings_json,
+					blocked_reasons_json,
+					route_created_at,
+					added_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				""",
+			favoriteRoute.userId(),
+			favoriteRoute.routeSearchId(),
+			route.originStationId(),
+			route.originStationName(),
+			route.destinationStationId(),
+			route.destinationStationName(),
+			route.mobilityType().name(),
+			route.status().name(),
+			route.lineId(),
+			route.lineName(),
+			route.score(),
+			writeJson(route.steps()),
+			writeJson(route.warnings()),
+			writeJson(route.blockedReasons()),
+			route.createdAt(),
+			favoriteRoute.addedAt()
+		);
+	}
+
+	private void replaceRouteStations(FavoriteRoute favoriteRoute) {
+		deleteRouteStations(favoriteRoute.userId(), favoriteRoute.routeSearchId());
+		// 알림 대상 조회는 경로 본문 JSON을 매번 파싱하지 않도록 역 식별자만 별도 인덱스로 유지한다.
+		for (String stationId : routeStationIds(favoriteRoute.route())) {
+			jdbcTemplate.update(
+				"""
+					INSERT INTO favorite_route_stations (
+						user_id,
+						route_search_id,
+						station_id
+					)
+					VALUES (?, ?, ?)
+					""",
+				favoriteRoute.userId(),
+				favoriteRoute.routeSearchId(),
+				stationId
+			);
+		}
+	}
+
+	private void deleteRouteStations(String userId, String routeSearchId) {
+		jdbcTemplate.update(
+			"""
+				DELETE FROM favorite_route_stations
+				WHERE user_id = ? AND route_search_id = ?
+				""",
+			userId,
+			routeSearchId
+		);
+	}
+
+	private Set<String> routeStationIds(RouteSearchResult route) {
+		Set<String> stationIds = new LinkedHashSet<>();
+		addStationId(stationIds, route.originStationId());
+		addStationId(stationIds, route.destinationStationId());
+		for (RouteStep step : route.steps()) {
+			addStationId(stationIds, step.fromStationId());
+			addStationId(stationIds, step.toStationId());
+		}
+		return stationIds;
+	}
+
+	private void addStationId(Set<String> stationIds, String stationId) {
+		if (stationId != null && !stationId.isBlank()) {
+			stationIds.add(stationId);
+		}
+	}
+
+	private FavoriteRoute mapFavoriteRoute(ResultSet resultSet, int rowNumber) throws SQLException {
+		RouteSearchResult route = new RouteSearchResult(
+			resultSet.getString("route_search_id"),
+			resultSet.getString("origin_station_id"),
+			resultSet.getString("origin_station_name"),
+			resultSet.getString("destination_station_id"),
+			resultSet.getString("destination_station_name"),
+			MobilityType.valueOf(resultSet.getString("mobility_type")),
+			RouteSearchStatus.valueOf(resultSet.getString("status")),
+			resultSet.getString("line_id"),
+			resultSet.getString("line_name"),
+			resultSet.getInt("score"),
+			readJson(resultSet.getString("steps_json"), ROUTE_STEPS_TYPE),
+			readJson(resultSet.getString("warnings_json"), ROUTE_WARNINGS_TYPE),
+			readJson(resultSet.getString("blocked_reasons_json"), STRING_LIST_TYPE),
+			resultSet.getTimestamp("route_created_at").toLocalDateTime()
+		);
+		return new FavoriteRoute(
+			resultSet.getString("user_id"),
+			route,
+			resultSet.getTimestamp("added_at").toLocalDateTime()
+		);
+	}
+
+	private String writeJson(Object value) {
+		try {
+			return objectMapper.writeValueAsString(value);
+		} catch (JsonProcessingException exception) {
+			throw new IllegalStateException("즐겨찾기 경로 JSON 저장값을 만들지 못했습니다.", exception);
+		}
+	}
+
+	private <T> T readJson(String json, TypeReference<T> typeReference) {
+		try {
+			return objectMapper.readValue(json, typeReference);
+		} catch (JsonProcessingException exception) {
+			throw new IllegalStateException("즐겨찾기 경로 JSON 저장값을 읽지 못했습니다.", exception);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteRouteRepository.java
+++ b/backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteRouteRepository.java
@@ -24,8 +24,8 @@ import java.util.Set;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,6 +48,7 @@ public class JdbcFavoriteRouteRepository implements
 
 	private final JdbcTemplate jdbcTemplate;
 	private final ObjectMapper objectMapper;
+	private final DatabaseDialect databaseDialect;
 
 	@Autowired
 	public JdbcFavoriteRouteRepository(DataSource dataSource, ObjectMapper objectMapper) {
@@ -61,6 +62,7 @@ public class JdbcFavoriteRouteRepository implements
 	JdbcFavoriteRouteRepository(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
 		this.jdbcTemplate = jdbcTemplate;
 		this.objectMapper = objectMapper;
+		this.databaseDialect = detectDatabaseDialect(jdbcTemplate);
 	}
 
 	@Override
@@ -145,26 +147,9 @@ public class JdbcFavoriteRouteRepository implements
 	@Override
 	@Transactional
 	public FavoriteRoute saveFavoriteRoute(FavoriteRoute favoriteRoute) {
-		DuplicateKeyException lastDuplicateKeyException = null;
-		for (int attempt = 0; attempt < 2; attempt++) {
-			if (updateFavoriteRoute(favoriteRoute) > 0) {
-				replaceRouteStations(favoriteRoute);
-				return favoriteRoute;
-			}
-			try {
-				insertFavoriteRoute(favoriteRoute);
-				replaceRouteStations(favoriteRoute);
-				return favoriteRoute;
-			} catch (DuplicateKeyException exception) {
-				lastDuplicateKeyException = exception;
-				// 저장과 삭제가 동시에 교차하면 재갱신이 빗나갈 수 있어 삽입 경로를 한 번 더 시도한다.
-				if (updateFavoriteRoute(favoriteRoute) > 0) {
-					replaceRouteStations(favoriteRoute);
-					return favoriteRoute;
-				}
-			}
-		}
-		throw new IllegalStateException("즐겨찾기 경로 저장 중 동시 변경이 반복되었습니다.", lastDuplicateKeyException);
+		upsertFavoriteRoute(favoriteRoute);
+		replaceRouteStations(favoriteRoute);
+		return favoriteRoute;
 	}
 
 	@Override
@@ -210,48 +195,16 @@ public class JdbcFavoriteRouteRepository implements
 		return favoriteRouteCount == null ? 0 : favoriteRouteCount;
 	}
 
-	private int updateFavoriteRoute(FavoriteRoute favoriteRoute) {
-		RouteSearchResult route = favoriteRoute.route();
-		return jdbcTemplate.update(
-			"""
-				UPDATE favorite_routes
-				SET origin_station_id = ?,
-					origin_station_name = ?,
-					destination_station_id = ?,
-					destination_station_name = ?,
-					mobility_type = ?,
-					status = ?,
-					line_id = ?,
-					line_name = ?,
-					score = ?,
-					steps_json = ?,
-					warnings_json = ?,
-					blocked_reasons_json = ?,
-					route_created_at = ?,
-					added_at = ?
-				WHERE user_id = ? AND route_search_id = ?
-				""",
-			route.originStationId(),
-			route.originStationName(),
-			route.destinationStationId(),
-			route.destinationStationName(),
-			route.mobilityType().name(),
-			route.status().name(),
-			route.lineId(),
-			route.lineName(),
-			route.score(),
-			writeJson(route.steps()),
-			writeJson(route.warnings()),
-			writeJson(route.blockedReasons()),
-			route.createdAt(),
-			favoriteRoute.addedAt(),
-			favoriteRoute.userId(),
-			favoriteRoute.routeSearchId()
-		);
+	private void upsertFavoriteRoute(FavoriteRoute favoriteRoute) {
+		if (databaseDialect == DatabaseDialect.H2) {
+			upsertFavoriteRouteWithH2Merge(favoriteRoute);
+			return;
+		}
+		upsertFavoriteRouteWithPostgresql(favoriteRoute);
 	}
 
-	private void insertFavoriteRoute(FavoriteRoute favoriteRoute) {
-		RouteSearchResult route = favoriteRoute.route();
+	private void upsertFavoriteRouteWithPostgresql(FavoriteRoute favoriteRoute) {
+		// PostgreSQL은 중복 키 예외 뒤 같은 트랜잭션 재시도가 불가능하므로 단일 upsert로 저장한다.
 		jdbcTemplate.update(
 			"""
 				INSERT INTO favorite_routes (
@@ -273,7 +226,57 @@ public class JdbcFavoriteRouteRepository implements
 					added_at
 				)
 				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT (user_id, route_search_id) DO UPDATE
+				SET origin_station_id = EXCLUDED.origin_station_id,
+					origin_station_name = EXCLUDED.origin_station_name,
+					destination_station_id = EXCLUDED.destination_station_id,
+					destination_station_name = EXCLUDED.destination_station_name,
+					mobility_type = EXCLUDED.mobility_type,
+					status = EXCLUDED.status,
+					line_id = EXCLUDED.line_id,
+					line_name = EXCLUDED.line_name,
+					score = EXCLUDED.score,
+					steps_json = EXCLUDED.steps_json,
+					warnings_json = EXCLUDED.warnings_json,
+					blocked_reasons_json = EXCLUDED.blocked_reasons_json,
+					route_created_at = EXCLUDED.route_created_at,
+					added_at = EXCLUDED.added_at
 				""",
+			favoriteRouteParameters(favoriteRoute)
+		);
+	}
+
+	private void upsertFavoriteRouteWithH2Merge(FavoriteRoute favoriteRoute) {
+		jdbcTemplate.update(
+			"""
+				MERGE INTO favorite_routes (
+					user_id,
+					route_search_id,
+					origin_station_id,
+					origin_station_name,
+					destination_station_id,
+					destination_station_name,
+					mobility_type,
+					status,
+					line_id,
+					line_name,
+					score,
+					steps_json,
+					warnings_json,
+					blocked_reasons_json,
+					route_created_at,
+					added_at
+				)
+				KEY (user_id, route_search_id)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				""",
+			favoriteRouteParameters(favoriteRoute)
+		);
+	}
+
+	private Object[] favoriteRouteParameters(FavoriteRoute favoriteRoute) {
+		RouteSearchResult route = favoriteRoute.route();
+		return new Object[] {
 			favoriteRoute.userId(),
 			favoriteRoute.routeSearchId(),
 			route.originStationId(),
@@ -290,7 +293,7 @@ public class JdbcFavoriteRouteRepository implements
 			writeJson(route.blockedReasons()),
 			route.createdAt(),
 			favoriteRoute.addedAt()
-		);
+		};
 	}
 
 	private void replaceRouteStations(FavoriteRoute favoriteRoute) {
@@ -379,5 +382,18 @@ public class JdbcFavoriteRouteRepository implements
 		} catch (JsonProcessingException exception) {
 			throw new IllegalStateException("즐겨찾기 경로 JSON 저장값을 읽지 못했습니다.", exception);
 		}
+	}
+
+	private DatabaseDialect detectDatabaseDialect(JdbcTemplate jdbcTemplate) {
+		DatabaseDialect dialect = jdbcTemplate.execute((ConnectionCallback<DatabaseDialect>) connection -> {
+			String productName = connection.getMetaData().getDatabaseProductName();
+			return "H2".equalsIgnoreCase(productName) ? DatabaseDialect.H2 : DatabaseDialect.POSTGRESQL;
+		});
+		return dialect == null ? DatabaseDialect.POSTGRESQL : dialect;
+	}
+
+	private enum DatabaseDialect {
+		POSTGRESQL,
+		H2
 	}
 }

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -134,3 +134,36 @@ CREATE INDEX IF NOT EXISTS idx_favorite_facilities_facility_user
 
 CREATE INDEX IF NOT EXISTS idx_favorite_facilities_user_added
 	ON favorite_facilities (user_id, added_at ASC, facility_id ASC);
+
+CREATE TABLE IF NOT EXISTS favorite_routes (
+	user_id VARCHAR(120) NOT NULL,
+	route_search_id VARCHAR(120) NOT NULL,
+	origin_station_id VARCHAR(120) NOT NULL,
+	origin_station_name VARCHAR(120) NOT NULL,
+	destination_station_id VARCHAR(120) NOT NULL,
+	destination_station_name VARCHAR(120) NOT NULL,
+	mobility_type VARCHAR(40) NOT NULL,
+	status VARCHAR(40) NOT NULL,
+	line_id VARCHAR(120) NOT NULL,
+	line_name VARCHAR(120) NOT NULL,
+	score INTEGER NOT NULL,
+	steps_json TEXT NOT NULL,
+	warnings_json TEXT NOT NULL,
+	blocked_reasons_json TEXT NOT NULL,
+	route_created_at TIMESTAMP NOT NULL,
+	added_at TIMESTAMP NOT NULL,
+	PRIMARY KEY (user_id, route_search_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_favorite_routes_user_added
+	ON favorite_routes (user_id, added_at ASC, route_search_id ASC);
+
+CREATE TABLE IF NOT EXISTS favorite_route_stations (
+	user_id VARCHAR(120) NOT NULL,
+	route_search_id VARCHAR(120) NOT NULL,
+	station_id VARCHAR(120) NOT NULL,
+	PRIMARY KEY (user_id, route_search_id, station_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_favorite_route_stations_station_user
+	ON favorite_route_stations (station_id, user_id);

--- a/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteRouteRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteRouteRepositoryTest.java
@@ -114,7 +114,7 @@ class JdbcFavoriteRouteRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("같은 사용자와 경로 즐겨찾기는 마지막 저장 값으로 갱신한다")
+	@DisplayName("같은 사용자와 경로 즐겨찾기는 upsert로 한 행만 갱신한다")
 	void saveFavoriteRouteUpdatesExistingFavorite() {
 		repository.saveFavoriteRoute(favorite("anonymous-user-1", directRouteSearch("route-search-1", "상록수", "사당"), 9));
 		var updatedFavorite = favorite("anonymous-user-1", transferRouteSearch("route-search-1"), 10);

--- a/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteRouteRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteRouteRepositoryTest.java
@@ -1,0 +1,212 @@
+package com.easysubway.favorite.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.favorite.domain.FavoriteRoute;
+import com.easysubway.favorite.domain.InvalidFavoriteRouteException;
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.route.domain.RouteStep;
+import com.easysubway.route.domain.RouteWarning;
+import com.easysubway.route.domain.RouteWarningCode;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("JDBC 즐겨찾기 경로 저장소")
+class JdbcFavoriteRouteRepositoryTest {
+
+	private JdbcFavoriteRouteRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:favorite-routes;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS favorite_route_stations");
+		jdbcTemplate.execute("DROP TABLE IF EXISTS favorite_routes");
+		jdbcTemplate.execute("""
+			CREATE TABLE favorite_routes (
+				user_id VARCHAR(120) NOT NULL,
+				route_search_id VARCHAR(120) NOT NULL,
+				origin_station_id VARCHAR(120) NOT NULL,
+				origin_station_name VARCHAR(120) NOT NULL,
+				destination_station_id VARCHAR(120) NOT NULL,
+				destination_station_name VARCHAR(120) NOT NULL,
+				mobility_type VARCHAR(40) NOT NULL,
+				status VARCHAR(40) NOT NULL,
+				line_id VARCHAR(120) NOT NULL,
+				line_name VARCHAR(120) NOT NULL,
+				score INTEGER NOT NULL,
+				steps_json TEXT NOT NULL,
+				warnings_json TEXT NOT NULL,
+				blocked_reasons_json TEXT NOT NULL,
+				route_created_at TIMESTAMP NOT NULL,
+				added_at TIMESTAMP NOT NULL,
+				PRIMARY KEY (user_id, route_search_id)
+			)
+			""");
+		jdbcTemplate.execute("""
+			CREATE TABLE favorite_route_stations (
+				user_id VARCHAR(120) NOT NULL,
+				route_search_id VARCHAR(120) NOT NULL,
+				station_id VARCHAR(120) NOT NULL,
+				PRIMARY KEY (user_id, route_search_id, station_id)
+			)
+			""");
+		repository = new JdbcFavoriteRouteRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("즐겨찾기 경로를 저장하고 사용자 식별자와 경로 검색 식별자로 조회한다")
+	void saveFavoriteRouteAndLoadByUserIdAndRouteSearchId() {
+		var favorite = favorite("anonymous-user-1", transferRouteSearch("route-search-1"), 9);
+
+		repository.saveFavoriteRoute(favorite);
+
+		assertThat(repository.loadFavoriteRoute("anonymous-user-1", "route-search-1")).contains(favorite);
+		assertThat(repository.loadFavoriteRoutes("anonymous-user-1")).containsExactly(favorite);
+	}
+
+	@Test
+	@DisplayName("사용자별 즐겨찾기 경로 목록은 추가 시각과 경로 검색 식별자 순서로 조회한다")
+	void loadFavoriteRoutesOrdersByAddedAtAndRouteSearchId() {
+		var laterFavorite = favorite("anonymous-user-1", directRouteSearch("route-search-3", "사당", "상록수"), 10);
+		var secondFavorite = favorite("anonymous-user-1", directRouteSearch("route-search-2", "중앙", "사당"), 9);
+		var firstFavorite = favorite("anonymous-user-1", transferRouteSearch("route-search-1"), 9);
+		repository.saveFavoriteRoute(laterFavorite);
+		repository.saveFavoriteRoute(secondFavorite);
+		repository.saveFavoriteRoute(firstFavorite);
+		repository.saveFavoriteRoute(favorite("anonymous-user-2", directRouteSearch("route-search-1", "상록수", "사당"), 8));
+
+		assertThat(repository.loadFavoriteRoutes("anonymous-user-1"))
+			.containsExactly(firstFavorite, secondFavorite, laterFavorite);
+	}
+
+	@Test
+	@DisplayName("경로 상태 알림 대상 사용자는 출발역과 도착역과 환승역 기준으로 조회한다")
+	void loadUserIdsByRouteStationIdMatchesRouteStations() {
+		repository.saveFavoriteRoute(favorite("anonymous-user-2", directRouteSearch("route-search-2", "상록수", "사당"), 9));
+		repository.saveFavoriteRoute(favorite("anonymous-user-1", transferRouteSearch("route-search-1"), 9));
+		repository.saveFavoriteRoute(favorite("anonymous-user-3", directRouteSearch("route-search-3", "중앙", "사당"), 9));
+
+		assertThat(repository.loadUserIdsByRouteStationId("station-transfer"))
+			.containsExactly("anonymous-user-1");
+		assertThat(repository.loadUserIdsByRouteStationId("station-sadang"))
+			.containsExactly("anonymous-user-2", "anonymous-user-3");
+	}
+
+	@Test
+	@DisplayName("경로 상태 알림 대상 조회는 빈 역 식별자를 거부한다")
+	void loadUserIdsByRouteStationIdRejectsBlankStationId() {
+		assertThatThrownBy(() -> repository.loadUserIdsByRouteStationId(""))
+			.isInstanceOf(InvalidFavoriteRouteException.class)
+			.hasMessage("역 식별자가 필요합니다.");
+	}
+
+	@Test
+	@DisplayName("같은 사용자와 경로 즐겨찾기는 마지막 저장 값으로 갱신한다")
+	void saveFavoriteRouteUpdatesExistingFavorite() {
+		repository.saveFavoriteRoute(favorite("anonymous-user-1", directRouteSearch("route-search-1", "상록수", "사당"), 9));
+		var updatedFavorite = favorite("anonymous-user-1", transferRouteSearch("route-search-1"), 10);
+
+		repository.saveFavoriteRoute(updatedFavorite);
+
+		assertThat(repository.loadFavoriteRoutes("anonymous-user-1")).containsExactly(updatedFavorite);
+		assertThat(repository.loadUserIdsByRouteStationId("station-transfer")).containsExactly("anonymous-user-1");
+	}
+
+	@Test
+	@DisplayName("사용자 데이터 삭제 요청은 해당 사용자의 즐겨찾기 경로 개수를 반환한다")
+	void deleteFavoriteRoutesByUserIdReturnsDeletedCount() {
+		repository.saveFavoriteRoute(favorite("anonymous-user-1", directRouteSearch("route-search-1", "상록수", "사당"), 9));
+		repository.saveFavoriteRoute(favorite("anonymous-user-1", transferRouteSearch("route-search-2"), 10));
+		repository.saveFavoriteRoute(favorite("anonymous-user-2", directRouteSearch("route-search-3", "중앙", "사당"), 9));
+
+		int deletedCount = repository.deleteFavoriteRoutesByUserId("anonymous-user-1");
+		int deletedAgainCount = repository.deleteFavoriteRoutesByUserId("anonymous-user-1");
+
+		assertThat(deletedCount).isEqualTo(2);
+		assertThat(deletedAgainCount).isZero();
+		assertThat(repository.loadFavoriteRoutes("anonymous-user-1")).isEmpty();
+		assertThat(repository.loadFavoriteRoutes("anonymous-user-2"))
+			.containsExactly(favorite("anonymous-user-2", directRouteSearch("route-search-3", "중앙", "사당"), 9));
+		assertThat(repository.loadUserIdsByRouteStationId("station-transfer")).isEmpty();
+	}
+
+	private FavoriteRoute favorite(String userId, RouteSearchResult route, int hour) {
+		return new FavoriteRoute(
+			userId,
+			route,
+			LocalDateTime.of(2026, 6, 17, hour, 0)
+		);
+	}
+
+	private RouteSearchResult directRouteSearch(String routeSearchId, String originStationName, String destinationStationName) {
+		return new RouteSearchResult(
+			routeSearchId,
+			originStationId(originStationName),
+			originStationName,
+			destinationStationId(destinationStationName),
+			destinationStationName,
+			MobilityType.SENIOR,
+			RouteSearchStatus.FOUND,
+			"line-4",
+			"수도권 4호선",
+			90,
+			List.of(new RouteStep(1, "4호선 이동", "열차로 이동합니다.", "line-4", "수도권 4호선", originStationId(originStationName), destinationStationId(destinationStationName), 12, 5200, false, false)),
+			List.of(new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE, "시설 정보를 한 번 확인해 주세요.")),
+			List.of(),
+			LocalDateTime.of(2026, 6, 13, 9, 0)
+		);
+	}
+
+	private RouteSearchResult transferRouteSearch(String routeSearchId) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-origin",
+			"출발역",
+			"station-destination",
+			"도착역",
+			MobilityType.WHEELCHAIR,
+			RouteSearchStatus.FOUND,
+			"line-a/line-b",
+			"A 노선 / B 노선",
+			45,
+			List.of(
+				new RouteStep(1, "출발역에서 A 노선 승강장으로 이동", "엘리베이터를 확인합니다.", "line-a", "A 노선", "station-origin", "station-origin", 4, 180, false, true),
+				new RouteStep(2, "A 노선으로 환승역까지 이동", "2개 역을 이동한 뒤 환승합니다.", "line-a", "A 노선", "station-origin", "station-transfer", 4, 1800, false, false),
+				new RouteStep(3, "환승역에서 B 노선 승강장으로 환승", "환승역의 엘리베이터를 확인합니다.", "line-b", "B 노선", "station-transfer", "station-transfer", 6, 260, false, true),
+				new RouteStep(4, "B 노선으로 도착역까지 이동", "2개 역을 이동합니다.", "line-b", "B 노선", "station-transfer", "station-destination", 4, 1800, false, false)
+			),
+			List.of(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS, "일부 구간은 도움을 요청해야 할 수 있습니다.")),
+			List.of(),
+			LocalDateTime.of(2026, 6, 13, 9, 0)
+		);
+	}
+
+	private String originStationId(String stationName) {
+		return switch (stationName) {
+			case "상록수" -> "station-sangnoksu";
+			case "중앙" -> "station-jungang";
+			default -> "station-origin";
+		};
+	}
+
+	private String destinationStationId(String stationName) {
+		return switch (stationName) {
+			case "상록수" -> "station-sangnoksu";
+			case "사당" -> "station-sadang";
+			default -> "station-destination";
+		};
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1126,6 +1126,7 @@ test("백엔드 즐겨찾기 경로는 경로 검색 결과 기반 헥사고날 
   assert.match(jdbcRepository, /Optional<FavoriteRoute> loadFavoriteRoute\(String userId, String routeSearchId\)/);
   assert.match(jdbcRepository, /List<String> loadUserIdsByRouteStationId\(String stationId\)/);
   assert.match(jdbcRepository, /FavoriteRoute saveFavoriteRoute\(FavoriteRoute favoriteRoute\)/);
+  assert.match(jdbcRepository, /ON CONFLICT \(user_id, route_search_id\) DO UPDATE/);
   assert.match(jdbcRepository, /int deleteFavoriteRoutesByUserId\(String userId\)/);
   assert.match(jdbcRepository, /favorite_routes/);
   assert.match(jdbcRepository, /favorite_route_stations/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1091,6 +1091,8 @@ test("백엔드 즐겨찾기 경로는 경로 검색 결과 기반 헥사고날 
   const deletePort = read("backend/src/main/java/com/easysubway/favorite/application/port/out/DeleteFavoriteRoutePort.java");
   const service = read("backend/src/main/java/com/easysubway/favorite/application/service/FavoriteRouteService.java");
   const repository = read("backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/InMemoryFavoriteRouteRepository.java");
+  const jdbcRepository = read("backend/src/main/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteRouteRepository.java");
+  const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
   const controller = read("backend/src/main/java/com/easysubway/favorite/adapter/in/web/FavoriteRouteController.java");
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
 
@@ -1118,6 +1120,20 @@ test("백엔드 즐겨찾기 경로는 경로 검색 결과 기반 헥사고날 
   assert.match(service, /RouteSearchNotFoundException/);
   assert.match(repository, /implements[\s\S]*LoadFavoriteRoutePort[\s\S]*LoadFavoriteRouteAlertTargetPort[\s\S]*SaveFavoriteRoutePort[\s\S]*DeleteFavoriteRoutePort/);
   assert.match(repository, /loadUserIdsByRouteStationId/);
+  assert.match(jdbcRepository, /@Profile\("prod"\)/);
+  assert.match(jdbcRepository, /implements[\s\S]*LoadFavoriteRoutePort[\s\S]*LoadFavoriteRouteAlertTargetPort[\s\S]*SaveFavoriteRoutePort[\s\S]*DeleteFavoriteRoutePort[\s\S]*DeleteUserFavoriteRoutePort/);
+  assert.match(jdbcRepository, /List<FavoriteRoute> loadFavoriteRoutes\(String userId\)/);
+  assert.match(jdbcRepository, /Optional<FavoriteRoute> loadFavoriteRoute\(String userId, String routeSearchId\)/);
+  assert.match(jdbcRepository, /List<String> loadUserIdsByRouteStationId\(String stationId\)/);
+  assert.match(jdbcRepository, /FavoriteRoute saveFavoriteRoute\(FavoriteRoute favoriteRoute\)/);
+  assert.match(jdbcRepository, /int deleteFavoriteRoutesByUserId\(String userId\)/);
+  assert.match(jdbcRepository, /favorite_routes/);
+  assert.match(jdbcRepository, /favorite_route_stations/);
+  assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS favorite_routes/);
+  assert.match(batchPostgresSchema, /PRIMARY KEY \(user_id, route_search_id\)/);
+  assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS favorite_route_stations/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_favorite_routes_user_added/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_favorite_route_stations_station_user/);
   assert.match(controller, /@GetMapping\("\/api\/v1\/me\/favorites\/routes"\)/);
   assert.match(controller, /@PostMapping\("\/api\/v1\/me\/favorites\/routes"\)/);
   assert.match(controller, /@DeleteMapping\("\/api\/v1\/me\/favorites\/routes\/\{favoriteRouteId\}"\)/);


### PR DESCRIPTION
## 관련 이슈

close #250

## 작업 배경

- 즐겨찾기 경로는 사용자가 다시 이용할 이동 후보와 시설 상태 변경 알림 대상을 판단하는 기준 데이터입니다.
- 기존 경로 즐겨찾기 저장소는 개발용 인메모리 구현만 있어 운영 배포, 서버 재시작, 다중 인스턴스 환경에서 사용자 데이터가 유지되지 않습니다.

## 작업 내용

- `prod` 프로필 전용 `JdbcFavoriteRouteRepository`를 추가했습니다.
- 경로 검색 결과의 핵심 스칼라 값과 단계, 경고, 차단 사유를 저장해 임시 경로 검색 캐시와 분리했습니다.
- 출발역, 도착역, 환승 단계에 포함된 역을 `favorite_route_stations` 인덱스 테이블로 분리해 시설 상태 알림 대상 조회가 경로 JSON 파싱 없이 동작하게 했습니다.
- 운영 PostgreSQL 스키마에 `favorite_routes`, `favorite_route_stations` 테이블과 조회 인덱스를 추가했습니다.
- 저장소 계약 테스트에 JDBC 경로 즐겨찾기 저장소와 운영 스키마 검증을 추가했습니다.
- Codex CLI 리뷰 지적으로 확인한 PostgreSQL 중복 키 트랜잭션 문제를 `ON CONFLICT (user_id, route_search_id) DO UPDATE` upsert로 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "*JdbcFavoriteRouteRepositoryTest"`: RED 확인 후 성공
  - `node --test tools/ci/repository-contract.test.mjs`: upsert 계약 추가 후 RED 확인, 수정 후 성공, 41개 테스트 통과
  - `./gradlew test`: 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `README.md`, `.github/pull_request_template.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - GitHub Actions PR CI `27635640538`: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 성공
  - CodeRabbit: 한도/크레딧 부족으로 리뷰가 시작되지 않아 Codex CLI code review로 대체
  - Codex CLI code review: PostgreSQL 중복 키 트랜잭션 지적 1건을 inline review comment로 게시하고 `061b91608138ba7c07d205930db7dedbdb2c6f59`에서 수정

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `JdbcFavoriteRouteRepository.saveFavoriteRoute`가 운영 PostgreSQL에서는 단일 upsert로 저장하고, 테스트 H2에서는 동일 키 `MERGE` 경로로 검증되는지 여부
  - `favorite_route_stations`가 출발역, 도착역, 환승 단계의 역 식별자를 모두 포함하는지 여부
  - 경로 단계와 경고를 JSON으로 보존하는 방식이 현재 API 응답 계약과 맞는지 여부

## 리스크

- 이번 PR은 모바일 화면과 API 응답 형식을 바꾸지 않습니다.
- 경로 단계와 경고는 JSON 문자열로 저장하므로, 도메인 record 구조가 바뀌면 저장값 변환 호환성을 별도 검토해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
