### PR TITLE
[Fix] 로컬 사용자 데이터 삭제 누락 수정

### DIFF
--- a/apps/mobile/lib/app/app_dependencies.dart
+++ b/apps/mobile/lib/app/app_dependencies.dart
@@ -165,10 +165,12 @@ class AppDependencies {
           locationProvider ?? MethodChannelCurrentLocationProvider(),
       userDataDeletionRepository:
           userDataDeletionRepository ??
-          _defaultUserDataDeletionRepository(
-            baseUri: baseUri,
-            authProvider: sharedAuthProvider,
-          ),
+          (userDatabase != null
+              ? UserDataDeletionLocalRepository(userDatabase: userDatabase)
+              : _defaultUserDataDeletionRepository(
+                  baseUri: baseUri,
+                  authProvider: sharedAuthProvider,
+                )),
       anonymousAuthSession: anonymousAuthSession,
     );
   }

--- a/apps/mobile/lib/app/app_dependencies.dart
+++ b/apps/mobile/lib/app/app_dependencies.dart
@@ -165,12 +165,11 @@ class AppDependencies {
           locationProvider ?? MethodChannelCurrentLocationProvider(),
       userDataDeletionRepository:
           userDataDeletionRepository ??
-          (userDatabase != null
-              ? UserDataDeletionLocalRepository(userDatabase: userDatabase)
-              : _defaultUserDataDeletionRepository(
-                  baseUri: baseUri,
-                  authProvider: sharedAuthProvider,
-                )),
+          _defaultUserDataDeletionRepository(
+            baseUri: baseUri,
+            authProvider: sharedAuthProvider,
+            userDatabase: userDatabase,
+          ),
       anonymousAuthSession: anonymousAuthSession,
     );
   }
