### PR TITLE
[Test] 모바일 접근성 QA 기준선 추가

### DIFF
--- a/apps/mobile/test/accessibility_baseline_test.dart
+++ b/apps/mobile/test/accessibility_baseline_test.dart
@@ -1,0 +1,148 @@
+import 'dart:ui';
+
+import 'package:easysubway_mobile/facility_report.dart';
+import 'package:easysubway_mobile/main.dart';
+import 'package:easysubway_mobile/mobility_profile.dart';
+import 'package:easysubway_mobile/onboarding.dart';
+import 'package:easysubway_mobile/route_search.dart';
+import 'package:easysubway_mobile/station_search.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('모바일 접근성 QA 기준선은 큰 글씨와 고대비 홈 화면을 검증한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: _AccessibilityStationSearchRepository(),
+          reportRepository: _AccessibilityFacilityReportRepository(),
+          routeRepository: _AccessibilityRouteSearchRepository(),
+          locationProvider: _AccessibilityCurrentLocationProvider(),
+          enableAnonymousAuth: false,
+          initialOnboardingState: _completedOnboardingState(
+            preferences: const OnboardingViewPreferences(
+              largeTextEnabled: true,
+              highContrastEnabled: true,
+              simpleViewEnabled: false,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final homeContext = tester.element(find.byType(HomeScreen));
+      expect(MediaQuery.of(homeContext).highContrast, isTrue);
+      expect(
+        MediaQuery.textScalerOf(homeContext).scale(20),
+        closeTo(23.6, 0.01),
+      );
+      expect(
+        Theme.of(homeContext).colorScheme.primary,
+        const Color(0xFF003D40),
+      );
+      expect(find.bySemanticsLabel('역 검색'), findsOneWidget);
+      expect(find.bySemanticsLabel('길찾기'), findsOneWidget);
+
+      final stationSearchSemantics = tester
+          .getSemantics(find.byKey(const Key('stationSearchButton')))
+          .getSemanticsData();
+      final routeSearchSemantics = tester
+          .getSemantics(find.byKey(const Key('routeSearchButton')))
+          .getSemanticsData();
+
+      expect(stationSearchSemantics.label, contains('역 검색'));
+      expect(stationSearchSemantics.hasAction(SemanticsAction.tap), isTrue);
+      expect(routeSearchSemantics.label, contains('길찾기'));
+      expect(routeSearchSemantics.hasAction(SemanticsAction.tap), isTrue);
+
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+}
+
+OnboardingState _completedOnboardingState({
+  required OnboardingViewPreferences preferences,
+}) {
+  return OnboardingState.completed(
+    result: OnboardingResult(
+      profile: mobilityProfileOptions.first,
+      preferences: preferences,
+    ),
+  );
+}
+
+class _AccessibilityStationSearchRepository implements StationSearchRepository {
+  @override
+  Future<List<StationSearchResult>> searchStations(String query) {
+    throw UnimplementedError('접근성 기준선 테스트는 역 검색 API를 호출하지 않는다.');
+  }
+
+  @override
+  Future<List<StationSearchResult>> searchNearbyStations(
+    CurrentLocation location, {
+    int radiusMeters = 2000,
+    int limit = 10,
+  }) {
+    throw UnimplementedError('접근성 기준선 테스트는 주변 역 API를 호출하지 않는다.');
+  }
+
+  @override
+  Future<StationDetail> getStationDetail(String stationId) {
+    throw UnimplementedError('접근성 기준선 테스트는 역 상세 API를 호출하지 않는다.');
+  }
+
+  @override
+  Future<List<StationExitInfo>> listStationExits(String stationId) {
+    throw UnimplementedError('접근성 기준선 테스트는 출구 API를 호출하지 않는다.');
+  }
+
+  @override
+  Future<List<StationFacilityInfo>> listStationFacilities(String stationId) {
+    throw UnimplementedError('접근성 기준선 테스트는 시설 API를 호출하지 않는다.');
+  }
+}
+
+class _AccessibilityRouteSearchRepository implements RouteSearchRepository {
+  @override
+  Future<RouteSearchResult> searchRoute(RouteSearchRequest request) {
+    throw UnimplementedError('접근성 기준선 테스트는 경로 검색 API를 호출하지 않는다.');
+  }
+}
+
+class _AccessibilityFacilityReportRepository
+    implements FacilityReportRepository {
+  @override
+  Future<FacilityReportResult> createReport(FacilityReportRequest request) {
+    throw UnimplementedError('접근성 기준선 테스트는 신고 API를 호출하지 않는다.');
+  }
+
+  @override
+  Future<FacilityReportResult> getReport(String reportId) {
+    throw UnimplementedError('접근성 기준선 테스트는 신고 상세 API를 호출하지 않는다.');
+  }
+
+  @override
+  Future<List<FacilityReportResult>> listMyReports() {
+    throw UnimplementedError('접근성 기준선 테스트는 내 신고 API를 호출하지 않는다.');
+  }
+}
+
+class _AccessibilityCurrentLocationProvider implements CurrentLocationProvider {
+  @override
+  Future<bool> needsLocationPermissionRequest() async => false;
+
+  @override
+  Future<CurrentLocation> currentLocation() async {
+    return const CurrentLocation(latitude: 37.3028, longitude: 126.8665);
+  }
+
+  @override
+  Future<bool> openLocationSettings() async => true;
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1690,6 +1690,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   const notificationSettings = read("apps/mobile/lib/notification_settings.dart");
   const notificationSettingsTest = read("apps/mobile/test/notification_settings_test.dart");
   const widgetTest = read("apps/mobile/test/widget_test.dart");
+  const accessibilityBaselineTest = read("apps/mobile/test/accessibility_baseline_test.dart");
 
   assert.ok(existsSync(path.join(root, "apps/mobile/android")));
   assert.ok(existsSync(path.join(root, "apps/mobile/ios")));
@@ -1763,6 +1764,12 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(widgetTest, /온보딩 이동 조건은 경로 검색 기본값으로 이어진다/);
   assert.match(widgetTest, /온보딩 보기 설정은 완료 뒤 홈 UI에 적용된다/);
   assert.match(widgetTest, /MediaQuery\.textScalerOf/);
+  assert.match(accessibilityBaselineTest, /모바일 접근성 QA 기준선은 큰 글씨와 고대비 홈 화면을 검증한다/);
+  assert.match(accessibilityBaselineTest, /tester\.ensureSemantics\(\)/);
+  assert.match(accessibilityBaselineTest, /androidTapTargetGuideline/);
+  assert.match(accessibilityBaselineTest, /iOSTapTargetGuideline/);
+  assert.match(accessibilityBaselineTest, /labeledTapTargetGuideline/);
+  assert.match(accessibilityBaselineTest, /textContrastGuideline/);
   assert.match(onboardingTest, /온보딩은 이동 조건과 보기 설정을 선택한 뒤 완료 결과를 반환한다/);
   assert.match(onboardingTest, /hasTapAction: true/);
   assert.match(authHeaders, /abstract class AuthorizationHeaderProvider/);


### PR DESCRIPTION
## 관련 이슈

close #294

## 작업 배경

- 모바일 앱의 출시 전 접근성 QA에서 큰 글씨, 고대비, 주요 홈 액션 semantics, tap target, text contrast를 반복 검증할 기준선이 필요했다.
- 기존 테스트는 개별 화면과 온보딩 설정 반영을 확인했지만, Flutter 접근성 guideline을 한 번에 실행하는 모바일 QA 테스트는 분리되어 있지 않았다.

## 작업 내용

- `apps/mobile/test/accessibility_baseline_test.dart`를 추가해 큰 글씨와 고대비가 홈 화면 `MediaQuery`, `Theme`, 주요 액션 semantics에 반영되는지 검증했다.
- Android/iOS tap target, labeled tap target, text contrast Flutter guideline 검증을 같은 widget test에 포함했다.
- repository contract가 접근성 QA 기준선 테스트 파일과 핵심 guideline 검증을 요구하도록 보강했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` 성공
  - `flutter test test/accessibility_baseline_test.dart` 성공
  - `flutter test` 성공
  - `flutter analyze` 성공
  - `env EASYSUBWAY_ANDROID_KEYSTORE_PATH=ci-release-manifest-only.jks EASYSUBWAY_ANDROID_STORE_PASSWORD=ci-release-manifest-only EASYSUBWAY_ANDROID_KEY_ALIAS=ci-release-manifest-only EASYSUBWAY_ANDROID_KEY_PASSWORD=ci-release-manifest-only flutter build apk --config-only` 성공
  - `env EASYSUBWAY_ANDROID_KEYSTORE_PATH=ci-release-manifest-only.jks EASYSUBWAY_ANDROID_STORE_PASSWORD=ci-release-manifest-only EASYSUBWAY_ANDROID_KEY_ALIAS=ci-release-manifest-only EASYSUBWAY_ANDROID_KEY_PASSWORD=ci-release-manifest-only android/gradlew -p android :app:processReleaseMainManifest --no-daemon` 성공
  - `env EASYSUBWAY_EXPECT_ANDROID_RELEASE_MANIFEST=true node --test --test-name-pattern "모바일 generic catch|Android 릴리즈 권한|iOS 앱은 개인정보 매니페스트|Android 런처 아이콘" tools/ci/repository-contract.test.mjs` 성공
  - `flutter build apk --debug` 성공
  - `flutter build ios --simulator --no-codesign` 성공
  - iOS Simulator `Maum iPhone 17`에 `Runner.app` 설치, launch, screenshot 캡처 성공
  - Android emulator/device는 연결된 대상이 없어 실행 smoke는 수행하지 못했고, debug APK build로 대체 확인했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 새 접근성 기준선 테스트가 홈 화면 시작 상태만 검증하면서 실제 API 호출을 하지 않도록 fake repository를 제한한 부분
  - Flutter guideline 검증이 `tester.ensureSemantics()` scope 안에서 실행되는지 여부

## 리스크

- 접근성 guideline은 홈 화면 기준선만 다루므로, 역 검색/경로 검색/신고 화면의 세부 QA는 기존 개별 widget test와 후속 device QA로 계속 보완해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
