### PR TITLE
[Feat] 현재 위치 품질 계약 적용

### DIFF
--- a/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
@@ -270,10 +270,24 @@ class MainActivity : FlutterActivity() {
         }
     }
 
-    private fun Location.toFlutterMap(): Map<String, Double> {
+    private fun Location.toFlutterMap(): Map<String, Any?> {
         return mapOf(
             "latitude" to latitude,
             "longitude" to longitude,
+            "accuracyMeters" to if (hasAccuracy()) accuracy.toDouble() else null,
+            "measuredAtMillis" to time,
+            "provider" to provider,
+            "isMocked" to isMockLocation(),
+            "permissionPrecision" to if (hasFineLocationPermission()) "precise" else "approximate",
         )
+    }
+
+    private fun Location.isMockLocation(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            isMock
+        } else {
+            @Suppress("DEPRECATION")
+            isFromMockProvider
+        }
     }
 }

--- a/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
@@ -23,6 +23,7 @@ class MainActivity : FlutterActivity() {
     private val notificationPermissionRequestCode = 2402
     private val locationTimeoutMillis = 10_000L
     private val nearbyLocationMaxAgeMillis = 5 * 60 * 1000L
+    private val nearbyLocationMaxAccuracyMeters = 500f
 
     private var pendingLocationResult: MethodChannel.Result? = null
     private var pendingNotificationPermissionResult: MethodChannel.Result? = null
@@ -132,11 +133,12 @@ class MainActivity : FlutterActivity() {
             return
         }
 
-        val lastKnownLocation = providers
+        val cachedLocation = providers
             .mapNotNull { provider -> locationManager.safeLastKnownLocation(provider) }
+            .filter { location -> location.canUseCachedForNearbySearch() }
             .maxByOrNull { location -> location.time }
-        if (lastKnownLocation != null && lastKnownLocation.isFreshEnoughForNearbySearch()) {
-            result.success(lastKnownLocation.toFlutterMap())
+        if (cachedLocation != null) {
+            result.success(cachedLocation.toFlutterMap())
             return
         }
 
@@ -292,8 +294,11 @@ class MainActivity : FlutterActivity() {
         }
     }
 
-    private fun Location.isFreshEnoughForNearbySearch(): Boolean {
+    private fun Location.canUseCachedForNearbySearch(): Boolean {
         val ageMillis = System.currentTimeMillis() - time
-        return ageMillis in 0..nearbyLocationMaxAgeMillis
+        return ageMillis in 0..nearbyLocationMaxAgeMillis &&
+            !isMockLocation() &&
+            hasAccuracy() &&
+            accuracy <= nearbyLocationMaxAccuracyMeters
     }
 }

--- a/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/MainActivity.kt
@@ -22,6 +22,7 @@ class MainActivity : FlutterActivity() {
     private val locationPermissionRequestCode = 2401
     private val notificationPermissionRequestCode = 2402
     private val locationTimeoutMillis = 10_000L
+    private val nearbyLocationMaxAgeMillis = 5 * 60 * 1000L
 
     private var pendingLocationResult: MethodChannel.Result? = null
     private var pendingNotificationPermissionResult: MethodChannel.Result? = null
@@ -134,7 +135,7 @@ class MainActivity : FlutterActivity() {
         val lastKnownLocation = providers
             .mapNotNull { provider -> locationManager.safeLastKnownLocation(provider) }
             .maxByOrNull { location -> location.time }
-        if (lastKnownLocation != null) {
+        if (lastKnownLocation != null && lastKnownLocation.isFreshEnoughForNearbySearch()) {
             result.success(lastKnownLocation.toFlutterMap())
             return
         }
@@ -289,5 +290,10 @@ class MainActivity : FlutterActivity() {
             @Suppress("DEPRECATION")
             isFromMockProvider
         }
+    }
+
+    private fun Location.isFreshEnoughForNearbySearch(): Boolean {
+        val ageMillis = System.currentTimeMillis() - time
+        return ageMillis in 0..nearbyLocationMaxAgeMillis
     }
 }

--- a/apps/mobile/ios/Runner/AppDelegate.swift
+++ b/apps/mobile/ios/Runner/AppDelegate.swift
@@ -104,6 +104,11 @@ import UserNotifications
     finishLocationRequest(value: [
       "latitude": location.coordinate.latitude,
       "longitude": location.coordinate.longitude,
+      "accuracyMeters": location.horizontalAccuracy >= 0 ? location.horizontalAccuracy : nil,
+      "measuredAtMillis": Int(location.timestamp.timeIntervalSince1970 * 1000),
+      "provider": "core-location",
+      "isMocked": false,
+      "permissionPrecision": permissionPrecision(),
     ])
   }
 
@@ -140,6 +145,13 @@ import UserNotifications
     @unknown default:
       return true
     }
