### PR TITLE
[Feat] 내부 이동 간선 모델 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
@@ -13,6 +13,8 @@ import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.NearbyStation;
+import com.easysubway.transit.domain.RouteEdge;
+import com.easysubway.transit.domain.RouteEdgeType;
 import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.RouteNodeType;
 import com.easysubway.transit.domain.Station;
@@ -166,6 +168,16 @@ class TransitMasterController {
 		List<RouteNodeResponse> response = transitMasterQueryUseCase.listRouteNodes(stationId)
 			.stream()
 			.map(RouteNodeResponse::from)
+			.toList();
+
+		return ApiResponse.ok(response);
+	}
+
+	@GetMapping("/admin/stations/{stationId}/route-edges")
+	ApiResponse<List<RouteEdgeResponse>> routeEdges(@PathVariable String stationId) {
+		List<RouteEdgeResponse> response = transitMasterQueryUseCase.listRouteEdges(stationId)
+			.stream()
+			.map(RouteEdgeResponse::from)
 			.toList();
 
 		return ApiResponse.ok(response);
@@ -526,6 +538,43 @@ class TransitMasterController {
 				node.displayY(),
 				node.displayLabel(),
 				node.accessibilityNote()
+			);
+		}
+	}
+
+	record RouteEdgeResponse(
+		String id,
+		String stationId,
+		String fromNodeId,
+		String toNodeId,
+		RouteEdgeType type,
+		int distanceMeters,
+		int estimatedSeconds,
+		boolean hasStairs,
+		boolean requiresElevator,
+		boolean requiresEscalator,
+		int slopeLevel,
+		int widthLevel,
+		int reliabilityScore,
+		boolean active
+	) {
+
+		static RouteEdgeResponse from(RouteEdge edge) {
+			return new RouteEdgeResponse(
+				edge.id(),
+				edge.stationId(),
+				edge.fromNodeId(),
+				edge.toNodeId(),
+				edge.type(),
+				edge.distanceMeters(),
+				edge.estimatedSeconds(),
+				edge.hasStairs(),
+				edge.requiresElevator(),
+				edge.requiresEscalator(),
+				edge.slopeLevel(),
+				edge.widthLevel(),
+				edge.reliabilityScore(),
+				edge.active()
 			);
 		}
 	}

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -8,6 +8,8 @@ import com.easysubway.transit.domain.AccessibilityFacilityType;
 import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.RouteEdge;
+import com.easysubway.transit.domain.RouteEdgeType;
 import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.RouteNodeType;
 import com.easysubway.transit.domain.Station;
@@ -196,6 +198,25 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 		)
 	);
 
