### PR TITLE
[Feat] 푸시 알림 발송 상태 처리

### DIFF
--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationController.java
@@ -1,10 +1,13 @@
 package com.easysubway.notification.adapter.in.web;
 
 import com.easysubway.common.web.ApiResponse;
+import com.easysubway.notification.application.port.in.DeliverPushNotificationsCommand;
 import com.easysubway.notification.application.port.in.DispatchPushNotificationCommand;
+import com.easysubway.notification.application.port.in.PushNotificationDeliveryUseCase;
 import com.easysubway.notification.application.port.in.PushNotificationDispatchUseCase;
 import com.easysubway.notification.domain.DevicePlatform;
 import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationDeliveryResult;
 import com.easysubway.notification.domain.PushNotificationDispatchResult;
 import com.easysubway.notification.domain.PushNotificationStatus;
 import com.easysubway.notification.domain.PushNotificationType;
@@ -18,9 +21,14 @@ import org.springframework.web.bind.annotation.RestController;
 class PushNotificationController {
 
 	private final PushNotificationDispatchUseCase pushNotificationDispatchUseCase;
+	private final PushNotificationDeliveryUseCase pushNotificationDeliveryUseCase;
 
-	PushNotificationController(PushNotificationDispatchUseCase pushNotificationDispatchUseCase) {
+	PushNotificationController(
+		PushNotificationDispatchUseCase pushNotificationDispatchUseCase,
+		PushNotificationDeliveryUseCase pushNotificationDeliveryUseCase
+	) {
 		this.pushNotificationDispatchUseCase = pushNotificationDispatchUseCase;
+		this.pushNotificationDeliveryUseCase = pushNotificationDeliveryUseCase;
 	}
 
 	@PostMapping("/admin/notifications/push")
@@ -36,12 +44,23 @@ class PushNotificationController {
 		return ApiResponse.ok(PushNotificationDispatchResponse.from(result));
 	}
 
+	@PostMapping("/admin/notifications/push/deliveries")
+	ApiResponse<PushNotificationDeliveryResponse> deliver(@RequestBody PushNotificationDeliveryRequest request) {
+		PushNotificationDeliveryResult result = pushNotificationDeliveryUseCase.deliverPending(
+			new DeliverPushNotificationsCommand(request.userId())
+		);
+		return ApiResponse.ok(PushNotificationDeliveryResponse.from(result));
+	}
+
 	record PushNotificationDispatchRequest(
 		String userId,
 		PushNotificationType type,
 		String title,
 		String body
 	) {
+	}
+
+	record PushNotificationDeliveryRequest(String userId) {
 	}
 
 	record PushNotificationDispatchResponse(
@@ -56,6 +75,27 @@ class PushNotificationController {
 				result.requestedUserId(),
 				result.type(),
 				result.createdCount(),
+				result.notifications().stream()
+					.map(PushNotificationResponse::from)
+					.toList()
+			);
+		}
+	}
+
+	record PushNotificationDeliveryResponse(
+		String requestedUserId,
+		int processedCount,
+		int sentCount,
+		int failedCount,
+		List<PushNotificationResponse> notifications
+	) {
+
+		static PushNotificationDeliveryResponse from(PushNotificationDeliveryResult result) {
+			return new PushNotificationDeliveryResponse(
+				result.requestedUserId(),
+				result.processedCount(),
+				result.sentCount(),
+				result.failedCount(),
 				result.notifications().stream()
 					.map(PushNotificationResponse::from)
 					.toList()

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
@@ -26,17 +26,25 @@ public class InMemoryPushNotificationOutboxRepository implements
 	@Override
 	public PushNotification savePushNotification(PushNotification notification) {
 		// outbox는 실제 발송 어댑터가 붙기 전까지 생성 순서를 보존해 운영자가 대기열을 확인할 수 있게 둔다.
-		List<PushNotification> notifications = notificationsByUserId.computeIfAbsent(
+		for (Map.Entry<String, List<PushNotification>> entry : notificationsByUserId.entrySet()) {
+			List<PushNotification> notifications = entry.getValue();
+			for (int index = 0; index < notifications.size(); index++) {
+				if (!notifications.get(index).notificationId().equals(notification.notificationId())) {
+					continue;
+				}
+				if (entry.getKey().equals(notification.userId())) {
+					notifications.set(index, notification);
+					return notification;
+				}
+				notifications.remove(index);
+				break;
+			}
+		}
+		List<PushNotification> targetNotifications = notificationsByUserId.computeIfAbsent(
 			notification.userId(),
 			ignored -> new CopyOnWriteArrayList<>()
 		);
-		for (int index = 0; index < notifications.size(); index++) {
-			if (notifications.get(index).notificationId().equals(notification.notificationId())) {
-				notifications.set(index, notification);
-				return notification;
-			}
-		}
-		notifications.add(notification);
+		targetNotifications.add(notification);
 		return notification;
 	}
 

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
@@ -1,8 +1,10 @@
 package com.easysubway.notification.adapter.out.persistence;
 
+import com.easysubway.notification.application.port.out.LoadPendingPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.LoadPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.SavePushNotificationOutboxPort;
 import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationStatus;
 import com.easysubway.user.application.port.out.DeleteUserPushNotificationPort;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Repository;
 @Profile("!prod")
 public class InMemoryPushNotificationOutboxRepository implements
 	LoadPushNotificationOutboxPort,
+	LoadPendingPushNotificationOutboxPort,
 	SavePushNotificationOutboxPort,
 	DeleteUserPushNotificationPort {
 
@@ -23,15 +26,30 @@ public class InMemoryPushNotificationOutboxRepository implements
 	@Override
 	public PushNotification savePushNotification(PushNotification notification) {
 		// outbox는 실제 발송 어댑터가 붙기 전까지 생성 순서를 보존해 운영자가 대기열을 확인할 수 있게 둔다.
-		notificationsByUserId
-			.computeIfAbsent(notification.userId(), ignored -> new CopyOnWriteArrayList<>())
-			.add(notification);
+		List<PushNotification> notifications = notificationsByUserId.computeIfAbsent(
+			notification.userId(),
+			ignored -> new CopyOnWriteArrayList<>()
+		);
+		for (int index = 0; index < notifications.size(); index++) {
+			if (notifications.get(index).notificationId().equals(notification.notificationId())) {
+				notifications.set(index, notification);
+				return notification;
+			}
+		}
+		notifications.add(notification);
 		return notification;
 	}
 
 	@Override
 	public List<PushNotification> loadPushNotifications(String userId) {
 		return List.copyOf(notificationsByUserId.getOrDefault(userId, List.of()));
+	}
+
+	@Override
+	public List<PushNotification> loadPendingPushNotifications(String userId) {
+		return notificationsByUserId.getOrDefault(userId, List.of()).stream()
+			.filter(notification -> notification.status() == PushNotificationStatus.PENDING)
+			.toList();
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
@@ -1,5 +1,6 @@
 package com.easysubway.notification.adapter.out.persistence;
 
+import com.easysubway.notification.application.port.out.LoadPendingPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.LoadPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.SavePushNotificationOutboxPort;
 import com.easysubway.notification.domain.DevicePlatform;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Repository;
 @Profile("prod")
 public class JdbcPushNotificationOutboxRepository implements
 	LoadPushNotificationOutboxPort,
+	LoadPendingPushNotificationOutboxPort,
 	SavePushNotificationOutboxPort,
 	DeleteUserPushNotificationPort {
 
@@ -52,6 +54,30 @@ public class JdbcPushNotificationOutboxRepository implements
 				""",
 			this::mapPushNotification,
 			userId
+		);
+	}
+
+	@Override
+	public List<PushNotification> loadPendingPushNotifications(String userId) {
+		return jdbcTemplate.query(
+			"""
+				SELECT notification_id,
+					user_id,
+					platform,
+					device_token,
+					notification_type,
+					title,
+					body,
+					status,
+					created_at
+				FROM push_notification_outbox
+				WHERE user_id = ?
+					AND status = ?
+				ORDER BY created_at ASC, notification_id ASC
+				""",
+			this::mapPushNotification,
+			userId,
+			PushNotificationStatus.PENDING.name()
 		);
 	}
 

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/push/UnavailablePushNotificationSender.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/push/UnavailablePushNotificationSender.java
@@ -1,0 +1,16 @@
+package com.easysubway.notification.adapter.out.push;
+
+import com.easysubway.notification.application.port.out.PushNotificationSenderPort;
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationSendResult;
+import org.springframework.stereotype.Component;
+
+@Component
+class UnavailablePushNotificationSender implements PushNotificationSenderPort {
+
+	@Override
+	public PushNotificationSendResult send(PushNotification notification) {
+		// 실제 FCM/APNs 어댑터가 붙기 전에는 성공으로 오인하지 않도록 명확히 실패로 기록한다.
+		return PushNotificationSendResult.failed("외부 푸시 발송 어댑터가 설정되지 않았습니다.");
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/DeliverPushNotificationsCommand.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/DeliverPushNotificationsCommand.java
@@ -1,0 +1,13 @@
+package com.easysubway.notification.application.port.in;
+
+import com.easysubway.notification.domain.InvalidPushNotificationException;
+
+public record DeliverPushNotificationsCommand(String userId) {
+
+	public DeliverPushNotificationsCommand {
+		if (userId == null || userId.isBlank()) {
+			throw new InvalidPushNotificationException("사용자 식별자가 필요합니다.");
+		}
+		userId = userId.trim();
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationDeliveryUseCase.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationDeliveryUseCase.java
@@ -1,0 +1,8 @@
+package com.easysubway.notification.application.port.in;
+
+import com.easysubway.notification.domain.PushNotificationDeliveryResult;
+
+public interface PushNotificationDeliveryUseCase {
+
+	PushNotificationDeliveryResult deliverPending(DeliverPushNotificationsCommand command);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/LoadPendingPushNotificationOutboxPort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/LoadPendingPushNotificationOutboxPort.java
@@ -1,0 +1,9 @@
+package com.easysubway.notification.application.port.out;
+
+import com.easysubway.notification.domain.PushNotification;
+import java.util.List;
+
+public interface LoadPendingPushNotificationOutboxPort {
+
+	List<PushNotification> loadPendingPushNotifications(String userId);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/PushNotificationSenderPort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/PushNotificationSenderPort.java
@@ -1,0 +1,9 @@
+package com.easysubway.notification.application.port.out;
+
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationSendResult;
+
+public interface PushNotificationSenderPort {
+
+	PushNotificationSendResult send(PushNotification notification);
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/PushNotificationSenderPort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/PushNotificationSenderPort.java
@@ -5,5 +5,9 @@ import com.easysubway.notification.domain.PushNotificationSendResult;
 
 public interface PushNotificationSenderPort {
 
+	/**
+	 * 외부 FCM/APNs 어댑터는 상태 저장 실패 후 재시도되어도 중복 발송되지 않도록
+	 * notificationId를 멱등성 키로 사용해야 한다.
+	 */
 	PushNotificationSendResult send(PushNotification notification);
 }

--- a/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDeliveryService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDeliveryService.java
@@ -7,6 +7,7 @@ import com.easysubway.notification.application.port.out.PushNotificationSenderPo
 import com.easysubway.notification.application.port.out.SavePushNotificationOutboxPort;
 import com.easysubway.notification.domain.PushNotification;
 import com.easysubway.notification.domain.PushNotificationDeliveryResult;
+import com.easysubway.notification.domain.PushNotificationSendResult;
 import com.easysubway.notification.domain.PushNotificationStatus;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +39,7 @@ public class PushNotificationDeliveryService implements PushNotificationDelivery
 		for (PushNotification notification : loadPendingPushNotificationOutboxPort.loadPendingPushNotifications(
 			command.userId()
 		)) {
-			var sendResult = pushNotificationSenderPort.send(notification);
+			var sendResult = safeSend(notification);
 			PushNotificationStatus nextStatus = sendResult.successful()
 				? PushNotificationStatus.SENT
 				: PushNotificationStatus.FAILED;
@@ -54,5 +55,13 @@ public class PushNotificationDeliveryService implements PushNotificationDelivery
 		}
 
 		return new PushNotificationDeliveryResult(command.userId(), sentCount, failedCount, deliveredNotifications);
+	}
+
+	private PushNotificationSendResult safeSend(PushNotification notification) {
+		try {
+			return pushNotificationSenderPort.send(notification);
+		} catch (RuntimeException exception) {
+			return PushNotificationSendResult.failed("푸시 발송 중 예외가 발생했습니다.");
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDeliveryService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDeliveryService.java
@@ -1,0 +1,58 @@
+package com.easysubway.notification.application.service;
+
+import com.easysubway.notification.application.port.in.DeliverPushNotificationsCommand;
+import com.easysubway.notification.application.port.in.PushNotificationDeliveryUseCase;
+import com.easysubway.notification.application.port.out.LoadPendingPushNotificationOutboxPort;
+import com.easysubway.notification.application.port.out.PushNotificationSenderPort;
+import com.easysubway.notification.application.port.out.SavePushNotificationOutboxPort;
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationDeliveryResult;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PushNotificationDeliveryService implements PushNotificationDeliveryUseCase {
+
+	private final LoadPendingPushNotificationOutboxPort loadPendingPushNotificationOutboxPort;
+	private final SavePushNotificationOutboxPort savePushNotificationOutboxPort;
+	private final PushNotificationSenderPort pushNotificationSenderPort;
+
+	public PushNotificationDeliveryService(
+		LoadPendingPushNotificationOutboxPort loadPendingPushNotificationOutboxPort,
+		SavePushNotificationOutboxPort savePushNotificationOutboxPort,
+		PushNotificationSenderPort pushNotificationSenderPort
+	) {
+		this.loadPendingPushNotificationOutboxPort = loadPendingPushNotificationOutboxPort;
+		this.savePushNotificationOutboxPort = savePushNotificationOutboxPort;
+		this.pushNotificationSenderPort = pushNotificationSenderPort;
+	}
+
+	@Override
+	public PushNotificationDeliveryResult deliverPending(DeliverPushNotificationsCommand command) {
+		List<PushNotification> deliveredNotifications = new ArrayList<>();
+		int sentCount = 0;
+		int failedCount = 0;
+
+		for (PushNotification notification : loadPendingPushNotificationOutboxPort.loadPendingPushNotifications(
+			command.userId()
+		)) {
+			var sendResult = pushNotificationSenderPort.send(notification);
+			PushNotificationStatus nextStatus = sendResult.successful()
+				? PushNotificationStatus.SENT
+				: PushNotificationStatus.FAILED;
+			PushNotification savedNotification = savePushNotificationOutboxPort.savePushNotification(
+				notification.withStatus(nextStatus)
+			);
+			deliveredNotifications.add(savedNotification);
+			if (sendResult.successful()) {
+				sentCount++;
+			} else {
+				failedCount++;
+			}
+		}
+
+		return new PushNotificationDeliveryResult(command.userId(), sentCount, failedCount, deliveredNotifications);
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotification.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotification.java
@@ -48,4 +48,18 @@ public record PushNotification(
 		title = title.trim();
 		body = body.trim();
 	}
+
+	public PushNotification withStatus(PushNotificationStatus nextStatus) {
+		return new PushNotification(
+			notificationId,
+			userId,
+			platform,
+			deviceToken,
+			type,
+			title,
+			body,
+			nextStatus,
+			createdAt
+		);
+	}
 }

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotificationDeliveryResult.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotificationDeliveryResult.java
@@ -1,0 +1,32 @@
+package com.easysubway.notification.domain;
+
+import java.util.List;
+
+public record PushNotificationDeliveryResult(
+	String requestedUserId,
+	int sentCount,
+	int failedCount,
+	List<PushNotification> notifications
+) {
+
+	public PushNotificationDeliveryResult {
+		if (requestedUserId == null || requestedUserId.isBlank()) {
+			throw new InvalidPushNotificationException("사용자 식별자가 필요합니다.");
+		}
+		if (sentCount < 0) {
+			throw new InvalidPushNotificationException("발송 완료 알림 수는 0 이상이어야 합니다.");
+		}
+		if (failedCount < 0) {
+			throw new InvalidPushNotificationException("발송 실패 알림 수는 0 이상이어야 합니다.");
+		}
+		if (notifications == null) {
+			throw new InvalidPushNotificationException("알림 목록이 필요합니다.");
+		}
+		requestedUserId = requestedUserId.trim();
+		notifications = List.copyOf(notifications);
+	}
+
+	public int processedCount() {
+		return sentCount + failedCount;
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotificationDeliveryResult.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotificationDeliveryResult.java
@@ -22,6 +22,9 @@ public record PushNotificationDeliveryResult(
 		if (notifications == null) {
 			throw new InvalidPushNotificationException("알림 목록이 필요합니다.");
 		}
+		if (sentCount + failedCount != notifications.size()) {
+			throw new InvalidPushNotificationException("처리 건수와 알림 목록 크기가 일치해야 합니다.");
+		}
 		requestedUserId = requestedUserId.trim();
 		notifications = List.copyOf(notifications);
 	}

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotificationSendResult.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotificationSendResult.java
@@ -1,0 +1,27 @@
+package com.easysubway.notification.domain;
+
+public record PushNotificationSendResult(
+	boolean successful,
+	String failureReason
+) {
+
+	public PushNotificationSendResult {
+		if (successful && failureReason != null && !failureReason.isBlank()) {
+			throw new InvalidPushNotificationException("발송 성공 결과에는 실패 사유를 둘 수 없습니다.");
+		}
+		if (!successful && (failureReason == null || failureReason.isBlank())) {
+			throw new InvalidPushNotificationException("발송 실패 사유가 필요합니다.");
+		}
+		if (failureReason != null) {
+			failureReason = failureReason.trim();
+		}
+	}
+
+	public static PushNotificationSendResult sent() {
+		return new PushNotificationSendResult(true, null);
+	}
+
+	public static PushNotificationSendResult failed(String failureReason) {
+		return new PushNotificationSendResult(false, failureReason);
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotificationSendResult.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotificationSendResult.java
@@ -6,14 +6,14 @@ public record PushNotificationSendResult(
 ) {
 
 	public PushNotificationSendResult {
-		if (successful && failureReason != null && !failureReason.isBlank()) {
+		if (failureReason != null) {
+			failureReason = failureReason.trim();
+		}
+		if (successful && failureReason != null) {
 			throw new InvalidPushNotificationException("발송 성공 결과에는 실패 사유를 둘 수 없습니다.");
 		}
 		if (!successful && (failureReason == null || failureReason.isBlank())) {
 			throw new InvalidPushNotificationException("발송 실패 사유가 필요합니다.");
-		}
-		if (failureReason != null) {
-			failureReason = failureReason.trim();
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotificationStatus.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotificationStatus.java
@@ -1,5 +1,7 @@
 package com.easysubway.notification.domain;
 
 public enum PushNotificationStatus {
-	PENDING
+	PENDING,
+	SENT,
+	FAILED
 }

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -244,7 +244,7 @@ CREATE TABLE IF NOT EXISTS push_notification_outbox (
 	CONSTRAINT chk_push_notification_outbox_type
 		CHECK (notification_type IN ('FAVORITE_STATION_FACILITY', 'FAVORITE_ROUTE_FACILITY', 'REPORT_STATUS', 'DATA_QUALITY')),
 	CONSTRAINT chk_push_notification_outbox_status
-		CHECK (status IN ('PENDING'))
+		CHECK (status IN ('PENDING', 'SENT', 'FAILED'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_push_notification_outbox_user_created

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -247,5 +247,12 @@ CREATE TABLE IF NOT EXISTS push_notification_outbox (
 		CHECK (status IN ('PENDING', 'SENT', 'FAILED'))
 );
 
+ALTER TABLE push_notification_outbox
+	DROP CONSTRAINT IF EXISTS chk_push_notification_outbox_status;
+
+ALTER TABLE push_notification_outbox
+	ADD CONSTRAINT chk_push_notification_outbox_status
+		CHECK (status IN ('PENDING', 'SENT', 'FAILED'));
+
 CREATE INDEX IF NOT EXISTS idx_push_notification_outbox_user_created
 	ON push_notification_outbox (user_id, created_at ASC, notification_id ASC);

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(properties = {
@@ -21,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 	"easysubway.user.password=user-test-password"
 })
 @AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @DisplayName("푸시 알림 발송 API")
 class PushNotificationControllerTest {
 
@@ -79,5 +81,52 @@ class PushNotificationControllerTest {
 					}
 					"""))
 			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("관리자는 대기 중인 푸시 알림 발송 처리를 실행할 수 있다")
+	void adminDeliversPendingPushNotifications() throws Exception {
+		mockMvc.perform(post("/api/v1/devices")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "platform": "ANDROID",
+					  "deviceToken": "secret-device-token"
+					}
+					"""))
+			.andExpect(status().isOk());
+
+		mockMvc.perform(post("/admin/notifications/push")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "type": "REPORT_STATUS",
+					  "title": "신고 처리 알림",
+					  "body": "제보한 내용이 확인되었습니다."
+					}
+					"""))
+			.andExpect(status().isOk());
+
+		mockMvc.perform(post("/admin/notifications/push/deliveries")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.requestedUserId").value("anonymous-user-1"))
+			.andExpect(jsonPath("$.data.processedCount").value(1))
+			.andExpect(jsonPath("$.data.sentCount").value(0))
+			.andExpect(jsonPath("$.data.failedCount").value(1))
+			.andExpect(jsonPath("$.data.notifications[0].status").value("FAILED"))
+			.andExpect(jsonPath("$.data.notifications[0].deviceToken").doesNotExist());
 	}
 }

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepositoryTest.java
@@ -1,0 +1,43 @@
+package com.easysubway.notification.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import com.easysubway.notification.domain.PushNotificationType;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("인메모리 푸시 알림 outbox 저장소")
+class InMemoryPushNotificationOutboxRepositoryTest {
+
+	private final InMemoryPushNotificationOutboxRepository repository = new InMemoryPushNotificationOutboxRepository();
+
+	@Test
+	@DisplayName("같은 알림 식별자는 사용자 버킷을 옮겨도 한 번만 저장한다")
+	void savePushNotificationKeepsNotificationIdUniqueAcrossUsers() {
+		repository.savePushNotification(notification("push-1", "anonymous-user-1", PushNotificationStatus.PENDING));
+		var movedNotification = notification("push-1", "anonymous-user-2", PushNotificationStatus.SENT);
+
+		repository.savePushNotification(movedNotification);
+
+		assertThat(repository.loadPushNotifications("anonymous-user-1")).isEmpty();
+		assertThat(repository.loadPushNotifications("anonymous-user-2")).containsExactly(movedNotification);
+	}
+
+	private PushNotification notification(String notificationId, String userId, PushNotificationStatus status) {
+		return new PushNotification(
+			notificationId,
+			userId,
+			DevicePlatform.ANDROID,
+			"device-token-" + notificationId,
+			PushNotificationType.REPORT_STATUS,
+			"신고 처리 알림",
+			"제보한 내용이 확인되었습니다.",
+			status,
+			LocalDateTime.of(2026, 6, 17, 10, 0)
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
@@ -40,7 +40,7 @@ class JdbcPushNotificationOutboxRepositoryTest {
 				created_at TIMESTAMP NOT NULL,
 				CONSTRAINT chk_push_notification_outbox_platform CHECK (platform IN ('ANDROID', 'IOS')),
 				CONSTRAINT chk_push_notification_outbox_type CHECK (notification_type IN ('FAVORITE_STATION_FACILITY', 'FAVORITE_ROUTE_FACILITY', 'REPORT_STATUS', 'DATA_QUALITY')),
-				CONSTRAINT chk_push_notification_outbox_status CHECK (status IN ('PENDING'))
+				CONSTRAINT chk_push_notification_outbox_status CHECK (status IN ('PENDING', 'SENT', 'FAILED'))
 			)
 			""");
 		repository = new JdbcPushNotificationOutboxRepository(jdbcTemplate);
@@ -63,11 +63,41 @@ class JdbcPushNotificationOutboxRepositoryTest {
 	@DisplayName("같은 푸시 알림 식별자는 한 행만 갱신한다")
 	void savePushNotificationUpdatesExistingNotification() {
 		repository.savePushNotification(notification("push-1", "anonymous-user-1", PushNotificationType.REPORT_STATUS, 9));
-		var updatedNotification = notification("push-1", "anonymous-user-1", PushNotificationType.DATA_QUALITY, 10);
+		var updatedNotification = notification(
+			"push-1",
+			"anonymous-user-1",
+			PushNotificationType.DATA_QUALITY,
+			PushNotificationStatus.SENT,
+			10
+		);
 
 		repository.savePushNotification(updatedNotification);
 
 		assertThat(repository.loadPushNotifications("anonymous-user-1")).containsExactly(updatedNotification);
+	}
+
+	@Test
+	@DisplayName("대기 중인 푸시 알림만 발송 대상으로 조회한다")
+	void loadPendingPushNotificationsReturnsPendingOnly() {
+		var pendingNotification = notification("push-1", "anonymous-user-1", PushNotificationType.REPORT_STATUS, 9);
+		repository.savePushNotification(pendingNotification);
+		repository.savePushNotification(notification(
+			"push-2",
+			"anonymous-user-1",
+			PushNotificationType.DATA_QUALITY,
+			PushNotificationStatus.SENT,
+			10
+		));
+		repository.savePushNotification(notification(
+			"push-3",
+			"anonymous-user-1",
+			PushNotificationType.FAVORITE_ROUTE_FACILITY,
+			PushNotificationStatus.FAILED,
+			11
+		));
+
+		assertThat(repository.loadPendingPushNotifications("anonymous-user-1"))
+			.containsExactly(pendingNotification);
 	}
 
 	@Test
@@ -93,6 +123,16 @@ class JdbcPushNotificationOutboxRepositoryTest {
 		PushNotificationType type,
 		int hour
 	) {
+		return notification(notificationId, userId, type, PushNotificationStatus.PENDING, hour);
+	}
+
+	private PushNotification notification(
+		String notificationId,
+		String userId,
+		PushNotificationType type,
+		PushNotificationStatus status,
+		int hour
+	) {
 		return new PushNotification(
 			notificationId,
 			userId,
@@ -101,7 +141,7 @@ class JdbcPushNotificationOutboxRepositoryTest {
 			type,
 			"알림 제목 " + notificationId,
 			"알림 본문 " + notificationId,
-			PushNotificationStatus.PENDING,
+			status,
 			LocalDateTime.of(2026, 6, 17, hour, 0)
 		);
 	}

--- a/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDeliveryServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDeliveryServiceTest.java
@@ -1,0 +1,124 @@
+package com.easysubway.notification.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.notification.adapter.out.persistence.InMemoryPushNotificationOutboxRepository;
+import com.easysubway.notification.application.port.in.DeliverPushNotificationsCommand;
+import com.easysubway.notification.application.port.out.PushNotificationSenderPort;
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.InvalidPushNotificationException;
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationSendResult;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import com.easysubway.notification.domain.PushNotificationType;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("푸시 알림 발송 처리 서비스")
+class PushNotificationDeliveryServiceTest {
+
+	private final InMemoryPushNotificationOutboxRepository outboxRepository =
+		new InMemoryPushNotificationOutboxRepository();
+	private final RecordingPushNotificationSender sender = new RecordingPushNotificationSender();
+	private final PushNotificationDeliveryService deliveryService = new PushNotificationDeliveryService(
+		outboxRepository,
+		outboxRepository,
+		sender
+	);
+
+	@Test
+	@DisplayName("대기 중인 알림은 sender 성공 결과에 따라 발송 완료로 저장한다")
+	void deliverPendingNotificationsMarksSentWhenSenderSucceeds() {
+		outboxRepository.savePushNotification(notification("push-1", PushNotificationStatus.PENDING));
+		sender.nextResult = PushNotificationSendResult.sent();
+
+		var result = deliveryService.deliverPending(new DeliverPushNotificationsCommand("anonymous-user-1"));
+
+		assertThat(result.requestedUserId()).isEqualTo("anonymous-user-1");
+		assertThat(result.sentCount()).isEqualTo(1);
+		assertThat(result.failedCount()).isZero();
+		assertThat(result.processedCount()).isEqualTo(1);
+		assertThat(sender.sentNotifications).extracting("notificationId").containsExactly("push-1");
+		assertThat(outboxRepository.loadPushNotifications("anonymous-user-1"))
+			.extracting("notificationId", "status")
+			.containsExactly(tuple("push-1", PushNotificationStatus.SENT));
+	}
+
+	@Test
+	@DisplayName("sender가 실패한 알림은 실패 상태로 저장한다")
+	void deliverPendingNotificationsMarksFailedWhenSenderFails() {
+		outboxRepository.savePushNotification(notification("push-1", PushNotificationStatus.PENDING));
+		sender.nextResult = PushNotificationSendResult.failed("외부 발송 어댑터가 설정되지 않았습니다.");
+
+		var result = deliveryService.deliverPending(new DeliverPushNotificationsCommand("anonymous-user-1"));
+
+		assertThat(result.sentCount()).isZero();
+		assertThat(result.failedCount()).isEqualTo(1);
+		assertThat(result.processedCount()).isEqualTo(1);
+		assertThat(outboxRepository.loadPushNotifications("anonymous-user-1"))
+			.extracting("notificationId", "status")
+			.containsExactly(tuple("push-1", PushNotificationStatus.FAILED));
+	}
+
+	@Test
+	@DisplayName("이미 처리된 알림은 다시 발송하지 않는다")
+	void deliverPendingNotificationsSkipsAlreadyProcessedNotifications() {
+		outboxRepository.savePushNotification(notification("push-1", PushNotificationStatus.SENT));
+		outboxRepository.savePushNotification(notification("push-2", PushNotificationStatus.FAILED));
+
+		var result = deliveryService.deliverPending(new DeliverPushNotificationsCommand("anonymous-user-1"));
+
+		assertThat(result.sentCount()).isZero();
+		assertThat(result.failedCount()).isZero();
+		assertThat(result.processedCount()).isZero();
+		assertThat(sender.sentNotifications).isEmpty();
+		assertThat(outboxRepository.loadPushNotifications("anonymous-user-1"))
+			.extracting("notificationId", "status")
+			.containsExactly(
+				tuple("push-1", PushNotificationStatus.SENT),
+				tuple("push-2", PushNotificationStatus.FAILED)
+			);
+	}
+
+	@Test
+	@DisplayName("발송 처리 명령은 사용자 식별자를 요구한다")
+	void deliverCommandRequiresUserId() {
+		assertThatThrownBy(() -> new DeliverPushNotificationsCommand(" "))
+			.isInstanceOf(InvalidPushNotificationException.class)
+			.hasMessage("사용자 식별자가 필요합니다.");
+	}
+
+	private PushNotification notification(String notificationId, PushNotificationStatus status) {
+		return new PushNotification(
+			notificationId,
+			"anonymous-user-1",
+			DevicePlatform.ANDROID,
+			"device-token-" + notificationId,
+			PushNotificationType.REPORT_STATUS,
+			"신고 처리 알림",
+			"제보한 내용이 확인되었습니다.",
+			status,
+			LocalDateTime.of(2026, 6, 17, 10, 0)
+		);
+	}
+
+	private static org.assertj.core.groups.Tuple tuple(String notificationId, PushNotificationStatus status) {
+		return org.assertj.core.api.Assertions.tuple(notificationId, status);
+	}
+
+	private static class RecordingPushNotificationSender implements PushNotificationSenderPort {
+
+		private final List<PushNotification> sentNotifications = new ArrayList<>();
+		private PushNotificationSendResult nextResult = PushNotificationSendResult.sent();
+
+		@Override
+		public PushNotificationSendResult send(PushNotification notification) {
+			sentNotifications.add(notification);
+			return nextResult;
+		}
+	}
+}

--- a/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDeliveryServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDeliveryServiceTest.java
@@ -13,8 +13,10 @@ import com.easysubway.notification.domain.PushNotificationSendResult;
 import com.easysubway.notification.domain.PushNotificationStatus;
 import com.easysubway.notification.domain.PushNotificationType;
 import java.time.LocalDateTime;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -85,6 +87,28 @@ class PushNotificationDeliveryServiceTest {
 	}
 
 	@Test
+	@DisplayName("sender 예외는 실패 상태로 저장하고 다음 알림 처리를 계속한다")
+	void deliverPendingNotificationsContinuesWhenSenderThrowsException() {
+		outboxRepository.savePushNotification(notification("push-1", PushNotificationStatus.PENDING));
+		outboxRepository.savePushNotification(notification("push-2", PushNotificationStatus.PENDING));
+		sender.throwOnNextSend = true;
+		sender.results.add(PushNotificationSendResult.sent());
+
+		var result = deliveryService.deliverPending(new DeliverPushNotificationsCommand("anonymous-user-1"));
+
+		assertThat(result.sentCount()).isEqualTo(1);
+		assertThat(result.failedCount()).isEqualTo(1);
+		assertThat(result.processedCount()).isEqualTo(2);
+		assertThat(sender.sentNotifications).extracting("notificationId").containsExactly("push-1", "push-2");
+		assertThat(outboxRepository.loadPushNotifications("anonymous-user-1"))
+			.extracting("notificationId", "status")
+			.containsExactly(
+				tuple("push-1", PushNotificationStatus.FAILED),
+				tuple("push-2", PushNotificationStatus.SENT)
+			);
+	}
+
+	@Test
 	@DisplayName("발송 처리 명령은 사용자 식별자를 요구한다")
 	void deliverCommandRequiresUserId() {
 		assertThatThrownBy(() -> new DeliverPushNotificationsCommand(" "))
@@ -113,11 +137,20 @@ class PushNotificationDeliveryServiceTest {
 	private static class RecordingPushNotificationSender implements PushNotificationSenderPort {
 
 		private final List<PushNotification> sentNotifications = new ArrayList<>();
+		private final Queue<PushNotificationSendResult> results = new ArrayDeque<>();
 		private PushNotificationSendResult nextResult = PushNotificationSendResult.sent();
+		private boolean throwOnNextSend;
 
 		@Override
 		public PushNotificationSendResult send(PushNotification notification) {
 			sentNotifications.add(notification);
+			if (throwOnNextSend) {
+				throwOnNextSend = false;
+				throw new IllegalStateException("푸시 발송 실패");
+			}
+			if (!results.isEmpty()) {
+				return results.remove();
+			}
 			return nextResult;
 		}
 	}

--- a/backend/src/test/java/com/easysubway/notification/domain/PushNotificationDeliveryResultTest.java
+++ b/backend/src/test/java/com/easysubway/notification/domain/PushNotificationDeliveryResultTest.java
@@ -1,0 +1,19 @@
+package com.easysubway.notification.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("푸시 알림 발송 처리 결과")
+class PushNotificationDeliveryResultTest {
+
+	@Test
+	@DisplayName("처리 건수와 알림 목록 크기가 다르면 생성할 수 없다")
+	void deliveryResultRequiresCountsToMatchNotifications() {
+		assertThatThrownBy(() -> new PushNotificationDeliveryResult("anonymous-user-1", 1, 0, List.of()))
+			.isInstanceOf(InvalidPushNotificationException.class)
+			.hasMessage("처리 건수와 알림 목록 크기가 일치해야 합니다.");
+	}
+}

--- a/backend/src/test/java/com/easysubway/notification/domain/PushNotificationSendResultTest.java
+++ b/backend/src/test/java/com/easysubway/notification/domain/PushNotificationSendResultTest.java
@@ -1,0 +1,18 @@
+package com.easysubway.notification.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("푸시 알림 발송 결과")
+class PushNotificationSendResultTest {
+
+	@Test
+	@DisplayName("성공 결과에는 공백 실패 사유도 남길 수 없다")
+	void successfulResultRejectsBlankFailureReason() {
+		assertThatThrownBy(() -> new PushNotificationSendResult(true, " "))
+			.isInstanceOf(InvalidPushNotificationException.class)
+			.hasMessage("발송 성공 결과에는 실패 사유를 둘 수 없습니다.");
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #274

## 작업 배경

- 푸시 알림 후보는 outbox에 `PENDING` 상태로 쌓이고 있었지만, 후보를 실제 발송 처리 흐름으로 넘긴 뒤 성공/실패 상태를 저장하는 유스케이스가 없었다.
- 운영자가 같은 사용자의 대기 알림을 처리했을 때 이미 처리된 알림이 다시 발송되지 않도록 `PENDING -> SENT/FAILED` 전이를 명확히 분리할 필요가 있었다.
- FCM/APNs 어댑터가 아직 붙기 전이므로 발송 포트는 먼저 열어두고, 기본 어댑터는 성공으로 오인하지 않게 실패 결과를 반환하도록 구성했다.

## 작업 내용

- 푸시 알림 발송 처리 유스케이스를 추가해 `PENDING` 알림만 sender 포트로 전달하고 결과에 따라 `SENT` 또는 `FAILED`로 저장했다.
- `PushNotificationSenderPort`, pending outbox 조회 포트, 발송 처리 command/result 모델을 추가해 도메인/애플리케이션/어댑터 경계를 분리했다.
- 관리자 API에 `POST /admin/notifications/push/deliveries`를 추가해 사용자별 대기 알림 처리 결과와 상태가 바뀐 알림 목록을 응답하도록 했다.
- JDBC/in-memory outbox 저장소가 대기 알림만 조회하고 같은 알림 ID는 중복 추가가 아니라 기존 행을 갱신하도록 정리했다.
- PostgreSQL 스키마와 JDBC 테스트 스키마의 outbox status 제약에 `SENT`, `FAILED`를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "com.easysubway.notification.application.service.PushNotificationDeliveryServiceTest"`: 성공
  - `./gradlew test --tests "com.easysubway.notification.adapter.out.persistence.JdbcPushNotificationOutboxRepositoryTest"`: 성공
  - `./gradlew test --tests "com.easysubway.notification.adapter.in.web.PushNotificationControllerTest"`: 성공
  - `./gradlew test`: 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적됨

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `PushNotificationDeliveryService`가 `PENDING` 알림만 처리하고 성공/실패 상태를 저장하는 흐름
  - `UnavailablePushNotificationSender`가 기본 상태에서 성공으로 표시하지 않고 `FAILED`를 반환하는 정책
  - outbox 저장소의 같은 `notificationId` 갱신 처리와 pending-only 조회 쿼리

## 리스크

- 실제 FCM/APNs 연동 전까지 관리자 발송 처리 API를 실행하면 대기 알림은 `FAILED`로 기록된다. 외부 발송 어댑터가 붙을 때 sender 포트 구현을 교체해야 한다.
- status 제약에 새 값을 추가했지만 기존 `PENDING` 데이터와 조회 계약은 유지된다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
