### PR TITLE
[Feat] 역 검색 출발 도착 초안 연결

### DIFF
--- a/apps/mobile/lib/features/route_draft/application/route_draft_controller.dart
+++ b/apps/mobile/lib/features/route_draft/application/route_draft_controller.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+
+import '../domain/route_draft.dart';
+
+class RouteDraftController extends ChangeNotifier {
+  RouteDraft _draft = const RouteDraft.empty();
+
+  RouteDraft get draft => _draft;
+
+  void setOrigin(RouteDraftStation station) {
+    _draft = RouteDraft(
+      origin: station,
+      destination: _draft.destination,
+      lastModifiedAt: DateTime.now(),
+    );
+    notifyListeners();
+  }
+
+  void setDestination(RouteDraftStation station) {
+    _draft = RouteDraft(
+      origin: _draft.origin,
+      destination: station,
+      lastModifiedAt: DateTime.now(),
+    );
+    notifyListeners();
+  }
+
+  void clear() {
+    if (_draft.isEmpty) {
+      return;
+    }
+    _draft = const RouteDraft.empty();
+    notifyListeners();
+  }
+}

--- a/apps/mobile/lib/features/route_draft/domain/route_draft.dart
+++ b/apps/mobile/lib/features/route_draft/domain/route_draft.dart
@@ -1,0 +1,46 @@
+class RouteDraftStation {
+  const RouteDraftStation({required this.id, required this.nameKo});
+
+  final String id;
+  final String nameKo;
+
+  String get displayName {
+    final trimmedName = nameKo.trim();
+    if (trimmedName.endsWith('역')) {
+      return trimmedName;
+    }
+    return '$trimmedName역';
+  }
+}
+
+class RouteDraft {
+  const RouteDraft({
+    required this.origin,
+    required this.destination,
+    required this.lastModifiedAt,
+    this.invalidatedReason,
+  });
+
+  const RouteDraft.empty()
+    : origin = null,
+      destination = null,
+      lastModifiedAt = null,
+      invalidatedReason = null;
+
+  final RouteDraftStation? origin;
+  final RouteDraftStation? destination;
+  final DateTime? lastModifiedAt;
+  final String? invalidatedReason;
+
+  bool get isEmpty => origin == null && destination == null;
+
+  String get originLabel {
+    final station = origin;
+    return station == null ? '출발 미정' : '출발 ${station.displayName}';
+  }
+
+  String get destinationLabel {
+    final station = destination;
+    return station == null ? '도착 미정' : '도착 ${station.displayName}';
+  }
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -10,6 +10,8 @@ import 'app/app_bootstrap.dart';
 import 'app/app_dependencies.dart';
 import 'facility_report.dart';
 import 'favorite_facility.dart';
+import 'features/route_draft/application/route_draft_controller.dart';
+import 'features/route_draft/domain/route_draft.dart';
 import 'internal_route.dart';
 import 'legacy_credential_cleanup.dart';
 import 'mobility_profile.dart';
@@ -794,11 +796,19 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   late String _mobilityType;
+  late final RouteDraftController _routeDraftController;
 
   @override
   void initState() {
     super.initState();
     _mobilityType = widget.initialMobilityType;
+    _routeDraftController = RouteDraftController();
+  }
+
+  @override
+  void dispose() {
+    _routeDraftController.dispose();
+    super.dispose();
   }
 
   @override
@@ -877,7 +887,15 @@ class _HomeScreenState extends State<HomeScreen> {
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
           children: [
-            _HomeTripControlPanel(profile: currentProfile),
+            AnimatedBuilder(
+              animation: _routeDraftController,
+              builder: (context, _) {
+                return _HomeTripControlPanel(
+                  profile: currentProfile,
+                  draft: _routeDraftController.draft,
+                );
+              },
+            ),
             const SizedBox(height: 6),
             Semantics(
               header: true,
@@ -906,6 +924,7 @@ class _HomeScreenState extends State<HomeScreen> {
                           facilityReportDraftTargetStore,
                       internalRouteRepository: internalRouteRepository,
                       internalRouteMobilityType: initialMobilityType,
+                      routeDraftController: _routeDraftController,
                     ),
                   ),
                 );
@@ -1044,9 +1063,10 @@ class _HomeScreenState extends State<HomeScreen> {
 }
 
 class _HomeTripControlPanel extends StatelessWidget {
-  const _HomeTripControlPanel({required this.profile});
+  const _HomeTripControlPanel({required this.profile, required this.draft});
 
   final MobilityProfileOption profile;
+  final RouteDraft draft;
 
   @override
   Widget build(BuildContext context) {
@@ -1092,6 +1112,31 @@ class _HomeTripControlPanel extends StatelessWidget {
             profile.summary,
             style: textTheme.bodyLarge?.copyWith(
               color: EasySubwayAccessibleColors.mutedText,
+              height: 1.2,
+            ),
+          ),
+          Text(
+            '길찾기 초안',
+            key: const Key('homeRouteDraftPanel'),
+            style: textTheme.labelLarge?.copyWith(
+              color: EasySubwayAccessibleColors.mutedText,
+              fontWeight: FontWeight.w800,
+              height: 1.2,
+            ),
+          ),
+          Text(
+            draft.originLabel,
+            style: textTheme.bodyMedium?.copyWith(
+              color: EasySubwayAccessibleColors.text,
+              fontWeight: FontWeight.w900,
+              height: 1.2,
+            ),
+          ),
+          Text(
+            draft.destinationLabel,
+            style: textTheme.bodyMedium?.copyWith(
+              color: EasySubwayAccessibleColors.text,
+              fontWeight: FontWeight.w900,
               height: 1.2,
             ),
           ),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2476,7 +2476,9 @@ class _StationRoleButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
+      enabled: onPressed != null,
       label: semanticLabel,
+      onTap: onPressed,
       child: ExcludeSemantics(
         child: OutlinedButton.icon(
           onPressed: onPressed,

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -5,7 +5,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import 'accessible_design.dart';
 import 'facility_report.dart';
+import 'features/route_draft/application/route_draft_controller.dart';
+import 'features/route_draft/domain/route_draft.dart';
 import 'internal_route.dart';
 import 'map_adapter.dart';
 import 'mobile_error_reporter.dart';
@@ -1656,6 +1659,7 @@ class StationSearchScreen extends StatefulWidget {
     this.facilityReportDraftTargetStore,
     this.internalRouteRepository,
     this.internalRouteMobilityType = 'SENIOR',
+    this.routeDraftController,
     super.key,
   });
 
@@ -1667,6 +1671,7 @@ class StationSearchScreen extends StatefulWidget {
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
   final InternalRouteRepository? internalRouteRepository;
   final String internalRouteMobilityType;
+  final RouteDraftController? routeDraftController;
 
   @override
   State<StationSearchScreen> createState() => _StationSearchScreenState();
@@ -1792,6 +1797,12 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
                 return _StationSearchBody(
                   state: _controller.state,
                   onResultTap: _openStationDetail,
+                  onSetOrigin: widget.routeDraftController == null
+                      ? null
+                      : _setRouteOrigin,
+                  onSetDestination: widget.routeDraftController == null
+                      ? null
+                      : _setRouteDestination,
                   isOpeningLocationSettings: _isOpeningLocationSettings,
                   onOpenLocationSettings: _openLocationSettings,
                 );
@@ -1820,6 +1831,24 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
 
   void _selectLine(SubwayLineOption? line) {
     setState(() => _selectedLine = line);
+  }
+
+  void _setRouteOrigin(StationSearchResult result) {
+    final station = RouteDraftStation(id: result.id, nameKo: result.nameKo);
+    widget.routeDraftController?.setOrigin(station);
+    _showRouteDraftSnack('${station.displayName}을 출발역으로 설정했습니다');
+  }
+
+  void _setRouteDestination(StationSearchResult result) {
+    final station = RouteDraftStation(id: result.id, nameKo: result.nameKo);
+    widget.routeDraftController?.setDestination(station);
+    _showRouteDraftSnack('${station.displayName}을 도착역으로 설정했습니다');
+  }
+
+  void _showRouteDraftSnack(String message) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 
   Future<void> _searchNearby() async {
@@ -2110,12 +2139,16 @@ class _StationSearchBody extends StatelessWidget {
     required this.onResultTap,
     required this.isOpeningLocationSettings,
     required this.onOpenLocationSettings,
+    this.onSetOrigin,
+    this.onSetDestination,
   });
 
   final StationSearchState state;
   final ValueChanged<StationSearchResult> onResultTap;
   final bool isOpeningLocationSettings;
   final VoidCallback onOpenLocationSettings;
+  final ValueChanged<StationSearchResult>? onSetOrigin;
+  final ValueChanged<StationSearchResult>? onSetDestination;
 
   @override
   Widget build(BuildContext context) {
@@ -2149,6 +2182,12 @@ class _StationSearchBody extends StatelessWidget {
             _StationSearchResultTile(
               result: result,
               onTap: () => onResultTap(result),
+              onSetOrigin: onSetOrigin == null
+                  ? null
+                  : () => onSetOrigin!(result),
+              onSetDestination: onSetDestination == null
+                  ? null
+                  : () => onSetDestination!(result),
             ),
         ],
       ),
@@ -2248,108 +2287,206 @@ class _StationSearchMessage extends StatelessWidget {
 }
 
 class _StationSearchResultTile extends StatelessWidget {
-  const _StationSearchResultTile({required this.result, required this.onTap});
+  const _StationSearchResultTile({
+    required this.result,
+    required this.onTap,
+    this.onSetOrigin,
+    this.onSetDestination,
+  });
 
   final StationSearchResult result;
   final VoidCallback onTap;
+  final VoidCallback? onSetOrigin;
+  final VoidCallback? onSetDestination;
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     final stationName = _stationResultDisplayName(result.nameKo);
     final semanticLabel = _stationResultSemanticLabel(result);
+    final hasRoleActions = onSetOrigin != null || onSetDestination != null;
 
-    return MergeSemantics(
-      child: Semantics(
-        label: semanticLabel,
-        button: true,
-        onTap: onTap,
-        child: ExcludeSemantics(
-          child: Card(
-            margin: const EdgeInsets.only(bottom: 8),
-            color: Colors.white,
-            elevation: 0,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-              side: const BorderSide(color: Color(0xFFD5E2E4)),
-            ),
-            child: InkWell(
-              key: Key('stationSearchResult-${result.id}'),
-              borderRadius: BorderRadius.circular(8),
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      color: Colors.white,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: const BorderSide(color: Color(0xFFD5E2E4)),
+      ),
+      child: Column(
+        children: [
+          MergeSemantics(
+            child: Semantics(
+              label: semanticLabel,
+              button: true,
               onTap: onTap,
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(minHeight: 88),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 14,
-                    vertical: 10,
-                  ),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      ConstrainedBox(
-                        constraints: const BoxConstraints(maxWidth: 72),
-                        child: StationLineBadges(
-                          lines: result.lines,
-                          size: 32,
-                          maxBadgeCount: 2,
-                        ),
+              child: ExcludeSemantics(
+                child: InkWell(
+                  key: Key('stationSearchResult-${result.id}'),
+                  borderRadius: BorderRadius.circular(8),
+                  onTap: onTap,
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(minHeight: 88),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 14,
+                        vertical: 10,
                       ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              stationName,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: textTheme.headlineSmall?.copyWith(
-                                color: const Color(0xFF102A2C),
-                                fontWeight: FontWeight.w900,
-                                height: 1.15,
-                              ),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          ConstrainedBox(
+                            constraints: const BoxConstraints(maxWidth: 72),
+                            child: StationLineBadges(
+                              lines: result.lines,
+                              size: 32,
+                              maxBadgeCount: 2,
                             ),
-                            const SizedBox(height: 4),
-                            Text(
-                              result.distanceLabel.isEmpty
-                                  ? result.lineLabel
-                                  : '${result.distanceLabel} · ${result.lineLabel}',
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: textTheme.bodyLarge?.copyWith(
-                                color: const Color(0xFF29484B),
-                                fontWeight: FontWeight.w700,
-                                height: 1.25,
-                              ),
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  stationName,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: textTheme.headlineSmall?.copyWith(
+                                    color: const Color(0xFF102A2C),
+                                    fontWeight: FontWeight.w900,
+                                    height: 1.15,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  result.distanceLabel.isEmpty
+                                      ? result.lineLabel
+                                      : '${result.distanceLabel} · ${result.lineLabel}',
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: textTheme.bodyLarge?.copyWith(
+                                    color: const Color(0xFF29484B),
+                                    fontWeight: FontWeight.w700,
+                                    height: 1.25,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  '${result.dataQualityLabel} · ${result.dataSourceLabel}',
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: textTheme.bodyMedium?.copyWith(
+                                    color: const Color(0xFF405A5D),
+                                    fontWeight: FontWeight.w800,
+                                    height: 1.25,
+                                  ),
+                                ),
+                              ],
                             ),
-                            const SizedBox(height: 4),
-                            Text(
-                              '${result.dataQualityLabel} · ${result.dataSourceLabel}',
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: textTheme.bodyMedium?.copyWith(
-                                color: const Color(0xFF405A5D),
-                                fontWeight: FontWeight.w800,
-                                height: 1.25,
-                              ),
-                            ),
-                          ],
-                        ),
+                          ),
+                          const SizedBox(width: 8),
+                          const Icon(
+                            Icons.chevron_right,
+                            color: Color(0xFF405A5D),
+                            size: 30,
+                          ),
+                        ],
                       ),
-                      const SizedBox(width: 8),
-                      const Icon(
-                        Icons.chevron_right,
-                        color: Color(0xFF405A5D),
-                        size: 30,
-                      ),
-                    ],
+                    ),
                   ),
                 ),
               ),
             ),
           ),
+          if (hasRoleActions)
+            _StationRoleActionBar(
+              stationId: result.id,
+              stationName: stationName,
+              onSetOrigin: onSetOrigin,
+              onSetDestination: onSetDestination,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StationRoleActionBar extends StatelessWidget {
+  const _StationRoleActionBar({
+    required this.stationId,
+    required this.stationName,
+    this.onSetOrigin,
+    this.onSetDestination,
+  });
+
+  final String stationId;
+  final String stationName;
+  final VoidCallback? onSetOrigin;
+  final VoidCallback? onSetDestination;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+      child: Row(
+        children: [
+          Expanded(
+            child: _StationRoleButton(
+              key: Key('stationRoleOrigin-$stationId'),
+              icon: Icons.trip_origin,
+              label: '출발',
+              semanticLabel: '$stationName을 출발역으로 설정',
+              onPressed: onSetOrigin,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: _StationRoleButton(
+              key: Key('stationRoleDestination-$stationId'),
+              icon: Icons.flag_outlined,
+              label: '도착',
+              semanticLabel: '$stationName을 도착역으로 설정',
+              onPressed: onSetDestination,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StationRoleButton extends StatelessWidget {
+  const _StationRoleButton({
+    required this.icon,
+    required this.label,
+    required this.semanticLabel,
+    required this.onPressed,
+    super.key,
+  });
+
+  final IconData icon;
+  final String label;
+  final String semanticLabel;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: semanticLabel,
+      child: ExcludeSemantics(
+        child: OutlinedButton.icon(
+          onPressed: onPressed,
+          style: OutlinedButton.styleFrom(
+            minimumSize: const Size.fromHeight(EasySubwayTouchTarget.iconOnly),
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+            textStyle: const TextStyle(fontWeight: FontWeight.w800),
+          ),
+          icon: Icon(icon, size: 20),
+          label: Text(label, textAlign: TextAlign.center),
         ),
       ),
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1680,6 +1680,13 @@ void main() {
       findsOneWidget,
     );
     expect(find.bySemanticsLabel('상록수역을 출발역으로 설정'), findsOneWidget);
+    expect(
+      tester
+          .getSemantics(find.bySemanticsLabel('상록수역을 출발역으로 설정'))
+          .getSemanticsData()
+          .hasAction(SemanticsAction.tap),
+      isTrue,
+    );
     await tester.tap(
       find.byKey(const Key('stationRoleOrigin-station-sangnoksu')),
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -45,6 +45,8 @@ OnboardingState _completedOnboardingStateWithPreferences({
 }
 
 Future<void> _openFavoriteList(WidgetTester tester, {Key? tabKey}) async {
+  await tester.ensureVisible(find.byKey(const Key('favoritesButton')));
+  await tester.pumpAndSettle();
   await tester.tap(find.byKey(const Key('favoritesButton')));
   await tester.pumpAndSettle();
   if (tabKey != null) {
@@ -81,6 +83,8 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    await tester.ensureVisible(find.byKey(const Key('myReportsButton')));
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('myReportsButton')));
     await tester.pumpAndSettle();
 
@@ -123,6 +127,8 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    await tester.ensureVisible(find.byKey(const Key('myReportsButton')));
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('myReportsButton')));
     await tester.pumpAndSettle();
     final reportSemantics = tester.getSemantics(
@@ -508,6 +514,8 @@ void main() {
     expect(find.byKey(const Key('favoriteStationsButton')), findsNothing);
     expect(find.byKey(const Key('favoriteFacilitiesButton')), findsNothing);
 
+    await tester.ensureVisible(find.byKey(const Key('favoritesButton')));
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('favoritesButton')));
     await tester.pumpAndSettle();
 
@@ -1632,6 +1640,65 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('역 검색 결과에서 출발 도착 역할을 지정하면 홈 초안이 갱신된다', (tester) async {
+    final repository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '사당': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    expect(find.byKey(const Key('homeRouteDraftPanel')), findsOneWidget);
+    expect(find.text('출발 미정'), findsOneWidget);
+    expect(find.text('도착 미정'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('stationRoleOrigin-station-sangnoksu')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('stationRoleDestination-station-sangnoksu')),
+      findsOneWidget,
+    );
+    expect(find.bySemanticsLabel('상록수역을 출발역으로 설정'), findsOneWidget);
+    await tester.tap(
+      find.byKey(const Key('stationRoleOrigin-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '사당');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('stationRoleDestination-station-sadang')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    expect(find.text('출발 상록수역'), findsOneWidget);
+    expect(find.text('도착 사당역'), findsOneWidget);
   });
 
   testWidgets('역 검색 결과는 환승 노선 배지를 대표 노선과 추가 개수로 줄인다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

close #737

## 작업 배경

역 검색 결과는 지금까지 상세 화면 진입만 제공해서 사용자가 출발역이나 도착역으로 쓰려면 길찾기 화면에서 같은 역을 다시 입력해야 했습니다. 이번 변경은 경유역, 최근 검색, 즐겨찾기 연동까지 확장하기 전 단계로, 홈과 역 검색 사이에서 공유되는 출발/도착 초안만 먼저 고정합니다.

## 작업 내용

- `RouteDraft`와 `RouteDraftController`를 추가해 출발역, 도착역, 마지막 변경 시각을 표현합니다.
- 홈의 이동 조건 요약에 `길찾기 초안`, `출발 미정`, `도착 미정` 또는 선택된 역 이름을 함께 보여줍니다.
- 역 검색 결과 카드 아래에 `출발`, `도착` 역할 버튼을 추가하고, 스크린리더용 label과 semantic tap action을 분리했습니다.
- 출발/도착 지정 뒤 홈으로 돌아오면 초안 요약이 선택한 역으로 갱신됩니다.
- 홈 보조 버튼 테스트는 초안 요약 추가로 세로 위치가 내려간 만큼 실제 스크롤 후 탭하도록 보정했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --name "역 검색 결과에서 출발 도착"`: 구현 전 `homeRouteDraftPanel` 없음으로 실패를 확인했습니다.
  - `cd apps/mobile && flutter test test/widget_test.dart --name "역 검색 결과에서 출발 도착"`: 1개 테스트 통과.
  - `cd apps/mobile && flutter test test/widget_test.dart --name "역 검색"`: 13개 테스트 통과.
  - `cd apps/mobile && flutter test test/widget_test.dart --name "홈"`: 16개 테스트 통과.
  - `cd apps/mobile && flutter analyze`: no issues.
  - `cd apps/mobile && flutter test test/widget_test.dart`: 88개 테스트 통과.
  - `git diff --check`: 통과.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 검색 역할 버튼 | Flutter widget test | 검색 결과 카드에서 출발/도착 버튼 key, semantics label, semantic tap action 확인 | `flutter test test/widget_test.dart --name "역 검색 결과에서 출발 도착"` | `stationRoleOrigin-*`, `stationRoleDestination-*`, `상록수역을 출발역으로 설정`, `SemanticsAction.tap` 확인 |
| 홈 초안 갱신 | Flutter widget test | 출발 `상록수`, 도착 `사당` 지정 후 홈으로 복귀 | `flutter test test/widget_test.dart --name "역 검색 결과에서 출발 도착"` | `출발 상록수역`, `도착 사당역` 표시 |
| 역 검색 회귀 | Flutter widget test | 역 검색 관련 그룹 실행 | `flutter test test/widget_test.dart --name "역 검색"` | 13개 테스트 통과 |
| 홈 회귀 | Flutter widget test | 홈 관련 그룹 실행 | `flutter test test/widget_test.dart --name "홈"` | 16개 테스트 통과 |
| 전체 위젯 회귀 | Flutter widget test | 전체 `widget_test.dart` 실행 | `flutter test test/widget_test.dart` | 88개 테스트 통과 |
| 정적 분석 | local | Flutter analyzer 실행 | `flutter analyze` | no issues |
| CI | GitHub Actions | PR head `899afb6` required CI 확인 | [CI run 27993562997](https://github.com/AquilaXk/easysubway/actions/runs/27993562997) | Android CI, Mobile App CI, Backend CI, Repository CI, dependency scan 통과 |
| Release artifact 실패 상태 | GitHub Actions | 일반 UI PR이지만 release artifact run 실패 여부 확인 | [Release Artifacts run 27993562851](https://github.com/AquilaXk/easysubway/actions/runs/27993562851) | Android Release Artifact 통과, Backend Release Image skipped |
| 코드 리뷰 | GitHub PR review | CodeRabbit rate limit 후 Codex fallback review와 수정 후 재검토 확인 | [초기 Codex review](https://github.com/AquilaXk/easysubway/pull/738#pullrequestreview-4549092219), [수정 답글](https://github.com/AquilaXk/easysubway/pull/738#discussion_r3456267845), [재검토](https://github.com/AquilaXk/easysubway/pull/738#pullrequestreview-4549115231) | 최초 semantics action 지적 수정, 재검토 actionable 0 |
| 화면 증거 대체 | Flutter semantics/widget test | Android emulator 수동 캡처 대신 role button semantics와 홈 갱신을 테스트로 검증 | 위 테스트 출력 | 플랫폼 공통 Flutter 위젯 변경이며 native API 변경 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 이번 PR은 경유역, route v2 요청, 최근 검색/즐겨찾기 역할 지정은 포함하지 않습니다. 홈과 역 검색 사이의 최소 출발/도착 초안 상태만 다룹니다.

## 리스크

- 홈 상단 요약에 `길찾기 초안` 텍스트가 추가되어 보조 버튼 위치가 약간 내려갑니다. 기존 테스트는 보조 버튼을 스크롤 후 탭하도록 바꿨고, 핵심 `역 검색`/`길찾기` 버튼은 그대로 첫 화면에 남습니다.
- iOS 수동 화면 캡처는 수행하지 않았습니다. 변경은 Flutter 공통 위젯과 in-memory controller 범위이며, semantics label, semantic tap action, 화면 갱신은 widget test로 검증했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
