### PR TITLE
[Docs] 경로 source contract 불변식 정리

### DIFF
--- a/apps/mobile/lib/features/routes/application/accessibility_cost_calculator.dart
+++ b/apps/mobile/lib/features/routes/application/accessibility_cost_calculator.dart
@@ -28,6 +28,10 @@ class AccessibilityCostCalculator {
         warningCodes: ['FACILITY_UNAVAILABLE'],
       );
     }
+
+    // route contract: unknown accessibility data
+    // Missing source data must not be treated as accessible for profiles that
+    // cannot safely use stairs; other profiles keep the route with a warning.
     if (edge.accessibilityState == RouteAccessibilityState.unknown) {
       if (mobilityType.blocksStairOnlyAccess) {
         return const AccessibilityCost(
@@ -39,6 +43,9 @@ class AccessibilityCostCalculator {
       warningCodes.add('ACCESSIBILITY_STATE_UNKNOWN');
     }
 
+    // route contract: stair-only block
+    // Stair-only or unknown stair state blocks wheelchair-style profiles and
+    // only becomes a penalty/warning for profiles that can still choose it.
     if (edge.stairAccessState == RouteStairAccessState.unknown) {
       if (mobilityType.blocksStairOnlyAccess) {
         return const AccessibilityCost(

--- a/apps/mobile/lib/features/routes/application/network_graph.dart
+++ b/apps/mobile/lib/features/routes/application/network_graph.dart
@@ -55,6 +55,12 @@ class RouteEdge {
   final String fromNodeId;
   final String toNodeId;
   final RouteEdgeType type;
+
+  /// route contract: baseCost seconds
+  ///
+  /// `baseCost` is the routing weight in seconds before profile penalties.
+  /// `durationSeconds` may stay 0 when source data has no reliable duration,
+  /// but route ordering still needs a positive fallback weight.
   final int baseCost;
   final int durationSeconds;
   final int distanceMeters;
@@ -62,6 +68,12 @@ class RouteEdge {
   final String transferStationId;
   final bool includesStairs;
   final RouteStairAccessState stairAccessState;
+
+  /// route contract: reliability thresholds
+  ///
+  /// 100 means verified or default confidence, values below 80 trigger a
+  /// low-confidence penalty, and UNKNOWN source accessibility data is capped
+  /// by the repository before it reaches the route engine.
   final int reliabilityScore;
   final bool isDataStale;
   final RouteAccessibilityState accessibilityState;

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -569,6 +569,11 @@ class _RouteCatalogSnapshot {
       }
     }
 
+    // route contract: synthetic connector edge
+    // These fixture-derived entry, exit, and transfer edges only connect known
+    // station-line nodes when explicit source edges are absent. They are
+    // step-free defaults for local fallback routing, not proof of field-verified
+    // elevator or ramp availability.
     for (final stationEntry in nodeKeysByStation.entries) {
       final stationId = stationEntry.key;
       final stationNodes = stationEntry.value.values.toList(growable: false);
@@ -762,6 +767,11 @@ graph.RouteEdge _toGraphRouteEdge(
   String? toNodeId,
 }) {
   final effectiveFromNodeId = fromNodeId ?? networkEdge.fromNodeId;
+
+  // route contract: local metric fallback
+  // Source durations of 0 keep `durationSeconds` at 0 so UI can say the time
+  // needs checking, while `baseCost` gets a conservative 60-second routing
+  // weight so the graph remains searchable.
   return graph.RouteEdge(
     id: id ?? networkEdge.id,
     fromNodeId: effectiveFromNodeId,
@@ -1026,6 +1036,8 @@ class _NetworkEdgeSnapshot {
   }
 
   int get effectiveReliabilityScore {
+    // UNKNOWN accessibility is stale by definition and cannot carry a high
+    // confidence score into accessibility-safe routing.
     if (_accessibilityStatusUpper == 'UNKNOWN' && reliabilityScore > 60) {
       return 60;
     }

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -847,6 +847,10 @@ String _routeDistanceLabel(int distanceMeters) {
 }
 
 String _routeTimeSourceLabel(String source) {
+  // route contract: realtime ETA fallback
+  // Local route results may carry STATIC_ESTIMATE when realtime providers are
+  // unavailable. Unknown labels must stay explicit instead of implying live ETA
+  // accuracy.
   return switch (source) {
     'STATIC_ESTIMATE' => '정적 추정',
     'REALTIME_ADJUSTED' => '실시간 보정',

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -882,6 +882,23 @@ test("공개 source contract 불변식은 README와 public interfaces에 남는�
   assert.match(userDatabase, /user-data preservation contract/);
 });
 
+test("경로 source contract 불변식은 접근성 안전과 metric fallback 의미를 고정한다", () => {
+  const networkGraph = read("apps/mobile/lib/features/routes/application/network_graph.dart");
+  const accessibilityCostCalculator = read(
+    "apps/mobile/lib/features/routes/application/accessibility_cost_calculator.dart",
+  );
+  const localRouteRepository = read("apps/mobile/lib/features/routes/data/local_route_repository.dart");
+  const routeSearch = read("apps/mobile/lib/route_search.dart");
+
+  assert.match(networkGraph, /route contract: baseCost seconds/);
+  assert.match(networkGraph, /route contract: reliability thresholds/);
+  assert.match(accessibilityCostCalculator, /route contract: unknown accessibility data/);
+  assert.match(accessibilityCostCalculator, /route contract: stair-only block/);
+  assert.match(localRouteRepository, /route contract: synthetic connector edge/);
+  assert.match(localRouteRepository, /route contract: local metric fallback/);
+  assert.match(routeSearch, /route contract: realtime ETA fallback/);
+});
+
 test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 보관 계약을 고정한다", () => {
   const gatePath = "apps/mobile/release/operations-observability-gate.json";
   assert.ok(existsSync(path.join(root, gatePath)), "operations observability gate artifact must exist");


### PR DESCRIPTION
## 관련 이슈

close #610

## 작업 배경

로컬 우선 경로 탐색은 데이터팩의 접근성 상태, 계단 여부, 정적 추정 시간, 신뢰도 값을 조합해 안내합니다. `UNKNOWN` 데이터와 synthetic connector edge는 실제 현장 검증을 의미하지 않으므로, 향후 경로 알고리즘이나 fixture 수정에서 접근성 안전 계약이 흐려지지 않도록 코드 수준 contract와 repository 검증을 추가했습니다.

## 작업 내용

- route graph의 `baseCost`, `durationSeconds`, `reliabilityScore` 의미를 public interface 주석으로 고정했습니다.
- 접근성 상태 `UNKNOWN`과 계단 전용/미확인 상태가 계단 차단 사용자에게 어떻게 차단되는지 contract 주석을 추가했습니다.
- local route repository의 synthetic entry/exit/transfer edge와 metric fallback 의미를 문서화했습니다.
- realtime ETA가 없을 때 `STATIC_ESTIMATE`가 live ETA를 의미하지 않도록 route UI label contract를 남겼습니다.
- repository contract에 route source contract marker 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "경로 source contract" tools/ci/repository-contract.test.mjs`: RED 후 pass, 1 test
  - `dart format apps/mobile/lib/features/routes/application/network_graph.dart apps/mobile/lib/features/routes/application/accessibility_cost_calculator.dart apps/mobile/lib/features/routes/data/local_route_repository.dart apps/mobile/lib/route_search.dart`: pass
  - `node --test tools/ci/*.test.mjs`: pass, 87 tests
  - `cd apps/mobile && flutter analyze`: pass, No issues found
  - `cd apps/mobile && flutter test`: pass, 331 tests
  - `git diff --check`: pass
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md` only

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 경로 source contract marker | repository | repository contract | `node --test --test-name-pattern "경로 source contract" tools/ci/repository-contract.test.mjs` | pass, 1 test |
| 저장소 contract 전체 | repository | Node test runner | `node --test tools/ci/*.test.mjs` | pass, 87 tests |
| 모바일 정적 분석 | mobile | Flutter analyzer | `cd apps/mobile && flutter analyze` | pass, No issues found |
| 모바일 테스트 | mobile | Flutter tests | `cd apps/mobile && flutter test` | pass, 331 tests |
| Markdown 추적 정책 | repository | tracked Markdown 확인 | `git ls-files '*.md'` | `.github/pull_request_template.md`, `README.md` only |
| 화면 증거 | mobile | 증거 불필요 사유 | UI/동작 변경 없이 코드 주석과 repository contract만 변경 | not needed |
| PR CI | GitHub Actions | PR check rollup | https://github.com/AquilaXk/easysubway/actions/runs/27919683987 | success |
| PR Release Artifacts | GitHub Actions | PR check rollup | https://github.com/AquilaXk/easysubway/actions/runs/27919683871 | success |
| 코드리뷰 | GitHub PR review | CodeRabbit 상태 확인 후 Codex CLI fallback | https://github.com/AquilaXk/easysubway/pull/611#pullrequestreview-4540367012 | actionable 0 |
| post-merge CI | GitHub Actions | main push workflow | https://github.com/AquilaXk/easysubway/actions/runs/27919809642 | success |
| post-merge CD | GitHub Actions | main push workflow | https://github.com/AquilaXk/easysubway/actions/runs/27919809495 | success |
| post-merge Release Artifacts | GitHub Actions | main push workflow | https://github.com/AquilaXk/easysubway/actions/runs/27919809498 | failed: existing #600 blocker, `EASYSUBWAY_PRIVACY_POLICY_URL is required` |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `UNKNOWN` 접근성 데이터와 synthetic connector edge 주석이 실제 구현보다 강한 보장을 말하지 않는지 확인해 주세요.

## 리스크

- 런타임 동작 변경은 없습니다. 다만 contract marker가 구현과 어긋나면 향후 route 변경 PR에서 잘못된 기준이 될 수 있으므로, route cost 또는 local repository 동작이 바뀌면 이 marker도 함께 갱신해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