+  }
+
+  private func permissionPrecision() -> String {
+    if #available(iOS 14.0, *) {
+      return locationManager.accuracyAuthorization == .fullAccuracy ? "precise" : "approximate"
+    }
+    return "precise"
   }
 
   private func openLocationSettings(_ result: @escaping FlutterResult) {

--- a/apps/mobile/ios/Runner/AppDelegate.swift
+++ b/apps/mobile/ios/Runner/AppDelegate.swift
@@ -107,7 +107,7 @@ import UserNotifications
       "accuracyMeters": location.horizontalAccuracy >= 0 ? location.horizontalAccuracy : nil,
       "measuredAtMillis": Int(location.timestamp.timeIntervalSince1970 * 1000),
       "provider": "core-location",
-      "isMocked": false,
+      "isMocked": isMockedLocation(location),
       "permissionPrecision": permissionPrecision(),
     ])
   }
@@ -152,6 +152,13 @@ import UserNotifications
       return locationManager.accuracyAuthorization == .fullAccuracy ? "precise" : "approximate"
     }
     return "precise"
+  }
+
+  private func isMockedLocation(_ location: CLLocation) -> Bool {
+    if #available(iOS 15.0, *) {
+      return location.sourceInformation?.isSimulatedBySoftware ?? false
+    }
+    return false
   }
 
   private func openLocationSettings(_ result: @escaping FlutterResult) {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -15,6 +15,16 @@ import 'mobile_error_reporter.dart';
 const _stationSearchTimeout = Duration(seconds: 8);
 const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
 const _currentLocationDisabledMessage = '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
+const _nearbyLocationMaxAge = Duration(minutes: 5);
+const _nearbyLocationMaxAccuracyMeters = 500.0;
+const _locationQualityUnavailableMessage =
+    '현재 위치 정확도 정보를 확인하지 못했어요. 출발역을 직접 선택해 주세요.';
+const _locationQualityStaleMessage =
+    '현재 위치가 오래되어 가까운 역을 정확히 찾기 어려워요. 출발역을 직접 선택해 주세요.';
+const _locationQualityCoarseMessage =
+    '현재 위치 정확도가 낮아 가까운 역을 정확히 찾기 어려워요. 출발역을 직접 선택해 주세요.';
+const _locationQualityMockedMessage =
+    '모의 위치는 가까운 역 찾기에 사용할 수 없어요. 출발역을 직접 선택해 주세요.';
 const _locationPermissionRationaleTitle = '현재 위치 사용';
 const _locationPermissionRationalePurpose =
     '가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다.';
@@ -58,11 +68,73 @@ abstract class StationLineFilterRepository {
   );
 }
 
