### PR TITLE
[Feat] 즐겨찾기와 개인 설정 로컬화

### DIFF
--- a/apps/mobile/lib/app/app_bootstrap.dart
+++ b/apps/mobile/lib/app/app_bootstrap.dart
@@ -77,6 +77,7 @@ class AppBootstrap {
       anonymousAuthCredentialStore: anonymousAuthCredentialStore,
       userDataDeletionRepository: userDataDeletionRepository,
       catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
       enableAnonymousAuth: enableAnonymousAuth,
       enablePushNotifications: enablePushNotifications,
     );

--- a/apps/mobile/lib/app/app_dependencies.dart
+++ b/apps/mobile/lib/app/app_dependencies.dart
@@ -1,8 +1,12 @@
 import '../anonymous_auth.dart';
 import '../auth_headers.dart';
 import '../core/database/catalog/catalog_database.dart';
+import '../core/database/user/user_database.dart';
 import '../facility_report.dart';
 import '../favorite_facility.dart';
+import '../features/favorites/data/drift_favorite_repositories.dart';
+import '../features/preferences/data/drift_notification_settings_repository.dart';
+import '../features/search_history/data/drift_search_history_repository.dart';
 import '../features/stations/data/drift_station_repository.dart';
 import '../internal_route.dart';
 import '../notification_settings.dart';
