### PR TITLE
[Feat] 관리자 경로 검색 차단 사유 현황 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageController.java
@@ -29,7 +29,8 @@ class RouteSearchAdminPageController {
 		long foundCount,
 		long blockedCount,
 		List<MobilityTypeCountRow> mobilityTypeRows,
-		List<RegionUsageCountRow> regionUsageRows
+		List<RegionUsageCountRow> regionUsageRows,
+		List<BlockedReasonCountRow> blockedReasonRows
 	) {
 
 		static RouteSearchDashboardView from(RouteSearchDashboardSummary summary) {
@@ -44,6 +45,10 @@ class RouteSearchAdminPageController {
 				summary.regionUsageCounts()
 					.stream()
 					.map(row -> new RegionUsageCountRow(row.region(), row.originCount(), row.destinationCount()))
+					.toList(),
+				summary.blockedReasonCounts()
+					.stream()
+					.map(row -> new BlockedReasonCountRow(row.reason(), row.count()))
 					.toList()
 			);
 		}
@@ -53,6 +58,9 @@ class RouteSearchAdminPageController {
 	}
 
 	record RegionUsageCountRow(String region, long originCount, long destinationCount) {
+	}
+
+	record BlockedReasonCountRow(String reason, long count) {
 	}
 
 	private static String mobilityTypeLabel(MobilityType mobilityType) {

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
@@ -6,6 +6,7 @@ import com.easysubway.route.application.port.out.SaveRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
 import com.easysubway.route.application.port.out.SummarizeRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort;
+import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchBlockedReasons;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchStationPair;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
@@ -100,6 +101,17 @@ public class InMemoryRouteSearchRepository
 					routeSearch.originStationId(),
 					routeSearch.destinationStationId()
 				))
+				.toList();
+		}
+	}
+
+	@Override
+	public List<RouteSearchBlockedReasons> loadRouteSearchBlockedReasonsForDashboard() {
+		synchronized (routeSearches) {
+			return routeSearches.values()
+				.stream()
+				.filter(routeSearch -> routeSearch.status() == RouteSearchStatus.BLOCKED)
+				.map(routeSearch -> new RouteSearchBlockedReasons(routeSearch.blockedReasons()))
 				.toList();
 		}
 	}

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
@@ -177,7 +177,6 @@ public class JdbcRouteSearchRepository
 				SELECT blocked_reasons_json
 				FROM route_search_results
 				WHERE status = 'BLOCKED'
