### PR TITLE
[Feat] 상록수역 현장 검증 기준선 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminController.java
+++ b/backend/src/main/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminController.java
@@ -1,0 +1,76 @@
+package com.easysubway.field.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.field.application.port.in.FieldVerificationUseCase;
+import com.easysubway.field.domain.FieldVerificationItem;
+import com.easysubway.field.domain.FieldVerificationItemType;
+import com.easysubway.field.domain.FieldVerificationSession;
+import com.easysubway.field.domain.FieldVerificationStatus;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class FieldVerificationAdminController {
+
+	private final FieldVerificationUseCase fieldVerificationUseCase;
+
+	FieldVerificationAdminController(FieldVerificationUseCase fieldVerificationUseCase) {
+		this.fieldVerificationUseCase = fieldVerificationUseCase;
+	}
+
+	@GetMapping("/admin/field-verifications/stations/{stationId}")
+	ApiResponse<FieldVerificationView> stationFieldVerification(@PathVariable String stationId) {
+		return ApiResponse.ok(FieldVerificationView.from(fieldVerificationUseCase.getStationVerification(stationId)));
+	}
+
+	record FieldVerificationView(
+		String sessionId,
+		String stationId,
+		String stationName,
+		LocalDate verifiedAt,
+		String verifiedBy,
+		FieldVerificationStatus status,
+		String note,
+		List<FieldVerificationItemView> items
+	) {
+
+		static FieldVerificationView from(FieldVerificationSession session) {
+			return new FieldVerificationView(
+				session.id(),
+				session.stationId(),
+				session.stationName(),
+				session.verifiedAt(),
+				session.verifiedBy(),
+				session.status(),
+				session.note(),
+				session.items().stream()
+					.map(FieldVerificationItemView::from)
+					.toList()
+			);
+		}
+	}
+
+	record FieldVerificationItemView(
+		String itemId,
+		FieldVerificationItemType type,
+		String label,
+		String targetName,
+		FieldVerificationStatus status,
+		String note
+	) {
+
+		static FieldVerificationItemView from(FieldVerificationItem item) {
+			return new FieldVerificationItemView(
+				item.id(),
+				item.type(),
+				item.type().label(),
+				item.targetName(),
+				item.status(),
+				item.note()
+			);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/field/application/port/in/FieldVerificationUseCase.java
+++ b/backend/src/main/java/com/easysubway/field/application/port/in/FieldVerificationUseCase.java
@@ -1,0 +1,8 @@
+package com.easysubway.field.application.port.in;
+
+import com.easysubway.field.domain.FieldVerificationSession;
+
+public interface FieldVerificationUseCase {
+
+	FieldVerificationSession getStationVerification(String stationId);
+}

--- a/backend/src/main/java/com/easysubway/field/application/service/FieldVerificationService.java
+++ b/backend/src/main/java/com/easysubway/field/application/service/FieldVerificationService.java
@@ -1,0 +1,50 @@
+package com.easysubway.field.application.service;
+
+import com.easysubway.common.error.ResourceNotFoundException;
+import com.easysubway.field.application.port.in.FieldVerificationUseCase;
+import com.easysubway.field.domain.FieldVerificationItem;
+import com.easysubway.field.domain.FieldVerificationItemType;
+import com.easysubway.field.domain.FieldVerificationSession;
+import com.easysubway.field.domain.FieldVerificationStatus;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FieldVerificationService implements FieldVerificationUseCase {
+
+	private static final String SANGNOKSU_STATION_ID = "station-sangnoksu";
+	private static final FieldVerificationSession SANGNOKSU_BASELINE = new FieldVerificationSession(
+		"field-verification-sangnoksu-2026-06",
+		SANGNOKSU_STATION_ID,
+		"상록수역",
+		LocalDate.of(2026, 6, 19),
+		"field-team",
+		FieldVerificationStatus.IN_PROGRESS,
+		"첫 현장 검증 지역 기준선",
+		List.of(
+			item("field-verification-sangnoksu-exit", FieldVerificationItemType.EXIT, "주요 출구 연결", FieldVerificationStatus.VERIFIED),
+			item("field-verification-sangnoksu-elevator", FieldVerificationItemType.ELEVATOR, "엘리베이터 위치와 운행 상태", FieldVerificationStatus.VERIFIED),
+			item("field-verification-sangnoksu-escalator", FieldVerificationItemType.ESCALATOR, "에스컬레이터 위치와 방향", FieldVerificationStatus.PLANNED),
+			item("field-verification-sangnoksu-restroom", FieldVerificationItemType.RESTROOM, "일반/장애인 화장실 위치", FieldVerificationStatus.PLANNED),
+			item("field-verification-sangnoksu-platform-transfer", FieldVerificationItemType.PLATFORM_TRANSFER, "승강장과 환승 접근 동선", FieldVerificationStatus.PLANNED)
+		)
+	);
+
+	@Override
+	public FieldVerificationSession getStationVerification(String stationId) {
+		if (SANGNOKSU_STATION_ID.equals(stationId)) {
+			return SANGNOKSU_BASELINE;
+		}
+		throw new ResourceNotFoundException("현장 검증 기준선을 찾을 수 없습니다.");
+	}
+
+	private static FieldVerificationItem item(
+		String id,
+		FieldVerificationItemType type,
+		String targetName,
+		FieldVerificationStatus status
+	) {
+		return new FieldVerificationItem(id, type, targetName, status, null);
+	}
+}

--- a/backend/src/main/java/com/easysubway/field/domain/FieldVerificationItem.java
+++ b/backend/src/main/java/com/easysubway/field/domain/FieldVerificationItem.java
@@ -1,0 +1,39 @@
+package com.easysubway.field.domain;
+
+public record FieldVerificationItem(
+	String id,
+	FieldVerificationItemType type,
+	String targetName,
+	FieldVerificationStatus status,
+	String note
+) {
+
+	public FieldVerificationItem {
+		id = requireText(id, "id");
+		type = requireNonNull(type, "type");
+		targetName = requireText(targetName, "targetName");
+		status = requireNonNull(status, "status");
+		note = cleanOptionalText(note);
+	}
+
+	private static String requireText(String value, String fieldName) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(fieldName + " must not be blank.");
+		}
+		return value.trim();
+	}
+
+	private static String cleanOptionalText(String value) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		return value.trim();
+	}
+
+	private static <T> T requireNonNull(T value, String fieldName) {
+		if (value == null) {
+			throw new IllegalArgumentException(fieldName + " must not be null.");
+		}
+		return value;
+	}
+}

