### PR TITLE
[Style] 모바일 시설 신고 제출 전 개인정보 안내 보강

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -22,6 +22,11 @@ const _facilityReportLocationRationalePurpose =
     '가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다.';
 const _facilityReportLocationRationaleFallback =
     '위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다.';
+const _facilityReportUploadDisclosureTitle = '사진·위치 확인';
+const _facilityReportUploadDisclosurePurpose =
+    '사진과 신고 위치는 시설 신고 확인과 운영 검수에만 사용됩니다.';
+const _facilityReportUploadDisclosureScope =
+    '신고 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다.';
 const _facilityReportDraftTargetStorageKey =
     'easysubway.facilityReport.draftTarget';
 
@@ -1430,7 +1435,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       _locationMessage == _facilityReportLocationDisabledMessage;
 
   Future<void> _submit() async {
-    if (_photoAttachment != null && _attachedLocation != null) {
+    if (_photoAttachment != null || _attachedLocation != null) {
       final confirmed = await _confirmReportUpload();
       if (!confirmed) {
         return;
@@ -1450,8 +1455,16 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('사진 보내기'),
-        content: const Text('이 사진을 함께 보낼까요?'),
+        title: const Text(_facilityReportUploadDisclosureTitle),
+        content: const Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(_facilityReportUploadDisclosurePurpose),
+            SizedBox(height: 8),
+            Text(_facilityReportUploadDisclosureScope),
+          ],
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3327,6 +3327,10 @@ void main() {
       await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
       await tester.pumpAndSettle();
 
+      expect(find.text('사진·위치 확인'), findsOneWidget);
+      await tester.tap(find.text('보내기'));
+      await tester.pumpAndSettle();
+
       expect(reportRepository.requests, hasLength(1));
       expect(reportRepository.requests.single.stationId, 'station-sangnoksu');
       expect(
@@ -3633,6 +3637,10 @@ void main() {
     await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
     await tester.pumpAndSettle();
 
+    expect(find.text('사진·위치 확인'), findsOneWidget);
+    await tester.tap(find.text('보내기'));
+    await tester.pumpAndSettle();
+
     expect(reportRepository.requests, hasLength(1));
     expect(
       reportRepository.requests.single.photoFileName,
@@ -3831,7 +3839,7 @@ void main() {
     expect(find.text('사진 1장 추가됨'), findsOneWidget);
   });
 
-  testWidgets('시설 신고 화면은 사진을 보내기 전에 쉬운 문구로 확인한다', (tester) async {
+  testWidgets('시설 신고 화면은 사진과 위치를 보내기 전에 공개 범위를 안내한다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
 
     await tester.pumpWidget(
@@ -3887,12 +3895,13 @@ void main() {
     await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('사진 보내기'), findsOneWidget);
-    expect(find.text('이 사진을 함께 보낼까요?'), findsOneWidget);
+    expect(find.text('사진·위치 확인'), findsOneWidget);
+    expect(find.text('사진과 신고 위치는 시설 신고 확인과 운영 검수에만 사용됩니다.'), findsOneWidget);
+    expect(
+      find.text('신고 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다.'),
+      findsOneWidget,
+    );
     expect(find.text('사진 확인'), findsNothing);
-    expect(find.text('사진과 위치를 함께 보냅니다.'), findsNothing);
-    expect(find.text('사진·위치 확인'), findsNothing);
-    expect(find.text('사진과 신고 위치를 함께 보냅니다.'), findsNothing);
     expect(reportRepository.requests, isEmpty);
 
     await tester.tap(find.text('취소'));
@@ -4006,6 +4015,10 @@ void main() {
       '권한 요청 후 바로 확인된 위치입니다.',
     );
     await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('사진·위치 확인'), findsOneWidget);
+    await tester.tap(find.text('보내기'));
     await tester.pumpAndSettle();
 
     expect(reportRepository.requests, hasLength(1));
@@ -4375,7 +4388,7 @@ void main() {
     await tester.pumpAndSettle();
   });
 
-  testWidgets('시설 신고 화면은 현재 위치를 함께 보낸다', (tester) async {
+  testWidgets('시설 신고 화면은 현재 위치를 보내기 전에 공개 범위를 안내한다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
     final locationProvider = FakeCurrentLocationProvider(
       location: const CurrentLocation(
@@ -4456,6 +4469,17 @@ void main() {
       '승강기 앞에서 확인했습니다.',
     );
     await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('사진·위치 확인'), findsOneWidget);
+    expect(find.text('사진과 신고 위치는 시설 신고 확인과 운영 검수에만 사용됩니다.'), findsOneWidget);
+    expect(
+      find.text('신고 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다.'),
+      findsOneWidget,
+    );
+    expect(reportRepository.requests, isEmpty);
+
+    await tester.tap(find.text('보내기'));
     await tester.pumpAndSettle();
 
     expect(reportRepository.requests, hasLength(1));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1865,8 +1865,12 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(notificationSettingsTest, /알림 설정 컨트롤러는 조회와 저장 상태를 구분한다/);
   assert.match(stationSearch, /가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다/);
   assert.match(stationSearch, /위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다/);
+  assert.match(facilityReport, /사진과 신고 위치는 시설 신고 확인과 운영 검수에만 사용됩니다/);
+  assert.match(facilityReport, /신고 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다/);
   assert.match(widgetTest, /역 검색은 첫 위치 권한 요청 전에 사용 목적을 안내한다/);
   assert.match(widgetTest, /시설 신고 화면은 첫 위치 권한 요청 전에 사용 목적을 안내한다/);
+  assert.match(widgetTest, /시설 신고 화면은 사진과 위치를 보내기 전에 공개 범위를 안내한다/);
+  assert.match(widgetTest, /시설 신고 화면은 현재 위치를 보내기 전에 공개 범위를 안내한다/);
   assert.doesNotMatch(main, /빠른 길보다, 갈 수 있는 길을 먼저 안내합니다|고령자, 임산부, 장애인도 편하게 이동할 수 있도록|현장에서 발견한 불편 정보를 신고하고 검수할 수 있게/);
   assert.match(widgetTest, /EasySubwayApp/);
   assert.match(widgetTest, /홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다/);


### PR DESCRIPTION
## 관련 이슈

close #300

## 작업 배경

- 시설 신고에서 사진이나 현재 위치를 함께 보내는 경우, 제출 버튼을 누른 뒤 업로드 직전에 수집 목적과 공개 범위를 다시 확인할 수 있어야 합니다.
- 교통약자 사용자가 사진과 위치 제공 여부를 쉽게 판단할 수 있도록 짧고 직접적인 문구로 안내합니다.

## 작업 내용

- 시설 신고 제출 흐름에서 사진 또는 현재 위치가 포함되면 `사진·위치 확인` 다이얼로그를 표시하도록 변경했습니다.
- 다이얼로그에 사진과 신고 위치의 사용 목적, 접수 담당자 전달 범위, 앱 사용자 비공개 범위를 안내했습니다.
- 사진+위치, 위치 단독 제출 경로의 위젯 테스트와 저장소 계약 테스트를 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "시설 신고 화면은 사진과 위치를 보내기 전에 공개 범위를 안내한다"` 통과
  - `flutter test test/widget_test.dart --name "시설 신고 화면은 현재 위치를 보내기 전에 공개 범위를 안내한다"` 통과
  - `node --test tools/ci/repository-contract.test.mjs` 통과
  - `flutter analyze` 통과
  - `flutter test` 통과
  - `EASYSUBWAY_ANDROID_KEYSTORE_PATH=/private/tmp/easysubway-upload-keystore.jks EASYSUBWAY_ANDROID_STORE_PASSWORD=dummy-store-password EASYSUBWAY_ANDROID_KEY_ALIAS=dummy-upload EASYSUBWAY_ANDROID_KEY_PASSWORD=dummy-key-password android/gradlew -p android :app:processReleaseMainManifest --no-daemon` 통과
  - `EASYSUBWAY_EXPECT_ANDROID_RELEASE_MANIFEST=true node --test --test-name-pattern "Android 릴리즈 권한" tools/ci/repository-contract.test.mjs` 통과
  - `flutter build apk --debug` 통과
  - `flutter build ios --simulator --no-codesign` 통과
  - iOS Simulator `Maum iPhone 17` 설치, 실행, 스크린샷 캡처 통과
  - Android emulator는 연결된 기기가 없어 실행 스모크는 생략
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/facility_report.dart`의 `_submit()` 조건이 사진 또는 위치 첨부 모두에서 사전 안내를 띄우는지 확인해 주세요.
  - 다이얼로그 문구가 개인정보 제공 판단에 충분히 짧고 명확한지 확인해 주세요.

## 리스크

- 사진 또는 위치를 포함한 신고 제출에는 확인 탭이 한 번 추가됩니다.
- 첨부가 없는 텍스트 신고 제출 흐름은 기존처럼 바로 접수됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
