### PR TITLE
[Build] KRIC 승강장 정보 상세 근거 기록

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1660,19 +1660,36 @@ test("KRIC 역사별 환승정보 후보는 샘플 근거만 기록하고 라이
   assert.deepEqual(candidate.evidence.missingEvidence.sort(), ["licenseDetail", "outputFields"]);
 });
 
-test("KRIC 역사별 승강장 정보 후보는 샘플 근거만 기록하고 라이선스 partial을 유지한다", () => {
+test("KRIC 역사별 승강장 정보 후보는 상세 페이지 라이선스와 출력변수 근거를 기록한다", () => {
   const candidates = readJson("tools/datapack/source-candidates.json");
   const candidate = candidates.candidates.find(({ id }) => id === "kric-station-platform");
 
   assert.ok(candidate);
-  assert.equal(candidate.licenseEvidenceStatus, "partial");
+  assert.equal(candidate.licenseEvidenceStatus, "confirmed_attribution");
   assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
-  assert.equal(candidate.admissionStatus, "needs_sample_and_license_evidence");
-  assert.equal(candidate.evidence.listPageUrl, candidate.detailUrl);
+  assert.equal(candidate.admissionStatus, "evidence_recorded_admin_review_required");
+  assert.equal(candidate.detailUrl, "https://data.kric.go.kr/rips/M_01_02/detail.do?id=433&service=convenientInfo&operation=stPlf&page=1");
+  assert.equal(candidate.evidence.detailPageUrl, candidate.detailUrl);
+  assert.equal(candidate.evidence.usePermissionRange, "저작권표시");
   assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
   assert.match(candidate.evidence.sampleUrl, /serviceKey=\[서비스키값\]/);
   assert.deepEqual(candidate.evidence.formats.sort(), ["JSON", "XML"]);
-  assert.deepEqual(candidate.evidence.missingEvidence.sort(), ["licenseDetail", "outputFields"]);
+  assert.deepEqual(candidate.evidence.outputFields.sort(), [
+    "grndDvCd",
+    "lnCd",
+    "plfCplFlg",
+    "plfNo",
+    "plfTpCd",
+    "plfTpNm",
+    "railOprIsttCd",
+    "runDirTmnStinCd",
+    "scrCharExt",
+    "sfFotExt",
+    "stinCd",
+    "stinFlor",
+    "updnDvcd",
+  ]);
+  assert.deepEqual(candidate.evidence.missingEvidence, ["sampleResponse"]);
 });
 
 test("운영 데이터팩 공식 출처 ingest adapter는 stable id mapping과 retired id 재사용 금지를 강제한다", () => {

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -113,26 +113,42 @@
       "priority": "P0",
       "domain": "accessibility_platform",
       "displayName": "역사별 승강장 정보",
-      "detailUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=1",
+      "detailUrl": "https://data.kric.go.kr/rips/M_01_02/detail.do?id=433&service=convenientInfo&operation=stPlf&page=1",
       "requestUrl": "https://openapi.kric.go.kr/openapi/convenientInfo/stPlf",
-      "licenseEvidenceStatus": "partial",
+      "licenseEvidenceStatus": "confirmed_attribution",
       "sampleEvidenceStatus": "sample_url_documented_key_required",
-      "admissionStatus": "needs_sample_and_license_evidence",
+      "admissionStatus": "evidence_recorded_admin_review_required",
       "evidence": {
         "listPageUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=1",
+        "detailPageUrl": "https://data.kric.go.kr/rips/M_01_02/detail.do?id=433&service=convenientInfo&operation=stPlf&page=1",
         "retrievedAt": "2026-06-23",
         "endpoint": "https://openapi.kric.go.kr/openapi/convenientInfo/stPlf",
         "sampleUrl": "https://openapi.kric.go.kr/openapi/convenientInfo/stPlf?serviceKey=[서비스키값]&format=json&railOprIsttCd=S1&lnCd=1&stinCd=152",
+        "usePermissionRange": "저작권표시",
         "formats": [
           "JSON",
           "XML"
         ],
+        "outputFields": [
+          "grndDvCd",
+          "lnCd",
+          "plfCplFlg",
+          "plfNo",
+          "plfTpCd",
+          "plfTpNm",
+          "railOprIsttCd",
+          "runDirTmnStinCd",
+          "scrCharExt",
+          "sfFotExt",
+          "stinCd",
+          "stinFlor",
+          "updnDvcd"
+        ],
         "missingEvidence": [
-          "licenseDetail",
-          "outputFields"
+          "sampleResponse"
         ]
       },
-      "nextAction": "verify operator field completeness and platform direction codes before production inventory admission"
+      "nextAction": "verify live sample response and operator field completeness before production inventory admission"
     },
     {
       "id": "kric-station-movement-standard",


### PR DESCRIPTION
## 관련 이슈

close #703

## 작업 배경

KRIC `역사별 승강장 정보` 후보는 목록 페이지의 샘플 URL만 기록되어 있었고, 상세 페이지 기준의 이용허락범위와 출력변수 근거가 계약에 고정되어 있지 않았습니다. production 데이터팩 source로 승격하기 전 후보별 증거 상태를 분리해 추적하기 위한 보강입니다.

## 작업 내용

- `kric-station-platform`의 상세 페이지 URL을 공식 KRIC detail URL로 갱신했습니다.
- 이용허락범위 `저작권표시`와 출력변수 13개를 source candidate evidence에 기록했습니다.
- live API 샘플 응답 본문은 아직 확인하지 않았으므로 `missingEvidence: ["sampleResponse"]`로 유지했습니다.
- production source inventory에는 승격하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 역사별 승강장 정보"`: 101 pass / 0 fail
  - `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs`: 175 pass / 0 fail
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC 상세 근거 | local | 공식 상세 페이지 확인 | https://data.kric.go.kr/rips/M_01_02/detail.do?id=433&service=convenientInfo&operation=stPlf&page=1 | 이용허락범위 `저작권표시`, 출력변수 13개 확인 |
| 후보 계약 테스트 | local | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 역사별 승강장 정보"` | command output | 101 pass / 0 fail |
| 데이터팩/CI 계약 테스트 | local | `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs` | command output | 175 pass / 0 fail |
| 공백 문자 검사 | local | `git diff --check` | command output | exit 0 |
| PR CI | GitHub Actions | required checks 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27975464509 | pass |
| Release Artifacts | GitHub Actions | 일반 data contract PR의 CD 실패 상태 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27975462810 | pass |
| CodeRabbit | GitHub PR | bot comment/status 확인 | https://github.com/AquilaXk/easysubway/pull/704#issuecomment-4771646283 | rate limit/credit exhausted로 실제 review 미시작 |
| Codex fallback review | GitHub PR review | summary-only fallback review 게시 | https://github.com/AquilaXk/easysubway/pull/704#pullrequestreview-4547136492 | actionable 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/source-candidates.json`의 `kric-station-platform` evidence와 남은 증거 `sampleResponse` 유지 여부

## 리스크

- live API serviceKey를 사용한 실제 응답 본문은 이번 범위에서 확인하지 않았습니다.
- 승강장 정보의 운영기관별 완전성은 production source 승격 전 별도 표본 검증이 필요합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
