### PR TITLE
[Fix] 방향 suffix 경로 노드 보존

### DIFF
--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -721,7 +721,7 @@ class _RouteNodeKey {
     return _RouteNodeKey(
       stationId: parts[0],
       lineId: parts[1],
-      servicePattern: parts.length >= 3 ? parts[2] : '',
+      servicePattern: parts.length >= 3 ? parts.skip(2).join(':') : '',
     );
   }
 

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -584,6 +584,69 @@ void main() {
     expect(skippedStopResult.steps, isEmpty);
   });
 
+  test(
+    'service pattern 방향 suffix가 있는 node도 entry와 ride edge를 같은 node로 연결한다',
+    () async {
+      final database = CatalogDatabase.memory();
+      addTearDown(database.close);
+      await _seedLineWithoutNetworkEdges(database);
+      await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        service_pattern, stair_access_state, accessibility_status,
+        reliability_score
+      )
+      VALUES
+        (
+          'edge-a-b-local-clockwise',
+          'station-a:line-test:LOCAL:CLOCKWISE',
+          'station-b:line-test:LOCAL:CLOCKWISE',
+          90,
+          'RIDE',
+          'LOCAL:CLOCKWISE',
+          'STEP_FREE',
+          'AVAILABLE',
+          95
+        ),
+        (
+          'edge-b-c-local-clockwise',
+          'station-b:line-test:LOCAL:CLOCKWISE',
+          'station-c:line-test:LOCAL:CLOCKWISE',
+          90,
+          'RIDE',
+          'LOCAL:CLOCKWISE',
+          'STEP_FREE',
+          'AVAILABLE',
+          95
+        )
+    ''');
+      final repository = LocalRouteRepository(catalogDatabase: database);
+
+      final result = await repository.searchRoute(
+        const RouteSearchRequest(
+          originStationId: 'station-a',
+          destinationStationId: 'station-c',
+          mobilityType: 'WHEELCHAIR',
+        ),
+      );
+
+      expect(result.status, 'FOUND');
+      expect(result.blockedReasons, isEmpty);
+      expect(
+        result.steps.map((step) => step.fromStationId),
+        contains('station-a'),
+      );
+      expect(
+        result.steps.map((step) => step.toStationId),
+        contains('station-c'),
+      );
+      expect(
+        result.steps.map((step) => step.lineId).where((id) => id.isNotEmpty),
+        everyElement('line-test'),
+      );
+    },
+  );
+
   test('step 소요시간은 접근성 패널티가 아니라 사용된 edge 시간에서 만든다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);


### PR DESCRIPTION
## 관련 이슈

#534 부분 해결입니다. route graph accuracy 잔여 범위가 남아 있어 자동 close하지 않습니다.

## 작업 배경

순환선 방향, 완행/급행, 분기 운행을 같은 station-line 안에서 구분하려면 route node의 service pattern 뒤에 붙는 방향 suffix까지 같은 node identity로 보존해야 합니다. 기존 parser는 node id의 세 번째 segment만 service pattern으로 사용해서 `station:line:LOCAL:CLOCKWISE` 같은 node를 generated entry/exit와 실제 ride edge에서 서로 다른 node처럼 다룰 수 있었습니다.

## 작업 내용

- `station:line:<service-pattern-suffix>` 형태의 세 번째 이후 segment 전체를 route node service pattern으로 보존했습니다.
- 방향 suffix가 붙은 LOCAL node가 generated entry를 통해 실제 ride edge와 연결되는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/features/routes/local_route_repository_test.dart --plain-name "service pattern 방향 suffix가 있는 node도 entry와 ride edge를 같은 node로 연결한다"`: 수정 전 `BLOCKED`로 실패, 수정 후 통과
  - `flutter test test/features/routes/local_route_repository_test.dart`: 28개 테스트 통과
  - `flutter test test/features/routes/route_engine_test.dart`: 11개 테스트 통과
  - `flutter analyze`: No issues found
  - `flutter test`: 301개 테스트 통과

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `_RouteNodeKey.tryParse`가 세 번째 이후 segment를 `:`로 다시 합쳐 direction/stop-pattern suffix를 보존하는지 확인해 주세요.
  - 새 테스트가 explicit ride edge와 generated entry/exit가 같은 suffixed node id를 공유해야만 통과하는지 확인해 주세요.

## 리스크

- 기존 3-segment node id(`station:line:EXPRESS`)는 동일하게 유지됩니다.
- 4개 이상 segment를 가진 node id는 이전보다 더 구체적인 node로 유지되므로, 기존에 잘못 collapse되던 경로가 분리됩니다.

## 체크리스트

- [x] CI 결과를 확인했다. 로컬 검증은 완료했고 GitHub CI는 PR 생성 후 확인합니다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
