### PR TITLE
[Build] Android applicationId 상용 식별자 확정

### DIFF
--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -43,7 +43,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.easysubway.easysubway_mobile"
+        applicationId = "com.easysubway.app"
         minSdk = flutter.minSdkVersion
         targetSdk = maxOf(35, flutter.targetSdkVersion)
         versionCode = flutter.versionCode

--- a/apps/mobile/release/release-security-gate.json
+++ b/apps/mobile/release/release-security-gate.json
@@ -1,6 +1,7 @@
 {
   "schemaVersion": 1,
   "applicationId": "easysubway",
+  "androidApplicationId": "com.easysubway.app",
   "releaseGate": "release-security-gate",
   "releaseBlockerPolicy": true,
   "policyRefreshKo": "출시 전 최신 모바일 스토어 보안 요구사항, 백엔드 운영 보안 설정, 의존성 취약점 상태를 다시 확인한다.",

--- a/apps/mobile/release/signed-release-artifact-gate.json
+++ b/apps/mobile/release/signed-release-artifact-gate.json
@@ -1,6 +1,7 @@
 {
   "schemaVersion": 1,
   "applicationId": "easysubway",
+  "androidApplicationId": "com.easysubway.app",
   "releaseGate": "mobile-signed-release-artifacts",
   "storeReadyStatus": "blocked_external_distribution_evidence_missing",
   "officialRequirements": {

--- a/apps/mobile/release/store-submission-readiness.json
+++ b/apps/mobile/release/store-submission-readiness.json
@@ -1,6 +1,7 @@
 {
   "schemaVersion": 1,
   "applicationId": "easysubway",
+  "androidApplicationId": "com.easysubway.app",
   "releaseGate": "store-submission-readiness",
   "appNameKo": "쉬운 지하철",
   "appNameEn": "easysubway",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -670,6 +670,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
 
   assert.equal(gate.schemaVersion, 1);
   assert.equal(gate.applicationId, "easysubway");
+  assert.equal(gate.androidApplicationId, "com.easysubway.app");
   assert.equal(gate.releaseGate, "mobile-signed-release-artifacts");
   assert.equal(gate.storeReadyStatus, "blocked_external_distribution_evidence_missing");
 
@@ -4030,6 +4031,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(androidProfileManifest, /android:usesCleartextTraffic="true"/);
   assert.match(androidProfileManifest, /tools:replace="android:usesCleartextTraffic"/);
   assert.match(androidManifest, /<uses-permission android:name="android\.permission\.INTERNET"\/>/);
+  assert.match(androidBuildGradle, /applicationId\s*=\s*"com\.easysubway\.app"/);
   assert.match(androidBuildGradle, /targetSdk\s*=\s*maxOf\(35,\s*flutter\.targetSdkVersion\)/);
   assert.match(androidBuildGradle, /create\("release"\)/);
   assert.doesNotMatch(androidBuildGradle, /signingConfig\s*=\s*signingConfigs\.getByName\("debug"\)/);
@@ -4403,6 +4405,7 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
 
   assert.equal(readiness.schemaVersion, 1);
   assert.equal(readiness.applicationId, "easysubway");
+  assert.equal(readiness.androidApplicationId, "com.easysubway.app");
   assert.equal(readiness.releaseGate, "store-submission-readiness");
   assert.equal(readiness.appNameKo, "쉬운 지하철");
   assert.equal(readiness.appNameEn, "easysubway");
@@ -4497,6 +4500,7 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
 
   assert.equal(gate.schemaVersion, 1);
   assert.equal(gate.applicationId, "easysubway");
+  assert.equal(gate.androidApplicationId, "com.easysubway.app");
   assert.equal(gate.releaseGate, "release-security-gate");
   assert.equal(gate.releaseBlockerPolicy, true);
   assert.match(gate.policyRefreshKo, /출시 전|최신/);


### PR DESCRIPTION
## 관련 이슈

close #648

## 작업 배경

- Android `applicationId`는 기기와 Google Play에서 앱을 식별하는 고유 ID라 Play 등록 전에 확정해야 한다.
- 현재 값은 Flutter scaffold 패키지명에 가까운 `com.easysubway.easysubway_mobile`였고, 상용 앱 식별자 기준으로 `com.easysubway.app`을 사용하도록 바꾼다.
- Android Developers 문서 기준으로 출시 후 `applicationId`를 바꾸면 Google Play가 다른 앱으로 취급하므로, store submission 전 제품 식별자 정리로 선반영한다.
- 이번 PR은 Android 앱 식별자와 검증 계약만 바꾸며, Play Console 등록, signing secret 구성, store submission은 전국 단위 기능 커버리지 이후로 유지한다.

## 작업 내용

- `apps/mobile/android/app/build.gradle.kts`의 Android `applicationId`를 `com.easysubway.app`으로 변경했다.
- release/security/readiness JSON에 Android 전용 `androidApplicationId` 값을 추가해 기존 제품 식별자 `applicationId: easysubway`와 분리했다.
- repository contract가 Gradle applicationId와 release metadata의 Android applicationId를 검증하도록 보강했다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다|모바일 signed release artifact gate|모바일 스토어 심사 정보 기준선|릴리즈 보안 기준선" tools/ci/repository-contract.test.mjs`: RED 단계에서 기대 실패 확인 후 구현 뒤 통과
  - `cd apps/mobile && flutter build apk --debug`: 통과
  - `apkanalyzer manifest application-id apps/mobile/build/app/outputs/flutter-apk/app-debug.apk`: `com.easysubway.app`
  - `cd apps/mobile && flutter test`: 통과, 344 tests
  - `cd apps/mobile && flutter analyze`: 통과, No issues found
  - `node --test tools/ci/repository-contract.test.mjs`: 통과, 88 tests
  - `git diff --check`: 통과
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`만 추적 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Android applicationId | Android debug APK | `apkanalyzer manifest application-id apps/mobile/build/app/outputs/flutter-apk/app-debug.apk` | 로컬 명령 출력: `com.easysubway.app` | 통과 |
| Android build | Android | `flutter build apk --debug` | 로컬 명령 출력: `Built build/app/outputs/flutter-apk/app-debug.apk` | 통과 |
| 모바일 테스트 | Flutter | `flutter test` | 로컬 명령 출력: 344 tests 통과 | 통과 |
| 정적 분석 | Flutter analyzer | `flutter analyze` | 로컬 명령 출력: No issues found | 통과 |
| repository contract | Node test | `node --test tools/ci/repository-contract.test.mjs` | 로컬 명령 출력: 88 tests 통과 | 통과 |
| 보안 diff scan | Local | Codex Security diff scan | `/tmp/codex-security-scans/swieun-jihacheol/7892556_20260622T085201Z/report.html` | findings 0 |
| 화면 증거 | Android/iOS | 증거 불필요 사유 | 앱 식별자와 release metadata 변경만 포함하며 런타임 UI, 접근성, 권한 문구 화면을 변경하지 않음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `applicationId`만 `com.easysubway.app`으로 변경했고 Android namespace와 Kotlin package는 유지했다.
  - release JSON의 기존 `applicationId: easysubway`는 제품/게이트 식별자로 남기고 Android 전용 값은 `androidApplicationId`로 분리했다.

## 리스크

- 이미 Play에 같은 앱으로 등록한 기록이 있다면 applicationId 변경은 새 앱으로 취급된다. 현재 프로젝트 원칙상 store submission은 아직 시작하지 않았고, Play 등록 전 식별자 확정 작업으로 처리한다.
- package/namespace를 함께 이동하지 않았으므로 Kotlin source path와 method channel 이름은 그대로 유지된다.
- 이 PR은 Play Console 등록, production signing key, Play internal track, TestFlight, public store submission을 수행하지 않는다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
