### PR TITLE
[Fix] 신고 상태 조회와 경로 피드백 권한 경계 수정

### DIFF
--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -55,7 +55,9 @@ public class SecurityConfig {
 				"/api/v1/me/reports",
 				"/api/v1/me/favorites/**",
 				"/api/v1/reports",
+				"/api/v1/reports/*",
 				"/api/v1/reports/*/confirm",
+				"/api/v1/routes/*/feedback",
 				"/api/v1/devices",
 				"/api/v1/me/notification-settings"
 			)

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
@@ -41,15 +41,20 @@ class FacilityReportController {
 	}
 
 	@GetMapping("/api/v1/reports/{reportId}")
-	ApiResponse<FacilityReportStatusResponse> report(@PathVariable String reportId) {
-		return ApiResponse.ok(FacilityReportStatusResponse.from(facilityReportUseCase.getReport(reportId)));
+	ApiResponse<FacilityReportStatusResponse> report(
+		@PathVariable String reportId,
+		Principal principal
+	) {
+		return ApiResponse.ok(FacilityReportStatusResponse.from(
+			facilityReportUseCase.getUserReport(reportId, principal.getName())
+		));
 	}
 
 	@GetMapping("/api/v1/me/reports")
-	ApiResponse<List<FacilityReportListResponse>> myReports(Principal principal) {
-		List<FacilityReportListResponse> reports = facilityReportUseCase.listUserReports(principal.getName())
+	ApiResponse<List<FacilityReportStatusResponse>> myReports(Principal principal) {
+		List<FacilityReportStatusResponse> reports = facilityReportUseCase.listUserReports(principal.getName())
 			.stream()
-			.map(FacilityReportListResponse::from)
+			.map(FacilityReportStatusResponse::from)
 			.toList();
 		return ApiResponse.ok(reports);
 	}
@@ -168,40 +173,28 @@ class FacilityReportController {
 
 	record FacilityReportStatusResponse(
 		String id,
-		String userId,
 		String stationId,
 		String facilityId,
 		FacilityReportType reportType,
 		String description,
-		String photoFileName,
-		String photoContentType,
-		BigDecimal latitude,
-		BigDecimal longitude,
 		String duplicateOfReportId,
 		FacilityReportStatus status,
 		LocalDateTime createdAt,
-		LocalDateTime reviewedAt,
-		String reviewedBy
+		LocalDateTime reviewedAt
 	) {
 
 		static FacilityReportStatusResponse from(FacilityReport report) {
-			// 공개 상태 조회는 모바일 진행 상태 확인용이므로 첨부 사진 본문은 관리자 상세에서만 내려준다.
+			// 사용자용 상태 조회는 소유자에게도 내부 식별자와 정확한 위치 메타데이터를 숨긴다.
 			return new FacilityReportStatusResponse(
 				report.id(),
-				report.userId(),
 				report.stationId(),
 				report.facilityId(),
 				report.reportType(),
 				report.description(),
-				report.photoFileName(),
-				report.photoContentType(),
-				report.latitude(),
-				report.longitude(),
 				report.duplicateOfReportId(),
 				report.status(),
 				report.createdAt(),
-				report.reviewedAt(),
-				report.reviewedBy()
+				report.reviewedAt()
 			);
 		}
 	}

--- a/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java
@@ -13,6 +13,8 @@ public interface FacilityReportUseCase {
 
 	FacilityReport getReport(String reportId);
 
+	FacilityReport getUserReport(String reportId, String userId);
+
 	List<FacilityReport> listUserReports(String userId);
 
 	List<FacilityReport> listReports(FacilityReportStatus status);

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -259,6 +259,13 @@ public class FacilityReportService implements FacilityReportUseCase {
 	}
 
 	@Override
+	public FacilityReport getUserReport(String reportId, String userId) {
+		FacilityReport report = getReport(reportId);
+		requireReportOwner(report, userId);
+		return report;
+	}
+
+	@Override
 	public List<FacilityReport> listUserReports(String userId) {
 		return sortedReports()
 			.stream()

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -10,6 +10,7 @@ import com.easysubway.route.domain.InternalRouteResult;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteFeedbackRating;
 import com.easysubway.route.domain.RouteSearchResult;
+import java.security.Principal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,9 +45,10 @@ class RouteSearchController {
 	@PostMapping("/api/v1/routes/{routeSearchId}/feedback")
 	ApiResponse<RouteFeedback> submitRouteFeedback(
 		@PathVariable String routeSearchId,
-		@RequestBody SubmitRouteFeedbackRequest request
+		@RequestBody SubmitRouteFeedbackRequest request,
+		Principal principal
 	) {
-		return ApiResponse.ok(routeSearchUseCase.submitRouteFeedback(request.toCommand(routeSearchId)));
+		return ApiResponse.ok(routeSearchUseCase.submitRouteFeedback(request.toCommand(routeSearchId, principal.getName())));
 	}
 
 	record SearchRouteRequest(
@@ -73,13 +75,12 @@ class RouteSearchController {
 	}
 
 	record SubmitRouteFeedbackRequest(
-		String userId,
 		RouteFeedbackRating rating,
 		String comment
 	) {
 
-		SubmitRouteFeedbackCommand toCommand(String routeSearchId) {
-			return new SubmitRouteFeedbackCommand(routeSearchId, userId, rating, comment);
+		SubmitRouteFeedbackCommand toCommand(String routeSearchId, String authenticatedUserId) {
+			return new SubmitRouteFeedbackCommand(routeSearchId, authenticatedUserId, rating, comment);
 		}
 	}
 }

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportControllerTest.java
@@ -92,6 +92,7 @@ class OperatorRouteFeedbackReportControllerTest {
 
 	private void submitRouteFeedback(String routeSearchId, String rating, String comment) throws Exception {
 		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.with(httpBasic("basic-user", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportPageControllerTest.java
@@ -99,6 +99,7 @@ class OperatorRouteFeedbackReportPageControllerTest {
 
 	private void submitRouteFeedback(String routeSearchId, String rating, String comment) throws Exception {
 		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.with(httpBasic("basic-user", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -56,18 +56,25 @@ class FacilityReportControllerTest {
 			.andExpect(jsonPath("$.data.facilityId").value("facility-sangnoksu-elevator-1"))
 			.andExpect(jsonPath("$.data.reportType").value("BROKEN"))
 			.andExpect(jsonPath("$.data.status").value("SUBMITTED"))
-			.andExpect(jsonPath("$.data.userId").value("basic-user"))
+			.andExpect(jsonPath("$.data.userId").doesNotExist())
+			.andExpect(jsonPath("$.data.latitude").doesNotExist())
+			.andExpect(jsonPath("$.data.longitude").doesNotExist())
 			.andReturn()
 			.getResponse()
 			.getContentAsString();
 
 		String reportId = JsonPath.read(response, "$.data.id");
 
-		mockMvc.perform(get("/api/v1/reports/{reportId}", reportId))
+		mockMvc.perform(get("/api/v1/reports/{reportId}", reportId)
+				.with(httpBasic("basic-user", "user-test-password")))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.id").value(reportId))
-			.andExpect(jsonPath("$.data.description").value("엘리베이터 문이 열리지 않습니다."));
+			.andExpect(jsonPath("$.data.status").value("SUBMITTED"))
+			.andExpect(jsonPath("$.data.userId").doesNotExist())
+			.andExpect(jsonPath("$.data.latitude").doesNotExist())
+			.andExpect(jsonPath("$.data.longitude").doesNotExist())
+			.andExpect(jsonPath("$.data.reviewedBy").doesNotExist());
 	}
 
 	@Test
@@ -152,7 +159,24 @@ class FacilityReportControllerTest {
 	@Test
 	@DisplayName("존재하지 않는 신고 조회는 공통 404 응답을 반환한다")
 	void missingReportReturnsCommonErrorResponse() throws Exception {
-		mockMvc.perform(get("/api/v1/reports/missing-report"))
+		mockMvc.perform(get("/api/v1/reports/missing-report")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("신고 정보를 찾을 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("신고 상세 조회는 인증된 신고 소유자만 사용할 수 있다")
+	void reportDetailRequiresAuthenticationAndOwner() throws Exception {
+		String reportId = createReport("basic-user", "user-test-password", "spoofed-user", "소유자만 볼 수 있는 신고");
+
+		mockMvc.perform(get("/api/v1/reports/{reportId}", reportId))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/api/v1/reports/{reportId}", reportId)
+				.with(httpBasic("admin-test", "admin-test-password")))
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.data").doesNotExist())
@@ -184,23 +208,34 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
-	@DisplayName("신고 목록은 사진 본문을 제외하고 메타데이터만 반환한다")
-	void reportListsReturnPhotoMetadataWithoutPayload() throws Exception {
-		createReportWithPhoto("basic-user", "user-test-password", "spoofed-user", "사진이 있는 신고");
+	@DisplayName("내 신고 이력은 내부 사용자 식별자와 위치 메타데이터를 반환하지 않는다")
+	void myReportListDoesNotReturnInternalUserOrLocationMetadata() throws Exception {
+		createReportWithPhoto("basic-user", "user-test-password", "spoofed-user", "사진이 있는 내 신고");
 
-		String myReportsResponse = mockMvc.perform(get("/api/v1/me/reports")
+		String response = mockMvc.perform(get("/api/v1/me/reports")
 				.with(httpBasic("basic-user", "user-test-password")))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].userId").doesNotExist())
+			.andExpect(jsonPath("$.data[0].photoFileName").doesNotExist())
+			.andExpect(jsonPath("$.data[0].photoContentType").doesNotExist())
+			.andExpect(jsonPath("$.data[0].latitude").doesNotExist())
+			.andExpect(jsonPath("$.data[0].longitude").doesNotExist())
+			.andExpect(jsonPath("$.data[0].reviewedBy").doesNotExist())
 			.andReturn()
 			.getResponse()
 			.getContentAsString();
 
-		// 목록 화면에서는 사진 존재만 알면 충분하므로 실제 이미지 본문은 상세에서만 내려준다.
-		Assertions.assertThat(myReportsResponse)
-			.contains("photoFileName")
-			.contains("photoContentType")
-			.doesNotContain("photoDataBase64");
+		Assertions.assertThat(response)
+			.doesNotContain("basic-user")
+			.doesNotContain("elevator-notice.jpg")
+			.doesNotContain("image/jpeg");
+	}
+
+	@Test
+	@DisplayName("관리자 신고 목록은 사진 본문을 제외하고 메타데이터만 반환한다")
+	void reportListsReturnPhotoMetadataWithoutPayload() throws Exception {
+		createReportWithPhoto("basic-user", "user-test-password", "spoofed-user", "사진이 있는 신고");
 
 		String adminReportsResponse = mockMvc.perform(get("/admin/reports")
 				.with(httpBasic("admin-test", "admin-test-password")))
@@ -261,10 +296,11 @@ class FacilityReportControllerTest {
 			.andExpect(jsonPath("$.data.reviewedAt").isNotEmpty())
 			.andExpect(jsonPath("$.data.reviewedBy").value("admin-test"));
 
-		mockMvc.perform(get("/api/v1/reports/{reportId}", reportId))
+		mockMvc.perform(get("/api/v1/reports/{reportId}", reportId)
+				.with(httpBasic("basic-user", "user-test-password")))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.status").value("ACCEPTED"))
-			.andExpect(jsonPath("$.data.reviewedBy").value("admin-test"));
+			.andExpect(jsonPath("$.data.reviewedBy").doesNotExist());
 
 		mockMvc.perform(get("/api/v1/stations/station-sangnoksu/facilities"))
 			.andExpect(status().isOk())
@@ -296,7 +332,7 @@ class FacilityReportControllerTest {
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.id").value(reportId))
 			.andExpect(jsonPath("$.data.status").value("RESOLVED"))
-			.andExpect(jsonPath("$.data.reviewedBy").value("admin-test"));
+			.andExpect(jsonPath("$.data.reviewedBy").doesNotExist());
 	}
 
 	@Test
@@ -550,20 +586,26 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
-	@DisplayName("공개 신고 조회는 사진 본문을 반환하지 않는다")
-	void publicReportDetailDoesNotReturnPhotoPayload() throws Exception {
+	@DisplayName("사용자 신고 상세는 사진과 위치 메타데이터를 반환하지 않는다")
+	void userReportDetailDoesNotReturnPhotoOrLocationMetadata() throws Exception {
 		String reportId = createReportWithPhoto("basic-user", "user-test-password", "spoofed-user", "사진이 있는 신고");
 
-		String response = mockMvc.perform(get("/api/v1/reports/{reportId}", reportId))
+		String response = mockMvc.perform(get("/api/v1/reports/{reportId}", reportId)
+				.with(httpBasic("basic-user", "user-test-password")))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
-			.andExpect(jsonPath("$.data.photoFileName").value("elevator-notice.jpg"))
-			.andExpect(jsonPath("$.data.photoContentType").value("image/jpeg"))
+			.andExpect(jsonPath("$.data.photoFileName").doesNotExist())
+			.andExpect(jsonPath("$.data.photoContentType").doesNotExist())
+			.andExpect(jsonPath("$.data.latitude").doesNotExist())
+			.andExpect(jsonPath("$.data.longitude").doesNotExist())
 			.andReturn()
 			.getResponse()
 			.getContentAsString();
 
 		Assertions.assertThat(response)
+			.doesNotContain("basic-user")
+			.doesNotContain("elevator-notice.jpg")
+			.doesNotContain("image/jpeg")
 			.doesNotContain("photoDataBase64")
 			.doesNotContain("aW1hZ2UtYnl0ZXM=");
 	}

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminApiControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminApiControllerTest.java
@@ -91,6 +91,7 @@ class RouteFeedbackAdminApiControllerTest {
 
 	private void submitRouteFeedback(String routeSearchId, String rating, String comment) throws Exception {
 		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteFeedbackAdminPageControllerTest.java
@@ -92,6 +92,7 @@ class RouteFeedbackAdminPageControllerTest {
 
 	private void submitRouteFeedback(String routeSearchId, String rating, String comment) throws Exception {
 		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.with(httpBasic("anonymous-user-1", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
@@ -15,7 +15,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
 @AutoConfigureMockMvc
 @DisplayName("경로 검색 API")
 class RouteSearchControllerTest {
@@ -148,10 +151,11 @@ class RouteSearchControllerTest {
 		String routeSearchId = JsonPath.read(result.getResponse().getContentAsString(), "$.data.routeSearchId");
 
 		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.with(httpBasic("basic-user", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
-					  "userId": "anonymous-user-1",
+					  "userId": "spoofed-user",
 					  "rating": "HELPFUL",
 					  "comment": "엘리베이터 안내가 실제 이동에 맞았어요"
 					}
@@ -160,19 +164,48 @@ class RouteSearchControllerTest {
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.feedbackId").exists())
 			.andExpect(jsonPath("$.data.routeSearchId").value(routeSearchId))
-			.andExpect(jsonPath("$.data.userId").value("anonymous-user-1"))
+			.andExpect(jsonPath("$.data.userId").value("basic-user"))
 			.andExpect(jsonPath("$.data.rating").value("HELPFUL"))
 			.andExpect(jsonPath("$.data.comment").value("엘리베이터 안내가 실제 이동에 맞았어요"));
+	}
+
+	@Test
+	@DisplayName("경로 피드백은 인증된 사용자만 제출할 수 있다")
+	void postRouteFeedbackRequiresAuthentication() throws Exception {
+		var result = mockMvc.perform(post("/api/v1/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "mobilityType": "SENIOR"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andReturn();
+		String routeSearchId = JsonPath.read(result.getResponse().getContentAsString(), "$.data.routeSearchId");
+
+		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "userId": "spoofed-user",
+					  "rating": "HELPFUL",
+					  "comment": "안내가 도움이 됐어요"
+					}
+					"""))
+			.andExpect(status().isUnauthorized());
 	}
 
 	@Test
 	@DisplayName("알 수 없는 경로 검색 결과에는 피드백을 저장하지 않는다")
 	void postRouteFeedbackRejectsUnknownRouteSearchId() throws Exception {
 		mockMvc.perform(post("/api/v1/routes/route-missing/feedback")
+				.with(httpBasic("basic-user", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
-					  "userId": "anonymous-user-1",
+					  "userId": "spoofed-user",
 					  "rating": "HELPFUL",
 					  "comment": "안내가 도움이 됐어요"
 					}
@@ -199,6 +232,7 @@ class RouteSearchControllerTest {
 		String routeSearchId = JsonPath.read(result.getResponse().getContentAsString(), "$.data.routeSearchId");
 
 		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.with(httpBasic("basic-user", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{
@@ -209,9 +243,10 @@ class RouteSearchControllerTest {
 					"""))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.success").value(false))
-			.andExpect(jsonPath("$.message").value("피드백 작성자를 확인해야 합니다."));
+			.andExpect(jsonPath("$.message").value("피드백 평가를 선택해야 합니다."));
 
 		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.with(httpBasic("basic-user", "user-test-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{

--- a/backend/src/test/java/com/easysubway/user/adapter/in/web/UserDataControllerTest.java
+++ b/backend/src/test/java/com/easysubway/user/adapter/in/web/UserDataControllerTest.java
@@ -112,6 +112,7 @@ class UserDataControllerTest {
 					""".formatted(routeSearchId)))
 			.andExpect(status().isOk());
 		mockMvc.perform(post("/api/v1/routes/{routeSearchId}/feedback", routeSearchId)
+				.with(httpBasic("configured-user", "configured-password"))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 					{

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1358,6 +1358,7 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(security, /securityMatcher\("\/operator\/\*\*"\)/);
   assert.match(security, /anyRequest\(\)\.hasRole\("OPERATOR_ADMIN"\)/);
   assert.match(security, /@Order\(3\)[\s\S]*?securityMatcher\([\s\S]*?"\/api\/v1\/me"/);
+  assert.match(security, /"\/api\/v1\/reports\/\*"/);
   assert.match(security, /"\/api\/v1\/reports\/\*\/confirm"/);
   assert.match(security, /@Order\(4\)[\s\S]*?anyRequest\(\)\.permitAll\(\)/);
   assert.match(security, /easysubway\.operator\.username/);
@@ -1455,6 +1456,33 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
     operatorDataCollectionFailuresTemplate,
     /<form|_csrf|runId|requestedBy|\/admin\/collections/,
   );
+});
+
+test("신고 조회와 경로 피드백 권한 경계는 인증 사용자 기준이다", () => {
+  const reportUseCase = read("backend/src/main/java/com/easysubway/report/application/port/in/FacilityReportUseCase.java");
+  const reportService = read("backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java");
+  const reportController = read("backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java");
+  const routeController = read("backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java");
+  const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
+
+  assert.match(security, /"\/api\/v1\/reports\/\*"/);
+  assert.match(security, /"\/api\/v1\/routes\/\*\/feedback"/);
+  assert.match(reportUseCase, /getUserReport\(String reportId, String userId\)/);
+  assert.match(reportService, /getUserReport\(String reportId, String userId\)/);
+  assert.match(reportService, /requireReportOwner\(report, userId\)/);
+  assert.match(reportController, /report\(\s*@PathVariable String reportId,\s*Principal principal\s*\)/);
+  assert.match(reportController, /facilityReportUseCase\.getUserReport\(reportId, principal\.getName\(\)\)/);
+  assert.match(reportController, /ApiResponse<List<FacilityReportStatusResponse>> myReports\(Principal principal\)/);
+  assert.match(reportController, /map\(FacilityReportStatusResponse::from\)/);
+  assert.match(reportController, /record FacilityReportStatusResponse\([^)]*String id,[^)]*String stationId,[^)]*String facilityId,[^)]*FacilityReportType reportType,[^)]*FacilityReportStatus status,[^)]*LocalDateTime createdAt,[^)]*LocalDateTime reviewedAt/);
+  assert.doesNotMatch(reportController, /record FacilityReportStatusResponse\([^)]*String userId/);
+  assert.doesNotMatch(reportController, /record FacilityReportStatusResponse\([^)]*photoFileName/);
+  assert.doesNotMatch(reportController, /record FacilityReportStatusResponse\([^)]*BigDecimal latitude/);
+  assert.doesNotMatch(reportController, /record FacilityReportStatusResponse\([^)]*String reviewedBy/);
+  assert.match(routeController, /submitRouteFeedback\([\s\S]*Principal principal[\s\S]*\)/);
+  assert.match(routeController, /request\.toCommand\(routeSearchId, principal\.getName\(\)\)/);
+  assert.match(routeController, /record SubmitRouteFeedbackRequest\(\s*RouteFeedbackRating rating,\s*String comment\s*\)/);
+  assert.doesNotMatch(routeController, /record SubmitRouteFeedbackRequest\([\s\S]*String userId/);
 });
 
 test("운영기관 제휴 제안 export는 접근성 리포트 CSV를 제공한다", () => {


### PR DESCRIPTION
## 관련 이슈

close #476

## 작업 배경

- 신고 상세 조회와 경로 피드백 제출은 사용자 데이터와 운영 검수 정보를 다루므로 인증 사용자 기준의 권한 경계가 필요하다.
- 기존 신고 상세 조회는 공개 endpoint로 열려 있었고, 경로 피드백은 요청 본문의 `userId`를 사용할 수 있어 다른 사용자 신고 조회나 피드백 작성자 사칭 위험이 있었다.

## 작업 내용

- `/api/v1/reports/{reportId}`를 인증 사용자 API로 보호하고 신고 소유자만 조회할 수 있게 변경했다.
- 사용자 신고 상태 응답과 내 신고 목록 응답에서 `userId`, 사진 메타데이터, 정확한 위치, 검수자 ID를 제거했다.
- `/api/v1/routes/{routeSearchId}/feedback`를 인증 사용자 API로 보호하고 요청 본문의 `userId` 대신 `Principal` 사용자로 저장하게 변경했다.
- 신고 조회, 경로 피드백, 저장소 계약 회귀 테스트를 보강했다.
- 기존 관리자/운영기관 테스트 fixture는 새 인증 계약에 맞춰 경로 피드백을 인증 사용자로 제출하게 조정했다.

## 검증

- 실행한 명령과 결과:
  - `backend/gradlew -p backend test --tests '*FacilityReportControllerTest'`: 신규 보안 테스트 RED 확인 후 구현, 이후 성공
  - `backend/gradlew -p backend test --tests '*RouteSearchControllerTest'`: 신규 보안 테스트 RED 확인 후 구현, 이후 성공
  - `node --test --test-name-pattern "신고 조회와 경로 피드백 권한 경계" tools/ci/repository-contract.test.mjs`: 신규 계약 테스트 RED 확인 후 구현, 이후 성공
  - `backend/gradlew -p backend test --tests '*OperatorRouteFeedbackReportControllerTest' --tests '*OperatorRouteFeedbackReportPageControllerTest' --tests '*RouteFeedbackAdminApiControllerTest' --tests '*RouteFeedbackAdminPageControllerTest' --tests '*UserDataControllerTest'`: 성공
  - `backend/gradlew -p backend test`: 성공
  - `node --test tools/ci/*.test.mjs`: 63개 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`
  - GitHub Actions CI run `27808892350`: Android CI, Backend CI, Changes, CodeRabbit, Dependency Vulnerability Scan, Mobile App CI, Repository CI, iOS CI, osv-scanner 모두 성공
  - Codex CLI fallback review: CodeRabbit이 rate limit으로 시작되지 않아 `codex review --base origin/main --title "[Fix] 신고 상태 조회와 경로 피드백 권한 경계 수정"` 실행, actionable 0건으로 PR review 기록
  - Post-merge CD run `27809208276`: 성공
  - Post-merge main CI run `27809208489`: Changes, Backend CI, Mobile App CI, Repository CI, Android CI, iOS CI 성공

## 리뷰어 메모

- 관리자 신고 상세과 관리자/운영기관 피드백 집계는 기존 운영 확인 범위를 유지한다.
- 사용자-facing 신고 응답은 소유자에게도 내부 사용자 식별자, 정확한 위치, 사진 메타데이터, 검수자 ID를 내려주지 않는다.
- 모바일 화면 변경은 이번 범위에 포함하지 않는다.

## 리스크

- 모바일이 내 신고 목록에서 사진 파일명이나 정확한 위치를 직접 사용하고 있었다면 화면 표시 항목 조정이 필요할 수 있다. 현재 변경은 보안 경계를 우선해 사용자 응답을 축소한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
