### PR TITLE
[Fix] 경로 추천 근거 문구 제한

### DIFF
--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -64,7 +64,7 @@ class LocalRouteRepository implements RouteSearchRepository {
             ),
           )
           .toList(growable: false),
-      recommendationReasons: _recommendationReasons(request.mobilityType),
+      recommendationReasons: _recommendationReasons(result),
       blockedReasons: result.blockedReasonCodes
           .map(_blockedReasonMessage)
           .toList(growable: false),
@@ -134,16 +134,15 @@ class LocalRouteRepository implements RouteSearchRepository {
     return (100 - (cost / 20).round()).clamp(1, 100);
   }
 
-  List<String> _recommendationReasons(String mobilityType) {
+  List<String> _recommendationReasons(local.LocalRouteResult result) {
+    if (result.status != local.RouteStatus.found) {
+      return const [];
+    }
+
     return [
-      '현재 데이터 기준으로 이동 가능한 철도 구간을 계산했습니다.',
+      '현재 데이터 기준으로 선택된 경로 단계를 계산했습니다.',
       '출구와 시설 상태는 현장 안내를 함께 확인해 주세요.',
-      switch (mobilityType) {
-        'WHEELCHAIR' => '휠체어 이동 조건에서 차단된 계단 구간은 제외했습니다.',
-        'STROLLER' => '유모차 이동 조건에서 차단된 계단 구간은 제외했습니다.',
-        'SENIOR' => '고령자 이동 조건의 접근 비용을 반영했습니다.',
-        _ => '선택한 이동 조건의 접근 비용을 반영했습니다.',
-      },
+      if (result.warnings.isNotEmpty) '확인 필요 구간은 주의 안내와 함께 표시합니다.',
     ];
   }
 

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -70,6 +70,46 @@ void main() {
     expect(reasons, contains('현장 안내'));
   });
 
+  test('로컬 경로 추천 이유와 음성 안내는 선택 경로에 없는 계단 차단 근거를 말하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, accessibility_status, reliability_score
+      )
+      VALUES (
+        'edge-a-b-local',
+        'station-a:line-test:LOCAL',
+        'station-b:line-test:LOCAL',
+        120,
+        'RIDE',
+        'LOCAL',
+        'AVAILABLE',
+        95
+      )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    const unusedEvidenceClaim = '차단된 계단 구간은 제외했습니다.';
+    expect(result.status, 'FOUND');
+    expect(result.steps.any((step) => step.includesStairs), isFalse);
+    expect(
+      result.recommendationReasons.join('\n'),
+      isNot(contains(unusedEvidenceClaim)),
+    );
+    expect(result.semanticLabel, isNot(contains(unusedEvidenceClaim)));
+  });
+
   test('로컬 catalog가 모르는 역 경로는 API fallback 없이 차단 결과를 반환한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);


### PR DESCRIPTION
## 관련 이슈

#534 일부 범위 해결. 이 PR은 issue를 닫지 않습니다.

## 작업 배경

로컬 경로 추천 이유가 실제 선택 경로에 없는 접근성 근거를 고정 문구로 말하면, screen reader 사용자에게도 같은 과장 안내가 전달됩니다. 이번 변경은 route reason과 semantics가 선택 경로/경고 상태에서 확인 가능한 내용만 말하도록 제한합니다.

## 작업 내용

- 로컬 경로 추천 이유 생성 입력을 mobility type에서 LocalRouteResult로 변경했습니다.
- FOUND 결과에서만 추천 이유를 만들고, BLOCKED 결과에는 추천 이유를 만들지 않도록 했습니다.
- 선택 경로에 없는 "차단된 계단 구간 제외" 문구가 추천 이유와 semantics에 노출되지 않는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/features/routes/local_route_repository_test.dart --plain-name '로컬 경로 추천 이유와 음성 안내는 선택 경로에 없는 계단 차단 근거를 말하지 않는다'` 통과
  - `flutter test test/features/routes/local_route_repository_test.dart` 통과
  - `flutter test test/route_search_test.dart` 통과
  - `flutter analyze` 통과
  - `git diff --check` 통과
  - PR #537 CI 통과: Android CI, Mobile App CI, iOS CI, Backend CI, Repository CI, Dependency Vulnerability Scan
  - PR #537 Release Artifacts 통과: Android Release Artifact, iOS Release Artifact, Backend Release Image
  - CodeRabbit은 rate limit으로 review를 시작하지 못했고, Codex CLI fallback review를 PR review로 기록했습니다. 결과는 actionable 0입니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `LocalRouteRepository._recommendationReasons`가 더 이상 mobility type만으로 접근성 조치 완료를 단정하지 않는지 확인해 주세요.

## 리스크

- 로컬 경로 결과의 추천 이유 문구가 더 보수적으로 바뀝니다. 기존 API 응답 DTO와 위젯 fixture의 외부 추천 이유 파싱 동작은 변경하지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.