### PR TITLE
[Feat] 접근성 길찾기 워크플로우 v3 반영

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1212,7 +1212,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
   void _updateOriginStation(StationSearchResult? station) {
     setState(() {
       _originStation = station;
-      _activeStationPicker = null;
+      if (station != null) {
+        _activeStationPicker = null;
+      }
       _validationMessage = '';
     });
     _controller.reset();
@@ -1221,7 +1223,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
   void _updateDestinationStation(StationSearchResult? station) {
     setState(() {
       _destinationStation = station;
-      _activeStationPicker = null;
+      if (station != null) {
+        _activeStationPicker = null;
+      }
       _validationMessage = '';
     });
     _controller.reset();
@@ -2372,6 +2376,8 @@ class _RouteSearchResultCardState extends State<_RouteSearchResultCard> {
         canUseApiActions &&
         widget.favoriteRouteRepository != null &&
         !result.isBlocked;
+    final canOpenFeedback =
+        canUseApiActions && widget.routeFeedbackRepository != null;
 
     return switch (_view) {
       _RouteWorkflowView.list => _RouteResultsListView(
@@ -2383,7 +2389,7 @@ class _RouteSearchResultCardState extends State<_RouteSearchResultCard> {
         onBack: () => setState(() => _view = _RouteWorkflowView.list),
         onStartGuidance: () =>
             setState(() => _view = _RouteWorkflowView.guidance),
-        onOpenFeedback: widget.routeFeedbackRepository == null
+        onOpenFeedback: !canOpenFeedback
             ? null
             : () => setState(() => _view = _RouteWorkflowView.feedback),
         favoriteSaveButton: canSaveRoute
@@ -2398,8 +2404,10 @@ class _RouteSearchResultCardState extends State<_RouteSearchResultCard> {
         onBack: () => setState(() => _view = _RouteWorkflowView.detail),
         onOpenInternalRoute: () =>
             setState(() => _view = _RouteWorkflowView.internalRoute),
-        onOpenBlocked: () => setState(() => _view = _RouteWorkflowView.blocked),
-        onOpenFeedback: widget.routeFeedbackRepository == null
+        onOpenBlocked: !canOpenFeedback
+            ? null
+            : () => setState(() => _view = _RouteWorkflowView.feedback),
+        onOpenFeedback: !canOpenFeedback
             ? null
             : () => setState(() => _view = _RouteWorkflowView.feedback),
       ),
@@ -2530,7 +2538,7 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
   final RouteSearchResult result;
   final VoidCallback onBack;
   final VoidCallback onOpenInternalRoute;
-  final VoidCallback onOpenBlocked;
+  final VoidCallback? onOpenBlocked;
   final VoidCallback? onOpenFeedback;
 
   @override
@@ -2591,25 +2599,35 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
             text: nextStep.title,
             icon: Icons.near_me_outlined,
           ),
-        Row(
-          children: [
-            Expanded(
-              child: OutlinedButton(
-                key: const Key('routeOpenInternalRouteButton'),
-                onPressed: onOpenInternalRoute,
-                child: const Text('전체 순서'),
+        if (onOpenBlocked case final openBlocked?)
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  key: const Key('routeOpenInternalRouteButton'),
+                  onPressed: onOpenInternalRoute,
+                  child: const Text('전체 순서'),
+                ),
               ),
-            ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: OutlinedButton(
-                key: const Key('routeOpenBlockedButton'),
-                onPressed: onOpenBlocked,
-                child: const Text('길이 막혔어요'),
+              const SizedBox(width: 10),
+              Expanded(
+                child: OutlinedButton(
+                  key: const Key('routeOpenBlockedButton'),
+                  onPressed: openBlocked,
+                  child: const Text('길이 막혔어요'),
+                ),
               ),
+            ],
+          )
+        else
+          SizedBox(
+            width: double.infinity,
+            child: OutlinedButton(
+              key: const Key('routeOpenInternalRouteButton'),
+              onPressed: onOpenInternalRoute,
+              child: const Text('전체 순서'),
             ),
-          ],
-        ),
+          ),
         if (onOpenFeedback != null) ...[
           const SizedBox(height: 8),
           TextButton(

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2436,25 +2436,42 @@ class _RouteResultsListView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Semantics(
-      label: result.semanticLabel,
-      liveRegion: true,
-      child: ExcludeSemantics(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            _RouteWorkflowSummary(result: result),
-            const SizedBox(height: 12),
-            const _RouteSegmentedLabels(labels: ['편한 순', '빠른 순', '환승 적은 순']),
-            const SizedBox(height: 18),
-            _RouteSectionHeader(title: '추천 경로 목록'),
-            const SizedBox(height: 8),
-            _RouteResultListButton(result: result, onPressed: onOpenDetail),
-          ],
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Semantics(
+          label: result.semanticLabel,
+          liveRegion: true,
+          child: ExcludeSemantics(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _RouteWorkflowSummary(result: result),
+                const SizedBox(height: 12),
+                const _RouteSegmentedLabels(
+                  labels: ['편한 순', '빠른 순', '환승 적은 순'],
+                ),
+                const SizedBox(height: 18),
+                _RouteSectionHeader(title: '추천 경로 목록'),
+                const SizedBox(height: 8),
+              ],
+            ),
+          ),
         ),
-      ),
+        _RouteResultListButton(result: result, onPressed: onOpenDetail),
+      ],
     );
   }
+}
+
+bool _routeStepIsExplicitTransfer(RouteSearchStep step) {
+  return step.actionTitle.contains('환승') ||
+      step.title.contains('환승') ||
+      step.description.contains('환승');
+}
+
+int _routeExplicitTransferCount(List<RouteSearchStep> steps) {
+  return steps.where(_routeStepIsExplicitTransfer).length;
 }
 
 class _RouteDetailWorkflowView extends StatelessWidget {
@@ -3015,6 +3032,10 @@ int _routeTotalDistanceMeters(RouteSearchResult result) {
 
 String _routeTransferLabel(RouteSearchResult result) {
   final movementSteps = result.movementSteps;
+  final explicitTransfers = _routeExplicitTransferCount(movementSteps);
+  if (explicitTransfers > 0) {
+    return '환승 $explicitTransfers회';
+  }
   var previousLine = '';
   var changes = 0;
   for (final step in movementSteps) {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1027,6 +1027,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
   late final RouteSearchController _controller;
   StationSearchResult? _originStation;
   StationSearchResult? _destinationStation;
+  _RouteStationRole? _activeStationPicker;
   late String _selectedMobilityType;
   String _validationMessage = '';
 
@@ -1048,31 +1049,85 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('경로 검색')),
+      appBar: AppBar(title: const Text('길찾기')),
+      bottomNavigationBar: SafeArea(
+        minimum: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+        child: AnimatedBuilder(
+          animation: _controller,
+          builder: (context, _) {
+            final isLoading =
+                _controller.state.status == RouteSearchViewStatus.loading;
+            return FilledButton(
+              key: const Key('routeSearchSubmitButton'),
+              onPressed: isLoading ? null : _submit,
+              style: FilledButton.styleFrom(
+                minimumSize: const Size.fromHeight(60),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              child: Text(isLoading ? '경로 검색 중' : '길찾기'),
+            );
+          },
+        ),
+      ),
       body: SafeArea(
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
           children: [
-            _RouteStationPicker(
-              labelText: '출발역',
-              inputKey: const Key('routeOriginStationInput'),
-              searchButtonKey: const Key('routeOriginStationSearchButton'),
-              optionKeyPrefix: 'routeOriginStationOption',
-              selectedStation: _originStation,
-              repository: widget.stationRepository,
-              onSelected: _updateOriginStation,
+            _RoutePointPickerCard(
+              originStation: _originStation,
+              destinationStation: _destinationStation,
+              onOriginTap: () => _openStationPicker(_RouteStationRole.origin),
+              onDestinationTap: () =>
+                  _openStationPicker(_RouteStationRole.destination),
+              onSwap: _swapStations,
             ),
-            const SizedBox(height: 16),
-            _RouteStationPicker(
-              labelText: '도착역',
-              inputKey: const Key('routeDestinationStationInput'),
-              searchButtonKey: const Key('routeDestinationStationSearchButton'),
-              optionKeyPrefix: 'routeDestinationStationOption',
-              selectedStation: _destinationStation,
-              repository: widget.stationRepository,
-              onSelected: _updateDestinationStation,
+            if (_activeStationPicker != null) ...[
+              const SizedBox(height: 12),
+              _RouteStationPicker(
+                labelText: _activeStationPicker == _RouteStationRole.origin
+                    ? '출발역'
+                    : '도착역',
+                inputKey: _activeStationPicker == _RouteStationRole.origin
+                    ? const Key('routeOriginStationInput')
+                    : const Key('routeDestinationStationInput'),
+                searchButtonKey:
+                    _activeStationPicker == _RouteStationRole.origin
+                    ? const Key('routeOriginStationSearchButton')
+                    : const Key('routeDestinationStationSearchButton'),
+                optionKeyPrefix:
+                    _activeStationPicker == _RouteStationRole.origin
+                    ? 'routeOriginStationOption'
+                    : 'routeDestinationStationOption',
+                selectedStation:
+                    _activeStationPicker == _RouteStationRole.origin
+                    ? _originStation
+                    : _destinationStation,
+                repository: widget.stationRepository,
+                onSelected: _activeStationPicker == _RouteStationRole.origin
+                    ? _updateOriginStation
+                    : _updateDestinationStation,
+              ),
+            ],
+            const SizedBox(height: 18),
+            if (_validationMessage.isNotEmpty) ...[
+              _RouteSearchMessage(
+                message: _validationMessage,
+                liveRegion: true,
+              ),
+              const SizedBox(height: 16),
+            ],
+            _RouteSectionHeader(
+              title: widget.simpleViewEnabled ? '이동 조건' : '검색 조건',
+              trailing: widget.simpleViewEnabled
+                  ? _RouteHeaderActionButton(
+                      label: '변경',
+                      onPressed: _showMobilityTypePicker,
+                    )
+                  : null,
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: 8),
             // 단순 보기에서는 드롭다운 대신 현재 조건을 크게 보여주고, 필요할 때만 바꿀 수 있게 한다.
             if (widget.simpleViewEnabled)
               _RouteMobilityTypeSummary(
@@ -1110,28 +1165,11 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
                   ),
                 ),
               ),
-            const SizedBox(height: 12),
-            AnimatedBuilder(
-              animation: _controller,
-              builder: (context, _) {
-                final isLoading =
-                    _controller.state.status == RouteSearchViewStatus.loading;
-                return FilledButton.icon(
-                  key: const Key('routeSearchSubmitButton'),
-                  onPressed: isLoading ? null : _submit,
-                  icon: const Icon(Icons.route),
-                  label: const Text('경로 찾기'),
-                );
-              },
+            const SizedBox(height: 18),
+            _RouteRecentDestinationList(
+              repository: widget.favoriteRouteRepository,
+              onSelected: _updateDestinationStation,
             ),
-            const SizedBox(height: 20),
-            if (_validationMessage.isNotEmpty) ...[
-              _RouteSearchMessage(
-                message: _validationMessage,
-                liveRegion: true,
-              ),
-              const SizedBox(height: 16),
-            ],
             AnimatedBuilder(
               animation: _controller,
               builder: (context, _) => _RouteSearchBody(
@@ -1174,6 +1212,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
   void _updateOriginStation(StationSearchResult? station) {
     setState(() {
       _originStation = station;
+      _activeStationPicker = null;
       _validationMessage = '';
     });
     _controller.reset();
@@ -1182,6 +1221,25 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
   void _updateDestinationStation(StationSearchResult? station) {
     setState(() {
       _destinationStation = station;
+      _activeStationPicker = null;
+      _validationMessage = '';
+    });
+    _controller.reset();
+  }
+
+  void _openStationPicker(_RouteStationRole role) {
+    setState(() {
+      _activeStationPicker = _activeStationPicker == role ? null : role;
+      _validationMessage = '';
+    });
+  }
+
+  void _swapStations() {
+    setState(() {
+      final origin = _originStation;
+      _originStation = _destinationStation;
+      _destinationStation = origin;
+      _activeStationPicker = null;
       _validationMessage = '';
     });
     _controller.reset();
@@ -1245,6 +1303,444 @@ StationSearchResult? _stationFromDraft(RouteDraftStation? station) {
   );
 }
 
+enum _RouteStationRole { origin, destination }
+
+class _RoutePointPickerCard extends StatelessWidget {
+  const _RoutePointPickerCard({
+    required this.originStation,
+    required this.destinationStation,
+    required this.onOriginTap,
+    required this.onDestinationTap,
+    required this.onSwap,
+  });
+
+  final StationSearchResult? originStation;
+  final StationSearchResult? destinationStation;
+  final VoidCallback onOriginTap;
+  final VoidCallback onDestinationTap;
+  final VoidCallback onSwap;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: const Color(0xFFD5E2E4)),
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x0F071B2F),
+            blurRadius: 16,
+            offset: Offset(0, 5),
+          ),
+        ],
+      ),
+      child: Stack(
+        alignment: Alignment.centerRight,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(8, 8, 58, 8),
+            child: Column(
+              children: [
+                _RoutePointRow(
+                  key: const Key('routeOriginPointButton'),
+                  label: '출발',
+                  station: originStation,
+                  fallback: '출발역 선택',
+                  onTap: onOriginTap,
+                ),
+                const Divider(height: 1, color: Color(0xFFE0E7EC)),
+                _RoutePointRow(
+                  key: const Key('routeDestinationPointButton'),
+                  label: '도착',
+                  station: destinationStation,
+                  fallback: '도착역 선택',
+                  onTap: onDestinationTap,
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(right: 9),
+            child: Semantics(
+              button: true,
+              label: '출발 도착 바꾸기',
+              onTap: onSwap,
+              child: ExcludeSemantics(
+                child: IconButton.outlined(
+                  key: const Key('routeSwapStationsButton'),
+                  onPressed: onSwap,
+                  icon: const Icon(Icons.swap_vert),
+                  color: const Color(0xFF102A2C),
+                  style: IconButton.styleFrom(
+                    backgroundColor: const Color(0xFFF3F7F8),
+                    fixedSize: const Size(42, 42),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(13),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RoutePointRow extends StatelessWidget {
+  const _RoutePointRow({
+    required this.label,
+    required this.station,
+    required this.fallback,
+    required this.onTap,
+    super.key,
+  });
+
+  final String label;
+  final StationSearchResult? station;
+  final String fallback;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final stationName = station == null
+        ? fallback
+        : _routeStationDisplayName(station!);
+    final semanticsLabel = station == null
+        ? stationName
+        : '$label $stationName';
+    return Semantics(
+      button: true,
+      label: semanticsLabel,
+      onTap: onTap,
+      child: ExcludeSemantics(
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(14),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    stationName,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: const Color(0xFF102A2C),
+                      fontSize: 22,
+                      height: 1.2,
+                    ),
+                  ),
+                ),
+                const Icon(Icons.map_outlined, color: Color(0xFF50656F)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RouteSectionHeader extends StatelessWidget {
+  const _RouteSectionHeader({required this.title, this.trailing});
+
+  final String title;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            title,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              color: const Color(0xFF102A2C),
+              fontWeight: FontWeight.w900,
+              height: 1.25,
+            ),
+          ),
+        ),
+        ?trailing,
+      ],
+    );
+  }
+}
+
+class _RouteHeaderActionButton extends StatelessWidget {
+  const _RouteHeaderActionButton({
+    required this.label,
+    required this.onPressed,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: label,
+      onTap: onPressed,
+      child: ExcludeSemantics(
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: onPressed,
+            borderRadius: BorderRadius.circular(8),
+            child: Ink(
+              decoration: BoxDecoration(
+                color: Colors.white,
+                border: Border.all(color: const Color(0xFF006D77)),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 9,
+                ),
+                child: Text(
+                  label,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: const Color(0xFF006D77),
+                    height: 1.2,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RouteRecentDestinationList extends StatefulWidget {
+  const _RouteRecentDestinationList({
+    required this.repository,
+    required this.onSelected,
+  });
+
+  final FavoriteRouteRepository? repository;
+  final ValueChanged<StationSearchResult> onSelected;
+
+  @override
+  State<_RouteRecentDestinationList> createState() =>
+      _RouteRecentDestinationListState();
+}
+
+class _RouteRecentDestinationListState
+    extends State<_RouteRecentDestinationList> {
+  Future<List<FavoriteRoute>>? _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = widget.repository?.listFavoriteRoutes();
+  }
+
+  @override
+  void didUpdateWidget(_RouteRecentDestinationList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.repository != widget.repository) {
+      _future = widget.repository?.listFavoriteRoutes();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final future = _future;
+    if (future == null) {
+      return const SizedBox.shrink();
+    }
+    return FutureBuilder<List<FavoriteRoute>>(
+      future: future,
+      builder: (context, snapshot) {
+        final routes = snapshot.data ?? const <FavoriteRoute>[];
+        final destinations = _routeRecentDestinations(routes);
+        if (destinations.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const _RouteSectionHeader(title: '최근 도착지'),
+            const SizedBox(height: 8),
+            DecoratedBox(
+              decoration: BoxDecoration(
+                color: Colors.white,
+                border: Border.all(color: const Color(0xFFD5E2E4)),
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: Column(
+                children: [
+                  for (final entry in destinations.indexed) ...[
+                    if (entry.$1 > 0)
+                      const Divider(height: 1, color: Color(0xFFE0E7EC)),
+                    _RouteRecentDestinationRow(
+                      route: entry.$2,
+                      onSelected: () => widget.onSelected(
+                        _stationFromFavoriteDestination(entry.$2),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            const SizedBox(height: 18),
+          ],
+        );
+      },
+    );
+  }
+}
+
+List<FavoriteRoute> _routeRecentDestinations(List<FavoriteRoute> routes) {
+  final seen = <String>{};
+  final destinations = <FavoriteRoute>[];
+  for (final route in routes) {
+    if (seen.add(route.destinationStationId)) {
+      destinations.add(route);
+    }
+    if (destinations.length == 2) {
+      break;
+    }
+  }
+  return destinations;
+}
+
+StationSearchResult _stationFromFavoriteDestination(FavoriteRoute route) {
+  final lineName = route.lineName;
+  return StationSearchResult(
+    id: route.destinationStationId,
+    nameKo: route.destinationStationName,
+    nameEn: '',
+    region: '',
+    dataQualityLevel: '',
+    lastVerifiedAt: '',
+    lines: lineName.isEmpty ? const [] : [_routeRecentLine(lineName)],
+  );
+}
+
+StationSearchLine _routeRecentLine(String name) {
+  final id = 'line-${stationLineBadgeText(name)}';
+  return StationSearchLine(
+    id: id,
+    name: name,
+    color: _routeLineColor(name),
+    stationCode: '',
+  );
+}
+
+String _routeLineColor(String name) {
+  const colors = {
+    '1호선': '#263C96',
+    '2호선': '#00A84D',
+    '3호선': '#EF7C1C',
+    '4호선': '#00A5DE',
+    '5호선': '#996CAC',
+    '6호선': '#CD7C2F',
+    '7호선': '#747F00',
+    '8호선': '#E6186C',
+    '9호선': '#BDB092',
+    '경의중앙선': '#77C4A3',
+    '수인분당선': '#F5A200',
+    '신분당선': '#D4003B',
+    '공항철도': '#0090D2',
+  };
+  for (final entry in colors.entries) {
+    if (name.contains(entry.key)) {
+      return entry.value;
+    }
+  }
+  return '#006D77';
+}
+
+class _RouteRecentDestinationRow extends StatelessWidget {
+  const _RouteRecentDestinationRow({
+    required this.route,
+    required this.onSelected,
+  });
+
+  final FavoriteRoute route;
+  final VoidCallback onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final title = _routeStationNameDisplay(route.destinationStationName);
+    final lines = route.lineName.isEmpty
+        ? const <StationSearchLine>[]
+        : [_routeRecentLine(route.lineName)];
+    final lineLabel = lines.isEmpty
+        ? route.lineLabel
+        : lines.map((line) => line.name).join(', ');
+    return Semantics(
+      button: true,
+      label: '$title, $lineLabel, 선택',
+      onTap: onSelected,
+      child: ExcludeSemantics(
+        child: InkWell(
+          onTap: onSelected,
+          borderRadius: BorderRadius.circular(14),
+          child: ListTile(
+            leading: const Icon(Icons.train_outlined, color: Color(0xFF006D77)),
+            title: Text(
+              title,
+              style: const TextStyle(
+                color: Color(0xFF102A2C),
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+            subtitle: Padding(
+              padding: const EdgeInsets.only(top: 6),
+              child: lines.isEmpty
+                  ? Text(lineLabel)
+                  : Wrap(
+                      spacing: 10,
+                      runSpacing: 6,
+                      children: [
+                        for (final line in lines) _RouteRecentLine(line: line),
+                      ],
+                    ),
+            ),
+            trailing: const Text('선택'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RouteRecentLine extends StatelessWidget {
+  const _RouteRecentLine({required this.line});
+
+  final StationSearchLine line;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          key: Key('routeRecentLineMark-${line.id}'),
+          child: StationLineBadge(line: line, size: 16),
+        ),
+        const SizedBox(width: 5),
+        Text(
+          line.name,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: const Color(0xFF50656F),
+            fontSize: 16,
+            height: 1.2,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 class _RouteMobilityTypeSummary extends StatelessWidget {
   const _RouteMobilityTypeSummary({
     required this.mobilityType,
@@ -1262,7 +1758,7 @@ class _RouteMobilityTypeSummary extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          '적용 중인 이동 조건',
+          '적용 중인 조건',
           style: Theme.of(context).textTheme.bodyMedium?.copyWith(
             color: const Color(0xFF29484B),
             fontWeight: FontWeight.w700,
@@ -1278,15 +1774,16 @@ class _RouteMobilityTypeSummary extends StatelessWidget {
             height: 1.25,
           ),
         ),
+        const SizedBox(height: 3),
+        Text(
+          _routeMobilityConditionLabel(option),
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: const Color(0xFF50656F),
+            fontWeight: FontWeight.w700,
+            height: 1.3,
+          ),
+        ),
       ],
-    );
-    final changeLabel = Text(
-      '바꾸기',
-      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-        color: const Color(0xFF006D77),
-        fontWeight: FontWeight.w900,
-        height: 1.25,
-      ),
     );
     return Semantics(
       button: true,
@@ -1326,11 +1823,6 @@ class _RouteMobilityTypeSummary extends StatelessWidget {
                               Expanded(child: content),
                             ],
                           ),
-                          const SizedBox(height: 8),
-                          Align(
-                            alignment: Alignment.centerRight,
-                            child: changeLabel,
-                          ),
                         ],
                       )
                     : Row(
@@ -1342,7 +1834,6 @@ class _RouteMobilityTypeSummary extends StatelessWidget {
                           ),
                           const SizedBox(width: 10),
                           Expanded(child: content),
-                          changeLabel,
                         ],
                       ),
               ),
@@ -1410,6 +1901,18 @@ MobilityProfileOption _mobilityOptionFor(String mobilityType) {
   );
 }
 
+String _routeMobilityConditionLabel(MobilityProfileOption option) {
+  final conditions = <String>[];
+  if (option.avoidStairs) {
+    conditions.add('계단 피하기');
+  }
+  conditions.add('엘리베이터 이동');
+  if (option.minimizeTransfers) {
+    conditions.add('환승 줄이기');
+  }
+  return conditions.take(2).join(' · ');
+}
+
 class _RouteStationPicker extends StatefulWidget {
   const _RouteStationPicker({
     required this.labelText,
@@ -1462,50 +1965,64 @@ class _RouteStationPickerState extends State<_RouteStationPicker> {
 
   @override
   Widget build(BuildContext context) {
+    final selectedStation = widget.selectedStation;
+    final labelText = selectedStation == null
+        ? widget.labelText
+        : '${widget.labelText.replaceAll('역', '')} ${_routeStationDisplayName(selectedStation)}';
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Semantics(
-          label: '${widget.labelText} 입력',
-          textField: true,
-          child: TextField(
-            key: widget.inputKey,
-            controller: _textController,
-            minLines: 1,
-            textInputAction: TextInputAction.search,
-            style: const TextStyle(fontSize: 20, height: 1.35),
-            decoration: InputDecoration(
-              labelText: widget.labelText,
-              hintText: '역 이름을 입력해 주세요',
-              floatingLabelBehavior: FloatingLabelBehavior.always,
-              border: const OutlineInputBorder(
-                borderRadius: BorderRadius.all(Radius.circular(8)),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Semantics(
+                label: selectedStation == null
+                    ? '${widget.labelText} 입력'
+                    : '${widget.labelText} 선택됨, ${selectedStation.nameKo}',
+                textField: true,
+                liveRegion: selectedStation != null,
+                child: TextField(
+                  key: widget.inputKey,
+                  controller: _textController,
+                  minLines: 1,
+                  textInputAction: TextInputAction.search,
+                  style: const TextStyle(fontSize: 20, height: 1.35),
+                  decoration: InputDecoration(
+                    labelText: labelText,
+                    hintText: '역 이름을 입력해 주세요',
+                    floatingLabelBehavior: FloatingLabelBehavior.always,
+                    border: const OutlineInputBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(8)),
+                    ),
+                  ),
+                  onSubmitted: (_) => _search(),
+                ),
               ),
             ),
-            onSubmitted: (_) => _search(),
-          ),
+            const SizedBox(width: 8),
+            AnimatedBuilder(
+              animation: _controller,
+              builder: (context, _) {
+                final isLoading =
+                    _controller.state.status == StationSearchStatus.loading;
+                return IconButton.outlined(
+                  key: widget.searchButtonKey,
+                  tooltip: '${widget.labelText} 검색',
+                  onPressed: isLoading ? null : _search,
+                  icon: const Icon(Icons.search),
+                  style: IconButton.styleFrom(
+                    minimumSize: const Size(56, 56),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ],
         ),
         const SizedBox(height: 8),
-        AnimatedBuilder(
-          animation: _controller,
-          builder: (context, _) {
-            final isLoading =
-                _controller.state.status == StationSearchStatus.loading;
-            return OutlinedButton.icon(
-              key: widget.searchButtonKey,
-              onPressed: isLoading ? null : _search,
-              icon: const Icon(Icons.search),
-              label: Text('${widget.labelText} 검색'),
-            );
-          },
-        ),
-        if (widget.selectedStation case final selectedStation?) ...[
-          const SizedBox(height: 8),
-          _RouteSelectedStationSummary(
-            labelText: widget.labelText,
-            station: selectedStation,
-          ),
-        ],
         const SizedBox(height: 8),
         AnimatedBuilder(
           animation: _controller,
@@ -1557,77 +2074,13 @@ class _RouteStationPickerState extends State<_RouteStationPicker> {
   }
 }
 
-class _RouteSelectedStationSummary extends StatelessWidget {
-  const _RouteSelectedStationSummary({
-    required this.labelText,
-    required this.station,
-  });
+String _routeStationDisplayName(StationSearchResult station) {
+  return _routeStationNameDisplay(station.nameKo);
+}
 
-  final String labelText;
-  final StationSearchResult station;
-
-  @override
-  Widget build(BuildContext context) {
-    final hasLineMetadata = station.lines.isNotEmpty;
-    final semanticsLabel = hasLineMetadata
-        ? '$labelText 선택됨, ${station.semanticLabel}'
-        : '$labelText 선택됨, ${station.nameKo}';
-    return MergeSemantics(
-      child: Semantics(
-        label: semanticsLabel,
-        liveRegion: true,
-        child: ExcludeSemantics(
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: const Color(0xFFE9F5F6),
-              border: Border.all(color: const Color(0xFFB9D4D8)),
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.all(12),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Icon(Icons.check_circle, color: Color(0xFF006D77)),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          '$labelText ${station.nameKo}',
-                          style: Theme.of(context).textTheme.bodyLarge
-                              ?.copyWith(
-                                color: const Color(0xFF102A2C),
-                                fontWeight: FontWeight.w900,
-                                height: 1.3,
-                              ),
-                        ),
-                        if (hasLineMetadata) ...[
-                          const SizedBox(height: 6),
-                          StationLineBadges(lines: station.lines),
-                          const SizedBox(height: 6),
-                          Text(
-                            station.lineLabel,
-                            style: Theme.of(context).textTheme.bodyMedium
-                                ?.copyWith(
-                                  color: const Color(0xFF29484B),
-                                  fontWeight: FontWeight.w700,
-                                  height: 1.3,
-                                ),
-                          ),
-                        ],
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
+String _routeStationNameDisplay(String value) {
+  final name = value.trim();
+  return name.endsWith('역') ? name : '$name역';
 }
 
 class _RouteStationSearchBody extends StatelessWidget {
@@ -1872,7 +2325,16 @@ class _RouteSearchMessage extends StatelessWidget {
   }
 }
 
-class _RouteSearchResultCard extends StatelessWidget {
+enum _RouteWorkflowView {
+  list,
+  detail,
+  guidance,
+  internalRoute,
+  blocked,
+  feedback,
+}
+
+class _RouteSearchResultCard extends StatefulWidget {
   const _RouteSearchResultCard({
     required this.result,
     required this.routeFeedbackRepository,
@@ -1884,134 +2346,88 @@ class _RouteSearchResultCard extends StatelessWidget {
   final FavoriteRouteRepository? favoriteRouteRepository;
 
   @override
-  Widget build(BuildContext context) {
-    final canUseApiActions = !result.isLocalResult;
-    final canSaveRoute =
-        canUseApiActions &&
-        favoriteRouteRepository != null &&
-        !result.isBlocked;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        _RouteSearchResultSummaryCard(result: result),
-        if (canUseApiActions && routeFeedbackRepository != null) ...[
-          const SizedBox(height: 12),
-          _RouteFeedbackButtons(
-            result: result,
-            repository: routeFeedbackRepository!,
-          ),
-        ],
-        if (canSaveRoute) ...[
-          const SizedBox(height: 12),
-          _RouteFavoriteSaveButton(
-            result: result,
-            repository: favoriteRouteRepository!,
-          ),
-        ],
-      ],
-    );
-  }
+  State<_RouteSearchResultCard> createState() => _RouteSearchResultCardState();
 }
 
-class _RouteSearchResultSummaryCard extends StatelessWidget {
-  const _RouteSearchResultSummaryCard({required this.result});
+class _RouteSearchResultCardState extends State<_RouteSearchResultCard> {
+  _RouteWorkflowView _view = _RouteWorkflowView.list;
 
-  final RouteSearchResult result;
-
-  int get _totalMinutes {
-    return result.steps.fold<int>(
-      0,
-      (sum, step) => sum + step.estimatedMinutes,
-    );
-  }
-
-  int get _totalDistanceMeters {
-    return result.steps.fold<int>(0, (sum, step) => sum + step.distanceMeters);
-  }
-
-  int get _transferCount {
-    final explicitTransferSteps = result.movementSteps
-        .where(_isTransferStep)
-        .length;
-    if (explicitTransferSteps > 0) {
-      return explicitTransferSteps;
+  @override
+  void didUpdateWidget(_RouteSearchResultCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.result.routeSearchId != widget.result.routeSearchId) {
+      _view = _RouteWorkflowView.list;
     }
-
-    var previousLine = '';
-    var lineChanges = 0;
-    for (final step in result.movementSteps) {
-      final lineKey = step.lineId.isNotEmpty ? step.lineId : step.lineName;
-      if (lineKey.isEmpty) {
-        continue;
-      }
-      if (previousLine.isNotEmpty && previousLine != lineKey) {
-        lineChanges += 1;
-      }
-      previousLine = lineKey;
-    }
-    return lineChanges;
-  }
-
-  String get _transferLabel {
-    final transferCount = _transferCount;
-    return transferCount == 0 ? '환승 없음' : '환승 $transferCount회';
-  }
-
-  String get _walkingDistanceLabel {
-    if (_totalDistanceMeters <= 0) {
-      return '확인 필요';
-    }
-    return _routeDistanceLabel(_totalDistanceMeters);
-  }
-
-  String get _routeMeta => '$_transferLabel · 이동 $_walkingDistanceLabel';
-
-  String get _mobilityHeaderLabel {
-    final mobilityLabel = result.mobilityLabel;
-    if (mobilityLabel == '이동 조건 확인 필요') {
-      return mobilityLabel;
-    }
-
-    final option = _mobilityOptionFor(result.mobilityType);
-    final priority = _mobilityPriorityLabel(option);
-    return priority.isEmpty ? mobilityLabel : '$mobilityLabel · $priority';
-  }
-
-  bool get _isRecommendedRoute => result.status == 'FOUND' && !result.isBlocked;
-
-  static bool _isTransferStep(RouteSearchStep step) {
-    return step.title.contains('환승') ||
-        step.actionTitle.contains('환승') ||
-        step.description.contains('환승') ||
-        step.actionDetail.contains('환승');
-  }
-
-  static String _mobilityPriorityLabel(MobilityProfileOption option) {
-    if (option.requireElevator) {
-      return '엘리베이터 필수';
-    }
-    if (option.avoidStairs && option.minimizeTransfers) {
-      return '계단 회피 · 쉬운 환승';
-    }
-    if (option.avoidStairs && option.avoidLongWalks) {
-      return '계단 회피 · 짧은 보행';
-    }
-    if (option.avoidStairs) {
-      return '계단 회피';
-    }
-    if (option.minimizeTransfers) {
-      return '환승 적게';
-    }
-    return '';
   }
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    final textScale = MediaQuery.textScalerOf(context).scale(1);
-    final arrivalStep = result.arrivalGuidanceStep;
+    final result = widget.result;
+    if (result.isBlocked) {
+      return _RouteBlockedWorkflow(result: result);
+    }
 
+    final canUseApiActions = !result.isLocalResult;
+    final canSaveRoute =
+        canUseApiActions &&
+        widget.favoriteRouteRepository != null &&
+        !result.isBlocked;
+
+    return switch (_view) {
+      _RouteWorkflowView.list => _RouteResultsListView(
+        result: result,
+        onOpenDetail: () => setState(() => _view = _RouteWorkflowView.detail),
+      ),
+      _RouteWorkflowView.detail => _RouteDetailWorkflowView(
+        result: result,
+        onBack: () => setState(() => _view = _RouteWorkflowView.list),
+        onStartGuidance: () =>
+            setState(() => _view = _RouteWorkflowView.guidance),
+        onOpenFeedback: widget.routeFeedbackRepository == null
+            ? null
+            : () => setState(() => _view = _RouteWorkflowView.feedback),
+        favoriteSaveButton: canSaveRoute
+            ? _RouteFavoriteSaveButton(
+                result: result,
+                repository: widget.favoriteRouteRepository!,
+              )
+            : null,
+      ),
+      _RouteWorkflowView.guidance => _RouteGuidanceWorkflowView(
+        result: result,
+        onBack: () => setState(() => _view = _RouteWorkflowView.detail),
+        onOpenInternalRoute: () =>
+            setState(() => _view = _RouteWorkflowView.internalRoute),
+        onOpenBlocked: () => setState(() => _view = _RouteWorkflowView.blocked),
+        onOpenFeedback: widget.routeFeedbackRepository == null
+            ? null
+            : () => setState(() => _view = _RouteWorkflowView.feedback),
+      ),
+      _RouteWorkflowView.internalRoute => _RouteInternalWorkflowView(
+        result: result,
+        onBack: () => setState(() => _view = _RouteWorkflowView.guidance),
+      ),
+      _RouteWorkflowView.blocked => _RouteBlockedWorkflow(result: result),
+      _RouteWorkflowView.feedback => _RouteFeedbackWorkflowView(
+        result: result,
+        repository: widget.routeFeedbackRepository,
+        onBack: () => setState(() => _view = _RouteWorkflowView.detail),
+      ),
+    };
+  }
+}
+
+class _RouteResultsListView extends StatelessWidget {
+  const _RouteResultsListView({
+    required this.result,
+    required this.onOpenDetail,
+  });
+
+  final RouteSearchResult result;
+  final VoidCallback onOpenDetail;
+
+  @override
+  Widget build(BuildContext context) {
     return Semantics(
       label: result.semanticLabel,
       liveRegion: true,
@@ -2019,307 +2435,13 @@ class _RouteSearchResultSummaryCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: EasySubwayAccessibleColors.mintSoft,
-                    border: Border.all(
-                      color: EasySubwayAccessibleColors.mintBorder,
-                    ),
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: textScale >= 2
-                        ? Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                '${result.originStationName} → ${result.destinationStationName}',
-                                style: textTheme.titleMedium?.copyWith(
-                                  color: EasySubwayAccessibleColors.text,
-                                  fontWeight: FontWeight.w900,
-                                  height: 1.25,
-                                ),
-                              ),
-                              const SizedBox(height: 4),
-                              Text(
-                                _mobilityHeaderLabel,
-                                key: const Key('routeGuidanceMobilityChip'),
-                                style: textTheme.bodySmall?.copyWith(
-                                  color: EasySubwayAccessibleColors.mutedText,
-                                  height: 1.4,
-                                ),
-                              ),
-                              const SizedBox(height: 8),
-                              Align(
-                                alignment: Alignment.centerRight,
-                                child: DecoratedBox(
-                                  decoration: BoxDecoration(
-                                    color:
-                                        EasySubwayAccessibleColors.mintBorder,
-                                    borderRadius: BorderRadius.circular(14),
-                                  ),
-                                  child: const SizedBox(
-                                    width: 39,
-                                    height: 39,
-                                    child: Icon(
-                                      Icons.edit_outlined,
-                                      color:
-                                          EasySubwayAccessibleColors.mintDark,
-                                      size: 17,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ],
-                          )
-                        : Row(
-                            children: [
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      '${result.originStationName} → ${result.destinationStationName}',
-                                      style: textTheme.titleMedium?.copyWith(
-                                        color: EasySubwayAccessibleColors.text,
-                                        fontWeight: FontWeight.w900,
-                                        height: 1.25,
-                                      ),
-                                    ),
-                                    const SizedBox(height: 4),
-                                    Text(
-                                      _mobilityHeaderLabel,
-                                      key: const Key(
-                                        'routeGuidanceMobilityChip',
-                                      ),
-                                      style: textTheme.bodySmall?.copyWith(
-                                        color: EasySubwayAccessibleColors
-                                            .mutedText,
-                                        height: 1.4,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              DecoratedBox(
-                                decoration: BoxDecoration(
-                                  color: EasySubwayAccessibleColors.mintBorder,
-                                  borderRadius: BorderRadius.circular(14),
-                                ),
-                                child: const SizedBox(
-                                  width: 39,
-                                  height: 39,
-                                  child: Icon(
-                                    Icons.edit_outlined,
-                                    color: EasySubwayAccessibleColors.mintDark,
-                                    size: 17,
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                  ),
-                ),
-                const SizedBox(height: 22),
-                _RoutePrototypeSection(
-                  title: result.isBlocked
-                      ? '안내 불가 이유'
-                      : _isRecommendedRoute
-                      ? '추천 경로 1개'
-                      : result.statusLabel,
-                  subtitle: result.isBlocked
-                      ? '현재 조건에서 막힌 이유를 확인하세요'
-                      : _isRecommendedRoute
-                      ? '편함·불편함과 시간·환승·걷기만 비교합니다.'
-                      : '이 경로는 이동 전 확인이 필요합니다',
-                ),
-                DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: Colors.white,
-                    border: Border.all(
-                      color: result.isBlocked
-                          ? const Color(0xFFEFCCCC)
-                          : EasySubwayAccessibleColors.mint,
-                      width: 2,
-                    ),
-                    borderRadius: BorderRadius.circular(20),
-                    boxShadow: const [
-                      BoxShadow(
-                        color: Color(0x1A0D8A6D),
-                        blurRadius: 18,
-                        offset: Offset(0, 6),
-                      ),
-                    ],
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        if (textScale >= 2)
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                _isRecommendedRoute && _totalMinutes > 0
-                                    ? '$_totalMinutes분'
-                                    : result.isBlocked
-                                    ? result.guidanceLabel
-                                    : result.statusLabel,
-                                style: textTheme.headlineSmall?.copyWith(
-                                  color: EasySubwayAccessibleColors.text,
-                                  fontWeight: FontWeight.w900,
-                                  height: 1.1,
-                                ),
-                              ),
-                              const SizedBox(height: 4),
-                              Text(
-                                _isRecommendedRoute
-                                    ? _routeMeta
-                                    : result.statusLabel,
-                                style: textTheme.bodySmall?.copyWith(
-                                  color: EasySubwayAccessibleColors.mutedText,
-                                  height: 1.4,
-                                ),
-                              ),
-                              const SizedBox(height: 8),
-                              if (_isRecommendedRoute)
-                                const _RoutePrototypeChip(
-                                  label: '가장 추천',
-                                  icon: Icons.check,
-                                ),
-                              const SizedBox(height: 5),
-                              Text(
-                                result.comfortLabel,
-                                style: textTheme.bodyMedium?.copyWith(
-                                  color: EasySubwayAccessibleColors.mintDark,
-                                  fontWeight: FontWeight.w900,
-                                ),
-                              ),
-                            ],
-                          )
-                        else
-                          Row(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      _isRecommendedRoute && _totalMinutes > 0
-                                          ? '$_totalMinutes분'
-                                          : result.isBlocked
-                                          ? result.guidanceLabel
-                                          : result.statusLabel,
-                                      style: textTheme.headlineSmall?.copyWith(
-                                        color: EasySubwayAccessibleColors.text,
-                                        fontWeight: FontWeight.w900,
-                                        height: 1.1,
-                                      ),
-                                    ),
-                                    const SizedBox(height: 4),
-                                    Text(
-                                      _isRecommendedRoute
-                                          ? _routeMeta
-                                          : result.statusLabel,
-                                      style: textTheme.bodySmall?.copyWith(
-                                        color: EasySubwayAccessibleColors
-                                            .mutedText,
-                                        height: 1.4,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              Column(
-                                crossAxisAlignment: CrossAxisAlignment.end,
-                                children: [
-                                  if (_isRecommendedRoute)
-                                    const _RoutePrototypeChip(
-                                      label: '가장 추천',
-                                      icon: Icons.check,
-                                    ),
-                                  const SizedBox(height: 5),
-                                  Text(
-                                    result.comfortLabel,
-                                    style: textTheme.bodyMedium?.copyWith(
-                                      color:
-                                          EasySubwayAccessibleColors.mintDark,
-                                      fontWeight: FontWeight.w900,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ],
-                          ),
-                        if (_isRecommendedRoute &&
-                            result.movementSteps.isNotEmpty) ...[
-                          const SizedBox(height: 15),
-                          const _RoutePrototypeLinePath(),
-                        ],
-                        if (result.blockedReasons.isNotEmpty) ...[
-                          const SizedBox(height: 13),
-                          for (final reason in result.blockedReasons)
-                            _RoutePrototypeReason(text: reason, blocked: true),
-                        ],
-                        if (arrivalStep != null) ...[
-                          const SizedBox(height: 16),
-                          _RouteArrivalGuidance(step: arrivalStep),
-                        ],
-                        if (result.warnings.isNotEmpty) ...[
-                          const SizedBox(height: 16),
-                          for (final warning in result.warnings)
-                            _RouteNotice(
-                              title: '주의 확인',
-                              text: warning.message,
-                              icon: Icons.warning_amber,
-                            ),
-                        ],
-                        if (result.movementSteps.isNotEmpty) ...[
-                          const SizedBox(height: 18),
-                          _RouteStepSection(steps: result.movementSteps),
-                        ],
-                      ],
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            if (result.isBlocked)
-              const _RouteNotice(
-                key: Key('routeBlockedNextActionNotice'),
-                title: '다음 행동',
-                text: _routeSearchFailureNextAction,
-                icon: Icons.refresh,
-                semanticsLabel: '다음 행동, $_routeSearchFailureNextAction',
-              ),
+            _RouteWorkflowSummary(result: result),
             const SizedBox(height: 12),
-            if (result.isBlocked)
-              const _RouteNotice(
-                title: '안전 안내',
-                text: _routeSafetyGuidanceNotice,
-                icon: Icons.shield_outlined,
-              )
-            else
-              const _RouteNotice(
-                key: Key('routeSafetyGuidanceNotice'),
-                title: '안전 안내',
-                text: _routeSafetyGuidanceNotice,
-                icon: Icons.shield_outlined,
-              ),
-            if (result.isBlocked) ...[
-              const SizedBox(height: 12),
-              const _RouteNotice(
-                title: '확인 요청',
-                text: _routeBlockedConfirmationNotice,
-                icon: Icons.support_agent,
-              ),
-            ],
+            const _RouteSegmentedLabels(labels: ['편한 순', '빠른 순', '환승 적은 순']),
+            const SizedBox(height: 18),
+            _RouteSectionHeader(title: '추천 경로 목록'),
+            const SizedBox(height: 8),
+            _RouteResultListButton(result: result, onPressed: onOpenDetail),
           ],
         ),
       ),
@@ -2327,43 +2449,587 @@ class _RouteSearchResultSummaryCard extends StatelessWidget {
   }
 }
 
-class _RoutePrototypeSection extends StatelessWidget {
-  const _RoutePrototypeSection({required this.title, required this.subtitle});
+class _RouteDetailWorkflowView extends StatelessWidget {
+  const _RouteDetailWorkflowView({
+    required this.result,
+    required this.onBack,
+    required this.onStartGuidance,
+    required this.onOpenFeedback,
+    required this.favoriteSaveButton,
+  });
 
-  final String title;
-  final String subtitle;
+  final RouteSearchResult result;
+  final VoidCallback onBack;
+  final VoidCallback onStartGuidance;
+  final VoidCallback? onOpenFeedback;
+  final Widget? favoriteSaveButton;
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(1, 0, 1, 11),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            title,
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: EasySubwayAccessibleColors.text,
-              fontWeight: FontWeight.w900,
-              height: 1.2,
+    final totalMinutes = _routeTotalMinutes(result);
+    final meta = _routeMetaLabel(result);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _RouteWorkflowBackButton(label: '추천 경로', onPressed: onBack),
+        const SizedBox(height: 8),
+        _RouteDarkSummaryCard(
+          title: totalMinutes > 0 ? '$totalMinutes분' : result.statusLabel,
+          subtitle: meta,
+          chips: [
+            result.comfortLabel,
+            if (_routeHasNoStairs(result)) '계단 없음',
+            '엘리베이터 이용',
+          ],
+        ),
+        const SizedBox(height: 16),
+        _RouteStepSection(steps: result.movementSteps),
+        if (result.arrivalGuidanceStep case final arrivalStep?) ...[
+          const SizedBox(height: 8),
+          _RouteArrivalGuidance(step: arrivalStep),
+        ],
+        if (result.warnings.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          for (final warning in result.warnings)
+            _RouteNotice(
+              title: '주의 확인',
+              text: warning.message,
+              icon: Icons.warning_amber,
             ),
-          ),
-          const SizedBox(height: 3),
-          Text(
-            subtitle,
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: EasySubwayAccessibleColors.mutedText,
-              height: 1.35,
-            ),
+        ],
+        const SizedBox(height: 12),
+        ?favoriteSaveButton,
+        const SizedBox(height: 10),
+        FilledButton(
+          key: const Key('routeStartGuidanceButton'),
+          onPressed: onStartGuidance,
+          child: const Text('안내 시작'),
+        ),
+        if (onOpenFeedback != null) ...[
+          const SizedBox(height: 8),
+          TextButton(
+            key: const Key('routeOpenFeedbackButton'),
+            onPressed: onOpenFeedback,
+            child: const Text('경로 피드백'),
           ),
         ],
+      ],
+    );
+  }
+}
+
+class _RouteGuidanceWorkflowView extends StatelessWidget {
+  const _RouteGuidanceWorkflowView({
+    required this.result,
+    required this.onBack,
+    required this.onOpenInternalRoute,
+    required this.onOpenBlocked,
+    required this.onOpenFeedback,
+  });
+
+  final RouteSearchResult result;
+  final VoidCallback onBack;
+  final VoidCallback onOpenInternalRoute;
+  final VoidCallback onOpenBlocked;
+  final VoidCallback? onOpenFeedback;
+
+  @override
+  Widget build(BuildContext context) {
+    final steps = result.movementSteps;
+    final currentStep = steps.isEmpty ? null : steps.first;
+    final nextStep = steps.length > 1 ? steps[1] : result.arrivalGuidanceStep;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _RouteWorkflowBackButton(label: '경로 상세', onPressed: onBack),
+        const SizedBox(height: 8),
+        _RouteSectionHeader(title: '단계별 안내'),
+        const SizedBox(height: 8),
+        DecoratedBox(
+          decoration: BoxDecoration(
+            color: const Color(0xFF073245),
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(18),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '1 / ${steps.isEmpty ? 1 : steps.length}',
+                  style: const TextStyle(color: Color(0xFFD7F5EB)),
+                ),
+                const SizedBox(height: 18),
+                const Icon(Icons.arrow_forward, color: Colors.white, size: 38),
+                const SizedBox(height: 14),
+                Text(
+                  currentStep?.title ?? result.guidanceLabel,
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w900,
+                    height: 1.25,
+                  ),
+                ),
+                if (currentStep != null) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                    currentStep.description,
+                    style: const TextStyle(
+                      color: Color(0xFFC7D8E3),
+                      height: 1.4,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 14),
+        if (nextStep != null)
+          _RouteNotice(
+            title: '다음',
+            text: nextStep.title,
+            icon: Icons.near_me_outlined,
+          ),
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                key: const Key('routeOpenInternalRouteButton'),
+                onPressed: onOpenInternalRoute,
+                child: const Text('전체 순서'),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: OutlinedButton(
+                key: const Key('routeOpenBlockedButton'),
+                onPressed: onOpenBlocked,
+                child: const Text('길이 막혔어요'),
+              ),
+            ),
+          ],
+        ),
+        if (onOpenFeedback != null) ...[
+          const SizedBox(height: 8),
+          TextButton(
+            key: const Key('routeGuidanceFeedbackButton'),
+            onPressed: onOpenFeedback,
+            child: const Text('안내 피드백'),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _RouteInternalWorkflowView extends StatelessWidget {
+  const _RouteInternalWorkflowView({
+    required this.result,
+    required this.onBack,
+  });
+
+  final RouteSearchResult result;
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _RouteWorkflowBackButton(label: '단계별 안내', onPressed: onBack),
+        const SizedBox(height: 8),
+        _RouteDarkSummaryCard(
+          title:
+              '${result.originStationName} → ${result.lineName.isEmpty ? '승강장' : result.lineName}',
+          subtitle: _routeMetaLabel(result),
+          chips: const ['계단 없음', '엘리베이터 이용'],
+        ),
+        const SizedBox(height: 14),
+        _RouteSectionHeader(title: '역 안 이동 순서'),
+        const SizedBox(height: 8),
+        _RouteStepSection(steps: result.movementSteps),
+      ],
+    );
+  }
+}
+
+class _RouteBlockedWorkflow extends StatelessWidget {
+  const _RouteBlockedWorkflow({required this.result});
+
+  final RouteSearchResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    final reasons = result.blockedReasons.isNotEmpty
+        ? result.blockedReasons
+        : result.warnings.map((warning) => warning.message);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Icon(Icons.warning_amber, size: 64, color: Color(0xFFA93434)),
+        const SizedBox(height: 10),
+        Text(
+          '계단 없는 경로가 없습니다',
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+            color: const Color(0xFF102A2C),
+            fontWeight: FontWeight.w900,
+          ),
+        ),
+        const SizedBox(height: 12),
+        for (final reason in reasons)
+          _RoutePrototypeReason(text: reason, blocked: true),
+        const SizedBox(height: 12),
+        const _RouteNotice(
+          key: Key('routeBlockedNextActionNotice'),
+          title: '다른 방법',
+          text: _routeSearchFailureNextAction,
+          icon: Icons.refresh,
+          semanticsLabel: '다음 행동, $_routeSearchFailureNextAction',
+        ),
+        const _RouteNotice(
+          title: '안전 안내',
+          text: _routeSafetyGuidanceNotice,
+          icon: Icons.shield_outlined,
+        ),
+      ],
+    );
+  }
+}
+
+class _RouteFeedbackWorkflowView extends StatelessWidget {
+  const _RouteFeedbackWorkflowView({
+    required this.result,
+    required this.repository,
+    required this.onBack,
+  });
+
+  final RouteSearchResult result;
+  final RouteFeedbackRepository? repository;
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final feedbackRepository = repository;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _RouteWorkflowBackButton(label: '경로 상세', onPressed: onBack),
+        const SizedBox(height: 8),
+        Text(
+          '방금 안내가\n실제 이동에 도움이 됐나요?',
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+            color: const Color(0xFF102A2C),
+            fontWeight: FontWeight.w900,
+            height: 1.25,
+          ),
+        ),
+        const SizedBox(height: 14),
+        if (feedbackRepository == null)
+          const _RouteNotice(
+            title: '피드백 준비 중',
+            text: '잠시 후 다시 시도해 주세요.',
+            icon: Icons.info_outline,
+          )
+        else
+          _RouteFeedbackButtons(result: result, repository: feedbackRepository),
+      ],
+    );
+  }
+}
+
+class _RouteWorkflowSummary extends StatelessWidget {
+  const _RouteWorkflowSummary({required this.result});
+
+  final RouteSearchResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: const Color(0xFFE9F5F6),
+        border: Border.all(color: const Color(0xFFB9D4D8)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '${result.originStationName} → ${result.destinationStationName}',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      color: const Color(0xFF102A2C),
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    _routeMobilityConditionLabel(
+                      _mobilityOptionFor(result.mobilityType),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Icon(Icons.edit_outlined, color: Color(0xFF006D77)),
+          ],
+        ),
       ),
     );
   }
 }
 
+class _RouteSegmentedLabels extends StatelessWidget {
+  const _RouteSegmentedLabels({required this.labels});
+
+  final List<String> labels;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        for (final label in labels) ...[
+          Expanded(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: label == labels.first
+                    ? const Color(0xFF006D77)
+                    : const Color(0xFFE8F0F1),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                child: Text(
+                  label,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: label == labels.first
+                        ? Colors.white
+                        : const Color(0xFF29484B),
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          if (label != labels.last) const SizedBox(width: 6),
+        ],
+      ],
+    );
+  }
+}
+
+class _RouteResultListButton extends StatelessWidget {
+  const _RouteResultListButton({required this.result, required this.onPressed});
+
+  final RouteSearchResult result;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final totalMinutes = _routeTotalMinutes(result);
+    return Semantics(
+      button: true,
+      label:
+          '${result.summaryTitle}, ${_routeMetaLabel(result)}, ${result.comfortLabel}',
+      onTap: onPressed,
+      child: ExcludeSemantics(
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            key: const Key('routeResultListItem'),
+            onTap: onPressed,
+            borderRadius: BorderRadius.circular(8),
+            child: Ink(
+              decoration: BoxDecoration(
+                color: Colors.white,
+                border: Border.all(color: const Color(0xFF0D8A6D), width: 2),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            totalMinutes > 0 ? '$totalMinutes분' : '시간 확인',
+                            style: Theme.of(context).textTheme.headlineSmall
+                                ?.copyWith(
+                                  color: const Color(0xFF102A2C),
+                                  fontWeight: FontWeight.w900,
+                                ),
+                          ),
+                        ),
+                        const _RoutePrototypeChip(
+                          label: '추천',
+                          icon: Icons.check,
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(_routeMetaLabel(result)),
+                    const SizedBox(height: 12),
+                    const _RoutePrototypeLinePath(),
+                    const SizedBox(height: 12),
+                    Wrap(
+                      spacing: 6,
+                      runSpacing: 6,
+                      children: [
+                        _RoutePrototypeChip(
+                          label: _routeTransferLabel(result),
+                          icon: Icons.route_outlined,
+                        ),
+                        _RoutePrototypeChip(
+                          label: '걷기 ${_routeWalkingDistanceLabel(result)}',
+                          icon: Icons.directions_walk,
+                        ),
+                        _RoutePrototypeChip(
+                          key: const Key('routeGuidanceMobilityChip'),
+                          label: result.mobilityLabel == '이동 조건 확인 필요'
+                              ? result.mobilityLabel
+                              : result.comfortLabel,
+                          icon: Icons.accessible_forward,
+                        ),
+                        _RoutePrototypeChip(
+                          label: _routeHasNoStairs(result) ? '계단 없음' : '계단 있음',
+                          icon: _routeHasNoStairs(result)
+                              ? Icons.check
+                              : Icons.stairs_outlined,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RouteDarkSummaryCard extends StatelessWidget {
+  const _RouteDarkSummaryCard({
+    required this.title,
+    required this.subtitle,
+    required this.chips,
+  });
+
+  final String title;
+  final String subtitle;
+  final List<String> chips;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: const Color(0xFF073245),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                color: Colors.white,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(subtitle, style: const TextStyle(color: Color(0xFFC7D8E3))),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 6,
+              runSpacing: 6,
+              children: [
+                for (final chip in chips)
+                  _RoutePrototypeChip(label: chip, icon: Icons.check),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RouteWorkflowBackButton extends StatelessWidget {
+  const _RouteWorkflowBackButton({
+    required this.label,
+    required this.onPressed,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: TextButton.icon(
+        onPressed: onPressed,
+        icon: const Icon(Icons.arrow_back),
+        label: Text(label),
+      ),
+    );
+  }
+}
+
+int _routeTotalMinutes(RouteSearchResult result) {
+  return result.steps.fold<int>(0, (sum, step) => sum + step.estimatedMinutes);
+}
+
+int _routeTotalDistanceMeters(RouteSearchResult result) {
+  return result.steps.fold<int>(0, (sum, step) => sum + step.distanceMeters);
+}
+
+String _routeTransferLabel(RouteSearchResult result) {
+  final movementSteps = result.movementSteps;
+  var previousLine = '';
+  var changes = 0;
+  for (final step in movementSteps) {
+    final line = step.lineId.isNotEmpty ? step.lineId : step.lineName;
+    if (line.isEmpty) {
+      continue;
+    }
+    if (previousLine.isNotEmpty && previousLine != line) {
+      changes += 1;
+    }
+    previousLine = line;
+  }
+  return changes == 0 ? '환승 없음' : '환승 $changes회';
+}
+
+String _routeWalkingDistanceLabel(RouteSearchResult result) {
+  return _routeDistanceLabel(_routeTotalDistanceMeters(result));
+}
+
+String _routeMetaLabel(RouteSearchResult result) {
+  return '${_routeTransferLabel(result)} · 걷기 ${_routeWalkingDistanceLabel(result)}';
+}
+
+bool _routeHasNoStairs(RouteSearchResult result) {
+  return result.steps.every((step) => !step.includesStairs);
+}
+
 class _RoutePrototypeChip extends StatelessWidget {
-  const _RoutePrototypeChip({required this.label, required this.icon});
+  const _RoutePrototypeChip({
+    super.key,
+    required this.label,
+    required this.icon,
+  });
 
   final String label;
   final IconData icon;

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -4192,6 +4192,193 @@ void main() {
     expect(helpfulButton.onPressed, isNull);
   });
 
+  testWidgets('선택한 출발역을 수정해도 역 검색 입력은 닫히지 않는다', (tester) async {
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '사': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(),
+          stationRepository: stationRepository,
+          initialMobilityType: 'SENIOR',
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 6, 23),
+          ),
+        ),
+      ),
+    );
+
+    await _openRouteOriginStationInput(tester);
+    await tester.enterText(
+      find.byKey(const Key('routeOriginStationInput')),
+      '사',
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('routeOriginStationInput')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('routeOriginStationOption-station-sadang')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('로컬 경로 결과는 서버 피드백 행동을 숨긴다', (tester) async {
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '사당': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
+    final routeRepository = FakeRouteSearchRepository(
+      result: _sampleRouteSearchResult(
+        routeSearchId: 'local-station-sangnoksu-station-sadang',
+      ),
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: routeRepository,
+        routeFeedbackRepository: FakeRouteFeedbackRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchButton')));
+    await tester.pumpAndSettle();
+    await _openRouteOriginStationInput(tester);
+    await tester.enterText(
+      find.byKey(const Key('routeOriginStationInput')),
+      '상록수',
+    );
+    await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+    await _openRouteDestinationStationInput(tester);
+    await tester.enterText(
+      find.byKey(const Key('routeDestinationStationInput')),
+      '사당',
+    );
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationSearchButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationOption-station-sadang')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(ListView), const Offset(0, -360));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    await _openFirstRouteResultDetail(tester);
+
+    expect(find.byKey(const Key('routeOpenFeedbackButton')), findsNothing);
+
+    await tester.ensureVisible(
+      find.byKey(const Key('routeStartGuidanceButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeStartGuidanceButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('routeGuidanceFeedbackButton')), findsNothing);
+    expect(find.byKey(const Key('routeOpenBlockedButton')), findsNothing);
+    expect(
+      find.byKey(const Key('routeOpenInternalRouteButton')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('길이 막혔어요는 성공 경로를 blocked 화면으로 바꾸지 않는다', (tester) async {
+    final stationRepository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+        '사당': [_stationResult(id: 'station-sadang', name: '사당')],
+      },
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: stationRepository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        routeFeedbackRepository: FakeRouteFeedbackRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchButton')));
+    await tester.pumpAndSettle();
+    await _openRouteOriginStationInput(tester);
+    await tester.enterText(
+      find.byKey(const Key('routeOriginStationInput')),
+      '상록수',
+    );
+    await tester.tap(find.byKey(const Key('routeOriginStationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+    await _openRouteDestinationStationInput(tester);
+    await tester.enterText(
+      find.byKey(const Key('routeDestinationStationInput')),
+      '사당',
+    );
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationSearchButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('routeDestinationStationOption-station-sadang')),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(ListView), const Offset(0, -360));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    await _openFirstRouteResultDetail(tester);
+    await tester.ensureVisible(
+      find.byKey(const Key('routeStartGuidanceButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeStartGuidanceButton')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('routeOpenBlockedButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('방금 안내가\n실제 이동에 도움이 됐나요?'), findsOneWidget);
+    expect(find.text('계단 없는 경로가 없습니다'), findsNothing);
+  });
+
   testWidgets('경로 피드백 실패는 다음 행동을 쉬운 문구로 안내한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final stationRepository = FakeStationSearchRepository(
@@ -6949,6 +7136,7 @@ StationDetail _stationDetail({
 }
 
 RouteSearchResult _sampleRouteSearchResult({
+  String routeSearchId = 'route-1',
   String status = 'FOUND',
   String mobilityType = 'SENIOR',
   List<String> recommendationReasons = const [
@@ -6958,7 +7146,7 @@ RouteSearchResult _sampleRouteSearchResult({
   ],
 }) {
   return RouteSearchResult(
-    routeSearchId: 'route-1',
+    routeSearchId: routeSearchId,
     originStationId: 'station-sangnoksu',
     originStationName: '상록수',
     destinationStationId: 'station-sadang',

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -4313,6 +4313,105 @@ void main() {
     );
   });
 
+  testWidgets('추천 경로 항목은 스크린리더에서 상세 진입 버튼으로 남는다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteSearchScreen(
+            repository: FakeRouteSearchRepository(),
+            stationRepository: FakeStationSearchRepository(),
+            initialMobilityType: 'SENIOR',
+            initialDraft: RouteDraft(
+              origin: const RouteDraftStation(
+                id: 'station-sangnoksu',
+                nameKo: '상록수',
+              ),
+              destination: const RouteDraftStation(
+                id: 'station-sadang',
+                nameKo: '사당',
+              ),
+              lastModifiedAt: DateTime(2026, 6, 23),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('routeResultListItem')), findsOneWidget);
+      expect(
+        tester
+            .getSemantics(find.byKey(const Key('routeResultListItem')))
+            .getSemanticsData()
+            .hasAction(SemanticsAction.tap),
+        isTrue,
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
+  testWidgets('같은 노선의 명시적 환승 단계는 환승 횟수에 포함된다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(
+            result: _sampleRouteSearchResult(
+              steps: const [
+                RouteSearchStep(
+                  sequence: 1,
+                  title: '상록수역에서 대기',
+                  description: '승강장에서 다음 열차를 기다립니다.',
+                  lineId: 'seoul-4',
+                  lineName: '수도권 4호선',
+                  fromStationId: 'station-sangnoksu',
+                  toStationId: 'station-sangnoksu',
+                  estimatedMinutes: 2,
+                  distanceMeters: 0,
+                  includesStairs: false,
+                  requiresAccessibilityCheck: false,
+                  actionTitle: '환승',
+                ),
+                RouteSearchStep(
+                  sequence: 2,
+                  title: '사당역까지 이동',
+                  description: '같은 4호선 열차로 이동합니다.',
+                  lineId: 'seoul-4',
+                  lineName: '수도권 4호선',
+                  fromStationId: 'station-sangnoksu',
+                  toStationId: 'station-sadang',
+                  estimatedMinutes: 20,
+                  distanceMeters: 0,
+                  includesStairs: false,
+                  requiresAccessibilityCheck: false,
+                  actionTitle: '열차 이동',
+                ),
+              ],
+            ),
+          ),
+          stationRepository: FakeStationSearchRepository(),
+          initialMobilityType: 'SENIOR',
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 6, 23),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('환승 1회'), findsWidgets);
+  });
+
   testWidgets('길이 막혔어요는 성공 경로를 blocked 화면으로 바꾸지 않는다', (tester) async {
     final stationRepository = FakeStationSearchRepository(
       queryResults: {
@@ -7139,6 +7238,7 @@ RouteSearchResult _sampleRouteSearchResult({
   String routeSearchId = 'route-1',
   String status = 'FOUND',
   String mobilityType = 'SENIOR',
+  List<RouteSearchStep>? steps,
   List<String> recommendationReasons = const [
     '엘리베이터 동선을 우선했어요',
     '계단 없는 출구를 확인했어요',
@@ -7156,41 +7256,43 @@ RouteSearchResult _sampleRouteSearchResult({
     lineId: 'seoul-4',
     lineName: '수도권 4호선',
     score: 92,
-    steps: const [
-      RouteSearchStep(
-        sequence: 1,
-        title: '상록수역에서 4호선 승강장으로 이동',
-        description: '엘리베이터를 이용해 승강장으로 이동합니다.',
-        lineId: 'seoul-4',
-        lineName: '수도권 4호선',
-        fromStationId: 'station-sangnoksu',
-        toStationId: 'station-sadang',
-        estimatedMinutes: 4,
-        distanceMeters: 180,
-        includesStairs: false,
-        requiresAccessibilityCheck: true,
-        actionTitle: '열차 이동',
-        actionDetail: '엘리베이터를 이용해 승강장으로 이동합니다.',
-        reason: '선택된 경로 edge:edge-sangnoksu-sadang 근거로 안내합니다.',
-        evidenceSources: ['edge:edge-sangnoksu-sadang'],
-        timeSource: 'STATIC_ESTIMATE',
-        distanceSource: 'MEASURED',
-        confidenceLabel: '높은 신뢰도',
-      ),
-      RouteSearchStep(
-        sequence: 2,
-        title: '사당역에서 출구 접근성 정보를 확인',
-        description: '2번 출구의 엘리베이터를 먼저 확인하세요.',
-        lineId: 'seoul-4',
-        lineName: '수도권 4호선',
-        fromStationId: 'station-sadang',
-        toStationId: 'station-sadang',
-        estimatedMinutes: 3,
-        distanceMeters: 120,
-        includesStairs: false,
-        requiresAccessibilityCheck: true,
-      ),
-    ],
+    steps:
+        steps ??
+        const [
+          RouteSearchStep(
+            sequence: 1,
+            title: '상록수역에서 4호선 승강장으로 이동',
+            description: '엘리베이터를 이용해 승강장으로 이동합니다.',
+            lineId: 'seoul-4',
+            lineName: '수도권 4호선',
+            fromStationId: 'station-sangnoksu',
+            toStationId: 'station-sadang',
+            estimatedMinutes: 4,
+            distanceMeters: 180,
+            includesStairs: false,
+            requiresAccessibilityCheck: true,
+            actionTitle: '열차 이동',
+            actionDetail: '엘리베이터를 이용해 승강장으로 이동합니다.',
+            reason: '선택된 경로 edge:edge-sangnoksu-sadang 근거로 안내합니다.',
+            evidenceSources: ['edge:edge-sangnoksu-sadang'],
+            timeSource: 'STATIC_ESTIMATE',
+            distanceSource: 'MEASURED',
+            confidenceLabel: '높은 신뢰도',
+          ),
+          RouteSearchStep(
+            sequence: 2,
+            title: '사당역에서 출구 접근성 정보를 확인',
+            description: '2번 출구의 엘리베이터를 먼저 확인하세요.',
+            lineId: 'seoul-4',
+            lineName: '수도권 4호선',
+            fromStationId: 'station-sadang',
+            toStationId: 'station-sadang',
+            estimatedMinutes: 3,
+            distanceMeters: 120,
+            includesStairs: false,
+            requiresAccessibilityCheck: true,
+          ),
+        ],
     warnings: const [
       RouteSearchWarning(
         code: 'LOW_DATA_CONFIDENCE',

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5,6 +5,7 @@ import 'package:easysubway_mobile/accessible_design.dart';
 import 'package:easysubway_mobile/main.dart';
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/favorite_facility.dart';
+import 'package:easysubway_mobile/features/route_draft/domain/route_draft.dart';
 import 'package:easysubway_mobile/internal_route.dart';
 import 'package:easysubway_mobile/legacy_credential_cleanup.dart';
 import 'package:easysubway_mobile/mobility_profile.dart';
@@ -113,6 +114,36 @@ Future<void> _openSupportAccessScreen(WidgetTester tester) async {
   );
   await tester.pumpAndSettle();
   await tester.tap(find.byKey(const Key('settingsSupportPrivacyButton')));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openRouteOriginStationInput(WidgetTester tester) async {
+  if (find.byKey(const Key('routeOriginStationInput')).evaluate().isNotEmpty) {
+    return;
+  }
+  await tester.ensureVisible(find.byKey(const Key('routeOriginPointButton')));
+  await tester.tap(find.byKey(const Key('routeOriginPointButton')));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openRouteDestinationStationInput(WidgetTester tester) async {
+  if (find
+      .byKey(const Key('routeDestinationStationInput'))
+      .evaluate()
+      .isNotEmpty) {
+    return;
+  }
+  await tester.ensureVisible(
+    find.byKey(const Key('routeDestinationPointButton')),
+  );
+  await tester.tap(find.byKey(const Key('routeDestinationPointButton')));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openFirstRouteResultDetail(WidgetTester tester) async {
+  await tester.ensureVisible(find.byKey(const Key('routeResultListItem')));
+  await tester.pumpAndSettle();
+  await tester.tap(find.byKey(const Key('routeResultListItem')));
   await tester.pumpAndSettle();
 }
 
@@ -296,7 +327,7 @@ void main() {
 
     await tester.tap(find.byKey(const Key('routeSearchButton')));
     await tester.pumpAndSettle();
-
+    await _openRouteOriginStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeOriginStationInput')),
       '상록수',
@@ -307,7 +338,7 @@ void main() {
       find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
     );
     await tester.pumpAndSettle();
-
+    await _openRouteDestinationStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeDestinationStationInput')),
       '사당',
@@ -696,7 +727,10 @@ void main() {
 
     await tester.tap(find.byKey(const Key('routeSearchButton')));
     await tester.pumpAndSettle();
-    expect(find.text('경로 검색'), findsOneWidget);
+    expect(
+      find.descendant(of: find.byType(AppBar), matching: find.text('길찾기')),
+      findsOneWidget,
+    );
 
     await tester.pageBack();
     await tester.pumpAndSettle();
@@ -2024,30 +2058,103 @@ void main() {
     await tester.tap(find.byKey(const Key('homeRouteDraftPanel')));
     await tester.pumpAndSettle();
 
-    expect(find.text('경로 검색'), findsOneWidget);
     expect(
-      tester
-          .widget<TextField>(find.byKey(const Key('routeOriginStationInput')))
-          .controller
-          ?.text,
-      '상록수',
+      find.descendant(of: find.byType(AppBar), matching: find.text('길찾기')),
+      findsOneWidget,
     );
     expect(
-      tester
-          .widget<TextField>(
-            find.byKey(const Key('routeDestinationStationInput')),
-          )
-          .controller
-          ?.text,
-      '사당',
+      find.descendant(
+        of: find.byKey(const Key('routeOriginPointButton')),
+        matching: find.text('상록수역'),
+      ),
+      findsOneWidget,
     );
-    expect(find.text('출발역 상록수'), findsOneWidget);
-    expect(find.text('도착역 사당'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const Key('routeDestinationPointButton')),
+        matching: find.text('사당역'),
+      ),
+      findsOneWidget,
+    );
     expect(find.text('노선 정보 없음'), findsNothing);
     final semanticsHandle = tester.ensureSemantics();
     try {
-      expect(find.bySemanticsLabel('출발역 선택됨, 상록수'), findsOneWidget);
-      expect(find.bySemanticsLabel('도착역 선택됨, 사당'), findsOneWidget);
+      expect(find.bySemanticsLabel('출발 상록수역'), findsOneWidget);
+      expect(find.bySemanticsLabel('도착 사당역'), findsOneWidget);
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
+  testWidgets('경로 검색 첫 화면은 v3 출발 도착 입력 구조를 보여준다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteSearchScreen(
+            repository: FakeRouteSearchRepository(),
+            stationRepository: FakeStationSearchRepository(),
+            favoriteRouteRepository: FakeFavoriteRouteRepository(
+              favorites: [_favoriteRoute()],
+            ),
+            initialMobilityType: 'SENIOR',
+            initialDraft: RouteDraft(
+              origin: const RouteDraftStation(
+                id: 'station-sangnoksu',
+                nameKo: '상록수',
+              ),
+              destination: const RouteDraftStation(
+                id: 'station-sadang',
+                nameKo: '사당',
+              ),
+              lastModifiedAt: DateTime(2026, 6, 23),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.descendant(of: find.byType(AppBar), matching: find.text('길찾기')),
+        findsOneWidget,
+      );
+      expect(find.text('출발·도착 입력'), findsNothing);
+      expect(find.text('출'), findsNothing);
+      expect(find.text('도'), findsNothing);
+      expect(find.text('출발역'), findsNothing);
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('routeOriginPointButton')),
+          matching: find.text('상록수역'),
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('도착역'), findsNothing);
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('routeDestinationPointButton')),
+          matching: find.text('사당역'),
+        ),
+        findsOneWidget,
+      );
+      expect(find.byType(TextField), findsNothing);
+      expect(find.byKey(const Key('routeOriginPointButton')), findsOneWidget);
+      expect(
+        find.byKey(const Key('routeDestinationPointButton')),
+        findsOneWidget,
+      );
+      expect(find.bySemanticsLabel('출발 도착 바꾸기'), findsOneWidget);
+      expect(find.text('이동 조건'), findsOneWidget);
+      expect(find.text('계단 피하기 · 엘리베이터 이동'), findsWidgets);
+      expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
+
+      await tester.drag(find.byType(ListView), const Offset(0, -260));
+      await tester.pumpAndSettle();
+      expect(find.text('최근 도착지'), findsOneWidget);
+      expect(find.text('사당역'), findsWidgets);
+      expect(
+        find.byKey(const Key('routeRecentLineMark-line-4')),
+        findsOneWidget,
+      );
     } finally {
       semanticsHandle.dispose();
     }
@@ -3491,7 +3598,7 @@ void main() {
     await tester.tap(find.byKey(const Key('routeSearchButton')));
     await tester.pumpAndSettle();
     expect(find.text('휠체어'), findsOneWidget);
-
+    await _openRouteOriginStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeOriginStationInput')),
       '상록수',
@@ -3502,7 +3609,7 @@ void main() {
       find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
     );
     await tester.pumpAndSettle();
-
+    await _openRouteDestinationStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeDestinationStationInput')),
       '사당',
@@ -3548,20 +3655,23 @@ void main() {
       await tester.tap(find.byKey(const Key('routeSearchButton')));
       await tester.pumpAndSettle();
 
-      expect(find.text('경로 검색'), findsOneWidget);
-      expect(find.text('출발역'), findsOneWidget);
-      expect(find.text('도착역'), findsOneWidget);
+      expect(
+        find.descendant(of: find.byType(AppBar), matching: find.text('길찾기')),
+        findsOneWidget,
+      );
+      expect(find.text('출발역 선택'), findsOneWidget);
+      expect(find.text('도착역 선택'), findsOneWidget);
       expect(find.text('출발역 ID'), findsNothing);
       expect(find.text('도착역 ID'), findsNothing);
-      expect(find.text('적용 중인 이동 조건'), findsOneWidget);
+      expect(find.text('적용 중인 조건'), findsOneWidget);
       expect(find.text('고령자'), findsOneWidget);
       expect(find.byType(DropdownButton<String>), findsNothing);
 
+      await _openRouteOriginStationInput(tester);
       final originInput = tester.widget<TextField>(
         find.byKey(const Key('routeOriginStationInput')),
       );
       expect(originInput.decoration?.hintText, '역 이름을 입력해 주세요');
-
       await tester.enterText(
         find.byKey(const Key('routeOriginStationInput')),
         '상록수',
@@ -3582,7 +3692,7 @@ void main() {
         find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
       );
       await tester.pumpAndSettle();
-
+      await _openRouteDestinationStationInput(tester);
       await tester.enterText(
         find.byKey(const Key('routeDestinationStationInput')),
         '사당',
@@ -3612,25 +3722,33 @@ void main() {
         'station-sadang',
       );
       expect(routeRepository.requests.single.mobilityType, 'SENIOR');
-      expect(find.text('추천 경로 1개'), findsOneWidget);
-      expect(find.text('편함·불편함과 시간·환승·걷기만 비교합니다.'), findsOneWidget);
-      expect(find.text('이동 편한 순'), findsNothing);
-      expect(find.text('짧은 시간 순'), findsNothing);
-      expect(find.text('환승 적은 순'), findsNothing);
+      expect(find.text('추천 경로 목록'), findsOneWidget);
+      expect(find.text('편한 순'), findsOneWidget);
+      expect(find.text('빠른 순'), findsOneWidget);
+      expect(find.text('환승 적은 순'), findsOneWidget);
       expect(find.text('상록수 → 사당'), findsOneWidget);
-      expect(find.text('고령자 · 계단 회피 · 쉬운 환승'), findsOneWidget);
+      expect(find.text('계단 피하기 · 엘리베이터 이동'), findsWidgets);
       expect(find.text('7분'), findsOneWidget);
-      expect(find.text('환승 없음 · 이동 300m'), findsOneWidget);
-      expect(find.text('가장 추천'), findsOneWidget);
-      expect(find.text('이동 편함'), findsOneWidget);
+      expect(find.text('환승 없음 · 걷기 300m'), findsOneWidget);
+      expect(find.text('추천'), findsOneWidget);
       expect(find.textContaining('이동 점수'), findsNothing);
       expect(find.text('추천 이유'), findsNothing);
       expect(find.text('엘리베이터 동선을 우선했어요'), findsNothing);
       expect(find.text('계단 없는 출구를 확인했어요'), findsNothing);
       expect(find.text('천천히 이동하기 쉬운 동선을 확인했어요'), findsNothing);
+      expect(find.text('경로 상세'), findsNothing);
+      expect(find.text('도착 안내'), findsNothing);
+      expect(find.text('이동 순서'), findsNothing);
+
+      await tester.ensureVisible(find.byKey(const Key('routeResultListItem')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('routeResultListItem')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('추천 경로'), findsOneWidget);
+      expect(find.text('이동 순서'), findsOneWidget);
       expect(find.text('도착 안내'), findsOneWidget);
       expect(find.text('2번 출구의 엘리베이터를 먼저 확인하세요.'), findsOneWidget);
-      expect(find.text('이동 순서'), findsOneWidget);
       expect(find.byKey(const Key('routeStepNumber-1')), findsOneWidget);
       expect(find.text('열차 이동'), findsOneWidget);
       expect(
@@ -3644,16 +3762,26 @@ void main() {
         find.text('접근성 시설 정보가 최근 30일 이내 확인되지 않았습니다. 이동 전 역 상세 정보를 확인하세요.'),
         findsOneWidget,
       );
-      expect(find.text('왜 가장 빠른 길이 첫 번째가 아닌가요?'), findsNothing);
-      expect(find.text('계단과 시설 상태, 걷는 거리를 먼저 고려했어요.'), findsNothing);
-      expect(find.text('안전 안내'), findsOneWidget);
-      expect(find.text('이동 전 현장 안내와 역무원 안내를 확인해 주세요.'), findsOneWidget);
+
+      await tester.ensureVisible(
+        find.byKey(const Key('routeStartGuidanceButton')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('routeStartGuidanceButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('단계별 안내'), findsOneWidget);
+      expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
+      expect(find.text('다음'), findsOneWidget);
       expect(
-        find.bySemanticsLabel(
-          RegExp('경로 검색 결과, 이동할 수 있는 경로, 고령자, 상록수에서 사당까지, 수도권 4호선, 이동 편함'),
-        ),
+        find.byKey(const Key('routeOpenInternalRouteButton')),
         findsOneWidget,
       );
+
+      await tester.tap(find.byKey(const Key('routeOpenInternalRouteButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('역 안 이동 순서'), findsOneWidget);
       expect(find.bySemanticsLabel(RegExp('이동 점수')), findsNothing);
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
@@ -3699,7 +3827,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.text('휠체어').last);
     await tester.pumpAndSettle();
-
+    await _openRouteOriginStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeOriginStationInput')),
       '상록수',
@@ -3710,7 +3838,7 @@ void main() {
       find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
     );
     await tester.pumpAndSettle();
-
+    await _openRouteDestinationStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeDestinationStationInput')),
       '사당',
@@ -3763,7 +3891,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('휠체어'), findsOneWidget);
-
+    await _openRouteOriginStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeOriginStationInput')),
       '상록수',
@@ -3774,7 +3902,7 @@ void main() {
       find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
     );
     await tester.pumpAndSettle();
-
+    await _openRouteDestinationStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeDestinationStationInput')),
       '사당',
@@ -3848,7 +3976,7 @@ void main() {
 
     await tester.tap(find.byKey(const Key('routeSearchButton')));
     await tester.pumpAndSettle();
-
+    await _openRouteOriginStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeOriginStationInput')),
       '상록수',
@@ -3859,7 +3987,7 @@ void main() {
       find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
     );
     await tester.pumpAndSettle();
-
+    await _openRouteDestinationStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeDestinationStationInput')),
       '사당',
@@ -3877,6 +4005,8 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
     await tester.pumpAndSettle();
+
+    await _openFirstRouteResultDetail(tester);
 
     expect(find.bySemanticsLabel('자주 쓰는 경로 저장'), findsOneWidget);
 
@@ -3916,7 +4046,7 @@ void main() {
 
       await tester.tap(find.byKey(const Key('routeSearchButton')));
       await tester.pumpAndSettle();
-
+      await _openRouteOriginStationInput(tester);
       await tester.enterText(
         find.byKey(const Key('routeOriginStationInput')),
         '상록수',
@@ -3927,7 +4057,7 @@ void main() {
         find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
       );
       await tester.pumpAndSettle();
-
+      await _openRouteDestinationStationInput(tester);
       await tester.enterText(
         find.byKey(const Key('routeDestinationStationInput')),
         '사당',
@@ -3945,6 +4075,8 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
       await tester.pumpAndSettle();
+
+      await _openFirstRouteResultDetail(tester);
 
       await tester.ensureVisible(
         find.byKey(const Key('routeFavoriteSaveButton')),
@@ -4000,7 +4132,7 @@ void main() {
 
     await tester.tap(find.byKey(const Key('routeSearchButton')));
     await tester.pumpAndSettle();
-
+    await _openRouteOriginStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeOriginStationInput')),
       '상록수',
@@ -4011,7 +4143,7 @@ void main() {
       find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
     );
     await tester.pumpAndSettle();
-
+    await _openRouteDestinationStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeDestinationStationInput')),
       '사당',
@@ -4028,6 +4160,14 @@ void main() {
     await tester.drag(find.byType(ListView), const Offset(0, -360));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    await _openFirstRouteResultDetail(tester);
+    await tester.ensureVisible(
+      find.byKey(const Key('routeOpenFeedbackButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeOpenFeedbackButton')));
     await tester.pumpAndSettle();
 
     await tester.ensureVisible(
@@ -4077,7 +4217,7 @@ void main() {
 
       await tester.tap(find.byKey(const Key('routeSearchButton')));
       await tester.pumpAndSettle();
-
+      await _openRouteOriginStationInput(tester);
       await tester.enterText(
         find.byKey(const Key('routeOriginStationInput')),
         '상록수',
@@ -4088,7 +4228,7 @@ void main() {
         find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
       );
       await tester.pumpAndSettle();
-
+      await _openRouteDestinationStationInput(tester);
       await tester.enterText(
         find.byKey(const Key('routeDestinationStationInput')),
         '사당',
@@ -4105,6 +4245,14 @@ void main() {
       await tester.drag(find.byType(ListView), const Offset(0, -360));
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+      await tester.pumpAndSettle();
+
+      await _openFirstRouteResultDetail(tester);
+      await tester.ensureVisible(
+        find.byKey(const Key('routeOpenFeedbackButton')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('routeOpenFeedbackButton')));
       await tester.pumpAndSettle();
 
       await tester.ensureVisible(
@@ -4172,7 +4320,7 @@ void main() {
         ),
       ),
     );
-
+    await _openRouteOriginStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeOriginStationInput')),
       '상록수',
@@ -4183,7 +4331,7 @@ void main() {
       find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
     );
     await tester.pumpAndSettle();
-
+    await _openRouteDestinationStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeDestinationStationInput')),
       '사당',
@@ -4222,11 +4370,12 @@ void main() {
 
     await tester.tap(find.byKey(const Key('routeSearchButton')));
     await tester.pumpAndSettle();
-
+    await _openRouteOriginStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeOriginStationInput')),
       '상록수',
     );
+    await _openRouteDestinationStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeDestinationStationInput')),
       '사당',
@@ -4264,7 +4413,7 @@ void main() {
 
       await tester.tap(find.byKey(const Key('routeSearchButton')));
       await tester.pumpAndSettle();
-
+      await _openRouteOriginStationInput(tester);
       await tester.enterText(
         find.byKey(const Key('routeOriginStationInput')),
         '상록수',
@@ -4275,7 +4424,7 @@ void main() {
         find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
       );
       await tester.pumpAndSettle();
-
+      await _openRouteDestinationStationInput(tester);
       await tester.enterText(
         find.byKey(const Key('routeDestinationStationInput')),
         '사당',
@@ -4339,7 +4488,7 @@ void main() {
 
     await tester.tap(find.byKey(const Key('routeSearchButton')));
     await tester.pumpAndSettle();
-
+    await _openRouteOriginStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeOriginStationInput')),
       '상록수',
@@ -4350,7 +4499,7 @@ void main() {
       find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
     );
     await tester.pumpAndSettle();
-
+    await _openRouteDestinationStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeDestinationStationInput')),
       '사당',
@@ -4373,6 +4522,7 @@ void main() {
 
     await tester.drag(find.byType(ListView), const Offset(0, 700));
     await tester.pumpAndSettle();
+    await _openRouteOriginStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeOriginStationInput')),
       '상록',
@@ -4419,7 +4569,7 @@ void main() {
 
       await tester.tap(find.byKey(const Key('routeSearchButton')));
       await tester.pumpAndSettle();
-
+      await _openRouteOriginStationInput(tester);
       await tester.enterText(
         find.byKey(const Key('routeOriginStationInput')),
         '상록수',
@@ -4430,7 +4580,7 @@ void main() {
         find.byKey(const Key('routeOriginStationOption-station-sangnoksu')),
       );
       await tester.pumpAndSettle();
-
+      await _openRouteDestinationStationInput(tester);
       await tester.enterText(
         find.byKey(const Key('routeDestinationStationInput')),
         '없는역',
@@ -4450,7 +4600,7 @@ void main() {
       await tester.pump();
 
       expect(routeRepository.requests, hasLength(1));
-      expect(find.bySemanticsLabel('경로 검색 중'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, '경로 검색 중'), findsOneWidget);
       final loadingButton = tester.widget<FilledButton>(
         find.byKey(const Key('routeSearchSubmitButton')),
       );
@@ -4459,17 +4609,11 @@ void main() {
       routeRepository.complete(_blockedRouteSearchResult());
       await tester.pumpAndSettle();
 
-      expect(find.text('다른 경로가 필요합니다'), findsOneWidget);
-      expect(
-        find.byKey(const Key('routeGuidanceMobilityChip')),
-        findsOneWidget,
-      );
-      expect(find.text('안내할 수 있는 경로가 없습니다'), findsOneWidget);
+      expect(find.text('계단 없는 경로가 없습니다'), findsOneWidget);
       expect(find.text('추천 이유'), findsNothing);
       expect(find.text('엘리베이터 동선을 우선했어요'), findsNothing);
       expect(find.text('휠체어로 이동 가능한 엘리베이터가 없습니다.'), findsOneWidget);
       expect(find.text('이동 전 현장 안내와 역무원 안내를 확인해 주세요.'), findsOneWidget);
-      expect(find.text('역무원이나 현장 안내를 확인한 뒤 이동해 주세요.'), findsOneWidget);
       expect(
         find.text('역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'),
         findsOneWidget,
@@ -4481,16 +4625,6 @@ void main() {
       expect(tester.getSize(nextActionNotice).height, greaterThanOrEqualTo(44));
       expect(
         find.bySemanticsLabel('다음 행동, 역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'),
-        findsNothing,
-      );
-      expect(
-        find.bySemanticsLabel(
-          '경로 검색 결과, 다른 경로가 필요합니다, 휠체어, 상록수에서 없는역까지, 노선 확인 필요, 다른 경로 필요, '
-          '안내 불가 이유 휠체어로 이동 가능한 엘리베이터가 없습니다., '
-          '다음 행동 역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요., '
-          '안전 안내 이동 전 현장 안내와 역무원 안내를 확인해 주세요., '
-          '확인 요청 역무원이나 현장 안내를 확인한 뒤 이동해 주세요.',
-        ),
         findsOneWidget,
       );
       final completedButton = tester.widget<FilledButton>(


### PR DESCRIPTION
## 관련 이슈

close #765

## 작업 배경

접근성 길찾기 화면이 기존 단일 결과 카드 중심이라 v3의 입력 → 추천 경로 → 상세 → 이동 안내 → 내부 이동 → 안내 불가 → 피드백 흐름을 따라가기 어려웠다. 교통약자 사용자가 큰 입력 카드와 명확한 단계 화면으로 경로를 확인할 수 있게 길찾기 워크플로우를 정리했다.

## 작업 내용

- 길찾기 첫 화면을 큰 출발/도착 선택 카드, 이동 조건 카드, 하단 `길찾기` 주요 버튼 구조로 정리했다.
- 저장된 즐겨찾기 경로에서 최근 도착지를 불러오고, 대표 노선명 옆에 기존 `StationLineBadge` 기반 노선 마크를 표시한다.
- 경로 검색 성공 후 추천 경로 목록, 경로 상세, 단계별 안내, 역 안 이동 순서, 경로 피드백 화면으로 이동하는 상태 흐름을 분리했다.
- 안내 불가 결과는 `계단 없는 경로가 없습니다` 화면으로 표시하고 blocked reason, 다음 행동, 안전 안내를 실제 결과 데이터로 보여준다.
- `엘리베이터 확인` 대신 길찾기 조건 문맥에서는 `엘리베이터 이동`으로 표시한다.
- 선택한 출발/도착역을 수정할 때 검색 입력이 닫히지 않도록 하고, 로컬 경로 결과에서는 서버 피드백 버튼을 숨기며, 정상 경로에서 `길이 막혔어요`가 안내 불가 화면으로 바뀌지 않게 했다.
- 추천 경로 항목이 스크린리더에서 탭 가능한 상세 진입 버튼으로 남도록 하고, 같은 노선 안의 명시적 환승 단계도 환승 횟수에 포함했다.
- 기존 widget test를 새 워크플로우에 맞게 갱신하고 큰 글씨/터치 영역 회귀를 유지했다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter analyze`: No issues found
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "선택한 출발역을 수정해도 역 검색 입력은 닫히지 않는다"`: 1 test passed
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "로컬 경로 결과는 서버 피드백 행동을 숨긴다"`: 1 test passed
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "길이 막혔어요는 성공 경로를 blocked 화면으로 바꾸지 않는다"`: 1 test passed
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "추천 경로 항목은 스크린리더에서 상세 진입 버튼으로 남는다"`: 1 test passed
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "같은 노선의 명시적 환승 단계는 환승 횟수에 포함된다"`: 1 test passed
  - `cd apps/mobile && flutter test test/widget_test.dart`: 102 tests passed
  - `cd apps/mobile && flutter test test/accessibility_baseline_test.dart`: 1 test passed
  - `cd apps/mobile && flutter build apk --debug`: built `build/app/outputs/flutter-apk/app-debug.apk`
  - GitHub Actions `CI`: Changes, Backend CI, Repository CI, Mobile App CI, Android CI, Dependency Vulnerability Scan 통과
  - GitHub Actions `Release Artifacts`: Android Release Artifact 통과, Backend Release Image skipped

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 길찾기 입력/추천/상세/단계/내부/blocked/피드백 흐름 | Flutter widget test | `flutter test test/widget_test.dart` | 로컬 명령 출력: 102 tests passed | 통과 |
| 회귀 수정 5건 | Flutter widget test | 관련 `--plain-name` 단위 검증 5개 실행 | 로컬 명령 출력: 각 1 test passed | 통과 |
| 큰 글씨/접근성 기준선 | Flutter widget test | `flutter test test/accessibility_baseline_test.dart` | 로컬 명령 출력: 1 test passed | 통과 |
| 정적 분석 | Flutter analyzer | `flutter analyze` | 로컬 명령 출력: No issues found | 통과 |
| Android debug 빌드 | Android debug APK | `flutter build apk --debug` | `build/app/outputs/flutter-apk/app-debug.apk` 생성 | 통과 |
| PR CI | GitHub Actions | PR #766 status check 확인 | CI, Mobile App CI, Android CI, OSV scan 성공 | 통과 |
| Android release artifact | GitHub Actions | PR #766 Release Artifacts 확인 | Android Release Artifact 성공 | 통과 |
| Android 화면 증거 | Android emulator | 사용자 요청으로 이번 단계에서는 에뮬레이터 확인 생략 | 추후 일괄 확인 때 스크린샷/UI tree 캡처 예정 | 보류 |
| 코드 리뷰 | PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review 수행 | Actionable 5건 inline 등록, `43955dc`와 `ddf17af`에서 수정 답글 작성 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteSearchScreen`의 최근 도착지는 고정 샘플이 아니라 `FavoriteRouteRepository.listFavoriteRoutes()` 결과를 사용한다.
  - 추천 경로 이후 화면 전환은 `_RouteWorkflowView` 상태로 분리했다.
  - 앱 패키지명과 Android 플랫폼 설정은 변경하지 않았다.
  - Android 화면 증거는 사용자 요청에 따라 나중에 일괄 확인한다.

## 리스크

- 실제 에뮬레이터 화면 캡처는 사용자 요청으로 아직 수행하지 않았다. 머지 전 별도 수동 QA에서 화면 밀림과 노선 배지 크기를 확인해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
