### PR TITLE
[Feat] 주변 역 거리 의미 명확화

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -458,9 +458,9 @@ class StationSearchResult {
       return '';
     }
     if (distance < 1000) {
-      return '${distance}m 거리';
+      return '현재 위치 기준 ${distance}m';
     }
-    return '${(distance / 1000).toStringAsFixed(1)}km 거리';
+    return '현재 위치 기준 ${(distance / 1000).toStringAsFixed(1)}km';
   }
 
   String get semanticLabel {

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -369,7 +369,7 @@ void main() {
     expect(requestedUri.queryParameters['limit'], '5');
     expect(results.single.nameKo, '상록수');
     expect(results.single.distanceMeters, 230);
-    expect(results.single.distanceLabel, '230m 거리');
+    expect(results.single.distanceLabel, '현재 위치 기준 230m');
   });
 
   test('역 API 저장소는 정수가 아닌 거리 응답을 계약 위반으로 처리한다', () async {
@@ -964,7 +964,7 @@ void main() {
     expect(repository.requestedNearbyLocations.single.latitude, 37.3028);
     expect(repository.requestedNearbyLocations.single.longitude, 126.8665);
     expect(controller.state.status, StationSearchStatus.success);
-    expect(controller.state.results.single.distanceLabel, '230m 거리');
+    expect(controller.state.results.single.distanceLabel, '현재 위치 기준 230m');
   });
 
   test('역 검색 컨트롤러는 정확도 정보가 없는 기존 위치 응답을 주변역 검색에 쓰지 않는다', () async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2083,10 +2083,10 @@ void main() {
       expect(repository.requestedNearbyLocations.single.latitude, 37.3028);
       expect(repository.requestedNearbyLocations.single.longitude, 126.8665);
       expect(find.text('상록수역'), findsOneWidget);
-      expect(find.text('230m 거리 · 수도권 2호선'), findsOneWidget);
+      expect(find.text('현재 위치 기준 230m · 수도권 2호선'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
-          '상록수역, 230m 거리, 수도권 2호선, 수도권, 기본 정보만 있음, 출처 공식 파일',
+          '상록수역, 현재 위치 기준 230m, 수도권 2호선, 수도권, 기본 정보만 있음, 출처 공식 파일',
         ),
         findsOneWidget,
       );
@@ -2235,7 +2235,7 @@ void main() {
 
     expect(repository.requestedNearbyLocations, hasLength(1));
     expect(find.text('상록수역'), findsOneWidget);
-    expect(find.text('230m 거리 · 수도권 2호선'), findsOneWidget);
+    expect(find.text('현재 위치 기준 230m · 수도권 2호선'), findsOneWidget);
   });
 
   testWidgets('역 검색은 현재 위치를 확인하지 못하면 짧은 안내를 보여준다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

close #741

## 작업 배경

주변 역 검색 결과의 `230m 거리` 문구는 접근 가능한 도보 거리처럼 읽힐 수 있었습니다. 실제 값은 현재 위치 기준 거리값이므로, 지도 없이 리스트만 보는 사용자도 의미를 오해하지 않도록 문구를 좁혔습니다.

## 작업 내용

- 주변 역 검색 결과 거리 문구를 `현재 위치 기준 230m` 형태로 변경했습니다.
- 같은 문구가 screen reader label에도 들어가도록 기존 distance label 경계를 수정했습니다.
- 거리값이 없는 일반 역명 검색 결과는 기존 노선 중심 문구를 유지합니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --name "주변 역"`: 구현 전 2개 기대 문구 실패, 구현 후 3개 테스트 통과.
  - `cd apps/mobile && flutter test test/station_search_test.dart --name "거리"`: 3개 테스트 통과.
  - `cd apps/mobile && flutter test test/station_search_test.dart`: 37개 테스트 통과.
  - `cd apps/mobile && flutter test test/widget_test.dart --name "역 검색"`: 14개 테스트 통과.
  - `cd apps/mobile && flutter analyze`: no issues.
  - `cd apps/mobile && flutter test test/widget_test.dart`: 89개 테스트 통과.
  - `git diff --check`: 통과.
  - `gh pr checks 742 --watch --interval 20`: PR head `d3c67c42d148c16cc6958298263062772f899ef9` 기준 CI 통과.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 주변 역 거리 문구 | Flutter widget test | 주변 역 결과 텍스트 확인 | `flutter test test/widget_test.dart --name "주변 역"` | `현재 위치 기준 230m · 수도권 2호선` 표시 |
| 주변 역 접근성 문구 | Flutter semantics test | 주변 역 결과 screen reader label 확인 | `flutter test test/widget_test.dart --name "주변 역"` | `상록수역, 현재 위치 기준 230m, ...` 확인 |
| 거리 label API/컨트롤러 계약 | Flutter unit test | `distanceLabel` 반환값과 컨트롤러 상태 확인 | `flutter test test/station_search_test.dart` | 37개 테스트 통과 |
| 역 검색 회귀 | Flutter widget test | 역 검색 관련 그룹 실행 | `flutter test test/widget_test.dart --name "역 검색"` | 14개 테스트 통과 |
| 전체 위젯 회귀 | Flutter widget test | 전체 `widget_test.dart` 실행 | `flutter test test/widget_test.dart` | 89개 테스트 통과 |
| 정적 분석 | local | Flutter analyzer 실행 | `flutter analyze` | no issues |
| 지도 증거 대체 | Flutter widget/semantics test | 지도 SDK/native API 변경 없이 리스트 문구만 변경 | 위 테스트 출력 | 지도 전용 기능 없이 리스트에서 거리 의미 확인 |
| CI | GitHub Actions | PR checks watch | [CI run 27994848743](https://github.com/AquilaXk/easysubway/actions/runs/27994848743) | Backend/Repository/Mobile/Android CI 통과 |
| Release/CD 실패 감시 | GitHub Actions | 일반 코드 PR 기준 실패 상태 확인 | [Release Artifacts run 27994848464](https://github.com/AquilaXk/easysubway/actions/runs/27994848464) | Android Release Artifact 통과, Backend Release Image skipped |
| CodeRabbit 상태 | GitHub PR comment | bot comment와 status 확인 | [CodeRabbit comment](https://github.com/AquilaXk/easysubway/pull/742#issuecomment-4774533655) | rate limit으로 실제 리뷰 미시작 |
| Codex fallback review | GitHub PR review | inline finding 게시 후 수정 thread resolve | [initial review](https://github.com/AquilaXk/easysubway/pull/742#pullrequestreview-4549200198), [resolved thread](https://github.com/AquilaXk/easysubway/pull/742#discussion_r3456362626) | actionable 1건 수정 완료 |
| Codex fallback re-review | GitHub PR review | 수정 후 재검토 | [re-review](https://github.com/AquilaXk/easysubway/pull/742#pullrequestreview-4549215727) | actionable 0건 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 새 지도 SDK, 오프라인 노선도 렌더러, 접근 가능한 도보거리 계산은 포함하지 않았습니다. 이번 PR은 주변 역 리스트의 거리 의미를 명확히 하는 최소 변경입니다.

## 리스크

- `distanceLabel` 공통 getter를 바꿔 거리값이 있는 모든 역 검색 결과 문구가 함께 바뀝니다. 현재 거리값은 주변 역 검색에서만 쓰이며 관련 widget test로 확인했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
