### PR TITLE
[Feat] 운영기관 알림 발송 현황 화면 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportPageController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportPageController.java
@@ -1,0 +1,23 @@
+package com.easysubway.operator.adapter.in.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class OperatorPushNotificationReportPageController {
+
+	private final OperatorPushNotificationReportAssembler pushNotificationReportAssembler;
+
+	OperatorPushNotificationReportPageController(
+		OperatorPushNotificationReportAssembler pushNotificationReportAssembler
+	) {
+		this.pushNotificationReportAssembler = pushNotificationReportAssembler;
+	}
+
+	@GetMapping("/operator/push-notification-report/page")
+	String pushNotificationReportPage(Model model) {
+		model.addAttribute("report", pushNotificationReportAssembler.assemble());
+		return "operator/push-notification-report";
+	}
+}

--- a/backend/src/main/resources/templates/operator/push-notification-report.html
+++ b/backend/src/main/resources/templates/operator/push-notification-report.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>운영기관 알림 발송 현황</title>
+	<style>
+		body {
+			margin: 0;
+			background: #f5f7f8;
+			color: #102a2c;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+		}
+
+		main {
+			max-width: 1120px;
+			margin: 0 auto;
+			padding: 32px 24px 48px;
+		}
+
+		h1 {
+			margin: 0 0 10px;
+			font-size: 32px;
+			line-height: 1.2;
+		}
+
+		p {
+			margin: 0 0 24px;
+			color: #40585a;
+			font-size: 17px;
+			line-height: 1.55;
+		}
+
+		h2 {
+			margin: 0;
+			padding: 16px 18px;
+			background: #e8f1ef;
+			font-size: 20px;
+		}
+
+		.metric-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+			gap: 12px;
+			margin-bottom: 24px;
+		}
+
+		.metric {
+			background: #fff;
+			border: 1px solid #d6e0df;
+			padding: 18px;
+		}
+
+		.metric span {
+			display: block;
+			color: #536b6d;
+			font-weight: 800;
+			line-height: 1.4;
+		}
+
+		.metric strong {
+			display: block;
+			margin-top: 8px;
+			font-size: 30px;
+			line-height: 1.15;
+		}
+
+		section {
+			margin-top: 24px;
+			background: #fff;
+			border: 1px solid #d6e0df;
+		}
+
+		table {
+			width: 100%;
+			border-collapse: collapse;
+		}
+
+		th,
+		td {
+			padding: 14px 18px;
+			border-top: 1px solid #d6e0df;
+			text-align: left;
+			vertical-align: top;
+			font-size: 15px;
+			line-height: 1.45;
+		}
+
+		th {
+			background: #f8fbfb;
+			font-weight: 800;
+		}
+
+		td:nth-child(3),
+		th:nth-child(3) {
+			text-align: right;
+			font-weight: 800;
+		}
+
+		.notice {
+			padding: 18px;
+			border-top: 1px solid #d6e0df;
+			font-size: 16px;
+			line-height: 1.55;
+		}
+	</style>
+</head>
+<body>
+<main>
+	<h1>운영기관 알림 발송 현황</h1>
+	<p>운영기관 담당자가 사용자 알림 발송 규모와 실패 여부를 확인하는 읽기 전용 리포트입니다.</p>
+
+	<div class="metric-grid" aria-label="알림 발송 현황 요약">
+		<div class="metric">
+			<span>전체 알림</span>
+			<strong th:text="${report.totalCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>대기 중</span>
+			<strong th:text="${report.pendingCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>발송 완료</span>
+			<strong th:text="${report.sentCount}">0</strong>
+		</div>
+		<div class="metric">
+			<span>발송 실패</span>
+			<strong th:text="${report.failedCount}">0</strong>
+		</div>
+	</div>
+
+	<section>
+		<h2>상태별 발송 현황</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">상태</th>
+				<th scope="col">설명</th>
+				<th scope="col">건수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${report.statusRows}">
+				<td th:text="${row.label}">대기 중</td>
+				<td th:text="${row.description}">아직 발송 처리 전</td>
+				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>최근 실패 안내</h2>
+		<div class="notice" th:if="${report.latestFailureReason != null}" th:text="${report.latestFailureReason}">
+			푸시 발송 처리 중 오류가 발생했습니다. 관리자 점검이 필요합니다.
+		</div>
+		<div class="notice" th:if="${report.latestFailureReason == null}">
+			최근 실패 없음
+		</div>
+	</section>
+</main>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportPageControllerTest.java
@@ -1,0 +1,127 @@
+package com.easysubway.operator.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.operator.username=operator-user",
+	"easysubway.operator.password=operator-test-password",
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("운영기관 알림 발송 현황 화면")
+class OperatorPushNotificationReportPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("운영기관 계정은 읽기 전용 알림 발송 현황을 확인한다")
+	void operatorGetsPushNotificationReportPage() throws Exception {
+		registerAndroidDevice();
+		dispatchReportStatusNotification();
+		deliverPendingNotifications();
+		dispatchReportStatusNotification();
+
+		String html = mockMvc.perform(get("/operator/push-notification-report/page")
+				.with(httpBasic("operator-user", "operator-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("운영기관 알림 발송 현황")
+			.contains("읽기 전용 리포트")
+			.contains("전체 알림")
+			.contains("대기 중")
+			.contains("발송 완료")
+			.contains("발송 실패")
+			.contains("상태별 발송 현황")
+			.contains("아직 발송 처리 전")
+			.contains("외부 발송 성공")
+			.contains("푸시 발송 처리 중 오류가 발생했습니다. 관리자 점검이 필요합니다.")
+			.doesNotContain("notificationId")
+			.doesNotContain("userId")
+			.doesNotContain("deviceToken")
+			.doesNotContain("secret-device-token")
+			.doesNotContain("외부 푸시 발송 어댑터가 설정되지 않았습니다.")
+			.doesNotContain("name=\"_csrf\"")
+			.doesNotContain("<form")
+			.doesNotContain("/admin/notifications");
+	}
+
+	@Test
+	@DisplayName("운영기관 알림 발송 현황 화면은 운영기관 계정 인증을 요구한다")
+	void pushNotificationReportPageRequiresOperatorAuthentication() throws Exception {
+		mockMvc.perform(get("/operator/push-notification-report/page"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/operator/push-notification-report/page")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/operator/push-notification-report/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	private void registerAndroidDevice() throws Exception {
+		mockMvc.perform(post("/api/v1/devices")
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "platform": "ANDROID",
+					  "deviceToken": "secret-device-token"
+					}
+					"""))
+			.andExpect(status().isOk());
+	}
+
+	private void dispatchReportStatusNotification() throws Exception {
+		mockMvc.perform(post("/admin/notifications/push")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1",
+					  "type": "REPORT_STATUS",
+					  "title": "신고 처리 알림",
+					  "body": "제보한 내용이 확인되었습니다."
+					}
+					"""))
+			.andExpect(status().isOk());
+	}
+
+	private void deliverPendingNotifications() throws Exception {
+		mockMvc.perform(post("/admin/notifications/push/deliveries")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "anonymous-user-1"
+					}
+					"""))
+			.andExpect(status().isOk());
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1478,6 +1478,9 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   const operatorPushNotificationReportController = read(
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportController.java",
   );
+  const operatorPushNotificationReportPageController = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportPageController.java",
+  );
   const operatorPushNotificationReportAssembler = read(
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportAssembler.java",
   );
@@ -1485,6 +1488,9 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportView.java",
   );
   const dashboardTemplate = read("backend/src/main/resources/templates/admin/notifications/push.html");
+  const operatorPushNotificationReportTemplate = read(
+    "backend/src/main/resources/templates/operator/push-notification-report.html",
+  );
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
 
   assert.match(notification, /record PushNotification/);
@@ -1549,6 +1555,13 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   assert.match(operatorPushNotificationReportController, /@GetMapping\("\/operator\/api\/push-notification-report"\)/);
   assert.match(operatorPushNotificationReportController, /ApiResponse<OperatorPushNotificationReportView>/);
   assert.match(operatorPushNotificationReportController, /pushNotificationReportAssembler\.assemble\(\)/);
+  assert.match(
+    operatorPushNotificationReportPageController,
+    /@GetMapping\("\/operator\/push-notification-report\/page"\)/,
+  );
+  assert.match(operatorPushNotificationReportPageController, /OperatorPushNotificationReportAssembler/);
+  assert.match(operatorPushNotificationReportPageController, /pushNotificationReportAssembler\.assemble\(\)/);
+  assert.match(operatorPushNotificationReportPageController, /return "operator\/push-notification-report"/);
   assert.match(operatorPushNotificationReportAssembler, /PushNotificationDashboardUseCase/);
   assert.match(operatorPushNotificationReportAssembler, /summarizePushNotifications/);
   assert.match(operatorPushNotificationReportAssembler, /OPERATOR_SAFE_FAILURE_REASON/);
@@ -1572,6 +1585,15 @@ test("백엔드 푸시 알림 outbox는 관리자 API와 헥사고날 경계를 
   assert.match(dashboardTemplate, /상태별 알림/);
   assert.match(dashboardTemplate, /최근 실패/);
   assert.doesNotMatch(dashboardTemplate, /deviceToken/);
+  assert.match(operatorPushNotificationReportTemplate, /운영기관 알림 발송 현황/);
+  assert.match(operatorPushNotificationReportTemplate, /읽기 전용 리포트/);
+  assert.match(operatorPushNotificationReportTemplate, /전체 알림/);
+  assert.match(operatorPushNotificationReportTemplate, /상태별 발송 현황/);
+  assert.match(operatorPushNotificationReportTemplate, /최근 실패 안내/);
+  assert.doesNotMatch(
+    operatorPushNotificationReportTemplate,
+    /<form|_csrf|notificationId|userId|deviceToken|\/admin\/notifications/,
+  );
   assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
 });
 


### PR DESCRIPTION
## 관련 이슈

close #395

## 작업 배경

- 운영기관 알림 발송 현황은 JSON API로 제공되고 있지만, 운영 담당자가 브라우저에서 바로 확인할 수 있는 화면이 없었다.
- 신고 처리 알림과 접근성 상태 알림은 교통약자 사용자에게 직접 영향을 주므로, 발송 실패 규모와 점검 필요 여부를 운영기관 화면에서 읽기 전용으로 확인할 필요가 있다.

## 작업 내용

- `GET /operator/push-notification-report/page` 운영기관 전용 화면을 추가했다.
- 기존 `OperatorPushNotificationReportAssembler`를 재사용해 API와 화면이 동일한 공개 범위의 알림 발송 요약을 사용하게 했다.
- 화면에는 전체 알림, 대기 중, 발송 완료, 발송 실패 수와 상태별 설명, 최근 실패 안내를 표시한다.
- notificationId, userId, deviceToken, 외부 푸시 어댑터 원문 오류, 관리자 처리 링크, form/CSRF 필드가 화면에 노출되지 않도록 테스트와 저장소 계약을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests com.easysubway.operator.adapter.in.web.OperatorPushNotificationReportPageControllerTest --tests com.easysubway.operator.adapter.in.web.OperatorPushNotificationReportControllerTest` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공
  - `git diff --check` 성공
  - `backend/gradlew -p backend test` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md .codex/issue-operator-push-notification-report-page.local.md` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `OperatorPushNotificationReportPageController`가 기존 API assembler를 재사용하는 구조
  - `operator/push-notification-report.html`에서 운영기관 공개 범위에 맞지 않는 알림/사용자/기기 식별자와 관리자 링크를 노출하지 않는지 여부

## 리스크

- 기존 API와 같은 view 객체를 사용하므로 알림 발송 집계 기준은 바뀌지 않는다.
- 운영기관 계정 전용 `/operator/**` 보안 설정을 그대로 사용하며, 알림 재발송이나 상태 변경 기능은 추가하지 않았다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
