### PR TITLE
[Style] 통합 관리자 v3 화면 구성

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminLoginPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminLoginPageController.java
@@ -1,0 +1,13 @@
+package com.easysubway.admin.adapter.in.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class AdminLoginPageController {
+
+	@GetMapping("/admin/login")
+	String loginPage() {
+		return "admin/login";
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
@@ -1,0 +1,142 @@
+package com.easysubway.admin.adapter.in.web;
+
+import com.easysubway.collection.application.port.in.DataCollectionUseCase;
+import com.easysubway.collection.domain.DataCollectionRun;
+import com.easysubway.health.application.port.in.CheckHealthUseCase;
+import com.easysubway.health.domain.HealthStatus;
+import com.easysubway.notification.application.port.in.PushNotificationDashboardUseCase;
+import com.easysubway.notification.domain.PushNotificationDashboardSummary;
+import com.easysubway.quality.application.port.in.DataQualityUseCase;
+import com.easysubway.quality.domain.DataQualitySummary;
+import com.easysubway.report.application.port.in.FacilityReportUseCase;
+import com.easysubway.report.domain.FacilityReportStatus;
+import com.easysubway.route.application.port.in.RouteSearchDashboardUseCase;
+import com.easysubway.route.domain.RouteSearchDashboardSummary;
+import com.easysubway.usage.application.port.in.UserActivityDashboardUseCase;
+import com.easysubway.usage.domain.UserActivityDashboardSummary;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class AdminOverviewPageController {
+
+	private final DataQualityUseCase dataQualityUseCase;
+	private final FacilityReportUseCase facilityReportUseCase;
+	private final RouteSearchDashboardUseCase routeSearchDashboardUseCase;
+	private final PushNotificationDashboardUseCase pushNotificationDashboardUseCase;
+	private final UserActivityDashboardUseCase userActivityDashboardUseCase;
+	private final DataCollectionUseCase dataCollectionUseCase;
+	private final CheckHealthUseCase checkHealthUseCase;
+
+	AdminOverviewPageController(
+		DataQualityUseCase dataQualityUseCase,
+		FacilityReportUseCase facilityReportUseCase,
+		RouteSearchDashboardUseCase routeSearchDashboardUseCase,
+		PushNotificationDashboardUseCase pushNotificationDashboardUseCase,
+		UserActivityDashboardUseCase userActivityDashboardUseCase,
+		DataCollectionUseCase dataCollectionUseCase,
+		CheckHealthUseCase checkHealthUseCase
+	) {
+		this.dataQualityUseCase = dataQualityUseCase;
+		this.facilityReportUseCase = facilityReportUseCase;
+		this.routeSearchDashboardUseCase = routeSearchDashboardUseCase;
+		this.pushNotificationDashboardUseCase = pushNotificationDashboardUseCase;
+		this.userActivityDashboardUseCase = userActivityDashboardUseCase;
+		this.dataCollectionUseCase = dataCollectionUseCase;
+		this.checkHealthUseCase = checkHealthUseCase;
+	}
+
+	@GetMapping("/admin/dashboard/page")
+	String dashboardPage(Model model) {
+		DataQualitySummary quality = dataQualityUseCase.summarizeDataQuality();
+		Map<FacilityReportStatus, Long> reportCounts = facilityReportUseCase.countReportsByStatus();
+		RouteSearchDashboardSummary routes = routeSearchDashboardUseCase.summarizeRouteSearches();
+		PushNotificationDashboardSummary push = pushNotificationDashboardUseCase.summarizePushNotifications();
+		UserActivityDashboardSummary usage = userActivityDashboardUseCase.summarizeUserActivity();
+		HealthStatus health = checkHealthUseCase.checkHealth();
+		model.addAttribute("dashboard", new DashboardView(
+			count(reportCounts, FacilityReportStatus.SUBMITTED) + count(reportCounts, FacilityReportStatus.UNDER_REVIEW),
+			facilityReportUseCase.countReportsCreatedSince(LocalDateTime.now().minusHours(24)),
+			quality.needsVerificationFacilityCount(),
+			quality.delayedFacilityStatusCount(),
+			routes.totalCount(),
+			routes.blockedCount(),
+			blockedRateLabel(routes),
+			push.failedCount(),
+			usage.totalActiveUsers(),
+			usage.apiErrorRatePercent(),
+			health.status(),
+			health.service()
+		));
+		return "admin/dashboard";
+	}
+
+	@GetMapping("/admin/system/page")
+	String systemPage(Model model) {
+		HealthStatus health = checkHealthUseCase.checkHealth();
+		List<DataCollectionRun> runs = dataCollectionUseCase.listRecentRuns(5);
+		PushNotificationDashboardSummary push = pushNotificationDashboardUseCase.summarizePushNotifications();
+		UserActivityDashboardSummary usage = userActivityDashboardUseCase.summarizeUserActivity();
+		model.addAttribute("health", health);
+		model.addAttribute("runs", runs.stream().map(CollectionRunRow::from).toList());
+		model.addAttribute("push", push);
+		model.addAttribute("usage", usage);
+		return "admin/system";
+	}
+
+	private static long count(Map<FacilityReportStatus, Long> counts, FacilityReportStatus status) {
+		return counts.getOrDefault(status, 0L);
+	}
+
+	private static String blockedRateLabel(RouteSearchDashboardSummary summary) {
+		if (summary.totalCount() == 0) {
+			return "0.0%";
+		}
+		return String.format("%.1f%%", (double) summary.blockedCount() * 100 / summary.totalCount());
+	}
+
+	record DashboardView(
+		long pendingReports,
+		long recentReports,
+		long needsVerificationFacilities,
+		long delayedFacilities,
+		long routeSearches,
+		long blockedRoutes,
+		String blockedRate,
+		long failedPushes,
+		long activeUsers,
+		String apiErrorRate,
+		String healthStatus,
+		String serviceName
+	) {
+	}
+
+	record CollectionRunRow(
+		String runId,
+		String source,
+		String status,
+		String requestedBy,
+		String startedAt,
+		String completedAt,
+		int collectedCount,
+		String failureMessage
+	) {
+
+		static CollectionRunRow from(DataCollectionRun run) {
+			return new CollectionRunRow(
+				run.runId(),
+				run.source().name(),
+				run.status().name(),
+				run.requestedBy(),
+				String.valueOf(run.startedAt()),
+				String.valueOf(run.completedAt()),
+				run.collectedCount(),
+				run.failureMessage()
+			);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -35,7 +36,26 @@ public class SecurityConfig {
 		return http
 			.securityMatcher("/admin/**")
 			.authorizeHttpRequests(authorize -> authorize
+				.requestMatchers("/admin/login").permitAll()
 				.anyRequest().hasRole("ADMIN")
+			)
+			.exceptionHandling(exception -> exception
+				.defaultAuthenticationEntryPointFor(
+					new LoginUrlAuthenticationEntryPoint("/admin/login"),
+					request -> {
+						String accept = request.getHeader("Accept");
+						return accept != null && accept.contains("text/html");
+					}
+				)
+				.defaultAuthenticationEntryPointFor(
+					new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED),
+					new AntPathRequestMatcher("/admin/**")
+				)
+			)
+			.formLogin(form -> form
+				.loginPage("/admin/login")
+				.defaultSuccessUrl("/admin/dashboard/page", true)
+				.permitAll()
 			)
 			.httpBasic(Customizer.withDefaults())
 			.addFilterAfter(auditFilter, BasicAuthenticationFilter.class)

--- a/backend/src/main/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminPageController.java
@@ -1,0 +1,152 @@
+package com.easysubway.field.adapter.in.web;
+
+import com.easysubway.field.application.port.in.FieldVerificationUseCase;
+import com.easysubway.field.application.port.in.UpdateFieldVerificationItemStatusCommand;
+import com.easysubway.field.domain.FieldVerificationChangeHistory;
+import com.easysubway.field.domain.FieldVerificationItem;
+import com.easysubway.field.domain.FieldVerificationSession;
+import com.easysubway.field.domain.FieldVerificationStatus;
+import java.security.Principal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+class FieldVerificationAdminPageController {
+
+	private final FieldVerificationUseCase fieldVerificationUseCase;
+
+	FieldVerificationAdminPageController(FieldVerificationUseCase fieldVerificationUseCase) {
+		this.fieldVerificationUseCase = fieldVerificationUseCase;
+	}
+
+	@GetMapping("/admin/field-verifications/page")
+	String fieldVerificationsPage(Model model) {
+		model.addAttribute("verifications", fieldVerificationUseCase.listStationVerifications().stream()
+			.map(SessionRow::from)
+			.toList());
+		return "admin/field/list";
+	}
+
+	@GetMapping("/admin/field-verifications/{stationId}/page")
+	String fieldVerificationDetailPage(@PathVariable String stationId, Model model) {
+		FieldVerificationSession session = fieldVerificationUseCase.getStationVerification(stationId);
+		model.addAttribute("verification", SessionRow.from(session));
+		model.addAttribute("items", session.items().stream().map(ItemRow::from).toList());
+		model.addAttribute("history", fieldVerificationUseCase.listStationChangeHistory(stationId).stream()
+			.map(HistoryRow::from)
+			.toList());
+		model.addAttribute("statusOptions", List.of(FieldVerificationStatus.VERIFIED, FieldVerificationStatus.NEEDS_RECHECK));
+		return "admin/field/detail";
+	}
+
+	@PostMapping("/admin/field-verifications/{stationId}/items/{itemId}/page/status")
+	String updateFieldVerificationItemStatusFromPage(
+		@PathVariable String stationId,
+		@PathVariable String itemId,
+		@RequestParam FieldVerificationStatus status,
+		@RequestParam(required = false) String note,
+		Principal principal
+	) {
+		fieldVerificationUseCase.updateItemStatus(
+			new UpdateFieldVerificationItemStatusCommand(stationId, itemId, status, note, principal.getName())
+		);
+		return "redirect:/admin/field-verifications/%s/page".formatted(stationId);
+	}
+
+	private static String statusLabel(FieldVerificationStatus status) {
+		return switch (status) {
+			case PLANNED -> "예정";
+			case IN_PROGRESS -> "진행 중";
+			case VERIFIED -> "검증 완료";
+			case NEEDS_RECHECK -> "재확인 필요";
+		};
+	}
+
+	record SessionRow(
+		String sessionId,
+		String stationId,
+		String stationName,
+		LocalDate verifiedAt,
+		String verifiedBy,
+		String statusLabel,
+		String note,
+		int itemCount,
+		long verifiedCount,
+		long recheckCount
+	) {
+
+		static SessionRow from(FieldVerificationSession session) {
+			long verifiedCount = session.items().stream()
+				.filter(item -> item.status() == FieldVerificationStatus.VERIFIED)
+				.count();
+			long recheckCount = session.items().stream()
+				.filter(item -> item.status() == FieldVerificationStatus.NEEDS_RECHECK)
+				.count();
+			return new SessionRow(
+				session.id(),
+				session.stationId(),
+				session.stationName(),
+				session.verifiedAt(),
+				session.verifiedBy(),
+				FieldVerificationAdminPageController.statusLabel(session.status()),
+				session.note(),
+				session.items().size(),
+				verifiedCount,
+				recheckCount
+			);
+		}
+	}
+
+	record ItemRow(
+		String itemId,
+		String typeLabel,
+		String targetName,
+		FieldVerificationStatus status,
+		String statusLabel,
+		String note
+	) {
+
+		static ItemRow from(FieldVerificationItem item) {
+			return new ItemRow(
+				item.id(),
+				item.type().label(),
+				item.targetName(),
+				item.status(),
+				FieldVerificationAdminPageController.statusLabel(item.status()),
+				item.note()
+			);
+		}
+	}
+
+	record HistoryRow(
+		String historyId,
+		String itemId,
+		String previousStatus,
+		String newStatus,
+		String previousNote,
+		String newNote,
+		String changedBy,
+		LocalDateTime changedAt
+	) {
+
+		static HistoryRow from(FieldVerificationChangeHistory history) {
+			return new HistoryRow(
+				history.id(),
+				history.itemId(),
+				FieldVerificationAdminPageController.statusLabel(history.previousStatus()),
+				FieldVerificationAdminPageController.statusLabel(history.newStatus()),
+				history.previousNote(),
+				history.newNote(),
+				history.changedBy(),
+				history.changedAt()
+			);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
@@ -1,0 +1,340 @@
+package com.easysubway.transit.adapter.in.web;
+
+import com.easysubway.transit.application.port.in.CreateAccessibilityFacilityCommand;
+import com.easysubway.transit.application.port.in.StationMasterDataCounts;
+import com.easysubway.transit.application.port.in.StationSearchCommand;
+import com.easysubway.transit.application.port.in.TransitMasterAdminUseCase;
+import com.easysubway.transit.application.port.in.TransitMasterQueryUseCase;
+import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilityCommand;
+import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import com.easysubway.transit.domain.AccessibilityFacilityType;
+import com.easysubway.transit.domain.DataConfidenceLevel;
+import com.easysubway.transit.domain.DataQualityLevel;
+import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.RouteEdge;
+import com.easysubway.transit.domain.RouteNode;
+import com.easysubway.transit.domain.StationExit;
+import com.easysubway.transit.domain.StationLayoutSource;
+import com.easysubway.transit.domain.StationWithLines;
+import java.math.BigDecimal;
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+class TransitStationAdminPageController {
+
+	private final TransitMasterQueryUseCase transitMasterQueryUseCase;
+	private final TransitMasterAdminUseCase transitMasterAdminUseCase;
+
+	TransitStationAdminPageController(
+		TransitMasterQueryUseCase transitMasterQueryUseCase,
+		TransitMasterAdminUseCase transitMasterAdminUseCase
+	) {
+		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
+		this.transitMasterAdminUseCase = transitMasterAdminUseCase;
+	}
+
+	@GetMapping("/admin/stations/page")
+	String stationsPage(
+		@RequestParam(required = false) String query,
+		Model model
+	) {
+		Map<String, StationMasterDataCounts> counts = transitMasterQueryUseCase.countStationMasterDataByStationId();
+		List<StationRow> stations = transitMasterQueryUseCase.searchStations(new StationSearchCommand(query, null))
+			.stream()
+			.map(station -> StationRow.from(station, counts.getOrDefault(
+				station.station().id(),
+				StationMasterDataCounts.empty()
+			)))
+			.toList();
+		model.addAttribute("stations", stations);
+		model.addAttribute("query", query);
+		return "admin/stations/list";
+	}
+
+	@GetMapping("/admin/stations/{stationId}/page")
+	String stationDetailPage(@PathVariable String stationId, Model model) {
+		StationWithLines station = transitMasterQueryUseCase.getStation(stationId);
+		model.addAttribute("station", StationDetail.from(station));
+		model.addAttribute("exits", transitMasterQueryUseCase.listStationExits(stationId).stream()
+			.map(ExitRow::from)
+			.toList());
+		model.addAttribute("facilities", transitMasterQueryUseCase.listStationFacilities(stationId).stream()
+			.map(FacilityRow::from)
+			.toList());
+		model.addAttribute("layoutSourceCount", transitMasterQueryUseCase.listStationLayoutSources(stationId).size());
+		model.addAttribute("layoutCount", transitMasterQueryUseCase.listSimplifiedStationLayouts(stationId).size());
+		model.addAttribute("routeNodeCount", transitMasterQueryUseCase.listRouteNodes(stationId).size());
+		model.addAttribute("routeEdgeCount", transitMasterQueryUseCase.listRouteEdges(stationId).size());
+		return "admin/stations/detail";
+	}
+
+	@GetMapping("/admin/facilities/editor/page")
+	String facilityEditorPage(
+		@RequestParam(required = false) String stationId,
+		@RequestParam(required = false) String facilityId,
+		Model model
+	) {
+		List<StationWithLines> stations = transitMasterQueryUseCase.searchStations(new StationSearchCommand(null, null));
+		String selectedStationId = stationId == null && !stations.isEmpty() ? stations.getFirst().station().id() : stationId;
+		List<FacilityRow> facilities = selectedStationId == null ? List.of() : transitMasterQueryUseCase
+			.listStationFacilities(selectedStationId)
+			.stream()
+			.map(FacilityRow::from)
+			.toList();
+		FacilityRow selectedFacility = "__new".equals(facilityId) ? null : facilities.stream()
+			.filter(facility -> facility.facilityId().equals(facilityId))
+			.findFirst()
+			.orElse(facilities.isEmpty() ? null : facilities.getFirst());
+		model.addAttribute("stations", stations.stream().map(StationOption::from).toList());
+		model.addAttribute("selectedStationId", selectedStationId);
+		model.addAttribute("facilities", facilities);
+		model.addAttribute("selectedFacility", selectedFacility);
+		model.addAttribute("typeOptions", Arrays.asList(AccessibilityFacilityType.values()));
+		model.addAttribute("statusOptions", Arrays.asList(AccessibilityFacilityStatus.values()));
+		model.addAttribute("confidenceOptions", Arrays.asList(DataConfidenceLevel.values()));
+		model.addAttribute("sourceTypeOptions", Arrays.asList(DataSourceType.values()));
+		return "admin/facilities/editor";
+	}
+
+	@PostMapping("/admin/facilities/editor/page")
+	String saveFacilityFromPage(
+		@RequestParam(required = false) String facilityId,
+		@RequestParam String stationId,
+		@RequestParam(required = false) String exitId,
+		@RequestParam AccessibilityFacilityType type,
+		@RequestParam String name,
+		@RequestParam(required = false) String floorFrom,
+		@RequestParam(required = false) String floorTo,
+		@RequestParam(required = false) BigDecimal latitude,
+		@RequestParam(required = false) BigDecimal longitude,
+		@RequestParam(required = false) String description,
+		@RequestParam AccessibilityFacilityStatus status,
+		@RequestParam DataConfidenceLevel dataConfidence,
+		@RequestParam DataSourceType dataSourceType,
+		Principal principal
+	) {
+		if (facilityId == null || facilityId.isBlank()) {
+			String newFacilityId = "facility-" + stationId + "-" + type.name().toLowerCase() + "-" + System.currentTimeMillis();
+			transitMasterAdminUseCase.createAccessibilityFacility(new CreateAccessibilityFacilityCommand(
+				newFacilityId,
+				stationId,
+				blankToNull(exitId),
+				type,
+				name,
+				blankToNull(floorFrom),
+				blankToNull(floorTo),
+				latitude,
+				longitude,
+				blankToNull(description),
+				status,
+				dataConfidence,
+				dataSourceType,
+				principal.getName()
+			));
+			return "redirect:/admin/facilities/editor/page?stationId=%s&facilityId=%s".formatted(stationId, newFacilityId);
+		}
+		transitMasterAdminUseCase.updateAccessibilityFacility(new UpdateAccessibilityFacilityCommand(
+			facilityId,
+			stationId,
+			blankToNull(exitId),
+			type,
+			name,
+			blankToNull(floorFrom),
+			blankToNull(floorTo),
+			latitude,
+			longitude,
+			blankToNull(description),
+			status,
+			dataConfidence,
+			dataSourceType,
+			principal.getName()
+		));
+		return "redirect:/admin/facilities/editor/page?stationId=%s&facilityId=%s".formatted(stationId, facilityId);
+	}
+
+	private static String qualityLabel(DataQualityLevel level) {
+		return switch (level) {
+			case LEVEL_1 -> "Level 1";
+			case LEVEL_2 -> "Level 2";
+			case LEVEL_3 -> "Level 3";
+			case LEVEL_4 -> "Level 4";
+		};
+	}
+
+	private static String confidenceLabel(DataConfidenceLevel level) {
+		return switch (level) {
+			case HIGH -> "높음";
+			case MEDIUM -> "보통";
+			case LOW -> "낮음";
+			case NEEDS_VERIFICATION -> "확인 필요";
+		};
+	}
+
+	private static String statusLabel(AccessibilityFacilityStatus status) {
+		return FacilityStatusRow.statusLabel(status);
+	}
+
+	record StationRow(
+		String stationId,
+		String stationName,
+		String lineNames,
+		String region,
+		String qualityLabel,
+		String lastVerifiedAt,
+		int exitCount,
+		int facilityCount,
+		int layoutSourceCount,
+		int routeNodeCount,
+		int routeEdgeCount
+	) {
+
+		static StationRow from(StationWithLines stationWithLines, StationMasterDataCounts counts) {
+			return new StationRow(
+				stationWithLines.station().id(),
+				stationWithLines.station().nameKo(),
+				stationWithLines.lines().stream().map(line -> line.name()).reduce((a, b) -> a + ", " + b).orElse("-"),
+				stationWithLines.station().region(),
+				TransitStationAdminPageController.qualityLabel(stationWithLines.station().dataQualityLevel()),
+				String.valueOf(stationWithLines.station().lastVerifiedAt()),
+				counts.exitCount(),
+				counts.facilityCount(),
+				counts.layoutSourceCount(),
+				counts.routeNodeCount(),
+				counts.routeEdgeCount()
+			);
+		}
+	}
+
+	record StationDetail(
+		String stationId,
+		String stationName,
+		String lineNames,
+		String region,
+		String latitude,
+		String longitude,
+		String qualityLabel,
+		String sourceType,
+		String lastVerifiedAt
+	) {
+
+		static StationDetail from(StationWithLines stationWithLines) {
+			return new StationDetail(
+				stationWithLines.station().id(),
+				stationWithLines.station().nameKo(),
+				stationWithLines.lines().stream().map(line -> line.name()).reduce((a, b) -> a + ", " + b).orElse("-"),
+				stationWithLines.station().region(),
+				String.valueOf(stationWithLines.station().latitude()),
+				String.valueOf(stationWithLines.station().longitude()),
+				TransitStationAdminPageController.qualityLabel(stationWithLines.station().dataQualityLevel()),
+				stationWithLines.station().dataSourceType().name(),
+				String.valueOf(stationWithLines.station().lastVerifiedAt())
+			);
+		}
+	}
+
+	record StationOption(String stationId, String stationName) {
+
+		static StationOption from(StationWithLines stationWithLines) {
+			return new StationOption(stationWithLines.station().id(), stationWithLines.station().nameKo());
+		}
+	}
+
+	record ExitRow(String exitNumber, String name, String elevatorLabel, String stairOnlyLabel, String confidenceLabel) {
+
+		static ExitRow from(StationExit exit) {
+			return new ExitRow(
+				exit.exitNumber(),
+				exit.name(),
+				exit.hasElevatorConnection() ? "엘리베이터 연결" : "엘리베이터 미확인",
+				exit.hasStairOnlyPath() ? "계단 전용 경로 있음" : "계단 전용 아님",
+				TransitStationAdminPageController.confidenceLabel(exit.dataConfidence())
+			);
+		}
+	}
+
+	record FacilityRow(
+		String facilityId,
+		String facilityName,
+		AccessibilityFacilityType type,
+		String typeLabel,
+		String exitId,
+		String floorFrom,
+		String floorTo,
+		String floorLabel,
+		AccessibilityFacilityStatus status,
+		String statusLabel,
+		DataConfidenceLevel dataConfidence,
+		String confidenceLabel,
+		DataSourceType dataSourceType,
+		String latitude,
+		String longitude,
+		String lastUpdatedAt,
+		String description
+	) {
+
+		static FacilityRow from(AccessibilityFacility facility) {
+			return new FacilityRow(
+				facility.id(),
+				facility.name(),
+				facility.type(),
+				facility.type().name(),
+				facility.exitId(),
+				facility.floorFrom(),
+				facility.floorTo(),
+				facility.floorFrom() + " → " + facility.floorTo(),
+				facility.status(),
+				TransitStationAdminPageController.statusLabel(facility.status()),
+				facility.dataConfidence(),
+				TransitStationAdminPageController.confidenceLabel(facility.dataConfidence()),
+				facility.dataSourceType(),
+				TransitStationAdminPageController.optionalText(facility.latitude()),
+				TransitStationAdminPageController.optionalText(facility.longitude()),
+				String.valueOf(facility.lastUpdatedAt()),
+				facility.description()
+			);
+		}
+	}
+
+	private static String optionalText(Object value) {
+		return value == null ? "" : String.valueOf(value);
+	}
+
+	private static String blankToNull(String value) {
+		return value == null || value.isBlank() ? null : value;
+	}
+
+	record LayoutSourceRow(String sourceName, String sourceType, String license) {
+
+		static LayoutSourceRow from(StationLayoutSource source) {
+			return new LayoutSourceRow(source.sourceName(), source.sourceType().name(), source.license());
+		}
+	}
+
+	record RouteNodeRow(String nodeName, String nodeType, String floor) {
+
+		static RouteNodeRow from(RouteNode node) {
+			return new RouteNodeRow(node.name(), node.type().name(), node.floor());
+		}
+	}
+
+	record RouteEdgeRow(String edgeName, String edgeType, int confidenceScore) {
+
+		static RouteEdgeRow from(RouteEdge edge) {
+			return new RouteEdgeRow(
+				edge.fromNodeId() + " → " + edge.toNodeId(),
+				edge.type().name(),
+				edge.reliabilityScore()
+			);
+		}
+	}
+}

--- a/backend/src/main/resources/static/css/admin-v3.css
+++ b/backend/src/main/resources/static/css/admin-v3.css
@@ -1,0 +1,369 @@
+* {
+	box-sizing: border-box;
+}
+
+body.admin-v3 {
+	margin: 0;
+	background: #eef3f0;
+	color: #102a2c;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.admin-shell {
+	display: grid;
+	grid-template-columns: 260px minmax(0, 1fr);
+	min-height: 100vh;
+}
+
+.admin-sidebar {
+	position: sticky;
+	top: 0;
+	align-self: start;
+	min-height: 100vh;
+	padding: 20px 16px;
+	background: #0f2730;
+	color: #d8e8e6;
+}
+
+.admin-brand {
+	display: flex;
+	gap: 12px;
+	align-items: center;
+	padding: 6px 6px 20px;
+}
+
+.admin-brand-mark {
+	display: grid;
+	width: 38px;
+	height: 38px;
+	place-items: center;
+	border-radius: 10px;
+	background: #48d6b5;
+	color: #07251f;
+	font-weight: 900;
+}
+
+.admin-brand strong,
+.admin-brand span {
+	display: block;
+}
+
+.admin-brand strong {
+	color: #fff;
+	font-size: 17px;
+	line-height: 1.25;
+}
+
+.admin-brand span {
+	margin-top: 2px;
+	color: #a8c2bf;
+	font-size: 12px;
+	font-weight: 800;
+}
+
+.admin-nav-group {
+	margin-top: 18px;
+}
+
+.admin-nav-group p {
+	margin: 0 0 7px 8px;
+	color: #87a5a1;
+	font-size: 12px;
+	font-weight: 900;
+}
+
+.admin-nav-group a {
+	display: flex;
+	align-items: center;
+	min-height: 39px;
+	padding: 0 11px;
+	border-radius: 8px;
+	color: #d8e8e6;
+	font-size: 14px;
+	font-weight: 800;
+	text-decoration: none;
+}
+
+.admin-nav-group a:hover,
+.admin-nav-group a.is-active {
+	background: #dff7ef;
+	color: #082720;
+}
+
+.admin-main {
+	width: 100%;
+	max-width: none;
+	margin: 0;
+	padding: 28px 30px 48px;
+}
+
+.admin-page-head {
+	display: flex;
+	gap: 16px;
+	align-items: flex-start;
+	justify-content: space-between;
+	margin-bottom: 18px;
+}
+
+.admin-page-head h1 {
+	margin: 0;
+	font-size: 30px;
+	line-height: 1.18;
+	letter-spacing: 0;
+}
+
+.admin-page-head p {
+	margin: 6px 0 0;
+	color: #4a6669;
+	font-size: 15px;
+	font-weight: 750;
+	line-height: 1.45;
+}
+
+.admin-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	justify-content: flex-end;
+}
+
+.admin-btn,
+.admin-v3 button,
+.admin-v3 .detail-link,
+.admin-v3 .tiny-btn,
+.admin-v3 .status-filter a,
+.admin-v3 .pagination a,
+.admin-v3 .pagination span {
+	border-radius: 8px;
+}
+
+.admin-btn,
+.admin-v3 button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 40px;
+	padding: 0 14px;
+	border: 0;
+	background: #0f3f3c;
+	color: #fff;
+	font-size: 14px;
+	font-weight: 900;
+	cursor: pointer;
+	text-decoration: none;
+}
+
+.admin-v3 input,
+.admin-v3 select,
+.admin-v3 textarea {
+	min-height: 40px;
+	padding: 0 11px;
+	border: 1px solid #9fb4b1;
+	border-radius: 8px;
+	background: #fff;
+	color: #102a2c;
+	font: inherit;
+	font-weight: 750;
+}
+
+.admin-v3 textarea {
+	min-height: 92px;
+	padding: 10px 11px;
+}
+
+.admin-card,
+.admin-v3 section,
+.admin-v3 table,
+.admin-v3 .metric,
+.admin-v3 .alert,
+.admin-v3 .empty,
+.admin-v3 .surge-alert,
+.admin-v3 .processing-time {
+	border: 1px solid #d7e2df;
+	border-radius: 10px;
+	background: #fff;
+	box-shadow: 0 14px 34px rgba(22, 55, 59, 0.07);
+}
+
+.admin-v3 table {
+	overflow: hidden;
+}
+
+.admin-v3 th {
+	background: #f3f8f6;
+	color: #244548;
+	font-size: 13px;
+}
+
+.admin-v3 td {
+	color: #18383b;
+}
+
+.admin-v3 .metric-grid {
+	grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+}
+
+.admin-v3 .metric strong {
+	color: #0f3032;
+	font-size: 28px;
+}
+
+.admin-status {
+	display: inline-flex;
+	align-items: center;
+	min-height: 26px;
+	padding: 0 9px;
+	border-radius: 999px;
+	background: #e6f3ff;
+	color: #155070;
+	font-size: 12px;
+	font-weight: 900;
+}
+
+.admin-status.good {
+	background: #ddf7eb;
+	color: #0c6441;
+}
+
+.admin-status.warn {
+	background: #fff2d6;
+	color: #8b5500;
+}
+
+.admin-status.bad {
+	background: #ffe2dc;
+	color: #9d2c1b;
+}
+
+.admin-grid-2 {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(320px, 0.62fr);
+	gap: 14px;
+}
+
+.admin-panel {
+	padding: 18px;
+}
+
+.admin-panel h2 {
+	margin: 0 0 12px;
+	padding: 0;
+	background: transparent;
+	font-size: 18px;
+}
+
+.admin-form {
+	display: grid;
+	gap: 12px;
+}
+
+.admin-form label,
+.admin-panel form label {
+	display: grid;
+	gap: 6px;
+}
+
+.admin-form button {
+	justify-self: start;
+}
+
+.login-screen {
+	display: grid;
+	min-height: 100vh;
+	place-items: center;
+	padding: 32px 18px;
+	background:
+		linear-gradient(135deg, rgba(15, 39, 48, 0.92), rgba(12, 80, 73, 0.88)),
+		#0f2730;
+}
+
+.login-card {
+	width: min(100%, 420px);
+	padding: 28px;
+	border: 1px solid rgba(255, 255, 255, 0.18);
+	border-radius: 14px;
+	background: #fff;
+	box-shadow: 0 22px 70px rgba(0, 0, 0, 0.28);
+}
+
+.login-card .login-brand {
+	padding: 0;
+	color: #102a2c;
+}
+
+.login-card .login-brand strong {
+	color: #102a2c;
+}
+
+.login-card h1 {
+	margin: 24px 0 8px;
+	font-size: 30px;
+	line-height: 1.2;
+}
+
+.login-card p,
+.login-note {
+	color: #4a6669;
+	font-weight: 750;
+	line-height: 1.5;
+}
+
+.login-field {
+	display: grid;
+	gap: 7px;
+	margin-top: 16px;
+}
+
+.login-field label {
+	font-size: 13px;
+	font-weight: 900;
+}
+
+.login-field input,
+.login-submit {
+	width: 100%;
+}
+
+.login-submit {
+	margin-top: 18px;
+}
+
+.login-note {
+	margin-top: 14px;
+	padding: 12px;
+	border-radius: 10px;
+	background: #eef7f4;
+	font-size: 13px;
+}
+
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+@media (max-width: 900px) {
+	.admin-shell {
+		grid-template-columns: 1fr;
+	}
+
+	.admin-sidebar {
+		position: static;
+		min-height: auto;
+	}
+
+	.admin-main {
+		padding: 22px 16px 36px;
+	}
+
+	.admin-grid-2,
+	.admin-page-head {
+		display: block;
+	}
+}

--- a/backend/src/main/resources/templates/admin/collections/list.html
+++ b/backend/src/main/resources/templates/admin/collections/list.html
@@ -93,10 +93,18 @@
 			font-weight: 700;
 		}
 	</style>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
 </head>
-<body>
-<main>
-	<h1>데이터 수집 배치</h1>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-collections')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>데이터 수집</h1>
+			<p>도시철도 마스터 수집을 실행하고 성공·실패·재시도 가능 여부를 확인합니다.</p>
+		</div>
+	</header>
 
 	<form class="run-form" th:action="@{/admin/data-collections/page/run}" method="post">
 		<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
@@ -145,5 +153,6 @@
 		</table>
 	</section>
 </main>
+</div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>통합 대시보드</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-dashboard')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>통합 대시보드</h1>
+			<p>신고·시설·데이터·경로·알림·시스템 이상을 한 화면에 모읍니다.</p>
+		</div>
+		<div class="admin-actions">
+			<a class="admin-btn" th:href="@{/admin/reports/page}">긴급 작업 보기</a>
+		</div>
+	</header>
+
+	<div class="metric-grid">
+		<div class="metric"><span>미검수 제보</span><strong th:text="${dashboard.pendingReports}">0</strong><em th:text="|최근 24시간 ${dashboard.recentReports}건|">최근 24시간 0건</em></div>
+		<div class="metric"><span>확인 필요 시설</span><strong th:text="${dashboard.needsVerificationFacilities}">0</strong><em th:text="|갱신 지연 ${dashboard.delayedFacilities}건|">갱신 지연 0건</em></div>
+		<div class="metric"><span>경로 차단률</span><strong th:text="${dashboard.blockedRate}">0.0%</strong><em th:text="|차단 ${dashboard.blockedRoutes} / 검색 ${dashboard.routeSearches}|">0 / 0</em></div>
+		<div class="metric"><span>서비스 상태</span><strong th:text="${dashboard.healthStatus}">UP</strong><em th:text="${dashboard.serviceName}">easysubway</em></div>
+	</div>
+
+	<div class="admin-grid-2">
+		<section class="admin-panel">
+			<h2>우선 검수 제보</h2>
+			<p class="summary">미검수 제보는 제보 검수 큐에서 상태·사진·위치를 함께 확인합니다.</p>
+			<a class="admin-btn" th:href="@{/admin/reports/page}">제보 검수 큐 열기</a>
+		</section>
+		<section class="admin-panel">
+			<h2>운영 이상 신호</h2>
+			<table>
+				<tbody>
+				<tr><th scope="row">푸시 실패</th><td th:text="${dashboard.failedPushes}">0</td></tr>
+				<tr><th scope="row">7일 활성 사용자</th><td th:text="${dashboard.activeUsers}">0</td></tr>
+				<tr><th scope="row">API 오류율</th><td th:text="${dashboard.apiErrorRate}">0.0%</td></tr>
+				</tbody>
+			</table>
+		</section>
+	</div>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/facilities/editor.html
+++ b/backend/src/main/resources/templates/admin/facilities/editor.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>시설 등록·수정</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-facilities')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>시설 등록·수정</h1>
+			<p>시설 종류, 출구, 층, 좌표, 설명, 상태, 신뢰도, 출처를 확인합니다.</p>
+		</div>
+		<div class="admin-actions">
+			<a class="admin-btn" th:href="@{/admin/facilities/editor/page(stationId=${selectedStationId},facilityId='__new')}">새 시설</a>
+			<a class="admin-btn" th:href="@{/admin/facilities/page}">상태판</a>
+		</div>
+	</header>
+
+	<div class="admin-grid-2">
+		<section class="admin-panel">
+			<h2>역과 시설 선택</h2>
+			<form th:action="@{/admin/facilities/editor/page}" method="get">
+				<label>
+					<span class="meta">역</span>
+					<select name="stationId">
+						<option th:each="station : ${stations}"
+						        th:value="${station.stationId}"
+						        th:selected="${station.stationId == selectedStationId}"
+						        th:text="${station.stationName}">상록수</option>
+					</select>
+				</label>
+				<button type="submit">역 시설 보기</button>
+			</form>
+
+			<table>
+				<thead>
+				<tr>
+					<th scope="col">시설</th>
+					<th scope="col">상태</th>
+					<th scope="col">수정</th>
+				</tr>
+				</thead>
+				<tbody>
+				<tr th:each="facility : ${facilities}">
+					<td th:text="${facility.facilityName}">엘리베이터</td>
+					<td th:text="${facility.statusLabel}">정상</td>
+					<td>
+						<a class="admin-btn"
+						   th:href="@{/admin/facilities/editor/page(stationId=${selectedStationId},facilityId=${facility.facilityId})}">열기</a>
+					</td>
+				</tr>
+				</tbody>
+			</table>
+		</section>
+
+		<section class="admin-panel">
+			<h2 th:text="${selectedFacility == null ? '시설 등록' : '시설 수정'}">시설 수정</h2>
+			<form class="admin-form" th:action="@{/admin/facilities/editor/page}" method="post">
+				<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+				<input type="hidden" name="facilityId" th:value="${selectedFacility == null ? '' : selectedFacility.facilityId}">
+				<label>
+					<span class="meta">역</span>
+					<select name="stationId" required>
+						<option th:each="station : ${stations}"
+						        th:value="${station.stationId}"
+						        th:selected="${station.stationId == selectedStationId}"
+						        th:text="${station.stationName}">상록수</option>
+					</select>
+				</label>
+				<label>
+					<span class="meta">시설 종류</span>
+					<select name="type" required>
+						<option th:each="option : ${typeOptions}"
+						        th:value="${option}"
+						        th:selected="${selectedFacility != null && option == selectedFacility.type}"
+						        th:text="${option}">ELEVATOR</option>
+					</select>
+				</label>
+				<label>
+					<span class="meta">시설명</span>
+					<input name="name" th:value="${selectedFacility == null ? '' : selectedFacility.facilityName}" required>
+				</label>
+				<label>
+					<span class="meta">출구 ID</span>
+					<input name="exitId" th:value="${selectedFacility == null ? '' : selectedFacility.exitId}">
+				</label>
+				<label>
+					<span class="meta">시작 층</span>
+					<input name="floorFrom" th:value="${selectedFacility == null ? '' : selectedFacility.floorFrom}">
+				</label>
+				<label>
+					<span class="meta">도착 층</span>
+					<input name="floorTo" th:value="${selectedFacility == null ? '' : selectedFacility.floorTo}">
+				</label>
+				<label>
+					<span class="meta">위도</span>
+					<input name="latitude" inputmode="decimal" th:value="${selectedFacility == null ? '' : selectedFacility.latitude}">
+				</label>
+				<label>
+					<span class="meta">경도</span>
+					<input name="longitude" inputmode="decimal" th:value="${selectedFacility == null ? '' : selectedFacility.longitude}">
+				</label>
+				<label>
+					<span class="meta">현재 상태</span>
+					<select name="status" required>
+						<option th:each="option : ${statusOptions}"
+						        th:value="${option}"
+						        th:selected="${selectedFacility != null && option == selectedFacility.status}"
+						        th:text="${option}">NORMAL</option>
+					</select>
+				</label>
+				<label>
+					<span class="meta">신뢰도</span>
+					<select name="dataConfidence" required>
+						<option th:each="option : ${confidenceOptions}"
+						        th:value="${option}"
+						        th:selected="${selectedFacility != null && option == selectedFacility.dataConfidence}"
+						        th:text="${option}">HIGH</option>
+					</select>
+				</label>
+				<label>
+					<span class="meta">출처 유형</span>
+					<select name="dataSourceType" required>
+						<option th:each="option : ${sourceTypeOptions}"
+						        th:value="${option}"
+						        th:selected="${selectedFacility != null && option == selectedFacility.dataSourceType}"
+						        th:text="${option}">ADMIN_VERIFIED</option>
+					</select>
+				</label>
+				<label>
+					<span class="meta">사용자 위치 설명</span>
+					<textarea name="description" th:text="${selectedFacility == null ? '' : selectedFacility.description}"></textarea>
+				</label>
+				<button type="submit" th:text="${selectedFacility == null ? '등록' : '저장'}">저장</button>
+			</form>
+		</section>
+	</div>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/facilities/list.html
+++ b/backend/src/main/resources/templates/admin/facilities/list.html
@@ -103,10 +103,21 @@
 			font-weight: 800;
 		}
 	</style>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
 </head>
-<body>
-<main>
-	<h1>시설 상태 관리</h1>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-facilities')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>시설 상태판</h1>
+			<p>모든 접근성 시설의 상태·신뢰도·갱신일을 필터링하고 즉시 변경합니다.</p>
+		</div>
+		<div class="admin-actions">
+			<a class="admin-btn" th:href="@{/admin/facilities/editor/page}">시설 등록·수정</a>
+		</div>
+	</header>
 	<p class="summary">역 상세와 경로 안내에 쓰는 시설 상태를 확인하고 수정합니다.</p>
 
 	<p class="empty" th:if="${facilities.isEmpty()}">등록된 시설이 없습니다.</p>
@@ -155,5 +166,6 @@
 		</tbody>
 	</table>
 </main>
+</div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/admin/field/detail.html
+++ b/backend/src/main/resources/templates/admin/field/detail.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>현장 검증 상세</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-field-verifications')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>현장 검증 상세</h1>
+			<p>
+				<span th:text="${verification.stationName}">상록수</span>
+				<span> · </span>
+				<span th:text="${verification.sessionId}">session-id</span>
+			</p>
+		</div>
+		<div class="admin-actions">
+			<a class="admin-btn" th:href="@{/admin/field-verifications/stations/{stationId}/export.csv(stationId=${verification.stationId})}">CSV 내보내기</a>
+			<a class="admin-btn" th:href="@{/admin/field-verifications/page}">목록</a>
+		</div>
+	</header>
+
+	<div class="metric-grid">
+		<div class="metric"><span>전체 항목</span><strong th:text="${verification.itemCount}">0</strong></div>
+		<div class="metric"><span>확인 완료</span><strong th:text="${verification.verifiedCount}">0</strong></div>
+		<div class="metric"><span>재확인 필요</span><strong th:text="${verification.recheckCount}">0</strong></div>
+		<div class="metric"><span>검증자</span><strong th:text="${verification.verifiedBy}">field-worker</strong></div>
+	</div>
+
+	<div class="admin-grid-2">
+		<section class="admin-panel">
+			<h2>검증 항목</h2>
+			<table>
+				<thead>
+				<tr>
+					<th scope="col">항목</th>
+					<th scope="col">대상</th>
+					<th scope="col">상태</th>
+					<th scope="col">메모</th>
+					<th scope="col">상태 변경</th>
+				</tr>
+				</thead>
+				<tbody>
+				<tr th:each="item : ${items}">
+					<td th:text="${item.typeLabel}">시설</td>
+					<td>
+						<strong th:text="${item.targetName}">엘리베이터</strong>
+						<span class="meta" th:text="${item.itemId}">item-id</span>
+					</td>
+					<td th:text="${item.statusLabel}">검증 완료</td>
+					<td th:text="${item.note}">메모</td>
+					<td>
+						<form th:action="@{/admin/field-verifications/{stationId}/items/{itemId}/page/status(stationId=${verification.stationId},itemId=${item.itemId})}"
+						      method="post">
+							<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+							<label>
+								<span class="meta">검증 상태</span>
+								<select name="status">
+									<option value=""
+									        th:if="${item.status != T(com.easysubway.field.domain.FieldVerificationStatus).VERIFIED && item.status != T(com.easysubway.field.domain.FieldVerificationStatus).NEEDS_RECHECK}"
+									        selected
+									        disabled>변경할 상태 선택</option>
+									<option th:each="status : ${statusOptions}"
+									        th:value="${status}"
+									        th:selected="${status == item.status}"
+									        th:text="${status}">VERIFIED</option>
+								</select>
+							</label>
+							<label>
+								<span class="meta">현장 메모</span>
+								<textarea name="note" th:text="${item.note}">메모</textarea>
+							</label>
+							<button type="submit">상태 저장</button>
+						</form>
+					</td>
+				</tr>
+				</tbody>
+			</table>
+		</section>
+	</div>
+
+	<section>
+		<h2>변경 이력</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">항목</th>
+				<th scope="col">이전</th>
+				<th scope="col">변경</th>
+				<th scope="col">변경자</th>
+				<th scope="col">시각</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${history}">
+				<td th:text="${row.itemId}">item-id</td>
+				<td th:text="${row.previousStatus}">진행 중</td>
+				<td th:text="${row.newStatus}">검증 완료</td>
+				<td th:text="${row.changedBy}">worker</td>
+				<td th:text="${row.changedAt}">2026-06-20</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/field/list.html
+++ b/backend/src/main/resources/templates/admin/field/list.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>현장 검증 목록</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-field-verifications')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>현장 검증 목록</h1>
+			<p>역별 현장 검증 진행률과 재확인 대상을 관리합니다.</p>
+		</div>
+	</header>
+
+	<table>
+		<thead>
+		<tr>
+			<th scope="col">역</th>
+			<th scope="col">검증일</th>
+			<th scope="col">검증자</th>
+			<th scope="col">상태</th>
+			<th scope="col">완료 / 전체</th>
+			<th scope="col">재확인</th>
+			<th scope="col">상세</th>
+		</tr>
+		</thead>
+		<tbody>
+		<tr th:if="${verifications.isEmpty()}">
+			<td colspan="7">현장 검증 세션이 없습니다.</td>
+		</tr>
+		<tr th:each="verification : ${verifications}">
+			<td>
+				<strong th:text="${verification.stationName}">상록수</strong>
+				<span class="meta" th:text="${verification.stationId}">station-id</span>
+			</td>
+			<td th:text="${verification.verifiedAt}">2026-06-20</td>
+			<td th:text="${verification.verifiedBy}">field-worker</td>
+			<td><span class="admin-status" th:text="${verification.statusLabel}">검증 완료</span></td>
+			<td th:text="|${verification.verifiedCount} / ${verification.itemCount}|">0 / 0</td>
+			<td th:text="${verification.recheckCount}">0</td>
+			<td>
+				<a class="admin-btn" th:href="@{/admin/field-verifications/{stationId}/page(stationId=${verification.stationId})}">상세</a>
+			</td>
+		</tr>
+		</tbody>
+	</table>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/fragments/shell.html
+++ b/backend/src/main/resources/templates/admin/fragments/shell.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<body>
+<nav class="admin-sidebar" th:fragment="sidebar(active)" aria-label="통합 관리자 화면">
+	<div class="admin-brand">
+		<div class="admin-brand-mark" aria-hidden="true">길</div>
+		<div>
+			<strong>쉬운 지하철</strong>
+			<span>통합 관리자</span>
+		</div>
+	</div>
+	<div class="admin-nav-group">
+		<p>접속·개요</p>
+		<a th:classappend="${active == 'a-dashboard'} ? ' is-active'" th:href="@{/admin/dashboard/page}">통합 대시보드</a>
+	</div>
+	<div class="admin-nav-group">
+		<p>역·시설 마스터</p>
+		<a th:classappend="${active == 'a-stations'} ? ' is-active'" th:href="@{/admin/stations/page}">역 목록</a>
+		<a th:classappend="${active == 'a-facilities'} ? ' is-active'" th:href="@{/admin/facilities/page}">시설 상태판</a>
+		<a th:classappend="${active == 'a-layout-editor'} ? ' is-active'" th:href="@{/admin/stations/page}">역 구조·동선 편집</a>
+	</div>
+	<div class="admin-nav-group">
+		<p>제보·품질·검증</p>
+		<a th:classappend="${active == 'a-reports'} ? ' is-active'" th:href="@{/admin/reports/page}">제보 검수 큐</a>
+		<a th:classappend="${active == 'a-quality'} ? ' is-active'" th:href="@{/admin/data-quality/page}">데이터 품질</a>
+		<a th:classappend="${active == 'a-field-verifications'} ? ' is-active'" th:href="@{/admin/field-verifications/page}">현장 검증</a>
+	</div>
+	<div class="admin-nav-group">
+		<p>운영·분석</p>
+		<a th:classappend="${active == 'a-collections'} ? ' is-active'" th:href="@{/admin/data-collections/page}">데이터 수집</a>
+		<a th:classappend="${active == 'a-route-searches'} ? ' is-active'" th:href="@{/admin/routes/searches/page}">경로 검색 분석</a>
+		<a th:classappend="${active == 'a-route-feedback'} ? ' is-active'" th:href="@{/admin/routes/feedback/page}">경로 피드백 분석</a>
+		<a th:classappend="${active == 'a-push'} ? ' is-active'" th:href="@{/admin/notifications/push/page}">푸시 알림</a>
+		<a th:classappend="${active == 'a-usage'} ? ' is-active'" th:href="@{/admin/usage/activity/page}">사용 현황</a>
+		<a th:classappend="${active == 'a-system'} ? ' is-active'" th:href="@{/admin/system/page}">시스템 상태</a>
+	</div>
+</nav>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/login.html
+++ b/backend/src/main/resources/templates/admin/login.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>관리자 로그인</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<main class="login-screen">
+	<form class="login-card" method="post" th:action="@{/admin/login}">
+		<div class="admin-brand login-brand">
+			<div class="admin-brand-mark" aria-hidden="true">길</div>
+			<div><strong>쉬운 지하철</strong><span>통합 관리자 콘솔</span></div>
+		</div>
+		<h1>관리자 로그인</h1>
+		<p>역·시설 데이터와 사용자 제보를 안전하게 관리합니다.</p>
+		<input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+		<div class="login-field">
+			<label for="username">아이디</label>
+			<input id="username" name="username" autocomplete="username" required>
+		</div>
+		<div class="login-field">
+			<label for="password">비밀번호</label>
+			<input id="password" name="password" type="password" autocomplete="current-password" required>
+		</div>
+		<button class="login-submit" type="submit">안전하게 로그인</button>
+		<div class="login-note">로그인 실패가 반복되면 15분 동안 접속이 제한됩니다. 계정 공유 없이 개인 계정을 사용해 주세요.</div>
+	</form>
+</main>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/notifications/push.html
+++ b/backend/src/main/resources/templates/admin/notifications/push.html
@@ -124,10 +124,18 @@
 			font-weight: 800;
 		}
 	</style>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
 </head>
-<body>
-<main>
-	<h1>푸시 알림 현황</h1>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-push')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>푸시 알림</h1>
+			<p>발송 성공률·실패 원인을 확인하고 특정 사용자 알림을 생성·전달합니다.</p>
+		</div>
+	</header>
 
 	<div class="metric-grid" aria-label="푸시 알림 outbox 요약">
 		<div class="metric">
@@ -189,5 +197,6 @@
 		</table>
 	</section>
 </main>
+</div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/admin/quality/dashboard.html
+++ b/backend/src/main/resources/templates/admin/quality/dashboard.html
@@ -90,10 +90,18 @@
 			font-weight: 800;
 		}
 	</style>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
 </head>
-<body>
-<main>
-	<h1>데이터 품질 대시보드</h1>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-quality')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>데이터 품질</h1>
+			<p>지역·역·출구·시설 신뢰도와 개선 우선순위를 한눈에 봅니다.</p>
+		</div>
+	</header>
 
 	<div class="metric-grid" aria-label="전체 데이터 품질 요약">
 		<div class="metric">
@@ -326,5 +334,6 @@
 		</table>
 	</section>
 </main>
+</div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -103,11 +103,22 @@
 			background: #8a1d1d;
 		}
 	</style>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
 </head>
-<body>
-<main>
-	<a class="back-link" th:href="@{/admin/reports/page}">목록으로</a>
-	<h1>신고 상세</h1>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-reports')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>제보 상세·판정</h1>
+			<p>사진·위치·설명·중복 후보·감사 이력을 보고 승인·반려·중복 판정합니다.</p>
+		</div>
+		<div class="admin-actions">
+			<a class="admin-btn" th:href="@{/admin/reports/page}">목록으로</a>
+		</div>
+	</header>
+	<h1 class="sr-only">신고 상세</h1>
 
 	<section>
 		<h2>신고 내용</h2>
@@ -201,5 +212,6 @@
 		<button class="secondary" type="submit" name="decision" value="MARK_DUPLICATE">중복 처리</button>
 	</form>
 </main>
+</div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -199,10 +199,18 @@
 			background: #eaf0f0;
 		}
 	</style>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
 </head>
