### PR TITLE
[Feat] 신고 검수 트랜잭션과 outbox 정리

### DIFF
--- a/backend/src/main/java/com/easysubway/common/error/ConflictException.java
+++ b/backend/src/main/java/com/easysubway/common/error/ConflictException.java
@@ -1,0 +1,8 @@
+package com.easysubway.common.error;
+
+public class ConflictException extends RuntimeException {
+
+	public ConflictException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/com/easysubway/common/web/CommonExceptionHandler.java
+++ b/backend/src/main/java/com/easysubway/common/web/CommonExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.easysubway.common.web;
 
+import com.easysubway.common.error.ConflictException;
 import com.easysubway.common.error.InvalidRequestException;
 import com.easysubway.common.error.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
@@ -39,6 +40,12 @@ class CommonExceptionHandler {
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	ApiResponse<Void> handleInvalidRequestParameter() {
 		return ApiResponse.fail("요청 값을 확인해야 합니다.");
+	}
+
+	@ExceptionHandler(ConflictException.class)
+	@ResponseStatus(HttpStatus.CONFLICT)
+	ApiResponse<Void> handleConflict(ConflictException exception) {
+		return ApiResponse.fail(exception.getMessage());
 	}
 
 	@ExceptionHandler(ResourceNotFoundException.class)

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/InMemoryPushNotificationOutboxRepository.java
@@ -55,6 +55,12 @@ public class InMemoryPushNotificationOutboxRepository implements
 	}
 
 	@Override
+	public PushNotification savePendingPushNotificationIfAbsent(PushNotification notification) {
+		return findNotification(notification.notificationId())
+			.orElseGet(() -> savePushNotification(notification));
+	}
+
+	@Override
 	public List<PushNotification> loadPushNotifications(String userId) {
 		return List.copyOf(notificationsByUserId.getOrDefault(userId, List.of()));
 	}
@@ -122,6 +128,14 @@ public class InMemoryPushNotificationOutboxRepository implements
 			.filter(notification -> notification.status() == PushNotificationStatus.PENDING)
 			.map(PushNotification::createdAt)
 			.min(Comparator.naturalOrder());
+	}
+
+	private Optional<PushNotification> findNotification(String notificationId) {
+		return notificationsByUserId.values()
+			.stream()
+			.flatMap(List::stream)
+			.filter(notification -> notification.notificationId().equals(notificationId))
+			.findFirst();
 	}
 
 	private record PendingUser(String userId, LocalDateTime oldestPendingCreatedAt) {

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
@@ -116,6 +116,17 @@ public class JdbcPushNotificationOutboxRepository implements
 	}
 
 	@Override
