### PR TITLE
[Build] KRIC 출입구 승강장 이동경로 표준 샘플 증거 기록

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1548,6 +1548,22 @@ test("KRIC 출입구 승강장 이동경로 후보는 샘플 근거만 기록하
   assert.deepEqual(candidate.evidence.missingEvidence.sort(), ["licenseDetail", "outputFields"]);
 });
 
+test("KRIC 출입구 승강장 이동경로 표준 후보는 샘플 근거만 기록하고 라이선스 partial을 유지한다", () => {
+  const candidates = readJson("tools/datapack/source-candidates.json");
+  const candidate = candidates.candidates.find(({ id }) => id === "kric-station-movement-standard");
+
+  assert.ok(candidate);
+  assert.equal(candidate.licenseEvidenceStatus, "partial");
+  assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
+  assert.equal(candidate.admissionStatus, "needs_sample_and_license_evidence");
+  assert.equal(candidate.automaticRouteGraphEdgeAllowed, false);
+  assert.equal(candidate.evidence.listPageUrl, candidate.detailUrl);
+  assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
+  assert.match(candidate.evidence.sampleUrl, /serviceKey=\[서비스키값\]/);
+  assert.deepEqual(candidate.evidence.formats.sort(), ["JSON", "XML"]);
+  assert.deepEqual(candidate.evidence.missingEvidence.sort(), ["licenseDetail", "outputFields"]);
+});
+
 test("KRIC 도시철도 전체노선정보 후보는 샘플 근거만 기록하고 라이선스 partial을 유지한다", () => {
   const candidates = readJson("tools/datapack/source-candidates.json");
   const candidate = candidates.candidates.find(({ id }) => id === "kric-subway-route-info");

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -139,10 +139,26 @@
       "priority": "P0",
       "domain": "indoor_movement_paths",
       "displayName": "출입구-승강장 이동경로(표준)",
-      "detailUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do",
+      "detailUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=1",
       "requestUrl": "https://openapi.kric.go.kr/openapi/handicapped/stationMovement",
       "licenseEvidenceStatus": "partial",
+      "sampleEvidenceStatus": "sample_url_documented_key_required",
       "admissionStatus": "needs_sample_and_license_evidence",
+      "automaticRouteGraphEdgeAllowed": false,
+      "evidence": {
+        "listPageUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=1",
+        "retrievedAt": "2026-06-23",
+        "endpoint": "https://openapi.kric.go.kr/openapi/handicapped/stationMovement",
+        "sampleUrl": "https://openapi.kric.go.kr/openapi/handicapped/stationMovement?serviceKey=[서비스키값]&format=xml&railOprIsttCd=S1&lnCd=3&stinCd=322&nextStinCd=323",
+        "formats": [
+          "JSON",
+          "XML"
+        ],
+        "missingEvidence": [
+          "licenseDetail",
+          "outputFields"
+        ]
+      },
       "nextAction": "keep as admin review candidate until distance and duration evidence exists"
     },
     {


### PR DESCRIPTION
## 관련 이슈

close #695

## 작업 배경

KRIC `출입구 승강장 이동경로(표준)`은 전국 지하철 공공기관 API 인벤토리에서 P0 후보로 분류되어 있지만, 저장소의 후보 계약에는 공식 샘플 URL과 검증 상태가 비어 있었다.

이 API는 교통약자 이동 동선 후보를 제공하지만, 현재 확인된 목록 페이지 기준으로 거리(m)와 소요시간(s) 필드 근거가 없다. 따라서 production route graph edge로 자동 승격하지 않고 관리자 검수 후보로 유지해야 한다.

## 작업 내용

- `kric-station-movement-standard` 후보에 KRIC 공식 목록 페이지, 요청 URL, 샘플 URL, 지원 포맷을 기록했다.
- 라이선스 상세와 출력 필드는 아직 추가 확인이 필요하므로 `licenseEvidenceStatus: partial`과 `admissionStatus: needs_sample_and_license_evidence`를 유지했다.
- `automaticRouteGraphEdgeAllowed: false`를 명시해 자동 route graph edge 승격을 차단했다.
- production source inventory에는 추가하지 않았다.
- repository contract 테스트가 이 후보의 샘플 근거와 미승격 상태를 검증하도록 추가했다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 출입구 승강장 이동경로 표준"`: 99 pass / 0 fail
- `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs`: 173 pass / 0 fail
- `git diff --check`: exit 0
- PR CI: https://github.com/AquilaXk/easysubway/actions/runs/27972512396
- PR Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/27972509981
- Codex fallback review: https://github.com/AquilaXk/easysubway/pull/696#pullrequestreview-4546678629

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC 표준 출입구-승강장 이동경로 후보 계약 | local | repository contract focused test | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 출입구 승강장 이동경로 표준"` | 99 pass / 0 fail |
| 데이터팩/저장소 계약 회귀 | local | Node test suite | `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs` | 173 pass / 0 fail |
| whitespace 검증 | local | Git diff check | `git diff --check` | exit 0 |
| 공식 샘플 URL 근거 | KRIC public page | 공식 목록 페이지 확인 | `https://data.kric.go.kr/rips/M_01_02/intro.do?page=1` | 요청 URL과 샘플 URL 확인 |
| PR CI | GitHub Actions | required checks 확인 | `https://github.com/AquilaXk/easysubway/actions/runs/27972512396` | success |
| PR Release Artifacts | GitHub Actions | release artifact check 확인 | `https://github.com/AquilaXk/easysubway/actions/runs/27972509981` | success |
| PR 리뷰 fallback | GitHub PR review | CodeRabbit rate limit 후 Codex CLI review | `https://github.com/AquilaXk/easysubway/pull/696#pullrequestreview-4546678629` | actionable 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `source-candidates.json`의 후보는 production source inventory가 아니라 미승격 후보 목록이다.
- 이 PR은 샘플 URL 근거만 기록하며, 실제 서비스키 호출 결과나 라이선스 상세 원문 확인은 다음 검증 단위로 남긴다.

## 리스크

- KRIC 목록 페이지는 샘플 URL과 포맷만 확인되며, 응답 필드와 이용허락 상세는 아직 production source 승인 근거로 충분하지 않다.
- route graph edge 자동 생성은 계속 차단되어 있어 사용자 경로 계산 동작은 바뀌지 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
