### PR TITLE
[CI] CD dotenv fallback 계약 정렬

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,19 +49,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-
-          missing_names=()
-          while IFS= read -r name; do
-            if [[ -n "${name}" ]] && ! grep -Eq "^${name}=" "${EASYSUBWAY_ENV_FILE}"; then
-              missing_names+=("${name}")
-            fi
-          done < <(sed -nE 's/^([A-Z0-9_]+)=.*/\1/p' .env.example)
-
-          if (( ${#missing_names[@]} > 0 )); then
-            printf 'Missing required deployment env names:\n' >&2
-            printf ' - %s\n' "${missing_names[@]}" >&2
-            exit 1
-          fi
+          tools/ci/validate-deployment-env.sh "${EASYSUBWAY_ENV_FILE}"
 
       - name: CD Readiness / Validate Docker Compose deployment config
         shell: bash

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -417,6 +417,7 @@ test("환경 예시는 비밀값 없는 로컬 데이터 인프라 기본값을 
 test("GitHub Actions 환경값은 dotenv secret 하나로 관리한다", () => {
   const readme = read("README.md");
   const script = read("scripts/github/sync-actions-env-secret.sh");
+  const cdWorkflow = read(".github/workflows/cd.yml");
 
   assert.match(readme, /`EASYSUBWAY_ENV` secret 하나/);
   assert.match(readme, /GitHub Actions secret 이름은 반드시 `EASYSUBWAY_ENV`만 사용합니다/);
@@ -427,11 +428,59 @@ test("GitHub Actions 환경값은 dotenv secret 하나로 관리한다", () => {
   assert.doesNotMatch(script, /EASYSUBWAY_ACTIONS_ENV_SECRET_NAME/);
   assert.match(script, /gh secret set "\$\{SECRET_NAME\}" --repo "\$\{REPO\}" < "\$\{ENV_FILE\}"/);
   assert.match(script, /\.env\.example is a template/);
+  assert.match(cdWorkflow, /tools\/ci\/validate-deployment-env\.sh "\$\{EASYSUBWAY_ENV_FILE\}"/);
 
   for (const file of workflowFiles()) {
     const source = read(file);
     assertActionsEnvSecretPolicy(file, source);
   }
+});
+
+test("CD dotenv 검증은 운영 fallback env 계약을 반영한다", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "easysubway-cd-env-"));
+  const envFile = path.join(dir, "deploy.env");
+  await writeFile(envFile, [
+    "EASYSUBWAY_POSTGRES_DB=easysubway",
+    "EASYSUBWAY_POSTGRES_USER=easysubway",
+    "EASYSUBWAY_POSTGRES_PASSWORD=secret",
+    "EASYSUBWAY_POSTGRES_PORT=5432",
+    "EASYSUBWAY_DATASOURCE_URL=jdbc:postgresql://db:5432/easysubway",
+    "EASYSUBWAY_DATASOURCE_USERNAME=easysubway",
+    "EASYSUBWAY_DATASOURCE_PASSWORD=secret",
+    "EASYSUBWAY_DATA_PACK_BASE_URL=https://cdn.example.com/easysubway-datapacks",
+    "EASYSUBWAY_REPORT_API_BASE_URL=https://api.example.com",
+    "EASYSUBWAY_REPORT_RECEIPT_TOKEN_PEPPER=legacy-pepper-with-enough-entropy",
+    "EASYSUBWAY_REPORT_UPLOAD_BUCKET=easysubway-report-uploads",
+    "EASYSUBWAY_REPORT_UPLOAD_MAX_BYTES=921600",
+    "EASYSUBWAY_REPORT_UPLOAD_URL_TTL_SECONDS=900",
+    "EASYSUBWAY_OBJECT_STORAGE_ENDPOINT=https://object-storage.example.com",
+    "EASYSUBWAY_OBJECT_STORAGE_ACCESS_KEY=access-key",
+    "EASYSUBWAY_OBJECT_STORAGE_SECRET_KEY=secret-key",
+    "EASYSUBWAY_DATAPACK_BUCKET=easysubway-datapacks",
+    "EASYSUBWAY_DATAPACK_SIGNING_KEY=datapack-signing-key",
+    "EASYSUBWAY_TRUSTED_PROXY_CIDRS=",
+    "EASYSUBWAY_PUSH_EXTERNAL_ENABLED=false",
+    "EASYSUBWAY_ENABLE_PUSH_NOTIFICATIONS=false",
+    "EASYSUBWAY_ADMIN_USERNAME=admin",
+    "EASYSUBWAY_ADMIN_PASSWORD=secret",
+    "EASYSUBWAY_PRIVACY_POLICY_URL=https://example.com/privacy",
+    "EASYSUBWAY_SUPPORT_EMAIL=support@example.com",
+    "EASYSUBWAY_SECURITY_EMAIL=security@example.com",
+    "EASYSUBWAY_DATA_DELETION_EMAIL=privacy@example.com",
+    "EASYSUBWAY_ANDROID_KEYSTORE_PATH=",
+    "EASYSUBWAY_ANDROID_STORE_PASSWORD=",
+    "EASYSUBWAY_ANDROID_KEY_ALIAS=",
+    "EASYSUBWAY_ANDROID_KEY_PASSWORD=",
+    "",
+  ].join("\n"));
+
+  await execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root });
+
+  await writeFile(envFile, "EASYSUBWAY_POSTGRES_DB=easysubway\n");
+  await assert.rejects(
+    execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root }),
+    /Missing required deployment env names/
+  );
 });
 
 test("GitHub Actions 환경값 계약은 bracket notation 우회를 차단한다", () => {

--- a/tools/ci/validate-deployment-env.sh
+++ b/tools/ci/validate-deployment-env.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  printf 'usage: %s <dotenv-file>\n' "$0" >&2
+  exit 2
+fi
+
+env_file="$1"
+if [[ ! -f "${env_file}" ]]; then
+  printf 'deployment env file not found: %s\n' "${env_file}" >&2
+  exit 2
+fi
+
+has_env_name() {
+  local name="$1"
+  grep -Eq "^${name}=" "${env_file}"
+}
+
+is_satisfied_by_runtime_fallback() {
+  local name="$1"
+  case "${name}" in
+    EASYSUBWAY_REPORT_RECEIPT_PEPPER)
+      has_env_name EASYSUBWAY_REPORT_RECEIPT_TOKEN_PEPPER
+      ;;
+    EASYSUBWAY_REPORT_UPLOAD_INTENT_SIGNING_KEY)
+      has_env_name EASYSUBWAY_REPORT_RECEIPT_PEPPER || has_env_name EASYSUBWAY_REPORT_RECEIPT_TOKEN_PEPPER
+      ;;
+    EASYSUBWAY_OBJECT_STORAGE_REGION)
+      true
+      ;;
+    *)
+      false
+      ;;
+  esac
+}
+
+missing_names=()
+while IFS= read -r name; do
+  if [[ -n "${name}" ]] && ! has_env_name "${name}" && ! is_satisfied_by_runtime_fallback "${name}"; then
+    missing_names+=("${name}")
+  fi
+done < <(sed -nE 's/^([A-Z0-9_]+)=.*/\1/p' .env.example)
+
+if (( ${#missing_names[@]} > 0 )); then
+  printf 'Missing required deployment env names:\n' >&2
+  printf ' - %s\n' "${missing_names[@]}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## 관련 이슈

close #532

## 작업 배경

- PR #531 merge 이후 main CD가 `CD Readiness / Validate deployment dotenv contract` 단계에서 실패했습니다.
- 애플리케이션 prod 설정은 receipt pepper, upload intent signing key, object storage region에 fallback/default를 갖고 있지만 CD workflow는 `.env.example`의 새 키 이름을 단순 필수값으로만 검사했습니다.

## 작업 내용

- CD dotenv 검증을 `tools/ci/validate-deployment-env.sh`로 분리했습니다.
- `EASYSUBWAY_REPORT_RECEIPT_PEPPER`는 기존 `EASYSUBWAY_REPORT_RECEIPT_TOKEN_PEPPER`가 있으면 통과하도록 했습니다.
- `EASYSUBWAY_REPORT_UPLOAD_INTENT_SIGNING_KEY`는 별도 값이 없어도 receipt pepper fallback이 있으면 통과하도록 했습니다.
- `EASYSUBWAY_OBJECT_STORAGE_REGION`은 런타임 기본값 `us-east-1`과 맞춰 누락을 허용했습니다.
- 다른 `.env.example` 키 누락은 계속 실패하도록 contract test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs`: 70 pass
  - `tools/ci/validate-deployment-env.sh .env.example`: 통과
  - `node --test tools/ci/*.test.mjs`: 70 pass
  - `git diff --check`: 통과
  - GitHub Actions: CI, Release Artifacts 통과
  - CodeRabbit: check success with review skipped
  - Codex CLI fallback review: 최신 커밋 `5fadeb3dbc7fdaf9aedcf45e87759cbcc6b7f327` 기준 `Actionable comments posted: 0`

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 허용 예외가 런타임 `application-prod.yml` fallback/default와 같은 세 항목으로만 제한되는지 확인해 주세요.
  - 다른 배포 env 누락은 `Missing required deployment env names`로 계속 실패하는지 확인해 주세요.

## 리스크

- 이 변경은 GitHub Actions secret 값을 바꾸지 않고 CD readiness 검증 계약만 런타임 fallback과 맞춥니다.
- 추후 운영 secret을 새 env 이름으로 정리하면 fallback 허용 범위를 별도 작업에서 줄일 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.