### PR TITLE
[Feat] 운영기관 이동 불편 신고 분석 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportController.java
@@ -1,0 +1,22 @@
+package com.easysubway.operator.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.route.adapter.in.web.RouteFeedbackDashboardAssembler;
+import com.easysubway.route.adapter.in.web.RouteFeedbackDashboardView;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class OperatorRouteFeedbackReportController {
+
+	private final RouteFeedbackDashboardAssembler routeFeedbackDashboardAssembler;
+
+	OperatorRouteFeedbackReportController(RouteFeedbackDashboardAssembler routeFeedbackDashboardAssembler) {
+		this.routeFeedbackDashboardAssembler = routeFeedbackDashboardAssembler;
+	}
+
+	@GetMapping("/operator/api/route-feedback-report")
+	ApiResponse<RouteFeedbackDashboardView> routeFeedbackReport() {
+		return ApiResponse.ok(routeFeedbackDashboardAssembler.assemble());
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageController.java
@@ -1,10 +1,5 @@
 package com.easysubway.route.adapter.in.web;
 
-import com.easysubway.profile.domain.MobilityType;
-import com.easysubway.route.application.port.in.RouteFeedbackDashboardUseCase;
-import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,74 +7,15 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 class RouteFeedbackAdminPageController {
 
-	private final RouteFeedbackDashboardUseCase routeFeedbackDashboardUseCase;
+	private final RouteFeedbackDashboardAssembler routeFeedbackDashboardAssembler;
 
-	RouteFeedbackAdminPageController(RouteFeedbackDashboardUseCase routeFeedbackDashboardUseCase) {
-		this.routeFeedbackDashboardUseCase = routeFeedbackDashboardUseCase;
+	RouteFeedbackAdminPageController(RouteFeedbackDashboardAssembler routeFeedbackDashboardAssembler) {
+		this.routeFeedbackDashboardAssembler = routeFeedbackDashboardAssembler;
 	}
 
 	@GetMapping("/admin/routes/feedback/page")
 	String routeFeedbackDashboardPage(Model model) {
-		RouteFeedbackDashboardSummary summary = routeFeedbackDashboardUseCase.summarizeRouteFeedbacks();
-		model.addAttribute("summary", RouteFeedbackDashboardView.from(summary));
+		model.addAttribute("summary", routeFeedbackDashboardAssembler.assemble());
 		return "admin/routes/feedback";
-	}
-
-	record RouteFeedbackDashboardView(
-		long totalCount,
-		long helpfulCount,
-		long notHelpfulCount,
-		long blockedByRealWorldCount,
-		List<RatingCountRow> ratingRows,
-		List<RecentBlockedFeedbackRow> recentBlockedFeedbacks
-	) {
-
-		private static final DateTimeFormatter RECENT_FEEDBACK_TIME_FORMATTER =
-			DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
-
-		static RouteFeedbackDashboardView from(RouteFeedbackDashboardSummary summary) {
-			return new RouteFeedbackDashboardView(
-				summary.totalCount(),
-				summary.helpfulCount(),
-				summary.notHelpfulCount(),
-				summary.blockedByRealWorldCount(),
-				List.of(
-					new RatingCountRow("도움이 됨", "경로 안내가 실제 이동에 도움됨", summary.helpfulCount()),
-					new RatingCountRow("도움이 안 됨", "경로 안내가 실제 이동과 맞지 않음", summary.notHelpfulCount()),
-					new RatingCountRow("현장 차단", "엘리베이터 고장, 공사, 폐쇄 등으로 이동 불가", summary.blockedByRealWorldCount())
-				),
-				summary.recentBlockedFeedbacks()
-					.stream()
-					.map(row -> new RecentBlockedFeedbackRow(
-						row.createdAt().format(RECENT_FEEDBACK_TIME_FORMATTER),
-						row.originStationName(),
-						row.destinationStationName(),
-						mobilityTypeLabel(row.mobilityType())
-					))
-					.toList()
-			);
-		}
-
-		private static String mobilityTypeLabel(MobilityType mobilityType) {
-			return switch (mobilityType) {
-				case SENIOR -> "고령자";
-				case STROLLER -> "유모차";
-				case WHEELCHAIR -> "휠체어";
-				case PREGNANT -> "임산부";
-				case TEMPORARY_INJURY -> "일시 부상";
-				case LUGGAGE -> "큰 짐";
-			};
-		}
-	}
-
-	record RatingCountRow(String label, String description, long count) {
-	}
-
-	record RecentBlockedFeedbackRow(
-		String createdAtLabel,
-		String originStationName,
-		String destinationStationName,
-		String mobilityTypeLabel
-	) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackDashboardAssembler.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackDashboardAssembler.java
@@ -1,0 +1,68 @@
+package com.easysubway.route.adapter.in.web;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.application.port.in.RouteFeedbackDashboardUseCase;
+import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RouteFeedbackDashboardAssembler {
+
+	private static final DateTimeFormatter RECENT_FEEDBACK_TIME_FORMATTER =
+		DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+	private final RouteFeedbackDashboardUseCase routeFeedbackDashboardUseCase;
+
+	RouteFeedbackDashboardAssembler(RouteFeedbackDashboardUseCase routeFeedbackDashboardUseCase) {
+		this.routeFeedbackDashboardUseCase = routeFeedbackDashboardUseCase;
+	}
+
+	public RouteFeedbackDashboardView assemble() {
+		RouteFeedbackDashboardSummary summary = routeFeedbackDashboardUseCase.summarizeRouteFeedbacks();
+		return new RouteFeedbackDashboardView(
+			summary.totalCount(),
+			summary.helpfulCount(),
+			summary.notHelpfulCount(),
+			summary.blockedByRealWorldCount(),
+			List.of(
+				new RouteFeedbackDashboardView.RatingCountRow(
+					"도움이 됨",
+					"경로 안내가 실제 이동에 도움됨",
+					summary.helpfulCount()
+				),
+				new RouteFeedbackDashboardView.RatingCountRow(
+					"도움이 안 됨",
+					"경로 안내가 실제 이동과 맞지 않음",
+					summary.notHelpfulCount()
+				),
+				new RouteFeedbackDashboardView.RatingCountRow(
+					"현장 차단",
+					"엘리베이터 고장, 공사, 폐쇄 등으로 이동 불가",
+					summary.blockedByRealWorldCount()
+				)
+			),
+			summary.recentBlockedFeedbacks()
+				.stream()
+				.map(row -> new RouteFeedbackDashboardView.RecentBlockedFeedbackRow(
+					row.createdAt().format(RECENT_FEEDBACK_TIME_FORMATTER),
+					row.originStationName(),
+					row.destinationStationName(),
+					mobilityTypeLabel(row.mobilityType())
+				))
+				.toList()
+		);
+	}
+
+	private static String mobilityTypeLabel(MobilityType mobilityType) {
+		return switch (mobilityType) {
+			case SENIOR -> "고령자";
+			case STROLLER -> "유모차";
+			case WHEELCHAIR -> "휠체어";
+			case PREGNANT -> "임산부";
+			case TEMPORARY_INJURY -> "일시 부상";
+			case LUGGAGE -> "큰 짐";
+		};
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackDashboardView.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackDashboardView.java
@@ -1,0 +1,24 @@
+package com.easysubway.route.adapter.in.web;
+
+import java.util.List;
+
+public record RouteFeedbackDashboardView(
+	long totalCount,
+	long helpfulCount,
+	long notHelpfulCount,
+	long blockedByRealWorldCount,
+	List<RatingCountRow> ratingRows,
+	List<RecentBlockedFeedbackRow> recentBlockedFeedbacks
+) {
+
+	public record RatingCountRow(String label, String description, long count) {
+	}
+
+	public record RecentBlockedFeedbackRow(
+		String createdAtLabel,
+		String originStationName,
+		String destinationStationName,
+		String mobilityTypeLabel
+	) {
+	}
+}

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportControllerTest.java
@@ -1,0 +1,105 @@
+package com.easysubway.operator.adapter.in.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.operator.username=operator-user",
+	"easysubway.operator.password=operator-test-password",
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("운영기관 이동 불편 신고 분석 API")
+class OperatorRouteFeedbackReportControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("운영기관 계정은 이동 불편 신고 분석을 JSON으로 조회한다")
+	void operatorGetsRouteFeedbackReport() throws Exception {
+		String routeSearchId = createRouteSearch();
+		submitRouteFeedback(routeSearchId, "HELPFUL", "안내가 도움이 됐어요");
+		submitRouteFeedback(routeSearchId, "NOT_HELPFUL", "실제 이동 상황과 달랐어요");
+		submitRouteFeedback(routeSearchId, "BLOCKED_BY_REAL_WORLD", "엘리베이터가 막혀 있었어요");
+
+		mockMvc.perform(get("/operator/api/route-feedback-report")
+				.with(httpBasic("operator-user", "operator-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.totalCount").value(3))
+			.andExpect(jsonPath("$.data.helpfulCount").value(1))
+			.andExpect(jsonPath("$.data.notHelpfulCount").value(1))
+			.andExpect(jsonPath("$.data.blockedByRealWorldCount").value(1))
+			.andExpect(jsonPath("$.data.ratingRows[0].label").value("도움이 됨"))
+			.andExpect(jsonPath("$.data.ratingRows[0].description").value("경로 안내가 실제 이동에 도움됨"))
+			.andExpect(jsonPath("$.data.ratingRows[0].count").value(1))
+			.andExpect(jsonPath("$.data.recentBlockedFeedbacks[0].originStationName").value("상록수"))
+			.andExpect(jsonPath("$.data.recentBlockedFeedbacks[0].destinationStationName").value("사당"))
+			.andExpect(jsonPath("$.data.recentBlockedFeedbacks[0].mobilityTypeLabel").value("고령자"))
+			.andExpect(jsonPath("$.data.recentBlockedFeedbacks[0].createdAtLabel").exists())
+			.andExpect(jsonPath("$.data.recentBlockedFeedbacks[0].routeSearchId").doesNotExist())
+			.andExpect(jsonPath("$.data.recentBlockedFeedbacks[0].userId").doesNotExist())
+			.andExpect(jsonPath("$.data.recentBlockedFeedbacks[0].comment").doesNotExist());
+	}
+
+	@Test
+	@DisplayName("운영기관 이동 불편 신고 분석 API는 운영기관 계정 인증을 요구한다")
+	void routeFeedbackReportRequiresOperatorAuthentication() throws Exception {
+		mockMvc.perform(get("/operator/api/route-feedback-report"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/operator/api/route-feedback-report")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/operator/api/route-feedback-report")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private String createRouteSearch() throws Exception {
+		var result = mockMvc.perform(post("/api/v1/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "mobilityType": "SENIOR"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andReturn();
+		return JsonPath.read(result.getResponse().getContentAsString(), "$.data.routeSearchId");
+	}
+
+	private void submitRouteFeedback(String routeSearchId, String rating, String comment) throws Exception {
+		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "basic-user",
+					  "rating": "%s",
+					  "comment": "%s"
+					}
+					""".formatted(rating, comment)))
+			.andExpect(status().isOk());
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1689,6 +1689,15 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   const feedbackDashboardController = read(
     "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageController.java",
   );
+  const feedbackDashboardAssembler = read(
+    "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackDashboardAssembler.java",
+  );
+  const feedbackDashboardView = read(
+    "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackDashboardView.java",
+  );
+  const operatorRouteFeedbackReportController = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportController.java",
+  );
   const searchDashboardTemplate = read("backend/src/main/resources/templates/admin/routes/searches.html");
   const feedbackDashboardTemplate = read("backend/src/main/resources/templates/admin/routes/feedback.html");
   const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
@@ -1793,9 +1802,19 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(searchDashboardTemplate, /도착 검색/);
   assert.doesNotMatch(searchDashboardTemplate, /routeSearchId/);
   assert.match(feedbackDashboardController, /@GetMapping\("\/admin\/routes\/feedback\/page"\)/);
-  assert.match(feedbackDashboardController, /RouteFeedbackDashboardUseCase/);
-  assert.match(feedbackDashboardController, /recentBlockedFeedbacks/);
-  assert.match(feedbackDashboardController, /mobilityTypeLabel/);
+  assert.match(feedbackDashboardController, /RouteFeedbackDashboardAssembler/);
+  assert.match(feedbackDashboardController, /routeFeedbackDashboardAssembler\.assemble\(\)/);
+  assert.match(feedbackDashboardAssembler, /RouteFeedbackDashboardUseCase/);
+  assert.match(feedbackDashboardAssembler, /summarizeRouteFeedbacks/);
+  assert.match(feedbackDashboardAssembler, /recentBlockedFeedbacks/);
+  assert.match(feedbackDashboardAssembler, /mobilityTypeLabel/);
+  assert.match(feedbackDashboardView, /record RouteFeedbackDashboardView/);
+  assert.match(feedbackDashboardView, /record RatingCountRow/);
+  assert.match(feedbackDashboardView, /record RecentBlockedFeedbackRow/);
+  assert.doesNotMatch(feedbackDashboardView, /routeSearchId|userId|comment/);
+  assert.match(operatorRouteFeedbackReportController, /@GetMapping\("\/operator\/api\/route-feedback-report"\)/);
+  assert.match(operatorRouteFeedbackReportController, /ApiResponse<RouteFeedbackDashboardView>/);
+  assert.match(operatorRouteFeedbackReportController, /routeFeedbackDashboardAssembler\.assemble\(\)/);
   assert.match(feedbackDashboardTemplate, /경로 피드백 현황/);
   assert.match(feedbackDashboardTemplate, /전체 피드백/);
   assert.match(feedbackDashboardTemplate, /평점별 피드백/);


### PR DESCRIPTION
## 관련 이슈

close #349

## 작업 배경

- 운영기관/B2G 연동에서 교통약자 이동 불편 신고 분석을 JSON으로 가져갈 API가 필요하다.
- 기존 관리자 경로 피드백 화면은 HTML 전용 controller 내부에서 view model을 만들고 있어 API와 재사용하기 어렵다.

## 작업 내용

- `/operator/api/route-feedback-report` 운영기관 전용 읽기 API를 추가한다.
- 경로 피드백 현황 view model과 assembler를 분리해 관리자 화면과 운영기관 API가 같은 조립 로직을 사용하도록 변경한다.
- 전체 피드백 수, 평점별 건수, 최근 현장 차단 신고 목록을 제공한다.
- 운영기관 API 응답에서 사용자 ID, routeSearchId, 원문 comment가 노출되지 않는 테스트를 추가한다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.operator.adapter.in.web.OperatorRouteFeedbackReportControllerTest` (backend): 통과
  - `./gradlew test --tests com.easysubway.route.adapter.in.web.RouteFeedbackAdminPageControllerTest` (backend): 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과, 43개 테스트
  - `./gradlew test` (backend): 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 출력
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 모두 ignore 규칙 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteFeedbackDashboardAssembler`가 관리자 화면과 운영기관 API에서 동일하게 쓰이는지
  - 운영기관 API 응답에 내부 추적값이나 사용자 작성 원문이 포함되지 않는지

## 리스크

- 기관별 경로 피드백 스코프 제한은 이번 범위에 포함하지 않아 전체 경로 피드백 분석 기준선만 제공한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
