### PR TITLE
[Style] 역 탐색 화면 v3 디자인 정리

### DIFF
--- a/apps/mobile/lib/internal_route.dart
+++ b/apps/mobile/lib/internal_route.dart
@@ -322,7 +322,7 @@ class InternalRouteResult {
 
   String get semanticLabel {
     final parts = <String>[
-      '내부 이동 안내',
+      '역 안 이동 순서',
       statusLabel,
       summaryLabel,
       totalBurdenLabel,

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2369,7 +2369,7 @@ class _NearbyStationOverview extends StatelessWidget {
           Semantics(
             container: true,
             button: true,
-            label: '가장 가까운 역, $stationName, ${result.distanceLabel}',
+            label: '가장 가까운 역, ${_stationResultSemanticLabel(result)}',
             onTap: onTap,
             child: ExcludeSemantics(
               child: InkWell(

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2301,20 +2301,28 @@ class _StationSearchBody extends StatelessWidget {
             child: const SizedBox(width: 1, height: 1),
           ),
           if (state.source == StationSearchResultSource.nearby) ...[
-            _NearbyStationOverview(
-              result: state.results.first,
-              onTap: () => onResultTap(state.results.first),
-              onSetOrigin: onSetOrigin == null
-                  ? null
-                  : () => onSetOrigin!(state.results.first),
-              onSetDestination: onSetDestination == null
-                  ? null
-                  : () => onSetDestination!(state.results.first),
-            ),
-            if (state.results.length > 1) ...[
-              const SizedBox(height: 18),
-              const _StationDetailSectionTitle(title: '다른 주변 역'),
-              const SizedBox(height: 12),
+            if (state.results.isEmpty)
+              _StationSearchFailureMessage(
+                message: '주변 역을 찾지 못했습니다.',
+                isOpeningLocationSettings: isOpeningLocationSettings,
+                onOpenLocationSettings: onOpenLocationSettings,
+              )
+            else ...[
+              _NearbyStationOverview(
+                result: state.results.first,
+                onTap: () => onResultTap(state.results.first),
+                onSetOrigin: onSetOrigin == null
+                    ? null
+                    : () => onSetOrigin!(state.results.first),
+                onSetDestination: onSetDestination == null
+                    ? null
+                    : () => onSetDestination!(state.results.first),
+              ),
+              if (state.results.length > 1) ...[
+                const SizedBox(height: 18),
+                const _StationDetailSectionTitle(title: '다른 주변 역'),
+                const SizedBox(height: 12),
+              ],
             ],
           ] else ...[
             const _StationDetailSectionTitle(title: '검색 결과'),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2301,15 +2301,23 @@ class _StationSearchBody extends StatelessWidget {
             child: const SizedBox(width: 1, height: 1),
           ),
           if (state.source == StationSearchResultSource.nearby) ...[
-            _NearbyStationOverview(result: state.results.first),
-            const SizedBox(height: 18),
-            const _StationDetailSectionTitle(title: '주변 역 목록'),
-            const SizedBox(height: 12),
+            _NearbyStationOverview(
+              result: state.results.first,
+              onTap: () => onResultTap(state.results.first),
+            ),
+            if (state.results.length > 1) ...[
+              const SizedBox(height: 18),
+              const _StationDetailSectionTitle(title: '다른 주변 역'),
+              const SizedBox(height: 12),
+            ],
           ] else ...[
             const _StationDetailSectionTitle(title: '검색 결과'),
             const SizedBox(height: 12),
           ],
-          for (final result in state.results)
+          for (final result
+              in state.source == StationSearchResultSource.nearby
+                  ? state.results.skip(1)
+                  : state.results)
             _StationSearchResultTile(
               result: result,
               onTap: () => onResultTap(result),
@@ -2327,120 +2335,89 @@ class _StationSearchBody extends StatelessWidget {
 }
 
 class _NearbyStationOverview extends StatelessWidget {
-  const _NearbyStationOverview({required this.result});
+  const _NearbyStationOverview({required this.result, required this.onTap});
 
   final StationSearchResult result;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final stationName = _stationResultDisplayName(result.nameKo);
     return Semantics(
       container: true,
+      button: true,
       label: '가장 가까운 역, $stationName, ${result.distanceLabel}',
+      onTap: onTap,
       child: ExcludeSemantics(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            SegmentedButton<String>(
-              segments: const [
-                ButtonSegment(value: 'map', label: Text('지도')),
-                ButtonSegment(value: 'list', label: Text('목록')),
-              ],
-              selected: const {'map'},
-              onSelectionChanged: (_) {},
-            ),
-            const SizedBox(height: 12),
-            Card(
-              margin: EdgeInsets.zero,
-              color: const Color(0xFFEAF3F5),
-              elevation: 0,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(18),
-                side: const BorderSide(color: EasySubwayAccessibleColors.line),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 16, 16, 14),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
+        child: Card(
+          margin: EdgeInsets.zero,
+          color: EasySubwayAccessibleColors.skySoft,
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(18),
+            side: const BorderSide(color: EasySubwayAccessibleColors.line),
+          ),
+          child: InkWell(
+            key: const Key('nearbyStationPrimaryCard'),
+            borderRadius: BorderRadius.circular(18),
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        const CircleAvatar(
-                          radius: 9,
-                          backgroundColor: EasySubwayAccessibleColors.red,
-                        ),
-                        const SizedBox(width: 8),
                         Text(
-                          '지도와 목록으로 주변 역을 확인합니다',
+                          '가장 가까운 역',
                           style: Theme.of(context).textTheme.bodyMedium
                               ?.copyWith(
                                 color: EasySubwayAccessibleColors.mutedText,
-                                fontWeight: FontWeight.w700,
+                                fontWeight: FontWeight.w800,
+                                height: 1.25,
                               ),
+                        ),
+                        const SizedBox(height: 5),
+                        Text(
+                          stationName,
+                          style: Theme.of(context).textTheme.headlineSmall
+                              ?.copyWith(
+                                color: EasySubwayAccessibleColors.text,
+                                fontWeight: FontWeight.w800,
+                                height: 1.2,
+                              ),
+                        ),
+                        const SizedBox(height: 6),
+                        Text(
+                          result.distanceLabel.isEmpty
+                              ? result.lineLabel
+                              : '${result.distanceLabel} · ${result.lineLabel}',
+                          style: Theme.of(context).textTheme.bodyLarge
+                              ?.copyWith(
+                                color: EasySubwayAccessibleColors.mutedText,
+                                fontWeight: FontWeight.w700,
+                                height: 1.3,
+                              ),
+                        ),
+                        const SizedBox(height: 8),
+                        _StationDetailTextPill(
+                          text:
+                              '${result.dataQualityLabel} · ${result.dataSourceLabel}',
                         ),
                       ],
                     ),
-                    const SizedBox(height: 34),
-                    Card(
-                      margin: EdgeInsets.zero,
-                      color: Colors.white,
-                      elevation: 0,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(16),
-                        side: const BorderSide(
-                          color: EasySubwayAccessibleColors.line,
-                        ),
-                      ),
-                      child: Padding(
-                        padding: const EdgeInsets.all(14),
-                        child: Row(
-                          children: [
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    '가장 가까운 역',
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .titleLarge
-                                        ?.copyWith(
-                                          color:
-                                              EasySubwayAccessibleColors.text,
-                                          fontWeight: FontWeight.w700,
-                                        ),
-                                  ),
-                                  const SizedBox(height: 4),
-                                  Text(
-                                    result.distanceLabel.isEmpty
-                                        ? '가까운 역 후보'
-                                        : '가까운 역 후보 · ${result.distanceLabel}',
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .bodyMedium
-                                        ?.copyWith(
-                                          color: EasySubwayAccessibleColors
-                                              .mutedText,
-                                          fontWeight: FontWeight.w600,
-                                        ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                            StationLineBadges(
-                              lines: result.lines,
-                              size: 34,
-                              maxBadgeCount: 1,
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
+                  ),
+                  const SizedBox(width: 12),
+                  StationLineBadges(
+                    lines: result.lines,
+                    size: 38,
+                    maxBadgeCount: 1,
+                  ),
+                ],
               ),
             ),
-          ],
+          ),
         ),
       ),
     );
@@ -3265,7 +3242,7 @@ class _StationDetailContent extends StatelessWidget {
           const SizedBox(height: 24),
         ],
         if (internalRouteState != null) ...[
-          const _StationDetailSectionTitle(title: '내부 이동 안내'),
+          const _StationDetailSectionTitle(title: '역 안 이동 순서'),
           const SizedBox(height: 12),
           _StationInternalRouteGuidance(state: internalRouteState!),
           const SizedBox(height: 24),
@@ -3287,21 +3264,13 @@ class _StationDetailContent extends StatelessWidget {
         const SizedBox(height: 12),
         if (facilities.isEmpty)
           const _StationDetailEmptyMessage(message: '시설 정보가 아직 없습니다.')
-        else ...[
-          if (facilityAttentionSummary.isNotEmpty) ...[
-            _StationFacilityStatusSummary(
-              text: facilityAttentionSummary,
-              semanticLabel: facilityAttentionSemanticLabel,
-            ),
-            const SizedBox(height: 12),
-          ],
+        else
           for (final facility in facilities)
             _StationFacilityCard(
               facility: facility,
               station: detail,
               onReportTap: () => _openFacilityReport(context, facility),
             ),
-        ],
       ],
     );
   }
@@ -3864,11 +3833,11 @@ class _StationInternalRouteGuidance extends StatelessWidget {
   Widget build(BuildContext context) {
     return switch (state.status) {
       InternalRouteViewStatus.loading => Semantics(
-        label: '내부 이동 안내 불러오는 중',
+        label: '역 안 이동 순서 불러오는 중',
         liveRegion: true,
         child: const _StationDetailInfoRow(
           icon: Icons.sync,
-          text: '내부 이동 안내를 불러오는 중입니다.',
+          text: '역 안 이동 순서를 불러오는 중입니다.',
         ),
       ),
       InternalRouteViewStatus.failure => Semantics(
@@ -4449,12 +4418,12 @@ String _facilityFloorLabel(StationFacilityInfo facility) {
   final from = facility.floorFrom.trim();
   final to = facility.floorTo.trim();
   if (from.isEmpty && to.isEmpty) {
-    return '연결 층 확인 필요';
+    return '연결 위치 확인 필요';
   }
   if (from.isEmpty || to.isEmpty) {
-    return '연결 층 ${from.isEmpty ? to : from}';
+    return '연결 위치 ${from.isEmpty ? to : from}';
   }
-  return '연결 층 $from ↔ $to';
+  return '연결 위치 $from ↔ $to';
 }
 
 String _facilityStatusTitle(StationFacilityInfo facility) {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2304,6 +2304,12 @@ class _StationSearchBody extends StatelessWidget {
             _NearbyStationOverview(
               result: state.results.first,
               onTap: () => onResultTap(state.results.first),
+              onSetOrigin: onSetOrigin == null
+                  ? null
+                  : () => onSetOrigin!(state.results.first),
+              onSetDestination: onSetDestination == null
+                  ? null
+                  : () => onSetDestination!(state.results.first),
             ),
             if (state.results.length > 1) ...[
               const SizedBox(height: 18),
@@ -2335,90 +2341,108 @@ class _StationSearchBody extends StatelessWidget {
 }
 
 class _NearbyStationOverview extends StatelessWidget {
-  const _NearbyStationOverview({required this.result, required this.onTap});
+  const _NearbyStationOverview({
+    required this.result,
+    required this.onTap,
+    this.onSetOrigin,
+    this.onSetDestination,
+  });
 
   final StationSearchResult result;
   final VoidCallback onTap;
+  final VoidCallback? onSetOrigin;
+  final VoidCallback? onSetDestination;
 
   @override
   Widget build(BuildContext context) {
     final stationName = _stationResultDisplayName(result.nameKo);
-    return Semantics(
-      container: true,
-      button: true,
-      label: '가장 가까운 역, $stationName, ${result.distanceLabel}',
-      onTap: onTap,
-      child: ExcludeSemantics(
-        child: Card(
-          margin: EdgeInsets.zero,
-          color: EasySubwayAccessibleColors.skySoft,
-          elevation: 0,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(18),
-            side: const BorderSide(color: EasySubwayAccessibleColors.line),
-          ),
-          child: InkWell(
-            key: const Key('nearbyStationPrimaryCard'),
-            borderRadius: BorderRadius.circular(18),
+    return Card(
+      margin: EdgeInsets.zero,
+      color: EasySubwayAccessibleColors.skySoft,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(18),
+        side: const BorderSide(color: EasySubwayAccessibleColors.line),
+      ),
+      child: Column(
+        children: [
+          Semantics(
+            container: true,
+            button: true,
+            label: '가장 가까운 역, $stationName, ${result.distanceLabel}',
             onTap: onTap,
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          '가장 가까운 역',
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(
-                                color: EasySubwayAccessibleColors.mutedText,
-                                fontWeight: FontWeight.w800,
-                                height: 1.25,
-                              ),
+            child: ExcludeSemantics(
+              child: InkWell(
+                key: const Key('nearbyStationPrimaryCard'),
+                borderRadius: BorderRadius.circular(18),
+                onTap: onTap,
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              '가장 가까운 역',
+                              style: Theme.of(context).textTheme.bodyMedium
+                                  ?.copyWith(
+                                    color: EasySubwayAccessibleColors.mutedText,
+                                    fontWeight: FontWeight.w800,
+                                    height: 1.25,
+                                  ),
+                            ),
+                            const SizedBox(height: 5),
+                            Text(
+                              stationName,
+                              style: Theme.of(context).textTheme.headlineSmall
+                                  ?.copyWith(
+                                    color: EasySubwayAccessibleColors.text,
+                                    fontWeight: FontWeight.w800,
+                                    height: 1.2,
+                                  ),
+                            ),
+                            const SizedBox(height: 6),
+                            Text(
+                              result.distanceLabel.isEmpty
+                                  ? result.lineLabel
+                                  : '${result.distanceLabel} · ${result.lineLabel}',
+                              style: Theme.of(context).textTheme.bodyLarge
+                                  ?.copyWith(
+                                    color: EasySubwayAccessibleColors.mutedText,
+                                    fontWeight: FontWeight.w700,
+                                    height: 1.3,
+                                  ),
+                            ),
+                            const SizedBox(height: 8),
+                            _StationDetailTextPill(
+                              text:
+                                  '${result.dataQualityLabel} · ${result.dataSourceLabel}',
+                            ),
+                          ],
                         ),
-                        const SizedBox(height: 5),
-                        Text(
-                          stationName,
-                          style: Theme.of(context).textTheme.headlineSmall
-                              ?.copyWith(
-                                color: EasySubwayAccessibleColors.text,
-                                fontWeight: FontWeight.w800,
-                                height: 1.2,
-                              ),
-                        ),
-                        const SizedBox(height: 6),
-                        Text(
-                          result.distanceLabel.isEmpty
-                              ? result.lineLabel
-                              : '${result.distanceLabel} · ${result.lineLabel}',
-                          style: Theme.of(context).textTheme.bodyLarge
-                              ?.copyWith(
-                                color: EasySubwayAccessibleColors.mutedText,
-                                fontWeight: FontWeight.w700,
-                                height: 1.3,
-                              ),
-                        ),
-                        const SizedBox(height: 8),
-                        _StationDetailTextPill(
-                          text:
-                              '${result.dataQualityLabel} · ${result.dataSourceLabel}',
-                        ),
-                      ],
-                    ),
+                      ),
+                      const SizedBox(width: 12),
+                      StationLineBadges(
+                        lines: result.lines,
+                        size: 38,
+                        maxBadgeCount: 1,
+                      ),
+                    ],
                   ),
-                  const SizedBox(width: 12),
-                  StationLineBadges(
-                    lines: result.lines,
-                    size: 38,
-                    maxBadgeCount: 1,
-                  ),
-                ],
+                ),
               ),
             ),
           ),
-        ),
+          if (onSetOrigin != null || onSetDestination != null)
+            _StationRoleActionBar(
+              stationId: result.id,
+              stationName: stationName,
+              onSetOrigin: onSetOrigin,
+              onSetDestination: onSetDestination,
+            ),
+        ],
       ),
     );
   }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2881,6 +2881,8 @@ void main() {
         find.bySemanticsLabel('가장 가까운 역, 상록수역, 현재 위치 기준 230m'),
         findsOneWidget,
       );
+      expect(find.bySemanticsLabel('상록수역을 출발역으로 설정'), findsOneWidget);
+      expect(find.bySemanticsLabel('상록수역을 도착역으로 설정'), findsOneWidget);
 
       final nearbyButtonSize = tester.getSize(
         find.byKey(const Key('nearbyStationSearchButton')),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2876,10 +2876,9 @@ void main() {
       expect(repository.requestedNearbyLocations.single.longitude, 126.8665);
       expect(find.text('상록수역'), findsOneWidget);
       expect(find.text('현재 위치 기준 230m · 수도권 2호선'), findsOneWidget);
+      expect(find.byKey(const Key('nearbyStationPrimaryCard')), findsOneWidget);
       expect(
-        find.bySemanticsLabel(
-          '상록수역, 현재 위치 기준 230m, 수도권 2호선, 수도권, 기본 정보만 있음, 출처 공식 파일',
-        ),
+        find.bySemanticsLabel('가장 가까운 역, 상록수역, 현재 위치 기준 230m'),
         findsOneWidget,
       );
 
@@ -3329,8 +3328,8 @@ void main() {
       );
       await tester.pumpAndSettle();
       expect(find.text('시설'), findsOneWidget);
-      expect(find.text('확인 필요 1개'), findsOneWidget);
-      expect(find.bySemanticsLabel('확인이 필요한 시설 1개'), findsOneWidget);
+      expect(find.text('확인 필요 1개'), findsNothing);
+      expect(find.bySemanticsLabel('확인이 필요한 시설 1개'), findsNothing);
       expect(find.text('2번 출구 엘리베이터'), findsOneWidget);
       expect(find.text('엘리베이터'), findsWidgets);
       expect(find.text('고장'), findsOneWidget);
@@ -3439,7 +3438,7 @@ void main() {
     expect(find.text('2번 출구 엘리베이터'), findsOneWidget);
     expect(find.text('현재 이용이 어려울 수 있어요'), findsOneWidget);
     expect(find.text('고장'), findsOneWidget);
-    expect(find.text('연결 층 B1 ↔ 1F'), findsOneWidget);
+    expect(find.text('연결 위치 B1 ↔ 1F'), findsOneWidget);
     expect(find.text('2번 출구 앞'), findsOneWidget);
     expect(find.text('최근 확인 2026-06-14'), findsOneWidget);
     expect(find.text('정보 신뢰도 높음 · 출처 공식 파일'), findsOneWidget);
@@ -3614,7 +3613,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(internalRouteRepository.requests, hasLength(1));
-    expect(find.text('내부 이동 안내'), findsOneWidget);
+    expect(find.text('역 안 이동 순서'), findsOneWidget);
     expect(find.text('내부 이동 경로를 찾았습니다'), findsOneWidget);
     expect(find.text('1번 출구 엘리베이터에서 개찰구까지'), findsWidgets);
     expect(find.text('약 1분 15초 · 28m'), findsOneWidget);
@@ -3673,7 +3672,7 @@ void main() {
       'node-sangnoksu-faregate',
     );
     expect(internalRouteRepository.requests.single.mobilityType, 'WHEELCHAIR');
-    expect(find.text('내부 이동 안내'), findsOneWidget);
+    expect(find.text('역 안 이동 순서'), findsOneWidget);
     expect(find.text('내부 이동 경로를 찾았습니다'), findsOneWidget);
   });
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2899,6 +2899,64 @@ void main() {
     }
   });
 
+  testWidgets('주변 역은 첫 결과를 대표 카드로 분리하고 나머지만 목록에 보여준다', (tester) async {
+    final locationProvider = FakeCurrentLocationProvider(
+      location: _freshCurrentLocation(),
+      needsPermissionRequest: false,
+    );
+    final repository = FakeStationSearchRepository(
+      nearbyResults: [
+        _stationResult(
+          id: 'station-sangnoksu',
+          name: '상록수',
+          distanceMeters: 230,
+        ),
+        _stationResult(id: 'station-sadang', name: '사당', distanceMeters: 520),
+        _stationResult(id: 'station-gangnam', name: '강남', distanceMeters: 790),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        locationProvider: locationProvider,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
+    await tester.pumpAndSettle();
+
+    final primaryCard = find.byKey(const Key('nearbyStationPrimaryCard'));
+    expect(primaryCard, findsOneWidget);
+    expect(
+      find.descendant(of: primaryCard, matching: find.text('상록수역')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: primaryCard, matching: find.text('사당역')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+      findsNothing,
+    );
+    expect(find.text('다른 주변 역'), findsOneWidget);
+    expect(
+      find.byKey(const Key('stationSearchResult-station-sadang')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('stationSearchResult-station-gangnam')),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('역 검색은 첫 위치 권한 요청 전에 사용 목적을 안내한다', (tester) async {
     final locationProvider = FakeCurrentLocationProvider(
       location: _freshCurrentLocation(),
@@ -3625,7 +3683,7 @@ void main() {
     expect(find.text('약 1분 15초 · 28m · 현장 검증 전 · 엘리베이터 필요'), findsOneWidget);
     expect(
       find.bySemanticsLabel(
-        '내부 이동 안내, 내부 이동 경로를 찾았습니다, 1번 출구 엘리베이터에서 개찰구까지, 약 1분 15초 · 28m, 이동 단계 1번 내부 이동, 1번 출구 엘리베이터에서 개찰구까지, 약 1분 15초 · 28m · 현장 검증 전 · 엘리베이터 필요, 엘리베이터에서 개찰구까지 이동합니다.',
+        '역 안 이동 순서, 내부 이동 경로를 찾았습니다, 1번 출구 엘리베이터에서 개찰구까지, 약 1분 15초 · 28m, 이동 단계 1번 내부 이동, 1번 출구 엘리베이터에서 개찰구까지, 약 1분 15초 · 28m · 현장 검증 전 · 엘리베이터 필요, 엘리베이터에서 개찰구까지 이동합니다.',
       ),
       findsOneWidget,
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2878,7 +2878,9 @@ void main() {
       expect(find.text('현재 위치 기준 230m · 수도권 2호선'), findsOneWidget);
       expect(find.byKey(const Key('nearbyStationPrimaryCard')), findsOneWidget);
       expect(
-        find.bySemanticsLabel('가장 가까운 역, 상록수역, 현재 위치 기준 230m'),
+        find.bySemanticsLabel(
+          '가장 가까운 역, 상록수역, 현재 위치 기준 230m, 수도권 2호선, 수도권, 기본 정보만 있음, 출처 공식 파일',
+        ),
         findsOneWidget,
       );
       expect(find.bySemanticsLabel('상록수역을 출발역으로 설정'), findsOneWidget);


### PR DESCRIPTION
## 관련 이슈

close #775

## 작업 배경

08 역 검색, 09 주변 역, 10 역 상세, 11 시설 상세 화면을 v3 디자인 기준에 맞춰 실제 역/시설 데이터 기반으로 정리합니다.

## 작업 내용

- 주변 역 화면에서 가짜 지도/목록 전환 UI를 제거하고 실제 주변 역 결과의 가장 가까운 역 카드를 탭 가능한 대표 카드로 정리했습니다.
- 주변 역 목록은 대표 카드와 같은 역을 중복 표시하지 않고 나머지 주변 역만 보여주도록 바꿨습니다.
- 역 상세의 시설 경고는 상단 상태 카드 한 곳에만 남기고 시설 목록 안의 중복 경고를 제거했습니다.
- 내부 이동 섹션 문구를 v3 기준의 역 안 이동 순서로 정리했습니다.
- 시설 상세 위치 문구를 연결 층에서 연결 위치로 바꿔 실제 위치 안내 의도를 더 명확히 했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter analyze --no-pub`: exit 0, No issues found
  - `flutter test --no-pub test/widget_test.dart`: exit 0, 113 tests passed
  - `git diff --check`: exit 0
  - 보안 diff 확인: 변경 diff에서 네트워크, 파일, 권한, 토큰/시크릿, 프로세스 실행 변경 없음. 탭 처리와 Semantics, 표시 문구 변경만 확인했습니다.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 정적 분석 | Flutter local | `flutter analyze --no-pub` | 명령 출력 | 통과 |
| 08~11 화면 widget 회귀 | Flutter local | `flutter test --no-pub test/widget_test.dart` | 113 tests passed | 통과 |
| Android 화면 캡처 | Android emulator | 사용자 지시로 이번 작업에서는 에뮬 확인 스킵 | 스크린샷 없음. 이후 한 번에 수동 확인 예정 | 미수행, 잔여 리스크 있음 |
| 보안 diff | Local diff | 위험 키워드 및 변경 파일 확인 | 네트워크/파일/권한/시크릿 처리 변경 없음 | 신규 보안 영향 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/station_search.dart`의 주변 역 대표 카드 탭 동작과 역 상세 시설 경고 중복 제거입니다.

## 리스크

- Android 에뮬레이터 시각 확인은 사용자 요청으로 이번 PR에서 생략했습니다. 실제 기기에서 카드 간격과 터치 피드백은 후속 일괄 확인이 필요합니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 가까운 역 화면이 개선되었습니다. 가장 가까운 역이 전용 카드로 분리되고, 경로 설정 액션이 추가되었습니다.
  * 역 안내 섹션 명칭과 시설 정보 표기가 명확하게 업데이트되었습니다.
  * 시설 섹션이 간소화되어 더 직관적으로 표시됩니다.

* **테스트**
  * 접근성 및 UI 텍스트 검증이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->