### PR TITLE
[Feat] 역 검색 최근 검색 빠른 재사용

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1681,6 +1681,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   late final StationSearchController _controller;
   final TextEditingController _queryController = TextEditingController();
   Future<List<SubwayLineOption>>? _lineOptionsFuture;
+  List<String> _recentQueries = const [];
   SubwayLineOption? _selectedLine;
   bool _isNearbySearchRunning = false;
   bool _isOpeningLocationSettings = false;
@@ -1697,6 +1698,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     if (lineRepository != null) {
       _lineOptionsFuture = lineRepository.listLines();
     }
+    unawaited(_loadRecentQueries());
   }
 
   @override
@@ -1771,6 +1773,24 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
               builder: (context, _) {
                 final isSearching =
                     _controller.state.status == StationSearchStatus.loading;
+                if (_hasSearchQuery || _recentQueries.isEmpty) {
+                  return const SizedBox.shrink();
+                }
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: _StationRecentSearchSection(
+                    queries: _recentQueries,
+                    enabled: !isSearching && !_isNearbySearchRunning,
+                    onQuerySelected: _searchRecentQuery,
+                  ),
+                );
+              },
+            ),
+            AnimatedBuilder(
+              animation: _controller,
+              builder: (context, _) {
+                final isSearching =
+                    _controller.state.status == StationSearchStatus.loading;
                 final isNearbyDisabled = isSearching || _isNearbySearchRunning;
                 if (_hasSearchQuery) {
                   return FilledButton.icon(
@@ -1818,7 +1838,36 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
     if (_controller.state.status == StationSearchStatus.loading) {
       return;
     }
-    _controller.search(query, lineId: _selectedLine?.id);
+    unawaited(_runSearch(query));
+  }
+
+  Future<void> _runSearch(String query) async {
+    await _controller.search(query, lineId: _selectedLine?.id);
+    await _loadRecentQueries();
+  }
+
+  void _searchRecentQuery(String query) {
+    _queryController.value = TextEditingValue(
+      text: query,
+      selection: TextSelection.collapsed(offset: query.length),
+    );
+    _submit(query);
+  }
+
+  Future<void> _loadRecentQueries() async {
+    final repository = widget.searchHistoryRepository;
+    if (repository == null) {
+      return;
+    }
+    try {
+      final queries = await repository.listRecentQueries();
+      if (!mounted) {
+        return;
+      }
+      setState(() => _recentQueries = queries);
+    } catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '최근 검색어 조회 중 예외가 발생했습니다.');
+    }
   }
 
   StationLineFilterRepository? get _lineFilterRepository {
@@ -1944,6 +1993,71 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
           internalRouteMobilityType: widget.internalRouteMobilityType,
         ),
       ),
