### PR TITLE
[Refactor] 역 검색 API 공통 네트워크 경계 적용

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -7,12 +7,12 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'auth_headers.dart';
+import 'core/network/api_client.dart';
 import 'facility_report.dart';
 import 'internal_route.dart';
 import 'map_adapter.dart';
 import 'mobile_error_reporter.dart';
 
-const _stationSearchTimeout = Duration(seconds: 8);
 const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
 const _currentLocationDisabledMessage = '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
 const _nearbyLocationMaxAge = Duration(minutes: 5);
@@ -298,11 +298,15 @@ class MethodChannelCurrentLocationProvider implements CurrentLocationProvider {
 
 class StationSearchApiRepository
     implements StationSearchRepository, StationLineFilterRepository {
-  StationSearchApiRepository({required this.baseUri, HttpClient? httpClient})
-    : _httpClient = httpClient ?? HttpClient();
+  StationSearchApiRepository({
+    required this.baseUri,
+    ApiClient? apiClient,
+    HttpClient? httpClient,
+  }) : _apiClient =
+           apiClient ?? ApiClient(baseUri: baseUri, httpClient: httpClient);
 
   final Uri baseUri;
-  final HttpClient _httpClient;
+  final ApiClient _apiClient;
 
   @override
   Future<List<StationSearchResult>> searchStations(String query) async {
@@ -320,11 +324,12 @@ class StationSearchApiRepository
   Future<List<StationSearchResult>> _searchStations(
     Map<String, String> queryParameters,
   ) async {
-    final uri = baseUri
-        .resolve('/api/v1/stations')
-        .replace(queryParameters: queryParameters);
+    final path = Uri(
+      path: '/api/v1/stations',
+      queryParameters: queryParameters,
+    ).toString();
 
-    final data = await _getData(uri);
+    final data = await _getData(path);
     if (data is! List<Object?>) {
       throw const StationSearchException(_stationSearchErrorMessage);
     }
@@ -350,7 +355,7 @@ class StationSearchApiRepository
 
   @override
   Future<List<SubwayLineOption>> listLines() async {
-    final data = await _getData(baseUri.resolve('/api/v1/lines'));
+    final data = await _getData('/api/v1/lines');
     if (data is! List<Object?>) {
       throw const StationSearchException(_stationSearchErrorMessage);
     }
@@ -380,18 +385,17 @@ class StationSearchApiRepository
     int radiusMeters = 2000,
     int limit = 10,
   }) async {
-    final uri = baseUri
-        .resolve('/api/v1/stations/nearby')
-        .replace(
-          queryParameters: {
-            'lat': location.latitude.toString(),
-            'lng': location.longitude.toString(),
-            'radiusMeters': radiusMeters.toString(),
-            'limit': limit.toString(),
-          },
-        );
+    final path = Uri(
+      path: '/api/v1/stations/nearby',
+      queryParameters: {
+        'lat': location.latitude.toString(),
+        'lng': location.longitude.toString(),
+        'radiusMeters': radiusMeters.toString(),
+        'limit': limit.toString(),
+      },
+    ).toString();
 
-    final data = await _getData(uri);
+    final data = await _getData(path);
     if (data is! List<Object?>) {
       throw const StationSearchException(_stationSearchErrorMessage);
     }
@@ -417,10 +421,9 @@ class StationSearchApiRepository
 
   @override
   Future<StationDetail> getStationDetail(String stationId) async {
-    final uri = baseUri.resolve(
+    final data = await _getData(
       '/api/v1/stations/${Uri.encodeComponent(stationId)}',
     );
-    final data = await _getData(uri);
     if (data is! Map<String, Object?>) {
       throw const StationSearchException(_stationSearchErrorMessage);
     }
@@ -434,10 +437,9 @@ class StationSearchApiRepository
 
   @override
   Future<List<StationExitInfo>> listStationExits(String stationId) async {
-    final uri = baseUri.resolve(
+    final data = await _getData(
       '/api/v1/stations/${Uri.encodeComponent(stationId)}/exits',
     );
-    final data = await _getData(uri);
     if (data is! List<Object?>) {
       throw const StationSearchException(_stationSearchErrorMessage);
     }
@@ -464,10 +466,9 @@ class StationSearchApiRepository
   Future<List<StationFacilityInfo>> listStationFacilities(
     String stationId,
   ) async {
-    final uri = baseUri.resolve(
+    final data = await _getData(
       '/api/v1/stations/${Uri.encodeComponent(stationId)}/facilities',
     );
-    final data = await _getData(uri);
     if (data is! List<Object?>) {
       throw const StationSearchException(_stationSearchErrorMessage);
     }
@@ -490,21 +491,13 @@ class StationSearchApiRepository
     }
   }
 
-  Future<Object?> _getData(Uri uri) async {
+  Future<Object?> _getData(String path) async {
     try {
-      final request = await _httpClient
-          .getUrl(uri)
-          .timeout(_stationSearchTimeout);
-      final response = await request.close().timeout(_stationSearchTimeout);
-      final body = await utf8
-          .decodeStream(response)
-          .timeout(_stationSearchTimeout);
-
+      final response = await _apiClient.getJson(path);
       if (response.statusCode != HttpStatus.ok) {
         throw const StationSearchException(_stationSearchErrorMessage);
       }
-
-      final decoded = jsonDecode(body);
+      final decoded = response.jsonBody;
       if (decoded is! Map<String, Object?> || decoded['success'] != true) {
         throw const StationSearchException(_stationSearchErrorMessage);
       }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4128,8 +4128,13 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(stationSearch, /final double\? longitude/);
   assert.match(stationSearch, /_optionalDouble\(json, 'latitude'\)/);
   assert.match(stationSearch, /_optionalDouble\(json, 'longitude'\)/);
-  assert.match(stationSearch, /_httpClient\s*\.\s*getUrl\(uri\)\s*\.\s*timeout\(_stationSearchTimeout\)/);
-  assert.match(stationSearch, /request\.close\(\)\.timeout\(_stationSearchTimeout\)/);
+  assert.match(stationSearch, /import 'core\/network\/api_client\.dart';/);
+  assert.match(stationSearch, /class StationSearchApiRepository[\s\S]*final ApiClient _apiClient;/);
+  assert.match(stationSearch, /_apiClient\.getJson\(/);
+  assert.doesNotMatch(
+    stationSearch,
+    /class StationSearchApiRepository[\s\S]*?_httpClient[\s\S]*?class FavoriteStationApiRepository/,
+  );
   assert.match(stationSearch, /HttpStatus\.unauthorized/);
   assert.match(stationSearch, /invalidateAuthorization\(\)/);
   assert.match(stationSearch, /package:flutter\/foundation\.dart/);


### PR DESCRIPTION
## 관련 이슈

close #632

## 작업 배경

역 검색 원격 repository가 직접 `HttpClient.getUrl`과 개별 timeout/json decode 경계를 가지고 있어, 이미 도입된 shared `ApiClient` 정책과 분리되어 있었습니다. 이번 PR은 task9 잔여 범위 중 역 검색 GET 호출만 좁게 이전합니다.

## 작업 내용

- `StationSearchApiRepository`가 역 검색, 노선 목록, 주변 역, 역 상세/출구/시설 GET 요청을 `ApiClient.getJson`으로 수행하도록 변경했습니다.
- 기존 `StationSearchException` 사용자 문구와 backend `success/data` payload 파싱 계약은 유지했습니다.
- repository contract에서 역 검색 repository가 `ApiClient` 경계를 사용하고 직접 `_httpClient`를 갖지 않도록 회귀 검사를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` RED: `api_client.dart` import와 `_apiClient` 부재로 실패 확인
  - `flutter test test/station_search_test.dart test/core/network/api_client_test.dart`: 41 tests passed
  - `node --test tools/ci/repository-contract.test.mjs`: 88 tests passed
  - `flutter analyze`: No issues found
  - `flutter test`: 339 tests passed
  - `git diff --check`: passed
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md` only
  - PR CI: https://github.com/AquilaXk/easysubway/actions/runs/27932070413 success
  - PR Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/27932070301 success
  - Codex CLI fallback review: https://github.com/AquilaXk/easysubway/pull/633#pullrequestreview-4541412502 actionable 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| StationSearch API client boundary | local | repository contract RED/GREEN | `node --test tools/ci/repository-contract.test.mjs` | RED 후 88 tests passed |
| 역 검색 repository 동작 | Flutter local | 관련 단위 테스트 | `flutter test test/station_search_test.dart test/core/network/api_client_test.dart` | 41 tests passed |
| 모바일 전체 회귀 | Flutter local | 전체 테스트 | `flutter test` | 339 tests passed |
| 정적 분석 | Flutter local | analyzer | `flutter analyze` | No issues found |
| 문서 추적 정책 | local git | tracked Markdown 확인 | `git ls-files '*.md'` | 허용된 2개만 추적 |
| PR CI | GitHub Actions | PR check run | https://github.com/AquilaXk/easysubway/actions/runs/27932070413 | success |
| PR Release Artifacts | GitHub Actions | PR artifact run | https://github.com/AquilaXk/easysubway/actions/runs/27932070301 | success |
| Code review | GitHub PR review | CodeRabbit rate limit 후 Codex CLI fallback | https://github.com/AquilaXk/easysubway/pull/633#pullrequestreview-4541412502 | actionable 0 |
| 화면 증거 | 해당 없음 | UI/문구 변경 없음 | 증거 불필요 사유: 네트워크 repository 경계 이전만 수행 | 영향 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `StationSearchApiRepository._getData`가 `ApiClient.getJson` 응답을 기존 `success/data` contract로 해석하는 부분

## 리스크

- query parameter 생성 경로가 `Uri(path:, queryParameters:)`로 바뀌었으므로 기존 검색어/노선/위치 파라미터 인코딩이 유지되는지 테스트로 확인했습니다.
- 즐겨찾기 역 API repository는 이번 slice 범위 밖이라 직접 `HttpClient` 경계가 남아 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.