### PR TITLE
[Feat] 푸시 발송 실패 사유 보존

### DIFF
--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
@@ -28,6 +28,7 @@ class PushNotificationAdminPageController {
 		long pendingCount,
 		long sentCount,
 		long failedCount,
+		String latestFailureReason,
 		List<StatusCountRow> statusRows
 	) {
 
@@ -37,12 +38,20 @@ class PushNotificationAdminPageController {
 				summary.pendingCount(),
 				summary.sentCount(),
 				summary.failedCount(),
+				summary.latestFailureReason(),
 				List.of(
 					new StatusCountRow("대기 중", "아직 발송 처리 전", summary.pendingCount()),
 					new StatusCountRow("발송 완료", "외부 발송 성공", summary.sentCount()),
-					new StatusCountRow("발송 실패", "발송 어댑터 실패 또는 예외", summary.failedCount())
+					new StatusCountRow("발송 실패", failedDescription(summary.latestFailureReason()), summary.failedCount())
 				)
 			);
+		}
+
+		private static String failedDescription(String latestFailureReason) {
+			if (latestFailureReason == null || latestFailureReason.isBlank()) {
+				return "발송 어댑터 실패 또는 예외";
+			}
+			return "발송 어댑터 실패 또는 예외 · 최근 실패: " + latestFailureReason;
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationController.java
@@ -111,6 +111,7 @@ class PushNotificationController {
 		String title,
 		String body,
 		PushNotificationStatus status,
+		String failureReason,
 		LocalDateTime createdAt
 	) {
 
@@ -123,6 +124,7 @@ class PushNotificationController {
 				notification.title(),
 				notification.body(),
 				notification.status(),
+				notification.failureReason(),
 				notification.createdAt()
 			);
 		}

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
@@ -68,12 +68,21 @@ public class InMemoryPushNotificationOutboxRepository implements
 		long pendingCount = 0;
 		long sentCount = 0;
 		long failedCount = 0;
+		PushNotification latestFailedNotification = null;
 		for (List<PushNotification> notifications : notificationsByUserId.values()) {
 			for (PushNotification notification : notifications) {
 				switch (notification.status()) {
 					case PENDING -> pendingCount++;
 					case SENT -> sentCount++;
-					case FAILED -> failedCount++;
+					case FAILED -> {
+						failedCount++;
+						if (latestFailedNotification == null ||
+							notification.createdAt().isAfter(latestFailedNotification.createdAt()) ||
+							(notification.createdAt().isEqual(latestFailedNotification.createdAt()) &&
+								notification.notificationId().compareTo(latestFailedNotification.notificationId()) > 0)) {
+							latestFailedNotification = notification;
+						}
+					}
 				}
 			}
 		}
@@ -81,7 +90,8 @@ public class InMemoryPushNotificationOutboxRepository implements
 			pendingCount + sentCount + failedCount,
 			pendingCount,
 			sentCount,
-			failedCount
+			failedCount,
+			latestFailedNotification == null ? null : latestFailedNotification.failureReason()
 		);
 	}
 

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
@@ -50,6 +50,7 @@ public class JdbcPushNotificationOutboxRepository implements
 					title,
 					body,
 					status,
+					failure_reason,
 					created_at
 				FROM push_notification_outbox
 				WHERE user_id = ?
@@ -72,6 +73,7 @@ public class JdbcPushNotificationOutboxRepository implements
 					title,
 					body,
 					status,
+					failure_reason,
 					created_at
 				FROM push_notification_outbox
 				WHERE user_id = ?
@@ -113,11 +115,13 @@ public class JdbcPushNotificationOutboxRepository implements
 		long pendingCount = countByStatus(statusCounts, PushNotificationStatus.PENDING);
 		long sentCount = countByStatus(statusCounts, PushNotificationStatus.SENT);
 		long failedCount = countByStatus(statusCounts, PushNotificationStatus.FAILED);
+		String latestFailureReason = latestFailureReason();
 		return new PushNotificationDashboardSummary(
 			pendingCount + sentCount + failedCount,
 			pendingCount,
 			sentCount,
-			failedCount
+			failedCount,
+			latestFailureReason
 		);
 	}
 
@@ -150,6 +154,7 @@ public class JdbcPushNotificationOutboxRepository implements
 					title = ?,
 					body = ?,
 					status = ?,
