### PR TITLE
[Fix] 온보딩 선택·권한 문구와 실제 동작 정합화

### DIFF
--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -1347,19 +1347,27 @@ class _OnboardingConditionRow extends StatelessWidget {
                       : const Color(0xFFEEF3F6),
                   borderRadius: BorderRadius.circular(18),
                 ),
-                child: SizedBox(
-                  width: 72,
-                  height: 36,
-                  child: Center(
-                    child: Text(
-                      state,
-                      style: TextStyle(
-                        color: enabled
-                            ? const Color(0xFF0D8A6D)
-                            : const Color(0xFF647686),
-                        fontSize: 13,
-                        fontWeight: FontWeight.w800,
-                        height: 1.1,
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    minWidth: 72,
+                    minHeight: 36,
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 7,
+                    ),
+                    child: Center(
+                      child: Text(
+                        state,
+                        style: TextStyle(
+                          color: enabled
+                              ? const Color(0xFF0D8A6D)
+                              : const Color(0xFF647686),
+                          fontSize: 13,
+                          fontWeight: FontWeight.w800,
+                          height: 1.1,
+                        ),
                       ),
                     ),
                   ),

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -323,7 +323,17 @@ class OnboardingIntroScreen extends StatelessWidget {
                   borderRadius: BorderRadius.circular(8),
                 ),
               ),
-              child: const Text('바로 시작'),
+              child: const Text('기본 설정으로 시작'),
+            ),
+            const SizedBox(height: 7),
+            Text(
+              '천천히 이동 · 큰 글씨 · 단순 보기 적용',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: const Color(0xFF647686),
+                fontWeight: FontWeight.w700,
+                height: 1.3,
+              ),
             ),
           ],
         ),
@@ -731,8 +741,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   OnboardingViewPreferences _preferences =
       const OnboardingViewPreferences.defaults();
   int _currentStep = 0;
-  bool _locationPermissionSelected = true;
-  bool _notificationPermissionSelected = true;
+  bool _locationPermissionSelected = false;
+  bool _notificationPermissionSelected = false;
   bool _showNotificationPermissionFailureNextAction = false;
 
   @override
@@ -765,7 +775,16 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
           };
 
     return Scaffold(
-      appBar: AppBar(title: const Text('쉬운 지하철')),
+      appBar: AppBar(
+        title: const Text('쉬운 지하철'),
+        leading: _currentStep == 0
+            ? null
+            : IconButton(
+                tooltip: '이전 단계',
+                onPressed: _goBack,
+                icon: const Icon(Icons.arrow_back),
+              ),
+      ),
       bottomNavigationBar: _currentStep == 2
           ? null
           : SafeArea(
@@ -819,7 +838,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                   Semantics(
                     header: true,
                     child: Text(
-                      '원하는 조건을 고르세요',
+                      '적용할 조건을 확인하세요',
                       style: textTheme.headlineSmall?.copyWith(
                         color: const Color(0xFF102A2C),
                         fontWeight: FontWeight.w900,
@@ -926,7 +945,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                   Semantics(
                     header: true,
                     child: Text(
-                      '권한을 선택하세요',
+                      '필요한 권한을 나중에 켤 수 있어요',
                       style: textTheme.headlineSmall?.copyWith(
                         color: const Color(0xFF102A2C),
                         fontWeight: FontWeight.w900,
@@ -962,21 +981,44 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                     ),
                   ],
                   const SizedBox(height: 22),
+                  FilledButton(
+                    key: const Key('onboardingPermissionAllowButton'),
+                    onPressed:
+                        _locationPermissionSelected ||
+                            _notificationPermissionSelected
+                        ? _handlePermissionAllow
+                        : null,
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size.fromHeight(60),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: const Text('선택한 권한 허용하고 시작'),
+                  ),
+                  const SizedBox(height: 9),
                   OutlinedButton(
                     key: const Key('onboardingPermissionSkipButton'),
-                    onPressed: _handlePermissionSkip,
+                    onPressed: _completeOnboarding,
                     style: OutlinedButton.styleFrom(
                       minimumSize: const Size.fromHeight(60),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(8),
                       ),
                     ),
-                    child: const Text('건너뛰기'),
+                    child: const Text('나중에 설정'),
                   ),
                 ],
         ),
       ),
     );
+  }
+
+  void _goBack() {
+    if (_currentStep == 0) {
+      return;
+    }
+    setState(() => _currentStep -= 1);
   }
 
   void _completeOnboarding() {
@@ -989,28 +1031,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     );
   }
 
