### PR TITLE
[Refactor] 시설 신고 사진 업로드 intent API 공통 네트워크 경계 적용

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -172,31 +172,23 @@ class FacilityReportApiRepository implements FacilityReportRepository {
     required String photoSha256,
     required int photoSizeBytes,
   }) async {
-    final uploadRequest = await _httpClient
-        .postUrl(baseUri.resolve('/api/v1/report-uploads'))
-        .timeout(_facilityReportTimeout);
-    uploadRequest.headers.contentType = ContentType.json;
-    uploadRequest.write(
-      jsonEncode({
+    final uploadResponse = await _apiClient.postJson(
+      '/api/v1/report-uploads',
+      body: {
         'clientSubmissionId': clientSubmissionId,
         'photoFileName': request.photoFileName,
         'photoContentType': request.photoContentType,
         'photoSha256': photoSha256,
         'photoSizeBytes': photoSizeBytes,
-      }),
+      },
     );
-    final uploadResponse = await uploadRequest.close().timeout(
-      _facilityReportTimeout,
-    );
-    final body = await utf8
-        .decodeStream(uploadResponse)
-        .timeout(_facilityReportTimeout);
+
     if (uploadResponse.statusCode != HttpStatus.created &&
-        uploadResponse.statusCode != HttpStatus.ok) {
+        !uploadResponse.isOk) {
       throw const FacilityReportException(_facilityReportErrorMessage);
     }
-    return FacilityReportPhotoUploadIntent.fromBody(
-      body,
+    return FacilityReportPhotoUploadIntent.fromJson(
+      uploadResponse.jsonBody,
       errorMessage: _facilityReportErrorMessage,
     );
   }
@@ -509,11 +501,10 @@ class FacilityReportPhotoUploadIntent {
     this.uploadHeaders = const {},
   });
 
-  factory FacilityReportPhotoUploadIntent.fromBody(
-    String body, {
+  factory FacilityReportPhotoUploadIntent.fromJson(
+    Object? decoded, {
     required String errorMessage,
   }) {
-    final decoded = jsonDecode(body);
     if (decoded is! Map<String, Object?> || decoded['success'] != true) {
       throw FacilityReportException(errorMessage);
     }

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -98,6 +98,7 @@ void main() {
 
   test('시설 신고 API 저장소는 백엔드 계약에 맞춰 신고를 전송한다', () async {
     late String? authorizationHeader;
+    late String? uploadIntentAcceptHeader;
     late String? uploadChecksumHeader;
     late String? uploadSizeHeader;
     late String? uploadContentTypeHeader;
@@ -111,6 +112,9 @@ void main() {
     server.listen((request) async {
       switch ((request.method, request.uri.path)) {
         case ('POST', '/api/v1/report-uploads'):
+          uploadIntentAcceptHeader = request.headers.value(
+            HttpHeaders.acceptHeader,
+          );
           uploadIntentBody =
               jsonDecode(await utf8.decodeStream(request))
                   as Map<String, Object?>;
@@ -206,6 +210,7 @@ void main() {
       ),
     );
 
+    expect(uploadIntentAcceptHeader, ContentType.json.mimeType);
     expect(uploadIntentBody['clientSubmissionId'], 'client-submission-1');
     expect(uploadIntentBody['photoFileName'], 'elevator-door.jpg');
     expect(uploadIntentBody['photoContentType'], 'image/jpeg');

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4274,6 +4274,8 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
     /_apiClient\.getJson\([\s\S]*'\/api\/v1\/reports\/\$\{Uri\.encodeComponent\(trimmedReportId\)\}'/,
   );
   assert.match(facilityReport, /X-Easysubway-Report-Receipt-Token/);
+  assert.match(facilityReport, /_apiClient\.postJson\([\s\S]*'\/api\/v1\/report-uploads'/);
+  assert.doesNotMatch(facilityReport, /postUrl\(baseUri\.resolve\('\/api\/v1\/report-uploads'\)\)/);
   assert.match(facilityReport, /_apiClient\.postJson\([\s\S]*'\/api\/v1\/reports'/);
   assert.match(appDependencies, /FacilityReportApiRepository\([\s\S]*apiClient: ApiClient\(baseUri: resolvedBaseUri\)/);
   assert.match(apiClientTest, /ApiClient는 GET 요청에 공통 header와 custom header를 적용한다/);


### PR DESCRIPTION
## 관련 이슈

close #628

## 작업 배경

시설 신고 접수 POST와 상태 조회 GET은 공통 `ApiClient` 경계를 사용하지만, 사진 업로드 intent 생성 POST는 직접 `HttpClient.postUrl`과 수동 JSON decode를 사용하고 있었습니다. 같은 시설 신고 흐름의 JSON API 요청이 서로 다른 timeout, header, decode 경계를 갖지 않도록 upload intent 생성 요청도 공통 client로 맞췄습니다.

## 작업 내용

- `FacilityReportApiRepository`의 `POST /api/v1/report-uploads` 요청을 `_apiClient.postJson`으로 전환했습니다.
- upload intent 요청 body의 `clientSubmissionId`, `photoFileName`, `photoContentType`, `photoSha256`, `photoSizeBytes` 계약은 유지했습니다.
- upload intent 응답 파싱을 문자열 body decode 대신 `ApiClient`가 decode한 `jsonBody` 기준으로 바꿨습니다.
- 테스트에서 upload intent POST의 `Accept: application/json` 헤더를 확인하고, repository contract에 직접 `postUrl` 회귀 방지를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - RED: `flutter test test/facility_report_test.dart --plain-name "시설 신고 API 저장소는 백엔드 계약에 맞춰 신고를 전송한다"` 실패 확인, upload intent POST의 Accept header가 `null`이라 실패
  - `dart format apps/mobile/lib/facility_report.dart apps/mobile/test/facility_report_test.dart` 통과
  - `flutter test test/facility_report_test.dart --plain-name "시설 신고 API 저장소는 백엔드 계약에 맞춰 신고를 전송한다"` 통과
  - `flutter test test/core/network/api_client_test.dart test/facility_report_test.dart` 통과, `All tests passed!`
  - `node --test tools/ci/repository-contract.test.mjs` 통과, 88개 테스트 통과
  - `flutter analyze` 통과, `No issues found!`
  - `flutter test` 통과, `All tests passed!`
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과는 `.github/pull_request_template.md`, `README.md`만 추적
  - PR CI 통과: https://github.com/AquilaXk/easysubway/actions/runs/27930747936
  - PR Release Artifacts 통과: https://github.com/AquilaXk/easysubway/actions/runs/27930747810
  - CodeRabbit check는 success이나 PR comment에서 review rate limit으로 실제 리뷰가 시작되지 않았음을 확인
  - Codex CLI fallback review 통과: https://github.com/AquilaXk/easysubway/pull/629#pullrequestreview-4541261157, actionable comments 0
  - unresolved review thread 0개 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| upload intent 공통 API client 경계 | local macOS / Flutter test | `flutter test test/facility_report_test.dart --plain-name "시설 신고 API 저장소는 백엔드 계약에 맞춰 신고를 전송한다"` | RED에서 Accept header `null` 실패 후 GREEN 통과 | upload intent POST가 공통 JSON header 경계를 사용함 |
| 시설 신고/API client 회귀 | local macOS / Flutter test | `flutter test test/core/network/api_client_test.dart test/facility_report_test.dart` | 명령 출력: `All tests passed!` | 시설 신고 접수, 상태 조회, upload intent 흐름 회귀 없음 |
| repository contract | local Node.js | `node --test tools/ci/repository-contract.test.mjs` | 명령 출력: 88개 테스트 통과 | upload intent 직접 `postUrl` 회귀 방지 고정 |
| 모바일 정적 분석 | local Flutter analyzer | `flutter analyze` | 명령 출력: `No issues found!` | analyzer 경고 없음 |
| 전체 모바일 테스트 | local Flutter test | `flutter test` | 명령 출력: `All tests passed!` | 기존 모바일 테스트 회귀 없음 |
| PR CI | GitHub Actions | CI workflow | https://github.com/AquilaXk/easysubway/actions/runs/27930747936 | Android CI, iOS CI, Mobile App CI, Backend CI, Repository CI, osv-scan 통과 |
| PR Release Artifacts | GitHub Actions | Release Artifacts workflow | https://github.com/AquilaXk/easysubway/actions/runs/27930747810 | Android/iOS release artifact와 backend release image 생성 검증 통과 |
| 코드 리뷰 | GitHub PR review | CodeRabbit 상태 확인 후 Codex CLI fallback review | https://github.com/AquilaXk/easysubway/pull/629#pullrequestreview-4541261157 | CodeRabbit은 rate limit으로 실제 리뷰 미시작, Codex CLI fallback actionable 0 |
| 시각 증거 | 해당 없음 | 코드 리팩터 및 네트워크 경계 테스트 | 증거 불필요 사유: UI, 문구, 접근성 흐름, 화면 배치 변경 없음 | 스크린샷 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `_createPhotoUploadIntent`가 `_apiClient.postJson`을 사용하면서 signed URL `PUT` 업로드는 기존 직접 `HttpClient.putUrl` 경로로 유지한 부분입니다.

## 리스크

- upload intent JSON 응답 파싱 실패는 이제 `ApiClient`의 JSON decode 경계를 먼저 탑니다. 최종 사용자 노출 오류 문구는 기존 시설 신고 실패 문구로 유지됩니다.
- 사진 object signed URL `PUT`은 이번 범위 밖이라 직접 `HttpClient` 경로가 남아 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
