### PR TITLE
[Refactor] 시설 신고 상태 조회 API 공통 네트워크 경계 적용

### DIFF
--- a/apps/mobile/lib/core/network/api_client.dart
+++ b/apps/mobile/lib/core/network/api_client.dart
@@ -19,6 +19,13 @@ class ApiClient {
   final Duration timeout;
   final HttpClient _httpClient;
 
+  Future<ApiResponse> getJson(
+    String path, {
+    Map<String, String> headers = const {},
+  }) {
+    return _requestJson(HttpMethod.get, path, headers: headers);
+  }
+
   Future<ApiResponse> deleteJson(
     String path, {
     Map<String, String> headers = const {},
@@ -94,6 +101,8 @@ class ApiClient {
 
   Future<HttpClientRequest> _open(HttpMethod method, Uri uri) {
     switch (method) {
+      case HttpMethod.get:
+        return _httpClient.getUrl(uri);
       case HttpMethod.delete:
         return _httpClient.deleteUrl(uri);
       case HttpMethod.post:
@@ -112,7 +121,7 @@ class ApiResponse {
   bool get isOk => statusCode == HttpStatus.ok;
 }
 
-enum HttpMethod { delete, post }
+enum HttpMethod { get, delete, post }
 
 Object? _decodeJson(String body, {required int statusCode, required Uri uri}) {
   try {

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -268,31 +268,23 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       throw const FacilityReportException(_facilityReportStatusErrorMessage);
     }
 
-    final uri = baseUri.resolve(
-      '/api/v1/reports/${Uri.encodeComponent(trimmedReportId)}',
-    );
-
     try {
-      final request = await _httpClient
-          .getUrl(uri)
-          .timeout(_facilityReportTimeout);
       final receiptToken = await receiptStore
           ?.receiptTokenForReport(trimmedReportId)
           .timeout(_facilityReportTimeout);
-      if (receiptToken != null && receiptToken.isNotEmpty) {
-        request.headers.set('X-Easysubway-Report-Receipt-Token', receiptToken);
-      }
-      final response = await request.close().timeout(_facilityReportTimeout);
+      final response = await _apiClient.getJson(
+        '/api/v1/reports/${Uri.encodeComponent(trimmedReportId)}',
+        headers: receiptToken == null || receiptToken.isEmpty
+            ? const {}
+            : {'X-Easysubway-Report-Receipt-Token': receiptToken},
+      );
 
-      if (response.statusCode != HttpStatus.ok) {
+      if (!response.isOk) {
         throw const FacilityReportException(_facilityReportStatusErrorMessage);
       }
 
-      final body = await utf8
-          .decodeStream(response)
-          .timeout(_facilityReportTimeout);
-      return _reportResultFromBody(
-        body,
+      return _reportResultFromJson(
+        response.jsonBody,
         errorMessage: _facilityReportStatusErrorMessage,
       );
     } on FacilityReportException {
@@ -341,14 +333,6 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       );
       throw const FacilityReportException(_facilityReportListErrorMessage);
     }
-  }
-
-  FacilityReportResult _reportResultFromBody(
-    String body, {
-    required String errorMessage,
-  }) {
-    final decoded = jsonDecode(body);
-    return _reportResultFromJson(decoded, errorMessage: errorMessage);
   }
 
   FacilityReportResult _reportResultFromJson(

--- a/apps/mobile/test/core/network/api_client_test.dart
+++ b/apps/mobile/test/core/network/api_client_test.dart
@@ -5,6 +5,53 @@ import 'package:easysubway_mobile/core/network/api_client.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('ApiClient는 GET 요청에 공통 header와 custom header를 적용한다', () async {
+    late String requestedMethod;
+    late Uri requestedUri;
+    late String? acceptHeader;
+    late String? receiptTokenHeader;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      requestedMethod = request.method;
+      requestedUri = request.uri;
+      acceptHeader = request.headers.value(HttpHeaders.acceptHeader);
+      receiptTokenHeader = request.headers.value(
+        'X-Easysubway-Report-Receipt-Token',
+      );
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {'id': 'report-1', 'status': 'ACCEPTED'},
+          }),
+        )
+        ..close();
+    });
+
+    final client = ApiClient(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    final response = await client.getJson(
+      '/api/v1/reports/report-1',
+      headers: const {'X-Easysubway-Report-Receipt-Token': 'receipt-token-1'},
+    );
+
+    expect(requestedMethod, 'GET');
+    expect(requestedUri.path, '/api/v1/reports/report-1');
+    expect(acceptHeader, ContentType.json.mimeType);
+    expect(receiptTokenHeader, 'receipt-token-1');
+    expect(response.statusCode, HttpStatus.ok);
+    expect(response.jsonBody, {
+      'success': true,
+      'data': {'id': 'report-1', 'status': 'ACCEPTED'},
+    });
+  });
+
   test('ApiClient는 POST 요청에 JSON body와 공통 header를 적용한다', () async {
     late String requestedMethod;
     late Uri requestedUri;

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4259,6 +4259,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(main, /데이터 삭제 요청 시 즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용·사진·위치와 경로 피드백을 삭제하거나 익명화합니다/);
   assert.match(apiClient, /class ApiClient/);
   assert.match(apiClient, /const defaultApiTimeout = Duration\(seconds: 8\)/);
+  assert.match(apiClient, /Future<ApiResponse> getJson/);
   assert.match(apiClient, /Future<ApiResponse> deleteJson/);
   assert.match(apiClient, /Future<ApiResponse> postJson/);
   assert.match(apiClient, /HttpHeaders\.acceptHeader/);
@@ -4268,8 +4269,14 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(apiError, /class ApiException implements Exception/);
   assert.match(facilityReport, /import 'core\/network\/api_client\.dart';/);
   assert.match(facilityReport, /final ApiClient _apiClient;/);
+  assert.match(
+    facilityReport,
+    /_apiClient\.getJson\([\s\S]*'\/api\/v1\/reports\/\$\{Uri\.encodeComponent\(trimmedReportId\)\}'/,
+  );
+  assert.match(facilityReport, /X-Easysubway-Report-Receipt-Token/);
   assert.match(facilityReport, /_apiClient\.postJson\([\s\S]*'\/api\/v1\/reports'/);
   assert.match(appDependencies, /FacilityReportApiRepository\([\s\S]*apiClient: ApiClient\(baseUri: resolvedBaseUri\)/);
+  assert.match(apiClientTest, /ApiClient는 GET 요청에 공통 header와 custom header를 적용한다/);
   assert.match(apiClientTest, /ApiClient는 POST 요청에 JSON body와 공통 header를 적용한다/);
   assert.match(apiClientTest, /ApiClient는 DELETE 요청에 공통 timeout과 JSON decode 경계를 적용한다/);
   assert.match(apiClientTest, /ApiClient 예외는 인증 토큰을 노출하지 않는다/);


### PR DESCRIPTION
## 관련 이슈

close #626

## 작업 배경

시설 신고 상태 조회는 receipt token 헤더와 JSON 응답 파싱을 직접 `HttpClient`로 처리하고 있어, task9의 shared API client 경계 확대 기준에서 아직 남은 조각이었습니다. 신고 접수 POST와 사용자 데이터 삭제 DELETE가 이미 `ApiClient`를 쓰는 흐름에 맞춰 상태 조회 GET도 같은 경계로 모았습니다.

## 작업 내용

- `ApiClient.getJson`을 추가하고 GET 요청도 공통 Accept header, timeout, JSON decode, `ApiException` 경계를 사용하게 했습니다.
- `FacilityReportApiRepository.getReport`가 `GET /api/v1/reports/{reportId}`를 `_apiClient.getJson`으로 호출하도록 바꿨습니다.
- 상태 조회 receipt token 헤더 `X-Easysubway-Report-Receipt-Token` 동작과 기존 오류 문구는 유지했습니다.
- repository contract에 상태 조회 GET 경계와 `ApiClient` GET 테스트를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/facility_report.dart apps/mobile/lib/core/network/api_client.dart apps/mobile/test/core/network/api_client_test.dart` 통과
  - `flutter analyze` 통과, `No issues found!`
  - `flutter test test/core/network/api_client_test.dart test/facility_report_test.dart` 통과, `All tests passed!`
  - `node --test tools/ci/repository-contract.test.mjs` 통과, 88개 테스트 통과
  - `flutter test` 통과, `All tests passed!`
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과는 `.github/pull_request_template.md`, `README.md`만 추적
  - PR CI 통과: https://github.com/AquilaXk/easysubway/actions/runs/27930175610
  - Release Artifacts 통과: https://github.com/AquilaXk/easysubway/actions/runs/27930175437
  - CodeRabbit 완료: actionable comment 0개

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 공통 API client GET 경계 | local macOS / Flutter test | `flutter test test/core/network/api_client_test.dart test/facility_report_test.dart` | 명령 출력: `All tests passed!` | GET header, receipt token, 시설 신고 상태 조회 회귀 없음 |
| repository contract | local Node.js | `node --test tools/ci/repository-contract.test.mjs` | 명령 출력: 88개 테스트 통과 | 상태 조회가 `_apiClient.getJson` 경계를 사용함을 contract로 고정 |
| 모바일 정적 분석 | local Flutter analyzer | `flutter analyze` | 명령 출력: `No issues found!` | analyzer 경고 없음 |
| 전체 모바일 테스트 | local Flutter test | `flutter test` | 명령 출력: `All tests passed!` | 기존 모바일 테스트 회귀 없음 |
| PR CI | GitHub Actions | CI workflow | https://github.com/AquilaXk/easysubway/actions/runs/27930175610 | Android CI, iOS CI, Mobile App CI, Backend CI, Repository CI, OSV 통과 |
| Release Artifacts | GitHub Actions | Release Artifacts workflow | https://github.com/AquilaXk/easysubway/actions/runs/27930175437 | Android/iOS release artifact, backend release image 통과 |
| CodeRabbit review | GitHub PR | CodeRabbit status/comment 확인 | PR #627 conversation | actionable comment 0개, unresolved review thread 0개 |
| 시각 증거 | 해당 없음 | 코드 리팩터 및 네트워크 경계 테스트 | 증거 불필요 사유: UI, 문구, 접근성 흐름, 화면 배치 변경 없음 | 스크린샷 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `FacilityReportApiRepository.getReport`가 receipt token 헤더를 유지하면서 `_apiClient.getJson`을 통해 상태 조회 JSON을 파싱하는 부분입니다.

## 리스크

- GET 요청이 공통 `ApiClient` decode 경계를 타면서 JSON 파싱 실패가 `ApiException`으로 감싸진 뒤 기존 시설 신고 상태 조회 오류 문구로 바뀝니다. 사용자 노출 문구는 기존과 동일합니다.
- 사진 upload intent POST와 object upload PUT은 이번 범위 밖이라 기존 직접 `HttpClient` 경로가 남아 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.