### PR TITLE
[Style] 시설 신고 실패 다음 행동 안내

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -13,6 +13,7 @@ const _facilityReportTimeout = Duration(seconds: 8);
 const _facilityReportErrorMessage = '신고를 보내지 못했습니다.';
 const _facilityReportStatusErrorMessage = '처리 상태를 확인하지 못했습니다.';
 const _facilityReportListErrorMessage = '신고 내역을 불러오지 못했습니다.';
+const _facilityReportFailureNextAction = '내용을 확인한 뒤 네트워크 상태를 보고 다시 보내 주세요.';
 const _anonymousReportUserId = 'anonymous-mobile-user';
 const _facilityReportPhotoTooLargeMessage = '사진이 너무 큽니다. 다른 사진을 선택해 주세요.';
 const _facilityReportLocationDisabledMessage =
@@ -2031,30 +2032,62 @@ class _FacilityReportMessage extends StatelessWidget {
     final isFailure = state.status == FacilityReportViewStatus.failure;
     final color = isFailure ? const Color(0xFF8A4B00) : const Color(0xFF006D77);
     final icon = isFailure ? Icons.error_outline : Icons.check_circle_outline;
+    final shouldShowNextAction = _shouldShowFacilityReportFailureNextAction(
+      state,
+    );
 
-    return Semantics(
-      label: state.message,
-      liveRegion: true,
-      child: ExcludeSemantics(
-        child: Row(
-          children: [
-            Icon(icon, color: color, size: 26),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                state.message,
-                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: const Color(0xFF102A2C),
-                  fontWeight: FontWeight.w800,
-                  height: 1.3,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Semantics(
+          container: true,
+          label: state.message,
+          liveRegion: true,
+          child: ExcludeSemantics(
+            child: Row(
+              children: [
+                Icon(icon, color: color, size: 26),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    state.message,
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: const Color(0xFF102A2C),
+                      fontWeight: FontWeight.w800,
+                      height: 1.3,
+                    ),
+                  ),
                 ),
+              ],
+            ),
+          ),
+        ),
+        if (shouldShowNextAction) ...[
+          const SizedBox(height: 8),
+          Semantics(
+            key: const Key('facilityReportFailureNextAction'),
+            container: true,
+            excludeSemantics: true,
+            liveRegion: true,
+            label: '다음 행동, $_facilityReportFailureNextAction',
+            child: Text(
+              _facilityReportFailureNextAction,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: const Color(0xFF506B6F),
+                fontWeight: FontWeight.w700,
+                height: 1.35,
               ),
             ),
-          ],
-        ),
-      ),
+          ),
+        ],
+      ],
     );
   }
+}
+
+bool _shouldShowFacilityReportFailureNextAction(FacilityReportState state) {
+  return state.status == FacilityReportViewStatus.failure &&
+      state.result == null;
 }
 
 class _FacilityReportLocationMessage extends StatelessWidget {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3659,6 +3659,66 @@ void main() {
     }
   });
 
