### PR TITLE
[Feat] 역 내부 이동 경로 계산 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -3,8 +3,10 @@ package com.easysubway.route.adapter.in.web;
 import com.easysubway.common.web.ApiResponse;
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
+import com.easysubway.route.application.port.in.SearchInternalRouteCommand;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
+import com.easysubway.route.domain.InternalRouteResult;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteFeedbackRating;
 import com.easysubway.route.domain.RouteSearchResult;
@@ -29,6 +31,11 @@ class RouteSearchController {
 		return ApiResponse.ok(routeSearchUseCase.searchRoute(request.toCommand()));
 	}
 
+	@PostMapping("/api/v1/routes/internal")
+	ApiResponse<InternalRouteResult> searchInternalRoute(@RequestBody SearchInternalRouteRequest request) {
+		return ApiResponse.ok(routeSearchUseCase.searchInternalRoute(request.toCommand()));
+	}
+
 	@GetMapping("/api/v1/routes/{routeSearchId}")
 	ApiResponse<RouteSearchResult> getRouteSearch(@PathVariable String routeSearchId) {
 		return ApiResponse.ok(routeSearchUseCase.getRouteSearch(routeSearchId));
@@ -50,6 +57,18 @@ class RouteSearchController {
 
 		SearchRouteCommand toCommand() {
 			return new SearchRouteCommand(originStationId, destinationStationId, mobilityType);
+		}
+	}
+
+	record SearchInternalRouteRequest(
+		String stationId,
+		String fromNodeId,
+		String toNodeId,
+		MobilityType mobilityType
+	) {
+
+		SearchInternalRouteCommand toCommand() {
+			return new SearchInternalRouteCommand(stationId, fromNodeId, toNodeId, mobilityType);
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
@@ -1,11 +1,14 @@
 package com.easysubway.route.application.port.in;
 
+import com.easysubway.route.domain.InternalRouteResult;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteSearchResult;
 
 public interface RouteSearchUseCase {
 
 	RouteSearchResult searchRoute(SearchRouteCommand command);
+
+	InternalRouteResult searchInternalRoute(SearchInternalRouteCommand command);
 
 	RouteSearchResult getRouteSearch(String routeSearchId);
 

--- a/backend/src/main/java/com/easysubway/route/application/port/in/SearchInternalRouteCommand.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/SearchInternalRouteCommand.java
@@ -1,0 +1,11 @@
+package com.easysubway.route.application.port.in;
+
+import com.easysubway.profile.domain.MobilityType;
+
+public record SearchInternalRouteCommand(
+	String stationId,
+	String fromNodeId,
+	String toNodeId,
+	MobilityType mobilityType
+) {
+}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -188,7 +188,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			edges,
 			fromNode.id(),
 			toNode.id(),
-			edge -> isAllowedInternalEdge(station.id(), edge, profileWeight)
+			edge -> isAllowedInternalEdge(station.id(), edge, profileWeight, nodesById)
 		);
 		if (path.isEmpty()) {
 			if (profileWeight.blocksStairOnlyAccess() && hasAnyInternalPath(edges, fromNode.id(), toNode.id())) {
@@ -450,13 +450,37 @@ public class RouteSearchService implements RouteSearchUseCase {
 		if (activeStationEdges.isEmpty()) {
 			return Optional.empty();
 		}
+		Optional<Map<String, RouteNode>> nodesById = stationRouteNodesByIdIfSupported(stationId);
+		if (nodesById.isEmpty()) {
+			return Optional.empty();
+		}
+		List<RouteEdge> edgesWithNodes = activeStationEdges.stream()
+			.filter(edge -> nodesById.get().containsKey(edge.fromNodeId()) && nodesById.get().containsKey(edge.toNodeId()))
+			.toList();
+		if (edgesWithNodes.isEmpty()) {
+			return Optional.empty();
+		}
 		// 내부 이동 간선 데이터가 있으면 출구 요약보다 실제 승강장 연결 동선을 우선한다.
-		boolean hasUsableStepFreeInternalEdge = activeStationEdges.stream()
-			.anyMatch(edge -> isUsableStepFreeInternalEdge(stationId, edge));
+		boolean hasUsableStepFreeInternalEdge = edgesWithNodes.stream()
+			.anyMatch(edge -> isUsableStepFreeInternalEdge(stationId, edge, nodesById.get()));
 		return Optional.of(!hasUsableStepFreeInternalEdge);
 	}
 
-	private boolean isUsableStepFreeInternalEdge(String stationId, RouteEdge edge) {
+	private Optional<Map<String, RouteNode>> stationRouteNodesByIdIfSupported(String stationId) {
+		try {
+			return Optional.of(stationRouteNodes(stationId)
+				.stream()
+				.collect(Collectors.toMap(RouteNode::id, Function.identity())));
+		} catch (UnsupportedOperationException ignored) {
+			return Optional.empty();
+		}
+	}
+
+	private boolean isUsableStepFreeInternalEdge(
+		String stationId,
+		RouteEdge edge,
+		Map<String, RouteNode> nodesById
+	) {
 		if (edge.hasStairs()) {
 			return false;
 		}
@@ -464,7 +488,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			return false;
 		}
 		if (edge.requiresElevator()) {
-			return hasUsableStepFreeFacility(stationId);
+			return hasUsableStepFreeFacilityForInternalEdge(stationId, edge, nodesById);
 		}
 		return true;
 	}
@@ -562,14 +586,48 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.toList();
 	}
 
-	private boolean isAllowedInternalEdge(String stationId, RouteEdge edge, RouteProfileWeight profileWeight) {
+	private boolean isAllowedInternalEdge(
+		String stationId,
+		RouteEdge edge,
+		RouteProfileWeight profileWeight,
+		Map<String, RouteNode> nodesById
+	) {
 		if (!profileWeight.blocksStairOnlyAccess()) {
 			return true;
 		}
 		if (edge.hasStairs() || edge.requiresEscalator()) {
 			return false;
 		}
-		return !edge.requiresElevator() || hasUsableStepFreeFacility(stationId);
+		return !edge.requiresElevator() || hasUsableStepFreeFacilityForInternalEdge(stationId, edge, nodesById);
+	}
+
+	private boolean hasUsableStepFreeFacilityForInternalEdge(
+		String stationId,
+		RouteEdge edge,
+		Map<String, RouteNode> nodesById
+	) {
+		List<String> facilityIds = internalEdgeFacilityIds(edge, nodesById);
+		if (facilityIds.isEmpty()) {
+			return false;
+		}
+		return stationFacilities(stationId).stream()
+			.filter(facility -> facilityIds.contains(facility.id()))
+			.filter(facility -> facility.dataConfidence() == DataConfidenceLevel.HIGH)
+			.filter(this::isStepFreeFacility)
+			.anyMatch(this::hasUsableStatus);
+	}
+
+	private List<String> internalEdgeFacilityIds(RouteEdge edge, Map<String, RouteNode> nodesById) {
+		List<String> facilityIds = new ArrayList<>();
+		addFacilityId(facilityIds, nodesById.get(edge.fromNodeId()));
+		addFacilityId(facilityIds, nodesById.get(edge.toNodeId()));
+		return List.copyOf(facilityIds);
+	}
+
+	private void addFacilityId(List<String> facilityIds, RouteNode node) {
+		if (node != null && node.facilityId() != null) {
+			facilityIds.add(node.facilityId());
+		}
 	}
 
 	private Optional<List<RouteEdge>> findInternalRoutePath(

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -1,11 +1,15 @@
 package com.easysubway.route.application.service;
 
+import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
+import com.easysubway.route.application.port.in.SearchInternalRouteCommand;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
 import com.easysubway.route.application.port.out.LoadRouteSearchPort;
 import com.easysubway.route.application.port.out.SaveRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
+import com.easysubway.route.domain.InternalRouteResult;
+import com.easysubway.route.domain.InternalRouteStep;
 import com.easysubway.route.domain.InvalidRouteFeedbackException;
 import com.easysubway.route.domain.InvalidRouteSearchException;
 import com.easysubway.route.domain.RouteFeedback;
@@ -24,6 +28,7 @@ import com.easysubway.transit.domain.AccessibilityFacilityType;
 import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteEdgeType;
+import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLine;
@@ -38,6 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.PriorityQueue;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -164,6 +170,53 @@ public class RouteSearchService implements RouteSearchUseCase {
 	}
 
 	@Override
+	public InternalRouteResult searchInternalRoute(SearchInternalRouteCommand command) {
+		requireInternalRouteCommand(command);
+		Station station = loadActiveStation(command.stationId());
+		Map<String, RouteNode> nodesById = stationRouteNodes(station.id())
+			.stream()
+			.collect(Collectors.toMap(RouteNode::id, Function.identity()));
+		RouteNode fromNode = loadStationRouteNode(nodesById, command.fromNodeId());
+		RouteNode toNode = loadStationRouteNode(nodesById, command.toNodeId());
+		if (fromNode.id().equals(toNode.id())) {
+			throw new InvalidRouteSearchException("출발 노드와 도착 노드가 달라야 합니다.");
+		}
+
+		RouteProfileWeight profileWeight = RouteProfileWeight.from(command.mobilityType());
+		List<RouteEdge> edges = stationInternalRouteEdges(station.id(), nodesById);
+		Optional<List<RouteEdge>> path = findInternalRoutePath(
+			edges,
+			fromNode.id(),
+			toNode.id(),
+			edge -> isAllowedInternalEdge(station.id(), edge, profileWeight)
+		);
+		if (path.isEmpty()) {
+			if (profileWeight.blocksStairOnlyAccess() && hasAnyInternalPath(edges, fromNode.id(), toNode.id())) {
+				return blockedInternalRoute(station, fromNode, toNode, command.mobilityType());
+			}
+			throw new RouteNotFoundException();
+		}
+
+		List<InternalRouteStep> steps = internalRouteSteps(path.get(), nodesById);
+		List<RouteWarning> warnings = internalRouteWarnings(steps);
+		return new InternalRouteResult(
+			station.id(),
+			station.nameKo(),
+			fromNode.id(),
+			fromNode.name(),
+			toNode.id(),
+			toNode.name(),
+			command.mobilityType(),
+			RouteSearchStatus.FOUND,
+			steps.stream().mapToInt(InternalRouteStep::distanceMeters).sum(),
+			steps.stream().mapToInt(InternalRouteStep::estimatedSeconds).sum(),
+			steps,
+			warnings,
+			List.of()
+		);
+	}
+
+	@Override
 	public RouteSearchResult getRouteSearch(String routeSearchId) {
 		if (routeSearchId == null || routeSearchId.isBlank()) {
 			throw new RouteSearchNotFoundException();
@@ -195,6 +248,21 @@ public class RouteSearchService implements RouteSearchUseCase {
 		}
 		if (command.destinationStationId() == null || command.destinationStationId().isBlank()) {
 			throw new InvalidRouteSearchException("도착역을 선택해야 합니다.");
+		}
+		if (command.mobilityType() == null) {
+			throw new InvalidRouteSearchException("이동 유형을 선택해야 합니다.");
+		}
+	}
+
+	private void requireInternalRouteCommand(SearchInternalRouteCommand command) {
+		if (command.stationId() == null || command.stationId().isBlank()) {
+			throw new InvalidRouteSearchException("역을 선택해야 합니다.");
+		}
+		if (command.fromNodeId() == null || command.fromNodeId().isBlank()) {
+			throw new InvalidRouteSearchException("출발 노드를 선택해야 합니다.");
+		}
+		if (command.toNodeId() == null || command.toNodeId().isBlank()) {
+			throw new InvalidRouteSearchException("도착 노드를 선택해야 합니다.");
 		}
 		if (command.mobilityType() == null) {
 			throw new InvalidRouteSearchException("이동 유형을 선택해야 합니다.");
@@ -469,6 +537,177 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.toList();
 	}
 
+	private List<RouteNode> stationRouteNodes(String stationId) {
+		return loadTransitMasterPort.loadRouteNodes()
+			.stream()
+			.filter(node -> node.stationId().equals(stationId))
+			.toList();
+	}
+
+	private RouteNode loadStationRouteNode(Map<String, RouteNode> nodesById, String nodeId) {
+		RouteNode node = nodesById.get(nodeId);
+		if (node == null) {
+			throw new RouteNotFoundException();
+		}
+		return node;
+	}
+
+	private List<RouteEdge> stationInternalRouteEdges(String stationId, Map<String, RouteNode> nodesById) {
+		return loadTransitMasterPort.loadRouteEdges()
+			.stream()
+			.filter(RouteEdge::active)
+			.filter(edge -> edge.stationId().equals(stationId))
+			.filter(this::isInternalMovementEdge)
+			.filter(edge -> nodesById.containsKey(edge.fromNodeId()) && nodesById.containsKey(edge.toNodeId()))
+			.toList();
+	}
+
+	private boolean isAllowedInternalEdge(String stationId, RouteEdge edge, RouteProfileWeight profileWeight) {
+		if (!profileWeight.blocksStairOnlyAccess()) {
+			return true;
+		}
+		if (edge.hasStairs() || edge.requiresEscalator()) {
+			return false;
+		}
+		return !edge.requiresElevator() || hasUsableStepFreeFacility(stationId);
+	}
+
+	private Optional<List<RouteEdge>> findInternalRoutePath(
+		List<RouteEdge> edges,
+		String fromNodeId,
+		String toNodeId,
+		Predicate<RouteEdge> edgeFilter
+	) {
+		Map<String, List<RouteEdge>> edgesByFromNode = edges.stream()
+			.filter(edgeFilter)
+			.collect(Collectors.groupingBy(RouteEdge::fromNodeId));
+		PriorityQueue<InternalRouteCandidate> queue = new PriorityQueue<>(
+			Comparator.comparingInt(InternalRouteCandidate::cost)
+		);
+		Map<String, Integer> bestCostByNodeId = new HashMap<>();
+		queue.add(new InternalRouteCandidate(fromNodeId, 0, List.of()));
+		bestCostByNodeId.put(fromNodeId, 0);
+
+		while (!queue.isEmpty()) {
+			InternalRouteCandidate current = queue.poll();
+			if (current.cost() > bestCostByNodeId.getOrDefault(current.nodeId(), Integer.MAX_VALUE)) {
+				continue;
+			}
+			if (current.nodeId().equals(toNodeId)) {
+				return Optional.of(current.path());
+			}
+			for (RouteEdge edge : edgesByFromNode.getOrDefault(current.nodeId(), List.of())) {
+				int nextCost = current.cost() + internalEdgeCost(edge);
+				if (nextCost >= bestCostByNodeId.getOrDefault(edge.toNodeId(), Integer.MAX_VALUE)) {
+					continue;
+				}
+				List<RouteEdge> nextPath = new ArrayList<>(current.path());
+				nextPath.add(edge);
+				bestCostByNodeId.put(edge.toNodeId(), nextCost);
+				queue.add(new InternalRouteCandidate(edge.toNodeId(), nextCost, List.copyOf(nextPath)));
+			}
+		}
+		return Optional.empty();
+	}
+
+	private boolean hasAnyInternalPath(List<RouteEdge> edges, String fromNodeId, String toNodeId) {
+		return findInternalRoutePath(edges, fromNodeId, toNodeId, edge -> true).isPresent();
+	}
+
+	private int internalEdgeCost(RouteEdge edge) {
+		int stairPenalty = edge.hasStairs() ? 120 : 0;
+		int elevatorPenalty = edge.requiresElevator() ? 20 : 0;
+		int escalatorPenalty = edge.requiresEscalator() ? 35 : 0;
+		int slopePenalty = edge.slopeLevel() * 8;
+		int widthPenalty = (6 - edge.widthLevel()) * 4;
+		return edge.distanceMeters() + edge.estimatedSeconds() + stairPenalty + elevatorPenalty + escalatorPenalty
+			+ slopePenalty + widthPenalty;
+	}
+
+	private List<InternalRouteStep> internalRouteSteps(List<RouteEdge> path, Map<String, RouteNode> nodesById) {
+		List<InternalRouteStep> steps = new ArrayList<>();
+		for (int index = 0; index < path.size(); index++) {
+			RouteEdge edge = path.get(index);
+			RouteNode fromNode = nodesById.get(edge.fromNodeId());
+			RouteNode toNode = nodesById.get(edge.toNodeId());
+			steps.add(new InternalRouteStep(
+				index + 1,
+				edge.id(),
+				fromNode.id(),
+				fromNode.name(),
+				toNode.id(),
+				toNode.name(),
+				edge.type(),
+				edge.distanceMeters(),
+				edge.estimatedSeconds(),
+				edge.hasStairs(),
+				edge.requiresElevator(),
+				edge.requiresEscalator(),
+				edge.slopeLevel(),
+				edge.widthLevel(),
+				edge.reliabilityScore(),
+				internalRouteGuidance(edge, fromNode, toNode)
+			));
+		}
+		return List.copyOf(steps);
+	}
+
+	private String internalRouteGuidance(RouteEdge edge, RouteNode fromNode, RouteNode toNode) {
+		if (edge.hasStairs()) {
+			return fromNode.displayLabel() + "에서 " + toNode.displayLabel() + "까지 계단 포함 구간입니다.";
+		}
+		if (edge.requiresElevator()) {
+			return fromNode.displayLabel() + "에서 " + toNode.displayLabel() + "까지 엘리베이터 연결을 이용합니다.";
+		}
+		if (edge.requiresEscalator()) {
+			return fromNode.displayLabel() + "에서 " + toNode.displayLabel() + "까지 에스컬레이터 연결을 확인합니다.";
+		}
+		return fromNode.displayLabel() + "에서 " + toNode.displayLabel() + "까지 이동합니다.";
+	}
+
+	private List<RouteWarning> internalRouteWarnings(List<InternalRouteStep> steps) {
+		List<RouteWarning> warnings = new ArrayList<>();
+		if (steps.stream().anyMatch(InternalRouteStep::includesStairs)) {
+			warnings.add(new RouteWarning(
+				RouteWarningCode.STAIR_ONLY_ACCESS,
+				"역 내부 이동 경로에 계단 포함 구간이 있습니다."
+			));
+		}
+		if (steps.stream().anyMatch(step -> step.reliabilityScore() < 80)) {
+			warnings.add(new RouteWarning(
+				RouteWarningCode.LOW_DATA_CONFIDENCE,
+				"역 내부 이동 경로의 일부 구간은 추가 검증이 필요합니다."
+			));
+		}
+		return List.copyOf(warnings);
+	}
+
+	private InternalRouteResult blockedInternalRoute(
+		Station station,
+		RouteNode fromNode,
+		RouteNode toNode,
+		MobilityType mobilityType
+	) {
+		return new InternalRouteResult(
+			station.id(),
+			station.nameKo(),
+			fromNode.id(),
+			fromNode.name(),
+			toNode.id(),
+			toNode.name(),
+			mobilityType,
+			RouteSearchStatus.BLOCKED,
+			0,
+			0,
+			List.of(),
+			List.of(new RouteWarning(
+				RouteWarningCode.STAIR_ONLY_ACCESS,
+				"역 내부 이동 경로에 계단 포함 구간이 있습니다."
+			)),
+			List.of("계단 없는 내부 이동 경로를 찾을 수 없습니다.")
+		);
+	}
+
 	private int routeScore(RouteProfileWeight profileWeight, RoutePlan routePlan, List<RouteWarning> warnings) {
 		// 점수는 시간이 아니라 상대 비용이다. 낮을수록 쉬운 경로에 가깝다.
 		int trainTime = routePlan.stopCount() * 3;
@@ -650,6 +889,13 @@ public class RouteSearchService implements RouteSearchUseCase {
 
 	private String newRouteFeedbackId() {
 		return "route-feedback-" + UUID.randomUUID();
+	}
+
+	private record InternalRouteCandidate(
+		String nodeId,
+		int cost,
+		List<RouteEdge> path
+	) {
 	}
 
 	private record DirectLine(

--- a/backend/src/main/java/com/easysubway/route/domain/InternalRouteResult.java
+++ b/backend/src/main/java/com/easysubway/route/domain/InternalRouteResult.java
@@ -1,0 +1,21 @@
+package com.easysubway.route.domain;
+
+import com.easysubway.profile.domain.MobilityType;
+import java.util.List;
+
+public record InternalRouteResult(
+	String stationId,
+	String stationName,
+	String fromNodeId,
+	String fromNodeName,
+	String toNodeId,
+	String toNodeName,
+	MobilityType mobilityType,
+	RouteSearchStatus status,
+	int totalDistanceMeters,
+	int totalEstimatedSeconds,
+	List<InternalRouteStep> steps,
+	List<RouteWarning> warnings,
+	List<String> blockedReasons
+) {
+}

--- a/backend/src/main/java/com/easysubway/route/domain/InternalRouteStep.java
+++ b/backend/src/main/java/com/easysubway/route/domain/InternalRouteStep.java
@@ -1,0 +1,23 @@
+package com.easysubway.route.domain;
+
+import com.easysubway.transit.domain.RouteEdgeType;
+
+public record InternalRouteStep(
+	int sequence,
+	String edgeId,
+	String fromNodeId,
+	String fromNodeName,
+	String toNodeId,
+	String toNodeName,
+	RouteEdgeType edgeType,
+	int distanceMeters,
+	int estimatedSeconds,
+	boolean includesStairs,
+	boolean requiresElevator,
+	boolean requiresEscalator,
+	int slopeLevel,
+	int widthLevel,
+	int reliabilityScore,
+	String guidance
+) {
+}

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
@@ -80,6 +80,32 @@ class RouteSearchControllerTest {
 	}
 
 	@Test
+	@DisplayName("역 내부 이동 경로는 노드 간 이동 단계를 반환한다")
+	void postInternalRouteSearchReturnsNodeSteps() throws Exception {
+		mockMvc.perform(post("/api/v1/routes/internal")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "stationId": "station-sangnoksu",
+					  "fromNodeId": "node-sangnoksu-elevator-1",
+					  "toNodeId": "node-sangnoksu-faregate",
+					  "mobilityType": "WHEELCHAIR"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.status").value("FOUND"))
+			.andExpect(jsonPath("$.data.stationId").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data.totalDistanceMeters").value(28))
+			.andExpect(jsonPath("$.data.totalEstimatedSeconds").value(75))
+			.andExpect(jsonPath("$.data.steps[0].edgeId").value("edge-sangnoksu-elevator-to-faregate"))
+			.andExpect(jsonPath("$.data.steps[0].fromNodeName").value("1번 출구 엘리베이터"))
+			.andExpect(jsonPath("$.data.steps[0].toNodeName").value("개찰구"))
+			.andExpect(jsonPath("$.data.steps[0].includesStairs").value(false))
+			.andExpect(jsonPath("$.data.steps[0].requiresElevator").value(true));
+	}
+
+	@Test
 	@DisplayName("존재하지 않는 역으로 경로 검색을 요청하면 공통 404 응답을 반환한다")
 	void postRouteSearchRejectsUnknownStation() throws Exception {
 		mockMvc.perform(post("/api/v1/routes/search")

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -743,6 +743,30 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 역 내부 이동 경로는 해당 간선의 엘리베이터가 고장나면 다른 정상 시설이 있어도 차단한다")
+	void wheelchairInternalRouteBlocksBrokenEdgeElevatorEvenWithOtherNormalFacility() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeEdgeService = new RouteSearchService(
+			repository,
+			repository,
+			new BrokenElevatorWithOtherNormalFacilityInternalEdgeTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = routeEdgeService.searchInternalRoute(new SearchInternalRouteCommand(
+			"station-a",
+			"node-station-a-entrance",
+			"node-station-a-platform",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
+		assertThat(result.steps()).isEmpty();
+		assertThat(result.blockedReasons())
+			.containsExactly("계단 없는 내부 이동 경로를 찾을 수 없습니다.");
+	}
+
+	@Test
 	@DisplayName("유모차 역 내부 이동 경로는 계단 포함 구간을 경고로 표시한다")
 	void strollerInternalRouteWarnsStairIncludedInternalPath() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -1340,6 +1364,44 @@ class RouteSearchServiceTest {
 		}
 	}
 
+	private static class BrokenElevatorWithOtherNormalFacilityInternalEdgeTransitMasterPort
+		extends BrokenElevatorInternalEdgeTransitMasterPort {
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility(
+					"facility-a-elevator",
+					"station-a",
+					"exit-a-1",
+					AccessibilityFacilityType.ELEVATOR,
+					AccessibilityFacilityStatus.BROKEN
+				),
+				facility(
+					"facility-a-other-elevator",
+					"station-a",
+					"exit-a-2",
+					AccessibilityFacilityType.ELEVATOR,
+					AccessibilityFacilityStatus.NORMAL
+				)
+			);
+		}
+
+		@Override
+		public List<RouteNode> loadRouteNodes() {
+			return List.of(
+				routeNode(
+					"node-station-a-entrance",
+					"station-a",
+					RouteNodeType.ENTRANCE,
+					"출입구",
+					"facility-a-elevator"
+				),
+				routeNode("node-station-a-platform", "station-a", RouteNodeType.PLATFORM, "승강장")
+			);
+		}
+	}
+
 	private static class MixedInternalAndTrainEdgeTransitMasterPort extends ExitSummaryAccessibleTransitMasterPort {
 
 		@Override
@@ -1349,6 +1411,18 @@ class RouteSearchServiceTest {
 				trainEdge("edge-a-train", "station-a"),
 				stairEdge("edge-b-stair", "station-b"),
 				trainEdge("edge-b-train", "station-b")
+			);
+		}
+
+		@Override
+		public List<RouteNode> loadRouteNodes() {
+			return List.of(
+				routeNode("node-station-a-entrance", "station-a", RouteNodeType.ENTRANCE, "출입구"),
+				routeNode("node-station-a-platform", "station-a", RouteNodeType.PLATFORM, "승강장"),
+				routeNode("node-station-a-next-platform", "station-a", RouteNodeType.PLATFORM, "다음 승강장"),
+				routeNode("node-station-b-entrance", "station-b", RouteNodeType.ENTRANCE, "출입구"),
+				routeNode("node-station-b-platform", "station-b", RouteNodeType.PLATFORM, "승강장"),
+				routeNode("node-station-b-next-platform", "station-b", RouteNodeType.PLATFORM, "다음 승강장")
 			);
 		}
 	}
@@ -1491,6 +1565,10 @@ class RouteSearchServiceTest {
 	}
 
 	private static RouteNode routeNode(String id, String stationId, RouteNodeType type, String name) {
+		return routeNode(id, stationId, type, name, null);
+	}
+
+	private static RouteNode routeNode(String id, String stationId, RouteNodeType type, String name, String facilityId) {
 		return new RouteNode(
 			id,
 			stationId,
@@ -1499,7 +1577,7 @@ class RouteSearchServiceTest {
 			"B1",
 			null,
 			null,
-			null,
+			facilityId,
 			"layout-" + stationId,
 			10,
 			20,

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
+import com.easysubway.route.application.port.in.SearchInternalRouteCommand;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
 import com.easysubway.route.domain.InvalidRouteFeedbackException;
@@ -23,6 +24,8 @@ import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
 import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteEdgeType;
+import com.easysubway.transit.domain.RouteNode;
+import com.easysubway.transit.domain.RouteNodeType;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
 import com.easysubway.transit.domain.StationLine;
@@ -690,6 +693,95 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("역 내부 이동 경로는 활성 노드와 간선을 단계로 반환한다")
+	void searchInternalRouteReturnsActiveRouteEdgesAsSteps() {
+		var result = service.searchInternalRoute(new SearchInternalRouteCommand(
+			"station-sangnoksu",
+			"node-sangnoksu-elevator-1",
+			"node-sangnoksu-faregate",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.totalDistanceMeters()).isEqualTo(28);
+		assertThat(result.totalEstimatedSeconds()).isEqualTo(75);
+		assertThat(result.blockedReasons()).isEmpty();
+		assertThat(result.steps()).hasSize(1);
+		assertThat(result.steps().getFirst().edgeId()).isEqualTo("edge-sangnoksu-elevator-to-faregate");
+		assertThat(result.steps().getFirst().fromNodeName()).isEqualTo("1번 출구 엘리베이터");
+		assertThat(result.steps().getFirst().toNodeName()).isEqualTo("개찰구");
+		assertThat(result.steps().getFirst().edgeType()).isEqualTo(RouteEdgeType.WALK);
+		assertThat(result.steps().getFirst().requiresElevator()).isTrue();
+		assertThat(result.steps().getFirst().includesStairs()).isFalse();
+	}
+
+	@Test
+	@DisplayName("휠체어 역 내부 이동 경로는 계단만 있으면 차단한다")
+	void wheelchairInternalRouteBlocksStairOnlyInternalPath() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeEdgeService = new RouteSearchService(
+			repository,
+			repository,
+			new InternalStairEdgeTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = routeEdgeService.searchInternalRoute(new SearchInternalRouteCommand(
+			"station-a",
+			"node-station-a-entrance",
+			"node-station-a-platform",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
+		assertThat(result.steps()).isEmpty();
+		assertThat(result.blockedReasons())
+			.containsExactly("계단 없는 내부 이동 경로를 찾을 수 없습니다.");
+		assertThat(result.warnings())
+			.extracting("code")
+			.containsExactly(RouteWarningCode.STAIR_ONLY_ACCESS);
+	}
+
+	@Test
+	@DisplayName("유모차 역 내부 이동 경로는 계단 포함 구간을 경고로 표시한다")
+	void strollerInternalRouteWarnsStairIncludedInternalPath() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeEdgeService = new RouteSearchService(
+			repository,
+			repository,
+			new InternalStairEdgeTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = routeEdgeService.searchInternalRoute(new SearchInternalRouteCommand(
+			"station-a",
+			"node-station-a-entrance",
+			"node-station-a-platform",
+			MobilityType.STROLLER
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.steps()).hasSize(1);
+		assertThat(result.steps().getFirst().includesStairs()).isTrue();
+		assertThat(result.warnings())
+			.extracting("code")
+			.containsExactly(RouteWarningCode.STAIR_ONLY_ACCESS);
+	}
+
+	@Test
+	@DisplayName("역 내부 이동 경로는 같은 역에 속한 노드를 요구한다")
+	void searchInternalRouteRequiresNodesInStation() {
+		assertThatThrownBy(() -> service.searchInternalRoute(new SearchInternalRouteCommand(
+			"station-sangnoksu",
+			"node-sangnoksu-elevator-1",
+			"missing-node",
+			MobilityType.SENIOR
+		)))
+			.isInstanceOf(RouteNotFoundException.class)
+			.hasMessage("연결 가능한 경로를 찾을 수 없습니다.");
+	}
+
+	@Test
 	@DisplayName("경로 검색은 존재하는 역과 공통 노선을 요구한다")
 	void searchRouteRequiresExistingStationsAndSharedLine() {
 		assertThatThrownBy(() -> service.searchRoute(new SearchRouteCommand(
@@ -1217,6 +1309,16 @@ class RouteSearchServiceTest {
 				stairEdge("edge-b-stair", "station-b")
 			);
 		}
+
+		@Override
+		public List<RouteNode> loadRouteNodes() {
+			return List.of(
+				routeNode("node-station-a-entrance", "station-a", RouteNodeType.ENTRANCE, "출입구"),
+				routeNode("node-station-a-platform", "station-a", RouteNodeType.PLATFORM, "승강장"),
+				routeNode("node-station-b-entrance", "station-b", RouteNodeType.ENTRANCE, "출입구"),
+				routeNode("node-station-b-platform", "station-b", RouteNodeType.PLATFORM, "승강장")
+			);
+		}
 	}
 
 	private static class BrokenElevatorInternalEdgeTransitMasterPort extends ExitSummaryAccessibleTransitMasterPort {
@@ -1385,6 +1487,24 @@ class RouteSearchServiceTest {
 			2,
 			95,
 			true
+		);
+	}
+
+	private static RouteNode routeNode(String id, String stationId, RouteNodeType type, String name) {
+		return new RouteNode(
+			id,
+			stationId,
+			type,
+			name,
+			"B1",
+			null,
+			null,
+			null,
+			"layout-" + stationId,
+			10,
+			20,
+			name,
+			null
 		);
 	}
 


### PR DESCRIPTION
## 관련 이슈

close #407

## 작업 배경

- 역 간 경로 검색은 제공되지만, 역 내부에서 엘리베이터, 개찰구, 승강장 같은 구조도 노드 사이를 이동하는 단계 안내는 별도 API로 제공되지 않았다.
- 교통약자 사용자는 역 안에서 계단 포함 여부, 엘리베이터 필요 여부, 거리와 예상 시간을 함께 확인해야 실제 이동 결정을 할 수 있다.

## 작업 내용

- 같은 역의 내부 노드 두 개와 이동 유형을 입력받아 활성 내부 간선 기반 경로를 계산하는 use case를 추가했다.
- 내부 경로 결과에 단계별 간선, 노드명, 거리, 예상 시간, 계단/엘리베이터/에스컬레이터 여부, 신뢰도, 안내 문구를 포함했다.
- 휠체어 이동 유형은 계단 또는 에스컬레이터가 필요한 내부 경로를 차단하고, 대체 경로가 없으면 차단 응답을 반환한다.
- 유모차 등 계단 경로를 차단하지 않는 이동 유형은 계단 포함 구간을 경고로 표시한다.
- 공개 API `POST /api/v1/routes/internal`을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests com.easysubway.route.application.service.RouteSearchServiceTest --tests com.easysubway.route.adapter.in.web.RouteSearchControllerTest` 성공
  - `backend/gradlew -p backend test --tests com.easysubway.route.application.service.RouteSearchServiceTest.wheelchairInternalRouteBlocksBrokenEdgeElevatorEvenWithOtherNormalFacility` 실패 후 엘리베이터 간선 시설 검증 보강, 재실행 성공
  - `git diff --check` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공, 43개 테스트 통과
  - `backend/gradlew -p backend test` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - GitHub Actions CI run `27764082805` 성공
  - merge 후 main CI run `27764312526` 성공
  - merge 후 main CD run `27764312574` 성공

## 리뷰어 메모

- `RouteSearchService#searchInternalRoute`의 내부 그래프 탐색, 휠체어 차단 조건, 계단 경고 생성 흐름을 먼저 보면 된다.
- 기존 역 간 경로 검색 응답 구조는 변경하지 않고, 별도 내부 경로 API만 추가했다.
- CodeRabbit은 rate limit으로 실제 리뷰가 시작되지 않아 Codex CLI 대체 리뷰를 PR review `4525408635`로 남겼고, 지적 1건은 `d4e9380`에서 수정 후 thread를 resolve했다.

## 리스크

- 현재 내부 경로는 활성 간선을 방향성 있는 그래프로 계산하므로 반대 방향 안내가 필요하면 반대 간선 데이터가 필요하다.
- 운영 DB 영속화나 모바일 렌더링은 이번 범위에 포함하지 않았다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
