### PR TITLE
[Feat] 운영기관 접근성 시설 현황 리포트 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportPageController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportPageController.java
@@ -1,0 +1,205 @@
+package com.easysubway.operator.adapter.in.web;
+
+import com.easysubway.quality.application.port.in.DataQualityUseCase;
+import com.easysubway.quality.domain.AccessibilityImprovementPriority;
+import com.easysubway.quality.domain.DataQualitySummary;
+import com.easysubway.quality.domain.RegionDataQualitySummary;
+import com.easysubway.quality.domain.StationAccessibilityScore;
+import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
+import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.StationNotFoundException;
+import com.easysubway.transit.domain.StationWithLines;
+import com.easysubway.transit.domain.TransitRegionSummary;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class OperatorAccessibilityReportPageController {
+
+	private final DataQualityUseCase dataQualityUseCase;
+	private final TransitMasterQueryUseCase transitMasterQueryUseCase;
+
+	OperatorAccessibilityReportPageController(
+		DataQualityUseCase dataQualityUseCase,
+		TransitMasterQueryUseCase transitMasterQueryUseCase
+	) {
+		this.dataQualityUseCase = dataQualityUseCase;
+		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
+	}
+
+	@GetMapping("/operator/accessibility-report/page")
+	String accessibilityReportPage(Model model) {
+		DataQualitySummary summary = dataQualityUseCase.summarizeDataQuality();
+		List<TransitRegionSummary> regions = transitMasterQueryUseCase.listRegions();
+		List<StationAccessibilityScoreRow> stationAccessibilityScoreRows = summary
+			.stationAccessibilityScores()
+			.stream()
+			.map(StationAccessibilityScoreRow::from)
+			.toList();
+		List<AccessibilityImprovementPriorityRow> accessibilityImprovementPriorityRows = summary
+			.accessibilityImprovementPriorities()
+			.stream()
+			.map(this::accessibilityImprovementPriorityRow)
+			.flatMap(Optional::stream)
+			.toList();
+		model.addAttribute(
+			"report",
+			OperatorAccessibilityReportView.from(
+				summary,
+				regions,
+				stationAccessibilityScoreRows,
+				accessibilityImprovementPriorityRows
+			)
+		);
+		return "operator/accessibility-report";
+	}
+
+	private Optional<AccessibilityImprovementPriorityRow> accessibilityImprovementPriorityRow(
+		AccessibilityImprovementPriority priority
+	) {
+		try {
+			StationWithLines station = transitMasterQueryUseCase.getStation(priority.stationId());
+			return transitMasterQueryUseCase.listStationFacilities(priority.stationId())
+				.stream()
+				.filter(candidate -> candidate.id().equals(priority.facilityId()))
+				.findFirst()
+				.map(facility -> new AccessibilityImprovementPriorityRow(
+					station.station().nameKo(),
+					facility.name(),
+					priority.priorityScore(),
+					String.join(", ", priority.reasons())
+				));
+		} catch (StationNotFoundException exception) {
+			return Optional.empty();
+		}
+	}
+
+	private static String qualityLabel(DataQualityLevel level) {
+		return switch (level) {
+			case LEVEL_1 -> "Level 1";
+			case LEVEL_2 -> "Level 2";
+			case LEVEL_3 -> "Level 3";
+			case LEVEL_4 -> "Level 4";
+		};
+	}
+
+	private static String qualityDescription(DataQualityLevel level) {
+		return switch (level) {
+			case LEVEL_1 -> "기본 정보 확인";
+			case LEVEL_2 -> "일부 정보 확인";
+			case LEVEL_3 -> "정보 보강 필요";
+			case LEVEL_4 -> "제보 필요";
+		};
+	}
+
+	record OperatorAccessibilityReportView(
+		int totalStations,
+		int totalFacilities,
+		long needsVerificationFacilityCount,
+		long delayedFacilityStatusCount,
+		long missingStationVerificationDateCount,
+		List<QualityCountRow> stationQualityRows,
+		List<RegionQualityRow> regionQualityRows,
+		List<StationAccessibilityScoreRow> stationAccessibilityScoreRows,
+		List<AccessibilityImprovementPriorityRow> accessibilityImprovementPriorityRows
+	) {
+
+		static OperatorAccessibilityReportView from(
+			DataQualitySummary summary,
+			List<TransitRegionSummary> regions,
+			List<StationAccessibilityScoreRow> stationAccessibilityScoreRows,
+			List<AccessibilityImprovementPriorityRow> accessibilityImprovementPriorityRows
+		) {
+			return new OperatorAccessibilityReportView(
+				summary.totalStations(),
+				summary.totalFacilities(),
+				summary.needsVerificationFacilityCount(),
+				summary.delayedFacilityStatusCount(),
+				summary.missingStationVerificationDateCount(),
+				qualityRows(summary.stationQualityCounts()),
+				regionQualityRows(summary.regionSummaries(), regions),
+				stationAccessibilityScoreRows,
+				accessibilityImprovementPriorityRows
+			);
+		}
+
+		private static List<QualityCountRow> qualityRows(Map<DataQualityLevel, Long> counts) {
+			return Arrays.stream(DataQualityLevel.values())
+				.map(level -> new QualityCountRow(
+					qualityLabel(level),
+					qualityDescription(level),
+					counts.getOrDefault(level, 0L)
+				))
+				.toList();
+		}
+
+		private static List<RegionQualityRow> regionQualityRows(
+			List<RegionDataQualitySummary> regionSummaries,
+			List<TransitRegionSummary> regions
+		) {
+			Map<String, TransitRegionSummary> regionsByName = regions.stream()
+				.collect(Collectors.toMap(TransitRegionSummary::name, region -> region));
+			return regionSummaries.stream()
+				.map(region -> {
+					TransitRegionSummary masterRegion = regionsByName.get(region.name());
+					return new RegionQualityRow(
+						region.name(),
+						masterRegion == null ? 0 : masterRegion.operatorCount(),
+						masterRegion == null ? 0 : masterRegion.lineCount(),
+						region.stationCount(),
+						region.stationQualityCounts().getOrDefault(DataQualityLevel.LEVEL_1, 0L),
+						region.stationQualityCounts().getOrDefault(DataQualityLevel.LEVEL_2, 0L),
+						region.stationQualityCounts().getOrDefault(DataQualityLevel.LEVEL_3, 0L),
+						region.stationQualityCounts().getOrDefault(DataQualityLevel.LEVEL_4, 0L)
+					);
+				})
+				.toList();
+		}
+	}
+
+	record QualityCountRow(String label, String description, long count) {
+	}
+
+	record RegionQualityRow(
+		String name,
+		int operatorCount,
+		int lineCount,
+		int stationCount,
+		long level1Count,
+		long level2Count,
+		long level3Count,
+		long level4Count
+	) {
+	}
+
+	record StationAccessibilityScoreRow(
+		String stationName,
+		String region,
+		int score,
+		String reasons
+	) {
+
+		static StationAccessibilityScoreRow from(StationAccessibilityScore score) {
+			return new StationAccessibilityScoreRow(
+				score.stationName(),
+				score.region(),
+				score.score(),
+				String.join(", ", score.reasons())
+			);
+		}
+	}
+
+	record AccessibilityImprovementPriorityRow(
+		String stationName,
+		String facilityName,
+		int priorityScore,
+		String reasons
+	) {
+	}
+}