+  testWidgets('시설 신고 실패는 다음 행동을 쉬운 문구로 안내한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final reportRepository = FakeFacilityReportRepository()
+      ..error = const FacilityReportException('신고를 보내지 못했습니다.');
+
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FacilityReportScreen(
+            repository: reportRepository,
+            target: const FacilityReportTarget(
+              stationId: 'station-sangnoksu',
+              stationName: '상록수',
+              facilityId: 'facility-sangnoksu-elevator-1',
+              facilityName: '1번 출구 엘리베이터',
+              facilityTypeLabel: '엘리베이터',
+              facilityStatusLabel: '정상',
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(
+        find.byKey(const Key('facilityReportDescriptionInput')),
+        '출입문이 막혀 있습니다.',
+      );
+      await tester.dragUntilVisible(
+        find.byKey(const Key('facilityReportSubmitButton')),
+        find.byType(Scrollable).first,
+        const Offset(0, -300),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('facilityReportSubmitButton')));
+      await tester.pumpAndSettle();
+
+      expect(reportRepository.requests, hasLength(1));
+      expect(find.text('신고를 보내지 못했습니다.'), findsOneWidget);
+      expect(find.text('내용을 확인한 뒤 네트워크 상태를 보고 다시 보내 주세요.'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('다음 행동, 내용을 확인한 뒤 네트워크 상태를 보고 다시 보내 주세요.'),
+        findsOneWidget,
+      );
+      expect(
+        tester.getSemantics(
+          find.byKey(const Key('facilityReportFailureNextAction')),
+        ),
+        isSemantics(
+          label: '다음 행동, 내용을 확인한 뒤 네트워크 상태를 보고 다시 보내 주세요.',
+          isLiveRegion: true,
+        ),
+      );
+      expect(
+        find.byKey(const Key('facilityReportRefreshButton')),
+        findsNothing,
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('시설 신고 화면은 사진 선택 전에 짧은 개인정보 안내를 보여준다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
     var pickerCallCount = 0;

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1860,9 +1860,12 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(facilityReport, /처리 상태 확인 중/);
   assert.match(facilityReport, /접수번호/);
   assert.match(facilityReport, /facilityReportRefreshButton/);
+  assert.match(facilityReport, /facilityReportFailureNextAction/);
+  assert.match(facilityReport, /내용을 확인한 뒤 네트워크 상태를 보고 다시 보내 주세요\./);
   assert.match(facilityReportTest, /접수번호로 처리 상태를 조회한다/);
   assert.match(facilityReportTest, /접수 후 처리 상태를 다시 확인한다/);
   assert.match(widgetTest, /신고 접수번호 report-1, 현재 상태 반영됨/);
+  assert.match(widgetTest, /시설 신고 실패는 다음 행동을 쉬운 문구로 안내한다/);
   assert.match(notificationSettings, /class NotificationSettingsApiRepository/);
   assert.match(notificationSettings, /\/api\/v1\/me\/notification-settings/);
   assert.match(notificationSettings, /AuthorizationHeaderProvider/);


### PR DESCRIPTION
## 관련 이슈

close #314

## 작업 배경

- 시설 신고 제출 실패 화면은 오류 문구만 보여 주어 사용자가 내용을 유지한 채 다시 보낼 수 있는지 판단하기 어려웠습니다.
- 현장에서 신고하는 사용자는 네트워크 상태를 확인하고 다시 제출하는 다음 행동을 짧고 명확하게 안내받아야 합니다.

## 작업 내용

- 시설 신고 제출 실패 상태에 `내용을 확인한 뒤 네트워크 상태를 보고 다시 보내 주세요.` 안내를 추가했습니다.
- 다음 행동 안내를 별도 live region semantics로 제공해 스크린리더가 실패 직후 대안 행동까지 읽을 수 있게 했습니다.
- 접수 후 처리 상태 확인 실패처럼 기존 접수 결과가 남아 있는 실패 상태에는 새 제출 실패 안내가 표시되지 않도록 범위를 제한했습니다.
- repository contract가 신고 실패 다음 행동 안내 문구와 widget test 고정을 확인하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "시설 신고 실패는 다음 행동을 쉬운 문구로 안내한다"` RED 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs` RED 확인 후 구현 뒤 통과
  - `dart format lib/facility_report.dart test/widget_test.dart` 통과
  - `flutter test test/widget_test.dart --name "시설 신고 화면은 신고 유형과 내용을 보내고 접수 결과를 보여준다"` 통과
  - `flutter test test/widget_test.dart --name "시설 신고 화면"` 통과
  - `flutter analyze` 통과
  - `flutter test` 통과
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md docs/agent/facility-report-failure-next-actions.md .codex/current-task.local swieun-jihacheol-project-plan.md` 통과
  - `flutter build apk --debug` 통과
  - `flutter build ios --simulator --no-codesign` 통과
  - Android emulator는 연결된 기기가 없어 실행 스모크는 생략
  - GitHub Actions PR CI 통과: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI
  - merge 후 main CI 통과: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI
  - merge 후 main CD 통과
  - CodeRabbit 리뷰가 시작되지 않아 Codex CLI review로 대체 확인
  - Codex CLI review 결과 actionable issue 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 제출 실패 상태에서만 다음 행동 안내가 표시되고, 처리 상태 확인 실패에는 기존 접수 결과와 재확인 버튼 흐름이 유지됩니다.
  - semantics는 실패 문구와 다음 행동을 별도 live region으로 나눠 읽습니다.

## 리스크

- 화면 문구가 한 줄 늘어나지만 신고 API 요청, 사진 첨부, 위치 첨부, 접수 결과 카드 동작은 바꾸지 않습니다.
- 백엔드 계약과 데이터 저장 구조 변경은 없습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
