### PR TITLE
[Fix] generated connector edge 비율 분리

### DIFF
--- a/apps/mobile/lib/features/routes/application/network_graph.dart
+++ b/apps/mobile/lib/features/routes/application/network_graph.dart
@@ -31,6 +31,7 @@ class RouteEdge {
     RouteStairAccessState? stairAccessState,
     this.reliabilityScore = 100,
     this.isDataStale = false,
+    this.isGeneratedConnector = false,
     RouteAccessibilityState accessibilityState =
         RouteAccessibilityState.available,
     bool? isAvailable,
@@ -76,6 +77,7 @@ class RouteEdge {
   /// by the repository before it reaches the route engine.
   final int reliabilityScore;
   final bool isDataStale;
+  final bool isGeneratedConnector;
   final RouteAccessibilityState accessibilityState;
 
   bool get isAvailable =>
@@ -94,6 +96,21 @@ class NetworkGraph {
 
   Iterable<RouteEdge> edgesFrom(String nodeId) {
     return _edgesByFromNodeId[nodeId] ?? const [];
+  }
+
+  /// route contract: generated connector ratio
+  ///
+  /// Generated entry, exit, and transfer connector edges are source gaps, not
+  /// verified step-free coverage. Report their share separately from
+  /// accessibility availability metrics.
+  double get generatedConnectorEdgeRatio {
+    if (edges.isEmpty) {
+      return 0;
+    }
+    final generatedCount = edges
+        .where((edge) => edge.isGeneratedConnector)
+        .length;
+    return generatedCount / edges.length;
   }
 }
 

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -549,6 +549,7 @@ class _RouteCatalogSnapshot {
               type: graph.RouteEdgeType.entry,
               baseCost: 90,
               stairAccessState: graph.RouteStairAccessState.unknown,
+              isGeneratedConnector: true,
             ),
           );
         }
@@ -563,6 +564,7 @@ class _RouteCatalogSnapshot {
               type: graph.RouteEdgeType.exit,
               baseCost: 60,
               stairAccessState: graph.RouteStairAccessState.unknown,
+              isGeneratedConnector: true,
             ),
           );
         }
@@ -602,6 +604,7 @@ class _RouteCatalogSnapshot {
               baseCost: 140,
               transferStationId: stationId,
               stairAccessState: graph.RouteStairAccessState.unknown,
+              isGeneratedConnector: true,
             ),
           );
         }

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -242,6 +242,44 @@ void main() {
       expect(result.status, RouteStatus.found);
       expect(result.edgeIds.length, 9999);
     });
+
+    test('generated connector edge 비율을 일반 접근성 edge와 별도로 계산한다', () {
+      final graph = NetworkGraph(
+        nodes: const [
+          RouteNode(
+            id: 'station-a:line-1',
+            stationId: 'station-a',
+            lineId: 'line-1',
+          ),
+          RouteNode(
+            id: 'station-b:line-1',
+            stationId: 'station-b',
+            lineId: 'line-1',
+          ),
+        ],
+        edges: const [
+          RouteEdge(
+            id: 'entry-a-generated',
+            fromNodeId: 'station-a',
+            toNodeId: 'station-a:line-1',
+            type: RouteEdgeType.entry,
+            baseCost: 90,
+            stairAccessState: RouteStairAccessState.unknown,
+            isGeneratedConnector: true,
+          ),
+          RouteEdge(
+            id: 'ride-a-b',
+            fromNodeId: 'station-a:line-1',
+            toNodeId: 'station-b:line-1',
+            type: RouteEdgeType.ride,
+            baseCost: 180,
+            lineId: 'line-1',
+          ),
+        ],
+      );
+
+      expect(graph.generatedConnectorEdgeRatio, 0.5);
+    });
   });
 }
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -965,9 +965,11 @@ test("경로 source contract 불변식은 접근성 안전과 metric fallback �
 
   assert.match(networkGraph, /route contract: baseCost seconds/);
   assert.match(networkGraph, /route contract: reliability thresholds/);
+  assert.match(networkGraph, /route contract: generated connector ratio/);
   assert.match(accessibilityCostCalculator, /route contract: unknown accessibility data/);
   assert.match(accessibilityCostCalculator, /route contract: stair-only block/);
   assert.match(localRouteRepository, /route contract: synthetic connector edge/);
+  assert.match(localRouteRepository, /isGeneratedConnector: true/);
   assert.match(localRouteRepository, /route contract: local metric fallback/);
   assert.match(routeSearch, /route contract: realtime ETA fallback/);
 });


### PR DESCRIPTION
## 관련 이슈

close #727

## 작업 배경

generated entry, exit, transfer connector edge는 실제 검증된 무장애 동선이 아니라 source gap을 메우는 연결 edge입니다. 이 값이 일반 접근성 edge와 섞이면 verified step-free coverage처럼 보일 수 있어 graph 수준에서 별도 비율로 확인할 수 있게 분리합니다.

## 작업 내용

- `RouteEdge`에 `isGeneratedConnector` 플래그를 추가했습니다.
- `NetworkGraph.generatedConnectorEdgeRatio`로 전체 edge 대비 generated connector edge 비율을 계산합니다.
- `LocalRouteRepository`가 explicit source edge 없이 생성하는 entry, exit, transfer fallback edge에만 `isGeneratedConnector: true`를 붙였습니다.
- repository contract 테스트에 generated connector ratio와 fallback marker 불변식을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/features/routes/route_engine_test.dart`: 12 tests passed
  - `flutter test test/features/routes/local_route_repository_test.dart`: 42 tests passed
  - `flutter analyze`: No issues found
  - `node --test tools/ci/repository-contract.test.mjs`: 101 pass, 0 fail
  - `git diff --check`: passed
  - PR CI: https://github.com/AquilaXk/easysubway/actions/runs/27989103101 passed
  - Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/27989102805 passed
  - Codex fallback review: https://github.com/AquilaXk/easysubway/pull/728#pullrequestreview-4548664768 actionable 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| generated connector ratio | Flutter test | `route_engine_test.dart`에서 generated edge 1개와 일반 edge 1개의 비율 확인 | `flutter test test/features/routes/route_engine_test.dart` | 12 tests passed |
| fallback edge marker 회귀 | Flutter test | local route catalog fallback/explicit edge 경로 회귀 확인 | `flutter test test/features/routes/local_route_repository_test.dart` | 42 tests passed |
| route source contract | Repository CI contract | generated connector ratio와 fallback marker 문자열 계약 확인 | `node --test tools/ci/repository-contract.test.mjs` | 101 pass, 0 fail |
| 정적 분석 | Android/iOS 공통 Flutter 코드 | analyzer 실행 | `flutter analyze` | No issues found |
| PR gate | GitHub Actions | required CI와 Release Artifacts 결과 확인 | CI run 27989103101, Release Artifacts run 27989102805 | passed |
| 리뷰 fallback | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review 게시 | PR review 4548664768 | actionable 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `LocalRouteRepository`에서 explicit source edge가 없는 fallback connector에만 `isGeneratedConnector: true`가 붙는지 확인하면 됩니다.

## 리스크

- 새 getter는 현재 graph 내부 metric용으로만 추가되어 사용자 화면 동작 변화는 없습니다.
- ratio는 전체 edge 대비 generated connector edge 개수 기준입니다. 이후 source coverage 리포트가 들어오면 이 getter를 사용해 verified coverage와 분리 표시할 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
