### PR TITLE
[Build] 모바일 async lint 기준선 보강

### DIFF
--- a/apps/mobile/analysis/async-lint-baseline.json
+++ b/apps/mobile/analysis/async-lint-baseline.json
@@ -1,0 +1,16 @@
+{
+  "schema": "easysubway.mobile_async_lint_baseline.v1",
+  "enabledNow": [
+    "unawaited_futures"
+  ],
+  "staged": {
+    "discarded_futures": {
+      "status": "staged_existing_findings",
+      "findingCount": 82,
+      "target": [
+        "convert callback-only Future calls to unawaited() when fire-and-forget is intentional",
+        "await Future-returning test matchers and setup operations where order matters"
+      ]
+    }
+  }
+}

--- a/apps/mobile/analysis_options.yaml
+++ b/apps/mobile/analysis_options.yaml
@@ -27,6 +27,8 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
+    unawaited_futures: true
+    discarded_futures: false # staged in apps/mobile/analysis/async-lint-baseline.json
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1805,13 +1805,15 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
         return;
       }
     }
-    _controller.submit(
-      target: widget.target,
-      selectedType: _selectedType,
-      description: _descriptionController.text,
-      photoAttachment: _photoAttachment,
-      latitude: _attachedLocation?.latitude,
-      longitude: _attachedLocation?.longitude,
+    unawaited(
+      _controller.submit(
+        target: widget.target,
+        selectedType: _selectedType,
+        description: _descriptionController.text,
+        photoAttachment: _photoAttachment,
+        latitude: _attachedLocation?.latitude,
+        longitude: _attachedLocation?.longitude,
+      ),
     );
   }
 

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -535,19 +535,21 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
       return;
     }
 
-    Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        builder: (_) => FacilityReportScreen(
-          repository: widget.reportRepository,
-          target: target!,
-          locationLoader: _facilityReportLocationLoader(
-            widget.locationProvider,
+    unawaited(
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => FacilityReportScreen(
+            repository: widget.reportRepository,
+            target: target!,
+            locationLoader: _facilityReportLocationLoader(
+              widget.locationProvider,
+            ),
+            needsLocationPermissionRequest:
+                widget.locationProvider.needsLocationPermissionRequest,
+            openLocationSettings: widget.locationProvider.openLocationSettings,
+            draftTargetStore: draftTargetStore,
+            initialPhotoAttachment: photoAttachment,
           ),
-          needsLocationPermissionRequest:
-              widget.locationProvider.needsLocationPermissionRequest,
-          openLocationSettings: widget.locationProvider.openLocationSettings,
-          draftTargetStore: draftTargetStore,
-          initialPhotoAttachment: photoAttachment,
         ),
       ),
     );

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2839,7 +2839,7 @@ class _FavoriteStationListContentState
     if (!mounted) {
       return;
     }
-    _controller.load();
+    unawaited(_controller.load());
   }
 }
 

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -133,8 +133,8 @@ void main() {
                   },
                 },
               }),
-            )
-            ..close();
+            );
+          await request.response.close();
         case ('PUT', '/api/v1/report-uploads/client-submission-1-photo.jpg'):
           uploadChecksumHeader = request.headers.value(
             'x-easysubway-upload-sha256',
@@ -146,9 +146,8 @@ void main() {
             <int>[],
             (bytes, chunk) => bytes..addAll(chunk),
           );
-          request.response
-            ..statusCode = HttpStatus.noContent
-            ..close();
+          request.response.statusCode = HttpStatus.noContent;
+          await request.response.close();
         case ('POST', '/api/v1/reports'):
           authorizationHeader = request.headers.value(
             HttpHeaders.authorizationHeader,
@@ -173,13 +172,12 @@ void main() {
                   'receiptToken': 'receipt-token-1',
                 },
               }),
-            )
-            ..close();
+            );
+          await request.response.close();
         default:
           await utf8.decodeStream(request);
-          request.response
-            ..statusCode = HttpStatus.notFound
-            ..close();
+          request.response.statusCode = HttpStatus.notFound;
+          await request.response.close();
       }
     });
 
@@ -299,8 +297,8 @@ void main() {
               'receiptToken': 'receipt-token-1',
             },
           }),
-        )
-        ..close();
+        );
+      await request.response.close();
     });
 
     final repository = FacilityReportApiRepository(
@@ -349,8 +347,8 @@ void main() {
               'receiptToken': 'receipt-token-1',
             },
           }),
-        )
-        ..close();
+        );
+      await request.response.close();
     });
 
     final repository = FacilityReportApiRepository(
@@ -396,8 +394,8 @@ void main() {
               'uploadMethod': 'POST',
             },
           }),
