### PR TITLE
[Build] 백업 복구 리허설 기준선 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Migration 실패를 무시하고 DB를 삭제하거나 재생성하지 않습니
 
 운영 로그와 artifact에는 receipt token, upload URL, photo metadata를 남기지 않습니다. 장애 증거에는 app version, datapack version, route engine version, provider snapshot id를 함께 기록해야 하며, 외부 provider나 store console이 필요한 신호는 PR 검증 증거에 외부 차단 조건과 남은 리스크를 기록합니다.
 
+백업과 복구 리허설 기준선은 `apps/mobile/release/backup-restore-rehearsal-gate.json`으로 검증합니다. PR과 릴리즈 후보에서는 `node tools/ops/backup-restore-rehearsal-check.mjs`로 PostgreSQL dump, 신고 사진 object manifest, 데이터팩 source inventory, 데이터팩 release manifest history가 모두 복구 리허설 대상에 포함되는지 확인합니다. 실제 database dump, 사진 object, signed URL, credential, receipt token은 GitHub에 올리지 않고 `.codex/evidence/backup-restore-rehearsal/<date>/` 아래 로컬 전용 증거로만 보관합니다.
+
 ## Workflow
 
 Tracked work follows this order:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Migration 실패를 무시하고 DB를 삭제하거나 재생성하지 않습니
 
 운영 로그와 artifact에는 receipt token, upload URL, photo metadata를 남기지 않습니다. 장애 증거에는 app version, datapack version, route engine version, provider snapshot id를 함께 기록해야 하며, 외부 provider나 store console이 필요한 신호는 PR 검증 증거에 외부 차단 조건과 남은 리스크를 기록합니다.
 
-백업과 복구 리허설 기준선은 `apps/mobile/release/backup-restore-rehearsal-gate.json`으로 검증합니다. PR과 릴리즈 후보에서는 `node tools/ops/backup-restore-rehearsal-check.mjs`로 PostgreSQL dump, 신고 사진 object manifest, 데이터팩 source inventory, 데이터팩 release manifest history가 모두 복구 리허설 대상에 포함되는지 확인합니다. 실제 database dump, 사진 object, signed URL, credential, receipt token은 GitHub에 올리지 않고 `.codex/evidence/backup-restore-rehearsal/<date>/` 아래 로컬 전용 증거로만 보관합니다.
+백업과 복구 리허설 기준선은 `apps/mobile/release/backup-restore-rehearsal-gate.json`으로 검증합니다. PR과 릴리즈 후보에서는 `node tools/ops/backup-restore-rehearsal-check.mjs`로 PostgreSQL dump, 신고 사진 object manifest, 데이터팩 source inventory, 데이터팩 release manifest history가 모두 복구 리허설 대상에 포함되는지 확인하고, 신고 사진 백업은 `node tools/ops/facility-report-photo-restore-check.mjs "$EASYSUBWAY_PHOTO_RESTORE_DIR"`로 `manifest.tsv`와 `objects/` 산출물을 검증합니다. 실제 database dump, 사진 object, signed URL, credential, receipt token은 GitHub에 올리지 않고 `.codex/evidence/backup-restore-rehearsal/<date>/` 아래 로컬 전용 증거로만 보관합니다.
 
 ## Workflow
 

