### PR TITLE
[Feat] 관리자 API 응답 시간 현황 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityAdminPageController.java
@@ -27,6 +27,8 @@ class UserActivityAdminPageController {
 		long totalApiRequests,
 		long totalApiErrors,
 		String apiErrorRatePercent,
+		long averageApiResponseMillis,
+		String averageApiResponseTimeLabel,
 		List<DailyUserActivityRow> dailyActivityRows
 	) {
 
@@ -36,6 +38,8 @@ class UserActivityAdminPageController {
 				summary.totalApiRequests(),
 				summary.totalApiErrors(),
 				summary.apiErrorRatePercent(),
+				summary.averageApiResponseMillis(),
+				summary.averageApiResponseTimeLabel(),
 				summary.dailyActivities()
 					.stream()
 					.map(row -> new DailyUserActivityRow(
@@ -43,7 +47,9 @@ class UserActivityAdminPageController {
 						row.activeUserCount(),
 						row.apiRequestCount(),
 						row.apiErrorCount(),
-						row.apiErrorRatePercent()
+						row.apiErrorRatePercent(),
+						row.averageApiResponseMillis(),
+						row.averageApiResponseTimeLabel()
 					))
 					.toList()
 			);
@@ -55,7 +61,9 @@ class UserActivityAdminPageController {
 		long activeUserCount,
 		long apiRequestCount,
 		long apiErrorCount,
-		String apiErrorRatePercent
+		String apiErrorRatePercent,
+		long averageApiResponseMillis,
+		String averageApiResponseTimeLabel
 	) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilter.java
+++ b/backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilter.java
@@ -55,14 +55,17 @@ class UserActivityTrackingFilter extends OncePerRequestFilter {
 		HttpServletResponse response,
 		FilterChain filterChain
 	) throws ServletException, IOException {
+		long startedAtMillis = clock.millis();
+		LocalDateTime requestedAt = LocalDateTime.now(clock);
 		filterChain.doFilter(request, response);
+		long durationMillis = Math.max(0, clock.millis() - startedAtMillis);
 		if (shouldRecordApiTraffic(request)) {
-			recordApiTrafficPort.recordApiTraffic(response.getStatus(), LocalDateTime.now(clock));
+			recordApiTrafficPort.recordApiTraffic(response.getStatus(), durationMillis, LocalDateTime.now(clock));
 		}
 		if (shouldRecord(request, response)) {
 			recordUserActivityPort.recordUserActivity(
 				request.getUserPrincipal().getName(),
-				LocalDateTime.now(clock)
+				requestedAt
 			);
 		}
 	}

--- a/backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilter.java
+++ b/backend/src/main/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilter.java
@@ -9,7 +9,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.Principal;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.function.LongSupplier;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
@@ -27,6 +29,7 @@ class UserActivityTrackingFilter extends OncePerRequestFilter {
 	private final RecordUserActivityPort recordUserActivityPort;
 	private final RecordApiTrafficPort recordApiTrafficPort;
 	private final Clock clock;
+	private final LongSupplier nanoTimeSupplier;
 	private final AuthenticationTrustResolver authenticationTrustResolver;
 
 	@Autowired
@@ -35,7 +38,12 @@ class UserActivityTrackingFilter extends OncePerRequestFilter {
 		RecordApiTrafficPort recordApiTrafficPort,
 		ObjectProvider<Clock> clockProvider
 	) {
-		this(recordUserActivityPort, recordApiTrafficPort, clockProvider.getIfAvailable(Clock::systemDefaultZone));
+		this(
+			recordUserActivityPort,
+			recordApiTrafficPort,
+			clockProvider.getIfAvailable(Clock::systemDefaultZone),
+			System::nanoTime
+		);
 	}
 
 	UserActivityTrackingFilter(
@@ -43,9 +51,19 @@ class UserActivityTrackingFilter extends OncePerRequestFilter {
 		RecordApiTrafficPort recordApiTrafficPort,
 		Clock clock
 	) {
+		this(recordUserActivityPort, recordApiTrafficPort, clock, System::nanoTime);
+	}
+
+	UserActivityTrackingFilter(
+		RecordUserActivityPort recordUserActivityPort,
+		RecordApiTrafficPort recordApiTrafficPort,
+		Clock clock,
+		LongSupplier nanoTimeSupplier
+	) {
 		this.recordUserActivityPort = recordUserActivityPort;
 		this.recordApiTrafficPort = recordApiTrafficPort;
 		this.clock = clock;
+		this.nanoTimeSupplier = nanoTimeSupplier;
 		this.authenticationTrustResolver = new AuthenticationTrustResolverImpl();
 	}
 
@@ -55,10 +73,10 @@ class UserActivityTrackingFilter extends OncePerRequestFilter {
 		HttpServletResponse response,
 		FilterChain filterChain
 	) throws ServletException, IOException {
-		long startedAtMillis = clock.millis();
+		long startedAtNanos = nanoTimeSupplier.getAsLong();
 		LocalDateTime requestedAt = LocalDateTime.now(clock);
 		filterChain.doFilter(request, response);
-		long durationMillis = Math.max(0, clock.millis() - startedAtMillis);
+		long durationMillis = Duration.ofNanos(Math.max(0, nanoTimeSupplier.getAsLong() - startedAtNanos)).toMillis();
 		if (shouldRecordApiTraffic(request)) {
 			recordApiTrafficPort.recordApiTraffic(response.getStatus(), durationMillis, LocalDateTime.now(clock));
 		}

--- a/backend/src/main/java/com/easysubway/usage/adapter/out/persistence/InMemoryUserActivityRepository.java
+++ b/backend/src/main/java/com/easysubway/usage/adapter/out/persistence/InMemoryUserActivityRepository.java
@@ -37,16 +37,19 @@ public class InMemoryUserActivityRepository implements RecordUserActivityPort, R
 	}
 
 	@Override
-	public synchronized void recordApiTraffic(int statusCode, LocalDateTime occurredAt) {
+	public synchronized void recordApiTraffic(int statusCode, long durationMillis, LocalDateTime occurredAt) {
 		if (statusCode < 100 || statusCode > 599) {
 			throw new InvalidUserActivityException("API 응답 상태 코드는 100부터 599 사이여야 합니다.");
+		}
+		if (durationMillis < 0) {
+			throw new InvalidUserActivityException("API 응답 시간은 0 이상이어야 합니다.");
 		}
 		if (occurredAt == null) {
 			throw new InvalidUserActivityException("API 요청 시간이 필요합니다.");
 		}
 
 		apiTrafficByDate.computeIfAbsent(occurredAt.toLocalDate(), ignored -> new ApiTrafficCount())
-			.add(statusCode);
+			.add(statusCode, durationMillis);
 	}
 
 	@Override
@@ -69,26 +72,36 @@ public class InMemoryUserActivityRepository implements RecordUserActivityPort, R
 					date,
 					userIds.size(),
 					apiTrafficCount.requestCount(),
-					apiTrafficCount.errorCount()
+					apiTrafficCount.errorCount(),
+					apiTrafficCount.responseMillis()
 				);
 			})
 			.toList();
 		long totalApiRequests = rows.stream().mapToLong(DailyUserActivity::apiRequestCount).sum();
 		long totalApiErrors = rows.stream().mapToLong(DailyUserActivity::apiErrorCount).sum();
-		return new UserActivityDashboardSummary(activeUserIds.size(), totalApiRequests, totalApiErrors, rows);
+		long totalApiResponseMillis = rows.stream().mapToLong(DailyUserActivity::apiResponseMillis).sum();
+		return new UserActivityDashboardSummary(
+			activeUserIds.size(),
+			totalApiRequests,
+			totalApiErrors,
+			totalApiResponseMillis,
+			rows
+		);
 	}
 
 	private static final class ApiTrafficCount {
 
 		private long requestCount;
 		private long errorCount;
+		private long responseMillis;
 
 		static ApiTrafficCount empty() {
 			return new ApiTrafficCount();
 		}
 
-		void add(int statusCode) {
+		void add(int statusCode, long durationMillis) {
 			requestCount++;
+			responseMillis += durationMillis;
 			if (statusCode >= 400) {
 				errorCount++;
 			}
@@ -100,6 +113,10 @@ public class InMemoryUserActivityRepository implements RecordUserActivityPort, R
 
 		long errorCount() {
 			return errorCount;
+		}
+
+		long responseMillis() {
+			return responseMillis;
 		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/usage/application/port/out/RecordApiTrafficPort.java
+++ b/backend/src/main/java/com/easysubway/usage/application/port/out/RecordApiTrafficPort.java
@@ -4,5 +4,5 @@ import java.time.LocalDateTime;
 
 public interface RecordApiTrafficPort {
 
-	void recordApiTraffic(int statusCode, LocalDateTime occurredAt);
+	void recordApiTraffic(int statusCode, long durationMillis, LocalDateTime occurredAt);
 }

--- a/backend/src/main/java/com/easysubway/usage/domain/UserActivityDashboardSummary.java
+++ b/backend/src/main/java/com/easysubway/usage/domain/UserActivityDashboardSummary.java
@@ -8,6 +8,7 @@ public record UserActivityDashboardSummary(
 	long totalActiveUsers,
 	long totalApiRequests,
 	long totalApiErrors,
+	long totalApiResponseMillis,
 	List<DailyUserActivity> dailyActivities
 ) {
 
@@ -24,6 +25,12 @@ public record UserActivityDashboardSummary(
 		if (totalApiErrors > totalApiRequests) {
 			throw new InvalidUserActivityException("전체 API 오류 수는 전체 API 요청 수보다 클 수 없습니다.");
 		}
+		if (totalApiResponseMillis < 0) {
+			throw new InvalidUserActivityException("전체 API 응답 시간은 0 이상이어야 합니다.");
+		}
+		if (totalApiRequests == 0 && totalApiResponseMillis > 0) {
+			throw new InvalidUserActivityException("전체 API 요청이 없으면 응답 시간을 집계할 수 없습니다.");
+		}
 		dailyActivities = List.copyOf(dailyActivities);
 		long maxDailyCount = dailyActivities.stream()
 			.mapToLong(DailyUserActivity::activeUserCount)
@@ -38,11 +45,20 @@ public record UserActivityDashboardSummary(
 		return formatPercent(totalApiErrors, totalApiRequests);
 	}
 
+	public long averageApiResponseMillis() {
+		return averageMillis(totalApiResponseMillis, totalApiRequests);
+	}
+
+	public String averageApiResponseTimeLabel() {
+		return formatMillis(averageApiResponseMillis());
+	}
+
 	public record DailyUserActivity(
 		LocalDate date,
 		long activeUserCount,
 		long apiRequestCount,
-		long apiErrorCount
+		long apiErrorCount,
+		long apiResponseMillis
 	) {
 
 		public DailyUserActivity {
@@ -61,11 +77,36 @@ public record UserActivityDashboardSummary(
 			if (apiErrorCount > apiRequestCount) {
 				throw new InvalidUserActivityException("일별 API 오류 수는 일별 API 요청 수보다 클 수 없습니다.");
 			}
+			if (apiResponseMillis < 0) {
+				throw new InvalidUserActivityException("일별 API 응답 시간은 0 이상이어야 합니다.");
+			}
+			if (apiRequestCount == 0 && apiResponseMillis > 0) {
+				throw new InvalidUserActivityException("일별 API 요청이 없으면 응답 시간을 집계할 수 없습니다.");
+			}
 		}
 
 		public String apiErrorRatePercent() {
 			return formatPercent(apiErrorCount, apiRequestCount);
 		}
+
+		public long averageApiResponseMillis() {
+			return averageMillis(apiResponseMillis, apiRequestCount);
+		}
+
+		public String averageApiResponseTimeLabel() {
+			return formatMillis(averageApiResponseMillis());
+		}
+	}
+
+	private static long averageMillis(long totalMillis, long count) {
+		if (count == 0) {
+			return 0;
+		}
+		return totalMillis / count;
+	}
+
+	private static String formatMillis(long millis) {
+		return millis + "ms";
 	}
 
 	private static String formatPercent(long numerator, long denominator) {

--- a/backend/src/main/resources/templates/admin/usage/activity.html
+++ b/backend/src/main/resources/templates/admin/usage/activity.html
@@ -110,6 +110,10 @@
 			<span>API 오류율</span>
 			<strong th:text="${summary.apiErrorRatePercent}">0.0%</strong>
 		</div>
+		<div class="metric">
+			<span>평균 응답 시간</span>
+			<strong th:text="${summary.averageApiResponseTimeLabel}">0ms</strong>
+		</div>
 	</div>
 
 	<section>
@@ -122,6 +126,7 @@
 				<th scope="col">API 요청</th>
 				<th scope="col">오류 응답</th>
 				<th scope="col">API 오류율</th>
+				<th scope="col">평균 응답 시간</th>
 			</tr>
 			</thead>
 			<tbody>
@@ -131,6 +136,7 @@
 				<td th:text="${row.apiRequestCount}">0</td>
 				<td th:text="${row.apiErrorCount}">0</td>
 				<td th:text="${row.apiErrorRatePercent}">0.0%</td>
+				<td th:text="${row.averageApiResponseTimeLabel}">0ms</td>
 			</tr>
 			</tbody>
 		</table>

--- a/backend/src/test/java/com/easysubway/usage/adapter/in/web/UserActivityAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/usage/adapter/in/web/UserActivityAdminPageControllerTest.java
@@ -24,9 +24,10 @@ class UserActivityAdminPageControllerTest {
 			3,
 			12,
 			2,
+			3_240,
 			List.of(
-				new DailyUserActivity(LocalDate.of(2026, 6, 17), 2, 7, 1),
-				new DailyUserActivity(LocalDate.of(2026, 6, 16), 1, 5, 1)
+				new DailyUserActivity(LocalDate.of(2026, 6, 17), 2, 7, 1, 1_400),
+				new DailyUserActivity(LocalDate.of(2026, 6, 16), 1, 5, 1, 1_840)
 			)
 		));
 		var controller = new UserActivityAdminPageController(useCase);
@@ -41,9 +42,11 @@ class UserActivityAdminPageControllerTest {
 		assertThat(view.totalApiRequests()).isEqualTo(12);
 		assertThat(view.totalApiErrors()).isEqualTo(2);
 		assertThat(view.apiErrorRatePercent()).isEqualTo("16.7%");
+		assertThat(view.averageApiResponseMillis()).isEqualTo(270);
+		assertThat(view.averageApiResponseTimeLabel()).isEqualTo("270ms");
 		assertThat(view.dailyActivityRows())
-			.extracting(row -> row.dateLabel() + ":" + row.activeUserCount() + ":" + row.apiRequestCount() + ":" + row.apiErrorCount() + ":" + row.apiErrorRatePercent())
-			.containsExactly("2026-06-17:2:7:1:14.3%", "2026-06-16:1:5:1:20.0%");
+			.extracting(row -> row.dateLabel() + ":" + row.activeUserCount() + ":" + row.apiRequestCount() + ":" + row.apiErrorCount() + ":" + row.apiErrorRatePercent() + ":" + row.averageApiResponseTimeLabel())
+			.containsExactly("2026-06-17:2:7:1:14.3%:200ms", "2026-06-16:1:5:1:20.0%:368ms");
 		assertThat(view.toString()).doesNotContain("anonymous-user");
 	}
 }

--- a/backend/src/test/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilterTest.java
+++ b/backend/src/test/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilterTest.java
@@ -12,6 +12,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +31,8 @@ class UserActivityTrackingFilterTest {
 	);
 
 	private final RecordingUserActivityPort port = new RecordingUserActivityPort();
-	private final UserActivityTrackingFilter filter = new UserActivityTrackingFilter(port, port, FIXED_CLOCK);
+	private final MutableClock clock = new MutableClock(FIXED_CLOCK.instant(), FIXED_CLOCK.getZone());
+	private final UserActivityTrackingFilter filter = new UserActivityTrackingFilter(port, port, clock);
 
 	@Test
 	@DisplayName("성공한 인증 사용자 API 요청은 활동으로 기록한다")
@@ -38,38 +40,42 @@ class UserActivityTrackingFilterTest {
 		MockHttpServletRequest request = apiRequest("/api/v1/routes/search", "anonymous-user-1");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
-		filter.doFilter(request, response, successfulChain());
+		filter.doFilter(request, response, successfulChain(Duration.ofMillis(125)));
 
 		assertThat(port.records)
 			.extracting(record -> record.userId() + ":" + record.occurredAt())
 			.containsExactly("anonymous-user-1:2026-06-17T09:00");
 		assertThat(port.apiTrafficRecords)
-			.extracting(record -> record.statusCode() + ":" + record.occurredAt())
-			.containsExactly("200:2026-06-17T09:00");
+			.extracting(record -> record.statusCode() + ":" + record.durationMillis() + ":" + record.occurredAt())
+			.containsExactly("200:125:2026-06-17T09:00:00.125");
 	}
 
 	@Test
 	@DisplayName("실패 응답은 API 오류율에 기록하고 활성 사용자 지표에서는 제외한다")
 	void failedApiRequestsRecordTrafficAndSkipActiveUserMetric() throws Exception {
-		filter.doFilter(apiRequest("/api/v1/routes/search", "anonymous-user-1"), new MockHttpServletResponse(), failingChain());
+		filter.doFilter(
+			apiRequest("/api/v1/routes/search", "anonymous-user-1"),
+			new MockHttpServletResponse(),
+			failingChain(Duration.ofMillis(480))
+		);
 
 		assertThat(port.records).isEmpty();
 		assertThat(port.apiTrafficRecords)
-			.extracting(record -> record.statusCode() + ":" + record.occurredAt())
-			.containsExactly("500:2026-06-17T09:00");
+			.extracting(record -> record.statusCode() + ":" + record.durationMillis() + ":" + record.occurredAt())
+			.containsExactly("500:480:2026-06-17T09:00:00.480");
 	}
 
 	@Test
 	@DisplayName("인증 발급과 관리자 요청은 제외하고 일반 API 요청은 오류율에 기록한다")
 	void authAndAdminRequestsAreIgnoredFromTrafficMetric() throws Exception {
-		filter.doFilter(apiRequest("/api/v1/auth/anonymous", "anonymous-user-1"), new MockHttpServletResponse(), successfulChain());
-		filter.doFilter(apiRequest("/admin/routes/searches/page", "admin-user"), new MockHttpServletResponse(), successfulChain());
-		filter.doFilter(apiRequest("/api/v1/routes/search", null), new MockHttpServletResponse(), successfulChain());
+		filter.doFilter(apiRequest("/api/v1/auth/anonymous", "anonymous-user-1"), new MockHttpServletResponse(), successfulChain(Duration.ofMillis(90)));
+		filter.doFilter(apiRequest("/admin/routes/searches/page", "admin-user"), new MockHttpServletResponse(), successfulChain(Duration.ofMillis(95)));
+		filter.doFilter(apiRequest("/api/v1/routes/search", null), new MockHttpServletResponse(), successfulChain(Duration.ofMillis(110)));
 
 		assertThat(port.records).isEmpty();
 		assertThat(port.apiTrafficRecords)
-			.extracting(record -> record.statusCode() + ":" + record.occurredAt())
-			.containsExactly("200:2026-06-17T09:00");
+			.extracting(record -> record.statusCode() + ":" + record.durationMillis() + ":" + record.occurredAt())
+			.containsExactly("200:110:2026-06-17T09:00:00.295");
 	}
 
 	@Test
@@ -82,7 +88,7 @@ class UserActivityTrackingFilterTest {
 			AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")
 		));
 
-		filter.doFilter(request, new MockHttpServletResponse(), successfulChain());
+		filter.doFilter(request, new MockHttpServletResponse(), successfulChain(Duration.ofMillis(100)));
 
 		assertThat(port.records).isEmpty();
 	}
@@ -95,13 +101,17 @@ class UserActivityTrackingFilterTest {
 		return request;
 	}
 
-	private static FilterChain successfulChain() {
+	private FilterChain successfulChain(Duration duration) {
 		return (request, response) -> {
+			clock.advance(duration);
 		};
 	}
 
-	private static FilterChain failingChain() {
-		return (request, response) -> ((MockHttpServletResponse) response).setStatus(500);
+	private FilterChain failingChain(Duration duration) {
+		return (request, response) -> {
+			clock.advance(duration);
+			((MockHttpServletResponse) response).setStatus(500);
+		};
 	}
 
 	private static final class RecordingUserActivityPort implements RecordUserActivityPort, RecordApiTrafficPort {
@@ -115,14 +125,44 @@ class UserActivityTrackingFilterTest {
 		}
 
 		@Override
-		public void recordApiTraffic(int statusCode, LocalDateTime occurredAt) {
-			apiTrafficRecords.add(new ApiTrafficRecord(statusCode, occurredAt));
+		public void recordApiTraffic(int statusCode, long durationMillis, LocalDateTime occurredAt) {
+			apiTrafficRecords.add(new ApiTrafficRecord(statusCode, durationMillis, occurredAt));
+		}
+	}
+
+	private static final class MutableClock extends Clock {
+
+		private Instant instant;
+		private final ZoneId zone;
+
+		private MutableClock(Instant instant, ZoneId zone) {
+			this.instant = instant;
+			this.zone = zone;
+		}
+
+		@Override
+		public ZoneId getZone() {
+			return zone;
+		}
+
+		@Override
+		public Clock withZone(ZoneId zone) {
+			return new MutableClock(instant, zone);
+		}
+
+		@Override
+		public Instant instant() {
+			return instant;
+		}
+
+		private void advance(Duration duration) {
+			instant = instant.plus(duration);
 		}
 	}
 
 	private record Record(String userId, LocalDateTime occurredAt) {
 	}
 
-	private record ApiTrafficRecord(int statusCode, LocalDateTime occurredAt) {
+	private record ApiTrafficRecord(int statusCode, long durationMillis, LocalDateTime occurredAt) {
 	}
 }

--- a/backend/src/test/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilterTest.java
+++ b/backend/src/test/java/com/easysubway/usage/adapter/in/web/UserActivityTrackingFilterTest.java
@@ -32,7 +32,8 @@ class UserActivityTrackingFilterTest {
 
 	private final RecordingUserActivityPort port = new RecordingUserActivityPort();
 	private final MutableClock clock = new MutableClock(FIXED_CLOCK.instant(), FIXED_CLOCK.getZone());
-	private final UserActivityTrackingFilter filter = new UserActivityTrackingFilter(port, port, clock);
+	private final TestTicker ticker = new TestTicker();
+	private final UserActivityTrackingFilter filter = new UserActivityTrackingFilter(port, port, clock, ticker::nanoTime);
 
 	@Test
 	@DisplayName("성공한 인증 사용자 API 요청은 활동으로 기록한다")
@@ -47,7 +48,7 @@ class UserActivityTrackingFilterTest {
 			.containsExactly("anonymous-user-1:2026-06-17T09:00");
 		assertThat(port.apiTrafficRecords)
 			.extracting(record -> record.statusCode() + ":" + record.durationMillis() + ":" + record.occurredAt())
-			.containsExactly("200:125:2026-06-17T09:00:00.125");
+			.containsExactly("200:125:2026-06-17T09:00");
 	}
 
 	@Test
@@ -62,7 +63,7 @@ class UserActivityTrackingFilterTest {
 		assertThat(port.records).isEmpty();
 		assertThat(port.apiTrafficRecords)
 			.extracting(record -> record.statusCode() + ":" + record.durationMillis() + ":" + record.occurredAt())
-			.containsExactly("500:480:2026-06-17T09:00:00.480");
+			.containsExactly("500:480:2026-06-17T09:00");
 	}
 
 	@Test
@@ -75,7 +76,7 @@ class UserActivityTrackingFilterTest {
 		assertThat(port.records).isEmpty();
 		assertThat(port.apiTrafficRecords)
 			.extracting(record -> record.statusCode() + ":" + record.durationMillis() + ":" + record.occurredAt())
-			.containsExactly("200:110:2026-06-17T09:00:00.295");
+			.containsExactly("200:110:2026-06-17T09:00");
 	}
 
 	@Test
@@ -103,13 +104,13 @@ class UserActivityTrackingFilterTest {
 
 	private FilterChain successfulChain(Duration duration) {
 		return (request, response) -> {
-			clock.advance(duration);
+			ticker.advance(duration);
 		};
 	}
 
 	private FilterChain failingChain(Duration duration) {
 		return (request, response) -> {
-			clock.advance(duration);
+			ticker.advance(duration);
 			((MockHttpServletResponse) response).setStatus(500);
 		};
 	}
@@ -157,6 +158,19 @@ class UserActivityTrackingFilterTest {
 
 		private void advance(Duration duration) {
 			instant = instant.plus(duration);
+		}
+	}
+
+	private static final class TestTicker {
+
+		private long nanos;
+
+		private long nanoTime() {
+			return nanos;
+		}
+
+		private void advance(Duration duration) {
+			nanos += duration.toNanos();
 		}
 	}
 

--- a/backend/src/test/java/com/easysubway/usage/adapter/out/persistence/InMemoryUserActivityRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/usage/adapter/out/persistence/InMemoryUserActivityRepositoryTest.java
@@ -36,19 +36,21 @@ class InMemoryUserActivityRepositoryTest {
 	@Test
 	@DisplayName("최근 기간의 API 요청 수와 오류율을 일별로 집계한다")
 	void summarizeUserActivityIncludesApiTrafficErrorRate() {
-		repository.recordApiTraffic(200, LocalDateTime.of(2026, 6, 17, 9, 0));
-		repository.recordApiTraffic(404, LocalDateTime.of(2026, 6, 17, 9, 5));
-		repository.recordApiTraffic(500, LocalDateTime.of(2026, 6, 16, 11, 0));
-		repository.recordApiTraffic(200, LocalDateTime.of(2026, 6, 15, 11, 0));
+		repository.recordApiTraffic(200, 120, LocalDateTime.of(2026, 6, 17, 9, 0));
+		repository.recordApiTraffic(404, 280, LocalDateTime.of(2026, 6, 17, 9, 5));
+		repository.recordApiTraffic(500, 900, LocalDateTime.of(2026, 6, 16, 11, 0));
+		repository.recordApiTraffic(200, 50, LocalDateTime.of(2026, 6, 15, 11, 0));
 
 		var summary = repository.summarizeUserActivity(LocalDate.of(2026, 6, 17), 2);
 
 		assertThat(summary.totalApiRequests()).isEqualTo(3);
 		assertThat(summary.totalApiErrors()).isEqualTo(2);
 		assertThat(summary.apiErrorRatePercent()).isEqualTo("66.7%");
+		assertThat(summary.averageApiResponseMillis()).isEqualTo(433);
+		assertThat(summary.averageApiResponseTimeLabel()).isEqualTo("433ms");
 		assertThat(summary.dailyActivities())
-			.extracting(row -> row.date() + ":" + row.apiRequestCount() + ":" + row.apiErrorCount() + ":" + row.apiErrorRatePercent())
-			.containsExactly("2026-06-17:2:1:50.0%", "2026-06-16:1:1:100.0%");
+			.extracting(row -> row.date() + ":" + row.apiRequestCount() + ":" + row.apiErrorCount() + ":" + row.apiErrorRatePercent() + ":" + row.averageApiResponseMillis() + ":" + row.averageApiResponseTimeLabel())
+			.containsExactly("2026-06-17:2:1:50.0%:200:200ms", "2026-06-16:1:1:100.0%:900:900ms");
 	}
 
 	@Test
@@ -62,8 +64,16 @@ class InMemoryUserActivityRepositoryTest {
 	@Test
 	@DisplayName("잘못된 API 상태 코드는 운영 지표로 저장하지 않는다")
 	void recordApiTrafficRejectsInvalidStatusCode() {
-		assertThatThrownBy(() -> repository.recordApiTraffic(99, LocalDateTime.of(2026, 6, 17, 9, 0)))
+		assertThatThrownBy(() -> repository.recordApiTraffic(99, 120, LocalDateTime.of(2026, 6, 17, 9, 0)))
 			.isInstanceOf(InvalidUserActivityException.class)
 			.hasMessage("API 응답 상태 코드는 100부터 599 사이여야 합니다.");
+	}
+
+	@Test
+	@DisplayName("음수 API 응답 시간은 운영 지표로 저장하지 않는다")
+	void recordApiTrafficRejectsNegativeDuration() {
+		assertThatThrownBy(() -> repository.recordApiTraffic(200, -1, LocalDateTime.of(2026, 6, 17, 9, 0)))
+			.isInstanceOf(InvalidUserActivityException.class)
+			.hasMessage("API 응답 시간은 0 이상이어야 합니다.");
 	}
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2034,19 +2034,25 @@ test("관리자 사용자 활동 화면은 API 오류율 운영 지표를 표시
   const repositoryTest = read("backend/src/test/java/com/easysubway/usage/adapter/out/persistence/InMemoryUserActivityRepositoryTest.java");
 
   assert.match(userActivityFilter, /RecordApiTrafficPort/);
-  assert.match(userActivityFilter, /recordApiTraffic\(\s*response\.getStatus\(\),\s*LocalDateTime\.now\(clock\)\s*\)/);
+  assert.match(userActivityFilter, /recordApiTraffic\(\s*response\.getStatus\(\),\s*durationMillis,\s*LocalDateTime\.now\(clock\)\s*\)/);
   assert.match(userActivityFilter, /response\.getStatus\(\) < 400/);
   assert.match(summary, /totalApiRequests/);
   assert.match(summary, /totalApiErrors/);
+  assert.match(summary, /totalApiResponseMillis/);
   assert.match(summary, /apiErrorRatePercent\(\)/);
-  assert.match(repository, /recordApiTraffic\(int statusCode, LocalDateTime occurredAt\)/);
+  assert.match(summary, /averageApiResponseTimeLabel\(\)/);
+  assert.match(repository, /recordApiTraffic\(int statusCode, long durationMillis, LocalDateTime occurredAt\)/);
   assert.match(repository, /statusCode >= 400/);
+  assert.match(repository, /durationMillis/);
   assert.match(controller, /apiErrorRatePercent/);
+  assert.match(controller, /averageApiResponseTimeLabel/);
   assert.match(template, /API 오류율/);
+  assert.match(template, /평균 응답 시간/);
   assert.match(template, /API 요청/);
   assert.match(template, /오류 응답/);
   assert.match(filterTest, /실패 응답은 API 오류율에 기록하고 활성 사용자 지표에서는 제외한다/);
   assert.match(repositoryTest, /최근 기간의 API 요청 수와 오류율을 일별로 집계한다/);
+  assert.match(repositoryTest, /음수 API 응답 시간은 운영 지표로 저장하지 않는다/);
 });
 
 test("iOS 앱은 개인정보 매니페스트를 번들 리소스로 포함한다", () => {


### PR DESCRIPTION
## 관련 이슈

close #341

## 작업 배경

- 운영 지표에는 API 응답 시간이 포함되어야 하지만 관리자 사용자 활동 화면은 요청 수와 오류율만 보여 줍니다.
- 장애 전조나 성능 저하를 빠르게 확인할 수 있도록 최근 API 요청의 평균 처리 시간을 개인정보 없이 집계하는 기준선이 필요합니다.

## 작업 내용

- API 트래픽 기록 포트가 상태 코드와 함께 처리 시간(ms)을 받도록 확장했습니다.
- 사용자 활동 추적 필터가 `/api/v1/**` 일반 API 요청의 처리 시간을 측정해 운영 지표로 기록하도록 했습니다.
- 익명 인증 API와 관리자 화면 요청은 기존처럼 API 운영 지표에서 제외했습니다.
- 인메모리 사용자 활동 저장소가 최근 7일 전체/일별 평균 API 응답 시간을 계산하도록 확장했습니다.
- 관리자 사용자 활동 화면에 전체/일별 평균 응답 시간을 표시했습니다.
- repository contract와 backend tests로 응답 시간 집계 계약과 화면 문구를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests "com.easysubway.usage.*"`: RED 실패 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs`: RED 실패 확인 후 구현 뒤 통과, 43개 테스트
  - `backend/gradlew -p backend test`: 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/api-response-time-dashboard.md .codex/issue-api-response-time-dashboard.local.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - CodeRabbit: rate limit으로 실제 리뷰 미시작, Codex CLI fallback review `4520743822`에서 응답 시간 측정 시간원 지적 1건 확인
  - 리뷰 지적 수정 커밋 `050b75a`: `System.nanoTime()` 기반 단조 시간원으로 처리 시간 측정 변경
  - 수정 후 `backend/gradlew -p backend test --tests "com.easysubway.usage.*"`: 통과
  - 수정 후 `node --test tools/ci/repository-contract.test.mjs`: 통과, 43개 테스트
  - 수정 후 `backend/gradlew -p backend test`: 통과
  - 수정 후 `git diff --check`: 통과
  - Codex CLI 재검토: 추가 지적 0건
  - PR CI run `27729989943`: 통과
  - merge 후 main CI run `27730195715`: 통과
  - merge 후 main CD run `27730195720`: 통과

## 리뷰어 메모

- 새 집계는 API 경로, query string, request body, 사용자 ID, IP를 저장하지 않고 상태 코드, 발생 날짜, 처리 시간만 사용합니다.
- 활성 사용자 수는 기존처럼 성공한 인증 사용자 API 요청 기준을 유지합니다.
- 평균 응답 시간은 총 처리 시간 ÷ 요청 수의 ms 단위 정수값으로 표시합니다.

## 리스크

- 현재 구현은 인메모리 운영 지표 기준선입니다. 운영 프로필의 영속 저장소와 percentile 지표는 별도 작업에서 다뤄야 합니다.
- 필터 체인 밖으로 전파된 예외는 응답 상태와 처리 시간이 확정되지 않아 이번 기준선 집계에 포함되지 않을 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다. (PR CI run `27729989943` 통과)
- [x] CodeRabbit 리뷰를 확인했다. (rate limit으로 실제 리뷰 미시작, Codex CLI fallback 사용)
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (지적 1건 수정, 재검토 0건)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (main CD run `27730195720` 통과)
