### PR TITLE
[Feat] 역 내부 구조도 기준 자료 모델 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
@@ -15,6 +15,8 @@ import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.NearbyStation;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
+import com.easysubway.transit.domain.StationLayoutSource;
+import com.easysubway.transit.domain.StationLayoutSourceType;
 import com.easysubway.transit.domain.StationLineSummary;
 import com.easysubway.transit.domain.StationWithLines;
 import com.easysubway.transit.domain.SubwayLine;
@@ -128,6 +130,16 @@ class TransitMasterController {
 		List<AccessibilityFacilityResponse> response = transitMasterQueryUseCase.listStationFacilities(stationId)
 			.stream()
 			.map(AccessibilityFacilityResponse::from)
+			.toList();
+
+		return ApiResponse.ok(response);
+	}
+
+	@GetMapping("/admin/stations/{stationId}/layout-sources")
+	ApiResponse<List<StationLayoutSourceResponse>> stationLayoutSources(@PathVariable String stationId) {
+		List<StationLayoutSourceResponse> response = transitMasterQueryUseCase.listStationLayoutSources(stationId)
+			.stream()
+			.map(StationLayoutSourceResponse::from)
 			.toList();
 
 		return ApiResponse.ok(response);
@@ -389,6 +401,35 @@ class TransitMasterController {
 				facility.dataConfidence(),
 				facility.dataSourceType(),
 				facility.lastUpdatedAt()
+			);
+		}
+	}
+
+	record StationLayoutSourceResponse(
+		String id,
+		String stationId,
+		StationLayoutSourceType sourceType,
+		String sourceName,
+		String sourceUrl,
+		String license,
+		boolean commercialUseAllowed,
+		boolean attributionRequired,
+		LocalDate capturedAt,
+		LocalDate reviewedAt
+	) {
+
+		static StationLayoutSourceResponse from(StationLayoutSource source) {
+			return new StationLayoutSourceResponse(
+				source.id(),
+				source.stationId(),
+				source.sourceType(),
+				source.sourceName(),
+				source.sourceUrl(),
+				source.license(),
+				source.commercialUseAllowed(),
+				source.attributionRequired(),
+				source.capturedAt(),
+				source.reviewedAt()
 			);
 		}
 	}

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -10,6 +10,8 @@ import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
+import com.easysubway.transit.domain.StationLayoutSource;
+import com.easysubway.transit.domain.StationLayoutSourceType;
 import com.easysubway.transit.domain.StationLine;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
@@ -122,6 +124,22 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 		)
 	);
 
