### PR TITLE
[Fix] 관리자 Basic auth 실패 잠금 추가

### DIFF
--- a/apps/mobile/release/release-security-gate.json
+++ b/apps/mobile/release/release-security-gate.json
@@ -71,9 +71,9 @@
       "severity": "release-blocker",
       "titleKo": "관리자 Basic auth 운영 전환 기준",
       "ownerKo": "백엔드/운영 담당",
-      "readyWhenKo": "현재 Basic auth는 임시 운영 보호 수단이며, 상용 출시 전에는 lockout 정책 또는 OIDC/MFA/SSO 전환 결정과 구현 증거가 PR 검증 증거에 남아야 한다.",
-      "evidence": ["admin-auth-transition-decision-record", "lockout-or-oidc-mfa-implementation-evidence", "admin-security-config-review"],
-      "linkedArtifacts": ["backend/src/main/java/com/easysubway/common/security/SecurityConfig.java", ".github/pull_request_template.md", "tools/ci/repository-contract.test.mjs"]
+      "readyWhenKo": "현재 Basic auth는 임시 운영 보호 수단이며, 상용 출시 전에는 관리자와 운영기관 인증 실패 lockout 정책 또는 OIDC/MFA/SSO 전환 결정과 구현 증거가 PR 검증 증거에 남아야 한다.",
+      "evidence": ["admin-auth-transition-decision-record", "lockout-or-oidc-mfa-implementation-evidence", "admin-basic-auth-lockout-tests", "admin-security-config-review"],
+      "linkedArtifacts": ["backend/src/main/java/com/easysubway/common/security/SecurityConfig.java", "backend/src/main/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProvider.java", "backend/src/test/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProviderTest.java", ".github/pull_request_template.md", "tools/ci/repository-contract.test.mjs"]
     },
     {
       "id": "backend_role_authorization",

--- a/backend/src/main/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProvider.java
+++ b/backend/src/main/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProvider.java
@@ -1,0 +1,104 @@
+package com.easysubway.common.security;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.util.Assert;
+
+public class AdminOperatorLockoutAuthenticationProvider implements AuthenticationProvider {
+
+	private final DaoAuthenticationProvider delegate = new DaoAuthenticationProvider();
+	private final Set<String> protectedUsernames;
+	private final int maxFailures;
+	private final Duration lockoutDuration;
+	private final Clock clock;
+	private final ConcurrentMap<String, AttemptState> attemptsByUsername = new ConcurrentHashMap<>();
+
+	public AdminOperatorLockoutAuthenticationProvider(
+		UserDetailsService userDetailsService,
+		PasswordEncoder passwordEncoder,
+		Collection<String> protectedUsernames,
+		int maxFailures,
+		Duration lockoutDuration,
+		Clock clock
+	) {
+		Assert.isTrue(maxFailures > 0, "maxFailures must be positive");
+		Assert.isTrue(!lockoutDuration.isNegative() && !lockoutDuration.isZero(), "lockoutDuration must be positive");
+		this.delegate.setUserDetailsService(userDetailsService);
+		this.delegate.setPasswordEncoder(passwordEncoder);
+		this.protectedUsernames = protectedUsernames.stream()
+			.filter(username -> username != null && !username.isBlank())
+			.map(AdminOperatorLockoutAuthenticationProvider::normalize)
+			.collect(Collectors.toUnmodifiableSet());
+		this.maxFailures = maxFailures;
+		this.lockoutDuration = lockoutDuration;
+		this.clock = clock;
+	}
+
+	@Override
+	public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+		String username = normalize(authentication.getName());
+		if (!protectedUsernames.contains(username)) {
+			return delegate.authenticate(authentication);
+		}
+
+		rejectIfLocked(username);
+		try {
+			Authentication result = delegate.authenticate(authentication);
+			attemptsByUsername.remove(username);
+			return result;
+		} catch (BadCredentialsException exception) {
+			recordFailure(username);
+			throw exception;
+		}
+	}
+
+	@Override
+	public boolean supports(Class<?> authentication) {
+		return delegate.supports(authentication);
+	}
+
+	private void rejectIfLocked(String username) {
+		AttemptState state = attemptsByUsername.get(username);
+		if (state == null || state.lockedUntil == null) {
+			return;
+		}
+		if (state.lockedUntil.isAfter(clock.instant())) {
+			throw new LockedException("관리자 인증 실패 횟수가 초과되었습니다.");
+		}
+		attemptsByUsername.remove(username, state);
+	}
+
+	private void recordFailure(String username) {
+		Instant now = clock.instant();
+		attemptsByUsername.compute(username, (key, current) -> {
+			int failures = current == null ? 1 : current.failures + 1;
+			Instant lockedUntil = failures >= maxFailures ? now.plus(lockoutDuration) : null;
+			return new AttemptState(failures, lockedUntil);
+		});
+	}
+
+	private static String normalize(String username) {
+		if (username == null) {
+			return "";
+		}
+		return username.toLowerCase(Locale.ROOT);
+	}
+
+	private record AttemptState(int failures, Instant lockedUntil) {
+	}
+}

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -1,11 +1,15 @@
 package com.easysubway.common.security;
 