--- a/backend/src/main/resources/templates/operator/accessibility-report.html
+++ b/backend/src/main/resources/templates/operator/accessibility-report.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>운영기관 접근성 시설 현황</title>
+	<style>
+		body {
+			margin: 0;
+			background: #f5f7f8;
+			color: #102a2c;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+		}
+
+		main {
+			max-width: 1120px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}
+
+		h1 {
+			margin: 0 0 10px;
+			font-size: 32px;
+			line-height: 1.2;
+		}
+
+		p {
+			margin: 0 0 24px;
+			color: #40585a;
+			font-size: 17px;
+			line-height: 1.55;
+		}
+
+		h2 {
+			margin: 0;
+			padding: 16px 18px;
+			background: #e8f1ef;
+			font-size: 20px;
+		}
+
+		.metric-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+			gap: 12px;
+			margin-bottom: 24px;
+		}
+
+		.metric {
+			background: #fff;
+			border: 1px solid #d6e0df;
+			padding: 18px;
+		}
+
+		.metric span {
+			display: block;
+			color: #536b6d;
+			font-weight: 800;
+			line-height: 1.4;
+		}
+
+		.metric strong {
+			display: block;
+			margin-top: 8px;
+			font-size: 30px;
+			line-height: 1.15;
+		}
+
+		section {
+			margin-bottom: 24px;
+			background: #fff;
+			border: 1px solid #d6e0df;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		th,
+		td {
+			padding: 14px 18px;
+			border-top: 1px solid #d6e0df;
+			text-align: left;
+			vertical-align: top;
+			font-size: 15px;
+			line-height: 1.45;
+		}
+
+		th {
+			background: #f8fbfb;
+			font-weight: 800;
+		}
+
+		td:last-child,
+		th:last-child {
+			text-align: right;
+			font-weight: 800;
+		}
+	</style>
+</head>
+<body>
+<main>
+	<h1>운영기관 접근성 시설 현황</h1>
+	<p>운영기관 담당자가 접근성 데이터 품질과 시설 보강 대상을 확인하는 읽기 전용 리포트입니다.</p>
+
+	<div class="metric-grid" aria-label="접근성 시설 현황 요약">
+		<div class="metric">
+			<span>전체 역</span>
+			<strong th:text="${report.totalStations}">0</strong>
+		</div>
+		<div class="metric">
+			<span>전체 시설</span>
+			<strong th:text="${report.totalFacilities}">0</strong>
+		</div>
+		<div class="metric">
+			<span>확인 필요한 시설</span>
+			<strong th:text="${report.needsVerificationFacilityCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>갱신 지연 시설</span>
+			<strong th:text="${report.delayedFacilityStatusCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>검수일 없는 역</span>
+			<strong th:text="${report.missingStationVerificationDateCount}">0</strong>
+		</div>
+	</div>
+
+	<section>
+		<h2>역 품질 등급</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">등급</th>
+				<th scope="col">상태</th>
+				<th scope="col">역 수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${report.stationQualityRows}">
+				<td th:text="${row.label}">Level 1</td>
+				<td th:text="${row.description}">기본 정보 확인</td>
+				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>지역별 데이터 품질</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">지역</th>
+				<th scope="col">운영기관</th>
+				<th scope="col">노선</th>
+				<th scope="col">역</th>
+				<th scope="col">Level 1</th>
+				<th scope="col">Level 2</th>
+				<th scope="col">Level 3</th>
+				<th scope="col">Level 4</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${report.regionQualityRows}">
+				<td th:text="${row.name}">수도권</td>
+				<td th:text="${row.operatorCount}">0</td>
+				<td th:text="${row.lineCount}">0</td>
+				<td th:text="${row.stationCount}">0</td>
+				<td th:text="${row.level1Count}">0</td>
+				<td th:text="${row.level2Count}">0</td>
+				<td th:text="${row.level3Count}">0</td>
+				<td th:text="${row.level4Count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>역별 접근성 점수</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">역</th>
+				<th scope="col">지역</th>
+				<th scope="col">보강 사유</th>
+				<th scope="col">접근성 점수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${report.stationAccessibilityScoreRows}">
+				<td th:text="${row.stationName}">상록수</td>
+				<td th:text="${row.region}">수도권</td>
+				<td th:text="${row.reasons}">기본 정보만 있음</td>
+				<td th:text="${row.score}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>접근성 개선 우선순위</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">역</th>
+				<th scope="col">시설</th>
+				<th scope="col">개선 사유</th>
+				<th scope="col">우선순위 점수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${report.accessibilityImprovementPriorityRows}">
+				<td th:text="${row.stationName}">상록수</td>
+				<td th:text="${row.facilityName}">장애인 화장실</td>
+				<td th:text="${row.reasons}">확인 필요 상태, 신뢰도 확인 필요</td>
+				<td th:text="${row.priorityScore}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportPageControllerTest.java
@@ -1,0 +1,81 @@
+package com.easysubway.operator.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.operator.username=operator-user",
+	"easysubway.operator.password=operator-test-password",
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("운영기관 접근성 시설 현황 리포트 화면")
+class OperatorAccessibilityReportPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("운영기관 계정은 읽기 전용 접근성 시설 현황을 확인한다")
+	void operatorGetsAccessibilityReportPage() throws Exception {
+		String html = mockMvc.perform(get("/operator/accessibility-report/page")
+				.with(httpBasic("operator-user", "operator-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("운영기관 접근성 시설 현황")
+			.contains("전체 역")
+			.contains("전체 시설")
+			.contains("확인 필요한 시설")
+			.contains("갱신 지연 시설")
+			.contains("지역별 데이터 품질")
+			.contains("수도권")
+			.contains("운영기관")
+			.contains("노선")
+			.contains("역")
+			.contains("역별 접근성 점수")
+			.contains("접근성 점수")
+			.contains("보강 사유")
+			.contains("접근성 개선 우선순위")
+			.contains("우선순위 점수")
+			.contains("개선 사유")
+			.contains("상록수")
+			.contains("장애인 화장실")
+			.contains("확인 필요 상태")
+			.doesNotContain("name=\"_csrf\"")
+			.doesNotContain("<form")
+			.doesNotContain("/admin/reports")
+			.doesNotContain("station-sangnoksu")
+			.doesNotContain("facility-sangnoksu");
+	}
+
+	@Test
+	@DisplayName("운영기관 접근성 리포트는 운영기관 계정 인증을 요구한다")
+	void accessibilityReportRequiresOperatorAuthentication() throws Exception {
+		mockMvc.perform(get("/operator/accessibility-report/page"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/operator/accessibility-report/page")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/operator/accessibility-report/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isForbidden());
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -837,6 +837,10 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
   const controller = read("backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java");
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
+  const operatorReportController = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportPageController.java",
+  );
+  const operatorReportTemplate = read("backend/src/main/resources/templates/operator/accessibility-report.html");
 
   assert.match(report, /record FacilityReport/);
   assert.match(report, /reviewedAt/);
@@ -921,6 +925,15 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(security, /PasswordEncoder/);
   assert.match(security, /passwordEncoder\.encode\(adminPassword\)/);
   assert.match(security, /passwordEncoder\.encode\(operatorPassword\)/);
+  assert.match(operatorReportController, /@GetMapping\("\/operator\/accessibility-report\/page"\)/);
+  assert.match(operatorReportController, /DataQualityUseCase/);
+  assert.match(operatorReportController, /TransitMasterQueryUseCase/);
+  assert.match(operatorReportController, /return "operator\/accessibility-report"/);
+  assert.match(operatorReportTemplate, /운영기관 접근성 시설 현황/);
+  assert.match(operatorReportTemplate, /읽기 전용 리포트/);
+  assert.match(operatorReportTemplate, /역별 접근성 점수/);
+  assert.match(operatorReportTemplate, /접근성 개선 우선순위/);
+  assert.doesNotMatch(operatorReportTemplate, /<form/);
 });
 
 test("백엔드 이동 프로필은 헥사고날 API 경계를 따른다", () => {


### PR DESCRIPTION
## 관련 이슈

close #345

## 작업 배경

- 운영기관 관리자 계정과 `/operator/**` 보안 체인은 준비되어 있으나 운영기관 담당자가 확인할 수 있는 전용 화면은 아직 없다.
- 운영기관/B2G 협업 기준선으로 접근성 시설 품질과 보강 우선순위를 읽기 전용으로 확인하는 화면이 필요하다.

## 작업 내용

- `/operator/accessibility-report/page` 운영기관 접근성 리포트 페이지를 추가한다.
- 전체 데이터 요약, 지역별 품질, 역별 접근성 점수, 접근성 개선 우선순위를 표시한다.
- 운영기관 전용 인증을 요구하고 일반 사용자 계정 접근을 차단한다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.operator.adapter.in.web.OperatorAccessibilityReportPageControllerTest` (backend): 통과
  - `./gradlew test` (backend): 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과, 43개 테스트
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 출력
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 모두 ignore 규칙 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - operator 페이지가 관리자 action 없이 읽기 전용 정보만 노출하는지
  - 운영기관 계정과 일반 사용자 계정의 접근 제어가 분리되어 있는지

## 리스크

- 기관별 데이터 스코프 제한은 이번 범위에 포함하지 않아 전체 접근성 현황 기준선만 제공한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
