### PR TITLE
[Style] 도움말 안전 고지 보강

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1138,6 +1138,8 @@ class SupportAccessScreen extends StatelessWidget {
           children: [
             const _PrivacyDataUseSummary(),
             const SizedBox(height: 12),
+            const _SafetyDataNotice(),
+            const SizedBox(height: 12),
             _SupportAccessItem(
               key: const Key('privacyPolicyAccessItem'),
               icon: Icons.privacy_tip_outlined,
@@ -1166,6 +1168,99 @@ class SupportAccessScreen extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _SafetyDataNotice extends StatelessWidget {
+  const _SafetyDataNotice();
+
+  static const _title = '안전과 데이터 안내';
+  static const _referenceNotice = '경로와 시설 정보는 이동을 돕는 참고 정보입니다.';
+  static const _fieldNotice = '실제 이동 전에는 현장 안내, 역무원 안내, 운영기관 공지를 먼저 확인해 주세요.';
+  static const _limitationNotice = '실시간 상태나 무조건 안전한 경로를 보장하지 않습니다.';
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Semantics(
+      key: const Key('safetyDataNotice'),
+      container: true,
+      label: '$_title, $_referenceNotice $_fieldNotice $_limitationNotice',
+      child: ExcludeSemantics(
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: const Color(0xFFFFF7E8),
+            border: Border.all(color: const Color(0xFFE3C37D)),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Icon(
+                      Icons.info_outline,
+                      color: Color(0xFF6B4D00),
+                      size: 24,
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        _title,
+                        style: textTheme.titleMedium?.copyWith(
+                          color: const Color(0xFF2C2200),
+                          fontWeight: FontWeight.w800,
+                          height: 1.25,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                const _SafetyDataNoticeLine(text: _referenceNotice),
+                const _SafetyDataNoticeLine(text: _fieldNotice),
+                const _SafetyDataNoticeLine(text: _limitationNotice),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SafetyDataNoticeLine extends StatelessWidget {
+  const _SafetyDataNoticeLine({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Padding(
+            padding: EdgeInsets.only(top: 7),
+            child: Icon(Icons.circle, size: 7, color: Color(0xFF8A6400)),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              text,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: const Color(0xFF3A2A00),
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -657,6 +657,12 @@ void main() {
       expect(find.text('https://easysubway.example/privacy'), findsOneWidget);
       expect(find.text('고객지원'), findsOneWidget);
       expect(find.text('support@easysubway.example'), findsOneWidget);
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('dataDeletionAccessItem')),
+        120,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.pumpAndSettle();
       expect(find.text('데이터 삭제 요청'), findsOneWidget);
       expect(find.text('privacy@easysubway.example'), findsOneWidget);
 
@@ -738,6 +744,53 @@ void main() {
     }
   });
 
+  testWidgets('도움말은 안전 고지와 데이터 한계를 쉬운 문구로 안내한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
+          supportAccessInfo: const SupportAccessInfo(
+            privacyPolicyUrl: 'https://easysubway.example/privacy',
+            supportEmail: 'support@easysubway.example',
+            dataDeletionEmail: 'privacy@easysubway.example',
+          ),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('homeHelpActionButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('안전과 데이터 안내'), findsOneWidget);
+      expect(find.text('경로와 시설 정보는 이동을 돕는 참고 정보입니다.'), findsOneWidget);
+      expect(
+        find.text('실제 이동 전에는 현장 안내, 역무원 안내, 운영기관 공지를 먼저 확인해 주세요.'),
+        findsOneWidget,
+      );
+      expect(find.text('실시간 상태나 무조건 안전한 경로를 보장하지 않습니다.'), findsOneWidget);
+
+      final noticeSize = tester.getSize(
+        find.byKey(const Key('safetyDataNotice')),
+      );
+      expect(noticeSize.height, greaterThanOrEqualTo(120));
+
+      final noticeSemantics = tester
+          .getSemantics(find.byKey(const Key('safetyDataNotice')))
+          .getSemanticsData();
+      expect(
+        noticeSemantics.label,
+        '안전과 데이터 안내, 경로와 시설 정보는 이동을 돕는 참고 정보입니다. 실제 이동 전에는 현장 안내, 역무원 안내, 운영기관 공지를 먼저 확인해 주세요. 실시간 상태나 무조건 안전한 경로를 보장하지 않습니다.',
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('도움말은 개인정보 링크를 값 복사 화면이 아니라 외부 연결로 처리한다', (tester) async {
     final launcher = RecordingSupportAccessLauncher();
 
@@ -792,7 +845,19 @@ void main() {
 
     await tester.tap(find.byKey(const Key('homeHelpActionButton')));
     await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('supportAccessItem')),
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('supportAccessItem')));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('dataDeletionAccessItem')),
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
     await tester.pumpAndSettle();
@@ -827,10 +892,42 @@ void main() {
     await tester.tap(find.byKey(const Key('homeHelpActionButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('준비 중입니다.'), findsNWidgets(3));
+    expect(
+      tester
+          .getSemantics(find.byKey(const Key('privacyPolicyAccessItem')))
+          .getSemanticsData()
+          .label,
+      '개인정보처리방침, 준비 중입니다.',
+    );
 
     await tester.tap(find.byKey(const Key('privacyPolicyAccessItem')));
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('supportAccessItem')),
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.pumpAndSettle();
+    expect(
+      tester
+          .getSemantics(find.byKey(const Key('supportAccessItem')))
+          .getSemanticsData()
+          .label,
+      '고객지원, 준비 중입니다.',
+    );
     await tester.tap(find.byKey(const Key('supportAccessItem')));
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('dataDeletionAccessItem')),
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.pumpAndSettle();
+    expect(
+      tester
+          .getSemantics(find.byKey(const Key('dataDeletionAccessItem')))
+          .getSemanticsData()
+          .label,
+      '데이터 삭제 요청, 준비 중입니다.',
+    );
     await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
     await tester.pumpAndSettle();
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1887,8 +1887,13 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(widgetTest, /홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다/);
   assert.match(widgetTest, /홈 즐겨찾기는 하나의 진입점에서 탭 목록을 바로 보여준다/);
   assert.match(widgetTest, /도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다/);
+  assert.match(widgetTest, /도움말은 안전 고지와 데이터 한계를 쉬운 문구로 안내한다/);
   assert.match(main, /개인정보 사용 안내/);
+  assert.match(main, /안전과 데이터 안내/);
   assert.match(main, /현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다/);
+  assert.match(main, /경로와 시설 정보는 이동을 돕는 참고 정보입니다/);
+  assert.match(main, /현장 안내, 역무원 안내, 운영기관 공지를 먼저 확인해 주세요/);
+  assert.match(main, /실시간 상태나 무조건 안전한 경로를 보장하지 않습니다/);
   assert.match(main, /데이터 삭제 요청 시 즐겨찾기, 이동 조건, 익명 인증, 기기 알림 정보, 신고 내용·사진·위치와 경로 피드백을 삭제하거나 익명화합니다/);
   assert.match(widgetTest, /알림 설정 화면은 현재 설정을 불러오고 바꾼 값을 저장한다/);
   assert.match(widgetTest, /bySemanticsLabel/);


### PR DESCRIPTION
## 관련 이슈

close #308

## 작업 배경

- 역 상세와 경로 결과에는 안전 안내가 있지만, 도움말 화면에서는 개인정보 안내가 중심이라 앱 기능을 쓰기 전 데이터 한계를 확인하기 어려웠습니다.
- 출시 전 안전 고지 기준에 맞춰 경로와 시설 정보가 참고 정보이며 현장 안내와 운영기관 공지가 우선이라는 점을 도움말에서도 명확히 보여야 합니다.

## 작업 내용

- 도움말 화면에 `안전과 데이터 안내` 카드를 추가했습니다.
- 안내 문구에 참고 정보, 현장 안내 우선, 실시간 상태나 무조건 안전한 경로를 보장하지 않는다는 내용을 포함했습니다.
- 스크린리더 label에서 안전 고지 핵심 문구를 한 번에 읽을 수 있게 했습니다.
- 도움말 항목이 아래로 밀린 기존 테스트는 스크롤 후 검증하도록 조정했습니다.
- repository contract가 도움말 안전 고지 문구와 테스트 이름을 고정하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "도움말은 안전 고지와 데이터 한계를 쉬운 문구로 안내한다"` RED 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs` RED 확인 후 구현 뒤 통과
  - `dart format lib/main.dart test/widget_test.dart` 통과
  - `flutter test test/widget_test.dart --name "도움말"` 통과
  - `flutter test` 통과
  - `flutter analyze` 통과
  - `flutter build apk --debug` 통과
  - `flutter build ios --simulator --no-codesign` 통과
  - iOS Simulator `Maum iPhone 17` 설치, 실행, 스크린샷 캡처 통과
  - Android emulator는 연결된 기기가 없어 실행 스모크는 생략
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 도움말 화면에서 안전 안내 카드가 개인정보 안내와 고객지원 링크 사이에 자연스럽게 배치되는지 확인해 주세요.
  - 큰 글씨 사용 시 고객지원/삭제 요청 항목은 스크롤로 접근하는 흐름입니다.

## 리스크

- 도움말 화면 콘텐츠가 길어져 고객지원과 데이터 삭제 요청 항목은 초기 화면 아래로 내려갑니다.
- 문구 변경은 안내성 UI에 한정되며 API 동작이나 저장 데이터는 바꾸지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. Rate limit으로 리뷰가 시작되지 않아 fallback을 실행했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. main CD run 27671705614 성공.
