### PR TITLE
[Feat] 관리자 경로 피드백 현황 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageController.java
@@ -1,0 +1,51 @@
+package com.easysubway.route.adapter.in.web;
+
+import com.easysubway.route.application.port.in.RouteFeedbackDashboardUseCase;
+import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
+import java.util.List;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class RouteFeedbackAdminPageController {
+
+	private final RouteFeedbackDashboardUseCase routeFeedbackDashboardUseCase;
+
+	RouteFeedbackAdminPageController(RouteFeedbackDashboardUseCase routeFeedbackDashboardUseCase) {
+		this.routeFeedbackDashboardUseCase = routeFeedbackDashboardUseCase;
+	}
+
+	@GetMapping("/admin/routes/feedback/page")
+	String routeFeedbackDashboardPage(Model model) {
+		RouteFeedbackDashboardSummary summary = routeFeedbackDashboardUseCase.summarizeRouteFeedbacks();
+		model.addAttribute("summary", RouteFeedbackDashboardView.from(summary));
+		return "admin/routes/feedback";
+	}
+
+	record RouteFeedbackDashboardView(
+		long totalCount,
+		long helpfulCount,
+		long notHelpfulCount,
+		long blockedByRealWorldCount,
+		List<RatingCountRow> ratingRows
+	) {
+
+		static RouteFeedbackDashboardView from(RouteFeedbackDashboardSummary summary) {
+			return new RouteFeedbackDashboardView(
+				summary.totalCount(),
+				summary.helpfulCount(),
+				summary.notHelpfulCount(),
+				summary.blockedByRealWorldCount(),
+				List.of(
+					new RatingCountRow("도움이 됨", "경로 안내가 실제 이동에 도움됨", summary.helpfulCount()),
+					new RatingCountRow("도움이 안 됨", "경로 안내가 실제 이동과 맞지 않음", summary.notHelpfulCount()),
+					new RatingCountRow("현장 차단", "엘리베이터 고장, 공사, 폐쇄 등으로 이동 불가", summary.blockedByRealWorldCount())
+				)
+			);
+		}
+	}
+
+	record RatingCountRow(String label, String description, long count) {
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
@@ -3,7 +3,10 @@ package com.easysubway.route.adapter.out.persistence;
 import com.easysubway.route.application.port.out.LoadRouteSearchPort;
 import com.easysubway.route.application.port.out.SaveRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
+import com.easysubway.route.application.port.out.SummarizeRouteFeedbackPort;
 import com.easysubway.route.domain.RouteFeedback;
+import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
+import com.easysubway.route.domain.RouteFeedbackRating;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.user.application.port.out.AnonymizeUserRouteFeedbackPort;
 import java.util.LinkedHashMap;
@@ -15,7 +18,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 @Profile("!prod")
 public class InMemoryRouteSearchRepository
-	implements LoadRouteSearchPort, SaveRouteSearchPort, SaveRouteFeedbackPort, AnonymizeUserRouteFeedbackPort {
+	implements LoadRouteSearchPort, SaveRouteSearchPort, SaveRouteFeedbackPort, SummarizeRouteFeedbackPort,
+	AnonymizeUserRouteFeedbackPort {
 
 	static final int MAX_STORED_ROUTE_SEARCHES = 1_000;
 	static final int MAX_STORED_ROUTE_FEEDBACKS = 5_000;
@@ -51,6 +55,21 @@ public class InMemoryRouteSearchRepository
 	}
 
 	@Override
+	public RouteFeedbackDashboardSummary summarizeRouteFeedbacks() {
+		synchronized (routeFeedbacks) {
+			long helpfulCount = countByRating(RouteFeedbackRating.HELPFUL);
+			long notHelpfulCount = countByRating(RouteFeedbackRating.NOT_HELPFUL);
+			long blockedByRealWorldCount = countByRating(RouteFeedbackRating.BLOCKED_BY_REAL_WORLD);
+			return new RouteFeedbackDashboardSummary(
+				routeFeedbacks.size(),
+				helpfulCount,
+				notHelpfulCount,
+				blockedByRealWorldCount
+			);
+		}
+	}
+
+	@Override
 	public int anonymizeRouteFeedbacksByUserId(String userId) {
 		synchronized (routeFeedbacks) {
 			int anonymizedCount = 0;
@@ -75,6 +94,13 @@ public class InMemoryRouteSearchRepository
 			DELETED_COMMENT,
 			feedback.createdAt()
 		);
+	}
+
+	private long countByRating(RouteFeedbackRating rating) {
+		return routeFeedbacks.values()
+			.stream()
+			.filter(feedback -> feedback.rating() == rating)
+			.count();
 	}
 
 	private void evictOldestRouteSearches() {

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
@@ -4,7 +4,9 @@ import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.out.LoadRouteSearchPort;
 import com.easysubway.route.application.port.out.SaveRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
+import com.easysubway.route.application.port.out.SummarizeRouteFeedbackPort;
 import com.easysubway.route.domain.RouteFeedback;
+import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
@@ -28,7 +30,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 @Profile("prod")
 public class JdbcRouteSearchRepository
-	implements LoadRouteSearchPort, SaveRouteSearchPort, SaveRouteFeedbackPort, AnonymizeUserRouteFeedbackPort {
+	implements LoadRouteSearchPort, SaveRouteSearchPort, SaveRouteFeedbackPort, SummarizeRouteFeedbackPort,
+	AnonymizeUserRouteFeedbackPort {
 
 	private static final TypeReference<List<RouteStep>> ROUTE_STEPS_TYPE = new TypeReference<>() {
 	};
@@ -98,6 +101,25 @@ public class JdbcRouteSearchRepository
 	public RouteFeedback saveRouteFeedback(RouteFeedback feedback) {
 		upsertRouteFeedback(feedback);
 		return feedback;
+	}
+
+	@Override
+	public RouteFeedbackDashboardSummary summarizeRouteFeedbacks() {
+		return jdbcTemplate.queryForObject(
+			"""
+				SELECT COUNT(*) AS total_count,
+					SUM(CASE WHEN rating = 'HELPFUL' THEN 1 ELSE 0 END) AS helpful_count,
+					SUM(CASE WHEN rating = 'NOT_HELPFUL' THEN 1 ELSE 0 END) AS not_helpful_count,
+					SUM(CASE WHEN rating = 'BLOCKED_BY_REAL_WORLD' THEN 1 ELSE 0 END) AS blocked_by_real_world_count
+				FROM route_feedbacks
+				""",
+			(resultSet, rowNumber) -> new RouteFeedbackDashboardSummary(
+				resultSet.getLong("total_count"),
+				resultSet.getLong("helpful_count"),
+				resultSet.getLong("not_helpful_count"),
+				resultSet.getLong("blocked_by_real_world_count")
+			)
+		);
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteFeedbackDashboardUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteFeedbackDashboardUseCase.java
@@ -1,0 +1,8 @@
+package com.easysubway.route.application.port.in;
+
+import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
+
+public interface RouteFeedbackDashboardUseCase {
+
+	RouteFeedbackDashboardSummary summarizeRouteFeedbacks();
+}

--- a/backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteFeedbackPort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteFeedbackPort.java
@@ -1,0 +1,8 @@
+package com.easysubway.route.application.port.out;
+
+import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
+
+public interface SummarizeRouteFeedbackPort {
+
+	RouteFeedbackDashboardSummary summarizeRouteFeedbacks();
+}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteFeedbackDashboardService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteFeedbackDashboardService.java
@@ -1,0 +1,21 @@
+package com.easysubway.route.application.service;
+
+import com.easysubway.route.application.port.in.RouteFeedbackDashboardUseCase;
+import com.easysubway.route.application.port.out.SummarizeRouteFeedbackPort;
+import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RouteFeedbackDashboardService implements RouteFeedbackDashboardUseCase {
+
+	private final SummarizeRouteFeedbackPort summarizeRouteFeedbackPort;
+
+	public RouteFeedbackDashboardService(SummarizeRouteFeedbackPort summarizeRouteFeedbackPort) {
+		this.summarizeRouteFeedbackPort = summarizeRouteFeedbackPort;
+	}
+
+	@Override
+	public RouteFeedbackDashboardSummary summarizeRouteFeedbacks() {
+		return summarizeRouteFeedbackPort.summarizeRouteFeedbacks();
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteFeedbackDashboardSummary.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteFeedbackDashboardSummary.java
@@ -1,0 +1,18 @@
+package com.easysubway.route.domain;
+
+public record RouteFeedbackDashboardSummary(
+	long totalCount,
+	long helpfulCount,
+	long notHelpfulCount,
+	long blockedByRealWorldCount
+) {
+
+	public RouteFeedbackDashboardSummary {
+		if (totalCount < 0 || helpfulCount < 0 || notHelpfulCount < 0 || blockedByRealWorldCount < 0) {
+			throw new InvalidRouteFeedbackException("경로 피드백 집계 수는 0 이상이어야 합니다.");
+		}
+		if (totalCount != helpfulCount + notHelpfulCount + blockedByRealWorldCount) {
+			throw new InvalidRouteFeedbackException("전체 경로 피드백 수와 평점별 피드백 수가 일치하지 않습니다.");
+		}
+	}
+}

--- a/backend/src/main/resources/templates/admin/routes/feedback.html
+++ b/backend/src/main/resources/templates/admin/routes/feedback.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>경로 피드백 현황</title>
+	<style>
+		body {
+			margin: 0;
+			background: #f6f8f8;
+			color: #102a2c;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+		}
+
+		main {
+			max-width: 960px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}
+
+		h1 {
+			margin: 0 0 24px;
+			font-size: 32px;
+			line-height: 1.2;
+		}
+
+		h2 {
+			margin: 0;
+			padding: 16px 18px;
+			background: #eaf0f0;
+			font-size: 20px;
+		}
+
+		.metric-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+			gap: 12px;
+			margin-bottom: 24px;
+		}
+
+		.metric {
+			background: #fff;
+			border: 1px solid #d8e0e0;
+			padding: 18px;
+		}
+
+		.metric span {
+			display: block;
+			color: #536b6d;
+			font-weight: 800;
+			line-height: 1.4;
+		}
+
+		.metric strong {
+			display: block;
+			margin-top: 8px;
+			font-size: 30px;
+			line-height: 1.15;
+		}
+
+		section {
+			background: #fff;
+			border: 1px solid #d8e0e0;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		th,
+		td {
+			padding: 14px 18px;
+			border-top: 1px solid #d8e0e0;
+			text-align: left;
+			vertical-align: top;
+			font-size: 15px;
+			line-height: 1.45;
+		}
+
+		th {
+			background: #f8fbfb;
+			font-weight: 800;
+		}
+
+		td:last-child,
+		th:last-child {
+			text-align: right;
+			font-weight: 800;
+		}
+	</style>
+</head>
+<body>
+<main>
+	<h1>경로 피드백 현황</h1>
+
+	<div class="metric-grid" aria-label="경로 피드백 요약">
+		<div class="metric">
+			<span>전체 피드백</span>
+			<strong th:text="${summary.totalCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>도움이 됨</span>
+			<strong th:text="${summary.helpfulCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>도움이 안 됨</span>
+			<strong th:text="${summary.notHelpfulCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>현장 차단</span>
+			<strong th:text="${summary.blockedByRealWorldCount}">0</strong>
+		</div>
+	</div>
+
+	<section>
+		<h2>평점별 피드백</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">평점</th>
+				<th scope="col">설명</th>
+				<th scope="col">건수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.ratingRows}">
+				<td th:text="${row.label}">도움이 됨</td>
+				<td th:text="${row.description}">경로 안내가 실제 이동에 도움됨</td>
+				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageControllerTest.java
@@ -1,0 +1,100 @@
+package com.easysubway.route.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("관리자 경로 피드백 현황 페이지")
+class RouteFeedbackAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("관리자는 경로 피드백의 전체와 평점별 건수를 확인한다")
+	void adminGetsRouteFeedbackDashboardPage() throws Exception {
+		String routeSearchId = createRouteSearch();
+		submitRouteFeedback(routeSearchId, "HELPFUL", "안내가 도움이 됐어요");
+		submitRouteFeedback(routeSearchId, "NOT_HELPFUL", "실제 이동 상황과 달랐어요");
+		submitRouteFeedback(routeSearchId, "BLOCKED_BY_REAL_WORLD", "엘리베이터가 막혀 있었어요");
+
+		String html = mockMvc.perform(get("/admin/routes/feedback/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("경로 피드백 현황")
+			.contains("전체 피드백")
+			.contains(">3<")
+			.contains("도움이 됨")
+			.contains("도움이 안 됨")
+			.contains("현장 차단")
+			.contains("경로 안내가 실제 이동에 도움됨")
+			.contains("경로 안내가 실제 이동과 맞지 않음")
+			.contains("엘리베이터 고장, 공사, 폐쇄 등으로 이동 불가")
+			.doesNotContain("anonymous-user-1")
+			.doesNotContain("엘리베이터가 막혀 있었어요");
+	}
+
+	@Test
+	@DisplayName("경로 피드백 현황 페이지는 관리자 인증을 요구한다")
+	void routeFeedbackDashboardRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/routes/feedback/page"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/routes/feedback/page")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private String createRouteSearch() throws Exception {
+		var result = mockMvc.perform(post("/api/v1/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "mobilityType": "SENIOR"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andReturn();
+		return JsonPath.read(result.getResponse().getContentAsString(), "$.data.routeSearchId");
+	}
+
+	private void submitRouteFeedback(String routeSearchId, String rating, String comment) throws Exception {
+		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "rating": "%s",
+					  "comment": "%s"
+					}
+					""".formatted(rating, comment)))
+			.andExpect(status().isOk());
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
@@ -155,6 +155,25 @@ class JdbcRouteSearchRepositoryTest {
 		)).isEqualTo("실제 이동 상황과 맞지 않았습니다.");
 	}
 
+	@Test
+	@DisplayName("경로 피드백을 평점별로 집계한다")
+	void summarizeRouteFeedbacksByRating() {
+		repository.saveRouteFeedback(routeFeedback("feedback-1", RouteFeedbackRating.HELPFUL, "도움이 되었습니다."));
+		repository.saveRouteFeedback(routeFeedback("feedback-2", RouteFeedbackRating.NOT_HELPFUL, "동선 설명이 부족합니다."));
+		repository.saveRouteFeedback(routeFeedback(
+			"feedback-3",
+			RouteFeedbackRating.BLOCKED_BY_REAL_WORLD,
+			"실제로는 엘리베이터가 막혀 있었습니다."
+		));
+
+		var summary = repository.summarizeRouteFeedbacks();
+
+		assertThat(summary.totalCount()).isEqualTo(3);
+		assertThat(summary.helpfulCount()).isEqualTo(1);
+		assertThat(summary.notHelpfulCount()).isEqualTo(1);
+		assertThat(summary.blockedByRealWorldCount()).isEqualTo(1);
+	}
+
 	private RouteSearchResult directRouteSearch(
 		String routeSearchId,
 		String originStationName,

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteFeedbackDashboardServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteFeedbackDashboardServiceTest.java
@@ -1,0 +1,42 @@
+package com.easysubway.route.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
+import com.easysubway.route.domain.RouteFeedback;
+import com.easysubway.route.domain.RouteFeedbackRating;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("경로 피드백 현황 서비스")
+class RouteFeedbackDashboardServiceTest {
+
+	@Test
+	@DisplayName("전체 경로 피드백을 평점별로 집계한다")
+	void summarizeRouteFeedbacksByRating() {
+		var repository = new InMemoryRouteSearchRepository();
+		repository.saveRouteFeedback(routeFeedback("feedback-1", RouteFeedbackRating.HELPFUL));
+		repository.saveRouteFeedback(routeFeedback("feedback-2", RouteFeedbackRating.NOT_HELPFUL));
+		repository.saveRouteFeedback(routeFeedback("feedback-3", RouteFeedbackRating.BLOCKED_BY_REAL_WORLD));
+		var service = new RouteFeedbackDashboardService(repository);
+
+		var summary = service.summarizeRouteFeedbacks();
+
+		assertThat(summary.totalCount()).isEqualTo(3);
+		assertThat(summary.helpfulCount()).isEqualTo(1);
+		assertThat(summary.notHelpfulCount()).isEqualTo(1);
+		assertThat(summary.blockedByRealWorldCount()).isEqualTo(1);
+	}
+
+	private RouteFeedback routeFeedback(String feedbackId, RouteFeedbackRating rating) {
+		return new RouteFeedback(
+			feedbackId,
+			"route-search-1",
+			"anonymous-user-1",
+			rating,
+			"경로 피드백 " + feedbackId,
+			LocalDateTime.of(2026, 6, 17, 10, 0)
+		);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1509,6 +1509,7 @@ test("백엔드 데이터 품질 요약은 관리자 API와 헥사고날 경계�
 
 test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   const result = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java");
+  const feedbackSummary = read("backend/src/main/java/com/easysubway/route/domain/RouteFeedbackDashboardSummary.java");
   const status = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchStatus.java");
   const warning = read("backend/src/main/java/com/easysubway/route/domain/RouteWarning.java");
   const warningCode = read("backend/src/main/java/com/easysubway/route/domain/RouteWarningCode.java");
@@ -1518,18 +1519,35 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   const routeNotFound = read("backend/src/main/java/com/easysubway/route/domain/RouteNotFoundException.java");
   const searchNotFound = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchNotFoundException.java");
   const useCase = read("backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java");
+  const dashboardUseCase = read(
+    "backend/src/main/java/com/easysubway/route/application/port/in/RouteFeedbackDashboardUseCase.java",
+  );
   const command = read("backend/src/main/java/com/easysubway/route/application/port/in/SearchRouteCommand.java");
   const loadPort = read("backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteSearchPort.java");
   const savePort = read("backend/src/main/java/com/easysubway/route/application/port/out/SaveRouteSearchPort.java");
+  const summarizeFeedbackPort = read(
+    "backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteFeedbackPort.java",
+  );
   const service = read("backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java");
+  const dashboardService = read(
+    "backend/src/main/java/com/easysubway/route/application/service/RouteFeedbackDashboardService.java",
+  );
   const repository = read("backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java");
   const jdbcRepository = read("backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java");
   const controller = read("backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java");
+  const dashboardController = read(
+    "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageController.java",
+  );
+  const dashboardTemplate = read("backend/src/main/resources/templates/admin/routes/feedback.html");
   const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
 
   assert.match(result, /record RouteSearchResult/);
   assert.match(result, /mobilityType/);
   assert.match(result, /blockedReasons/);
+  assert.match(feedbackSummary, /record RouteFeedbackDashboardSummary/);
+  assert.match(feedbackSummary, /helpfulCount/);
+  assert.match(feedbackSummary, /notHelpfulCount/);
+  assert.match(feedbackSummary, /blockedByRealWorldCount/);
   assert.match(status, /FOUND/);
   assert.match(status, /BLOCKED/);
   assert.match(warning, /record RouteWarning/);
@@ -1545,22 +1563,30 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(useCase, /interface RouteSearchUseCase/);
   assert.match(useCase, /searchRoute/);
   assert.match(useCase, /getRouteSearch/);
+  assert.match(dashboardUseCase, /interface RouteFeedbackDashboardUseCase/);
+  assert.match(dashboardUseCase, /summarizeRouteFeedbacks/);
   assert.match(command, /record SearchRouteCommand/);
   assert.match(loadPort, /interface LoadRouteSearchPort/);
   assert.match(savePort, /interface SaveRouteSearchPort/);
+  assert.match(summarizeFeedbackPort, /interface SummarizeRouteFeedbackPort/);
+  assert.match(summarizeFeedbackPort, /summarizeRouteFeedbacks/);
   assert.match(service, /implements RouteSearchUseCase/);
   assert.match(service, /LoadTransitMasterPort/);
   assert.match(service, /RouteProfileWeight\.from/);
   assert.match(service, /RouteSearchStatus\.BLOCKED/);
   assert.match(service, /hasStairOnlyAccess/);
   assert.match(service, /routeScore/);
-  assert.match(repository, /implements LoadRouteSearchPort, SaveRouteSearchPort/);
+  assert.match(dashboardService, /implements RouteFeedbackDashboardUseCase/);
+  assert.match(dashboardService, /SummarizeRouteFeedbackPort/);
+  assert.match(repository, /implements[\s\S]*LoadRouteSearchPort[\s\S]*SaveRouteSearchPort[\s\S]*SaveRouteFeedbackPort[\s\S]*SummarizeRouteFeedbackPort/);
   assert.match(repository, /@Profile\("!prod"\)/);
   assert.match(jdbcRepository, /@Profile\("prod"\)/);
-  assert.match(jdbcRepository, /implements[\s\S]*LoadRouteSearchPort[\s\S]*SaveRouteSearchPort[\s\S]*SaveRouteFeedbackPort[\s\S]*AnonymizeUserRouteFeedbackPort/);
+  assert.match(jdbcRepository, /implements[\s\S]*LoadRouteSearchPort[\s\S]*SaveRouteSearchPort[\s\S]*SaveRouteFeedbackPort[\s\S]*SummarizeRouteFeedbackPort[\s\S]*AnonymizeUserRouteFeedbackPort/);
   assert.match(jdbcRepository, /JdbcTemplate/);
   assert.match(jdbcRepository, /INSERT INTO route_search_results/);
   assert.match(jdbcRepository, /INSERT INTO route_feedbacks/);
+  assert.match(jdbcRepository, /RouteFeedbackDashboardSummary summarizeRouteFeedbacks\(\)/);
+  assert.match(jdbcRepository, /SUM\(CASE WHEN rating = 'HELPFUL' THEN 1 ELSE 0 END\)/);
   assert.match(jdbcRepository, /ON CONFLICT \(route_search_id\) DO UPDATE/);
   assert.match(jdbcRepository, /ON CONFLICT \(feedback_id\) DO UPDATE/);
   assert.match(jdbcRepository, /steps_json/);
@@ -1572,6 +1598,12 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(batchPostgresSchema, /CHECK \(rating IN \('HELPFUL', 'NOT_HELPFUL', 'BLOCKED_BY_REAL_WORLD'\)\)/);
   assert.match(controller, /@PostMapping\("\/api\/v1\/routes\/search"\)/);
   assert.match(controller, /@GetMapping\("\/api\/v1\/routes\/\{routeSearchId\}"\)/);
+  assert.match(dashboardController, /@GetMapping\("\/admin\/routes\/feedback\/page"\)/);
+  assert.match(dashboardController, /RouteFeedbackDashboardUseCase/);
+  assert.match(dashboardTemplate, /경로 피드백 현황/);
+  assert.match(dashboardTemplate, /전체 피드백/);
+  assert.match(dashboardTemplate, /평점별 피드백/);
+  assert.doesNotMatch(dashboardTemplate, /userId/);
 });
 
 test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다", () => {


### PR DESCRIPTION
## 관련 이슈

close #280

## 작업 배경

- 경로 피드백은 실제 이동 가능 경로 품질을 개선하는 운영 신호이지만, 관리자가 전체 규모와 평점별 분포를 한 화면에서 확인할 수 없었다.
- 현장 차단 피드백은 엘리베이터 고장, 공사, 폐쇄처럼 사용자의 실제 이동 실패로 이어질 수 있어 운영 검수 우선순위 판단에 필요하다.

## 작업 내용

- route 도메인에 경로 피드백 현황 요약 모델과 input/output port, 서비스 계층을 추가했다.
- InMemory/JDBC 경로 검색 저장소에 `route_feedbacks` 평점별 요약 조회를 추가했다.
- `/admin/routes/feedback/page` 관리자 페이지에서 전체, 도움이 됨, 도움이 안 됨, 현장 차단 건수를 표시한다.
- 서비스, JDBC 저장소, 관리자 페이지 테스트와 repository contract 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests "com.easysubway.route.application.service.RouteFeedbackDashboardServiceTest"`: 성공
  - `backend/gradlew -p backend test --tests "com.easysubway.route.adapter.out.persistence.JdbcRouteSearchRepositoryTest.summarizeRouteFeedbacksByRating"`: 성공
  - `backend/gradlew -p backend test --tests "com.easysubway.route.adapter.in.web.RouteFeedbackAdminPageControllerTest"`: 성공
  - `backend/gradlew -p backend test --tests "com.easysubway.route.application.service.RouteFeedbackDashboardServiceTest" --tests "com.easysubway.route.adapter.out.persistence.JdbcRouteSearchRepositoryTest" --tests "com.easysubway.route.adapter.in.web.RouteFeedbackAdminPageControllerTest"`: 성공
  - `backend/gradlew -p backend test`: 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `README.md`, `.github/pull_request_template.md`만 추적됨

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `JdbcRouteSearchRepository.summarizeRouteFeedbacks()`의 평점별 집계 쿼리
  - `RouteFeedbackAdminPageControllerTest`가 작성자 식별자와 자유 입력 코멘트를 관리자 현황 화면에 노출하지 않는지 검증하는 부분
  - `tools/ci/repository-contract.test.mjs`의 route 피드백 현황 헥사고날 경계 검증

## 리스크

- 관리자 페이지는 전체 누적 건수만 제공하며 기간 필터나 개별 피드백 목록은 포함하지 않는다.
- 운영 DB의 `route_feedbacks` 행 수가 크게 증가하면 기간 조건 또는 집계 테이블이 필요할 수 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
