### PR TITLE
[Test] 앱 시작 HTTP 요청 없음 검증

### DIFF
--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -554,6 +554,38 @@ void main() {
     );
   });
 
+  test('앱 부트스트랩은 API와 데이터팩 base가 없어도 HTTP request를 열지 않는다', () async {
+    final directory = await Directory.systemTemp.createTemp(
+      'easysubway-bootstrap-no-network-',
+    );
+    addTearDown(() => directory.delete(recursive: true));
+    var httpRequestCount = 0;
+
+    AppBootstrap? bootstrap;
+    addTearDown(() => bootstrap?.close());
+    bootstrap = await HttpOverrides.runZoned(
+      () => AppBootstrap.initialize(
+        databaseDirectory: directory,
+        assetBundle: rootBundle,
+        enablePushNotifications: false,
+      ),
+      createHttpClient: (context) {
+        return _RequestCountingHttpClient(() {
+          httpRequestCount++;
+        });
+      },
+    );
+
+    final metadata = await bootstrap!.catalogDatabase.customSelect('''
+          SELECT value
+          FROM catalog_metadata
+          WHERE key = 'schemaVersion'
+          ''').getSingle();
+
+    expect(metadata.read<String>('value'), '1');
+    expect(httpRequestCount, 0);
+  });
+
   test('user DB는 catalog 데이터팩 교체와 독립적으로 즐겨찾기와 신고 receipt를 보존한다', () async {
     final directory = await Directory.systemTemp.createTemp('easysubway-user-');
     addTearDown(() => directory.delete(recursive: true));
@@ -598,4 +630,25 @@ void main() {
     expect(receipts.single.reportId, 'report-1');
     expect(receipts.single.status, 'RECEIVED');
   });
+}
+
+class _RequestCountingHttpClient implements HttpClient {
+  _RequestCountingHttpClient(this.onRequest);
+
+  final void Function() onRequest;
+
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) => openUrl('GET', url);
+
+  @override
+  Future<HttpClientRequest> postUrl(Uri url) => openUrl('POST', url);
+
+  @override
+  Future<HttpClientRequest> openUrl(String method, Uri url) {
+    onRequest();
+    throw StateError('startup must not open HTTP request: $method $url');
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }


### PR DESCRIPTION
## 관련 이슈

refs AquilaXk/easysubway-mobile#7

## 작업 배경

서버 최소화 최종 인수 QA에서 앱 시작 시 API 요청이 발생하지 않는다는 증거가 로그 grep 중심으로 남아 있었다. 이번 변경은 bootstrap 단위 테스트에서 HTTP request open 횟수를 직접 계측해 `no_api_call_on_app_start` 항목의 정확한 request count 0 증거를 보강한다.

## 작업 내용

- `mobile_local_database_test.dart`에 app bootstrap HTTP request 계측 테스트를 추가했다.
- `HttpOverrides.runZoned`로 `HttpClient`를 계측하고, startup 중 `openUrl`, `getUrl`, `postUrl`이 호출되면 실패하도록 했다.
- API/data pack base를 따로 주입하지 않은 앱 bootstrap이 내장 catalog schema를 열고도 HTTP request count 0을 유지하는지 검증한다.
- production code는 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `dart format test/core/database/mobile_local_database_test.dart`: pass
  - `flutter test test/core/database/mobile_local_database_test.dart`: pass, 13 tests
  - `git diff --check`: pass
  - GitHub CI: Android CI, Backend CI, Mobile App CI, Repository CI, iOS CI, Dependency Vulnerability Scan pass
  - GitHub Release Artifacts: Android Release Artifact, iOS Release Artifact pass; Backend Release Image skipped because backend files did not change

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 앱 시작 HTTP request count | Flutter test | `HttpOverrides`로 `openUrl/getUrl/postUrl` 호출 계측 | `flutter test test/core/database/mobile_local_database_test.dart` 출력 | app bootstrap 후 `httpRequestCount == 0` 확인 |
| 내장 catalog 시작 | Flutter test | bootstrap catalog metadata 조회 | 같은 test 출력 | `schemaVersion == 1` 확인 |
| PR CI | GitHub Actions | PR AquilaXk/easysubway#574 checks 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27901831649 | Android CI, Backend CI, Mobile App CI, Repository CI, iOS CI, Dependency Vulnerability Scan 통과 |
| PR release artifacts | GitHub Actions | PR AquilaXk/easysubway#574 Release Artifacts 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27901831560 | Android Release Artifact, iOS Release Artifact 통과; Backend Release Image skipped |
| 코드리뷰 | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review 게시 | https://github.com/AquilaXk/easysubway/pull/574#pullrequestreview-4539556160 | Actionable comments posted: 0 |
| 문서 추적 정책 | Git | tracked Markdown 목록 확인 | `git ls-files '*.md'` | `.github/pull_request_template.md`, `README.md`만 추적 |
| 시각 증거 | 해당 없음 | test-only startup/network 계측 | 증거 불필요 사유: UI/시각 변경 없음 | 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `_RequestCountingHttpClient`가 request open 메서드만 계측하고, production code를 변경하지 않는 점.

## 리스크

- 테스트 전용 변경이라 runtime 동작 리스크는 낮다.
- AquilaXk/easysubway-mobile#7 전체는 이 PR만으로 닫히지 않는다. `admin_review_reaches_override_or_next_pack`와 store distribution/secret blocker가 남아 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
