### PR TITLE
[Feat] 운영기관 데이터 수집 실패 현황 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresAssembler.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresAssembler.java
@@ -1,0 +1,75 @@
+package com.easysubway.operator.adapter.in.web;
+
+import com.easysubway.collection.application.port.in.DataCollectionUseCase;
+import com.easysubway.collection.domain.DataCollectionRun;
+import com.easysubway.collection.domain.DataCollectionSource;
+import com.easysubway.collection.domain.DataCollectionStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+class OperatorDataCollectionFailuresAssembler {
+
+	private static final int DEFAULT_RECENT_RUN_LIMIT = 20;
+
+	private final DataCollectionUseCase dataCollectionUseCase;
+
+	OperatorDataCollectionFailuresAssembler(DataCollectionUseCase dataCollectionUseCase) {
+		this.dataCollectionUseCase = dataCollectionUseCase;
+	}
+
+	OperatorDataCollectionFailuresView assemble() {
+		List<DataCollectionRun> runs = dataCollectionUseCase.listRecentRuns(DEFAULT_RECENT_RUN_LIMIT);
+		long failedRunCount = runs.stream()
+			.filter(run -> run.status() == DataCollectionStatus.FAILED)
+			.count();
+		long retryableRunCount = runs.stream()
+			.filter(DataCollectionRun::retryable)
+			.count();
+		List<OperatorDataCollectionFailuresView.DataCollectionRunRow> rows = runs.stream()
+			.map(OperatorDataCollectionFailuresAssembler::row)
+			.toList();
+		return new OperatorDataCollectionFailuresView(
+			rows.size(),
+			failedRunCount,
+			retryableRunCount,
+			rows
+		);
+	}
+
+	private static OperatorDataCollectionFailuresView.DataCollectionRunRow row(DataCollectionRun run) {
+		return new OperatorDataCollectionFailuresView.DataCollectionRunRow(
+			sourceLabel(run.source()),
+			statusLabel(run.status()),
+			timeLabel(run.startedAt()),
+			timeLabel(run.completedAt()),
+			run.collectedCount(),
+			failureLabel(run.failureMessage()),
+			run.retryable(),
+			run.operatorAction()
+		);
+	}
+
+	private static String sourceLabel(DataCollectionSource source) {
+		return switch (source) {
+			case TRANSIT_MASTER -> "도시철도 마스터";
+		};
+	}
+
+	private static String statusLabel(DataCollectionStatus status) {
+		return switch (status) {
+			case RUNNING -> "실행 중";
+			case COMPLETED -> "완료";
+			case FAILED -> "실패";
+		};
+	}
+
+	private static String timeLabel(LocalDateTime value) {
+		return value == null ? "-" : value.toString();
+	}
+
+	private static String failureLabel(String value) {
+		return value == null || value.isBlank() ? "-" : value;
+	}
+}

--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresController.java
@@ -1,0 +1,22 @@
+package com.easysubway.operator.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class OperatorDataCollectionFailuresController {
+
+	private final OperatorDataCollectionFailuresAssembler dataCollectionFailuresAssembler;
+
+	OperatorDataCollectionFailuresController(
+		OperatorDataCollectionFailuresAssembler dataCollectionFailuresAssembler
+	) {
+		this.dataCollectionFailuresAssembler = dataCollectionFailuresAssembler;
+	}
+
+	@GetMapping("/operator/api/data-collection-failures")
+	ApiResponse<OperatorDataCollectionFailuresView> dataCollectionFailures() {
+		return ApiResponse.ok(dataCollectionFailuresAssembler.assemble());
+	}
+}

