### PR TITLE
[Refactor] 역 노선 배지 presentation 경계 분리

### DIFF
--- a/apps/mobile/lib/features/stations/domain/station_line.dart
+++ b/apps/mobile/lib/features/stations/domain/station_line.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+class StationSearchLine {
+  const StationSearchLine({
+    required this.id,
+    required this.name,
+    required this.color,
+    required this.stationCode,
+  });
+
+  factory StationSearchLine.fromJson(Map<String, Object?> json) {
+    return StationSearchLine(
+      id: _requiredString(json, 'id'),
+      name: _requiredString(json, 'name'),
+      color: _requiredString(json, 'color'),
+      stationCode: _requiredString(json, 'stationCode'),
+    );
+  }
+
+  final String id;
+  final String name;
+  final String color;
+  final String stationCode;
+
+  String get badgeText => stationLineBadgeText(name);
+
+  Color get badgeColor => stationLineColor(color);
+}
+
+String stationLineBadgeText(String name) {
+  const knownBadgeLabels = <String, String>{
+    '경의중앙': '경의중앙',
+    '수인분당': '수인분당',
+    '신분당': '신분당',
+    '인천1': '인천1',
+    '인천2': '인천2',
+  };
+  for (final entry in knownBadgeLabels.entries) {
+    if (name.contains(entry.key)) {
+      return entry.value;
+    }
+  }
+
+  final numberedLine = RegExp(r'(\d+)\s*호선').firstMatch(name);
+  if (numberedLine != null) {
+    return numberedLine.group(1) ?? name;
+  }
+
+  final compactName = name
+      .replaceAll('수도권 ', '')
+      .replaceAll('광역 ', '')
+      .replaceAll('선', '')
+      .trim();
+  if (compactName.length <= 4) {
+    return compactName;
+  }
+  return compactName.substring(0, 4);
+}
+
+Color stationLineColor(String color) {
+  final normalized = color.trim().replaceFirst('#', '');
+  if (normalized.length == 6) {
+    final parsed = int.tryParse(normalized, radix: 16);
+    if (parsed != null) {
+      return Color(0xFF000000 | parsed);
+    }
+  }
+  return const Color(0xFF006D77);
+}
+
+Color stationLineTextColor(Color backgroundColor) {
+  const darkText = Color(0xFF102A2C);
+  final darkContrast = _contrastRatio(backgroundColor, darkText);
+  final lightContrast = _contrastRatio(backgroundColor, Colors.white);
+  return darkContrast >= lightContrast ? darkText : Colors.white;
+}
+
+double _contrastRatio(Color first, Color second) {
+  final firstLuminance = first.computeLuminance() + 0.05;
+  final secondLuminance = second.computeLuminance() + 0.05;
+  if (firstLuminance > secondLuminance) {
+    return firstLuminance / secondLuminance;
+  }
+  return secondLuminance / firstLuminance;
+}
+
+String _requiredString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is String && value.trim().isNotEmpty) {
+    return value;
+  }
+  throw FormatException('Missing required station field: $key');
+}

