### PR TITLE
[Style] 역 검색 결과 출처 표시

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2460,6 +2460,17 @@ class _StationSearchResultTile extends StatelessWidget {
                                 height: 1.25,
                               ),
                             ),
+                            const SizedBox(height: 4),
+                            Text(
+                              '${result.dataQualityLabel} · ${result.dataSourceLabel}',
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: textTheme.bodyMedium?.copyWith(
+                                color: const Color(0xFF405A5D),
+                                fontWeight: FontWeight.w800,
+                                height: 1.25,
+                              ),
+                            ),
                           ],
                         ),
                       ),
@@ -2494,9 +2505,9 @@ String _stationResultSemanticLabel(StationSearchResult result) {
   final stationName = _stationResultDisplayName(result.nameKo);
   final distance = result.distanceLabel;
   if (distance.isEmpty) {
-    return '$stationName, ${result.lineLabel}, ${result.region}, ${result.dataQualityLabel}';
+    return '$stationName, ${result.lineLabel}, ${result.region}, ${result.dataQualityLabel}, ${result.dataSourceLabel}';
   }
-  return '$stationName, $distance, ${result.lineLabel}, ${result.region}, ${result.dataQualityLabel}';
+  return '$stationName, $distance, ${result.lineLabel}, ${result.region}, ${result.dataQualityLabel}, ${result.dataSourceLabel}';
 }
 
 class FavoriteStationListScreen extends StatefulWidget {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1361,17 +1361,20 @@ void main() {
       expect(find.text('수도권 4호선, 경의중앙선'), findsOneWidget);
       expect(find.text('수도권'), findsNothing);
       expect(find.text('기본 정보만 있음'), findsNothing);
+      expect(find.text('기본 정보만 있음 · 출처 확인 필요'), findsOneWidget);
       expect(find.bySemanticsLabel('검색 결과 1개'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
+        find.bySemanticsLabel('상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음, 출처 확인 필요'),
         findsOneWidget,
       );
       expect(
         tester.getSemantics(
-          find.bySemanticsLabel('상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
+          find.bySemanticsLabel(
+            '상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음, 출처 확인 필요',
+          ),
         ),
         isSemantics(
-          label: '상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음',
+          label: '상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음, 출처 확인 필요',
           isButton: true,
           hasTapAction: true,
         ),
@@ -1721,7 +1724,9 @@ void main() {
       expect(find.text('상록수역'), findsOneWidget);
       expect(find.text('230m 거리 · 수도권 2호선'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('상록수역, 230m 거리, 수도권 2호선, 수도권, 기본 정보만 있음'),
+        find.bySemanticsLabel(
+          '상록수역, 230m 거리, 수도권 2호선, 수도권, 기본 정보만 있음, 출처 공식 파일',
+        ),
         findsOneWidget,
       );
 
@@ -2023,6 +2028,11 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
       await tester.pumpAndSettle();
+      expect(find.text('기본 정보만 있음 · 출처 공식 파일'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('상록수역, 수도권 2호선, 수도권, 기본 정보만 있음, 출처 공식 파일'),
+        findsOneWidget,
+      );
       await tester.tap(
         find.byKey(const Key('stationSearchResult-station-sangnoksu')),
       );

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1830,6 +1830,8 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(stationSearch, /Release API base URL must use HTTPS\./);
   assert.match(stationSearch, /baseUri\.host\.isEmpty/);
   assert.match(stationSearch, /Release API base URL must include a host\./);
+  assert.match(stationSearch, /result\.dataQualityLabel\} · \$\{result\.dataSourceLabel/);
+  assert.match(stationSearch, /result\.dataQualityLabel\}, \$\{result\.dataSourceLabel/);
   assert.match(read("apps/mobile/test/station_search_test.dart"), /인증 실패 시 인증을 지우고 한 번 재시도한다/);
   assert.match(read("apps/mobile/test/station_search_test.dart"), /릴리즈 빌드는 API 기본 주소를 반드시 설정해야 한다/);
   assert.match(read("apps/mobile/test/station_search_test.dart"), /릴리즈 빌드는 HTTPS API 주소만 사용한다/);


### PR DESCRIPTION
## 관련 이슈

close #306

## 작업 배경

- 역 상세 화면은 데이터 품질, 출처, 마지막 확인일을 보여주지만 검색 결과 목록에서는 출처를 바로 확인하기 어려웠습니다.
- 사용자가 상세 화면에 들어가기 전에도 검색 결과가 공식 파일, 운영기관 페이지, 사용자 제보 등 어떤 출처를 기반으로 하는지 알 수 있어야 합니다.

## 작업 내용

- 역 검색 결과 카드에 `기본 정보만 있음 · 출처 공식 파일`처럼 데이터 품질과 출처를 함께 표시했습니다.
- 역 검색 결과 스크린리더 label에 출처 라벨을 포함했습니다.
- 출처가 없는 검색 결과는 `출처 확인 필요` fallback을 화면과 semantics에 그대로 노출하도록 테스트했습니다.
- 저장소 계약 테스트가 검색 결과 카드의 출처 표시와 semantics 포함을 고정하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다"` RED 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs` RED 확인 후 구현 뒤 통과
  - `dart format apps/mobile/lib/station_search.dart apps/mobile/test/widget_test.dart` 통과
  - `flutter analyze` 통과
  - `flutter test` 통과
  - `flutter build apk --debug` 통과
  - `flutter build ios --simulator --no-codesign` 통과
  - iOS Simulator `Maum iPhone 17` 설치, 실행, 스크린샷 캡처 통과
  - Android emulator는 연결된 기기가 없어 실행 스모크는 생략
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 검색 결과 카드의 세 번째 줄이 작은 화면에서도 역명/노선 정보를 밀어내지 않는지 확인해 주세요.
  - 출처가 비어 있는 경우 `출처 확인 필요`가 의도한 fallback으로 보이는지 확인해 주세요.

## 리스크

- 검색 결과 카드 높이가 데이터 품질/출처 한 줄만큼 커집니다.
- 데이터 출처가 비어 있는 백엔드 응답은 사용자에게 `출처 확인 필요`로 노출됩니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. Rate limit으로 리뷰가 시작되지 않아 fallback을 실행했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
