### PR TITLE
[Feat] 현장 검증 변경 이력 저장소 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/field/adapter/out/persistence/InMemoryFieldVerificationChangeHistoryRepository.java
+++ b/backend/src/main/java/com/easysubway/field/adapter/out/persistence/InMemoryFieldVerificationChangeHistoryRepository.java
@@ -1,0 +1,27 @@
+package com.easysubway.field.adapter.out.persistence;
+
+import com.easysubway.field.application.port.out.FieldVerificationChangeHistoryRepository;
+import com.easysubway.field.domain.FieldVerificationChangeHistory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("!prod")
+public class InMemoryFieldVerificationChangeHistoryRepository implements FieldVerificationChangeHistoryRepository {
+
+	private final Map<String, List<FieldVerificationChangeHistory>> historiesByStationId = new ConcurrentHashMap<>();
+
+	@Override
+	public synchronized void save(FieldVerificationChangeHistory history) {
+		historiesByStationId.computeIfAbsent(history.stationId(), ignored -> new ArrayList<>()).add(0, history);
+	}
+
+	@Override
+	public synchronized List<FieldVerificationChangeHistory> listByStationId(String stationId) {
+		return List.copyOf(historiesByStationId.getOrDefault(stationId, List.of()));
+	}
+}

--- a/backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationChangeHistoryRepository.java
+++ b/backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationChangeHistoryRepository.java
@@ -1,0 +1,96 @@
+package com.easysubway.field.adapter.out.persistence;
+
+import com.easysubway.field.application.port.out.FieldVerificationChangeHistoryRepository;
+import com.easysubway.field.domain.FieldVerificationChangeHistory;
+import com.easysubway.field.domain.FieldVerificationStatus;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("prod")
+public class JdbcFieldVerificationChangeHistoryRepository implements FieldVerificationChangeHistoryRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public JdbcFieldVerificationChangeHistoryRepository(DataSource dataSource) {
+		this(new JdbcTemplate(dataSource));
+	}
+
+	JdbcFieldVerificationChangeHistoryRepository(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public void save(FieldVerificationChangeHistory history) {
+		jdbcTemplate.update(
+			"""
+				INSERT INTO field_verification_change_history (
+					history_id,
+					session_id,
+					station_id,
+					item_id,
+					previous_status,
+					new_status,
+					previous_note,
+					new_note,
+					changed_by,
+					changed_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				""",
+			history.id(),
+			history.sessionId(),
+			history.stationId(),
+			history.itemId(),
+			history.previousStatus().name(),
+			history.newStatus().name(),
+			history.previousNote(),
+			history.newNote(),
+			history.changedBy(),
+			history.changedAt()
+		);
+	}
+
+	@Override
+	public List<FieldVerificationChangeHistory> listByStationId(String stationId) {
+		return jdbcTemplate.query(
+			"""
+				SELECT history_id,
+					session_id,
+					station_id,
+					item_id,
+					previous_status,
+					new_status,
+					previous_note,
+					new_note,
+					changed_by,
+					changed_at
+				FROM field_verification_change_history
+				WHERE station_id = ?
+				ORDER BY changed_at DESC, history_id ASC
+				""",
+			this::mapHistory,
+			stationId
+		);
+	}
+
+	private FieldVerificationChangeHistory mapHistory(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new FieldVerificationChangeHistory(
+			resultSet.getString("history_id"),
+			resultSet.getString("session_id"),
+			resultSet.getString("station_id"),
+			resultSet.getString("item_id"),
+			FieldVerificationStatus.valueOf(resultSet.getString("previous_status")),
+			FieldVerificationStatus.valueOf(resultSet.getString("new_status")),
+			resultSet.getString("previous_note"),
+			resultSet.getString("new_note"),
+			resultSet.getString("changed_by"),
+			resultSet.getTimestamp("changed_at").toLocalDateTime()
+		);
+	}
+}

--- a/backend/src/main/java/com/easysubway/field/application/port/out/FieldVerificationChangeHistoryRepository.java
+++ b/backend/src/main/java/com/easysubway/field/application/port/out/FieldVerificationChangeHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.easysubway.field.application.port.out;
+
+import com.easysubway.field.domain.FieldVerificationChangeHistory;
+import java.util.List;
+
+public interface FieldVerificationChangeHistoryRepository {
+
+	void save(FieldVerificationChangeHistory history);
+
+	List<FieldVerificationChangeHistory> listByStationId(String stationId);
+}

