### PR TITLE
[Refactor] 모바일 로컬 경로 저장소 명칭과 zero-http 계약 정리

### DIFF
--- a/apps/mobile/lib/app/app_dependencies.dart
+++ b/apps/mobile/lib/app/app_dependencies.dart
@@ -14,7 +14,7 @@ import '../station_search.dart';
 import '../user_data_deletion.dart';
 import '../features/internal_route/data/local_internal_route_repository.dart';
 import '../features/routes/data/local_route_repository.dart'
-    show FallbackRouteSearchRepository, LocalRouteRepository;
+    show LocalFirstRouteSearchRepository, LocalRouteRepository;
 
 class AppDependencies {
   const AppDependencies({
@@ -105,7 +105,7 @@ class AppDependencies {
           routeRepository ??
           (catalogDatabase == null
               ? RouteSearchApiRepository(baseUri: requireBaseUri())
-              : FallbackRouteSearchRepository(
+              : LocalFirstRouteSearchRepository(
                   localRepository: LocalRouteRepository(
                     catalogDatabase: catalogDatabase,
                   ),
@@ -158,7 +158,7 @@ class AppDependencies {
           internalRouteRepository ??
           (catalogDatabase == null
               ? InternalRouteApiRepository(baseUri: requireBaseUri())
-              : FallbackInternalRouteRepository(
+              : LocalFirstInternalRouteRepository(
                   localRepository: LocalInternalRouteRepository(
                     catalogDatabase: catalogDatabase,
                   ),

--- a/apps/mobile/lib/features/internal_route/data/local_internal_route_repository.dart
+++ b/apps/mobile/lib/features/internal_route/data/local_internal_route_repository.dart
@@ -168,8 +168,8 @@ class LocalInternalRouteRepository implements InternalRouteRepository {
   }
 }
 
-class FallbackInternalRouteRepository implements InternalRouteRepository {
-  const FallbackInternalRouteRepository({required this.localRepository});
+class LocalFirstInternalRouteRepository implements InternalRouteRepository {
+  const LocalFirstInternalRouteRepository({required this.localRepository});
 
   final LocalInternalRouteRepository localRepository;
 

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -215,8 +215,8 @@ class LocalRouteRepository implements RouteSearchRepository {
   }
 }
 
-class FallbackRouteSearchRepository implements RouteSearchRepository {
-  const FallbackRouteSearchRepository({required this.localRepository});
+class LocalFirstRouteSearchRepository implements RouteSearchRepository {
+  const LocalFirstRouteSearchRepository({required this.localRepository});
 
   final LocalRouteRepository localRepository;
 

--- a/apps/mobile/test/app_dependencies_test.dart
+++ b/apps/mobile/test/app_dependencies_test.dart
@@ -3,30 +3,49 @@ import 'package:easysubway_mobile/core/database/catalog/catalog_database.dart';
 import 'package:easysubway_mobile/core/database/user/user_database.dart'
     as user_db;
 import 'package:easysubway_mobile/facility_report.dart';
-import 'package:easysubway_mobile/features/routes/data/local_route_repository.dart';
 import 'package:easysubway_mobile/features/stations/data/drift_station_repository.dart';
+import 'package:easysubway_mobile/route_search.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('로컬 데이터베이스가 있으면 API 주소 없이도 앱 의존성을 만든다', () {
+  test('로컬 데이터베이스가 있으면 API 주소 없이도 경로 의존성이 동작한다', () async {
     final catalogDatabase = CatalogDatabase.memory();
     final userDatabase = user_db.UserDatabase.memory();
     addTearDown(catalogDatabase.close);
     addTearDown(userDatabase.close);
+    await catalogDatabase.seedBaselineIfEmpty();
 
     final dependencies = AppDependencies.resolve(
       catalogDatabase: catalogDatabase,
       userDatabase: userDatabase,
-      apiBaseUri: () => null,
+      reportRepository: const UnavailableFacilityReportRepository(),
+      apiBaseUri: () {
+        throw StateError('Local catalog defaults must not read API base URL.');
+      },
       enablePushNotifications: false,
     );
 
     expect(dependencies.repository, isA<DriftStationRepository>());
-    expect(dependencies.routeRepository, isA<FallbackRouteSearchRepository>());
     expect(
       dependencies.reportRepository,
       isA<UnavailableFacilityReportRepository>(),
     );
+
+    final routeResult = await dependencies.routeRepository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(routeResult.status, 'FOUND');
+    expect(routeResult.isLocalResult, isTrue);
+
+    final internalNodes = await dependencies.internalRouteRepository
+        .listRouteNodes('station-sangnoksu');
+
+    expect(internalNodes, isEmpty);
   });
 
   test('로컬 데이터베이스가 없으면 API 주소 없는 원격 fallback을 만들지 않는다', () {

--- a/apps/mobile/test/features/internal_route/local_internal_route_repository_test.dart
+++ b/apps/mobile/test/features/internal_route/local_internal_route_repository_test.dart
@@ -320,7 +320,7 @@ void main() {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
     await database.seedBaselineIfEmpty();
-    final repository = FallbackInternalRouteRepository(
+    final repository = LocalFirstInternalRouteRepository(
       localRepository: LocalInternalRouteRepository(catalogDatabase: database),
     );
 

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -1,26 +1,38 @@
 import 'package:easysubway_mobile/app/app_dependencies.dart';
 import 'package:easysubway_mobile/core/database/catalog/catalog_database.dart';
-import 'package:easysubway_mobile/features/internal_route/data/local_internal_route_repository.dart';
+import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/features/routes/data/local_route_repository.dart';
 import 'package:easysubway_mobile/route_search.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('catalog DB가 있으면 기본 경로 repository는 route API 대신 로컬 구현을 사용한다', () async {
+  test('catalog DB가 있으면 기본 경로 repository는 API 주소 없이 로컬 결과를 반환한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
     await database.seedBaselineIfEmpty();
 
     final dependencies = AppDependencies.resolve(
       catalogDatabase: database,
+      reportRepository: const UnavailableFacilityReportRepository(),
+      apiBaseUri: () {
+        throw StateError('Local route defaults must not read API base URL.');
+      },
       enablePushNotifications: false,
     );
 
-    expect(dependencies.routeRepository, isA<FallbackRouteSearchRepository>());
-    expect(
-      dependencies.internalRouteRepository,
-      isA<FallbackInternalRouteRepository>(),
+    final routeResult = await dependencies.routeRepository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
     );
+    final internalNodes = await dependencies.internalRouteRepository
+        .listRouteNodes('station-sangnoksu');
+
+    expect(routeResult.status, 'FOUND');
+    expect(routeResult.isLocalResult, isTrue);
+    expect(internalNodes, isEmpty);
   });
 
   test('로컬 경로 repository는 baseline catalog에서 상록수-사당 경로를 계산한다', () async {
@@ -201,7 +213,7 @@ void main() {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
     await database.seedBaselineIfEmpty();
-    final repository = FallbackRouteSearchRepository(
+    final repository = LocalFirstRouteSearchRepository(
       localRepository: LocalRouteRepository(catalogDatabase: database),
     );
 


### PR DESCRIPTION
## 관련 이슈

close #620

## 작업 배경

task9 모바일 안정화 범위에서 로컬 catalog 기반 경로 저장소가 `Fallback*Repository` 명칭으로 남아 있어 backend API fallback처럼 읽혔습니다. 또한 앱 의존성 테스트가 repository 타입 단언에 기대고 있어, API base URL 없이 로컬 경로가 동작해야 한다는 계약을 직접 확인하지 못했습니다.

## 작업 내용

- `FallbackRouteSearchRepository`를 `LocalFirstRouteSearchRepository`로 변경했습니다.
- `FallbackInternalRouteRepository`를 `LocalFirstInternalRouteRepository`로 변경했습니다.
- 앱 의존성 wiring이 catalog DB가 있을 때 local-first route/internal route 저장소를 사용하도록 이름을 맞췄습니다.
- 기존 `Fallback*Repository` 타입 단언 테스트를 API base URL을 읽으면 실패하는 local route/internal route 동작 테스트로 바꿨습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter analyze`: 통과
  - `cd apps/mobile && flutter test test/app_dependencies_test.dart test/features/routes/local_route_repository_test.dart test/features/internal_route/local_internal_route_repository_test.dart`: 통과, 45개 테스트 통과
  - `node --test tools/ci/*.test.mjs`: 통과, 88개 테스트 통과
  - `cd apps/mobile && flutter test`: 통과, 전체 334개 테스트 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 출력
  - GitHub Actions CI: 통과
  - GitHub Actions Release Artifacts: 통과
  - CodeRabbit: rate limit/credit exhausted로 실제 리뷰 미시작
  - Codex CLI fallback review: actionable 0건

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| local-first route/internal route 계약 | Flutter test | API base URL 접근 시 예외가 나는 테스트에서 local route/internal route 동작 확인 | `flutter test test/app_dependencies_test.dart test/features/routes/local_route_repository_test.dart test/features/internal_route/local_internal_route_repository_test.dart` | 통과 |
| 모바일 정적 분석 | Flutter analyzer | `flutter analyze` | 명령 출력 | 통과 |
| 저장소 계약과 Markdown 추적 정책 | Local CI contract | `node --test tools/ci/*.test.mjs`, `git ls-files '*.md'` | 명령 출력 | 통과 |
| 모바일 전체 회귀 | Flutter test | `flutter test` | 명령 출력 | 통과 |
| 원격 CI | GitHub Actions | PR #621 check suite | https://github.com/AquilaXk/easysubway/actions/runs/27927936310 | 통과 |
| 릴리즈 산출물 gate | GitHub Actions | PR #621 release artifact workflow | https://github.com/AquilaXk/easysubway/actions/runs/27927936270 | 통과 |
| 대체 코드 리뷰 | GitHub PR review | CodeRabbit rate limit 후 Codex CLI fallback review | https://github.com/AquilaXk/easysubway/pull/621#pullrequestreview-4540923919 | actionable 0건 |
| UI/시각 증거 | 해당 없음 | repository 명칭과 테스트 계약 정리이며 화면 렌더링 변경 없음 | 증거 불필요 사유: UI 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `AppDependencies.resolve`에서 catalog DB가 있는 route/internal route 경로가 여전히 backend API base URL을 요구하지 않는지 확인해 주세요.
  - task9의 shared API client 도입과 대형 파일 분리는 이 PR 범위가 아니라 후속 작업으로 남겼습니다.

## 리스크

- class 이름이 바뀌므로 같은 브랜치 위에서 `Fallback*Repository`를 직접 참조하던 후속 작업이 있으면 rebase 시 충돌할 수 있습니다.
- 동작은 기존 local repository 위임 구조를 유지하므로 사용자 화면 변화는 없습니다.
- 배포 설정 변경은 없고 PR release artifact gate는 통과했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