--- a/backend/src/main/java/com/easysubway/field/domain/FieldVerificationItemType.java
+++ b/backend/src/main/java/com/easysubway/field/domain/FieldVerificationItemType.java
@@ -1,0 +1,19 @@
+package com.easysubway.field.domain;
+
+public enum FieldVerificationItemType {
+	EXIT("출구"),
+	ELEVATOR("엘리베이터"),
+	ESCALATOR("에스컬레이터"),
+	RESTROOM("화장실"),
+	PLATFORM_TRANSFER("승강장/환승 동선");
+
+	private final String label;
+
+	FieldVerificationItemType(String label) {
+		this.label = label;
+	}
+
+	public String label() {
+		return label;
+	}
+}

--- a/backend/src/main/java/com/easysubway/field/domain/FieldVerificationSession.java
+++ b/backend/src/main/java/com/easysubway/field/domain/FieldVerificationSession.java
@@ -1,0 +1,57 @@
+package com.easysubway.field.domain;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record FieldVerificationSession(
+	String id,
+	String stationId,
+	String stationName,
+	LocalDate verifiedAt,
+	String verifiedBy,
+	FieldVerificationStatus status,
+	String note,
+	List<FieldVerificationItem> items
+) {
+
+	public FieldVerificationSession {
+		id = requireText(id, "id");
+		stationId = requireText(stationId, "stationId");
+		stationName = requireText(stationName, "stationName");
+		verifiedAt = requireNonNull(verifiedAt, "verifiedAt");
+		verifiedBy = requireText(verifiedBy, "verifiedBy");
+		status = requireNonNull(status, "status");
+		note = cleanOptionalText(note);
+		items = cleanItems(items);
+	}
+
+	private static List<FieldVerificationItem> cleanItems(List<FieldVerificationItem> values) {
+		if (values == null || values.isEmpty()) {
+			throw new IllegalArgumentException("items must not be empty.");
+		}
+		return List.copyOf(values.stream()
+			.map(value -> requireNonNull(value, "items"))
+			.toList());
+	}
+
+	private static String requireText(String value, String fieldName) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(fieldName + " must not be blank.");
+		}
+		return value.trim();
+	}
+
+	private static String cleanOptionalText(String value) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		return value.trim();
+	}
+
+	private static <T> T requireNonNull(T value, String fieldName) {
+		if (value == null) {
+			throw new IllegalArgumentException(fieldName + " must not be null.");
+		}
+		return value;
+	}
+}

