### PR TITLE
[Feat] 설정 화면을 교통약자 사용 맥락으로 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1268,6 +1268,7 @@ class _AppSettingsActionTile extends StatelessWidget {
     return Semantics(
       button: true,
       label: '$title, $subtitle',
+      onTap: onTap,
       child: ExcludeSemantics(
         child: ListTile(
           onTap: onTap,

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -409,6 +409,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         notificationPermissionProvider: widget.notificationPermissionProvider,
         locationProvider: widget.locationProvider,
         initialMobilityType: onboardingResult?.profile.mobilityType,
+        viewPreferences: preferences,
         simpleViewEnabled: preferences.simpleViewEnabled,
         facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
         supportAccessInfo: widget.supportAccessInfo,
@@ -761,6 +762,7 @@ class HomeScreen extends StatefulWidget {
     required this.userDataDeletionRepository,
     required this.onUserDataDeleted,
     required this.onMobilityProfileChanged,
+    this.viewPreferences = const OnboardingViewPreferences.defaults(),
     this.simpleViewEnabled = true,
     this.facilityReportDraftTargetStore,
     String? initialMobilityType,
@@ -787,6 +789,7 @@ class HomeScreen extends StatefulWidget {
   final Future<void> Function(MobilityProfileOption profile)?
   onMobilityProfileChanged;
   final String initialMobilityType;
+  final OnboardingViewPreferences viewPreferences;
   final bool simpleViewEnabled;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
 
@@ -860,6 +863,21 @@ class _HomeScreenState extends State<HomeScreen> {
             launcher: supportAccessLauncher,
             userDataDeletionRepository: userDataDeletionRepository,
             onUserDataDeleted: onUserDataDeleted,
+          ),
+        ),
+      );
+    }
+
+    void openSettings() {
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => AppSettingsScreen(
+            currentProfile: currentProfile,
+            viewPreferences: widget.viewPreferences,
+            notificationRepository: notificationRepository,
+            notificationPermissionProvider: notificationPermissionProvider,
+            onOpenMobilityProfile: _openMobilityProfile,
+            onOpenSupportAccess: openSupportAccess,
           ),
         ),
       );
@@ -960,28 +978,11 @@ class _HomeScreenState extends State<HomeScreen> {
               groupKey: const Key('homeSettingsActionsGroup'),
               children: [
                 AccessibleShortcutButton(
-                  key: const Key('mobilityProfileButton'),
-                  onPressed: _openMobilityProfile,
-                  icon: const Icon(Icons.accessibility_new),
-                  label: '이동 조건',
+                  key: const Key('appSettingsButton'),
+                  onPressed: openSettings,
+                  icon: const Icon(Icons.settings_outlined),
+                  label: '설정',
                 ),
-                if (notificationRepository != null)
-                  AccessibleShortcutButton(
-                    key: const Key('notificationSettingsButton'),
-                    onPressed: () {
-                      Navigator.of(context).push(
-                        MaterialPageRoute<void>(
-                          builder: (_) => NotificationSettingsScreen(
-                            repository: notificationRepository,
-                            notificationPermissionProvider:
-                                notificationPermissionProvider,
-                          ),
-                        ),
-                      );
-                    },
-                    icon: const Icon(Icons.notifications_active_outlined),
-                    label: '알림 설정',
-                  ),
               ],
             ),
             const SizedBox(height: 18),
@@ -1036,7 +1037,7 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  Future<void> _openMobilityProfile() async {
+  Future<MobilityProfileOption?> _openMobilityProfile() async {
     final currentProfile = mobilityProfileOptions.firstWhere(
       (option) => option.mobilityType == _mobilityType,
       orElse: () => mobilityProfileOptions.first,
@@ -1047,17 +1048,298 @@ class _HomeScreenState extends State<HomeScreen> {
       ),
     );
     if (!mounted || selectedProfile == null) {
-      return;
+      return null;
     }
     setState(() {
       _mobilityType = selectedProfile.mobilityType;
     });
     await widget.onMobilityProfileChanged?.call(selectedProfile);
     if (!mounted) {
-      return;
+      return null;
     }
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('${selectedProfile.title} 조건으로 변경했습니다')),
+    );
+    return selectedProfile;
+  }
+}
+
+class AppSettingsScreen extends StatefulWidget {
+  const AppSettingsScreen({
+    required this.currentProfile,
+    required this.viewPreferences,
+    required this.notificationRepository,
+    required this.notificationPermissionProvider,
+    required this.onOpenMobilityProfile,
+    required this.onOpenSupportAccess,
+    super.key,
+  });
+
+  final MobilityProfileOption currentProfile;
+  final OnboardingViewPreferences viewPreferences;
+  final NotificationSettingsRepository? notificationRepository;
+  final NotificationPermissionProvider? notificationPermissionProvider;
+  final Future<MobilityProfileOption?> Function() onOpenMobilityProfile;
+  final VoidCallback onOpenSupportAccess;
+
+  @override
+  State<AppSettingsScreen> createState() => _AppSettingsScreenState();
+}
+
+class _AppSettingsScreenState extends State<AppSettingsScreen> {
+  late MobilityProfileOption _profile = widget.currentProfile;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('설정')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+          children: [
+            _AppSettingsSection(
+              key: const Key('settingsSection-mobility'),
+              title: '내 이동 조건',
+              children: [
+                _AppSettingsActionTile(
+                  key: const Key('mobilityProfileButton'),
+                  icon: Icons.accessibility_new,
+                  title: _profile.title,
+                  subtitle: _profile.summary,
+                  onTap: () async {
+                    final selected = await widget.onOpenMobilityProfile();
+                    if (!mounted || selected == null) {
+                      return;
+                    }
+                    setState(() {
+                      _profile = selected;
+                    });
+                  },
+                ),
+              ],
+            ),
+            _AppSettingsSection(
+              key: const Key('settingsSection-reading'),
+              title: '화면과 읽기',
+              children: [
+                _AppSettingsInfoTile(
+                  icon: Icons.text_fields,
+                  title: widget.viewPreferences.largeTextEnabled
+                      ? '큰 글자 켜짐'
+                      : '기본 글자 크기',
+                  subtitle: widget.viewPreferences.highContrastEnabled
+                      ? '고대비 표시를 사용해요'
+                      : '기본 대비로 표시해요',
+                ),
+                _AppSettingsInfoTile(
+                  icon: Icons.visibility_outlined,
+                  title: widget.viewPreferences.simpleViewEnabled
+                      ? '간편 보기 켜짐'
+                      : '전체 보기 켜짐',
+                  subtitle: '핵심 행동을 먼저 보여줘요',
+                ),
+              ],
+            ),
+            _AppSettingsSection(
+              key: const Key('settingsSection-route'),
+              title: '경로 찾기',
+              children: [
+                _AppSettingsInfoTile(
+                  icon: Icons.route,
+                  title: '${_profile.title} 조건 적용 중',
+                  subtitle: _profile.summary,
+                ),
+              ],
+            ),
+            _AppSettingsSection(
+              key: const Key('settingsSection-region-data'),
+              title: '지역과 데이터',
+              children: const [
+                _AppSettingsInfoTile(
+                  icon: Icons.public,
+                  title: '수도권 우선',
+                  subtitle: '오프라인 데이터팩과 검증된 출처를 먼저 사용해요',
+                ),
+              ],
+            ),
+            _AppSettingsSection(
+              key: const Key('settingsSection-notification'),
+              title: '알림',
+              children: [
+                if (widget.notificationRepository == null)
+                  const _AppSettingsInfoTile(
+                    icon: Icons.notifications_off_outlined,
+                    title: '알림 설정 대기 중',
+                    subtitle: '실기기 QA 전에는 푸시 알림을 켜지 않아요',
+                  )
+                else
+                  _AppSettingsActionTile(
+                    key: const Key('notificationSettingsButton'),
+                    icon: Icons.notifications_active_outlined,
+                    title: '알림 설정',
+                    subtitle: '시설 상태, 신고 처리, 정보 갱신 알림을 관리해요',
+                    onTap: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => NotificationSettingsScreen(
+                            repository: widget.notificationRepository!,
+                            notificationPermissionProvider:
+                                widget.notificationPermissionProvider,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+              ],
+            ),
+            _AppSettingsSection(
+              key: const Key('settingsSection-help-privacy'),
+              title: '도움말과 개인정보',
+              children: [
+                _AppSettingsActionTile(
+                  key: const Key('settingsSupportPrivacyButton'),
+                  icon: Icons.privacy_tip_outlined,
+                  title: '도움말과 개인정보',
+                  subtitle: '지원, 개인정보 처리방침, 데이터 삭제 안내를 확인해요',
+                  onTap: widget.onOpenSupportAccess,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AppSettingsSection extends StatelessWidget {
+  const _AppSettingsSection({
+    required this.title,
+    required this.children,
+    super.key,
+  });
+
+  final String title;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 18),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Semantics(
+            header: true,
+            child: Text(
+              title,
+              style: textTheme.titleMedium?.copyWith(
+                color: EasySubwayAccessibleColors.text,
+                fontWeight: FontWeight.w900,
+                height: 1.25,
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          ...children,
+        ],
+      ),
+    );
+  }
+}
+
+class _AppSettingsActionTile extends StatelessWidget {
+  const _AppSettingsActionTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+    super.key,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: '$title, $subtitle',
+      child: ExcludeSemantics(
+        child: ListTile(
+          onTap: onTap,
+          minVerticalPadding: 12,
+          minLeadingWidth: 32,
+          leading: Icon(icon, color: EasySubwayAccessibleColors.primary),
+          title: Text(
+            title,
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: EasySubwayAccessibleColors.text,
+              fontWeight: FontWeight.w800,
+              height: 1.25,
+            ),
+          ),
+          subtitle: Text(
+            subtitle,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: EasySubwayAccessibleColors.mutedText,
+              height: 1.3,
+            ),
+          ),
+          trailing: const Icon(Icons.chevron_right),
+          shape: Border(
+            bottom: BorderSide(
+              color: Theme.of(context).colorScheme.outlineVariant,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AppSettingsInfoTile extends StatelessWidget {
+  const _AppSettingsInfoTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return MergeSemantics(
+      child: ListTile(
+        minVerticalPadding: 12,
+        minLeadingWidth: 32,
+        leading: Icon(icon, color: EasySubwayAccessibleColors.mutedText),
+        title: Text(
+          title,
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+            color: EasySubwayAccessibleColors.text,
+            fontWeight: FontWeight.w800,
+            height: 1.25,
+          ),
+        ),
+        subtitle: Text(
+          subtitle,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: EasySubwayAccessibleColors.mutedText,
+            height: 1.3,
+          ),
+        ),
+        shape: Border(
+          bottom: BorderSide(
+            color: Theme.of(context).colorScheme.outlineVariant,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -484,6 +484,14 @@ void main() {
 
       await _openSettingsScreen(tester);
 
+      settingsActionSemantics(String label) {
+        return tester.getSemantics(
+          find.byWidgetPredicate(
+            (widget) => widget is Semantics && widget.properties.label == label,
+          ),
+        );
+      }
+
       expect(find.text('설정'), findsOneWidget);
       expect(find.text('내 이동 조건'), findsOneWidget);
       expect(find.text('화면과 읽기'), findsOneWidget);
@@ -495,6 +503,12 @@ void main() {
       expect(find.text('고대비 표시를 사용해요'), findsOneWidget);
       expect(find.text('전체 보기 켜짐'), findsOneWidget);
       expect(find.byKey(const Key('mobilityProfileButton')), findsOneWidget);
+      expect(
+        settingsActionSemantics(
+          '고령자, 계단을 피하고 쉬운 환승을 우선해요',
+        ).getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
+      );
       await tester.tap(find.byKey(const Key('mobilityProfileButton')));
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('mobilityProfileCard-wheelchair')));
@@ -523,6 +537,18 @@ void main() {
       expect(
         find.byKey(const Key('settingsSupportPrivacyButton')),
         findsOneWidget,
+      );
+      expect(
+        settingsActionSemantics(
+          '알림 설정, 시설 상태, 신고 처리, 정보 갱신 알림을 관리해요',
+        ).getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
+      );
+      expect(
+        settingsActionSemantics(
+          '도움말과 개인정보, 지원, 개인정보 처리방침, 데이터 삭제 안내를 확인해요',
+        ).getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
       );
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -55,6 +55,30 @@ Future<void> _openFavoriteList(WidgetTester tester, {Key? tabKey}) async {
   }
 }
 
+Future<void> _openSettingsScreen(WidgetTester tester) async {
+  await tester.ensureVisible(find.byKey(const Key('appSettingsButton')));
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(const Key('appSettingsButton')));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openMobilityProfileFromSettings(WidgetTester tester) async {
+  await _openSettingsScreen(tester);
+  await tester.tap(find.byKey(const Key('mobilityProfileButton')));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openNotificationSettings(WidgetTester tester) async {
+  await _openSettingsScreen(tester);
+  await tester.scrollUntilVisible(
+    find.byKey(const Key('notificationSettingsButton')),
+    160,
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(const Key('notificationSettingsButton')));
+  await tester.pumpAndSettle();
+}
+
 void main() {
   testWidgets('홈에서 내 신고 화면으로 이동한다', (tester) async {
     final reportRepository = FakeFacilityReportRepository(
@@ -333,10 +357,11 @@ void main() {
       expect(find.byKey(const Key('homeTripControlPanel')), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '역 검색'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
-      expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '설정'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsNothing);
+      expect(find.widgetWithText(OutlinedButton, '알림 설정'), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '즐겨찾기'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '내 신고'), findsOneWidget);
-      expect(find.widgetWithText(OutlinedButton, '알림 설정'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '도움말'), findsNothing);
       expect(find.byKey(const Key('homeHelpActionButton')), findsOneWidget);
       expect(find.widgetWithText(TextButton, '도움말'), findsOneWidget);
@@ -356,35 +381,24 @@ void main() {
       final routeButtonSize = tester.getSize(
         find.byKey(const Key('routeSearchButton')),
       );
-      final profileButtonSize = tester.getSize(
-        find.byKey(const Key('mobilityProfileButton')),
+      final settingsButtonSize = tester.getSize(
+        find.byKey(const Key('appSettingsButton')),
       );
       final myReportsButtonSize = tester.getSize(
         find.byKey(const Key('myReportsButton')),
       );
-      final notificationButtonSize = tester.getSize(
-        find.byKey(const Key('notificationSettingsButton')),
-      );
 
       expect(stationButtonSize.height, greaterThanOrEqualTo(88));
       expect(routeButtonSize.height, greaterThanOrEqualTo(88));
-      expect(profileButtonSize.height, lessThanOrEqualTo(58));
+      expect(settingsButtonSize.height, lessThanOrEqualTo(58));
       expect(myReportsButtonSize.height, lessThanOrEqualTo(58));
-      expect(notificationButtonSize.height, lessThanOrEqualTo(58));
-      expect(profileButtonSize.height, lessThan(stationButtonSize.height));
+      expect(settingsButtonSize.height, lessThan(stationButtonSize.height));
       expect(myReportsButtonSize.height, lessThan(stationButtonSize.height));
-      expect(notificationButtonSize.height, lessThan(stationButtonSize.height));
 
       final settingsTop = tester.getTopLeft(find.text('개인 설정')).dy;
       final myInfoTop = tester.getTopLeft(find.text('내 정보')).dy;
       expect(
-        tester.getTopLeft(find.byKey(const Key('mobilityProfileButton'))).dy,
-        greaterThan(settingsTop),
-      );
-      expect(
-        tester
-            .getTopLeft(find.byKey(const Key('notificationSettingsButton')))
-            .dy,
+        tester.getTopLeft(find.byKey(const Key('appSettingsButton'))).dy,
         greaterThan(settingsTop),
       );
       expect(
@@ -434,17 +448,89 @@ void main() {
     await tester.drag(find.byType(ListView), const Offset(0, -700));
     await tester.pumpAndSettle();
 
-    final mobilityButton = find.byKey(const Key('mobilityProfileButton'));
+    final settingsButton = find.byKey(const Key('appSettingsButton'));
     final favoritesButton = find.byKey(const Key('favoritesButton'));
 
     expect(EasySubwayTouchTarget.iconOnly, 48);
     expect(EasySubwayTouchTarget.general, 56);
     expect(EasySubwayTouchTarget.primary, 60);
-    expect(find.text('이동 조건'), findsOneWidget);
+    expect(find.text('설정'), findsOneWidget);
     expect(find.text('즐겨찾기'), findsOneWidget);
-    expect(tester.getSize(mobilityButton).height, greaterThan(56));
+    expect(tester.getSize(settingsButton).height, greaterThan(56));
     expect(tester.getSize(favoritesButton).height, greaterThan(56));
-    expect(tester.getSize(mobilityButton).height, greaterThanOrEqualTo(60));
+    expect(tester.getSize(settingsButton).height, greaterThanOrEqualTo(60));
+  });
+
+  testWidgets('설정 화면은 교통약자 사용 맥락별 섹션과 기존 설정 진입점을 제공한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
+          initialOnboardingState: _completedOnboardingStateWithPreferences(
+            preferences: const OnboardingViewPreferences(
+              largeTextEnabled: true,
+              highContrastEnabled: true,
+              simpleViewEnabled: false,
+            ),
+          ),
+        ),
+      );
+
+      await _openSettingsScreen(tester);
+
+      expect(find.text('설정'), findsOneWidget);
+      expect(find.text('내 이동 조건'), findsOneWidget);
+      expect(find.text('화면과 읽기'), findsOneWidget);
+      expect(find.text('경로 찾기'), findsOneWidget);
+      expect(find.text('지역과 데이터'), findsOneWidget);
+      expect(find.text('고령자'), findsOneWidget);
+      expect(find.text('계단을 피하고 쉬운 환승을 우선해요'), findsNWidgets(2));
+      expect(find.text('큰 글자 켜짐'), findsOneWidget);
+      expect(find.text('고대비 표시를 사용해요'), findsOneWidget);
+      expect(find.text('전체 보기 켜짐'), findsOneWidget);
+      expect(find.byKey(const Key('mobilityProfileButton')), findsOneWidget);
+      await tester.tap(find.byKey(const Key('mobilityProfileButton')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('mobilityProfileCard-wheelchair')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('mobilityProfileDoneButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('휠체어'), findsOneWidget);
+      expect(find.text('계단 없는 길만 안내해요'), findsNWidgets(2));
+
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('notificationSettingsButton')),
+        160,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('알림'), findsOneWidget);
+      expect(
+        find.byKey(const Key('settingsSection-help-privacy')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('notificationSettingsButton')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('settingsSupportPrivacyButton')),
+        findsOneWidget,
+      );
+
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+    } finally {
+      semanticsHandle.dispose();
+    }
   });
 
   testWidgets('홈 이동 조건 요약은 현재 profile과 변경 결과를 보여준다', (tester) async {
@@ -502,13 +588,12 @@ void main() {
       findsOneWidget,
     );
 
-    await tester.ensureVisible(find.byKey(const Key('mobilityProfileButton')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('mobilityProfileButton')));
-    await tester.pumpAndSettle();
+    await _openMobilityProfileFromSettings(tester);
     await tester.tap(find.byKey(const Key('mobilityProfileCard-wheelchair')));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('mobilityProfileDoneButton')));
+    await tester.pumpAndSettle();
+    await tester.pageBack();
     await tester.pumpAndSettle();
 
     expect(
@@ -1115,13 +1200,7 @@ void main() {
         ),
       );
 
-      await tester.scrollUntilVisible(
-        find.byKey(const Key('notificationSettingsButton')),
-        120,
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('notificationSettingsButton')));
-      await tester.pumpAndSettle();
+      await _openNotificationSettings(tester);
 
       expect(find.text('알림 설정'), findsOneWidget);
       expect(find.text('역 시설 알림'), findsOneWidget);
@@ -1177,13 +1256,7 @@ void main() {
       ),
     );
 
-    await tester.scrollUntilVisible(
-      find.byKey(const Key('notificationSettingsButton')),
-      120,
-    );
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('notificationSettingsButton')));
-    await tester.pumpAndSettle();
+    await _openNotificationSettings(tester);
 
     await tester.tap(find.byKey(const Key('notificationPermissionButton')));
     await tester.pumpAndSettle();
@@ -1222,13 +1295,7 @@ void main() {
       ),
     );
 
-    await tester.scrollUntilVisible(
-      find.byKey(const Key('notificationSettingsButton')),
-      120,
-    );
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('notificationSettingsButton')));
-    await tester.pumpAndSettle();
+    await _openNotificationSettings(tester);
     await tester.tap(find.byKey(const Key('notificationPermissionButton')));
     await tester.pumpAndSettle();
     await tester.tap(find.text('켜기'));
@@ -1260,13 +1327,7 @@ void main() {
         ),
       );
 
-      await tester.scrollUntilVisible(
-        find.byKey(const Key('notificationSettingsButton')),
-        120,
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('notificationSettingsButton')));
-      await tester.pumpAndSettle();
+      await _openNotificationSettings(tester);
       await tester.tap(find.byKey(const Key('notificationPermissionButton')));
       await tester.pumpAndSettle();
       await tester.tap(find.text('켜기'));
@@ -3059,8 +3120,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byKey(const Key('mobilityProfileButton')));
-      await tester.pumpAndSettle();
+      await _openMobilityProfileFromSettings(tester);
 
       expect(find.text('이동 조건'), findsOneWidget);
       expect(find.text('고령자'), findsOneWidget);
@@ -3119,8 +3179,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byKey(const Key('mobilityProfileButton')));
-      await tester.pumpAndSettle();
+      await _openMobilityProfileFromSettings(tester);
 
       expect(find.bySemanticsLabel('휠체어 선택됨, 계단 없는 길만 안내해요'), findsOneWidget);
       expect(find.text('휠체어 조건을 선택했습니다'), findsOneWidget);
@@ -3152,8 +3211,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byKey(const Key('mobilityProfileButton')));
-    await tester.pumpAndSettle();
+    await _openMobilityProfileFromSettings(tester);
     await tester.tap(find.byKey(const Key('mobilityProfileCard-wheelchair')));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('mobilityProfileDoneButton')));


### PR DESCRIPTION
## 관련 이슈

close #756

## 작업 배경

홈의 개인 설정 영역이 이동 조건과 알림을 직접 나열하면서 화면이 다시 메뉴처럼 늘어날 위험이 있었습니다. 이번 PR은 설정을 하나의 진입점으로 묶고, 교통약자 사용자가 먼저 찾는 이동 조건과 읽기/경로/데이터/알림/개인정보 섹션을 한 화면에 정리합니다.

## 작업 내용

- 홈 개인 설정 영역을 `설정` 단일 진입점으로 정리했습니다.
- 설정 화면에 내 이동 조건, 화면과 읽기, 경로 찾기, 지역과 데이터, 알림, 도움말과 개인정보 섹션을 추가했습니다.
- 기존 이동 조건, 알림 설정, 도움말/개인정보 화면은 새 설정 화면에서 그대로 연결합니다.
- 알림 저장소가 없는 기본 앱에서는 푸시 알림을 켜지 않는 상태를 설정 화면에 명시합니다.
- 홈/설정/이동 조건/알림 widget 테스트를 새 흐름에 맞게 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --name "설정"`: 9 tests passed
  - `cd apps/mobile && flutter test test/widget_test.dart --name "설정 화면은 교통약자 사용 맥락별 섹션과 기존 설정 진입점을 제공한다"`: 1 test passed
  - `cd apps/mobile && flutter test test/widget_test.dart --name "홈|이동 조건|알림 설정"`: 25 tests passed
  - `cd apps/mobile && flutter test test/widget_test.dart`: 90 tests passed
  - `cd apps/mobile && flutter analyze`: No issues found
  - `cd apps/mobile && flutter build apk --debug`: Built `build/app/outputs/flutter-apk/app-debug.apk`
  - `node --test tools/ci/*.test.mjs`: 102 tests passed
  - `cd apps/mobile && flutter test test/easy_subway_app_defaults_test.dart`: 3 tests passed
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 설정 화면 섹션 | Android emulator `maum_on_api36` | debug APK 설치 후 설정 화면 screenshot | `.codex/evidence/756/android-after-semantics-fix-settings.png` | 설정 섹션 노출 확인 |
| 설정 화면 접근성 tree | Android emulator `maum_on_api36` | `uiautomator dump` XML | `.codex/evidence/756/android-after-semantics-fix-settings-ui.xml` | 이동 조건과 도움말/개인정보 action row가 `android.widget.Button`, `clickable=true`로 노출됨 |
| 홈 설정 진입점 | Android emulator `maum_on_api36` | `uiautomator dump` XML | `.codex/evidence/756/android-after-semantics-fix-home-ui.xml` | 홈에 `설정` 단일 진입점 확인 |
| large text/layout | Flutter widget test | 좁은 화면과 큰 글자 설정 테스트 | `flutter test test/widget_test.dart` | core text/섹션 테스트 통과 |
| iOS | local environment | 대체 검증 | Flutter widget tests, `flutter doctor -v` shows CocoaPods missing | iOS 실기/시뮬레이터 UI 증거는 이번 Android-first slice에서 미수집 |

## 리뷰어 메모

- 새 저장소, DB migration, 라우터 도입은 하지 않았습니다. 기존 화면을 설정 화면 아래로 모은 UI slice입니다.
- notification repository가 없는 기본 앱에서는 기존처럼 푸시 설정을 활성화하지 않습니다.

## 리스크

- 설정 값 편집은 아직 이동 조건과 알림 설정에 한정됩니다. 화면/읽기, 지역/데이터, 경로 찾기 세부 편집은 후속 slice에서 별도 저장소와 함께 다루는 편이 안전합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
