### PR TITLE
[Style] 역 검색 실패 다음 행동 안내

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2335,26 +2335,30 @@ class _StationSearchFailureMessage extends StatelessWidget {
   Widget build(BuildContext context) {
     final shouldShowLocationSettings =
         message == _currentLocationDisabledMessage;
+    final shouldShowStationSearchFallback =
+        _shouldShowStationSearchFailureNextAction(message);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _StationSearchMessage(message: message, liveRegion: true),
-        const SizedBox(height: 8),
-        Semantics(
-          key: const Key('stationSearchFailureNextAction'),
-          container: true,
-          excludeSemantics: true,
-          label: '다음 행동, $_stationSearchFailureNextAction',
-          child: Text(
-            _stationSearchFailureNextAction,
-            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: const Color(0xFF506B6F),
-              fontWeight: FontWeight.w700,
-              height: 1.35,
+        if (shouldShowStationSearchFallback) ...[
+          const SizedBox(height: 8),
+          Semantics(
+            key: const Key('stationSearchFailureNextAction'),
+            container: true,
+            excludeSemantics: true,
+            label: '다음 행동, $_stationSearchFailureNextAction',
+            child: Text(
+              _stationSearchFailureNextAction,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: const Color(0xFF506B6F),
+                fontWeight: FontWeight.w700,
+                height: 1.35,
+              ),
             ),
           ),
-        ),
+        ],
         if (shouldShowLocationSettings) ...[
           const SizedBox(height: 12),
           OutlinedButton.icon(
@@ -2375,6 +2379,13 @@ class _StationSearchFailureMessage extends StatelessWidget {
       ],
     );
   }
+}
+
+bool _shouldShowStationSearchFailureNextAction(String message) {
+  return message == '위치 권한을 확인해 주세요.' ||
+      message == _currentLocationDisabledMessage ||
+      message == '현재 위치를 확인하지 못했습니다.' ||
+      message == '주변 역을 찾지 못했습니다.';
 }
 
 class _StationSearchMessage extends StatelessWidget {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -18,6 +18,7 @@ const _locationPermissionRationalePurpose =
     '가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다.';
 const _locationPermissionRationaleFallback =
     '위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다.';
+const _stationSearchFailureNextAction = '역명으로 검색하면 위치 권한 없이도 계속 이용할 수 있습니다.';
 const _stationSafetyGuidanceNotice = '이동 전 현장 안내와 역무원 안내를 확인해 주세요.';
 const _favoriteStationTimeout = Duration(seconds: 8);
 const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했습니다.';
@@ -2339,6 +2340,21 @@ class _StationSearchFailureMessage extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _StationSearchMessage(message: message, liveRegion: true),
+        const SizedBox(height: 8),
+        Semantics(
+          key: const Key('stationSearchFailureNextAction'),
+          container: true,
+          excludeSemantics: true,
+          label: '다음 행동, $_stationSearchFailureNextAction',
+          child: Text(
+            _stationSearchFailureNextAction,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: const Color(0xFF506B6F),
+              fontWeight: FontWeight.w700,
+              height: 1.35,
+            ),
+          ),
+        ),
         if (shouldShowLocationSettings) ...[
           const SizedBox(height: 12),
           OutlinedButton.icon(
@@ -2370,6 +2386,7 @@ class _StationSearchMessage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Semantics(
+      container: true,
       liveRegion: liveRegion,
       child: Text(
         message,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2007,6 +2007,11 @@ void main() {
       expect(repository.requestedNearbyLocations, isEmpty);
       expect(find.text('위치 권한을 확인해 주세요.'), findsOneWidget);
       expect(find.bySemanticsLabel('위치 권한을 확인해 주세요.'), findsOneWidget);
+      expect(find.text('역명으로 검색하면 위치 권한 없이도 계속 이용할 수 있습니다.'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('다음 행동, 역명으로 검색하면 위치 권한 없이도 계속 이용할 수 있습니다.'),
+        findsOneWidget,
+      );
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2021,6 +2021,35 @@ void main() {
     }
   });
 
+  testWidgets('역명 검색 빈 결과에는 위치 권한 대안 안내를 보여주지 않는다', (tester) async {
+    final repository = FakeStationSearchRepository();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '없는역');
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(repository.requestedQueries, ['없는역']);
+    expect(find.text('검색 결과가 없습니다.'), findsOneWidget);
+    expect(find.text('역명으로 검색하면 위치 권한 없이도 계속 이용할 수 있습니다.'), findsNothing);
+    expect(
+      find.bySemanticsLabel('다음 행동, 역명으로 검색하면 위치 권한 없이도 계속 이용할 수 있습니다.'),
+      findsNothing,
+    );
+  });
+
   testWidgets('역 검색은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다', (tester) async {
     final locationProvider = FakeCurrentLocationProvider(
       error: const CurrentLocationException(

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1738,6 +1738,9 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(main, /NotificationSettingsApiRepository/);
   assert.match(main, /OnboardingScreen/);
   assert.match(main, /initialOnboardingState/);
+  assert.match(stationSearch, /stationSearchFailureNextAction/);
+  assert.match(stationSearch, /역명으로 검색하면 위치 권한 없이도 계속 이용할 수 있습니다\./);
+  assert.match(widgetTest, /역명으로 검색하면 위치 권한 없이도 계속 이용할 수 있습니다\./);
   assert.match(main, /initialMobilityType: onboardingResult\?\.profile\.mobilityType/);
   assert.match(main, /initialMobilityType: initialMobilityType/);
   assert.match(main, /_OnboardingPreferenceScope/);


### PR DESCRIPTION
## 관련 이슈

close #310

## 작업 배경

- 출시 품질 기준에서는 오류 화면이 고령자와 스크린리더 사용자가 다음 행동을 바로 알 수 있게 안내해야 합니다.
- 역 검색에서 위치 확인이 실패하면 오류 문구는 보이지만, 위치 권한 없이도 역명 검색을 계속 사용할 수 있다는 대안이 충분히 드러나지 않았습니다.

## 작업 내용

- 위치 권한 실패와 주변 역 찾기 실패 영역에 `역명으로 검색하면 위치 권한 없이도 계속 이용할 수 있습니다.` 안내를 추가했습니다.
- 다음 행동 안내를 별도 semantics label로 제공해 스크린리더에서 실패 메시지와 대안 안내를 구분해 읽을 수 있게 했습니다.
- 역명 검색 빈 결과와 API 실패에는 위치 권한 대안 안내가 나오지 않도록 표시 범위를 제한했습니다.
- 기존 GPS 꺼짐 상태의 `위치 설정 열기` 버튼과 동작은 유지했습니다.
- repository contract가 역 검색 실패 다음 행동 안내 문구와 테스트 고정을 확인하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "역 검색은 현재 위치를 확인하지 못하면 짧은 안내를 보여준다"` RED 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs` RED 확인 후 구현 뒤 통과
  - `flutter test test/widget_test.dart --name "역명 검색 빈 결과에는 위치 권한 대안 안내를 보여주지 않는다"` RED 확인 후 구현 뒤 통과
  - `flutter test test/widget_test.dart --name "역 검색은 현재 위치를 확인하지 못하면 짧은 안내를 보여준다"` 리뷰 수정 후 통과
  - `dart format lib/station_search.dart test/widget_test.dart` 통과
  - `flutter test test/widget_test.dart --name "역 검색은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다"` 통과
  - `flutter test test/widget_test.dart --name "역 검색"` 통과
  - `flutter analyze` 통과
  - `flutter test` 통과
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - `flutter build apk --debug` 통과
  - `flutter build ios --simulator --no-codesign` 통과
  - Android emulator는 연결된 기기가 없어 실행 스모크는 생략
  - PR CI 확인: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 통과
  - CodeRabbit 확인: PR review rate limit으로 실제 리뷰 시작 불가
  - Codex CLI review 확인: 1건 지적 반영 후 재실행 결과 추가 지적 없음
  - main CD 확인: merge commit `7540b91` 기준 CD 성공
  - main CI 확인: merge commit `7540b91` 기준 CI 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 위치 권한 실패 후 안내 문구가 기존 오류 문구와 중복되거나 과도하게 길어 보이지 않는지 확인해 주세요.
  - 역명 검색 빈 결과에는 위치 권한 대안 안내가 표시되지 않는지 확인해 주세요.
  - GPS 꺼짐 상태에서 위치 설정 버튼이 기존처럼 유지되는지 확인해 주세요.

## 리스크

- 화면 문구가 한 줄 늘어나지만 역 검색 결과 목록이나 상세 화면 동작은 바꾸지 않습니다.
- API 요청, 인증, 저장 데이터 계약 변경은 없습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
