### PR TITLE
[Refactor] 시설 신고 접수 API 공통 네트워크 경계 적용

### DIFF
--- a/apps/mobile/lib/app/app_dependencies.dart
+++ b/apps/mobile/lib/app/app_dependencies.dart
@@ -203,6 +203,7 @@ FacilityReportRepository _defaultFacilityReportRepository({
   }
   return FacilityReportApiRepository(
     baseUri: resolvedBaseUri,
+    apiClient: ApiClient(baseUri: resolvedBaseUri),
     authProvider: null,
     receiptStore: userDatabase == null
         ? null

--- a/apps/mobile/lib/core/network/api_client.dart
+++ b/apps/mobile/lib/core/network/api_client.dart
@@ -26,24 +26,42 @@ class ApiClient {
     return _requestJson(HttpMethod.delete, path, headers: headers);
   }
 
+  Future<ApiResponse> postJson(
+    String path, {
+    required Map<String, Object?> body,
+    Map<String, String> headers = const {},
+  }) {
+    return _requestJson(
+      HttpMethod.post,
+      path,
+      headers: headers,
+      requestBody: body,
+    );
+  }
+
   Future<ApiResponse> _requestJson(
     HttpMethod method,
     String path, {
     required Map<String, String> headers,
+    Map<String, Object?>? requestBody,
   }) async {
     final uri = baseUri.resolve(path);
     try {
       final request = await _open(method, uri).timeout(timeout);
       request.headers.set(HttpHeaders.acceptHeader, ContentType.json.mimeType);
       headers.forEach(request.headers.set);
+      if (requestBody != null) {
+        request.headers.contentType = ContentType.json;
+        request.write(jsonEncode(requestBody));
+      }
 
       final response = await request.close().timeout(timeout);
-      final body = await utf8.decodeStream(response).timeout(timeout);
+      final responseBody = await utf8.decodeStream(response).timeout(timeout);
       if (!_isSuccessStatus(response.statusCode)) {
         return ApiResponse(statusCode: response.statusCode, jsonBody: null);
       }
       final decoded = _decodeJson(
-        body,
+        responseBody,
         statusCode: response.statusCode,
         uri: uri,
       );
@@ -78,6 +96,8 @@ class ApiClient {
     switch (method) {
       case HttpMethod.delete:
         return _httpClient.deleteUrl(uri);
+      case HttpMethod.post:
+        return _httpClient.postUrl(uri);
     }
   }
 }
@@ -92,16 +112,18 @@ class ApiResponse {
   bool get isOk => statusCode == HttpStatus.ok;
 }
 
-enum HttpMethod { delete }
+enum HttpMethod { delete, post }
 
 Object? _decodeJson(String body, {required int statusCode, required Uri uri}) {
   try {
     return jsonDecode(body);
-  } on FormatException {
+  } on FormatException catch (error, stackTrace) {
     throw ApiException(
       'API JSON 응답을 해석하지 못했습니다.',
       statusCode: statusCode,
       path: uri.path,
+      cause: error,
+      causeStackTrace: stackTrace,
     );
   }
 }

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -10,6 +10,7 @@ import 'package:image_picker/image_picker.dart';
 
 import 'auth_headers.dart';
 import 'core/database/user/user_database.dart' as user_db;
+import 'core/network/api_client.dart';
 import 'mobile_error_reporter.dart';
 import 'secure_key_value_storage.dart';
 
@@ -68,12 +69,16 @@ class FacilityReportApiRepository implements FacilityReportRepository {
     required this.baseUri,
     this.authProvider,
     this.receiptStore,
+    ApiClient? apiClient,
     HttpClient? httpClient,
-  }) : _httpClient = httpClient ?? HttpClient();
+  }) : _apiClient =
+           apiClient ?? ApiClient(baseUri: baseUri, httpClient: httpClient),
+       _httpClient = httpClient ?? HttpClient();
 
   final Uri baseUri;
   final AuthorizationHeaderProvider? authProvider;
   final FacilityReportReceiptStore? receiptStore;
+  final ApiClient _apiClient;
   final HttpClient _httpClient;
 
   @override
