### PR TITLE
[Feat] 역 내부 구조도 초안 모델 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
@@ -19,6 +19,9 @@ import com.easysubway.transit.domain.StationLayoutSource;
 import com.easysubway.transit.domain.StationLayoutSourceType;
 import com.easysubway.transit.domain.StationLineSummary;
 import com.easysubway.transit.domain.StationWithLines;
+import com.easysubway.transit.domain.SimplifiedStationLayout;
+import com.easysubway.transit.domain.SimplifiedStationLayoutConfidence;
+import com.easysubway.transit.domain.SimplifiedStationLayoutStatus;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
 import com.easysubway.transit.domain.TransitRegionSummary;
@@ -140,6 +143,17 @@ class TransitMasterController {
 		List<StationLayoutSourceResponse> response = transitMasterQueryUseCase.listStationLayoutSources(stationId)
 			.stream()
 			.map(StationLayoutSourceResponse::from)
+			.toList();
+
+		return ApiResponse.ok(response);
+	}
+
+	@GetMapping("/admin/stations/{stationId}/layouts")
+	ApiResponse<List<SimplifiedStationLayoutResponse>> simplifiedStationLayouts(@PathVariable String stationId) {
+		List<SimplifiedStationLayoutResponse> response = transitMasterQueryUseCase
+			.listSimplifiedStationLayouts(stationId)
+			.stream()
+			.map(SimplifiedStationLayoutResponse::from)
 			.toList();
 
 		return ApiResponse.ok(response);
@@ -430,6 +444,41 @@ class TransitMasterController {
 				source.attributionRequired(),
 				source.capturedAt(),
 				source.reviewedAt()
+			);
+		}
+	}
+
+	record SimplifiedStationLayoutResponse(
+		String id,
+		String stationId,
+		int version,
+		SimplifiedStationLayoutStatus status,
+		List<String> sourceIds,
+		SimplifiedStationLayoutConfidence confidenceLevel,
+		String baseFloor,
+		String layoutJson,
+		String renderedPreviewUrl,
+		String createdBy,
+		String reviewedBy,
+		LocalDate publishedAt,
+		LocalDate lastVerifiedAt
+	) {
+
+		static SimplifiedStationLayoutResponse from(SimplifiedStationLayout layout) {
+			return new SimplifiedStationLayoutResponse(
+				layout.id(),
+				layout.stationId(),
+				layout.version(),
+				layout.status(),
+				layout.sourceIds(),
+				layout.confidenceLevel(),
+				layout.baseFloor(),
+				layout.layoutJson(),
+				layout.renderedPreviewUrl(),
+				layout.createdBy(),
+				layout.reviewedBy(),
+				layout.publishedAt(),
+				layout.lastVerifiedAt()
 			);
 		}
 	}

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -13,6 +13,9 @@ import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLayoutSource;
 import com.easysubway.transit.domain.StationLayoutSourceType;
 import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.SimplifiedStationLayout;
+import com.easysubway.transit.domain.SimplifiedStationLayoutConfidence;
+import com.easysubway.transit.domain.SimplifiedStationLayoutStatus;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
 import java.math.BigDecimal;
@@ -140,6 +143,24 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 		)
 	);
 
