### PR TITLE
[Fix] 백엔드 기본 접근 차단과 공개 경로 명시

### DIFF
--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -76,6 +76,7 @@ public class SecurityConfig {
 					"/api/health",
 					"/actuator/health",
 					"/actuator/health/**",
+					"/actuator/prometheus",
 					"/favicon.ico",
 					"/css/**",
 					"/js/**",

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -68,11 +68,21 @@ public class SecurityConfig {
 	@Bean
 	@Order(4)
 	SecurityFilterChain publicSecurityFilterChain(HttpSecurity http) throws Exception {
-		// 앱 기본 데이터는 로컬 데이터팩이 담당하고, 백엔드는 신고 접수와 운영 화면만 남긴다.
+		// 신고/관리자/운영 matcher 밖의 새 경로가 실수로 공개되지 않도록 기본 차단한다.
 		return http
 			.csrf(AbstractHttpConfigurer::disable)
 			.authorizeHttpRequests(authorize -> authorize
-				.anyRequest().permitAll()
+				.requestMatchers(
+					"/api/health",
+					"/actuator/health",
+					"/actuator/health/**",
+					"/favicon.ico",
+					"/css/**",
+					"/js/**",
+					"/images/**",
+					"/webjars/**"
+				).permitAll()
+				.anyRequest().denyAll()
 			)
 			.build();
 	}

--- a/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
+++ b/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
@@ -60,4 +60,11 @@ class HealthCheckControllerTest {
 			.extracting(endpoint -> endpoint.getEndpointId().toString())
 			.contains("prometheus");
 	}
+
+	@Test
+	@DisplayName("명시적으로 허용되지 않은 백엔드 경로는 기본 차단된다")
+	void unknownBackendPathIsDeniedByDefault() throws Exception {
+		mockMvc.perform(get("/api/v1/internal-unlisted-resource"))
+			.andExpect(status().isForbidden());
+	}
 }

--- a/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
+++ b/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
@@ -59,6 +59,9 @@ class HealthCheckControllerTest {
 		assertThat(webEndpointsSupplier.getEndpoints())
 			.extracting(endpoint -> endpoint.getEndpointId().toString())
 			.contains("prometheus");
+
+		mockMvc.perform(get("/actuator/prometheus"))
+			.andExpect(status().isOk());
 	}
 
 	@Test

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2016,7 +2016,7 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(security, /@Order\(4\)[\s\S]*?publicSecurityFilterChain/);
   assert.match(
     security,
-    /requestMatchers\([\s\S]*"\/api\/health"[\s\S]*"\/actuator\/health"[\s\S]*"\/actuator\/health\/\*\*"[\s\S]*\)\.permitAll\(\)/,
+    /requestMatchers\([\s\S]*"\/api\/health"[\s\S]*"\/actuator\/health"[\s\S]*"\/actuator\/health\/\*\*"[\s\S]*"\/actuator\/prometheus"[\s\S]*\)\.permitAll\(\)/,
   );
   assert.match(security, /@Order\(4\)[\s\S]*?anyRequest\(\)\.denyAll\(\)/);
   assert.match(security, /easysubway\.operator\.username/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2013,12 +2013,17 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.doesNotMatch(security, /"\/api\/v1\/me"/);
   assert.match(security, /"\/api\/v1\/reports\/\*"/);
   assert.match(security, /"\/api\/v1\/reports\/\*\/confirm"/);
-  assert.match(security, /@Order\(4\)[\s\S]*?anyRequest\(\)\.permitAll\(\)/);
+  assert.match(security, /@Order\(4\)[\s\S]*?publicSecurityFilterChain/);
+  assert.match(
+    security,
+    /requestMatchers\([\s\S]*"\/api\/health"[\s\S]*"\/actuator\/health"[\s\S]*"\/actuator\/health\/\*\*"[\s\S]*\)\.permitAll\(\)/,
+  );
+  assert.match(security, /@Order\(4\)[\s\S]*?anyRequest\(\)\.denyAll\(\)/);
   assert.match(security, /easysubway\.operator\.username/);
   assert.match(security, /easysubway\.operator\.password/);
   assert.match(security, /roles\("OPERATOR_ADMIN"\)/);
   assert.match(security, /validateOperatorCredentials/);
-  assert.match(security, /anyRequest\(\)\.permitAll\(\)/);
+  assert.doesNotMatch(security, /publicSecurityFilterChain[\s\S]*?anyRequest\(\)\.permitAll\(\)/);
   assert.match(security, /httpBasic/);
   assert.match(security, /PasswordEncoder/);
   assert.match(security, /passwordEncoder\.encode\(adminPassword\)/);


### PR DESCRIPTION
## 관련 이슈

close #584

## 작업 배경

백엔드 fallback security chain이 모든 unmatched request를 허용하면 새 endpoint가 matcher 없이 추가될 때 의도하지 않게 공개될 수 있습니다. 서버 최소화 이후 public backend 표면은 신고 receipt 흐름, health/metrics, static asset으로 좁혀야 하므로, 기본 정책을 deny-by-default로 바꾸고 허용 경로를 코드와 contract에 명시했습니다.

## 작업 내용

- `publicSecurityFilterChain`의 fallback을 `anyRequest().denyAll()`로 변경했습니다.
- `/api/health`, `/actuator/health`, `/actuator/health/**`, `/actuator/prometheus`, 기본 static asset 경로를 public allowlist로 명시했습니다.
- unknown backend path가 403으로 차단되는 MockMvc 회귀 테스트를 추가했습니다.
- Prometheus scrape HTTP 경로가 default-deny 정책에서도 200으로 통과하는 MockMvc 검증을 추가했습니다.
- repository contract가 public fallback `permitAll` 회귀와 metrics allowlist 누락을 차단하도록 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests com.easysubway.health.adapter.in.web.HealthCheckControllerTest.unknownBackendPathIsDeniedByDefault`: 수정 전 실패, 수정 후 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 수정 전 실패, 수정 후 통과, 77 tests
  - `cd backend && ./gradlew test --tests com.easysubway.health.adapter.in.web.HealthCheckControllerTest`: 통과
  - `cd backend && ./gradlew test --tests com.easysubway.health.adapter.in.web.HealthCheckControllerTest --tests com.easysubway.report.adapter.in.web.FacilityReportControllerTest --tests com.easysubway.report.adapter.in.web.FacilityReportUploadIntentsTest --tests com.easysubway.common.security.SecurityConfigTest`: 통과
  - `cd backend && ./gradlew check`: 통과
  - `node --test tools/ci/*.test.mjs`: 통과, 77 tests
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 기본 차단 회귀 | Backend Spring Security | `./gradlew test --tests com.easysubway.health.adapter.in.web.HealthCheckControllerTest.unknownBackendPathIsDeniedByDefault` | 수정 전 403 기대 테스트 실패, 수정 후 통과 | 통과 |
| public allowlist 유지 | Backend Spring Security | `./gradlew test --tests com.easysubway.health.adapter.in.web.HealthCheckControllerTest` | `/api/health`, `/actuator/health`, `/actuator/health/readiness`, `/actuator/prometheus`, unknown path 차단 확인 | 통과 |
| report/admin security 회귀 | Backend Spring Security | `./gradlew test --tests com.easysubway.health.adapter.in.web.HealthCheckControllerTest --tests com.easysubway.report.adapter.in.web.FacilityReportControllerTest --tests com.easysubway.report.adapter.in.web.FacilityReportUploadIntentsTest --tests com.easysubway.common.security.SecurityConfigTest` | health/report/security 관련 MockMvc 테스트 통과 | 통과 |
| repository contract | Node.js | `node --test tools/ci/*.test.mjs` | public fallback `denyAll`, health/metrics allowlist, Markdown 추적 정책 검증 | 통과 |
| 전체 backend 회귀 | Backend Gradle | `./gradlew check` | backend test suite 통과 | 통과 |
| PR CI | GitHub Actions | PR #585 checks | CI run `27908541363`, Release Artifacts run `27908541283` | 통과 |
| 코드 리뷰 | GitHub PR review | CodeRabbit 상태 확인 후 Codex CLI fallback | CodeRabbit rate limit comment `4762369796`, Codex review `4539885138`, re-review `4539891019`, resolved thread `PRRT_kwDOS4Iqac6LGR8W` | 통과 |
| 저장소 정책 | Git | `git ls-files '*.md'` | 추적 Markdown이 `.github/pull_request_template.md`, `README.md`뿐임 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `SecurityConfig.publicSecurityFilterChain()`의 allowlist 범위와 report 전용 chain이 기존 receipt flow를 계속 담당하는지입니다.
- rate limit, MFA/SSO/OIDC provider 연동은 이 PR 범위가 아니라 후속 보안 slice로 남깁니다.

## 리스크

- 명시 allowlist 밖의 새 public endpoint는 403으로 막힙니다. 새 public API를 추가할 때는 security matcher와 contract를 함께 갱신해야 합니다.
- admin/operator/report 전용 chain 순서가 중요하므로 `@Order` 변경은 하지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
