### PR TITLE
[Fix] 릴리즈 산출물 API 기준 URL 주입

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -120,6 +120,7 @@ jobs:
           set -euo pipefail
           flutter pub get
           flutter build appbundle --release \
+            --dart-define=EASYSUBWAY_API_BASE_URL=https://api.easysubway.local \
             --dart-define=EASYSUBWAY_PRIVACY_POLICY_URL=https://easysubway.local/privacy \
             --dart-define=EASYSUBWAY_SUPPORT_EMAIL=support@easysubway.local \
             --dart-define=EASYSUBWAY_DATA_DELETION_EMAIL=privacy@easysubway.local \
@@ -177,6 +178,7 @@ jobs:
           set -euo pipefail
           flutter pub get
           flutter build ios --release --no-codesign \
+            --dart-define=EASYSUBWAY_API_BASE_URL=https://api.easysubway.local \
             --dart-define=EASYSUBWAY_PRIVACY_POLICY_URL=https://easysubway.local/privacy \
             --dart-define=EASYSUBWAY_SUPPORT_EMAIL=support@easysubway.local \
             --dart-define=EASYSUBWAY_DATA_DELETION_EMAIL=privacy@easysubway.local \

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -120,7 +120,6 @@ jobs:
           set -euo pipefail
           flutter pub get
           flutter build appbundle --release \
-            --dart-define=EASYSUBWAY_API_BASE_URL=https://api.easysubway.local \
             --dart-define=EASYSUBWAY_PRIVACY_POLICY_URL=https://easysubway.local/privacy \
             --dart-define=EASYSUBWAY_SUPPORT_EMAIL=support@easysubway.local \
             --dart-define=EASYSUBWAY_DATA_DELETION_EMAIL=privacy@easysubway.local \
@@ -178,7 +177,6 @@ jobs:
           set -euo pipefail
           flutter pub get
           flutter build ios --release --no-codesign \
-            --dart-define=EASYSUBWAY_API_BASE_URL=https://api.easysubway.local \
             --dart-define=EASYSUBWAY_PRIVACY_POLICY_URL=https://easysubway.local/privacy \
             --dart-define=EASYSUBWAY_SUPPORT_EMAIL=support@easysubway.local \
             --dart-define=EASYSUBWAY_DATA_DELETION_EMAIL=privacy@easysubway.local \

--- a/apps/mobile/lib/app/app_dependencies.dart
+++ b/apps/mobile/lib/app/app_dependencies.dart
@@ -49,9 +49,27 @@ class AppDependencies {
     UserDataDeletionRepository? userDataDeletionRepository,
     CatalogDatabase? catalogDatabase,
     UserDatabase? userDatabase,
+    Uri? Function() apiBaseUri = defaultOptionalStationApiBaseUri,
     required bool enablePushNotifications,
   }) {
-    final baseUri = defaultStationApiBaseUri();
+    Uri? cachedBaseUri;
+    var baseUriResolved = false;
+    Uri? optionalBaseUri() {
+      if (!baseUriResolved) {
+        cachedBaseUri = apiBaseUri();
+        baseUriResolved = true;
+      }
+      return cachedBaseUri;
+    }
+
+    Uri requireBaseUri() {
+      final baseUri = optionalBaseUri();
+      if (baseUri == null) {
+        throw StateError('Release API base URL must be configured.');
+      }
+      return baseUri;
+    }
+
     final pushNotificationsEnabled =
         enablePushNotifications ||
         notificationRepository != null ||
@@ -63,7 +81,7 @@ class AppDependencies {
                       userDatabase: userDatabase,
                     )
                   : _defaultNotificationSettingsRepository(
-                      baseUri: baseUri,
+                      baseUri: requireBaseUri,
                       authProvider: null,
                     ))
         : null;
