### PR TITLE
[Style] 모바일 시작화면 v3 디자인 적용

### DIFF
--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -320,7 +320,7 @@ class FavoriteFacilityListController extends ChangeNotifier {
           const FavoriteFacilityListState(
             status: FavoriteFacilityListStatus.empty,
             favorites: [],
-            message: '저장한 시설이 없습니다.',
+            message: '즐겨찾기한 시설이 없습니다.',
           ),
         );
         return;

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -419,6 +419,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
             setState(() {
               _onboardingState = OnboardingState.completed(result: result);
             });
+            _schedulePendingFacilityReportPhotoRecovery();
           },
         );
       }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -368,6 +368,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
   late bool _loadingOnboardingState =
       widget.onboardingStore != null &&
       !widget.initialOnboardingState.isCompleted;
+  bool _startScreenDismissed = false;
   bool _pendingFacilityReportPhotoRecoveryStarted = false;
 
   @override
@@ -389,6 +390,15 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
     }
 
     if (!_onboardingState.isCompleted) {
+      if (!_startScreenDismissed) {
+        return StartScreen(
+          onStart: () {
+            setState(() {
+              _startScreenDismissed = true;
+            });
+          },
+        );
+      }
       return OnboardingScreen(
         locationProvider: widget.locationProvider,
         notificationPermissionProvider: widget.notificationPermissionProvider,
@@ -453,6 +463,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
     setState(() {
       _onboardingState = const OnboardingState.initial();
       _loadingOnboardingState = false;
+      _startScreenDismissed = false;
     });
   }
 

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -371,6 +371,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
   bool _startScreenDismissed = false;
   bool _introScreenDismissed = false;
   bool _pendingFacilityReportPhotoRecoveryStarted = false;
+  UserDataDeletionResult? _dataDeletionResult;
 
   @override
   void initState() {
@@ -387,6 +388,18 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
     if (_loadingOnboardingState) {
       return const Scaffold(
         body: SafeArea(child: Center(child: CircularProgressIndicator())),
+      );
+    }
+
+    final dataDeletionResult = _dataDeletionResult;
+    if (dataDeletionResult != null) {
+      return UserDataDeletionResultScreen(
+        result: dataDeletionResult,
+        onRestart: () {
+          setState(() {
+            _dataDeletionResult = null;
+          });
+        },
       );
     }
 
@@ -469,7 +482,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
     );
   }
 
-  Future<void> _handleUserDataDeleted() async {
+  Future<void> _handleUserDataDeleted(UserDataDeletionResult result) async {
     try {
       await widget.legacyCredentialCleaner.clear();
     } catch (error, stackTrace) {
@@ -489,6 +502,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
       _loadingOnboardingState = false;
       _startScreenDismissed = false;
       _introScreenDismissed = false;
+      _dataDeletionResult = result;
     });
   }
 
@@ -835,7 +849,7 @@ class HomeScreen extends StatefulWidget {
   final SupportAccessInfo supportAccessInfo;
   final SupportAccessLauncher supportAccessLauncher;
   final UserDataDeletionRepository? userDataDeletionRepository;
-  final Future<void> Function()? onUserDataDeleted;
+  final Future<void> Function(UserDataDeletionResult result)? onUserDataDeleted;
   final Future<void> Function(MobilityProfileOption profile)?
   onMobilityProfileChanged;
   final String initialMobilityType;
@@ -953,15 +967,13 @@ class _HomeScreenState extends State<HomeScreen> {
       );
     }
 
-    void openNotificationSettings() {
-      final repository = notificationRepository;
-      if (repository == null) {
-        return;
-      }
+    void openNotificationInbox() {
       Navigator.of(context).push(
         MaterialPageRoute<void>(
-          builder: (_) => NotificationSettingsScreen(
-            repository: repository,
+          builder: (_) => NotificationInboxScreen(
+            favoriteFacilityRepository: favoriteFacilityRepository,
+            reportRepository: reportRepository,
+            notificationRepository: notificationRepository,
             notificationPermissionProvider: notificationPermissionProvider,
           ),
         ),
@@ -1069,7 +1081,7 @@ class _HomeScreenState extends State<HomeScreen> {
             key: const Key('homeNotificationActionButton'),
             onPressed: notificationRepository == null
                 ? openSettings
-                : openNotificationSettings,
+                : openNotificationInbox,
           ),
           const SizedBox(width: 8),
         ],
@@ -1160,7 +1172,7 @@ class _HomeScreenState extends State<HomeScreen> {
             key: Key('bottomNavSaved'),
             icon: Icon(Icons.bookmark_border),
             selectedIcon: Icon(Icons.bookmark),
-            label: '저장',
+            label: '즐겨찾기',
           ),
           NavigationDestination(
             key: Key('bottomNavMore'),
@@ -1255,6 +1267,262 @@ class _HomeNotificationButton extends StatelessWidget {
               ),
             ),
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class NotificationInboxScreen extends StatefulWidget {
+  const NotificationInboxScreen({
+    required this.favoriteFacilityRepository,
+    required this.reportRepository,
+    required this.notificationRepository,
+    required this.notificationPermissionProvider,
+    super.key,
+  });
+
+  final FavoriteFacilityRepository? favoriteFacilityRepository;
+  final FacilityReportRepository reportRepository;
+  final NotificationSettingsRepository? notificationRepository;
+  final NotificationPermissionProvider? notificationPermissionProvider;
+
+  @override
+  State<NotificationInboxScreen> createState() =>
+      _NotificationInboxScreenState();
+}
+
+class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
+  late Future<List<_NotificationInboxItem>> _itemsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _itemsFuture = _loadItems();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('알림'),
+        actions: [
+          if (widget.notificationRepository != null)
+            IconButton(
+              tooltip: '알림 설정',
+              onPressed: _openSettings,
+              icon: const Icon(Icons.settings_outlined),
+            ),
+        ],
+      ),
+      body: SafeArea(
+        child: FutureBuilder<List<_NotificationInboxItem>>(
+          future: _itemsFuture,
+          builder: (context, snapshot) {
+            final items = snapshot.data ?? const <_NotificationInboxItem>[];
+            return RefreshIndicator(
+              onRefresh: () async {
+                final next = _loadItems();
+                setState(() {
+                  _itemsFuture = next;
+                });
+                await next;
+              },
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: const EdgeInsets.fromLTRB(17, 18, 17, 32),
+                children: [
+                  if (snapshot.connectionState != ConnectionState.done)
+                    const LinearProgressIndicator(minHeight: 3),
+                  if (items.isEmpty)
+                    const _PrototypeCard(
+                      child: _PrototypeInfoRow(
+                        icon: Icons.notifications_none,
+                        iconBackground: EasySubwayAccessibleColors.mintSoft,
+                        iconColor: EasySubwayAccessibleColors.mintDark,
+                        title: '새 알림이 없습니다',
+                        subtitle: '즐겨찾기 시설과 제보 상태가 바뀌면 여기에서 볼 수 있어요.',
+                      ),
+                    )
+                  else ...[
+                    _NotificationInboxChips(items: items),
+                    const SizedBox(height: 12),
+                    for (final item in items)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 10),
+                        child: _NotificationInboxCard(item: item),
+                      ),
+                  ],
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Future<List<_NotificationInboxItem>> _loadItems() async {
+    final items = <_NotificationInboxItem>[];
+    final favoriteFacilityRepository = widget.favoriteFacilityRepository;
+    if (favoriteFacilityRepository != null) {
+      try {
+        final facilities = await favoriteFacilityRepository
+            .listFavoriteFacilities();
+        for (final facility in facilities.where(_isFacilityAlert)) {
+          items.add(_NotificationInboxItem.facility(facility));
+        }
+      } catch (error, stackTrace) {
+        reportMobileError(
+          error,
+          stackTrace,
+          context: '알림함 즐겨찾기 시설 상태를 불러오는 중 예외가 발생했습니다.',
+        );
+      }
+    }
+
+    try {
+      final reports = await widget.reportRepository.listMyReports();
+      for (final report in reports) {
+        items.add(_NotificationInboxItem.report(report));
+      }
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '알림함 제보 상태를 불러오는 중 예외가 발생했습니다.',
+      );
+    }
+    return items;
+  }
+
+  void _openSettings() {
+    final repository = widget.notificationRepository;
+    if (repository == null) {
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => NotificationSettingsScreen(
+          repository: repository,
+          notificationPermissionProvider: widget.notificationPermissionProvider,
+        ),
+      ),
+    );
+  }
+}
+
+class _NotificationInboxItem {
+  const _NotificationInboxItem({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.kind,
+    this.report,
+    this.warning = false,
+  });
+
+  factory _NotificationInboxItem.facility(FavoriteFacility facility) {
+    final name = facility.name.trim().isEmpty
+        ? facility.typeLabel
+        : facility.name;
+    return _NotificationInboxItem(
+      icon: _facilityIcon(facility.type),
+      title: '${facility.stationLabel} $name',
+      subtitle: '${facility.typeLabel} ${facility.statusLabel}',
+      kind: '시설',
+      warning: true,
+    );
+  }
+
+  factory _NotificationInboxItem.report(FacilityReportResult report) {
+    return _NotificationInboxItem(
+      icon: Icons.report_outlined,
+      title: '제보 ${report.statusLabel}',
+      subtitle: '접수번호 ${report.id}',
+      kind: '제보',
+      report: report,
+    );
+  }
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final String kind;
+  final FacilityReportResult? report;
+  final bool warning;
+}
+
+class _NotificationInboxChips extends StatelessWidget {
+  const _NotificationInboxChips({required this.items});
+
+  final List<_NotificationInboxItem> items;
+
+  @override
+  Widget build(BuildContext context) {
+    final facilityCount = items.where((item) => item.kind == '시설').length;
+    final reportCount = items.length - facilityCount;
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        _HomeMiniBadge('전체 ${items.length}'),
+        if (facilityCount > 0) _HomeMiniBadge('시설 $facilityCount'),
+        if (reportCount > 0) _HomeMiniBadge('제보 $reportCount'),
+      ],
+    );
+  }
+}
+
+class _NotificationInboxCard extends StatelessWidget {
+  const _NotificationInboxCard({required this.item});
+
+  final _NotificationInboxItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    void open() {
+      final report = item.report;
+      if (report == null) {
+        return;
+      }
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => MyFacilityReportDetailScreen(report: report),
+        ),
+      );
+    }
+
+    final card = _PrototypeCard(
+      backgroundColor: item.warning
+          ? EasySubwayAccessibleColors.amberSoft
+          : Colors.white,
+      borderColor: item.warning
+          ? const Color(0xFFF1D49A)
+          : EasySubwayAccessibleColors.line,
+      child: _PrototypeInfoRow(
+        icon: item.icon,
+        iconBackground: Colors.white,
+        iconColor: item.warning
+            ? EasySubwayAccessibleColors.amber
+            : EasySubwayAccessibleColors.mintDark,
+        title: item.title,
+        subtitle: item.subtitle,
+        trailing: item.kind,
+      ),
+    );
+    if (item.report == null) {
+      return card;
+    }
+    return Semantics(
+      button: true,
+      label: '${item.title}, ${item.subtitle}',
+      onTap: open,
+      child: ExcludeSemantics(
+        child: InkWell(
+          onTap: open,
+          borderRadius: BorderRadius.circular(20),
+          child: card,
         ),
       ),
     );
@@ -1820,7 +2088,7 @@ class _HomeSavedRouteErrorCard extends StatelessWidget {
             icon: Icons.bookmark_border,
             iconBackground: EasySubwayAccessibleColors.amberSoft,
             iconColor: EasySubwayAccessibleColors.amber,
-            title: '저장한 경로를 불러오지 못했습니다',
+            title: '즐겨찾기한 경로를 불러오지 못했습니다',
             subtitle: '즐겨찾기 화면에서 다시 확인해 주세요',
             trailing: '확인 필요',
           ),
@@ -1837,7 +2105,7 @@ class _HomeSavedRouteErrorCard extends StatelessWidget {
                   borderRadius: BorderRadius.circular(12),
                 ),
               ),
-              child: const Text('저장한 경로 보기'),
+              child: const Text('즐겨찾기 경로 보기'),
             ),
           ),
         ],
@@ -2132,7 +2400,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('설정')),
+      appBar: AppBar(title: const Text('화면·접근성 설정')),
       body: SafeArea(
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
@@ -2247,13 +2515,26 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
             ),
             _AppSettingsSection(
               key: const Key('settingsSection-help-privacy'),
-              title: '도움말과 개인정보',
+              title: '도움말·문의',
               children: [
                 _AppSettingsActionTile(
+                  key: const Key('offlineDataSettingsButton'),
+                  icon: Icons.offline_pin_outlined,
+                  title: '인터넷 없이 이용',
+                  subtitle: '노선도와 역 정보 사용 범위를 확인해요',
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const OfflineDataScreen(),
+                      ),
+                    );
+                  },
+                ),
+                _AppSettingsActionTile(
                   key: const Key('settingsSupportPrivacyButton'),
-                  icon: Icons.privacy_tip_outlined,
-                  title: '도움말과 개인정보',
-                  subtitle: '지원, 개인정보 처리방침, 데이터 삭제 안내를 확인해요',
+                  icon: Icons.help_outline,
+                  title: '도움말·문의',
+                  subtitle: '사용법, 개인정보, 문의 경로를 확인해요',
                   onTap: widget.onOpenSupportAccess,
                 ),
               ],
@@ -2398,7 +2679,7 @@ class _AppSettingsInfoTile extends StatelessWidget {
   }
 }
 
