### PR TITLE
[Feat] 운영기관 반복 고장 시설 통계 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesAssembler.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesAssembler.java
@@ -1,0 +1,68 @@
+package com.easysubway.operator.adapter.in.web;
+
+import com.easysubway.report.application.port.in.FacilityReportUseCase;
+import com.easysubway.report.domain.RepeatedBrokenFacilityReportSummary;
+import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
+import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import com.easysubway.transit.domain.StationNotFoundException;
+import com.easysubway.transit.domain.StationWithLines;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+@Component
+class OperatorRepeatedBrokenFacilitiesAssembler {
+
+	private final FacilityReportUseCase facilityReportUseCase;
+	private final TransitMasterQueryUseCase transitMasterQueryUseCase;
+
+	OperatorRepeatedBrokenFacilitiesAssembler(
+		FacilityReportUseCase facilityReportUseCase,
+		TransitMasterQueryUseCase transitMasterQueryUseCase
+	) {
+		this.facilityReportUseCase = facilityReportUseCase;
+		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
+	}
+
+	OperatorRepeatedBrokenFacilitiesView assemble() {
+		List<OperatorRepeatedBrokenFacilitiesView.RepeatedBrokenFacilityRow> rows = facilityReportUseCase
+			.listRepeatedBrokenReportFacilities()
+			.stream()
+			.map(this::row)
+			.flatMap(Optional::stream)
+			.toList();
+		return new OperatorRepeatedBrokenFacilitiesView(rows.size(), rows);
+	}
+
+	private Optional<OperatorRepeatedBrokenFacilitiesView.RepeatedBrokenFacilityRow> row(
+		RepeatedBrokenFacilityReportSummary summary
+	) {
+		try {
+			StationWithLines station = transitMasterQueryUseCase.getStation(summary.stationId());
+			return transitMasterQueryUseCase.listStationFacilities(summary.stationId())
+				.stream()
+				.filter(candidate -> candidate.id().equals(summary.facilityId()))
+				.findFirst()
+				.map(facility -> new OperatorRepeatedBrokenFacilitiesView.RepeatedBrokenFacilityRow(
+					station.station().nameKo(),
+					facility.name(),
+					statusLabel(facility.status()),
+					summary.reportCount()
+				));
+		} catch (StationNotFoundException exception) {
+			return Optional.empty();
+		}
+	}
+
+	private static String statusLabel(AccessibilityFacilityStatus status) {
+		return switch (status) {
+			case NORMAL -> "정상";
+			case BROKEN -> "고장";
+			case UNDER_CONSTRUCTION -> "공사 중";
+			case CLOSED -> "폐쇄";
+			case UNKNOWN -> "확인 필요";
+			case USER_REPORTED -> "사용자 제보";
+			case ADMIN_VERIFIED -> "관리자 확인";
+		};
+	}
+}

--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesController.java
@@ -1,0 +1,22 @@
+package com.easysubway.operator.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class OperatorRepeatedBrokenFacilitiesController {
+
+	private final OperatorRepeatedBrokenFacilitiesAssembler repeatedBrokenFacilitiesAssembler;
+
+	OperatorRepeatedBrokenFacilitiesController(
+		OperatorRepeatedBrokenFacilitiesAssembler repeatedBrokenFacilitiesAssembler
+	) {
+		this.repeatedBrokenFacilitiesAssembler = repeatedBrokenFacilitiesAssembler;
+	}
+
+	@GetMapping("/operator/api/repeated-broken-facilities")
+	ApiResponse<OperatorRepeatedBrokenFacilitiesView> repeatedBrokenFacilities() {
+		return ApiResponse.ok(repeatedBrokenFacilitiesAssembler.assemble());
+	}
+}