+	private static final List<StationLayoutSource> STATION_LAYOUT_SOURCES = List.of(
+		// 저작권 리스크가 있는 원본 도면은 저장하지 않고, 구조도 단순화에 사용한 출처 메타데이터만 보관한다.
+		new StationLayoutSource(
+			"layout-source-sangnoksu-station-map",
+			"station-sangnoksu",
+			StationLayoutSourceType.OPERATOR_DIAGRAM,
+			"상록수역 역사 안내도",
+			"https://www.seoulmetro.co.kr",
+			"운영기관 안내도 확인용",
+			false,
+			true,
+			LocalDate.of(2026, 6, 12),
+			LocalDate.of(2026, 6, 12)
+		)
+	);
+
 	private final Map<String, AccessibilityFacility> accessibilityFacilities = new LinkedHashMap<>();
 
 	public InMemoryTransitMasterRepository() {
@@ -156,6 +174,11 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 	@Override
 	public List<AccessibilityFacility> loadAccessibilityFacilities() {
 		return List.copyOf(accessibilityFacilities.values());
+	}
+
+	@Override
+	public List<StationLayoutSource> loadStationLayoutSources() {
+		return STATION_LAYOUT_SOURCES;
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
@@ -4,6 +4,7 @@ import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.NearbyStation;
 import com.easysubway.transit.domain.StationWithLines;
 import com.easysubway.transit.domain.StationExit;
+import com.easysubway.transit.domain.StationLayoutSource;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
 import com.easysubway.transit.domain.TransitRegionSummary;
@@ -26,4 +27,6 @@ public interface TransitMasterQueryUseCase {
 	List<StationExit> listStationExits(String stationId);
 
 	List<AccessibilityFacility> listStationFacilities(String stationId);
+
+	List<StationLayoutSource> listStationLayoutSources(String stationId);
 }

--- a/backend/src/main/java/com/easysubway/transit/application/port/out/LoadTransitMasterPort.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/out/LoadTransitMasterPort.java
@@ -3,6 +3,7 @@ package com.easysubway.transit.application.port.out;
 import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
+import com.easysubway.transit.domain.StationLayoutSource;
 import com.easysubway.transit.domain.StationLine;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
@@ -22,6 +23,10 @@ public interface LoadTransitMasterPort {
 	List<StationExit> loadStationExits();
 
 	List<AccessibilityFacility> loadAccessibilityFacilities();
+
+	default List<StationLayoutSource> loadStationLayoutSources() {
+		return List.of();
+	}
 
 	default Optional<Station> loadStation(String stationId) {
 		return loadStations()

--- a/backend/src/main/java/com/easysubway/transit/application/port/out/LoadTransitMasterPort.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/out/LoadTransitMasterPort.java
@@ -25,7 +25,7 @@ public interface LoadTransitMasterPort {
 	List<AccessibilityFacility> loadAccessibilityFacilities();
 
 	default List<StationLayoutSource> loadStationLayoutSources() {
-		return List.of();
+		throw new UnsupportedOperationException("Station layout source loading is not implemented.");
 	}
 
 	default Optional<Station> loadStation(String stationId) {

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -17,6 +17,7 @@ import com.easysubway.transit.domain.InvalidAccessibilityFacilityException;
 import com.easysubway.transit.domain.NearbyStation;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
+import com.easysubway.transit.domain.StationLayoutSource;
 import com.easysubway.transit.domain.StationLine;
 import com.easysubway.transit.domain.StationLineSummary;
 import com.easysubway.transit.domain.StationNotFoundException;
@@ -165,6 +166,15 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		return loadTransitMasterPort.loadAccessibilityFacilities()
 			.stream()
 			.filter(facility -> facility.stationId().equals(stationId))
+			.toList();
+	}
+
+	@Override
+	public List<StationLayoutSource> listStationLayoutSources(String stationId) {
+		loadActiveStation(stationId);
+		return loadTransitMasterPort.loadStationLayoutSources()
+			.stream()
+			.filter(source -> source.stationId().equals(stationId))
 			.toList();
 	}
 

--- a/backend/src/main/java/com/easysubway/transit/domain/StationLayoutSource.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/StationLayoutSource.java
@@ -1,0 +1,17 @@
+package com.easysubway.transit.domain;
+
+import java.time.LocalDate;
+
+public record StationLayoutSource(
+	String id,
+	String stationId,
+	StationLayoutSourceType sourceType,
+	String sourceName,
+	String sourceUrl,
+	String license,
+	boolean commercialUseAllowed,
+	boolean attributionRequired,
+	LocalDate capturedAt,
+	LocalDate reviewedAt
+) {
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/StationLayoutSource.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/StationLayoutSource.java
@@ -14,4 +14,31 @@ public record StationLayoutSource(
 	LocalDate capturedAt,
 	LocalDate reviewedAt
 ) {
+
+	public StationLayoutSource {
+		id = requireText(id, "id");
+		stationId = requireText(stationId, "stationId");
+		sourceType = requireNonNull(sourceType, "sourceType");
+		sourceName = requireText(sourceName, "sourceName");
+		sourceUrl = requireText(sourceUrl, "sourceUrl");
+		license = requireText(license, "license");
+		capturedAt = requireNonNull(capturedAt, "capturedAt");
+		if (reviewedAt != null && reviewedAt.isBefore(capturedAt)) {
+			throw new IllegalArgumentException("reviewedAt must not be before capturedAt.");
+		}
+	}
+
+	private static String requireText(String value, String fieldName) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(fieldName + " must not be blank.");
+		}
+		return value.trim();
+	}
+
+	private static <T> T requireNonNull(T value, String fieldName) {
+		if (value == null) {
+			throw new IllegalArgumentException(fieldName + " must not be null.");
+		}
+		return value;
+	}
 }

--- a/backend/src/main/java/com/easysubway/transit/domain/StationLayoutSourceType.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/StationLayoutSourceType.java
@@ -1,0 +1,10 @@
+package com.easysubway.transit.domain;
+
+public enum StationLayoutSourceType {
+	PUBLIC_DATA,
+	OPERATOR_DIAGRAM,
+	OPERATOR_PAGE,
+	FIELD_SURVEY,
+	USER_REPORT,
+	PARTNER_FEED
+}

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -230,6 +230,46 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 역 내부 구조도 기준 자료의 출처와 검수일을 조회한다")
+	void adminListsStationLayoutSourcesWithLicenseAndReviewMetadata() throws Exception {
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/layout-sources")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].id").value("layout-source-sangnoksu-station-map"))
+			.andExpect(jsonPath("$.data[0].stationId").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data[0].sourceType").value("OPERATOR_DIAGRAM"))
+			.andExpect(jsonPath("$.data[0].sourceName").value("상록수역 역사 안내도"))
+			.andExpect(jsonPath("$.data[0].license").value("운영기관 안내도 확인용"))
+			.andExpect(jsonPath("$.data[0].commercialUseAllowed").value(false))
+			.andExpect(jsonPath("$.data[0].attributionRequired").value(true))
+			.andExpect(jsonPath("$.data[0].capturedAt").value("2026-06-12"))
+			.andExpect(jsonPath("$.data[0].reviewedAt").value("2026-06-12"));
+	}
+
+	@Test
+	@DisplayName("역 내부 구조도 기준 자료 관리자 API는 관리자 인증을 요구한다")
+	void adminStationLayoutSourcesRequireAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/layout-sources"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/layout-sources")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 역의 구조도 기준 자료는 공통 404 응답을 반환한다")
+	void missingStationLayoutSourcesReturnCommonErrorResponse() throws Exception {
+		mockMvc.perform(get("/admin/stations/unknown-station/layout-sources")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("역 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
 	@DisplayName("관리자는 시설 상태를 수정하고 공개 시설 목록에서 확인할 수 있다")
 	@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
 	void adminUpdatesFacilityStatusAndPublicListReflectsIt() throws Exception {

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -21,6 +21,7 @@ import com.easysubway.transit.domain.InvalidAccessibilityFacilityException;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.StationLayoutSourceType;
 import com.easysubway.transit.domain.StationNotFoundException;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
@@ -181,12 +182,30 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
-	@DisplayName("역 출구와 시설 목록은 존재하는 역을 요구한다")
-	void stationExitsAndFacilitiesRequireExistingStation() {
+	@DisplayName("역 내부 구조도 기준 자료는 출처와 검수 정보를 함께 반환한다")
+	void listStationLayoutSourcesReturnsLicenseAndReviewMetadata() {
+		var sources = service.listStationLayoutSources("station-sangnoksu");
+
+		assertThat(sources)
+			.extracting("id")
+			.containsExactly("layout-source-sangnoksu-station-map");
+		assertThat(sources.getFirst().sourceType()).isEqualTo(StationLayoutSourceType.OPERATOR_DIAGRAM);
+		assertThat(sources.getFirst().sourceName()).isEqualTo("상록수역 역사 안내도");
+		assertThat(sources.getFirst().commercialUseAllowed()).isFalse();
+		assertThat(sources.getFirst().attributionRequired()).isTrue();
+		assertThat(sources.getFirst().reviewedAt()).isEqualTo(LocalDate.of(2026, 6, 12));
+	}
+
+	@Test
+	@DisplayName("역 출구와 시설과 구조도 기준 자료 목록은 존재하는 역을 요구한다")
+	void stationExitsFacilitiesAndLayoutSourcesRequireExistingStation() {
 		assertThatThrownBy(() -> service.listStationExits("missing"))
 			.isInstanceOf(StationNotFoundException.class)
 			.hasMessage("역 정보를 찾을 수 없습니다.");
 		assertThatThrownBy(() -> service.listStationFacilities("missing"))
+			.isInstanceOf(StationNotFoundException.class)
+			.hasMessage("역 정보를 찾을 수 없습니다.");
+		assertThatThrownBy(() -> service.listStationLayoutSources("missing"))
 			.isInstanceOf(StationNotFoundException.class)
 			.hasMessage("역 정보를 찾을 수 없습니다.");
 	}

--- a/backend/src/test/java/com/easysubway/transit/domain/StationLayoutSourceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/domain/StationLayoutSourceTest.java
@@ -1,0 +1,77 @@
+package com.easysubway.transit.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("역 내부 구조도 기준 자료")
+class StationLayoutSourceTest {
+
+	@Test
+	@DisplayName("필수 문자열은 공백을 정리해 저장한다")
+	void trimsRequiredTextFields() {
+		var source = new StationLayoutSource(
+			" layout-source-1 ",
+			" station-sangnoksu ",
+			StationLayoutSourceType.OPERATOR_DIAGRAM,
+			" 상록수역 역사 안내도 ",
+			" https://www.seoulmetro.co.kr ",
+			" 운영기관 안내도 확인용 ",
+			false,
+			true,
+			LocalDate.of(2026, 6, 12),
+			LocalDate.of(2026, 6, 13)
+		);
+
+		assertThat(source.id()).isEqualTo("layout-source-1");
+		assertThat(source.stationId()).isEqualTo("station-sangnoksu");
+		assertThat(source.sourceName()).isEqualTo("상록수역 역사 안내도");
+		assertThat(source.sourceUrl()).isEqualTo("https://www.seoulmetro.co.kr");
+		assertThat(source.license()).isEqualTo("운영기관 안내도 확인용");
+	}
+
+	@Test
+	@DisplayName("필수 필드가 비어 있으면 기준 자료를 만들 수 없다")
+	void rejectsBlankRequiredFields() {
+		assertThatThrownBy(() -> sourceWithBlankId())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("id must not be blank.");
+	}
+
+	@Test
+	@DisplayName("검수일은 수집일보다 빠를 수 없다")
+	void rejectsReviewedAtBeforeCapturedAt() {
+		assertThatThrownBy(() -> new StationLayoutSource(
+			"layout-source-1",
+			"station-sangnoksu",
+			StationLayoutSourceType.OPERATOR_DIAGRAM,
+			"상록수역 역사 안내도",
+			"https://www.seoulmetro.co.kr",
+			"운영기관 안내도 확인용",
+			false,
+			true,
+			LocalDate.of(2026, 6, 12),
+			LocalDate.of(2026, 6, 11)
+		))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("reviewedAt must not be before capturedAt.");
+	}
+
+	private StationLayoutSource sourceWithBlankId() {
+		return new StationLayoutSource(
+			" ",
+			"station-sangnoksu",
+			StationLayoutSourceType.OPERATOR_DIAGRAM,
+			"상록수역 역사 안내도",
+			"https://www.seoulmetro.co.kr",
+			"운영기관 안내도 확인용",
+			false,
+			true,
+			LocalDate.of(2026, 6, 12),
+			LocalDate.of(2026, 6, 12)
+		);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #262

## 작업 배경

역 내부 이동 안내를 만들려면 어떤 자료를 기준으로 구조도를 단순화했는지 추적할 수 있어야 합니다. 원본 도면 이미지를 API에 싣지 않고, 운영자가 출처와 라이선스와 검수일을 확인할 수 있는 메타데이터부터 분리했습니다.

## 작업 내용

- `StationLayoutSource` 도메인 모델과 기준 자료 유형 enum을 추가했습니다.
- transit 조회 포트와 서비스 use case에 역별 구조도 기준 자료 조회를 추가했습니다.
- 개발용 인메모리 저장소에 상록수역 구조도 기준 자료 시드를 추가했습니다.
- 관리자 API `GET /admin/stations/{stationId}/layout-sources`를 추가했습니다.
- 관리자 인증, 404 공통 응답, 출처/라이선스/검수일 응답 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.transit.application.service.TransitMasterServiceTest --tests com.easysubway.transit.adapter.in.web.TransitMasterControllerTest` 성공
  - `./gradlew test` 성공
  - `git diff --check` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 관리자 API가 원본 이미지나 도면 데이터를 반환하지 않고 출처 메타데이터만 반환하는지
  - 존재하지 않는 역에서 기존 `StationNotFoundException` 기반 404 계약을 유지하는지
  - `LoadTransitMasterPort` 확장이 기존 테스트용 포트 구현에 불필요한 구현 부담을 만들지 않는지

## 리스크

- 현재는 개발용 인메모리 시드만 추가했으므로 운영 DB 저장소가 붙을 때 별도 마이그레이션과 영속 어댑터가 필요합니다.
- `sourceUrl`은 관리자 검수용 메타데이터이며 앱 사용자 화면에는 노출하지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