+	private static final List<SimplifiedStationLayout> SIMPLIFIED_STATION_LAYOUTS = List.of(
+		new SimplifiedStationLayout(
+			"layout-sangnoksu-draft",
+			"station-sangnoksu",
+			1,
+			SimplifiedStationLayoutStatus.DRAFT,
+			List.of("layout-source-sangnoksu-station-map"),
+			SimplifiedStationLayoutConfidence.OFFICIAL_DIAGRAM_REFERENCED,
+			"B1",
+			"{\"nodes\":[],\"edges\":[]}",
+			null,
+			"admin-user",
+			null,
+			null,
+			LocalDate.of(2026, 6, 12)
+		)
+	);
+
 	private final Map<String, AccessibilityFacility> accessibilityFacilities = new LinkedHashMap<>();
 
 	public InMemoryTransitMasterRepository() {
@@ -179,6 +200,11 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 	@Override
 	public List<StationLayoutSource> loadStationLayoutSources() {
 		return STATION_LAYOUT_SOURCES;
+	}
+
+	@Override
+	public List<SimplifiedStationLayout> loadSimplifiedStationLayouts() {
+		return SIMPLIFIED_STATION_LAYOUTS;
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
@@ -5,6 +5,7 @@ import com.easysubway.transit.domain.NearbyStation;
 import com.easysubway.transit.domain.StationWithLines;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLayoutSource;
+import com.easysubway.transit.domain.SimplifiedStationLayout;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
 import com.easysubway.transit.domain.TransitRegionSummary;
@@ -29,4 +30,6 @@ public interface TransitMasterQueryUseCase {
 	List<AccessibilityFacility> listStationFacilities(String stationId);
 
 	List<StationLayoutSource> listStationLayoutSources(String stationId);
+
+	List<SimplifiedStationLayout> listSimplifiedStationLayouts(String stationId);
 }

--- a/backend/src/main/java/com/easysubway/transit/application/port/out/LoadTransitMasterPort.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/out/LoadTransitMasterPort.java
@@ -5,6 +5,7 @@ import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLayoutSource;
 import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.SimplifiedStationLayout;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
 import java.util.List;
@@ -26,6 +27,10 @@ public interface LoadTransitMasterPort {
 
 	default List<StationLayoutSource> loadStationLayoutSources() {
 		throw new UnsupportedOperationException("Station layout source loading is not implemented.");
+	}
+
+	default List<SimplifiedStationLayout> loadSimplifiedStationLayouts() {
+		throw new UnsupportedOperationException("Simplified station layout loading is not implemented.");
 	}
 
 	default Optional<Station> loadStation(String stationId) {

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -22,6 +22,7 @@ import com.easysubway.transit.domain.StationLine;
 import com.easysubway.transit.domain.StationLineSummary;
 import com.easysubway.transit.domain.StationNotFoundException;
 import com.easysubway.transit.domain.StationWithLines;
+import com.easysubway.transit.domain.SimplifiedStationLayout;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
 import com.easysubway.transit.domain.TransitRegionSummary;
@@ -175,6 +176,15 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		return loadTransitMasterPort.loadStationLayoutSources()
 			.stream()
 			.filter(source -> source.stationId().equals(stationId))
+			.toList();
+	}
+
+	@Override
+	public List<SimplifiedStationLayout> listSimplifiedStationLayouts(String stationId) {
+		loadActiveStation(stationId);
+		return loadTransitMasterPort.loadSimplifiedStationLayouts()
+			.stream()
+			.filter(layout -> layout.stationId().equals(stationId))
 			.toList();
 	}
 

--- a/backend/src/main/java/com/easysubway/transit/domain/SimplifiedStationLayout.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/SimplifiedStationLayout.java
@@ -1,0 +1,73 @@
+package com.easysubway.transit.domain;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record SimplifiedStationLayout(
+	String id,
+	String stationId,
+	int version,
+	SimplifiedStationLayoutStatus status,
+	List<String> sourceIds,
+	SimplifiedStationLayoutConfidence confidenceLevel,
+	String baseFloor,
+	String layoutJson,
+	String renderedPreviewUrl,
+	String createdBy,
+	String reviewedBy,
+	LocalDate publishedAt,
+	LocalDate lastVerifiedAt
+) {
+
+	public SimplifiedStationLayout {
+		id = requireText(id, "id");
+		stationId = requireText(stationId, "stationId");
+		if (version < 1) {
+			throw new IllegalArgumentException("version must be greater than zero.");
+		}
+		status = requireNonNull(status, "status");
+		sourceIds = cleanSourceIds(sourceIds);
+		confidenceLevel = requireNonNull(confidenceLevel, "confidenceLevel");
+		baseFloor = requireText(baseFloor, "baseFloor");
+		layoutJson = requireText(layoutJson, "layoutJson");
+		renderedPreviewUrl = cleanOptionalText(renderedPreviewUrl);
+		createdBy = requireText(createdBy, "createdBy");
+		reviewedBy = cleanOptionalText(reviewedBy);
+		lastVerifiedAt = requireNonNull(lastVerifiedAt, "lastVerifiedAt");
+	}
+
+	private static List<String> cleanSourceIds(List<String> values) {
+		if (values == null || values.isEmpty()) {
+			throw new IllegalArgumentException("sourceIds must not be empty.");
+		}
+		List<String> cleanedValues = values.stream()
+			.map(value -> requireText(value, "sourceIds"))
+			.distinct()
+			.toList();
+		if (cleanedValues.isEmpty()) {
+			throw new IllegalArgumentException("sourceIds must not be empty.");
+		}
+		return List.copyOf(cleanedValues);
+	}
+
+	private static String cleanOptionalText(String value) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		return value.trim();
+	}
+
+	private static String requireText(String value, String fieldName) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(fieldName + " must not be blank.");
+		}
+		return value.trim();
+	}
+
+	private static <T> T requireNonNull(T value, String fieldName) {
+		if (value == null) {
+			throw new IllegalArgumentException(fieldName + " must not be null.");
+		}
+		return value;
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/SimplifiedStationLayoutConfidence.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/SimplifiedStationLayoutConfidence.java
@@ -1,0 +1,9 @@
+package com.easysubway.transit.domain;
+
+public enum SimplifiedStationLayoutConfidence {
+	OFFICIAL_DIAGRAM_REFERENCED,
+	OFFICIAL_FACILITY_DATA,
+	FIELD_VERIFIED,
+	USER_CORRECTED,
+	INFERRED_LAYOUT
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/SimplifiedStationLayoutStatus.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/SimplifiedStationLayoutStatus.java
@@ -1,0 +1,9 @@
+package com.easysubway.transit.domain;
+
+public enum SimplifiedStationLayoutStatus {
+	DRAFT,
+	READY_FOR_REVIEW,
+	PUBLISHED,
+	NEEDS_VERIFICATION,
+	ARCHIVED
+}

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -270,6 +270,47 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 역별 쉬운 내부 구조도 초안의 상태와 신뢰도를 조회한다")
+	void adminListsSimplifiedStationLayoutsWithStatusAndConfidence() throws Exception {
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/layouts")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].id").value("layout-sangnoksu-draft"))
+			.andExpect(jsonPath("$.data[0].stationId").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data[0].version").value(1))
+			.andExpect(jsonPath("$.data[0].status").value("DRAFT"))
+			.andExpect(jsonPath("$.data[0].sourceIds[0]").value("layout-source-sangnoksu-station-map"))
+			.andExpect(jsonPath("$.data[0].confidenceLevel").value("OFFICIAL_DIAGRAM_REFERENCED"))
+			.andExpect(jsonPath("$.data[0].baseFloor").value("B1"))
+			.andExpect(jsonPath("$.data[0].layoutJson").value("{\"nodes\":[],\"edges\":[]}"))
+			.andExpect(jsonPath("$.data[0].createdBy").value("admin-user"))
+			.andExpect(jsonPath("$.data[0].lastVerifiedAt").value("2026-06-12"));
+	}
+
+	@Test
+	@DisplayName("쉬운 내부 구조도 관리자 API는 관리자 인증을 요구한다")
+	void adminSimplifiedStationLayoutsRequireAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/layouts"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/layouts")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 역의 쉬운 내부 구조도는 공통 404 응답을 반환한다")
+	void missingSimplifiedStationLayoutsReturnCommonErrorResponse() throws Exception {
+		mockMvc.perform(get("/admin/stations/unknown-station/layouts")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("역 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
 	@DisplayName("관리자는 시설 상태를 수정하고 공개 시설 목록에서 확인할 수 있다")
 	@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
 	void adminUpdatesFacilityStatusAndPublicListReflectsIt() throws Exception {

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -23,6 +23,8 @@ import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLine;
 import com.easysubway.transit.domain.StationLayoutSourceType;
 import com.easysubway.transit.domain.StationNotFoundException;
+import com.easysubway.transit.domain.SimplifiedStationLayoutConfidence;
+import com.easysubway.transit.domain.SimplifiedStationLayoutStatus;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
 import java.math.BigDecimal;
@@ -197,8 +199,26 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
-	@DisplayName("역 출구와 시설과 구조도 기준 자료 목록은 존재하는 역을 요구한다")
-	void stationExitsFacilitiesAndLayoutSourcesRequireExistingStation() {
+	@DisplayName("쉬운 내부 구조도 초안은 상태와 신뢰도와 기준 자료를 함께 반환한다")
+	void listSimplifiedStationLayoutsReturnsStatusConfidenceAndSources() {
+		var layouts = service.listSimplifiedStationLayouts("station-sangnoksu");
+
+		assertThat(layouts)
+			.extracting("id")
+			.containsExactly("layout-sangnoksu-draft");
+		assertThat(layouts.getFirst().version()).isEqualTo(1);
+		assertThat(layouts.getFirst().status()).isEqualTo(SimplifiedStationLayoutStatus.DRAFT);
+		assertThat(layouts.getFirst().confidenceLevel())
+			.isEqualTo(SimplifiedStationLayoutConfidence.OFFICIAL_DIAGRAM_REFERENCED);
+		assertThat(layouts.getFirst().sourceIds())
+			.containsExactly("layout-source-sangnoksu-station-map");
+		assertThat(layouts.getFirst().layoutJson()).contains("\"nodes\"");
+		assertThat(layouts.getFirst().lastVerifiedAt()).isEqualTo(LocalDate.of(2026, 6, 12));
+	}
+
+	@Test
+	@DisplayName("역 출구와 시설과 구조도 목록은 존재하는 역을 요구한다")
+	void stationExitsFacilitiesAndLayoutsRequireExistingStation() {
 		assertThatThrownBy(() -> service.listStationExits("missing"))
 			.isInstanceOf(StationNotFoundException.class)
 			.hasMessage("역 정보를 찾을 수 없습니다.");
@@ -206,6 +226,9 @@ class TransitMasterServiceTest {
 			.isInstanceOf(StationNotFoundException.class)
 			.hasMessage("역 정보를 찾을 수 없습니다.");
 		assertThatThrownBy(() -> service.listStationLayoutSources("missing"))
+			.isInstanceOf(StationNotFoundException.class)
+			.hasMessage("역 정보를 찾을 수 없습니다.");
+		assertThatThrownBy(() -> service.listSimplifiedStationLayouts("missing"))
 			.isInstanceOf(StationNotFoundException.class)
 			.hasMessage("역 정보를 찾을 수 없습니다.");
 	}

--- a/backend/src/test/java/com/easysubway/transit/domain/SimplifiedStationLayoutTest.java
+++ b/backend/src/test/java/com/easysubway/transit/domain/SimplifiedStationLayoutTest.java
@@ -1,0 +1,88 @@
+package com.easysubway.transit.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("쉬운 내부 구조도")
+class SimplifiedStationLayoutTest {
+
+	@Test
+	@DisplayName("필수 문자열과 기준 자료 식별자는 공백을 정리해 저장한다")
+	void trimsRequiredTextAndSourceIds() {
+		var layout = new SimplifiedStationLayout(
+			" layout-sangnoksu-draft ",
+			" station-sangnoksu ",
+			1,
+			SimplifiedStationLayoutStatus.DRAFT,
+			List.of(" layout-source-sangnoksu-station-map "),
+			SimplifiedStationLayoutConfidence.OFFICIAL_DIAGRAM_REFERENCED,
+			" B1 ",
+			" {\"nodes\":[],\"edges\":[]} ",
+			null,
+			" admin-user ",
+			null,
+			null,
+			LocalDate.of(2026, 6, 12)
+		);
+
+		assertThat(layout.id()).isEqualTo("layout-sangnoksu-draft");
+		assertThat(layout.stationId()).isEqualTo("station-sangnoksu");
+		assertThat(layout.sourceIds()).containsExactly("layout-source-sangnoksu-station-map");
+		assertThat(layout.baseFloor()).isEqualTo("B1");
+		assertThat(layout.layoutJson()).isEqualTo("{\"nodes\":[],\"edges\":[]}");
+		assertThat(layout.createdBy()).isEqualTo("admin-user");
+	}
+
+	@Test
+	@DisplayName("버전은 1 이상이어야 한다")
+	void rejectsVersionLowerThanOne() {
+		assertThatThrownBy(() -> layoutWithVersion(0))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("version must be greater than zero.");
+	}
+
+	@Test
+	@DisplayName("기준 자료 식별자가 없으면 구조도를 만들 수 없다")
+	void rejectsEmptySourceIds() {
+		assertThatThrownBy(() -> new SimplifiedStationLayout(
+			"layout-sangnoksu-draft",
+			"station-sangnoksu",
+			1,
+			SimplifiedStationLayoutStatus.DRAFT,
+			List.of(),
+			SimplifiedStationLayoutConfidence.OFFICIAL_DIAGRAM_REFERENCED,
+			"B1",
+			"{\"nodes\":[],\"edges\":[]}",
+			null,
+			"admin-user",
+			null,
+			null,
+			LocalDate.of(2026, 6, 12)
+		))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("sourceIds must not be empty.");
+	}
+
+	private SimplifiedStationLayout layoutWithVersion(int version) {
+		return new SimplifiedStationLayout(
+			"layout-sangnoksu-draft",
+			"station-sangnoksu",
+			version,
+			SimplifiedStationLayoutStatus.DRAFT,
+			List.of("layout-source-sangnoksu-station-map"),
+			SimplifiedStationLayoutConfidence.OFFICIAL_DIAGRAM_REFERENCED,
+			"B1",
+			"{\"nodes\":[],\"edges\":[]}",
+			null,
+			"admin-user",
+			null,
+			null,
+			LocalDate.of(2026, 6, 12)
+		);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #264

## 작업 배경

역 내부 이동 안내를 제공하려면 원본 안내도를 그대로 노출하는 대신 앱에서 이해하기 쉬운 자체 구조도 초안을 관리해야 합니다. 기준 자료 메타데이터에 이어, 구조도 상태와 신뢰도와 렌더링 JSON을 백엔드에서 조회할 수 있는 기반을 추가했습니다.

## 작업 내용

- `SimplifiedStationLayout` 도메인 모델과 상태/신뢰도 enum을 추가했습니다.
- 구조도 필수 필드, 버전, 기준 자료 식별자에 대한 도메인 검증을 추가했습니다.
- transit 조회 포트와 서비스 use case에 역별 쉬운 구조도 조회를 추가했습니다.
- 개발용 인메모리 저장소에 상록수역 구조도 초안 시드를 추가했습니다.
- 관리자 API `GET /admin/stations/{stationId}/layouts`를 추가했습니다.
- 관리자 인증, 404 공통 응답, 상태/신뢰도/검수일 응답 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.transit.domain.SimplifiedStationLayoutTest --tests com.easysubway.transit.application.service.TransitMasterServiceTest --tests com.easysubway.transit.adapter.in.web.TransitMasterControllerTest` 성공
  - `./gradlew test` 성공
  - `git diff --check` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 구조도 API가 관리자 전용으로만 열려 있는지
  - `layoutJson`이 원본 안내도 이미지나 픽셀 좌표가 아니라 자체 렌더링용 단순 JSON으로만 취급되는지
  - 새 포트 확장이 미구현 어댑터를 조용히 빈 값으로 처리하지 않는지

## 리스크

- 현재 구조도는 개발용 인메모리 초안 데이터만 포함합니다. 운영 DB 저장소와 편집 API는 별도 작업이 필요합니다.
- 모바일 렌더링은 이번 범위가 아니며, 이 API는 관리자 검수용 기반으로 제한했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
