### PR TITLE
[Build] 로컬 PostgreSQL 백업 복구 리허설 기준선 추가

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -563,9 +563,12 @@ test("로컬 PostgreSQL 백업과 복구 리허설 기준선을 제공한다", (
   assert.match(backupScript, /set -euo pipefail/);
   assert.match(backupScript, /EASYSUBWAY_ENV_FILE:-\$\{ROOT_DIR\}\/\.env\.example/);
   assert.match(backupScript, /EASYSUBWAY_BACKUP_DIR:-\$\{ROOT_DIR\}\/\.codex\/backups/);
+  assert.match(backupScript, /umask 077/);
+  assert.match(backupScript, /chmod 700 "\$\{BACKUP_DIR\}"/);
+  assert.match(backupScript, /mktemp "\$\{BACKUP_DIR\}\/easysubway-postgres-\$\{timestamp\}\.XXXXXX"/);
+  assert.match(backupScript, /backup_file="\$\{temp_file\}\.dump"/);
   assert.match(backupScript, /docker compose --env-file "\$\{ENV_FILE\}" -f "\$\{COMPOSE_FILE\}" exec -T postgres sh -lc/);
   assert.match(backupScript, /pg_dump --format=custom --no-owner --no-privileges -U "\$POSTGRES_USER" "\$POSTGRES_DB"/);
-  assert.match(backupScript, /easysubway-postgres-\$\{timestamp\}\.dump/);
   assert.match(backupScript, /test -s "\$\{backup_file\}"/);
 
   assert.match(restoreScript, /set -euo pipefail/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -556,6 +556,28 @@ test("로컬 PostGIS와 Redis 서비스가 Docker Compose에 정의된다", () =
   assert.match(compose, /^volumes:\n  postgres-data:\n  redis-data:/m);
 });
 
+test("로컬 PostgreSQL 백업과 복구 리허설 기준선을 제공한다", () => {
+  const backupScript = read("tools/ops/postgres-backup.sh");
+  const restoreScript = read("tools/ops/postgres-restore-rehearsal.sh");
+
+  assert.match(backupScript, /set -euo pipefail/);
+  assert.match(backupScript, /EASYSUBWAY_ENV_FILE:-\$\{ROOT_DIR\}\/\.env\.example/);
+  assert.match(backupScript, /EASYSUBWAY_BACKUP_DIR:-\$\{ROOT_DIR\}\/\.codex\/backups/);
+  assert.match(backupScript, /docker compose --env-file "\$\{ENV_FILE\}" -f "\$\{COMPOSE_FILE\}" exec -T postgres sh -lc/);
+  assert.match(backupScript, /pg_dump --format=custom --no-owner --no-privileges -U "\$POSTGRES_USER" "\$POSTGRES_DB"/);
+  assert.match(backupScript, /easysubway-postgres-\$\{timestamp\}\.dump/);
+  assert.match(backupScript, /test -s "\$\{backup_file\}"/);
+
+  assert.match(restoreScript, /set -euo pipefail/);
+  assert.match(restoreScript, /Usage: tools\/ops\/postgres-restore-rehearsal\.sh <backup-file>/);
+  assert.match(restoreScript, /EASYSUBWAY_RESTORE_DB:-easysubway_restore_rehearsal/);
+  assert.match(restoreScript, /docker compose --env-file "\$\{ENV_FILE\}" -f "\$\{COMPOSE_FILE\}" exec -T -e RESTORE_DB="\$\{RESTORE_DB\}" postgres sh -lc/);
+  assert.match(restoreScript, /dropdb --if-exists -U "\$POSTGRES_USER" "\$RESTORE_DB"/);
+  assert.match(restoreScript, /createdb -U "\$POSTGRES_USER" "\$RESTORE_DB"/);
+  assert.match(restoreScript, /pg_restore --clean --if-exists --no-owner --no-privileges -U "\$POSTGRES_USER" -d "\$RESTORE_DB"/);
+  assert.match(restoreScript, /trap cleanup EXIT/);
+});
+
 test("저장소 지속적 통합은 Docker Compose 설정을 검증한다", () => {
   const workflow = read(".github/workflows/ci.yml");
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -572,6 +572,7 @@ test("로컬 PostgreSQL 백업과 복구 리허설 기준선을 제공한다", (
   assert.match(restoreScript, /Usage: tools\/ops\/postgres-restore-rehearsal\.sh <backup-file>/);
   assert.match(restoreScript, /EASYSUBWAY_RESTORE_DB:-easysubway_restore_rehearsal/);
   assert.match(restoreScript, /docker compose --env-file "\$\{ENV_FILE\}" -f "\$\{COMPOSE_FILE\}" exec -T -e RESTORE_DB="\$\{RESTORE_DB\}" postgres sh -lc/);
+  assert.match(restoreScript, /sh -lc '\nset -eu\n/);
   assert.match(restoreScript, /dropdb --if-exists -U "\$POSTGRES_USER" "\$RESTORE_DB"/);
   assert.match(restoreScript, /createdb -U "\$POSTGRES_USER" "\$RESTORE_DB"/);
   assert.match(restoreScript, /pg_restore --clean --if-exists --no-owner --no-privileges -U "\$POSTGRES_USER" -d "\$RESTORE_DB"/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -567,15 +567,21 @@ test("로컬 PostgreSQL 백업과 복구 리허설 기준선을 제공한다", (
   assert.match(backupScript, /chmod 700 "\$\{BACKUP_DIR\}"/);
   assert.match(backupScript, /mktemp "\$\{BACKUP_DIR\}\/easysubway-postgres-\$\{timestamp\}\.XXXXXX"/);
   assert.match(backupScript, /backup_file="\$\{temp_file\}\.dump"/);
+  assert.match(backupScript, /trap cleanup EXIT/);
   assert.match(backupScript, /docker compose --env-file "\$\{ENV_FILE\}" -f "\$\{COMPOSE_FILE\}" exec -T postgres sh -lc/);
   assert.match(backupScript, /pg_dump --format=custom --no-owner --no-privileges -U "\$POSTGRES_USER" "\$POSTGRES_DB"/);
-  assert.match(backupScript, /test -s "\$\{backup_file\}"/);
+  assert.match(backupScript, /> "\$\{temp_file\}"/);
+  assert.match(backupScript, /test -s "\$\{temp_file\}"/);
+  assert.match(backupScript, /mv "\$\{temp_file\}" "\$\{backup_file\}"/);
+  assert.match(backupScript, /trap - EXIT/);
 
   assert.match(restoreScript, /set -euo pipefail/);
   assert.match(restoreScript, /Usage: tools\/ops\/postgres-restore-rehearsal\.sh <backup-file>/);
   assert.match(restoreScript, /EASYSUBWAY_RESTORE_DB:-easysubway_restore_rehearsal/);
   assert.match(restoreScript, /docker compose --env-file "\$\{ENV_FILE\}" -f "\$\{COMPOSE_FILE\}" exec -T -e RESTORE_DB="\$\{RESTORE_DB\}" postgres sh -lc/);
   assert.match(restoreScript, /sh -lc '\nset -eu\n/);
+  assert.match(restoreScript, /"\$POSTGRES_DB"\|postgres\|template0\|template1/);
+  assert.match(restoreScript, /Refusing to use protected restore database/);
   assert.match(restoreScript, /dropdb --if-exists -U "\$POSTGRES_USER" "\$RESTORE_DB"/);
   assert.match(restoreScript, /createdb -U "\$POSTGRES_USER" "\$RESTORE_DB"/);
   assert.match(restoreScript, /pg_restore --clean --if-exists --no-owner --no-privileges -U "\$POSTGRES_USER" -d "\$RESTORE_DB"/);

--- a/tools/ops/postgres-backup.sh
+++ b/tools/ops/postgres-backup.sh
@@ -14,11 +14,17 @@ chmod 700 "${BACKUP_DIR}"
 
 temp_file="$(mktemp "${BACKUP_DIR}/easysubway-postgres-${timestamp}.XXXXXX")"
 backup_file="${temp_file}.dump"
-mv "${temp_file}" "${backup_file}"
+
+cleanup() {
+	rm -f "${temp_file}"
+}
+trap cleanup EXIT
 
 docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" exec -T postgres sh -lc \
 	'pg_dump --format=custom --no-owner --no-privileges -U "$POSTGRES_USER" "$POSTGRES_DB"' \
-	> "${backup_file}"
+	> "${temp_file}"
 
-test -s "${backup_file}"
+test -s "${temp_file}"
+mv "${temp_file}" "${backup_file}"
+trap - EXIT
 printf '%s\n' "${backup_file}"

--- a/tools/ops/postgres-backup.sh
+++ b/tools/ops/postgres-backup.sh
@@ -6,10 +6,15 @@ ENV_FILE="${EASYSUBWAY_ENV_FILE:-${ROOT_DIR}/.env.example}"
 COMPOSE_FILE="${EASYSUBWAY_COMPOSE_FILE:-${ROOT_DIR}/infra/docker-compose.yml}"
 BACKUP_DIR="${1:-${EASYSUBWAY_BACKUP_DIR:-${ROOT_DIR}/.codex/backups}}"
 
+umask 077
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
-backup_file="${BACKUP_DIR}/easysubway-postgres-${timestamp}.dump"
 
 mkdir -p "${BACKUP_DIR}"
+chmod 700 "${BACKUP_DIR}"
+
+temp_file="$(mktemp "${BACKUP_DIR}/easysubway-postgres-${timestamp}.XXXXXX")"
+backup_file="${temp_file}.dump"
+mv "${temp_file}" "${backup_file}"
 
 docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" exec -T postgres sh -lc \
 	'pg_dump --format=custom --no-owner --no-privileges -U "$POSTGRES_USER" "$POSTGRES_DB"' \

--- a/tools/ops/postgres-backup.sh
+++ b/tools/ops/postgres-backup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="${EASYSUBWAY_ENV_FILE:-${ROOT_DIR}/.env.example}"
+COMPOSE_FILE="${EASYSUBWAY_COMPOSE_FILE:-${ROOT_DIR}/infra/docker-compose.yml}"
+BACKUP_DIR="${1:-${EASYSUBWAY_BACKUP_DIR:-${ROOT_DIR}/.codex/backups}}"
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+backup_file="${BACKUP_DIR}/easysubway-postgres-${timestamp}.dump"
+
+mkdir -p "${BACKUP_DIR}"
+
+docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" exec -T postgres sh -lc \
+	'pg_dump --format=custom --no-owner --no-privileges -U "$POSTGRES_USER" "$POSTGRES_DB"' \
+	> "${backup_file}"
+
+test -s "${backup_file}"
+printf '%s\n' "${backup_file}"

--- a/tools/ops/postgres-restore-rehearsal.sh
+++ b/tools/ops/postgres-restore-rehearsal.sh
@@ -13,7 +13,7 @@ if [[ -z "${BACKUP_FILE}" || ! -f "${BACKUP_FILE}" ]]; then
 fi
 
 cat "${BACKUP_FILE}" | docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" exec -T -e RESTORE_DB="${RESTORE_DB}" postgres sh -lc '
-set -euo pipefail
+set -eu
 
 cleanup() {
 	dropdb --if-exists -U "$POSTGRES_USER" "$RESTORE_DB"

--- a/tools/ops/postgres-restore-rehearsal.sh
+++ b/tools/ops/postgres-restore-rehearsal.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="${EASYSUBWAY_ENV_FILE:-${ROOT_DIR}/.env.example}"
+COMPOSE_FILE="${EASYSUBWAY_COMPOSE_FILE:-${ROOT_DIR}/infra/docker-compose.yml}"
+BACKUP_FILE="${1:-}"
+RESTORE_DB="${EASYSUBWAY_RESTORE_DB:-easysubway_restore_rehearsal}"
+
+if [[ -z "${BACKUP_FILE}" || ! -f "${BACKUP_FILE}" ]]; then
+	printf 'Usage: tools/ops/postgres-restore-rehearsal.sh <backup-file>\n' >&2
+	exit 2
+fi
+
+cat "${BACKUP_FILE}" | docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" exec -T -e RESTORE_DB="${RESTORE_DB}" postgres sh -lc '
+set -euo pipefail
+
+cleanup() {
+	dropdb --if-exists -U "$POSTGRES_USER" "$RESTORE_DB"
+}
+
+dropdb --if-exists -U "$POSTGRES_USER" "$RESTORE_DB"
+createdb -U "$POSTGRES_USER" "$RESTORE_DB"
+trap cleanup EXIT
+pg_restore --clean --if-exists --no-owner --no-privileges -U "$POSTGRES_USER" -d "$RESTORE_DB"
+'
+
+printf 'restore rehearsal succeeded: %s\n' "${RESTORE_DB}"

--- a/tools/ops/postgres-restore-rehearsal.sh
+++ b/tools/ops/postgres-restore-rehearsal.sh
@@ -19,6 +19,13 @@ cleanup() {
 	dropdb --if-exists -U "$POSTGRES_USER" "$RESTORE_DB"
 }
 
+case "$RESTORE_DB" in
+	"$POSTGRES_DB"|postgres|template0|template1)
+		printf 'Refusing to use protected restore database: %s\n' "$RESTORE_DB" >&2
+		exit 2
+		;;
+esac
+
 dropdb --if-exists -U "$POSTGRES_USER" "$RESTORE_DB"
 createdb -U "$POSTGRES_USER" "$RESTORE_DB"
 trap cleanup EXIT


### PR DESCRIPTION
## 관련 이슈

close #437

## 작업 배경

- 로컬 PostgreSQL/PostGIS 기준선은 있으나, 백업 파일 생성과 복구 가능 여부를 반복 확인하는 절차가 없었습니다.
- 장애 대응 준비를 위해 백업 생성 명령과 임시 데이터베이스 복구 리허설 명령을 같은 기준으로 실행할 수 있게 했습니다.

## 작업 내용

- `tools/ops/postgres-backup.sh`를 추가해 compose의 `postgres` 서비스에서 custom format dump 파일을 생성하도록 했습니다.
- 백업 파일은 private umask, `700` 백업 디렉터리, 충돌 방지 임시 파일, 성공 후 `.dump` rename 흐름으로 생성합니다.
- `tools/ops/postgres-restore-rehearsal.sh`를 추가해 백업 파일을 임시 DB에 복원한 뒤 정리하도록 했습니다.
- 복구 리허설은 앱 DB, `postgres`, template DB 이름을 보호 DB로 거부합니다.
- 기본 env는 `.env.example`, 기본 백업 위치는 추적되지 않는 `.codex/backups`로 지정했습니다.
- repository contract에 `pg_dump`, `pg_restore`, 임시 DB 생성/정리, 백업 파일 권한/생성 안전장치 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "백업|복구" tools/ci/repository-contract.test.mjs` 성공
  - `bash -n tools/ops/postgres-backup.sh` 성공
  - `bash -n tools/ops/postgres-restore-rehearsal.sh` 성공
  - `docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공, 55개 테스트 통과
  - `git diff --check` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`
  - PR CI 통과: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI, Dependency Vulnerability Scan / osv-scan
  - CodeRabbit은 rate limit으로 리뷰를 시작하지 못했고, Codex CLI fallback review에서 나온 지적을 반영한 뒤 최종 `Actionable comments posted: 0`을 확인했습니다.

## 리뷰어 메모

- 실제 백업/복구 리허설은 compose `postgres` 서비스가 실행 중일 때 수행합니다.
- 현재 로컬에서는 `postgres` 서비스가 떠 있지 않아 컨테이너를 새로 띄우는 방식의 상태 변경은 하지 않았고, 스크립트 구문과 계약 검증으로 확인했습니다.

## 리스크

- 이 스크립트는 로컬 운영 리허설 기준선이며 원격 자동 백업 스케줄러나 객체 스토리지 업로드는 포함하지 않습니다.
- 복구 리허설은 기본 임시 DB 이름 `easysubway_restore_rehearsal`을 사용하므로 같은 이름의 수동 DB가 있으면 삭제될 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
