### PR TITLE
[Build] 로컬 로그 관측성 기준선 추가

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     command:
       - "--config.file=/etc/loki/loki.yml"
     ports:
-      - "${EASYSUBWAY_LOKI_PORT:-3100}:3100"
+      - "127.0.0.1:${EASYSUBWAY_LOKI_PORT:-3100}:3100"
     volumes:
       - ./loki/loki.yml:/etc/loki/loki.yml:ro
       - loki-data:/loki

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -85,6 +85,8 @@ services:
     depends_on:
       prometheus:
         condition: service_healthy
+      loki:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget --spider -q http://localhost:3000/api/health"]
       interval: 10s

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -53,6 +53,23 @@ services:
       retries: 5
       start_period: 20s
 
+  loki:
+    image: grafana/loki:3.6.0
+    container_name: easysubway-loki
+    command:
+      - "--config.file=/etc/loki/loki.yml"
+    ports:
+      - "${EASYSUBWAY_LOKI_PORT:-3100}:3100"
+    volumes:
+      - ./loki/loki.yml:/etc/loki/loki.yml:ro
+      - loki-data:/loki
+    healthcheck:
+      test: ["CMD", "loki", "-config.file=/etc/loki/loki.yml", "-verify-config"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
   grafana:
     image: grafana/grafana:12.2.9
     container_name: easysubway-grafana
@@ -79,4 +96,5 @@ volumes:
   postgres-data:
   redis-data:
   prometheus-data:
+  loki-data:
   grafana-data:

--- a/infra/grafana/provisioning/datasources/loki.yml
+++ b/infra/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: easysubway-loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: true

--- a/infra/loki/loki.yml
+++ b/infra/loki/loki.yml
@@ -1,0 +1,52 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true
+  retention_period: 168h
+
+schema_config:
+  configs:
+    - from: 2024-04-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /loki/rules
+  rule_path: /loki/rules-temp
+  enable_api: true
+
+compactor:
+  working_directory: /loki/retention
+  delete_request_store: filesystem
+  retention_enabled: true

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -611,7 +611,7 @@ test("로컬 로그 관측성 스택은 Loki 기준선을 제공한다", () => {
   assert.match(compose, /image: grafana\/loki:3\.6\.0/);
   assert.match(compose, /--config\.file=\/etc\/loki\/loki\.yml/);
   assert.match(compose, /\.\/loki\/loki\.yml:\/etc\/loki\/loki\.yml:ro/);
-  assert.match(compose, /"\$\{EASYSUBWAY_LOKI_PORT:-3100\}:3100"/);
+  assert.match(compose, /"127\.0\.0\.1:\$\{EASYSUBWAY_LOKI_PORT:-3100\}:3100"/);
   assert.match(compose, /loki-data:\/loki/);
   assert.match(compose, /test: \["CMD", "loki", "-config\.file=\/etc\/loki\/loki\.yml", "-verify-config"\]/);
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -589,6 +589,7 @@ test("로컬 관측성 스택은 Prometheus와 Grafana 기준선을 제공한다
   assert.match(compose, /GF_SECURITY_ADMIN_PASSWORD: \$\{EASYSUBWAY_GRAFANA_ADMIN_PASSWORD:-easysubway_local\}/);
   assert.match(compose, /grafana-data:\/var\/lib\/grafana/);
   assert.match(compose, /\.\/grafana\/provisioning:\/etc\/grafana\/provisioning:ro/);
+  assert.match(compose, /depends_on:\s*\n\s*prometheus:\s*\n\s*condition: service_healthy[\s\S]*loki:\s*\n\s*condition: service_healthy/);
 
   assert.match(prometheusConfig, /job_name: "easysubway-backend"/);
   assert.match(prometheusConfig, /metrics_path: "\/actuator\/prometheus"/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -600,6 +600,35 @@ test("로컬 관측성 스택은 Prometheus와 Grafana 기준선을 제공한다
   assert.match(grafanaDatasource, /isDefault: true/);
 });
 
+test("로컬 로그 관측성 스택은 Loki 기준선을 제공한다", () => {
+  const compose = read("infra/docker-compose.yml");
+  const lokiConfig = read("infra/loki/loki.yml");
+  const lokiDatasource = read("infra/grafana/provisioning/datasources/loki.yml");
+  const prometheusDatasource = read("infra/grafana/provisioning/datasources/prometheus.yml");
+
+  assert.match(compose, /loki:\n/);
+  assert.match(compose, /image: grafana\/loki:3\.6\.0/);
+  assert.match(compose, /--config\.file=\/etc\/loki\/loki\.yml/);
+  assert.match(compose, /\.\/loki\/loki\.yml:\/etc\/loki\/loki\.yml:ro/);
+  assert.match(compose, /"\$\{EASYSUBWAY_LOKI_PORT:-3100\}:3100"/);
+  assert.match(compose, /loki-data:\/loki/);
+  assert.match(compose, /test: \["CMD", "loki", "-config\.file=\/etc\/loki\/loki\.yml", "-verify-config"\]/);
+
+  assert.match(lokiConfig, /auth_enabled: false/);
+  assert.match(lokiConfig, /http_listen_port: 3100/);
+  assert.match(lokiConfig, /path_prefix: \/loki/);
+  assert.match(lokiConfig, /chunks_directory: \/loki\/chunks/);
+  assert.match(lokiConfig, /rules_directory: \/loki\/rules/);
+  assert.match(lokiConfig, /store: tsdb/);
+  assert.match(lokiConfig, /object_store: filesystem/);
+
+  assert.match(lokiDatasource, /name: easysubway-loki/);
+  assert.match(lokiDatasource, /type: loki/);
+  assert.match(lokiDatasource, /url: http:\/\/loki:3100/);
+  assert.match(lokiDatasource, /isDefault: false/);
+  assert.match(prometheusDatasource, /isDefault: true/);
+});
+
 test("백엔드 스캐폴드는 eGovFrame 5.0 Spring Boot Java 21 헥사고날 프로젝트다", () => {
   const build = read("backend/build.gradle");
   const wrapper = read("backend/gradle/wrapper/gradle-wrapper.properties");


### PR DESCRIPTION
## 관련 이슈

close #435

## 작업 배경

- Prometheus/Grafana 기준선 이후 로컬에서 로그 저장소를 함께 확인할 수 있는 기준선이 필요했습니다.
- 운영 로그 수집기나 외부 클라우드 연동 전에, 로컬 Docker Compose에서 안전하게 확장 가능한 Loki 저장소와 Grafana datasource 계약을 먼저 고정했습니다.

## 작업 내용

- Docker Compose에 `grafana/loki:3.6.0` 기반 Loki 서비스를 추가했습니다.
- Loki는 로컬 파일시스템 저장소와 `loki-data` named volume을 사용하도록 구성했습니다.
- Loki HTTP 포트는 인증이 꺼진 로컬 기준선 특성에 맞춰 `127.0.0.1`에만 바인딩했습니다.
- Grafana provisioning에 `easysubway-loki` datasource를 추가하고 Prometheus datasource는 기본값으로 유지했습니다.
- Grafana가 Loki healthcheck 이후 시작되도록 의존성을 추가했습니다.
- repository contract에 Loki 서비스, 포트 바인딩, 설정 파일, Grafana datasource 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "Loki" tools/ci/repository-contract.test.mjs` 성공
  - `docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet` 성공
  - `docker run --rm -v /Volumes/MACSSD/Projects/GitProjects/swieun-jihacheol/infra/loki/loki.yml:/etc/loki/loki.yml:ro grafana/loki:3.6.0 -config.file=/etc/loki/loki.yml -verify-config` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공, 54개 테스트 통과
  - `git diff --check` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`

## 리뷰어 메모

- `grafana/loki:3.6.0` 이미지는 shell이 없어 `CMD-SHELL` healthcheck를 사용할 수 없습니다. healthcheck는 Loki binary의 `-verify-config` exec로 구성했습니다.
- CodeRabbit은 rate limit으로 실제 리뷰를 시작하지 못해 Codex CLI fallback review를 PR review 형식으로 기록했습니다.
- Codex CLI review 지적 2건은 같은 PR에서 수정했고, 최신 fallback review는 추가 지적 없이 완료됐습니다.
- 이번 PR은 로그 저장소와 Grafana datasource 기준선만 추가하며, Docker socket 기반 로그 수집기나 운영 배포 설정은 포함하지 않습니다.

## 리스크

- 실제 애플리케이션 로그 shipper는 아직 연결하지 않았으므로, 이번 변경만으로 로그가 자동 수집되지는 않습니다.
- Loki 로컬 저장소는 개발 환경 기준 named volume이며 운영 보존 정책으로 사용하지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
