### PR TITLE
[Feat] 앱 내 사용자 데이터 삭제 흐름 추가

### DIFF
--- a/apps/mobile/lib/anonymous_auth.dart
+++ b/apps/mobile/lib/anonymous_auth.dart
@@ -219,7 +219,9 @@ class AnonymousAuthSession implements AuthorizationHeaderProvider {
     }
   }
 
-  Future<bool> refreshExistingAuthorization() async {
+  Future<bool> refreshExistingAuthorization(
+    String failedAuthorizationHeader,
+  ) async {
     final issuingCredentials = _issuingCredentials;
     if (issuingCredentials != null) {
       try {
@@ -236,6 +238,9 @@ class AnonymousAuthSession implements AuthorizationHeaderProvider {
 
     final credentials = _credentials ?? await credentialStore.readCredentials();
     if (credentials == null) {
+      return false;
+    }
+    if (credentials.authorizationHeader != failedAuthorizationHeader) {
       return false;
     }
 

--- a/apps/mobile/lib/anonymous_auth.dart
+++ b/apps/mobile/lib/anonymous_auth.dart
@@ -219,6 +219,25 @@ class AnonymousAuthSession implements AuthorizationHeaderProvider {
     }
   }
 
+  Future<void> clearCredentials() async {
+    final issuingCredentials = _issuingCredentials;
+    if (issuingCredentials != null) {
+      try {
+        await issuingCredentials;
+      } catch (error, stackTrace) {
+        reportMobileError(
+          error,
+          stackTrace,
+          context: '데이터 삭제 전 익명 인증 발급을 기다리는 중 예외가 발생했습니다.',
+        );
+        // 삭제 흐름에서는 진행 중인 발급 실패와 무관하게 로컬 인증 상태를 비운다.
+      }
+    }
+    _issuingCredentials = null;
+    _credentials = null;
+    await credentialStore.clearCredentials();
+  }
+
   Future<AnonymousAuthCredentials> _refreshOrIssueCredentials(
     AnonymousAuthCredentials credentials,
   ) async {

--- a/apps/mobile/lib/anonymous_auth.dart
+++ b/apps/mobile/lib/anonymous_auth.dart
@@ -219,6 +219,46 @@ class AnonymousAuthSession implements AuthorizationHeaderProvider {
     }
   }
 
+  Future<bool> refreshExistingAuthorization() async {
+    final issuingCredentials = _issuingCredentials;
+    if (issuingCredentials != null) {
+      try {
+        await issuingCredentials;
+      } catch (error, stackTrace) {
+        reportMobileError(
+          error,
+          stackTrace,
+          context: '기존 익명 인증 갱신 전 진행 중인 발급을 기다리는 중 예외가 발생했습니다.',
+        );
+        return false;
+      }
+    }
+
+    final credentials = _credentials ?? await credentialStore.readCredentials();
+    if (credentials == null) {
+      return false;
+    }
+
+    _credentials = null;
+    final nextIssuingCredentials = _refreshExistingCredentials(credentials);
+    _issuingCredentials = nextIssuingCredentials;
+    try {
+      await nextIssuingCredentials;
+      return true;
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '기존 익명 인증 갱신 결과를 처리하는 중 예외가 발생했습니다.',
+      );
+      return false;
+    } finally {
+      if (identical(_issuingCredentials, nextIssuingCredentials)) {
+        _issuingCredentials = null;
+      }
+    }
+  }
+
   Future<void> clearCredentials() async {
     final issuingCredentials = _issuingCredentials;
     if (issuingCredentials != null) {
@@ -236,6 +276,24 @@ class AnonymousAuthSession implements AuthorizationHeaderProvider {
     _issuingCredentials = null;
     _credentials = null;
     await credentialStore.clearCredentials();
+  }
+
+  Future<AnonymousAuthCredentials> _refreshExistingCredentials(
+    AnonymousAuthCredentials credentials,
+  ) async {
+    try {
+      final refreshedCredentials = await repository.refreshAnonymousUser(
+        credentials.refreshToken,
+      );
+      return await _saveCurrentCredentials(refreshedCredentials);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '기존 익명 인증 refresh token 갱신 중 예외가 발생했습니다.',
+      );
+      rethrow;
+    }
   }
 
   Future<AnonymousAuthCredentials> _refreshOrIssueCredentials(

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -818,6 +818,9 @@ UserDataDeletionRepository? _defaultUserDataDeletionRepository({
   return UserDataDeletionApiRepository(
     baseUri: baseUri,
     authProvider: authProvider,
+    refreshExistingAuthorization: authProvider is AnonymousAuthSession
+        ? authProvider.refreshExistingAuthorization
+        : null,
   );
 }
 

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -16,6 +16,7 @@ import 'onboarding.dart';
 import 'route_search.dart';
 import 'station_search.dart';
 import 'mobile_error_reporter.dart';
+import 'user_data_deletion.dart';
 
 void main() {
   final photoPicker = ImagePickerFacilityReportPhotoPicker();
@@ -43,6 +44,8 @@ class EasySubwayApp extends StatelessWidget {
     NotificationPermissionProvider? notificationPermissionProvider,
     CurrentLocationProvider? locationProvider,
     AnonymousAuthRepository? anonymousAuthRepository,
+    AnonymousAuthCredentialStore? anonymousAuthCredentialStore,
+    UserDataDeletionRepository? userDataDeletionRepository,
     OnboardingResultStore? onboardingStore,
     FacilityReportDraftTargetStore? facilityReportDraftTargetStore,
     FacilityReportLostPhotoRestorer? facilityReportLostPhotoRestorer,
@@ -67,6 +70,8 @@ class EasySubwayApp extends StatelessWidget {
            notificationPermissionProvider: notificationPermissionProvider,
            locationProvider: locationProvider,
            anonymousAuthRepository: anonymousAuthRepository,
+           anonymousAuthCredentialStore: anonymousAuthCredentialStore,
+           userDataDeletionRepository: userDataDeletionRepository,
            enableAnonymousAuth: enableAnonymousAuth,
          ),
          initialOnboardingState: initialOnboardingState,
@@ -100,7 +105,9 @@ class EasySubwayApp extends StatelessWidget {
        notificationRepository = dependencies.notificationRepository,
        notificationPermissionProvider =
            dependencies.notificationPermissionProvider,
-       locationProvider = dependencies.locationProvider;
+       locationProvider = dependencies.locationProvider,
+       userDataDeletionRepository = dependencies.userDataDeletionRepository,
+       anonymousAuthSession = dependencies.anonymousAuthSession;
 
   final StationSearchRepository repository;
   final FacilityReportRepository reportRepository;
@@ -113,6 +120,8 @@ class EasySubwayApp extends StatelessWidget {
   final NotificationSettingsRepository? notificationRepository;
   final NotificationPermissionProvider? notificationPermissionProvider;
   final CurrentLocationProvider locationProvider;
+  final UserDataDeletionRepository? userDataDeletionRepository;
+  final AnonymousAuthSession? anonymousAuthSession;
   final OnboardingState initialOnboardingState;
   final OnboardingResultStore? onboardingStore;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
@@ -182,6 +191,8 @@ class EasySubwayApp extends StatelessWidget {
         facilityReportLostPhotoRestorer: facilityReportLostPhotoRestorer,
         supportAccessInfo: supportAccessInfo,
         supportAccessLauncher: supportAccessLauncher,
+        userDataDeletionRepository: userDataDeletionRepository,
+        anonymousAuthSession: anonymousAuthSession,
       ),
     );
   }
@@ -282,6 +293,8 @@ class _EasySubwayHome extends StatefulWidget {
     required this.facilityReportLostPhotoRestorer,
     required this.supportAccessInfo,
     required this.supportAccessLauncher,
+    required this.userDataDeletionRepository,
+    required this.anonymousAuthSession,
   });
 
   final StationSearchRepository repository;
@@ -301,6 +314,8 @@ class _EasySubwayHome extends StatefulWidget {
   final FacilityReportLostPhotoRestorer? facilityReportLostPhotoRestorer;
   final SupportAccessInfo supportAccessInfo;
   final SupportAccessLauncher supportAccessLauncher;
+  final UserDataDeletionRepository? userDataDeletionRepository;
+  final AnonymousAuthSession? anonymousAuthSession;
 
   @override
   State<_EasySubwayHome> createState() => _EasySubwayHomeState();
@@ -369,8 +384,23 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
         supportAccessInfo: widget.supportAccessInfo,
         supportAccessLauncher: widget.supportAccessLauncher,
+        userDataDeletionRepository: widget.userDataDeletionRepository,
+        onUserDataDeleted: _handleUserDataDeleted,
       ),
     );
+  }
+
+  Future<void> _handleUserDataDeleted() async {
+    await widget.anonymousAuthSession?.clearCredentials();
+    await widget.onboardingStore?.clearResult();
+    await widget.facilityReportDraftTargetStore?.clearTarget();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _onboardingState = const OnboardingState.initial();
+      _loadingOnboardingState = false;
+    });
   }
 
   Future<void> _restoreOnboardingState() async {
@@ -655,6 +685,8 @@ class _EasySubwayAppDependencies {
     required this.notificationRepository,
     required this.notificationPermissionProvider,
     required this.locationProvider,
+    required this.userDataDeletionRepository,
+    required this.anonymousAuthSession,
   });
 
   factory _EasySubwayAppDependencies.resolve({
@@ -670,14 +702,18 @@ class _EasySubwayAppDependencies {
     NotificationPermissionProvider? notificationPermissionProvider,
     CurrentLocationProvider? locationProvider,
     AnonymousAuthRepository? anonymousAuthRepository,
+    AnonymousAuthCredentialStore? anonymousAuthCredentialStore,
+    UserDataDeletionRepository? userDataDeletionRepository,
     required bool enableAnonymousAuth,
   }) {
     final baseUri = defaultStationApiBaseUri();
-    final sharedAuthProvider = _defaultAuthorizationHeaderProvider(
+    final anonymousAuthSession = _defaultAnonymousAuthSession(
       baseUri: baseUri,
       anonymousAuthRepository: anonymousAuthRepository,
+      credentialStore: anonymousAuthCredentialStore,
       enableAnonymousAuth: enableAnonymousAuth,
     );
+    final sharedAuthProvider = anonymousAuthSession;
     final resolvedNotificationRepository =
         notificationRepository ??
         _defaultNotificationSettingsRepository(
@@ -731,6 +767,13 @@ class _EasySubwayAppDependencies {
       notificationPermissionProvider: resolvedNotificationPermissionProvider,
       locationProvider:
           locationProvider ?? MethodChannelCurrentLocationProvider(),
+      userDataDeletionRepository:
+          userDataDeletionRepository ??
+          _defaultUserDataDeletionRepository(
+            baseUri: baseUri,
+            authProvider: sharedAuthProvider,
+          ),
+      anonymousAuthSession: anonymousAuthSession,
     );
   }
 
@@ -745,12 +788,15 @@ class _EasySubwayAppDependencies {
   final NotificationSettingsRepository? notificationRepository;
   final NotificationPermissionProvider? notificationPermissionProvider;
   final CurrentLocationProvider locationProvider;
+  final UserDataDeletionRepository? userDataDeletionRepository;
+  final AnonymousAuthSession? anonymousAuthSession;
 }
 
-AuthorizationHeaderProvider? _defaultAuthorizationHeaderProvider({
+AnonymousAuthSession? _defaultAnonymousAuthSession({
   required Uri baseUri,
   required bool enableAnonymousAuth,
   AnonymousAuthRepository? anonymousAuthRepository,
+  AnonymousAuthCredentialStore? credentialStore,
 }) {
   if (!enableAnonymousAuth) {
     return null;
@@ -758,6 +804,20 @@ AuthorizationHeaderProvider? _defaultAuthorizationHeaderProvider({
   return AnonymousAuthSession(
     repository:
         anonymousAuthRepository ?? AnonymousAuthApiRepository(baseUri: baseUri),
+    credentialStore: credentialStore,
+  );
+}
+
+UserDataDeletionRepository? _defaultUserDataDeletionRepository({
+  required Uri baseUri,
+  required AuthorizationHeaderProvider? authProvider,
+}) {
+  if (authProvider == null) {
+    return null;
+  }
+  return UserDataDeletionApiRepository(
+    baseUri: baseUri,
+    authProvider: authProvider,
   );
 }
 
@@ -841,6 +901,8 @@ class HomeScreen extends StatelessWidget {
     required this.locationProvider,
     required this.supportAccessInfo,
     required this.supportAccessLauncher,
+    required this.userDataDeletionRepository,
+    required this.onUserDataDeleted,
     this.simpleViewEnabled = true,
     this.facilityReportDraftTargetStore,
     String? initialMobilityType,
@@ -861,6 +923,8 @@ class HomeScreen extends StatelessWidget {
   final CurrentLocationProvider locationProvider;
   final SupportAccessInfo supportAccessInfo;
   final SupportAccessLauncher supportAccessLauncher;
+  final UserDataDeletionRepository? userDataDeletionRepository;
+  final Future<void> Function()? onUserDataDeleted;
   final String initialMobilityType;
   final bool simpleViewEnabled;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
@@ -884,6 +948,8 @@ class HomeScreen extends StatelessWidget {
           builder: (_) => SupportAccessScreen(
             accessInfo: supportAccessInfo,
             launcher: supportAccessLauncher,
+            userDataDeletionRepository: userDataDeletionRepository,
+            onUserDataDeleted: onUserDataDeleted,
           ),
         ),
       );
@@ -1266,11 +1332,15 @@ class SupportAccessScreen extends StatelessWidget {
   const SupportAccessScreen({
     required this.accessInfo,
     required this.launcher,
+    required this.userDataDeletionRepository,
+    required this.onUserDataDeleted,
     super.key,
   });
 
   final SupportAccessInfo accessInfo;
   final SupportAccessLauncher launcher;
+  final UserDataDeletionRepository? userDataDeletionRepository;
+  final Future<void> Function()? onUserDataDeleted;
 
   @override
   Widget build(BuildContext context) {
@@ -1313,16 +1383,289 @@ class SupportAccessScreen extends StatelessWidget {
               launcher: launcher,
             ),
             const SizedBox(height: 12),
-            _SupportAccessItem(
-              key: const Key('dataDeletionAccessItem'),
-              icon: Icons.delete_outline,
-              title: '데이터 삭제 요청',
-              value: accessInfo.dataDeletionEmail,
-              uri: _mailtoUri(accessInfo.dataDeletionEmail, '쉬운 지하철 데이터 삭제 요청'),
-              launcher: launcher,
+            if (userDataDeletionRepository == null)
+              _SupportAccessItem(
+                key: const Key('dataDeletionAccessItem'),
+                icon: Icons.delete_outline,
+                title: '데이터 삭제 요청',
+                value: accessInfo.dataDeletionEmail,
+                uri: _mailtoUri(
+                  accessInfo.dataDeletionEmail,
+                  '쉬운 지하철 데이터 삭제 요청',
+                ),
+                launcher: launcher,
+              )
+            else
+              _UserDataDeletionAccessItem(
+                repository: userDataDeletionRepository!,
+                onDeleted: onUserDataDeleted,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _UserDataDeletionAccessItem extends StatelessWidget {
+  const _UserDataDeletionAccessItem({
+    required this.repository,
+    required this.onDeleted,
+  });
+
+  final UserDataDeletionRepository repository;
+  final Future<void> Function()? onDeleted;
+
+  @override
+  Widget build(BuildContext context) {
+    void openDeletionScreen() {
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => UserDataDeletionScreen(
+            repository: repository,
+            onDeleted: onDeleted,
+          ),
+        ),
+      );
+    }
+
+    return Semantics(
+      key: const Key('dataDeletionAccessItem'),
+      button: true,
+      label: '데이터 삭제 요청, 앱 안에서 삭제를 진행합니다.',
+      onTap: openDeletionScreen,
+      child: ExcludeSemantics(
+        child: Material(
+          color: Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+            side: BorderSide(
+              color: Theme.of(context).colorScheme.outlineVariant,
+            ),
+          ),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(8),
+            onTap: openDeletionScreen,
+            child: const Padding(
+              padding: EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.delete_outline,
+                    color: Color(0xFF8B1E1E),
+                    size: 28,
+                  ),
+                  SizedBox(width: 14),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '데이터 삭제 요청',
+                          style: TextStyle(
+                            color: Color(0xFF102A2C),
+                            fontSize: 18,
+                            fontWeight: FontWeight.w800,
+                            height: 1.25,
+                          ),
+                        ),
+                        SizedBox(height: 4),
+                        Text(
+                          '앱 안에서 삭제 대상을 확인하고 직접 요청합니다.',
+                          style: TextStyle(
+                            color: Color(0xFF466467),
+                            fontSize: 15,
+                            fontWeight: FontWeight.w600,
+                            height: 1.3,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Icon(Icons.chevron_right, color: Color(0xFF466467)),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class UserDataDeletionScreen extends StatefulWidget {
+  const UserDataDeletionScreen({
+    required this.repository,
+    required this.onDeleted,
+    super.key,
+  });
+
+  final UserDataDeletionRepository repository;
+  final Future<void> Function()? onDeleted;
+
+  @override
+  State<UserDataDeletionScreen> createState() => _UserDataDeletionScreenState();
+}
+
+class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
+  bool _isDeleting = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Scaffold(
+      appBar: AppBar(title: const Text('내 데이터 삭제')),
+      bottomNavigationBar: SafeArea(
+        minimum: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+        child: FilledButton.icon(
+          key: const Key('dataDeletionStartButton'),
+          onPressed: _isDeleting ? null : _confirmAndDelete,
+          icon: _isDeleting
+              ? const SizedBox(
+                  width: 22,
+                  height: 22,
+                  child: CircularProgressIndicator(strokeWidth: 2.5),
+                )
+              : const Icon(Icons.delete_forever_outlined),
+          label: Text(_isDeleting ? '삭제 중' : '내 데이터 삭제'),
+          style: FilledButton.styleFrom(
+            backgroundColor: const Color(0xFF8B1E1E),
+            foregroundColor: Colors.white,
+          ),
+        ),
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          children: [
+            Semantics(
+              header: true,
+              child: Text(
+                '삭제 전에 확인해 주세요',
+                style: textTheme.headlineSmall?.copyWith(
+                  color: const Color(0xFF102A2C),
+                  fontWeight: FontWeight.w800,
+                  height: 1.25,
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              '즐겨찾기, 이동 조건, 알림 설정, 익명 인증, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.',
+              style: textTheme.bodyLarge?.copyWith(
+                color: const Color(0xFF102A2C),
+                height: 1.4,
+              ),
+            ),
+            const SizedBox(height: 16),
+            const _DataDeletionNoticeLine(
+              text: '삭제가 끝나면 현재 로그인 정보는 지워지고 처음 설정 화면으로 돌아갑니다.',
+            ),
+            const _DataDeletionNoticeLine(
+              text: '네트워크 오류가 나면 기존 데이터는 지우지 않고 다시 시도할 수 있습니다.',
+            ),
+            const _DataDeletionNoticeLine(
+              text: '법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관될 수 있습니다.',
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  Future<void> _confirmAndDelete() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('정말 삭제할까요?'),
+        content: const Text('삭제 후에는 앱에 저장된 인증 정보와 설정이 지워지고 되돌릴 수 없습니다.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('취소'),
+          ),
+          FilledButton(
+            key: const Key('dataDeletionConfirmButton'),
+            onPressed: () => Navigator.of(context).pop(true),
+            style: FilledButton.styleFrom(
+              backgroundColor: const Color(0xFF8B1E1E),
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('삭제'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      await _deleteCurrentUserData();
+    }
+  }
+
+  Future<void> _deleteCurrentUserData() async {
+    setState(() {
+      _isDeleting = true;
+    });
+    try {
+      await widget.repository.deleteCurrentUserData();
+      await widget.onDeleted?.call();
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context).popUntil((route) => route.isFirst);
+    } on UserDataDeletionException catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(error.message)));
+      }
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '사용자 데이터 삭제 처리 중 예외가 발생했습니다.',
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text(userDataDeletionErrorMessage)),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isDeleting = false;
+        });
+      }
+    }
+  }
+}
+
+class _DataDeletionNoticeLine extends StatelessWidget {
+  const _DataDeletionNoticeLine({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Padding(
+            padding: EdgeInsets.only(top: 7),
+            child: Icon(Icons.circle, size: 7, color: Color(0xFF8B1E1E)),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              text,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: const Color(0xFF3B2020),
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/user_data_deletion.dart
+++ b/apps/mobile/lib/user_data_deletion.dart
@@ -16,11 +16,13 @@ class UserDataDeletionApiRepository implements UserDataDeletionRepository {
   UserDataDeletionApiRepository({
     required this.baseUri,
     required this.authProvider,
+    this.refreshExistingAuthorization,
     HttpClient? httpClient,
   }) : _httpClient = httpClient ?? HttpClient();
 
   final Uri baseUri;
   final AuthorizationHeaderProvider authProvider;
+  final Future<bool> Function()? refreshExistingAuthorization;
   final HttpClient _httpClient;
 
   @override
@@ -63,9 +65,11 @@ class UserDataDeletionApiRepository implements UserDataDeletionRepository {
       if (response.statusCode == HttpStatus.unauthorized &&
           authorizationHeader != null &&
           attempt == 0) {
-        await authProvider.invalidateAuthorization().timeout(
-          _userDataDeletionTimeout,
-        );
+        final refreshedAuthorization = await _refreshExistingAuthorization()
+            .timeout(_userDataDeletionTimeout);
+        if (!refreshedAuthorization) {
+          throw const UserDataDeletionException(userDataDeletionErrorMessage);
+        }
         continue;
       }
 
@@ -76,6 +80,14 @@ class UserDataDeletionApiRepository implements UserDataDeletionRepository {
       return UserDataDeletionResult.fromResponseBody(body);
     }
     throw const UserDataDeletionException(userDataDeletionErrorMessage);
+  }
+
+  Future<bool> _refreshExistingAuthorization() async {
+    final refresh = refreshExistingAuthorization;
+    if (refresh == null) {
+      return false;
+    }
+    return refresh();
   }
 }
 

--- a/apps/mobile/lib/user_data_deletion.dart
+++ b/apps/mobile/lib/user_data_deletion.dart
@@ -1,0 +1,199 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'auth_headers.dart';
+import 'mobile_error_reporter.dart';
+
+const userDataDeletionErrorMessage = '데이터 삭제를 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+const _userDataDeletionTimeout = Duration(seconds: 8);
+
+abstract class UserDataDeletionRepository {
+  Future<UserDataDeletionResult> deleteCurrentUserData();
+}
+
+class UserDataDeletionApiRepository implements UserDataDeletionRepository {
+  UserDataDeletionApiRepository({
+    required this.baseUri,
+    required this.authProvider,
+    HttpClient? httpClient,
+  }) : _httpClient = httpClient ?? HttpClient();
+
+  final Uri baseUri;
+  final AuthorizationHeaderProvider authProvider;
+  final HttpClient _httpClient;
+
+  @override
+  Future<UserDataDeletionResult> deleteCurrentUserData() async {
+    try {
+      return await _deleteCurrentUserDataWithAuthorizationRetry();
+    } on UserDataDeletionException {
+      rethrow;
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '사용자 데이터 삭제 API 응답 처리 중 예외가 발생했습니다.',
+      );
+      throw const UserDataDeletionException(userDataDeletionErrorMessage);
+    }
+  }
+
+  Future<UserDataDeletionResult>
+  _deleteCurrentUserDataWithAuthorizationRetry() async {
+    for (var attempt = 0; attempt < 2; attempt++) {
+      final request = await _httpClient
+          .deleteUrl(baseUri.resolve('/api/v1/me'))
+          .timeout(_userDataDeletionTimeout);
+      final authorizationHeader = await authProvider
+          .authorizationHeader()
+          .timeout(_userDataDeletionTimeout);
+      if (authorizationHeader != null) {
+        request.headers.set(
+          HttpHeaders.authorizationHeader,
+          authorizationHeader,
+        );
+      }
+
+      final response = await request.close().timeout(_userDataDeletionTimeout);
+      final body = await utf8
+          .decodeStream(response)
+          .timeout(_userDataDeletionTimeout);
+
+      if (response.statusCode == HttpStatus.unauthorized &&
+          authorizationHeader != null &&
+          attempt == 0) {
+        await authProvider.invalidateAuthorization().timeout(
+          _userDataDeletionTimeout,
+        );
+        continue;
+      }
+
+      if (response.statusCode != HttpStatus.ok) {
+        throw const UserDataDeletionException(userDataDeletionErrorMessage);
+      }
+
+      return UserDataDeletionResult.fromResponseBody(body);
+    }
+    throw const UserDataDeletionException(userDataDeletionErrorMessage);
+  }
+}
+
+class UserDataDeletionResult {
+  const UserDataDeletionResult({
+    required this.userId,
+    required this.deletedFavoriteStationCount,
+    required this.deletedFavoriteFacilityCount,
+    required this.deletedFavoriteRouteCount,
+    required this.anonymizedRouteFeedbackCount,
+    required this.notificationSettingsDeleted,
+    required this.deletedRegisteredDeviceCount,
+    required this.deletedPushNotificationCount,
+    required this.mobilityProfileDeleted,
+    required this.anonymizedReportCount,
+    required this.anonymousCredentialsDeleted,
+  });
+
+  factory UserDataDeletionResult.fromResponseBody(String body) {
+    final decoded = jsonDecode(body);
+    if (decoded is! Map<String, Object?> || decoded['success'] != true) {
+      throw const UserDataDeletionException(userDataDeletionErrorMessage);
+    }
+    final data = decoded['data'];
+    if (data is! Map<String, Object?>) {
+      throw const UserDataDeletionException(userDataDeletionErrorMessage);
+    }
+    return UserDataDeletionResult.fromJson(data);
+  }
+
+  factory UserDataDeletionResult.fromJson(Map<String, Object?> json) {
+    return UserDataDeletionResult(
+      userId: _requiredDeletionString(json, 'userId'),
+      deletedFavoriteStationCount: _requiredDeletionInt(
+        json,
+        'deletedFavoriteStationCount',
+      ),
+      deletedFavoriteFacilityCount: _requiredDeletionInt(
+        json,
+        'deletedFavoriteFacilityCount',
+      ),
+      deletedFavoriteRouteCount: _requiredDeletionInt(
+        json,
+        'deletedFavoriteRouteCount',
+      ),
+      anonymizedRouteFeedbackCount: _requiredDeletionInt(
+        json,
+        'anonymizedRouteFeedbackCount',
+      ),
+      notificationSettingsDeleted: _requiredDeletionBool(
+        json,
+        'notificationSettingsDeleted',
+      ),
+      deletedRegisteredDeviceCount: _requiredDeletionInt(
+        json,
+        'deletedRegisteredDeviceCount',
+      ),
+      deletedPushNotificationCount: _requiredDeletionInt(
+        json,
+        'deletedPushNotificationCount',
+      ),
+      mobilityProfileDeleted: _requiredDeletionBool(
+        json,
+        'mobilityProfileDeleted',
+      ),
+      anonymizedReportCount: _requiredDeletionInt(
+        json,
+        'anonymizedReportCount',
+      ),
+      anonymousCredentialsDeleted: _requiredDeletionBool(
+        json,
+        'anonymousCredentialsDeleted',
+      ),
+    );
+  }
+
+  final String userId;
+  final int deletedFavoriteStationCount;
+  final int deletedFavoriteFacilityCount;
+  final int deletedFavoriteRouteCount;
+  final int anonymizedRouteFeedbackCount;
+  final bool notificationSettingsDeleted;
+  final int deletedRegisteredDeviceCount;
+  final int deletedPushNotificationCount;
+  final bool mobilityProfileDeleted;
+  final int anonymizedReportCount;
+  final bool anonymousCredentialsDeleted;
+}
+
+class UserDataDeletionException implements Exception {
+  const UserDataDeletionException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+String _requiredDeletionString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! String || value.trim().isEmpty) {
+    throw const UserDataDeletionException(userDataDeletionErrorMessage);
+  }
+  return value.trim();
+}
+
+int _requiredDeletionInt(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! int || value < 0) {
+    throw const UserDataDeletionException(userDataDeletionErrorMessage);
+  }
+  return value;
+}
+
+bool _requiredDeletionBool(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! bool) {
+    throw const UserDataDeletionException(userDataDeletionErrorMessage);
+  }
+  return value;
+}

--- a/apps/mobile/lib/user_data_deletion.dart
+++ b/apps/mobile/lib/user_data_deletion.dart
@@ -22,7 +22,8 @@ class UserDataDeletionApiRepository implements UserDataDeletionRepository {
 
   final Uri baseUri;
   final AuthorizationHeaderProvider authProvider;
-  final Future<bool> Function()? refreshExistingAuthorization;
+  final Future<bool> Function(String authorizationHeader)?
+  refreshExistingAuthorization;
   final HttpClient _httpClient;
 
   @override
@@ -65,8 +66,9 @@ class UserDataDeletionApiRepository implements UserDataDeletionRepository {
       if (response.statusCode == HttpStatus.unauthorized &&
           authorizationHeader != null &&
           attempt == 0) {
-        final refreshedAuthorization = await _refreshExistingAuthorization()
-            .timeout(_userDataDeletionTimeout);
+        final refreshedAuthorization = await _refreshExistingAuthorization(
+          authorizationHeader,
+        ).timeout(_userDataDeletionTimeout);
         if (!refreshedAuthorization) {
           throw const UserDataDeletionException(userDataDeletionErrorMessage);
         }
@@ -82,12 +84,12 @@ class UserDataDeletionApiRepository implements UserDataDeletionRepository {
     throw const UserDataDeletionException(userDataDeletionErrorMessage);
   }
 
-  Future<bool> _refreshExistingAuthorization() async {
+  Future<bool> _refreshExistingAuthorization(String authorizationHeader) async {
     final refresh = refreshExistingAuthorization;
     if (refresh == null) {
       return false;
     }
-    return refresh();
+    return refresh(authorizationHeader);
   }
 }
 

--- a/apps/mobile/test/anonymous_auth_test.dart
+++ b/apps/mobile/test/anonymous_auth_test.dart
@@ -172,6 +172,69 @@ void main() {
     expect(credentialStore.credentials?.userId, 'fresh-anonymous-user');
   });
 
+  test('익명 인증 세션은 삭제 요청에 사용한 인증 정보가 바뀌면 기존 인증 갱신을 실패 처리한다', () async {
+    final credentialStore = MemoryAnonymousAuthCredentialStore(
+      const AnonymousAuthCredentials(
+        userId: 'stale-anonymous-user',
+        accessToken: 'stale-access-token',
+        refreshToken: 'stale-refresh-token',
+      ),
+    );
+    final repository = FakeAnonymousAuthRepository(
+      userId: 'fresh-anonymous-user',
+      accessToken: 'fresh-access-token',
+      refreshToken: 'fresh-refresh-token',
+    );
+    final session = AnonymousAuthSession(
+      repository: repository,
+      credentialStore: credentialStore,
+    );
+
+    final staleHeader = await session.authorizationHeader();
+    await session.invalidateAuthorization();
+
+    final refreshed = await session.refreshExistingAuthorization(staleHeader!);
+
+    expect(refreshed, isFalse);
+    expect(repository.refreshCount, 1);
+    expect(
+      credentialStore.credentials?.authorizationHeader,
+      'Bearer fresh-access-token',
+    );
+  });
+
+  test('익명 인증 세션은 삭제 요청에 사용한 인증 정보만 기존 인증 갱신한다', () async {
+    final credentialStore = MemoryAnonymousAuthCredentialStore(
+      const AnonymousAuthCredentials(
+        userId: 'stale-anonymous-user',
+        accessToken: 'stale-access-token',
+        refreshToken: 'stale-refresh-token',
+      ),
+    );
+    final repository = FakeAnonymousAuthRepository(
+      userId: 'fresh-anonymous-user',
+      accessToken: 'fresh-access-token',
+      refreshToken: 'fresh-refresh-token',
+    );
+    final session = AnonymousAuthSession(
+      repository: repository,
+      credentialStore: credentialStore,
+    );
+
+    final staleHeader = await session.authorizationHeader();
+
+    final refreshed = await session.refreshExistingAuthorization(staleHeader!);
+
+    expect(refreshed, isTrue);
+    expect(repository.issueCount, 0);
+    expect(repository.refreshCount, 1);
+    expect(repository.refreshedTokens, ['stale-refresh-token']);
+    expect(
+      credentialStore.credentials?.authorizationHeader,
+      'Bearer fresh-access-token',
+    );
+  });
+
   test('익명 인증 세션은 동시 인증 무효화 후 하나의 새 인증 정보를 공유한다', () async {
     final credentialStore = MemoryAnonymousAuthCredentialStore(
       const AnonymousAuthCredentials(

--- a/apps/mobile/test/user_data_deletion_test.dart
+++ b/apps/mobile/test/user_data_deletion_test.dart
@@ -68,6 +68,87 @@ void main() {
     expect(result.anonymousCredentialsDeleted, isTrue);
   });
 
+  test('사용자 데이터 삭제 API 저장소는 기존 인증 갱신 성공 시 삭제를 한 번 재시도한다', () async {
+    var requestCount = 0;
+    final authorizationHeaders = <String?>[];
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestCount++;
+      authorizationHeaders.add(
+        request.headers.value(HttpHeaders.authorizationHeader),
+      );
+      if (requestCount == 1) {
+        request.response
+          ..statusCode = HttpStatus.unauthorized
+          ..write('expired')
+          ..close();
+        return;
+      }
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(_successfulDeletionBody())
+        ..close();
+    });
+
+    final authProvider = RefreshingAuthorizationHeaderProvider(
+      header: 'Bearer stale-access-token',
+      refreshedHeader: 'Bearer fresh-access-token',
+      refreshResult: true,
+    );
+    final repository = UserDataDeletionApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: authProvider,
+      refreshExistingAuthorization: authProvider.refreshExistingAuthorization,
+    );
+
+    final result = await repository.deleteCurrentUserData();
+
+    expect(result.userId, 'anonymous-user-1');
+    expect(requestCount, 2);
+    expect(authorizationHeaders, [
+      'Bearer stale-access-token',
+      'Bearer fresh-access-token',
+    ]);
+    expect(authProvider.refreshCount, 1);
+    expect(authProvider.invalidateCount, 0);
+  });
+
+  test('사용자 데이터 삭제 API 저장소는 기존 인증 갱신 실패 시 새 사용자 삭제로 처리하지 않는다', () async {
+    var requestCount = 0;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestCount++;
+      request.response
+        ..statusCode = HttpStatus.unauthorized
+        ..write('expired')
+        ..close();
+    });
+
+    final authProvider = RefreshingAuthorizationHeaderProvider(
+      header: 'Bearer stale-access-token',
+      refreshedHeader: 'Bearer new-user-access-token',
+      refreshResult: false,
+    );
+    final repository = UserDataDeletionApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: authProvider,
+      refreshExistingAuthorization: authProvider.refreshExistingAuthorization,
+    );
+
+    await expectLater(
+      repository.deleteCurrentUserData(),
+      throwsA(isA<UserDataDeletionException>()),
+    );
+    expect(requestCount, 1);
+    expect(authProvider.refreshCount, 1);
+    expect(authProvider.invalidateCount, 0);
+  });
+
   test('사용자 데이터 삭제 API 저장소는 실패 응답에서 쉬운 오류를 던진다', () async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(server.close);
@@ -99,6 +180,25 @@ void main() {
   });
 }
 
+String _successfulDeletionBody() {
+  return jsonEncode({
+    'success': true,
+    'data': {
+      'userId': 'anonymous-user-1',
+      'deletedFavoriteStationCount': 1,
+      'deletedFavoriteFacilityCount': 2,
+      'deletedFavoriteRouteCount': 3,
+      'anonymizedRouteFeedbackCount': 4,
+      'notificationSettingsDeleted': true,
+      'deletedRegisteredDeviceCount': 5,
+      'deletedPushNotificationCount': 6,
+      'mobilityProfileDeleted': true,
+      'anonymizedReportCount': 7,
+      'anonymousCredentialsDeleted': true,
+    },
+  });
+}
+
 class FixedAuthorizationHeaderProvider implements AuthorizationHeaderProvider {
   const FixedAuthorizationHeaderProvider(this.header);
 
@@ -109,4 +209,36 @@ class FixedAuthorizationHeaderProvider implements AuthorizationHeaderProvider {
 
   @override
   Future<void> invalidateAuthorization() async {}
+}
+
+class RefreshingAuthorizationHeaderProvider
+    implements AuthorizationHeaderProvider {
+  RefreshingAuthorizationHeaderProvider({
+    required this.header,
+    required this.refreshedHeader,
+    required this.refreshResult,
+  });
+
+  String header;
+  final String refreshedHeader;
+  final bool refreshResult;
+  int refreshCount = 0;
+  int invalidateCount = 0;
+
+  @override
+  Future<String?> authorizationHeader() async => header;
+
+  @override
+  Future<void> invalidateAuthorization() async {
+    invalidateCount++;
+  }
+
+  Future<bool> refreshExistingAuthorization() async {
+    refreshCount++;
+    if (!refreshResult) {
+      return false;
+    }
+    header = refreshedHeader;
+    return true;
+  }
 }

--- a/apps/mobile/test/user_data_deletion_test.dart
+++ b/apps/mobile/test/user_data_deletion_test.dart
@@ -113,6 +113,9 @@ void main() {
       'Bearer fresh-access-token',
     ]);
     expect(authProvider.refreshCount, 1);
+    expect(authProvider.refreshedAuthorizationHeaders, [
+      'Bearer stale-access-token',
+    ]);
     expect(authProvider.invalidateCount, 0);
   });
 
@@ -146,6 +149,9 @@ void main() {
     );
     expect(requestCount, 1);
     expect(authProvider.refreshCount, 1);
+    expect(authProvider.refreshedAuthorizationHeaders, [
+      'Bearer stale-access-token',
+    ]);
     expect(authProvider.invalidateCount, 0);
   });
 
@@ -224,6 +230,7 @@ class RefreshingAuthorizationHeaderProvider
   final bool refreshResult;
   int refreshCount = 0;
   int invalidateCount = 0;
+  final refreshedAuthorizationHeaders = <String>[];
 
   @override
   Future<String?> authorizationHeader() async => header;
@@ -233,8 +240,9 @@ class RefreshingAuthorizationHeaderProvider
     invalidateCount++;
   }
 
-  Future<bool> refreshExistingAuthorization() async {
+  Future<bool> refreshExistingAuthorization(String authorizationHeader) async {
     refreshCount++;
+    refreshedAuthorizationHeaders.add(authorizationHeader);
     if (!refreshResult) {
       return false;
     }

--- a/apps/mobile/test/user_data_deletion_test.dart
+++ b/apps/mobile/test/user_data_deletion_test.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:easysubway_mobile/auth_headers.dart';
+import 'package:easysubway_mobile/user_data_deletion.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('사용자 데이터 삭제 API 저장소는 인증 헤더로 DELETE /api/v1/me를 호출한다', () async {
+    late String requestedMethod;
+    late Uri requestedUri;
+    late String? authorizationHeader;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestedMethod = request.method;
+      requestedUri = request.uri;
+      authorizationHeader = request.headers.value(
+        HttpHeaders.authorizationHeader,
+      );
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {
+              'userId': 'anonymous-user-1',
+              'deletedFavoriteStationCount': 1,
+              'deletedFavoriteFacilityCount': 2,
+              'deletedFavoriteRouteCount': 3,
+              'anonymizedRouteFeedbackCount': 4,
+              'notificationSettingsDeleted': true,
+              'deletedRegisteredDeviceCount': 5,
+              'deletedPushNotificationCount': 6,
+              'mobilityProfileDeleted': true,
+              'anonymizedReportCount': 7,
+              'anonymousCredentialsDeleted': true,
+            },
+          }),
+        )
+        ..close();
+    });
+
+    final repository = UserDataDeletionApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: const FixedAuthorizationHeaderProvider(
+        'Bearer access-token-1',
+      ),
+    );
+
+    final result = await repository.deleteCurrentUserData();
+
+    expect(requestedMethod, 'DELETE');
+    expect(requestedUri.path, '/api/v1/me');
+    expect(authorizationHeader, 'Bearer access-token-1');
+    expect(result.userId, 'anonymous-user-1');
+    expect(result.deletedFavoriteStationCount, 1);
+    expect(result.deletedFavoriteFacilityCount, 2);
+    expect(result.deletedFavoriteRouteCount, 3);
+    expect(result.anonymizedRouteFeedbackCount, 4);
+    expect(result.notificationSettingsDeleted, isTrue);
+    expect(result.deletedRegisteredDeviceCount, 5);
+    expect(result.deletedPushNotificationCount, 6);
+    expect(result.mobilityProfileDeleted, isTrue);
+    expect(result.anonymizedReportCount, 7);
+    expect(result.anonymousCredentialsDeleted, isTrue);
+  });
+
+  test('사용자 데이터 삭제 API 저장소는 실패 응답에서 쉬운 오류를 던진다', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      request.response
+        ..statusCode = HttpStatus.internalServerError
+        ..write('server error')
+        ..close();
+    });
+
+    final repository = UserDataDeletionApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: const FixedAuthorizationHeaderProvider(
+        'Bearer access-token-1',
+      ),
+    );
+
+    await expectLater(
+      repository.deleteCurrentUserData(),
+      throwsA(
+        isA<UserDataDeletionException>().having(
+          (error) => error.message,
+          'message',
+          '데이터 삭제를 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+        ),
+      ),
+    );
+  });
+}
+
+class FixedAuthorizationHeaderProvider implements AuthorizationHeaderProvider {
+  const FixedAuthorizationHeaderProvider(this.header);
+
+  final String header;
+
+  @override
+  Future<String?> authorizationHeader() async => header;
+
+  @override
+  Future<void> invalidateAuthorization() async {}
+}

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -12,6 +12,7 @@ import 'package:easysubway_mobile/notification_settings.dart';
 import 'package:easysubway_mobile/onboarding.dart';
 import 'package:easysubway_mobile/route_search.dart';
 import 'package:easysubway_mobile/station_search.dart';
