### PR TITLE
[Style] 사용자 앱 핵심 화면 v3 디자인 반영

### DIFF
--- a/apps/mobile/lib/accessible_design.dart
+++ b/apps/mobile/lib/accessible_design.dart
@@ -12,6 +12,8 @@ class EasySubwayAccessibleColors {
   static const mintBorder = Color(0xFFCBEADD);
   static const amberSoft = Color(0xFFFFF0D1);
   static const amber = Color(0xFF9A5600);
+  static const redSoft = Color(0xFFFFE8E6);
+  static const red = Color(0xFFB42318);
   static const skySoft = Color(0xFFE6F5FF);
   static const line = Color(0xFFDBE3E9);
   static const text = Color(0xFF102A2C);

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -892,6 +892,15 @@ class _HomeScreenState extends State<HomeScreen> {
       );
     }
 
+    void openMyReports() {
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) =>
+              MyFacilityReportListScreen(repository: reportRepository),
+        ),
+      );
+    }
+
     void openSettings() {
       Navigator.of(context).push(
         MaterialPageRoute<void>(
@@ -902,6 +911,7 @@ class _HomeScreenState extends State<HomeScreen> {
             notificationPermissionProvider: notificationPermissionProvider,
             onOpenMobilityProfile: _openMobilityProfile,
             onOpenSupportAccess: openSupportAccess,
+            onOpenMyReports: openMyReports,
           ),
         ),
       );
@@ -2064,6 +2074,7 @@ class AppSettingsScreen extends StatefulWidget {
     required this.notificationPermissionProvider,
     required this.onOpenMobilityProfile,
     required this.onOpenSupportAccess,
+    required this.onOpenMyReports,
     super.key,
   });
 
@@ -2073,6 +2084,7 @@ class AppSettingsScreen extends StatefulWidget {
   final NotificationPermissionProvider? notificationPermissionProvider;
   final Future<MobilityProfileOption?> Function() onOpenMobilityProfile;
   final VoidCallback onOpenSupportAccess;
+  final VoidCallback onOpenMyReports;
 
   @override
   State<AppSettingsScreen> createState() => _AppSettingsScreenState();
@@ -2182,6 +2194,19 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
                       );
                     },
                   ),
