### PR TITLE
[Style] 홈 이동 조건 요약 패널 추가

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1051,57 +1051,51 @@ class _HomeTripControlPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-    return Semantics(
-      container: true,
-      label: '현재 이동 조건, ${profile.title}, ${profile.summary}',
-      child: Container(
-        key: const Key('homeTripControlPanel'),
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-        decoration: BoxDecoration(
-          color: EasySubwayAccessibleColors.surface,
-          border: Border.all(
-            color: Theme.of(context).colorScheme.outlineVariant,
+    return Container(
+      key: const Key('homeTripControlPanel'),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: EasySubwayAccessibleColors.surface,
+        border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 2,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          Text(
+            '안녕하세요',
+            style: textTheme.titleMedium?.copyWith(
+              color: EasySubwayAccessibleColors.mutedText,
+              fontWeight: FontWeight.w800,
+              height: 1.2,
+            ),
           ),
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Wrap(
-          spacing: 8,
-          runSpacing: 2,
-          crossAxisAlignment: WrapCrossAlignment.center,
-          children: [
-            Text(
-              '안녕하세요',
-              style: textTheme.titleMedium?.copyWith(
-                color: EasySubwayAccessibleColors.mutedText,
-                fontWeight: FontWeight.w800,
-                height: 1.2,
-              ),
+          Text(
+            '현재 이동 조건',
+            style: textTheme.labelLarge?.copyWith(
+              color: EasySubwayAccessibleColors.mutedText,
+              fontWeight: FontWeight.w800,
+              height: 1.2,
             ),
-            Text(
-              '현재 이동 조건',
-              style: textTheme.labelLarge?.copyWith(
-                color: EasySubwayAccessibleColors.mutedText,
-                fontWeight: FontWeight.w800,
-                height: 1.2,
-              ),
+          ),
+          Text(
+            profile.title,
+            style: textTheme.bodyLarge?.copyWith(
+              color: EasySubwayAccessibleColors.text,
+              fontWeight: FontWeight.w900,
+              height: 1.2,
             ),
-            Text(
-              profile.title,
-              style: textTheme.bodyLarge?.copyWith(
-                color: EasySubwayAccessibleColors.text,
-                fontWeight: FontWeight.w900,
-                height: 1.2,
-              ),
+          ),
+          Text(
+            profile.summary,
+            style: textTheme.bodyLarge?.copyWith(
+              color: EasySubwayAccessibleColors.mutedText,
+              height: 1.2,
             ),
-            Text(
-              profile.summary,
-              style: textTheme.bodyLarge?.copyWith(
-                color: EasySubwayAccessibleColors.mutedText,
-                height: 1.2,
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -834,6 +834,10 @@ class _HomeScreenState extends State<HomeScreen> {
     final facilityReportDraftTargetStore =
         widget.facilityReportDraftTargetStore;
     final initialMobilityType = _mobilityType;
+    final currentProfile = mobilityProfileOptions.firstWhere(
+      (option) => option.mobilityType == _mobilityType,
+      orElse: () => mobilityProfileOptions.first,
+    );
     final hasFavorites =
         favoriteRepository != null ||
         favoriteFacilityRepository != null ||
@@ -871,16 +875,9 @@ class _HomeScreenState extends State<HomeScreen> {
       ),
       body: SafeArea(
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
           children: [
-            Text(
-              '안녕하세요',
-              style: textTheme.titleLarge?.copyWith(
-                color: const Color(0xFF466467),
-                fontWeight: FontWeight.w800,
-                height: 1.25,
-              ),
-            ),
+            _HomeTripControlPanel(profile: currentProfile),
             const SizedBox(height: 6),
             Semantics(
               header: true,
@@ -1042,6 +1039,70 @@ class _HomeScreenState extends State<HomeScreen> {
     }
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('${selectedProfile.title} 조건으로 변경했습니다')),
+    );
+  }
+}
+
+class _HomeTripControlPanel extends StatelessWidget {
+  const _HomeTripControlPanel({required this.profile});
+
+  final MobilityProfileOption profile;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Semantics(
+      container: true,
+      label: '현재 이동 조건, ${profile.title}, ${profile.summary}',
+      child: Container(
+        key: const Key('homeTripControlPanel'),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          color: EasySubwayAccessibleColors.surface,
+          border: Border.all(
+            color: Theme.of(context).colorScheme.outlineVariant,
+          ),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Wrap(
+          spacing: 8,
+          runSpacing: 2,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            Text(
+              '안녕하세요',
+              style: textTheme.titleMedium?.copyWith(
+                color: EasySubwayAccessibleColors.mutedText,
+                fontWeight: FontWeight.w800,
+                height: 1.2,
+              ),
+            ),
+            Text(
+              '현재 이동 조건',
+              style: textTheme.labelLarge?.copyWith(
+                color: EasySubwayAccessibleColors.mutedText,
+                fontWeight: FontWeight.w800,
+                height: 1.2,
+              ),
+            ),
+            Text(
+              profile.title,
+              style: textTheme.bodyLarge?.copyWith(
+                color: EasySubwayAccessibleColors.text,
+                fontWeight: FontWeight.w900,
+                height: 1.2,
+              ),
+            ),
+            Text(
+              profile.summary,
+              style: textTheme.bodyLarge?.copyWith(
+                color: EasySubwayAccessibleColors.mutedText,
+                height: 1.2,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -324,6 +324,7 @@ void main() {
       expect(find.byKey(const Key('homeSecondaryActionsGroup')), findsNothing);
       expect(find.byKey(const Key('homeSettingsActionsGroup')), findsOneWidget);
       expect(find.byKey(const Key('homeMyInfoActionsGroup')), findsOneWidget);
+      expect(find.byKey(const Key('homeTripControlPanel')), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '역 검색'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsOneWidget);
@@ -339,7 +340,8 @@ void main() {
       expect(find.text('즐겨찾기 역'), findsNothing);
       expect(find.text('즐겨찾기 시설'), findsNothing);
       expect(find.textContaining('빠른 길보다'), findsNothing);
-      expect(find.textContaining('고령자'), findsNothing);
+      expect(find.text('고령자'), findsOneWidget);
+      expect(find.text('계단을 피하고 쉬운 환승을 우선해요'), findsOneWidget);
       expect(find.textContaining('휠체어'), findsNothing);
 
       final stationButtonSize = tester.getSize(
@@ -423,6 +425,9 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    await tester.drag(find.byType(ListView), const Offset(0, -700));
+    await tester.pumpAndSettle();
+
     final mobilityButton = find.byKey(const Key('mobilityProfileButton'));
     final favoritesButton = find.byKey(const Key('favoritesButton'));
 
@@ -434,6 +439,55 @@ void main() {
     expect(tester.getSize(mobilityButton).height, greaterThan(56));
     expect(tester.getSize(favoritesButton).height, greaterThan(56));
     expect(tester.getSize(mobilityButton).height, greaterThanOrEqualTo(60));
+  });
+
+  testWidgets('홈 이동 조건 요약은 현재 profile과 변경 결과를 보여준다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final panel = find.byKey(const Key('homeTripControlPanel'));
+    expect(panel, findsOneWidget);
+    expect(
+      find.descendant(of: panel, matching: find.text('현재 이동 조건')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('고령자')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('계단을 피하고 쉬운 환승을 우선해요')),
+      findsOneWidget,
+    );
+
+    await tester.ensureVisible(find.byKey(const Key('mobilityProfileButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('mobilityProfileButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('mobilityProfileCard-wheelchair')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('mobilityProfileDoneButton')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.descendant(of: panel, matching: find.text('휠체어')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('계단 없는 길만 안내해요')),
+      findsOneWidget,
+    );
   });
 
   testWidgets('홈 즐겨찾기는 하나의 진입점에서 탭 목록을 바로 보여준다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

close #735

## 작업 배경

홈 첫 화면은 역 검색과 길찾기 진입은 크지만, 현재 어떤 이동 조건이 길찾기에 적용되는지 바로 확인하기 어려웠습니다. 직전 작업에서 이동 조건 저장과 홈 버튼 터치 기준을 정리했으므로 이번 PR은 별도 route draft를 만들지 않고 현재 profile 요약만 홈 상단에 노출합니다.

## 작업 내용

- 기존 인사 영역을 `현재 이동 조건` 요약 스트립으로 바꿔 profile 이름과 설명을 함께 보여줍니다.
- 이동 조건 변경 후 홈으로 돌아오면 요약 스트립이 새 profile로 갱신되게 했습니다.
- 좁은 화면/큰 글자 테스트는 실제 스크롤 후 보조 행동 버튼 터치 기준을 확인하도록 조정했습니다.
- 접근성 중복 안내를 피하기 위해 custom `Semantics` label wrapper 없이 화면 텍스트 자체가 읽히도록 정리했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --name "홈 이동 조건 요약"`: 구현 전 `homeTripControlPanel` 없음으로 실패를 확인했습니다.
  - `cd apps/mobile && flutter test test/widget_test.dart --name "홈 이동 조건 요약"`: 1개 테스트 통과.
  - `cd apps/mobile && flutter analyze`: no issues.
  - `cd apps/mobile && flutter test test/widget_test.dart --name "홈"`: 15개 테스트 통과.
  - `cd apps/mobile && flutter test test/widget_test.dart`: 87개 테스트 통과.
  - `git diff --check`: 통과.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 홈 이동 조건 요약 | Flutter widget test | 홈의 `homeTripControlPanel`에서 현재 profile 이름과 설명 확인 | `flutter test test/widget_test.dart --name "홈 이동 조건 요약"` | 기본 `고령자` 조건과 설명 노출 |
| profile 변경 후 홈 갱신 | Flutter widget test | 이동 조건 화면에서 `휠체어` 선택 후 홈 요약 재검증 | `flutter test test/widget_test.dart --name "홈 이동 조건 요약"` | `휠체어`, `계단 없는 길만 안내해요`로 갱신 |
| 홈 회귀 | Flutter widget test | 홈 관련 테스트 그룹 실행 | `flutter test test/widget_test.dart --name "홈"` | 15개 테스트 통과 |
| 전체 위젯 회귀 | Flutter widget test | 전체 `widget_test.dart` 실행 | `flutter test test/widget_test.dart` | 87개 테스트 통과 |
| 정적 분석 | local | Flutter analyzer 실행 | `flutter analyze` | no issues |
| PR CI | GitHub Actions | PR #736 head `117443e` checks 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27992470741 | Repository, Backend, Mobile, Android, osv-scan 통과 |
| Release Artifact 상태 | GitHub Actions | 일반 UI PR의 Release Artifact 실패 여부 확인 | https://github.com/AquilaXk/easysubway/actions/runs/27992470487 | Android Release Artifact 통과, Backend Release Image skip |
| CodeRabbit 상태 | GitHub PR | bot comment와 status 확인 | https://github.com/AquilaXk/easysubway/pull/736#issuecomment-4774213002 | rate limit으로 실제 리뷰 불가 |
| Codex fallback review | GitHub PR review | CodeRabbit 대체 리뷰와 수정 후 재리뷰 확인 | https://github.com/AquilaXk/easysubway/pull/736#pullrequestreview-4548965238, https://github.com/AquilaXk/easysubway/pull/736#pullrequestreview-4548991944 | 1건 수정 후 재리뷰 actionable 0 |
| 리뷰 thread 정리 | GitHub PR review thread | 중복 semantics 지적 thread에 수정 답글 후 resolve | https://github.com/AquilaXk/easysubway/pull/736#discussion_r3456179409 | resolved |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 별도 route draft나 출발/도착 선택 상태는 추가하지 않았습니다. 이번 PR은 현재 이동 조건이 홈에서 보이는 최소 패널만 다룹니다.

## 리스크

- 홈 상단 세로 여백을 20px에서 12px로 줄였습니다. 기존 첫 화면 버튼 접근성을 깨지 않도록 홈 테스트에서 주요 버튼과 큰 글자 조건을 확인했습니다.
- iOS 수동 화면 캡처는 수행하지 않았습니다. 플랫폼별 native 동작이 아니라 Flutter 공통 홈 위젯 배치 변경이며, 위젯 테스트로 핵심 표시와 갱신을 검증했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