+import 'package:easysubway_mobile/user_data_deletion.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -823,7 +824,7 @@ void main() {
       );
       await tester.pumpAndSettle();
       expect(find.text('데이터 삭제 요청'), findsOneWidget);
-      expect(find.text('privacy@easysubway.example'), findsOneWidget);
+      expect(find.text('앱 안에서 삭제 대상을 확인하고 직접 요청합니다.'), findsOneWidget);
 
       final privacyButtonSize = tester.getSize(
         find.byKey(const Key('privacyPolicyAccessItem')),
@@ -842,6 +843,11 @@ void main() {
         '개인정보처리방침, https://easysubway.example/privacy',
       );
       expect(privacySemantics.hasAction(SemanticsAction.tap), isTrue);
+      final deletionSemantics = tester
+          .getSemantics(find.byKey(const Key('dataDeletionAccessItem')))
+          .getSemanticsData();
+      expect(deletionSemantics.label, '데이터 삭제 요청, 앱 안에서 삭제를 진행합니다.');
+      expect(deletionSemantics.hasAction(SemanticsAction.tap), isTrue);
     } finally {
       semanticsHandle.dispose();
     }
@@ -1026,6 +1032,7 @@ void main() {
           supportEmail: 'support@easysubway.example',
           dataDeletionEmail: 'privacy@easysubway.example',
         ),
