### PR TITLE
[Feat] 역 검색 접근성 정보 우선 정렬

### DIFF
--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -129,6 +129,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 			.filter(station -> station.matches(command.query()))
 			.map(station -> withLines(station, linesById, stationLinesByStationId))
 			.filter(station -> hasLine(station, command.lineId()))
+			.sorted(stationSearchResultComparator())
 			.toList();
 	}
 
@@ -250,6 +251,17 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 			counts.merge(station.dataQualityLevel(), 1L, Long::sum);
 		}
 		return counts;
+	}
+
+	private static Comparator<StationWithLines> stationSearchResultComparator() {
+		return Comparator
+			.comparingInt((StationWithLines station) -> dataQualityPriority(station.station().dataQualityLevel()))
+			.thenComparing(station -> station.station().nameKo())
+			.thenComparing(station -> station.station().id());
+	}
+
+	private static int dataQualityPriority(DataQualityLevel dataQualityLevel) {
+		return -dataQualityLevel.ordinal();
 	}
 
 	private List<TransitOperator> activeOperators() {

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -92,6 +92,38 @@ class TransitMasterServiceTest {
 	}
 
 	@Test
+	@DisplayName("역 검색은 접근성 정보 품질이 높은 역을 먼저 반환한다")
+	void searchStationsPrioritizesHighQualityAccessibilityData() {
+		var qualityService = new TransitMasterService(
+			new QualityPriorityTransitMasterPort(),
+			(facilityId, status, updatedAt) -> {
+			}
+		);
+
+		var stations = qualityService.searchStations(new StationSearchCommand("중앙", null));
+
+		assertThat(stations)
+			.extracting(station -> station.station().id())
+			.containsExactly("station-central-level-4", "station-central-level-3", "station-central-level-2", "station-central-level-1");
+	}
+
+	@Test
+	@DisplayName("노선 필터 역 검색도 접근성 정보 품질이 높은 역을 먼저 반환한다")
+	void searchStationsOnLinePrioritizesHighQualityAccessibilityData() {
+		var qualityService = new TransitMasterService(
+			new QualityPriorityTransitMasterPort(),
+			(facilityId, status, updatedAt) -> {
+			}
+		);
+
+		var stations = qualityService.searchStations(new StationSearchCommand("중앙", "quality-line-a"));
+
+		assertThat(stations)
+			.extracting(station -> station.station().id())
+			.containsExactly("station-central-level-4", "station-central-level-2");
+	}
+
+	@Test
 	@DisplayName("역 검색은 한글 초성만 입력해도 역을 찾는다")
 	void searchStationsMatchesKoreanInitialConsonants() {
 		var stations = service.searchStations(new StationSearchCommand("ㅅㄹㅅ", null));
@@ -452,6 +484,77 @@ class TransitMasterServiceTest {
 		@Override
 		public List<AccessibilityFacility> loadAccessibilityFacilities() {
 			return List.of();
+		}
+	}
+
+	private static class QualityPriorityTransitMasterPort implements LoadTransitMasterPort {
+
+		@Override
+		public List<TransitOperator> loadOperators() {
+			return List.of(
+				new TransitOperator(
+					"quality-operator",
+					"품질 운영기관",
+					"수도권",
+					"https://operator.easysubway.example",
+					"https://operator.easysubway.example/help",
+					DataSourceType.OFFICIAL_FILE,
+					true
+				)
+			);
+		}
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of(
+				new SubwayLine("quality-line-a", "quality-operator", "품질 A선", "#006D77", "수도권", "A", true),
+				new SubwayLine("quality-line-b", "quality-operator", "품질 B선", "#83C5BE", "수도권", "B", true)
+			);
+		}
+
+		@Override
+		public List<Station> loadStations() {
+			return List.of(
+				station("station-central-level-1", "중앙역", DataQualityLevel.LEVEL_1),
+				station("station-central-level-3", "중앙역", DataQualityLevel.LEVEL_3),
+				station("station-central-level-2", "중앙역", DataQualityLevel.LEVEL_2),
+				station("station-central-level-4", "중앙역", DataQualityLevel.LEVEL_4)
+			);
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of(
+				new StationLine("station-central-level-1", "quality-line-b", "101", 101, "상행 / 하행"),
+				new StationLine("station-central-level-2", "quality-line-a", "102", 102, "상행 / 하행"),
+				new StationLine("station-central-level-3", "quality-line-b", "103", 103, "상행 / 하행"),
+				new StationLine("station-central-level-4", "quality-line-a", "104", 104, "상행 / 하행")
+			);
+		}
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of();
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of();
+		}
+
+		private Station station(String id, String nameKo, DataQualityLevel dataQualityLevel) {
+			return new Station(
+				id,
+				nameKo,
+				"Central",
+				"수도권",
+				new BigDecimal("37.300000"),
+				new BigDecimal("126.800000"),
+				dataQualityLevel,
+				DataSourceType.OFFICIAL_FILE,
+				LocalDate.of(2026, 6, 12),
+				true
+			);
 		}
 	}
 


### PR DESCRIPTION
## 관련 이슈

close #369

## 작업 배경

- 같은 검색어로 여러 역이 조회될 때 접근성 정보가 더 충분한 역을 먼저 보여야 교통약자가 확인할 역을 빠르게 고를 수 있다.
- 기존 역 검색은 저장소 응답 순서를 그대로 반환해 데이터 품질 단계가 높은 역이 뒤로 밀릴 수 있었다.

## 작업 내용

- 역명 검색 결과를 `LEVEL_4`, `LEVEL_3`, `LEVEL_2`, `LEVEL_1` 순서로 정렬하도록 했다.
- 같은 데이터 품질에서는 역 이름과 역 식별자로 안정적인 순서를 유지하도록 했다.
- 노선 필터가 적용된 역 검색도 같은 정렬 기준을 사용하도록 했다.
- 가까운 역 검색은 기존 거리순 정렬을 유지했다.
- 서비스 테스트에 전체 검색과 노선 필터 검색의 품질 우선 정렬 케이스를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.transit.application.service.TransitMasterServiceTest`: RED 단계에서 신규 정렬 테스트 2건 실패 확인 후 구현 뒤 통과
  - `./gradlew test --tests com.easysubway.transit.adapter.in.web.TransitMasterControllerTest`: 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과
  - `git diff --check`: 통과
  - `./gradlew test`: 통과
  - GitHub Actions PR CI: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 통과
  - CodeRabbit: 한도 초과 안내 확인
  - Codex CLI fallback review: 지적 0건 확인, PR review `4522156584` 게시
  - GitHub Actions main CI: merge commit `326c9ccd01880107abe31e1c433f0ef92040e2d0` 기준 통과
  - GitHub Actions main CD: merge commit `326c9ccd01880107abe31e1c433f0ef92040e2d0` 기준 통과

## 리뷰어 메모

- 정렬은 일반 역 검색에만 적용했다.
- 가까운 역 검색은 사용자의 현재 위치 기준 의미가 더 크므로 기존 거리순 정렬을 그대로 유지했다.

## 리스크

- 검색 결과 순서가 바뀌므로 동일 검색어에 여러 역이 잡히는 화면에서 기존 응답 순서와 달라질 수 있다.
- 같은 품질 단계에서는 역 이름과 식별자로 고정 정렬해 페이지마다 순서가 흔들리는 리스크를 줄였다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
