### PR TITLE
[Feat] 내부 이동 노드 모델 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
@@ -13,6 +13,8 @@ import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.NearbyStation;
+import com.easysubway.transit.domain.RouteNode;
+import com.easysubway.transit.domain.RouteNodeType;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLayoutSource;
@@ -154,6 +156,16 @@ class TransitMasterController {
 			.listSimplifiedStationLayouts(stationId)
 			.stream()
 			.map(SimplifiedStationLayoutResponse::from)
+			.toList();
+
+		return ApiResponse.ok(response);
+	}
+
+	@GetMapping("/admin/stations/{stationId}/route-nodes")
+	ApiResponse<List<RouteNodeResponse>> routeNodes(@PathVariable String stationId) {
+		List<RouteNodeResponse> response = transitMasterQueryUseCase.listRouteNodes(stationId)
+			.stream()
+			.map(RouteNodeResponse::from)
 			.toList();
 
 		return ApiResponse.ok(response);
@@ -479,6 +491,41 @@ class TransitMasterController {
 				layout.reviewedBy(),
 				layout.publishedAt(),
 				layout.lastVerifiedAt()
+			);
+		}
+	}
+
+	record RouteNodeResponse(
+		String id,
+		String stationId,
+		RouteNodeType type,
+		String name,
+		String floor,
+		BigDecimal latitude,
+		BigDecimal longitude,
+		String facilityId,
+		String layoutId,
+		int displayX,
+		int displayY,
+		String displayLabel,
+		String accessibilityNote
+	) {
+
+		static RouteNodeResponse from(RouteNode node) {
+			return new RouteNodeResponse(
+				node.id(),
+				node.stationId(),
+				node.type(),
+				node.name(),
+				node.floor(),
+				node.latitude(),
+				node.longitude(),
+				node.facilityId(),
+				node.layoutId(),
+				node.displayX(),
+				node.displayY(),
+				node.displayLabel(),
+				node.accessibilityNote()
 			);
 		}
 	}

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -8,6 +8,8 @@ import com.easysubway.transit.domain.AccessibilityFacilityType;
 import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.RouteNode;
+import com.easysubway.transit.domain.RouteNodeType;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLayoutSource;
@@ -161,6 +163,39 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 		)
 	);
 
