### PR TITLE
[Fix] 릴리즈 비밀값 노출 방지 계약 추가

### DIFF
--- a/apps/mobile/release/release-security-gate.json
+++ b/apps/mobile/release/release-security-gate.json
@@ -136,6 +136,16 @@
       "linkedArtifacts": [".gitignore", ".env.example", ".github/workflows/ci.yml", "tools/ci/repository-contract.test.mjs"]
     },
     {
+      "id": "repository_provider_storage_exposure_guard",
+      "area": "repository",
+      "severity": "release-blocker",
+      "titleKo": "provider key와 object storage 노출 방지",
+      "ownerKo": "보안/릴리즈 담당",
+      "readyWhenKo": "모바일 릴리즈 산출물은 provider key, object storage credential, signed URL을 직접 포함하지 않고, 백엔드가 짧은 만료 signed upload URL만 발급하며 로그와 감사 기록에는 upload intent와 receipt token 원문을 남기지 않는다.",
+      "evidence": ["release-artifact-credential-search", "signed-upload-url-expiry-contract", "sensitive-log-redaction-review"],
+      "linkedArtifacts": [".github/workflows/release-artifacts.yml", "backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportUploadIntentsTest.java", "backend/src/main/java/com/easysubway/report/adapter/out/storage/ObjectStorageFacilityReportPhotoStorage.java", "tools/ci/repository-contract.test.mjs"]
+    },
+    {
       "id": "repository_dependency_review",
       "area": "repository",
       "severity": "release-blocker",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3945,6 +3945,7 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   const androidDebugManifest = read("apps/mobile/android/app/src/debug/AndroidManifest.xml");
   const androidProfileManifest = read("apps/mobile/android/app/src/profile/AndroidManifest.xml");
   const androidBuildGradle = read("apps/mobile/android/app/build.gradle.kts");
+  const releaseArtifactsWorkflow = read(".github/workflows/release-artifacts.yml");
   const gitignore = read(".gitignore");
   const commonExceptionHandler = read("backend/src/main/java/com/easysubway/common/web/CommonExceptionHandler.java");
   const securityConfig = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
@@ -3978,6 +3979,7 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
     "backend_api_traffic_monitoring",
     "backend_sensitive_log_minimization",
     "repository_secrets_not_tracked",
+    "repository_provider_storage_exposure_guard",
     "repository_dependency_review",
     "repository_codex_security_scan_before_release",
     "cross_store_privacy_security_consistency",
@@ -4039,6 +4041,16 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.match(gitignore, /^\*.pem$/m);
   assert.match(gitignore, /^\*.key$/m);
   assert.match(gitignore, /^google-services\.json$/m);
+  const providerStorageExposureGuard = items.get("repository_provider_storage_exposure_guard");
+  assert.match(providerStorageExposureGuard.readyWhenKo, /provider key|object storage|signed URL/i);
+  assert.ok(providerStorageExposureGuard.evidence.includes("release-artifact-credential-search"));
+  assert.ok(providerStorageExposureGuard.evidence.includes("signed-upload-url-expiry-contract"));
+  assert.ok(providerStorageExposureGuard.linkedArtifacts.includes(".github/workflows/release-artifacts.yml"));
+  assert.ok(providerStorageExposureGuard.linkedArtifacts.includes("backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportUploadIntentsTest.java"));
+  assert.ok(providerStorageExposureGuard.linkedArtifacts.includes("tools/ci/repository-contract.test.mjs"));
+  assert.doesNotMatch(releaseArtifactsWorkflow, /EASYSUBWAY_OBJECT_STORAGE_(?:ACCESS_KEY|SECRET_KEY|ENDPOINT|REGION)/);
+  assert.doesNotMatch(releaseArtifactsWorkflow, /EASYSUBWAY_[A-Z0-9_]*(?:PROVIDER|REALTIME)[A-Z0-9_]*KEY/);
+  assert.doesNotMatch(androidBuildGradle, /EASYSUBWAY_OBJECT_STORAGE|PROVIDER_API_KEY|REALTIME_PROVIDER_KEY/);
   const dependencyReview = items.get("repository_dependency_review");
   assert.ok(dependencyReview.evidence.includes("osv-scanner-pr-result"));
   assert.match(dependencyReview.readyWhenKo, /OSV Scanner|취약/);


### PR DESCRIPTION
## 관련 이슈

close #594

## 작업 배경

출시 전 보안 기준에는 provider key, object storage credential, signed upload URL, receipt token, upload intent가 모바일 릴리즈 산출물이나 로그에 노출되지 않아야 한다는 조건이 필요하다. 기존 signed upload 경로와 단일 dotenv secret 계약은 있지만, 릴리즈 게이트와 repository contract가 이 조건을 직접 고정하지 않아 회귀를 놓칠 수 있었다.

## 작업 내용

- release security gate에 `repository_provider_storage_exposure_guard` 항목을 추가했다.
- 모바일 릴리즈 산출물 workflow와 Android release build 설정이 object storage credential 또는 provider key를 직접 주입하지 않는지 repository contract로 검증한다.
- signed upload URL 만료 계약과 민감 로그 redaction 검토를 PR 증거 요구사항으로 연결했다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "릴리즈 보안 기준선" tools/ci/repository-contract.test.mjs`: 새 gate 누락 상태에서 실패 확인 후 통과
  - `node --test tools/ci/*.test.mjs`: 성공, 77개 통과
  - `cd backend && ./gradlew check`: 성공
  - `git diff --check`: 성공
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 출력

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 릴리즈 비밀값 노출 방지 gate | Repository | `node --test --test-name-pattern "릴리즈 보안 기준선" tools/ci/repository-contract.test.mjs` | gate 누락 RED 후 GREEN | 성공 |
| repository contract 전체 | Repository | `node --test tools/ci/*.test.mjs` | 77개 통과 | 성공 |
| backend 회귀 확인 | Backend | `cd backend && ./gradlew check` | Gradle check 통과 | 성공 |
| Markdown 업로드 정책 | Repository | `git ls-files '*.md'` | `.github/pull_request_template.md`, `README.md`만 추적 | 성공 |
| 화면 증거 | Repository | UI 변경 없음 | 증거 불필요 사유: release gate JSON과 repository contract만 변경 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 새 release security gate 항목이 provider key, object storage credential, signed URL 비노출 조건을 충분히 명시하는지
  - repository contract의 release workflow/Android build 설정 정규식이 과도하거나 부족하지 않은지

## 리스크

- 이 PR은 release gate와 static contract를 강화한다. 실제 production object storage credential 주입이나 publish 동작은 #547 소유 범위라 변경하지 않았다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