-<body>
-<main>
-	<h1>시설 신고 검수</h1>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-reports')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>시설 신고 검수</h1>
+			<p>상태·사진·위치·접수일 기준으로 제보를 검수 큐에 배치합니다.</p>
+		</div>
+	</header>
 
 	<section class="surge-alert"
 	         th:classappend="${reportSurgeAlert.alertClass}"
@@ -273,5 +281,6 @@
 		   th:href="@{/admin/reports/page(status=${selectedStatus},page=${page.nextPage},size=${page.size})}">다음</a>
 	</nav>
 </main>
+</div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/admin/routes/feedback.html
+++ b/backend/src/main/resources/templates/admin/routes/feedback.html
@@ -93,10 +93,18 @@
 			margin-top: 24px;
 		}
 	</style>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
 </head>
-<body>
-<main>
-	<h1>경로 피드백 현황</h1>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-route-feedback')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>경로 피드백 분석</h1>
+			<p>도움됨·도움 안 됨·현장 차단 피드백과 최근 사례를 분석합니다.</p>
+		</div>
+	</header>
 
 	<div class="metric-grid" aria-label="경로 피드백 요약">
 		<div class="metric">
@@ -162,5 +170,6 @@
 		</table>
 	</section>
 </main>
+</div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/admin/routes/searches.html
+++ b/backend/src/main/resources/templates/admin/routes/searches.html
@@ -131,10 +131,18 @@
 			font-weight: 800;
 		}
 	</style>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
 </head>