+import java.time.Clock;
+import java.time.Duration;
 import java.util.Arrays;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -124,6 +128,25 @@ public class SecurityConfig {
 				.build());
 		}
 		return users;
+	}
+
+	@Bean
+	AuthenticationProvider adminOperatorLockoutAuthenticationProvider(
+		ConcurrentUserDetailsManager userDetailsService,
+		PasswordEncoder passwordEncoder,
+		@Value("${easysubway.admin.username:}") String adminUsername,
+		@Value("${easysubway.operator.username:}") String operatorUsername,
+		@Value("${easysubway.admin.lockout.max-failures:5}") int maxFailures,
+		@Value("${easysubway.admin.lockout.duration:PT15M}") String lockoutDuration
+	) {
+		return new AdminOperatorLockoutAuthenticationProvider(
+			userDetailsService,
+			passwordEncoder,
+			List.of(adminUsername, operatorUsername),
+			maxFailures,
+			Duration.parse(lockoutDuration),
+			Clock.systemUTC()
+		);
 	}
 
 	@Bean

--- a/backend/src/test/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProviderTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProviderTest.java
@@ -1,0 +1,114 @@
+package com.easysubway.common.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+
+@DisplayName("관리자 Basic auth 실패 잠금 provider")
+class AdminOperatorLockoutAuthenticationProviderTest {
+
+	@Test
+	@DisplayName("잠금 기간이 지나면 올바른 비밀번호 인증을 다시 허용한다")
+	void lockoutExpiresAfterDuration() {
+		var clock = new MutableClock(Instant.parse("2026-06-22T00:00:00Z"));
+		var provider = provider(clock, List.of("admin-user"), 2, Duration.ofMinutes(5));
+
+		assertThatThrownBy(() -> provider.authenticate(token("admin-user", "bad-password")))
+			.isInstanceOf(BadCredentialsException.class);
+		assertThatThrownBy(() -> provider.authenticate(token("admin-user", "bad-password")))
+			.isInstanceOf(BadCredentialsException.class);
+		assertThatThrownBy(() -> provider.authenticate(token("admin-user", "admin-password")))
+			.isInstanceOf(LockedException.class);
+
+		clock.advance(Duration.ofMinutes(5).plusSeconds(1));
+
+		assertThat(provider.authenticate(token("admin-user", "admin-password")).isAuthenticated())
+			.isTrue();
+	}
+
+	@Test
+	@DisplayName("보호 대상이 아닌 사용자는 실패 누적으로 잠기지 않는다")
+	void nonProtectedUserDoesNotLock() {
+		var provider = provider(new MutableClock(Instant.parse("2026-06-22T00:00:00Z")), List.of("admin-user"), 2,
+			Duration.ofMinutes(5));
+
+		assertThatThrownBy(() -> provider.authenticate(token("app-user", "bad-password")))
+			.isInstanceOf(BadCredentialsException.class);
+		assertThatThrownBy(() -> provider.authenticate(token("app-user", "bad-password")))
+			.isInstanceOf(BadCredentialsException.class);
+
+		assertThat(provider.authenticate(token("app-user", "app-password")).isAuthenticated())
+			.isTrue();
+	}
+
+	private AdminOperatorLockoutAuthenticationProvider provider(
+		Clock clock,
+		List<String> protectedUsernames,
+		int maxFailures,
+		Duration lockoutDuration
+	) {
+		var users = new ConcurrentUserDetailsManager();
+		var passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+		users.createUser(User.withUsername("admin-user")
+			.password(passwordEncoder.encode("admin-password"))
+			.roles("ADMIN")
+			.build());
+		users.createUser(User.withUsername("app-user")
+			.password(passwordEncoder.encode("app-password"))
+			.roles("USER")
+			.build());
+		return new AdminOperatorLockoutAuthenticationProvider(
+			users,
+			passwordEncoder,
+			protectedUsernames,
+			maxFailures,
+			lockoutDuration,
+			clock
+		);
+	}
+
+	private Authentication token(String username, String password) {
+		return UsernamePasswordAuthenticationToken.unauthenticated(username, password);
+	}
+
+	private static final class MutableClock extends Clock {
+
+		private Instant instant;
+
+		private MutableClock(Instant instant) {
+			this.instant = instant;
+		}
+
+		@Override
+		public ZoneId getZone() {
+			return ZoneId.of("UTC");
+		}
+
+		@Override
+		public Clock withZone(ZoneId zone) {
+			return this;
+		}
+
+		@Override
+		public Instant instant() {
+			return instant;
+		}
+
+		private void advance(Duration duration) {
+			instant = instant.plus(duration);
+		}
+	}
+}

