### PR TITLE
[Build] KRIC 도시철도 전체노선정보 샘플 근거 계약 추가

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1548,6 +1548,21 @@ test("KRIC 출입구 승강장 이동경로 후보는 샘플 근거만 기록하
   assert.deepEqual(candidate.evidence.missingEvidence.sort(), ["licenseDetail", "outputFields"]);
 });
 
+test("KRIC 도시철도 전체노선정보 후보는 샘플 근거만 기록하고 라이선스 partial을 유지한다", () => {
+  const candidates = readJson("tools/datapack/source-candidates.json");
+  const candidate = candidates.candidates.find(({ id }) => id === "kric-subway-route-info");
+
+  assert.ok(candidate);
+  assert.equal(candidate.licenseEvidenceStatus, "partial");
+  assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
+  assert.equal(candidate.admissionStatus, "needs_sample_and_license_evidence");
+  assert.equal(candidate.evidence.listPageUrl, candidate.detailUrl);
+  assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
+  assert.match(candidate.evidence.sampleUrl, /serviceKey=\[서비스키값\]/);
+  assert.deepEqual(candidate.evidence.formats.sort(), ["JSON", "XML"]);
+  assert.deepEqual(candidate.evidence.missingEvidence.sort(), ["licenseDetail", "outputFields"]);
+});
+
 test("운영 데이터팩 공식 출처 ingest adapter는 stable id mapping과 retired id 재사용 금지를 강제한다", () => {
   const importer = read("tools/datapack/import-official-sources.mjs");
 

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -12,7 +12,22 @@
       "detailUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=2",
       "requestUrl": "https://openapi.kric.go.kr/openapi/trainUseInfo/subwayRouteInfo",
       "licenseEvidenceStatus": "partial",
+      "sampleEvidenceStatus": "sample_url_documented_key_required",
       "admissionStatus": "needs_sample_and_license_evidence",
+      "evidence": {
+        "listPageUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=2",
+        "retrievedAt": "2026-06-23",
+        "endpoint": "https://openapi.kric.go.kr/openapi/trainUseInfo/subwayRouteInfo",
+        "sampleUrl": "https://openapi.kric.go.kr/openapi/trainUseInfo/subwayRouteInfo?serviceKey=[서비스키값]&format=xml&mreaWideCd=01&lnCd=A1",
+        "formats": [
+          "JSON",
+          "XML"
+        ],
+        "missingEvidence": [
+          "licenseDetail",
+          "outputFields"
+        ]
+      },
       "nextAction": "verify KRIC sample response and redistributable license evidence before production inventory admission"
     },
     {


### PR DESCRIPTION
## 관련 이슈

close #685

## 작업 배경

KRIC 부분확인 P0 후보 중 `도시철도 전체노선정보`는 전국 역·노선 마스터의 운영기관·노선별 구성역 순서 근거 후보입니다.

공식 KRIC Open API 목록 페이지에서 요청 URL과 샘플 URL은 확인되지만, 현재 범위에서는 이용허락범위 상세와 출력 필드를 확정하지 않습니다. 이 PR은 샘플 URL 근거만 기록하고 production source 승격은 계속 막습니다.

## 작업 내용

- `kric-subway-route-info` 후보에 공식 목록 페이지 기반 sample evidence를 추가했습니다.
- 라이선스 상태는 `partial`로 유지했습니다.
- 누락 근거 목록에 `licenseDetail`, `outputFields`를 기록했습니다.
- repository contract test로 샘플 근거와 partial 상태 유지를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 도시철도"`: exit 0, 94 pass / 0 fail
  - `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs`: exit 0, 168 pass / 0 fail
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC 전체노선정보 sample evidence 계약 | local | repository contract focused test | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 도시철도"` 출력 | 94 pass / 0 fail |
| 데이터팩/CI 계약 회귀 | local | datapack tools + CI test suite | `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs` 출력 | 168 pass / 0 fail |
| 공식 목록 페이지 근거 | web | KRIC Open API 목록 페이지 확인 | https://data.kric.go.kr/rips/M_01_02/intro.do?page=2 | 요청 URL과 샘플 URL 확인 |
| diff hygiene | local | whitespace check | `git diff --check` 출력 | exit 0 |
| 화면 증거 | local | 증거 불필요 사유 | source registry와 contract test만 변경하며 앱 UI를 변경하지 않음 | 화면 증거 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 이 PR은 sample evidence만 기록합니다.
  - `licenseEvidenceStatus: partial`과 `admissionStatus: needs_sample_and_license_evidence`는 의도적으로 유지합니다.

## 리스크

- 상세 이용허락범위와 출력 필드는 아직 별도 확인이 필요합니다.
- 이 후보는 production source inventory에 들어가지 않으며, 전국 마스터 ingest 입력으로 쓰려면 추가 샘플 응답 검증이 필요합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능하여 Codex CLI fallback은 불필요함.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