@@ -210,17 +209,27 @@ AnonymousAuthSession? _defaultAnonymousAuthSession({
 UserDataDeletionRepository? _defaultUserDataDeletionRepository({
   required Uri baseUri,
   required AuthorizationHeaderProvider? authProvider,
+  required UserDatabase? userDatabase,
 }) {
-  if (authProvider == null) {
-    return null;
+  final localRepository = userDatabase == null
+      ? null
+      : UserDataDeletionLocalRepository(userDatabase: userDatabase);
+  final remoteRepository = authProvider == null
+      ? null
+      : UserDataDeletionApiRepository(
+          baseUri: baseUri,
+          authProvider: authProvider,
+          refreshExistingAuthorization: authProvider is AnonymousAuthSession
+              ? authProvider.refreshExistingAuthorization
+              : null,
+        );
+  if (remoteRepository != null && localRepository != null) {
+    return UserDataDeletionCompositeRepository(
+      remoteRepository: remoteRepository,
+      localRepository: localRepository,
+    );
   }
-  return UserDataDeletionApiRepository(
-    baseUri: baseUri,
-    authProvider: authProvider,
-    refreshExistingAuthorization: authProvider is AnonymousAuthSession
-        ? authProvider.refreshExistingAuthorization
-        : null,
-  );
+  return remoteRepository ?? localRepository;
 }
 
 FavoriteStationRepository? _defaultFavoriteStationRepository({

--- a/apps/mobile/lib/user_data_deletion.dart
+++ b/apps/mobile/lib/user_data_deletion.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'auth_headers.dart';
+import 'core/database/user/user_database.dart';
 import 'mobile_error_reporter.dart';
 
 const userDataDeletionErrorMessage = '데이터 삭제를 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.';
@@ -90,6 +91,67 @@ class UserDataDeletionApiRepository implements UserDataDeletionRepository {
       return false;
     }
     return refresh(authorizationHeader);
+  }
+}
+
+class UserDataDeletionLocalRepository implements UserDataDeletionRepository {
+  UserDataDeletionLocalRepository({required this.userDatabase});
+
+  final UserDatabase userDatabase;
+
+  @override
+  Future<UserDataDeletionResult> deleteCurrentUserData() async {
+    try {
+      late final int deletedFavoriteStationCount;
+      late final int deletedFavoriteFacilityCount;
+      late final int deletedFavoriteRouteCount;
+      late final int deletedAppPreferenceCount;
+      late final int deletedReportReceiptCount;
+      late final int deletedReportDraftCount;
+      await userDatabase.transaction(() async {
+        deletedFavoriteStationCount = await userDatabase
+            .delete(userDatabase.favoriteStations)
+            .go();
+        deletedFavoriteFacilityCount = await userDatabase
+            .delete(userDatabase.favoriteFacilities)
+            .go();
+        deletedFavoriteRouteCount = await userDatabase
+            .delete(userDatabase.favoriteRoutes)
+            .go();
+        await userDatabase.delete(userDatabase.searchHistory).go();
+        deletedAppPreferenceCount = await userDatabase
+            .delete(userDatabase.appPreferences)
+            .go();
+        deletedReportReceiptCount = await userDatabase
+            .delete(userDatabase.reportReceipts)
+            .go();
+        deletedReportDraftCount = await userDatabase
+            .delete(userDatabase.reportDrafts)
+            .go();
+      });
+
+      return UserDataDeletionResult(
+        userId: 'local-user',
+        deletedFavoriteStationCount: deletedFavoriteStationCount,
+        deletedFavoriteFacilityCount: deletedFavoriteFacilityCount,
+        deletedFavoriteRouteCount: deletedFavoriteRouteCount,
+        anonymizedRouteFeedbackCount: 0,
+        notificationSettingsDeleted: deletedAppPreferenceCount > 0,
+        deletedRegisteredDeviceCount: 0,
+        deletedPushNotificationCount: 0,
+        mobilityProfileDeleted: false,
+        anonymizedReportCount:
+            deletedReportReceiptCount + deletedReportDraftCount,
+        anonymousCredentialsDeleted: false,
+      );
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '로컬 사용자 데이터 삭제 처리 중 예외가 발생했습니다.',
+      );
+      throw const UserDataDeletionException(userDataDeletionErrorMessage);
+    }
   }
 }
 

--- a/apps/mobile/lib/user_data_deletion.dart
+++ b/apps/mobile/lib/user_data_deletion.dart
@@ -155,6 +155,56 @@ class UserDataDeletionLocalRepository implements UserDataDeletionRepository {
   }
 }
 
+class UserDataDeletionCompositeRepository
+    implements UserDataDeletionRepository {
+  UserDataDeletionCompositeRepository({
+    required this.remoteRepository,
+    required this.localRepository,
+  });
+
+  final UserDataDeletionRepository remoteRepository;
+  final UserDataDeletionRepository localRepository;
+
+  @override
+  Future<UserDataDeletionResult> deleteCurrentUserData() async {
+    final remoteResult = await remoteRepository.deleteCurrentUserData();
+    final localResult = await localRepository.deleteCurrentUserData();
+    return UserDataDeletionResult(
+      userId: remoteResult.userId,
+      deletedFavoriteStationCount:
+          remoteResult.deletedFavoriteStationCount +
+          localResult.deletedFavoriteStationCount,
+      deletedFavoriteFacilityCount:
+          remoteResult.deletedFavoriteFacilityCount +
+          localResult.deletedFavoriteFacilityCount,
+      deletedFavoriteRouteCount:
+          remoteResult.deletedFavoriteRouteCount +
+          localResult.deletedFavoriteRouteCount,
+      anonymizedRouteFeedbackCount:
+          remoteResult.anonymizedRouteFeedbackCount +
+          localResult.anonymizedRouteFeedbackCount,
+      notificationSettingsDeleted:
+          remoteResult.notificationSettingsDeleted ||
+          localResult.notificationSettingsDeleted,
+      deletedRegisteredDeviceCount:
+          remoteResult.deletedRegisteredDeviceCount +
+          localResult.deletedRegisteredDeviceCount,
+      deletedPushNotificationCount:
+          remoteResult.deletedPushNotificationCount +
+          localResult.deletedPushNotificationCount,
+      mobilityProfileDeleted:
+          remoteResult.mobilityProfileDeleted ||
+          localResult.mobilityProfileDeleted,
+      anonymizedReportCount:
+          remoteResult.anonymizedReportCount +
+          localResult.anonymizedReportCount,
+      anonymousCredentialsDeleted:
+          remoteResult.anonymousCredentialsDeleted ||
+          localResult.anonymousCredentialsDeleted,
+    );
+  }
+}
+
 class UserDataDeletionResult {
   const UserDataDeletionResult({
     required this.userId,

--- a/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
+++ b/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
@@ -281,6 +281,10 @@ void main() {
     );
     await dependencies.favoriteRepository!.listFavoriteStations();
 
+    expect(
+      dependencies.userDataDeletionRepository,
+      isA<UserDataDeletionCompositeRepository>(),
+    );
     expect(anonymousAuthRepository.issueCount, 0);
     expect(anonymousAuthRepository.refreshCount, 0);
     expect(anonymousAuthStore.readCount, 0);

--- a/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
+++ b/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
@@ -7,6 +7,7 @@ import 'package:easysubway_mobile/features/favorites/data/drift_favorite_reposit
 import 'package:easysubway_mobile/features/preferences/data/drift_notification_settings_repository.dart';
 import 'package:easysubway_mobile/features/search_history/data/drift_search_history_repository.dart';
 import 'package:easysubway_mobile/route_search.dart';
+import 'package:easysubway_mobile/user_data_deletion.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -249,6 +250,10 @@ void main() {
     expect(
       dependencies.favoriteRouteRepository,
       isA<DriftFavoriteRouteRepository>(),
+    );
+    expect(
+      dependencies.userDataDeletionRepository,
+      isA<UserDataDeletionLocalRepository>(),
     );
     expect(dependencies.anonymousAuthSession, isNull);
   });

--- a/apps/mobile/test/user_data_deletion_test.dart
+++ b/apps/mobile/test/user_data_deletion_test.dart
@@ -289,6 +289,100 @@ void main() {
     );
     expect(await userDatabase.select(userDatabase.reportDrafts).get(), isEmpty);
   });
