### PR TITLE
[Fix] 관리자 Basic auth 출시 차단 기준 추가

### DIFF
--- a/apps/mobile/release/release-security-gate.json
+++ b/apps/mobile/release/release-security-gate.json
@@ -66,6 +66,16 @@
       "linkedArtifacts": ["backend/src/main/java/com/easysubway/common/security/SecurityConfig.java", "backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java"]
     },
     {
+      "id": "backend_admin_basic_auth_transition_gate",
+      "area": "backend",
+      "severity": "release-blocker",
+      "titleKo": "관리자 Basic auth 운영 전환 기준",
+      "ownerKo": "백엔드/운영 담당",
+      "readyWhenKo": "현재 Basic auth는 임시 운영 보호 수단이며, 상용 출시 전에는 lockout 정책 또는 OIDC/MFA/SSO 전환 결정과 구현 증거가 PR 검증 증거에 남아야 한다.",
+      "evidence": ["admin-auth-transition-decision-record", "lockout-or-oidc-mfa-implementation-evidence", "admin-security-config-review"],
+      "linkedArtifacts": ["backend/src/main/java/com/easysubway/common/security/SecurityConfig.java", ".github/pull_request_template.md", "tools/ci/repository-contract.test.mjs"]
+    },
+    {
       "id": "backend_role_authorization",
       "area": "backend",
       "severity": "release-blocker",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3968,6 +3968,7 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
     "mobile_test_credentials_absent",
     "mobile_error_stacktrace_sanitized",
     "backend_admin_auth_required",
+    "backend_admin_basic_auth_transition_gate",
     "backend_role_authorization",
     "backend_report_photo_upload_limits",
     "backend_error_response_sanitized",
@@ -4010,6 +4011,13 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.match(securityConfig, /hasRole\("ADMIN"\)/);
   assert.match(securityConfig, /hasRole\("OPERATOR_ADMIN"\)/);
   assert.match(securityConfig, /validateProdAdminCredentials/);
+  const adminBasicAuthGate = items.get("backend_admin_basic_auth_transition_gate");
+  assert.match(adminBasicAuthGate.readyWhenKo, /lockout|OIDC|MFA|SSO/i);
+  assert.match(adminBasicAuthGate.readyWhenKo, /Basic auth/);
+  assert.ok(adminBasicAuthGate.evidence.includes("admin-auth-transition-decision-record"));
+  assert.ok(adminBasicAuthGate.evidence.includes("lockout-or-oidc-mfa-implementation-evidence"));
+  assert.ok(adminBasicAuthGate.linkedArtifacts.includes("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java"));
+  assert.ok(adminBasicAuthGate.linkedArtifacts.includes(".github/pull_request_template.md"));
   assert.match(facilityReportPhotoProcessor, /MAX_PHOTO_BYTES = 900 \* 1024/);
   assert.match(facilityReportPhotoProcessor, /MAX_PHOTO_WIDTH = 4_096/);
   assert.match(facilityReportPhotoProcessor, /MAX_PHOTO_PIXELS = 12_000_000/);


### PR DESCRIPTION
## 관련 이슈

close #590

## 작업 배경

관리자 영역은 현재 운영 프로필에서 Basic auth 계정 검증과 역할 분리를 수행하지만, 상용 출시 전 lockout 정책 또는 OIDC/MFA/SSO 전환 결정이 release gate에 명시적으로 고정되어 있지 않았다. 이 상태에서는 관리자 인증의 남은 보안 판단이 PR 검증 증거에서 누락될 수 있으므로 출시 차단 기준으로 기록한다.

## 작업 내용

- `release-security-gate.json`에 `backend_admin_basic_auth_transition_gate` release-blocker 항목을 추가했다.
- Basic auth가 임시 운영 보호 수단임을 명시하고, 상용 출시 전 lockout 또는 OIDC/MFA/SSO 전환 결정과 구현 증거를 요구하도록 했다.
- repository contract 테스트가 해당 gate의 evidence와 linked artifact를 검증하도록 보강했다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "릴리즈 보안 기준선" tools/ci/repository-contract.test.mjs` 통과: 1개 테스트 pass, fail 0
  - `node --test tools/ci/*.test.mjs` 통과: 77개 테스트 pass, fail 0
  - `git diff --check` 통과
  - `git ls-files '*.md'` 확인: `.github/pull_request_template.md`, `README.md`만 출력
  - `node -e "JSON.parse(require('fs').readFileSync('apps/mobile/release/release-security-gate.json','utf8')); console.log('release-security-gate.json ok')"` 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 관리자 Basic auth 전환 gate | repository | focused contract test | `node --test --test-name-pattern "릴리즈 보안 기준선" tools/ci/repository-contract.test.mjs` 출력: 1 pass, 0 fail | 통과 |
| repository contract | repository | 전체 CI 계약 테스트 | `node --test tools/ci/*.test.mjs` 출력: 77 pass, 0 fail | 통과 |
| Markdown 추적 제한 | repository | tracked Markdown 목록 확인 | `git ls-files '*.md'` 출력: `.github/pull_request_template.md`, `README.md` | 통과 |
| release gate JSON 구문 | repository | JSON parse 확인 | `release-security-gate.json ok` 출력 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `backend_admin_basic_auth_transition_gate`의 `readyWhenKo`, `evidence`, `linkedArtifacts`가 상용 출시 전 관리자 인증 전환 판단을 충분히 차단하는지 확인해 주세요.

## 리스크

- 런타임 인증 동작은 변경하지 않는다. 이번 PR은 상용 출시 전 보안 전환 기준을 release gate와 contract test에 고정하는 변경이다.
- 실제 lockout 구현 또는 OIDC/MFA/SSO 연동은 별도 작업으로 남아 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
