### PR TITLE
[Fix] secure storage 복원 실패 흐름 보강

### DIFF
--- a/apps/mobile/lib/anonymous_auth.dart
+++ b/apps/mobile/lib/anonymous_auth.dart
@@ -3,10 +3,10 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'auth_headers.dart';
 import 'mobile_error_reporter.dart';
+import 'secure_key_value_storage.dart';
 
 const _anonymousAuthTimeout = Duration(seconds: 8);
 const _anonymousAuthErrorMessage = '인증을 준비하지 못했습니다. 잠시 후 다시 시도해 주세요.';
@@ -29,19 +29,18 @@ abstract class AnonymousAuthCredentialStore {
 class SecureAnonymousAuthCredentialStore
     implements AnonymousAuthCredentialStore {
   const SecureAnonymousAuthCredentialStore({
-    this.storage = const FlutterSecureStorage(),
+    this.storage = const FlutterSecureKeyValueStorage(),
   });
 
-  final FlutterSecureStorage storage;
+  final SecureKeyValueStorage storage;
 
   @override
   Future<AnonymousAuthCredentials?> readCredentials() async {
-    final value = await storage.read(key: _anonymousAuthCredentialsKey);
-    if (value == null) {
-      return null;
-    }
-
     try {
+      final value = await storage.read(key: _anonymousAuthCredentialsKey);
+      if (value == null) {
+        return null;
+      }
       final decoded = jsonDecode(value);
       if (decoded is! Map<String, Object?>) {
         throw const FormatException('Invalid anonymous auth storage payload');
@@ -53,7 +52,7 @@ class SecureAnonymousAuthCredentialStore
         stackTrace,
         context: '저장된 익명 인증 정보를 읽는 중 예외가 발생했습니다.',
       );
-      await clearCredentials();
+      await _clearCredentialsAfterReadFailure();
       return null;
     }
   }
@@ -72,6 +71,18 @@ class SecureAnonymousAuthCredentialStore
   @override
   Future<void> clearCredentials() async {
     await storage.delete(key: _anonymousAuthCredentialsKey);
+  }
+
+  Future<void> _clearCredentialsAfterReadFailure() async {
+    try {
+      await clearCredentials();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '손상된 익명 인증 정보를 지우는 중 예외가 발생했습니다.',
+      );
+    }
   }
 }
 

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -3,11 +3,11 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:image_picker/image_picker.dart';
 
 import 'auth_headers.dart';
 import 'mobile_error_reporter.dart';
+import 'secure_key_value_storage.dart';
 
 const _facilityReportTimeout = Duration(seconds: 8);
 const _facilityReportErrorMessage = '신고를 보내지 못했습니다.';
@@ -574,18 +574,20 @@ abstract class FacilityReportDraftTargetStore {
 class SecureFacilityReportDraftTargetStore
     implements FacilityReportDraftTargetStore {
   const SecureFacilityReportDraftTargetStore({
-    this.storage = const FlutterSecureStorage(),
+    this.storage = const FlutterSecureKeyValueStorage(),
   });
 
-  final FlutterSecureStorage storage;
+  final SecureKeyValueStorage storage;
 
   @override
   Future<FacilityReportTarget?> readTarget() async {
-    final value = await storage.read(key: _facilityReportDraftTargetStorageKey);
-    if (value == null) {
-      return null;
-    }
     try {
+      final value = await storage.read(
+        key: _facilityReportDraftTargetStorageKey,
+      );
+      if (value == null) {
+        return null;
+      }
       return FacilityReportTarget.decode(value);
     } catch (error, stackTrace) {
       reportMobileError(
@@ -593,7 +595,7 @@ class SecureFacilityReportDraftTargetStore
         stackTrace,
         context: '저장된 시설 신고 대상을 읽는 중 예외가 발생했습니다.',
       );
-      await clearTarget();
+      await _clearTargetAfterReadFailure();
       return null;
     }
   }
@@ -609,6 +611,18 @@ class SecureFacilityReportDraftTargetStore
   @override
   Future<void> clearTarget() async {
     await storage.delete(key: _facilityReportDraftTargetStorageKey);
+  }
+
+  Future<void> _clearTargetAfterReadFailure() async {
+    try {
+      await clearTarget();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '손상된 시설 신고 대상을 지우는 중 예외가 발생했습니다.',
+      );
+    }
   }
 }
 

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -1,11 +1,11 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'mobility_profile.dart';
 import 'mobile_error_reporter.dart';
 import 'notification_settings.dart';
