### PR TITLE
[Build] KRIC 도시철도 전체노선정보 상세 근거 기록

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1626,19 +1626,31 @@ test("KRIC 편의정보 표준 후보는 상세 페이지 라이선스와 출력
   assert.deepEqual(candidate.evidence.missingEvidence.sort(), ["sampleResponse"]);
 });
 
-test("KRIC 도시철도 전체노선정보 후보는 샘플 근거만 기록하고 라이선스 partial을 유지한다", () => {
+test("KRIC 도시철도 전체노선정보 후보는 상세 페이지 라이선스와 출력변수 근거를 기록한다", () => {
   const candidates = readJson("tools/datapack/source-candidates.json");
   const candidate = candidates.candidates.find(({ id }) => id === "kric-subway-route-info");
 
   assert.ok(candidate);
-  assert.equal(candidate.licenseEvidenceStatus, "partial");
+  assert.equal(candidate.licenseEvidenceStatus, "confirmed_attribution");
   assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
-  assert.equal(candidate.admissionStatus, "needs_sample_and_license_evidence");
-  assert.equal(candidate.evidence.listPageUrl, candidate.detailUrl);
+  assert.equal(candidate.admissionStatus, "evidence_recorded_admin_review_required");
+  assert.equal(candidate.detailUrl, "https://data.kric.go.kr/rips/M_01_02/detail.do?id=431&service=trainUseInfo&operation=subwayRouteInfo&page=2");
+  assert.equal(candidate.evidence.detailPageUrl, candidate.detailUrl);
+  assert.equal(candidate.evidence.usePermissionRange, "저작권표시");
   assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
   assert.match(candidate.evidence.sampleUrl, /serviceKey=\[서비스키값\]/);
   assert.deepEqual(candidate.evidence.formats.sort(), ["JSON", "XML"]);
-  assert.deepEqual(candidate.evidence.missingEvidence.sort(), ["licenseDetail", "outputFields"]);
+  assert.deepEqual(candidate.evidence.outputFields.sort(), [
+    "lnCd",
+    "mreaWideCd",
+    "railOprIsttCd",
+    "routCd",
+    "routNm",
+    "stinCd",
+    "stinConsOrdr",
+    "stinNm",
+  ]);
+  assert.deepEqual(candidate.evidence.missingEvidence, ["sampleResponse"]);
 });
 
 test("KRIC 역사별 정보 후보는 샘플 근거만 기록하고 라이선스 partial을 유지한다", () => {

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -9,26 +9,37 @@
       "priority": "P0",
       "domain": "station_line_membership",
       "displayName": "도시철도 전체노선정보",
-      "detailUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=2",
+      "detailUrl": "https://data.kric.go.kr/rips/M_01_02/detail.do?id=431&service=trainUseInfo&operation=subwayRouteInfo&page=2",
       "requestUrl": "https://openapi.kric.go.kr/openapi/trainUseInfo/subwayRouteInfo",
-      "licenseEvidenceStatus": "partial",
+      "licenseEvidenceStatus": "confirmed_attribution",
       "sampleEvidenceStatus": "sample_url_documented_key_required",
-      "admissionStatus": "needs_sample_and_license_evidence",
+      "admissionStatus": "evidence_recorded_admin_review_required",
       "evidence": {
         "listPageUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=2",
+        "detailPageUrl": "https://data.kric.go.kr/rips/M_01_02/detail.do?id=431&service=trainUseInfo&operation=subwayRouteInfo&page=2",
         "retrievedAt": "2026-06-23",
         "endpoint": "https://openapi.kric.go.kr/openapi/trainUseInfo/subwayRouteInfo",
         "sampleUrl": "https://openapi.kric.go.kr/openapi/trainUseInfo/subwayRouteInfo?serviceKey=[서비스키값]&format=xml&mreaWideCd=01&lnCd=A1",
+        "usePermissionRange": "저작권표시",
         "formats": [
           "JSON",
           "XML"
         ],
+        "outputFields": [
+          "lnCd",
+          "mreaWideCd",
+          "railOprIsttCd",
+          "routCd",
+          "routNm",
+          "stinCd",
+          "stinConsOrdr",
+          "stinNm"
+        ],
         "missingEvidence": [
-          "licenseDetail",
-          "outputFields"
+          "sampleResponse"
         ]
       },
-      "nextAction": "verify KRIC sample response and redistributable license evidence before production inventory admission"
+      "nextAction": "verify live sample response and route station order coverage before production inventory admission"
     },
     {
       "id": "kric-station-info",


### PR DESCRIPTION
## 관련 이슈

close #711

## 작업 배경

KRIC `도시철도 전체노선정보` 후보는 전국 마스터 구축 P0 후보지만, 저장소에는 목록 페이지와 샘플 URL만 기록되어 있었습니다. production 데이터팩 source로 승격하기 전 상세 페이지 기준 이용허락범위와 출력변수 근거를 후보 계약에 고정합니다.

## 작업 내용

- `kric-subway-route-info`의 상세 페이지 URL을 공식 KRIC detail URL로 갱신했습니다.
- 이용허락범위 `저작권표시`와 출력변수 8개를 source candidate evidence에 기록했습니다.
- live API 샘플 응답 본문은 아직 확인하지 않았으므로 `missingEvidence: ["sampleResponse"]`로 유지했습니다.
- production source inventory 미승격 상태를 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 도시철도 전체노선정보"`: JSON 갱신 전 RED 100 pass / 1 fail, 갱신 후 GREEN 101 pass / 0 fail
  - `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs`: 175 pass / 0 fail
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC 상세 근거 | local | 공식 상세 페이지 확인 | https://data.kric.go.kr/rips/M_01_02/detail.do?id=431&service=trainUseInfo&operation=subwayRouteInfo&page=2 | 이용허락범위 `저작권표시`, 출력변수 8개 확인 |
| 후보 계약 RED | local | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 도시철도 전체노선정보"` | command output | JSON 갱신 전 `licenseEvidenceStatus` partial로 실패 |
| 후보 계약 GREEN | local | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 도시철도 전체노선정보"` | command output | 101 pass / 0 fail |
| 데이터팩/CI 계약 테스트 | local | `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs` | command output | 175 pass / 0 fail |
| 공백 문자 검사 | local | `git diff --check` | command output | exit 0 |
| PR CI | GitHub Actions | required checks 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27978732068 | success |
| Release Artifacts | GitHub Actions | data contract PR의 release artifact 실패 상태 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27978730895 | success |
| CodeRabbit | GitHub PR | bot comment/status 확인 | https://github.com/AquilaXk/easysubway/pull/712#issuecomment-4772261986 | rate limit으로 실제 review 미시작 |
| Codex fallback review | GitHub PR review | summary-only fallback review 게시 | https://github.com/AquilaXk/easysubway/pull/712#pullrequestreview-4547543100 | actionable 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `missingEvidence: ["sampleResponse"]` 유지와 production source inventory 미승격 상태

## 리스크

- live API serviceKey를 사용한 실제 응답 본문은 이번 범위에서 확인하지 않았습니다.
- 이 후보는 역 순서와 노선 구성 근거이며, 거리·소요시간·역사 내부 동선 근거로 자동 승격하지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