+        enableAnonymousAuth: false,
         initialOnboardingState: _completedOnboardingState(),
       ),
     );
@@ -1042,7 +1049,7 @@ void main() {
     );
   });
 
-  testWidgets('도움말은 고객지원과 데이터 삭제 요청을 메일 앱으로 연결한다', (tester) async {
+  testWidgets('도움말은 고객지원을 메일 앱으로 연결한다', (tester) async {
     final launcher = RecordingSupportAccessLauncher();
 
     await tester.pumpWidget(
@@ -1072,20 +1079,140 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('supportAccessItem')));
     await tester.pumpAndSettle();
+    expect(launcher.openedUris, hasLength(1));
+    expect(launcher.openedUris.single.scheme, 'mailto');
+    expect(launcher.openedUris.single.path, 'support@easysubway.example');
+  });
+
+  testWidgets('도움말은 앱 안에서 데이터 삭제를 재확인하고 로컬 상태를 정리한다', (tester) async {
+    final deletionRepository = FakeUserDataDeletionRepository();
+    final anonymousStore = MemoryAnonymousAuthCredentialStore(
+      const AnonymousAuthCredentials(
+        userId: 'anonymous-user-1',
+        accessToken: 'access-token-1',
+        refreshToken: 'refresh-token-1',
+      ),
+    );
+    final onboardingStore = MemoryOnboardingResultStore(
+      initialResult: _completedOnboardingState().result,
+    );
+    final draftTargetStore = MemoryFacilityReportDraftTargetStore(
+      const FacilityReportTarget(
+        stationId: 'station-1',
+        stationName: '상록수',
+        facilityId: 'facility-1',
+        facilityName: '1번 엘리베이터',
+        facilityTypeLabel: '엘리베이터',
+        facilityStatusLabel: '정상',
+      ),
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        userDataDeletionRepository: deletionRepository,
+        anonymousAuthCredentialStore: anonymousStore,
+        onboardingStore: onboardingStore,
+        facilityReportDraftTargetStore: draftTargetStore,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('homeHelpActionButton')));
+    await tester.pumpAndSettle();
     await tester.scrollUntilVisible(
       find.byKey(const Key('dataDeletionAccessItem')),
       120,
       scrollable: find.byType(Scrollable).last,
     );
-    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
     await tester.pumpAndSettle();
 
-    expect(launcher.openedUris, hasLength(2));
-    expect(launcher.openedUris.first.scheme, 'mailto');
-    expect(launcher.openedUris.first.path, 'support@easysubway.example');
-    expect(launcher.openedUris.last.scheme, 'mailto');
-    expect(launcher.openedUris.last.path, 'privacy@easysubway.example');
+    expect(find.byKey(const Key('dataDeletionStartButton')), findsOneWidget);
+    expect(find.textContaining('즐겨찾기, 이동 조건, 알림 설정'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('dataDeletionStartButton')));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.text('정말 삭제할까요?'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('dataDeletionConfirmButton')));
+    await tester.pumpAndSettle();
+
+    expect(deletionRepository.deleteCount, 1);
+    expect(anonymousStore.clearCount, 1);
+    expect(anonymousStore.credentials, isNull);
+    expect(onboardingStore.savedResult, isNull);
+    expect(draftTargetStore.target, isNull);
+    expect(find.text('먼저 이동 조건을 골라 주세요'), findsOneWidget);
+  });
+
+  testWidgets('데이터 삭제 실패 시 로컬 상태를 유지하고 오류를 안내한다', (tester) async {
+    final deletionRepository = FakeUserDataDeletionRepository(
+      error: const UserDataDeletionException(
+        '데이터 삭제를 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      ),
+    );
+    final anonymousStore = MemoryAnonymousAuthCredentialStore(
+      const AnonymousAuthCredentials(
+        userId: 'anonymous-user-1',
+        accessToken: 'access-token-1',
+        refreshToken: 'refresh-token-1',
+      ),
+    );
+    final onboardingStore = MemoryOnboardingResultStore(
+      initialResult: _completedOnboardingState().result,
+    );
+    final draftTargetStore = MemoryFacilityReportDraftTargetStore(
+      const FacilityReportTarget(
+        stationId: 'station-1',
+        stationName: '상록수',
+        facilityId: 'facility-1',
+        facilityName: '1번 엘리베이터',
+        facilityTypeLabel: '엘리베이터',
+        facilityStatusLabel: '정상',
+      ),
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        userDataDeletionRepository: deletionRepository,
+        anonymousAuthCredentialStore: anonymousStore,
+        onboardingStore: onboardingStore,
+        facilityReportDraftTargetStore: draftTargetStore,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('homeHelpActionButton')));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('dataDeletionAccessItem')),
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('dataDeletionStartButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('dataDeletionConfirmButton')));
+    await tester.pumpAndSettle();
+
+    expect(deletionRepository.deleteCount, 1);
+    expect(anonymousStore.clearCount, 0);
+    expect(anonymousStore.credentials, isNotNull);
+    expect(onboardingStore.savedResult, isNotNull);
+    expect(draftTargetStore.target, isNotNull);
+    expect(find.text('데이터 삭제를 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.'), findsOneWidget);
   });
 
   testWidgets('도움말은 연결값이 비어 있으면 준비 중으로 보여주고 실행하지 않는다', (tester) async {
@@ -1104,6 +1231,7 @@ void main() {
           supportEmail: '',
           dataDeletionEmail: '',
         ),
+        enableAnonymousAuth: false,
         initialOnboardingState: _completedOnboardingState(),
       ),
     );
