### PR TITLE
[Feat] 관리자 경로 검색 요약 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchAdminApiController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchAdminApiController.java
@@ -1,0 +1,21 @@
+package com.easysubway.route.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.route.application.port.in.RouteSearchDashboardUseCase;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class RouteSearchAdminApiController {
+
+	private final RouteSearchDashboardUseCase routeSearchDashboardUseCase;
+
+	RouteSearchAdminApiController(RouteSearchDashboardUseCase routeSearchDashboardUseCase) {
+		this.routeSearchDashboardUseCase = routeSearchDashboardUseCase;
+	}
+
+	@GetMapping("/admin/routes/searches/summary")
+	ApiResponse<RouteSearchDashboardView> routeSearchSummary() {
+		return ApiResponse.ok(RouteSearchDashboardView.from(routeSearchDashboardUseCase.summarizeRouteSearches()));
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageController.java
@@ -1,9 +1,7 @@
 package com.easysubway.route.adapter.in.web;
 
-import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchDashboardUseCase;
 import com.easysubway.route.domain.RouteSearchDashboardSummary;
-import java.util.List;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,55 +20,5 @@ class RouteSearchAdminPageController {
 		RouteSearchDashboardSummary summary = routeSearchDashboardUseCase.summarizeRouteSearches();
 		model.addAttribute("summary", RouteSearchDashboardView.from(summary));
 		return "admin/routes/searches";
-	}
-
-	record RouteSearchDashboardView(
-		long totalCount,
-		long foundCount,
-		long blockedCount,
-		List<MobilityTypeCountRow> mobilityTypeRows,
-		List<RegionUsageCountRow> regionUsageRows,
-		List<BlockedReasonCountRow> blockedReasonRows
-	) {
-
-		static RouteSearchDashboardView from(RouteSearchDashboardSummary summary) {
-			return new RouteSearchDashboardView(
-				summary.totalCount(),
-				summary.foundCount(),
-				summary.blockedCount(),
-				summary.mobilityTypeCounts()
-					.stream()
-					.map(row -> new MobilityTypeCountRow(mobilityTypeLabel(row.mobilityType()), row.count()))
-					.toList(),
-				summary.regionUsageCounts()
-					.stream()
-					.map(row -> new RegionUsageCountRow(row.region(), row.originCount(), row.destinationCount()))
-					.toList(),
-				summary.blockedReasonCounts()
-					.stream()
-					.map(row -> new BlockedReasonCountRow(row.reason(), row.count()))
-					.toList()
-			);
-		}
-	}
-
-	record MobilityTypeCountRow(String label, long count) {
-	}
-
-	record RegionUsageCountRow(String region, long originCount, long destinationCount) {
-	}
-
-	record BlockedReasonCountRow(String reason, long count) {
-	}
-
-	private static String mobilityTypeLabel(MobilityType mobilityType) {
-		return switch (mobilityType) {
-			case SENIOR -> "고령자";
-			case STROLLER -> "유모차 동반";
-			case WHEELCHAIR -> "휠체어 사용자";
-			case PREGNANT -> "임산부";
-			case TEMPORARY_INJURY -> "일시 부상";
-			case LUGGAGE -> "큰 짐 동반";
-		};
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchDashboardView.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchDashboardView.java
@@ -1,0 +1,55 @@
+package com.easysubway.route.adapter.in.web;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.domain.RouteSearchDashboardSummary;
+import java.util.List;
+
+public record RouteSearchDashboardView(
+	long totalCount,
+	long foundCount,
+	long blockedCount,
+	List<MobilityTypeCountRow> mobilityTypeRows,
+	List<RegionUsageCountRow> regionUsageRows,
+	List<BlockedReasonCountRow> blockedReasonRows
+) {
+
+	static RouteSearchDashboardView from(RouteSearchDashboardSummary summary) {
+		return new RouteSearchDashboardView(
+			summary.totalCount(),
+			summary.foundCount(),
+			summary.blockedCount(),
+			summary.mobilityTypeCounts()
+				.stream()
+				.map(row -> new MobilityTypeCountRow(mobilityTypeLabel(row.mobilityType()), row.count()))
+				.toList(),
+			summary.regionUsageCounts()
+				.stream()
+				.map(row -> new RegionUsageCountRow(row.region(), row.originCount(), row.destinationCount()))
+				.toList(),
+			summary.blockedReasonCounts()
+				.stream()
+				.map(row -> new BlockedReasonCountRow(row.reason(), row.count()))
+				.toList()
+		);
+	}
+
+	public record MobilityTypeCountRow(String label, long count) {
+	}
+
+	public record RegionUsageCountRow(String region, long originCount, long destinationCount) {
+	}
+
+	public record BlockedReasonCountRow(String reason, long count) {
+	}
+
+	private static String mobilityTypeLabel(MobilityType mobilityType) {
+		return switch (mobilityType) {
+			case SENIOR -> "고령자";
+			case STROLLER -> "유모차 동반";
+			case WHEELCHAIR -> "휠체어 사용자";
+			case PREGNANT -> "임산부";
+			case TEMPORARY_INJURY -> "일시 부상";
+			case LUGGAGE -> "큰 짐 동반";
+		};
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchAdminApiControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchAdminApiControllerTest.java
@@ -1,0 +1,118 @@
+package com.easysubway.route.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.application.port.out.SaveRouteSearchPort;
+import com.easysubway.route.domain.RouteSearchResult;
+import com.easysubway.route.domain.RouteSearchStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("관리자 경로 검색 요약 API")
+class RouteSearchAdminApiControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private SaveRouteSearchPort saveRouteSearchPort;
+
+	@Test
+	@DisplayName("관리자는 경로 검색 요약을 JSON으로 조회한다")
+	void adminGetsRouteSearchSummary() throws Exception {
+		createRouteSearch("SENIOR");
+		createRouteSearch("WHEELCHAIR");
+		saveRouteSearchPort.saveRouteSearch(blockedRouteSearch(
+			"route-search-blocked-1",
+			"계단 없는 역 접근 경로를 확인할 수 없습니다."
+		));
+
+		var result = mockMvc.perform(get("/admin/routes/searches/summary")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.totalCount").value(3))
+			.andExpect(jsonPath("$.data.foundCount").value(2))
+			.andExpect(jsonPath("$.data.blockedCount").value(1))
+			.andExpect(jsonPath("$.data.mobilityTypeRows[0].label").value("고령자"))
+			.andExpect(jsonPath("$.data.mobilityTypeRows[0].count").value(1))
+			.andExpect(jsonPath("$.data.mobilityTypeRows[1].label").value("휠체어 사용자"))
+			.andExpect(jsonPath("$.data.regionUsageRows[0].region").value("수도권"))
+			.andExpect(jsonPath("$.data.regionUsageRows[0].originCount").value(3))
+			.andExpect(jsonPath("$.data.regionUsageRows[0].destinationCount").value(3))
+			.andExpect(jsonPath("$.data.blockedReasonRows[0].reason").value("계단 없는 역 접근 경로를 확인할 수 없습니다."))
+			.andExpect(jsonPath("$.data.blockedReasonRows[0].count").value(1))
+			.andReturn();
+
+		String json = result.getResponse().getContentAsString();
+		assertThat(json)
+			.doesNotContain("route-search-blocked-1")
+			.doesNotContain("station-sangnoksu")
+			.doesNotContain("station-sadang");
+	}
+
+	@Test
+	@DisplayName("경로 검색 요약 API는 관리자 인증을 요구한다")
+	void routeSearchSummaryRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/routes/searches/summary"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/routes/searches/summary")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private void createRouteSearch(String mobilityType) throws Exception {
+		mockMvc.perform(post("/api/v1/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "mobilityType": "%s"
+					}
+					""".formatted(mobilityType)))
+			.andExpect(status().isOk());
+	}
+
+	private RouteSearchResult blockedRouteSearch(String routeSearchId, String blockedReason) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-sangnoksu",
+			"상록수",
+			"station-sadang",
+			"사당",
+			MobilityType.WHEELCHAIR,
+			RouteSearchStatus.BLOCKED,
+			"line-4",
+			"수도권 4호선",
+			0,
+			List.of(),
+			List.of(),
+			List.of(blockedReason),
+			LocalDateTime.of(2026, 6, 17, 10, 0)
+		);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1821,6 +1821,12 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   const searchDashboardController = read(
     "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageController.java",
   );
+  const searchDashboardApiController = read(
+    "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchAdminApiController.java",
+  );
+  const searchDashboardView = read(
+    "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchDashboardView.java",
+  );
   const feedbackDashboardController = read(
     "backend/src/main/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageController.java",
   );
@@ -1932,6 +1938,16 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(controller, /@GetMapping\("\/api\/v1\/routes\/\{routeSearchId\}"\)/);
   assert.match(searchDashboardController, /@GetMapping\("\/admin\/routes\/searches\/page"\)/);
   assert.match(searchDashboardController, /RouteSearchDashboardUseCase/);
+  assert.match(searchDashboardController, /RouteSearchDashboardView\.from\(summary\)/);
+  assert.match(searchDashboardApiController, /@RestController/);
+  assert.match(searchDashboardApiController, /@GetMapping\("\/admin\/routes\/searches\/summary"\)/);
+  assert.match(searchDashboardApiController, /ApiResponse<RouteSearchDashboardView>/);
+  assert.match(searchDashboardApiController, /RouteSearchDashboardView\.from\(routeSearchDashboardUseCase\.summarizeRouteSearches\(\)\)/);
+  assert.match(searchDashboardView, /record RouteSearchDashboardView/);
+  assert.match(searchDashboardView, /record MobilityTypeCountRow/);
+  assert.match(searchDashboardView, /record RegionUsageCountRow/);
+  assert.match(searchDashboardView, /record BlockedReasonCountRow/);
+  assert.doesNotMatch(searchDashboardView, /routeSearchId|stationId/);
   assert.match(searchDashboardTemplate, /경로 검색 현황/);
   assert.match(searchDashboardTemplate, /전체 검색/);
   assert.match(searchDashboardTemplate, /이동 프로필별 검색/);


### PR DESCRIPTION
## 관련 이슈

close #381

## 작업 배경

- 경로 검색 현황은 이동 프로필별 사용 흐름과 경로 차단 원인을 확인하는 운영 지표입니다.
- 관리자는 기존 화면에서 경로 검색 요약을 볼 수 있지만, 별도 운영 도구나 관리자 화면이 같은 값을 JSON으로 조회할 API가 없었습니다.
- HTML 화면 해석 없이 전체 검색 수, 찾음/차단 건수, 이동 프로필별 검색, 지역별 사용량, 차단 사유별 현황을 재사용할 수 있도록 관리자 API 경계를 추가합니다.

## 작업 내용

- `GET /admin/routes/searches/summary` API를 추가했습니다.
- 기존 페이지 controller 안에 있던 경로 검색 대시보드 view 변환을 `RouteSearchDashboardView`로 분리해 페이지와 JSON API가 함께 사용하도록 했습니다.
- 응답에는 전체 검색 수, 경로 찾음/차단 건수, 이동 프로필별 행, 지역별 사용량 행, 차단 사유별 행을 포함했습니다.
- 응답에서 내부 routeSearchId와 stationId가 노출되지 않도록 컨트롤러 테스트로 고정했습니다.
- repository contract test에 관리자 경로 검색 요약 API endpoint와 응답 경계를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests com.easysubway.route.adapter.in.web.RouteSearchAdminApiControllerTest` RED: API 미구현으로 성공 케이스 실패 확인
  - `node --test tools/ci/repository-contract.test.mjs` RED: `RouteSearchAdminApiController.java` 누락 실패 확인
  - `backend/gradlew -p backend test --tests com.easysubway.route.adapter.in.web.RouteSearchAdminApiControllerTest --tests com.easysubway.route.adapter.in.web.RouteSearchAdminPageControllerTest` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공
  - `git diff --check` 성공
  - `backend/gradlew -p backend test` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - GitHub PR CI 전체 성공
  - CodeRabbit rate limit으로 리뷰가 시작되지 않아 Codex CLI fallback review 실행, 지적 없음
  - merge 후 main CI 성공: https://github.com/AquilaXk/easysubway/actions/runs/27747709744
  - merge 후 main CD 성공: https://github.com/AquilaXk/easysubway/actions/runs/27747709778

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteSearchDashboardView` 분리가 페이지와 JSON API의 응답 변환 중복을 줄이는 방향인지 확인해 주세요.
  - 경로 검색 요약 응답이 routeSearchId, stationId를 노출하지 않는지 확인해 주세요.

## 리스크

- 현재 API는 기존 대시보드 요약과 같은 무필터 전체 집계입니다. 기간 필터나 페이지네이션은 별도 작업에서 추가해야 합니다.
- 페이지와 API가 같은 view record를 사용하므로, 표시 문구 변경은 화면과 API에 함께 반영됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