+    );
+  }
+}
+
+class _StationRecentSearchSection extends StatelessWidget {
+  const _StationRecentSearchSection({
+    required this.queries,
+    required this.enabled,
+    required this.onQuerySelected,
+  });
+
+  final List<String> queries;
+  final bool enabled;
+  final ValueChanged<String> onQuerySelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      key: const Key('stationRecentSearchSection'),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '최근 검색',
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+            color: EasySubwayAccessibleColors.text,
+            fontWeight: FontWeight.w900,
+            height: 1.25,
+          ),
+        ),
+        const SizedBox(height: 10),
+        Wrap(
+          spacing: 10,
+          runSpacing: 10,
+          children: [
+            for (final query in queries)
+              Semantics(
+                label: '최근 검색어 $query 검색',
+                button: true,
+                enabled: enabled,
+                onTap: enabled ? () => onQuerySelected(query) : null,
+                child: ExcludeSemantics(
+                  child: OutlinedButton.icon(
+                    key: Key('stationRecentSearchQuery-$query'),
+                    onPressed: enabled ? () => onQuerySelected(query) : null,
+                    icon: const Icon(Icons.history),
+                    label: Text(query),
+                    style: OutlinedButton.styleFrom(
+                      minimumSize: const Size(
+                        EasySubwayTouchTarget.general,
+                        EasySubwayTouchTarget.general,
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 14,
+                        vertical: 12,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1708,6 +1708,73 @@ void main() {
     expect(find.text('도착 사당역'), findsOneWidget);
   });
 
+  testWidgets('역 검색 화면은 최근 검색어를 탭해 빠르게 다시 검색한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final repository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      },
+    );
+    final searchHistoryRepository = FakeSearchHistoryRepository(['상록수', '사당']);
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: repository,
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          searchHistoryRepository: searchHistoryRepository,
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('stationSearchButton')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('stationRecentSearchSection')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('stationRecentSearchQuery-상록수')),
+        findsOneWidget,
+      );
+      expect(find.bySemanticsLabel('최근 검색어 상록수 검색'), findsOneWidget);
+      expect(
+        tester
+            .getSemantics(find.bySemanticsLabel('최근 검색어 상록수 검색'))
+            .getSemanticsData()
+            .hasAction(SemanticsAction.tap),
+        isTrue,
+      );
+
+      await tester.tap(find.byKey(const Key('stationRecentSearchQuery-상록수')));
+      await tester.pumpAndSettle();
+
+      final searchInput = tester.widget<TextField>(
+        find.byKey(const Key('stationSearchInput')),
+      );
+      expect(searchInput.controller?.text, '상록수');
+      expect(repository.requestedQueries, ['상록수']);
+      expect(searchHistoryRepository.recordedQueries, ['상록수']);
+      expect(
+        find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('stationRoleOrigin-station-sangnoksu')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('stationRoleDestination-station-sangnoksu')),
+        findsOneWidget,
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('역 검색 결과는 환승 노선 배지를 대표 노선과 추가 개수로 줄인다', (tester) async {
     final repository = FakeStationSearchRepository(
       nextResults: [
@@ -5768,6 +5835,32 @@ class FakeStationSearchRepository
   ) async {
     requestedFacilityStationIds.add(stationId);
     return stationFacilities;
+  }
+}
+
+class FakeSearchHistoryRepository implements SearchHistoryRepository {
+  FakeSearchHistoryRepository(List<String> queries) : queries = [...queries];
+
+  final List<String> queries;
+  final recordedQueries = <String>[];
+  int listRequestCount = 0;
+
+  @override
+  Future<void> recordSearch(String query) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) {
+      return;
+    }
+    recordedQueries.add(trimmed);
+    queries
+      ..remove(trimmed)
+      ..insert(0, trimmed);
+  }
+
+  @override
+  Future<List<String>> listRecentQueries() async {
+    listRequestCount++;
+    return [...queries];
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

close #739

## 작업 배경

역 검색 화면은 검색어를 저장하고 있었지만, 사용자가 최근 검색어를 화면에서 다시 선택할 수 없었습니다. 출발역/도착역 초안 지정 흐름을 쓰려면 같은 역명을 반복 입력해야 해서, 기존 `SearchHistoryRepository` 범위 안에서 최근 검색어를 빠르게 재사용하도록 연결했습니다.

## 작업 내용

- 역 검색 화면 진입 시 저장된 최근 검색어를 불러와 입력창 아래에 표시합니다.
- 최근 검색어 버튼을 누르면 입력창에 query를 채우고 바로 검색을 실행합니다.
- 최근 검색어 버튼에 screen reader label, enabled 상태, semantic tap action을 노출합니다.
- 검색 성공 후 최근 검색어 목록을 다시 불러와 최신 순서를 반영합니다.
- 기존 출발/도착 역할 버튼과 함께 동작하는 widget test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --name "최근 검색어"`: 구현 전 `stationRecentSearchSection` 없음으로 실패 확인, 구현 후 1개 테스트 통과.
  - `cd apps/mobile && flutter test test/widget_test.dart --name "역 검색"`: 14개 테스트 통과.
  - `cd apps/mobile && flutter analyze`: no issues.
  - `cd apps/mobile && flutter test test/widget_test.dart`: 89개 테스트 통과.
  - `git diff --check`: 통과.
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb devices`: 연결된 emulator 없음.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 최근 검색어 표시 | Flutter widget test | 역 검색 진입 후 최근 검색어 섹션과 query 버튼 key 확인 | `flutter test test/widget_test.dart --name "최근 검색어"` | `stationRecentSearchSection`, `stationRecentSearchQuery-상록수` 확인 |
| 최근 검색어 접근성 | Flutter semantics test | 최근 검색어 버튼의 screen reader label과 tap action 확인 | `flutter test test/widget_test.dart --name "최근 검색어"` | `최근 검색어 상록수 검색`, `SemanticsAction.tap` 확인 |
| 최근 검색어 재검색 | Flutter widget test | 최근 검색어 탭 후 입력창 값, repository query, 결과 카드 확인 | `flutter test test/widget_test.dart --name "최근 검색어"` | 입력 `상록수`, requested query `상록수`, 검색 결과 표시 |
| 출발/도착 역할 공존 | Flutter widget test | 최근 검색어로 검색된 결과에 역할 버튼이 남는지 확인 | `flutter test test/widget_test.dart --name "최근 검색어"` | `stationRoleOrigin-station-sangnoksu`, `stationRoleDestination-station-sangnoksu` 확인 |
| 역 검색 회귀 | Flutter widget test | 역 검색 관련 그룹 실행 | `flutter test test/widget_test.dart --name "역 검색"` | 14개 테스트 통과 |
| 전체 위젯 회귀 | Flutter widget test | 전체 `widget_test.dart` 실행 | `flutter test test/widget_test.dart` | 89개 테스트 통과 |
| 정적 분석 | local | Flutter analyzer 실행 | `flutter analyze` | no issues |
| CI | GitHub Actions | PR head `9d9451c` required CI 확인 | [CI run 27994143174](https://github.com/AquilaXk/easysubway/actions/runs/27994143174) | Android CI, Mobile App CI, Backend CI, Repository CI, dependency scan 통과 |
| Release artifact 실패 상태 | GitHub Actions | 일반 UI PR이지만 release artifact run 실패 여부 확인 | [Release Artifacts run 27994142957](https://github.com/AquilaXk/easysubway/actions/runs/27994142957) | Android Release Artifact 통과, Backend Release Image skipped |
| 코드 리뷰 | GitHub PR review | CodeRabbit rate limit 후 Codex fallback review 확인 | [CodeRabbit rate limit](https://github.com/AquilaXk/easysubway/pull/740#issuecomment-4774479675), [Codex fallback review](https://github.com/AquilaXk/easysubway/pull/740#pullrequestreview-4549165985) | Codex fallback actionable 0, review thread 없음 |
| Android emulator 증거 대체 | local adb | 실행 중인 emulator 확인 | `adb devices` | 연결된 device 없음. native API 변경 없는 Flutter 공통 UI이며 widget semantics/test output으로 대체 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 이번 PR은 기존 query 문자열 history만 화면에 노출합니다. `search_history` schema 변경, station/route/place 구조화, pin/delete/expiry는 포함하지 않았습니다.

## 리스크

- 최근 검색어가 많아지면 입력창 아래 vertical 공간을 더 씁니다. 현재 repository limit을 그대로 따르고 Wrap으로 줄바꿈합니다.
- 검색 기록 조회 실패는 사용자 흐름을 막지 않고 error reporter로만 보냅니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
