### PR TITLE
[Build] KRIC 환승 이동경로 후보 근거 승격 계약 추가

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1493,13 +1493,43 @@ test("KRIC 부분확인 source 후보는 production inventory와 분리한다", 
 
   for (const candidate of candidates.candidates) {
     assert.equal(candidate.priority, "P0");
-    assert.equal(candidate.licenseEvidenceStatus, "partial");
-    assert.equal(candidate.admissionStatus, "needs_sample_and_license_evidence");
+    assert.ok(["partial", "confirmed_attribution"].includes(candidate.licenseEvidenceStatus));
+    assert.ok(["needs_sample_and_license_evidence", "evidence_recorded_admin_review_required"].includes(candidate.admissionStatus));
     assert.equal(productionSourceIds.has(candidate.id), false, `${candidate.id} must not be in production source inventory`);
     assert.match(candidate.detailUrl, /^https:\/\/data\.kric\.go\.kr\/rips\/M_01_02\//);
     assert.match(candidate.requestUrl, /^https:\/\/openapi\.kric\.go\.kr\/openapi\//);
     assert.ok(candidate.nextAction);
   }
+});
+
+test("KRIC 환승 이동경로 후보는 상세 근거가 있어도 route graph edge로 자동 승격하지 않는다", () => {
+  const candidates = readJson("tools/datapack/source-candidates.json");
+  const candidate = candidates.candidates.find(({ id }) => id === "kric-transfer-movement-detailed");
+
+  assert.ok(candidate);
+  assert.equal(candidate.licenseEvidenceStatus, "confirmed_attribution");
+  assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
+  assert.equal(candidate.admissionStatus, "evidence_recorded_admin_review_required");
+  assert.equal(candidate.automaticRouteGraphEdgeAllowed, false);
+  assert.equal(candidate.evidence.detailPageUrl, candidate.detailUrl);
+  assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
+  assert.equal(candidate.evidence.usePermissionRange, "저작권표시");
+  assert.deepEqual(candidate.evidence.formats.sort(), ["JSON", "XML"]);
+  assert.match(candidate.evidence.sampleUrl, /serviceKey=\[서비스키값\]/);
+  assert.deepEqual(
+    candidate.evidence.outputFields.sort(),
+    [
+      "chtnMvTpOrdr",
+      "edMovePath",
+      "elvtSttCd",
+      "elvtTpCd",
+      "imgPath",
+      "mvContDtl",
+      "mvPathMgNo",
+      "stMovePath",
+    ],
+  );
+  assert.deepEqual(candidate.evidence.missingConfirmedEdgeFields.sort(), ["distanceMeters", "durationSeconds"]);
 });
 
 test("운영 데이터팩 공식 출처 ingest adapter는 stable id mapping과 retired id 재사용 금지를 강제한다", () => {

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -99,8 +99,35 @@
       "displayName": "환승 이동경로",
       "detailUrl": "https://data.kric.go.kr/rips/M_01_02/detail.do?id=307&operation=transferMovement&service=vulnerableUserInfo",
       "requestUrl": "https://openapi.kric.go.kr/openapi/vulnerableUserInfo/transferMovement",
-      "licenseEvidenceStatus": "partial",
-      "admissionStatus": "needs_sample_and_license_evidence",
+      "licenseEvidenceStatus": "confirmed_attribution",
+      "sampleEvidenceStatus": "sample_url_documented_key_required",
+      "admissionStatus": "evidence_recorded_admin_review_required",
+      "automaticRouteGraphEdgeAllowed": false,
+      "evidence": {
+        "detailPageUrl": "https://data.kric.go.kr/rips/M_01_02/detail.do?id=307&operation=transferMovement&service=vulnerableUserInfo",
+        "retrievedAt": "2026-06-23",
+        "endpoint": "https://openapi.kric.go.kr/openapi/vulnerableUserInfo/transferMovement",
+        "sampleUrl": "https://openapi.kric.go.kr/openapi/vulnerableUserInfo/transferMovement?serviceKey=[서비스키값]&format=xml&railOprIsttCd=S1&lnCd=3&stinCd=321&prevStinCd=422&chthTgtLn=4&chtnNextStinCd=424",
+        "formats": [
+          "JSON",
+          "XML"
+        ],
+        "usePermissionRange": "저작권표시",
+        "outputFields": [
+          "chtnMvTpOrdr",
+          "edMovePath",
+          "elvtSttCd",
+          "elvtTpCd",
+          "imgPath",
+          "mvContDtl",
+          "mvPathMgNo",
+          "stMovePath"
+        ],
+        "missingConfirmedEdgeFields": [
+          "distanceMeters",
+          "durationSeconds"
+        ]
+      },
       "nextAction": "verify image redistribution rights and keep as admin review candidate until distance and duration evidence exists"
     },
     {


### PR DESCRIPTION
## 관련 이슈

close #681

## 작업 배경

KRIC 부분확인 P0 후보 중 `환승 이동경로` 상세 API는 공식 KRIC 포털 상세 페이지에서 요청 URL, 샘플 URL, 데이터 포맷, 이용허락범위, 출력 필드를 확인할 수 있습니다.

다만 출력 필드는 이동 문구와 이미지 경로 중심이고 거리·소요시간이 없어 route graph edge로 자동 확정하면 안 됩니다. 이번 PR은 근거 확인 상태만 후보 registry에 기록하고, 관리자 검수 후보 상태를 유지합니다.

## 작업 내용

- `kric-transfer-movement-detailed` 후보에 공식 상세 페이지 evidence를 추가했습니다.
- 이용허락범위 `저작권표시`, 샘플 URL, JSON/XML 포맷, 출력 필드, edge 확정에 부족한 필드를 기록했습니다.
- repository contract test로 evidence 기록과 route graph edge 자동 승격 금지를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC"`: exit 0, 92 pass / 0 fail
  - `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs`: exit 0, 166 pass / 0 fail
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC 후보 evidence 계약 | local | repository contract focused test | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC"` 출력 | 92 pass / 0 fail |
| 데이터팩/CI 계약 회귀 | local | datapack tools + CI test suite | `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs` 출력 | 166 pass / 0 fail |
| 공식 상세 페이지 근거 | web | KRIC Open API 상세 페이지 확인 | https://data.kric.go.kr/rips/M_01_02/detail.do?id=307&operation=transferMovement&service=vulnerableUserInfo | 요청 URL, 샘플 URL, 이용허락범위, 출력 필드 확인 |
| diff hygiene | local | whitespace check | `git diff --check` 출력 | exit 0 |
| 화면 증거 | local | 증거 불필요 사유 | source registry와 contract test만 변경하며 앱 UI를 변경하지 않음 | 화면 증거 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `automaticRouteGraphEdgeAllowed: false`가 핵심 안전장치입니다.
  - 이 PR은 source production 승격이나 importer 연결이 아니라 후보 근거 기록만 다룹니다.

## 리스크

- KRIC 상세 페이지의 이용허락범위 표기가 바뀌면 registry evidence를 갱신해야 합니다.
- 이미지 경로 재배포 권리와 거리·시간 근거는 아직 별도 확인이 필요합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
