### PR TITLE
[Feat] 운영기관 반복 고장 시설 통계 화면 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesPageController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesPageController.java
@@ -1,0 +1,23 @@
+package com.easysubway.operator.adapter.in.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class OperatorRepeatedBrokenFacilitiesPageController {
+
+	private final OperatorRepeatedBrokenFacilitiesAssembler repeatedBrokenFacilitiesAssembler;
+
+	OperatorRepeatedBrokenFacilitiesPageController(
+		OperatorRepeatedBrokenFacilitiesAssembler repeatedBrokenFacilitiesAssembler
+	) {
+		this.repeatedBrokenFacilitiesAssembler = repeatedBrokenFacilitiesAssembler;
+	}
+
+	@GetMapping("/operator/repeated-broken-facilities/page")
+	String repeatedBrokenFacilitiesPage(Model model) {
+		model.addAttribute("report", repeatedBrokenFacilitiesAssembler.assemble());
+		return "operator/repeated-broken-facilities";
+	}
+}

--- a/backend/src/main/resources/templates/operator/repeated-broken-facilities.html
+++ b/backend/src/main/resources/templates/operator/repeated-broken-facilities.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>운영기관 반복 고장 시설 통계</title>
+	<style>
+		body {
+			margin: 0;
+			background: #f5f7f8;
+			color: #102a2c;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+		}
+
+		main {
+			max-width: 960px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}
+
+		h1 {
+			margin: 0 0 10px;
+			font-size: 32px;
+			line-height: 1.2;
+		}
+
+		p {
+			margin: 0 0 24px;
+			color: #40585a;
+			font-size: 17px;
+			line-height: 1.55;
+		}
+
+		h2 {
+			margin: 0;
+			padding: 16px 18px;
+			background: #e8f1ef;
+			font-size: 20px;
+		}
+
+		.metric-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+			gap: 12px;
+			margin-bottom: 24px;
+		}
+
+		.metric {
+			background: #fff;
+			border: 1px solid #d6e0df;
+			padding: 18px;
+		}
+
+		.metric span {
+			display: block;
+			color: #536b6d;
+			font-weight: 800;
+			line-height: 1.4;
+		}
+
+		.metric strong {
+			display: block;
+			margin-top: 8px;
+			font-size: 30px;
+			line-height: 1.15;
+		}
+
+		section {
+			background: #fff;
+			border: 1px solid #d6e0df;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		th,
+		td {
+			padding: 14px 18px;
+			border-top: 1px solid #d6e0df;
+			text-align: left;
+			vertical-align: top;
+			font-size: 15px;
+			line-height: 1.45;
+		}
+
+		th {
+			background: #f8fbfb;
+			font-weight: 800;
+		}
+
+		td:last-child,
+		th:last-child {
+			text-align: right;
+			font-weight: 800;
+		}
+	</style>
+</head>
+<body>
+<main>
+	<h1>운영기관 반복 고장 시설 통계</h1>
+	<p>운영기관 담당자가 반복 신고된 시설과 현재 상태를 확인하는 읽기 전용 리포트입니다.</p>
+
+	<div class="metric-grid" aria-label="반복 고장 시설 통계 요약">
+		<div class="metric">
+			<span>반복 고장 시설</span>
+			<strong th:text="${report.totalRepeatedFacilityCount}">0</strong>
+		</div>
+	</div>
+
+	<section>
+		<h2>시설별 반복 신고</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">역</th>
+				<th scope="col">시설</th>
+				<th scope="col">현재 상태</th>
+				<th scope="col">신고 건수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${report.rows}">
+				<td th:text="${row.stationName}">상록수</td>
+				<td th:text="${row.facilityName}">1번 출구 엘리베이터</td>
+				<td th:text="${row.statusLabel}">정상</td>
+				<td th:text="${row.reportCount}">0</td>
+			</tr>
+			<tr th:if="${#lists.isEmpty(report.rows)}">
+				<td colspan="4">반복 고장으로 집계된 시설이 없습니다.</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesPageControllerTest.java
@@ -1,0 +1,115 @@
+package com.easysubway.operator.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.operator.username=operator-user",
+	"easysubway.operator.password=operator-test-password",
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("운영기관 반복 고장 시설 통계 화면")
+class OperatorRepeatedBrokenFacilitiesPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("운영기관 계정은 읽기 전용 반복 고장 시설 통계를 확인한다")
+	void operatorGetsRepeatedBrokenFacilitiesPage() throws Exception {
+		createBrokenReport("첫 번째 엘리베이터 고장 신고");
+		createBrokenReport("두 번째 엘리베이터 고장 신고");
+		createReport("facility-sangnoksu-elevator-1", "LOCATION_WRONG", "위치 설명 오류 신고");
+		createBrokenReport("station-sangnoksu", "facility-sangnoksu-escalator-1", "에스컬레이터 단일 고장 신고");
+
+		String html = mockMvc.perform(get("/operator/repeated-broken-facilities/page")
+				.with(httpBasic("operator-user", "operator-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("운영기관 반복 고장 시설 통계")
+			.contains("읽기 전용 리포트")
+			.contains("반복 고장 시설")
+			.contains("시설별 반복 신고")
+			.contains("역")
+			.contains("시설")
+			.contains("현재 상태")
+			.contains("신고 건수")
+			.contains("상록수")
+			.contains("1번 출구 엘리베이터")
+			.contains("정상")
+			.contains(">2<")
+			.doesNotContain("facility-sangnoksu-escalator-1")
+			.doesNotContain("station-sangnoksu")
+			.doesNotContain("facility-sangnoksu-elevator-1")
+			.doesNotContain("basic-user")
+			.doesNotContain("첫 번째 엘리베이터 고장 신고")
+			.doesNotContain("두 번째 엘리베이터 고장 신고")
+			.doesNotContain("에스컬레이터 단일 고장 신고")
+			.doesNotContain("name=\"_csrf\"")
+			.doesNotContain("<form")
+			.doesNotContain("/admin/reports");
+	}
+
+	@Test
+	@DisplayName("운영기관 반복 고장 시설 통계 화면은 운영기관 계정 인증을 요구한다")
+	void repeatedBrokenFacilitiesPageRequiresOperatorAuthentication() throws Exception {
+		mockMvc.perform(get("/operator/repeated-broken-facilities/page"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/operator/repeated-broken-facilities/page")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/operator/repeated-broken-facilities/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private void createBrokenReport(String description) throws Exception {
+		createBrokenReport("station-sangnoksu", "facility-sangnoksu-elevator-1", description);
+	}
+
+	private void createBrokenReport(String stationId, String facilityId, String description) throws Exception {
+		createReport(stationId, facilityId, "BROKEN", description);
+	}
+
+	private void createReport(String facilityId, String reportType, String description) throws Exception {
+		createReport("station-sangnoksu", facilityId, reportType, description);
+	}
+
+	private void createReport(String stationId, String facilityId, String reportType, String description) throws Exception {
+		mockMvc.perform(post("/api/v1/reports")
+				.with(httpBasic("basic-user", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "stationId": "%s",
+					  "facilityId": "%s",
+					  "reportType": "%s",
+					  "description": "%s"
+					}
+					""".formatted(stationId, facilityId, reportType, description)))
+			.andExpect(status().isCreated());
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -919,6 +919,9 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   const operatorRepeatedBrokenFacilitiesController = read(
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesController.java",
   );
+  const operatorRepeatedBrokenFacilitiesPageController = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesPageController.java",
+  );
   const operatorRepeatedBrokenFacilitiesAssembler = read(
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesAssembler.java",
   );
@@ -935,6 +938,9 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresView.java",
   );
   const operatorReportTemplate = read("backend/src/main/resources/templates/operator/accessibility-report.html");
+  const operatorRepeatedBrokenFacilitiesTemplate = read(
+    "backend/src/main/resources/templates/operator/repeated-broken-facilities.html",
+  );
 
   assert.match(report, /record FacilityReport/);
   assert.match(report, /reviewedAt/);
@@ -1042,6 +1048,13 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   );
   assert.match(operatorRepeatedBrokenFacilitiesController, /ApiResponse<OperatorRepeatedBrokenFacilitiesView>/);
   assert.match(operatorRepeatedBrokenFacilitiesController, /repeatedBrokenFacilitiesAssembler\.assemble\(\)/);
+  assert.match(
+    operatorRepeatedBrokenFacilitiesPageController,
+    /@GetMapping\("\/operator\/repeated-broken-facilities\/page"\)/,
+  );
+  assert.match(operatorRepeatedBrokenFacilitiesPageController, /OperatorRepeatedBrokenFacilitiesAssembler/);
+  assert.match(operatorRepeatedBrokenFacilitiesPageController, /repeatedBrokenFacilitiesAssembler\.assemble\(\)/);
+  assert.match(operatorRepeatedBrokenFacilitiesPageController, /return "operator\/repeated-broken-facilities"/);
   assert.match(operatorRepeatedBrokenFacilitiesAssembler, /FacilityReportUseCase/);
   assert.match(operatorRepeatedBrokenFacilitiesAssembler, /TransitMasterQueryUseCase/);
   assert.match(operatorRepeatedBrokenFacilitiesAssembler, /listRepeatedBrokenReportFacilities/);
@@ -1070,6 +1083,14 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(operatorReportTemplate, /역별 접근성 점수/);
   assert.match(operatorReportTemplate, /접근성 개선 우선순위/);
   assert.doesNotMatch(operatorReportTemplate, /<form/);
+  assert.match(operatorRepeatedBrokenFacilitiesTemplate, /운영기관 반복 고장 시설 통계/);
+  assert.match(operatorRepeatedBrokenFacilitiesTemplate, /읽기 전용 리포트/);
+  assert.match(operatorRepeatedBrokenFacilitiesTemplate, /반복 고장 시설/);
+  assert.match(operatorRepeatedBrokenFacilitiesTemplate, /시설별 반복 신고/);
+  assert.doesNotMatch(
+    operatorRepeatedBrokenFacilitiesTemplate,
+    /<form|_csrf|stationId|facilityId|userId|description|\/admin\/reports/,
+  );
 });
 
 test("백엔드 이동 프로필은 헥사고날 API 경계를 따른다", () => {


### PR DESCRIPTION
## 관련 이슈

close #391

## 작업 배경

- 반복 고장 시설 통계는 운영기관 전용 JSON API로 제공되고 있지만, 현장 담당자가 브라우저에서 바로 확인할 수 있는 화면이 없었다.
- 기존 운영기관 접근성 시설 현황과 이동 불편 신고 분석 화면처럼, 같은 집계 기준을 재사용하는 읽기 전용 리포트가 필요하다.

## 작업 내용

- `GET /operator/repeated-broken-facilities/page` 운영기관 전용 화면을 추가했다.
- 기존 `OperatorRepeatedBrokenFacilitiesAssembler`를 재사용해 API와 화면이 동일한 반복 고장 집계와 공개 범위를 사용하게 했다.
- 화면에는 반복 고장 시설 수, 역명, 시설명, 현재 상태, 신고 건수를 표시한다.
- stationId, facilityId, userId, 신고 원문, 관리자 처리 링크, form/CSRF 필드가 화면에 노출되지 않도록 테스트와 저장소 계약을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests com.easysubway.operator.adapter.in.web.OperatorRepeatedBrokenFacilitiesPageControllerTest --tests com.easysubway.operator.adapter.in.web.OperatorRepeatedBrokenFacilitiesControllerTest` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공
  - `git diff --check` 성공
  - `backend/gradlew -p backend test` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md .codex/issue-operator-repeated-broken-facilities-page.local.md` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `OperatorRepeatedBrokenFacilitiesPageController`가 기존 API assembler를 재사용하는 구조
  - `operator/repeated-broken-facilities.html`에서 운영기관 공개 범위에 맞지 않는 내부 식별자와 신고 원문을 노출하지 않는지 여부

## 리스크

- 기존 API와 같은 view 객체를 사용하므로 반복 고장 집계 기준은 바뀌지 않는다.
- 운영기관 계정 전용 `/operator/**` 보안 설정을 그대로 사용하며, 신고 처리/상태 변경 기능은 추가하지 않았다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