-<body>
-<main>
-	<h1>경로 검색 현황</h1>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-route-searches')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>경로 검색 분석</h1>
+			<p>경로 탐색 성공·차단률과 이동 유형·지역·차단 사유를 분석합니다.</p>
+		</div>
+	</header>
 
 	<div class="metric-grid" aria-label="경로 검색 요약">
 		<div class="metric">
@@ -217,5 +225,6 @@
 		</table>
 	</section>
 </main>
+</div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/admin/stations/detail.html
+++ b/backend/src/main/resources/templates/admin/stations/detail.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>역 상세</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-stations')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1 th:text="${station.stationName}">역 상세</h1>
+			<p>
+				<span th:text="${station.stationId}">station-id</span>
+				<span> · </span>
+				<span th:text="${station.region}">수도권</span>
+				<span> · </span>
+				<span th:text="${station.lineNames}">4호선</span>
+			</p>
+		</div>
+		<div class="admin-actions">
+			<a class="admin-btn" th:href="@{/admin/stations/{stationId}/layouts/page(stationId=${station.stationId})}">구조·동선 편집</a>
+			<a class="admin-btn" th:href="@{/admin/stations/page}">역 목록</a>
+		</div>
+	</header>
+
+	<div class="metric-grid">
+		<div class="metric"><span>데이터 품질</span><strong th:text="${station.qualityLabel}">Level 1</strong></div>
+		<div class="metric"><span>접근성 시설</span><strong th:text="${facilities.size()}">0</strong></div>
+		<div class="metric"><span>구조 자료</span><strong th:text="${layoutSourceCount}">0</strong></div>
+		<div class="metric"><span>노드 / 간선</span><strong th:text="|${routeNodeCount} / ${routeEdgeCount}|">0 / 0</strong></div>
+	</div>
+
+	<div class="admin-grid-2">
+		<section class="admin-panel">
+			<h2>역 기본정보</h2>
+			<table>
+				<tbody>
+				<tr><th scope="row">한글 역명</th><td th:text="${station.stationName}">상록수</td></tr>
+				<tr><th scope="row">지역</th><td th:text="${station.region}">수도권</td></tr>
+				<tr><th scope="row">위도</th><td th:text="${station.latitude}">0</td></tr>
+				<tr><th scope="row">경도</th><td th:text="${station.longitude}">0</td></tr>
+				<tr><th scope="row">출처 유형</th><td th:text="${station.sourceType}">OPERATOR</td></tr>
+				<tr><th scope="row">마지막 검증</th><td th:text="${station.lastVerifiedAt}">2026-06-20</td></tr>
+				</tbody>
+			</table>
+		</section>
+
+		<section class="admin-panel">
+			<h2>사용자 화면 미리보기</h2>
+			<p class="summary">현재 시설 상태와 검증일을 사용자가 읽을 수 있는 형태로 확인합니다.</p>
+			<div class="admin-status warn" th:if="${!facilities.isEmpty()}" th:text="|시설 ${facilities.size()}개 연결됨|">시설 0개</div>
+		</section>
+	</div>
+
+	<section>
+		<h2>출구</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">출구</th>
+				<th scope="col">이름</th>
+				<th scope="col">엘리베이터</th>
+				<th scope="col">계단 경로</th>
+				<th scope="col">신뢰도</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="exit : ${exits}">
+				<td th:text="${exit.exitNumber}">1</td>
+				<td th:text="${exit.name}">1번 출구</td>
+				<td th:text="${exit.elevatorLabel}">엘리베이터 연결</td>
+				<td th:text="${exit.stairOnlyLabel}">계단 전용 아님</td>
+				<td th:text="${exit.confidenceLabel}">높음</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>접근성 시설</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">시설</th>
+				<th scope="col">위치</th>
+				<th scope="col">상태</th>
+				<th scope="col">신뢰도</th>
+				<th scope="col">수정</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="facility : ${facilities}">
+				<td>
+					<strong th:text="${facility.facilityName}">엘리베이터</strong>
+					<span class="meta" th:text="${facility.typeLabel}">ELEVATOR</span>
+				</td>
+				<td th:text="${facility.floorLabel}">B1 → 지상</td>
+				<td th:text="${facility.statusLabel}">정상</td>
+				<td th:text="${facility.confidenceLabel}">높음</td>
+				<td>
+					<a class="admin-btn"
+					   th:href="@{/admin/facilities/editor/page(stationId=${station.stationId},facilityId=${facility.facilityId})}">수정</a>
+				</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/stations/layouts.html
+++ b/backend/src/main/resources/templates/admin/stations/layouts.html
@@ -116,14 +116,24 @@
 			font-weight: 800;
 		}
 	</style>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
 </head>
