### PR TITLE
[Refactor] 즐겨찾기 역 API 공통 네트워크 경계 적용

### DIFF
--- a/apps/mobile/lib/core/network/api_client.dart
+++ b/apps/mobile/lib/core/network/api_client.dart
@@ -46,6 +46,19 @@ class ApiClient {
     );
   }
 
+  Future<ApiResponse> putJson(
+    String path, {
+    Map<String, Object?>? body,
+    Map<String, String> headers = const {},
+  }) {
+    return _requestJson(
+      HttpMethod.put,
+      path,
+      headers: headers,
+      requestBody: body,
+    );
+  }
+
   Future<ApiResponse> putBytes(
     Uri uri, {
     required List<int> body,
@@ -147,6 +160,8 @@ class ApiClient {
         return _httpClient.deleteUrl(uri);
       case HttpMethod.post:
         return _httpClient.postUrl(uri);
+      case HttpMethod.put:
+        return _httpClient.putUrl(uri);
     }
   }
 }
@@ -162,7 +177,7 @@ class ApiResponse {
   bool get isSuccess => _isSuccessStatus(statusCode);
 }
 
-enum HttpMethod { get, delete, post }
+enum HttpMethod { get, delete, post, put }
 
 Object? _decodeJson(String body, {required int statusCode, required Uri uri}) {
   try {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -552,18 +551,20 @@ class FavoriteStationApiRepository implements FavoriteStationRepository {
   FavoriteStationApiRepository({
     required this.baseUri,
     required this.authProvider,
+    ApiClient? apiClient,
     HttpClient? httpClient,
-  }) : _httpClient = httpClient ?? HttpClient();
+  }) : _apiClient =
+           apiClient ?? ApiClient(baseUri: baseUri, httpClient: httpClient);
 
   final Uri baseUri;
   final FavoriteStationAuthProvider authProvider;
-  final HttpClient _httpClient;
+  final ApiClient _apiClient;
 
   @override
   Future<List<FavoriteStation>> listFavoriteStations() async {
     final data = await _requestData(
       'GET',
-      baseUri.resolve('/api/v1/me/favorites/stations'),
+      '/api/v1/me/favorites/stations',
       errorMessage: _favoriteStationLoadErrorMessage,
     );
     if (data is! List<Object?>) {
@@ -591,12 +592,11 @@ class FavoriteStationApiRepository implements FavoriteStationRepository {
 
   @override
   Future<FavoriteStation> saveFavoriteStation(String stationId) async {
-    final uri = baseUri.resolve(
-      '/api/v1/me/favorites/stations/${Uri.encodeComponent(stationId)}',
-    );
+    final path =
+        '/api/v1/me/favorites/stations/${Uri.encodeComponent(stationId)}';
     final data = await _requestData(
       'PUT',
-      uri,
+      path,
       errorMessage: _favoriteStationChangeErrorMessage,
     );
     if (data is! Map<String, Object?>) {
@@ -617,40 +617,34 @@ class FavoriteStationApiRepository implements FavoriteStationRepository {
 
   @override
   Future<void> removeFavoriteStation(String stationId) async {
-    final uri = baseUri.resolve(
-      '/api/v1/me/favorites/stations/${Uri.encodeComponent(stationId)}',
-    );
+    final path =
+        '/api/v1/me/favorites/stations/${Uri.encodeComponent(stationId)}';
     await _requestData(
       'DELETE',
-      uri,
+      path,
       errorMessage: _favoriteStationChangeErrorMessage,
     );
   }
 
   Future<Object?> _requestData(
     String method,
-    Uri uri, {
+    String path, {
     required String errorMessage,
   }) async {
     for (var attempt = 0; attempt < 2; attempt++) {
       try {
-        final request = await _httpClient
-            .openUrl(method, uri)
-            .timeout(_favoriteStationTimeout);
         final authorizationHeader = await authProvider
             .authorizationHeader()
             .timeout(_favoriteStationTimeout);
-        if (authorizationHeader != null) {
-          request.headers.set(
-            HttpHeaders.authorizationHeader,
-            authorizationHeader,
-          );
-        }
-
-        final response = await request.close().timeout(_favoriteStationTimeout);
-        final body = await utf8
-            .decodeStream(response)
-            .timeout(_favoriteStationTimeout);
+        final headers = authorizationHeader == null
+            ? const <String, String>{}
+            : {HttpHeaders.authorizationHeader: authorizationHeader};
+        final response = await switch (method) {
+          'GET' => _apiClient.getJson(path, headers: headers),
+          'PUT' => _apiClient.putJson(path, headers: headers),
+          'DELETE' => _apiClient.deleteJson(path, headers: headers),
+          _ => throw FavoriteStationException(errorMessage),
+        };
 
         if (response.statusCode == HttpStatus.unauthorized &&
             authorizationHeader != null &&
@@ -667,7 +661,7 @@ class FavoriteStationApiRepository implements FavoriteStationRepository {
           throw FavoriteStationException(errorMessage);
         }
 
-        final decoded = jsonDecode(body);
+        final decoded = response.jsonBody;
         if (decoded is! Map<String, Object?> || decoded['success'] != true) {
           throw FavoriteStationException(errorMessage);
         }

--- a/apps/mobile/test/core/network/api_client_test.dart
+++ b/apps/mobile/test/core/network/api_client_test.dart
@@ -105,6 +105,64 @@ void main() {
     });
   });
 
+  test('ApiClient는 PUT 요청에 JSON body와 공통 header를 적용한다', () async {
+    late String requestedMethod;
+    late Uri requestedUri;
+    late String? acceptHeader;
+    late String? authorizationHeader;
+    late ContentType? contentType;
+    late Map<String, Object?> requestBody;
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) async {
+      requestedMethod = request.method;
+      requestedUri = request.uri;
+      acceptHeader = request.headers.value(HttpHeaders.acceptHeader);
+      authorizationHeader = request.headers.value(
+        HttpHeaders.authorizationHeader,
+      );
+      contentType = request.headers.contentType;
+      requestBody =
+          jsonDecode(await utf8.decodeStream(request)) as Map<String, Object?>;
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {'stationId': 'station-sangnoksu'},
+          }),
+        );
+      await request.response.close();
+    });
+
+    final client = ApiClient(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    final response = await client.putJson(
+      '/api/v1/me/favorites/stations/station-sangnoksu',
+      body: const {'source': 'station-detail'},
+      headers: const {HttpHeaders.authorizationHeader: 'Basic token-1'},
+    );
+
+    expect(requestedMethod, 'PUT');
+    expect(
+      requestedUri.path,
+      '/api/v1/me/favorites/stations/station-sangnoksu',
+    );
+    expect(acceptHeader, ContentType.json.mimeType);
+    expect(authorizationHeader, 'Basic token-1');
+    expect(contentType?.mimeType, ContentType.json.mimeType);
+    expect(requestBody, {'source': 'station-detail'});
+    expect(response.statusCode, HttpStatus.ok);
+    expect(response.jsonBody, {
+      'success': true,
+      'data': {'stationId': 'station-sangnoksu'},
+    });
+  });
+
   test('ApiClient는 PUT bytes 요청에 body와 upload header를 적용한다', () async {
     late String requestedMethod;
     late Uri requestedUri;

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4135,6 +4135,14 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
     stationSearch,
     /class StationSearchApiRepository[\s\S]*?_httpClient[\s\S]*?class FavoriteStationApiRepository/,
   );
+  assert.match(stationSearch, /class FavoriteStationApiRepository[\s\S]*final ApiClient _apiClient;/);
+  assert.match(stationSearch, /class FavoriteStationApiRepository[\s\S]*_apiClient\.getJson\(/);
+  assert.match(stationSearch, /class FavoriteStationApiRepository[\s\S]*_apiClient\.putJson\(/);
+  assert.match(stationSearch, /class FavoriteStationApiRepository[\s\S]*_apiClient\.deleteJson\(/);
+  assert.doesNotMatch(
+    stationSearch,
+    /class FavoriteStationApiRepository[\s\S]*?_httpClient[\s\S]*?class FavoriteStationException/,
+  );
   assert.match(stationSearch, /HttpStatus\.unauthorized/);
   assert.match(stationSearch, /invalidateAuthorization\(\)/);
   assert.match(stationSearch, /package:flutter\/foundation\.dart/);


### PR DESCRIPTION
## 관련 이슈

close #636

## 작업 배경

역 검색, 시설 신고, 경로 검색 쪽 API repository는 shared `ApiClient` 경계로 이동했지만 즐겨찾기 역 repository는 아직 직접 `HttpClient`와 JSON decode를 처리하고 있었다. 즐겨찾기 역 list/save/remove 요청도 같은 timeout, status, JSON decode 경계로 맞춰 task9 잔여 API client 범위를 줄인다.

## 작업 내용

- `ApiClient.putJson`을 추가해 JSON PUT 요청도 공통 header, timeout, status, JSON decode 경계를 사용하게 했다.
- `FavoriteStationApiRepository`의 list/save/remove 요청을 `ApiClient.getJson`, `putJson`, `deleteJson`으로 전환했다.
- 기존 인증 헤더 전달, 401 1회 invalidation 재시도, 쉬운 오류 문구, favorite station payload 검증은 유지했다.
- repository contract에 `FavoriteStationApiRepository`의 direct `_httpClient` 회귀 방지 조건을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs`: RED에서 FavoriteStationApiRepository `_apiClient` 미사용으로 실패 확인 후 GREEN 88개 통과
  - `cd apps/mobile && flutter test test/core/network/api_client_test.dart`: RED에서 `ApiClient.putJson` 미정의로 실패 확인 후 GREEN 6개 통과
  - `cd apps/mobile && flutter test test/station_search_test.dart test/core/network/api_client_test.dart`: 42개 통과
  - `cd apps/mobile && flutter analyze`: No issues found
  - `cd apps/mobile && flutter test`: 340개 통과
  - `git diff --check`: 통과
  - `git ls-files "*.md"`: `.github/pull_request_template.md`, `README.md`만 출력
  - PR CI: https://github.com/AquilaXk/easysubway/actions/runs/27933810905 성공
  - PR Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/27933810751 성공
  - CodeRabbit: rate limit과 prepaid credit exhaustion으로 실제 리뷰 시작 불가 확인
  - Codex CLI fallback review: https://github.com/AquilaXk/easysubway/pull/637#pullrequestreview-4541627989, actionable 0
  - Post-merge CD: https://github.com/AquilaXk/easysubway/actions/runs/27934320714 성공
  - Post-merge CI: https://github.com/AquilaXk/easysubway/actions/runs/27934320956 성공
  - Post-merge Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/27934320707 성공

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| FavoriteStation API client 경계 | local | repository contract RED/GREEN | `node --test tools/ci/repository-contract.test.mjs` | RED 실패 확인 후 88개 통과 |
| ApiClient JSON PUT | local Flutter | API client unit test RED/GREEN | `flutter test test/core/network/api_client_test.dart` | RED 실패 확인 후 6개 통과 |
| station search/favorite station 회귀 | local Flutter | station/API targeted test | `flutter test test/station_search_test.dart test/core/network/api_client_test.dart` | 42개 통과 |
| 모바일 전체 회귀 | local Flutter | analyzer와 전체 test | `flutter analyze`, `flutter test` | analyzer clean, 340개 통과 |
| PR CI | GitHub Actions | CI workflow | https://github.com/AquilaXk/easysubway/actions/runs/27933810905 | 성공 |
| PR Release Artifacts | GitHub Actions | release artifact workflow | https://github.com/AquilaXk/easysubway/actions/runs/27933810751 | 성공 |
| CodeRabbit/Codex review | GitHub PR review | CodeRabbit 상태 확인 후 fallback review | https://github.com/AquilaXk/easysubway/pull/637#pullrequestreview-4541627989 | CodeRabbit 미시작, Codex actionable 0 |
| Post-merge CI/CD | GitHub Actions | merge commit `2a8b629441ceeb454de40c11091e8e14b1ab01a4` 기준 workflow 확인 | CD https://github.com/AquilaXk/easysubway/actions/runs/27934320714, CI https://github.com/AquilaXk/easysubway/actions/runs/27934320956, Release Artifacts https://github.com/AquilaXk/easysubway/actions/runs/27934320707 | 모두 성공 |
| tracked Markdown 정책 | local git | tracked Markdown 목록 확인 | `git ls-files "*.md"` | README와 PR template만 추적 |
| 화면 증거 | local | 코드성 network boundary refactor | 증거 불필요 사유: UI 문구, layout, navigation 변경 없음 | 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `FavoriteStationApiRepository._requestData`의 401 invalidation 재시도와 `ApiClient.putJson`의 optional body 처리입니다.

## 리스크

- 즐겨찾기 역 저장 요청은 기존처럼 body 없이 PUT을 보낸다. `ApiClient.putJson`은 body가 주어질 때만 JSON body를 쓰므로 기존 save endpoint 요청 의미를 유지한다.
- 시설 즐겨찾기 API client migration과 큰 파일 split은 이번 PR 범위가 아니며 task9 잔여 slice로 남긴다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
