### PR TITLE
[Feat] 현장 검증 세션 저장소 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/field/adapter/out/persistence/InMemoryFieldVerificationSessionRepository.java
+++ b/backend/src/main/java/com/easysubway/field/adapter/out/persistence/InMemoryFieldVerificationSessionRepository.java
@@ -1,0 +1,32 @@
+package com.easysubway.field.adapter.out.persistence;
+
+import com.easysubway.field.application.port.out.FieldVerificationSessionRepository;
+import com.easysubway.field.domain.FieldVerificationSession;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("!prod")
+public class InMemoryFieldVerificationSessionRepository implements FieldVerificationSessionRepository {
+
+	private final Map<String, FieldVerificationSession> sessionsByStationId = new LinkedHashMap<>();
+
+	@Override
+	public synchronized List<FieldVerificationSession> listAll() {
+		return List.copyOf(sessionsByStationId.values());
+	}
+
+	@Override
+	public synchronized Optional<FieldVerificationSession> findByStationId(String stationId) {
+		return Optional.ofNullable(sessionsByStationId.get(stationId));
+	}
+
+	@Override
+	public synchronized void save(FieldVerificationSession session) {
+		sessionsByStationId.put(session.stationId(), session);
+	}
+}

--- a/backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepository.java
+++ b/backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
 import org.springframework.context.annotation.Profile;
-import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class JdbcFieldVerificationSessionRepository implements FieldVerificationSessionRepository {
 
 	private final JdbcTemplate jdbcTemplate;
+	private final DatabaseDialect databaseDialect;
 
 	public JdbcFieldVerificationSessionRepository(DataSource dataSource) {
 		this(new JdbcTemplate(dataSource));
@@ -28,6 +29,7 @@ public class JdbcFieldVerificationSessionRepository implements FieldVerification
 
 	JdbcFieldVerificationSessionRepository(JdbcTemplate jdbcTemplate) {
 		this.jdbcTemplate = jdbcTemplate;
+		this.databaseDialect = detectDatabaseDialect(jdbcTemplate);
 	}
 
 	@Override
@@ -87,15 +89,55 @@ public class JdbcFieldVerificationSessionRepository implements FieldVerification
 	@Override
 	@Transactional
 	public void save(FieldVerificationSession session) {
-		if (updateSession(session) == 0) {
-			try {
-				insertSession(session);
-			} catch (DuplicateKeyException exception) {
-				// 운영 다중 인스턴스가 같은 세션을 동시에 만들면 삽입 충돌 후 최신 값으로 수렴시킨다.
-				updateSession(session);
-			}
+		if (databaseDialect == DatabaseDialect.H2) {
+			saveWithUpdateInsert(session);
+			return;
 		}
-		session.items().forEach(item -> saveItem(session, item));
+		upsertSession(session);
+		session.items().forEach(item -> upsertItem(session, item));
+	}
+
+	private void saveWithUpdateInsert(FieldVerificationSession session) {
+		if (updateSession(session) == 0) {
+			insertSession(session);
+		}
+		session.items().forEach(item -> {
+			if (updateItem(session, item) == 0) {
+				insertItem(session, item);
+			}
+		});
+	}
+
+	private void upsertSession(FieldVerificationSession session) {
+		// PostgreSQL upsert로 다중 인스턴스 기준선 부트스트랩 충돌을 원자적으로 수렴시킨다.
+		jdbcTemplate.update(
+			"""
+				INSERT INTO field_verification_sessions (
+					session_id,
+					station_id,
+					station_name,
+					verified_at,
+					verified_by,
+					status,
+					note
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT (session_id) DO UPDATE
+				SET station_id = EXCLUDED.station_id,
+					station_name = EXCLUDED.station_name,
+					verified_at = EXCLUDED.verified_at,
+					verified_by = EXCLUDED.verified_by,
+					status = EXCLUDED.status,
+					note = EXCLUDED.note
+				""",
+			session.id(),
+			session.stationId(),
+			session.stationName(),
+			session.verifiedAt(),
+			session.verifiedBy(),
+			session.status().name(),
+			session.note()
+		);
 	}
 
 	private int updateSession(FieldVerificationSession session) {
@@ -144,15 +186,32 @@ public class JdbcFieldVerificationSessionRepository implements FieldVerification
 		);
 	}
 
-	private void saveItem(FieldVerificationSession session, FieldVerificationItem item) {
-		if (updateItem(session, item) == 0) {
-			try {
-				insertItem(session, item);
-			} catch (DuplicateKeyException exception) {
-				// 세션 항목도 같은 부트스트랩 race에서 삽입 충돌 후 최신 값으로 맞춘다.
-				updateItem(session, item);
-			}
-		}
+	private void upsertItem(FieldVerificationSession session, FieldVerificationItem item) {
+		jdbcTemplate.update(
+			"""
+				INSERT INTO field_verification_items (
+					item_id,
+					session_id,
+					item_type,
+					target_name,
+					status,
+					note
+				)
+				VALUES (?, ?, ?, ?, ?, ?)
+				ON CONFLICT (item_id) DO UPDATE
+				SET session_id = EXCLUDED.session_id,
+					item_type = EXCLUDED.item_type,
+					target_name = EXCLUDED.target_name,
+					status = EXCLUDED.status,
+					note = EXCLUDED.note
+				""",
+			item.id(),
+			session.id(),
+			item.type().name(),
+			item.targetName(),
+			item.status().name(),
+			item.note()
+		);
 	}
 
 	private int updateItem(FieldVerificationSession session, FieldVerificationItem item) {
@@ -243,5 +302,18 @@ public class JdbcFieldVerificationSessionRepository implements FieldVerification
 			FieldVerificationStatus.valueOf(resultSet.getString("status")),
 			resultSet.getString("note")
 		);
+	}
+
+	private DatabaseDialect detectDatabaseDialect(JdbcTemplate jdbcTemplate) {
+		DatabaseDialect dialect = jdbcTemplate.execute((ConnectionCallback<DatabaseDialect>) connection -> {
+			String productName = connection.getMetaData().getDatabaseProductName();
+			return "H2".equalsIgnoreCase(productName) ? DatabaseDialect.H2 : DatabaseDialect.POSTGRESQL;
+		});
+		return dialect == null ? DatabaseDialect.POSTGRESQL : dialect;
+	}
+
+	private enum DatabaseDialect {
+		POSTGRESQL,
+		H2
 	}
 }

--- a/backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepository.java
+++ b/backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepository.java
@@ -56,7 +56,7 @@ public class JdbcFieldVerificationSessionRepository implements FieldVerification
 					FROM field_verification_sessions
 				) ranked_sessions
 				WHERE row_number = 1
-				ORDER BY verified_at DESC, session_id ASC
+				ORDER BY verified_at DESC, station_id DESC, session_id ASC
 				""",
 			this::mapSession
 		);
@@ -221,7 +221,14 @@ public class JdbcFieldVerificationSessionRepository implements FieldVerification
 					note
 				FROM field_verification_items
 				WHERE session_id = ?
-				ORDER BY item_type ASC, item_id ASC
+				ORDER BY CASE item_type
+					WHEN 'EXIT' THEN 1
+					WHEN 'ELEVATOR' THEN 2
+					WHEN 'ESCALATOR' THEN 3
+					WHEN 'RESTROOM' THEN 4
+					WHEN 'PLATFORM_TRANSFER' THEN 5
+					ELSE 99
+				END ASC, item_id ASC
 				""",
 			this::mapItem,
 			sessionId

