### PR TITLE
[Refactor] 사용자 데이터 삭제 API 공통 네트워크 경계 도입

### DIFF
--- a/apps/mobile/lib/app/app_dependencies.dart
+++ b/apps/mobile/lib/app/app_dependencies.dart
@@ -1,6 +1,7 @@
 import '../auth_headers.dart';
 import '../core/database/catalog/catalog_database.dart';
 import '../core/database/user/user_database.dart';
+import '../core/network/api_client.dart';
 import '../facility_report.dart';
 import '../favorite_facility.dart';
 import '../features/favorites/data/drift_favorite_repositories.dart';
@@ -219,10 +220,14 @@ UserDataDeletionRepository? _defaultUserDataDeletionRepository({
       : UserDataDeletionLocalRepository(userDatabase: userDatabase);
   final remoteRepository = authProvider == null
       ? null
-      : UserDataDeletionApiRepository(
-          baseUri: baseUri(),
-          authProvider: authProvider,
-        );
+      : (() {
+          final resolvedBaseUri = baseUri();
+          return UserDataDeletionApiRepository(
+            baseUri: resolvedBaseUri,
+            apiClient: ApiClient(baseUri: resolvedBaseUri),
+            authProvider: authProvider,
+          );
+        })();
   if (remoteRepository != null && localRepository != null) {
     return UserDataDeletionCompositeRepository(
       remoteRepository: remoteRepository,

--- a/apps/mobile/lib/core/network/api_client.dart
+++ b/apps/mobile/lib/core/network/api_client.dart
@@ -1,0 +1,96 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'api_error.dart';
+
+export 'api_error.dart';
+
+const defaultApiTimeout = Duration(seconds: 8);
+
+class ApiClient {
+  ApiClient({
+    required this.baseUri,
+    HttpClient? httpClient,
+    this.timeout = defaultApiTimeout,
+  }) : _httpClient = httpClient ?? HttpClient();
+
+  final Uri baseUri;
+  final Duration timeout;
+  final HttpClient _httpClient;
+
+  Future<ApiResponse> deleteJson(
+    String path, {
+    Map<String, String> headers = const {},
+  }) {
+    return _requestJson(HttpMethod.delete, path, headers: headers);
+  }
+
+  Future<ApiResponse> _requestJson(
+    HttpMethod method,
+    String path, {
+    required Map<String, String> headers,
+  }) async {
+    final uri = baseUri.resolve(path);
+    try {
+      final request = await _open(method, uri).timeout(timeout);
+      request.headers.set(HttpHeaders.acceptHeader, ContentType.json.mimeType);
+      headers.forEach(request.headers.set);
+
+      final response = await request.close().timeout(timeout);
+      final body = await utf8.decodeStream(response).timeout(timeout);
+      if (!_isSuccessStatus(response.statusCode)) {
+        return ApiResponse(statusCode: response.statusCode, jsonBody: null);
+      }
+      final decoded = _decodeJson(
+        body,
+        statusCode: response.statusCode,
+        uri: uri,
+      );
+      return ApiResponse(statusCode: response.statusCode, jsonBody: decoded);
+    } on ApiException {
+      rethrow;
+    } on TimeoutException {
+      throw ApiException('API 요청 시간이 초과되었습니다.', path: uri.path);
+    } on SocketException {
+      throw ApiException('API 서버에 연결하지 못했습니다.', path: uri.path);
+    } catch (_) {
+      throw ApiException('API 요청을 처리하지 못했습니다.', path: uri.path);
+    }
+  }
+
+  Future<HttpClientRequest> _open(HttpMethod method, Uri uri) {
+    switch (method) {
+      case HttpMethod.delete:
+        return _httpClient.deleteUrl(uri);
+    }
+  }
+}
+
+class ApiResponse {
+  const ApiResponse({required this.statusCode, required this.jsonBody});
+
+  final int statusCode;
+  final Object? jsonBody;
+
+  bool get isUnauthorized => statusCode == HttpStatus.unauthorized;
+  bool get isOk => statusCode == HttpStatus.ok;
+}
+
+enum HttpMethod { delete }
+
+Object? _decodeJson(String body, {required int statusCode, required Uri uri}) {
+  try {
+    return jsonDecode(body);
+  } on FormatException {
+    throw ApiException(
+      'API JSON 응답을 해석하지 못했습니다.',
+      statusCode: statusCode,
+      path: uri.path,
+    );
+  }
+}
+
+bool _isSuccessStatus(int statusCode) {
+  return statusCode >= HttpStatus.ok && statusCode < HttpStatus.multipleChoices;
+}

--- a/apps/mobile/lib/core/network/api_client.dart
+++ b/apps/mobile/lib/core/network/api_client.dart
@@ -50,12 +50,27 @@ class ApiClient {
       return ApiResponse(statusCode: response.statusCode, jsonBody: decoded);
     } on ApiException {
       rethrow;
-    } on TimeoutException {
-      throw ApiException('API 요청 시간이 초과되었습니다.', path: uri.path);
-    } on SocketException {
-      throw ApiException('API 서버에 연결하지 못했습니다.', path: uri.path);
-    } catch (_) {
-      throw ApiException('API 요청을 처리하지 못했습니다.', path: uri.path);
+    } on TimeoutException catch (error, stackTrace) {
+      throw ApiException(
+        'API 요청 시간이 초과되었습니다.',
+        path: uri.path,
+        cause: error,
+        causeStackTrace: stackTrace,
+      );
+    } on SocketException catch (error, stackTrace) {
+      throw ApiException(
+        'API 서버에 연결하지 못했습니다.',
+        path: uri.path,
+        cause: error,
+        causeStackTrace: stackTrace,
+      );
+    } catch (error, stackTrace) {
+      throw ApiException(
+        'API 요청을 처리하지 못했습니다.',
+        path: uri.path,
+        cause: error,
+        causeStackTrace: stackTrace,
+      );
     }
   }
 

--- a/apps/mobile/lib/core/network/api_error.dart
+++ b/apps/mobile/lib/core/network/api_error.dart
@@ -1,0 +1,19 @@
+class ApiException implements Exception {
+  const ApiException(this.message, {this.statusCode, this.path});
+
+  final String message;
+  final int? statusCode;
+  final String? path;
+
+  @override
+  String toString() {
+    final parts = <String>[message];
+    if (statusCode != null) {
+      parts.add('status=$statusCode');
+    }
+    if (path != null && path!.isNotEmpty) {
+      parts.add('path=$path');
+    }
+    return parts.join(' ');
+  }
+}

--- a/apps/mobile/lib/core/network/api_error.dart
+++ b/apps/mobile/lib/core/network/api_error.dart
@@ -1,9 +1,17 @@
 class ApiException implements Exception {
-  const ApiException(this.message, {this.statusCode, this.path});
+  const ApiException(
+    this.message, {
+    this.statusCode,
+    this.path,
+    this.cause,
+    this.causeStackTrace,
+  });
 
   final String message;
   final int? statusCode;
   final String? path;
+  final Object? cause;
+  final StackTrace? causeStackTrace;
 
   @override
   String toString() {

--- a/apps/mobile/lib/user_data_deletion.dart
+++ b/apps/mobile/lib/user_data_deletion.dart
@@ -4,10 +4,11 @@ import 'dart:io';
 
 import 'auth_headers.dart';
 import 'core/database/user/user_database.dart';
+import 'core/network/api_client.dart';
 import 'mobile_error_reporter.dart';
 
 const userDataDeletionErrorMessage = '데이터 삭제를 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.';
-const _userDataDeletionTimeout = Duration(seconds: 8);
+const _userDataDeletionTimeout = defaultApiTimeout;
 
 abstract class UserDataDeletionRepository {
   Future<UserDataDeletionResult> deleteCurrentUserData();
@@ -18,14 +19,17 @@ class UserDataDeletionApiRepository implements UserDataDeletionRepository {
     required this.baseUri,
     required this.authProvider,
     this.refreshExistingAuthorization,
+    ApiClient? apiClient,
     HttpClient? httpClient,
-  }) : _httpClient = httpClient ?? HttpClient();
+  }) : assert(apiClient == null || httpClient == null),
+       _apiClient =
+           apiClient ?? ApiClient(baseUri: baseUri, httpClient: httpClient);
 
   final Uri baseUri;
   final AuthorizationHeaderProvider authProvider;
   final Future<bool> Function(String authorizationHeader)?
   refreshExistingAuthorization;
-  final HttpClient _httpClient;
+  final ApiClient _apiClient;
 
   @override
   Future<UserDataDeletionResult> deleteCurrentUserData() async {
@@ -46,25 +50,17 @@ class UserDataDeletionApiRepository implements UserDataDeletionRepository {
   Future<UserDataDeletionResult>
   _deleteCurrentUserDataWithAuthorizationRetry() async {
     for (var attempt = 0; attempt < 2; attempt++) {
-      final request = await _httpClient
-          .deleteUrl(baseUri.resolve('/api/v1/me'))
-          .timeout(_userDataDeletionTimeout);
       final authorizationHeader = await authProvider
           .authorizationHeader()
           .timeout(_userDataDeletionTimeout);
-      if (authorizationHeader != null) {
-        request.headers.set(
-          HttpHeaders.authorizationHeader,
-          authorizationHeader,
-        );
-      }
+      final response = await _apiClient.deleteJson(
+        '/api/v1/me',
+        headers: authorizationHeader == null
+            ? const {}
+            : {HttpHeaders.authorizationHeader: authorizationHeader},
+      );
 
-      final response = await request.close().timeout(_userDataDeletionTimeout);
-      final body = await utf8
-          .decodeStream(response)
-          .timeout(_userDataDeletionTimeout);
-
-      if (response.statusCode == HttpStatus.unauthorized &&
+      if (response.isUnauthorized &&
           authorizationHeader != null &&
           attempt == 0) {
         final refreshedAuthorization = await _refreshExistingAuthorization(
@@ -76,11 +72,11 @@ class UserDataDeletionApiRepository implements UserDataDeletionRepository {
         continue;
       }
 
-      if (response.statusCode != HttpStatus.ok) {
+      if (!response.isOk) {
         throw const UserDataDeletionException(userDataDeletionErrorMessage);
       }
 
-      return UserDataDeletionResult.fromResponseBody(body);
+      return UserDataDeletionResult.fromResponseJson(response.jsonBody);
     }
     throw const UserDataDeletionException(userDataDeletionErrorMessage);
   }
@@ -217,6 +213,10 @@ class UserDataDeletionResult {
 
   factory UserDataDeletionResult.fromResponseBody(String body) {
     final decoded = jsonDecode(body);
+    return UserDataDeletionResult.fromResponseJson(decoded);
+  }
+
+  factory UserDataDeletionResult.fromResponseJson(Object? decoded) {
     if (decoded is! Map<String, Object?> || decoded['success'] != true) {
       throw const UserDataDeletionException(userDataDeletionErrorMessage);
     }

--- a/apps/mobile/test/core/network/api_client_test.dart
+++ b/apps/mobile/test/core/network/api_client_test.dart
@@ -1,0 +1,93 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:easysubway_mobile/core/network/api_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('ApiClient는 DELETE 요청에 공통 timeout과 JSON decode 경계를 적용한다', () async {
+    late String requestedMethod;
+    late Uri requestedUri;
+    late String? acceptHeader;
+    late String? authorizationHeader;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestedMethod = request.method;
+      requestedUri = request.uri;
+      acceptHeader = request.headers.value(HttpHeaders.acceptHeader);
+      authorizationHeader = request.headers.value(
+        HttpHeaders.authorizationHeader,
+      );
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {'userId': 'anonymous-user-1'},
+          }),
+        )
+        ..close();
+    });
+
+    final client = ApiClient(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    final response = await client.deleteJson(
+      '/api/v1/me',
+      headers: const {HttpHeaders.authorizationHeader: 'Bearer secret-token'},
+    );
+
+    expect(requestedMethod, 'DELETE');
+    expect(requestedUri.path, '/api/v1/me');
+    expect(acceptHeader, ContentType.json.mimeType);
+    expect(authorizationHeader, 'Bearer secret-token');
+    expect(response.statusCode, HttpStatus.ok);
+    expect(response.jsonBody, {
+      'success': true,
+      'data': {'userId': 'anonymous-user-1'},
+    });
+  });
+
+  test('ApiClient 예외는 인증 토큰을 노출하지 않는다', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write('not-json')
+        ..close();
+    });
+
+    final client = ApiClient(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    await expectLater(
+      client.deleteJson(
+        '/api/v1/me',
+        headers: const {
+          HttpHeaders.authorizationHeader: 'Bearer sensitive-access-token',
+        },
+      ),
+      throwsA(
+        isA<ApiException>()
+            .having(
+              (error) => error.toString(),
+              'error text',
+              isNot(contains('sensitive-access-token')),
+            )
+            .having(
+              (error) => error.toString(),
+              'error text',
+              isNot(contains('Bearer')),
+            ),
+      ),
+    );
+  });
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4001,6 +4001,9 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   const notificationSettings = read("apps/mobile/lib/notification_settings.dart");
   const notificationSettingsTest = read("apps/mobile/test/notification_settings_test.dart");
   const widgetTest = read("apps/mobile/test/widget_test.dart");
+  const apiClient = read("apps/mobile/lib/core/network/api_client.dart");
+  const apiError = read("apps/mobile/lib/core/network/api_error.dart");
+  const apiClientTest = read("apps/mobile/test/core/network/api_client_test.dart");
   const accessibilityBaselineTest = read("apps/mobile/test/accessibility_baseline_test.dart");
 
   assert.ok(existsSync(path.join(root, "apps/mobile/android")));
@@ -4254,8 +4257,18 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(main, /현장 안내, 역무원 안내, 운영기관 공지를 먼저 확인해 주세요/);
   assert.match(main, /실시간 상태나 무조건 안전한 경로를 보장하지 않습니다/);
   assert.match(main, /데이터 삭제 요청 시 즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용·사진·위치와 경로 피드백을 삭제하거나 익명화합니다/);
+  assert.match(apiClient, /class ApiClient/);
+  assert.match(apiClient, /const defaultApiTimeout = Duration\(seconds: 8\)/);
+  assert.match(apiClient, /Future<ApiResponse> deleteJson/);
+  assert.match(apiClient, /HttpHeaders\.acceptHeader/);
+  assert.match(apiClient, /ContentType\.json\.mimeType/);
+  assert.match(apiClient, /jsonDecode\(body\)/);
+  assert.match(apiClient, /class ApiResponse/);
+  assert.match(apiError, /class ApiException implements Exception/);
+  assert.match(apiClientTest, /ApiClient는 DELETE 요청에 공통 timeout과 JSON decode 경계를 적용한다/);
+  assert.match(apiClientTest, /ApiClient 예외는 인증 토큰을 노출하지 않는다/);
   assert.match(userDataDeletion, /class UserDataDeletionApiRepository implements UserDataDeletionRepository/);
-  assert.match(userDataDeletion, /deleteUrl\(baseUri\.resolve\('\/api\/v1\/me'\)\)/);
+  assert.match(userDataDeletion, /_apiClient\.deleteJson\([\s\S]*'\/api\/v1\/me'/);
   assert.match(userDataDeletion, /HttpHeaders\.authorizationHeader/);
   assert.match(userDataDeletion, /refreshExistingAuthorization/);
   assert.match(


### PR DESCRIPTION
## 관련 이슈

close #622

## 작업 배경

사용자 데이터 삭제 API repository가 `HttpClient`, timeout, 응답 decode, 상태 코드 판정을 직접 처리하고 있어 task9의 shared API client 잔여 범위가 남아 있었다. 이번 PR은 리포트 업로드나 대형 파일 split과 분리해 사용자 데이터 삭제 API부터 공통 네트워크 경계로 이동한다.

## 작업 내용

- `apps/mobile/lib/core/network/api_client.dart`와 `api_error.dart`를 추가해 DELETE JSON 요청, 8초 timeout, JSON decode, 민감 토큰을 포함하지 않는 예외 문자열 경계를 만들었다.
- `UserDataDeletionApiRepository`가 직접 `HttpClient.deleteUrl`과 body decode를 처리하지 않고 `ApiClient.deleteJson('/api/v1/me')`를 사용하도록 변경했다.
- Authorization header 전달, 401 응답 후 기존 인증 갱신 재시도, 쉬운 오류 메시지 매핑은 기존 동작대로 유지했다.
- CI generic catch 계약에 맞춰 `ApiException`이 원본 error와 stackTrace를 보관하되 사용자 노출 문자열에는 포함하지 않도록 했다.
- repository contract 테스트를 기존 직접 `HttpClient` 구현 고정에서 공통 `ApiClient` 경계 고정으로 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/core/network/api_client_test.dart`를 API client 구현 전 실행해 컴파일 실패를 확인했다.
  - `flutter test test/core/network/api_client_test.dart test/user_data_deletion_test.dart` 통과, 9 tests.
  - `flutter analyze` 통과, No issues found.
  - `flutter test` 통과, 336 tests.
  - `node --test tools/ci/*.test.mjs` 통과, 88 tests.
  - `git diff --check` 통과.
  - `git ls-files "*.md"` 결과는 `.github/pull_request_template.md`, `README.md`만 포함했다.
  - GitHub Actions CI 통과: https://github.com/AquilaXk/easysubway/actions/runs/27928756334
  - GitHub Actions Release Artifacts 통과: https://github.com/AquilaXk/easysubway/actions/runs/27928756230

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| API client RED 확인 | local Flutter test | 구현 전 `flutter test test/core/network/api_client_test.dart` | 로컬 명령 출력: `lib/core/network/api_client.dart` 없음으로 컴파일 실패 | 기대한 실패 확인 |
| 사용자 데이터 삭제 API 경계 | local Flutter test | `flutter test test/core/network/api_client_test.dart test/user_data_deletion_test.dart` | 로컬 명령 출력: `All tests passed!`, 9 tests | 통과 |
| 모바일 정적 분석 | local Flutter analyze | `flutter analyze` | 로컬 명령 출력: `No issues found!` | 통과 |
| 모바일 전체 테스트 | local Flutter test | `flutter test` | 로컬 명령 출력: `All tests passed!`, 336 tests | 통과 |
| 저장소 계약 | local Node test | `node --test tools/ci/*.test.mjs` | 로컬 명령 출력: pass 88, fail 0 | 통과 |
| PR CI | GitHub Actions | PR #623 CI workflow | https://github.com/AquilaXk/easysubway/actions/runs/27928756334 | 통과 |
| 릴리즈 산출물 gate | GitHub Actions | PR #623 Release Artifacts workflow | https://github.com/AquilaXk/easysubway/actions/runs/27928756230 | 통과 |
| Code review fallback | GitHub PR review | CodeRabbit rate limit/credit exhausted 확인 후 Codex CLI fallback review | https://github.com/AquilaXk/easysubway/pull/623#pullrequestreview-4541019649 | actionable 0 |
| 화면 증거 | Android/iOS UI | 네트워크 repository refactor이며 화면 동작과 UI copy를 변경하지 않음 | 증거 불필요 사유: UI/접근성 흐름 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `ApiClient.deleteJson`의 non-2xx 응답 처리와 `UserDataDeletionApiRepository`의 401 재시도 유지 여부.

## 리스크

- 이번 PR은 사용자 데이터 삭제 API만 이관한다. facility report upload의 receipt token/retry 정책, station/route/favorite API repository, 데이터팩 manifest client, 대형 파일 split은 task9 잔여 범위로 남는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.