### PR TITLE
[Refactor] 경로 검색 API 공통 네트워크 경계 적용

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import 'auth_headers.dart';
+import 'core/network/api_client.dart';
 import 'mobile_error_reporter.dart';
 import 'mobility_profile.dart';
 import 'station_search.dart';
@@ -78,33 +79,29 @@ class RouteFeedbackRequest {
 }
 
 class RouteSearchApiRepository implements RouteSearchRepository {
-  RouteSearchApiRepository({required this.baseUri, HttpClient? httpClient})
-    : _httpClient = httpClient ?? HttpClient();
+  RouteSearchApiRepository({
+    required this.baseUri,
+    ApiClient? apiClient,
+    HttpClient? httpClient,
+  }) : _apiClient =
+           apiClient ?? ApiClient(baseUri: baseUri, httpClient: httpClient);
 
   final Uri baseUri;
-  final HttpClient _httpClient;
+  final ApiClient _apiClient;
 
   @override
   Future<RouteSearchResult> searchRoute(RouteSearchRequest routeRequest) async {
-    final uri = baseUri.resolve('/api/v1/routes/search');
-
     try {
-      final request = await _httpClient
-          .postUrl(uri)
-          .timeout(_routeSearchTimeout);
-      request.headers.contentType = ContentType.json;
-      request.write(jsonEncode(routeRequest.toJson()));
+      final response = await _apiClient.postJson(
+        '/api/v1/routes/search',
+        body: routeRequest.toJson(),
+      );
 
-      final response = await request.close().timeout(_routeSearchTimeout);
-      final body = await utf8
-          .decodeStream(response)
-          .timeout(_routeSearchTimeout);
-
-      if (response.statusCode != HttpStatus.ok) {
+      if (!response.isOk) {
         throw const RouteSearchException(_routeSearchErrorMessage);
       }
 
-      final decoded = jsonDecode(body);
+      final decoded = response.jsonBody;
       if (decoded is! Map<String, Object?> || decoded['success'] != true) {
         throw const RouteSearchException(_routeSearchErrorMessage);
       }
@@ -132,12 +129,14 @@ class RouteFeedbackApiRepository implements RouteFeedbackRepository {
   RouteFeedbackApiRepository({
     required this.baseUri,
     required this.authProvider,
+    ApiClient? apiClient,
     HttpClient? httpClient,
-  }) : _httpClient = httpClient ?? HttpClient();
+  }) : _apiClient =
+           apiClient ?? ApiClient(baseUri: baseUri, httpClient: httpClient);
 
   final Uri baseUri;
   final AuthorizationHeaderProvider authProvider;
-  final HttpClient _httpClient;
+  final ApiClient _apiClient;
 
   @override
   Future<void> submitRouteFeedback(RouteFeedbackRequest feedbackRequest) async {
@@ -146,9 +145,8 @@ class RouteFeedbackApiRepository implements RouteFeedbackRepository {
       throw const RouteFeedbackException(_routeFeedbackErrorMessage);
     }
 
-    final uri = baseUri.resolve(
-      '/api/v1/routes/${Uri.encodeComponent(trimmedRequest.routeSearchId)}/feedback',
-    );
+    final path =
+        '/api/v1/routes/${Uri.encodeComponent(trimmedRequest.routeSearchId)}/feedback';
 
     for (var attempt = 0; attempt < 2; attempt++) {
       try {
@@ -161,34 +159,25 @@ class RouteFeedbackApiRepository implements RouteFeedbackRepository {
           throw const RouteFeedbackException(_routeFeedbackErrorMessage);
         }
 
-        final request = await _httpClient
-            .postUrl(uri)
-            .timeout(_routeSearchTimeout);
-        request.headers.contentType = ContentType.json;
-        request.headers.set(
-          HttpHeaders.authorizationHeader,
-          authorizationHeader!,
+        final response = await _apiClient.postJson(
+          path,
+          body: trimmedRequest.toJson(userId: userId),
+          headers: {HttpHeaders.authorizationHeader: authorizationHeader!},
         );
-        request.write(jsonEncode(trimmedRequest.toJson(userId: userId)));
-
-        final response = await request.close().timeout(_routeSearchTimeout);
-        final body = await utf8
-            .decodeStream(response)
-            .timeout(_routeSearchTimeout);
 
         // 저장된 인증이 만료된 경우 한 번만 재시도한다.
-        if (response.statusCode == HttpStatus.unauthorized && attempt == 0) {
+        if (response.isUnauthorized && attempt == 0) {
           await authProvider.invalidateAuthorization().timeout(
             _routeSearchTimeout,
           );
           continue;
         }
 
-        if (response.statusCode != HttpStatus.ok) {
+        if (!response.isOk) {
           throw const RouteFeedbackException(_routeFeedbackErrorMessage);
         }
 
-        final decoded = jsonDecode(body);
+        final decoded = response.jsonBody;
         if (decoded is! Map<String, Object?> || decoded['success'] != true) {
           throw const RouteFeedbackException(_routeFeedbackErrorMessage);
         }
@@ -259,18 +248,20 @@ class FavoriteRouteApiRepository implements FavoriteRouteRepository {
   FavoriteRouteApiRepository({
     required this.baseUri,
     required this.authProvider,
+    ApiClient? apiClient,
     HttpClient? httpClient,
-  }) : _httpClient = httpClient ?? HttpClient();
+  }) : _apiClient =
+           apiClient ?? ApiClient(baseUri: baseUri, httpClient: httpClient);
 
   final Uri baseUri;
   final AuthorizationHeaderProvider authProvider;
-  final HttpClient _httpClient;
+  final ApiClient _apiClient;
 
   @override
   Future<List<FavoriteRoute>> listFavoriteRoutes() async {
     final data = await _requestData(
       'GET',
-      baseUri.resolve('/api/v1/me/favorites/routes'),
+      '/api/v1/me/favorites/routes',
       errorMessage: _favoriteRouteLoadErrorMessage,
     );
     if (data is! List<Object?>) {
@@ -303,7 +294,7 @@ class FavoriteRouteApiRepository implements FavoriteRouteRepository {
   }) async {
     final data = await _requestData(
       'POST',
-      baseUri.resolve('/api/v1/me/favorites/routes'),
+      '/api/v1/me/favorites/routes',
       body: {'routeSearchId': routeSearchId},
       errorMessage: _favoriteRouteErrorMessage,
     );
@@ -327,42 +318,35 @@ class FavoriteRouteApiRepository implements FavoriteRouteRepository {
   Future<void> removeFavoriteRoute(String favoriteRouteId) async {
     await _requestData(
       'DELETE',
-      baseUri.resolve('/api/v1/me/favorites/routes/$favoriteRouteId'),
+      '/api/v1/me/favorites/routes/$favoriteRouteId',
       errorMessage: _favoriteRouteErrorMessage,
     );
   }
 
   Future<Object?> _requestData(
     String method,
-    Uri uri, {
+    String path, {
     Map<String, Object?>? body,
     required String errorMessage,
   }) async {
     for (var attempt = 0; attempt < 2; attempt++) {
       try {
-        final request = await _httpClient
-            .openUrl(method, uri)
-            .timeout(_routeSearchTimeout);
         final authorizationHeader = await authProvider
             .authorizationHeader()
             .timeout(_routeSearchTimeout);
+        final headers = <String, String>{};
         if (authorizationHeader != null) {
-          request.headers.set(
-            HttpHeaders.authorizationHeader,
-            authorizationHeader,
-          );
-        }
-        if (body != null) {
-          request.headers.contentType = ContentType.json;
-          request.write(jsonEncode(body));
+          headers[HttpHeaders.authorizationHeader] = authorizationHeader;
         }
 
-        final response = await request.close().timeout(_routeSearchTimeout);
-        final responseBody = await utf8
-            .decodeStream(response)
-            .timeout(_routeSearchTimeout);
+        final response = await switch (method) {
+          'GET' => _apiClient.getJson(path, headers: headers),
+          'POST' => _apiClient.postJson(path, body: body!, headers: headers),
+          'DELETE' => _apiClient.deleteJson(path, headers: headers),
+          _ => throw FavoriteRouteException(errorMessage),
+        };
 
-        if (response.statusCode == HttpStatus.unauthorized &&
+        if (response.isUnauthorized &&
             authorizationHeader != null &&
             attempt == 0) {
           // 만료된 인증은 비우고 한 번만 다시 시도한다.
@@ -372,12 +356,11 @@ class FavoriteRouteApiRepository implements FavoriteRouteRepository {
           continue;
         }
 
-        if (response.statusCode < HttpStatus.ok ||
-            response.statusCode >= HttpStatus.multipleChoices) {
+        if (!response.isSuccess) {
           throw FavoriteRouteException(errorMessage);
         }
 
-        final decoded = jsonDecode(responseBody);
+        final decoded = response.jsonBody;
         if (decoded is! Map<String, Object?> || decoded['success'] != true) {
           throw FavoriteRouteException(errorMessage);
         }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4255,6 +4255,27 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(routeSearch, /네트워크 상태를 확인한 뒤 다시 불러와 주세요\./);
   assert.match(widgetTest, /즐겨찾기 경로 저장 실패는 다음 행동을 쉬운 문구로 안내한다/);
   assert.match(widgetTest, /즐겨찾기 경로 목록 실패는 다음 행동을 쉬운 문구로 안내한다/);
+  assert.match(routeSearch, /import 'core\/network\/api_client\.dart';/);
+  assert.match(routeSearch, /class RouteSearchApiRepository[\s\S]*final ApiClient _apiClient;/);
+  assert.match(routeSearch, /class RouteSearchApiRepository[\s\S]*_apiClient\.postJson\(/);
+  assert.doesNotMatch(
+    routeSearch,
+    /class RouteSearchApiRepository[\s\S]*?_httpClient[\s\S]*?class RouteFeedbackApiRepository/,
+  );
+  assert.match(routeSearch, /class RouteFeedbackApiRepository[\s\S]*final ApiClient _apiClient;/);
+  assert.match(routeSearch, /class RouteFeedbackApiRepository[\s\S]*_apiClient\.postJson\(/);
+  assert.doesNotMatch(
+    routeSearch,
+    /class RouteFeedbackApiRepository[\s\S]*?_httpClient[\s\S]*?class RouteFeedbackException/,
+  );
+  assert.match(routeSearch, /class FavoriteRouteApiRepository[\s\S]*final ApiClient _apiClient;/);
+  assert.match(routeSearch, /class FavoriteRouteApiRepository[\s\S]*_apiClient\.getJson\(/);
+  assert.match(routeSearch, /class FavoriteRouteApiRepository[\s\S]*_apiClient\.postJson\(/);
+  assert.match(routeSearch, /class FavoriteRouteApiRepository[\s\S]*_apiClient\.deleteJson\(/);
+  assert.doesNotMatch(
+    routeSearch,
+    /class FavoriteRouteApiRepository[\s\S]*?_httpClient[\s\S]*?class FavoriteRouteException/,
+  );
   assert.match(main, /개인정보 사용 안내/);
   assert.match(main, /안전과 데이터 안내/);
   assert.match(main, /현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다/);


### PR DESCRIPTION
## 관련 이슈

close #634

## 작업 배경

경로 검색, 경로 피드백, 즐겨찾기 경로 API repository가 직접 `HttpClient`와 JSON decode를 처리하고 있었다. user data, facility report, station search 쪽은 이미 `ApiClient` 경계로 이동했으므로 route/favorite route 호출도 같은 timeout, status, JSON decode 경계로 맞춘다.

## 작업 내용

- `RouteSearchApiRepository`의 `/api/v1/routes/search` POST를 `ApiClient.postJson`으로 교체했다.
- `RouteFeedbackApiRepository`의 feedback POST를 `ApiClient.postJson`으로 교체하고 Basic 인증 사용자 식별자 추출과 401 1회 invalidation 재시도는 유지했다.
- `FavoriteRouteApiRepository`의 list/save/remove 요청을 `ApiClient.getJson`, `postJson`, `deleteJson`으로 교체했다.
- repository contract에 `route_search.dart`의 route/favorite route repository가 shared `ApiClient`를 쓰고 직접 `_httpClient`를 갖지 않도록 고정했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs`: RED에서 route_search ApiClient import 누락으로 실패 확인 후 GREEN 88개 통과
  - `cd apps/mobile && flutter test test/route_search_test.dart test/core/network/api_client_test.dart`: 16개 통과
  - `cd apps/mobile && flutter analyze`: No issues found
  - `cd apps/mobile && flutter test`: 339개 통과
  - `git diff --check`: 통과
  - `git ls-files "*.md"`: `.github/pull_request_template.md`, `README.md`만 출력
  - PR CI: https://github.com/AquilaXk/easysubway/actions/runs/27932866718 성공
  - PR Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/27932866524 성공
  - CodeRabbit: rate limit과 prepaid credit exhaustion으로 실제 리뷰 시작 불가 확인
  - Codex CLI fallback review: https://github.com/AquilaXk/easysubway/pull/635#pullrequestreview-4541501921, actionable 0
  - post-merge CI: https://github.com/AquilaXk/easysubway/actions/runs/27933129924 성공
  - post-merge CD: https://github.com/AquilaXk/easysubway/actions/runs/27933129647 성공
  - post-merge Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/27933129616 성공

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| route/favorite route API client 경계 | local | repository contract RED/GREEN | `node --test tools/ci/repository-contract.test.mjs` | RED 실패 확인 후 88개 통과 |
| route search 기능 회귀 | local Flutter | route/API targeted test | `flutter test test/route_search_test.dart test/core/network/api_client_test.dart` | 16개 통과 |
| 모바일 전체 회귀 | local Flutter | analyzer와 전체 test | `flutter analyze`, `flutter test` | analyzer clean, 339개 통과 |
| PR CI | GitHub Actions | CI workflow | https://github.com/AquilaXk/easysubway/actions/runs/27932866718 | 성공 |
| PR Release Artifacts | GitHub Actions | release artifact workflow | https://github.com/AquilaXk/easysubway/actions/runs/27932866524 | 성공 |
| CodeRabbit/Codex review | GitHub PR review | CodeRabbit 상태 확인 후 fallback review | https://github.com/AquilaXk/easysubway/pull/635#pullrequestreview-4541501921 | CodeRabbit 미시작, Codex actionable 0 |
| post-merge CI/CD | GitHub Actions | merge commit `805831c4bf8d03d17b1bec1bf41018677bda3a63` workflow 확인 | CI https://github.com/AquilaXk/easysubway/actions/runs/27933129924, CD https://github.com/AquilaXk/easysubway/actions/runs/27933129647, Release Artifacts https://github.com/AquilaXk/easysubway/actions/runs/27933129616 | 모두 성공 |
| tracked Markdown 정책 | local git | tracked Markdown 목록 확인 | `git ls-files "*.md"` | README와 PR template만 추적 |
| 화면 증거 | local | 코드성 network boundary refactor | 증거 불필요 사유: UI 문구, layout, navigation 변경 없음 | 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteFeedbackApiRepository`와 `FavoriteRouteApiRepository`의 401 invalidation 재시도 의미가 기존과 같은지 확인해 주세요.

## 리스크

- `ApiClient`가 2xx 응답만 JSON decode하고 비성공 status는 body를 버리므로, 기존처럼 사용자에게는 동일한 쉬운 오류 문구만 노출된다.
- station favorite와 facility favorite API migration은 이번 PR 범위가 아니며 task9 잔여 slice로 남긴다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