+
+  test('합성 사용자 데이터 삭제 저장소는 서버 삭제 성공 후 로컬 삭제를 실행한다', () async {
+    final calls = <String>[];
+    final remoteRepository = RecordingUserDataDeletionRepository(
+      label: 'remote',
+      calls: calls,
+      result: const UserDataDeletionResult(
+        userId: 'anonymous-user-1',
+        deletedFavoriteStationCount: 1,
+        deletedFavoriteFacilityCount: 1,
+        deletedFavoriteRouteCount: 1,
+        anonymizedRouteFeedbackCount: 2,
+        notificationSettingsDeleted: false,
+        deletedRegisteredDeviceCount: 1,
+        deletedPushNotificationCount: 1,
+        mobilityProfileDeleted: true,
+        anonymizedReportCount: 3,
+        anonymousCredentialsDeleted: true,
+      ),
+    );
+    final localRepository = RecordingUserDataDeletionRepository(
+      label: 'local',
+      calls: calls,
+      result: const UserDataDeletionResult(
+        userId: 'local-user',
+        deletedFavoriteStationCount: 4,
+        deletedFavoriteFacilityCount: 5,
+        deletedFavoriteRouteCount: 6,
+        anonymizedRouteFeedbackCount: 0,
+        notificationSettingsDeleted: true,
+        deletedRegisteredDeviceCount: 0,
+        deletedPushNotificationCount: 0,
+        mobilityProfileDeleted: false,
+        anonymizedReportCount: 1,
+        anonymousCredentialsDeleted: false,
+      ),
+    );
+    final repository = UserDataDeletionCompositeRepository(
+      remoteRepository: remoteRepository,
+      localRepository: localRepository,
+    );
+
+    final result = await repository.deleteCurrentUserData();
+
+    expect(calls, ['remote', 'local']);
+    expect(result.userId, 'anonymous-user-1');
+    expect(result.deletedFavoriteStationCount, 5);
+    expect(result.deletedFavoriteFacilityCount, 6);
+    expect(result.deletedFavoriteRouteCount, 7);
+    expect(result.anonymizedRouteFeedbackCount, 2);
+    expect(result.notificationSettingsDeleted, isTrue);
+    expect(result.deletedRegisteredDeviceCount, 1);
+    expect(result.deletedPushNotificationCount, 1);
+    expect(result.mobilityProfileDeleted, isTrue);
+    expect(result.anonymizedReportCount, 4);
+    expect(result.anonymousCredentialsDeleted, isTrue);
+  });
+
+  test('합성 사용자 데이터 삭제 저장소는 서버 삭제 실패 시 로컬 데이터를 유지한다', () async {
+    final calls = <String>[];
+    final remoteRepository = RecordingUserDataDeletionRepository(
+      label: 'remote',
+      calls: calls,
+      error: const UserDataDeletionException(userDataDeletionErrorMessage),
+    );
+    final localRepository = RecordingUserDataDeletionRepository(
+      label: 'local',
+      calls: calls,
+      result: const UserDataDeletionResult(
+        userId: 'local-user',
+        deletedFavoriteStationCount: 1,
+        deletedFavoriteFacilityCount: 1,
+        deletedFavoriteRouteCount: 1,
+        anonymizedRouteFeedbackCount: 0,
+        notificationSettingsDeleted: true,
+        deletedRegisteredDeviceCount: 0,
+        deletedPushNotificationCount: 0,
+        mobilityProfileDeleted: false,
+        anonymizedReportCount: 0,
+        anonymousCredentialsDeleted: false,
+      ),
+    );
+    final repository = UserDataDeletionCompositeRepository(
+      remoteRepository: remoteRepository,
+      localRepository: localRepository,
+    );
+
+    await expectLater(
+      repository.deleteCurrentUserData(),
+      throwsA(isA<UserDataDeletionException>()),
+    );
+
+    expect(calls, ['remote']);
+  });
 }
 
 String _successfulDeletionBody() {
@@ -353,5 +447,30 @@ class RefreshingAuthorizationHeaderProvider
     }
     header = refreshedHeader;
     return true;
