### PR TITLE
[Style] 홈 접근성 버튼 토큰 정리

### DIFF
--- a/apps/mobile/lib/accessible_design.dart
+++ b/apps/mobile/lib/accessible_design.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+class EasySubwayAccessibleColors {
+  const EasySubwayAccessibleColors._();
+
+  static const primary = Color(0xFF006D77);
+  static const text = Color(0xFF102A2C);
+  static const mutedText = Color(0xFF466467);
+  static const surface = Colors.white;
+}
+
+class EasySubwayTouchTarget {
+  const EasySubwayTouchTarget._();
+
+  static const iconOnly = 48.0;
+  static const general = 56.0;
+  static const primary = 60.0;
+}
+
+class AccessibleShortcutButton extends StatelessWidget {
+  const AccessibleShortcutButton({
+    required this.onPressed,
+    required this.icon,
+    required this.label,
+    super.key,
+  });
+
+  final VoidCallback onPressed;
+  final Widget icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return OutlinedButton.icon(
+      onPressed: onPressed,
+      style: OutlinedButton.styleFrom(
+        alignment: Alignment.center,
+        backgroundColor: EasySubwayAccessibleColors.surface,
+        foregroundColor: EasySubwayAccessibleColors.primary,
+        minimumSize: const Size.fromHeight(EasySubwayTouchTarget.general),
+        side: BorderSide(color: colorScheme.outlineVariant),
+        textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+      ),
+      icon: IconTheme.merge(data: const IconThemeData(size: 22), child: icon),
+      label: Text(label, textAlign: TextAlign.center),
+    );
+  }
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import 'accessible_design.dart';
 import 'app/app_bootstrap.dart';
 import 'app/app_dependencies.dart';
 import 'facility_report.dart';
