### PR TITLE
[Fix] 운영 health readiness 마스터 데이터 복구

### DIFF
--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/UnavailableTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/UnavailableTransitMasterRepository.java
@@ -10,6 +10,7 @@ import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteNode;
+import com.easysubway.transit.domain.SimplifiedStationLayout;
 import com.easysubway.transit.domain.SimplifiedStationLayoutStatus;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationExit;
@@ -32,34 +33,57 @@ public class UnavailableTransitMasterRepository implements
 	SaveRouteNodePort,
 	SaveRouteEdgePort {
 
+	// ponytail: reuse the existing static seed until a real data-pack adapter exists.
+	private final InMemoryTransitMasterRepository seedRepository = new InMemoryTransitMasterRepository();
+
 	@Override
 	public List<TransitOperator> loadOperators() {
-		return List.of();
+		return seedRepository.loadOperators();
 	}
 
 	@Override
 	public List<SubwayLine> loadLines() {
-		return List.of();
+		return seedRepository.loadLines();
 	}
 
 	@Override
 	public List<Station> loadStations() {
-		return List.of();
+		return seedRepository.loadStations();
 	}
 
 	@Override
 	public List<StationLine> loadStationLines() {
-		return List.of();
+		return seedRepository.loadStationLines();
 	}
 
 	@Override
 	public List<StationExit> loadStationExits() {
-		return List.of();
+		return seedRepository.loadStationExits();
 	}
 
 	@Override
 	public List<AccessibilityFacility> loadAccessibilityFacilities() {
-		return List.of();
+		return seedRepository.loadAccessibilityFacilities();
+	}
+
+	@Override
+	public List<StationLayoutSource> loadStationLayoutSources() {
+		return seedRepository.loadStationLayoutSources();
+	}
+
+	@Override
+	public List<SimplifiedStationLayout> loadSimplifiedStationLayouts() {
+		return seedRepository.loadSimplifiedStationLayouts();
+	}
+
+	@Override
+	public List<RouteNode> loadRouteNodes() {
+		return seedRepository.loadRouteNodes();
+	}
+
+	@Override
+	public List<RouteEdge> loadRouteEdges() {
+		return seedRepository.loadRouteEdges();
 	}
 
 	@Override

--- a/backend/src/test/java/com/easysubway/EasySubwayBackendApplicationTests.java
+++ b/backend/src/test/java/com/easysubway/EasySubwayBackendApplicationTests.java
@@ -55,12 +55,12 @@ class EasySubwayBackendApplicationTests {
 		private MockMvc mockMvc;
 
 		@Test
-		@DisplayName("운영 프로필은 readiness DOWN 응답까지 기동된다")
+		@DisplayName("운영 프로필은 readiness UP 응답까지 기동된다")
 		void prodProfileStartsUntilReadinessEndpoint() throws Exception {
 			mockMvc.perform(get("/actuator/health/readiness"))
-				.andExpect(status().isServiceUnavailable())
-				.andExpect(jsonPath("$.status").value("DOWN"))
-				.andExpect(jsonPath("$.components.productionReadiness.status").value("DOWN"));
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.status").value("UP"))
+				.andExpect(jsonPath("$.components.productionReadiness.status").value("UP"));
 		}
 
 	}

--- a/backend/src/test/java/com/easysubway/transit/adapter/out/persistence/UnavailableTransitMasterRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/out/persistence/UnavailableTransitMasterRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.easysubway.transit.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.SimplifiedStationLayoutStatus;
@@ -13,6 +14,14 @@ import org.junit.jupiter.api.Test;
 class UnavailableTransitMasterRepositoryTest {
 
 	private final UnavailableTransitMasterRepository repository = new UnavailableTransitMasterRepository();
+
+	@Test
+	@DisplayName("읽기 포트는 운영 readiness 기준 데이터를 반환한다")
+	void readOperationsReturnSeedMasterData() {
+		assertThat(repository.loadOperators()).isNotEmpty();
+		assertThat(repository.loadLines()).isNotEmpty();
+		assertThat(repository.loadStations()).isNotEmpty();
+	}
 
 	@Test
 	@DisplayName("쓰기 포트 호출은 조용히 무시하지 않고 명시적으로 실패한다")


### PR DESCRIPTION
## 관련 이슈

close #794

## 작업 배경

- 운영 서버의 PostgreSQL, nginx, 백엔드 서비스와 관리자 로그인은 정상 기동했지만 `/actuator/health`가 `DOWN`을 반환했다.
- 원인은 prod profile의 transit master repository가 operators/lines/stations를 빈 목록으로 반환해 productionReadiness가 masterData empty로 판단하는 동작이었다.

## 작업 내용

- prod profile transit master repository가 기존 정적 기준 데이터를 읽기 포트에서 반환하도록 변경했다.
- 운영 쓰기 포트는 기존처럼 `UnsupportedOperationException`으로 실패하게 유지했다.
- prod profile context test를 readiness `UP` 기대값으로 갱신했다.
- prod transit repository read/write 동작 테스트를 보강했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests 'com.easysubway.transit.adapter.out.persistence.UnavailableTransitMasterRepositoryTest' --tests 'com.easysubway.EasySubwayBackendApplicationTests$ProductionProfileContextTests' --no-daemon`: exit 0
  - `./gradlew test --no-daemon`: exit 0
  - `./gradlew bootJar --no-daemon`: exit 0
  - `curl -sS --max-time 20 https://easysubway-api.aquilaxk.site/actuator/health`: `{"status":"UP","groups":["liveness","readiness"]}`
  - `curl -I --max-time 20 https://easysubway-api.aquilaxk.site/admin/login`: HTTP/2 200

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| prod readiness | 운영 API | `/actuator/health` curl | `{"status":"UP","groups":["liveness","readiness"]}` | 통과 |
| 관리자 로그인 | 운영 API | `/admin/login` HEAD 요청 | HTTP/2 200 | 통과 |
| backend regression | local macOS | Gradle 전체 테스트 | `./gradlew test --no-daemon` exit 0 | 통과 |
| deploy artifact | local macOS | Spring Boot jar 빌드 | `./gradlew bootJar --no-daemon` exit 0 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 운영 쓰기는 계속 막고, 읽기 포트만 기존 정적 기준 데이터로 복구한 부분이다.

## 리스크

- 이 변경은 실제 데이터팩 adapter가 아니라 기존 seed data 재사용이다. 전국/실데이터 확장은 별도 작업으로 진행해야 한다.
- 운영 서버에는 QA 요청에 따라 이 커밋의 jar를 먼저 수동 반영했다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