+enum LocationPermissionPrecision { precise, approximate, unknown }
+
+enum CurrentLocationQualityStatus {
+  freshPrecise,
+  unavailable,
+  stale,
+  coarse,
+  mocked,
+}
+
 class CurrentLocation {
-  const CurrentLocation({required this.latitude, required this.longitude});
+  const CurrentLocation({
+    required this.latitude,
+    required this.longitude,
+    this.accuracyMeters,
+    this.measuredAt,
+    this.provider = 'unknown',
+    this.isMocked = false,
+    this.permissionPrecision = LocationPermissionPrecision.unknown,
+  });
 
   final double latitude;
   final double longitude;
+  final double? accuracyMeters;
+  final DateTime? measuredAt;
+  final String provider;
+  final bool isMocked;
+  final LocationPermissionPrecision permissionPrecision;
+
+  CurrentLocationQualityStatus qualityStatus({
+    DateTime? now,
+    Duration maxAge = _nearbyLocationMaxAge,
+    double maxAccuracyMeters = _nearbyLocationMaxAccuracyMeters,
+  }) {
+    if (isMocked) {
+      return CurrentLocationQualityStatus.mocked;
+    }
+    final measuredAt = this.measuredAt;
+    final accuracyMeters = this.accuracyMeters;
+    if (measuredAt == null || accuracyMeters == null) {
+      return CurrentLocationQualityStatus.unavailable;
+    }
+    final age = (now ?? DateTime.now()).difference(measuredAt);
+    if (age > maxAge || age.isNegative) {
+      return CurrentLocationQualityStatus.stale;
+    }
+    if (permissionPrecision == LocationPermissionPrecision.approximate ||
+        accuracyMeters > maxAccuracyMeters) {
+      return CurrentLocationQualityStatus.coarse;
+    }
+    return CurrentLocationQualityStatus.freshPrecise;
+  }
+
+  bool canUseForNearbySearch({DateTime? now}) {
+    return qualityStatus(now: now) == CurrentLocationQualityStatus.freshPrecise;
+  }
+
+  String? nearbySearchBlockedMessage({DateTime? now}) {
+    return switch (qualityStatus(now: now)) {
+      CurrentLocationQualityStatus.freshPrecise => null,
+      CurrentLocationQualityStatus.unavailable =>
+        _locationQualityUnavailableMessage,
+      CurrentLocationQualityStatus.stale => _locationQualityStaleMessage,
+      CurrentLocationQualityStatus.coarse => _locationQualityCoarseMessage,
+      CurrentLocationQualityStatus.mocked => _locationQualityMockedMessage,
+    };
+  }
 }
 
 abstract class CurrentLocationProvider {
@@ -119,7 +191,17 @@ class MethodChannelCurrentLocationProvider implements CurrentLocationProvider {
       if (latitude == null || longitude == null) {
         throw const CurrentLocationException('현재 위치를 확인하지 못했습니다.');
       }
-      return CurrentLocation(latitude: latitude, longitude: longitude);
+      return CurrentLocation(
+        latitude: latitude,
+        longitude: longitude,
+        accuracyMeters: _doubleFrom(response, 'accuracyMeters'),
+        measuredAt: _dateTimeFromMillis(response, 'measuredAtMillis'),
+        provider: _stringFrom(response, 'provider') ?? 'unknown',
+        isMocked: _boolFrom(response, 'isMocked') ?? false,
+        permissionPrecision: _permissionPrecisionFrom(
+          _stringFrom(response, 'permissionPrecision'),
+        ),
+      );
     } on CurrentLocationException {
       rethrow;
     } on PlatformException catch (error) {
@@ -153,6 +235,55 @@ class MethodChannelCurrentLocationProvider implements CurrentLocationProvider {
       return double.tryParse(value);
     }
     return null;
+  }
+
+  double? _doubleFrom(Map<String, Object?>? response, String key) {
+    final value = response?[key];
+    if (value is num) {
+      return value.toDouble();
+    }
+    if (value is String) {
+      return double.tryParse(value);
+    }
+    return null;
+  }
+
+  DateTime? _dateTimeFromMillis(Map<String, Object?>? response, String key) {
+    final value = response?[key];
+    final millis = switch (value) {
+      int() => value,
+      double() => value.round(),
+      String() => int.tryParse(value),
+      _ => null,
+    };
+    if (millis == null) {
+      return null;
+    }
+    return DateTime.fromMillisecondsSinceEpoch(millis, isUtc: true);
+  }
+
+  String? _stringFrom(Map<String, Object?>? response, String key) {
+    final value = response?[key];
+    if (value is String && value.trim().isNotEmpty) {
+      return value;
+    }
+    return null;
+  }
+
+  bool? _boolFrom(Map<String, Object?>? response, String key) {
+    final value = response?[key];
+    if (value is bool) {
+      return value;
+    }
+    return null;
+  }
+
+  LocationPermissionPrecision _permissionPrecisionFrom(String? value) {
+    return switch (value) {
+      'precise' => LocationPermissionPrecision.precise,
+      'approximate' => LocationPermissionPrecision.approximate,
+      _ => LocationPermissionPrecision.unknown,
+    };
   }
 
   String _locationErrorMessage(String code) {
@@ -1339,6 +1470,18 @@ class StationSearchController extends ChangeNotifier {
 
     try {
       final location = await locationProvider.currentLocation();
+      final blockedMessage = location.nearbySearchBlockedMessage();
+      if (blockedMessage != null) {
+        if (!_isActiveRequest(requestId)) {
+          return;
+        }
+        _state = StationSearchState(
+          status: StationSearchStatus.failure,
+          results: const [],
+          message: blockedMessage,
+        );
+        return;
+      }
       final results = await repository.searchNearbyStations(location);
       if (!_isActiveRequest(requestId)) {
         return;

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1480,6 +1480,7 @@ class StationSearchController extends ChangeNotifier {
           results: const [],
           message: blockedMessage,
         );
+        _notifyIfActive(requestId);
         return;
       }
       final results = await repository.searchNearbyStations(location);

--- a/apps/mobile/test/current_location_provider_test.dart
+++ b/apps/mobile/test/current_location_provider_test.dart
@@ -3,6 +3,66 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('현재 위치 제공자는 정확도와 측정 시각과 권한 정밀도를 함께 읽는다', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    const channel = MethodChannel('test/current-location-quality');
+    final measuredAt = DateTime.utc(2026, 6, 21, 14);
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      return {
+        'latitude': 37.3028,
+        'longitude': 126.8665,
+        'accuracyMeters': 35.5,
+        'measuredAtMillis': measuredAt.millisecondsSinceEpoch,
+        'provider': 'gps',
+        'isMocked': false,
+        'permissionPrecision': 'precise',
+      };
+    });
+    addTearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+    final provider = MethodChannelCurrentLocationProvider(channel: channel);
+
+    final location = await provider.currentLocation();
+
+    expect(location.accuracyMeters, 35.5);
+    expect(location.measuredAt, measuredAt);
+    expect(location.provider, 'gps');
+    expect(location.isMocked, isFalse);
+    expect(location.permissionPrecision, LocationPermissionPrecision.precise);
+    expect(
+      location.qualityStatus(now: measuredAt.add(const Duration(minutes: 1))),
+      CurrentLocationQualityStatus.freshPrecise,
+    );
+  });
+
+  test('현재 위치 제공자는 기존 좌표만 있는 응답을 자동 검색 불가 품질로 판정한다', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    const channel = MethodChannel('test/current-location-legacy');
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      return {'latitude': 37.3028, 'longitude': 126.8665};
+    });
+    addTearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+    final provider = MethodChannelCurrentLocationProvider(channel: channel);
+
+    final location = await provider.currentLocation();
+
+    expect(location.accuracyMeters, isNull);
+    expect(location.measuredAt, isNull);
+    expect(
+      location.qualityStatus(now: DateTime.utc(2026, 6, 21, 14)),
+      CurrentLocationQualityStatus.unavailable,
+    );
+    expect(
+      location.canUseForNearbySearch(now: DateTime.utc(2026, 6, 21, 14)),
+      isFalse,
+    );
+  });
+
   test('현재 위치 제공자는 권한 요청 필요 여부를 네이티브 채널로 확인한다', () async {
     TestWidgetsFlutterBinding.ensureInitialized();
     const channel = MethodChannel('test/current-location');

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -972,6 +972,10 @@ void main() {
       location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
     );
     final controller = StationSearchController(repository: repository);
+    var notificationCount = 0;
+    controller.addListener(() {
+      notificationCount++;
+    });
 
     await controller.searchNearby(locationProvider);
 
@@ -982,6 +986,7 @@ void main() {
       controller.state.message,
       '현재 위치 정확도 정보를 확인하지 못했어요. 출발역을 직접 선택해 주세요.',
     );
+    expect(notificationCount, 2);
   });
 
   test('역 검색 컨트롤러는 오래된 위치를 주변역 검색에 쓰지 않는다', () async {

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -946,7 +946,14 @@ void main() {
         ),
       ];
     final locationProvider = FakeCurrentLocationProvider(
-      location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
+      location: CurrentLocation(
+        latitude: 37.3028,
+        longitude: 126.8665,
+        accuracyMeters: 25,
+        measuredAt: DateTime.now(),
+        provider: 'gps',
+        permissionPrecision: LocationPermissionPrecision.precise,
+      ),
     );
     final controller = StationSearchController(repository: repository);
 
@@ -957,6 +964,99 @@ void main() {
     expect(repository.requestedNearbyLocations.single.longitude, 126.8665);
     expect(controller.state.status, StationSearchStatus.success);
     expect(controller.state.results.single.distanceLabel, '230m 거리');
+  });
+
+  test('역 검색 컨트롤러는 정확도 정보가 없는 기존 위치 응답을 주변역 검색에 쓰지 않는다', () async {
+    final repository = FakeStationSearchRepository();
+    final locationProvider = FakeCurrentLocationProvider(
+      location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
+    );
+    final controller = StationSearchController(repository: repository);
+
+    await controller.searchNearby(locationProvider);
+
+    expect(locationProvider.requestCount, 1);
+    expect(repository.requestedNearbyLocations, isEmpty);
+    expect(controller.state.status, StationSearchStatus.failure);
+    expect(
+      controller.state.message,
+      '현재 위치 정확도 정보를 확인하지 못했어요. 출발역을 직접 선택해 주세요.',
+    );
+  });
+
+  test('역 검색 컨트롤러는 오래된 위치를 주변역 검색에 쓰지 않는다', () async {
+    final repository = FakeStationSearchRepository();
+    final locationProvider = FakeCurrentLocationProvider(
+      location: CurrentLocation(
+        latitude: 37.3028,
+        longitude: 126.8665,
+        accuracyMeters: 25,
+        measuredAt: DateTime.now().subtract(const Duration(minutes: 20)),
+        provider: 'gps',
+        permissionPrecision: LocationPermissionPrecision.precise,
+      ),
+    );
+    final controller = StationSearchController(repository: repository);
+
+    await controller.searchNearby(locationProvider);
+
+    expect(repository.requestedNearbyLocations, isEmpty);
+    expect(controller.state.status, StationSearchStatus.failure);
+    expect(
+      controller.state.message,
+      '현재 위치가 오래되어 가까운 역을 정확히 찾기 어려워요. 출발역을 직접 선택해 주세요.',
+    );
+  });
+
+  test('역 검색 컨트롤러는 낮은 정확도와 모의 위치를 서로 다른 안내 문구로 막는다', () async {
+    final coarseRepository = FakeStationSearchRepository();
+    final coarseController = StationSearchController(
+      repository: coarseRepository,
+    );
+
+    await coarseController.searchNearby(
+      FakeCurrentLocationProvider(
+        location: CurrentLocation(
+          latitude: 37.3028,
+          longitude: 126.8665,
+          accuracyMeters: 1200,
+          measuredAt: DateTime.now(),
+          provider: 'network',
+          permissionPrecision: LocationPermissionPrecision.approximate,
+        ),
+      ),
+    );
+
+    expect(coarseRepository.requestedNearbyLocations, isEmpty);
+    expect(
+      coarseController.state.message,
+      '현재 위치 정확도가 낮아 가까운 역을 정확히 찾기 어려워요. 출발역을 직접 선택해 주세요.',
+    );
+
+    final mockedRepository = FakeStationSearchRepository();
+    final mockedController = StationSearchController(
+      repository: mockedRepository,
+    );
+
+    await mockedController.searchNearby(
+      FakeCurrentLocationProvider(
+        location: CurrentLocation(
+          latitude: 37.3028,
+          longitude: 126.8665,
+          accuracyMeters: 20,
+          measuredAt: DateTime.now(),
+          provider: 'gps',
+          isMocked: true,
+          permissionPrecision: LocationPermissionPrecision.precise,
+        ),
+      ),
+    );
+
+    expect(mockedRepository.requestedNearbyLocations, isEmpty);
+    expect(
+      mockedController.state.message,
+      '모의 위치는 가까운 역 찾기에 사용할 수 없어요. 출발역을 직접 선택해 주세요.',
+    );
   });
 
   test('역 검색 컨트롤러는 위치 조회 실패를 쉬운 문구로 표시한다', () async {
@@ -980,7 +1080,14 @@ void main() {
 
     final searchFuture = controller.searchNearby(
       FakeCurrentLocationProvider(
-        location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
+        location: CurrentLocation(
+          latitude: 37.3028,
+          longitude: 126.8665,
+          accuracyMeters: 25,
+          measuredAt: DateTime.now(),
+          provider: 'gps',
+          permissionPrecision: LocationPermissionPrecision.precise,
+        ),
       ),
     );
     await Future<void>.delayed(Duration.zero);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -216,7 +216,7 @@ void main() {
 
   testWidgets('첫 실행 앱은 온보딩에서 위치 권한을 준비할 수 있다', (tester) async {
     final locationProvider = FakeCurrentLocationProvider(
-      location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
+      location: _freshCurrentLocation(),
     );
 
     await tester.pumpWidget(
@@ -2225,7 +2225,7 @@ void main() {
   testWidgets('역 검색은 현재 위치 주변 역을 큰 버튼으로 찾고 거리를 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final locationProvider = FakeCurrentLocationProvider(
-      location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
+      location: _freshCurrentLocation(),
       needsPermissionRequest: false,
     );
     final repository = FakeStationSearchRepository(
@@ -2283,7 +2283,7 @@ void main() {
 
   testWidgets('역 검색은 첫 위치 권한 요청 전에 사용 목적을 안내한다', (tester) async {
     final locationProvider = FakeCurrentLocationProvider(
-      location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
+      location: _freshCurrentLocation(),
     );
     final repository = FakeStationSearchRepository(
       nearbyResults: [
@@ -2364,9 +2364,7 @@ void main() {
     expect(locationProvider.permissionCheckCount, 1);
     expect(locationProvider.requestCount, 1);
 
-    locationCompleter.complete(
-      const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
-    );
+    locationCompleter.complete(_freshCurrentLocation());
     await tester.pumpAndSettle();
 
     expect(repository.requestedNearbyLocations, hasLength(1));
@@ -2409,9 +2407,7 @@ void main() {
     await tester.enterText(find.byKey(const Key('stationSearchInput')), '');
     await tester.pump();
 
-    locationCompleter.complete(
-      const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
-    );
+    locationCompleter.complete(_freshCurrentLocation());
     await tester.pumpAndSettle();
 
     expect(repository.requestedNearbyLocations, hasLength(1));
@@ -6434,6 +6430,20 @@ StationSearchResult _stationResult({
   );
 }
 
+CurrentLocation _freshCurrentLocation({
+  double latitude = 37.3028,
+  double longitude = 126.8665,
+}) {
+  return CurrentLocation(
+    latitude: latitude,
+    longitude: longitude,
+    accuracyMeters: 25,
+    measuredAt: DateTime.now(),
+    provider: 'test',
+    permissionPrecision: LocationPermissionPrecision.precise,
+  );
+}
+
 class FakeCurrentLocationProvider implements CurrentLocationProvider {
   FakeCurrentLocationProvider({
     this.location,
@@ -6473,8 +6483,7 @@ class FakeCurrentLocationProvider implements CurrentLocationProvider {
     if (currentError != null) {
       throw currentError;
     }
-    return location ??
-        const CurrentLocation(latitude: 37.3028, longitude: 126.8665);
+    return location ?? _freshCurrentLocation();
   }
 
   @override


### PR DESCRIPTION
## 관련 이슈

close #582

## 작업 배경

현재 위치 기반 주변역 검색이 위도/경도만 받은 위치를 최신 정밀 위치처럼 사용하면 오래되었거나 정확도가 낮거나 모의 위치인 값을 실제 출발 후보처럼 과신할 수 있습니다. 주변역 자동 검색은 신선하고 정밀도 조건을 만족한 위치에서만 실행하고, 품질이 부족하면 수동 출발역 선택으로 유도합니다.

## 작업 내용

- `CurrentLocation`에 정확도, 측정 시각, provider, 모의 위치 여부, 권한 정밀도 필드를 추가했습니다.
- fresh/precise, unavailable, stale, coarse, mocked 품질 판정을 추가하고 주변역 검색 전에 품질 gate를 적용했습니다.
- Android/iOS location MethodChannel 응답에 가능한 위치 품질 필드를 포함했습니다.
- Android cached 위치는 age, mock 여부, accuracy 500m 이하 조건을 만족하는 후보만 사용하고, 부적합하면 single update 요청으로 넘어갑니다.
- iOS 15 이상에서는 simulated software location 여부를 `isMocked`에 반영합니다.
- legacy latitude/longitude-only 응답은 주변역 자동 검색에 쓰지 않도록 보수적으로 처리했습니다.
- provider/controller/widget 테스트에 품질 필드 파싱, legacy/stale/coarse/mocked 차단, 기존 성공 flow fixture를 반영했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test --reporter compact test/current_location_provider_test.dart test/station_search_test.dart test/widget_test.dart`: 통과, 138 tests
  - `cd apps/mobile && flutter test --reporter compact`: 통과, 331 tests
  - `cd apps/mobile && flutter analyze`: 통과, `No issues found!`
  - `node --test tools/ci/*.test.mjs`: 통과, 77 tests
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적
  - `cd apps/mobile && flutter build apk --debug`: 통과, `build/app/outputs/flutter-apk/app-debug.apk`
  - `cd apps/mobile && flutter build ios --simulator --debug`: 통과, `build/ios/iphonesimulator/Runner.app`
  - GitHub Actions CI run `27907557854`: 통과
  - GitHub Actions Release Artifacts run `27907557792`: 통과
  - CodeRabbit status: 기존 자동 상태 확인, 수동 재호출 없음
  - Codex CLI fallback review: initial actionable 2건 수정, re-review actionable 2건 수정, final re-review actionable 0건

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 위치 채널 파싱 | Android/iOS 공통 Dart | `flutter test --reporter compact test/current_location_provider_test.dart test/station_search_test.dart test/widget_test.dart` | provider 테스트가 accuracy, measuredAt, provider, isMocked, permissionPrecision 파싱과 legacy 응답 차단을 검증 | 통과 |
| 주변역 품질 gate | Android/iOS 공통 Dart | `flutter test --reporter compact test/current_location_provider_test.dart test/station_search_test.dart test/widget_test.dart` | station search controller 테스트가 legacy/stale/coarse/mocked 위치에서 repository 호출 없음과 안내 문구를 검증 | 통과 |
| 화면 안내 문구 | Flutter widget | `flutter test --reporter compact test/current_location_provider_test.dart test/station_search_test.dart test/widget_test.dart` | 주변역 성공/권한 rationale/widget 회귀 테스트 통과. 스크린샷 불필요 사유: 새 화면 레이아웃 추가가 아니라 기존 안내 flow의 텍스트 상태 검증 | 통과 |
| Android 채널 스키마 | Android | `flutter build apk --debug` 및 Release Artifacts run `27907557792` | Kotlin location response 컴파일, debug APK 생성, Android Release Artifact job 통과 | 통과 |
| iOS 채널 스키마 | iOS Simulator | `flutter build ios --simulator --debug` 및 Release Artifacts run `27907557792` | Swift location response dictionary 컴파일, simulator app 생성, iOS Release Artifact job 통과 | 통과 |
| 저장소 정책 | 로컬 git | `git ls-files '*.md'` | 추적 Markdown이 `.github/pull_request_template.md`, `README.md`뿐임 | 통과 |
| PR CI | GitHub Actions | PR #583 check rollup | CI run `27907557854`, Release Artifacts run `27907557792`, CodeRabbit status success | 통과 |
| 코드 리뷰 | GitHub PR review | CodeRabbit 상태 확인 및 Codex CLI fallback review | CodeRabbit 수동 호출 없음. Codex review `4539835767`, `4539841757` 지적 4건 수정 후 thread 4개 resolve, final review `4539849660` actionable 0건 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `CurrentLocation.qualityStatus()`의 차단 순서와 Android/iOS `permissionPrecision`, `isMocked` 매핑입니다.
- 이 PR은 realtime provider 요청이나 전체 journey mode ETA 계산을 구현하지 않습니다.

## 리스크

- Android/iOS 플랫폼별 위치 정확도 의미가 다를 수 있어 허용 정확도 기준은 현재 주변역 검색 gate에만 적용했습니다.
- legacy latitude/longitude-only 응답은 기존 자동 검색 성공 대신 수동 선택 안내로 내려갑니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