-class FavoriteHomeScreen extends StatelessWidget {
+class FavoriteHomeScreen extends StatefulWidget {
   const FavoriteHomeScreen({
     required this.favoriteRepository,
     required this.favoriteFacilityRepository,
@@ -2423,72 +2704,396 @@ class FavoriteHomeScreen extends StatelessWidget {
   final String initialMobilityType;
 
   @override
+  State<FavoriteHomeScreen> createState() => _FavoriteHomeScreenState();
+}
+
+class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
+  late Future<_FavoriteHomeData> _dataFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _dataFuture = _loadData();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final sections = _favoriteSections(context);
-    return DefaultTabController(
-      length: sections.length,
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text('즐겨찾기'),
-          bottom: TabBar(tabs: [for (final section in sections) section.tab]),
-        ),
-        body: TabBarView(
-          children: [for (final section in sections) section.content],
+    return Scaffold(
+      appBar: AppBar(title: const Text('즐겨찾기')),
+      body: SafeArea(
+        child: FutureBuilder<_FavoriteHomeData>(
+          future: _dataFuture,
+          builder: (context, snapshot) {
+            final data = snapshot.data ?? const _FavoriteHomeData();
+            return RefreshIndicator(
+              onRefresh: () async {
+                final next = _loadData();
+                setState(() {
+                  _dataFuture = next;
+                });
+                await next;
+              },
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: const EdgeInsets.fromLTRB(17, 18, 17, 32),
+                children: [
+                  if (snapshot.connectionState != ConnectionState.done)
+                    const LinearProgressIndicator(minHeight: 3),
+                  const _HomePrototypeSection(title: '즐겨찾기한 항목'),
+                  _FavoriteHomeQuickGrid(
+                    stationCount: data.stations.length,
+                    facilityCount: data.facilities.length,
+                    routeCount: data.routes.length,
+                    onStations: widget.favoriteRepository == null
+                        ? null
+                        : _openFavoriteStations,
+                    onFacilities: widget.favoriteFacilityRepository == null
+                        ? null
+                        : _openFavoriteFacilities,
+                    onRoutes: widget.favoriteRouteRepository == null
+                        ? null
+                        : _openFavoriteRoutes,
+                  ),
+                  if (_firstFacilityAlert(data.facilities)
+                      case final alert?) ...[
+                    const _HomePrototypeSection(title: '확인 필요'),
+                    _HomeFacilityAlertCard(facility: alert),
+                  ],
+                  if (data.routes.isNotEmpty) ...[
+                    const _HomePrototypeSection(title: '최근 경로'),
+                    _HomeSavedRouteCard(
+                      route: data.routes.first,
+                      onTap: _openFavoriteRoutes,
+                    ),
+                  ],
+                  if (data.isEmpty)
+                    const Padding(
+                      padding: EdgeInsets.only(top: 16),
+                      child: _PrototypeCard(
+                        child: _PrototypeInfoRow(
+                          icon: Icons.bookmark_border,
+                          iconBackground: EasySubwayAccessibleColors.mintSoft,
+                          iconColor: EasySubwayAccessibleColors.mintDark,
+                          title: '즐겨찾기한 항목이 없습니다',
+                          subtitle: '역, 시설, 경로에서 즐겨찾기를 추가해 주세요.',
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            );
+          },
         ),
       ),
     );
   }
 
-  List<_FavoriteSection> _favoriteSections(BuildContext context) {
-    final sections = <_FavoriteSection>[];
-    final favoriteRouteRepository = this.favoriteRouteRepository;
-    final favoriteRepository = this.favoriteRepository;
-    final favoriteFacilityRepository = this.favoriteFacilityRepository;
-    if (favoriteRouteRepository != null) {
-      sections.add(
-        _FavoriteSection(
-          tab: const Tab(key: Key('favoriteRoutesTabButton'), text: '경로'),
-          content: FavoriteRouteListContent(
-            repository: favoriteRouteRepository,
+  Future<_FavoriteHomeData> _loadData() async {
+    final stations = await _loadFavoriteList(
+      widget.favoriteRepository?.listFavoriteStations,
+    );
+    final facilities = await _loadFavoriteList(
+      widget.favoriteFacilityRepository?.listFavoriteFacilities,
+    );
+    final routes = await _loadFavoriteList(
+      widget.favoriteRouteRepository?.listFavoriteRoutes,
+    );
+    return _FavoriteHomeData(
+      stations: stations,
+      facilities: facilities,
+      routes: routes,
+    );
+  }
+
+  Future<List<T>> _loadFavoriteList<T>(Future<List<T>> Function()? load) async {
+    if (load == null) {
+      return const [];
+    }
+    try {
+      return await load();
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  void _openFavoriteRoutes() {
+    final repository = widget.favoriteRouteRepository;
+    if (repository == null) {
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => _FavoriteListScreen(
+          title: '즐겨찾기한 경로',
+          child: FavoriteRouteListContent(repository: repository),
+        ),
+      ),
+    );
+  }
+
+  void _openFavoriteStations() {
+    final repository = widget.favoriteRepository;
+    if (repository == null) {
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => _FavoriteListScreen(
+          title: '즐겨찾기한 역',
+          child: FavoriteStationListContent(
+            repository: repository,
+            stationRepository: widget.stationRepository,
+            reportRepository: widget.reportRepository,
+            locationProvider: widget.locationProvider,
+            facilityReportDraftTargetStore:
+                widget.facilityReportDraftTargetStore,
+            internalRouteRepository: widget.internalRouteRepository,
+            internalRouteMobilityType: widget.initialMobilityType,
           ),
         ),
-      );
+      ),
+    );
+  }
+
+  void _openFavoriteFacilities() {
+    final repository = widget.favoriteFacilityRepository;
+    if (repository == null) {
+      return;
     }
-    if (favoriteRepository != null) {
-      sections.add(
-        _FavoriteSection(
-          tab: const Tab(key: Key('favoriteStationsTabButton'), text: '역'),
-          content: FavoriteStationListContent(
-            repository: favoriteRepository,
-            stationRepository: stationRepository,
-            reportRepository: reportRepository,
-            locationProvider: locationProvider,
-            facilityReportDraftTargetStore: facilityReportDraftTargetStore,
-            internalRouteRepository: internalRouteRepository,
-            internalRouteMobilityType: initialMobilityType,
-          ),
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => _FavoriteListScreen(
+          title: '즐겨찾기한 시설',
+          child: FavoriteFacilityListContent(repository: repository),
         ),
-      );
-    }
-    if (favoriteFacilityRepository != null) {
-      sections.add(
-        _FavoriteSection(
-          tab: const Tab(key: Key('favoriteFacilitiesTabButton'), text: '시설'),
-          content: FavoriteFacilityListContent(
-            repository: favoriteFacilityRepository,
-          ),
-        ),
-      );
-    }
-    return sections;
+      ),
+    );
   }
 }
 
-class _FavoriteSection {
-  const _FavoriteSection({required this.tab, required this.content});
+class _FavoriteHomeData {
+  const _FavoriteHomeData({
+    this.stations = const [],
+    this.facilities = const [],
+    this.routes = const [],
+  });
 
-  final Tab tab;
-  final Widget content;
+  final List<FavoriteStation> stations;
+  final List<FavoriteFacility> facilities;
+  final List<FavoriteRoute> routes;
+
+  bool get isEmpty => stations.isEmpty && facilities.isEmpty && routes.isEmpty;
+}
+
+class _FavoriteHomeQuickGrid extends StatelessWidget {
+  const _FavoriteHomeQuickGrid({
+    required this.stationCount,
+    required this.facilityCount,
+    required this.routeCount,
+    required this.onStations,
+    required this.onFacilities,
+    required this.onRoutes,
+  });
+
+  final int stationCount;
+  final int facilityCount;
+  final int routeCount;
+  final VoidCallback? onStations;
+  final VoidCallback? onFacilities;
+  final VoidCallback? onRoutes;
+
+  @override
+  Widget build(BuildContext context) {
+    return GridView.count(
+      crossAxisCount: 2,
+      crossAxisSpacing: 10,
+      mainAxisSpacing: 10,
+      childAspectRatio: 1.45,
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      children: [
+        _FavoriteHomeQuickCard(
+          key: const Key('favoriteHomeStationsButton'),
+          icon: Icons.train_outlined,
+          label: '역 ${_countLabel(stationCount)}',
+          onTap: onStations,
+        ),
+        _FavoriteHomeQuickCard(
+          key: const Key('favoriteHomeFacilitiesButton'),
+          icon: Icons.elevator_outlined,
+          label: '시설 ${_countLabel(facilityCount)}',
+          onTap: onFacilities,
+        ),
+        _FavoriteHomeQuickCard(
+          key: const Key('favoriteHomeRoutesButton'),
+          icon: Icons.route_outlined,
+          label: '경로 ${_countLabel(routeCount)}',
+          onTap: onRoutes,
+        ),
+      ],
+    );
+  }
+}
+
+class _FavoriteHomeQuickCard extends StatelessWidget {
+  const _FavoriteHomeQuickCard({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    super.key,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      enabled: onTap != null,
+      label: label,
+      onTap: onTap,
+      child: ExcludeSemantics(
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(18),
+          child: _PrototypeCard(
+            backgroundColor: Colors.white,
+            borderRadius: 18,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: EasySubwayAccessibleColors.mintSoft,
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: SizedBox(
+                    width: 44,
+                    height: 44,
+                    child: Icon(
+                      icon,
+                      color: EasySubwayAccessibleColors.mintDark,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 9),
+                Text(
+                  label,
+                  style: const TextStyle(
+                    color: EasySubwayAccessibleColors.text,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String _countLabel(int count) => '$count개';
+
+class _FavoriteListScreen extends StatelessWidget {
+  const _FavoriteListScreen({required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: SafeArea(child: child),
+    );
+  }
+}
+
+class OfflineDataScreen extends StatelessWidget {
+  const OfflineDataScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('인터넷 없이 이용')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          children: const [
+            _PrototypeCard(
+              backgroundColor: EasySubwayAccessibleColors.mintSoft,
+              borderColor: EasySubwayAccessibleColors.mintBorder,
+              child: _PrototypeInfoRow(
+                icon: Icons.check_circle_outline,
+                iconBackground: Colors.white,
+                iconColor: EasySubwayAccessibleColors.mintDark,
+                title: '인터넷 없이도 이용할 수 있어요',
+                subtitle: '마지막으로 받은 노선도와 역 정보를 보여줍니다.',
+              ),
+            ),
+            _HomePrototypeSection(title: '이용 가능'),
+            _PrototypeCard(
+              child: Column(
+                children: [
+                  _PrototypeInfoRow(
+                    icon: Icons.map_outlined,
+                    iconBackground: EasySubwayAccessibleColors.mintSoft,
+                    iconColor: EasySubwayAccessibleColors.mintDark,
+                    title: '노선도',
+                    subtitle: '지역·노선·역 보기',
+                    trailing: '가능',
+                  ),
+                  _PrototypeInfoRow(
+                    icon: Icons.train_outlined,
+                    iconBackground: EasySubwayAccessibleColors.mintSoft,
+                    iconColor: EasySubwayAccessibleColors.mintDark,
+                    title: '역·시설 정보',
+                    subtitle: '출구와 엘리베이터 보기',
+                    trailing: '가능',
+                  ),
+                  _PrototypeInfoRow(
+                    icon: Icons.bookmark_border,
+                    iconBackground: EasySubwayAccessibleColors.mintSoft,
+                    iconColor: EasySubwayAccessibleColors.mintDark,
+                    title: '즐겨찾기한 항목',
+                    subtitle: '역·시설·경로 보기',
+                    trailing: '가능',
+                  ),
+                ],
+              ),
+            ),
+            _HomePrototypeSection(title: '인터넷 연결 필요'),
+            _PrototypeCard(
+              child: Column(
+                children: [
+                  _PrototypeInfoRow(
+                    icon: Icons.report_outlined,
+                    iconBackground: EasySubwayAccessibleColors.amberSoft,
+                    iconColor: EasySubwayAccessibleColors.amber,
+                    title: '시설 제보',
+                    subtitle: '사진과 제보 보내기',
+                    trailing: '연결 필요',
+                  ),
+                  _PrototypeInfoRow(
+                    icon: Icons.refresh,
+                    iconBackground: EasySubwayAccessibleColors.amberSoft,
+                    iconColor: EasySubwayAccessibleColors.amber,
+                    title: '시설 상태 새로 확인',
+                    subtitle: '최신 고장·복구 확인',
+                    trailing: '연결 필요',
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class SupportAccessScreen extends StatelessWidget {
@@ -2503,12 +3108,12 @@ class SupportAccessScreen extends StatelessWidget {
   final SupportAccessInfo accessInfo;
   final SupportAccessLauncher launcher;
   final UserDataDeletionRepository? userDataDeletionRepository;
-  final Future<void> Function()? onUserDataDeleted;
+  final Future<void> Function(UserDataDeletionResult result)? onUserDataDeleted;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('도움말')),
+      appBar: AppBar(title: const Text('도움말·문의')),
       body: SafeArea(
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
@@ -2577,7 +3182,7 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
   });
 
   final UserDataDeletionRepository repository;
-  final Future<void> Function()? onDeleted;
+  final Future<void> Function(UserDataDeletionResult result)? onDeleted;
 
   @override
   Widget build(BuildContext context) {
@@ -2664,7 +3269,7 @@ class UserDataDeletionScreen extends StatefulWidget {
   });
 
   final UserDataDeletionRepository repository;
-  final Future<void> Function()? onDeleted;
+  final Future<void> Function(UserDataDeletionResult result)? onDeleted;
 
   @override
   State<UserDataDeletionScreen> createState() => _UserDataDeletionScreenState();
@@ -2769,8 +3374,8 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
       _isDeleting = true;
     });
     try {
-      await widget.repository.deleteCurrentUserData();
-      await widget.onDeleted?.call();
+      final result = await widget.repository.deleteCurrentUserData();
+      await widget.onDeleted?.call(result);
       if (!mounted) {
         return;
       }
@@ -2830,6 +3435,144 @@ class _DataDeletionNoticeLine extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class UserDataDeletionResultScreen extends StatelessWidget {
+  const UserDataDeletionResultScreen({
+    required this.result,
+    required this.onRestart,
+    super.key,
+  });
+
+  final UserDataDeletionResult result;
+  final VoidCallback onRestart;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('삭제 완료'),
+        automaticallyImplyLeading: false,
+      ),
+      bottomNavigationBar: SafeArea(
+        minimum: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+        child: FilledButton.icon(
+          key: const Key('dataDeletionResultStartButton'),
+          onPressed: onRestart,
+          icon: const Icon(Icons.restart_alt),
+          label: const Text('처음부터 시작'),
+        ),
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          children: [
+            _PrototypeCard(
+              backgroundColor: EasySubwayAccessibleColors.mintSoft,
+              borderColor: EasySubwayAccessibleColors.mintBorder,
+              child: Column(
+                children: [
+                  const Icon(
+                    Icons.check_circle,
+                    color: EasySubwayAccessibleColors.mintDark,
+                    size: 56,
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    '내 데이터가 삭제됐어요',
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      color: EasySubwayAccessibleColors.text,
+                      fontWeight: FontWeight.w900,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 6),
+                  const Text(
+                    '앱이 처음 사용하는 상태로 돌아갑니다.',
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+            const _HomePrototypeSection(title: '처리 결과'),
+            _PrototypeCard(
+              child: Column(
+                children: [
+                  _DataDeletionResultRow(
+                    icon: Icons.train_outlined,
+                    title: '즐겨찾기한 역',
+                    value: '${result.deletedFavoriteStationCount}개 삭제',
+                  ),
+                  _DataDeletionResultRow(
+                    icon: Icons.elevator_outlined,
+                    title: '즐겨찾기한 시설',
+                    value: '${result.deletedFavoriteFacilityCount}개 삭제',
+                  ),
+                  _DataDeletionResultRow(
+                    icon: Icons.route_outlined,
+                    title: '즐겨찾기한 경로',
+                    value: '${result.deletedFavoriteRouteCount}개 삭제',
+                  ),
+                  _DataDeletionResultRow(
+                    icon: Icons.notifications_none,
+                    title: '알림 설정',
+                    value: result.notificationSettingsDeleted
+                        ? '삭제'
+                        : '삭제할 항목 없음',
+                  ),
+                  _DataDeletionResultRow(
+                    icon: Icons.report_outlined,
+                    title: '제보 연결 정보',
+                    value: '${result.anonymizedReportCount}건 익명화',
+                  ),
+                  _DataDeletionResultRow(
+                    icon: Icons.rate_review_outlined,
+                    title: '경로 의견 연결 정보',
+                    value: '${result.anonymizedRouteFeedbackCount}건 익명화',
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 12),
+            const _PrototypeCard(
+              backgroundColor: EasySubwayAccessibleColors.skySoft,
+              borderColor: Color(0xFFB7DDF4),
+              child: _PrototypeInfoRow(
+                icon: Icons.map_outlined,
+                iconBackground: Colors.white,
+                iconColor: EasySubwayAccessibleColors.brand,
+                title: '노선도와 역 정보는 계속 이용할 수 있어요',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DataDeletionResultRow extends StatelessWidget {
+  const _DataDeletionResultRow({
+    required this.icon,
+    required this.title,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String title;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return _PrototypeInfoRow(
+      icon: icon,
+      iconBackground: EasySubwayAccessibleColors.mintSoft,
+      iconColor: EasySubwayAccessibleColors.mintDark,
+      title: title,
+      subtitle: value,
+      trailing: '완료',
     );
   }
 }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -369,6 +369,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
       widget.onboardingStore != null &&
       !widget.initialOnboardingState.isCompleted;
   bool _startScreenDismissed = false;
+  bool _introScreenDismissed = false;
   bool _pendingFacilityReportPhotoRecoveryStarted = false;
 
   @override
@@ -395,6 +396,28 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
           onStart: () {
             setState(() {
               _startScreenDismissed = true;
+            });
+          },
+        );
+      }
+      if (!_introScreenDismissed) {
+        return OnboardingIntroScreen(
+          onConfigure: () {
+            setState(() {
+              _introScreenDismissed = true;
+            });
+          },
+          onSkip: () async {
+            final result = OnboardingResult(
+              profile: mobilityProfileOptions.first,
+              preferences: const OnboardingViewPreferences.defaults(),
+            );
+            await _saveOnboardingResult(result);
+            if (!mounted) {
+              return;
+            }
+            setState(() {
+              _onboardingState = OnboardingState.completed(result: result);
             });
           },
         );
@@ -464,6 +487,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
       _onboardingState = const OnboardingState.initial();
       _loadingOnboardingState = false;
       _startScreenDismissed = false;
+      _introScreenDismissed = false;
     });
   }
 

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -2812,11 +2812,10 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
     try {
       return await load();
     } catch (error, stackTrace) {
-      reportMobileError(
-        error,
-        stackTrace,
-        context: '즐겨찾기 홈 요약을 불러오는 중 예외가 발생했습니다.',
-      );
+      assert(() {
+        stackTrace.toString();
+        return true;
+      }());
       return const [];
     }
   }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -2821,12 +2821,10 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
     if (repository == null) {
       return;
     }
-    Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        builder: (_) => _FavoriteListScreen(
-          title: '즐겨찾기한 경로',
-          child: FavoriteRouteListContent(repository: repository),
-        ),
+    unawaited(
+      _openFavoriteListScreen(
+        title: '즐겨찾기한 경로',
+        child: FavoriteRouteListContent(repository: repository),
       ),
     );
   }
@@ -2836,20 +2834,17 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
     if (repository == null) {
       return;
     }
-    Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        builder: (_) => _FavoriteListScreen(
-          title: '즐겨찾기한 역',
-          child: FavoriteStationListContent(
-            repository: repository,
-            stationRepository: widget.stationRepository,
-            reportRepository: widget.reportRepository,
-            locationProvider: widget.locationProvider,
-            facilityReportDraftTargetStore:
-                widget.facilityReportDraftTargetStore,
-            internalRouteRepository: widget.internalRouteRepository,
-            internalRouteMobilityType: widget.initialMobilityType,
-          ),
+    unawaited(
+      _openFavoriteListScreen(
+        title: '즐겨찾기한 역',
+        child: FavoriteStationListContent(
+          repository: repository,
+          stationRepository: widget.stationRepository,
+          reportRepository: widget.reportRepository,
+          locationProvider: widget.locationProvider,
+          facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
+          internalRouteRepository: widget.internalRouteRepository,
+          internalRouteMobilityType: widget.initialMobilityType,
         ),
       ),
     );
@@ -2860,14 +2855,31 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
     if (repository == null) {
       return;
     }
-    Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        builder: (_) => _FavoriteListScreen(
-          title: '즐겨찾기한 시설',
-          child: FavoriteFacilityListContent(repository: repository),
-        ),
+    unawaited(
+      _openFavoriteListScreen(
+        title: '즐겨찾기한 시설',
+        child: FavoriteFacilityListContent(repository: repository),
       ),
     );
+  }
+
+  Future<void> _openFavoriteListScreen({
+    required String title,
+    required Widget child,
+  }) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => _FavoriteListScreen(title: title, child: child),
+      ),
+    );
+    if (!mounted) {
+      return;
+    }
+    final next = _loadData();
+    setState(() {
+      _dataFuture = next;
+    });
+    await next;
   }
 }
 

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -2811,7 +2811,12 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
     }
     try {
       return await load();
-    } catch (_) {
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '즐겨찾기 홈 요약을 불러오는 중 예외가 발생했습니다.',
+      );
       return const [];
     }
   }

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -193,60 +193,72 @@ class StartScreen extends StatelessWidget {
           ),
         ),
         child: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(24, 48, 24, 35),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const SizedBox(height: 212),
-                Semantics(
-                  header: true,
-                  child: Text.rich(
-                    TextSpan(
-                      children: [
-                        TextSpan(text: '빠른 길보다,\n'),
-                        TextSpan(
-                          text: '갈 수 있는 길',
-                          style: TextStyle(color: Color(0xFFB8F4DF)),
-                        ),
-                        TextSpan(text: '을\n먼저 안내해요.'),
-                      ],
-                    ),
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 44,
-                      fontWeight: FontWeight.w900,
-                      height: 1.12,
-                    ),
-                  ),
-                ),
-                const Spacer(),
-                SizedBox(
-                  width: double.infinity,
-                  child: FilledButton(
-                    key: const Key('startScreenStartButton'),
-                    onPressed: onStart,
-                    style: FilledButton.styleFrom(
-                      backgroundColor: Colors.white,
-                      foregroundColor: const Color(0xFF0B3B42),
-                      minimumSize: const Size.fromHeight(60),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(15),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final topGap = (constraints.maxHeight * 0.34).clamp(84.0, 212.0);
+              return SingleChildScrollView(
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                  child: IntrinsicHeight(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(24, 48, 24, 35),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          SizedBox(height: topGap),
+                          Semantics(
+                            header: true,
+                            child: Text.rich(
+                              TextSpan(
+                                children: [
+                                  TextSpan(text: '빠른 길보다,\n'),
+                                  TextSpan(
+                                    text: '갈 수 있는 길',
+                                    style: TextStyle(color: Color(0xFFB8F4DF)),
+                                  ),
+                                  TextSpan(text: '을\n먼저 안내해요.'),
+                                ],
+                              ),
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 44,
+                                fontWeight: FontWeight.w900,
+                                height: 1.12,
+                              ),
+                            ),
+                          ),
+                          const Spacer(),
+                          SizedBox(
+                            width: double.infinity,
+                            child: FilledButton(
+                              key: const Key('startScreenStartButton'),
+                              onPressed: onStart,
+                              style: FilledButton.styleFrom(
+                                backgroundColor: Colors.white,
+                                foregroundColor: const Color(0xFF0B3B42),
+                                minimumSize: const Size.fromHeight(60),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(15),
+                                ),
+                              ),
+                              child: const Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Text('쉬운 지하철 시작하기'),
+                                  SizedBox(width: 8),
+                                  Icon(Icons.arrow_forward),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                    child: const Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text('쉬운 지하철 시작하기'),
-                        SizedBox(width: 8),
-                        Icon(Icons.arrow_forward),
-                      ],
-                    ),
                   ),
                 ),
-              ],
-            ),
+              );
+            },
           ),
         ),
       ),

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -9,8 +9,6 @@ import 'secure_key_value_storage.dart';
 import 'station_search.dart';
 
 const _onboardingResultStorageKey = 'easysubway.onboarding.result';
-const _onboardingNotificationFailureNextAction = '나중에 알림 설정에서 다시 켤 수 있습니다.';
-const startScreenAppIconAsset = 'assets/branding/app_icon.png';
 
 abstract class OnboardingResultStore {
   Future<OnboardingResult?> readResult();
@@ -191,7 +189,7 @@ class StartScreen extends StatelessWidget {
           gradient: LinearGradient(
             begin: Alignment.topLeft,
             end: Alignment.bottomRight,
-            colors: [Color(0xFF071B2F), Color(0xFF17527C)],
+            colors: [Color(0xFF0D8A6D), Color(0xFF17527C)],
           ),
         ),
         child: SafeArea(
@@ -200,22 +198,7 @@ class StartScreen extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Semantics(
-                  image: true,
-                  label: '쉬운 지하철 앱 아이콘',
-                  child: ExcludeSemantics(
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(20),
-                      child: Image.asset(
-                        startScreenAppIconAsset,
-                        width: 62,
-                        height: 62,
-                        fit: BoxFit.cover,
-                      ),
-                    ),
-                  ),
-                ),
-                const Spacer(flex: 5),
+                const SizedBox(height: 212),
                 Semantics(
                   header: true,
                   child: Text.rich(
@@ -224,45 +207,41 @@ class StartScreen extends StatelessWidget {
                         TextSpan(text: '빠른 길보다,\n'),
                         TextSpan(
                           text: '갈 수 있는 길',
-                          style: TextStyle(color: Color(0xFF84E2C5)),
+                          style: TextStyle(color: Color(0xFFB8F4DF)),
                         ),
                         TextSpan(text: '을\n먼저 안내해요.'),
                       ],
                     ),
                     style: TextStyle(
                       color: Colors.white,
-                      fontSize: 38,
+                      fontSize: 44,
                       fontWeight: FontWeight.w900,
-                      height: 1.18,
+                      height: 1.12,
                     ),
                   ),
                 ),
-                const Spacer(flex: 6),
+                const Spacer(),
                 SizedBox(
                   width: double.infinity,
-                  child: FilledButton.icon(
+                  child: FilledButton(
                     key: const Key('startScreenStartButton'),
                     onPressed: onStart,
-                    icon: const Icon(Icons.arrow_forward),
-                    label: const Text('쉬운 지하철 시작하기'),
                     style: FilledButton.styleFrom(
                       backgroundColor: Colors.white,
-                      foregroundColor: const Color(0xFF071B2F),
+                      foregroundColor: const Color(0xFF0B3B42),
                       minimumSize: const Size.fromHeight(60),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(15),
                       ),
                     ),
-                  ),
-                ),
-                const SizedBox(height: 13),
-                const Center(
-                  child: Text(
-                    '로그인 없이도 이용할 수 있어요',
-                    style: TextStyle(
-                      color: Color(0xFFA9BFCD),
-                      fontSize: 11,
-                      fontWeight: FontWeight.w700,
+                    child: const Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text('쉬운 지하철 시작하기'),
+                        SizedBox(width: 8),
+                        Icon(Icons.arrow_forward),
+                      ],
                     ),
                   ),
                 ),
@@ -271,6 +250,448 @@ class StartScreen extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class OnboardingIntroScreen extends StatelessWidget {
+  const OnboardingIntroScreen({
+    required this.onConfigure,
+    required this.onSkip,
+    super.key,
+  });
+
+  final VoidCallback onConfigure;
+  final VoidCallback onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('쉬운 지하철')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          children: [
+            const _IntroVisual(),
+            const SizedBox(height: 25),
+            Semantics(
+              header: true,
+              child: Text(
+                '계단 없는 길을\n먼저 찾습니다',
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                  color: const Color(0xFF102A2C),
+                  fontWeight: FontWeight.w900,
+                  height: 1.25,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            const _IntroInfoCard(),
+            const SizedBox(height: 20),
+            FilledButton(
+              key: const Key('onboardingIntroConfigureButton'),
+              onPressed: onConfigure,
+              style: FilledButton.styleFrom(
+                minimumSize: const Size.fromHeight(60),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              child: const Text('이동 조건 설정'),
+            ),
+            const SizedBox(height: 9),
+            OutlinedButton(
+              key: const Key('onboardingIntroSkipButton'),
+              onPressed: onSkip,
+              style: OutlinedButton.styleFrom(
+                minimumSize: const Size.fromHeight(60),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              child: const Text('바로 시작'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IntroVisual extends StatelessWidget {
+  const _IntroVisual();
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 230,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: const LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [Color(0xFFE4F7F0), Color(0xFFEAF5FF)],
+          ),
+          border: Border.all(color: const Color(0xFFC8D3DC)),
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: const Stack(
+          children: [
+            Positioned(
+              left: 28,
+              top: 38,
+              child: _IntroIcon(
+                icon: Icons.accessible_forward,
+                color: Color(0xFF0A705A),
+              ),
+            ),
+            Positioned(
+              right: 30,
+              top: 80,
+              child: _IntroIcon(
+                icon: Icons.elevator_outlined,
+                color: Color(0xFF17527C),
+              ),
+            ),
+            Positioned(
+              left: 117,
+              bottom: 26,
+              child: _IntroIcon(
+                icon: Icons.route,
+                color: Colors.white,
+                backgroundColor: Color(0xFF071B2F),
+                size: 94,
+                iconSize: 44,
+                radius: 29,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IntroIcon extends StatelessWidget {
+  const _IntroIcon({
+    required this.icon,
+    required this.color,
+    this.backgroundColor = Colors.white,
+    this.size = 86,
+    this.iconSize = 43,
+    this.radius = 27,
+  });
+
+  final IconData icon;
+  final Color color;
+  final Color backgroundColor;
+  final double size;
+  final double iconSize;
+  final double radius;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(radius),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x16071B2F),
+            blurRadius: 20,
+            offset: Offset(0, 8),
+          ),
+        ],
+      ),
+      child: SizedBox(
+        width: size,
+        height: size,
+        child: Icon(icon, color: color, size: iconSize),
+      ),
+    );
+  }
+}
+
+class _IntroInfoCard extends StatelessWidget {
+  const _IntroInfoCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return const _IntroCard(
+      child: Column(
+        children: [
+          _IntroInfoRow(
+            icon: Icons.elevator_outlined,
+            title: '엘리베이터 확인',
+            subtitle: '고장 시설을 피해 안내',
+          ),
+          _IntroDivider(),
+          _IntroInfoRow(
+            icon: Icons.route_outlined,
+            title: '걷기와 환승 줄이기',
+            subtitle: '내 이동 조건에 맞춰 안내',
+          ),
+          _IntroDivider(),
+          _IntroInfoRow(
+            icon: Icons.map_outlined,
+            title: '인터넷 없이 이용',
+            subtitle: '노선도와 역 정보 확인',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _IntroCard extends StatelessWidget {
+  const _IntroCard({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: const Color(0xFFD5E2E4)),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Padding(padding: const EdgeInsets.all(16), child: child),
+    );
+  }
+}
+
+class _IntroInfoRow extends StatelessWidget {
+  const _IntroInfoRow({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        DecoratedBox(
+          decoration: BoxDecoration(
+            color: const Color(0xFFDFF7EF),
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: SizedBox(
+            width: 43,
+            height: 43,
+            child: Icon(icon, color: const Color(0xFF0A705A), size: 22),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: const Color(0xFF102A2C),
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 3),
+              Text(
+                subtitle,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: const Color(0xFF647686),
+                  fontWeight: FontWeight.w700,
+                  height: 1.35,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _IntroDivider extends StatelessWidget {
+  const _IntroDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 13),
+      child: Divider(height: 1, color: Color(0xFFE0E7EC)),
+    );
+  }
+}
+
+class _OnboardingStepIndicator extends StatelessWidget {
+  const _OnboardingStepIndicator({
+    required this.currentStep,
+    required this.totalSteps,
+  });
+
+  final int currentStep;
+  final int totalSteps;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            for (var step = 1; step <= totalSteps; step++) ...[
+              Expanded(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: step <= currentStep
+                        ? const Color(0xFF0D8A6D)
+                        : const Color(0xFFDBE3E9),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: const SizedBox(height: 5),
+                ),
+              ),
+              if (step != totalSteps) const SizedBox(width: 4),
+            ],
+          ],
+        ),
+        const SizedBox(height: 5),
+        Text(
+          '$currentStep / $totalSteps',
+          textAlign: TextAlign.right,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: const Color(0xFF647686),
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PermissionInfoCard extends StatelessWidget {
+  const _PermissionInfoCard({
+    required this.locationSelected,
+    required this.notificationSelected,
+    required this.onLocationChanged,
+    required this.onNotificationChanged,
+  });
+
+  final bool locationSelected;
+  final bool notificationSelected;
+  final ValueChanged<bool> onLocationChanged;
+  final ValueChanged<bool> onNotificationChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return _IntroCard(
+      child: Column(
+        children: [
+          _PermissionInfoRow(
+            icon: Icons.location_on_outlined,
+            title: '현재 위치',
+            subtitle: '가까운 역 찾기',
+            mint: true,
+            value: locationSelected,
+            onChanged: onLocationChanged,
+          ),
+          const _IntroDivider(),
+          _PermissionInfoRow(
+            icon: Icons.notifications_none,
+            title: '알림',
+            subtitle: '시설 고장·복구 알림',
+            value: notificationSelected,
+            onChanged: onNotificationChanged,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PermissionInfoRow extends StatelessWidget {
+  const _PermissionInfoRow({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+    this.mint = false,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final bool mint;
+
+  @override
+  Widget build(BuildContext context) {
+    final iconColor = mint ? const Color(0xFF0A705A) : const Color(0xFF17527C);
+    final iconBackground = mint
+        ? const Color(0xFFDFF7EF)
+        : const Color(0xFFEEF3F6);
+
+    return Row(
+      children: [
+        DecoratedBox(
+          decoration: BoxDecoration(
+            color: iconBackground,
+            borderRadius: BorderRadius.circular(14),
+          ),
+          child: SizedBox(
+            width: 43,
+            height: 43,
+            child: Icon(icon, color: iconColor, size: 22),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: const Color(0xFF102A2C),
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 3),
+              Text(
+                subtitle,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: const Color(0xFF647686),
+                  fontWeight: FontWeight.w700,
+                  height: 1.35,
+                ),
+              ),
+            ],
+          ),
+        ),
+        Semantics(
+          label: '$title ${value ? '켜짐' : '꺼짐'}',
+          toggled: value,
+          onTap: () => onChanged(!value),
+          child: ExcludeSemantics(
+            child: Switch(
+              value: value,
+              onChanged: onChanged,
+              activeThumbColor: Colors.white,
+              activeTrackColor: const Color(0xFF0D8A6D),
+              inactiveThumbColor: Colors.white,
+              inactiveTrackColor: const Color(0xFFC8D3DC),
+              materialTapTargetSize: MaterialTapTargetSize.padded,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }
@@ -293,496 +714,227 @@ class OnboardingScreen extends StatefulWidget {
 
 class _OnboardingScreenState extends State<OnboardingScreen> {
   MobilityProfileOption? _selectedProfile;
-  OnboardingViewPreferences _preferences =
+  final OnboardingViewPreferences _preferences =
       const OnboardingViewPreferences.defaults();
-  String _locationMessage = '';
-  bool _isLocationFailure = false;
-  bool _isCheckingLocation = false;
-  bool _isOpeningLocationSettings = false;
-  String _notificationMessage = '';
-  bool _isNotificationFailure = false;
-  bool _isRequestingNotificationPermission = false;
+  int _currentStep = 0;
+  bool _avoidStairs = true;
+  bool _requireElevator = true;
+  bool _minimizeTransfers = true;
+  bool _avoidLongWalks = true;
+  bool _locationPermissionSelected = true;
+  bool _notificationPermissionSelected = true;
 
   @override
   Widget build(BuildContext context) {
     final selectedProfile = _selectedProfile;
     final textTheme = Theme.of(context).textTheme;
+    final profileOptions = [
+      mobilityProfileOptions.firstWhere((profile) => profile.id == 'elderly'),
+      mobilityProfileOptions.firstWhere(
+        (profile) => profile.id == 'wheelchair',
+      ),
+      mobilityProfileOptions.firstWhere((profile) => profile.id == 'stroller'),
+      mobilityProfileOptions.firstWhere((profile) => profile.id == 'pregnant'),
+      mobilityProfileOptions.firstWhere((profile) => profile.id == 'injured'),
+      mobilityProfileOptions.firstWhere((profile) => profile.id == 'luggage'),
+    ];
+
+    final onNext = selectedProfile == null
+        ? null
+        : () {
+            if (_currentStep == 0) {
+              setState(() => _currentStep = 1);
+              return;
+            }
+            if (_currentStep == 1) {
+              setState(() => _currentStep = 2);
+              return;
+            }
+            _completeOnboarding();
+          };
 
     return Scaffold(
       appBar: AppBar(title: const Text('쉬운 지하철')),
-      bottomNavigationBar: SafeArea(
-        minimum: const EdgeInsets.fromLTRB(20, 8, 20, 20),
-        child: FilledButton.icon(
-          key: const Key('onboardingDoneButton'),
-          onPressed: selectedProfile == null
-              ? null
-              : () {
-                  widget.onCompleted(
-                    OnboardingResult(
-                      profile: selectedProfile,
-                      preferences: _preferences,
-                    ),
-                  );
-                },
-          icon: const Icon(Icons.check),
-          label: const Text('시작하기'),
-          style: FilledButton.styleFrom(
-            minimumSize: const Size.fromHeight(60),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
+      bottomNavigationBar: _currentStep == 2
+          ? null
+          : SafeArea(
+              minimum: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+              child: FilledButton(
+                key: const Key('onboardingDoneButton'),
+                onPressed: onNext,
+                style: FilledButton.styleFrom(
+                  minimumSize: const Size.fromHeight(60),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                child: const Text('다음'),
+              ),
             ),
-          ),
-        ),
-      ),
       body: SafeArea(
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
-          children: [
-            Semantics(
-              header: true,
-              child: Text(
-                '먼저 이동 조건을 골라 주세요',
-                style: textTheme.headlineSmall?.copyWith(
-                  color: const Color(0xFF102A2C),
-                  fontWeight: FontWeight.w900,
-                  height: 1.25,
-                ),
-              ),
-            ),
-            const SizedBox(height: 20),
-            Text(
-              '이동 조건',
-              style: textTheme.titleLarge?.copyWith(
-                color: const Color(0xFF102A2C),
-                fontWeight: FontWeight.w900,
-              ),
-            ),
-            const SizedBox(height: 12),
-            for (final profile in mobilityProfileOptions)
-              _OnboardingProfileCard(
-                profile: profile,
-                selected: profile.id == selectedProfile?.id,
-                onTap: () {
-                  setState(() {
-                    _selectedProfile = profile;
-                  });
-                },
-              ),
-            if (widget.locationProvider != null) ...[
-              const SizedBox(height: 12),
-              Text(
-                '현재 위치',
-                style: textTheme.titleLarge?.copyWith(
-                  color: const Color(0xFF102A2C),
-                  fontWeight: FontWeight.w900,
-                ),
-              ),
-              const SizedBox(height: 12),
-              _OnboardingLocationSection(
-                message: _locationMessage,
-                isFailure: _isLocationFailure,
-                isChecking: _isCheckingLocation,
-                isOpeningSettings: _isOpeningLocationSettings,
-                isBlocked: _isRequestingNotificationPermission,
-                onPrepareLocation: _prepareLocation,
-                onOpenSettings: _openLocationSettings,
-              ),
-            ],
-            if (widget.notificationPermissionProvider != null) ...[
-              const SizedBox(height: 12),
-              Text(
-                '알림',
-                style: textTheme.titleLarge?.copyWith(
-                  color: const Color(0xFF102A2C),
-                  fontWeight: FontWeight.w900,
-                ),
-              ),
-              const SizedBox(height: 12),
-              _OnboardingNotificationSection(
-                message: _notificationMessage,
-                isFailure: _isNotificationFailure,
-                isRequesting: _isRequestingNotificationPermission,
-                isBlocked: _isCheckingLocation || _isOpeningLocationSettings,
-                onPrepareNotification: _prepareNotification,
-              ),
-            ],
-            const SizedBox(height: 12),
-            Text(
-              '보기 설정',
-              style: textTheme.titleLarge?.copyWith(
-                color: const Color(0xFF102A2C),
-                fontWeight: FontWeight.w900,
-              ),
-            ),
-            const SizedBox(height: 12),
-            _OnboardingPreferenceSwitch(
-              key: const Key('onboardingPreference-largeText'),
-              title: '큰 글씨',
-              value: _preferences.largeTextEnabled,
-              onChanged: (value) {
-                setState(() {
-                  _preferences = _preferences.copyWith(largeTextEnabled: value);
-                });
-              },
-            ),
-            _OnboardingPreferenceSwitch(
-              key: const Key('onboardingPreference-highContrast'),
-              title: '고대비',
-              value: _preferences.highContrastEnabled,
-              onChanged: (value) {
-                setState(() {
-                  _preferences = _preferences.copyWith(
-                    highContrastEnabled: value,
-                  );
-                });
-              },
-            ),
-            _OnboardingPreferenceSwitch(
-              key: const Key('onboardingPreference-simpleView'),
-              title: '단순 보기',
-              value: _preferences.simpleViewEnabled,
-              onChanged: (value) {
-                setState(() {
-                  _preferences = _preferences.copyWith(
-                    simpleViewEnabled: value,
-                  );
-                });
-              },
-            ),
-          ],
+          children: _currentStep == 0
+              ? [
+                  const _OnboardingStepIndicator(currentStep: 1, totalSteps: 3),
+                  const SizedBox(height: 15),
+                  Semantics(
+                    header: true,
+                    child: Text(
+                      '어떤 도움이 필요한가요?',
+                      style: textTheme.headlineSmall?.copyWith(
+                        color: const Color(0xFF102A2C),
+                        fontWeight: FontWeight.w900,
+                        height: 1.25,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  for (final profile in profileOptions)
+                    _OnboardingProfileCard(
+                      profile: profile,
+                      selected: profile.id == selectedProfile?.id,
+                      onTap: () {
+                        setState(() {
+                          _selectedProfile = profile;
+                        });
+                      },
+                    ),
+                ]
+              : _currentStep == 1
+              ? [
+                  const _OnboardingStepIndicator(currentStep: 2, totalSteps: 3),
+                  const SizedBox(height: 15),
+                  Semantics(
+                    header: true,
+                    child: Text(
+                      '원하는 조건을 고르세요',
+                      style: textTheme.headlineSmall?.copyWith(
+                        color: const Color(0xFF102A2C),
+                        fontWeight: FontWeight.w900,
+                        height: 1.25,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  _OnboardingPreferenceCard(
+                    children: [
+                      _OnboardingPreferenceSwitch(
+                        key: const Key('onboardingRoutePreference-avoidStairs'),
+                        title: '계단 피하기',
+                        subtitle: '계단 없는 길',
+                        value: _avoidStairs,
+                        onChanged: (value) =>
+                            setState(() => _avoidStairs = value),
+                      ),
+                      const _OnboardingPreferenceDivider(),
+                      _OnboardingPreferenceSwitch(
+                        key: const Key(
+                          'onboardingRoutePreference-requireElevator',
+                        ),
+                        title: '엘리베이터 이용',
+                        subtitle: '엘리베이터 연결',
+                        value: _requireElevator,
+                        onChanged: (value) =>
+                            setState(() => _requireElevator = value),
+                      ),
+                      const _OnboardingPreferenceDivider(),
+                      _OnboardingPreferenceSwitch(
+                        key: const Key(
+                          'onboardingRoutePreference-minimizeTransfers',
+                        ),
+                        title: '환승 줄이기',
+                        subtitle: '갈아타는 횟수 줄이기',
+                        value: _minimizeTransfers,
+                        onChanged: (value) =>
+                            setState(() => _minimizeTransfers = value),
+                      ),
+                      const _OnboardingPreferenceDivider(),
+                      _OnboardingPreferenceSwitch(
+                        key: const Key(
+                          'onboardingRoutePreference-avoidLongWalks',
+                        ),
+                        title: '걷는 거리 줄이기',
+                        subtitle: '오래 걷는 길 피하기',
+                        value: _avoidLongWalks,
+                        onChanged: (value) =>
+                            setState(() => _avoidLongWalks = value),
+                      ),
+                    ],
+                  ),
+                ]
+              : [
+                  const _OnboardingStepIndicator(currentStep: 3, totalSteps: 3),
+                  const SizedBox(height: 15),
+                  Semantics(
+                    header: true,
+                    child: Text(
+                      '권한을 선택하세요',
+                      style: textTheme.headlineSmall?.copyWith(
+                        color: const Color(0xFF102A2C),
+                        fontWeight: FontWeight.w900,
+                        height: 1.25,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  _PermissionInfoCard(
+                    locationSelected: _locationPermissionSelected,
+                    notificationSelected: _notificationPermissionSelected,
+                    onLocationChanged: (value) =>
+                        setState(() => _locationPermissionSelected = value),
+                    onNotificationChanged: (value) =>
+                        setState(() => _notificationPermissionSelected = value),
+                  ),
+                  const SizedBox(height: 22),
+                  OutlinedButton(
+                    key: const Key('onboardingPermissionSkipButton'),
+                    onPressed: _handlePermissionSkip,
+                    style: OutlinedButton.styleFrom(
+                      minimumSize: const Size.fromHeight(60),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: const Text('건너뛰기'),
+                  ),
+                ],
         ),
       ),
     );
   }
 
-  Future<void> _prepareLocation() async {
-    final locationProvider = widget.locationProvider;
-    if (locationProvider == null ||
-        _isCheckingLocation ||
-        _isOpeningLocationSettings ||
-        _isRequestingNotificationPermission) {
+  void _completeOnboarding() {
+    final selectedProfile = _selectedProfile;
+    if (selectedProfile == null) {
       return;
     }
-    setState(() {
-      _isCheckingLocation = true;
-      _locationMessage = '';
-      _isLocationFailure = false;
-    });
-    try {
-      // 온보딩에서는 좌표를 저장하지 않고, 이후 주변 역 찾기에서 바로 쓸 권한과 GPS 상태만 준비한다.
-      await locationProvider.currentLocation();
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _locationMessage = '위치 준비 완료';
-        _isLocationFailure = false;
-      });
-    } on CurrentLocationException catch (error) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _locationMessage = error.message;
-        _isLocationFailure = true;
-      });
-    } catch (error, stackTrace) {
-      reportMobileError(
-        error,
-        stackTrace,
-        context: '온보딩 현재 위치 준비 중 예외가 발생했습니다.',
-      );
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _locationMessage = '현재 위치를 확인하지 못했습니다.';
-        _isLocationFailure = true;
-      });
-    } finally {
-      if (mounted) {
-        setState(() => _isCheckingLocation = false);
-      }
-    }
-  }
-
-  Future<void> _openLocationSettings() async {
-    final locationProvider = widget.locationProvider;
-    if (locationProvider == null ||
-        _isOpeningLocationSettings ||
-        _isCheckingLocation ||
-        _isRequestingNotificationPermission) {
-      return;
-    }
-    setState(() => _isOpeningLocationSettings = true);
-    try {
-      await locationProvider.openLocationSettings();
-    } finally {
-      if (mounted) {
-        setState(() => _isOpeningLocationSettings = false);
-      }
-    }
-  }
-
-  Future<void> _prepareNotification() async {
-    final notificationPermissionProvider =
-        widget.notificationPermissionProvider;
-    if (notificationPermissionProvider == null ||
-        _isRequestingNotificationPermission ||
-        _isCheckingLocation ||
-        _isOpeningLocationSettings) {
-      return;
-    }
-    setState(() {
-      _isRequestingNotificationPermission = true;
-      _notificationMessage = '';
-      _isNotificationFailure = false;
-    });
-    try {
-      // 온보딩에서는 토큰을 등록하지 않고, 이후 알림 설정에서 쓸 기기 권한만 준비한다.
-      final status = await notificationPermissionProvider
-          .requestNotificationPermission();
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _notificationMessage = status == NotificationPermissionStatus.granted
-            ? '알림 준비 완료'
-            : '설정에서 알림 권한을 켜 주세요.';
-        _isNotificationFailure = status != NotificationPermissionStatus.granted;
-      });
-    } on NotificationSettingsException catch (error) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _notificationMessage = error.message;
-        _isNotificationFailure = true;
-      });
-    } catch (error, stackTrace) {
-      reportMobileError(
-        error,
-        stackTrace,
-        context: '온보딩 알림 권한 준비 중 예외가 발생했습니다.',
-      );
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _notificationMessage = '알림 권한을 확인하지 못했습니다.';
-        _isNotificationFailure = true;
-      });
-    } finally {
-      if (mounted) {
-        setState(() => _isRequestingNotificationPermission = false);
-      }
-    }
-  }
-}
-
-class _OnboardingLocationSection extends StatelessWidget {
-  const _OnboardingLocationSection({
-    required this.message,
-    required this.isFailure,
-    required this.isChecking,
-    required this.isOpeningSettings,
-    required this.isBlocked,
-    required this.onPrepareLocation,
-    required this.onOpenSettings,
-  });
-
-  final String message;
-  final bool isFailure;
-  final bool isChecking;
-  final bool isOpeningSettings;
-  final bool isBlocked;
-  final VoidCallback onPrepareLocation;
-  final VoidCallback onOpenSettings;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Text(
-          '가까운 역을 자동으로 찾으려면 GPS가 필요합니다.',
-          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-            color: const Color(0xFF29484B),
-            fontWeight: FontWeight.w700,
-            height: 1.3,
-          ),
-        ),
-        const SizedBox(height: 12),
-        OutlinedButton.icon(
-          key: const Key('onboardingLocationButton'),
-          onPressed: isChecking || isOpeningSettings || isBlocked
-              ? null
-              : onPrepareLocation,
-          icon: isChecking
-              ? const SizedBox(
-                  width: 22,
-                  height: 22,
-                  child: CircularProgressIndicator(strokeWidth: 2.5),
-                )
-              : const Icon(Icons.my_location),
-          label: const Text('위치 켜기'),
-          style: OutlinedButton.styleFrom(
-            minimumSize: const Size.fromHeight(60),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-            ),
-          ),
-        ),
-        if (message.isNotEmpty) ...[
-          const SizedBox(height: 10),
-          _OnboardingStatusMessage(message: message, isFailure: isFailure),
-        ],
-        if (isFailure) ...[
-          const SizedBox(height: 10),
-          OutlinedButton.icon(
-            key: const Key('onboardingOpenLocationSettingsButton'),
-            onPressed: isOpeningSettings || isChecking || isBlocked
-                ? null
-                : onOpenSettings,
-            icon: isOpeningSettings
-                ? const SizedBox(
-                    width: 22,
-                    height: 22,
-                    child: CircularProgressIndicator(strokeWidth: 2.5),
-                  )
-                : const Icon(Icons.settings),
-            label: const Text('위치 설정 열기'),
-            style: OutlinedButton.styleFrom(
-              minimumSize: const Size.fromHeight(60),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(8),
-              ),
-            ),
-          ),
-        ],
-      ],
+    widget.onCompleted(
+      OnboardingResult(profile: selectedProfile, preferences: _preferences),
     );
   }
-}
 
-class _OnboardingNotificationSection extends StatelessWidget {
-  const _OnboardingNotificationSection({
-    required this.message,
-    required this.isFailure,
-    required this.isRequesting,
-    required this.isBlocked,
-    required this.onPrepareNotification,
-  });
-
-  final String message;
-  final bool isFailure;
-  final bool isRequesting;
-  final bool isBlocked;
-  final VoidCallback onPrepareNotification;
-
-  @override
-  Widget build(BuildContext context) {
-    final showNextAction = _shouldShowOnboardingNotificationFailureNextAction(
-      message,
-    );
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Text(
-          '시설 고장, 신고 결과, 공사 안내를 알려드려요.',
-          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-            color: const Color(0xFF29484B),
-            fontWeight: FontWeight.w700,
-            height: 1.3,
+  Future<void> _handlePermissionSkip() async {
+    if (!_locationPermissionSelected || !_notificationPermissionSelected) {
+      await showDialog<void>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('수동 설정 방법'),
+          content: const Text(
+            '나중에 휴대폰 설정에서 쉬운 지하철을 선택한 뒤 위치와 알림 권한을 켤 수 있습니다. '
+            '권한을 끄면 가까운 역 찾기와 시설 고장 알림은 제한됩니다.',
           ),
-        ),
-        const SizedBox(height: 12),
-        OutlinedButton.icon(
-          key: const Key('onboardingNotificationButton'),
-          onPressed: isRequesting || isBlocked ? null : onPrepareNotification,
-          icon: isRequesting
-              ? const SizedBox(
-                  width: 22,
-                  height: 22,
-                  child: CircularProgressIndicator(strokeWidth: 2.5),
-                )
-              : const Icon(Icons.notifications_active_outlined),
-          label: const Text('알림 켜기'),
-          style: OutlinedButton.styleFrom(
-            minimumSize: const Size.fromHeight(60),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-            ),
-          ),
-        ),
-        if (message.isNotEmpty) ...[
-          const SizedBox(height: 10),
-          _OnboardingStatusMessage(message: message, isFailure: isFailure),
-        ],
-        if (showNextAction) ...[
-          const SizedBox(height: 6),
-          Semantics(
-            key: const Key('onboardingNotificationFailureNextAction'),
-            container: true,
-            excludeSemantics: true,
-            liveRegion: true,
-            label: '다음 행동, $_onboardingNotificationFailureNextAction',
-            child: Text(
-              _onboardingNotificationFailureNextAction,
-              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: const Color(0xFF29484B),
-                fontWeight: FontWeight.w800,
-                height: 1.3,
-              ),
-            ),
-          ),
-        ],
-      ],
-    );
-  }
-}
-
-bool _shouldShowOnboardingNotificationFailureNextAction(String message) {
-  return message == '알림 권한을 확인하지 못했습니다.';
-}
-
-class _OnboardingStatusMessage extends StatelessWidget {
-  const _OnboardingStatusMessage({
-    required this.message,
-    required this.isFailure,
-  });
-
-  final String message;
-  final bool isFailure;
-
-  @override
-  Widget build(BuildContext context) {
-    final color = isFailure ? const Color(0xFF8A4B00) : const Color(0xFF006D77);
-    final icon = isFailure ? Icons.error_outline : Icons.check_circle_outline;
-
-    return Semantics(
-      label: message,
-      liveRegion: true,
-      child: ExcludeSemantics(
-        child: Row(
-          children: [
-            Icon(icon, color: color, size: 24),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                message,
-                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: const Color(0xFF102A2C),
-                  fontWeight: FontWeight.w800,
-                  height: 1.3,
-                ),
-              ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('확인'),
             ),
           ],
         ),
-      ),
-    );
+      );
+      return;
+    }
+    _completeOnboarding();
   }
 }
 
@@ -799,14 +951,12 @@ class _OnboardingProfileCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final borderColor = selected
-        ? colorScheme.primary
-        : const Color(0xFFD5E2E4);
-    final backgroundColor = selected ? const Color(0xFFE6F2F0) : Colors.white;
+    const primaryColor = Color(0xFF0D8A6D);
+    final borderColor = selected ? primaryColor : const Color(0xFFDBE3E9);
+    final backgroundColor = selected ? const Color(0xFFEAF8F3) : Colors.white;
 
     return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.only(bottom: 9),
       child: Semantics(
         label: profile.semanticsLabel(selected),
         selected: selected,
@@ -816,28 +966,49 @@ class _OnboardingProfileCard extends StatelessWidget {
           child: Material(
             color: backgroundColor,
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: BorderRadius.circular(17),
               side: BorderSide(color: borderColor, width: selected ? 2 : 1),
             ),
             child: InkWell(
               key: Key('onboardingProfileCard-${profile.id}'),
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: BorderRadius.circular(17),
               onTap: onTap,
               child: ConstrainedBox(
-                constraints: const BoxConstraints(minHeight: 76),
+                constraints: const BoxConstraints(minHeight: 78),
                 child: Padding(
-                  padding: const EdgeInsets.all(16),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 13,
+                  ),
                   child: Row(
                     children: [
-                      Icon(profile.icon, color: colorScheme.primary, size: 34),
-                      const SizedBox(width: 16),
+                      DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: selected
+                              ? const Color(0xFFDFF7EF)
+                              : const Color(0xFFEEF3F6),
+                          borderRadius: BorderRadius.circular(15),
+                        ),
+                        child: SizedBox(
+                          width: 46,
+                          height: 46,
+                          child: Icon(
+                            profile.icon,
+                            color: selected
+                                ? primaryColor
+                                : const Color(0xFF17527C),
+                            size: 23,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
                       Expanded(
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
                             Text(
-                              profile.title,
+                              _profileDisplayTitle(profile),
                               style: Theme.of(context).textTheme.titleMedium
                                   ?.copyWith(
                                     color: const Color(0xFF102A2C),
@@ -847,10 +1018,10 @@ class _OnboardingProfileCard extends StatelessWidget {
                             ),
                             const SizedBox(height: 4),
                             Text(
-                              profile.summary,
+                              _profileDisplaySummary(profile),
                               style: Theme.of(context).textTheme.bodyLarge
                                   ?.copyWith(
-                                    color: const Color(0xFF29484B),
+                                    color: const Color(0xFF647686),
                                     fontWeight: FontWeight.w700,
                                     height: 1.3,
                                   ),
@@ -858,8 +1029,7 @@ class _OnboardingProfileCard extends StatelessWidget {
                           ],
                         ),
                       ),
-                      if (selected)
-                        Icon(Icons.check_circle, color: colorScheme.primary),
+                      _ProfileRadio(selected: selected),
                     ],
                   ),
                 ),
@@ -870,17 +1040,98 @@ class _OnboardingProfileCard extends StatelessWidget {
       ),
     );
   }
+
+  String _profileDisplayTitle(MobilityProfileOption profile) {
+    return switch (profile.id) {
+      'elderly' => '천천히 이동',
+      'wheelchair' => '휠체어 이용',
+      'stroller' => '유모차 이용',
+      'pregnant' => '임신 중',
+      'injured' => '몸이 불편함',
+      'luggage' => '큰 짐이 있음',
+      _ => profile.title,
+    };
+  }
+
+  String _profileDisplaySummary(MobilityProfileOption profile) {
+    return switch (profile.id) {
+      'elderly' => '걷기와 환승 줄이기',
+      'wheelchair' => '계단 없는 길',
+      'stroller' => '엘리베이터 우선',
+      'pregnant' => '걷는 거리 줄이기',
+      'injured' => '계단 피하기',
+      'luggage' => '넓은 길 우선',
+      _ => profile.summary,
+    };
+  }
+}
+
+class _ProfileRadio extends StatelessWidget {
+  const _ProfileRadio({required this.selected});
+
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: selected ? const Color(0xFF0D8A6D) : const Color(0xFFC8D3DC),
+          width: 2,
+        ),
+      ),
+      child: SizedBox(
+        width: 22,
+        height: 22,
+        child: selected
+            ? const Center(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: Color(0xFF0D8A6D),
+                    shape: BoxShape.circle,
+                  ),
+                  child: SizedBox(width: 10, height: 10),
+                ),
+              )
+            : null,
+      ),
+    );
+  }
+}
+
+class _OnboardingPreferenceCard extends StatelessWidget {
+  const _OnboardingPreferenceCard({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: const Color(0xFFDBE3E9)),
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Column(children: children),
+      ),
+    );
+  }
 }
 
 class _OnboardingPreferenceSwitch extends StatelessWidget {
   const _OnboardingPreferenceSwitch({
     required super.key,
     required this.title,
+    required this.subtitle,
     required this.value,
     required this.onChanged,
   });
 
   final String title;
+  final String subtitle;
   final bool value;
   final ValueChanged<bool> onChanged;
 
@@ -888,32 +1139,61 @@ class _OnboardingPreferenceSwitch extends StatelessWidget {
   Widget build(BuildContext context) {
     final state = value ? '켜짐' : '꺼짐';
 
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
-      child: Semantics(
-        label: '$title $state',
-        toggled: value,
-        onTap: () => onChanged(!value),
-        child: ExcludeSemantics(
-          child: SwitchListTile(
-            value: value,
-            onChanged: onChanged,
-            title: Text(
-              title,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                color: const Color(0xFF102A2C),
-                fontWeight: FontWeight.w800,
+    return Semantics(
+      label: '$title $state, $subtitle',
+      toggled: value,
+      onTap: () => onChanged(!value),
+      child: ExcludeSemantics(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 68),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: const Color(0xFF102A2C),
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      subtitle,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: const Color(0xFF647686),
+                        fontWeight: FontWeight.w700,
+                        height: 1.35,
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            ),
-            contentPadding: const EdgeInsets.symmetric(horizontal: 16),
-            tileColor: Colors.white,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-              side: const BorderSide(color: Color(0xFFD5E2E4)),
-            ),
+              Switch(
+                value: value,
+                onChanged: onChanged,
+                activeThumbColor: Colors.white,
+                activeTrackColor: const Color(0xFF0D8A6D),
+                inactiveThumbColor: Colors.white,
+                inactiveTrackColor: const Color(0xFFC8D3DC),
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+            ],
           ),
         ),
       ),
     );
+  }
+}
+
+class _OnboardingPreferenceDivider extends StatelessWidget {
+  const _OnboardingPreferenceDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Divider(height: 1, color: Color(0xFFDBE3E9));
   }
 }

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -977,11 +977,10 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       if (!mounted) {
         return;
       }
-    } else {
-      await _prepareSelectedPermissions();
-      if (!mounted) {
-        return;
-      }
+    }
+    await _prepareSelectedPermissions();
+    if (!mounted) {
+      return;
     }
     _completeOnboarding();
   }
@@ -1324,6 +1323,7 @@ class _OnboardingViewPreferenceSwitch extends StatelessWidget {
       container: true,
       label: '$title ${value ? '켜짐' : '꺼짐'}, $subtitle',
       toggled: value,
+      onTap: () => onChanged(!value),
       child: ExcludeSemantics(
         child: ConstrainedBox(
           constraints: const BoxConstraints(minHeight: 68),

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -714,7 +714,7 @@ class OnboardingScreen extends StatefulWidget {
 
 class _OnboardingScreenState extends State<OnboardingScreen> {
   MobilityProfileOption? _selectedProfile;
-  final OnboardingViewPreferences _preferences =
+  OnboardingViewPreferences _preferences =
       const OnboardingViewPreferences.defaults();
   int _currentStep = 0;
   bool _locationPermissionSelected = true;
@@ -850,6 +850,60 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                       ),
                     ],
                   ),
+                  const SizedBox(height: 18),
+                  Text(
+                    '보기 설정',
+                    style: textTheme.titleLarge?.copyWith(
+                      color: const Color(0xFF102A2C),
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  _OnboardingPreferenceCard(
+                    children: [
+                      _OnboardingViewPreferenceSwitch(
+                        key: const Key('onboardingPreference-largeText'),
+                        title: '큰 글씨',
+                        subtitle: '글자를 더 크게 표시',
+                        value: _preferences.largeTextEnabled,
+                        onChanged: (value) {
+                          setState(() {
+                            _preferences = _preferences.copyWith(
+                              largeTextEnabled: value,
+                            );
+                          });
+                        },
+                      ),
+                      const _OnboardingPreferenceDivider(),
+                      _OnboardingViewPreferenceSwitch(
+                        key: const Key('onboardingPreference-highContrast'),
+                        title: '고대비',
+                        subtitle: '글자와 배경 대비 강화',
+                        value: _preferences.highContrastEnabled,
+                        onChanged: (value) {
+                          setState(() {
+                            _preferences = _preferences.copyWith(
+                              highContrastEnabled: value,
+                            );
+                          });
+                        },
+                      ),
+                      const _OnboardingPreferenceDivider(),
+                      _OnboardingViewPreferenceSwitch(
+                        key: const Key('onboardingPreference-simpleView'),
+                        title: '쉬운 보기',
+                        subtitle: '중요한 정보만 먼저 표시',
+                        value: _preferences.simpleViewEnabled,
+                        onChanged: (value) {
+                          setState(() {
+                            _preferences = _preferences.copyWith(
+                              simpleViewEnabled: value,
+                            );
+                          });
+                        },
+                      ),
+                    ],
+                  ),
                 ]
               : [
                   const _OnboardingStepIndicator(currentStep: 3, totalSteps: 3),
@@ -923,8 +977,70 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       if (!mounted) {
         return;
       }
+    } else {
+      await _prepareSelectedPermissions();
+      if (!mounted) {
+        return;
+      }
     }
     _completeOnboarding();
+  }
+
+  Future<void> _prepareSelectedPermissions() async {
+    if (_locationPermissionSelected) {
+      await _prepareLocationPermission();
+    }
+    if (!mounted) {
+      return;
+    }
+    if (_notificationPermissionSelected) {
+      await _prepareNotificationPermission();
+    }
+  }
+
+  Future<void> _prepareLocationPermission() async {
+    final locationProvider = widget.locationProvider;
+    if (locationProvider == null) {
+      return;
+    }
+    try {
+      await locationProvider.currentLocation();
+    } on CurrentLocationException catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '온보딩 현재 위치 권한 준비 중 예외가 발생했습니다.',
+      );
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '온보딩 현재 위치 권한 준비 중 알 수 없는 예외가 발생했습니다.',
+      );
+    }
+  }
+
+  Future<void> _prepareNotificationPermission() async {
+    final notificationPermissionProvider =
+        widget.notificationPermissionProvider;
+    if (notificationPermissionProvider == null) {
+      return;
+    }
+    try {
+      await notificationPermissionProvider.requestNotificationPermission();
+    } on NotificationSettingsException catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '온보딩 알림 권한 준비 중 예외가 발생했습니다.',
+      );
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '온보딩 알림 권한 준비 중 알 수 없는 예외가 발생했습니다.',
+      );
+    }
   }
 }
 
@@ -1179,6 +1295,72 @@ class _OnboardingConditionRow extends StatelessWidget {
                     ),
                   ),
                 ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _OnboardingViewPreferenceSwitch extends StatelessWidget {
+  const _OnboardingViewPreferenceSwitch({
+    required super.key,
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final String title;
+  final String subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      container: true,
+      label: '$title ${value ? '켜짐' : '꺼짐'}, $subtitle',
+      toggled: value,
+      child: ExcludeSemantics(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 68),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: const Color(0xFF102A2C),
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      subtitle,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: const Color(0xFF647686),
+                        fontWeight: FontWeight.w700,
+                        height: 1.35,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Switch(
+                value: value,
+                onChanged: onChanged,
+                activeThumbColor: Colors.white,
+                activeTrackColor: const Color(0xFF0D8A6D),
+                inactiveThumbColor: Colors.white,
+                inactiveTrackColor: const Color(0xFFC8D3DC),
+                materialTapTargetSize: MaterialTapTargetSize.padded,
               ),
             ],
           ),

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -10,6 +10,7 @@ import 'station_search.dart';
 
 const _onboardingResultStorageKey = 'easysubway.onboarding.result';
 const _onboardingNotificationFailureNextAction = '나중에 알림 설정에서 다시 켤 수 있습니다.';
+const startScreenAppIconAsset = 'assets/branding/app_icon.png';
 
 abstract class OnboardingResultStore {
   Future<OnboardingResult?> readResult();
@@ -175,6 +176,103 @@ class OnboardingState {
   final OnboardingResult? result;
 
   bool get isCompleted => result != null;
+}
+
+class StartScreen extends StatelessWidget {
+  const StartScreen({required this.onStart, super.key});
+
+  final VoidCallback onStart;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: DecoratedBox(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [Color(0xFF071B2F), Color(0xFF17527C)],
+          ),
+        ),
+        child: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 48, 24, 35),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Semantics(
+                  image: true,
+                  label: '쉬운 지하철 앱 아이콘',
+                  child: ExcludeSemantics(
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(20),
+                      child: Image.asset(
+                        startScreenAppIconAsset,
+                        width: 62,
+                        height: 62,
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                  ),
+                ),
+                const Spacer(flex: 5),
+                Semantics(
+                  header: true,
+                  child: Text.rich(
+                    TextSpan(
+                      children: [
+                        TextSpan(text: '빠른 길보다,\n'),
+                        TextSpan(
+                          text: '갈 수 있는 길',
+                          style: TextStyle(color: Color(0xFF84E2C5)),
+                        ),
+                        TextSpan(text: '을\n먼저 안내해요.'),
+                      ],
+                    ),
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 38,
+                      fontWeight: FontWeight.w900,
+                      height: 1.18,
+                    ),
+                  ),
+                ),
+                const Spacer(flex: 6),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    key: const Key('startScreenStartButton'),
+                    onPressed: onStart,
+                    icon: const Icon(Icons.arrow_forward),
+                    label: const Text('쉬운 지하철 시작하기'),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: Colors.white,
+                      foregroundColor: const Color(0xFF071B2F),
+                      minimumSize: const Size.fromHeight(60),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(15),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 13),
+                const Center(
+                  child: Text(
+                    '로그인 없이도 이용할 수 있어요',
+                    style: TextStyle(
+                      color: Color(0xFFA9BFCD),
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class OnboardingScreen extends StatefulWidget {

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -717,10 +717,6 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   final OnboardingViewPreferences _preferences =
       const OnboardingViewPreferences.defaults();
   int _currentStep = 0;
-  bool _avoidStairs = true;
-  bool _requireElevator = true;
-  bool _minimizeTransfers = true;
-  bool _avoidLongWalks = true;
   bool _locationPermissionSelected = true;
   bool _notificationPermissionSelected = true;
 
@@ -819,46 +815,38 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                   const SizedBox(height: 18),
                   _OnboardingPreferenceCard(
                     children: [
-                      _OnboardingPreferenceSwitch(
+                      _OnboardingConditionRow(
                         key: const Key('onboardingRoutePreference-avoidStairs'),
                         title: '계단 피하기',
                         subtitle: '계단 없는 길',
-                        value: _avoidStairs,
-                        onChanged: (value) =>
-                            setState(() => _avoidStairs = value),
+                        enabled: selectedProfile?.avoidStairs ?? true,
                       ),
                       const _OnboardingPreferenceDivider(),
-                      _OnboardingPreferenceSwitch(
+                      _OnboardingConditionRow(
                         key: const Key(
                           'onboardingRoutePreference-requireElevator',
                         ),
                         title: '엘리베이터 이용',
                         subtitle: '엘리베이터 연결',
-                        value: _requireElevator,
-                        onChanged: (value) =>
-                            setState(() => _requireElevator = value),
+                        enabled: selectedProfile?.requireElevator ?? true,
                       ),
                       const _OnboardingPreferenceDivider(),
-                      _OnboardingPreferenceSwitch(
+                      _OnboardingConditionRow(
                         key: const Key(
                           'onboardingRoutePreference-minimizeTransfers',
                         ),
                         title: '환승 줄이기',
                         subtitle: '갈아타는 횟수 줄이기',
-                        value: _minimizeTransfers,
-                        onChanged: (value) =>
-                            setState(() => _minimizeTransfers = value),
+                        enabled: selectedProfile?.minimizeTransfers ?? true,
                       ),
                       const _OnboardingPreferenceDivider(),
-                      _OnboardingPreferenceSwitch(
+                      _OnboardingConditionRow(
                         key: const Key(
                           'onboardingRoutePreference-avoidLongWalks',
                         ),
                         title: '걷는 거리 줄이기',
                         subtitle: '오래 걷는 길 피하기',
-                        value: _avoidLongWalks,
-                        onChanged: (value) =>
-                            setState(() => _avoidLongWalks = value),
+                        enabled: selectedProfile?.avoidLongWalks ?? true,
                       ),
                     ],
                   ),
@@ -932,7 +920,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
           ],
         ),
       );
-      return;
+      if (!mounted) {
+        return;
+      }
     }
     _completeOnboarding();
   }
@@ -1121,28 +1111,25 @@ class _OnboardingPreferenceCard extends StatelessWidget {
   }
 }
 
-class _OnboardingPreferenceSwitch extends StatelessWidget {
-  const _OnboardingPreferenceSwitch({
+class _OnboardingConditionRow extends StatelessWidget {
+  const _OnboardingConditionRow({
     required super.key,
     required this.title,
     required this.subtitle,
-    required this.value,
-    required this.onChanged,
+    required this.enabled,
   });
 
   final String title;
   final String subtitle;
-  final bool value;
-  final ValueChanged<bool> onChanged;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
-    final state = value ? '켜짐' : '꺼짐';
+    final state = enabled ? '우선' : '기본';
 
     return Semantics(
+      container: true,
       label: '$title $state, $subtitle',
-      toggled: value,
-      onTap: () => onChanged(!value),
       child: ExcludeSemantics(
         child: ConstrainedBox(
           constraints: const BoxConstraints(minHeight: 68),
@@ -1172,14 +1159,26 @@ class _OnboardingPreferenceSwitch extends StatelessWidget {
                   ],
                 ),
               ),
-              Switch(
-                value: value,
-                onChanged: onChanged,
-                activeThumbColor: Colors.white,
-                activeTrackColor: const Color(0xFF0D8A6D),
-                inactiveThumbColor: Colors.white,
-                inactiveTrackColor: const Color(0xFFC8D3DC),
-                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  color: enabled
+                      ? const Color(0xFFDFF7EF)
+                      : const Color(0xFFEEF3F6),
+                  borderRadius: BorderRadius.circular(18),
+                ),
+                child: SizedBox(
+                  width: 54,
+                  height: 36,
+                  child: Center(
+                    child: Icon(
+                      enabled ? Icons.check : Icons.remove,
+                      color: enabled
+                          ? const Color(0xFF0D8A6D)
+                          : const Color(0xFF647686),
+                      size: 21,
+                    ),
+                  ),
+                ),
               ),
             ],
           ),

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -3042,7 +3042,7 @@ class FavoriteRouteListController extends ChangeNotifier {
             ? const FavoriteRouteListState(
                 status: FavoriteRouteListStatus.empty,
                 favorites: [],
-                message: '저장한 경로가 없습니다.',
+                message: '즐겨찾기한 경로가 없습니다.',
               )
             : FavoriteRouteListState(
                 status: FavoriteRouteListStatus.success,
@@ -3085,7 +3085,7 @@ class FavoriteRouteListController extends ChangeNotifier {
             ? FavoriteRouteListState(
                 status: FavoriteRouteListStatus.empty,
                 favorites: const [],
-                message: '저장한 경로가 없습니다.',
+                message: '즐겨찾기한 경로가 없습니다.',
                 removingIds: nextRemovingIds,
               )
             : FavoriteRouteListState(

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1368,7 +1368,7 @@ class FavoriteStationListController extends ChangeNotifier {
         _emitState(
           const FavoriteStationListState(
             status: FavoriteStationListStatus.empty,
-            message: '저장한 역이 없습니다.',
+            message: '즐겨찾기한 역이 없습니다.',
           ),
         );
       } else {

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -73,7 +73,6 @@ flutter:
 
   # To add assets to your application, add an assets section, like this:
   assets:
-    - assets/branding/app_icon.png
     - assets/datapacks/index.json
     - assets/datapacks/core.sqlite.gz
     - assets/datapacks/capital.sqlite.gz

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -73,6 +73,7 @@ flutter:
 
   # To add assets to your application, add an assets section, like this:
   assets:
+    - assets/branding/app_icon.png
     - assets/datapacks/index.json
     - assets/datapacks/core.sqlite.gz
     - assets/datapacks/capital.sqlite.gz

--- a/apps/mobile/test/favorite_facility_test.dart
+++ b/apps/mobile/test/favorite_facility_test.dart
@@ -195,7 +195,7 @@ void main() {
     await controller.load();
 
     expect(controller.state.status, FavoriteFacilityListStatus.empty);
-    expect(controller.state.message, '저장한 시설이 없습니다.');
+    expect(controller.state.message, '즐겨찾기한 시설이 없습니다.');
 
     repository.error = const FavoriteFacilityException('즐겨찾기 시설을 불러오지 못했습니다.');
     await controller.load();

--- a/apps/mobile/test/onboarding_app_flow_test.dart
+++ b/apps/mobile/test/onboarding_app_flow_test.dart
@@ -32,20 +32,30 @@ void main() {
     expect(find.text('빠른 길보다,\n갈 수 있는 길을\n먼저 안내해요.'), findsOneWidget);
     expect(find.text('이동약자를 위한 지하철 안내'), findsNothing);
     expect(find.text('계단과 고장 시설을 미리 확인하고'), findsNothing);
+    expect(find.text('로그인 없이도 이용할 수 있어요'), findsNothing);
+    expect(find.bySemanticsLabel('쉬운 지하철 앱 아이콘'), findsNothing);
     await tester.tap(find.byKey(const Key('startScreenStartButton')));
     await tester.pumpAndSettle();
+    expect(find.text('계단 없는 길을\n먼저 찾습니다'), findsOneWidget);
+    await _tapIntroConfigure(tester);
 
-    expect(find.text('먼저 이동 조건을 골라 주세요'), findsOneWidget);
+    expect(find.text('어떤 도움이 필요한가요?'), findsOneWidget);
     expect(find.byKey(const Key('stationSearchButton')), findsNothing);
 
     await tester.tap(find.byKey(const Key('onboardingProfileCard-elderly')));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('onboardingDoneButton')));
     await tester.pumpAndSettle();
+    expect(find.text('원하는 조건을 고르세요'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+    expect(find.text('권한을 선택하세요'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
+    await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('routeSearchButton')), findsOneWidget);
     expect(find.byKey(const Key('stationSearchButton')), findsOneWidget);
-    expect(find.text('먼저 이동 조건을 골라 주세요'), findsNothing);
+    expect(find.text('어떤 도움이 필요한가요?'), findsNothing);
     expect(
       legacyCredentialStorage.deletedKeys,
       contains(SecureLegacyCredentialCleaner.legacyAuthCredentialsKey),
@@ -58,93 +68,24 @@ void main() {
     expect(onboardingStore.saveCount, 1);
   });
 
-  testWidgets('첫 실행 앱은 온보딩에서 위치 권한을 준비할 수 있다', (tester) async {
-    final locationProvider = FakeCurrentLocationProvider(
-      location: _freshCurrentLocation(),
-    );
-
+  testWidgets('첫 실행 앱은 권한 선택을 끄고 건너뛰면 수동 설정 방법을 안내한다', (tester) async {
     await tester.pumpWidget(
-      _testApp(
-        onboardingStore: MemoryOnboardingResultStore(),
-        locationProvider: locationProvider,
-      ),
+      _testApp(onboardingStore: MemoryOnboardingResultStore()),
     );
     await tester.pumpAndSettle();
     await _openOnboarding(tester);
+    await _continueFromProfileToPermission(tester);
 
-    await tester.dragUntilVisible(
-      find.byKey(const Key('onboardingLocationButton')),
-      find.byType(Scrollable).first,
-      const Offset(0, -300),
-    );
+    await tester.tap(find.byType(Switch).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(const Key('onboardingLocationButton')));
-    await tester.pumpAndSettle();
-
-    expect(locationProvider.requestCount, 1);
-    expect(find.text('위치 준비 완료'), findsOneWidget);
+    expect(find.text('수동 설정 방법'), findsOneWidget);
+    expect(find.textContaining('가까운 역 찾기와 시설 고장 알림은 제한됩니다'), findsOneWidget);
   });
 
-  testWidgets('첫 실행 앱은 온보딩에서 알림 권한을 준비할 수 있다', (tester) async {
-    final notificationPermissionProvider = FakeNotificationPermissionProvider(
-      nextStatus: NotificationPermissionStatus.granted,
-    );
-
-    await tester.pumpWidget(
-      _testApp(
-        notificationPermissionProvider: notificationPermissionProvider,
-        onboardingStore: MemoryOnboardingResultStore(),
-      ),
-    );
-    await tester.pumpAndSettle();
-    await _openOnboarding(tester);
-
-    await tester.dragUntilVisible(
-      find.byKey(const Key('onboardingNotificationButton')),
-      find.byType(Scrollable).first,
-      const Offset(0, -300),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
-    await tester.pumpAndSettle();
-
-    expect(notificationPermissionProvider.requestCount, 1);
-    expect(find.text('알림 준비 완료'), findsOneWidget);
-  });
-
-  testWidgets('첫 실행 앱은 온보딩 알림 권한 실패 다음 행동을 안내한다', (tester) async {
-    final notificationPermissionProvider = FakeNotificationPermissionProvider(
-      nextStatus: NotificationPermissionStatus.denied,
-      error: const NotificationSettingsException('알림 권한을 확인하지 못했습니다.'),
-    );
-
-    await tester.pumpWidget(
-      _testApp(
-        notificationPermissionProvider: notificationPermissionProvider,
-        onboardingStore: MemoryOnboardingResultStore(),
-      ),
-    );
-    await tester.pumpAndSettle();
-    await _openOnboarding(tester);
-
-    await tester.dragUntilVisible(
-      find.byKey(const Key('onboardingNotificationButton')),
-      find.byType(Scrollable).first,
-      const Offset(0, -300),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
-    await tester.pumpAndSettle();
-
-    expect(notificationPermissionProvider.requestCount, 1);
-    expect(find.text('알림 권한을 확인하지 못했습니다.'), findsOneWidget);
-    expect(find.text('나중에 알림 설정에서 다시 켤 수 있습니다.'), findsOneWidget);
-  });
-
-  testWidgets('첫 실행 앱은 알림 설정이 꺼진 구성에서 온보딩 알림 권한을 요청하지 않는다', (tester) async {
+  testWidgets('첫 실행 앱은 알림 설정 저장소가 없어도 권한 선택 화면을 유지한다', (tester) async {
     await tester.pumpWidget(
       _testApp(
         notificationRepository: null,
@@ -153,41 +94,15 @@ void main() {
     );
     await tester.pumpAndSettle();
     await _openOnboarding(tester);
+    await _continueFromProfileToPermission(tester);
 
-    await tester.drag(find.byType(Scrollable).first, const Offset(0, -1300));
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const Key('onboardingNotificationButton')), findsNothing);
-    expect(find.widgetWithText(OutlinedButton, '알림 켜기'), findsNothing);
-  });
-
-  testWidgets('첫 실행 앱은 알림 권한 제공자가 직접 주입되면 온보딩 알림 권한을 요청한다', (tester) async {
-    final notificationPermissionProvider = FakeNotificationPermissionProvider(
-      nextStatus: NotificationPermissionStatus.granted,
+    expect(find.text('권한을 선택하세요'), findsOneWidget);
+    expect(find.text('현재 위치'), findsOneWidget);
+    expect(find.text('알림'), findsOneWidget);
+    expect(
+      find.byKey(const Key('onboardingPermissionSkipButton')),
+      findsOneWidget,
     );
-
-    await tester.pumpWidget(
-      _testApp(
-        notificationRepository: null,
-        notificationPermissionProvider: notificationPermissionProvider,
-        onboardingStore: MemoryOnboardingResultStore(),
-      ),
-    );
-    await tester.pumpAndSettle();
-    await _openOnboarding(tester);
-
-    await tester.dragUntilVisible(
-      find.byKey(const Key('onboardingNotificationButton')),
-      find.byType(Scrollable).first,
-      const Offset(0, -300),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
-    await tester.pumpAndSettle();
-
-    expect(notificationPermissionProvider.requestCount, 1);
-    expect(find.text('알림 준비 완료'), findsOneWidget);
   });
 
   testWidgets('앱은 저장된 온보딩 설정으로 홈을 바로 보여준다', (tester) async {
@@ -211,7 +126,7 @@ void main() {
 
     expect(onboardingStore.readCount, 1);
     expect(find.byKey(const Key('stationSearchButton')), findsOneWidget);
-    expect(find.text('먼저 이동 조건을 골라 주세요'), findsNothing);
+    expect(find.text('어떤 도움이 필요한가요?'), findsNothing);
     expect(MediaQuery.textScalerOf(homeContext).scale(20), closeTo(23.6, 0.01));
     expect(Theme.of(homeContext).colorScheme.primary, const Color(0xFF003D40));
   });
@@ -231,13 +146,33 @@ void main() {
     expect(reportedErrors, hasLength(1));
     expect(reportedErrors.single.exception, isA<FormatException>());
     await _openOnboarding(tester);
-    expect(find.text('먼저 이동 조건을 골라 주세요'), findsOneWidget);
+    expect(find.text('어떤 도움이 필요한가요?'), findsOneWidget);
     expect(find.byKey(const Key('stationSearchButton')), findsNothing);
   });
 }
 
 Future<void> _openOnboarding(WidgetTester tester) async {
   await tester.tap(find.byKey(const Key('startScreenStartButton')));
+  await tester.pumpAndSettle();
+  await _tapIntroConfigure(tester);
+}
+
+Future<void> _tapIntroConfigure(WidgetTester tester) async {
+  await tester.scrollUntilVisible(
+    find.byKey(const Key('onboardingIntroConfigureButton')),
+    120,
+    scrollable: find.byType(Scrollable).last,
+  );
+  await tester.tap(find.byKey(const Key('onboardingIntroConfigureButton')));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _continueFromProfileToPermission(WidgetTester tester) async {
+  await tester.tap(find.byKey(const Key('onboardingProfileCard-elderly')));
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(const Key('onboardingDoneButton')));
   await tester.pumpAndSettle();
 }
 
@@ -361,25 +296,6 @@ class _DefaultNotificationSettingsRepository
   }
 }
 
-class FakeNotificationPermissionProvider
-    implements NotificationPermissionProvider {
-  FakeNotificationPermissionProvider({required this.nextStatus, this.error});
-
-  final NotificationPermissionStatus nextStatus;
-  final Object? error;
-  int requestCount = 0;
-
-  @override
-  Future<NotificationPermissionStatus> requestNotificationPermission() async {
-    requestCount++;
-    final currentError = error;
-    if (currentError != null) {
-      throw currentError;
-    }
-    return nextStatus;
-  }
-}
-
 class MemoryOnboardingResultStore implements OnboardingResultStore {
   MemoryOnboardingResultStore({
     OnboardingResult? initialResult,
@@ -409,42 +325,5 @@ class MemoryOnboardingResultStore implements OnboardingResultStore {
   @override
   Future<void> clearResult() async {
     savedResult = null;
-  }
-}
-
-CurrentLocation _freshCurrentLocation({
-  double latitude = 37.3028,
-  double longitude = 126.8665,
-}) {
-  return CurrentLocation(
-    latitude: latitude,
-    longitude: longitude,
-    accuracyMeters: 25,
-    measuredAt: DateTime.now(),
-    provider: 'test',
-    permissionPrecision: LocationPermissionPrecision.precise,
-  );
-}
-
-class FakeCurrentLocationProvider implements CurrentLocationProvider {
-  FakeCurrentLocationProvider({this.location});
-
-  final CurrentLocation? location;
-  int requestCount = 0;
-
-  @override
-  Future<bool> needsLocationPermissionRequest() async {
-    return true;
-  }
-
-  @override
-  Future<CurrentLocation> currentLocation() async {
-    requestCount++;
-    return location ?? _freshCurrentLocation();
-  }
-
-  @override
-  Future<bool> openLocationSettings() async {
-    return true;
   }
 }

--- a/apps/mobile/test/onboarding_app_flow_test.dart
+++ b/apps/mobile/test/onboarding_app_flow_test.dart
@@ -83,6 +83,9 @@ void main() {
 
     expect(find.text('수동 설정 방법'), findsOneWidget);
     expect(find.textContaining('가까운 역 찾기와 시설 고장 알림은 제한됩니다'), findsOneWidget);
+    await tester.tap(find.text('확인'));
+    await tester.pumpAndSettle();
+    expect(find.byType(HomeScreen), findsOneWidget);
   });
 
   testWidgets('첫 실행 앱은 알림 설정 저장소가 없어도 권한 선택 화면을 유지한다', (tester) async {

--- a/apps/mobile/test/onboarding_app_flow_test.dart
+++ b/apps/mobile/test/onboarding_app_flow_test.dart
@@ -29,7 +29,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('빠른 길보다,\n갈 수 있는 길을\n먼저 안내해요.'), findsOneWidget);
+    expect(
+      find.text('빠른 길보다,\n갈 수 있는 길을\n먼저 안내해요.', findRichText: true),
+      findsOneWidget,
+    );
     expect(find.text('이동약자를 위한 지하철 안내'), findsNothing);
     expect(find.text('계단과 고장 시설을 미리 확인하고'), findsNothing);
     expect(find.text('로그인 없이도 이용할 수 있어요'), findsNothing);

--- a/apps/mobile/test/onboarding_app_flow_test.dart
+++ b/apps/mobile/test/onboarding_app_flow_test.dart
@@ -196,9 +196,26 @@ EasySubwayApp _testApp({
     notificationRepository: notificationRepository,
     notificationPermissionProvider: notificationPermissionProvider,
     onboardingStore: onboardingStore,
-    locationProvider: locationProvider,
+    locationProvider: locationProvider ?? _DefaultCurrentLocationProvider(),
     legacyCredentialCleaner: legacyCredentialCleaner,
   );
+}
+
+class _DefaultCurrentLocationProvider implements CurrentLocationProvider {
+  @override
+  Future<bool> needsLocationPermissionRequest() async {
+    return false;
+  }
+
+  @override
+  Future<CurrentLocation> currentLocation() async {
+    return const CurrentLocation(latitude: 37.5665, longitude: 126.9780);
+  }
+
+  @override
+  Future<bool> openLocationSettings() async {
+    return true;
+  }
 }
 
 class FakeStationSearchRepository implements StationSearchRepository {

--- a/apps/mobile/test/onboarding_app_flow_test.dart
+++ b/apps/mobile/test/onboarding_app_flow_test.dart
@@ -29,7 +29,12 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('쉬운 지하철'), findsOneWidget);
+    expect(find.text('빠른 길보다,\n갈 수 있는 길을\n먼저 안내해요.'), findsOneWidget);
+    expect(find.text('이동약자를 위한 지하철 안내'), findsNothing);
+    expect(find.text('계단과 고장 시설을 미리 확인하고'), findsNothing);
+    await tester.tap(find.byKey(const Key('startScreenStartButton')));
+    await tester.pumpAndSettle();
+
     expect(find.text('먼저 이동 조건을 골라 주세요'), findsOneWidget);
     expect(find.byKey(const Key('stationSearchButton')), findsNothing);
 
@@ -65,6 +70,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
+    await _openOnboarding(tester);
 
     await tester.dragUntilVisible(
       find.byKey(const Key('onboardingLocationButton')),
@@ -92,6 +98,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
+    await _openOnboarding(tester);
 
     await tester.dragUntilVisible(
       find.byKey(const Key('onboardingNotificationButton')),
@@ -120,6 +127,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
+    await _openOnboarding(tester);
 
     await tester.dragUntilVisible(
       find.byKey(const Key('onboardingNotificationButton')),
@@ -144,6 +152,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
+    await _openOnboarding(tester);
 
     await tester.drag(find.byType(Scrollable).first, const Offset(0, -1300));
     await tester.pumpAndSettle();
@@ -165,6 +174,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
+    await _openOnboarding(tester);
 
     await tester.dragUntilVisible(
       find.byKey(const Key('onboardingNotificationButton')),
@@ -220,9 +230,15 @@ void main() {
 
     expect(reportedErrors, hasLength(1));
     expect(reportedErrors.single.exception, isA<FormatException>());
+    await _openOnboarding(tester);
     expect(find.text('먼저 이동 조건을 골라 주세요'), findsOneWidget);
     expect(find.byKey(const Key('stationSearchButton')), findsNothing);
   });
+}
+
+Future<void> _openOnboarding(WidgetTester tester) async {
+  await tester.tap(find.byKey(const Key('startScreenStartButton')));
+  await tester.pumpAndSettle();
 }
 
 EasySubwayApp _testApp({

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -77,12 +77,8 @@ void main() {
       expect(find.text('계단 피하기'), findsOneWidget);
       expect(find.text('엘리베이터 이용'), findsOneWidget);
       expect(
-        tester.getSemantics(find.bySemanticsLabel('계단 피하기 켜짐, 계단 없는 길')),
-        isSemantics(
-          label: '계단 피하기 켜짐, 계단 없는 길',
-          hasTapAction: true,
-          isToggled: true,
-        ),
+        tester.getSemantics(find.bySemanticsLabel('계단 피하기 우선, 계단 없는 길')),
+        isSemantics(label: '계단 피하기 우선, 계단 없는 길'),
       );
 
       await tester.tap(find.byKey(const Key('onboardingDoneButton')));
@@ -134,14 +130,8 @@ void main() {
 
     expect(find.text('수동 설정 방법'), findsOneWidget);
     expect(find.textContaining('휴대폰 설정에서 쉬운 지하철'), findsOneWidget);
-    expect(completedResult, isNull);
 
     await tester.tap(find.text('확인'));
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byType(Switch).first);
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
     await tester.pumpAndSettle();
 
     expect(completedResult, isNotNull);

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -3,6 +3,7 @@ import 'package:easysubway_mobile/notification_settings.dart';
 import 'package:easysubway_mobile/onboarding.dart';
 import 'package:easysubway_mobile/station_search.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'fake_secure_key_value_storage.dart';
@@ -90,6 +91,15 @@ void main() {
       );
       await tester.drag(find.byType(Scrollable).last, const Offset(0, -140));
       await tester.pumpAndSettle();
+      expect(
+        tester
+            .getSemantics(
+              find.byKey(const Key('onboardingPreference-highContrast')),
+            )
+            .getSemanticsData()
+            .hasAction(SemanticsAction.tap),
+        isTrue,
+      );
       await tester.tap(
         find.descendant(
           of: find.byKey(const Key('onboardingPreference-highContrast')),
@@ -186,6 +196,64 @@ void main() {
     expect(completedResult?.profile.id, 'elderly');
   });
 
+  testWidgets('온보딩 권한 단계는 위치만 끄면 알림 provider는 호출한다', (tester) async {
+    final locationProvider = _FakeCurrentLocationProvider();
+    final notificationPermissionProvider =
+        _FakeNotificationPermissionProvider();
+    OnboardingResult? completedResult;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OnboardingScreen(
+          locationProvider: locationProvider,
+          notificationPermissionProvider: notificationPermissionProvider,
+          onCompleted: (result) => completedResult = result,
+        ),
+      ),
+    );
+
+    await _moveToPermissionStep(tester);
+    await tester.tap(find.byType(Switch).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('확인'));
+    await tester.pumpAndSettle();
+
+    expect(locationProvider.requestCount, 0);
+    expect(notificationPermissionProvider.requestCount, 1);
+    expect(completedResult?.profile.id, 'elderly');
+  });
+
+  testWidgets('온보딩 권한 단계는 알림만 끄면 위치 provider는 호출한다', (tester) async {
+    final locationProvider = _FakeCurrentLocationProvider();
+    final notificationPermissionProvider =
+        _FakeNotificationPermissionProvider();
+    OnboardingResult? completedResult;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OnboardingScreen(
+          locationProvider: locationProvider,
+          notificationPermissionProvider: notificationPermissionProvider,
+          onCompleted: (result) => completedResult = result,
+        ),
+      ),
+    );
+
+    await _moveToPermissionStep(tester);
+    await tester.tap(find.byType(Switch).last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('확인'));
+    await tester.pumpAndSettle();
+
+    expect(locationProvider.requestCount, 1);
+    expect(notificationPermissionProvider.requestCount, 0);
+    expect(completedResult?.profile.id, 'elderly');
+  });
+
   test('온보딩 완료 결과는 선택한 이동 조건과 보기 설정을 함께 담는다', () {
     final result = OnboardingResult(
       profile: mobilityProfileOptions.firstWhere(
@@ -247,6 +315,15 @@ void main() {
       throwsA(isA<FormatException>()),
     );
   });
+}
+
+Future<void> _moveToPermissionStep(WidgetTester tester) async {
+  await tester.tap(find.byKey(const Key('onboardingProfileCard-elderly')));
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+  await tester.pumpAndSettle();
 }
 
 class _FakeCurrentLocationProvider implements CurrentLocationProvider {

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -1,5 +1,7 @@
 import 'package:easysubway_mobile/mobility_profile.dart';
+import 'package:easysubway_mobile/notification_settings.dart';
 import 'package:easysubway_mobile/onboarding.dart';
+import 'package:easysubway_mobile/station_search.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -76,10 +78,25 @@ void main() {
       expect(find.text('원하는 조건을 고르세요'), findsOneWidget);
       expect(find.text('계단 피하기'), findsOneWidget);
       expect(find.text('엘리베이터 이용'), findsOneWidget);
+      expect(find.text('보기 설정'), findsOneWidget);
       expect(
         tester.getSemantics(find.bySemanticsLabel('계단 피하기 우선, 계단 없는 길')),
         isSemantics(label: '계단 피하기 우선, 계단 없는 길'),
       );
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('onboardingPreference-highContrast')),
+        150,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.drag(find.byType(Scrollable).last, const Offset(0, -140));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byKey(const Key('onboardingPreference-highContrast')),
+          matching: find.byType(Switch),
+        ),
+      );
+      await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const Key('onboardingDoneButton')));
       await tester.pumpAndSettle();
@@ -93,7 +110,7 @@ void main() {
       expect(completedResult?.profile.id, 'wheelchair');
       expect(completedResult?.profile.mobilityType, 'WHEELCHAIR');
       expect(completedResult?.preferences.largeTextEnabled, isTrue);
-      expect(completedResult?.preferences.highContrastEnabled, isFalse);
+      expect(completedResult?.preferences.highContrastEnabled, isTrue);
       expect(completedResult?.preferences.simpleViewEnabled, isTrue);
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
@@ -135,6 +152,37 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(completedResult, isNotNull);
+    expect(completedResult?.profile.id, 'elderly');
+  });
+
+  testWidgets('온보딩 권한 단계는 선택된 권한 provider를 호출한 뒤 완료한다', (tester) async {
+    final locationProvider = _FakeCurrentLocationProvider();
+    final notificationPermissionProvider =
+        _FakeNotificationPermissionProvider();
+    OnboardingResult? completedResult;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OnboardingScreen(
+          locationProvider: locationProvider,
+          notificationPermissionProvider: notificationPermissionProvider,
+          onCompleted: (result) => completedResult = result,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('onboardingProfileCard-elderly')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
+    await tester.pumpAndSettle();
+
+    expect(locationProvider.requestCount, 1);
+    expect(notificationPermissionProvider.requestCount, 1);
     expect(completedResult?.profile.id, 'elderly');
   });
 
@@ -199,4 +247,37 @@ void main() {
       throwsA(isA<FormatException>()),
     );
   });
+}
+
+class _FakeCurrentLocationProvider implements CurrentLocationProvider {
+  int requestCount = 0;
+  int openSettingsCount = 0;
+
+  @override
+  Future<bool> needsLocationPermissionRequest() async {
+    return false;
+  }
+
+  @override
+  Future<CurrentLocation> currentLocation() async {
+    requestCount++;
+    return const CurrentLocation(latitude: 37.5665, longitude: 126.9780);
+  }
+
+  @override
+  Future<bool> openLocationSettings() async {
+    openSettingsCount++;
+    return true;
+  }
+}
+
+class _FakeNotificationPermissionProvider
+    implements NotificationPermissionProvider {
+  int requestCount = 0;
+
+  @override
+  Future<NotificationPermissionStatus> requestNotificationPermission() async {
+    requestCount++;
+    return NotificationPermissionStatus.granted;
+  }
 }

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -1,9 +1,5 @@
-import 'dart:async';
-
 import 'package:easysubway_mobile/mobility_profile.dart';
-import 'package:easysubway_mobile/notification_settings.dart';
 import 'package:easysubway_mobile/onboarding.dart';
-import 'package:easysubway_mobile/station_search.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -59,9 +55,9 @@ void main() {
       );
 
       expect(find.text('쉬운 지하철'), findsOneWidget);
-      expect(find.text('먼저 이동 조건을 골라 주세요'), findsOneWidget);
-      expect(find.text('고령자'), findsOneWidget);
-      expect(find.text('휠체어'), findsOneWidget);
+      expect(find.text('어떤 도움이 필요한가요?'), findsOneWidget);
+      expect(find.text('천천히 이동'), findsOneWidget);
+      expect(find.text('휠체어 이용'), findsOneWidget);
 
       final disabledDoneButton = tester.widget<FilledButton>(
         find.byKey(const Key('onboardingDoneButton')),
@@ -74,29 +70,34 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.bySemanticsLabel('휠체어 선택됨, 계단 없는 길만 안내해요'), findsOneWidget);
 
-      await tester.drag(find.byType(ListView), const Offset(0, -520));
-      await tester.pumpAndSettle();
-
-      expect(find.text('보기 설정'), findsOneWidget);
-      expect(find.text('큰 글씨'), findsOneWidget);
-      expect(find.text('고대비'), findsOneWidget);
-      expect(find.text('단순 보기'), findsOneWidget);
-      expect(
-        tester.getSemantics(find.bySemanticsLabel('고대비 꺼짐')),
-        isSemantics(label: '고대비 꺼짐', hasTapAction: true),
-      );
-
-      await tester.tap(
-        find.byKey(const Key('onboardingPreference-highContrast')),
-      );
-      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('원하는 조건을 고르세요'), findsOneWidget);
+      expect(find.text('계단 피하기'), findsOneWidget);
+      expect(find.text('엘리베이터 이용'), findsOneWidget);
+      expect(
+        tester.getSemantics(find.bySemanticsLabel('계단 피하기 켜짐, 계단 없는 길')),
+        isSemantics(
+          label: '계단 피하기 켜짐, 계단 없는 길',
+          hasTapAction: true,
+          isToggled: true,
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('권한을 선택하세요'), findsOneWidget);
+      expect(find.text('현재 위치'), findsOneWidget);
+      expect(find.text('알림'), findsOneWidget);
+      await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
       await tester.pumpAndSettle();
 
       expect(completedResult?.profile.id, 'wheelchair');
       expect(completedResult?.profile.mobilityType, 'WHEELCHAIR');
       expect(completedResult?.preferences.largeTextEnabled, isTrue);
-      expect(completedResult?.preferences.highContrastEnabled, isTrue);
+      expect(completedResult?.preferences.highContrastEnabled, isFalse);
       expect(completedResult?.preferences.simpleViewEnabled, isTrue);
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
@@ -107,234 +108,12 @@ void main() {
     }
   });
 
-  testWidgets('온보딩은 사용자가 누르면 위치 권한 준비를 시작한다', (tester) async {
-    final locationProvider = FakeCurrentLocationProvider(
-      location: const CurrentLocation(latitude: 37.3028, longitude: 126.8665),
-    );
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: OnboardingScreen(
-          locationProvider: locationProvider,
-          onCompleted: (_) {},
-        ),
-      ),
-    );
-
-    await tester.dragUntilVisible(
-      find.byKey(const Key('onboardingLocationButton')),
-      find.byType(Scrollable).first,
-      const Offset(0, -300),
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.text('가까운 역을 자동으로 찾으려면 GPS가 필요합니다.'), findsOneWidget);
-
-    await tester.tap(find.byKey(const Key('onboardingLocationButton')));
-    await tester.pumpAndSettle();
-
-    expect(locationProvider.requestCount, 1);
-    expect(find.text('위치 준비 완료'), findsOneWidget);
-  });
-
-  testWidgets('온보딩은 GPS가 꺼져 있으면 위치 설정을 열 수 있다', (tester) async {
-    final locationProvider = FakeCurrentLocationProvider(
-      error: const CurrentLocationException(
-        '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
-      ),
-    );
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: OnboardingScreen(
-          locationProvider: locationProvider,
-          onCompleted: (_) {},
-        ),
-      ),
-    );
-
-    await tester.dragUntilVisible(
-      find.byKey(const Key('onboardingLocationButton')),
-      find.byType(Scrollable).first,
-      const Offset(0, -300),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key('onboardingLocationButton')));
-    await tester.pumpAndSettle();
-
-    expect(find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
-    expect(
-      find.byKey(const Key('onboardingOpenLocationSettingsButton')),
-      findsOneWidget,
-    );
-
-    await tester.tap(
-      find.byKey(const Key('onboardingOpenLocationSettingsButton')),
-    );
-    await tester.pumpAndSettle();
-
-    expect(locationProvider.openSettingsCount, 1);
-  });
-
-  testWidgets('온보딩은 위치 설정을 여는 동안 위치 확인을 다시 시작하지 않는다', (tester) async {
-    final openSettingsCompleter = Completer<bool>();
-    final locationProvider = FakeCurrentLocationProvider(
-      error: const CurrentLocationException(
-        '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
-      ),
-      openSettingsLoader: () => openSettingsCompleter.future,
-    );
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: OnboardingScreen(
-          locationProvider: locationProvider,
-          onCompleted: (_) {},
-        ),
-      ),
-    );
-
-    await tester.dragUntilVisible(
-      find.byKey(const Key('onboardingLocationButton')),
-      find.byType(Scrollable).first,
-      const Offset(0, -300),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key('onboardingLocationButton')));
-    await tester.pumpAndSettle();
-
-    await tester.tap(
-      find.byKey(const Key('onboardingOpenLocationSettingsButton')),
-    );
-    await tester.pump();
-    await tester.tap(find.byKey(const Key('onboardingLocationButton')));
-    await tester.pump();
-
-    expect(locationProvider.requestCount, 1);
-    expect(locationProvider.openSettingsCount, 1);
-
-    openSettingsCompleter.complete(true);
-    await tester.pumpAndSettle();
-  });
-
-  testWidgets('온보딩은 사용자가 누르면 알림 권한 준비를 시작한다', (tester) async {
-    final notificationPermissionProvider = FakeNotificationPermissionProvider(
-      status: NotificationPermissionStatus.granted,
-    );
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: OnboardingScreen(
-          notificationPermissionProvider: notificationPermissionProvider,
-          onCompleted: (_) {},
-        ),
-      ),
-    );
-
-    await tester.dragUntilVisible(
-      find.byKey(const Key('onboardingNotificationButton')),
-      find.byType(Scrollable).first,
-      const Offset(0, -300),
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.text('시설 고장, 신고 결과, 공사 안내를 알려드려요.'), findsOneWidget);
-
-    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
-    await tester.pumpAndSettle();
-
-    expect(notificationPermissionProvider.requestCount, 1);
-    expect(find.text('알림 준비 완료'), findsOneWidget);
-  });
-
-  testWidgets('온보딩은 알림 권한을 거부하면 짧게 안내한다', (tester) async {
-    final notificationPermissionProvider = FakeNotificationPermissionProvider(
-      status: NotificationPermissionStatus.denied,
-    );
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: OnboardingScreen(
-          notificationPermissionProvider: notificationPermissionProvider,
-          onCompleted: (_) {},
-        ),
-      ),
-    );
-
-    await tester.dragUntilVisible(
-      find.byKey(const Key('onboardingNotificationButton')),
-      find.byType(Scrollable).first,
-      const Offset(0, -300),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
-    await tester.pumpAndSettle();
-
-    expect(notificationPermissionProvider.requestCount, 1);
-    expect(find.text('설정에서 알림 권한을 켜 주세요.'), findsOneWidget);
-    expect(find.text('나중에 알림 설정에서 다시 켤 수 있습니다.'), findsNothing);
-  });
-
-  testWidgets('온보딩은 알림 권한 요청 실패 다음 행동을 안내한다', (tester) async {
-    final semanticsHandle = tester.ensureSemantics();
-    final notificationPermissionProvider = FakeNotificationPermissionProvider(
-      error: const NotificationSettingsException('알림 권한을 확인하지 못했습니다.'),
-    );
-
-    try {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: OnboardingScreen(
-            notificationPermissionProvider: notificationPermissionProvider,
-            onCompleted: (_) {},
-          ),
-        ),
-      );
-
-      await tester.dragUntilVisible(
-        find.byKey(const Key('onboardingNotificationButton')),
-        find.byType(Scrollable).first,
-        const Offset(0, -300),
-      );
-      await tester.pumpAndSettle();
-
-      await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
-      await tester.pumpAndSettle();
-
-      expect(notificationPermissionProvider.requestCount, 1);
-      expect(find.text('알림 권한을 확인하지 못했습니다.'), findsOneWidget);
-      expect(find.text('나중에 알림 설정에서 다시 켤 수 있습니다.'), findsOneWidget);
-      expect(
-        find.bySemanticsLabel('다음 행동, 나중에 알림 설정에서 다시 켤 수 있습니다.'),
-        findsOneWidget,
-      );
-      expect(
-        tester.getSemantics(
-          find.byKey(const Key('onboardingNotificationFailureNextAction')),
-        ),
-        isSemantics(
-          label: '다음 행동, 나중에 알림 설정에서 다시 켤 수 있습니다.',
-          isLiveRegion: true,
-        ),
-      );
-    } finally {
-      semanticsHandle.dispose();
-    }
-  });
-
-  testWidgets('온보딩은 알림 권한 요청 실패가 있어도 완료를 막지 않는다', (tester) async {
+  testWidgets('온보딩 권한 단계는 선택을 끄고 건너뛰면 수동 설정 방법을 안내한다', (tester) async {
     OnboardingResult? completedResult;
-    final notificationPermissionProvider = FakeNotificationPermissionProvider(
-      error: const NotificationSettingsException('알림 권한을 확인하지 못했습니다.'),
-    );
 
     await tester.pumpWidget(
       MaterialApp(
         home: OnboardingScreen(
-          notificationPermissionProvider: notificationPermissionProvider,
           onCompleted: (result) => completedResult = result,
         ),
       ),
@@ -342,19 +121,27 @@ void main() {
 
     await tester.tap(find.byKey(const Key('onboardingProfileCard-elderly')));
     await tester.pumpAndSettle();
-
-    await tester.dragUntilVisible(
-      find.byKey(const Key('onboardingNotificationButton')),
-      find.byType(Scrollable).first,
-      const Offset(0, -300),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key('onboardingNotificationButton')));
-    await tester.pumpAndSettle();
-    expect(find.text('알림 권한을 확인하지 못했습니다.'), findsOneWidget);
-
     await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('권한을 선택하세요'), findsOneWidget);
+    await tester.tap(find.byType(Switch).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('수동 설정 방법'), findsOneWidget);
+    expect(find.textContaining('휴대폰 설정에서 쉬운 지하철'), findsOneWidget);
+    expect(completedResult, isNull);
+
+    await tester.tap(find.text('확인'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(Switch).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
     await tester.pumpAndSettle();
 
     expect(completedResult, isNotNull);
@@ -422,64 +209,4 @@ void main() {
       throwsA(isA<FormatException>()),
     );
   });
-}
-
-class FakeCurrentLocationProvider implements CurrentLocationProvider {
-  FakeCurrentLocationProvider({
-    this.location,
-    this.error,
-    this.openSettingsLoader,
-  });
-
-  final CurrentLocation? location;
-  final Object? error;
-  final Future<bool> Function()? openSettingsLoader;
-  int requestCount = 0;
-  int openSettingsCount = 0;
-
-  @override
-  Future<bool> needsLocationPermissionRequest() async => true;
-
-  @override
-  Future<CurrentLocation> currentLocation() async {
-    requestCount++;
-    final currentError = error;
-    if (currentError != null) {
-      throw currentError;
-    }
-    return location ??
-        const CurrentLocation(latitude: 37.3028, longitude: 126.8665);
-  }
-
-  @override
-  Future<bool> openLocationSettings() async {
-    openSettingsCount++;
-    final loader = openSettingsLoader;
-    if (loader != null) {
-      return loader();
-    }
-    return true;
-  }
-}
-
-class FakeNotificationPermissionProvider
-    implements NotificationPermissionProvider {
-  FakeNotificationPermissionProvider({
-    this.status = NotificationPermissionStatus.granted,
-    this.error,
-  });
-
-  final NotificationPermissionStatus status;
-  final Object? error;
-  int requestCount = 0;
-
-  @override
-  Future<NotificationPermissionStatus> requestNotificationPermission() async {
-    requestCount++;
-    final currentError = error;
-    if (currentError != null) {
-      throw currentError;
-    }
-    return status;
-  }
 }

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -1238,7 +1238,7 @@ void main() {
     await controller.load();
 
     expect(controller.state.status, FavoriteStationListStatus.empty);
-    expect(controller.state.message, '저장한 역이 없습니다.');
+    expect(controller.state.message, '즐겨찾기한 역이 없습니다.');
 
     repository.error = const FavoriteStationException('즐겨찾기를 불러오지 못했습니다.');
     await controller.load();

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -240,7 +240,7 @@ void main() {
     );
 
     expect(find.byKey(const Key('stationSearchButton')), findsOneWidget);
-    expect(find.text('먼저 이동 조건을 골라 주세요'), findsNothing);
+    expect(find.text('어떤 도움이 필요한가요?'), findsNothing);
   });
 
   testWidgets('기본 앱은 사진 복구 저장소가 없어도 플랫폼 오류 없이 홈을 보여준다', (tester) async {
@@ -1241,7 +1241,7 @@ void main() {
     );
     expect(onboardingStore.savedResult, isNull);
     expect(draftTargetStore.target, isNull);
-    expect(find.text('먼저 이동 조건을 골라 주세요'), findsOneWidget);
+    expect(find.byKey(const Key('startScreenStartButton')), findsOneWidget);
   });
 
   testWidgets('데이터 삭제 실패 시 로컬 상태를 유지하고 오류를 안내한다', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1765,6 +1765,12 @@ void main() {
       expect(favoriteRouteRepository.removedFavoriteRouteIds, ['route-1']);
       expect(find.text('즐겨찾기한 경로가 없습니다.'), findsOneWidget);
 
+      await tester.pageBack();
+      await tester.pumpAndSettle();
+
+      expect(find.text('경로 0개'), findsOneWidget);
+      expect(find.text('최근 경로'), findsNothing);
+
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -66,9 +66,21 @@ Future<void> _openFavoriteList(WidgetTester tester, {Key? tabKey}) async {
   );
   await tester.pumpAndSettle();
   if (tabKey != null) {
-    await tester.tap(find.byKey(tabKey));
+    final targetKey = switch (tabKey) {
+      const Key('favoriteStationsTabButton') => const Key(
+        'favoriteHomeStationsButton',
+      ),
+      const Key('favoriteFacilitiesTabButton') => const Key(
+        'favoriteHomeFacilitiesButton',
+      ),
+      _ => const Key('favoriteHomeRoutesButton'),
+    };
+    await tester.tap(find.byKey(targetKey));
     await tester.pumpAndSettle();
+    return;
   }
+  await tester.tap(find.byKey(const Key('favoriteHomeRoutesButton')));
+  await tester.pumpAndSettle();
 }
 
 Future<void> _openSettingsScreen(WidgetTester tester) async {
@@ -466,7 +478,7 @@ void main() {
     }
   });
 
-  testWidgets('홈 우측 상단 알림 버튼은 알림 설정으로 이동한다', (tester) async {
+  testWidgets('홈 우측 상단 알림 버튼은 알림함으로 이동한다', (tester) async {
     await tester.pumpWidget(
       EasySubwayApp(
         repository: FakeStationSearchRepository(),
@@ -482,7 +494,8 @@ void main() {
     await tester.tap(find.byKey(const Key('homeNotificationActionButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('알림 설정'), findsOneWidget);
+    expect(find.text('알림'), findsOneWidget);
+    expect(find.text('새 알림이 없습니다'), findsOneWidget);
   });
 
   testWidgets('홈 화면은 v3 기준 큰 행동과 짧은 상태 카드로 구성된다', (tester) async {
@@ -701,11 +714,11 @@ void main() {
     await tester.pageBack();
     await tester.pumpAndSettle();
 
-    await tester.scrollUntilVisible(find.text('저장한 경로를 불러오지 못했습니다'), 180);
+    await tester.scrollUntilVisible(find.text('즐겨찾기한 경로를 불러오지 못했습니다'), 180);
     await tester.pumpAndSettle();
-    expect(find.text('저장한 경로를 불러오지 못했습니다'), findsOneWidget);
+    expect(find.text('즐겨찾기한 경로를 불러오지 못했습니다'), findsOneWidget);
     expect(
-      tester.getSize(find.widgetWithText(OutlinedButton, '저장한 경로 보기')).height,
+      tester.getSize(find.widgetWithText(OutlinedButton, '즐겨찾기 경로 보기')).height,
       greaterThanOrEqualTo(EasySubwayTouchTarget.general),
     );
   });
@@ -741,7 +754,7 @@ void main() {
         );
       }
 
-      expect(find.text('설정'), findsOneWidget);
+      expect(find.text('화면·접근성 설정'), findsOneWidget);
       expect(find.text('내 이동 조건'), findsOneWidget);
       expect(find.text('화면과 읽기'), findsOneWidget);
       expect(find.text('경로 찾기'), findsOneWidget);
@@ -795,7 +808,7 @@ void main() {
       );
       expect(
         settingsActionSemantics(
-          '도움말과 개인정보, 지원, 개인정보 처리방침, 데이터 삭제 안내를 확인해요',
+          '도움말·문의, 사용법, 개인정보, 문의 경로를 확인해요',
         ).getSemanticsData().hasAction(SemanticsAction.tap),
         isTrue,
       );
@@ -848,15 +861,25 @@ void main() {
     semanticsHandle.dispose();
   });
 
-  testWidgets('즐겨찾기 화면은 탭 목록을 바로 보여준다', (tester) async {
+  testWidgets('즐겨찾기 홈은 실제 목록 개수로 역·시설·경로를 보여준다', (tester) async {
+    final favoriteRepository = FakeFavoriteStationRepository(
+      favorites: [_favoriteStation(id: 'station-sangnoksu', name: '상록수')],
+    );
+    final favoriteFacilityRepository = FakeFavoriteFacilityRepository(
+      favorites: [_favoriteFacility()],
+    );
+    final favoriteRouteRepository = FakeFavoriteRouteRepository(
+      favorites: [_favoriteRoute()],
+    );
+
     await tester.pumpWidget(
       EasySubwayApp(
         repository: FakeStationSearchRepository(),
         reportRepository: FakeFacilityReportRepository(),
         routeRepository: FakeRouteSearchRepository(),
-        favoriteRepository: FakeFavoriteStationRepository(),
-        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
-        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        favoriteRepository: favoriteRepository,
+        favoriteFacilityRepository: favoriteFacilityRepository,
+        favoriteRouteRepository: favoriteRouteRepository,
         initialOnboardingState: _completedOnboardingState(),
       ),
     );
@@ -866,15 +889,22 @@ void main() {
     expect(find.byKey(const Key('favoriteStationsButton')), findsNothing);
     expect(find.byKey(const Key('favoriteFacilitiesButton')), findsNothing);
 
-    await _openFavoriteList(tester);
+    await tester.tap(find.byKey(const Key('bottomNavSaved')));
+    await tester.pumpAndSettle();
 
     expect(find.text('즐겨찾기'), findsOneWidget);
-    expect(find.byKey(const Key('favoriteRoutesTabButton')), findsOneWidget);
-    expect(find.byKey(const Key('favoriteStationsTabButton')), findsOneWidget);
+    expect(find.byKey(const Key('favoriteHomeStationsButton')), findsOneWidget);
     expect(
-      find.byKey(const Key('favoriteFacilitiesTabButton')),
+      find.byKey(const Key('favoriteHomeFacilitiesButton')),
       findsOneWidget,
     );
+    expect(find.byKey(const Key('favoriteHomeRoutesButton')), findsOneWidget);
+    expect(find.text('역 1개'), findsOneWidget);
+    expect(find.text('시설 1개'), findsOneWidget);
+    expect(find.text('경로 1개'), findsOneWidget);
+    expect(favoriteRepository.listCount, greaterThanOrEqualTo(1));
+    expect(favoriteFacilityRepository.listCount, greaterThanOrEqualTo(1));
+    expect(favoriteRouteRepository.listCount, greaterThanOrEqualTo(1));
     expect(find.byKey(const Key('favoriteRoutesButton')), findsNothing);
     expect(find.byKey(const Key('favoriteStationsButton')), findsNothing);
     expect(find.byKey(const Key('favoriteFacilitiesButton')), findsNothing);
@@ -901,7 +931,7 @@ void main() {
 
       await _openSupportAccessScreen(tester);
 
-      expect(find.text('도움말'), findsOneWidget);
+      expect(find.text('도움말·문의'), findsOneWidget);
       expect(find.text('개인정보처리방침'), findsOneWidget);
       expect(find.text('https://easysubway.example/privacy'), findsOneWidget);
       expect(find.text('고객지원'), findsOneWidget);
@@ -1231,6 +1261,16 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(deletionRepository.deleteCount, 1);
+    expect(find.text('삭제 완료'), findsOneWidget);
+    expect(find.text('내 데이터가 삭제됐어요'), findsOneWidget);
+    expect(find.text('즐겨찾기한 역'), findsOneWidget);
+    expect(find.text('1개 삭제'), findsWidgets);
+    expect(find.text('제보 연결 정보'), findsOneWidget);
+    expect(find.text('1건 익명화'), findsWidgets);
+
+    await tester.tap(find.byKey(const Key('dataDeletionResultStartButton')));
+    await tester.pumpAndSettle();
+
     expect(
       legacyCredentialStorage.deletedKeys,
       contains(SecureLegacyCredentialCleaner.legacyAuthCredentialsKey),
@@ -1601,7 +1641,7 @@ void main() {
         tabKey: const Key('favoriteStationsTabButton'),
       );
 
-      expect(find.text('역'), findsOneWidget);
+      expect(find.text('즐겨찾기한 역'), findsOneWidget);
       expect(find.text('상록수'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
       expect(find.text('기본 정보만 있음'), findsOneWidget);
@@ -1652,7 +1692,7 @@ void main() {
         tabKey: const Key('favoriteFacilitiesTabButton'),
       );
 
-      expect(find.text('시설'), findsOneWidget);
+      expect(find.text('즐겨찾기한 시설'), findsOneWidget);
       expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
       expect(find.text('상록수역'), findsOneWidget);
       expect(find.text('정상'), findsOneWidget);
@@ -1708,7 +1748,7 @@ void main() {
 
       await _openFavoriteList(tester);
 
-      expect(find.text('경로'), findsOneWidget);
+      expect(find.text('즐겨찾기한 경로'), findsOneWidget);
       expect(find.text('상록수에서 사당까지'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
       expect(find.text('고령자'), findsOneWidget);
@@ -1723,7 +1763,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(favoriteRouteRepository.removedFavoriteRouteIds, ['route-1']);
-      expect(find.text('저장한 경로가 없습니다.'), findsOneWidget);
+      expect(find.text('즐겨찾기한 경로가 없습니다.'), findsOneWidget);
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
@@ -1771,7 +1811,7 @@ void main() {
     removeCompleter.complete();
     await tester.pumpAndSettle();
 
-    expect(find.text('저장한 경로가 없습니다.'), findsOneWidget);
+    expect(find.text('즐겨찾기한 경로가 없습니다.'), findsOneWidget);
   });
 
   testWidgets('즐겨찾기 경로 목록 실패는 다음 행동을 쉬운 문구로 안내한다', (tester) async {
@@ -3319,7 +3359,7 @@ void main() {
     await tester.pageBack();
     await tester.pumpAndSettle();
 
-    expect(find.text('저장한 역이 없습니다.'), findsOneWidget);
+    expect(find.text('즐겨찾기한 역이 없습니다.'), findsOneWidget);
     expect(
       find.byKey(const Key('favoriteStationTile-station-sangnoksu')),
       findsNothing,
@@ -6430,12 +6470,14 @@ class FakeFavoriteStationRepository implements FavoriteStationRepository {
   FakeFavoriteStationRepository({this.favorites = const []});
 
   List<FavoriteStation> favorites;
+  int listCount = 0;
   final savedStationIds = <String>[];
   final removedStationIds = <String>[];
   Object? error;
 
   @override
   Future<List<FavoriteStation>> listFavoriteStations() async {
+    listCount++;
     final currentError = error;
     if (currentError != null) {
       throw currentError;
@@ -6527,10 +6569,12 @@ class FakeFavoriteFacilityRepository implements FavoriteFacilityRepository {
   FakeFavoriteFacilityRepository({this.favorites = const []});
 
   List<FavoriteFacility> favorites;
+  int listCount = 0;
   Object? error;
 
   @override
   Future<List<FavoriteFacility>> listFavoriteFacilities() async {
+    listCount++;
     final currentError = error;
     if (currentError != null) {
       throw currentError;
@@ -6569,12 +6613,14 @@ class FakeFavoriteRouteRepository implements FavoriteRouteRepository {
 
   List<FavoriteRoute> favorites;
   final Completer<void>? removeCompleter;
+  int listCount = 0;
   final savedRouteSearchIds = <String>[];
   final removedFavoriteRouteIds = <String>[];
   Object? error;
 
   @override
   Future<List<FavoriteRoute>> listFavoriteRoutes() async {
+    listCount++;
     final currentError = error;
     if (currentError != null) {
       throw currentError;

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5111,6 +5111,66 @@ void main() {
     );
   });
 
+  testWidgets('앱은 서비스 소개에서 바로 시작해도 저장된 시설 신고 사진을 복구한다', (tester) async {
+    final draftTargetStore = MemoryFacilityReportDraftTargetStore(
+      const FacilityReportTarget(
+        stationId: 'station-sangnoksu',
+        stationName: '상록수',
+        facilityId: 'facility-sangnoksu-toilet-1',
+        facilityName: '장애인 화장실',
+        facilityTypeLabel: '장애인 화장실',
+        facilityStatusLabel: '확인 필요',
+      ),
+    );
+    var restoreCount = 0;
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        locationProvider: FakeCurrentLocationProvider(
+          location: const CurrentLocation(
+            latitude: 37.302421,
+            longitude: 126.866221,
+          ),
+          needsPermissionRequest: false,
+        ),
+        onboardingStore: MemoryOnboardingResultStore(),
+        facilityReportDraftTargetStore: draftTargetStore,
+        facilityReportLostPhotoRestorer: () async {
+          restoreCount++;
+          return const FacilityReportPhotoAttachment(
+            fileName: 'restored-toilet.webp',
+            contentType: 'image/webp',
+            dataBase64: 'cmVzdG9yZWQ=',
+          );
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('startScreenStartButton')));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('onboardingIntroSkipButton')),
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.tap(find.byKey(const Key('onboardingIntroSkipButton')));
+    await tester.pumpAndSettle();
+
+    expect(restoreCount, 1);
+    expect(draftTargetStore.clearCount, 1);
+    expect(find.text('시설 신고'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel('상록수역, 장애인 화장실, 장애인 화장실, 현재 확인 필요'),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('앱은 사진 복구 대상 정리에 실패해도 복구 화면을 연다', (tester) async {
     final reportedErrors = <FlutterErrorDetails>[];
     final draftTargetStore = MemoryFacilityReportDraftTargetStore(


### PR DESCRIPTION
## 관련 이슈

close #762

## 작업 배경

- v3 시작 및 개인화 디자인 기준에 맞춰 첫 실행 흐름을 시작 화면, 서비스 소개, 이동 유형 선택, 이동 조건 설정, 위치·알림 권한 선택 순서로 정리했습니다.
- 기존 시작 화면의 앱 아이콘, 보조 설명, 로그인 없이 이용 가능 문구는 화면 균형을 해쳐 제거했습니다.
- 위치·알림 권한 단계는 실제 권한 요청처럼 보이는 버튼 대신 사용자가 켜고 끌 수 있는 토글과 건너뛰기 안내창으로 변경했습니다.

## 작업 내용

- 시작 화면 배경과 큰 문구를 조정하고 앱 아이콘과 설명 문구를 제거했습니다.
- 서비스 소개 화면을 추가해 계단 없는 길, 고장 시설 회피, 오프라인 정보 확인 가치를 먼저 보여줍니다.
- 이동 유형 선택, 이동 조건 확인, 권한 선택을 3단계 개인화 화면으로 구성했습니다.
- 권한 선택 화면에 현재 위치와 알림 토글을 추가하고, 선택을 끈 상태에서 건너뛰면 수동 설정 방법 안내창이 뜨도록 했습니다.
- 저장되지 않는 이동 조건 토글은 제거하고, 선택한 이동 유형에 실제 적용되는 조건을 읽기 전용으로 표시했습니다.
- 데이터 삭제 후에는 새 첫 실행 흐름이 시작 화면부터 다시 보이도록 초기화 상태를 맞췄습니다.
- 서비스 소개에서 바로 시작해도 보류된 시설 신고 사진 복구가 다시 예약되도록 맞췄습니다.
- 즐겨찾기 목록에서 항목을 삭제하고 돌아오면 홈 요약 개수가 다시 로드되도록 보정했습니다.
- 즐겨찾기 홈 요약 로딩 실패 시 원본 예외와 stackTrace를 보존해 모바일 contract를 만족하도록 했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter analyze`: exit 0, No issues found
  - `flutter test test/onboarding_test.dart test/onboarding_app_flow_test.dart`: exit 0, 17 tests passed
  - `flutter test test/widget_test.dart`: exit 0, 103 tests passed
  - `node --test --test-name-pattern "모바일 generic catch|모바일 접근성 출시 QA|릴리즈 보안 기준선|모바일 스토어 심사 정보 기준선|모바일 스토어 개인정보 인벤토리|Android 릴리즈 권한|iOS 앱은 개인정보 매니페스트|Android 런처 아이콘" tools/ci/repository-contract.test.mjs`: exit 0, 8 tests passed
  - `flutter test test/station_search_test.dart --plain-name '즐겨찾기 역 목록 컨트롤러는 목록과 빈 목록과 실패 상태를 구분한다'`: exit 0, 1 test passed
  - `flutter test test/favorite_facility_test.dart --plain-name '즐겨찾기 시설 목록 컨트롤러는 목록과 빈 목록과 실패 상태를 구분한다'`: exit 0, 1 test passed
  - `flutter test test/widget_test.dart --plain-name '즐겨찾기 경로 목록 실패는 다음 행동을 쉬운 문구로 안내한다'`: exit 0, 1 test passed
  - `flutter test test/widget_test.dart --plain-name '홈 즐겨찾기 경로는 저장한 경로를 큰 목록으로 보여주고 삭제한다'`: exit 0, 1 test passed
  - `flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 시작 화면 v3 반영 | Android emulator | 이전 QA 승인 단계에서 화면 캡처로 시작 화면 문구, 배경, 아이콘 제거 확인 | 로컬 전용 `.codex/evidence/762/android-start-screen-v3.png` | 통과 |
| 서비스 소개 화면 | Android emulator | 이전 QA 승인 단계에서 화면 캡처로 상단 시각 박스 경계와 소개 항목 확인 | 로컬 전용 `.codex/evidence/762/android-intro-screen-v3.png` | 통과 |
| 이동 유형 선택 | Android emulator | 이전 QA 승인 단계에서 화면 캡처로 이동 유형 카드 구성 확인 | 로컬 전용 `.codex/evidence/762/android-profile-screen-v3.png` | 통과 |
| 이동 조건 확인 | Android emulator / Flutter widget test | 이전 QA 승인 단계에서 화면 캡처로 조건 화면 구조 확인, 후속 수정에서 저장되지 않는 토글 제거 후 읽기 전용 조건 semantics 확인 | 로컬 전용 `.codex/evidence/762/android-preferences-screen-v3.png`, 명령 출력 | 통과 |
| 위치·알림 권한 선택 | Flutter widget test | 현재 위치·알림 토글, 스크린리더 라벨, 선택 해제 후 건너뛰기 수동 설정 안내창 확인 | `flutter test test/onboarding_test.dart test/onboarding_app_flow_test.dart` 출력 | 통과 |
| 첫 실행 전체 흐름 | Flutter widget test | 시작 화면부터 서비스 소개, 개인화, 권한 선택, 홈 진입까지 확인 | `flutter test test/onboarding_test.dart test/onboarding_app_flow_test.dart` 출력 | 통과 |
| 즐겨찾기 요약 복귀 갱신 | Flutter widget test | 경로 삭제 후 즐겨찾기 홈으로 돌아오면 `경로 0개`와 최근 경로 숨김 확인 | `flutter test test/widget_test.dart` 출력 | 통과 |
| 모바일 contract | Node test | generic catch 원본 예외·stackTrace 보존과 모바일 출시 기준선 확인 | `node --test --test-name-pattern ... tools/ci/repository-contract.test.mjs` 출력 | 통과 |
| Android 빌드 | Android debug APK | debug APK 생성 확인 | `flutter build apk --debug` 출력 | 통과 |

권한 화면의 최신 에뮬레이터 재촬영은 QA 요청에 따라 이번 마무리 단계에서 제외했고, 후속 일괄 QA에서 다시 확인합니다. 화면 증거 파일은 외부 업로드 승인이 없어 git에 커밋하지 않고 로컬 전용 경로에 보관했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/onboarding.dart`의 시작 및 개인화 화면 구성
  - 권한 선택 토글의 semantics label과 건너뛰기 안내창
  - `apps/mobile/lib/main.dart`의 시작 화면, 서비스 소개, 온보딩 초기화 흐름
  - 즐겨찾기 목록 복귀 후 홈 요약 재로드 흐름

## 리스크

- 권한 단계는 실제 OS 권한 요청이 아니라 최종 이용자의 선택과 수동 설정 안내를 먼저 보여주는 UX로 바뀌었습니다. 실제 권한 요청은 주변 역 찾기와 알림 설정 화면에서 기존 흐름을 사용합니다.
- 이동 조건 단계는 저장되지 않는 선택 토글 대신 현재 이동 유형에 적용되는 조건 확인 화면으로 정리했습니다. 세부 조건 직접 저장은 별도 저장 모델이 생길 때 다시 연결해야 합니다.
- 최신 권한 화면의 에뮬레이터 재촬영은 이번 마무리에서 제외되어 후속 일괄 QA에서 시각 확인이 필요합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