@@ -942,14 +943,14 @@ class _HomeScreenState extends State<HomeScreen> {
               title: '개인 설정',
               groupKey: const Key('homeSettingsActionsGroup'),
               children: [
-                _HomeSecondaryActionButton(
+                AccessibleShortcutButton(
                   key: const Key('mobilityProfileButton'),
                   onPressed: _openMobilityProfile,
                   icon: const Icon(Icons.accessibility_new),
                   label: '이동 조건',
                 ),
                 if (notificationRepository != null)
-                  _HomeSecondaryActionButton(
+                  AccessibleShortcutButton(
                     key: const Key('notificationSettingsButton'),
                     onPressed: () {
                       Navigator.of(context).push(
@@ -973,7 +974,7 @@ class _HomeScreenState extends State<HomeScreen> {
               groupKey: const Key('homeMyInfoActionsGroup'),
               children: [
                 if (hasFavorites)
-                  _HomeSecondaryActionButton(
+                  AccessibleShortcutButton(
                     key: const Key('favoritesButton'),
                     onPressed: () {
                       Navigator.of(context).push(
@@ -997,7 +998,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     icon: const Icon(Icons.star_outline),
                     label: '즐겨찾기',
                   ),
-                _HomeSecondaryActionButton(
+                AccessibleShortcutButton(
                   key: const Key('myReportsButton'),
                   onPressed: () {
                     Navigator.of(context).push(
@@ -1109,43 +1110,20 @@ class _HomeActionSection extends StatelessWidget {
               runSpacing: spacing,
               children: [
                 for (final child in children)
-                  SizedBox(width: itemWidth, height: 56, child: child),
+                  SizedBox(
+                    width: itemWidth,
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(
+                        minHeight: EasySubwayTouchTarget.general,
+                      ),
+                      child: child,
+                    ),
+                  ),
               ],
             );
           },
         ),
       ],
-    );
-  }
-}
-
-class _HomeSecondaryActionButton extends StatelessWidget {
-  const _HomeSecondaryActionButton({
-    required this.onPressed,
-    required this.icon,
-    required this.label,
-    super.key,
-  });
-
-  final VoidCallback onPressed;
-  final Widget icon;
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    return OutlinedButton.icon(
-      onPressed: onPressed,
-      style: OutlinedButton.styleFrom(
-        alignment: Alignment.center,
-        backgroundColor: Colors.white,
-        foregroundColor: const Color(0xFF006D77),
-        side: BorderSide(color: colorScheme.outlineVariant),
-        textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
-        padding: const EdgeInsets.symmetric(horizontal: 8),
-      ),
-      icon: IconTheme.merge(data: const IconThemeData(size: 22), child: icon),
-      label: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
     );
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:easysubway_mobile/accessible_design.dart';
 import 'package:easysubway_mobile/main.dart';
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/favorite_facility.dart';
@@ -396,6 +397,43 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('홈 보조 행동은 좁은 화면과 큰 글자에서도 줄임표 없이 터치 기준을 지킨다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    tester.platformDispatcher.textScaleFactorTestValue = 3.2;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      tester.platformDispatcher.clearTextScaleFactorTestValue();
+    });
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final mobilityButton = find.byKey(const Key('mobilityProfileButton'));
+    final favoritesButton = find.byKey(const Key('favoritesButton'));
+
+    expect(EasySubwayTouchTarget.iconOnly, 48);
+    expect(EasySubwayTouchTarget.general, 56);
+    expect(EasySubwayTouchTarget.primary, 60);
+    expect(find.text('이동 조건'), findsOneWidget);
+    expect(find.text('즐겨찾기'), findsOneWidget);
+    expect(tester.getSize(mobilityButton).height, greaterThan(56));
+    expect(tester.getSize(favoritesButton).height, greaterThan(56));
+    expect(tester.getSize(mobilityButton).height, greaterThanOrEqualTo(60));
   });
 
   testWidgets('홈 즐겨찾기는 하나의 진입점에서 탭 목록을 바로 보여준다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

close #733

## 작업 배경

홈 보조 행동 버튼은 좁은 화면과 큰 글자 설정에서 56px 고정 높이에 갇혀 텍스트가 눌리거나 줄임 처리될 위험이 있었습니다. 교통약자 사용자를 기본 대상으로 두는 앱 기준에 맞춰 버튼 높이와 색상 토큰을 재사용 가능한 작은 경계로 분리합니다.

## 작업 내용

- `EasySubwayAccessibleColors`, `EasySubwayTouchTarget`, `AccessibleShortcutButton`을 추가해 홈 보조 행동 버튼의 색상과 터치 기준을 한 곳에서 참조하게 했습니다.
- 홈 보조 행동 버튼을 고정 높이 박스 대신 최소 높이 제약으로 배치해 큰 글자 설정에서 버튼이 필요한 만큼 커질 수 있게 했습니다.
- 320px 폭과 text scale 3.2 조건에서 버튼 라벨과 터치 기준을 검증하는 위젯 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --name "홈 보조 행동"`: 구현 전 56.0 고정 높이 조건으로 실패를 확인했습니다.
  - `cd apps/mobile && flutter test test/widget_test.dart --name "홈 보조 행동"`: 1개 테스트 통과.
  - `cd apps/mobile && flutter test test/widget_test.dart --name "홈"`: 14개 테스트 통과.
  - `cd apps/mobile && flutter analyze`: no issues.
  - `cd apps/mobile && flutter test test/widget_test.dart`: 86개 테스트 통과.
  - `git diff --check`: 통과.
  - PR CI: https://github.com/AquilaXk/easysubway/actions/runs/27991453845 통과.
  - PR Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/27991453639 통과.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 홈 보조 행동 버튼 큰 글자 레이아웃 | Flutter widget test | 320px 폭, text scale 3.2에서 `역검색`, `최근검색`, `내주변` 버튼 높이와 라벨 노출 검증 | `flutter test test/widget_test.dart --name "홈 보조 행동"` | 버튼 높이가 56px를 초과하고 최소 60px 이상으로 확장됨 |
| 접근성 터치 기준 토큰 | Flutter widget test | `EasySubwayTouchTarget.iconOnly/general/primary` 상수 검증 | `flutter test test/widget_test.dart --name "홈 보조 행동"` | 48/56/60 기준 유지 |
| 전체 홈 화면 회귀 | Flutter widget test | 홈 관련 테스트 그룹 실행 | `flutter test test/widget_test.dart --name "홈"` | 14개 테스트 통과 |
| 정적 분석과 위젯 회귀 | local | analyzer 및 전체 위젯 테스트 실행 | `flutter analyze`, `flutter test test/widget_test.dart` | no issues, 86개 테스트 통과 |
| PR CI | GitHub Actions | required CI/check 상태 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27991453845 | Android CI, Mobile App CI, Repository CI, Backend CI, osv-scan 통과 |
| PR Release Artifacts | GitHub Actions | 일반 UI PR 기준 실패 상태 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27991453639 | Android Release Artifact 통과, Backend Release Image는 변경 없음으로 skipped |
| 코드 리뷰 fallback | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review 게시 | https://github.com/AquilaXk/easysubway/pull/734#pullrequestreview-4548902746 | Actionable comments 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `AccessibleShortcutButton`은 전체 디자인 시스템이 아니라 홈 접근성 버튼에 필요한 최소 재사용 경계입니다. 이후 역검색/경로검색 화면 토큰 확장은 별도 작업으로 남깁니다.

## 리스크

- 홈 화면 보조 행동 버튼의 실제 높이가 큰 글자 설정에서 기존보다 커질 수 있습니다. 의도한 접근성 동작이며, 홈 위젯 테스트로 주요 라벨 노출을 확인했습니다.
- iOS 수동 화면 캡처는 이번 범위에서 수행하지 않았습니다. 플랫폼별 native chrome을 바꾸지 않고 Flutter 공통 위젯 배치만 변경했으므로 공통 위젯 테스트를 증거로 사용합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.