### PR TITLE
[Feat] 관리자 푸시 알림 요약 API 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminApiController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminApiController.java
@@ -1,0 +1,21 @@
+package com.easysubway.notification.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.notification.application.port.in.PushNotificationDashboardUseCase;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class PushNotificationAdminApiController {
+
+	private final PushNotificationDashboardUseCase pushNotificationDashboardUseCase;
+
+	PushNotificationAdminApiController(PushNotificationDashboardUseCase pushNotificationDashboardUseCase) {
+		this.pushNotificationDashboardUseCase = pushNotificationDashboardUseCase;
+	}
+
+	@GetMapping("/admin/notifications/push/summary")
+	ApiResponse<PushNotificationDashboardView> pushNotificationSummary() {
+		return ApiResponse.ok(PushNotificationDashboardView.from(pushNotificationDashboardUseCase.summarizePushNotifications()));
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java
@@ -2,8 +2,6 @@ package com.easysubway.notification.adapter.in.web;
 
 import com.easysubway.notification.application.port.in.PushNotificationDashboardUseCase;
 import com.easysubway.notification.domain.PushNotificationDashboardSummary;
-import java.util.List;
-import java.util.Locale;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,84 +20,5 @@ class PushNotificationAdminPageController {
 		PushNotificationDashboardSummary summary = pushNotificationDashboardUseCase.summarizePushNotifications();
 		model.addAttribute("summary", PushNotificationDashboardView.from(summary));
 		return "admin/notifications/push";
-	}
-
-	record PushNotificationDashboardView(
-		long totalCount,
-		long pendingCount,
-		long sentCount,
-		long failedCount,
-		long deliveryAttemptCount,
-		String successRateLabel,
-		String failureRateLabel,
-		String failureAlertLabel,
-		String failureAlertDescription,
-		String failureAlertClass,
-		String latestFailureReason,
-		List<StatusCountRow> statusRows
-	) {
-
-		static PushNotificationDashboardView from(PushNotificationDashboardSummary summary) {
-			long deliveryAttemptCount = summary.sentCount() + summary.failedCount();
-			return new PushNotificationDashboardView(
-				summary.totalCount(),
-				summary.pendingCount(),
-				summary.sentCount(),
-				summary.failedCount(),
-				deliveryAttemptCount,
-				percentageLabel(summary.sentCount(), deliveryAttemptCount),
-				percentageLabel(summary.failedCount(), deliveryAttemptCount),
-				failureAlertLabel(summary.failedCount(), deliveryAttemptCount),
-				failureAlertDescription(summary.failedCount(), deliveryAttemptCount),
-				failureAlertClass(summary.failedCount(), deliveryAttemptCount),
-				summary.latestFailureReason(),
-				List.of(
-					new StatusCountRow("대기 중", "아직 발송 처리 전", summary.pendingCount()),
-					new StatusCountRow("발송 완료", "외부 발송 성공", summary.sentCount()),
-					new StatusCountRow("발송 실패", failedDescription(summary.latestFailureReason()), summary.failedCount())
-				)
-			);
-		}
-
-		private static String percentageLabel(long numerator, long denominator) {
-			if (denominator == 0) {
-				return "0.0%";
-			}
-			return String.format(Locale.ROOT, "%.1f%%", numerator * 100.0 / denominator);
-		}
-
-		private static String failureAlertLabel(long failedCount, long deliveryAttemptCount) {
-			if (deliveryAttemptCount == 0) {
-				return "발송 대기";
-			}
-			return failedCount == 0 ? "정상" : "점검 필요";
-		}
-
-		private static String failureAlertDescription(long failedCount, long deliveryAttemptCount) {
-			if (deliveryAttemptCount == 0) {
-				return "아직 발송 시도 기록이 없습니다.";
-			}
-			if (failedCount == 0) {
-				return "발송 실패 없이 처리되고 있습니다.";
-			}
-			return "발송 실패가 있어 푸시 어댑터와 provider 상태를 확인하세요.";
-		}
-
-		private static String failureAlertClass(long failedCount, long deliveryAttemptCount) {
-			if (deliveryAttemptCount == 0) {
-				return "pending";
-			}
-			return failedCount == 0 ? "ok" : "failure";
-		}
-
-		private static String failedDescription(String latestFailureReason) {
-			if (latestFailureReason == null || latestFailureReason.isBlank()) {
-				return "발송 어댑터 실패 또는 예외";
-			}
-			return "발송 어댑터 실패 또는 예외 · 최근 실패: " + latestFailureReason;
-		}
-	}
-
-	record StatusCountRow(String label, String description, long count) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationDashboardView.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationDashboardView.java
@@ -1,0 +1,84 @@
+package com.easysubway.notification.adapter.in.web;
+
+import com.easysubway.notification.domain.PushNotificationDashboardSummary;
+import java.util.List;
+import java.util.Locale;
+
+record PushNotificationDashboardView(
+	long totalCount,
+	long pendingCount,
+	long sentCount,
+	long failedCount,
+	long deliveryAttemptCount,
+	String successRateLabel,
+	String failureRateLabel,
+	String failureAlertLabel,
+	String failureAlertDescription,
+	String failureAlertClass,
+	String latestFailureReason,
+	List<StatusCountRow> statusRows
+) {
+
+	static PushNotificationDashboardView from(PushNotificationDashboardSummary summary) {
+		long deliveryAttemptCount = summary.sentCount() + summary.failedCount();
+		return new PushNotificationDashboardView(
+			summary.totalCount(),
+			summary.pendingCount(),
+			summary.sentCount(),
+			summary.failedCount(),
+			deliveryAttemptCount,
+			percentageLabel(summary.sentCount(), deliveryAttemptCount),
+			percentageLabel(summary.failedCount(), deliveryAttemptCount),
+			failureAlertLabel(summary.failedCount(), deliveryAttemptCount),
+			failureAlertDescription(summary.failedCount(), deliveryAttemptCount),
+			failureAlertClass(summary.failedCount(), deliveryAttemptCount),
+			summary.latestFailureReason(),
+			List.of(
+				new StatusCountRow("대기 중", "아직 발송 처리 전", summary.pendingCount()),
+				new StatusCountRow("발송 완료", "외부 발송 성공", summary.sentCount()),
+				new StatusCountRow("발송 실패", failedDescription(summary.latestFailureReason()), summary.failedCount())
+			)
+		);
+	}
+
+	private static String percentageLabel(long numerator, long denominator) {
+		if (denominator == 0) {
+			return "0.0%";
+		}
+		return String.format(Locale.ROOT, "%.1f%%", numerator * 100.0 / denominator);
+	}
+
+	private static String failureAlertLabel(long failedCount, long deliveryAttemptCount) {
+		if (deliveryAttemptCount == 0) {
+			return "발송 대기";
+		}
+		return failedCount == 0 ? "정상" : "점검 필요";
+	}
+
+	private static String failureAlertDescription(long failedCount, long deliveryAttemptCount) {
+		if (deliveryAttemptCount == 0) {
+			return "아직 발송 시도 기록이 없습니다.";
+		}
+		if (failedCount == 0) {
+			return "발송 실패 없이 처리되고 있습니다.";
+		}
+		return "발송 실패가 있어 푸시 어댑터와 provider 상태를 확인하세요.";
+	}
+
+	private static String failureAlertClass(long failedCount, long deliveryAttemptCount) {
+		if (deliveryAttemptCount == 0) {
+			return "pending";
+		}
+		return failedCount == 0 ? "ok" : "failure";
+	}
+
+	private static String failedDescription(String latestFailureReason) {
+		if (latestFailureReason == null || latestFailureReason.isBlank()) {
+			return "발송 어댑터 실패 또는 예외";
+		}
+		return "발송 어댑터 실패 또는 예외 · 최근 실패: " + latestFailureReason;
+	}
+
+	record StatusCountRow(String label, String description, long count) {
+	}
+}

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminApiControllerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminApiControllerTest.java
@@ -1,0 +1,122 @@
+package com.easysubway.notification.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("관리자 푸시 알림 요약 API")
+class PushNotificationAdminApiControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("관리자는 푸시 알림 outbox 요약을 JSON으로 조회한다")
+	void adminGetsPushNotificationSummary() throws Exception {
+		registerDevice();
+		dispatchNotification("REPORT_STATUS", "신고 처리 알림");
+		deliverPendingNotifications();
+		dispatchNotification("FAVORITE_STATION_FACILITY", "시설 변경 알림");
+
+		var result = mockMvc.perform(get("/admin/notifications/push/summary")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.totalCount").value(2))
+			.andExpect(jsonPath("$.data.pendingCount").value(1))
+			.andExpect(jsonPath("$.data.sentCount").value(0))
+			.andExpect(jsonPath("$.data.failedCount").value(1))
+			.andExpect(jsonPath("$.data.deliveryAttemptCount").value(1))
+			.andExpect(jsonPath("$.data.successRateLabel").value("0.0%"))
+			.andExpect(jsonPath("$.data.failureRateLabel").value("100.0%"))
+			.andExpect(jsonPath("$.data.failureAlertLabel").value("점검 필요"))
+			.andExpect(jsonPath("$.data.failureAlertClass").value("failure"))
+			.andExpect(jsonPath("$.data.latestFailureReason").value("외부 푸시 발송 어댑터가 설정되지 않았습니다."))
+			.andExpect(jsonPath("$.data.statusRows[0].label").value("대기 중"))
+			.andExpect(jsonPath("$.data.statusRows[0].count").value(1))
+			.andExpect(jsonPath("$.data.statusRows[1].label").value("발송 완료"))
+			.andExpect(jsonPath("$.data.statusRows[1].count").value(0))
+			.andExpect(jsonPath("$.data.statusRows[2].label").value("발송 실패"))
+			.andExpect(jsonPath("$.data.statusRows[2].count").value(1))
+			.andReturn();
+
+		String json = result.getResponse().getContentAsString();
+		assertThat(json)
+			.doesNotContain("secret-device-token")
+			.doesNotContain("anonymous-user-1");
+	}
+
+	@Test
+	@DisplayName("푸시 알림 요약 API는 관리자 인증을 요구한다")
+	void pushNotificationSummaryRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/notifications/push/summary"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/notifications/push/summary")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private void registerDevice() throws Exception {
+		mockMvc.perform(post("/api/v1/devices")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "platform": "ANDROID",
+					  "deviceToken": "secret-device-token"
+					}
+					"""))
+			.andExpect(status().isOk());
+	}
+
+	private void dispatchNotification(String type, String title) throws Exception {
+		mockMvc.perform(post("/admin/notifications/push")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "type": "%s",
+					  "title": "%s",
+					  "body": "상록수역 시설 상태를 확인하세요."
+					}
+					""".formatted(type, title)))
+			.andExpect(status().isOk());
+	}
+
+	private void deliverPendingNotifications() throws Exception {
+		mockMvc.perform(post("/admin/notifications/push/deliveries")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1"
+					}
+					"""))
+			.andExpect(status().isOk());
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1400,6 +1400,12 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   const dashboardController = read(
     "backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminPageController.java",
   );
+  const dashboardApiController = read(
+    "backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationAdminApiController.java",
+  );
+  const dashboardView = read(
+    "backend/src/main/java/com/easysubway/notification/adapter/in/web/PushNotificationDashboardView.java",
+  );
   const operatorPushNotificationReportController = read(
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportController.java",
   );
@@ -1461,11 +1467,16 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   assert.doesNotMatch(controller, /deviceToken/);
   assert.match(dashboardController, /@GetMapping\("\/admin\/notifications\/push\/page"\)/);
   assert.match(dashboardController, /PushNotificationDashboardUseCase/);
-  assert.match(dashboardController, /deliveryAttemptCount/);
-  assert.match(dashboardController, /successRateLabel/);
-  assert.match(dashboardController, /failureRateLabel/);
-  assert.match(dashboardController, /failureAlertLabel/);
-  assert.match(dashboardController, /failureAlertClass/);
+  assert.match(dashboardApiController, /@GetMapping\("\/admin\/notifications\/push\/summary"\)/);
+  assert.match(dashboardApiController, /ApiResponse<PushNotificationDashboardView>/);
+  assert.match(dashboardView, /record PushNotificationDashboardView/);
+  assert.match(dashboardView, /deliveryAttemptCount/);
+  assert.match(dashboardView, /successRateLabel/);
+  assert.match(dashboardView, /failureRateLabel/);
+  assert.match(dashboardView, /failureAlertLabel/);
+  assert.match(dashboardView, /failureAlertClass/);
+  assert.match(dashboardView, /StatusCountRow/);
+  assert.doesNotMatch(dashboardView, /notificationId|userId|deviceToken/);
   assert.match(operatorPushNotificationReportController, /@GetMapping\("\/operator\/api\/push-notification-report"\)/);
   assert.match(operatorPushNotificationReportController, /ApiResponse<OperatorPushNotificationReportView>/);
   assert.match(operatorPushNotificationReportController, /pushNotificationReportAssembler\.assemble\(\)/);


### PR DESCRIPTION
## 관련 이슈

close #385

## 작업 배경

- 푸시 알림 현황은 신고 처리 결과와 시설 상태 변경 알림의 발송 대기/성공/실패 상태를 확인하는 운영 지표입니다.
- 관리자는 기존 화면에서 푸시 알림 outbox 현황을 볼 수 있지만, 별도 운영 도구나 자동 점검 스크립트가 같은 값을 JSON으로 조회할 API가 없었습니다.
- HTML 화면 해석 없이 전체 알림 수, 상태별 건수, 성공률/실패율, 최근 실패 사유를 재사용할 수 있도록 관리자 API 경계를 추가합니다.

## 작업 내용

- `GET /admin/notifications/push/summary` API를 추가했습니다.
- 기존 페이지 controller 안에 있던 푸시 알림 대시보드 view 변환을 `PushNotificationDashboardView`로 분리해 페이지와 JSON API가 함께 사용하도록 했습니다.
- 응답에는 전체, 대기, 발송 완료, 발송 실패, 발송 시도 수, 성공률, 실패율, 실패 경고 상태, 최근 실패 사유, 상태별 행을 포함했습니다.
- 응답에서 deviceToken과 개별 사용자 식별자가 노출되지 않도록 컨트롤러 테스트로 고정했습니다.
- repository contract test에 관리자 푸시 알림 요약 API endpoint와 응답 경계를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests com.easysubway.notification.adapter.in.web.PushNotificationAdminApiControllerTest` RED: API 응답 기대 실패 확인
  - `node --test tools/ci/repository-contract.test.mjs` RED: `PushNotificationAdminApiController.java` 누락 실패 확인
  - `backend/gradlew -p backend test --tests com.easysubway.notification.adapter.in.web.PushNotificationAdminApiControllerTest --tests com.easysubway.notification.adapter.in.web.PushNotificationAdminPageControllerTest` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공
  - `git diff --check` 성공
  - `backend/gradlew -p backend test` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - GitHub PR CI 전체 성공
  - CodeRabbit rate limit으로 리뷰가 시작되지 않아 Codex CLI fallback review 실행, 지적 없음
  - merge 후 main CI 성공: https://github.com/AquilaXk/easysubway/actions/runs/27749779500
  - merge 후 main CD 성공: https://github.com/AquilaXk/easysubway/actions/runs/27749779505

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `PushNotificationDashboardView` 분리가 페이지와 JSON API의 응답 변환 중복을 줄이는 방향인지 확인해 주세요.
  - 푸시 알림 요약 응답이 deviceToken이나 개별 사용자 식별자를 노출하지 않는지 확인해 주세요.

## 리스크

- 현재 API는 기존 대시보드와 같은 전체 outbox 집계입니다. 기간 필터나 상태별 목록 조회는 별도 작업에서 추가해야 합니다.
- 페이지와 API가 같은 view record를 사용하므로, 표시 문구 변경은 화면과 API에 함께 반영됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
