### PR TITLE
[Feat] 신고 처리 시간 운영 지표 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -10,6 +10,7 @@ import com.easysubway.report.domain.FacilityReportType;
 import java.math.BigDecimal;
 import java.security.Principal;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -59,6 +60,7 @@ class FacilityReportAdminPageController {
 		model.addAttribute("selectedStatus", status);
 		model.addAttribute("statusOptions", statusOptions());
 		model.addAttribute("reportSurgeAlert", ReportSurgeAlertView.from(allReports, clock));
+		model.addAttribute("processingTime", ReportProcessingTimeView.from(allReports));
 		return "admin/reports/list";
 	}
 
@@ -252,6 +254,52 @@ class FacilityReportAdminPageController {
 				"최근 24시간 신고 %d건입니다. 접수량은 정상 범위입니다.".formatted(recentReportCount),
 				"normal"
 			);
+		}
+	}
+
+	record ReportProcessingTimeView(
+		String title,
+		String label,
+		String description,
+		String metricClass
+	) {
+
+		static ReportProcessingTimeView from(List<FacilityReport> reports) {
+			List<Long> processingMinutes = reports.stream()
+				.filter(report -> report.reviewedAt() != null)
+				.map(report -> Duration.between(report.createdAt(), report.reviewedAt()).toMinutes())
+				.filter(minutes -> minutes >= 0)
+				.toList();
+			if (processingMinutes.isEmpty()) {
+				return new ReportProcessingTimeView(
+					"신고 처리 시간",
+					"처리 완료 신고 없음",
+					"검수 완료 후 평균 처리 시간을 표시합니다.",
+					"empty"
+				);
+			}
+
+			long averageMinutes = processingMinutes.stream()
+				.mapToLong(Long::longValue)
+				.sum() / processingMinutes.size();
+			return new ReportProcessingTimeView(
+				"신고 처리 시간",
+				"평균 " + durationLabel(averageMinutes),
+				"처리 완료 신고 %d건 기준입니다.".formatted(processingMinutes.size()),
+				"ok"
+			);
+		}
+
+		private static String durationLabel(long minutes) {
+			if (minutes < 60) {
+				return minutes + "분";
+			}
+			long hours = minutes / 60;
+			long remainingMinutes = minutes % 60;
+			if (remainingMinutes == 0) {
+				return hours + "시간";
+			}
+			return "%d시간 %d분".formatted(hours, remainingMinutes);
 		}
 	}
 

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -69,6 +69,50 @@
 			color: #8f2d00;
 		}
 