+  }
+}
+
+class RecordingUserDataDeletionRepository
+    implements UserDataDeletionRepository {
+  RecordingUserDataDeletionRepository({
+    required this.label,
+    required this.calls,
+    this.result,
+    this.error,
+  });
+
+  final String label;
+  final List<String> calls;
+  final UserDataDeletionResult? result;
+  final UserDataDeletionException? error;
+
+  @override
+  Future<UserDataDeletionResult> deleteCurrentUserData() async {
+    calls.add(label);
+    final currentError = error;
+    if (currentError != null) {
+      throw currentError;
+    }
+    return result!;
   }
 }

--- a/apps/mobile/test/user_data_deletion_test.dart
+++ b/apps/mobile/test/user_data_deletion_test.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:easysubway_mobile/auth_headers.dart';
+import 'package:easysubway_mobile/core/database/user/user_database.dart'
+    as user_db;
 import 'package:easysubway_mobile/user_data_deletion.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -183,6 +185,109 @@ void main() {
         ),
       ),
     );
+  });
+
+  test('로컬 사용자 데이터 삭제 저장소는 user DB 개인 데이터를 비운다', () async {
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final now = DateTime.utc(2026, 6, 19, 9);
+    await userDatabase
+        .into(userDatabase.favoriteStations)
+        .insert(
+          user_db.FavoriteStationsCompanion.insert(
+            stationId: 'station-sangnoksu',
+            addedAt: now,
+          ),
+        );
+    await userDatabase
+        .into(userDatabase.favoriteFacilities)
+        .insert(
+          user_db.FavoriteFacilitiesCompanion.insert(
+            facilityId: 'facility-sangnoksu-elevator-1',
+            stationId: 'station-sangnoksu',
+            addedAt: now,
+          ),
+        );
+    await userDatabase
+        .into(userDatabase.favoriteRoutes)
+        .insert(
+          user_db.FavoriteRoutesCompanion.insert(
+            routeId: 'local-station-sangnoksu-station-sadang::SENIOR',
+            originStationId: 'station-sangnoksu',
+            destinationStationId: 'station-sadang',
+            mobilityProfile: 'SENIOR',
+            addedAt: now,
+          ),
+        );
+    await userDatabase
+        .into(userDatabase.searchHistory)
+        .insert(
+          user_db.SearchHistoryCompanion.insert(query: '상록수', searchedAt: now),
+        );
+    await userDatabase
+        .into(userDatabase.appPreferences)
+        .insert(
+          user_db.AppPreferencesCompanion.insert(
+            key: 'notification_settings',
+            value: '{}',
+            updatedAt: now,
+          ),
+        );
+    await userDatabase
+        .into(userDatabase.reportReceipts)
+        .insert(
+          user_db.ReportReceiptsCompanion.insert(
+            receiptId: 'receipt-1',
+            status: 'SUBMITTED',
+            createdAt: now,
+          ),
+        );
+    await userDatabase
+        .into(userDatabase.reportDrafts)
+        .insert(
+          user_db.ReportDraftsCompanion.insert(
+            draftId: 'draft-1',
+            payloadJson: '{}',
+            updatedAt: now,
+          ),
+        );
+    final repository = UserDataDeletionLocalRepository(
+      userDatabase: userDatabase,
+    );
+
+    final result = await repository.deleteCurrentUserData();
+
+    expect(result.userId, 'local-user');
+    expect(result.deletedFavoriteStationCount, 1);
+    expect(result.deletedFavoriteFacilityCount, 1);
+    expect(result.deletedFavoriteRouteCount, 1);
+    expect(result.notificationSettingsDeleted, isTrue);
+    expect(result.anonymizedReportCount, 2);
+    expect(
+      await userDatabase.select(userDatabase.favoriteStations).get(),
+      isEmpty,
+    );
+    expect(
+      await userDatabase.select(userDatabase.favoriteFacilities).get(),
+      isEmpty,
+    );
+    expect(
+      await userDatabase.select(userDatabase.favoriteRoutes).get(),
+      isEmpty,
+    );
+    expect(
+      await userDatabase.select(userDatabase.searchHistory).get(),
+      isEmpty,
+    );
+    expect(
+      await userDatabase.select(userDatabase.appPreferences).get(),
+      isEmpty,
+    );
+    expect(
+      await userDatabase.select(userDatabase.reportReceipts).get(),
+      isEmpty,
+    );
+    expect(await userDatabase.select(userDatabase.reportDrafts).get(), isEmpty);
   });
 }
 


