### PR TITLE
[Fix] strict profile generated connector 차단

### DIFF
--- a/apps/mobile/lib/features/routes/application/accessibility_cost_calculator.dart
+++ b/apps/mobile/lib/features/routes/application/accessibility_cost_calculator.dart
@@ -21,6 +21,17 @@ class AccessibilityCostCalculator {
     final weight = RouteWeight.from(mobilityType);
     final warningCodes = <String>[];
 
+    // route contract: generated connector strict block
+    // Generated connectors are topology scaffolding, not verified step-free
+    // accessibility evidence for profiles that cannot safely use stairs.
+    if (edge.isGeneratedConnector && mobilityType.blocksStairOnlyAccess) {
+      return const AccessibilityCost(
+        cost: 0,
+        isBlocked: true,
+        warningCodes: ['GENERATED_CONNECTOR_UNVERIFIED'],
+      );
+    }
+
     if (edge.accessibilityState == RouteAccessibilityState.unavailable) {
       return const AccessibilityCost(
         cost: 0,

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -196,6 +196,7 @@ class LocalRouteRepository implements RouteSearchRepository {
     return switch (code) {
       'STAIR_ONLY_ACCESS' => '계단 없는 경로를 찾지 못했습니다.',
       'STAIR_ONLY_ACCESS_UNKNOWN' => '계단 없는 동선 여부를 확인할 수 없습니다.',
+      'GENERATED_CONNECTOR_UNVERIFIED' => '계단 없는 동선 여부를 확인할 수 없습니다.',
       'FACILITY_UNAVAILABLE' => '필수 접근성 시설을 사용할 수 없습니다.',
       'ACCESSIBILITY_STATE_UNKNOWN' => '접근성 시설 이용 가능 여부를 확인할 수 없습니다.',
       _ => '안내 가능한 경로를 찾지 못했습니다.',

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -280,6 +280,63 @@ void main() {
 
       expect(graph.generatedConnectorEdgeRatio, 0.5);
     });
+
+    test('휠체어 경로는 generated connector edge가 stepFree여도 FOUND가 되지 않는다', () {
+      final engine = LocalRouteEngine(
+        graph: NetworkGraph(
+          nodes: const [
+            RouteNode(
+              id: 'station-a:line-1',
+              stationId: 'station-a',
+              lineId: 'line-1',
+            ),
+            RouteNode(
+              id: 'station-b:line-1',
+              stationId: 'station-b',
+              lineId: 'line-1',
+            ),
+          ],
+          edges: const [
+            RouteEdge(
+              id: 'entry-a-generated',
+              fromNodeId: 'station-a',
+              toNodeId: 'station-a:line-1',
+              type: RouteEdgeType.entry,
+              baseCost: 90,
+              stairAccessState: RouteStairAccessState.stepFree,
+              isGeneratedConnector: true,
+            ),
+            RouteEdge(
+              id: 'ride-a-b',
+              fromNodeId: 'station-a:line-1',
+              toNodeId: 'station-b:line-1',
+              type: RouteEdgeType.ride,
+              baseCost: 180,
+              lineId: 'line-1',
+            ),
+            RouteEdge(
+              id: 'exit-b-step-free',
+              fromNodeId: 'station-b:line-1',
+              toNodeId: 'station-b',
+              type: RouteEdgeType.exit,
+              baseCost: 60,
+              stairAccessState: RouteStairAccessState.stepFree,
+            ),
+          ],
+        ),
+      );
+
+      final result = engine.search(
+        const RouteRequest(
+          originStationId: 'station-a',
+          destinationStationId: 'station-b',
+          mobilityType: MobilityType.wheelchair,
+        ),
+      );
+
+      expect(result.status, RouteStatus.blocked);
+      expect(result.blockedReasonCodes, ['GENERATED_CONNECTOR_UNVERIFIED']);
+    });
   });
 }
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -968,6 +968,7 @@ test("경로 source contract 불변식은 접근성 안전과 metric fallback �
   assert.match(networkGraph, /route contract: generated connector ratio/);
   assert.match(accessibilityCostCalculator, /route contract: unknown accessibility data/);
   assert.match(accessibilityCostCalculator, /route contract: stair-only block/);
+  assert.match(accessibilityCostCalculator, /route contract: generated connector strict block/);
   assert.match(localRouteRepository, /route contract: synthetic connector edge/);
   assert.match(localRouteRepository, /isGeneratedConnector: true/);
   assert.match(localRouteRepository, /route contract: local metric fallback/);


### PR DESCRIPTION
## 관련 이슈

close #729

## 작업 배경

generated connector edge는 역/노선 topology 연결용 scaffolding이며 검증된 step-free 접근성 근거가 아닙니다. 데이터가 잘못 들어와 generated connector가 `STEP_FREE`처럼 표시되더라도 wheelchair profile에서 `FOUND` 경로가 나오지 않도록 route engine 단계의 마지막 안전장치를 추가합니다.

## 작업 내용

- `AccessibilityCostCalculator`가 wheelchair profile에서 generated connector edge를 `GENERATED_CONNECTOR_UNVERIFIED`로 차단하게 했습니다.
- `LocalRouteRepository`는 새 내부 차단 코드를 기존 “계단 없는 동선 여부 확인 불가” 사용자 문구로 매핑합니다.
- route engine 테스트에 generated connector가 `stepFree`여도 wheelchair 경로는 `BLOCKED`가 되는 회귀 케이스를 추가했습니다.
- repository contract에 generated connector strict block 주석 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/features/routes/route_engine_test.dart`: 13 tests passed
  - `flutter test test/features/routes/local_route_repository_test.dart`: 42 tests passed
  - `flutter test test/route_search_test.dart`: 11 tests passed
  - `flutter analyze`: No issues found
  - `node --test tools/ci/repository-contract.test.mjs`: 101 pass, 0 fail
  - `git diff --check`: passed
  - PR CI: https://github.com/AquilaXk/easysubway/actions/runs/27989702036 passed
  - Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/27989701776 passed
  - Codex fallback review: https://github.com/AquilaXk/easysubway/pull/730#pullrequestreview-4548733532 actionable 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| strict generated connector 차단 | Flutter test | generated connector가 `stepFree`여도 wheelchair 결과가 `BLOCKED`인지 확인 | `flutter test test/features/routes/route_engine_test.dart` | 13 tests passed |
| 로컬 경로 사용자 문구 회귀 | Flutter test | 기존 생성 access/transfer 차단 문구 유지 확인 | `flutter test test/features/routes/local_route_repository_test.dart` | 42 tests passed |
| route search 회귀 | Flutter test | route search controller/repository 계약 확인 | `flutter test test/route_search_test.dart` | 11 tests passed |
| 정적 분석 | Flutter analyzer | analyzer 실행 | `flutter analyze` | No issues found |
| repository contract | Node test | route safety contract marker 확인 | `node --test tools/ci/repository-contract.test.mjs` | 101 pass, 0 fail |
| PR gate | GitHub Actions | required CI와 Release Artifacts 결과 확인 | CI run 27989702036, Release Artifacts run 27989701776 | passed |
| 리뷰 fallback | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review 게시 | PR review 4548733532 | actionable 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `AccessibilityCostCalculator.costFor`의 generated connector block이 wheelchair profile에만 적용되는지 확인하면 됩니다.

## 리스크

- generated connector를 `STEP_FREE`로 잘못 넣은 데이터가 있었다면 wheelchair 경로가 더 보수적으로 차단됩니다. 이는 의도한 안전 동작입니다.
- UI 텍스트는 기존 “계단 없는 동선 여부 확인 불가” 문구를 재사용해 사용자-visible 문구 변화는 없습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
