### PR TITLE
[Feat] 운영기관 접근성 리포트 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportAssembler.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportAssembler.java
@@ -1,0 +1,144 @@
+package com.easysubway.operator.adapter.in.web;
+
+import com.easysubway.quality.application.port.in.DataQualityUseCase;
+import com.easysubway.quality.domain.AccessibilityImprovementPriority;
+import com.easysubway.quality.domain.DataQualitySummary;
+import com.easysubway.quality.domain.RegionDataQualitySummary;
+import com.easysubway.quality.domain.StationAccessibilityScore;
+import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
+import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.StationNotFoundException;
+import com.easysubway.transit.domain.StationWithLines;
+import com.easysubway.transit.domain.TransitRegionSummary;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+class OperatorAccessibilityReportAssembler {
+
+	private final DataQualityUseCase dataQualityUseCase;
+	private final TransitMasterQueryUseCase transitMasterQueryUseCase;
+
+	OperatorAccessibilityReportAssembler(
+		DataQualityUseCase dataQualityUseCase,
+		TransitMasterQueryUseCase transitMasterQueryUseCase
+	) {
+		this.dataQualityUseCase = dataQualityUseCase;
+		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
+	}
+
+	OperatorAccessibilityReportView assemble() {
+		DataQualitySummary summary = dataQualityUseCase.summarizeDataQuality();
+		List<TransitRegionSummary> regions = transitMasterQueryUseCase.listRegions();
+		return new OperatorAccessibilityReportView(
+			summary.totalStations(),
+			summary.totalFacilities(),
+			summary.needsVerificationFacilityCount(),
+			summary.delayedFacilityStatusCount(),
+			summary.missingStationVerificationDateCount(),
+			qualityRows(summary.stationQualityCounts()),
+			regionQualityRows(summary.regionSummaries(), regions),
+			stationAccessibilityScoreRows(summary.stationAccessibilityScores()),
+			accessibilityImprovementPriorityRows(summary.accessibilityImprovementPriorities())
+		);
+	}
+
+	private List<OperatorAccessibilityReportView.QualityCountRow> qualityRows(
+		Map<DataQualityLevel, Long> counts
+	) {
+		return Arrays.stream(DataQualityLevel.values())
+			.map(level -> new OperatorAccessibilityReportView.QualityCountRow(
+				qualityLabel(level),
+				qualityDescription(level),
+				counts.getOrDefault(level, 0L)
+			))
+			.toList();
+	}
+
+	private List<OperatorAccessibilityReportView.RegionQualityRow> regionQualityRows(
+		List<RegionDataQualitySummary> regionSummaries,
+		List<TransitRegionSummary> regions
+	) {
+		Map<String, TransitRegionSummary> regionsByName = regions.stream()
+			.collect(Collectors.toMap(TransitRegionSummary::name, region -> region));
+		return regionSummaries.stream()
+			.map(region -> {
+				TransitRegionSummary masterRegion = regionsByName.get(region.name());
+				return new OperatorAccessibilityReportView.RegionQualityRow(
+					region.name(),
+					masterRegion == null ? 0 : masterRegion.operatorCount(),
+					masterRegion == null ? 0 : masterRegion.lineCount(),
+					region.stationCount(),
+					region.stationQualityCounts().getOrDefault(DataQualityLevel.LEVEL_1, 0L),
+					region.stationQualityCounts().getOrDefault(DataQualityLevel.LEVEL_2, 0L),
+					region.stationQualityCounts().getOrDefault(DataQualityLevel.LEVEL_3, 0L),
+					region.stationQualityCounts().getOrDefault(DataQualityLevel.LEVEL_4, 0L)
+				);
+			})
+			.toList();
+	}
+
+	private List<OperatorAccessibilityReportView.StationAccessibilityScoreRow> stationAccessibilityScoreRows(
+		List<StationAccessibilityScore> scores
+	) {
+		return scores.stream()
+			.map(score -> new OperatorAccessibilityReportView.StationAccessibilityScoreRow(
+				score.stationName(),
+				score.region(),
+				score.score(),
+				score.reasons()
+			))
+			.toList();
+	}
+
+	private List<OperatorAccessibilityReportView.AccessibilityImprovementPriorityRow> accessibilityImprovementPriorityRows(
+		List<AccessibilityImprovementPriority> priorities
+	) {
+		return priorities.stream()
+			.map(this::accessibilityImprovementPriorityRow)
+			.flatMap(Optional::stream)
+			.toList();
+	}
+
+	private Optional<OperatorAccessibilityReportView.AccessibilityImprovementPriorityRow> accessibilityImprovementPriorityRow(
+		AccessibilityImprovementPriority priority
+	) {
+		try {
+			StationWithLines station = transitMasterQueryUseCase.getStation(priority.stationId());
+			return transitMasterQueryUseCase.listStationFacilities(priority.stationId())
+				.stream()
+				.filter(candidate -> candidate.id().equals(priority.facilityId()))
+				.findFirst()
+				.map(facility -> new OperatorAccessibilityReportView.AccessibilityImprovementPriorityRow(
+					station.station().nameKo(),
+					facility.name(),
+					priority.priorityScore(),
+					priority.reasons()
+				));
+		} catch (StationNotFoundException exception) {
+			return Optional.empty();
+		}
+	}
+
+	private static String qualityLabel(DataQualityLevel level) {
+		return switch (level) {
+			case LEVEL_1 -> "Level 1";
+			case LEVEL_2 -> "Level 2";
+			case LEVEL_3 -> "Level 3";
+			case LEVEL_4 -> "Level 4";
+		};
+	}
+
+	private static String qualityDescription(DataQualityLevel level) {
+		return switch (level) {
+			case LEVEL_1 -> "기본 정보 확인";
+			case LEVEL_2 -> "일부 정보 확인";
+			case LEVEL_3 -> "정보 보강 필요";
+			case LEVEL_4 -> "제보 필요";
+		};
+	}
+}

