### PR TITLE
[Style] 모바일 알림 권한 사전 안내 보강

### DIFF
--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -681,7 +681,9 @@ class _NotificationSettingsScreenState
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('알림 받기'),
-        content: const Text('시설 상태와 신고 결과를 알려드립니다.'),
+        content: const Text(
+          '즐겨찾는 역과 경로의 시설 상태, 내 신고 처리 결과, 정보 갱신을 알려드립니다. 알림 설정에서 언제든 끌 수 있습니다.',
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -974,7 +974,12 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('알림 받기'), findsOneWidget);
-    expect(find.text('시설 상태와 신고 결과를 알려드립니다.'), findsOneWidget);
+    expect(
+      find.text(
+        '즐겨찾는 역과 경로의 시설 상태, 내 신고 처리 결과, 정보 갱신을 알려드립니다. 알림 설정에서 언제든 끌 수 있습니다.',
+      ),
+      findsOneWidget,
+    );
     expect(notificationPermissionProvider.requestCount, 0);
 
     await tester.tap(find.text('켜기'));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1859,6 +1859,8 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(notificationSettings, /경로 시설 알림/);
   assert.match(notificationSettings, /신고 처리 알림/);
   assert.match(notificationSettings, /정보 갱신 알림/);
+  assert.match(notificationSettings, /즐겨찾는 역과 경로의 시설 상태/);
+  assert.match(notificationSettings, /알림 설정에서 언제든 끌 수 있습니다/);
   assert.match(notificationSettingsTest, /인증 실패 시 인증을 지우고 한 번 재시도한다/);
   assert.match(notificationSettingsTest, /알림 설정 컨트롤러는 조회와 저장 상태를 구분한다/);
   assert.doesNotMatch(main, /빠른 길보다, 갈 수 있는 길을 먼저 안내합니다|고령자, 임산부, 장애인도 편하게 이동할 수 있도록|현장에서 발견한 불편 정보를 신고하고 검수할 수 있게/);


### PR DESCRIPTION
## 관련 이슈

close #296

## 작업 배경

- 출시 전 권한 고지 기준에서는 OS 알림 권한 요청 전에 앱 화면에서 알림 목적과 설정 변경 가능성을 먼저 안내해야 한다.
- 기존 알림 설정 dialog는 짧은 목적만 안내해 즐겨찾기, 신고 처리, 정보 갱신 알림 범위와 사용자가 나중에 끌 수 있다는 점이 충분히 드러나지 않았다.

## 작업 내용

- 알림 권한 확인 dialog 문구를 즐겨찾는 역/경로 시설 상태, 내 신고 처리 결과, 정보 갱신 알림 목적을 포함하도록 보강했다.
- 같은 dialog에서 알림 설정에서 언제든 끌 수 있음을 안내하도록 했다.
- 권한 요청 widget test와 repository contract가 새 사전 안내 문구를 검증하도록 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "알림 설정 화면은 기기 알림 권한을 사용자 확인 뒤 요청한다"` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공
  - `flutter analyze` 성공
  - `flutter test` 성공
  - `env EASYSUBWAY_ANDROID_KEYSTORE_PATH=ci-release-manifest-only.jks EASYSUBWAY_ANDROID_STORE_PASSWORD=ci-release-manifest-only EASYSUBWAY_ANDROID_KEY_ALIAS=ci-release-manifest-only EASYSUBWAY_ANDROID_KEY_PASSWORD=ci-release-manifest-only flutter build apk --config-only` 성공
  - `env EASYSUBWAY_ANDROID_KEYSTORE_PATH=ci-release-manifest-only.jks EASYSUBWAY_ANDROID_STORE_PASSWORD=ci-release-manifest-only EASYSUBWAY_ANDROID_KEY_ALIAS=ci-release-manifest-only EASYSUBWAY_ANDROID_KEY_PASSWORD=ci-release-manifest-only android/gradlew -p android :app:processReleaseMainManifest --no-daemon` 성공
  - `env EASYSUBWAY_EXPECT_ANDROID_RELEASE_MANIFEST=true node --test --test-name-pattern "모바일 generic catch|Android 릴리즈 권한|iOS 앱은 개인정보 매니페스트|Android 런처 아이콘" tools/ci/repository-contract.test.mjs` 성공
  - `flutter build apk --debug` 성공
  - `flutter build ios --simulator --no-codesign` 성공
  - iOS Simulator `Maum iPhone 17`에 `Runner.app` 설치와 launch 성공
  - Android emulator/device는 연결된 대상이 없어 실행 smoke는 수행하지 못했고, debug APK build로 대체 확인했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 알림 권한 dialog 문구가 출시 전 권한 사전 안내 기준에 맞는지
  - 권한 요청이 여전히 `켜기` 선택 이후에만 실행되는지

## 리스크

- 실제 푸시 토큰 등록과 FCM/APNs 연동은 이 PR 범위가 아니며, 별도 작업으로 다뤄야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