--- a/apps/mobile/release/backup-restore-rehearsal-gate.json
+++ b/apps/mobile/release/backup-restore-rehearsal-gate.json
@@ -1,0 +1,88 @@
+{
+  "schemaVersion": 1,
+  "applicationId": "easysubway",
+  "releaseGate": "backup-restore-rehearsal",
+  "releaseBlockerPolicy": true,
+  "policyRefreshKo": "상용 배포 전 백업 대상과 복구 리허설 경로를 최신 main 기준으로 확인한다.",
+  "backupTargets": [
+    {
+      "id": "postgres_application_database",
+      "area": "database",
+      "ownerKo": "백엔드 운영 담당자",
+      "backupCommand": "tools/ops/postgres-backup.sh",
+      "restoreRehearsalCommand": "tools/ops/postgres-restore-rehearsal.sh <backup-file>",
+      "successEvidence": "restore rehearsal succeeded 로그와 격리 restore database 생성/삭제 확인",
+      "failureConditions": [
+        "pg_dump 산출물이 비어 있음",
+        "보호 database 이름으로 restore 시도",
+        "pg_restore 실패"
+      ],
+      "linkedArtifacts": [
+        "tools/ops/postgres-backup.sh",
+        "tools/ops/postgres-restore-rehearsal.sh",
+        "infra/docker-compose.yml",
+        "backend/src/main/resources/application-prod.yml"
+      ]
+    },
+    {
+      "id": "facility_report_photo_objects",
+      "area": "object-storage",
+      "ownerKo": "신고 운영 담당자",
+      "backupCommand": "tools/ops/facility-report-photo-backup.sh",
+      "restoreRehearsalCommand": "tools/ops/backup-restore-rehearsal-check.mjs",
+      "successEvidence": "manifest.tsv와 objects 경로가 생성되고 누락 object key가 없음을 확인",
+      "failureConditions": [
+        "photo object key가 비어 있거나 경로 traversal을 포함함",
+        "manifest에 있는 object file이 로컬 storage에 없음",
+        "manifest column이 누락됨"
+      ],
+      "linkedArtifacts": [
+        "tools/ops/facility-report-photo-backup.sh",
+        "backend/src/main/resources/db/migration/postgresql/V2__facility_report_photo_object_storage.sql",
+        "README.md"
+      ]
+    },
+    {
+      "id": "datapack_source_inventory",
+      "area": "datapack",
+      "ownerKo": "데이터팩 운영 담당자",
+      "backupCommand": "tools/ops/data-source-raw-archive.sh",
+      "restoreRehearsalCommand": "node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json",
+      "successEvidence": "source archive manifest와 source-inventory validation 통과",
+      "failureConditions": [
+        "source inventory license 또는 updatedAt 누락",
+        "source archive manifest가 비어 있음",
+        "official source 원본 경로가 재현 불가"
+      ],
+      "linkedArtifacts": [
+        "tools/ops/data-source-raw-archive.sh",
+        "tools/datapack/source-inventory.json",
+        "tools/datapack/validate-source-inventory.mjs"
+      ]
+    },
+    {
+      "id": "datapack_release_manifest_history",
+      "area": "datapack",
+      "ownerKo": "릴리즈 운영 담당자",
+      "backupCommand": "gh run download <data-pack-release-run> --name easysubway-datapacks-<sha>",
+      "restoreRehearsalCommand": "node tools/datapack/validate-datapack.mjs --manifest <restored>/catalog/current.json --root <restored>",
+      "successEvidence": "restored catalog/current.json과 pack sqlite checksum validation 통과",
+      "failureConditions": [
+        "manifest history artifact를 찾을 수 없음",
+        "current.json이 pack보다 먼저 복구됨",
+        "restored sqlite checksum이 manifest와 불일치"
+      ],
+      "linkedArtifacts": [
+        ".github/workflows/datapack-release.yml",
+        "tools/datapack/validate-datapack.mjs",
+        "tools/datapack/create-publish-plan.mjs"
+      ]
+    }
+  ],
+  "rehearsalPolicy": {
+    "frequencyKo": "월 1회 또는 릴리즈 후보 freeze 전 1회 실행한다.",
+    "dataSafetyKo": "운영 데이터 직접 복원 금지, 격리 restore database와 로컬 전용 object directory에서만 리허설한다.",
+    "requiredOutputKo": ".codex/evidence/backup-restore-rehearsal/<date>/ 아래 명령 출력, manifest checksum, 실패 조건 확인 결과를 로컬 전용으로 보관한다.",
+    "sensitiveDataPolicyKo": "database dump, 사진 object, signed URL, credential, receipt token은 GitHub에 업로드하지 않는다."
+  }
+}

--- a/apps/mobile/release/backup-restore-rehearsal-gate.json
+++ b/apps/mobile/release/backup-restore-rehearsal-gate.json
@@ -29,7 +29,7 @@
       "area": "object-storage",
       "ownerKo": "신고 운영 담당자",
       "backupCommand": "tools/ops/facility-report-photo-backup.sh",