@@ -6180,6 +6308,63 @@ class FakeAnonymousAuthRepository implements AnonymousAuthRepository {
       accessToken: 'access-token-2',
       refreshToken: 'refresh-token-2',
     );
+  }
+}
+
+class FakeUserDataDeletionRepository implements UserDataDeletionRepository {
+  FakeUserDataDeletionRepository({this.error});
+
+  final UserDataDeletionException? error;
+  int deleteCount = 0;
+
+  @override
+  Future<UserDataDeletionResult> deleteCurrentUserData() async {
+    deleteCount++;
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return const UserDataDeletionResult(
+      userId: 'anonymous-user-1',
+      deletedFavoriteStationCount: 1,
+      deletedFavoriteFacilityCount: 1,
+      deletedFavoriteRouteCount: 1,
+      anonymizedRouteFeedbackCount: 1,
+      notificationSettingsDeleted: true,
+      deletedRegisteredDeviceCount: 1,
+      deletedPushNotificationCount: 1,
+      mobilityProfileDeleted: true,
+      anonymizedReportCount: 1,
+      anonymousCredentialsDeleted: true,
+    );
+  }
+}
+
+class MemoryAnonymousAuthCredentialStore
+    implements AnonymousAuthCredentialStore {
+  MemoryAnonymousAuthCredentialStore([this.credentials]);
+
+  AnonymousAuthCredentials? credentials;
+  int readCount = 0;
+  int saveCount = 0;
+  int clearCount = 0;
+
+  @override
+  Future<AnonymousAuthCredentials?> readCredentials() async {
+    readCount++;
+    return credentials;
+  }
+
+  @override
+  Future<void> saveCredentials(AnonymousAuthCredentials credentials) async {
+    saveCount++;
+    this.credentials = credentials;
+  }
+
+  @override
+  Future<void> clearCredentials() async {
+    clearCount++;
+    credentials = null;
   }
 }
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3243,13 +3243,14 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(userDataDeletion, /deleteUrl\(baseUri\.resolve\('\/api\/v1\/me'\)\)/);
   assert.match(userDataDeletion, /HttpHeaders\.authorizationHeader/);
   assert.match(userDataDeletion, /refreshExistingAuthorization/);
