### PR TITLE
[Style] 홈 화면 주요 동선 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -115,6 +115,7 @@ class EasySubwayApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'EasySubway',
+      debugShowCheckedModeBanner: false,
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF006D77)),
         scaffoldBackgroundColor: const Color(0xFFF6F8F9),
@@ -839,101 +840,84 @@ class HomeScreen extends StatelessWidget {
             const SizedBox(height: 22),
             const Divider(height: 1),
             const SizedBox(height: 14),
-            LayoutBuilder(
-              builder: (context, constraints) {
-                const spacing = 10.0;
-                final itemWidth = (constraints.maxWidth - spacing) / 2;
-                return Wrap(
-                  key: const Key('homeSecondaryActionsGroup'),
-                  spacing: spacing,
-                  runSpacing: spacing,
-                  children: [
-                    SizedBox(
-                      width: itemWidth,
-                      height: 56,
-                      child: _HomeSecondaryActionButton(
-                        key: const Key('mobilityProfileButton'),
-                        onPressed: () {
-                          Navigator.of(context).push(
-                            MaterialPageRoute<MobilityProfileOption>(
-                              builder: (_) => const MobilityProfileScreen(),
-                            ),
-                          );
-                        },
-                        icon: const Icon(Icons.accessibility_new),
-                        label: '이동 조건',
+            _HomeActionSection(
+              title: '개인 설정',
+              groupKey: const Key('homeSettingsActionsGroup'),
+              children: [
+                _HomeSecondaryActionButton(
+                  key: const Key('mobilityProfileButton'),
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<MobilityProfileOption>(
+                        builder: (_) => const MobilityProfileScreen(),
                       ),
-                    ),
-                    if (hasFavorites)
-                      SizedBox(
-                        width: itemWidth,
-                        height: 56,
-                        child: _HomeSecondaryActionButton(
-                          key: const Key('favoritesButton'),
-                          onPressed: () {
-                            Navigator.of(context).push(
-                              MaterialPageRoute<void>(
-                                builder: (_) => FavoriteHomeScreen(
-                                  favoriteRepository: favoriteRepository,
-                                  favoriteFacilityRepository:
-                                      favoriteFacilityRepository,
-                                  favoriteRouteRepository:
-                                      favoriteRouteRepository,
-                                  stationRepository: repository,
-                                  reportRepository: reportRepository,
-                                  locationProvider: locationProvider,
-                                  facilityReportDraftTargetStore:
-                                      facilityReportDraftTargetStore,
-                                ),
-                              ),
-                            );
-                          },
-                          icon: const Icon(Icons.star_outline),
-                          label: '즐겨찾기',
+                    );
+                  },
+                  icon: const Icon(Icons.accessibility_new),
+                  label: '이동 조건',
+                ),
+                if (notificationRepository != null)
+                  _HomeSecondaryActionButton(
+                    key: const Key('notificationSettingsButton'),
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => NotificationSettingsScreen(
+                            repository: notificationRepository,
+                            notificationPermissionProvider:
+                                notificationPermissionProvider,
+                          ),
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.notifications_active_outlined),
+                    label: '알림 설정',
+                  ),
+              ],
+            ),
+            const SizedBox(height: 18),
+            _HomeActionSection(
+              title: '내 정보',
+              groupKey: const Key('homeMyInfoActionsGroup'),
+              children: [
+                if (hasFavorites)
+                  _HomeSecondaryActionButton(
+                    key: const Key('favoritesButton'),
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => FavoriteHomeScreen(
+                            favoriteRepository: favoriteRepository,
+                            favoriteFacilityRepository:
+                                favoriteFacilityRepository,
+                            favoriteRouteRepository: favoriteRouteRepository,
+                            stationRepository: repository,
+                            reportRepository: reportRepository,
+                            locationProvider: locationProvider,
+                            facilityReportDraftTargetStore:
+                                facilityReportDraftTargetStore,
+                          ),
+                        ),
+                      );
+                    },
+                    icon: const Icon(Icons.star_outline),
+                    label: '즐겨찾기',
+                  ),
+                _HomeSecondaryActionButton(
+                  key: const Key('myReportsButton'),
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => MyFacilityReportListScreen(
+                          repository: reportRepository,
                         ),
                       ),
-                    SizedBox(
-                      width: itemWidth,
-                      height: 56,
-                      child: _HomeSecondaryActionButton(
-                        key: const Key('myReportsButton'),
-                        onPressed: () {
-                          Navigator.of(context).push(
-                            MaterialPageRoute<void>(
-                              builder: (_) => MyFacilityReportListScreen(
-                                repository: reportRepository,
-                              ),
-                            ),
-                          );
-                        },
-                        icon: const Icon(Icons.receipt_long_outlined),
-                        label: '내 신고',
-                      ),
-                    ),
-                    if (notificationRepository != null)
-                      SizedBox(
-                        width: itemWidth,
-                        height: 56,
-                        child: _HomeSecondaryActionButton(
-                          key: const Key('notificationSettingsButton'),
-                          onPressed: () {
-                            Navigator.of(context).push(
-                              MaterialPageRoute<void>(
-                                builder: (_) => NotificationSettingsScreen(
-                                  repository: notificationRepository,
-                                  notificationPermissionProvider:
-                                      notificationPermissionProvider,
-                                ),
-                              ),
-                            );
-                          },
-                          icon: const Icon(Icons.notifications_active_outlined),
-                          label: '알림 설정',
-                        ),
-                      ),
-                  ],
-                );
-              },
+                    );
+                  },
+                  icon: const Icon(Icons.receipt_long_outlined),
+                  label: '내 신고',
+                ),
+              ],
             ),
           ],
         ),