--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresView.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresView.java
@@ -1,0 +1,23 @@
+package com.easysubway.operator.adapter.in.web;
+
+import java.util.List;
+
+record OperatorDataCollectionFailuresView(
+	int totalRunCount,
+	long failedRunCount,
+	long retryableRunCount,
+	List<DataCollectionRunRow> rows
+) {
+
+	record DataCollectionRunRow(
+		String sourceLabel,
+		String statusLabel,
+		String startedAtLabel,
+		String completedAtLabel,
+		int collectedCount,
+		String failureMessage,
+		boolean retryable,
+		String operatorAction
+	) {
+	}
+}

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresControllerTest.java
@@ -1,0 +1,109 @@
+package com.easysubway.operator.adapter.in.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.easysubway.collection.application.port.out.SaveDataCollectionRunPort;
+import com.easysubway.collection.domain.DataCollectionRun;
+import com.easysubway.collection.domain.DataCollectionSource;
+import com.easysubway.collection.domain.DataCollectionStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.operator.username=operator-user",
+	"easysubway.operator.password=operator-test-password",
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("운영기관 데이터 수집 실패 현황 API")
+class OperatorDataCollectionFailuresControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private SaveDataCollectionRunPort saveDataCollectionRunPort;
+
+	@Test
+	@DisplayName("운영기관 계정은 최근 데이터 수집 실패와 재시도 안내를 JSON으로 조회한다")
+	void operatorGetsDataCollectionFailures() throws Exception {
+		saveRun(new DataCollectionRun(
+			"collection-completed",
+			DataCollectionSource.TRANSIT_MASTER,
+			DataCollectionStatus.COMPLETED,
+			"admin-user",
+			LocalDateTime.parse("2026-06-18T09:00:00"),
+			LocalDateTime.parse("2026-06-18T09:01:00"),
+			14,
+			null,
+			false,
+			"수집이 완료되었습니다. 최근 데이터 품질 화면에서 반영 결과를 확인하세요."
+		));
+		saveRun(new DataCollectionRun(
+			"collection-failed",
+			DataCollectionSource.TRANSIT_MASTER,
+			DataCollectionStatus.FAILED,
+			"admin-user",
+			LocalDateTime.parse("2026-06-18T10:00:00"),
+			LocalDateTime.parse("2026-06-18T10:00:30"),
+			0,
+			"공공데이터 응답 지연",
+			true,
+			"일시 오류일 수 있습니다. 실패 사유를 확인한 뒤 같은 수집 대상을 다시 실행하세요."
+		));
+
+		mockMvc.perform(get("/operator/api/data-collection-failures")
+				.with(httpBasic("operator-user", "operator-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.totalRunCount").value(2))
+			.andExpect(jsonPath("$.data.failedRunCount").value(1))
+			.andExpect(jsonPath("$.data.retryableRunCount").value(1))
+			.andExpect(jsonPath("$.data.rows[0].sourceLabel").value("도시철도 마스터"))
+			.andExpect(jsonPath("$.data.rows[0].statusLabel").value("실패"))
+			.andExpect(jsonPath("$.data.rows[0].startedAtLabel").value("2026-06-18T10:00"))
+			.andExpect(jsonPath("$.data.rows[0].completedAtLabel").value("2026-06-18T10:00:30"))
+			.andExpect(jsonPath("$.data.rows[0].collectedCount").value(0))
+			.andExpect(jsonPath("$.data.rows[0].failureMessage").value("공공데이터 응답 지연"))
+			.andExpect(jsonPath("$.data.rows[0].retryable").value(true))
+			.andExpect(jsonPath("$.data.rows[0].operatorAction")
+				.value("일시 오류일 수 있습니다. 실패 사유를 확인한 뒤 같은 수집 대상을 다시 실행하세요."))
+			.andExpect(jsonPath("$.data.rows[0].runId").doesNotExist())
+			.andExpect(jsonPath("$.data.rows[0].requestedBy").doesNotExist())
+			.andExpect(jsonPath("$.data.rows[1].statusLabel").value("완료"))
+			.andExpect(jsonPath("$.data.rows[1].failureMessage").value("-"))
+			.andExpect(jsonPath("$.data.rows[1].retryable").value(false));
+	}
+
+	@Test
+	@DisplayName("운영기관 데이터 수집 실패 현황 API는 운영기관 계정 인증을 요구한다")
+	void dataCollectionFailuresRequireOperatorAuthentication() throws Exception {
+		mockMvc.perform(get("/operator/api/data-collection-failures"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/operator/api/data-collection-failures")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/operator/api/data-collection-failures")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private void saveRun(DataCollectionRun run) {
+		saveDataCollectionRunPort.saveRun(run);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -858,6 +858,15 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   const operatorRepeatedBrokenFacilitiesView = read(
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesView.java",
   );
+  const operatorDataCollectionFailuresController = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresController.java",
+  );
+  const operatorDataCollectionFailuresAssembler = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresAssembler.java",
+  );
+  const operatorDataCollectionFailuresView = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresView.java",
+  );
   const operatorReportTemplate = read("backend/src/main/resources/templates/operator/accessibility-report.html");
 
   assert.match(report, /record FacilityReport/);
@@ -967,6 +976,21 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(operatorRepeatedBrokenFacilitiesView, /int totalRepeatedFacilityCount/);
   assert.match(operatorRepeatedBrokenFacilitiesView, /record RepeatedBrokenFacilityRow/);
   assert.doesNotMatch(operatorRepeatedBrokenFacilitiesView, /stationId|facilityId|userId|description/);
+  assert.match(
+    operatorDataCollectionFailuresController,
+    /@GetMapping\("\/operator\/api\/data-collection-failures"\)/,
+  );
+  assert.match(operatorDataCollectionFailuresController, /ApiResponse<OperatorDataCollectionFailuresView>/);
+  assert.match(operatorDataCollectionFailuresController, /dataCollectionFailuresAssembler\.assemble\(\)/);
+  assert.match(operatorDataCollectionFailuresAssembler, /DataCollectionUseCase/);
+  assert.match(operatorDataCollectionFailuresAssembler, /listRecentRuns/);
+  assert.match(operatorDataCollectionFailuresAssembler, /DataCollectionStatus\.FAILED/);
+  assert.match(operatorDataCollectionFailuresView, /record OperatorDataCollectionFailuresView/);
+  assert.match(operatorDataCollectionFailuresView, /int totalRunCount/);
+  assert.match(operatorDataCollectionFailuresView, /long failedRunCount/);
+  assert.match(operatorDataCollectionFailuresView, /long retryableRunCount/);
+  assert.match(operatorDataCollectionFailuresView, /record DataCollectionRunRow/);
+  assert.doesNotMatch(operatorDataCollectionFailuresView, /runId|requestedBy/);
   assert.match(operatorReportTemplate, /운영기관 접근성 시설 현황/);
   assert.match(operatorReportTemplate, /읽기 전용 리포트/);
   assert.match(operatorReportTemplate, /역별 접근성 점수/);


### PR DESCRIPTION
## 관련 이슈

close #353

## 작업 배경

- 운영기관은 접근성 데이터 신뢰도를 판단할 때 최근 공공데이터 수집 실패 여부와 재시도 필요 상태를 확인해야 한다.
- 기존 데이터 수집 실행 이력은 관리자 API와 화면 중심이라 운영기관 계정에는 실행 권한 없이 읽기 전용 현황만 제공하는 JSON API가 필요하다.

## 작업 내용

- `/operator/api/data-collection-failures` 운영기관 전용 읽기 API를 추가한다.
- 최근 데이터 수집 실행 이력을 수집 대상, 상태, 시작/완료 시각, 수집 건수, 실패 사유, 재시도 가능 여부, 다음 행동 안내 중심의 view model로 조립한다.
- 응답에서 내부 실행 ID와 관리자 계정명이 노출되지 않도록 controller 테스트와 repository contract를 추가한다.
- 기존 관리자 수집 실행 API와 배치 동작은 변경하지 않는다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.operator.adapter.in.web.OperatorDataCollectionFailuresControllerTest` (backend): RED 확인 후 구현 완료, 최종 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과, 43개 테스트
  - `./gradlew test` (backend): 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 출력
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/operator-data-collection-failure-api.md .codex/issue-operator-data-collection-failure-api.local.md swieun-jihacheol-project-plan.md`: 모두 ignore 규칙 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 운영기관 응답에서 `runId`, `requestedBy`가 빠져 있는지
  - 관리자 실행 API와 달리 운영기관 endpoint가 읽기 전용 조회만 제공하는지
  - 최근 실행 이력 label이 운영기관 담당자가 이해할 수 있는 표현인지

## 리스크

- 이번 범위는 최근 실행 이력 조회만 제공하며, 운영기관별 수집 대상 분리나 재시도 실행 권한은 포함하지 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
