### PR TITLE
[Feat] 운영기관 관리자 계정 기준선 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -34,6 +34,19 @@ public class SecurityConfig {
 
 	@Bean
 	@Order(2)
+	SecurityFilterChain operatorSecurityFilterChain(HttpSecurity http) throws Exception {
+		// 운영기관 전용 화면은 전역 관리자와 별도 역할로 분리해 이후 기관별 범위 제한을 붙일 수 있게 한다.
+		return http
+			.securityMatcher("/operator/**")
+			.authorizeHttpRequests(authorize -> authorize
+				.anyRequest().hasRole("OPERATOR_ADMIN")
+			)
+			.httpBasic(Customizer.withDefaults())
+			.build();
+	}
+
+	@Bean
+	@Order(3)
 	SecurityFilterChain userSecurityFilterChain(HttpSecurity http) throws Exception {
 		// 사용자별 데이터는 URL이나 본문 userId가 아니라 인증 계정을 기준으로 다룬다.
 		return http
@@ -54,7 +67,7 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	@Order(3)
+	@Order(4)
 	SecurityFilterChain publicSecurityFilterChain(HttpSecurity http) throws Exception {
 		// 역 검색과 경로 검색은 로그인 전 이동 계획에 필요한 공개 조회 기능이다.
 		return http
@@ -69,17 +82,26 @@ public class SecurityConfig {
 	ConcurrentUserDetailsManager userDetailsService(
 		@Value("${easysubway.admin.username:}") String adminUsername,
 		@Value("${easysubway.admin.password:}") String adminPassword,
+		@Value("${easysubway.operator.username:}") String operatorUsername,
+		@Value("${easysubway.operator.password:}") String operatorPassword,
 		@Value("${easysubway.user.username:}") String userUsername,
 		@Value("${easysubway.user.password:}") String userPassword,
 		PasswordEncoder passwordEncoder,
 		Environment environment
 	) {
 		validateProdAdminCredentials(adminUsername, adminPassword, environment);
+		validateOperatorCredentials(operatorUsername, operatorPassword);
 		var users = new ConcurrentUserDetailsManager();
 		if (!adminUsername.isBlank() && !adminPassword.isBlank()) {
 			users.createUser(User.withUsername(adminUsername)
 				.password(passwordEncoder.encode(adminPassword))
 				.roles("ADMIN")
+				.build());
+		}
+		if (!operatorUsername.isBlank() && !operatorPassword.isBlank()) {
+			users.createUser(User.withUsername(operatorUsername)
+				.password(passwordEncoder.encode(operatorPassword))
+				.roles("OPERATOR_ADMIN")
 				.build());
 		}
 		if (!userUsername.isBlank() && !userPassword.isBlank()) {
@@ -100,6 +122,12 @@ public class SecurityConfig {
 		if (Arrays.asList(environment.getActiveProfiles()).contains("prod")
 			&& (adminUsername.isBlank() || adminPassword.isBlank())) {
 			throw new IllegalStateException("운영 관리자 계정 설정이 필요합니다.");
+		}
+	}
+
+	private void validateOperatorCredentials(String operatorUsername, String operatorPassword) {
+		if (operatorUsername.isBlank() != operatorPassword.isBlank()) {
+			throw new IllegalStateException("운영기관 관리자 계정 설정은 아이디와 비밀번호를 함께 입력해야 합니다.");
 		}
 	}
 }

--- a/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
@@ -8,6 +8,8 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
 @DisplayName("보안 설정")
 class SecurityConfigTest {
@@ -49,5 +51,43 @@ class SecurityConfigTest {
 				"easysubway.admin.password=admin-password"
 			)
 			.run(context -> assertThat(context).hasNotFailed());
+	}
+
+	@Test
+	@DisplayName("운영기관 관리자 계정 설정이 있으면 전용 역할 사용자를 등록한다")
+	void operatorAdminCredentialsRegisterOperatorAdminUser() {
+		contextRunner
+			.withPropertyValues(
+				"easysubway.operator.username=operator-user",
+				"easysubway.operator.password=operator-password"
+			)
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				UserDetailsService userDetailsService = context.getBean(UserDetailsService.class);
+
+				assertThat(userDetailsService.loadUserByUsername("operator-user").getAuthorities())
+					.extracting(GrantedAuthority::getAuthority)
+					.containsExactly("ROLE_OPERATOR_ADMIN");
+			});
+	}
+
+	@Test
+	@DisplayName("운영기관 관리자 계정은 아이디와 비밀번호를 함께 설정해야 한다")
+	void operatorAdminCredentialsFailWhenPartiallyConfigured() {
+		contextRunner
+			.withPropertyValues("easysubway.operator.username=operator-user")
+			.run(context -> {
+				assertThat(context).hasFailed();
+				assertThat(context.getStartupFailure())
+					.hasMessageContaining("운영기관 관리자 계정 설정은 아이디와 비밀번호를 함께 입력해야 합니다.");
+			});
+
+		contextRunner
+			.withPropertyValues("easysubway.operator.password=operator-password")
+			.run(context -> {
+				assertThat(context).hasFailed();
+				assertThat(context.getStartupFailure())
+					.hasMessageContaining("운영기관 관리자 계정 설정은 아이디와 비밀번호를 함께 입력해야 합니다.");
+			});
 	}
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -904,10 +904,14 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(controller, /Principal principal/);
   assert.match(controller, /principal\.getName\(\)/);
   assert.match(controller, /@ResponseStatus\(HttpStatus\.CREATED\)/);
+  assert.match(security, /@Order\(1\)[\s\S]*?securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(security, /anyRequest\(\)\.hasRole\("ADMIN"\)/);
+  assert.match(security, /@Order\(2\)[\s\S]*?securityMatcher\("\/operator\/\*\*"\)/);
   assert.match(security, /securityMatcher\("\/operator\/\*\*"\)/);
   assert.match(security, /anyRequest\(\)\.hasRole\("OPERATOR_ADMIN"\)/);
+  assert.match(security, /@Order\(3\)[\s\S]*?securityMatcher\([\s\S]*?"\/api\/v1\/me"/);
+  assert.match(security, /@Order\(4\)[\s\S]*?anyRequest\(\)\.permitAll\(\)/);
   assert.match(security, /easysubway\.operator\.username/);
   assert.match(security, /easysubway\.operator\.password/);
   assert.match(security, /roles\("OPERATOR_ADMIN"\)/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -906,10 +906,17 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(controller, /@ResponseStatus\(HttpStatus\.CREATED\)/);
   assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(security, /anyRequest\(\)\.hasRole\("ADMIN"\)/);
+  assert.match(security, /securityMatcher\("\/operator\/\*\*"\)/);
+  assert.match(security, /anyRequest\(\)\.hasRole\("OPERATOR_ADMIN"\)/);
+  assert.match(security, /easysubway\.operator\.username/);
+  assert.match(security, /easysubway\.operator\.password/);
+  assert.match(security, /roles\("OPERATOR_ADMIN"\)/);
+  assert.match(security, /validateOperatorCredentials/);
   assert.match(security, /anyRequest\(\)\.permitAll\(\)/);
   assert.match(security, /httpBasic/);
   assert.match(security, /PasswordEncoder/);
   assert.match(security, /passwordEncoder\.encode\(adminPassword\)/);
+  assert.match(security, /passwordEncoder\.encode\(operatorPassword\)/);
 });
 
 test("백엔드 이동 프로필은 헥사고날 API 경계를 따른다", () => {


### PR DESCRIPTION
## 관련 이슈

close #335

## 작업 배경

- 운영기관 담당자용 B2G/B2B 기능을 전역 관리자 계정과 같은 권한으로 묶으면 이후 기관별 범위 제한을 적용하기 어렵습니다.
- 운영기관 전용 화면을 만들기 전에 별도 역할과 인증 경로 기준선을 먼저 마련합니다.

## 작업 내용

- `easysubway.operator.username`, `easysubway.operator.password` 설정으로 운영기관 관리자 계정을 등록하도록 했습니다.
- 운영기관 관리자 계정에 `OPERATOR_ADMIN` 역할을 부여했습니다.
- `/operator/**` 경로를 `OPERATOR_ADMIN` 역할로 보호하는 별도 security chain을 추가했습니다.
- 운영기관 관리자 username/password 중 하나만 설정된 경우 애플리케이션 시작이 실패하도록 검증했습니다.
- 보안 설정 테스트와 repository contract를 운영기관 관리자 보안 계약에 맞춰 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests "com.easysubway.common.security.SecurityConfigTest"`: RED 실패 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과, 42개 테스트
  - `backend/gradlew -p backend test`: 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/operator-admin-account.md .codex/issue-operator-admin-account.local.md swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - CodeRabbit 지적 반영 후 `node --test tools/ci/repository-contract.test.mjs`: 통과, 42개 테스트
  - CodeRabbit 지적 반영 후 `git diff --check`: 통과
  - GitHub Actions PR checks: Android CI, Backend CI, iOS CI, Mobile App CI, Repository CI, Changes, CodeRabbit 통과
  - merge 후 main CI `27727412936`: 통과
  - merge 후 main CD `27727412927`: 통과

## 리뷰어 메모

- 이번 변경은 운영기관 계정의 인증 기준선만 추가합니다.
- 운영기관별 데이터 범위 제한과 운영기관 관리자 화면은 후속 작업 범위입니다.
- CodeRabbit 지적으로 보안 필터 chain `@Order(1..4)` 순서를 repository contract에 추가했고, review thread resolved 상태를 확인했습니다.

## 리스크

- 아직 `/operator/**` 실제 화면은 없으므로, 이번 PR만으로 운영기관 담당자가 사용할 기능은 늘어나지 않습니다.
- 운영 환경에서 운영기관 계정은 선택 설정입니다. username/password 중 하나만 설정하면 시작이 실패합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (해당 없음: CodeRabbit 리뷰 완료)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