-<body>
-<main>
-	<h1>역 구조도 요약</h1>
-	<p>
-		<span th:text="${station.stationName}">상록수</span>
-		<span class="meta" th:text="${station.lineNames}">수도권 4호선</span>
-	</p>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-layout-editor')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>역 구조·동선 편집</h1>
+			<p>
+				<span th:text="${station.stationName}">상록수</span>
+				<span class="meta" th:text="${station.lineNames}">수도권 4호선</span>
+			</p>
+		</div>
+		<div class="admin-actions">
+			<a class="admin-btn" th:href="@{/admin/stations/{stationId}/page(stationId=${station.stationId})}">역 상세</a>
+		</div>
+	</header>
 
 	<section>
 		<h2>구조도 기준 자료</h2>
@@ -362,5 +372,6 @@
 		</table>
 	</section>
 </main>
+</div>
 </body>
 </html>

--- a/backend/src/main/resources/templates/admin/stations/list.html
+++ b/backend/src/main/resources/templates/admin/stations/list.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>역 목록</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-stations')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>역 목록</h1>
+			<p>역을 검색하고 데이터 품질과 하위 데이터 개수를 비교합니다.</p>
+		</div>
+		<form class="admin-actions" th:action="@{/admin/stations/page}" method="get">
+			<input name="query" th:value="${query}" placeholder="역 이름 검색">
+			<button type="submit">검색</button>
+		</form>
+	</header>
+
+	<table>
+		<thead>
+		<tr>
+			<th scope="col">역</th>
+			<th scope="col">노선</th>
+			<th scope="col">지역</th>
+			<th scope="col">품질</th>
+			<th scope="col">출구 / 시설 / 자료</th>
+			<th scope="col">노드 / 간선</th>
+			<th scope="col">마지막 검증</th>
+			<th scope="col">작업</th>
+		</tr>
+		</thead>
+		<tbody>
+		<tr th:if="${stations.isEmpty()}">
+			<td colspan="8">검색된 역이 없습니다.</td>
+		</tr>
+		<tr th:each="station : ${stations}">
+			<td>
+				<strong th:text="${station.stationName}">상록수</strong>
+				<span class="meta" th:text="${station.stationId}">station-id</span>
+			</td>
+			<td th:text="${station.lineNames}">4호선</td>
+			<td th:text="${station.region}">수도권</td>
+			<td><span class="admin-status" th:text="${station.qualityLabel}">Level 1</span></td>
+			<td th:text="|${station.exitCount} / ${station.facilityCount} / ${station.layoutSourceCount}|">0 / 0 / 0</td>
+			<td th:text="|${station.routeNodeCount} / ${station.routeEdgeCount}|">0 / 0</td>
+			<td th:text="${station.lastVerifiedAt}">2026-06-20</td>
+			<td>
+				<a class="admin-btn" th:href="@{/admin/stations/{stationId}/page(stationId=${station.stationId})}">상세</a>
+			</td>
+		</tr>
+		</tbody>
+	</table>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/system.html
+++ b/backend/src/main/resources/templates/admin/system.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>시스템 상태</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-system')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>시스템 상태</h1>
+			<p>애플리케이션·DB·수집·푸시·데이터 최신성을 한 화면에서 점검합니다.</p>
+		</div>
+	</header>
+
+	<div class="metric-grid">
+		<div class="metric"><span>애플리케이션</span><strong th:text="${health.status}">UP</strong><em th:text="${health.service}">service</em></div>
+		<div class="metric"><span>푸시 대기</span><strong th:text="${push.pendingCount}">0</strong><em th:text="|실패 ${push.failedCount}건|">실패 0건</em></div>
+		<div class="metric"><span>API 요청</span><strong th:text="${usage.totalApiRequests}">0</strong><em th:text="|오류율 ${usage.apiErrorRatePercent()}|">오류율 0.0%</em></div>
+		<div class="metric"><span>평균 응답</span><strong th:text="${usage.averageApiResponseTimeLabel()}">0ms</strong><em>최근 활동 집계 기준</em></div>
+	</div>
+
+	<section>
+		<h2>최근 데이터 수집</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">실행 ID</th>
+				<th scope="col">소스</th>
+				<th scope="col">상태</th>
+				<th scope="col">요청자</th>
+				<th scope="col">시작</th>
+				<th scope="col">완료</th>
+				<th scope="col">수집</th>
+				<th scope="col">실패</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:if="${runs.isEmpty()}">
+				<td colspan="8">최근 데이터 수집 실행이 없습니다.</td>
+			</tr>
+			<tr th:each="run : ${runs}">
+				<td th:text="${run.runId}">run-id</td>
+				<td th:text="${run.source}">TRANSIT_MASTER</td>
+				<td th:text="${run.status}">COMPLETED</td>
+				<td th:text="${run.requestedBy}">admin</td>
+				<td th:text="${run.startedAt}">2026-06-20</td>
+				<td th:text="${run.completedAt}">2026-06-20</td>
+				<td th:text="${run.collectedCount}">0</td>
+				<td th:text="${run.failureMessage ?: '-'}">-</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/usage/activity.html
+++ b/backend/src/main/resources/templates/admin/usage/activity.html
@@ -121,10 +121,18 @@
 			font-weight: 800;
 		}
 	</style>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
 </head>
