### PR TITLE
[Feat] 운영기관 제휴 제안 export 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportController.java
@@ -1,11 +1,17 @@
 package com.easysubway.operator.adapter.in.web;
 
 import com.easysubway.common.web.ApiResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 class OperatorAccessibilityReportController {
+
+	private static final String TEXT_CSV_UTF8 = "text/csv;charset=UTF-8";
+	private static final String PROPOSAL_FILENAME = "easysubway-operator-accessibility-proposal.csv";
 
 	private final OperatorAccessibilityReportAssembler reportAssembler;
 
@@ -16,5 +22,48 @@ class OperatorAccessibilityReportController {
 	@GetMapping("/operator/api/accessibility-report")
 	ApiResponse<OperatorAccessibilityReportView> accessibilityReport() {
 		return ApiResponse.ok(reportAssembler.assemble());
+	}
+
+	@GetMapping("/operator/api/accessibility-report/proposal.csv")
+	ResponseEntity<String> partnershipProposalCsv() {
+		HttpHeaders headers = new HttpHeaders();
+		headers.add(HttpHeaders.CONTENT_TYPE, TEXT_CSV_UTF8);
+		headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + PROPOSAL_FILENAME + "\"");
+		return new ResponseEntity<>(toCsv(reportAssembler.assemble()), headers, HttpStatus.OK);
+	}
+
+	private String toCsv(OperatorAccessibilityReportView report) {
+		StringBuilder csv = new StringBuilder("section,metric,value,detail\n");
+		appendRow(csv, "summary", "totalStations", report.totalStations(), "");
+		appendRow(csv, "summary", "totalFacilities", report.totalFacilities(), "");
+		appendRow(csv, "summary", "needsVerificationFacilityCount", report.needsVerificationFacilityCount(), "");
+		appendRow(csv, "summary", "delayedFacilityStatusCount", report.delayedFacilityStatusCount(), "");
+		appendRow(csv, "summary", "missingStationVerificationDateCount", report.missingStationVerificationDateCount(), "");
+		report.stationAccessibilityScoreRows()
+			.forEach(row -> appendRow(csv, "stationScore", row.stationName(), row.score(), row.region() + " - " + row.reasonText()));
+		report.accessibilityImprovementPriorityRows()
+			.forEach(row -> appendRow(csv, "priority", row.stationName(), row.facilityName(), row.priorityScore() + " - " + row.reasonText()));
+		return csv.toString();
+	}
+
+	private void appendRow(StringBuilder csv, String section, String metric, Object value, String detail) {
+		csv.append(csvValue(section))
+			.append(',')
+			.append(csvValue(metric))
+			.append(',')
+			.append(csvValue(String.valueOf(value)))
+			.append(',')
+			.append(csvValue(detail))
+			.append('\n');
+	}
+
+	private String csvValue(String value) {
+		if (value == null) {
+			return "";
+		}
+		if (value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r")) {
+			return "\"" + value.replace("\"", "\"\"") + "\"";
+		}
+		return value;
 	}
 }

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportControllerTest.java
@@ -4,10 +4,12 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import org.springframework.http.HttpHeaders;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,6 +66,29 @@ class OperatorAccessibilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("운영기관 계정은 제휴 제안용 접근성 리포트 CSV를 내려받는다")
+	void operatorDownloadsPartnershipProposalCsv() throws Exception {
+		mockMvc.perform(get("/operator/api/accessibility-report/proposal.csv")
+				.with(httpBasic("operator-user", "operator-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(header().string(
+				HttpHeaders.CONTENT_DISPOSITION,
+				"attachment; filename=\"easysubway-operator-accessibility-proposal.csv\""
+			))
+			.andExpect(header().string(HttpHeaders.CONTENT_TYPE, "text/csv;charset=UTF-8"))
+			.andExpect(result -> {
+				String csv = result.getResponse().getContentAsString();
+				org.assertj.core.api.Assertions.assertThat(csv)
+					.startsWith("section,metric,value,detail\n")
+					.contains("summary,totalStations,2,")
+					.contains("summary,totalFacilities,3,")
+					.contains("summary,needsVerificationFacilityCount,1,")
+					.contains("stationScore,상록수,")
+					.contains("priority,상록수,장애인 화장실,\"60 - 확인 필요 상태");
+			});
+	}
+
+	@Test
 	@DisplayName("운영기관 접근성 리포트 API는 운영기관 계정 인증을 요구한다")
 	void accessibilityReportRequiresOperatorAuthentication() throws Exception {
 		mockMvc.perform(get("/operator/api/accessibility-report"))
@@ -74,6 +99,21 @@ class OperatorAccessibilityReportControllerTest {
 			.andExpect(status().isForbidden());
 
 		mockMvc.perform(get("/operator/api/accessibility-report")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("제휴 제안용 CSV export는 운영기관 계정 인증을 요구한다")
+	void partnershipProposalCsvRequiresOperatorAuthentication() throws Exception {
+		mockMvc.perform(get("/operator/api/accessibility-report/proposal.csv"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/operator/api/accessibility-report/proposal.csv")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/operator/api/accessibility-report/proposal.csv")
 				.with(httpBasic("admin-user", "admin-test-password")))
 			.andExpect(status().isForbidden());
 	}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1457,6 +1457,38 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   );
 });
 
+test("운영기관 제휴 제안 export는 접근성 리포트 CSV를 제공한다", () => {
+  const operatorReportController = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportController.java",
+  );
+  const operatorReportView = read(
+    "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportView.java",
+  );
+  const controllerTest = read(
+    "backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportControllerTest.java",
+  );
+
+  assert.match(operatorReportController, /@GetMapping\("\/operator\/api\/accessibility-report\/proposal\.csv"\)/);
+  assert.match(operatorReportController, /TEXT_CSV_UTF8/);
+  assert.match(operatorReportController, /HttpHeaders\.CONTENT_DISPOSITION/);
+  assert.match(operatorReportController, /easysubway-operator-accessibility-proposal\.csv/);
+  assert.match(operatorReportController, /section,metric,value,detail\\n/);
+  assert.match(operatorReportController, /"summary", "totalStations"/);
+  assert.match(operatorReportController, /"summary", "totalFacilities"/);
+  assert.match(operatorReportController, /"summary", "needsVerificationFacilityCount"/);
+  assert.match(operatorReportController, /"summary", "delayedFacilityStatusCount"/);
+  assert.match(operatorReportController, /stationScore/);
+  assert.match(operatorReportController, /priority/);
+  assert.match(operatorReportController, /csvValue/);
+  assert.match(operatorReportView, /reasonText\(\)/);
+  assert.match(controllerTest, /proposal\.csv/);
+  assert.match(controllerTest, /text\/csv;charset=UTF-8/);
+  assert.match(controllerTest, /stationScore,상록수/);
+  assert.match(controllerTest, /priority,상록수,장애인 화장실,\\"60 - 확인 필요 상태/);
+  assert.match(controllerTest, /admin-user/);
+  assert.match(controllerTest, /isForbidden/);
+});
+
 test("백엔드 이동 프로필은 헥사고날 API 경계를 따른다", () => {
   const profile = read("backend/src/main/java/com/easysubway/profile/domain/MobilityProfile.java");
   const mobilityType = read("backend/src/main/java/com/easysubway/profile/domain/MobilityType.java");


### PR DESCRIPTION
## 관련 이슈

close #455

## 작업 배경

- 운영기관 접근성 리포트 JSON API와 화면은 현황 조회에 적합하지만, 제휴 제안이나 기관 내부 공유에는 파일로 전달 가능한 요약 자료가 필요하다.
- 별도 공개 Markdown 문서를 추가하지 않고 실제 운영 데이터에서 내려받는 export 경계를 마련한다.

## 작업 내용

- `GET /operator/api/accessibility-report/proposal.csv` endpoint를 추가했다.
- CSV에는 전체 역/시설 수, 검증 필요 시설 수, 상태 갱신 지연 수, 누락 검증일 수, 역별 접근성 점수, 개선 우선순위를 포함한다.
- 응답은 `text/csv;charset=UTF-8`와 `attachment; filename="easysubway-operator-accessibility-proposal.csv"` header를 반환한다.
- 운영기관 계정만 CSV export에 접근할 수 있음을 controller test로 고정했다.
- repository contract에 endpoint, 파일명, 주요 CSV section/column 기준을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests '*OperatorAccessibilityReport*'`: endpoint 미구현으로 실패 확인 후 구현, 이후 성공
  - `node --test --test-name-pattern "제휴 제안" tools/ci/repository-contract.test.mjs`: 실패 확인 후 구현, 이후 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 59개 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`
  - GitHub Actions CI: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI, Dependency Vulnerability Scan, OSV scanner 성공
  - Android CI 최초 실행은 Maven artifact 다운로드 403으로 실패했으나 동일 commit 재실행에서 성공
  - CodeRabbit status: Review completed
  - Merge 후 CD run `27800264717`: 성공
  - Merge 후 main CI run `27800264772`: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI 성공

## 리뷰어 메모

- 이번 범위는 운영기관 리포트 데이터를 CSV로 내려받는 read-only export다.
- 별도 문서 파일 생성, 사용자 모바일 노출, 운영기관별 커스텀 브랜딩은 포함하지 않았다.
- 사유 문자열에 쉼표가 포함될 수 있어 CSV 값 quote escaping을 적용했다.

## 리스크

- CSV schema는 제휴 자료 공유의 초기 기준선이므로 실제 기관별 제출 양식이 확정되면 컬럼 추가가 필요할 수 있다.
- 기존 운영기관 리포트 assembler 결과를 재사용하므로 리포트 집계 변경이 CSV에도 함께 반영된다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
