### PR TITLE
[Feat] 역 상세 지도 대체 목록 추가

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 
 import 'auth_headers.dart';
 import 'facility_report.dart';
+import 'map_adapter.dart';
 import 'mobile_error_reporter.dart';
 
 const _stationSearchTimeout = Duration(seconds: 8);
@@ -2947,6 +2948,12 @@ class _StationDetailContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final mapMarkers = const EasySubwayMapAdapter().markersForStationDetail(
+      station: detail,
+      exits: exits,
+      facilities: facilities,
+    );
+
     return ListView(
       padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
       children: [
@@ -2968,6 +2975,12 @@ class _StationDetailContent extends StatelessWidget {
             items: layoutSummaryItems,
             semanticLabel: layoutSummarySemanticLabel,
           ),
+          const SizedBox(height: 24),
+        ],
+        if (mapMarkers.isNotEmpty) ...[
+          const _StationDetailSectionTitle(title: '지도 위치 목록'),
+          const SizedBox(height: 12),
+          _StationMapTextFallback(markers: mapMarkers),
           const SizedBox(height: 24),
         ],
         const _StationDetailSectionTitle(title: '출구'),
@@ -3054,6 +3067,80 @@ class _StationDetailContent extends StatelessWidget {
     }
     return provider.openLocationSettings;
   }