+              ],
+            ),
+            _AppSettingsSection(
+              key: const Key('settingsSection-activity'),
+              title: '내 활동',
+              children: [
+                _AppSettingsActionTile(
+                  key: const Key('myReportsSettingsButton'),
+                  icon: Icons.receipt_long_outlined,
+                  title: '내 신고',
+                  subtitle: '접수한 시설 신고와 처리 상태를 확인해요',
+                  onTap: widget.onOpenMyReports,
+                ),
               ],
             ),
             _AppSettingsSection(

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -815,6 +815,7 @@ class _HomeScreenState extends State<HomeScreen> {
   late String _mobilityType;
   late final RouteDraftController _routeDraftController;
   Future<List<FavoriteRoute>>? _favoriteRoutesFuture;
+  Future<List<FavoriteFacility>>? _favoriteFacilitiesFuture;
 
   @override
   void initState() {
@@ -823,6 +824,8 @@ class _HomeScreenState extends State<HomeScreen> {
     _routeDraftController = RouteDraftController();
     _favoriteRoutesFuture = widget.favoriteRouteRepository
         ?.listFavoriteRoutes();
+    _favoriteFacilitiesFuture = widget.favoriteFacilityRepository
+        ?.listFavoriteFacilities();
   }
 
   @override
@@ -841,6 +844,11 @@ class _HomeScreenState extends State<HomeScreen> {
     if (widget.favoriteRouteRepository != oldWidget.favoriteRouteRepository) {
       _favoriteRoutesFuture = widget.favoriteRouteRepository
           ?.listFavoriteRoutes();
+    }
+    if (widget.favoriteFacilityRepository !=
+        oldWidget.favoriteFacilityRepository) {
+      _favoriteFacilitiesFuture = widget.favoriteFacilityRepository
+          ?.listFavoriteFacilities();
     }
   }
 
@@ -871,11 +879,6 @@ class _HomeScreenState extends State<HomeScreen> {
       (option) => option.mobilityType == _mobilityType,
       orElse: () => mobilityProfileOptions.first,
     );
-    final hasFavorites =
-        favoriteRepository != null ||
-        favoriteFacilityRepository != null ||
-        favoriteRouteRepository != null;
-    final hasFavoriteRoutes = favoriteRouteRepository != null;
     void openSupportAccess() {
       Navigator.of(context).push(
         MaterialPageRoute<void>(
@@ -904,6 +907,21 @@ class _HomeScreenState extends State<HomeScreen> {
       );
     }
 
+    void openNotificationSettings() {
+      final repository = notificationRepository;
+      if (repository == null) {
+        return;
+      }
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => NotificationSettingsScreen(
+            repository: repository,
+            notificationPermissionProvider: notificationPermissionProvider,
+          ),
+        ),
+      );
+    }
+
     void openStationSearch() {
       Navigator.of(context).push(
         MaterialPageRoute<void>(
@@ -923,16 +941,22 @@ class _HomeScreenState extends State<HomeScreen> {
     }
 
     Future<void> refreshHomeState() async {
-      final repository = widget.favoriteRouteRepository;
-      if (repository == null) {
+      final routeRepository = widget.favoriteRouteRepository;
+      final facilityRepository = widget.favoriteFacilityRepository;
+      if (routeRepository == null && facilityRepository == null) {
         return;
       }
-      final routesFuture = repository.listFavoriteRoutes();
+      final routesFuture = routeRepository?.listFavoriteRoutes();
+      final facilitiesFuture = facilityRepository?.listFavoriteFacilities();
       setState(() {
         _favoriteRoutesFuture = routesFuture;
+        _favoriteFacilitiesFuture = facilitiesFuture;
       });
       try {
-        await routesFuture;
+        await Future.wait<void>([
+          if (routesFuture != null) routesFuture.then((_) {}),
+          if (facilitiesFuture != null) facilitiesFuture.then((_) {}),
+        ]);
       } catch (error, stackTrace) {
         (error, stackTrace);
         // FutureBuilder가 오류 상태를 표시하므로 refresh callback은 정상 종료한다.
@@ -981,24 +1005,25 @@ class _HomeScreenState extends State<HomeScreen> {
       await refreshHomeState();
     }
 
-    void openReports() {
-      Navigator.of(context).push(
-        MaterialPageRoute<void>(
-          builder: (_) =>
-              MyFacilityReportListScreen(repository: reportRepository),
-        ),
-      );
+    void openSavedItems() {
+      if (favoriteRepository == null &&
+          favoriteFacilityRepository == null &&
+          favoriteRouteRepository == null) {
+        openSettings();
+        return;
+      }
+      unawaited(openFavorites());
     }
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('쉬운 지하철'),
         actions: [
-          IconButton(
-            key: const Key('homeHelpActionButton'),
-            onPressed: openSupportAccess,
-            icon: const Icon(Icons.help_outline),
-            tooltip: '도움말',
+          _HomeNotificationButton(
+            key: const Key('homeNotificationActionButton'),
+            onPressed: notificationRepository == null
+                ? openSettings
+                : openNotificationSettings,
           ),
           const SizedBox(width: 8),
         ],
@@ -1016,6 +1041,8 @@ class _HomeScreenState extends State<HomeScreen> {
                 profile: currentProfile,
                 onRouteSearch: openRouteSearch,
                 onStationSearch: openStationSearch,
+                onNetworkMap: openStationSearch,
+                onProfileTap: openSettings,
               ),
               AnimatedBuilder(
                 animation: _routeDraftController,
@@ -1030,33 +1057,72 @@ class _HomeScreenState extends State<HomeScreen> {
                   );
                 },
               ),
-              _HomePrototypeSection(
-                title: '지금 주변 상태',
-                action: TextButton(
-                  onPressed: openStationSearch,
-                  child: const Text('주변 역 보기'),
-                ),
+              _HomeFacilityAlertSection(
+                facilitiesFuture: _favoriteFacilitiesFuture,
               ),
-              _HomeStatusUnavailableCard(onTap: openStationSearch),
-              if (hasFavoriteRoutes) ...[
-                _HomePrototypeSection(title: '자주 가는 곳'),
-                _HomeSavedRouteSection(
-                  key: const Key('homeSavedRouteSection'),
-                  routesFuture: _favoriteRoutesFuture,
-                  onOpenFavorites: openFavorites,
-                ),
-              ],
-              const _HomePrototypeSection(title: '바로가기'),
-              _HomeShortcutGrid(
-                hasFavorites: hasFavorites,
-                onNearby: openStationSearch,
-                onReports: openReports,
-                onFavorites: openFavorites,
-                onSettings: openSettings,
+              _HomeSavedRouteSection(
+                key: const Key('homeSavedRouteSection'),
+                routesFuture: _favoriteRoutesFuture,
+                onOpenFavorites: openFavorites,
               ),
             ],
           ),
         ),
+      ),
+      bottomNavigationBar: NavigationBar(
+        key: const Key('homeBottomNavigationBar'),
+        selectedIndex: 0,
+        height: 72,
+        onDestinationSelected: (index) {
+          switch (index) {
+            case 0:
+              break;
+            case 1:
+              openStationSearch();
+              break;
+            case 2:
+              unawaited(openRouteSearch());
+              break;
+            case 3:
+              openSavedItems();
+              break;
+            case 4:
+              openSettings();
+              break;
+          }
+        },
+        destinations: const [
+          NavigationDestination(
+            key: Key('bottomNavHome'),
+            icon: Icon(Icons.home_outlined),
+            selectedIcon: Icon(Icons.home),
+            label: '홈',
+          ),
+          NavigationDestination(
+            key: Key('bottomNavMap'),
+            icon: Icon(Icons.map_outlined),
+            selectedIcon: Icon(Icons.map),
+            label: '노선도',
+          ),
+          NavigationDestination(
+            key: Key('bottomNavRoute'),
+            icon: Icon(Icons.route_outlined),
+            selectedIcon: Icon(Icons.route),
+            label: '길찾기',
+          ),
+          NavigationDestination(
+            key: Key('bottomNavSaved'),
+            icon: Icon(Icons.bookmark_border),
+            selectedIcon: Icon(Icons.bookmark),
+            label: '저장',
+          ),
+          NavigationDestination(
+            key: Key('bottomNavMore'),
+            icon: Icon(Icons.more_horiz),
+            selectedIcon: Icon(Icons.more),
+            label: '더보기',
+          ),
+        ],
       ),
     );
   }
@@ -1088,23 +1154,88 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 }
 
+class _HomeNotificationButton extends StatelessWidget {
+  const _HomeNotificationButton({required this.onPressed, super.key});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: '알림',
+      onTap: onPressed,
+      child: ExcludeSemantics(
+        child: Tooltip(
+          message: '알림',
+          child: InkWell(
+            onTap: onPressed,
+            borderRadius: BorderRadius.circular(14),
+            child: SizedBox(
+              width: 48,
+              height: 48,
+              child: Stack(
+                clipBehavior: Clip.none,
+                alignment: Alignment.center,
+                children: [
+                  DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      border: Border.all(
+                        color: EasySubwayAccessibleColors.mintBorder,
+                      ),
+                      borderRadius: BorderRadius.circular(14),
+                    ),
+                    child: const SizedBox(width: 44, height: 44),
+                  ),
+                  const Icon(
+                    Icons.notifications_none,
+                    color: EasySubwayAccessibleColors.mintDark,
+                    size: 26,
+                  ),
+                  Positioned(
+                    top: 9,
+                    right: 9,
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: EasySubwayAccessibleColors.red,
+                        border: Border.all(color: Colors.white, width: 2),
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                      child: const SizedBox(width: 10, height: 10),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _HomePrototypeHero extends StatelessWidget {
   const _HomePrototypeHero({
     required this.profile,
     required this.onRouteSearch,
     required this.onStationSearch,
+    required this.onNetworkMap,
+    required this.onProfileTap,
   });
 
   final MobilityProfileOption profile;
   final VoidCallback onRouteSearch;
   final VoidCallback onStationSearch;
+  final VoidCallback onNetworkMap;
+  final VoidCallback onProfileTap;
 
   @override
   Widget build(BuildContext context) {
     return Semantics(
       container: true,
       explicitChildNodes: true,
-      label: '길찾기 시작, 현재 이동 조건 ${profile.title}',
+      label: '길찾기와 노선도, 현재 이동 조건 ${profile.title}',
       child: DecoratedBox(
         decoration: BoxDecoration(
           gradient: const LinearGradient(
@@ -1134,7 +1265,7 @@ class _HomePrototypeHero extends StatelessWidget {
                   Expanded(
                     child: ExcludeSemantics(
                       child: Text(
-                        '길찾기',
+                        '어디로 가시나요?',
                         style: Theme.of(context).textTheme.headlineSmall
                             ?.copyWith(
                               color: Colors.white,
@@ -1144,7 +1275,7 @@ class _HomePrototypeHero extends StatelessWidget {
                       ),
                     ),
                   ),
-                  _HomeProfilePill(profile: profile),
+                  _HomeProfilePill(profile: profile, onTap: onProfileTap),
                 ],
               ),
               const SizedBox(height: 18),
@@ -1160,49 +1291,93 @@ class _HomePrototypeHero extends StatelessWidget {
                         child: FilledButton.icon(
                           onPressed: onRouteSearch,
                           style: FilledButton.styleFrom(
-                            backgroundColor: Colors.white,
-                            foregroundColor:
-                                EasySubwayAccessibleColors.brandDark,
-                            minimumSize: const Size.fromHeight(
-                              EasySubwayTouchTarget.primary,
-                            ),
+                            backgroundColor: EasySubwayAccessibleColors.mint,
+                            foregroundColor: Colors.white,
+                            minimumSize: const Size.fromHeight(104),
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(15),
                             ),
                             textStyle: const TextStyle(
-                              fontSize: 16,
+                              fontSize: 22,
                               fontWeight: FontWeight.w900,
                             ),
                           ),
                           icon: const Icon(Icons.route),
-                          label: const Text('길찾기 시작'),
+                          label: const Text('길찾기'),
                         ),
                       ),
                     ),
                   ),
                   const SizedBox(width: 9),
-                  SizedBox(
-                    width: 55,
-                    height: 52,
+                  Expanded(
                     child: Semantics(
-                      key: const Key('stationSearchButton'),
+                      key: const Key('networkMapButton'),
                       button: true,
-                      label: '역 검색',
-                      onTap: onStationSearch,
+                      label: '노선도',
+                      onTap: onNetworkMap,
                       child: ExcludeSemantics(
-                        child: OutlinedButton(
-                          onPressed: onStationSearch,
+                        child: FilledButton.icon(
+                          onPressed: onNetworkMap,
                           style: OutlinedButton.styleFrom(
-                            foregroundColor: Colors.white,
-                            side: const BorderSide(color: Color(0x59FFFFFF)),
+                            backgroundColor: Colors.white,
+                            foregroundColor:
+                                EasySubwayAccessibleColors.brandDark,
+                            minimumSize: const Size.fromHeight(104),
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(15),
                             ),
-                            padding: EdgeInsets.zero,
+                            textStyle: const TextStyle(
+                              fontSize: 22,
+                              fontWeight: FontWeight.w900,
+                            ),
                           ),
-                          child: const Icon(Icons.search, size: 22),
+                          icon: const Icon(Icons.map_outlined),
+                          label: const Text('노선도'),
                         ),
                       ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      key: const Key('stationSearchButton'),
+                      onPressed: onStationSearch,
+                      style: OutlinedButton.styleFrom(
+                        backgroundColor: Colors.white,
+                        foregroundColor: EasySubwayAccessibleColors.brandDark,
+                        side: BorderSide.none,
+                        minimumSize: const Size.fromHeight(
+                          EasySubwayTouchTarget.general,
+                        ),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(13),
+                        ),
+                      ),
+                      icon: const Icon(Icons.search),
+                      label: const Text('역 검색'),
+                    ),
+                  ),
+                  const SizedBox(width: 9),
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: onStationSearch,
+                      style: OutlinedButton.styleFrom(
+                        backgroundColor: Colors.white,
+                        foregroundColor: EasySubwayAccessibleColors.brandDark,
+                        side: BorderSide.none,
+                        minimumSize: const Size.fromHeight(
+                          EasySubwayTouchTarget.general,
+                        ),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(13),
+                        ),
+                      ),
+                      icon: const Icon(Icons.location_on_outlined),
+                      label: const Text('가까운 역'),
                     ),
                   ),
                 ],
@@ -1216,34 +1391,53 @@ class _HomePrototypeHero extends StatelessWidget {
 }
 
 class _HomeProfilePill extends StatelessWidget {
-  const _HomeProfilePill({required this.profile});
+  const _HomeProfilePill({required this.profile, required this.onTap});
 
   final MobilityProfileOption profile;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.11),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.26)),
-        borderRadius: BorderRadius.circular(999),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(Icons.directions_walk, size: 16, color: Colors.white),
-            const SizedBox(width: 7),
-            Text(
-              profile.title,
-              style: const TextStyle(
-                color: Colors.white,
-                fontSize: 12,
-                fontWeight: FontWeight.w800,
+    return Semantics(
+      button: true,
+      label: '현재 이동 조건 ${profile.title}',
+      onTap: onTap,
+      child: ExcludeSemantics(
+        child: InkWell(
+          key: const Key('homeProfilePill'),
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(999),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(minHeight: 48),
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.11),
+                border: Border.all(color: Colors.white.withValues(alpha: 0.26)),
+                borderRadius: BorderRadius.circular(999),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 9,
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(profile.icon, size: 16, color: Colors.white),
+                    const SizedBox(width: 7),
+                    Text(
+                      profile.title,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ],
+          ),
         ),
       ),
     );
@@ -1338,95 +1532,183 @@ class _HomeRouteDraftCard extends StatelessWidget {
 }
 
 class _HomePrototypeSection extends StatelessWidget {
-  const _HomePrototypeSection({required this.title, this.action});
+  const _HomePrototypeSection({required this.title});
 
   final String title;
-  final Widget? action;
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(1, 22, 1, 11),
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final titleBlock = Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                title,
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: EasySubwayAccessibleColors.text,
-                  fontWeight: FontWeight.w900,
-                  height: 1.2,
-                ),
-              ),
-            ],
-          );
-          if (action == null) {
-            return titleBlock;
-          }
-          if (constraints.maxWidth < 340) {
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                titleBlock,
-                const SizedBox(height: 6),
-                Align(alignment: Alignment.centerRight, child: action!),
-              ],
-            );
-          }
-          return Row(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Expanded(child: titleBlock),
-              action!,
-            ],
-          );
-        },
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+          color: EasySubwayAccessibleColors.text,
+          fontWeight: FontWeight.w900,
+          height: 1.2,
+        ),
       ),
     );
   }
 }
 
