### PR TITLE
[Fix] 관리자 운영자 상태 변경 감사 로그 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/common/security/AdminOperatorAuditFilter.java
+++ b/backend/src/main/java/com/easysubway/common/security/AdminOperatorAuditFilter.java
@@ -34,12 +34,16 @@ class AdminOperatorAuditFilter extends OncePerRequestFilter {
 		FilterChain filterChain
 	)
 		throws ServletException, IOException {
+		Exception failure = null;
 		try {
 			filterChain.doFilter(request, response);
+		} catch (ServletException | IOException | RuntimeException exception) {
+			failure = exception;
+			throw exception;
 		} finally {
 			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 			if (isAuthenticated(authentication)) {
-				writeAuditLog(request, response, authentication);
+				writeAuditLog(request, response, authentication, failure);
 			}
 		}
 	}
@@ -47,7 +51,8 @@ class AdminOperatorAuditFilter extends OncePerRequestFilter {
 	private void writeAuditLog(
 		HttpServletRequest request,
 		HttpServletResponse response,
-		Authentication authentication
+		Authentication authentication,
+		Exception failure
 	) {
 		log.info(
 			"admin_operator_state_change_audit method={} path={} principal={} roles={} status={}",
@@ -55,8 +60,15 @@ class AdminOperatorAuditFilter extends OncePerRequestFilter {
 			normalizedPath(request),
 			authentication.getName(),
 			roles(authentication),
-			response.getStatus()
+			status(response, failure)
 		);
+	}
+
+	private static int status(HttpServletResponse response, Exception failure) {
+		if (failure == null || response.getStatus() >= HttpServletResponse.SC_BAD_REQUEST) {
+			return response.getStatus();
+		}
+		return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 	}
 
 	private static boolean isAuthenticated(Authentication authentication) {

--- a/backend/src/main/java/com/easysubway/common/security/AdminOperatorAuditFilter.java
+++ b/backend/src/main/java/com/easysubway/common/security/AdminOperatorAuditFilter.java
@@ -1,0 +1,83 @@
+package com.easysubway.common.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerMapping;
+
+class AdminOperatorAuditFilter extends OncePerRequestFilter {
+
+	private static final Logger log = LoggerFactory.getLogger(AdminOperatorAuditFilter.class);
+	private static final Set<String> MUTATING_METHODS = Set.of("POST", "PUT", "PATCH", "DELETE");
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		return !MUTATING_METHODS.contains(request.getMethod()) || !(path.startsWith("/admin/") || path.startsWith("/operator/"));
+	}
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	)
+		throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} finally {
+			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+			if (isAuthenticated(authentication)) {
+				writeAuditLog(request, response, authentication);
+			}
+		}
+	}
+
+	private void writeAuditLog(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		Authentication authentication
+	) {
+		log.info(
+			"admin_operator_state_change_audit method={} path={} principal={} roles={} status={}",
+			request.getMethod(),
+			normalizedPath(request),
+			authentication.getName(),
+			roles(authentication),
+			response.getStatus()
+		);
+	}
+
+	private static boolean isAuthenticated(Authentication authentication) {
+		return authentication != null
+			&& authentication.isAuthenticated()
+			&& !(authentication instanceof AnonymousAuthenticationToken);
+	}
+
+	private static String normalizedPath(HttpServletRequest request) {
+		Object bestPattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+		if (bestPattern instanceof String pattern && !pattern.isBlank() && !"/**".equals(pattern)) {
+			return pattern;
+		}
+		return request.getRequestURI();
+	}
+
+	private static String roles(Authentication authentication) {
+		return authentication.getAuthorities()
+			.stream()
+			.map(authority -> authority.getAuthority())
+			.sorted(Comparator.naturalOrder())
+			.collect(Collectors.joining(","));
+	}
+}

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -21,7 +22,7 @@ public class SecurityConfig {
 
 	@Bean
 	@Order(1)
-	SecurityFilterChain adminSecurityFilterChain(HttpSecurity http) throws Exception {
+	SecurityFilterChain adminSecurityFilterChain(HttpSecurity http, AdminOperatorAuditFilter auditFilter) throws Exception {
 		// 관리자 검수 화면에는 상태 변경 form이 있으므로 CSRF 보호를 유지한다.
 		return http
 			.securityMatcher("/admin/**")
@@ -29,12 +30,13 @@ public class SecurityConfig {
 				.anyRequest().hasRole("ADMIN")
 			)
 			.httpBasic(Customizer.withDefaults())
+			.addFilterAfter(auditFilter, BasicAuthenticationFilter.class)
 			.build();
 	}
 
 	@Bean
 	@Order(2)
-	SecurityFilterChain operatorSecurityFilterChain(HttpSecurity http) throws Exception {
+	SecurityFilterChain operatorSecurityFilterChain(HttpSecurity http, AdminOperatorAuditFilter auditFilter) throws Exception {
 		// 운영기관 전용 화면은 전역 관리자와 별도 역할로 분리해 이후 기관별 범위 제한을 붙일 수 있게 한다.
 		return http
 			.securityMatcher("/operator/**")
@@ -42,6 +44,7 @@ public class SecurityConfig {
 				.anyRequest().hasRole("OPERATOR_ADMIN")
 			)
 			.httpBasic(Customizer.withDefaults())
+			.addFilterAfter(auditFilter, BasicAuthenticationFilter.class)
 			.build();
 	}
 
@@ -126,6 +129,11 @@ public class SecurityConfig {
 	@Bean
 	PasswordEncoder passwordEncoder() {
 		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+	}
+
+	@Bean
+	AdminOperatorAuditFilter adminOperatorAuditFilter() {
+		return new AdminOperatorAuditFilter();
 	}
 
 	private void validateProdAdminCredentials(String adminUsername, String adminPassword, Environment environment) {

--- a/backend/src/test/java/com/easysubway/common/security/AdminOperatorAuditFilterTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/AdminOperatorAuditFilterTest.java
@@ -1,0 +1,102 @@
+package com.easysubway.common.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-test",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.operator.username=operator-test",
+	"easysubway.operator.password=operator-test-password"
+})
+@AutoConfigureMockMvc
+@ExtendWith(OutputCaptureExtension.class)
+@DisplayName("관리자 운영자 감사 필터")
+class AdminOperatorAuditFilterTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("관리자 상태 변경 요청은 민감값 없는 감사 로그를 남긴다")
+	void adminMutatingRequestWritesRedactedAuditLog(CapturedOutput output) throws Exception {
+		String reportId = createReport();
+
+		mockMvc.perform(post("/admin/reports/{reportId}/page/review", reportId)
+				.queryParam("receiptToken", "plain-receipt-token")
+				.queryParam("latitude", "37.302421")
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("decision", "ACCEPT")
+				.param("privateNote", "do-not-log-private-note")
+				.param("uploadUrl", "https://storage.example/upload"))
+			.andExpect(status().is3xxRedirection());
+
+		assertThat(output.getOut())
+			.contains("admin_operator_state_change_audit")
+			.contains("method=POST")
+			.contains("path=/admin/reports/{reportId}/page/review")
+			.contains("principal=admin-test")
+			.contains("status=302")
+			.doesNotContain("plain-receipt-token")
+			.doesNotContain("37.302421")
+			.doesNotContain("do-not-log-private-note")
+			.doesNotContain("https://storage.example/upload");
+	}
+
+	@Test
+	@DisplayName("운영기관 상태 변경 경로도 동일한 감사 로그 경계에 걸린다")
+	void operatorMutatingRequestWritesRedactedAuditLog(CapturedOutput output) throws Exception {
+		mockMvc.perform(post("/operator/future-state-change")
+				.queryParam("uploadUrl", "https://storage.example/operator-upload")
+				.with(httpBasic("operator-test", "operator-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("privateNote", "operator-private-note"))
+			.andExpect(status().isNotFound());
+
+		assertThat(output.getOut())
+			.contains("admin_operator_state_change_audit")
+			.contains("method=POST")
+			.contains("path=/operator/future-state-change")
+			.contains("principal=operator-test")
+			.contains("status=404")
+			.doesNotContain("https://storage.example/operator-upload")
+			.doesNotContain("operator-private-note");
+	}
+
+	private String createReport() throws Exception {
+		String response = mockMvc.perform(post("/api/v1/reports")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "clientSubmissionId": "admin-audit-report",
+					  "stationId": "station-sangnoksu",
+					  "facilityId": "facility-sangnoksu-elevator-1",
+					  "reportType": "BROKEN",
+					  "description": "감사 로그 테스트 신고"
+					}
+					"""))
+			.andExpect(status().isCreated())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		return JsonPath.read(response, "$.data.id");
+	}
+}

--- a/backend/src/test/java/com/easysubway/common/security/AdminOperatorAuditFilterTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/AdminOperatorAuditFilterTest.java
@@ -1,6 +1,7 @@
 package com.easysubway.common.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -13,10 +14,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootTest(properties = {
 	"easysubway.admin.username=admin-test",
@@ -31,6 +36,24 @@ class AdminOperatorAuditFilterTest {
 
 	@Autowired
 	private MockMvc mockMvc;
+
+	@TestConfiguration
+	static class FailingAdminMutationConfiguration {
+
+		@Bean
+		FailingAdminMutationController failingAdminMutationController() {
+			return new FailingAdminMutationController();
+		}
+	}
+
+	@RestController
+	static class FailingAdminMutationController {
+
+		@PostMapping("/admin/audit-test/fail")
+		void fail() {
+			throw new IllegalStateException("forced admin audit failure");
+		}
+	}
 
 	@Test
 	@DisplayName("관리자 상태 변경 요청은 민감값 없는 감사 로그를 남긴다")
@@ -58,6 +81,23 @@ class AdminOperatorAuditFilterTest {
 			.doesNotContain("37.302421")
 			.doesNotContain("do-not-log-private-note")
 			.doesNotContain("https://storage.example/upload");
+	}
+
+	@Test
+	@DisplayName("관리자 상태 변경 예외 요청은 500 감사 로그를 남긴다")
+	void adminMutationFailureWritesServerErrorAuditLog(CapturedOutput output) {
+		assertThatThrownBy(() -> mockMvc.perform(post("/admin/audit-test/fail")
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf()))
+			.andReturn())
+			.hasRootCauseMessage("forced admin audit failure");
+
+		assertThat(output.getOut())
+			.contains("admin_operator_state_change_audit")
+			.contains("method=POST")
+			.contains("path=/admin/audit-test/fail")
+			.contains("principal=admin-test")
+			.contains("status=500");
 	}
 
 	@Test

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1814,6 +1814,9 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
     "backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java",
   );
   const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
+  const adminOperatorAuditFilter = read(
+    "backend/src/main/java/com/easysubway/common/security/AdminOperatorAuditFilter.java",
+  );
   const operatorReportController = read(
     "backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportController.java",
   );
@@ -2036,9 +2039,13 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(security, /@Order\(1\)[\s\S]*?securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(security, /anyRequest\(\)\.hasRole\("ADMIN"\)/);
+  assert.match(security, /adminSecurityFilterChain\(HttpSecurity http, AdminOperatorAuditFilter auditFilter\)/);
+  assert.match(security, /adminSecurityFilterChain[\s\S]*addFilterAfter\(auditFilter, BasicAuthenticationFilter\.class\)/);
   assert.match(security, /@Order\(2\)[\s\S]*?securityMatcher\("\/operator\/\*\*"\)/);
   assert.match(security, /securityMatcher\("\/operator\/\*\*"\)/);
   assert.match(security, /anyRequest\(\)\.hasRole\("OPERATOR_ADMIN"\)/);
+  assert.match(security, /operatorSecurityFilterChain\(HttpSecurity http, AdminOperatorAuditFilter auditFilter\)/);
+  assert.match(security, /operatorSecurityFilterChain[\s\S]*addFilterAfter\(auditFilter, BasicAuthenticationFilter\.class\)/);
   assert.match(security, /@Order\(3\)[\s\S]*?reportSecurityFilterChain/);
   assert.doesNotMatch(security, /"\/api\/v1\/me"/);
   assert.match(security, /"\/api\/v1\/reports\/\*"/);
@@ -2058,6 +2065,15 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(security, /PasswordEncoder/);
   assert.match(security, /passwordEncoder\.encode\(adminPassword\)/);
   assert.match(security, /passwordEncoder\.encode\(operatorPassword\)/);
+  assert.match(security, /AdminOperatorAuditFilter adminOperatorAuditFilter\(\)/);
+  assert.match(security, /return new AdminOperatorAuditFilter\(\)/);
+  assert.match(adminOperatorAuditFilter, /extends OncePerRequestFilter/);
+  assert.match(adminOperatorAuditFilter, /MUTATING_METHODS = Set\.of\("POST", "PUT", "PATCH", "DELETE"\)/);
+  assert.match(adminOperatorAuditFilter, /path\.startsWith\("\/admin\/"\) \|\| path\.startsWith\("\/operator\/"\)/);
+  assert.match(adminOperatorAuditFilter, /admin_operator_state_change_audit method=\{\} path=\{\} principal=\{\} roles=\{\} status=\{\}/);
+  assert.match(adminOperatorAuditFilter, /HandlerMapping\.BEST_MATCHING_PATTERN_ATTRIBUTE/);
+  assert.doesNotMatch(adminOperatorAuditFilter, /getQueryString|getParameter|getParameterMap|getInputStream|getReader/);
+  assert.doesNotMatch(adminOperatorAuditFilter, /receiptToken|uploadUrl|privateNote|latitude|longitude/);
   assert.match(operatorReportController, /@GetMapping\("\/operator\/api\/accessibility-report"\)/);
   assert.match(operatorReportController, /ApiResponse<OperatorAccessibilityReportView>/);
   assert.match(operatorReportController, /reportAssembler\.assemble\(\)/);


### PR DESCRIPTION
## 관련 이슈

close #588

## 작업 배경

관리자와 운영기관 전용 경로는 Basic auth와 역할 분리가 적용되어 있지만, 상태 변경 요청을 민감값 없이 추적하는 감사 로그 경계가 없었습니다. 신고 검수, 향후 운영기관 상태 변경 화면, 배포 전 보안 점검에서 누가 어떤 보호 경로를 변경했는지 확인할 수 있도록 최소 감사 이벤트를 추가했습니다.

## 작업 내용

- `/admin/**`, `/operator/**`의 `POST`, `PUT`, `PATCH`, `DELETE` 요청에 대해 인증된 principal, role, method, normalized path, response status만 남기는 `AdminOperatorAuditFilter`를 추가했습니다.
- 감사 필터를 admin/operator security chain의 Basic auth 뒤에 연결했습니다.
- query string, form parameter, body stream, receipt token, upload URL, private note, 위치값을 감사 로그에 포함하지 않는 contract와 MockMvc 회귀 테스트를 추가했습니다.
- unhandled exception이 발생한 상태 변경 요청은 감사 로그 status를 500으로 보정하도록 follow-up 수정했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests com.easysubway.common.security.AdminOperatorAuditFilterTest --tests com.easysubway.common.security.SecurityConfigTest`: `BUILD SUCCESSFUL`
  - `node --test tools/ci/*.test.mjs`: 77개 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 출력
  - `cd backend && ./gradlew check`: `BUILD SUCCESSFUL`
  - PR CI run `27911027402`: 통과
  - PR Release Artifacts run `27911027370`: 통과
  - post-merge CI run `27911205844`: 통과
  - post-merge CD run `27911205660`: 통과
  - post-merge Release Artifacts run `27911205658`: 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 관리자/운영기관 상태 변경 감사 로그 | Backend | MockMvc로 admin 검수 POST와 operator POST 요청 실행 | `AdminOperatorAuditFilterTest`에서 audit marker, principal, normalized path, status 확인 | 통과 |
| 예외 경로 감사 상태 | Backend | test-only admin mutation controller가 예외를 던지는 요청 실행 | `AdminOperatorAuditFilterTest`에서 `status=500` 확인 | 통과 |
| 민감값 비기록 경계 | Backend | query/form/body 접근 API와 민감 키워드 contract 검사 | `tools/ci/repository-contract.test.mjs` 77개 통과 | 통과 |
| 전체 backend 회귀 | Backend | Gradle 전체 check | `./gradlew check` `BUILD SUCCESSFUL` | 통과 |
| 문서 추적 정책 | Repository | tracked Markdown 목록 확인 | `git ls-files '*.md'`가 `.github/pull_request_template.md`, `README.md`만 출력 | 통과 |
| PR CI | GitHub Actions | PR head `706d54e68ce8edaf6378afba77ccb7441d1977dc` checks 확인 | CI `27911027402`, Release Artifacts `27911027370` | 통과 |
| 코드 리뷰 | GitHub PR review | CodeRabbit rate-limit 확인 후 Codex CLI fallback review와 re-review 확인 | Review `4539993446` actionable 1건 수정, Review `4540003440` actionable 0건, thread resolved | 통과 |
| post-merge 배포 확인 | GitHub Actions | main merge commit `5b4e54338d5741bdac4e9dc3fae21844f2effaf2` workflow 확인 | CI `27911205844`, CD `27911205660`, Release Artifacts `27911205658` | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `AdminOperatorAuditFilter`가 body/query/parameter를 읽지 않고 path pattern과 인증 정보만 기록하는지 확인해 주세요.
- CodeRabbit은 rate limit/credit exhausted로 실제 리뷰를 시작하지 못해 수동 재호출 없이 Codex CLI fallback을 사용했습니다.

## 리스크

- 현재 감사 이벤트는 애플리케이션 로그 기반입니다. 장기 보관, 검색, 위변조 방지 저장소는 별도 운영 감사 로그 저장소 작업이 필요합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
