### PR TITLE
[Style] 경로 피드백 실패 다음 행동 안내

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -16,6 +16,7 @@ const _favoriteRouteErrorMessage = '즐겨찾기 경로를 처리하지 못했�
 const _favoriteRouteLoadErrorMessage = '즐겨찾기 경로를 불러오지 못했습니다.';
 const _routeSafetyGuidanceNotice = '이동 전 현장 안내와 역무원 안내를 확인해 주세요.';
 const _routeSearchFailureNextAction = '역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.';
+const _routeFeedbackFailureNextAction = '잠시 후 다시 보내거나 경로 조건을 바꿔 다시 찾아보세요.';
 
 String _mobilityLabelFor(String mobilityType) {
   for (final option in mobilityProfileOptions) {
@@ -2209,6 +2210,7 @@ class _RouteFeedbackButtonsState extends State<_RouteFeedbackButtons> {
   bool _submitting = false;
   bool _submitted = false;
   String _message = '';
+  bool _isFailure = false;
 
   @override
   void didUpdateWidget(_RouteFeedbackButtons oldWidget) {
@@ -2217,11 +2219,14 @@ class _RouteFeedbackButtonsState extends State<_RouteFeedbackButtons> {
       _submitting = false;
       _submitted = false;
       _message = '';
+      _isFailure = false;
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    final shouldShowNextAction = _isFailure && _message.isNotEmpty;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -2267,6 +2272,24 @@ class _RouteFeedbackButtonsState extends State<_RouteFeedbackButtons> {
             ),
           ),
         ],
+        if (shouldShowNextAction) ...[
+          const SizedBox(height: 6),
+          Semantics(
+            key: const Key('routeFeedbackFailureNextAction'),
+            container: true,
+            excludeSemantics: true,
+            liveRegion: true,
+            label: '다음 행동, $_routeFeedbackFailureNextAction',
+            child: Text(
+              _routeFeedbackFailureNextAction,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: const Color(0xFF506B6F),
+                fontWeight: FontWeight.w700,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
       ],
     );
   }
@@ -2277,6 +2300,7 @@ class _RouteFeedbackButtonsState extends State<_RouteFeedbackButtons> {
     setState(() {
       _submitting = true;
       _message = '';
+      _isFailure = false;
     });
 
     try {
@@ -2294,6 +2318,7 @@ class _RouteFeedbackButtonsState extends State<_RouteFeedbackButtons> {
         _submitting = false;
         _submitted = true;
         _message = '의견을 보냈습니다.';
+        _isFailure = false;
       });
     } on RouteFeedbackException catch (error) {
       if (!mounted) {
@@ -2302,6 +2327,7 @@ class _RouteFeedbackButtonsState extends State<_RouteFeedbackButtons> {
       setState(() {
         _submitting = false;
         _message = error.message;
+        _isFailure = true;
       });
     } catch (error, stackTrace) {
       reportMobileError(
@@ -2315,6 +2341,7 @@ class _RouteFeedbackButtonsState extends State<_RouteFeedbackButtons> {
       setState(() {
         _submitting = false;
         _message = _routeFeedbackErrorMessage;
+        _isFailure = true;
       });
     }
   }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3187,7 +3187,8 @@ void main() {
     expect(helpfulButton.onPressed, isNull);
   });
 
-  testWidgets('경로 피드백 실패는 짧은 오류 문구로 알린다', (tester) async {
+  testWidgets('경로 피드백 실패는 다음 행동을 쉬운 문구로 안내한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
     final stationRepository = FakeStationSearchRepository(
       queryResults: {
         '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
@@ -3197,55 +3198,75 @@ void main() {
     final routeFeedbackRepository = FakeRouteFeedbackRepository()
       ..error = const RouteFeedbackException('의견을 보내지 못했습니다.');
 
-    await tester.pumpWidget(
-      EasySubwayApp(
-        repository: stationRepository,
-        reportRepository: FakeFacilityReportRepository(),
-        routeRepository: FakeRouteSearchRepository(),
-        routeFeedbackRepository: routeFeedbackRepository,
-        favoriteRepository: FakeFavoriteStationRepository(),
-        initialOnboardingState: _completedOnboardingState(),
-      ),
-    );
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: stationRepository,
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          routeFeedbackRepository: routeFeedbackRepository,
+          favoriteRepository: FakeFavoriteStationRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
 
-    await tester.tap(find.byKey(const Key('routeSearchButton')));
-    await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('routeSearchButton')));
+      await tester.pumpAndSettle();
 
-    await tester.enterText(
-      find.byKey(const Key('routeOriginStationInput')),
-      '상록수',
-    );
-    await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
-    await tester.pumpAndSettle();
-    await tester.tap(
-      find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
-    );
-    await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('routeOriginStationInput')),
+        '상록수',
+      );
+      await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+      );
+      await tester.pumpAndSettle();
 
-    await tester.enterText(
-      find.byKey(const Key('routeDestinationStationInput')),
-      '사당',
-    );
-    await tester.tap(
-      find.byKey(const Key('routeDestinationStationSearchButton')),
-    );
-    await tester.pumpAndSettle();
-    await tester.tap(
-      find.byKey(const Key('routeDestinationStationOption-station-sadang')),
-    );
-    await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('routeDestinationStationInput')),
+        '사당',
+      );
+      await tester.tap(
+        find.byKey(const Key('routeDestinationStationSearchButton')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('routeDestinationStationOption-station-sadang')),
+      );
+      await tester.pumpAndSettle();
 
-    await tester.drag(find.byType(ListView), const Offset(0, -360));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
-    await tester.pumpAndSettle();
+      await tester.drag(find.byType(ListView), const Offset(0, -360));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+      await tester.pumpAndSettle();
 
-    await tester.ensureVisible(
-      find.byKey(const Key('routeFeedbackNotHelpfulButton')),
-    );
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('routeFeedbackNotHelpfulButton')));
-    await tester.pumpAndSettle();
+      await tester.ensureVisible(
+        find.byKey(const Key('routeFeedbackNotHelpfulButton')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('routeFeedbackNotHelpfulButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('의견을 보내지 못했습니다.'), findsOneWidget);
+      expect(find.text('잠시 후 다시 보내거나 경로 조건을 바꿔 다시 찾아보세요.'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('다음 행동, 잠시 후 다시 보내거나 경로 조건을 바꿔 다시 찾아보세요.'),
+        findsOneWidget,
+      );
+      expect(
+        tester.getSemantics(
+          find.byKey(const Key('routeFeedbackFailureNextAction')),
+        ),
+        isSemantics(
+          label: '다음 행동, 잠시 후 다시 보내거나 경로 조건을 바꿔 다시 찾아보세요.',
+          isLiveRegion: true,
+        ),
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
 
     expect(
       routeFeedbackRepository.requests.single.rating,

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1904,6 +1904,9 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(routeSearch, /routeSearchFailureNextAction/);
   assert.match(routeSearch, /역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요\./);
   assert.match(widgetTest, /경로 검색 실패는 다음 행동을 쉬운 문구로 안내한다/);
+  assert.match(routeSearch, /routeFeedbackFailureNextAction/);
+  assert.match(routeSearch, /잠시 후 다시 보내거나 경로 조건을 바꿔 다시 찾아보세요\./);
+  assert.match(widgetTest, /경로 피드백 실패는 다음 행동을 쉬운 문구로 안내한다/);
   assert.match(main, /개인정보 사용 안내/);
   assert.match(main, /안전과 데이터 안내/);
   assert.match(main, /현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다/);


### PR DESCRIPTION
## 관련 이슈

close #320

## 작업 배경

- 경로 결과 피드백 전송에 실패하면 짧은 실패 문구만 표시되어, 사용자가 다시 보내야 하는지 경로 조건을 바꿔 재검색해야 하는지 바로 판단하기 어렵습니다.
- 경로 검색 화면은 교통약자가 이동 전 확인하는 핵심 흐름이므로 실패 상태에서도 다음 행동이 명확해야 합니다.

## 작업 내용

- 경로 피드백 전송 실패 상태에 다음 행동 안내 문구를 추가했습니다.
- 다음 행동 안내를 별도 live region semantics로 제공해 스크린리더가 실패 후 조치 문구를 읽을 수 있게 했습니다.
- 피드백 성공이나 새 경로 검색 결과로 전환되는 경우 실패 다음 행동 상태가 남지 않도록 초기화했습니다.
- widget test와 repository contract에 문구, semantics key, live region 계약을 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "경로 피드백 실패는 다음 행동을 쉬운 문구로 안내한다"`: RED 실패 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs`: RED 실패 확인 후 구현 뒤 통과
  - `dart format lib/route_search.dart test/widget_test.dart`: 통과
  - `flutter test test/widget_test.dart --name "경로 검색 결과는 큰 버튼으로 추천 피드백을 보낸다"`: 통과
  - `flutter test test/widget_test.dart --name "경로 검색 화면"`: 통과
  - `flutter analyze`: 통과
  - `flutter test`: 통과, 184개 테스트
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md docs/agent/route-feedback-failure-next-actions.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - `flutter build apk --debug`: 통과
  - `flutter build ios --simulator --no-codesign`: 통과
  - `/opt/homebrew/share/android-commandlinetools/platform-tools/adb devices`: 연결된 device 없음, Android emulator smoke 스킵

## 리뷰어 메모

- `apps/mobile/lib/route_search.dart`의 `_RouteFeedbackButtons` 실패 상태 초기화와 `routeFeedbackFailureNextAction` semantics 처리를 먼저 확인해 주세요.

## 리스크

- 경로 피드백 실패 UI 문구와 semantics만 변경하며 API payload와 경로 검색 결과 구조는 변경하지 않습니다.
- 화면 하단 피드백 영역에 한 줄 안내가 추가되어 작은 화면에서 세로 공간이 소폭 늘어납니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