+	private static final List<RouteEdge> ROUTE_EDGES = List.of(
+		new RouteEdge(
+			"edge-sangnoksu-elevator-to-faregate",
+			"station-sangnoksu",
+			"node-sangnoksu-elevator-1",
+			"node-sangnoksu-faregate",
+			RouteEdgeType.WALK,
+			28,
+			75,
+			false,
+			true,
+			false,
+			1,
+			2,
+			92,
+			true
+		)
+	);
+
 	private final Map<String, AccessibilityFacility> accessibilityFacilities = new LinkedHashMap<>();
 
 	public InMemoryTransitMasterRepository() {
@@ -245,6 +266,11 @@ public class InMemoryTransitMasterRepository implements LoadTransitMasterPort, S
 	@Override
 	public List<RouteNode> loadRouteNodes() {
 		return ROUTE_NODES;
+	}
+
+	@Override
+	public List<RouteEdge> loadRouteEdges() {
+		return ROUTE_EDGES;
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterQueryUseCase.java
@@ -2,6 +2,7 @@ package com.easysubway.transit.application.port.in;
 
 import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.NearbyStation;
+import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.StationWithLines;
 import com.easysubway.transit.domain.StationExit;
@@ -35,4 +36,6 @@ public interface TransitMasterQueryUseCase {
 	List<SimplifiedStationLayout> listSimplifiedStationLayouts(String stationId);
 
 	List<RouteNode> listRouteNodes(String stationId);
+
+	List<RouteEdge> listRouteEdges(String stationId);
 }

--- a/backend/src/main/java/com/easysubway/transit/application/port/out/LoadTransitMasterPort.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/out/LoadTransitMasterPort.java
@@ -1,6 +1,7 @@
 package com.easysubway.transit.application.port.out;
 
 import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
@@ -36,6 +37,10 @@ public interface LoadTransitMasterPort {
 
 	default List<RouteNode> loadRouteNodes() {
 		throw new UnsupportedOperationException("Route node loading is not implemented.");
+	}
+
+	default List<RouteEdge> loadRouteEdges() {
+		throw new UnsupportedOperationException("Route edge loading is not implemented.");
 	}
 
 	default Optional<Station> loadStation(String stationId) {

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -15,6 +15,7 @@ import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.InvalidAccessibilityFacilityException;
 import com.easysubway.transit.domain.NearbyStation;
+import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
@@ -195,6 +196,15 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		return loadTransitMasterPort.loadRouteNodes()
 			.stream()
 			.filter(node -> node.stationId().equals(stationId))
+			.toList();
+	}
+
+	@Override
+	public List<RouteEdge> listRouteEdges(String stationId) {
+		loadActiveStation(stationId);
+		return loadTransitMasterPort.loadRouteEdges()
+			.stream()
+			.filter(edge -> edge.stationId().equals(stationId))
 			.toList();
 	}
 

--- a/backend/src/main/java/com/easysubway/transit/domain/RouteEdge.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/RouteEdge.java
@@ -1,0 +1,64 @@
+package com.easysubway.transit.domain;
+
+public record RouteEdge(
+	String id,
+	String stationId,
+	String fromNodeId,
+	String toNodeId,
+	RouteEdgeType type,
+	int distanceMeters,
+	int estimatedSeconds,
+	boolean hasStairs,
+	boolean requiresElevator,
+	boolean requiresEscalator,
+	int slopeLevel,
+	int widthLevel,
+	int reliabilityScore,
+	boolean active
+) {
+
+	public RouteEdge {
+		id = requireText(id, "id");
+		stationId = requireText(stationId, "stationId");
+		fromNodeId = requireText(fromNodeId, "fromNodeId");
+		toNodeId = requireText(toNodeId, "toNodeId");
+		type = requireNonNull(type, "type");
+		requireNotNegative(distanceMeters, "distanceMeters");
+		requireNotNegative(estimatedSeconds, "estimatedSeconds");
+		requireLevel(slopeLevel, "slopeLevel");
+		requireLevel(widthLevel, "widthLevel");
+		requireReliabilityScore(reliabilityScore);
+	}
+
+	private static void requireNotNegative(int value, String fieldName) {
+		if (value < 0) {
+			throw new IllegalArgumentException(fieldName + " must not be negative.");
+		}
+	}
+
+	private static void requireLevel(int value, String fieldName) {
+		if (value < 1 || value > 5) {
+			throw new IllegalArgumentException(fieldName + " must be between 1 and 5.");
+		}
+	}
+
+	private static void requireReliabilityScore(int value) {
+		if (value < 0 || value > 100) {
+			throw new IllegalArgumentException("reliabilityScore must be between 0 and 100.");
+		}
+	}
+
+	private static String requireText(String value, String fieldName) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(fieldName + " must not be blank.");
+		}
+		return value.trim();
+	}
+
+	private static <T> T requireNonNull(T value, String fieldName) {
+		if (value == null) {
+			throw new IllegalArgumentException(fieldName + " must not be null.");
+		}
+		return value;
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/RouteEdgeType.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/RouteEdgeType.java
@@ -1,0 +1,11 @@
+package com.easysubway.transit.domain;
+
+public enum RouteEdgeType {
+	WALK,
+	STAIR,
+	ELEVATOR,
+	ESCALATOR,
+	RAMP,
+	TRAIN,
+	TRANSFER
+}

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -353,6 +353,51 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 역별 내부 이동 간선의 난이도와 접근성 제약을 조회한다")
+	void adminListsRouteEdgesWithAccessibilityMetadata() throws Exception {
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/route-edges")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].id").value("edge-sangnoksu-elevator-to-faregate"))
+			.andExpect(jsonPath("$.data[0].stationId").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data[0].fromNodeId").value("node-sangnoksu-elevator-1"))
+			.andExpect(jsonPath("$.data[0].toNodeId").value("node-sangnoksu-faregate"))
+			.andExpect(jsonPath("$.data[0].type").value("WALK"))
+			.andExpect(jsonPath("$.data[0].distanceMeters").value(28))
+			.andExpect(jsonPath("$.data[0].estimatedSeconds").value(75))
+			.andExpect(jsonPath("$.data[0].hasStairs").value(false))
+			.andExpect(jsonPath("$.data[0].requiresElevator").value(true))
+			.andExpect(jsonPath("$.data[0].requiresEscalator").value(false))
+			.andExpect(jsonPath("$.data[0].slopeLevel").value(1))
+			.andExpect(jsonPath("$.data[0].widthLevel").value(2))
+			.andExpect(jsonPath("$.data[0].reliabilityScore").value(92))
+			.andExpect(jsonPath("$.data[0].active").value(true));
+	}
+
+	@Test
+	@DisplayName("내부 이동 간선 관리자 API는 관리자 인증을 요구한다")
+	void adminRouteEdgesRequireAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/route-edges"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/route-edges")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 역의 내부 이동 간선은 공통 404 응답을 반환한다")
+	void missingRouteEdgesReturnCommonErrorResponse() throws Exception {
+		mockMvc.perform(get("/admin/stations/unknown-station/route-edges")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("역 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
 	@DisplayName("관리자는 시설 상태를 수정하고 공개 시설 목록에서 확인할 수 있다")
 	@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
 	void adminUpdatesFacilityStatusAndPublicListReflectsIt() throws Exception {

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -18,6 +18,7 @@ import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.InvalidAccessibilityFacilityException;
+import com.easysubway.transit.domain.RouteEdgeType;
 import com.easysubway.transit.domain.RouteNodeType;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
@@ -234,8 +235,29 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
-	@DisplayName("역 출구와 시설과 구조도와 노드 목록은 존재하는 역을 요구한다")
-	void stationExitsFacilitiesLayoutsAndNodesRequireExistingStation() {
+	@DisplayName("내부 이동 간선은 이동 난이도와 접근성 제약을 함께 반환한다")
+	void listRouteEdgesReturnsDifficultyAndAccessibilityMetadata() {
+		var edges = service.listRouteEdges("station-sangnoksu");
+
+		assertThat(edges)
+			.extracting("id")
+			.containsExactly("edge-sangnoksu-elevator-to-faregate");
+		assertThat(edges.getFirst().type()).isEqualTo(RouteEdgeType.WALK);
+		assertThat(edges.getFirst().fromNodeId()).isEqualTo("node-sangnoksu-elevator-1");
+		assertThat(edges.getFirst().toNodeId()).isEqualTo("node-sangnoksu-faregate");
+		assertThat(edges.getFirst().distanceMeters()).isEqualTo(28);
+		assertThat(edges.getFirst().estimatedSeconds()).isEqualTo(75);
+		assertThat(edges.getFirst().hasStairs()).isFalse();
+		assertThat(edges.getFirst().requiresElevator()).isTrue();
+		assertThat(edges.getFirst().slopeLevel()).isEqualTo(1);
+		assertThat(edges.getFirst().widthLevel()).isEqualTo(2);
+		assertThat(edges.getFirst().reliabilityScore()).isEqualTo(92);
+		assertThat(edges.getFirst().active()).isTrue();
+	}
+
+	@Test
+	@DisplayName("역 출구와 시설과 구조도와 노드와 간선 목록은 존재하는 역을 요구한다")
+	void stationExitsFacilitiesLayoutsNodesAndEdgesRequireExistingStation() {
 		assertThatThrownBy(() -> service.listStationExits("missing"))
 			.isInstanceOf(StationNotFoundException.class)
 			.hasMessage("역 정보를 찾을 수 없습니다.");
@@ -249,6 +271,9 @@ class TransitMasterServiceTest {
 			.isInstanceOf(StationNotFoundException.class)
 			.hasMessage("역 정보를 찾을 수 없습니다.");
 		assertThatThrownBy(() -> service.listRouteNodes("missing"))
+			.isInstanceOf(StationNotFoundException.class)
+			.hasMessage("역 정보를 찾을 수 없습니다.");
+		assertThatThrownBy(() -> service.listRouteEdges("missing"))
 			.isInstanceOf(StationNotFoundException.class)
 			.hasMessage("역 정보를 찾을 수 없습니다.");
 	}

--- a/backend/src/test/java/com/easysubway/transit/domain/RouteEdgeTest.java
+++ b/backend/src/test/java/com/easysubway/transit/domain/RouteEdgeTest.java
@@ -1,0 +1,114 @@
+package com.easysubway.transit.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("내부 이동 간선")
+class RouteEdgeTest {
+
+	@Test
+	@DisplayName("필수 문자열은 공백을 정리해 저장한다")
+	void trimsRequiredTextFields() {
+		var edge = new RouteEdge(
+			" edge-sangnoksu-elevator-to-faregate ",
+			" station-sangnoksu ",
+			" node-sangnoksu-elevator-1 ",
+			" node-sangnoksu-faregate ",
+			RouteEdgeType.WALK,
+			28,
+			75,
+			false,
+			true,
+			false,
+			1,
+			2,
+			92,
+			true
+		);
+
+		assertThat(edge.id()).isEqualTo("edge-sangnoksu-elevator-to-faregate");
+		assertThat(edge.stationId()).isEqualTo("station-sangnoksu");
+		assertThat(edge.fromNodeId()).isEqualTo("node-sangnoksu-elevator-1");
+		assertThat(edge.toNodeId()).isEqualTo("node-sangnoksu-faregate");
+	}
+
+	@Test
+	@DisplayName("거리와 예상 시간은 0 이상이어야 한다")
+	void rejectsNegativeDistanceAndSeconds() {
+		assertThatThrownBy(() -> edgeWithDistanceMeters(-1))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("distanceMeters must not be negative.");
+
+		assertThatThrownBy(() -> edgeWithEstimatedSeconds(-1))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("estimatedSeconds must not be negative.");
+	}
+
+	@Test
+	@DisplayName("경사와 통로 폭 수준은 1에서 5 사이여야 한다")
+	void rejectsOutOfRangeSlopeAndWidthLevels() {
+		assertThatThrownBy(() -> edgeWithSlopeLevel(0))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("slopeLevel must be between 1 and 5.");
+
+		assertThatThrownBy(() -> edgeWithWidthLevel(6))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("widthLevel must be between 1 and 5.");
+	}
+
+	@Test
+	@DisplayName("신뢰도 점수는 0에서 100 사이여야 한다")
+	void rejectsOutOfRangeReliabilityScore() {
+		assertThatThrownBy(() -> edgeWithReliabilityScore(101))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("reliabilityScore must be between 0 and 100.");
+	}
+
+	private RouteEdge edgeWithDistanceMeters(int distanceMeters) {
+		return edge(distanceMeters, 75, 1, 2, 92);
+	}
+
+	private RouteEdge edgeWithEstimatedSeconds(int estimatedSeconds) {
+		return edge(28, estimatedSeconds, 1, 2, 92);
+	}
+
+	private RouteEdge edgeWithSlopeLevel(int slopeLevel) {
+		return edge(28, 75, slopeLevel, 2, 92);
+	}
+
+	private RouteEdge edgeWithWidthLevel(int widthLevel) {
+		return edge(28, 75, 1, widthLevel, 92);
+	}
+
+	private RouteEdge edgeWithReliabilityScore(int reliabilityScore) {
+		return edge(28, 75, 1, 2, reliabilityScore);
+	}
+
+	private RouteEdge edge(
+		int distanceMeters,
+		int estimatedSeconds,
+		int slopeLevel,
+		int widthLevel,
+		int reliabilityScore
+	) {
+		return new RouteEdge(
+			"edge-sangnoksu-elevator-to-faregate",
+			"station-sangnoksu",
+			"node-sangnoksu-elevator-1",
+			"node-sangnoksu-faregate",
+			RouteEdgeType.WALK,
+			distanceMeters,
+			estimatedSeconds,
+			false,
+			true,
+			false,
+			slopeLevel,
+			widthLevel,
+			reliabilityScore,
+			true
+		);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #268

## 작업 배경

- 내부 이동 노드만으로는 엘리베이터에서 개찰구, 개찰구에서 승강장처럼 실제 이동 가능한 구간을 표현할 수 없습니다.
- 교통약자 경로 추천은 노드 사이의 계단 여부, 엘리베이터 필요 여부, 이동 거리와 신뢰도를 함께 판단해야 하므로 간선 기준이 필요합니다.

## 작업 내용

- 내부 이동 간선 도메인 모델과 간선 유형 enum을 추가했습니다.
- 간선 생성 시 필수 문자열, 거리, 예상 시간, 경사/폭 수준, 신뢰도 점수를 검증하도록 했습니다.
- 역별 내부 이동 간선 목록을 조회하는 use case와 persistence port를 추가했습니다.
- 관리자 API `GET /admin/stations/{stationId}/route-edges`를 추가했습니다.
- 상록수역 샘플 간선으로 엘리베이터에서 개찰구까지의 이동 구간을 구성했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.transit.domain.RouteEdgeTest --tests com.easysubway.transit.application.service.TransitMasterServiceTest --tests com.easysubway.transit.adapter.in.web.TransitMasterControllerTest` 성공
  - `./gradlew test` 성공
  - `git diff --check` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteEdge`의 거리, 시간, 경사/폭 수준, 신뢰도 검증 범위
  - 관리자 조회 API 응답 필드가 이후 경로 그래프 계산에 충분한지
  - `LoadTransitMasterPort`의 기본 메서드 추가가 기존 테스트 어댑터와 호환되는지

## 리스크

- 현재는 간선 조회 기준만 추가했으며, 실제 경로 탐색 알고리즘과 간선 편집 API는 포함하지 않았습니다.
- 샘플 데이터는 상록수역 기준 최소 데이터라 실제 역별 운영 데이터 연동 시 노드 참조 무결성 검증이 별도로 필요합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. rate limit으로 실제 리뷰가 시작되지 않았다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