@@ -76,20 +94,17 @@ class AppDependencies {
           repository ??
           (catalogDatabase != null
               ? DriftStationRepository(database: catalogDatabase)
-              : StationSearchApiRepository(baseUri: baseUri)),
+              : StationSearchApiRepository(baseUri: requireBaseUri())),
       reportRepository:
           reportRepository ??
-          FacilityReportApiRepository(
-            baseUri: baseUri,
-            authProvider: null,
-            receiptStore: userDatabase == null
-                ? null
-                : DriftFacilityReportReceiptStore(userDatabase: userDatabase),
+          _defaultFacilityReportRepository(
+            baseUri: optionalBaseUri,
+            userDatabase: userDatabase,
           ),
       routeRepository:
           routeRepository ??
           (catalogDatabase == null
-              ? RouteSearchApiRepository(baseUri: baseUri)
+              ? RouteSearchApiRepository(baseUri: requireBaseUri())
               : FallbackRouteSearchRepository(
                   localRepository: LocalRouteRepository(
                     catalogDatabase: catalogDatabase,
@@ -97,7 +112,10 @@ class AppDependencies {
                 )),
       routeFeedbackRepository:
           routeFeedbackRepository ??
-          _defaultRouteFeedbackRepository(baseUri: baseUri, authProvider: null),
+          _defaultRouteFeedbackRepository(
+            baseUri: requireBaseUri,
+            authProvider: null,
+          ),
       favoriteRepository:
           favoriteRepository ??
           (catalogDatabase != null && userDatabase != null
@@ -106,7 +124,7 @@ class AppDependencies {
                   userDatabase: userDatabase,
                 )
               : _defaultFavoriteStationRepository(
-                  baseUri: baseUri,
+                  baseUri: requireBaseUri,
                   authProvider: null,
                 )),
       favoriteFacilityRepository:
@@ -117,7 +135,7 @@ class AppDependencies {
                   userDatabase: userDatabase,
                 )
               : _defaultFavoriteFacilityRepository(
-                  baseUri: baseUri,
+                  baseUri: requireBaseUri,
                   authProvider: null,
                 )),
       favoriteRouteRepository:
@@ -128,7 +146,7 @@ class AppDependencies {
                   userDatabase: userDatabase,
                 )
               : _defaultFavoriteRouteRepository(
-                  baseUri: baseUri,
+                  baseUri: requireBaseUri,
                   authProvider: null,
                 )),
       searchHistoryRepository:
@@ -139,7 +157,7 @@ class AppDependencies {
       internalRouteRepository:
           internalRouteRepository ??
           (catalogDatabase == null
-              ? InternalRouteApiRepository(baseUri: baseUri)
+              ? InternalRouteApiRepository(baseUri: requireBaseUri())
               : FallbackInternalRouteRepository(
                   localRepository: LocalInternalRouteRepository(
                     catalogDatabase: catalogDatabase,
@@ -152,7 +170,7 @@ class AppDependencies {
       userDataDeletionRepository:
           userDataDeletionRepository ??
           _defaultUserDataDeletionRepository(
-            baseUri: baseUri,
+            baseUri: requireBaseUri,
             authProvider: null,
             userDatabase: userDatabase,
           ),
@@ -174,8 +192,25 @@ class AppDependencies {
   final UserDataDeletionRepository? userDataDeletionRepository;
 }
 
+FacilityReportRepository _defaultFacilityReportRepository({
+  required Uri? Function() baseUri,
+  required UserDatabase? userDatabase,
+}) {
+  final resolvedBaseUri = baseUri();
+  if (resolvedBaseUri == null) {
+    return const UnavailableFacilityReportRepository();
+  }
+  return FacilityReportApiRepository(
+    baseUri: resolvedBaseUri,
+    authProvider: null,
+    receiptStore: userDatabase == null
+        ? null
+        : DriftFacilityReportReceiptStore(userDatabase: userDatabase),
+  );
+}
+
 UserDataDeletionRepository? _defaultUserDataDeletionRepository({
-  required Uri baseUri,
+  required Uri Function() baseUri,
   required AuthorizationHeaderProvider? authProvider,
   required UserDatabase? userDatabase,
 }) {
@@ -185,7 +220,7 @@ UserDataDeletionRepository? _defaultUserDataDeletionRepository({
   final remoteRepository = authProvider == null
       ? null
       : UserDataDeletionApiRepository(
-          baseUri: baseUri,
+          baseUri: baseUri(),
           authProvider: authProvider,
         );
   if (remoteRepository != null && localRepository != null) {
@@ -198,66 +233,66 @@ UserDataDeletionRepository? _defaultUserDataDeletionRepository({
 }
 
 FavoriteStationRepository? _defaultFavoriteStationRepository({
-  required Uri baseUri,
+  required Uri Function() baseUri,
   required AuthorizationHeaderProvider? authProvider,
 }) {
   if (authProvider == null) {
     return null;
   }
   return FavoriteStationApiRepository(
-    baseUri: baseUri,
+    baseUri: baseUri(),
     authProvider: authProvider,
   );
 }
 
 FavoriteFacilityRepository? _defaultFavoriteFacilityRepository({
-  required Uri baseUri,
+  required Uri Function() baseUri,
   required AuthorizationHeaderProvider? authProvider,
 }) {
   if (authProvider == null) {
     return null;
   }
   return FavoriteFacilityApiRepository(
-    baseUri: baseUri,
+    baseUri: baseUri(),
     authProvider: authProvider,
   );
 }
 
 FavoriteRouteRepository? _defaultFavoriteRouteRepository({
-  required Uri baseUri,
+  required Uri Function() baseUri,
   required AuthorizationHeaderProvider? authProvider,
 }) {
   if (authProvider == null) {
     return null;
   }
   return FavoriteRouteApiRepository(
-    baseUri: baseUri,
+    baseUri: baseUri(),
     authProvider: authProvider,
   );
 }
 
 RouteFeedbackRepository? _defaultRouteFeedbackRepository({
-  required Uri baseUri,
+  required Uri Function() baseUri,
   required AuthorizationHeaderProvider? authProvider,
 }) {
   if (authProvider == null) {
     return null;
   }
   return RouteFeedbackApiRepository(
-    baseUri: baseUri,
+    baseUri: baseUri(),
     authProvider: authProvider,
   );
 }
 
 NotificationSettingsRepository? _defaultNotificationSettingsRepository({
-  required Uri baseUri,
+  required Uri Function() baseUri,
   required AuthorizationHeaderProvider? authProvider,
 }) {
   if (authProvider == null) {
     return null;
   }
   return NotificationSettingsApiRepository(
-    baseUri: baseUri,
+    baseUri: baseUri(),
     authProvider: authProvider,
   );
 }

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -42,6 +42,27 @@ abstract class FacilityReportRepository {
   Future<List<FacilityReportResult>> listMyReports();
 }
 
+class UnavailableFacilityReportRepository implements FacilityReportRepository {
+  const UnavailableFacilityReportRepository();
+
+  @override
+  Future<FacilityReportResult> createReport(
+    FacilityReportRequest request,
+  ) async {
+    throw const FacilityReportException(_facilityReportErrorMessage);
+  }
+
+  @override
+  Future<FacilityReportResult> getReport(String reportId) async {
+    throw const FacilityReportException(_facilityReportStatusErrorMessage);
+  }
+
+  @override
+  Future<List<FacilityReportResult>> listMyReports() async {
+    throw const FacilityReportException(_facilityReportListErrorMessage);
+  }
+}
+
 class FacilityReportApiRepository implements FacilityReportRepository {
   FacilityReportApiRepository({
     required this.baseUri,

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -4062,6 +4062,30 @@ Uri defaultStationApiBaseUri() {
   );
 }
 
+Uri? defaultOptionalStationApiBaseUri() {
+  const configuredBaseUrl = String.fromEnvironment('EASYSUBWAY_API_BASE_URL');
+  return optionalStationApiBaseUriForEnvironment(
+    configuredBaseUrl: configuredBaseUrl,
+    isAndroid: Platform.isAndroid,
+    isReleaseMode: kReleaseMode,
+  );
+}
+
+Uri? optionalStationApiBaseUriForEnvironment({
+  required String configuredBaseUrl,
+  required bool isAndroid,
+  required bool isReleaseMode,
+}) {
+  if (configuredBaseUrl.trim().isEmpty && isReleaseMode) {
+    return null;
+  }
+  return stationApiBaseUriForEnvironment(
+    configuredBaseUrl: configuredBaseUrl,
+    isAndroid: isAndroid,
+    isReleaseMode: isReleaseMode,
+  );
+}
+
 Uri stationApiBaseUriForEnvironment({
   required String configuredBaseUrl,
   required bool isAndroid,

--- a/apps/mobile/test/app_dependencies_test.dart
+++ b/apps/mobile/test/app_dependencies_test.dart
@@ -1,0 +1,47 @@
+import 'package:easysubway_mobile/app/app_dependencies.dart';
+import 'package:easysubway_mobile/core/database/catalog/catalog_database.dart';
+import 'package:easysubway_mobile/core/database/user/user_database.dart'
+    as user_db;
+import 'package:easysubway_mobile/facility_report.dart';
+import 'package:easysubway_mobile/features/routes/data/local_route_repository.dart';
+import 'package:easysubway_mobile/features/stations/data/drift_station_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('로컬 데이터베이스가 있으면 API 주소 없이도 앱 의존성을 만든다', () {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+
+    final dependencies = AppDependencies.resolve(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+      apiBaseUri: () => null,
+      enablePushNotifications: false,
+    );
+
+    expect(dependencies.repository, isA<DriftStationRepository>());
+    expect(dependencies.routeRepository, isA<FallbackRouteSearchRepository>());
+    expect(
+      dependencies.reportRepository,
+      isA<UnavailableFacilityReportRepository>(),
+    );
+  });
+
+  test('로컬 데이터베이스가 없으면 API 주소 없는 원격 fallback을 만들지 않는다', () {
+    expect(
+      () => AppDependencies.resolve(
+        apiBaseUri: () => null,
+        enablePushNotifications: false,
+      ),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'Release API base URL must be configured.',
+        ),
+      ),
+    );
+  });
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -619,10 +619,9 @@ test("릴리즈 산출물 워크플로우는 모바일 스토어 산출물과 ba
   assert.match(workflow, /EASYSUBWAY_ANDROID_KEY_ALIAS: ci-release/);
   assert.match(workflow, /EASYSUBWAY_ANDROID_KEY_PASSWORD: ci-release-password/);
   assert.match(workflow, /flutter build appbundle --release/);
-  assert.match(workflow, /--dart-define=EASYSUBWAY_API_BASE_URL=https:\/\/api\.easysubway\.local/);
   assert.equal(
-    (workflow.match(/--dart-define=EASYSUBWAY_API_BASE_URL=https:\/\/api\.easysubway\.local/g) ?? []).length,
-    2,
+    (workflow.match(/--dart-define=EASYSUBWAY_API_BASE_URL=https:\/\/\S+\.local/g) ?? []).length,
+    0,
   );
   assert.match(workflow, /--dart-define=EASYSUBWAY_PRIVACY_POLICY_URL=https:\/\/easysubway\.local\/privacy/);
   assert.match(workflow, /--dart-define=EASYSUBWAY_SUPPORT_EMAIL=support@easysubway\.local/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -619,6 +619,11 @@ test("릴리즈 산출물 워크플로우는 모바일 스토어 산출물과 ba
   assert.match(workflow, /EASYSUBWAY_ANDROID_KEY_ALIAS: ci-release/);
   assert.match(workflow, /EASYSUBWAY_ANDROID_KEY_PASSWORD: ci-release-password/);
   assert.match(workflow, /flutter build appbundle --release/);
+  assert.match(workflow, /--dart-define=EASYSUBWAY_API_BASE_URL=https:\/\/api\.easysubway\.local/);
+  assert.equal(
+    (workflow.match(/--dart-define=EASYSUBWAY_API_BASE_URL=https:\/\/api\.easysubway\.local/g) ?? []).length,
+    2,
+  );
   assert.match(workflow, /--dart-define=EASYSUBWAY_PRIVACY_POLICY_URL=https:\/\/easysubway\.local\/privacy/);
   assert.match(workflow, /--dart-define=EASYSUBWAY_SUPPORT_EMAIL=support@easysubway\.local/);
   assert.match(workflow, /--dart-define=EASYSUBWAY_DATA_DELETION_EMAIL=privacy@easysubway\.local/);


### PR DESCRIPTION
## 관련 이슈

refs AquilaXk/easysubway-mobile#7

이 PR은 #571의 release artifact/API base 경계와 Android emulator/iOS no-codesign 검증을 보강하지만, Play internal track/TestFlight/secret 반영 증거가 남아 있으므로 issue를 닫지 않는다.

## 작업 배경

- 서버 최소화 전환 후 실제 제출 전 기준에서 Android/iOS 릴리즈 산출물이 로컬 카탈로그만으로 시작 가능한지 확인해야 한다.
- PR 생성 후 코드리뷰에서 릴리즈 빌드에 임시 `.local` API 기준 URL을 주입하면 제출 산출물에 운영 불가능한 URL이 남을 수 있다는 문제가 확인됐다.
- 최종 방향은 API 기준 URL을 강제로 넣는 것이 아니라, 로컬 DB 기반 시작 경로는 API 기준 URL 없이 동작하고 원격 기능을 실제 사용할 때만 API 기준 URL을 요구하도록 분리하는 것이다.

## 작업 내용

- 릴리즈 환경의 station API 기준 URL 해석을 nullable 경로로 분리해, 로컬 카탈로그와 사용자 DB가 준비된 시작 경로에서는 API 기준 URL 없이 의존성을 구성한다.
- 원격 station repository가 필요한 경로에서는 기존처럼 `Release API base URL must be configured.` 오류를 유지한다.
- 시설 제보 API 기준 URL이 없는 제출 산출물에서는 `UnavailableFacilityReportRepository`를 사용해 사용자 메시지로 기능 불가 상태를 반환한다.
- 앱 의존성 해석 테스트를 추가해 API 기준 URL 없는 로컬 DB 시작 성공과 원격 DB 필요 시 실패를 고정했다.
- release artifact workflow에 `.local` API 기준 URL을 주입하지 못하도록 repository contract를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/app_dependencies_test.dart test/station_search_test.dart test/facility_report_test.dart` 통과
  - `node --test tools/ci/*.test.mjs` 통과
  - `flutter analyze` 통과
  - `flutter test` 통과, 324개 테스트 통과
  - `flutter build appbundle --release` 통과, API 기준 URL dart-define 없이 Android release AAB 생성
  - `bundletool build-apks` 통과
  - `bundletool install-apks` 통과
  - Android emulator에서 API 기준 URL 없는 release 설치본 실행 확인
  - `flutter build ios --release --no-codesign` 통과, API 기준 URL dart-define 없이 Runner.app 생성
  - `git diff --check` 통과
  - `git ls-files '*.md'` 확인, 추적 Markdown은 `.github/pull_request_template.md`, `README.md`만 존재
  - GitHub CI 통과: https://github.com/AquilaXk/easysubway/actions/runs/27900393740
  - Release Artifacts 통과: https://github.com/AquilaXk/easysubway/actions/runs/27900393692

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| API 기준 URL 없는 앱 의존성 구성 | local Flutter | `flutter test test/app_dependencies_test.dart test/station_search_test.dart test/facility_report_test.dart` | 명령 출력 | 통과 |
| 전체 모바일 테스트 | local Flutter | `flutter analyze`, `flutter test` | 명령 출력 | 통과 |
| release workflow `.local` API 주입 금지 | local Node | `node --test tools/ci/*.test.mjs` | 명령 출력 | 통과 |
| Android release AAB | Android | API 기준 URL 없이 `flutter build appbundle --release` | AAB sha256 `f71d08d788eaf20b3dafd42757db569ffd49fa423c92372faa459beb7918a4ce`, mapping sha256 `60925ee9287094c367caa4f8912a7cb9de1ed17b4c9455cdb20062a184b78f2d` | 생성 성공 |
| Android release 설치 실행 | Android emulator | `bundletool install-apks`, `adb shell am start` | `.codex/evidence/server-minimization/pr10/android/internal-test-track-install/release-no-api-base-launch-home.png`, `release-no-api-base-launch-ui.xml`, `release-no-api-base-launch-logcat.txt` | 홈 화면 실행, release API base 오류와 `.local` API URL 로그 없음 |
| iOS release build | iOS | API 기준 URL 없이 `flutter build ios --release --no-codesign` | 명령 출력, `build/ios/iphoneos/Runner.app` | 생성 성공 |
| PR CI | GitHub Actions | PR head `0c61e3259137c407bfe3738b975032b8f4723525` 기준 CI 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27900393740 | 통과 |
| Release artifact CI | GitHub Actions | PR head `0c61e3259137c407bfe3738b975032b8f4723525` 기준 release artifact 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27900393692 | 통과 |
| CodeRabbit 상태 확인 | GitHub PR | 기존 bot comment, PR status 확인. 수동 `@coderabbitai review` 또는 CLI 호출 없음 | https://github.com/AquilaXk/easysubway/pull/572#issuecomment-4761531746 | rate limit 상태 확인 후 Codex CLI fallback 사용 |
| Codex CLI fallback 리뷰 | GitHub PR review | finding inline 게시 후 수정 커밋, 원래 thread 답글, resolve, 재리뷰 기록 | https://github.com/AquilaXk/easysubway/pull/572#pullrequestreview-4539478116, https://github.com/AquilaXk/easysubway/pull/572#pullrequestreview-4539493608 | 1건 수정 완료, 재리뷰 추가 지적 0 |
| `EASYSUBWAY_ENV` secret 반영 | GitHub Actions secret | 사용자 승인 후 저장소 스크립트 실행 시도 | 정책 심사에서 production `.env` 전체 외부 전송으로 차단 | 미반영, 사용자 수동 반영 필요 |

## 리뷰어 메모

- 먼저 볼 지점:
  - `AppDependencies.resolve`가 API 기준 URL을 eager하게 요구하지 않고 remote fallback이 필요할 때만 요구하는지
  - `UnavailableFacilityReportRepository`가 API 기준 URL 없는 제출 산출물에서 시설 제보 기능의 실패를 사용자 메시지로 제한하는지
  - release artifact workflow에 임시 `.local` API URL이 남지 않는지

## 리스크

- 실제 Play internal track 설치와 TestFlight 설치는 계정/서명/스토어 권한이 필요해 아직 완료되지 않았다.
- `EASYSUBWAY_ENV` secret은 로컬 production `.env` 전체 외부 전송 정책 차단으로 이 스레드에서 갱신하지 못했다. 사용자 계정에서 수동 반영 후 release workflow 재확인이 필요하다.
- API 기준 URL이 없는 제출 산출물에서는 시설 제보 원격 기능이 의도적으로 비활성화된다. 서버 연동을 제출 산출물에 포함할 때는 운영 `EASYSUBWAY_REPORT_API_BASE_URL`과 station API 기준 URL을 별도 설정해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
