### PR TITLE
[Build] 서울 실시간 도착 공급자 후보 계약 고정

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1474,12 +1474,13 @@ test("KRIC source 후보는 상세 근거 완료 상태와 production 분리를 
   const inventory = readJson("tools/datapack/source-inventory.json");
   const candidates = readJson("tools/datapack/source-candidates.json");
   const productionSourceIds = new Set(inventory.sources.map((source) => source.id));
+  const kricCandidates = candidates.candidates.filter((candidate) => candidate.id.startsWith("kric-"));
 
   assert.equal(candidates.schemaVersion, 1);
   assert.equal(candidates.artifactKind, "production-source-candidates");
   assert.equal(candidates.source, "easysubway_public_subway_api_inventory.xlsx");
   assert.deepEqual(
-    candidates.candidates.map((candidate) => candidate.id).sort(),
+    kricCandidates.map((candidate) => candidate.id).sort(),
     [
       "kric-station-convenience-standard",
       "kric-station-info",
@@ -1494,7 +1495,7 @@ test("KRIC source 후보는 상세 근거 완료 상태와 production 분리를 
     ],
   );
 
-  for (const candidate of candidates.candidates) {
+  for (const candidate of kricCandidates) {
     assert.equal(candidate.priority, "P0");
     assert.equal(candidate.licenseEvidenceStatus, "confirmed_attribution");
     assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
@@ -1508,6 +1509,40 @@ test("KRIC source 후보는 상세 근거 완료 상태와 production 분리를 
     assert.deepEqual(candidate.evidence.formats.sort(), ["JSON", "XML"]);
     assert.match(candidate.evidence.sampleUrl, /serviceKey=\[서비스키값\]/);
     assert.ok(candidate.evidence.outputFields.length > 0);
+    assert.deepEqual(candidate.evidence.missingEvidence, ["sampleResponse"]);
+    assert.ok(candidate.nextAction);
+  }
+});
+
+test("서울 TOPIS 실시간 후보는 backend-only key 경계와 production 분리를 고정한다", () => {
+  const inventory = readJson("tools/datapack/source-inventory.json");
+  const candidates = readJson("tools/datapack/source-candidates.json");
+  const productionSourceIds = new Set(inventory.sources.map((source) => source.id));
+  const topisCandidates = candidates.candidates.filter((candidate) => candidate.id.startsWith("seoul-topis-realtime-"));
+
+  assert.deepEqual(
+    topisCandidates.map((candidate) => candidate.id).sort(),
+    ["seoul-topis-realtime-station-arrival", "seoul-topis-realtime-train-position"],
+  );
+
+  for (const candidate of topisCandidates) {
+    assert.equal(candidate.priority, "P0");
+    assert.equal(candidate.licenseEvidenceStatus, "confirmed_attribution");
+    assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
+    assert.equal(candidate.admissionStatus, "evidence_recorded_admin_review_required");
+    assert.equal(candidate.serviceKeyHandling, "backend_secret_only");
+    assert.equal(candidate.mobileEmbeddingAllowed, false);
+    assert.equal(candidate.dataRetentionPolicy, "provider_does_not_offer_past_realtime_data");
+    assert.equal(productionSourceIds.has(candidate.id), false, `${candidate.id} must not be in production source inventory`);
+    assert.match(candidate.detailUrl, /^https:\/\/data\.seoul\.go\.kr\/dataList\/OA-/);
+    assert.match(candidate.requestUrl, /^http:\/\/swopenapi\.seoul\.go\.kr\/api\/subway\/\{serviceKey\}\/json\/realtime/);
+    assert.equal(candidate.evidence.detailPageUrl, candidate.detailUrl);
+    assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
+    assert.equal(candidate.evidence.usePermissionRange, "공공누리 1유형");
+    assert.deepEqual(candidate.evidence.formats, ["JSON"]);
+    assert.match(candidate.evidence.sampleUrl, /\[서비스키값\]/);
+    assert.ok(candidate.evidence.coverageLimitations.length >= 2);
+    assert.ok(candidate.evidence.outputFields.includes("recptnDt"));
     assert.deepEqual(candidate.evidence.missingEvidence, ["sampleResponse"]);
     assert.ok(candidate.nextAction);
   }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1518,6 +1518,7 @@ test("서울 TOPIS 실시간 후보는 backend-only key 경계와 production 분
   const inventory = readJson("tools/datapack/source-inventory.json");
   const candidates = readJson("tools/datapack/source-candidates.json");
   const productionSourceIds = new Set(inventory.sources.map((source) => source.id));
+  const productionSourceByDatasetUrl = new Map(inventory.sources.map((source) => [source.datasetUrl, source]));
   const topisCandidates = candidates.candidates.filter((candidate) => candidate.id.startsWith("seoul-topis-realtime-"));
 
   assert.deepEqual(
@@ -1545,6 +1546,12 @@ test("서울 TOPIS 실시간 후보는 backend-only key 경계와 production 분
     assert.ok(candidate.evidence.outputFields.includes("recptnDt"));
     assert.deepEqual(candidate.evidence.missingEvidence, ["sampleResponse"]);
     assert.ok(candidate.nextAction);
+
+    const productionSource = productionSourceByDatasetUrl.get(candidate.detailUrl);
+    if (productionSource) {
+      assert.equal(candidate.productionInventoryReferenceId, productionSource.id);
+      assert.match(candidate.productionInventoryRelationship, /live_provider_contract_remains_candidate/);
+    }
   }
 });
 

--- a/tools/datapack/build-source-candidate-sample-evidence.mjs
+++ b/tools/datapack/build-source-candidate-sample-evidence.mjs
@@ -31,6 +31,7 @@ async function readJson(filePath) {
 function assertNoServiceKey(value) {
   if (
     /serviceKey=(?!\[서비스키값\])[^&\s<"]+/i.test(value) ||
+    /swopenapi\.seoul\.go\.kr\/api\/subway\/(?!\[서비스키값\]\/)(?!\{serviceKey\}\/)[^/\s<"]+\/json\//i.test(value) ||
     /"serviceKey"\s*:\s*"(?!\[서비스키값\]")[^"]+"/i.test(value) ||
     /<serviceKey\b[^>]*>\s*(?!\[서비스키값\]\s*<\/serviceKey>)[\s\S]*?<\/serviceKey>/i.test(value)
   ) {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -3341,6 +3341,55 @@ test("source candidate sample 검증기는 serviceKey credential 포함을 거�
   );
 });
 
+test("source candidate sample 검증기는 TOPIS path serviceKey credential 포함을 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-topis-secret-${Date.now()}`);
+  const samplePath = path.join(outputDir, "sample.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    samplePath,
+    `${JSON.stringify(
+      {
+        candidateId: "seoul-topis-realtime-station-arrival",
+        endpoint: "http://swopenapi.seoul.go.kr/api/subway/{serviceKey}/json/realtimeStationArrival",
+        format: "json",
+        fields: [
+          "arvlCd",
+          "arvlMsg2",
+          "arvlMsg3",
+          "barvlDt",
+          "bstatnNm",
+          "btrainNo",
+          "recptnDt",
+          "statnId",
+          "statnNm",
+          "subwayId",
+          "trainLineNm",
+          "updnLine",
+        ],
+        observedUrl: "http://swopenapi.seoul.go.kr/api/subway/actual-secret/json/realtimeStationArrival/0/5/서울",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-candidate-sample.mjs",
+        "--candidate",
+        "seoul-topis-realtime-station-arrival",
+        "--sample",
+        samplePath,
+      ],
+      { cwd: root },
+    ),
+    /sample evidence must not contain serviceKey credentials: observedUrl/,
+  );
+});
+
 test("source candidate sample evidence builder는 raw JSON response를 validator 입력으로 변환한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-candidate-json-evidence-${Date.now()}`);
   const responsePath = path.join(outputDir, "response.json");
@@ -3455,6 +3504,39 @@ test("source candidate sample evidence builder는 raw response의 serviceKey cre
         "tools/datapack/build-source-candidate-sample-evidence.mjs",
         "--candidate",
         "kric-train-operation-organ",
+        "--response",
+        responsePath,
+      ],
+      { cwd: root },
+    ),
+    /raw sample response must not contain serviceKey credentials/,
+  );
+});
+
+test("source candidate sample evidence builder는 raw response의 TOPIS path serviceKey credential을 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-raw-topis-secret-${Date.now()}`);
+  const responsePath = path.join(outputDir, "response.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    responsePath,
+    `${JSON.stringify({
+      response: {
+        url: "http://swopenapi.seoul.go.kr/api/subway/actual-secret/json/realtimePosition/0/5/1호선",
+        body: {
+          statnNm: "서울",
+        },
+      },
+    })}\n`,
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/build-source-candidate-sample-evidence.mjs",
+        "--candidate",
+        "seoul-topis-realtime-train-position",
         "--response",
         responsePath,
       ],

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -397,6 +397,100 @@
         ]
       },
       "nextAction": "verify live sample response and decide primary or secondary role against detailed facility APIs before production inventory admission"
+    },
+    {
+      "id": "seoul-topis-realtime-station-arrival",
+      "priority": "P0",
+      "domain": "realtime_arrivals",
+      "displayName": "서울시 지하철 실시간 도착정보",
+      "detailUrl": "https://data.seoul.go.kr/dataList/OA-12764/F/1/datasetView.do",
+      "requestUrl": "http://swopenapi.seoul.go.kr/api/subway/{serviceKey}/json/realtimeStationArrival",
+      "licenseEvidenceStatus": "confirmed_attribution",
+      "sampleEvidenceStatus": "sample_url_documented_key_required",
+      "admissionStatus": "evidence_recorded_admin_review_required",
+      "serviceKeyHandling": "backend_secret_only",
+      "mobileEmbeddingAllowed": false,
+      "dataRetentionPolicy": "provider_does_not_offer_past_realtime_data",
+      "evidence": {
+        "detailPageUrl": "https://data.seoul.go.kr/dataList/OA-12764/F/1/datasetView.do",
+        "retrievedAt": "2026-06-23",
+        "endpoint": "http://swopenapi.seoul.go.kr/api/subway/{serviceKey}/json/realtimeStationArrival",
+        "sampleUrl": "http://swopenapi.seoul.go.kr/api/subway/[서비스키값]/json/realtimeStationArrival/0/5/서울",
+        "formats": [
+          "JSON"
+        ],
+        "usePermissionRange": "공공누리 1유형",
+        "coverageLimitations": [
+          "서울시 이외의 역구간은 미제공",
+          "recptnDt 기준 수신 지연 보정 필요",
+          "과거 실시간 데이터는 별도 제공하지 않음"
+        ],
+        "outputFields": [
+          "arvlCd",
+          "arvlMsg2",
+          "arvlMsg3",
+          "barvlDt",
+          "bstatnNm",
+          "btrainNo",
+          "recptnDt",
+          "statnId",
+          "statnNm",
+          "subwayId",
+          "trainLineNm",
+          "updnLine"
+        ],
+        "missingEvidence": [
+          "sampleResponse"
+        ]
+      },
+      "nextAction": "capture sanitized live sample with backend-only Seoul API key and confirm quota before production provider adapter"
+    },
+    {
+      "id": "seoul-topis-realtime-train-position",
+      "priority": "P0",
+      "domain": "realtime_train_positions",
+      "displayName": "서울시 지하철 실시간 열차 위치정보",
+      "detailUrl": "https://data.seoul.go.kr/dataList/OA-12601/A/1/datasetView.do",
+      "requestUrl": "http://swopenapi.seoul.go.kr/api/subway/{serviceKey}/json/realtimePosition",
+      "licenseEvidenceStatus": "confirmed_attribution",
+      "sampleEvidenceStatus": "sample_url_documented_key_required",
+      "admissionStatus": "evidence_recorded_admin_review_required",
+      "serviceKeyHandling": "backend_secret_only",
+      "mobileEmbeddingAllowed": false,
+      "dataRetentionPolicy": "provider_does_not_offer_past_realtime_data",
+      "evidence": {
+        "detailPageUrl": "https://data.seoul.go.kr/dataList/OA-12601/A/1/datasetView.do",
+        "retrievedAt": "2026-06-23",
+        "endpoint": "http://swopenapi.seoul.go.kr/api/subway/{serviceKey}/json/realtimePosition",
+        "sampleUrl": "http://swopenapi.seoul.go.kr/api/subway/[서비스키값]/json/realtimePosition/0/5/1호선",
+        "formats": [
+          "JSON"
+        ],
+        "usePermissionRange": "공공누리 1유형",
+        "coverageLimitations": [
+          "서울시 TOPIS 제공 범위로 한정",
+          "열차 위치는 GPS 정밀 위치가 아니라 운영 상태 snapshot으로 취급",
+          "과거 실시간 데이터는 별도 제공하지 않음"
+        ],
+        "outputFields": [
+          "directAt",
+          "lastRecptnDt",
+          "recptnDt",
+          "statnId",
+          "statnNm",
+          "statnTid",
+          "statnTnm",
+          "subwayId",
+          "subwayNm",
+          "trainNo",
+          "trainSttus",
+          "updnLine"
+        ],
+        "missingEvidence": [
+          "sampleResponse"
+        ]
+      },
+      "nextAction": "capture sanitized live sample with backend-only Seoul API key and keep train position separate from precise GPS claims"
     }
   ]
 }

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -408,6 +408,8 @@
       "licenseEvidenceStatus": "confirmed_attribution",
       "sampleEvidenceStatus": "sample_url_documented_key_required",
       "admissionStatus": "evidence_recorded_admin_review_required",
