### PR TITLE
[Feat] 신고 처리 결과 확인 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
 				"/api/v1/me/reports",
 				"/api/v1/me/favorites/**",
 				"/api/v1/reports",
+				"/api/v1/reports/*/confirm",
 				"/api/v1/devices",
 				"/api/v1/me/notification-settings"
 			)

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
@@ -54,6 +54,16 @@ class FacilityReportController {
 		return ApiResponse.ok(reports);
 	}
 
+	@PostMapping("/api/v1/reports/{reportId}/confirm")
+	ApiResponse<FacilityReportStatusResponse> confirmReportResult(
+		@PathVariable String reportId,
+		Principal principal
+	) {
+		return ApiResponse.ok(FacilityReportStatusResponse.from(
+			facilityReportUseCase.confirmReportResult(reportId, principal.getName())
+		));
+	}
+
 	@GetMapping("/admin/reports")
 	ApiResponse<List<FacilityReportListResponse>> adminReports(@RequestParam(required = false) FacilityReportStatus status) {
 		List<FacilityReportListResponse> reports = facilityReportUseCase.listReports(status)

--- a/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
@@ -23,5 +23,7 @@ public interface FacilityReportUseCase {
 
 	FacilityReport reviewReport(ReviewFacilityReportCommand command);
 
+	FacilityReport confirmReportResult(String reportId, String userId);
+
 	List<FacilityReportReviewAudit> listReviewAudits(String reportId);
 }

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -333,6 +333,34 @@ public class FacilityReportService implements FacilityReportUseCase {
 	}
 
 	@Override
+	public FacilityReport confirmReportResult(String reportId, String userId) {
+		FacilityReport report = getReport(reportId);
+		requireReportOwner(report, userId);
+		requireConfirmableStatus(report);
+		if (report.status() == FacilityReportStatus.RESOLVED) {
+			return report;
+		}
+		return saveFacilityReportPort.saveReport(new FacilityReport(
+			report.id(),
+			report.userId(),
+			report.stationId(),
+			report.facilityId(),
+			report.reportType(),
+			report.description(),
+			report.photoFileName(),
+			report.photoContentType(),
+			report.photoDataBase64(),
+			report.latitude(),
+			report.longitude(),
+			report.duplicateOfReportId(),
+			FacilityReportStatus.RESOLVED,
+			report.createdAt(),
+			report.reviewedAt(),
+			report.reviewedBy()
+		));
+	}
+
+	@Override
 	public List<FacilityReportReviewAudit> listReviewAudits(String reportId) {
 		getReport(reportId);
 		return loadFacilityReportReviewAuditPort.loadAuditsByReportId(reportId)
@@ -436,6 +464,21 @@ public class FacilityReportService implements FacilityReportUseCase {
 		if (command.reviewedBy() == null || command.reviewedBy().isBlank()) {
 			throw new InvalidFacilityReportException("검수자 식별자가 필요합니다.");
 		}
+	}
+
+	private void requireReportOwner(FacilityReport report, String userId) {
+		if (userId == null || userId.isBlank() || !userId.equals(report.userId())) {
+			throw new FacilityReportNotFoundException();
+		}
+	}
+
+	private void requireConfirmableStatus(FacilityReport report) {
+		if (report.status() == FacilityReportStatus.ACCEPTED
+			|| report.status() == FacilityReportStatus.REJECTED
+			|| report.status() == FacilityReportStatus.RESOLVED) {
+			return;
+		}
+		throw new InvalidFacilityReportException("검수 완료된 신고만 확인할 수 있습니다.");
 	}
 
 	private String resolveDuplicateOfReportId(ReviewFacilityReportCommand command, FacilityReport report) {

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -273,6 +273,72 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("신고 작성자는 처리 결과를 확인 완료 상태로 바꿀 수 있다")
+	void reporterConfirmsReviewedReportResult() throws Exception {
+		String reportId = createReport("basic-user", "user-test-password", "spoofed-user", "처리 결과를 확인할 신고");
+
+		mockMvc.perform(post("/admin/reports/{reportId}/review", reportId)
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "decision": "REJECT"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.status").value("REJECTED"));
+
+		mockMvc.perform(post("/api/v1/reports/{reportId}/confirm", reportId)
+				.with(httpBasic("basic-user", "user-test-password"))
+				.with(csrf()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.id").value(reportId))
+			.andExpect(jsonPath("$.data.status").value("RESOLVED"))
+			.andExpect(jsonPath("$.data.reviewedBy").value("admin-test"));
+	}
+
+	@Test
+	@DisplayName("다른 사용자의 신고 처리 결과 확인은 공통 404 응답을 반환한다")
+	void confirmReportResultRequiresOwner() throws Exception {
+		String reportId = createReport("basic-user", "user-test-password", "spoofed-user", "다른 사용자가 확인하면 안 되는 신고");
+
+		mockMvc.perform(post("/admin/reports/{reportId}/review", reportId)
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "decision": "REJECT"
+					}
+					"""))
+			.andExpect(status().isOk());
+
+		mockMvc.perform(post("/api/v1/reports/{reportId}/confirm", reportId)
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf()))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("신고 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("검수 전 신고 처리 결과 확인은 공통 400 응답을 반환한다")
+	void confirmReportResultRequiresReviewedStatus() throws Exception {
+		String reportId = createReport("basic-user", "user-test-password", "spoofed-user", "아직 검수되지 않은 신고");
+
+		mockMvc.perform(post("/api/v1/reports/{reportId}/confirm", reportId)
+				.with(httpBasic("basic-user", "user-test-password"))
+				.with(csrf()))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("검수 완료된 신고만 확인할 수 있습니다."));
+	}
+
+	@Test
 	@DisplayName("신고 검수는 관리자 인증을 요구한다")
 	void reviewReportRequiresAdminAuthentication() throws Exception {
 		mockMvc.perform(post("/admin/reports/report-1/review")

--- a/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
@@ -140,6 +140,35 @@ class JdbcFacilityReportRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("이미 저장된 시설 신고는 처리 결과 확인 완료 상태로 갱신된다")
+	void saveReportUpdatesExistingReportToResolvedStatus() {
+		var submittedReport = submittedReport("report-1", "anonymous-user-1", 9);
+		var confirmedReport = new FacilityReport(
+			"report-1",
+			"anonymous-user-1",
+			"station-sangnoksu",
+			"facility-elevator-1",
+			FacilityReportType.BROKEN,
+			"엘리베이터가 멈춰 있습니다.",
+			"elevator.jpg",
+			"image/jpeg",
+			"aW1hZ2UtYnl0ZXM=",
+			new BigDecimal("37.3123450"),
+			new BigDecimal("126.9876540"),
+			null,
+			FacilityReportStatus.RESOLVED,
+			LocalDateTime.of(2026, 6, 17, 9, 0),
+			LocalDateTime.of(2026, 6, 17, 10, 0),
+			"admin-user"
+		);
+		repository.saveReport(submittedReport);
+
+		repository.saveReport(confirmedReport);
+
+		assertThat(repository.loadReport("report-1")).contains(confirmedReport);
+	}
+
+	@Test
 	@DisplayName("이미 저장된 시설 신고 갱신은 최초 생성 시각을 유지한다")
 	void saveReportKeepsOriginalCreatedAtWhenUpdatingExistingReport() {
 		var originalReport = submittedReport("report-1", "anonymous-user-1", 9);

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -815,6 +815,72 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
+	@DisplayName("신고 작성자는 처리 결과 확인으로 검수 완료 신고를 완료 상태로 바꾼다")
+	void reporterConfirmsReviewedReportResult() {
+		var report = service.createReport(reportCommand(
+			"anonymous-user-confirm",
+			FacilityReportType.INFORMATION_WRONG,
+			"처리 결과를 확인할 신고입니다."
+		));
+		service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT));
+
+		var confirmed = service.confirmReportResult(report.id(), "anonymous-user-confirm");
+
+		assertThat(confirmed.status()).isEqualTo(FacilityReportStatus.RESOLVED);
+		assertThat(confirmed.reviewedAt()).isEqualTo(LocalDateTime.of(2026, 6, 12, 9, 0));
+		assertThat(confirmed.reviewedBy()).isEqualTo("admin-1");
+		assertThat(service.getReport(report.id()).status()).isEqualTo(FacilityReportStatus.RESOLVED);
+	}
+
+	@Test
+	@DisplayName("다른 사용자의 신고 처리 결과는 확인할 수 없다")
+	void confirmReportResultRequiresReportOwner() {
+		var report = service.createReport(reportCommand(
+			"anonymous-user-owner",
+			FacilityReportType.INFORMATION_WRONG,
+			"다른 사용자가 확인하면 안 되는 신고입니다."
+		));
+		service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT));
+
+		assertThatThrownBy(() -> service.confirmReportResult(report.id(), "anonymous-user-other"))
+			.isInstanceOf(FacilityReportNotFoundException.class)
+			.hasMessage("신고 정보를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("검수 완료 전이나 중복 처리된 신고는 처리 결과를 확인할 수 없다")
+	void confirmReportResultRequiresReviewedReport() {
+		var submitted = service.createReport(reportCommand(
+			"anonymous-user-submitted-confirm",
+			FacilityReportType.BROKEN,
+			"아직 검수되지 않은 신고입니다."
+		));
+		var original = service.createReport(reportCommand(
+			"anonymous-user-original-confirm",
+			FacilityReportType.BROKEN,
+			"중복 기준 신고입니다."
+		));
+		var duplicated = service.createReport(reportCommand(
+			"anonymous-user-duplicate-confirm",
+			FacilityReportType.BROKEN,
+			"중복 처리된 신고입니다."
+		));
+		service.reviewReport(new ReviewFacilityReportCommand(
+			duplicated.id(),
+			FacilityReportReviewDecision.MARK_DUPLICATE,
+			"admin-1",
+			original.id()
+		));
+
+		assertThatThrownBy(() -> service.confirmReportResult(submitted.id(), "anonymous-user-submitted-confirm"))
+			.isInstanceOf(InvalidFacilityReportException.class)
+			.hasMessage("검수 완료된 신고만 확인할 수 있습니다.");
+		assertThatThrownBy(() -> service.confirmReportResult(duplicated.id(), "anonymous-user-duplicate-confirm"))
+			.isInstanceOf(InvalidFacilityReportException.class)
+			.hasMessage("검수 완료된 신고만 확인할 수 있습니다.");
+	}
+
+	@Test
 	@DisplayName("중복 처리된 신고는 기준 신고 식별자를 함께 저장한다")
 	void duplicateReportStoresMergedReportId() {
 		var original = service.createReport(reportCommand(

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -885,6 +885,7 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(useCase, /getReport/);
   assert.match(useCase, /listReports/);
   assert.match(useCase, /reviewReport/);
+  assert.match(useCase, /confirmReportResult\(String reportId, String userId\)/);
   assert.match(command, /record CreateFacilityReportCommand/);
   assert.match(reviewCommand, /record ReviewFacilityReportCommand/);
   assert.match(loadPort, /interface LoadFacilityReportPort/);
@@ -903,7 +904,10 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(service, /FacilityReportStatus\.SUBMITTED/);
   assert.match(service, /FacilityReportStatus\.ACCEPTED/);
   assert.match(service, /FacilityReportStatus\.REJECTED/);
+  assert.match(service, /FacilityReportStatus\.RESOLVED/);
   assert.match(service, /FacilityReportStatus\.DUPLICATE/);
+  assert.match(service, /confirmReportResult\(String reportId, String userId\)/);
+  assert.match(service, /requireConfirmableStatus/);
   assert.match(repository, /implements[\s\S]*LoadFacilityReportPort[\s\S]*SaveFacilityReportPort/);
   assert.match(repository, /List<FacilityReport> loadReports\(\)/);
   assert.match(jdbcRepository, /@Profile\("prod"\)/);
@@ -929,6 +933,8 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(transitRepository, /saveFacilityStatus\(String facilityId, AccessibilityFacilityStatus status, LocalDate updatedAt\)/);
   assert.match(controller, /@PostMapping\("\/api\/v1\/reports"\)/);
   assert.match(controller, /@GetMapping\("\/api\/v1\/reports\/\{reportId\}"\)/);
+  assert.match(controller, /@PostMapping\("\/api\/v1\/reports\/\{reportId\}\/confirm"\)/);
+  assert.match(controller, /confirmReportResult\(reportId, principal\.getName\(\)\)/);
   assert.match(controller, /@GetMapping\("\/admin\/reports"\)/);
   assert.match(controller, /@GetMapping\("\/admin\/reports\/\{reportId\}"\)/);
   assert.match(controller, /@RequestParam\(required = false\) FacilityReportStatus status/);
@@ -943,6 +949,7 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(security, /securityMatcher\("\/operator\/\*\*"\)/);
   assert.match(security, /anyRequest\(\)\.hasRole\("OPERATOR_ADMIN"\)/);
   assert.match(security, /@Order\(3\)[\s\S]*?securityMatcher\([\s\S]*?"\/api\/v1\/me"/);
+  assert.match(security, /"\/api\/v1\/reports\/\*\/confirm"/);
   assert.match(security, /@Order\(4\)[\s\S]*?anyRequest\(\)\.permitAll\(\)/);
   assert.match(security, /easysubway\.operator\.username/);
   assert.match(security, /easysubway\.operator\.password/);


### PR DESCRIPTION
## 관련 이슈

close #371

## 작업 배경

- 시설 신고는 접수 후 상태 조회와 관리자 검수까지 가능하지만, 사용자가 처리 결과를 확인했다는 완료 상태를 서버에 남기는 흐름이 없었습니다.
- 검수 결과를 확인 완료로 전환하면 운영자가 미확인 신고와 사용자 확인 완료 신고를 구분할 수 있습니다.

## 작업 내용

- `POST /api/v1/reports/{reportId}/confirm` 사용자 인증 API를 추가했습니다.
- 본인 신고의 `ACCEPTED` 또는 `REJECTED` 상태를 `RESOLVED`로 전환하고, 이미 `RESOLVED`인 신고는 그대로 반환하게 했습니다.
- 다른 사용자의 신고는 404로 처리하고, 검수 전 또는 중복 신고는 공통 400 오류로 응답하게 했습니다.
- 서비스, 컨트롤러, JDBC 저장소, repository contract 테스트를 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.report.application.service.FacilityReportServiceTest` 성공
  - `./gradlew test --tests com.easysubway.report.adapter.in.web.FacilityReportControllerTest` 성공
  - `./gradlew test --tests com.easysubway.report.adapter.out.persistence.JdbcFacilityReportRepositoryTest` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공, 43개 테스트 통과
  - `git diff --check` 성공
  - `./gradlew test` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md .codex/issue-report-result-confirmation.local.md` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `FacilityReportService.confirmReportResult`의 소유자 확인과 허용 상태 검증
  - `SecurityConfig`의 사용자 인증 대상 경로 추가가 기존 공개 신고 조회를 막지 않는지

## 리스크

- 새 API는 기존 신고 상태 enum의 `RESOLVED`를 재사용하므로 DB schema 변경은 없습니다.
- 모바일 UI는 이번 범위에 포함하지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