--- a/backend/src/main/java/com/easysubway/field/domain/FieldVerificationStatus.java
+++ b/backend/src/main/java/com/easysubway/field/domain/FieldVerificationStatus.java
@@ -1,0 +1,8 @@
+package com.easysubway.field.domain;
+
+public enum FieldVerificationStatus {
+	PLANNED,
+	IN_PROGRESS,
+	VERIFIED,
+	NEEDS_RECHECK
+}

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -124,6 +124,40 @@ CREATE INDEX IF NOT EXISTS idx_data_source_raw_archives_run
 CREATE INDEX IF NOT EXISTS idx_data_source_raw_archives_source_captured
 	ON data_source_raw_archives (source, captured_at DESC, archive_id ASC);
 
+CREATE TABLE IF NOT EXISTS field_verification_sessions (
+	session_id VARCHAR(120) NOT NULL PRIMARY KEY,
+	station_id VARCHAR(120) NOT NULL,
+	station_name VARCHAR(120) NOT NULL,
+	verified_at DATE NOT NULL,
+	verified_by VARCHAR(120) NOT NULL,
+	status VARCHAR(40) NOT NULL,
+	note VARCHAR(1000),
+	CONSTRAINT chk_field_verification_sessions_status
+		CHECK (status IN ('PLANNED', 'IN_PROGRESS', 'VERIFIED', 'NEEDS_RECHECK'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_field_verification_sessions_station
+	ON field_verification_sessions (station_id, verified_at DESC, session_id ASC);
+
+CREATE TABLE IF NOT EXISTS field_verification_items (
+	item_id VARCHAR(120) NOT NULL PRIMARY KEY,
+	session_id VARCHAR(120) NOT NULL,
+	item_type VARCHAR(40) NOT NULL,
+	target_name VARCHAR(200) NOT NULL,
+	status VARCHAR(40) NOT NULL,
+	note VARCHAR(1000),
+	CONSTRAINT fk_field_verification_items_session
+		FOREIGN KEY (session_id) REFERENCES field_verification_sessions(session_id)
+		ON DELETE CASCADE ON UPDATE CASCADE,
+	CONSTRAINT chk_field_verification_items_type
+		CHECK (item_type IN ('EXIT', 'ELEVATOR', 'ESCALATOR', 'RESTROOM', 'PLATFORM_TRANSFER')),
+	CONSTRAINT chk_field_verification_items_status
+		CHECK (status IN ('PLANNED', 'IN_PROGRESS', 'VERIFIED', 'NEEDS_RECHECK'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_field_verification_items_session
+	ON field_verification_items (session_id, item_type ASC, item_id ASC);
+
 CREATE TABLE IF NOT EXISTS mobility_profiles (
 	user_id VARCHAR(120) NOT NULL PRIMARY KEY,
 	mobility_type VARCHAR(40) NOT NULL,

--- a/backend/src/test/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminControllerTest.java
+++ b/backend/src/test/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminControllerTest.java
@@ -1,0 +1,57 @@
+package com.easysubway.field.adapter.in.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.user.username=anonymous-user-1",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("관리자 현장 검증 API")
+class FieldVerificationAdminControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("관리자는 역별 현장 검증 세션과 항목을 조회한다")
+	void adminGetsStationFieldVerification() throws Exception {
+		mockMvc.perform(get("/admin/field-verifications/stations/station-sangnoksu")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.sessionId").value("field-verification-sangnoksu-2026-06"))
+			.andExpect(jsonPath("$.data.stationId").value("station-sangnoksu"))
+			.andExpect(jsonPath("$.data.stationName").value("상록수역"))
+			.andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+			.andExpect(jsonPath("$.data.items[0].type").value("EXIT"))
+			.andExpect(jsonPath("$.data.items[0].label").value("출구"))
+			.andExpect(jsonPath("$.data.items[4].type").value("PLATFORM_TRANSFER"))
+			.andExpect(jsonPath("$.data.items[4].label").value("승강장/환승 동선"));
+	}
+
+	@Test
+	@DisplayName("현장 검증 API는 관리자 인증을 요구한다")
+	void fieldVerificationRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/field-verifications/stations/station-sangnoksu"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/field-verifications/stations/station-sangnoksu")
+				.with(httpBasic("anonymous-user-1", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+}

--- a/backend/src/test/java/com/easysubway/field/application/service/FieldVerificationServiceTest.java
+++ b/backend/src/test/java/com/easysubway/field/application/service/FieldVerificationServiceTest.java
@@ -1,0 +1,40 @@
+package com.easysubway.field.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.field.domain.FieldVerificationItemType;
+import com.easysubway.field.domain.FieldVerificationStatus;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("현장 검증 기준선")
+class FieldVerificationServiceTest {
+
+	private final FieldVerificationService service = new FieldVerificationService();
+
+	@Test
+	@DisplayName("상록수역 필수 현장 검증 항목을 조회한다")
+	void getsSangnoksuFieldVerificationBaseline() {
+		var session = service.getStationVerification("station-sangnoksu");
+
+		assertThat(session.id()).isEqualTo("field-verification-sangnoksu-2026-06");
+		assertThat(session.stationId()).isEqualTo("station-sangnoksu");
+		assertThat(session.stationName()).isEqualTo("상록수역");
+		assertThat(session.verifiedAt()).isEqualTo(LocalDate.of(2026, 6, 19));
+		assertThat(session.verifiedBy()).isEqualTo("field-team");
+		assertThat(session.status()).isEqualTo(FieldVerificationStatus.IN_PROGRESS);
+		assertThat(session.items())
+			.extracting(item -> item.type())
+			.containsExactly(
+				FieldVerificationItemType.EXIT,
+				FieldVerificationItemType.ELEVATOR,
+				FieldVerificationItemType.ESCALATOR,
+				FieldVerificationItemType.RESTROOM,
+				FieldVerificationItemType.PLATFORM_TRANSFER
+			);
+		assertThat(session.items())
+			.extracting(item -> item.status())
+			.containsOnly(FieldVerificationStatus.PLANNED, FieldVerificationStatus.VERIFIED);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2174,6 +2174,54 @@ test("데이터 소스 원본 archive는 로컬 전용 산출물 기준선을 �
   assert.match(archiveScript, /printf 'data source archive written: %s\\n' "\$\{run_dir\}"/);
 });
 
+test("현장 검증 기준선은 세션과 항목을 관리자 API로 추적한다", () => {
+  const batchPostgresSchema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
+  const session = read("backend/src/main/java/com/easysubway/field/domain/FieldVerificationSession.java");
+  const item = read("backend/src/main/java/com/easysubway/field/domain/FieldVerificationItem.java");
+  const itemType = read("backend/src/main/java/com/easysubway/field/domain/FieldVerificationItemType.java");
+  const status = read("backend/src/main/java/com/easysubway/field/domain/FieldVerificationStatus.java");
+  const useCase = read("backend/src/main/java/com/easysubway/field/application/port/in/FieldVerificationUseCase.java");
+  const service = read("backend/src/main/java/com/easysubway/field/application/service/FieldVerificationService.java");
+  const controller = read("backend/src/main/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminController.java");
+  const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
+
+  assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS field_verification_sessions/);
+  assert.match(batchPostgresSchema, /session_id VARCHAR\(120\) NOT NULL PRIMARY KEY/);
+  assert.match(batchPostgresSchema, /station_id VARCHAR\(120\) NOT NULL/);
+  assert.match(batchPostgresSchema, /verified_at DATE NOT NULL/);
+  assert.match(batchPostgresSchema, /verified_by VARCHAR\(120\) NOT NULL/);
+  assert.match(batchPostgresSchema, /CONSTRAINT chk_field_verification_sessions_status/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_field_verification_sessions_station/);
+  assert.match(batchPostgresSchema, /CREATE TABLE IF NOT EXISTS field_verification_items/);
+  assert.match(batchPostgresSchema, /item_type VARCHAR\(40\) NOT NULL/);
+  assert.match(batchPostgresSchema, /FOREIGN KEY \(session_id\) REFERENCES field_verification_sessions\(session_id\)/);
+  assert.match(batchPostgresSchema, /CONSTRAINT chk_field_verification_items_type/);
+  assert.match(batchPostgresSchema, /CONSTRAINT chk_field_verification_items_status/);
+  assert.match(batchPostgresSchema, /CREATE INDEX IF NOT EXISTS idx_field_verification_items_session/);
+
+  assert.match(session, /record FieldVerificationSession/);
+  assert.match(session, /List<FieldVerificationItem> items/);
+  assert.match(item, /record FieldVerificationItem/);
+  assert.match(itemType, /EXIT\("출구"\)/);
+  assert.match(itemType, /PLATFORM_TRANSFER\("승강장\/환승 동선"\)/);
+  assert.match(status, /PLANNED/);
+  assert.match(status, /IN_PROGRESS/);
+  assert.match(status, /VERIFIED/);
+  assert.match(status, /NEEDS_RECHECK/);
+  assert.match(useCase, /FieldVerificationSession getStationVerification\(String stationId\)/);
+  assert.match(service, /SANGNOKSU_STATION_ID = "station-sangnoksu"/);
+  assert.match(service, /field-verification-sangnoksu-2026-06/);
+  assert.match(service, /FieldVerificationItemType\.EXIT/);
+  assert.match(service, /FieldVerificationItemType\.ELEVATOR/);
+  assert.match(service, /FieldVerificationItemType\.ESCALATOR/);
+  assert.match(service, /FieldVerificationItemType\.RESTROOM/);
+  assert.match(service, /FieldVerificationItemType\.PLATFORM_TRANSFER/);
+  assert.match(controller, /@GetMapping\("\/admin\/field-verifications\/stations\/\{stationId\}"\)/);
+  assert.match(controller, /ApiResponse<FieldVerificationView>/);
+  assert.match(controller, /record FieldVerificationItemView/);
+  assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
+});
+
 test("백엔드 데이터 품질 요약은 관리자 API와 헥사고날 경계를 따른다", () => {
   const summary = read("backend/src/main/java/com/easysubway/quality/domain/DataQualitySummary.java");
   const useCase = read("backend/src/main/java/com/easysubway/quality/application/port/in/DataQualityUseCase.java");


### PR DESCRIPTION
## 관련 이슈

close #453

## 작업 배경

- 전국 베타 출시 전에는 첫 현장 검증 지역인 상록수역에서 실제로 확인해야 할 출구, 엘리베이터, 에스컬레이터, 화장실, 승강장/환승 접근 동선을 운영 데이터로 추적해야 한다.
- 기존 구조도 검수와 사용자 신고 검수만으로는 현장 이동 동선 검증 범위와 항목 상태를 분리해서 확인하기 어렵다.

## 작업 내용

- `field` 도메인을 추가해 현장 검증 세션, 검증 항목, 항목 종류, 검증 상태를 표현했다.
- 상록수역 기준 현장 검증 세션 seed와 관리자 조회 use case를 추가했다.
- `GET /admin/field-verifications/stations/{stationId}` 관리자 API를 추가해 현장 검증 세션과 항목 목록을 조회할 수 있게 했다.
- PostgreSQL schema에 `field_verification_sessions`, `field_verification_items` 테이블과 type/status CHECK, 조회 index 기준을 추가했다.
- backend test와 repository contract로 API, 도메인, schema 기준을 고정했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests '*FieldVerification*'` (backend 디렉터리): 새 클래스 미구현으로 실패 확인
  - `backend/gradlew -p backend test --tests '*FieldVerification*'`: 구현 후 성공
  - `node --test --test-name-pattern "현장 검증" tools/ci/repository-contract.test.mjs`: 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 58개 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`
  - PR CI run `27799374468`: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI, Dependency Vulnerability Scan 모두 성공
  - OSV scanner run `82266202512`: 성공
  - merge 후 CD run `27799542289`: 성공
  - merge 후 CI run `27799542371`: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 성공, Dependency Vulnerability Scan skipped

## 리뷰어 메모

- 이번 범위는 상록수역 현장 검증 기준선을 관리자 API와 schema로 추적 가능하게 만드는 것이다.
- 실제 현장 검증 입력/수정 화면, 모바일 사용자 노출, 외부 지도/공공데이터 호출은 포함하지 않았다.
- `PLATFORM_TRANSFER` 항목은 승강장 접근과 환승 동선 검증을 하나의 필수 항목으로 묶었다.
- CodeRabbit 리뷰는 완료됐고 별도 inline 지적은 없었다.

## 리스크

- 현재 구현은 상록수역 기준 read-only seed이므로 다른 역의 현장 검증 데이터 입력과 영속 저장은 후속 작업이 필요하다.
- schema는 운영 DB 적용 대상이므로 배포 전 init schema 적용 순서를 확인해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
