### PR TITLE
[Build] Android 릴리즈 평문 통신 차단 고정

### DIFF
--- a/apps/mobile/android/app/src/debug/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/debug/AndroidManifest.xml
@@ -1,7 +1,12 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <application
+        android:usesCleartextTraffic="true"
+        tools:replace="android:usesCleartextTraffic"/>
 </manifest>

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:allowBackup="false"
-        android:fullBackupContent="false">
+        android:fullBackupContent="false"
+        android:usesCleartextTraffic="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/apps/mobile/android/app/src/profile/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/profile/AndroidManifest.xml
@@ -1,7 +1,12 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <application
+        android:usesCleartextTraffic="true"
+        tools:replace="android:usesCleartextTraffic"/>
 </manifest>

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1672,6 +1672,8 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   const pubspec = read("apps/mobile/pubspec.yaml");
   const analysisOptions = read("apps/mobile/analysis_options.yaml");
   const androidManifest = read("apps/mobile/android/app/src/main/AndroidManifest.xml");
+  const androidDebugManifest = read("apps/mobile/android/app/src/debug/AndroidManifest.xml");
+  const androidProfileManifest = read("apps/mobile/android/app/src/profile/AndroidManifest.xml");
   const androidBuildGradle = read("apps/mobile/android/app/build.gradle.kts");
   const envExample = read(".env.example");
   const iosInfoPlist = read("apps/mobile/ios/Runner/Info.plist");
@@ -1705,6 +1707,13 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(androidManifest, /android:label="쉬운 지하철"/);
   assert.match(androidManifest, /android:allowBackup="false"/);
   assert.match(androidManifest, /android:fullBackupContent="false"/);
+  assert.match(androidManifest, /android:usesCleartextTraffic="false"/);
+  assert.match(androidDebugManifest, /xmlns:tools="http:\/\/schemas\.android\.com\/tools"/);
+  assert.match(androidDebugManifest, /android:usesCleartextTraffic="true"/);
+  assert.match(androidDebugManifest, /tools:replace="android:usesCleartextTraffic"/);
+  assert.match(androidProfileManifest, /xmlns:tools="http:\/\/schemas\.android\.com\/tools"/);
+  assert.match(androidProfileManifest, /android:usesCleartextTraffic="true"/);
+  assert.match(androidProfileManifest, /tools:replace="android:usesCleartextTraffic"/);
   assert.match(androidManifest, /<uses-permission android:name="android\.permission\.INTERNET"\/>/);
   assert.match(androidBuildGradle, /create\("release"\)/);
   assert.doesNotMatch(androidBuildGradle, /signingConfig\s*=\s*signingConfigs\.getByName\("debug"\)/);


### PR DESCRIPTION
## 관련 이슈

close #304

## 작업 배경

- 릴리즈 빌드에서는 평문 HTTP 통신 허용 설정이 남아 있지 않아야 합니다.
- 앱 코드는 릴리즈 API 기본 주소를 HTTPS로 제한하고 있지만 Android 매니페스트 정책은 별도 계약으로 고정되어 있지 않았습니다.
- debug/profile 빌드는 로컬 API 확인과 Flutter 개발 도구 통신을 위해 HTTP가 필요하므로 release 정책과 분리했습니다.

## 작업 내용

- main Android 매니페스트에 `android:usesCleartextTraffic="false"`를 명시했습니다.
- debug/profile Android 매니페스트에는 개발 빌드용 `usesCleartextTraffic="true"` override를 명시했습니다.
- 저장소 계약 테스트가 release 차단과 debug/profile 허용 분리를 검사하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` RED 확인 후 구현 뒤 통과
  - `flutter build apk --debug` 통과
  - `rg -n "usesCleartextTraffic" apps/mobile/build/app/intermediates -g 'AndroidManifest.xml'` 결과 debug merged manifest에 `android:usesCleartextTraffic="true"` 반영 확인
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - main/debug/profile 매니페스트의 cleartext 정책 분리가 의도한 빌드 타입에 맞는지 확인해 주세요.
  - debug 빌드의 로컬 API HTTP 흐름을 유지해야 하므로 debug/profile override는 남겨두는 것이 맞습니다.

## 리스크

- 릴리즈 빌드에서 HTTP API 주소나 평문 리소스 호출은 Android 네트워크 보안 정책에 의해 차단됩니다.
- debug/profile 빌드는 기존 로컬 개발 HTTP 흐름을 유지합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
