### PR TITLE
[Test] 모바일 앱 기본 의존성 계약 테스트 분리

### DIFF
--- a/apps/mobile/test/easy_subway_app_defaults_test.dart
+++ b/apps/mobile/test/easy_subway_app_defaults_test.dart
@@ -1,0 +1,89 @@
+import 'package:easysubway_mobile/facility_report.dart';
+import 'package:easysubway_mobile/main.dart';
+import 'package:easysubway_mobile/route_search.dart';
+import 'package:easysubway_mobile/station_search.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('기본 앱은 출시 범위에서 원격 개인 데이터 저장소를 만들지 않는다', () {
+    final app = EasySubwayApp(
+      repository: _UnusedStationSearchRepository(),
+      reportRepository: _UnusedFacilityReportRepository(),
+      routeRepository: _UnusedRouteSearchRepository(),
+    );
+
+    expect(app.favoriteRepository, isNull);
+    expect(app.favoriteFacilityRepository, isNull);
+    expect(app.favoriteRouteRepository, isNull);
+    expect(app.notificationRepository, isNull);
+    expect(app.notificationPermissionProvider, isNull);
+  });
+
+  test('푸시 알림을 명시적으로 켜도 인증 없는 원격 저장소는 만들지 않는다', () {
+    final app = EasySubwayApp(
+      repository: _UnusedStationSearchRepository(),
+      reportRepository: _UnusedFacilityReportRepository(),
+      routeRepository: _UnusedRouteSearchRepository(),
+      enablePushNotifications: true,
+    );
+
+    expect(app.favoriteRouteRepository, isNull);
+    expect(app.notificationRepository, isNull);
+    expect(app.notificationPermissionProvider, isNull);
+  });
+}
+
+class _UnusedStationSearchRepository implements StationSearchRepository {
+  @override
+  Future<List<StationSearchResult>> searchStations(String query) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<StationSearchResult>> searchNearbyStations(
+    CurrentLocation location, {
+    int radiusMeters = 2000,
+    int limit = 10,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<StationDetail> getStationDetail(String stationId) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<StationExitInfo>> listStationExits(String stationId) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<StationFacilityInfo>> listStationFacilities(String stationId) {
+    throw UnimplementedError();
+  }
+}
+
+class _UnusedFacilityReportRepository implements FacilityReportRepository {
+  @override
+  Future<FacilityReportResult> createReport(FacilityReportRequest request) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<FacilityReportResult> getReport(String reportId) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<FacilityReportResult>> listMyReports() {
+    throw UnimplementedError();
+  }
+}
+
+class _UnusedRouteSearchRepository implements RouteSearchRepository {
+  @override
+  Future<RouteSearchResult> searchRoute(RouteSearchRequest request) {
+    throw UnimplementedError();
+  }
+}

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1234,35 +1234,6 @@ void main() {
     expect(find.widgetWithText(OutlinedButton, '알림 설정'), findsNothing);
   });
 
-  test('기본 앱은 출시 범위에서 원격 개인 데이터 저장소를 만들지 않는다', () {
-    final app = EasySubwayApp(
-      repository: FakeStationSearchRepository(),
-      reportRepository: FakeFacilityReportRepository(),
-      routeRepository: FakeRouteSearchRepository(),
-      initialOnboardingState: _completedOnboardingState(),
-    );
-
-    expect(app.favoriteRepository, isNull);
-    expect(app.favoriteFacilityRepository, isNull);
-    expect(app.favoriteRouteRepository, isNull);
-    expect(app.notificationRepository, isNull);
-    expect(app.notificationPermissionProvider, isNull);
-  });
-
-  test('푸시 알림을 명시적으로 켜도 인증 없는 원격 저장소는 만들지 않는다', () {
-    final app = EasySubwayApp(
-      repository: FakeStationSearchRepository(),
-      reportRepository: FakeFacilityReportRepository(),
-      routeRepository: FakeRouteSearchRepository(),
-      initialOnboardingState: _completedOnboardingState(),
-      enablePushNotifications: true,
-    );
-
-    expect(app.favoriteRouteRepository, isNull);
-    expect(app.notificationRepository, isNull);
-    expect(app.notificationPermissionProvider, isNull);
-  });
-
   testWidgets('알림 설정 화면은 현재 설정을 불러오고 바꾼 값을 저장한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final notificationRepository = FakeNotificationSettingsRepository();

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4002,6 +4002,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   const notificationSettingsTest = read("apps/mobile/test/notification_settings_test.dart");
   const widgetTest = read("apps/mobile/test/widget_test.dart");
   const supportAccessInfoTest = read("apps/mobile/test/support_access_info_test.dart");
+  const easySubwayAppDefaultsTest = read("apps/mobile/test/easy_subway_app_defaults_test.dart");
   const apiClient = read("apps/mobile/lib/core/network/api_client.dart");
   const apiError = read("apps/mobile/lib/core/network/api_error.dart");
   const apiClientTest = read("apps/mobile/test/core/network/api_client_test.dart");
@@ -4224,6 +4225,9 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(widgetTest, /시설 신고 화면은 현재 위치를 보내기 전에 공개 범위를 안내한다/);
   assert.doesNotMatch(main, /빠른 길보다, 갈 수 있는 길을 먼저 안내합니다|고령자, 임산부, 장애인도 편하게 이동할 수 있도록|현장에서 발견한 불편 정보를 신고하고 검수할 수 있게/);
   assert.match(widgetTest, /EasySubwayApp/);
+  assert.match(easySubwayAppDefaultsTest, /기본 앱은 출시 범위에서 원격 개인 데이터 저장소를 만들지 않는다/);
+  assert.match(easySubwayAppDefaultsTest, /푸시 알림을 명시적으로 켜도 인증 없는 원격 저장소는 만들지 않는다/);
+  assert.match(easySubwayAppDefaultsTest, /enablePushNotifications: true/);
   assert.match(widgetTest, /홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다/);
   assert.match(widgetTest, /홈 즐겨찾기는 하나의 진입점에서 탭 목록을 바로 보여준다/);
   assert.match(widgetTest, /도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다/);


### PR DESCRIPTION
## 관련 이슈

close #644

## 작업 배경

`apps/mobile/test/widget_test.dart`에 남아 있던 비위젯 `EasySubwayApp` 기본 의존성 계약 테스트 2개를 별도 단위 테스트 파일로 분리해 task9 잔여 대형 테스트 축소를 계속 진행합니다. 이 작업은 스토어 제출, 서명, Google Play/App Store 등록과 무관하며 전국 단위 기능 커버리지 이전의 테스트 구조 정리입니다.

## 작업 내용

- `apps/mobile/test/easy_subway_app_defaults_test.dart`를 추가해 기본 앱이 인증 없는 원격 개인 데이터 저장소와 알림 저장소를 만들지 않는 계약을 독립 테스트로 고정했습니다.
- `apps/mobile/test/widget_test.dart`에서는 동일한 비위젯 테스트 2개만 제거했습니다.
- `tools/ci/repository-contract.test.mjs`가 새 테스트 파일의 계약 문구와 `enablePushNotifications: true` 경로를 확인하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --plain-name "기본 앱은 출시 범위에서 원격 개인 데이터 저장소를 만들지 않는다"`: 분리 전 baseline 통과
  - `flutter test test/widget_test.dart --plain-name "푸시 알림을 명시적으로 켜도 인증 없는 원격 저장소는 만들지 않는다"`: 분리 전 baseline 통과
  - `node --test --test-name-pattern "모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다" tools/ci/repository-contract.test.mjs`: RED, 새 파일 부재로 실패 확인
  - `dart format test/easy_subway_app_defaults_test.dart test/widget_test.dart`: 통과
  - `flutter test test/easy_subway_app_defaults_test.dart`: 통과, 2 tests
  - `node --test --test-name-pattern "모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다" tools/ci/repository-contract.test.mjs`: 통과
  - `flutter test test/widget_test.dart`: 통과, 92 tests
  - `flutter analyze`: 통과, No issues found
  - `flutter test`: 통과, 344 tests
  - `node --test tools/ci/repository-contract.test.mjs`: 통과, 88 tests
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 출력
  - Codex Security diff scan: 후보 0건, report `/tmp/codex-security-scans/swieun-jihacheol/e7918ee_20260622T081247Z/report.html`

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| EasySubwayApp 기본 의존성 계약 | local Flutter test | `flutter test test/easy_subway_app_defaults_test.dart` | 터미널 출력: `All tests passed!`, 2 tests | 통과 |
| 기존 widget suite 회귀 | local Flutter test | `flutter test test/widget_test.dart` | 터미널 출력: `All tests passed!`, 92 tests | 통과 |
| 모바일 전체 테스트 | local Flutter test | `flutter test` | 터미널 출력: `All tests passed!`, 344 tests | 통과 |
| Repository contract | local Node test | `node --test tools/ci/repository-contract.test.mjs` | 터미널 출력: 88 pass, 0 fail | 통과 |
| 보안 diff scan | local Codex Security | 변경 파일 3개 diff-scoped scan | `/tmp/codex-security-scans/swieun-jihacheol/e7918ee_20260622T081247Z/report.html` | 후보 0건 |
| UI/접근성 화면 증거 | 해당 없음 | 테스트 파일 분리만 수행 | 증거 불필요 사유: 앱 런타임 UI, 접근성 문구, 권한, 라우팅, 릴리즈 동작 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 새 `easy_subway_app_defaults_test.dart`가 기존 widget 테스트의 두 계약을 같은 의미로 유지하는지, repository contract가 새 파일을 읽어 분리 회귀를 막는지 확인하면 됩니다.

## 리스크

- 프로덕션 코드 변경은 없어 런타임 리스크는 낮습니다.
- 테스트 위치가 바뀌었으므로 CI에서 새 파일 누락이나 import 회귀만 확인하면 됩니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
