### PR TITLE
[Feat] 시설 신고 영속 저장소 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
@@ -1,0 +1,262 @@
+package com.easysubway.report.adapter.out.persistence;
+
+import com.easysubway.report.application.port.out.LoadFacilityReportPort;
+import com.easysubway.report.application.port.out.SaveFacilityReportPort;
+import com.easysubway.report.domain.FacilityReport;
+import com.easysubway.report.domain.FacilityReportStatus;
+import com.easysubway.report.domain.FacilityReportType;
+import com.easysubway.user.application.port.out.AnonymizeUserFacilityReportPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("prod")
+public class JdbcFacilityReportRepository implements
+	LoadFacilityReportPort,
+	SaveFacilityReportPort,
+	AnonymizeUserFacilityReportPort {
+
+	private static final String DELETED_DESCRIPTION = "사용자 데이터 삭제로 신고 내용이 삭제되었습니다.";
+
+	private final JdbcTemplate jdbcTemplate;
+	private final DatabaseDialect databaseDialect;
+
+	@Autowired
+	public JdbcFacilityReportRepository(DataSource dataSource) {
+		this(new JdbcTemplate(dataSource));
+	}
+
+	JdbcFacilityReportRepository(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+		this.databaseDialect = detectDatabaseDialect(jdbcTemplate);
+	}
+
+	@Override
+	public Optional<FacilityReport> loadReport(String reportId) {
+		try {
+			return Optional.ofNullable(jdbcTemplate.queryForObject(
+				"""
+					SELECT report_id,
+						user_id,
+						station_id,
+						facility_id,
+						report_type,
+						description,
+						photo_file_name,
+						photo_content_type,
+						photo_data_base64,
+						latitude,
+						longitude,
+						duplicate_of_report_id,
+						status,
+						created_at,
+						reviewed_at,
+						reviewed_by
+					FROM facility_reports
+					WHERE report_id = ?
+					""",
+				this::mapFacilityReport,
+				reportId
+			));
+		} catch (EmptyResultDataAccessException exception) {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public List<FacilityReport> loadReports() {
+		return jdbcTemplate.query(
+			"""
+				SELECT report_id,
+					user_id,
+					station_id,
+					facility_id,
+					report_type,
+					description,
+					photo_file_name,
+					photo_content_type,
+					photo_data_base64,
+					latitude,
+					longitude,
+					duplicate_of_report_id,
+					status,
+					created_at,
+					reviewed_at,
+					reviewed_by
+				FROM facility_reports
+				ORDER BY created_at DESC, report_id ASC
+				""",
+			this::mapFacilityReport
+		);
+	}
+
+	@Override
+	public FacilityReport saveReport(FacilityReport report) {
+		upsertReport(report);
+		return report;
+	}
+
+	@Override
+	public int anonymizeFacilityReportsByUserId(String userId) {
+		return jdbcTemplate.update(
+			"""
+				UPDATE facility_reports
+				SET user_id = ?,
+					description = ?,
+					photo_file_name = NULL,
+					photo_content_type = NULL,
+					photo_data_base64 = NULL,
+					latitude = NULL,
+					longitude = NULL
+				WHERE user_id = ?
+				""",
+			FacilityReport.ANONYMIZED_USER_ID,
+			DELETED_DESCRIPTION,
+			userId
+		);
+	}
+
+	private void upsertReport(FacilityReport report) {
+		if (databaseDialect == DatabaseDialect.H2) {
+			upsertReportWithH2Merge(report);
+			return;
+		}
+		upsertReportWithPostgresql(report);
+	}
+
+	private void upsertReportWithPostgresql(FacilityReport report) {
+		// 검수 상태 갱신과 재저장을 같은 SQL 경로로 처리해 운영 저장소의 행 단위 일관성을 유지한다.
+		jdbcTemplate.update(
+			"""
+				INSERT INTO facility_reports (
+					report_id,
+					user_id,
+					station_id,
+					facility_id,
+					report_type,
+					description,
+					photo_file_name,
+					photo_content_type,
+					photo_data_base64,
+					latitude,
+					longitude,
+					duplicate_of_report_id,
+					status,
+					created_at,
+					reviewed_at,
+					reviewed_by
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT (report_id) DO UPDATE
+				SET user_id = EXCLUDED.user_id,
+					station_id = EXCLUDED.station_id,
+					facility_id = EXCLUDED.facility_id,
+					report_type = EXCLUDED.report_type,
+					description = EXCLUDED.description,
+					photo_file_name = EXCLUDED.photo_file_name,
+					photo_content_type = EXCLUDED.photo_content_type,
+					photo_data_base64 = EXCLUDED.photo_data_base64,
+					latitude = EXCLUDED.latitude,
+					longitude = EXCLUDED.longitude,
+					duplicate_of_report_id = EXCLUDED.duplicate_of_report_id,
+					status = EXCLUDED.status,
+					created_at = EXCLUDED.created_at,
+					reviewed_at = EXCLUDED.reviewed_at,
+					reviewed_by = EXCLUDED.reviewed_by
+				""",
+			reportParameters(report)
+		);
+	}
+
+	private void upsertReportWithH2Merge(FacilityReport report) {
+		jdbcTemplate.update(
+			"""
+				MERGE INTO facility_reports (
+					report_id,
+					user_id,
+					station_id,
+					facility_id,
+					report_type,
+					description,
+					photo_file_name,
+					photo_content_type,
+					photo_data_base64,
+					latitude,
+					longitude,
+					duplicate_of_report_id,
+					status,
+					created_at,
+					reviewed_at,
+					reviewed_by
+				)
+				KEY (report_id)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				""",
+			reportParameters(report)
+		);
+	}
+
+	private Object[] reportParameters(FacilityReport report) {
+		return new Object[] {
+			report.id(),
+			report.userId(),
+			report.stationId(),
+			report.facilityId(),
+			report.reportType().name(),
+			report.description(),
+			report.photoFileName(),
+			report.photoContentType(),
+			report.photoDataBase64(),
+			report.latitude(),
+			report.longitude(),
+			report.duplicateOfReportId(),
+			report.status().name(),
+			report.createdAt(),
+			report.reviewedAt(),
+			report.reviewedBy()
+		};
+	}
+
+	private FacilityReport mapFacilityReport(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new FacilityReport(
+			resultSet.getString("report_id"),
+			resultSet.getString("user_id"),
+			resultSet.getString("station_id"),
+			resultSet.getString("facility_id"),
+			FacilityReportType.valueOf(resultSet.getString("report_type")),
+			resultSet.getString("description"),
+			resultSet.getString("photo_file_name"),
+			resultSet.getString("photo_content_type"),
+			resultSet.getString("photo_data_base64"),
+			resultSet.getBigDecimal("latitude"),
+			resultSet.getBigDecimal("longitude"),
+			resultSet.getString("duplicate_of_report_id"),
+			FacilityReportStatus.valueOf(resultSet.getString("status")),
+			resultSet.getTimestamp("created_at").toLocalDateTime(),
+			resultSet.getTimestamp("reviewed_at") == null ? null : resultSet.getTimestamp("reviewed_at").toLocalDateTime(),
+			resultSet.getString("reviewed_by")
+		);
+	}
+
+	private DatabaseDialect detectDatabaseDialect(JdbcTemplate jdbcTemplate) {
+		DatabaseDialect dialect = jdbcTemplate.execute((ConnectionCallback<DatabaseDialect>) connection -> {
+			String productName = connection.getMetaData().getDatabaseProductName();
+			return "H2".equalsIgnoreCase(productName) ? DatabaseDialect.H2 : DatabaseDialect.POSTGRESQL;
+		});
+		return dialect == null ? DatabaseDialect.POSTGRESQL : dialect;
+	}
+
+	private enum DatabaseDialect {
+		POSTGRESQL,
+		H2
+	}
+}

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
@@ -127,7 +127,9 @@ public class JdbcFacilityReportRepository implements
 
 	private void upsertReport(FacilityReport report) {
 		if (databaseDialect == DatabaseDialect.H2) {
-			upsertReportWithH2Merge(report);
+			if (updateReportPreservingCreatedAt(report) == 0) {
+				insertReport(report);
+			}
 			return;
 		}
 		upsertReportWithPostgresql(report);
@@ -169,7 +171,6 @@ public class JdbcFacilityReportRepository implements
 					longitude = EXCLUDED.longitude,
 					duplicate_of_report_id = EXCLUDED.duplicate_of_report_id,
 					status = EXCLUDED.status,
-					created_at = EXCLUDED.created_at,
 					reviewed_at = EXCLUDED.reviewed_at,
 					reviewed_by = EXCLUDED.reviewed_by
 				""",
@@ -177,10 +178,48 @@ public class JdbcFacilityReportRepository implements
 		);
 	}
 
-	private void upsertReportWithH2Merge(FacilityReport report) {
+	private int updateReportPreservingCreatedAt(FacilityReport report) {
+		return jdbcTemplate.update(
+			"""
+				UPDATE facility_reports
+				SET user_id = ?,
+					station_id = ?,
+					facility_id = ?,
+					report_type = ?,
+					description = ?,
+					photo_file_name = ?,
+					photo_content_type = ?,
+					photo_data_base64 = ?,
+					latitude = ?,
+					longitude = ?,
+					duplicate_of_report_id = ?,
+					status = ?,
+					reviewed_at = ?,
+					reviewed_by = ?
+				WHERE report_id = ?
+				""",
+			report.userId(),
+			report.stationId(),
+			report.facilityId(),
+			report.reportType().name(),
+			report.description(),
+			report.photoFileName(),
+			report.photoContentType(),
+			report.photoDataBase64(),
+			report.latitude(),
+			report.longitude(),
+			report.duplicateOfReportId(),
+			report.status().name(),
+			report.reviewedAt(),
+			report.reviewedBy(),
+			report.id()
+		);
+	}
+
+	private void insertReport(FacilityReport report) {
 		jdbcTemplate.update(
 			"""
-				MERGE INTO facility_reports (
+				INSERT INTO facility_reports (
 					report_id,
 					user_id,
 					station_id,
@@ -198,7 +237,6 @@ public class JdbcFacilityReportRepository implements
 					reviewed_at,
 					reviewed_by
 				)
-				KEY (report_id)
 				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 				""",
 			reportParameters(report)

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -184,7 +184,14 @@ CREATE TABLE IF NOT EXISTS facility_reports (
 	status VARCHAR(40) NOT NULL,
 	created_at TIMESTAMP NOT NULL,
 	reviewed_at TIMESTAMP,
-	reviewed_by VARCHAR(120)
+	reviewed_by VARCHAR(120),
+	CONSTRAINT fk_facility_reports_duplicate
+		FOREIGN KEY (duplicate_of_report_id) REFERENCES facility_reports(report_id)
+		ON DELETE SET NULL ON UPDATE CASCADE,
+	CONSTRAINT chk_facility_reports_report_type
+		CHECK (report_type IN ('BROKEN', 'UNDER_CONSTRUCTION', 'CLOSED', 'LOCATION_WRONG', 'INFORMATION_WRONG', 'RECOVERED')),
+	CONSTRAINT chk_facility_reports_status
+		CHECK (status IN ('SUBMITTED', 'DUPLICATE', 'UNDER_REVIEW', 'ACCEPTED', 'REJECTED', 'RESOLVED'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_facility_reports_created

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -167,3 +167,31 @@ CREATE TABLE IF NOT EXISTS favorite_route_stations (
 
 CREATE INDEX IF NOT EXISTS idx_favorite_route_stations_station_user
 	ON favorite_route_stations (station_id, user_id);
+
+CREATE TABLE IF NOT EXISTS facility_reports (
+	report_id VARCHAR(120) NOT NULL PRIMARY KEY,
+	user_id VARCHAR(120) NOT NULL,
+	station_id VARCHAR(120) NOT NULL,
+	facility_id VARCHAR(120) NOT NULL,
+	report_type VARCHAR(40) NOT NULL,
+	description VARCHAR(1000),
+	photo_file_name VARCHAR(255),
+	photo_content_type VARCHAR(80),
+	photo_data_base64 TEXT,
+	latitude DECIMAL(10, 7),
+	longitude DECIMAL(10, 7),
+	duplicate_of_report_id VARCHAR(120),
+	status VARCHAR(40) NOT NULL,
+	created_at TIMESTAMP NOT NULL,
+	reviewed_at TIMESTAMP,
+	reviewed_by VARCHAR(120)
+);
+
+CREATE INDEX IF NOT EXISTS idx_facility_reports_created
+	ON facility_reports (created_at DESC, report_id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_facility_reports_user
+	ON facility_reports (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_facility_reports_status_created
+	ON facility_reports (status, created_at DESC, report_id ASC);

--- a/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
@@ -44,7 +44,14 @@ class JdbcFacilityReportRepositoryTest {
 				status VARCHAR(40) NOT NULL,
 				created_at TIMESTAMP NOT NULL,
 				reviewed_at TIMESTAMP,
-				reviewed_by VARCHAR(120)
+				reviewed_by VARCHAR(120),
+				CONSTRAINT fk_facility_reports_duplicate
+					FOREIGN KEY (duplicate_of_report_id) REFERENCES facility_reports(report_id)
+					ON DELETE SET NULL ON UPDATE CASCADE,
+				CONSTRAINT chk_facility_reports_report_type
+					CHECK (report_type IN ('BROKEN', 'UNDER_CONSTRUCTION', 'CLOSED', 'LOCATION_WRONG', 'INFORMATION_WRONG', 'RECOVERED')),
+				CONSTRAINT chk_facility_reports_status
+					CHECK (status IN ('SUBMITTED', 'DUPLICATE', 'UNDER_REVIEW', 'ACCEPTED', 'REJECTED', 'RESOLVED'))
 			)
 			""");
 		repository = new JdbcFacilityReportRepository(jdbcTemplate);
@@ -77,6 +84,7 @@ class JdbcFacilityReportRepositoryTest {
 	@Test
 	@DisplayName("이미 저장된 시설 신고는 검수 상태와 중복 신고 정보를 갱신한다")
 	void saveReportUpdatesExistingReport() {
+		repository.saveReport(submittedReport("report-0", "anonymous-user-2", 8));
 		repository.saveReport(submittedReport("report-1", "anonymous-user-1", 9));
 		var reviewedReport = reviewedReport("report-1");
 
@@ -86,8 +94,40 @@ class JdbcFacilityReportRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("사용자 데이터 삭제 요청은 신고 본문과 사진과 위치를 익명화한다")
-	void anonymizeFacilityReportsByUserIdClearsPersonalReportData() {
+	@DisplayName("이미 저장된 시설 신고 갱신은 최초 생성 시각을 유지한다")
+	void saveReportKeepsOriginalCreatedAtWhenUpdatingExistingReport() {
+		var originalReport = submittedReport("report-1", "anonymous-user-1", 9);
+		var updatedReport = new FacilityReport(
+			"report-1",
+			"anonymous-user-1",
+			"station-sangnoksu",
+			"facility-elevator-1",
+			FacilityReportType.BROKEN,
+			"엘리베이터가 다시 움직이지 않습니다.",
+			"elevator-updated.jpg",
+			"image/jpeg",
+			"dXBkYXRlZC1pbWFnZQ==",
+			new BigDecimal("37.3123450"),
+			new BigDecimal("126.9876540"),
+			null,
+			FacilityReportStatus.UNDER_REVIEW,
+			LocalDateTime.of(2026, 6, 17, 11, 0),
+			LocalDateTime.of(2026, 6, 17, 11, 10),
+			"admin-user"
+		);
+		repository.saveReport(originalReport);
+
+		repository.saveReport(updatedReport);
+
+		FacilityReport savedReport = repository.loadReport("report-1").orElseThrow();
+		assertThat(savedReport.createdAt()).isEqualTo(originalReport.createdAt());
+		assertThat(savedReport.status()).isEqualTo(FacilityReportStatus.UNDER_REVIEW);
+		assertThat(savedReport.reviewedAt()).isEqualTo(updatedReport.reviewedAt());
+	}
+
+	@Test
+	@DisplayName("사용자 데이터 삭제 요청은 미검수 신고 본문과 사진과 위치를 익명화한다")
+	void anonymizeFacilityReportsByUserIdClearsSubmittedReportPersonalData() {
 		var targetReport = submittedReport("report-1", "anonymous-user-1", 9);
 		var otherUserReport = submittedReport("report-2", "anonymous-user-2", 10);
 		repository.saveReport(targetReport);
@@ -117,6 +157,28 @@ class JdbcFacilityReportRepositoryTest {
 			targetReport.reviewedBy()
 		));
 		assertThat(repository.loadReport("report-2")).contains(otherUserReport);
+	}
+
+	@Test
+	@DisplayName("사용자 데이터 삭제 요청은 검수 완료 신고의 검수 정보를 유지한다")
+	void anonymizeFacilityReportsByUserIdKeepsReviewedReportMetadata() {
+		repository.saveReport(submittedReport("report-0", "anonymous-user-2", 8));
+		var targetReport = reviewedReport("report-1");
+		repository.saveReport(targetReport);
+
+		int anonymizedCount = repository.anonymizeFacilityReportsByUserId("anonymous-user-1");
+
+		assertThat(anonymizedCount).isEqualTo(1);
+		FacilityReport anonymizedReport = repository.loadReport("report-1").orElseThrow();
+		assertThat(anonymizedReport.userId()).isEqualTo(FacilityReport.ANONYMIZED_USER_ID);
+		assertThat(anonymizedReport.description()).isEqualTo("사용자 데이터 삭제로 신고 내용이 삭제되었습니다.");
+		assertThat(anonymizedReport.photoDataBase64()).isNull();
+		assertThat(anonymizedReport.latitude()).isNull();
+		assertThat(anonymizedReport.longitude()).isNull();
+		assertThat(anonymizedReport.duplicateOfReportId()).isEqualTo(targetReport.duplicateOfReportId());
+		assertThat(anonymizedReport.status()).isEqualTo(targetReport.status());
+		assertThat(anonymizedReport.reviewedAt()).isEqualTo(targetReport.reviewedAt());
+		assertThat(anonymizedReport.reviewedBy()).isEqualTo(targetReport.reviewedBy());
 	}
 
 	private FacilityReport submittedReport(String reportId, String userId, int hour) {

--- a/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
@@ -1,0 +1,163 @@
+package com.easysubway.report.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.report.domain.FacilityReport;
+import com.easysubway.report.domain.FacilityReportStatus;
+import com.easysubway.report.domain.FacilityReportType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("JDBC 시설 신고 저장소")
+class JdbcFacilityReportRepositoryTest {
+
+	private JdbcFacilityReportRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:facility-reports;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS facility_reports");
+		jdbcTemplate.execute("""
+			CREATE TABLE facility_reports (
+				report_id VARCHAR(120) NOT NULL PRIMARY KEY,
+				user_id VARCHAR(120) NOT NULL,
+				station_id VARCHAR(120) NOT NULL,
+				facility_id VARCHAR(120) NOT NULL,
+				report_type VARCHAR(40) NOT NULL,
+				description VARCHAR(1000),
+				photo_file_name VARCHAR(255),
+				photo_content_type VARCHAR(80),
+				photo_data_base64 TEXT,
+				latitude DECIMAL(10, 7),
+				longitude DECIMAL(10, 7),
+				duplicate_of_report_id VARCHAR(120),
+				status VARCHAR(40) NOT NULL,
+				created_at TIMESTAMP NOT NULL,
+				reviewed_at TIMESTAMP,
+				reviewed_by VARCHAR(120)
+			)
+			""");
+		repository = new JdbcFacilityReportRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("시설 신고를 저장하고 신고 식별자로 조회한다")
+	void saveFacilityReportAndLoadByReportId() {
+		var report = submittedReport("report-1", "anonymous-user-1", 9);
+
+		repository.saveReport(report);
+
+		assertThat(repository.loadReport("report-1")).contains(report);
+	}
+
+	@Test
+	@DisplayName("시설 신고 목록은 생성 시각 최신순과 신고 식별자 순서로 조회한다")
+	void loadReportsOrdersByCreatedAtDescAndReportId() {
+		var olderReport = submittedReport("report-2", "anonymous-user-1", 8);
+		var sameTimeSecondReport = submittedReport("report-3", "anonymous-user-2", 9);
+		var sameTimeFirstReport = submittedReport("report-1", "anonymous-user-3", 9);
+		repository.saveReport(olderReport);
+		repository.saveReport(sameTimeSecondReport);
+		repository.saveReport(sameTimeFirstReport);
+
+		assertThat(repository.loadReports())
+			.containsExactly(sameTimeFirstReport, sameTimeSecondReport, olderReport);
+	}
+
+	@Test
+	@DisplayName("이미 저장된 시설 신고는 검수 상태와 중복 신고 정보를 갱신한다")
+	void saveReportUpdatesExistingReport() {
+		repository.saveReport(submittedReport("report-1", "anonymous-user-1", 9));
+		var reviewedReport = reviewedReport("report-1");
+
+		repository.saveReport(reviewedReport);
+
+		assertThat(repository.loadReport("report-1")).contains(reviewedReport);
+	}
+
+	@Test
+	@DisplayName("사용자 데이터 삭제 요청은 신고 본문과 사진과 위치를 익명화한다")
+	void anonymizeFacilityReportsByUserIdClearsPersonalReportData() {
+		var targetReport = submittedReport("report-1", "anonymous-user-1", 9);
+		var otherUserReport = submittedReport("report-2", "anonymous-user-2", 10);
+		repository.saveReport(targetReport);
+		repository.saveReport(otherUserReport);
+
+		int anonymizedCount = repository.anonymizeFacilityReportsByUserId("anonymous-user-1");
+		int anonymizedAgainCount = repository.anonymizeFacilityReportsByUserId("anonymous-user-1");
+
+		assertThat(anonymizedCount).isEqualTo(1);
+		assertThat(anonymizedAgainCount).isZero();
+		assertThat(repository.loadReport("report-1")).contains(new FacilityReport(
+			"report-1",
+			FacilityReport.ANONYMIZED_USER_ID,
+			targetReport.stationId(),
+			targetReport.facilityId(),
+			targetReport.reportType(),
+			"사용자 데이터 삭제로 신고 내용이 삭제되었습니다.",
+			null,
+			null,
+			null,
+			null,
+			null,
+			targetReport.duplicateOfReportId(),
+			targetReport.status(),
+			targetReport.createdAt(),
+			targetReport.reviewedAt(),
+			targetReport.reviewedBy()
+		));
+		assertThat(repository.loadReport("report-2")).contains(otherUserReport);
+	}
+
+	private FacilityReport submittedReport(String reportId, String userId, int hour) {
+		return new FacilityReport(
+			reportId,
+			userId,
+			"station-sangnoksu",
+			"facility-elevator-1",
+			FacilityReportType.BROKEN,
+			"엘리베이터가 멈춰 있습니다.",
+			"elevator.jpg",
+			"image/jpeg",
+			"aW1hZ2UtYnl0ZXM=",
+			new BigDecimal("37.3123450"),
+			new BigDecimal("126.9876540"),
+			null,
+			FacilityReportStatus.SUBMITTED,
+			LocalDateTime.of(2026, 6, 17, hour, 0),
+			null,
+			null
+		);
+	}
+
+	private FacilityReport reviewedReport(String reportId) {
+		return new FacilityReport(
+			reportId,
+			"anonymous-user-1",
+			"station-sangnoksu",
+			"facility-elevator-1",
+			FacilityReportType.BROKEN,
+			"엘리베이터가 멈춰 있습니다.",
+			"elevator.jpg",
+			"image/jpeg",
+			"aW1hZ2UtYnl0ZXM=",
+			new BigDecimal("37.3123450"),
+			new BigDecimal("126.9876540"),
+			"report-0",
+			FacilityReportStatus.DUPLICATE,
+			LocalDateTime.of(2026, 6, 17, 9, 0),
+			LocalDateTime.of(2026, 6, 17, 10, 0),
+			"admin-user"
+		);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -877,8 +877,15 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(jdbcRepository, /FacilityReport\.ANONYMIZED_USER_ID/);
   assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS facility_reports/);
   assert.match(batchPostgresSchema, /photo_data_base64 TEXT/);
+  assert.match(batchPostgresSchema, /CONSTRAINT fk_facility_reports_duplicate/);
+  assert.match(batchPostgresSchema, /FOREIGN KEY \(duplicate_of_report_id\) REFERENCES facility_reports\(report_id\)/);
+  assert.match(batchPostgresSchema, /CONSTRAINT chk_facility_reports_report_type/);
+  assert.match(batchPostgresSchema, /CHECK \(report_type IN \('BROKEN', 'UNDER_CONSTRUCTION', 'CLOSED', 'LOCATION_WRONG', 'INFORMATION_WRONG', 'RECOVERED'\)\)/);
+  assert.match(batchPostgresSchema, /CONSTRAINT chk_facility_reports_status/);
+  assert.match(batchPostgresSchema, /CHECK \(status IN \('SUBMITTED', 'DUPLICATE', 'UNDER_REVIEW', 'ACCEPTED', 'REJECTED', 'RESOLVED'\)\)/);
   assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_facility_reports_created/);
   assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_facility_reports_user/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_facility_reports_status_created/);
   assert.match(transitRepository, /implements LoadTransitMasterPort, SaveAccessibilityFacilityStatusPort/);
   assert.match(transitRepository, /saveFacilityStatus\(String facilityId, AccessibilityFacilityStatus status, LocalDate updatedAt\)/);
   assert.match(controller, /@PostMapping\("\/api\/v1\/reports"\)/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -823,9 +823,11 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   );
   const service = read("backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java");
   const repository = read("backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java");
+  const jdbcRepository = read("backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java");
   const transitRepository = read(
     "backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java",
   );
+  const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
   const controller = read("backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java");
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
 
@@ -865,6 +867,18 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(service, /FacilityReportStatus\.DUPLICATE/);
   assert.match(repository, /implements[\s\S]*LoadFacilityReportPort[\s\S]*SaveFacilityReportPort/);
   assert.match(repository, /List<FacilityReport> loadReports\(\)/);
+  assert.match(jdbcRepository, /@Profile\("prod"\)/);
+  assert.match(jdbcRepository, /implements[\s\S]*LoadFacilityReportPort[\s\S]*SaveFacilityReportPort[\s\S]*AnonymizeUserFacilityReportPort/);
+  assert.match(jdbcRepository, /Optional<FacilityReport> loadReport\(String reportId\)/);
+  assert.match(jdbcRepository, /List<FacilityReport> loadReports\(\)/);
+  assert.match(jdbcRepository, /FacilityReport saveReport\(FacilityReport report\)/);
+  assert.match(jdbcRepository, /int anonymizeFacilityReportsByUserId\(String userId\)/);
+  assert.match(jdbcRepository, /ON CONFLICT \(report_id\) DO UPDATE/);
+  assert.match(jdbcRepository, /FacilityReport\.ANONYMIZED_USER_ID/);
+  assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS facility_reports/);
+  assert.match(batchPostgresSchema, /photo_data_base64 TEXT/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_facility_reports_created/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_facility_reports_user/);
   assert.match(transitRepository, /implements LoadTransitMasterPort, SaveAccessibilityFacilityStatusPort/);
   assert.match(transitRepository, /saveFacilityStatus\(String facilityId, AccessibilityFacilityStatus status, LocalDate updatedAt\)/);
   assert.match(controller, /@PostMapping\("\/api\/v1\/reports"\)/);


### PR DESCRIPTION
## 관련 이슈

close #252

## 작업 배경

- 시설 신고는 엘리베이터 고장, 출구 폐쇄, 위치 오류 같은 현장 정보를 보완하는 핵심 데이터입니다.
- 개발용 인메모리 저장소만 사용하면 서버 재시작이나 다중 인스턴스 환경에서 신고 본문, 사진, 위치, 관리자 검수 상태가 유지되지 않습니다.

## 작업 내용

- `prod` 프로필 전용 `JdbcFacilityReportRepository`를 추가했습니다.
- 신고 본문, 사진 파일 정보, 사진 base64 본문, 위치 좌표, 중복 신고 식별자, 검수 상태와 검수자를 저장하고 조회하도록 했습니다.
- 신고 목록 조회가 `created_at DESC, report_id ASC` 기준으로 안정적으로 정렬되게 했습니다.
- 사용자 데이터 삭제 요청 시 신고 본문, 사진, 좌표를 제거하고 익명 사용자 식별자로 바꾸도록 구현했습니다.
- 운영 PostgreSQL 스키마에 `facility_reports` 테이블과 목록/사용자/상태 조회 인덱스를 추가했습니다.
- 중복 신고 참조 FK와 신고 유형/상태 CHECK 제약을 추가해 잘못된 운영 데이터가 도메인 enum 역직렬화 실패로 이어지지 않게 했습니다.
- 저장소 계약 테스트에 운영 시설 신고 저장소, DDL 제약, 상태 조회 인덱스 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "*JdbcFacilityReportRepositoryTest"`: RED 확인 후 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 성공, 41개 테스트 통과
  - `./gradlew test`: 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `README.md`, `.github/pull_request_template.md`만 추적 확인
  - GitHub Actions PR CI `27637339911`: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 모두 성공
  - CodeRabbit 리뷰: actionable comment 5개 확인, `61b49f4`에서 수정 후 스레드 resolve
  - GitHub Actions main CI `27637644934`: merge commit `9f8fcd5` 기준 성공
  - GitHub Actions main CD `27637644959`: merge commit `9f8fcd5` 기준 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `JdbcFacilityReportRepository.saveReport`의 PostgreSQL upsert가 기존 `created_at`을 보존하는지 여부
  - `anonymizeFacilityReportsByUserId`가 본문, 사진, 좌표만 제거하고 운영 검수 상태는 유지하는지 여부
  - `facility_reports` FK, CHECK 제약, 상태 조회 인덱스가 운영 데이터 무결성과 조회 패턴에 충분한지 여부

## 리스크

- 사진 본문은 현재 API 계약에 맞춰 base64 문자열로 DB에 저장합니다. object storage 분리는 별도 작업에서 검토해야 합니다.
- 검수 감사 이력 저장소는 이번 변경 범위에 포함하지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (해당 없음: CodeRabbit 리뷰 완료)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 시설 신고 저장 및 조회 기능 추가
  * 신고 검수 상태 업데이트 기능 추가
  * 사용자 개인정보 삭제 요청 시 신고 익명화 기능 추가

* **Tests**
  * 시설 신고 저장 및 조회 동작 검증 테스트 추가
  * 신고 익명화 기능 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
