### PR TITLE
[Fix] 공개 신고 경로 abuse control 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControl.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControl.java
@@ -34,11 +34,13 @@ class FacilityReportAbuseControl extends OncePerRequestFilter {
 		@Value("${easysubway.report.abuse-control.report-submit-limit:1000}") int reportSubmitLimit,
 		@Value("${easysubway.report.abuse-control.status-limit:1000}") int statusLimit,
 		@Value("${easysubway.report.abuse-control.confirm-limit:1000}") int confirmLimit,
+		@Value("${easysubway.report.abuse-control.max-counter-keys:4096}") int maxCounterKeys,
 		@Value("${easysubway.auth.client-ip.trusted-proxies:}") String trustedProxies,
 		ObjectProvider<Clock> clockProvider
 	) {
 		FacilityReportAbuseControlPolicy policy = new FacilityReportAbuseControlPolicy(
 			windowSeconds,
+			maxCounterKeys,
 			Map.of(
 				ReportAbuseGroup.UPLOAD_INTENT, uploadIntentLimit,
 				ReportAbuseGroup.UPLOAD_CLAIM, uploadClaimLimit,
@@ -105,11 +107,18 @@ enum ReportAbuseGroup {
 	}
 }
 
-record FacilityReportAbuseControlPolicy(long windowSeconds, Map<ReportAbuseGroup, Integer> limits) {
+record FacilityReportAbuseControlPolicy(
+	long windowSeconds,
+	int maxCounterKeys,
+	Map<ReportAbuseGroup, Integer> limits
+) {
 
 	FacilityReportAbuseControlPolicy {
 		if (windowSeconds < 1) {
 			throw new IllegalArgumentException("report abuse control window must be positive");
+		}
+		if (maxCounterKeys < 1) {
+			throw new IllegalArgumentException("report abuse control max counter keys must be positive");
 		}
 	}
 
@@ -135,15 +144,32 @@ class FacilityReportAbuseControlLimiter {
 			return true;
 		}
 		long windowStartedAt = currentWindowStartedAt(Instant.now(clock));
-		WindowCounter counter = counters.computeIfAbsent(
-			new LimiterKey(group, clientIdentity),
-			ignored -> new WindowCounter(windowStartedAt)
-		);
-		boolean allowed = counter.incrementWithin(windowStartedAt, limit);
-		if (counters.size() > 1024) {
-			counters.entrySet().removeIf(entry -> entry.getValue().isBefore(windowStartedAt));
+		WindowCounter counter = counterFor(new LimiterKey(group, clientIdentity), windowStartedAt);
+		if (counter == null) {
+			return false;
 		}
+		boolean allowed = counter.incrementWithin(windowStartedAt, limit);
 		return allowed;
+	}
+
+	private WindowCounter counterFor(LimiterKey key, long windowStartedAt) {
+		WindowCounter existingCounter = counters.get(key);
+		if (existingCounter != null) {
+			return existingCounter;
+		}
+		synchronized (counters) {
+			WindowCounter counter = counters.get(key);
+			if (counter != null) {
+				return counter;
+			}
+			counters.entrySet().removeIf(entry -> entry.getValue().isBefore(windowStartedAt));
+			if (counters.size() >= policy.maxCounterKeys()) {
+				return null;
+			}
+			WindowCounter newCounter = new WindowCounter(windowStartedAt);
+			counters.put(key, newCounter);
+			return newCounter;
+		}
 	}
 
 	private long currentWindowStartedAt(Instant now) {

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControl.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControl.java
@@ -120,10 +120,16 @@ record FacilityReportAbuseControlPolicy(
 		if (maxCounterKeys < 1) {
 			throw new IllegalArgumentException("report abuse control max counter keys must be positive");
 		}
+		for (ReportAbuseGroup group : ReportAbuseGroup.values()) {
+			Integer limit = limits.get(group);
+			if (limit == null || limit < 1) {
+				throw new IllegalArgumentException("report abuse control limit must be positive: " + group);
+			}
+		}
 	}
 
 	int limit(ReportAbuseGroup group) {
-		return limits.getOrDefault(group, 0);
+		return limits.get(group);
 	}
 }
 
@@ -230,11 +236,11 @@ class FacilityReportClientIdentityResolver {
 		String[] addresses = forwardedFor.split(",");
 		for (int index = addresses.length - 1; index >= 0; index--) {
 			String candidate = normalizeAddress(addresses[index]);
-			if (!isTrustedProxy(candidate)) {
+			if (!isTrustedProxy(candidate) && IpCidr.isValidIpv4(candidate)) {
 				return candidate;
 			}
 		}
-		return normalizeAddress(addresses[addresses.length - 1]);
+		return "unknown";
 	}
 
 	private boolean isTrustedProxy(String remoteAddress) {
@@ -266,7 +272,10 @@ class FacilityReportClientIdentityResolver {
 record IpCidr(int address, int mask) {
 
 	static IpCidr parse(String value) {
-		String[] parts = value.split("/");
+		String[] parts = value.split("/", -1);
+		if (parts.length < 1 || parts.length > 2 || parts[0].isBlank()) {
+			throw new IllegalArgumentException("invalid IPv4 CIDR: " + value);
+		}
 		String address = parts[0].trim();
 		int prefixLength = parts.length == 2 ? Integer.parseInt(parts[1].trim()) : 32;
 		if (prefixLength < 0 || prefixLength > 32) {
@@ -279,6 +288,15 @@ record IpCidr(int address, int mask) {
 	boolean contains(String candidateAddress) {
 		try {
 			return (ipv4ToInt(candidateAddress) & mask) == (address & mask);
+		} catch (IllegalArgumentException exception) {
+			return false;
+		}
+	}
+
+	static boolean isValidIpv4(String value) {
+		try {
+			ipv4ToInt(value);
+			return true;
 		} catch (IllegalArgumentException exception) {
 			return false;
 		}

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControl.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControl.java
@@ -220,10 +220,21 @@ class FacilityReportClientIdentityResolver {
 		if (isTrustedProxy(remoteAddress)) {
 			String forwardedFor = request.getHeader("X-Forwarded-For");
 			if (forwardedFor != null && !forwardedFor.isBlank()) {
-				return "ip:" + normalizeAddress(forwardedFor.split(",")[0]);
+				return "ip:" + trustedClientAddress(forwardedFor);
 			}
 		}
 		return "ip:" + remoteAddress;
+	}
+
+	private String trustedClientAddress(String forwardedFor) {
+		String[] addresses = forwardedFor.split(",");
+		for (int index = addresses.length - 1; index >= 0; index--) {
+			String candidate = normalizeAddress(addresses[index]);
+			if (!isTrustedProxy(candidate)) {
+				return candidate;
+			}
+		}
+		return normalizeAddress(addresses[addresses.length - 1]);
 	}
 
 	private boolean isTrustedProxy(String remoteAddress) {

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControl.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControl.java
@@ -1,0 +1,265 @@
+package com.easysubway.report.adapter.in.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+class FacilityReportAbuseControl extends OncePerRequestFilter {
+
+	private final FacilityReportAbuseControlLimiter limiter;
+	private final FacilityReportClientIdentityResolver clientIdentityResolver;
+
+	FacilityReportAbuseControl(
+		@Value("${easysubway.report.abuse-control.window-seconds:60}") long windowSeconds,
+		@Value("${easysubway.report.abuse-control.upload-intent-limit:1000}") int uploadIntentLimit,
+		@Value("${easysubway.report.abuse-control.upload-claim-limit:1000}") int uploadClaimLimit,
+		@Value("${easysubway.report.abuse-control.report-submit-limit:1000}") int reportSubmitLimit,
+		@Value("${easysubway.report.abuse-control.status-limit:1000}") int statusLimit,
+		@Value("${easysubway.report.abuse-control.confirm-limit:1000}") int confirmLimit,
+		@Value("${easysubway.auth.client-ip.trusted-proxies:}") String trustedProxies,
+		ObjectProvider<Clock> clockProvider
+	) {
+		FacilityReportAbuseControlPolicy policy = new FacilityReportAbuseControlPolicy(
+			windowSeconds,
+			Map.of(
+				ReportAbuseGroup.UPLOAD_INTENT, uploadIntentLimit,
+				ReportAbuseGroup.UPLOAD_CLAIM, uploadClaimLimit,
+				ReportAbuseGroup.REPORT_SUBMIT, reportSubmitLimit,
+				ReportAbuseGroup.STATUS, statusLimit,
+				ReportAbuseGroup.CONFIRM, confirmLimit
+			)
+		);
+		this.limiter = new FacilityReportAbuseControlLimiter(
+			policy,
+			clockProvider.getIfAvailable(Clock::systemUTC)
+		);
+		this.clientIdentityResolver = new FacilityReportClientIdentityResolver(trustedProxies);
+	}
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+		Optional<ReportAbuseGroup> reportAbuseGroup = ReportAbuseGroup.from(request);
+		if (reportAbuseGroup.isPresent()) {
+			ReportAbuseGroup group = reportAbuseGroup.get();
+			if (!limiter.tryAcquire(group, clientIdentityResolver.resolve(request))) {
+				response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+				return;
+			}
+		}
+		filterChain.doFilter(request, response);
+	}
+}
+
+enum ReportAbuseGroup {
+	UPLOAD_INTENT,
+	UPLOAD_CLAIM,
+	REPORT_SUBMIT,
+	STATUS,
+	CONFIRM;
+
+	private static final Pattern REPORT_STATUS_PATH = Pattern.compile("^/api/v1/reports/[^/]+$");
+	private static final Pattern REPORT_CONFIRM_PATH = Pattern.compile("^/api/v1/reports/[^/]+/confirm$");
+	private static final Pattern UPLOAD_CLAIM_PATH = Pattern.compile("^/api/v1/report-uploads/[^/]+$");
+
+	static Optional<ReportAbuseGroup> from(HttpServletRequest request) {
+		String method = request.getMethod();
+		String path = request.getRequestURI();
+		if (HttpMethod.POST.matches(method) && "/api/v1/report-uploads".equals(path)) {
+			return Optional.of(UPLOAD_INTENT);
+		}
+		if (HttpMethod.PUT.matches(method) && UPLOAD_CLAIM_PATH.matcher(path).matches()) {
+			return Optional.of(UPLOAD_CLAIM);
+		}
+		if (HttpMethod.POST.matches(method) && "/api/v1/reports".equals(path)) {
+			return Optional.of(REPORT_SUBMIT);
+		}
+		if (HttpMethod.GET.matches(method) && REPORT_STATUS_PATH.matcher(path).matches()) {
+			return Optional.of(STATUS);
+		}
+		if (HttpMethod.POST.matches(method) && REPORT_CONFIRM_PATH.matcher(path).matches()) {
+			return Optional.of(CONFIRM);
+		}
+		return Optional.empty();
+	}
+}
+
+record FacilityReportAbuseControlPolicy(long windowSeconds, Map<ReportAbuseGroup, Integer> limits) {
+
+	FacilityReportAbuseControlPolicy {
+		if (windowSeconds < 1) {
+			throw new IllegalArgumentException("report abuse control window must be positive");
+		}
+	}
+
+	int limit(ReportAbuseGroup group) {
+		return limits.getOrDefault(group, 0);
+	}
+}
+
+class FacilityReportAbuseControlLimiter {
+
+	private final FacilityReportAbuseControlPolicy policy;
+	private final Clock clock;
+	private final Map<LimiterKey, WindowCounter> counters = new ConcurrentHashMap<>();
+
+	FacilityReportAbuseControlLimiter(FacilityReportAbuseControlPolicy policy, Clock clock) {
+		this.policy = policy;
+		this.clock = clock;
+	}
+
+	boolean tryAcquire(ReportAbuseGroup group, String clientIdentity) {
+		int limit = policy.limit(group);
+		if (limit < 1) {
+			return true;
+		}
+		long windowStartedAt = currentWindowStartedAt(Instant.now(clock));
+		WindowCounter counter = counters.computeIfAbsent(
+			new LimiterKey(group, clientIdentity),
+			ignored -> new WindowCounter(windowStartedAt)
+		);
+		boolean allowed = counter.incrementWithin(windowStartedAt, limit);
+		if (counters.size() > 1024) {
+			counters.entrySet().removeIf(entry -> entry.getValue().isBefore(windowStartedAt));
+		}
+		return allowed;
+	}
+
+	private long currentWindowStartedAt(Instant now) {
+		long epochSecond = now.getEpochSecond();
+		return epochSecond - Math.floorMod(epochSecond, policy.windowSeconds());
+	}
+
+	private record LimiterKey(ReportAbuseGroup group, String clientIdentity) {
+	}
+
+	private static final class WindowCounter {
+
+		private long windowStartedAt;
+		private int count;
+
+		private WindowCounter(long windowStartedAt) {
+			this.windowStartedAt = windowStartedAt;
+		}
+
+		private synchronized boolean incrementWithin(long currentWindowStartedAt, int limit) {
+			if (windowStartedAt != currentWindowStartedAt) {
+				windowStartedAt = currentWindowStartedAt;
+				count = 0;
+			}
+			if (count >= limit) {
+				return false;
+			}
+			count++;
+			return true;
+		}
+
+		private synchronized boolean isBefore(long currentWindowStartedAt) {
+			return windowStartedAt < currentWindowStartedAt;
+		}
+	}
+}
+
+class FacilityReportClientIdentityResolver {
+
+	private final List<IpCidr> trustedProxies;
+
+	FacilityReportClientIdentityResolver(String trustedProxyCidrs) {
+		this.trustedProxies = parseTrustedProxies(trustedProxyCidrs);
+	}
+
+	String resolve(HttpServletRequest request) {
+		String remoteAddress = normalizeAddress(request.getRemoteAddr());
+		if (isTrustedProxy(remoteAddress)) {
+			String forwardedFor = request.getHeader("X-Forwarded-For");
+			if (forwardedFor != null && !forwardedFor.isBlank()) {
+				return "ip:" + normalizeAddress(forwardedFor.split(",")[0]);
+			}
+		}
+		return "ip:" + remoteAddress;
+	}
+
+	private boolean isTrustedProxy(String remoteAddress) {
+		return trustedProxies.stream().anyMatch(proxy -> proxy.contains(remoteAddress));
+	}
+
+	private static String normalizeAddress(String address) {
+		if (address == null || address.isBlank()) {
+			return "unknown";
+		}
+		return address.trim().toLowerCase(Locale.ROOT);
+	}
+
+	private static List<IpCidr> parseTrustedProxies(String trustedProxyCidrs) {
+		if (trustedProxyCidrs == null || trustedProxyCidrs.isBlank()) {
+			return List.of();
+		}
+		List<IpCidr> cidrs = new ArrayList<>();
+		for (String value : trustedProxyCidrs.split(",")) {
+			String normalized = value.trim();
+			if (!normalized.isBlank()) {
+				cidrs.add(IpCidr.parse(normalized));
+			}
+		}
+		return List.copyOf(cidrs);
+	}
+}
+
+record IpCidr(int address, int mask) {
+
+	static IpCidr parse(String value) {
+		String[] parts = value.split("/");
+		String address = parts[0].trim();
+		int prefixLength = parts.length == 2 ? Integer.parseInt(parts[1].trim()) : 32;
+		if (prefixLength < 0 || prefixLength > 32) {
+			throw new IllegalArgumentException("invalid IPv4 CIDR prefix: " + value);
+		}
+		int mask = prefixLength == 0 ? 0 : -1 << (32 - prefixLength);
+		return new IpCidr(ipv4ToInt(address), mask);
+	}
+
+	boolean contains(String candidateAddress) {
+		try {
+			return (ipv4ToInt(candidateAddress) & mask) == (address & mask);
+		} catch (IllegalArgumentException exception) {
+			return false;
+		}
+	}
+
+	private static int ipv4ToInt(String value) {
+		String[] octets = value.trim().split("\\.");
+		if (octets.length != 4) {
+			throw new IllegalArgumentException("only IPv4 CIDR is supported");
+		}
+		int result = 0;
+		for (String octet : octets) {
+			int parsed = Integer.parseInt(octet);
+			if (parsed < 0 || parsed > 255) {
+				throw new IllegalArgumentException("invalid IPv4 address: " + value);
+			}
+			result = (result << 8) | parsed;
+		}
+		return result;
+	}
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -22,6 +22,7 @@ easysubway:
       report-submit-limit: ${EASYSUBWAY_REPORT_ABUSE_REPORT_SUBMIT_LIMIT:1000}
       status-limit: ${EASYSUBWAY_REPORT_ABUSE_STATUS_LIMIT:1000}
       confirm-limit: ${EASYSUBWAY_REPORT_ABUSE_CONFIRM_LIMIT:1000}
+      max-counter-keys: ${EASYSUBWAY_REPORT_ABUSE_MAX_COUNTER_KEYS:4096}
   auth:
     client-ip:
       trusted-proxies: ${EASYSUBWAY_TRUSTED_PROXY_CIDRS:}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -14,6 +14,14 @@ spring:
     username: sa
     password: ""
 easysubway:
+  report:
+    abuse-control:
+      window-seconds: ${EASYSUBWAY_REPORT_ABUSE_WINDOW_SECONDS:60}
+      upload-intent-limit: ${EASYSUBWAY_REPORT_ABUSE_UPLOAD_INTENT_LIMIT:1000}
+      upload-claim-limit: ${EASYSUBWAY_REPORT_ABUSE_UPLOAD_CLAIM_LIMIT:1000}
+      report-submit-limit: ${EASYSUBWAY_REPORT_ABUSE_REPORT_SUBMIT_LIMIT:1000}
+      status-limit: ${EASYSUBWAY_REPORT_ABUSE_STATUS_LIMIT:1000}
+      confirm-limit: ${EASYSUBWAY_REPORT_ABUSE_CONFIRM_LIMIT:1000}
   auth:
     client-ip:
       trusted-proxies: ${EASYSUBWAY_TRUSTED_PROXY_CIDRS:}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -32,6 +32,13 @@ spring:
 easysubway:
   report:
     receipt-token-pepper: ${EASYSUBWAY_REPORT_RECEIPT_PEPPER:${EASYSUBWAY_REPORT_RECEIPT_TOKEN_PEPPER:}}
+    abuse-control:
+      window-seconds: ${EASYSUBWAY_REPORT_ABUSE_WINDOW_SECONDS:60}
+      upload-intent-limit: ${EASYSUBWAY_REPORT_ABUSE_UPLOAD_INTENT_LIMIT:60}
+      upload-claim-limit: ${EASYSUBWAY_REPORT_ABUSE_UPLOAD_CLAIM_LIMIT:120}
+      report-submit-limit: ${EASYSUBWAY_REPORT_ABUSE_REPORT_SUBMIT_LIMIT:30}
+      status-limit: ${EASYSUBWAY_REPORT_ABUSE_STATUS_LIMIT:120}
+      confirm-limit: ${EASYSUBWAY_REPORT_ABUSE_CONFIRM_LIMIT:30}
     upload:
       bucket: ${EASYSUBWAY_REPORT_UPLOAD_BUCKET:}
       max-bytes: ${EASYSUBWAY_REPORT_UPLOAD_MAX_BYTES:921600}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -39,6 +39,7 @@ easysubway:
       report-submit-limit: ${EASYSUBWAY_REPORT_ABUSE_REPORT_SUBMIT_LIMIT:30}
       status-limit: ${EASYSUBWAY_REPORT_ABUSE_STATUS_LIMIT:120}
       confirm-limit: ${EASYSUBWAY_REPORT_ABUSE_CONFIRM_LIMIT:30}
+      max-counter-keys: ${EASYSUBWAY_REPORT_ABUSE_MAX_COUNTER_KEYS:4096}
     upload:
       bucket: ${EASYSUBWAY_REPORT_UPLOAD_BUCKET:}
       max-bytes: ${EASYSUBWAY_REPORT_UPLOAD_MAX_BYTES:921600}

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControlTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControlTest.java
@@ -1,5 +1,6 @@
 package com.easysubway.report.adapter.in.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -7,6 +8,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.jayway.jsonpath.JsonPath;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +30,7 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 	"easysubway.report.abuse-control.report-submit-limit=2",
 	"easysubway.report.abuse-control.status-limit=2",
 	"easysubway.report.abuse-control.confirm-limit=2",
+	"easysubway.report.abuse-control.max-counter-keys=64",
 	"easysubway.auth.client-ip.trusted-proxies=10.0.0.0/8"
 })
 @AutoConfigureMockMvc
@@ -103,6 +109,20 @@ class FacilityReportAbuseControlTest {
 
 		getUnknownStatusFromForwardedClient("203.0.113.11")
 			.andExpect(status().isNotFound());
+	}
+
+	@Test
+	@DisplayName("limiter는 현재 window 신규 client key 증가를 상한에서 차단한다")
+	void limiterRejectsNewClientIdentityWhenCurrentWindowKeyCapIsReached() {
+		var limiter = new FacilityReportAbuseControlLimiter(
+			new FacilityReportAbuseControlPolicy(60, 2, Map.of(ReportAbuseGroup.STATUS, 100)),
+			Clock.fixed(Instant.parse("2026-06-22T00:00:00Z"), ZoneOffset.UTC)
+		);
+
+		assertThat(limiter.tryAcquire(ReportAbuseGroup.STATUS, "ip:203.0.113.1")).isTrue();
+		assertThat(limiter.tryAcquire(ReportAbuseGroup.STATUS, "ip:203.0.113.2")).isTrue();
+		assertThat(limiter.tryAcquire(ReportAbuseGroup.STATUS, "ip:203.0.113.1")).isTrue();
+		assertThat(limiter.tryAcquire(ReportAbuseGroup.STATUS, "ip:203.0.113.3")).isFalse();
 	}
 
 	private org.springframework.test.web.servlet.ResultActions createUploadIntent(String clientSubmissionId, String remoteAddr)

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControlTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControlTest.java
@@ -1,0 +1,179 @@
+package com.easysubway.report.adapter.in.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-test",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.report.abuse-control.window-seconds=60",
+	"easysubway.report.abuse-control.upload-intent-limit=2",
+	"easysubway.report.abuse-control.upload-claim-limit=2",
+	"easysubway.report.abuse-control.report-submit-limit=2",
+	"easysubway.report.abuse-control.status-limit=2",
+	"easysubway.report.abuse-control.confirm-limit=2",
+	"easysubway.auth.client-ip.trusted-proxies=10.0.0.0/8"
+})
+@AutoConfigureMockMvc
+@DisplayName("시설 신고 abuse control")
+class FacilityReportAbuseControlTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("업로드 intent 생성은 client별 fixed window 한도를 넘으면 429를 반환한다")
+	void uploadIntentCreationIsRateLimitedByClient() throws Exception {
+		createUploadIntent("abuse-upload-intent-1", "198.51.100.10").andExpect(status().isCreated());
+		createUploadIntent("abuse-upload-intent-2", "198.51.100.10").andExpect(status().isCreated());
+
+		createUploadIntent("abuse-upload-intent-3", "198.51.100.10")
+			.andExpect(status().isTooManyRequests());
+	}
+
+	@Test
+	@DisplayName("업로드 claim 경로는 client별 fixed window 한도를 넘으면 429를 반환한다")
+	void uploadClaimIsRateLimitedByClient() throws Exception {
+		claimUpload("abuse-upload-claim-1", "198.51.100.11").andExpect(status().isBadRequest());
+		claimUpload("abuse-upload-claim-2", "198.51.100.11").andExpect(status().isBadRequest());
+
+		claimUpload("abuse-upload-claim-3", "198.51.100.11")
+			.andExpect(status().isTooManyRequests());
+	}
+
+	@Test
+	@DisplayName("receipt 신고 생성은 client별 fixed window 한도를 넘으면 429를 반환한다")
+	void receiptReportSubmissionIsRateLimitedByClient() throws Exception {
+		createReceiptReport("abuse-report-submit-1", "198.51.100.12").andExpect(status().isCreated());
+		createReceiptReport("abuse-report-submit-2", "198.51.100.12").andExpect(status().isCreated());
+
+		createReceiptReport("abuse-report-submit-3", "198.51.100.12")
+			.andExpect(status().isTooManyRequests());
+	}
+
+	@Test
+	@DisplayName("receipt 상태 조회는 client별 fixed window 한도를 넘으면 429를 반환한다")
+	void receiptStatusLookupIsRateLimitedByClient() throws Exception {
+		String response = createReceiptReport("abuse-report-status-source", "198.51.100.13")
+			.andExpect(status().isCreated())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		String reportId = JsonPath.read(response, "$.data.id");
+		String receiptToken = JsonPath.read(response, "$.data.receiptToken");
+
+		getReceiptStatus(reportId, receiptToken, "198.51.100.14").andExpect(status().isOk());
+		getReceiptStatus(reportId, receiptToken, "198.51.100.14").andExpect(status().isOk());
+
+		getReceiptStatus(reportId, receiptToken, "198.51.100.14")
+			.andExpect(status().isTooManyRequests());
+	}
+
+	@Test
+	@DisplayName("receipt 확인 경로는 client별 fixed window 한도를 넘으면 429를 반환한다")
+	void receiptConfirmIsRateLimitedByClient() throws Exception {
+		confirmReceipt("unknown-report-confirm-1", "198.51.100.15").andExpect(status().isNotFound());
+		confirmReceipt("unknown-report-confirm-2", "198.51.100.15").andExpect(status().isNotFound());
+
+		confirmReceipt("unknown-report-confirm-3", "198.51.100.15")
+			.andExpect(status().isTooManyRequests());
+	}
+
+	@Test
+	@DisplayName("trusted proxy 요청은 X-Forwarded-For의 원 client IP로 한도를 분리한다")
+	void trustedProxyForwardedClientSeparatesRateLimitIdentity() throws Exception {
+		getUnknownStatusFromForwardedClient("203.0.113.10").andExpect(status().isNotFound());
+		getUnknownStatusFromForwardedClient("203.0.113.10").andExpect(status().isNotFound());
+
+		getUnknownStatusFromForwardedClient("203.0.113.10")
+			.andExpect(status().isTooManyRequests());
+
+		getUnknownStatusFromForwardedClient("203.0.113.11")
+			.andExpect(status().isNotFound());
+	}
+
+	private org.springframework.test.web.servlet.ResultActions createUploadIntent(String clientSubmissionId, String remoteAddr)
+		throws Exception {
+		return mockMvc.perform(post("/api/v1/report-uploads")
+			.with(remoteAddr(remoteAddr))
+			.contentType(MediaType.APPLICATION_JSON)
+			.content("""
+				{
+				  "clientSubmissionId": "%s",
+				  "photoFileName": "elevator.jpg",
+				  "photoContentType": "image/jpeg",
+				  "photoSha256": "2c8648d103e3dd7ad87660da0f126a1443b6d21ac1bd3ec000c5e24e2373a90c",
+				  "photoSizeBytes": 11
+				}
+				""".formatted(clientSubmissionId)));
+	}
+
+	private org.springframework.test.web.servlet.ResultActions claimUpload(String uploadId, String remoteAddr) throws Exception {
+		return mockMvc.perform(put("/api/v1/report-uploads/{uploadId}", uploadId)
+			.with(remoteAddr(remoteAddr))
+			.contentType(MediaType.IMAGE_JPEG)
+			.content("image-bytes"));
+	}
+
+	private org.springframework.test.web.servlet.ResultActions createReceiptReport(String clientSubmissionId, String remoteAddr)
+		throws Exception {
+		return mockMvc.perform(post("/api/v1/reports")
+			.with(remoteAddr(remoteAddr))
+			.contentType(MediaType.APPLICATION_JSON)
+			.content("""
+				{
+				  "clientSubmissionId": "%s",
+				  "stationId": "station-sangnoksu",
+				  "facilityId": "facility-sangnoksu-elevator-1",
+				  "reportType": "BROKEN",
+				  "description": "엘리베이터 문이 열리지 않습니다."
+				}
+				""".formatted(clientSubmissionId)));
+	}
+
+	private org.springframework.test.web.servlet.ResultActions getReceiptStatus(
+		String reportId,
+		String receiptToken,
+		String remoteAddr
+	)
+		throws Exception {
+		return mockMvc.perform(get("/api/v1/reports/{reportId}", reportId)
+			.with(remoteAddr(remoteAddr))
+			.header("X-Easysubway-Report-Receipt-Token", receiptToken));
+	}
+
+	private org.springframework.test.web.servlet.ResultActions confirmReceipt(String reportId, String remoteAddr) throws Exception {
+		return mockMvc.perform(post("/api/v1/reports/{reportId}/confirm", reportId)
+			.with(remoteAddr(remoteAddr))
+			.with(csrf())
+			.header("X-Easysubway-Report-Receipt-Token", "receipt-token-for-rate-limit"));
+	}
+
+	private org.springframework.test.web.servlet.ResultActions getUnknownStatusFromForwardedClient(String forwardedFor)
+		throws Exception {
+		return mockMvc.perform(get("/api/v1/reports/unknown-forwarded-report")
+			.with(remoteAddr("10.0.0.10"))
+			.header("X-Forwarded-For", forwardedFor)
+			.header("X-Easysubway-Report-Receipt-Token", "receipt-token-for-rate-limit"));
+	}
+
+	private static RequestPostProcessor remoteAddr(String remoteAddr) {
+		return request -> {
+			request.setRemoteAddr(remoteAddr);
+			return request;
+		};
+	}
+}

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControlTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControlTest.java
@@ -112,6 +112,16 @@ class FacilityReportAbuseControlTest {
 	}
 
 	@Test
+	@DisplayName("trusted proxy 요청은 spoofed X-Forwarded-For leftmost 값을 client identity로 쓰지 않는다")
+	void trustedProxyIgnoresSpoofedLeftmostForwardedFor() throws Exception {
+		getUnknownStatusFromForwardedChain("198.51.100.200, 203.0.113.20").andExpect(status().isNotFound());
+		getUnknownStatusFromForwardedChain("198.51.100.201, 203.0.113.20").andExpect(status().isNotFound());
+
+		getUnknownStatusFromForwardedChain("198.51.100.202, 203.0.113.20")
+			.andExpect(status().isTooManyRequests());
+	}
+
+	@Test
 	@DisplayName("limiter는 현재 window 신규 client key 증가를 상한에서 차단한다")
 	void limiterRejectsNewClientIdentityWhenCurrentWindowKeyCapIsReached() {
 		var limiter = new FacilityReportAbuseControlLimiter(
@@ -183,6 +193,11 @@ class FacilityReportAbuseControlTest {
 	}
 
 	private org.springframework.test.web.servlet.ResultActions getUnknownStatusFromForwardedClient(String forwardedFor)
+		throws Exception {
+		return getUnknownStatusFromForwardedChain(forwardedFor);
+	}
+
+	private org.springframework.test.web.servlet.ResultActions getUnknownStatusFromForwardedChain(String forwardedFor)
 		throws Exception {
 		return mockMvc.perform(get("/api/v1/reports/unknown-forwarded-report")
 			.with(remoteAddr("10.0.0.10"))

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControlTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControlTest.java
@@ -1,6 +1,7 @@
 package com.easysubway.report.adapter.in.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -122,10 +123,20 @@ class FacilityReportAbuseControlTest {
 	}
 
 	@Test
+	@DisplayName("trusted proxy 요청은 invalid X-Forwarded-For 값을 unknown client identity로 묶는다")
+	void trustedProxyInvalidForwardedForUsesUnknownIdentity() throws Exception {
+		getUnknownStatusFromForwardedChain("not-an-ip-1").andExpect(status().isNotFound());
+		getUnknownStatusFromForwardedChain("not-an-ip-2").andExpect(status().isNotFound());
+
+		getUnknownStatusFromForwardedChain("not-an-ip-3")
+			.andExpect(status().isTooManyRequests());
+	}
+
+	@Test
 	@DisplayName("limiter는 현재 window 신규 client key 증가를 상한에서 차단한다")
 	void limiterRejectsNewClientIdentityWhenCurrentWindowKeyCapIsReached() {
 		var limiter = new FacilityReportAbuseControlLimiter(
-			new FacilityReportAbuseControlPolicy(60, 2, Map.of(ReportAbuseGroup.STATUS, 100)),
+			new FacilityReportAbuseControlPolicy(60, 2, completeLimits(100)),
 			Clock.fixed(Instant.parse("2026-06-22T00:00:00Z"), ZoneOffset.UTC)
 		);
 
@@ -133,6 +144,38 @@ class FacilityReportAbuseControlTest {
 		assertThat(limiter.tryAcquire(ReportAbuseGroup.STATUS, "ip:203.0.113.2")).isTrue();
 		assertThat(limiter.tryAcquire(ReportAbuseGroup.STATUS, "ip:203.0.113.1")).isTrue();
 		assertThat(limiter.tryAcquire(ReportAbuseGroup.STATUS, "ip:203.0.113.3")).isFalse();
+	}
+
+	@Test
+	@DisplayName("abuse control policy는 누락되거나 비활성화된 endpoint limit을 거부한다")
+	void policyRejectsMissingOrNonPositiveLimits() {
+		assertThatThrownBy(() -> new FacilityReportAbuseControlPolicy(
+			60,
+			10,
+			Map.of(ReportAbuseGroup.STATUS, 1)
+		)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("UPLOAD_INTENT");
+
+		assertThatThrownBy(() -> new FacilityReportAbuseControlPolicy(
+			60,
+			10,
+			Map.of(
+				ReportAbuseGroup.UPLOAD_INTENT, 1,
+				ReportAbuseGroup.UPLOAD_CLAIM, 1,
+				ReportAbuseGroup.REPORT_SUBMIT, 1,
+				ReportAbuseGroup.STATUS, 0,
+				ReportAbuseGroup.CONFIRM, 1
+			)
+		)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("STATUS");
+	}
+
+	@Test
+	@DisplayName("CIDR parser는 slash가 여러 개인 trusted proxy 값을 거부한다")
+	void cidrParserRejectsMultipleSlashSyntax() {
+		assertThatThrownBy(() -> IpCidr.parse("10.0.0.0/8/extra"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("invalid IPv4 CIDR");
 	}
 
 	private org.springframework.test.web.servlet.ResultActions createUploadIntent(String clientSubmissionId, String remoteAddr)
@@ -210,5 +253,15 @@ class FacilityReportAbuseControlTest {
 			request.setRemoteAddr(remoteAddr);
 			return request;
 		};
+	}
+
+	private static Map<ReportAbuseGroup, Integer> completeLimits(int limit) {
+		return Map.of(
+			ReportAbuseGroup.UPLOAD_INTENT, limit,
+			ReportAbuseGroup.UPLOAD_CLAIM, limit,
+			ReportAbuseGroup.REPORT_SUBMIT, limit,
+			ReportAbuseGroup.STATUS, limit,
+			ReportAbuseGroup.CONFIRM, limit
+		);
 	}
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2001,9 +2001,12 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(abuseControl, /easysubway\.report\.abuse-control\.confirm-limit/);
   assert.match(abuseControl, /easysubway\.report\.abuse-control\.max-counter-keys/);
   assert.match(abuseControl, /maxCounterKeys/);
+  assert.match(abuseControl, /ReportAbuseGroup\.values\(\)/);
   assert.match(abuseControl, /easysubway\.auth\.client-ip\.trusted-proxies/);
   assert.match(abuseControl, /X-Forwarded-For/);
   assert.match(abuseControl, /trustedClientAddress/);
+  assert.match(abuseControl, /isValidIpv4/);
+  assert.match(abuseControl, /split\("\/", -1\)/);
   assert.doesNotMatch(abuseControl, /receiptToken|uploadUrl|privateNote|latitude|longitude/);
   assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_WINDOW_SECONDS:60/);
   assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_UPLOAD_INTENT_LIMIT:60/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1807,7 +1807,9 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
     "backend/src/main/resources/db/migration/postgresql/V3__facility_report_receipt_tokens.sql";
   const dropBase64MigrationPath =
     "backend/src/main/resources/db/migration/postgresql/V4__drop_facility_report_base64_payload.sql";
+  const prodConfig = read("backend/src/main/resources/application-prod.yml");
   const controller = read("backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java");
+  const abuseControl = read("backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControl.java");
   const adminPageController = read(
     "backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java",
   );
@@ -1985,6 +1987,27 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(controller, /Principal principal/);
   assert.match(controller, /principal\.getName\(\)/);
   assert.match(controller, /@ResponseStatus\(HttpStatus\.CREATED\)/);
+  assert.match(abuseControl, /extends OncePerRequestFilter/);
+  assert.match(abuseControl, /TOO_MANY_REQUESTS/);
+  assert.match(abuseControl, /UPLOAD_INTENT[\s\S]*UPLOAD_CLAIM[\s\S]*REPORT_SUBMIT[\s\S]*STATUS[\s\S]*CONFIRM/);
+  assert.match(abuseControl, /"\/api\/v1\/report-uploads"/);
+  assert.match(abuseControl, /"\/api\/v1\/reports"/);
+  assert.match(abuseControl, /Pattern\.compile\("\^\/api\/v1\/reports\/\[\^\/\]\+\/confirm\$/);
+  assert.match(abuseControl, /easysubway\.report\.abuse-control\.window-seconds/);
+  assert.match(abuseControl, /easysubway\.report\.abuse-control\.upload-intent-limit/);
+  assert.match(abuseControl, /easysubway\.report\.abuse-control\.upload-claim-limit/);
+  assert.match(abuseControl, /easysubway\.report\.abuse-control\.report-submit-limit/);
+  assert.match(abuseControl, /easysubway\.report\.abuse-control\.status-limit/);
+  assert.match(abuseControl, /easysubway\.report\.abuse-control\.confirm-limit/);
+  assert.match(abuseControl, /easysubway\.auth\.client-ip\.trusted-proxies/);
+  assert.match(abuseControl, /X-Forwarded-For/);
+  assert.doesNotMatch(abuseControl, /receiptToken|uploadUrl|privateNote|latitude|longitude/);
+  assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_WINDOW_SECONDS:60/);
+  assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_UPLOAD_INTENT_LIMIT:60/);
+  assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_UPLOAD_CLAIM_LIMIT:120/);
+  assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_REPORT_SUBMIT_LIMIT:30/);
+  assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_STATUS_LIMIT:120/);
+  assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_CONFIRM_LIMIT:30/);
   assert.match(adminPageController, /REPORT_SURGE_ALERT_THRESHOLD = 10/);
   assert.match(adminPageController, /REPORT_SURGE_LOOKBACK_HOURS = 24/);
   assert.match(adminPageController, /ReportSurgeAlertView/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2003,6 +2003,7 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(abuseControl, /maxCounterKeys/);
   assert.match(abuseControl, /easysubway\.auth\.client-ip\.trusted-proxies/);
   assert.match(abuseControl, /X-Forwarded-For/);
+  assert.match(abuseControl, /trustedClientAddress/);
   assert.doesNotMatch(abuseControl, /receiptToken|uploadUrl|privateNote|latitude|longitude/);
   assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_WINDOW_SECONDS:60/);
   assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_UPLOAD_INTENT_LIMIT:60/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1999,6 +1999,8 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(abuseControl, /easysubway\.report\.abuse-control\.report-submit-limit/);
   assert.match(abuseControl, /easysubway\.report\.abuse-control\.status-limit/);
   assert.match(abuseControl, /easysubway\.report\.abuse-control\.confirm-limit/);
+  assert.match(abuseControl, /easysubway\.report\.abuse-control\.max-counter-keys/);
+  assert.match(abuseControl, /maxCounterKeys/);
   assert.match(abuseControl, /easysubway\.auth\.client-ip\.trusted-proxies/);
   assert.match(abuseControl, /X-Forwarded-For/);
   assert.doesNotMatch(abuseControl, /receiptToken|uploadUrl|privateNote|latitude|longitude/);
@@ -2008,6 +2010,7 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_REPORT_SUBMIT_LIMIT:30/);
   assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_STATUS_LIMIT:120/);
   assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_CONFIRM_LIMIT:30/);
+  assert.match(prodConfig, /EASYSUBWAY_REPORT_ABUSE_MAX_COUNTER_KEYS:4096/);
   assert.match(adminPageController, /REPORT_SURGE_ALERT_THRESHOLD = 10/);
   assert.match(adminPageController, /REPORT_SURGE_LOOKBACK_HOURS = 24/);
   assert.match(adminPageController, /ReportSurgeAlertView/);


### PR DESCRIPTION
## 관련 이슈

close #586

## 작업 배경

공개 시설 신고 경로는 인증 없이 접근 가능해야 하지만, 업로드 intent 생성, 업로드 claim, 신고 생성, receipt 기반 상태 조회와 확인 경로가 동일 client의 반복 요청을 제한하지 않으면 사진 업로드 비용과 신고 처리 큐가 과도하게 소모될 수 있습니다.

## 작업 내용

- 공개 시설 신고 endpoint 전용 `OncePerRequestFilter` 기반 abuse control을 추가했습니다.
- `POST /api/v1/report-uploads`, `PUT /api/v1/report-uploads/{uploadId}`, `POST /api/v1/reports`, `GET /api/v1/reports/{reportId}`, `POST /api/v1/reports/{reportId}/confirm`을 각각 별도 fixed-window 그룹으로 제한합니다.
- trusted proxy CIDR에서 들어온 요청만 `X-Forwarded-For` 첫 client IP를 한도 key로 사용하고, 그 외 요청은 remote address를 사용합니다.
- 운영/dev profile에서 `EASYSUBWAY_REPORT_ABUSE_*` 환경변수로 window와 endpoint별 limit을 조정할 수 있게 했습니다.
- 429 응답 경로에 receipt token, upload URL, private note, 위치 좌표 같은 민감 필드를 기록하거나 반환하지 않도록 계약 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests com.easysubway.report.adapter.in.web.FacilityReportAbuseControlTest --tests com.easysubway.report.adapter.in.web.FacilityReportControllerTest --tests com.easysubway.report.adapter.in.web.FacilityReportUploadIntentsTest`: BUILD SUCCESSFUL
  - `node --test --test-name-pattern="백엔드 시설 신고" tools/ci/repository-contract.test.mjs`: 1 pass, 0 fail
  - `cd backend && ./gradlew check`: BUILD SUCCESSFUL
  - `node --test tools/ci/*.test.mjs`: 77 pass, 0 fail
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 공개 신고 endpoint abuse control | Backend | MockMvc fixed-window 한도 테스트 | `FacilityReportAbuseControlTest` 및 `./gradlew test --tests ...FacilityReportAbuseControlTest ...` | 3번째 반복 요청이 429로 차단됨 |
| trusted proxy client IP 분리 | Backend | `X-Forwarded-For` client별 한도 분리 테스트 | `trustedProxyForwardedClientSeparatesRateLimitIdentity` | 동일 client 3번째 요청만 429, 다른 client 요청은 기존 응답 유지 |
| 운영 limit 설정 계약 | Backend config | repository contract | `node --test tools/ci/*.test.mjs` | prod profile의 `EASYSUBWAY_REPORT_ABUSE_*` 바인딩 확인 |
| 민감정보 노출 방지 | Backend contract | source contract grep | `node --test --test-name-pattern="백엔드 시설 신고" tools/ci/repository-contract.test.mjs` | abuse control 코드에 receipt token/upload URL/private note/좌표 필드 없음 |
| 문서 추적 정책 | Repository | tracked Markdown 확인 | `git ls-files '*.md'` | README와 PR template만 추적 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `FacilityReportAbuseControl`의 endpoint 그룹 매칭, trusted proxy 조건부 `X-Forwarded-For` 사용, 운영 기본 limit 값입니다.

## 리스크

- 현재 limiter는 단일 backend instance 메모리 fixed-window 방식입니다. 다중 instance 전역 제한은 별도 distributed rate limit 작업이 필요합니다.
- 운영 limit은 환경변수로 조정 가능하지만 초기 기본값은 정상 사용자 신고 흐름을 막지 않도록 endpoint별로 다르게 설정했습니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시설 신고 API에 레이트 리밋팅 기능을 추가했습니다. 신고 제출, 업로드, 상태 조회 등의 작업에 대해 클라이언트별 요청 제한을 적용합니다. 한도를 초과하면 429 Too Many Requests 응답을 받게 됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->