+}
+
+class _StationMapTextFallback extends StatelessWidget {
+  const _StationMapTextFallback({required this.markers});
+
+  final List<MapMarker> markers;
+
+  @override
+  Widget build(BuildContext context) {
+    final semanticLabel =
+        '지도 대체 위치 목록, ${markers.map((marker) => marker.title).join(', ')}';
+
+    return Semantics(
+      container: true,
+      label: semanticLabel,
+      child: ExcludeSemantics(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const _StationDetailInfoRow(
+              icon: Icons.map_outlined,
+              text: '지도를 열 수 없어도 아래 위치 목록으로 확인할 수 있습니다.',
+            ),
+            const SizedBox(height: 12),
+            for (final marker in markers)
+              _StationMapTextFallbackItem(marker: marker),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StationMapTextFallbackItem extends StatelessWidget {
+  const _StationMapTextFallbackItem({required this.marker});
+
+  final MapMarker marker;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            _mapMarkerIcon(marker.type),
+            size: 22,
+            color: const Color(0xFF006D77),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              marker.title,
+              key: Key('stationMapTextFallbackItem-${marker.id}'),
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: const Color(0xFF102A2C),
+                fontWeight: FontWeight.w800,
+                height: 1.3,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+IconData _mapMarkerIcon(MapMarkerType type) {
+  return switch (type) {
+    MapMarkerType.station => Icons.train_outlined,
+    MapMarkerType.exit => Icons.exit_to_app,
+    MapMarkerType.facility => Icons.accessible_forward,
+  };
 }
 
 class _StationLayoutSummary extends StatelessWidget {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -3076,26 +3076,28 @@ class _StationMapTextFallback extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final semanticLabel =
-        '지도 대체 위치 목록, ${markers.map((marker) => marker.title).join(', ')}';
-
-    return Semantics(
-      container: true,
-      label: semanticLabel,
-      child: ExcludeSemantics(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const _StationDetailInfoRow(
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Semantics(
+          container: true,
+          label: '지도 대체 위치 목록',
+          child: const SizedBox.shrink(),
+        ),
+        Semantics(
+          container: true,
+          label: '지도를 열 수 없어도 아래 위치 목록으로 확인할 수 있습니다.',
+          child: const ExcludeSemantics(
+            child: _StationDetailInfoRow(
               icon: Icons.map_outlined,
               text: '지도를 열 수 없어도 아래 위치 목록으로 확인할 수 있습니다.',
             ),
-            const SizedBox(height: 12),
-            for (final marker in markers)
-              _StationMapTextFallbackItem(marker: marker),
-          ],
+          ),
         ),
-      ),
+        const SizedBox(height: 12),
+        for (final marker in markers)
+          _StationMapTextFallbackItem(marker: marker),
+      ],
     );
   }
 }
@@ -3107,29 +3109,35 @@ class _StationMapTextFallbackItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Icon(
-            _mapMarkerIcon(marker.type),
-            size: 22,
-            color: const Color(0xFF006D77),
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              marker.title,
-              key: Key('stationMapTextFallbackItem-${marker.id}'),
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: const Color(0xFF102A2C),
-                fontWeight: FontWeight.w800,
-                height: 1.3,
+    return Semantics(
+      container: true,
+      label: marker.semanticLabel,
+      child: ExcludeSemantics(
+        child: Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                _mapMarkerIcon(marker.type),
+                size: 22,
+                color: const Color(0xFF006D77),
               ),
-            ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  marker.title,
+                  key: Key('stationMapTextFallbackItem-${marker.id}'),
+                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: const Color(0xFF102A2C),
+                    fontWeight: FontWeight.w800,
+                    height: 1.3,
+                  ),
+                ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2345,8 +2345,43 @@ void main() {
       expect(find.text('1번 출구'), findsWidgets);
       expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
       expect(find.text('2번 출구'), findsNothing);
+      expect(find.bySemanticsLabel('지도 대체 위치 목록'), findsOneWidget);
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('stationMapTextFallbackItem-station-sangnoksu')),
+        120,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.pumpAndSettle();
       expect(
-        find.bySemanticsLabel('지도 대체 위치 목록, 상록수역, 1번 출구, 1번 출구 엘리베이터'),
+        find.bySemanticsLabel(
+          '상록수역 상세 정보, 수도권 2호선, 기본 정보만 있음, 출처 공식 파일, 마지막 확인 2026-06-13, 지도 위치',
+        ),
+        findsOneWidget,
+      );
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('stationMapTextFallbackItem-exit-sangnoksu-1')),
+        120,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.pumpAndSettle();
+      expect(
+        find.bySemanticsLabel(
+          '1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 정보 신뢰도 높음, 출처 공식 파일, 지도 위치',
+        ),
+        findsOneWidget,
+      );
+      await tester.scrollUntilVisible(
+        find.byKey(
+          const Key('stationMapTextFallbackItem-facility-sangnoksu-elevator-1'),
+        ),
+        120,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.pumpAndSettle();
+      expect(
+        find.bySemanticsLabel(
+          '1번 출구 엘리베이터, 엘리베이터, 정상, 1번 출구 앞, 최근 확인 2026-06-12, 정보 신뢰도 높음, 출처 공식 파일, 지도 위치',
+        ),
         findsOneWidget,
       );
       await tester.scrollUntilVisible(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2227,13 +2227,20 @@ void main() {
     final semanticsHandle = tester.ensureSemantics();
     final repository = FakeStationSearchRepository(
       nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
-      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      stationDetail: _stationDetail(
+        id: 'station-sangnoksu',
+        name: '상록수',
+        latitude: 37.302795,
+        longitude: 126.866489,
+      ),
       stationExits: const [
         StationExitInfo(
           id: 'exit-sangnoksu-1',
           stationId: 'station-sangnoksu',
           exitNumber: '1',
           name: '1번 출구',
+          latitude: 37.3021,
+          longitude: 126.8661,
           hasElevatorConnection: true,
           hasStairOnlyPath: false,
           dataConfidence: 'HIGH',
@@ -2249,6 +2256,8 @@ void main() {
           name: '1번 출구 엘리베이터',
           floorFrom: 'B1',
           floorTo: '1F',
+          latitude: 37.3022,
+          longitude: 126.8662,
           description: '1번 출구 앞',
           status: 'NORMAL',
           dataConfidence: 'HIGH',
@@ -2324,7 +2333,27 @@ void main() {
       expect(find.text('이동 구조'), findsOneWidget);
       expect(find.text('승강장'), findsOneWidget);
       expect(find.bySemanticsLabel('이동 구조, 1번 출구, 엘리베이터, 승강장'), findsOneWidget);
-      await tester.drag(find.byType(ListView), const Offset(0, -260));
+      await tester.scrollUntilVisible(
+        find.text('지도 위치 목록'),
+        120,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('지도 위치 목록'), findsOneWidget);
+      expect(find.text('지도를 열 수 없어도 아래 위치 목록으로 확인할 수 있습니다.'), findsOneWidget);
+      expect(find.text('상록수역'), findsWidgets);
+      expect(find.text('1번 출구'), findsWidgets);
+      expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
+      expect(find.text('2번 출구'), findsNothing);
+      expect(
+        find.bySemanticsLabel('지도 대체 위치 목록, 상록수역, 1번 출구, 1번 출구 엘리베이터'),
+        findsOneWidget,
+      );
+      await tester.scrollUntilVisible(
+        find.text('출구'),
+        120,
+        scrollable: find.byType(Scrollable).last,
+      );
       await tester.pumpAndSettle();
       expect(find.text('출구'), findsOneWidget);
       expect(find.text('1번 출구'), findsWidgets);
@@ -2336,7 +2365,11 @@ void main() {
         ),
         findsOneWidget,
       );
-      await tester.drag(find.byType(ListView), const Offset(0, -520));
+      await tester.scrollUntilVisible(
+        find.text('시설'),
+        120,
+        scrollable: find.byType(Scrollable).last,
+      );
       await tester.pumpAndSettle();
       expect(find.text('시설'), findsOneWidget);
       expect(find.text('확인 필요 1개'), findsOneWidget);
@@ -5859,12 +5892,19 @@ class FakeCurrentLocationProvider implements CurrentLocationProvider {
   }
 }
 
-StationDetail _stationDetail({required String id, required String name}) {
+StationDetail _stationDetail({
+  required String id,
+  required String name,
+  double? latitude,
+  double? longitude,
+}) {
   return StationDetail(
     id: id,
     nameKo: name,
     nameEn: id,
     region: '수도권',
+    latitude: latitude,
+    longitude: longitude,
     dataQualityLevel: 'LEVEL_1',
     dataSourceType: 'OFFICIAL_FILE',
     lastVerifiedAt: '2026-06-13',

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2099,8 +2099,12 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(mapAdapter, /_coordinateFrom\(station\.latitude, station\.longitude\)/);
   assert.match(mapAdapter, /_coordinateFrom\(exit\.latitude, exit\.longitude\)/);
   assert.match(mapAdapter, /_coordinateFrom\(facility\.latitude, facility\.longitude\)/);
+  assert.match(stationSearch, /EasySubwayMapAdapter\(\)\.markersForStationDetail/);
+  assert.match(stationSearch, /지도 위치 목록/);
+  assert.match(stationSearch, /지도를 열 수 없어도 아래 위치 목록으로 확인할 수 있습니다\./);
   assert.match(mapAdapterTest, /지도 제공자는 네이버를 기본값으로 두고 카카오를 대체 후보로 둔다/);
   assert.match(mapAdapterTest, /지도 어댑터는 좌표가 있는 역 출구 시설만 쉬운 이름의 마커로 만든다/);
+  assert.match(widgetTest, /지도 대체 위치 목록, 상록수역, 1번 출구, 1번 출구 엘리베이터/);
   assert.match(facilityReport, /Future<FacilityReportResult> getReport\(String reportId\)/);
   assert.match(facilityReport, /\/api\/v1\/reports\/\$\{Uri\.encodeComponent\(trimmedReportId\)\}/);
   assert.match(facilityReport, /refreshCurrentReport/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2104,7 +2104,9 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(stationSearch, /지도를 열 수 없어도 아래 위치 목록으로 확인할 수 있습니다\./);
   assert.match(mapAdapterTest, /지도 제공자는 네이버를 기본값으로 두고 카카오를 대체 후보로 둔다/);
   assert.match(mapAdapterTest, /지도 어댑터는 좌표가 있는 역 출구 시설만 쉬운 이름의 마커로 만든다/);
-  assert.match(widgetTest, /지도 대체 위치 목록, 상록수역, 1번 출구, 1번 출구 엘리베이터/);
+  assert.match(widgetTest, /지도 대체 위치 목록/);
+  assert.match(widgetTest, /상록수역 상세 정보[\s\S]*지도 위치/);
+  assert.match(widgetTest, /1번 출구, 엘리베이터 연결, 계단 없는 이동 가능[\s\S]*지도 위치/);
   assert.match(facilityReport, /Future<FacilityReportResult> getReport\(String reportId\)/);
   assert.match(facilityReport, /\/api\/v1\/reports\/\$\{Uri\.encodeComponent\(trimmedReportId\)\}/);
   assert.match(facilityReport, /refreshCurrentReport/);


### PR DESCRIPTION
## 관련 이슈

close #361

## 작업 배경

- 역 상세 화면의 지도 정보가 지도 SDK나 지도 렌더링 상태에만 의존하면 좌표가 있는 출구와 시설 위치를 텍스트로 확인하기 어렵다.
- 고령자, 임산부, 장애인 사용자가 지도를 보지 못하는 상황에서도 주요 위치를 스크린리더와 큰 목록으로 확인할 수 있어야 한다.

## 작업 내용

- 역 상세 화면에서 역, 출구, 시설 좌표를 지도 마커 어댑터로 변환해 `지도 위치 목록` 섹션을 노출한다.
- 좌표가 있는 항목만 텍스트 대체 목록에 포함하고, 스크린리더가 전체 위치 목록과 각 위치의 상세 이동 정보를 읽을 수 있는 semantics label을 추가했다.
- 위젯 테스트와 저장소 계약 테스트에 지도 대체 목록 노출 기준을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --plain-name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다"`: 통과
  - `flutter test test/map_adapter_test.dart`: 통과
  - `flutter test`: 통과
  - `flutter analyze`: 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과
  - `git ls-files "*.md"`: `.github/pull_request_template.md`, `README.md`만 추적 확인
  - PR CI: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 통과
  - main CI: merge commit `82f669b` 기준 통과
  - CD: merge commit `82f669b` 기준 통과

## 리뷰어 메모

- 역 상세 화면의 텍스트 대체 목록이 `EasySubwayMapAdapter`의 좌표 필터링 결과를 그대로 사용하는지 먼저 확인해 주세요.
- 좌표가 없는 출구는 목록에서 제외되어야 한다.
- CodeRabbit은 rate limit으로 실제 리뷰를 시작하지 못해 Codex CLI 리뷰를 대체 실행했고, 접근성 지적 1건을 수정 커밋으로 반영했다.

## 리스크

- 역 상세 화면에 섹션이 추가되어 기존 출구/시설 영역의 스크롤 위치가 아래로 이동한다.
- 지도 SDK 직접 연동이 아니라 텍스트 대체 목록 추가이므로 외부 지도 앱 동작에는 영향이 없다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.