### PR TITLE
[Refactor] 경로 안내 다음 행동 접근성 구조 정리

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1839,12 +1839,6 @@ class _RouteSearchResultSummaryCard extends StatelessWidget {
                           icon: Icons.block,
                         ),
                     ],
-                    if (result.isBlocked)
-                      const _RouteNotice(
-                        title: '다음 행동',
-                        text: _routeSearchFailureNextAction,
-                        icon: Icons.refresh,
-                      ),
                     if (result.warnings.isNotEmpty) ...[
                       const SizedBox(height: 16),
                       for (final warning in result.warnings)
@@ -1864,10 +1858,12 @@ class _RouteSearchResultSummaryCard extends StatelessWidget {
             ),
           ),
           if (result.isBlocked)
-            Semantics(
-              container: true,
-              label: '다음 행동, $_routeSearchFailureNextAction',
-              child: const SizedBox.shrink(),
+            const _RouteNotice(
+              key: Key('routeBlockedNextActionNotice'),
+              title: '다음 행동',
+              text: _routeSearchFailureNextAction,
+              icon: Icons.refresh,
+              semanticsLabel: '다음 행동, $_routeSearchFailureNextAction',
             ),
         ],
       ),
@@ -2070,18 +2066,21 @@ class _RouteGuidanceChip extends StatelessWidget {
 
 class _RouteNotice extends StatelessWidget {
   const _RouteNotice({
+    super.key,
     required this.title,
     required this.text,
     required this.icon,
+    this.semanticsLabel,
   });
 
   final String title;
   final String text;
   final IconData icon;
+  final String? semanticsLabel;
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
+    final notice = Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: DecoratedBox(
         decoration: BoxDecoration(
@@ -2124,6 +2123,15 @@ class _RouteNotice extends StatelessWidget {
           ),
         ),
       ),
+    );
+    final label = semanticsLabel;
+    if (label == null) {
+      return notice;
+    }
+    return Semantics(
+      container: true,
+      label: label,
+      child: ExcludeSemantics(child: notice),
     );
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3808,6 +3808,15 @@ void main() {
         find.text('역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'),
         findsOneWidget,
       );
+      final nextActionNotice = find.byKey(
+        const Key('routeBlockedNextActionNotice'),
+      );
+      expect(nextActionNotice, findsOneWidget);
+      expect(tester.getSize(nextActionNotice).height, greaterThanOrEqualTo(44));
+      expect(
+        tester.getSemantics(nextActionNotice).label,
+        '다음 행동, 역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.',
+      );
       expect(
         find.bySemanticsLabel('다음 행동, 역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'),
         findsOneWidget,

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2157,6 +2157,11 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(routeSearch, /routeSearchFailureNextAction/);
   assert.match(routeSearch, /역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요\./);
   assert.match(routeSearch, /다음 행동 \$_routeSearchFailureNextAction/);
+  assert.match(routeSearch, /routeBlockedNextActionNotice/);
+  assert.doesNotMatch(
+    routeSearch,
+    /label: '다음 행동, \$_routeSearchFailureNextAction'[\s\S]{0,120}child: const SizedBox\.shrink\(\)/,
+  );
   assert.match(widgetTest, /경로 검색 실패는 다음 행동을 쉬운 문구로 안내한다/);
   assert.match(widgetTest, /안내 불가 이유[\s\S]*다음 행동/);
   assert.match(routeSearch, /routeFeedbackFailureNextAction/);


### PR DESCRIPTION
## 관련 이슈

close #365

## 작업 배경

- 안내 불가 경로 결과는 사용자가 다음 행동을 바로 이해해야 하므로, 보이는 안내와 스크린리더 라벨이 같은 UI 요소에서 관리되는 편이 안전하다.
- 다음 행동 문구를 별도 숨김 semantics node로 제공하면 시각 UI와 접근성 구조가 분리되어 회귀를 놓치기 쉽다.

## 작업 내용

- 안내 불가 경로 결과의 `다음 행동` 안내를 보이는 `_RouteNotice` 요소가 직접 semantics label을 제공하도록 정리했다.
- 숨겨진 zero-size semantics node를 제거했다.
- 안내 불가 다음 행동 요소의 key, 크기, semantics label을 위젯 테스트로 고정했다.
- 저장소 계약 테스트에 숨겨진 zero-size 다음 행동 semantics 회귀 방지를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --plain-name "경로 검색 중에는 버튼을 비활성화하고 안내 불가 이유를 보여준다"`: 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과
  - `flutter analyze`: 통과
  - `flutter test`: 통과
  - `git diff --check`: 통과
  - `git ls-files "*.md"`: `.github/pull_request_template.md`, `README.md`만 추적 확인
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md`: 로컬 전용 문서 ignore 확인
  - GitHub Actions PR CI: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 통과
  - CodeRabbit: 한도 초과 안내 확인
  - Codex CLI fallback review: 지적 0건 확인
  - main CI: merge commit `ccf94fcabe0f6615c840d0494fd8e56c89ff83b9` 기준 통과
  - main CD: merge commit `ccf94fcabe0f6615c840d0494fd8e56c89ff83b9` 기준 통과

## 리뷰어 메모

- `_RouteNotice`의 선택적 `semanticsLabel`이 기존 안내/주의 문구에는 영향을 주지 않고, 안내 불가 다음 행동에만 적용되는지 확인해 주세요.
- 안내 불가 결과의 전체 summary semantics label은 유지하고, 별도 다음 행동 label만 보이는 요소로 옮겼다.

## 리스크

- 안내 불가 결과에서 `다음 행동` 안내가 카드 밖 독립 요소로 배치되어 화면 높이가 약간 달라진다.
- 스크린리더 탐색 시 전체 결과 요약과 다음 행동 요소를 각각 읽을 수 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
