### PR TITLE
[Build] KRIC 역사별 승강장 정보 샘플 근거 계약 추가

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1608,6 +1608,21 @@ test("KRIC 역사별 환승정보 후보는 샘플 근거만 기록하고 라이
   assert.deepEqual(candidate.evidence.missingEvidence.sort(), ["licenseDetail", "outputFields"]);
 });
 
+test("KRIC 역사별 승강장 정보 후보는 샘플 근거만 기록하고 라이선스 partial을 유지한다", () => {
+  const candidates = readJson("tools/datapack/source-candidates.json");
+  const candidate = candidates.candidates.find(({ id }) => id === "kric-station-platform");
+
+  assert.ok(candidate);
+  assert.equal(candidate.licenseEvidenceStatus, "partial");
+  assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
+  assert.equal(candidate.admissionStatus, "needs_sample_and_license_evidence");
+  assert.equal(candidate.evidence.listPageUrl, candidate.detailUrl);
+  assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
+  assert.match(candidate.evidence.sampleUrl, /serviceKey=\[서비스키값\]/);
+  assert.deepEqual(candidate.evidence.formats.sort(), ["JSON", "XML"]);
+  assert.deepEqual(candidate.evidence.missingEvidence.sort(), ["licenseDetail", "outputFields"]);
+});
+
 test("운영 데이터팩 공식 출처 ingest adapter는 stable id mapping과 retired id 재사용 금지를 강제한다", () => {
   const importer = read("tools/datapack/import-official-sources.mjs");
 

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -113,10 +113,25 @@
       "priority": "P0",
       "domain": "accessibility_platform",
       "displayName": "역사별 승강장 정보",
-      "detailUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do",
+      "detailUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=1",
       "requestUrl": "https://openapi.kric.go.kr/openapi/convenientInfo/stPlf",
       "licenseEvidenceStatus": "partial",
+      "sampleEvidenceStatus": "sample_url_documented_key_required",
       "admissionStatus": "needs_sample_and_license_evidence",
+      "evidence": {
+        "listPageUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=1",
+        "retrievedAt": "2026-06-23",
+        "endpoint": "https://openapi.kric.go.kr/openapi/convenientInfo/stPlf",
+        "sampleUrl": "https://openapi.kric.go.kr/openapi/convenientInfo/stPlf?serviceKey=[서비스키값]&format=json&railOprIsttCd=S1&lnCd=1&stinCd=152",
+        "formats": [
+          "JSON",
+          "XML"
+        ],
+        "missingEvidence": [
+          "licenseDetail",
+          "outputFields"
+        ]
+      },
       "nextAction": "verify operator field completeness and platform direction codes before production inventory admission"
     },
     {


### PR DESCRIPTION
## 관련 이슈

close #693

## 작업 배경

KRIC 부분확인 P0 후보 중 `역사별 승강장 정보`는 승강장 접근성 속성을 보강하는 후보 source입니다.

공식 KRIC Open API 목록 페이지에서 요청 URL과 샘플 URL은 확인되지만, 현재 범위에서는 이용허락범위 상세와 출력 필드를 확정하지 않습니다. 이 PR은 샘플 URL 근거만 기록하고 production source 승격은 계속 막습니다.

## 작업 내용

- `kric-station-platform` 후보에 공식 목록 페이지 기반 sample evidence를 추가했습니다.
- 라이선스 상태는 `partial`로 유지했습니다.
- 누락 근거 목록에 `licenseDetail`, `outputFields`를 기록했습니다.
- repository contract test로 샘플 근거와 partial 상태 유지를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 역사별 승강장 정보"`: RED에서 `sampleEvidenceStatus` 누락으로 실패 후, 변경 뒤 exit 0, 98 pass / 0 fail
  - `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs`: exit 0, 172 pass / 0 fail
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC 역사별 승강장 정보 sample evidence 계약 | local | repository contract focused test | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 역사별 승강장 정보"` 출력 | 98 pass / 0 fail |
| 데이터팩/CI 계약 회귀 | local | datapack tools + CI test suite | `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs` 출력 | 172 pass / 0 fail |
| 공식 목록 페이지 근거 | web | KRIC Open API 목록 페이지 확인 | https://data.kric.go.kr/rips/M_01_02/intro.do?page=1 | 요청 URL과 샘플 URL 확인 |
| diff hygiene | local | whitespace check | `git diff --check` 출력 | exit 0 |
| 화면 증거 | local | 증거 불필요 사유 | source registry와 contract test만 변경하며 앱 UI를 변경하지 않음 | 화면 증거 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 이 PR은 sample evidence만 기록합니다.
  - `licenseEvidenceStatus: partial`과 `admissionStatus: needs_sample_and_license_evidence`는 의도적으로 유지합니다.

## 리스크

- 상세 이용허락범위와 출력 필드는 아직 별도 확인이 필요합니다.
- 이 후보는 production source inventory에 들어가지 않으며, 승강장 방향/번호 필드의 운영기관별 completeness 검증은 별도 slice에서 다룹니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
