### PR TITLE
[Style] 즐겨찾기 경로 실패 다음 행동 안내

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -17,6 +17,9 @@ const _favoriteRouteLoadErrorMessage = '즐겨찾기 경로를 불러오지 못�
 const _routeSafetyGuidanceNotice = '이동 전 현장 안내와 역무원 안내를 확인해 주세요.';
 const _routeSearchFailureNextAction = '역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.';
 const _routeFeedbackFailureNextAction = '잠시 후 다시 보내거나 경로 조건을 바꿔 다시 찾아보세요.';
+const _favoriteRouteSaveFailureNextAction =
+    '네트워크 상태를 확인한 뒤 자주 쓰는 경로 저장을 다시 눌러 주세요.';
+const _favoriteRouteLoadFailureNextAction = '네트워크 상태를 확인한 뒤 다시 불러와 주세요.';
 
 String _mobilityLabelFor(String mobilityType) {
   for (final option in mobilityProfileOptions) {
@@ -2364,6 +2367,7 @@ class _RouteFavoriteSaveButton extends StatefulWidget {
 class _RouteFavoriteSaveButtonState extends State<_RouteFavoriteSaveButton> {
   bool _saving = false;
   String _message = '';
+  bool _isFailure = false;
 
   @override
   void didUpdateWidget(_RouteFavoriteSaveButton oldWidget) {
@@ -2371,11 +2375,14 @@ class _RouteFavoriteSaveButtonState extends State<_RouteFavoriteSaveButton> {
     if (oldWidget.result.routeSearchId != widget.result.routeSearchId) {
       _saving = false;
       _message = '';
+      _isFailure = false;
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    final shouldShowNextAction = _isFailure && _message.isNotEmpty;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -2399,6 +2406,24 @@ class _RouteFavoriteSaveButtonState extends State<_RouteFavoriteSaveButton> {
             ),
           ),
         ],
+        if (shouldShowNextAction) ...[
+          const SizedBox(height: 6),
+          Semantics(
+            key: const Key('favoriteRouteSaveFailureNextAction'),
+            container: true,
+            excludeSemantics: true,
+            liveRegion: true,
+            label: '다음 행동, $_favoriteRouteSaveFailureNextAction',
+            child: Text(
+              _favoriteRouteSaveFailureNextAction,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: const Color(0xFF506B6F),
+                fontWeight: FontWeight.w700,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
       ],
     );
   }
@@ -2407,6 +2432,7 @@ class _RouteFavoriteSaveButtonState extends State<_RouteFavoriteSaveButton> {
     setState(() {
       _saving = true;
       _message = '';
+      _isFailure = false;
     });
 
     try {
@@ -2417,6 +2443,7 @@ class _RouteFavoriteSaveButtonState extends State<_RouteFavoriteSaveButton> {
       setState(() {
         _saving = false;
         _message = '자주 쓰는 경로에 저장했습니다.';
+        _isFailure = false;
       });
     } on FavoriteRouteException catch (error) {
       if (!mounted) {
@@ -2425,6 +2452,7 @@ class _RouteFavoriteSaveButtonState extends State<_RouteFavoriteSaveButton> {
       setState(() {
         _saving = false;
         _message = error.message;
+        _isFailure = true;
       });
     } catch (error, stackTrace) {
       reportMobileError(
@@ -2438,6 +2466,7 @@ class _RouteFavoriteSaveButtonState extends State<_RouteFavoriteSaveButton> {
       setState(() {
         _saving = false;
         _message = _favoriteRouteErrorMessage;
+        _isFailure = true;
       });
     }
   }
@@ -2693,6 +2722,22 @@ class _FavoriteRouteListBody extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               _RouteSearchMessage(message: state.message, liveRegion: true),
+              const SizedBox(height: 6),
+              Semantics(
+                key: const Key('favoriteRouteLoadFailureNextAction'),
+                container: true,
+                excludeSemantics: true,
+                liveRegion: true,
+                label: '다음 행동, $_favoriteRouteLoadFailureNextAction',
+                child: Text(
+                  _favoriteRouteLoadFailureNextAction,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: const Color(0xFF506B6F),
+                    fontWeight: FontWeight.w700,
+                    height: 1.35,
+                  ),
+                ),
+              ),
               const SizedBox(height: 12),
               OutlinedButton.icon(
                 key: const Key('favoriteRoutesRetryButton'),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1461,6 +1461,51 @@ void main() {
     expect(find.text('저장한 경로가 없습니다.'), findsOneWidget);
   });
 
+  testWidgets('즐겨찾기 경로 목록 실패는 다음 행동을 쉬운 문구로 안내한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final favoriteRouteRepository = FakeFavoriteRouteRepository()
+      ..error = const FavoriteRouteException('즐겨찾기 경로를 불러오지 못했습니다.');
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+          favoriteRouteRepository: favoriteRouteRepository,
+          notificationRepository: FakeNotificationSettingsRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await _openFavoriteList(tester);
+
+      expect(find.text('즐겨찾기 경로를 불러오지 못했습니다.'), findsOneWidget);
+      expect(find.text('네트워크 상태를 확인한 뒤 다시 불러와 주세요.'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('다음 행동, 네트워크 상태를 확인한 뒤 다시 불러와 주세요.'),
+        findsOneWidget,
+      );
+      expect(
+        tester.getSemantics(
+          find.byKey(const Key('favoriteRouteLoadFailureNextAction')),
+        ),
+        isSemantics(
+          label: '다음 행동, 네트워크 상태를 확인한 뒤 다시 불러와 주세요.',
+          isLiveRegion: true,
+        ),
+      );
+      expect(
+        find.byKey(const Key('favoriteRoutesRetryButton')),
+        findsOneWidget,
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('역 검색은 접근성 표시가 포함된 백엔드 결과를 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final repository = FakeStationSearchRepository(
@@ -3111,6 +3156,93 @@ void main() {
 
     expect(favoriteRouteRepository.savedRouteSearchIds, ['route-1']);
     expect(find.text('자주 쓰는 경로에 저장했습니다.'), findsOneWidget);
+  });
+
+  testWidgets('즐겨찾기 경로 저장 실패는 다음 행동을 쉬운 문구로 안내한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '사당': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
+    final favoriteRouteRepository = FakeFavoriteRouteRepository()
+      ..error = const FavoriteRouteException('즐겨찾기 경로를 처리하지 못했습니다.');
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: stationRepository,
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          favoriteRouteRepository: favoriteRouteRepository,
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('routeSearchButton')));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('routeOriginStationInput')),
+        '상록수',
+      );
+      await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('routeDestinationStationInput')),
+        '사당',
+      );
+      await tester.tap(
+        find.byKey(const Key('routeDestinationStationSearchButton')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('routeDestinationStationOption-station-sadang')),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.drag(find.byType(ListView), const Offset(0, -360));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(
+        find.byKey(const Key('routeFavoriteSaveButton')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('routeFavoriteSaveButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('즐겨찾기 경로를 처리하지 못했습니다.'), findsOneWidget);
+      expect(
+        find.text('네트워크 상태를 확인한 뒤 자주 쓰는 경로 저장을 다시 눌러 주세요.'),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel('다음 행동, 네트워크 상태를 확인한 뒤 자주 쓰는 경로 저장을 다시 눌러 주세요.'),
+        findsOneWidget,
+      );
+      expect(
+        tester.getSemantics(
+          find.byKey(const Key('favoriteRouteSaveFailureNextAction')),
+        ),
+        isSemantics(
+          label: '다음 행동, 네트워크 상태를 확인한 뒤 자주 쓰는 경로 저장을 다시 눌러 주세요.',
+          isLiveRegion: true,
+        ),
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
+
+    expect(favoriteRouteRepository.savedRouteSearchIds, ['route-1']);
   });
 
   testWidgets('경로 검색 결과는 큰 버튼으로 추천 피드백을 보낸다', (tester) async {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1907,6 +1907,12 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(routeSearch, /routeFeedbackFailureNextAction/);
   assert.match(routeSearch, /잠시 후 다시 보내거나 경로 조건을 바꿔 다시 찾아보세요\./);
   assert.match(widgetTest, /경로 피드백 실패는 다음 행동을 쉬운 문구로 안내한다/);
+  assert.match(routeSearch, /favoriteRouteSaveFailureNextAction/);
+  assert.match(routeSearch, /네트워크 상태를 확인한 뒤 자주 쓰는 경로 저장을 다시 눌러 주세요\./);
+  assert.match(routeSearch, /favoriteRouteLoadFailureNextAction/);
+  assert.match(routeSearch, /네트워크 상태를 확인한 뒤 다시 불러와 주세요\./);
+  assert.match(widgetTest, /즐겨찾기 경로 저장 실패는 다음 행동을 쉬운 문구로 안내한다/);
+  assert.match(widgetTest, /즐겨찾기 경로 목록 실패는 다음 행동을 쉬운 문구로 안내한다/);
   assert.match(main, /개인정보 사용 안내/);
   assert.match(main, /안전과 데이터 안내/);
   assert.match(main, /현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다/);


### PR DESCRIPTION
## 관련 이슈

close #322

## 작업 배경

- 즐겨찾기 경로 저장과 목록은 자주 쓰는 이동 동선을 빠르게 다시 확인하는 흐름입니다.
- 저장 실패와 목록 불러오기 실패가 짧은 실패 문구 중심이면 사용자가 네트워크 확인, 다시 저장, 다시 불러오기 중 다음 행동을 바로 고르기 어렵습니다.

## 작업 내용

- 경로 검색 결과의 `자주 쓰는 경로 저장` 실패 상태에 다음 행동 안내 문구를 추가했습니다.
- 홈 즐겨찾기 경로 목록의 불러오기 실패 상태에 다시 불러오기 전 확인할 다음 행동 안내를 추가했습니다.
- 두 안내 모두 별도 live region semantics로 제공해 스크린리더가 실패 후 조치 문구를 읽을 수 있게 했습니다.
- widget test와 repository contract에 문구, semantics key, live region 계약을 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "즐겨찾기 경로 저장 실패는 다음 행동을 쉬운 문구로 안내한다"`: RED 실패 확인 후 구현 뒤 통과
  - `flutter test test/widget_test.dart --name "즐겨찾기 경로 목록 실패는 다음 행동을 쉬운 문구로 안내한다"`: RED 실패 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs`: RED 실패 확인 후 구현 뒤 통과, 41개 테스트
  - `dart format lib/route_search.dart test/widget_test.dart`: 통과
  - `flutter test test/widget_test.dart --name "홈 즐겨찾기 경로"`: 통과
  - `flutter analyze`: 통과
  - `flutter test`: 통과, 186개 테스트
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md docs/agent/favorite-route-failure-next-actions.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - `flutter build apk --debug`: 통과
  - `flutter build ios --simulator --no-codesign`: 통과
  - `/opt/homebrew/share/android-commandlinetools/platform-tools/adb devices`: 연결된 device 없음, Android emulator smoke 스킵

## 리뷰어 메모

- `apps/mobile/lib/route_search.dart`의 `_RouteFavoriteSaveButton` 실패 상태 초기화와 `FavoriteRouteListStatus.failure` 안내 순서를 먼저 확인해 주세요.

## 리스크

- 즐겨찾기 경로 저장/목록 실패 UI 문구와 semantics만 변경하며 API 요청/응답 계약은 변경하지 않습니다.
- 실패 상태에 한 줄 안내가 추가되어 작은 화면에서 세로 공간이 소폭 늘어납니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
