### PR TITLE
[Feat] 운영기관 데이터 수집 실패 현황 화면 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresPageController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresPageController.java
@@ -1,0 +1,23 @@
+package com.easysubway.operator.adapter.in.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class OperatorDataCollectionFailuresPageController {
+
+	private final OperatorDataCollectionFailuresAssembler dataCollectionFailuresAssembler;
+
+	OperatorDataCollectionFailuresPageController(
+		OperatorDataCollectionFailuresAssembler dataCollectionFailuresAssembler
+	) {
+		this.dataCollectionFailuresAssembler = dataCollectionFailuresAssembler;
+	}
+
+	@GetMapping("/operator/data-collection-failures/page")
+	String dataCollectionFailuresPage(Model model) {
+		model.addAttribute("report", dataCollectionFailuresAssembler.assemble());
+		return "operator/data-collection-failures";
+	}
+}

--- a/backend/src/main/resources/templates/operator/data-collection-failures.html
+++ b/backend/src/main/resources/templates/operator/data-collection-failures.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>운영기관 데이터 수집 실패 현황</title>
+	<style>
+		body {
+			margin: 0;
+			background: #f5f7f8;
+			color: #102a2c;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+		}
+
+		main {
+			max-width: 1120px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}
+
+		h1 {
+			margin: 0 0 10px;
+			font-size: 32px;
+			line-height: 1.2;
+		}
+
+		p {
+			margin: 0 0 24px;
+			color: #40585a;
+			font-size: 17px;
+			line-height: 1.55;
+		}
+
+		h2 {
+			margin: 0;
+			padding: 16px 18px;
+			background: #e8f1ef;
+			font-size: 20px;
+		}
+
+		.metric-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+			gap: 12px;
+			margin-bottom: 24px;
+		}
+
+		.metric {
+			background: #fff;
+			border: 1px solid #d6e0df;
+			padding: 18px;
+		}
+
+		.metric span {
+			display: block;
+			color: #536b6d;
+			font-weight: 800;
+			line-height: 1.4;
+		}
+
+		.metric strong {
+			display: block;
+			margin-top: 8px;
+			font-size: 30px;
+			line-height: 1.15;
+		}
+
+		section {
+			background: #fff;
+			border: 1px solid #d6e0df;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		th,
+		td {
+			padding: 14px 18px;
+			border-top: 1px solid #d6e0df;
+			text-align: left;
+			vertical-align: top;
+			font-size: 15px;
+			line-height: 1.45;
+		}
+
+		th {
+			background: #f8fbfb;
+			font-weight: 800;
+		}
+
+		td:nth-child(5),
+		th:nth-child(5) {
+			text-align: right;
+			font-weight: 800;
+		}
+	</style>
+</head>
+<body>
+<main>
+	<h1>운영기관 데이터 수집 실패 현황</h1>
+	<p>운영기관 담당자가 최근 데이터 수집 상태와 재시도 필요 여부를 확인하는 읽기 전용 리포트입니다.</p>
+
+	<div class="metric-grid" aria-label="데이터 수집 실패 현황 요약">
+		<div class="metric">
+			<span>전체 수집 실행</span>
+			<strong th:text="${report.totalRunCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>실패 실행</span>
+			<strong th:text="${report.failedRunCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>재시도 가능</span>
+			<strong th:text="${report.retryableRunCount}">0</strong>
+		</div>
+	</div>
+
+	<section>
+		<h2>최근 수집 실행</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">수집 원천</th>
+				<th scope="col">상태</th>
+				<th scope="col">시작 시각</th>
+				<th scope="col">종료 시각</th>
+				<th scope="col">수집 건수</th>
+				<th scope="col">실패 사유</th>
+				<th scope="col">운영 조치</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${report.rows}">
+				<td th:text="${row.sourceLabel}">도시철도 마스터</td>
+				<td th:text="${row.statusLabel}">실패</td>
+				<td th:text="${row.startedAtLabel}">2026-06-18T10:00</td>
+				<td th:text="${row.completedAtLabel}">2026-06-18T10:00:30</td>
+				<td th:text="${row.collectedCount}">0</td>
+				<td th:text="${row.failureMessage}">공공데이터 응답 지연</td>
+				<td th:text="${row.operatorAction}">재시도하세요.</td>
+			</tr>
+			<tr th:if="${#lists.isEmpty(report.rows)}">
+				<td colspan="7">최근 데이터 수집 실행 기록이 없습니다.</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresPageControllerTest.java
@@ -1,0 +1,122 @@
+package com.easysubway.operator.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.easysubway.collection.application.port.out.SaveDataCollectionRunPort;
+import com.easysubway.collection.domain.DataCollectionRun;
+import com.easysubway.collection.domain.DataCollectionSource;
+import com.easysubway.collection.domain.DataCollectionStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.operator.username=operator-user",
+	"easysubway.operator.password=operator-test-password",
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("운영기관 데이터 수집 실패 현황 화면")
+class OperatorDataCollectionFailuresPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private SaveDataCollectionRunPort saveDataCollectionRunPort;
+
+	@Test
+	@DisplayName("운영기관 계정은 읽기 전용 데이터 수집 실패 현황을 확인한다")
+	void operatorGetsDataCollectionFailuresPage() throws Exception {
+		saveRun(new DataCollectionRun(
+			"collection-completed",
+			DataCollectionSource.TRANSIT_MASTER,
+			DataCollectionStatus.COMPLETED,
+			"admin-user",
+			LocalDateTime.parse("2026-06-18T09:00:00"),
+			LocalDateTime.parse("2026-06-18T09:01:00"),
+			14,
+			null,
+			false,
+			"수집이 완료되었습니다. 최근 데이터 품질 화면에서 반영 결과를 확인하세요."
+		));
+		saveRun(new DataCollectionRun(
+			"collection-failed",
+			DataCollectionSource.TRANSIT_MASTER,
+			DataCollectionStatus.FAILED,
+			"admin-user",
+			LocalDateTime.parse("2026-06-18T10:00:00"),
+			LocalDateTime.parse("2026-06-18T10:00:30"),
+			0,
+			"공공데이터 응답 지연",
+			true,
+			"일시 오류일 수 있습니다. 실패 사유를 확인한 뒤 같은 수집 대상을 다시 실행하세요."
+		));
+
+		String html = mockMvc.perform(get("/operator/data-collection-failures/page")
+				.with(httpBasic("operator-user", "operator-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("운영기관 데이터 수집 실패 현황")
+			.contains("읽기 전용 리포트")
+			.contains("전체 수집 실행")
+			.contains("실패 실행")
+			.contains("재시도 가능")
+			.contains("최근 수집 실행")
+			.contains("수집 원천")
+			.contains("상태")
+			.contains("시작 시각")
+			.contains("종료 시각")
+			.contains("수집 건수")
+			.contains("실패 사유")
+			.contains("운영 조치")
+			.contains("도시철도 마스터")
+			.contains("실패")
+			.contains("완료")
+			.contains("2026-06-18T10:00")
+			.contains("2026-06-18T10:00:30")
+			.contains("공공데이터 응답 지연")
+			.contains("일시 오류일 수 있습니다. 실패 사유를 확인한 뒤 같은 수집 대상을 다시 실행하세요.")
+			.doesNotContain("collection-failed")
+			.doesNotContain("collection-completed")
+			.doesNotContain("admin-user")
+			.doesNotContain("name=\"_csrf\"")
+			.doesNotContain("<form")
+			.doesNotContain("/admin/collections");
+	}
+
+	@Test
+	@DisplayName("운영기관 데이터 수집 실패 현황 화면은 운영기관 계정 인증을 요구한다")
+	void dataCollectionFailuresPageRequiresOperatorAuthentication() throws Exception {
+		mockMvc.perform(get("/operator/data-collection-failures/page"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/operator/data-collection-failures/page")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/operator/data-collection-failures/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private void saveRun(DataCollectionRun run) {
+		saveDataCollectionRunPort.saveRun(run);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -931,6 +931,9 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   const operatorDataCollectionFailuresController = read(
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresController.java",
   );
+  const operatorDataCollectionFailuresPageController = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresPageController.java",
+  );
   const operatorDataCollectionFailuresAssembler = read(
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresAssembler.java",
   );
@@ -940,6 +943,9 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   const operatorReportTemplate = read("backend/src/main/resources/templates/operator/accessibility-report.html");
   const operatorRepeatedBrokenFacilitiesTemplate = read(
     "backend/src/main/resources/templates/operator/repeated-broken-facilities.html",
+  );
+  const operatorDataCollectionFailuresTemplate = read(
+    "backend/src/main/resources/templates/operator/data-collection-failures.html",
   );
 
   assert.match(report, /record FacilityReport/);
@@ -1069,6 +1075,13 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   );
   assert.match(operatorDataCollectionFailuresController, /ApiResponse<OperatorDataCollectionFailuresView>/);
   assert.match(operatorDataCollectionFailuresController, /dataCollectionFailuresAssembler\.assemble\(\)/);
+  assert.match(
+    operatorDataCollectionFailuresPageController,
+    /@GetMapping\("\/operator\/data-collection-failures\/page"\)/,
+  );
+  assert.match(operatorDataCollectionFailuresPageController, /OperatorDataCollectionFailuresAssembler/);
+  assert.match(operatorDataCollectionFailuresPageController, /dataCollectionFailuresAssembler\.assemble\(\)/);
+  assert.match(operatorDataCollectionFailuresPageController, /return "operator\/data-collection-failures"/);
   assert.match(operatorDataCollectionFailuresAssembler, /DataCollectionUseCase/);
   assert.match(operatorDataCollectionFailuresAssembler, /listRecentRuns/);
   assert.match(operatorDataCollectionFailuresAssembler, /DataCollectionStatus\.FAILED/);
@@ -1090,6 +1103,14 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.doesNotMatch(
     operatorRepeatedBrokenFacilitiesTemplate,
     /<form|_csrf|stationId|facilityId|userId|description|\/admin\/reports/,
+  );
+  assert.match(operatorDataCollectionFailuresTemplate, /운영기관 데이터 수집 실패 현황/);
+  assert.match(operatorDataCollectionFailuresTemplate, /읽기 전용 리포트/);
+  assert.match(operatorDataCollectionFailuresTemplate, /전체 수집 실행/);
+  assert.match(operatorDataCollectionFailuresTemplate, /최근 수집 실행/);
+  assert.doesNotMatch(
+    operatorDataCollectionFailuresTemplate,
+    /<form|_csrf|runId|requestedBy|\/admin\/collections/,
   );
 });
 


### PR DESCRIPTION
## 관련 이슈

close #393

## 작업 배경

- 데이터 수집 실패 현황은 운영기관 전용 JSON API로 제공되고 있지만, 운영 담당자가 브라우저에서 바로 확인할 수 있는 화면이 없었다.
- 접근성 데이터 품질을 운영기관과 함께 관리하려면 실패한 수집 작업, 재시도 가능 여부, 운영 조치 문구를 읽기 전용 화면으로 제공할 필요가 있다.

## 작업 내용

- `GET /operator/data-collection-failures/page` 운영기관 전용 화면을 추가했다.
- 기존 `OperatorDataCollectionFailuresAssembler`를 재사용해 API와 화면이 동일한 최근 수집 실행 기준과 공개 범위를 사용하게 했다.
- 화면에는 전체 수집 실행, 실패 실행, 재시도 가능 실행 수와 최근 수집 실행 목록을 표시한다.
- runId, requestedBy, 관리자 처리 링크, form/CSRF 필드가 화면에 노출되지 않도록 테스트와 저장소 계약을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests com.easysubway.operator.adapter.in.web.OperatorDataCollectionFailuresPageControllerTest --tests com.easysubway.operator.adapter.in.web.OperatorDataCollectionFailuresControllerTest` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공
  - `git diff --check` 성공
  - `backend/gradlew -p backend test` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md .codex/issue-operator-data-collection-failures-page.local.md` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `OperatorDataCollectionFailuresPageController`가 기존 API assembler를 재사용하는 구조
  - `operator/data-collection-failures.html`에서 운영기관 공개 범위에 맞지 않는 내부 실행 ID와 요청자 계정을 노출하지 않는지 여부

## 리스크

- 기존 API와 같은 view 객체를 사용하므로 데이터 수집 실패 집계 기준은 바뀌지 않는다.
- 운영기관 계정 전용 `/operator/**` 보안 설정을 그대로 사용하며, 수집 실행/재시도 기능은 추가하지 않았다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