--- a/apps/mobile/lib/features/stations/presentation/station_line_badges.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_line_badges.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+
+import '../domain/station_line.dart';
+
+class StationLineBadges extends StatelessWidget {
+  const StationLineBadges({
+    required this.lines,
+    this.size = 40,
+    this.maxBadgeCount,
+    super.key,
+  });
+
+  final List<StationSearchLine> lines;
+  final double size;
+  final int? maxBadgeCount;
+
+  @override
+  Widget build(BuildContext context) {
+    if (lines.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final maxCount = maxBadgeCount;
+    final shouldCollapse = maxCount != null && lines.length > maxCount;
+    final visibleLineCount = shouldCollapse
+        ? (maxCount - 1).clamp(1, lines.length).toInt()
+        : lines.length;
+    final hiddenLineCount = lines.length - visibleLineCount;
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        for (final line in lines.take(visibleLineCount))
+          StationLineBadge(line: line, size: size),
+        if (hiddenLineCount > 0)
+          _StationLineOverflowBadge(count: hiddenLineCount, size: size),
+      ],
+    );
+  }
+}
+
+class StationLineBadge extends StatelessWidget {
+  const StationLineBadge({required this.line, this.size = 40, super.key});
+
+  final StationSearchLine line;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final backgroundColor = line.badgeColor;
+    final foregroundColor = stationLineTextColor(backgroundColor);
+    final badgeText = line.badgeText;
+    final scale = size / 40;
+    final badgeFontSize = RegExp(r'^\d+$').hasMatch(badgeText)
+        ? 25.0 * scale
+        : 15.0 * scale;
+
+    return Container(
+      key: Key('stationLineBadge-${line.id}'),
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(color: backgroundColor, shape: BoxShape.circle),
+      child: Text(
+        badgeText,
+        textAlign: TextAlign.center,
+        maxLines: 2,
+        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+          color: foregroundColor,
+          fontSize: badgeFontSize,
+          fontWeight: FontWeight.w900,
+          height: 1.05,
+        ),
+      ),
+    );
+  }
+}
+
+class _StationLineOverflowBadge extends StatelessWidget {
+  const _StationLineOverflowBadge({required this.count, required this.size});
+
+  final int count;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const Key('stationLineBadgeOverflow'),
+      width: size,
+      height: size,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: const Color(0xFFE8F0F1),
+        shape: BoxShape.circle,
+        border: Border.all(color: const Color(0xFFB8CACC)),
+      ),
+      child: Text(
+        '+$count',
+        textAlign: TextAlign.center,
+        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+          color: const Color(0xFF29484B),
+          fontSize: 13 * (size / 32),
+          fontWeight: FontWeight.w900,
+          height: 1.0,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 
 import 'auth_headers.dart';
 import 'core/network/api_client.dart';
+import 'features/stations/presentation/station_line_badges.dart';
 import 'mobile_error_reporter.dart';
 import 'mobility_profile.dart';
 import 'station_search.dart';

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -9,9 +9,13 @@ import 'accessible_design.dart';
 import 'facility_report.dart';
 import 'features/route_draft/application/route_draft_controller.dart';
 import 'features/route_draft/domain/route_draft.dart';
+import 'features/stations/domain/station_line.dart';
+import 'features/stations/presentation/station_line_badges.dart';
 import 'internal_route.dart';
 import 'map_adapter.dart';
 import 'mobile_error_reporter.dart';
+
+export 'features/stations/domain/station_line.dart';
 
 const _currentLocationDisabledMessage = '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
 const _nearbyLocationMaxAge = Duration(minutes: 5);
@@ -779,50 +783,6 @@ class StationLayoutSummaryItem {
   final String text;
 }
 
-class StationSearchLine {
-  const StationSearchLine({
-    required this.id,
-    required this.name,
-    required this.color,
-    required this.stationCode,
-  });
-
-  factory StationSearchLine.fromJson(Map<String, Object?> json) {
-    return StationSearchLine(
-      id: _requiredString(json, 'id'),
-      name: _requiredString(json, 'name'),
-      color: _requiredString(json, 'color'),
-      stationCode: _requiredString(json, 'stationCode'),
-    );
-  }
-
-  static const _knownBadgeLabels = <String, String>{
-    '경의중앙': '경의중앙',
-    '수인분당': '수인분당',
-    '신분당': '신분당',
-    '인천1': '인천1',
-    '인천2': '인천2',
-  };
-
-  final String id;
-  final String name;
-  final String color;
-  final String stationCode;
-
-  String get badgeText => _lineBadgeText(name);
-
-  Color get badgeColor {
-    final normalized = color.trim().replaceFirst('#', '');
-    if (normalized.length == 6) {
-      final parsed = int.tryParse(normalized, radix: 16);
-      if (parsed != null) {
-        return Color(0xFF000000 | parsed);
-      }
-    }
-    return const Color(0xFF006D77);
-  }
-}
-
 class SubwayLineOption {
   const SubwayLineOption({
     required this.id,
@@ -855,44 +815,12 @@ class SubwayLineOption {
     if (lineCode.trim().isNotEmpty) {
       return lineCode.trim();
     }
-    return _lineBadgeText(name);
+    return stationLineBadgeText(name);
   }
 
   String get semanticLabel => name;
 
-  Color get badgeColor {
-    final normalized = color.trim().replaceFirst('#', '');
-    if (normalized.length == 6) {
-      final parsed = int.tryParse(normalized, radix: 16);
-      if (parsed != null) {
-        return Color(0xFF000000 | parsed);
-      }
-    }
-    return const Color(0xFF006D77);
-  }
-}
-
-String _lineBadgeText(String name) {
-  for (final entry in StationSearchLine._knownBadgeLabels.entries) {
-    if (name.contains(entry.key)) {
-      return entry.value;
-    }
-  }
-
-  final numberedLine = RegExp(r'(\d+)\s*호선').firstMatch(name);
-  if (numberedLine != null) {
-    return numberedLine.group(1) ?? name;
-  }
-
-  final compactName = name
-      .replaceAll('수도권 ', '')
-      .replaceAll('광역 ', '')
-      .replaceAll('선', '')
-      .trim();
-  if (compactName.length <= 4) {
-    return compactName;
-  }
-  return compactName.substring(0, 4);
+  Color get badgeColor => stationLineColor(color);
 }
 
 String _requiredString(Map<String, Object?> json, String key) {
@@ -2224,7 +2152,7 @@ class _LineFilterBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textColor = _higherContrastTextColor(color);
+    final textColor = stationLineTextColor(color);
     final fontSize = RegExp(r'^\d+$').hasMatch(text) ? 20.0 : 12.0;
 
     return Container(
@@ -3981,129 +3909,6 @@ class _StationDetailTextPill extends StatelessWidget {
       ),
     );
   }
-}
-
-class StationLineBadges extends StatelessWidget {
-  const StationLineBadges({
-    required this.lines,
-    this.size = 40,
-    this.maxBadgeCount,
-    super.key,
-  });
-
-  final List<StationSearchLine> lines;
-  final double size;
-  final int? maxBadgeCount;
-
-  @override
-  Widget build(BuildContext context) {
-    if (lines.isEmpty) {
-      return const SizedBox.shrink();
-    }
-
-    final maxCount = maxBadgeCount;
-    final shouldCollapse = maxCount != null && lines.length > maxCount;
-    final visibleLineCount = shouldCollapse
-        ? (maxCount - 1).clamp(1, lines.length).toInt()
-        : lines.length;
-    final hiddenLineCount = lines.length - visibleLineCount;
-
-    return Wrap(
-      spacing: 8,
-      runSpacing: 8,
-      children: [
-        for (final line in lines.take(visibleLineCount))
-          StationLineBadge(line: line, size: size),
-        if (hiddenLineCount > 0)
-          _StationLineOverflowBadge(count: hiddenLineCount, size: size),
-      ],
-    );
-  }
-}
-
-class StationLineBadge extends StatelessWidget {
-  const StationLineBadge({required this.line, this.size = 40, super.key});
-
-  final StationSearchLine line;
-  final double size;
-
-  @override
-  Widget build(BuildContext context) {
-    final backgroundColor = line.badgeColor;
-    final foregroundColor = _higherContrastTextColor(backgroundColor);
-    final badgeText = line.badgeText;
-    final scale = size / 40;
-    final badgeFontSize = RegExp(r'^\d+$').hasMatch(badgeText)
-        ? 25.0 * scale
-        : 15.0 * scale;
-
-    return Container(
-      key: Key('stationLineBadge-${line.id}'),
-      width: size,
-      height: size,
-      alignment: Alignment.center,
-      decoration: BoxDecoration(color: backgroundColor, shape: BoxShape.circle),
-      child: Text(
-        badgeText,
-        textAlign: TextAlign.center,
-        maxLines: 2,
-        style: Theme.of(context).textTheme.titleMedium?.copyWith(
-          color: foregroundColor,
-          fontSize: badgeFontSize,
-          fontWeight: FontWeight.w900,
-          height: 1.05,
-        ),
-      ),
-    );
-  }
-}
-
-class _StationLineOverflowBadge extends StatelessWidget {
-  const _StationLineOverflowBadge({required this.count, required this.size});
-
-  final int count;
-  final double size;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      key: const Key('stationLineBadgeOverflow'),
-      width: size,
-      height: size,
-      alignment: Alignment.center,
-      decoration: BoxDecoration(
-        color: const Color(0xFFE8F0F1),
-        shape: BoxShape.circle,
-        border: Border.all(color: const Color(0xFFB8CACC)),
-      ),
-      child: Text(
-        '+$count',
-        textAlign: TextAlign.center,
-        style: Theme.of(context).textTheme.labelLarge?.copyWith(
-          color: const Color(0xFF29484B),
-          fontSize: 13 * (size / 32),
-          fontWeight: FontWeight.w900,
-          height: 1.0,
-        ),
-      ),
-    );
-  }
-}
-
-Color _higherContrastTextColor(Color backgroundColor) {
-  const darkText = Color(0xFF102A2C);
-  final darkContrast = _contrastRatio(backgroundColor, darkText);
-  final lightContrast = _contrastRatio(backgroundColor, Colors.white);
-  return darkContrast >= lightContrast ? darkText : Colors.white;
-}
-
-double _contrastRatio(Color first, Color second) {
-  final firstLuminance = first.computeLuminance() + 0.05;
-  final secondLuminance = second.computeLuminance() + 0.05;
-  if (firstLuminance > secondLuminance) {
-    return firstLuminance / secondLuminance;
-  }
-  return secondLuminance / firstLuminance;
 }
 
 Uri defaultStationApiBaseUri() {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4570,6 +4570,8 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   const onboardingTest = read("apps/mobile/test/onboarding_test.dart");
   const routeSearch = read("apps/mobile/lib/route_search.dart");
   const stationSearch = read("apps/mobile/lib/station_search.dart");
+  const stationLineBadges = read("apps/mobile/lib/features/stations/presentation/station_line_badges.dart");
+  const stationLine = read("apps/mobile/lib/features/stations/domain/station_line.dart");
   const stationApiRepository = read(
     "apps/mobile/lib/features/stations/data/station_api_repository.dart",
   );
@@ -4714,6 +4716,12 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(facilityReportTest, /시설 신고 임시 대상 저장소는 secure storage 복원 실패 시 저장값을 지운다/);
   assert.match(facilityReportTest, /시설 신고 임시 대상 저장소는 secure storage 삭제 실패에도 null로 복구한다/);
   assert.ok(existsSync(path.join(root, "apps/mobile/lib/station_search.dart")));
+  assert.match(stationSearch, /features\/stations\/presentation\/station_line_badges\.dart/);
+  assert.doesNotMatch(stationSearch, /class StationLineBadges|class StationLineBadge/);
+  assert.match(stationLineBadges, /class StationLineBadges extends StatelessWidget/);
+  assert.match(stationLineBadges, /class StationLineBadge extends StatelessWidget/);
+  assert.match(stationLine, /class StationSearchLine/);
+  assert.match(routeSearch, /features\/stations\/presentation\/station_line_badges\.dart/);
   assert.match(stationApiRepository, /typedef FavoriteStationAuthProvider = AuthorizationHeaderProvider/);
   assert.match(stationSearch, /final double\? latitude/);
   assert.match(stationSearch, /final double\? longitude/);


### PR DESCRIPTION
## 관련 이슈

close #660

## 작업 배경

`station_search.dart`가 역 검색 모델, 화면, 세부 위젯을 계속 함께 들고 있어 task9의 large file split 잔여 범위를 막고 있습니다. 이번 PR은 동작 변경 없이 노선 배지 표시만 feature presentation 경계로 분리합니다.

## 작업 내용

- `StationLineBadges`, `StationLineBadge`를 `apps/mobile/lib/features/stations/presentation/station_line_badges.dart`로 이동했습니다.
- `StationSearchLine`과 노선 배지 텍스트/색상 helper를 `apps/mobile/lib/features/stations/domain/station_line.dart`로 분리했습니다.
- `station_search.dart`는 새 presentation 파일을 import하고, 기존 테스트 호환을 위해 `StationSearchLine`은 export합니다.
- `route_search.dart`는 노선 배지 presentation 파일을 직접 import합니다.
- repository contract에 배지 presentation 분리 기준을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/features/stations/domain/station_line.dart apps/mobile/lib/features/stations/presentation/station_line_badges.dart apps/mobile/lib/station_search.dart apps/mobile/lib/route_search.dart`: 0 changed
  - `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "모바일 스캐폴드"`: 102 tests passed
  - `flutter test test/station_search_test.dart test/route_search_test.dart`: 47 tests passed
  - `flutter analyze`: No issues found
  - `node --test tools/ci/*.test.mjs`: 102 tests passed
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| presentation split contract | local Node.js | repository contract | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "모바일 스캐폴드"` | 102 tests passed |
| station/route behavior | Flutter test | targeted station/route tests | `flutter test test/station_search_test.dart test/route_search_test.dart` | 47 tests passed |
| static analysis | Flutter analyzer | analyzer gate | `flutter analyze` | No issues found |
| repository contracts | local Node.js | full CI contract tests | `node --test tools/ci/*.test.mjs` | 102 tests passed |
| formatting | local Dart/git | formatter and whitespace check | `dart format ...`, `git diff --check` | 0 changed, exit 0 |
| UI screenshot | 해당 없음 | pure presentation file move | 렌더링/문구/상태 변경 없음 | 증거 불필요 |

## 리뷰어 메모

- 이 PR은 노선 배지 구현 위치만 분리합니다. 검색/상세/길찾기 화면 동작과 badge rendering 값은 유지했습니다.
- `StationSearchLine`은 기존 테스트 import 호환을 위해 `station_search.dart`에서 export합니다.

## 리스크

- `station_search.dart` 자체는 여전히 큽니다. 이번 PR은 task9 전체 완료가 아니라 노선 배지 presentation 분리 slice입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
