### PR TITLE
[Build] Android target API 출시 기준선 고정

### DIFF
--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -45,7 +45,7 @@ android {
     defaultConfig {
         applicationId = "com.easysubway.easysubway_mobile"
         minSdk = flutter.minSdkVersion
-        targetSdk = flutter.targetSdkVersion
+        targetSdk = maxOf(35, flutter.targetSdkVersion)
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2234,6 +2234,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(androidProfileManifest, /android:usesCleartextTraffic="true"/);
   assert.match(androidProfileManifest, /tools:replace="android:usesCleartextTraffic"/);
   assert.match(androidManifest, /<uses-permission android:name="android\.permission\.INTERNET"\/>/);
+  assert.match(androidBuildGradle, /targetSdk\s*=\s*maxOf\(35,\s*flutter\.targetSdkVersion\)/);
   assert.match(androidBuildGradle, /create\("release"\)/);
   assert.doesNotMatch(androidBuildGradle, /signingConfig\s*=\s*signingConfigs\.getByName\("debug"\)/);
   assert.match(androidBuildGradle, /"EASYSUBWAY_ANDROID_KEYSTORE_PATH"/);


### PR DESCRIPTION
## 관련 이슈

close #415

## 작업 배경

Google Play 출시 준비 항목은 Android 15(API 35) 이상 target API 기준선을 요구한다. 기존 Android Gradle 설정은 Flutter 기본 targetSdk 값을 그대로 사용해 저장소에서 API 35 이상을 명시적으로 보장하지 못했다.

## 작업 내용

- Android 앱 `targetSdk`를 `maxOf(35, flutter.targetSdkVersion)`로 계산해 API 35 이상을 보장했다.
- Flutter 기본 targetSdk가 35보다 높아지면 더 높은 값을 유지하도록 했다.
- repository contract가 Android target API 기준선 설정을 검증하도록 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "모바일 스캐폴드는" tools/ci/repository-contract.test.mjs` 통과
  - `node --test tools/ci/repository-contract.test.mjs` 통과, 44개 테스트 통과
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - `cd apps/mobile/android && ./gradlew :app:properties --console=plain --quiet` 통과
  - PR #416 CI 통과: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI
  - merge 후 main CI run `27772444006` 통과
  - merge 후 main CD run `27772444162` 통과

## 리뷰어 메모

- 이번 변경은 Android build 설정과 CI 계약 검증에 한정된다.
- CodeRabbit은 한도 초과로 실제 리뷰를 시작하지 못해 Codex CLI fallback 리뷰를 PR review로 남겼고, actionable/nitpick 모두 0건이었다.
- 실제 Play Console 제출, 릴리즈 AAB 업로드, 실제 기기/에뮬레이터 수동 QA는 별도 작업 범위다.

## 리스크

- Flutter/Android Gradle Plugin 기본 targetSdk가 올라가면 자동으로 더 높은 값을 사용하므로, 향후 Play 정책 변화에 따라 추가 기준선 조정이 필요할 수 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