-      "restoreRehearsalCommand": "tools/ops/backup-restore-rehearsal-check.mjs",
+      "restoreRehearsalCommand": "node tools/ops/facility-report-photo-restore-check.mjs \"$EASYSUBWAY_PHOTO_RESTORE_DIR\"",
       "successEvidence": "manifest.tsv와 objects 경로가 생성되고 누락 object key가 없음을 확인",
       "failureConditions": [
         "photo object key가 비어 있거나 경로 traversal을 포함함",
@@ -38,6 +38,7 @@
       ],
       "linkedArtifacts": [
         "tools/ops/facility-report-photo-backup.sh",
+        "tools/ops/facility-report-photo-restore-check.mjs",
         "backend/src/main/resources/db/migration/postgresql/V2__facility_report_photo_object_storage.sql",
         "README.md"
       ]

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile, execFileSync } from "node:child_process";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -1262,14 +1262,46 @@ test("시설 신고 사진 백업은 로컬 전용 객체와 manifest 기준선�
   assert.match(backupScript, /printf 'facility report photo backup written: %s\\n' "\$\{run_dir\}"/);
 });
 
+test("시설 신고 사진 복구 리허설은 manifest와 object 산출물을 검증한다", async () => {
+  const restoreCheckPath = "tools/ops/facility-report-photo-restore-check.mjs";
+  const restoreCheckScript = read(restoreCheckPath);
+  const fixtureDir = await mkdtemp(path.join(tmpdir(), "easysubway-photo-restore-"));
+  const objectsDir = path.join(fixtureDir, "objects", "facility-reports", "report-1");
+  const objectPath = path.join(objectsDir, "photo.jpg");
+  const objectBytes = Buffer.from("photo-bytes");
+  const objectSha256 = "dac6f451810bc38390a3b6e278d686b332a77cf21b2ea95145ad73722b77035d";
+
+  await mkdir(objectsDir, { recursive: true });
+  await writeFile(objectPath, objectBytes);
+  await writeFile(
+    path.join(fixtureDir, "manifest.tsv"),
+    [
+      "report_id\tfile_name\tcontent_type\tobject_key\tthumbnail_object_key\tsha256\tsize_bytes\tobject_path\tthumbnail_path",
+      `report-1\televator.jpg\timage/jpeg\tfacility-reports/report-1/photo.jpg\t\t${objectSha256}\t${objectBytes.length}\tobjects/facility-reports/report-1/photo.jpg\tobjects/`,
+    ].join("\n"),
+  );
+
+  assert.match(restoreCheckScript, /Usage: node tools\/ops\/facility-report-photo-restore-check\.mjs <restored-photo-backup-dir>/);
+  assert.match(restoreCheckScript, /manifest\.tsv/);
+  assert.match(restoreCheckScript, /object_path must match object_key/);
+  assert.match(restoreCheckScript, /object size mismatch/);
+  assert.match(restoreCheckScript, /object sha256 mismatch/);
+
+  const result = execFileSync(process.execPath, [restoreCheckPath, fixtureDir], { cwd: root, encoding: "utf8" });
+  assert.match(result, /facility report photo restore rehearsal ok/);
+});
+
 test("운영 백업 복구 리허설 gate는 필수 백업 대상과 dry-run 검증 명령을 고정한다", () => {
   const gatePath = "apps/mobile/release/backup-restore-rehearsal-gate.json";
   const checkScriptPath = "tools/ops/backup-restore-rehearsal-check.mjs";
+  const photoRestoreCheckPath = "tools/ops/facility-report-photo-restore-check.mjs";
   assert.ok(existsSync(path.join(root, gatePath)), "backup restore rehearsal gate artifact must exist");
   assert.ok(existsSync(path.join(root, checkScriptPath)), "backup restore rehearsal check script must exist");
+  assert.ok(existsSync(path.join(root, photoRestoreCheckPath)), "photo restore rehearsal check script must exist");
 
   const gate = readJson(gatePath);
   const checkScript = read(checkScriptPath);
+  const photoRestoreCheckScript = read(photoRestoreCheckPath);
   const readme = read("README.md");
 
   assert.equal(gate.schemaVersion, 1);
@@ -1299,14 +1331,27 @@ test("운영 백업 복구 리허설 gate는 필수 백업 대상과 dry-run 검
     }
   }
 
+  const photoTarget = backupTargets.get("facility_report_photo_objects");
+  assert.equal(
+    photoTarget.restoreRehearsalCommand,
+    'node tools/ops/facility-report-photo-restore-check.mjs "$EASYSUBWAY_PHOTO_RESTORE_DIR"',
+  );
+  assert.ok(
+    photoTarget.linkedArtifacts.includes(photoRestoreCheckPath),
+    "facility photo restore target must link the restore check script",
+  );
+
   assert.match(gate.rehearsalPolicy.frequencyKo, /월 1회|릴리즈/);
   assert.match(gate.rehearsalPolicy.dataSafetyKo, /운영 데이터 직접 복원 금지|격리/);
   assert.match(gate.rehearsalPolicy.requiredOutputKo, /backup-restore-rehearsal/);
   assert.match(checkScript, /backup-restore-rehearsal-gate\.json/);
   assert.match(checkScript, /postgres_application_database/);
   assert.match(checkScript, /datapack_release_manifest_history/);
+  assert.match(photoRestoreCheckScript, /manifest\.tsv/);
+  assert.match(photoRestoreCheckScript, /sha256/);
   assert.match(readme, /backup-restore-rehearsal-gate\.json/);
   assert.match(readme, /tools\/ops\/backup-restore-rehearsal-check\.mjs/);
+  assert.match(readme, /tools\/ops\/facility-report-photo-restore-check\.mjs/);
   assert.doesNotMatch(readme, /backup secret|restore secret/i);
 
   execFileSync(process.execPath, [checkScriptPath], { cwd: root, encoding: "utf8" });

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1262,6 +1262,56 @@ test("시설 신고 사진 백업은 로컬 전용 객체와 manifest 기준선�
   assert.match(backupScript, /printf 'facility report photo backup written: %s\\n' "\$\{run_dir\}"/);
 });
 
