### PR TITLE
[Feat] 관리자 경로 피드백 요약 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminApiController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminApiController.java
@@ -1,0 +1,20 @@
+package com.easysubway.route.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class RouteFeedbackAdminApiController {
+
+	private final RouteFeedbackDashboardAssembler routeFeedbackDashboardAssembler;
+
+	RouteFeedbackAdminApiController(RouteFeedbackDashboardAssembler routeFeedbackDashboardAssembler) {
+		this.routeFeedbackDashboardAssembler = routeFeedbackDashboardAssembler;
+	}
+
+	@GetMapping("/admin/routes/feedback/summary")
+	ApiResponse<RouteFeedbackDashboardView> routeFeedbackSummary() {
+		return ApiResponse.ok(routeFeedbackDashboardAssembler.assemble());
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminApiControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminApiControllerTest.java
@@ -1,0 +1,104 @@
+package com.easysubway.route.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("관리자 경로 피드백 요약 API")
+class RouteFeedbackAdminApiControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("관리자는 경로 피드백 요약을 JSON으로 조회한다")
+	void adminGetsRouteFeedbackSummary() throws Exception {
+		String routeSearchId = createRouteSearch();
+		submitRouteFeedback(routeSearchId, "HELPFUL", "안내가 도움이 됐어요");
+		submitRouteFeedback(routeSearchId, "NOT_HELPFUL", "실제 이동 상황과 달랐어요");
+		submitRouteFeedback(routeSearchId, "BLOCKED_BY_REAL_WORLD", "엘리베이터가 막혀 있었어요");
+
+		var result = mockMvc.perform(get("/admin/routes/feedback/summary")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.totalCount").value(3))
+			.andExpect(jsonPath("$.data.helpfulCount").value(1))
+			.andExpect(jsonPath("$.data.notHelpfulCount").value(1))
+			.andExpect(jsonPath("$.data.blockedByRealWorldCount").value(1))
+			.andExpect(jsonPath("$.data.ratingRows[0].label").value("도움이 됨"))
+			.andExpect(jsonPath("$.data.ratingRows[0].description").value("경로 안내가 실제 이동에 도움됨"))
+			.andExpect(jsonPath("$.data.ratingRows[0].count").value(1))
+			.andExpect(jsonPath("$.data.ratingRows[2].label").value("현장 차단"))
+			.andExpect(jsonPath("$.data.recentBlockedFeedbacks[0].originStationName").value("상록수"))
+			.andExpect(jsonPath("$.data.recentBlockedFeedbacks[0].destinationStationName").value("사당"))
+			.andExpect(jsonPath("$.data.recentBlockedFeedbacks[0].mobilityTypeLabel").value("고령자"))
+			.andReturn();
+
+		String json = result.getResponse().getContentAsString();
+		assertThat(json)
+			.doesNotContain("anonymous-user-1")
+			.doesNotContain(routeSearchId)
+			.doesNotContain("엘리베이터가 막혀 있었어요");
+	}
+
+	@Test
+	@DisplayName("경로 피드백 요약 API는 관리자 인증을 요구한다")
+	void routeFeedbackSummaryRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/routes/feedback/summary"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/routes/feedback/summary")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private String createRouteSearch() throws Exception {
+		var result = mockMvc.perform(post("/api/v1/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "mobilityType": "SENIOR"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andReturn();
+		return JsonPath.read(result.getResponse().getContentAsString(), "$.data.routeSearchId");
+	}
+
+	private void submitRouteFeedback(String routeSearchId, String rating, String comment) throws Exception {
+		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "rating": "%s",
+					  "comment": "%s"
+					}
+					""".formatted(rating, comment)))
+			.andExpect(status().isOk());
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1824,6 +1824,9 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   const feedbackDashboardController = read(
     "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageController.java",
   );
+  const feedbackDashboardApiController = read(
+    "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminApiController.java",
+  );
   const feedbackDashboardAssembler = read(
     "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackDashboardAssembler.java",
   );
@@ -1939,6 +1942,10 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(feedbackDashboardController, /@GetMapping\("\/admin\/routes\/feedback\/page"\)/);
   assert.match(feedbackDashboardController, /RouteFeedbackDashboardAssembler/);
   assert.match(feedbackDashboardController, /routeFeedbackDashboardAssembler\.assemble\(\)/);
+  assert.match(feedbackDashboardApiController, /@RestController/);
+  assert.match(feedbackDashboardApiController, /@GetMapping\("\/admin\/routes\/feedback\/summary"\)/);
+  assert.match(feedbackDashboardApiController, /ApiResponse<RouteFeedbackDashboardView>/);
+  assert.match(feedbackDashboardApiController, /routeFeedbackDashboardAssembler\.assemble\(\)/);
   assert.match(feedbackDashboardAssembler, /RouteFeedbackDashboardUseCase/);
   assert.match(feedbackDashboardAssembler, /summarizeRouteFeedbacks/);
   assert.match(feedbackDashboardAssembler, /recentBlockedFeedbacks/);


### PR DESCRIPTION
## 관련 이슈

close #379

## 작업 배경

- 경로 피드백은 실제 이동 가능한 경로 품질을 개선하는 운영 신호입니다.
- 관리자는 기존 화면에서 경로 피드백 요약을 볼 수 있지만, 별도 운영 도구나 관리자 화면이 같은 값을 JSON으로 조회할 API가 없었습니다.
- HTML 화면 해석 없이 전체 피드백 수, 평점별 건수, 최근 현장 차단 피드백을 재사용할 수 있도록 관리자 API 경계를 추가합니다.

## 작업 내용

- `GET /admin/routes/feedback/summary` API를 추가했습니다.
- 기존 `RouteFeedbackDashboardAssembler`를 재사용해 관리자 페이지와 JSON API가 같은 요약 계산을 사용하도록 했습니다.
- 응답에는 전체 피드백 수, 도움이 됨, 도움이 안 됨, 현장 차단 건수, 평점별 행, 최근 현장 차단 피드백 요약을 포함했습니다.
- 응답에서 사용자 식별자, 내부 routeSearchId, 원문 코멘트가 노출되지 않도록 컨트롤러 테스트로 고정했습니다.
- repository contract test에 관리자 경로 피드백 요약 API endpoint와 응답 경계를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests com.easysubway.route.adapter.in.web.RouteFeedbackAdminApiControllerTest` RED: API 미구현으로 성공 케이스 실패 확인
  - `node --test tools/ci/repository-contract.test.mjs` RED: `RouteFeedbackAdminApiController.java` 누락 실패 확인
  - `backend/gradlew -p backend test --tests com.easysubway.route.adapter.in.web.RouteFeedbackAdminApiControllerTest` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공
  - `git diff --check` 성공
  - `backend/gradlew -p backend test` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - GitHub PR CI 전체 성공
  - CodeRabbit rate limit으로 리뷰가 시작되지 않아 Codex CLI fallback review 실행, 지적 없음
  - merge 후 main CD 성공
  - merge 후 main CI 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 관리자 페이지와 JSON API가 같은 `RouteFeedbackDashboardAssembler`를 공유하는 경계가 적절한지 확인해 주세요.
  - 최근 현장 차단 피드백 응답이 routeSearchId, userId, comment를 노출하지 않는지 확인해 주세요.

## 리스크

- 현재 API는 기존 대시보드 요약과 같은 무필터 전체 집계입니다. 기간 필터나 페이지네이션은 별도 작업에서 추가해야 합니다.
- API 응답 문구는 관리자 화면의 표시 문구와 같은 assembler에서 나오므로, 문구 변경은 화면과 API에 함께 반영됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
