### PR TITLE
[CI] 스토어 배포 증거 수집 워크플로우 구성

### DIFF
--- a/.github/workflows/store-distribution-evidence.yml
+++ b/.github/workflows/store-distribution-evidence.yml
@@ -1,0 +1,70 @@
+name: Store Distribution Evidence
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: store-distribution-evidence-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    name: Store Distribution Evidence / Preflight
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --disable-warning=ExperimentalWarning
+
+    steps:
+      - name: Store Distribution Evidence / Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Store Distribution Evidence / Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Store Distribution Evidence / Restore GitHub Actions dotenv secret
+        env:
+          EASYSUBWAY_ENV_SECRET: ${{ secrets.EASYSUBWAY_ENV }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${EASYSUBWAY_ENV_SECRET}" ]]; then
+            echo "::error title=Store distribution evidence env::EASYSUBWAY_ENV secret is not configured."
+            exit 1
+          fi
+          env_file="${RUNNER_TEMP}/easysubway-store-distribution.env"
+          printf '%s' "${EASYSUBWAY_ENV_SECRET}" > "${env_file}"
+          chmod 600 "${env_file}"
+          echo "EASYSUBWAY_ENV_FILE=${env_file}" >> "${GITHUB_ENV}"
+
+      - name: Store Distribution Evidence / Check credential and publish env readiness
+        id: store-env
+        run: |
+          set -euo pipefail
+          node tools/ci/check-store-distribution-evidence-env.mjs \
+            --env-file "${EASYSUBWAY_ENV_FILE}" \
+            --github-output "${GITHUB_OUTPUT}" \
+            --report "${RUNNER_TEMP}/store-distribution-evidence-preflight.txt"
+
+      - name: Store Distribution Evidence / Validate data pack object storage publish env
+        id: datapack-env
+        run: |
+          set -euo pipefail
+          node tools/datapack/export-publish-env.mjs \
+            --env-file "${EASYSUBWAY_ENV_FILE}" \
+            --github-env "${GITHUB_ENV}" \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Store Distribution Evidence / Upload preflight evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: store-distribution-evidence-preflight-${{ github.sha }}
+          path: ${{ runner.temp }}/store-distribution-evidence-preflight.txt
+          if-no-files-found: warn
+          retention-days: 14

--- a/tools/ci/check-store-distribution-evidence-env.mjs
+++ b/tools/ci/check-store-distribution-evidence-env.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+import { appendFile, readFile, writeFile } from "node:fs/promises";
+
+const androidRequiredAny = [
+  "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON",
+  "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64",
+];
+const androidRequiredAll = ["EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME"];
+const iosRequiredAll = [
+  "EASYSUBWAY_APP_STORE_CONNECT_KEY_ID",
+  "EASYSUBWAY_APP_STORE_CONNECT_ISSUER_ID",
+  "EASYSUBWAY_APP_STORE_CONNECT_PRIVATE_KEY_PEM",
+  "EASYSUBWAY_APP_STORE_APPLE_ID",
+  "EASYSUBWAY_APP_STORE_BUNDLE_ID",
+];
+const datapackRequiredAll = [
+  "EASYSUBWAY_DATAPACK_REMOTE_PUBLISH_ENABLED",
+  "EASYSUBWAY_DATA_PACK_BASE_URL",
+  "EASYSUBWAY_OBJECT_STORAGE_ENDPOINT",
+  "EASYSUBWAY_OBJECT_STORAGE_ACCESS_KEY",
+  "EASYSUBWAY_OBJECT_STORAGE_SECRET_KEY",
+  "EASYSUBWAY_OBJECT_STORAGE_REGION",
+  "EASYSUBWAY_DATAPACK_BUCKET",
+];
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const envFile = requireArg(args, "env-file");
+  const githubOutput = requireArg(args, "github-output");
+  const reportPath = requireArg(args, "report");
+  const env = parseDotenv(await readFile(envFile, "utf8"));
+
+  const android = credentialGroupStatus(env, {
+    label: "android_play_internal_track",
+    requiredAll: androidRequiredAll,
+    requiredAny: androidRequiredAny,
+  });
+  const ios = credentialGroupStatus(env, {
+    label: "ios_testflight",
+    requiredAll: iosRequiredAll,
+    requiredAny: [],
+  });
+  const datapack = datapackStatus(env);
+  const groups = [android, ios, datapack];
+
+  await appendFile(githubOutput, groups.map((group) => `${group.outputName}=${group.ready}`).join("\n") + "\n");
+  await writeFile(reportPath, renderReport(groups));
+
+  const notReady = groups.filter((group) => !group.ready);
+  if (notReady.length > 0) {
+    throw new Error(`store distribution evidence preflight failed: ${notReady.map((group) => group.label).join(", ")}`);
+  }
+}
+
+function credentialGroupStatus(env, group) {
+  const missingAll = group.requiredAll.filter((name) => !hasValue(env, name));
+  const anySatisfied = group.requiredAny.length === 0 || group.requiredAny.some((name) => hasValue(env, name));
+  return {
+    label: group.label,
+    outputName: outputName(group.label),
+    ready: missingAll.length === 0 && anySatisfied,
+    missing: [
+      ...missingAll,
+      ...(anySatisfied ? [] : [`one_of:${group.requiredAny.join("|")}`]),
+    ],
+    present: [
+      ...group.requiredAll.filter((name) => hasValue(env, name)),
+      ...group.requiredAny.filter((name) => hasValue(env, name)),
+    ],
+  };
+}
+
+function datapackStatus(env) {
+  const base = credentialGroupStatus(env, {
+    label: "datapack_object_storage_publish",
+    requiredAll: datapackRequiredAll,
+    requiredAny: [],
+  });
+  const missing = [...base.missing];
+  if (env.EASYSUBWAY_DATAPACK_REMOTE_PUBLISH_ENABLED !== "true") {
+    missing.push("EASYSUBWAY_DATAPACK_REMOTE_PUBLISH_ENABLED:true");
+  }
+  for (const name of ["EASYSUBWAY_DATA_PACK_BASE_URL", "EASYSUBWAY_OBJECT_STORAGE_ENDPOINT"]) {
+    if (hasValue(env, name) && !isPublicHttps(env[name])) {
+      missing.push(`${name}:public_https`);
+    }
+  }
+  return {
+    ...base,
+    ready: missing.length === 0,
+    missing,
+  };
+}
+
+function renderReport(groups) {
+  return [
+    "store_distribution_evidence_preflight",
+    ...groups.flatMap((group) => [
+      `${group.label}.ready=${group.ready}`,
+      `${group.label}.present=${group.present.toSorted().join(",") || "none"}`,
+      `${group.label}.missing=${group.missing.toSorted().join(",") || "none"}`,
+    ]),
+    "",
+  ].join("\n");
+}
+
+function parseDotenv(source) {
+  const values = {};
+  for (const line of source.split(/\r?\n/)) {
+    if (!line || line.trimStart().startsWith("#")) {
+      continue;
+    }
+    const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (!match) {
+      continue;
+    }
+    values[match[1]] = unquote(match[2]);
+  }
+  return values;
+}
+
+function unquote(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith("\"") && trimmed.endsWith("\""))
+    || (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return value;
+}
+
+function hasValue(env, name) {
+  return typeof env[name] === "string" && env[name].trim().length > 0;
+}
+
+function isPublicHttps(value) {
+  try {
+    const url = new URL(value);
+    const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    return (
+      url.protocol === "https:"
+      && host !== "localhost"
+      && host !== "::1"
+      && host !== "0.0.0.0"
+      && !host.startsWith("127.")
+      && !host.endsWith(".localhost")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function outputName(label) {
+  return `${label.replace(/[^a-z0-9]+/g, "_")}_ready`;
+}
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined || value.startsWith("--")) {
+      throw new Error(`invalid argument near ${key ?? "<end>"}`);
+    }
+    const normalized = key.slice(2);
+    if (args.has(normalized)) {
+      throw new Error(`duplicate argument: ${key}`);
+    }
+    args.set(normalized, value);
+    index += 1;
+  }
+  return args;
+}
+
+function requireArg(args, name) {
+  const value = args.get(name);
+  if (!value) {
+    throw new Error(`missing required argument: --${name}`);
+  }
+  return value;
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -847,6 +847,42 @@ test("데이터팩 workflow는 pack 검증 이후 manifest 배포 순서를 강�
   assert.match(workflow, /path: \$\{\{ runner\.temp \}\}\/easysubway-datapack-stage/);
 });
 
