### PR TITLE
[Fix] Android 앱 아이콘 배경 흰색 고정

### DIFF
--- a/apps/mobile/android/app/src/main/res/drawable-v21/launch_background.xml
+++ b/apps/mobile/android/app/src/main/res/drawable-v21/launch_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="?android:colorBackground" />
+    <item android:drawable="@android:color/white" />
 
     <!-- You can insert your own image assets here -->
     <!-- <item>

--- a/apps/mobile/android/app/src/main/res/values-night/styles.xml
+++ b/apps/mobile/android/app/src/main/res/values-night/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is on -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
@@ -12,7 +12,7 @@
          running.
 
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
-        <item name="android:windowBackground">?android:colorBackground</item>
+    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+        <item name="android:windowBackground">@android:color/white</item>
     </style>
 </resources>

--- a/apps/mobile/android/app/src/main/res/values/colors.xml
+++ b/apps/mobile/android/app/src/main/res/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#178BFA</color>
+    <color name="ic_launcher_background">#FFFFFF</color>
 </resources>


### PR DESCRIPTION
## 관련 이슈

close #747

## 작업 배경

Android 앱을 종료하거나 최근 앱 화면으로 전환할 때 launcher icon과 native launch surface가 어두운 배경처럼 보일 수 있어, 앱 아이콘과 시작 배경을 흰색 기준으로 고정했습니다.

## 작업 내용

- adaptive launcher icon background color를 흰색으로 변경했습니다.
- API 21+ launch background가 dark mode 시스템 배경색을 따라가지 않도록 흰색으로 고정했습니다.
- night mode native launch/normal theme도 Light theme과 흰색 window background를 사용하도록 맞췄습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter build apk --debug`: debug APK 빌드 통과.
  - `node --test --test-name-pattern "Android 런처 아이콘" tools/ci/repository-contract.test.mjs`: 1개 테스트 통과.
  - `git diff --check`: 통과.
  - Android emulator `emulator-5554` 설치/실행 후 screenshot 캡처.
  - PR CI: `https://github.com/AquilaXk/easysubway/actions/runs/27996919790` 통과.
  - Android Release Artifact: `https://github.com/AquilaXk/easysubway/actions/runs/27996919626` 통과.
  - CodeRabbit: rate limit으로 실제 리뷰 시작 불가 확인.
  - Codex CLI fallback review: `https://github.com/AquilaXk/easysubway/pull/748#pullrequestreview-4549448840` actionable 0건.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Android debug APK | Android | `flutter build apk --debug` | command output | 빌드 통과 |
| Android launcher icon contract | local | `node --test --test-name-pattern "Android 런처 아이콘" tools/ci/repository-contract.test.mjs` | command output | 1개 테스트 통과 |
| 앱 실행 화면 | Android emulator | 앱 설치 후 홈 화면 screenshot | `.codex/evidence/747/android-home-after-white-background.png` | native/app 배경이 흰색 기준으로 표시됨 |
| 최근 앱 화면 아이콘 | Android emulator | 최근 앱 화면 screenshot | `.codex/evidence/747/android-recents-after-white-background.png` | 앱 아이콘 바깥 원형 배경이 흰색으로 표시됨 |
| PR CI | GitHub Actions | PR checks 확인 | `https://github.com/AquilaXk/easysubway/actions/runs/27996919790` | Android CI, Mobile App CI, Repository CI, Backend CI, osv 통과 |
| Release Artifact | GitHub Actions | Android artifact workflow 확인 | `https://github.com/AquilaXk/easysubway/actions/runs/27996919626` | Android Release Artifact 통과 |
| Code review fallback | GitHub PR review | CodeRabbit rate limit 후 Codex CLI review | `https://github.com/AquilaXk/easysubway/pull/748#pullrequestreview-4549448840` | actionable 0건 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: Android XML resource만 변경했습니다. Flutter 화면 구조나 launcher foreground 이미지는 바꾸지 않았습니다.

## 리스크

- dark mode에서도 native launch surface는 흰색으로 고정됩니다. 현재 앱의 밝은 배경 디자인과 launcher icon 흰 배경 기준을 우선했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
