### PR TITLE
[Feat] 관리자 경로 실패 신고 최근 현황 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageController.java
@@ -1,7 +1,9 @@
 package com.easysubway.route.adapter.in.web;
 
+import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteFeedbackDashboardUseCase;
 import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -28,8 +30,12 @@ class RouteFeedbackAdminPageController {
 		long helpfulCount,
 		long notHelpfulCount,
 		long blockedByRealWorldCount,
-		List<RatingCountRow> ratingRows
+		List<RatingCountRow> ratingRows,
+		List<RecentBlockedFeedbackRow> recentBlockedFeedbacks
 	) {
+
+		private static final DateTimeFormatter RECENT_FEEDBACK_TIME_FORMATTER =
+			DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
 		static RouteFeedbackDashboardView from(RouteFeedbackDashboardSummary summary) {
 			return new RouteFeedbackDashboardView(
@@ -41,11 +47,39 @@ class RouteFeedbackAdminPageController {
 					new RatingCountRow("도움이 됨", "경로 안내가 실제 이동에 도움됨", summary.helpfulCount()),
 					new RatingCountRow("도움이 안 됨", "경로 안내가 실제 이동과 맞지 않음", summary.notHelpfulCount()),
 					new RatingCountRow("현장 차단", "엘리베이터 고장, 공사, 폐쇄 등으로 이동 불가", summary.blockedByRealWorldCount())
-				)
+				),
+				summary.recentBlockedFeedbacks()
+					.stream()
+					.map(row -> new RecentBlockedFeedbackRow(
+						row.createdAt().format(RECENT_FEEDBACK_TIME_FORMATTER),
+						row.originStationName(),
+						row.destinationStationName(),
+						mobilityTypeLabel(row.mobilityType())
+					))
+					.toList()
 			);
+		}
+
+		private static String mobilityTypeLabel(MobilityType mobilityType) {
+			return switch (mobilityType) {
+				case SENIOR -> "고령자";
+				case STROLLER -> "유모차";
+				case WHEELCHAIR -> "휠체어";
+				case PREGNANT -> "임산부";
+				case TEMPORARY_INJURY -> "일시 부상";
+				case LUGGAGE -> "큰 짐";
+			};
 		}
 	}
 
 	record RatingCountRow(String label, String description, long count) {
+	}
+
+	record RecentBlockedFeedbackRow(
+		String createdAtLabel,
+		String originStationName,
+		String destinationStationName,
+		String mobilityTypeLabel
+	) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
@@ -10,6 +10,7 @@ import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteS
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchStationPair;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
+import com.easysubway.route.domain.RouteFeedbackDashboardSummary.RecentBlockedFeedback;
 import com.easysubway.route.domain.RouteFeedbackRating;
 import com.easysubway.route.domain.RouteSearchDashboardSummary;
 import com.easysubway.route.domain.RouteSearchDashboardSummary.MobilityTypeCount;
@@ -17,9 +18,11 @@ import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.user.application.port.out.AnonymizeUserRouteFeedbackPort;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
@@ -73,7 +76,8 @@ public class InMemoryRouteSearchRepository
 				routeFeedbacks.size(),
 				helpfulCount,
 				notHelpfulCount,
-				blockedByRealWorldCount
+				blockedByRealWorldCount,
+				recentBlockedFeedbacks()
 			);
 		}
 	}
@@ -148,6 +152,32 @@ public class InMemoryRouteSearchRepository
 			.stream()
 			.filter(feedback -> feedback.rating() == rating)
 			.count();
