### PR TITLE
[Build] KRIC 출입구 승강장 이동경로 상세 근거 기록

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1532,20 +1532,36 @@ test("KRIC 환승 이동경로 후보는 상세 근거가 있어도 route graph 
   assert.deepEqual(candidate.evidence.missingConfirmedEdgeFields.sort(), ["distanceMeters", "durationSeconds"]);
 });
 
-test("KRIC 출입구 승강장 이동경로 후보는 샘플 근거만 기록하고 라이선스 partial을 유지한다", () => {
+test("KRIC 출입구 승강장 이동경로 후보는 상세 근거가 있어도 route graph edge로 자동 승격하지 않는다", () => {
   const candidates = readJson("tools/datapack/source-candidates.json");
   const candidate = candidates.candidates.find(({ id }) => id === "kric-station-movement-detailed");
 
   assert.ok(candidate);
-  assert.equal(candidate.licenseEvidenceStatus, "partial");
+  assert.equal(candidate.licenseEvidenceStatus, "confirmed_attribution");
   assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
-  assert.equal(candidate.admissionStatus, "needs_sample_and_license_evidence");
+  assert.equal(candidate.admissionStatus, "evidence_recorded_admin_review_required");
   assert.equal(candidate.automaticRouteGraphEdgeAllowed, false);
-  assert.equal(candidate.evidence.listPageUrl, candidate.detailUrl);
+  assert.equal(
+    candidate.detailUrl,
+    "https://data.kric.go.kr/rips/M_01_02/detail.do?id=306&service=vulnerableUserInfo&operation=stationMovement&page=2",
+  );
+  assert.equal(candidate.evidence.detailPageUrl, candidate.detailUrl);
   assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
+  assert.equal(candidate.evidence.usePermissionRange, "저작권표시");
   assert.match(candidate.evidence.sampleUrl, /serviceKey=\[서비스키값\]/);
   assert.deepEqual(candidate.evidence.formats.sort(), ["JSON", "XML"]);
-  assert.deepEqual(candidate.evidence.missingEvidence.sort(), ["licenseDetail", "outputFields"]);
+  assert.deepEqual(candidate.evidence.outputFields.sort(), [
+    "edMovePath",
+    "elvtSttCd",
+    "elvtTpCd",
+    "exitMvTpOrdr",
+    "imgPath",
+    "mvContDtl",
+    "mvPathMgNo",
+    "stMovePath",
+  ]);
+  assert.deepEqual(candidate.evidence.missingConfirmedEdgeFields.sort(), ["distanceMeters", "durationSeconds"]);
+  assert.deepEqual(candidate.evidence.missingEvidence, ["sampleResponse"]);
 });
 
 test("KRIC 출입구 승강장 이동경로 표준 후보는 상세 페이지 라이선스와 출력변수 근거를 기록한다", () => {

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -242,24 +242,39 @@
       "priority": "P0",
       "domain": "indoor_movement_paths",
       "displayName": "출입구-승강장 이동경로",
-      "detailUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=2",
+      "detailUrl": "https://data.kric.go.kr/rips/M_01_02/detail.do?id=306&service=vulnerableUserInfo&operation=stationMovement&page=2",
       "requestUrl": "https://openapi.kric.go.kr/openapi/vulnerableUserInfo/stationMovement",
-      "licenseEvidenceStatus": "partial",
+      "licenseEvidenceStatus": "confirmed_attribution",
       "sampleEvidenceStatus": "sample_url_documented_key_required",
-      "admissionStatus": "needs_sample_and_license_evidence",
+      "admissionStatus": "evidence_recorded_admin_review_required",
       "automaticRouteGraphEdgeAllowed": false,
       "evidence": {
         "listPageUrl": "https://data.kric.go.kr/rips/M_01_02/intro.do?page=2",
+        "detailPageUrl": "https://data.kric.go.kr/rips/M_01_02/detail.do?id=306&service=vulnerableUserInfo&operation=stationMovement&page=2",
         "retrievedAt": "2026-06-23",
         "endpoint": "https://openapi.kric.go.kr/openapi/vulnerableUserInfo/stationMovement",
-        "sampleUrl": "https://openapi.kric.go.kr/openapi/vulnerableUserInfo/stationMovement?serviceKey=[서비스키값]&format=xml&railOprIsttCd=S1&lnCd=3&stinCd=321",
+        "usePermissionRange": "저작권표시",
+        "sampleUrl": "https://openapi.kric.go.kr/openapi/vulnerableUserInfo/stationMovement?serviceKey=[서비스키값]&format=xml&railOprIsttCd=S1&lnCd=3&stinCd=322&nextStinCd=323",
         "formats": [
           "JSON",
           "XML"
         ],
+        "outputFields": [
+          "edMovePath",
+          "elvtSttCd",
+          "elvtTpCd",
+          "exitMvTpOrdr",
+          "imgPath",
+          "mvContDtl",
+          "mvPathMgNo",
+          "stMovePath"
+        ],
+        "missingConfirmedEdgeFields": [
+          "distanceMeters",
+          "durationSeconds"
+        ],
         "missingEvidence": [
-          "licenseDetail",
-          "outputFields"
+          "sampleResponse"
         ]
       },
       "nextAction": "compare with standard movement API before choosing a primary source"


### PR DESCRIPTION
## 관련 이슈

close #717

## 작업 배경

KRIC `출입구 승강장 이동경로` 후보는 source candidate 중 남은 `partial` 상태였습니다. 공식 상세 페이지에서 이용허락범위와 출력변수는 확인되지만, 거리·시간 비용이 없는 문구형 동선이므로 production route graph edge로 자동 승격하지 않는 조건을 같이 고정합니다.

## 작업 내용

- `kric-station-movement-detailed`의 상세 페이지 URL을 공식 KRIC detail URL로 갱신했습니다.
- 이용허락범위 `저작권표시`와 출력변수 8개를 source candidate evidence에 기록했습니다.
- live API 샘플 응답 본문은 아직 확인하지 않았으므로 `missingEvidence: ["sampleResponse"]`로 유지했습니다.
- `automaticRouteGraphEdgeAllowed: false`와 `missingConfirmedEdgeFields: ["distanceMeters", "durationSeconds"]`를 유지했습니다.
- production source inventory 미승격 상태를 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 출입구 승강장 이동경로 후보"`: JSON 갱신 전 RED 100 pass / 1 fail, 갱신 후 GREEN 101 pass / 0 fail
  - `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs`: 175 pass / 0 fail
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC 상세 근거 | local | 공식 상세 페이지 확인 | https://data.kric.go.kr/rips/M_01_02/detail.do?id=306&service=vulnerableUserInfo&operation=stationMovement&page=2 | 이용허락범위 `저작권표시`, 출력변수 8개 확인 |
| 후보 계약 RED | local | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 출입구 승강장 이동경로 후보"` | command output | JSON 갱신 전 `licenseEvidenceStatus` partial로 실패 |
| 후보 계약 GREEN | local | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "KRIC 출입구 승강장 이동경로 후보"` | command output | 101 pass / 0 fail |
| 데이터팩/CI 계약 테스트 | local | `node --test tools/datapack/datapack-tools.test.mjs tools/ci/*.test.mjs` | command output | 175 pass / 0 fail |
| 공백 문자 검사 | local | `git diff --check` | command output | exit 0 |
| PR CI | GitHub Actions | PR check rollup 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27980763552 | success |
| Release Artifacts | GitHub Actions | PR check rollup 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27980762959 | success |
| CodeRabbit | GitHub PR | 기존 bot 상태 확인 | https://github.com/AquilaXk/easysubway/pull/718#issuecomment-4772578239 | rate limit으로 fallback 필요 |
| Codex fallback review | GitHub PR review | `codex review --base origin/main --title "[Build] KRIC 출입구 승강장 이동경로 상세 근거 기록"` | https://github.com/AquilaXk/easysubway/pull/718#pullrequestreview-4547783525 | Actionable comments posted: 0 |
| Review threads | GitHub GraphQL | `reviewThreads(first:100)` 확인 | command output | unresolved thread 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 상세 근거를 기록하더라도 거리·시간 비용이 없어 route graph edge 자동 승격은 계속 금지됩니다.

## 리스크

- live API serviceKey를 사용한 실제 응답 본문은 이번 범위에서 확인하지 않았습니다.
- KRIC 표준 이동경로 API와 상세 이동경로 API 중 primary source 선정은 이번 범위에서 바꾸지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
