### PR TITLE
[Style] 모바일 위치 권한 사전 안내 보강

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -17,6 +17,11 @@ const _anonymousReportUserId = 'anonymous-mobile-user';
 const _facilityReportPhotoTooLargeMessage = '사진이 너무 큽니다. 다른 사진을 선택해 주세요.';
 const _facilityReportLocationDisabledMessage =
     '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
+const _facilityReportLocationRationaleTitle = '현재 위치 사용';
+const _facilityReportLocationRationalePurpose =
+    '가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다.';
+const _facilityReportLocationRationaleFallback =
+    '위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다.';
 const _facilityReportDraftTargetStorageKey =
     'easysubway.facilityReport.draftTarget';
 
@@ -1495,8 +1500,67 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     if (widget.locationLoader == null || _isLoadingLocation) {
       return;
     }
-    // 권한 요청과 GPS 상태 확인은 네이티브 채널이 맡고, 화면은 실패 안내만 보여준다.
+    final shouldContinue = await _confirmLocationUseIfNeeded();
+    if (!shouldContinue) {
+      if (mounted) {
+        setState(() {
+          _attachedLocation = null;
+          _locationMessage = '위치 안내를 확인한 뒤 신고 위치를 첨부해 주세요.';
+          _isLocationFailure = true;
+        });
+      }
+      return;
+    }
     await _loadCurrentLocation();
+  }
+
+  Future<bool> _confirmLocationUseIfNeeded() async {
+    final checker = widget.needsLocationPermissionRequest;
+    if (checker == null) {
+      return true;
+    }
+    var needsPermissionRequest = true;
+    try {
+      needsPermissionRequest = await checker();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '시설 신고 위치 권한 사전 확인 중 예외가 발생했습니다.',
+      );
+    }
+    if (!needsPermissionRequest) {
+      return true;
+    }
+    if (!mounted) {
+      return false;
+    }
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text(_facilityReportLocationRationaleTitle),
+            content: const Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(_facilityReportLocationRationalePurpose),
+                SizedBox(height: 8),
+                Text(_facilityReportLocationRationaleFallback),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('취소'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('계속'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
   }
 
   Future<void> _openLocationSettings() async {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -13,6 +13,11 @@ import 'mobile_error_reporter.dart';
 const _stationSearchTimeout = Duration(seconds: 8);
 const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
 const _currentLocationDisabledMessage = '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
+const _locationPermissionRationaleTitle = '현재 위치 사용';
+const _locationPermissionRationalePurpose =
+    '가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다.';
+const _locationPermissionRationaleFallback =
+    '위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다.';
 const _stationSafetyGuidanceNotice = '이동 전 현장 안내와 역무원 안내를 확인해 주세요.';
 const _favoriteStationTimeout = Duration(seconds: 8);
 const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했습니다.';
@@ -1988,15 +1993,63 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       return;
     }
     setState(() => _isNearbySearchRunning = true);
-    // OS 권한 요청과 GPS 상태 확인은 네이티브 위치 조회에 맡기고,
-    // 사용자가 누른 즉시 가까운 역을 찾는 흐름으로 유지한다.
     try {
+      final shouldContinue = await _confirmLocationUseIfNeeded();
+      if (!shouldContinue) {
+        return;
+      }
       await _controller.searchNearby(widget.locationProvider);
     } finally {
       if (mounted) {
         setState(() => _isNearbySearchRunning = false);
       }
     }
+  }
+
+  Future<bool> _confirmLocationUseIfNeeded() async {
+    var needsPermissionRequest = true;
+    try {
+      needsPermissionRequest = await widget.locationProvider
+          .needsLocationPermissionRequest();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '주변 역 위치 권한 사전 확인 중 예외가 발생했습니다.',
+      );
+    }
+    if (!needsPermissionRequest) {
+      return true;
+    }
+    if (!mounted) {
+      return false;
+    }
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text(_locationPermissionRationaleTitle),
+            content: const Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(_locationPermissionRationalePurpose),
+                SizedBox(height: 8),
+                Text(_locationPermissionRationaleFallback),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('취소'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('계속'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
   }
 
   Future<void> _openLocationSettings() async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1682,7 +1682,7 @@ void main() {
     }
   });
 
