### PR TITLE
[Refactor] 시설 신고 사진 PUT 업로드 API 공통 네트워크 경계 적용

### DIFF
--- a/apps/mobile/lib/core/network/api_client.dart
+++ b/apps/mobile/lib/core/network/api_client.dart
@@ -46,6 +46,46 @@ class ApiClient {
     );
   }
 
+  Future<ApiResponse> putBytes(
+    Uri uri, {
+    required List<int> body,
+    required ContentType contentType,
+    Map<String, String> headers = const {},
+  }) async {
+    try {
+      final request = await _httpClient.putUrl(uri).timeout(timeout);
+      headers.forEach(request.headers.set);
+      request.headers.contentType = contentType;
+      request.contentLength = body.length;
+      request.add(body);
+
+      final response = await request.close().timeout(timeout);
+      await response.drain<void>().timeout(timeout);
+      return ApiResponse(statusCode: response.statusCode, jsonBody: null);
+    } on TimeoutException catch (error, stackTrace) {
+      throw ApiException(
+        'API 요청 시간이 초과되었습니다.',
+        path: uri.path,
+        cause: error,
+        causeStackTrace: stackTrace,
+      );
+    } on SocketException catch (error, stackTrace) {
+      throw ApiException(
+        'API 서버에 연결하지 못했습니다.',
+        path: uri.path,
+        cause: error,
+        causeStackTrace: stackTrace,
+      );
+    } catch (error, stackTrace) {
+      throw ApiException(
+        'API 요청을 처리하지 못했습니다.',
+        path: uri.path,
+        cause: error,
+        causeStackTrace: stackTrace,
+      );
+    }
+  }
+
   Future<ApiResponse> _requestJson(
     HttpMethod method,
     String path, {
@@ -119,6 +159,7 @@ class ApiResponse {
 
   bool get isUnauthorized => statusCode == HttpStatus.unauthorized;
   bool get isOk => statusCode == HttpStatus.ok;
+  bool get isSuccess => _isSuccessStatus(statusCode);
 }
 
 enum HttpMethod { get, delete, post }

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -72,14 +72,12 @@ class FacilityReportApiRepository implements FacilityReportRepository {
     ApiClient? apiClient,
     HttpClient? httpClient,
   }) : _apiClient =
-           apiClient ?? ApiClient(baseUri: baseUri, httpClient: httpClient),
-       _httpClient = httpClient ?? HttpClient();
+           apiClient ?? ApiClient(baseUri: baseUri, httpClient: httpClient);
 
   final Uri baseUri;
   final AuthorizationHeaderProvider? authProvider;
   final FacilityReportReceiptStore? receiptStore;
   final ApiClient _apiClient;
-  final HttpClient _httpClient;
 
   @override
   Future<FacilityReportResult> createReport(
@@ -201,20 +199,13 @@ class FacilityReportApiRepository implements FacilityReportRepository {
     if (uploadIntent.uploadMethod.trim().toUpperCase() != 'PUT') {
       throw const FacilityReportException(_facilityReportErrorMessage);
     }
-    final uploadRequest = await _httpClient
-        .putUrl(uploadIntent.uploadUri(baseUri))
-        .timeout(_facilityReportTimeout);
-    for (final header in uploadIntent.uploadHeaders.entries) {
-      uploadRequest.headers.set(header.key, header.value);
-    }
-    uploadRequest.headers.contentType = ContentType.parse(contentType);
-    uploadRequest.contentLength = photoBytes.length;
-    uploadRequest.add(photoBytes);
-    final uploadResponse = await uploadRequest.close().timeout(
-      _facilityReportTimeout,
+    final uploadResponse = await _apiClient.putBytes(
+      uploadIntent.uploadUri(baseUri),
+      body: photoBytes,
+      contentType: ContentType.parse(contentType),
+      headers: uploadIntent.uploadHeaders,
     );
-    await uploadResponse.drain<void>();
-    if (uploadResponse.statusCode < 200 || uploadResponse.statusCode >= 300) {
+    if (!uploadResponse.isSuccess) {
       throw const FacilityReportException(_facilityReportErrorMessage);
     }
   }

--- a/apps/mobile/test/core/network/api_client_test.dart
+++ b/apps/mobile/test/core/network/api_client_test.dart
@@ -105,6 +105,51 @@ void main() {
     });
   });
 
+  test('ApiClient는 PUT bytes 요청에 body와 upload header를 적용한다', () async {
+    late String requestedMethod;
+    late Uri requestedUri;
+    late String? checksumHeader;
+    late ContentType? contentType;
+    late int? contentLength;
+    late List<int> requestBody;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) async {
+      requestedMethod = request.method;
+      requestedUri = request.uri;
+      checksumHeader = request.headers.value('x-amz-checksum-sha256');
+      contentType = request.headers.contentType;
+      contentLength = request.headers.contentLength;
+      requestBody = await request.fold<List<int>>(
+        <int>[],
+        (bytes, chunk) => bytes..addAll(chunk),
+      );
+      request.response.statusCode = HttpStatus.created;
+      await request.response.close();
+    });
+
+    final client = ApiClient(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    final response = await client.putBytes(
+      Uri.parse('http://${server.address.host}:${server.port}/uploads/photo'),
+      body: const [1, 2, 3, 4],
+      contentType: ContentType('image', 'jpeg'),
+      headers: const {'x-amz-checksum-sha256': 'checksum-1'},
+    );
+
+    expect(requestedMethod, 'PUT');
+    expect(requestedUri.path, '/uploads/photo');
+    expect(checksumHeader, 'checksum-1');
+    expect(contentType?.mimeType, 'image/jpeg');
+    expect(contentLength, 4);
+    expect(requestBody, [1, 2, 3, 4]);
+    expect(response.statusCode, HttpStatus.created);
+    expect(response.isSuccess, isTrue);
+  });
+
   test('ApiClient는 DELETE 요청에 공통 timeout과 JSON decode 경계를 적용한다', () async {
     late String requestedMethod;
     late Uri requestedUri;

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4276,6 +4276,8 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(facilityReport, /X-Easysubway-Report-Receipt-Token/);
   assert.match(facilityReport, /_apiClient\.postJson\([\s\S]*'\/api\/v1\/report-uploads'/);
   assert.doesNotMatch(facilityReport, /postUrl\(baseUri\.resolve\('\/api\/v1\/report-uploads'\)\)/);
+  assert.match(facilityReport, /_apiClient\.putBytes\([\s\S]*uploadIntent\.uploadUri\(baseUri\)/);
+  assert.doesNotMatch(facilityReport, /putUrl\(uploadIntent\.uploadUri\(baseUri\)\)/);
   assert.match(facilityReport, /_apiClient\.postJson\([\s\S]*'\/api\/v1\/reports'/);
   assert.match(appDependencies, /FacilityReportApiRepository\([\s\S]*apiClient: ApiClient\(baseUri: resolvedBaseUri\)/);
   assert.match(apiClientTest, /ApiClient는 GET 요청에 공통 header와 custom header를 적용한다/);


### PR DESCRIPTION
## 관련 이슈

close #630

## 작업 배경

시설 신고의 접수, 상태 조회, 사진 업로드 intent 생성은 공통 `ApiClient` 경계를 사용하지만 signed URL 사진 `PUT` 업로드는 직접 `HttpClient.putUrl`로 열고 있었습니다. 사진 업로드 흐름의 timeout, socket error, 성공 status 판단을 같은 네트워크 경계로 모으기 위해 binary upload 전용 `putBytes`를 좁게 추가했습니다.

## 작업 내용

- `ApiClient.putBytes`를 추가해 bytes body, content type, content length, upload headers, timeout, socket error를 공통 처리하도록 했습니다.
- `FacilityReportApiRepository._uploadPhoto`가 직접 `putUrl`을 열지 않고 `_apiClient.putBytes`를 사용하도록 전환했습니다.
- `ApiResponse.isSuccess`를 추가해 JSON 응답이 없는 upload status도 같은 성공 판정 경계를 쓰게 했습니다.
- API client 테스트와 repository contract에 사진 `PUT` 업로드 공통 client 사용 회귀 방지를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - RED: `flutter test test/core/network/api_client_test.dart --plain-name "ApiClient는 PUT bytes 요청에 body와 upload header를 적용한다"` 실패 확인, `ApiClient.putBytes` 미정의
  - `dart format lib/core/network/api_client.dart lib/facility_report.dart test/core/network/api_client_test.dart` 통과
  - `flutter test test/core/network/api_client_test.dart --plain-name "ApiClient는 PUT bytes 요청에 body와 upload header를 적용한다"` 통과
  - `flutter test test/core/network/api_client_test.dart test/facility_report_test.dart` 통과, 27개 테스트 통과
  - `node --test tools/ci/repository-contract.test.mjs` 통과, 88개 테스트 통과
  - `flutter analyze` 통과, `No issues found!`
  - `flutter test` 통과, `All tests passed!`, 339개 테스트 통과
  - `git diff --check` 통과
  - `git ls-files '*.md'` 결과는 `.github/pull_request_template.md`, `README.md`만 추적
  - PR CI 통과: https://github.com/AquilaXk/easysubway/actions/runs/27931429014
  - PR Release Artifacts 통과: https://github.com/AquilaXk/easysubway/actions/runs/27931428884
  - CodeRabbit check는 success이나 PR comment에서 review rate limit으로 실제 리뷰가 시작되지 않았음을 확인
  - Codex CLI fallback review 통과: https://github.com/AquilaXk/easysubway/pull/631#pullrequestreview-4541343313, actionable comments 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| ApiClient binary PUT 경계 | local macOS / Flutter test | `flutter test test/core/network/api_client_test.dart --plain-name "ApiClient는 PUT bytes 요청에 body와 upload header를 적용한다"` | RED에서 `putBytes` 미정의 실패 후 GREEN 통과 | bytes body, upload header, content type, content length, success status 확인 |
| 시설 신고 사진 업로드 회귀 | local macOS / Flutter test | `flutter test test/core/network/api_client_test.dart test/facility_report_test.dart` | 명령 출력: 27개 테스트 통과 | 시설 신고 사진 upload intent와 signed URL PUT 흐름 회귀 없음 |
| repository contract | local Node.js | `node --test tools/ci/repository-contract.test.mjs` | 명령 출력: 88개 테스트 통과 | 직접 `putUrl(uploadIntent.uploadUri(baseUri))` 회귀 방지 |
| 모바일 정적 분석 | local Flutter analyzer | `flutter analyze` | 명령 출력: `No issues found!` | analyzer 경고 없음 |
| 전체 모바일 테스트 | local Flutter test | `flutter test` | 명령 출력: `All tests passed!`, 339개 테스트 통과 | 기존 모바일 테스트 회귀 없음 |
| PR CI | GitHub Actions | CI workflow | https://github.com/AquilaXk/easysubway/actions/runs/27931429014 | Android CI, iOS CI, Mobile App CI, Backend CI, Repository CI, osv-scan 통과 |
| PR Release Artifacts | GitHub Actions | Release Artifacts workflow | https://github.com/AquilaXk/easysubway/actions/runs/27931428884 | Android/iOS release artifact와 backend release image 생성 검증 통과 |
| 코드 리뷰 | GitHub PR review | CodeRabbit 상태 확인 후 Codex CLI fallback review | https://github.com/AquilaXk/easysubway/pull/631#pullrequestreview-4541343313 | CodeRabbit은 rate limit으로 실제 리뷰 미시작, Codex CLI fallback actionable 0 |
| 시각 증거 | 해당 없음 | 코드 리팩터 및 네트워크 경계 테스트 | 증거 불필요 사유: UI, 문구, 접근성 흐름, 화면 배치 변경 없음 | 스크린샷 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `ApiClient.putBytes`가 JSON decode를 하지 않고 response body를 drain한 뒤 status만 반환하는 점입니다. signed URL upload 응답은 JSON body 계약이 아니므로 기존 `postJson/getJson`과 분리했습니다.

## 리스크

- `ApiClient.putBytes`는 absolute signed URL도 받도록 `Uri`를 직접 인자로 사용합니다. 기존 상대 upload URL 해석은 `FacilityReportPhotoUploadIntent.uploadUri(baseUri)`에 남겼습니다.
- station, route, favorite API repository migration과 대형 파일 분리는 이번 범위 밖입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
