### PR TITLE
[Fix] 미확인 이동 시간 표시 보강

### DIFF
--- a/apps/mobile/lib/features/routes/application/network_graph.dart
+++ b/apps/mobile/lib/features/routes/application/network_graph.dart
@@ -23,6 +23,7 @@ class RouteEdge {
     required this.toNodeId,
     required this.type,
     required this.baseCost,
+    int? durationSeconds,
     this.distanceMeters = 0,
     this.lineId = '',
     this.transferStationId = '',
@@ -33,7 +34,8 @@ class RouteEdge {
     RouteAccessibilityState accessibilityState =
         RouteAccessibilityState.available,
     bool? isAvailable,
-  }) : stairAccessState =
+  }) : durationSeconds = durationSeconds ?? baseCost,
+       stairAccessState =
            stairAccessState ??
            (includesStairs == true
                ? RouteStairAccessState.stairOnly
@@ -54,6 +56,7 @@ class RouteEdge {
   final String toNodeId;
   final RouteEdgeType type;
   final int baseCost;
+  final int durationSeconds;
   final int distanceMeters;
   final String lineId;
   final String transferStationId;

--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -52,7 +52,7 @@ class LocalRouteEngine {
           toNodeId: edge.toNodeId,
           type: _stepType(edge.type),
           cost: accessCost.cost,
-          durationSeconds: edge.baseCost,
+          durationSeconds: edge.durationSeconds,
           distanceMeters: edge.distanceMeters,
           lineId: edge.lineId,
           transferStationId: _transferStationId(edge),

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -92,7 +92,7 @@ class LocalRouteRepository implements RouteSearchRepository {
             lineName: lineName,
             fromStationId: fromStationId,
             toStationId: toStationId,
-            estimatedMinutes: (step.durationSeconds / 60).ceil().clamp(1, 999),
+            estimatedMinutes: _estimatedMinutesFor(step.durationSeconds),
             distanceMeters: step.distanceMeters,
             includesStairs: step.includesStairs,
             requiresAccessibilityCheck:
@@ -724,6 +724,9 @@ graph.RouteEdge _toGraphRouteEdge(
     baseCost: networkEdge.durationSeconds <= 0
         ? 60
         : networkEdge.durationSeconds,
+    durationSeconds: networkEdge.durationSeconds <= 0
+        ? 0
+        : networkEdge.durationSeconds,
     lineId: _lineIdForNode(effectiveFromNodeId),
     distanceMeters: networkEdge.distanceMeters,
     includesStairs: networkEdge.includesStairs,
@@ -732,6 +735,13 @@ graph.RouteEdge _toGraphRouteEdge(
     isDataStale: networkEdge.isDataStale,
     accessibilityState: networkEdge.accessibilityState,
   );
+}
+
+int _estimatedMinutesFor(int durationSeconds) {
+  if (durationSeconds <= 0) {
+    return 0;
+  }
+  return (durationSeconds / 60).ceil().clamp(1, 999);
 }
 
 String _lineIdForNode(String nodeId) {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -756,13 +756,20 @@ class RouteSearchStep {
 
   String get burdenLabel {
     final labels = <String>[
-      '약 $estimatedMinutes분',
+      _routeDurationLabel(estimatedMinutes),
       _routeDistanceLabel(distanceMeters),
       if (includesStairs) '계단 포함',
       if (requiresAccessibilityCheck) '접근성 확인',
     ];
     return labels.join(' · ');
   }
+}
+
+String _routeDurationLabel(int estimatedMinutes) {
+  if (estimatedMinutes <= 0) {
+    return '시간 확인 필요';
+  }
+  return '약 $estimatedMinutes분';
 }
 
 String _routeDistanceLabel(int distanceMeters) {

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -1127,6 +1127,49 @@ void main() {
     expect(rideStep.estimatedMinutes, 2);
   });
 
+  test('step 소요시간은 측정값이 없으면 ranking fallback 시간으로 표시하지 않는다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await _addDistanceMetersColumnIfMissing(database);
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, distance_meters,
+        edge_type, service_pattern, accessibility_status, reliability_score,
+        stair_access_state, last_verified_at
+      )
+      VALUES (
+        'edge-a-b-duration-unknown',
+        'station-a:line-test:LOCAL',
+        'station-b:line-test:LOCAL',
+        0,
+        850,
+        'RIDE',
+        'LOCAL',
+        'AVAILABLE',
+        100,
+        'STEP_FREE',
+        1700000000
+      )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    final rideStep = result.steps.singleWhere(
+      (step) => step.lineId == 'line-test',
+    );
+    expect(result.status, 'FOUND');
+    expect(rideStep.estimatedMinutes, 0);
+    expect(rideStep.distanceMeters, 850);
+  });
+
   test('step 거리는 ranking cost에서 만들지 않고 측정값이 없으면 미확인으로 둔다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -357,6 +357,24 @@ void main() {
     expect(step.burdenLabel, '약 30분 · 거리 확인 필요');
   });
 
+  test('경로 단계 이동 부담은 측정 시간 없음 상태를 0분으로 표시하지 않는다', () {
+    const step = RouteSearchStep(
+      sequence: 2,
+      title: '수도권 4호선으로 사당역까지 이동',
+      description: '15개 역을 이동합니다. 환승은 없습니다.',
+      lineId: 'seoul-4',
+      lineName: '수도권 4호선',
+      fromStationId: 'station-sangnoksu',
+      toStationId: 'station-sadang',
+      estimatedMinutes: 0,
+      distanceMeters: 180,
+      includesStairs: false,
+      requiresAccessibilityCheck: false,
+    );
+
+    expect(step.burdenLabel, '시간 확인 필요 · 180m');
+  });
+
   test('즐겨찾기 경로 API 저장소는 인증 헤더로 저장과 목록과 삭제를 요청한다', () async {
     final requestedMethods = <String>[];
     final requestedPaths = <String>[];


### PR DESCRIPTION
## 관련 이슈

close #534

## 작업 배경

- 로컬 경로 그래프가 이동 시간 측정값이 없는 edge를 ranking fallback 시간으로 표시하면, 사용자는 실제 측정 근거가 없는 구간을 `약 1분`처럼 확정 시간으로 오인할 수 있다.
- 거리 미확인 상태는 `거리 확인 필요`로 표시되고 있었지만, 시간 미확인 상태는 `약 0분` 또는 fallback 시간으로 노출될 여지가 남아 있었다.

## 작업 내용

- route graph edge에 ranking용 `baseCost`와 표시용 `durationSeconds`를 분리했다.
- `duration_seconds`가 0 이하인 catalog edge는 경로 탐색 ranking에서는 기존 fallback cost를 쓰되, 사용자 표시용 시간은 0으로 유지해 미확인 상태를 보존한다.
- route search 단계 표시에서 `estimatedMinutes <= 0`은 `약 0분` 대신 `시간 확인 필요`로 표시한다.
- 측정 시간 없음 상태와 fallback 시간 혼동을 막는 route repository, route search 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/route_search_test.dart` 통과
  - `flutter test test/features/routes/local_route_repository_test.dart` 통과
  - `flutter test test/widget_test.dart --plain-name "경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다"` 통과
  - `flutter test test/features/routes` 통과
  - `flutter test test/features/internal_route` 통과
  - `flutter test test/features/stations` 통과
  - `flutter analyze` 통과
  - `node --test tools/ci/repository-contract.test.mjs` 통과
  - `git diff --check` 통과
  - `flutter build apk --debug` 통과
  - `flutter build ios --simulator --debug` 통과

## 리뷰어 메모

- `RouteEdge.baseCost`는 경로 탐색 ranking용이고, `RouteEdge.durationSeconds`는 사용자에게 표시할 측정 시간 근거다.
- `duration_seconds=0`은 route search 결과에서 `estimatedMinutes=0`으로 유지되어 `시간 확인 필요`로 표시된다.

## 리스크

- API 모델은 기존 `estimatedMinutes` 정수 계약을 유지하므로 서버/클라이언트 JSON 호환성 변화는 없다.
- 시간 미확인 구간은 이동 순서와 스크린리더 안내에서 확정 소요시간 대신 확인 필요 문구로 노출된다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
