### PR TITLE
[Feat] 플랫폼 접근성 설정 반영

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -477,7 +478,10 @@ class _OnboardingPreferenceScope extends StatelessWidget {
         textScaler: textScaler,
       ),
       child: Theme(
-        data: _themeForPreferences(Theme.of(context), preferences),
+        data: _themeForPlatformAccessibility(
+          _themeForPreferences(Theme.of(context), preferences),
+          mediaQuery,
+        ),
         child: child,
       ),
     );
@@ -513,6 +517,74 @@ ThemeData _themeForPreferences(
         color: textColor,
       ),
     ),
+  );
+}
+
+ThemeData _themeForPlatformAccessibility(
+  ThemeData baseTheme,
+  MediaQueryData mediaQuery,
+) {
+  if (!mediaQuery.boldText) {
+    return baseTheme;
+  }
+
+  return baseTheme.copyWith(
+    textTheme: _boldTextTheme(baseTheme.textTheme),
+    primaryTextTheme: _boldTextTheme(baseTheme.primaryTextTheme),
+    appBarTheme: baseTheme.appBarTheme.copyWith(
+      titleTextStyle: _boldTextStyle(baseTheme.appBarTheme.titleTextStyle),
+      toolbarTextStyle: _boldTextStyle(baseTheme.appBarTheme.toolbarTextStyle),
+    ),
+    filledButtonTheme: FilledButtonThemeData(
+      style: _boldButtonTextStyle(baseTheme.filledButtonTheme.style),
+    ),
+    outlinedButtonTheme: OutlinedButtonThemeData(
+      style: _boldButtonTextStyle(baseTheme.outlinedButtonTheme.style),
+    ),
+    textButtonTheme: TextButtonThemeData(
+      style: _boldButtonTextStyle(baseTheme.textButtonTheme.style),
+    ),
+  );
+}
+
+TextTheme _boldTextTheme(TextTheme textTheme) {
+  return textTheme.copyWith(
+    displayLarge: _boldTextStyle(textTheme.displayLarge),
+    displayMedium: _boldTextStyle(textTheme.displayMedium),
+    displaySmall: _boldTextStyle(textTheme.displaySmall),
+    headlineLarge: _boldTextStyle(textTheme.headlineLarge),
+    headlineMedium: _boldTextStyle(textTheme.headlineMedium),
+    headlineSmall: _boldTextStyle(textTheme.headlineSmall),
+    titleLarge: _boldTextStyle(textTheme.titleLarge),
+    titleMedium: _boldTextStyle(textTheme.titleMedium),
+    titleSmall: _boldTextStyle(textTheme.titleSmall),
+    bodyLarge: _boldTextStyle(textTheme.bodyLarge),
+    bodyMedium: _boldTextStyle(textTheme.bodyMedium),
+    bodySmall: _boldTextStyle(textTheme.bodySmall),
+    labelLarge: _boldTextStyle(textTheme.labelLarge),
+    labelMedium: _boldTextStyle(textTheme.labelMedium),
+    labelSmall: _boldTextStyle(textTheme.labelSmall),
+  );
+}
+
+ButtonStyle _boldButtonTextStyle(ButtonStyle? baseStyle) {
+  return (baseStyle ?? const ButtonStyle()).copyWith(
+    textStyle: WidgetStateProperty.resolveWith((states) {
+      return _boldTextStyle(baseStyle?.textStyle?.resolve(states));
+    }),
+  );
+}
+
+TextStyle _boldTextStyle(TextStyle? style) {
+  final currentWeight = style?.fontWeight ?? FontWeight.w400;
+  final currentIndex = FontWeight.values.indexOf(currentWeight);
+  final minimumBoldIndex = FontWeight.values.indexOf(FontWeight.w700);
+  final nextIndex = math.min(
+    FontWeight.values.length - 1,
+    math.max(currentIndex + 2, minimumBoldIndex),
+  );
+  return (style ?? const TextStyle()).copyWith(
+    fontWeight: FontWeight.values[nextIndex],
   );
 }
 

