### PR TITLE
[Feat] 관리자 경로 검색 지역별 사용량 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageController.java
@@ -28,7 +28,8 @@ class RouteSearchAdminPageController {
 		long totalCount,
 		long foundCount,
 		long blockedCount,
-		List<MobilityTypeCountRow> mobilityTypeRows
+		List<MobilityTypeCountRow> mobilityTypeRows,
+		List<RegionUsageCountRow> regionUsageRows
 	) {
 
 		static RouteSearchDashboardView from(RouteSearchDashboardSummary summary) {
@@ -39,12 +40,19 @@ class RouteSearchAdminPageController {
 				summary.mobilityTypeCounts()
 					.stream()
 					.map(row -> new MobilityTypeCountRow(mobilityTypeLabel(row.mobilityType()), row.count()))
+					.toList(),
+				summary.regionUsageCounts()
+					.stream()
+					.map(row -> new RegionUsageCountRow(row.region(), row.originCount(), row.destinationCount()))
 					.toList()
 			);
 		}
 	}
 
 	record MobilityTypeCountRow(String label, long count) {
+	}
+
+	record RegionUsageCountRow(String region, long originCount, long destinationCount) {
 	}
 
 	private static String mobilityTypeLabel(MobilityType mobilityType) {

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
@@ -6,6 +6,7 @@ import com.easysubway.route.application.port.out.SaveRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
 import com.easysubway.route.application.port.out.SummarizeRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort;
+import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchStationPair;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
 import com.easysubway.route.domain.RouteFeedbackRating;
@@ -91,9 +92,15 @@ public class InMemoryRouteSearchRepository
 	}
 
 	@Override