--- a/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
@@ -1,6 +1,7 @@
 package com.easysubway.common.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -8,6 +9,11 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
@@ -89,6 +95,67 @@ class SecurityConfigTest {
 				assertThat(context.getStartupFailure())
 					.hasMessageContaining("운영기관 관리자 계정 설정은 아이디와 비밀번호를 함께 입력해야 합니다.");
 			});
+	}
+
+	@Test
+	@DisplayName("관리자 Basic auth는 연속 실패 후 잠금 기간 동안 올바른 비밀번호도 거절한다")
+	void adminBasicAuthLocksAfterConsecutiveFailures() {
+		contextRunner
+			.withPropertyValues(
+				"easysubway.admin.username=admin-user",
+				"easysubway.admin.password=admin-password",
+				"easysubway.admin.lockout.max-failures=2",
+				"easysubway.admin.lockout.duration=PT10M"
+			)
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				AuthenticationManager authenticationManager = context.getBean(AuthenticationConfiguration.class)
+					.getAuthenticationManager();
+
+				assertThatThrownBy(() -> authenticate(authenticationManager, "admin-user", "bad-password"))
+					.isInstanceOf(BadCredentialsException.class);
+				assertThatThrownBy(() -> authenticate(authenticationManager, "admin-user", "bad-password"))
+					.isInstanceOf(BadCredentialsException.class);
+				assertThatThrownBy(() -> authenticate(authenticationManager, "admin-user", "admin-password"))
+					.isInstanceOf(LockedException.class)
+					.hasMessageContaining("관리자 인증 실패 횟수가 초과되었습니다.");
+			});
+	}
+
+	@Test
+	@DisplayName("운영기관 Basic auth 성공은 실패 카운터를 초기화한다")
+	void operatorBasicAuthSuccessResetsFailureCounter() {
+		contextRunner
+			.withPropertyValues(
+				"easysubway.operator.username=operator-user",
+				"easysubway.operator.password=operator-password",
+				"easysubway.admin.lockout.max-failures=2",
+				"easysubway.admin.lockout.duration=PT10M"
+			)
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				AuthenticationManager authenticationManager = context.getBean(AuthenticationConfiguration.class)
+					.getAuthenticationManager();
+
+				assertThatThrownBy(() -> authenticate(authenticationManager, "operator-user", "bad-password"))
+					.isInstanceOf(BadCredentialsException.class);
+				assertThat(authenticate(authenticationManager, "operator-user", "operator-password").isAuthenticated())
+					.isTrue();
+				assertThatThrownBy(() -> authenticate(authenticationManager, "operator-user", "bad-password"))
+					.isInstanceOf(BadCredentialsException.class);
+				assertThat(authenticate(authenticationManager, "operator-user", "operator-password").isAuthenticated())
+					.isTrue();
+			});
+	}
+
+	private org.springframework.security.core.Authentication authenticate(
+		AuthenticationManager authenticationManager,
+		String username,
+		String password
+	) {
+		return authenticationManager.authenticate(
+			UsernamePasswordAuthenticationToken.unauthenticated(username, password)
+		);
 	}
 
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3948,6 +3948,9 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   const gitignore = read(".gitignore");
   const commonExceptionHandler = read("backend/src/main/java/com/easysubway/common/web/CommonExceptionHandler.java");
   const securityConfig = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