+test("스토어 배포 증거 workflow는 단일 dotenv secret과 명시적 credential preflight를 사용한다", () => {
+  assert.ok(
+    existsSync(path.join(root, ".github/workflows/store-distribution-evidence.yml")),
+    "store distribution evidence workflow must exist",
+  );
+  assert.ok(
+    existsSync(path.join(root, "tools/ci/check-store-distribution-evidence-env.mjs")),
+    "store distribution evidence env preflight must exist",
+  );
+
+  const workflow = read(".github/workflows/store-distribution-evidence.yml");
+  const preflight = read("tools/ci/check-store-distribution-evidence-env.mjs");
+
+  assert.match(workflow, /^name: Store Distribution Evidence$/m);
+  assert.match(workflow, /workflow_dispatch:/);
+  assertActionsEnvSecretPolicy(".github/workflows/store-distribution-evidence.yml", workflow);
+  assert.match(workflow, /EASYSUBWAY_ENV_SECRET: \$\{\{ secrets\.EASYSUBWAY_ENV \}\}/);
+  assert.match(workflow, /printf '%s' "\$\{EASYSUBWAY_ENV_SECRET\}" > "\$\{env_file\}"/);
+  assert.doesNotMatch(workflow, /printf '%s\\n' "\$\{EASYSUBWAY_ENV_SECRET\}"/);
+  assert.match(workflow, /node tools\/ci\/check-store-distribution-evidence-env\.mjs/);
+  assert.match(workflow, /--env-file "\$\{EASYSUBWAY_ENV_FILE\}"/);
+  assert.match(workflow, /--github-output "\$\{GITHUB_OUTPUT\}"/);
+  assert.match(workflow, /--report "\$\{RUNNER_TEMP\}\/store-distribution-evidence-preflight\.txt"/);
+  assert.match(workflow, /node tools\/datapack\/export-publish-env\.mjs/);
+  assert.match(workflow, /store-distribution-evidence-preflight-\$\{\{ github\.sha \}\}/);
+
+  assert.match(preflight, /EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON/);
+  assert.match(preflight, /EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME/);
+  assert.match(preflight, /EASYSUBWAY_APP_STORE_CONNECT_KEY_ID/);
+  assert.match(preflight, /EASYSUBWAY_APP_STORE_CONNECT_ISSUER_ID/);
+  assert.match(preflight, /EASYSUBWAY_APP_STORE_CONNECT_PRIVATE_KEY_PEM/);
+  assert.match(preflight, /EASYSUBWAY_APP_STORE_APPLE_ID/);
+  assert.match(preflight, /EASYSUBWAY_DATAPACK_REMOTE_PUBLISH_ENABLED/);
+  assert.doesNotMatch(preflight, /console\.log\(.*env\[/, "preflight must not print secret values");
+});
+
 test("데이터팩 도구는 앱 manifest 계약과 SQLite 검증 계약을 고정한다", () => {
   const fixture = JSON.parse(read("tools/datapack/fixtures/catalog-fixture.json"));
   const schema = read("tools/datapack/schema/catalog-schema.sql");


### PR DESCRIPTION
## 관련 이슈

close #576

## 작업 배경

서버 최소화 최종 인수 QA에서 Android Play internal track, iOS TestFlight 또는 signed-device install, Data Pack object storage publish 증거가 외부 credential과 public HTTPS storage env 부족으로 막혀 있습니다. 현재 상태를 성공으로 위장하지 않고, `EASYSUBWAY_ENV` 단일 secret에서 필요한 값이 준비됐는지 workflow_dispatch로 검증하는 실행 경로가 필요합니다.

## 작업 내용

- `Store Distribution Evidence` workflow를 추가해 `EASYSUBWAY_ENV` secret을 임시 dotenv 파일로 복원합니다.
- `tools/ci/check-store-distribution-evidence-env.mjs`를 추가해 Play, TestFlight, Data Pack publish 준비 상태를 값 출력 없이 변수명/상태 단위로 검사합니다.
- Data Pack publish env는 기존 `tools/datapack/export-publish-env.mjs` 검증을 재사용해 public HTTPS 조건을 유지합니다.
- repository contract test로 단일 secret 정책, 값 비노출 복원, preflight 스크립트와 workflow_dispatch 경로를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs --test-name-pattern '스토어 배포 증거 workflow'`: RED에서 workflow 없음으로 실패 확인 후 구현, 이후 77 pass.
  - `node tools/ci/check-store-distribution-evidence-env.mjs --env-file /Volumes/MACSSD/Projects/GitProjects/swieun-jihacheol/.env --github-output /tmp/store-distribution-output.txt --report /tmp/store-distribution-report.txt`: 현재 로컬 env 기준 expected failure. Android/iOS credential과 Data Pack public HTTPS 조건 부족을 값 없이 보고.
  - `node --test tools/ci/*.test.mjs`: 77 pass.
  - `git diff --check`: pass.
  - GitHub Actions CI run `27905046472`: success.
  - GitHub Actions Release Artifacts run `27905046365`: success.
  - CodeRabbit: rate limit/credit exhausted로 실제 리뷰 미시작 확인.
  - Codex CLI fallback: `codex review --base origin/main --title "[CI] 스토어 배포 증거 수집 워크플로우 구성"` 결과 actionable 0건, PR review `4539728395` 기록.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Store evidence contract | CI | `node --test tools/ci/*.test.mjs` | 로컬 출력 77 pass | 통과 |
| Current local env preflight | Android/iOS/Data Pack | `check-store-distribution-evidence-env.mjs` | `/tmp/store-distribution-report.txt` local-only | credential/public HTTPS 부족을 값 없이 보고 |
| Markdown policy | Repository | `git ls-files '*.md'` | `.github/pull_request_template.md`, `README.md`만 출력 | 통과 |
| PR CI | GitHub Actions | `gh pr checks 577 --repo AquilaXk/easysubway` | CI run `27905046472`, Release Artifacts run `27905046365` | 통과 |
| Code review | GitHub PR review | CodeRabbit 상태 확인 후 Codex CLI fallback | CodeRabbit rate limit comment, Codex review `4539728395` | actionable 0건 |

## 리뷰어 메모

- 이 PR은 실제 Play/TestFlight 업로드를 성공 처리하지 않습니다. credential/public HTTPS env가 없으면 workflow가 실패하고 preflight artifact로 부족한 변수명을 남기도록 하는 준비 gate입니다.
- 민감값은 `secrets.EASYSUBWAY_ENV` 하나만 사용하며, 개별 GitHub Actions secret/variable 접근을 추가하지 않았습니다.

## 리스크

- 실제 Play/TestFlight 업로드 자동화는 credential이 들어온 뒤 별도 upload step을 추가해야 합니다.
- 현재 workflow는 missing credential을 성공으로 처리하지 않으므로, 준비 전 수동 실행은 실패가 정상입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