-<body>
-<main>
-	<h1>사용자 활동 현황</h1>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-usage')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>사용 현황</h1>
+			<p>7일 활성 사용자, API 요청·오류율·응답 시간을 확인합니다.</p>
+		</div>
+	</header>
 
 	<div class="metric-grid" aria-label="사용자 활동 요약">
 		<div class="metric">
@@ -181,5 +189,6 @@
 		</table>
 	</section>
 </main>
+</div>
 </body>
 </html>

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -1,0 +1,186 @@
+package com.easysubway.admin.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayName("통합 관리자 v3 화면")
+class AdminV3PageSmokeTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("관리자는 v3 신규 관리자 화면을 실제 백엔드 모델로 렌더링한다")
+	void adminRendersNewV3Pages() throws Exception {
+		assertPage("/admin/dashboard/page", "통합 대시보드");
+		assertPage("/admin/stations/page", "역 목록");
+		assertPage("/admin/stations/station-sangnoksu/page", "상록수");
+		assertPage("/admin/facilities/editor/page", "시설 등록·수정");
+		assertPage("/admin/field-verifications/page", "현장 검증 목록");
+		assertPage("/admin/field-verifications/station-sangnoksu/page", "현장 검증 상세");
+		assertPage("/admin/system/page", "시스템 상태");
+	}
+
+	@Test
+	@DisplayName("관리자 로그인 화면은 Spring Security form login으로 대시보드에 진입한다")
+	void adminLoginUsesSecurityFormLogin() throws Exception {
+		mockMvc.perform(get("/admin/dashboard/page")
+				.header("Accept", "text/html"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrlPattern("**/admin/login"));
+
+		String html = mockMvc.perform(get("/admin/login"))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("관리자 로그인")
+			.contains("통합 관리자 콘솔")
+			.contains("name=\"username\"")
+			.contains("name=\"password\"");
+
+		mockMvc.perform(post("/admin/login")
+				.with(csrf())
+				.param("username", "admin-user")
+				.param("password", "admin-test-password"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/dashboard/page"));
+	}
+
+	@Test
+	@DisplayName("시설 등록·수정 화면은 실제 마스터 데이터 저장 흐름을 사용한다")
+	void facilityEditorSavesMasterData() throws Exception {
+		mockMvc.perform(post("/admin/facilities/editor/page")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.param("facilityId", "facility-sangnoksu-elevator-1")
+				.param("stationId", "station-sangnoksu")
+				.param("exitId", "exit-sangnoksu-1")
+				.param("type", "ELEVATOR")
+				.param("name", "1번 출구 엘리베이터 QA 수정")
+				.param("floorFrom", "지상")
+				.param("floorTo", "대합실")
+				.param("latitude", "37.302421")
+				.param("longitude", "126.866221")
+				.param("description", "QA 요청으로 관리자 편집 저장을 확인합니다.")
+				.param("status", "ADMIN_VERIFIED")
+				.param("dataConfidence", "HIGH")
+				.param("dataSourceType", "ADMIN_VERIFIED"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/facilities/editor/page?stationId=station-sangnoksu&facilityId=facility-sangnoksu-elevator-1"));
+
+		String updatedHtml = mockMvc.perform(get("/admin/facilities/editor/page")
+				.param("stationId", "station-sangnoksu")
+				.param("facilityId", "facility-sangnoksu-elevator-1")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(updatedHtml)
+			.contains("1번 출구 엘리베이터 QA 수정")
+			.contains("ADMIN_VERIFIED")
+			.contains("QA 요청으로 관리자 편집 저장을 확인합니다.");
+
+		mockMvc.perform(post("/admin/facilities/editor/page")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.param("stationId", "station-sangnoksu")
+				.param("exitId", "exit-sangnoksu-2")
+				.param("type", "RAMP")
+				.param("name", "2번 출구 경사로")
+				.param("floorFrom", "지상")
+				.param("floorTo", "대합실")
+				.param("latitude", "37.302500")
+				.param("longitude", "126.866300")
+				.param("description", "휠체어 이용자가 2번 출구에서 대합실로 이동하는 경로입니다.")
+				.param("status", "NORMAL")
+				.param("dataConfidence", "MEDIUM")
+				.param("dataSourceType", "ADMIN_VERIFIED"))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrlPattern("/admin/facilities/editor/page?stationId=station-sangnoksu&facilityId=facility-station-sangnoksu-ramp-*"));
+
+		String listHtml = mockMvc.perform(get("/admin/facilities/editor/page")
+				.param("stationId", "station-sangnoksu")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(listHtml).contains("2번 출구 경사로");
+	}
+
+	@Test
+	@DisplayName("현장 검증 상세 화면은 각 검증 항목을 개별 저장한다")
+	void fieldVerificationDetailSavesEachItem() throws Exception {
+		String html = mockMvc.perform(get("/admin/field-verifications/station-sangnoksu/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("/admin/field-verifications/station-sangnoksu/items/field-verification-sangnoksu-exit/page/status")
+			.contains("/admin/field-verifications/station-sangnoksu/items/field-verification-sangnoksu-escalator/page/status")
+			.contains("상록수역")
+			.contains("변경할 상태 선택");
+
+		mockMvc.perform(post("/admin/field-verifications/station-sangnoksu/items/field-verification-sangnoksu-escalator/page/status")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.param("status", "NEEDS_RECHECK")
+				.param("note", "에스컬레이터 방향 재확인이 필요합니다."))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(redirectedUrl("/admin/field-verifications/station-sangnoksu/page"));
+
+		String updatedHtml = mockMvc.perform(get("/admin/field-verifications/station-sangnoksu/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(updatedHtml)
+			.contains("재확인 필요")
+			.contains("에스컬레이터 방향 재확인이 필요합니다.");
+	}
+
+	private void assertPage(String path, String expectedText) throws Exception {
+		String html = mockMvc.perform(get(path)
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("통합 관리자")
+			.contains("admin-v3")
+			.contains(expectedText);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #771

## 작업 배경

통합 관리자 v3 시안 기준으로 운영자가 역·시설 마스터, 제보 검수, 품질 검증, 현장 검증, 수집/분석 상태를 한 화면 체계에서 탐색할 수 있어야 합니다. 기존 관리자 화면은 기능별로 흩어져 있어 운영 흐름 전체를 확인하기 어렵고, 로그인/대시보드/역 상세/현장 검증 상세/시스템 상태 화면이 v3 목록 기준으로 부족했습니다.

## 작업 내용

- 관리자 v3 공통 sidebar shell과 `admin-v3.css`를 추가했습니다.
- 관리자 로그인, 통합 대시보드, 시스템 상태 화면을 추가했습니다.
- 역 목록, 역 상세, 시설 등록·수정 화면을 추가하고 실제 `TransitMasterAdminUseCase` 생성·수정 흐름에 연결했습니다.
- 현장 검증 목록과 상세 화면을 추가하고 각 검증 항목별 상태 저장을 실제 `FieldVerificationUseCase`에 연결했습니다.
- 기존 관리자 화면인 제보 검수, 데이터 품질, 데이터 수집, 경로 검색/피드백 분석, 푸시 알림, 사용 현황, 역 구조·동선 편집 화면을 v3 관리자 shell에 통합했습니다.
- 관리자 HTML 보호 경로는 브라우저 요청 시 `/admin/login`으로 이동하고, API/비 HTML 요청은 기존처럼 401을 유지하게 했습니다.

## 검증

- 실행한 명령과 결과:
- `./gradlew test --tests com.easysubway.admin.adapter.in.web.AdminV3PageSmokeTest --no-daemon --max-workers=1`: 통과
- `./gradlew test --no-daemon --max-workers=1`: 통과
- `codex review --base origin/main --title "[Style] 통합 관리자 v3 화면 구성"`: 현장 검증 항목별 저장, 로그인 리다이렉트, 현장 검증 역명 렌더링 지적 확인 후 수정

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 관리자 v3 화면 렌더링 | backend test | `AdminV3PageSmokeTest` | 로컬 테스트 출력 | 로그인, 대시보드, 역/시설, 현장 검증, 시스템 화면 렌더링 통과 |
| 시설 등록·수정 저장 | backend test | `AdminV3PageSmokeTest` | 로컬 테스트 출력 | 기존 시설 수정과 신규 시설 등록 후 조회 통과 |
| 현장 검증 항목 저장 | backend test | `AdminV3PageSmokeTest` | 로컬 테스트 출력 | 두 번째 검증 항목 상태 저장 및 재조회 통과 |
| 전체 회귀 | backend test | `./gradlew test --no-daemon --max-workers=1` | 로컬 테스트 출력 | 전체 backend test 통과 |
| 시각 QA | QA 후속 검증 | 후속 일괄 품질검증 예정 | QA 요청에 따라 이번 PR은 자동/서버 렌더링 검증으로 대체 | 디자인 최종 품질검증은 별도 진행 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `SecurityConfig`의 관리자 로그인 진입 정책, `TransitStationAdminPageController`의 시설 저장 form flow, `FieldVerificationAdminPageController`의 항목별 상태 저장 flow를 먼저 확인해 주세요.

## 리스크

- 기존 관리자 템플릿에 v3 shell을 덧씌우는 방식이라 일부 legacy inline style이 남아 있습니다. v3 전체 시각 QA에서 색상/간격을 한 번에 정리할 수 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
