### PR TITLE
[Refactor] 모바일 local-first API base 의존성 분리

### DIFF
--- a/apps/mobile/lib/app/app_dependencies.dart
+++ b/apps/mobile/lib/app/app_dependencies.dart
@@ -197,18 +197,56 @@ FacilityReportRepository _defaultFacilityReportRepository({
   required Uri? Function() baseUri,
   required UserDatabase? userDatabase,
 }) {
-  final resolvedBaseUri = baseUri();
-  if (resolvedBaseUri == null) {
-    return const UnavailableFacilityReportRepository();
+  return _LazyDefaultFacilityReportRepository(baseUri, userDatabase);
+}
+
+class _LazyDefaultFacilityReportRepository implements FacilityReportRepository {
+  _LazyDefaultFacilityReportRepository(this._baseUri, this._userDatabase);
+
+  // 시설 신고 API는 선택 기능이라 앱 시작 중 base URL을 강제 평가하지 않는다.
+  final Uri? Function() _baseUri;
+  final UserDatabase? _userDatabase;
+  FacilityReportRepository? _delegate;
+
+  @override
+  Future<FacilityReportResult> createReport(FacilityReportRequest request) {
+    return _resolveDelegate().createReport(request);
   }
-  return FacilityReportApiRepository(
-    baseUri: resolvedBaseUri,
-    apiClient: ApiClient(baseUri: resolvedBaseUri),
-    authProvider: null,
-    receiptStore: userDatabase == null
-        ? null
-        : DriftFacilityReportReceiptStore(userDatabase: userDatabase),
-  );
+
+  @override
+  Future<FacilityReportResult> getReport(String reportId) {
+    return _resolveDelegate().getReport(reportId);
+  }
+
+  @override
+  Future<List<FacilityReportResult>> listMyReports() {
+    return _resolveDelegate().listMyReports();
+  }
+
+  FacilityReportRepository _resolveDelegate() {
+    final cachedDelegate = _delegate;
+    if (cachedDelegate != null) {
+      return cachedDelegate;
+    }
+    final resolvedDelegate = _createDelegate();
+    _delegate = resolvedDelegate;
+    return resolvedDelegate;
+  }
+
+  FacilityReportRepository _createDelegate() {
+    final resolvedBaseUri = _baseUri();
+    if (resolvedBaseUri == null) {
+      return const UnavailableFacilityReportRepository();
+    }
+    return FacilityReportApiRepository(
+      baseUri: resolvedBaseUri,
+      apiClient: ApiClient(baseUri: resolvedBaseUri),
+      authProvider: null,
+      receiptStore: _userDatabase == null
+          ? null
+          : DriftFacilityReportReceiptStore(userDatabase: _userDatabase),
+    );
+  }
 }
 
 UserDataDeletionRepository? _defaultUserDataDeletionRepository({

--- a/apps/mobile/test/app_dependencies_test.dart
+++ b/apps/mobile/test/app_dependencies_test.dart
@@ -48,6 +48,54 @@ void main() {
     expect(internalNodes, isEmpty);
   });
 
+  test('로컬 데이터베이스 기본 의존성은 시설 신고 fallback 때문에 API 주소를 읽지 않는다', () async {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    var apiBaseReads = 0;
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+    await catalogDatabase.seedBaselineIfEmpty();
+
+    final dependencies = AppDependencies.resolve(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+      apiBaseUri: () {
+        apiBaseReads++;
+        throw StateError('Local app defaults must not read API base URL.');
+      },
+      enablePushNotifications: false,
+    );
+
+    expect(apiBaseReads, 0);
+    expect(dependencies.repository, isA<DriftStationRepository>());
+  });
+
+  test('시설 신고 기본 의존성은 API 주소가 없으면 호출 시점에 unavailable로 동작한다', () async {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+
+    final dependencies = AppDependencies.resolve(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+      apiBaseUri: () => null,
+      enablePushNotifications: false,
+    );
+
+    await expectLater(
+      dependencies.reportRepository.createReport(
+        const FacilityReportRequest(
+          stationId: 'station-sangnoksu',
+          facilityId: 'facility-elevator-sangnoksu-1',
+          reportType: 'BROKEN',
+          description: '승강기 고장',
+        ),
+      ),
+      throwsA(isA<FacilityReportException>()),
+    );
+  });
+
   test('로컬 데이터베이스가 없으면 API 주소 없는 원격 fallback을 만들지 않는다', () {
     expect(
       () => AppDependencies.resolve(


### PR DESCRIPTION
## 관련 이슈

close #638

## 작업 배경

- 모바일 local-first 기본 경로는 catalog DB와 user DB만으로 역/경로/즐겨찾기 흐름을 시작할 수 있어야 한다.
- 시설 신고 API는 선택 기능인데, 기본 의존성 생성 시점에 API base URL을 먼저 평가하면 로컬 기본 경로도 backend 설정에 묶일 수 있다.

## 작업 내용

- 기본 시설 신고 repository 생성을 lazy wrapper로 바꿔 앱 의존성 구성 중에는 API base URL을 평가하지 않도록 했다.
- 시설 신고 기능을 실제 호출할 때 API base URL이 있으면 기존 `FacilityReportApiRepository`를 만들고, base URL이 없으면 기존 `UnavailableFacilityReportRepository` 경로로 실패하게 했다.
- release API base URL 검증 오류는 숨기지 않고 기존처럼 드러나도록 유지했다.
- local-first 의존성 생성이 API base URL을 읽지 않는 회귀 테스트와, base URL이 없는 시설 신고 호출이 `FacilityReportException`으로 안내되는 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - RED 확인: 구현 전 `flutter test test/app_dependencies_test.dart`가 `Bad state: Local app defaults must not read API base URL.`로 실패했다.
  - `flutter test test/app_dependencies_test.dart`: 4개 통과.
  - `flutter analyze`: No issues found.
  - `flutter test`: 342개 통과.
  - `node --test tools/ci/repository-contract.test.mjs`: 88개 통과.
  - `git diff --check`: 통과.
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적됨.
  - Codex Security diff scan: no finding. 보고서: `/tmp/codex-security-scans/swieun-jihacheol/2a8b629_20260622T065159Z/report.md`
  - GitHub Actions CI: https://github.com/AquilaXk/easysubway/actions/runs/27935312115 통과.
  - GitHub Actions Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/27935311984 통과. Backend image는 backend 변경이 없어 skip.
  - CodeRabbit 상태 확인: https://github.com/AquilaXk/easysubway/pull/639#issuecomment-4765708919 에서 rate limit으로 실제 리뷰 미시작 확인.
  - Codex CLI fallback review: https://github.com/AquilaXk/easysubway/pull/639#pullrequestreview-4541816716, actionable 0.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| local-first API base 지연 회귀 | local Flutter test | `flutter test test/app_dependencies_test.dart` | command output: 4 tests passed | 통과 |
| 모바일 정적 분석 | local Flutter analyzer | `flutter analyze` | command output: No issues found | 통과 |
| 모바일 전체 테스트 | local Flutter test | `flutter test` | command output: 342 tests passed | 통과 |
| 저장소 계약 | local Node test | `node --test tools/ci/repository-contract.test.mjs` | command output: 88 tests passed | 통과 |
| 보안 diff 검토 | local Codex Security scan | changed dependency boundary and supporting files reviewed | `/tmp/codex-security-scans/swieun-jihacheol/2a8b629_20260622T065159Z/report.md` | finding 없음 |
| PR CI | GitHub Actions | CI workflow run | https://github.com/AquilaXk/easysubway/actions/runs/27935312115 | 통과 |
| Release artifact gate | GitHub Actions | Release Artifacts workflow run | https://github.com/AquilaXk/easysubway/actions/runs/27935311984 | Android/iOS 통과, backend image skip |
| 리뷰 gate | GitHub PR conversation | CodeRabbit 상태 확인 후 Codex CLI fallback review | https://github.com/AquilaXk/easysubway/pull/639#pullrequestreview-4541816716 | actionable 0 |
| UI 증거 | Android/iOS | 화면, navigation, 접근성 트리를 바꾸지 않는 dependency wiring/test 변경 | 증거 불필요 사유: 사용자 화면 렌더링과 상호작용 코드를 변경하지 않음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `_LazyDefaultFacilityReportRepository`가 앱 시작 시점에는 API base URL provider를 호출하지 않고, 시설 신고 메서드 호출 시점에만 delegate를 만든다는 점.

## 리스크

- 시설 신고 첫 호출 시 delegate가 생성되므로, API base URL 설정 오류는 앱 시작이 아니라 시설 신고 사용 시점에 드러난다. release 기본 경로에서 base URL이 필요한 케이스는 기존 `StateError` 검증을 그대로 유지했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