-				ORDER BY created_at DESC, route_search_id
 				""",
 			(resultSet, rowNumber) -> new RouteSearchBlockedReasons(
 				readJson(resultSet.getString("blocked_reasons_json"), STRING_LIST_TYPE)

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
@@ -6,6 +6,7 @@ import com.easysubway.route.application.port.out.SaveRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
 import com.easysubway.route.application.port.out.SummarizeRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort;
+import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchBlockedReasons;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchStationPair;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
@@ -165,6 +166,21 @@ public class JdbcRouteSearchRepository
 			(resultSet, rowNumber) -> new RouteSearchStationPair(
 				resultSet.getString("origin_station_id"),
 				resultSet.getString("destination_station_id")
+			)
+		);
+	}
+
+	@Override
+	public List<RouteSearchBlockedReasons> loadRouteSearchBlockedReasonsForDashboard() {
+		return jdbcTemplate.query(
+			"""
+				SELECT blocked_reasons_json
+				FROM route_search_results
+				WHERE status = 'BLOCKED'
+				ORDER BY created_at DESC, route_search_id
+				""",
+			(resultSet, rowNumber) -> new RouteSearchBlockedReasons(
+				readJson(resultSet.getString("blocked_reasons_json"), STRING_LIST_TYPE)
 			)
 		);
 	}

--- a/backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteSearchPort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteSearchPort.java
@@ -9,6 +9,15 @@ public interface SummarizeRouteSearchPort {
 
 	List<RouteSearchStationPair> loadRouteSearchStationPairsForDashboard();
 
+	List<RouteSearchBlockedReasons> loadRouteSearchBlockedReasonsForDashboard();
+
 	record RouteSearchStationPair(String originStationId, String destinationStationId) {
+	}
+
+	record RouteSearchBlockedReasons(List<String> blockedReasons) {
+
+		public RouteSearchBlockedReasons {
+			blockedReasons = List.copyOf(blockedReasons);
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchDashboardService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchDashboardService.java
@@ -2,8 +2,10 @@ package com.easysubway.route.application.service;
 
 import com.easysubway.route.application.port.in.RouteSearchDashboardUseCase;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort;
+import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchBlockedReasons;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchStationPair;
 import com.easysubway.route.domain.RouteSearchDashboardSummary;
+import com.easysubway.route.domain.RouteSearchDashboardSummary.BlockedReasonCount;
 import com.easysubway.route.domain.RouteSearchDashboardSummary.RegionUsageCount;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.transit.domain.Station;
@@ -38,8 +40,30 @@ public class RouteSearchDashboardService implements RouteSearchDashboardUseCase 
 			summary.foundCount(),
 			summary.blockedCount(),
 			summary.mobilityTypeCounts(),
-			regionUsageCounts(summarizeRouteSearchPort.loadRouteSearchStationPairsForDashboard())
+			regionUsageCounts(summarizeRouteSearchPort.loadRouteSearchStationPairsForDashboard()),
+			blockedReasonCounts(summarizeRouteSearchPort.loadRouteSearchBlockedReasonsForDashboard())
 		);
+	}
+
+	private List<BlockedReasonCount> blockedReasonCounts(List<RouteSearchBlockedReasons> blockedReasonsRows) {
+		Map<String, Long> countsByReason = new HashMap<>();
+		for (RouteSearchBlockedReasons blockedReasonsRow : blockedReasonsRows) {
+			for (String reason : blockedReasonsRow.blockedReasons()) {
+				if (reason == null || reason.isBlank()) {
+					continue;
+				}
+				String normalizedReason = reason.trim();
+				countsByReason.merge(normalizedReason, 1L, Long::sum);
+			}
+		}
+		return countsByReason.entrySet()
+			.stream()
+			.map(entry -> new BlockedReasonCount(entry.getKey(), entry.getValue()))
+			.sorted(Comparator
+				.comparingLong(BlockedReasonCount::count)
+				.reversed()
+				.thenComparing(BlockedReasonCount::reason))
+			.toList();
 	}
 
 	private List<RegionUsageCount> regionUsageCounts(List<RouteSearchStationPair> stationPairs) {

--- a/backend/src/main/java/com/easysubway/route/domain/RouteSearchDashboardSummary.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteSearchDashboardSummary.java
@@ -8,7 +8,8 @@ public record RouteSearchDashboardSummary(
 	long foundCount,
 	long blockedCount,
 	List<MobilityTypeCount> mobilityTypeCounts,
-	List<RegionUsageCount> regionUsageCounts
+	List<RegionUsageCount> regionUsageCounts,
+	List<BlockedReasonCount> blockedReasonCounts
 ) {
 
 	public RouteSearchDashboardSummary(
@@ -17,7 +18,17 @@ public record RouteSearchDashboardSummary(
 		long blockedCount,
 		List<MobilityTypeCount> mobilityTypeCounts
 	) {
-		this(totalCount, foundCount, blockedCount, mobilityTypeCounts, List.of());
+		this(totalCount, foundCount, blockedCount, mobilityTypeCounts, List.of(), List.of());
+	}
+
+	public RouteSearchDashboardSummary(
+		long totalCount,
+		long foundCount,
+		long blockedCount,
+		List<MobilityTypeCount> mobilityTypeCounts,
+		List<RegionUsageCount> regionUsageCounts
+	) {
+		this(totalCount, foundCount, blockedCount, mobilityTypeCounts, regionUsageCounts, List.of());
 	}
 
 	public RouteSearchDashboardSummary {
@@ -35,6 +46,7 @@ public record RouteSearchDashboardSummary(
 			throw new InvalidRouteSearchException("전체 경로 검색 수와 이동 프로필별 검색 수가 일치하지 않습니다.");
 		}
 		regionUsageCounts = List.copyOf(regionUsageCounts);
+		blockedReasonCounts = List.copyOf(blockedReasonCounts);
 	}
 
 	public record MobilityTypeCount(MobilityType mobilityType, long count) {
@@ -57,6 +69,18 @@ public record RouteSearchDashboardSummary(
 			}
 			if (originCount < 0 || destinationCount < 0) {
 				throw new InvalidRouteSearchException("지역별 경로 검색 수는 0 이상이어야 합니다.");
+			}
+		}
+	}
+
+	public record BlockedReasonCount(String reason, long count) {
+
+		public BlockedReasonCount {
+			if (reason == null || reason.isBlank()) {
+				throw new InvalidRouteSearchException("경로 검색 차단 사유 집계에는 사유가 필요합니다.");
+			}
+			if (count < 0) {
+				throw new InvalidRouteSearchException("경로 검색 차단 사유 수는 0 이상이어야 합니다.");
 			}
 		}
 	}

--- a/backend/src/main/resources/templates/admin/routes/searches.html
+++ b/backend/src/main/resources/templates/admin/routes/searches.html
@@ -147,6 +147,24 @@
 			</tbody>
 		</table>
 	</section>
+
+	<section>
+		<h2>차단 사유별 현황</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">차단 사유</th>
+				<th scope="col">건수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.blockedReasonRows}">
+				<td th:text="${row.reason}">계단 없는 역 접근 경로를 확인할 수 없습니다.</td>
+				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
 </main>
 </body>
 </html>

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageControllerTest.java
@@ -6,6 +6,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.application.port.out.SaveRouteSearchPort;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +34,9 @@ class RouteSearchAdminPageControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
+
+	@Autowired
+	private SaveRouteSearchPort saveRouteSearchPort;
 
 	@Test
 	@DisplayName("관리자는 경로 검색의 전체, 상태별, 이동 프로필별 건수를 확인한다")
@@ -62,6 +71,33 @@ class RouteSearchAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 경로 검색 차단 사유별 건수를 확인한다")
+	void adminGetsRouteSearchBlockedReasonCounts() throws Exception {
+		saveRouteSearchPort.saveRouteSearch(blockedRouteSearch(
+			"route-search-blocked-1",
+			"계단 없는 역 접근 경로를 확인할 수 없습니다."
+		));
+		saveRouteSearchPort.saveRouteSearch(blockedRouteSearch(
+			"route-search-blocked-2",
+			"계단 없는 역 접근 경로를 확인할 수 없습니다."
+		));
+
+		String html = mockMvc.perform(get("/admin/routes/searches/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("차단 사유별 현황")
+			.contains("차단 사유")
+			.contains("계단 없는 역 접근 경로를 확인할 수 없습니다.")
+			.contains(">2<")
+			.doesNotContain("route-search-blocked-1");
+	}
+
+	@Test
 	@DisplayName("경로 검색 현황 페이지는 관리자 인증을 요구한다")
 	void routeSearchDashboardRequiresAdminAuthentication() throws Exception {
 		mockMvc.perform(get("/admin/routes/searches/page"))
@@ -83,5 +119,24 @@ class RouteSearchAdminPageControllerTest {
 					}
 					""".formatted(mobilityType)))
 			.andExpect(status().isOk());
