### PR TITLE
[Test] 모바일 기본 홈 인증 없음 계약 테스트 분리

### DIFF
--- a/apps/mobile/test/easy_subway_app_defaults_test.dart
+++ b/apps/mobile/test/easy_subway_app_defaults_test.dart
@@ -1,7 +1,10 @@
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/main.dart';
+import 'package:easysubway_mobile/mobility_profile.dart';
+import 'package:easysubway_mobile/onboarding.dart';
 import 'package:easysubway_mobile/route_search.dart';
 import 'package:easysubway_mobile/station_search.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -31,6 +34,33 @@ void main() {
     expect(app.notificationRepository, isNull);
     expect(app.notificationPermissionProvider, isNull);
   });
+
+  testWidgets('인증 저장소가 없으면 홈 즐겨찾기를 노출하지 않는다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: _UnusedStationSearchRepository(),
+        reportRepository: _UnusedFacilityReportRepository(),
+        routeRepository: _UnusedRouteSearchRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    expect(find.byKey(const Key('favoritesButton')), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, '즐겨찾기'), findsNothing);
+    expect(find.byKey(const Key('notificationSettingsButton')), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, '알림 설정'), findsNothing);
+  });
+}
+
+OnboardingState _completedOnboardingState() {
+  return OnboardingState.completed(
+    result: OnboardingResult(
+      profile: mobilityProfileOptions.firstWhere(
+        (option) => option.id == 'elderly',
+      ),
+      preferences: const OnboardingViewPreferences.defaults(),
+    ),
+  );
 }
 
 class _UnusedStationSearchRepository implements StationSearchRepository {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1218,22 +1218,6 @@ void main() {
     expect(find.text('연결할 수 없습니다. 잠시 후 다시 시도해 주세요.'), findsOneWidget);
   });
 
-  testWidgets('인증 저장소가 없으면 홈 즐겨찾기를 노출하지 않는다', (tester) async {
-    await tester.pumpWidget(
-      EasySubwayApp(
-        repository: FakeStationSearchRepository(),
-        reportRepository: FakeFacilityReportRepository(),
-        routeRepository: FakeRouteSearchRepository(),
-        initialOnboardingState: _completedOnboardingState(),
-      ),
-    );
-
-    expect(find.byKey(const Key('favoritesButton')), findsNothing);
-    expect(find.widgetWithText(OutlinedButton, '즐겨찾기'), findsNothing);
-    expect(find.byKey(const Key('notificationSettingsButton')), findsNothing);
-    expect(find.widgetWithText(OutlinedButton, '알림 설정'), findsNothing);
-  });
-
   testWidgets('알림 설정 화면은 현재 설정을 불러오고 바꾼 값을 저장한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final notificationRepository = FakeNotificationSettingsRepository();

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4228,6 +4228,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(easySubwayAppDefaultsTest, /기본 앱은 출시 범위에서 원격 개인 데이터 저장소를 만들지 않는다/);
   assert.match(easySubwayAppDefaultsTest, /푸시 알림을 명시적으로 켜도 인증 없는 원격 저장소는 만들지 않는다/);
   assert.match(easySubwayAppDefaultsTest, /enablePushNotifications: true/);
+  assert.match(easySubwayAppDefaultsTest, /인증 저장소가 없으면 홈 즐겨찾기를 노출하지 않는다/);
   assert.match(widgetTest, /홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다/);
   assert.match(widgetTest, /홈 즐겨찾기는 하나의 진입점에서 탭 목록을 바로 보여준다/);
   assert.match(widgetTest, /도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다/);


### PR DESCRIPTION
## 관련 이슈

close #646

## 작업 배경

- `apps/mobile/test/widget_test.dart`가 계속 커져서 기본 앱 의존성 계약 테스트를 별도 파일로 옮기는 task9 잔여 범위를 진행했습니다.
- 이번 slice는 인증 저장소가 없을 때 홈 즐겨찾기와 알림 설정 진입점이 노출되지 않는 계약을 `easy_subway_app_defaults_test.dart`로 이동합니다.
- 계획서 최신 우선순위에 따라 store submission, signing, Google Play/App Store 작업은 전국 단위 기능 커버리지 검증 이후로 유지했습니다.

## 작업 내용

- `apps/mobile/test/easy_subway_app_defaults_test.dart`에 인증 저장소 없음 홈 controls widget 계약을 추가했습니다.
- 같은 테스트를 `apps/mobile/test/widget_test.dart`에서 제거해 중복 없이 전용 파일에서 관리하도록 했습니다.
- repository contract가 이동된 테스트명을 새 파일에서 확인하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "인증 저장소가 없으면 홈 즐겨찾기를 노출하지 않는다"`: 통과
  - `node --test --test-name-pattern "모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다" tools/ci/repository-contract.test.mjs`: RED 단계에서 기대 실패 확인 후 구현 뒤 통과
  - `cd apps/mobile && dart format test/easy_subway_app_defaults_test.dart test/widget_test.dart`: 통과
  - `cd apps/mobile && flutter test test/easy_subway_app_defaults_test.dart`: 통과
  - `cd apps/mobile && flutter test test/widget_test.dart`: 통과
  - `cd apps/mobile && flutter analyze`: 통과
  - `cd apps/mobile && flutter test`: 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 기본 앱 인증 없음 홈 controls 계약 | Flutter test | `flutter test test/easy_subway_app_defaults_test.dart` | 로컬 명령 출력: 3 tests 통과 | 통과 |
| 기존 대형 widget 회귀 | Flutter test | `flutter test test/widget_test.dart` | 로컬 명령 출력: 91 tests 통과 | 통과 |
| 모바일 전체 테스트 | Flutter test | `flutter test` | 로컬 명령 출력: 344 tests 통과 | 통과 |
| 정적 분석 | Flutter analyzer | `flutter analyze` | 로컬 명령 출력: No issues found | 통과 |
| repository contract | Node test | `node --test tools/ci/repository-contract.test.mjs` | 로컬 명령 출력: 88 tests 통과 | 통과 |
| 보안 diff scan | Local | Codex Security diff scan | `/tmp/codex-security-scans/swieun-jihacheol/12b76cd_20260622T083427Z/report.html` | findings 0 |
| 화면 증거 | Android/iOS | 증거 불필요 사유 | 테스트 파일 이동만 포함하며 런타임 UI, 접근성, 권한 문구, release/store 동작을 변경하지 않음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/test/easy_subway_app_defaults_test.dart`의 새 widget test가 기존 `widget_test.dart` 테스트와 같은 계약을 유지하는지
  - `tools/ci/repository-contract.test.mjs`가 이동된 테스트명을 새 파일에서 확인하는지

## 리스크

- 프로덕션 런타임 변경은 없습니다.
- 테스트 이동 범위라 기능 리스크는 낮지만, `widget_test.dart`에서 제거된 계약이 새 전용 테스트와 repository contract에 의해 유지되는지 확인이 필요합니다.
- store submission, signing, Google Play/App Store 등록 작업은 이번 PR 범위가 아니며 전국 단위 기능 커버리지 이후로 유지됩니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
