### PR TITLE
[Feat] 신고 검수 감사 로그 JDBC 저장소 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportReviewAuditRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportReviewAuditRepository.java
@@ -1,0 +1,89 @@
+package com.easysubway.report.adapter.out.persistence;
+
+import com.easysubway.report.application.port.out.LoadFacilityReportReviewAuditPort;
+import com.easysubway.report.application.port.out.SaveFacilityReportReviewAuditPort;
+import com.easysubway.report.domain.FacilityReportReviewAudit;
+import com.easysubway.report.domain.FacilityReportReviewDecision;
+import com.easysubway.report.domain.FacilityReportStatus;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("prod")
+public class JdbcFacilityReportReviewAuditRepository implements
+	LoadFacilityReportReviewAuditPort,
+	SaveFacilityReportReviewAuditPort {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public JdbcFacilityReportReviewAuditRepository(DataSource dataSource) {
+		this(new JdbcTemplate(dataSource));
+	}
+
+	JdbcFacilityReportReviewAuditRepository(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public FacilityReportReviewAudit saveAudit(FacilityReportReviewAudit audit) {
+		jdbcTemplate.update(
+			"""
+				INSERT INTO facility_report_review_audits (
+					audit_id,
+					report_id,
+					reviewer_id,
+					decision,
+					previous_status,
+					next_status,
+					created_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?)
+				""",
+			audit.id(),
+			audit.reportId(),
+			audit.reviewerId(),
+			audit.decision().name(),
+			audit.previousStatus().name(),
+			audit.nextStatus().name(),
+			audit.createdAt()
+		);
+		return audit;
+	}
+
+	@Override
+	public List<FacilityReportReviewAudit> loadAuditsByReportId(String reportId) {
+		return jdbcTemplate.query(
+			"""
+				SELECT audit_id,
+					report_id,
+					reviewer_id,
+					decision,
+					previous_status,
+					next_status,
+					created_at
+				FROM facility_report_review_audits
+				WHERE report_id = ?
+				ORDER BY created_at ASC, audit_id ASC
+				""",
+			this::mapAudit,
+			reportId
+		);
+	}
+
+	private FacilityReportReviewAudit mapAudit(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new FacilityReportReviewAudit(
+			resultSet.getString("audit_id"),
+			resultSet.getString("report_id"),
+			resultSet.getString("reviewer_id"),
+			FacilityReportReviewDecision.valueOf(resultSet.getString("decision")),
+			FacilityReportStatus.valueOf(resultSet.getString("previous_status")),
+			FacilityReportStatus.valueOf(resultSet.getString("next_status")),
+			resultSet.getTimestamp("created_at").toLocalDateTime()
+		);
+	}
+}

--- a/backend/src/main/resources/db/batch/schema-postgresql.sql
+++ b/backend/src/main/resources/db/batch/schema-postgresql.sql
@@ -359,6 +359,28 @@ CREATE INDEX IF NOT EXISTS idx_facility_reports_user
 CREATE INDEX IF NOT EXISTS idx_facility_reports_status_created
 	ON facility_reports (status, created_at DESC, report_id ASC);
 
+CREATE TABLE IF NOT EXISTS facility_report_review_audits (
+	audit_id VARCHAR(120) NOT NULL PRIMARY KEY,
+	report_id VARCHAR(120) NOT NULL,
+	reviewer_id VARCHAR(120) NOT NULL,
+	decision VARCHAR(40) NOT NULL,
+	previous_status VARCHAR(40) NOT NULL,
+	next_status VARCHAR(40) NOT NULL,
+	created_at TIMESTAMP NOT NULL,
+	CONSTRAINT fk_facility_report_review_audits_report
+		FOREIGN KEY (report_id) REFERENCES facility_reports(report_id)
+		ON DELETE RESTRICT ON UPDATE CASCADE,
+	CONSTRAINT chk_facility_report_review_audits_decision
+		CHECK (decision IN ('ACCEPT', 'REJECT', 'MARK_DUPLICATE')),
+	CONSTRAINT chk_facility_report_review_audits_previous_status
+		CHECK (previous_status IN ('SUBMITTED', 'DUPLICATE', 'UNDER_REVIEW', 'ACCEPTED', 'REJECTED', 'RESOLVED')),
+	CONSTRAINT chk_facility_report_review_audits_next_status
+		CHECK (next_status IN ('SUBMITTED', 'DUPLICATE', 'UNDER_REVIEW', 'ACCEPTED', 'REJECTED', 'RESOLVED'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_facility_report_review_audits_report
+	ON facility_report_review_audits (report_id, created_at ASC, audit_id ASC);
+
 CREATE TABLE IF NOT EXISTS notification_settings (
 	user_id VARCHAR(120) NOT NULL PRIMARY KEY,
 	favorite_station_facility_alerts BOOLEAN NOT NULL,

--- a/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportReviewAuditRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportReviewAuditRepositoryTest.java
@@ -1,0 +1,136 @@
+package com.easysubway.report.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.report.domain.FacilityReportReviewAudit;
+import com.easysubway.report.domain.FacilityReportReviewDecision;
+import com.easysubway.report.domain.FacilityReportStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("JDBC 신고 검수 감사 로그 저장소")
+class JdbcFacilityReportReviewAuditRepositoryTest {
+
+	private JdbcFacilityReportReviewAuditRepository repository;
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:facility-report-review-audits;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS facility_report_review_audits");
+		jdbcTemplate.execute("""
+			CREATE TABLE facility_report_review_audits (
+				audit_id VARCHAR(120) NOT NULL PRIMARY KEY,
+				report_id VARCHAR(120) NOT NULL,
+				reviewer_id VARCHAR(120) NOT NULL,
+				decision VARCHAR(40) NOT NULL,
+				previous_status VARCHAR(40) NOT NULL,
+				next_status VARCHAR(40) NOT NULL,
+				created_at TIMESTAMP NOT NULL,
+				CONSTRAINT chk_facility_report_review_audits_decision
+					CHECK (decision IN ('ACCEPT', 'REJECT', 'MARK_DUPLICATE')),
+				CONSTRAINT chk_facility_report_review_audits_previous_status
+					CHECK (previous_status IN ('SUBMITTED', 'DUPLICATE', 'UNDER_REVIEW', 'ACCEPTED', 'REJECTED', 'RESOLVED')),
+				CONSTRAINT chk_facility_report_review_audits_next_status
+					CHECK (next_status IN ('SUBMITTED', 'DUPLICATE', 'UNDER_REVIEW', 'ACCEPTED', 'REJECTED', 'RESOLVED'))
+			)
+			""");
+		repository = new JdbcFacilityReportReviewAuditRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("신고 검수 감사 로그를 저장하고 신고 식별자 기준 생성순으로 조회한다")
+	void saveAuditAndLoadAuditsByReportIdOldestFirst() {
+		repository.saveAudit(audit(
+			"audit-new",
+			"report-target",
+			FacilityReportReviewDecision.REJECT,
+			FacilityReportStatus.UNDER_REVIEW,
+			FacilityReportStatus.REJECTED,
+			LocalDateTime.of(2026, 6, 19, 11, 0)
+		));
+		repository.saveAudit(audit(
+			"audit-old",
+			"report-target",
+			FacilityReportReviewDecision.ACCEPT,
+			FacilityReportStatus.SUBMITTED,
+			FacilityReportStatus.ACCEPTED,
+			LocalDateTime.of(2026, 6, 19, 10, 0)
+		));
+		repository.saveAudit(audit(
+			"audit-other-report",
+			"report-other",
+			FacilityReportReviewDecision.MARK_DUPLICATE,
+			FacilityReportStatus.SUBMITTED,
+			FacilityReportStatus.DUPLICATE,
+			LocalDateTime.of(2026, 6, 19, 12, 0)
+		));
+
+		var audits = repository.loadAuditsByReportId("report-target");
+
+		assertThat(audits)
+			.extracting(FacilityReportReviewAudit::id)
+			.containsExactly("audit-old", "audit-new");
+		assertThat(audits.get(0)).satisfies(audit -> {
+			assertThat(audit.reportId()).isEqualTo("report-target");
+			assertThat(audit.reviewerId()).isEqualTo("admin-reviewer");
+			assertThat(audit.decision()).isEqualTo(FacilityReportReviewDecision.ACCEPT);
+			assertThat(audit.previousStatus()).isEqualTo(FacilityReportStatus.SUBMITTED);
+			assertThat(audit.nextStatus()).isEqualTo(FacilityReportStatus.ACCEPTED);
+			assertThat(audit.createdAt()).isEqualTo(LocalDateTime.of(2026, 6, 19, 10, 0));
+		});
+	}
+
+	@Test
+	@DisplayName("저장소를 재생성해도 저장된 신고 검수 감사 로그를 조회한다")
+	void loadAuditsByReportIdAfterRepositoryRecreation() {
+		repository.saveAudit(audit(
+			"audit-persisted",
+			"report-persisted",
+			FacilityReportReviewDecision.REJECT,
+			FacilityReportStatus.UNDER_REVIEW,
+			FacilityReportStatus.REJECTED,
+			LocalDateTime.of(2026, 6, 19, 13, 0)
+		));
+
+		var recreatedRepository = new JdbcFacilityReportReviewAuditRepository(jdbcTemplate);
+
+		assertThat(recreatedRepository.loadAuditsByReportId("report-persisted"))
+			.extracting(FacilityReportReviewAudit::id)
+			.containsExactly("audit-persisted");
+	}
+
+	@Test
+	@DisplayName("감사 로그가 없는 신고는 빈 목록을 반환한다")
+	void loadAuditsByReportIdReturnsEmptyWhenAuditDoesNotExist() {
+		assertThat(repository.loadAuditsByReportId("missing-report")).isEmpty();
+	}
+
+	private FacilityReportReviewAudit audit(
+		String auditId,
+		String reportId,
+		FacilityReportReviewDecision decision,
+		FacilityReportStatus previousStatus,
+		FacilityReportStatus nextStatus,
+		LocalDateTime createdAt
+	) {
+		return new FacilityReportReviewAudit(
+			auditId,
+			reportId,
+			"admin-reviewer",
+			decision,
+			previousStatus,
+			nextStatus,
+			createdAt
+		);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2488,6 +2488,35 @@ test("사용자 활동 JDBC 저장소는 운영 프로필에서 활동 지표를
   assert.match(repositoryTest, /summarizeUserActivityAfterRepositoryRecreation/);
 });
 
+test("신고 검수 감사 로그 JDBC 저장소는 운영 프로필에서 검수 이력을 영속화한다", () => {
+  const schema = read("backend/src/main/resources/db/batch/schema-postgresql.sql");
+  const repository = read(
+    "backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportReviewAuditRepository.java",
+  );
+  const repositoryTest = read(
+    "backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportReviewAuditRepositoryTest.java",
+  );
+
+  assert.match(schema, /CREATE TABLE IF NOT EXISTS facility_report_review_audits/);
+  assert.match(schema, /audit_id VARCHAR\(120\) NOT NULL PRIMARY KEY/);
+  assert.match(schema, /report_id VARCHAR\(120\) NOT NULL/);
+  assert.match(schema, /reviewer_id VARCHAR\(120\) NOT NULL/);
+  assert.match(schema, /CONSTRAINT chk_facility_report_review_audits_decision/);
+  assert.match(schema, /CHECK \(decision IN \('ACCEPT', 'REJECT', 'MARK_DUPLICATE'\)\)/);
+  assert.match(schema, /CONSTRAINT chk_facility_report_review_audits_previous_status/);
+  assert.match(schema, /CONSTRAINT chk_facility_report_review_audits_next_status/);
+  assert.match(
+    schema,
+    /CREATE INDEX IF NOT EXISTS idx_facility_report_review_audits_report[\s\S]*ON facility_report_review_audits \(report_id, created_at ASC, audit_id ASC\)/,
+  );
+  assert.match(repository, /@Profile\("prod"\)/);
+  assert.match(repository, /implements[\s\S]*LoadFacilityReportReviewAuditPort[\s\S]*SaveFacilityReportReviewAuditPort/);
+  assert.match(repository, /INSERT INTO facility_report_review_audits/);
+  assert.match(repository, /WHERE report_id = \?/);
+  assert.match(repository, /ORDER BY created_at ASC, audit_id ASC/);
+  assert.match(repositoryTest, /loadAuditsByReportIdAfterRepositoryRecreation/);
+});
+
 test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   const result = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java");
   const searchSummary = read("backend/src/main/java/com/easysubway/route/domain/RouteSearchDashboardSummary.java");


### PR DESCRIPTION
## 관련 이슈

close #474

## 작업 배경

- 신고 검수 감사 로그는 관리자 검수 이력과 운영 대응 근거로 사용된다.
- 기존 구현은 non-prod 인메모리 저장소만 있어 운영 프로필에서 재시작 후 감사 이력이 유지되는 저장 경계가 필요했다.

## 작업 내용

- prod 프로필용 `JdbcFacilityReportReviewAuditRepository`를 추가해 신고 검수 감사 로그를 PostgreSQL에 저장하도록 한다.
- `facility_report_review_audits` 운영 schema와 신고 ID 기준 조회 index를 추가한다.
- JDBC 저장소가 감사 로그 저장, 신고 ID별 조회, 저장소 재생성 후 조회 계약을 인메모리 저장소와 같은 경계로 제공하도록 한다.
- 저장소 테스트와 repository contract를 추가한다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests '*JdbcFacilityReportReviewAuditRepositoryTest'`: `JdbcFacilityReportReviewAuditRepository` 미구현 컴파일 실패 확인 후 구현, 이후 성공
  - `node --test --test-name-pattern "신고 검수 감사 로그 JDBC 저장소" tools/ci/repository-contract.test.mjs`: JDBC 저장소 파일 미존재 실패 확인 후 구현, 이후 성공
  - `backend/gradlew -p backend test --tests '*FacilityReport*' --tests '*InMemoryRepositoryProfile*'`: 성공
  - `node --test tools/ci/repository-contract.test.mjs`: 62개 성공
  - `backend/gradlew -p backend test`: 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`
  - GitHub Actions CI run `27808032328`: Android CI, Backend CI, Changes, CodeRabbit, Dependency Vulnerability Scan, Mobile App CI, Repository CI, iOS CI, osv-scanner 모두 성공
  - Codex CLI fallback review: CodeRabbit이 rate limit으로 시작되지 않아 `codex review --base origin/main --title "[Feat] 신고 검수 감사 로그 JDBC 저장소 추가"` 실행, actionable 0건으로 PR review 기록
  - Post-merge CD run `27808221134`: 성공
  - Post-merge main CI run `27808221304`: Changes, Backend CI, Mobile App CI, Repository CI, Android CI, iOS CI 성공

## 리뷰어 메모

- 감사 로그는 신고 검수 시점의 변경 전/후 상태와 검수자를 append-only로 남긴다.
- 관리자 화면과 신고 검수 의사결정 로직은 이번 변경 범위에 포함하지 않는다.

## 리스크

- 감사 로그 보관 기간과 archive 정책은 별도 운영 정책으로 정해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