+	public PushNotification savePendingPushNotificationIfAbsent(PushNotification notification) {
+		try {
+			insertPushNotification(notification);
+			return notification;
+		} catch (DuplicateKeyException exception) {
+			return loadPushNotification(notification.notificationId())
+				.orElse(notification);
+		}
+	}
+
+	@Override
 	public PushNotificationDashboardSummary summarizePushNotificationOutbox() {
 		List<StatusCountRow> statusCounts = jdbcTemplate.query(
 			"""
@@ -231,6 +242,29 @@ public class JdbcPushNotificationOutboxRepository implements
 			resultSet.getString("failure_reason"),
 			resultSet.getTimestamp("created_at").toLocalDateTime()
 		);
+	}
+
+	private java.util.Optional<PushNotification> loadPushNotification(String notificationId) {
+		return jdbcTemplate.query(
+				"""
+					SELECT notification_id,
+						user_id,
+						platform,
+						device_token,
+						notification_type,
+						title,
+						body,
+						status,
+						failure_reason,
+						created_at
+					FROM push_notification_outbox
+					WHERE notification_id = ?
+					""",
+				this::mapPushNotification,
+				notificationId
+			)
+			.stream()
+			.findFirst();
 	}
 
 	private String latestFailureReason() {

--- a/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
+++ b/backend/src/main/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepository.java
@@ -13,10 +13,12 @@ import com.easysubway.user.application.port.out.DeleteUserPushNotificationPort;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -30,6 +32,7 @@ public class JdbcPushNotificationOutboxRepository implements
 	DeleteUserPushNotificationPort {
 
 	private final JdbcTemplate jdbcTemplate;
+	private final DatabaseDialect databaseDialect;
 
 	@Autowired
 	public JdbcPushNotificationOutboxRepository(DataSource dataSource) {
@@ -38,6 +41,7 @@ public class JdbcPushNotificationOutboxRepository implements
 
 	JdbcPushNotificationOutboxRepository(JdbcTemplate jdbcTemplate) {
 		this.jdbcTemplate = jdbcTemplate;
+		this.databaseDialect = detectDatabaseDialect(jdbcTemplate);
 	}
 
 	@Override
@@ -117,13 +121,11 @@ public class JdbcPushNotificationOutboxRepository implements
 
 	@Override
 	public PushNotification savePendingPushNotificationIfAbsent(PushNotification notification) {
-		try {
-			insertPushNotification(notification);
+		if (insertPendingPushNotificationIfAbsent(notification) > 0) {
 			return notification;
-		} catch (DuplicateKeyException exception) {
-			return loadPushNotification(notification.notificationId())
-				.orElse(notification);
 		}
+		return loadPushNotification(notification.notificationId())
+			.orElse(notification);
 	}
 
 	@Override
@@ -229,6 +231,82 @@ public class JdbcPushNotificationOutboxRepository implements
 		);
 	}
 
+	private int insertPendingPushNotificationIfAbsent(PushNotification notification) {
+		if (databaseDialect == DatabaseDialect.H2) {
+			return insertPendingPushNotificationIfAbsentWithH2(notification);
+		}
+		return jdbcTemplate.update(
+			"""
+				INSERT INTO push_notification_outbox (
+					notification_id,
+					user_id,
+					platform,
+					device_token,
+					notification_type,
+					title,
+					body,
+					status,
+					failure_reason,
+					created_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT (notification_id) DO NOTHING
+				""",
+			pushNotificationParameters(notification)
+		);
+	}
+
+	private int insertPendingPushNotificationIfAbsentWithH2(PushNotification notification) {
+		return jdbcTemplate.update(
+			"""
+				INSERT INTO push_notification_outbox (
+					notification_id,
+					user_id,
+					platform,
+					device_token,
+					notification_type,
+					title,
+					body,
+					status,
+					failure_reason,
+					created_at
+				)
+				SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+				WHERE NOT EXISTS (
+					SELECT 1
+					FROM push_notification_outbox
+					WHERE notification_id = ?
+				)
+				""",
+			notification.notificationId(),
+			notification.userId(),
+			notification.platform().name(),
+			notification.deviceToken(),
+			notification.type().name(),
+			notification.title(),
+			notification.body(),
+			notification.status().name(),
+			notification.failureReason(),
+			notification.createdAt(),
+			notification.notificationId()
+		);
+	}
+
+	private Object[] pushNotificationParameters(PushNotification notification) {
+		return new Object[] {
+			notification.notificationId(),
+			notification.userId(),
+			notification.platform().name(),
+			notification.deviceToken(),
+			notification.type().name(),
+			notification.title(),
+			notification.body(),
+			notification.status().name(),
+			notification.failureReason(),
+			notification.createdAt()
+		};
+	}
+
 	private PushNotification mapPushNotification(ResultSet resultSet, int rowNumber) throws SQLException {
 		return new PushNotification(
 			resultSet.getString("notification_id"),
@@ -244,7 +322,7 @@ public class JdbcPushNotificationOutboxRepository implements
 		);
 	}
 
-	private java.util.Optional<PushNotification> loadPushNotification(String notificationId) {
+	private Optional<PushNotification> loadPushNotification(String notificationId) {
 		return jdbcTemplate.query(
 				"""
 					SELECT notification_id,
@@ -285,6 +363,19 @@ public class JdbcPushNotificationOutboxRepository implements
 			.orElse(null);
 	}
 
+	private DatabaseDialect detectDatabaseDialect(JdbcTemplate jdbcTemplate) {
+		DatabaseDialect dialect = jdbcTemplate.execute((ConnectionCallback<DatabaseDialect>) connection -> {
+			String productName = connection.getMetaData().getDatabaseProductName();
+			return "H2".equalsIgnoreCase(productName) ? DatabaseDialect.H2 : DatabaseDialect.POSTGRESQL;
+		});
+		return dialect == null ? DatabaseDialect.POSTGRESQL : dialect;
+	}
+
 	private record StatusCountRow(PushNotificationStatus status, long count) {
+	}
+
+	private enum DatabaseDialect {
+		POSTGRESQL,
+		H2
 	}
 }

--- a/backend/src/main/java/com/easysubway/notification/application/port/in/DispatchPushNotificationCommand.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/in/DispatchPushNotificationCommand.java
@@ -7,8 +7,18 @@ public record DispatchPushNotificationCommand(
 	String userId,
 	PushNotificationType type,
 	String title,
-	String body
+	String body,
+	String idempotencyKey
 ) {
+
+	public DispatchPushNotificationCommand(
+		String userId,
+		PushNotificationType type,
+		String title,
+		String body
+	) {
+		this(userId, type, title, body, null);
+	}
 
 	public DispatchPushNotificationCommand {
 		if (userId == null || userId.isBlank()) {
@@ -26,5 +36,8 @@ public record DispatchPushNotificationCommand(
 		userId = userId.trim();
 		title = title.trim();
 		body = body.trim();
+		idempotencyKey = idempotencyKey == null || idempotencyKey.isBlank()
+			? null
+			: idempotencyKey.trim();
 	}
 }

--- a/backend/src/main/java/com/easysubway/notification/application/port/out/SavePushNotificationOutboxPort.java
+++ b/backend/src/main/java/com/easysubway/notification/application/port/out/SavePushNotificationOutboxPort.java
@@ -5,4 +5,8 @@ import com.easysubway.notification.domain.PushNotification;
 public interface SavePushNotificationOutboxPort {
 
 	PushNotification savePushNotification(PushNotification notification);
+
+	default PushNotification savePendingPushNotificationIfAbsent(PushNotification notification) {
+		return savePushNotification(notification);
+	}
 }

--- a/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDispatchService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDispatchService.java
@@ -65,7 +65,7 @@ public class PushNotificationDispatchService implements PushNotificationDispatch
 				PushNotificationStatus.PENDING,
 				LocalDateTime.now(clock)
 			);
-			savedNotifications.add(savePushNotificationOutboxPort.savePushNotification(notification));
+			savedNotifications.add(savePushNotificationOutboxPort.savePendingPushNotificationIfAbsent(notification));
 		}
 
 		return new PushNotificationDispatchResult(

--- a/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDispatchService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/PushNotificationDispatchService.java
@@ -9,6 +9,8 @@ import com.easysubway.notification.domain.PushNotification;
 import com.easysubway.notification.domain.PushNotificationDispatchResult;
 import com.easysubway.notification.domain.PushNotificationStatus;
 import com.easysubway.notification.domain.PushNotificationType;
+import com.easysubway.notification.domain.RegisteredDevice;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -53,7 +55,7 @@ public class PushNotificationDispatchService implements PushNotificationDispatch
 		List<PushNotification> savedNotifications = new ArrayList<>();
 		for (var device : loadNotificationPreferencePort.loadDevices(command.userId())) {
 			var notification = new PushNotification(
-				"push-" + UUID.randomUUID(),
+				notificationId(command, device),
 				command.userId(),
 				device.platform(),
 				device.deviceToken(),
@@ -72,6 +74,14 @@ public class PushNotificationDispatchService implements PushNotificationDispatch
 			savedNotifications.size(),
 			savedNotifications
 		);
+	}
+
+	private String notificationId(DispatchPushNotificationCommand command, RegisteredDevice device) {
+		if (command.idempotencyKey() == null) {
+			return "push-" + UUID.randomUUID();
+		}
+		String key = "%s|%s|%s".formatted(command.idempotencyKey(), device.platform(), device.deviceToken());
+		return "push-" + UUID.nameUUIDFromBytes(key.getBytes(StandardCharsets.UTF_8));
 	}
 
 	private PushNotificationDispatchResult emptyResult(DispatchPushNotificationCommand command) {

--- a/backend/src/main/java/com/easysubway/notification/application/service/ReportStatusAlertService.java
+++ b/backend/src/main/java/com/easysubway/notification/application/service/ReportStatusAlertService.java
@@ -23,7 +23,8 @@ public class ReportStatusAlertService implements ReportStatusAlertUseCase {
 			command.userId(),
 			PushNotificationType.REPORT_STATUS,
 			"신고 처리 결과",
-			body(command.status())
+			body(command.status()),
+			"report-status:%s:%s".formatted(command.reportId(), command.status().name())
 		));
 	}
 

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
@@ -79,6 +79,19 @@ public class InMemoryFacilityReportRepository implements
 	}
 
 	@Override