+	}
+
+	private List<RecentBlockedFeedback> recentBlockedFeedbacks() {
+		synchronized (routeSearches) {
+			return routeFeedbacks.values()
+				.stream()
+				.filter(feedback -> feedback.rating() == RouteFeedbackRating.BLOCKED_BY_REAL_WORLD)
+				.map(this::toRecentBlockedFeedback)
+				.filter(Objects::nonNull)
+				.sorted(Comparator.comparing(RecentBlockedFeedback::createdAt).reversed())
+				.limit(5)
+				.toList();
+		}
+	}
+
+	private RecentBlockedFeedback toRecentBlockedFeedback(RouteFeedback feedback) {
+		RouteSearchResult routeSearch = routeSearches.get(feedback.routeSearchId());
+		if (routeSearch == null) {
+			return null;
+		}
+		return new RecentBlockedFeedback(
+			routeSearch.originStationName(),
+			routeSearch.destinationStationName(),
+			routeSearch.mobilityType(),
+			feedback.createdAt()
+		);
 	}
 
 	private long countByStatus(RouteSearchStatus status) {

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
@@ -10,6 +10,7 @@ import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteS
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchStationPair;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
+import com.easysubway.route.domain.RouteFeedbackDashboardSummary.RecentBlockedFeedback;
 import com.easysubway.route.domain.RouteSearchDashboardSummary;
 import com.easysubway.route.domain.RouteSearchDashboardSummary.MobilityTypeCount;
 import com.easysubway.route.domain.RouteSearchResult;
@@ -110,7 +111,7 @@ public class JdbcRouteSearchRepository
 
 	@Override
 	public RouteFeedbackDashboardSummary summarizeRouteFeedbacks() {
-		return jdbcTemplate.queryForObject(
+		RouteFeedbackDashboardSummary countSummary = jdbcTemplate.queryForObject(
 			"""
 				SELECT COUNT(*) AS total_count,
 					SUM(CASE WHEN rating = 'HELPFUL' THEN 1 ELSE 0 END) AS helpful_count,
@@ -122,7 +123,38 @@ public class JdbcRouteSearchRepository
 				resultSet.getLong("total_count"),
 				resultSet.getLong("helpful_count"),
 				resultSet.getLong("not_helpful_count"),
-				resultSet.getLong("blocked_by_real_world_count")
+				resultSet.getLong("blocked_by_real_world_count"),
+				List.of()
+			)
+		);
+		return new RouteFeedbackDashboardSummary(
+			countSummary.totalCount(),
+			countSummary.helpfulCount(),
+			countSummary.notHelpfulCount(),
+			countSummary.blockedByRealWorldCount(),
+			loadRecentBlockedFeedbacks()
+		);
+	}
+
+	private List<RecentBlockedFeedback> loadRecentBlockedFeedbacks() {
+		return jdbcTemplate.query(
+			"""
+				SELECT route_search_results.origin_station_name,
+					route_search_results.destination_station_name,
+					route_search_results.mobility_type,
+					route_feedbacks.created_at AS feedback_created_at
+				FROM route_feedbacks
+				JOIN route_search_results
+					ON route_feedbacks.route_search_id = route_search_results.route_search_id
+				WHERE route_feedbacks.rating = 'BLOCKED_BY_REAL_WORLD'
+				ORDER BY feedback_created_at DESC, route_feedbacks.feedback_id
+				LIMIT 5
+				""",
+			(resultSet, rowNumber) -> new RecentBlockedFeedback(
+				resultSet.getString("origin_station_name"),
+				resultSet.getString("destination_station_name"),
+				MobilityType.valueOf(resultSet.getString("mobility_type")),
+				resultSet.getTimestamp("feedback_created_at").toLocalDateTime()
 			)
 		);
 	}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteFeedbackDashboardSummary.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteFeedbackDashboardSummary.java
@@ -1,10 +1,15 @@
 package com.easysubway.route.domain;
 
+import com.easysubway.profile.domain.MobilityType;
+import java.time.LocalDateTime;
+import java.util.List;
+
 public record RouteFeedbackDashboardSummary(
 	long totalCount,
 	long helpfulCount,
 	long notHelpfulCount,
-	long blockedByRealWorldCount
+	long blockedByRealWorldCount,
+	List<RecentBlockedFeedback> recentBlockedFeedbacks
 ) {
 
 	public RouteFeedbackDashboardSummary {
@@ -13,6 +18,30 @@ public record RouteFeedbackDashboardSummary(
 		}
 		if (totalCount != helpfulCount + notHelpfulCount + blockedByRealWorldCount) {
 			throw new InvalidRouteFeedbackException("전체 경로 피드백 수와 평점별 피드백 수가 일치하지 않습니다.");
+		}
+		recentBlockedFeedbacks = List.copyOf(recentBlockedFeedbacks);
+	}
+
+	public record RecentBlockedFeedback(
+		String originStationName,
+		String destinationStationName,
+		MobilityType mobilityType,
+		LocalDateTime createdAt
+	) {
+
+		public RecentBlockedFeedback {
+			if (originStationName == null || originStationName.isBlank()) {
+				throw new InvalidRouteFeedbackException("현장 차단 신고 출발역 이름이 필요합니다.");
+			}
+			if (destinationStationName == null || destinationStationName.isBlank()) {
+				throw new InvalidRouteFeedbackException("현장 차단 신고 도착역 이름이 필요합니다.");
+			}
+			if (mobilityType == null) {
+				throw new InvalidRouteFeedbackException("현장 차단 신고 이동 프로필이 필요합니다.");
+			}
+			if (createdAt == null) {
+				throw new InvalidRouteFeedbackException("현장 차단 신고 시각이 필요합니다.");
+			}
 		}
 	}
 }

--- a/backend/src/main/resources/templates/admin/routes/feedback.html
+++ b/backend/src/main/resources/templates/admin/routes/feedback.html
@@ -88,6 +88,10 @@
 			text-align: right;
 			font-weight: 800;
 		}
+
+		section + section {
+			margin-top: 24px;
+		}
 	</style>
 </head>
 <body>
@@ -128,6 +132,31 @@
 				<td th:text="${row.label}">도움이 됨</td>
 				<td th:text="${row.description}">경로 안내가 실제 이동에 도움됨</td>
 				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>최근 현장 차단 신고</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">신고 시각</th>
+				<th scope="col">출발역</th>
+				<th scope="col">도착역</th>
+				<th scope="col">이동 프로필</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.recentBlockedFeedbacks}">
+				<td th:text="${row.createdAtLabel}">2026-06-17 10:00</td>
+				<td th:text="${row.originStationName}">상록수</td>
+				<td th:text="${row.destinationStationName}">사당</td>
+				<td th:text="${row.mobilityTypeLabel}">고령자</td>
+			</tr>
+			<tr th:if="${#lists.isEmpty(summary.recentBlockedFeedbacks)}">
+				<td colspan="4">최근 현장 차단 신고가 없습니다.</td>
 			</tr>
 			</tbody>
 		</table>

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageControllerTest.java
@@ -55,7 +55,12 @@ class RouteFeedbackAdminPageControllerTest {
 			.contains("경로 안내가 실제 이동에 도움됨")
 			.contains("경로 안내가 실제 이동과 맞지 않음")
 			.contains("엘리베이터 고장, 공사, 폐쇄 등으로 이동 불가")
+			.contains("최근 현장 차단 신고")
+			.contains("상록수")
+			.contains("사당")
+			.contains("고령자")
 			.doesNotContain("anonymous-user-1")
+			.doesNotContain(routeSearchId)
 			.doesNotContain("엘리베이터가 막혀 있었어요");
 	}
 

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepositoryTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.domain.RouteFeedback;
+import com.easysubway.route.domain.RouteFeedbackRating;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import java.time.LocalDateTime;
@@ -31,14 +33,58 @@ class InMemoryRouteSearchRepositoryTest {
 			.contains(tuple("station-a", "station-b"));
 	}
 
+	@Test
+	@DisplayName("최근 현장 차단 신고는 연결된 경로 정보와 함께 최신순으로 집계한다")
+	void summarizeRecentBlockedFeedbacksWithRouteContext() {
+		var repository = new InMemoryRouteSearchRepository();
+		repository.saveRouteSearch(routeSearchResult("route-1", "상록수", "사당", MobilityType.SENIOR));
+		repository.saveRouteSearch(routeSearchResult("route-2", "서울역", "시청", MobilityType.WHEELCHAIR));
+		repository.saveRouteFeedback(routeFeedback(
+			"feedback-1",
+			"route-1",
+			RouteFeedbackRating.BLOCKED_BY_REAL_WORLD,
+			LocalDateTime.of(2026, 6, 17, 10, 0)
+		));
+		repository.saveRouteFeedback(routeFeedback(
+			"feedback-2",
+			"route-2",
+			RouteFeedbackRating.BLOCKED_BY_REAL_WORLD,
+			LocalDateTime.of(2026, 6, 17, 11, 0)
+		));
+		repository.saveRouteFeedback(routeFeedback(
+			"feedback-3",
+			"route-1",
+			RouteFeedbackRating.NOT_HELPFUL,
+			LocalDateTime.of(2026, 6, 17, 12, 0)
+		));
+
+		var summary = repository.summarizeRouteFeedbacks();
+
+		assertThat(summary.recentBlockedFeedbacks())
+			.extracting("originStationName", "destinationStationName", "mobilityType", "createdAt")
+			.containsExactly(
+				tuple("서울역", "시청", MobilityType.WHEELCHAIR, LocalDateTime.of(2026, 6, 17, 11, 0)),
+				tuple("상록수", "사당", MobilityType.SENIOR, LocalDateTime.of(2026, 6, 17, 10, 0))
+			);
+	}
+
 	private RouteSearchResult routeSearchResult(String routeSearchId) {
+		return routeSearchResult(routeSearchId, "출발역", "도착역", MobilityType.SENIOR);
+	}
+
+	private RouteSearchResult routeSearchResult(
+		String routeSearchId,
+		String originStationName,
+		String destinationStationName,
+		MobilityType mobilityType
+	) {
 		return new RouteSearchResult(
 			routeSearchId,
 			"station-a",
-			"출발역",
+			originStationName,
 			"station-b",
-			"도착역",
-			MobilityType.SENIOR,
+			destinationStationName,
+			mobilityType,
 			RouteSearchStatus.FOUND,
 			"line-a",
 			"테스트 노선",
@@ -47,6 +93,22 @@ class InMemoryRouteSearchRepositoryTest {
 			List.of(),
 			List.of(),
 			LocalDateTime.of(2026, 6, 13, 9, 0)
+		);
+	}
+
+	private RouteFeedback routeFeedback(
+		String feedbackId,
+		String routeSearchId,
+		RouteFeedbackRating rating,
+		LocalDateTime createdAt
+	) {
+		return new RouteFeedback(
+			feedbackId,
+			routeSearchId,
+			"anonymous-user",
+			rating,
+			"관리자 화면에 직접 노출하지 않는 코멘트",
+			createdAt
 		);
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
@@ -176,6 +176,43 @@ class JdbcRouteSearchRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("최근 현장 차단 신고는 경로 검색 정보와 조인해 최신순으로 집계한다")
+	void summarizeRecentBlockedFeedbacksWithRouteSearchContext() {
+		repository.saveRouteSearch(directRouteSearch("route-search-1", "상록수", "사당"));
+		repository.saveRouteSearch(transferRouteSearch("route-search-2"));
+		repository.saveRouteFeedback(routeFeedback(
+			"feedback-1",
+			"route-search-1",
+			RouteFeedbackRating.BLOCKED_BY_REAL_WORLD,
+			"엘리베이터가 막혀 있었습니다.",
+			LocalDateTime.of(2026, 6, 17, 10, 0)
+		));
+		repository.saveRouteFeedback(routeFeedback(
+			"feedback-2",
+			"route-search-2",
+			RouteFeedbackRating.BLOCKED_BY_REAL_WORLD,
+			"공사로 이동할 수 없었습니다.",
+			LocalDateTime.of(2026, 6, 17, 11, 0)
+		));
+		repository.saveRouteFeedback(routeFeedback(
+			"feedback-3",
+			"route-search-1",
+			RouteFeedbackRating.NOT_HELPFUL,
+			"설명이 부족했습니다.",
+			LocalDateTime.of(2026, 6, 17, 12, 0)
+		));
+
+		var summary = repository.summarizeRouteFeedbacks();
+
+		assertThat(summary.recentBlockedFeedbacks())
+			.extracting("originStationName", "destinationStationName", "mobilityType", "createdAt")
+			.containsExactly(
+				tuple("출발역", "도착역", MobilityType.WHEELCHAIR, LocalDateTime.of(2026, 6, 17, 11, 0)),
+				tuple("상록수", "사당", MobilityType.SENIOR, LocalDateTime.of(2026, 6, 17, 10, 0))
+			);
+	}
+
+	@Test
 	@DisplayName("경로 검색 결과를 상태와 이동 프로필별로 집계한다")
 	void summarizeRouteSearchesByStatusAndMobilityType() {
 		repository.saveRouteSearch(directRouteSearch("route-search-1", "상록수", "사당"));
@@ -271,13 +308,29 @@ class JdbcRouteSearchRepositoryTest {
 	}
 
 	private RouteFeedback routeFeedback(String feedbackId, RouteFeedbackRating rating, String comment) {
-		return new RouteFeedback(
+		return routeFeedback(
 			feedbackId,
 			"route-search-1",
-			"anonymous-user-1",
 			rating,
 			comment,
 			LocalDateTime.of(2026, 6, 17, 10, 0)
+		);
+	}
+
+	private RouteFeedback routeFeedback(
+		String feedbackId,
+		String routeSearchId,
+		RouteFeedbackRating rating,
+		String comment,
+		LocalDateTime createdAt
+	) {
+		return new RouteFeedback(
+			feedbackId,
+			routeSearchId,
+			"anonymous-user-1",
+			rating,
+			comment,
+			createdAt
 		);
 	}
 

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteFeedbackDashboardServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteFeedbackDashboardServiceTest.java
@@ -1,11 +1,16 @@
 package com.easysubway.route.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
+import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteFeedbackRating;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -29,14 +34,98 @@ class RouteFeedbackDashboardServiceTest {
 		assertThat(summary.blockedByRealWorldCount()).isEqualTo(1);
 	}
 
+	@Test
+	@DisplayName("최근 현장 차단 신고를 사용자 정보 없이 최신순으로 집계한다")
+	void summarizeRecentBlockedRouteFeedbacks() {
+		var repository = new InMemoryRouteSearchRepository();
+		repository.saveRouteSearch(routeSearch("route-search-1", "상록수", "사당", MobilityType.SENIOR));
+		repository.saveRouteSearch(routeSearch("route-search-2", "서울역", "시청", MobilityType.WHEELCHAIR));
+		repository.saveRouteFeedback(routeFeedback(
+			"feedback-1",
+			"route-search-1",
+			RouteFeedbackRating.BLOCKED_BY_REAL_WORLD,
+			"anonymous-user-1",
+			"엘리베이터가 막혀 있었어요",
+			LocalDateTime.of(2026, 6, 17, 10, 0)
+		));
+		repository.saveRouteFeedback(routeFeedback(
+			"feedback-2",
+			"route-search-2",
+			RouteFeedbackRating.BLOCKED_BY_REAL_WORLD,
+			"anonymous-user-2",
+			"공사로 우회가 필요했어요",
+			LocalDateTime.of(2026, 6, 17, 11, 0)
+		));
+		repository.saveRouteFeedback(routeFeedback(
+			"feedback-3",
+			"route-search-1",
+			RouteFeedbackRating.HELPFUL,
+			"anonymous-user-3",
+			"도움이 됐어요",
+			LocalDateTime.of(2026, 6, 17, 12, 0)
+		));
+		var service = new RouteFeedbackDashboardService(repository);
+
+		var summary = service.summarizeRouteFeedbacks();
+
+		assertThat(summary.recentBlockedFeedbacks())
+			.extracting("originStationName", "destinationStationName", "mobilityType", "createdAt")
+			.containsExactly(
+				tuple("서울역", "시청", MobilityType.WHEELCHAIR, LocalDateTime.of(2026, 6, 17, 11, 0)),
+				tuple("상록수", "사당", MobilityType.SENIOR, LocalDateTime.of(2026, 6, 17, 10, 0))
+			);
+	}
+
 	private RouteFeedback routeFeedback(String feedbackId, RouteFeedbackRating rating) {
-		return new RouteFeedback(
+		return routeFeedback(
 			feedbackId,
 			"route-search-1",
-			"anonymous-user-1",
 			rating,
+			"anonymous-user-1",
 			"경로 피드백 " + feedbackId,
 			LocalDateTime.of(2026, 6, 17, 10, 0)
+		);
+	}
+
+	private RouteFeedback routeFeedback(
+		String feedbackId,
+		String routeSearchId,
+		RouteFeedbackRating rating,
+		String userId,
+		String comment,
+		LocalDateTime createdAt
+	) {
+		return new RouteFeedback(
+			feedbackId,
+			routeSearchId,
+			userId,
+			rating,
+			comment,
+			createdAt
+		);
+	}
+
+	private RouteSearchResult routeSearch(
+		String routeSearchId,
+		String originStationName,
+		String destinationStationName,
+		MobilityType mobilityType
+	) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-origin-" + routeSearchId,
+			originStationName,
+			"station-destination-" + routeSearchId,
+			destinationStationName,
+			mobilityType,
+			RouteSearchStatus.FOUND,
+			"line-a",
+			"테스트 노선",
+			90,
+			List.of(),
+			List.of(),
+			List.of(),
+			LocalDateTime.of(2026, 6, 17, 9, 0)
 		);
 	}
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1679,6 +1679,8 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(feedbackSummary, /helpfulCount/);
   assert.match(feedbackSummary, /notHelpfulCount/);
   assert.match(feedbackSummary, /blockedByRealWorldCount/);
+  assert.match(feedbackSummary, /recentBlockedFeedbacks/);
+  assert.match(feedbackSummary, /RecentBlockedFeedback/);
   assert.match(status, /FOUND/);
   assert.match(status, /BLOCKED/);
   assert.match(warning, /record RouteWarning/);
@@ -1739,6 +1741,9 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(jdbcRepository, /same DB statement snapshot|같은 DB statement snapshot/);
   assert.match(jdbcRepository, /RouteFeedbackDashboardSummary summarizeRouteFeedbacks\(\)/);
   assert.match(jdbcRepository, /SUM\(CASE WHEN rating = 'HELPFUL' THEN 1 ELSE 0 END\)/);
+  assert.match(jdbcRepository, /rating = 'BLOCKED_BY_REAL_WORLD'/);
+  assert.match(jdbcRepository, /JOIN route_search_results/);
+  assert.match(jdbcRepository, /ORDER BY feedback_created_at DESC/);
   assert.match(jdbcRepository, /ON CONFLICT \(route_search_id\) DO UPDATE/);
   assert.match(jdbcRepository, /ON CONFLICT \(feedback_id\) DO UPDATE/);
   assert.match(jdbcRepository, /steps_json/);
@@ -1761,10 +1766,18 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.doesNotMatch(searchDashboardTemplate, /routeSearchId/);
   assert.match(feedbackDashboardController, /@GetMapping\("\/admin\/routes\/feedback\/page"\)/);
   assert.match(feedbackDashboardController, /RouteFeedbackDashboardUseCase/);
+  assert.match(feedbackDashboardController, /recentBlockedFeedbacks/);
+  assert.match(feedbackDashboardController, /mobilityTypeLabel/);
   assert.match(feedbackDashboardTemplate, /경로 피드백 현황/);
   assert.match(feedbackDashboardTemplate, /전체 피드백/);
   assert.match(feedbackDashboardTemplate, /평점별 피드백/);
+  assert.match(feedbackDashboardTemplate, /최근 현장 차단 신고/);
+  assert.match(feedbackDashboardTemplate, /출발역/);
+  assert.match(feedbackDashboardTemplate, /도착역/);
+  assert.match(feedbackDashboardTemplate, /이동 프로필/);
   assert.doesNotMatch(feedbackDashboardTemplate, /userId/);
+  assert.doesNotMatch(feedbackDashboardTemplate, /routeSearchId/);
+  assert.doesNotMatch(feedbackDashboardTemplate, /comment/);
 });
 
 test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다", () => {


### PR DESCRIPTION
## 관련 이슈

close #343

## 작업 배경

- 관리자 경로 피드백 화면은 전체/평점별 건수만 보여 줘서 최근 현장 차단 신고가 어느 출발/도착역 조합에서 발생했는지 바로 확인하기 어렵습니다.
- 운영자는 사용자 식별자나 자유 입력 코멘트 없이도 최근 차단 신고의 이동 맥락을 보고 데이터 검수 우선순위를 정할 수 있어야 합니다.

## 작업 내용

- 경로 피드백 대시보드 요약에 최근 현장 차단 신고 행을 추가했습니다.
- 최근 현황은 신고 시각, 출발역, 도착역, 이동 프로필만 포함하도록 했습니다.
- 인메모리 저장소와 JDBC 저장소가 `BLOCKED_BY_REAL_WORLD` 피드백을 경로 검색 결과와 연결해 최신 5건을 반환하도록 했습니다.
- 관리자 경로 피드백 화면에 최근 현장 차단 신고 섹션을 추가했습니다.
- route tests와 repository contract로 개인정보 비노출 및 최신순 정렬 계약을 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests "com.easysubway.route.*"`: RED 실패 확인 후 구현 뒤 통과
  - `node --test tools/ci/repository-contract.test.mjs`: RED 실패 확인 후 구현 뒤 통과, 43개 테스트
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/route-blocked-feedback-recent.md .codex/issue-route-blocked-feedback-recent.local.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - `backend/gradlew -p backend test`: 통과
  - CodeRabbit: rate limit으로 실제 리뷰 미시작, Codex CLI fallback review `4520864219`에서 추가 지적 0건 확인
  - PR CI run `27730728962`: 통과
  - merge 후 main CI run `27730954563`: 통과
  - merge 후 main CD run `27730954544`: 통과

## 리뷰어 메모

- 최근 현장 차단 신고 목록은 `userId`, `routeSearchId`, 자유 입력 `comment`를 관리자 목록에 표시하지 않습니다.
- 운영자가 바로 판단할 수 있는 출발역/도착역/이동 프로필/신고 시각만 노출합니다.
- JDBC 조회는 기존 `route_feedbacks`와 `route_search_results`를 조인하므로 신규 컬럼이나 스키마 변경은 없습니다.

## 리스크

- 현재 최근 목록은 최신 5건 기준입니다. 기간 필터, 반복 신고 집계, 역별 drill-down은 별도 작업이 필요합니다.
- 경로 검색 결과가 이미 삭제된 피드백은 최근 목록에서 제외됩니다.

## 체크리스트

- [x] CI 결과를 확인했다. (PR CI run `27730728962` 통과)
- [x] CodeRabbit 리뷰를 확인했다. (rate limit으로 실제 리뷰 미시작, Codex CLI fallback 사용)
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (추가 지적 0건)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (main CD run `27730954544` 통과)