@@ -99,27 +104,18 @@ class FacilityReportApiRepository implements FacilityReportRepository {
   ) async {
     final preparedRequest = await _prepareReportRequest(reportRequest);
     for (var attempt = 0; attempt < 2; attempt++) {
-      final request = await _httpClient
-          .postUrl(baseUri.resolve('/api/v1/reports'))
-          .timeout(_facilityReportTimeout);
       final authorizationHeader = await authProvider
           ?.authorizationHeader()
           .timeout(_facilityReportTimeout);
-      if (authorizationHeader != null) {
-        request.headers.set(
-          HttpHeaders.authorizationHeader,
-          authorizationHeader,
-        );
-      }
-      request.headers.contentType = ContentType.json;
-      request.write(jsonEncode(preparedRequest.toJson()));
+      final response = await _apiClient.postJson(
+        '/api/v1/reports',
+        body: preparedRequest.toJson(),
+        headers: authorizationHeader == null
+            ? const {}
+            : {HttpHeaders.authorizationHeader: authorizationHeader},
+      );
 
-      final response = await request.close().timeout(_facilityReportTimeout);
-      final body = await utf8
-          .decodeStream(response)
-          .timeout(_facilityReportTimeout);
-
-      if (response.statusCode == HttpStatus.unauthorized &&
+      if (response.isUnauthorized &&
           authorizationHeader != null &&
           attempt == 0) {
         // 만료된 인증은 비우고 한 번만 다시 시도한다.
@@ -129,13 +125,12 @@ class FacilityReportApiRepository implements FacilityReportRepository {
         continue;
       }
 
-      if (response.statusCode != HttpStatus.created &&
-          response.statusCode != HttpStatus.ok) {
+      if (response.statusCode != HttpStatus.created && !response.isOk) {
         throw const FacilityReportException(_facilityReportErrorMessage);
       }
 
-      final result = _reportResultFromBody(
-        body,
+      final result = _reportResultFromJson(
+        response.jsonBody,
         errorMessage: _facilityReportErrorMessage,
       );
       await _saveReceiptIfPresentSafely(result);
@@ -353,6 +348,13 @@ class FacilityReportApiRepository implements FacilityReportRepository {
     required String errorMessage,
   }) {
     final decoded = jsonDecode(body);
+    return _reportResultFromJson(decoded, errorMessage: errorMessage);
+  }
+
+  FacilityReportResult _reportResultFromJson(
+    Object? decoded, {
+    required String errorMessage,
+  }) {
     if (decoded is! Map<String, Object?> || decoded['success'] != true) {
       throw FacilityReportException(errorMessage);
     }

--- a/apps/mobile/test/core/network/api_client_test.dart
+++ b/apps/mobile/test/core/network/api_client_test.dart
@@ -5,6 +5,59 @@ import 'package:easysubway_mobile/core/network/api_client.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('ApiClient는 POST 요청에 JSON body와 공통 header를 적용한다', () async {
+    late String requestedMethod;
+    late Uri requestedUri;
+    late String? acceptHeader;
+    late ContentType? contentType;
+    late Map<String, Object?> requestBody;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) async {
+      requestedMethod = request.method;
+      requestedUri = request.uri;
+      acceptHeader = request.headers.value(HttpHeaders.acceptHeader);
+      contentType = request.headers.contentType;
+      requestBody =
+          jsonDecode(await utf8.decodeStream(request)) as Map<String, Object?>;
+      request.response
+        ..statusCode = HttpStatus.created
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {'id': 'report-1'},
+          }),
+        );
+      await request.response.close();
+    });
+
+    final client = ApiClient(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    final response = await client.postJson(
+      '/api/v1/reports',
+      body: const {
+        'stationId': 'station-sangnoksu',
+        'description': '문이 열리지 않습니다.',
+      },
+    );
+
+    expect(requestedMethod, 'POST');
+    expect(requestedUri.path, '/api/v1/reports');
+    expect(acceptHeader, ContentType.json.mimeType);
+    expect(contentType?.mimeType, ContentType.json.mimeType);
+    expect(requestBody['stationId'], 'station-sangnoksu');
+    expect(requestBody['description'], '문이 열리지 않습니다.');
+    expect(response.statusCode, HttpStatus.created);
+    expect(response.jsonBody, {
+      'success': true,
+      'data': {'id': 'report-1'},
+    });
+  });
+
   test('ApiClient는 DELETE 요청에 공통 timeout과 JSON decode 경계를 적용한다', () async {
     late String requestedMethod;
     late Uri requestedUri;

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:easysubway_mobile/auth_headers.dart';
+import 'package:easysubway_mobile/core/network/api_client.dart';
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:flutter/foundation.dart';
@@ -595,7 +596,11 @@ void main() {
     });
 
     expect(reportedErrors, hasLength(1));
-    expect(reportedErrors.single.exception, isA<FormatException>());
+    expect(reportedErrors.single.exception, isA<ApiException>());
+    expect(
+      (reportedErrors.single.exception as ApiException).cause,
+      isA<FormatException>(),
+    );
     expect(reportedErrors.single.stack, isNotNull);
   });
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4260,11 +4260,17 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(apiClient, /class ApiClient/);
   assert.match(apiClient, /const defaultApiTimeout = Duration\(seconds: 8\)/);
   assert.match(apiClient, /Future<ApiResponse> deleteJson/);
