### PR TITLE
[Feat] 데이터팩 업데이트와 긴급 override 구현

### DIFF
--- a/apps/mobile/lib/app/app_bootstrap.dart
+++ b/apps/mobile/lib/app/app_bootstrap.dart
@@ -10,15 +10,28 @@ import '../anonymous_auth.dart';
 import '../facility_report.dart';
 import '../favorite_facility.dart';
 import '../internal_route.dart';
+import '../mobile_error_reporter.dart';
 import '../notification_settings.dart';
 import '../route_search.dart';
 import '../station_search.dart';
+import '../core/datapack/data_pack_client.dart';
+import '../core/datapack/data_pack_installer.dart';
+import '../core/datapack/data_pack_update_state.dart';
+import '../core/datapack/data_pack_updater.dart';
+import '../core/datapack/emergency_override_repository.dart';
 import '../user_data_deletion.dart';
 import '../core/database/catalog/catalog_database.dart';
 import '../core/database/catalog/catalog_database_opener.dart';
 import '../core/database/user/user_database.dart';
 import '../core/database/user/user_database_opener.dart';
+import 'app_endpoints.dart';
 import 'app_dependencies.dart';
+
+typedef DataPackUpdateRunner =
+    Future<void> Function({
+      required Directory supportDirectory,
+      required UserDatabase userDatabase,
+    });
 
 class AppBootstrap {
   const AppBootstrap({
@@ -48,51 +61,105 @@ class AppBootstrap {
     AnonymousAuthRepository? anonymousAuthRepository,
     AnonymousAuthCredentialStore? anonymousAuthCredentialStore,
     UserDataDeletionRepository? userDataDeletionRepository,
+    DataPackUpdateRunner? dataPackUpdateRunner,
     required bool enableAnonymousAuth,
     required bool enablePushNotifications,
   }) async {
     final supportDirectory =
         databaseDirectory ?? await getApplicationSupportDirectory();
-    final catalogDatabase = await CatalogDatabaseOpener(
-      databaseDirectory: supportDirectory,
-      assetBundle: assetBundle ?? rootBundle,
-    ).open();
     final userDatabase = await UserDatabaseOpener(
       databaseDirectory: Directory(p.join(supportDirectory.path, 'user')),
     ).open();
 
-    final dependencies = AppDependencies.resolve(
-      repository: repository,
-      reportRepository: reportRepository,
-      routeRepository: routeRepository,
-      routeFeedbackRepository: routeFeedbackRepository,
-      favoriteRepository: favoriteRepository,
-      favoriteFacilityRepository: favoriteFacilityRepository,
-      favoriteRouteRepository: favoriteRouteRepository,
-      internalRouteRepository: internalRouteRepository,
-      notificationRepository: notificationRepository,
-      notificationPermissionProvider: notificationPermissionProvider,
-      locationProvider: locationProvider,
-      anonymousAuthRepository: anonymousAuthRepository,
-      anonymousAuthCredentialStore: anonymousAuthCredentialStore,
-      userDataDeletionRepository: userDataDeletionRepository,
-      catalogDatabase: catalogDatabase,
-      userDatabase: userDatabase,
-      enableAnonymousAuth: enableAnonymousAuth,
-      enablePushNotifications: enablePushNotifications,
-    );
+    try {
+      await _runDataPackUpdateSafely(
+        supportDirectory: supportDirectory,
+        userDatabase: userDatabase,
+        runner: dataPackUpdateRunner ?? _defaultDataPackUpdateRunner,
+      );
+      final catalogDatabase = await CatalogDatabaseOpener(
+        databaseDirectory: supportDirectory,
+        assetBundle: assetBundle ?? rootBundle,
+      ).open();
 
-    return AppBootstrap(
-      dependencies: dependencies,
-      catalogDatabase: catalogDatabase,
-      userDatabase: userDatabase,
-    );
+      final dependencies = AppDependencies.resolve(
+        repository: repository,
+        reportRepository: reportRepository,
+        routeRepository: routeRepository,
+        routeFeedbackRepository: routeFeedbackRepository,
+        favoriteRepository: favoriteRepository,
+        favoriteFacilityRepository: favoriteFacilityRepository,
+        favoriteRouteRepository: favoriteRouteRepository,
+        internalRouteRepository: internalRouteRepository,
+        notificationRepository: notificationRepository,
+        notificationPermissionProvider: notificationPermissionProvider,
+        locationProvider: locationProvider,
+        anonymousAuthRepository: anonymousAuthRepository,
+        anonymousAuthCredentialStore: anonymousAuthCredentialStore,
+        userDataDeletionRepository: userDataDeletionRepository,
+        catalogDatabase: catalogDatabase,
+        userDatabase: userDatabase,
+        enableAnonymousAuth: enableAnonymousAuth,
+        enablePushNotifications: enablePushNotifications,
+      );
+
+      return AppBootstrap(
+        dependencies: dependencies,
+        catalogDatabase: catalogDatabase,
+        userDatabase: userDatabase,
+      );
+    } catch (error, stackTrace) {
+      await userDatabase.close();
+      Error.throwWithStackTrace(error, stackTrace);
+    }
   }
 
   Future<void> close() async {
     await catalogDatabase.close();
     await userDatabase.close();
   }
+}
+
+Future<void> _runDataPackUpdateSafely({
+  required Directory supportDirectory,
+  required UserDatabase userDatabase,
+  required DataPackUpdateRunner runner,
+}) async {
+  try {
+    await runner(
+      supportDirectory: supportDirectory,
+      userDatabase: userDatabase,
+    );
+  } catch (error, stackTrace) {
+    reportMobileError(error, stackTrace, context: '데이터팩 업데이트 확인 중 예외가 발생했습니다.');
+  }
+}
+
+Future<void> _defaultDataPackUpdateRunner({
+  required Directory supportDirectory,
+  required UserDatabase userDatabase,
+}) async {
+  final manifestUri = AppEndpoints.fromEnvironment().dataPackManifestUri;
+  if (manifestUri == null) {
+    return;
+  }
+  final stateRepository = DataPackUpdateStateRepository(
+    userDatabase: userDatabase,
+  );
+  final catalogDirectory = Directory(p.join(supportDirectory.path, 'catalog'));
+  await DataPackUpdater(
+    client: DataPackClient(
+      manifestUri: manifestUri,
+      stateRepository: stateRepository,
+    ),
+    installer: DataPackInstaller(
+      catalogDirectory: catalogDirectory,
+      userDatabase: userDatabase,
+    ),
+    emergencyOverrideRepository: EmergencyOverrideRepository(
+      userDatabase: userDatabase,
+    ),
+  ).checkForUpdates();
 }
 
 class AppBootstrapLifecycle extends StatefulWidget {

--- a/apps/mobile/lib/app/app_bootstrap.dart
+++ b/apps/mobile/lib/app/app_bootstrap.dart
@@ -70,6 +70,9 @@ class AppBootstrap {
     final userDatabase = await UserDatabaseOpener(
       databaseDirectory: Directory(p.join(supportDirectory.path, 'user')),
     ).open();
+    final emergencyOverrideRepository = EmergencyOverrideRepository(
+      userDatabase: userDatabase,
+    );
 
     try {
       await _runDataPackUpdateSafely(
@@ -80,6 +83,7 @@ class AppBootstrap {
       final catalogDatabase = await CatalogDatabaseOpener(
         databaseDirectory: supportDirectory,
         assetBundle: assetBundle ?? rootBundle,
+        emergencyOverrideRepository: emergencyOverrideRepository,
       ).open();
 
       final dependencies = AppDependencies.resolve(

--- a/apps/mobile/lib/app/app_endpoints.dart
+++ b/apps/mobile/lib/app/app_endpoints.dart
@@ -25,7 +25,8 @@ class AppEndpoints {
     if (trimmed.isEmpty) {
       return null;
     }
-    final base = Uri.tryParse(trimmed);
+    final normalized = trimmed.endsWith('/') ? trimmed : '$trimmed/';
+    final base = Uri.tryParse(normalized);
     if (base == null || !base.hasScheme || base.host.isEmpty) {
       return null;
     }

--- a/apps/mobile/lib/app/app_endpoints.dart
+++ b/apps/mobile/lib/app/app_endpoints.dart
@@ -1,0 +1,34 @@
+class AppEndpoints {
+  const AppEndpoints({
+    required this.dataPackBaseUrl,
+    required this.reportApiBaseUrl,
+  });
+
+  factory AppEndpoints.fromEnvironment() {
+    return const AppEndpoints(
+      dataPackBaseUrl: String.fromEnvironment(
+        'EASYSUBWAY_DATA_PACK_BASE_URL',
+        defaultValue: '',
+      ),
+      reportApiBaseUrl: String.fromEnvironment(
+        'EASYSUBWAY_REPORT_API_BASE_URL',
+        defaultValue: '',
+      ),
+    );
+  }
+
+  final String dataPackBaseUrl;
+  final String reportApiBaseUrl;
+
+  Uri? get dataPackManifestUri {
+    final trimmed = dataPackBaseUrl.trim();
+    if (trimmed.isEmpty) {
+      return null;
+    }
+    final base = Uri.tryParse(trimmed);
+    if (base == null || !base.hasScheme || base.host.isEmpty) {
+      return null;
+    }
+    return base.resolve('catalog/current.json');
+  }
+}

--- a/apps/mobile/lib/core/database/catalog/catalog_database_opener.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_database_opener.dart
@@ -41,6 +41,11 @@ class CatalogDatabaseOpener {
   }
 
   Future<CatalogDatabase?> _openInstalledCurrentDataPack() async {
+    final overrideDatabase = await _openEmergencyOverrideDataPack();
+    if (overrideDatabase != null) {
+      return overrideDatabase;
+    }
+
     final pointer = File(
       p.join(databaseDirectory.path, 'catalog', 'current.json'),
     );
@@ -55,10 +60,6 @@ class CatalogDatabaseOpener {
       final path = decoded['path'];
       if (path is! String || path.trim().isEmpty) {
         return null;
-      }
-      final overrideDatabase = await _openEmergencyOverrideDataPack();
-      if (overrideDatabase != null) {
-        return overrideDatabase;
       }
       final file = File(path);
       if (!await file.exists()) {

--- a/apps/mobile/lib/core/database/catalog/catalog_database_opener.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_database_opener.dart
@@ -57,11 +57,10 @@ class CatalogDatabaseOpener {
       if (decoded is! Map<String, Object?>) {
         return null;
       }
-      final path = decoded['path'];
-      if (path is! String || path.trim().isEmpty) {
+      final file = _currentDataPackFile(decoded);
+      if (file == null) {
         return null;
       }
-      final file = File(path);
       if (!await file.exists()) {
         return null;
       }
@@ -73,6 +72,29 @@ class CatalogDatabaseOpener {
       await database.close();
     } on Object {
       return null;
+    }
+    return null;
+  }
+
+  File? _currentDataPackFile(Map<String, Object?> pointer) {
+    final id = pointer['id'];
+    final version = pointer['version'];
+    if (id is String &&
+        id.trim().isNotEmpty &&
+        version is String &&
+        version.trim().isNotEmpty) {
+      return File(
+        p.join(
+          databaseDirectory.path,
+          'catalog',
+          '${id.trim()}-v${version.trim()}.sqlite',
+        ),
+      );
+    }
+
+    final path = pointer['path'];
+    if (path is String && path.trim().isNotEmpty) {
+      return File(path.trim());
     }
     return null;
   }

--- a/apps/mobile/lib/core/database/catalog/catalog_database_opener.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_database_opener.dart
@@ -64,16 +64,10 @@ class CatalogDatabaseOpener {
       if (!await file.exists()) {
         return null;
       }
-      final database = CatalogDatabase.file(file);
-      final usable = await _isUsableCatalogDatabase(database);
-      if (usable) {
-        return database;
-      }
-      await database.close();
+      return await _openUsableCatalogDatabase(file);
     } on Object {
       return null;
     }
-    return null;
   }
 
   File? _currentDataPackFile(Map<String, Object?> pointer) {
@@ -119,16 +113,26 @@ class CatalogDatabaseOpener {
       if (!await file.exists()) {
         return null;
       }
-      final database = CatalogDatabase.file(file);
-      final usable = await _isUsableCatalogDatabase(database);
-      if (usable) {
-        return database;
-      }
-      await database.close();
+      return await _openUsableCatalogDatabase(file);
     } on Object {
       return null;
     }
-    return null;
+  }
+
+  Future<CatalogDatabase?> _openUsableCatalogDatabase(File file) async {
+    final database = CatalogDatabase.file(file);
+    var returned = false;
+    try {
+      if (await _isUsableCatalogDatabase(database)) {
+        returned = true;
+        return database;
+      }
+      return null;
+    } finally {
+      if (!returned) {
+        await database.close();
+      }
+    }
   }
 
   Future<bool> _isUsableCatalogDatabase(CatalogDatabase database) async {

--- a/apps/mobile/lib/core/database/catalog/catalog_database_opener.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_database_opener.dart
@@ -19,6 +19,11 @@ class CatalogDatabaseOpener {
   final AssetBundle assetBundle;
 
   Future<CatalogDatabase> open() async {
+    final installedDatabase = await _openInstalledCurrentDataPack();
+    if (installedDatabase != null) {
+      return installedDatabase;
+    }
+
     final datapackDirectory = Directory(
       p.join(databaseDirectory.path, 'datapacks'),
     );
@@ -30,6 +35,51 @@ class CatalogDatabaseOpener {
     );
     await database.seedBaselineIfEmpty();
     return database;
+  }
+
+  Future<CatalogDatabase?> _openInstalledCurrentDataPack() async {
+    final pointer = File(
+      p.join(databaseDirectory.path, 'catalog', 'current.json'),
+    );
+    if (!await pointer.exists()) {
+      return null;
+    }
+    try {
+      final decoded = jsonDecode(await pointer.readAsString());
+      if (decoded is! Map<String, Object?>) {
+        return null;
+      }
+      final path = decoded['path'];
+      if (path is! String || path.trim().isEmpty) {
+        return null;
+      }
+      final file = File(path);
+      if (!await file.exists()) {
+        return null;
+      }
+      final database = CatalogDatabase.file(file);
+      final usable = await _isUsableCatalogDatabase(database);
+      if (usable) {
+        return database;
+      }
+      await database.close();
+    } on Object {
+      return null;
+    }
+    return null;
+  }
+
+  Future<bool> _isUsableCatalogDatabase(CatalogDatabase database) async {
+    final quickCheck = await database.customSelect('PRAGMA quick_check').get();
+    if (quickCheck.any((row) => row.data.values.first != 'ok')) {
+      return false;
+    }
+    final schemaVersion = await database
+        .customSelect(
+          "SELECT value FROM catalog_metadata WHERE key = 'schemaVersion'",
+        )
+        .getSingleOrNull();
+    return schemaVersion != null;
   }
 
   Future<void> _installBundledDataPacks(Directory datapackDirectory) async {

--- a/apps/mobile/lib/core/database/catalog/catalog_database_opener.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_database_opener.dart
@@ -5,18 +5,21 @@ import 'package:crypto/crypto.dart';
 import 'package:flutter/services.dart';
 import 'package:path/path.dart' as p;
 
+import '../../datapack/emergency_override_repository.dart';
 import 'catalog_database.dart';
 
 class CatalogDatabaseOpener {
   CatalogDatabaseOpener({
     required this.databaseDirectory,
     required this.assetBundle,
+    this.emergencyOverrideRepository,
   });
 
   static const indexAssetPath = 'assets/datapacks/index.json';
 
   final Directory databaseDirectory;
   final AssetBundle assetBundle;
+  final EmergencyOverrideRepository? emergencyOverrideRepository;
 
   Future<CatalogDatabase> open() async {
     final installedDatabase = await _openInstalledCurrentDataPack();
@@ -53,7 +56,43 @@ class CatalogDatabaseOpener {
       if (path is! String || path.trim().isEmpty) {
         return null;
       }
+      final overrideDatabase = await _openEmergencyOverrideDataPack();
+      if (overrideDatabase != null) {
+        return overrideDatabase;
+      }
       final file = File(path);
+      if (!await file.exists()) {
+        return null;
+      }
+      final database = CatalogDatabase.file(file);
+      final usable = await _isUsableCatalogDatabase(database);
+      if (usable) {
+        return database;
+      }
+      await database.close();
+    } on Object {
+      return null;
+    }
+    return null;
+  }
+
+  Future<CatalogDatabase?> _openEmergencyOverrideDataPack() async {
+    final repository = emergencyOverrideRepository;
+    if (repository == null) {
+      return null;
+    }
+    try {
+      final override = await repository.readOverride();
+      if (override == null) {
+        return null;
+      }
+      final file = File(
+        p.join(
+          databaseDirectory.path,
+          'catalog',
+          '${override.id}-v${override.version}.sqlite',
+        ),
+      );
       if (!await file.exists()) {
         return null;
       }

--- a/apps/mobile/lib/core/datapack/data_pack_client.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_client.dart
@@ -60,23 +60,40 @@ class DataPackClient {
       throw const DataPackClientException('데이터팩 정보 형식이 올바르지 않습니다.');
     }
     final manifest = DataPackManifest.fromJson(decoded);
-    await stateRepository.saveManifestCache(
-      etag: response.headers.value(HttpHeaders.etagHeader),
-      checkedAt: _now().toUtc(),
-      ttl: manifest.ttl,
-    );
     return DataPackManifestFetchResult(
       status: DataPackManifestFetchStatus.updated,
       manifest: manifest,
+      etag: response.headers.value(HttpHeaders.etagHeader),
+      checkedAt: _now().toUtc(),
+    );
+  }
+
+  Future<void> saveManifestCache(DataPackManifestFetchResult result) async {
+    final manifest = result.manifest;
+    final checkedAt = result.checkedAt;
+    if (manifest == null || checkedAt == null) {
+      return;
+    }
+    await stateRepository.saveManifestCache(
+      etag: result.etag,
+      checkedAt: checkedAt,
+      ttl: manifest.ttl,
     );
   }
 }
 
 class DataPackManifestFetchResult {
-  const DataPackManifestFetchResult({required this.status, this.manifest});
+  const DataPackManifestFetchResult({
+    required this.status,
+    this.manifest,
+    this.etag,
+    this.checkedAt,
+  });
 
   final DataPackManifestFetchStatus status;
   final DataPackManifest? manifest;
+  final String? etag;
+  final DateTime? checkedAt;
 }
 
 enum DataPackManifestFetchStatus { freshCache, notModified, updated }

--- a/apps/mobile/lib/core/datapack/data_pack_client.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_client.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'data_pack_manifest.dart';
+import 'data_pack_update_state.dart';
+
+const _manifestFetchTimeout = Duration(seconds: 8);
+
+class DataPackClient {
+  DataPackClient({
+    required this.manifestUri,
+    required this.stateRepository,
+    HttpClient? httpClient,
+    DateTime Function()? now,
+  }) : _httpClient = httpClient ?? HttpClient(),
+       _now = now ?? DateTime.now;
+
+  final Uri manifestUri;
+  final DataPackUpdateStateRepository stateRepository;
+  final HttpClient _httpClient;
+  final DateTime Function() _now;
+
+  Future<DataPackManifestFetchResult> fetchManifestIfNeeded() async {
+    final cache = await stateRepository.readManifestCache();
+    if (cache != null && stateRepository.isFresh(cache)) {
+      return const DataPackManifestFetchResult(
+        status: DataPackManifestFetchStatus.freshCache,
+      );
+    }
+
+    final request = await _httpClient
+        .getUrl(manifestUri)
+        .timeout(_manifestFetchTimeout);
+    final etag = cache?.etag;
+    if (etag != null && etag.isNotEmpty) {
+      request.headers.set(HttpHeaders.ifNoneMatchHeader, etag);
+    }
+
+    final response = await request.close().timeout(_manifestFetchTimeout);
+    if (response.statusCode == HttpStatus.notModified && cache != null) {
+      await stateRepository.saveManifestCache(
+        etag: cache.etag,
+        checkedAt: _now().toUtc(),
+        ttl: cache.ttl,
+      );
+      return const DataPackManifestFetchResult(
+        status: DataPackManifestFetchStatus.notModified,
+      );
+    }
+    if (response.statusCode != HttpStatus.ok) {
+      throw const DataPackClientException('데이터팩 정보를 확인하지 못했습니다.');
+    }
+
+    final body = await utf8
+        .decodeStream(response)
+        .timeout(_manifestFetchTimeout);
+    final decoded = jsonDecode(body);
+    if (decoded is! Map<String, Object?>) {
+      throw const DataPackClientException('데이터팩 정보 형식이 올바르지 않습니다.');
+    }
+    final manifest = DataPackManifest.fromJson(decoded);
+    await stateRepository.saveManifestCache(
+      etag: response.headers.value(HttpHeaders.etagHeader),
+      checkedAt: _now().toUtc(),
+      ttl: manifest.ttl,
+    );
+    return DataPackManifestFetchResult(
+      status: DataPackManifestFetchStatus.updated,
+      manifest: manifest,
+    );
+  }
+}
+
+class DataPackManifestFetchResult {
+  const DataPackManifestFetchResult({required this.status, this.manifest});
+
+  final DataPackManifestFetchStatus status;
+  final DataPackManifest? manifest;
+}
+
+enum DataPackManifestFetchStatus { freshCache, notModified, updated }
+
+class DataPackClientException implements Exception {
+  const DataPackClientException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}

--- a/apps/mobile/lib/core/datapack/data_pack_installer.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_installer.dart
@@ -23,6 +23,7 @@ class DataPackInstaller {
   Future<DataPackInstallResult> install({
     required DataPackManifestEntry pack,
     required List<int> compressedBytes,
+    Set<String> protectedVersions = const {},
   }) async {
     await catalogDirectory.create(recursive: true);
     final compressedHash = sha256.convert(compressedBytes).toString();
@@ -75,7 +76,11 @@ class DataPackInstaller {
       installedAt: _now().toUtc(),
     );
     await _writeCurrentPointer(pointer);
-    await _pruneObsoletePacks(pack.id, keepVersionCount: 2);
+    await _pruneObsoletePacks(
+      pack.id,
+      keepVersionCount: 2,
+      protectedVersions: protectedVersions,
+    );
     await userDatabase
         .into(userDatabase.installedDataPacks)
         .insertOnConflictUpdate(
@@ -168,6 +173,7 @@ class DataPackInstaller {
   Future<void> _pruneObsoletePacks(
     String packId, {
     required int keepVersionCount,
+    required Set<String> protectedVersions,
   }) async {
     final packFiles = await catalogDirectory
         .list()
@@ -179,7 +185,16 @@ class DataPackInstaller {
     packFiles.sort((left, right) {
       return _versionNumber(right.path).compareTo(_versionNumber(left.path));
     });
-    for (final file in packFiles.skip(keepVersionCount)) {
+    var keptUnprotectedCount = 0;
+    for (final file in packFiles) {
+      final version = _versionNumber(file.path).toString();
+      if (protectedVersions.contains(version)) {
+        continue;
+      }
+      keptUnprotectedCount++;
+      if (keptUnprotectedCount <= keepVersionCount) {
+        continue;
+      }
       await _deleteIfExists(file);
     }
   }

--- a/apps/mobile/lib/core/datapack/data_pack_installer.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_installer.dart
@@ -1,0 +1,291 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:drift/drift.dart';
+import 'package:path/path.dart' as p;
+
+import '../database/catalog/catalog_database.dart';
+import '../database/user/user_database.dart' as user_db;
+import 'data_pack_manifest.dart';
+
+class DataPackInstaller {
+  DataPackInstaller({
+    required this.catalogDirectory,
+    required this.userDatabase,
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
+
+  final Directory catalogDirectory;
+  final user_db.UserDatabase userDatabase;
+  final DateTime Function() _now;
+
+  Future<DataPackInstallResult> install({
+    required DataPackManifestEntry pack,
+    required List<int> compressedBytes,
+  }) async {
+    await catalogDirectory.create(recursive: true);
+    final compressedHash = sha256.convert(compressedBytes).toString();
+    if (compressedHash != pack.compressedSha256) {
+      return const DataPackInstallResult(
+        status: DataPackInstallStatus.rejected,
+        reason: DataPackInstallRejectionReason.sha256Mismatch,
+      );
+    }
+
+    late final List<int> sqliteBytes;
+    try {
+      sqliteBytes = gzip.decode(compressedBytes);
+    } on FormatException {
+      return const DataPackInstallResult(
+        status: DataPackInstallStatus.rejected,
+        reason: DataPackInstallRejectionReason.invalidArchive,
+      );
+    }
+
+    if (sha256.convert(sqliteBytes).toString() != pack.sqliteSha256) {
+      return const DataPackInstallResult(
+        status: DataPackInstallStatus.rejected,
+        reason: DataPackInstallRejectionReason.sqliteSha256Mismatch,
+      );
+    }
+
+    final temporary = File(
+      p.join(catalogDirectory.path, '${pack.id}-v${pack.version}.sqlite.tmp'),
+    );
+    final target = File(
+      p.join(catalogDirectory.path, '${pack.id}-v${pack.version}.sqlite'),
+    );
+    await temporary.writeAsBytes(sqliteBytes, flush: true);
+    final rejection = await _validateSqlite(temporary, pack);
+    if (rejection != null) {
+      await _deleteIfExists(temporary);
+      return DataPackInstallResult(
+        status: DataPackInstallStatus.rejected,
+        reason: rejection,
+      );
+    }
+
+    await _replaceFile(temporary, target);
+    final pointer = InstalledDataPackPointer(
+      id: pack.id,
+      version: pack.version,
+      path: target.path,
+      sha256: pack.sqliteSha256,
+      installedAt: _now().toUtc(),
+    );
+    await _writeCurrentPointer(pointer);
+    await _pruneObsoletePacks(pack.id, keepVersionCount: 2);
+    await userDatabase
+        .into(userDatabase.installedDataPacks)
+        .insertOnConflictUpdate(
+          user_db.InstalledDataPacksCompanion.insert(
+            packId: pack.id,
+            version: pack.version,
+            sha256: pack.sqliteSha256,
+            installedAt: pointer.installedAt!,
+          ),
+        );
+
+    return DataPackInstallResult(
+      status: DataPackInstallStatus.installed,
+      pointer: pointer,
+    );
+  }
+
+  Future<InstalledDataPackPointer?> readCurrentPointer() async {
+    final file = File(p.join(catalogDirectory.path, 'current.json'));
+    if (!await file.exists()) {
+      return null;
+    }
+    final decoded = jsonDecode(await file.readAsString());
+    if (decoded is! Map<String, Object?>) {
+      return null;
+    }
+    return InstalledDataPackPointer.fromJson(decoded);
+  }
+
+  Future<DataPackInstallRejectionReason?> _validateSqlite(
+    File file,
+    DataPackManifestEntry pack,
+  ) async {
+    final header = await file.openRead(0, 16).first;
+    if (!_hasSqliteHeader(header)) {
+      return DataPackInstallRejectionReason.invalidSqliteHeader;
+    }
+
+    final database = CatalogDatabase.file(file);
+    try {
+      final quickCheck = await database
+          .customSelect('PRAGMA quick_check')
+          .get();
+      if (quickCheck.any((row) => row.data.values.first != 'ok')) {
+        return DataPackInstallRejectionReason.quickCheckFailed;
+      }
+      final schemaVersion = await database
+          .customSelect(
+            "SELECT value FROM catalog_metadata WHERE key = 'schemaVersion'",
+          )
+          .getSingleOrNull();
+      if (schemaVersion?.read<String>('value') != pack.schemaVersion) {
+        return DataPackInstallRejectionReason.schemaVersionMismatch;
+      }
+      for (final table in pack.requiredTables) {
+        final row = await database
+            .customSelect(
+              "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+              variables: [Variable<String>(table)],
+            )
+            .getSingleOrNull();
+        if (row == null) {
+          return DataPackInstallRejectionReason.requiredTableMissing;
+        }
+      }
+      for (final entry in pack.minimumTableRows.entries) {
+        final rows = await database
+            .customSelect('SELECT COUNT(*) AS count FROM ${entry.key}')
+            .getSingle();
+        if (rows.read<int>('count') < entry.value) {
+          return DataPackInstallRejectionReason.minimumRowsMissing;
+        }
+      }
+    } on Object {
+      return DataPackInstallRejectionReason.quickCheckFailed;
+    } finally {
+      await database.close();
+    }
+
+    return null;
+  }
+
+  Future<void> _writeCurrentPointer(InstalledDataPackPointer pointer) async {
+    final target = File(p.join(catalogDirectory.path, 'current.json'));
+    final temporary = File('${target.path}.installing');
+    await temporary.writeAsString(jsonEncode(pointer.toJson()), flush: true);
+    await _replaceFile(temporary, target);
+  }
+
+  Future<void> _pruneObsoletePacks(
+    String packId, {
+    required int keepVersionCount,
+  }) async {
+    final packFiles = await catalogDirectory
+        .list()
+        .where((entity) => entity is File)
+        .cast<File>()
+        .where((file) => p.basename(file.path).startsWith('$packId-v'))
+        .where((file) => p.extension(file.path) == '.sqlite')
+        .toList();
+    packFiles.sort((left, right) {
+      return _versionNumber(right.path).compareTo(_versionNumber(left.path));
+    });
+    for (final file in packFiles.skip(keepVersionCount)) {
+      await _deleteIfExists(file);
+    }
+  }
+
+  Future<void> _replaceFile(File temporary, File target) async {
+    try {
+      await temporary.rename(target.path);
+    } on FileSystemException {
+      await _deleteIfExists(target);
+      await temporary.rename(target.path);
+    }
+  }
+}
+
+class DataPackInstallResult {
+  const DataPackInstallResult({
+    required this.status,
+    this.reason,
+    this.pointer,
+  });
+
+  final DataPackInstallStatus status;
+  final DataPackInstallRejectionReason? reason;
+  final InstalledDataPackPointer? pointer;
+}
+
+enum DataPackInstallStatus { installed, rejected }
+
+enum DataPackInstallRejectionReason {
+  invalidArchive,
+  sha256Mismatch,
+  sqliteSha256Mismatch,
+  invalidSqliteHeader,
+  quickCheckFailed,
+  schemaVersionMismatch,
+  requiredTableMissing,
+  minimumRowsMissing,
+}
+
+class InstalledDataPackPointer {
+  const InstalledDataPackPointer({
+    required this.id,
+    required this.version,
+    required this.path,
+    this.sha256,
+    this.installedAt,
+    this.reason,
+  });
+
+  factory InstalledDataPackPointer.fromJson(Map<String, Object?> json) {
+    final installedAt = json['installedAt'];
+    return InstalledDataPackPointer(
+      id: _readString(json, 'id'),
+      version: _readString(json, 'version'),
+      path: _readString(json, 'path'),
+      sha256: json['sha256'] is String ? json['sha256'] as String : null,
+      installedAt: installedAt is String
+          ? DateTime.tryParse(installedAt)
+          : null,
+      reason: json['reason'] is String ? json['reason'] as String : null,
+    );
+  }
+
+  final String id;
+  final String version;
+  final String path;
+  final String? sha256;
+  final DateTime? installedAt;
+  final String? reason;
+
+  Map<String, Object?> toJson() {
+    return {
+      'id': id,
+      'version': version,
+      'path': path,
+      if (sha256 != null) 'sha256': sha256,
+      if (installedAt != null) 'installedAt': installedAt!.toIso8601String(),
+      if (reason != null) 'reason': reason,
+    };
+  }
+}
+
+bool _hasSqliteHeader(List<int> header) {
+  return header.length == 16 &&
+      String.fromCharCodes(header.take(15)) == 'SQLite format 3' &&
+      header[15] == 0;
+}
+
+Future<void> _deleteIfExists(File file) async {
+  if (await file.exists()) {
+    await file.delete();
+  }
+}
+
+String _readString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! String || value.trim().isEmpty) {
+    throw const FormatException('Invalid data pack pointer.');
+  }
+  return value.trim();
+}
+
+int _versionNumber(String path) {
+  final match = RegExp(r'-v(\d+)\.sqlite$').firstMatch(p.basename(path));
+  if (match == null) {
+    return 0;
+  }
+  return int.tryParse(match.group(1)!) ?? 0;
+}

--- a/apps/mobile/lib/core/datapack/data_pack_installer.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_installer.dart
@@ -78,12 +78,12 @@ class DataPackInstaller {
     );
     if (activateCurrent) {
       await activateCurrentPointer(pointer);
+      await pruneObsoletePacks(
+        pack.id,
+        keepVersionCount: 2,
+        protectedVersions: protectedVersions,
+      );
     }
-    await _pruneObsoletePacks(
-      pack.id,
-      keepVersionCount: 2,
-      protectedVersions: protectedVersions,
-    );
     await userDatabase
         .into(userDatabase.installedDataPacks)
         .insertOnConflictUpdate(
@@ -115,6 +115,18 @@ class DataPackInstaller {
 
   Future<void> activateCurrentPointer(InstalledDataPackPointer pointer) async {
     await _writeCurrentPointer(pointer);
+  }
+
+  Future<void> pruneObsoletePacks(
+    String packId, {
+    required int keepVersionCount,
+    required Set<String> protectedVersions,
+  }) async {
+    await _pruneObsoletePacks(
+      packId,
+      keepVersionCount: keepVersionCount,
+      protectedVersions: protectedVersions,
+    );
   }
 
   Future<DataPackInstallRejectionReason?> _validateSqlite(

--- a/apps/mobile/lib/core/datapack/data_pack_installer.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_installer.dart
@@ -24,6 +24,7 @@ class DataPackInstaller {
     required DataPackManifestEntry pack,
     required List<int> compressedBytes,
     Set<String> protectedVersions = const {},
+    bool activateCurrent = true,
   }) async {
     await catalogDirectory.create(recursive: true);
     final compressedHash = sha256.convert(compressedBytes).toString();
@@ -75,7 +76,9 @@ class DataPackInstaller {
       sha256: pack.sqliteSha256,
       installedAt: _now().toUtc(),
     );
-    await _writeCurrentPointer(pointer);
+    if (activateCurrent) {
+      await activateCurrentPointer(pointer);
+    }
     await _pruneObsoletePacks(
       pack.id,
       keepVersionCount: 2,
@@ -108,6 +111,10 @@ class DataPackInstaller {
       return null;
     }
     return InstalledDataPackPointer.fromJson(decoded);
+  }
+
+  Future<void> activateCurrentPointer(InstalledDataPackPointer pointer) async {
+    await _writeCurrentPointer(pointer);
   }
 
   Future<DataPackInstallRejectionReason?> _validateSqlite(

--- a/apps/mobile/lib/core/datapack/data_pack_installer.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_installer.dart
@@ -114,7 +114,9 @@ class DataPackInstaller {
     File file,
     DataPackManifestEntry pack,
   ) async {
-    final header = await file.openRead(0, 16).first;
+    final header = await file
+        .openRead(0, 16)
+        .fold<List<int>>(<int>[], (bytes, chunk) => bytes..addAll(chunk));
     if (!_hasSqliteHeader(header)) {
       return DataPackInstallRejectionReason.invalidSqliteHeader;
     }

--- a/apps/mobile/lib/core/datapack/data_pack_manifest.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_manifest.dart
@@ -44,8 +44,8 @@ class DataPackManifestEntry {
   });
 
   factory DataPackManifestEntry.fromJson(Map<String, Object?> json) {
-    final id = _requiredString(json, 'id');
-    final version = _requiredString(json, 'version');
+    final id = _readPackId(json['id']);
+    final version = _readPackVersion(json['version']);
     final url = _requiredString(json, 'url');
     final requiredTables = json['requiredTables'];
     final minimumTableRows = json['minimumTableRows'];
@@ -99,8 +99,8 @@ EmergencyOverrideManifest? _parseOverride(Object? rawOverride) {
     throw const FormatException('Invalid emergency override.');
   }
   return EmergencyOverrideManifest(
-    id: _requiredString(rawOverride, 'id'),
-    version: _requiredString(rawOverride, 'version'),
+    id: _readPackId(rawOverride['id']),
+    version: _readPackVersion(rawOverride['version']),
     reason: _requiredString(rawOverride, 'reason'),
   );
 }
@@ -139,4 +139,28 @@ String _readTableName(Object? value) {
     throw const FormatException('Invalid data pack table name.');
   }
   return tableName;
+}
+
+String _readPackId(Object? value) {
+  if (value is! String) {
+    throw const FormatException('Invalid data pack identity.');
+  }
+  final packId = value.trim();
+  final identifier = RegExp(r'^[A-Za-z][A-Za-z0-9_-]*$');
+  if (!identifier.hasMatch(packId)) {
+    throw const FormatException('Invalid data pack identity.');
+  }
+  return packId;
+}
+
+String _readPackVersion(Object? value) {
+  if (value is! String) {
+    throw const FormatException('Invalid data pack version.');
+  }
+  final version = value.trim();
+  final numericVersion = RegExp(r'^[0-9]+$');
+  if (!numericVersion.hasMatch(version)) {
+    throw const FormatException('Invalid data pack version.');
+  }
+  return version;
 }

--- a/apps/mobile/lib/core/datapack/data_pack_manifest.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_manifest.dart
@@ -62,10 +62,7 @@ class DataPackManifestEntry {
       schemaVersion: _requiredString(json, 'schemaVersion'),
       requiredTables: requiredTables
           .map((table) {
-            if (table is! String || table.trim().isEmpty) {
-              throw const FormatException('Invalid required data pack table.');
-            }
-            return table.trim();
+            return _readTableName(table);
           })
           .toList(growable: false),
       minimumTableRows: _parseMinimumTableRows(minimumTableRows),
@@ -116,10 +113,11 @@ Map<String, int> _parseMinimumTableRows(Object? rawRows) {
     throw const FormatException('Invalid minimum table rows.');
   }
   return rawRows.map((key, value) {
-    if (key.trim().isEmpty || value is! int || value < 0) {
+    final tableName = _readTableName(key);
+    if (value is! int || value < 0) {
       throw const FormatException('Invalid minimum table row entry.');
     }
-    return MapEntry(key.trim(), value);
+    return MapEntry(tableName, value);
   });
 }
 
@@ -129,4 +127,16 @@ String _requiredString(Map<String, Object?> json, String key) {
     throw const FormatException('Invalid data pack manifest value.');
   }
   return value.trim();
+}
+
+String _readTableName(Object? value) {
+  if (value is! String) {
+    throw const FormatException('Invalid data pack table name.');
+  }
+  final tableName = value.trim();
+  final identifier = RegExp(r'^[A-Za-z_][A-Za-z0-9_]*$');
+  if (!identifier.hasMatch(tableName)) {
+    throw const FormatException('Invalid data pack table name.');
+  }
+  return tableName;
 }

--- a/apps/mobile/lib/core/datapack/data_pack_manifest.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_manifest.dart
@@ -1,0 +1,132 @@
+class DataPackManifest {
+  const DataPackManifest({
+    required this.ttl,
+    required this.packs,
+    this.emergencyOverride,
+  });
+
+  factory DataPackManifest.fromJson(Map<String, Object?> json) {
+    final ttlSeconds = json['ttlSeconds'];
+    final rawPacks = json['packs'];
+    if (ttlSeconds is! int || ttlSeconds <= 0 || rawPacks is! List) {
+      throw const FormatException('Invalid data pack manifest.');
+    }
+
+    return DataPackManifest(
+      ttl: Duration(seconds: ttlSeconds),
+      packs: rawPacks
+          .map((rawPack) {
+            if (rawPack is! Map<String, Object?>) {
+              throw const FormatException('Invalid data pack entry.');
+            }
+            return DataPackManifestEntry.fromJson(rawPack);
+          })
+          .toList(growable: false),
+      emergencyOverride: _parseOverride(json['emergencyOverride']),
+    );
+  }
+
+  final Duration ttl;
+  final List<DataPackManifestEntry> packs;
+  final EmergencyOverrideManifest? emergencyOverride;
+}
+
+class DataPackManifestEntry {
+  const DataPackManifestEntry({
+    required this.id,
+    required this.version,
+    required this.url,
+    required this.compressedSha256,
+    required this.sqliteSha256,
+    required this.schemaVersion,
+    required this.requiredTables,
+    this.minimumTableRows = const {},
+  });
+
+  factory DataPackManifestEntry.fromJson(Map<String, Object?> json) {
+    final id = _requiredString(json, 'id');
+    final version = _requiredString(json, 'version');
+    final url = _requiredString(json, 'url');
+    final requiredTables = json['requiredTables'];
+    final minimumTableRows = json['minimumTableRows'];
+    if (requiredTables is! List || requiredTables.isEmpty) {
+      throw const FormatException('Invalid required data pack tables.');
+    }
+
+    return DataPackManifestEntry(
+      id: id,
+      version: version,
+      url: Uri.parse(url),
+      compressedSha256: _requiredString(json, 'sha256'),
+      sqliteSha256: _requiredString(json, 'sqliteSha256'),
+      schemaVersion: _requiredString(json, 'schemaVersion'),
+      requiredTables: requiredTables
+          .map((table) {
+            if (table is! String || table.trim().isEmpty) {
+              throw const FormatException('Invalid required data pack table.');
+            }
+            return table.trim();
+          })
+          .toList(growable: false),
+      minimumTableRows: _parseMinimumTableRows(minimumTableRows),
+    );
+  }
+
+  final String id;
+  final String version;
+  final Uri url;
+  final String compressedSha256;
+  final String sqliteSha256;
+  final String schemaVersion;
+  final List<String> requiredTables;
+  final Map<String, int> minimumTableRows;
+}
+
+class EmergencyOverrideManifest {
+  const EmergencyOverrideManifest({
+    required this.id,
+    required this.version,
+    required this.reason,
+  });
+
+  final String id;
+  final String version;
+  final String reason;
+}
+
+EmergencyOverrideManifest? _parseOverride(Object? rawOverride) {
+  if (rawOverride == null) {
+    return null;
+  }
+  if (rawOverride is! Map<String, Object?>) {
+    throw const FormatException('Invalid emergency override.');
+  }
+  return EmergencyOverrideManifest(
+    id: _requiredString(rawOverride, 'id'),
+    version: _requiredString(rawOverride, 'version'),
+    reason: _requiredString(rawOverride, 'reason'),
+  );
+}
+
+Map<String, int> _parseMinimumTableRows(Object? rawRows) {
+  if (rawRows == null) {
+    return const {};
+  }
+  if (rawRows is! Map<String, Object?>) {
+    throw const FormatException('Invalid minimum table rows.');
+  }
+  return rawRows.map((key, value) {
+    if (key.trim().isEmpty || value is! int || value < 0) {
+      throw const FormatException('Invalid minimum table row entry.');
+    }
+    return MapEntry(key.trim(), value);
+  });
+}
+
+String _requiredString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! String || value.trim().isEmpty) {
+    throw const FormatException('Invalid data pack manifest value.');
+  }
+  return value.trim();
+}

--- a/apps/mobile/lib/core/datapack/data_pack_update_state.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_update_state.dart
@@ -1,0 +1,96 @@
+import 'package:drift/drift.dart';
+
+import '../database/user/user_database.dart' as user_db;
+
+class DataPackUpdateStateRepository {
+  DataPackUpdateStateRepository({
+    required this.userDatabase,
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
+
+  static const _manifestEtagKey = 'datapack_manifest_etag';
+  static const _manifestCheckedAtKey = 'datapack_manifest_checked_at_ms';
+  static const _manifestTtlKey = 'datapack_manifest_ttl_seconds';
+
+  final user_db.UserDatabase userDatabase;
+  final DateTime Function() _now;
+
+  Future<DataPackManifestCache?> readManifestCache() async {
+    final rows = await userDatabase
+        .customSelect(
+          'SELECT key, value FROM data_pack_update_state WHERE key IN (?, ?, ?)',
+          variables: [
+            Variable<String>(_manifestEtagKey),
+            Variable<String>(_manifestCheckedAtKey),
+            Variable<String>(_manifestTtlKey),
+          ],
+          readsFrom: {userDatabase.dataPackUpdateState},
+        )
+        .get();
+    final values = {
+      for (final row in rows)
+        row.read<String>('key'): row.read<String>('value'),
+    };
+    final checkedAtMs = int.tryParse(values[_manifestCheckedAtKey] ?? '');
+    final ttlSeconds = int.tryParse(values[_manifestTtlKey] ?? '');
+    if (checkedAtMs == null || ttlSeconds == null || ttlSeconds <= 0) {
+      return null;
+    }
+    return DataPackManifestCache(
+      etag: values[_manifestEtagKey],
+      checkedAt: DateTime.fromMillisecondsSinceEpoch(checkedAtMs, isUtc: true),
+      ttl: Duration(seconds: ttlSeconds),
+    );
+  }
+
+  Future<void> saveManifestCache({
+    required String? etag,
+    required DateTime checkedAt,
+    required Duration ttl,
+  }) async {
+    await userDatabase.transaction(() async {
+      if (etag == null || etag.isEmpty) {
+        await userDatabase.customStatement(
+          'DELETE FROM data_pack_update_state WHERE key = ?',
+          [_manifestEtagKey],
+        );
+      } else {
+        await _put(_manifestEtagKey, etag, checkedAt);
+      }
+      await _put(
+        _manifestCheckedAtKey,
+        checkedAt.toUtc().millisecondsSinceEpoch.toString(),
+        checkedAt,
+      );
+      await _put(_manifestTtlKey, ttl.inSeconds.toString(), checkedAt);
+    });
+  }
+
+  bool isFresh(DataPackManifestCache cache) {
+    return !_now().toUtc().isAfter(cache.checkedAt.add(cache.ttl));
+  }
+
+  Future<void> _put(String key, String value, DateTime updatedAt) async {
+    await userDatabase
+        .into(userDatabase.dataPackUpdateState)
+        .insertOnConflictUpdate(
+          user_db.DataPackUpdateStateCompanion.insert(
+            key: key,
+            value: value,
+            updatedAt: updatedAt.toUtc(),
+          ),
+        );
+  }
+}
+
+class DataPackManifestCache {
+  const DataPackManifestCache({
+    required this.checkedAt,
+    required this.ttl,
+    this.etag,
+  });
+
+  final String? etag;
+  final DateTime checkedAt;
+  final Duration ttl;
+}

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -42,24 +42,41 @@ class DataPackUpdater {
       await emergencyOverrideRepository?.clearOverride();
     }
 
+    final packBaseUri = _packBaseUriForManifest(client.manifestUri);
     final results = <DataPackInstallResult>[];
     for (final pack in manifest.packs) {
-      final uri = client.manifestUri.resolve(pack.url.toString());
+      final uri = packBaseUri.resolve(pack.url.toString());
       final compressedBytes = await _download(uri);
       results.add(
         await installer.install(
           pack: pack,
           compressedBytes: compressedBytes,
           protectedVersions: protectedVersions,
+          activateCurrent: false,
         ),
       );
     }
     if (results.every(
       (result) => result.status == DataPackInstallStatus.installed,
     )) {
+      final currentPointer = results.lastOrNull?.pointer;
+      if (currentPointer != null) {
+        await installer.activateCurrentPointer(currentPointer);
+      }
       await client.saveManifestCache(manifestResult);
     }
     return results;
+  }
+
+  Uri _packBaseUriForManifest(Uri manifestUri) {
+    final manifestDirectory = manifestUri.resolve('./');
+    final pathSegments = manifestUri.pathSegments;
+    if (pathSegments.length >= 2 &&
+        pathSegments[pathSegments.length - 2] == 'catalog' &&
+        pathSegments.last == 'current.json') {
+      return manifestDirectory.resolve('../');
+    }
+    return manifestDirectory;
   }
 
   Future<List<int>> _download(Uri uri) async {

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -31,15 +31,6 @@ class DataPackUpdater {
     final protectedVersions = <String>{};
     if (override != null) {
       protectedVersions.add(override.version);
-      await emergencyOverrideRepository?.saveOverride(
-        EmergencyDataPackOverride(
-          id: override.id,
-          version: override.version,
-          reason: override.reason,
-        ),
-      );
-    } else {
-      await emergencyOverrideRepository?.clearOverride();
     }
 
     final packBaseUri = _packBaseUriForManifest(client.manifestUri);
@@ -62,6 +53,24 @@ class DataPackUpdater {
       final currentPointer = results.lastOrNull?.pointer;
       if (currentPointer != null) {
         await installer.activateCurrentPointer(currentPointer);
+      }
+      for (final packId in manifest.packs.map((pack) => pack.id).toSet()) {
+        await installer.pruneObsoletePacks(
+          packId,
+          keepVersionCount: 2,
+          protectedVersions: protectedVersions,
+        );
+      }
+      if (override != null) {
+        await emergencyOverrideRepository?.saveOverride(
+          EmergencyDataPackOverride(
+            id: override.id,
+            version: override.version,
+            reason: override.reason,
+          ),
+        );
+      } else {
+        await emergencyOverrideRepository?.clearOverride();
       }
       await client.saveManifestCache(manifestResult);
     }

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'data_pack_client.dart';
+import 'data_pack_installer.dart';
+import 'emergency_override_repository.dart';
+
+const _dataPackDownloadTimeout = Duration(seconds: 20);
+
+class DataPackUpdater {
+  DataPackUpdater({
+    required this.client,
+    required this.installer,
+    this.emergencyOverrideRepository,
+    HttpClient? httpClient,
+  }) : _httpClient = httpClient ?? HttpClient();
+
+  final DataPackClient client;
+  final DataPackInstaller installer;
+  final EmergencyOverrideRepository? emergencyOverrideRepository;
+  final HttpClient _httpClient;
+
+  Future<List<DataPackInstallResult>> checkForUpdates() async {
+    final manifestResult = await client.fetchManifestIfNeeded();
+    final manifest = manifestResult.manifest;
+    if (manifest == null) {
+      return const [];
+    }
+
+    final override = manifest.emergencyOverride;
+    if (override != null) {
+      await emergencyOverrideRepository?.saveOverride(
+        EmergencyDataPackOverride(
+          id: override.id,
+          version: override.version,
+          reason: override.reason,
+        ),
+      );
+    }
+
+    final results = <DataPackInstallResult>[];
+    for (final pack in manifest.packs) {
+      final uri = client.manifestUri.resolve(pack.url.toString());
+      final compressedBytes = await _download(uri);
+      results.add(
+        await installer.install(pack: pack, compressedBytes: compressedBytes),
+      );
+    }
+    return results;
+  }
+
+  Future<List<int>> _download(Uri uri) async {
+    final request = await _httpClient
+        .getUrl(uri)
+        .timeout(_dataPackDownloadTimeout);
+    final response = await request.close().timeout(_dataPackDownloadTimeout);
+    if (response.statusCode != HttpStatus.ok) {
+      throw const DataPackClientException('데이터팩을 내려받지 못했습니다.');
+    }
+    final bytes = <int>[];
+    await for (final chunk in response.timeout(_dataPackDownloadTimeout)) {
+      bytes.addAll(chunk);
+    }
+    return bytes;
+  }
+}

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -54,6 +54,11 @@ class DataPackUpdater {
         ),
       );
     }
+    if (results.every(
+      (result) => result.status == DataPackInstallStatus.installed,
+    )) {
+      await client.saveManifestCache(manifestResult);
+    }
     return results;
   }
 

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -28,7 +28,9 @@ class DataPackUpdater {
     }
 
     final override = manifest.emergencyOverride;
+    final protectedVersions = <String>{};
     if (override != null) {
+      protectedVersions.add(override.version);
       await emergencyOverrideRepository?.saveOverride(
         EmergencyDataPackOverride(
           id: override.id,
@@ -36,6 +38,8 @@ class DataPackUpdater {
           reason: override.reason,
         ),
       );
+    } else {
+      await emergencyOverrideRepository?.clearOverride();
     }
 
     final results = <DataPackInstallResult>[];
@@ -43,7 +47,11 @@ class DataPackUpdater {
       final uri = client.manifestUri.resolve(pack.url.toString());
       final compressedBytes = await _download(uri);
       results.add(
-        await installer.install(pack: pack, compressedBytes: compressedBytes),
+        await installer.install(
+          pack: pack,
+          compressedBytes: compressedBytes,
+          protectedVersions: protectedVersions,
+        ),
       );
     }
     return results;

--- a/apps/mobile/lib/core/datapack/emergency_override_repository.dart
+++ b/apps/mobile/lib/core/datapack/emergency_override_repository.dart
@@ -26,6 +26,13 @@ class EmergencyOverrideRepository {
         );
   }
 
+  Future<void> clearOverride() async {
+    await userDatabase.customStatement(
+      'DELETE FROM data_pack_update_state WHERE key = ?',
+      [_overrideKey],
+    );
+  }
+
   Future<EmergencyDataPackOverride?> readOverride() async {
     final row = await userDatabase
         .customSelect(

--- a/apps/mobile/lib/core/datapack/emergency_override_repository.dart
+++ b/apps/mobile/lib/core/datapack/emergency_override_repository.dart
@@ -1,0 +1,99 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+
+import '../database/user/user_database.dart' as user_db;
+import 'data_pack_installer.dart';
+
+export 'data_pack_installer.dart' show InstalledDataPackPointer;
+
+class EmergencyOverrideRepository {
+  EmergencyOverrideRepository({required this.userDatabase});
+
+  static const _overrideKey = 'datapack_emergency_override';
+
+  final user_db.UserDatabase userDatabase;
+
+  Future<void> saveOverride(EmergencyDataPackOverride override) async {
+    await userDatabase
+        .into(userDatabase.dataPackUpdateState)
+        .insertOnConflictUpdate(
+          user_db.DataPackUpdateStateCompanion.insert(
+            key: _overrideKey,
+            value: jsonEncode(override.toJson()),
+            updatedAt: DateTime.now().toUtc(),
+          ),
+        );
+  }
+
+  Future<EmergencyDataPackOverride?> readOverride() async {
+    final row = await userDatabase
+        .customSelect(
+          'SELECT value FROM data_pack_update_state WHERE key = ?',
+          variables: [Variable<String>(_overrideKey)],
+          readsFrom: {userDatabase.dataPackUpdateState},
+        )
+        .getSingleOrNull();
+    if (row == null) {
+      return null;
+    }
+    final decoded = jsonDecode(row.read<String>('value'));
+    if (decoded is! Map<String, Object?>) {
+      return null;
+    }
+    return EmergencyDataPackOverride.fromJson(decoded);
+  }
+}
+
+class EmergencyDataPackOverride {
+  const EmergencyDataPackOverride({
+    required this.id,
+    required this.version,
+    required this.reason,
+  });
+
+  factory EmergencyDataPackOverride.fromJson(Map<String, Object?> json) {
+    return EmergencyDataPackOverride(
+      id: _readString(json, 'id'),
+      version: _readString(json, 'version'),
+      reason: _readString(json, 'reason'),
+    );
+  }
+
+  final String id;
+  final String version;
+  final String reason;
+
+  Map<String, Object?> toJson() {
+    return {'id': id, 'version': version, 'reason': reason};
+  }
+}
+
+class DataPackSelectionPolicy {
+  const DataPackSelectionPolicy({required this.emergencyOverrideRepository});
+
+  final EmergencyOverrideRepository emergencyOverrideRepository;
+
+  Future<InstalledDataPackPointer> select({
+    required InstalledDataPackPointer installed,
+  }) async {
+    final override = await emergencyOverrideRepository.readOverride();
+    if (override == null) {
+      return installed;
+    }
+    return InstalledDataPackPointer(
+      id: override.id,
+      version: override.version,
+      path: installed.path,
+      reason: override.reason,
+    );
+  }
+}
+
+String _readString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! String || value.trim().isEmpty) {
+    throw const FormatException('Invalid emergency data pack override.');
+  }
+  return value.trim();
+}

--- a/apps/mobile/test/app_endpoints_test.dart
+++ b/apps/mobile/test/app_endpoints_test.dart
@@ -1,0 +1,35 @@
+import 'package:easysubway_mobile/app/app_endpoints.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('앱 endpoint는 데이터팩 base URL에서 manifest URI를 만든다', () {
+    const endpoints = AppEndpoints(
+      dataPackBaseUrl: 'https://cdn.easysubway.example/datapacks/',
+      reportApiBaseUrl: 'https://api.easysubway.example',
+    );
+
+    expect(
+      endpoints.dataPackManifestUri,
+      Uri.parse(
+        'https://cdn.easysubway.example/datapacks/catalog/current.json',
+      ),
+    );
+  });
+
+  test('앱 endpoint는 비어 있거나 host가 없는 데이터팩 URL을 사용하지 않는다', () {
+    expect(
+      const AppEndpoints(
+        dataPackBaseUrl: '',
+        reportApiBaseUrl: 'https://api.easysubway.example',
+      ).dataPackManifestUri,
+      isNull,
+    );
+    expect(
+      const AppEndpoints(
+        dataPackBaseUrl: 'not-a-url',
+        reportApiBaseUrl: 'https://api.easysubway.example',
+      ).dataPackManifestUri,
+      isNull,
+    );
+  });
+}

--- a/apps/mobile/test/app_endpoints_test.dart
+++ b/apps/mobile/test/app_endpoints_test.dart
@@ -16,6 +16,20 @@ void main() {
     );
   });
 
+  test('앱 endpoint는 slash가 없는 데이터팩 base URL도 directory로 처리한다', () {
+    const endpoints = AppEndpoints(
+      dataPackBaseUrl: 'https://cdn.easysubway.example/datapacks',
+      reportApiBaseUrl: 'https://api.easysubway.example',
+    );
+
+    expect(
+      endpoints.dataPackManifestUri,
+      Uri.parse(
+        'https://cdn.easysubway.example/datapacks/catalog/current.json',
+      ),
+    );
+  });
+
   test('앱 endpoint는 비어 있거나 host가 없는 데이터팩 URL을 사용하지 않는다', () {
     expect(
       const AppEndpoints(

--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -8,6 +8,7 @@ import 'package:easysubway_mobile/core/database/catalog/catalog_database.dart';
 import 'package:easysubway_mobile/core/database/catalog/catalog_database_opener.dart';
 import 'package:easysubway_mobile/core/database/user/user_database.dart';
 import 'package:easysubway_mobile/core/database/user/user_database_opener.dart';
+import 'package:easysubway_mobile/core/datapack/emergency_override_repository.dart';
 import 'package:easysubway_mobile/features/stations/data/drift_station_repository.dart';
 import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:flutter/services.dart';
@@ -236,6 +237,69 @@ void main() {
           ''').getSingle();
 
     expect(metadata.read<String>('value'), 'capital-v18');
+  });
+
+  test('catalog opener는 emergency override가 있으면 current보다 우선한다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-catalog-override-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final overrideRepository = EmergencyOverrideRepository(
+      userDatabase: userDatabase,
+    );
+    await overrideRepository.saveOverride(
+      const EmergencyDataPackOverride(
+        id: 'capital',
+        version: '17',
+        reason: '시설 상태 긴급 정정',
+      ),
+    );
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    await catalogDirectory.create(recursive: true);
+    final overridePack = File('${catalogDirectory.path}/capital-v17.sqlite');
+    final currentPack = File('${catalogDirectory.path}/capital-v18.sqlite');
+    for (final entry in [
+      (file: overridePack, activePack: 'capital-v17'),
+      (file: currentPack, activePack: 'capital-v18'),
+    ]) {
+      final database = CatalogDatabase.file(entry.file);
+      await database.seedBaselineIfEmpty();
+      await database
+          .into(database.catalogMetadata)
+          .insertOnConflictUpdate(
+            CatalogMetadataCompanion.insert(
+              key: 'activePack',
+              value: entry.activePack,
+              updatedAt: Value(DateTime.utc(2026, 6, 19, 14)),
+            ),
+          );
+      await database.close();
+    }
+    await File('${catalogDirectory.path}/current.json').writeAsString(
+      jsonEncode({
+        'id': 'capital',
+        'version': '18',
+        'path': currentPack.path,
+        'sha256': 'current-fixture',
+      }),
+    );
+
+    final database = await CatalogDatabaseOpener(
+      databaseDirectory: directory,
+      assetBundle: rootBundle,
+      emergencyOverrideRepository: overrideRepository,
+    ).open();
+    addTearDown(database.close);
+
+    final metadata = await database.customSelect('''
+          SELECT value
+          FROM catalog_metadata
+          WHERE key = 'activePack'
+          ''').getSingle();
+
+    expect(metadata.read<String>('value'), 'capital-v17');
   });
 
   test('앱 부트스트랩은 데이터팩 업데이트 후 current pointer로 catalog를 연다', () async {

--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -239,6 +239,53 @@ void main() {
     expect(metadata.read<String>('value'), 'capital-v18');
   });
 
+  test(
+    'catalog opener는 이전 컨테이너 경로의 current pointer도 현재 catalog에서 복원한다',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'easysubway-catalog-current-relocated-',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final catalogDirectory = Directory('${directory.path}/catalog');
+      await catalogDirectory.create(recursive: true);
+      final updatedPack = File('${catalogDirectory.path}/capital-v18.sqlite');
+      final updatedDatabase = CatalogDatabase.file(updatedPack);
+      await updatedDatabase.seedBaselineIfEmpty();
+      await updatedDatabase
+          .into(updatedDatabase.catalogMetadata)
+          .insertOnConflictUpdate(
+            CatalogMetadataCompanion.insert(
+              key: 'activePack',
+              value: 'capital-v18-relocated',
+              updatedAt: Value(DateTime.utc(2026, 6, 19, 15)),
+            ),
+          );
+      await updatedDatabase.close();
+      await File('${catalogDirectory.path}/current.json').writeAsString(
+        jsonEncode({
+          'id': 'capital',
+          'version': '18',
+          'path': '/stale/mobile/container/catalog/capital-v18.sqlite',
+          'sha256': 'local-fixture',
+        }),
+      );
+
+      final database = await CatalogDatabaseOpener(
+        databaseDirectory: directory,
+        assetBundle: rootBundle,
+      ).open();
+      addTearDown(database.close);
+
+      final metadata = await database.customSelect('''
+          SELECT value
+          FROM catalog_metadata
+          WHERE key = 'activePack'
+          ''').getSingle();
+
+      expect(metadata.read<String>('value'), 'capital-v18-relocated');
+    },
+  );
+
   test('catalog opener는 emergency override가 있으면 current보다 우선한다', () async {
     final directory = await Directory.systemTemp.createTemp(
       'easysubway-catalog-override-',

--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -1,12 +1,15 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:drift/drift.dart';
 import 'package:easysubway_mobile/app/app_bootstrap.dart';
 import 'package:easysubway_mobile/core/database/catalog/catalog_database.dart';
 import 'package:easysubway_mobile/core/database/catalog/catalog_database_opener.dart';
 import 'package:easysubway_mobile/core/database/user/user_database.dart';
 import 'package:easysubway_mobile/core/database/user/user_database_opener.dart';
 import 'package:easysubway_mobile/features/stations/data/drift_station_repository.dart';
+import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -188,6 +191,141 @@ void main() {
     expect(
       await installedCapitalPack.openRead(0, 16).first,
       'SQLite format 3'.codeUnits.followedBy([0]).toList(),
+    );
+  });
+
+  test('catalog opener는 업데이트된 current pointer가 있으면 해당 데이터팩을 연다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-catalog-current-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    await catalogDirectory.create(recursive: true);
+    final updatedPack = File('${catalogDirectory.path}/capital-v18.sqlite');
+    final updatedDatabase = CatalogDatabase.file(updatedPack);
+    await updatedDatabase.seedBaselineIfEmpty();
+    await updatedDatabase
+        .into(updatedDatabase.catalogMetadata)
+        .insertOnConflictUpdate(
+          CatalogMetadataCompanion.insert(
+            key: 'activePack',
+            value: 'capital-v18',
+            updatedAt: Value(DateTime.utc(2026, 6, 19, 12)),
+          ),
+        );
+    await updatedDatabase.close();
+    await File('${catalogDirectory.path}/current.json').writeAsString(
+      jsonEncode({
+        'id': 'capital',
+        'version': '18',
+        'path': updatedPack.path,
+        'sha256': 'local-fixture',
+      }),
+    );
+
+    final database = await CatalogDatabaseOpener(
+      databaseDirectory: directory,
+      assetBundle: rootBundle,
+    ).open();
+    addTearDown(database.close);
+
+    final metadata = await database.customSelect('''
+          SELECT value
+          FROM catalog_metadata
+          WHERE key = 'activePack'
+          ''').getSingle();
+
+    expect(metadata.read<String>('value'), 'capital-v18');
+  });
+
+  test('앱 부트스트랩은 데이터팩 업데이트 후 current pointer로 catalog를 연다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-bootstrap-current-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+
+    AppBootstrap? bootstrap;
+    addTearDown(() => bootstrap?.close());
+    bootstrap = await AppBootstrap.initialize(
+      databaseDirectory: directory,
+      assetBundle: rootBundle,
+      dataPackUpdateRunner:
+          ({required supportDirectory, required userDatabase}) async {
+            final catalogDirectory = Directory(
+              '${supportDirectory.path}/catalog',
+            );
+            await catalogDirectory.create(recursive: true);
+            final updatedPack = File(
+              '${catalogDirectory.path}/capital-v19.sqlite',
+            );
+            final updatedDatabase = CatalogDatabase.file(updatedPack);
+            await updatedDatabase.seedBaselineIfEmpty();
+            await updatedDatabase
+                .into(updatedDatabase.catalogMetadata)
+                .insertOnConflictUpdate(
+                  CatalogMetadataCompanion.insert(
+                    key: 'activePack',
+                    value: 'capital-v19',
+                    updatedAt: Value(DateTime.utc(2026, 6, 19, 13)),
+                  ),
+                );
+            await updatedDatabase.close();
+            await File('${catalogDirectory.path}/current.json').writeAsString(
+              jsonEncode({
+                'id': 'capital',
+                'version': '19',
+                'path': updatedPack.path,
+                'sha256': 'bootstrap-fixture',
+              }),
+            );
+          },
+      enableAnonymousAuth: false,
+      enablePushNotifications: false,
+    );
+
+    final metadata = await bootstrap.catalogDatabase.customSelect('''
+          SELECT value
+          FROM catalog_metadata
+          WHERE key = 'activePack'
+          ''').getSingle();
+
+    expect(metadata.read<String>('value'), 'capital-v19');
+  });
+
+  test('앱 부트스트랩은 데이터팩 업데이트 실패 시 내장 catalog로 계속 시작한다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-bootstrap-update-failure-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final reports = <FlutterErrorDetails>[];
+
+    AppBootstrap? bootstrap;
+    addTearDown(() => bootstrap?.close());
+    bootstrap = await runWithMobileErrorReporter(
+      reports.add,
+      () => AppBootstrap.initialize(
+        databaseDirectory: directory,
+        assetBundle: rootBundle,
+        dataPackUpdateRunner:
+            ({required supportDirectory, required userDatabase}) async {
+              throw const SocketException('manifest unavailable');
+            },
+        enableAnonymousAuth: false,
+        enablePushNotifications: false,
+      ),
+    );
+
+    final metadata = await bootstrap!.catalogDatabase.customSelect('''
+          SELECT value
+          FROM catalog_metadata
+          WHERE key = 'schemaVersion'
+          ''').getSingle();
+
+    expect(metadata.read<String>('value'), '1');
+    expect(reports, hasLength(1));
+    expect(
+      reports.single.context.toString(),
+      contains('데이터팩 업데이트 확인 중 예외가 발생했습니다.'),
     );
   });
 

--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -302,6 +302,55 @@ void main() {
     expect(metadata.read<String>('value'), 'capital-v17');
   });
 
+  test('catalog opener는 current pointer가 없어도 emergency override를 연다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-catalog-override-no-current-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final overrideRepository = EmergencyOverrideRepository(
+      userDatabase: userDatabase,
+    );
+    await overrideRepository.saveOverride(
+      const EmergencyDataPackOverride(
+        id: 'capital',
+        version: '17',
+        reason: '시설 상태 긴급 정정',
+      ),
+    );
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    await catalogDirectory.create(recursive: true);
+    final overridePack = File('${catalogDirectory.path}/capital-v17.sqlite');
+    final overrideDatabase = CatalogDatabase.file(overridePack);
+    await overrideDatabase.seedBaselineIfEmpty();
+    await overrideDatabase
+        .into(overrideDatabase.catalogMetadata)
+        .insertOnConflictUpdate(
+          CatalogMetadataCompanion.insert(
+            key: 'activePack',
+            value: 'capital-v17',
+            updatedAt: Value(DateTime.utc(2026, 6, 19, 16)),
+          ),
+        );
+    await overrideDatabase.close();
+
+    final database = await CatalogDatabaseOpener(
+      databaseDirectory: directory,
+      assetBundle: rootBundle,
+      emergencyOverrideRepository: overrideRepository,
+    ).open();
+    addTearDown(database.close);
+
+    final metadata = await database.customSelect('''
+          SELECT value
+          FROM catalog_metadata
+          WHERE key = 'activePack'
+          ''').getSingle();
+
+    expect(metadata.read<String>('value'), 'capital-v17');
+  });
+
   test('앱 부트스트랩은 데이터팩 업데이트 후 current pointer로 catalog를 연다', () async {
     final directory = await Directory.systemTemp.createTemp(
       'easysubway-bootstrap-current-',

--- a/apps/mobile/test/core/datapack/data_pack_installer_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_installer_test.dart
@@ -52,6 +52,42 @@ void main() {
     expect(await oldPack.exists(), isTrue);
   });
 
+  test('installer는 빈 sqlite payload를 rejected로 처리하고 임시 파일을 지운다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-empty-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    final installer = DataPackInstaller(
+      catalogDirectory: catalogDirectory,
+      userDatabase: userDatabase,
+    );
+    final sqliteBytes = <int>[];
+    final compressedBytes = gzip.encode(sqliteBytes);
+
+    final result = await installer.install(
+      pack: _pack(
+        version: '18',
+        sha256: sha256.convert(compressedBytes).toString(),
+        sqliteSha256: sha256.convert(sqliteBytes).toString(),
+      ),
+      compressedBytes: compressedBytes,
+    );
+
+    expect(result.status, DataPackInstallStatus.rejected);
+    expect(result.reason, DataPackInstallRejectionReason.invalidSqliteHeader);
+    expect(
+      await File('${catalogDirectory.path}/capital-v18.sqlite.tmp').exists(),
+      isFalse,
+    );
+    expect(
+      await File('${catalogDirectory.path}/current.json').exists(),
+      isFalse,
+    );
+  });
+
   test('installer는 검증된 sqlite pack을 버전별 파일로 설치하고 current를 전환한다', () async {
     final directory = await Directory.systemTemp.createTemp(
       'easysubway-datapack-install-',

--- a/apps/mobile/test/core/datapack/data_pack_installer_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_installer_test.dart
@@ -195,6 +195,53 @@ void main() {
       isTrue,
     );
   });
+
+  test('installer는 staged install 중 기존 current pack을 정리하지 않는다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-stage-prune-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    await catalogDirectory.create(recursive: true);
+    final currentPack = File('${catalogDirectory.path}/capital-v16.sqlite');
+    final previousPack = File('${catalogDirectory.path}/capital-v17.sqlite');
+    await currentPack.writeAsString('current');
+    await previousPack.writeAsString('previous');
+    await File('${catalogDirectory.path}/current.json').writeAsString(
+      jsonEncode({
+        'id': 'capital',
+        'version': '16',
+        'path': currentPack.path,
+        'sha256': 'current-sha',
+      }),
+    );
+    final sqliteBytes = await _validCatalogSqliteBytes(directory);
+    final compressedBytes = gzip.encode(sqliteBytes);
+    final installer = DataPackInstaller(
+      catalogDirectory: catalogDirectory,
+      userDatabase: userDatabase,
+    );
+
+    final result = await installer.install(
+      pack: _pack(
+        version: '18',
+        sha256: sha256.convert(compressedBytes).toString(),
+        sqliteSha256: sha256.convert(sqliteBytes).toString(),
+      ),
+      compressedBytes: compressedBytes,
+      activateCurrent: false,
+    );
+
+    expect(result.status, DataPackInstallStatus.installed);
+    expect(await currentPack.exists(), isTrue);
+    expect(await previousPack.exists(), isTrue);
+    expect(
+      await File('${catalogDirectory.path}/capital-v18.sqlite').exists(),
+      isTrue,
+    );
+  });
 }
 
 DataPackManifestEntry _pack({

--- a/apps/mobile/test/core/datapack/data_pack_installer_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_installer_test.dart
@@ -122,6 +122,43 @@ void main() {
       isTrue,
     );
   });
+
+  test('installer는 emergency override 대상 버전을 정리하지 않는다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-prune-override-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    await catalogDirectory.create(recursive: true);
+    final overridePack = File('${catalogDirectory.path}/capital-v17.sqlite');
+    final previous = File('${catalogDirectory.path}/capital-v18.sqlite');
+    await overridePack.writeAsString('override');
+    await previous.writeAsString('previous');
+    final sqliteBytes = await _validCatalogSqliteBytes(directory);
+    final compressedBytes = gzip.encode(sqliteBytes);
+    final installer = DataPackInstaller(
+      catalogDirectory: catalogDirectory,
+      userDatabase: userDatabase,
+    );
+
+    await installer.install(
+      pack: _pack(
+        version: '19',
+        sha256: sha256.convert(compressedBytes).toString(),
+        sqliteSha256: sha256.convert(sqliteBytes).toString(),
+      ),
+      compressedBytes: compressedBytes,
+      protectedVersions: const {'17'},
+    );
+
+    expect(await overridePack.exists(), isTrue);
+    expect(
+      await File('${catalogDirectory.path}/capital-v19.sqlite').exists(),
+      isTrue,
+    );
+  });
 }
 
 DataPackManifestEntry _pack({

--- a/apps/mobile/test/core/datapack/data_pack_installer_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_installer_test.dart
@@ -1,0 +1,150 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:easysubway_mobile/core/database/catalog/catalog_database.dart';
+import 'package:easysubway_mobile/core/database/user/user_database.dart'
+    as user_db;
+import 'package:easysubway_mobile/core/datapack/data_pack_installer.dart';
+import 'package:easysubway_mobile/core/datapack/data_pack_manifest.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('installer는 손상 gzip이면 기존 current pointer를 유지한다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-corrupt-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    await catalogDirectory.create(recursive: true);
+    final oldPack = File('${catalogDirectory.path}/capital-v17.sqlite');
+    await oldPack.writeAsString('old pack');
+    final current = File('${catalogDirectory.path}/current.json');
+    await current.writeAsString(
+      jsonEncode({
+        'id': 'capital',
+        'version': '17',
+        'path': oldPack.path,
+        'sha256': 'old-sha',
+      }),
+    );
+    final installer = DataPackInstaller(
+      catalogDirectory: catalogDirectory,
+      userDatabase: userDatabase,
+    );
+
+    final corruptBytes = [1, 2, 3, 4];
+    final result = await installer.install(
+      pack: _pack(
+        version: '18',
+        sha256: sha256.convert(corruptBytes).toString(),
+        sqliteSha256: '1' * 64,
+      ),
+      compressedBytes: corruptBytes,
+    );
+    final pointer = await installer.readCurrentPointer();
+
+    expect(result.status, DataPackInstallStatus.rejected);
+    expect(result.reason, DataPackInstallRejectionReason.invalidArchive);
+    expect(pointer?.version, '17');
+    expect(await oldPack.exists(), isTrue);
+  });
+
+  test('installer는 검증된 sqlite pack을 버전별 파일로 설치하고 current를 전환한다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-install-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final sqliteBytes = await _validCatalogSqliteBytes(directory);
+    final compressedBytes = gzip.encode(sqliteBytes);
+    final installer = DataPackInstaller(
+      catalogDirectory: Directory('${directory.path}/catalog'),
+      userDatabase: userDatabase,
+    );
+
+    final result = await installer.install(
+      pack: _pack(
+        version: '18',
+        sha256: sha256.convert(compressedBytes).toString(),
+        sqliteSha256: sha256.convert(sqliteBytes).toString(),
+      ),
+      compressedBytes: compressedBytes,
+    );
+    final pointer = await installer.readCurrentPointer();
+    final installedRows = await userDatabase
+        .select(userDatabase.installedDataPacks)
+        .get();
+
+    expect(result.status, DataPackInstallStatus.installed);
+    expect(pointer?.path.endsWith('catalog/capital-v18.sqlite'), isTrue);
+    expect(File(pointer!.path).existsSync(), isTrue);
+    expect(installedRows.single.packId, 'capital');
+    expect(installedRows.single.version, '18');
+  });
+
+  test('installer는 새 pack 설치 후 같은 pack의 오래된 버전을 정리한다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-prune-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    await catalogDirectory.create(recursive: true);
+    final oldest = File('${catalogDirectory.path}/capital-v16.sqlite');
+    final previous = File('${catalogDirectory.path}/capital-v17.sqlite');
+    await oldest.writeAsString('oldest');
+    await previous.writeAsString('previous');
+    final sqliteBytes = await _validCatalogSqliteBytes(directory);
+    final compressedBytes = gzip.encode(sqliteBytes);
+    final installer = DataPackInstaller(
+      catalogDirectory: catalogDirectory,
+      userDatabase: userDatabase,
+    );
+
+    await installer.install(
+      pack: _pack(
+        version: '18',
+        sha256: sha256.convert(compressedBytes).toString(),
+        sqliteSha256: sha256.convert(sqliteBytes).toString(),
+      ),
+      compressedBytes: compressedBytes,
+    );
+
+    expect(await oldest.exists(), isFalse);
+    expect(await previous.exists(), isTrue);
+    expect(
+      await File('${catalogDirectory.path}/capital-v18.sqlite').exists(),
+      isTrue,
+    );
+  });
+}
+
+DataPackManifestEntry _pack({
+  required String version,
+  required String sha256,
+  required String sqliteSha256,
+}) {
+  return DataPackManifestEntry(
+    id: 'capital',
+    version: version,
+    url: Uri.parse('capital-v$version.sqlite.gz'),
+    compressedSha256: sha256,
+    sqliteSha256: sqliteSha256,
+    schemaVersion: '1',
+    requiredTables: const ['catalog_metadata', 'stations', 'station_lines'],
+    minimumTableRows: const {'stations': 2},
+  );
+}
+
+Future<List<int>> _validCatalogSqliteBytes(Directory directory) async {
+  final file = File('${directory.path}/fixture.sqlite');
+  final database = CatalogDatabase.file(file);
+  await database.seedBaselineIfEmpty();
+  await database.close();
+  return file.readAsBytes();
+}

--- a/apps/mobile/test/core/datapack/data_pack_manifest_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_manifest_test.dart
@@ -1,0 +1,41 @@
+import 'package:easysubway_mobile/core/datapack/data_pack_manifest.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('데이터팩 manifest는 TTL과 pack 검증 조건을 파싱한다', () {
+    final manifest = DataPackManifest.fromJson({
+      'ttlSeconds': 3600,
+      'packs': [
+        {
+          'id': 'capital',
+          'version': '18',
+          'url': 'catalog/capital-v18.sqlite.gz',
+          'sha256': 'a' * 64,
+          'sqliteSha256': 'b' * 64,
+          'schemaVersion': '1',
+          'requiredTables': ['catalog_metadata', 'stations'],
+          'minimumTableRows': {'stations': 2},
+        },
+      ],
+      'emergencyOverride': {
+        'id': 'capital',
+        'version': '17',
+        'reason': '시설 상태 긴급 정정',
+      },
+    });
+
+    expect(manifest.ttl, const Duration(hours: 1));
+    expect(manifest.packs.single.id, 'capital');
+    expect(manifest.packs.single.version, '18');
+    expect(
+      manifest.packs.single.url,
+      Uri.parse('catalog/capital-v18.sqlite.gz'),
+    );
+    expect(manifest.packs.single.requiredTables, [
+      'catalog_metadata',
+      'stations',
+    ]);
+    expect(manifest.packs.single.minimumTableRows, {'stations': 2});
+    expect(manifest.emergencyOverride?.version, '17');
+  });
+}

--- a/apps/mobile/test/core/datapack/data_pack_manifest_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_manifest_test.dart
@@ -59,4 +59,46 @@ void main() {
       throwsFormatException,
     );
   });
+
+  test('데이터팩 manifest는 파일 경로로 안전하지 않은 pack id와 version을 거부한다', () {
+    expect(
+      () => DataPackManifest.fromJson({
+        'ttlSeconds': 3600,
+        'packs': [
+          {
+            'id': '../capital',
+            'version': '18',
+            'url': 'catalog/capital-v18.sqlite.gz',
+            'sha256': 'a' * 64,
+            'sqliteSha256': 'b' * 64,
+            'schemaVersion': '1',
+            'requiredTables': ['catalog_metadata'],
+          },
+        ],
+      }),
+      throwsFormatException,
+    );
+    expect(
+      () => DataPackManifest.fromJson({
+        'ttlSeconds': 3600,
+        'packs': [
+          {
+            'id': 'capital',
+            'version': '../18',
+            'url': 'catalog/capital-v18.sqlite.gz',
+            'sha256': 'a' * 64,
+            'sqliteSha256': 'b' * 64,
+            'schemaVersion': '1',
+            'requiredTables': ['catalog_metadata'],
+          },
+        ],
+        'emergencyOverride': {
+          'id': 'capital',
+          'version': '../17',
+          'reason': '시설 상태 긴급 정정',
+        },
+      }),
+      throwsFormatException,
+    );
+  });
 }

--- a/apps/mobile/test/core/datapack/data_pack_manifest_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_manifest_test.dart
@@ -38,4 +38,25 @@ void main() {
     expect(manifest.packs.single.minimumTableRows, {'stations': 2});
     expect(manifest.emergencyOverride?.version, '17');
   });
+
+  test('데이터팩 manifest는 SQL 식별자로 안전하지 않은 테이블명을 거부한다', () {
+    expect(
+      () => DataPackManifest.fromJson({
+        'ttlSeconds': 3600,
+        'packs': [
+          {
+            'id': 'capital',
+            'version': '18',
+            'url': 'catalog/capital-v18.sqlite.gz',
+            'sha256': 'a' * 64,
+            'sqliteSha256': 'b' * 64,
+            'schemaVersion': '1',
+            'requiredTables': ['catalog_metadata'],
+            'minimumTableRows': {'stations; DROP TABLE stations;': 1},
+          },
+        ],
+      }),
+      throwsFormatException,
+    );
+  });
 }

--- a/apps/mobile/test/core/datapack/data_pack_update_state_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_update_state_test.dart
@@ -45,7 +45,7 @@ void main() {
     expect(requestCount, 0);
   });
 
-  test('manifest client는 TTL 만료 후 ETag로 조건부 요청한다', () async {
+  test('manifest client는 TTL 만료 후 ETag 요청 결과를 성공 후 저장한다', () async {
     final userDatabase = user_db.UserDatabase.memory();
     addTearDown(userDatabase.close);
     final stateRepository = DataPackUpdateStateRepository(
@@ -93,6 +93,7 @@ void main() {
     );
 
     final result = await client.fetchManifestIfNeeded();
+    await client.saveManifestCache(result);
     final cache = await stateRepository.readManifestCache();
 
     expect(ifNoneMatch, 'etag-v17');

--- a/apps/mobile/test/core/datapack/data_pack_update_state_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_update_state_test.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:easysubway_mobile/core/database/user/user_database.dart'
+    as user_db;
+import 'package:easysubway_mobile/core/datapack/data_pack_client.dart';
+import 'package:easysubway_mobile/core/datapack/data_pack_update_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('manifest client는 TTL 안에서는 네트워크를 호출하지 않는다', () async {
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final stateRepository = DataPackUpdateStateRepository(
+      userDatabase: userDatabase,
+      now: () => DateTime.utc(2026, 6, 19, 10, 30),
+    );
+    await stateRepository.saveManifestCache(
+      etag: 'etag-v18',
+      checkedAt: DateTime.utc(2026, 6, 19, 10),
+      ttl: const Duration(hours: 1),
+    );
+    var requestCount = 0;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) {
+      requestCount++;
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..write('{}')
+        ..close();
+    });
+
+    final client = DataPackClient(
+      manifestUri: Uri.parse(
+        'http://${server.address.host}:${server.port}/manifest.json',
+      ),
+      stateRepository: stateRepository,
+    );
+
+    final result = await client.fetchManifestIfNeeded();
+
+    expect(result.status, DataPackManifestFetchStatus.freshCache);
+    expect(result.manifest, isNull);
+    expect(requestCount, 0);
+  });
+
+  test('manifest client는 TTL 만료 후 ETag로 조건부 요청한다', () async {
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final stateRepository = DataPackUpdateStateRepository(
+      userDatabase: userDatabase,
+      now: () => DateTime.utc(2026, 6, 19, 12),
+    );
+    await stateRepository.saveManifestCache(
+      etag: 'etag-v17',
+      checkedAt: DateTime.utc(2026, 6, 19, 10),
+      ttl: const Duration(minutes: 30),
+    );
+    String? ifNoneMatch;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) {
+      ifNoneMatch = request.headers.value(HttpHeaders.ifNoneMatchHeader);
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.set(HttpHeaders.etagHeader, 'etag-v18')
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'ttlSeconds': 60,
+            'packs': [
+              {
+                'id': 'capital',
+                'version': '18',
+                'url': 'capital-v18.sqlite.gz',
+                'sha256': 'a' * 64,
+                'sqliteSha256': 'b' * 64,
+                'schemaVersion': '1',
+                'requiredTables': ['catalog_metadata'],
+              },
+            ],
+          }),
+        )
+        ..close();
+    });
+
+    final client = DataPackClient(
+      manifestUri: Uri.parse(
+        'http://${server.address.host}:${server.port}/manifest.json',
+      ),
+      stateRepository: stateRepository,
+    );
+
+    final result = await client.fetchManifestIfNeeded();
+    final cache = await stateRepository.readManifestCache();
+
+    expect(ifNoneMatch, 'etag-v17');
+    expect(result.status, DataPackManifestFetchStatus.updated);
+    expect(result.manifest?.packs.single.version, '18');
+    expect(cache?.etag, 'etag-v18');
+    expect(cache?.ttl, const Duration(minutes: 1));
+  });
+}

--- a/apps/mobile/test/core/datapack/data_pack_updater_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_updater_test.dart
@@ -83,6 +83,7 @@ void main() {
 
     final results = await updater.checkForUpdates();
     final pointer = await installer.readCurrentPointer();
+    final manifestCache = await stateRepository.readManifestCache();
 
     expect(results.single.status, DataPackInstallStatus.rejected);
     expect(
@@ -91,6 +92,7 @@ void main() {
     );
     expect(pointer?.version, '17');
     expect(await oldPack.exists(), isTrue);
+    expect(manifestCache, isNull);
   });
 
   test('updater는 manifest에서 emergency override가 해제되면 저장값을 지운다', () async {
@@ -136,5 +138,6 @@ void main() {
     await updater.checkForUpdates();
 
     expect(await overrideRepository.readOverride(), isNull);
+    expect(await stateRepository.readManifestCache(), isNotNull);
   });
 }

--- a/apps/mobile/test/core/datapack/data_pack_updater_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_updater_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
+import 'package:easysubway_mobile/core/database/catalog/catalog_database.dart';
 import 'package:easysubway_mobile/core/database/user/user_database.dart'
     as user_db;
 import 'package:easysubway_mobile/core/datapack/data_pack_client.dart';
@@ -140,4 +141,198 @@ void main() {
     expect(await overrideRepository.readOverride(), isNull);
     expect(await stateRepository.readManifestCache(), isNotNull);
   });
+
+  test('updater는 pack URL을 데이터팩 base URL 기준으로 해석한다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-updater-url-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    final sqliteBytes = await _validCatalogSqliteBytes(directory);
+    final compressedBytes = gzip.encode(sqliteBytes);
+    final requestedPaths = <String>[];
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) {
+      requestedPaths.add(request.uri.path);
+      switch (request.uri.path) {
+        case '/datapacks/catalog/current.json':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..headers.contentType = ContentType.json
+            ..write(
+              jsonEncode({
+                'ttlSeconds': 60,
+                'packs': [
+                  _packJson(
+                    version: '18',
+                    url: 'catalog/capital-v18.sqlite.gz',
+                    compressedBytes: compressedBytes,
+                    sqliteBytes: sqliteBytes,
+                  ),
+                ],
+              }),
+            )
+            ..close();
+        case '/datapacks/catalog/capital-v18.sqlite.gz':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..add(compressedBytes)
+            ..close();
+        default:
+          request.response
+            ..statusCode = HttpStatus.notFound
+            ..close();
+      }
+    });
+    final updater = DataPackUpdater(
+      client: DataPackClient(
+        manifestUri: Uri.parse(
+          'http://${server.address.host}:${server.port}/datapacks/catalog/current.json',
+        ),
+        stateRepository: DataPackUpdateStateRepository(
+          userDatabase: userDatabase,
+          now: () => DateTime.utc(2026, 6, 19, 16),
+        ),
+      ),
+      installer: DataPackInstaller(
+        catalogDirectory: catalogDirectory,
+        userDatabase: userDatabase,
+      ),
+    );
+
+    final results = await updater.checkForUpdates();
+
+    expect(results.single.status, DataPackInstallStatus.installed);
+    expect(requestedPaths, [
+      '/datapacks/catalog/current.json',
+      '/datapacks/catalog/capital-v18.sqlite.gz',
+    ]);
+  });
+
+  test('updater는 multi-pack 실패 시 기존 current pointer를 유지한다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-updater-partial-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    await catalogDirectory.create(recursive: true);
+    final oldPack = File('${catalogDirectory.path}/capital-v17.sqlite');
+    await oldPack.writeAsString('old pack');
+    await File('${catalogDirectory.path}/current.json').writeAsString(
+      jsonEncode({
+        'id': 'capital',
+        'version': '17',
+        'path': oldPack.path,
+        'sha256': 'old-sha',
+      }),
+    );
+    final validSqliteBytes = await _validCatalogSqliteBytes(directory);
+    final validCompressedBytes = gzip.encode(validSqliteBytes);
+    final corruptBytes = gzip.encode(<int>[]);
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) {
+      switch (request.uri.path) {
+        case '/datapacks/catalog/current.json':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..headers.contentType = ContentType.json
+            ..write(
+              jsonEncode({
+                'ttlSeconds': 60,
+                'packs': [
+                  _packJson(
+                    version: '18',
+                    url: 'catalog/capital-v18.sqlite.gz',
+                    compressedBytes: validCompressedBytes,
+                    sqliteBytes: validSqliteBytes,
+                  ),
+                  _packJson(
+                    version: '19',
+                    url: 'catalog/capital-v19.sqlite.gz',
+                    compressedBytes: corruptBytes,
+                    sqliteBytes: const <int>[],
+                  ),
+                ],
+              }),
+            )
+            ..close();
+        case '/datapacks/catalog/capital-v18.sqlite.gz':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..add(validCompressedBytes)
+            ..close();
+        case '/datapacks/catalog/capital-v19.sqlite.gz':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..add(corruptBytes)
+            ..close();
+        default:
+          request.response
+            ..statusCode = HttpStatus.notFound
+            ..close();
+      }
+    });
+    final stateRepository = DataPackUpdateStateRepository(
+      userDatabase: userDatabase,
+      now: () => DateTime.utc(2026, 6, 19, 17),
+    );
+    final installer = DataPackInstaller(
+      catalogDirectory: catalogDirectory,
+      userDatabase: userDatabase,
+    );
+    final updater = DataPackUpdater(
+      client: DataPackClient(
+        manifestUri: Uri.parse(
+          'http://${server.address.host}:${server.port}/datapacks/catalog/current.json',
+        ),
+        stateRepository: stateRepository,
+      ),
+      installer: installer,
+    );
+
+    final results = await updater.checkForUpdates();
+    final pointer = await installer.readCurrentPointer();
+
+    expect(results.map((result) => result.status), [
+      DataPackInstallStatus.installed,
+      DataPackInstallStatus.rejected,
+    ]);
+    expect(pointer?.version, '17');
+    expect(
+      await File('${catalogDirectory.path}/capital-v18.sqlite').exists(),
+      isTrue,
+    );
+    expect(await stateRepository.readManifestCache(), isNull);
+  });
+}
+
+Map<String, Object?> _packJson({
+  required String version,
+  required String url,
+  required List<int> compressedBytes,
+  required List<int> sqliteBytes,
+}) {
+  return {
+    'id': 'capital',
+    'version': version,
+    'url': url,
+    'sha256': sha256.convert(compressedBytes).toString(),
+    'sqliteSha256': sha256.convert(sqliteBytes).toString(),
+    'schemaVersion': '1',
+    'requiredTables': ['catalog_metadata'],
+  };
+}
+
+Future<List<int>> _validCatalogSqliteBytes(Directory directory) async {
+  final file = File('${directory.path}/fixture.sqlite');
+  final database = CatalogDatabase.file(file);
+  await database.seedBaselineIfEmpty();
+  await database.close();
+  return file.readAsBytes();
 }

--- a/apps/mobile/test/core/datapack/data_pack_updater_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_updater_test.dart
@@ -233,6 +233,8 @@ void main() {
     );
     final validSqliteBytes = await _validCatalogSqliteBytes(directory);
     final validCompressedBytes = gzip.encode(validSqliteBytes);
+    final secondSqliteBytes = await _validCatalogSqliteBytes(directory);
+    final secondCompressedBytes = gzip.encode(secondSqliteBytes);
     final corruptBytes = gzip.encode(<int>[]);
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(server.close);
@@ -255,6 +257,12 @@ void main() {
                   _packJson(
                     version: '19',
                     url: 'catalog/capital-v19.sqlite.gz',
+                    compressedBytes: secondCompressedBytes,
+                    sqliteBytes: secondSqliteBytes,
+                  ),
+                  _packJson(
+                    version: '20',
+                    url: 'catalog/capital-v20.sqlite.gz',
                     compressedBytes: corruptBytes,
                     sqliteBytes: const <int>[],
                   ),
@@ -268,6 +276,11 @@ void main() {
             ..add(validCompressedBytes)
             ..close();
         case '/datapacks/catalog/capital-v19.sqlite.gz':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..add(secondCompressedBytes)
+            ..close();
+        case '/datapacks/catalog/capital-v20.sqlite.gz':
           request.response
             ..statusCode = HttpStatus.ok
             ..add(corruptBytes)
@@ -301,14 +314,95 @@ void main() {
 
     expect(results.map((result) => result.status), [
       DataPackInstallStatus.installed,
+      DataPackInstallStatus.installed,
       DataPackInstallStatus.rejected,
     ]);
     expect(pointer?.version, '17');
+    expect(await oldPack.exists(), isTrue);
     expect(
       await File('${catalogDirectory.path}/capital-v18.sqlite').exists(),
       isTrue,
     );
     expect(await stateRepository.readManifestCache(), isNull);
+  });
+
+  test('updater는 pack 검증 실패 시 기존 emergency override를 유지한다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-updater-override-fail-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final overrideRepository = EmergencyOverrideRepository(
+      userDatabase: userDatabase,
+    );
+    await overrideRepository.saveOverride(
+      const EmergencyDataPackOverride(
+        id: 'capital',
+        version: '17',
+        reason: '시설 상태 긴급 정정',
+      ),
+    );
+    final corruptBytes = [1, 2, 3, 4];
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) {
+      switch (request.uri.path) {
+        case '/datapacks/catalog/current.json':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..headers.contentType = ContentType.json
+            ..write(
+              jsonEncode({
+                'ttlSeconds': 60,
+                'packs': [
+                  {
+                    'id': 'capital',
+                    'version': '18',
+                    'url': 'catalog/capital-v18.sqlite.gz',
+                    'sha256': sha256.convert(corruptBytes).toString(),
+                    'sqliteSha256': '1' * 64,
+                    'schemaVersion': '1',
+                    'requiredTables': ['catalog_metadata'],
+                  },
+                ],
+              }),
+            )
+            ..close();
+        case '/datapacks/catalog/capital-v18.sqlite.gz':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..add(corruptBytes)
+            ..close();
+        default:
+          request.response
+            ..statusCode = HttpStatus.notFound
+            ..close();
+      }
+    });
+    final updater = DataPackUpdater(
+      client: DataPackClient(
+        manifestUri: Uri.parse(
+          'http://${server.address.host}:${server.port}/datapacks/catalog/current.json',
+        ),
+        stateRepository: DataPackUpdateStateRepository(
+          userDatabase: userDatabase,
+          now: () => DateTime.utc(2026, 6, 19, 18),
+        ),
+      ),
+      installer: DataPackInstaller(
+        catalogDirectory: Directory('${directory.path}/catalog'),
+        userDatabase: userDatabase,
+      ),
+      emergencyOverrideRepository: overrideRepository,
+    );
+
+    final results = await updater.checkForUpdates();
+    final override = await overrideRepository.readOverride();
+
+    expect(results.single.status, DataPackInstallStatus.rejected);
+    expect(override?.version, '17');
+    expect(override?.reason, '시설 상태 긴급 정정');
   });
 }
 

--- a/apps/mobile/test/core/datapack/data_pack_updater_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_updater_test.dart
@@ -8,6 +8,7 @@ import 'package:easysubway_mobile/core/datapack/data_pack_client.dart';
 import 'package:easysubway_mobile/core/datapack/data_pack_installer.dart';
 import 'package:easysubway_mobile/core/datapack/data_pack_update_state.dart';
 import 'package:easysubway_mobile/core/datapack/data_pack_updater.dart';
+import 'package:easysubway_mobile/core/datapack/emergency_override_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -84,8 +85,56 @@ void main() {
     final pointer = await installer.readCurrentPointer();
 
     expect(results.single.status, DataPackInstallStatus.rejected);
-    expect(results.single.reason, DataPackInstallRejectionReason.invalidArchive);
+    expect(
+      results.single.reason,
+      DataPackInstallRejectionReason.invalidArchive,
+    );
     expect(pointer?.version, '17');
     expect(await oldPack.exists(), isTrue);
+  });
+
+  test('updater는 manifest에서 emergency override가 해제되면 저장값을 지운다', () async {
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final overrideRepository = EmergencyOverrideRepository(
+      userDatabase: userDatabase,
+    );
+    await overrideRepository.saveOverride(
+      const EmergencyDataPackOverride(
+        id: 'capital',
+        version: '17',
+        reason: '시설 상태 긴급 정정',
+      ),
+    );
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) {
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(jsonEncode({'ttlSeconds': 60, 'packs': []}))
+        ..close();
+    });
+    final stateRepository = DataPackUpdateStateRepository(
+      userDatabase: userDatabase,
+      now: () => DateTime.utc(2026, 6, 19, 15),
+    );
+    final updater = DataPackUpdater(
+      client: DataPackClient(
+        manifestUri: Uri.parse(
+          'http://${server.address.host}:${server.port}/manifest.json',
+        ),
+        stateRepository: stateRepository,
+      ),
+      installer: DataPackInstaller(
+        catalogDirectory: Directory.systemTemp,
+        userDatabase: userDatabase,
+      ),
+      emergencyOverrideRepository: overrideRepository,
+    );
+
+    await updater.checkForUpdates();
+
+    expect(await overrideRepository.readOverride(), isNull);
   });
 }

--- a/apps/mobile/test/core/datapack/data_pack_updater_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_updater_test.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:easysubway_mobile/core/database/user/user_database.dart'
+    as user_db;
+import 'package:easysubway_mobile/core/datapack/data_pack_client.dart';
+import 'package:easysubway_mobile/core/datapack/data_pack_installer.dart';
+import 'package:easysubway_mobile/core/datapack/data_pack_update_state.dart';
+import 'package:easysubway_mobile/core/datapack/data_pack_updater.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('updater는 서버가 손상 pack을 내려주면 기존 current를 유지한다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-updater-corrupt-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    await catalogDirectory.create(recursive: true);
+    final oldPack = File('${catalogDirectory.path}/capital-v17.sqlite');
+    await oldPack.writeAsString('old pack');
+    await File('${catalogDirectory.path}/current.json').writeAsString(
+      jsonEncode({
+        'id': 'capital',
+        'version': '17',
+        'path': oldPack.path,
+        'sha256': 'old-sha',
+      }),
+    );
+    final corruptBytes = [1, 2, 3, 4];
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) {
+      if (request.uri.path == '/manifest.json') {
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.contentType = ContentType.json
+          ..write(
+            jsonEncode({
+              'ttlSeconds': 60,
+              'packs': [
+                {
+                  'id': 'capital',
+                  'version': '18',
+                  'url': 'capital-v18.sqlite.gz',
+                  'sha256': sha256.convert(corruptBytes).toString(),
+                  'sqliteSha256': '1' * 64,
+                  'schemaVersion': '1',
+                  'requiredTables': ['catalog_metadata'],
+                },
+              ],
+            }),
+          )
+          ..close();
+        return;
+      }
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..add(corruptBytes)
+        ..close();
+    });
+    final stateRepository = DataPackUpdateStateRepository(
+      userDatabase: userDatabase,
+      now: () => DateTime.utc(2026, 6, 19, 10),
+    );
+    final installer = DataPackInstaller(
+      catalogDirectory: catalogDirectory,
+      userDatabase: userDatabase,
+    );
+    final updater = DataPackUpdater(
+      client: DataPackClient(
+        manifestUri: Uri.parse(
+          'http://${server.address.host}:${server.port}/manifest.json',
+        ),
+        stateRepository: stateRepository,
+      ),
+      installer: installer,
+    );
+
+    final results = await updater.checkForUpdates();
+    final pointer = await installer.readCurrentPointer();
+
+    expect(results.single.status, DataPackInstallStatus.rejected);
+    expect(results.single.reason, DataPackInstallRejectionReason.invalidArchive);
+    expect(pointer?.version, '17');
+    expect(await oldPack.exists(), isTrue);
+  });
+}

--- a/apps/mobile/test/core/datapack/emergency_override_repository_test.dart
+++ b/apps/mobile/test/core/datapack/emergency_override_repository_test.dart
@@ -1,0 +1,34 @@
+import 'package:easysubway_mobile/core/database/user/user_database.dart'
+    as user_db;
+import 'package:easysubway_mobile/core/datapack/emergency_override_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('emergency override는 설치된 데이터팩 선택보다 우선한다', () async {
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final repository = EmergencyOverrideRepository(userDatabase: userDatabase);
+    await repository.saveOverride(
+      const EmergencyDataPackOverride(
+        id: 'capital',
+        version: '17',
+        reason: '시설 상태 긴급 정정',
+      ),
+    );
+
+    final selected =
+        await DataPackSelectionPolicy(
+          emergencyOverrideRepository: repository,
+        ).select(
+          installed: const InstalledDataPackPointer(
+            id: 'capital',
+            version: '18',
+            path: '/catalog/capital-v18.sqlite',
+          ),
+        );
+
+    expect(selected.id, 'capital');
+    expect(selected.version, '17');
+    expect(selected.reason, '시설 상태 긴급 정정');
+  });
+}


### PR DESCRIPTION
## 관련 이슈

close #509

## 작업 배경

- 도시철도 catalog 데이터팩을 앱 재배포 없이 교체할 수 있어야 시설/역 정보 정정 속도를 높일 수 있습니다.
- 앱 시작 경로는 네트워크 상태가 나빠도 내장 데이터팩으로 계속 시작해야 하며, manifest 확인은 TTL/ETag 기준으로 제한되어야 합니다.

## 작업 내용

- `EASYSUBWAY_DATA_PACK_BASE_URL` 기반 manifest endpoint를 추가하고, 앱 부트스트랩에서 user DB를 연 뒤 데이터팩 업데이트를 확인하고 catalog DB를 여는 순서로 연결했습니다.
- manifest client, TTL/ETag 캐시, gzip+sha256+SQLite quick_check 검증, schema/table/row-count 검증, versioned 데이터팩 파일 설치, atomic current pointer 전환을 추가했습니다.
- 손상된 pack은 기존 current pointer를 유지하고, 같은 pack의 오래된 버전 파일은 최근 2개만 남기도록 정리합니다.
- 긴급 override 저장소와 catalog 선택 우선순위를 추가해 override가 있으면 current pointer보다 먼저 해당 pack을 열도록 했습니다.
- manifest의 table 이름은 SQL identifier 형식으로 제한해 검증 쿼리 조립 시 안전한 값만 통과하도록 했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/core/database/mobile_local_database_test.dart test/core/datapack test/app_endpoints_test.dart`: 통과
  - `flutter analyze`: 통과
  - `flutter test`: 통과
  - `node --test tools/ci/*.test.mjs`: 통과, 66개 테스트
  - `flutter build apk --debug`: 통과, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - Android emulator `maum_on_api36`: APK 설치 성공, `am start -n com.easysubway.easysubway_mobile/.MainActivity` 성공, 앱 프로세스 확인, `AndroidRuntime:E` fatal 로그 없음
  - iOS Simulator XcodeBuildMCP `build_run_sim`: 통과, 앱 실행 성공

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/core/datapack/data_pack_installer.dart`의 검증 순서와 current pointer 전환 조건
  - `apps/mobile/lib/app/app_bootstrap.dart`의 앱 시작 순서 변경과 실패 흡수 경로
  - `apps/mobile/lib/core/database/catalog/catalog_database_opener.dart`의 emergency override 우선순위

## 리스크

- manifest URL이 설정된 빌드에서는 앱 시작 시 update check가 catalog open 전에 실행됩니다. TTL 캐시와 timeout을 적용했지만, endpoint 장애가 잦으면 error reporter에 보고가 누적될 수 있습니다.
- 이번 변경은 데이터팩 설치/선택 경로를 추가하며, 별도의 사용자 노출 UI는 만들지 않았습니다. 실패 시 앱은 내장 또는 기존 catalog로 계속 동작합니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