+	private static final List<RouteNode> ROUTE_NODES = List.of(
+		new RouteNode(
+			"node-sangnoksu-elevator-1",
+			"station-sangnoksu",
+			RouteNodeType.ELEVATOR,
+			"1번 출구 엘리베이터",
+			"B1",
+			new BigDecimal("37.302421"),
+			new BigDecimal("126.866221"),
+			"facility-sangnoksu-elevator-1",
+			"layout-sangnoksu-draft",
+			120,
+			240,
+			"엘리베이터",
+			"휠체어 이동 가능"
+		),
+		new RouteNode(
+			"node-sangnoksu-faregate",
+			"station-sangnoksu",
+			RouteNodeType.FAREGATE,
+			"개찰구",
+			"B1",
+			null,
+			null,
+			null,
+			"layout-sangnoksu-draft",
+			260,
+			240,
+			"개찰구",
+			null
+		)
+	);
+
 	private final Map<String, AccessibilityFacility> accessibilityFacilities = new LinkedHashMap<>();
 
 	public InMemoryTransitMasterRepository() {
@@ -205,6 +240,11 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 	@Override
 	public List<SimplifiedStationLayout> loadSimplifiedStationLayouts() {
 		return SIMPLIFIED_STATION_LAYOUTS;
+	}
+
+	@Override
+	public List<RouteNode> loadRouteNodes() {
+		return ROUTE_NODES;
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
@@ -2,6 +2,7 @@ package com.easysubway.transit.application.port.in;
 
 import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.NearbyStation;
+import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.StationWithLines;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLayoutSource;
@@ -32,4 +33,6 @@ public interface TransitMasterQueryUseCase {
 	List<StationLayoutSource> listStationLayoutSources(String stationId);
 
 	List<SimplifiedStationLayout> listSimplifiedStationLayouts(String stationId);
+
+	List<RouteNode> listRouteNodes(String stationId);
 }

--- a/backend/src/main/java/com/easysubway/transit/application/port/out/LoadTransitMasterPort.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/out/LoadTransitMasterPort.java
@@ -1,6 +1,7 @@
 package com.easysubway.transit.application.port.out;
 
 import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLayoutSource;
@@ -31,6 +32,10 @@ public interface LoadTransitMasterPort {
 
 	default List<SimplifiedStationLayout> loadSimplifiedStationLayouts() {
 		throw new UnsupportedOperationException("Simplified station layout loading is not implemented.");
+	}
+
+	default List<RouteNode> loadRouteNodes() {
+		throw new UnsupportedOperationException("Route node loading is not implemented.");
 	}
 
 	default Optional<Station> loadStation(String stationId) {

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -15,6 +15,7 @@ import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.InvalidAccessibilityFacilityException;
 import com.easysubway.transit.domain.NearbyStation;
+import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLayoutSource;
@@ -185,6 +186,15 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		return loadTransitMasterPort.loadSimplifiedStationLayouts()
 			.stream()
 			.filter(layout -> layout.stationId().equals(stationId))
+			.toList();
+	}
+
+	@Override
+	public List<RouteNode> listRouteNodes(String stationId) {
+		loadActiveStation(stationId);
+		return loadTransitMasterPort.loadRouteNodes()
+			.stream()
+			.filter(node -> node.stationId().equals(stationId))
 			.toList();
 	}
 

--- a/backend/src/main/java/com/easysubway/transit/domain/RouteNode.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/RouteNode.java
@@ -1,0 +1,79 @@
+package com.easysubway.transit.domain;
+
+import java.math.BigDecimal;
+
+public record RouteNode(
+	String id,
+	String stationId,
+	RouteNodeType type,
+	String name,
+	String floor,
+	BigDecimal latitude,
+	BigDecimal longitude,
+	String facilityId,
+	String layoutId,
+	int displayX,
+	int displayY,
+	String displayLabel,
+	String accessibilityNote
+) {
+
+	public RouteNode {
+		id = requireText(id, "id");
+		stationId = requireText(stationId, "stationId");
+		type = requireNonNull(type, "type");
+		name = requireText(name, "name");
+		floor = requireText(floor, "floor");
+		requireCoordinates(latitude, longitude);
+		facilityId = cleanOptionalText(facilityId);
+		layoutId = requireText(layoutId, "layoutId");
+		requireDisplayCoordinate(displayX, "displayX");
+		requireDisplayCoordinate(displayY, "displayY");
+		displayLabel = requireText(displayLabel, "displayLabel");
+		accessibilityNote = cleanOptionalText(accessibilityNote);
+	}
+
+	private static void requireCoordinates(BigDecimal latitude, BigDecimal longitude) {
+		if ((latitude == null) != (longitude == null)) {
+			throw new IllegalArgumentException("latitude and longitude must be provided together.");
+		}
+		if (latitude == null) {
+			return;
+		}
+		requireCoordinateRange(latitude, "-90", "90", "latitude");
+		requireCoordinateRange(longitude, "-180", "180", "longitude");
+	}
+
+	private static void requireCoordinateRange(BigDecimal value, String minimum, String maximum, String fieldName) {
+		if (value.compareTo(new BigDecimal(minimum)) < 0 || value.compareTo(new BigDecimal(maximum)) > 0) {
+			throw new IllegalArgumentException(fieldName + " must be between " + minimum + " and " + maximum + ".");
+		}
+	}
+
+	private static void requireDisplayCoordinate(int value, String fieldName) {
+		if (value < 0) {
+			throw new IllegalArgumentException(fieldName + " must not be negative.");
+		}
+	}
+
+	private static String cleanOptionalText(String value) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		return value.trim();
+	}
+
+	private static String requireText(String value, String fieldName) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(fieldName + " must not be blank.");
+		}
+		return value.trim();
+	}
+
+	private static <T> T requireNonNull(T value, String fieldName) {
+		if (value == null) {
+			throw new IllegalArgumentException(fieldName + " must not be null.");
+		}
+		return value;
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/RouteNodeType.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/RouteNodeType.java
@@ -1,0 +1,18 @@
+package com.easysubway.transit.domain;
+
+public enum RouteNodeType {
+	ENTRANCE,
+	EXIT,
+	CONCOURSE,
+	FAREGATE,
+	PLATFORM,
+	TRANSFER_PASSAGE,
+	ELEVATOR,
+	ESCALATOR,
+	STAIR,
+	RAMP,
+	TOILET,
+	ACCESSIBLE_TOILET,
+	NURSING_ROOM,
+	CUSTOMER_CENTER
+}

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -311,6 +311,48 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 역별 내부 이동 노드의 유형과 표시 정보를 조회한다")
+	void adminListsRouteNodesWithDisplayMetadata() throws Exception {
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/route-nodes")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].id").value("node-sangnoksu-elevator-1"))
+			.andExpect(jsonPath("$.data[0].stationId").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data[0].type").value("ELEVATOR"))
+			.andExpect(jsonPath("$.data[0].name").value("1번 출구 엘리베이터"))
+			.andExpect(jsonPath("$.data[0].floor").value("B1"))
+			.andExpect(jsonPath("$.data[0].facilityId").value("facility-sangnoksu-elevator-1"))
+			.andExpect(jsonPath("$.data[0].layoutId").value("layout-sangnoksu-draft"))
+			.andExpect(jsonPath("$.data[0].displayX").value(120))
+			.andExpect(jsonPath("$.data[0].displayY").value(240))
+			.andExpect(jsonPath("$.data[0].displayLabel").value("엘리베이터"))
+			.andExpect(jsonPath("$.data[0].accessibilityNote").value("휠체어 이동 가능"));
+	}
+
+	@Test
+	@DisplayName("내부 이동 노드 관리자 API는 관리자 인증을 요구한다")
+	void adminRouteNodesRequireAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/route-nodes"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/route-nodes")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 역의 내부 이동 노드는 공통 404 응답을 반환한다")
+	void missingRouteNodesReturnCommonErrorResponse() throws Exception {
+		mockMvc.perform(get("/admin/stations/unknown-station/route-nodes")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("역 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
 	@DisplayName("관리자는 시설 상태를 수정하고 공개 시설 목록에서 확인할 수 있다")
 	@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
 	void adminUpdatesFacilityStatusAndPublicListReflectsIt() throws Exception {

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -18,6 +18,7 @@ import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.InvalidAccessibilityFacilityException;
+import com.easysubway.transit.domain.RouteNodeType;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLine;
@@ -217,8 +218,24 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
-	@DisplayName("역 출구와 시설과 구조도 목록은 존재하는 역을 요구한다")
-	void stationExitsFacilitiesAndLayoutsRequireExistingStation() {
+	@DisplayName("내부 이동 노드는 구조도와 현장 표시 정보를 함께 반환한다")
+	void listRouteNodesReturnsLayoutAndDisplayMetadata() {
+		var nodes = service.listRouteNodes("station-sangnoksu");
+
+		assertThat(nodes)
+			.extracting("id")
+			.containsExactly("node-sangnoksu-elevator-1", "node-sangnoksu-faregate");
+		assertThat(nodes.getFirst().type()).isEqualTo(RouteNodeType.ELEVATOR);
+		assertThat(nodes.getFirst().layoutId()).isEqualTo("layout-sangnoksu-draft");
+		assertThat(nodes.getFirst().facilityId()).isEqualTo("facility-sangnoksu-elevator-1");
+		assertThat(nodes.getFirst().displayLabel()).isEqualTo("엘리베이터");
+		assertThat(nodes.getFirst().displayX()).isEqualTo(120);
+		assertThat(nodes.getFirst().displayY()).isEqualTo(240);
+	}
+
+	@Test
+	@DisplayName("역 출구와 시설과 구조도와 노드 목록은 존재하는 역을 요구한다")
+	void stationExitsFacilitiesLayoutsAndNodesRequireExistingStation() {
 		assertThatThrownBy(() -> service.listStationExits("missing"))
 			.isInstanceOf(StationNotFoundException.class)
 			.hasMessage("역 정보를 찾을 수 없습니다.");
@@ -229,6 +246,9 @@ class TransitMasterServiceTest {
 			.isInstanceOf(StationNotFoundException.class)
 			.hasMessage("역 정보를 찾을 수 없습니다.");
 		assertThatThrownBy(() -> service.listSimplifiedStationLayouts("missing"))
+			.isInstanceOf(StationNotFoundException.class)
+			.hasMessage("역 정보를 찾을 수 없습니다.");
+		assertThatThrownBy(() -> service.listRouteNodes("missing"))
 			.isInstanceOf(StationNotFoundException.class)
 			.hasMessage("역 정보를 찾을 수 없습니다.");
 	}

--- a/backend/src/test/java/com/easysubway/transit/domain/RouteNodeTest.java
+++ b/backend/src/test/java/com/easysubway/transit/domain/RouteNodeTest.java
@@ -1,0 +1,108 @@
+package com.easysubway.transit.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("내부 이동 노드")
+class RouteNodeTest {
+
+	@Test
+	@DisplayName("필수 문자열은 공백을 정리해 저장한다")
+	void trimsRequiredTextFields() {
+		var node = new RouteNode(
+			" node-sangnoksu-elevator-1 ",
+			" station-sangnoksu ",
+			RouteNodeType.ELEVATOR,
+			" 1번 출구 엘리베이터 ",
+			" B1 ",
+			new BigDecimal("37.302421"),
+			new BigDecimal("126.866221"),
+			" facility-sangnoksu-elevator-1 ",
+			" layout-sangnoksu-draft ",
+			120,
+			240,
+			" 엘리베이터 ",
+			" 휠체어 이동 가능 "
+		);
+
+		assertThat(node.id()).isEqualTo("node-sangnoksu-elevator-1");
+		assertThat(node.stationId()).isEqualTo("station-sangnoksu");
+		assertThat(node.name()).isEqualTo("1번 출구 엘리베이터");
+		assertThat(node.facilityId()).isEqualTo("facility-sangnoksu-elevator-1");
+		assertThat(node.layoutId()).isEqualTo("layout-sangnoksu-draft");
+		assertThat(node.displayLabel()).isEqualTo("엘리베이터");
+		assertThat(node.accessibilityNote()).isEqualTo("휠체어 이동 가능");
+	}
+
+	@Test
+	@DisplayName("표시 좌표는 0 이상이어야 한다")
+	void rejectsNegativeDisplayCoordinates() {
+		assertThatThrownBy(() -> nodeWithDisplayX(-1))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("displayX must not be negative.");
+	}
+
+	@Test
+	@DisplayName("위도와 경도는 함께 있거나 함께 없어야 한다")
+	void rejectsOnlyOneCoordinate() {
+		assertThatThrownBy(() -> new RouteNode(
+			"node-sangnoksu-elevator-1",
+			"station-sangnoksu",
+			RouteNodeType.ELEVATOR,
+			"1번 출구 엘리베이터",
+			"B1",
+			new BigDecimal("37.302421"),
+			null,
+			"facility-sangnoksu-elevator-1",
+			"layout-sangnoksu-draft",
+			120,
+			240,
+			"엘리베이터",
+			"휠체어 이동 가능"
+		))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("latitude and longitude must be provided together.");
+	}
+
+	@Test
+	@DisplayName("위도와 경도는 실제 좌표 범위를 벗어날 수 없다")
+	void rejectsOutOfRangeCoordinates() {
+		assertThatThrownBy(() -> nodeWithCoordinates(new BigDecimal("91"), new BigDecimal("126.866221")))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("latitude must be between -90 and 90.");
+
+		assertThatThrownBy(() -> nodeWithCoordinates(new BigDecimal("37.302421"), new BigDecimal("181")))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("longitude must be between -180 and 180.");
+	}
+
+	private RouteNode nodeWithDisplayX(int displayX) {
+		return nodeWithCoordinatesAndDisplayX(new BigDecimal("37.302421"), new BigDecimal("126.866221"), displayX);
+	}
+
+	private RouteNode nodeWithCoordinates(BigDecimal latitude, BigDecimal longitude) {
+		return nodeWithCoordinatesAndDisplayX(latitude, longitude, 120);
+	}
+
+	private RouteNode nodeWithCoordinatesAndDisplayX(BigDecimal latitude, BigDecimal longitude, int displayX) {
+		return new RouteNode(
+			"node-sangnoksu-elevator-1",
+			"station-sangnoksu",
+			RouteNodeType.ELEVATOR,
+			"1번 출구 엘리베이터",
+			"B1",
+			latitude,
+			longitude,
+			"facility-sangnoksu-elevator-1",
+			"layout-sangnoksu-draft",
+			displayX,
+			240,
+			"엘리베이터",
+			"휠체어 이동 가능"
+		);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #266

## 작업 배경

- 역 내부 구조도 초안만으로는 엘리베이터, 개찰구, 출입구처럼 실제 이동 판단에 쓰이는 지점을 개별적으로 다루기 어렵습니다.
- 교통약자 길찾기에서는 "어느 지점에서 어디로 이동하는지"를 명확히 표현해야 하므로, 경로 간선 모델을 추가하기 전에 내부 이동 노드 기준이 필요합니다.

## 작업 내용

- 내부 이동 노드 도메인 모델과 노드 유형 enum을 추가했습니다.
- 노드 생성 시 필수 문자열, 표시 좌표, GPS 좌표 쌍, 위도/경도 범위를 검증하도록 했습니다.
- 역별 내부 이동 노드 목록을 조회하는 use case와 persistence port를 추가했습니다.
- 관리자 API `GET /admin/stations/{stationId}/route-nodes`를 추가했습니다.
- 상록수역 샘플 노드로 엘리베이터와 개찰구 데이터를 구성했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.transit.domain.RouteNodeTest --tests com.easysubway.transit.application.service.TransitMasterServiceTest --tests com.easysubway.transit.adapter.in.web.TransitMasterControllerTest` 성공
  - `./gradlew test` 성공
  - `git diff --check` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteNode`의 필수값 및 좌표 검증 범위
  - 관리자 조회 API 응답 필드가 추후 앱 화면 표시와 경로 그래프 구성에 충분한지
  - `LoadTransitMasterPort`의 기본 메서드 추가가 기존 테스트 어댑터와 호환되는지

## 리스크

- 현재는 노드 조회 기준만 추가했으며, 노드 간 연결 관계나 앱 내 구조도 렌더링은 포함하지 않았습니다.
- 샘플 데이터는 상록수역 기준 최소 데이터라 실제 역별 운영 데이터 연동 시 별도 검증이 필요합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. rate limit으로 실제 리뷰가 시작되지 않았다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