-        )
-        ..close();
+        );
+      await request.response.close();
     });
 
     final repository = FacilityReportApiRepository(
@@ -467,8 +465,8 @@ void main() {
       if (requestCount == 1) {
         request.response
           ..statusCode = HttpStatus.unauthorized
-          ..write(jsonEncode({'success': false}))
-          ..close();
+          ..write(jsonEncode({'success': false}));
+        await request.response.close();
         return;
       }
 
@@ -487,8 +485,8 @@ void main() {
               'createdAt': '2026-06-13T10:00:00',
             },
           }),
-        )
-        ..close();
+        );
+      await request.response.close();
     });
 
     final authProvider = RetryAuthorizationHeaderProvider();

--- a/apps/mobile/test/notification_settings_test.dart
+++ b/apps/mobile/test/notification_settings_test.dart
@@ -35,8 +35,8 @@ void main() {
               'registeredAt': '2026-06-15T09:00:00',
             },
           }),
-        )
-        ..close();
+        );
+      await request.response.close();
     });
 
     final repository = DeviceRegistrationApiRepository(
@@ -87,8 +87,8 @@ void main() {
       if (requestCount == 1) {
         request.response
           ..statusCode = HttpStatus.unauthorized
-          ..write(jsonEncode({'success': false}))
-          ..close();
+          ..write(jsonEncode({'success': false}));
+        await request.response.close();
         return;
       }
 
@@ -104,8 +104,8 @@ void main() {
               'registeredAt': '2026-06-15T09:05:00',
             },
           }),
-        )
-        ..close();
+        );
+      await request.response.close();
     });
 
     final authProvider = RetryAuthorizationHeaderProvider();
@@ -136,8 +136,8 @@ void main() {
       request.response
         ..statusCode = HttpStatus.badRequest
         ..headers.contentType = ContentType.json
-        ..write(jsonEncode({'success': false}))
-        ..close();
+        ..write(jsonEncode({'success': false}));
+      await request.response.close();
     });
 
     final repository = DeviceRegistrationApiRepository(
@@ -168,7 +168,7 @@ void main() {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(server.close);
 
-    server.listen((request) {
+    server.listen((request) async {
       requestedUri = request.uri;
       authorizationHeader = request.headers.value(
         HttpHeaders.authorizationHeader,
@@ -188,8 +188,8 @@ void main() {
               'updatedAt': '2026-06-14T09:00:00',
             },
           }),
-        )
-        ..close();
+        );
+      await request.response.close();
     });
 
     final repository = NotificationSettingsApiRepository(
@@ -241,8 +241,8 @@ void main() {
               'updatedAt': '2026-06-14T09:05:00',
             },
           }),
-        )
-        ..close();
+        );
+      await request.response.close();
     });
 
     final repository = NotificationSettingsApiRepository(

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -202,8 +202,8 @@ void main() {
               'createdAt': '2026-06-13T04:20:00',
             },
           }),
-        )
-        ..close();
+        );
+      await request.response.close();
     });
 
     final repository = RouteSearchApiRepository(
@@ -510,8 +510,8 @@ void main() {
               'createdAt': '2026-06-15T12:00:00',
             },
           }),
-        )
-        ..close();
+        );
+      await request.response.close();
     });
 
     final repository = RouteFeedbackApiRepository(

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3949,6 +3949,24 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.doesNotMatch(operatorRouteFeedbackReportTemplate, /<form|_csrf|routeSearchId|userId|comment|\/admin\/reports/);
 });
 