-class _HomeStatusUnavailableCard extends StatelessWidget {
-  const _HomeStatusUnavailableCard({required this.onTap});
+class _HomeFacilityAlertSection extends StatelessWidget {
+  const _HomeFacilityAlertSection({required this.facilitiesFuture});
 
-  final VoidCallback onTap;
+  final Future<List<FavoriteFacility>>? facilitiesFuture;
 
   @override
   Widget build(BuildContext context) {
+    final facilitiesFuture = this.facilitiesFuture;
+    if (facilitiesFuture == null) {
+      return const SizedBox.shrink();
+    }
+    return FutureBuilder<List<FavoriteFacility>>(
+      future: facilitiesFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done ||
+            snapshot.hasError) {
+          return const SizedBox.shrink();
+        }
+        final alert = _firstFacilityAlert(
+          snapshot.data ?? const <FavoriteFacility>[],
+        );
+        if (alert == null) {
+          return const SizedBox.shrink();
+        }
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const _HomePrototypeSection(title: '시설 알림'),
+            _HomeFacilityAlertCard(facility: alert),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _HomeFacilityAlertCard extends StatelessWidget {
+  const _HomeFacilityAlertCard({required this.facility});
+
+  final FavoriteFacility facility;
+
+  @override
+  Widget build(BuildContext context) {
+    final facilityName = facility.name.trim().isEmpty
+        ? facility.typeLabel
+        : facility.name;
     return _PrototypeCard(
-      backgroundColor: const Color(0xFFFFFAF0),
-      borderColor: const Color(0xFFF1D49A),
+      backgroundColor: EasySubwayAccessibleColors.redSoft,
+      borderColor: EasySubwayAccessibleColors.red,
       child: Column(
         children: [
-          const _PrototypeInfoRow(
-            icon: Icons.info_outline,
-            iconBackground: EasySubwayAccessibleColors.amberSoft,
-            iconColor: EasySubwayAccessibleColors.amber,
-            title: '주변 시설 상태 없음',
-            trailing: '확인 필요',
+          _PrototypeInfoRow(
+            icon: _facilityIcon(facility.type),
+            iconBackground: Colors.white,
+            iconColor: EasySubwayAccessibleColors.red,
+            title: '${facility.stationLabel} $facilityName',
+            subtitle: '${facility.typeLabel} ${facility.statusLabel}',
+            subtitleColor: EasySubwayAccessibleColors.red,
+            iconBoxSize: 56,
+            iconSize: 30,
           ),
           const SizedBox(height: 13),
-          SizedBox(
-            width: double.infinity,
-            child: OutlinedButton(
-              onPressed: onTap,
-              style: OutlinedButton.styleFrom(
-                minimumSize: const Size.fromHeight(
-                  EasySubwayTouchTarget.general,
-                ),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-              ),
-              child: const Text('주변 역 보기'),
-            ),
-          ),
+          _HomeFacilityNoticeMessage(facility: facility),
         ],
       ),
     );
   }
+}
+
+class _HomeFacilityNoticeMessage extends StatelessWidget {
+  const _HomeFacilityNoticeMessage({required this.facility});
+
+  final FavoriteFacility facility;
+
+  @override
+  Widget build(BuildContext context) {
+    final facilityName = facility.name.trim().isEmpty
+        ? facility.typeLabel
+        : facility.name;
+    final notice =
+        '$facilityName 상태가 ${facility.statusLabel}입니다. 다른 출구 또는 역무원 안내를 확인하세요.';
+    return Semantics(
+      container: true,
+      label: '주의, $notice',
+      child: ExcludeSemantics(
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 13, vertical: 12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '주의',
+                  style: TextStyle(
+                    color: EasySubwayAccessibleColors.red,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w900,
+                    height: 1.35,
+                  ),
+                ),
+                const SizedBox(width: 9),
+                Expanded(
+                  child: Text(
+                    notice,
+                    style: const TextStyle(
+                      color: EasySubwayAccessibleColors.text,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w800,
+                      height: 1.35,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+bool _isFacilityAlert(FavoriteFacility facility) {
+  return switch (facility.status) {
+    'BROKEN' ||
+    'UNDER_CONSTRUCTION' ||
+    'CONSTRUCTION' ||
+    'CLOSED' ||
+    'UNKNOWN' ||
+    'USER_REPORTED' ||
+    'NEEDS_REPORT' ||
+    'NEEDS_CHECK' => true,
+    _ => false,
+  };
+}
+
+FavoriteFacility? _firstFacilityAlert(List<FavoriteFacility> facilities) {
+  for (final facility in facilities) {
+    if (_isFacilityAlert(facility)) {
+      return facility;
+    }
+  }
+  return null;
+}
+
+IconData _facilityIcon(String type) {
+  return switch (type) {
+    'ELEVATOR' => Icons.elevator_outlined,
+    'ESCALATOR' => Icons.escalator_warning_outlined,
+    'WHEELCHAIR_LIFT' => Icons.accessible_forward,
+    'RAMP' => Icons.accessible,
+    'ACCESSIBLE_TOILET' || 'TOILET' => Icons.wc_outlined,
+    _ => Icons.warning_amber_outlined,
+  };
 }
 
 class _HomeSavedRouteSection extends StatelessWidget {
@@ -1443,43 +1725,35 @@ class _HomeSavedRouteSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final routesFuture = this.routesFuture;
     if (routesFuture == null) {
-      return const _HomeSavedRouteEmptyCard();
+      return const SizedBox.shrink();
     }
     return FutureBuilder<List<FavoriteRoute>>(
       future: routesFuture,
       builder: (context, snapshot) {
         if (snapshot.connectionState != ConnectionState.done) {
-          return const _HomeSavedRouteLoadingCard();
+          return const SizedBox.shrink();
         }
         if (snapshot.hasError) {
-          return _HomeSavedRouteErrorCard(onTap: onOpenFavorites);
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const _HomePrototypeSection(title: '최근 경로'),
+              _HomeSavedRouteErrorCard(onTap: onOpenFavorites),
+            ],
+          );
         }
         final routes = snapshot.data ?? const <FavoriteRoute>[];
         if (routes.isEmpty) {
-          return const _HomeSavedRouteEmptyCard();
+          return const SizedBox.shrink();
         }
-        return _HomeSavedRouteCard(route: routes.first, onTap: onOpenFavorites);
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const _HomePrototypeSection(title: '최근 경로'),
+            _HomeSavedRouteCard(route: routes.first, onTap: onOpenFavorites),
+          ],
+        );
       },
-    );
-  }
-}
-
-class _HomeSavedRouteLoadingCard extends StatelessWidget {
-  const _HomeSavedRouteLoadingCard();
-
-  @override
-  Widget build(BuildContext context) {
-    return const _PrototypeCard(
-      backgroundColor: EasySubwayAccessibleColors.skySoft,
-      borderColor: Color(0xFFB7DDF4),
-      child: _PrototypeInfoRow(
-        icon: Icons.bookmark_border,
-        iconBackground: Colors.white,
-        iconColor: EasySubwayAccessibleColors.brand,
-        title: '저장한 경로 확인 중',
-        subtitle: '자주 가는 경로를 불러오고 있어요',
-        trailing: '잠시만요',
-      ),
     );
   }
 }
@@ -1534,10 +1808,14 @@ class _HomeSavedRouteCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final originName = _stationNameWithSuffix(route.originStationName);
+    final destinationName = _stationNameWithSuffix(
+      route.destinationStationName,
+    );
     return Semantics(
       button: true,
       label:
-          '저장한 경로, ${route.summaryTitle}, ${route.lineLabel}, ${route.mobilityLabel}, ${route.scoreLabel}',
+          '최근 경로, $originName에서 $destinationName까지, ${route.lineLabel}, ${route.mobilityLabel}',
       onTap: onTap,
       child: ExcludeSemantics(
         child: InkWell(
@@ -1566,7 +1844,7 @@ class _HomeSavedRouteCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        '${route.originStationName} → ${route.destinationStationName}',
+                        '$originName → $destinationName',
                         style: const TextStyle(
                           color: EasySubwayAccessibleColors.text,
                           fontSize: 16,
@@ -1581,7 +1859,6 @@ class _HomeSavedRouteCard extends StatelessWidget {
                         children: [
                           _HomeMiniBadge(route.lineLabel),
                           _HomeMiniBadge(route.mobilityLabel),
-                          _HomeMiniBadge(route.scoreLabel),
                         ],
                       ),
                     ],
@@ -1599,6 +1876,10 @@ class _HomeSavedRouteCard extends StatelessWidget {
       ),
     );
   }
+}
+
+String _stationNameWithSuffix(String name) {
+  return name.endsWith('역') ? name : '$name역';
 }
 
 class _HomeMiniBadge extends StatelessWidget {
@@ -1622,180 +1903,6 @@ class _HomeMiniBadge extends StatelessWidget {
             fontSize: 11,
             fontWeight: FontWeight.w900,
             height: 1.2,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _HomeSavedRouteEmptyCard extends StatelessWidget {
-  const _HomeSavedRouteEmptyCard();
-
-  @override
-  Widget build(BuildContext context) {
-    return _PrototypeCard(
-      backgroundColor: EasySubwayAccessibleColors.skySoft,
-      borderColor: const Color(0xFFB7DDF4),
-      child: Semantics(
-        container: true,
-        label: '저장한 경로가 없습니다.',
-        child: const ExcludeSemantics(
-          child: Row(
-            children: [
-              Icon(
-                Icons.bookmark_add_outlined,
-                color: EasySubwayAccessibleColors.brand,
-                size: 30,
-              ),
-              SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      '저장한 경로가 없습니다',
-                      style: TextStyle(
-                        color: EasySubwayAccessibleColors.text,
-                        fontSize: 16,
-                        fontWeight: FontWeight.w900,
-                        height: 1.25,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _HomeShortcutGrid extends StatelessWidget {
-  const _HomeShortcutGrid({
-    required this.hasFavorites,
-    required this.onNearby,
-    required this.onReports,
-    required this.onFavorites,
-    required this.onSettings,
-  });
-
-  final bool hasFavorites;
-  final VoidCallback onNearby;
-  final VoidCallback onReports;
-  final VoidCallback onFavorites;
-  final VoidCallback onSettings;
-
-  @override
-  Widget build(BuildContext context) {
-    final cards = [
-      _HomeQuickCard(
-        key: const Key('nearbyStationButton'),
-        icon: Icons.location_on_outlined,
-        title: '가까운 역',
-        onTap: onNearby,
-      ),
-      _HomeQuickCard(
-        key: const Key('myReportsButton'),
-        icon: Icons.report_outlined,
-        title: '내 신고',
-        onTap: onReports,
-      ),
-      if (hasFavorites)
-        _HomeQuickCard(
-          key: const Key('favoritesButton'),
-          icon: Icons.bookmark_border,
-          title: '저장한 곳',
-          onTap: onFavorites,
-        ),
-      _HomeQuickCard(
-        key: const Key('appSettingsButton'),
-        icon: Icons.settings_outlined,
-        title: '설정',
-        onTap: onSettings,
-      ),
-    ];
-    final textScale = MediaQuery.textScalerOf(context).scale(1);
-    if (textScale >= 2) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          for (var index = 0; index < cards.length; index++) ...[
-            if (index > 0) const SizedBox(height: 10),
-            cards[index],
-          ],
-        ],
-      );
-    }
-    return GridView.count(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      crossAxisCount: 2,
-      crossAxisSpacing: 10,
-      mainAxisSpacing: 10,
-      childAspectRatio: 1.18,
-      children: cards,
-    );
-  }
-}
-
-class _HomeQuickCard extends StatelessWidget {
-  const _HomeQuickCard({
-    required this.icon,
-    required this.title,
-    required this.onTap,
-    super.key,
-  });
-
-  final IconData icon;
-  final String title;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      button: true,
-      label: title,
-      onTap: onTap,
-      child: ExcludeSemantics(
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(18),
-          child: _PrototypeCard(
-            borderRadius: 18,
-            padding: const EdgeInsets.all(14),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: EasySubwayAccessibleColors.mintSoft,
-                    borderRadius: BorderRadius.circular(13),
-                  ),
-                  child: SizedBox(
-                    width: 39,
-                    height: 39,
-                    child: Icon(
-                      icon,
-                      color: EasySubwayAccessibleColors.mintDark,
-                      size: 21,
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 10),
-                Text(
-                  title,
-                  style: const TextStyle(
-                    color: EasySubwayAccessibleColors.text,
-                    fontSize: 15,
-                    fontWeight: FontWeight.w900,
-                    height: 1.2,
-                  ),
-                ),
-              ],
-            ),
           ),
         ),
       ),
@@ -1845,6 +1952,9 @@ class _PrototypeInfoRow extends StatelessWidget {
     required this.iconColor,
     required this.title,
     this.subtitle,
+    this.subtitleColor = EasySubwayAccessibleColors.mutedText,
+    this.iconBoxSize = 43,
+    this.iconSize = 22,
     this.trailing,
   });
 
@@ -1853,6 +1963,9 @@ class _PrototypeInfoRow extends StatelessWidget {
   final Color iconColor;
   final String title;
   final String? subtitle;
+  final Color subtitleColor;
+  final double iconBoxSize;
+  final double iconSize;
   final String? trailing;
 
   @override
@@ -1864,9 +1977,9 @@ class _PrototypeInfoRow extends StatelessWidget {
         borderRadius: BorderRadius.circular(14),
       ),
       child: SizedBox(
-        width: 43,
-        height: 43,
-        child: Icon(icon, color: iconColor, size: 22),
+        width: iconBoxSize,
+        height: iconBoxSize,
+        child: Icon(icon, color: iconColor, size: iconSize),
       ),
     );
     final content = Column(
@@ -1885,9 +1998,10 @@ class _PrototypeInfoRow extends StatelessWidget {
           const SizedBox(height: 3),
           Text(
             subtitle,
-            style: const TextStyle(
-              color: EasySubwayAccessibleColors.mutedText,
+            style: TextStyle(
+              color: subtitleColor,
               fontSize: 12,
+              fontWeight: FontWeight.w900,
               height: 1.4,
             ),
           ),

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -782,8 +782,9 @@ class RouteSearchStep {
   String get burdenLabel {
     final labels = <String>[
       _routeDurationLabel(estimatedMinutes),
-      if (distanceMeters > 0) '도보 ${distanceMeters}m',
+      _routeDistanceLabel(distanceMeters),
       if (includesStairs) '계단 포함',
+      if (requiresAccessibilityCheck) '접근성 확인',
     ];
     return labels.join(' · ');
   }
@@ -794,6 +795,10 @@ class RouteSearchStep {
       actionDetail.isEmpty ? description : actionDetail,
       if (reason.isNotEmpty) reason,
       burdenLabel,
+      if (hasMetricSourceMetadata) '시간 ${_routeTimeSourceLabel(timeSource)}',
+      if (hasMetricSourceMetadata)
+        '거리 ${_routeDistanceSourceLabel(distanceSource)}',
+      if (hasMetricSourceMetadata) confidenceLabel,
       if (evidenceSources.isNotEmpty) '근거 ${evidenceSources.join(', ')}',
     ];
     return labels.join(', ');
@@ -809,8 +814,9 @@ class RouteSearchStep {
       return '';
     }
     return [
-      if (estimatedMinutes > 0) '약 $estimatedMinutes분',
-      if (distanceMeters > 0) '도보 ${distanceMeters}m',
+      '시간 ${_routeTimeSourceLabel(timeSource)}',
+      '거리 ${_routeDistanceSourceLabel(distanceSource)}',
+      confidenceLabel,
     ].join(' · ');
   }
 }
@@ -835,6 +841,23 @@ String _routeDistanceLabel(int distanceMeters) {
     return '${kilometers.toStringAsFixed(0)}km';
   }
   return '${kilometers.toStringAsFixed(1)}km';
+}
+
+String _routeTimeSourceLabel(String source) {
+  return switch (source) {
+    'STATIC_ESTIMATE' => '정적 추정',
+    'REALTIME_ADJUSTED' => '실시간 보정',
+    'MEASURED' => '측정값',
+    _ => '확인 필요',
+  };
+}
+
+String _routeDistanceSourceLabel(String source) {
+  return switch (source) {
+    'MEASURED' => '측정값',
+    'STATIC_ESTIMATE' => '정적 추정',
+    _ => '확인 필요',
+  };
 }
 
 class RouteSearchWarning {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -634,6 +634,13 @@ class RouteSearchResult {
 
   String get mobilityLabel => _mobilityLabelFor(mobilityType);
 
+  String get comfortLabel {
+    if (isBlocked) {
+      return '다른 경로 필요';
+    }
+    return score >= 80 ? '이동 편함' : '조금 불편';
+  }
+
   String get guidanceLabel {
     if (isBlocked) {
       return '다른 경로가 필요합니다';
@@ -663,7 +670,7 @@ class RouteSearchResult {
       mobilityLabel,
       summaryTitle,
       lineLabel,
-      scoreLabel,
+      comfortLabel,
     ];
     if (!isBlocked && warnings.isNotEmpty) {
       parts.add(attentionLabel);
@@ -775,9 +782,8 @@ class RouteSearchStep {
   String get burdenLabel {
     final labels = <String>[
       _routeDurationLabel(estimatedMinutes),
-      _routeDistanceLabel(distanceMeters),
+      if (distanceMeters > 0) '도보 ${distanceMeters}m',
       if (includesStairs) '계단 포함',
-      if (requiresAccessibilityCheck) '접근성 확인',
     ];
     return labels.join(' · ');
   }
@@ -788,10 +794,6 @@ class RouteSearchStep {
       actionDetail.isEmpty ? description : actionDetail,
       if (reason.isNotEmpty) reason,
       burdenLabel,
-      if (hasMetricSourceMetadata) '시간 ${_routeTimeSourceLabel(timeSource)}',
-      if (hasMetricSourceMetadata)
-        '거리 ${_routeDistanceSourceLabel(distanceSource)}',
-      if (hasMetricSourceMetadata) confidenceLabel,
       if (evidenceSources.isNotEmpty) '근거 ${evidenceSources.join(', ')}',
     ];
     return labels.join(', ');
@@ -807,9 +809,8 @@ class RouteSearchStep {
       return '';
     }
     return [
-      '시간 ${_routeTimeSourceLabel(timeSource)}',
-      '거리 ${_routeDistanceSourceLabel(distanceSource)}',
-      confidenceLabel,
+      if (estimatedMinutes > 0) '약 $estimatedMinutes분',
+      if (distanceMeters > 0) '도보 ${distanceMeters}m',
     ].join(' · ');
   }
 }
@@ -834,27 +835,6 @@ String _routeDistanceLabel(int distanceMeters) {
     return '${kilometers.toStringAsFixed(0)}km';
   }
   return '${kilometers.toStringAsFixed(1)}km';
-}
-
-String _routeTimeSourceLabel(String source) {
-  // route contract: realtime ETA fallback
-  // Local route results may carry STATIC_ESTIMATE when realtime providers are
-  // unavailable. Unknown labels must stay explicit instead of implying live ETA
-  // accuracy.
-  return switch (source) {
-    'STATIC_ESTIMATE' => '정적 추정',
-    'REALTIME_ADJUSTED' => '실시간 보정',
-    'MEASURED' => '측정값',
-    _ => '확인 필요',
-  };
-}
-
-String _routeDistanceSourceLabel(String source) {
-  return switch (source) {
-    'MEASURED' => '측정값',
-    'STATIC_ESTIMATE' => '정적 추정',
-    _ => '확인 필요',
-  };
 }
 
 class RouteSearchWarning {
@@ -2131,7 +2111,7 @@ class _RouteSearchResultSummaryCard extends StatelessWidget {
                   subtitle: result.isBlocked
                       ? '현재 조건에서 막힌 이유를 확인하세요'
                       : _isRecommendedRoute
-                      ? '시설 상태와 신뢰도를 함께 계산했어요'
+                      ? '편함·불편함과 시간·환승·걷기만 비교합니다.'
                       : '이 경로는 이동 전 확인이 필요합니다',
                 ),
                 DecoratedBox(
@@ -2191,12 +2171,7 @@ class _RouteSearchResultSummaryCard extends StatelessWidget {
                                 ),
                               const SizedBox(height: 5),
                               Text(
-                                _isRecommendedRoute
-                                    ? result.scoreLabel.replaceFirst(
-                                        '점수 ',
-                                        '편함 ',
-                                      )
-                                    : result.scoreLabel,
+                                result.comfortLabel,
                                 style: textTheme.bodyMedium?.copyWith(
                                   color: EasySubwayAccessibleColors.mintDark,
                                   fontWeight: FontWeight.w900,
@@ -2248,12 +2223,7 @@ class _RouteSearchResultSummaryCard extends StatelessWidget {
                                     ),
                                   const SizedBox(height: 5),
                                   Text(
-                                    _isRecommendedRoute
-                                        ? result.scoreLabel.replaceFirst(
-                                            '점수 ',
-                                            '편함 ',
-                                          )
-                                        : result.scoreLabel,
+                                    result.comfortLabel,
                                     style: textTheme.bodyMedium?.copyWith(
                                       color:
                                           EasySubwayAccessibleColors.mintDark,
@@ -2268,13 +2238,6 @@ class _RouteSearchResultSummaryCard extends StatelessWidget {
                             result.movementSteps.isNotEmpty) ...[
                           const SizedBox(height: 15),
                           const _RoutePrototypeLinePath(),
-                        ],
-                        if (_isRecommendedRoute &&
-                            result.recommendationReasons.isNotEmpty) ...[
-                          const SizedBox(height: 13),
-                          _RouteRecommendationReasons(
-                            reasons: result.recommendationReasons,
-                          ),
                         ],
                         if (result.blockedReasons.isNotEmpty) ...[
                           const SizedBox(height: 13),
@@ -2302,10 +2265,6 @@ class _RouteSearchResultSummaryCard extends StatelessWidget {
                     ),
                   ),
                 ),
-                if (_isRecommendedRoute) ...[
-                  const SizedBox(height: 12),
-                  const _RoutePrototypeInfoBox(),
-                ],
               ],
             ),
             if (result.isBlocked)
@@ -2487,112 +2446,6 @@ class _RoutePrototypeReason extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _RoutePrototypeInfoBox extends StatelessWidget {
-  const _RoutePrototypeInfoBox();
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: EasySubwayAccessibleColors.skySoft,
-        borderRadius: BorderRadius.circular(15),
-      ),
-      child: const Padding(
-        padding: EdgeInsets.all(12),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Icon(Icons.info_outline, color: EasySubwayAccessibleColors.brand),
-            SizedBox(width: 10),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    '왜 가장 빠른 길이 첫 번째가 아닌가요?',
-                    style: TextStyle(
-                      color: EasySubwayAccessibleColors.brand,
-                      fontSize: 13,
-                      fontWeight: FontWeight.w900,
-                      height: 1.25,
-                    ),
-                  ),
-                  SizedBox(height: 3),
-                  Text(
-                    '계단과 시설 상태, 걷는 거리를 먼저 고려했어요.',
-                    style: TextStyle(
-                      color: EasySubwayAccessibleColors.brand,
-                      fontSize: 12,
-                      height: 1.45,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _RouteRecommendationReasons extends StatelessWidget {
-  const _RouteRecommendationReasons({required this.reasons});
-
-  final List<String> reasons;
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: const Color(0xFFE6F2F0),
-        border: Border.all(color: const Color(0xFF9FCACE)),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                const Icon(
-                  Icons.check_circle,
-                  color: Color(0xFF004A50),
-                  size: 26,
-                ),
-                const SizedBox(width: 8),
-                Text(
-                  '추천 이유',
-                  style: textTheme.bodyLarge?.copyWith(
-                    color: const Color(0xFF004A50),
-                    fontWeight: FontWeight.w900,
-                    height: 1.25,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 8),
-            for (final reason in reasons.take(3))
-              Padding(
-                padding: const EdgeInsets.only(bottom: 4),
-                child: Text(
-                  reason,
-                  style: textTheme.bodyLarge?.copyWith(
-                    color: const Color(0xFF102A2C),
-                    fontWeight: FontWeight.w800,
-                    height: 1.3,
-                  ),
-                ),
-              ),
-          ],
-        ),
       ),
     );
   }
@@ -2820,17 +2673,6 @@ class _RouteStepTile extends StatelessWidget {
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       color: const Color(0xFF405A5D),
                       fontWeight: FontWeight.w700,
-                      height: 1.3,
-                    ),
-                  ),
-                ],
-                if (step.hasMetricSourceMetadata) ...[
-                  const SizedBox(height: 4),
-                  Text(
-                    step.metricSourceLabel,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: const Color(0xFF29484B),
-                      fontWeight: FontWeight.w800,
                       height: 1.3,
                     ),
                   ),

--- a/apps/mobile/test/onboarding_app_flow_test.dart
+++ b/apps/mobile/test/onboarding_app_flow_test.dart
@@ -38,7 +38,7 @@ void main() {
     await tester.tap(find.byKey(const Key('onboardingDoneButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('길찾기'), findsOneWidget);
+    expect(find.byKey(const Key('routeSearchButton')), findsOneWidget);
     expect(find.byKey(const Key('stationSearchButton')), findsOneWidget);
     expect(find.text('먼저 이동 조건을 골라 주세요'), findsNothing);
     expect(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -77,16 +77,14 @@ Future<void> _openSettingsScreen(WidgetTester tester) async {
 }
 
 Future<void> _openMyReportsScreen(WidgetTester tester) async {
-  final homeContext = tester.element(find.byType(HomeScreen));
-  final home = tester.widget<HomeScreen>(find.byType(HomeScreen));
-  unawaited(
-    Navigator.of(homeContext).push(
-      MaterialPageRoute<void>(
-        builder: (_) =>
-            MyFacilityReportListScreen(repository: home.reportRepository),
-      ),
-    ),
+  await tester.tap(find.byKey(const Key('bottomNavMore')));
+  await tester.pumpAndSettle();
+  await tester.scrollUntilVisible(
+    find.byKey(const Key('myReportsSettingsButton')),
+    160,
   );
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(const Key('myReportsSettingsButton')));
   await tester.pumpAndSettle();
 }
 
@@ -3640,7 +3638,7 @@ void main() {
         findsOneWidget,
       );
       expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
-      expect(find.text('약 4분 · 도보 180m'), findsOneWidget);
+      expect(find.text('약 4분 · 180m · 접근성 확인'), findsOneWidget);
       expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
       expect(
         find.text('접근성 시설 정보가 최근 30일 이내 확인되지 않았습니다. 이동 전 역 상세 정보를 확인하세요.'),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -45,9 +45,25 @@ OnboardingState _completedOnboardingStateWithPreferences({
 }
 
 Future<void> _openFavoriteList(WidgetTester tester, {Key? tabKey}) async {
-  await _scrollHomeActionIntoView(tester, const Key('favoritesButton'));
-  await tester.pumpAndSettle();
-  await tester.tap(find.byKey(const Key('favoritesButton')));
+  final homeContext = tester.element(find.byType(HomeScreen));
+  final home = tester.widget<HomeScreen>(find.byType(HomeScreen));
+  unawaited(
+    Navigator.of(homeContext).push(
+      MaterialPageRoute<void>(
+        builder: (_) => FavoriteHomeScreen(
+          favoriteRepository: home.favoriteRepository,
+          favoriteFacilityRepository: home.favoriteFacilityRepository,
+          favoriteRouteRepository: home.favoriteRouteRepository,
+          stationRepository: home.repository,
+          reportRepository: home.reportRepository,
+          locationProvider: home.locationProvider,
+          facilityReportDraftTargetStore: home.facilityReportDraftTargetStore,
+          internalRouteRepository: home.internalRouteRepository,
+          initialMobilityType: home.initialMobilityType,
+        ),
+      ),
+    ),
+  );
   await tester.pumpAndSettle();
   if (tabKey != null) {
     await tester.tap(find.byKey(tabKey));
@@ -56,25 +72,22 @@ Future<void> _openFavoriteList(WidgetTester tester, {Key? tabKey}) async {
 }
 
 Future<void> _openSettingsScreen(WidgetTester tester) async {
-  await _scrollHomeActionIntoView(tester, const Key('appSettingsButton'));
-  await tester.pumpAndSettle();
-  await tester.tap(find.byKey(const Key('appSettingsButton')));
+  await tester.tap(find.byKey(const Key('homeProfilePill')));
   await tester.pumpAndSettle();
 }
 
 Future<void> _openMyReportsScreen(WidgetTester tester) async {
-  await _scrollHomeActionIntoView(tester, const Key('myReportsButton'));
-  await tester.pumpAndSettle();
-  await tester.tap(find.byKey(const Key('myReportsButton')));
-  await tester.pumpAndSettle();
-}
-
-Future<void> _scrollHomeActionIntoView(WidgetTester tester, Key key) async {
-  await tester.dragUntilVisible(
-    find.byKey(key),
-    find.byKey(const Key('homePrototypeList')),
-    const Offset(0, -180),
+  final homeContext = tester.element(find.byType(HomeScreen));
+  final home = tester.widget<HomeScreen>(find.byType(HomeScreen));
+  unawaited(
+    Navigator.of(homeContext).push(
+      MaterialPageRoute<void>(
+        builder: (_) =>
+            MyFacilityReportListScreen(repository: home.reportRepository),
+      ),
+    ),
   );
+  await tester.pumpAndSettle();
 }
 
 Future<void> _openMobilityProfileFromSettings(WidgetTester tester) async {
@@ -91,6 +104,17 @@ Future<void> _openNotificationSettings(WidgetTester tester) async {
   );
   await tester.pumpAndSettle();
   await tester.tap(find.byKey(const Key('notificationSettingsButton')));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openSupportAccessScreen(WidgetTester tester) async {
+  await _openSettingsScreen(tester);
+  await tester.scrollUntilVisible(
+    find.byKey(const Key('settingsSupportPrivacyButton')),
+    160,
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(const Key('settingsSupportPrivacyButton')));
   await tester.pumpAndSettle();
 }
 
@@ -240,16 +264,13 @@ void main() {
 
     expect(reportedErrors, isEmpty);
     expect(find.byKey(const Key('stationSearchButton')), findsOneWidget);
-
-    await tester.dragUntilVisible(
-      find.text('바로가기'),
-      find.byKey(const Key('homePrototypeList')),
-      const Offset(0, -180),
+    expect(
+      find.byKey(const Key('homeNotificationActionButton')),
+      findsOneWidget,
     );
-    await tester.pumpAndSettle();
 
     expect(find.text('자주 가는 곳'), findsNothing);
-    expect(find.byKey(const Key('homeSavedRouteSection')), findsNothing);
+    expect(find.text('최근 경로'), findsNothing);
     expect(find.text('저장한 경로가 없습니다'), findsNothing);
   });
 
@@ -368,40 +389,51 @@ void main() {
       );
 
       expect(find.text('안녕하세요'), findsNothing);
-      expect(find.text('어디로 가시나요?'), findsNothing);
+      expect(find.text('어디로 가시나요?'), findsOneWidget);
       expect(find.text('안녕하세요, 오늘도 편안하게'), findsNothing);
-      expect(find.text('길찾기'), findsOneWidget);
-      expect(find.text('길찾기 시작'), findsOneWidget);
+      expect(find.byKey(const Key('routeSearchButton')), findsOneWidget);
+      expect(find.byKey(const Key('networkMapButton')), findsOneWidget);
       expect(find.byKey(const Key('homeRouteDraftPanel')), findsNothing);
-      expect(find.text('지금 주변 상태'), findsOneWidget);
-      expect(find.text('주변 시설 상태 없음'), findsOneWidget);
-      expect(
-        tester.getSize(find.widgetWithText(OutlinedButton, '주변 역 보기')).height,
-        greaterThanOrEqualTo(EasySubwayTouchTarget.general),
-      );
+      expect(find.text('시설 알림'), findsNothing);
+      expect(find.text('주의'), findsNothing);
+      expect(find.text('대체 1번 출구'), findsNothing);
+      expect(find.widgetWithText(OutlinedButton, '대체 길 보기'), findsNothing);
 
       expect(find.byKey(const Key('homeSecondaryActionsGroup')), findsNothing);
       expect(find.byKey(const Key('homeSettingsActionsGroup')), findsNothing);
       expect(find.byKey(const Key('homeMyInfoActionsGroup')), findsNothing);
       expect(find.byKey(const Key('homeTripControlPanel')), findsNothing);
-      expect(find.widgetWithText(FilledButton, '역 검색'), findsNothing);
-      expect(find.widgetWithText(FilledButton, '길찾기 시작'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '역 검색'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '노선도'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '설정'), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '알림 설정'), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '즐겨찾기'), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '내 신고'), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '도움말'), findsNothing);
-      expect(find.byKey(const Key('homeHelpActionButton')), findsOneWidget);
+      expect(
+        find.byKey(const Key('homeNotificationActionButton')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('homeBottomNavigationBar')), findsOneWidget);
+      expect(find.byKey(const Key('bottomNavHome')), findsOneWidget);
+      expect(find.byKey(const Key('bottomNavMap')), findsOneWidget);
+      expect(find.byKey(const Key('bottomNavRoute')), findsOneWidget);
+      expect(find.byKey(const Key('bottomNavSaved')), findsOneWidget);
+      expect(find.byKey(const Key('bottomNavMore')), findsOneWidget);
+      expect(find.byKey(const Key('homeHelpActionButton')), findsNothing);
       expect(find.widgetWithText(TextButton, '도움말'), findsNothing);
       expect(find.widgetWithText(FilledButton, '내 신고'), findsNothing);
       expect(find.widgetWithText(FilledButton, '알림 설정'), findsNothing);
+      expect(find.text('바로가기'), findsNothing);
+      expect(find.text('저장한 곳'), findsNothing);
       expect(find.text('즐겨찾기 경로'), findsNothing);
       expect(find.text('즐겨찾기 역'), findsNothing);
       expect(find.text('즐겨찾기 시설'), findsNothing);
       expect(find.textContaining('빠른 길보다'), findsNothing);
       expect(find.text('고령자'), findsOneWidget);
-      expect(find.bySemanticsLabel('길찾기 시작, 현재 이동 조건 고령자'), findsOneWidget);
+      expect(find.bySemanticsLabel('길찾기와 노선도, 현재 이동 조건 고령자'), findsOneWidget);
       expect(find.textContaining('휠체어'), findsNothing);
 
       final stationButtonSize = tester.getSize(
@@ -412,46 +444,15 @@ void main() {
       );
 
       expect(stationButtonSize.height, greaterThanOrEqualTo(48));
+      expect(routeButtonSize.height, greaterThanOrEqualTo(104));
       expect(
-        routeButtonSize.height,
-        greaterThanOrEqualTo(EasySubwayTouchTarget.primary),
+        routeButtonSize.width,
+        greaterThanOrEqualTo(stationButtonSize.width),
       );
-      expect(routeButtonSize.width, greaterThan(stationButtonSize.width));
 
-      await tester.scrollUntilVisible(find.text('저장한 경로가 없습니다'), 180);
-      await tester.pumpAndSettle();
-      expect(find.text('저장한 경로가 없습니다'), findsOneWidget);
+      expect(find.text('최근 경로'), findsNothing);
+      expect(find.text('저장한 경로가 없습니다'), findsNothing);
       expect(find.text('경로를 저장하면 현재 시설 상태와 함께 다시 볼 수 있어요.'), findsNothing);
-
-      await tester.dragUntilVisible(
-        find.text('바로가기'),
-        find.byKey(const Key('homePrototypeList')),
-        const Offset(0, -180),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.text('바로가기'), findsOneWidget);
-
-      await tester.dragUntilVisible(
-        find.text('설정'),
-        find.byKey(const Key('homePrototypeList')),
-        const Offset(0, -180),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.text('가까운 역'), findsOneWidget);
-      expect(find.text('내 신고'), findsOneWidget);
-      expect(find.text('저장한 곳'), findsOneWidget);
-      expect(find.text('설정'), findsOneWidget);
-
-      final settingsButtonSize = tester.getSize(
-        find.byKey(const Key('appSettingsButton')),
-      );
-      final myReportsButtonSize = tester.getSize(
-        find.byKey(const Key('myReportsButton')),
-      );
-      expect(settingsButtonSize.height, greaterThanOrEqualTo(100));
-      expect(myReportsButtonSize.height, greaterThanOrEqualTo(100));
 
       await tester.drag(
         find.byKey(const Key('homePrototypeList')),
@@ -467,7 +468,141 @@ void main() {
     }
   });
 
-  testWidgets('홈 보조 행동은 좁은 화면과 큰 글자에서도 줄임표 없이 터치 기준을 지킨다', (tester) async {
+  testWidgets('홈 우측 상단 알림 버튼은 알림 설정으로 이동한다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('homeNotificationActionButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('알림 설정'), findsOneWidget);
+  });
+
+  testWidgets('홈 화면은 v3 기준 큰 행동과 짧은 상태 카드로 구성된다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(
+          favorites: [
+            _favoriteFacility(
+              status: 'NEEDS_CHECK',
+              name: '3번 출구 엘리베이터',
+              exitId: 'exit-sangnoksu-3',
+              description: '3번 출구 앞',
+            ),
+          ],
+        ),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(
+          favorites: [_favoriteRoute()],
+        ),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('어디로 가시나요?'), findsOneWidget);
+    expect(find.byKey(const Key('routeSearchButton')), findsOneWidget);
+    expect(find.byKey(const Key('networkMapButton')), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, '노선도'), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, '역 검색'), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, '가까운 역'), findsOneWidget);
+    expect(find.text('시설 알림'), findsOneWidget);
+    expect(find.text('상록수역 3번 출구 엘리베이터'), findsOneWidget);
+    expect(find.text('엘리베이터 확인 필요'), findsOneWidget);
+    expect(find.text('주의'), findsOneWidget);
+    expect(
+      find.text('3번 출구 엘리베이터 상태가 확인 필요입니다. 다른 출구 또는 역무원 안내를 확인하세요.'),
+      findsOneWidget,
+    );
+    expect(find.text('대체 1번 출구'), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, '대체 길 보기'), findsNothing);
+    final routeButtonSize = tester.getSize(
+      find.byKey(const Key('routeSearchButton')),
+    );
+    final mapButtonSize = tester.getSize(
+      find.byKey(const Key('networkMapButton')),
+    );
+    expect(routeButtonSize.height, greaterThanOrEqualTo(104));
+    expect(mapButtonSize.height, greaterThanOrEqualTo(104));
+
+    await tester.dragUntilVisible(
+      find.text('최근 경로'),
+      find.byKey(const Key('homePrototypeList')),
+      const Offset(0, -160),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('최근 경로'), findsOneWidget);
+    await tester.dragUntilVisible(
+      find.text('상록수역 → 사당역'),
+      find.byKey(const Key('homePrototypeList')),
+      const Offset(0, -120),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('상록수역 → 사당역'), findsOneWidget);
+    expect(find.textContaining('이동 점수'), findsNothing);
+    expect(find.textContaining('정보 신뢰도'), findsNothing);
+  });
+
+  testWidgets('홈 시설 알림은 주의 상태 시설이 없으면 섹션을 숨긴다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(
+          favorites: [_favoriteFacility()],
+        ),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('시설 알림'), findsNothing);
+    expect(find.text('정상'), findsNothing);
+    expect(find.text('주의'), findsNothing);
+  });
+
+  testWidgets('홈 이동 조건 pill은 모든 이동 유형에 맞는 아이콘을 보여준다', (tester) async {
+    for (final option in mobilityProfileOptions) {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          key: ValueKey('home-profile-${option.id}'),
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+          favoriteRouteRepository: FakeFavoriteRouteRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
+          initialOnboardingState: _completedOnboardingState(
+            profileId: option.id,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(option.title), findsOneWidget);
+      expect(find.byIcon(option.icon), findsOneWidget);
+      expect(find.byIcon(Icons.directions_walk), findsNothing);
+    }
+  });
+
+  testWidgets('홈 핵심 행동은 좁은 화면과 큰 글자에서도 터치 기준을 지킨다', (tester) async {
     tester.view.physicalSize = const Size(320, 1200);
     tester.view.devicePixelRatio = 1;
     tester.platformDispatcher.textScaleFactorTestValue = 3.2;
@@ -491,26 +626,23 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.dragUntilVisible(
-      find.byKey(const Key('appSettingsButton')),
-      find.byKey(const Key('homePrototypeList')),
-      const Offset(0, -180),
-    );
-    await tester.pumpAndSettle();
-
-    final settingsButton = find.byKey(const Key('appSettingsButton'));
-    final favoritesButton = find.byKey(const Key('favoritesButton'));
-
     expect(EasySubwayTouchTarget.iconOnly, 48);
     expect(EasySubwayTouchTarget.general, 56);
     expect(EasySubwayTouchTarget.primary, 60);
-    expect(find.text('설정'), findsOneWidget);
-    expect(favoritesButton, findsOneWidget);
-    expect(tester.getSize(settingsButton).height, greaterThan(56));
-    expect(tester.getSize(favoritesButton).height, greaterThan(56));
-    expect(tester.getSize(settingsButton).width, greaterThan(280));
-    expect(tester.getSize(favoritesButton).width, greaterThan(280));
-    expect(tester.getSize(settingsButton).height, greaterThanOrEqualTo(60));
+    expect(find.text('바로가기'), findsNothing);
+    expect(find.byKey(const Key('homeHelpActionButton')), findsNothing);
+    expect(
+      tester.getSize(find.byKey(const Key('routeSearchButton'))).height,
+      greaterThanOrEqualTo(104),
+    );
+    expect(
+      tester.getSize(find.byKey(const Key('networkMapButton'))).height,
+      greaterThanOrEqualTo(104),
+    );
+    expect(
+      tester.getSize(find.byKey(const Key('homeProfilePill'))).height,
+      greaterThanOrEqualTo(36),
+    );
   });
 
   testWidgets('홈 자주 가는 곳은 저장한 경로가 있으면 빈 상태 대신 경로를 보여준다', (tester) async {
@@ -530,12 +662,16 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.scrollUntilVisible(find.text('상록수 → 사당'), 180);
+      await tester.dragUntilVisible(
+        find.text('상록수역 → 사당역'),
+        find.byKey(const Key('homePrototypeList')),
+        const Offset(0, -180),
+      );
       await tester.pumpAndSettle();
 
-      expect(find.text('상록수 → 사당'), findsOneWidget);
+      expect(find.text('상록수역 → 사당역'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('저장한 경로, 상록수에서 사당까지, 수도권 4호선, 고령자, 이동 점수 92점'),
+        find.bySemanticsLabel(RegExp('최근 경로, 상록수역에서 사당역까지')),
         findsOneWidget,
       );
       expect(find.text('저장한 경로가 없습니다'), findsNothing);
@@ -693,7 +829,7 @@ void main() {
 
     expect(find.byKey(const Key('homeTripControlPanel')), findsNothing);
     expect(find.text('고령자'), findsOneWidget);
-    expect(find.bySemanticsLabel('길찾기 시작, 현재 이동 조건 고령자'), findsOneWidget);
+    expect(find.bySemanticsLabel('길찾기와 노선도, 현재 이동 조건 고령자'), findsOneWidget);
 
     await _openMobilityProfileFromSettings(tester);
     await tester.tap(find.byKey(const Key('mobilityProfileCard-wheelchair')));
@@ -703,18 +839,18 @@ void main() {
     await tester.pageBack();
     await tester.pumpAndSettle();
     await tester.dragUntilVisible(
-      find.text('길찾기'),
+      find.byKey(const Key('routeSearchButton')),
       find.byKey(const Key('homePrototypeList')),
       const Offset(0, 180),
     );
     await tester.pumpAndSettle();
 
     expect(find.text('휠체어'), findsOneWidget);
-    expect(find.bySemanticsLabel('길찾기 시작, 현재 이동 조건 휠체어'), findsOneWidget);
+    expect(find.bySemanticsLabel('길찾기와 노선도, 현재 이동 조건 휠체어'), findsOneWidget);
     semanticsHandle.dispose();
   });
 
-  testWidgets('홈 즐겨찾기는 하나의 진입점에서 탭 목록을 바로 보여준다', (tester) async {
+  testWidgets('즐겨찾기 화면은 탭 목록을 바로 보여준다', (tester) async {
     await tester.pumpWidget(
       EasySubwayApp(
         repository: FakeStationSearchRepository(),
@@ -727,16 +863,12 @@ void main() {
       ),
     );
 
-    await _scrollHomeActionIntoView(tester, const Key('favoritesButton'));
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const Key('favoritesButton')), findsOneWidget);
+    expect(find.byKey(const Key('favoritesButton')), findsNothing);
     expect(find.byKey(const Key('favoriteRoutesButton')), findsNothing);
     expect(find.byKey(const Key('favoriteStationsButton')), findsNothing);
     expect(find.byKey(const Key('favoriteFacilitiesButton')), findsNothing);
 
-    await tester.tap(find.byKey(const Key('favoritesButton')));
-    await tester.pumpAndSettle();
+    await _openFavoriteList(tester);
 
     expect(find.text('즐겨찾기'), findsOneWidget);
     expect(find.byKey(const Key('favoriteRoutesTabButton')), findsOneWidget);
@@ -769,8 +901,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byKey(const Key('homeHelpActionButton')));
-      await tester.pumpAndSettle();
+      await _openSupportAccessScreen(tester);
 
       expect(find.text('도움말'), findsOneWidget);
       expect(find.text('개인정보처리방침'), findsOneWidget);
@@ -839,8 +970,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byKey(const Key('homeHelpActionButton')));
-      await tester.pumpAndSettle();
+      await _openSupportAccessScreen(tester);
 
       expect(find.text('개인정보 사용 안내'), findsOneWidget);
       expect(
@@ -895,8 +1025,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byKey(const Key('homeHelpActionButton')));
-      await tester.pumpAndSettle();
+      await _openSupportAccessScreen(tester);
 
       expect(find.text('안전과 데이터 안내'), findsOneWidget);
       expect(find.text('경로와 시설 정보는 이동을 돕는 참고 정보입니다.'), findsOneWidget);
@@ -945,8 +1074,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.byKey(const Key('homeHelpActionButton')));
-      await tester.pumpAndSettle();
+      await _openSupportAccessScreen(tester);
 
       await tester.scrollUntilVisible(
         find.byKey(const Key('securityContactNotice')),
@@ -1003,8 +1131,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byKey(const Key('homeHelpActionButton')));
-    await tester.pumpAndSettle();
+    await _openSupportAccessScreen(tester);
     await tester.tap(find.byKey(const Key('privacyPolicyAccessItem')));
     await tester.pumpAndSettle();
 
@@ -1035,8 +1162,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byKey(const Key('homeHelpActionButton')));
-    await tester.pumpAndSettle();
+    await _openSupportAccessScreen(tester);
     await tester.scrollUntilVisible(
       find.byKey(const Key('supportAccessItem')),
       120,
@@ -1086,8 +1212,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byKey(const Key('homeHelpActionButton')));
-    await tester.pumpAndSettle();
+    await _openSupportAccessScreen(tester);
     await tester.scrollUntilVisible(
       find.byKey(const Key('dataDeletionAccessItem')),
       120,
@@ -1155,8 +1280,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byKey(const Key('homeHelpActionButton')));
-    await tester.pumpAndSettle();
+    await _openSupportAccessScreen(tester);
     await tester.scrollUntilVisible(
       find.byKey(const Key('dataDeletionAccessItem')),
       120,
@@ -1195,8 +1319,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byKey(const Key('homeHelpActionButton')));
-    await tester.pumpAndSettle();
+    await _openSupportAccessScreen(tester);
 
     await tester.scrollUntilVisible(
       find.byKey(const Key('privacyPolicyAccessItem')),
@@ -1280,8 +1403,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byKey(const Key('homeHelpActionButton')));
-    await tester.pumpAndSettle();
+    await _openSupportAccessScreen(tester);
     await tester.tap(find.byKey(const Key('privacyPolicyAccessItem')));
     await tester.pump();
 
@@ -3493,7 +3615,7 @@ void main() {
       );
       expect(routeRepository.requests.single.mobilityType, 'SENIOR');
       expect(find.text('추천 경로 1개'), findsOneWidget);
-      expect(find.text('시설 상태와 신뢰도를 함께 계산했어요'), findsOneWidget);
+      expect(find.text('편함·불편함과 시간·환승·걷기만 비교합니다.'), findsOneWidget);
       expect(find.text('이동 편한 순'), findsNothing);
       expect(find.text('짧은 시간 순'), findsNothing);
       expect(find.text('환승 적은 순'), findsNothing);
@@ -3502,11 +3624,12 @@ void main() {
       expect(find.text('7분'), findsOneWidget);
       expect(find.text('환승 없음 · 이동 300m'), findsOneWidget);
       expect(find.text('가장 추천'), findsOneWidget);
-      expect(find.text('이동 편함 92점'), findsOneWidget);
-      expect(find.text('추천 이유'), findsOneWidget);
-      expect(find.text('엘리베이터 동선을 우선했어요'), findsOneWidget);
-      expect(find.text('계단 없는 출구를 확인했어요'), findsOneWidget);
-      expect(find.text('천천히 이동하기 쉬운 동선을 확인했어요'), findsOneWidget);
+      expect(find.text('이동 편함'), findsOneWidget);
+      expect(find.textContaining('이동 점수'), findsNothing);
+      expect(find.text('추천 이유'), findsNothing);
+      expect(find.text('엘리베이터 동선을 우선했어요'), findsNothing);
+      expect(find.text('계단 없는 출구를 확인했어요'), findsNothing);
+      expect(find.text('천천히 이동하기 쉬운 동선을 확인했어요'), findsNothing);
       expect(find.text('도착 안내'), findsOneWidget);
       expect(find.text('2번 출구의 엘리베이터를 먼저 확인하세요.'), findsOneWidget);
       expect(find.text('이동 순서'), findsOneWidget);
@@ -3516,29 +3639,24 @@ void main() {
         find.text('선택된 경로 edge:edge-sangnoksu-sadang 근거로 안내합니다.'),
         findsOneWidget,
       );
-      expect(find.text('시간 정적 추정 · 거리 측정값 · 높은 신뢰도'), findsOneWidget);
       expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
-      expect(find.text('약 4분 · 180m · 접근성 확인'), findsOneWidget);
+      expect(find.text('약 4분 · 도보 180m'), findsOneWidget);
       expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
       expect(
         find.text('접근성 시설 정보가 최근 30일 이내 확인되지 않았습니다. 이동 전 역 상세 정보를 확인하세요.'),
         findsOneWidget,
       );
-      expect(find.text('왜 가장 빠른 길이 첫 번째가 아닌가요?'), findsOneWidget);
-      expect(find.text('계단과 시설 상태, 걷는 거리를 먼저 고려했어요.'), findsOneWidget);
+      expect(find.text('왜 가장 빠른 길이 첫 번째가 아닌가요?'), findsNothing);
+      expect(find.text('계단과 시설 상태, 걷는 거리를 먼저 고려했어요.'), findsNothing);
       expect(find.text('안전 안내'), findsOneWidget);
       expect(find.text('이동 전 현장 안내와 역무원 안내를 확인해 주세요.'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
-          '경로 검색 결과, 이동할 수 있는 경로, 고령자, 상록수에서 사당까지, 수도권 4호선, 이동 점수 92점, 주의 확인, '
-          '추천 이유 엘리베이터 동선을 우선했어요, 계단 없는 출구를 확인했어요, 천천히 이동하기 쉬운 동선을 확인했어요, '
-          '도착 안내 2번 출구의 엘리베이터를 먼저 확인하세요., '
-          '주의 일부 시설 정보는 확인이 필요합니다., 접근성 시설 정보가 최근 30일 이내 확인되지 않았습니다. 이동 전 역 상세 정보를 확인하세요., '
-          '이동 안내 1번 열차 이동, 엘리베이터를 이용해 승강장으로 이동합니다., 선택된 경로 edge:edge-sangnoksu-sadang 근거로 안내합니다., 약 4분 · 180m · 접근성 확인, 시간 정적 추정, 거리 측정값, 높은 신뢰도, 근거 edge:edge-sangnoksu-sadang, '
-          '안전 안내 이동 전 현장 안내와 역무원 안내를 확인해 주세요.',
+          RegExp('경로 검색 결과, 이동할 수 있는 경로, 고령자, 상록수에서 사당까지, 수도권 4호선, 이동 편함'),
         ),
         findsOneWidget,
       );
+      expect(find.bySemanticsLabel(RegExp('이동 점수')), findsNothing);
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
@@ -4369,7 +4487,7 @@ void main() {
       );
       expect(
         find.bySemanticsLabel(
-          '경로 검색 결과, 다른 경로가 필요합니다, 휠체어, 상록수에서 없는역까지, 노선 확인 필요, 이동 점수 0점, '
+          '경로 검색 결과, 다른 경로가 필요합니다, 휠체어, 상록수에서 없는역까지, 노선 확인 필요, 다른 경로 필요, '
           '안내 불가 이유 휠체어로 이동 가능한 엘리베이터가 없습니다., '
           '다음 행동 역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요., '
           '안전 안내 이동 전 현장 안내와 역무원 안내를 확인해 주세요., '
@@ -5858,20 +5976,25 @@ FavoriteStation _favoriteStation({required String id, required String name}) {
   );
 }
 
-FavoriteFacility _favoriteFacility() {
-  return const FavoriteFacility(
+FavoriteFacility _favoriteFacility({
+  String status = 'NORMAL',
+  String name = '1번 출구 엘리베이터',
+  String exitId = 'exit-sangnoksu-1',
+  String description = '1번 출구 앞',
+}) {
+  return FavoriteFacility(
     userId: 'anonymous-user-1',
     facilityId: 'facility-sangnoksu-elevator-1',
     stationId: 'station-sangnoksu',
     stationNameKo: '상록수',
     stationNameEn: 'Sangnoksu',
-    exitId: 'exit-sangnoksu-1',
+    exitId: exitId,
     type: 'ELEVATOR',
-    name: '1번 출구 엘리베이터',
+    name: name,
     floorFrom: '1F',
     floorTo: 'B1',
-    description: '1번 출구 앞',
-    status: 'NORMAL',
+    description: description,
+    status: status,
     dataConfidence: 'HIGH',
     dataSourceType: 'OFFICIAL_FILE',
     lastUpdatedAt: '2026-06-12',


### PR DESCRIPTION
## 관련 이슈

close #760

## 작업 배경

- 사용자 앱 홈과 경로 결과 화면이 v3 기준 화면 구조와 달라 핵심 행동, 시설 알림, 최근 경로 표시, 하단 내비게이션을 정리했다.
- Android 배포 기준 작업으로 진행하며 iOS 화면 증거는 이번 PR 범위에서 제외한다.

## 작업 내용

- 홈 화면을 v3 기준의 큰 길찾기/노선도 행동, 역 검색/가까운 역 보조 행동, 상단 알림 버튼, 하단 내비게이션 구조로 맞췄다.
- 최근 경로는 저장된 경로 데이터가 있을 때만 표시하고, 데이터가 없을 때 빈 최근 경로처럼 보이지 않게 숨겼다.
- 시설 알림은 하드코딩 문구 대신 저장 시설 데이터의 주의 상태가 있을 때만 표시하도록 연결했다.
- 경로 결과의 점수/내부 품질 출처 문구를 줄이고 사용자에게 보이는 이동 편의 문구 중심으로 정리했다.
- 홈 UI 변경에 맞춰 widget test를 갱신하고 Android 접근성 기준선 테스트를 유지했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test`: 370 tests passed
  - `flutter test test/widget_test.dart`: 96 tests passed
  - `flutter test test/onboarding_app_flow_test.dart --name "첫 실행 앱은 온보딩을 완료한 뒤 홈으로 이동한다"`: All tests passed
  - `flutter analyze`: No issues found
  - `flutter test test/accessibility_baseline_test.dart`: 1 test passed
  - `git diff --check`: exit 0
  - Android fresh run: `flutter run -d emulator-5554 --debug`로 debug build/install/run 성공
  - GitHub required CI: Android CI, Mobile App CI, Backend CI, Repository CI, Changes 모두 pass
  - GitHub Release/CD 상태: Android Release Artifact success, Backend Release Image skipped

## 검증 증거

Android fresh run 화면 증거:

<img src="https://gist.githubusercontent.com/AquilaXk/fbc3e351cfabe3c4df0724ccefd5110e/raw/e87ebb1824ed1e46b5dceda8cab7435c3fe9552c/easysubway-pr-761-android-home.svg" alt="Android 홈 v3 fresh run" width="360">

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 홈 v3 구조 | Android emulator `emulator-5554` | fresh run 후 screenshot 확인 | PR 본문 Android 이미지 | 상단 알림 버튼, 큰 길찾기/노선도, 역 검색/가까운 역, 하단 nav 표시 확인 |
| 홈 접근성 tree | Android emulator `emulator-5554` | `uiautomator dump` | `.codex/evidence/760/android-ui.xml` | 홈 주요 버튼과 하단 nav 라벨 노출 확인 |
| 전체 Flutter 회귀 | local Flutter test | `flutter test` | command output | 370 tests passed |
| 위젯 회귀 | local Flutter test | `flutter test test/widget_test.dart` | command output | 96 tests passed |
| 접근성 기준선 | local Flutter test | `flutter test test/accessibility_baseline_test.dart` | command output | 1 test passed |
| PR required CI | GitHub Actions | PR #761 checks | https://github.com/AquilaXk/easysubway/actions/runs/28023837435 | Android CI, Mobile App CI, Backend CI, Repository CI, Changes pass |
| Release/CD 실패 여부 | GitHub Actions | Android Release Artifact 상태 확인 | https://github.com/AquilaXk/easysubway/actions/runs/28023837092 | Android Release Artifact success, Backend Release Image skipped |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/main.dart`의 홈 화면 섹션 표시 조건과 시설 알림 데이터 연결
  - `apps/mobile/lib/route_search.dart`의 사용자 노출 문구 단순화

## 리스크

- Android 배포 기준으로 화면 증거를 수집했다. iOS는 이번 작업 목표에서 제외했다.
- 시설 알림은 저장 시설 데이터에 주의 상태가 있을 때만 보이므로, 실제 데이터 상태에 따라 홈의 알림 섹션 노출 여부가 달라진다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 실패 여부를 확인했다.
