### PR TITLE
[Feat] 푸시 알림 자동 발송 작업 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/EasySubwayBackendApplication.java
+++ b/backend/src/main/java/com/easysubway/EasySubwayBackendApplication.java
@@ -2,8 +2,10 @@ package com.easysubway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class EasySubwayBackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/scheduler/PushNotificationDeliveryScheduler.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/scheduler/PushNotificationDeliveryScheduler.java
@@ -3,9 +3,14 @@ package com.easysubway.notification.adapter.in.scheduler;
 import com.easysubway.notification.application.port.in.DeliverPushNotificationsCommand;
 import com.easysubway.notification.application.port.in.PushNotificationDeliveryUseCase;
 import com.easysubway.notification.application.port.out.LoadPendingPushNotificationOutboxPort;
+import java.util.List;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -18,16 +23,35 @@ import org.springframework.stereotype.Component;
 public class PushNotificationDeliveryScheduler {
 
 	private static final Logger log = LoggerFactory.getLogger(PushNotificationDeliveryScheduler.class);
+	private static final String DELIVERY_LOCK_KEY = "easysubway:notifications:push:delivery:scheduler-lock";
+	private static final RedisScript<Long> ACQUIRE_LOCK_SCRIPT = RedisScript.of("""
+		if redis.call('SET', KEYS[1], ARGV[1], 'NX', 'PX', ARGV[2]) then
+			return 1
+		end
+		return 0
+		""", Long.class);
+	private static final RedisScript<Long> RELEASE_LOCK_SCRIPT = RedisScript.of("""
+		if redis.call('GET', KEYS[1]) == ARGV[1] then
+			return redis.call('DEL', KEYS[1])
+		end
+		return 0
+		""", Long.class);
 
 	private final LoadPendingPushNotificationOutboxPort pendingPushNotificationOutboxPort;
 	private final PushNotificationDeliveryUseCase deliveryUseCase;
+	private final StringRedisTemplate redisTemplate;
+	private final long lockTtlMillis;
 
 	public PushNotificationDeliveryScheduler(
 		LoadPendingPushNotificationOutboxPort pendingPushNotificationOutboxPort,
-		PushNotificationDeliveryUseCase deliveryUseCase
+		PushNotificationDeliveryUseCase deliveryUseCase,
+		StringRedisTemplate redisTemplate,
+		@Value("${easysubway.notifications.push.delivery.lock-ttl-ms:300000}") long lockTtlMillis
 	) {
 		this.pendingPushNotificationOutboxPort = pendingPushNotificationOutboxPort;
 		this.deliveryUseCase = deliveryUseCase;
+		this.redisTemplate = redisTemplate;
+		this.lockTtlMillis = lockTtlMillis;
 	}
 
 	@Scheduled(
@@ -35,8 +59,39 @@ public class PushNotificationDeliveryScheduler {
 		fixedDelayString = "${easysubway.notifications.push.delivery.fixed-delay-ms:60000}"
 	)
 	void deliverPendingNotifications() {
-		for (String userId : pendingPushNotificationOutboxPort.loadPendingPushNotificationUserIds()) {
-			deliverPendingNotifications(userId);
+		String lockToken = UUID.randomUUID().toString();
+		if (!acquireDeliveryLock(lockToken)) {
+			return;
+		}
+		try {
+			for (String userId : pendingPushNotificationOutboxPort.loadPendingPushNotificationUserIds()) {
+				deliverPendingNotifications(userId);
+			}
+		} finally {
+			releaseDeliveryLock(lockToken);
+		}
+	}
+
+	private boolean acquireDeliveryLock(String lockToken) {
+		try {
+			Long acquired = redisTemplate.execute(
+				ACQUIRE_LOCK_SCRIPT,
+				List.of(DELIVERY_LOCK_KEY),
+				lockToken,
+				String.valueOf(lockTtlMillis)
+			);
+			return Long.valueOf(1).equals(acquired);
+		} catch (RuntimeException exception) {
+			log.warn("Pending push notification scheduler lock acquisition failed.", exception);
+			return false;
+		}
+	}
+
+	private void releaseDeliveryLock(String lockToken) {
+		try {
+			redisTemplate.execute(RELEASE_LOCK_SCRIPT, List.of(DELIVERY_LOCK_KEY), lockToken);
+		} catch (RuntimeException exception) {
+			log.warn("Pending push notification scheduler lock release failed.", exception);
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/notification/adapter/in/scheduler/PushNotificationDeliveryScheduler.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/in/scheduler/PushNotificationDeliveryScheduler.java
@@ -1,0 +1,58 @@
+package com.easysubway.notification.adapter.in.scheduler;
+
+import com.easysubway.notification.application.port.in.DeliverPushNotificationsCommand;
+import com.easysubway.notification.application.port.in.PushNotificationDeliveryUseCase;
+import com.easysubway.notification.application.port.out.LoadPendingPushNotificationOutboxPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(
+	prefix = "easysubway.notifications.push.delivery",
+	name = "enabled",
+	havingValue = "true"
+)
+public class PushNotificationDeliveryScheduler {
+
+	private static final Logger log = LoggerFactory.getLogger(PushNotificationDeliveryScheduler.class);
+
+	private final LoadPendingPushNotificationOutboxPort pendingPushNotificationOutboxPort;
+	private final PushNotificationDeliveryUseCase deliveryUseCase;
+
+	public PushNotificationDeliveryScheduler(
+		LoadPendingPushNotificationOutboxPort pendingPushNotificationOutboxPort,
+		PushNotificationDeliveryUseCase deliveryUseCase
+	) {
+		this.pendingPushNotificationOutboxPort = pendingPushNotificationOutboxPort;
+		this.deliveryUseCase = deliveryUseCase;
+	}
+
+	@Scheduled(
+		initialDelayString = "${easysubway.notifications.push.delivery.initial-delay-ms:10000}",
+		fixedDelayString = "${easysubway.notifications.push.delivery.fixed-delay-ms:60000}"
+	)
+	void deliverPendingNotifications() {
+		for (String userId : pendingPushNotificationOutboxPort.loadPendingPushNotificationUserIds()) {
+			deliverPendingNotifications(userId);
+		}
+	}
+
+	private void deliverPendingNotifications(String userId) {
+		try {
+			var result = deliveryUseCase.deliverPending(new DeliverPushNotificationsCommand(userId));
+			if (result.processedCount() > 0) {
+				log.info(
+					"Pending push notifications delivered. userId={}, sent={}, failed={}",
+					userId,
+					result.sentCount(),
+					result.failedCount()
+				);
+			}
+		} catch (RuntimeException exception) {
+			log.warn("Pending push notification delivery failed. userId={}", userId, exception);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
@@ -8,8 +8,11 @@ import com.easysubway.notification.domain.PushNotification;
 import com.easysubway.notification.domain.PushNotificationDashboardSummary;
 import com.easysubway.notification.domain.PushNotificationStatus;
 import com.easysubway.user.application.port.out.DeleteUserPushNotificationPort;
+import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.springframework.context.annotation.Profile;
@@ -64,6 +67,19 @@ public class InMemoryPushNotificationOutboxRepository implements
 	}
 
 	@Override
+	public List<String> loadPendingPushNotificationUserIds() {
+		return notificationsByUserId.entrySet().stream()
+			.flatMap(entry -> oldestPendingCreatedAt(entry.getValue())
+				.map(createdAt -> new PendingUser(entry.getKey(), createdAt))
+				.stream())
+			.sorted(Comparator
+				.comparing(PendingUser::oldestPendingCreatedAt)
+				.thenComparing(PendingUser::userId))
+			.map(PendingUser::userId)
+			.toList();
+	}
+
+	@Override
 	public PushNotificationDashboardSummary summarizePushNotificationOutbox() {
 		long pendingCount = 0;
 		long sentCount = 0;
@@ -99,5 +115,15 @@ public class InMemoryPushNotificationOutboxRepository implements
 	public int deletePushNotifications(String userId) {
 		List<PushNotification> removed = notificationsByUserId.remove(userId);
 		return removed == null ? 0 : removed.size();
+	}
+
+	private Optional<LocalDateTime> oldestPendingCreatedAt(List<PushNotification> notifications) {
+		return notifications.stream()
+			.filter(notification -> notification.status() == PushNotificationStatus.PENDING)
+			.map(PushNotification::createdAt)
+			.min(Comparator.naturalOrder());
+	}
+
+	private record PendingUser(String userId, LocalDateTime oldestPendingCreatedAt) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
@@ -87,6 +87,21 @@ public class JdbcPushNotificationOutboxRepository implements
 	}
 
 	@Override
+	public List<String> loadPendingPushNotificationUserIds() {
+		return jdbcTemplate.query(
+			"""
+				SELECT user_id
+				FROM push_notification_outbox
+				WHERE status = ?
+				GROUP BY user_id
+				ORDER BY MIN(created_at) ASC, user_id ASC
+				""",
+			(resultSet, rowNumber) -> resultSet.getString("user_id"),
+			PushNotificationStatus.PENDING.name()
+		);
+	}
+
+	@Override
 	public PushNotification savePushNotification(PushNotification notification) {
 		if (updatePushNotification(notification) == 0) {
 			try {

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/LoadPendingPushNotificationOutboxPort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/LoadPendingPushNotificationOutboxPort.java
@@ -6,4 +6,6 @@ import java.util.List;
 public interface LoadPendingPushNotificationOutboxPort {
 
 	List<PushNotification> loadPendingPushNotifications(String userId);
+
+	List<String> loadPendingPushNotificationUserIds();
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,3 +12,11 @@ management:
     web:
       exposure:
         include: "health,info"
+
+easysubway:
+  notifications:
+    push:
+      delivery:
+        enabled: ${EASYSUBWAY_PUSH_DELIVERY_ENABLED:false}
+        initial-delay-ms: ${EASYSUBWAY_PUSH_DELIVERY_INITIAL_DELAY_MS:10000}
+        fixed-delay-ms: ${EASYSUBWAY_PUSH_DELIVERY_FIXED_DELAY_MS:60000}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -20,3 +20,4 @@ easysubway:
         enabled: ${EASYSUBWAY_PUSH_DELIVERY_ENABLED:false}
         initial-delay-ms: ${EASYSUBWAY_PUSH_DELIVERY_INITIAL_DELAY_MS:10000}
         fixed-delay-ms: ${EASYSUBWAY_PUSH_DELIVERY_FIXED_DELAY_MS:60000}
+        lock-ttl-ms: ${EASYSUBWAY_PUSH_DELIVERY_LOCK_TTL_MS:300000}

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -318,3 +318,6 @@ ALTER TABLE push_notification_outbox
 
 CREATE INDEX IF NOT EXISTS idx_push_notification_outbox_user_created
 	ON push_notification_outbox (user_id, created_at ASC, notification_id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_push_notification_outbox_status_user_created
+	ON push_notification_outbox (status, user_id, created_at ASC, notification_id ASC);

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/scheduler/PushNotificationDeliverySchedulerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/scheduler/PushNotificationDeliverySchedulerTest.java
@@ -1,6 +1,11 @@
 package com.easysubway.notification.adapter.in.scheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.easysubway.notification.application.port.in.DeliverPushNotificationsCommand;
 import com.easysubway.notification.application.port.in.PushNotificationDeliveryUseCase;
@@ -13,19 +18,35 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 
 @DisplayName("푸시 알림 자동 발송 스케줄러")
 class PushNotificationDeliverySchedulerTest {
 
 	private PendingUserOutbox pendingUserOutbox;
 	private RecordingDeliveryUseCase deliveryUseCase;
+	private StringRedisTemplate redisTemplate;
 	private PushNotificationDeliveryScheduler scheduler;
 
 	@BeforeEach
+	@SuppressWarnings("unchecked")
 	void setUp() {
 		pendingUserOutbox = new PendingUserOutbox();
 		deliveryUseCase = new RecordingDeliveryUseCase();
-		scheduler = new PushNotificationDeliveryScheduler(pendingUserOutbox, deliveryUseCase);
+		redisTemplate = org.mockito.Mockito.mock(StringRedisTemplate.class);
+		when(redisTemplate.execute(
+			any(RedisScript.class),
+			eq(List.of("easysubway:notifications:push:delivery:scheduler-lock")),
+			anyString(),
+			eq("300000")
+		)).thenReturn(1L);
+		when(redisTemplate.execute(
+			any(RedisScript.class),
+			eq(List.of("easysubway:notifications:push:delivery:scheduler-lock")),
+			anyString()
+		)).thenReturn(1L);
+		scheduler = new PushNotificationDeliveryScheduler(pendingUserOutbox, deliveryUseCase, redisTemplate, 300000L);
 	}
 
 	@Test
@@ -37,6 +58,38 @@ class PushNotificationDeliverySchedulerTest {
 
 		assertThat(deliveryUseCase.deliveredUserIds)
 			.containsExactly("anonymous-user-1", "anonymous-user-2");
+	}
+
+	@Test
+	@DisplayName("다른 인스턴스가 lock을 보유하면 발송 유스케이스를 호출하지 않는다")
+	@SuppressWarnings("unchecked")
+	void deliverPendingNotificationsSkipsWhenLockIsAlreadyHeld() {
+		when(redisTemplate.execute(
+			any(RedisScript.class),
+			eq(List.of("easysubway:notifications:push:delivery:scheduler-lock")),
+			anyString(),
+			eq("300000")
+		)).thenReturn(0L);
+		pendingUserOutbox.userIds = List.of("anonymous-user-1");
+
+		scheduler.deliverPendingNotifications();
+
+		assertThat(deliveryUseCase.deliveredUserIds).isEmpty();
+	}
+
+	@Test
+	@DisplayName("lock을 획득한 실행은 완료 후 같은 token으로 lock을 해제한다")
+	@SuppressWarnings("unchecked")
+	void deliverPendingNotificationsReleasesAcquiredLock() {
+		pendingUserOutbox.userIds = List.of("anonymous-user-1");
+
+		scheduler.deliverPendingNotifications();
+
+		verify(redisTemplate).execute(
+			any(RedisScript.class),
+			eq(List.of("easysubway:notifications:push:delivery:scheduler-lock")),
+			anyString()
+		);
 	}
 
 	@Test
@@ -72,6 +125,7 @@ class PushNotificationDeliverySchedulerTest {
 		return new ApplicationContextRunner()
 			.withBean(LoadPendingPushNotificationOutboxPort.class, PendingUserOutbox::new)
 			.withBean(PushNotificationDeliveryUseCase.class, RecordingDeliveryUseCase::new)
+			.withBean(StringRedisTemplate.class, () -> org.mockito.Mockito.mock(StringRedisTemplate.class))
 			.withUserConfiguration(PushNotificationDeliveryScheduler.class);
 	}
 

--- a/backend/src/test/java/com/easysubway/notification/adapter/in/scheduler/PushNotificationDeliverySchedulerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/in/scheduler/PushNotificationDeliverySchedulerTest.java
@@ -1,0 +1,107 @@
+package com.easysubway.notification.adapter.in.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.notification.application.port.in.DeliverPushNotificationsCommand;
+import com.easysubway.notification.application.port.in.PushNotificationDeliveryUseCase;
+import com.easysubway.notification.application.port.out.LoadPendingPushNotificationOutboxPort;
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationDeliveryResult;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+@DisplayName("푸시 알림 자동 발송 스케줄러")
+class PushNotificationDeliverySchedulerTest {
+
+	private PendingUserOutbox pendingUserOutbox;
+	private RecordingDeliveryUseCase deliveryUseCase;
+	private PushNotificationDeliveryScheduler scheduler;
+
+	@BeforeEach
+	void setUp() {
+		pendingUserOutbox = new PendingUserOutbox();
+		deliveryUseCase = new RecordingDeliveryUseCase();
+		scheduler = new PushNotificationDeliveryScheduler(pendingUserOutbox, deliveryUseCase);
+	}
+
+	@Test
+	@DisplayName("대기 중인 알림이 있는 사용자별로 발송 유스케이스를 호출한다")
+	void deliverPendingNotificationsCallsDeliveryUseCaseForPendingUsers() {
+		pendingUserOutbox.userIds = List.of("anonymous-user-1", "anonymous-user-2");
+
+		scheduler.deliverPendingNotifications();
+
+		assertThat(deliveryUseCase.deliveredUserIds)
+			.containsExactly("anonymous-user-1", "anonymous-user-2");
+	}
+
+	@Test
+	@DisplayName("한 사용자 발송이 실패해도 다음 사용자 처리를 계속한다")
+	void deliverPendingNotificationsContinuesWhenOneUserFails() {
+		pendingUserOutbox.userIds = List.of("anonymous-user-1", "anonymous-user-2");
+		deliveryUseCase.failedUserId = "anonymous-user-1";
+
+		scheduler.deliverPendingNotifications();
+
+		assertThat(deliveryUseCase.deliveredUserIds)
+			.containsExactly("anonymous-user-1", "anonymous-user-2");
+	}
+
+	@Test
+	@DisplayName("자동 발송 스케줄러는 설정이 꺼져 있으면 빈을 등록하지 않는다")
+	void schedulerBeanIsDisabledByDefault() {
+		schedulerContextRunner()
+			.run(context -> assertThat(context)
+				.doesNotHaveBean(PushNotificationDeliveryScheduler.class));
+	}
+
+	@Test
+	@DisplayName("자동 발송 스케줄러는 설정이 켜져 있으면 빈을 등록한다")
+	void schedulerBeanIsEnabledWhenConfigured() {
+		schedulerContextRunner()
+			.withPropertyValues("easysubway.notifications.push.delivery.enabled=true")
+			.run(context -> assertThat(context)
+				.hasSingleBean(PushNotificationDeliveryScheduler.class));
+	}
+
+	private ApplicationContextRunner schedulerContextRunner() {
+		return new ApplicationContextRunner()
+			.withBean(LoadPendingPushNotificationOutboxPort.class, PendingUserOutbox::new)
+			.withBean(PushNotificationDeliveryUseCase.class, RecordingDeliveryUseCase::new)
+			.withUserConfiguration(PushNotificationDeliveryScheduler.class);
+	}
+
+	private static class PendingUserOutbox implements LoadPendingPushNotificationOutboxPort {
+
+		private List<String> userIds = List.of();
+
+		@Override
+		public List<PushNotification> loadPendingPushNotifications(String userId) {
+			return List.of();
+		}
+
+		@Override
+		public List<String> loadPendingPushNotificationUserIds() {
+			return userIds;
+		}
+	}
+
+	private static class RecordingDeliveryUseCase implements PushNotificationDeliveryUseCase {
+
+		private final List<String> deliveredUserIds = new ArrayList<>();
+		private String failedUserId;
+
+		@Override
+		public PushNotificationDeliveryResult deliverPending(DeliverPushNotificationsCommand command) {
+			deliveredUserIds.add(command.userId());
+			if (command.userId().equals(failedUserId)) {
+				throw new IllegalStateException("푸시 알림 발송 실패");
+			}
+			return new PushNotificationDeliveryResult(command.userId(), 0, 0, List.of());
+		}
+	}
+}

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepositoryTest.java
@@ -27,7 +27,42 @@ class InMemoryPushNotificationOutboxRepositoryTest {
 		assertThat(repository.loadPushNotifications("anonymous-user-2")).containsExactly(movedNotification);
 	}
 
+	@Test
+	@DisplayName("대기 중인 알림이 있는 사용자만 가장 오래된 대기 알림 순서로 조회한다")
+	void loadPendingPushNotificationUserIdsReturnsUsersByOldestPendingNotification() {
+		repository.savePushNotification(notification(
+			"push-1",
+			"anonymous-user-2",
+			PushNotificationStatus.PENDING,
+			LocalDateTime.of(2026, 6, 17, 10, 0)
+		));
+		repository.savePushNotification(notification(
+			"push-2",
+			"anonymous-user-1",
+			PushNotificationStatus.PENDING,
+			LocalDateTime.of(2026, 6, 17, 9, 0)
+		));
+		repository.savePushNotification(notification(
+			"push-3",
+			"anonymous-user-3",
+			PushNotificationStatus.SENT,
+			LocalDateTime.of(2026, 6, 17, 8, 0)
+		));
+
+		assertThat(repository.loadPendingPushNotificationUserIds())
+			.containsExactly("anonymous-user-1", "anonymous-user-2");
+	}
+
 	private PushNotification notification(String notificationId, String userId, PushNotificationStatus status) {
+		return notification(notificationId, userId, status, LocalDateTime.of(2026, 6, 17, 10, 0));
+	}
+
+	private PushNotification notification(
+		String notificationId,
+		String userId,
+		PushNotificationStatus status,
+		LocalDateTime createdAt
+	) {
 		return new PushNotification(
 			notificationId,
 			userId,
@@ -37,7 +72,7 @@ class InMemoryPushNotificationOutboxRepositoryTest {
 			"신고 처리 알림",
 			"제보한 내용이 확인되었습니다.",
 			status,
-			LocalDateTime.of(2026, 6, 17, 10, 0)
+			createdAt
 		);
 	}
 }

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
@@ -120,6 +120,24 @@ class JdbcPushNotificationOutboxRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("대기 중인 알림이 있는 사용자만 가장 오래된 대기 알림 순서로 조회한다")
+	void loadPendingPushNotificationUserIdsReturnsUsersByOldestPendingNotification() {
+		repository.savePushNotification(notification("push-1", "anonymous-user-2", PushNotificationType.REPORT_STATUS, 10));
+		repository.savePushNotification(notification("push-2", "anonymous-user-1", PushNotificationType.DATA_QUALITY, 9));
+		repository.savePushNotification(notification(
+			"push-3",
+			"anonymous-user-3",
+			PushNotificationType.FAVORITE_ROUTE_FACILITY,
+			PushNotificationStatus.SENT,
+			8
+		));
+		repository.savePushNotification(notification("push-4", "anonymous-user-2", PushNotificationType.DATA_QUALITY, 11));
+
+		assertThat(repository.loadPendingPushNotificationUserIds())
+			.containsExactly("anonymous-user-1", "anonymous-user-2");
+	}
+
+	@Test
 	@DisplayName("전체 outbox를 상태별로 집계한다")
 	void summarizePushNotificationOutboxByStatus() {
 		repository.savePushNotification(notification("push-1", "anonymous-user-1", PushNotificationType.REPORT_STATUS, 9));


### PR DESCRIPTION
## 관련 이슈

close #411

## 작업 배경

- 푸시 알림 outbox는 사용자별 수동 발송 API를 제공하지만, 서버가 주기적으로 대기 알림을 처리하는 작업은 없었다.
- 시설 상태와 신고 처리 결과 알림이 outbox에 쌓인 뒤 운영자가 매번 수동 API를 호출하지 않아도 되도록, 설정 기반 자동 발송 경로가 필요하다.

## 작업 내용

- `easysubway.notifications.push.delivery.enabled` 설정이 `true`일 때만 등록되는 푸시 알림 자동 발송 스케줄러를 추가했다.
- 스케줄러는 pending 알림이 있는 사용자 목록을 조회하고, 사용자별 기존 발송 유스케이스를 호출한다.
- 한 사용자 발송 중 예외가 발생해도 다음 사용자 처리를 계속하도록 사용자 단위 예외 처리를 추가했다.
- Redis 기반 scheduler lock을 추가해 여러 백엔드 인스턴스에서 자동 발송이 동시에 실행되지 않도록 했다.
- JDBC/인메모리 outbox 저장소에 pending 알림 보유 사용자 조회 기능을 추가하고, 가장 오래된 pending 알림 기준으로 처리 순서를 고정했다.
- pending 사용자 polling 쿼리를 지원하도록 운영 schema에 `status` 선행 outbox 인덱스를 추가했다.
- 기본 설정은 자동 발송 비활성화이며, `EASYSUBWAY_PUSH_DELIVERY_ENABLED`, `EASYSUBWAY_PUSH_DELIVERY_INITIAL_DELAY_MS`, `EASYSUBWAY_PUSH_DELIVERY_FIXED_DELAY_MS`, `EASYSUBWAY_PUSH_DELIVERY_LOCK_TTL_MS`로 조정할 수 있다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.notification.adapter.out.persistence.InMemoryPushNotificationOutboxRepositoryTest --tests com.easysubway.notification.adapter.out.persistence.JdbcPushNotificationOutboxRepositoryTest --tests com.easysubway.notification.adapter.in.scheduler.PushNotificationDeliverySchedulerTest`: 성공
  - `./gradlew test --tests 'com.easysubway.notification.*'`: 성공
  - `./gradlew test`: 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 성공, 43개 테스트 통과
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적
  - GitHub CI: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 성공
  - Codex CLI code review: actionable 2건 확인 후 `40f43ea`에서 수정, review thread 2건 resolve
  - merge 후 main CI `27769429396`: 성공
  - merge 후 main CD `27769429394`: 성공

## 리뷰어 메모

- `PushNotificationDeliveryScheduler`의 조건부 등록 설정, Redis lock acquire/release, 사용자 단위 예외 처리 흐름을 먼저 확인하면 된다.
- 실제 FCM/APNs 연동은 범위 밖이며, 기존 발송 포트와 outbox 상태 갱신 경로를 그대로 사용한다.

## 리스크

- 자동 발송을 켜면 현재 설정된 발송 어댑터 결과에 따라 pending outbox 상태가 주기적으로 갱신된다.
- 기본값은 비활성화라 기존 개발/운영 실행 흐름에는 즉시 자동 발송이 적용되지 않는다.
- 자동 발송을 켠 환경에서 Redis lock을 획득하지 못하면 해당 tick은 안전하게 skip된다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. rate limit으로 실제 리뷰가 시작되지 않은 것을 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
