### PR TITLE
[Feat] 관리자 푸시 알림 현황 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
@@ -1,0 +1,51 @@
+package com.easysubway.notification.adapter.in.web;
+
+import com.easysubway.notification.application.port.in.PushNotificationDashboardUseCase;
+import com.easysubway.notification.domain.PushNotificationDashboardSummary;
+import java.util.List;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class PushNotificationAdminPageController {
+
+	private final PushNotificationDashboardUseCase pushNotificationDashboardUseCase;
+
+	PushNotificationAdminPageController(PushNotificationDashboardUseCase pushNotificationDashboardUseCase) {
+		this.pushNotificationDashboardUseCase = pushNotificationDashboardUseCase;
+	}
+
+	@GetMapping("/admin/notifications/push/page")
+	String pushNotificationDashboardPage(Model model) {
+		PushNotificationDashboardSummary summary = pushNotificationDashboardUseCase.summarizePushNotifications();
+		model.addAttribute("summary", PushNotificationDashboardView.from(summary));
+		return "admin/notifications/push";
+	}
+
+	record PushNotificationDashboardView(
+		long totalCount,
+		long pendingCount,
+		long sentCount,
+		long failedCount,
+		List<StatusCountRow> statusRows
+	) {
+
+		static PushNotificationDashboardView from(PushNotificationDashboardSummary summary) {
+			return new PushNotificationDashboardView(
+				summary.totalCount(),
+				summary.pendingCount(),
+				summary.sentCount(),
+				summary.failedCount(),
+				List.of(
+					new StatusCountRow("대기 중", "아직 발송 처리 전", summary.pendingCount()),
+					new StatusCountRow("발송 완료", "외부 발송 성공", summary.sentCount()),
+					new StatusCountRow("발송 실패", "발송 어댑터 실패 또는 예외", summary.failedCount())
+				)
+			);
+		}
+	}
+
+	record StatusCountRow(String label, String description, long count) {
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
@@ -3,7 +3,9 @@ package com.easysubway.notification.adapter.out.persistence;
 import com.easysubway.notification.application.port.out.LoadPendingPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.LoadPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.SavePushNotificationOutboxPort;
+import com.easysubway.notification.application.port.out.SummarizePushNotificationOutboxPort;
 import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationDashboardSummary;
 import com.easysubway.notification.domain.PushNotificationStatus;
 import com.easysubway.user.application.port.out.DeleteUserPushNotificationPort;
 import java.util.List;
@@ -19,6 +21,7 @@ public class InMemoryPushNotificationOutboxRepository implements
 	LoadPushNotificationOutboxPort,
 	LoadPendingPushNotificationOutboxPort,
 	SavePushNotificationOutboxPort,
+	SummarizePushNotificationOutboxPort,
 	DeleteUserPushNotificationPort {
 
 	private final Map<String, List<PushNotification>> notificationsByUserId = new ConcurrentHashMap<>();
@@ -58,6 +61,28 @@ public class InMemoryPushNotificationOutboxRepository implements
 		return notificationsByUserId.getOrDefault(userId, List.of()).stream()
 			.filter(notification -> notification.status() == PushNotificationStatus.PENDING)
 			.toList();
+	}
+
+	@Override
+	public PushNotificationDashboardSummary summarizePushNotificationOutbox() {
+		long pendingCount = 0;
+		long sentCount = 0;
+		long failedCount = 0;
+		for (List<PushNotification> notifications : notificationsByUserId.values()) {
+			for (PushNotification notification : notifications) {
+				switch (notification.status()) {
+					case PENDING -> pendingCount++;
+					case SENT -> sentCount++;
+					case FAILED -> failedCount++;
+				}
+			}
+		}
+		return new PushNotificationDashboardSummary(
+			pendingCount + sentCount + failedCount,
+			pendingCount,
+			sentCount,
+			failedCount
+		);
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
@@ -3,8 +3,10 @@ package com.easysubway.notification.adapter.out.persistence;
 import com.easysubway.notification.application.port.out.LoadPendingPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.LoadPushNotificationOutboxPort;
 import com.easysubway.notification.application.port.out.SavePushNotificationOutboxPort;
+import com.easysubway.notification.application.port.out.SummarizePushNotificationOutboxPort;
 import com.easysubway.notification.domain.DevicePlatform;
 import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationDashboardSummary;
 import com.easysubway.notification.domain.PushNotificationStatus;
 import com.easysubway.notification.domain.PushNotificationType;
 import com.easysubway.user.application.port.out.DeleteUserPushNotificationPort;
@@ -23,6 +25,7 @@ public class JdbcPushNotificationOutboxRepository implements
 	LoadPushNotificationOutboxPort,
 	LoadPendingPushNotificationOutboxPort,
 	SavePushNotificationOutboxPort,
+	SummarizePushNotificationOutboxPort,
 	DeleteUserPushNotificationPort {
 
 	private final JdbcTemplate jdbcTemplate;
@@ -94,6 +97,31 @@ public class JdbcPushNotificationOutboxRepository implements
 	}
 
 	@Override
+	public PushNotificationDashboardSummary summarizePushNotificationOutbox() {
+		List<StatusCountRow> statusCounts = jdbcTemplate.query(
+			"""
+				SELECT status,
+					COUNT(*) AS count
+				FROM push_notification_outbox
+				GROUP BY status
+				""",
+			(resultSet, rowNumber) -> new StatusCountRow(
+				PushNotificationStatus.valueOf(resultSet.getString("status")),
+				resultSet.getLong("count")
+			)
+		);
+		long pendingCount = countByStatus(statusCounts, PushNotificationStatus.PENDING);
+		long sentCount = countByStatus(statusCounts, PushNotificationStatus.SENT);
+		long failedCount = countByStatus(statusCounts, PushNotificationStatus.FAILED);
+		return new PushNotificationDashboardSummary(
+			pendingCount + sentCount + failedCount,
+			pendingCount,
+			sentCount,
+			failedCount
+		);
+	}
+
+	@Override
 	public int deletePushNotifications(String userId) {
 		return jdbcTemplate.update(
 			"""
@@ -102,6 +130,13 @@ public class JdbcPushNotificationOutboxRepository implements
 				""",
 			userId
 		);
+	}
+
+	private long countByStatus(List<StatusCountRow> rows, PushNotificationStatus status) {
+		return rows.stream()
+			.filter(row -> row.status() == status)
+			.mapToLong(StatusCountRow::count)
+			.sum();
 	}
 
 	private int updatePushNotification(PushNotification notification) {
@@ -170,5 +205,8 @@ public class JdbcPushNotificationOutboxRepository implements
 			PushNotificationStatus.valueOf(resultSet.getString("status")),
 			resultSet.getTimestamp("created_at").toLocalDateTime()
 		);
+	}
+
+	private record StatusCountRow(PushNotificationStatus status, long count) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationDashboardUseCase.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationDashboardUseCase.java
@@ -1,0 +1,8 @@
+package com.easysubway.notification.application.port.in;
+
+import com.easysubway.notification.domain.PushNotificationDashboardSummary;
+
+public interface PushNotificationDashboardUseCase {
+
+	PushNotificationDashboardSummary summarizePushNotifications();
+}

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/SummarizePushNotificationOutboxPort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/SummarizePushNotificationOutboxPort.java
@@ -1,0 +1,8 @@
+package com.easysubway.notification.application.port.out;
+
+import com.easysubway.notification.domain.PushNotificationDashboardSummary;
+
+public interface SummarizePushNotificationOutboxPort {
+
+	PushNotificationDashboardSummary summarizePushNotificationOutbox();
+}

--- a/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDashboardService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDashboardService.java
@@ -1,0 +1,21 @@
+package com.easysubway.notification.application.service;
+
+import com.easysubway.notification.application.port.in.PushNotificationDashboardUseCase;
+import com.easysubway.notification.application.port.out.SummarizePushNotificationOutboxPort;
+import com.easysubway.notification.domain.PushNotificationDashboardSummary;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PushNotificationDashboardService implements PushNotificationDashboardUseCase {
+
+	private final SummarizePushNotificationOutboxPort summarizePushNotificationOutboxPort;
+
+	public PushNotificationDashboardService(SummarizePushNotificationOutboxPort summarizePushNotificationOutboxPort) {
+		this.summarizePushNotificationOutboxPort = summarizePushNotificationOutboxPort;
+	}
+
+	@Override
+	public PushNotificationDashboardSummary summarizePushNotifications() {
+		return summarizePushNotificationOutboxPort.summarizePushNotificationOutbox();
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotificationDashboardSummary.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotificationDashboardSummary.java
@@ -1,0 +1,18 @@
+package com.easysubway.notification.domain;
+
+public record PushNotificationDashboardSummary(
+	long totalCount,
+	long pendingCount,
+	long sentCount,
+	long failedCount
+) {
+
+	public PushNotificationDashboardSummary {
+		if (totalCount < 0 || pendingCount < 0 || sentCount < 0 || failedCount < 0) {
+			throw new InvalidPushNotificationException("알림 집계 수는 0 이상이어야 합니다.");
+		}
+		if (totalCount != pendingCount + sentCount + failedCount) {
+			throw new InvalidPushNotificationException("전체 알림 수와 상태별 알림 수가 일치하지 않습니다.");
+		}
+	}
+}

--- a/backend/src/main/resources/templates/admin/notifications/push.html
+++ b/backend/src/main/resources/templates/admin/notifications/push.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>푸시 알림 현황</title>
+	<style>
+		body {
+			margin: 0;
+			background: #f6f8f8;
+			color: #102a2c;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+		}
+
+		main {
+			max-width: 960px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}
+
+		h1 {
+			margin: 0 0 24px;
+			font-size: 32px;
+			line-height: 1.2;
+		}
+
+		h2 {
+			margin: 0;
+			padding: 16px 18px;
+			background: #eaf0f0;
+			font-size: 20px;
+		}
+
+		.metric-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+			gap: 12px;
+			margin-bottom: 24px;
+		}
+
+		.metric {
+			background: #fff;
+			border: 1px solid #d8e0e0;
+			padding: 18px;
+		}
+
+		.metric span {
+			display: block;
+			color: #536b6d;
+			font-weight: 800;
+			line-height: 1.4;
+		}
+
+		.metric strong {
+			display: block;
+			margin-top: 8px;
+			font-size: 30px;
+			line-height: 1.15;
+		}
+
+		section {
+			background: #fff;
+			border: 1px solid #d8e0e0;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		th,
+		td {
+			padding: 14px 18px;
+			border-top: 1px solid #d8e0e0;
+			text-align: left;
+			vertical-align: top;
+			font-size: 15px;
+			line-height: 1.45;
+		}
+
+		th {
+			background: #f8fbfb;
+			font-weight: 800;
+		}
+
+		td:last-child,
+		th:last-child {
+			text-align: right;
+			font-weight: 800;
+		}
+	</style>
+</head>
+<body>
+<main>
+	<h1>푸시 알림 현황</h1>
+
+	<div class="metric-grid" aria-label="푸시 알림 outbox 요약">
+		<div class="metric">
+			<span>전체 알림</span>
+			<strong th:text="${summary.totalCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>대기 중</span>
+			<strong th:text="${summary.pendingCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>발송 완료</span>
+			<strong th:text="${summary.sentCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>발송 실패</span>
+			<strong th:text="${summary.failedCount}">0</strong>
+		</div>
+	</div>
+
+	<section>
+		<h2>상태별 알림</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">상태</th>
+				<th scope="col">설명</th>
+				<th scope="col">건수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.statusRows}">
+				<td th:text="${row.label}">대기 중</td>
+				<td th:text="${row.description}">아직 발송 처리 전</td>
+				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
@@ -1,0 +1,113 @@
+package com.easysubway.notification.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("관리자 푸시 알림 현황 페이지")
+class PushNotificationAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("관리자는 푸시 알림 outbox의 전체와 상태별 건수를 확인한다")
+	void adminGetsPushNotificationDashboardPage() throws Exception {
+		registerDevice();
+		dispatchNotification("REPORT_STATUS", "신고 처리 알림");
+		deliverPendingNotifications();
+		dispatchNotification("FAVORITE_STATION_FACILITY", "시설 변경 알림");
+
+		String html = mockMvc.perform(get("/admin/notifications/push/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("푸시 알림 현황")
+			.contains("전체 알림")
+			.contains(">2<")
+			.contains("대기 중")
+			.contains("발송 완료")
+			.contains("발송 실패")
+			.contains("아직 발송 처리 전")
+			.contains("외부 발송 성공")
+			.contains("발송 어댑터 실패 또는 예외")
+			.doesNotContain("secret-device-token");
+	}
+
+	@Test
+	@DisplayName("푸시 알림 현황 페이지는 관리자 인증을 요구한다")
+	void pushNotificationDashboardRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/notifications/push/page"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/notifications/push/page")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private void registerDevice() throws Exception {
+		mockMvc.perform(post("/api/v1/devices")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "platform": "ANDROID",
+					  "deviceToken": "secret-device-token"
+					}
+					"""))
+			.andExpect(status().isOk());
+	}
+
+	private void dispatchNotification(String type, String title) throws Exception {
+		mockMvc.perform(post("/admin/notifications/push")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "type": "%s",
+					  "title": "%s",
+					  "body": "상록수역 시설 상태를 확인하세요."
+					}
+					""".formatted(type, title)))
+			.andExpect(status().isOk());
+	}
+
+	private void deliverPendingNotifications() throws Exception {
+		mockMvc.perform(post("/admin/notifications/push/deliveries")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1"
+					}
+					"""))
+			.andExpect(status().isOk());
+	}
+}

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
@@ -101,6 +101,34 @@ class JdbcPushNotificationOutboxRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("전체 outbox를 상태별로 집계한다")
+	void summarizePushNotificationOutboxByStatus() {
+		repository.savePushNotification(notification("push-1", "anonymous-user-1", PushNotificationType.REPORT_STATUS, 9));
+		repository.savePushNotification(notification("push-2", "anonymous-user-1", PushNotificationType.DATA_QUALITY, 10));
+		repository.savePushNotification(notification(
+			"push-3",
+			"anonymous-user-2",
+			PushNotificationType.FAVORITE_ROUTE_FACILITY,
+			PushNotificationStatus.SENT,
+			11
+		));
+		repository.savePushNotification(notification(
+			"push-4",
+			"anonymous-user-3",
+			PushNotificationType.FAVORITE_STATION_FACILITY,
+			PushNotificationStatus.FAILED,
+			12
+		));
+
+		var summary = repository.summarizePushNotificationOutbox();
+
+		assertThat(summary.totalCount()).isEqualTo(4);
+		assertThat(summary.pendingCount()).isEqualTo(2);
+		assertThat(summary.sentCount()).isEqualTo(1);
+		assertThat(summary.failedCount()).isEqualTo(1);
+	}
+
+	@Test
 	@DisplayName("사용자 데이터 삭제 요청은 해당 사용자의 푸시 알림 개수를 반환한다")
 	void deletePushNotificationsByUserIdReturnsDeletedCount() {
 		repository.savePushNotification(notification("push-1", "anonymous-user-1", PushNotificationType.REPORT_STATUS, 9));

--- a/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDashboardServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDashboardServiceTest.java
@@ -1,0 +1,51 @@
+package com.easysubway.notification.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.notification.adapter.out.persistence.InMemoryPushNotificationOutboxRepository;
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import com.easysubway.notification.domain.PushNotificationType;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("푸시 알림 현황 서비스")
+class PushNotificationDashboardServiceTest {
+
+	@Test
+	@DisplayName("전체 outbox를 상태별로 집계한다")
+	void summarizePushNotificationOutboxByStatus() {
+		var repository = new InMemoryPushNotificationOutboxRepository();
+		repository.savePushNotification(notification("push-1", "anonymous-user-1", PushNotificationStatus.PENDING));
+		repository.savePushNotification(notification("push-2", "anonymous-user-1", PushNotificationStatus.SENT));
+		repository.savePushNotification(notification("push-3", "anonymous-user-2", PushNotificationStatus.FAILED));
+		var service = new PushNotificationDashboardService(repository);
+
+		var summary = service.summarizePushNotifications();
+
+		assertThat(summary.totalCount()).isEqualTo(3);
+		assertThat(summary.pendingCount()).isEqualTo(1);
+		assertThat(summary.sentCount()).isEqualTo(1);
+		assertThat(summary.failedCount()).isEqualTo(1);
+	}
+
+	private PushNotification notification(
+		String notificationId,
+		String userId,
+		PushNotificationStatus status
+	) {
+		return new PushNotification(
+			notificationId,
+			userId,
+			DevicePlatform.ANDROID,
+			"device-token-" + notificationId,
+			PushNotificationType.REPORT_STATUS,
+			"알림 제목 " + notificationId,
+			"알림 본문 " + notificationId,
+			status,
+			LocalDateTime.of(2026, 6, 17, 9, 0)
+		);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1231,26 +1231,46 @@ test("백엔드 알림 설정은 인증 사용자 기준 헥사고날 API 경계
 test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 따른다", () => {
   const notification = read("backend/src/main/java/com/easysubway/notification/domain/PushNotification.java");
   const result = read("backend/src/main/java/com/easysubway/notification/domain/PushNotificationDispatchResult.java");
+  const dashboardSummary = read(
+    "backend/src/main/java/com/easysubway/notification/domain/PushNotificationDashboardSummary.java",
+  );
   const type = read("backend/src/main/java/com/easysubway/notification/domain/PushNotificationType.java");
   const status = read("backend/src/main/java/com/easysubway/notification/domain/PushNotificationStatus.java");
   const invalidPush = read("backend/src/main/java/com/easysubway/notification/domain/InvalidPushNotificationException.java");
   const useCase = read("backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationDispatchUseCase.java");
+  const dashboardUseCase = read(
+    "backend/src/main/java/com/easysubway/notification/application/port/in/PushNotificationDashboardUseCase.java",
+  );
   const command = read("backend/src/main/java/com/easysubway/notification/application/port/in/DispatchPushNotificationCommand.java");
   const loadOutboxPort = read("backend/src/main/java/com/easysubway/notification/application/port/out/LoadPushNotificationOutboxPort.java");
   const saveOutboxPort = read("backend/src/main/java/com/easysubway/notification/application/port/out/SavePushNotificationOutboxPort.java");
+  const summarizeOutboxPort = read(
+    "backend/src/main/java/com/easysubway/notification/application/port/out/SummarizePushNotificationOutboxPort.java",
+  );
   const service = read("backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDispatchService.java");
+  const dashboardService = read(
+    "backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDashboardService.java",
+  );
   const repository = read("backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java");
   const jdbcRepository = read(
     "backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java",
   );
   const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
   const controller = read("backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationController.java");
+  const dashboardController = read(
+    "backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java",
+  );
+  const dashboardTemplate = read("backend/src/main/resources/templates/admin/notifications/push.html");
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
 
   assert.match(notification, /record PushNotification/);
   assert.match(notification, /deviceToken/);
   assert.match(notification, /PushNotificationStatus/);
   assert.match(result, /record PushNotificationDispatchResult/);
+  assert.match(dashboardSummary, /record PushNotificationDashboardSummary/);
+  assert.match(dashboardSummary, /pendingCount/);
+  assert.match(dashboardSummary, /sentCount/);
+  assert.match(dashboardSummary, /failedCount/);
   assert.match(type, /FAVORITE_STATION_FACILITY/);
   assert.match(type, /FAVORITE_ROUTE_FACILITY/);
   assert.match(type, /REPORT_STATUS/);
@@ -1259,17 +1279,24 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   assert.match(invalidPush, /extends InvalidRequestException/);
   assert.match(useCase, /interface PushNotificationDispatchUseCase/);
   assert.match(useCase, /dispatch/);
+  assert.match(dashboardUseCase, /interface PushNotificationDashboardUseCase/);
+  assert.match(dashboardUseCase, /summarizePushNotifications/);
   assert.match(command, /record DispatchPushNotificationCommand/);
   assert.match(loadOutboxPort, /interface LoadPushNotificationOutboxPort/);
   assert.match(saveOutboxPort, /interface SavePushNotificationOutboxPort/);
+  assert.match(summarizeOutboxPort, /interface SummarizePushNotificationOutboxPort/);
+  assert.match(summarizeOutboxPort, /summarizePushNotificationOutbox/);
   assert.match(service, /implements PushNotificationDispatchUseCase/);
   assert.match(service, /LoadNotificationPreferencePort/);
   assert.match(service, /SavePushNotificationOutboxPort/);
-  assert.match(repository, /implements[\s\S]*LoadPushNotificationOutboxPort[\s\S]*SavePushNotificationOutboxPort/);
+  assert.match(dashboardService, /implements PushNotificationDashboardUseCase/);
+  assert.match(dashboardService, /SummarizePushNotificationOutboxPort/);
+  assert.match(repository, /implements[\s\S]*LoadPushNotificationOutboxPort[\s\S]*SavePushNotificationOutboxPort[\s\S]*SummarizePushNotificationOutboxPort/);
   assert.match(jdbcRepository, /@Profile\("prod"\)/);
-  assert.match(jdbcRepository, /implements[\s\S]*LoadPushNotificationOutboxPort[\s\S]*SavePushNotificationOutboxPort[\s\S]*DeleteUserPushNotificationPort/);
+  assert.match(jdbcRepository, /implements[\s\S]*LoadPushNotificationOutboxPort[\s\S]*SavePushNotificationOutboxPort[\s\S]*SummarizePushNotificationOutboxPort[\s\S]*DeleteUserPushNotificationPort/);
   assert.match(jdbcRepository, /List<PushNotification> loadPushNotifications\(String userId\)/);
   assert.match(jdbcRepository, /PushNotification savePushNotification\(PushNotification notification\)/);
+  assert.match(jdbcRepository, /PushNotificationDashboardSummary summarizePushNotificationOutbox\(\)/);
   assert.match(jdbcRepository, /int deletePushNotifications\(String userId\)/);
   assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS push_notification_outbox/);
   assert.match(batchPostgresSchema, /CONSTRAINT chk_push_notification_outbox_platform/);
@@ -1279,6 +1306,12 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   assert.match(controller, /@PostMapping\("\/admin\/notifications\/push"\)/);
   assert.match(controller, /PushNotificationDispatchUseCase/);
   assert.doesNotMatch(controller, /deviceToken/);
+  assert.match(dashboardController, /@GetMapping\("\/admin\/notifications\/push\/page"\)/);
+  assert.match(dashboardController, /PushNotificationDashboardUseCase/);
+  assert.match(dashboardTemplate, /푸시 알림 현황/);
+  assert.match(dashboardTemplate, /전체 알림/);
+  assert.match(dashboardTemplate, /상태별 알림/);
+  assert.doesNotMatch(dashboardTemplate, /deviceToken/);
   assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
 });
 


### PR DESCRIPTION
## 관련 이슈

close #276

## 작업 배경

- 푸시 알림 outbox는 발송 대기, 성공, 실패 상태를 저장하지만 운영자가 현재 적체나 실패 규모를 한눈에 확인할 화면이 없었다.
- 발송 API와 별도로 관리자 페이지에서 전체/상태별 건수를 확인할 수 있어야 장애 대응과 운영 점검이 쉬워진다.

## 작업 내용

- 푸시 알림 outbox 집계를 위한 `PushNotificationDashboardUseCase`와 `SummarizePushNotificationOutboxPort`를 추가했다.
- 인메모리/JDBC outbox 저장소가 전체, 대기 중, 발송 완료, 발송 실패 건수를 같은 계약으로 반환하도록 구현했다.
- `/admin/notifications/push/page` 관리자 페이지를 추가해 상태별 한국어 설명과 건수를 노출했다.
- repository contract 테스트에 새 관리자 현황 경계와 템플릿 계약을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "com.easysubway.notification.application.service.PushNotificationDashboardServiceTest"` 성공
  - `./gradlew test --tests "com.easysubway.notification.adapter.out.persistence.JdbcPushNotificationOutboxRepositoryTest"` 성공
  - `./gradlew test --tests "com.easysubway.notification.adapter.in.web.PushNotificationAdminPageControllerTest"` 성공
  - `./gradlew test` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공
  - `git diff --check` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `PushNotificationDashboardSummary`의 전체 수와 상태별 수 일치 검증
  - `JdbcPushNotificationOutboxRepository.summarizePushNotificationOutbox()`의 상태별 집계 쿼리
  - 관리자 페이지에서 기기 토큰 같은 민감값을 노출하지 않는지

## 리스크

- 신규 관리자 HTML 페이지와 조회용 집계만 추가했으며 기존 발송/전달 API 응답 계약은 변경하지 않았다.
- 운영 outbox 행이 매우 많아질 경우 전체 상태 집계 쿼리는 테이블 크기에 영향을 받는다. 현재는 상태별 `GROUP BY`만 수행하며, 대량 데이터가 쌓이면 status 인덱스 추가를 별도 이슈로 다룬다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