+	}
+
+	private RouteSearchResult blockedRouteSearch(String routeSearchId, String blockedReason) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-sangnoksu",
+			"상록수",
+			"station-sadang",
+			"사당",
+			MobilityType.WHEELCHAIR,
+			RouteSearchStatus.BLOCKED,
+			"line-4",
+			"수도권 4호선",
+			0,
+			List.of(),
+			List.of(),
+			List.of(blockedReason),
+			LocalDateTime.of(2026, 6, 17, 10, 0)
+		);
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
@@ -200,6 +200,9 @@ class JdbcRouteSearchRepositoryTest {
 				tuple("station-origin", "station-destination"),
 				tuple("station-origin", "station-destination")
 			);
+		assertThat(repository.loadRouteSearchBlockedReasonsForDashboard())
+			.flatExtracting("blockedReasons")
+			.containsExactly("계단 없는 역 접근 경로를 확인할 수 없습니다.");
 	}
 
 	private RouteSearchResult directRouteSearch(

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchDashboardServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchDashboardServiceTest.java
@@ -91,6 +91,33 @@ class RouteSearchDashboardServiceTest {
 			);
 	}
 
+	@Test
+	@DisplayName("경로 검색 차단 사유를 빈도순으로 집계한다")
+	void summarizeRouteSearchesByBlockedReason() {
+		var repository = new InMemoryRouteSearchRepository();
+		repository.saveRouteSearch(blockedRouteSearch(
+			"route-search-1",
+			"엘리베이터 없는 출입구만 확인됩니다.",
+			"휠체어로 이동 가능한 환승 동선을 확인할 수 없습니다."
+		));
+		repository.saveRouteSearch(blockedRouteSearch(
+			"route-search-2",
+			"엘리베이터 없는 출입구만 확인됩니다.",
+			" "
+		));
+		repository.saveRouteSearch(routeSearch("route-search-3", MobilityType.SENIOR, RouteSearchStatus.FOUND));
+		var service = new RouteSearchDashboardService(repository, new FakeTransitMasterPort());
+
+		var summary = service.summarizeRouteSearches();
+
+		assertThat(summary.blockedReasonCounts())
+			.extracting("reason", "count")
+			.containsExactly(
+				tuple("엘리베이터 없는 출입구만 확인됩니다.", 2L),
+				tuple("휠체어로 이동 가능한 환승 동선을 확인할 수 없습니다.", 1L)
+			);
+	}
+
 	private RouteSearchResult routeSearch(
 		String routeSearchId,
 		MobilityType mobilityType,
@@ -130,6 +157,25 @@ class RouteSearchDashboardServiceTest {
 			List.of(),
 			List.of(),
 			status == RouteSearchStatus.FOUND ? List.of() : List.of("계단 없는 역 접근 경로를 확인할 수 없습니다."),
+			LocalDateTime.of(2026, 6, 17, 10, 0)
+		);
+	}
+
+	private RouteSearchResult blockedRouteSearch(String routeSearchId, String... blockedReasons) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-sangnoksu",
+			"상록수",
+			"station-sadang",
+			"사당",
+			MobilityType.WHEELCHAIR,
+			RouteSearchStatus.BLOCKED,
+			"line-4",
+			"수도권 4호선",
+			0,
+			List.of(),
+			List.of(),
+			List.of(blockedReasons),
 			LocalDateTime.of(2026, 6, 17, 10, 0)
 		);
 	}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1676,6 +1676,8 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(summarizeSearchPort, /summarizeRouteSearches/);
   assert.match(summarizeSearchPort, /loadRouteSearchStationPairsForDashboard/);
   assert.match(summarizeSearchPort, /record RouteSearchStationPair/);
