### PR TITLE
[Feat] 관리자 구조도 간선 정보 수정 기능 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
@@ -9,6 +9,7 @@ import com.easysubway.transit.application.port.in.TransitMasterAdminUseCase;
 import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
 import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilityCommand;
 import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilityStatusCommand;
+import com.easysubway.transit.application.port.in.UpdateRouteEdgeCommand;
 import com.easysubway.transit.application.port.in.UpdateRouteNodeDisplayCommand;
 import com.easysubway.transit.application.port.in.UpdateSimplifiedStationLayoutStatusCommand;
 import com.easysubway.transit.domain.AccessibilityFacility;
@@ -17,6 +18,7 @@ import com.easysubway.transit.domain.AccessibilityFacilityType;
 import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.InvalidRouteEdgeException;
 import com.easysubway.transit.domain.InvalidRouteNodeException;
 import com.easysubway.transit.domain.NearbyStation;
 import com.easysubway.transit.domain.RouteEdge;
@@ -221,6 +223,19 @@ class TransitMasterController {
 	@GetMapping("/admin/stations/{stationId}/route-edges")
 	ApiResponse<List<RouteEdgeResponse>> routeEdges(@PathVariable String stationId) {
 		return ApiResponse.ok(routeEdgeResponses(stationId));
+	}
+
+	@PatchMapping("/admin/stations/{stationId}/route-edges/{edgeId}")
+	ApiResponse<RouteEdgeResponse> updateRouteEdge(
+		@PathVariable String stationId,
+		@PathVariable String edgeId,
+		@RequestBody UpdateRouteEdgeRequest request,
+		Principal principal
+	) {
+		RouteEdge routeEdge = transitMasterAdminUseCase.updateRouteEdge(
+			request.toCommand(stationId, edgeId, principal.getName())
+		);
+		return ApiResponse.ok(RouteEdgeResponse.from(routeEdge));
 	}
 
 	@PostMapping("/admin/facilities")
@@ -790,6 +805,48 @@ class TransitMasterController {
 				displayY,
 				displayLabel,
 				accessibilityNote,
+				updatedBy
+			);
+		}
+	}
+
+	record UpdateRouteEdgeRequest(
+		Integer distanceMeters,
+		Integer estimatedSeconds,
+		Boolean hasStairs,
+		Boolean requiresElevator,
+		Boolean requiresEscalator,
+		Integer slopeLevel,
+		Integer widthLevel,
+		Integer reliabilityScore,
+		Boolean active
+	) {
+
+		UpdateRouteEdgeCommand toCommand(String stationId, String edgeId, String updatedBy) {
+			if (distanceMeters == null || estimatedSeconds == null) {
+				throw new InvalidRouteEdgeException("간선 거리와 예상 시간이 필요합니다.");
+			}
+			if (slopeLevel == null || widthLevel == null) {
+				throw new InvalidRouteEdgeException("간선 경사와 폭 레벨이 필요합니다.");
+			}
+			if (reliabilityScore == null) {
+				throw new InvalidRouteEdgeException("간선 신뢰도가 필요합니다.");
+			}
+			if (hasStairs == null || requiresElevator == null || requiresEscalator == null || active == null) {
+				throw new InvalidRouteEdgeException("간선 접근성 제약 상태가 필요합니다.");
+			}
+			return new UpdateRouteEdgeCommand(
+				stationId,
+				edgeId,
+				distanceMeters,
+				estimatedSeconds,
+				hasStairs,
+				requiresElevator,
+				requiresEscalator,
+				slopeLevel,
+				widthLevel,
+				reliabilityScore,
+				active,
 				updatedBy
 			);
 		}

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageController.java
@@ -2,9 +2,11 @@ package com.easysubway.transit.adapter.in.web;
 
 import com.easysubway.transit.application.port.in.TransitMasterAdminUseCase;
 import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
+import com.easysubway.transit.application.port.in.UpdateRouteEdgeCommand;
 import com.easysubway.transit.application.port.in.UpdateRouteNodeDisplayCommand;
 import com.easysubway.transit.application.port.in.UpdateSimplifiedStationLayoutStatusCommand;
 import com.easysubway.transit.domain.RouteEdge;
+import com.easysubway.transit.domain.RouteEdgeNotFoundException;
 import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.RouteNodeNotFoundException;
 import com.easysubway.transit.domain.SimplifiedStationLayout;
@@ -89,6 +91,39 @@ class TransitStationLayoutAdminPageController {
 		return "redirect:/admin/stations/%s/layouts/page".formatted(stationId);
 	}
 
+	@PostMapping("/admin/stations/{stationId}/route-edges/{edgeId}/page")
+	String updateRouteEdgeFromPage(
+		@PathVariable String stationId,
+		@PathVariable String edgeId,
+		@RequestParam int distanceMeters,
+		@RequestParam int estimatedSeconds,
+		@RequestParam boolean hasStairs,
+		@RequestParam boolean requiresElevator,
+		@RequestParam boolean requiresEscalator,
+		@RequestParam int slopeLevel,
+		@RequestParam int widthLevel,
+		@RequestParam int reliabilityScore,
+		@RequestParam boolean active,
+		Principal principal
+	) {
+		requireRouteEdgeInStation(stationId, edgeId);
+		transitMasterAdminUseCase.updateRouteEdge(new UpdateRouteEdgeCommand(
+			stationId,
+			edgeId,
+			distanceMeters,
+			estimatedSeconds,
+			hasStairs,
+			requiresElevator,
+			requiresEscalator,
+			slopeLevel,
+			widthLevel,
+			reliabilityScore,
+			active,
+			principal.getName()
+		));
+		return "redirect:/admin/stations/%s/layouts/page".formatted(stationId);
+	}
+
 	private void requireLayoutInStation(String stationId, String layoutId) {
 		transitMasterQueryUseCase.getStation(stationId);
 		boolean matched = transitMasterQueryUseCase.listSimplifiedStationLayouts(stationId)
@@ -106,6 +141,16 @@ class TransitStationLayoutAdminPageController {
 			.anyMatch(node -> node.id().equals(nodeId));
 		if (!matched) {
 			throw new RouteNodeNotFoundException();
+		}
+	}
+
+	private void requireRouteEdgeInStation(String stationId, String edgeId) {
+		transitMasterQueryUseCase.getStation(stationId);
+		boolean matched = transitMasterQueryUseCase.listRouteEdges(stationId)
+			.stream()
+			.anyMatch(edge -> edge.id().equals(edgeId));
+		if (!matched) {
+			throw new RouteEdgeNotFoundException();
 		}
 	}
 
@@ -244,11 +289,21 @@ class TransitStationLayoutAdminPageController {
 		String fromNodeId,
 		String toNodeId,
 		String type,
+		int distanceMeters,
 		String distanceLabel,
+		int estimatedSeconds,
 		String estimatedSecondsLabel,
+		boolean hasStairs,
 		String stairsLabel,
+		boolean requiresElevator,
 		String elevatorLabel,
+		boolean requiresEscalator,
 		String escalatorLabel,
+		int slopeLevel,
+		int widthLevel,
+		int reliabilityScore,
+		boolean active,
+		String activeLabel,
 		String reliabilityLabel
 	) {
 
@@ -258,11 +313,21 @@ class TransitStationLayoutAdminPageController {
 				edge.fromNodeId(),
 				edge.toNodeId(),
 				edge.type().name(),
+				edge.distanceMeters(),
 				edge.distanceMeters() + "m",
+				edge.estimatedSeconds(),
 				edge.estimatedSeconds() + "초",
+				edge.hasStairs(),
 				edge.hasStairs() ? "계단 포함" : "계단 없음",
+				edge.requiresElevator(),
 				edge.requiresElevator() ? "엘리베이터 필요" : "엘리베이터 불필요",
+				edge.requiresEscalator(),
 				edge.requiresEscalator() ? "에스컬레이터 필요" : "에스컬레이터 불필요",
+				edge.slopeLevel(),
+				edge.widthLevel(),
+				edge.reliabilityScore(),
+				edge.active(),
+				edge.active() ? "활성" : "비활성",
 				"신뢰도 " + edge.reliabilityScore()
 			);
 		}

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -2,6 +2,7 @@ package com.easysubway.transit.adapter.out.persistence;
 
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.transit.application.port.out.SaveAccessibilityFacilityStatusPort;
+import com.easysubway.transit.application.port.out.SaveRouteEdgePort;
 import com.easysubway.transit.application.port.out.SaveRouteNodePort;
 import com.easysubway.transit.application.port.out.SaveSimplifiedStationLayoutStatusPort;
 import com.easysubway.transit.domain.AccessibilityFacility;
@@ -38,7 +39,8 @@ public class InMemoryTransitMasterRepository implements
 	LoadTransitMasterPort,
 	SaveAccessibilityFacilityStatusPort,
 	SaveSimplifiedStationLayoutStatusPort,
-	SaveRouteNodePort {
+	SaveRouteNodePort,
+	SaveRouteEdgePort {
 
 	private static final List<TransitOperator> OPERATORS = List.of(
 		new TransitOperator(
@@ -226,11 +228,13 @@ public class InMemoryTransitMasterRepository implements
 	private final Map<String, AccessibilityFacility> accessibilityFacilities = new LinkedHashMap<>();
 	private final Map<String, SimplifiedStationLayout> simplifiedStationLayouts = new LinkedHashMap<>();
 	private final Map<String, RouteNode> routeNodes = new LinkedHashMap<>();
+	private final Map<String, RouteEdge> routeEdges = new LinkedHashMap<>();
 
 	public InMemoryTransitMasterRepository() {
 		seedAccessibilityFacilities();
 		seedSimplifiedStationLayouts();
 		seedRouteNodes();
+		seedRouteEdges();
 	}
 
 	@Override
@@ -280,7 +284,7 @@ public class InMemoryTransitMasterRepository implements
 
 	@Override
 	public List<RouteEdge> loadRouteEdges() {
-		return ROUTE_EDGES;
+		return List.copyOf(routeEdges.values());
 	}
 
 	@Override
@@ -348,6 +352,11 @@ public class InMemoryTransitMasterRepository implements
 		routeNodes.put(routeNode.id(), routeNode);
 	}
 
+	@Override
+	public void saveRouteEdge(RouteEdge routeEdge) {
+		routeEdges.put(routeEdge.id(), routeEdge);
+	}
+
 	private void seedAccessibilityFacilities() {
 		saveSeedFacility(new AccessibilityFacility(
 			"facility-sangnoksu-elevator-1",
@@ -409,5 +418,9 @@ public class InMemoryTransitMasterRepository implements
 
 	private void seedRouteNodes() {
 		ROUTE_NODES.forEach(routeNode -> routeNodes.put(routeNode.id(), routeNode));
+	}
+
+	private void seedRouteEdges() {
+		ROUTE_EDGES.forEach(routeEdge -> routeEdges.put(routeEdge.id(), routeEdge));
 	}
 }

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterAdminUseCase.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterAdminUseCase.java
@@ -1,6 +1,7 @@
 package com.easysubway.transit.application.port.in;
 
 import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.SimplifiedStationLayout;
 
@@ -15,4 +16,6 @@ public interface TransitMasterAdminUseCase {
 	SimplifiedStationLayout updateSimplifiedStationLayoutStatus(UpdateSimplifiedStationLayoutStatusCommand command);
 
 	RouteNode updateRouteNodeDisplay(UpdateRouteNodeDisplayCommand command);
+
+	RouteEdge updateRouteEdge(UpdateRouteEdgeCommand command);
 }

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/UpdateRouteEdgeCommand.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/UpdateRouteEdgeCommand.java
@@ -1,0 +1,17 @@
+package com.easysubway.transit.application.port.in;
+
+public record UpdateRouteEdgeCommand(
+	String stationId,
+	String edgeId,
+	int distanceMeters,
+	int estimatedSeconds,
+	boolean hasStairs,
+	boolean requiresElevator,
+	boolean requiresEscalator,
+	int slopeLevel,
+	int widthLevel,
+	int reliabilityScore,
+	boolean active,
+	String updatedBy
+) {
+}

--- a/backend/src/main/java/com/easysubway/transit/application/port/out/SaveRouteEdgePort.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/out/SaveRouteEdgePort.java
@@ -1,0 +1,8 @@
+package com.easysubway.transit.application.port.out;
+
+import com.easysubway.transit.domain.RouteEdge;
+
+public interface SaveRouteEdgePort {
+
+	void saveRouteEdge(RouteEdge routeEdge);
+}

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -8,12 +8,14 @@ import com.easysubway.transit.application.port.in.TransitMasterAdminUseCase;
 import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
 import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilityCommand;
 import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilityStatusCommand;
+import com.easysubway.transit.application.port.in.UpdateRouteEdgeCommand;
 import com.easysubway.transit.application.port.in.UpdateRouteNodeDisplayCommand;
 import com.easysubway.transit.application.port.in.UpdateSimplifiedStationLayoutStatusCommand;
 import com.easysubway.notification.application.port.in.FacilityStatusAlertUseCase;
 import com.easysubway.notification.application.port.in.FacilityStatusChangedAlertCommand;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.transit.application.port.out.SaveAccessibilityFacilityStatusPort;
+import com.easysubway.transit.application.port.out.SaveRouteEdgePort;
 import com.easysubway.transit.application.port.out.SaveRouteNodePort;
 import com.easysubway.transit.application.port.out.SaveSimplifiedStationLayoutStatusPort;
 import com.easysubway.transit.domain.AccessibilityFacility;
@@ -24,10 +26,12 @@ import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.InvalidAccessibilityFacilityException;
+import com.easysubway.transit.domain.InvalidRouteEdgeException;
 import com.easysubway.transit.domain.InvalidRouteNodeException;
 import com.easysubway.transit.domain.InvalidSimplifiedStationLayoutException;
 import com.easysubway.transit.domain.NearbyStation;
 import com.easysubway.transit.domain.RouteEdge;
+import com.easysubway.transit.domain.RouteEdgeNotFoundException;
 import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.RouteNodeNotFoundException;
 import com.easysubway.transit.domain.Station;
@@ -64,6 +68,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 	private final SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort;
 	private final SaveSimplifiedStationLayoutStatusPort saveSimplifiedStationLayoutStatusPort;
 	private final SaveRouteNodePort saveRouteNodePort;
+	private final SaveRouteEdgePort saveRouteEdgePort;
 	private final FacilityStatusAlertUseCase facilityStatusAlertUseCase;
 	private final Clock clock;
 
@@ -73,6 +78,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort,
 		SaveSimplifiedStationLayoutStatusPort saveSimplifiedStationLayoutStatusPort,
 		SaveRouteNodePort saveRouteNodePort,
+		SaveRouteEdgePort saveRouteEdgePort,
 		FacilityStatusAlertUseCase facilityStatusAlertUseCase
 	) {
 		this(
@@ -80,6 +86,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 			saveAccessibilityFacilityStatusPort,
 			saveSimplifiedStationLayoutStatusPort,
 			saveRouteNodePort,
+			saveRouteEdgePort,
 			facilityStatusAlertUseCase,
 			Clock.systemDefaultZone()
 		);
@@ -94,6 +101,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 			saveAccessibilityFacilityStatusPort,
 			layoutStatusPortOrNoop(loadTransitMasterPort),
 			routeNodePortOrNoop(loadTransitMasterPort),
+			routeEdgePortOrNoop(loadTransitMasterPort),
 			command -> {
 			},
 			Clock.systemDefaultZone()
@@ -110,6 +118,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 			saveAccessibilityFacilityStatusPort,
 			layoutStatusPortOrNoop(loadTransitMasterPort),
 			routeNodePortOrNoop(loadTransitMasterPort),
+			routeEdgePortOrNoop(loadTransitMasterPort),
 			command -> {
 			},
 			clock
@@ -127,6 +136,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 			saveAccessibilityFacilityStatusPort,
 			layoutStatusPortOrNoop(loadTransitMasterPort),
 			routeNodePortOrNoop(loadTransitMasterPort),
+			routeEdgePortOrNoop(loadTransitMasterPort),
 			facilityStatusAlertUseCase,
 			clock
 		);
@@ -137,6 +147,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort,
 		SaveSimplifiedStationLayoutStatusPort saveSimplifiedStationLayoutStatusPort,
 		SaveRouteNodePort saveRouteNodePort,
+		SaveRouteEdgePort saveRouteEdgePort,
 		FacilityStatusAlertUseCase facilityStatusAlertUseCase,
 		Clock clock
 	) {
@@ -144,6 +155,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		this.saveAccessibilityFacilityStatusPort = saveAccessibilityFacilityStatusPort;
 		this.saveSimplifiedStationLayoutStatusPort = saveSimplifiedStationLayoutStatusPort;
 		this.saveRouteNodePort = saveRouteNodePort;
+		this.saveRouteEdgePort = saveRouteEdgePort;
 		this.facilityStatusAlertUseCase = facilityStatusAlertUseCase;
 		this.clock = clock;
 	}
@@ -431,6 +443,20 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		return updated;
 	}
 
+	@Override
+	public RouteEdge updateRouteEdge(UpdateRouteEdgeCommand command) {
+		requireRouteEdge(command);
+		loadActiveStation(command.stationId());
+		RouteEdge routeEdge = loadRouteEdge(command.edgeId());
+		if (!routeEdge.stationId().equals(command.stationId())) {
+			throw new RouteEdgeNotFoundException();
+		}
+
+		RouteEdge updated = withRouteEdge(routeEdge, command);
+		saveRouteEdgePort.saveRouteEdge(updated);
+		return updated;
+	}
+
 	private TransitRegionSummary summarizeRegion(
 		String region,
 		List<TransitOperator> operators,
@@ -667,6 +693,28 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		}
 	}
 
+	private void requireRouteEdge(UpdateRouteEdgeCommand command) {
+		if (command.stationId() == null || command.stationId().isBlank()) {
+			throw new InvalidRouteEdgeException("역 식별자가 필요합니다.");
+		}
+		if (command.edgeId() == null || command.edgeId().isBlank()) {
+			throw new InvalidRouteEdgeException("간선 식별자가 필요합니다.");
+		}
+		if (command.distanceMeters() < 0 || command.estimatedSeconds() < 0) {
+			throw new InvalidRouteEdgeException("간선 거리와 예상 시간은 0 이상이어야 합니다.");
+		}
+		if (command.slopeLevel() < 1 || command.slopeLevel() > 5
+			|| command.widthLevel() < 1 || command.widthLevel() > 5) {
+			throw new InvalidRouteEdgeException("간선 경사와 폭 레벨은 1부터 5까지 입력해야 합니다.");
+		}
+		if (command.reliabilityScore() < 0 || command.reliabilityScore() > 100) {
+			throw new InvalidRouteEdgeException("간선 신뢰도는 0부터 100까지 입력해야 합니다.");
+		}
+		if (command.updatedBy() == null || command.updatedBy().isBlank()) {
+			throw new InvalidRouteEdgeException("수정자 식별자가 필요합니다.");
+		}
+	}
+
 	private AccessibilityFacility loadAccessibilityFacility(String facilityId) {
 		return loadTransitMasterPort.loadAccessibilityFacilities()
 			.stream()
@@ -689,6 +737,14 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 			.filter(node -> node.id().equals(nodeId))
 			.findFirst()
 			.orElseThrow(RouteNodeNotFoundException::new);
+	}
+
+	private RouteEdge loadRouteEdge(String edgeId) {
+		return loadTransitMasterPort.loadRouteEdges()
+			.stream()
+			.filter(edge -> edge.id().equals(edgeId))
+			.findFirst()
+			.orElseThrow(RouteEdgeNotFoundException::new);
 	}
 
 	private static String blankToNull(String value) {
@@ -762,6 +818,25 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		);
 	}
 
+	private RouteEdge withRouteEdge(RouteEdge routeEdge, UpdateRouteEdgeCommand command) {
+		return new RouteEdge(
+			routeEdge.id(),
+			routeEdge.stationId(),
+			routeEdge.fromNodeId(),
+			routeEdge.toNodeId(),
+			routeEdge.type(),
+			command.distanceMeters(),
+			command.estimatedSeconds(),
+			command.hasStairs(),
+			command.requiresElevator(),
+			command.requiresEscalator(),
+			command.slopeLevel(),
+			command.widthLevel(),
+			command.reliabilityScore(),
+			command.active()
+		);
+	}
+
 	private static SaveSimplifiedStationLayoutStatusPort layoutStatusPortOrNoop(
 		LoadTransitMasterPort loadTransitMasterPort
 	) {
@@ -777,6 +852,14 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 			return port;
 		}
 		return routeNode -> {
+		};
+	}
+
+	private static SaveRouteEdgePort routeEdgePortOrNoop(LoadTransitMasterPort loadTransitMasterPort) {
+		if (loadTransitMasterPort instanceof SaveRouteEdgePort port) {
+			return port;
+		}
+		return routeEdge -> {
 		};
 	}
 }

