### PR TITLE
[Fix] 경로 service pattern 환승 경계 보강

### DIFF
--- a/apps/mobile/lib/features/routes/application/network_graph.dart
+++ b/apps/mobile/lib/features/routes/application/network_graph.dart
@@ -43,12 +43,25 @@ class RouteEdge {
 class NetworkGraph {
   NetworkGraph({required List<RouteNode> nodes, required List<RouteEdge> edges})
     : nodes = List.unmodifiable(nodes),
-      edges = List.unmodifiable(edges);
+      edges = List.unmodifiable(edges),
+      _edgesByFromNodeId = _indexEdgesByFromNodeId(edges);
 
   final List<RouteNode> nodes;
   final List<RouteEdge> edges;
+  final Map<String, List<RouteEdge>> _edgesByFromNodeId;
 
   Iterable<RouteEdge> edgesFrom(String nodeId) {
-    return edges.where((edge) => edge.fromNodeId == nodeId);
+    return _edgesByFromNodeId[nodeId] ?? const [];
   }
+}
+
+Map<String, List<RouteEdge>> _indexEdgesByFromNodeId(List<RouteEdge> edges) {
+  final indexed = <String, List<RouteEdge>>{};
+  for (final edge in edges) {
+    indexed.putIfAbsent(edge.fromNodeId, () => <RouteEdge>[]).add(edge);
+  }
+  return {
+    for (final entry in indexed.entries)
+      entry.key: List.unmodifiable(entry.value),
+  };
 }

--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -52,6 +52,7 @@ class LocalRouteEngine {
           toNodeId: edge.toNodeId,
           type: _stepType(edge.type),
           cost: accessCost.cost,
+          durationSeconds: edge.baseCost,
           lineId: edge.lineId,
           transferStationId: edge.transferStationId,
           includesStairs: edge.includesStairs,
@@ -90,6 +91,13 @@ class LocalRouteEngine {
       visited.add(current);
 
       for (final edge in graph.edgesFrom(current)) {
+        if (edge.type == RouteEdgeType.entry && current != originNodeId) {
+          continue;
+        }
+        if (edge.type == RouteEdgeType.exit &&
+            edge.toNodeId != destinationNodeId) {
+          continue;
+        }
         final edgeCost = costCalculator.costFor(edge, mobilityType);
         if (edgeCost.isBlocked) {
           blockedReasonCodes.addAll(edgeCost.warningCodes);

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -288,6 +288,10 @@ class _RouteCatalogSnapshot {
     final edges = <graph.RouteEdge>[];
     final nodeKeysByStation = <String, Map<String, _RouteNodeKey>>{};
     final explicitTransferPairs = <String>{};
+    final stationLineKeys = {
+      for (final stationLine in stationLines)
+        _stationLineKey(stationLine.stationId, stationLine.lineId),
+    };
 
     for (final stationLine in stationLines) {
       _addRouteNodeKey(nodeKeysByStation, stationLine.routeNodeKey);
@@ -299,10 +303,10 @@ class _RouteCatalogSnapshot {
       }
       final fromNode = _RouteNodeKey.tryParse(networkEdge.fromNodeId);
       final toNode = _RouteNodeKey.tryParse(networkEdge.toNodeId);
-      if (fromNode != null && _hasStationLine(fromNode)) {
+      if (fromNode != null && _hasStationLine(fromNode, stationLineKeys)) {
         _addRouteNodeKey(nodeKeysByStation, fromNode);
       }
-      if (toNode != null && _hasStationLine(toNode)) {
+      if (toNode != null && _hasStationLine(toNode, stationLineKeys)) {
         _addRouteNodeKey(nodeKeysByStation, toNode);
       }
       if (networkEdge.routeEdgeType == graph.RouteEdgeType.transfer) {
@@ -402,11 +406,9 @@ class _RouteCatalogSnapshot {
     return graph.NetworkGraph(nodes: nodes, edges: edges);
   }
 
-  bool _hasStationLine(_RouteNodeKey nodeKey) {
-    return stationLines.any(
-      (stationLine) =>
-          stationLine.stationId == nodeKey.stationId &&
-          stationLine.lineId == nodeKey.lineId,
+  bool _hasStationLine(_RouteNodeKey nodeKey, Set<String> stationLineKeys) {
+    return stationLineKeys.contains(
+      _stationLineKey(nodeKey.stationId, nodeKey.lineId),
     );
   }
 
@@ -435,6 +437,10 @@ class _RouteCatalogSnapshot {
 
 String _edgePairKey(String fromNodeId, String toNodeId) {
   return '$fromNodeId->$toNodeId';
+}
+
+String _stationLineKey(String stationId, String lineId) {
+  return '$stationId:$lineId';
 }
 
 String _selectNetworkEdgeColumn(

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -288,6 +288,7 @@ class _RouteCatalogSnapshot {
     final edges = <graph.RouteEdge>[];
     final nodeKeysByStation = <String, Map<String, _RouteNodeKey>>{};
     final explicitAccessPairs = <String>{};
+    final actualExplicitTransferPairs = <String>{};
     final explicitTransferPairs = <String>{};
     final explicitTransferLinePairs = <String>{};
     final stationLineKeys = {
@@ -319,6 +320,9 @@ class _RouteCatalogSnapshot {
         );
       }
       if (routeEdgeType == graph.RouteEdgeType.transfer) {
+        actualExplicitTransferPairs.add(
+          _edgePairKey(networkEdge.fromNodeId, networkEdge.toNodeId),
+        );
         explicitTransferPairs.add(
           _edgePairKey(networkEdge.fromNodeId, networkEdge.toNodeId),
         );
@@ -352,6 +356,10 @@ class _RouteCatalogSnapshot {
           continue;
         }
         final pairKey = _edgePairKey(pair.fromNodeId, pair.toNodeId);
+        if (routeEdgeType == graph.RouteEdgeType.transfer &&
+            actualExplicitTransferPairs.contains(pairKey)) {
+          continue;
+        }
         if (routeEdgeType == graph.RouteEdgeType.entry ||
             routeEdgeType == graph.RouteEdgeType.exit) {
           explicitAccessPairs.add(pairKey);
@@ -421,7 +429,8 @@ class _RouteCatalogSnapshot {
           if (from.nodeId == to.nodeId) {
             continue;
           }
-          if (from.lineId == to.lineId) {
+          if (from.lineId == to.lineId &&
+              !_isDifferentServicePatternTransfer(from, to)) {
             continue;
           }
           if (_hasExplicitTransferPair(
@@ -528,9 +537,19 @@ List<({String fromNodeId, String toNodeId})> _expandedExplicitEdgePairs(
         for (final to in _matchingNodeKeys(toNode, nodeKeysByStation))
           if (from.nodeId != to.nodeId)
             (fromNodeId: from.nodeId, toNodeId: to.nodeId),
+      for (final to in _matchingNodeKeys(toNode, nodeKeysByStation))
+        for (final from in _matchingNodeKeys(fromNode, nodeKeysByStation))
+          if (from.nodeId != to.nodeId)
+            (fromNodeId: to.nodeId, toNodeId: from.nodeId),
     ];
   }
   return const [];
+}
+
+bool _isDifferentServicePatternTransfer(_RouteNodeKey from, _RouteNodeKey to) {
+  return from.servicePattern.isNotEmpty &&
+      to.servicePattern.isNotEmpty &&
+      from.servicePattern != to.servicePattern;
 }
 
 List<_RouteNodeKey> _matchingNodeKeys(

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -288,6 +288,7 @@ class _RouteCatalogSnapshot {
     final edges = <graph.RouteEdge>[];
     final nodeKeysByStation = <String, Map<String, _RouteNodeKey>>{};
     final explicitTransferPairs = <String>{};
+    final explicitTransferLinePairs = <String>{};
     final stationLineKeys = {
       for (final stationLine in stationLines)
         _stationLineKey(stationLine.stationId, stationLine.lineId),
@@ -313,6 +314,9 @@ class _RouteCatalogSnapshot {
         explicitTransferPairs.add(
           _edgePairKey(networkEdge.fromNodeId, networkEdge.toNodeId),
         );
+        if (fromNode != null && toNode != null) {
+          explicitTransferLinePairs.add(_lineTransferPairKey(fromNode, toNode));
+        }
       }
     }
 
@@ -361,8 +365,11 @@ class _RouteCatalogSnapshot {
           if (from.nodeId == to.nodeId) {
             continue;
           }
-          if (explicitTransferPairs.contains(
-            _edgePairKey(from.nodeId, to.nodeId),
+          if (_hasExplicitTransferPair(
+            from,
+            to,
+            explicitTransferPairs,
+            explicitTransferLinePairs,
           )) {
             continue;
           }
@@ -437,6 +444,21 @@ class _RouteCatalogSnapshot {
 
 String _edgePairKey(String fromNodeId, String toNodeId) {
   return '$fromNodeId->$toNodeId';
+}
+
+bool _hasExplicitTransferPair(
+  _RouteNodeKey from,
+  _RouteNodeKey to,
+  Set<String> explicitTransferPairs,
+  Set<String> explicitTransferLinePairs,
+) {
+  return explicitTransferPairs.contains(_edgePairKey(from.nodeId, to.nodeId)) ||
+      explicitTransferLinePairs.contains(_lineTransferPairKey(from, to));
+}
+
+String _lineTransferPairKey(_RouteNodeKey from, _RouteNodeKey to) {
+  return '${_stationLineKey(from.stationId, from.lineId)}'
+      '->${_stationLineKey(to.stationId, to.lineId)}';
 }
 
 String _stationLineKey(String stationId, String lineId) {

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -287,6 +287,7 @@ class _RouteCatalogSnapshot {
     final nodes = <graph.RouteNode>[];
     final edges = <graph.RouteEdge>[];
     final nodeKeysByStation = <String, Map<String, _RouteNodeKey>>{};
+    final explicitAccessPairs = <String>{};
     final explicitTransferPairs = <String>{};
     final explicitTransferLinePairs = <String>{};
     final stationLineKeys = {
@@ -310,7 +311,14 @@ class _RouteCatalogSnapshot {
       if (toNode != null && _hasStationLine(toNode, stationLineKeys)) {
         _addRouteNodeKey(nodeKeysByStation, toNode);
       }
-      if (networkEdge.routeEdgeType == graph.RouteEdgeType.transfer) {
+      final routeEdgeType = networkEdge.routeEdgeType;
+      if (routeEdgeType == graph.RouteEdgeType.entry ||
+          routeEdgeType == graph.RouteEdgeType.exit) {
+        explicitAccessPairs.add(
+          _edgePairKey(networkEdge.fromNodeId, networkEdge.toNodeId),
+        );
+      }
+      if (routeEdgeType == graph.RouteEdgeType.transfer) {
         explicitTransferPairs.add(
           _edgePairKey(networkEdge.fromNodeId, networkEdge.toNodeId),
         );
@@ -340,24 +348,32 @@ class _RouteCatalogSnapshot {
           ),
         );
         final accessEdgeSuffix = nodeKey.accessEdgeSuffix;
-        edges.add(
-          graph.RouteEdge(
-            id: 'entry-${stationLine.stationId}-${stationLine.lineId}$accessEdgeSuffix',
-            fromNodeId: stationLine.stationId,
-            toNodeId: nodeKey.nodeId,
-            type: graph.RouteEdgeType.entry,
-            baseCost: 90,
-          ),
-        );
-        edges.add(
-          graph.RouteEdge(
-            id: 'exit-${stationLine.stationId}-${stationLine.lineId}$accessEdgeSuffix',
-            fromNodeId: nodeKey.nodeId,
-            toNodeId: stationLine.stationId,
-            type: graph.RouteEdgeType.exit,
-            baseCost: 60,
-          ),
-        );
+        if (!explicitAccessPairs.contains(
+          _edgePairKey(stationLine.stationId, nodeKey.nodeId),
+        )) {
+          edges.add(
+            graph.RouteEdge(
+              id: 'entry-${stationLine.stationId}-${stationLine.lineId}$accessEdgeSuffix',
+              fromNodeId: stationLine.stationId,
+              toNodeId: nodeKey.nodeId,
+              type: graph.RouteEdgeType.entry,
+              baseCost: 90,
+            ),
+          );
+        }
+        if (!explicitAccessPairs.contains(
+          _edgePairKey(nodeKey.nodeId, stationLine.stationId),
+        )) {
+          edges.add(
+            graph.RouteEdge(
+              id: 'exit-${stationLine.stationId}-${stationLine.lineId}$accessEdgeSuffix',
+              fromNodeId: nodeKey.nodeId,
+              toNodeId: stationLine.stationId,
+              type: graph.RouteEdgeType.exit,
+              baseCost: 60,
+            ),
+          );
+        }
       }
     }
 
@@ -367,6 +383,9 @@ class _RouteCatalogSnapshot {
       for (final from in stationNodes) {
         for (final to in stationNodes) {
           if (from.nodeId == to.nodeId) {
+            continue;
+          }
+          if (from.lineId == to.lineId) {
             continue;
           }
           if (_hasExplicitTransferPair(

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -92,7 +92,7 @@ class LocalRouteRepository implements RouteSearchRepository {
             lineName: lineName,
             fromStationId: fromStationId,
             toStationId: toStationId,
-            estimatedMinutes: (step.cost / 60).ceil().clamp(1, 999),
+            estimatedMinutes: (step.durationSeconds / 60).ceil().clamp(1, 999),
             distanceMeters: step.cost * 2,
             includesStairs: step.includesStairs,
             requiresAccessibilityCheck:
@@ -286,34 +286,94 @@ class _RouteCatalogSnapshot {
   graph.NetworkGraph toGraph() {
     final nodes = <graph.RouteNode>[];
     final edges = <graph.RouteEdge>[];
+    final nodeKeysByStation = <String, Map<String, _RouteNodeKey>>{};
+    final explicitTransferPairs = <String>{};
 
     for (final stationLine in stationLines) {
-      final nodeId = stationLine.nodeId;
-      nodes.add(
-        graph.RouteNode(
-          id: nodeId,
-          stationId: stationLine.stationId,
-          lineId: stationLine.lineId,
-        ),
-      );
-      edges.add(
-        graph.RouteEdge(
-          id: 'entry-${stationLine.stationId}-${stationLine.lineId}',
-          fromNodeId: stationLine.stationId,
-          toNodeId: nodeId,
-          type: graph.RouteEdgeType.entry,
-          baseCost: 90,
-        ),
-      );
-      edges.add(
-        graph.RouteEdge(
-          id: 'exit-${stationLine.stationId}-${stationLine.lineId}',
-          fromNodeId: nodeId,
-          toNodeId: stationLine.stationId,
-          type: graph.RouteEdgeType.exit,
-          baseCost: 60,
-        ),
-      );
+      _addRouteNodeKey(nodeKeysByStation, stationLine.routeNodeKey);
+    }
+
+    for (final networkEdge in networkEdges) {
+      if (networkEdge.routeEdgeType == null) {
+        continue;
+      }
+      final fromNode = _RouteNodeKey.tryParse(networkEdge.fromNodeId);
+      final toNode = _RouteNodeKey.tryParse(networkEdge.toNodeId);
+      if (fromNode != null && _hasStationLine(fromNode)) {
+        _addRouteNodeKey(nodeKeysByStation, fromNode);
+      }
+      if (toNode != null && _hasStationLine(toNode)) {
+        _addRouteNodeKey(nodeKeysByStation, toNode);
+      }
+      if (networkEdge.routeEdgeType == graph.RouteEdgeType.transfer) {
+        explicitTransferPairs.add(
+          _edgePairKey(networkEdge.fromNodeId, networkEdge.toNodeId),
+        );
+      }
+    }
+
+    for (final stationLine in stationLines) {
+      final stationNodes = nodeKeysByStation[stationLine.stationId]?.values;
+      if (stationNodes == null) {
+        continue;
+      }
+      for (final nodeKey in stationNodes.where(
+        (nodeKey) => nodeKey.lineId == stationLine.lineId,
+      )) {
+        nodes.add(
+          graph.RouteNode(
+            id: nodeKey.nodeId,
+            stationId: nodeKey.stationId,
+            lineId: nodeKey.lineId,
+          ),
+        );
+        final accessEdgeSuffix = nodeKey.accessEdgeSuffix;
+        edges.add(
+          graph.RouteEdge(
+            id: 'entry-${stationLine.stationId}-${stationLine.lineId}$accessEdgeSuffix',
+            fromNodeId: stationLine.stationId,
+            toNodeId: nodeKey.nodeId,
+            type: graph.RouteEdgeType.entry,
+            baseCost: 90,
+          ),
+        );
+        edges.add(
+          graph.RouteEdge(
+            id: 'exit-${stationLine.stationId}-${stationLine.lineId}$accessEdgeSuffix',
+            fromNodeId: nodeKey.nodeId,
+            toNodeId: stationLine.stationId,
+            type: graph.RouteEdgeType.exit,
+            baseCost: 60,
+          ),
+        );
+      }
+    }
+
+    for (final stationEntry in nodeKeysByStation.entries) {
+      final stationId = stationEntry.key;
+      final stationNodes = stationEntry.value.values.toList(growable: false);
+      for (final from in stationNodes) {
+        for (final to in stationNodes) {
+          if (from.nodeId == to.nodeId) {
+            continue;
+          }
+          if (explicitTransferPairs.contains(
+            _edgePairKey(from.nodeId, to.nodeId),
+          )) {
+            continue;
+          }
+          edges.add(
+            graph.RouteEdge(
+              id: 'transfer-$stationId-${from.transferEdgeSuffix}-${to.transferEdgeSuffix}',
+              fromNodeId: from.nodeId,
+              toNodeId: to.nodeId,
+              type: graph.RouteEdgeType.transfer,
+              baseCost: 140,
+              transferStationId: stationId,
+            ),
+          );
+        }
+      }
     }
 
     for (final networkEdge in networkEdges) {
@@ -339,31 +399,15 @@ class _RouteCatalogSnapshot {
       );
     }
 
-    final stationIds = stationLines.map((line) => line.stationId).toSet();
-    for (final stationId in stationIds) {
-      final lines = stationLines
-          .where((line) => line.stationId == stationId)
-          .toList(growable: false);
-      for (final from in lines) {
-        for (final to in lines) {
-          if (from.lineId == to.lineId) {
-            continue;
-          }
-          edges.add(
-            graph.RouteEdge(
-              id: 'transfer-$stationId-${from.lineId}-${to.lineId}',
-              fromNodeId: from.nodeId,
-              toNodeId: to.nodeId,
-              type: graph.RouteEdgeType.transfer,
-              baseCost: 140,
-              transferStationId: stationId,
-            ),
-          );
-        }
-      }
-    }
-
     return graph.NetworkGraph(nodes: nodes, edges: edges);
+  }
+
+  bool _hasStationLine(_RouteNodeKey nodeKey) {
+    return stationLines.any(
+      (stationLine) =>
+          stationLine.stationId == nodeKey.stationId &&
+          stationLine.lineId == nodeKey.lineId,
+    );
   }
 
   String stationName(String stationId) {
@@ -389,6 +433,10 @@ class _RouteCatalogSnapshot {
   }
 }
 
+String _edgePairKey(String fromNodeId, String toNodeId) {
+  return '$fromNodeId->$toNodeId';
+}
+
 String _selectNetworkEdgeColumn(
   Set<String> columnNames,
   String columnName,
@@ -408,7 +456,62 @@ class _StationLineSnapshot {
   final String lineId;
   final int sequence;
 
-  String get nodeId => '$stationId:$lineId';
+  _RouteNodeKey get routeNodeKey =>
+      _RouteNodeKey(stationId: stationId, lineId: lineId, servicePattern: '');
+}
+
+void _addRouteNodeKey(
+  Map<String, Map<String, _RouteNodeKey>> nodeKeysByStation,
+  _RouteNodeKey nodeKey,
+) {
+  nodeKeysByStation
+      .putIfAbsent(nodeKey.stationId, () => <String, _RouteNodeKey>{})
+      .putIfAbsent(nodeKey.nodeId, () => nodeKey);
+}
+
+class _RouteNodeKey {
+  const _RouteNodeKey({
+    required this.stationId,
+    required this.lineId,
+    required this.servicePattern,
+  });
+
+  final String stationId;
+  final String lineId;
+  final String servicePattern;
+
+  static _RouteNodeKey? tryParse(String nodeId) {
+    final parts = nodeId.split(':');
+    if (parts.length < 2 || parts[0].isEmpty || parts[1].isEmpty) {
+      return null;
+    }
+    return _RouteNodeKey(
+      stationId: parts[0],
+      lineId: parts[1],
+      servicePattern: parts.length >= 3 ? parts[2] : '',
+    );
+  }
+
+  String get nodeId {
+    if (servicePattern.isEmpty) {
+      return '$stationId:$lineId';
+    }
+    return '$stationId:$lineId:$servicePattern';
+  }
+
+  String get accessEdgeSuffix {
+    if (servicePattern.isEmpty) {
+      return '';
+    }
+    return '-${servicePattern.toLowerCase()}';
+  }
+
+  String get transferEdgeSuffix {
+    if (servicePattern.isEmpty) {
+      return lineId;
+    }
+    return '$lineId-${servicePattern.toLowerCase()}';
+  }
 }
 
 class _NetworkEdgeSnapshot {

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -332,6 +332,42 @@ class _RouteCatalogSnapshot {
       }
     }
 
+    final expandedExplicitEdges = <graph.RouteEdge>[];
+    for (final networkEdge in networkEdges) {
+      final routeEdgeType = networkEdge.routeEdgeType;
+      if (routeEdgeType == null) {
+        continue;
+      }
+      if (routeEdgeType != graph.RouteEdgeType.entry &&
+          routeEdgeType != graph.RouteEdgeType.exit &&
+          routeEdgeType != graph.RouteEdgeType.transfer) {
+        continue;
+      }
+      for (final pair in _expandedExplicitEdgePairs(
+        networkEdge,
+        nodeKeysByStation,
+      )) {
+        if (pair.fromNodeId == networkEdge.fromNodeId &&
+            pair.toNodeId == networkEdge.toNodeId) {
+          continue;
+        }
+        final pairKey = _edgePairKey(pair.fromNodeId, pair.toNodeId);
+        if (routeEdgeType == graph.RouteEdgeType.entry ||
+            routeEdgeType == graph.RouteEdgeType.exit) {
+          explicitAccessPairs.add(pairKey);
+        }
+        expandedExplicitEdges.add(
+          _toGraphRouteEdge(
+            networkEdge,
+            routeEdgeType,
+            id: '${networkEdge.id}@$pairKey',
+            fromNodeId: pair.fromNodeId,
+            toNodeId: pair.toNodeId,
+          ),
+        );
+      }
+    }
+
     for (final stationLine in stationLines) {
       final stationNodes = nodeKeysByStation[stationLine.stationId]?.values;
       if (stationNodes == null) {
@@ -410,27 +446,14 @@ class _RouteCatalogSnapshot {
       }
     }
 
+    edges.addAll(expandedExplicitEdges);
+
     for (final networkEdge in networkEdges) {
       final routeEdgeType = networkEdge.routeEdgeType;
       if (routeEdgeType == null) {
         continue;
       }
-      edges.add(
-        graph.RouteEdge(
-          id: networkEdge.id,
-          fromNodeId: networkEdge.fromNodeId,
-          toNodeId: networkEdge.toNodeId,
-          type: routeEdgeType,
-          baseCost: networkEdge.durationSeconds <= 0
-              ? 60
-              : networkEdge.durationSeconds,
-          lineId: networkEdge.lineId,
-          includesStairs: networkEdge.includesStairs,
-          reliabilityScore: networkEdge.effectiveReliabilityScore,
-          isDataStale: networkEdge.isDataStale,
-          isAvailable: networkEdge.isAvailable,
-        ),
-      );
+      edges.add(_toGraphRouteEdge(networkEdge, routeEdgeType));
     }
 
     return graph.NetworkGraph(nodes: nodes, edges: edges);
@@ -469,6 +492,60 @@ String _edgePairKey(String fromNodeId, String toNodeId) {
   return '$fromNodeId->$toNodeId';
 }
 
+List<({String fromNodeId, String toNodeId})> _expandedExplicitEdgePairs(
+  _NetworkEdgeSnapshot networkEdge,
+  Map<String, Map<String, _RouteNodeKey>> nodeKeysByStation,
+) {
+  final routeEdgeType = networkEdge.routeEdgeType;
+  if (routeEdgeType == graph.RouteEdgeType.entry) {
+    final toNode = _RouteNodeKey.tryParse(networkEdge.toNodeId);
+    if (toNode == null) {
+      return const [];
+    }
+    return [
+      for (final candidate in _matchingNodeKeys(toNode, nodeKeysByStation))
+        (fromNodeId: networkEdge.fromNodeId, toNodeId: candidate.nodeId),
+    ];
+  }
+  if (routeEdgeType == graph.RouteEdgeType.exit) {
+    final fromNode = _RouteNodeKey.tryParse(networkEdge.fromNodeId);
+    if (fromNode == null) {
+      return const [];
+    }
+    return [
+      for (final candidate in _matchingNodeKeys(fromNode, nodeKeysByStation))
+        (fromNodeId: candidate.nodeId, toNodeId: networkEdge.toNodeId),
+    ];
+  }
+  if (routeEdgeType == graph.RouteEdgeType.transfer) {
+    final fromNode = _RouteNodeKey.tryParse(networkEdge.fromNodeId);
+    final toNode = _RouteNodeKey.tryParse(networkEdge.toNodeId);
+    if (fromNode == null || toNode == null) {
+      return const [];
+    }
+    return [
+      for (final from in _matchingNodeKeys(fromNode, nodeKeysByStation))
+        for (final to in _matchingNodeKeys(toNode, nodeKeysByStation))
+          if (from.nodeId != to.nodeId)
+            (fromNodeId: from.nodeId, toNodeId: to.nodeId),
+    ];
+  }
+  return const [];
+}
+
+List<_RouteNodeKey> _matchingNodeKeys(
+  _RouteNodeKey nodeKey,
+  Map<String, Map<String, _RouteNodeKey>> nodeKeysByStation,
+) {
+  if (nodeKey.servicePattern.isNotEmpty) {
+    return [nodeKey];
+  }
+  return nodeKeysByStation[nodeKey.stationId]?.values
+          .where((candidate) => candidate.lineId == nodeKey.lineId)
+          .toList(growable: false) ??
+      [nodeKey];
+}
+
 bool _hasExplicitTransferPair(
   _RouteNodeKey from,
   _RouteNodeKey to,
@@ -486,6 +563,38 @@ String _lineTransferPairKey(_RouteNodeKey from, _RouteNodeKey to) {
 
 String _stationLineKey(String stationId, String lineId) {
   return '$stationId:$lineId';
+}
+
+graph.RouteEdge _toGraphRouteEdge(
+  _NetworkEdgeSnapshot networkEdge,
+  graph.RouteEdgeType routeEdgeType, {
+  String? id,
+  String? fromNodeId,
+  String? toNodeId,
+}) {
+  final effectiveFromNodeId = fromNodeId ?? networkEdge.fromNodeId;
+  return graph.RouteEdge(
+    id: id ?? networkEdge.id,
+    fromNodeId: effectiveFromNodeId,
+    toNodeId: toNodeId ?? networkEdge.toNodeId,
+    type: routeEdgeType,
+    baseCost: networkEdge.durationSeconds <= 0
+        ? 60
+        : networkEdge.durationSeconds,
+    lineId: _lineIdForNode(effectiveFromNodeId),
+    includesStairs: networkEdge.includesStairs,
+    reliabilityScore: networkEdge.effectiveReliabilityScore,
+    isDataStale: networkEdge.isDataStale,
+    isAvailable: networkEdge.isAvailable,
+  );
+}
+
+String _lineIdForNode(String nodeId) {
+  final parts = nodeId.split(':');
+  if (parts.length < 2) {
+    return '';
+  }
+  return parts[1];
 }
 
 String _selectNetworkEdgeColumn(
@@ -598,14 +707,6 @@ class _NetworkEdgeSnapshot {
       'EXIT' => graph.RouteEdgeType.exit,
       _ => null,
     };
-  }
-
-  String get lineId {
-    final parts = fromNodeId.split(':');
-    if (parts.length < 2) {
-      return '';
-    }
-    return parts[1];
   }
 
   String get _accessibilityStatusUpper => accessibilityStatus.toUpperCase();

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -362,6 +362,9 @@ class _RouteCatalogSnapshot {
         }
         if (routeEdgeType == graph.RouteEdgeType.entry ||
             routeEdgeType == graph.RouteEdgeType.exit) {
+          if (explicitAccessPairs.contains(pairKey)) {
+            continue;
+          }
           explicitAccessPairs.add(pairKey);
         }
         expandedExplicitEdges.add(

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -319,20 +319,31 @@ class _RouteCatalogSnapshot {
           _edgePairKey(networkEdge.fromNodeId, networkEdge.toNodeId),
         );
       }
-      if (routeEdgeType == graph.RouteEdgeType.transfer) {
-        actualExplicitTransferPairs.add(
-          _edgePairKey(networkEdge.fromNodeId, networkEdge.toNodeId),
-        );
-        explicitTransferPairs.add(
-          _edgePairKey(networkEdge.fromNodeId, networkEdge.toNodeId),
-        );
-        explicitTransferPairs.add(
-          _edgePairKey(networkEdge.toNodeId, networkEdge.fromNodeId),
-        );
-        if (fromNode != null && toNode != null) {
-          explicitTransferLinePairs.add(_lineTransferPairKey(fromNode, toNode));
-          explicitTransferLinePairs.add(_lineTransferPairKey(toNode, fromNode));
-        }
+    }
+
+    for (final networkEdge in networkEdges) {
+      if (networkEdge.routeEdgeType != graph.RouteEdgeType.transfer) {
+        continue;
+      }
+      final fromNode = _RouteNodeKey.tryParse(networkEdge.fromNodeId);
+      final toNode = _RouteNodeKey.tryParse(networkEdge.toNodeId);
+      if (fromNode == null || toNode == null) {
+        continue;
+      }
+      actualExplicitTransferPairs.add(
+        _edgePairKey(networkEdge.fromNodeId, networkEdge.toNodeId),
+      );
+      for (final pair in _expandedExplicitEdgePairs(
+        networkEdge,
+        nodeKeysByStation,
+      )) {
+        explicitTransferPairs.add(_edgePairKey(pair.fromNodeId, pair.toNodeId));
+      }
+      explicitTransferPairs.add(_edgePairKey(fromNode.nodeId, toNode.nodeId));
+      explicitTransferPairs.add(_edgePairKey(toNode.nodeId, fromNode.nodeId));
+      if (_isBaseStationLineNode(fromNode) && _isBaseStationLineNode(toNode)) {
+        explicitTransferLinePairs.add(_lineTransferPairKey(fromNode, toNode));
+        explicitTransferLinePairs.add(_lineTransferPairKey(toNode, fromNode));
       }
     }
 
@@ -593,6 +604,10 @@ bool _hasExplicitTransferPair(
 ) {
   return explicitTransferPairs.contains(_edgePairKey(from.nodeId, to.nodeId)) ||
       explicitTransferLinePairs.contains(_lineTransferPairKey(from, to));
+}
+
+bool _isBaseStationLineNode(_RouteNodeKey nodeKey) {
+  return nodeKey.servicePattern.isEmpty;
 }
 
 String _lineTransferPairKey(_RouteNodeKey from, _RouteNodeKey to) {

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -432,8 +432,7 @@ class _RouteCatalogSnapshot {
           if (from.nodeId == to.nodeId) {
             continue;
           }
-          if (from.lineId == to.lineId &&
-              !_isDifferentServicePatternTransfer(from, to)) {
+          if (!_isStationLineTransferAllowed(from, to, explicitAccessPairs)) {
             continue;
           }
           if (_hasExplicitTransferPair(
@@ -549,10 +548,28 @@ List<({String fromNodeId, String toNodeId})> _expandedExplicitEdgePairs(
   return const [];
 }
 
-bool _isDifferentServicePatternTransfer(_RouteNodeKey from, _RouteNodeKey to) {
-  return from.servicePattern.isNotEmpty &&
-      to.servicePattern.isNotEmpty &&
-      from.servicePattern != to.servicePattern;
+bool _isStationLineTransferAllowed(
+  _RouteNodeKey from,
+  _RouteNodeKey to,
+  Set<String> explicitAccessPairs,
+) {
+  if (from.lineId != to.lineId) {
+    return true;
+  }
+  if (from.servicePattern == to.servicePattern) {
+    return false;
+  }
+  if (from.servicePattern.isNotEmpty && to.servicePattern.isNotEmpty) {
+    return true;
+  }
+
+  final patternNode = from.servicePattern.isEmpty ? to : from;
+  return !explicitAccessPairs.contains(
+        _edgePairKey(patternNode.stationId, patternNode.nodeId),
+      ) &&
+      !explicitAccessPairs.contains(
+        _edgePairKey(patternNode.nodeId, patternNode.stationId),
+      );
 }
 
 List<_RouteNodeKey> _matchingNodeKeys(

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -314,8 +314,12 @@ class _RouteCatalogSnapshot {
         explicitTransferPairs.add(
           _edgePairKey(networkEdge.fromNodeId, networkEdge.toNodeId),
         );
+        explicitTransferPairs.add(
+          _edgePairKey(networkEdge.toNodeId, networkEdge.fromNodeId),
+        );
         if (fromNode != null && toNode != null) {
           explicitTransferLinePairs.add(_lineTransferPairKey(fromNode, toNode));
+          explicitTransferLinePairs.add(_lineTransferPairKey(toNode, fromNode));
         }
       }
     }

--- a/apps/mobile/lib/features/routes/domain/route_step.dart
+++ b/apps/mobile/lib/features/routes/domain/route_step.dart
@@ -8,6 +8,7 @@ class RouteStep {
     required this.toNodeId,
     required this.type,
     required this.cost,
+    required this.durationSeconds,
     this.lineId = '',
     this.transferStationId = '',
     this.includesStairs = false,
@@ -19,6 +20,7 @@ class RouteStep {
   final String toNodeId;
   final RouteStepType type;
   final int cost;
+  final int durationSeconds;
   final String lineId;
   final String transferStationId;
   final bool includesStairs;

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -428,6 +428,63 @@ void main() {
     expect(result.steps, isEmpty);
     expect(result.blockedReasons, contains('필수 접근성 시설을 사용할 수 없습니다.'));
   });
+
+  test('service pattern transfer도 사용 불가 explicit transfer를 우회하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await _addSecondLineForTransferFixture(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES
+        (
+          'edge-b-a-line-test-local',
+          'station-b:line-test:LOCAL',
+          'station-a:line-test:LOCAL',
+          90,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        ),
+        (
+          'transfer-a-test-alt-unavailable',
+          'station-a:line-test',
+          'station-a:line-alt',
+          140,
+          'TRANSFER',
+          '',
+          'UNAVAILABLE',
+          95
+        ),
+        (
+          'edge-a-c-line-alt',
+          'station-a:line-alt',
+          'station-c:line-alt',
+          90,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-b',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(result.status, 'BLOCKED');
+    expect(result.steps, isEmpty);
+    expect(result.blockedReasons, contains('필수 접근성 시설을 사용할 수 없습니다.'));
+  });
 }
 
 Future<void> _seedLineWithoutNetworkEdges(CatalogDatabase database) async {

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -639,6 +639,117 @@ void main() {
     );
   });
 
+  test('같은 노선의 서로 다른 service pattern 사이를 환승할 수 있다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES
+        (
+          'edge-a-b-local',
+          'station-a:line-test:LOCAL',
+          'station-b:line-test:LOCAL',
+          90,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        ),
+        (
+          'edge-b-c-express',
+          'station-b:line-test:EXPRESS',
+          'station-c:line-test:EXPRESS',
+          90,
+          'RIDE',
+          'EXPRESS',
+          'AVAILABLE',
+          95
+        )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(result.status, 'FOUND');
+    expect(result.blockedReasons, isEmpty);
+    expect(
+      result.steps.map((step) => step.lineId).where((id) => id.isNotEmpty),
+      everyElement('line-test'),
+    );
+  });
+
+  test('단방향 explicit transfer가 역방향 환승 경로를 제거하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await _addSecondLineForTransferFixture(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES
+        (
+          'edge-c-a-line-alt',
+          'station-c:line-alt',
+          'station-a:line-alt',
+          90,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        ),
+        (
+          'transfer-a-test-alt-available',
+          'station-a:line-test',
+          'station-a:line-alt',
+          140,
+          'TRANSFER',
+          '',
+          'AVAILABLE',
+          95
+        ),
+        (
+          'edge-a-b-line-test',
+          'station-a:line-test',
+          'station-b:line-test',
+          90,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-c',
+        destinationStationId: 'station-b',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(result.status, 'FOUND');
+    expect(
+      result.steps
+          .map((step) => step.lineId)
+          .where((id) => id.isNotEmpty)
+          .toSet(),
+      {'line-test', 'line-alt'},
+    );
+  });
+
   test(
     '역방향 service pattern transfer도 사용 불가 explicit transfer를 우회하지 않는다',
     () async {

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -289,6 +289,52 @@ void main() {
     expect(result.blockedReasons, isEmpty);
   });
 
+  test('service pattern entry가 사용 불가이면 생성 entry로 우회하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES
+        (
+          'entry-a-line-test-local-unavailable',
+          'station-a',
+          'station-a:line-test:LOCAL',
+          90,
+          'ENTRY',
+          'LOCAL',
+          'UNAVAILABLE',
+          95
+        ),
+        (
+          'edge-a-b-local',
+          'station-a:line-test:LOCAL',
+          'station-b:line-test:LOCAL',
+          120,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(result.status, 'BLOCKED');
+    expect(result.steps, isEmpty);
+    expect(result.blockedReasons, contains('필수 접근성 시설을 사용할 수 없습니다.'));
+  });
+
   test('급행 pattern은 미정차역을 경유한 것처럼 연결하지 않는다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
@@ -483,7 +529,6 @@ void main() {
 
     expect(result.status, 'BLOCKED');
     expect(result.steps, isEmpty);
-    expect(result.blockedReasons, contains('필수 접근성 시설을 사용할 수 없습니다.'));
   });
 
   test(

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -335,6 +335,52 @@ void main() {
     expect(result.blockedReasons, contains('필수 접근성 시설을 사용할 수 없습니다.'));
   });
 
+  test('base entry가 사용 불가이면 service pattern entry로 우회하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES
+        (
+          'entry-a-line-test-unavailable',
+          'station-a',
+          'station-a:line-test',
+          90,
+          'ENTRY',
+          '',
+          'UNAVAILABLE',
+          95
+        ),
+        (
+          'edge-a-b-local',
+          'station-a:line-test:LOCAL',
+          'station-b:line-test:LOCAL',
+          120,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(result.status, 'BLOCKED');
+    expect(result.steps, isEmpty);
+    expect(result.blockedReasons, contains('필수 접근성 시설을 사용할 수 없습니다.'));
+  });
+
   test('급행 pattern은 미정차역을 경유한 것처럼 연결하지 않는다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
@@ -529,6 +575,68 @@ void main() {
 
     expect(result.status, 'BLOCKED');
     expect(result.steps, isEmpty);
+  });
+
+  test('service pattern ride 뒤 base explicit transfer를 사용할 수 있다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await _addSecondLineForTransferFixture(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES
+        (
+          'edge-b-a-line-test-local',
+          'station-b:line-test:LOCAL',
+          'station-a:line-test:LOCAL',
+          90,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        ),
+        (
+          'transfer-a-test-alt-available',
+          'station-a:line-test',
+          'station-a:line-alt',
+          140,
+          'TRANSFER',
+          '',
+          'AVAILABLE',
+          95
+        ),
+        (
+          'edge-a-c-line-alt',
+          'station-a:line-alt',
+          'station-c:line-alt',
+          90,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-b',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(result.status, 'FOUND');
+    expect(
+      result.steps
+          .map((step) => step.lineId)
+          .where((id) => id.isNotEmpty)
+          .toSet(),
+      {'line-test', 'line-alt'},
+    );
   });
 
   test(

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -633,6 +633,68 @@ void main() {
     expect(result.steps, isEmpty);
   });
 
+  test('service pattern explicit transfer는 다른 pattern의 환승을 막지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await _addSecondLineForTransferFixture(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES
+        (
+          'edge-b-a-line-test-express',
+          'station-b:line-test:EXPRESS',
+          'station-a:line-test:EXPRESS',
+          90,
+          'RIDE',
+          'EXPRESS',
+          'AVAILABLE',
+          95
+        ),
+        (
+          'transfer-a-local-alt-unavailable',
+          'station-a:line-test:LOCAL',
+          'station-a:line-alt',
+          140,
+          'TRANSFER',
+          'LOCAL',
+          'UNAVAILABLE',
+          95
+        ),
+        (
+          'edge-a-c-line-alt',
+          'station-a:line-alt',
+          'station-c:line-alt',
+          90,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-b',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(result.status, 'FOUND');
+    expect(
+      result.steps
+          .map((step) => step.lineId)
+          .where((id) => id.isNotEmpty)
+          .toSet(),
+      {'line-test', 'line-alt'},
+    );
+  });
+
   test('service pattern ride 뒤 base explicit transfer를 사용할 수 있다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -381,6 +381,62 @@ void main() {
     expect(result.blockedReasons, contains('필수 접근성 시설을 사용할 수 없습니다.'));
   });
 
+  test('명시 service pattern entry는 base entry 확장으로 우회하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES
+        (
+          'entry-a-line-test-available',
+          'station-a',
+          'station-a:line-test',
+          90,
+          'ENTRY',
+          '',
+          'AVAILABLE',
+          95
+        ),
+        (
+          'entry-a-line-test-local-unavailable',
+          'station-a',
+          'station-a:line-test:LOCAL',
+          90,
+          'ENTRY',
+          'LOCAL',
+          'UNAVAILABLE',
+          95
+        ),
+        (
+          'edge-a-b-local',
+          'station-a:line-test:LOCAL',
+          'station-b:line-test:LOCAL',
+          120,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(result.status, 'BLOCKED');
+    expect(result.steps, isEmpty);
+    expect(result.blockedReasons, contains('필수 접근성 시설을 사용할 수 없습니다.'));
+  });
+
   test('급행 pattern은 미정차역을 경유한 것처럼 연결하지 않는다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -250,6 +250,184 @@ void main() {
       'STALE_ACCESSIBILITY_DATA',
     });
   });
+
+  test('service pattern node는 역-노선 node로 뭉개지지 않고 출입구와 연결된다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES (
+        'edge-a-b-local',
+        'station-a:line-test:LOCAL',
+        'station-b:line-test:LOCAL',
+        120,
+        'RIDE',
+        'LOCAL',
+        'AVAILABLE',
+        95
+      )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(result.status, 'FOUND');
+    expect(
+      result.steps.map((step) => step.lineId).where((id) => id.isNotEmpty),
+      ['line-test'],
+    );
+    expect(result.blockedReasons, isEmpty);
+  });
+
+  test('급행 pattern은 미정차역을 경유한 것처럼 연결하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES (
+        'edge-a-c-express',
+        'station-a:line-test:EXPRESS',
+        'station-c:line-test:EXPRESS',
+        150,
+        'RIDE',
+        'EXPRESS',
+        'AVAILABLE',
+        95
+      )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final expressResult = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+    final skippedStopResult = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-b',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(expressResult.status, 'FOUND');
+    expect(skippedStopResult.status, 'BLOCKED');
+    expect(skippedStopResult.steps, isEmpty);
+  });
+
+  test('step 소요시간은 접근성 패널티가 아니라 사용된 edge 시간에서 만든다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES (
+        'edge-a-b-low-confidence',
+        'station-a:line-test:LOCAL',
+        'station-b:line-test:LOCAL',
+        120,
+        'RIDE',
+        'LOCAL',
+        'UNKNOWN',
+        50
+      )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final rideStep = result.steps.singleWhere(
+      (step) => step.lineId == 'line-test',
+    );
+    expect(result.status, 'FOUND');
+    expect(result.warnings.map((warning) => warning.code), {
+      'LOW_DATA_CONFIDENCE',
+      'STALE_ACCESSIBILITY_DATA',
+    });
+    expect(rideStep.estimatedMinutes, 2);
+  });
+
+  test('사용 불가 explicit transfer edge는 자동 환승 edge로 우회하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await _addSecondLineForTransferFixture(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES
+        (
+          'edge-b-a-line-test',
+          'station-b:line-test',
+          'station-a:line-test',
+          90,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        ),
+        (
+          'transfer-a-test-alt-unavailable',
+          'station-a:line-test',
+          'station-a:line-alt',
+          140,
+          'TRANSFER',
+          '',
+          'UNAVAILABLE',
+          95
+        ),
+        (
+          'edge-a-c-line-alt',
+          'station-a:line-alt',
+          'station-c:line-alt',
+          90,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-b',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(result.status, 'BLOCKED');
+    expect(result.steps, isEmpty);
+    expect(result.blockedReasons, contains('필수 접근성 시설을 사용할 수 없습니다.'));
+  });
 }
 
 Future<void> _seedLineWithoutNetworkEdges(CatalogDatabase database) async {
@@ -288,6 +466,24 @@ Future<void> _seedLineWithoutNetworkEdges(CatalogDatabase database) async {
         VALUES (?, 'line-test', ?, ?, '')
       ''',
       [station.$1, station.$3.toString(), station.$3],
+    );
+  }
+}
+
+Future<void> _addSecondLineForTransferFixture(CatalogDatabase database) async {
+  await database.customStatement('''
+    INSERT INTO lines (id, operator_id, name_ko, name_en, color)
+    VALUES ('line-alt', 'operator-test', '대체 노선', 'Alt Line', '#654321')
+  ''');
+  for (final station in const [('station-a', 'A1'), ('station-c', 'C2')]) {
+    await database.customStatement(
+      '''
+        INSERT INTO station_lines (
+          station_id, line_id, station_code, line_sequence, platform_info
+        )
+        VALUES (?, 'line-alt', ?, 1, '')
+      ''',
+      [station.$1, station.$2],
     );
   }
 }

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -485,6 +485,65 @@ void main() {
     expect(result.steps, isEmpty);
     expect(result.blockedReasons, contains('필수 접근성 시설을 사용할 수 없습니다.'));
   });
+
+  test(
+    '역방향 service pattern transfer도 사용 불가 explicit transfer를 우회하지 않는다',
+    () async {
+      final database = CatalogDatabase.memory();
+      addTearDown(database.close);
+      await _seedLineWithoutNetworkEdges(database);
+      await _addSecondLineForTransferFixture(database);
+      await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES
+        (
+          'edge-c-a-line-alt',
+          'station-c:line-alt',
+          'station-a:line-alt',
+          90,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        ),
+        (
+          'transfer-a-test-alt-unavailable',
+          'station-a:line-test',
+          'station-a:line-alt',
+          140,
+          'TRANSFER',
+          '',
+          'UNAVAILABLE',
+          95
+        ),
+        (
+          'edge-a-b-line-test-local',
+          'station-a:line-test:LOCAL',
+          'station-b:line-test:LOCAL',
+          90,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        )
+    ''');
+      final repository = LocalRouteRepository(catalogDatabase: database);
+
+      final result = await repository.searchRoute(
+        const RouteSearchRequest(
+          originStationId: 'station-c',
+          destinationStationId: 'station-b',
+          mobilityType: 'WHEELCHAIR',
+        ),
+      );
+
+      expect(result.status, 'BLOCKED');
+      expect(result.steps, isEmpty);
+    },
+  );
 }
 
 Future<void> _seedLineWithoutNetworkEdges(CatalogDatabase database) async {

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -744,6 +744,55 @@ void main() {
     );
   });
 
+  test('같은 역의 base node와 service pattern node를 연결해 혼합 경로를 찾는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES
+        (
+          'edge-a-b-base',
+          'station-a:line-test',
+          'station-b:line-test',
+          90,
+          'RIDE',
+          '',
+          'AVAILABLE',
+          95
+        ),
+        (
+          'edge-b-c-local',
+          'station-b:line-test:LOCAL',
+          'station-c:line-test:LOCAL',
+          90,
+          'RIDE',
+          'LOCAL',
+          'AVAILABLE',
+          95
+        )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(result.status, 'FOUND');
+    expect(result.blockedReasons, isEmpty);
+    expect(
+      result.steps.map((step) => step.lineId).where((id) => id.isNotEmpty),
+      everyElement('line-test'),
+    );
+  });
+
   test('단방향 explicit transfer가 역방향 환승 경로를 제거하지 않는다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -94,6 +94,24 @@ void main() {
       expect(result.totalCost, 674);
       expect(result.includesStairs, isFalse);
     });
+
+    test('10000 node 그래프 경로 탐색은 2초 예산 안에서 완료한다', () {
+      final engine = LocalRouteEngine(graph: _largeLinearGraph(10000));
+      final stopwatch = Stopwatch()..start();
+
+      final result = engine.search(
+        const RouteRequest(
+          originStationId: 'station-0',
+          destinationStationId: 'station-9999',
+          mobilityType: MobilityType.wheelchair,
+        ),
+      );
+
+      stopwatch.stop();
+      expect(result.status, RouteStatus.found);
+      expect(result.edgeIds.length, 9999);
+      expect(stopwatch.elapsed, lessThan(const Duration(seconds: 2)));
+    });
   });
 }
 
@@ -254,6 +272,30 @@ NetworkGraph _lowQualityFixtureGraph() {
         baseCost: 90,
         isDataStale: true,
       ),
+    ],
+  );
+}
+
+NetworkGraph _largeLinearGraph(int nodeCount) {
+  return NetworkGraph(
+    nodes: [
+      for (var index = 0; index < nodeCount; index++)
+        RouteNode(
+          id: 'station-$index',
+          stationId: 'station-$index',
+          lineId: 'line-large',
+        ),
+    ],
+    edges: [
+      for (var index = 0; index < nodeCount - 1; index++)
+        RouteEdge(
+          id: 'edge-$index-${index + 1}',
+          fromNodeId: 'station-$index',
+          toNodeId: 'station-${index + 1}',
+          type: RouteEdgeType.ride,
+          baseCost: 30,
+          lineId: 'line-large',
+        ),
     ],
   );
 }

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -95,9 +95,9 @@ void main() {
       expect(result.includesStairs, isFalse);
     });
 
-    test('10000 node 그래프 경로 탐색은 2초 예산 안에서 완료한다', () {
-      final engine = LocalRouteEngine(graph: _largeLinearGraph(10000));
-      final stopwatch = Stopwatch()..start();
+    test('10000 node 그래프는 fromNode index로 필요한 edge만 조회한다', () {
+      final graph = _largeLinearGraph(10000);
+      final engine = LocalRouteEngine(graph: graph);
 
       final result = engine.search(
         const RouteRequest(
@@ -107,10 +107,12 @@ void main() {
         ),
       );
 
-      stopwatch.stop();
+      expect(graph.edgesFrom('station-5000').map((edge) => edge.id), [
+        'edge-5000-5001',
+      ]);
+      expect(graph.edgesFrom('station-9999'), isEmpty);
       expect(result.status, RouteStatus.found);
       expect(result.edgeIds.length, 9999);
-      expect(stopwatch.elapsed, lessThan(const Duration(seconds: 2)));
     });
   });
 }


### PR DESCRIPTION
## 관련 이슈

close #528

## 작업 배경

- 로컬 경로 그래프가 `station:line:servicePattern` node를 실제 정차 node로 연결하지 못하면 급행/완행/지선 edge를 안전하게 사용할 수 없습니다.
- 명시된 환승 edge가 사용 불가인 경우에도 자동 환승 edge나 중간역 exit/entry 우회로 FOUND가 나오면 휠체어 사용자에게 갈 수 없는 경로를 안내할 수 있습니다.
- 경로 step 소요시간은 접근성 패널티가 섞인 cost가 아니라 실제 사용 edge의 `duration_seconds`에서 만들어야 합니다.

## 작업 내용

- `network_edges`의 endpoint node를 역, 노선, service pattern 단위로 route graph에 반영했습니다.
- service pattern node에도 출발 entry와 도착 exit edge가 연결되도록 catalog graph 생성을 보강했습니다.
- 같은 방향의 explicit transfer edge가 있으면 자동 transfer edge가 그 상태를 우회하지 않도록 했습니다.
- 경로 탐색 중 중간역에서 exit 후 다시 entry하는 환승 우회를 제외했습니다.
- route step에 실제 edge 소요시간을 보존하고, `estimatedMinutes`는 접근성 패널티가 아니라 edge duration에서 계산하도록 바꿨습니다.
- service pattern 연결, 급행 미정차역 차단, explicit transfer unavailable 차단, 10,000 node 성능 예산 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/features/routes/local_route_repository_test.dart`: 통과
  - `cd apps/mobile && flutter test test/features/routes`: 통과
  - `cd apps/mobile && flutter test test/features/internal_route`: 통과
  - `cd apps/mobile && flutter test test/features/stations`: 통과
  - `cd apps/mobile && flutter analyze`: `No issues found!`
  - `node --test tools/ci/*.test.mjs`: 69개 통과
  - `git diff --check`: 통과
  - `cd apps/mobile && flutter test`: 277개 통과

## 리뷰어 메모

- `LocalRouteRepository.toGraph()`에서 service pattern node와 자동 transfer edge 생성을 분리한 부분을 먼저 봐 주세요.
- `LocalRouteEngine`에서 entry는 출발역, exit은 도착역에서만 사용하는 제약이 기존 경로에 맞는지 봐 주세요.
- `RouteStep.durationSeconds`가 UI 소요시간 근거로 쓰이고, `cost`는 탐색 점수용으로 남는 구조를 확인해 주세요.

## 리스크

- 운영 데이터에 explicit transfer edge가 일부 방향만 들어오는 경우 자동 transfer 생성 범위가 기대와 다를 수 있습니다.
- 중간역 exit/entry 우회가 필요한 실제 개찰구 밖 환승은 별도 explicit edge로 모델링해야 합니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 경로 단계의 예상 소요 시간 산정이 실제 엣지 `durationSeconds`를 기반으로 정확하게 반영되도록 개선했습니다.
  * 경로 탐색 시작/종료 경계에서 entry/exit 엣지가 올바르게 처리되며, `UNAVAILABLE`인 명시 환승이 자동 환승으로 우회되지 않도록 했습니다.
* **Performance**
  * 네트워크 그래프에서 엣지를 `fromNodeId` 기준으로 인덱싱해 검색 응답 속도를 개선했습니다.
* **Tests**
  * 네트워크 엣지 처리 규칙, 환승/패턴 동작, 대규모 그래프 탐색 성능을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->