### PR TITLE
[Feat] 관리자 구조도 기준 자료 수정 기능 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitMasterController.java
@@ -12,6 +12,7 @@ import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilitySta
 import com.easysubway.transit.application.port.in.UpdateRouteEdgeCommand;
 import com.easysubway.transit.application.port.in.UpdateRouteNodeDisplayCommand;
 import com.easysubway.transit.application.port.in.UpdateSimplifiedStationLayoutStatusCommand;
+import com.easysubway.transit.application.port.in.UpdateStationLayoutSourceCommand;
 import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.AccessibilityFacilityType;
@@ -20,6 +21,7 @@ import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.InvalidRouteEdgeException;
 import com.easysubway.transit.domain.InvalidRouteNodeException;
+import com.easysubway.transit.domain.InvalidStationLayoutSourceException;
 import com.easysubway.transit.domain.NearbyStation;
 import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteEdgeType;
@@ -195,6 +197,19 @@ class TransitMasterController {
 	@GetMapping("/admin/stations/{stationId}/layout-sources")
 	ApiResponse<List<StationLayoutSourceResponse>> stationLayoutSources(@PathVariable String stationId) {
 		return ApiResponse.ok(stationLayoutSourceResponses(stationId));
+	}
+
+	@PatchMapping("/admin/stations/{stationId}/layout-sources/{sourceId}")
+	ApiResponse<StationLayoutSourceResponse> updateStationLayoutSource(
+		@PathVariable String stationId,
+		@PathVariable String sourceId,
+		@RequestBody UpdateStationLayoutSourceRequest request,
+		Principal principal
+	) {
+		StationLayoutSource source = transitMasterAdminUseCase.updateStationLayoutSource(
+			request.toCommand(stationId, sourceId, principal.getName())
+		);
+		return ApiResponse.ok(StationLayoutSourceResponse.from(source));
 	}
 
 	@GetMapping("/admin/stations/{stationId}/layouts")
@@ -847,6 +862,37 @@ class TransitMasterController {
 				widthLevel,
 				reliabilityScore,
 				active,
+				updatedBy
+			);
+		}
+	}
+
+	record UpdateStationLayoutSourceRequest(
+		StationLayoutSourceType sourceType,
+		String sourceName,
+		String sourceUrl,
+		String license,
+		Boolean commercialUseAllowed,
+		Boolean attributionRequired,
+		LocalDate capturedAt,
+		LocalDate reviewedAt
+	) {
+
+		UpdateStationLayoutSourceCommand toCommand(String stationId, String sourceId, String updatedBy) {
+			if (commercialUseAllowed == null || attributionRequired == null) {
+				throw new InvalidStationLayoutSourceException("기준 자료 이용 조건을 선택해야 합니다.");
+			}
+			return new UpdateStationLayoutSourceCommand(
+				stationId,
+				sourceId,
+				sourceType,
+				sourceName,
+				sourceUrl,
+				license,
+				commercialUseAllowed,
+				attributionRequired,
+				capturedAt,
+				reviewedAt,
 				updatedBy
 			);
 		}

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageController.java
@@ -5,6 +5,7 @@ import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
 import com.easysubway.transit.application.port.in.UpdateRouteEdgeCommand;
 import com.easysubway.transit.application.port.in.UpdateRouteNodeDisplayCommand;
 import com.easysubway.transit.application.port.in.UpdateSimplifiedStationLayoutStatusCommand;
+import com.easysubway.transit.application.port.in.UpdateStationLayoutSourceCommand;
 import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteEdgeNotFoundException;
 import com.easysubway.transit.domain.RouteNode;
@@ -13,9 +14,12 @@ import com.easysubway.transit.domain.SimplifiedStationLayout;
 import com.easysubway.transit.domain.SimplifiedStationLayoutNotFoundException;
 import com.easysubway.transit.domain.SimplifiedStationLayoutStatus;
 import com.easysubway.transit.domain.StationLayoutSource;
+import com.easysubway.transit.domain.StationLayoutSourceNotFoundException;
+import com.easysubway.transit.domain.StationLayoutSourceType;
 import com.easysubway.transit.domain.StationLineSummary;
 import com.easysubway.transit.domain.StationWithLines;
 import java.security.Principal;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -45,6 +49,7 @@ class TransitStationLayoutAdminPageController {
 		StationWithLines station = transitMasterQueryUseCase.getStation(stationId);
 		model.addAttribute("station", StationLayoutPageStation.from(station));
 		model.addAttribute("layoutSources", layoutSourceRows(stationId));
+		model.addAttribute("sourceTypeOptions", sourceTypeOptions());
 		model.addAttribute("layouts", layoutRows(stationId));
 		model.addAttribute("layoutStatusOptions", layoutStatusOptions());
 		model.addAttribute("routeNodes", routeNodeRows(stationId));
@@ -63,6 +68,37 @@ class TransitStationLayoutAdminPageController {
 		transitMasterAdminUseCase.updateSimplifiedStationLayoutStatus(new UpdateSimplifiedStationLayoutStatusCommand(
 			layoutId,
 			status,
+			principal.getName()
+		));
+		return "redirect:/admin/stations/%s/layouts/page".formatted(stationId);
+	}
+
+	@PostMapping("/admin/stations/{stationId}/layout-sources/{sourceId}/page")
+	String updateStationLayoutSourceFromPage(
+		@PathVariable String stationId,
+		@PathVariable String sourceId,
+		@RequestParam StationLayoutSourceType sourceType,
+		@RequestParam String sourceName,
+		@RequestParam String sourceUrl,
+		@RequestParam String license,
+		@RequestParam boolean commercialUseAllowed,
+		@RequestParam boolean attributionRequired,
+		@RequestParam LocalDate capturedAt,
+		@RequestParam(required = false) LocalDate reviewedAt,
+		Principal principal
+	) {
+		requireStationLayoutSourceInStation(stationId, sourceId);
+		transitMasterAdminUseCase.updateStationLayoutSource(new UpdateStationLayoutSourceCommand(
+			stationId,
+			sourceId,
+			sourceType,
+			sourceName,
+			sourceUrl,
+			license,
+			commercialUseAllowed,
+			attributionRequired,
+			capturedAt,
+			reviewedAt,
 			principal.getName()
 		));
 		return "redirect:/admin/stations/%s/layouts/page".formatted(stationId);
@@ -134,6 +170,16 @@ class TransitStationLayoutAdminPageController {
 		}
 	}
 
+	private void requireStationLayoutSourceInStation(String stationId, String sourceId) {
+		transitMasterQueryUseCase.getStation(stationId);
+		boolean matched = transitMasterQueryUseCase.listStationLayoutSources(stationId)
+			.stream()
+			.anyMatch(source -> source.id().equals(sourceId));
+		if (!matched) {
+			throw new StationLayoutSourceNotFoundException();
+		}
+	}
+
 	private void requireRouteNodeInStation(String stationId, String nodeId) {
 		transitMasterQueryUseCase.getStation(stationId);
 		boolean matched = transitMasterQueryUseCase.listRouteNodes(stationId)
@@ -188,6 +234,12 @@ class TransitStationLayoutAdminPageController {
 			.toList();
 	}
 
+	private static List<SourceTypeOption> sourceTypeOptions() {
+		return Arrays.stream(StationLayoutSourceType.values())
+			.map(type -> new SourceTypeOption(type, type.name()))
+			.toList();
+	}
+
 	record StationLayoutPageStation(String stationId, String stationName, String lineNames) {
 
 		static StationLayoutPageStation from(StationWithLines stationWithLines) {
@@ -203,23 +255,35 @@ class TransitStationLayoutAdminPageController {
 	}
 
 	record StationLayoutSourceRow(
+		String id,
+		StationLayoutSourceType sourceTypeValue,
 		String sourceName,
 		String sourceType,
+		String sourceUrl,
 		String license,
+		boolean commercialUseAllowed,
 		String commercialUseLabel,
+		boolean attributionRequired,
 		String attributionLabel,
 		String capturedAt,
+		String rawReviewedAt,
 		String reviewedAt
 	) {
 
 		static StationLayoutSourceRow from(StationLayoutSource source) {
 			return new StationLayoutSourceRow(
+				source.id(),
+				source.sourceType(),
 				source.sourceName(),
 				source.sourceType().name(),
+				source.sourceUrl(),
 				source.license(),
+				source.commercialUseAllowed(),
 				source.commercialUseAllowed() ? "상업적 사용 가능" : "상업적 사용 불가",
+				source.attributionRequired(),
 				source.attributionRequired() ? "출처 표시 필요" : "출처 표시 불필요",
 				source.capturedAt().toString(),
+				source.reviewedAt() == null ? "" : source.reviewedAt().toString(),
 				source.reviewedAt() == null ? "검수 전" : source.reviewedAt().toString()
 			);
 		}
@@ -251,6 +315,9 @@ class TransitStationLayoutAdminPageController {
 	}
 
 	record LayoutStatusOption(SimplifiedStationLayoutStatus value, String label) {
+	}
+
+	record SourceTypeOption(StationLayoutSourceType value, String label) {
 	}
 
 	record RouteNodeRow(

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -4,6 +4,7 @@ import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.transit.application.port.out.SaveAccessibilityFacilityStatusPort;
 import com.easysubway.transit.application.port.out.SaveRouteEdgePort;
 import com.easysubway.transit.application.port.out.SaveRouteNodePort;
+import com.easysubway.transit.application.port.out.SaveStationLayoutSourcePort;
 import com.easysubway.transit.application.port.out.SaveSimplifiedStationLayoutStatusPort;
 import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
@@ -38,6 +39,7 @@ import org.springframework.stereotype.Repository;
 public class InMemoryTransitMasterRepository implements
 	LoadTransitMasterPort,
 	SaveAccessibilityFacilityStatusPort,
+	SaveStationLayoutSourcePort,
 	SaveSimplifiedStationLayoutStatusPort,
 	SaveRouteNodePort,
 	SaveRouteEdgePort {
@@ -226,12 +228,14 @@ public class InMemoryTransitMasterRepository implements
 	);
 
 	private final Map<String, AccessibilityFacility> accessibilityFacilities = new LinkedHashMap<>();
+	private final Map<String, StationLayoutSource> stationLayoutSources = new LinkedHashMap<>();
 	private final Map<String, SimplifiedStationLayout> simplifiedStationLayouts = new LinkedHashMap<>();
 	private final Map<String, RouteNode> routeNodes = new LinkedHashMap<>();
 	private final Map<String, RouteEdge> routeEdges = new LinkedHashMap<>();
 
 	public InMemoryTransitMasterRepository() {
 		seedAccessibilityFacilities();
+		seedStationLayoutSources();
 		seedSimplifiedStationLayouts();
 		seedRouteNodes();
 		seedRouteEdges();
@@ -269,7 +273,7 @@ public class InMemoryTransitMasterRepository implements
 
 	@Override
 	public List<StationLayoutSource> loadStationLayoutSources() {
-		return STATION_LAYOUT_SOURCES;
+		return List.copyOf(stationLayoutSources.values());
 	}
 
 	@Override
@@ -316,6 +320,11 @@ public class InMemoryTransitMasterRepository implements
 	@Override
 	public void saveAccessibilityFacility(AccessibilityFacility facility) {
 		accessibilityFacilities.put(facility.id(), facility);
+	}
+
+	@Override
+	public void saveStationLayoutSource(StationLayoutSource source) {
+		stationLayoutSources.put(source.id(), source);
 	}
 
 	@Override
@@ -414,6 +423,10 @@ public class InMemoryTransitMasterRepository implements
 
 	private void seedSimplifiedStationLayouts() {
 		SIMPLIFIED_STATION_LAYOUTS.forEach(layout -> simplifiedStationLayouts.put(layout.id(), layout));
+	}
+
+	private void seedStationLayoutSources() {
+		STATION_LAYOUT_SOURCES.forEach(source -> stationLayoutSources.put(source.id(), source));
 	}
 
 	private void seedRouteNodes() {

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterAdminUseCase.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterAdminUseCase.java
@@ -3,6 +3,7 @@ package com.easysubway.transit.application.port.in;
 import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteNode;
+import com.easysubway.transit.domain.StationLayoutSource;
 import com.easysubway.transit.domain.SimplifiedStationLayout;
 
 public interface TransitMasterAdminUseCase {
@@ -12,6 +13,8 @@ public interface TransitMasterAdminUseCase {
 	AccessibilityFacility updateAccessibilityFacility(UpdateAccessibilityFacilityCommand command);
 
 	AccessibilityFacility updateFacilityStatus(UpdateAccessibilityFacilityStatusCommand command);
+
+	StationLayoutSource updateStationLayoutSource(UpdateStationLayoutSourceCommand command);
 
 	SimplifiedStationLayout updateSimplifiedStationLayoutStatus(UpdateSimplifiedStationLayoutStatusCommand command);
 

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/UpdateStationLayoutSourceCommand.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/UpdateStationLayoutSourceCommand.java
@@ -1,0 +1,19 @@
+package com.easysubway.transit.application.port.in;
+
+import com.easysubway.transit.domain.StationLayoutSourceType;
+import java.time.LocalDate;
+
+public record UpdateStationLayoutSourceCommand(
+	String stationId,
+	String sourceId,
+	StationLayoutSourceType sourceType,
+	String sourceName,
+	String sourceUrl,
+	String license,
+	boolean commercialUseAllowed,
+	boolean attributionRequired,
+	LocalDate capturedAt,
+	LocalDate reviewedAt,
+	String updatedBy
+) {
+}

--- a/backend/src/main/java/com/easysubway/transit/application/port/out/SaveStationLayoutSourcePort.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/out/SaveStationLayoutSourcePort.java
@@ -1,0 +1,8 @@
+package com.easysubway.transit.application.port.out;
+
+import com.easysubway.transit.domain.StationLayoutSource;
+
+public interface SaveStationLayoutSourcePort {
+
+	void saveStationLayoutSource(StationLayoutSource source);
+}

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -11,12 +11,14 @@ import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilitySta
 import com.easysubway.transit.application.port.in.UpdateRouteEdgeCommand;
 import com.easysubway.transit.application.port.in.UpdateRouteNodeDisplayCommand;
 import com.easysubway.transit.application.port.in.UpdateSimplifiedStationLayoutStatusCommand;
+import com.easysubway.transit.application.port.in.UpdateStationLayoutSourceCommand;
 import com.easysubway.notification.application.port.in.FacilityStatusAlertUseCase;
 import com.easysubway.notification.application.port.in.FacilityStatusChangedAlertCommand;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.transit.application.port.out.SaveAccessibilityFacilityStatusPort;
 import com.easysubway.transit.application.port.out.SaveRouteEdgePort;
 import com.easysubway.transit.application.port.out.SaveRouteNodePort;
+import com.easysubway.transit.application.port.out.SaveStationLayoutSourcePort;
 import com.easysubway.transit.application.port.out.SaveSimplifiedStationLayoutStatusPort;
 import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.AccessibilityFacilityNotFoundException;
@@ -29,6 +31,7 @@ import com.easysubway.transit.domain.InvalidAccessibilityFacilityException;
 import com.easysubway.transit.domain.InvalidRouteEdgeException;
 import com.easysubway.transit.domain.InvalidRouteNodeException;
 import com.easysubway.transit.domain.InvalidSimplifiedStationLayoutException;
+import com.easysubway.transit.domain.InvalidStationLayoutSourceException;
 import com.easysubway.transit.domain.NearbyStation;
 import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteEdgeNotFoundException;
@@ -37,6 +40,7 @@ import com.easysubway.transit.domain.RouteNodeNotFoundException;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLayoutSource;
+import com.easysubway.transit.domain.StationLayoutSourceNotFoundException;
 import com.easysubway.transit.domain.StationLine;
 import com.easysubway.transit.domain.StationLineSummary;
 import com.easysubway.transit.domain.StationNotFoundException;
@@ -66,6 +70,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 
 	private final LoadTransitMasterPort loadTransitMasterPort;
 	private final SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort;
+	private final SaveStationLayoutSourcePort saveStationLayoutSourcePort;
 	private final SaveSimplifiedStationLayoutStatusPort saveSimplifiedStationLayoutStatusPort;
 	private final SaveRouteNodePort saveRouteNodePort;
 	private final SaveRouteEdgePort saveRouteEdgePort;
@@ -76,6 +81,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 	public TransitMasterService(
 		LoadTransitMasterPort loadTransitMasterPort,
 		SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort,
+		SaveStationLayoutSourcePort saveStationLayoutSourcePort,
 		SaveSimplifiedStationLayoutStatusPort saveSimplifiedStationLayoutStatusPort,
 		SaveRouteNodePort saveRouteNodePort,
 		SaveRouteEdgePort saveRouteEdgePort,
@@ -84,6 +90,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		this(
 			loadTransitMasterPort,
 			saveAccessibilityFacilityStatusPort,
+			saveStationLayoutSourcePort,
 			saveSimplifiedStationLayoutStatusPort,
 			saveRouteNodePort,
 			saveRouteEdgePort,
@@ -99,6 +106,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		this(
 			loadTransitMasterPort,
 			saveAccessibilityFacilityStatusPort,
+			stationLayoutSourcePortOrNoop(loadTransitMasterPort),
 			layoutStatusPortOrNoop(loadTransitMasterPort),
 			routeNodePortOrNoop(loadTransitMasterPort),
 			routeEdgePortOrNoop(loadTransitMasterPort),
@@ -116,6 +124,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		this(
 			loadTransitMasterPort,
 			saveAccessibilityFacilityStatusPort,
+			stationLayoutSourcePortOrNoop(loadTransitMasterPort),
 			layoutStatusPortOrNoop(loadTransitMasterPort),
 			routeNodePortOrNoop(loadTransitMasterPort),
 			routeEdgePortOrNoop(loadTransitMasterPort),
@@ -134,6 +143,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		this(
 			loadTransitMasterPort,
 			saveAccessibilityFacilityStatusPort,
+			stationLayoutSourcePortOrNoop(loadTransitMasterPort),
 			layoutStatusPortOrNoop(loadTransitMasterPort),
 			routeNodePortOrNoop(loadTransitMasterPort),
 			routeEdgePortOrNoop(loadTransitMasterPort),
@@ -145,6 +155,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 	public TransitMasterService(
 		LoadTransitMasterPort loadTransitMasterPort,
 		SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort,
+		SaveStationLayoutSourcePort saveStationLayoutSourcePort,
 		SaveSimplifiedStationLayoutStatusPort saveSimplifiedStationLayoutStatusPort,
 		SaveRouteNodePort saveRouteNodePort,
 		SaveRouteEdgePort saveRouteEdgePort,
@@ -153,6 +164,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 	) {
 		this.loadTransitMasterPort = loadTransitMasterPort;
 		this.saveAccessibilityFacilityStatusPort = saveAccessibilityFacilityStatusPort;
+		this.saveStationLayoutSourcePort = saveStationLayoutSourcePort;
 		this.saveSimplifiedStationLayoutStatusPort = saveSimplifiedStationLayoutStatusPort;
 		this.saveRouteNodePort = saveRouteNodePort;
 		this.saveRouteEdgePort = saveRouteEdgePort;
@@ -413,6 +425,20 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 	}
 
 	@Override
+	public StationLayoutSource updateStationLayoutSource(UpdateStationLayoutSourceCommand command) {
+		requireStationLayoutSource(command);
+		loadActiveStation(command.stationId());
+		StationLayoutSource source = loadStationLayoutSource(command.sourceId());
+		if (!source.stationId().equals(command.stationId())) {
+			throw new StationLayoutSourceNotFoundException();
+		}
+
+		StationLayoutSource updated = withStationLayoutSource(source, command);
+		saveStationLayoutSourcePort.saveStationLayoutSource(updated);
+		return updated;
+	}
+
+	@Override
 	public SimplifiedStationLayout updateSimplifiedStationLayoutStatus(UpdateSimplifiedStationLayoutStatusCommand command) {
 		requireLayoutStatus(command);
 		requireReviewer(command);
@@ -669,6 +695,36 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		}
 	}
 
+	private void requireStationLayoutSource(UpdateStationLayoutSourceCommand command) {
+		if (command.stationId() == null || command.stationId().isBlank()) {
+			throw new InvalidStationLayoutSourceException("역 식별자가 필요합니다.");
+		}
+		if (command.sourceId() == null || command.sourceId().isBlank()) {
+			throw new InvalidStationLayoutSourceException("기준 자료 식별자가 필요합니다.");
+		}
+		if (command.sourceType() == null) {
+			throw new InvalidStationLayoutSourceException("기준 자료 유형을 선택해야 합니다.");
+		}
+		if (command.sourceName() == null || command.sourceName().isBlank()) {
+			throw new InvalidStationLayoutSourceException("기준 자료 이름을 입력해야 합니다.");
+		}
+		if (command.sourceUrl() == null || command.sourceUrl().isBlank()) {
+			throw new InvalidStationLayoutSourceException("기준 자료 URL을 입력해야 합니다.");
+		}
+		if (command.license() == null || command.license().isBlank()) {
+			throw new InvalidStationLayoutSourceException("기준 자료 라이선스를 입력해야 합니다.");
+		}
+		if (command.capturedAt() == null) {
+			throw new InvalidStationLayoutSourceException("기준 자료 수집일을 입력해야 합니다.");
+		}
+		if (command.reviewedAt() != null && command.reviewedAt().isBefore(command.capturedAt())) {
+			throw new InvalidStationLayoutSourceException("기준 자료 검수일은 수집일보다 빠를 수 없습니다.");
+		}
+		if (command.updatedBy() == null || command.updatedBy().isBlank()) {
+			throw new InvalidStationLayoutSourceException("수정자 식별자가 필요합니다.");
+		}
+	}
+
 	private void requireReviewer(UpdateSimplifiedStationLayoutStatusCommand command) {
 		if (command.reviewedBy() == null || command.reviewedBy().isBlank()) {
 			throw new InvalidSimplifiedStationLayoutException("검수자 식별자가 필요합니다.");
@@ -729,6 +785,14 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 			.filter(layout -> layout.id().equals(layoutId))
 			.findFirst()
 			.orElseThrow(SimplifiedStationLayoutNotFoundException::new);
+	}
+
+	private StationLayoutSource loadStationLayoutSource(String sourceId) {
+		return loadTransitMasterPort.loadStationLayoutSources()
+			.stream()
+			.filter(source -> source.id().equals(sourceId))
+			.findFirst()
+			.orElseThrow(StationLayoutSourceNotFoundException::new);
 	}
 
 	private RouteNode loadRouteNode(String nodeId) {
@@ -800,6 +864,24 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		);
 	}
 
+	private StationLayoutSource withStationLayoutSource(
+		StationLayoutSource source,
+		UpdateStationLayoutSourceCommand command
+	) {
+		return new StationLayoutSource(
+			source.id(),
+			source.stationId(),
+			command.sourceType(),
+			command.sourceName(),
+			command.sourceUrl(),
+			command.license(),
+			command.commercialUseAllowed(),
+			command.attributionRequired(),
+			command.capturedAt(),
+			command.reviewedAt()
+		);
+	}
+
 	private RouteNode withRouteNodeDisplay(RouteNode routeNode, UpdateRouteNodeDisplayCommand command) {
 		return new RouteNode(
 			routeNode.id(),
@@ -844,6 +926,14 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 			return port;
 		}
 		return (layoutId, status, reviewedBy, updatedAt) -> {
+		};
+	}
+
+	private static SaveStationLayoutSourcePort stationLayoutSourcePortOrNoop(LoadTransitMasterPort loadTransitMasterPort) {
+		if (loadTransitMasterPort instanceof SaveStationLayoutSourcePort port) {
+			return port;
+		}
+		return source -> {
 		};
 	}
 

--- a/backend/src/main/java/com/easysubway/transit/domain/InvalidStationLayoutSourceException.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/InvalidStationLayoutSourceException.java
@@ -1,0 +1,10 @@
+package com.easysubway.transit.domain;
+
+import com.easysubway.common.error.InvalidRequestException;
+
+public class InvalidStationLayoutSourceException extends InvalidRequestException {
+
+	public InvalidStationLayoutSourceException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/domain/StationLayoutSourceNotFoundException.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/StationLayoutSourceNotFoundException.java
@@ -1,0 +1,10 @@
+package com.easysubway.transit.domain;
+
+import com.easysubway.common.error.ResourceNotFoundException;
+
+public class StationLayoutSourceNotFoundException extends ResourceNotFoundException {
+
+	public StationLayoutSourceNotFoundException() {
+		super("구조도 기준 자료 정보를 찾을 수 없습니다.");
+	}
+}

--- a/backend/src/main/resources/templates/admin/stations/layouts.html
+++ b/backend/src/main/resources/templates/admin/stations/layouts.html
@@ -140,7 +140,46 @@
 			</thead>
 			<tbody>
 			<tr th:each="source : ${layoutSources}">
-				<td th:text="${source.sourceName}">상록수역 역사 안내도</td>
+				<td>
+					<form th:action="@{/admin/stations/{stationId}/layout-sources/{sourceId}/page(stationId=${station.stationId}, sourceId=${source.id})}"
+					      method="post">
+						<label class="meta" th:for="|source-type-${source.id}|">자료 유형</label>
+						<select name="sourceType" th:id="|source-type-${source.id}|">
+							<option th:each="option : ${sourceTypeOptions}"
+							        th:value="${option.value}"
+							        th:text="${option.label}"
+							        th:selected="${option.value == source.sourceTypeValue}">OPERATOR_DIAGRAM</option>
+						</select>
+						<label class="meta" th:for="|source-name-${source.id}|">자료 이름</label>
+						<input type="text" name="sourceName" th:id="|source-name-${source.id}|"
+						       th:value="${source.sourceName}" required>
+						<label class="meta" th:for="|source-url-${source.id}|">자료 URL</label>
+						<input type="url" name="sourceUrl" th:id="|source-url-${source.id}|"
+						       th:value="${source.sourceUrl}" required>
+						<label class="meta" th:for="|source-license-${source.id}|">라이선스</label>
+						<input type="text" name="license" th:id="|source-license-${source.id}|"
+						       th:value="${source.license}" required>
+						<label class="meta" th:for="|commercial-use-${source.id}|">상업적 이용</label>
+						<select name="commercialUseAllowed" th:id="|commercial-use-${source.id}|">
+							<option value="false" th:selected="${!source.commercialUseAllowed}">불가</option>
+							<option value="true" th:selected="${source.commercialUseAllowed}">가능</option>
+						</select>
+						<label class="meta" th:for="|attribution-${source.id}|">출처 표시</label>
+						<select name="attributionRequired" th:id="|attribution-${source.id}|">
+							<option value="true" th:selected="${source.attributionRequired}">필요</option>
+							<option value="false" th:selected="${!source.attributionRequired}">불필요</option>
+						</select>
+						<label class="meta" th:for="|captured-at-${source.id}|">수집일</label>
+						<input type="date" name="capturedAt" th:id="|captured-at-${source.id}|"
+						       th:value="${source.capturedAt}" required>
+						<label class="meta" th:for="|reviewed-at-${source.id}|">검수일</label>
+						<input type="date" name="reviewedAt" th:id="|reviewed-at-${source.id}|"
+						       th:value="${source.rawReviewedAt}">
+						<button type="submit">저장</button>
+					</form>
+					<span class="meta" th:text="${source.sourceName}">상록수역 역사 안내도</span>
+					<span class="meta" th:text="${source.sourceUrl}">https://www.seoulmetro.co.kr</span>
+				</td>
 				<td th:text="${source.sourceType}">OPERATOR_DIAGRAM</td>
 				<td th:text="${source.license}">운영기관 안내도 확인용</td>
 				<td>

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -332,6 +332,157 @@ class TransitMasterControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 구조도 기준 자료의 출처와 이용 조건과 검수일을 수정한다")
+	@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+	void adminUpdatesStationLayoutSourceMetadataAndListReflectsIt() throws Exception {
+		mockMvc.perform(patch("/admin/stations/station-sangnoksu/layout-sources/layout-source-sangnoksu-station-map")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "sourceType": "OPERATOR_PAGE",
+					  "sourceName": "상록수역 운영기관 안내 페이지",
+					  "sourceUrl": "https://www.seoulmetro.co.kr/station/sangnoksu",
+					  "license": "운영기관 페이지 확인용",
+					  "commercialUseAllowed": true,
+					  "attributionRequired": false,
+					  "capturedAt": "2026-06-13",
+					  "reviewedAt": "2026-06-14"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.id").value("layout-source-sangnoksu-station-map"))
+			.andExpect(jsonPath("$.data.sourceType").value("OPERATOR_PAGE"))
+			.andExpect(jsonPath("$.data.sourceName").value("상록수역 운영기관 안내 페이지"))
+			.andExpect(jsonPath("$.data.sourceUrl").value("https://www.seoulmetro.co.kr/station/sangnoksu"))
+			.andExpect(jsonPath("$.data.license").value("운영기관 페이지 확인용"))
+			.andExpect(jsonPath("$.data.commercialUseAllowed").value(true))
+			.andExpect(jsonPath("$.data.attributionRequired").value(false))
+			.andExpect(jsonPath("$.data.capturedAt").value("2026-06-13"))
+			.andExpect(jsonPath("$.data.reviewedAt").value("2026-06-14"));
+
+		mockMvc.perform(get("/admin/stations/station-sangnoksu/layout-sources")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data[0].sourceName").value("상록수역 운영기관 안내 페이지"))
+			.andExpect(jsonPath("$.data[0].commercialUseAllowed").value(true))
+			.andExpect(jsonPath("$.data[0].attributionRequired").value(false))
+			.andExpect(jsonPath("$.data[0].reviewedAt").value("2026-06-14"));
+	}
+
+	@Test
+	@DisplayName("구조도 기준 자료 수정 API는 관리자 인증을 요구한다")
+	void updateStationLayoutSourceMetadataRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(patch("/admin/stations/station-sangnoksu/layout-sources/layout-source-sangnoksu-station-map")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "sourceType": "OPERATOR_PAGE",
+					  "sourceName": "상록수역 운영기관 안내 페이지",
+					  "sourceUrl": "https://www.seoulmetro.co.kr/station/sangnoksu",
+					  "license": "운영기관 페이지 확인용",
+					  "commercialUseAllowed": true,
+					  "attributionRequired": false,
+					  "capturedAt": "2026-06-13",
+					  "reviewedAt": "2026-06-14"
+					}
+					"""))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(patch("/admin/stations/station-sangnoksu/layout-sources/layout-source-sangnoksu-station-map")
+				.with(httpBasic("basic-user", "user-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "sourceType": "OPERATOR_PAGE",
+					  "sourceName": "상록수역 운영기관 안내 페이지",
+					  "sourceUrl": "https://www.seoulmetro.co.kr/station/sangnoksu",
+					  "license": "운영기관 페이지 확인용",
+					  "commercialUseAllowed": true,
+					  "attributionRequired": false,
+					  "capturedAt": "2026-06-13",
+					  "reviewedAt": "2026-06-14"
+					}
+					"""))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("구조도 기준 자료 수정은 필수 값과 검수일 범위를 요구한다")
+	void updateStationLayoutSourceMetadataRequiresValidInputs() throws Exception {
+		mockMvc.perform(patch("/admin/stations/station-sangnoksu/layout-sources/layout-source-sangnoksu-station-map")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "sourceType": "OPERATOR_PAGE",
+					  "sourceName": " ",
+					  "sourceUrl": "https://www.seoulmetro.co.kr/station/sangnoksu",
+					  "license": "운영기관 페이지 확인용",
+					  "commercialUseAllowed": true,
+					  "attributionRequired": false,
+					  "capturedAt": "2026-06-13",
+					  "reviewedAt": "2026-06-14"
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("기준 자료 이름을 입력해야 합니다."));
+
+		mockMvc.perform(patch("/admin/stations/station-sangnoksu/layout-sources/layout-source-sangnoksu-station-map")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "sourceType": "OPERATOR_PAGE",
+					  "sourceName": "상록수역 운영기관 안내 페이지",
+					  "sourceUrl": "https://www.seoulmetro.co.kr/station/sangnoksu",
+					  "license": "운영기관 페이지 확인용",
+					  "commercialUseAllowed": true,
+					  "attributionRequired": false,
+					  "capturedAt": "2026-06-13",
+					  "reviewedAt": "2026-06-12"
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("기준 자료 검수일은 수집일보다 빠를 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("구조도 기준 자료 수정은 URL 역과 기준 자료 소속이 일치해야 한다")
+	void updateStationLayoutSourceMetadataRequiresSourceInStation() throws Exception {
+		mockMvc.perform(patch("/admin/stations/station-sadang/layout-sources/layout-source-sangnoksu-station-map")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "sourceType": "OPERATOR_PAGE",
+					  "sourceName": "상록수역 운영기관 안내 페이지",
+					  "sourceUrl": "https://www.seoulmetro.co.kr/station/sangnoksu",
+					  "license": "운영기관 페이지 확인용",
+					  "commercialUseAllowed": true,
+					  "attributionRequired": false,
+					  "capturedAt": "2026-06-13",
+					  "reviewedAt": "2026-06-14"
+					}
+					"""))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("구조도 기준 자료 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
 	@DisplayName("존재하지 않는 역의 구조도 기준 자료는 공통 404 응답을 반환한다")
 	void missingStationLayoutSourcesReturnCommonErrorResponse() throws Exception {
 		mockMvc.perform(get("/admin/stations/unknown-station/layout-sources")

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageControllerTest.java
@@ -50,6 +50,14 @@ class TransitStationLayoutAdminPageControllerTest {
 			.contains("운영기관 안내도 확인용")
 			.contains("상업적 사용 불가")
 			.contains("출처 표시 필요")
+			.contains("name=\"sourceType\"")
+			.contains("name=\"sourceName\"")
+			.contains("name=\"sourceUrl\"")
+			.contains("name=\"license\"")
+			.contains("name=\"commercialUseAllowed\"")
+			.contains("name=\"attributionRequired\"")
+			.contains("name=\"capturedAt\"")
+			.contains("name=\"reviewedAt\"")
 			.contains("쉬운 내부 구조도")
 			.contains("DRAFT")
 			.contains("OFFICIAL_DIAGRAM_REFERENCED")
@@ -108,6 +116,40 @@ class TransitStationLayoutAdminPageControllerTest {
 		assertThat(html)
 			.contains("layout-sangnoksu-draft")
 			.contains("READY_FOR_REVIEW");
+	}
+
+	@Test
+	@DisplayName("관리자는 역 구조도 화면에서 기준 자료 정보를 변경한다")
+	@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+	void adminUpdatesStationLayoutSourceMetadataFromPageAndRedirectsToLayoutPage() throws Exception {
+		mockMvc.perform(post("/admin/stations/station-sangnoksu/layout-sources/layout-source-sangnoksu-station-map/page")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("sourceType", "OPERATOR_PAGE")
+				.param("sourceName", "상록수역 운영기관 안내 페이지")
+				.param("sourceUrl", "https://www.seoulmetro.co.kr/station/sangnoksu")
+				.param("license", "운영기관 페이지 확인용")
+				.param("commercialUseAllowed", "true")
+				.param("attributionRequired", "false")
+				.param("capturedAt", "2026-06-13")
+				.param("reviewedAt", "2026-06-14"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(header().string("Location", "/admin/stations/station-sangnoksu/layouts/page"));
+
+		String html = mockMvc.perform(get("/admin/stations/station-sangnoksu/layouts/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("상록수역 운영기관 안내 페이지")
+			.contains("운영기관 페이지 확인용")
+			.contains("상업적 사용 가능")
+			.contains("출처 표시 불필요")
+			.contains("2026-06-14");
 	}
 
 	@Test
@@ -226,6 +268,33 @@ class TransitStationLayoutAdminPageControllerTest {
 				.param("status", "READY_FOR_REVIEW"))
 			.andExpect(status().isForbidden());
 
+		mockMvc.perform(post("/admin/stations/station-sangnoksu/layout-sources/layout-source-sangnoksu-station-map/page")
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("sourceType", "OPERATOR_PAGE")
+				.param("sourceName", "상록수역 운영기관 안내 페이지")
+				.param("sourceUrl", "https://www.seoulmetro.co.kr/station/sangnoksu")
+				.param("license", "운영기관 페이지 확인용")
+				.param("commercialUseAllowed", "true")
+				.param("attributionRequired", "false")
+				.param("capturedAt", "2026-06-13")
+				.param("reviewedAt", "2026-06-14"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(post("/admin/stations/station-sangnoksu/layout-sources/layout-source-sangnoksu-station-map/page")
+				.with(httpBasic("basic-user", "user-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("sourceType", "OPERATOR_PAGE")
+				.param("sourceName", "상록수역 운영기관 안내 페이지")
+				.param("sourceUrl", "https://www.seoulmetro.co.kr/station/sangnoksu")
+				.param("license", "운영기관 페이지 확인용")
+				.param("commercialUseAllowed", "true")
+				.param("attributionRequired", "false")
+				.param("capturedAt", "2026-06-13")
+				.param("reviewedAt", "2026-06-14"))
+			.andExpect(status().isForbidden());
+
 		mockMvc.perform(post("/admin/stations/station-sangnoksu/route-nodes/node-sangnoksu-elevator-1/page")
 				.with(csrf())
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
@@ -298,6 +367,27 @@ class TransitStationLayoutAdminPageControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.data").doesNotExist())
 			.andExpect(jsonPath("$.message").value("내부 이동 노드 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("역 구조도 기준 자료 변경은 URL 역과 기준 자료 소속이 일치해야 한다")
+	void stationLayoutSourceUpdateRequiresSourceInStation() throws Exception {
+		mockMvc.perform(post("/admin/stations/station-sadang/layout-sources/layout-source-sangnoksu-station-map/page")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("sourceType", "OPERATOR_PAGE")
+				.param("sourceName", "상록수역 운영기관 안내 페이지")
+				.param("sourceUrl", "https://www.seoulmetro.co.kr/station/sangnoksu")
+				.param("license", "운영기관 페이지 확인용")
+				.param("commercialUseAllowed", "true")
+				.param("attributionRequired", "false")
+				.param("capturedAt", "2026-06-13")
+				.param("reviewedAt", "2026-06-14"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("구조도 기준 자료 정보를 찾을 수 없습니다."));
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -11,6 +11,7 @@ import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilitySta
 import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilityCommand;
 import com.easysubway.transit.application.port.in.UpdateRouteEdgeCommand;
 import com.easysubway.transit.application.port.in.UpdateRouteNodeDisplayCommand;
+import com.easysubway.transit.application.port.in.UpdateStationLayoutSourceCommand;
 import com.easysubway.transit.application.port.in.UpdateSimplifiedStationLayoutStatusCommand;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.notification.application.port.in.FacilityStatusAlertUseCase;
@@ -25,6 +26,7 @@ import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.InvalidAccessibilityFacilityException;
 import com.easysubway.transit.domain.InvalidRouteEdgeException;
 import com.easysubway.transit.domain.InvalidRouteNodeException;
+import com.easysubway.transit.domain.InvalidStationLayoutSourceException;
 import com.easysubway.transit.domain.InvalidSimplifiedStationLayoutException;
 import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteEdgeNotFoundException;
@@ -36,6 +38,7 @@ import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLine;
 import com.easysubway.transit.domain.StationLayoutSource;
+import com.easysubway.transit.domain.StationLayoutSourceNotFoundException;
 import com.easysubway.transit.domain.StationLayoutSourceType;
 import com.easysubway.transit.domain.StationNotFoundException;
 import com.easysubway.transit.domain.SimplifiedStationLayout;
@@ -267,6 +270,116 @@ class TransitMasterServiceTest {
 		assertThat(sources.getFirst().commercialUseAllowed()).isFalse();
 		assertThat(sources.getFirst().attributionRequired()).isTrue();
 		assertThat(sources.getFirst().reviewedAt()).isEqualTo(LocalDate.of(2026, 6, 12));
+	}
+
+	@Test
+	@DisplayName("관리자는 구조도 기준 자료의 출처와 이용 조건과 검수일을 수정한다")
+	void updateStationLayoutSourceStoresSourceMetadata() {
+		var repository = new InMemoryTransitMasterRepository();
+		var service = new TransitMasterService(repository, repository);
+
+		var updated = service.updateStationLayoutSource(new UpdateStationLayoutSourceCommand(
+			"station-sangnoksu",
+			"layout-source-sangnoksu-station-map",
+			StationLayoutSourceType.OPERATOR_PAGE,
+			"상록수역 운영기관 안내 페이지",
+			"https://www.seoulmetro.co.kr/station/sangnoksu",
+			"운영기관 페이지 확인용",
+			true,
+			false,
+			LocalDate.of(2026, 6, 13),
+			LocalDate.of(2026, 6, 14),
+			"admin-user"
+		));
+
+		assertThat(updated.sourceType()).isEqualTo(StationLayoutSourceType.OPERATOR_PAGE);
+		assertThat(updated.sourceName()).isEqualTo("상록수역 운영기관 안내 페이지");
+		assertThat(updated.sourceUrl()).isEqualTo("https://www.seoulmetro.co.kr/station/sangnoksu");
+		assertThat(updated.license()).isEqualTo("운영기관 페이지 확인용");
+		assertThat(updated.commercialUseAllowed()).isTrue();
+		assertThat(updated.attributionRequired()).isFalse();
+		assertThat(updated.capturedAt()).isEqualTo(LocalDate.of(2026, 6, 13));
+		assertThat(updated.reviewedAt()).isEqualTo(LocalDate.of(2026, 6, 14));
+		assertThat(service.listStationLayoutSources("station-sangnoksu").getFirst().sourceName())
+			.isEqualTo("상록수역 운영기관 안내 페이지");
+	}
+
+	@Test
+	@DisplayName("구조도 기준 자료 수정은 필수 값과 검수일 범위와 관리자 식별자를 요구한다")
+	void updateStationLayoutSourceRequiresValidInputsAndUpdater() {
+		var repository = new InMemoryTransitMasterRepository();
+		var service = new TransitMasterService(repository, repository);
+
+		assertThatThrownBy(() -> service.updateStationLayoutSource(new UpdateStationLayoutSourceCommand(
+			"station-sangnoksu",
+			"layout-source-sangnoksu-station-map",
+			StationLayoutSourceType.OPERATOR_PAGE,
+			" ",
+			"https://www.seoulmetro.co.kr/station/sangnoksu",
+			"운영기관 페이지 확인용",
+			true,
+			false,
+			LocalDate.of(2026, 6, 13),
+			LocalDate.of(2026, 6, 14),
+			"admin-user"
+		)))
+			.isInstanceOf(InvalidStationLayoutSourceException.class)
+			.hasMessage("기준 자료 이름을 입력해야 합니다.");
+
+		assertThatThrownBy(() -> service.updateStationLayoutSource(new UpdateStationLayoutSourceCommand(
+			"station-sangnoksu",
+			"layout-source-sangnoksu-station-map",
+			StationLayoutSourceType.OPERATOR_PAGE,
+			"상록수역 운영기관 안내 페이지",
+			"https://www.seoulmetro.co.kr/station/sangnoksu",
+			"운영기관 페이지 확인용",
+			true,
+			false,
+			LocalDate.of(2026, 6, 13),
+			LocalDate.of(2026, 6, 12),
+			"admin-user"
+		)))
+			.isInstanceOf(InvalidStationLayoutSourceException.class)
+			.hasMessage("기준 자료 검수일은 수집일보다 빠를 수 없습니다.");
+
+		assertThatThrownBy(() -> service.updateStationLayoutSource(new UpdateStationLayoutSourceCommand(
+			"station-sangnoksu",
+			"layout-source-sangnoksu-station-map",
+			StationLayoutSourceType.OPERATOR_PAGE,
+			"상록수역 운영기관 안내 페이지",
+			"https://www.seoulmetro.co.kr/station/sangnoksu",
+			"운영기관 페이지 확인용",
+			true,
+			false,
+			LocalDate.of(2026, 6, 13),
+			LocalDate.of(2026, 6, 14),
+			""
+		)))
+			.isInstanceOf(InvalidStationLayoutSourceException.class)
+			.hasMessage("수정자 식별자가 필요합니다.");
+	}
+
+	@Test
+	@DisplayName("구조도 기준 자료 수정은 URL 역과 기준 자료 소속이 일치해야 한다")
+	void updateStationLayoutSourceRequiresSourceInStation() {
+		var repository = new InMemoryTransitMasterRepository();
+		var service = new TransitMasterService(repository, repository);
+
+		assertThatThrownBy(() -> service.updateStationLayoutSource(new UpdateStationLayoutSourceCommand(
+			"station-sadang",
+			"layout-source-sangnoksu-station-map",
+			StationLayoutSourceType.OPERATOR_PAGE,
+			"상록수역 운영기관 안내 페이지",
+			"https://www.seoulmetro.co.kr/station/sangnoksu",
+			"운영기관 페이지 확인용",
+			true,
+			false,
+			LocalDate.of(2026, 6, 13),
+			LocalDate.of(2026, 6, 14),
+			"admin-user"
+		)))
+			.isInstanceOf(StationLayoutSourceNotFoundException.class)
+			.hasMessage("구조도 기준 자료 정보를 찾을 수 없습니다.");
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

close #405

## 작업 배경

- 관리자 구조도 화면에서 기준 자료의 출처, URL, 라이선스, 이용 조건, 수집일, 검수일을 바로 보정할 수 없어 운영자가 잘못된 기준 자료 정보를 코드 변경 없이 정정하기 어렵다.
- 구조도 신뢰도와 저작권 판단에 직접 쓰이는 메타데이터이므로 API와 관리자 화면에서 같은 검증 규칙으로 수정해야 한다.

## 작업 내용

- 관리자 API에 역별 구조도 기준 자료 수정 엔드포인트를 추가했다.
- 관리자 구조도 화면의 기준 자료 목록에 수정 폼을 추가해 유형, 이름, URL, 라이선스, 상업적 이용 가능 여부, 출처 표시 필요 여부, 수집일, 검수일을 변경할 수 있게 했다.
- 기준 자료가 URL의 역에 속하지 않으면 404를 반환하고, 필수 값과 검수일 범위를 서비스 계층에서 검증한다.
- 인메모리 마스터데이터 저장소에 기준 자료 저장 포트를 추가해 수정 후 조회 목록에 즉시 반영되도록 했다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공, 43개 테스트 통과
  - `backend/gradlew -p backend test` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`

## 리뷰어 메모

- `TransitMasterService#updateStationLayoutSource`의 필수 값 검증, 역 소속 검증, 저장 포트 호출 흐름을 먼저 확인하면 된다.
- 관리자 HTML 폼은 기존 구조도 상태/노드/간선 수정 화면과 같은 페이지 리다이렉트 흐름을 따른다.
- CodeRabbit이 완료되지 않아 Codex CLI fallback review를 PR review #4525254702로 남겼고 지적은 0건이다.

## 리스크

- 현재 저장 포트는 인메모리 저장소 기준으로 동작하므로 운영 DB 영속화 어댑터가 추가될 때 같은 포트를 구현해야 한다.
- 기준 자료 생성/삭제와 원본 이미지 업로드는 이번 변경 범위에 포함하지 않았다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
