### PR TITLE
[Style] 역 탐색 화면 v3 디자인 반영

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1043,7 +1043,7 @@ class _HomeScreenState extends State<HomeScreen> {
     super.initState();
     _mobilityType = widget.initialMobilityType;
     _routeDraftController = RouteDraftController();
-    _recentRoutesFuture = widget.recentRoutesFuture;
+    _recentRoutesFuture = _loadRecentRoutes();
     _favoriteFacilitiesFuture = widget.favoriteFacilityRepository
         ?.listFavoriteFacilities();
   }
@@ -1061,8 +1061,9 @@ class _HomeScreenState extends State<HomeScreen> {
         widget.initialMobilityType != oldWidget.initialMobilityType) {
       _mobilityType = widget.initialMobilityType;
     }
-    if (widget.recentRoutesFuture != oldWidget.recentRoutesFuture) {
-      _recentRoutesFuture = widget.recentRoutesFuture;
+    if (widget.recentRoutesFuture != oldWidget.recentRoutesFuture ||
+        widget.favoriteRouteRepository != oldWidget.favoriteRouteRepository) {
+      _recentRoutesFuture = _loadRecentRoutes();
     }
     if (widget.favoriteFacilityRepository !=
         oldWidget.favoriteFacilityRepository) {
@@ -1187,17 +1188,38 @@ class _HomeScreenState extends State<HomeScreen> {
       );
     }
 
+    void openNearbyStations() {
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => StationSearchScreen(
+            repository: repository,
+            reportRepository: reportRepository,
+            favoriteRepository: favoriteRepository,
+            searchHistoryRepository: searchHistoryRepository,
+            locationProvider: locationProvider,
+            facilityReportDraftTargetStore: facilityReportDraftTargetStore,
+            internalRouteRepository: internalRouteRepository,
+            internalRouteMobilityType: initialMobilityType,
+            routeDraftController: _routeDraftController,
+            entryMode: StationSearchEntryMode.nearby,
+          ),
+        ),
+      );
+    }
+
     Future<void> refreshHomeState() async {
-      final facilityRepository = widget.favoriteFacilityRepository;
-      if (facilityRepository == null) {
-        return;
-      }
-      final facilitiesFuture = facilityRepository.listFavoriteFacilities();
+      final facilitiesFuture = widget.favoriteFacilityRepository
+          ?.listFavoriteFacilities();
+      final routesFuture = _loadRecentRoutes();
       setState(() {
         _favoriteFacilitiesFuture = facilitiesFuture;
+        _recentRoutesFuture = routesFuture;
       });
       try {
-        await facilitiesFuture;
+        await Future.wait<void>([
+          if (facilitiesFuture != null) facilitiesFuture.then((_) {}),
+          if (routesFuture != null) routesFuture.then((_) {}),
+        ]);
       } catch (error, stackTrace) {
         (error, stackTrace);
         // FutureBuilder가 오류 상태를 표시하므로 refresh callback은 정상 종료한다.
@@ -1301,7 +1323,7 @@ class _HomeScreenState extends State<HomeScreen> {
               ),
               _HomeStationActionRow(
                 onRecentSearch: openRecentSearch,
-                onStationSearch: openStationSearch,
+                onNearbyStations: openNearbyStations,
               ),
               AnimatedBuilder(
                 animation: _routeDraftController,
@@ -1384,6 +1406,11 @@ class _HomeScreenState extends State<HomeScreen> {
         ],
       ),
     );
+  }
+
+  Future<List<FavoriteRoute>>? _loadRecentRoutes() {
+    return widget.recentRoutesFuture ??
+        widget.favoriteRouteRepository?.listFavoriteRoutes();
   }
 
   Future<MobilityProfileOption?> _openMobilityProfile() async {
@@ -1831,11 +1858,11 @@ class _HomePrototypeHero extends StatelessWidget {
 class _HomeStationActionRow extends StatelessWidget {
   const _HomeStationActionRow({
     required this.onRecentSearch,
-    required this.onStationSearch,
+    required this.onNearbyStations,
   });
 
   final VoidCallback onRecentSearch;
-  final VoidCallback onStationSearch;
+  final VoidCallback onNearbyStations;
 
   @override
   Widget build(BuildContext context) {
@@ -1859,7 +1886,7 @@ class _HomeStationActionRow extends StatelessWidget {
                 key: const Key('nearbyStationButton'),
                 icon: Icons.location_on_outlined,
                 label: '가까운 역',
-                onPressed: onStationSearch,
+                onPressed: onNearbyStations,
               ),
             ),
           ),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1632,6 +1632,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       repository: widget.repository,
       searchHistoryRepository: widget.searchHistoryRepository,
     );
+    _controller.addListener(_handleControllerChanged);
     _queryController.addListener(_handleQueryChanged);
     final lineRepository = _lineFilterRepository;
     if (lineRepository != null) {
@@ -1649,10 +1650,18 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
 
   @override
   void dispose() {
-    _controller.dispose();
+    _controller
+      ..removeListener(_handleControllerChanged)
+      ..dispose();
     _queryController.removeListener(_handleQueryChanged);
     _queryController.dispose();
     super.dispose();
+  }
+
+  void _handleControllerChanged() {
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   void _handleQueryChanged() {
@@ -1669,12 +1678,22 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
 
   bool get _hasSearchQuery => _queryController.text.trim().isNotEmpty;
 
+  bool get _shouldShowNearbyFallbackSearch {
+    return widget.entryMode == StationSearchEntryMode.nearby &&
+        switch (_controller.state.status) {
+          StationSearchStatus.empty || StationSearchStatus.failure => true,
+          _ => false,
+        };
+  }
+
   @override
   Widget build(BuildContext context) {
     final isRecentEntry = widget.entryMode == StationSearchEntryMode.recent;
     final isNearbyEntry = widget.entryMode == StationSearchEntryMode.nearby;
     final showSearchInput =
-        (!isRecentEntry && !isNearbyEntry) || _hasSearchQuery;
+        (!isRecentEntry && !isNearbyEntry) ||
+        _hasSearchQuery ||
+        _shouldShowNearbyFallbackSearch;
     final showNearbyRetryButton = isNearbyEntry && !_hasSearchQuery;
     return Scaffold(
       appBar: AppBar(

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1614,7 +1614,7 @@ class StationSearchScreen extends StatefulWidget {
   State<StationSearchScreen> createState() => _StationSearchScreenState();
 }
 
-enum StationSearchEntryMode { search, recent }
+enum StationSearchEntryMode { search, recent, nearby }
 
 class _StationSearchScreenState extends State<StationSearchScreen> {
   late final StationSearchController _controller;
@@ -1638,6 +1638,13 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       _lineOptionsFuture = lineRepository.listLines();
     }
     unawaited(_loadRecentQueries());
+    if (widget.entryMode == StationSearchEntryMode.nearby) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          unawaited(_searchNearby());
+        }
+      });
+    }
   }
 
   @override
@@ -1665,12 +1672,18 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   @override
   Widget build(BuildContext context) {
     final isRecentEntry = widget.entryMode == StationSearchEntryMode.recent;
-    final showSearchControls = !isRecentEntry || _hasSearchQuery;
+    final isNearbyEntry = widget.entryMode == StationSearchEntryMode.nearby;
+    final showSearchControls =
+        (!isRecentEntry && !isNearbyEntry) || _hasSearchQuery;
     return Scaffold(
       appBar: AppBar(
-        title: Text(isRecentEntry ? '최근 검색' : '역 검색'),
+        title: Text(switch (widget.entryMode) {
+          StationSearchEntryMode.recent => '최근 검색',
+          StationSearchEntryMode.nearby => '가까운 역',
+          StationSearchEntryMode.search => '역 검색',
+        }),
         actions: [
-          if (!isRecentEntry)
+          if (!isRecentEntry && !isNearbyEntry)
             IconButton(
               tooltip: '가까운 역',
               onPressed: _isNearbySearchRunning ? null : _searchNearby,
@@ -1747,7 +1760,9 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
               builder: (context, _) {
                 final isSearching =
                     _controller.state.status == StationSearchStatus.loading;
-                if (_hasSearchQuery || _recentQueries.isEmpty) {
+                if (isNearbyEntry ||
+                    _hasSearchQuery ||
+                    _recentQueries.isEmpty) {
                   return const SizedBox.shrink();
                 }
                 return Padding(
@@ -4293,6 +4308,7 @@ class FacilityDetailScreen extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             Card(
+              key: Key('facilityDetailStatusNotice-${facility.id}'),
               margin: EdgeInsets.zero,
               color: isProblem
                   ? EasySubwayAccessibleColors.redSoft
@@ -4302,10 +4318,46 @@ class FacilityDetailScreen extends StatelessWidget {
                 borderRadius: BorderRadius.circular(16),
               ),
               child: Padding(
-                padding: const EdgeInsets.all(14),
-                child: _StationDetailInfoRow(
-                  icon: isProblem ? Icons.warning_amber : Icons.check_circle,
-                  text: facility.statusLabel,
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Icon(
+                      isProblem ? Icons.warning_amber : Icons.check_circle,
+                      color: isProblem
+                          ? EasySubwayAccessibleColors.red
+                          : EasySubwayAccessibleColors.mint,
+                      size: 28,
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            _facilityStatusTitle(facility),
+                            style: Theme.of(context).textTheme.titleMedium
+                                ?.copyWith(
+                                  color: isProblem
+                                      ? EasySubwayAccessibleColors.red
+                                      : EasySubwayAccessibleColors.text,
+                                  fontWeight: FontWeight.w800,
+                                  height: 1.25,
+                                ),
+                          ),
+                          const SizedBox(height: 3),
+                          Text(
+                            facility.statusLabel,
+                            style: Theme.of(context).textTheme.bodyMedium
+                                ?.copyWith(
+                                  color: EasySubwayAccessibleColors.mutedText,
+                                  fontWeight: FontWeight.w700,
+                                  height: 1.3,
+                                ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),
@@ -4375,6 +4427,10 @@ String _facilityFloorLabel(StationFacilityInfo facility) {
     return '연결 층 ${from.isEmpty ? to : from}';
   }
   return '연결 층 $from ↔ $to';
+}
+
+String _facilityStatusTitle(StationFacilityInfo facility) {
+  return facility.needsAttention ? '현재 이용이 어려울 수 있어요' : '이용 가능해요';
 }
 
 class _StationDetailStatusPill extends StatelessWidget {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1673,8 +1673,9 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   Widget build(BuildContext context) {
     final isRecentEntry = widget.entryMode == StationSearchEntryMode.recent;
     final isNearbyEntry = widget.entryMode == StationSearchEntryMode.nearby;
-    final showSearchControls =
+    final showSearchInput =
         (!isRecentEntry && !isNearbyEntry) || _hasSearchQuery;
+    final showNearbyRetryButton = isNearbyEntry && !_hasSearchQuery;
     return Scaffold(
       appBar: AppBar(
         title: Text(switch (widget.entryMode) {
@@ -1695,7 +1696,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
           children: [
-            if (showSearchControls) ...[
+            if (showSearchInput) ...[
               TextField(
                 key: const Key('stationSearchInput'),
                 controller: _queryController,
@@ -1739,7 +1740,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
               ),
               const SizedBox(height: 12),
             ],
-            if (showSearchControls && _lineOptionsFuture != null) ...[
+            if (showSearchInput && _lineOptionsFuture != null) ...[
               AnimatedBuilder(
                 animation: _controller,
                 builder: (context, _) {
@@ -1775,7 +1776,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
                 );
               },
             ),
-            if (showSearchControls) ...[
+            if (showSearchInput || showNearbyRetryButton) ...[
               AnimatedBuilder(
                 animation: _controller,
                 builder: (context, _) {
@@ -1783,6 +1784,14 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
                       _controller.state.status == StationSearchStatus.loading;
                   final isNearbyDisabled =
                       isSearching || _isNearbySearchRunning;
+                  if (showNearbyRetryButton) {
+                    return OutlinedButton.icon(
+                      key: const Key('nearbyStationSearchButton'),
+                      onPressed: isNearbyDisabled ? null : _searchNearby,
+                      icon: const Icon(Icons.my_location),
+                      label: const Text('내 주변 역 다시 찾기'),
+                    );
+                  }
                   if (_hasSearchQuery) {
                     return FilledButton.icon(
                       key: const Key('stationSearchSubmitButton'),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -868,6 +868,49 @@ void main() {
     expect(locationProvider.requestCount, 0);
   });
 
+  testWidgets('가까운 역 화면은 위치 실패 후 역명 검색 입력을 보여준다', (tester) async {
+    final locationProvider = FakeCurrentLocationProvider(
+      error: const CurrentLocationException('현재 위치를 확인하지 못했습니다.'),
+      needsPermissionRequest: false,
+    );
+    final repository = FakeStationSearchRepository(
+      queryResults: {
+        '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      },
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        locationProvider: locationProvider,
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('현재 위치를 확인하지 못했습니다.'), findsOneWidget);
+    expect(find.byKey(const Key('stationSearchInput')), findsOneWidget);
+    expect(find.byKey(const Key('nearbyStationSearchButton')), findsOneWidget);
+    expect(find.byKey(const Key('stationRecentSearchSection')), findsNothing);
+
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(repository.requestedQueries, contains('상록수'));
+    expect(find.text('상록수역'), findsOneWidget);
+  });
+
   testWidgets('홈 이동 조건 pill은 모든 이동 유형에 맞는 아이콘을 보여준다', (tester) async {
     for (final option in mobilityProfileOptions) {
       await tester.pumpWidget(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -319,14 +319,16 @@ void main() {
   });
 
   testWidgets('홈 최근 경로는 저장소 데이터가 있으면 표시된다', (tester) async {
+    final favoriteRouteRepository = FakeFavoriteRouteRepository(
+      favorites: [_favoriteRoute()],
+    );
+
     await tester.pumpWidget(
       EasySubwayApp(
         repository: FakeStationSearchRepository(),
         reportRepository: FakeFacilityReportRepository(),
         routeRepository: FakeRouteSearchRepository(),
-        favoriteRouteRepository: FakeFavoriteRouteRepository(
-          favorites: [_favoriteRoute()],
-        ),
+        favoriteRouteRepository: favoriteRouteRepository,
         notificationRepository: FakeNotificationSettingsRepository(),
         initialOnboardingState: _completedOnboardingState(),
       ),
@@ -344,6 +346,7 @@ void main() {
     expect(find.byKey(const Key('homeRecentRouteCard')), findsOneWidget);
     expect(find.text('상록수역'), findsOneWidget);
     expect(find.text('사당역'), findsOneWidget);
+    expect(favoriteRouteRepository.listCount, greaterThanOrEqualTo(1));
   });
 
   testWidgets('온보딩 이동 조건은 경로 검색 기본값으로 이어진다', (tester) async {
@@ -819,10 +822,50 @@ void main() {
     );
     expect(locationProvider.requestCount, 1);
     expect(repository.requestedNearbyLocations, hasLength(1));
+    final requested = repository.requestedNearbyLocations.single;
+    expect(requested.latitude, closeTo(37.3028, 0.0001));
+    expect(requested.longitude, closeTo(126.8665, 0.0001));
     expect(find.text('가장 가까운 역'), findsOneWidget);
     expect(find.text('상록수역'), findsOneWidget);
     expect(find.text('현재 위치 기준 230m · 수도권 2호선'), findsOneWidget);
     expect(find.byKey(const Key('stationSearchInput')), findsNothing);
+    expect(find.byKey(const Key('stationRecentSearchSection')), findsNothing);
+  });
+
+  testWidgets('가까운 역 화면은 위치 권한 안내 취소 후 재시도 버튼을 유지한다', (tester) async {
+    final locationProvider = FakeCurrentLocationProvider(
+      location: _freshCurrentLocation(),
+      needsPermissionRequest: true,
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        locationProvider: locationProvider,
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, '취소'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.descendant(of: find.byType(AppBar), matching: find.text('가까운 역')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('stationSearchInput')), findsNothing);
+    expect(find.byKey(const Key('nearbyStationSearchButton')), findsOneWidget);
+    expect(find.text('내 주변 역 다시 찾기'), findsOneWidget);
+    expect(locationProvider.requestCount, 0);
   });
 
   testWidgets('홈 이동 조건 pill은 모든 이동 유형에 맞는 아이콘을 보여준다', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -318,6 +318,34 @@ void main() {
     expect(find.text('저장한 경로가 없습니다'), findsNothing);
   });
 
+  testWidgets('홈 최근 경로는 저장소 데이터가 있으면 표시된다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(
+          favorites: [_favoriteRoute()],
+        ),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.text('최근 경로'),
+      find.byKey(const Key('homePrototypeList')),
+      const Offset(0, -160),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('최근 경로'), findsOneWidget);
+    expect(find.byKey(const Key('homeRecentRouteCard')), findsOneWidget);
+    expect(find.text('상록수역'), findsOneWidget);
+    expect(find.text('사당역'), findsOneWidget);
+  });
+
   testWidgets('온보딩 이동 조건은 경로 검색 기본값으로 이어진다', (tester) async {
     final stationRepository = FakeStationSearchRepository(
       queryResults: {
@@ -752,6 +780,51 @@ void main() {
     expect(find.byKey(const Key('homeSavedItemsCard')), findsNothing);
   });
 
+  testWidgets('홈 가까운 역은 실제 주변 역 검색 화면으로 바로 연결된다', (tester) async {
+    final locationProvider = FakeCurrentLocationProvider(
+      location: _freshCurrentLocation(),
+      needsPermissionRequest: false,
+    );
+    final repository = FakeStationSearchRepository(
+      nearbyResults: [
+        _stationResult(
+          id: 'station-sangnoksu',
+          name: '상록수',
+          distanceMeters: 230,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        locationProvider: locationProvider,
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.descendant(of: find.byType(AppBar), matching: find.text('가까운 역')),
+      findsOneWidget,
+    );
+    expect(locationProvider.requestCount, 1);
+    expect(repository.requestedNearbyLocations, hasLength(1));
+    expect(find.text('가장 가까운 역'), findsOneWidget);
+    expect(find.text('상록수역'), findsOneWidget);
+    expect(find.text('현재 위치 기준 230m · 수도권 2호선'), findsOneWidget);
+    expect(find.byKey(const Key('stationSearchInput')), findsNothing);
+  });
+
   testWidgets('홈 이동 조건 pill은 모든 이동 유형에 맞는 아이콘을 보여준다', (tester) async {
     for (final option in mobilityProfileOptions) {
       await tester.pumpWidget(
@@ -832,7 +905,7 @@ void main() {
     );
   });
 
-  testWidgets('홈은 저장한 경로가 있어도 즐겨찾기 카드처럼 보여주지 않는다', (tester) async {
+  testWidgets('홈은 저장한 경로를 최근 경로로 보여주되 즐겨찾기 카드처럼 보여주지 않는다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
 
     try {
@@ -852,7 +925,7 @@ void main() {
       expect(find.text('상록수역 → 사당역'), findsNothing);
       expect(
         find.bySemanticsLabel(RegExp('최근 경로, 상록수역에서 사당역까지')),
-        findsNothing,
+        findsOneWidget,
       );
       expect(find.text('저장한 경로가 없습니다'), findsNothing);
     } finally {
@@ -3207,6 +3280,93 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('시설 상세는 실제 시설 데이터로 위치 상태 제보 진입을 보여준다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+    final repository = FakeStationSearchRepository(
+      nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      stationFacilities: const [
+        StationFacilityInfo(
+          id: 'facility-sangnoksu-elevator-2',
+          stationId: 'station-sangnoksu',
+          exitId: 'exit-sangnoksu-2',
+          type: 'ELEVATOR',
+          name: '2번 출구 엘리베이터',
+          floorFrom: 'B1',
+          floorTo: '1F',
+          description: '2번 출구 앞',
+          status: 'BROKEN',
+          dataConfidence: 'HIGH',
+          dataSourceType: 'OFFICIAL_FILE',
+          lastUpdatedAt: '2026-06-14',
+          fieldValidationStatus: 'VERIFIED',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: reportRepository,
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        locationProvider: FakeCurrentLocationProvider(
+          location: _freshCurrentLocation(),
+          needsPermissionRequest: false,
+        ),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(
+        const Key('stationFacilityCard-facility-sangnoksu-elevator-2'),
+      ),
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(
+        const Key('stationFacilityCard-facility-sangnoksu-elevator-2'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.descendant(of: find.byType(AppBar), matching: find.text('시설 상세')),
+      findsOneWidget,
+    );
+    expect(find.text('상록수역'), findsOneWidget);
+    expect(find.text('2번 출구 엘리베이터'), findsOneWidget);
+    expect(find.text('현재 이용이 어려울 수 있어요'), findsOneWidget);
+    expect(find.text('고장'), findsOneWidget);
+    expect(find.text('연결 층 B1 ↔ 1F'), findsOneWidget);
+    expect(find.text('2번 출구 앞'), findsOneWidget);
+    expect(find.text('최근 확인 2026-06-14'), findsOneWidget);
+    expect(find.text('정보 신뢰도 높음 · 출처 공식 파일'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(
+        const Key('facilityDetailReportButton-facility-sangnoksu-elevator-2'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('시설 신고'), findsOneWidget);
+    expect(find.text('2번 출구 엘리베이터'), findsOneWidget);
   });
 
   testWidgets('역 상세에서 연 시설 신고는 앱에 주입한 사진 복구 대상을 저장한다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

close #773

## 작업 배경

홈·역 탐색 흐름에서 최근 검색, 가까운 역, 역 상세, 시설 상세 진입이 v3 화면 기준과 맞지 않는 부분을 정리했습니다. 가짜 최근 경로는 표시하지 않되, 실제 저장된 경로 데이터가 있으면 홈의 최근 경로 카드가 유지되어야 합니다.

## 작업 내용

- 홈의 가까운 역 버튼을 실제 현재 위치 기반 주변 역 검색 화면으로 연결했습니다.
- 홈 최근 경로를 명시 future가 없을 때도 실제 저장 경로 저장소에서 불러오도록 복구했습니다.
- 주변 역 진입 모드는 검색 입력과 최근 검색 칩을 숨기고, 진입 즉시 가까운 역 조회를 실행하도록 분리했습니다.
- 시설 상세 상태 영역을 실제 시설 상태 데이터 기반 안내와 제보 진입 흐름으로 정리했습니다.
- 최근 경로, 가까운 역, 시설 상세 흐름의 위젯 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `flutter analyze --no-pub`: No issues found
- `flutter test --no-pub`: 380 tests passed
- `node --test tools/ci/*.test.mjs`: 102 tests passed
- `git diff --check origin/main`: 문제 없음
- 보안 diff 확인: 새 외부 URL, 인증 토큰 처리, 파일 실행/쓰기, 임의 process 실행 추가 없음. 기존 위치 provider와 저장소 조회를 화면 진입에 연결한 변경입니다.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 홈 최근 경로 데이터 표시 | Flutter widget test | `flutter test --no-pub test/widget_test.dart --plain-name 홈 최근 경로는 저장소 데이터가 있으면 표시된다` | 테스트 출력: All tests passed | 실제 저장소 데이터가 있을 때 최근 경로 카드 표시 |
| 홈 가까운 역 진입 | Flutter widget test | `flutter test --no-pub test/widget_test.dart --plain-name 홈 가까운 역은 실제 주변 역 검색 화면으로 바로 연결된다` | 테스트 출력: All tests passed | 가까운 역 화면 진입과 위치 기반 조회 확인 |
| 시설 상세 상태/제보 | Flutter widget test | `flutter test --no-pub test/widget_test.dart --plain-name 시설 상세는 실제 시설 데이터로 위치 상태 제보 진입을 보여준다` | 테스트 출력: All tests passed | 실제 시설 상태와 시설 신고 진입 확인 |
| 전체 모바일 회귀 | Flutter test | `flutter test --no-pub` | 테스트 출력: 380 tests passed | 전체 모바일 테스트 통과 |
| 정적 분석 | Flutter analyze | `flutter analyze --no-pub` | 명령 출력: No issues found | 분석 통과 |
| 저장소 계약 | Node test | `node --test tools/ci/*.test.mjs` | 명령 출력: 102 tests passed | 저장소 계약 테스트 통과 |
| 화면 캡처 | Android emulator | 사용자 요청으로 이번 작업에서는 에뮬레이터 캡처를 스킵 | 스크린샷 없음 | 추후 묶음 확인 예정 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 홈 최근 경로가 실제 저장소 데이터가 있을 때만 보이고, 가까운 역 버튼이 검색 화면 재사용이 아니라 주변 역 진입 모드로 동작하는지 확인해 주세요.

## 리스크

- 최근 경로는 현재 저장된 경로 저장소 데이터를 사용합니다. 별도 최근 경로 전용 저장소가 추가되면 소스 분리가 필요합니다.
- 에뮬레이터 시각 증거는 사용자 요청으로 이번 PR에는 첨부하지 않았습니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 홈 화면에 "가까운 역" 검색 기능 추가
  * 최근 경로 로딩 방식 개선 및 자동 갱신

* **Bug Fixes**
  * 시설 상태 정보 카드 표시 개선 및 안내 문구 최적화

* **Tests**
  * 홈 화면 및 역 검색 UI 흐름 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->