### PR TITLE
[Build] KRIC raw sample evidence 변환 도구 추가

### DIFF
--- a/tools/datapack/build-source-candidate-sample-evidence.mjs
+++ b/tools/datapack/build-source-candidate-sample-evidence.mjs
@@ -29,7 +29,11 @@ async function readJson(filePath) {
 }
 
 function assertNoServiceKey(value) {
-  if (/serviceKey=(?!\[서비스키값\])[^&\s<"]+/i.test(value)) {
+  if (
+    /serviceKey=(?!\[서비스키값\])[^&\s<"]+/i.test(value) ||
+    /"serviceKey"\s*:\s*"(?!\[서비스키값\]")[^"]+"/i.test(value) ||
+    /<serviceKey\b[^>]*>\s*(?!\[서비스키값\]\s*<\/serviceKey>)[\s\S]*?<\/serviceKey>/i.test(value)
+  ) {
     throw new Error("raw sample response must not contain serviceKey credentials");
   }
 }
@@ -63,9 +67,27 @@ function bestJsonRow(value, best = { row: null, count: 0 }) {
   return best;
 }
 
+function itemRows(value) {
+  if (Array.isArray(value)) {
+    return value.flatMap(itemRows);
+  }
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  if (Object.hasOwn(value, "item")) {
+    return Array.isArray(value.item)
+      ? value.item.filter((item) => item && typeof item === "object")
+      : value.item && typeof value.item === "object" ? [value.item] : [];
+  }
+  return Object.values(value).flatMap(itemRows);
+}
+
 function fieldsFromJson(raw) {
   const parsed = JSON.parse(raw);
-  const { row } = bestJsonRow(parsed);
+  const rows = itemRows(parsed);
+  const row = rows.length > 0
+    ? rows.reduce((best, item) => (scalarFieldCount(item) > scalarFieldCount(best) ? item : best))
+    : bestJsonRow(parsed).row;
   if (!row) {
     throw new Error("JSON response has no object fields");
   }

--- a/tools/datapack/build-source-candidate-sample-evidence.mjs
+++ b/tools/datapack/build-source-candidate-sample-evidence.mjs
@@ -97,13 +97,16 @@ function fieldsFromJson(raw) {
 }
 
 function fieldsFromXml(raw) {
-  const item = raw.match(/<item\b[^>]*>([\s\S]*?)<\/item>/i)?.[1] ?? raw;
+  const items = [...raw.matchAll(/<item\b[^>]*>([\s\S]*?)<\/item>/gi)].map((match) => match[1]);
+  const fragments = items.length > 0 ? items : [raw];
   const fields = new Set();
-  const tagPattern = /<([A-Za-z_][\w.-]*)\b[^>]*>([\s\S]*?)<\/\1>/g;
-  for (const match of item.matchAll(tagPattern)) {
-    const [, tagName, body] = match;
-    if (!/<[A-Za-z_][\w.-]*\b/.test(body)) {
-      fields.add(tagName);
+  for (const fragment of fragments) {
+    const tagPattern = /<([A-Za-z_][\w.-]*)\b[^>]*>([\s\S]*?)<\/\1>/g;
+    for (const match of fragment.matchAll(tagPattern)) {
+      const [, tagName, body] = match;
+      if (!/<[A-Za-z_][\w.-]*\b/.test(body)) {
+        fields.add(tagName);
+      }
     }
   }
   if (fields.size === 0) {

--- a/tools/datapack/build-source-candidate-sample-evidence.mjs
+++ b/tools/datapack/build-source-candidate-sample-evidence.mjs
@@ -85,9 +85,22 @@ function itemRows(value) {
 function fieldsFromJson(raw) {
   const parsed = JSON.parse(raw);
   const rows = itemRows(parsed);
-  const row = rows.length > 0
-    ? rows.reduce((best, item) => (scalarFieldCount(item) > scalarFieldCount(best) ? item : best))
-    : bestJsonRow(parsed).row;
+  if (rows.length > 0) {
+    const fields = new Set();
+    for (const row of rows) {
+      for (const [key, value] of Object.entries(row)) {
+        if (value == null || typeof value !== "object") {
+          fields.add(key);
+        }
+      }
+    }
+    if (fields.size === 0) {
+      throw new Error("JSON response has no object fields");
+    }
+    return [...fields].sort();
+  }
+
+  const row = bestJsonRow(parsed).row;
   if (!row) {
     throw new Error("JSON response has no object fields");
   }
@@ -101,6 +114,10 @@ function fieldsFromXml(raw) {
   const fragments = items.length > 0 ? items : [raw];
   const fields = new Set();
   for (const fragment of fragments) {
+    const selfClosingTagPattern = /<([A-Za-z_][\w.-]*)\b[^>]*\/>/g;
+    for (const match of fragment.matchAll(selfClosingTagPattern)) {
+      fields.add(match[1]);
+    }
     const tagPattern = /<([A-Za-z_][\w.-]*)\b[^>]*>([\s\S]*?)<\/\1>/g;
     for (const match of fragment.matchAll(tagPattern)) {
       const [, tagName, body] = match;

--- a/tools/datapack/build-source-candidate-sample-evidence.mjs
+++ b/tools/datapack/build-source-candidate-sample-evidence.mjs
@@ -1,0 +1,137 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const args = { candidates: "tools/datapack/source-candidates.json" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag.startsWith("--")) {
+      throw new Error(`unexpected argument: ${flag}`);
+    }
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${flag} requires a value`);
+    }
+    args[flag.slice(2)] = value;
+    index += 1;
+  }
+  if (!args.candidate) {
+    throw new Error("--candidate is required");
+  }
+  if (!args.response) {
+    throw new Error("--response is required");
+  }
+  return args;
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+function assertNoServiceKey(value) {
+  if (/serviceKey=(?!\[서비스키값\])[^&\s<"]+/i.test(value)) {
+    throw new Error("raw sample response must not contain serviceKey credentials");
+  }
+}
+
+function scalarFieldCount(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return 0;
+  }
+  return Object.values(value).filter((item) => item == null || typeof item !== "object").length;
+}
+
+function bestJsonRow(value, best = { row: null, count: 0 }) {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      bestJsonRow(item, best);
+    }
+    return best;
+  }
+  if (!value || typeof value !== "object") {
+    return best;
+  }
+
+  const count = scalarFieldCount(value);
+  if (count > best.count) {
+    best.row = value;
+    best.count = count;
+  }
+  for (const item of Object.values(value)) {
+    bestJsonRow(item, best);
+  }
+  return best;
+}
+
+function fieldsFromJson(raw) {
+  const parsed = JSON.parse(raw);
+  const { row } = bestJsonRow(parsed);
+  if (!row) {
+    throw new Error("JSON response has no object fields");
+  }
+  return Object.keys(row)
+    .filter((key) => row[key] == null || typeof row[key] !== "object")
+    .sort();
+}
+
+function fieldsFromXml(raw) {
+  const item = raw.match(/<item\b[^>]*>([\s\S]*?)<\/item>/i)?.[1] ?? raw;
+  const fields = new Set();
+  const tagPattern = /<([A-Za-z_][\w.-]*)\b[^>]*>([\s\S]*?)<\/\1>/g;
+  for (const match of item.matchAll(tagPattern)) {
+    const [, tagName, body] = match;
+    if (!/<[A-Za-z_][\w.-]*\b/.test(body)) {
+      fields.add(tagName);
+    }
+  }
+  if (fields.size === 0) {
+    throw new Error("XML response has no leaf fields");
+  }
+  return [...fields].sort();
+}
+
+function detectFormat(raw, explicitFormat) {
+  if (explicitFormat) {
+    return explicitFormat.toLowerCase();
+  }
+  const trimmed = raw.trimStart();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    return "json";
+  }
+  if (trimmed.startsWith("<")) {
+    return "xml";
+  }
+  throw new Error("response format must be json or xml");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const candidates = await readJson(path.resolve(args.candidates));
+  const candidate = candidates.candidates.find(({ id }) => id === args.candidate);
+  if (!candidate) {
+    throw new Error(`unknown source candidate: ${args.candidate}`);
+  }
+
+  const raw = await readFile(path.resolve(args.response), "utf8");
+  assertNoServiceKey(raw);
+  const format = detectFormat(raw, args.format);
+  const fields = format === "json" ? fieldsFromJson(raw) : fieldsFromXml(raw);
+
+  console.log(
+    JSON.stringify(
+      {
+        candidateId: args.candidate,
+        endpoint: candidate.evidence.endpoint,
+        format,
+        fields,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -3352,17 +3352,14 @@ test("source candidate sample evidence builder는 raw JSON response를 validator
     `${JSON.stringify({
       response: {
         body: {
+          pageNo: 1,
+          numOfRows: 10,
+          totalCount: 1,
           items: {
             item: [
               {
-                lnCd: "A1",
-                mreaWideCd: "01",
                 railOprIsttCd: "S1",
-                routCd: "A1",
-                routNm: "1호선",
-                stinCd: "100",
-                stinConsOrdr: "1",
-                stinNm: "테스트역",
+                railOprIsttNm: "서울교통공사",
               },
             ],
           },
@@ -3376,7 +3373,7 @@ test("source candidate sample evidence builder는 raw JSON response를 validator
     [
       "tools/datapack/build-source-candidate-sample-evidence.mjs",
       "--candidate",
-      "kric-subway-route-info",
+      "kric-train-operation-organ",
       "--response",
       responsePath,
     ],
@@ -3389,7 +3386,7 @@ test("source candidate sample evidence builder는 raw JSON response를 validator
     [
       "tools/datapack/validate-source-candidate-sample.mjs",
       "--candidate",
-      "kric-subway-route-info",
+      "kric-train-operation-organ",
       "--sample",
       evidencePath,
     ],
@@ -3444,7 +3441,7 @@ test("source candidate sample evidence builder는 raw response의 serviceKey cre
   await mkdir(outputDir, { recursive: true });
   await writeFile(
     responsePath,
-    `<response><echo>https://openapi.kric.go.kr/openapi/convenientInfo/trainOperationOrgan?serviceKey=actual-secret</echo></response>\n`,
+    `${JSON.stringify({ response: { body: { serviceKey: "actual-secret" } } })}\n`,
   );
 
   await assert.rejects(

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -3404,6 +3404,8 @@ test("source candidate sample evidence builder는 raw XML response를 validator 
     responsePath,
     `<response><body><items><item>
       <railOprIsttCd>S1</railOprIsttCd>
+    </item><item>
+      <railOprIsttCd>S2</railOprIsttCd>
       <railOprIsttNm>서울교통공사</railOprIsttNm>
     </item></items></body></response>\n`,
   );

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -3359,6 +3359,8 @@ test("source candidate sample evidence builder는 raw JSON response를 validator
             item: [
               {
                 railOprIsttCd: "S1",
+              },
+              {
                 railOprIsttNm: "서울교통공사",
               },
             ],
@@ -3406,7 +3408,7 @@ test("source candidate sample evidence builder는 raw XML response를 validator 
       <railOprIsttCd>S1</railOprIsttCd>
     </item><item>
       <railOprIsttCd>S2</railOprIsttCd>
-      <railOprIsttNm>서울교통공사</railOprIsttNm>
+      <railOprIsttNm/>
     </item></items></body></response>\n`,
   );
 

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -3341,6 +3341,128 @@ test("source candidate sample 검증기는 serviceKey credential 포함을 거�
   );
 });
 
+test("source candidate sample evidence builder는 raw JSON response를 validator 입력으로 변환한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-json-evidence-${Date.now()}`);
+  const responsePath = path.join(outputDir, "response.json");
+  const evidencePath = path.join(outputDir, "evidence.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    responsePath,
+    `${JSON.stringify({
+      response: {
+        body: {
+          items: {
+            item: [
+              {
+                lnCd: "A1",
+                mreaWideCd: "01",
+                railOprIsttCd: "S1",
+                routCd: "A1",
+                routNm: "1호선",
+                stinCd: "100",
+                stinConsOrdr: "1",
+                stinNm: "테스트역",
+              },
+            ],
+          },
+        },
+      },
+    })}\n`,
+  );
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-source-candidate-sample-evidence.mjs",
+      "--candidate",
+      "kric-subway-route-info",
+      "--response",
+      responsePath,
+    ],
+    { cwd: root },
+  );
+  await writeFile(evidencePath, stdout);
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/validate-source-candidate-sample.mjs",
+      "--candidate",
+      "kric-subway-route-info",
+      "--sample",
+      evidencePath,
+    ],
+    { cwd: root },
+  );
+});
+
+test("source candidate sample evidence builder는 raw XML response를 validator 입력으로 변환한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-xml-evidence-${Date.now()}`);
+  const responsePath = path.join(outputDir, "response.xml");
+  const evidencePath = path.join(outputDir, "evidence.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    responsePath,
+    `<response><body><items><item>
+      <railOprIsttCd>S1</railOprIsttCd>
+      <railOprIsttNm>서울교통공사</railOprIsttNm>
+    </item></items></body></response>\n`,
+  );
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-source-candidate-sample-evidence.mjs",
+      "--candidate",
+      "kric-train-operation-organ",
+      "--response",
+      responsePath,
+    ],
+    { cwd: root },
+  );
+  await writeFile(evidencePath, stdout);
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/validate-source-candidate-sample.mjs",
+      "--candidate",
+      "kric-train-operation-organ",
+      "--sample",
+      evidencePath,
+    ],
+    { cwd: root },
+  );
+});
+
+test("source candidate sample evidence builder는 raw response의 serviceKey credential을 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-raw-secret-${Date.now()}`);
+  const responsePath = path.join(outputDir, "response.xml");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    responsePath,
+    `<response><echo>https://openapi.kric.go.kr/openapi/convenientInfo/trainOperationOrgan?serviceKey=actual-secret</echo></response>\n`,
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/build-source-candidate-sample-evidence.mjs",
+        "--candidate",
+        "kric-train-operation-organ",
+        "--response",
+        responsePath,
+      ],
+      { cwd: root },
+    ),
+    /raw sample response must not contain serviceKey credentials/,
+  );
+});
+
 test("전국 coverage gap report는 현재 source inventory의 누락 coverage를 실패로 노출한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-coverage-gap-fail-${Date.now()}`);
   const reportPath = path.join(outputDir, "coverage-gap-report.json");


### PR DESCRIPTION
## 관련 이슈

close #725

## 작업 배경

KRIC live sample 검증은 서비스키가 필요하지만 현재 로컬 환경에는 KRIC 키가 없다. 키가 들어온 뒤 raw API 응답에서 fields 목록을 손으로 옮기면 누락과 credential 유출 위험이 남으므로, raw response 파일을 로컬에서 sanitized sample evidence JSON으로 바꾸는 최소 도구를 추가한다.

## 작업 내용

- `tools/datapack/build-source-candidate-sample-evidence.mjs`를 추가해 candidate id와 raw response 파일에서 validator 입력 JSON을 생성한다.
- JSON 응답은 `item` row가 있으면 wrapper metadata보다 item row를 우선하고, sparse row에 나뉜 scalar field를 합집합으로 수집한다.
- XML 응답은 모든 `<item>` row의 leaf tag와 self-closing leaf tag를 합집합으로 추출한다.
- raw response 안에 실제 `serviceKey` query string, JSON field, XML tag가 포함되면 evidence 출력 전에 실패시킨다.
- 생성된 evidence를 기존 `validate-source-candidate-sample.mjs`로 검증하는 JSON/XML/credential guard 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/datapack-tools.test.mjs`: 82 tests passed
  - `node --test tools/ci/*.test.mjs`: 101 tests passed
  - `node --check tools/datapack/build-source-candidate-sample-evidence.mjs`: exit 0
  - `git diff --check`: exit 0
  - PR #726 CI: Android CI, Mobile App CI, Backend CI, Repository CI, Dependency Vulnerability Scan, Release Artifacts checks passed
  - CodeRabbit: PR check success
  - Codex CLI fallback review: 최종 `Actionable comments posted: 0`

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| KRIC sample evidence 변환 | local Node.js | raw JSON/XML fixture를 evidence JSON으로 변환한 뒤 validator 실행 | `node --test tools/datapack/datapack-tools.test.mjs` 출력 | JSON/XML sparse row, self-closing tag, credential guard 포함 82 tests passed |
| 저장소 계약 | local Node.js | CI contract 테스트 실행 | `node --test tools/ci/*.test.mjs` 출력 | 101 tests passed |
| 문법 및 whitespace | local shell | Node syntax check와 diff whitespace 검사 | `node --check tools/datapack/build-source-candidate-sample-evidence.mjs`, `git diff --check` 출력 | 둘 다 exit 0 |
| PR CI | GitHub Actions | `gh pr checks 726 --watch=false` | Android CI, Mobile App CI, Backend CI, Repository CI, Dependency Vulnerability Scan, Release Artifacts workflow links | 모든 check passed |
| Review gate | GitHub PR | CodeRabbit check와 Codex CLI fallback review 확인 | CodeRabbit check success, Codex fallback final review `Actionable comments posted: 0`, unresolved review threads 0 | merge gate clean |
| UI 증거 | 해당 없음 | CLI와 테스트 도구 변경이며 사용자 화면 변경 없음 | 증거 불필요 사유: UI, 접근성, 권한 문구, 릴리즈 산출물 변경이 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 이 PR은 live fetch를 추가하지 않는다. 서비스키가 필요한 호출은 로컬 curl로 충분하고, 이 도구는 저장소에 남길 수 없는 raw response를 sanitized evidence JSON으로 바꾸는 역할만 한다.

## 리스크

- XML 파서는 KRIC 샘플의 item/leaf field 구조만 대상으로 한다. 복잡한 XML schema 범용 파싱은 의도적으로 제외했다.
- 실제 KRIC 서비스키가 없어 live response evidence 생성은 후속 작업에서 수행한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
