### PR TITLE
[Style] 운영기관 포털 v3 화면 디자인 반영

### DIFF
--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -14,11 +14,15 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -45,7 +49,23 @@ public class SecurityConfig {
 		return http
 			.securityMatcher("/operator/**")
 			.authorizeHttpRequests(authorize -> authorize
+				.requestMatchers("/operator/login").permitAll()
 				.anyRequest().hasRole("OPERATOR_ADMIN")
+			)
+			.exceptionHandling(exception -> exception
+				.defaultAuthenticationEntryPointFor(
+					new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),
+					new AntPathRequestMatcher("/operator/api/**")
+				)
+				.defaultAuthenticationEntryPointFor(
+					new LoginUrlAuthenticationEntryPoint("/operator/login"),
+					new AntPathRequestMatcher("/operator/**")
+				)
+			)
+			.formLogin(form -> form
+				.loginPage("/operator/login")
+				.defaultSuccessUrl("/operator/accessibility-report/page", true)
+				.permitAll()
 			)
 			.httpBasic(Customizer.withDefaults())
 			.addFilterAfter(auditFilter, BasicAuthenticationFilter.class)

--- a/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorLoginPageController.java
+++ b/backend/src/main/java/com/easysubway/operator/adapter/in/web/OperatorLoginPageController.java
@@ -1,0 +1,13 @@
+package com.easysubway.operator.adapter.in.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class OperatorLoginPageController {
+
+	@GetMapping("/operator/login")
+	String loginPage() {
+		return "operator/login";
+	}
+}

--- a/backend/src/main/resources/static/css/operator-v3.css
+++ b/backend/src/main/resources/static/css/operator-v3.css
@@ -318,7 +318,8 @@ input:focus-visible {
 	color: var(--amber-700);
 }
 
