### PR TITLE
[Style] 홈 이동 요약 카드 간소화

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1071,76 +1071,62 @@ class _HomeTripControlPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-    return Container(
+    return Semantics(
       key: const Key('homeTripControlPanel'),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-      decoration: BoxDecoration(
-        color: EasySubwayAccessibleColors.surface,
-        border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 2,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          Text(
-            '안녕하세요',
-            style: textTheme.titleMedium?.copyWith(
-              color: EasySubwayAccessibleColors.mutedText,
-              fontWeight: FontWeight.w800,
-              height: 1.2,
-            ),
+      container: true,
+      label:
+          '이동 조건 ${profile.title}, ${profile.summary}. 길찾기 초안 ${draft.originLabel}, ${draft.destinationLabel}',
+      child: ExcludeSemantics(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+          child: Wrap(
+            spacing: 6,
+            runSpacing: 2,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              Text(
+                '이동 조건',
+                style: textTheme.labelMedium?.copyWith(
+                  color: EasySubwayAccessibleColors.mutedText,
+                  fontWeight: FontWeight.w800,
+                  height: 1.2,
+                ),
+              ),
+              Text(
+                profile.title,
+                style: textTheme.bodyMedium?.copyWith(
+                  color: EasySubwayAccessibleColors.text,
+                  fontWeight: FontWeight.w900,
+                  height: 1.2,
+                ),
+              ),
+              Text(
+                profile.summary,
+                style: textTheme.bodyMedium?.copyWith(
+                  color: EasySubwayAccessibleColors.mutedText,
+                  height: 1.2,
+                ),
+              ),
+              Text(
+                '길찾기 초안',
+                key: const Key('homeRouteDraftPanel'),
+                style: textTheme.labelMedium?.copyWith(
+                  color: EasySubwayAccessibleColors.mutedText,
+                  fontWeight: FontWeight.w800,
+                  height: 1.2,
+                ),
+              ),
+              Text(
+                '${draft.originLabel} / ${draft.destinationLabel}',
+                style: textTheme.bodyMedium?.copyWith(
+                  color: EasySubwayAccessibleColors.text,
+                  fontWeight: FontWeight.w900,
+                  height: 1.2,
+                ),
+              ),
+            ],
           ),
-          Text(
-            '현재 이동 조건',
-            style: textTheme.labelLarge?.copyWith(
-              color: EasySubwayAccessibleColors.mutedText,
-              fontWeight: FontWeight.w800,
-              height: 1.2,
-            ),
-          ),
-          Text(
-            profile.title,
-            style: textTheme.bodyLarge?.copyWith(
-              color: EasySubwayAccessibleColors.text,
-              fontWeight: FontWeight.w900,
-              height: 1.2,
-            ),
-          ),
-          Text(
-            profile.summary,
-            style: textTheme.bodyLarge?.copyWith(
-              color: EasySubwayAccessibleColors.mutedText,
-              height: 1.2,
-            ),
-          ),
-          Text(
-            '길찾기 초안',
-            key: const Key('homeRouteDraftPanel'),
-            style: textTheme.labelLarge?.copyWith(
-              color: EasySubwayAccessibleColors.mutedText,
-              fontWeight: FontWeight.w800,
-              height: 1.2,
-            ),
-          ),
-          Text(
-            draft.originLabel,
-            style: textTheme.bodyMedium?.copyWith(
-              color: EasySubwayAccessibleColors.text,
-              fontWeight: FontWeight.w900,
-              height: 1.2,
-            ),
-          ),
-          Text(
-            draft.destinationLabel,
-            style: textTheme.bodyMedium?.copyWith(
-              color: EasySubwayAccessibleColors.text,
-              fontWeight: FontWeight.w900,
-              height: 1.2,
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -323,7 +323,7 @@ void main() {
         ),
       );
 
-      expect(find.text('안녕하세요'), findsOneWidget);
+      expect(find.text('안녕하세요'), findsNothing);
       expect(find.text('어디로 가시나요?'), findsOneWidget);
       expect(find.text('개인 설정'), findsOneWidget);
       expect(find.text('내 정보'), findsOneWidget);
@@ -448,6 +448,8 @@ void main() {
   });
 
   testWidgets('홈 이동 조건 요약은 현재 profile과 변경 결과를 보여준다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+
     await tester.pumpWidget(
       EasySubwayApp(
         repository: FakeStationSearchRepository(),
@@ -465,7 +467,20 @@ void main() {
     final panel = find.byKey(const Key('homeTripControlPanel'));
     expect(panel, findsOneWidget);
     expect(
-      find.descendant(of: panel, matching: find.text('현재 이동 조건')),
+      find.ancestor(
+        of: panel,
+        matching: find.byWidgetPredicate(
+          (widget) => widget is Container && widget.decoration != null,
+        ),
+      ),
+      findsNothing,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('안녕하세요')),
+      findsNothing,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('이동 조건')),
       findsOneWidget,
     );
     expect(
@@ -474,6 +489,16 @@ void main() {
     );
     expect(
       find.descendant(of: panel, matching: find.text('계단을 피하고 쉬운 환승을 우선해요')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: panel, matching: find.text('출발 미정 / 도착 미정')),
+      findsOneWidget,
+    );
+    expect(
+      find.bySemanticsLabel(
+        '이동 조건 고령자, 계단을 피하고 쉬운 환승을 우선해요. 길찾기 초안 출발 미정, 도착 미정',
+      ),
       findsOneWidget,
     );
 
@@ -494,6 +519,11 @@ void main() {
       find.descendant(of: panel, matching: find.text('계단 없는 길만 안내해요')),
       findsOneWidget,
     );
+    expect(
+      find.bySemanticsLabel('이동 조건 휠체어, 계단 없는 길만 안내해요. 길찾기 초안 출발 미정, 도착 미정'),
+      findsOneWidget,
+    );
+    semanticsHandle.dispose();
   });
 
   testWidgets('홈 즐겨찾기는 하나의 진입점에서 탭 목록을 바로 보여준다', (tester) async {
@@ -1661,8 +1691,7 @@ void main() {
     );
 
     expect(find.byKey(const Key('homeRouteDraftPanel')), findsOneWidget);
-    expect(find.text('출발 미정'), findsOneWidget);
-    expect(find.text('도착 미정'), findsOneWidget);
+    expect(find.text('출발 미정 / 도착 미정'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('stationSearchButton')));
     await tester.pumpAndSettle();
@@ -1704,8 +1733,7 @@ void main() {
     await tester.pageBack();
     await tester.pumpAndSettle();
 
-    expect(find.text('출발 상록수역'), findsOneWidget);
-    expect(find.text('도착 사당역'), findsOneWidget);
+    expect(find.text('출발 상록수역 / 도착 사당역'), findsOneWidget);
   });
 
   testWidgets('역 검색 화면은 최근 검색어를 탭해 빠르게 다시 검색한다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

close #749

## 작업 배경

홈 첫 화면의 이동 조건 요약이 테두리 카드와 인사말 중심으로 보이면서 실제 핵심 행동보다 먼저 시선을 끌었습니다. 사용자가 문제로 지적한 `안녕하세요`, 큰 카드 테두리, 이전 placeholder 잔여 인상을 없애고 요약만 남깁니다.

## 작업 내용

- 홈 이동 조건 요약을 장식 카드가 아닌 짧은 inline 요약으로 바꿨습니다.
- 스크린리더에는 `이동 조건`, profile, 길찾기 초안 출발/도착 상태가 한 문장으로 읽히도록 semantic label을 유지했습니다.
- widget test에 카드형 decoration 조상이 없는 조건과 금지 문구 제거 조건을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/main.dart apps/mobile/test/widget_test.dart`: exit 0, 변경 없음
  - `cd apps/mobile && flutter test test/widget_test.dart --name "홈"`: 16 tests passed
  - `cd apps/mobile && flutter analyze`: No issues found
  - `git diff --check`: exit 0
  - `cd apps/mobile && flutter build apk --debug`: debug APK build 성공
  - Android emulator `maum_on_api36`에 debug APK 설치: `Success`

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 홈 이동 조건 요약 시각 확인 | Android emulator | debug APK 설치 후 홈 화면 캡처 | `.codex/evidence/749/android-home-compact-trip-panel.png` | 테두리 카드/인사말 없이 inline 요약으로 표시됨 |
| 홈 이동 조건 접근성 label | Android emulator | `uiautomator dump` | `.codex/evidence/749/android-home-compact-trip-panel-ui.xml` | `이동 조건 고령자... 길찾기 초안 출발 미정, 도착 미정` label 확인 |
| 금지 문구 제거 | Android emulator | UI tree에서 `안녕하세요`, `현재 이동 조건`, `오프라인 노선도` 검색 | `.codex/evidence/749/android-home-compact-trip-panel-ui.xml` | 세 문구 모두 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/main.dart`의 `_HomeTripControlPanel`

## 리스크

- 홈 요약이 더 작아져 시각 강조는 줄지만, semantic label과 핵심 텍스트는 유지했습니다.
- 배포/스토어/CD 설정 변경은 없습니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