+      "productionInventoryReferenceId": "seoul-realtime-arrival-station-info",
+      "productionInventoryRelationship": "same_dataset_station_reference_is_production_live_provider_contract_remains_candidate",
       "serviceKeyHandling": "backend_secret_only",
       "mobileEmbeddingAllowed": false,
       "dataRetentionPolicy": "provider_does_not_offer_past_realtime_data",

--- a/tools/datapack/validate-source-candidate-sample.mjs
+++ b/tools/datapack/validate-source-candidate-sample.mjs
@@ -35,7 +35,10 @@ async function readJson(filePath) {
 
 function findCredentialLeak(value, pathParts = []) {
   if (typeof value === "string") {
-    if (/serviceKey=(?!\[서비스키값\])[^&\s]+/i.test(value)) {
+    if (
+      /serviceKey=(?!\[서비스키값\])[^&\s]+/i.test(value) ||
+      /swopenapi\.seoul\.go\.kr\/api\/subway\/(?!\[서비스키값\]\/)(?!\{serviceKey\}\/)[^/\s<"]+\/json\//i.test(value)
+    ) {
       return pathParts.join(".") || "sample";
     }
     return null;


### PR DESCRIPTION
## 관련 이슈

close #751

## 작업 배경

서울 TOPIS 실시간 도착/열차 위치 provider를 backend adapter로 붙이기 전에, source candidate 단계에서 endpoint, 라이선스, key 보관 경계, sample evidence 상태를 먼저 고정합니다.

## 작업 내용

- 서울 TOPIS 실시간 도착정보 후보를 production source candidates에 추가했습니다.
- 서울 TOPIS 실시간 열차 위치정보 후보를 production source candidates에 추가했습니다.
- 두 후보 모두 backend-only service key, 모바일 key 포함 금지, sampleResponse 미확보 상태를 contract로 고정했습니다.
- 기존 KRIC 후보 contract 테스트는 KRIC 후보만 검증하도록 좁히고, TOPIS 후보 전용 contract 테스트를 추가했습니다.
- TOPIS path segment service key가 sample evidence나 raw response에 섞이면 validator가 거부하도록 credential leak guard를 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs`: 102 tests passed
  - `node --test tools/datapack/datapack-tools.test.mjs`: 84 tests passed
  - `node --test tools/ci/repository-contract.test.mjs tools/datapack/datapack-tools.test.mjs`: 186 tests passed
  - `node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json`: exit 0
  - `node -e 'JSON.parse(require("fs").readFileSync("tools/datapack/source-candidates.json", "utf8")); console.log("source-candidates json ok")'`: source-candidates json ok
  - `git diff --check`: exit 0
  - `git ls-files '*.md'`: only `.github/pull_request_template.md` and `README.md`

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| source candidate contract | local Node.js | repository contract test | `node --test tools/ci/repository-contract.test.mjs` | 102 tests passed |
| source candidate tools | local Node.js | datapack tool test | `node --test tools/datapack/datapack-tools.test.mjs` | 84 tests passed |
| Codex fallback rereview verification | local Node.js | combined test suite | `node --test tools/ci/repository-contract.test.mjs tools/datapack/datapack-tools.test.mjs` | 186 tests passed |
| production inventory 유지 | local Node.js | source inventory validator | `node tools/datapack/validate-source-inventory.mjs --inventory tools/datapack/source-inventory.json` | exit 0 |
| source candidates JSON | local Node.js | JSON parse check | `node -e 'JSON.parse(require("fs").readFileSync("tools/datapack/source-candidates.json", "utf8")); console.log("source-candidates json ok")'` | source-candidates json ok |
| UI 증거 | 해당 없음 | contract-only 변경 | 화면 변경 없음 | 증거 불필요 |

## 리뷰어 메모

- 이번 PR은 실시간 provider runtime 구현이 아니라 후보 계약 고정입니다.
- 실제 API key와 live sample response는 저장하지 않았고, 다음 slice에서 backend-only key로 sanitized sample을 확보해야 합니다.
- CodeRabbit은 status check가 완료됐고, conversation의 review limit 상태 때문에 Codex CLI fallback review를 병행했습니다. Codex fallback 최종 재리뷰는 actionable 0건입니다.

## 리스크

- TOPIS live API 필드가 실제 응답에서 추가/변경될 수 있습니다. 이번 PR은 후보 단계이므로 production inventory 승격은 막아 둔 상태입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