-.alert-banner.good {
+.alert-banner.good,
+.alert-banner.ok {
 	background: var(--green-100);
 	color: var(--green-700);
 }

--- a/backend/src/main/resources/static/css/operator-v3.css
+++ b/backend/src/main/resources/static/css/operator-v3.css
@@ -1,0 +1,507 @@
+:root {
+	--brand-950: #071b2f;
+	--brand-900: #0b2947;
+	--brand-700: #17527c;
+	--mint-700: #0a705a;
+	--mint-600: #0d8a6d;
+	--mint-100: #dff7ef;
+	--amber-700: #9a5600;
+	--amber-100: #fff0d1;
+	--red-700: #a93434;
+	--red-100: #ffe7e7;
+	--green-700: #187548;
+	--green-100: #def5e7;
+	--ink: #102335;
+	--ink-2: #3b5062;
+	--ink-3: #647686;
+	--line: #dbe3e9;
+	--line-strong: #c8d3dc;
+	--surface: #fff;
+	--surface-2: #f7f9fb;
+	--surface-3: #eef3f6;
+	--canvas: #e9eef2;
+}
+
+* {
+	box-sizing: border-box;
+}
+
+html,
+body {
+	margin: 0;
+	min-height: 100%;
+	background: var(--canvas);
+	color: var(--ink);
+	font-family: -apple-system, BlinkMacSystemFont, "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", sans-serif;
+}
+
+button,
+input {
+	font: inherit;
+}
+
+a {
+	color: inherit;
+	text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible {
+	outline: 4px solid #54a9ff;
+	outline-offset: 2px;
+}
+
+.desktop-frame {
+	min-height: 100vh;
+	display: grid;
+	grid-template-columns: 252px minmax(0, 1fr);
+	background: var(--surface-2);
+}
+
+.desktop-sidebar {
+	background: var(--brand-950);
+	color: #d7e5ee;
+	padding: 18px 14px;
+	display: flex;
+	flex-direction: column;
+	gap: 18px;
+}
+
+.desktop-brand,
+.desktop-user {
+	display: flex;
+	align-items: center;
+	gap: 11px;
+}
+
+.logo-mark {
+	width: 38px;
+	height: 38px;
+	border-radius: 12px;
+	display: grid;
+	place-items: center;
+	background: linear-gradient(145deg, #12a27f, var(--brand-700));
+	color: #fff;
+	font-weight: 900;
+}
+
+.desktop-brand strong,
+.desktop-user strong {
+	display: block;
+	color: #fff;
+	font-size: 15px;
+}
+
+.desktop-brand span,
+.desktop-user span {
+	display: block;
+	margin-top: 3px;
+	color: #96adbc;
+	font-size: 11px;
+	font-weight: 700;
+}
+
+.desktop-nav {
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+}
+
+.nav-group {
+	margin: 8px 8px 4px;
+	color: #8fa7b8;
+	font-size: 11px;
+	font-weight: 900;
+	letter-spacing: .05em;
+}
+
+.nav-link {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-height: 39px;
+	border-radius: 11px;
+	padding: 0 11px;
+	color: #cfe0eb;
+	font-size: 13px;
+	font-weight: 800;
+}
+
+.nav-link.active {
+	background: var(--mint-100);
+	color: var(--mint-700);
+}
+
+.desktop-user {
+	margin-top: auto;
+	border-top: 1px solid rgba(255, 255, 255, .1);
+	padding-top: 14px;
+}
+
+.avatar {
+	width: 35px;
+	height: 35px;
+	border-radius: 11px;
+	display: grid;
+	place-items: center;
+	background: rgba(255, 255, 255, .11);
+	color: #fff;
+	font-size: 11px;
+	font-weight: 900;
+}
+
+.desktop-workspace {
+	min-width: 0;
+}
+
+.desktop-topbar {
+	min-height: 72px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 18px;
+	padding: 14px 22px;
+	background: rgba(255, 255, 255, .94);
+	border-bottom: 1px solid var(--line);
+}
+
+.desktop-breadcrumb {
+	color: var(--mint-700);
+	font-size: 11px;
+	font-weight: 900;
+	letter-spacing: .05em;
+}
+
+.desktop-page-name {
+	margin-top: 3px;
+	font-size: 22px;
+	font-weight: 900;
+	letter-spacing: -.04em;
+}
+
+.topbar-note {
+	border: 1px solid var(--line);
+	border-radius: 12px;
+	background: var(--surface-2);
+	padding: 10px 12px;
+	color: var(--ink-3);
+	font-size: 12px;
+	font-weight: 800;
+	white-space: nowrap;
+}
+
+.desktop-content {
+	padding: 18px 22px 42px;
+}
+
+.page-head {
+	display: flex;
+	align-items: flex-end;
+	justify-content: space-between;
+	gap: 16px;
+	margin-bottom: 14px;
+}
+
+.page-head h1 {
+	margin: 0;
+	font-size: 24px;
+	line-height: 1.2;
+	letter-spacing: -.045em;
+}
+
+.page-head p {
+	margin: 6px 0 0;
+	color: var(--ink-3);
+	font-size: 13px;
+	line-height: 1.55;
+}
+
+.desk-btn {
+	min-height: 35px;
+	border: 1px solid var(--line);
+	border-radius: 11px;
+	background: var(--surface);
+	color: var(--ink-2);
+	padding: 0 12px;
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	font-size: 12px;
+	font-weight: 900;
+}
+
+.desk-btn.primary {
+	border-color: var(--mint-600);
+	background: var(--mint-600);
+	color: #fff;
+}
+
+.metric-grid {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+	gap: 12px;
+	margin-bottom: 12px;
+}
+
+.metric {
+	min-height: 104px;
+	border: 1px solid var(--line);
+	border-radius: 15px;
+	background: var(--surface);
+	padding: 15px;
+}
+
+.metric span {
+	display: block;
+	color: var(--ink-3);
+	font-size: 11px;
+	font-weight: 900;
+	line-height: 1.4;
+}
+
+.metric strong {
+	display: block;
+	margin-top: 12px;
+	font-size: 26px;
+	line-height: 1.1;
+	letter-spacing: -.04em;
+}
+
+.desktop-grid-2 {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 12px;
+}
+
+.panel {
+	overflow-x: auto;
+	border: 1px solid var(--line);
+	border-radius: 15px;
+	background: var(--surface);
+}
+
+.panel + .panel,
+.stack-gap {
+	margin-top: 12px;
+}
+
+.panel-head {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 14px 15px 10px;
+}
+
+.panel-title h2 {
+	margin: 0;
+	font-size: 14px;
+	letter-spacing: -.03em;
+}
+
+.panel-title p {
+	margin: 4px 0 0;
+	color: var(--ink-3);
+	font-size: 11px;
+	line-height: 1.45;
+}
+
+.alert-banner {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	border-radius: 13px;
+	margin-bottom: 12px;
+	padding: 12px 13px;
+	background: var(--amber-100);
+	color: var(--amber-700);
+}
+
+.alert-banner.good {
+	background: var(--green-100);
+	color: var(--green-700);
+}
+
+.alert-banner.bad,
+.alert-banner.stale {
+	background: var(--red-100);
+	color: var(--red-700);
+}
+
+.alert-banner strong {
+	display: block;
+	font-size: 13px;
+}
+
+.alert-banner span,
+.alert-banner p {
+	display: block;
+	margin: 3px 0 0;
+	font-size: 11px;
+	font-weight: 700;
+	line-height: 1.45;
+}
+
+.data-table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+	border-top: 1px solid var(--line);
+	padding: 12px 14px;
+	text-align: left;
+	vertical-align: top;
+	font-size: 12px;
+	line-height: 1.45;
+}
+
+.data-table th {
+	background: var(--surface-2);
+	color: var(--ink-2);
+	font-weight: 900;
+	white-space: nowrap;
+}
+
+.data-table td:last-child,
+.data-table th:last-child,
+.numeric {
+	text-align: right;
+	font-weight: 900;
+}
+
+.status {
+	display: inline-flex;
+	align-items: center;
+	min-height: 24px;
+	border-radius: 999px;
+	padding: 0 8px;
+	background: var(--surface-3);
+	color: var(--ink-2);
+	font-size: 11px;
+	font-weight: 900;
+}
+
+.source-note {
+	margin-top: 12px;
+	border-radius: 13px;
+	background: #f0fbf7;
+	color: var(--mint-700);
+	padding: 12px;
+	font-size: 12px;
+	font-weight: 800;
+	line-height: 1.55;
+}
+
+.login-screen {
+	min-height: 100vh;
+	display: grid;
+	place-items: center;
+	background: radial-gradient(circle at 20% 20%, #174b72 0, var(--brand-950) 48%, #04111f 100%);
+	padding: 24px;
+}
+
+.login-card {
+	width: min(390px, 100%);
+	border-radius: 22px;
+	background: #fff;
+	padding: 27px;
+	box-shadow: 0 28px 70px rgba(0, 0, 0, .28);
+}
+
+.login-card .desktop-brand strong {
+	color: var(--ink);
+}
+
+.login-card .desktop-brand span {
+	color: var(--ink-3);
+}
+
+.login-card h1 {
+	margin: 24px 0 6px;
+	font-size: 22px;
+	letter-spacing: -.04em;
+}
+
+.login-card p {
+	margin: 0 0 20px;
+	color: var(--ink-3);
+	font-size: 13px;
+	line-height: 1.5;
+}
+
+.login-field {
+	margin-bottom: 12px;
+}
+
+.login-field label {
+	display: block;
+	margin: 0 0 6px 2px;
+	font-size: 12px;
+	font-weight: 900;
+}
+
+.login-field input {
+	width: 100%;
+	height: 44px;
+	border: 1px solid var(--line-strong);
+	border-radius: 11px;
+	padding: 0 12px;
+}
+
+.login-submit {
+	width: 100%;
+	height: 44px;
+	border: 0;
+	border-radius: 12px;
+	background: var(--mint-600);
+	color: #fff;
+	font-weight: 900;
+}
+
+.login-note {
+	margin-top: 14px;
+	border-radius: 10px;
+	background: var(--surface-2);
+	color: var(--ink-3);
+	padding: 10px;
+	font-size: 12px;
+	line-height: 1.5;
+}
+
+@media (max-width: 980px) {
+	.desktop-frame {
+		grid-template-columns: 1fr;
+	}
+
+	.desktop-sidebar {
+		position: static;
+	}
+
+	.desktop-nav {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.nav-group,
+	.desktop-user {
+		display: none;
+	}
+
+	.metric-grid,
+	.desktop-grid-2 {
+		grid-template-columns: 1fr;
+	}
+
+	.page-head,
+	.desktop-topbar {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.topbar-note {
+		white-space: normal;
+	}
+}

--- a/backend/src/main/resources/templates/operator/accessibility-report.html
+++ b/backend/src/main/resources/templates/operator/accessibility-report.html
@@ -3,222 +3,176 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>운영기관 접근성 시설 현황</title>
-	<style>
-		body {
-			margin: 0;
-			background: #f5f7f8;
-			color: #102a2c;
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-		}
-
-		main {
-			max-width: 1120px;
-			margin: 0 auto;
-			padding: 32px 24px 48px;
-		}
-
-		h1 {
-			margin: 0 0 10px;
-			font-size: 32px;
-			line-height: 1.2;
-		}
-
-		p {
-			margin: 0 0 24px;
-			color: #40585a;
-			font-size: 17px;
-			line-height: 1.55;
-		}
-
-		h2 {
-			margin: 0;
-			padding: 16px 18px;
-			background: #e8f1ef;
-			font-size: 20px;
-		}
-
-		.metric-grid {
-			display: grid;
-			grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-			gap: 12px;
-			margin-bottom: 24px;
-		}
-
-		.metric {
-			background: #fff;
-			border: 1px solid #d6e0df;
-			padding: 18px;
-		}
-
-		.metric span {
-			display: block;
-			color: #536b6d;
-			font-weight: 800;
-			line-height: 1.4;
-		}
-
-		.metric strong {
-			display: block;
-			margin-top: 8px;
-			font-size: 30px;
-			line-height: 1.15;
-		}
-
-		section {
-			margin-bottom: 24px;
-			background: #fff;
-			border: 1px solid #d6e0df;
-		}
-
-		table {
-			width: 100%;
-			border-collapse: collapse;
-		}
-
-		th,
-		td {
-			padding: 14px 18px;
-			border-top: 1px solid #d6e0df;
-			text-align: left;
-			vertical-align: top;
-			font-size: 15px;
-			line-height: 1.45;
-		}
-
-		th {
-			background: #f8fbfb;
-			font-weight: 800;
-		}
-
-		td:last-child,
-		th:last-child {
-			text-align: right;
-			font-weight: 800;
-		}
-	</style>
+	<title>운영기관 접근성 현황 보고서</title>
+	<link rel="stylesheet" href="/css/operator-v3.css">
 </head>
 <body>
-<main>
-	<h1>운영기관 접근성 시설 현황</h1>
-	<p>운영기관 담당자가 접근성 데이터 품질과 시설 보강 대상을 확인하는 읽기 전용 리포트입니다.</p>
+<div class="desktop-frame">
+	<aside class="desktop-sidebar" aria-label="운영기관 포털 메뉴">
+		<div class="desktop-brand">
+			<div class="logo-mark">길</div>
+			<div><strong>쉬운 지하철</strong><span>운영기관 포털</span></div>
+		</div>
+		<nav class="desktop-nav">
+			<div class="nav-group">보고서</div>
+			<a class="nav-link active" href="/operator/accessibility-report/page">접근성 현황</a>
+			<a class="nav-link" href="/operator/repeated-broken-facilities/page">반복 고장 시설</a>
+			<a class="nav-link" href="/operator/data-collection-failures/page">수집 실패</a>
+			<a class="nav-link" href="/operator/route-feedback-report/page">현장 피드백</a>
+			<a class="nav-link" href="/operator/push-notification-report/page">알림 보고서</a>
+		</nav>
+		<div class="desktop-user">
+			<div class="avatar">MO</div>
+			<div><strong>Metro 운영자</strong><span>OPERATOR_ADMIN</span></div>
+		</div>
+	</aside>
 
-	<div class="metric-grid" aria-label="접근성 시설 현황 요약">
-		<div class="metric">
-			<span>전체 역</span>
-			<strong th:text="${report.totalStations}">0</strong>
-		</div>
-		<div class="metric">
-			<span>전체 시설</span>
-			<strong th:text="${report.totalFacilities}">0</strong>
-		</div>
-		<div class="metric">
-			<span>확인 필요한 시설</span>
-			<strong th:text="${report.needsVerificationFacilityCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>갱신 지연 시설</span>
-			<strong th:text="${report.delayedFacilityStatusCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>검수일 없는 역</span>
-			<strong th:text="${report.missingStationVerificationDateCount}">0</strong>
-		</div>
-	</div>
+	<section class="desktop-workspace">
+		<header class="desktop-topbar">
+			<div>
+				<div class="desktop-breadcrumb">운영기관 보고서</div>
+				<div class="desktop-page-name">접근성 현황</div>
+			</div>
+			<div class="topbar-note">읽기 전용 · 실제 운영 데이터 연동</div>
+		</header>
 
-	<section>
-		<h2>역 품질 등급</h2>
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">등급</th>
-				<th scope="col">상태</th>
-				<th scope="col">역 수</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:each="row : ${report.stationQualityRows}">
-				<td th:text="${row.label}">Level 1</td>
-				<td th:text="${row.description}">기본 정보 확인</td>
-				<td th:text="${row.count}">0</td>
-			</tr>
-			</tbody>
-		</table>
+		<main class="desktop-content">
+			<div class="page-head">
+				<div>
+					<h1>접근성 현황 보고서</h1>
+					<p>기관 담당 노선의 역·시설 품질과 개선 우선순위를 확인합니다.</p>
+				</div>
+				<a class="desk-btn primary" href="/operator/api/accessibility-report/proposal.csv">협력 제안서 CSV</a>
+			</div>
+
+			<div class="metric-grid" aria-label="접근성 시설 현황 요약">
+				<div class="metric"><span>전체 역</span><strong th:text="${report.totalStations}">0</strong></div>
+				<div class="metric"><span>접근성 시설</span><strong th:text="${report.totalFacilities}">0</strong></div>
+				<div class="metric"><span>확인 필요 시설</span><strong th:text="${report.needsVerificationFacilityCount}">0</strong></div>
+				<div class="metric"><span>검증일 누락 역</span><strong th:text="${report.missingStationVerificationDateCount}">0</strong></div>
+			</div>
+
+			<div class="desktop-grid-2">
+				<div>
+					<section class="panel">
+						<div class="panel-head">
+							<div class="panel-title">
+								<h2>지역별 데이터 품질</h2>
+								<p>Level 1-4 역 개수와 운영기관·노선 범위를 함께 봅니다.</p>
+							</div>
+						</div>
+						<table class="data-table">
+							<thead>
+							<tr>
+								<th scope="col">지역</th>
+								<th scope="col">운영기관</th>
+								<th scope="col">노선</th>
+								<th scope="col">역</th>
+								<th scope="col">Level 1</th>
+								<th scope="col">Level 2</th>
+								<th scope="col">Level 3</th>
+								<th scope="col">Level 4</th>
+							</tr>
+							</thead>
+							<tbody>
+							<tr th:each="row : ${report.regionQualityRows}">
+								<td th:text="${row.name}">수도권</td>
+								<td th:text="${row.operatorCount}">0</td>
+								<td th:text="${row.lineCount}">0</td>
+								<td th:text="${row.stationCount}">0</td>
+								<td th:text="${row.level1Count}">0</td>
+								<td th:text="${row.level2Count}">0</td>
+								<td th:text="${row.level3Count}">0</td>
+								<td th:text="${row.level4Count}">0</td>
+							</tr>
+							</tbody>
+						</table>
+					</section>
+
+					<section class="panel stack-gap">
+						<div class="panel-head">
+							<div class="panel-title">
+								<h2>역 접근성 점수</h2>
+								<p>낮은 점수부터 개선 검토합니다.</p>
+							</div>
+						</div>
+						<table class="data-table">
+							<thead>
+							<tr>
+								<th scope="col">역</th>
+								<th scope="col">지역</th>
+								<th scope="col">보강 사유</th>
+								<th scope="col">접근성 점수</th>
+							</tr>
+							</thead>
+							<tbody>
+							<tr th:each="row : ${report.stationAccessibilityScoreRows}">
+								<td th:text="${row.stationName}">상록수</td>
+								<td th:text="${row.region}">수도권</td>
+								<td th:text="${row.reasonText}">기본 정보만 있음</td>
+								<td th:text="${row.score}">0</td>
+							</tr>
+							</tbody>
+						</table>
+					</section>
+				</div>
+
+				<div>
+					<section class="panel">
+						<div class="panel-head">
+							<div class="panel-title">
+								<h2>역 품질 등급</h2>
+								<p>기관 보고용 품질 분포입니다.</p>
+							</div>
+						</div>
+						<table class="data-table">
+							<thead>
+							<tr>
+								<th scope="col">등급</th>
+								<th scope="col">상태</th>
+								<th scope="col">역 수</th>
+							</tr>
+							</thead>
+							<tbody>
+							<tr th:each="row : ${report.stationQualityRows}">
+								<td th:text="${row.label}">Level 1</td>
+								<td th:text="${row.description}">기본 정보 확인</td>
+								<td th:text="${row.count}">0</td>
+							</tr>
+							</tbody>
+						</table>
+					</section>
+
+					<section class="panel stack-gap">
+						<div class="panel-head">
+							<div class="panel-title">
+								<h2>개선 우선순위</h2>
+								<p>점수와 구체적인 이유를 함께 제공합니다.</p>
+							</div>
+						</div>
+						<table class="data-table">
+							<thead>
+							<tr>
+								<th scope="col">역</th>
+								<th scope="col">시설</th>
+								<th scope="col">개선 사유</th>
+								<th scope="col">우선순위 점수</th>
+							</tr>
+							</thead>
+							<tbody>
+							<tr th:each="row : ${report.accessibilityImprovementPriorityRows}">
+								<td th:text="${row.stationName}">상록수</td>
+								<td th:text="${row.facilityName}">장애인 화장실</td>
+								<td th:text="${row.reasonText}">확인 필요 상태, 신뢰도 확인 필요</td>
+								<td th:text="${row.priorityScore}">0</td>
+							</tr>
+							</tbody>
+						</table>
+					</section>
+				</div>
+			</div>
+		</main>
 	</section>
-
-	<section>
-		<h2>지역별 데이터 품질</h2>
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">지역</th>
-				<th scope="col">운영기관</th>
-				<th scope="col">노선</th>
-				<th scope="col">역</th>
-				<th scope="col">Level 1</th>
-				<th scope="col">Level 2</th>
-				<th scope="col">Level 3</th>
-				<th scope="col">Level 4</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:each="row : ${report.regionQualityRows}">
-				<td th:text="${row.name}">수도권</td>
-				<td th:text="${row.operatorCount}">0</td>
-				<td th:text="${row.lineCount}">0</td>
-				<td th:text="${row.stationCount}">0</td>
-				<td th:text="${row.level1Count}">0</td>
-				<td th:text="${row.level2Count}">0</td>
-				<td th:text="${row.level3Count}">0</td>
-				<td th:text="${row.level4Count}">0</td>
-			</tr>
-			</tbody>
-		</table>
-	</section>
-
-	<section>
-		<h2>역별 접근성 점수</h2>
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">역</th>
-				<th scope="col">지역</th>
-				<th scope="col">보강 사유</th>
-				<th scope="col">접근성 점수</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:each="row : ${report.stationAccessibilityScoreRows}">
-				<td th:text="${row.stationName}">상록수</td>
-				<td th:text="${row.region}">수도권</td>
-				<td th:text="${row.reasonText}">기본 정보만 있음</td>
-				<td th:text="${row.score}">0</td>
-			</tr>
-			</tbody>
-		</table>
-	</section>
-
-	<section>
-		<h2>접근성 개선 우선순위</h2>
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">역</th>
-				<th scope="col">시설</th>
-				<th scope="col">개선 사유</th>
-				<th scope="col">우선순위 점수</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:each="row : ${report.accessibilityImprovementPriorityRows}">
-				<td th:text="${row.stationName}">상록수</td>
-				<td th:text="${row.facilityName}">장애인 화장실</td>
-				<td th:text="${row.reasonText}">확인 필요 상태, 신뢰도 확인 필요</td>
-				<td th:text="${row.priorityScore}">0</td>
-			</tr>
-			</tbody>
-		</table>
-	</section>
-</main>
+</div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/operator/accessibility-report.html
+++ b/backend/src/main/resources/templates/operator/accessibility-report.html
@@ -49,6 +49,7 @@
 				<div class="metric"><span>전체 역</span><strong th:text="${report.totalStations}">0</strong></div>
 				<div class="metric"><span>접근성 시설</span><strong th:text="${report.totalFacilities}">0</strong></div>
 				<div class="metric"><span>확인 필요 시설</span><strong th:text="${report.needsVerificationFacilityCount}">0</strong></div>
+				<div class="metric"><span>갱신 지연 시설</span><strong th:text="${report.delayedFacilityStatusCount}">0</strong></div>
 				<div class="metric"><span>검증일 누락 역</span><strong th:text="${report.missingStationVerificationDateCount}">0</strong></div>
 			</div>
 

--- a/backend/src/main/resources/templates/operator/data-collection-failures.html
+++ b/backend/src/main/resources/templates/operator/data-collection-failures.html
@@ -3,192 +3,99 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>운영기관 데이터 수집 실패 현황</title>
-	<style>
-		body {
-			margin: 0;
-			background: #f5f7f8;
-			color: #102a2c;
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-		}
-
-		main {
-			max-width: 1120px;
-			margin: 0 auto;
-			padding: 32px 24px 48px;
-		}
-
-		h1 {
-			margin: 0 0 10px;
-			font-size: 32px;
-			line-height: 1.2;
-		}
-
-		p {
-			margin: 0 0 24px;
-			color: #40585a;
-			font-size: 17px;
-			line-height: 1.55;
-		}
-
-		h2 {
-			margin: 0;
-			padding: 16px 18px;
-			background: #e8f1ef;
-			font-size: 20px;
-		}
-
-		.metric-grid {
-			display: grid;
-			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-			gap: 12px;
-			margin-bottom: 24px;
-		}
-
-		.metric {
-			background: #fff;
-			border: 1px solid #d6e0df;
-			padding: 18px;
-		}
-
-		.metric span {
-			display: block;
-			color: #536b6d;
-			font-weight: 800;
-			line-height: 1.4;
-		}
-
-		.metric strong {
-			display: block;
-			margin-top: 8px;
-			font-size: 30px;
-			line-height: 1.15;
-		}
-
-		.freshness-alert {
-			background: #fff;
-			border: 1px solid #d6e0df;
-			margin-bottom: 24px;
-			padding: 18px;
-		}
-
-		.freshness-alert strong {
-			display: block;
-			font-size: 20px;
-			line-height: 1.3;
-		}
-
-		.freshness-alert span {
-			display: block;
-			margin-top: 8px;
-			color: #536b6d;
-			font-weight: 800;
-			line-height: 1.4;
-		}
-
-		.freshness-alert p {
-			margin: 8px 0 0;
-			color: #40585a;
-			font-weight: 700;
-			line-height: 1.5;
-		}
-
-		.freshness-alert.ok {
-			border-color: #82c69b;
-		}
-
-		.freshness-alert.stale {
-			border-color: #d37c75;
-		}
-
-		section {
-			background: #fff;
-			border: 1px solid #d6e0df;
-		}
-
-		table {
-			width: 100%;
-			border-collapse: collapse;
-		}
-
-		th,
-		td {
-			padding: 14px 18px;
-			border-top: 1px solid #d6e0df;
-			text-align: left;
-			vertical-align: top;
-			font-size: 15px;
-			line-height: 1.45;
-		}
-
-		th {
-			background: #f8fbfb;
-			font-weight: 800;
-		}
-
-		td:nth-child(5),
-		th:nth-child(5) {
-			text-align: right;
-			font-weight: 800;
-		}
-	</style>
+	<title>운영기관 데이터 수집 실패 보고서</title>
+	<link rel="stylesheet" href="/css/operator-v3.css">
 </head>
 <body>
-<main>
-	<h1>운영기관 데이터 수집 실패 현황</h1>
-	<p>운영기관 담당자가 최근 데이터 수집 상태와 재시도 필요 여부를 확인하는 읽기 전용 리포트입니다.</p>
-
-	<div class="metric-grid" aria-label="데이터 수집 실패 현황 요약">
-		<div class="metric">
-			<span>전체 수집 실행</span>
-			<strong th:text="${report.totalRunCount}">0</strong>
+<div class="desktop-frame">
+	<aside class="desktop-sidebar" aria-label="운영기관 포털 메뉴">
+		<div class="desktop-brand">
+			<div class="logo-mark">길</div>
+			<div><strong>쉬운 지하철</strong><span>운영기관 포털</span></div>
 		</div>
-		<div class="metric">
-			<span>실패 실행</span>
-			<strong th:text="${report.failedRunCount}">0</strong>
+		<nav class="desktop-nav">
+			<div class="nav-group">보고서</div>
+			<a class="nav-link" href="/operator/accessibility-report/page">접근성 현황</a>
+			<a class="nav-link" href="/operator/repeated-broken-facilities/page">반복 고장 시설</a>
+			<a class="nav-link active" href="/operator/data-collection-failures/page">수집 실패</a>
+			<a class="nav-link" href="/operator/route-feedback-report/page">현장 피드백</a>
+			<a class="nav-link" href="/operator/push-notification-report/page">알림 보고서</a>
+		</nav>
+		<div class="desktop-user">
+			<div class="avatar">MO</div>
+			<div><strong>Metro 운영자</strong><span>OPERATOR_ADMIN</span></div>
 		</div>
-		<div class="metric">
-			<span>재시도 가능</span>
-			<strong th:text="${report.retryableRunCount}">0</strong>
-		</div>
-	</div>
+	</aside>
 
-	<div class="freshness-alert" th:classappend="${report.freshnessAlertClass}">
-		<strong>데이터 갱신 상태: <span th:text="${report.freshnessAlertLabel}">점검 필요</span></strong>
-		<span>최신 완료 수집: <b th:text="${report.latestCompletedAtLabel}">-</b></span>
-		<p th:text="${report.freshnessAlertDescription}">데이터 수집 완료 기록이 없습니다.</p>
-	</div>
+	<section class="desktop-workspace">
+		<header class="desktop-topbar">
+			<div>
+				<div class="desktop-breadcrumb">운영기관 보고서</div>
+				<div class="desktop-page-name">데이터 수집 실패</div>
+			</div>
+			<div class="topbar-note">최근 20회 · 재시도 가능 여부</div>
+		</header>
 
-	<section>
-		<h2>최근 수집 실행</h2>
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">수집 원천</th>
-				<th scope="col">상태</th>
-				<th scope="col">시작 시각</th>
-				<th scope="col">종료 시각</th>
-				<th scope="col">수집 건수</th>
-				<th scope="col">실패 사유</th>
-				<th scope="col">운영 조치</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:each="row : ${report.rows}">
-				<td th:text="${row.sourceLabel}">도시철도 마스터</td>
-				<td th:text="${row.statusLabel}">실패</td>
-				<td th:text="${row.startedAtLabel}">2026-06-18T10:00</td>
-				<td th:text="${row.completedAtLabel}">2026-06-18T10:00:30</td>
-				<td th:text="${row.collectedCount}">0</td>
-				<td th:text="${row.failureMessage}">공공데이터 응답 지연</td>
-				<td th:text="${row.operatorAction}">재시도하세요.</td>
-			</tr>
-			<tr th:if="${#lists.isEmpty(report.rows)}">
-				<td colspan="7">최근 데이터 수집 실행 기록이 없습니다.</td>
-			</tr>
-			</tbody>
-		</table>
+		<main class="desktop-content">
+			<div class="page-head">
+				<div>
+					<h1>데이터 수집 실패 보고서</h1>
+					<p>최근 수집 이력과 실패 원인, 재시도 가능 여부를 확인합니다.</p>
+				</div>
+			</div>
+
+			<div class="alert-banner" th:classappend="${report.freshnessAlertClass}">
+				<strong>데이터 갱신 상태: <span th:text="${report.freshnessAlertLabel}">점검 필요</span></strong>
+				<span>최신 완료 수집: <b th:text="${report.latestCompletedAtLabel}">-</b></span>
+				<p th:text="${report.freshnessAlertDescription}">데이터 수집 완료 기록이 없습니다.</p>
+			</div>
+
+			<div class="metric-grid" aria-label="데이터 수집 실패 현황 요약">
+				<div class="metric"><span>전체 수집 실행</span><strong th:text="${report.totalRunCount}">0</strong></div>
+				<div class="metric"><span>실패 실행</span><strong th:text="${report.failedRunCount}">0</strong></div>
+				<div class="metric"><span>재시도 가능</span><strong th:text="${report.retryableRunCount}">0</strong></div>
+				<div class="metric"><span>최신 완료</span><strong th:text="${report.latestCompletedAtLabel}">-</strong></div>
+			</div>
+
+			<section class="panel">
+				<div class="panel-head">
+					<div class="panel-title">
+						<h2>최근 수집 실행</h2>
+						<p>운영 행동 문구까지 함께 제공합니다.</p>
+					</div>
+				</div>
+				<table class="data-table">
+					<thead>
+					<tr>
+						<th scope="col">수집 원천</th>
+						<th scope="col">상태</th>
+						<th scope="col">시작 시각</th>
+						<th scope="col">종료 시각</th>
+						<th scope="col">수집 건수</th>
+						<th scope="col">실패 사유</th>
+						<th scope="col">운영 조치</th>
+					</tr>
+					</thead>
+					<tbody>
+					<tr th:each="row : ${report.rows}">
+						<td th:text="${row.sourceLabel}">도시철도 마스터</td>
+						<td><span class="status" th:text="${row.statusLabel}">실패</span></td>
+						<td th:text="${row.startedAtLabel}">2026-06-18T10:00</td>
+						<td th:text="${row.completedAtLabel}">2026-06-18T10:00:30</td>
+						<td th:text="${row.collectedCount}">0</td>
+						<td th:text="${row.failureMessage}">공공데이터 응답 지연</td>
+						<td th:text="${row.operatorAction}">재시도하세요.</td>
+					</tr>
+					<tr th:if="${#lists.isEmpty(report.rows)}">
+						<td colspan="7">최근 데이터 수집 실행 기록이 없습니다.</td>
+					</tr>
+					</tbody>
+				</table>
+			</section>
+
+			<div class="source-note">완료 기록이 24시간 이상 갱신되지 않으면 점검 필요 경고로 전환됩니다.</div>
+		</main>
 	</section>
-</main>
+</div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/operator/login.html
+++ b/backend/src/main/resources/templates/operator/login.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>운영기관 로그인</title>
+	<link rel="stylesheet" href="/css/operator-v3.css">
+</head>
+<body>
+<main class="login-screen">
+	<form class="login-card" method="post" action="/operator/login">
+		<div class="desktop-brand">
+			<div class="logo-mark">길</div>
+			<div><strong>쉬운 지하철</strong><span>운영기관 포털</span></div>
+		</div>
+		<h1>운영기관 로그인</h1>
+		<p>기관 담당자에게 발급된 계정으로 접근성 보고서를 확인하세요.</p>
+		<input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+		<div class="login-field">
+			<label for="username">아이디</label>
+			<input id="username" name="username" autocomplete="username" required>
+		</div>
+		<div class="login-field">
+			<label for="password">비밀번호</label>
+			<input id="password" name="password" type="password" autocomplete="current-password" required>
+		</div>
+		<button class="login-submit" type="submit">안전하게 로그인</button>
+		<div class="login-note">로그인 실패가 반복되면 15분 동안 접속이 제한됩니다. 계정 공유 없이 개인 계정을 사용해 주세요.</div>
+	</form>
+</main>
+</body>
+</html>

--- a/backend/src/main/resources/templates/operator/push-notification-report.html
+++ b/backend/src/main/resources/templates/operator/push-notification-report.html
@@ -3,161 +3,102 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>운영기관 알림 발송 현황</title>
-	<style>
-		body {
-			margin: 0;
-			background: #f5f7f8;
-			color: #102a2c;
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-		}
-
-		main {
-			max-width: 1120px;
-			margin: 0 auto;
-			padding: 32px 24px 48px;
-		}
-
-		h1 {
-			margin: 0 0 10px;
-			font-size: 32px;
-			line-height: 1.2;
-		}
-
-		p {
-			margin: 0 0 24px;
-			color: #40585a;
-			font-size: 17px;
-			line-height: 1.55;
-		}
-
-		h2 {
-			margin: 0;
-			padding: 16px 18px;
-			background: #e8f1ef;
-			font-size: 20px;
-		}
-
-		.metric-grid {
-			display: grid;
-			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-			gap: 12px;
-			margin-bottom: 24px;
-		}
-
-		.metric {
-			background: #fff;
-			border: 1px solid #d6e0df;
-			padding: 18px;
-		}
-
-		.metric span {
-			display: block;
-			color: #536b6d;
-			font-weight: 800;
-			line-height: 1.4;
-		}
-
-		.metric strong {
-			display: block;
-			margin-top: 8px;
-			font-size: 30px;
-			line-height: 1.15;
-		}
-
-		section {
-			margin-top: 24px;
-			background: #fff;
-			border: 1px solid #d6e0df;
-		}
-
-		table {
-			width: 100%;
-			border-collapse: collapse;
-		}
-
-		th,
-		td {
-			padding: 14px 18px;
-			border-top: 1px solid #d6e0df;
-			text-align: left;
-			vertical-align: top;
-			font-size: 15px;
-			line-height: 1.45;
-		}
-
-		th {
-			background: #f8fbfb;
-			font-weight: 800;
-		}
-
-		td:nth-child(3),
-		th:nth-child(3) {
-			text-align: right;
-			font-weight: 800;
-		}
-
-		.notice {
-			padding: 18px;
-			border-top: 1px solid #d6e0df;
-			font-size: 16px;
-			line-height: 1.55;
-		}
-	</style>
+	<title>운영기관 알림 발송 보고서</title>
+	<link rel="stylesheet" href="/css/operator-v3.css">
 </head>
 <body>
-<main>
-	<h1>운영기관 알림 발송 현황</h1>
-	<p>운영기관 담당자가 사용자 알림 발송 규모와 실패 여부를 확인하는 읽기 전용 리포트입니다.</p>
+<div class="desktop-frame">
+	<aside class="desktop-sidebar" aria-label="운영기관 포털 메뉴">
+		<div class="desktop-brand">
+			<div class="logo-mark">길</div>
+			<div><strong>쉬운 지하철</strong><span>운영기관 포털</span></div>
+		</div>
+		<nav class="desktop-nav">
+			<div class="nav-group">보고서</div>
+			<a class="nav-link" href="/operator/accessibility-report/page">접근성 현황</a>
+			<a class="nav-link" href="/operator/repeated-broken-facilities/page">반복 고장 시설</a>
+			<a class="nav-link" href="/operator/data-collection-failures/page">수집 실패</a>
+			<a class="nav-link" href="/operator/route-feedback-report/page">현장 피드백</a>
+			<a class="nav-link active" href="/operator/push-notification-report/page">알림 보고서</a>
+		</nav>
+		<div class="desktop-user">
+			<div class="avatar">MO</div>
+			<div><strong>Metro 운영자</strong><span>OPERATOR_ADMIN</span></div>
+		</div>
+	</aside>
 
-	<div class="metric-grid" aria-label="알림 발송 현황 요약">
-		<div class="metric">
-			<span>전체 알림</span>
-			<strong th:text="${report.totalCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>대기 중</span>
-			<strong th:text="${report.pendingCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>발송 완료</span>
-			<strong th:text="${report.sentCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>발송 실패</span>
-			<strong th:text="${report.failedCount}">0</strong>
-		</div>
-	</div>
+	<section class="desktop-workspace">
+		<header class="desktop-topbar">
+			<div>
+				<div class="desktop-breadcrumb">운영기관 보고서</div>
+				<div class="desktop-page-name">알림 발송 보고서</div>
+			</div>
+			<div class="topbar-note">읽기 전용 · 전달 상태</div>
+		</header>
 
-	<section>
-		<h2>상태별 발송 현황</h2>
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">상태</th>
-				<th scope="col">설명</th>
-				<th scope="col">건수</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:each="row : ${report.statusRows}">
-				<td th:text="${row.label}">대기 중</td>
-				<td th:text="${row.description}">아직 발송 처리 전</td>
-				<td th:text="${row.count}">0</td>
-			</tr>
-			</tbody>
-		</table>
+		<main class="desktop-content">
+			<div class="page-head">
+				<div>
+					<h1>알림 발송 보고서</h1>
+					<p>시설·경로·제보·데이터 품질 알림의 전달 상태를 읽기 전용으로 확인합니다.</p>
+				</div>
+			</div>
+
+			<div class="alert-banner" th:if="${report.latestFailureReason != null}">
+				<strong>최근 실패 원인</strong>
+				<span th:text="${report.latestFailureReason}">Provider timeout</span>
+			</div>
+
+			<div class="metric-grid" aria-label="알림 발송 현황 요약">
+				<div class="metric"><span>전체 알림</span><strong th:text="${report.totalCount}">0</strong></div>
+				<div class="metric"><span>대기 중</span><strong th:text="${report.pendingCount}">0</strong></div>
+				<div class="metric"><span>발송 완료</span><strong th:text="${report.sentCount}">0</strong></div>
+				<div class="metric"><span>발송 실패</span><strong th:text="${report.failedCount}">0</strong></div>
+			</div>
+
+			<div class="desktop-grid-2">
+				<section class="panel">
+					<div class="panel-head">
+						<div class="panel-title">
+							<h2>전달 상태</h2>
+							<p>대기·완료·실패 건수입니다.</p>
+						</div>
+					</div>
+					<table class="data-table">
+						<thead>
+						<tr>
+							<th scope="col">상태</th>
+							<th scope="col">설명</th>
+							<th scope="col">건수</th>
+						</tr>
+						</thead>
+						<tbody>
+						<tr th:each="row : ${report.statusRows}">
+							<td><span class="status" th:text="${row.label}">대기 중</span></td>
+							<td th:text="${row.description}">아직 발송 처리 전</td>
+							<td th:text="${row.count}">0</td>
+						</tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section class="panel">
+					<div class="panel-head">
+						<div class="panel-title">
+							<h2>최근 실패 안내</h2>
+							<p>실패 원인이 있으면 운영 담당자 확인 대상으로 표시합니다.</p>
+						</div>
+					</div>
+					<div class="source-note" th:if="${report.latestFailureReason != null}" th:text="${report.latestFailureReason}">
+						푸시 발송 처리 중 오류가 발생했습니다. 관리자 점검이 필요합니다.
+					</div>
+					<div class="source-note" th:if="${report.latestFailureReason == null}">
+						최근 실패 없음
+					</div>
+				</section>
+			</div>
+		</main>
 	</section>
-
-	<section>
-		<h2>최근 실패 안내</h2>
-		<div class="notice" th:if="${report.latestFailureReason != null}" th:text="${report.latestFailureReason}">
-			푸시 발송 처리 중 오류가 발생했습니다. 관리자 점검이 필요합니다.
-		</div>
-		<div class="notice" th:if="${report.latestFailureReason == null}">
-			최근 실패 없음
-		</div>
-	</section>
-</main>
+</div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/operator/repeated-broken-facilities.html
+++ b/backend/src/main/resources/templates/operator/repeated-broken-facilities.html
@@ -3,136 +3,92 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>운영기관 반복 고장 시설 통계</title>
-	<style>
-		body {
-			margin: 0;
-			background: #f5f7f8;
-			color: #102a2c;
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-		}
-
-		main {
-			max-width: 960px;
-			margin: 0 auto;
-			padding: 32px 24px 48px;
-		}
-
-		h1 {
-			margin: 0 0 10px;
-			font-size: 32px;
-			line-height: 1.2;
-		}
-
-		p {
-			margin: 0 0 24px;
-			color: #40585a;
-			font-size: 17px;
-			line-height: 1.55;
-		}
-
-		h2 {
-			margin: 0;
-			padding: 16px 18px;
-			background: #e8f1ef;
-			font-size: 20px;
-		}
-
-		.metric-grid {
-			display: grid;
-			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-			gap: 12px;
-			margin-bottom: 24px;
-		}
-
-		.metric {
-			background: #fff;
-			border: 1px solid #d6e0df;
-			padding: 18px;
-		}
-
-		.metric span {
-			display: block;
-			color: #536b6d;
-			font-weight: 800;
-			line-height: 1.4;
-		}
-
-		.metric strong {
-			display: block;
-			margin-top: 8px;
-			font-size: 30px;
-			line-height: 1.15;
-		}
-
-		section {
-			background: #fff;
-			border: 1px solid #d6e0df;
-		}
-
-		table {
-			width: 100%;
-			border-collapse: collapse;
-		}
-
-		th,
-		td {
-			padding: 14px 18px;
-			border-top: 1px solid #d6e0df;
-			text-align: left;
-			vertical-align: top;
-			font-size: 15px;
-			line-height: 1.45;
-		}
-
-		th {
-			background: #f8fbfb;
-			font-weight: 800;
-		}
-
-		td:last-child,
-		th:last-child {
-			text-align: right;
-			font-weight: 800;
-		}
-	</style>
+	<title>운영기관 반복 고장 시설</title>
+	<link rel="stylesheet" href="/css/operator-v3.css">
 </head>
 <body>
-<main>
-	<h1>운영기관 반복 고장 시설 통계</h1>
-	<p>운영기관 담당자가 반복 신고된 시설과 현재 상태를 확인하는 읽기 전용 리포트입니다.</p>
-
-	<div class="metric-grid" aria-label="반복 고장 시설 통계 요약">
-		<div class="metric">
-			<span>반복 고장 시설</span>
-			<strong th:text="${report.totalRepeatedFacilityCount}">0</strong>
+<div class="desktop-frame">
+	<aside class="desktop-sidebar" aria-label="운영기관 포털 메뉴">
+		<div class="desktop-brand">
+			<div class="logo-mark">길</div>
+			<div><strong>쉬운 지하철</strong><span>운영기관 포털</span></div>
 		</div>
-	</div>
+		<nav class="desktop-nav">
+			<div class="nav-group">보고서</div>
+			<a class="nav-link" href="/operator/accessibility-report/page">접근성 현황</a>
+			<a class="nav-link active" href="/operator/repeated-broken-facilities/page">반복 고장 시설</a>
+			<a class="nav-link" href="/operator/data-collection-failures/page">수집 실패</a>
+			<a class="nav-link" href="/operator/route-feedback-report/page">현장 피드백</a>
+			<a class="nav-link" href="/operator/push-notification-report/page">알림 보고서</a>
+		</nav>
+		<div class="desktop-user">
+			<div class="avatar">MO</div>
+			<div><strong>Metro 운영자</strong><span>OPERATOR_ADMIN</span></div>
+		</div>
+	</aside>
 
-	<section>
-		<h2>시설별 반복 신고</h2>
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">역</th>
-				<th scope="col">시설</th>
-				<th scope="col">현재 상태</th>
-				<th scope="col">신고 건수</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:each="row : ${report.rows}">
-				<td th:text="${row.stationName}">상록수</td>
-				<td th:text="${row.facilityName}">1번 출구 엘리베이터</td>
-				<td th:text="${row.statusLabel}">정상</td>
-				<td th:text="${row.reportCount}">0</td>
-			</tr>
-			<tr th:if="${#lists.isEmpty(report.rows)}">
-				<td colspan="4">반복 고장으로 집계된 시설이 없습니다.</td>
-			</tr>
-			</tbody>
-		</table>
+	<section class="desktop-workspace">
+		<header class="desktop-topbar">
+			<div>
+				<div class="desktop-breadcrumb">운영기관 보고서</div>
+				<div class="desktop-page-name">반복 고장 시설</div>
+			</div>
+			<div class="topbar-note">읽기 전용 · 현장 조치 우선순위</div>
+		</header>
+
+		<main class="desktop-content">
+			<div class="page-head">
+				<div>
+					<h1>반복 고장 시설</h1>
+					<p>동일 시설에 반복 접수된 고장 제보를 현장 조치 우선순위로 봅니다.</p>
+				</div>
+			</div>
+
+			<div class="alert-banner bad" th:if="${report.totalRepeatedFacilityCount > 0}">
+				<strong>반복 확인 대상</strong>
+				<span th:text="|총 ${report.totalRepeatedFacilityCount}개 시설이 반복 고장으로 집계되었습니다.|">총 0개 시설</span>
+			</div>
+
+			<div class="metric-grid" aria-label="반복 고장 시설 통계 요약">
+				<div class="metric"><span>반복 제보 시설</span><strong th:text="${report.totalRepeatedFacilityCount}">0</strong></div>
+				<div class="metric"><span>운영 상태</span><strong>읽기 전용</strong></div>
+				<div class="metric"><span>판정 기준</span><strong>2건+</strong></div>
+				<div class="metric"><span>조치 연결</span><strong>관리자 요청</strong></div>
+			</div>
+
+			<section class="panel">
+				<div class="panel-head">
+					<div class="panel-title">
+						<h2>시설별 반복 신고</h2>
+						<p>제보 건수 내림차순으로 현재 시설 상태를 함께 표시합니다.</p>
+					</div>
+				</div>
+				<table class="data-table">
+					<thead>
+					<tr>
+						<th scope="col">역</th>
+						<th scope="col">시설</th>
+						<th scope="col">현재 상태</th>
+						<th scope="col">신고 건수</th>
+					</tr>
+					</thead>
+					<tbody>
+					<tr th:each="row : ${report.rows}">
+						<td th:text="${row.stationName}">상록수</td>
+						<td th:text="${row.facilityName}">1번 출구 엘리베이터</td>
+						<td><span class="status" th:text="${row.statusLabel}">정상</span></td>
+						<td th:text="${row.reportCount}">0</td>
+					</tr>
+					<tr th:if="${#lists.isEmpty(report.rows)}">
+						<td colspan="4">반복 고장으로 집계된 시설이 없습니다.</td>
+					</tr>
+					</tbody>
+				</table>
+			</section>
+
+			<div class="source-note">이 보고서는 읽기 전용입니다. 상태 수정과 제보 판정은 통합 관리자에게 요청해 주세요.</div>
+		</main>
 	</section>
-</main>
+</div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/operator/route-feedback-report.html
+++ b/backend/src/main/resources/templates/operator/route-feedback-report.html
@@ -3,172 +3,117 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>운영기관 이동 불편 신고 분석</title>
-	<style>
-		body {
-			margin: 0;
-			background: #f5f7f8;
-			color: #102a2c;
-			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-		}
-
-		main {
-			max-width: 960px;
-			margin: 0 auto;
-			padding: 32px 24px 48px;
-		}
-
-		h1 {
-			margin: 0 0 10px;
-			font-size: 32px;
-			line-height: 1.2;
-		}
-
-		p {
-			margin: 0 0 24px;
-			color: #40585a;
-			font-size: 17px;
-			line-height: 1.55;
-		}
-
-		h2 {
-			margin: 0;
-			padding: 16px 18px;
-			background: #e8f1ef;
-			font-size: 20px;
-		}
-
-		.metric-grid {
-			display: grid;
-			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-			gap: 12px;
-			margin-bottom: 24px;
-		}
-
-		.metric {
-			background: #fff;
-			border: 1px solid #d6e0df;
-			padding: 18px;
-		}
-
-		.metric span {
-			display: block;
-			color: #536b6d;
-			font-weight: 800;
-			line-height: 1.4;
-		}
-
-		.metric strong {
-			display: block;
-			margin-top: 8px;
-			font-size: 30px;
-			line-height: 1.15;
-		}
-
-		section {
-			background: #fff;
-			border: 1px solid #d6e0df;
-		}
-
-		section + section {
-			margin-top: 24px;
-		}
-
-		table {
-			width: 100%;
-			border-collapse: collapse;
-		}
-
-		th,
-		td {
-			padding: 14px 18px;
-			border-top: 1px solid #d6e0df;
-			text-align: left;
-			vertical-align: top;
-			font-size: 15px;
-			line-height: 1.45;
-		}
-
-		th {
-			background: #f8fbfb;
-			font-weight: 800;
-		}
-
-		td:last-child,
-		th:last-child {
-			text-align: right;
-			font-weight: 800;
-		}
-	</style>
+	<title>운영기관 현장 차단 피드백</title>
+	<link rel="stylesheet" href="/css/operator-v3.css">
 </head>
 <body>
-<main>
-	<h1>운영기관 이동 불편 신고 분석</h1>
-	<p>운영기관 담당자가 경로 안내 만족도와 현장 차단 신고 흐름을 확인하는 읽기 전용 리포트입니다.</p>
+<div class="desktop-frame">
+	<aside class="desktop-sidebar" aria-label="운영기관 포털 메뉴">
+		<div class="desktop-brand">
+			<div class="logo-mark">길</div>
+			<div><strong>쉬운 지하철</strong><span>운영기관 포털</span></div>
+		</div>
+		<nav class="desktop-nav">
+			<div class="nav-group">보고서</div>
+			<a class="nav-link" href="/operator/accessibility-report/page">접근성 현황</a>
+			<a class="nav-link" href="/operator/repeated-broken-facilities/page">반복 고장 시설</a>
+			<a class="nav-link" href="/operator/data-collection-failures/page">수집 실패</a>
+			<a class="nav-link active" href="/operator/route-feedback-report/page">현장 피드백</a>
+			<a class="nav-link" href="/operator/push-notification-report/page">알림 보고서</a>
+		</nav>
+		<div class="desktop-user">
+			<div class="avatar">MO</div>
+			<div><strong>Metro 운영자</strong><span>OPERATOR_ADMIN</span></div>
+		</div>
+	</aside>
 
-	<div class="metric-grid" aria-label="이동 불편 신고 분석 요약">
-		<div class="metric">
-			<span>전체 피드백</span>
-			<strong th:text="${summary.totalCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>도움이 됨</span>
-			<strong th:text="${summary.helpfulCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>도움이 안 됨</span>
-			<strong th:text="${summary.notHelpfulCount}">0</strong>
-		</div>
-		<div class="metric">
-			<span>현장 차단</span>
-			<strong th:text="${summary.blockedByRealWorldCount}">0</strong>
-		</div>
-	</div>
+	<section class="desktop-workspace">
+		<header class="desktop-topbar">
+			<div>
+				<div class="desktop-breadcrumb">운영기관 보고서</div>
+				<div class="desktop-page-name">현장 차단 피드백</div>
+			</div>
+			<div class="topbar-note">최근 사례 · 이동 유형별 확인</div>
+		</header>
 
-	<section>
-		<h2>평점별 피드백</h2>
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">평점</th>
-				<th scope="col">설명</th>
-				<th scope="col">건수</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:each="row : ${summary.ratingRows}">
-				<td th:text="${row.label}">도움이 됨</td>
-				<td th:text="${row.description}">경로 안내가 실제 이동에 도움됨</td>
-				<td th:text="${row.count}">0</td>
-			</tr>
-			</tbody>
-		</table>
+		<main class="desktop-content">
+			<div class="page-head">
+				<div>
+					<h1>현장 차단 피드백</h1>
+					<p>실제 이동 중 막힌 최근 사례를 역·이동 유형별로 확인합니다.</p>
+				</div>
+			</div>
+
+			<div class="metric-grid" aria-label="이동 불편 신고 분석 요약">
+				<div class="metric"><span>전체 피드백</span><strong th:text="${summary.totalCount}">0</strong></div>
+				<div class="metric"><span>도움이 됨</span><strong th:text="${summary.helpfulCount}">0</strong></div>
+				<div class="metric"><span>도움이 안 됨</span><strong th:text="${summary.notHelpfulCount}">0</strong></div>
+				<div class="metric"><span>현장 차단</span><strong th:text="${summary.blockedByRealWorldCount}">0</strong></div>
+			</div>
+
+			<div class="alert-banner bad" th:if="${summary.blockedByRealWorldCount > 0}">
+				<strong>현장 차단 확인 대상</strong>
+				<span th:text="|총 ${summary.blockedByRealWorldCount}건 · 시설 고장·공사·통로 적치 가능성을 확인하세요.|">총 0건</span>
+			</div>
+
+			<div class="desktop-grid-2">
+				<section class="panel">
+					<div class="panel-head">
+						<div class="panel-title">
+							<h2>피드백 구성</h2>
+							<p>도움됨·도움 안 됨·현장 차단 분포입니다.</p>
+						</div>
+					</div>
+					<table class="data-table">
+						<thead>
+						<tr>
+							<th scope="col">평점</th>
+							<th scope="col">설명</th>
+							<th scope="col">건수</th>
+						</tr>
+						</thead>
+						<tbody>
+						<tr th:each="row : ${summary.ratingRows}">
+							<td th:text="${row.label}">도움이 됨</td>
+							<td th:text="${row.description}">경로 안내가 실제 이동에 도움됨</td>
+							<td th:text="${row.count}">0</td>
+						</tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section class="panel">
+					<div class="panel-head">
+						<div class="panel-title">
+							<h2>최근 현장 차단 사례</h2>
+							<p>운영기관 현장 확인이 필요한 피드백입니다.</p>
+						</div>
+					</div>
+					<table class="data-table">
+						<thead>
+						<tr>
+							<th scope="col">신고 시각</th>
+							<th scope="col">출발역</th>
+							<th scope="col">도착역</th>
+							<th scope="col">이동 프로필</th>
+						</tr>
+						</thead>
+						<tbody>
+						<tr th:each="row : ${summary.recentBlockedFeedbacks}">
+							<td th:text="${row.createdAtLabel}">2026-06-17 10:00</td>
+							<td th:text="${row.originStationName}">상록수</td>
+							<td th:text="${row.destinationStationName}">사당</td>
+							<td th:text="${row.mobilityTypeLabel}">고령자</td>
+						</tr>
+						<tr th:if="${#lists.isEmpty(summary.recentBlockedFeedbacks)}">
+							<td colspan="4">최근 현장 차단 신고가 없습니다.</td>
+						</tr>
+						</tbody>
+					</table>
+				</section>
+			</div>
+		</main>
 	</section>
-
-	<section>
-		<h2>최근 현장 차단 신고</h2>
-		<table>
-			<thead>
-			<tr>
-				<th scope="col">신고 시각</th>
-				<th scope="col">출발역</th>
-				<th scope="col">도착역</th>
-				<th scope="col">이동 프로필</th>
-			</tr>
-			</thead>
-			<tbody>
-			<tr th:each="row : ${summary.recentBlockedFeedbacks}">
-				<td th:text="${row.createdAtLabel}">2026-06-17 10:00</td>
-				<td th:text="${row.originStationName}">상록수</td>
-				<td th:text="${row.destinationStationName}">사당</td>
-				<td th:text="${row.mobilityTypeLabel}">고령자</td>
-			</tr>
-			<tr th:if="${#lists.isEmpty(summary.recentBlockedFeedbacks)}">
-				<td colspan="4">최근 현장 차단 신고가 없습니다.</td>
-			</tr>
-			</tbody>
-		</table>
-	</section>
-</main>
+</div>
 </body>
 </html>

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorAccessibilityReportPageControllerTest.java
@@ -3,6 +3,7 @@ package com.easysubway.operator.adapter.in.web;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
@@ -38,20 +39,22 @@ class OperatorAccessibilityReportPageControllerTest {
 			.getContentAsString();
 
 		assertThat(html)
-			.contains("운영기관 접근성 시설 현황")
+			.contains("접근성 현황 보고서")
+			.contains("운영기관 포털")
+			.contains("협력 제안서 CSV")
 			.contains("전체 역")
-			.contains("전체 시설")
-			.contains("확인 필요한 시설")
-			.contains("갱신 지연 시설")
+			.contains("접근성 시설")
+			.contains("확인 필요 시설")
+			.contains("검증일 누락 역")
 			.contains("지역별 데이터 품질")
 			.contains("수도권")
 			.contains("운영기관")
 			.contains("노선")
 			.contains("역")
-			.contains("역별 접근성 점수")
+			.contains("역 접근성 점수")
 			.contains("접근성 점수")
 			.contains("보강 사유")
-			.contains("접근성 개선 우선순위")
+			.contains("개선 우선순위")
 			.contains("우선순위 점수")
 			.contains("개선 사유")
 			.contains("상록수")
@@ -68,7 +71,8 @@ class OperatorAccessibilityReportPageControllerTest {
 	@DisplayName("운영기관 접근성 리포트는 운영기관 계정 인증을 요구한다")
 	void accessibilityReportRequiresOperatorAuthentication() throws Exception {
 		mockMvc.perform(get("/operator/accessibility-report/page"))
-			.andExpect(status().isUnauthorized());
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("http://localhost/operator/login"));
 
 		mockMvc.perform(get("/operator/accessibility-report/page")
 				.with(httpBasic("basic-user", "user-test-password")))

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorDataCollectionFailuresPageControllerTest.java
@@ -3,6 +3,7 @@ package com.easysubway.operator.adapter.in.web;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.easysubway.collection.application.port.out.SaveDataCollectionRunPort;
@@ -87,8 +88,8 @@ class OperatorDataCollectionFailuresPageControllerTest {
 			.getContentAsString();
 
 		assertThat(html)
-			.contains("운영기관 데이터 수집 실패 현황")
-			.contains("읽기 전용 리포트")
+			.contains("데이터 수집 실패 보고서")
+			.contains("운영기관 포털")
 			.contains("전체 수집 실행")
 			.contains("실패 실행")
 			.contains("재시도 가능")
@@ -124,7 +125,8 @@ class OperatorDataCollectionFailuresPageControllerTest {
 	@DisplayName("운영기관 데이터 수집 실패 현황 화면은 운영기관 계정 인증을 요구한다")
 	void dataCollectionFailuresPageRequiresOperatorAuthentication() throws Exception {
 		mockMvc.perform(get("/operator/data-collection-failures/page"))
-			.andExpect(status().isUnauthorized());
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("http://localhost/operator/login"));
 
 		mockMvc.perform(get("/operator/data-collection-failures/page")
 				.with(httpBasic("basic-user", "user-test-password")))

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorLoginPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorLoginPageControllerTest.java
@@ -1,0 +1,58 @@
+package com.easysubway.operator.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.operator.username=operator-user",
+	"easysubway.operator.password=operator-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("운영기관 로그인 화면")
+class OperatorLoginPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("운영기관 로그인 화면은 공개로 렌더링된다")
+	void operatorLoginPageRenders() throws Exception {
+		String html = mockMvc.perform(get("/operator/login"))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("운영기관 로그인")
+			.contains("운영기관 포털")
+			.contains("아이디")
+			.contains("비밀번호")
+			.contains("안전하게 로그인")
+			.contains("name=\"_csrf\"");
+	}
+
+	@Test
+	@DisplayName("운영기관 계정은 로그인 후 접근성 보고서로 이동한다")
+	void operatorLoginRedirectsToAccessibilityReport() throws Exception {
+		mockMvc.perform(post("/operator/login")
+				.with(csrf())
+				.param("username", "operator-user")
+				.param("password", "operator-test-password"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/operator/accessibility-report/page"));
+	}
+}

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorPushNotificationReportPageControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.easysubway.notification.application.port.in.NotificationPreferenceUseCase;
@@ -54,13 +55,13 @@ class OperatorPushNotificationReportPageControllerTest {
 			.getContentAsString();
 
 		assertThat(html)
-			.contains("운영기관 알림 발송 현황")
-			.contains("읽기 전용 리포트")
+			.contains("알림 발송 보고서")
+			.contains("운영기관 포털")
 			.contains("전체 알림")
 			.contains("대기 중")
 			.contains("발송 완료")
 			.contains("발송 실패")
-			.contains("상태별 발송 현황")
+			.contains("전달 상태")
 			.contains("아직 발송 처리 전")
 			.contains("외부 발송 성공")
 			.contains("푸시 발송 처리 중 오류가 발생했습니다. 관리자 점검이 필요합니다.")
@@ -78,7 +79,8 @@ class OperatorPushNotificationReportPageControllerTest {
 	@DisplayName("운영기관 알림 발송 현황 화면은 운영기관 계정 인증을 요구한다")
 	void pushNotificationReportPageRequiresOperatorAuthentication() throws Exception {
 		mockMvc.perform(get("/operator/push-notification-report/page"))
-			.andExpect(status().isUnauthorized());
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("http://localhost/operator/login"));
 
 		mockMvc.perform(get("/operator/push-notification-report/page")
 				.with(httpBasic("anonymous-user-1", "user-test-password")))

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRepeatedBrokenFacilitiesPageControllerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
@@ -47,8 +48,8 @@ class OperatorRepeatedBrokenFacilitiesPageControllerTest {
 			.getContentAsString();
 
 		assertThat(html)
-			.contains("운영기관 반복 고장 시설 통계")
-			.contains("읽기 전용 리포트")
+			.contains("반복 고장 시설")
+			.contains("운영기관 포털")
 			.contains("반복 고장 시설")
 			.contains("시설별 반복 신고")
 			.contains("역")
@@ -75,7 +76,8 @@ class OperatorRepeatedBrokenFacilitiesPageControllerTest {
 	@DisplayName("운영기관 반복 고장 시설 통계 화면은 운영기관 계정 인증을 요구한다")
 	void repeatedBrokenFacilitiesPageRequiresOperatorAuthentication() throws Exception {
 		mockMvc.perform(get("/operator/repeated-broken-facilities/page"))
-			.andExpect(status().isUnauthorized());
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("http://localhost/operator/login"));
 
 		mockMvc.perform(get("/operator/repeated-broken-facilities/page")
 				.with(httpBasic("basic-user", "user-test-password")))

--- a/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/operator/adapter/in/web/OperatorRouteFeedbackReportPageControllerTest.java
@@ -3,6 +3,7 @@ package com.easysubway.operator.adapter.in.web;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.easysubway.profile.domain.MobilityType;
@@ -53,14 +54,14 @@ class OperatorRouteFeedbackReportPageControllerTest {
 			.getContentAsString();
 
 		assertThat(html)
-			.contains("운영기관 이동 불편 신고 분석")
-			.contains("읽기 전용 리포트")
+			.contains("현장 차단 피드백")
+			.contains("운영기관 포털")
 			.contains("전체 피드백")
 			.contains("도움이 됨")
 			.contains("도움이 안 됨")
 			.contains("현장 차단")
-			.contains("평점별 피드백")
-			.contains("최근 현장 차단 신고")
+			.contains("피드백 구성")
+			.contains("최근 현장 차단 사례")
 			.contains("상록수")
 			.contains("사당")
 			.contains("고령자")
@@ -76,7 +77,8 @@ class OperatorRouteFeedbackReportPageControllerTest {
 	@DisplayName("운영기관 이동 불편 신고 분석 화면은 운영기관 계정 인증을 요구한다")
 	void routeFeedbackReportPageRequiresOperatorAuthentication() throws Exception {
 		mockMvc.perform(get("/operator/route-feedback-report/page"))
-			.andExpect(status().isUnauthorized());
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("http://localhost/operator/login"));
 
 		mockMvc.perform(get("/operator/route-feedback-report/page")
 				.with(httpBasic("basic-user", "user-test-password")))


### PR DESCRIPTION
## 관련 이슈

close #768

## 작업 배경

운영기관 담당자가 로그인 후 접근성 현황, 반복 고장 시설, 데이터 수집 실패, 현장 차단 피드백, 알림 발송 보고서를 같은 포털 구조에서 확인할 수 있도록 v3 화면 기준으로 정리합니다.

## 작업 내용

- 운영기관 로그인 화면을 추가하고 HTML 페이지는 로그인 화면으로 이동하도록 form login을 연결했습니다.
- 운영기관 API 미인증 응답은 기존처럼 401을 유지하도록 분리했습니다.
- 5개 운영기관 보고서 템플릿을 공통 v3 포털 shell, 좌측 메뉴, metric, panel/table 스타일로 정리했습니다.
- 기존 `report`/`summary` 모델 바인딩은 유지해 실제 운영 집계 데이터가 렌더링되도록 했습니다.
- 운영기관 페이지 인증과 화면 문구 테스트를 갱신했습니다.
- Codex CLI review 지적에 따라 접근성 현황 요약의 `갱신 지연 시설` metric과 데이터 수집 실패 정상 alert 스타일 연결을 보완했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew cleanTest test`: exit 0
  - `git diff --check`: exit 0
  - `codex review --base origin/main --title "[Style] 운영기관 포털 v3 화면 디자인 반영"`: P2/P3 각 1건 확인, `55bb526` 및 `4716911`에서 수정 후 review thread resolve
  - `gh pr checks 770 --watch --interval 15`: CI, Release Artifacts, CodeRabbit status 모두 pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 운영기관 로그인 | 로컬 브라우저 | `/operator/login` 렌더링과 로그인 후 접근성 보고서 이동 확인 | 로컬 전용: `.codex/evidence/issue-768/operator-login.png` | 정상 |
| 접근성 현황 보고서 | 로컬 브라우저 | 로그인 세션으로 접근 후 active 메뉴, metric, table 렌더링 확인 | 로컬 전용: `.codex/evidence/issue-768/operator-accessibility.png` | 정상 |
| 데이터 수집 실패 보고서 | 로컬 브라우저 | 로그인 세션으로 접근 후 최신성 경고, metric, table 렌더링 확인 | 로컬 전용: `.codex/evidence/issue-768/operator-collection.png` | 정상 |
| 운영기관 보고서 데이터 바인딩 | backend test | 페이지 컨트롤러 테스트에서 실제 `report`/`summary` 값과 민감 ID 비노출 확인 | `./gradlew cleanTest test` exit 0 | 정상 |
| Review gate | GitHub PR | CodeRabbit pending 상태 확인 후 Codex CLI fallback review 게시, 지적 2건 수정·resolve | PR reviews `4558532854`, `4558572109`; fix commits `55bb526`, `4716911` | 정상 |
| CI gate | GitHub Actions | `gh pr checks 770 --watch --interval 15`로 Actions checks 완료 확인 | CI run `28070970567`, Release Artifacts run `28070970401` | 정상 |
| 화면 증거 첨부 방식 | PR | 저장소에 스크린샷을 커밋하지 않고 로컬 evidence 경로로 보관 | 외부 업로드 승인 전이라 로컬 전용 보관 | 정상 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `SecurityConfig`에서 `/operator/api/**`는 401, `/operator/**` HTML 페이지는 login redirect로 분기되는지
  - 운영기관 템플릿이 form 없이 읽기 전용으로 유지되는지
  - 신규 `operator-v3.css`가 운영기관 화면에만 적용되는지
  - CodeRabbit은 rate limit/credit exhausted로 실제 리뷰를 시작하지 못해 Codex CLI fallback review를 PR review로 남겼습니다.

## 리스크

- Spring Security `AntPathRequestMatcher` deprecation warning이 남아 있습니다. 기존 보안 동작을 작게 유지하기 위해 이번 PR에서는 동작 변경 없이 사용했습니다.
- 화면 캡처는 외부 업로드 승인 전이라 PR에 직접 첨부하지 않고 로컬 evidence 경로로만 보관했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