+					failure_reason = ?,
 					created_at = ?
 				WHERE notification_id = ?
 				""",
@@ -160,6 +165,7 @@ public class JdbcPushNotificationOutboxRepository implements
 			notification.title(),
 			notification.body(),
 			notification.status().name(),
+			notification.failureReason(),
 			notification.createdAt(),
 			notification.notificationId()
 		);
@@ -177,9 +183,10 @@ public class JdbcPushNotificationOutboxRepository implements
 					title,
 					body,
 					status,
+					failure_reason,
 					created_at
 				)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 				""",
 			notification.notificationId(),
 			notification.userId(),
@@ -189,6 +196,7 @@ public class JdbcPushNotificationOutboxRepository implements
 			notification.title(),
 			notification.body(),
 			notification.status().name(),
+			notification.failureReason(),
 			notification.createdAt()
 		);
 	}
@@ -203,8 +211,27 @@ public class JdbcPushNotificationOutboxRepository implements
 			resultSet.getString("title"),
 			resultSet.getString("body"),
 			PushNotificationStatus.valueOf(resultSet.getString("status")),
+			resultSet.getString("failure_reason"),
 			resultSet.getTimestamp("created_at").toLocalDateTime()
 		);
+	}
+
+	private String latestFailureReason() {
+		return jdbcTemplate.query(
+				"""
+					SELECT failure_reason
+					FROM push_notification_outbox
+					WHERE status = ?
+						AND failure_reason IS NOT NULL
+					ORDER BY created_at DESC, notification_id DESC
+					LIMIT 1
+					""",
+				(resultSet, rowNumber) -> resultSet.getString("failure_reason"),
+				PushNotificationStatus.FAILED.name()
+			)
+			.stream()
+			.findFirst()
+			.orElse(null);
 	}
 
 	private record StatusCountRow(PushNotificationStatus status, long count) {

--- a/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDeliveryService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDeliveryService.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class PushNotificationDeliveryService implements PushNotificationDeliveryUseCase {
 
+	private static final String DEFAULT_SEND_EXCEPTION_FAILURE_REASON = "푸시 발송 중 예외가 발생했습니다.";
+
 	private final LoadPendingPushNotificationOutboxPort loadPendingPushNotificationOutboxPort;
 	private final SavePushNotificationOutboxPort savePushNotificationOutboxPort;
 	private final PushNotificationSenderPort pushNotificationSenderPort;
@@ -57,7 +59,15 @@ public class PushNotificationDeliveryService implements PushNotificationDelivery
 		try {
 			return pushNotificationSenderPort.send(notification);
 		} catch (RuntimeException exception) {
-			return PushNotificationSendResult.failed("푸시 발송 중 예외가 발생했습니다.");
+			return PushNotificationSendResult.failed(sendExceptionFailureReason(exception));
 		}
+	}
+
+	private String sendExceptionFailureReason(RuntimeException exception) {
+		String message = exception.getMessage();
+		if (message == null || message.isBlank()) {
+			return DEFAULT_SEND_EXCEPTION_FAILURE_REASON;
+		}
+		return message;
 	}
 }

--- a/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDeliveryService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDeliveryService.java
@@ -8,7 +8,6 @@ import com.easysubway.notification.application.port.out.SavePushNotificationOutb
 import com.easysubway.notification.domain.PushNotification;
 import com.easysubway.notification.domain.PushNotificationDeliveryResult;
 import com.easysubway.notification.domain.PushNotificationSendResult;