### PR DESCRIPTION
## 관련 이슈

close #507

## 작업 배경

- 개인 데이터가 앱 로컬 DB에 저장되는 기본 구성에서 도움말의 데이터 삭제가 서버 사용자 데이터와 `user.db` 개인 테이블을 함께 정리해야 한다.
- 기존 삭제 흐름은 인증 정보와 온보딩 상태 정리에 집중되어 있어, 로컬 즐겨찾기와 최근 검색, 알림 설정이 남을 수 있었다.
- 앱 부트스트랩은 기본적으로 `userDatabase`와 익명 인증을 함께 준비하므로, 서버 삭제를 우회하지 않고 성공 후 로컬 정리를 이어가야 한다.

## 작업 내용

- `UserDataDeletionLocalRepository`를 추가해 `favorite_stations`, `favorite_facilities`, `favorite_routes`, `search_history`, `app_preferences`, 신고 draft/receipt를 트랜잭션으로 삭제한다.
- `UserDataDeletionCompositeRepository`를 추가해 API 삭제를 먼저 실행하고 성공한 뒤 로컬 DB 삭제를 수행한다.
- `AppDependencies.resolve`에서 `userDatabase`와 인증 provider가 모두 있으면 composite deletion repository를 사용하고, 한쪽만 있으면 해당 repository만 선택하도록 연결했다.
- 삭제 저장소 단위 테스트와 기본 의존성 선택 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/user_data_deletion_test.dart test/features/favorites/drift_favorite_repositories_test.dart` 성공
  - `flutter analyze` 성공
  - `flutter test` 성공
  - PR CI 전체 성공: Repository CI, Backend CI, Mobile App CI, Android CI, iOS CI, Dependency Vulnerability Scan, osv-scanner
  - Release Artifacts 전체 성공: Backend Release Image, Android Release Artifact, iOS Release Artifact
  - CodeRabbit은 rate limit으로 실제 리뷰가 시작되지 않아 Codex CLI fallback review를 실행했고, 후속 재검토에서 actionable issue 0건을 확인했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `UserDataDeletionLocalRepository`의 삭제 대상 테이블
  - `UserDataDeletionCompositeRepository`의 서버 삭제 성공 후 로컬 삭제 순서
  - `AppDependencies.resolve`에서 local/API/composite deletion repository를 선택하는 분기

## 리스크

- local deletion은 데이터팩 설치 상태 테이블은 지우지 않는다. 개인 데이터 삭제 범위와 앱 재설치 없이 유지해도 되는 데이터팩 상태를 분리하기 위한 선택이다.
- 서버 삭제가 실패하면 로컬 DB 삭제도 실행하지 않는다. 서버에 남은 사용자 데이터와 앱 로컬 상태가 서로 다르게 삭제되는 상황을 피하기 위한 동작이다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