-  Future<void> _handlePermissionSkip() async {
-    if (!_locationPermissionSelected || !_notificationPermissionSelected) {
-      await showDialog<void>(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: const Text('수동 설정 방법'),
-          content: const Text(
-            '나중에 휴대폰 설정에서 쉬운 지하철을 선택한 뒤 위치와 알림 권한을 켤 수 있습니다. '
-            '권한을 끄면 가까운 역 찾기와 시설 고장 알림은 제한됩니다.',
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('확인'),
-            ),
-          ],
-        ),
-      );
-      if (!mounted) {
-        return;
-      }
-    }
+  Future<void> _handlePermissionAllow() async {
     final permissionsReady = await _prepareSelectedPermissions();
     if (!mounted) {
       return;
@@ -1285,7 +1306,7 @@ class _OnboardingConditionRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final state = enabled ? '우선' : '기본';
+    final state = enabled ? '우선 적용' : '기본 적용';
 
     return Semantics(
       container: true,
@@ -1327,15 +1348,19 @@ class _OnboardingConditionRow extends StatelessWidget {
                   borderRadius: BorderRadius.circular(18),
                 ),
                 child: SizedBox(
-                  width: 54,
+                  width: 72,
                   height: 36,
                   child: Center(
-                    child: Icon(
-                      enabled ? Icons.check : Icons.remove,
-                      color: enabled
-                          ? const Color(0xFF0D8A6D)
-                          : const Color(0xFF647686),
-                      size: 21,
+                    child: Text(
+                      state,
+                      style: TextStyle(
+                        color: enabled
+                            ? const Color(0xFF0D8A6D)
+                            : const Color(0xFF647686),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w800,
+                        height: 1.1,
+                      ),
                     ),
                   ),
                 ),

--- a/apps/mobile/test/onboarding_app_flow_test.dart
+++ b/apps/mobile/test/onboarding_app_flow_test.dart
@@ -56,10 +56,10 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('onboardingDoneButton')));
     await tester.pumpAndSettle();
-    expect(find.text('원하는 조건을 고르세요'), findsOneWidget);
+    expect(find.text('적용할 조건을 확인하세요'), findsOneWidget);
     await tester.tap(find.byKey(const Key('onboardingDoneButton')));
     await tester.pumpAndSettle();
-    expect(find.text('권한을 선택하세요'), findsOneWidget);
+    expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsOneWidget);
     await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
     await tester.pumpAndSettle();
 
@@ -78,7 +78,7 @@ void main() {
     expect(onboardingStore.saveCount, 1);
   });
 
-  testWidgets('첫 실행 앱은 권한 선택을 끄고 건너뛰면 수동 설정 방법을 안내한다', (tester) async {
+  testWidgets('첫 실행 앱은 권한을 나중에 설정하고 홈으로 이동한다', (tester) async {
     await tester.pumpWidget(
       _testApp(onboardingStore: MemoryOnboardingResultStore()),
     );
@@ -86,15 +86,11 @@ void main() {
     await _openOnboarding(tester);
     await _continueFromProfileToPermission(tester);
 
-    await tester.tap(find.byType(Switch).first);
-    await tester.pumpAndSettle();
+    expect(find.bySemanticsLabel('현재 위치 꺼짐'), findsOneWidget);
+    expect(find.bySemanticsLabel('알림 꺼짐'), findsOneWidget);
     await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('수동 설정 방법'), findsOneWidget);
-    expect(find.textContaining('가까운 역 찾기와 시설 고장 알림은 제한됩니다'), findsOneWidget);
-    await tester.tap(find.text('확인'));
-    await tester.pumpAndSettle();
     expect(find.byType(HomeScreen), findsOneWidget);
   });
 
@@ -109,11 +105,15 @@ void main() {
     await _openOnboarding(tester);
     await _continueFromProfileToPermission(tester);
 
-    expect(find.text('권한을 선택하세요'), findsOneWidget);
+    expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsOneWidget);
     expect(find.text('현재 위치'), findsOneWidget);
     expect(find.text('알림'), findsOneWidget);
     expect(
       find.byKey(const Key('onboardingPermissionSkipButton')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('onboardingPermissionAllowButton')),
       findsOneWidget,
     );
   });

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -319,6 +319,27 @@ void main() {
     expect(find.text('적용할 조건을 확인하세요'), findsOneWidget);
   });
 