--- a/backend/src/main/java/com/easysubway/field/application/service/FieldVerificationService.java
+++ b/backend/src/main/java/com/easysubway/field/application/service/FieldVerificationService.java
@@ -3,6 +3,7 @@ package com.easysubway.field.application.service;
 import com.easysubway.common.error.ResourceNotFoundException;
 import com.easysubway.field.application.port.in.FieldVerificationUseCase;
 import com.easysubway.field.application.port.in.UpdateFieldVerificationItemStatusCommand;
+import com.easysubway.field.application.port.out.FieldVerificationChangeHistoryRepository;
 import com.easysubway.field.domain.FieldVerificationChangeHistory;
 import com.easysubway.field.domain.FieldVerificationItem;
 import com.easysubway.field.domain.FieldVerificationItemType;
@@ -10,7 +11,6 @@ import com.easysubway.field.domain.FieldVerificationSession;
 import com.easysubway.field.domain.FieldVerificationStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,13 +54,12 @@ public class FieldVerificationService implements FieldVerificationUseCase {
 		)
 	);
 	private final Map<String, FieldVerificationSession> sessionsByStationId = new LinkedHashMap<>();
-	private final Map<String, List<FieldVerificationChangeHistory>> historiesByStationId = new LinkedHashMap<>();
+	private final FieldVerificationChangeHistoryRepository historyRepository;
 
