### PR TITLE
[Feat] 관리자 경로 검색 현황 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageController.java
@@ -1,0 +1,60 @@
+package com.easysubway.route.adapter.in.web;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.application.port.in.RouteSearchDashboardUseCase;
+import com.easysubway.route.domain.RouteSearchDashboardSummary;
+import java.util.List;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class RouteSearchAdminPageController {
+
+	private final RouteSearchDashboardUseCase routeSearchDashboardUseCase;
+
+	RouteSearchAdminPageController(RouteSearchDashboardUseCase routeSearchDashboardUseCase) {
+		this.routeSearchDashboardUseCase = routeSearchDashboardUseCase;
+	}
+
+	@GetMapping("/admin/routes/searches/page")
+	String routeSearchDashboardPage(Model model) {
+		RouteSearchDashboardSummary summary = routeSearchDashboardUseCase.summarizeRouteSearches();
+		model.addAttribute("summary", RouteSearchDashboardView.from(summary));
+		return "admin/routes/searches";
+	}
+
+	record RouteSearchDashboardView(
+		long totalCount,
+		long foundCount,
+		long blockedCount,
+		List<MobilityTypeCountRow> mobilityTypeRows
+	) {
+
+		static RouteSearchDashboardView from(RouteSearchDashboardSummary summary) {
+			return new RouteSearchDashboardView(
+				summary.totalCount(),
+				summary.foundCount(),
+				summary.blockedCount(),
+				summary.mobilityTypeCounts()
+					.stream()
+					.map(row -> new MobilityTypeCountRow(mobilityTypeLabel(row.mobilityType()), row.count()))
+					.toList()
+			);
+		}
+	}
+
+	record MobilityTypeCountRow(String label, long count) {
+	}
+
+	private static String mobilityTypeLabel(MobilityType mobilityType) {
+		return switch (mobilityType) {
+			case SENIOR -> "고령자";
+			case STROLLER -> "유모차 동반";
+			case WHEELCHAIR -> "휠체어 사용자";
+			case PREGNANT -> "임산부";
+			case TEMPORARY_INJURY -> "일시 부상";
+			case LUGGAGE -> "큰 짐 동반";
+		};
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
@@ -1,15 +1,22 @@
 package com.easysubway.route.adapter.out.persistence;
 
+import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.out.LoadRouteSearchPort;
 import com.easysubway.route.application.port.out.SaveRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
 import com.easysubway.route.application.port.out.SummarizeRouteFeedbackPort;
+import com.easysubway.route.application.port.out.SummarizeRouteSearchPort;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
 import com.easysubway.route.domain.RouteFeedbackRating;
+import com.easysubway.route.domain.RouteSearchDashboardSummary;
+import com.easysubway.route.domain.RouteSearchDashboardSummary.MobilityTypeCount;
 import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.user.application.port.out.AnonymizeUserRouteFeedbackPort;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.springframework.context.annotation.Profile;
@@ -19,7 +26,7 @@ import org.springframework.stereotype.Repository;
 @Profile("!prod")
 public class InMemoryRouteSearchRepository
 	implements LoadRouteSearchPort, SaveRouteSearchPort, SaveRouteFeedbackPort, SummarizeRouteFeedbackPort,
-	AnonymizeUserRouteFeedbackPort {
+	SummarizeRouteSearchPort, AnonymizeUserRouteFeedbackPort {
 
 	static final int MAX_STORED_ROUTE_SEARCHES = 1_000;
 	static final int MAX_STORED_ROUTE_FEEDBACKS = 5_000;
@@ -70,6 +77,20 @@ public class InMemoryRouteSearchRepository
 	}
 
 	@Override
+	public RouteSearchDashboardSummary summarizeRouteSearches() {
+		synchronized (routeSearches) {
+			long foundCount = countByStatus(RouteSearchStatus.FOUND);
+			long blockedCount = countByStatus(RouteSearchStatus.BLOCKED);
+			return new RouteSearchDashboardSummary(
+				routeSearches.size(),
+				foundCount,
+				blockedCount,
+				mobilityTypeCounts()
+			);
+		}
+	}
+
+	@Override
 	public int anonymizeRouteFeedbacksByUserId(String userId) {
 		synchronized (routeFeedbacks) {
 			int anonymizedCount = 0;
@@ -100,6 +121,27 @@ public class InMemoryRouteSearchRepository
 		return routeFeedbacks.values()
 			.stream()
 			.filter(feedback -> feedback.rating() == rating)
+			.count();
+	}
+
+	private long countByStatus(RouteSearchStatus status) {
+		return routeSearches.values()
+			.stream()
+			.filter(routeSearch -> routeSearch.status() == status)
+			.count();
+	}
+
+	private List<MobilityTypeCount> mobilityTypeCounts() {
+		return Arrays.stream(MobilityType.values())
+			.map(mobilityType -> new MobilityTypeCount(mobilityType, countByMobilityType(mobilityType)))
+			.filter(row -> row.count() > 0)
+			.toList();
+	}
+
+	private long countByMobilityType(MobilityType mobilityType) {
+		return routeSearches.values()
+			.stream()
+			.filter(routeSearch -> routeSearch.mobilityType() == mobilityType)
 			.count();
 	}
 

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
@@ -5,8 +5,11 @@ import com.easysubway.route.application.port.out.LoadRouteSearchPort;
 import com.easysubway.route.application.port.out.SaveRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
 import com.easysubway.route.application.port.out.SummarizeRouteFeedbackPort;
+import com.easysubway.route.application.port.out.SummarizeRouteSearchPort;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
+import com.easysubway.route.domain.RouteSearchDashboardSummary;
+import com.easysubway.route.domain.RouteSearchDashboardSummary.MobilityTypeCount;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
@@ -31,7 +34,7 @@ import org.springframework.stereotype.Repository;
 @Profile("prod")
 public class JdbcRouteSearchRepository
 	implements LoadRouteSearchPort, SaveRouteSearchPort, SaveRouteFeedbackPort, SummarizeRouteFeedbackPort,
-	AnonymizeUserRouteFeedbackPort {
+	SummarizeRouteSearchPort, AnonymizeUserRouteFeedbackPort {
 
 	private static final TypeReference<List<RouteStep>> ROUTE_STEPS_TYPE = new TypeReference<>() {
 	};
@@ -119,6 +122,42 @@ public class JdbcRouteSearchRepository
 				resultSet.getLong("not_helpful_count"),
 				resultSet.getLong("blocked_by_real_world_count")
 			)
+		);
+	}
+
+	@Override
+	public RouteSearchDashboardSummary summarizeRouteSearches() {
+		List<StatusCountRow> statusCounts = jdbcTemplate.query(
+			"""
+				SELECT status,
+					COUNT(*) AS count
+				FROM route_search_results
+				GROUP BY status
+				""",
+			(resultSet, rowNumber) -> new StatusCountRow(
+				RouteSearchStatus.valueOf(resultSet.getString("status")),
+				resultSet.getLong("count")
+			)
+		);
+		List<MobilityTypeCount> mobilityTypeCounts = jdbcTemplate.query(
+			"""
+				SELECT mobility_type,
+					COUNT(*) AS count
+				FROM route_search_results
+				GROUP BY mobility_type
+				""",
+			(resultSet, rowNumber) -> new MobilityTypeCount(
+				MobilityType.valueOf(resultSet.getString("mobility_type")),
+				resultSet.getLong("count")
+			)
+		);
+		long foundCount = countByStatus(statusCounts, RouteSearchStatus.FOUND);
+		long blockedCount = countByStatus(statusCounts, RouteSearchStatus.BLOCKED);
+		return new RouteSearchDashboardSummary(
+			foundCount + blockedCount,
+			foundCount,
+			blockedCount,
+			sortedMobilityTypeCounts(mobilityTypeCounts)
 		);
 	}
 
@@ -317,6 +356,28 @@ public class JdbcRouteSearchRepository
 		);
 	}
 
+	private long countByStatus(List<StatusCountRow> rows, RouteSearchStatus status) {
+		return rows.stream()
+			.filter(row -> row.status() == status)
+			.mapToLong(StatusCountRow::count)
+			.sum();
+	}
+
+	private List<MobilityTypeCount> sortedMobilityTypeCounts(List<MobilityTypeCount> rows) {
+		return List.of(MobilityType.values())
+			.stream()
+			.map(mobilityType -> new MobilityTypeCount(mobilityType, countByMobilityType(rows, mobilityType)))
+			.filter(row -> row.count() > 0)
+			.toList();
+	}
+
+	private long countByMobilityType(List<MobilityTypeCount> rows, MobilityType mobilityType) {
+		return rows.stream()
+			.filter(row -> row.mobilityType() == mobilityType)
+			.mapToLong(MobilityTypeCount::count)
+			.sum();
+	}
+
 	private String writeJson(Object value) {
 		try {
 			return objectMapper.writeValueAsString(value);
@@ -344,5 +405,8 @@ public class JdbcRouteSearchRepository
 	private enum DatabaseDialect {
 		POSTGRESQL,
 		H2
+	}
+
+	private record StatusCountRow(RouteSearchStatus status, long count) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
@@ -127,37 +127,28 @@ public class JdbcRouteSearchRepository
 
 	@Override
 	public RouteSearchDashboardSummary summarizeRouteSearches() {
-		List<StatusCountRow> statusCounts = jdbcTemplate.query(
+		// 상태별 집계와 이동 프로필별 집계가 같은 DB statement snapshot에서 계산되도록 한 번만 읽는다.
+		List<RouteSearchDashboardCountRow> countRows = jdbcTemplate.query(
 			"""
 				SELECT status,
+					mobility_type,
 					COUNT(*) AS count
 				FROM route_search_results
-				GROUP BY status
+				GROUP BY status, mobility_type
 				""",
-			(resultSet, rowNumber) -> new StatusCountRow(
+			(resultSet, rowNumber) -> new RouteSearchDashboardCountRow(
 				RouteSearchStatus.valueOf(resultSet.getString("status")),
-				resultSet.getLong("count")
-			)
-		);
-		List<MobilityTypeCount> mobilityTypeCounts = jdbcTemplate.query(
-			"""
-				SELECT mobility_type,
-					COUNT(*) AS count
-				FROM route_search_results
-				GROUP BY mobility_type
-				""",
-			(resultSet, rowNumber) -> new MobilityTypeCount(
 				MobilityType.valueOf(resultSet.getString("mobility_type")),
 				resultSet.getLong("count")
 			)
 		);
-		long foundCount = countByStatus(statusCounts, RouteSearchStatus.FOUND);
-		long blockedCount = countByStatus(statusCounts, RouteSearchStatus.BLOCKED);
+		long foundCount = countByStatus(countRows, RouteSearchStatus.FOUND);
+		long blockedCount = countByStatus(countRows, RouteSearchStatus.BLOCKED);
 		return new RouteSearchDashboardSummary(
 			foundCount + blockedCount,
 			foundCount,
 			blockedCount,
-			sortedMobilityTypeCounts(mobilityTypeCounts)
+			sortedMobilityTypeCounts(countRows)
 		);
 	}
 
@@ -356,14 +347,14 @@ public class JdbcRouteSearchRepository
 		);
 	}
 
-	private long countByStatus(List<StatusCountRow> rows, RouteSearchStatus status) {
+	private long countByStatus(List<RouteSearchDashboardCountRow> rows, RouteSearchStatus status) {
 		return rows.stream()
 			.filter(row -> row.status() == status)
-			.mapToLong(StatusCountRow::count)
+			.mapToLong(RouteSearchDashboardCountRow::count)
 			.sum();
 	}
 
-	private List<MobilityTypeCount> sortedMobilityTypeCounts(List<MobilityTypeCount> rows) {
+	private List<MobilityTypeCount> sortedMobilityTypeCounts(List<RouteSearchDashboardCountRow> rows) {
 		return List.of(MobilityType.values())
 			.stream()
 			.map(mobilityType -> new MobilityTypeCount(mobilityType, countByMobilityType(rows, mobilityType)))
@@ -371,10 +362,10 @@ public class JdbcRouteSearchRepository
 			.toList();
 	}
 
-	private long countByMobilityType(List<MobilityTypeCount> rows, MobilityType mobilityType) {
+	private long countByMobilityType(List<RouteSearchDashboardCountRow> rows, MobilityType mobilityType) {
 		return rows.stream()
 			.filter(row -> row.mobilityType() == mobilityType)
-			.mapToLong(MobilityTypeCount::count)
+			.mapToLong(RouteSearchDashboardCountRow::count)
 			.sum();
 	}
 
@@ -407,6 +398,6 @@ public class JdbcRouteSearchRepository
 		H2
 	}
 
-	private record StatusCountRow(RouteSearchStatus status, long count) {
+	private record RouteSearchDashboardCountRow(RouteSearchStatus status, MobilityType mobilityType, long count) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchDashboardUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchDashboardUseCase.java
@@ -1,0 +1,8 @@
+package com.easysubway.route.application.port.in;
+
+import com.easysubway.route.domain.RouteSearchDashboardSummary;
+
+public interface RouteSearchDashboardUseCase {
+
+	RouteSearchDashboardSummary summarizeRouteSearches();
+}

--- a/backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteSearchPort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteSearchPort.java
@@ -1,0 +1,8 @@
+package com.easysubway.route.application.port.out;
+
+import com.easysubway.route.domain.RouteSearchDashboardSummary;
+
+public interface SummarizeRouteSearchPort {
+
+	RouteSearchDashboardSummary summarizeRouteSearches();
+}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchDashboardService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchDashboardService.java
@@ -1,0 +1,21 @@
+package com.easysubway.route.application.service;
+
+import com.easysubway.route.application.port.in.RouteSearchDashboardUseCase;
+import com.easysubway.route.application.port.out.SummarizeRouteSearchPort;
+import com.easysubway.route.domain.RouteSearchDashboardSummary;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RouteSearchDashboardService implements RouteSearchDashboardUseCase {
+
+	private final SummarizeRouteSearchPort summarizeRouteSearchPort;
+
+	public RouteSearchDashboardService(SummarizeRouteSearchPort summarizeRouteSearchPort) {
+		this.summarizeRouteSearchPort = summarizeRouteSearchPort;
+	}
+
+	@Override
+	public RouteSearchDashboardSummary summarizeRouteSearches() {
+		return summarizeRouteSearchPort.summarizeRouteSearches();
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteSearchDashboardSummary.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteSearchDashboardSummary.java
@@ -1,0 +1,40 @@
+package com.easysubway.route.domain;
+
+import com.easysubway.profile.domain.MobilityType;
+import java.util.List;
+
+public record RouteSearchDashboardSummary(
+	long totalCount,
+	long foundCount,
+	long blockedCount,
+	List<MobilityTypeCount> mobilityTypeCounts
+) {
+
+	public RouteSearchDashboardSummary {
+		if (totalCount < 0 || foundCount < 0 || blockedCount < 0) {
+			throw new InvalidRouteSearchException("경로 검색 집계 수는 0 이상이어야 합니다.");
+		}
+		if (totalCount != foundCount + blockedCount) {
+			throw new InvalidRouteSearchException("전체 경로 검색 수와 상태별 검색 수가 일치하지 않습니다.");
+		}
+		mobilityTypeCounts = List.copyOf(mobilityTypeCounts);
+		long mobilityTotalCount = mobilityTypeCounts.stream()
+			.mapToLong(MobilityTypeCount::count)
+			.sum();
+		if (totalCount != mobilityTotalCount) {
+			throw new InvalidRouteSearchException("전체 경로 검색 수와 이동 프로필별 검색 수가 일치하지 않습니다.");
+		}
+	}
+
+	public record MobilityTypeCount(MobilityType mobilityType, long count) {
+
+		public MobilityTypeCount {
+			if (mobilityType == null) {
+				throw new InvalidRouteSearchException("이동 프로필별 검색 집계에는 이동 프로필이 필요합니다.");
+			}
+			if (count < 0) {
+				throw new InvalidRouteSearchException("이동 프로필별 경로 검색 수는 0 이상이어야 합니다.");
+			}
+		}
+	}
+}

--- a/backend/src/main/resources/templates/admin/routes/searches.html
+++ b/backend/src/main/resources/templates/admin/routes/searches.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>경로 검색 현황</title>
+	<style>
+		body {
+			margin: 0;
+			background: #f6f8f8;
+			color: #102a2c;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+		}
+
+		main {
+			max-width: 960px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}
+
+		h1 {
+			margin: 0 0 24px;
+			font-size: 32px;
+			line-height: 1.2;
+		}
+
+		h2 {
+			margin: 0;
+			padding: 16px 18px;
+			background: #eaf0f0;
+			font-size: 20px;
+		}
+
+		.metric-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+			gap: 12px;
+			margin-bottom: 24px;
+		}
+
+		.metric {
+			background: #fff;
+			border: 1px solid #d8e0e0;
+			padding: 18px;
+		}
+
+		.metric span {
+			display: block;
+			color: #536b6d;
+			font-weight: 800;
+			line-height: 1.4;
+		}
+
+		.metric strong {
+			display: block;
+			margin-top: 8px;
+			font-size: 30px;
+			line-height: 1.15;
+		}
+
+		section {
+			background: #fff;
+			border: 1px solid #d8e0e0;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		th,
+		td {
+			padding: 14px 18px;
+			border-top: 1px solid #d8e0e0;
+			text-align: left;
+			vertical-align: top;
+			font-size: 15px;
+			line-height: 1.45;
+		}
+
+		th {
+			background: #f8fbfb;
+			font-weight: 800;
+		}
+
+		td:last-child,
+		th:last-child {
+			text-align: right;
+			font-weight: 800;
+		}
+	</style>
+</head>
+<body>
+<main>
+	<h1>경로 검색 현황</h1>
+
+	<div class="metric-grid" aria-label="경로 검색 요약">
+		<div class="metric">
+			<span>전체 검색</span>
+			<strong th:text="${summary.totalCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>경로 찾음</span>
+			<strong th:text="${summary.foundCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>경로 차단</span>
+			<strong th:text="${summary.blockedCount}">0</strong>
+		</div>
+	</div>
+
+	<section>
+		<h2>이동 프로필별 검색</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">이동 프로필</th>
+				<th scope="col">건수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.mobilityTypeRows}">
+				<td th:text="${row.label}">고령자</td>
+				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageControllerTest.java
@@ -1,0 +1,82 @@
+package com.easysubway.route.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("관리자 경로 검색 현황 페이지")
+class RouteSearchAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("관리자는 경로 검색의 전체, 상태별, 이동 프로필별 건수를 확인한다")
+	void adminGetsRouteSearchDashboardPage() throws Exception {
+		createRouteSearch("SENIOR");
+		createRouteSearch("WHEELCHAIR");
+
+		String html = mockMvc.perform(get("/admin/routes/searches/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("경로 검색 현황")
+			.contains("전체 검색")
+			.contains(">2<")
+			.contains("경로 찾음")
+			.contains("경로 차단")
+			.contains(">0<")
+			.contains("이동 프로필별 검색")
+			.contains("고령자")
+			.contains("휠체어 사용자")
+			.doesNotContain("routeSearchId")
+			.doesNotContain("station-sangnoksu");
+	}
+
+	@Test
+	@DisplayName("경로 검색 현황 페이지는 관리자 인증을 요구한다")
+	void routeSearchDashboardRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/routes/searches/page"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/routes/searches/page")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private void createRouteSearch(String mobilityType) throws Exception {
+		mockMvc.perform(post("/api/v1/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "mobilityType": "%s"
+					}
+					""".formatted(mobilityType)))
+			.andExpect(status().isOk());
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.easysubway.route.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.domain.RouteFeedback;
@@ -174,6 +175,26 @@ class JdbcRouteSearchRepositoryTest {
 		assertThat(summary.blockedByRealWorldCount()).isEqualTo(1);
 	}
 
+	@Test
+	@DisplayName("경로 검색 결과를 상태와 이동 프로필별로 집계한다")
+	void summarizeRouteSearchesByStatusAndMobilityType() {
+		repository.saveRouteSearch(directRouteSearch("route-search-1", "상록수", "사당"));
+		repository.saveRouteSearch(blockedRouteSearch("route-search-2"));
+		repository.saveRouteSearch(transferRouteSearch("route-search-3"));
+
+		var summary = repository.summarizeRouteSearches();
+
+		assertThat(summary.totalCount()).isEqualTo(3);
+		assertThat(summary.foundCount()).isEqualTo(2);
+		assertThat(summary.blockedCount()).isEqualTo(1);
+		assertThat(summary.mobilityTypeCounts())
+			.extracting("mobilityType", "count")
+			.containsExactly(
+				tuple(MobilityType.SENIOR, 2L),
+				tuple(MobilityType.WHEELCHAIR, 1L)
+			);
+	}
+
 	private RouteSearchResult directRouteSearch(
 		String routeSearchId,
 		String originStationName,
@@ -217,6 +238,25 @@ class JdbcRouteSearchRepositoryTest {
 			List.of(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS, "일부 구간은 도움을 요청해야 할 수 있습니다.")),
 			List.of("엘리베이터 검증이 필요한 구간이 있습니다."),
 			LocalDateTime.of(2026, 6, 13, 9, 0)
+		);
+	}
+
+	private RouteSearchResult blockedRouteSearch(String routeSearchId) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-origin",
+			"출발역",
+			"station-destination",
+			"도착역",
+			MobilityType.SENIOR,
+			RouteSearchStatus.BLOCKED,
+			"line-4",
+			"수도권 4호선",
+			0,
+			List.of(),
+			List.of(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS, "계단 없는 접근 경로가 확인되지 않았습니다.")),
+			List.of("계단 없는 역 접근 경로를 확인할 수 없습니다."),
+			LocalDateTime.of(2026, 6, 17, 10, 0)
 		);
 	}
 

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchDashboardServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchDashboardServiceTest.java
@@ -1,0 +1,62 @@
+package com.easysubway.route.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("경로 검색 현황 서비스")
+class RouteSearchDashboardServiceTest {
+
+	@Test
+	@DisplayName("전체 경로 검색을 상태와 이동 프로필별로 집계한다")
+	void summarizeRouteSearchesByStatusAndMobilityType() {
+		var repository = new InMemoryRouteSearchRepository();
+		repository.saveRouteSearch(routeSearch("route-search-1", MobilityType.SENIOR, RouteSearchStatus.FOUND));
+		repository.saveRouteSearch(routeSearch("route-search-2", MobilityType.WHEELCHAIR, RouteSearchStatus.FOUND));
+		repository.saveRouteSearch(routeSearch("route-search-3", MobilityType.WHEELCHAIR, RouteSearchStatus.BLOCKED));
+		var service = new RouteSearchDashboardService(repository);
+
+		var summary = service.summarizeRouteSearches();
+
+		assertThat(summary.totalCount()).isEqualTo(3);
+		assertThat(summary.foundCount()).isEqualTo(2);
+		assertThat(summary.blockedCount()).isEqualTo(1);
+		assertThat(summary.mobilityTypeCounts())
+			.extracting("mobilityType", "count")
+			.containsExactly(
+				tuple(MobilityType.SENIOR, 1L),
+				tuple(MobilityType.WHEELCHAIR, 2L)
+			);
+	}
+
+	private RouteSearchResult routeSearch(
+		String routeSearchId,
+		MobilityType mobilityType,
+		RouteSearchStatus status
+	) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-sangnoksu",
+			"상록수",
+			"station-sadang",
+			"사당",
+			mobilityType,
+			status,
+			"line-4",
+			"수도권 4호선",
+			status == RouteSearchStatus.FOUND ? 90 : 0,
+			List.of(),
+			List.of(),
+			status == RouteSearchStatus.FOUND ? List.of() : List.of("계단 없는 역 접근 경로를 확인할 수 없습니다."),
+			LocalDateTime.of(2026, 6, 17, 10, 0)
+		);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1610,8 +1610,8 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(jdbcRepository, /INSERT INTO route_search_results/);
   assert.match(jdbcRepository, /INSERT INTO route_feedbacks/);
   assert.match(jdbcRepository, /RouteSearchDashboardSummary summarizeRouteSearches\(\)/);
-  assert.match(jdbcRepository, /GROUP BY status/);
-  assert.match(jdbcRepository, /GROUP BY mobility_type/);
+  assert.match(jdbcRepository, /GROUP BY status, mobility_type/);
+  assert.match(jdbcRepository, /same DB statement snapshot|같은 DB statement snapshot/);
   assert.match(jdbcRepository, /RouteFeedbackDashboardSummary summarizeRouteFeedbacks\(\)/);
   assert.match(jdbcRepository, /SUM\(CASE WHEN rating = 'HELPFUL' THEN 1 ELSE 0 END\)/);
   assert.match(jdbcRepository, /ON CONFLICT \(route_search_id\) DO UPDATE/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1509,6 +1509,7 @@ test("백엔드 데이터 품질 요약은 관리자 API와 헥사고날 경계�
 
 test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   const result = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java");
+  const searchSummary = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchDashboardSummary.java");
   const feedbackSummary = read("backend/src/main/java/com/easysubway/route/domain/RouteFeedbackDashboardSummary.java");
   const status = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchStatus.java");
   const warning = read("backend/src/main/java/com/easysubway/route/domain/RouteWarning.java");
@@ -1519,31 +1520,48 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   const routeNotFound = read("backend/src/main/java/com/easysubway/route/domain/RouteNotFoundException.java");
   const searchNotFound = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchNotFoundException.java");
   const useCase = read("backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java");
-  const dashboardUseCase = read(
+  const searchDashboardUseCase = read(
+    "backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchDashboardUseCase.java",
+  );
+  const feedbackDashboardUseCase = read(
     "backend/src/main/java/com/easysubway/route/application/port/in/RouteFeedbackDashboardUseCase.java",
   );
   const command = read("backend/src/main/java/com/easysubway/route/application/port/in/SearchRouteCommand.java");
   const loadPort = read("backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteSearchPort.java");
   const savePort = read("backend/src/main/java/com/easysubway/route/application/port/out/SaveRouteSearchPort.java");
+  const summarizeSearchPort = read(
+    "backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteSearchPort.java",
+  );
   const summarizeFeedbackPort = read(
     "backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteFeedbackPort.java",
   );
   const service = read("backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java");
-  const dashboardService = read(
+  const searchDashboardService = read(
+    "backend/src/main/java/com/easysubway/route/application/service/RouteSearchDashboardService.java",
+  );
+  const feedbackDashboardService = read(
     "backend/src/main/java/com/easysubway/route/application/service/RouteFeedbackDashboardService.java",
   );
   const repository = read("backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java");
   const jdbcRepository = read("backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java");
   const controller = read("backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java");
-  const dashboardController = read(
+  const searchDashboardController = read(
+    "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageController.java",
+  );
+  const feedbackDashboardController = read(
     "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageController.java",
   );
-  const dashboardTemplate = read("backend/src/main/resources/templates/admin/routes/feedback.html");
+  const searchDashboardTemplate = read("backend/src/main/resources/templates/admin/routes/searches.html");
+  const feedbackDashboardTemplate = read("backend/src/main/resources/templates/admin/routes/feedback.html");
   const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
 
   assert.match(result, /record RouteSearchResult/);
   assert.match(result, /mobilityType/);
   assert.match(result, /blockedReasons/);
+  assert.match(searchSummary, /record RouteSearchDashboardSummary/);
+  assert.match(searchSummary, /foundCount/);
+  assert.match(searchSummary, /blockedCount/);
+  assert.match(searchSummary, /MobilityTypeCount/);
   assert.match(feedbackSummary, /record RouteFeedbackDashboardSummary/);
   assert.match(feedbackSummary, /helpfulCount/);
   assert.match(feedbackSummary, /notHelpfulCount/);
@@ -1563,11 +1581,15 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(useCase, /interface RouteSearchUseCase/);
   assert.match(useCase, /searchRoute/);
   assert.match(useCase, /getRouteSearch/);
-  assert.match(dashboardUseCase, /interface RouteFeedbackDashboardUseCase/);
-  assert.match(dashboardUseCase, /summarizeRouteFeedbacks/);
+  assert.match(searchDashboardUseCase, /interface RouteSearchDashboardUseCase/);
+  assert.match(searchDashboardUseCase, /summarizeRouteSearches/);
+  assert.match(feedbackDashboardUseCase, /interface RouteFeedbackDashboardUseCase/);
+  assert.match(feedbackDashboardUseCase, /summarizeRouteFeedbacks/);
   assert.match(command, /record SearchRouteCommand/);
   assert.match(loadPort, /interface LoadRouteSearchPort/);
   assert.match(savePort, /interface SaveRouteSearchPort/);
+  assert.match(summarizeSearchPort, /interface SummarizeRouteSearchPort/);
+  assert.match(summarizeSearchPort, /summarizeRouteSearches/);
   assert.match(summarizeFeedbackPort, /interface SummarizeRouteFeedbackPort/);
   assert.match(summarizeFeedbackPort, /summarizeRouteFeedbacks/);
   assert.match(service, /implements RouteSearchUseCase/);
@@ -1576,15 +1598,20 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(service, /RouteSearchStatus\.BLOCKED/);
   assert.match(service, /hasStairOnlyAccess/);
   assert.match(service, /routeScore/);
-  assert.match(dashboardService, /implements RouteFeedbackDashboardUseCase/);
-  assert.match(dashboardService, /SummarizeRouteFeedbackPort/);
-  assert.match(repository, /implements[\s\S]*LoadRouteSearchPort[\s\S]*SaveRouteSearchPort[\s\S]*SaveRouteFeedbackPort[\s\S]*SummarizeRouteFeedbackPort/);
+  assert.match(searchDashboardService, /implements RouteSearchDashboardUseCase/);
+  assert.match(searchDashboardService, /SummarizeRouteSearchPort/);
+  assert.match(feedbackDashboardService, /implements RouteFeedbackDashboardUseCase/);
+  assert.match(feedbackDashboardService, /SummarizeRouteFeedbackPort/);
+  assert.match(repository, /implements[\s\S]*LoadRouteSearchPort[\s\S]*SaveRouteSearchPort[\s\S]*SaveRouteFeedbackPort[\s\S]*SummarizeRouteFeedbackPort[\s\S]*SummarizeRouteSearchPort/);
   assert.match(repository, /@Profile\("!prod"\)/);
   assert.match(jdbcRepository, /@Profile\("prod"\)/);
-  assert.match(jdbcRepository, /implements[\s\S]*LoadRouteSearchPort[\s\S]*SaveRouteSearchPort[\s\S]*SaveRouteFeedbackPort[\s\S]*SummarizeRouteFeedbackPort[\s\S]*AnonymizeUserRouteFeedbackPort/);
+  assert.match(jdbcRepository, /implements[\s\S]*LoadRouteSearchPort[\s\S]*SaveRouteSearchPort[\s\S]*SaveRouteFeedbackPort[\s\S]*SummarizeRouteFeedbackPort[\s\S]*SummarizeRouteSearchPort[\s\S]*AnonymizeUserRouteFeedbackPort/);
   assert.match(jdbcRepository, /JdbcTemplate/);
   assert.match(jdbcRepository, /INSERT INTO route_search_results/);
   assert.match(jdbcRepository, /INSERT INTO route_feedbacks/);
+  assert.match(jdbcRepository, /RouteSearchDashboardSummary summarizeRouteSearches\(\)/);
+  assert.match(jdbcRepository, /GROUP BY status/);
+  assert.match(jdbcRepository, /GROUP BY mobility_type/);
   assert.match(jdbcRepository, /RouteFeedbackDashboardSummary summarizeRouteFeedbacks\(\)/);
   assert.match(jdbcRepository, /SUM\(CASE WHEN rating = 'HELPFUL' THEN 1 ELSE 0 END\)/);
   assert.match(jdbcRepository, /ON CONFLICT \(route_search_id\) DO UPDATE/);
@@ -1598,12 +1625,18 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(batchPostgresSchema, /CHECK \(rating IN \('HELPFUL', 'NOT_HELPFUL', 'BLOCKED_BY_REAL_WORLD'\)\)/);
   assert.match(controller, /@PostMapping\("\/api\/v1\/routes\/search"\)/);
   assert.match(controller, /@GetMapping\("\/api\/v1\/routes\/\{routeSearchId\}"\)/);
-  assert.match(dashboardController, /@GetMapping\("\/admin\/routes\/feedback\/page"\)/);
-  assert.match(dashboardController, /RouteFeedbackDashboardUseCase/);
-  assert.match(dashboardTemplate, /경로 피드백 현황/);
-  assert.match(dashboardTemplate, /전체 피드백/);
-  assert.match(dashboardTemplate, /평점별 피드백/);
-  assert.doesNotMatch(dashboardTemplate, /userId/);
+  assert.match(searchDashboardController, /@GetMapping\("\/admin\/routes\/searches\/page"\)/);
+  assert.match(searchDashboardController, /RouteSearchDashboardUseCase/);
+  assert.match(searchDashboardTemplate, /경로 검색 현황/);
+  assert.match(searchDashboardTemplate, /전체 검색/);
+  assert.match(searchDashboardTemplate, /이동 프로필별 검색/);
+  assert.doesNotMatch(searchDashboardTemplate, /routeSearchId/);
+  assert.match(feedbackDashboardController, /@GetMapping\("\/admin\/routes\/feedback\/page"\)/);
+  assert.match(feedbackDashboardController, /RouteFeedbackDashboardUseCase/);
+  assert.match(feedbackDashboardTemplate, /경로 피드백 현황/);
+  assert.match(feedbackDashboardTemplate, /전체 피드백/);
+  assert.match(feedbackDashboardTemplate, /평점별 피드백/);
+  assert.doesNotMatch(feedbackDashboardTemplate, /userId/);
 });
 
 test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다", () => {


### PR DESCRIPTION
## 관련 이슈

close #282

## 작업 배경

- 경로 검색 수와 차단 비율은 쉬운 경로 추천 품질과 접근성 데이터 검수 우선순위를 판단하는 운영 지표다.
- 경로 검색 결과가 운영 저장소에 저장되므로, 관리자가 누적 검색 상태와 이동 프로필별 검색 분포를 한 화면에서 확인할 수 있어야 한다.

## 작업 내용

- route 도메인에 경로 검색 현황 요약 모델과 input/output port, 서비스 계층을 추가했다.
- InMemory/JDBC 경로 검색 저장소에 `route_search_results` 상태별, 이동 프로필별 요약 조회를 추가했다.
- `/admin/routes/searches/page` 관리자 페이지에서 전체 검색, 경로 찾음, 경로 차단, 이동 프로필별 검색 건수를 표시한다.
- 서비스, JDBC 저장소, 관리자 페이지 테스트와 repository contract 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests "com.easysubway.route.application.service.RouteSearchDashboardServiceTest"`: 성공
  - `backend/gradlew -p backend test --tests "com.easysubway.route.adapter.out.persistence.JdbcRouteSearchRepositoryTest.summarizeRouteSearchesByStatusAndMobilityType"`: 성공
  - `backend/gradlew -p backend test --tests "com.easysubway.route.adapter.in.web.RouteSearchAdminPageControllerTest"`: 성공
  - `backend/gradlew -p backend test --tests "com.easysubway.route.application.service.RouteSearchDashboardServiceTest" --tests "com.easysubway.route.adapter.out.persistence.JdbcRouteSearchRepositoryTest" --tests "com.easysubway.route.adapter.in.web.RouteSearchAdminPageControllerTest"`: 성공
  - `backend/gradlew -p backend test`: 성공
  - `backend/gradlew -p backend test --tests "com.easysubway.route.adapter.out.persistence.JdbcRouteSearchRepositoryTest.summarizeRouteSearchesByStatusAndMobilityType"`: 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 성공
  - `node --test tools/ci/*.test.mjs`: 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `README.md`, `.github/pull_request_template.md`만 추적됨
  - `gh pr checks 283 --watch --interval 20`: 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `JdbcRouteSearchRepository.summarizeRouteSearches()`의 단일 statement 기반 상태별, 이동 프로필별 집계
  - `RouteSearchAdminPageControllerTest`가 개별 경로 식별자와 역 ID를 관리자 현황 화면에 노출하지 않는지 검증하는 부분
  - `tools/ci/repository-contract.test.mjs`의 route search dashboard 헥사고날 경계 검증

## 리스크

- 관리자 페이지는 전체 누적 건수만 제공하며 기간 필터나 개별 검색 목록은 포함하지 않는다.
- 운영 DB의 `route_search_results` 행 수가 크게 증가하면 기간 조건 또는 집계 테이블이 필요할 수 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