-  testWidgets('역 검색은 현재 위치 확인창 없이 바로 주변 역을 찾는다', (tester) async {
+  testWidgets('역 검색은 첫 위치 권한 요청 전에 사용 목적을 안내한다', (tester) async {
     final locationProvider = FakeCurrentLocationProvider(
       location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
     );
@@ -1712,10 +1712,20 @@ void main() {
     await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
     await tester.pumpAndSettle();
 
-    expect(locationProvider.permissionCheckCount, 0);
+    expect(locationProvider.permissionCheckCount, 1);
+    expect(locationProvider.requestCount, 0);
+    expect(find.text('현재 위치 사용'), findsOneWidget);
+    expect(find.text('가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다.'), findsOneWidget);
+    expect(
+      find.text('위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다.'),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('계속'));
+    await tester.pumpAndSettle();
+
     expect(locationProvider.requestCount, 1);
     expect(repository.requestedNearbyLocations, hasLength(1));
-    expect(find.text('현재 위치 사용'), findsNothing);
     expect(find.text('상록수역'), findsOneWidget);
   });
 
@@ -1723,6 +1733,7 @@ void main() {
     final locationCompleter = Completer<CurrentLocation>();
     final locationProvider = FakeCurrentLocationProvider(
       locationLoader: () => locationCompleter.future,
+      needsPermissionRequest: false,
     );
     final repository = FakeStationSearchRepository(
       nearbyResults: [
@@ -1751,7 +1762,7 @@ void main() {
     await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
     await tester.pump();
 
-    expect(locationProvider.permissionCheckCount, 0);
+    expect(locationProvider.permissionCheckCount, 1);
     expect(locationProvider.requestCount, 1);
 
     locationCompleter.complete(
@@ -1766,6 +1777,7 @@ void main() {
     final locationCompleter = Completer<CurrentLocation>();
     final locationProvider = FakeCurrentLocationProvider(
       locationLoader: () => locationCompleter.future,
+      needsPermissionRequest: false,
     );
     final repository = FakeStationSearchRepository(
       nearbyResults: [
@@ -1812,6 +1824,7 @@ void main() {
     final semanticsHandle = tester.ensureSemantics();
     final locationProvider = FakeCurrentLocationProvider(
       error: const CurrentLocationException('위치 권한을 확인해 주세요.'),
+      needsPermissionRequest: false,
     );
     final repository = FakeStationSearchRepository();
 
@@ -3936,9 +3949,10 @@ void main() {
     );
   });
 
-  testWidgets('시설 신고 화면은 첫 위치 권한 요청도 화면 진입 시 자동으로 진행한다', (tester) async {
+  testWidgets('시설 신고 화면은 첫 위치 권한 요청 전에 사용 목적을 안내한다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
     var requestCount = 0;
+    var permissionCheckCount = 0;
 
     await tester.pumpWidget(
       MaterialApp(
@@ -3953,9 +3967,8 @@ void main() {
             facilityStatusLabel: '정상',
           ),
           needsLocationPermissionRequest: () async {
-            throw AssertionError(
-              '시설 신고 화면은 위치 preflight checker를 호출하지 않아야 합니다.',
-            );
+            permissionCheckCount++;
+            return true;
           },
           locationLoader: () async {
             requestCount++;
@@ -3969,10 +3982,20 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(requestCount, 1);
-    expect(find.text('위치 확인'), findsNothing);
-    expect(find.text('가까운 역과 신고 위치를 확인합니다.'), findsNothing);
+    expect(permissionCheckCount, 1);
+    expect(requestCount, 0);
+    expect(find.text('현재 위치 사용'), findsOneWidget);
+    expect(find.text('가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다.'), findsOneWidget);
+    expect(
+      find.text('위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다.'),
+      findsOneWidget,
+    );
     expect(find.text('현재 위치 첨부됨'), findsNothing);
+
+    await tester.tap(find.text('계속'));
+    await tester.pumpAndSettle();
+
+    expect(requestCount, 1);
 
     await tester.ensureVisible(
       find.byKey(const Key('facilityReportDescriptionInput')),

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1863,6 +1863,10 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(notificationSettings, /알림 설정에서 언제든 끌 수 있습니다/);
   assert.match(notificationSettingsTest, /인증 실패 시 인증을 지우고 한 번 재시도한다/);
   assert.match(notificationSettingsTest, /알림 설정 컨트롤러는 조회와 저장 상태를 구분한다/);
+  assert.match(stationSearch, /가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다/);
+  assert.match(stationSearch, /위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다/);
+  assert.match(widgetTest, /역 검색은 첫 위치 권한 요청 전에 사용 목적을 안내한다/);
+  assert.match(widgetTest, /시설 신고 화면은 첫 위치 권한 요청 전에 사용 목적을 안내한다/);
   assert.doesNotMatch(main, /빠른 길보다, 갈 수 있는 길을 먼저 안내합니다|고령자, 임산부, 장애인도 편하게 이동할 수 있도록|현장에서 발견한 불편 정보를 신고하고 검수할 수 있게/);
   assert.match(widgetTest, /EasySubwayApp/);
   assert.match(widgetTest, /홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다/);


### PR DESCRIPTION
## 관련 이슈

close #298

## 작업 배경

모바일 출시 게이트에서 위치 권한은 OS 권한 요청 전에 앱 화면에서 사용 목적을 설명해야 한다. 역 검색의 내 주변 역 찾기와 시설 신고 위치 첨부 흐름이 첫 권한 요청 전에 가까운 역 찾기, 신고 위치 확인 목적과 권한 거부 시 계속 사용할 수 있는 기능을 먼저 안내하도록 보강했다.

## 작업 내용

- 역 검색의 내 주변 역 찾기 버튼에서 위치 권한 요청이 필요한 경우 사전 안내 확인창을 먼저 보여준다.
- 시설 신고 화면 진입 시 위치 권한 요청이 필요한 경우 신고 위치 첨부 전에 같은 목적 안내를 먼저 보여준다.
- 이미 위치 권한이 준비된 상태에서는 기존 주변 역 검색과 신고 위치 자동 첨부 흐름을 유지한다.
- widget test와 repository contract에 위치 권한 사전 안내 기준선을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "역 검색은 첫 위치 권한 요청 전에 사용 목적을 안내한다"`: 통과
  - `flutter test test/widget_test.dart --name "시설 신고 화면은 첫 위치 권한 요청 전에 사용 목적을 안내한다"`: 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과
  - `flutter analyze`: 통과
  - `flutter test`: 통과
  - `android/gradlew -p android :app:processReleaseMainManifest --no-daemon`: 통과
  - `EASYSUBWAY_EXPECT_ANDROID_RELEASE_MANIFEST=true node --test --test-name-pattern "Android 릴리즈 권한" tools/ci/repository-contract.test.mjs`: 통과
  - `flutter build apk --debug`: 통과
  - `flutter build ios --simulator --no-codesign`: 통과
  - iOS Simulator 설치/실행/screenshot: 통과
  - Android emulator launch smoke: 연결된 emulator 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 위치 권한이 필요한 상태에서 `currentLocation()` 호출 전에 안내 확인창이 먼저 노출되는지
  - 위치 권한이 이미 준비된 상태에서 기존 검색/신고 흐름이 불필요하게 막히지 않는지

## 리스크

- 시설 신고 화면 진입 시 권한이 필요한 사용자는 안내 확인을 한 번 더 거친 뒤 위치 첨부가 진행된다. 취소하면 위치 재확인 버튼으로 다시 시도할 수 있다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