-	public FieldVerificationService() {
+	public FieldVerificationService(FieldVerificationChangeHistoryRepository historyRepository) {
+		this.historyRepository = historyRepository;
 		sessionsByStationId.put(SANGNOKSU_STATION_ID, SANGNOKSU_BASELINE);
 		sessionsByStationId.put(SADANG_STATION_ID, SADANG_BASELINE);
-		historiesByStationId.put(SANGNOKSU_STATION_ID, new ArrayList<>());
-		historiesByStationId.put(SADANG_STATION_ID, new ArrayList<>());
 	}
 
 	@Override
@@ -104,7 +103,7 @@ public class FieldVerificationService implements FieldVerificationUseCase {
 	@Override
 	public synchronized List<FieldVerificationChangeHistory> listStationChangeHistory(String stationId) {
 		findSession(stationId);
-		return List.copyOf(historiesByStationId.getOrDefault(stationId, List.of()));
+		return historyRepository.listByStationId(stationId);
 	}
 
 	private FieldVerificationSession findSession(String stationId) {
@@ -136,12 +135,9 @@ public class FieldVerificationService implements FieldVerificationUseCase {
 		FieldVerificationItem previousItem,
 		UpdateFieldVerificationItemStatusCommand command
 	) {
-		List<FieldVerificationChangeHistory> histories = historiesByStationId.computeIfAbsent(
-			session.stationId(),
-			ignored -> new ArrayList<>()
-		);
-		histories.add(0, new FieldVerificationChangeHistory(
-			"field-verification-history-" + (histories.size() + 1),
+		int nextSequence = historyRepository.listByStationId(session.stationId()).size() + 1;
+		historyRepository.save(new FieldVerificationChangeHistory(
+			"field-verification-history-" + session.stationId() + "-" + nextSequence,
 			session.id(),
 			session.stationId(),
 			previousItem.id(),

--- a/backend/src/test/java/com/easysubway/common/persistence/InMemoryRepositoryProfileTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/InMemoryRepositoryProfileTest.java
@@ -6,6 +6,7 @@ import com.easysubway.collection.adapter.out.persistence.InMemoryDataCollectionR
 import com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteFacilityRepository;
 import com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteRouteRepository;
 import com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteStationRepository;
+import com.easysubway.field.adapter.out.persistence.InMemoryFieldVerificationChangeHistoryRepository;
 import com.easysubway.notification.adapter.out.persistence.InMemoryNotificationPreferenceRepository;
 import com.easysubway.notification.adapter.out.persistence.InMemoryPushNotificationOutboxRepository;
 import com.easysubway.profile.adapter.out.persistence.InMemoryMobilityProfileRepository;
@@ -39,7 +40,7 @@ class InMemoryRepositoryProfileTest {
 	@Test
 	@DisplayName("검증 대상에는 운영 데이터가 유실될 수 있는 인메모리 저장소를 모두 포함한다")
 	void allStatefulInMemoryRepositoriesAreCovered() {
-		assertThat(inMemoryRepositories()).hasSize(12);
+		assertThat(inMemoryRepositories()).hasSize(13);
 	}
 
 	static Stream<Class<?>> inMemoryRepositories() {
@@ -48,6 +49,7 @@ class InMemoryRepositoryProfileTest {
 			InMemoryFavoriteFacilityRepository.class,
 			InMemoryFavoriteRouteRepository.class,
 			InMemoryFavoriteStationRepository.class,
+			InMemoryFieldVerificationChangeHistoryRepository.class,
 			InMemoryFacilityReportRepository.class,
 			InMemoryFacilityReportReviewAuditRepository.class,
 			InMemoryMobilityProfileRepository.class,

--- a/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationChangeHistoryRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationChangeHistoryRepositoryTest.java
@@ -1,0 +1,125 @@
+package com.easysubway.field.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.field.domain.FieldVerificationChangeHistory;
+import com.easysubway.field.domain.FieldVerificationStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("JDBC 현장 검증 변경 이력 저장소")
+class JdbcFieldVerificationChangeHistoryRepositoryTest {
+
+	private JdbcFieldVerificationChangeHistoryRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:field-verification-history;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS field_verification_change_history");
+		jdbcTemplate.execute("""
+			CREATE TABLE field_verification_change_history (
+				history_id VARCHAR(120) PRIMARY KEY,
+				session_id VARCHAR(120) NOT NULL,
+				station_id VARCHAR(120) NOT NULL,
+				item_id VARCHAR(120) NOT NULL,
+				previous_status VARCHAR(40) NOT NULL,
+				new_status VARCHAR(40) NOT NULL,
+				previous_note VARCHAR(1000),
+				new_note VARCHAR(1000),
+				changed_by VARCHAR(120) NOT NULL,
+				changed_at TIMESTAMP NOT NULL
+			)
+			""");
+		repository = new JdbcFieldVerificationChangeHistoryRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("현장 검증 변경 이력을 저장하고 역 기준 최신순으로 조회한다")
+	void saveHistoryAndListByStationIdNewestFirst() {
+		repository.save(history(
+			"history-old",
+			"station-sadang",
+			"field-verification-sadang-elevator",
+			FieldVerificationStatus.PLANNED,
+			FieldVerificationStatus.NEEDS_RECHECK,
+			null,
+			"엘리베이터 운행 중지 안내문 확인 필요",
+			LocalDateTime.of(2026, 6, 19, 10, 0)
+		));
+		repository.save(history(
+			"history-new",
+			"station-sadang",
+			"field-verification-sadang-restroom",
+			FieldVerificationStatus.PLANNED,
+			FieldVerificationStatus.VERIFIED,
+			null,
+			"화장실 위치 확인 완료",
+			LocalDateTime.of(2026, 6, 19, 11, 0)
+		));
+		repository.save(history(
+			"history-other-station",
+			"station-sangnoksu",
+			"field-verification-sangnoksu-exit",
+			FieldVerificationStatus.PLANNED,
+			FieldVerificationStatus.VERIFIED,
+			null,
+			"출구 연결 확인 완료",
+			LocalDateTime.of(2026, 6, 19, 12, 0)
+		));
+
+		var histories = repository.listByStationId("station-sadang");
+
+		assertThat(histories)
+			.extracting(FieldVerificationChangeHistory::id)
+			.containsExactly("history-new", "history-old");
+		assertThat(histories.get(0)).satisfies(history -> {
+			assertThat(history.sessionId()).isEqualTo("field-verification-sadang-2026-06");
+			assertThat(history.itemId()).isEqualTo("field-verification-sadang-restroom");
+			assertThat(history.previousStatus()).isEqualTo(FieldVerificationStatus.PLANNED);
+			assertThat(history.newStatus()).isEqualTo(FieldVerificationStatus.VERIFIED);
+			assertThat(history.previousNote()).isNull();
+			assertThat(history.newNote()).isEqualTo("화장실 위치 확인 완료");
+			assertThat(history.changedBy()).isEqualTo("admin-user");
+			assertThat(history.changedAt()).isEqualTo(LocalDateTime.of(2026, 6, 19, 11, 0));
+		});
+	}
+
+	@Test
+	@DisplayName("변경 이력이 없는 역은 빈 목록을 반환한다")
+	void listByStationIdReturnsEmptyWhenHistoryDoesNotExist() {
+		assertThat(repository.listByStationId("missing-station")).isEmpty();
+	}
+
+	private FieldVerificationChangeHistory history(
+		String historyId,
+		String stationId,
+		String itemId,
+		FieldVerificationStatus previousStatus,
+		FieldVerificationStatus newStatus,
+		String previousNote,
+		String newNote,
+		LocalDateTime changedAt
+	) {
+		return new FieldVerificationChangeHistory(
+			historyId,
+			"field-verification-sadang-2026-06",
+			stationId,
+			itemId,
+			previousStatus,
+			newStatus,
+			previousNote,
+			newNote,
+			"admin-user",
+			changedAt
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/field/application/service/FieldVerificationServiceTest.java
+++ b/backend/src/test/java/com/easysubway/field/application/service/FieldVerificationServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.easysubway.common.error.ResourceNotFoundException;
+import com.easysubway.field.adapter.out.persistence.InMemoryFieldVerificationChangeHistoryRepository;
 import com.easysubway.field.application.port.in.UpdateFieldVerificationItemStatusCommand;
 import com.easysubway.field.domain.FieldVerificationChangeHistory;
 import com.easysubway.field.domain.FieldVerificationItemType;
@@ -15,7 +16,9 @@ import org.junit.jupiter.api.Test;
 @DisplayName("현장 검증 기준선")
 class FieldVerificationServiceTest {
 
-	private final FieldVerificationService service = new FieldVerificationService();
+	private final InMemoryFieldVerificationChangeHistoryRepository historyRepository =
+		new InMemoryFieldVerificationChangeHistoryRepository();
+	private final FieldVerificationService service = new FieldVerificationService(historyRepository);
 
 	@Test
 	@DisplayName("상록수역 필수 현장 검증 항목을 조회한다")
@@ -147,6 +150,30 @@ class FieldVerificationServiceTest {
 		assertThatThrownBy(() -> service.listStationChangeHistory("missing-station"))
 			.isInstanceOf(ResourceNotFoundException.class)
 			.hasMessage("현장 검증 기준선을 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("서로 다른 역의 첫 변경 이력도 고유한 식별자를 가진다")
+	void changeHistoryIdsAreUniqueAcrossStations() {
+		service.updateItemStatus(new UpdateFieldVerificationItemStatusCommand(
+			"station-sadang",
+			"field-verification-sadang-elevator",
+			FieldVerificationStatus.VERIFIED,
+			"사당역 엘리베이터 확인 완료",
+			"admin-user"
+		));
+		service.updateItemStatus(new UpdateFieldVerificationItemStatusCommand(
+			"station-sangnoksu",
+			"field-verification-sangnoksu-restroom",
+			FieldVerificationStatus.NEEDS_RECHECK,
+			"상록수역 화장실 위치 재확인 필요",
+			"admin-user"
+		));
+
+		String sadangHistoryId = service.listStationChangeHistory("station-sadang").get(0).id();
+		String sangnoksuHistoryId = service.listStationChangeHistory("station-sangnoksu").get(0).id();
+
+		assertThat(sadangHistoryId).isNotEqualTo(sangnoksuHistoryId);
 	}
 
 	@Test

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2214,6 +2214,9 @@ test("현장 검증 기준선은 세션과 항목을 관리자 API로 추적한�
   const itemType = read("backend/src/main/java/com/easysubway/field/domain/FieldVerificationItemType.java");
   const status = read("backend/src/main/java/com/easysubway/field/domain/FieldVerificationStatus.java");
   const useCase = read("backend/src/main/java/com/easysubway/field/application/port/in/FieldVerificationUseCase.java");
+  const historyRepositoryPort = read("backend/src/main/java/com/easysubway/field/application/port/out/FieldVerificationChangeHistoryRepository.java");
+  const inMemoryHistoryRepository = read("backend/src/main/java/com/easysubway/field/adapter/out/persistence/InMemoryFieldVerificationChangeHistoryRepository.java");
+  const jdbcHistoryRepository = read("backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationChangeHistoryRepository.java");
   const service = read("backend/src/main/java/com/easysubway/field/application/service/FieldVerificationService.java");
   const controller = read("backend/src/main/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminController.java");
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
@@ -2256,7 +2259,17 @@ test("현장 검증 기준선은 세션과 항목을 관리자 API로 추적한�
   assert.match(useCase, /List<FieldVerificationSession> listStationVerifications\(\)/);
   assert.match(useCase, /FieldVerificationSession updateItemStatus\(UpdateFieldVerificationItemStatusCommand command\)/);
   assert.match(useCase, /List<FieldVerificationChangeHistory> listStationChangeHistory\(String stationId\)/);
+  assert.match(historyRepositoryPort, /void save\(FieldVerificationChangeHistory history\)/);
+  assert.match(historyRepositoryPort, /List<FieldVerificationChangeHistory> listByStationId\(String stationId\)/);
+  assert.match(inMemoryHistoryRepository, /@Repository\s+@Profile\("!prod"\)/);
+  assert.match(inMemoryHistoryRepository, /implements FieldVerificationChangeHistoryRepository/);
+  assert.match(jdbcHistoryRepository, /@Repository\s+@Profile\("prod"\)/);
+  assert.match(jdbcHistoryRepository, /JdbcTemplate/);
+  assert.match(jdbcHistoryRepository, /INSERT INTO field_verification_change_history/);
+  assert.match(jdbcHistoryRepository, /ORDER BY changed_at DESC, history_id ASC/);
   assert.match(service, /SANGNOKSU_STATION_ID = "station-sangnoksu"/);
+  assert.doesNotMatch(service, /historiesByStationId/);
+  assert.match(service, /FieldVerificationChangeHistoryRepository/);
   assert.match(service, /field-verification-sangnoksu-2026-06/);
   assert.match(service, /SADANG_STATION_ID = "station-sadang"/);
   assert.match(service, /field-verification-sadang-2026-06/);


### PR DESCRIPTION
## 관련 이슈

close #467

## 작업 배경

- 현장 검증 변경 이력은 운영자가 상태 변경 근거를 확인하기 위한 audit 데이터지만, service 내부 in-memory Map에 저장되어 운영 프로필에서 유지될 수 없는 구조였다.
- 기존 백엔드 저장소 패턴처럼 application out port와 non-prod/prod adapter를 분리해 운영 저장소 전환 기준을 명확히 해야 한다.

## 작업 내용

- `FieldVerificationChangeHistoryRepository` application out port를 추가했다.
- non-prod용 `InMemoryFieldVerificationChangeHistoryRepository`를 추가하고 운영 프로필 제외 검증 대상에 포함했다.
- prod용 `JdbcFieldVerificationChangeHistoryRepository`를 추가해 `field_verification_change_history` 테이블 저장과 역별 최신순 조회를 지원했다.
- `FieldVerificationService`가 변경 이력을 직접 Map에 저장하지 않고 repository port를 통해 저장/조회하도록 변경했다.
- 역별 첫 변경 이력이 같은 sequence를 가져도 history id가 충돌하지 않도록 station id를 포함했다.
- H2 PostgreSQL mode 기반 JDBC repository test와 repository contract를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests '*FieldVerification*' --tests '*InMemoryRepositoryProfile*'`: 새 repository class 미구현으로 실패 확인 후 구현
  - `node --test --test-name-pattern "현장 검증 기준선" tools/ci/repository-contract.test.mjs`: 새 port 파일 미존재로 실패 확인 후 구현, 이후 성공
  - `backend/gradlew -p backend test --tests 'com.easysubway.field.application.service.FieldVerificationServiceTest.changeHistoryIdsAreUniqueAcrossStations'`: 기존 id 생성 방식에서 실패 확인 후 station id 포함 수정, 이후 성공
  - `backend/gradlew -p backend test --tests '*FieldVerification*'`: 성공
  - `backend/gradlew -p backend test --tests '*InMemoryRepositoryProfile*'`: 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 59개 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`
  - GitHub Actions CI: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI, Dependency Vulnerability Scan 모두 성공
  - CodeRabbit: review completed, review thread 0건
  - Merge 후 main CD `27804320449`: 성공
  - Merge 후 main CI `27804320525`: 성공

## 리뷰어 메모

- 이번 범위는 변경 이력 저장소 분리다. 현장 검증 세션/항목 자체의 영속 저장소 전환은 별도 작업으로 남겨둔다.
- `JdbcFieldVerificationChangeHistoryRepository`는 prod profile 전용이며, non-prod API 테스트는 기존처럼 in-memory adapter로 동작한다.
- history id는 역별 sequence 앞에 station id를 붙여 JDBC primary key 충돌을 피한다.

## 리스크

- 현장 검증 세션/항목은 아직 in-memory 기준선이므로 상태 변경 결과 자체는 재시작 후 유지되지 않는다.
- history id는 현재 service에서 생성하므로 운영 저장소 전환 시 DB sequence나 ULID 전환을 검토할 수 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
