### PR TITLE
[Test] 신고 receipt 데이터팩 교체 보존 검증

### DIFF
--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -554,7 +554,7 @@ void main() {
     );
   });
 
-  test('user DB는 catalog 데이터팩 교체와 독립적으로 즐겨찾기를 보존한다', () async {
+  test('user DB는 catalog 데이터팩 교체와 독립적으로 즐겨찾기와 신고 receipt를 보존한다', () async {
     final directory = await Directory.systemTemp.createTemp('easysubway-user-');
     addTearDown(() => directory.delete(recursive: true));
 
@@ -565,6 +565,16 @@ void main() {
           FavoriteStationsCompanion.insert(
             stationId: 'station-sangnoksu',
             addedAt: DateTime.parse('2026-06-19T10:00:00Z'),
+          ),
+        );
+    await first
+        .into(first.reportReceipts)
+        .insert(
+          ReportReceiptsCompanion.insert(
+            receiptId: 'receipt-1',
+            reportId: const Value('report-1'),
+            status: 'RECEIVED',
+            createdAt: DateTime.parse('2026-06-19T10:05:00Z'),
           ),
         );
     await first.close();
@@ -579,8 +589,13 @@ void main() {
     addTearDown(reopened.close);
 
     final favorites = await reopened.select(reopened.favoriteStations).get();
+    final receipts = await reopened.select(reopened.reportReceipts).get();
 
     expect(favorites, hasLength(1));
     expect(favorites.single.stationId, 'station-sangnoksu');
+    expect(receipts, hasLength(1));
+    expect(receipts.single.receiptId, 'receipt-1');
+    expect(receipts.single.reportId, 'report-1');
+    expect(receipts.single.status, 'RECEIVED');
   });
 }


### PR DESCRIPTION
## 관련 이슈

refs AquilaXk/easysubway-mobile#7

## 작업 배경

서버 최소화 최종 인수 QA에서 catalog 데이터팩 교체 후 사용자 데이터 보존 항목 중 즐겨찾기 보존은 테스트 증거가 있었지만, 시설 신고 receipt metadata 보존 증거가 별도로 부족했다.

## 작업 내용

- `mobile_local_database_test.dart`의 user DB 보존 테스트에 `report_receipts` row 삽입을 추가했다.
- catalog 데이터팩 파일을 교체한 뒤 user DB를 재오픈해 즐겨찾기와 신고 receipt metadata가 함께 유지되는지 검증한다.
- production code는 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/test/core/database/mobile_local_database_test.dart`: pass, 0 changed
  - `flutter test test/core/database/mobile_local_database_test.dart`: pass, 12 tests
  - `git diff --check`: pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 신고 receipt metadata 보존 | Flutter test | catalog 데이터팩 파일 교체 후 user DB 재오픈 | `flutter test test/core/database/mobile_local_database_test.dart` 출력 | `report_receipts`의 `receiptId`, `reportId`, `status` 유지 확인 |
| 문서 추적 정책 | Git | tracked Markdown 목록 확인 | `git ls-files '*.md'` | `.github/pull_request_template.md`, `README.md`만 추적 |
| 시각 증거 | 해당 없음 | test-only DB 보존 검증 | 증거 불필요 사유: UI/시각 변경 없음 | 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/test/core/database/mobile_local_database_test.dart`의 user DB 보존 테스트 확장만 확인하면 된다.

## 리스크

- 테스트 전용 변경이라 runtime 동작 리스크는 낮다.
- AquilaXk/easysubway-mobile#7 전체는 이 PR만으로 닫히지 않는다. `no_api_call_on_app_start`, `admin_review_reaches_override_or_next_pack`, store distribution/secret blocker는 별도 증거가 남아 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 없는 test-only 변경이며 Release Artifacts 상태를 확인했다.