@@ -22,6 +26,7 @@ class AppDependencies {
     required this.favoriteRepository,
     required this.favoriteFacilityRepository,
     required this.favoriteRouteRepository,
+    required this.searchHistoryRepository,
     required this.internalRouteRepository,
     required this.notificationRepository,
     required this.notificationPermissionProvider,
@@ -38,6 +43,7 @@ class AppDependencies {
     FavoriteStationRepository? favoriteRepository,
     FavoriteFacilityRepository? favoriteFacilityRepository,
     FavoriteRouteRepository? favoriteRouteRepository,
+    SearchHistoryRepository? searchHistoryRepository,
     InternalRouteRepository? internalRouteRepository,
     NotificationSettingsRepository? notificationRepository,
     NotificationPermissionProvider? notificationPermissionProvider,
@@ -46,6 +52,7 @@ class AppDependencies {
     AnonymousAuthCredentialStore? anonymousAuthCredentialStore,
     UserDataDeletionRepository? userDataDeletionRepository,
     CatalogDatabase? catalogDatabase,
+    UserDatabase? userDatabase,
     required bool enableAnonymousAuth,
     required bool enablePushNotifications,
   }) {
@@ -63,10 +70,14 @@ class AppDependencies {
         notificationPermissionProvider != null;
     final resolvedNotificationRepository = pushNotificationsEnabled
         ? notificationRepository ??
-              _defaultNotificationSettingsRepository(
-                baseUri: baseUri,
-                authProvider: sharedAuthProvider,
-              )
+              (userDatabase != null
+                  ? DriftNotificationSettingsRepository(
+                      userDatabase: userDatabase,
+                    )
+                  : _defaultNotificationSettingsRepository(
+                      baseUri: baseUri,
+                      authProvider: sharedAuthProvider,
+                    ))
         : null;
     final resolvedNotificationPermissionProvider = pushNotificationsEnabled
         ? notificationPermissionProvider
@@ -102,22 +113,42 @@ class AppDependencies {
           ),
       favoriteRepository:
           favoriteRepository ??
-          _defaultFavoriteStationRepository(
-            baseUri: baseUri,
-            authProvider: sharedAuthProvider,
-          ),
+          (catalogDatabase != null && userDatabase != null
+              ? DriftFavoriteStationRepository(
+                  catalogDatabase: catalogDatabase,
+                  userDatabase: userDatabase,
+                )
+              : _defaultFavoriteStationRepository(
+                  baseUri: baseUri,
+                  authProvider: sharedAuthProvider,
+                )),
       favoriteFacilityRepository:
           favoriteFacilityRepository ??
-          _defaultFavoriteFacilityRepository(
-            baseUri: baseUri,
-            authProvider: sharedAuthProvider,
-          ),
+          (catalogDatabase != null && userDatabase != null
+              ? DriftFavoriteFacilityRepository(
+                  catalogDatabase: catalogDatabase,
+                  userDatabase: userDatabase,
+                )
+              : _defaultFavoriteFacilityRepository(
+                  baseUri: baseUri,
+                  authProvider: sharedAuthProvider,
+                )),
       favoriteRouteRepository:
           favoriteRouteRepository ??
-          _defaultFavoriteRouteRepository(
-            baseUri: baseUri,
-            authProvider: sharedAuthProvider,
-          ),
+          (catalogDatabase != null && userDatabase != null
+              ? DriftFavoriteRouteRepository(
+                  catalogDatabase: catalogDatabase,
+                  userDatabase: userDatabase,
+                )
+              : _defaultFavoriteRouteRepository(
+                  baseUri: baseUri,
+                  authProvider: sharedAuthProvider,
+                )),
+      searchHistoryRepository:
+          searchHistoryRepository ??
+          (userDatabase == null
+              ? null
+              : DriftSearchHistoryRepository(userDatabase: userDatabase)),
       internalRouteRepository:
           internalRouteRepository ??
           (catalogDatabase == null
@@ -149,6 +180,7 @@ class AppDependencies {
   final FavoriteStationRepository? favoriteRepository;
   final FavoriteFacilityRepository? favoriteFacilityRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
+  final SearchHistoryRepository? searchHistoryRepository;
   final InternalRouteRepository internalRouteRepository;
   final NotificationSettingsRepository? notificationRepository;
   final NotificationPermissionProvider? notificationPermissionProvider;

--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -9,9 +9,14 @@ import 'mobile_error_reporter.dart';
 
 const _favoriteFacilityTimeout = Duration(seconds: 8);
 const _favoriteFacilityLoadErrorMessage = '즐겨찾기 시설을 불러오지 못했습니다.';
+const _favoriteFacilityChangeErrorMessage = '즐겨찾기 시설을 처리하지 못했습니다.';
 
 abstract class FavoriteFacilityRepository {
   Future<List<FavoriteFacility>> listFavoriteFacilities();
+
+  Future<FavoriteFacility> saveFavoriteFacility(String facilityId);
+
+  Future<void> removeFavoriteFacility(String facilityId);
 }
 
 class FavoriteFacilityApiRepository implements FavoriteFacilityRepository {
@@ -53,6 +58,46 @@ class FavoriteFacilityApiRepository implements FavoriteFacilityRepository {
       );
       throw const FavoriteFacilityException(_favoriteFacilityLoadErrorMessage);
     }
+  }
+
+  @override
+  Future<FavoriteFacility> saveFavoriteFacility(String facilityId) async {
+    final data = await _requestData(
+      'PUT',
+      baseUri.resolve(
+        '/api/v1/me/favorites/facilities/${Uri.encodeComponent(facilityId)}',
+      ),
+      errorMessage: _favoriteFacilityChangeErrorMessage,
+    );
+    if (data is! Map<String, Object?>) {
+      throw const FavoriteFacilityException(
+        _favoriteFacilityChangeErrorMessage,
+      );
+    }
+
+    try {
+      return FavoriteFacility.fromJson(data);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '즐겨찾기 시설 저장 응답 처리 중 예외가 발생했습니다.',
+      );
+      throw const FavoriteFacilityException(
+        _favoriteFacilityChangeErrorMessage,
+      );
+    }
+  }
+
+  @override
+  Future<void> removeFavoriteFacility(String facilityId) async {
+    await _requestData(
+      'DELETE',
+      baseUri.resolve(
+        '/api/v1/me/favorites/facilities/${Uri.encodeComponent(facilityId)}',
+      ),
+      errorMessage: _favoriteFacilityChangeErrorMessage,
+    );
   }
 
   Future<Object?> _requestData(

--- a/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
+++ b/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
@@ -314,11 +314,14 @@ class DriftFavoriteRouteRepository implements FavoriteRouteRepository {
     String routeSearchId, {
     RouteSearchResult? result,
   }) async {
-    final routeId = routeSearchId.trim();
     final routeResult = result;
     if (routeResult == null) {
       throw const FavoriteRouteException('즐겨찾기 경로를 처리하지 못했습니다.');
     }
+    final routeId = _favoriteRouteStorageId(
+      routeSearchId: routeSearchId,
+      result: routeResult,
+    );
 
     final addedAt = DateTime.now().toUtc();
     await userDatabase
@@ -335,6 +338,7 @@ class DriftFavoriteRouteRepository implements FavoriteRouteRepository {
     await _writeRouteSnapshot(routeId, routeResult);
     return _favoriteRouteFromResult(
       result: routeResult,
+      favoriteRouteId: routeId,
       addedAt: _isoFromSql(addedAt),
     );
   }
@@ -393,10 +397,14 @@ class DriftFavoriteRouteRepository implements FavoriteRouteRepository {
     required Map<String, Object?> snapshot,
     required String addedAt,
   }) {
+    final originalRouteSearchId = _string(
+      snapshot['routeSearchId'],
+      fallback: routeId,
+    );
     return FavoriteRoute(
       userId: _localUserId,
       favoriteRouteId: routeId,
-      routeSearchId: routeId,
+      routeSearchId: originalRouteSearchId,
       originStationId: _string(snapshot['originStationId']),
       originStationName: _string(snapshot['originStationName']),
       destinationStationId: _string(snapshot['destinationStationId']),
@@ -500,11 +508,12 @@ class FavoriteStationBuilder {
 
 FavoriteRoute _favoriteRouteFromResult({
   required RouteSearchResult result,
+  required String favoriteRouteId,
   required String addedAt,
 }) {
   return FavoriteRoute(
     userId: _localUserId,
-    favoriteRouteId: result.routeSearchId,
+    favoriteRouteId: favoriteRouteId,
     routeSearchId: result.routeSearchId,
     originStationId: result.originStationId,
     originStationName: result.originStationName,
@@ -518,6 +527,20 @@ FavoriteRoute _favoriteRouteFromResult({
     routeCreatedAt: result.createdAt,
     addedAt: addedAt,
   );
+}
+
+String _favoriteRouteStorageId({
+  required String routeSearchId,
+  required RouteSearchResult result,
+}) {
+  final baseId = routeSearchId.trim().isNotEmpty
+      ? routeSearchId.trim()
+      : result.routeSearchId.trim();
+  final mobilityType = result.mobilityType.trim();
+  if (baseId.isEmpty || mobilityType.isEmpty) {
+    return baseId;
+  }
+  return '$baseId::$mobilityType';
 }
 
 Map<String, Object?> _routeResultToJson(RouteSearchResult result) {

--- a/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
+++ b/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
@@ -1,0 +1,592 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+
+import '../../../core/database/catalog/catalog_database.dart';
+import '../../../core/database/user/user_database.dart' as user_db;
+import '../../../favorite_facility.dart';
+import '../../../route_search.dart';
+import '../../../station_search.dart';
+
+const _localUserId = 'local-user';
+const _routeSnapshotPrefix = 'favorite_route_snapshot:';
+
+class DriftFavoriteStationRepository implements FavoriteStationRepository {
+  DriftFavoriteStationRepository({
+    required this.catalogDatabase,
+    required this.userDatabase,
+  });
+
+  final CatalogDatabase catalogDatabase;
+  final user_db.UserDatabase userDatabase;
+
+  @override
+  Future<List<FavoriteStation>> listFavoriteStations() async {
+    final favoriteRows = await userDatabase
+        .customSelect(
+          '''
+          SELECT station_id, added_at
+          FROM favorite_stations
+          ORDER BY added_at DESC
+          ''',
+          readsFrom: {userDatabase.favoriteStations},
+        )
+        .get();
+
+    final favorites = <FavoriteStation>[];
+    for (final favoriteRow in favoriteRows) {
+      final stationId = favoriteRow.read<String>('station_id');
+      final stationRows = await catalogDatabase
+          .customSelect(
+            '''
+            SELECT
+              s.id,
+              s.name_ko,
+              s.name_en,
+              s.region,
+              s.data_quality_level,
+              s.data_source_type,
+              CAST(s.last_verified_at AS INTEGER) AS last_verified_at_value,
+              l.id AS line_id,
+              l.name_ko AS line_name,
+              l.color AS line_color,
+              sl.station_code
+            FROM stations s
+            LEFT JOIN station_lines sl ON sl.station_id = s.id
+            LEFT JOIN lines l ON l.id = sl.line_id
+            WHERE s.id = ?
+            ORDER BY sl.line_sequence
+            ''',
+            variables: [Variable.withString(stationId)],
+            readsFrom: {
+              catalogDatabase.stations,
+              catalogDatabase.stationLines,
+              catalogDatabase.lines,
+            },
+          )
+          .get();
+      if (stationRows.isEmpty) {
+        continue;
+      }
+      final firstRow = stationRows.first;
+      final builder = FavoriteStationBuilder(
+        stationId: stationId,
+        nameKo: firstRow.read<String>('name_ko'),
+        nameEn: firstRow.read<String?>('name_en') ?? '',
+        region: firstRow.read<String?>('region') ?? '',
+        dataQualityLevel: firstRow.read<String?>('data_quality_level') ?? '',
+        dataSourceType: firstRow.read<String?>('data_source_type') ?? '',
+        lastVerifiedAt: _dateLabelFromEpoch(
+          firstRow.read<int?>('last_verified_at_value'),
+        ),
+        addedAt: _isoFromSql(favoriteRow.read<DateTime>('added_at')),
+      );
+      for (final row in stationRows) {
+        final lineId = row.read<String?>('line_id');
+        if (lineId != null) {
+          builder.lines.add(
+            StationSearchLine(
+              id: lineId,
+              name: row.read<String>('line_name'),
+              color: row.read<String>('line_color'),
+              stationCode: row.read<String>('station_code'),
+            ),
+          );
+        }
+      }
+      favorites.add(builder.build());
+    }
+
+    return favorites;
+  }
+
+  @override
+  Future<FavoriteStation> saveFavoriteStation(String stationId) async {
+    final trimmedStationId = stationId.trim();
+    await _ensureStationExists(trimmedStationId);
+    await userDatabase
+        .into(userDatabase.favoriteStations)
+        .insertOnConflictUpdate(
+          user_db.FavoriteStationsCompanion.insert(
+            stationId: trimmedStationId,
+            addedAt: DateTime.now().toUtc(),
+          ),
+        );
+    return (await listFavoriteStations()).singleWhere(
+      (favorite) => favorite.stationId == trimmedStationId,
+    );
+  }
+
+  @override
+  Future<void> removeFavoriteStation(String stationId) async {
+    await userDatabase.customStatement(
+      'DELETE FROM favorite_stations WHERE station_id = ?',
+      [stationId.trim()],
+    );
+  }
+
+  Future<void> _ensureStationExists(String stationId) async {
+    final row = await catalogDatabase
+        .customSelect(
+          'SELECT id FROM stations WHERE id = ?',
+          variables: [Variable.withString(stationId)],
+          readsFrom: {catalogDatabase.stations},
+        )
+        .getSingleOrNull();
+    if (row == null) {
+      throw const FavoriteStationException('즐겨찾기 역을 저장하지 못했습니다.');
+    }
+  }
+}
+
+class DriftFavoriteFacilityRepository implements FavoriteFacilityRepository {
+  DriftFavoriteFacilityRepository({
+    required this.catalogDatabase,
+    required this.userDatabase,
+  });
+
+  final CatalogDatabase catalogDatabase;
+  final user_db.UserDatabase userDatabase;
+
+  @override
+  Future<List<FavoriteFacility>> listFavoriteFacilities() async {
+    final favoriteRows = await userDatabase
+        .customSelect(
+          '''
+          SELECT facility_id, station_id, added_at
+          FROM favorite_facilities
+          ORDER BY added_at DESC
+          ''',
+          readsFrom: {userDatabase.favoriteFacilities},
+        )
+        .get();
+
+    final favorites = <FavoriteFacility>[];
+    for (final favoriteRow in favoriteRows) {
+      final facilityId = favoriteRow.read<String>('facility_id');
+      final row = await catalogDatabase
+          .customSelect(
+            '''
+            SELECT
+              f.id,
+              f.station_id,
+              f.exit_id,
+              f.type,
+              f.name,
+              f.floor_from,
+              f.floor_to,
+              f.description,
+              f.status,
+              s.name_ko AS station_name_ko,
+              s.name_en AS station_name_en,
+              s.data_source_type,
+              CAST(s.last_verified_at AS INTEGER) AS last_verified_at_value
+            FROM facilities f
+            JOIN stations s ON s.id = f.station_id
+            WHERE f.id = ?
+            ''',
+            variables: [Variable.withString(facilityId)],
+            readsFrom: {catalogDatabase.facilities, catalogDatabase.stations},
+          )
+          .getSingleOrNull();
+      if (row == null) {
+        continue;
+      }
+      favorites.add(
+        FavoriteFacility(
+          userId: _localUserId,
+          facilityId: row.read<String>('id'),
+          stationId: row.read<String>('station_id'),
+          stationNameKo: row.read<String>('station_name_ko'),
+          stationNameEn: row.read<String?>('station_name_en') ?? '',
+          exitId: row.read<String?>('exit_id') ?? '',
+          type: row.read<String?>('type') ?? '',
+          name: row.read<String?>('name') ?? '',
+          floorFrom: row.read<String?>('floor_from') ?? '',
+          floorTo: row.read<String?>('floor_to') ?? '',
+          description: row.read<String?>('description') ?? '',
+          status: row.read<String?>('status') ?? '',
+          dataConfidence: 'MEDIUM',
+          dataSourceType: row.read<String?>('data_source_type') ?? '',
+          lastUpdatedAt: _dateLabelFromEpoch(
+            row.read<int?>('last_verified_at_value'),
+          ),
+          addedAt: _isoFromSql(favoriteRow.read<DateTime>('added_at')),
+        ),
+      );
+    }
+    return favorites;
+  }
+
+  @override
+  Future<FavoriteFacility> saveFavoriteFacility(String facilityId) async {
+    final trimmedFacilityId = facilityId.trim();
+    final row = await _facilityCatalogRow(trimmedFacilityId);
+    if (row == null) {
+      throw const FavoriteFacilityException('즐겨찾기 시설을 처리하지 못했습니다.');
+    }
+    await userDatabase
+        .into(userDatabase.favoriteFacilities)
+        .insertOnConflictUpdate(
+          user_db.FavoriteFacilitiesCompanion.insert(
+            facilityId: trimmedFacilityId,
+            stationId: row.read<String>('station_id'),
+            addedAt: DateTime.now().toUtc(),
+          ),
+        );
+    return (await listFavoriteFacilities()).singleWhere(
+      (favorite) => favorite.facilityId == trimmedFacilityId,
+    );
+  }
+
+  @override
+  Future<void> removeFavoriteFacility(String facilityId) async {
+    await userDatabase.customStatement(
+      'DELETE FROM favorite_facilities WHERE facility_id = ?',
+      [facilityId.trim()],
+    );
+  }
+
+  Future<QueryRow?> _facilityCatalogRow(String facilityId) {
+    return catalogDatabase
+        .customSelect(
+          'SELECT id, station_id FROM facilities WHERE id = ?',
+          variables: [Variable.withString(facilityId)],
+          readsFrom: {catalogDatabase.facilities},
+        )
+        .getSingleOrNull();
+  }
+}
+
+class DriftFavoriteRouteRepository implements FavoriteRouteRepository {
+  DriftFavoriteRouteRepository({
+    required this.catalogDatabase,
+    required this.userDatabase,
+  });
+
+  final CatalogDatabase catalogDatabase;
+  final user_db.UserDatabase userDatabase;
+
+  @override
+  Future<List<FavoriteRoute>> listFavoriteRoutes() async {
+    final rows = await userDatabase
+        .customSelect(
+          '''
+          SELECT route_id, origin_station_id, destination_station_id,
+                 mobility_profile, added_at
+          FROM favorite_routes
+          ORDER BY added_at DESC
+          ''',
+          readsFrom: {userDatabase.favoriteRoutes},
+        )
+        .get();
+
+    final favorites = <FavoriteRoute>[];
+    for (final row in rows) {
+      final routeId = row.read<String>('route_id');
+      final snapshot = await _readRouteSnapshot(routeId);
+      if (snapshot != null) {
+        favorites.add(
+          _favoriteRouteFromSnapshot(
+            routeId: routeId,
+            snapshot: snapshot,
+            addedAt: _isoFromSql(row.read<DateTime>('added_at')),
+          ),
+        );
+        continue;
+      }
+
+      favorites.add(
+        await _fallbackFavoriteRoute(
+          routeId: routeId,
+          originStationId: row.read<String>('origin_station_id'),
+          destinationStationId: row.read<String>('destination_station_id'),
+          mobilityType: row.read<String>('mobility_profile'),
+          addedAt: _isoFromSql(row.read<DateTime>('added_at')),
+        ),
+      );
+    }
+    return favorites;
+  }
+
+  @override
+  Future<FavoriteRoute> saveFavoriteRoute(
+    String routeSearchId, {
+    RouteSearchResult? result,
+  }) async {
+    final routeId = routeSearchId.trim();
+    final routeResult = result;
+    if (routeResult == null) {
+      throw const FavoriteRouteException('즐겨찾기 경로를 처리하지 못했습니다.');
+    }
+
+    final addedAt = DateTime.now().toUtc();
+    await userDatabase
+        .into(userDatabase.favoriteRoutes)
+        .insertOnConflictUpdate(
+          user_db.FavoriteRoutesCompanion.insert(
+            routeId: routeId,
+            originStationId: routeResult.originStationId,
+            destinationStationId: routeResult.destinationStationId,
+            mobilityProfile: routeResult.mobilityType,
+            addedAt: addedAt,
+          ),
+        );
+    await _writeRouteSnapshot(routeId, routeResult);
+    return _favoriteRouteFromResult(
+      result: routeResult,
+      addedAt: _isoFromSql(addedAt),
+    );
+  }
+
+  @override
+  Future<void> removeFavoriteRoute(String favoriteRouteId) async {
+    final routeId = favoriteRouteId.trim();
+    await userDatabase.transaction(() async {
+      await userDatabase.customStatement(
+        'DELETE FROM favorite_routes WHERE route_id = ?',
+        [routeId],
+      );
+      await userDatabase.customStatement(
+        'DELETE FROM app_preferences WHERE key = ?',
+        ['$_routeSnapshotPrefix$routeId'],
+      );
+    });
+  }
+
+  Future<Map<String, Object?>?> _readRouteSnapshot(String routeId) async {
+    final row = await userDatabase
+        .customSelect(
+          'SELECT value FROM app_preferences WHERE key = ?',
+          variables: [Variable.withString('$_routeSnapshotPrefix$routeId')],
+          readsFrom: {userDatabase.appPreferences},
+        )
+        .getSingleOrNull();
+    if (row == null) {
+      return null;
+    }
+    final decoded = jsonDecode(row.read<String>('value'));
+    return decoded is Map<String, Object?> ? decoded : null;
+  }
+
+  Future<void> _writeRouteSnapshot(
+    String routeId,
+    RouteSearchResult result,
+  ) async {
+    final catalogVersion = await _catalogVersion();
+    await userDatabase
+        .into(userDatabase.appPreferences)
+        .insertOnConflictUpdate(
+          user_db.AppPreferencesCompanion.insert(
+            key: '$_routeSnapshotPrefix$routeId',
+            value: jsonEncode({
+              ..._routeResultToJson(result),
+              'savedCatalogVersion': catalogVersion,
+            }),
+            updatedAt: DateTime.now().toUtc(),
+          ),
+        );
+  }
+
+  FavoriteRoute _favoriteRouteFromSnapshot({
+    required String routeId,
+    required Map<String, Object?> snapshot,
+    required String addedAt,
+  }) {
+    return FavoriteRoute(
+      userId: _localUserId,
+      favoriteRouteId: routeId,
+      routeSearchId: routeId,
+      originStationId: _string(snapshot['originStationId']),
+      originStationName: _string(snapshot['originStationName']),
+      destinationStationId: _string(snapshot['destinationStationId']),
+      destinationStationName: _string(snapshot['destinationStationName']),
+      mobilityType: _string(snapshot['mobilityType']),
+      status: _string(snapshot['status'], fallback: 'FOUND'),
+      lineId: _string(snapshot['lineId']),
+      lineName: _string(snapshot['lineName']),
+      score: snapshot['score'] is int ? snapshot['score'] as int : 0,
+      routeCreatedAt: _string(snapshot['createdAt']),
+      addedAt: addedAt,
+    );
+  }
+
+  Future<FavoriteRoute> _fallbackFavoriteRoute({
+    required String routeId,
+    required String originStationId,
+    required String destinationStationId,
+    required String mobilityType,
+    required String addedAt,
+  }) async {
+    final originName = await _stationName(originStationId);
+    final destinationName = await _stationName(destinationStationId);
+    return FavoriteRoute(
+      userId: _localUserId,
+      favoriteRouteId: routeId,
+      routeSearchId: routeId,
+      originStationId: originStationId,
+      originStationName: originName,
+      destinationStationId: destinationStationId,
+      destinationStationName: destinationName,
+      mobilityType: mobilityType,
+      status: 'FOUND',
+      lineId: '',
+      lineName: '',
+      score: 0,
+      routeCreatedAt: addedAt,
+      addedAt: addedAt,
+    );
+  }
+
+  Future<String> _stationName(String stationId) async {
+    final row = await catalogDatabase
+        .customSelect(
+          'SELECT name_ko FROM stations WHERE id = ?',
+          variables: [Variable.withString(stationId)],
+          readsFrom: {catalogDatabase.stations},
+        )
+        .getSingleOrNull();
+    return row?.read<String>('name_ko') ?? stationId;
+  }
+
+  Future<String> _catalogVersion() async {
+    final row = await catalogDatabase
+        .customSelect(
+          "SELECT value FROM catalog_metadata WHERE key = 'schemaVersion'",
+          readsFrom: {catalogDatabase.catalogMetadata},
+        )
+        .getSingleOrNull();
+    return row?.read<String>('value') ?? '';
+  }
+}
+
+class FavoriteStationBuilder {
+  FavoriteStationBuilder({
+    required this.stationId,
+    required this.nameKo,
+    required this.nameEn,
+    required this.region,
+    required this.dataQualityLevel,
+    required this.dataSourceType,
+    required this.lastVerifiedAt,
+    required this.addedAt,
+  });
+
+  final String stationId;
+  final String nameKo;
+  final String nameEn;
+  final String region;
+  final String dataQualityLevel;
+  final String dataSourceType;
+  final String lastVerifiedAt;
+  final String addedAt;
+  final List<StationSearchLine> lines = [];
+
+  FavoriteStation build() {
+    return FavoriteStation(
+      userId: _localUserId,
+      stationId: stationId,
+      nameKo: nameKo,
+      nameEn: nameEn,
+      region: region,
+      dataQualityLevel: dataQualityLevel,
+      dataSourceType: dataSourceType,
+      lastVerifiedAt: lastVerifiedAt,
+      lines: List.unmodifiable(lines),
+      addedAt: addedAt,
+    );
+  }
+}
+
+FavoriteRoute _favoriteRouteFromResult({
+  required RouteSearchResult result,
+  required String addedAt,
+}) {
+  return FavoriteRoute(
+    userId: _localUserId,
+    favoriteRouteId: result.routeSearchId,
+    routeSearchId: result.routeSearchId,
+    originStationId: result.originStationId,
+    originStationName: result.originStationName,
+    destinationStationId: result.destinationStationId,
+    destinationStationName: result.destinationStationName,
+    mobilityType: result.mobilityType,
+    status: result.status,
+    lineId: result.lineId,
+    lineName: result.lineName,
+    score: result.score,
+    routeCreatedAt: result.createdAt,
+    addedAt: addedAt,
+  );
+}
+
+Map<String, Object?> _routeResultToJson(RouteSearchResult result) {
+  return {
+    'routeSearchId': result.routeSearchId,
+    'originStationId': result.originStationId,
+    'originStationName': result.originStationName,
+    'destinationStationId': result.destinationStationId,
+    'destinationStationName': result.destinationStationName,
+    'mobilityType': result.mobilityType,
+    'status': result.status,
+    'lineId': result.lineId,
+    'lineName': result.lineName,
+    'score': result.score,
+    'steps': result.steps.map(_routeStepToJson).toList(growable: false),
+    'warnings': result.warnings
+        .map(_routeWarningToJson)
+        .toList(growable: false),
+    'recommendationReasons': result.recommendationReasons,
+    'blockedReasons': result.blockedReasons,
+    'createdAt': result.createdAt,
+  };
+}
+
+Map<String, Object?> _routeStepToJson(RouteSearchStep step) {
+  return {
+    'sequence': step.sequence,
+    'title': step.title,
+    'description': step.description,
+    'lineId': step.lineId,
+    'lineName': step.lineName,
+    'fromStationId': step.fromStationId,
+    'toStationId': step.toStationId,
+    'estimatedMinutes': step.estimatedMinutes,
+    'distanceMeters': step.distanceMeters,
+    'includesStairs': step.includesStairs,
+    'requiresAccessibilityCheck': step.requiresAccessibilityCheck,
+  };
+}
+
+Map<String, Object?> _routeWarningToJson(RouteSearchWarning warning) {
+  return {'code': warning.code, 'message': warning.message};
+}
+
+String _isoFromSql(DateTime value) => value.toUtc().toIso8601String();
+
+String _dateLabelFromEpoch(int? value) {
+  if (value == null) {
+    return '';
+  }
+  final utc = switch (value.abs()) {
+    < 10000000000 => DateTime.fromMillisecondsSinceEpoch(
+      value * 1000,
+      isUtc: true,
+    ),
+    > 100000000000000 => DateTime.fromMicrosecondsSinceEpoch(
+      value,
+      isUtc: true,
+    ),
+    _ => DateTime.fromMillisecondsSinceEpoch(value, isUtc: true),
+  };
+  return '${utc.year.toString().padLeft(4, '0')}-'
+      '${utc.month.toString().padLeft(2, '0')}-'
+      '${utc.day.toString().padLeft(2, '0')}';
+}
+
+String _string(Object? value, {String fallback = ''}) {
+  if (value is String) {
+    return value;
+  }
+  return fallback;
+}

--- a/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
+++ b/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
@@ -25,7 +25,7 @@ class DriftFavoriteStationRepository implements FavoriteStationRepository {
     final favoriteRows = await userDatabase
         .customSelect(
           '''
-          SELECT station_id, added_at
+          SELECT station_id, CAST(added_at AS INTEGER) AS added_at_value
           FROM favorite_stations
           ORDER BY added_at DESC
           ''',
@@ -79,7 +79,7 @@ class DriftFavoriteStationRepository implements FavoriteStationRepository {
         lastVerifiedAt: _dateLabelFromEpoch(
           firstRow.read<int?>('last_verified_at_value'),
         ),
-        addedAt: _isoFromSql(favoriteRow.read<DateTime>('added_at')),
+        addedAt: _isoFromEpoch(favoriteRow.read<int?>('added_at_value')),
       );
       for (final row in stationRows) {
         final lineId = row.read<String?>('line_id');
@@ -153,7 +153,7 @@ class DriftFavoriteFacilityRepository implements FavoriteFacilityRepository {
     final favoriteRows = await userDatabase
         .customSelect(
           '''
-          SELECT facility_id, station_id, added_at
+          SELECT facility_id, station_id, CAST(added_at AS INTEGER) AS added_at_value
           FROM favorite_facilities
           ORDER BY added_at DESC
           ''',
@@ -211,7 +211,7 @@ class DriftFavoriteFacilityRepository implements FavoriteFacilityRepository {
           lastUpdatedAt: _dateLabelFromEpoch(
             row.read<int?>('last_verified_at_value'),
           ),
-          addedAt: _isoFromSql(favoriteRow.read<DateTime>('added_at')),
+          addedAt: _isoFromEpoch(favoriteRow.read<int?>('added_at_value')),
         ),
       );
     }
@@ -273,7 +273,7 @@ class DriftFavoriteRouteRepository implements FavoriteRouteRepository {
         .customSelect(
           '''
           SELECT route_id, origin_station_id, destination_station_id,
-                 mobility_profile, added_at
+                 mobility_profile, CAST(added_at AS INTEGER) AS added_at_value
           FROM favorite_routes
           ORDER BY added_at DESC
           ''',
@@ -290,7 +290,7 @@ class DriftFavoriteRouteRepository implements FavoriteRouteRepository {
           _favoriteRouteFromSnapshot(
             routeId: routeId,
             snapshot: snapshot,
-            addedAt: _isoFromSql(row.read<DateTime>('added_at')),
+            addedAt: _isoFromEpoch(row.read<int?>('added_at_value')),
           ),
         );
         continue;
@@ -302,7 +302,7 @@ class DriftFavoriteRouteRepository implements FavoriteRouteRepository {
           originStationId: row.read<String>('origin_station_id'),
           destinationStationId: row.read<String>('destination_station_id'),
           mobilityType: row.read<String>('mobility_profile'),
-          addedAt: _isoFromSql(row.read<DateTime>('added_at')),
+          addedAt: _isoFromEpoch(row.read<int?>('added_at_value')),
         ),
       );
     }
@@ -564,11 +564,25 @@ Map<String, Object?> _routeWarningToJson(RouteSearchWarning warning) {
 
 String _isoFromSql(DateTime value) => value.toUtc().toIso8601String();
 
+String _isoFromEpoch(int? value) {
+  if (value == null) {
+    return '';
+  }
+  return _dateTimeFromEpoch(value).toIso8601String();
+}
+
 String _dateLabelFromEpoch(int? value) {
   if (value == null) {
     return '';
   }
-  final utc = switch (value.abs()) {
+  final utc = _dateTimeFromEpoch(value);
+  return '${utc.year.toString().padLeft(4, '0')}-'
+      '${utc.month.toString().padLeft(2, '0')}-'
+      '${utc.day.toString().padLeft(2, '0')}';
+}
+
+DateTime _dateTimeFromEpoch(int value) {
+  return switch (value.abs()) {
     < 10000000000 => DateTime.fromMillisecondsSinceEpoch(
       value * 1000,
       isUtc: true,
@@ -579,9 +593,6 @@ String _dateLabelFromEpoch(int? value) {
     ),
     _ => DateTime.fromMillisecondsSinceEpoch(value, isUtc: true),
   };
-  return '${utc.year.toString().padLeft(4, '0')}-'
-      '${utc.month.toString().padLeft(2, '0')}-'
-      '${utc.day.toString().padLeft(2, '0')}';
 }
 
 String _string(Object? value, {String fallback = ''}) {

--- a/apps/mobile/lib/features/preferences/data/drift_notification_settings_repository.dart
+++ b/apps/mobile/lib/features/preferences/data/drift_notification_settings_repository.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+
+import '../../../core/database/user/user_database.dart' as user_db;
+import '../../../notification_settings.dart';
+
+const _localUserId = 'local-user';
+const _notificationSettingsKey = 'notification_settings';
+
+class DriftNotificationSettingsRepository
+    implements NotificationSettingsRepository {
+  DriftNotificationSettingsRepository({required this.userDatabase});
+
+  final user_db.UserDatabase userDatabase;
+
+  @override
+  Future<NotificationSettings> getNotificationSettings() async {
+    final row = await userDatabase
+        .customSelect(
+          'SELECT value FROM app_preferences WHERE key = ?',
+          variables: [Variable.withString(_notificationSettingsKey)],
+          readsFrom: {userDatabase.appPreferences},
+        )
+        .getSingleOrNull();
+    if (row == null) {
+      return _defaultSettings();
+    }
+
+    final decoded = jsonDecode(row.read<String>('value'));
+    if (decoded is! Map<String, Object?>) {
+      return _defaultSettings();
+    }
+    return NotificationSettings.fromJson(decoded);
+  }
+
+  @override
+  Future<NotificationSettings> saveNotificationSettings(
+    NotificationSettings settings,
+  ) async {
+    final savedAt = DateTime.now().toUtc();
+    final nextSettings = settings.copyWith(
+      userId: _localUserId,
+      updatedAt: savedAt.toIso8601String(),
+    );
+    await userDatabase
+        .into(userDatabase.appPreferences)
+        .insertOnConflictUpdate(
+          user_db.AppPreferencesCompanion.insert(
+            key: _notificationSettingsKey,
+            value: jsonEncode({
+              ...nextSettings.toRequestJson(),
+              'updatedAt': nextSettings.updatedAt,
+            }),
+            updatedAt: savedAt,
+          ),
+        );
+    return nextSettings;
+  }
+
+  NotificationSettings _defaultSettings() {
+    return NotificationSettings(
+      userId: _localUserId,
+      favoriteStationFacilityAlerts: false,
+      favoriteRouteFacilityAlerts: false,
+      reportStatusAlerts: false,
+      dataQualityAlerts: false,
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        0,
+        isUtc: true,
+      ).toIso8601String(),
+    );
+  }
+}

--- a/apps/mobile/lib/features/search_history/data/drift_search_history_repository.dart
+++ b/apps/mobile/lib/features/search_history/data/drift_search_history_repository.dart
@@ -1,0 +1,66 @@
+import 'package:drift/drift.dart';
+
+import '../../../core/database/user/user_database.dart' as user_db;
+import '../../../station_search.dart';
+
+class DriftSearchHistoryRepository implements SearchHistoryRepository {
+  DriftSearchHistoryRepository({
+    required this.userDatabase,
+    this.maxEntries = 10,
+  });
+
+  final user_db.UserDatabase userDatabase;
+  final int maxEntries;
+
+  @override
+  Future<void> recordSearch(String query) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) {
+      return;
+    }
+
+    await userDatabase.transaction(() async {
+      await userDatabase.customStatement(
+        'DELETE FROM search_history WHERE query = ?',
+        [trimmed],
+      );
+      await userDatabase
+          .into(userDatabase.searchHistory)
+          .insert(
+            user_db.SearchHistoryCompanion.insert(
+              query: trimmed,
+              searchedAt: DateTime.now().toUtc(),
+            ),
+          );
+      await userDatabase.customStatement(
+        '''
+        DELETE FROM search_history
+        WHERE id NOT IN (
+          SELECT id
+          FROM search_history
+          ORDER BY searched_at DESC, id DESC
+          LIMIT ?
+        )
+        ''',
+        [maxEntries],
+      );
+    });
+  }
+
+  @override
+  Future<List<String>> listRecentQueries() async {
+    final rows = await userDatabase
+        .customSelect(
+          '''
+          SELECT query
+          FROM search_history
+          ORDER BY searched_at DESC, id DESC
+          LIMIT ?
+          ''',
+          variables: [Variable.withInt(maxEntries)],
+          readsFrom: {userDatabase.searchHistory},
+        )
+        .get();
+    return rows.map((row) => row.read<String>('query')).toList(growable: false);
+  }
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -55,6 +55,7 @@ class EasySubwayApp extends StatelessWidget {
     FavoriteStationRepository? favoriteRepository,
     FavoriteFacilityRepository? favoriteFacilityRepository,
     FavoriteRouteRepository? favoriteRouteRepository,
+    SearchHistoryRepository? searchHistoryRepository,
     InternalRouteRepository? internalRouteRepository,
     NotificationSettingsRepository? notificationRepository,
     NotificationPermissionProvider? notificationPermissionProvider,
@@ -84,6 +85,7 @@ class EasySubwayApp extends StatelessWidget {
                favoriteRepository: favoriteRepository,
                favoriteFacilityRepository: favoriteFacilityRepository,
                favoriteRouteRepository: favoriteRouteRepository,
+               searchHistoryRepository: searchHistoryRepository,
                internalRouteRepository: internalRouteRepository,
                notificationRepository: notificationRepository,
                notificationPermissionProvider: notificationPermissionProvider,
@@ -121,6 +123,7 @@ class EasySubwayApp extends StatelessWidget {
        favoriteRepository = dependencies.favoriteRepository,
        favoriteFacilityRepository = dependencies.favoriteFacilityRepository,
        favoriteRouteRepository = dependencies.favoriteRouteRepository,
+       searchHistoryRepository = dependencies.searchHistoryRepository,
        internalRouteRepository = dependencies.internalRouteRepository,
        notificationRepository = dependencies.notificationRepository,
        notificationPermissionProvider =
@@ -136,6 +139,7 @@ class EasySubwayApp extends StatelessWidget {
   final FavoriteStationRepository? favoriteRepository;
   final FavoriteFacilityRepository? favoriteFacilityRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
+  final SearchHistoryRepository? searchHistoryRepository;
   final InternalRouteRepository internalRouteRepository;
   final NotificationSettingsRepository? notificationRepository;
   final NotificationPermissionProvider? notificationPermissionProvider;
@@ -201,6 +205,7 @@ class EasySubwayApp extends StatelessWidget {
         favoriteRepository: favoriteRepository,
         favoriteFacilityRepository: favoriteFacilityRepository,
         favoriteRouteRepository: favoriteRouteRepository,
+        searchHistoryRepository: searchHistoryRepository,
         internalRouteRepository: internalRouteRepository,
         notificationRepository: notificationRepository,
         notificationPermissionProvider: notificationPermissionProvider,
@@ -303,6 +308,7 @@ class _EasySubwayHome extends StatefulWidget {
     required this.favoriteRepository,
     required this.favoriteFacilityRepository,
     required this.favoriteRouteRepository,
+    required this.searchHistoryRepository,
     required this.internalRouteRepository,
     required this.notificationRepository,
     required this.notificationPermissionProvider,
@@ -324,6 +330,7 @@ class _EasySubwayHome extends StatefulWidget {
   final FavoriteStationRepository? favoriteRepository;
   final FavoriteFacilityRepository? favoriteFacilityRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
+  final SearchHistoryRepository? searchHistoryRepository;
   final InternalRouteRepository internalRouteRepository;
   final NotificationSettingsRepository? notificationRepository;
   final NotificationPermissionProvider? notificationPermissionProvider;
@@ -395,6 +402,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         favoriteRepository: widget.favoriteRepository,
         favoriteFacilityRepository: widget.favoriteFacilityRepository,
         favoriteRouteRepository: widget.favoriteRouteRepository,
+        searchHistoryRepository: widget.searchHistoryRepository,
         internalRouteRepository: widget.internalRouteRepository,
         notificationRepository: widget.notificationRepository,
         notificationPermissionProvider: widget.notificationPermissionProvider,
@@ -701,6 +709,7 @@ class HomeScreen extends StatelessWidget {
     required this.favoriteRepository,
     required this.favoriteFacilityRepository,
     required this.favoriteRouteRepository,
+    required this.searchHistoryRepository,
     required this.internalRouteRepository,
     required this.notificationRepository,
     required this.notificationPermissionProvider,
@@ -723,6 +732,7 @@ class HomeScreen extends StatelessWidget {
   final FavoriteStationRepository? favoriteRepository;
   final FavoriteFacilityRepository? favoriteFacilityRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
+  final SearchHistoryRepository? searchHistoryRepository;
   final InternalRouteRepository internalRouteRepository;
   final NotificationSettingsRepository? notificationRepository;
   final NotificationPermissionProvider? notificationPermissionProvider;
@@ -813,6 +823,7 @@ class HomeScreen extends StatelessWidget {
                       repository: repository,
                       reportRepository: reportRepository,
                       favoriteRepository: favoriteRepository,
+                      searchHistoryRepository: searchHistoryRepository,
                       locationProvider: locationProvider,
                       facilityReportDraftTargetStore:
                           facilityReportDraftTargetStore,

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -247,7 +247,10 @@ class RouteFeedbackException implements Exception {
 abstract class FavoriteRouteRepository {
   Future<List<FavoriteRoute>> listFavoriteRoutes();
 
-  Future<FavoriteRoute> saveFavoriteRoute(String routeSearchId);
+  Future<FavoriteRoute> saveFavoriteRoute(
+    String routeSearchId, {
+    RouteSearchResult? result,
+  });
 
   Future<void> removeFavoriteRoute(String favoriteRouteId);
 }
@@ -294,7 +297,10 @@ class FavoriteRouteApiRepository implements FavoriteRouteRepository {
   }
 
   @override
-  Future<FavoriteRoute> saveFavoriteRoute(String routeSearchId) async {
+  Future<FavoriteRoute> saveFavoriteRoute(
+    String routeSearchId, {
+    RouteSearchResult? result,
+  }) async {
     final data = await _requestData(
       'POST',
       baseUri.resolve('/api/v1/me/favorites/routes'),
@@ -2469,7 +2475,10 @@ class _RouteFavoriteSaveButtonState extends State<_RouteFavoriteSaveButton> {
     });
 
     try {
-      await widget.repository.saveFavoriteRoute(widget.result.routeSearchId);
+      await widget.repository.saveFavoriteRoute(
+        widget.result.routeSearchId,
+        result: widget.result,
+      );
       if (!mounted) {
         return;
       }

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -43,6 +43,12 @@ abstract class StationSearchRepository {
   Future<List<StationFacilityInfo>> listStationFacilities(String stationId);
 }
 
+abstract class SearchHistoryRepository {
+  Future<void> recordSearch(String query);
+
+  Future<List<String>> listRecentQueries();
+}
+
 abstract class StationLineFilterRepository {
   Future<List<SubwayLineOption>> listLines();
 
@@ -1234,9 +1240,13 @@ class StationSearchState {
 }
 
 class StationSearchController extends ChangeNotifier {
-  StationSearchController({required this.repository});
+  StationSearchController({
+    required this.repository,
+    this.searchHistoryRepository,
+  });
 
   final StationSearchRepository repository;
+  final SearchHistoryRepository? searchHistoryRepository;
 
   StationSearchState _state = const StationSearchState.idle();
   int _searchRequestId = 0;
@@ -1268,6 +1278,7 @@ class StationSearchController extends ChangeNotifier {
           ? await (repository as StationLineFilterRepository)
                 .searchStationsOnLine(trimmedQuery, selectedLineId)
           : await repository.searchStations(trimmedQuery);
+      await _recordSearch(trimmedQuery);
       if (!_isActiveRequest(requestId)) {
         return;
       }
@@ -1304,6 +1315,18 @@ class StationSearchController extends ChangeNotifier {
       );
     }
     _notifyIfActive(requestId);
+  }
+
+  Future<void> _recordSearch(String query) async {
+    final repository = searchHistoryRepository;
+    if (repository == null) {
+      return;
+    }
+    try {
+      await repository.recordSearch(query);
+    } catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '최근 검색어 저장 중 예외가 발생했습니다.');
+    }
   }
 
   Future<void> searchNearby(CurrentLocationProvider locationProvider) async {
@@ -1829,6 +1852,7 @@ class StationSearchScreen extends StatefulWidget {
     required this.reportRepository,
     required this.locationProvider,
     this.favoriteRepository,
+    this.searchHistoryRepository,
     this.facilityReportDraftTargetStore,
     this.internalRouteRepository,
     this.internalRouteMobilityType = 'SENIOR',
@@ -1839,6 +1863,7 @@ class StationSearchScreen extends StatefulWidget {
   final FacilityReportRepository reportRepository;
   final CurrentLocationProvider locationProvider;
   final FavoriteStationRepository? favoriteRepository;
+  final SearchHistoryRepository? searchHistoryRepository;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
   final InternalRouteRepository? internalRouteRepository;
   final String internalRouteMobilityType;
@@ -1858,7 +1883,10 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   @override
   void initState() {
     super.initState();
-    _controller = StationSearchController(repository: widget.repository);
+    _controller = StationSearchController(
+      repository: widget.repository,
+      searchHistoryRepository: widget.searchHistoryRepository,
+    );
     _queryController.addListener(_handleQueryChanged);
     final lineRepository = _lineFilterRepository;
     if (lineRepository != null) {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1278,10 +1278,10 @@ class StationSearchController extends ChangeNotifier {
           ? await (repository as StationLineFilterRepository)
                 .searchStationsOnLine(trimmedQuery, selectedLineId)
           : await repository.searchStations(trimmedQuery);
-      await _recordSearch(trimmedQuery);
       if (!_isActiveRequest(requestId)) {
         return;
       }
+      await _recordSearch(trimmedQuery);
       if (results.isEmpty) {
         _state = const StationSearchState(
           status: StationSearchStatus.empty,

--- a/apps/mobile/test/favorite_facility_test.dart
+++ b/apps/mobile/test/favorite_facility_test.dart
@@ -116,6 +116,70 @@ void main() {
     expect(authProvider.invalidateCount, 1);
   });
 
+  test('즐겨찾기 시설 API 저장소는 시설 저장과 해제를 요청한다', () async {
+    final requestedMethods = <String>[];
+    final requestedPaths = <String>[];
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestedMethods.add(request.method);
+      requestedPaths.add(request.uri.path);
+      request.response.headers.contentType = ContentType.json;
+      if (request.method == 'PUT') {
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..write(
+            jsonEncode({
+              'success': true,
+              'data': {
+                'userId': 'anonymous-user-1',
+                'facilityId': 'facility-sangnoksu-elevator-1',
+                'stationId': 'station-sangnoksu',
+                'stationNameKo': '상록수',
+                'stationNameEn': 'Sangnoksu',
+                'exitId': 'exit-sangnoksu-1',
+                'type': 'ELEVATOR',
+                'name': '1번 출구 엘리베이터',
+                'floorFrom': '1F',
+                'floorTo': 'B1',
+                'description': '1번 출구 앞',
+                'status': 'NORMAL',
+                'dataConfidence': 'HIGH',
+                'dataSourceType': 'OFFICIAL_FILE',
+                'lastUpdatedAt': '2026-06-12',
+                'addedAt': '2026-06-14T10:00:00',
+              },
+            }),
+          )
+          ..close();
+        return;
+      }
+
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..write(jsonEncode({'success': true, 'data': null}))
+        ..close();
+    });
+
+    final repository = FavoriteFacilityApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      authProvider: const NoAuthorizationHeaderProvider(),
+    );
+
+    final saved = await repository.saveFavoriteFacility(
+      'facility-sangnoksu-elevator-1',
+    );
+    await repository.removeFavoriteFacility('facility-sangnoksu-elevator-1');
+
+    expect(saved.facilityId, 'facility-sangnoksu-elevator-1');
+    expect(requestedMethods, ['PUT', 'DELETE']);
+    expect(requestedPaths, [
+      '/api/v1/me/favorites/facilities/facility-sangnoksu-elevator-1',
+      '/api/v1/me/favorites/facilities/facility-sangnoksu-elevator-1',
+    ]);
+  });
+
   test('즐겨찾기 시설 목록 컨트롤러는 목록과 빈 목록과 실패 상태를 구분한다', () async {
     final repository = FakeFavoriteFacilityRepository();
     final controller = FavoriteFacilityListController(repository: repository);
@@ -170,6 +234,28 @@ class FakeFavoriteFacilityRepository implements FavoriteFacilityRepository {
       throw currentError;
     }
     return favorites;
+  }
+
+  @override
+  Future<FavoriteFacility> saveFavoriteFacility(String facilityId) async {
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    final favorite = _favoriteFacility();
+    favorites = [favorite];
+    return favorite;
+  }
+
+  @override
+  Future<void> removeFavoriteFacility(String facilityId) async {
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    favorites = favorites
+        .where((favorite) => favorite.facilityId != facilityId)
+        .toList(growable: false);
   }
 }
 

--- a/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
+++ b/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
@@ -119,12 +119,77 @@ void main() {
     final favorites = await repository.listFavoriteRoutes();
 
     expect(saved.summaryTitle, '상록수에서 사당까지');
+    expect(saved.routeSearchId, result.routeSearchId);
     expect(favorites.single.lineName, '수도권 4호선');
     expect(favorites.single.score, 92);
 
-    await repository.removeFavoriteRoute(result.routeSearchId);
+    await repository.removeFavoriteRoute(saved.favoriteRouteId);
 
     expect(await repository.listFavoriteRoutes(), isEmpty);
+  });
+
+  test('로컬 경로 즐겨찾기는 같은 구간도 이동 조건별로 분리해 저장한다', () async {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+    await catalogDatabase.seedBaselineIfEmpty();
+    final repository = DriftFavoriteRouteRepository(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+    );
+    final seniorResult = RouteSearchResult(
+      routeSearchId: 'local-station-sangnoksu-station-sadang',
+      originStationId: 'station-sangnoksu',
+      originStationName: '상록수',
+      destinationStationId: 'station-sadang',
+      destinationStationName: '사당',
+      mobilityType: 'SENIOR',
+      status: 'FOUND',
+      lineId: 'seoul-4',
+      lineName: '수도권 4호선',
+      score: 92,
+      steps: const [],
+      warnings: const [],
+      blockedReasons: const [],
+      createdAt: '2026-06-19T09:00:00.000Z',
+    );
+    final wheelchairResult = RouteSearchResult(
+      routeSearchId: 'local-station-sangnoksu-station-sadang',
+      originStationId: 'station-sangnoksu',
+      originStationName: '상록수',
+      destinationStationId: 'station-sadang',
+      destinationStationName: '사당',
+      mobilityType: 'WHEELCHAIR',
+      status: 'FOUND',
+      lineId: 'seoul-4',
+      lineName: '수도권 4호선',
+      score: 88,
+      steps: const [],
+      warnings: const [],
+      blockedReasons: const [],
+      createdAt: '2026-06-19T09:01:00.000Z',
+    );
+
+    await repository.saveFavoriteRoute(
+      seniorResult.routeSearchId,
+      result: seniorResult,
+    );
+    await repository.saveFavoriteRoute(
+      wheelchairResult.routeSearchId,
+      result: wheelchairResult,
+    );
+    final favorites = await repository.listFavoriteRoutes();
+
+    expect(favorites, hasLength(2));
+    expect(favorites.map((favorite) => favorite.mobilityType).toSet(), {
+      'SENIOR',
+      'WHEELCHAIR',
+    });
+    expect(
+      favorites.map((favorite) => favorite.favoriteRouteId).toSet(),
+      hasLength(2),
+    );
   });
 
   test('로컬 알림 설정과 최근 검색은 app_preferences와 search_history에 보관한다', () async {

--- a/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
+++ b/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
@@ -1,0 +1,272 @@
+import 'package:easysubway_mobile/app/app_dependencies.dart';
+import 'package:easysubway_mobile/anonymous_auth.dart';
+import 'package:easysubway_mobile/core/database/catalog/catalog_database.dart';
+import 'package:easysubway_mobile/core/database/user/user_database.dart'
+    as user_db;
+import 'package:easysubway_mobile/features/favorites/data/drift_favorite_repositories.dart';
+import 'package:easysubway_mobile/features/preferences/data/drift_notification_settings_repository.dart';
+import 'package:easysubway_mobile/features/search_history/data/drift_search_history_repository.dart';
+import 'package:easysubway_mobile/route_search.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('로컬 역 즐겨찾기는 user DB에 저장하고 catalog DB 정보로 목록을 만든다', () async {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+    await catalogDatabase.seedBaselineIfEmpty();
+    final repository = DriftFavoriteStationRepository(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+    );
+
+    final saved = await repository.saveFavoriteStation('station-sangnoksu');
+    final favorites = await repository.listFavoriteStations();
+
+    expect(saved.stationId, 'station-sangnoksu');
+    expect(favorites.single.nameKo, '상록수');
+    expect(favorites.single.lines.single.name, '수도권 4호선');
+
+    await repository.removeFavoriteStation('station-sangnoksu');
+
+    expect(await repository.listFavoriteStations(), isEmpty);
+  });
+
+  test('로컬 시설 즐겨찾기는 데이터팩 catalog 정보와 user DB 보관 시간을 조합한다', () async {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+    await catalogDatabase.seedBaselineIfEmpty();
+    await userDatabase
+        .into(userDatabase.favoriteFacilities)
+        .insert(
+          user_db.FavoriteFacilitiesCompanion.insert(
+            facilityId: 'facility-sangnoksu-elevator-1',
+            stationId: 'station-sangnoksu',
+            addedAt: DateTime.utc(2026, 6, 19, 9),
+          ),
+        );
+    final repository = DriftFavoriteFacilityRepository(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+    );
+
+    final favorites = await repository.listFavoriteFacilities();
+
+    expect(favorites.single.facilityId, 'facility-sangnoksu-elevator-1');
+    expect(favorites.single.stationNameKo, '상록수');
+    expect(favorites.single.name, '1번 출구 엘리베이터');
+    expect(favorites.single.addedAt, '2026-06-19T09:00:00.000Z');
+  });
+
+  test('로컬 시설 즐겨찾기는 시설 id로 저장하고 삭제한다', () async {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+    await catalogDatabase.seedBaselineIfEmpty();
+    final repository = DriftFavoriteFacilityRepository(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+    );
+
+    final saved = await repository.saveFavoriteFacility(
+      'facility-sangnoksu-elevator-1',
+    );
+    final favorites = await repository.listFavoriteFacilities();
+
+    expect(saved.facilityId, 'facility-sangnoksu-elevator-1');
+    expect(favorites.single.name, '1번 출구 엘리베이터');
+
+    await repository.removeFavoriteFacility('facility-sangnoksu-elevator-1');
+
+    expect(await repository.listFavoriteFacilities(), isEmpty);
+  });
+
+  test('로컬 경로 즐겨찾기는 검색 결과 요약을 user DB에 저장하고 삭제한다', () async {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+    await catalogDatabase.seedBaselineIfEmpty();
+    final repository = DriftFavoriteRouteRepository(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+    );
+    final result = RouteSearchResult(
+      routeSearchId: 'local-station-sangnoksu-station-sadang',
+      originStationId: 'station-sangnoksu',
+      originStationName: '상록수',
+      destinationStationId: 'station-sadang',
+      destinationStationName: '사당',
+      mobilityType: 'SENIOR',
+      status: 'FOUND',
+      lineId: 'seoul-4',
+      lineName: '수도권 4호선',
+      score: 92,
+      steps: const [],
+      warnings: const [],
+      blockedReasons: const [],
+      createdAt: '2026-06-19T09:00:00.000Z',
+    );
+
+    final saved = await repository.saveFavoriteRoute(
+      result.routeSearchId,
+      result: result,
+    );
+    final favorites = await repository.listFavoriteRoutes();
+
+    expect(saved.summaryTitle, '상록수에서 사당까지');
+    expect(favorites.single.lineName, '수도권 4호선');
+    expect(favorites.single.score, 92);
+
+    await repository.removeFavoriteRoute(result.routeSearchId);
+
+    expect(await repository.listFavoriteRoutes(), isEmpty);
+  });
+
+  test('로컬 알림 설정과 최근 검색은 app_preferences와 search_history에 보관한다', () async {
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final notificationRepository = DriftNotificationSettingsRepository(
+      userDatabase: userDatabase,
+    );
+    final searchHistoryRepository = DriftSearchHistoryRepository(
+      userDatabase: userDatabase,
+      maxEntries: 2,
+    );
+
+    final defaultSettings = await notificationRepository
+        .getNotificationSettings();
+    final savedSettings = await notificationRepository.saveNotificationSettings(
+      defaultSettings.copyWith(
+        favoriteStationFacilityAlerts: true,
+        favoriteRouteFacilityAlerts: true,
+      ),
+    );
+    await searchHistoryRepository.recordSearch(' 상록수 ');
+    await searchHistoryRepository.recordSearch('사당');
+    await searchHistoryRepository.recordSearch('상록수');
+
+    expect(defaultSettings.userId, 'local-user');
+    expect(savedSettings.favoriteStationFacilityAlerts, isTrue);
+    expect(
+      (await notificationRepository.getNotificationSettings())
+          .favoriteRouteFacilityAlerts,
+      isTrue,
+    );
+    expect(await searchHistoryRepository.listRecentQueries(), ['상록수', '사당']);
+  });
+
+  test('앱 기본 의존성은 user DB가 있으면 개인 데이터 API와 익명 인증을 만들지 않는다', () async {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+
+    final dependencies = AppDependencies.resolve(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+      enableAnonymousAuth: false,
+      enablePushNotifications: false,
+    );
+
+    expect(
+      dependencies.favoriteRepository,
+      isA<DriftFavoriteStationRepository>(),
+    );
+    expect(
+      dependencies.favoriteFacilityRepository,
+      isA<DriftFavoriteFacilityRepository>(),
+    );
+    expect(
+      dependencies.favoriteRouteRepository,
+      isA<DriftFavoriteRouteRepository>(),
+    );
+    expect(dependencies.anonymousAuthSession, isNull);
+  });
+
+  test('즐겨찾기 저장과 조회는 익명 인증 발급 없이 user DB만 사용한다', () async {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    final anonymousAuthRepository = CountingAnonymousAuthRepository();
+    final anonymousAuthStore = CountingAnonymousAuthCredentialStore();
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+    await catalogDatabase.seedBaselineIfEmpty();
+
+    final dependencies = AppDependencies.resolve(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+      anonymousAuthRepository: anonymousAuthRepository,
+      anonymousAuthCredentialStore: anonymousAuthStore,
+      enableAnonymousAuth: true,
+      enablePushNotifications: false,
+    );
+
+    await dependencies.favoriteRepository!.saveFavoriteStation(
+      'station-sangnoksu',
+    );
+    await dependencies.favoriteRepository!.listFavoriteStations();
+
+    expect(anonymousAuthRepository.issueCount, 0);
+    expect(anonymousAuthRepository.refreshCount, 0);
+    expect(anonymousAuthStore.readCount, 0);
+    expect(anonymousAuthStore.writeCount, 0);
+  });
+}
+
+class CountingAnonymousAuthRepository implements AnonymousAuthRepository {
+  int issueCount = 0;
+  int refreshCount = 0;
+
+  @override
+  bool get canReuseStoredCredentials => true;
+
+  @override
+  Future<AnonymousAuthCredentials> issueAnonymousUser() async {
+    issueCount++;
+    return const AnonymousAuthCredentials(
+      userId: 'guest-user',
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    );
+  }
+
+  @override
+  Future<AnonymousAuthCredentials> refreshAnonymousUser(
+    String refreshToken,
+  ) async {
+    refreshCount++;
+    return const AnonymousAuthCredentials(
+      userId: 'guest-user',
+      accessToken: 'refreshed-access-token',
+      refreshToken: 'refreshed-refresh-token',
+    );
+  }
+}
+
+class CountingAnonymousAuthCredentialStore
+    implements AnonymousAuthCredentialStore {
+  int readCount = 0;
+  int writeCount = 0;
+  int clearCount = 0;
+
+  @override
+  Future<AnonymousAuthCredentials?> readCredentials() async {
+    readCount++;
+    return null;
+  }
+
+  @override
+  Future<void> saveCredentials(AnonymousAuthCredentials credentials) async {
+    writeCount++;
+  }
+
+  @override
+  Future<void> clearCredentials() async {
+    clearCount++;
+  }
+}

--- a/apps/mobile/test/features/settings/drift_notification_settings_repository_test.dart
+++ b/apps/mobile/test/features/settings/drift_notification_settings_repository_test.dart
@@ -1,0 +1,45 @@
+import 'package:easysubway_mobile/core/database/user/user_database.dart'
+    as user_db;
+import 'package:easysubway_mobile/features/preferences/data/drift_notification_settings_repository.dart';
+import 'package:easysubway_mobile/features/search_history/data/drift_search_history_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('로컬 알림 설정은 user DB app_preferences에 저장된다', () async {
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final repository = DriftNotificationSettingsRepository(
+      userDatabase: userDatabase,
+    );
+
+    final defaultSettings = await repository.getNotificationSettings();
+    final savedSettings = await repository.saveNotificationSettings(
+      defaultSettings.copyWith(
+        favoriteStationFacilityAlerts: true,
+        favoriteRouteFacilityAlerts: true,
+      ),
+    );
+
+    expect(defaultSettings.userId, 'local-user');
+    expect(savedSettings.favoriteStationFacilityAlerts, isTrue);
+    expect(
+      (await repository.getNotificationSettings()).favoriteRouteFacilityAlerts,
+      isTrue,
+    );
+  });
+
+  test('최근 검색은 중복 검색어를 최신순으로 보관하고 최대 개수를 지킨다', () async {
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final repository = DriftSearchHistoryRepository(
+      userDatabase: userDatabase,
+      maxEntries: 2,
+    );
+
+    await repository.recordSearch(' 상록수 ');
+    await repository.recordSearch('사당');
+    await repository.recordSearch('상록수');
+
+    expect(await repository.listRecentQueries(), ['상록수', '사당']);
+  });
+}

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -855,6 +855,21 @@ void main() {
     expect(controller.state.status, StationSearchStatus.success);
   });
 
+  test('역 검색 컨트롤러는 검색어를 로컬 최근 검색 저장소에 기록한다', () async {
+    final repository = FakeStationSearchRepository()
+      ..nextResults = [_stationResult(id: 'station-sangnoksu', name: '상록수')];
+    final historyRepository = FakeSearchHistoryRepository();
+    final controller = StationSearchController(
+      repository: repository,
+      searchHistoryRepository: historyRepository,
+    );
+
+    await controller.search(' 상록수 ');
+
+    expect(repository.requestedQueries, ['상록수']);
+    expect(historyRepository.recordedQueries, ['상록수']);
+  });
+
   test('역 검색 컨트롤러는 늦게 도착한 이전 응답을 무시한다', () async {
     final repository = ControlledStationSearchRepository();
     final controller = StationSearchController(repository: repository);
@@ -1380,6 +1395,20 @@ class ControlledStationSearchRepository implements StationSearchRepository {
       throw StateError('Pending search not found: $query');
     }
     completer.complete(results);
+  }
+}
+
+class FakeSearchHistoryRepository implements SearchHistoryRepository {
+  final recordedQueries = <String>[];
+
+  @override
+  Future<void> recordSearch(String query) async {
+    recordedQueries.add(query);
+  }
+
+  @override
+  Future<List<String>> listRecentQueries() async {
+    return recordedQueries.reversed.toList(growable: false);
   }
 }
 

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -896,6 +896,29 @@ void main() {
     expect(controller.state.results.single.nameKo, '강남');
   });
 
+  test('역 검색 컨트롤러는 늦게 도착한 이전 검색어를 최근 검색에 기록하지 않는다', () async {
+    final repository = ControlledStationSearchRepository();
+    final historyRepository = FakeSearchHistoryRepository();
+    final controller = StationSearchController(
+      repository: repository,
+      searchHistoryRepository: historyRepository,
+    );
+
+    final firstSearch = controller.search('상록수');
+    final secondSearch = controller.search('강남');
+
+    repository.complete('강남', [
+      _stationResult(id: 'station-gangnam', name: '강남'),
+    ]);
+    await secondSearch;
+    repository.complete('상록수', [
+      _stationResult(id: 'station-sangnoksu', name: '상록수'),
+    ]);
+    await firstSearch;
+
+    expect(historyRepository.recordedQueries, ['강남']);
+  });
+
   test('역 검색 컨트롤러는 빈 결과와 실패 상태를 표시한다', () async {
     final repository = FakeStationSearchRepository();
     final controller = StationSearchController(repository: repository);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -6224,6 +6224,28 @@ class FakeFavoriteFacilityRepository implements FavoriteFacilityRepository {
     }
     return favorites;
   }
+
+  @override
+  Future<FavoriteFacility> saveFavoriteFacility(String facilityId) async {
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    final favorite = _favoriteFacility();
+    favorites = [favorite];
+    return favorite;
+  }
+
+  @override
+  Future<void> removeFavoriteFacility(String facilityId) async {
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    favorites = favorites
+        .where((favorite) => favorite.facilityId != facilityId)
+        .toList(growable: false);
+  }
 }
 
 class FakeFavoriteRouteRepository implements FavoriteRouteRepository {
@@ -6248,7 +6270,10 @@ class FakeFavoriteRouteRepository implements FavoriteRouteRepository {
   }
 
   @override
-  Future<FavoriteRoute> saveFavoriteRoute(String routeSearchId) async {
+  Future<FavoriteRoute> saveFavoriteRoute(
+    String routeSearchId, {
+    RouteSearchResult? result,
+  }) async {
     savedRouteSearchIds.add(routeSearchId);
     final currentError = error;
     if (currentError != null) {


### PR DESCRIPTION
## 관련 이슈

close #505

## 작업 배경

- 즐겨찾기 역, 시설, 경로와 최근 검색, 알림 설정은 사용자 개인 데이터라 서버 계정 API 없이 앱 내부 `user.db`에 유지해야 한다.
- 데이터팩은 교체될 수 있으므로 개인 데이터는 `catalog.db`와 분리해 보관하고, 목록 조회 시 현재 catalog 정보와 조합한다.

## 작업 내용

- `AppBootstrap`에서 이미 열고 있던 `user.db`를 앱 의존성 구성에 전달했다.
- 역/시설/경로 즐겨찾기 Drift 저장소를 추가해 `favorite_stations`, `favorite_facilities`, `favorite_routes`, `app_preferences`를 사용하도록 연결했다.
- 경로 즐겨찾기 저장 시 현재 검색 결과 요약과 catalog 버전을 snapshot으로 보관해 데이터팩 교체 후에도 목록 표시 정보를 유지한다.
- 같은 출발/도착 구간도 이동 조건별로 즐겨찾기 경로가 분리 저장되도록 로컬 route key를 보강했다.
- 알림 설정은 push가 켜진 경우에도 `app_preferences` 기반 로컬 저장소를 우선 사용하도록 했다.
- 역 검색 컨트롤러에 최근 검색 기록 저장소를 연결하고, 늦게 완료된 이전 검색 요청은 최근 검색에 기록하지 않도록 했다.
- 앱 내 데이터 삭제 요청이 `user.db`의 즐겨찾기, 최근 검색, 앱 설정, 신고 임시 데이터를 함께 비우도록 로컬 삭제 저장소를 연결했다.
- 시설 즐겨찾기 저장/삭제 계약과 API 저장소 구현을 보강해 로컬/서버 저장소 인터페이스를 맞췄다.

## 검증

- 실행한 명령과 결과:
  - `flutter test` 성공
  - `flutter analyze` 성공
  - `node --test tools/ci/*.test.mjs` 성공
  - `flutter build apk --debug` 성공
  - iOS Simulator `Runner` build/run 성공, Dynamic Type 큰 글씨에서 즐겨찾기 목록 overflow 없음 확인
  - Android emulator `maum_on_api36` 설치/실행 성공, 앱 재시작 후 `user.db`에 저장된 `상록수` 즐겨찾기 역 표시 확인
  - PR CI: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI, Dependency Vulnerability Scan 성공
  - PR Release Artifacts: Android Release Artifact, iOS Release Artifact, Backend Release Image 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `AppDependencies.resolve`가 `catalogDatabase + userDatabase` 조합에서 개인 데이터 저장소를 API 대신 Drift 구현으로 선택하는 흐름
  - `DriftFavoriteRouteRepository`의 경로 snapshot 저장 방식과 이동 조건별 route key
  - 최근 검색 기록이 정상 검색 흐름에서만 저장되고 오래된 요청은 무시되는 동작
  - `UserDataDeletionLocalRepository`가 앱 내 삭제 요청에서 `user.db` 개인 데이터 테이블을 비우는 범위

## 리스크

- 시설 즐겨찾기 저장/삭제 API 경로를 인터페이스에 맞춰 추가했으므로, 서버 계약과 경로가 달라지면 API 저장소만 조정이 필요하다.
- 최근 검색 UI 노출은 아직 없고, 이번 변경은 검색어 저장 경로와 로컬 조회 저장소까지만 포함한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
