### PR TITLE
[Feat] 운영기관 알림 발송 현황 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportAssembler.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportAssembler.java
@@ -1,0 +1,51 @@
+package com.easysubway.operator.adapter.in.web;
+
+import com.easysubway.notification.application.port.in.PushNotificationDashboardUseCase;
+import com.easysubway.notification.domain.PushNotificationDashboardSummary;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+class OperatorPushNotificationReportAssembler {
+
+	private final PushNotificationDashboardUseCase pushNotificationDashboardUseCase;
+
+	OperatorPushNotificationReportAssembler(PushNotificationDashboardUseCase pushNotificationDashboardUseCase) {
+		this.pushNotificationDashboardUseCase = pushNotificationDashboardUseCase;
+	}
+
+	OperatorPushNotificationReportView assemble() {
+		PushNotificationDashboardSummary summary = pushNotificationDashboardUseCase.summarizePushNotifications();
+		return new OperatorPushNotificationReportView(
+			summary.totalCount(),
+			summary.pendingCount(),
+			summary.sentCount(),
+			summary.failedCount(),
+			summary.latestFailureReason(),
+			List.of(
+				new OperatorPushNotificationReportView.StatusCountRow(
+					"대기 중",
+					"아직 발송 처리 전",
+					summary.pendingCount()
+				),
+				new OperatorPushNotificationReportView.StatusCountRow(
+					"발송 완료",
+					"외부 발송 성공",
+					summary.sentCount()
+				),
+				new OperatorPushNotificationReportView.StatusCountRow(
+					"발송 실패",
+					failedDescription(summary.latestFailureReason()),
+					summary.failedCount()
+				)
+			)
+		);
+	}
+
+	private static String failedDescription(String latestFailureReason) {
+		if (latestFailureReason == null || latestFailureReason.isBlank()) {
+			return "발송 어댑터 실패 또는 예외";
+		}
+		return "발송 어댑터 실패 또는 예외 · 최근 실패: " + latestFailureReason;
+	}
+}

