### PR TITLE
[Fix] 데이터팩 활성 pack 선택 보정

### DIFF
--- a/apps/mobile/lib/core/datapack/data_pack_manifest.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_manifest.dart
@@ -2,6 +2,7 @@ class DataPackManifest {
   const DataPackManifest({
     required this.ttl,
     required this.packs,
+    this.activePack,
     this.emergencyOverride,
   });
 
@@ -22,12 +23,14 @@ class DataPackManifest {
             return DataPackManifestEntry.fromJson(rawPack);
           })
           .toList(growable: false),
+      activePack: _parseActivePack(json['activePack']),
       emergencyOverride: _parseOverride(json['emergencyOverride']),
     );
   }
 
   final Duration ttl;
   final List<DataPackManifestEntry> packs;
+  final ActiveDataPackManifest? activePack;
   final EmergencyOverrideManifest? emergencyOverride;
 }
 
@@ -89,6 +92,26 @@ class EmergencyOverrideManifest {
   final String id;
   final String version;
   final String reason;
+}
+
+class ActiveDataPackManifest {
+  const ActiveDataPackManifest({required this.id, required this.version});
+
+  final String id;
+  final String version;
+}
+
+ActiveDataPackManifest? _parseActivePack(Object? rawActivePack) {
+  if (rawActivePack == null) {
+    return null;
+  }
+  if (rawActivePack is! Map<String, Object?>) {
+    throw const FormatException('Invalid active data pack.');
+  }
+  return ActiveDataPackManifest(
+    id: _readPackId(rawActivePack['id']),
+    version: _readPackVersion(rawActivePack['version']),
+  );
 }
 
 EmergencyOverrideManifest? _parseOverride(Object? rawOverride) {

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -33,7 +33,7 @@ class DataPackUpdater {
     final override = manifest.emergencyOverride;
     final protectedVersions = <String>{};
     if (override != null) {
-      protectedVersions.add(override.version);
+      protectedVersions.add(_normalizedVersion(override.version));
     }
 
     final packBaseUri = _packBaseUriForManifest(client.manifestUri);
@@ -59,7 +59,7 @@ class DataPackUpdater {
       );
       if (currentPointer != null) {
         await installer.activateCurrentPointer(currentPointer);
-        protectedVersions.add(currentPointer.version);
+        protectedVersions.add(_normalizedVersion(currentPointer.version));
       }
       for (final packId in manifest.packs.map((pack) => pack.id).toSet()) {
         await installer.pruneObsoletePacks(
@@ -150,4 +150,8 @@ class DataPackUpdater {
 
 int _versionNumber(String version) {
   return int.tryParse(version) ?? 0;
+}
+
+String _normalizedVersion(String version) {
+  return _versionNumber(version).toString();
 }

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'data_pack_client.dart';
 import 'data_pack_installer.dart';
+import 'data_pack_manifest.dart';
 import 'emergency_override_repository.dart';
 
 const _dataPackDownloadTimeout = Duration(seconds: 20);
@@ -12,12 +13,14 @@ class DataPackUpdater {
     required this.client,
     required this.installer,
     this.emergencyOverrideRepository,
+    this.activePackId = 'capital',
     HttpClient? httpClient,
   }) : _httpClient = httpClient ?? HttpClient();
 
   final DataPackClient client;
   final DataPackInstaller installer;
   final EmergencyOverrideRepository? emergencyOverrideRepository;
+  final String activePackId;
   final HttpClient _httpClient;
 
   Future<List<DataPackInstallResult>> checkForUpdates() async {
@@ -50,7 +53,10 @@ class DataPackUpdater {
     if (results.every(
       (result) => result.status == DataPackInstallStatus.installed,
     )) {
-      final currentPointer = results.lastOrNull?.pointer;
+      final currentPointer = _currentPointerForManifest(
+        manifest: manifest,
+        results: results,
+      );
       if (currentPointer != null) {
         await installer.activateCurrentPointer(currentPointer);
       }
@@ -75,6 +81,43 @@ class DataPackUpdater {
       await client.saveManifestCache(manifestResult);
     }
     return results;
+  }
+
+  InstalledDataPackPointer? _currentPointerForManifest({
+    required DataPackManifest manifest,
+    required List<DataPackInstallResult> results,
+  }) {
+    if (results.isEmpty) {
+      return null;
+    }
+
+    final activePack = manifest.activePack;
+    if (activePack != null) {
+      for (final result in results) {
+        final pointer = result.pointer;
+        if (pointer?.id == activePack.id &&
+            pointer?.version == activePack.version) {
+          return pointer;
+        }
+      }
+      throw const DataPackClientException('활성 데이터팩을 선택하지 못했습니다.');
+    }
+
+    InstalledDataPackPointer? selected;
+    for (final result in results) {
+      final pointer = result.pointer;
+      if (pointer == null || pointer.id != activePackId) {
+        continue;
+      }
+      if (selected == null ||
+          _versionNumber(pointer.version) > _versionNumber(selected.version)) {
+        selected = pointer;
+      }
+    }
+    if (selected == null) {
+      throw const DataPackClientException('활성 데이터팩을 선택하지 못했습니다.');
+    }
+    return selected;
   }
 
   Uri _packBaseUriForManifest(Uri manifestUri) {
@@ -102,4 +145,8 @@ class DataPackUpdater {
     }
     return bytes;
   }
+}
+
+int _versionNumber(String version) {
+  return int.tryParse(version) ?? 0;
 }

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -59,6 +59,7 @@ class DataPackUpdater {
       );
       if (currentPointer != null) {
         await installer.activateCurrentPointer(currentPointer);
+        protectedVersions.add(currentPointer.version);
       }
       for (final packId in manifest.packs.map((pack) => pack.id).toSet()) {
         await installer.pruneObsoletePacks(

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -97,7 +97,8 @@ class DataPackUpdater {
       for (final result in results) {
         final pointer = result.pointer;
         if (pointer?.id == activePack.id &&
-            pointer?.version == activePack.version) {
+            _versionNumber(pointer?.version ?? '') ==
+                _versionNumber(activePack.version)) {
           return pointer;
         }
       }

--- a/apps/mobile/lib/core/datapack/emergency_override_repository.dart
+++ b/apps/mobile/lib/core/datapack/emergency_override_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:drift/drift.dart';
+import 'package:path/path.dart' as p;
 
 import '../database/user/user_database.dart' as user_db;
 import 'data_pack_installer.dart';
@@ -91,7 +92,10 @@ class DataPackSelectionPolicy {
     return InstalledDataPackPointer(
       id: override.id,
       version: override.version,
-      path: installed.path,
+      path: p.join(
+        p.dirname(installed.path),
+        '${override.id}-v${override.version}.sqlite',
+      ),
       reason: override.reason,
     );
   }

--- a/apps/mobile/lib/core/datapack/emergency_override_repository.dart
+++ b/apps/mobile/lib/core/datapack/emergency_override_repository.dart
@@ -62,8 +62,8 @@ class EmergencyDataPackOverride {
 
   factory EmergencyDataPackOverride.fromJson(Map<String, Object?> json) {
     return EmergencyDataPackOverride(
-      id: _readString(json, 'id'),
-      version: _readString(json, 'version'),
+      id: _readFilenamePart(json, 'id'),
+      version: _readFilenamePart(json, 'version'),
       reason: _readString(json, 'reason'),
     );
   }
@@ -107,4 +107,14 @@ String _readString(Map<String, Object?> json, String key) {
     throw const FormatException('Invalid emergency data pack override.');
   }
   return value.trim();
+}
+
+String _readFilenamePart(Map<String, Object?> json, String key) {
+  final value = _readString(json, key);
+  final hasUnsafePathPart =
+      value.contains('..') || value.contains('/') || value.contains('\\');
+  if (hasUnsafePathPart || !RegExp(r'^[A-Za-z0-9._-]+$').hasMatch(value)) {
+    throw const FormatException('Invalid emergency data pack override.');
+  }
+  return value;
 }

--- a/apps/mobile/test/core/datapack/data_pack_manifest_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_manifest_test.dart
@@ -5,6 +5,7 @@ void main() {
   test('데이터팩 manifest는 TTL과 pack 검증 조건을 파싱한다', () {
     final manifest = DataPackManifest.fromJson({
       'ttlSeconds': 3600,
+      'activePack': {'id': 'capital', 'version': '18'},
       'packs': [
         {
           'id': 'capital',
@@ -25,6 +26,8 @@ void main() {
     });
 
     expect(manifest.ttl, const Duration(hours: 1));
+    expect(manifest.activePack?.id, 'capital');
+    expect(manifest.activePack?.version, '18');
     expect(manifest.packs.single.id, 'capital');
     expect(manifest.packs.single.version, '18');
     expect(

--- a/apps/mobile/test/core/datapack/data_pack_updater_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_updater_test.dart
@@ -411,7 +411,7 @@ void main() {
     expect(pointer?.version, '19');
   });
 
-  test('updater는 manifest activePack으로 선택한 이전 version을 prune하지 않는다', () async {
+  test('updater는 zero-padded activePack 이전 version을 prune하지 않는다', () async {
     final directory = await Directory.systemTemp.createTemp(
       'easysubway-datapack-updater-active-prune-',
     );
@@ -419,8 +419,8 @@ void main() {
     final userDatabase = user_db.UserDatabase.memory();
     addTearDown(userDatabase.close);
     final catalogDirectory = Directory('${directory.path}/catalog');
-    final v17SqliteBytes = await _validCatalogSqliteBytes(directory);
-    final v17CompressedBytes = gzip.encode(v17SqliteBytes);
+    final v017SqliteBytes = await _validCatalogSqliteBytes(directory);
+    final v017CompressedBytes = gzip.encode(v017SqliteBytes);
     final v18SqliteBytes = await _validCatalogSqliteBytes(directory);
     final v18CompressedBytes = gzip.encode(v18SqliteBytes);
     final v19SqliteBytes = await _validCatalogSqliteBytes(directory);
@@ -436,7 +436,7 @@ void main() {
             ..write(
               jsonEncode({
                 'ttlSeconds': 60,
-                'activePack': {'id': 'capital', 'version': '17'},
+                'activePack': {'id': 'capital', 'version': '017'},
                 'packs': [
                   _packJson(
                     version: '19',
@@ -451,19 +451,19 @@ void main() {
                     sqliteBytes: v18SqliteBytes,
                   ),
                   _packJson(
-                    version: '17',
-                    url: 'catalog/capital-v17.sqlite.gz',
-                    compressedBytes: v17CompressedBytes,
-                    sqliteBytes: v17SqliteBytes,
+                    version: '017',
+                    url: 'catalog/capital-v017.sqlite.gz',
+                    compressedBytes: v017CompressedBytes,
+                    sqliteBytes: v017SqliteBytes,
                   ),
                 ],
               }),
             )
             ..close();
-        case '/datapacks/catalog/capital-v17.sqlite.gz':
+        case '/datapacks/catalog/capital-v017.sqlite.gz':
           request.response
             ..statusCode = HttpStatus.ok
-            ..add(v17CompressedBytes)
+            ..add(v017CompressedBytes)
             ..close();
         case '/datapacks/catalog/capital-v18.sqlite.gz':
           request.response
@@ -507,9 +507,9 @@ void main() {
       ),
       isTrue,
     );
-    expect(pointer?.version, '17');
+    expect(pointer?.version, '017');
     expect(
-      await File('${catalogDirectory.path}/capital-v17.sqlite').exists(),
+      await File('${catalogDirectory.path}/capital-v017.sqlite').exists(),
       isTrue,
     );
   });

--- a/apps/mobile/test/core/datapack/data_pack_updater_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_updater_test.dart
@@ -327,6 +327,7 @@ void main() {
   });
 
   test('updater는 manifest 순서와 무관하게 최신 capital pack을 current로 선택한다', () async {
+    // activePack이 없는 manifest에서는 기본 pack id의 최신 version을 current로 선택한다.
     final directory = await Directory.systemTemp.createTemp(
       'easysubway-datapack-updater-active-',
     );
@@ -510,6 +511,14 @@ void main() {
     expect(pointer?.version, '017');
     expect(
       await File('${catalogDirectory.path}/capital-v017.sqlite').exists(),
+      isTrue,
+    );
+    expect(
+      await File('${catalogDirectory.path}/capital-v18.sqlite').exists(),
+      isTrue,
+    );
+    expect(
+      await File('${catalogDirectory.path}/capital-v19.sqlite').exists(),
       isTrue,
     );
   });

--- a/apps/mobile/test/core/datapack/data_pack_updater_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_updater_test.dart
@@ -326,6 +326,91 @@ void main() {
     expect(await stateRepository.readManifestCache(), isNull);
   });
 
+  test('updater는 manifest 순서와 무관하게 최신 capital pack을 current로 선택한다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-updater-active-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    final olderSqliteBytes = await _validCatalogSqliteBytes(directory);
+    final olderCompressedBytes = gzip.encode(olderSqliteBytes);
+    final newerSqliteBytes = await _validCatalogSqliteBytes(directory);
+    final newerCompressedBytes = gzip.encode(newerSqliteBytes);
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) {
+      switch (request.uri.path) {
+        case '/datapacks/catalog/current.json':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..headers.contentType = ContentType.json
+            ..write(
+              jsonEncode({
+                'ttlSeconds': 60,
+                'packs': [
+                  _packJson(
+                    version: '19',
+                    url: 'catalog/capital-v19.sqlite.gz',
+                    compressedBytes: newerCompressedBytes,
+                    sqliteBytes: newerSqliteBytes,
+                  ),
+                  _packJson(
+                    version: '18',
+                    url: 'catalog/capital-v18.sqlite.gz',
+                    compressedBytes: olderCompressedBytes,
+                    sqliteBytes: olderSqliteBytes,
+                  ),
+                ],
+              }),
+            )
+            ..close();
+        case '/datapacks/catalog/capital-v18.sqlite.gz':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..add(olderCompressedBytes)
+            ..close();
+        case '/datapacks/catalog/capital-v19.sqlite.gz':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..add(newerCompressedBytes)
+            ..close();
+        default:
+          request.response
+            ..statusCode = HttpStatus.notFound
+            ..close();
+      }
+    });
+    final installer = DataPackInstaller(
+      catalogDirectory: catalogDirectory,
+      userDatabase: userDatabase,
+    );
+    final updater = DataPackUpdater(
+      client: DataPackClient(
+        manifestUri: Uri.parse(
+          'http://${server.address.host}:${server.port}/datapacks/catalog/current.json',
+        ),
+        stateRepository: DataPackUpdateStateRepository(
+          userDatabase: userDatabase,
+          now: () => DateTime.utc(2026, 6, 19, 18, 30),
+        ),
+      ),
+      installer: installer,
+    );
+
+    final results = await updater.checkForUpdates();
+    final pointer = await installer.readCurrentPointer();
+
+    expect(
+      results.every(
+        (result) => result.status == DataPackInstallStatus.installed,
+      ),
+      isTrue,
+    );
+    expect(pointer?.version, '19');
+  });
+
   test('updater는 pack 검증 실패 시 기존 emergency override를 유지한다', () async {
     final directory = await Directory.systemTemp.createTemp(
       'easysubway-datapack-updater-override-fail-',

--- a/apps/mobile/test/core/datapack/data_pack_updater_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_updater_test.dart
@@ -411,6 +411,109 @@ void main() {
     expect(pointer?.version, '19');
   });
 
+  test('updater는 manifest activePack으로 선택한 이전 version을 prune하지 않는다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-datapack-updater-active-prune-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final catalogDirectory = Directory('${directory.path}/catalog');
+    final v17SqliteBytes = await _validCatalogSqliteBytes(directory);
+    final v17CompressedBytes = gzip.encode(v17SqliteBytes);
+    final v18SqliteBytes = await _validCatalogSqliteBytes(directory);
+    final v18CompressedBytes = gzip.encode(v18SqliteBytes);
+    final v19SqliteBytes = await _validCatalogSqliteBytes(directory);
+    final v19CompressedBytes = gzip.encode(v19SqliteBytes);
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) {
+      switch (request.uri.path) {
+        case '/datapacks/catalog/current.json':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..headers.contentType = ContentType.json
+            ..write(
+              jsonEncode({
+                'ttlSeconds': 60,
+                'activePack': {'id': 'capital', 'version': '17'},
+                'packs': [
+                  _packJson(
+                    version: '19',
+                    url: 'catalog/capital-v19.sqlite.gz',
+                    compressedBytes: v19CompressedBytes,
+                    sqliteBytes: v19SqliteBytes,
+                  ),
+                  _packJson(
+                    version: '18',
+                    url: 'catalog/capital-v18.sqlite.gz',
+                    compressedBytes: v18CompressedBytes,
+                    sqliteBytes: v18SqliteBytes,
+                  ),
+                  _packJson(
+                    version: '17',
+                    url: 'catalog/capital-v17.sqlite.gz',
+                    compressedBytes: v17CompressedBytes,
+                    sqliteBytes: v17SqliteBytes,
+                  ),
+                ],
+              }),
+            )
+            ..close();
+        case '/datapacks/catalog/capital-v17.sqlite.gz':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..add(v17CompressedBytes)
+            ..close();
+        case '/datapacks/catalog/capital-v18.sqlite.gz':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..add(v18CompressedBytes)
+            ..close();
+        case '/datapacks/catalog/capital-v19.sqlite.gz':
+          request.response
+            ..statusCode = HttpStatus.ok
+            ..add(v19CompressedBytes)
+            ..close();
+        default:
+          request.response
+            ..statusCode = HttpStatus.notFound
+            ..close();
+      }
+    });
+    final installer = DataPackInstaller(
+      catalogDirectory: catalogDirectory,
+      userDatabase: userDatabase,
+    );
+    final updater = DataPackUpdater(
+      client: DataPackClient(
+        manifestUri: Uri.parse(
+          'http://${server.address.host}:${server.port}/datapacks/catalog/current.json',
+        ),
+        stateRepository: DataPackUpdateStateRepository(
+          userDatabase: userDatabase,
+          now: () => DateTime.utc(2026, 6, 19, 18, 45),
+        ),
+      ),
+      installer: installer,
+    );
+
+    final results = await updater.checkForUpdates();
+    final pointer = await installer.readCurrentPointer();
+
+    expect(
+      results.every(
+        (result) => result.status == DataPackInstallStatus.installed,
+      ),
+      isTrue,
+    );
+    expect(pointer?.version, '17');
+    expect(
+      await File('${catalogDirectory.path}/capital-v17.sqlite').exists(),
+      isTrue,
+    );
+  });
+
   test('updater는 pack 검증 실패 시 기존 emergency override를 유지한다', () async {
     final directory = await Directory.systemTemp.createTemp(
       'easysubway-datapack-updater-override-fail-',

--- a/apps/mobile/test/core/datapack/emergency_override_repository_test.dart
+++ b/apps/mobile/test/core/datapack/emergency_override_repository_test.dart
@@ -32,4 +32,19 @@ void main() {
     expect(selected.path, '/catalog/capital-v17.sqlite');
     expect(selected.reason, '시설 상태 긴급 정정');
   });
+
+  test('emergency override는 파일 경로 조작 문자를 거부한다', () async {
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(userDatabase.close);
+    final repository = EmergencyOverrideRepository(userDatabase: userDatabase);
+    await repository.saveOverride(
+      const EmergencyDataPackOverride(
+        id: '../capital',
+        version: '17',
+        reason: '시설 상태 긴급 정정',
+      ),
+    );
+
+    await expectLater(repository.readOverride(), throwsFormatException);
+  });
 }

--- a/apps/mobile/test/core/datapack/emergency_override_repository_test.dart
+++ b/apps/mobile/test/core/datapack/emergency_override_repository_test.dart
@@ -29,6 +29,7 @@ void main() {
 
     expect(selected.id, 'capital');
     expect(selected.version, '17');
+    expect(selected.path, '/catalog/capital-v17.sqlite');
     expect(selected.reason, '시설 상태 긴급 정정');
   });
 }


### PR DESCRIPTION
## 관련 이슈

close #511

## 작업 배경

데이터팩 manifest에 여러 pack 또는 같은 pack의 여러 version이 포함될 때 배열 마지막 항목을 current pointer로 쓰면 의도한 catalog가 아닌 pack이 활성화될 수 있다. emergency override 선택 정책도 override id/version과 기존 current path를 섞어 반환해 실제로 다른 DB 파일을 열 위험이 있었다.

## 작업 내용

- manifest의 `activePack` id/version을 파싱해 명시된 활성 pack을 current pointer로 선택한다.
- `activePack`이 없을 때는 앱 기본 catalog id인 `capital` 중 가장 높은 숫자 version을 선택한다.
- emergency override 선택 결과가 override version의 `${id}-v${version}.sqlite` 파일을 가리키도록 path를 재구성한다.
- manifest 순서가 뒤섞인 경우와 override path 일관성 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/core/datapack/data_pack_manifest_test.dart test/core/datapack/data_pack_updater_test.dart test/core/datapack/emergency_override_repository_test.dart` 통과
  - `flutter test test/app_endpoints_test.dart test/core/datapack/data_pack_manifest_test.dart test/core/datapack/data_pack_update_state_test.dart test/core/datapack/data_pack_installer_test.dart test/core/datapack/data_pack_updater_test.dart test/core/datapack/emergency_override_repository_test.dart test/core/database/mobile_local_database_test.dart` 통과
  - `flutter analyze` 통과

## 리뷰어 메모

- `DataPackUpdater._currentPointerForManifest`가 `activePack` 우선, 기본 catalog 최신 version fallback 순서로 선택하는지 먼저 봐야 한다.
- `DataPackSelectionPolicy.select`의 override path가 id/version과 같은 파일명을 가리키는지 확인하면 된다.

## 리스크

- manifest에 `activePack`이 잘못 지정되면 update를 실패시켜 기존 current/cache를 유지한다. 잘못된 manifest를 조용히 적용하지 않기 위한 동작이다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.