+test("모바일 async lint 기준선은 Future 처리 누락을 analyzer에서 잡는다", () => {
+  const analysisOptions = read("apps/mobile/analysis_options.yaml");
+  const asyncLintBaseline = readJson("apps/mobile/analysis/async-lint-baseline.json");
+
+  assert.match(analysisOptions, /package:flutter_lints\/flutter\.yaml/);
+  assert.match(analysisOptions, /^analyzer:\n  language:\n    strict-casts: true\n    strict-inference: true\n    strict-raw-types: true$/m);
+  assert.match(analysisOptions, /^\s{4}unawaited_futures: true$/m);
+  assert.match(analysisOptions, /^\s{4}discarded_futures: false # staged in apps\/mobile\/analysis\/async-lint-baseline\.json$/m);
+  assert.equal(asyncLintBaseline.schema, "easysubway.mobile_async_lint_baseline.v1");
+  assert.deepEqual(asyncLintBaseline.enabledNow, ["unawaited_futures"]);
+  assert.equal(asyncLintBaseline.staged.discarded_futures.status, "staged_existing_findings");
+  assert.ok(asyncLintBaseline.staged.discarded_futures.findingCount > 0);
+  assert.deepEqual(asyncLintBaseline.staged.discarded_futures.target, [
+    "convert callback-only Future calls to unawaited() when fire-and-forget is intentional",
+    "await Future-returning test matchers and setup operations where order matters",
+  ]);
+});
+
 test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다", () => {
   const pubspec = read("apps/mobile/pubspec.yaml");
   const analysisOptions = read("apps/mobile/analysis_options.yaml");


### PR DESCRIPTION
## 관련 이슈

close #612

## 작업 배경

모바일 앱은 `flutter_lints`와 strict language analyzer 옵션을 사용하고 있지만, Future 처리 누락을 명시적으로 잡는 async lint 기준선은 없었습니다. `unawaited_futures`는 즉시 적용 가능한 수준으로 정리하고, 기존 `discarded_futures` 발견량은 별도 baseline으로 남겨 다음 slice에서 줄일 수 있게 했습니다.

## 작업 내용

- `apps/mobile/analysis_options.yaml`에 `unawaited_futures`를 활성화했습니다.
- `discarded_futures`는 기존 발견량이 커서 `apps/mobile/analysis/async-lint-baseline.json`에 staged baseline으로 기록했습니다.
- 의도적 fire-and-forget 호출은 `unawaited(...)`로 표시했습니다.
- 테스트 HTTP response close는 `await request.response.close()`로 바꿔 flush 순서를 명확히 했습니다.
- repository contract에 모바일 async lint 기준선 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "모바일 async lint 기준선" tools/ci/repository-contract.test.mjs`: RED 후 pass, 1 test
  - `dart format apps/mobile/lib/facility_report.dart apps/mobile/lib/main.dart apps/mobile/lib/station_search.dart apps/mobile/test/facility_report_test.dart apps/mobile/test/notification_settings_test.dart apps/mobile/test/route_search_test.dart`: pass, 6 files unchanged
  - `cd apps/mobile && flutter analyze`: pass, No issues found
  - `cd apps/mobile && flutter test`: pass, 331 tests
  - `node --test tools/ci/*.test.mjs`: pass, 88 tests
  - `git diff --check`: pass
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md` only
  - PR CI: pass, https://github.com/AquilaXk/easysubway/actions/runs/27921658797
  - PR Release Artifacts: pass, https://github.com/AquilaXk/easysubway/actions/runs/27921658750
  - CodeRabbit: pass, actionable comments 0, https://github.com/AquilaXk/easysubway/pull/613#issuecomment-4763695043

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| async lint contract | repository | Node test runner | `node --test --test-name-pattern "모바일 async lint 기준선" tools/ci/repository-contract.test.mjs` | pass, 1 test |
| 모바일 정적 분석 | mobile | Flutter analyzer | `cd apps/mobile && flutter analyze` | pass, No issues found |
| 모바일 테스트 | mobile | Flutter tests | `cd apps/mobile && flutter test` | pass, 331 tests |
| repository contract 전체 | repository | Node test runner | `node --test tools/ci/*.test.mjs` | pass, 88 tests |
| Markdown 추적 정책 | repository | tracked Markdown 확인 | `git ls-files '*.md'` | `.github/pull_request_template.md`, `README.md` only |
| PR CI | GitHub Actions | CI workflow 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27921658797 | pass, Changes/Repository CI/Backend CI/Mobile App CI/Android CI/iOS CI/osv-scanner |
| PR release artifact | GitHub Actions | Release Artifacts workflow 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27921658750 | pass, Changes/Android Release Artifact/Backend Release Image/iOS Release Artifact |
| CodeRabbit review | GitHub PR | 기존 CodeRabbit bot comment와 status context 확인 | https://github.com/AquilaXk/easysubway/pull/613#issuecomment-4763695043 | pass, actionable comments 0 |
| 화면 증거 | mobile | 증거 불필요 사유 | UI/동작 변경 없이 analyzer 설정과 Future 처리 명시만 변경 | not needed |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `discarded_futures`를 즉시 켜지 않고 baseline으로 분리한 판단이 적절한지 확인해 주세요. 이번 PR은 `unawaited_futures`를 실제 gate로 통과시키는 데 집중했습니다.

## 리스크

- 사용자 동작 변경은 없습니다. 다만 response close를 await하도록 바꾼 테스트는 서버 응답 flush 순서를 더 엄격하게 기다리므로 비동기 테스트 timing 문제가 드러날 수 있습니다.
- `discarded_futures`는 아직 활성화하지 않았으므로 후속 PR에서 baseline count를 줄여야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (CodeRabbit 성공으로 fallback 미사용)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
