### PR TITLE
[Fix] 온보딩과 홈 하단 고정 영역 콘텐츠 가림 방지

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1294,9 +1294,6 @@ class _HomeScreenState extends State<HomeScreen> {
       );
     }
 
-    final homeListBottomPadding =
-        96.0 + MediaQuery.viewPaddingOf(context).bottom;
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('쉬운 지하철'),
@@ -1317,7 +1314,7 @@ class _HomeScreenState extends State<HomeScreen> {
           child: ListView(
             key: const Key('homePrototypeList'),
             physics: const AlwaysScrollableScrollPhysics(),
-            padding: EdgeInsets.fromLTRB(17, 18, 17, homeListBottomPadding),
+            padding: const EdgeInsets.fromLTRB(17, 18, 17, 96),
             children: [
               _HomePrototypeHero(
                 profile: currentProfile,

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1294,6 +1294,9 @@ class _HomeScreenState extends State<HomeScreen> {
       );
     }
 
+    final homeListBottomPadding =
+        96.0 + MediaQuery.viewPaddingOf(context).bottom;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('쉬운 지하철'),
@@ -1314,7 +1317,7 @@ class _HomeScreenState extends State<HomeScreen> {
           child: ListView(
             key: const Key('homePrototypeList'),
             physics: const AlwaysScrollableScrollPhysics(),
-            padding: const EdgeInsets.fromLTRB(17, 18, 17, 32),
+            padding: EdgeInsets.fromLTRB(17, 18, 17, homeListBottomPadding),
             children: [
               _HomePrototypeHero(
                 profile: currentProfile,

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -749,9 +749,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   Widget build(BuildContext context) {
     final selectedProfile = _selectedProfile;
     final textTheme = Theme.of(context).textTheme;
-    final listBottomPadding = _currentStep == 2
-        ? 32.0
-        : 104.0 + MediaQuery.viewPaddingOf(context).bottom;
+    final listBottomPadding = _currentStep == 2 ? 32.0 : 104.0;
     final profileOptions = [
       mobilityProfileOptions.firstWhere((profile) => profile.id == 'elderly'),
       mobilityProfileOptions.firstWhere(

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -749,6 +749,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   Widget build(BuildContext context) {
     final selectedProfile = _selectedProfile;
     final textTheme = Theme.of(context).textTheme;
+    final listBottomPadding = _currentStep == 2
+        ? 32.0
+        : 104.0 + MediaQuery.viewPaddingOf(context).bottom;
     final profileOptions = [
       mobilityProfileOptions.firstWhere((profile) => profile.id == 'elderly'),
       mobilityProfileOptions.firstWhere(
@@ -803,7 +806,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
             ),
       body: SafeArea(
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          padding: EdgeInsets.fromLTRB(20, 20, 20, listBottomPadding),
           children: _currentStep == 0
               ? [
                   const _OnboardingStepIndicator(currentStep: 1, totalSteps: 3),

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -341,6 +341,9 @@ void main() {
   });
 
   testWidgets('온보딩 고정 CTA 단계는 하단 스크롤 여백을 확보한다', (tester) async {
+    tester.view.viewPadding = const FakeViewPadding(bottom: 34);
+    addTearDown(tester.view.resetViewPadding);
+
     await tester.pumpWidget(
       MaterialApp(home: OnboardingScreen(onCompleted: (_) {})),
     );

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -340,6 +340,23 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets('온보딩 고정 CTA 단계는 하단 스크롤 여백을 확보한다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(home: OnboardingScreen(onCompleted: (_) {})),
+    );
+
+    final firstStepList = tester.widget<ListView>(find.byType(ListView));
+    expect(firstStepList.padding?.resolve(TextDirection.ltr).bottom, 104);
+
+    await tester.tap(find.byKey(const Key('onboardingProfileCard-elderly')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('onboardingDoneButton')));
+    await tester.pumpAndSettle();
+
+    final secondStepList = tester.widget<ListView>(find.byType(ListView));
+    expect(secondStepList.padding?.resolve(TextDirection.ltr).bottom, 104);
+  });
+
   test('온보딩 완료 결과는 선택한 이동 조건과 보기 설정을 함께 담는다', () {
     final result = OnboardingResult(
       profile: mobilityProfileOptions.firstWhere(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -364,6 +364,9 @@ void main() {
   });
 
   testWidgets('홈 스크롤은 하단 내비게이션 높이만큼 여백을 둔다', (tester) async {
+    tester.view.viewPadding = const FakeViewPadding(bottom: 34);
+    addTearDown(tester.view.resetViewPadding);
+
     await tester.pumpWidget(
       EasySubwayApp(
         repository: FakeStationSearchRepository(),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -363,6 +363,24 @@ void main() {
     expect(favoriteRouteRepository.listCount, greaterThanOrEqualTo(1));
   });
 
+  testWidgets('홈 스크롤은 하단 내비게이션 높이만큼 여백을 둔다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final homeList = tester.widget<ListView>(
+      find.byKey(const Key('homePrototypeList')),
+    );
+    expect(homeList.padding?.resolve(TextDirection.ltr).bottom, 96);
+  });
+
   testWidgets('온보딩 이동 조건은 경로 검색 기본값으로 이어진다', (tester) async {
     final stationRepository = FakeStationSearchRepository(
       queryResults: {


### PR DESCRIPTION
## 관련 이슈

close #784

## 작업 배경

- QA 리뷰에서 온보딩 2단계와 홈 하단 콘텐츠가 고정 CTA·하단 내비게이션과 가까워 큰 글씨 환경에서 마지막 항목을 읽기 어렵다는 문제가 확인됐다.
- 온보딩과 홈은 교통약자 사용자가 처음 접하는 핵심 흐름이므로, 스크롤 마지막 콘텐츠가 고정 하단 영역에 덮이지 않도록 여백을 명확히 보장한다.

## 작업 내용

- 온보딩 1·2단계 ListView 하단 padding을 고정 CTA 높이와 최소 여백 기준으로 늘렸다.
- 홈 ListView 하단 padding을 NavigationBar 높이와 최소 여백 기준으로 늘렸다.
- 온보딩 고정 CTA 단계와 홈 스크롤 하단 padding을 검증하는 widget test를 추가하고, `FakeViewPadding(bottom: 34)` 조건에서 SafeArea 하단 inset이 중복 반영되지 않는지 확인했다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/onboarding_test.dart --plain-name '온보딩 고정 CTA 단계는 하단 스크롤 여백을 확보한다'`: exit 0, 1 test passed
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name '홈 스크롤은 하단 내비게이션 높이만큼 여백을 둔다'`: exit 0, 1 test passed
  - `cd apps/mobile && flutter test test/onboarding_test.dart test/widget_test.dart`: exit 0, 131 tests passed
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `cd apps/mobile && flutter build apk --debug`: exit 0, debug APK built at `build/app/outputs/flutter-apk/app-debug.apk`
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 온보딩 2단계 하단 | Android emulator `sdk gphone64 arm64` API 36 | debug APK 설치 후 100% 글자 배율에서 하단까지 스크롤 | 로컬 전용 `.codex/evidence/784/android-100-onboarding-step2-bottom.png`, `.codex/evidence/784/android-100-onboarding-step2-bottom-ui.xml` | 마지막 보기 설정 항목과 `다음` CTA 사이 여백이 유지됨 |
| 온보딩 2단계 큰 글씨 | Android emulator `sdk gphone64 arm64` API 36 | 130%, 200% 글자 배율에서 하단까지 스크롤 | 로컬 전용 `.codex/evidence/784/android-130-onboarding-step2-bottom.png`, `.codex/evidence/784/android-200-onboarding-step2-bottom.png`, 각 UI tree XML | 200%에서도 `단순 보기` 항목이 CTA에 가려지지 않음 |
| 홈 하단 내비게이션 | Android emulator `sdk gphone64 arm64` API 36 | 100%, 130%, 200% 글자 배율에서 홈 하단 캡처 | 로컬 전용 `.codex/evidence/784/android-100-home-bottom.png`, `.codex/evidence/784/android-130-home-bottom.png`, `.codex/evidence/784/android-200-home-bottom.png`, 각 UI tree XML | 홈 콘텐츠 영역과 NavigationBar가 분리되어 보임 |
| 홈 하단 SafeArea | iOS Simulator `Maum iPhone 17` | 현재 빌드 실행 후 홈 하단 캡처 | 로컬 전용 `.codex/evidence/784/ios-home-bottom.png` | iOS 하단 SafeArea와 NavigationBar가 겹치지 않음 |
| 최근 경로 포함 홈 padding | Flutter widget test | fake 최근 경로 데이터가 있는 홈 ListView padding 확인 | `cd apps/mobile && flutter test test/widget_test.dart --plain-name '홈 스크롤은 하단 내비게이션 높이만큼 여백을 둔다'` | NavigationBar 높이 기준 하단 padding 96px을 검증함 |
| 하단 SafeArea 중복 방지 | Flutter widget test | `FakeViewPadding(bottom: 34)` 조건에서 온보딩·홈 ListView padding 확인 | `cd apps/mobile && flutter test test/onboarding_test.dart test/widget_test.dart` | 하단 inset이 104px/96px padding에 추가로 더해지지 않음을 검증함 |

증거 파일은 화면 캡처와 UI tree이며, 이 저장소 정책상 사진·스크린샷·녹화 증거를 git에 커밋하지 않기 때문에 로컬 전용 `.codex/evidence/784/` 아래에 보관했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - 수정은 하단 padding 두 곳만 바꾸는 최소 변경이다.
  - 고정 CTA 자체를 스크롤 안으로 옮기지는 않았다. Scaffold가 body와 bottomNavigationBar를 이미 분리하고 있어 padding 보강으로 가림 방지 기준을 충족한다.

## 리스크

- Android 수동 홈 증거는 실제 앱 기본 데이터 기준이라 최근 경로 카드가 없는 상태로 캡처했다. 최근 경로가 있는 홈 padding은 widget test로 별도 검증했다.
- 하단 여백이 늘어나 스크롤 끝의 빈 공간이 기존보다 커진다. 접근성 가림 방지 목적의 의도된 변화다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
