### PR TITLE
[Style] 알림 등록 실패 다음 행동 안내

### DIFF
--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -13,6 +13,8 @@ const _notificationSettingsLoadErrorMessage = '알림 설정을 불러오지 못
 const _notificationSettingsSaveErrorMessage = '알림 설정을 저장하지 못했습니다.';
 const _deviceRegistrationErrorMessage = '기기 알림 등록을 마치지 못했습니다.';
 const _notificationPermissionErrorMessage = '알림 권한을 확인하지 못했습니다.';
+const _notificationRegistrationFailureNextAction =
+    '기기 알림 설정과 네트워크 상태를 확인한 뒤 다시 시도해 주세요.';
 
 abstract class NotificationSettingsRepository {
   Future<NotificationSettings> getNotificationSettings();
@@ -868,22 +870,53 @@ class _NotificationSettingsMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Semantics(
-      container: true,
-      excludeSemantics: true,
-      liveRegion: true,
-      label: message,
-      child: Text(
-        message,
-        key: const Key('notificationSettingsMessage'),
-        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-          color: const Color(0xFF102A2C),
-          fontWeight: FontWeight.w700,
-          height: 1.35,
+    final shouldShowNextAction =
+        _shouldShowNotificationRegistrationFailureNextAction(message);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Semantics(
+          container: true,
+          excludeSemantics: true,
+          liveRegion: true,
+          label: message,
+          child: Text(
+            message,
+            key: const Key('notificationSettingsMessage'),
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: const Color(0xFF102A2C),
+              fontWeight: FontWeight.w700,
+              height: 1.35,
+            ),
+          ),
         ),
-      ),
+        if (shouldShowNextAction) ...[
+          const SizedBox(height: 8),
+          Semantics(
+            key: const Key('notificationRegistrationFailureNextAction'),
+            container: true,
+            excludeSemantics: true,
+            liveRegion: true,
+            label: '다음 행동, $_notificationRegistrationFailureNextAction',
+            child: Text(
+              _notificationRegistrationFailureNextAction,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: const Color(0xFF506B6F),
+                fontWeight: FontWeight.w700,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
+      ],
     );
   }
+}
+
+bool _shouldShowNotificationRegistrationFailureNextAction(String message) {
+  return message == _deviceRegistrationErrorMessage ||
+      message == _notificationPermissionErrorMessage;
 }
 
 class _NotificationSwitchTile extends StatelessWidget {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1175,6 +1175,60 @@ void main() {
     expect(notificationPermissionProvider.requestCount, 1);
     expect(find.text('기기 알림 권한을 켜 주세요.'), findsOneWidget);
     expect(find.bySemanticsLabel('기기 알림 권한을 켜 주세요.'), findsOneWidget);
+    expect(find.text('기기 알림 설정과 네트워크 상태를 확인한 뒤 다시 시도해 주세요.'), findsNothing);
+  });
+
+  testWidgets('알림 설정 화면은 기기 알림 실패 다음 행동을 안내한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final notificationPermissionProvider = FakeNotificationPermissionProvider(
+      nextStatus: NotificationPermissionStatus.denied,
+      error: const NotificationSettingsException('기기 알림 등록을 마치지 못했습니다.'),
+    );
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
+          notificationPermissionProvider: notificationPermissionProvider,
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('notificationSettingsButton')),
+        120,
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('notificationSettingsButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('notificationPermissionButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('켜기'));
+      await tester.pumpAndSettle();
+
+      expect(notificationPermissionProvider.requestCount, 1);
+      expect(find.text('기기 알림 등록을 마치지 못했습니다.'), findsOneWidget);
+      expect(find.text('기기 알림 설정과 네트워크 상태를 확인한 뒤 다시 시도해 주세요.'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('다음 행동, 기기 알림 설정과 네트워크 상태를 확인한 뒤 다시 시도해 주세요.'),
+        findsOneWidget,
+      );
+      expect(
+        tester.getSemantics(
+          find.byKey(const Key('notificationRegistrationFailureNextAction')),
+        ),
+        isSemantics(
+          label: '다음 행동, 기기 알림 설정과 네트워크 상태를 확인한 뒤 다시 시도해 주세요.',
+          isLiveRegion: true,
+        ),
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
   });
 
   testWidgets('홈 즐겨찾기는 저장한 역을 큰 목록으로 보여준다', (tester) async {
@@ -5327,14 +5381,19 @@ class FakeNotificationSettingsRepository
 
 class FakeNotificationPermissionProvider
     implements NotificationPermissionProvider {
-  FakeNotificationPermissionProvider({required this.nextStatus});
+  FakeNotificationPermissionProvider({required this.nextStatus, this.error});
 
   final NotificationPermissionStatus nextStatus;
+  final Object? error;
   int requestCount = 0;
 
   @override
   Future<NotificationPermissionStatus> requestNotificationPermission() async {
     requestCount++;
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
     return nextStatus;
   }
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1878,8 +1878,11 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(notificationSettings, /정보 갱신 알림/);
   assert.match(notificationSettings, /즐겨찾는 역과 경로의 시설 상태/);
   assert.match(notificationSettings, /알림 설정에서 언제든 끌 수 있습니다/);
+  assert.match(notificationSettings, /notificationRegistrationFailureNextAction/);
+  assert.match(notificationSettings, /기기 알림 설정과 네트워크 상태를 확인한 뒤 다시 시도해 주세요\./);
   assert.match(notificationSettingsTest, /인증 실패 시 인증을 지우고 한 번 재시도한다/);
   assert.match(notificationSettingsTest, /알림 설정 컨트롤러는 조회와 저장 상태를 구분한다/);
+  assert.match(widgetTest, /알림 설정 화면은 기기 알림 실패 다음 행동을 안내한다/);
   assert.match(stationSearch, /가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다/);
   assert.match(stationSearch, /위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다/);
   assert.match(facilityReport, /사진과 신고 위치는 시설 신고 확인과 운영 검수에만 사용됩니다/);


### PR DESCRIPTION
## 관련 이슈

close #316

## 작업 배경

- 알림 설정 화면에서 기기 알림 요청 또는 등록 실패가 발생하면 실패 문구만 보여 주어 사용자가 다음에 확인할 지점을 알기 어려웠습니다.
- 알림은 즐겨찾는 역/경로 시설 상태와 신고 처리 결과를 받는 흐름이므로, 실패 시 기기 설정과 네트워크 상태를 확인한 뒤 다시 시도할 수 있게 안내해야 합니다.

## 작업 내용

- 기기 알림 등록/권한 확인 실패 메시지 아래에 `기기 알림 설정과 네트워크 상태를 확인한 뒤 다시 시도해 주세요.` 안내를 추가했습니다.
- 다음 행동 안내를 별도 live region semantics로 제공해 스크린리더가 실패 직후 복구 행동까지 읽을 수 있게 했습니다.
- 권한 거부 상태의 기존 짧은 안내에는 새 실패 안내가 표시되지 않도록 범위를 제한했습니다.
- repository contract가 알림 등록 실패 다음 행동 안내 문구와 widget test 고정을 확인하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "알림 설정 화면은 기기 알림 실패 다음 행동을 안내한다"` RED 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs` RED 확인 후 구현 뒤 통과
  - `dart format lib/notification_settings.dart test/widget_test.dart` 통과
  - `flutter test test/widget_test.dart --name "알림 설정 화면은 기기 알림 권한 거부를 짧게 안내한다"` 통과
  - `flutter test test/widget_test.dart --name "알림 설정 화면"` 통과
  - `flutter analyze` 통과
  - `flutter test` 통과
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md docs/agent/notification-registration-failure-next-actions.md .codex/current-task.local swieun-jihacheol-project-plan.md` 통과
  - `flutter build apk --debug` 통과
  - `flutter build ios --simulator --no-codesign` 통과
  - GitHub Actions PR CI 통과: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI
  - CodeRabbit 리뷰가 시작되지 않아 `codex review --base origin/main --title "[Style] 알림 등록 실패 다음 행동 안내"`로 대체 확인했고 추가 지적 없음
  - merge 후 main CI 통과: run `27677357181`
  - merge 후 main CD 통과: run `27677357184`
  - Android emulator는 연결된 기기가 없어 실행 스모크는 생략

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 기기 알림 등록/권한 확인 실패에만 다음 행동 안내가 추가됩니다.
  - 단순 권한 거부 문구는 기존처럼 짧게 유지되고 새 다음 행동 안내가 붙지 않습니다.

## 리스크

- 화면 문구가 한 줄 늘어나지만 알림 설정 조회/저장 API 계약과 토글 저장 동작은 바꾸지 않습니다.
- 온보딩 알림 권한 흐름과 백엔드 푸시 outbox 계약 변경은 없습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 알림 등록 실패 시 사용자에게 다음 조치 안내 메시지를 표시합니다.

* **Tests**
  * 알림 권한 거부 및 등록 실패 시나리오에 대한 테스트 케이스를 추가했습니다.
  * 접근성 시맨틱 라벨 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->