+  testWidgets('온보딩 조건 배지는 큰 글씨에서도 잘리지 않는다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(2.0)),
+          child: OnboardingScreen(onCompleted: (_) {}),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('onboardingProfileCard-elderly')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('적용할 조건을 확인하세요'), findsOneWidget);
+    expect(find.text('우선 적용'), findsWidgets);
+    expect(find.text('기본 적용'), findsWidgets);
+    expect(tester.takeException(), isNull);
+  });
+
   test('온보딩 완료 결과는 선택한 이동 조건과 보기 설정을 함께 담는다', () {
     final result = OnboardingResult(
       profile: mobilityProfileOptions.firstWhere(

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -76,13 +76,14 @@ void main() {
       await tester.tap(find.byKey(const Key('onboardingDoneButton')));
       await tester.pumpAndSettle();
 
-      expect(find.text('원하는 조건을 고르세요'), findsOneWidget);
+      expect(find.text('적용할 조건을 확인하세요'), findsOneWidget);
       expect(find.text('계단 피하기'), findsOneWidget);
       expect(find.text('엘리베이터 이용'), findsOneWidget);
+      expect(find.text('우선 적용'), findsWidgets);
       expect(find.text('보기 설정'), findsOneWidget);
       expect(
-        tester.getSemantics(find.bySemanticsLabel('계단 피하기 우선, 계단 없는 길')),
-        isSemantics(label: '계단 피하기 우선, 계단 없는 길'),
+        tester.getSemantics(find.bySemanticsLabel('계단 피하기 우선 적용, 계단 없는 길')),
+        isSemantics(label: '계단 피하기 우선 적용, 계단 없는 길'),
       );
       await tester.scrollUntilVisible(
         find.byKey(const Key('onboardingPreference-highContrast')),
@@ -108,9 +109,11 @@ void main() {
       await tester.tap(find.byKey(const Key('onboardingDoneButton')));
       await tester.pumpAndSettle();
 
-      expect(find.text('권한을 선택하세요'), findsOneWidget);
+      expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsOneWidget);
       expect(find.text('현재 위치'), findsOneWidget);
       expect(find.text('알림'), findsOneWidget);
+      expect(find.bySemanticsLabel('현재 위치 꺼짐'), findsOneWidget);
+      expect(find.bySemanticsLabel('알림 꺼짐'), findsOneWidget);
       await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
       await tester.pumpAndSettle();
 
@@ -128,41 +131,7 @@ void main() {
     }
   });
 
-  testWidgets('온보딩 권한 단계는 선택을 끄고 건너뛰면 수동 설정 방법을 안내한다', (tester) async {
-    OnboardingResult? completedResult;
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: OnboardingScreen(
-          onCompleted: (result) => completedResult = result,
-        ),
-      ),
-    );
-
-    await tester.tap(find.byKey(const Key('onboardingProfileCard-elderly')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
-    await tester.pumpAndSettle();
-
-    expect(find.text('권한을 선택하세요'), findsOneWidget);
-    await tester.tap(find.byType(Switch).first);
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
-    await tester.pumpAndSettle();
-
-    expect(find.text('수동 설정 방법'), findsOneWidget);
-    expect(find.textContaining('휴대폰 설정에서 쉬운 지하철'), findsOneWidget);
-
-    await tester.tap(find.text('확인'));
-    await tester.pumpAndSettle();
-
-    expect(completedResult, isNotNull);
-    expect(completedResult?.profile.id, 'elderly');
-  });
-
-  testWidgets('온보딩 권한 단계는 선택된 권한 provider를 호출한 뒤 완료한다', (tester) async {
+  testWidgets('온보딩 권한 단계는 나중에 설정을 누르면 권한 요청 없이 완료한다', (tester) async {
     final locationProvider = _FakeCurrentLocationProvider();
     final notificationPermissionProvider =
         _FakeNotificationPermissionProvider();
@@ -185,7 +154,43 @@ void main() {
     await tester.tap(find.byKey(const Key('onboardingDoneButton')));
     await tester.pumpAndSettle();
 
+    expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsOneWidget);
     await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
+    await tester.pumpAndSettle();
+
+    expect(completedResult, isNotNull);
+    expect(completedResult?.profile.id, 'elderly');
+    expect(locationProvider.requestCount, 0);
+    expect(notificationPermissionProvider.requestCount, 0);
+  });
+
+  testWidgets('온보딩 권한 단계는 켠 권한 provider를 호출한 뒤 완료한다', (tester) async {
+    final locationProvider = _FakeCurrentLocationProvider();
+    final notificationPermissionProvider =
+        _FakeNotificationPermissionProvider();
+    OnboardingResult? completedResult;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OnboardingScreen(
+          locationProvider: locationProvider,
+          notificationPermissionProvider: notificationPermissionProvider,
+          onCompleted: (result) => completedResult = result,
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('onboardingProfileCard-elderly')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(Switch).first);
+    await tester.tap(find.byType(Switch).last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingPermissionAllowButton')));
     await tester.pumpAndSettle();
 
     expect(locationProvider.requestCount, 1);
@@ -193,36 +198,7 @@ void main() {
     expect(completedResult?.profile.id, 'elderly');
   });
 
-  testWidgets('온보딩 권한 단계는 위치만 끄면 알림 provider는 호출한다', (tester) async {
-    final locationProvider = _FakeCurrentLocationProvider();
-    final notificationPermissionProvider =
-        _FakeNotificationPermissionProvider();
-    OnboardingResult? completedResult;
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: OnboardingScreen(
-          locationProvider: locationProvider,
-          notificationPermissionProvider: notificationPermissionProvider,
-          onCompleted: (result) => completedResult = result,
-        ),
-      ),
-    );
-
-    await _moveToPermissionStep(tester);
-    await tester.tap(find.byType(Switch).first);
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('확인'));
-    await tester.pumpAndSettle();
-
-    expect(locationProvider.requestCount, 0);
-    expect(notificationPermissionProvider.requestCount, 1);
-    expect(completedResult?.profile.id, 'elderly');
-  });
-
-  testWidgets('온보딩 권한 단계는 알림만 끄면 위치 provider는 호출한다', (tester) async {
+  testWidgets('온보딩 권한 단계는 알림만 켜면 알림 provider만 호출한다', (tester) async {
     final locationProvider = _FakeCurrentLocationProvider();
     final notificationPermissionProvider =
         _FakeNotificationPermissionProvider();
@@ -241,9 +217,34 @@ void main() {
     await _moveToPermissionStep(tester);
     await tester.tap(find.byType(Switch).last);
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
+    await tester.tap(find.byKey(const Key('onboardingPermissionAllowButton')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('확인'));
+
+    expect(locationProvider.requestCount, 0);
+    expect(notificationPermissionProvider.requestCount, 1);
+    expect(completedResult?.profile.id, 'elderly');
+  });
+
+  testWidgets('온보딩 권한 단계는 위치만 켜면 위치 provider만 호출한다', (tester) async {
+    final locationProvider = _FakeCurrentLocationProvider();
+    final notificationPermissionProvider =
+        _FakeNotificationPermissionProvider();
+    OnboardingResult? completedResult;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OnboardingScreen(
+          locationProvider: locationProvider,
+          notificationPermissionProvider: notificationPermissionProvider,
+          onCompleted: (result) => completedResult = result,
+        ),
+      ),
+    );
+
+    await _moveToPermissionStep(tester);
+    await tester.tap(find.byType(Switch).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingPermissionAllowButton')));
     await tester.pumpAndSettle();
 
     expect(locationProvider.requestCount, 1);
@@ -269,7 +270,11 @@ void main() {
       );
 
       await _moveToPermissionStep(tester);
-      await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
+      await tester.tap(find.byType(Switch).last);
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const Key('onboardingPermissionAllowButton')),
+      );
       await tester.pumpAndSettle();
     });
 
@@ -284,6 +289,34 @@ void main() {
       find.byKey(const Key('onboardingNotificationFailureNextAction')),
       findsOneWidget,
     );
+  });
+
+  testWidgets('온보딩 2·3단계는 이전 단계로 돌아갈 수 있다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(home: OnboardingScreen(onCompleted: (_) {})),
+    );
+
+    await tester.tap(find.byKey(const Key('onboardingProfileCard-elderly')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('적용할 조건을 확인하세요'), findsOneWidget);
+    expect(find.text('우선 적용'), findsWidgets);
+    expect(find.text('기본 적용'), findsWidgets);
+    await tester.tap(find.byTooltip('이전 단계'));
+    await tester.pumpAndSettle();
+    expect(find.text('어떤 도움이 필요한가요?'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsOneWidget);
+    await tester.tap(find.byTooltip('이전 단계'));
+    await tester.pumpAndSettle();
+    expect(find.text('적용할 조건을 확인하세요'), findsOneWidget);
   });
 
   test('온보딩 완료 결과는 선택한 이동 조건과 보기 설정을 함께 담는다', () {


### PR DESCRIPTION
## 관련 이슈

close #783

## 작업 배경

- QA 리뷰에서 온보딩 권한 단계의 기본 선택값, 버튼 문구, 실제 권한 요청 동작이 서로 다르게 읽히는 문제가 확인됐다.
- 교통약자 사용자가 첫 실행에서 권한 요청을 즉시 허용해야 하는 흐름으로 오해하지 않도록, 권한은 기본 꺼짐으로 두고 선택한 권한만 명시적으로 요청하도록 정리한다.

## 작업 내용

- 소개 화면의 `바로 시작` CTA를 `기본 설정으로 시작`으로 바꾸고 적용되는 기본 설정 설명을 함께 노출했다.
- 이동 조건 단계 문구를 선택 유도 대신 확인 문구로 바꾸고, 아이콘 상태값을 `우선 적용` / `기본 적용` 텍스트 배지로 변경했다.
- 권한 단계의 위치/알림 스위치를 기본 꺼짐으로 변경하고, `선택한 권한 허용하고 시작`과 `나중에 설정`을 분리했다.
- 온보딩 2·3단계에서 이전 단계로 돌아갈 수 있도록 AppBar 뒤로가기를 추가했다.
- 온보딩 단위 테스트와 첫 실행 앱 플로우 테스트를 새 문구와 권한 요청 조건에 맞게 갱신했다.
- 큰 글씨 환경에서 조건 상태 배지가 잘리지 않도록 고정 크기를 제거하고 200% text scale 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/onboarding_test.dart test/onboarding_app_flow_test.dart`: exit 0, 20 tests passed
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name '앱은 서비스 소개에서 바로 시작해도 저장된 시설 신고 사진을 복구한다'`: exit 0, 1 test passed
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `cd apps/mobile && flutter build apk --debug`: exit 0, debug APK built at `build/app/outputs/flutter-apk/app-debug.apk`
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 온보딩 조건 확인 단계 | Android emulator `sdk gphone64 arm64` API 36 | debug APK 설치 후 첫 실행 온보딩 2단계 스크린샷 및 UI tree 확인 | 로컬 전용 `.codex/evidence/783/android-100-step2.png`, `.codex/evidence/783/android-100-step2-ui.xml` | `적용할 조건을 확인하세요`와 `우선 적용` / `기본 적용` 배지가 표시됨 |
| 온보딩 권한 기본값과 CTA | Android emulator `sdk gphone64 arm64` API 36 | 첫 실행 온보딩 3단계 스크린샷 및 UI tree 확인 | 로컬 전용 `.codex/evidence/783/android-100-step3.png`, `.codex/evidence/783/android-100-step3-ui.xml` | 위치/알림이 꺼짐이며 `선택한 권한 허용하고 시작`과 `나중에 설정`이 분리됨 |
| 큰 글씨 권한 화면 | Android emulator `sdk gphone64 arm64` API 36 | 시스템 글꼴 130%, 200%에서 온보딩 3단계 캡처 | 로컬 전용 `.codex/evidence/783/android-130-step3.png`, `.codex/evidence/783/android-200-step3.png`, 각 UI tree XML | 권한 문구와 버튼이 화면 안에 유지되고 주요 조작이 보임 |
| 큰 글씨 조건 배지 | Flutter widget test | `MediaQueryData(textScaler: TextScaler.linear(2.0))`에서 온보딩 2단계 렌더링 | `cd apps/mobile && flutter test test/onboarding_test.dart test/onboarding_app_flow_test.dart` | `우선 적용` / `기본 적용` 배지가 overflow 예외 없이 표시됨 |
| iOS 빌드·런치 | iOS Simulator `Maum iPhone 17` | `flutter run -d 29E46350-DD26-44DB-9BA1-1EDBD6305AA2 --debug` 후 스크린샷 확인 | 로컬 전용 `.codex/evidence/783/ios-simulator-start.png` | 앱이 iOS simulator에서 빌드·실행됨. 온보딩 세부 화면은 Flutter widget/app flow 테스트로 대체 확인 |

증거 파일은 리뷰용 화면 캡처와 UI tree이며, 이 저장소 정책상 사진·스크린샷·녹화 증거를 git에 커밋하지 않기 때문에 로컬 전용 `.codex/evidence/783/` 아래에 보관했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 권한 스위치 기본값이 꺼짐이고, 권한 요청은 `선택한 권한 허용하고 시작`에서만 발생하는지 확인해 주세요.
  - `나중에 설정`은 권한 provider를 호출하지 않고 온보딩을 완료한다.
  - iOS 온보딩 세부 화면 증거는 현재 로컬 simulator 런치와 Flutter 테스트로 대체되어 있다.

## 리스크

- iOS 실기/Simulator에서 온보딩 각 단계의 시각 캡처는 아직 Android만큼 상세하게 수집하지 못했다. 공통 Flutter 테스트로 동작은 검증했지만, iOS 전용 렌더링 차이는 추가 수동 QA에서 재확인하는 것이 안전하다.
- 권한을 온보딩에서 기본 요청하지 않도록 바뀌었으므로, 위치 기반 기능 진입 시 기존 기능별 권한 안내가 계속 적절히 동작하는지 후속 플로우에서 확인할 필요가 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
