### PR TITLE
[Feat] 경로 안내 불가 다음 행동 추가

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -683,6 +683,9 @@ class RouteSearchResult {
     if (blockedReasons.isNotEmpty) {
       parts.add('안내 불가 이유 ${blockedReasons.join(', ')}');
     }
+    if (isBlocked) {
+      parts.add('다음 행동 $_routeSearchFailureNextAction');
+    }
     if (warnings.isNotEmpty) {
       parts.add('주의 ${warnings.map((warning) => warning.message).join(', ')}');
     }
@@ -1754,103 +1757,119 @@ class _RouteSearchResultSummaryCard extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
     final arrivalStep = result.arrivalGuidanceStep;
 
-    return MergeSemantics(
-      child: Semantics(
-        label: result.semanticLabel,
-        liveRegion: true,
-        child: ExcludeSemantics(
-          child: Card(
-            color: Colors.white,
-            elevation: 0,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-              side: const BorderSide(color: Color(0xFFD5E2E4)),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _RouteResultStatusHeader(result: result),
-                  const SizedBox(height: 14),
-                  Text(
-                    result.statusLabel,
-                    style: textTheme.titleMedium?.copyWith(
-                      color: const Color(0xFF102A2C),
-                      fontWeight: FontWeight.w900,
-                      height: 1.25,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    result.summaryTitle,
-                    style: textTheme.titleLarge?.copyWith(
-                      color: const Color(0xFF102A2C),
-                      fontWeight: FontWeight.w900,
-                      height: 1.25,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    result.lineLabel,
-                    style: textTheme.bodyLarge?.copyWith(
-                      color: const Color(0xFF29484B),
-                      fontWeight: FontWeight.w800,
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    result.scoreLabel,
-                    style: textTheme.bodyLarge?.copyWith(
-                      color: const Color(0xFF29484B),
-                      fontWeight: FontWeight.w800,
-                      height: 1.3,
-                    ),
-                  ),
-                  if (!result.isBlocked &&
-                      result.recommendationReasons.isNotEmpty) ...[
-                    const SizedBox(height: 16),
-                    _RouteRecommendationReasons(
-                      reasons: result.recommendationReasons,
-                    ),
-                  ],
-                  if (arrivalStep != null) ...[
-                    const SizedBox(height: 16),
-                    _RouteArrivalGuidance(step: arrivalStep),
-                  ],
-                  const SizedBox(height: 16),
-                  const _RouteNotice(
-                    title: '안전 안내',
-                    text: _routeSafetyGuidanceNotice,
-                    icon: Icons.info_outline,
-                  ),
-                  if (result.blockedReasons.isNotEmpty) ...[
-                    for (final reason in result.blockedReasons)
-                      _RouteNotice(
-                        title: '안내 불가 이유',
-                        text: reason,
-                        icon: Icons.block,
+    return Semantics(
+      label: result.semanticLabel,
+      liveRegion: true,
+      explicitChildNodes: result.isBlocked,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          ExcludeSemantics(
+            child: Card(
+              color: Colors.white,
+              elevation: 0,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+                side: const BorderSide(color: Color(0xFFD5E2E4)),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _RouteResultStatusHeader(result: result),
+                    const SizedBox(height: 14),
+                    Text(
+                      result.statusLabel,
+                      style: textTheme.titleMedium?.copyWith(
+                        color: const Color(0xFF102A2C),
+                        fontWeight: FontWeight.w900,
+                        height: 1.25,
                       ),
-                  ],
-                  if (result.warnings.isNotEmpty) ...[
-                    const SizedBox(height: 16),
-                    for (final warning in result.warnings)
-                      _RouteNotice(
-                        title: '주의 확인',
-                        text: warning.message,
-                        icon: Icons.warning_amber,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      result.summaryTitle,
+                      style: textTheme.titleLarge?.copyWith(
+                        color: const Color(0xFF102A2C),
+                        fontWeight: FontWeight.w900,
+                        height: 1.25,
                       ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      result.lineLabel,
+                      style: textTheme.bodyLarge?.copyWith(
+                        color: const Color(0xFF29484B),
+                        fontWeight: FontWeight.w800,
+                        height: 1.3,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      result.scoreLabel,
+                      style: textTheme.bodyLarge?.copyWith(
+                        color: const Color(0xFF29484B),
+                        fontWeight: FontWeight.w800,
+                        height: 1.3,
+                      ),
+                    ),
+                    if (!result.isBlocked &&
+                        result.recommendationReasons.isNotEmpty) ...[
+                      const SizedBox(height: 16),
+                      _RouteRecommendationReasons(
+                        reasons: result.recommendationReasons,
+                      ),
+                    ],
+                    if (arrivalStep != null) ...[
+                      const SizedBox(height: 16),
+                      _RouteArrivalGuidance(step: arrivalStep),
+                    ],
+                    const SizedBox(height: 16),
+                    const _RouteNotice(
+                      title: '안전 안내',
+                      text: _routeSafetyGuidanceNotice,
+                      icon: Icons.info_outline,
+                    ),
+                    if (result.blockedReasons.isNotEmpty) ...[
+                      for (final reason in result.blockedReasons)
+                        _RouteNotice(
+                          title: '안내 불가 이유',
+                          text: reason,
+                          icon: Icons.block,
+                        ),
+                    ],
+                    if (result.isBlocked)
+                      const _RouteNotice(
+                        title: '다음 행동',
+                        text: _routeSearchFailureNextAction,
+                        icon: Icons.refresh,
+                      ),
+                    if (result.warnings.isNotEmpty) ...[
+                      const SizedBox(height: 16),
+                      for (final warning in result.warnings)
+                        _RouteNotice(
+                          title: '주의 확인',
+                          text: warning.message,
+                          icon: Icons.warning_amber,
+                        ),
+                    ],
+                    if (result.movementSteps.isNotEmpty) ...[
+                      const SizedBox(height: 18),
+                      _RouteStepSection(steps: result.movementSteps),
+                    ],
                   ],
-                  if (result.movementSteps.isNotEmpty) ...[
-                    const SizedBox(height: 18),
-                    _RouteStepSection(steps: result.movementSteps),
-                  ],
-                ],
+                ),
               ),
             ),
           ),
-        ),
+          if (result.isBlocked)
+            Semantics(
+              container: true,
+              label: '다음 행동, $_routeSearchFailureNextAction',
+              child: const SizedBox.shrink(),
+            ),
+        ],
       ),
     );
   }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3804,11 +3804,19 @@ void main() {
       expect(find.text('엘리베이터 동선을 우선했어요'), findsNothing);
       expect(find.text('휠체어로 이동 가능한 엘리베이터가 없습니다.'), findsOneWidget);
       expect(find.text('이동 전 현장 안내와 역무원 안내를 확인해 주세요.'), findsOneWidget);
-      expect(find.text('역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'), findsNothing);
+      expect(
+        find.text('역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel('다음 행동, 역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'),
+        findsOneWidget,
+      );
       expect(
         find.bySemanticsLabel(
           '경로 검색 결과, 다른 경로가 필요합니다, 휠체어, 상록수에서 없는역까지, 노선 확인 필요, 이동 점수 0점, '
           '안내 불가 이유 휠체어로 이동 가능한 엘리베이터가 없습니다., '
+          '다음 행동 역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요., '
           '안전 안내 이동 전 현장 안내와 역무원 안내를 확인해 주세요.',
         ),
         findsOneWidget,

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2156,7 +2156,9 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(widgetTest, /도움말은 안전 고지와 데이터 한계를 쉬운 문구로 안내한다/);
   assert.match(routeSearch, /routeSearchFailureNextAction/);
   assert.match(routeSearch, /역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요\./);
+  assert.match(routeSearch, /다음 행동 \$_routeSearchFailureNextAction/);
   assert.match(widgetTest, /경로 검색 실패는 다음 행동을 쉬운 문구로 안내한다/);
+  assert.match(widgetTest, /안내 불가 이유[\s\S]*다음 행동/);
   assert.match(routeSearch, /routeFeedbackFailureNextAction/);
   assert.match(routeSearch, /잠시 후 다시 보내거나 경로 조건을 바꿔 다시 찾아보세요\./);
   assert.match(widgetTest, /경로 피드백 실패는 다음 행동을 쉬운 문구로 안내한다/);


### PR DESCRIPTION
## 관련 이슈

close #363

## 작업 배경

- 경로 안내가 불가능한 결과는 이유를 보여 주지만 사용자가 다음에 무엇을 해야 하는지 바로 확인하기 어렵다.
- 휠체어 등 이동 조건에서 안내 불가 상태가 나오면 역 선택이나 이동 조건을 바꿔 다시 시도할 수 있는 쉬운 안내가 필요하다.

## 작업 내용

- 안내 불가 경로 결과 카드에 `다음 행동` 안내를 추가했다.
- 스크린리더가 전체 경로 결과와 별도 다음 행동 문구를 모두 읽을 수 있게 semantics label을 보강했다.
- 안내 가능한 경로에는 기존처럼 다음 행동 안내가 노출되지 않도록 유지했다.
- 위젯 테스트와 저장소 계약 테스트에 안내 불가 다음 행동 계약을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --plain-name "경로 검색 중에는 버튼을 비활성화하고 안내 불가 이유를 보여준다"`: 통과
  - `flutter test`: 통과
  - `flutter analyze`: 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과
  - `git ls-files "*.md"`: `.github/pull_request_template.md`, `README.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - PR CI: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 통과
  - Codex CLI code review fallback: actionable 0, nitpick 0
  - main CI: 통과
  - main CD: 통과

## 리뷰어 메모

- `_RouteSearchResultSummaryCard`에서 안내 불가 결과만 별도 다음 행동 semantics node를 갖도록 한 부분을 먼저 확인해 주세요.
- 기존 실패 메시지의 다음 행동 문구를 재사용해 경로 검색 실패와 안내 불가 결과의 대안 안내를 일관되게 맞췄다.

## 리스크

- 안내 불가 결과 카드의 semantics 구조가 변경되어 스크린리더 읽기 순서에 영향이 있다.
- 시각 UI에는 안내 문구가 한 줄 추가되어 작은 화면에서 카드 높이가 늘어난다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
