### PR TITLE
[Feat] 알림 영속 저장소 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcNotificationPreferenceRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcNotificationPreferenceRepository.java
@@ -1,0 +1,221 @@
+package com.easysubway.notification.adapter.out.persistence;
+
+import com.easysubway.notification.application.port.out.LoadNotificationPreferencePort;
+import com.easysubway.notification.application.port.out.SaveNotificationSettingsPort;
+import com.easysubway.notification.application.port.out.SaveRegisteredDevicePort;
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.NotificationSettings;
+import com.easysubway.notification.domain.RegisteredDevice;
+import com.easysubway.user.application.port.out.DeleteUserNotificationPreferencePort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Profile("prod")
+public class JdbcNotificationPreferenceRepository implements
+	LoadNotificationPreferencePort,
+	SaveRegisteredDevicePort,
+	SaveNotificationSettingsPort,
+	DeleteUserNotificationPreferencePort {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public JdbcNotificationPreferenceRepository(DataSource dataSource) {
+		this(new JdbcTemplate(dataSource));
+	}
+
+	JdbcNotificationPreferenceRepository(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public Optional<NotificationSettings> loadNotificationSettings(String userId) {
+		try {
+			return Optional.ofNullable(jdbcTemplate.queryForObject(
+				"""
+					SELECT user_id,
+						favorite_station_facility_alerts,
+						favorite_route_facility_alerts,
+						report_status_alerts,
+						data_quality_alerts,
+						updated_at
+					FROM notification_settings
+					WHERE user_id = ?
+					""",
+				this::mapNotificationSettings,
+				userId
+			));
+		} catch (EmptyResultDataAccessException exception) {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public List<RegisteredDevice> loadDevices(String userId) {
+		return jdbcTemplate.query(
+			"""
+				SELECT user_id,
+					platform,
+					device_token,
+					registered_at
+				FROM registered_devices
+				WHERE user_id = ?
+				ORDER BY registered_at ASC, device_token ASC
+				""",
+			this::mapRegisteredDevice,
+			userId
+		);
+	}
+
+	@Override
+	@Transactional
+	public RegisteredDevice saveRegisteredDevice(RegisteredDevice device) {
+		// 같은 물리 기기가 여러 사용자에게 중복 발송되지 않도록 플랫폼/토큰 단위로 소유자를 하나만 둔다.
+		if (updateRegisteredDeviceOwner(device) == 0) {
+			try {
+				insertRegisteredDevice(device);
+			} catch (DuplicateKeyException exception) {
+				updateRegisteredDeviceOwner(device);
+			}
+		}
+		return device;
+	}
+
+	@Override
+	public NotificationSettings saveNotificationSettings(NotificationSettings settings) {
+		if (updateNotificationSettings(settings) == 0) {
+			try {
+				insertNotificationSettings(settings);
+			} catch (DuplicateKeyException exception) {
+				updateNotificationSettings(settings);
+			}
+		}
+		return settings;
+	}
+
+	@Override
+	public boolean deleteNotificationSettings(String userId) {
+		return jdbcTemplate.update(
+			"""
+				DELETE FROM notification_settings
+				WHERE user_id = ?
+				""",
+			userId
+		) > 0;
+	}
+
+	@Override
+	public int deleteRegisteredDevices(String userId) {
+		return jdbcTemplate.update(
+			"""
+				DELETE FROM registered_devices
+				WHERE user_id = ?
+				""",
+			userId
+		);
+	}
+
+	private int updateNotificationSettings(NotificationSettings settings) {
+		return jdbcTemplate.update(
+			"""
+				UPDATE notification_settings
+				SET favorite_station_facility_alerts = ?,
+					favorite_route_facility_alerts = ?,
+					report_status_alerts = ?,
+					data_quality_alerts = ?,
+					updated_at = ?
+				WHERE user_id = ?
+				""",
+			settings.favoriteStationFacilityAlerts(),
+			settings.favoriteRouteFacilityAlerts(),
+			settings.reportStatusAlerts(),
+			settings.dataQualityAlerts(),
+			settings.updatedAt(),
+			settings.userId()
+		);
+	}
+
+	private void insertNotificationSettings(NotificationSettings settings) {
+		jdbcTemplate.update(
+			"""
+				INSERT INTO notification_settings (
+					user_id,
+					favorite_station_facility_alerts,
+					favorite_route_facility_alerts,
+					report_status_alerts,
+					data_quality_alerts,
+					updated_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?)
+				""",
+			settings.userId(),
+			settings.favoriteStationFacilityAlerts(),
+			settings.favoriteRouteFacilityAlerts(),
+			settings.reportStatusAlerts(),
+			settings.dataQualityAlerts(),
+			settings.updatedAt()
+		);
+	}
+
+	private void insertRegisteredDevice(RegisteredDevice device) {
+		jdbcTemplate.update(
+			"""
+				INSERT INTO registered_devices (
+					user_id,
+					platform,
+					device_token,
+					registered_at
+				)
+				VALUES (?, ?, ?, ?)
+				""",
+			device.userId(),
+			device.platform().name(),
+			device.deviceToken(),
+			device.registeredAt()
+		);
+	}
+
+	private int updateRegisteredDeviceOwner(RegisteredDevice device) {
+		return jdbcTemplate.update(
+			"""
+				UPDATE registered_devices
+				SET user_id = ?,
+					registered_at = ?
+				WHERE platform = ? AND device_token = ?
+				""",
+			device.userId(),
+			device.registeredAt(),
+			device.platform().name(),
+			device.deviceToken()
+		);
+	}
+
+	private NotificationSettings mapNotificationSettings(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new NotificationSettings(
+			resultSet.getString("user_id"),
+			resultSet.getBoolean("favorite_station_facility_alerts"),
+			resultSet.getBoolean("favorite_route_facility_alerts"),
+			resultSet.getBoolean("report_status_alerts"),
+			resultSet.getBoolean("data_quality_alerts"),
+			resultSet.getTimestamp("updated_at").toLocalDateTime()
+		);
+	}
+
+	private RegisteredDevice mapRegisteredDevice(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new RegisteredDevice(
+			resultSet.getString("user_id"),
+			DevicePlatform.valueOf(resultSet.getString("platform")),
+			resultSet.getString("device_token"),
+			resultSet.getTimestamp("registered_at").toLocalDateTime()
+		);
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcNotificationPreferenceRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcNotificationPreferenceRepository.java
@@ -15,6 +15,7 @@ import javax.sql.DataSource;
 import org.springframework.context.annotation.Profile;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +29,7 @@ public class JdbcNotificationPreferenceRepository implements
 	DeleteUserNotificationPreferencePort {
 
 	private final JdbcTemplate jdbcTemplate;
+	private final DatabaseDialect databaseDialect;
 
 	public JdbcNotificationPreferenceRepository(DataSource dataSource) {
 		this(new JdbcTemplate(dataSource));
@@ -35,6 +37,7 @@ public class JdbcNotificationPreferenceRepository implements
 
 	JdbcNotificationPreferenceRepository(JdbcTemplate jdbcTemplate) {
 		this.jdbcTemplate = jdbcTemplate;
+		this.databaseDialect = detectDatabaseDialect(jdbcTemplate);
 	}
 
 	@Override
@@ -79,15 +82,40 @@ public class JdbcNotificationPreferenceRepository implements
 	@Override
 	@Transactional
 	public RegisteredDevice saveRegisteredDevice(RegisteredDevice device) {
-		// 같은 물리 기기가 여러 사용자에게 중복 발송되지 않도록 플랫폼/토큰 단위로 소유자를 하나만 둔다.
-		if (updateRegisteredDeviceOwner(device) == 0) {
-			try {
-				insertRegisteredDevice(device);
-			} catch (DuplicateKeyException exception) {
-				updateRegisteredDeviceOwner(device);
-			}
+		if (databaseDialect == DatabaseDialect.POSTGRESQL) {
+			upsertRegisteredDeviceWithPostgresql(device);
+			return device;
 		}
+		saveRegisteredDeviceWithUpdateInsert(device);
 		return device;
+	}
+
+	private void upsertRegisteredDeviceWithPostgresql(RegisteredDevice device) {
+		// 같은 물리 기기가 여러 사용자에게 중복 발송되지 않도록 플랫폼/토큰 단위로 소유자를 하나만 둔다.
+		jdbcTemplate.update(
+			"""
+				INSERT INTO registered_devices (
+					user_id,
+					platform,
+					device_token,
+					registered_at
+				)
+				VALUES (?, ?, ?, ?)
+				ON CONFLICT (platform, device_token) DO UPDATE
+				SET user_id = EXCLUDED.user_id,
+					registered_at = EXCLUDED.registered_at
+				""",
+			device.userId(),
+			device.platform().name(),
+			device.deviceToken(),
+			device.registeredAt()
+		);
+	}
+
+	private void saveRegisteredDeviceWithUpdateInsert(RegisteredDevice device) {
+		if (updateRegisteredDeviceOwner(device) == 0) {
+			insertRegisteredDevice(device);
+		}
 	}
 
 	@Override
@@ -217,5 +245,18 @@ public class JdbcNotificationPreferenceRepository implements
 			resultSet.getString("device_token"),
 			resultSet.getTimestamp("registered_at").toLocalDateTime()
 		);
+	}
+
+	private DatabaseDialect detectDatabaseDialect(JdbcTemplate jdbcTemplate) {
+		DatabaseDialect dialect = jdbcTemplate.execute((ConnectionCallback<DatabaseDialect>) connection -> {
+			String productName = connection.getMetaData().getDatabaseProductName();
+			return "H2".equalsIgnoreCase(productName) ? DatabaseDialect.H2 : DatabaseDialect.POSTGRESQL;
+		});
+		return dialect == null ? DatabaseDialect.POSTGRESQL : dialect;
+	}
+
+	private enum DatabaseDialect {
+		POSTGRESQL,
+		H2
 	}
 }

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
@@ -1,0 +1,148 @@
+package com.easysubway.notification.adapter.out.persistence;
+
+import com.easysubway.notification.application.port.out.LoadPushNotificationOutboxPort;
+import com.easysubway.notification.application.port.out.SavePushNotificationOutboxPort;
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import com.easysubway.notification.domain.PushNotificationType;
+import com.easysubway.user.application.port.out.DeleteUserPushNotificationPort;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("prod")
+public class JdbcPushNotificationOutboxRepository implements
+	LoadPushNotificationOutboxPort,
+	SavePushNotificationOutboxPort,
+	DeleteUserPushNotificationPort {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public JdbcPushNotificationOutboxRepository(DataSource dataSource) {
+		this(new JdbcTemplate(dataSource));
+	}
+
+	JdbcPushNotificationOutboxRepository(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public List<PushNotification> loadPushNotifications(String userId) {
+		return jdbcTemplate.query(
+			"""
+				SELECT notification_id,
+					user_id,
+					platform,
+					device_token,
+					notification_type,
+					title,
+					body,
+					status,
+					created_at
+				FROM push_notification_outbox
+				WHERE user_id = ?
+				ORDER BY created_at ASC, notification_id ASC
+				""",
+			this::mapPushNotification,
+			userId
+		);
+	}
+
+	@Override
+	public PushNotification savePushNotification(PushNotification notification) {
+		if (updatePushNotification(notification) == 0) {
+			try {
+				insertPushNotification(notification);
+			} catch (DuplicateKeyException exception) {
+				updatePushNotification(notification);
+			}
+		}
+		return notification;
+	}
+
+	@Override
+	public int deletePushNotifications(String userId) {
+		return jdbcTemplate.update(
+			"""
+				DELETE FROM push_notification_outbox
+				WHERE user_id = ?
+				""",
+			userId
+		);
+	}
+
+	private int updatePushNotification(PushNotification notification) {
+		return jdbcTemplate.update(
+			"""
+				UPDATE push_notification_outbox
+				SET user_id = ?,
+					platform = ?,
+					device_token = ?,
+					notification_type = ?,
+					title = ?,
+					body = ?,
+					status = ?,
+					created_at = ?
+				WHERE notification_id = ?
+				""",
+			notification.userId(),
+			notification.platform().name(),
+			notification.deviceToken(),
+			notification.type().name(),
+			notification.title(),
+			notification.body(),
+			notification.status().name(),
+			notification.createdAt(),
+			notification.notificationId()
+		);
+	}
+
+	private void insertPushNotification(PushNotification notification) {
+		jdbcTemplate.update(
+			"""
+				INSERT INTO push_notification_outbox (
+					notification_id,
+					user_id,
+					platform,
+					device_token,
+					notification_type,
+					title,
+					body,
+					status,
+					created_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+				""",
+			notification.notificationId(),
+			notification.userId(),
+			notification.platform().name(),
+			notification.deviceToken(),
+			notification.type().name(),
+			notification.title(),
+			notification.body(),
+			notification.status().name(),
+			notification.createdAt()
+		);
+	}
+
+	private PushNotification mapPushNotification(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new PushNotification(
+			resultSet.getString("notification_id"),
+			resultSet.getString("user_id"),
+			DevicePlatform.valueOf(resultSet.getString("platform")),
+			resultSet.getString("device_token"),
+			PushNotificationType.valueOf(resultSet.getString("notification_type")),
+			resultSet.getString("title"),
+			resultSet.getString("body"),
+			PushNotificationStatus.valueOf(resultSet.getString("status")),
+			resultSet.getTimestamp("created_at").toLocalDateTime()
+		);
+	}
+}

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -202,3 +202,50 @@ CREATE INDEX IF NOT EXISTS idx_facility_reports_user
 
 CREATE INDEX IF NOT EXISTS idx_facility_reports_status_created
 	ON facility_reports (status, created_at DESC, report_id ASC);
+
+CREATE TABLE IF NOT EXISTS notification_settings (
+	user_id VARCHAR(120) NOT NULL PRIMARY KEY,
+	favorite_station_facility_alerts BOOLEAN NOT NULL,
+	favorite_route_facility_alerts BOOLEAN NOT NULL,
+	report_status_alerts BOOLEAN NOT NULL,
+	data_quality_alerts BOOLEAN NOT NULL,
+	updated_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_settings_updated
+	ON notification_settings (updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS registered_devices (
+	user_id VARCHAR(120) NOT NULL,
+	platform VARCHAR(20) NOT NULL,
+	device_token VARCHAR(255) NOT NULL,
+	registered_at TIMESTAMP NOT NULL,
+	PRIMARY KEY (user_id, platform, device_token),
+	CONSTRAINT uq_registered_devices_platform_token UNIQUE (platform, device_token),
+	CONSTRAINT chk_registered_devices_platform
+		CHECK (platform IN ('ANDROID', 'IOS'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_registered_devices_user_registered
+	ON registered_devices (user_id, registered_at ASC, device_token ASC);
+
+CREATE TABLE IF NOT EXISTS push_notification_outbox (
+	notification_id VARCHAR(120) NOT NULL PRIMARY KEY,
+	user_id VARCHAR(120) NOT NULL,
+	platform VARCHAR(20) NOT NULL,
+	device_token VARCHAR(255) NOT NULL,
+	notification_type VARCHAR(60) NOT NULL,
+	title VARCHAR(120) NOT NULL,
+	body VARCHAR(1000) NOT NULL,
+	status VARCHAR(40) NOT NULL,
+	created_at TIMESTAMP NOT NULL,
+	CONSTRAINT chk_push_notification_outbox_platform
+		CHECK (platform IN ('ANDROID', 'IOS')),
+	CONSTRAINT chk_push_notification_outbox_type
+		CHECK (notification_type IN ('FAVORITE_STATION_FACILITY', 'FAVORITE_ROUTE_FACILITY', 'REPORT_STATUS', 'DATA_QUALITY')),
+	CONSTRAINT chk_push_notification_outbox_status
+		CHECK (status IN ('PENDING'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_notification_outbox_user_created
+	ON push_notification_outbox (user_id, created_at ASC, notification_id ASC);

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcNotificationPreferenceRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcNotificationPreferenceRepositoryTest.java
@@ -1,0 +1,154 @@
+package com.easysubway.notification.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.NotificationSettings;
+import com.easysubway.notification.domain.RegisteredDevice;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("JDBC 알림 설정 저장소")
+class JdbcNotificationPreferenceRepositoryTest {
+
+	private JdbcNotificationPreferenceRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:notification-preferences;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS registered_devices");
+		jdbcTemplate.execute("DROP TABLE IF EXISTS notification_settings");
+		jdbcTemplate.execute("""
+			CREATE TABLE notification_settings (
+				user_id VARCHAR(120) NOT NULL PRIMARY KEY,
+				favorite_station_facility_alerts BOOLEAN NOT NULL,
+				favorite_route_facility_alerts BOOLEAN NOT NULL,
+				report_status_alerts BOOLEAN NOT NULL,
+				data_quality_alerts BOOLEAN NOT NULL,
+				updated_at TIMESTAMP NOT NULL
+			)
+			""");
+		jdbcTemplate.execute("""
+			CREATE TABLE registered_devices (
+				user_id VARCHAR(120) NOT NULL,
+				platform VARCHAR(20) NOT NULL,
+				device_token VARCHAR(255) NOT NULL,
+				registered_at TIMESTAMP NOT NULL,
+				PRIMARY KEY (user_id, platform, device_token),
+				CONSTRAINT uq_registered_devices_platform_token UNIQUE (platform, device_token),
+				CONSTRAINT chk_registered_devices_platform CHECK (platform IN ('ANDROID', 'IOS'))
+			)
+			""");
+		repository = new JdbcNotificationPreferenceRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("알림 설정을 저장하고 사용자 식별자로 조회한다")
+	void saveNotificationSettingsAndLoadByUserId() {
+		var settings = settings("anonymous-user-1", true, false, true, false, 9);
+
+		repository.saveNotificationSettings(settings);
+
+		assertThat(repository.loadNotificationSettings("anonymous-user-1")).contains(settings);
+	}
+
+	@Test
+	@DisplayName("같은 사용자의 알림 설정은 한 행만 갱신한다")
+	void saveNotificationSettingsUpdatesExistingSettings() {
+		repository.saveNotificationSettings(settings("anonymous-user-1", true, true, true, false, 9));
+		var updatedSettings = settings("anonymous-user-1", false, true, false, true, 10);
+
+		repository.saveNotificationSettings(updatedSettings);
+
+		assertThat(repository.loadNotificationSettings("anonymous-user-1")).contains(updatedSettings);
+	}
+
+	@Test
+	@DisplayName("등록 기기는 사용자별 등록 시각과 토큰 순서로 조회한다")
+	void loadDevicesOrdersByRegisteredAtAndDeviceToken() {
+		var laterDevice = device("anonymous-user-1", DevicePlatform.ANDROID, "token-c", 10);
+		var secondDevice = device("anonymous-user-1", DevicePlatform.IOS, "token-b", 9);
+		var firstDevice = device("anonymous-user-1", DevicePlatform.ANDROID, "token-a", 9);
+		repository.saveRegisteredDevice(laterDevice);
+		repository.saveRegisteredDevice(secondDevice);
+		repository.saveRegisteredDevice(firstDevice);
+		repository.saveRegisteredDevice(device("anonymous-user-2", DevicePlatform.IOS, "token-d", 8));
+
+		assertThat(repository.loadDevices("anonymous-user-1"))
+			.containsExactly(firstDevice, secondDevice, laterDevice);
+	}
+
+	@Test
+	@DisplayName("같은 기기 토큰은 마지막으로 등록한 사용자에게만 연결된다")
+	void saveRegisteredDeviceMovesTokenToLatestUser() {
+		repository.saveRegisteredDevice(device("anonymous-user-1", DevicePlatform.ANDROID, "shared-token", 9));
+		var latestDevice = device("anonymous-user-2", DevicePlatform.ANDROID, "shared-token", 10);
+
+		repository.saveRegisteredDevice(latestDevice);
+
+		assertThat(repository.loadDevices("anonymous-user-1")).isEmpty();
+		assertThat(repository.loadDevices("anonymous-user-2")).containsExactly(latestDevice);
+	}
+
+	@Test
+	@DisplayName("사용자 데이터 삭제 요청은 알림 설정과 등록 기기를 삭제한다")
+	void deleteNotificationSettingsAndRegisteredDevicesByUserId() {
+		repository.saveNotificationSettings(settings("anonymous-user-1", true, true, true, false, 9));
+		repository.saveNotificationSettings(settings("anonymous-user-2", false, false, true, true, 9));
+		repository.saveRegisteredDevice(device("anonymous-user-1", DevicePlatform.ANDROID, "token-a", 9));
+		repository.saveRegisteredDevice(device("anonymous-user-1", DevicePlatform.IOS, "token-b", 10));
+		repository.saveRegisteredDevice(device("anonymous-user-2", DevicePlatform.IOS, "token-c", 8));
+
+		boolean deletedSettings = repository.deleteNotificationSettings("anonymous-user-1");
+		int deletedDeviceCount = repository.deleteRegisteredDevices("anonymous-user-1");
+		boolean deletedSettingsAgain = repository.deleteNotificationSettings("anonymous-user-1");
+		int deletedDeviceAgainCount = repository.deleteRegisteredDevices("anonymous-user-1");
+
+		assertThat(deletedSettings).isTrue();
+		assertThat(deletedDeviceCount).isEqualTo(2);
+		assertThat(deletedSettingsAgain).isFalse();
+		assertThat(deletedDeviceAgainCount).isZero();
+		assertThat(repository.loadNotificationSettings("anonymous-user-1")).isEmpty();
+		assertThat(repository.loadDevices("anonymous-user-1")).isEmpty();
+		assertThat(repository.loadNotificationSettings("anonymous-user-2"))
+			.contains(settings("anonymous-user-2", false, false, true, true, 9));
+		assertThat(repository.loadDevices("anonymous-user-2"))
+			.containsExactly(device("anonymous-user-2", DevicePlatform.IOS, "token-c", 8));
+	}
+
+	private NotificationSettings settings(
+		String userId,
+		boolean favoriteStationFacilityAlerts,
+		boolean favoriteRouteFacilityAlerts,
+		boolean reportStatusAlerts,
+		boolean dataQualityAlerts,
+		int hour
+	) {
+		return new NotificationSettings(
+			userId,
+			favoriteStationFacilityAlerts,
+			favoriteRouteFacilityAlerts,
+			reportStatusAlerts,
+			dataQualityAlerts,
+			LocalDateTime.of(2026, 6, 17, hour, 0)
+		);
+	}
+
+	private RegisteredDevice device(String userId, DevicePlatform platform, String deviceToken, int hour) {
+		return new RegisteredDevice(
+			userId,
+			platform,
+			deviceToken,
+			LocalDateTime.of(2026, 6, 17, hour, 0)
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
@@ -1,0 +1,108 @@
+package com.easysubway.notification.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import com.easysubway.notification.domain.PushNotificationType;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("JDBC 푸시 알림 outbox 저장소")
+class JdbcPushNotificationOutboxRepositoryTest {
+
+	private JdbcPushNotificationOutboxRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:push-notification-outbox;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS push_notification_outbox");
+		jdbcTemplate.execute("""
+			CREATE TABLE push_notification_outbox (
+				notification_id VARCHAR(120) NOT NULL PRIMARY KEY,
+				user_id VARCHAR(120) NOT NULL,
+				platform VARCHAR(20) NOT NULL,
+				device_token VARCHAR(255) NOT NULL,
+				notification_type VARCHAR(60) NOT NULL,
+				title VARCHAR(120) NOT NULL,
+				body VARCHAR(1000) NOT NULL,
+				status VARCHAR(40) NOT NULL,
+				created_at TIMESTAMP NOT NULL,
+				CONSTRAINT chk_push_notification_outbox_platform CHECK (platform IN ('ANDROID', 'IOS')),
+				CONSTRAINT chk_push_notification_outbox_type CHECK (notification_type IN ('FAVORITE_STATION_FACILITY', 'FAVORITE_ROUTE_FACILITY', 'REPORT_STATUS', 'DATA_QUALITY')),
+				CONSTRAINT chk_push_notification_outbox_status CHECK (status IN ('PENDING'))
+			)
+			""");
+		repository = new JdbcPushNotificationOutboxRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("푸시 알림을 저장하고 사용자 식별자로 생성 순서대로 조회한다")
+	void savePushNotificationAndLoadByUserId() {
+		var secondNotification = notification("push-2", "anonymous-user-1", PushNotificationType.REPORT_STATUS, 10);
+		var firstNotification = notification("push-1", "anonymous-user-1", PushNotificationType.FAVORITE_STATION_FACILITY, 9);
+		repository.savePushNotification(secondNotification);
+		repository.savePushNotification(firstNotification);
+		repository.savePushNotification(notification("push-3", "anonymous-user-2", PushNotificationType.DATA_QUALITY, 8));
+
+		assertThat(repository.loadPushNotifications("anonymous-user-1"))
+			.containsExactly(firstNotification, secondNotification);
+	}
+
+	@Test
+	@DisplayName("같은 푸시 알림 식별자는 한 행만 갱신한다")
+	void savePushNotificationUpdatesExistingNotification() {
+		repository.savePushNotification(notification("push-1", "anonymous-user-1", PushNotificationType.REPORT_STATUS, 9));
+		var updatedNotification = notification("push-1", "anonymous-user-1", PushNotificationType.DATA_QUALITY, 10);
+
+		repository.savePushNotification(updatedNotification);
+
+		assertThat(repository.loadPushNotifications("anonymous-user-1")).containsExactly(updatedNotification);
+	}
+
+	@Test
+	@DisplayName("사용자 데이터 삭제 요청은 해당 사용자의 푸시 알림 개수를 반환한다")
+	void deletePushNotificationsByUserIdReturnsDeletedCount() {
+		repository.savePushNotification(notification("push-1", "anonymous-user-1", PushNotificationType.REPORT_STATUS, 9));
+		repository.savePushNotification(notification("push-2", "anonymous-user-1", PushNotificationType.DATA_QUALITY, 10));
+		repository.savePushNotification(notification("push-3", "anonymous-user-2", PushNotificationType.FAVORITE_ROUTE_FACILITY, 11));
+
+		int deletedCount = repository.deletePushNotifications("anonymous-user-1");
+		int deletedAgainCount = repository.deletePushNotifications("anonymous-user-1");
+
+		assertThat(deletedCount).isEqualTo(2);
+		assertThat(deletedAgainCount).isZero();
+		assertThat(repository.loadPushNotifications("anonymous-user-1")).isEmpty();
+		assertThat(repository.loadPushNotifications("anonymous-user-2"))
+			.containsExactly(notification("push-3", "anonymous-user-2", PushNotificationType.FAVORITE_ROUTE_FACILITY, 11));
+	}
+
+	private PushNotification notification(
+		String notificationId,
+		String userId,
+		PushNotificationType type,
+		int hour
+	) {
+		return new PushNotification(
+			notificationId,
+			userId,
+			DevicePlatform.ANDROID,
+			"device-token-" + notificationId,
+			type,
+			"알림 제목 " + notificationId,
+			"알림 본문 " + notificationId,
+			PushNotificationStatus.PENDING,
+			LocalDateTime.of(2026, 6, 17, hour, 0)
+		);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1211,6 +1211,7 @@ test("백엔드 알림 설정은 인증 사용자 기준 헥사고날 API 경계
   assert.match(jdbcRepository, /Optional<NotificationSettings> loadNotificationSettings\(String userId\)/);
   assert.match(jdbcRepository, /List<RegisteredDevice> loadDevices\(String userId\)/);
   assert.match(jdbcRepository, /RegisteredDevice saveRegisteredDevice\(RegisteredDevice device\)/);
+  assert.match(jdbcRepository, /ON CONFLICT \(platform, device_token\) DO UPDATE/);
   assert.match(jdbcRepository, /NotificationSettings saveNotificationSettings\(NotificationSettings settings\)/);
   assert.match(jdbcRepository, /boolean deleteNotificationSettings\(String userId\)/);
   assert.match(jdbcRepository, /int deleteRegisteredDevices\(String userId\)/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1178,6 +1178,10 @@ test("백엔드 알림 설정은 인증 사용자 기준 헥사고날 API 경계
   const saveSettingsPort = read("backend/src/main/java/com/easysubway/notification/application/port/out/SaveNotificationSettingsPort.java");
   const service = read("backend/src/main/java/com/easysubway/notification/application/service/NotificationPreferenceService.java");
   const repository = read("backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryNotificationPreferenceRepository.java");
+  const jdbcRepository = read(
+    "backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcNotificationPreferenceRepository.java",
+  );
+  const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
   const controller = read("backend/src/main/java/com/easysubway/notification/adapter/in/web/NotificationPreferenceController.java");
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
 
@@ -1202,6 +1206,19 @@ test("백엔드 알림 설정은 인증 사용자 기준 헥사고날 API 경계
   assert.match(saveSettingsPort, /interface SaveNotificationSettingsPort/);
   assert.match(service, /implements NotificationPreferenceUseCase/);
   assert.match(repository, /implements[\s\S]*LoadNotificationPreferencePort[\s\S]*SaveRegisteredDevicePort[\s\S]*SaveNotificationSettingsPort/);
+  assert.match(jdbcRepository, /@Profile\("prod"\)/);
+  assert.match(jdbcRepository, /implements[\s\S]*LoadNotificationPreferencePort[\s\S]*SaveRegisteredDevicePort[\s\S]*SaveNotificationSettingsPort[\s\S]*DeleteUserNotificationPreferencePort/);
+  assert.match(jdbcRepository, /Optional<NotificationSettings> loadNotificationSettings\(String userId\)/);
+  assert.match(jdbcRepository, /List<RegisteredDevice> loadDevices\(String userId\)/);
+  assert.match(jdbcRepository, /RegisteredDevice saveRegisteredDevice\(RegisteredDevice device\)/);
+  assert.match(jdbcRepository, /NotificationSettings saveNotificationSettings\(NotificationSettings settings\)/);
+  assert.match(jdbcRepository, /boolean deleteNotificationSettings\(String userId\)/);
+  assert.match(jdbcRepository, /int deleteRegisteredDevices\(String userId\)/);
+  assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS notification_settings/);
+  assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS registered_devices/);
+  assert.match(batchPostgresSchema, /CONSTRAINT uq_registered_devices_platform_token/);
+  assert.match(batchPostgresSchema, /CHECK \(platform IN \('ANDROID', 'IOS'\)\)/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_registered_devices_user_registered/);
   assert.match(controller, /@PostMapping\("\/api\/v1\/devices"\)/);
   assert.match(controller, /@GetMapping\("\/api\/v1\/me\/notification-settings"\)/);
   assert.match(controller, /@PutMapping\("\/api\/v1\/me\/notification-settings"\)/);
@@ -1222,6 +1239,10 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   const saveOutboxPort = read("backend/src/main/java/com/easysubway/notification/application/port/out/SavePushNotificationOutboxPort.java");
   const service = read("backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDispatchService.java");
   const repository = read("backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java");
+  const jdbcRepository = read(
+    "backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java",
+  );
+  const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
   const controller = read("backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationController.java");
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
 
@@ -1244,6 +1265,16 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   assert.match(service, /LoadNotificationPreferencePort/);
   assert.match(service, /SavePushNotificationOutboxPort/);
   assert.match(repository, /implements[\s\S]*LoadPushNotificationOutboxPort[\s\S]*SavePushNotificationOutboxPort/);
+  assert.match(jdbcRepository, /@Profile\("prod"\)/);
+  assert.match(jdbcRepository, /implements[\s\S]*LoadPushNotificationOutboxPort[\s\S]*SavePushNotificationOutboxPort[\s\S]*DeleteUserPushNotificationPort/);
+  assert.match(jdbcRepository, /List<PushNotification> loadPushNotifications\(String userId\)/);
+  assert.match(jdbcRepository, /PushNotification savePushNotification\(PushNotification notification\)/);
+  assert.match(jdbcRepository, /int deletePushNotifications\(String userId\)/);
+  assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS push_notification_outbox/);
+  assert.match(batchPostgresSchema, /CONSTRAINT chk_push_notification_outbox_platform/);
+  assert.match(batchPostgresSchema, /CONSTRAINT chk_push_notification_outbox_type/);
+  assert.match(batchPostgresSchema, /CONSTRAINT chk_push_notification_outbox_status/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_push_notification_outbox_user_created/);
   assert.match(controller, /@PostMapping\("\/admin\/notifications\/push"\)/);
   assert.match(controller, /PushNotificationDispatchUseCase/);
   assert.doesNotMatch(controller, /deviceToken/);


### PR DESCRIPTION
## 관련 이슈

close #254

## 작업 배경

- 알림 설정, 등록 기기, push outbox가 개발용 인메모리 저장소에만 있으면 운영 재시작이나 다중 인스턴스 환경에서 알림 수신 설정과 발송 대기 데이터가 유지되지 않습니다.
- 엘리베이터 고장, 경로 시설 공사, 신고 처리 결과 알림은 교통약자 사용자가 이동 전에 확인해야 하는 정보라 운영 저장소에서 일관되게 보존되어야 합니다.

## 작업 내용

- `prod` 프로필 전용 `JdbcNotificationPreferenceRepository`를 추가했습니다.
- 알림 설정 저장/조회, 등록 기기 저장/조회, 사용자 데이터 삭제 요청 시 알림 설정과 기기 삭제를 지원했습니다.
- 같은 플랫폼/기기 토큰은 마지막 등록 사용자에게만 연결되도록 저장 경로를 구성했습니다.
- PostgreSQL에서는 `ON CONFLICT (platform, device_token) DO UPDATE`로 기기 토큰 재등록을 원자적으로 처리합니다.
- `prod` 프로필 전용 `JdbcPushNotificationOutboxRepository`를 추가했습니다.
- push outbox 저장/조회, 사용자 데이터 삭제 요청 시 push outbox 삭제를 지원했습니다.
- 운영 PostgreSQL 스키마에 `notification_settings`, `registered_devices`, `push_notification_outbox` 테이블과 enum CHECK, 중복 기기 방지 제약, 사용자별 조회 인덱스를 추가했습니다.
- 저장소 계약 테스트에 알림 JDBC 저장소와 운영 DDL 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "*JdbcNotificationPreferenceRepositoryTest" --tests "*JdbcPushNotificationOutboxRepositoryTest"`: RED 확인 후 성공
  - `./gradlew test`: 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 성공, 41개 테스트 통과
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `README.md`, `.github/pull_request_template.md`만 추적 확인
  - GitHub Actions PR CI `27638848786`: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 모두 성공
  - GitHub Actions main CI `27639195191`: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 모두 성공
  - GitHub Actions main CD `27639194884`: 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 같은 플랫폼/기기 토큰 재등록 시 기존 사용자 연결을 새 사용자로 옮기는 저장 로직
  - PostgreSQL 운영 경로와 H2 테스트 경로의 upsert 분기
  - push outbox 조회 정렬이 생성 시각과 알림 식별자 기준으로 안정적인지 여부
  - DDL의 enum CHECK와 중복 기기 방지 제약이 도메인 enum과 맞는지 여부
- CodeRabbit은 한도 제한으로 실제 리뷰가 시작되지 않았습니다.
- Codex CLI code review 1차 결과에서 PostgreSQL 중복 키 처리 지적 1건을 inline review comment로 남겼고, `1fab2d3`에서 수정했습니다.
- Codex CLI 재리뷰 결과 추가 지적은 없었습니다.

## 리스크

- 실제 APNs/FCM 발송 어댑터는 이번 범위에 포함하지 않았습니다.
- push outbox 상태는 현재 도메인 범위에 맞춰 `PENDING`만 허용합니다.
- main merge 이후 CI/CD가 모두 성공했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
