### PR TITLE
[Style] 온보딩 알림 실패 다음 행동 안내

### DIFF
--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -9,6 +9,7 @@ import 'notification_settings.dart';
 import 'station_search.dart';
 
 const _onboardingResultStorageKey = 'easysubway.onboarding.result';
+const _onboardingNotificationFailureNextAction = '나중에 알림 설정에서 다시 켤 수 있습니다.';
 
 abstract class OnboardingResultStore {
   Future<OnboardingResult?> readResult();
@@ -572,6 +573,10 @@ class _OnboardingNotificationSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final showNextAction = _shouldShowOnboardingNotificationFailureNextAction(
+      message,
+    );
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -606,9 +611,31 @@ class _OnboardingNotificationSection extends StatelessWidget {
           const SizedBox(height: 10),
           _OnboardingStatusMessage(message: message, isFailure: isFailure),
         ],
+        if (showNextAction) ...[
+          const SizedBox(height: 6),
+          Semantics(
+            key: const Key('onboardingNotificationFailureNextAction'),
+            container: true,
+            excludeSemantics: true,
+            liveRegion: true,
+            label: '다음 행동, $_onboardingNotificationFailureNextAction',
+            child: Text(
+              _onboardingNotificationFailureNextAction,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: const Color(0xFF29484B),
+                fontWeight: FontWeight.w800,
+                height: 1.3,
+              ),
+            ),
+          ),
+        ],
       ],
     );
   }
+}
+
+bool _shouldShowOnboardingNotificationFailureNextAction(String message) {
+  return message == '알림 권한을 확인하지 못했습니다.';
 }
 
 class _OnboardingStatusMessage extends StatelessWidget {

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -248,34 +248,54 @@ void main() {
 
     expect(notificationPermissionProvider.requestCount, 1);
     expect(find.text('설정에서 알림 권한을 켜 주세요.'), findsOneWidget);
+    expect(find.text('나중에 알림 설정에서 다시 켤 수 있습니다.'), findsNothing);
   });
 
-  testWidgets('온보딩은 알림 권한 요청 실패를 짧게 안내한다', (tester) async {
+  testWidgets('온보딩은 알림 권한 요청 실패 다음 행동을 안내한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
     final notificationPermissionProvider = FakeNotificationPermissionProvider(
       error: const NotificationSettingsException('알림 권한을 확인하지 못했습니다.'),
     );
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: OnboardingScreen(
-          notificationPermissionProvider: notificationPermissionProvider,
-          onCompleted: (_) {},
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: OnboardingScreen(
+            notificationPermissionProvider: notificationPermissionProvider,
+            onCompleted: (_) {},
+          ),
         ),
-      ),
-    );
+      );
 
-    await tester.dragUntilVisible(
-      find.byKey(const Key('onboardingNotificationButton')),
-      find.byType(Scrollable).first,
-      const Offset(0, -300),
-    );
-    await tester.pumpAndSettle();
+      await tester.dragUntilVisible(
+        find.byKey(const Key('onboardingNotificationButton')),
+        find.byType(Scrollable).first,
+        const Offset(0, -300),
+      );
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
-    await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
+      await tester.pumpAndSettle();
 
-    expect(notificationPermissionProvider.requestCount, 1);
-    expect(find.text('알림 권한을 확인하지 못했습니다.'), findsOneWidget);
+      expect(notificationPermissionProvider.requestCount, 1);
+      expect(find.text('알림 권한을 확인하지 못했습니다.'), findsOneWidget);
+      expect(find.text('나중에 알림 설정에서 다시 켤 수 있습니다.'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('다음 행동, 나중에 알림 설정에서 다시 켤 수 있습니다.'),
+        findsOneWidget,
+      );
+      expect(
+        tester.getSemantics(
+          find.byKey(const Key('onboardingNotificationFailureNextAction')),
+        ),
+        isSemantics(
+          label: '다음 행동, 나중에 알림 설정에서 다시 켤 수 있습니다.',
+          isLiveRegion: true,
+        ),
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
   });
 
   testWidgets('온보딩은 알림 권한 요청 실패가 있어도 완료를 막지 않는다', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -144,6 +144,40 @@ void main() {
     expect(find.text('알림 준비 완료'), findsOneWidget);
   });
 