-import com.easysubway.notification.domain.PushNotificationStatus;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -40,11 +39,8 @@ public class PushNotificationDeliveryService implements PushNotificationDelivery
 			command.userId()
 		)) {
 			var sendResult = safeSend(notification);
-			PushNotificationStatus nextStatus = sendResult.successful()
-				? PushNotificationStatus.SENT
-				: PushNotificationStatus.FAILED;
 			PushNotification savedNotification = savePushNotificationOutboxPort.savePushNotification(
-				notification.withStatus(nextStatus)
+				notification.withSendResult(sendResult)
 			);
 			deliveredNotifications.add(savedNotification);
 			if (sendResult.successful()) {

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotification.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotification.java
@@ -15,11 +15,15 @@ public record PushNotification(
 	LocalDateTime createdAt
 ) {
 
+	private static final int FAILURE_REASON_MAX_LENGTH = 1000;
+
 	public PushNotification {
 		if (failureReason != null) {
 			failureReason = failureReason.trim();
 			if (failureReason.isBlank()) {
 				failureReason = null;
+			} else if (failureReason.length() > FAILURE_REASON_MAX_LENGTH) {
+				failureReason = failureReason.substring(0, FAILURE_REASON_MAX_LENGTH);
 			}
 		}
 		if (notificationId == null || notificationId.isBlank()) {

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotification.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotification.java
@@ -11,10 +11,17 @@ public record PushNotification(
 	String title,
 	String body,
 	PushNotificationStatus status,
+	String failureReason,
 	LocalDateTime createdAt
 ) {
 
 	public PushNotification {
+		if (failureReason != null) {
+			failureReason = failureReason.trim();
+			if (failureReason.isBlank()) {
+				failureReason = null;
+			}
+		}
 		if (notificationId == null || notificationId.isBlank()) {
 			throw new InvalidPushNotificationException("알림 식별자가 필요합니다.");
 		}
@@ -39,6 +46,9 @@ public record PushNotification(
 		if (status == null) {
 			throw new InvalidPushNotificationException("알림 상태가 필요합니다.");
 		}
+		if (status != PushNotificationStatus.FAILED && failureReason != null) {
+			throw new InvalidPushNotificationException("실패하지 않은 알림에는 실패 사유를 둘 수 없습니다.");
+		}
 		if (createdAt == null) {
 			throw new InvalidPushNotificationException("알림 생성 시간이 필요합니다.");
 		}
@@ -47,6 +57,20 @@ public record PushNotification(
 		deviceToken = deviceToken.trim();
 		title = title.trim();
 		body = body.trim();
+	}
+
+	public PushNotification(
+		String notificationId,
+		String userId,
+		DevicePlatform platform,
+		String deviceToken,
+		PushNotificationType type,
+		String title,
+		String body,
+		PushNotificationStatus status,
+		LocalDateTime createdAt
+	) {
+		this(notificationId, userId, platform, deviceToken, type, title, body, status, null, createdAt);
 	}
 
 	public PushNotification withStatus(PushNotificationStatus nextStatus) {
@@ -59,6 +83,25 @@ public record PushNotification(
 			title,
 			body,
 			nextStatus,
+			null,
+			createdAt
+		);
+	}
+
+	public PushNotification withSendResult(PushNotificationSendResult sendResult) {
+		PushNotificationStatus nextStatus = sendResult.successful()
+			? PushNotificationStatus.SENT
+			: PushNotificationStatus.FAILED;
+		return new PushNotification(
+			notificationId,
+			userId,
+			platform,
+			deviceToken,
+			type,
+			title,
+			body,
+			nextStatus,
+			sendResult.failureReason(),
 			createdAt
 		);
 	}

--- a/backend/src/main/java/com/easysubway/notification/domain/PushNotificationDashboardSummary.java
+++ b/backend/src/main/java/com/easysubway/notification/domain/PushNotificationDashboardSummary.java
@@ -4,15 +4,31 @@ public record PushNotificationDashboardSummary(
 	long totalCount,
 	long pendingCount,
 	long sentCount,
-	long failedCount
+	long failedCount,
+	String latestFailureReason
 ) {
 
 	public PushNotificationDashboardSummary {
+		if (latestFailureReason != null) {
+			latestFailureReason = latestFailureReason.trim();
+			if (latestFailureReason.isBlank()) {
+				latestFailureReason = null;
+			}
+		}
 		if (totalCount < 0 || pendingCount < 0 || sentCount < 0 || failedCount < 0) {
 			throw new InvalidPushNotificationException("알림 집계 수는 0 이상이어야 합니다.");
 		}
 		if (totalCount != pendingCount + sentCount + failedCount) {
 			throw new InvalidPushNotificationException("전체 알림 수와 상태별 알림 수가 일치하지 않습니다.");
 		}
+	}
+
+	public PushNotificationDashboardSummary(
+		long totalCount,
+		long pendingCount,
+		long sentCount,
+		long failedCount
+	) {
+		this(totalCount, pendingCount, sentCount, failedCount, null);
 	}
 }

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -286,11 +286,16 @@ CREATE TABLE IF NOT EXISTS push_notification_outbox (
 	CONSTRAINT chk_push_notification_outbox_type
 		CHECK (notification_type IN ('FAVORITE_STATION_FACILITY', 'FAVORITE_ROUTE_FACILITY', 'REPORT_STATUS', 'DATA_QUALITY')),
 	CONSTRAINT chk_push_notification_outbox_status
-		CHECK (status IN ('PENDING', 'SENT', 'FAILED'))
+		CHECK (status IN ('PENDING', 'SENT', 'FAILED')),
+	CONSTRAINT chk_push_notification_outbox_failure_reason
+		CHECK (failure_reason IS NULL OR status = 'FAILED')
 );
 
 ALTER TABLE push_notification_outbox
 	DROP CONSTRAINT IF EXISTS chk_push_notification_outbox_status;
+
+ALTER TABLE push_notification_outbox
+	DROP CONSTRAINT IF EXISTS chk_push_notification_outbox_failure_reason;
 
 ALTER TABLE push_notification_outbox
 	ADD COLUMN IF NOT EXISTS failure_reason VARCHAR(1000);
@@ -298,6 +303,10 @@ ALTER TABLE push_notification_outbox
 ALTER TABLE push_notification_outbox
 	ADD CONSTRAINT chk_push_notification_outbox_status
 		CHECK (status IN ('PENDING', 'SENT', 'FAILED'));
+
+ALTER TABLE push_notification_outbox
+	ADD CONSTRAINT chk_push_notification_outbox_failure_reason
+		CHECK (failure_reason IS NULL OR status = 'FAILED');
 
 CREATE INDEX IF NOT EXISTS idx_push_notification_outbox_user_created
 	ON push_notification_outbox (user_id, created_at ASC, notification_id ASC);

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -279,6 +279,7 @@ CREATE TABLE IF NOT EXISTS push_notification_outbox (
 	title VARCHAR(120) NOT NULL,
 	body VARCHAR(1000) NOT NULL,
 	status VARCHAR(40) NOT NULL,
+	failure_reason VARCHAR(1000),
 	created_at TIMESTAMP NOT NULL,
 	CONSTRAINT chk_push_notification_outbox_platform
 		CHECK (platform IN ('ANDROID', 'IOS')),
@@ -290,6 +291,9 @@ CREATE TABLE IF NOT EXISTS push_notification_outbox (
 
 ALTER TABLE push_notification_outbox
 	DROP CONSTRAINT IF EXISTS chk_push_notification_outbox_status;
+
+ALTER TABLE push_notification_outbox
+	ADD COLUMN IF NOT EXISTS failure_reason VARCHAR(1000);
 
 ALTER TABLE push_notification_outbox
 	ADD CONSTRAINT chk_push_notification_outbox_status

--- a/backend/src/main/resources/templates/admin/notifications/push.html
+++ b/backend/src/main/resources/templates/admin/notifications/push.html
@@ -58,6 +58,16 @@
 			line-height: 1.15;
 		}
 
+		.failure-reason {
+			margin: -8px 0 24px;
+			padding: 14px 18px;
+			background: #fff7ed;
+			border: 1px solid #fed7aa;
+			color: #7c2d12;
+			font-weight: 800;
+			line-height: 1.45;
+		}
+
 		section {
 			background: #fff;
 			border: 1px solid #d8e0e0;
@@ -112,6 +122,10 @@
 			<strong th:text="${summary.failedCount}">0</strong>
 		</div>
 	</div>
+
+	<p class="failure-reason"
+	   th:if="${summary.latestFailureReason != null}"
+	   th:text="'최근 실패: ' + ${summary.latestFailureReason}">최근 실패: 외부 푸시 발송 어댑터가 설정되지 않았습니다.</p>
 
 	<section>
 		<h2>상태별 알림</h2>

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageControllerTest.java
@@ -55,6 +55,7 @@ class PushNotificationAdminPageControllerTest {
 			.contains("아직 발송 처리 전")
 			.contains("외부 발송 성공")
 			.contains("발송 어댑터 실패 또는 예외")
+			.contains("최근 실패: 외부 푸시 발송 어댑터가 설정되지 않았습니다.")
 			.doesNotContain("secret-device-token");
 	}
 

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
@@ -41,7 +41,8 @@ class JdbcPushNotificationOutboxRepositoryTest {
 				created_at TIMESTAMP NOT NULL,
 				CONSTRAINT chk_push_notification_outbox_platform CHECK (platform IN ('ANDROID', 'IOS')),
 				CONSTRAINT chk_push_notification_outbox_type CHECK (notification_type IN ('FAVORITE_STATION_FACILITY', 'FAVORITE_ROUTE_FACILITY', 'REPORT_STATUS', 'DATA_QUALITY')),
-				CONSTRAINT chk_push_notification_outbox_status CHECK (status IN ('PENDING', 'SENT', 'FAILED'))
+				CONSTRAINT chk_push_notification_outbox_status CHECK (status IN ('PENDING', 'SENT', 'FAILED')),
+				CONSTRAINT chk_push_notification_outbox_failure_reason CHECK (failure_reason IS NULL OR status = 'FAILED')
 			)
 			""");
 		repository = new JdbcPushNotificationOutboxRepository(jdbcTemplate);
@@ -130,11 +131,11 @@ class JdbcPushNotificationOutboxRepositoryTest {
 			PushNotificationStatus.SENT,
 			11
 		));
-		repository.savePushNotification(notification(
+		repository.savePushNotification(failedNotification(
 			"push-4",
 			"anonymous-user-3",
 			PushNotificationType.FAVORITE_STATION_FACILITY,
-			PushNotificationStatus.FAILED,
+			"외부 발송 어댑터가 설정되지 않았습니다.",
 			12
 		));
 
@@ -144,6 +145,7 @@ class JdbcPushNotificationOutboxRepositoryTest {
 		assertThat(summary.pendingCount()).isEqualTo(2);
 		assertThat(summary.sentCount()).isEqualTo(1);
 		assertThat(summary.failedCount()).isEqualTo(1);
+		assertThat(summary.latestFailureReason()).isEqualTo("외부 발송 어댑터가 설정되지 않았습니다.");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
@@ -37,6 +37,7 @@ class JdbcPushNotificationOutboxRepositoryTest {
 				title VARCHAR(120) NOT NULL,
 				body VARCHAR(1000) NOT NULL,
 				status VARCHAR(40) NOT NULL,
+				failure_reason VARCHAR(1000),
 				created_at TIMESTAMP NOT NULL,
 				CONSTRAINT chk_push_notification_outbox_platform CHECK (platform IN ('ANDROID', 'IOS')),
 				CONSTRAINT chk_push_notification_outbox_type CHECK (notification_type IN ('FAVORITE_STATION_FACILITY', 'FAVORITE_ROUTE_FACILITY', 'REPORT_STATUS', 'DATA_QUALITY')),
@@ -74,6 +75,23 @@ class JdbcPushNotificationOutboxRepositoryTest {
 		repository.savePushNotification(updatedNotification);
 
 		assertThat(repository.loadPushNotifications("anonymous-user-1")).containsExactly(updatedNotification);
+	}
+
+	@Test
+	@DisplayName("실패한 푸시 알림은 실패 사유를 저장하고 조회한다")
+	void savePushNotificationStoresFailureReasonForFailedNotification() {
+		var failedNotification = failedNotification(
+			"push-1",
+			"anonymous-user-1",
+			PushNotificationType.REPORT_STATUS,
+			"외부 발송 어댑터가 설정되지 않았습니다.",
+			9
+		);
+
+		repository.savePushNotification(failedNotification);
+
+		assertThat(repository.loadPushNotifications("anonymous-user-1"))
+			.containsExactly(failedNotification);
 	}
 
 	@Test
@@ -170,6 +188,27 @@ class JdbcPushNotificationOutboxRepositoryTest {
 			"알림 제목 " + notificationId,
 			"알림 본문 " + notificationId,
 			status,
+			LocalDateTime.of(2026, 6, 17, hour, 0)
+		);
+	}
+
+	private PushNotification failedNotification(
+		String notificationId,
+		String userId,
+		PushNotificationType type,
+		String failureReason,
+		int hour
+	) {
+		return new PushNotification(
+			notificationId,
+			userId,
+			DevicePlatform.ANDROID,
+			"device-token-" + notificationId,
+			type,
+			"알림 제목 " + notificationId,
+			"알림 본문 " + notificationId,
+			PushNotificationStatus.FAILED,
+			failureReason,
 			LocalDateTime.of(2026, 6, 17, hour, 0)
 		);
 	}

--- a/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDeliveryServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDeliveryServiceTest.java
@@ -52,7 +52,7 @@ class PushNotificationDeliveryServiceTest {
 
 	@Test
 	@DisplayName("sender가 실패한 알림은 실패 상태로 저장한다")
-	void deliverPendingNotificationsMarksFailedWhenSenderFails() {
+	void deliverPendingNotificationsMarksFailedWithFailureReasonWhenSenderFails() {
 		outboxRepository.savePushNotification(notification("push-1", PushNotificationStatus.PENDING));
 		sender.nextResult = PushNotificationSendResult.failed("외부 발송 어댑터가 설정되지 않았습니다.");
 
@@ -62,8 +62,8 @@ class PushNotificationDeliveryServiceTest {
 		assertThat(result.failedCount()).isEqualTo(1);
 		assertThat(result.processedCount()).isEqualTo(1);
 		assertThat(outboxRepository.loadPushNotifications("anonymous-user-1"))
-			.extracting("notificationId", "status")
-			.containsExactly(tuple("push-1", PushNotificationStatus.FAILED));
+			.extracting("notificationId", "status", "failureReason")
+			.containsExactly(tuple("push-1", PushNotificationStatus.FAILED, "외부 발송 어댑터가 설정되지 않았습니다."));
 	}
 
 	@Test
@@ -101,10 +101,10 @@ class PushNotificationDeliveryServiceTest {
 		assertThat(result.processedCount()).isEqualTo(2);
 		assertThat(sender.sentNotifications).extracting("notificationId").containsExactly("push-1", "push-2");
 		assertThat(outboxRepository.loadPushNotifications("anonymous-user-1"))
-			.extracting("notificationId", "status")
+			.extracting("notificationId", "status", "failureReason")
 			.containsExactly(
-				tuple("push-1", PushNotificationStatus.FAILED),
-				tuple("push-2", PushNotificationStatus.SENT)
+				tuple("push-1", PushNotificationStatus.FAILED, "푸시 발송 중 예외가 발생했습니다."),
+				tuple("push-2", PushNotificationStatus.SENT, null)
 			);
 	}
 
@@ -130,8 +130,8 @@ class PushNotificationDeliveryServiceTest {
 		);
 	}
 
-	private static org.assertj.core.groups.Tuple tuple(String notificationId, PushNotificationStatus status) {
-		return org.assertj.core.api.Assertions.tuple(notificationId, status);
+	private static org.assertj.core.groups.Tuple tuple(Object... values) {
+		return org.assertj.core.api.Assertions.tuple(values);
 	}
 
 	private static class RecordingPushNotificationSender implements PushNotificationSenderPort {

--- a/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDeliveryServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDeliveryServiceTest.java
@@ -103,7 +103,7 @@ class PushNotificationDeliveryServiceTest {
 		assertThat(outboxRepository.loadPushNotifications("anonymous-user-1"))
 			.extracting("notificationId", "status", "failureReason")
 			.containsExactly(
-				tuple("push-1", PushNotificationStatus.FAILED, "푸시 발송 중 예외가 발생했습니다."),
+				tuple("push-1", PushNotificationStatus.FAILED, "푸시 발송 실패"),
 				tuple("push-2", PushNotificationStatus.SENT, null)
 			);
 	}

--- a/backend/src/test/java/com/easysubway/notification/domain/PushNotificationTest.java
+++ b/backend/src/test/java/com/easysubway/notification/domain/PushNotificationTest.java
@@ -1,0 +1,32 @@
+package com.easysubway.notification.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("푸시 알림")
+class PushNotificationTest {
+
+	@Test
+	@DisplayName("실패 사유는 저장 가능한 최대 길이로 보존한다")
+	void failureReasonIsTrimmedToPersistenceLimit() {
+		String longFailureReason = "가".repeat(1001);
+
+		var notification = new PushNotification(
+			"push-1",
+			"anonymous-user-1",
+			DevicePlatform.ANDROID,
+			"device-token",
+			PushNotificationType.REPORT_STATUS,
+			"신고 처리 알림",
+			"제보한 내용이 확인되었습니다.",
+			PushNotificationStatus.FAILED,
+			longFailureReason,
+			LocalDateTime.of(2026, 6, 17, 10, 0)
+		);
+
+		assertThat(notification.failureReason()).hasSize(1000);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1272,6 +1272,7 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
 
   assert.match(notification, /record PushNotification/);
   assert.match(notification, /deviceToken/);
+  assert.match(notification, /failureReason/);
   assert.match(notification, /PushNotificationStatus/);
   assert.match(result, /record PushNotificationDispatchResult/);
   assert.match(dashboardSummary, /record PushNotificationDashboardSummary/);
@@ -1306,6 +1307,7 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   assert.match(jdbcRepository, /PushNotificationDashboardSummary summarizePushNotificationOutbox\(\)/);
   assert.match(jdbcRepository, /int deletePushNotifications\(String userId\)/);
   assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS push_notification_outbox/);
+  assert.match(batchPostgresSchema, /failure_reason VARCHAR\(1000\)/);
   assert.match(batchPostgresSchema, /CONSTRAINT chk_push_notification_outbox_platform/);
   assert.match(batchPostgresSchema, /CONSTRAINT chk_push_notification_outbox_type/);
   assert.match(batchPostgresSchema, /CONSTRAINT chk_push_notification_outbox_status/);
@@ -1318,6 +1320,7 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   assert.match(dashboardTemplate, /푸시 알림 현황/);
   assert.match(dashboardTemplate, /전체 알림/);
   assert.match(dashboardTemplate, /상태별 알림/);
+  assert.match(dashboardTemplate, /최근 실패/);
   assert.doesNotMatch(dashboardTemplate, /deviceToken/);
   assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
 });

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1311,6 +1311,8 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   assert.match(batchPostgresSchema, /CONSTRAINT chk_push_notification_outbox_platform/);
   assert.match(batchPostgresSchema, /CONSTRAINT chk_push_notification_outbox_type/);
   assert.match(batchPostgresSchema, /CONSTRAINT chk_push_notification_outbox_status/);
+  assert.match(batchPostgresSchema, /CONSTRAINT chk_push_notification_outbox_failure_reason/);
+  assert.match(batchPostgresSchema, /failure_reason IS NULL OR status = 'FAILED'/);
   assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_push_notification_outbox_user_created/);
   assert.match(controller, /@PostMapping\("\/admin\/notifications\/push"\)/);
   assert.match(controller, /PushNotificationDispatchUseCase/);


### PR DESCRIPTION
## 관련 이슈

close #324

## 작업 배경

- 푸시 알림은 시설 상태 변경, 신고 처리 결과, 데이터 품질 갱신을 사용자에게 전달하는 운영 흐름입니다.
- 발송 실패가 `FAILED` 상태와 건수로만 남으면 외부 발송 어댑터 미설정, 발송 예외, provider 오류를 운영자가 구분하기 어렵습니다.

## 작업 내용

- `PushNotification`에 실패 사유 필드를 추가하고, 성공/대기 상태에는 실패 사유가 남지 않도록 검증했습니다.
- 푸시 발송 처리에서 sender 실패 결과와 예외 메시지를 outbox 실패 사유로 저장하도록 연결했습니다.
- JDBC outbox 저장소와 PostgreSQL schema에 `failure_reason`을 추가하고 저장/조회/요약 경로를 반영했습니다.
- 실패 사유는 저장 가능한 길이로 정규화하고, DB에서도 실패 상태에만 사유를 둘 수 있도록 제약을 추가했습니다.
- 관리자 푸시 알림 현황 화면에 최근 실패 사유를 노출했습니다.
- 서비스, JDBC 저장소, 관리자 화면, repository contract 테스트로 계약을 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests '*PushNotificationDeliveryServiceTest*' --tests '*JdbcPushNotificationOutboxRepositoryTest*' --tests '*PushNotificationAdminPageControllerTest*'`: RED 실패 확인 후 구현 뒤 통과
  - `./gradlew test --tests '*PushNotificationTest*' --tests '*PushNotificationDeliveryServiceTest*' --tests '*JdbcPushNotificationOutboxRepositoryTest*'`: CodeRabbit 리뷰 반영 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 최초 실패 확인 후 contract 보강 뒤 통과, 41개 테스트
  - `./gradlew test`: 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md docs/agent/push-notification-failure-reason.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - GitHub Actions CI: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 모두 통과
  - Merge 후 main CI: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 모두 통과
  - Merge 후 CD: CD Readiness 통과

## 리뷰어 메모

- `PushNotification.withSendResult`가 성공 시 실패 사유를 비우고, 실패 시 sender의 사유를 보존하는지 먼저 확인해 주세요.
- 관리자 화면은 상세 목록이 아니라 현황 페이지의 최근 실패 사유만 보여주는 범위입니다.

## 리스크

- 운영 DB에는 `failure_reason` 컬럼과 상태-실패 사유 정합성 제약이 추가됩니다. 기존 행은 null로 유지됩니다.
- 실제 FCM/APNs provider 연동이나 재시도 스케줄러는 이번 범위에 포함하지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (해당 없음: CodeRabbit 리뷰 완료)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
