### PR TITLE
[Feat] 관리자 API 오류율 현황 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityAdminPageController.java
@@ -24,20 +24,38 @@ class UserActivityAdminPageController {
 
 	record UserActivityDashboardView(
 		long totalActiveUsers,
+		long totalApiRequests,
+		long totalApiErrors,
+		String apiErrorRatePercent,
 		List<DailyUserActivityRow> dailyActivityRows
 	) {
 
 		static UserActivityDashboardView from(UserActivityDashboardSummary summary) {
 			return new UserActivityDashboardView(
 				summary.totalActiveUsers(),
+				summary.totalApiRequests(),
+				summary.totalApiErrors(),
+				summary.apiErrorRatePercent(),
 				summary.dailyActivities()
 					.stream()
-					.map(row -> new DailyUserActivityRow(row.date().toString(), row.activeUserCount()))
+					.map(row -> new DailyUserActivityRow(
+						row.date().toString(),
+						row.activeUserCount(),
+						row.apiRequestCount(),
+						row.apiErrorCount(),
+						row.apiErrorRatePercent()
+					))
 					.toList()
 			);
 		}
 	}
 
-	record DailyUserActivityRow(String dateLabel, long activeUserCount) {
+	record DailyUserActivityRow(
+		String dateLabel,
+		long activeUserCount,
+		long apiRequestCount,
+		long apiErrorCount,
+		String apiErrorRatePercent
+	) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilter.java
+++ b/backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilter.java
@@ -1,5 +1,6 @@
 package com.easysubway.usage.adapter.in.web;
 
+import com.easysubway.usage.application.port.out.RecordApiTrafficPort;
 import com.easysubway.usage.application.port.out.RecordUserActivityPort;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -24,16 +25,26 @@ class UserActivityTrackingFilter extends OncePerRequestFilter {
 	private static final String ANONYMOUS_AUTH_PATH = "/api/v1/auth/anonymous";
 
 	private final RecordUserActivityPort recordUserActivityPort;
+	private final RecordApiTrafficPort recordApiTrafficPort;
 	private final Clock clock;
 	private final AuthenticationTrustResolver authenticationTrustResolver;
 
 	@Autowired
-	UserActivityTrackingFilter(RecordUserActivityPort recordUserActivityPort, ObjectProvider<Clock> clockProvider) {
-		this(recordUserActivityPort, clockProvider.getIfAvailable(Clock::systemDefaultZone));
+	UserActivityTrackingFilter(
+		RecordUserActivityPort recordUserActivityPort,
+		RecordApiTrafficPort recordApiTrafficPort,
+		ObjectProvider<Clock> clockProvider
+	) {
+		this(recordUserActivityPort, recordApiTrafficPort, clockProvider.getIfAvailable(Clock::systemDefaultZone));
 	}
 
-	UserActivityTrackingFilter(RecordUserActivityPort recordUserActivityPort, Clock clock) {
+	UserActivityTrackingFilter(
+		RecordUserActivityPort recordUserActivityPort,
+		RecordApiTrafficPort recordApiTrafficPort,
+		Clock clock
+	) {
 		this.recordUserActivityPort = recordUserActivityPort;
+		this.recordApiTrafficPort = recordApiTrafficPort;
 		this.clock = clock;
 		this.authenticationTrustResolver = new AuthenticationTrustResolverImpl();
 	}
@@ -45,12 +56,20 @@ class UserActivityTrackingFilter extends OncePerRequestFilter {
 		FilterChain filterChain
 	) throws ServletException, IOException {
 		filterChain.doFilter(request, response);
+		if (shouldRecordApiTraffic(request)) {
+			recordApiTrafficPort.recordApiTraffic(response.getStatus(), LocalDateTime.now(clock));
+		}
 		if (shouldRecord(request, response)) {
 			recordUserActivityPort.recordUserActivity(
 				request.getUserPrincipal().getName(),
 				LocalDateTime.now(clock)
 			);
 		}
+	}
+
+	private boolean shouldRecordApiTraffic(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		return path.startsWith(API_PREFIX) && !path.equals(ANONYMOUS_AUTH_PATH);
 	}
 
 	private boolean shouldRecord(HttpServletRequest request, HttpServletResponse response) {

--- a/backend/src/main/java/com/easysubway/usage/adapter/out/persistence/InMemoryUserActivityRepository.java
+++ b/backend/src/main/java/com/easysubway/usage/adapter/out/persistence/InMemoryUserActivityRepository.java
@@ -1,5 +1,6 @@
 package com.easysubway.usage.adapter.out.persistence;
 
+import com.easysubway.usage.application.port.out.RecordApiTrafficPort;
 import com.easysubway.usage.application.port.out.RecordUserActivityPort;
 import com.easysubway.usage.application.port.out.SummarizeUserActivityPort;
 import com.easysubway.usage.domain.InvalidUserActivityException;
@@ -18,9 +19,10 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @Profile("!prod")
-public class InMemoryUserActivityRepository implements RecordUserActivityPort, SummarizeUserActivityPort {
+public class InMemoryUserActivityRepository implements RecordUserActivityPort, RecordApiTrafficPort, SummarizeUserActivityPort {
 
 	private final Map<LocalDate, Set<String>> userIdsByDate = new HashMap<>();
+	private final Map<LocalDate, ApiTrafficCount> apiTrafficByDate = new HashMap<>();
 
 	@Override
 	public synchronized void recordUserActivity(String userId, LocalDateTime occurredAt) {
@@ -32,6 +34,19 @@ public class InMemoryUserActivityRepository implements RecordUserActivityPort, S
 		}
 
 		userIdsByDate.computeIfAbsent(occurredAt.toLocalDate(), ignored -> new HashSet<>()).add(userId.trim());
+	}
+
+	@Override
+	public synchronized void recordApiTraffic(int statusCode, LocalDateTime occurredAt) {
+		if (statusCode < 100 || statusCode > 599) {
+			throw new InvalidUserActivityException("API 응답 상태 코드는 100부터 599 사이여야 합니다.");
+		}
+		if (occurredAt == null) {
+			throw new InvalidUserActivityException("API 요청 시간이 필요합니다.");
+		}
+
+		apiTrafficByDate.computeIfAbsent(occurredAt.toLocalDate(), ignored -> new ApiTrafficCount())
+			.add(statusCode);
 	}
 
 	@Override
@@ -48,10 +63,43 @@ public class InMemoryUserActivityRepository implements RecordUserActivityPort, S
 		List<DailyUserActivity> rows = today.datesUntil(startDate.minusDays(1), java.time.Period.ofDays(-1))
 			.map(date -> {
 				Set<String> userIds = userIdsByDate.getOrDefault(date, Set.of());
+				ApiTrafficCount apiTrafficCount = apiTrafficByDate.getOrDefault(date, ApiTrafficCount.empty());
 				activeUserIds.addAll(userIds);
-				return new DailyUserActivity(date, userIds.size());
+				return new DailyUserActivity(
+					date,
+					userIds.size(),
+					apiTrafficCount.requestCount(),
+					apiTrafficCount.errorCount()
+				);
 			})
 			.toList();
-		return new UserActivityDashboardSummary(activeUserIds.size(), rows);
+		long totalApiRequests = rows.stream().mapToLong(DailyUserActivity::apiRequestCount).sum();
+		long totalApiErrors = rows.stream().mapToLong(DailyUserActivity::apiErrorCount).sum();
+		return new UserActivityDashboardSummary(activeUserIds.size(), totalApiRequests, totalApiErrors, rows);
+	}
+
+	private static final class ApiTrafficCount {
+
+		private long requestCount;
+		private long errorCount;
+
+		static ApiTrafficCount empty() {
+			return new ApiTrafficCount();
+		}
+
+		void add(int statusCode) {
+			requestCount++;
+			if (statusCode >= 400) {
+				errorCount++;
+			}
+		}
+
+		long requestCount() {
+			return requestCount;
+		}
+
+		long errorCount() {
+			return errorCount;
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/usage/application/port/out/RecordApiTrafficPort.java
+++ b/backend/src/main/java/com/easysubway/usage/application/port/out/RecordApiTrafficPort.java
@@ -1,0 +1,8 @@
+package com.easysubway.usage.application.port.out;
+
+import java.time.LocalDateTime;
+
+public interface RecordApiTrafficPort {
+
+	void recordApiTraffic(int statusCode, LocalDateTime occurredAt);
+}

--- a/backend/src/main/java/com/easysubway/usage/domain/UserActivityDashboardSummary.java
+++ b/backend/src/main/java/com/easysubway/usage/domain/UserActivityDashboardSummary.java
@@ -2,15 +2,27 @@ package com.easysubway.usage.domain;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Locale;
 
 public record UserActivityDashboardSummary(
 	long totalActiveUsers,
+	long totalApiRequests,
+	long totalApiErrors,
 	List<DailyUserActivity> dailyActivities
 ) {
 
 	public UserActivityDashboardSummary {
 		if (totalActiveUsers < 0) {
 			throw new InvalidUserActivityException("전체 활성 사용자 수는 0 이상이어야 합니다.");
+		}
+		if (totalApiRequests < 0) {
+			throw new InvalidUserActivityException("전체 API 요청 수는 0 이상이어야 합니다.");
+		}
+		if (totalApiErrors < 0) {
+			throw new InvalidUserActivityException("전체 API 오류 수는 0 이상이어야 합니다.");
+		}
+		if (totalApiErrors > totalApiRequests) {
+			throw new InvalidUserActivityException("전체 API 오류 수는 전체 API 요청 수보다 클 수 없습니다.");
 		}
 		dailyActivities = List.copyOf(dailyActivities);
 		long maxDailyCount = dailyActivities.stream()
@@ -22,7 +34,16 @@ public record UserActivityDashboardSummary(
 		}
 	}
 
-	public record DailyUserActivity(LocalDate date, long activeUserCount) {
+	public String apiErrorRatePercent() {
+		return formatPercent(totalApiErrors, totalApiRequests);
+	}
+
+	public record DailyUserActivity(
+		LocalDate date,
+		long activeUserCount,
+		long apiRequestCount,
+		long apiErrorCount
+	) {
 
 		public DailyUserActivity {
 			if (date == null) {
@@ -31,6 +52,27 @@ public record UserActivityDashboardSummary(
 			if (activeUserCount < 0) {
 				throw new InvalidUserActivityException("일별 활성 사용자 수는 0 이상이어야 합니다.");
 			}
+			if (apiRequestCount < 0) {
+				throw new InvalidUserActivityException("일별 API 요청 수는 0 이상이어야 합니다.");
+			}
+			if (apiErrorCount < 0) {
+				throw new InvalidUserActivityException("일별 API 오류 수는 0 이상이어야 합니다.");
+			}
+			if (apiErrorCount > apiRequestCount) {
+				throw new InvalidUserActivityException("일별 API 오류 수는 일별 API 요청 수보다 클 수 없습니다.");
+			}
 		}
+
+		public String apiErrorRatePercent() {
+			return formatPercent(apiErrorCount, apiRequestCount);
+		}
+	}
+
+	private static String formatPercent(long numerator, long denominator) {
+		if (denominator == 0) {
+			return "0.0%";
+		}
+		double percentage = (double) numerator * 100 / denominator;
+		return String.format(Locale.ROOT, "%.1f%%", percentage);
 	}
 }

--- a/backend/src/main/resources/templates/admin/usage/activity.html
+++ b/backend/src/main/resources/templates/admin/usage/activity.html
@@ -98,6 +98,18 @@
 			<span>최근 7일 활성 사용자</span>
 			<strong th:text="${summary.totalActiveUsers}">0</strong>
 		</div>
+		<div class="metric">
+			<span>API 요청</span>
+			<strong th:text="${summary.totalApiRequests}">0</strong>
+		</div>
+		<div class="metric">
+			<span>오류 응답</span>
+			<strong th:text="${summary.totalApiErrors}">0</strong>
+		</div>
+		<div class="metric">
+			<span>API 오류율</span>
+			<strong th:text="${summary.apiErrorRatePercent}">0.0%</strong>
+		</div>
 	</div>
 
 	<section>
@@ -107,12 +119,18 @@
 			<tr>
 				<th scope="col">날짜</th>
 				<th scope="col">고유 사용자</th>
+				<th scope="col">API 요청</th>
+				<th scope="col">오류 응답</th>
+				<th scope="col">API 오류율</th>
 			</tr>
 			</thead>
 			<tbody>
 			<tr th:each="row : ${summary.dailyActivityRows}">
 				<td th:text="${row.dateLabel}">2026-06-17</td>
 				<td th:text="${row.activeUserCount}">0</td>
+				<td th:text="${row.apiRequestCount}">0</td>
+				<td th:text="${row.apiErrorCount}">0</td>
+				<td th:text="${row.apiErrorRatePercent}">0.0%</td>
 			</tr>
 			</tbody>
 		</table>

--- a/backend/src/test/java/com/easysubway/usage/adapter/in/web/UserActivityAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/usage/adapter/in/web/UserActivityAdminPageControllerTest.java
@@ -22,9 +22,11 @@ class UserActivityAdminPageControllerTest {
 		UserActivityDashboardUseCase useCase = mock(UserActivityDashboardUseCase.class);
 		when(useCase.summarizeUserActivity()).thenReturn(new UserActivityDashboardSummary(
 			3,
+			12,
+			2,
 			List.of(
-				new DailyUserActivity(LocalDate.of(2026, 6, 17), 2),
-				new DailyUserActivity(LocalDate.of(2026, 6, 16), 1)
+				new DailyUserActivity(LocalDate.of(2026, 6, 17), 2, 7, 1),
+				new DailyUserActivity(LocalDate.of(2026, 6, 16), 1, 5, 1)
 			)
 		));
 		var controller = new UserActivityAdminPageController(useCase);
@@ -36,9 +38,12 @@ class UserActivityAdminPageControllerTest {
 		UserActivityAdminPageController.UserActivityDashboardView view =
 			(UserActivityAdminPageController.UserActivityDashboardView) model.getAttribute("summary");
 		assertThat(view.totalActiveUsers()).isEqualTo(3);
+		assertThat(view.totalApiRequests()).isEqualTo(12);
+		assertThat(view.totalApiErrors()).isEqualTo(2);
+		assertThat(view.apiErrorRatePercent()).isEqualTo("16.7%");
 		assertThat(view.dailyActivityRows())
-			.extracting(row -> row.dateLabel() + ":" + row.activeUserCount())
-			.containsExactly("2026-06-17:2", "2026-06-16:1");
+			.extracting(row -> row.dateLabel() + ":" + row.activeUserCount() + ":" + row.apiRequestCount() + ":" + row.apiErrorCount() + ":" + row.apiErrorRatePercent())
+			.containsExactly("2026-06-17:2:7:1:14.3%", "2026-06-16:1:5:1:20.0%");
 		assertThat(view.toString()).doesNotContain("anonymous-user");
 	}
 }

--- a/backend/src/test/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilterTest.java
+++ b/backend/src/test/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilterTest.java
@@ -3,6 +3,7 @@ package com.easysubway.usage.adapter.in.web;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.easysubway.usage.application.port.out.RecordUserActivityPort;
+import com.easysubway.usage.application.port.out.RecordApiTrafficPort;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import java.io.IOException;
@@ -29,7 +30,7 @@ class UserActivityTrackingFilterTest {
 	);
 
 	private final RecordingUserActivityPort port = new RecordingUserActivityPort();
-	private final UserActivityTrackingFilter filter = new UserActivityTrackingFilter(port, FIXED_CLOCK);
+	private final UserActivityTrackingFilter filter = new UserActivityTrackingFilter(port, port, FIXED_CLOCK);
 
 	@Test
 	@DisplayName("성공한 인증 사용자 API 요청은 활동으로 기록한다")
@@ -42,17 +43,33 @@ class UserActivityTrackingFilterTest {
 		assertThat(port.records)
 			.extracting(record -> record.userId() + ":" + record.occurredAt())
 			.containsExactly("anonymous-user-1:2026-06-17T09:00");
+		assertThat(port.apiTrafficRecords)
+			.extracting(record -> record.statusCode() + ":" + record.occurredAt())
+			.containsExactly("200:2026-06-17T09:00");
 	}
 
 	@Test
-	@DisplayName("실패 응답과 인증 발급 요청과 관리자 요청은 활성 사용자 지표에서 제외한다")
-	void failedAuthAndAdminRequestsAreIgnored() throws Exception {
+	@DisplayName("실패 응답은 API 오류율에 기록하고 활성 사용자 지표에서는 제외한다")
+	void failedApiRequestsRecordTrafficAndSkipActiveUserMetric() throws Exception {
 		filter.doFilter(apiRequest("/api/v1/routes/search", "anonymous-user-1"), new MockHttpServletResponse(), failingChain());
+
+		assertThat(port.records).isEmpty();
+		assertThat(port.apiTrafficRecords)
+			.extracting(record -> record.statusCode() + ":" + record.occurredAt())
+			.containsExactly("500:2026-06-17T09:00");
+	}
+
+	@Test
+	@DisplayName("인증 발급과 관리자 요청은 제외하고 일반 API 요청은 오류율에 기록한다")
+	void authAndAdminRequestsAreIgnoredFromTrafficMetric() throws Exception {
 		filter.doFilter(apiRequest("/api/v1/auth/anonymous", "anonymous-user-1"), new MockHttpServletResponse(), successfulChain());
 		filter.doFilter(apiRequest("/admin/routes/searches/page", "admin-user"), new MockHttpServletResponse(), successfulChain());
 		filter.doFilter(apiRequest("/api/v1/routes/search", null), new MockHttpServletResponse(), successfulChain());
 
 		assertThat(port.records).isEmpty();
+		assertThat(port.apiTrafficRecords)
+			.extracting(record -> record.statusCode() + ":" + record.occurredAt())
+			.containsExactly("200:2026-06-17T09:00");
 	}
 
 	@Test
@@ -87,16 +104,25 @@ class UserActivityTrackingFilterTest {
 		return (request, response) -> ((MockHttpServletResponse) response).setStatus(500);
 	}
 
-	private static final class RecordingUserActivityPort implements RecordUserActivityPort {
+	private static final class RecordingUserActivityPort implements RecordUserActivityPort, RecordApiTrafficPort {
 
 		private final List<Record> records = new ArrayList<>();
+		private final List<ApiTrafficRecord> apiTrafficRecords = new ArrayList<>();
 
 		@Override
 		public void recordUserActivity(String userId, LocalDateTime occurredAt) {
 			records.add(new Record(userId, occurredAt));
 		}
+
+		@Override
+		public void recordApiTraffic(int statusCode, LocalDateTime occurredAt) {
+			apiTrafficRecords.add(new ApiTrafficRecord(statusCode, occurredAt));
+		}
 	}
 
 	private record Record(String userId, LocalDateTime occurredAt) {
+	}
+
+	private record ApiTrafficRecord(int statusCode, LocalDateTime occurredAt) {
 	}
 }

--- a/backend/src/test/java/com/easysubway/usage/adapter/out/persistence/InMemoryUserActivityRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/usage/adapter/out/persistence/InMemoryUserActivityRepositoryTest.java
@@ -25,9 +25,30 @@ class InMemoryUserActivityRepositoryTest {
 		var summary = repository.summarizeUserActivity(LocalDate.of(2026, 6, 17), 2);
 
 		assertThat(summary.totalActiveUsers()).isEqualTo(2);
+		assertThat(summary.totalApiRequests()).isZero();
+		assertThat(summary.totalApiErrors()).isZero();
+		assertThat(summary.apiErrorRatePercent()).isEqualTo("0.0%");
 		assertThat(summary.dailyActivities())
 			.extracting(row -> row.date() + ":" + row.activeUserCount())
 			.containsExactly("2026-06-17:1", "2026-06-16:1");
+	}
+
+	@Test
+	@DisplayName("최근 기간의 API 요청 수와 오류율을 일별로 집계한다")
+	void summarizeUserActivityIncludesApiTrafficErrorRate() {
+		repository.recordApiTraffic(200, LocalDateTime.of(2026, 6, 17, 9, 0));
+		repository.recordApiTraffic(404, LocalDateTime.of(2026, 6, 17, 9, 5));
+		repository.recordApiTraffic(500, LocalDateTime.of(2026, 6, 16, 11, 0));
+		repository.recordApiTraffic(200, LocalDateTime.of(2026, 6, 15, 11, 0));
+
+		var summary = repository.summarizeUserActivity(LocalDate.of(2026, 6, 17), 2);
+
+		assertThat(summary.totalApiRequests()).isEqualTo(3);
+		assertThat(summary.totalApiErrors()).isEqualTo(2);
+		assertThat(summary.apiErrorRatePercent()).isEqualTo("66.7%");
+		assertThat(summary.dailyActivities())
+			.extracting(row -> row.date() + ":" + row.apiRequestCount() + ":" + row.apiErrorCount() + ":" + row.apiErrorRatePercent())
+			.containsExactly("2026-06-17:2:1:50.0%", "2026-06-16:1:1:100.0%");
 	}
 
 	@Test
@@ -36,5 +57,13 @@ class InMemoryUserActivityRepositoryTest {
 		assertThatThrownBy(() -> repository.recordUserActivity(" ", LocalDateTime.of(2026, 6, 17, 9, 0)))
 			.isInstanceOf(InvalidUserActivityException.class)
 			.hasMessage("사용자 활동 식별자가 필요합니다.");
+	}
+
+	@Test
+	@DisplayName("잘못된 API 상태 코드는 운영 지표로 저장하지 않는다")
+	void recordApiTrafficRejectsInvalidStatusCode() {
+		assertThatThrownBy(() -> repository.recordApiTraffic(99, LocalDateTime.of(2026, 6, 17, 9, 0)))
+			.isInstanceOf(InvalidUserActivityException.class)
+			.hasMessage("API 응답 상태 코드는 100부터 599 사이여야 합니다.");
 	}
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2024,6 +2024,31 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(widgetTest, /greaterThanOrEqualTo\(60\)/);
 });
 
+test("관리자 사용자 활동 화면은 API 오류율 운영 지표를 표시한다", () => {
+  const userActivityFilter = read("backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilter.java");
+  const summary = read("backend/src/main/java/com/easysubway/usage/domain/UserActivityDashboardSummary.java");
+  const repository = read("backend/src/main/java/com/easysubway/usage/adapter/out/persistence/InMemoryUserActivityRepository.java");
+  const controller = read("backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityAdminPageController.java");
+  const template = read("backend/src/main/resources/templates/admin/usage/activity.html");
+  const filterTest = read("backend/src/test/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilterTest.java");
+  const repositoryTest = read("backend/src/test/java/com/easysubway/usage/adapter/out/persistence/InMemoryUserActivityRepositoryTest.java");
+
+  assert.match(userActivityFilter, /RecordApiTrafficPort/);
+  assert.match(userActivityFilter, /recordApiTraffic\(\s*response\.getStatus\(\),\s*LocalDateTime\.now\(clock\)\s*\)/);
+  assert.match(userActivityFilter, /response\.getStatus\(\) < 400/);
+  assert.match(summary, /totalApiRequests/);
+  assert.match(summary, /totalApiErrors/);
+  assert.match(summary, /apiErrorRatePercent\(\)/);
+  assert.match(repository, /recordApiTraffic\(int statusCode, LocalDateTime occurredAt\)/);
+  assert.match(repository, /statusCode >= 400/);
+  assert.match(controller, /apiErrorRatePercent/);
+  assert.match(template, /API 오류율/);
+  assert.match(template, /API 요청/);
+  assert.match(template, /오류 응답/);
+  assert.match(filterTest, /실패 응답은 API 오류율에 기록하고 활성 사용자 지표에서는 제외한다/);
+  assert.match(repositoryTest, /최근 기간의 API 요청 수와 오류율을 일별로 집계한다/);
+});
+
 test("iOS 앱은 개인정보 매니페스트를 번들 리소스로 포함한다", () => {
   const privacyManifestPath = "apps/mobile/ios/Runner/PrivacyInfo.xcprivacy";
   assert.ok(existsSync(path.join(root, privacyManifestPath)));


### PR DESCRIPTION
## 관련 이슈

close #339

## 작업 배경

- 운영 품질 기준에는 API 오류율 증가 감지가 포함되어 있지만 관리자 화면은 활성 사용자 수만 보여 줍니다.
- 장애 상황에서 최근 요청 대비 오류 응답 비율을 빠르게 확인할 수 있도록 개인정보를 저장하지 않는 운영 지표 기준선이 필요합니다.

## 작업 내용

- API 요청 결과를 상태 코드와 발생 시각만으로 집계하는 `RecordApiTrafficPort`를 추가했습니다.
- 사용자 활동 추적 필터가 `/api/v1/**` 요청 결과를 API 오류율 지표로 기록하도록 했습니다.
- 익명 인증 API와 관리자 화면 요청은 API 오류율 집계에서 제외했습니다.
- 인메모리 사용자 활동 저장소가 최근 7일 API 요청 수, 오류 응답 수, 오류율을 집계하도록 확장했습니다.
- 관리자 사용자 활동 화면에 전체/일별 API 요청, 오류 응답, API 오류율을 표시했습니다.
- repository contract와 backend tests로 집계 계약과 화면 문구를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests "com.easysubway.usage.*"`: RED 실패 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs`: RED 실패 확인 후 구현 뒤 통과, 43개 테스트
  - `backend/gradlew -p backend test`: 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/api-error-rate-dashboard.md .codex/issue-api-error-rate-dashboard.local.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - PR CI run `27728996281`: 통과
  - CodeRabbit: rate limit으로 실제 리뷰 미시작, Codex CLI fallback review `4520670243`에서 지적 0건 확인
  - merge 후 main CI run `27729204122`: 통과
  - merge 후 main CD run `27729204132`: 통과

## 리뷰어 메모

- 새 집계는 요청 본문, query string, 사용자 ID, IP를 저장하지 않고 상태 코드와 날짜만 사용합니다.
- 활성 사용자 수는 기존처럼 성공한 인증 사용자 API 요청만 집계합니다.
- API 오류율은 일반 API 요청의 4xx/5xx 응답을 오류로 계산합니다.

## 리스크

- 현재 구현은 인메모리 운영 지표 기준선입니다. 운영 프로필의 영속 저장소 연결은 별도 작업에서 다뤄야 합니다.
- 필터 체인 밖으로 전파되어 응답 상태가 확정되지 않은 예외는 이번 기준선 집계에 포함되지 않을 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (rate limit으로 실제 리뷰 미시작, Codex CLI fallback 사용)
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