--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesView.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesView.java
@@ -1,0 +1,17 @@
+package com.easysubway.operator.adapter.in.web;
+
+import java.util.List;
+
+record OperatorRepeatedBrokenFacilitiesView(
+	int totalRepeatedFacilityCount,
+	List<RepeatedBrokenFacilityRow> rows
+) {
+
+	record RepeatedBrokenFacilityRow(
+		String stationName,
+		String facilityName,
+		String statusLabel,
+		long reportCount
+	) {
+	}
+}

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesAssemblerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesAssemblerTest.java
@@ -1,0 +1,94 @@
+package com.easysubway.operator.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.easysubway.report.application.port.in.FacilityReportUseCase;
+import com.easysubway.report.domain.RepeatedBrokenFacilityReportSummary;
+import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
+import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import com.easysubway.transit.domain.AccessibilityFacilityType;
+import com.easysubway.transit.domain.DataConfidenceLevel;
+import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.Station;
+import com.easysubway.transit.domain.StationNotFoundException;
+import com.easysubway.transit.domain.StationWithLines;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("운영기관 반복 고장 시설 통계 조립")
+class OperatorRepeatedBrokenFacilitiesAssemblerTest {
+
+	@Test
+	@DisplayName("현재 마스터데이터와 맞지 않는 반복 고장 시설 집계는 제외한다")
+	void assembleSkipsStaleRepeatedBrokenFacilityTargets() {
+		FacilityReportUseCase facilityReportUseCase = mock(FacilityReportUseCase.class);
+		TransitMasterQueryUseCase transitMasterQueryUseCase = mock(TransitMasterQueryUseCase.class);
+		OperatorRepeatedBrokenFacilitiesAssembler assembler = new OperatorRepeatedBrokenFacilitiesAssembler(
+			facilityReportUseCase,
+			transitMasterQueryUseCase
+		);
+		when(facilityReportUseCase.listRepeatedBrokenReportFacilities()).thenReturn(List.of(
+			new RepeatedBrokenFacilityReportSummary("station-sangnoksu", "facility-removed", 2),
+			new RepeatedBrokenFacilityReportSummary("station-removed", "facility-old", 3),
+			new RepeatedBrokenFacilityReportSummary("station-sangnoksu", "facility-sangnoksu-elevator-1", 4)
+		));
+		when(transitMasterQueryUseCase.getStation("station-sangnoksu")).thenReturn(station("station-sangnoksu", "상록수"));
+		when(transitMasterQueryUseCase.getStation("station-removed")).thenThrow(new StationNotFoundException());
+		when(transitMasterQueryUseCase.listStationFacilities("station-sangnoksu"))
+			.thenReturn(List.of(facility("facility-sangnoksu-elevator-1", "1번 출구 엘리베이터")));
+
+		OperatorRepeatedBrokenFacilitiesView view = assembler.assemble();
+
+		assertThat(view.totalRepeatedFacilityCount()).isEqualTo(1);
+		assertThat(view.rows()).hasSize(1);
+		OperatorRepeatedBrokenFacilitiesView.RepeatedBrokenFacilityRow row = view.rows().getFirst();
+		assertThat(row.stationName()).isEqualTo("상록수");
+		assertThat(row.facilityName()).isEqualTo("1번 출구 엘리베이터");
+		assertThat(row.statusLabel()).isEqualTo("정상");
+		assertThat(row.reportCount()).isEqualTo(4);
+	}
+
+	private static StationWithLines station(String id, String nameKo) {
+		return new StationWithLines(
+			new Station(
+				id,
+				nameKo,
+				"Sangnoksu",
+				"수도권",
+				BigDecimal.valueOf(37.302),
+				BigDecimal.valueOf(126.866),
+				DataQualityLevel.LEVEL_1,
+				DataSourceType.ADMIN_VERIFIED,
+				LocalDate.of(2026, 1, 1),
+				true
+			),
+			List.of()
+		);
+	}
+
+	private static AccessibilityFacility facility(String id, String name) {
+		return new AccessibilityFacility(
+			id,
+			"station-sangnoksu",
+			"exit-sangnoksu-1",
+			AccessibilityFacilityType.ELEVATOR,
+			name,
+			"B1",
+			"1F",
+			BigDecimal.valueOf(37.302),
+			BigDecimal.valueOf(126.866),
+			"승강장 연결",
+			AccessibilityFacilityStatus.NORMAL,
+			DataConfidenceLevel.HIGH,
+			DataSourceType.ADMIN_VERIFIED,
+			LocalDate.of(2026, 1, 1)
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesControllerTest.java
@@ -1,0 +1,98 @@
+package com.easysubway.operator.adapter.in.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.operator.username=operator-user",
+	"easysubway.operator.password=operator-test-password",
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("운영기관 반복 고장 시설 통계 API")
+class OperatorRepeatedBrokenFacilitiesControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("운영기관 계정은 반복 고장 시설 통계를 JSON으로 조회한다")
+	void operatorGetsRepeatedBrokenFacilities() throws Exception {
+		createBrokenReport("첫 번째 엘리베이터 고장 신고");
+		createBrokenReport("두 번째 엘리베이터 고장 신고");
+		createReport("facility-sangnoksu-elevator-1", "LOCATION_WRONG", "위치 설명 오류 신고");
+		createBrokenReport("station-sangnoksu", "facility-sangnoksu-escalator-1", "에스컬레이터 단일 고장 신고");
+
+		mockMvc.perform(get("/operator/api/repeated-broken-facilities")
+				.with(httpBasic("operator-user", "operator-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.totalRepeatedFacilityCount").value(1))
+			.andExpect(jsonPath("$.data.rows[0].stationName").value("상록수"))
+			.andExpect(jsonPath("$.data.rows[0].facilityName").value("1번 출구 엘리베이터"))
+			.andExpect(jsonPath("$.data.rows[0].statusLabel").value("정상"))
+			.andExpect(jsonPath("$.data.rows[0].reportCount").value(2))
+			.andExpect(jsonPath("$.data.rows[0].stationId").doesNotExist())
+			.andExpect(jsonPath("$.data.rows[0].facilityId").doesNotExist())
+			.andExpect(jsonPath("$.data.rows[0].userId").doesNotExist())
+			.andExpect(jsonPath("$.data.rows[0].description").doesNotExist());
+	}
+
+	@Test
+	@DisplayName("운영기관 반복 고장 시설 통계 API는 운영기관 계정 인증을 요구한다")
+	void repeatedBrokenFacilitiesRequiresOperatorAuthentication() throws Exception {
+		mockMvc.perform(get("/operator/api/repeated-broken-facilities"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/operator/api/repeated-broken-facilities")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/operator/api/repeated-broken-facilities")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private void createBrokenReport(String description) throws Exception {
+		createBrokenReport("station-sangnoksu", "facility-sangnoksu-elevator-1", description);
+	}
+
+	private void createBrokenReport(String stationId, String facilityId, String description) throws Exception {
+		createReport(stationId, facilityId, "BROKEN", description);
+	}
+
+	private void createReport(String facilityId, String reportType, String description) throws Exception {
+		createReport("station-sangnoksu", facilityId, reportType, description);
+	}
+
+	private void createReport(String stationId, String facilityId, String reportType, String description) throws Exception {
+		mockMvc.perform(post("/api/v1/reports")
+				.with(httpBasic("basic-user", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "stationId": "%s",
+					  "facilityId": "%s",
+					  "reportType": "%s",
+					  "description": "%s"
+					}
+					""".formatted(stationId, facilityId, reportType, description)))
+			.andExpect(status().isCreated());
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -849,6 +849,15 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   const operatorReportView = read(
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportView.java",
   );
+  const operatorRepeatedBrokenFacilitiesController = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesController.java",
+  );
+  const operatorRepeatedBrokenFacilitiesAssembler = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesAssembler.java",
+  );
+  const operatorRepeatedBrokenFacilitiesView = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesView.java",
+  );
   const operatorReportTemplate = read("backend/src/main/resources/templates/operator/accessibility-report.html");
 
   assert.match(report, /record FacilityReport/);
@@ -944,6 +953,20 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(operatorReportAssembler, /TransitMasterQueryUseCase/);
   assert.match(operatorReportView, /record AccessibilityImprovementPriorityRow\([\s\S]*String stationName,[\s\S]*String facilityName,[\s\S]*int priorityScore,[\s\S]*List<String> reasons/);
   assert.doesNotMatch(operatorReportView, /facilityId/);
+  assert.match(
+    operatorRepeatedBrokenFacilitiesController,
+    /@GetMapping\("\/operator\/api\/repeated-broken-facilities"\)/,
+  );
+  assert.match(operatorRepeatedBrokenFacilitiesController, /ApiResponse<OperatorRepeatedBrokenFacilitiesView>/);
+  assert.match(operatorRepeatedBrokenFacilitiesController, /repeatedBrokenFacilitiesAssembler\.assemble\(\)/);
+  assert.match(operatorRepeatedBrokenFacilitiesAssembler, /FacilityReportUseCase/);
+  assert.match(operatorRepeatedBrokenFacilitiesAssembler, /TransitMasterQueryUseCase/);
+  assert.match(operatorRepeatedBrokenFacilitiesAssembler, /listRepeatedBrokenReportFacilities/);
+  assert.match(operatorRepeatedBrokenFacilitiesAssembler, /StationNotFoundException/);
+  assert.match(operatorRepeatedBrokenFacilitiesView, /record OperatorRepeatedBrokenFacilitiesView/);
+  assert.match(operatorRepeatedBrokenFacilitiesView, /int totalRepeatedFacilityCount/);
+  assert.match(operatorRepeatedBrokenFacilitiesView, /record RepeatedBrokenFacilityRow/);
+  assert.doesNotMatch(operatorRepeatedBrokenFacilitiesView, /stationId|facilityId|userId|description/);
   assert.match(operatorReportTemplate, /운영기관 접근성 시설 현황/);
   assert.match(operatorReportTemplate, /읽기 전용 리포트/);
   assert.match(operatorReportTemplate, /역별 접근성 점수/);


### PR DESCRIPTION
## 관련 이슈

close #351

## 작업 배경

- 반복 고장 시설 통계는 운영기관이 시설 개선 우선순위를 판단하는 데 필요한 B2G/B2B 지표다.
- 현재 관리자 품질 화면에서는 확인할 수 있지만 운영기관 계정이 JSON으로 조회할 API가 없다.

## 작업 내용

- `/operator/api/repeated-broken-facilities` 운영기관 전용 읽기 API를 추가한다.
- 반복 고장 시설 집계 결과를 역명, 시설명, 현재 시설 상태, 고장 신고 수 중심의 view model로 조립한다.
- 현재 마스터데이터에서 찾을 수 없는 과거 신고 집계는 API 응답에서 제외한다.
- 응답에 `stationId`, `facilityId`, 신고자 ID, 신고 원문이 노출되지 않도록 테스트와 repository contract를 추가한다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.operator.adapter.in.web.OperatorRepeatedBrokenFacilitiesAssemblerTest` (backend): 통과
  - `./gradlew test --tests com.easysubway.operator.adapter.in.web.OperatorRepeatedBrokenFacilitiesControllerTest` (backend): 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과, 43개 테스트
  - `./gradlew test` (backend): 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 출력
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 모두 ignore 규칙 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 운영기관 API 응답에서 내부 ID와 신고 원문이 빠져 있는지
  - stale station/facility 집계를 제외하는 assembler 로직이 관리자 품질 화면의 기존 처리와 같은 기준인지

## 리스크

- 기관별 데이터 스코프 제한은 이번 범위에 포함하지 않아 전체 반복 고장 시설 통계 기준선만 제공한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