-	public List<RouteSearchResult> loadRouteSearchesForDashboard() {
+	public List<RouteSearchStationPair> loadRouteSearchStationPairsForDashboard() {
 		synchronized (routeSearches) {
-			return List.copyOf(routeSearches.values());
+			return routeSearches.values()
+				.stream()
+				.map(routeSearch -> new RouteSearchStationPair(
+					routeSearch.originStationId(),
+					routeSearch.destinationStationId()
+				))
+				.toList();
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
@@ -91,6 +91,13 @@ public class InMemoryRouteSearchRepository
 	}
 
 	@Override
+	public List<RouteSearchResult> loadRouteSearchesForDashboard() {
+		synchronized (routeSearches) {
+			return List.copyOf(routeSearches.values());
+		}
+	}
+
+	@Override
 	public int anonymizeRouteFeedbacksByUserId(String userId) {
 		synchronized (routeFeedbacks) {
 			int anonymizedCount = 0;

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
@@ -6,6 +6,7 @@ import com.easysubway.route.application.port.out.SaveRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
 import com.easysubway.route.application.port.out.SummarizeRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort;
+import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchStationPair;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
 import com.easysubway.route.domain.RouteSearchDashboardSummary;
@@ -153,27 +154,18 @@ public class JdbcRouteSearchRepository
 	}
 
 	@Override
-	public List<RouteSearchResult> loadRouteSearchesForDashboard() {
+	public List<RouteSearchStationPair> loadRouteSearchStationPairsForDashboard() {
 		return jdbcTemplate.query(
 			"""
-				SELECT route_search_id,
-					origin_station_id,
-					origin_station_name,
-					destination_station_id,
-					destination_station_name,
-					mobility_type,
-					status,
-					line_id,
-					line_name,
-					score,
-					steps_json,
-					warnings_json,
-					blocked_reasons_json,
-					created_at
+				SELECT origin_station_id,
+					destination_station_id
 				FROM route_search_results
 				ORDER BY created_at DESC, route_search_id
 				""",
-			this::mapRouteSearchResult
+			(resultSet, rowNumber) -> new RouteSearchStationPair(
+				resultSet.getString("origin_station_id"),
+				resultSet.getString("destination_station_id")
+			)
 		);
 	}
 

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
@@ -153,6 +153,31 @@ public class JdbcRouteSearchRepository
 	}
 
 	@Override
+	public List<RouteSearchResult> loadRouteSearchesForDashboard() {
+		return jdbcTemplate.query(
+			"""
+				SELECT route_search_id,
+					origin_station_id,
+					origin_station_name,
+					destination_station_id,
+					destination_station_name,
+					mobility_type,
+					status,
+					line_id,
+					line_name,
+					score,
+					steps_json,
+					warnings_json,
+					blocked_reasons_json,
+					created_at
+				FROM route_search_results
+				ORDER BY created_at DESC, route_search_id
+				""",
+			this::mapRouteSearchResult
+		);
+	}
+
+	@Override
 	public int anonymizeRouteFeedbacksByUserId(String userId) {
 		return jdbcTemplate.update(
 			"""

--- a/backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteSearchPort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteSearchPort.java
@@ -1,12 +1,14 @@
 package com.easysubway.route.application.port.out;
 
 import com.easysubway.route.domain.RouteSearchDashboardSummary;
-import com.easysubway.route.domain.RouteSearchResult;
 import java.util.List;
 
 public interface SummarizeRouteSearchPort {
 
 	RouteSearchDashboardSummary summarizeRouteSearches();
 
-	List<RouteSearchResult> loadRouteSearchesForDashboard();
+	List<RouteSearchStationPair> loadRouteSearchStationPairsForDashboard();
+
+	record RouteSearchStationPair(String originStationId, String destinationStationId) {
+	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteSearchPort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteSearchPort.java
@@ -1,8 +1,12 @@
 package com.easysubway.route.application.port.out;
 
 import com.easysubway.route.domain.RouteSearchDashboardSummary;
+import com.easysubway.route.domain.RouteSearchResult;
+import java.util.List;
 
 public interface SummarizeRouteSearchPort {
 
 	RouteSearchDashboardSummary summarizeRouteSearches();
+
+	List<RouteSearchResult> loadRouteSearchesForDashboard();
 }

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchDashboardService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchDashboardService.java
@@ -2,9 +2,9 @@ package com.easysubway.route.application.service;
 
 import com.easysubway.route.application.port.in.RouteSearchDashboardUseCase;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort;
+import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchStationPair;
 import com.easysubway.route.domain.RouteSearchDashboardSummary;
 import com.easysubway.route.domain.RouteSearchDashboardSummary.RegionUsageCount;
-import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.transit.domain.Station;
 import java.util.Comparator;
@@ -38,18 +38,19 @@ public class RouteSearchDashboardService implements RouteSearchDashboardUseCase 
 			summary.foundCount(),
 			summary.blockedCount(),
 			summary.mobilityTypeCounts(),
-			regionUsageCounts(summarizeRouteSearchPort.loadRouteSearchesForDashboard())
+			regionUsageCounts(summarizeRouteSearchPort.loadRouteSearchStationPairsForDashboard())
 		);
 	}
 
-	private List<RegionUsageCount> regionUsageCounts(List<RouteSearchResult> routeSearches) {
+	private List<RegionUsageCount> regionUsageCounts(List<RouteSearchStationPair> stationPairs) {
 		Map<String, String> stationRegionsById = loadTransitMasterPort.loadStations()
 			.stream()
+			.filter(station -> station.region() != null && !station.region().isBlank())
 			.collect(Collectors.toMap(Station::id, Station::region));
 		Map<String, MutableRegionUsageCount> countsByRegion = new HashMap<>();
-		for (RouteSearchResult routeSearch : routeSearches) {
-			countOriginRegion(stationRegionsById.get(routeSearch.originStationId()), countsByRegion);
-			countDestinationRegion(stationRegionsById.get(routeSearch.destinationStationId()), countsByRegion);
+		for (RouteSearchStationPair stationPair : stationPairs) {
+			countOriginRegion(stationRegionsById.get(stationPair.originStationId()), countsByRegion);
+			countDestinationRegion(stationRegionsById.get(stationPair.destinationStationId()), countsByRegion);
 		}
 		return countsByRegion.values()
 			.stream()

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchDashboardService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchDashboardService.java
@@ -3,19 +3,100 @@ package com.easysubway.route.application.service;
 import com.easysubway.route.application.port.in.RouteSearchDashboardUseCase;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort;
 import com.easysubway.route.domain.RouteSearchDashboardSummary;
+import com.easysubway.route.domain.RouteSearchDashboardSummary.RegionUsageCount;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.domain.Station;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class RouteSearchDashboardService implements RouteSearchDashboardUseCase {
 
 	private final SummarizeRouteSearchPort summarizeRouteSearchPort;
+	private final LoadTransitMasterPort loadTransitMasterPort;
 
-	public RouteSearchDashboardService(SummarizeRouteSearchPort summarizeRouteSearchPort) {
+	@Autowired
+	public RouteSearchDashboardService(
+		SummarizeRouteSearchPort summarizeRouteSearchPort,
+		LoadTransitMasterPort loadTransitMasterPort
+	) {
 		this.summarizeRouteSearchPort = summarizeRouteSearchPort;
+		this.loadTransitMasterPort = loadTransitMasterPort;
 	}
 
 	@Override
 	public RouteSearchDashboardSummary summarizeRouteSearches() {
-		return summarizeRouteSearchPort.summarizeRouteSearches();
+		RouteSearchDashboardSummary summary = summarizeRouteSearchPort.summarizeRouteSearches();
+		return new RouteSearchDashboardSummary(
+			summary.totalCount(),
+			summary.foundCount(),
+			summary.blockedCount(),
+			summary.mobilityTypeCounts(),
+			regionUsageCounts(summarizeRouteSearchPort.loadRouteSearchesForDashboard())
+		);
+	}
+
+	private List<RegionUsageCount> regionUsageCounts(List<RouteSearchResult> routeSearches) {
+		Map<String, String> stationRegionsById = loadTransitMasterPort.loadStations()
+			.stream()
+			.collect(Collectors.toMap(Station::id, Station::region));
+		Map<String, MutableRegionUsageCount> countsByRegion = new HashMap<>();
+		for (RouteSearchResult routeSearch : routeSearches) {
+			countOriginRegion(stationRegionsById.get(routeSearch.originStationId()), countsByRegion);
+			countDestinationRegion(stationRegionsById.get(routeSearch.destinationStationId()), countsByRegion);
+		}
+		return countsByRegion.values()
+			.stream()
+			.map(MutableRegionUsageCount::toRegionUsageCount)
+			.sorted(Comparator
+				.comparingLong((RegionUsageCount row) -> row.originCount() + row.destinationCount())
+				.reversed()
+				.thenComparing(RegionUsageCount::region))
+			.toList();
+	}
+
+	private void countOriginRegion(String region, Map<String, MutableRegionUsageCount> countsByRegion) {
+		if (region == null || region.isBlank()) {
+			return;
+		}
+		countsByRegion.computeIfAbsent(region, MutableRegionUsageCount::new)
+			.incrementOriginCount();
+	}
+
+	private void countDestinationRegion(String region, Map<String, MutableRegionUsageCount> countsByRegion) {
+		if (region == null || region.isBlank()) {
+			return;
+		}
+		countsByRegion.computeIfAbsent(region, MutableRegionUsageCount::new)
+			.incrementDestinationCount();
+	}
+
+	private static final class MutableRegionUsageCount {
+
+		private final String region;
+		private long originCount;
+		private long destinationCount;
+
+		private MutableRegionUsageCount(String region) {
+			this.region = region;
+		}
+
+		private void incrementOriginCount() {
+			originCount++;
+		}
+
+		private void incrementDestinationCount() {
+			destinationCount++;
+		}
+
+		private RegionUsageCount toRegionUsageCount() {
+			return new RegionUsageCount(region, originCount, destinationCount);
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/domain/RouteSearchDashboardSummary.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteSearchDashboardSummary.java
@@ -7,8 +7,18 @@ public record RouteSearchDashboardSummary(
 	long totalCount,
 	long foundCount,
 	long blockedCount,
-	List<MobilityTypeCount> mobilityTypeCounts
+	List<MobilityTypeCount> mobilityTypeCounts,
+	List<RegionUsageCount> regionUsageCounts
 ) {
+
+	public RouteSearchDashboardSummary(
+		long totalCount,
+		long foundCount,
+		long blockedCount,
+		List<MobilityTypeCount> mobilityTypeCounts
+	) {
+		this(totalCount, foundCount, blockedCount, mobilityTypeCounts, List.of());
+	}
 
 	public RouteSearchDashboardSummary {
 		if (totalCount < 0 || foundCount < 0 || blockedCount < 0) {
@@ -24,6 +34,7 @@ public record RouteSearchDashboardSummary(
 		if (totalCount != mobilityTotalCount) {
 			throw new InvalidRouteSearchException("전체 경로 검색 수와 이동 프로필별 검색 수가 일치하지 않습니다.");
 		}
+		regionUsageCounts = List.copyOf(regionUsageCounts);
 	}
 
 	public record MobilityTypeCount(MobilityType mobilityType, long count) {
@@ -34,6 +45,18 @@ public record RouteSearchDashboardSummary(
 			}
 			if (count < 0) {
 				throw new InvalidRouteSearchException("이동 프로필별 경로 검색 수는 0 이상이어야 합니다.");
+			}
+		}
+	}
+
+	public record RegionUsageCount(String region, long originCount, long destinationCount) {
+
+		public RegionUsageCount {
+			if (region == null || region.isBlank()) {
+				throw new InvalidRouteSearchException("지역별 경로 검색 집계에는 지역명이 필요합니다.");
+			}
+			if (originCount < 0 || destinationCount < 0) {
+				throw new InvalidRouteSearchException("지역별 경로 검색 수는 0 이상이어야 합니다.");
 			}
 		}
 	}

--- a/backend/src/main/resources/templates/admin/routes/searches.html
+++ b/backend/src/main/resources/templates/admin/routes/searches.html
@@ -61,6 +61,7 @@
 		section {
 			background: #fff;
 			border: 1px solid #d8e0e0;
+			margin-top: 18px;
 		}
 
 		table {
@@ -122,6 +123,26 @@
 			<tr th:each="row : ${summary.mobilityTypeRows}">
 				<td th:text="${row.label}">고령자</td>
 				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>지역별 사용량</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">지역</th>
+				<th scope="col">출발 검색</th>
+				<th scope="col">도착 검색</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.regionUsageRows}">
+				<td th:text="${row.region}">수도권</td>
+				<td th:text="${row.originCount}">0</td>
+				<td th:text="${row.destinationCount}">0</td>
 			</tr>
 			</tbody>
 		</table>

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageControllerTest.java
@@ -52,6 +52,11 @@ class RouteSearchAdminPageControllerTest {
 			.contains("이동 프로필별 검색")
 			.contains("고령자")
 			.contains("휠체어 사용자")
+			.contains("지역별 사용량")
+			.contains("지역")
+			.contains("출발 검색")
+			.contains("도착 검색")
+			.contains("수도권")
 			.doesNotContain("routeSearchId")
 			.doesNotContain("station-sangnoksu");
 	}

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.easysubway.route.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.domain.RouteSearchResult;
@@ -25,10 +26,9 @@ class InMemoryRouteSearchRepositoryTest {
 		assertThat(repository.loadRouteSearch("route-0")).isEmpty();
 		assertThat(repository.loadRouteSearch("route-" + InMemoryRouteSearchRepository.MAX_STORED_ROUTE_SEARCHES))
 			.isPresent();
-		assertThat(repository.loadRouteSearchesForDashboard())
-			.extracting(RouteSearchResult::routeSearchId)
-			.doesNotContain("route-0")
-			.contains("route-" + InMemoryRouteSearchRepository.MAX_STORED_ROUTE_SEARCHES);
+		assertThat(repository.loadRouteSearchStationPairsForDashboard())
+			.extracting("originStationId", "destinationStationId")
+			.contains(tuple("station-a", "station-b"));
 	}
 
 	private RouteSearchResult routeSearchResult(String routeSearchId) {

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepositoryTest.java
@@ -25,6 +25,10 @@ class InMemoryRouteSearchRepositoryTest {
 		assertThat(repository.loadRouteSearch("route-0")).isEmpty();
 		assertThat(repository.loadRouteSearch("route-" + InMemoryRouteSearchRepository.MAX_STORED_ROUTE_SEARCHES))
 			.isPresent();
+		assertThat(repository.loadRouteSearchesForDashboard())
+			.extracting(RouteSearchResult::routeSearchId)
+			.doesNotContain("route-0")
+			.contains("route-" + InMemoryRouteSearchRepository.MAX_STORED_ROUTE_SEARCHES);
 	}
 
 	private RouteSearchResult routeSearchResult(String routeSearchId) {

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
@@ -193,9 +193,13 @@ class JdbcRouteSearchRepositoryTest {
 				tuple(MobilityType.SENIOR, 2L),
 				tuple(MobilityType.WHEELCHAIR, 1L)
 			);
-		assertThat(repository.loadRouteSearchesForDashboard())
-			.extracting(RouteSearchResult::routeSearchId)
-			.containsExactlyInAnyOrder("route-search-1", "route-search-2", "route-search-3");
+		assertThat(repository.loadRouteSearchStationPairsForDashboard())
+			.extracting("originStationId", "destinationStationId")
+			.containsExactlyInAnyOrder(
+				tuple("station-sangnoksu", "station-sadang"),
+				tuple("station-origin", "station-destination"),
+				tuple("station-origin", "station-destination")
+			);
 	}
 
 	private RouteSearchResult directRouteSearch(

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
@@ -193,6 +193,9 @@ class JdbcRouteSearchRepositoryTest {
 				tuple(MobilityType.SENIOR, 2L),
 				tuple(MobilityType.WHEELCHAIR, 1L)
 			);
+		assertThat(repository.loadRouteSearchesForDashboard())
+			.extracting(RouteSearchResult::routeSearchId)
+			.containsExactlyInAnyOrder("route-search-1", "route-search-2", "route-search-3");
 	}
 
 	private RouteSearchResult directRouteSearch(

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchDashboardServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchDashboardServiceTest.java
@@ -7,6 +7,17 @@ import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationExit;
+import com.easysubway.transit.domain.StationLine;
+import com.easysubway.transit.domain.SubwayLine;
+import com.easysubway.transit.domain.TransitOperator;
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +33,7 @@ class RouteSearchDashboardServiceTest {
 		repository.saveRouteSearch(routeSearch("route-search-1", MobilityType.SENIOR, RouteSearchStatus.FOUND));
 		repository.saveRouteSearch(routeSearch("route-search-2", MobilityType.WHEELCHAIR, RouteSearchStatus.FOUND));
 		repository.saveRouteSearch(routeSearch("route-search-3", MobilityType.WHEELCHAIR, RouteSearchStatus.BLOCKED));
-		var service = new RouteSearchDashboardService(repository);
+		var service = new RouteSearchDashboardService(repository, new FakeTransitMasterPort());
 
 		var summary = service.summarizeRouteSearches();
 
@@ -37,17 +48,80 @@ class RouteSearchDashboardServiceTest {
 			);
 	}
 
+	@Test
+	@DisplayName("출발역과 도착역의 지역 기준으로 검색 사용량을 집계한다")
+	void summarizeRouteSearchesByOriginAndDestinationRegion() {
+		var repository = new InMemoryRouteSearchRepository();
+		repository.saveRouteSearch(routeSearch(
+			"route-search-1",
+			MobilityType.SENIOR,
+			RouteSearchStatus.FOUND,
+			"station-sangnoksu",
+			"상록수",
+			"station-sadang",
+			"사당"
+		));
+		repository.saveRouteSearch(routeSearch(
+			"route-search-2",
+			MobilityType.WHEELCHAIR,
+			RouteSearchStatus.FOUND,
+			"station-busan",
+			"부산",
+			"station-sangnoksu",
+			"상록수"
+		));
+		repository.saveRouteSearch(routeSearch(
+			"route-search-3",
+			MobilityType.PREGNANT,
+			RouteSearchStatus.BLOCKED,
+			"station-missing",
+			"미확인",
+			"station-busan",
+			"부산"
+		));
+		var service = new RouteSearchDashboardService(repository, new FakeTransitMasterPort());
+
+		var summary = service.summarizeRouteSearches();
+
+		assertThat(summary.regionUsageCounts())
+			.extracting("region", "originCount", "destinationCount")
+			.containsExactly(
+				tuple("수도권", 1L, 2L),
+				tuple("부산권", 1L, 1L)
+			);
+	}
+
 	private RouteSearchResult routeSearch(
 		String routeSearchId,
 		MobilityType mobilityType,
 		RouteSearchStatus status
 	) {
-		return new RouteSearchResult(
+		return routeSearch(
 			routeSearchId,
+			mobilityType,
+			status,
 			"station-sangnoksu",
 			"상록수",
 			"station-sadang",
-			"사당",
+			"사당"
+		);
+	}
+
+	private RouteSearchResult routeSearch(
+		String routeSearchId,
+		MobilityType mobilityType,
+		RouteSearchStatus status,
+		String originStationId,
+		String originStationName,
+		String destinationStationId,
+		String destinationStationName
+	) {
+		return new RouteSearchResult(
+			routeSearchId,
+			originStationId,
+			originStationName,
+			destinationStationId,
+			destinationStationName,
 			mobilityType,
 			status,
 			"line-4",
@@ -58,5 +132,57 @@ class RouteSearchDashboardServiceTest {
 			status == RouteSearchStatus.FOUND ? List.of() : List.of("계단 없는 역 접근 경로를 확인할 수 없습니다."),
 			LocalDateTime.of(2026, 6, 17, 10, 0)
 		);
+	}
+
+	private static final class FakeTransitMasterPort implements LoadTransitMasterPort {
+
+		@Override
+		public List<TransitOperator> loadOperators() {
+			return List.of();
+		}
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of();
+		}
+
+		@Override
+		public List<Station> loadStations() {
+			return List.of(
+				station("station-sangnoksu", "상록수", "수도권"),
+				station("station-sadang", "사당", "수도권"),
+				station("station-busan", "부산", "부산권")
+			);
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of();
+		}
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of();
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of();
+		}
+
+		private Station station(String id, String name, String region) {
+			return new Station(
+				id,
+				name,
+				name,
+				region,
+				BigDecimal.ZERO,
+				BigDecimal.ZERO,
+				DataQualityLevel.LEVEL_1,
+				DataSourceType.OFFICIAL_FILE,
+				LocalDate.of(2026, 6, 17),
+				true
+			);
+		}
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchDashboardServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchDashboardServiceTest.java
@@ -74,7 +74,7 @@ class RouteSearchDashboardServiceTest {
 			"route-search-3",
 			MobilityType.PREGNANT,
 			RouteSearchStatus.BLOCKED,
-			"station-missing",
+			"station-null-region",
 			"미확인",
 			"station-busan",
 			"부산"
@@ -151,7 +151,8 @@ class RouteSearchDashboardServiceTest {
 			return List.of(
 				station("station-sangnoksu", "상록수", "수도권"),
 				station("station-sadang", "사당", "수도권"),
-				station("station-busan", "부산", "부산권")
+				station("station-busan", "부산", "부산권"),
+				station("station-null-region", "미확인", null)
 			);
 		}
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1674,7 +1674,8 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(savePort, /interface SaveRouteSearchPort/);
   assert.match(summarizeSearchPort, /interface SummarizeRouteSearchPort/);
   assert.match(summarizeSearchPort, /summarizeRouteSearches/);
-  assert.match(summarizeSearchPort, /loadRouteSearchesForDashboard/);
+  assert.match(summarizeSearchPort, /loadRouteSearchStationPairsForDashboard/);
+  assert.match(summarizeSearchPort, /record RouteSearchStationPair/);
   assert.match(summarizeFeedbackPort, /interface SummarizeRouteFeedbackPort/);
   assert.match(summarizeFeedbackPort, /summarizeRouteFeedbacks/);
   assert.match(service, /implements RouteSearchUseCase/);
@@ -1698,7 +1699,8 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(jdbcRepository, /INSERT INTO route_search_results/);
   assert.match(jdbcRepository, /INSERT INTO route_feedbacks/);
   assert.match(jdbcRepository, /RouteSearchDashboardSummary summarizeRouteSearches\(\)/);
-  assert.match(jdbcRepository, /List<RouteSearchResult> loadRouteSearchesForDashboard\(\)/);
+  assert.match(jdbcRepository, /List<RouteSearchStationPair> loadRouteSearchStationPairsForDashboard\(\)/);
+  assert.match(jdbcRepository, /SELECT origin_station_id,\s+destination_station_id/);
   assert.match(jdbcRepository, /GROUP BY status, mobility_type/);
   assert.match(jdbcRepository, /same DB statement snapshot|같은 DB statement snapshot/);
   assert.match(jdbcRepository, /RouteFeedbackDashboardSummary summarizeRouteFeedbacks\(\)/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1643,6 +1643,9 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(searchSummary, /foundCount/);
   assert.match(searchSummary, /blockedCount/);
   assert.match(searchSummary, /MobilityTypeCount/);
+  assert.match(searchSummary, /RegionUsageCount/);
+  assert.match(searchSummary, /originCount/);
+  assert.match(searchSummary, /destinationCount/);
   assert.match(feedbackSummary, /record RouteFeedbackDashboardSummary/);
   assert.match(feedbackSummary, /helpfulCount/);
   assert.match(feedbackSummary, /notHelpfulCount/);
@@ -1671,6 +1674,7 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(savePort, /interface SaveRouteSearchPort/);
   assert.match(summarizeSearchPort, /interface SummarizeRouteSearchPort/);
   assert.match(summarizeSearchPort, /summarizeRouteSearches/);
+  assert.match(summarizeSearchPort, /loadRouteSearchesForDashboard/);
   assert.match(summarizeFeedbackPort, /interface SummarizeRouteFeedbackPort/);
   assert.match(summarizeFeedbackPort, /summarizeRouteFeedbacks/);
   assert.match(service, /implements RouteSearchUseCase/);
@@ -1681,6 +1685,9 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(service, /routeScore/);
   assert.match(searchDashboardService, /implements RouteSearchDashboardUseCase/);
   assert.match(searchDashboardService, /SummarizeRouteSearchPort/);
+  assert.match(searchDashboardService, /LoadTransitMasterPort/);
+  assert.match(searchDashboardService, /Station::region/);
+  assert.match(searchDashboardService, /RegionUsageCount/);
   assert.match(feedbackDashboardService, /implements RouteFeedbackDashboardUseCase/);
   assert.match(feedbackDashboardService, /SummarizeRouteFeedbackPort/);
   assert.match(repository, /implements[\s\S]*LoadRouteSearchPort[\s\S]*SaveRouteSearchPort[\s\S]*SaveRouteFeedbackPort[\s\S]*SummarizeRouteFeedbackPort[\s\S]*SummarizeRouteSearchPort/);
@@ -1691,6 +1698,7 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(jdbcRepository, /INSERT INTO route_search_results/);
   assert.match(jdbcRepository, /INSERT INTO route_feedbacks/);
   assert.match(jdbcRepository, /RouteSearchDashboardSummary summarizeRouteSearches\(\)/);
+  assert.match(jdbcRepository, /List<RouteSearchResult> loadRouteSearchesForDashboard\(\)/);
   assert.match(jdbcRepository, /GROUP BY status, mobility_type/);
   assert.match(jdbcRepository, /same DB statement snapshot|같은 DB statement snapshot/);
   assert.match(jdbcRepository, /RouteFeedbackDashboardSummary summarizeRouteFeedbacks\(\)/);
@@ -1711,6 +1719,9 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(searchDashboardTemplate, /경로 검색 현황/);
   assert.match(searchDashboardTemplate, /전체 검색/);
   assert.match(searchDashboardTemplate, /이동 프로필별 검색/);
+  assert.match(searchDashboardTemplate, /지역별 사용량/);
+  assert.match(searchDashboardTemplate, /출발 검색/);
+  assert.match(searchDashboardTemplate, /도착 검색/);
   assert.doesNotMatch(searchDashboardTemplate, /routeSearchId/);
   assert.match(feedbackDashboardController, /@GetMapping\("\/admin\/routes\/feedback\/page"\)/);
   assert.match(feedbackDashboardController, /RouteFeedbackDashboardUseCase/);


### PR DESCRIPTION
## 관련 이슈

close #330

## 작업 배경

- 운영자는 전체 경로 검색 수만으로는 어느 지역의 접근성 이동 수요가 늘어나는지 판단하기 어렵습니다.
- 출발 지역과 도착 지역 기준의 검색 수를 함께 보면 지역별 데이터 보강과 시설 개선 우선순위를 더 빠르게 잡을 수 있습니다.

## 작업 내용

- 경로 검색 현황 요약에 지역별 출발/도착 검색 수를 추가했습니다.
- dashboard service가 경로 검색 결과의 역 ID와 transit master의 station region을 조합해 지역별 사용량을 계산하도록 했습니다.
- in-memory/JDBC 경로 검색 저장소에 dashboard용 출발/도착 역 ID projection 조회를 추가했습니다.
- 관리자 페이지 `/admin/routes/searches/page`에 지역별 사용량 표를 추가했습니다.
- route dashboard 테스트와 repository contract를 지역별 사용량 계약에 맞춰 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "com.easysubway.route.application.service.RouteSearchDashboardServiceTest" --tests "com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepositoryTest" --tests "com.easysubway.route.adapter.out.persistence.JdbcRouteSearchRepositoryTest" --tests "com.easysubway.route.adapter.in.web.RouteSearchAdminPageControllerTest"`: RED 실패 확인 후 구현 뒤 통과
  - `./gradlew test --tests "com.easysubway.route.*"`: 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과, 42개 테스트
  - `./gradlew test`: 통과
  - Codex CLI review 지적 반영 후 `./gradlew test --tests "com.easysubway.route.application.service.RouteSearchDashboardServiceTest" --tests "com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepositoryTest" --tests "com.easysubway.route.adapter.out.persistence.JdbcRouteSearchRepositoryTest" --tests "com.easysubway.route.adapter.in.web.RouteSearchAdminPageControllerTest"`: 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/route-regional-usage-dashboard.md .codex/issue-route-regional-usage-dashboard.local.md swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - GitHub Actions PR checks: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 통과
  - CodeRabbit: 한도 초과로 실제 리뷰가 시작되지 않아 Codex CLI review를 대체 실행했고, 지적 2건을 수정 후 thread resolve 확인

## 리뷰어 메모

- `RouteSearchDashboardService`의 지역별 집계는 station master에 없는 역 ID를 건너뜁니다.
- 지역별 사용량은 같은 검색에서 출발 지역과 도착 지역을 각각 집계합니다.

## 리스크

- 지역 정보는 현재 station master의 `region` 값에 의존합니다.
- DB schema 변경은 없고, 기존 경로 검색 저장 데이터를 읽어 화면 집계만 확장합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
