### PR TITLE
[Build] KRIC 출입구 승강장 이동경로 샘플 근거 계약 추가

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1532,6 +1532,22 @@ test("KRIC 환승 이동경로 후보는 상세 근거가 있어도 route graph 
   assert.deepEqual(candidate.evidence.missingConfirmedEdgeFields.sort(), ["distanceMeters", "durationSeconds"]);
 });
 
+test("KRIC 출입구 승강장 이동경로 후보는 샘플 근거만 기록하고 라이선스 partial을 유지한다", () => {
+  const candidates = readJson("tools/datapack/source-candidates.json");
+  const candidate = candidates.candidates.find(({ id }) => id === "kric-station-movement-detailed");
+
+  assert.ok(candidate);
+  assert.equal(candidate.licenseEvidenceStatus, "partial");
+  assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
+  assert.equal(candidate.admissionStatus, "needs_sample_and_license_evidence");
+  assert.equal(candidate.automaticRouteGraphEdgeAllowed, false);
+  assert.equal(candidate.evidence.listPageUrl, candidate.detailUrl);
+  assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
+  assert.match(candidate.evidence.sampleUrl, /serviceKey=\[서비스키값\]/);
+  assert.deepEqual(candidate.evidence.formats.sort(), ["JSON", "XML"]);
+  assert.deepEqual(candidate.evidence.missingEvidence.sort(), ["licenseDetail", "outputFields"]);
+});
+
 test("운영 데이터팩 공식 출처 ingest adapter는 stable id mapping과 retired id 재사용 금지를 강제한다", () => {
   const importer = read("tools/datapack/import-official-sources.mjs");
 

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -78,7 +78,23 @@
       "detailUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=2",
       "requestUrl": "https://openapi.kric.go.kr/openapi/vulnerableUserInfo/stationMovement",
       "licenseEvidenceStatus": "partial",
+      "sampleEvidenceStatus": "sample_url_documented_key_required",
       "admissionStatus": "needs_sample_and_license_evidence",
+      "automaticRouteGraphEdgeAllowed": false,
+      "evidence": {
+        "listPageUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=2",
+        "retrievedAt": "2026-06-23",
+        "endpoint": "https://openapi.kric.go.kr/openapi/vulnerableUserInfo/stationMovement",
+        "sampleUrl": "https://openapi.kric.go.kr/openapi/vulnerableUserInfo/stationMovement?serviceKey=[서비스키값]&format=xml&railOprIsttCd=S1&lnCd=3&stinCd=321",
+        "formats": [
+          "JSON",
+          "XML"
+        ],
+        "missingEvidence": [
+          "licenseDetail",
+          "outputFields"
+        ]
+      },
       "nextAction": "compare with standard movement API before choosing a primary source"
     },
     {


### PR DESCRIPTION
## 관련 이슈

close #683

## 작업 배경

KRIC 부분확인 P0 후보 중 `출입구 승강장 이동경로`는 공식 KRIC Open API 목록 페이지에서 요청 URL과 샘플 URL을 확인할 수 있습니다.

다만 현재 확인 범위는 목록 페이지 수준이라 이용허락범위와 출력 필드는 아직 확정하지 않습니다. 이 PR은 샘플 URL 근거만 기록하고, production source 승격과 route graph edge 자동 확정은 계속 막습니다.

## 작업 내용

- `kric-station-movement-detailed` 후보에 공식 목록 페이지 기반 sample evidence를 추가했습니다.
- 라이선스 상태는 `partial`로 유지했습니다.
- `automaticRouteGraphEdgeAllowed: false`와 누락 근거 목록을 기록했습니다.
- repository contract test로 샘플 근거와 partial 상태 유지를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC"`: exit 0, 93 pass / 0 fail
  - `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs`: exit 0, 167 pass / 0 fail
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC 후보 sample evidence 계약 | local | repository contract focused test | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC"` 출력 | 93 pass / 0 fail |
| 데이터팩/CI 계약 회귀 | local | datapack tools + CI test suite | `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs` 출력 | 167 pass / 0 fail |
| 공식 목록 페이지 근거 | web | KRIC Open API 목록 페이지 확인 | https://data.kric.go.kr/rips/M_01_02/intro.do?page=2 | 요청 URL과 샘플 URL 확인 |
| diff hygiene | local | whitespace check | `git diff --check` 출력 | exit 0 |
| 화면 증거 | local | 증거 불필요 사유 | source registry와 contract test만 변경하며 앱 UI를 변경하지 않음 | 화면 증거 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 이 PR은 sample evidence만 기록합니다.
  - `licenseEvidenceStatus: partial`과 `admissionStatus: needs_sample_and_license_evidence`는 의도적으로 유지합니다.

## 리스크

- 상세 페이지의 이용허락범위와 출력 필드는 아직 별도 확인이 필요합니다.
- 이 후보는 production source inventory에 들어가지 않으며, 이동동선은 계속 관리자 검수 후보로만 다룹니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
