### PR TITLE
[Feat] 내부 이동 간선 경로 정책 반영

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -23,6 +23,7 @@ import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.AccessibilityFacilityType;
 import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.RouteEdge;
+import com.easysubway.transit.domain.RouteEdgeType;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLine;
@@ -376,6 +377,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.stream()
 			.filter(RouteEdge::active)
 			.filter(edge -> edge.stationId().equals(stationId))
+			.filter(this::isInternalMovementEdge)
 			.toList();
 		if (activeStationEdges.isEmpty()) {
 			return Optional.empty();
@@ -397,6 +399,13 @@ public class RouteSearchService implements RouteSearchUseCase {
 			return hasUsableStepFreeFacility(stationId);
 		}
 		return true;
+	}
+
+	private boolean isInternalMovementEdge(RouteEdge edge) {
+		return switch (edge.type()) {
+			case WALK, STAIR, ELEVATOR, ESCALATOR, RAMP -> true;
+			case TRAIN, TRANSFER -> false;
+		};
 	}
 
 	private String exitGuidance(String stationId, String fallbackGuidance) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -381,7 +381,22 @@ public class RouteSearchService implements RouteSearchUseCase {
 			return Optional.empty();
 		}
 		// 내부 이동 간선 데이터가 있으면 출구 요약보다 실제 승강장 연결 동선을 우선한다.
-		return Optional.of(activeStationEdges.stream().allMatch(RouteEdge::hasStairs));
+		boolean hasUsableStepFreeInternalEdge = activeStationEdges.stream()
+			.anyMatch(edge -> isUsableStepFreeInternalEdge(stationId, edge));
+		return Optional.of(!hasUsableStepFreeInternalEdge);
+	}
+
+	private boolean isUsableStepFreeInternalEdge(String stationId, RouteEdge edge) {
+		if (edge.hasStairs()) {
+			return false;
+		}
+		if (edge.requiresEscalator()) {
+			return false;
+		}
+		if (edge.requiresElevator()) {
+			return hasUsableStepFreeFacility(stationId);
+		}
+		return true;
 	}
 
 	private String exitGuidance(String stationId, String fallbackGuidance) {
@@ -406,6 +421,13 @@ public class RouteSearchService implements RouteSearchUseCase {
 			case ELEVATOR, WHEELCHAIR_LIFT, RAMP -> true;
 			default -> false;
 		};
+	}
+
+	private boolean hasUsableStepFreeFacility(String stationId) {
+		return stationFacilities(stationId).stream()
+			.filter(facility -> facility.dataConfidence() == DataConfidenceLevel.HIGH)
+			.filter(this::isStepFreeFacility)
+			.anyMatch(this::hasUsableStatus);
 	}
 
 	private boolean hasUsableStatus(AccessibilityFacility facility) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -22,6 +22,7 @@ import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.AccessibilityFacilityType;
 import com.easysubway.transit.domain.DataConfidenceLevel;