+import 'secure_key_value_storage.dart';
 import 'station_search.dart';
 
 const _onboardingResultStorageKey = 'easysubway.onboarding.result';
@@ -21,19 +21,18 @@ abstract class OnboardingResultStore {
 
 class SecureOnboardingResultStore implements OnboardingResultStore {
   const SecureOnboardingResultStore({
-    this.storage = const FlutterSecureStorage(),
+    this.storage = const FlutterSecureKeyValueStorage(),
   });
 
-  final FlutterSecureStorage storage;
+  final SecureKeyValueStorage storage;
 
   @override
   Future<OnboardingResult?> readResult() async {
-    final value = await storage.read(key: _onboardingResultStorageKey);
-    if (value == null) {
-      return null;
-    }
-
     try {
+      final value = await storage.read(key: _onboardingResultStorageKey);
+      if (value == null) {
+        return null;
+      }
       return OnboardingResult.decode(value);
     } catch (error, stackTrace) {
       reportMobileError(
@@ -41,7 +40,7 @@ class SecureOnboardingResultStore implements OnboardingResultStore {
         stackTrace,
         context: '저장된 온보딩 설정을 읽는 중 예외가 발생했습니다.',
       );
-      await clearResult();
+      await _clearResultAfterReadFailure();
       return null;
     }
   }
@@ -57,6 +56,18 @@ class SecureOnboardingResultStore implements OnboardingResultStore {
   @override
   Future<void> clearResult() async {
     await storage.delete(key: _onboardingResultStorageKey);
+  }
+
+  Future<void> _clearResultAfterReadFailure() async {
+    try {
+      await clearResult();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '손상된 온보딩 설정을 지우는 중 예외가 발생했습니다.',
+      );
+    }
   }
 }
 

--- a/apps/mobile/lib/secure_key_value_storage.dart
+++ b/apps/mobile/lib/secure_key_value_storage.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+abstract interface class SecureKeyValueStorage {
+  Future<String?> read({required String key});
+
+  Future<void> write({required String key, required String value});
+
+  Future<void> delete({required String key});
+}
+
+class FlutterSecureKeyValueStorage implements SecureKeyValueStorage {
+  const FlutterSecureKeyValueStorage({
+    this.storage = const FlutterSecureStorage(),
+  });
+
+  final FlutterSecureStorage storage;
+
+  @override
+  Future<String?> read({required String key}) => storage.read(key: key);
+
+  @override
+  Future<void> write({required String key, required String value}) {
+    return storage.write(key: key, value: value);
+  }
+
+  @override
+  Future<void> delete({required String key}) => storage.delete(key: key);
+}

--- a/apps/mobile/test/anonymous_auth_test.dart
+++ b/apps/mobile/test/anonymous_auth_test.dart
@@ -80,6 +80,19 @@ void main() {
     expect(storage.deletedKeys, hasLength(1));
   });
 
+  test('익명 인증 저장소는 secure storage 삭제 실패에도 null로 복구한다', () async {
+    final storage = FakeSecureKeyValueStorage(
+      readError: StateError('restored Android KeyStore value is invalid'),
+      deleteError: StateError('secure storage delete failed'),
+    );
+    final store = SecureAnonymousAuthCredentialStore(storage: storage);
+
+    final credentials = await store.readCredentials();
+
+    expect(credentials, isNull);
+    expect(storage.deletedKeys, isEmpty);
+  });
+
   test('익명 인증 세션은 저장된 인증 정보를 먼저 사용한다', () async {
     final repository = FakeAnonymousAuthRepository();
     final credentialStore = MemoryAnonymousAuthCredentialStore(

--- a/apps/mobile/test/anonymous_auth_test.dart
+++ b/apps/mobile/test/anonymous_auth_test.dart
@@ -5,6 +5,8 @@ import 'dart:io';
 import 'package:easysubway_mobile/anonymous_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'fake_secure_key_value_storage.dart';
+
 void main() {
   test('익명 인증 API 저장소는 발급 응답을 파싱한다', () async {
     late String requestedMethod;
@@ -64,6 +66,18 @@ void main() {
       firstHeader,
       'Basic ${base64Encode(utf8.encode('anonymous-user-1:user-test-password'))}',
     );
+  });
+
+  test('익명 인증 저장소는 secure storage 복원 실패 시 저장값을 지운다', () async {
+    final storage = FakeSecureKeyValueStorage(
+      readError: StateError('restored Android KeyStore value is invalid'),
+    );
+    final store = SecureAnonymousAuthCredentialStore(storage: storage);
+
+    final credentials = await store.readCredentials();
+
+    expect(credentials, isNull);
+    expect(storage.deletedKeys, hasLength(1));
   });
 
   test('익명 인증 세션은 저장된 인증 정보를 먼저 사용한다', () async {

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -10,6 +10,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker/image_picker.dart';
 
+import 'fake_secure_key_value_storage.dart';
+
 void main() {
   test('시설 신고 사진 선택기는 복구된 사진을 첨부 데이터로 바꾼다', () async {
     final tempDir = await Directory.systemTemp.createTemp(
@@ -34,6 +36,18 @@ void main() {
     expect(attachment!.fileName, 'restored-photo.png');
     expect(attachment.contentType, 'image/png');
     expect(attachment.dataBase64, 'AQIDBA==');
+  });
+
+  test('시설 신고 임시 대상 저장소는 secure storage 복원 실패 시 저장값을 지운다', () async {
+    final storage = FakeSecureKeyValueStorage(
+      readError: StateError('restored Android KeyStore value is invalid'),
+    );
+    final store = SecureFacilityReportDraftTargetStore(storage: storage);
+
+    final target = await store.readTarget();
+
+    expect(target, isNull);
+    expect(storage.deletedKeys, hasLength(1));
   });
 
   test('시설 신고 사진 선택기는 복구할 사진이 없으면 첨부하지 않는다', () async {

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -50,6 +50,19 @@ void main() {
     expect(storage.deletedKeys, hasLength(1));
   });
 
+  test('시설 신고 임시 대상 저장소는 secure storage 삭제 실패에도 null로 복구한다', () async {
+    final storage = FakeSecureKeyValueStorage(
+      readError: StateError('restored Android KeyStore value is invalid'),
+      deleteError: StateError('secure storage delete failed'),
+    );
+    final store = SecureFacilityReportDraftTargetStore(storage: storage);
+
+    final target = await store.readTarget();
+
+    expect(target, isNull);
+    expect(storage.deletedKeys, isEmpty);
+  });
+
   test('시설 신고 사진 선택기는 복구할 사진이 없으면 첨부하지 않는다', () async {
     final picker = ImagePickerFacilityReportPhotoPicker(
       imagePicker: FakeLostDataImagePicker(LostDataResponse.empty()),

--- a/apps/mobile/test/fake_secure_key_value_storage.dart
+++ b/apps/mobile/test/fake_secure_key_value_storage.dart
@@ -1,0 +1,29 @@
+import 'package:easysubway_mobile/secure_key_value_storage.dart';
+
+class FakeSecureKeyValueStorage implements SecureKeyValueStorage {
+  FakeSecureKeyValueStorage({this.readError});
+
+  final Object? readError;
+  final values = <String, String>{};
+  final deletedKeys = <String>[];
+
+  @override
+  Future<String?> read({required String key}) async {
+    final error = readError;
+    if (error != null) {
+      throw error;
+    }
+    return values[key];
+  }
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    values[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    deletedKeys.add(key);
+    values.remove(key);
+  }
+}

--- a/apps/mobile/test/fake_secure_key_value_storage.dart
+++ b/apps/mobile/test/fake_secure_key_value_storage.dart
@@ -1,9 +1,10 @@
 import 'package:easysubway_mobile/secure_key_value_storage.dart';
 
 class FakeSecureKeyValueStorage implements SecureKeyValueStorage {
-  FakeSecureKeyValueStorage({this.readError});
+  FakeSecureKeyValueStorage({this.readError, this.deleteError});
 
   final Object? readError;
+  final Object? deleteError;
   final values = <String, String>{};
   final deletedKeys = <String>[];
 
@@ -23,6 +24,10 @@ class FakeSecureKeyValueStorage implements SecureKeyValueStorage {
 
   @override
   Future<void> delete({required String key}) async {
+    final error = deleteError;
+    if (error != null) {
+      throw error;
+    }
     deletedKeys.add(key);
     values.remove(key);
   }

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -7,6 +7,8 @@ import 'package:easysubway_mobile/station_search.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'fake_secure_key_value_storage.dart';
+
 void main() {
   test('온보딩 보기 설정은 쉬운 기본값으로 시작한다', () {
     const preferences = OnboardingViewPreferences.defaults();
@@ -14,6 +16,18 @@ void main() {
     expect(preferences.largeTextEnabled, isTrue);
     expect(preferences.highContrastEnabled, isFalse);
     expect(preferences.simpleViewEnabled, isTrue);
+  });
+
+  test('온보딩 저장소는 secure storage 복원 실패 시 저장값을 지운다', () async {
+    final storage = FakeSecureKeyValueStorage(
+      readError: StateError('restored Android KeyStore value is invalid'),
+    );
+    final store = SecureOnboardingResultStore(storage: storage);
+
+    final result = await store.readResult();
+
+    expect(result, isNull);
+    expect(storage.deletedKeys, hasLength(1));
   });
 
   testWidgets('온보딩은 이동 조건과 보기 설정을 선택한 뒤 완료 결과를 반환한다', (tester) async {

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -30,6 +30,19 @@ void main() {
     expect(storage.deletedKeys, hasLength(1));
   });
 
+  test('온보딩 저장소는 secure storage 삭제 실패에도 null로 복구한다', () async {
+    final storage = FakeSecureKeyValueStorage(
+      readError: StateError('restored Android KeyStore value is invalid'),
+      deleteError: StateError('secure storage delete failed'),
+    );
+    final store = SecureOnboardingResultStore(storage: storage);
+
+    final result = await store.readResult();
+
+    expect(result, isNull);
+    expect(storage.deletedKeys, isEmpty);
+  });
+
   testWidgets('온보딩은 이동 조건과 보기 설정을 선택한 뒤 완료 결과를 반환한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     OnboardingResult? completedResult;

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2198,6 +2198,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   const iosInfoPlist = read("apps/mobile/ios/Runner/Info.plist");
   const main = read("apps/mobile/lib/main.dart");
   const authHeaders = read("apps/mobile/lib/auth_headers.dart");
+  const secureKeyValueStorage = read("apps/mobile/lib/secure_key_value_storage.dart");
   const anonymousAuth = read("apps/mobile/lib/anonymous_auth.dart");
   const anonymousAuthTest = read("apps/mobile/test/anonymous_auth_test.dart");
   const onboarding = read("apps/mobile/lib/onboarding.dart");
@@ -2314,9 +2315,13 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(authHeaders, /class BasicAuthorizationHeaderProvider implements AuthorizationHeaderProvider/);
   assert.match(authHeaders, /authorizationHeader/);
   assert.match(authHeaders, /invalidateAuthorization/);
+  assert.match(secureKeyValueStorage, /abstract interface class SecureKeyValueStorage/);
+  assert.match(secureKeyValueStorage, /class FlutterSecureKeyValueStorage implements SecureKeyValueStorage/);
+  assert.match(secureKeyValueStorage, /FlutterSecureStorage/);
   assert.match(anonymousAuth, /class AnonymousAuthApiRepository implements AnonymousAuthRepository/);
   assert.match(anonymousAuth, /class SecureAnonymousAuthCredentialStore/);
-  assert.match(anonymousAuth, /FlutterSecureStorage/);
+  assert.match(anonymousAuth, /SecureKeyValueStorage/);
+  assert.match(anonymousAuth, /_clearCredentialsAfterReadFailure/);
   assert.match(anonymousAuth, /readCredentials/);
   assert.match(anonymousAuth, /saveCredentials/);
   assert.match(anonymousAuth, /clearCredentials/);
@@ -2341,6 +2346,13 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(anonymousAuthTest, /인증 실패 후 저장된 인증 정보를 지우고 다시 발급한다/);
   assert.match(anonymousAuthTest, /동시 인증 무효화 후 하나의 새 인증 정보를 공유한다/);
   assert.match(anonymousAuthTest, /원격 HTTP 주소에서 저장된 Basic 인증 정보를 재사용하지 않는다/);
+  assert.match(anonymousAuthTest, /secure storage 복원 실패 시 저장값을 지운다/);
+  assert.match(onboarding, /SecureKeyValueStorage/);
+  assert.match(onboarding, /_clearResultAfterReadFailure/);
+  assert.match(onboardingTest, /온보딩 저장소는 secure storage 복원 실패 시 저장값을 지운다/);
+  assert.match(facilityReport, /SecureKeyValueStorage/);
+  assert.match(facilityReport, /_clearTargetAfterReadFailure/);
+  assert.match(facilityReportTest, /시설 신고 임시 대상 저장소는 secure storage 복원 실패 시 저장값을 지운다/);
   assert.ok(existsSync(path.join(root, "apps/mobile/lib/station_search.dart")));
   assert.match(stationSearch, /typedef FavoriteStationAuthProvider = AuthorizationHeaderProvider/);
   assert.match(stationSearch, /final double\? latitude/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2347,12 +2347,15 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(anonymousAuthTest, /동시 인증 무효화 후 하나의 새 인증 정보를 공유한다/);
   assert.match(anonymousAuthTest, /원격 HTTP 주소에서 저장된 Basic 인증 정보를 재사용하지 않는다/);
   assert.match(anonymousAuthTest, /secure storage 복원 실패 시 저장값을 지운다/);
+  assert.match(anonymousAuthTest, /secure storage 삭제 실패에도 null로 복구한다/);
   assert.match(onboarding, /SecureKeyValueStorage/);
   assert.match(onboarding, /_clearResultAfterReadFailure/);
   assert.match(onboardingTest, /온보딩 저장소는 secure storage 복원 실패 시 저장값을 지운다/);
+  assert.match(onboardingTest, /온보딩 저장소는 secure storage 삭제 실패에도 null로 복구한다/);
   assert.match(facilityReport, /SecureKeyValueStorage/);
   assert.match(facilityReport, /_clearTargetAfterReadFailure/);
   assert.match(facilityReportTest, /시설 신고 임시 대상 저장소는 secure storage 복원 실패 시 저장값을 지운다/);
+  assert.match(facilityReportTest, /시설 신고 임시 대상 저장소는 secure storage 삭제 실패에도 null로 복구한다/);
   assert.ok(existsSync(path.join(root, "apps/mobile/lib/station_search.dart")));
   assert.match(stationSearch, /typedef FavoriteStationAuthProvider = AuthorizationHeaderProvider/);
   assert.match(stationSearch, /final double\? latitude/);


### PR DESCRIPTION
## 관련 이슈

close #419

## 작업 배경

- Android 기기 교체, 앱 데이터 복원, KeyStore 상태 불일치 상황에서 secure storage read가 예외를 던지면 첫 실행 복구 흐름이 중단될 수 있다.
- 온보딩 설정, 익명 인증 정보, 시설 신고 사진 복구 대상은 앱 시작과 주요 사용자 흐름에 걸려 있어 read 실패 시 안전하게 초기 상태로 돌아가야 한다.

## 작업 내용

- `FlutterSecureStorage`를 앱 내부 `SecureKeyValueStorage` adapter 뒤로 감싸 저장소 단위 테스트에서 read 실패를 직접 재현할 수 있게 했다.
- 익명 인증, 온보딩 결과, 시설 신고 임시 대상 저장소가 secure storage read 또는 decode 실패를 오류 경계에 보고하고 저장값을 삭제한 뒤 `null`로 복구하도록 보강했다.
- 삭제 자체가 실패해도 사용자 흐름이 중단되지 않도록 삭제 실패도 별도 오류 경계에 보고하고 복구 반환을 유지했다.
- 세 저장소의 secure storage 복원 실패 회귀 테스트와 repository contract 검사를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/anonymous_auth_test.dart test/onboarding_test.dart test/facility_report_test.dart --name "secure storage 복원 실패"`: 통과
  - `flutter analyze`: 통과
  - `flutter test`: 통과
  - `node --test --test-name-pattern "모바일 스캐폴드는" tools/ci/repository-contract.test.mjs`: 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인

## 리뷰어 메모

- `apps/mobile/lib/secure_key_value_storage.dart`의 adapter 경계와 세 저장소의 read 실패 복구 방식이 동일한지 먼저 확인해 주세요.
- 테스트 중 의도적으로 오류 경계 로그가 출력되지만, 저장소 API는 `null`로 복구하고 테스트는 통과합니다.

## 리스크

- 손상되었거나 복원할 수 없는 secure storage 값은 삭제되므로 사용자는 온보딩을 다시 완료하거나 익명 인증을 새로 발급받을 수 있다.
- 시설 신고 사진 복구 대상이 삭제되면 복원된 사진을 이전 신고 대상에 자동 연결하지 않고 일반 흐름으로 돌아간다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
