### PR TITLE
[Build] KRIC 후보 live sample 검증 게이트 추가

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -3138,6 +3138,209 @@ test("source inventory 검증기는 coverageScope 누락을 거부한다", async
   );
 });
 
+test("source candidate sample 검증기는 KRIC live evidence metadata를 허용한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-sample-${Date.now()}`);
+  const samplePath = path.join(outputDir, "sample.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    samplePath,
+    `${JSON.stringify(
+      {
+        candidateId: "kric-subway-route-info",
+        endpoint: "https://openapi.kric.go.kr/openapi/trainUseInfo/subwayRouteInfo",
+        format: "json",
+        fields: [
+          "lnCd",
+          "mreaWideCd",
+          "railOprIsttCd",
+          "routCd",
+          "routNm",
+          "stinCd",
+          "stinConsOrdr",
+          "stinNm",
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/validate-source-candidate-sample.mjs",
+      "--candidate",
+      "kric-subway-route-info",
+      "--sample",
+      samplePath,
+    ],
+    { cwd: root },
+  );
+
+  assert.match(stdout, /source candidate sample evidence valid: kric-subway-route-info/);
+});
+
+test("source candidate sample 검증기는 endpoint mismatch를 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-endpoint-${Date.now()}`);
+  const samplePath = path.join(outputDir, "sample.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    samplePath,
+    `${JSON.stringify(
+      {
+        candidateId: "kric-subway-route-info",
+        endpoint: "https://openapi.kric.go.kr/openapi/convenientInfo/stationInfo",
+        format: "json",
+        fields: [
+          "lnCd",
+          "mreaWideCd",
+          "railOprIsttCd",
+          "routCd",
+          "routNm",
+          "stinCd",
+          "stinConsOrdr",
+          "stinNm",
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-candidate-sample.mjs",
+        "--candidate",
+        "kric-subway-route-info",
+        "--sample",
+        samplePath,
+      ],
+      { cwd: root },
+    ),
+    /endpoint mismatch/,
+  );
+});
+
+test("source candidate sample 검증기는 output field 누락을 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-field-${Date.now()}`);
+  const samplePath = path.join(outputDir, "sample.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    samplePath,
+    `${JSON.stringify(
+      {
+        candidateId: "kric-subway-route-info",
+        endpoint: "https://openapi.kric.go.kr/openapi/trainUseInfo/subwayRouteInfo",
+        format: "json",
+        fields: ["lnCd", "mreaWideCd", "railOprIsttCd", "routCd", "routNm", "stinCd", "stinNm"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-candidate-sample.mjs",
+        "--candidate",
+        "kric-subway-route-info",
+        "--sample",
+        samplePath,
+      ],
+      { cwd: root },
+    ),
+    /output field missing: stinConsOrdr/,
+  );
+});
+
+test("source candidate sample 검증기는 KRIC 이동동선 route graph 자동 승격을 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-route-edge-${Date.now()}`);
+  const samplePath = path.join(outputDir, "sample.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    samplePath,
+    `${JSON.stringify(
+      {
+        candidateId: "kric-transfer-movement-standard",
+        endpoint: "https://openapi.kric.go.kr/openapi/handicapped/transferMovement",
+        format: "json",
+        fields: [
+          "chtnMvTpOrdr",
+          "edMovePath",
+          "elvtSttCd",
+          "elvtTpCd",
+          "imgPath",
+          "mvContDtl",
+          "mvPathMgNo",
+          "stMovePath",
+        ],
+        routeGraphEdgeAdmission: "allowed",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-candidate-sample.mjs",
+        "--candidate",
+        "kric-transfer-movement-standard",
+        "--sample",
+        samplePath,
+      ],
+      { cwd: root },
+    ),
+    /route graph edge admission requires confirmed fields: distanceMeters, durationSeconds/,
+  );
+});
+
+test("source candidate sample 검증기는 serviceKey credential 포함을 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-secret-${Date.now()}`);
+  const samplePath = path.join(outputDir, "sample.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    samplePath,
+    `${JSON.stringify(
+      {
+        candidateId: "kric-train-operation-organ",
+        endpoint: "https://openapi.kric.go.kr/openapi/convenientInfo/trainOperationOrgan",
+        format: "json",
+        fields: ["railOprIsttCd", "railOprIsttNm"],
+        observedUrl: "https://openapi.kric.go.kr/openapi/convenientInfo/trainOperationOrgan?serviceKey=actual-secret",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-candidate-sample.mjs",
+        "--candidate",
+        "kric-train-operation-organ",
+        "--sample",
+        samplePath,
+      ],
+      { cwd: root },
+    ),
+    /sample evidence must not contain serviceKey credentials: observedUrl/,
+  );
+});
+
 test("전국 coverage gap report는 현재 source inventory의 누락 coverage를 실패로 노출한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-coverage-gap-fail-${Date.now()}`);
   const reportPath = path.join(outputDir, "coverage-gap-report.json");

--- a/tools/datapack/validate-source-candidate-sample.mjs
+++ b/tools/datapack/validate-source-candidate-sample.mjs
@@ -1,0 +1,125 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const args = {
+    candidates: "tools/datapack/source-candidates.json",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag.startsWith("--")) {
+      throw new Error(`unexpected argument: ${flag}`);
+    }
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${flag} requires a value`);
+    }
+    args[flag.slice(2)] = value;
+    index += 1;
+  }
+
+  if (!args.candidate) {
+    throw new Error("--candidate is required");
+  }
+  if (!args.sample) {
+    throw new Error("--sample is required");
+  }
+
+  return args;
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+function findCredentialLeak(value, pathParts = []) {
+  if (typeof value === "string") {
+    if (/serviceKey=(?!\[서비스키값\])[^&\s]+/i.test(value)) {
+      return pathParts.join(".") || "sample";
+    }
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      const leakPath = findCredentialLeak(item, [...pathParts, String(index)]);
+      if (leakPath) {
+        return leakPath;
+      }
+    }
+    return null;
+  }
+
+  if (value && typeof value === "object") {
+    for (const [key, item] of Object.entries(value)) {
+      if (/serviceKey/i.test(key) && item !== "[서비스키값]") {
+        return [...pathParts, key].join(".");
+      }
+      const leakPath = findCredentialLeak(item, [...pathParts, key]);
+      if (leakPath) {
+        return leakPath;
+      }
+    }
+  }
+
+  return null;
+}
+
+function validateSample({ candidate, candidateId, sample }) {
+  if (sample.candidateId !== candidateId) {
+    throw new Error(`sample candidateId mismatch: expected ${candidateId}`);
+  }
+
+  if (sample.endpoint !== candidate.evidence.endpoint) {
+    throw new Error(`endpoint mismatch: expected ${candidate.evidence.endpoint}`);
+  }
+
+  const supportedFormats = new Set(candidate.evidence.formats.map((format) => format.toLowerCase()));
+  if (!supportedFormats.has(String(sample.format).toLowerCase())) {
+    throw new Error(`format is not supported: ${sample.format}`);
+  }
+
+  if (!Array.isArray(sample.fields)) {
+    throw new Error("fields must be an array");
+  }
+
+  const sampleFields = new Set(sample.fields);
+  const missingFields = candidate.evidence.outputFields.filter((field) => !sampleFields.has(field));
+  if (missingFields.length > 0) {
+    throw new Error(`output field missing: ${missingFields.join(", ")}`);
+  }
+
+  const missingEdgeFields = candidate.evidence.missingConfirmedEdgeFields ?? [];
+  if (candidate.automaticRouteGraphEdgeAllowed === false && sample.routeGraphEdgeAdmission === "allowed") {
+    const suffix =
+      missingEdgeFields.length > 0 ? `: ${missingEdgeFields.join(", ")}` : "";
+    throw new Error(`route graph edge admission requires confirmed fields${suffix}`);
+  }
+
+  const leakPath = findCredentialLeak(sample);
+  if (leakPath) {
+    throw new Error(`sample evidence must not contain serviceKey credentials: ${leakPath}`);
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const candidatesPath = path.resolve(args.candidates);
+  const samplePath = path.resolve(args.sample);
+  const candidates = await readJson(candidatesPath);
+  const sample = await readJson(samplePath);
+  const candidate = candidates.candidates.find(({ id }) => id === args.candidate);
+
+  if (!candidate) {
+    throw new Error(`unknown source candidate: ${args.candidate}`);
+  }
+
+  validateSample({ candidate, candidateId: args.candidate, sample });
+  console.log(`source candidate sample evidence valid: ${args.candidate}`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## 관련 이슈

close #723

## 작업 배경

KRIC P0 source 후보는 endpoint, sample URL, 출력 필드, 라이선스 근거가 기록되어 있지만 실제 live sample 응답 근거는 아직 없다. 서비스키와 원본 응답을 저장소에 올리지 않고도 로컬에서 캡처한 sample evidence JSON이 후보 계약과 맞는지 검증할 수 있어야 production source inventory 승격 전에 누락 필드와 잘못된 endpoint를 잡을 수 있다.

## 작업 내용

- tools/datapack/validate-source-candidate-sample.mjs를 추가해 candidate id와 sample evidence JSON을 입력받아 endpoint, format, outputFields를 검증한다.
- sample evidence에 serviceKey credential이 포함된 URL 또는 필드가 들어오면 실패하도록 막았다.
- KRIC 이동동선 후보는 distanceMeters, durationSeconds 근거가 없는 한 route graph edge로 자동 승격할 수 없도록 검증 케이스를 추가했다.
- source-candidates.json 자체와 원본 샘플 응답은 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/datapack-tools.test.mjs`: 79 tests passed
  - `node --test tools/ci/*.test.mjs`: 101 tests passed
  - `node --check tools/datapack/validate-source-candidate-sample.mjs`: exit 0
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC sample evidence 검증 CLI | local Node.js | 성공/실패 fixture를 임시 JSON으로 생성해 CLI 실행 | `node --test tools/datapack/datapack-tools.test.mjs` 출력 | endpoint, field, route graph admission, credential guard 검증 포함 79 tests passed |
| 저장소 계약 | local Node.js | CI contract 테스트 실행 | `node --test tools/ci/*.test.mjs` 출력 | 101 tests passed |
| 문법 및 whitespace | local shell | Node syntax check와 diff whitespace 검사 | `node --check tools/datapack/validate-source-candidate-sample.mjs`, `git diff --check` 출력 | 둘 다 exit 0 |
| PR CI | GitHub Actions | PR #724 check 확인 | CI run 27986792900, Release Artifacts run 27986792790 | Android CI, Mobile App CI, Backend CI, Repository CI, OSV, Release Artifact checks all passed |
| 리뷰 | GitHub PR review | CodeRabbit 상태 확인 후 fallback review 게시 | CodeRabbit rate limit comment, Codex CLI review #4548390818 | Codex CLI actionable 0 |
| UI 증거 | 해당 없음 | CLI와 테스트 도구 변경이며 사용자 화면 변경 없음 | 증거 불필요 사유: UI, 접근성, 권한 문구, 릴리즈 산출물 변경이 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: sample evidence JSON은 원본 API 응답 저장 형식이 아니라 검증용 메타데이터 형식이다. serviceKey 또는 원본 credential이 저장소 fixture로 들어오지 않게 막는 것이 핵심이다.

## 리스크

- 실제 KRIC API 응답 구조를 자동 파싱하지 않는다. 이 PR은 production 승격 전 로컬 evidence metadata를 검증하는 gate만 추가하며, live fetch와 source inventory admission은 후속 작업으로 남긴다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
