### PR TITLE
[Style] 모바일 개인정보 사용 안내 보강

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1178,7 +1178,8 @@ class _PrivacyDataUseSummary extends StatelessWidget {
   static const _locationPurpose = '현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다.';
   static const _appDataPurpose =
       '즐겨찾기, 이동 조건, 신고 내용과 사진, 알림 설정은 앱 기능 제공에 사용됩니다.';
-  static const _deletionScope = '데이터 삭제 요청 시 즐겨찾기, 알림 토큰, 신고자 연결 정보를 지웁니다.';
+  static const _deletionScope =
+      '데이터 삭제 요청 시 즐겨찾기, 이동 조건, 익명 인증, 기기 알림 정보, 신고 내용·사진·위치와 경로 피드백을 삭제하거나 익명화합니다.';
   static const _retentionNotice = '법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관합니다.';
 
   @override

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1136,6 +1136,8 @@ class SupportAccessScreen extends StatelessWidget {
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
           children: [
+            const _PrivacyDataUseSummary(),
+            const SizedBox(height: 12),
             _SupportAccessItem(
               key: const Key('privacyPolicyAccessItem'),
               icon: Icons.privacy_tip_outlined,
@@ -1164,6 +1166,90 @@ class SupportAccessScreen extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _PrivacyDataUseSummary extends StatelessWidget {
+  const _PrivacyDataUseSummary();
+
+  static const _title = '개인정보 사용 안내';
+  static const _locationPurpose = '현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다.';
+  static const _appDataPurpose =
+      '즐겨찾기, 이동 조건, 신고 내용과 사진, 알림 설정은 앱 기능 제공에 사용됩니다.';
+  static const _deletionScope = '데이터 삭제 요청 시 즐겨찾기, 알림 토큰, 신고자 연결 정보를 지웁니다.';
+  static const _retentionNotice = '법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관합니다.';
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Semantics(
+      key: const Key('privacyDataUseSummary'),
+      container: true,
+      label:
+          '$_title, $_locationPurpose $_appDataPurpose $_deletionScope $_retentionNotice',
+      child: ExcludeSemantics(
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: const Color(0xFFEAF5F4),
+            border: Border.all(color: const Color(0xFFB7D7D3)),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  _title,
+                  style: textTheme.titleMedium?.copyWith(
+                    color: const Color(0xFF102A2C),
+                    fontWeight: FontWeight.w800,
+                    height: 1.25,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                const _PrivacyDataUseLine(text: _locationPurpose),
+                const _PrivacyDataUseLine(text: _appDataPurpose),
+                const _PrivacyDataUseLine(text: _deletionScope),
+                const _PrivacyDataUseLine(text: _retentionNotice),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PrivacyDataUseLine extends StatelessWidget {
+  const _PrivacyDataUseLine({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Padding(
+            padding: EdgeInsets.only(top: 7),
+            child: Icon(Icons.circle, size: 7, color: Color(0xFF006D77)),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              text,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: const Color(0xFF29484B),
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -682,6 +682,60 @@ void main() {
     }
   });
 
+  testWidgets('도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
+          supportAccessInfo: const SupportAccessInfo(
+            privacyPolicyUrl: 'https://easysubway.example/privacy',
+            supportEmail: 'support@easysubway.example',
+            dataDeletionEmail: 'privacy@easysubway.example',
+          ),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('homeHelpActionButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('개인정보 사용 안내'), findsOneWidget);
+      expect(
+        find.text('현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다.'),
+        findsOneWidget,
+      );
+      expect(
+        find.text('즐겨찾기, 이동 조건, 신고 내용과 사진, 알림 설정은 앱 기능 제공에 사용됩니다.'),
+        findsOneWidget,
+      );
+      expect(
+        find.text('데이터 삭제 요청 시 즐겨찾기, 알림 토큰, 신고자 연결 정보를 지웁니다.'),
+        findsOneWidget,
+      );
+      expect(find.text('법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관합니다.'), findsOneWidget);
+
+      final summarySize = tester.getSize(
+        find.byKey(const Key('privacyDataUseSummary')),
+      );
+      expect(summarySize.height, greaterThanOrEqualTo(120));
+
+      final summarySemantics = tester
+          .getSemantics(find.byKey(const Key('privacyDataUseSummary')))
+          .getSemanticsData();
+      expect(
+        summarySemantics.label,
+        contains('개인정보 사용 안내, 현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다.'),
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('도움말은 개인정보 링크를 값 복사 화면이 아니라 외부 연결로 처리한다', (tester) async {
     final launcher = RecordingSupportAccessLauncher();
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -714,7 +714,9 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.text('데이터 삭제 요청 시 즐겨찾기, 알림 토큰, 신고자 연결 정보를 지웁니다.'),
+        find.text(
+          '데이터 삭제 요청 시 즐겨찾기, 이동 조건, 익명 인증, 기기 알림 정보, 신고 내용·사진·위치와 경로 피드백을 삭제하거나 익명화합니다.',
+        ),
         findsOneWidget,
       );
       expect(find.text('법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관합니다.'), findsOneWidget);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1875,6 +1875,10 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(widgetTest, /EasySubwayApp/);
   assert.match(widgetTest, /홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다/);
   assert.match(widgetTest, /홈 즐겨찾기는 하나의 진입점에서 탭 목록을 바로 보여준다/);
+  assert.match(widgetTest, /도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다/);
+  assert.match(main, /개인정보 사용 안내/);
+  assert.match(main, /현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다/);
+  assert.match(main, /데이터 삭제 요청 시 즐겨찾기, 알림 토큰, 신고자 연결 정보를 지웁니다/);
   assert.match(widgetTest, /알림 설정 화면은 현재 설정을 불러오고 바꾼 값을 저장한다/);
   assert.match(widgetTest, /bySemanticsLabel/);
   assert.match(widgetTest, /greaterThanOrEqualTo\(60\)/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1878,7 +1878,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(widgetTest, /도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다/);
   assert.match(main, /개인정보 사용 안내/);
   assert.match(main, /현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다/);
-  assert.match(main, /데이터 삭제 요청 시 즐겨찾기, 알림 토큰, 신고자 연결 정보를 지웁니다/);
+  assert.match(main, /데이터 삭제 요청 시 즐겨찾기, 이동 조건, 익명 인증, 기기 알림 정보, 신고 내용·사진·위치와 경로 피드백을 삭제하거나 익명화합니다/);
   assert.match(widgetTest, /알림 설정 화면은 현재 설정을 불러오고 바꾼 값을 저장한다/);
   assert.match(widgetTest, /bySemanticsLabel/);
   assert.match(widgetTest, /greaterThanOrEqualTo\(60\)/);


### PR DESCRIPTION
## 관련 이슈

close #302

## 작업 배경

- 도움말 화면은 개인정보처리방침, 고객지원, 데이터 삭제 요청 진입점을 제공하지만 앱이 어떤 데이터를 어떤 목적으로 쓰는지 즉시 확인하기 어렵습니다.
- 삭제 요청 전에 현재 위치, 즐겨찾기, 신고, 알림, 오류 기록의 사용 목적과 삭제 범위를 쉬운 문장으로 안내할 필요가 있습니다.

## 작업 내용

- 도움말 화면 상단에 `개인정보 사용 안내` 섹션을 추가했습니다.
- 현재 위치, 즐겨찾기, 이동 조건, 신고 내용/사진, 알림 설정의 사용 목적을 짧게 안내했습니다.
- 데이터 삭제 요청 시 삭제 대상과 법적/보안상 최소 기록 보관 예외를 안내했습니다.
- 안내 섹션의 스크린리더 label과 높이 기준을 위젯 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다"` RED 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs` RED 확인 후 구현 뒤 통과
  - `dart format apps/mobile/lib/main.dart apps/mobile/test/widget_test.dart` 통과
  - `flutter analyze` 통과
  - `flutter test` 통과
  - `flutter build apk --debug` 통과
  - `flutter build ios --simulator --no-codesign` 통과
  - iOS Simulator `Maum iPhone 17` 설치, 실행, 스크린샷 캡처 통과
  - Android emulator는 연결된 기기가 없어 실행 스모크는 생략
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `SupportAccessScreen`의 안내 문구가 실제 앱 데이터 사용 범위와 맞는지 확인해 주세요.
  - 스크린리더 label이 중복 낭독 없이 핵심 문장을 전달하는지 확인해 주세요.

## 리스크

- 도움말 화면 상단에 정보 영역이 추가되어 기존 링크가 아래로 밀립니다.
- 법적 문서 전문은 아니며, 실제 개인정보처리방침 URL과 삭제 요청 이메일은 기존 링크로 유지됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