+  assert.match(summarizeSearchPort, /loadRouteSearchBlockedReasonsForDashboard/);
+  assert.match(summarizeSearchPort, /record RouteSearchBlockedReasons/);
   assert.match(summarizeFeedbackPort, /interface SummarizeRouteFeedbackPort/);
   assert.match(summarizeFeedbackPort, /summarizeRouteFeedbacks/);
   assert.match(service, /implements RouteSearchUseCase/);
@@ -1689,6 +1691,7 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(searchDashboardService, /LoadTransitMasterPort/);
   assert.match(searchDashboardService, /Station::region/);
   assert.match(searchDashboardService, /RegionUsageCount/);
+  assert.match(searchDashboardService, /BlockedReasonCount/);
   assert.match(feedbackDashboardService, /implements RouteFeedbackDashboardUseCase/);
   assert.match(feedbackDashboardService, /SummarizeRouteFeedbackPort/);
   assert.match(repository, /implements[\s\S]*LoadRouteSearchPort[\s\S]*SaveRouteSearchPort[\s\S]*SaveRouteFeedbackPort[\s\S]*SummarizeRouteFeedbackPort[\s\S]*SummarizeRouteSearchPort/);
@@ -1701,6 +1704,8 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(jdbcRepository, /RouteSearchDashboardSummary summarizeRouteSearches\(\)/);
   assert.match(jdbcRepository, /List<RouteSearchStationPair> loadRouteSearchStationPairsForDashboard\(\)/);
   assert.match(jdbcRepository, /SELECT origin_station_id,\s+destination_station_id/);
