### PR TITLE
[Feat] 홈 이동 조건 상태 반영

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -412,6 +412,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         supportAccessLauncher: widget.supportAccessLauncher,
         userDataDeletionRepository: widget.userDataDeletionRepository,
         onUserDataDeleted: _handleUserDataDeleted,
+        onMobilityProfileChanged: _saveMobilityProfile,
       ),
     );
   }
@@ -484,6 +485,24 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         context: '온보딩 설정을 저장하는 중 예외가 발생했습니다.',
       );
     }
+  }
+
+  Future<void> _saveMobilityProfile(MobilityProfileOption profile) async {
+    final currentResult = _onboardingState.result;
+    if (currentResult == null) {
+      return;
+    }
+    final nextResult = OnboardingResult(
+      profile: profile,
+      preferences: currentResult.preferences,
+    );
+    await _saveOnboardingResult(nextResult);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _onboardingState = OnboardingState.completed(result: nextResult);
+    });
   }
 
   void _schedulePendingFacilityReportPhotoRecovery() {
@@ -720,7 +739,7 @@ TextStyle _boldTextStyle(TextStyle? style) {
   );
 }
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   HomeScreen({
     required this.repository,
     required this.reportRepository,
@@ -738,6 +757,7 @@ class HomeScreen extends StatelessWidget {
     required this.supportAccessLauncher,
     required this.userDataDeletionRepository,
     required this.onUserDataDeleted,
+    required this.onMobilityProfileChanged,
     this.simpleViewEnabled = true,
     this.facilityReportDraftTargetStore,
     String? initialMobilityType,
@@ -761,19 +781,58 @@ class HomeScreen extends StatelessWidget {
   final SupportAccessLauncher supportAccessLauncher;
   final UserDataDeletionRepository? userDataDeletionRepository;
   final Future<void> Function()? onUserDataDeleted;
+  final Future<void> Function(MobilityProfileOption profile)?
+  onMobilityProfileChanged;
   final String initialMobilityType;
   final bool simpleViewEnabled;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
 
   @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  late String _mobilityType;
+
+  @override
+  void initState() {
+    super.initState();
+    _mobilityType = widget.initialMobilityType;
+  }
+
+  @override
+  void didUpdateWidget(HomeScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_mobilityType == oldWidget.initialMobilityType &&
+        widget.initialMobilityType != oldWidget.initialMobilityType) {
+      _mobilityType = widget.initialMobilityType;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-    final favoriteRepository = this.favoriteRepository;
-    final favoriteFacilityRepository = this.favoriteFacilityRepository;
-    final favoriteRouteRepository = this.favoriteRouteRepository;
-    final routeFeedbackRepository = this.routeFeedbackRepository;
-    final notificationRepository = this.notificationRepository;
-    final notificationPermissionProvider = this.notificationPermissionProvider;
+    final repository = widget.repository;
+    final reportRepository = widget.reportRepository;
+    final routeRepository = widget.routeRepository;
+    final favoriteRepository = widget.favoriteRepository;
+    final favoriteFacilityRepository = widget.favoriteFacilityRepository;
+    final favoriteRouteRepository = widget.favoriteRouteRepository;
+    final searchHistoryRepository = widget.searchHistoryRepository;
+    final internalRouteRepository = widget.internalRouteRepository;
+    final routeFeedbackRepository = widget.routeFeedbackRepository;
+    final notificationRepository = widget.notificationRepository;
+    final notificationPermissionProvider =
+        widget.notificationPermissionProvider;
+    final locationProvider = widget.locationProvider;
+    final supportAccessInfo = widget.supportAccessInfo;
+    final supportAccessLauncher = widget.supportAccessLauncher;
+    final userDataDeletionRepository = widget.userDataDeletionRepository;
+    final onUserDataDeleted = widget.onUserDataDeleted;
+    final simpleViewEnabled = widget.simpleViewEnabled;
+    final facilityReportDraftTargetStore =
+        widget.facilityReportDraftTargetStore;
+    final initialMobilityType = _mobilityType;
     final hasFavorites =
         favoriteRepository != null ||
         favoriteFacilityRepository != null ||
@@ -885,13 +944,7 @@ class HomeScreen extends StatelessWidget {
               children: [
                 _HomeSecondaryActionButton(
                   key: const Key('mobilityProfileButton'),
-                  onPressed: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute<MobilityProfileOption>(
-                        builder: (_) => const MobilityProfileScreen(),
-                      ),
-                    );
-                  },
+                  onPressed: _openMobilityProfile,
                   icon: const Icon(Icons.accessibility_new),
                   label: '이동 조건',
                 ),
@@ -963,6 +1016,31 @@ class HomeScreen extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+
+  Future<void> _openMobilityProfile() async {
+    final currentProfile = mobilityProfileOptions.firstWhere(
+      (option) => option.mobilityType == _mobilityType,
+      orElse: () => mobilityProfileOptions.first,
+    );
+    final selectedProfile = await Navigator.of(context).push(
+      MaterialPageRoute<MobilityProfileOption>(
+        builder: (_) => MobilityProfileScreen(initialSelection: currentProfile),
+      ),
+    );
+    if (!mounted || selectedProfile == null) {
+      return;
+    }
+    setState(() {
+      _mobilityType = selectedProfile.mobilityType;
+    });
+    await widget.onMobilityProfileChanged?.call(selectedProfile);
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('${selectedProfile.title} 조건으로 변경했습니다')),
     );
   }
 }

--- a/apps/mobile/lib/mobility_profile.dart
+++ b/apps/mobile/lib/mobility_profile.dart
@@ -108,7 +108,9 @@ const mobilityProfileOptions = <MobilityProfileOption>[
 ];
 
 class MobilityProfileScreen extends StatefulWidget {
-  const MobilityProfileScreen({super.key});
+  const MobilityProfileScreen({this.initialSelection, super.key});
+
+  final MobilityProfileOption? initialSelection;
 
   @override
   State<MobilityProfileScreen> createState() => _MobilityProfileScreenState();
@@ -116,6 +118,12 @@ class MobilityProfileScreen extends StatefulWidget {
 
 class _MobilityProfileScreenState extends State<MobilityProfileScreen> {
   MobilityProfileOption? _selectedOption;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedOption = widget.initialSelection;
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2842,6 +2842,113 @@ void main() {
     }
   });
 
+  testWidgets('홈 이동 조건 화면은 저장된 profile을 선택 상태로 연다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          initialOnboardingState: _completedOnboardingState(
+            profileId: 'wheelchair',
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('mobilityProfileButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel('휠체어 선택됨, 계단 없는 길만 안내해요'), findsOneWidget);
+      expect(find.text('휠체어 조건을 선택했습니다'), findsOneWidget);
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
+  testWidgets('홈에서 바꾼 이동 조건은 재시작 뒤 다음 경로 요청에 반영된다', (tester) async {
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '사당': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
+    final routeRepository = FakeRouteSearchRepository();
+    final onboardingStore = MemoryOnboardingResultStore(
+      initialResult: _completedOnboardingState().result,
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: routeRepository,
+        favoriteRepository: FakeFavoriteStationRepository(),
+        onboardingStore: onboardingStore,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('mobilityProfileButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('mobilityProfileCard-wheelchair')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('mobilityProfileDoneButton')));
+    await tester.pumpAndSettle();
+
+    expect(onboardingStore.savedResult?.profile.mobilityType, 'WHEELCHAIR');
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: routeRepository,
+        favoriteRepository: FakeFavoriteStationRepository(),
+        onboardingStore: onboardingStore,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('routeSearchButton')));
+    await tester.pumpAndSettle();
+    expect(find.text('휠체어'), findsOneWidget);
+
+    await tester.enterText(
+      find.byKey(const Key('routeOriginStationInput')),
+      '상록수',
+    );
+    await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const Key('routeDestinationStationInput')),
+      '사당',
+    );
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationSearchButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationOption-station-sadang')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(ListView), const Offset(0, -360));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(routeRepository.requests.single.mobilityType, 'WHEELCHAIR');
+  });
+
   testWidgets('경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final stationRepository = FakeStationSearchRepository(


### PR DESCRIPTION
## 관련 이슈

close #731

## 작업 배경

홈의 이동 조건 버튼이 선택 화면만 열고 선택 결과를 저장하지 않아, 사용자가 휠체어·고령자 같은 조건을 바꿔도 이후 길찾기 요청은 온보딩 당시 mobilityType을 계속 사용했습니다.

## 작업 내용

- `MobilityProfileScreen`이 현재 profile을 초기 선택 상태로 표시하도록 했습니다.
- `HomeScreen`이 이동 조건 선택 결과를 기다린 뒤 현재 세션 상태를 갱신합니다.
- 변경된 profile을 기존 `OnboardingResultStore`에 다시 저장해 앱 재시작 후에도 같은 이동 조건을 복원합니다.
- 홈에서 길찾기를 열 때 변경된 mobilityType이 route search 초기값과 요청 payload에 전달되도록 했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --name "홈 이동 조건"`: RED 확인, `휠체어 선택됨` semantics를 찾지 못해 실패
  - `cd apps/mobile && flutter test test/widget_test.dart --name "이동 조건"`: 7 tests passed
  - `cd apps/mobile && flutter test test/mobility_profile_test.dart`: 1 test passed
  - `cd apps/mobile && flutter analyze`: No issues found
  - `cd apps/mobile && flutter test test/widget_test.dart`: 85 tests passed
  - `cd apps/mobile && flutter build apk --debug`: built `build/app/outputs/flutter-apk/app-debug.apk`
  - `git diff --check`: passed
  - PR CI: Android CI, Mobile App CI, Repository CI, Backend CI, Dependency Vulnerability Scan pass
  - PR Release Artifacts: Android Release Artifact pass, Backend Release Image skipped by changes filter

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 저장된 profile 초기 선택 | Android emulator API 36 | 온보딩에서 휠체어 선택 후 홈 > 이동 조건 진입, UI tree 확인 | `.codex/evidence/731/android-mobility-selected-ui-summary.txt` | `휠체어 선택됨` 및 selected flag 확인 |
| profile 변경 후 길찾기 반영 | Android emulator API 36 | 이동 조건을 고령자로 변경 후 길찾기 진입, UI tree 확인 | `.codex/evidence/731/android-route-after-profile-change-ui-summary.txt` | `이동 조건 바꾸기, 현재 고령자` 확인 |
| 재시작 후 route request 반영 | Flutter widget test | `홈에서 바꾼 이동 조건은 재시작 뒤 다음 경로 요청에 반영된다` | `flutter test test/widget_test.dart --name "이동 조건"` | 저장 profile 복원 후 `WHEELCHAIR` request 확인 |
| iOS 대체 검증 | iOS | 이번 PR은 Android 우선 배포 흐름의 Flutter 공통 widget 상태 변경이며 iOS simulator 수동 확인은 수행하지 않음 | `flutter test test/widget_test.dart` | 공통 widget 계층에서 상태/semantics/route request 검증, iOS 수동 QA는 iOS 출시 재개 시 필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 새 설정 repository를 만들지 않고 기존 온보딩 저장소에 profile만 갱신한 점입니다. 현재 요구는 mobility profile 상태 반영이므로 별도 AppSettings 계층은 다음 설정 확장 시 추가하는 쪽이 작습니다.

## 리스크

- 홈 버튼 자체에는 현재 profile명이 표시되지 않습니다. 이번 PR은 선택 상태 저장과 route request 반영만 처리하고, 홈 trip control panel 개편은 별도 UI slice로 남깁니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