+  assert.match(apiClient, /Future<ApiResponse> postJson/);
   assert.match(apiClient, /HttpHeaders\.acceptHeader/);
   assert.match(apiClient, /ContentType\.json\.mimeType/);
   assert.match(apiClient, /jsonDecode\(body\)/);
   assert.match(apiClient, /class ApiResponse/);
   assert.match(apiError, /class ApiException implements Exception/);
+  assert.match(facilityReport, /import 'core\/network\/api_client\.dart';/);
+  assert.match(facilityReport, /final ApiClient _apiClient;/);
+  assert.match(facilityReport, /_apiClient\.postJson\([\s\S]*'\/api\/v1\/reports'/);
+  assert.match(appDependencies, /FacilityReportApiRepository\([\s\S]*apiClient: ApiClient\(baseUri: resolvedBaseUri\)/);
+  assert.match(apiClientTest, /ApiClient는 POST 요청에 JSON body와 공통 header를 적용한다/);
   assert.match(apiClientTest, /ApiClient는 DELETE 요청에 공통 timeout과 JSON decode 경계를 적용한다/);
   assert.match(apiClientTest, /ApiClient 예외는 인증 토큰을 노출하지 않는다/);
   assert.match(userDataDeletion, /class UserDataDeletionApiRepository implements UserDataDeletionRepository/);


### PR DESCRIPTION
## 관련 이슈

close #624

## 작업 배경

시설 신고 접수 생성 API가 공통 네트워크 경계 밖에서 직접 `HttpClient.postUrl`과 JSON 인코딩/디코딩을 처리하고 있어, task9 잔여 범위의 shared API client 전환을 작은 단위로 진행했습니다.

## 작업 내용

- `ApiClient`에 `postJson`을 추가해 JSON POST 요청의 Accept/Content-Type header, body 인코딩, timeout, JSON decode, 오류 wrapping을 공통화했습니다.
- `FacilityReportApiRepository`의 신고 접수 생성 `POST /api/v1/reports` 호출을 `_apiClient.postJson`으로 전환했습니다.
- 접수 응답 파싱은 이미 디코딩된 JSON을 받는 helper로 분리했고, JSON 파싱 실패 시 `ApiException.cause`에 원래 `FormatException`을 보존하도록 했습니다.
- 앱 기본 의존성에서 시설 신고 저장소에 `ApiClient`를 명시적으로 주입하고 repository contract 테스트로 회귀를 막았습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/core/network/api_client_test.dart`: 통과
  - `flutter test test/core/network/api_client_test.dart test/facility_report_test.dart`: 통과
  - `flutter analyze`: 통과
  - `flutter test`: 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 출력

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| ApiClient POST JSON 경계 | Flutter test | `flutter test test/core/network/api_client_test.dart` | 로컬 명령 출력: `All tests passed!` | 통과 |
| 시설 신고 접수 생성 경계 | Flutter test | `flutter test test/core/network/api_client_test.dart test/facility_report_test.dart` | 로컬 명령 출력: `All tests passed!` | 통과 |
| 모바일 정적 분석 | Flutter analyzer | `flutter analyze` | 로컬 명령 출력: `No issues found!` | 통과 |
| 전체 모바일 회귀 | Flutter test | `flutter test` | 로컬 명령 출력: `All tests passed!` | 통과 |
| 저장소 계약 | Node test | `node --test tools/ci/repository-contract.test.mjs` | 로컬 명령 출력: `pass 88, fail 0` | 통과 |
| PR CI | GitHub Actions | PR #625 check 확인 | CI: https://github.com/AquilaXk/easysubway/actions/runs/27929485901 | 통과 |
| 릴리즈 산출물 | GitHub Actions | PR #625 release artifact check 확인 | Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/27929485806 | 통과 |
| 코드 리뷰 fallback | GitHub PR review | CodeRabbit rate limit/credit exhausted 확인 후 Codex CLI fallback review 실행 | https://github.com/AquilaXk/easysubway/pull/625#pullrequestreview-4541102910 | 지적 0건 |
| 화면 증거 | Android/iOS | UI 동작, 화면 문구, 접근성 트리를 변경하지 않는 네트워크 경계 리팩터링 | 증거 불필요 사유: 사용자 화면 출력과 접근성 semantics 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `FacilityReportApiRepository._postReportWithAuthorizationRetry`에서 기존 인증 재시도와 200/201 성공 판정이 유지되는지 확인해 주세요.

## 리스크

- 이번 PR은 시설 신고 접수 생성 POST만 전환합니다. 사진 upload intent, 사진 PUT 업로드, receipt token 상태 조회, station/route/favorite API 전환은 task9 잔여 범위로 남습니다.
- 공통 `ApiClient`가 JSON decode 실패를 `ApiException`으로 감싸므로, 테스트는 원인 예외가 `cause`로 보존되는 계약을 확인합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