+test("운영 백업 복구 리허설 gate는 필수 백업 대상과 dry-run 검증 명령을 고정한다", () => {
+  const gatePath = "apps/mobile/release/backup-restore-rehearsal-gate.json";
+  const checkScriptPath = "tools/ops/backup-restore-rehearsal-check.mjs";
+  assert.ok(existsSync(path.join(root, gatePath)), "backup restore rehearsal gate artifact must exist");
+  assert.ok(existsSync(path.join(root, checkScriptPath)), "backup restore rehearsal check script must exist");
+
+  const gate = readJson(gatePath);
+  const checkScript = read(checkScriptPath);
+  const readme = read("README.md");
+
+  assert.equal(gate.schemaVersion, 1);
+  assert.equal(gate.applicationId, "easysubway");
+  assert.equal(gate.releaseGate, "backup-restore-rehearsal");
+  assert.equal(gate.releaseBlockerPolicy, true);
+  assert.doesNotMatch(JSON.stringify(gate), /\b(TBD|TODO|PLACEHOLDER)\b|\.{3}/i);
+
+  const backupTargets = new Map(gate.backupTargets.map((target) => [target.id, target]));
+  const requiredBackupTargetIds = [
+    "postgres_application_database",
+    "facility_report_photo_objects",
+    "datapack_source_inventory",
+    "datapack_release_manifest_history",
+  ];
+  assert.deepEqual([...backupTargets.keys()].sort(), requiredBackupTargetIds.toSorted());
+
+  for (const id of requiredBackupTargetIds) {
+    const target = backupTargets.get(id);
+    assert.match(target.ownerKo, /담당자/);
+    assert.ok(target.backupCommand.length > 0, `${id} must define backup command`);
+    assert.ok(target.restoreRehearsalCommand.length > 0, `${id} must define restore rehearsal command`);
+    assert.ok(target.successEvidence.length > 0, `${id} must define success evidence`);
+    assert.ok(target.failureConditions.length > 0, `${id} must define failure conditions`);
+    for (const artifact of target.linkedArtifacts) {
+      assert.ok(existsSync(path.join(root, artifact)), `${id} linked artifact must exist: ${artifact}`);
+    }
+  }
+
+  assert.match(gate.rehearsalPolicy.frequencyKo, /월 1회|릴리즈/);
+  assert.match(gate.rehearsalPolicy.dataSafetyKo, /운영 데이터 직접 복원 금지|격리/);
+  assert.match(gate.rehearsalPolicy.requiredOutputKo, /backup-restore-rehearsal/);
+  assert.match(checkScript, /backup-restore-rehearsal-gate\.json/);
+  assert.match(checkScript, /postgres_application_database/);
+  assert.match(checkScript, /datapack_release_manifest_history/);
+  assert.match(readme, /backup-restore-rehearsal-gate\.json/);
+  assert.match(readme, /tools\/ops\/backup-restore-rehearsal-check\.mjs/);
+  assert.doesNotMatch(readme, /backup secret|restore secret/i);
+
+  execFileSync(process.execPath, [checkScriptPath], { cwd: root, encoding: "utf8" });
+});
+
 test("저장소 지속적 통합은 Docker Compose 설정을 검증한다", () => {
   const workflow = read(".github/workflows/ci.yml");
 

--- a/tools/ops/backup-restore-rehearsal-check.mjs
+++ b/tools/ops/backup-restore-rehearsal-check.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const gatePath = path.join(root, "apps/mobile/release/backup-restore-rehearsal-gate.json");
+const gate = JSON.parse(readFileSync(gatePath, "utf8"));
+
+const requiredTargetIds = [
+  "postgres_application_database",
+  "facility_report_photo_objects",
+  "datapack_source_inventory",
+  "datapack_release_manifest_history",
+];
+
+assert.equal(gate.releaseGate, "backup-restore-rehearsal");
+assert.equal(gate.releaseBlockerPolicy, true);
+assert.doesNotMatch(JSON.stringify(gate), /\b(TBD|TODO|PLACEHOLDER)\b|\.{3}/i);
+
+const targets = new Map(gate.backupTargets.map((target) => [target.id, target]));
+assert.deepEqual([...targets.keys()].sort(), requiredTargetIds.toSorted());
+
+for (const id of requiredTargetIds) {
+  const target = targets.get(id);
+  assert.ok(target.ownerKo.includes("담당자"), `${id} owner must be assigned`);
+  assert.ok(target.backupCommand.length > 0, `${id} backup command must be defined`);
+  assert.ok(target.restoreRehearsalCommand.length > 0, `${id} restore command must be defined`);
+  assert.ok(target.successEvidence.length > 0, `${id} success evidence must be defined`);
+  assert.ok(target.failureConditions.length > 0, `${id} failure conditions must be defined`);
+
+  for (const artifact of target.linkedArtifacts) {
+    assert.ok(existsSync(path.join(root, artifact)), `${id} linked artifact missing: ${artifact}`);
+  }
+}
+
+assert.match(gate.rehearsalPolicy.frequencyKo, /월 1회|릴리즈/);
+assert.match(gate.rehearsalPolicy.dataSafetyKo, /운영 데이터 직접 복원 금지|격리/);
+assert.match(gate.rehearsalPolicy.requiredOutputKo, /backup-restore-rehearsal/);
+
+console.log("backup-restore-rehearsal gate ok");

--- a/tools/ops/facility-report-photo-restore-check.mjs
+++ b/tools/ops/facility-report-photo-restore-check.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const backupDir = process.argv[2] ?? process.env.EASYSUBWAY_PHOTO_RESTORE_DIR;
+
+if (!backupDir) {
+  console.error("Usage: node tools/ops/facility-report-photo-restore-check.mjs <restored-photo-backup-dir>");
+  process.exit(2);
+}
+
+const root = process.cwd();
+const restoredDir = path.resolve(root, backupDir);
+const manifestPath = path.join(restoredDir, "manifest.tsv");
+const expectedHeader = [
+  "report_id",
+  "file_name",
+  "content_type",
+  "object_key",
+  "thumbnail_object_key",
+  "sha256",
+  "size_bytes",
+  "object_path",
+  "thumbnail_path",
+];
+
+function assertSafeRelativeKey(value, label) {
+  assert.ok(value.length > 0, `${label} must not be empty`);
+  assert.equal(path.isAbsolute(value), false, `${label} must be relative`);
+  assert.equal(value.split(/[\\/]/).includes(".."), false, `${label} must not include traversal`);
+}
+
+function assertSafeOptionalKey(value, label) {
+  if (value.length === 0) {
+    return;
+  }
+  assertSafeRelativeKey(value, label);
+}
+
+function assertFileInsideBackup(relativePath, label) {
+  assertSafeRelativeKey(relativePath, label);
+  const resolvedPath = path.resolve(restoredDir, relativePath);
+  assert.ok(resolvedPath.startsWith(`${restoredDir}${path.sep}`), `${label} must stay inside backup directory`);
+  assert.ok(existsSync(resolvedPath), `${label} missing: ${relativePath}`);
+  return resolvedPath;
+}
+
+function sha256(filePath) {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+assert.ok(existsSync(restoredDir), `photo restore directory missing: ${restoredDir}`);
+assert.ok(existsSync(manifestPath), `photo restore manifest missing: ${manifestPath}`);
+
+const lines = readFileSync(manifestPath, "utf8").trimEnd().split(/\r?\n/);
+assert.ok(lines.length > 1, "photo restore manifest must contain at least one object row");
+assert.deepEqual(lines[0].split("\t"), expectedHeader);
+
+for (const [index, line] of lines.slice(1).entries()) {
+  const rowNumber = index + 2;
+  const columns = line.split("\t");
+  assert.equal(columns.length, expectedHeader.length, `manifest row ${rowNumber} must have ${expectedHeader.length} columns`);
+
+  const row = Object.fromEntries(expectedHeader.map((name, columnIndex) => [name, columns[columnIndex]]));
+  assert.ok(row.report_id.length > 0, `manifest row ${rowNumber} report_id must not be empty`);
+  assertSafeRelativeKey(row.object_key, `manifest row ${rowNumber} object_key`);
+  assertSafeOptionalKey(row.thumbnail_object_key, `manifest row ${rowNumber} thumbnail_object_key`);
+  assert.equal(row.object_path, `objects/${row.object_key}`, `manifest row ${rowNumber} object_path must match object_key`);
+
+  const objectFile = assertFileInsideBackup(row.object_path, `manifest row ${rowNumber} object_path`);
+
+  if (row.thumbnail_object_key.length > 0) {
+    assert.equal(
+      row.thumbnail_path,
+      `objects/${row.thumbnail_object_key}`,
+      `manifest row ${rowNumber} thumbnail_path must match thumbnail_object_key`,
+    );
+    assertFileInsideBackup(row.thumbnail_path, `manifest row ${rowNumber} thumbnail_path`);
+  } else {
+    assert.equal(row.thumbnail_path, "objects/", `manifest row ${rowNumber} thumbnail_path must be empty marker`);
+  }
+
+  if (row.size_bytes.length > 0) {
+    assert.match(row.size_bytes, /^\d+$/, `manifest row ${rowNumber} size_bytes must be numeric`);
+    assert.equal(statSync(objectFile).size, Number(row.size_bytes), `manifest row ${rowNumber} object size mismatch`);
+  }
+
+  if (row.sha256.length > 0) {
+    assert.match(row.sha256, /^[a-f0-9]{64}$/i, `manifest row ${rowNumber} sha256 must be hex`);
+    assert.equal(sha256(objectFile), row.sha256.toLowerCase(), `manifest row ${rowNumber} object sha256 mismatch`);
+  }
+}
+
+console.log(`facility report photo restore rehearsal ok: ${restoredDir}`);


### PR DESCRIPTION
## 관련 이슈

close #598

## 작업 배경

상용 배포 전 백업 대상과 복구 리허설 절차를 코드와 release gate로 확인할 수 있어야 합니다. PostgreSQL, 신고 사진 object, 데이터팩 source inventory, 데이터팩 release manifest history가 누락되면 장애 시 같은 시점의 데이터를 재구성할 수 없습니다.

## 작업 내용

- `apps/mobile/release/backup-restore-rehearsal-gate.json`을 추가해 필수 백업 대상, 복구 리허설 명령, 성공 증거, 실패 조건, linked artifact를 기계 검증 가능하게 고정했습니다.
- `tools/ops/backup-restore-rehearsal-check.mjs`를 추가해 gate artifact의 필수 대상과 artifact 경로를 비파괴 방식으로 검증하도록 했습니다.
- `tools/ops/facility-report-photo-restore-check.mjs`를 추가해 신고 사진 백업의 `manifest.tsv`, object key 안전성, object file 존재, size, sha256을 검증하도록 했습니다.
- README Operations 섹션에 백업/복구 리허설 gate와 민감 backup artifact 로컬 전용 보관 기준을 추가했습니다.
- repository contract가 새 gate와 photo restore checker를 실행하고 placeholder 설정을 거부하도록 확장했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "운영 백업 복구 리허설 gate" tools/ci/repository-contract.test.mjs`: RED에서 gate 파일 누락으로 실패 확인 후 GREEN 통과
  - `node --test --test-name-pattern "시설 신고 사진 복구 리허설|운영 백업 복구 리허설 gate" tools/ci/repository-contract.test.mjs`: 2개 통과
  - `node tools/ops/backup-restore-rehearsal-check.mjs`: `backup-restore-rehearsal gate ok`
  - `node --test tools/ci/*.test.mjs`: 80개 통과
  - `cd backend && ./gradlew check`: BUILD SUCCESSFUL
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 출력
  - PR checks: Android CI, Backend CI, Mobile App CI, iOS CI, Repository CI, Dependency Vulnerability Scan, Android Release Artifact, Backend Release Image, iOS Release Artifact 통과
  - CodeRabbit status: `CodeRabbit` check pass 확인, 수동 `@coderabbitai review` 트리거 없음
  - Codex CLI fallback review: review `4540149958` actionable 1건 게시, fix commit `53f28a8` 반영, original inline thread 해결 답글 작성 및 resolve, follow-up review `4540156380` actionable 0건
  - Merge: merge commit `d5cd2a8536692352a5ad2fe80f4aff6e49a7db17`, issue #598 closed
  - Post-merge main workflows: CI `27914801190`, CD `27914801041`, Release Artifacts `27914801044` 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 백업/복구 gate | repository | repository contract | `node --test --test-name-pattern "운영 백업 복구 리허설 gate" tools/ci/repository-contract.test.mjs` 통과 | 통과 |
| 신고 사진 복구 리허설 | repository | fixture 기반 contract | `node --test --test-name-pattern "시설 신고 사진 복구 리허설|운영 백업 복구 리허설 gate" tools/ci/repository-contract.test.mjs` 2개 통과 | 통과 |
| gate dry-run | repository | check script | `node tools/ops/backup-restore-rehearsal-check.mjs` 출력 `backup-restore-rehearsal gate ok` | 통과 |
| 전체 계약 | repository | contract suite | `node --test tools/ci/*.test.mjs` 80개 통과 | 통과 |
| 백엔드 영향 | backend | Gradle check | `cd backend && ./gradlew check` BUILD SUCCESSFUL | 통과 |
| 문서 추적 정책 | repository | tracked Markdown 확인 | `git ls-files '*.md'`가 PR template과 README만 출력 | 통과 |
| PR CI | GitHub Actions | required checks 확인 | Android CI, Backend CI, Mobile App CI, iOS CI, Repository CI, Dependency Vulnerability Scan, release artifact checks 통과 | 통과 |
| 코드 리뷰 | GitHub PR review | CodeRabbit 상태와 Codex fallback 확인 | CodeRabbit check pass, Codex review `4540149958` 지적 fix 후 `4540156380` actionable 0 | 통과 |
| Post-merge CI/CD | GitHub Actions main | merge commit workflow 확인 | CI `27914801190`, CD `27914801041`, Release Artifacts `27914801044` success | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `backup-restore-rehearsal-gate.json`의 네 백업 대상이 운영 복구 범위를 충분히 덮는지, 실패 조건이 실제 리허설에서 차단 조건으로 쓰기 충분한지 확인해 주세요.

## 리스크

- 실제 database dump와 사진 object는 민감한 로컬 증거이므로 PR에는 업로드하지 않습니다.
- 원격 object storage와 Data Pack Release publish는 별도 외부 public HTTPS 설정 blocker가 해결되어야 실제 원격 복구 리허설 증거까지 확장할 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