--- a/backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepository.java
+++ b/backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepository.java
@@ -13,6 +13,7 @@ import javax.sql.DataSource;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @Profile("prod")
@@ -39,7 +40,21 @@ public class JdbcFieldVerificationSessionRepository implements FieldVerification
 					verified_by,
 					status,
 					note
-				FROM field_verification_sessions
+				FROM (
+					SELECT session_id,
+						station_id,
+						station_name,
+						verified_at,
+						verified_by,
+						status,
+						note,
+						ROW_NUMBER() OVER (
+							PARTITION BY station_id
+							ORDER BY verified_at DESC, session_id ASC
+						) AS row_number
+					FROM field_verification_sessions
+				) ranked_sessions
+				WHERE row_number = 1
 				ORDER BY verified_at DESC, session_id ASC
 				""",
 			this::mapSession
@@ -69,6 +84,7 @@ public class JdbcFieldVerificationSessionRepository implements FieldVerification
 	}
 
 	@Override
+	@Transactional
 	public void save(FieldVerificationSession session) {
 		int updated = jdbcTemplate.update(
 			"""

--- a/backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepository.java
+++ b/backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepository.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
 import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,7 +87,19 @@ public class JdbcFieldVerificationSessionRepository implements FieldVerification
 	@Override
 	@Transactional
 	public void save(FieldVerificationSession session) {
-		int updated = jdbcTemplate.update(
+		if (updateSession(session) == 0) {
+			try {
+				insertSession(session);
+			} catch (DuplicateKeyException exception) {
+				// 운영 다중 인스턴스가 같은 세션을 동시에 만들면 삽입 충돌 후 최신 값으로 수렴시킨다.
+				updateSession(session);
+			}
+		}
+		session.items().forEach(item -> saveItem(session, item));
+	}
+
+	private int updateSession(FieldVerificationSession session) {
+		return jdbcTemplate.update(
 			"""
 				UPDATE field_verification_sessions
 				SET station_id = ?,
@@ -105,34 +118,45 @@ public class JdbcFieldVerificationSessionRepository implements FieldVerification
 			session.note(),
 			session.id()
 		);
-		if (updated == 0) {
-			jdbcTemplate.update(
-				"""
-					INSERT INTO field_verification_sessions (
-						session_id,
-						station_id,
-						station_name,
-						verified_at,
-						verified_by,
-						status,
-						note
-					)
-					VALUES (?, ?, ?, ?, ?, ?, ?)
-					""",
-				session.id(),
-				session.stationId(),
-				session.stationName(),
-				session.verifiedAt(),
-				session.verifiedBy(),
-				session.status().name(),
-				session.note()
-			);
-		}
-		session.items().forEach(item -> saveItem(session, item));
+	}
+
+	private void insertSession(FieldVerificationSession session) {
+		jdbcTemplate.update(
+			"""
+				INSERT INTO field_verification_sessions (
+					session_id,
+					station_id,
+					station_name,
+					verified_at,
+					verified_by,
+					status,
+					note
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?)
+				""",
+			session.id(),
+			session.stationId(),
+			session.stationName(),
+			session.verifiedAt(),
+			session.verifiedBy(),
+			session.status().name(),
+			session.note()
+		);
 	}
 
 	private void saveItem(FieldVerificationSession session, FieldVerificationItem item) {
-		int updated = jdbcTemplate.update(
+		if (updateItem(session, item) == 0) {
+			try {
+				insertItem(session, item);
+			} catch (DuplicateKeyException exception) {
+				// 세션 항목도 같은 부트스트랩 race에서 삽입 충돌 후 최신 값으로 맞춘다.
+				updateItem(session, item);
+			}
+		}
+	}
+
+	private int updateItem(FieldVerificationSession session, FieldVerificationItem item) {
+		return jdbcTemplate.update(
 			"""
 				UPDATE field_verification_items
 				SET session_id = ?,
@@ -149,27 +173,28 @@ public class JdbcFieldVerificationSessionRepository implements FieldVerification
 			item.note(),
 			item.id()
 		);
-		if (updated == 0) {
-			jdbcTemplate.update(
-				"""
-					INSERT INTO field_verification_items (
-						item_id,
-						session_id,
-						item_type,
-						target_name,
-						status,
-						note
-					)
-					VALUES (?, ?, ?, ?, ?, ?)
-					""",
-				item.id(),
-				session.id(),
-				item.type().name(),
-				item.targetName(),
-				item.status().name(),
-				item.note()
-			);
-		}
+	}
+
+	private void insertItem(FieldVerificationSession session, FieldVerificationItem item) {
+		jdbcTemplate.update(
+			"""
+				INSERT INTO field_verification_items (
+					item_id,
+					session_id,
+					item_type,
+					target_name,
+					status,
+					note
+				)
+				VALUES (?, ?, ?, ?, ?, ?)
+				""",
+			item.id(),
+			session.id(),
+			item.type().name(),
+			item.targetName(),
+			item.status().name(),
+			item.note()
+		);
 	}
 
 	private FieldVerificationSession mapSession(ResultSet resultSet, int rowNumber) throws SQLException {

--- a/backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepository.java
+++ b/backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepository.java
@@ -1,0 +1,199 @@
+package com.easysubway.field.adapter.out.persistence;
+
+import com.easysubway.field.application.port.out.FieldVerificationSessionRepository;
+import com.easysubway.field.domain.FieldVerificationItem;
+import com.easysubway.field.domain.FieldVerificationItemType;
+import com.easysubway.field.domain.FieldVerificationSession;
+import com.easysubway.field.domain.FieldVerificationStatus;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("prod")
+public class JdbcFieldVerificationSessionRepository implements FieldVerificationSessionRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public JdbcFieldVerificationSessionRepository(DataSource dataSource) {
+		this(new JdbcTemplate(dataSource));
+	}
+
+	JdbcFieldVerificationSessionRepository(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public List<FieldVerificationSession> listAll() {
+		return jdbcTemplate.query(
+			"""
+				SELECT session_id,
+					station_id,
+					station_name,
+					verified_at,
+					verified_by,
+					status,
+					note
+				FROM field_verification_sessions
+				ORDER BY verified_at DESC, session_id ASC
+				""",
+			this::mapSession
+		);
+	}
+
+	@Override
+	public Optional<FieldVerificationSession> findByStationId(String stationId) {
+		List<FieldVerificationSession> sessions = jdbcTemplate.query(
+			"""
+				SELECT session_id,
+					station_id,
+					station_name,
+					verified_at,
+					verified_by,
+					status,
+					note
+				FROM field_verification_sessions
+				WHERE station_id = ?
+				ORDER BY verified_at DESC, session_id ASC
+				LIMIT 1
+				""",
+			this::mapSession,
+			stationId
+		);
+		return sessions.stream().findFirst();
+	}
+
+	@Override
+	public void save(FieldVerificationSession session) {
+		int updated = jdbcTemplate.update(
+			"""
+				UPDATE field_verification_sessions
+				SET station_id = ?,
+					station_name = ?,
+					verified_at = ?,
+					verified_by = ?,
+					status = ?,
+					note = ?
+				WHERE session_id = ?
+				""",
+			session.stationId(),
+			session.stationName(),
+			session.verifiedAt(),
+			session.verifiedBy(),
+			session.status().name(),
+			session.note(),
+			session.id()
+		);
+		if (updated == 0) {
+			jdbcTemplate.update(
+				"""
+					INSERT INTO field_verification_sessions (
+						session_id,
+						station_id,
+						station_name,
+						verified_at,
+						verified_by,
+						status,
+						note
+					)
+					VALUES (?, ?, ?, ?, ?, ?, ?)
+					""",
+				session.id(),
+				session.stationId(),
+				session.stationName(),
+				session.verifiedAt(),
+				session.verifiedBy(),
+				session.status().name(),
+				session.note()
+			);
+		}
+		session.items().forEach(item -> saveItem(session, item));
+	}
+
+	private void saveItem(FieldVerificationSession session, FieldVerificationItem item) {
+		int updated = jdbcTemplate.update(
+			"""
+				UPDATE field_verification_items
+				SET session_id = ?,
+					item_type = ?,
+					target_name = ?,
+					status = ?,
+					note = ?
+				WHERE item_id = ?
+				""",
+			session.id(),
+			item.type().name(),
+			item.targetName(),
+			item.status().name(),
+			item.note(),
+			item.id()
+		);
+		if (updated == 0) {
+			jdbcTemplate.update(
+				"""
+					INSERT INTO field_verification_items (
+						item_id,
+						session_id,
+						item_type,
+						target_name,
+						status,
+						note
+					)
+					VALUES (?, ?, ?, ?, ?, ?)
+					""",
+				item.id(),
+				session.id(),
+				item.type().name(),
+				item.targetName(),
+				item.status().name(),
+				item.note()
+			);
+		}
+	}
+
+	private FieldVerificationSession mapSession(ResultSet resultSet, int rowNumber) throws SQLException {
+		String sessionId = resultSet.getString("session_id");
+		return new FieldVerificationSession(
+			sessionId,
+			resultSet.getString("station_id"),
+			resultSet.getString("station_name"),
+			resultSet.getDate("verified_at").toLocalDate(),
+			resultSet.getString("verified_by"),
+			FieldVerificationStatus.valueOf(resultSet.getString("status")),
+			resultSet.getString("note"),
+			listItems(sessionId)
+		);
+	}
+
+	private List<FieldVerificationItem> listItems(String sessionId) {
+		return jdbcTemplate.query(
+			"""
+				SELECT item_id,
+					item_type,
+					target_name,
+					status,
+					note
+				FROM field_verification_items
+				WHERE session_id = ?
+				ORDER BY item_type ASC, item_id ASC
+				""",
+			this::mapItem,
+			sessionId
+		);
+	}
+
+	private FieldVerificationItem mapItem(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new FieldVerificationItem(
+			resultSet.getString("item_id"),
+			FieldVerificationItemType.valueOf(resultSet.getString("item_type")),
+			resultSet.getString("target_name"),
+			FieldVerificationStatus.valueOf(resultSet.getString("status")),
+			resultSet.getString("note")
+		);
+	}
+}

--- a/backend/src/main/java/com/easysubway/field/application/port/out/FieldVerificationSessionRepository.java
+++ b/backend/src/main/java/com/easysubway/field/application/port/out/FieldVerificationSessionRepository.java
@@ -1,0 +1,14 @@
+package com.easysubway.field.application.port.out;
+
+import com.easysubway.field.domain.FieldVerificationSession;
+import java.util.List;
+import java.util.Optional;
+
+public interface FieldVerificationSessionRepository {
+
+	List<FieldVerificationSession> listAll();
+
+	Optional<FieldVerificationSession> findByStationId(String stationId);
+
+	void save(FieldVerificationSession session);
+}

--- a/backend/src/main/java/com/easysubway/field/application/service/FieldVerificationService.java
+++ b/backend/src/main/java/com/easysubway/field/application/service/FieldVerificationService.java
@@ -4,6 +4,7 @@ import com.easysubway.common.error.ResourceNotFoundException;
 import com.easysubway.field.application.port.in.FieldVerificationUseCase;
 import com.easysubway.field.application.port.in.UpdateFieldVerificationItemStatusCommand;
 import com.easysubway.field.application.port.out.FieldVerificationChangeHistoryRepository;
+import com.easysubway.field.application.port.out.FieldVerificationSessionRepository;
 import com.easysubway.field.domain.FieldVerificationChangeHistory;
 import com.easysubway.field.domain.FieldVerificationItem;
 import com.easysubway.field.domain.FieldVerificationItemType;
@@ -11,10 +12,9 @@ import com.easysubway.field.domain.FieldVerificationSession;
 import com.easysubway.field.domain.FieldVerificationStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class FieldVerificationService implements FieldVerificationUseCase {
@@ -53,18 +53,22 @@ public class FieldVerificationService implements FieldVerificationUseCase {
 			item("field-verification-sadang-platform-transfer", FieldVerificationItemType.PLATFORM_TRANSFER, "2호선과 4호선 환승 접근 동선", FieldVerificationStatus.PLANNED)
 		)
 	);
-	private final Map<String, FieldVerificationSession> sessionsByStationId = new LinkedHashMap<>();
+	private final FieldVerificationSessionRepository sessionRepository;
 	private final FieldVerificationChangeHistoryRepository historyRepository;
 
-	public FieldVerificationService(FieldVerificationChangeHistoryRepository historyRepository) {
+	public FieldVerificationService(
+		FieldVerificationSessionRepository sessionRepository,
+		FieldVerificationChangeHistoryRepository historyRepository
+	) {
+		this.sessionRepository = sessionRepository;
 		this.historyRepository = historyRepository;
-		sessionsByStationId.put(SANGNOKSU_STATION_ID, SANGNOKSU_BASELINE);
-		sessionsByStationId.put(SADANG_STATION_ID, SADANG_BASELINE);
+		seedBaselineSession(SANGNOKSU_BASELINE);
+		seedBaselineSession(SADANG_BASELINE);
 	}
 
 	@Override
 	public synchronized List<FieldVerificationSession> listStationVerifications() {
-		return List.copyOf(sessionsByStationId.values());
+		return sessionRepository.listAll();
 	}
 
 	@Override
@@ -73,6 +77,7 @@ public class FieldVerificationService implements FieldVerificationUseCase {
 	}
 
 	@Override
+	@Transactional
 	public synchronized FieldVerificationSession updateItemStatus(UpdateFieldVerificationItemStatusCommand command) {
 		FieldVerificationSession session = findSession(command.stationId());
 		FieldVerificationItem previousItem = session.items().stream()
@@ -95,7 +100,7 @@ public class FieldVerificationService implements FieldVerificationUseCase {
 			session.note(),
 			items
 		);
-		sessionsByStationId.put(session.stationId(), updated);
+		sessionRepository.save(updated);
 		addHistory(session, previousItem, command);
 		return updated;
 	}
@@ -107,11 +112,14 @@ public class FieldVerificationService implements FieldVerificationUseCase {
 	}
 
 	private FieldVerificationSession findSession(String stationId) {
-		FieldVerificationSession session = sessionsByStationId.get(stationId);
-		if (session == null) {
-			throw new ResourceNotFoundException("현장 검증 기준선을 찾을 수 없습니다.");
+		return sessionRepository.findByStationId(stationId)
+			.orElseThrow(() -> new ResourceNotFoundException("현장 검증 기준선을 찾을 수 없습니다."));
+	}
+
+	private void seedBaselineSession(FieldVerificationSession session) {
+		if (sessionRepository.findByStationId(session.stationId()).isEmpty()) {
+			sessionRepository.save(session);
 		}
-		return session;
 	}
 
 	private FieldVerificationItem updateItem(

--- a/backend/src/test/java/com/easysubway/common/persistence/InMemoryRepositoryProfileTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/InMemoryRepositoryProfileTest.java
@@ -7,6 +7,7 @@ import com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteFacilityR
 import com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteRouteRepository;
 import com.easysubway.favorite.adapter.out.persistence.InMemoryFavoriteStationRepository;
 import com.easysubway.field.adapter.out.persistence.InMemoryFieldVerificationChangeHistoryRepository;
+import com.easysubway.field.adapter.out.persistence.InMemoryFieldVerificationSessionRepository;
 import com.easysubway.notification.adapter.out.persistence.InMemoryNotificationPreferenceRepository;
 import com.easysubway.notification.adapter.out.persistence.InMemoryPushNotificationOutboxRepository;
 import com.easysubway.profile.adapter.out.persistence.InMemoryMobilityProfileRepository;
@@ -40,7 +41,7 @@ class InMemoryRepositoryProfileTest {
 	@Test
 	@DisplayName("검증 대상에는 운영 데이터가 유실될 수 있는 인메모리 저장소를 모두 포함한다")
 	void allStatefulInMemoryRepositoriesAreCovered() {
-		assertThat(inMemoryRepositories()).hasSize(13);
+		assertThat(inMemoryRepositories()).hasSize(14);
 	}
 
 	static Stream<Class<?>> inMemoryRepositories() {
@@ -50,6 +51,7 @@ class InMemoryRepositoryProfileTest {
 			InMemoryFavoriteRouteRepository.class,
 			InMemoryFavoriteStationRepository.class,
 			InMemoryFieldVerificationChangeHistoryRepository.class,
+			InMemoryFieldVerificationSessionRepository.class,
 			InMemoryFacilityReportRepository.class,
 			InMemoryFacilityReportReviewAuditRepository.class,
 			InMemoryMobilityProfileRepository.class,

--- a/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepositoryTest.java
@@ -1,0 +1,157 @@
+package com.easysubway.field.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.field.domain.FieldVerificationItem;
+import com.easysubway.field.domain.FieldVerificationItemType;
+import com.easysubway.field.domain.FieldVerificationSession;
+import com.easysubway.field.domain.FieldVerificationStatus;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("JDBC 현장 검증 세션 저장소")
+class JdbcFieldVerificationSessionRepositoryTest {
+
+	private JdbcFieldVerificationSessionRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:field-verification-session;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS field_verification_items");
+		jdbcTemplate.execute("DROP TABLE IF EXISTS field_verification_sessions");
+		jdbcTemplate.execute("""
+			CREATE TABLE field_verification_sessions (
+				session_id VARCHAR(120) PRIMARY KEY,
+				station_id VARCHAR(120) NOT NULL,
+				station_name VARCHAR(120) NOT NULL,
+				verified_at DATE NOT NULL,
+				verified_by VARCHAR(120) NOT NULL,
+				status VARCHAR(40) NOT NULL,
+				note VARCHAR(1000)
+			)
+			""");
+		jdbcTemplate.execute("""
+			CREATE TABLE field_verification_items (
+				item_id VARCHAR(120) PRIMARY KEY,
+				session_id VARCHAR(120) NOT NULL,
+				item_type VARCHAR(40) NOT NULL,
+				target_name VARCHAR(200) NOT NULL,
+				status VARCHAR(40) NOT NULL,
+				note VARCHAR(1000)
+			)
+			""");
+		repository = new JdbcFieldVerificationSessionRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("세션과 항목을 저장하고 역 기준으로 조회한다")
+	void saveSessionAndFindByStationId() {
+		repository.save(session("field-verification-sadang-2026-06", "station-sadang", FieldVerificationStatus.PLANNED));
+
+		var found = repository.findByStationId("station-sadang");
+
+		assertThat(found).isPresent();
+		assertThat(found.get()).satisfies(session -> {
+			assertThat(session.id()).isEqualTo("field-verification-sadang-2026-06");
+			assertThat(session.stationName()).isEqualTo("사당역");
+			assertThat(session.verifiedAt()).isEqualTo(LocalDate.of(2026, 6, 19));
+			assertThat(session.status()).isEqualTo(FieldVerificationStatus.PLANNED);
+			assertThat(session.items())
+				.extracting(FieldVerificationItem::id)
+				.containsExactly("field-verification-sadang-elevator", "field-verification-sadang-restroom");
+		});
+	}
+
+	@Test
+	@DisplayName("세션과 항목 상태를 다시 저장하면 기존 값을 갱신한다")
+	void saveUpdatesExistingSessionAndItems() {
+		repository.save(session("field-verification-sadang-2026-06", "station-sadang", FieldVerificationStatus.PLANNED));
+		repository.save(new FieldVerificationSession(
+			"field-verification-sadang-2026-06",
+			"station-sadang",
+			"사당역",
+			LocalDate.of(2026, 6, 19),
+			"field-team",
+			FieldVerificationStatus.NEEDS_RECHECK,
+			"주요 환승역 현장 검증 확대 기준선",
+			List.of(
+				new FieldVerificationItem(
+					"field-verification-sadang-elevator",
+					FieldVerificationItemType.ELEVATOR,
+					"환승 구간 엘리베이터 위치와 운행 상태",
+					FieldVerificationStatus.NEEDS_RECHECK,
+					"엘리베이터 운행 중지 안내문 확인 필요"
+				),
+				new FieldVerificationItem(
+					"field-verification-sadang-restroom",
+					FieldVerificationItemType.RESTROOM,
+					"일반/장애인 화장실 위치",
+					FieldVerificationStatus.PLANNED,
+					null
+				)
+			)
+		));
+
+		var found = repository.findByStationId("station-sadang").orElseThrow();
+
+		assertThat(found.status()).isEqualTo(FieldVerificationStatus.NEEDS_RECHECK);
+		assertThat(found.items())
+			.filteredOn(item -> item.id().equals("field-verification-sadang-elevator"))
+			.singleElement()
+			.satisfies(item -> {
+				assertThat(item.status()).isEqualTo(FieldVerificationStatus.NEEDS_RECHECK);
+				assertThat(item.note()).isEqualTo("엘리베이터 운행 중지 안내문 확인 필요");
+			});
+	}
+
+	@Test
+	@DisplayName("세션 목록은 검증일 최신순과 세션 식별자순으로 조회한다")
+	void listAllOrdersByVerificationDateAndSessionId() {
+		repository.save(session("field-verification-sadang-2026-06", "station-sadang", FieldVerificationStatus.PLANNED));
+		repository.save(session("field-verification-sangnoksu-2026-06", "station-sangnoksu", FieldVerificationStatus.IN_PROGRESS));
+
+		var sessions = repository.listAll();
+
+		assertThat(sessions)
+			.extracting(FieldVerificationSession::stationId)
+			.containsExactly("station-sadang", "station-sangnoksu");
+	}
+
+	private FieldVerificationSession session(String sessionId, String stationId, FieldVerificationStatus status) {
+		return new FieldVerificationSession(
+			sessionId,
+			stationId,
+			stationId.equals("station-sadang") ? "사당역" : "상록수역",
+			LocalDate.of(2026, 6, 19),
+			"field-team",
+			status,
+			stationId.equals("station-sadang") ? "주요 환승역 현장 검증 확대 기준선" : "첫 현장 검증 지역 기준선",
+			List.of(
+				new FieldVerificationItem(
+					"field-verification-" + stationId.replace("station-", "") + "-elevator",
+					FieldVerificationItemType.ELEVATOR,
+					stationId.equals("station-sadang") ? "환승 구간 엘리베이터 위치와 운행 상태" : "엘리베이터 위치와 운행 상태",
+					status,
+					null
+				),
+				new FieldVerificationItem(
+					"field-verification-" + stationId.replace("station-", "") + "-restroom",
+					FieldVerificationItemType.RESTROOM,
+					"일반/장애인 화장실 위치",
+					FieldVerificationStatus.PLANNED,
+					null
+				)
+			)
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepositoryTest.java
@@ -11,7 +11,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
@@ -116,22 +115,6 @@ class JdbcFieldVerificationSessionRepositoryTest {
 				assertThat(item.status()).isEqualTo(FieldVerificationStatus.NEEDS_RECHECK);
 				assertThat(item.note()).isEqualTo("엘리베이터 운행 중지 안내문 확인 필요");
 			});
-	}
-
-	@Test
-	@DisplayName("동시 생성 중복 키 충돌은 최신 세션과 항목 값으로 갱신한다")
-	void saveRetriesUpdateWhenConcurrentInsertCreatesRows() {
-		var jdbcTemplate = new DuplicateInsertOnceJdbcTemplate(repositoryJdbcTemplate("field-verification-session-retry"));
-		var retryRepository = new JdbcFieldVerificationSessionRepository(jdbcTemplate);
-		var session = session(
-			"field-verification-sadang-2026-06",
-			"station-sadang",
-			FieldVerificationStatus.NEEDS_RECHECK
-		);
-
-		retryRepository.save(session);
-
-		assertThat(retryRepository.findByStationId("station-sadang")).contains(session);
 	}
 
 	@Test
@@ -264,65 +247,5 @@ class JdbcFieldVerificationSessionRepositoryTest {
 			FieldVerificationStatus.PLANNED,
 			null
 		);
-	}
-
-	private JdbcTemplate repositoryJdbcTemplate(String databaseName) {
-		var dataSource = new DriverManagerDataSource(
-			"jdbc:h2:mem:" + databaseName + ";MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
-			"sa",
-			""
-		);
-		var jdbcTemplate = new JdbcTemplate(dataSource);
-		jdbcTemplate.execute("DROP TABLE IF EXISTS field_verification_items");
-		jdbcTemplate.execute("DROP TABLE IF EXISTS field_verification_sessions");
-		jdbcTemplate.execute("""
-			CREATE TABLE field_verification_sessions (
-				session_id VARCHAR(120) PRIMARY KEY,
-				station_id VARCHAR(120) NOT NULL,
-				station_name VARCHAR(120) NOT NULL,
-				verified_at DATE NOT NULL,
-				verified_by VARCHAR(120) NOT NULL,
-				status VARCHAR(40) NOT NULL,
-				note VARCHAR(1000)
-			)
-			""");
-		jdbcTemplate.execute("""
-			CREATE TABLE field_verification_items (
-				item_id VARCHAR(120) PRIMARY KEY,
-				session_id VARCHAR(120) NOT NULL,
-				item_type VARCHAR(40) NOT NULL,
-				target_name VARCHAR(200) NOT NULL,
-				status VARCHAR(40) NOT NULL,
-				note VARCHAR(1000),
-				CONSTRAINT fk_field_verification_items_session
-					FOREIGN KEY (session_id)
-					REFERENCES field_verification_sessions(session_id)
-			)
-			""");
-		return jdbcTemplate;
-	}
-
-	private static final class DuplicateInsertOnceJdbcTemplate extends JdbcTemplate {
-
-		private boolean sessionDuplicateRaised;
-		private boolean itemDuplicateRaised;
-
-		private DuplicateInsertOnceJdbcTemplate(JdbcTemplate delegate) {
-			super(delegate.getDataSource());
-		}
-
-		@Override
-		public int update(String sql, Object... args) {
-			int updated = super.update(sql, args);
-			if (!sessionDuplicateRaised && sql.contains("INSERT INTO field_verification_sessions")) {
-				sessionDuplicateRaised = true;
-				throw new DuplicateKeyException("concurrent session insert");
-			}
-			if (!itemDuplicateRaised && sql.contains("INSERT INTO field_verification_items")) {
-				itemDuplicateRaised = true;
-				throw new DuplicateKeyException("concurrent item insert");
-			}
-			return updated;
-		}
 	}
 }

--- a/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepositoryTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
@@ -118,6 +119,22 @@ class JdbcFieldVerificationSessionRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("동시 생성 중복 키 충돌은 최신 세션과 항목 값으로 갱신한다")
+	void saveRetriesUpdateWhenConcurrentInsertCreatesRows() {
+		var jdbcTemplate = new DuplicateInsertOnceJdbcTemplate(repositoryJdbcTemplate("field-verification-session-retry"));
+		var retryRepository = new JdbcFieldVerificationSessionRepository(jdbcTemplate);
+		var session = session(
+			"field-verification-sadang-2026-06",
+			"station-sadang",
+			FieldVerificationStatus.NEEDS_RECHECK
+		);
+
+		retryRepository.save(session);
+
+		assertThat(retryRepository.findByStationId("station-sadang")).contains(session);
+	}
+
+	@Test
 	@DisplayName("세션 목록은 역별 최신 세션만 검증일 최신순과 세션 식별자순으로 조회한다")
 	void listAllReturnsLatestSessionByStationAndOrdersByVerificationDate() {
 		repository.save(session(
@@ -181,5 +198,65 @@ class JdbcFieldVerificationSessionRepositoryTest {
 				)
 			)
 		);
+	}
+
+	private JdbcTemplate repositoryJdbcTemplate(String databaseName) {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:" + databaseName + ";MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS field_verification_items");
+		jdbcTemplate.execute("DROP TABLE IF EXISTS field_verification_sessions");
+		jdbcTemplate.execute("""
+			CREATE TABLE field_verification_sessions (
+				session_id VARCHAR(120) PRIMARY KEY,
+				station_id VARCHAR(120) NOT NULL,
+				station_name VARCHAR(120) NOT NULL,
+				verified_at DATE NOT NULL,
+				verified_by VARCHAR(120) NOT NULL,
+				status VARCHAR(40) NOT NULL,
+				note VARCHAR(1000)
+			)
+			""");
+		jdbcTemplate.execute("""
+			CREATE TABLE field_verification_items (
+				item_id VARCHAR(120) PRIMARY KEY,
+				session_id VARCHAR(120) NOT NULL,
+				item_type VARCHAR(40) NOT NULL,
+				target_name VARCHAR(200) NOT NULL,
+				status VARCHAR(40) NOT NULL,
+				note VARCHAR(1000),
+				CONSTRAINT fk_field_verification_items_session
+					FOREIGN KEY (session_id)
+					REFERENCES field_verification_sessions(session_id)
+			)
+			""");
+		return jdbcTemplate;
+	}
+
+	private static final class DuplicateInsertOnceJdbcTemplate extends JdbcTemplate {
+
+		private boolean sessionDuplicateRaised;
+		private boolean itemDuplicateRaised;
+
+		private DuplicateInsertOnceJdbcTemplate(JdbcTemplate delegate) {
+			super(delegate.getDataSource());
+		}
+
+		@Override
+		public int update(String sql, Object... args) {
+			int updated = super.update(sql, args);
+			if (!sessionDuplicateRaised && sql.contains("INSERT INTO field_verification_sessions")) {
+				sessionDuplicateRaised = true;
+				throw new DuplicateKeyException("concurrent session insert");
+			}
+			if (!itemDuplicateRaised && sql.contains("INSERT INTO field_verification_items")) {
+				itemDuplicateRaised = true;
+				throw new DuplicateKeyException("concurrent item insert");
+			}
+			return updated;
+		}
 	}
 }

--- a/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepositoryTest.java
@@ -47,7 +47,10 @@ class JdbcFieldVerificationSessionRepositoryTest {
 				item_type VARCHAR(40) NOT NULL,
 				target_name VARCHAR(200) NOT NULL,
 				status VARCHAR(40) NOT NULL,
-				note VARCHAR(1000)
+				note VARCHAR(1000),
+				CONSTRAINT fk_field_verification_items_session
+					FOREIGN KEY (session_id)
+					REFERENCES field_verification_sessions(session_id)
 			)
 			""");
 		repository = new JdbcFieldVerificationSessionRepository(jdbcTemplate);
@@ -115,24 +118,49 @@ class JdbcFieldVerificationSessionRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("세션 목록은 검증일 최신순과 세션 식별자순으로 조회한다")
-	void listAllOrdersByVerificationDateAndSessionId() {
-		repository.save(session("field-verification-sadang-2026-06", "station-sadang", FieldVerificationStatus.PLANNED));
-		repository.save(session("field-verification-sangnoksu-2026-06", "station-sangnoksu", FieldVerificationStatus.IN_PROGRESS));
+	@DisplayName("세션 목록은 역별 최신 세션만 검증일 최신순과 세션 식별자순으로 조회한다")
+	void listAllReturnsLatestSessionByStationAndOrdersByVerificationDate() {
+		repository.save(session(
+			"field-verification-sadang-2026-05",
+			"station-sadang",
+			FieldVerificationStatus.PLANNED,
+			LocalDate.of(2026, 5, 19)
+		));
+		repository.save(session(
+			"field-verification-sangnoksu-2026-06",
+			"station-sangnoksu",
+			FieldVerificationStatus.IN_PROGRESS,
+			LocalDate.of(2026, 6, 19)
+		));
+		repository.save(session(
+			"field-verification-sadang-2026-07",
+			"station-sadang",
+			FieldVerificationStatus.NEEDS_RECHECK,
+			LocalDate.of(2026, 7, 19)
+		));
 
 		var sessions = repository.listAll();
 
 		assertThat(sessions)
-			.extracting(FieldVerificationSession::stationId)
-			.containsExactly("station-sadang", "station-sangnoksu");
+			.extracting(FieldVerificationSession::id)
+			.containsExactly("field-verification-sadang-2026-07", "field-verification-sangnoksu-2026-06");
 	}
 
 	private FieldVerificationSession session(String sessionId, String stationId, FieldVerificationStatus status) {
+		return session(sessionId, stationId, status, LocalDate.of(2026, 6, 19));
+	}
+
+	private FieldVerificationSession session(
+		String sessionId,
+		String stationId,
+		FieldVerificationStatus status,
+		LocalDate verifiedAt
+	) {
 		return new FieldVerificationSession(
 			sessionId,
 			stationId,
 			stationId.equals("station-sadang") ? "사당역" : "상록수역",
-			LocalDate.of(2026, 6, 19),
+			verifiedAt,
 			"field-team",
 			status,
 			stationId.equals("station-sadang") ? "주요 환승역 현장 검증 확대 기준선" : "첫 현장 검증 지역 기준선",

--- a/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepositoryTest.java
@@ -163,6 +163,62 @@ class JdbcFieldVerificationSessionRepositoryTest {
 			.containsExactly("field-verification-sadang-2026-07", "field-verification-sangnoksu-2026-06");
 	}
 
+	@Test
+	@DisplayName("같은 검증일의 세션 목록은 기존 기준선 노출 순서를 유지한다")
+	void listAllKeepsBaselineDisplayOrderWhenVerificationDatesAreSame() {
+		repository.save(session(
+			"field-verification-sadang-2026-06",
+			"station-sadang",
+			FieldVerificationStatus.PLANNED,
+			LocalDate.of(2026, 6, 19)
+		));
+		repository.save(session(
+			"field-verification-sangnoksu-2026-06",
+			"station-sangnoksu",
+			FieldVerificationStatus.IN_PROGRESS,
+			LocalDate.of(2026, 6, 19)
+		));
+
+		var sessions = repository.listAll();
+
+		assertThat(sessions)
+			.extracting(FieldVerificationSession::id)
+			.containsExactly("field-verification-sangnoksu-2026-06", "field-verification-sadang-2026-06");
+	}
+
+	@Test
+	@DisplayName("항목 목록은 관리자 API와 CSV 출력 순서를 유지한다")
+	void findByStationIdKeepsFieldVerificationItemDisplayOrder() {
+		repository.save(new FieldVerificationSession(
+			"field-verification-sadang-2026-06",
+			"station-sadang",
+			"사당역",
+			LocalDate.of(2026, 6, 19),
+			"field-team",
+			FieldVerificationStatus.IN_PROGRESS,
+			"주요 환승역 현장 검증 확대 기준선",
+			List.of(
+				item("field-verification-sadang-elevator", FieldVerificationItemType.ELEVATOR),
+				item("field-verification-sadang-platform-transfer", FieldVerificationItemType.PLATFORM_TRANSFER),
+				item("field-verification-sadang-exit", FieldVerificationItemType.EXIT),
+				item("field-verification-sadang-restroom", FieldVerificationItemType.RESTROOM),
+				item("field-verification-sadang-escalator", FieldVerificationItemType.ESCALATOR)
+			)
+		));
+
+		var found = repository.findByStationId("station-sadang").orElseThrow();
+
+		assertThat(found.items())
+			.extracting(FieldVerificationItem::type)
+			.containsExactly(
+				FieldVerificationItemType.EXIT,
+				FieldVerificationItemType.ELEVATOR,
+				FieldVerificationItemType.ESCALATOR,
+				FieldVerificationItemType.RESTROOM,
+				FieldVerificationItemType.PLATFORM_TRANSFER
+			);
+	}
+
 	private FieldVerificationSession session(String sessionId, String stationId, FieldVerificationStatus status) {
 		return session(sessionId, stationId, status, LocalDate.of(2026, 6, 19));
 	}
@@ -197,6 +253,16 @@ class JdbcFieldVerificationSessionRepositoryTest {
 					null
 				)
 			)
+		);
+	}
+
+	private FieldVerificationItem item(String itemId, FieldVerificationItemType type) {
+		return new FieldVerificationItem(
+			itemId,
+			type,
+			type.label(),
+			FieldVerificationStatus.PLANNED,
+			null
 		);
 	}
 

--- a/backend/src/test/java/com/easysubway/field/application/service/FieldVerificationServiceTest.java
+++ b/backend/src/test/java/com/easysubway/field/application/service/FieldVerificationServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.easysubway.common.error.ResourceNotFoundException;
 import com.easysubway.field.adapter.out.persistence.InMemoryFieldVerificationChangeHistoryRepository;
+import com.easysubway.field.adapter.out.persistence.InMemoryFieldVerificationSessionRepository;
 import com.easysubway.field.application.port.in.UpdateFieldVerificationItemStatusCommand;
 import com.easysubway.field.domain.FieldVerificationChangeHistory;
 import com.easysubway.field.domain.FieldVerificationItemType;
@@ -18,7 +19,9 @@ class FieldVerificationServiceTest {
 
 	private final InMemoryFieldVerificationChangeHistoryRepository historyRepository =
 		new InMemoryFieldVerificationChangeHistoryRepository();
-	private final FieldVerificationService service = new FieldVerificationService(historyRepository);
+	private final InMemoryFieldVerificationSessionRepository sessionRepository =
+		new InMemoryFieldVerificationSessionRepository();
+	private final FieldVerificationService service = new FieldVerificationService(sessionRepository, historyRepository);
 
 	@Test
 	@DisplayName("상록수역 필수 현장 검증 항목을 조회한다")
@@ -104,6 +107,10 @@ class FieldVerificationServiceTest {
 				assertThat(item.status()).isEqualTo(FieldVerificationStatus.NEEDS_RECHECK);
 				assertThat(item.note()).isEqualTo("엘리베이터 운행 중지 안내문 확인 필요");
 			});
+		assertThat(sessionRepository.findByStationId("station-sadang"))
+			.get()
+			.extracting(stored -> stored.status())
+			.isEqualTo(FieldVerificationStatus.NEEDS_RECHECK);
 	}
 
 	@Test

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2323,6 +2323,9 @@ test("현장 검증 세션 저장소는 운영/비운영 저장소 경계를 분
   assert.match(jdbcSessionRepository, /INSERT INTO field_verification_sessions/);
   assert.match(jdbcSessionRepository, /UPDATE field_verification_items/);
   assert.match(jdbcSessionRepository, /INSERT INTO field_verification_items/);
+  assert.match(jdbcSessionRepository, /DuplicateKeyException/);
+  assert.match(jdbcSessionRepository, /updateSession\(session\)/);
+  assert.match(jdbcSessionRepository, /updateItem\(session, item\)/);
   assert.match(jdbcSessionRepository, /@Transactional\s+public void save\(FieldVerificationSession session\)/);
   assert.match(jdbcSessionRepository, /ORDER BY verified_at DESC, session_id ASC/);
   assert.match(jdbcSessionRepository, /ORDER BY item_type ASC, item_id ASC/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2317,10 +2317,13 @@ test("현장 검증 세션 저장소는 운영/비운영 저장소 경계를 분
   assert.match(inMemorySessionRepository, /implements FieldVerificationSessionRepository/);
   assert.match(inMemorySessionRepository, /LinkedHashMap/);
   assert.match(jdbcSessionRepository, /@Repository\s+@Profile\("prod"\)/);
+  assert.match(jdbcSessionRepository, /ROW_NUMBER\(\) OVER/);
+  assert.match(jdbcSessionRepository, /PARTITION BY station_id/);
   assert.match(jdbcSessionRepository, /UPDATE field_verification_sessions/);
   assert.match(jdbcSessionRepository, /INSERT INTO field_verification_sessions/);
   assert.match(jdbcSessionRepository, /UPDATE field_verification_items/);
   assert.match(jdbcSessionRepository, /INSERT INTO field_verification_items/);
+  assert.match(jdbcSessionRepository, /@Transactional\s+public void save\(FieldVerificationSession session\)/);
   assert.match(jdbcSessionRepository, /ORDER BY verified_at DESC, session_id ASC/);
   assert.match(jdbcSessionRepository, /ORDER BY item_type ASC, item_id ASC/);
   assert.match(service, /FieldVerificationSessionRepository/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2303,6 +2303,34 @@ test("현장 검증 기준선은 세션과 항목을 관리자 API로 추적한�
   assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
 });
 
+test("현장 검증 세션 저장소는 운영/비운영 저장소 경계를 분리한다", () => {
+  const sessionRepositoryPort = read("backend/src/main/java/com/easysubway/field/application/port/out/FieldVerificationSessionRepository.java");
+  const inMemorySessionRepository = read("backend/src/main/java/com/easysubway/field/adapter/out/persistence/InMemoryFieldVerificationSessionRepository.java");
+  const jdbcSessionRepository = read("backend/src/main/java/com/easysubway/field/adapter/out/persistence/JdbcFieldVerificationSessionRepository.java");
+  const service = read("backend/src/main/java/com/easysubway/field/application/service/FieldVerificationService.java");
+  const profileTest = read("backend/src/test/java/com/easysubway/common/persistence/InMemoryRepositoryProfileTest.java");
+
+  assert.match(sessionRepositoryPort, /List<FieldVerificationSession> listAll\(\)/);
+  assert.match(sessionRepositoryPort, /Optional<FieldVerificationSession> findByStationId\(String stationId\)/);
+  assert.match(sessionRepositoryPort, /void save\(FieldVerificationSession session\)/);
+  assert.match(inMemorySessionRepository, /@Repository\s+@Profile\("!prod"\)/);
+  assert.match(inMemorySessionRepository, /implements FieldVerificationSessionRepository/);
+  assert.match(inMemorySessionRepository, /LinkedHashMap/);
+  assert.match(jdbcSessionRepository, /@Repository\s+@Profile\("prod"\)/);
+  assert.match(jdbcSessionRepository, /UPDATE field_verification_sessions/);
+  assert.match(jdbcSessionRepository, /INSERT INTO field_verification_sessions/);
+  assert.match(jdbcSessionRepository, /UPDATE field_verification_items/);
+  assert.match(jdbcSessionRepository, /INSERT INTO field_verification_items/);
+  assert.match(jdbcSessionRepository, /ORDER BY verified_at DESC, session_id ASC/);
+  assert.match(jdbcSessionRepository, /ORDER BY item_type ASC, item_id ASC/);
+  assert.match(service, /FieldVerificationSessionRepository/);
+  assert.match(service, /sessionRepository\.save/);
+  assert.match(service, /sessionRepository\.findByStationId/);
+  assert.doesNotMatch(service, /Map<String, FieldVerificationSession>/);
+  assert.doesNotMatch(service, /sessionsByStationId/);
+  assert.match(profileTest, /InMemoryFieldVerificationSessionRepository/);
+});
+
 test("백엔드 데이터 품질 요약은 관리자 API와 헥사고날 경계를 따른다", () => {
   const summary = read("backend/src/main/java/com/easysubway/quality/domain/DataQualitySummary.java");
   const useCase = read("backend/src/main/java/com/easysubway/quality/application/port/in/DataQualityUseCase.java");

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2319,13 +2319,13 @@ test("현장 검증 세션 저장소는 운영/비운영 저장소 경계를 분
   assert.match(jdbcSessionRepository, /@Repository\s+@Profile\("prod"\)/);
   assert.match(jdbcSessionRepository, /ROW_NUMBER\(\) OVER/);
   assert.match(jdbcSessionRepository, /PARTITION BY station_id/);
-  assert.match(jdbcSessionRepository, /UPDATE field_verification_sessions/);
   assert.match(jdbcSessionRepository, /INSERT INTO field_verification_sessions/);
-  assert.match(jdbcSessionRepository, /UPDATE field_verification_items/);
+  assert.match(jdbcSessionRepository, /ON CONFLICT \(session_id\) DO UPDATE/);
+  assert.match(jdbcSessionRepository, /station_id = EXCLUDED\.station_id/);
   assert.match(jdbcSessionRepository, /INSERT INTO field_verification_items/);
-  assert.match(jdbcSessionRepository, /DuplicateKeyException/);
-  assert.match(jdbcSessionRepository, /updateSession\(session\)/);
-  assert.match(jdbcSessionRepository, /updateItem\(session, item\)/);
+  assert.match(jdbcSessionRepository, /ON CONFLICT \(item_id\) DO UPDATE/);
+  assert.match(jdbcSessionRepository, /session_id = EXCLUDED\.session_id/);
+  assert.doesNotMatch(jdbcSessionRepository, /DuplicateKeyException/);
   assert.match(jdbcSessionRepository, /@Transactional\s+public void save\(FieldVerificationSession session\)/);
   assert.match(jdbcSessionRepository, /ORDER BY verified_at DESC, station_id DESC, session_id ASC/);
   assert.match(jdbcSessionRepository, /WHEN 'EXIT' THEN 1/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2327,8 +2327,10 @@ test("현장 검증 세션 저장소는 운영/비운영 저장소 경계를 분
   assert.match(jdbcSessionRepository, /updateSession\(session\)/);
   assert.match(jdbcSessionRepository, /updateItem\(session, item\)/);
   assert.match(jdbcSessionRepository, /@Transactional\s+public void save\(FieldVerificationSession session\)/);
-  assert.match(jdbcSessionRepository, /ORDER BY verified_at DESC, session_id ASC/);
-  assert.match(jdbcSessionRepository, /ORDER BY item_type ASC, item_id ASC/);
+  assert.match(jdbcSessionRepository, /ORDER BY verified_at DESC, station_id DESC, session_id ASC/);
+  assert.match(jdbcSessionRepository, /WHEN 'EXIT' THEN 1/);
+  assert.match(jdbcSessionRepository, /WHEN 'PLATFORM_TRANSFER' THEN 5/);
+  assert.match(jdbcSessionRepository, /END ASC, item_id ASC/);
   assert.match(service, /FieldVerificationSessionRepository/);
   assert.match(service, /sessionRepository\.save/);
   assert.match(service, /sessionRepository\.findByStationId/);


### PR DESCRIPTION
## 관련 이슈

close #470

## 작업 배경

- 현장 검증 변경 이력은 저장소로 분리되었지만 세션과 항목은 service 내부 메모리에만 남아 있었다.
- 운영 프로필에서 변경 이력은 `field_verification_sessions`, `field_verification_items` FK를 참조하므로 세션/항목도 같은 저장소 경계로 저장되어야 상태 변경과 이력 저장이 함께 동작한다.

## 작업 내용

- `FieldVerificationSessionRepository` application out port를 추가했다.
- non-prod용 `InMemoryFieldVerificationSessionRepository`를 추가해 기존 API 기준선의 세션 순서와 동작을 유지했다.
- prod용 `JdbcFieldVerificationSessionRepository`를 추가해 `field_verification_sessions`, `field_verification_items` 저장/조회와 상태 갱신을 지원했다.
- `FieldVerificationService`가 세션/항목을 직접 `Map`에 보관하지 않고 repository port를 통해 조회/저장하도록 변경했다.
- 상태 변경 시 세션/항목 저장 후 변경 이력을 남기도록 저장 순서를 정리했다.
- 운영 PostgreSQL 저장은 `INSERT ... ON CONFLICT DO UPDATE` upsert로 처리해 다중 인스턴스 기준선 seed 충돌을 원자적으로 수렴하도록 했다.
- JDBC repository test와 repository contract, 인메모리 프로필 검증을 보강했다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests '*FieldVerification*' --tests '*InMemoryRepositoryProfile*'`: 새 repository class 미구현으로 실패 확인 후 구현, 이후 성공
  - `node --test --test-name-pattern "현장 검증 세션 저장소" tools/ci/repository-contract.test.mjs`: 새 port 파일 미존재로 실패 확인 후 구현, 이후 성공
  - `backend/gradlew -p backend test`: 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 60개 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`
  - GitHub Actions CI `27806256890`: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI, Dependency Vulnerability Scan 모두 성공
  - merge 후 CD `27806496605`: 성공
  - merge 후 main CI `27806496663`: 성공

## 리뷰어 메모

- service 생성 시 상록수역/사당역 기준 세션은 repository에 없을 때만 seed한다.
- JDBC 저장소는 운영 PostgreSQL에서 세션/항목을 `ON CONFLICT` upsert로 저장하고, H2 기반 단위 테스트에서는 동일 동작을 update/insert 경로로 검증한다.
- CodeRabbit 초기 리뷰 4건과 Codex CLI fallback 리뷰 4건은 모두 같은 PR에서 수정했고, 원래 review thread에 해결 commit 답글을 남긴 뒤 resolve했다.
- 최신 Codex CLI fallback 리뷰는 추가 지적 없이 종료했다.

## 리스크

- prod 시작 시 baseline seed가 실행되므로 이미 운영 DB에 같은 station id의 최신 세션이 있으면 기존 세션을 우선 사용한다.
- 항목 삭제/비활성화는 이번 범위가 아니며, 현재 저장소는 기존 항목을 갱신하거나 새 항목을 추가하는 기준선이다.
- 이번 변경은 backend 저장 경계 변경이라 merge 후 main CI/CD 상태를 별도로 확인했고 둘 다 성공했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