--- a/backend/src/main/java/com/easysubway/transit/domain/InvalidRouteEdgeException.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/InvalidRouteEdgeException.java
@@ -1,0 +1,10 @@
+package com.easysubway.transit.domain;
+
+import com.easysubway.common.error.InvalidRequestException;
+
+public class InvalidRouteEdgeException extends InvalidRequestException {
+
+	public InvalidRouteEdgeException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/RouteEdgeNotFoundException.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/RouteEdgeNotFoundException.java
@@ -1,0 +1,10 @@
+package com.easysubway.transit.domain;
+
+import com.easysubway.common.error.ResourceNotFoundException;
+
+public class RouteEdgeNotFoundException extends ResourceNotFoundException {
+
+	public RouteEdgeNotFoundException() {
+		super("내부 이동 간선 정보를 찾을 수 없습니다.");
+	}
+}

--- a/backend/src/main/resources/templates/admin/stations/layouts.html
+++ b/backend/src/main/resources/templates/admin/stations/layouts.html
@@ -83,6 +83,7 @@
 		}
 
 		select,
+		input,
 		button {
 			min-height: 44px;
 			border: 1px solid #7b9396;
@@ -94,6 +95,11 @@
 
 		select {
 			min-width: 180px;
+			padding: 0 10px;
+		}
+
+		input {
+			max-width: 160px;
 			padding: 0 10px;
 		}
 
@@ -261,7 +267,46 @@
 				</td>
 				<td th:text="${edge.type}">WALK</td>
 				<td>
-					<span th:text="${edge.distanceLabel}">28m</span>
+					<form th:action="@{/admin/stations/{stationId}/route-edges/{edgeId}/page(stationId=${station.stationId}, edgeId=${edge.id})}"
+					      method="post">
+						<label class="meta" th:for="|distance-meters-${edge.id}|">거리 m</label>
+						<input type="number" name="distanceMeters" th:id="|distance-meters-${edge.id}|"
+						       th:value="${edge.distanceMeters}" min="0" required>
+						<label class="meta" th:for="|estimated-seconds-${edge.id}|">예상 초</label>
+						<input type="number" name="estimatedSeconds" th:id="|estimated-seconds-${edge.id}|"
+						       th:value="${edge.estimatedSeconds}" min="0" required>
+						<label class="meta" th:for="|slope-level-${edge.id}|">경사</label>
+						<input type="number" name="slopeLevel" th:id="|slope-level-${edge.id}|"
+						       th:value="${edge.slopeLevel}" min="1" max="5" required>
+						<label class="meta" th:for="|width-level-${edge.id}|">폭</label>
+						<input type="number" name="widthLevel" th:id="|width-level-${edge.id}|"
+						       th:value="${edge.widthLevel}" min="1" max="5" required>
+						<label class="meta" th:for="|reliability-score-${edge.id}|">신뢰도</label>
+						<input type="number" name="reliabilityScore" th:id="|reliability-score-${edge.id}|"
+						       th:value="${edge.reliabilityScore}" min="0" max="100" required>
+						<label class="meta" th:for="|has-stairs-${edge.id}|">계단</label>
+						<select name="hasStairs" th:id="|has-stairs-${edge.id}|">
+							<option value="false" th:selected="${!edge.hasStairs}">없음</option>
+							<option value="true" th:selected="${edge.hasStairs}">포함</option>
+						</select>
+						<label class="meta" th:for="|requires-elevator-${edge.id}|">엘리베이터</label>
+						<select name="requiresElevator" th:id="|requires-elevator-${edge.id}|">
+							<option value="false" th:selected="${!edge.requiresElevator}">불필요</option>
+							<option value="true" th:selected="${edge.requiresElevator}">필요</option>
+						</select>
+						<label class="meta" th:for="|requires-escalator-${edge.id}|">에스컬레이터</label>
+						<select name="requiresEscalator" th:id="|requires-escalator-${edge.id}|">
+							<option value="false" th:selected="${!edge.requiresEscalator}">불필요</option>
+							<option value="true" th:selected="${edge.requiresEscalator}">필요</option>
+						</select>
+						<label class="meta" th:for="|active-${edge.id}|">활성</label>
+						<select name="active" th:id="|active-${edge.id}|">
+							<option value="true" th:selected="${edge.active}">활성</option>
+							<option value="false" th:selected="${!edge.active}">비활성</option>
+						</select>
+						<button type="submit">저장</button>
+					</form>
+					<span class="meta" th:text="${edge.distanceLabel}">28m</span>
 					<span class="meta" th:text="${edge.estimatedSecondsLabel}">75초</span>
 				</td>
 				<td>
@@ -269,7 +314,10 @@
 					<span class="meta" th:text="${edge.elevatorLabel}">엘리베이터 필요</span>
 					<span class="meta" th:text="${edge.escalatorLabel}">에스컬레이터 불필요</span>
 				</td>
-				<td th:text="${edge.reliabilityLabel}">신뢰도 92</td>
+				<td>
+					<span th:text="${edge.reliabilityLabel}">신뢰도 92</span>
+					<span class="meta" th:text="${edge.activeLabel}">활성</span>
+				</td>
 			</tr>
 			</tbody>
 		</table>

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -676,6 +676,168 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 내부 이동 간선의 이동 난이도와 접근성 제약을 수정한다")
+	@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+	void adminUpdatesRouteEdgeMetadataAndListReflectsIt() throws Exception {
+		mockMvc.perform(patch("/admin/stations/station-sangnoksu/route-edges/edge-sangnoksu-elevator-to-faregate")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "distanceMeters": 34,
+					  "estimatedSeconds": 90,
+					  "hasStairs": true,
+					  "requiresElevator": false,
+					  "requiresEscalator": true,
+					  "slopeLevel": 2,
+					  "widthLevel": 3,
+					  "reliabilityScore": 76,
+					  "active": false
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.id").value("edge-sangnoksu-elevator-to-faregate"))
+			.andExpect(jsonPath("$.data.distanceMeters").value(34))
+			.andExpect(jsonPath("$.data.estimatedSeconds").value(90))
+			.andExpect(jsonPath("$.data.hasStairs").value(true))
+			.andExpect(jsonPath("$.data.requiresElevator").value(false))
+			.andExpect(jsonPath("$.data.requiresEscalator").value(true))
+			.andExpect(jsonPath("$.data.slopeLevel").value(2))
+			.andExpect(jsonPath("$.data.widthLevel").value(3))
+			.andExpect(jsonPath("$.data.reliabilityScore").value(76))
+			.andExpect(jsonPath("$.data.active").value(false));
+
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/route-edges")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data[0].distanceMeters").value(34))
+			.andExpect(jsonPath("$.data[0].estimatedSeconds").value(90))
+			.andExpect(jsonPath("$.data[0].hasStairs").value(true))
+			.andExpect(jsonPath("$.data[0].requiresElevator").value(false))
+			.andExpect(jsonPath("$.data[0].requiresEscalator").value(true))
+			.andExpect(jsonPath("$.data[0].slopeLevel").value(2))
+			.andExpect(jsonPath("$.data[0].widthLevel").value(3))
+			.andExpect(jsonPath("$.data[0].reliabilityScore").value(76))
+			.andExpect(jsonPath("$.data[0].active").value(false));
+	}
+
+	@Test
+	@DisplayName("내부 이동 간선 수정 API는 관리자 인증을 요구한다")
+	void updateRouteEdgeMetadataRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(patch("/admin/stations/station-sangnoksu/route-edges/edge-sangnoksu-elevator-to-faregate")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "distanceMeters": 34,
+					  "estimatedSeconds": 90,
+					  "hasStairs": false,
+					  "requiresElevator": true,
+					  "requiresEscalator": false,
+					  "slopeLevel": 1,
+					  "widthLevel": 2,
+					  "reliabilityScore": 92,
+					  "active": true
+					}
+					"""))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(patch("/admin/stations/station-sangnoksu/route-edges/edge-sangnoksu-elevator-to-faregate")
+				.with(httpBasic("basic-user", "user-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "distanceMeters": 34,
+					  "estimatedSeconds": 90,
+					  "hasStairs": false,
+					  "requiresElevator": true,
+					  "requiresEscalator": false,
+					  "slopeLevel": 1,
+					  "widthLevel": 2,
+					  "reliabilityScore": 92,
+					  "active": true
+					}
+					"""))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("내부 이동 간선 수정은 필수 숫자와 유효 범위를 요구한다")
+	void updateRouteEdgeMetadataRequiresValidInputs() throws Exception {
+		mockMvc.perform(patch("/admin/stations/station-sangnoksu/route-edges/edge-sangnoksu-elevator-to-faregate")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "estimatedSeconds": 90,
+					  "hasStairs": false,
+					  "requiresElevator": true,
+					  "requiresEscalator": false,
+					  "slopeLevel": 1,
+					  "widthLevel": 2,
+					  "reliabilityScore": 92,
+					  "active": true
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("간선 거리와 예상 시간이 필요합니다."));
+
+		mockMvc.perform(patch("/admin/stations/station-sangnoksu/route-edges/edge-sangnoksu-elevator-to-faregate")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "distanceMeters": 34,
+					  "estimatedSeconds": 90,
+					  "hasStairs": false,
+					  "requiresElevator": true,
+					  "requiresEscalator": false,
+					  "slopeLevel": 1,
+					  "widthLevel": 2,
+					  "reliabilityScore": 101,
+					  "active": true
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("간선 신뢰도는 0부터 100까지 입력해야 합니다."));
+	}
+
+	@Test
+	@DisplayName("내부 이동 간선 수정은 URL 역과 간선 소속이 일치해야 한다")
+	void updateRouteEdgeMetadataRequiresEdgeInStation() throws Exception {
+		mockMvc.perform(patch("/admin/stations/station-sadang/route-edges/edge-sangnoksu-elevator-to-faregate")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "distanceMeters": 34,
+					  "estimatedSeconds": 90,
+					  "hasStairs": false,
+					  "requiresElevator": true,
+					  "requiresEscalator": false,
+					  "slopeLevel": 1,
+					  "widthLevel": 2,
+					  "reliabilityScore": 92,
+					  "active": true
+					}
+					"""))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("내부 이동 간선 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
 	@DisplayName("존재하지 않는 역의 내부 이동 간선은 공통 404 응답을 반환한다")
 	void missingRouteEdgesReturnCommonErrorResponse() throws Exception {
 		mockMvc.perform(get("/admin/stations/unknown-station/route-edges")

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageControllerTest.java
@@ -73,6 +73,15 @@ class TransitStationLayoutAdminPageControllerTest {
 			.contains("엘리베이터 필요")
 			.contains("75초")
 			.contains("신뢰도 92")
+			.contains("name=\"distanceMeters\"")
+			.contains("name=\"estimatedSeconds\"")
+			.contains("name=\"hasStairs\"")
+			.contains("name=\"requiresElevator\"")
+			.contains("name=\"requiresEscalator\"")
+			.contains("name=\"slopeLevel\"")
+			.contains("name=\"widthLevel\"")
+			.contains("name=\"reliabilityScore\"")
+			.contains("name=\"active\"")
 			.doesNotContain("{\"nodes\":[],\"edges\":[]}")
 			.doesNotContain("<img");
 	}
@@ -158,6 +167,43 @@ class TransitStationLayoutAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 역 구조도 화면에서 내부 이동 간선 정보를 변경한다")
+	@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+	void adminUpdatesRouteEdgeMetadataFromPageAndRedirectsToLayoutPage() throws Exception {
+		mockMvc.perform(post("/admin/stations/station-sangnoksu/route-edges/edge-sangnoksu-elevator-to-faregate/page")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("distanceMeters", "34")
+				.param("estimatedSeconds", "90")
+				.param("hasStairs", "true")
+				.param("requiresElevator", "false")
+				.param("requiresEscalator", "true")
+				.param("slopeLevel", "2")
+				.param("widthLevel", "3")
+				.param("reliabilityScore", "76")
+				.param("active", "false"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(header().string("Location", "/admin/stations/station-sangnoksu/layouts/page"));
+
+		String html = mockMvc.perform(get("/admin/stations/station-sangnoksu/layouts/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("34m")
+			.contains("90초")
+			.contains("계단 포함")
+			.contains("엘리베이터 불필요")
+			.contains("에스컬레이터 필요")
+			.contains("신뢰도 76")
+			.contains("비활성");
+	}
+
+	@Test
 	@DisplayName("관리자 역 구조도 요약 화면은 관리자 인증을 요구한다")
 	void stationLayoutPageRequiresAdminAuthentication() throws Exception {
 		mockMvc.perform(get("/admin/stations/station-sangnoksu/layouts/page"))
@@ -196,6 +242,35 @@ class TransitStationLayoutAdminPageControllerTest {
 				.param("displayY", "256")
 				.param("displayLabel", "1번 출구 승강기"))
 			.andExpect(status().isForbidden());
+
+		mockMvc.perform(post("/admin/stations/station-sangnoksu/route-edges/edge-sangnoksu-elevator-to-faregate/page")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("distanceMeters", "34")
+				.param("estimatedSeconds", "90")
+				.param("hasStairs", "false")
+				.param("requiresElevator", "true")
+				.param("requiresEscalator", "false")
+				.param("slopeLevel", "1")
+				.param("widthLevel", "2")
+				.param("reliabilityScore", "92")
+				.param("active", "true"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(post("/admin/stations/station-sangnoksu/route-edges/edge-sangnoksu-elevator-to-faregate/page")
+				.with(httpBasic("basic-user", "user-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("distanceMeters", "34")
+				.param("estimatedSeconds", "90")
+				.param("hasStairs", "false")
+				.param("requiresElevator", "true")
+				.param("requiresEscalator", "false")
+				.param("slopeLevel", "1")
+				.param("widthLevel", "2")
+				.param("reliabilityScore", "92")
+				.param("active", "true"))
+			.andExpect(status().isForbidden());
 	}
 
 	@Test
@@ -223,6 +298,28 @@ class TransitStationLayoutAdminPageControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.data").doesNotExist())
 			.andExpect(jsonPath("$.message").value("내부 이동 노드 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("역 구조도 간선 변경은 URL 역과 간선 소속이 일치해야 한다")
+	void stationLayoutEdgeUpdateRequiresEdgeInStation() throws Exception {
+		mockMvc.perform(post("/admin/stations/station-sadang/route-edges/edge-sangnoksu-elevator-to-faregate/page")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("distanceMeters", "34")
+				.param("estimatedSeconds", "90")
+				.param("hasStairs", "false")
+				.param("requiresElevator", "true")
+				.param("requiresEscalator", "false")
+				.param("slopeLevel", "1")
+				.param("widthLevel", "2")
+				.param("reliabilityScore", "92")
+				.param("active", "true"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("내부 이동 간선 정보를 찾을 수 없습니다."));
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -9,6 +9,7 @@ import com.easysubway.transit.application.port.in.NearbyStationSearchCommand;
 import com.easysubway.transit.application.port.in.StationSearchCommand;
 import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilityStatusCommand;
 import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilityCommand;
+import com.easysubway.transit.application.port.in.UpdateRouteEdgeCommand;
 import com.easysubway.transit.application.port.in.UpdateRouteNodeDisplayCommand;
 import com.easysubway.transit.application.port.in.UpdateSimplifiedStationLayoutStatusCommand;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
@@ -22,9 +23,11 @@ import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.InvalidAccessibilityFacilityException;
+import com.easysubway.transit.domain.InvalidRouteEdgeException;
 import com.easysubway.transit.domain.InvalidRouteNodeException;
 import com.easysubway.transit.domain.InvalidSimplifiedStationLayoutException;
 import com.easysubway.transit.domain.RouteEdge;
+import com.easysubway.transit.domain.RouteEdgeNotFoundException;
 import com.easysubway.transit.domain.RouteEdgeType;
 import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.RouteNodeNotFoundException;
@@ -604,6 +607,139 @@ class TransitMasterServiceTest {
 		)))
 			.isInstanceOf(RouteNodeNotFoundException.class)
 			.hasMessage("내부 이동 노드 정보를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("관리자는 내부 이동 간선의 이동 난이도와 접근성 제약을 수정한다")
+	void updateRouteEdgeStoresDifficultyAndAccessibilityMetadata() {
+		var repository = new InMemoryTransitMasterRepository();
+		var service = new TransitMasterService(repository, repository);
+
+		var updated = service.updateRouteEdge(new UpdateRouteEdgeCommand(
+			"station-sangnoksu",
+			"edge-sangnoksu-elevator-to-faregate",
+			34,
+			90,
+			true,
+			false,
+			true,
+			2,
+			3,
+			76,
+			false,
+			"admin-user"
+		));
+
+		assertThat(updated.distanceMeters()).isEqualTo(34);
+		assertThat(updated.estimatedSeconds()).isEqualTo(90);
+		assertThat(updated.hasStairs()).isTrue();
+		assertThat(updated.requiresElevator()).isFalse();
+		assertThat(updated.requiresEscalator()).isTrue();
+		assertThat(updated.slopeLevel()).isEqualTo(2);
+		assertThat(updated.widthLevel()).isEqualTo(3);
+		assertThat(updated.reliabilityScore()).isEqualTo(76);
+		assertThat(updated.active()).isFalse();
+		assertThat(service.listRouteEdges("station-sangnoksu").getFirst().reliabilityScore())
+			.isEqualTo(76);
+	}
+
+	@Test
+	@DisplayName("내부 이동 간선 수정은 범위 안의 숫자와 관리자 식별자를 요구한다")
+	void updateRouteEdgeRequiresValidInputsAndUpdater() {
+		var repository = new InMemoryTransitMasterRepository();
+		var service = new TransitMasterService(repository, repository);
+
+		assertThatThrownBy(() -> service.updateRouteEdge(new UpdateRouteEdgeCommand(
+			"station-sangnoksu",
+			"edge-sangnoksu-elevator-to-faregate",
+			-1,
+			90,
+			false,
+			true,
+			false,
+			1,
+			2,
+			92,
+			true,
+			"admin-user"
+		)))
+			.isInstanceOf(InvalidRouteEdgeException.class)
+			.hasMessage("간선 거리와 예상 시간은 0 이상이어야 합니다.");
+
+		assertThatThrownBy(() -> service.updateRouteEdge(new UpdateRouteEdgeCommand(
+			"station-sangnoksu",
+			"edge-sangnoksu-elevator-to-faregate",
+			34,
+			90,
+			false,
+			true,
+			false,
+			0,
+			2,
+			92,
+			true,
+			"admin-user"
+		)))
+			.isInstanceOf(InvalidRouteEdgeException.class)
+			.hasMessage("간선 경사와 폭 레벨은 1부터 5까지 입력해야 합니다.");
+
+		assertThatThrownBy(() -> service.updateRouteEdge(new UpdateRouteEdgeCommand(
+			"station-sangnoksu",
+			"edge-sangnoksu-elevator-to-faregate",
+			34,
+			90,
+			false,
+			true,
+			false,
+			1,
+			2,
+			101,
+			true,
+			"admin-user"
+		)))
+			.isInstanceOf(InvalidRouteEdgeException.class)
+			.hasMessage("간선 신뢰도는 0부터 100까지 입력해야 합니다.");
+
+		assertThatThrownBy(() -> service.updateRouteEdge(new UpdateRouteEdgeCommand(
+			"station-sangnoksu",
+			"edge-sangnoksu-elevator-to-faregate",
+			34,
+			90,
+			false,
+			true,
+			false,
+			1,
+			2,
+			92,
+			true,
+			""
+		)))
+			.isInstanceOf(InvalidRouteEdgeException.class)
+			.hasMessage("수정자 식별자가 필요합니다.");
+	}
+
+	@Test
+	@DisplayName("내부 이동 간선 수정은 URL 역과 간선 소속이 일치해야 한다")
+	void updateRouteEdgeRequiresEdgeInStation() {
+		var repository = new InMemoryTransitMasterRepository();
+		var service = new TransitMasterService(repository, repository);
+
+		assertThatThrownBy(() -> service.updateRouteEdge(new UpdateRouteEdgeCommand(
+			"station-sadang",
+			"edge-sangnoksu-elevator-to-faregate",
+			34,
+			90,
+			false,
+			true,
+			false,
+			1,
+			2,
+			92,
+			true,
+			"admin-user"
+		)))
+			.isInstanceOf(RouteEdgeNotFoundException.class)
+			.hasMessage("내부 이동 간선 정보를 찾을 수 없습니다.");
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

close #403

## 작업 배경

- 관리자 역 구조도 화면에서 내부 이동 간선의 거리, 예상 시간, 접근성 제약, 신뢰도를 조회할 수 있지만 현장 검수 결과를 반영해 수정할 수 없었다.
- 쉬운 내부 구조도 기반 경로 추천은 간선의 계단 포함 여부, 승강기 필요 여부, 신뢰도, 활성 상태에 직접 영향을 받는다.
- 노드 표시 위치 수정과 같은 관리자 경계에서 간선 소속 역을 검증하고, 잘못된 역의 간선을 수정하지 못하게 해야 한다.

## 작업 내용

- `UpdateRouteEdgeCommand`, `SaveRouteEdgePort`, 간선 검증/미존재 예외를 추가했다.
- `TransitMasterService.updateRouteEdge`가 간선 거리, 예상 시간, 계단/엘리베이터/에스컬레이터 제약, 경사/폭 레벨, 신뢰도, 활성 여부를 검증하고 저장하도록 구현했다.
- 인메모리 도시철도 마스터 저장소가 내부 이동 간선 수정 결과를 보존하도록 변경했다.
- `PATCH /admin/stations/{stationId}/route-edges/{edgeId}` 관리자 API를 추가했다.
- `GET /admin/stations/{stationId}/layouts/page` 화면의 내부 이동 간선 행에 수정 form을 추가했다.
- 화면 form 제출 경로에서 URL 역과 간선 소속이 일치하는지 확인하도록 했다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests com.easysubway.transit.adapter.in.web.TransitStationLayoutAdminPageControllerTest --tests com.easysubway.transit.adapter.in.web.TransitMasterControllerTest --tests com.easysubway.transit.application.service.TransitMasterServiceTest` RED: `UpdateRouteEdgeCommand`, `InvalidRouteEdgeException`, `RouteEdgeNotFoundException` 미존재로 실패 확인
  - `backend/gradlew -p backend test --tests com.easysubway.transit.adapter.in.web.TransitStationLayoutAdminPageControllerTest --tests com.easysubway.transit.adapter.in.web.TransitMasterControllerTest --tests com.easysubway.transit.application.service.TransitMasterServiceTest` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공
  - `git diff --check` 성공
  - `backend/gradlew -p backend test` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - `git check-ignore -v AGENTS.md docs/AGENT-CONTEXT.md docs/agent/_template.md .codex/current-task.local swieun-jihacheol-project-plan.md .codex/issue-admin-route-edge-update.local.md .codex/plan-admin-route-edge-update.local.md` 성공
  - PR CI run `27760703939` 성공
  - CodeRabbit은 review limit reached로 리뷰가 시작되지 않아 Codex CLI fallback review를 실행했고, 지적 0건 summary review를 남겼다.
  - 병합 후 CI run `27761083285` 성공
  - 병합 후 CD run `27761083180` 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `TransitMasterService.updateRouteEdge`가 URL의 역 ID와 간선 소속 역을 함께 검증하는지
  - JSON request DTO가 필수 숫자 값을 boxed 타입으로 받아 누락을 0으로 처리하지 않는지
  - 관리자 화면 form이 간선 생성/삭제가 아니라 기존 간선의 운영 메타데이터만 수정하는지

## 리스크

- 간선 생성/삭제와 노드 연결 관계 변경은 포함하지 않고, 기존 간선의 이동 메타데이터만 수정한다.
- 인메모리 저장소 기준 구현이므로 운영 DB 저장소가 추가될 때 같은 port 구현이 필요하다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