+  const adminOperatorLockoutProvider = read(
+    "backend/src/main/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProvider.java",
+  );
   const facilityReportPhotoProcessor = read(
     "backend/src/main/java/com/easysubway/report/application/service/FacilityReportPhotoProcessor.java",
   );
@@ -4016,8 +4019,14 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.match(adminBasicAuthGate.readyWhenKo, /Basic auth/);
   assert.ok(adminBasicAuthGate.evidence.includes("admin-auth-transition-decision-record"));
   assert.ok(adminBasicAuthGate.evidence.includes("lockout-or-oidc-mfa-implementation-evidence"));
+  assert.ok(adminBasicAuthGate.evidence.includes("admin-basic-auth-lockout-tests"));
   assert.ok(adminBasicAuthGate.linkedArtifacts.includes("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java"));
+  assert.ok(adminBasicAuthGate.linkedArtifacts.includes("backend/src/main/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProvider.java"));
+  assert.ok(adminBasicAuthGate.linkedArtifacts.includes("backend/src/test/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProviderTest.java"));
   assert.ok(adminBasicAuthGate.linkedArtifacts.includes(".github/pull_request_template.md"));
+  assert.match(adminOperatorLockoutProvider, /LockedException/);
+  assert.match(adminOperatorLockoutProvider, /BadCredentialsException/);
+  assert.match(adminOperatorLockoutProvider, /lockedUntil/);
   assert.match(facilityReportPhotoProcessor, /MAX_PHOTO_BYTES = 900 \* 1024/);
   assert.match(facilityReportPhotoProcessor, /MAX_PHOTO_WIDTH = 4_096/);
   assert.match(facilityReportPhotoProcessor, /MAX_PHOTO_PIXELS = 12_000_000/);


### PR DESCRIPTION
## 관련 이슈

close #592

## 작업 배경

관리자와 운영자 Basic auth는 상용 출시 전 임시 운영 경로로 남아 있지만, 반복 실패에 대한 잠금 정책이 없으면 credential stuffing이나 무차별 대입 시도를 계정 단위로 제한할 수 없다. 기존 운영 credential 검증과 역할 계약은 유지하면서, 관리자/운영자 계정에만 실패 횟수 기반 잠금 경계를 추가한다.

## 작업 내용

- 관리자/운영자 username을 대상으로 하는 `AdminOperatorLockoutAuthenticationProvider`를 추가했다.
- 보호 대상 계정은 연속 인증 실패가 설정된 횟수에 도달하면 설정된 기간 동안 `LockedException`으로 인증을 거부한다.
- 정상 인증 성공 시 해당 계정의 실패 카운터를 초기화한다.
- 보호 대상이 아닌 계정은 기존 인증 흐름으로 위임해 잠금 정책을 적용하지 않는다.
- 릴리즈 보안 게이트와 repository contract에 관리자 Basic auth 잠금 증거 요구사항을 반영했다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew check`: 성공
  - `node --test tools/ci/*.test.mjs`: 성공, 77개 통과
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 출력

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 관리자/운영자 실패 잠금 | Backend | `cd backend && ./gradlew check` | `SecurityConfigTest`, `AdminOperatorLockoutAuthenticationProviderTest` 실행 | 성공 |
| 릴리즈 보안 게이트 계약 | Repository | `node --test tools/ci/*.test.mjs` | repository contract 77개 통과 | 성공 |
| Markdown 업로드 정책 | Repository | `git ls-files '*.md'` | `.github/pull_request_template.md`, `README.md`만 추적 | 성공 |
| Whitespace | Repository | `git diff --check` | 출력 없음 | 성공 |
| 화면 증거 | Backend | UI 변경 없음 | 증거 불필요 사유: 인증 provider, backend test, release gate JSON만 변경 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `AdminOperatorLockoutAuthenticationProvider`가 보호 대상 계정에만 잠금을 적용하고 성공 시 실패 카운터를 초기화하는지
  - `SecurityConfig`의 기본 잠금 횟수와 기간이 prod credential validation 계약을 깨지 않는지
  - 릴리즈 보안 게이트가 실제 테스트 파일과 provider를 증거로 요구하는지

## 리스크

- 잠금 상태는 현재 프로세스 메모리 기반이다. 단일 backend 인스턴스에서는 즉시 동작하지만, 다중 인스턴스 운영에서는 분산 저장소 기반 잠금 또는 OIDC/MFA 전환이 별도 후속으로 필요하다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