--- a/apps/mobile/test/accessibility_baseline_test.dart
+++ b/apps/mobile/test/accessibility_baseline_test.dart
@@ -12,6 +12,12 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('모바일 접근성 QA 기준선은 큰 글씨와 고대비 홈 화면을 검증한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
+    tester.platformDispatcher.accessibilityFeaturesTestValue =
+        const FakeAccessibilityFeatures(
+          boldText: true,
+          disableAnimations: true,
+          reduceMotion: true,
+        );
 
     try {
       await tester.pumpWidget(
@@ -34,6 +40,8 @@ void main() {
 
       final homeContext = tester.element(find.byType(HomeScreen));
       expect(MediaQuery.of(homeContext).highContrast, isTrue);
+      expect(MediaQuery.boldTextOf(homeContext), isTrue);
+      expect(MediaQuery.disableAnimationsOf(homeContext), isTrue);
       expect(
         MediaQuery.textScalerOf(homeContext).scale(20),
         closeTo(23.6, 0.01),
@@ -41,6 +49,20 @@ void main() {
       expect(
         Theme.of(homeContext).colorScheme.primary,
         const Color(0xFF003D40),
+      );
+      expect(
+        Theme.of(homeContext).textTheme.bodyLarge?.fontWeight,
+        FontWeight.w700,
+      );
+      expect(
+        Theme.of(homeContext).appBarTheme.titleTextStyle?.fontWeight,
+        FontWeight.w900,
+      );
+      expect(
+        Theme.of(homeContext).filledButtonTheme.style?.textStyle
+            ?.resolve(<WidgetState>{})
+            ?.fontWeight,
+        FontWeight.w900,
       );
       expect(find.bySemanticsLabel('역 검색'), findsOneWidget);
       expect(find.bySemanticsLabel('길찾기'), findsOneWidget);
@@ -62,6 +84,7 @@ void main() {
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
       await expectLater(tester, meetsGuideline(textContrastGuideline));
     } finally {
+      tester.platformDispatcher.clearAccessibilityFeaturesTestValue();
       semanticsHandle.dispose();
     }
   });

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1987,6 +1987,9 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(main, /_OnboardingPreferenceScope/);
   assert.match(main, /mediaQuery\.textScaler\.clamp\(minScaleFactor: 1\.18\)/);
   assert.match(main, /highContrast:[\s\S]*preferences\.highContrastEnabled \|\| mediaQuery\.highContrast/);
+  assert.match(main, /mediaQuery\.boldText/);
+  assert.match(main, /_themeForPlatformAccessibility/);
+  assert.match(main, /WidgetStateProperty\.resolveWith/);
   assert.match(main, /_themeForPreferences/);
   assert.match(main, /simpleViewEnabled: preferences\.simpleViewEnabled/);
   assert.match(main, /RouteSearchScreen\([\s\S]*simpleViewEnabled: simpleViewEnabled/);
@@ -2019,6 +2022,9 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(widgetTest, /MediaQuery\.textScalerOf/);
   assert.match(accessibilityBaselineTest, /모바일 접근성 QA 기준선은 큰 글씨와 고대비 홈 화면을 검증한다/);
   assert.match(accessibilityBaselineTest, /tester\.ensureSemantics\(\)/);
+  assert.match(accessibilityBaselineTest, /FakeAccessibilityFeatures\([\s\S]*boldText: true[\s\S]*disableAnimations: true[\s\S]*reduceMotion: true/);
+  assert.match(accessibilityBaselineTest, /MediaQuery\.boldTextOf/);
+  assert.match(accessibilityBaselineTest, /MediaQuery\.disableAnimationsOf/);
   assert.match(accessibilityBaselineTest, /androidTapTargetGuideline/);
   assert.match(accessibilityBaselineTest, /iOSTapTargetGuideline/);
   assert.match(accessibilityBaselineTest, /labeledTapTargetGuideline/);


### PR DESCRIPTION
## 관련 이슈

close #359

## 작업 배경

- 모바일 앱의 접근성 품질 기준에서 Android/iOS 플랫폼 접근성 설정을 홈 UI에 더 명확히 반영해야 합니다.
- 기존 큰 글씨와 고대비 설정에 더해 Bold Text와 Reduce Motion 신호를 자동화 테스트로 고정합니다.

## 작업 내용

- 홈 화면 온보딩 선호 적용 범위에서 플랫폼 Bold Text가 켜진 경우 앱 텍스트 테마와 주요 버튼/앱바 텍스트 가중치를 더 굵게 적용했습니다.
- 플랫폼 Reduce Motion 계열 신호가 Flutter MediaQuery의 animation 비활성화 값으로 유지되는지 접근성 기준선 테스트에 추가했습니다.
- 저장소 계약 테스트에 Bold Text/Reduce Motion 접근성 기준선 검증 규칙을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/main.dart apps/mobile/test/accessibility_baseline_test.dart`: 성공
  - `flutter test test/accessibility_baseline_test.dart test/widget_test.dart`: 성공
  - `flutter test`: 성공
  - `flutter analyze`: 성공, No issues found
  - `node --test tools/ci/repository-contract.test.mjs`: 성공, 43개 테스트 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 모두 ignore 규칙 적용 확인

## 리뷰어 메모

- `_OnboardingPreferenceScope`에서 기존 큰 글씨/고대비 적용 후 플랫폼 Bold Text 테마를 덧입히는 순서를 먼저 확인해 주세요.
- 접근성 기준선 테스트는 `FakeAccessibilityFeatures`로 Bold Text, disableAnimations, reduceMotion을 함께 주입합니다.

## 리스크

- Bold Text 사용자의 버튼/제목 가중치가 더 굵어지면서 좁은 화면에서 일부 문구가 더 넓게 보일 수 있습니다. 기존 전체 위젯 테스트와 접근성 tap target/contrast guideline으로 주요 홈·검색·신고 흐름을 확인했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.