@@ -966,6 +950,52 @@ class _HomePrimaryActionButton extends StatelessWidget {
       ),
       icon: IconTheme.merge(data: const IconThemeData(size: 30), child: icon),
       label: Text(label, maxLines: 1),
+    );
+  }
+}
+
+class _HomeActionSection extends StatelessWidget {
+  const _HomeActionSection({
+    required this.title,
+    required this.groupKey,
+    required this.children,
+  });
+
+  final String title;
+  final Key groupKey;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: textTheme.titleMedium?.copyWith(
+            color: const Color(0xFF102A2C),
+            fontWeight: FontWeight.w800,
+            height: 1.25,
+          ),
+        ),
+        const SizedBox(height: 10),
+        LayoutBuilder(
+          builder: (context, constraints) {
+            const spacing = 10.0;
+            final itemWidth = (constraints.maxWidth - spacing) / 2;
+            return Wrap(
+              key: groupKey,
+              spacing: spacing,
+              runSpacing: spacing,
+              children: [
+                for (final child in children)
+                  SizedBox(width: itemWidth, height: 56, child: child),
+              ],
+            );
+          },
+        ),
+      ],
     );
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -517,10 +517,11 @@ void main() {
 
       expect(find.text('안녕하세요'), findsOneWidget);
       expect(find.text('어디로 가시나요?'), findsOneWidget);
-      expect(
-        find.byKey(const Key('homeSecondaryActionsGroup')),
-        findsOneWidget,
-      );
+      expect(find.text('개인 설정'), findsOneWidget);
+      expect(find.text('내 정보'), findsOneWidget);
+      expect(find.byKey(const Key('homeSecondaryActionsGroup')), findsNothing);
+      expect(find.byKey(const Key('homeSettingsActionsGroup')), findsOneWidget);
+      expect(find.byKey(const Key('homeMyInfoActionsGroup')), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '역 검색'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsOneWidget);
@@ -563,6 +564,27 @@ void main() {
       expect(profileButtonSize.height, lessThan(stationButtonSize.height));
       expect(myReportsButtonSize.height, lessThan(stationButtonSize.height));
       expect(notificationButtonSize.height, lessThan(stationButtonSize.height));
+
+      final settingsTop = tester.getTopLeft(find.text('개인 설정')).dy;
+      final myInfoTop = tester.getTopLeft(find.text('내 정보')).dy;
+      expect(
+        tester.getTopLeft(find.byKey(const Key('mobilityProfileButton'))).dy,
+        greaterThan(settingsTop),
+      );
+      expect(
+        tester
+            .getTopLeft(find.byKey(const Key('notificationSettingsButton')))
+            .dy,
+        greaterThan(settingsTop),
+      );
+      expect(
+        tester.getTopLeft(find.byKey(const Key('favoritesButton'))).dy,
+        greaterThan(myInfoTop),
+      );
+      expect(
+        tester.getTopLeft(find.byKey(const Key('myReportsButton'))).dy,
+        greaterThan(myInfoTop),
+      );
 
       await tester.drag(find.byType(ListView), const Offset(0, -620));
       await tester.pumpAndSettle();


### PR DESCRIPTION
## 관련 이슈

close #256

## 작업 배경

- 홈 화면은 앱을 열자마자 `역 검색`과 `길찾기`를 바로 선택할 수 있어야 합니다.
- 고령자, 임산부, 장애인 등 처음 쓰는 사용자가 보조 메뉴까지 같은 묶음으로 보지 않도록 정보 구조를 나눌 필요가 있습니다.
- 즐겨찾기 경로, 역, 시설은 이미 하나의 `즐겨찾기` 화면 안에서 탭으로 나뉘므로 홈에서는 단일 진입점을 유지합니다.

## 작업 내용

- 홈의 보조 메뉴를 `개인 설정`과 `내 정보`로 분리했습니다.
- `개인 설정`에는 `이동 조건`, `알림 설정`을 배치했습니다.
- `내 정보`에는 `즐겨찾기`, `내 신고`를 배치했습니다.
- 인증 저장소가 없는 경우 기존처럼 `즐겨찾기`와 `알림 설정`이 노출되지 않도록 조건부 노출을 유지했습니다.
- debug 실행 중 QA 화면을 가리지 않도록 Flutter debug banner를 숨겼습니다.
- 홈 widget test에 섹션 구조와 버튼 우선순위 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --plain-name "홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다"`: RED 확인 후 성공
  - `flutter test test/widget_test.dart`: 성공, 80개 테스트 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 성공, 41개 테스트 통과
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `README.md`, `.github/pull_request_template.md`만 추적 확인
  - Android emulator `emulator-5554`: 홈 화면 실제 실행 확인
  - GitHub Actions PR CI `27640117787`: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 모두 성공
  - GitHub Actions main CI `27640396764`: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 모두 성공
  - GitHub Actions main CD `27640396517`: 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 홈에서 `역 검색`, `길찾기`가 가장 큰 버튼으로 유지되는지
  - `개인 설정`과 `내 정보`의 분류가 사용자 동선에 맞는지
  - 인증 저장소가 없을 때 즐겨찾기/알림 설정이 계속 숨겨지는지
- CodeRabbit은 한도 제한으로 실제 리뷰가 시작되지 않았습니다.
- Codex CLI code review 결과 추가 수정이 필요한 이슈는 없었습니다.

## 리스크

- 홈 화면 정보 구조만 바꿨고 각 메뉴가 여는 상세 화면 동작은 바꾸지 않았습니다.
- QA 캡처를 위해 debug banner를 숨겼지만 release 동작에는 영향이 없습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
