### PR TITLE
[Feat] 노선도와 주변 지도 계약 분리

### DIFF
--- a/apps/mobile/lib/map_adapter.dart
+++ b/apps/mobile/lib/map_adapter.dart
@@ -1,5 +1,56 @@
 import 'station_search.dart';
 
+enum MapCapabilityType { offlineLineMap, nearbyGeographicMap }
+
+class MapCapabilityContract {
+  const MapCapabilityContract({
+    required this.type,
+    required this.title,
+    required this.listEquivalentLabel,
+    required this.needsCurrentLocation,
+    required this.canUseExternalMapProvider,
+    required this.requiresSdkKeyForTests,
+    required this.requiresListEquivalent,
+    required this.allowsMapOnlyCriticalGestures,
+  });
+
+  final MapCapabilityType type;
+  final String title;
+  final String listEquivalentLabel;
+  final bool needsCurrentLocation;
+  final bool canUseExternalMapProvider;
+  final bool requiresSdkKeyForTests;
+  final bool requiresListEquivalent;
+  final bool allowsMapOnlyCriticalGestures;
+}
+
+const offlineLineMapContract = MapCapabilityContract(
+  type: MapCapabilityType.offlineLineMap,
+  title: '오프라인 노선도',
+  listEquivalentLabel: '노선과 역 목록',
+  needsCurrentLocation: false,
+  canUseExternalMapProvider: false,
+  requiresSdkKeyForTests: false,
+  requiresListEquivalent: true,
+  allowsMapOnlyCriticalGestures: false,
+);
+
+const nearbyGeographicMapContract = MapCapabilityContract(
+  type: MapCapabilityType.nearbyGeographicMap,
+  title: '내 주변 지도',
+  listEquivalentLabel: '주변 역과 시설 목록',
+  needsCurrentLocation: true,
+  canUseExternalMapProvider: true,
+  requiresSdkKeyForTests: false,
+  requiresListEquivalent: true,
+  allowsMapOnlyCriticalGestures: false,
+);
+
+const mapCapabilityContracts = [
+  offlineLineMapContract,
+  nearbyGeographicMapContract,
+];
+
 enum MapProviderType {
   naver,
   kakao;

--- a/apps/mobile/test/map_adapter_test.dart
+++ b/apps/mobile/test/map_adapter_test.dart
@@ -3,6 +3,29 @@ import 'package:easysubway_mobile/station_search.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('지도 기능 계약은 노선도와 주변 지도를 분리하고 목록 대체를 필수로 둔다', () {
+    expect(mapCapabilityContracts.map((contract) => contract.type), [
+      MapCapabilityType.offlineLineMap,
+      MapCapabilityType.nearbyGeographicMap,
+    ]);
+
+    expect(offlineLineMapContract.title, '오프라인 노선도');
+    expect(offlineLineMapContract.needsCurrentLocation, isFalse);
+    expect(offlineLineMapContract.canUseExternalMapProvider, isFalse);
+    expect(offlineLineMapContract.requiresSdkKeyForTests, isFalse);
+    expect(offlineLineMapContract.requiresListEquivalent, isTrue);
+    expect(offlineLineMapContract.allowsMapOnlyCriticalGestures, isFalse);
+    expect(offlineLineMapContract.listEquivalentLabel, '노선과 역 목록');
+
+    expect(nearbyGeographicMapContract.title, '내 주변 지도');
+    expect(nearbyGeographicMapContract.needsCurrentLocation, isTrue);
+    expect(nearbyGeographicMapContract.canUseExternalMapProvider, isTrue);
+    expect(nearbyGeographicMapContract.requiresSdkKeyForTests, isFalse);
+    expect(nearbyGeographicMapContract.requiresListEquivalent, isTrue);
+    expect(nearbyGeographicMapContract.allowsMapOnlyCriticalGestures, isFalse);
+    expect(nearbyGeographicMapContract.listEquivalentLabel, '주변 역과 시설 목록');
+  });
+
   test('지도 제공자는 네이버를 기본값으로 두고 카카오를 대체 후보로 둔다', () {
     const configuration = MapProviderConfiguration.defaults();
 


### PR DESCRIPTION
## 관련 이슈

close #743

## 작업 배경

노선도와 내 주변 지도는 같은 “지도”처럼 보이지만 제약이 다릅니다. 오프라인 노선도는 SDK/API key 없이 테스트 가능해야 하고, 주변 지도는 현재 위치와 외부 provider 의존 가능성이 있습니다. 실제 지도 SDK를 붙이기 전에 두 기능을 분리하고 목록 대체 경로를 필수 계약으로 고정했습니다.

## 작업 내용

- `MapCapabilityContract`를 추가해 지도 기능별 제약을 표현했습니다.
- 오프라인 노선도와 내 주변 지도 capability를 별도 const로 분리했습니다.
- 두 capability 모두 list equivalent 필수, critical action의 map-only gesture 의존 금지로 고정했습니다.
- 기존 marker semantics 테스트를 유지하고 capability 계약 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/map_adapter_test.dart`: 구현 전 undefined symbol로 실패, 구현 후 3개 테스트 통과.
  - `cd apps/mobile && flutter analyze`: no issues.
  - `dart format apps/mobile/lib/map_adapter.dart apps/mobile/test/map_adapter_test.dart`: 2 files checked, 1 changed.
  - `git diff --check`: 통과.
  - `gh pr checks 744 --watch --interval 20`: PR head `e9bb47e41418adfd8802d2065894c79945cdbf00` 기준 CI 통과.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 지도 capability 계약 | Flutter unit test | 노선도/주변 지도 계약 값 확인 | `flutter test test/map_adapter_test.dart` | 3개 테스트 통과 |
| marker semantics 회귀 | Flutter unit test | 기존 marker semantic label 테스트 유지 | `flutter test test/map_adapter_test.dart` | 기존 marker 테스트 통과 |
| 정적 분석 | local | Flutter analyzer 실행 | `flutter analyze` | no issues |
| SDK/key 비의존 | 코드 리뷰 | pubspec/플랫폼 설정 변경 없음 | diff 확인 | 지도 SDK/API key 추가 없음 |
| CI | GitHub Actions | PR checks watch | [CI run 27995348318](https://github.com/AquilaXk/easysubway/actions/runs/27995348318) | Backend/Repository/Mobile/Android CI 통과 |
| Release/CD 실패 감시 | GitHub Actions | 일반 코드 PR 기준 실패 상태 확인 | [Release Artifacts run 27995348145](https://github.com/AquilaXk/easysubway/actions/runs/27995348145) | Android Release Artifact 통과, Backend Release Image skipped |
| CodeRabbit 상태 | GitHub PR comment | bot comment와 status 확인 | [CodeRabbit comment](https://github.com/AquilaXk/easysubway/pull/744#issuecomment-4774636502) | rate limit으로 실제 리뷰 미시작 |
| Codex fallback review | GitHub PR review | CodeRabbit rate limit 대체 리뷰 | [fallback review](https://github.com/AquilaXk/easysubway/pull/744#pullrequestreview-4549258354) | actionable 0건 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 실제 지도 렌더러, 지도 SDK, 공용 API key 설정은 포함하지 않았습니다. 이번 PR은 이후 지도 UI가 들어올 때 list equivalent와 제스처 접근성 계약을 깨지 못하게 하는 최소 경계입니다.

## 리스크

- 현재는 capability 계약만 추가되어 사용자 화면은 바뀌지 않습니다. 실제 노선도/주변 지도 화면에서 이 계약을 소비하는 작업은 별도 PR이 필요합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