--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportAssembler.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportAssembler.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Component;
 @Component
 class OperatorPushNotificationReportAssembler {
 
+	private static final String OPERATOR_SAFE_FAILURE_REASON = "푸시 발송 처리 중 오류가 발생했습니다. 관리자 점검이 필요합니다.";
+
 	private final PushNotificationDashboardUseCase pushNotificationDashboardUseCase;
 
 	OperatorPushNotificationReportAssembler(PushNotificationDashboardUseCase pushNotificationDashboardUseCase) {
@@ -21,7 +23,7 @@ class OperatorPushNotificationReportAssembler {
 			summary.pendingCount(),
 			summary.sentCount(),
 			summary.failedCount(),
-			summary.latestFailureReason(),
+			safeFailureReason(summary.failedCount()),
 			List.of(
 				new OperatorPushNotificationReportView.StatusCountRow(
 					"대기 중",
@@ -35,17 +37,21 @@ class OperatorPushNotificationReportAssembler {
 				),
 				new OperatorPushNotificationReportView.StatusCountRow(
 					"발송 실패",
-					failedDescription(summary.latestFailureReason()),
+					failedDescription(summary.failedCount()),
 					summary.failedCount()
 				)
 			)
 		);
 	}
 
-	private static String failedDescription(String latestFailureReason) {
-		if (latestFailureReason == null || latestFailureReason.isBlank()) {
-			return "발송 어댑터 실패 또는 예외";
+	private static String safeFailureReason(long failedCount) {
+		return failedCount == 0 ? null : OPERATOR_SAFE_FAILURE_REASON;
+	}
+
+	private static String failedDescription(long failedCount) {
+		if (failedCount == 0) {
+			return "최근 실패 없음";
 		}
-		return "발송 어댑터 실패 또는 예외 · 최근 실패: " + latestFailureReason;
+		return OPERATOR_SAFE_FAILURE_REASON;
 	}
 }

--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportController.java
@@ -1,0 +1,22 @@
+package com.easysubway.operator.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class OperatorPushNotificationReportController {
+
+	private final OperatorPushNotificationReportAssembler pushNotificationReportAssembler;
+
+	OperatorPushNotificationReportController(
+		OperatorPushNotificationReportAssembler pushNotificationReportAssembler
+	) {
+		this.pushNotificationReportAssembler = pushNotificationReportAssembler;
+	}
+
+	@GetMapping("/operator/api/push-notification-report")
+	ApiResponse<OperatorPushNotificationReportView> pushNotificationReport() {
+		return ApiResponse.ok(pushNotificationReportAssembler.assemble());
+	}
+}

--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportView.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportView.java
@@ -1,0 +1,20 @@
+package com.easysubway.operator.adapter.in.web;
+
+import java.util.List;
+
+record OperatorPushNotificationReportView(
+	long totalCount,
+	long pendingCount,
+	long sentCount,
+	long failedCount,
+	String latestFailureReason,
+	List<StatusCountRow> statusRows
+) {
+
+	record StatusCountRow(
+		String label,
+		String description,
+		long count
+	) {
+	}
+}

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportControllerTest.java
@@ -1,0 +1,123 @@
+package com.easysubway.operator.adapter.in.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.operator.username=operator-user",
+	"easysubway.operator.password=operator-test-password",
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("운영기관 알림 발송 현황 API")
+class OperatorPushNotificationReportControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("운영기관 계정은 알림 발송 현황과 최근 실패 사유를 JSON으로 조회한다")
+	void operatorGetsPushNotificationReport() throws Exception {
+		registerAndroidDevice();
+		dispatchReportStatusNotification();
+		deliverPendingNotifications();
+		dispatchReportStatusNotification();
+
+		mockMvc.perform(get("/operator/api/push-notification-report")
+				.with(httpBasic("operator-user", "operator-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.totalCount").value(2))
+			.andExpect(jsonPath("$.data.pendingCount").value(1))
+			.andExpect(jsonPath("$.data.sentCount").value(0))
+			.andExpect(jsonPath("$.data.failedCount").value(1))
+			.andExpect(jsonPath("$.data.latestFailureReason")
+				.value("외부 푸시 발송 어댑터가 설정되지 않았습니다."))
+			.andExpect(jsonPath("$.data.statusRows[0].label").value("대기 중"))
+			.andExpect(jsonPath("$.data.statusRows[0].description").value("아직 발송 처리 전"))
+			.andExpect(jsonPath("$.data.statusRows[0].count").value(1))
+			.andExpect(jsonPath("$.data.statusRows[1].label").value("발송 완료"))
+			.andExpect(jsonPath("$.data.statusRows[1].count").value(0))
+			.andExpect(jsonPath("$.data.statusRows[2].label").value("발송 실패"))
+			.andExpect(jsonPath("$.data.statusRows[2].description")
+				.value("발송 어댑터 실패 또는 예외 · 최근 실패: 외부 푸시 발송 어댑터가 설정되지 않았습니다."))
+			.andExpect(jsonPath("$.data.statusRows[2].count").value(1))
+			.andExpect(jsonPath("$.data.notificationId").doesNotExist())
+			.andExpect(jsonPath("$.data.userId").doesNotExist())
+			.andExpect(jsonPath("$.data.deviceToken").doesNotExist());
+	}
+
+	@Test
+	@DisplayName("운영기관 알림 발송 현황 API는 운영기관 계정 인증을 요구한다")
+	void pushNotificationReportRequiresOperatorAuthentication() throws Exception {
+		mockMvc.perform(get("/operator/api/push-notification-report"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/operator/api/push-notification-report")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/operator/api/push-notification-report")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private void registerAndroidDevice() throws Exception {
+		mockMvc.perform(post("/api/v1/devices")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "platform": "ANDROID",
+					  "deviceToken": "secret-device-token"
+					}
+					"""))
+			.andExpect(status().isOk());
+	}
+
+	private void dispatchReportStatusNotification() throws Exception {
+		mockMvc.perform(post("/admin/notifications/push")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "type": "REPORT_STATUS",
+					  "title": "신고 처리 알림",
+					  "body": "제보한 내용이 확인되었습니다."
+					}
+					"""))
+			.andExpect(status().isOk());
+	}
+
+	private void deliverPendingNotifications() throws Exception {
+		mockMvc.perform(post("/admin/notifications/push/deliveries")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1"
+					}
+					"""))
+			.andExpect(status().isOk());
+	}
+}

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportControllerTest.java
@@ -1,9 +1,12 @@
 package com.easysubway.operator.adapter.in.web;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -49,7 +52,7 @@ class OperatorPushNotificationReportControllerTest {
 			.andExpect(jsonPath("$.data.sentCount").value(0))
 			.andExpect(jsonPath("$.data.failedCount").value(1))
 			.andExpect(jsonPath("$.data.latestFailureReason")
-				.value("외부 푸시 발송 어댑터가 설정되지 않았습니다."))
+				.value("푸시 발송 처리 중 오류가 발생했습니다. 관리자 점검이 필요합니다."))
 			.andExpect(jsonPath("$.data.statusRows[0].label").value("대기 중"))
 			.andExpect(jsonPath("$.data.statusRows[0].description").value("아직 발송 처리 전"))
 			.andExpect(jsonPath("$.data.statusRows[0].count").value(1))
@@ -57,11 +60,12 @@ class OperatorPushNotificationReportControllerTest {
 			.andExpect(jsonPath("$.data.statusRows[1].count").value(0))
 			.andExpect(jsonPath("$.data.statusRows[2].label").value("발송 실패"))
 			.andExpect(jsonPath("$.data.statusRows[2].description")
-				.value("발송 어댑터 실패 또는 예외 · 최근 실패: 외부 푸시 발송 어댑터가 설정되지 않았습니다."))
+				.value("푸시 발송 처리 중 오류가 발생했습니다. 관리자 점검이 필요합니다."))
 			.andExpect(jsonPath("$.data.statusRows[2].count").value(1))
 			.andExpect(jsonPath("$.data.notificationId").doesNotExist())
 			.andExpect(jsonPath("$.data.userId").doesNotExist())
-			.andExpect(jsonPath("$.data.deviceToken").doesNotExist());
+			.andExpect(jsonPath("$.data.deviceToken").doesNotExist())
+			.andExpect(content().string(not(containsString("외부 푸시 발송 어댑터가 설정되지 않았습니다."))));
 	}
 
 	@Test

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1419,6 +1419,9 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   assert.match(operatorPushNotificationReportController, /pushNotificationReportAssembler\.assemble\(\)/);
   assert.match(operatorPushNotificationReportAssembler, /PushNotificationDashboardUseCase/);
   assert.match(operatorPushNotificationReportAssembler, /summarizePushNotifications/);
+  assert.match(operatorPushNotificationReportAssembler, /OPERATOR_SAFE_FAILURE_REASON/);
+  assert.doesNotMatch(operatorPushNotificationReportAssembler, /summary\.latestFailureReason\(\),/);
+  assert.doesNotMatch(operatorPushNotificationReportAssembler, /" \+ summary\.latestFailureReason\(\)/);
   assert.match(operatorPushNotificationReportView, /record OperatorPushNotificationReportView/);
   assert.match(operatorPushNotificationReportView, /long totalCount/);
   assert.match(operatorPushNotificationReportView, /long pendingCount/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1353,6 +1353,15 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   const dashboardController = read(
     "backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java",
   );
+  const operatorPushNotificationReportController = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportController.java",
+  );
+  const operatorPushNotificationReportAssembler = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportAssembler.java",
+  );
+  const operatorPushNotificationReportView = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportView.java",
+  );
   const dashboardTemplate = read("backend/src/main/resources/templates/admin/notifications/push.html");
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
 
@@ -1405,6 +1414,19 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   assert.doesNotMatch(controller, /deviceToken/);
   assert.match(dashboardController, /@GetMapping\("\/admin\/notifications\/push\/page"\)/);
   assert.match(dashboardController, /PushNotificationDashboardUseCase/);
+  assert.match(operatorPushNotificationReportController, /@GetMapping\("\/operator\/api\/push-notification-report"\)/);
+  assert.match(operatorPushNotificationReportController, /ApiResponse<OperatorPushNotificationReportView>/);
+  assert.match(operatorPushNotificationReportController, /pushNotificationReportAssembler\.assemble\(\)/);
+  assert.match(operatorPushNotificationReportAssembler, /PushNotificationDashboardUseCase/);
+  assert.match(operatorPushNotificationReportAssembler, /summarizePushNotifications/);
+  assert.match(operatorPushNotificationReportView, /record OperatorPushNotificationReportView/);
+  assert.match(operatorPushNotificationReportView, /long totalCount/);
+  assert.match(operatorPushNotificationReportView, /long pendingCount/);
+  assert.match(operatorPushNotificationReportView, /long sentCount/);
+  assert.match(operatorPushNotificationReportView, /long failedCount/);
+  assert.match(operatorPushNotificationReportView, /String latestFailureReason/);
+  assert.match(operatorPushNotificationReportView, /record StatusCountRow/);
+  assert.doesNotMatch(operatorPushNotificationReportView, /notificationId|userId|deviceToken/);
   assert.match(dashboardTemplate, /푸시 알림 현황/);
   assert.match(dashboardTemplate, /전체 알림/);
   assert.match(dashboardTemplate, /상태별 알림/);


### PR DESCRIPTION
## 관련 이슈

close #355

## 작업 배경

- 운영기관 담당자는 시설 상태 변경과 신고 처리 결과 같은 알림이 발송 대기 중인지, 실패했는지 확인해야 한다.
- 기존 푸시 알림 outbox 현황은 관리자 화면 중심이라 운영기관 계정에는 실행 권한 없이 읽기 전용 JSON API가 필요하다.

## 작업 내용

- `/operator/api/push-notification-report` 운영기관 전용 읽기 API를 추가한다.
- 전체 알림 수, 대기 수, 발송 완료 수, 발송 실패 수, 운영기관용 안전 실패 안내와 상태별 행을 view model로 조립한다.
- 응답에 알림 ID, 사용자 ID, 기기 토큰, 원시 푸시 실패 메시지가 노출되지 않도록 controller 테스트와 repository contract를 추가한다.
- 기존 관리자 푸시 알림 발송/전송 API와 관리자 화면 동작은 변경하지 않는다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.operator.adapter.in.web.OperatorPushNotificationReportControllerTest` (backend): RED 확인 후 구현 완료, 최종 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과, 43개 테스트
  - `./gradlew test` (backend): 통과
  - GitHub Actions PR CI: Android CI, Backend CI, Changes, Mobile App CI, Repository CI, iOS CI 모두 통과
  - GitHub Actions main CI/CD: merge commit `a0f1ca3` 기준 CI와 CD 모두 통과
  - CodeRabbit: rate limit으로 리뷰 시작 불가, Codex CLI fallback review 실행 및 지적 1건 수정 완료
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 출력
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/operator-push-notification-report-api.md .codex/issue-operator-push-notification-report-api.local.md swieun-jihacheol-project-plan.md`: 모두 ignore 규칙 확인

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 운영기관 응답에서 알림 ID, 사용자 ID, 기기 토큰이 빠져 있는지
  - 관리자 발송/전송 API와 달리 운영기관 endpoint가 읽기 전용 조회만 제공하는지
  - 상태별 행이 원시 provider/예외 메시지 대신 운영기관용 안전 문구만 반환하는지

## 리스크

- 이번 범위는 전체 outbox 요약 조회만 제공하며, 운영기관별 알림 범위 제한이나 발송 실행 권한은 포함하지 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