+	public synchronized Optional<FacilityReport> saveReviewedReportIfStatus(
+		FacilityReport report,
+		FacilityReportStatus expectedStatus
+	) {
+		FacilityReport currentReport = reports.get(report.id());
+		if (currentReport == null || currentReport.status() != expectedStatus) {
+			return Optional.empty();
+		}
+		reports.put(report.id(), report);
+		return Optional.of(report);
+	}
+
+	@Override
 	public int anonymizeFacilityReportsByUserId(String userId) {
 		int anonymizedCount = 0;
 		for (FacilityReport report : loadReports()) {

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
@@ -173,6 +173,60 @@ public class JdbcFacilityReportRepository implements
 	}
 
 	@Override
+	public Optional<FacilityReport> saveReviewedReportIfStatus(
+		FacilityReport report,
+		FacilityReportStatus expectedStatus
+	) {
+		int updatedCount = jdbcTemplate.update(
+			"""
+				UPDATE facility_reports
+				SET user_id = ?,
+					station_id = ?,
+					facility_id = ?,
+					report_type = ?,
+					description = ?,
+					photo_file_name = ?,
+					photo_content_type = ?,
+					photo_object_key = ?,
+					photo_thumbnail_object_key = ?,
+					photo_sha256 = ?,
+					photo_size_bytes = ?,
+					latitude = ?,
+					longitude = ?,
+					duplicate_of_report_id = ?,
+					status = ?,
+					reviewed_at = ?,
+					reviewed_by = ?
+				WHERE report_id = ?
+					AND status = ?
+				""",
+			report.userId(),
+			report.stationId(),
+			report.facilityId(),
+			report.reportType().name(),
+			report.description(),
+			report.photoFileName(),
+			report.photoContentType(),
+			report.photoObjectKey(),
+			report.photoThumbnailObjectKey(),
+			report.photoSha256(),
+			report.photoSizeBytes(),
+			report.latitude(),
+			report.longitude(),
+			report.duplicateOfReportId(),
+			report.status().name(),
+			report.reviewedAt(),
+			report.reviewedBy(),
+			report.id(),
+			expectedStatus.name()
+		);
+		if (updatedCount == 0) {
+			return Optional.empty();
+		}
+		return loadReport(report.id());
+	}
+
+	@Override
 	public int anonymizeFacilityReportsByUserId(String userId) {
 		List<String> photoObjectKeys = loadPhotoObjectKeysByUserId(userId);
 		int anonymizedCount = jdbcTemplate.update(

--- a/backend/src/main/java/com/easysubway/report/application/port/out/SaveFacilityReportPort.java
+++ b/backend/src/main/java/com/easysubway/report/application/port/out/SaveFacilityReportPort.java
@@ -1,8 +1,12 @@
 package com.easysubway.report.application.port.out;
 
 import com.easysubway.report.domain.FacilityReport;
+import com.easysubway.report.domain.FacilityReportStatus;
+import java.util.Optional;
 
 public interface SaveFacilityReportPort {
 
 	FacilityReport saveReport(FacilityReport report);
+
+	Optional<FacilityReport> saveReviewedReportIfStatus(FacilityReport report, FacilityReportStatus expectedStatus);
 }

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -13,6 +13,7 @@ import com.easysubway.report.application.port.out.StoreFacilityReportPhotoPort.S
 import com.easysubway.report.domain.FacilityReport;
 import com.easysubway.report.domain.FacilityReportNotFoundException;
 import com.easysubway.report.domain.FacilityReportReviewAudit;
+import com.easysubway.report.domain.FacilityReportReviewConflictException;
 import com.easysubway.report.domain.FacilityReportReviewDecision;
 import com.easysubway.report.domain.FacilityReportStatus;
 import com.easysubway.report.domain.FacilityReportTargetNotFoundException;
@@ -40,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class FacilityReportService implements FacilityReportUseCase {
@@ -327,11 +329,13 @@ public class FacilityReportService implements FacilityReportUseCase {
 	}
 
 	@Override
+	@Transactional
 	public FacilityReport reviewReport(ReviewFacilityReportCommand command) {
 		requireReviewDecision(command);
 		requireReviewer(command);
 
 		FacilityReport report = getReport(command.reportId());
+		requireReviewableStatus(report);
 		String duplicateOfReportId = resolveDuplicateOfReportId(command, report);
 		FacilityReport reviewed = new FacilityReport(
 			report.id(),
@@ -355,17 +359,19 @@ public class FacilityReportService implements FacilityReportUseCase {
 			command.reviewedBy()
 		);
 
-		FacilityReport saved = saveFacilityReportPort.saveReport(reviewed);
-		// 신고 상태 변경과 별개로 관리자 검수 행동 자체를 추적할 수 있게 별도 감사 로그를 남긴다.
+		// 감사 로그 저장 실패가 신고 상태 변경을 남기지 않도록 같은 트랜잭션에서 먼저 기록한다.
 		saveFacilityReportReviewAuditPort.saveAudit(new FacilityReportReviewAudit(
 			"audit-" + UUID.randomUUID(),
-			saved.id(),
+			reviewed.id(),
 			command.reviewedBy(),
 			command.decision(),
 			report.status(),
-			saved.status(),
-			saved.reviewedAt()
+			reviewed.status(),
+			reviewed.reviewedAt()
 		));
+		FacilityReport saved = saveFacilityReportPort
+			.saveReviewedReportIfStatus(reviewed, FacilityReportStatus.SUBMITTED)
+			.orElseThrow(FacilityReportReviewConflictException::new);
 		// 같은 결과로 재검수한 경우 사용자가 중복 처리 알림을 받지 않도록 상태 변경만 알린다.
 		if (report.status() != saved.status()) {
 			alertReportStatusChanged(saved);
@@ -500,6 +506,13 @@ public class FacilityReportService implements FacilityReportUseCase {
 			return;
 		}
 		throw new InvalidFacilityReportException("검수 완료된 신고만 확인할 수 있습니다.");
+	}
+
+	private void requireReviewableStatus(FacilityReport report) {
+		if (report.status() == FacilityReportStatus.SUBMITTED) {
+			return;
+		}
+		throw new FacilityReportReviewConflictException();
 	}
 
 	private String resolveDuplicateOfReportId(ReviewFacilityReportCommand command, FacilityReport report) {

--- a/backend/src/main/java/com/easysubway/report/domain/FacilityReportReviewConflictException.java
+++ b/backend/src/main/java/com/easysubway/report/domain/FacilityReportReviewConflictException.java
@@ -1,0 +1,10 @@
+package com.easysubway.report.domain;
+
+import com.easysubway.common.error.ConflictException;
+
+public class FacilityReportReviewConflictException extends ConflictException {
+
+	public FacilityReportReviewConflictException() {
+		super("이미 검수 처리된 신고입니다.");
+	}
+}

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryContainerTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryContainerTest.java
@@ -1,0 +1,80 @@
+package com.easysubway.notification.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.notification.domain.DevicePlatform;
+import com.easysubway.notification.domain.PushNotification;
+import com.easysubway.notification.domain.PushNotificationStatus;
+import com.easysubway.notification.domain.PushNotificationType;
+import java.time.LocalDateTime;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+@DisplayName("PostgreSQL 푸시 알림 outbox 저장소")
+class JdbcPushNotificationOutboxRepositoryContainerTest {
+
+	@Container
+	private static final PostgreSQLContainer<?> POSTGRES =
+		new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"));
+
+	@Test
+	@DisplayName("idempotent 대기 알림 저장은 같은 트랜잭션 안에서 중복 키 예외 없이 기존 알림을 반환한다")
+	void savePendingPushNotificationIfAbsentDoesNotAbortPostgresqlTransaction() {
+		var dataSource = new DriverManagerDataSource(
+			POSTGRES.getJdbcUrl(),
+			POSTGRES.getUsername(),
+			POSTGRES.getPassword()
+		);
+		Flyway.configure()
+			.dataSource(dataSource)
+			.locations("classpath:db/migration/postgresql")
+			.load()
+			.migrate();
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		var repository = new JdbcPushNotificationOutboxRepository(jdbcTemplate);
+		var transactionTemplate = new TransactionTemplate(new DataSourceTransactionManager(dataSource));
+		var pendingNotification = notification("push-postgres-idempotent", PushNotificationStatus.PENDING);
+		var sentNotification = notification("push-postgres-idempotent", PushNotificationStatus.SENT);
+		repository.savePushNotification(sentNotification);
+
+		PushNotification savedNotification = transactionTemplate.execute(status -> {
+			PushNotification existingNotification =
+				repository.savePendingPushNotificationIfAbsent(pendingNotification);
+			Integer count = jdbcTemplate.queryForObject(
+				"SELECT COUNT(*) FROM push_notification_outbox WHERE notification_id = ?",
+				Integer.class,
+				pendingNotification.notificationId()
+			);
+			assertThat(count).isEqualTo(1);
+			return existingNotification;
+		});
+
+		assertThat(savedNotification).isEqualTo(sentNotification);
+		assertThat(repository.loadPushNotifications("anonymous-user-postgres"))
+			.containsExactly(sentNotification);
+	}
+
+	private PushNotification notification(String notificationId, PushNotificationStatus status) {
+		return new PushNotification(
+			notificationId,
+			"anonymous-user-postgres",
+			DevicePlatform.ANDROID,
+			"device-token-" + notificationId,
+			PushNotificationType.REPORT_STATUS,
+			"신고 처리 결과",
+			"제보해 주신 신고가 확인되어 시설 정보에 반영되었습니다.",
+			status,
+			LocalDateTime.of(2026, 6, 19, 19, 40)
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/notification/adapter/out/persistence/JdbcPushNotificationOutboxRepositoryTest.java
@@ -79,6 +79,26 @@ class JdbcPushNotificationOutboxRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("idempotent 대기 알림 저장은 이미 처리된 알림 상태를 되돌리지 않는다")
+	void savePendingPushNotificationIfAbsentKeepsProcessedNotification() {
+		var pendingNotification = notification("push-1", "anonymous-user-1", PushNotificationType.REPORT_STATUS, 9);
+		var sentNotification = notification(
+			"push-1",
+			"anonymous-user-1",
+			PushNotificationType.REPORT_STATUS,
+			PushNotificationStatus.SENT,
+			10
+		);
+		repository.savePushNotification(pendingNotification);
+		repository.savePushNotification(sentNotification);
+
+		var savedNotification = repository.savePendingPushNotificationIfAbsent(pendingNotification);
+
+		assertThat(savedNotification).isEqualTo(sentNotification);
+		assertThat(repository.loadPushNotifications("anonymous-user-1")).containsExactly(sentNotification);
+	}
+
+	@Test
 	@DisplayName("실패한 푸시 알림은 실패 사유를 저장하고 조회한다")
 	void savePushNotificationStoresFailureReasonForFailedNotification() {
 		var failedNotification = failedNotification(

--- a/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDispatchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDispatchServiceTest.java
@@ -106,6 +106,32 @@ class PushNotificationDispatchServiceTest {
 	}
 
 	@Test
+	@DisplayName("같은 idempotency key 발송은 outbox 후보를 중복 생성하지 않는다")
+	void dispatchWithSameIdempotencyKeyDoesNotDuplicateOutboxMessage() {
+		registerDevice("anonymous-user-idempotent", DevicePlatform.ANDROID, "android-token-idempotent");
+
+		dispatchService.dispatch(new DispatchPushNotificationCommand(
+			"anonymous-user-idempotent",
+			PushNotificationType.REPORT_STATUS,
+			"신고 처리 결과",
+			"제보해 주신 신고가 확인되어 시설 정보에 반영되었습니다.",
+			"report-status:report-1:ACCEPTED"
+		));
+		dispatchService.dispatch(new DispatchPushNotificationCommand(
+			"anonymous-user-idempotent",
+			PushNotificationType.REPORT_STATUS,
+			"신고 처리 결과",
+			"제보해 주신 신고가 확인되어 시설 정보에 반영되었습니다.",
+			"report-status:report-1:ACCEPTED"
+		));
+
+		assertThat(outboxRepository.loadPushNotifications("anonymous-user-idempotent"))
+			.hasSize(1)
+			.extracting("type")
+			.containsExactly(PushNotificationType.REPORT_STATUS);
+	}
+
+	@Test
 	@DisplayName("발송 명령은 사용자, 알림 종류, 제목, 본문을 요구한다")
 	void dispatchCommandRequiresUserTypeTitleAndBody() {
 		assertThatThrownBy(() -> new DispatchPushNotificationCommand(

--- a/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDispatchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/notification/application/service/PushNotificationDispatchServiceTest.java
@@ -117,6 +117,9 @@ class PushNotificationDispatchServiceTest {
 			"제보해 주신 신고가 확인되어 시설 정보에 반영되었습니다.",
 			"report-status:report-1:ACCEPTED"
 		));
+		var sentNotification = outboxRepository.loadPushNotifications("anonymous-user-idempotent").getFirst()
+			.withStatus(PushNotificationStatus.SENT);
+		outboxRepository.savePushNotification(sentNotification);
 		dispatchService.dispatch(new DispatchPushNotificationCommand(
 			"anonymous-user-idempotent",
 			PushNotificationType.REPORT_STATUS,
@@ -127,8 +130,8 @@ class PushNotificationDispatchServiceTest {
 
 		assertThat(outboxRepository.loadPushNotifications("anonymous-user-idempotent"))
 			.hasSize(1)
-			.extracting("type")
-			.containsExactly(PushNotificationType.REPORT_STATUS);
+			.extracting("type", "status")
+			.containsExactly(tuple(PushNotificationType.REPORT_STATUS, PushNotificationStatus.SENT));
 	}
 
 	@Test
@@ -173,5 +176,9 @@ class PushNotificationDispatchServiceTest {
 
 	private void registerDevice(String userId, DevicePlatform platform, String deviceToken) {
 		preferenceService.registerDevice(new RegisterDeviceCommand(userId, platform, deviceToken));
+	}
+
+	private static org.assertj.core.groups.Tuple tuple(Object... values) {
+		return org.assertj.core.api.Assertions.tuple(values);
 	}
 }

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -312,6 +312,36 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("이미 검수된 신고 재검수는 공통 409 응답을 반환한다")
+	void repeatedReviewReportReturnsCommonConflictError() throws Exception {
+		String reportId = createReport("basic-user", "user-test-password", "spoofed-user", "이미 검수된 신고");
+		mockMvc.perform(post("/admin/reports/{reportId}/review", reportId)
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "decision": "REJECT"
+					}
+					"""))
+			.andExpect(status().isOk());
+
+		mockMvc.perform(post("/admin/reports/{reportId}/review", reportId)
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "decision": "REJECT"
+					}
+					"""))
+			.andExpect(status().isConflict())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("이미 검수 처리된 신고입니다."));
+	}
+
+	@Test
 	@DisplayName("신고 작성자는 처리 결과를 확인 완료 상태로 바꿀 수 있다")
 	void reporterConfirmsReviewedReportResult() throws Exception {
 		String reportId = createReport("basic-user", "user-test-password", "spoofed-user", "처리 결과를 확인할 신고");

--- a/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
@@ -206,6 +206,38 @@ class JdbcFacilityReportRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("검수 저장은 기대 상태와 일치할 때만 신고 상태를 바꾼다")
+	void saveReviewedReportIfStatusUpdatesOnlyWhenExpectedStatusMatches() {
+		var submittedReport = submittedReport("report-1", "anonymous-user-1", 9);
+		var reviewedReport = new FacilityReport(
+			"report-1",
+			"anonymous-user-1",
+			"station-sangnoksu",
+			"facility-elevator-1",
+			FacilityReportType.BROKEN,
+			"엘리베이터가 멈춰 있습니다.",
+			"elevator.jpg",
+			"image/jpeg",
+			"aW1hZ2UtYnl0ZXM=",
+			new BigDecimal("37.3123450"),
+			new BigDecimal("126.9876540"),
+			null,
+			FacilityReportStatus.ACCEPTED,
+			LocalDateTime.of(2026, 6, 17, 9, 0),
+			LocalDateTime.of(2026, 6, 17, 10, 0),
+			"admin-user"
+		);
+		repository.saveReport(submittedReport);
+
+		var savedReport = repository.saveReviewedReportIfStatus(reviewedReport, FacilityReportStatus.SUBMITTED);
+		var repeatedSave = repository.saveReviewedReportIfStatus(reviewedReport, FacilityReportStatus.SUBMITTED);
+
+		assertThat(savedReport).contains(reviewedReport);
+		assertThat(repeatedSave).isEmpty();
+		assertThat(repository.loadReport("report-1")).contains(reviewedReport);
+	}
+
+	@Test
 	@DisplayName("사용자 데이터 삭제 요청은 미검수 신고 본문과 사진과 위치를 익명화한다")
 	void anonymizeFacilityReportsByUserIdClearsSubmittedReportPersonalData() {
 		var targetReport = submittedReport("report-1", "anonymous-user-1", 9);

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -13,6 +13,7 @@ import com.easysubway.report.application.port.out.SaveFacilityReportReviewAuditP
 import com.easysubway.report.domain.FacilityReport;
 import com.easysubway.report.domain.FacilityReportNotFoundException;
 import com.easysubway.report.domain.FacilityReportReviewAudit;
+import com.easysubway.report.domain.FacilityReportReviewConflictException;
 import com.easysubway.report.domain.FacilityReportReviewDecision;
 import com.easysubway.report.domain.FacilityReportStatus;
 import com.easysubway.report.domain.FacilityReportTargetNotFoundException;
@@ -458,8 +459,40 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
-	@DisplayName("같은 신고를 다시 검수해도 관리자 행동은 감사 로그로 남긴다")
-	void repeatedReviewStoresAuditLogForEachReviewerAction() {
+	@DisplayName("감사 로그 저장 실패는 신고 상태 변경을 남기지 않는다")
+	void reviewReportKeepsSubmittedStatusWhenAuditSaveFails() {
+		var auditPort = new FailingFacilityReportReviewAuditPort();
+		var reportStatusAlertUseCase = new RecordingReportStatusAlertUseCase();
+		var facilityStatusAlertUseCase = new RecordingFacilityStatusAlertUseCase();
+		var repository = new InMemoryFacilityReportRepository();
+		var service = new FacilityReportService(
+			new InMemoryTransitMasterRepository(),
+			new InMemoryTransitMasterRepository(),
+			repository,
+			repository,
+			facilityStatusAlertUseCase,
+			reportStatusAlertUseCase,
+			auditPort,
+			Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+		);
+		var report = service.createReport(reportCommand(
+			"anonymous-user-audit-failure",
+			FacilityReportType.BROKEN,
+			"감사 로그 저장 실패 시 상태가 바뀌면 안 되는 신고입니다."
+		));
+
+		assertThatThrownBy(() -> service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.ACCEPT)))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessage("감사 로그 저장 실패");
+
+		assertThat(service.getReport(report.id()).status()).isEqualTo(FacilityReportStatus.SUBMITTED);
+		assertThat(reportStatusAlertUseCase.commands).isEmpty();
+		assertThat(facilityStatusAlertUseCase.commands).isEmpty();
+	}
+
+	@Test
+	@DisplayName("이미 검수된 신고는 다시 검수할 수 없다")
+	void reviewedReportCannotBeReviewedAgain() {
 		var auditPort = new RecordingFacilityReportReviewAuditPort();
 		var repository = new InMemoryFacilityReportRepository();
 		var service = new FacilityReportService(
@@ -481,14 +514,17 @@ class FacilityReportServiceTest {
 		));
 
 		service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT));
-		service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT));
+
+		assertThatThrownBy(() -> service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT)))
+			.isInstanceOf(FacilityReportReviewConflictException.class)
+			.hasMessage("이미 검수 처리된 신고입니다.");
 
 		assertThat(auditPort.savedAudits)
 			.extracting(FacilityReportReviewAudit::previousStatus)
-			.containsExactly(FacilityReportStatus.SUBMITTED, FacilityReportStatus.REJECTED);
+			.containsExactly(FacilityReportStatus.SUBMITTED);
 		assertThat(auditPort.savedAudits)
 			.extracting(FacilityReportReviewAudit::nextStatus)
-			.containsExactly(FacilityReportStatus.REJECTED, FacilityReportStatus.REJECTED);
+			.containsExactly(FacilityReportStatus.REJECTED);
 	}
 
 	@Test
@@ -563,8 +599,8 @@ class FacilityReportServiceTest {
 	}
 
 	@Test
-	@DisplayName("이미 같은 상태인 신고 재검수는 처리 알림을 다시 요청하지 않는다")
-	void repeatedSameReportReviewDoesNotRequestReportStatusAlertAgain() {
+	@DisplayName("이미 검수된 신고 재검수는 처리 알림을 다시 요청하지 않는다")
+	void repeatedReportReviewDoesNotRequestReportStatusAlertAgain() {
 		var reportStatusAlertUseCase = new RecordingReportStatusAlertUseCase();
 		var repository = new InMemoryFacilityReportRepository();
 		var service = new FacilityReportService(
@@ -584,7 +620,9 @@ class FacilityReportServiceTest {
 		));
 
 		service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT));
-		service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT));
+		assertThatThrownBy(() -> service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.REJECT)))
+			.isInstanceOf(FacilityReportReviewConflictException.class)
+			.hasMessage("이미 검수 처리된 신고입니다.");
 
 		assertThat(reportStatusAlertUseCase.commands)
 			.extracting(ReportStatusChangedAlertCommand::status)
@@ -1131,6 +1169,14 @@ class FacilityReportServiceTest {
 			return savedAudits.stream()
 				.filter(audit -> audit.reportId().equals(reportId))
 				.toList();
+		}
+	}
+
+	private static class FailingFacilityReportReviewAuditPort implements SaveFacilityReportReviewAuditPort {
+
+		@Override
+		public FacilityReportReviewAudit saveAudit(FacilityReportReviewAudit audit) {
+			throw new IllegalStateException("감사 로그 저장 실패");
 		}
 	}
 


### PR DESCRIPTION
## 관련 이슈

close #490

## 작업 배경

- 관리자 신고 검수는 신고 상태, 감사 로그, 시설 상태 변경 알림 outbox가 같은 검수 결정에 맞춰 움직여야 한다.
- 같은 신고가 재시도되거나 두 관리자가 거의 동시에 처리할 때 중복 outbox나 뒤늦은 상태 덮어쓰기가 생기지 않도록 저장 경계를 고정한다.

## 작업 내용

- 신고 검수 메서드에 트랜잭션 경계를 추가하고, 감사 로그 저장 실패 시 신고 상태가 바뀌지 않도록 저장 순서를 정리했다.
- 검수 결과 저장을 `SUBMITTED` 상태 조건부 update로 분리해 이미 검수된 신고는 409 conflict로 응답하게 했다.
- 푸시 outbox dispatch 명령에 선택적 idempotency key를 추가하고, 신고 처리 결과 알림은 신고 ID와 상태 기반 key로 중복 후보 생성을 막았다.
- 서비스, API, JDBC 저장소, outbox idempotency 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test` 성공
  - `node --test tools/ci/*.test.mjs` 성공
  - `git diff --check` 성공
  - `git ls-files '*.md'` 결과: `.github/pull_request_template.md`, `README.md`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `FacilityReportService.reviewReport`의 감사 로그, 조건부 검수 저장, 알림 outbox 호출 순서
  - `JdbcFacilityReportRepository.saveReviewedReportIfStatus`의 `status = SUBMITTED` 조건부 update
  - `DispatchPushNotificationCommand.idempotencyKey`와 `PushNotificationDispatchService`의 안정적 notification ID 생성

## 리스크

- 기존에는 같은 신고를 반복 검수하면 감사 로그를 추가로 남겼지만, 이제 이미 처리된 신고는 409로 거절한다. 관리자 화면/API 호출부는 재검수 실패를 사용자에게 명확히 보여줘야 한다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 푸시 알림 중복 전송 방지 기능 추가로 안정성 향상
  * 신고 검수 충돌 감지로 중복 검수 방지

* **버그 수정**
  * 이미 검수 완료된 신고의 재검수 시도 시 적절한 오류 응답(409) 반환으로 데이터 무결성 보장

* **테스트**
  * 알림 중복 전송 방지 및 신고 검수 충돌 처리에 대한 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->