+  testWidgets('첫 실행 앱은 온보딩 알림 권한 실패 다음 행동을 안내한다', (tester) async {
+    final notificationPermissionProvider = FakeNotificationPermissionProvider(
+      nextStatus: NotificationPermissionStatus.denied,
+      error: const NotificationSettingsException('알림 권한을 확인하지 못했습니다.'),
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        notificationPermissionProvider: notificationPermissionProvider,
+        onboardingStore: MemoryOnboardingResultStore(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('onboardingNotificationButton')),
+      find.byType(Scrollable).first,
+      const Offset(0, -300),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
+    await tester.pumpAndSettle();
+
+    expect(notificationPermissionProvider.requestCount, 1);
+    expect(find.text('알림 권한을 확인하지 못했습니다.'), findsOneWidget);
+    expect(find.text('나중에 알림 설정에서 다시 켤 수 있습니다.'), findsOneWidget);
+  });
+
   testWidgets('첫 실행 앱은 알림 설정이 꺼진 구성에서 온보딩 알림 권한을 요청하지 않는다', (tester) async {
     await tester.pumpWidget(
       EasySubwayApp(

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1883,6 +1883,10 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(notificationSettingsTest, /인증 실패 시 인증을 지우고 한 번 재시도한다/);
   assert.match(notificationSettingsTest, /알림 설정 컨트롤러는 조회와 저장 상태를 구분한다/);
   assert.match(widgetTest, /알림 설정 화면은 기기 알림 실패 다음 행동을 안내한다/);
+  assert.match(read("apps/mobile/lib/onboarding.dart"), /onboardingNotificationFailureNextAction/);
+  assert.match(read("apps/mobile/lib/onboarding.dart"), /나중에 알림 설정에서 다시 켤 수 있습니다\./);
+  assert.match(read("apps/mobile/test/onboarding_test.dart"), /온보딩은 알림 권한 요청 실패 다음 행동을 안내한다/);
+  assert.match(widgetTest, /첫 실행 앱은 온보딩 알림 권한 실패 다음 행동을 안내한다/);
   assert.match(stationSearch, /가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다/);
   assert.match(stationSearch, /위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다/);
   assert.match(facilityReport, /사진과 신고 위치는 시설 신고 확인과 운영 검수에만 사용됩니다/);


### PR DESCRIPTION
## 관련 이슈

close #318

## 작업 배경

- 온보딩에서 알림 권한 요청이 실패하면 실패 문구만 보여 사용자가 앱을 계속 시작해도 되는지, 나중에 어디에서 다시 시도할 수 있는지 알기 어려웠습니다.
- 알림은 시설 고장, 신고 처리 결과, 공사 안내를 받는 흐름이므로 첫 실행 실패 후에도 알림 설정에서 다시 켤 수 있음을 쉬운 문구로 알려야 합니다.

## 작업 내용

- 온보딩 알림 권한 요청 실패 메시지 아래에 `나중에 알림 설정에서 다시 켤 수 있습니다.` 안내를 추가했습니다.
- 다음 행동 안내를 별도 live region semantics로 제공해 스크린리더가 실패 직후 복구 행동까지 읽을 수 있게 했습니다.
- 알림 권한 거부 상태의 기존 짧은 안내에는 새 다음 행동 안내가 표시되지 않도록 범위를 제한했습니다.
- 온보딩 단위 test, 첫 실행 앱 widget test, repository contract가 새 문구와 semantics key를 확인하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/onboarding_test.dart --name "온보딩은 알림 권한 요청 실패 다음 행동을 안내한다"` RED 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs` RED 확인 후 구현 뒤 통과
  - `dart format lib/onboarding.dart test/onboarding_test.dart test/widget_test.dart` 통과
  - `flutter test test/onboarding_test.dart --name "온보딩은 알림 권한을 거부하면 짧게 안내한다"` 통과
  - `flutter test test/onboarding_test.dart --name "온보딩은 알림 권한 요청 실패가 있어도 완료를 막지 않는다"` 통과
  - `flutter test test/widget_test.dart --name "첫 실행 앱은 온보딩 알림 권한 실패 다음 행동을 안내한다"` 통과
  - `flutter analyze` 통과
  - `flutter test` 통과
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md docs/agent/onboarding-notification-failure-next-actions.md .codex/current-task.local swieun-jihacheol-project-plan.md` 통과
  - `flutter build apk --debug` 통과
  - `flutter build ios --simulator --no-codesign` 통과
  - GitHub Actions PR CI 통과: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI
  - CodeRabbit 리뷰가 시작되지 않아 `codex review --base origin/main --title "[Style] 온보딩 알림 실패 다음 행동 안내"`로 대체 확인했고 추가 지적 없음
  - merge 후 main CI 통과: run `27678396059`
  - merge 후 main CD 통과: run `27678395965`
  - Android emulator는 연결된 기기가 없어 실행 스모크는 생략

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 온보딩 알림 권한 요청 실패에만 다음 행동 안내가 추가됩니다.
  - 단순 권한 거부 문구는 기존처럼 짧게 유지되고 새 다음 행동 안내가 붙지 않습니다.

## 리스크

- 온보딩 알림 섹션의 실패 문구가 한 줄 늘어나지만 온보딩 완료 저장 계약과 알림 설정 화면 동작은 바꾸지 않습니다.
- 위치 권한 온보딩 흐름과 백엔드 API 계약 변경은 없습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
