### PR TITLE
[Feat] 운영기관 이동 불편 신고 분석 화면 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportPageController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportPageController.java
@@ -1,0 +1,22 @@
+package com.easysubway.operator.adapter.in.web;
+
+import com.easysubway.route.adapter.in.web.RouteFeedbackDashboardAssembler;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class OperatorRouteFeedbackReportPageController {
+
+	private final RouteFeedbackDashboardAssembler routeFeedbackDashboardAssembler;
+
+	OperatorRouteFeedbackReportPageController(RouteFeedbackDashboardAssembler routeFeedbackDashboardAssembler) {
+		this.routeFeedbackDashboardAssembler = routeFeedbackDashboardAssembler;
+	}
+
+	@GetMapping("/operator/route-feedback-report/page")
+	String routeFeedbackReportPage(Model model) {
+		model.addAttribute("summary", routeFeedbackDashboardAssembler.assemble());
+		return "operator/route-feedback-report";
+	}
+}

--- a/backend/src/main/resources/templates/operator/route-feedback-report.html
+++ b/backend/src/main/resources/templates/operator/route-feedback-report.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>운영기관 이동 불편 신고 분석</title>
+	<style>
+		body {
+			margin: 0;
+			background: #f5f7f8;
+			color: #102a2c;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+		}
+
+		main {
+			max-width: 960px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}
+
+		h1 {
+			margin: 0 0 10px;
+			font-size: 32px;
+			line-height: 1.2;
+		}
+
+		p {
+			margin: 0 0 24px;
+			color: #40585a;
+			font-size: 17px;
+			line-height: 1.55;
+		}
+
+		h2 {
+			margin: 0;
+			padding: 16px 18px;
+			background: #e8f1ef;
+			font-size: 20px;
+		}
+
+		.metric-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+			gap: 12px;
+			margin-bottom: 24px;
+		}
+
+		.metric {
+			background: #fff;
+			border: 1px solid #d6e0df;
+			padding: 18px;
+		}
+
+		.metric span {
+			display: block;
+			color: #536b6d;
+			font-weight: 800;
+			line-height: 1.4;
+		}
+
+		.metric strong {
+			display: block;
+			margin-top: 8px;
+			font-size: 30px;
+			line-height: 1.15;
+		}
+
+		section {
+			background: #fff;
+			border: 1px solid #d6e0df;
+		}
+
+		section + section {
+			margin-top: 24px;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		th,
+		td {
+			padding: 14px 18px;
+			border-top: 1px solid #d6e0df;
+			text-align: left;
+			vertical-align: top;
+			font-size: 15px;
+			line-height: 1.45;
+		}
+
+		th {
+			background: #f8fbfb;
+			font-weight: 800;
+		}
+
+		td:last-child,
+		th:last-child {
+			text-align: right;
+			font-weight: 800;
+		}
+	</style>
+</head>
+<body>
+<main>
+	<h1>운영기관 이동 불편 신고 분석</h1>
+	<p>운영기관 담당자가 경로 안내 만족도와 현장 차단 신고 흐름을 확인하는 읽기 전용 리포트입니다.</p>
+
+	<div class="metric-grid" aria-label="이동 불편 신고 분석 요약">
+		<div class="metric">
+			<span>전체 피드백</span>
+			<strong th:text="${summary.totalCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>도움이 됨</span>
+			<strong th:text="${summary.helpfulCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>도움이 안 됨</span>
+			<strong th:text="${summary.notHelpfulCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>현장 차단</span>
+			<strong th:text="${summary.blockedByRealWorldCount}">0</strong>
+		</div>
+	</div>
+
+	<section>
+		<h2>평점별 피드백</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">평점</th>
+				<th scope="col">설명</th>
+				<th scope="col">건수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.ratingRows}">
+				<td th:text="${row.label}">도움이 됨</td>
+				<td th:text="${row.description}">경로 안내가 실제 이동에 도움됨</td>
+				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>최근 현장 차단 신고</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">신고 시각</th>
+				<th scope="col">출발역</th>
+				<th scope="col">도착역</th>
+				<th scope="col">이동 프로필</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.recentBlockedFeedbacks}">
+				<td th:text="${row.createdAtLabel}">2026-06-17 10:00</td>
+				<td th:text="${row.originStationName}">상록수</td>
+				<td th:text="${row.destinationStationName}">사당</td>
+				<td th:text="${row.mobilityTypeLabel}">고령자</td>
+			</tr>
+			<tr th:if="${#lists.isEmpty(summary.recentBlockedFeedbacks)}">
+				<td colspan="4">최근 현장 차단 신고가 없습니다.</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportPageControllerTest.java
@@ -1,0 +1,112 @@
+package com.easysubway.operator.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.operator.username=operator-user",
+	"easysubway.operator.password=operator-test-password",
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("운영기관 이동 불편 신고 분석 화면")
+class OperatorRouteFeedbackReportPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("운영기관 계정은 읽기 전용 이동 불편 신고 분석 화면을 확인한다")
+	void operatorGetsRouteFeedbackReportPage() throws Exception {
+		String routeSearchId = createRouteSearch();
+		submitRouteFeedback(routeSearchId, "HELPFUL", "안내가 도움이 됐어요");
+		submitRouteFeedback(routeSearchId, "NOT_HELPFUL", "실제 이동 상황과 달랐어요");
+		submitRouteFeedback(routeSearchId, "BLOCKED_BY_REAL_WORLD", "엘리베이터가 막혀 있었어요");
+
+		String html = mockMvc.perform(get("/operator/route-feedback-report/page")
+				.with(httpBasic("operator-user", "operator-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("운영기관 이동 불편 신고 분석")
+			.contains("읽기 전용 리포트")
+			.contains("전체 피드백")
+			.contains("도움이 됨")
+			.contains("도움이 안 됨")
+			.contains("현장 차단")
+			.contains("평점별 피드백")
+			.contains("최근 현장 차단 신고")
+			.contains("상록수")
+			.contains("사당")
+			.contains("고령자")
+			.doesNotContain("basic-user")
+			.doesNotContain(routeSearchId)
+			.doesNotContain("엘리베이터가 막혀 있었어요")
+			.doesNotContain("name=\"_csrf\"")
+			.doesNotContain("<form")
+			.doesNotContain("/admin/reports");
+	}
+
+	@Test
+	@DisplayName("운영기관 이동 불편 신고 분석 화면은 운영기관 계정 인증을 요구한다")
+	void routeFeedbackReportPageRequiresOperatorAuthentication() throws Exception {
+		mockMvc.perform(get("/operator/route-feedback-report/page"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/operator/route-feedback-report/page")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/operator/route-feedback-report/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private String createRouteSearch() throws Exception {
+		var result = mockMvc.perform(post("/api/v1/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "mobilityType": "SENIOR"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andReturn();
+		return JsonPath.read(result.getResponse().getContentAsString(), "$.data.routeSearchId");
+	}
+
+	private void submitRouteFeedback(String routeSearchId, String rating, String comment) throws Exception {
+		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "basic-user",
+					  "rating": "%s",
+					  "comment": "%s"
+					}
+					""".formatted(rating, comment)))
+			.andExpect(status().isOk());
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1893,8 +1893,14 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   const operatorRouteFeedbackReportController = read(
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportController.java",
   );
+  const operatorRouteFeedbackReportPageController = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportPageController.java",
+  );
   const searchDashboardTemplate = read("backend/src/main/resources/templates/admin/routes/searches.html");
   const feedbackDashboardTemplate = read("backend/src/main/resources/templates/admin/routes/feedback.html");
+  const operatorRouteFeedbackReportTemplate = read(
+    "backend/src/main/resources/templates/operator/route-feedback-report.html",
+  );
   const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
 
   assert.match(result, /record RouteSearchResult/);
@@ -2024,6 +2030,10 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(operatorRouteFeedbackReportController, /@GetMapping\("\/operator\/api\/route-feedback-report"\)/);
   assert.match(operatorRouteFeedbackReportController, /ApiResponse<RouteFeedbackDashboardView>/);
   assert.match(operatorRouteFeedbackReportController, /routeFeedbackDashboardAssembler\.assemble\(\)/);
+  assert.match(operatorRouteFeedbackReportPageController, /@GetMapping\("\/operator\/route-feedback-report\/page"\)/);
+  assert.match(operatorRouteFeedbackReportPageController, /RouteFeedbackDashboardAssembler/);
+  assert.match(operatorRouteFeedbackReportPageController, /routeFeedbackDashboardAssembler\.assemble\(\)/);
+  assert.match(operatorRouteFeedbackReportPageController, /return "operator\/route-feedback-report"/);
   assert.match(feedbackDashboardTemplate, /경로 피드백 현황/);
   assert.match(feedbackDashboardTemplate, /전체 피드백/);
   assert.match(feedbackDashboardTemplate, /평점별 피드백/);
@@ -2034,6 +2044,11 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.doesNotMatch(feedbackDashboardTemplate, /userId/);
   assert.doesNotMatch(feedbackDashboardTemplate, /routeSearchId/);
   assert.doesNotMatch(feedbackDashboardTemplate, /comment/);
+  assert.match(operatorRouteFeedbackReportTemplate, /운영기관 이동 불편 신고 분석/);
+  assert.match(operatorRouteFeedbackReportTemplate, /읽기 전용 리포트/);
+  assert.match(operatorRouteFeedbackReportTemplate, /평점별 피드백/);
+  assert.match(operatorRouteFeedbackReportTemplate, /최근 현장 차단 신고/);
+  assert.doesNotMatch(operatorRouteFeedbackReportTemplate, /<form|_csrf|routeSearchId|userId|comment|\/admin\/reports/);
 });
 
 test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다", () => {


### PR DESCRIPTION
## 관련 이슈

close #389

## 작업 배경

- 운영기관 이동 불편 신고 분석은 JSON API로만 제공되어 운영 담당자가 브라우저에서 바로 확인하기 어려웠다.
- 기존 운영기관 접근성 시설 현황 화면처럼, 경로 피드백 현황도 읽기 전용 HTML 리포트로 제공할 필요가 있다.

## 작업 내용

- `GET /operator/route-feedback-report/page` 운영기관 전용 화면을 추가했다.
- 기존 `RouteFeedbackDashboardAssembler`를 재사용해 API와 화면이 동일한 피드백 요약 기준을 사용하게 했다.
- 화면에는 전체 피드백, 도움이 됨, 도움이 안 됨, 현장 차단 지표와 평점별 피드백, 최근 현장 차단 신고를 표시한다.
- 사용자 ID, route search ID, 신고 원문, 관리자 처리 링크, form/CSRF 필드가 화면에 노출되지 않도록 테스트와 저장소 계약을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests com.easysubway.operator.adapter.in.web.OperatorRouteFeedbackReportPageControllerTest --tests com.easysubway.operator.adapter.in.web.OperatorRouteFeedbackReportControllerTest` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공
  - `git diff --check` 성공
  - `backend/gradlew -p backend test` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md .codex/issue-operator-route-feedback-report-page.local.md` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `OperatorRouteFeedbackReportPageController`가 기존 API와 같은 assembler를 재사용하는 구조
  - `operator/route-feedback-report.html`에서 운영기관 공개 범위에 맞지 않는 내부 식별자와 신고 원문을 노출하지 않는지 여부

## 리스크

- 기존 API와 같은 요약 객체를 사용하므로 데이터 집계 기준은 바뀌지 않는다.
- 운영기관 계정 전용 `/operator/**` 보안 설정을 그대로 사용하며, 별도 처리/수정 기능은 추가하지 않았다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