-  assert.match(anonymousAuth, /refreshExistingAuthorization\(\)/);
+  assert.match(anonymousAuth, /refreshExistingAuthorization\(/);
   assert.match(
     userDataDeletion,
     /userDataDeletionErrorMessage = '데이터 삭제를 완료하지 못했습니다\. 잠시 후 다시 시도해 주세요\.'/,
   );
   assert.match(userDataDeletionTest, /인증 헤더로 DELETE \/api\/v1\/me를 호출한다/);
   assert.match(userDataDeletionTest, /기존 인증 갱신 실패 시 새 사용자 삭제로 처리하지 않는다/);
+  assert.match(anonymousAuthTest, /삭제 요청에 사용한 인증 정보가 바뀌면 기존 인증 갱신을 실패 처리한다/);
   assert.match(widgetTest, /도움말은 앱 안에서 데이터 삭제를 재확인하고 로컬 상태를 정리한다/);
   assert.match(widgetTest, /데이터 삭제 실패 시 로컬 상태를 유지하고 오류를 안내한다/);
   assert.match(main, /UserDataDeletionScreen/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3242,11 +3242,14 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(userDataDeletion, /class UserDataDeletionApiRepository implements UserDataDeletionRepository/);
   assert.match(userDataDeletion, /deleteUrl\(baseUri\.resolve\('\/api\/v1\/me'\)\)/);
   assert.match(userDataDeletion, /HttpHeaders\.authorizationHeader/);
+  assert.match(userDataDeletion, /refreshExistingAuthorization/);
+  assert.match(anonymousAuth, /refreshExistingAuthorization\(\)/);
   assert.match(
     userDataDeletion,
     /userDataDeletionErrorMessage = '데이터 삭제를 완료하지 못했습니다\. 잠시 후 다시 시도해 주세요\.'/,
   );
   assert.match(userDataDeletionTest, /인증 헤더로 DELETE \/api\/v1\/me를 호출한다/);
+  assert.match(userDataDeletionTest, /기존 인증 갱신 실패 시 새 사용자 삭제로 처리하지 않는다/);
   assert.match(widgetTest, /도움말은 앱 안에서 데이터 삭제를 재확인하고 로컬 상태를 정리한다/);
   assert.match(widgetTest, /데이터 삭제 실패 시 로컬 상태를 유지하고 오류를 안내한다/);
   assert.match(main, /UserDataDeletionScreen/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2944,6 +2944,8 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   const secureKeyValueStorage = read("apps/mobile/lib/secure_key_value_storage.dart");
   const anonymousAuth = read("apps/mobile/lib/anonymous_auth.dart");
   const anonymousAuthTest = read("apps/mobile/test/anonymous_auth_test.dart");
+  const userDataDeletion = read("apps/mobile/lib/user_data_deletion.dart");
+  const userDataDeletionTest = read("apps/mobile/test/user_data_deletion_test.dart");
   const onboarding = read("apps/mobile/lib/onboarding.dart");
   const onboardingTest = read("apps/mobile/test/onboarding_test.dart");
   const routeSearch = read("apps/mobile/lib/route_search.dart");
@@ -3237,6 +3239,18 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(main, /현장 안내, 역무원 안내, 운영기관 공지를 먼저 확인해 주세요/);
   assert.match(main, /실시간 상태나 무조건 안전한 경로를 보장하지 않습니다/);
   assert.match(main, /데이터 삭제 요청 시 즐겨찾기, 이동 조건, 익명 인증, 기기 알림 정보, 신고 내용·사진·위치와 경로 피드백을 삭제하거나 익명화합니다/);
+  assert.match(userDataDeletion, /class UserDataDeletionApiRepository implements UserDataDeletionRepository/);
+  assert.match(userDataDeletion, /deleteUrl\(baseUri\.resolve\('\/api\/v1\/me'\)\)/);
+  assert.match(userDataDeletion, /HttpHeaders\.authorizationHeader/);
+  assert.match(
+    userDataDeletion,
+    /userDataDeletionErrorMessage = '데이터 삭제를 완료하지 못했습니다\. 잠시 후 다시 시도해 주세요\.'/,
+  );
+  assert.match(userDataDeletionTest, /인증 헤더로 DELETE \/api\/v1\/me를 호출한다/);
+  assert.match(widgetTest, /도움말은 앱 안에서 데이터 삭제를 재확인하고 로컬 상태를 정리한다/);
+  assert.match(widgetTest, /데이터 삭제 실패 시 로컬 상태를 유지하고 오류를 안내한다/);
+  assert.match(main, /UserDataDeletionScreen/);
+  assert.match(main, /dataDeletionConfirmButton/);
   assert.match(widgetTest, /알림 설정 화면은 현재 설정을 불러오고 바꾼 값을 저장한다/);
   assert.match(widgetTest, /bySemanticsLabel/);
   assert.match(widgetTest, /greaterThanOrEqualTo\(60\)/);


### PR DESCRIPTION
## 관련 이슈

close #483

## 작업 배경

- 사용자가 앱을 삭제하거나 문의 메일을 보내지 않아도, 앱 안에서 본인 데이터 삭제 대상을 확인하고 직접 삭제를 요청할 수 있어야 합니다.
- 교통약자 사용자가 이해하기 쉬운 문구와 재확인 절차를 제공하고, 삭제 성공 후에는 익명 인증과 온보딩, 시설 신고 임시 대상을 로컬에서도 정리해야 합니다.

## 작업 내용

- 모바일 앱 도움말의 데이터 삭제 요청을 인증 사용자의 `DELETE /api/v1/me` 호출 기반 앱 내 흐름으로 연결했습니다.
- 삭제 전 확인 화면과 재확인 다이얼로그를 추가하고, 삭제 실패 시 기존 로컬 상태를 유지한 채 쉬운 오류 문구를 표시하도록 했습니다.
- 삭제 성공 후 익명 인증 저장소, 온보딩 저장 결과, 시설 신고 임시 대상을 정리하고 초기 설정 화면으로 돌려보내도록 했습니다.
- 삭제 전용 인증 갱신은 실패한 삭제 요청의 Authorization header와 같은 기존 인증 정보만 refresh 하도록 제한했습니다.
- 사용자 데이터 삭제 API 저장소와 모바일 위젯 테스트, 저장소 계약 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test`: 통과
  - `flutter analyze`: 통과
  - `node --test tools/ci/*.test.mjs`: 통과
  - `git diff --check`: 통과
  - `git ls-files "*.md"`: `README.md`, `.github/pull_request_template.md`만 추적
  - PR CI: Android, iOS, Backend, Mobile App, Repository, OSV, Changes 통과
  - post-merge CD: run 27817599165 success
  - post-merge main CI: run 27817599352 success

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/user_data_deletion.dart`의 `DELETE /api/v1/me` 응답 파싱과 인증 재시도 처리
  - `apps/mobile/lib/anonymous_auth.dart`의 삭제 전용 기존 인증 갱신 경계
  - `apps/mobile/lib/main.dart`의 삭제 확인 화면, 접근성 라벨, 삭제 성공 후 로컬 상태 정리
  - `apps/mobile/test/widget_test.dart`의 성공/실패 플로우 검증

## 리스크

- 백엔드 삭제 API 응답 필드명이 변경되면 모바일 파싱이 실패합니다.
- 삭제 성공 후 로컬 온보딩 상태를 초기화하므로 사용자는 이동 조건을 다시 설정해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.