### PR TITLE
[Fix] 다중 환승역 보존

### DIFF
--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -55,7 +55,7 @@ class LocalRouteEngine {
           durationSeconds: edge.baseCost,
           distanceMeters: edge.distanceMeters,
           lineId: edge.lineId,
-          transferStationId: edge.transferStationId,
+          transferStationId: _transferStationId(edge),
           includesStairs: edge.includesStairs,
         ),
       );
@@ -150,6 +150,25 @@ class LocalRouteEngine {
       RouteEdgeType.entry => RouteStepType.entry,
       RouteEdgeType.exit => RouteStepType.exit,
     };
+  }
+
+  String _transferStationId(RouteEdge edge) {
+    if (edge.transferStationId.isNotEmpty) {
+      return edge.transferStationId;
+    }
+    if (edge.type != RouteEdgeType.transfer) {
+      return '';
+    }
+    final fromStationId = _stationIdFromNode(edge.fromNodeId);
+    final toStationId = _stationIdFromNode(edge.toNodeId);
+    if (fromStationId.isEmpty || fromStationId != toStationId) {
+      return '';
+    }
+    return fromStationId;
+  }
+
+  String _stationIdFromNode(String nodeId) {
+    return nodeId.split(':').first;
   }
 
   String _warningMessage(String code) {

--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -159,9 +159,17 @@ class LocalRouteEngine {
     if (edge.type != RouteEdgeType.transfer) {
       return '';
     }
+    if (edge.fromNodeId == edge.toNodeId) {
+      return '';
+    }
     final fromStationId = _stationIdFromNode(edge.fromNodeId);
     final toStationId = _stationIdFromNode(edge.toNodeId);
     if (fromStationId.isEmpty || fromStationId != toStationId) {
+      return '';
+    }
+    final fromLineId = _lineIdFromNode(edge.fromNodeId);
+    final toLineId = _lineIdFromNode(edge.toNodeId);
+    if (fromLineId.isEmpty || toLineId.isEmpty || fromLineId == toLineId) {
       return '';
     }
     return fromStationId;
@@ -169,6 +177,11 @@ class LocalRouteEngine {
 
   String _stationIdFromNode(String nodeId) {
     return nodeId.split(':').first;
+  }
+
+  String _lineIdFromNode(String nodeId) {
+    final parts = nodeId.split(':');
+    return parts.length >= 2 ? parts[1] : '';
   }
 
   String _warningMessage(String code) {

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -81,6 +81,34 @@ void main() {
       ]);
     });
 
+    test('같은 노선 또는 다른 역 transfer edge는 환승역으로 보존하지 않는다', () {
+      final sameLineResult =
+          LocalRouteEngine(
+            graph: _sameLineTransferCatalogFixtureGraph(),
+          ).search(
+            const RouteRequest(
+              originStationId: 'station-a',
+              destinationStationId: 'station-b',
+              mobilityType: MobilityType.senior,
+            ),
+          );
+      final crossStationResult =
+          LocalRouteEngine(
+            graph: _crossStationTransferCatalogFixtureGraph(),
+          ).search(
+            const RouteRequest(
+              originStationId: 'station-a',
+              destinationStationId: 'station-c',
+              mobilityType: MobilityType.senior,
+            ),
+          );
+
+      expect(sameLineResult.status, RouteStatus.found);
+      expect(sameLineResult.transferStationIds, isEmpty);
+      expect(crossStationResult.status, RouteStatus.found);
+      expect(crossStationResult.transferStationIds, isEmpty);
+    });
+
     test('휠체어 조건은 계단만 있는 경로를 비용 증가가 아니라 차단으로 처리한다', () {
       final engine = LocalRouteEngine(graph: _stairOnlyFixtureGraph());
 
@@ -229,6 +257,112 @@ NetworkGraph _capitalFixtureGraph() {
         id: 'exit-cityhall-step-free',
         fromNodeId: 'station-cityhall:seoul-2',
         toNodeId: 'station-cityhall',
+        type: RouteEdgeType.exit,
+        baseCost: 90,
+      ),
+    ],
+  );
+}
+
+NetworkGraph _sameLineTransferCatalogFixtureGraph() {
+  return NetworkGraph(
+    nodes: const [
+      RouteNode(
+        id: 'station-a:line-1:LOCAL',
+        stationId: 'station-a',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-a:line-1:EXPRESS',
+        stationId: 'station-a',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-b:line-1:EXPRESS',
+        stationId: 'station-b',
+        lineId: 'line-1',
+      ),
+    ],
+    edges: const [
+      RouteEdge(
+        id: 'entry-a-line-1-local',
+        fromNodeId: 'station-a',
+        toNodeId: 'station-a:line-1:LOCAL',
+        type: RouteEdgeType.entry,
+        baseCost: 90,
+      ),
+      RouteEdge(
+        id: 'transfer-a-local-express',
+        fromNodeId: 'station-a:line-1:LOCAL',
+        toNodeId: 'station-a:line-1:EXPRESS',
+        type: RouteEdgeType.transfer,
+        baseCost: 80,
+      ),
+      RouteEdge(
+        id: 'ride-a-b-line-1-express',
+        fromNodeId: 'station-a:line-1:EXPRESS',
+        toNodeId: 'station-b:line-1:EXPRESS',
+        type: RouteEdgeType.ride,
+        baseCost: 180,
+        lineId: 'line-1',
+      ),
+      RouteEdge(
+        id: 'exit-b-line-1-express',
+        fromNodeId: 'station-b:line-1:EXPRESS',
+        toNodeId: 'station-b',
+        type: RouteEdgeType.exit,
+        baseCost: 90,
+      ),
+    ],
+  );
+}
+
+NetworkGraph _crossStationTransferCatalogFixtureGraph() {
+  return NetworkGraph(
+    nodes: const [
+      RouteNode(
+        id: 'station-a:line-1',
+        stationId: 'station-a',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-b:line-2',
+        stationId: 'station-b',
+        lineId: 'line-2',
+      ),
+      RouteNode(
+        id: 'station-c:line-2',
+        stationId: 'station-c',
+        lineId: 'line-2',
+      ),
+    ],
+    edges: const [
+      RouteEdge(
+        id: 'entry-a-line-1',
+        fromNodeId: 'station-a',
+        toNodeId: 'station-a:line-1',
+        type: RouteEdgeType.entry,
+        baseCost: 90,
+      ),
+      RouteEdge(
+        id: 'transfer-a-b-cross-station',
+        fromNodeId: 'station-a:line-1',
+        toNodeId: 'station-b:line-2',
+        type: RouteEdgeType.transfer,
+        baseCost: 240,
+      ),
+      RouteEdge(
+        id: 'ride-b-c-line-2',
+        fromNodeId: 'station-b:line-2',
+        toNodeId: 'station-c:line-2',
+        type: RouteEdgeType.ride,
+        baseCost: 180,
+        lineId: 'line-2',
+      ),
+      RouteEdge(
+        id: 'exit-c-line-2',
+        fromNodeId: 'station-c:line-2',
+        toNodeId: 'station-c',
         type: RouteEdgeType.exit,
         baseCost: 90,
       ),

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -56,6 +56,31 @@ void main() {
       expect(result.includesStairs, isFalse);
     });
 
+    test('2회 환승 경로는 catalog transfer edge에서 환승역 순서를 보존한다', () {
+      final engine = LocalRouteEngine(graph: _twoTransferCatalogFixtureGraph());
+
+      final result = engine.search(
+        const RouteRequest(
+          originStationId: 'station-a',
+          destinationStationId: 'station-d',
+          mobilityType: MobilityType.senior,
+        ),
+      );
+
+      expect(result.status, RouteStatus.found);
+      expect(result.lineIds, ['line-1', 'line-2', 'line-3']);
+      expect(result.transferStationIds, ['station-b', 'station-c']);
+      expect(result.edgeIds, [
+        'entry-a-line-1',
+        'ride-a-b-line-1',
+        'transfer-b-line-1-line-2',
+        'ride-b-c-line-2',
+        'transfer-c-line-2-line-3',
+        'ride-c-d-line-3',
+        'exit-d-line-3',
+      ]);
+    });
+
     test('휠체어 조건은 계단만 있는 경로를 비용 증가가 아니라 차단으로 처리한다', () {
       final engine = LocalRouteEngine(graph: _stairOnlyFixtureGraph());
 
@@ -204,6 +229,97 @@ NetworkGraph _capitalFixtureGraph() {
         id: 'exit-cityhall-step-free',
         fromNodeId: 'station-cityhall:seoul-2',
         toNodeId: 'station-cityhall',
+        type: RouteEdgeType.exit,
+        baseCost: 90,
+      ),
+    ],
+  );
+}
+
+NetworkGraph _twoTransferCatalogFixtureGraph() {
+  return NetworkGraph(
+    nodes: const [
+      RouteNode(
+        id: 'station-a:line-1',
+        stationId: 'station-a',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-b:line-1',
+        stationId: 'station-b',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-b:line-2',
+        stationId: 'station-b',
+        lineId: 'line-2',
+      ),
+      RouteNode(
+        id: 'station-c:line-2',
+        stationId: 'station-c',
+        lineId: 'line-2',
+      ),
+      RouteNode(
+        id: 'station-c:line-3',
+        stationId: 'station-c',
+        lineId: 'line-3',
+      ),
+      RouteNode(
+        id: 'station-d:line-3',
+        stationId: 'station-d',
+        lineId: 'line-3',
+      ),
+    ],
+    edges: const [
+      RouteEdge(
+        id: 'entry-a-line-1',
+        fromNodeId: 'station-a',
+        toNodeId: 'station-a:line-1',
+        type: RouteEdgeType.entry,
+        baseCost: 90,
+      ),
+      RouteEdge(
+        id: 'ride-a-b-line-1',
+        fromNodeId: 'station-a:line-1',
+        toNodeId: 'station-b:line-1',
+        type: RouteEdgeType.ride,
+        baseCost: 180,
+        lineId: 'line-1',
+      ),
+      RouteEdge(
+        id: 'transfer-b-line-1-line-2',
+        fromNodeId: 'station-b:line-1',
+        toNodeId: 'station-b:line-2',
+        type: RouteEdgeType.transfer,
+        baseCost: 140,
+      ),
+      RouteEdge(
+        id: 'ride-b-c-line-2',
+        fromNodeId: 'station-b:line-2',
+        toNodeId: 'station-c:line-2',
+        type: RouteEdgeType.ride,
+        baseCost: 210,
+        lineId: 'line-2',
+      ),
+      RouteEdge(
+        id: 'transfer-c-line-2-line-3',
+        fromNodeId: 'station-c:line-2',
+        toNodeId: 'station-c:line-3',
+        type: RouteEdgeType.transfer,
+        baseCost: 140,
+      ),
+      RouteEdge(
+        id: 'ride-c-d-line-3',
+        fromNodeId: 'station-c:line-3',
+        toNodeId: 'station-d:line-3',
+        type: RouteEdgeType.ride,
+        baseCost: 240,
+        lineId: 'line-3',
+      ),
+      RouteEdge(
+        id: 'exit-d-line-3',
+        fromNodeId: 'station-d:line-3',
+        toNodeId: 'station-d',
         type: RouteEdgeType.exit,
         baseCost: 90,
       ),


### PR DESCRIPTION
## 관련 이슈

#534 잔여 범위 중 `two_or_more_transfer_route_acceptance`를 처리합니다. 이 PR만으로 #534 전체를 닫지 않습니다.

## 작업 배경

로컬 경로 엔진은 explicit transfer edge를 따라 2회 이상 환승 경로를 계산할 수 있지만, catalog에서 생성된 transfer edge처럼 `transferStationId`가 비어 있는 경우 결과의 환승역 목록이 비어 경로 설명과 검증 근거가 약해질 수 있습니다.

## 작업 내용

- transfer edge에 `transferStationId`가 없더라도 양 끝 노드가 서로 다른 노선의 같은 역 노드이면 해당 역 ID를 환승역으로 복구합니다.
- 같은 노선 service-pattern transfer와 서로 다른 역을 잇는 비정상 transfer edge는 환승역으로 보존하지 않도록 경계를 제한했습니다.
- 3개 노선을 지나며 2회 환승하는 catalog 형태 fixture를 추가해 환승역 순서와 edge 순서를 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/features/routes/route_engine_test.dart --plain-name '2회 환승 경로는 catalog transfer edge에서 환승역 순서를 보존한다'`: 실패 확인 후 수정, 재실행 통과
  - `flutter test test/features/routes/route_engine_test.dart --plain-name '같은 노선 또는 다른 역 transfer edge는 환승역으로 보존하지 않는다'`: 실패 확인 후 수정, 재실행 통과
  - `flutter test test/features/routes`: 통과
  - `flutter analyze`: No issues found
  - `git diff --check`: 통과
  - PR CI: Backend CI, Repository CI, Mobile App CI, Android CI, iOS CI, Dependency Vulnerability Scan 통과
  - PR Release Artifacts: Backend Release Image, Android Release Artifact, iOS Release Artifact 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `LocalRouteEngine._transferStationId`가 기존 명시 `transferStationId`를 우선하고, 같은 역의 서로 다른 노선 노드 간 transfer일 때만 fallback을 적용하는지 확인해 주세요.

## 리스크

- 서로 다른 역 사이를 연결하거나 같은 노선 내부 service-pattern 전환인 transfer edge는 환승역을 복구하지 않으므로 빈 값 동작이 유지됩니다.
- 경로 비용 계산이나 edge 탐색 순서는 변경하지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (해당 없음: CodeRabbit 정상 완료)
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다. (merge 후 main CD 확인 예정)