+import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLine;
@@ -343,6 +344,11 @@ public class RouteSearchService implements RouteSearchUseCase {
 	}
 
 	private boolean hasStairOnlyAccess(String stationId) {
+		Optional<Boolean> stairOnlyInternalEdges = hasStairOnlyInternalEdges(stationId);
+		if (stairOnlyInternalEdges.isPresent()) {
+			return stairOnlyInternalEdges.get();
+		}
+
 		List<StationExit> exits = stationExits(stationId);
 		if (exits.isEmpty()) {
 			return false;
@@ -363,6 +369,19 @@ public class RouteSearchService implements RouteSearchUseCase {
 		boolean hasUsableStepFreeExit = highConfidenceExits.stream()
 			.anyMatch(exit -> isUsableStepFreeExit(exit, highConfidenceStepFreeFacilities));
 		return !hasUsableStepFreeFacility && !hasUsableStepFreeExit;
+	}
+
+	private Optional<Boolean> hasStairOnlyInternalEdges(String stationId) {
+		List<RouteEdge> activeStationEdges = loadTransitMasterPort.loadRouteEdges()
+			.stream()
+			.filter(RouteEdge::active)
+			.filter(edge -> edge.stationId().equals(stationId))
+			.toList();
+		if (activeStationEdges.isEmpty()) {
+			return Optional.empty();
+		}
+		// 내부 이동 간선 데이터가 있으면 출구 요약보다 실제 승강장 연결 동선을 우선한다.
+		return Optional.of(activeStationEdges.stream().allMatch(RouteEdge::hasStairs));
 	}
 
 	private String exitGuidance(String stationId, String fallbackGuidance) {

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -609,6 +609,30 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 이동 유형은 비내부 간선이 섞여도 내부 계단 간선을 기준으로 차단한다")
+	void wheelchairRouteIgnoresNonInternalEdgesWhenCheckingInternalStairs() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeEdgeService = new RouteSearchService(
+			repository,
+			repository,
+			new MixedInternalAndTrainEdgeTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = routeEdgeService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
+		assertThat(result.steps()).isEmpty();
+		assertThat(result.warnings())
+			.extracting("code")
+			.contains(RouteWarningCode.STAIR_ONLY_ACCESS);
+	}
+
+	@Test
 	@DisplayName("유모차 이동 유형은 역 내부 활성 간선의 계단 포함을 경고와 단계에 표시한다")
 	void strollerRouteWarnsWhenInternalEdgesIncludeStairs() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -1207,6 +1231,19 @@ class RouteSearchServiceTest {
 		}
 	}
 
+	private static class MixedInternalAndTrainEdgeTransitMasterPort extends ExitSummaryAccessibleTransitMasterPort {
+
+		@Override
+		public List<RouteEdge> loadRouteEdges() {
+			return List.of(
+				stairEdge("edge-a-stair", "station-a"),
+				trainEdge("edge-a-train", "station-a"),
+				stairEdge("edge-b-stair", "station-b"),
+				trainEdge("edge-b-train", "station-b")
+			);
+		}
+	}
+
 	private static TransitOperator operator() {
 		return new TransitOperator(
 			"operator-a",
@@ -1358,6 +1395,25 @@ class RouteSearchServiceTest {
 			false,
 			1,
 			2,
+			95,
+			true
+		);
+	}
+
+	private static RouteEdge trainEdge(String id, String stationId) {
+		return new RouteEdge(
+			id,
+			stationId,
+			"node-" + stationId + "-platform",
+			"node-" + stationId + "-next-platform",
+			RouteEdgeType.TRAIN,
+			900,
+			120,
+			false,
+			false,
+			false,
+			1,
+			3,
 			95,
 			true
 		);

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -21,6 +21,8 @@ import com.easysubway.transit.domain.AccessibilityFacilityType;
 import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.RouteEdge;
+import com.easysubway.transit.domain.RouteEdgeType;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLine;
@@ -581,6 +583,58 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 이동 유형은 역 내부 활성 간선이 계단만 제공하면 경로를 차단한다")
+	void wheelchairRouteBlocksWhenInternalEdgesRequireStairs() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeEdgeService = new RouteSearchService(
+			repository,
+			repository,
+			new InternalStairEdgeTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = routeEdgeService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
+		assertThat(result.steps()).isEmpty();
+		assertThat(result.blockedReasons())
+			.containsExactly("계단 없는 역 접근 경로를 확인할 수 없습니다.");
+		assertThat(result.warnings())
+			.extracting("code")
+			.contains(RouteWarningCode.STAIR_ONLY_ACCESS);
+	}
+
+	@Test
+	@DisplayName("유모차 이동 유형은 역 내부 활성 간선의 계단 포함을 경고와 단계에 표시한다")
+	void strollerRouteWarnsWhenInternalEdgesIncludeStairs() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeEdgeService = new RouteSearchService(
+			repository,
+			repository,
+			new InternalStairEdgeTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = routeEdgeService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.STROLLER
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.warnings())
+			.extracting("code")
+			.contains(RouteWarningCode.STAIR_ONLY_ACCESS);
+		assertThat(result.steps())
+			.extracting("includesStairs")
+			.containsExactly(true, false, true);
+	}
+
+	@Test
 	@DisplayName("경로 검색은 존재하는 역과 공통 노선을 요구한다")
 	void searchRouteRequiresExistingStationsAndSharedLine() {
 		assertThatThrownBy(() -> service.searchRoute(new SearchRouteCommand(
@@ -727,6 +781,11 @@ class RouteSearchServiceTest {
 
 		@Override
 		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of();
+		}
+
+		@Override
+		public List<RouteEdge> loadRouteEdges() {
 			return List.of();
 		}
 	}
@@ -1094,6 +1153,17 @@ class RouteSearchServiceTest {
 		}
 	}
 
+	private static class InternalStairEdgeTransitMasterPort extends ExitSummaryAccessibleTransitMasterPort {
+
+		@Override
+		public List<RouteEdge> loadRouteEdges() {
+			return List.of(
+				stairEdge("edge-a-stair", "station-a"),
+				stairEdge("edge-b-stair", "station-b")
+			);
+		}
+	}
+
 	private static TransitOperator operator() {
 		return new TransitOperator(
 			"operator-a",
@@ -1209,6 +1279,25 @@ class RouteSearchServiceTest {
 			false,
 			DataConfidenceLevel.HIGH,
 			DataSourceType.OFFICIAL_FILE
+		);
+	}
+
+	private static RouteEdge stairEdge(String id, String stationId) {
+		return new RouteEdge(
+			id,
+			stationId,
+			"node-" + stationId + "-entrance",
+			"node-" + stationId + "-platform",
+			RouteEdgeType.STAIR,
+			30,
+			90,
+			true,
+			false,
+			false,
+			3,
+			2,
+			95,
+			true
 		);
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -635,6 +635,30 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 이동 유형은 내부 간선의 엘리베이터가 고장나면 계단 없는 경로로 보지 않는다")
+	void wheelchairRouteBlocksWhenInternalEdgeElevatorIsBroken() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeEdgeService = new RouteSearchService(
+			repository,
+			repository,
+			new BrokenElevatorInternalEdgeTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = routeEdgeService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
+		assertThat(result.steps()).isEmpty();
+		assertThat(result.warnings())
+			.extracting("code")
+			.contains(RouteWarningCode.STAIR_ONLY_ACCESS);
+	}
+
+	@Test
 	@DisplayName("경로 검색은 존재하는 역과 공통 노선을 요구한다")
 	void searchRouteRequiresExistingStationsAndSharedLine() {
 		assertThatThrownBy(() -> service.searchRoute(new SearchRouteCommand(
@@ -1164,6 +1188,25 @@ class RouteSearchServiceTest {
 		}
 	}
 
+	private static class BrokenElevatorInternalEdgeTransitMasterPort extends ExitSummaryAccessibleTransitMasterPort {
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(facility(
+				"facility-a-elevator",
+				"station-a",
+				"exit-a-2",
+				AccessibilityFacilityType.ELEVATOR,
+				AccessibilityFacilityStatus.BROKEN
+			));
+		}
+
+		@Override
+		public List<RouteEdge> loadRouteEdges() {
+			return List.of(elevatorEdge("edge-a-elevator", "station-a"));
+		}
+	}
+
 	private static TransitOperator operator() {
 		return new TransitOperator(
 			"operator-a",
@@ -1295,6 +1338,25 @@ class RouteSearchServiceTest {
 			false,
 			false,
 			3,
+			2,
+			95,
+			true
+		);
+	}
+
+	private static RouteEdge elevatorEdge(String id, String stationId) {
+		return new RouteEdge(
+			id,
+			stationId,
+			"node-" + stationId + "-entrance",
+			"node-" + stationId + "-platform",
+			RouteEdgeType.ELEVATOR,
+			30,
+			90,
+			false,
+			true,
+			false,
+			1,
 			2,
 			95,
 			true


### PR DESCRIPTION
## 관련 이슈

close #270

## 작업 배경

- 역 내부 이동 간선 데이터가 추가되었지만 경로 검색의 계단 차단과 경고 판단은 여전히 출구/시설 요약만 보고 있었다.
- 휠체어 사용자는 승강장까지의 실제 내부 이동 동선이 계단뿐이면 경로를 제공하면 안 되고, 유모차 등 보조 이동 유형은 같은 정보를 단계와 경고에서 확인할 수 있어야 한다.

## 작업 내용

- 경로 검색의 계단 전용 접근 판단에서 활성 `RouteEdge.hasStairs`를 출구/시설 요약보다 우선 사용하도록 반영했다.
- 활성 내부 이동 간선이 없는 역은 기존 출구/시설 기반 판정을 그대로 사용하게 유지했다.
- 엘리베이터가 고장난 내부 간선과 비내부 `TRAIN` 간선 혼합 케이스가 차단 정책을 우회하지 못하도록 보완했다.
- 휠체어 이동 유형 차단 케이스와 유모차 이동 유형 경고/단계 표시 케이스를 테스트로 추가했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest`: 성공
  - `./gradlew test`: 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 활성 내부 이동 간선이 있을 때만 간선 기반 판정으로 전환하고, 간선 데이터가 비어 있으면 기존 출구/시설 판정을 유지하는 조건
  - 내부 간선 중 엘리베이터 요구 동선은 사용 가능한 무단차 시설 상태를 함께 확인하는 조건
  - `TRAIN`, `TRANSFER` 같은 비내부 간선을 계단 접근 판정에서 제외하는 조건
  - `RouteSearchServiceTest`의 휠체어 차단과 유모차 경고/단계 표시 기대값

## 리스크

- 현재는 역 내부 간선의 타입, 계단 여부, 엘리베이터 필요 여부, 시설 상태를 조합해 접근 가능성을 판단한다. 상세 노드 그래프 기반의 대체 동선 탐색은 별도 작업으로 다뤄야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
