### PR TITLE
[Feat] 신고 급증 알림 기준 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -47,9 +47,9 @@ class FacilityReportAdminPageController {
 		Model model
 	) {
 		List<FacilityReport> allReports = facilityReportUseCase.listReports(null);
-		List<FacilityReport> filteredReports = status == null
-			? allReports
-			: facilityReportUseCase.listReports(status);
+		List<FacilityReport> filteredReports = allReports.stream()
+			.filter(report -> status == null || report.status() == status)
+			.toList();
 		List<FacilityReportListPageRow> reports = filteredReports
 			.stream()
 			.map(FacilityReportListPageRow::from)

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -9,9 +9,12 @@ import com.easysubway.report.domain.FacilityReportStatus;
 import com.easysubway.report.domain.FacilityReportType;
 import java.math.BigDecimal;
 import java.security.Principal;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,10 +25,20 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Controller
 class FacilityReportAdminPageController {
 
-	private final FacilityReportUseCase facilityReportUseCase;
+	private static final int REPORT_SURGE_ALERT_THRESHOLD = 10;
+	private static final long REPORT_SURGE_LOOKBACK_HOURS = 24;
 
-	FacilityReportAdminPageController(FacilityReportUseCase facilityReportUseCase) {
+	private final FacilityReportUseCase facilityReportUseCase;
+	private final Clock clock;
+
+	@Autowired
+	FacilityReportAdminPageController(FacilityReportUseCase facilityReportUseCase, ObjectProvider<Clock> clockProvider) {
+		this(facilityReportUseCase, clockProvider.getIfAvailable(Clock::systemDefaultZone));
+	}
+
+	FacilityReportAdminPageController(FacilityReportUseCase facilityReportUseCase, Clock clock) {
 		this.facilityReportUseCase = facilityReportUseCase;
+		this.clock = clock;
 	}
 
 	@GetMapping("/admin/reports/page")
@@ -33,7 +46,11 @@ class FacilityReportAdminPageController {
 		@RequestParam(required = false) FacilityReportStatus status,
 		Model model
 	) {
-		List<FacilityReportListPageRow> reports = facilityReportUseCase.listReports(status)
+		List<FacilityReport> allReports = facilityReportUseCase.listReports(null);
+		List<FacilityReport> filteredReports = status == null
+			? allReports
+			: facilityReportUseCase.listReports(status);
+		List<FacilityReportListPageRow> reports = filteredReports
 			.stream()
 			.map(FacilityReportListPageRow::from)
 			.toList();
@@ -41,6 +58,7 @@ class FacilityReportAdminPageController {
 		model.addAttribute("reports", reports);
 		model.addAttribute("selectedStatus", status);
 		model.addAttribute("statusOptions", statusOptions());
+		model.addAttribute("reportSurgeAlert", ReportSurgeAlertView.from(allReports, clock));
 		return "admin/reports/list";
 	}
 
@@ -205,6 +223,36 @@ class FacilityReportAdminPageController {
 	}
 
 	record StatusOption(FacilityReportStatus value, String label) {
+	}
+
+	record ReportSurgeAlertView(
+		String title,
+		String label,
+		String description,
+		String alertClass
+	) {
+
+		static ReportSurgeAlertView from(List<FacilityReport> reports, Clock clock) {
+			LocalDateTime cutoff = LocalDateTime.now(clock).minusHours(REPORT_SURGE_LOOKBACK_HOURS);
+			long recentReportCount = reports.stream()
+				.filter(report -> !report.createdAt().isBefore(cutoff))
+				.count();
+
+			if (recentReportCount >= REPORT_SURGE_ALERT_THRESHOLD) {
+				return new ReportSurgeAlertView(
+					"신고 급증",
+					"점검 필요",
+					"최근 24시간 신고 %d건입니다. 신고가 평소보다 많습니다.".formatted(recentReportCount),
+					"warning"
+				);
+			}
+			return new ReportSurgeAlertView(
+				"신고 급증",
+				"정상",
+				"최근 24시간 신고 %d건입니다. 접수량은 정상 범위입니다.".formatted(recentReportCount),
+				"normal"
+			);
+		}
 	}
 
 	record ReviewAction(FacilityReportReviewDecision value, String label) {

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -24,6 +24,51 @@
 			line-height: 1.2;
 		}
 
+		.surge-alert {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) auto;
+			gap: 12px;
+			align-items: center;
+			margin-bottom: 20px;
+			padding: 16px 18px;
+			border: 1px solid #c9d6d7;
+			border-left: 6px solid #006d6f;
+			background: #fff;
+		}
+
+		.surge-alert.warning {
+			border-left-color: #c84a12;
+			background: #fff8f3;
+		}
+
+		.surge-alert h2 {
+			margin: 0 0 6px;
+			font-size: 18px;
+			line-height: 1.3;
+		}
+
+		.surge-alert p {
+			margin: 0;
+			color: #3f5658;
+			font-size: 15px;
+			line-height: 1.45;
+		}
+
+		.surge-alert .status-label {
+			justify-self: end;
+			padding: 6px 10px;
+			border-radius: 6px;
+			background: #e3f2ef;
+			color: #003d40;
+			font-weight: 800;
+			white-space: nowrap;
+		}
+
+		.surge-alert.warning .status-label {
+			background: #ffe8d9;
+			color: #8f2d00;
+		}
+
 		.status-filter {
 			display: flex;
 			flex-wrap: wrap;
@@ -88,6 +133,16 @@
 <body>
 <main>
 	<h1>시설 신고 검수</h1>
+
+	<section class="surge-alert"
+	         th:classappend="${reportSurgeAlert.alertClass}"
+	         aria-label="신고 급증 알림">
+		<div>
+			<h2 th:text="${reportSurgeAlert.title}">신고 급증</h2>
+			<p th:text="${reportSurgeAlert.description}">최근 24시간 신고 0건입니다. 접수량은 정상 범위입니다.</p>
+		</div>
+		<strong class="status-label" th:text="${reportSurgeAlert.label}">정상</strong>
+	</section>
 
 	<nav class="status-filter" aria-label="신고 상태 필터">
 		<a th:href="@{/admin/reports/page}" th:attr="aria-current=${selectedStatus == null ? 'page' : null}">전체</a>

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -51,6 +51,27 @@ class FacilityReportAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자는 신고 목록 화면에서 최근 24시간 신고 급증 경고를 확인한다")
+	void adminReportListPageShowsRecentReportSurgeAlert() throws Exception {
+		for (int index = 1; index <= 10; index++) {
+			createReport("최근 급증 신고 %02d".formatted(index));
+		}
+
+		String html = mockMvc.perform(get("/admin/reports/page")
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("신고 급증")
+			.contains("점검 필요")
+			.contains("신고가 평소보다 많습니다")
+			.containsPattern("최근 24시간 신고 \\d+건");
+	}
+
+	@Test
 	@DisplayName("관리자는 신고 상세 화면에서 사진과 위치와 검수 버튼을 확인한다")
 	void adminReportDetailPageShowsPhotoLocationAndReviewActions() throws Exception {
 		String reportId = createReportWithPhotoAndLocation("상세에서 확인할 신고");

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1187,6 +1187,9 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   );
   const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
   const controller = read("backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java");
+  const adminPageController = read(
+    "backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java",
+  );
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
   const operatorReportController = read(
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportController.java",
@@ -1231,6 +1234,7 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   const operatorDataCollectionFailuresTemplate = read(
     "backend/src/main/resources/templates/operator/data-collection-failures.html",
   );
+  const adminReportListTemplate = read("backend/src/main/resources/templates/admin/reports/list.html");
 
   assert.match(report, /record FacilityReport/);
   assert.match(report, /reviewedAt/);
@@ -1307,6 +1311,13 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(controller, /Principal principal/);
   assert.match(controller, /principal\.getName\(\)/);
   assert.match(controller, /@ResponseStatus\(HttpStatus\.CREATED\)/);
+  assert.match(adminPageController, /REPORT_SURGE_ALERT_THRESHOLD = 10/);
+  assert.match(adminPageController, /REPORT_SURGE_LOOKBACK_HOURS = 24/);
+  assert.match(adminPageController, /ReportSurgeAlertView/);
+  assert.match(adminPageController, /reportSurgeAlert/);
+  assert.match(adminPageController, /점검 필요/);
+  assert.match(adminReportListTemplate, /신고 급증/);
+  assert.match(adminReportListTemplate, /최근 24시간 신고/);
   assert.match(security, /@Order\(1\)[\s\S]*?securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(security, /anyRequest\(\)\.hasRole\("ADMIN"\)/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1316,6 +1316,7 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(adminPageController, /ReportSurgeAlertView/);
   assert.match(adminPageController, /reportSurgeAlert/);
   assert.match(adminPageController, /점검 필요/);
+  assert.doesNotMatch(adminPageController, /listReports\(status\)/);
   assert.match(adminReportListTemplate, /신고 급증/);
   assert.match(adminReportListTemplate, /최근 24시간 신고/);
   assert.match(security, /@Order\(1\)[\s\S]*?securityMatcher\("\/admin\/\*\*"\)/);


### PR DESCRIPTION
## 관련 이슈

close #445

## 작업 배경

- 시설 신고가 짧은 시간에 몰리면 특정 역 시설 장애나 데이터 오류가 동시에 발생했을 가능성이 높다.
- 관리자 시설 신고 검수 화면에서 최근 접수량 급증 여부를 바로 볼 수 있어야 운영자가 빠르게 확인 대상을 좁힐 수 있다.

## 작업 내용

- 관리자 시설 신고 목록 화면에 최근 24시간 신고 급증 알림 영역을 추가했다.
- 최근 24시간 전체 시설 신고가 10건 이상이면 `점검 필요`, 기준 미만이면 `정상`으로 표시하도록 했다.
- 신고 상태 필터를 적용해도 급증 알림은 전체 최근 접수량을 기준으로 계산하도록 했다.
- 시설 신고 화면 테스트와 repository contract 테스트에 급증 알림 기준을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests "*FacilityReportAdminPageControllerTest.adminReportListPageShowsRecentReportSurgeAlert"`: 실패 확인 후 구현, 이후 성공
  - `cd backend && ./gradlew test --tests "*FacilityReportAdminPageControllerTest"`: 성공
  - `cd backend && ./gradlew test --tests "*FacilityReport*"`: 성공
  - `cd backend && ./gradlew test`: 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`
  - GitHub Actions CI: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI, Dependency Vulnerability Scan / osv-scan 성공
  - CodeRabbit: actionable comment 없음
  - Codex CLI fallback review: 성능 지적 1건 확인 후 `7fd633d`에서 수정, thread resolved
  - merge 후 main CD `27796463397`: 성공
  - merge 후 main CI `27796463461`: 성공

## 리뷰어 메모

- `FacilityReportAdminPageController`의 `ReportSurgeAlertView`가 최근 24시간 전체 신고 수를 계산한다.
- 신고 목록 필터링은 기존 동작을 유지하고, 급증 기준만 전체 목록을 사용한다.

## 리스크

- 임계치 10건은 코드 상수로 고정되어 있어 운영 환경별 조정 화면은 이번 범위에 포함하지 않았다.
- 신고가 매우 많을 때 관리자 목록 조회에서 전체 신고를 함께 읽는 구조는 기존 목록 조회 방식의 범위 안에 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