+  assert.match(jdbcRepository, /List<RouteSearchBlockedReasons> loadRouteSearchBlockedReasonsForDashboard\(\)/);
+  assert.match(jdbcRepository, /SELECT blocked_reasons_json/);
   assert.match(jdbcRepository, /GROUP BY status, mobility_type/);
   assert.match(jdbcRepository, /same DB statement snapshot|같은 DB statement snapshot/);
   assert.match(jdbcRepository, /RouteFeedbackDashboardSummary summarizeRouteFeedbacks\(\)/);


### PR DESCRIPTION
## 관련 이슈

close #332

## 작업 배경

- 관리자 경로 검색 현황은 전체 차단 건수를 보여주지만 어떤 사유가 반복되는지 바로 확인하기 어렵습니다.
- 차단 사유별 빈도를 함께 보면 역 접근성 데이터 보강, 시설 상태 점검, 경로 그래프 개선 중 우선순위를 더 빠르게 정할 수 있습니다.

## 작업 내용

- 경로 검색 현황 summary에 차단 사유별 건수 목록을 추가했습니다.
- dashboard service가 빈 차단 사유를 제외하고 사유별 빈도를 집계하도록 했습니다.
- in-memory/JDBC 경로 검색 저장소에 dashboard용 차단 사유 JSON projection 조회를 추가했습니다.
- 관리자 페이지 `/admin/routes/searches/page`에 차단 사유별 현황 표를 추가했습니다.
- route dashboard 테스트와 repository contract를 차단 사유 현황 계약에 맞춰 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests "com.easysubway.route.application.service.RouteSearchDashboardServiceTest.summarizeRouteSearchesByBlockedReason"`: RED 실패 확인 후 구현 뒤 통과
  - `./gradlew test --tests "com.easysubway.route.adapter.in.web.RouteSearchAdminPageControllerTest.adminGetsRouteSearchBlockedReasonCounts"`: RED 실패 확인 후 구현 뒤 통과
  - `./gradlew test --tests "com.easysubway.route.application.service.RouteSearchDashboardServiceTest" --tests "com.easysubway.route.adapter.in.web.RouteSearchAdminPageControllerTest" --tests "com.easysubway.route.adapter.out.persistence.JdbcRouteSearchRepositoryTest"`: 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과, 42개 테스트
  - `./gradlew test --tests "com.easysubway.route.*"`: 통과
  - `./gradlew test`: 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/route-blocked-reason-dashboard.md .codex/issue-route-blocked-reason-dashboard.local.md swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - CodeRabbit 지적 반영 후 `./gradlew test --tests "com.easysubway.route.adapter.out.persistence.JdbcRouteSearchRepositoryTest"`: 통과
  - CodeRabbit 지적 반영 후 `node --test tools/ci/repository-contract.test.mjs`: 통과, 42개 테스트
  - CodeRabbit 지적 반영 후 `git diff --check`: 통과
  - GitHub Actions PR checks: Android CI, Backend CI, iOS CI, Mobile App CI, Repository CI, Changes, CodeRabbit 통과
  - merge 후 main CI `27691797205`: 통과
  - merge 후 main CD `27691797225`: 통과

## 리뷰어 메모

- 차단 사유별 현황은 `BLOCKED` 경로 검색의 `blockedReasons`만 사용합니다.
- JDBC 구현은 전체 `RouteSearchResult`를 역직렬화하지 않고 `blocked_reasons_json`만 조회합니다.
- CodeRabbit nitpick으로 확인된 불필요한 `ORDER BY`는 후속 커밋에서 제거했고 review thread resolved 상태를 확인했습니다.

## 리스크

- 기존 저장 데이터의 차단 사유 문구가 바뀌면 같은 의미의 사유가 별도 행으로 집계될 수 있습니다.
- DB schema 변경은 없고, 기존 경로 검색 저장 데이터를 읽어 화면 집계만 확장합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (해당 없음: CodeRabbit 리뷰 완료)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