--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportController.java
@@ -1,0 +1,20 @@
+package com.easysubway.operator.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class OperatorAccessibilityReportController {
+
+	private final OperatorAccessibilityReportAssembler reportAssembler;
+
+	OperatorAccessibilityReportController(OperatorAccessibilityReportAssembler reportAssembler) {
+		this.reportAssembler = reportAssembler;
+	}
+
+	@GetMapping("/operator/api/accessibility-report")
+	ApiResponse<OperatorAccessibilityReportView> accessibilityReport() {
+		return ApiResponse.ok(reportAssembler.assemble());
+	}
+}

--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportPageController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportPageController.java
@@ -1,20 +1,5 @@
 package com.easysubway.operator.adapter.in.web;
 
-import com.easysubway.quality.application.port.in.DataQualityUseCase;
-import com.easysubway.quality.domain.AccessibilityImprovementPriority;
-import com.easysubway.quality.domain.DataQualitySummary;
-import com.easysubway.quality.domain.RegionDataQualitySummary;
-import com.easysubway.quality.domain.StationAccessibilityScore;
-import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
-import com.easysubway.transit.domain.DataQualityLevel;
-import com.easysubway.transit.domain.StationNotFoundException;
-import com.easysubway.transit.domain.StationWithLines;
-import com.easysubway.transit.domain.TransitRegionSummary;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,184 +7,15 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 class OperatorAccessibilityReportPageController {
 
-	private final DataQualityUseCase dataQualityUseCase;
-	private final TransitMasterQueryUseCase transitMasterQueryUseCase;
+	private final OperatorAccessibilityReportAssembler reportAssembler;
 
-	OperatorAccessibilityReportPageController(
-		DataQualityUseCase dataQualityUseCase,
-		TransitMasterQueryUseCase transitMasterQueryUseCase
-	) {
-		this.dataQualityUseCase = dataQualityUseCase;
-		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
+	OperatorAccessibilityReportPageController(OperatorAccessibilityReportAssembler reportAssembler) {
+		this.reportAssembler = reportAssembler;
 	}
 
 	@GetMapping("/operator/accessibility-report/page")
 	String accessibilityReportPage(Model model) {
-		DataQualitySummary summary = dataQualityUseCase.summarizeDataQuality();
-		List<TransitRegionSummary> regions = transitMasterQueryUseCase.listRegions();
-		List<StationAccessibilityScoreRow> stationAccessibilityScoreRows = summary
-			.stationAccessibilityScores()
-			.stream()
-			.map(StationAccessibilityScoreRow::from)
-			.toList();
-		List<AccessibilityImprovementPriorityRow> accessibilityImprovementPriorityRows = summary
-			.accessibilityImprovementPriorities()
-			.stream()
-			.map(this::accessibilityImprovementPriorityRow)
-			.flatMap(Optional::stream)
-			.toList();
-		model.addAttribute(
-			"report",
-			OperatorAccessibilityReportView.from(
-				summary,
-				regions,
-				stationAccessibilityScoreRows,
-				accessibilityImprovementPriorityRows
-			)
-		);
+		model.addAttribute("report", reportAssembler.assemble());
 		return "operator/accessibility-report";
-	}
-
-	private Optional<AccessibilityImprovementPriorityRow> accessibilityImprovementPriorityRow(
-		AccessibilityImprovementPriority priority
-	) {
-		try {
-			StationWithLines station = transitMasterQueryUseCase.getStation(priority.stationId());
-			return transitMasterQueryUseCase.listStationFacilities(priority.stationId())
-				.stream()
-				.filter(candidate -> candidate.id().equals(priority.facilityId()))
-				.findFirst()
-				.map(facility -> new AccessibilityImprovementPriorityRow(
-					station.station().nameKo(),
-					facility.name(),
-					priority.priorityScore(),
-					String.join(", ", priority.reasons())
-				));
-		} catch (StationNotFoundException exception) {
-			return Optional.empty();
-		}
-	}
-
-	private static String qualityLabel(DataQualityLevel level) {
-		return switch (level) {
-			case LEVEL_1 -> "Level 1";
-			case LEVEL_2 -> "Level 2";
-			case LEVEL_3 -> "Level 3";
-			case LEVEL_4 -> "Level 4";
-		};
-	}
-
-	private static String qualityDescription(DataQualityLevel level) {
-		return switch (level) {
-			case LEVEL_1 -> "기본 정보 확인";
-			case LEVEL_2 -> "일부 정보 확인";
-			case LEVEL_3 -> "정보 보강 필요";
-			case LEVEL_4 -> "제보 필요";
-		};
-	}
-
-	record OperatorAccessibilityReportView(
-		int totalStations,
-		int totalFacilities,
-		long needsVerificationFacilityCount,
-		long delayedFacilityStatusCount,
-		long missingStationVerificationDateCount,
-		List<QualityCountRow> stationQualityRows,
-		List<RegionQualityRow> regionQualityRows,
-		List<StationAccessibilityScoreRow> stationAccessibilityScoreRows,
-		List<AccessibilityImprovementPriorityRow> accessibilityImprovementPriorityRows
-	) {
-
-		static OperatorAccessibilityReportView from(
-			DataQualitySummary summary,
-			List<TransitRegionSummary> regions,
-			List<StationAccessibilityScoreRow> stationAccessibilityScoreRows,
-			List<AccessibilityImprovementPriorityRow> accessibilityImprovementPriorityRows
-		) {
-			return new OperatorAccessibilityReportView(
-				summary.totalStations(),
-				summary.totalFacilities(),
-				summary.needsVerificationFacilityCount(),
-				summary.delayedFacilityStatusCount(),
-				summary.missingStationVerificationDateCount(),
-				qualityRows(summary.stationQualityCounts()),
-				regionQualityRows(summary.regionSummaries(), regions),
-				stationAccessibilityScoreRows,
-				accessibilityImprovementPriorityRows
-			);
-		}
-
-		private static List<QualityCountRow> qualityRows(Map<DataQualityLevel, Long> counts) {
-			return Arrays.stream(DataQualityLevel.values())
-				.map(level -> new QualityCountRow(
-					qualityLabel(level),
-					qualityDescription(level),
-					counts.getOrDefault(level, 0L)
-				))
-				.toList();
-		}
-
-		private static List<RegionQualityRow> regionQualityRows(
-			List<RegionDataQualitySummary> regionSummaries,
-			List<TransitRegionSummary> regions
-		) {
-			Map<String, TransitRegionSummary> regionsByName = regions.stream()
-				.collect(Collectors.toMap(TransitRegionSummary::name, region -> region));
-			return regionSummaries.stream()
-				.map(region -> {
-					TransitRegionSummary masterRegion = regionsByName.get(region.name());
-					return new RegionQualityRow(
-						region.name(),
-						masterRegion == null ? 0 : masterRegion.operatorCount(),
-						masterRegion == null ? 0 : masterRegion.lineCount(),
-						region.stationCount(),
-						region.stationQualityCounts().getOrDefault(DataQualityLevel.LEVEL_1, 0L),
-						region.stationQualityCounts().getOrDefault(DataQualityLevel.LEVEL_2, 0L),
-						region.stationQualityCounts().getOrDefault(DataQualityLevel.LEVEL_3, 0L),
-						region.stationQualityCounts().getOrDefault(DataQualityLevel.LEVEL_4, 0L)
-					);
-				})
-				.toList();
-		}
-	}
-
-	record QualityCountRow(String label, String description, long count) {
-	}
-
-	record RegionQualityRow(
-		String name,
-		int operatorCount,
-		int lineCount,
-		int stationCount,
-		long level1Count,
-		long level2Count,
-		long level3Count,
-		long level4Count
-	) {
-	}
-
-	record StationAccessibilityScoreRow(
-		String stationName,
-		String region,
-		int score,
-		String reasons
-	) {
-
-		static StationAccessibilityScoreRow from(StationAccessibilityScore score) {
-			return new StationAccessibilityScoreRow(
-				score.stationName(),
-				score.region(),
-				score.score(),
-				String.join(", ", score.reasons())
-			);
-		}
-	}
-
-	record AccessibilityImprovementPriorityRow(
-		String stationName,
-		String facilityName,
-		int priorityScore,
-		String reasons
-	) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportView.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportView.java
@@ -1,0 +1,55 @@
+package com.easysubway.operator.adapter.in.web;
+
+import java.util.List;
+
+public record OperatorAccessibilityReportView(
+	int totalStations,
+	int totalFacilities,
+	long needsVerificationFacilityCount,
+	long delayedFacilityStatusCount,
+	long missingStationVerificationDateCount,
+	List<QualityCountRow> stationQualityRows,
+	List<RegionQualityRow> regionQualityRows,
+	List<StationAccessibilityScoreRow> stationAccessibilityScoreRows,
+	List<AccessibilityImprovementPriorityRow> accessibilityImprovementPriorityRows
+) {
+
+	public record QualityCountRow(String label, String description, long count) {
+	}
+
+	public record RegionQualityRow(
+		String name,
+		int operatorCount,
+		int lineCount,
+		int stationCount,
+		long level1Count,
+		long level2Count,
+		long level3Count,
+		long level4Count
+	) {
+	}
+
+	public record StationAccessibilityScoreRow(
+		String stationName,
+		String region,
+		int score,
+		List<String> reasons
+	) {
+
+		public String reasonText() {
+			return String.join(", ", reasons);
+		}
+	}
+
+	public record AccessibilityImprovementPriorityRow(
+		String stationName,
+		String facilityName,
+		int priorityScore,
+		List<String> reasons
+	) {
+
+		public String reasonText() {
+			return String.join(", ", reasons);
+		}
+	}
+}

--- a/backend/src/main/resources/templates/operator/accessibility-report.html
+++ b/backend/src/main/resources/templates/operator/accessibility-report.html
@@ -191,7 +191,7 @@
 			<tr th:each="row : ${report.stationAccessibilityScoreRows}">
 				<td th:text="${row.stationName}">상록수</td>
 				<td th:text="${row.region}">수도권</td>
-				<td th:text="${row.reasons}">기본 정보만 있음</td>
+				<td th:text="${row.reasonText}">기본 정보만 있음</td>
 				<td th:text="${row.score}">0</td>
 			</tr>
 			</tbody>
@@ -213,7 +213,7 @@
 			<tr th:each="row : ${report.accessibilityImprovementPriorityRows}">
 				<td th:text="${row.stationName}">상록수</td>
 				<td th:text="${row.facilityName}">장애인 화장실</td>
-				<td th:text="${row.reasons}">확인 필요 상태, 신뢰도 확인 필요</td>
+				<td th:text="${row.reasonText}">확인 필요 상태, 신뢰도 확인 필요</td>
 				<td th:text="${row.priorityScore}">0</td>
 			</tr>
 			</tbody>

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportControllerTest.java
@@ -1,0 +1,80 @@
+package com.easysubway.operator.adapter.in.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.operator.username=operator-user",
+	"easysubway.operator.password=operator-test-password",
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("운영기관 접근성 리포트 API")
+class OperatorAccessibilityReportControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@TestConfiguration
+	static class FixedClockConfiguration {
+
+		@Bean
+		Clock operatorAccessibilityReportTestClock() {
+			return Clock.fixed(Instant.parse("2026-06-17T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+		}
+	}
+
+	@Test
+	@DisplayName("운영기관 계정은 접근성 시설 현황 리포트를 JSON으로 조회한다")
+	void operatorGetsAccessibilityReport() throws Exception {
+		mockMvc.perform(get("/operator/api/accessibility-report")
+				.with(httpBasic("operator-user", "operator-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.totalStations").value(2))
+			.andExpect(jsonPath("$.data.totalFacilities").value(3))
+			.andExpect(jsonPath("$.data.needsVerificationFacilityCount").value(1))
+			.andExpect(jsonPath("$.data.regionQualityRows[0].name").value("수도권"))
+			.andExpect(jsonPath("$.data.regionQualityRows[0].operatorCount").value(2))
+			.andExpect(jsonPath("$.data.stationAccessibilityScoreRows[0].stationName").value("상록수"))
+			.andExpect(jsonPath("$.data.stationAccessibilityScoreRows[0].reasons[0]").value("기본 정보만 있음"))
+			.andExpect(jsonPath("$.data.accessibilityImprovementPriorityRows[0].stationName").value("상록수"))
+			.andExpect(jsonPath("$.data.accessibilityImprovementPriorityRows[0].facilityName").value("장애인 화장실"))
+			.andExpect(jsonPath("$.data.accessibilityImprovementPriorityRows[0].priorityScore").value(60))
+			.andExpect(jsonPath("$.data.accessibilityImprovementPriorityRows[0].reasons[0]").value("확인 필요 상태"))
+			.andExpect(jsonPath("$.data.accessibilityImprovementPriorityRows[0].stationId").doesNotExist())
+			.andExpect(jsonPath("$.data.accessibilityImprovementPriorityRows[0].facilityId").doesNotExist());
+	}
+
+	@Test
+	@DisplayName("운영기관 접근성 리포트 API는 운영기관 계정 인증을 요구한다")
+	void accessibilityReportRequiresOperatorAuthentication() throws Exception {
+		mockMvc.perform(get("/operator/api/accessibility-report"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/operator/api/accessibility-report")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/operator/api/accessibility-report")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isForbidden());
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -838,7 +838,16 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   const controller = read("backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java");
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
   const operatorReportController = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportController.java",
+  );
+  const operatorReportPageController = read(
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportPageController.java",
+  );
+  const operatorReportAssembler = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportAssembler.java",
+  );
+  const operatorReportView = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportView.java",
   );
   const operatorReportTemplate = read("backend/src/main/resources/templates/operator/accessibility-report.html");
 
@@ -925,10 +934,16 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(security, /PasswordEncoder/);
   assert.match(security, /passwordEncoder\.encode\(adminPassword\)/);
   assert.match(security, /passwordEncoder\.encode\(operatorPassword\)/);
-  assert.match(operatorReportController, /@GetMapping\("\/operator\/accessibility-report\/page"\)/);
-  assert.match(operatorReportController, /DataQualityUseCase/);
-  assert.match(operatorReportController, /TransitMasterQueryUseCase/);
-  assert.match(operatorReportController, /return "operator\/accessibility-report"/);
+  assert.match(operatorReportController, /@GetMapping\("\/operator\/api\/accessibility-report"\)/);
+  assert.match(operatorReportController, /ApiResponse<OperatorAccessibilityReportView>/);
+  assert.match(operatorReportController, /reportAssembler\.assemble\(\)/);
+  assert.match(operatorReportPageController, /@GetMapping\("\/operator\/accessibility-report\/page"\)/);
+  assert.match(operatorReportPageController, /reportAssembler\.assemble\(\)/);
+  assert.match(operatorReportPageController, /return "operator\/accessibility-report"/);
+  assert.match(operatorReportAssembler, /DataQualityUseCase/);
+  assert.match(operatorReportAssembler, /TransitMasterQueryUseCase/);
+  assert.match(operatorReportView, /record AccessibilityImprovementPriorityRow\([\s\S]*String stationName,[\s\S]*String facilityName,[\s\S]*int priorityScore,[\s\S]*List<String> reasons/);
+  assert.doesNotMatch(operatorReportView, /facilityId/);
   assert.match(operatorReportTemplate, /운영기관 접근성 시설 현황/);
   assert.match(operatorReportTemplate, /읽기 전용 리포트/);
   assert.match(operatorReportTemplate, /역별 접근성 점수/);


### PR DESCRIPTION
## 관련 이슈

close #347

## 작업 배경

- 운영기관 접근성 시설 현황 화면은 제공되지만 운영기관/B2G 연동용 JSON API는 없다.
- 다른 보고 도구나 운영기관 내부 시스템이 같은 리포트 데이터를 활용할 수 있도록 운영기관 전용 읽기 API가 필요하다.

## 작업 내용

- `/operator/api/accessibility-report` API를 추가한다.
- 화면과 API가 같은 운영기관 접근성 리포트 view model 조립 로직을 사용하도록 공통화한다.
- 전체 요약, 지역별 데이터 품질, 역별 접근성 점수, 접근성 개선 우선순위를 JSON으로 제공한다.
- 운영기관 계정만 접근할 수 있도록 보안 테스트를 추가한다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.operator.adapter.in.web.OperatorAccessibilityReportControllerTest` (backend): 통과
  - `./gradlew test --tests com.easysubway.operator.adapter.in.web.OperatorAccessibilityReportPageControllerTest` (backend): 통과
  - `./gradlew test` (backend): 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과, 43개 테스트
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 출력
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 모두 ignore 규칙 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - operator 화면과 API가 같은 리포트 조립 로직을 쓰는지
  - API 응답에 내부 ID 대신 운영기관 담당자가 바로 이해할 수 있는 이름/사유 중심 데이터가 나가는지

## 리스크

- 기관별 데이터 스코프 제한은 이번 범위에 포함하지 않아 전체 접근성 현황 기준선만 제공한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
