### PR TITLE
[Fix] 미확인 접근성 경로 edge 차단

### DIFF
--- a/apps/mobile/lib/features/routes/application/accessibility_cost_calculator.dart
+++ b/apps/mobile/lib/features/routes/application/accessibility_cost_calculator.dart
@@ -21,12 +21,22 @@ class AccessibilityCostCalculator {
     final weight = RouteWeight.from(mobilityType);
     final warningCodes = <String>[];
 
-    if (!edge.isAvailable) {
+    if (edge.accessibilityState == RouteAccessibilityState.unavailable) {
       return const AccessibilityCost(
         cost: 0,
         isBlocked: true,
         warningCodes: ['FACILITY_UNAVAILABLE'],
       );
+    }
+    if (edge.accessibilityState == RouteAccessibilityState.unknown) {
+      if (mobilityType.blocksStairOnlyAccess) {
+        return const AccessibilityCost(
+          cost: 0,
+          isBlocked: true,
+          warningCodes: ['ACCESSIBILITY_STATE_UNKNOWN'],
+        );
+      }
+      warningCodes.add('ACCESSIBILITY_STATE_UNKNOWN');
     }
 
     if (edge.includesStairs && mobilityType.blocksStairOnlyAccess) {
@@ -44,6 +54,9 @@ class AccessibilityCostCalculator {
     if (edge.includesStairs) {
       cost += weight.stairOnlyAccessPenalty;
       warningCodes.add('STAIR_ONLY_ACCESS');
+    }
+    if (edge.accessibilityState == RouteAccessibilityState.unknown) {
+      cost += weight.lowDataConfidencePenalty;
     }
     if (edge.reliabilityScore < 80) {
       cost += weight.lowDataConfidencePenalty;

--- a/apps/mobile/lib/features/routes/application/network_graph.dart
+++ b/apps/mobile/lib/features/routes/application/network_graph.dart
@@ -1,5 +1,7 @@
 enum RouteEdgeType { ride, transfer, entry, exit }
 
+enum RouteAccessibilityState { available, unavailable, unknown }
+
 class RouteNode {
   const RouteNode({
     required this.id,
@@ -24,8 +26,14 @@ class RouteEdge {
     this.includesStairs = false,
     this.reliabilityScore = 100,
     this.isDataStale = false,
-    this.isAvailable = true,
-  });
+    RouteAccessibilityState accessibilityState =
+        RouteAccessibilityState.available,
+    bool? isAvailable,
+  }) : accessibilityState = isAvailable == null
+           ? accessibilityState
+           : isAvailable
+           ? RouteAccessibilityState.available
+           : RouteAccessibilityState.unavailable;
 
   final String id;
   final String fromNodeId;
@@ -37,7 +45,10 @@ class RouteEdge {
   final bool includesStairs;
   final int reliabilityScore;
   final bool isDataStale;
-  final bool isAvailable;
+  final RouteAccessibilityState accessibilityState;
+
+  bool get isAvailable =>
+      accessibilityState == RouteAccessibilityState.available;
 }
 
 class NetworkGraph {

--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -156,6 +156,7 @@ class LocalRouteEngine {
       'LOW_DATA_CONFIDENCE' => '일부 시설 정보는 확인이 필요합니다.',
       'STALE_ACCESSIBILITY_DATA' => '접근성 시설 정보가 최근 확인되지 않았습니다.',
       'STAIR_ONLY_ACCESS' => '계단 포함 구간이 있습니다.',
+      'ACCESSIBILITY_STATE_UNKNOWN' => '접근성 시설 이용 가능 여부를 확인할 수 없습니다.',
       _ => '이동 전 현장 안내를 확인해 주세요.',
     };
   }

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -151,6 +151,7 @@ class LocalRouteRepository implements RouteSearchRepository {
     return switch (code) {
       'STAIR_ONLY_ACCESS' => '계단 없는 경로를 찾지 못했습니다.',
       'FACILITY_UNAVAILABLE' => '필수 접근성 시설을 사용할 수 없습니다.',
+      'ACCESSIBILITY_STATE_UNKNOWN' => '접근성 시설 이용 가능 여부를 확인할 수 없습니다.',
       _ => '안내 가능한 경로를 찾지 못했습니다.',
     };
   }
@@ -639,7 +640,7 @@ graph.RouteEdge _toGraphRouteEdge(
     includesStairs: networkEdge.includesStairs,
     reliabilityScore: networkEdge.effectiveReliabilityScore,
     isDataStale: networkEdge.isDataStale,
-    isAvailable: networkEdge.isAvailable,
+    accessibilityState: networkEdge.accessibilityState,
   );
 }
 
@@ -765,7 +766,13 @@ class _NetworkEdgeSnapshot {
 
   String get _accessibilityStatusUpper => accessibilityStatus.toUpperCase();
 
-  bool get isAvailable => _accessibilityStatusUpper != 'UNAVAILABLE';
+  graph.RouteAccessibilityState get accessibilityState {
+    return switch (_accessibilityStatusUpper) {
+      'UNAVAILABLE' => graph.RouteAccessibilityState.unavailable,
+      'UNKNOWN' => graph.RouteAccessibilityState.unknown,
+      _ => graph.RouteAccessibilityState.available,
+    };
+  }
 
   int get effectiveReliabilityScore {
     if (_accessibilityStatusUpper == 'UNKNOWN' && reliabilityScore > 60) {

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -172,7 +172,7 @@ void main() {
     expect(result.steps, isEmpty);
   });
 
-  test('확인되지 않은 접근성 edge는 이동 가능 단정 없이 경고를 노출한다', () async {
+  test('확인되지 않은 접근성 edge는 휠체어 경로에서 이동 가능으로 안내하지 않는다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
     await _seedLineWithoutNetworkEdges(database);
@@ -200,15 +200,14 @@ void main() {
       ),
     );
 
-    expect(result.status, 'FOUND');
-    expect(result.warnings.map((warning) => warning.code), {
-      'LOW_DATA_CONFIDENCE',
-      'STALE_ACCESSIBILITY_DATA',
-    });
+    expect(result.status, 'BLOCKED');
+    expect(result.steps, isEmpty);
+    expect(result.blockedReasons, contains('접근성 시설 이용 가능 여부를 확인할 수 없습니다.'));
+    expect(result.warnings, isEmpty);
     expect(result.recommendationReasons.join('\n'), isNot(contains('확인했어요')));
   });
 
-  test('구형 catalog의 network_edges는 안전 기본값으로 읽는다', () async {
+  test('구형 catalog의 network_edges는 미확인 접근성 상태로 안전하게 차단한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
     await _seedLineWithoutNetworkEdges(database);
@@ -244,11 +243,10 @@ void main() {
       ),
     );
 
-    expect(result.status, 'FOUND');
-    expect(result.warnings.map((warning) => warning.code), {
-      'LOW_DATA_CONFIDENCE',
-      'STALE_ACCESSIBILITY_DATA',
-    });
+    expect(result.status, 'BLOCKED');
+    expect(result.steps, isEmpty);
+    expect(result.blockedReasons, contains('접근성 시설 이용 가능 여부를 확인할 수 없습니다.'));
+    expect(result.warnings, isEmpty);
   });
 
   test('service pattern node는 역-노선 node로 뭉개지지 않고 출입구와 연결된다', () async {
@@ -486,7 +484,8 @@ void main() {
     await database.customStatement('''
       INSERT INTO network_edges (
         id, from_node_id, to_node_id, duration_seconds, edge_type,
-        service_pattern, accessibility_status, reliability_score
+        service_pattern, accessibility_status, reliability_score,
+        last_verified_at
       )
       VALUES (
         'edge-a-b-low-confidence',
@@ -495,8 +494,9 @@ void main() {
         120,
         'RIDE',
         'LOCAL',
-        'UNKNOWN',
-        50
+        'AVAILABLE',
+        50,
+        0
       )
     ''');
     final repository = LocalRouteRepository(catalogDatabase: database);

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -75,6 +75,25 @@ void main() {
       expect(result.warningCodes, isEmpty);
     });
 
+    test('휠체어 조건은 미확인 접근성 edge를 안전한 경로로 사용하지 않는다', () {
+      final engine = LocalRouteEngine(
+        graph: _unknownAccessibilityFixtureGraph(),
+      );
+
+      final result = engine.search(
+        const RouteRequest(
+          originStationId: 'station-sangnoksu',
+          destinationStationId: 'station-sadang',
+          mobilityType: MobilityType.wheelchair,
+        ),
+      );
+
+      expect(result.status, RouteStatus.blocked);
+      expect(result.edgeIds, isEmpty);
+      expect(result.blockedReasonCodes, ['ACCESSIBILITY_STATE_UNKNOWN']);
+      expect(result.warningCodes, isEmpty);
+    });
+
     test('낮은 신뢰도와 오래된 데이터는 경고 코드와 비용에 반영한다', () {
       final engine = LocalRouteEngine(graph: _lowQualityFixtureGraph());
 
@@ -230,6 +249,48 @@ NetworkGraph _stairOnlyFixtureGraph() {
         type: RouteEdgeType.exit,
         baseCost: 45,
         includesStairs: true,
+      ),
+    ],
+  );
+}
+
+NetworkGraph _unknownAccessibilityFixtureGraph() {
+  return NetworkGraph(
+    nodes: const [
+      RouteNode(
+        id: 'station-sangnoksu:seoul-4',
+        stationId: 'station-sangnoksu',
+        lineId: 'seoul-4',
+      ),
+      RouteNode(
+        id: 'station-sadang:seoul-4',
+        stationId: 'station-sadang',
+        lineId: 'seoul-4',
+      ),
+    ],
+    edges: const [
+      RouteEdge(
+        id: 'entry-sangnoksu-unknown-elevator',
+        fromNodeId: 'station-sangnoksu',
+        toNodeId: 'station-sangnoksu:seoul-4',
+        type: RouteEdgeType.entry,
+        baseCost: 90,
+        accessibilityState: RouteAccessibilityState.unknown,
+      ),
+      RouteEdge(
+        id: 'ride-sangnoksu-sadang-line4',
+        fromNodeId: 'station-sangnoksu:seoul-4',
+        toNodeId: 'station-sadang:seoul-4',
+        type: RouteEdgeType.ride,
+        baseCost: 420,
+        lineId: 'seoul-4',
+      ),
+      RouteEdge(
+        id: 'exit-sadang-step-free',
+        fromNodeId: 'station-sadang:seoul-4',
+        toNodeId: 'station-sadang',
+        type: RouteEdgeType.exit,
+        baseCost: 60,
       ),
     ],
   );


### PR DESCRIPTION
## 관련 이슈

#534 일부 범위 해결. 이 PR은 issue를 닫지 않습니다.

## 작업 배경

미확인 접근성 상태가 있는 경로 edge를 이동 가능 상태처럼 다루면 휠체어 사용자가 실제 이용 가능 여부가 검증되지 않은 동선을 안전한 경로로 오인할 수 있습니다. 이번 PR은 잔여 정확도 보강 범위 중 `UNKNOWN` 접근성 상태의 fail-closed 처리를 먼저 분리해 고정합니다.

## 작업 내용

- route graph edge에 `RouteAccessibilityState`를 추가해 `available`, `unavailable`, `unknown`을 구분했습니다.
- `UNKNOWN` 접근성 edge는 휠체어 이동 조건에서 차단하고, 구형 catalog처럼 상태 컬럼이 없는 경우도 안전 기본값으로 차단하게 했습니다.
- local route repository가 catalog의 `accessibility_status`를 tri-state로 전달하도록 바꿨습니다.
- 기존 테스트에서 `UNKNOWN`을 `FOUND`로 보던 기대값을 출시 안전 기준에 맞게 수정했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/features/routes`: 통과
  - `cd apps/mobile && flutter test test/features/internal_route`: 통과
  - `cd apps/mobile && flutter test test/features/stations`: 통과
  - `cd apps/mobile && flutter analyze`: 통과
  - `cd apps/mobile && flutter test`: 통과
  - `git diff --check`: 통과
  - PR checks: Android CI, iOS CI, Mobile App CI, Backend CI, Repository CI, Dependency Vulnerability Scan, Android Release Artifact, iOS Release Artifact, Backend Release Image 통과
  - Codex CLI fallback review: actionable 0건
  - main post-merge CD run 27868221498: 통과
  - main post-merge CI run 27868221609: 통과
  - main post-merge Release Artifacts run 27868221499: 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteEdge.isAvailable` 호환 getter는 기존 호출부를 깨지 않기 위해 유지했습니다.
  - 이 PR은 `UNKNOWN` 접근성 상태 차단만 다루며, 거리·시간 source 분리와 loop/branch/multi-transfer 추가 fixture는 #534의 후속 범위로 남습니다.

## 리스크

- `UNKNOWN` edge를 포함한 휠체어 경로가 이전보다 더 자주 `BLOCKED`가 됩니다. 안전 기준상 의도한 변화지만, 실제 data pack에서 `AVAILABLE` 상태가 누락된 edge가 많으면 경로 탐색 가능성이 줄어들 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
