### PR TITLE
[Style] 경로 검색 실패 다음 행동 안내

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1657,6 +1657,7 @@ class _RouteSearchFailureMessage extends StatelessWidget {
             key: const Key('routeSearchFailureNextAction'),
             container: true,
             excludeSemantics: true,
+            liveRegion: true,
             label: '다음 행동, $_routeSearchFailureNextAction',
             child: Text(
               _routeSearchFailureNextAction,

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -15,6 +15,7 @@ const _routeFeedbackErrorMessage = '의견을 보내지 못했습니다.';
 const _favoriteRouteErrorMessage = '즐겨찾기 경로를 처리하지 못했습니다.';
 const _favoriteRouteLoadErrorMessage = '즐겨찾기 경로를 불러오지 못했습니다.';
 const _routeSafetyGuidanceNotice = '이동 전 현장 안내와 역무원 안내를 확인해 주세요.';
+const _routeSearchFailureNextAction = '역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.';
 
 String _mobilityLabelFor(String mobilityType) {
   for (final option in mobilityProfileOptions) {
@@ -1623,9 +1624,8 @@ class _RouteSearchBody extends StatelessWidget {
           ),
         ),
       ),
-      RouteSearchViewStatus.failure => _RouteSearchMessage(
+      RouteSearchViewStatus.failure => _RouteSearchFailureMessage(
         message: state.message,
-        liveRegion: true,
       ),
       RouteSearchViewStatus.success => _RouteSearchResultCard(
         result: state.result!,
@@ -1634,6 +1634,48 @@ class _RouteSearchBody extends StatelessWidget {
       ),
     };
   }
+}
+
+class _RouteSearchFailureMessage extends StatelessWidget {
+  const _RouteSearchFailureMessage({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final shouldShowNextAction = _shouldShowRouteSearchFailureNextAction(
+      message,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _RouteSearchMessage(message: message, liveRegion: true),
+        if (shouldShowNextAction) ...[
+          const SizedBox(height: 8),
+          Semantics(
+            key: const Key('routeSearchFailureNextAction'),
+            container: true,
+            excludeSemantics: true,
+            label: '다음 행동, $_routeSearchFailureNextAction',
+            child: Text(
+              _routeSearchFailureNextAction,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: const Color(0xFF506B6F),
+                fontWeight: FontWeight.w700,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+bool _shouldShowRouteSearchFailureNextAction(String message) {
+  return message != '출발역과 도착역을 입력해 주세요.' &&
+      message != '출발역과 도착역을 검색 결과에서 선택해 주세요.';
 }
 
 class _RouteSearchMessage extends StatelessWidget {
@@ -1645,6 +1687,7 @@ class _RouteSearchMessage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Semantics(
+      container: true,
       liveRegion: liveRegion,
       child: Text(
         message,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3262,6 +3262,77 @@ void main() {
 
     expect(routeRepository.requests, isEmpty);
     expect(find.text('출발역과 도착역을 검색 결과에서 선택해 주세요.'), findsOneWidget);
+    expect(find.text('역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'), findsNothing);
+  });
+
+  testWidgets('경로 검색 실패는 다음 행동을 쉬운 문구로 안내한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '사당': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
+    final routeRepository = FakeRouteSearchRepository(
+      error: const RouteSearchException('경로 정보를 불러오지 못했습니다.'),
+    );
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: stationRepository,
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: routeRepository,
+          favoriteRepository: FakeFavoriteStationRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('routeSearchButton')));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('routeOriginStationInput')),
+        '상록수',
+      );
+      await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('routeDestinationStationInput')),
+        '사당',
+      );
+      await tester.tap(
+        find.byKey(const Key('routeDestinationStationSearchButton')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('routeDestinationStationOption-station-sadang')),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.drag(find.byType(ListView), const Offset(0, -360));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+      await tester.pumpAndSettle();
+
+      expect(routeRepository.requests, hasLength(1));
+      expect(find.text('경로 정보를 불러오지 못했습니다.'), findsOneWidget);
+      expect(
+        find.text('역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel('다음 행동, 역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'),
+        findsOneWidget,
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
   });
 
   testWidgets('경로 검색은 역 선택이 바뀌면 이전 결과를 숨긴다', (tester) async {
@@ -3415,6 +3486,7 @@ void main() {
       expect(find.text('엘리베이터 동선을 우선했어요'), findsNothing);
       expect(find.text('휠체어로 이동 가능한 엘리베이터가 없습니다.'), findsOneWidget);
       expect(find.text('이동 전 현장 안내와 역무원 안내를 확인해 주세요.'), findsOneWidget);
+      expect(find.text('역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'), findsNothing);
       expect(
         find.bySemanticsLabel(
           '경로 검색 결과, 다른 경로가 필요합니다, 휠체어, 상록수에서 없는역까지, 노선 확인 필요, 이동 점수 0점, '
@@ -5015,15 +5087,20 @@ class ControlledStationSearchRepository implements StationSearchRepository {
 }
 
 class FakeRouteSearchRepository implements RouteSearchRepository {
-  FakeRouteSearchRepository({RouteSearchResult? result})
+  FakeRouteSearchRepository({RouteSearchResult? result, this.error})
     : result = result ?? _sampleRouteSearchResult();
 
   final RouteSearchResult result;
+  final Object? error;
   final requests = <RouteSearchRequest>[];
 
   @override
   Future<RouteSearchResult> searchRoute(RouteSearchRequest request) async {
     requests.add(request);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
     return result;
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3330,6 +3330,15 @@ void main() {
         find.bySemanticsLabel('다음 행동, 역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'),
         findsOneWidget,
       );
+      expect(
+        tester.getSemantics(
+          find.byKey(const Key('routeSearchFailureNextAction')),
+        ),
+        isSemantics(
+          label: '다음 행동, 역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.',
+          isLiveRegion: true,
+        ),
+      );
     } finally {
       semanticsHandle.dispose();
     }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1891,6 +1891,9 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(widgetTest, /홈 즐겨찾기는 하나의 진입점에서 탭 목록을 바로 보여준다/);
   assert.match(widgetTest, /도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다/);
   assert.match(widgetTest, /도움말은 안전 고지와 데이터 한계를 쉬운 문구로 안내한다/);
+  assert.match(routeSearch, /routeSearchFailureNextAction/);
+  assert.match(routeSearch, /역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요\./);
+  assert.match(widgetTest, /경로 검색 실패는 다음 행동을 쉬운 문구로 안내한다/);
   assert.match(main, /개인정보 사용 안내/);
   assert.match(main, /안전과 데이터 안내/);
   assert.match(main, /현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다/);


### PR DESCRIPTION
## 관련 이슈

close #312

## 작업 배경

- 경로 검색 실패 화면은 오류 문구만 보여 주어 사용자가 다음에 어떤 행동을 해야 하는지 판단하기 어려웠습니다.
- 고령자와 스크린리더 사용자는 실패 상태에서도 역 선택을 다시 확인할지, 이동 조건을 바꿔 다시 시도할지 짧게 안내받아야 합니다.

## 작업 내용

- 경로 검색 실패 메시지 아래에 `역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.` 안내를 추가했습니다.
- 다음 행동 안내를 별도 semantics label로 제공해 실패 문구와 대안 안내를 구분해 읽을 수 있게 했습니다.
- 입력만 하고 역을 선택하지 않은 검증 실패와 안내 불가 경로 결과 카드에는 새 실패 안내가 표시되지 않도록 범위를 제한했습니다.
- repository contract가 경로 검색 실패 다음 행동 안내 문구와 테스트 고정을 확인하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "경로 검색 실패는 다음 행동을 쉬운 문구로 안내한다"` RED 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs` RED 확인 후 구현 뒤 통과
  - `dart format lib/route_search.dart test/widget_test.dart` 통과
  - `flutter test test/widget_test.dart --name "경로 검색은 입력만 하고 선택하지 않은 역을 쉬운 문구로 안내한다"` 통과
  - `flutter test test/widget_test.dart --name "경로 검색 중에는 버튼을 비활성화하고 안내 불가 이유를 보여준다"` 통과
  - `flutter test test/widget_test.dart --name "경로 검색"` 통과
  - `flutter analyze` 통과
  - `flutter test` 통과
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md docs/agent/route-search-failure-next-actions.md .codex/current-task.local .codex/issue-route-search-failure-next-actions.local.md swieun-jihacheol-project-plan.md` 통과
  - `flutter build apk --debug` 통과
  - `flutter build ios --simulator --no-codesign` 통과
  - Android emulator는 연결된 기기가 없어 실행 스모크는 생략
  - GitHub Actions PR CI 통과: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI
  - merge 후 main CI 통과: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI
  - merge 후 main CD 통과
  - CodeRabbit은 review limit으로 시작되지 않아 Codex CLI review로 대체 확인
  - Codex CLI review 1차 지적 1건 수정, 재검토 결과 actionable issue 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - API 실패 상태에서만 다음 행동 안내가 추가되고, 역 선택 검증 실패에는 기존 안내만 유지됩니다.
  - 안내 불가 경로 결과 카드는 기존 안내 불가 이유와 안전 고지 흐름을 유지합니다.
  - Codex CLI inline 지적은 `liveRegion: true` 보강과 widget semantics assertion 추가로 해결했습니다.

## 리스크

- 화면 문구가 한 줄 늘어나지만 경로 검색 API 요청, 결과 카드, 즐겨찾기, 피드백 동작은 바꾸지 않습니다.
- 데이터 저장 구조와 백엔드 계약 변경은 없습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