+		.processing-time {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) auto;
+			gap: 12px;
+			align-items: center;
+			margin-bottom: 20px;
+			padding: 16px 18px;
+			border: 1px solid #c9d6d7;
+			border-left: 6px solid #005e68;
+			background: #fff;
+		}
+
+		.processing-time.empty {
+			border-left-color: #7b9294;
+		}
+
+		.processing-time h2 {
+			margin: 0 0 6px;
+			font-size: 18px;
+			line-height: 1.3;
+		}
+
+		.processing-time p {
+			margin: 0;
+			color: #3f5658;
+			font-size: 15px;
+			line-height: 1.45;
+		}
+
+		.processing-time .metric-label {
+			justify-self: end;
+			padding: 6px 10px;
+			border-radius: 6px;
+			background: #e4f0ff;
+			color: #06436f;
+			font-weight: 800;
+			white-space: nowrap;
+		}
+
+		.processing-time.empty .metric-label {
+			background: #eef2f2;
+			color: #465f61;
+		}
+
 		.status-filter {
 			display: flex;
 			flex-wrap: wrap;
@@ -142,6 +186,16 @@
 			<p th:text="${reportSurgeAlert.description}">최근 24시간 신고 0건입니다. 접수량은 정상 범위입니다.</p>
 		</div>
 		<strong class="status-label" th:text="${reportSurgeAlert.label}">정상</strong>
+	</section>
+
+	<section class="processing-time"
+	         th:classappend="${processingTime.metricClass}"
+	         aria-label="신고 처리 시간 지표">
+		<div>
+			<h2 th:text="${processingTime.title}">신고 처리 시간</h2>
+			<p th:text="${processingTime.description}">검수 완료 후 평균 처리 시간을 표시합니다.</p>
+		</div>
+		<strong class="metric-label" th:text="${processingTime.label}">처리 완료 신고 없음</strong>
 	</section>
 
 	<nav class="status-filter" aria-label="신고 상태 필터">

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -47,7 +47,9 @@ class FacilityReportAdminPageControllerTest {
 			.contains("접수됨")
 			.contains("관리자 목록에서 볼 신고")
 			.contains("/admin/reports/%s/page".formatted(reportId))
-			.contains("status=SUBMITTED");
+			.contains("status=SUBMITTED")
+			.contains("신고 처리 시간")
+			.contains("처리 완료 신고 없음");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportProcessingTimeViewTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportProcessingTimeViewTest.java
@@ -1,0 +1,73 @@
+package com.easysubway.report.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.report.domain.FacilityReport;
+import com.easysubway.report.domain.FacilityReportStatus;
+import com.easysubway.report.domain.FacilityReportType;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("시설 신고 처리 시간 지표")
+class FacilityReportProcessingTimeViewTest {
+
+	@Test
+	@DisplayName("검수 완료 신고의 평균 처리 시간과 처리 완료 건수를 표시한다")
+	void processingTimeViewShowsAverageDurationForReviewedReports() {
+		LocalDateTime baseTime = LocalDateTime.parse("2026-06-19T09:00:00");
+
+		var view = FacilityReportAdminPageController.ReportProcessingTimeView.from(List.of(
+			report("accepted", baseTime, baseTime.plusMinutes(90), FacilityReportStatus.ACCEPTED),
+			report("rejected", baseTime, baseTime.plusMinutes(30), FacilityReportStatus.REJECTED),
+			report("submitted", baseTime, null, FacilityReportStatus.SUBMITTED)
+		));
+
+		assertThat(view.title()).isEqualTo("신고 처리 시간");
+		assertThat(view.label()).isEqualTo("평균 1시간");
+		assertThat(view.description()).isEqualTo("처리 완료 신고 2건 기준입니다.");
+		assertThat(view.metricClass()).isEqualTo("ok");
+	}
+
+	@Test
+	@DisplayName("검수 완료 신고가 없으면 빈 처리 상태를 표시한다")
+	void processingTimeViewShowsEmptyStateWithoutReviewedReports() {
+		LocalDateTime baseTime = LocalDateTime.parse("2026-06-19T09:00:00");
+
+		var view = FacilityReportAdminPageController.ReportProcessingTimeView.from(List.of(
+			report("submitted", baseTime, null, FacilityReportStatus.SUBMITTED)
+		));
+
+		assertThat(view.title()).isEqualTo("신고 처리 시간");
+		assertThat(view.label()).isEqualTo("처리 완료 신고 없음");
+		assertThat(view.description()).isEqualTo("검수 완료 후 평균 처리 시간을 표시합니다.");
+		assertThat(view.metricClass()).isEqualTo("empty");
+	}
+
+	private static FacilityReport report(
+		String id,
+		LocalDateTime createdAt,
+		LocalDateTime reviewedAt,
+		FacilityReportStatus status
+	) {
+		return new FacilityReport(
+			id,
+			"user-" + id,
+			"station-sangnoksu",
+			"facility-sangnoksu-elevator-1",
+			FacilityReportType.BROKEN,
+			"처리 시간 지표 테스트 신고",
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			status,
+			createdAt,
+			reviewedAt,
+			reviewedAt == null ? null : "admin-test"
+		);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1317,8 +1317,13 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(adminPageController, /reportSurgeAlert/);
   assert.match(adminPageController, /점검 필요/);
   assert.doesNotMatch(adminPageController, /listReports\(status\)/);
+  assert.match(adminPageController, /ReportProcessingTimeView/);
+  assert.match(adminPageController, /processingTime/);
+  assert.match(adminPageController, /Duration\.between\(report\.createdAt\(\), report\.reviewedAt\(\)\)/);
   assert.match(adminReportListTemplate, /신고 급증/);
   assert.match(adminReportListTemplate, /최근 24시간 신고/);
+  assert.match(adminReportListTemplate, /신고 처리 시간/);
+  assert.match(adminReportListTemplate, /처리 완료 신고 없음/);
   assert.match(security, /@Order\(1\)[\s\S]*?securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(security, /anyRequest\(\)\.hasRole\("ADMIN"\)/);


### PR DESCRIPTION
## 관련 이슈

close #447

## 작업 배경

- 시설 신고는 접수 후 검수 완료까지의 시간이 길어지면 이동약자가 오래된 시설 정보를 보고 이동 계획을 세울 수 있다.
- 관리자 시설 신고 검수 화면에서 평균 처리 시간을 함께 확인하면 신고 업무 지연을 빠르게 파악할 수 있다.

## 작업 내용

- 관리자 시설 신고 목록 화면에 `신고 처리 시간` 운영 지표 영역을 추가했다.
- 검수 완료 시각이 있는 신고만 대상으로 접수 시각부터 검수 시각까지의 평균 처리 시간을 계산한다.
- 검수 완료 신고가 없으면 `처리 완료 신고 없음` 상태를 표시한다.
- 처리 시간 view 단위 테스트, 관리자 화면 회귀 테스트, repository contract를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests "*FacilityReportProcessingTimeViewTest"`: 실패 확인 후 구현, 이후 성공
  - `cd backend && ./gradlew test --tests "*FacilityReportAdminPageControllerTest"`: 성공
  - `cd backend && ./gradlew test --tests "*FacilityReport*"`: 성공
  - `cd backend && ./gradlew test`: 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`
  - PR CI: Android CI, Backend CI, Mobile App CI, Repository CI, iOS CI, Dependency Vulnerability Scan, Changes 모두 성공
  - CodeRabbit: rate limit으로 실제 리뷰가 시작되지 않아 Codex CLI fallback review를 PR review로 게시, actionable 0건
  - post-merge CD: `27797138014` 성공
  - post-merge CI: `27797138129` 성공

## 리뷰어 메모

- `ReportProcessingTimeView`는 `reviewedAt`이 있는 신고만 평균 처리 시간 계산에 포함한다.
- 접수 시각보다 검수 시각이 빠른 비정상 데이터는 운영 지표에서 제외한다.

## 리스크

- 현재 지표는 전체 관리자 신고 목록 기준 평균이며 운영자별, 역별, SLA별 분리는 이번 범위에 포함하지 않았다.
- 평균 지표라 긴 처리 건이 일부 있을 때 개별 지연 신고를 직접 노출하지는 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
