### PR TITLE
[Fix] 노선도 초기 확대와 접근성 대체 탐색 제공

### DIFF
--- a/apps/mobile/lib/features/stations/data/drift_station_repository.dart
+++ b/apps/mobile/lib/features/stations/data/drift_station_repository.dart
@@ -356,6 +356,14 @@ class DriftStationRepository
           ),
         )
         .toList(growable: false);
+    final stationLineMemberships = stationRows
+        .map(
+          (row) => NetworkMapStationLineMembership(
+            stationId: row.read<String>('id'),
+            lineId: row.read<String>('line_id'),
+          ),
+        )
+        .toList(growable: false);
     return NetworkMapData(
       regions: await _networkMapRegions(),
       selectedRegion: selectedRegion,
@@ -363,6 +371,7 @@ class DriftStationRepository
       stations: stations,
       edges: _networkMapEdges(stations),
       positionSources: await _networkMapPositionSources(selectedRegion),
+      stationLineMemberships: stationLineMemberships,
     );
   }
 

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -20,6 +20,7 @@ class NetworkMapData {
     required this.stations,
     required this.edges,
     required this.positionSources,
+    this.stationLineMemberships = const [],
   });
 
   final List<NetworkMapRegion> regions;
@@ -28,6 +29,7 @@ class NetworkMapData {
   final List<NetworkMapStation> stations;
   final List<NetworkMapEdge> edges;
   final List<NetworkMapPositionSource> positionSources;
+  final List<NetworkMapStationLineMembership> stationLineMemberships;
 
   factory NetworkMapData.fromJson(Map<String, Object?> json) {
     return NetworkMapData(
@@ -47,6 +49,26 @@ class NetworkMapData {
       positionSources: _objectList(
         json['positionSources'],
       ).map(NetworkMapPositionSource.fromJson).toList(growable: false),
+      stationLineMemberships: _objectList(
+        json['stationLineMemberships'],
+      ).map(NetworkMapStationLineMembership.fromJson).toList(growable: false),
+    );
+  }
+}
+
+class NetworkMapStationLineMembership {
+  const NetworkMapStationLineMembership({
+    required this.stationId,
+    required this.lineId,
+  });
+
+  final String stationId;
+  final String lineId;
+
+  factory NetworkMapStationLineMembership.fromJson(Map<String, Object?> json) {
+    return NetworkMapStationLineMembership(
+      stationId: json['stationId'] as String? ?? '',
+      lineId: json['lineId'] as String? ?? '',
     );
   }
 }
@@ -722,16 +744,11 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
   Widget build(BuildContext context) {
     final linesById = {for (final line in widget.data.lines) line.id: line};
     final stationsById = <String, NetworkMapStation>{};
-    final stationLinesById = <String, List<NetworkMapLine>>{};
     for (final station in widget.data.stations) {
       stationsById[_mapStationKey(station)] = station;
       stationsById.putIfAbsent(station.id, () => station);
-      final line = linesById[station.lineId];
-      if (line == null) {
-        continue;
-      }
-      stationLinesById.putIfAbsent(station.id, () => []).add(line);
     }
+    final stationLinesById = _stationLinesById(widget.data);
     final mapAsset = _routeMapAssetForRegion(widget.data.selectedRegion);
     return Container(
       key: const Key('networkMapSurface'),
@@ -879,11 +896,16 @@ class _SelectedLineOverlayPainter extends CustomPainter {
       if (from == null || to == null) {
         continue;
       }
-      canvas.drawLine(
-        Offset(geometry.x(from), geometry.y(from)),
-        Offset(geometry.x(to), geometry.y(to)),
-        pathPaint,
-      );
+      final segmentPath = _segmentPath(from, to);
+      if (segmentPath == null) {
+        canvas.drawLine(
+          Offset(geometry.x(from), geometry.y(from)),
+          Offset(geometry.x(to), geometry.y(to)),
+          pathPaint,
+        );
+      } else {
+        _drawScaledPath(canvas, segmentPath, pathPaint, geometry);
+      }
     }
     final stationBorderPaint = Paint()..color = lineColor;
     final stationFillPaint = Paint()..color = Colors.white;
@@ -905,6 +927,55 @@ class _SelectedLineOverlayPainter extends CustomPainter {
         oldDelegate.edges != edges ||
         oldDelegate.geometry != geometry;
   }
+}
+
+Path? _segmentPath(NetworkMapStation from, NetworkMapStation to) {
+  for (final pathData in [
+    from.position.downPath,
+    to.position.upPath,
+    from.position.upPath,
+    to.position.downPath,
+  ]) {
+    if (pathData.trim().isEmpty) {
+      continue;
+    }
+    final path = _pathFromSvg(pathData);
+    final bounds = path.getBounds().inflate(2);
+    final fromPoint = Offset(
+      from.position.x.toDouble(),
+      from.position.y.toDouble(),
+    );
+    final toPoint = Offset(to.position.x.toDouble(), to.position.y.toDouble());
+    if (bounds.contains(fromPoint) && bounds.contains(toPoint)) {
+      return path;
+    }
+  }
+  return null;
+}
+
+void _drawScaledPath(
+  Canvas canvas,
+  Path path,
+  Paint paint,
+  _MapGeometry geometry,
+) {
+  canvas
+    ..save()
+    ..scale(geometry.scaleX, geometry.scaleY)
+    ..translate(-geometry.origin.dx, -geometry.origin.dy);
+  final strokeScale = math.max(geometry.scaleX, geometry.scaleY);
+  canvas.drawPath(
+    path,
+    Paint()
+      ..color = paint.color
+      ..strokeCap = paint.strokeCap
+      ..strokeJoin = paint.strokeJoin
+      ..strokeWidth = strokeScale <= 0
+          ? paint.strokeWidth
+          : paint.strokeWidth / strokeScale
+      ..style = paint.style,
+  );
+  canvas.restore();
 }
 
 class _MapControls extends StatelessWidget {
@@ -1333,16 +1404,11 @@ class _NetworkMapListSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final linesById = {for (final line in data.lines) line.id: line};
     final stationsByLine = <String, List<NetworkMapStation>>{};
-    final stationLinesById = <String, List<NetworkMapLine>>{};
     for (final station in data.stations) {
       stationsByLine.putIfAbsent(station.lineId, () => []).add(station);
-      final line = linesById[station.lineId];
-      if (line != null) {
-        stationLinesById.putIfAbsent(station.id, () => []).add(line);
-      }
     }
+    final stationLinesById = _stationLinesById(data);
     return SafeArea(
       key: const Key('networkMapListSheet'),
       child: ListView(
@@ -1393,6 +1459,33 @@ class _NetworkMapListSheet extends StatelessWidget {
       ),
     );
   }
+}
+
+Map<String, List<NetworkMapLine>> _stationLinesById(NetworkMapData data) {
+  final linesById = {for (final line in data.lines) line.id: line};
+  final stationLinesById = <String, List<NetworkMapLine>>{};
+
+  void addLine(String stationId, String lineId) {
+    final line = linesById[lineId];
+    if (line == null) {
+      return;
+    }
+    final stationLines = stationLinesById.putIfAbsent(stationId, () => []);
+    if (!stationLines.any((existing) => existing.id == line.id)) {
+      stationLines.add(line);
+    }
+  }
+
+  if (data.stationLineMemberships.isNotEmpty) {
+    for (final membership in data.stationLineMemberships) {
+      addLine(membership.stationId, membership.lineId);
+    }
+  } else {
+    for (final station in data.stations) {
+      addLine(station.id, station.lineId);
+    }
+  }
+  return stationLinesById;
 }
 
 Path _pathFromSvg(String data) {

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -730,10 +730,10 @@ class _NetworkMapCanvas extends StatefulWidget {
   State<_NetworkMapCanvas> createState() => _NetworkMapCanvasState();
 }
 
-class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
-  static const _minScale = 0.08;
-  static const _maxScale = 4.8;
+const _minMapScale = 0.08;
+const _maxMapScale = 4.8;
 
+class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
   final TransformationController _controller = TransformationController();
   String? _layoutKey;
 
@@ -777,8 +777,8 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
                   key: const Key('networkMapInteractiveViewer'),
                   transformationController: _controller,
                   constrained: false,
-                  minScale: _minScale,
-                  maxScale: _maxScale,
+                  minScale: _minMapScale,
+                  maxScale: _maxMapScale,
                   boundaryMargin: const EdgeInsets.all(220),
                   child: SizedBox(
                     width: geometry.width,
@@ -858,7 +858,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
       return;
     }
     final targetScale = (currentScale * factor)
-        .clamp(_minScale, _maxScale)
+        .clamp(_minMapScale, _maxMapScale)
         .toDouble();
     final adjustedFactor = targetScale / currentScale;
     _controller.value = Matrix4.copy(_controller.value)
@@ -1172,9 +1172,12 @@ Matrix4 _mapTransformForBounds(
   }
   final widthScale = viewportWidth / bounds.width;
   final heightScale = viewportHeight / bounds.height;
-  final initialScale = contain
+  final computedScale = contain
       ? math.min(widthScale, heightScale)
       : math.max(widthScale, heightScale);
+  final initialScale = computedScale
+      .clamp(_minMapScale, _maxMapScale)
+      .toDouble();
   final dx =
       (viewportWidth - bounds.width * initialScale) / 2 -
       bounds.left * initialScale;

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -814,6 +814,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
                     _controller.value = _mapTransformForBounds(
                       Rect.fromLTWH(0, 0, geometry.width, geometry.height),
                       constraints,
+                      contain: true,
                     );
                   },
                   onLocate: () {
@@ -1075,7 +1076,11 @@ Matrix4 _initialMapTransform(
   return _mapTransformForBounds(geometry.initialBounds, constraints);
 }
 
-Matrix4 _mapTransformForBounds(Rect bounds, BoxConstraints constraints) {
+Matrix4 _mapTransformForBounds(
+  Rect bounds,
+  BoxConstraints constraints, {
+  bool contain = false,
+}) {
   final viewportWidth = constraints.hasBoundedWidth ? constraints.maxWidth : 0;
   final viewportHeight = constraints.hasBoundedHeight
       ? constraints.maxHeight
@@ -1083,10 +1088,11 @@ Matrix4 _mapTransformForBounds(Rect bounds, BoxConstraints constraints) {
   if (viewportWidth <= 0 || viewportHeight <= 0) {
     return Matrix4.identity();
   }
-  final initialScale = math.max(
-    viewportWidth / bounds.width,
-    viewportHeight / bounds.height,
-  );
+  final widthScale = viewportWidth / bounds.width;
+  final heightScale = viewportHeight / bounds.height;
+  final initialScale = contain
+      ? math.min(widthScale, heightScale)
+      : math.max(widthScale, heightScale);
   final dx =
       (viewportWidth - bounds.width * initialScale) / 2 -
       bounds.left * initialScale;
@@ -1329,8 +1335,13 @@ class _NetworkMapListSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     final linesById = {for (final line in data.lines) line.id: line};
     final stationsByLine = <String, List<NetworkMapStation>>{};
+    final stationLinesById = <String, List<NetworkMapLine>>{};
     for (final station in data.stations) {
       stationsByLine.putIfAbsent(station.lineId, () => []).add(station);
+      final line = linesById[station.lineId];
+      if (line != null) {
+        stationLinesById.putIfAbsent(station.id, () => []).add(line);
+      }
     }
     return SafeArea(
       key: const Key('networkMapListSheet'),
@@ -1366,13 +1377,15 @@ class _NetworkMapListSheet extends StatelessWidget {
                   children: [
                     for (final station in stationsByLine[line.id]!)
                       ListTile(
-                        key: Key('networkMapListStation-${station.id}'),
+                        key: Key(
+                          'networkMapListStation-${station.id}-${station.lineId}',
+                        ),
                         title: Text(station.displayName),
                         subtitle: Text(line.shortName),
-                        onTap: () => onStationTap(station, [
-                          if (linesById[station.lineId] != null)
-                            linesById[station.lineId]!,
-                        ]),
+                        onTap: () => onStationTap(
+                          station,
+                          stationLinesById[station.id] ?? const [],
+                        ),
                       ),
                   ],
                 ),

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -817,7 +817,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
                       contain: true,
                     );
                   },
-                  onLocate: () {
+                  onCenter: () {
                     _controller.value = _mapTransformForBounds(
                       _readableBoundsFor(geometry),
                       constraints,
@@ -912,13 +912,13 @@ class _MapControls extends StatelessWidget {
     required this.onZoomIn,
     required this.onZoomOut,
     required this.onOverview,
-    required this.onLocate,
+    required this.onCenter,
   });
 
   final VoidCallback onZoomIn;
   final VoidCallback onZoomOut;
   final VoidCallback onOverview;
-  final VoidCallback onLocate;
+  final VoidCallback onCenter;
 
   @override
   Widget build(BuildContext context) {
@@ -947,9 +947,9 @@ class _MapControls extends StatelessWidget {
         const SizedBox(height: 8),
         _MapControlButton(
           key: const Key('networkMapLocateButton'),
-          tooltip: '내 위치',
-          icon: Icons.my_location,
-          onPressed: onLocate,
+          tooltip: '중심 보기',
+          icon: Icons.center_focus_strong,
+          onPressed: onCenter,
         ),
       ],
     );

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -731,6 +731,9 @@ class _NetworkMapCanvas extends StatefulWidget {
 }
 
 class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
+  static const _minScale = 0.08;
+  static const _maxScale = 4.8;
+
   final TransformationController _controller = TransformationController();
   String? _layoutKey;
 
@@ -774,8 +777,8 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
                   key: const Key('networkMapInteractiveViewer'),
                   transformationController: _controller,
                   constrained: false,
-                  minScale: 0.08,
-                  maxScale: 4.8,
+                  minScale: _minScale,
+                  maxScale: _maxScale,
                   boundaryMargin: const EdgeInsets.all(220),
                   child: SizedBox(
                     width: geometry.width,
@@ -850,8 +853,16 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
   }
 
   void _scaleMap(double factor) {
+    final currentScale = _controller.value.getMaxScaleOnAxis();
+    if (currentScale <= 0) {
+      return;
+    }
+    final targetScale = (currentScale * factor)
+        .clamp(_minScale, _maxScale)
+        .toDouble();
+    final adjustedFactor = targetScale / currentScale;
     _controller.value = Matrix4.copy(_controller.value)
-      ..scaleByDouble(factor, factor, 1, 1);
+      ..scaleByDouble(adjustedFactor, adjustedFactor, 1, 1);
   }
 }
 

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -764,11 +764,22 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
                   mapAsset,
                   View.of(context).devicePixelRatio,
                 );
+          final fullBounds = Rect.fromLTWH(
+            0,
+            0,
+            geometry.width,
+            geometry.height,
+          );
+          final minScale = _minimumMapScaleForBounds(fullBounds, constraints);
           final layoutKey =
               '${widget.data.selectedRegion}:${geometry.width}:${geometry.height}:${constraints.maxWidth}:${constraints.maxHeight}';
           if (_layoutKey != layoutKey) {
             _layoutKey = layoutKey;
-            _controller.value = _initialMapTransform(geometry, constraints);
+            _controller.value = _initialMapTransform(
+              geometry,
+              constraints,
+              minScale: minScale,
+            );
           }
           return Stack(
             children: [
@@ -777,7 +788,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
                   key: const Key('networkMapInteractiveViewer'),
                   transformationController: _controller,
                   constrained: false,
-                  minScale: _minMapScale,
+                  minScale: minScale,
                   maxScale: _maxMapScale,
                   boundaryMargin: const EdgeInsets.all(220),
                   child: SizedBox(
@@ -828,19 +839,21 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
                 right: 14,
                 top: 12,
                 child: _MapControls(
-                  onZoomIn: () => _scaleMap(1.25),
-                  onZoomOut: () => _scaleMap(0.8),
+                  onZoomIn: () => _scaleMap(1.25, minScale),
+                  onZoomOut: () => _scaleMap(0.8, minScale),
                   onOverview: () {
                     _controller.value = _mapTransformForBounds(
-                      Rect.fromLTWH(0, 0, geometry.width, geometry.height),
+                      fullBounds,
                       constraints,
                       contain: true,
+                      minScale: minScale,
                     );
                   },
                   onCenter: () {
                     _controller.value = _mapTransformForBounds(
                       _readableBoundsFor(geometry),
                       constraints,
+                      minScale: minScale,
                     );
                   },
                 ),
@@ -852,13 +865,13 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
     );
   }
 
-  void _scaleMap(double factor) {
+  void _scaleMap(double factor, double minScale) {
     final currentScale = _controller.value.getMaxScaleOnAxis();
     if (currentScale <= 0) {
       return;
     }
     final targetScale = (currentScale * factor)
-        .clamp(_minMapScale, _maxMapScale)
+        .clamp(minScale, _maxMapScale)
         .toDouble();
     final adjustedFactor = targetScale / currentScale;
     _controller.value = Matrix4.copy(_controller.value)
@@ -1153,15 +1166,21 @@ String _displayRegionName(String region) {
 
 Matrix4 _initialMapTransform(
   _MapGeometry geometry,
-  BoxConstraints constraints,
-) {
-  return _mapTransformForBounds(geometry.initialBounds, constraints);
+  BoxConstraints constraints, {
+  required double minScale,
+}) {
+  return _mapTransformForBounds(
+    geometry.initialBounds,
+    constraints,
+    minScale: minScale,
+  );
 }
 
 Matrix4 _mapTransformForBounds(
   Rect bounds,
   BoxConstraints constraints, {
   bool contain = false,
+  double minScale = _minMapScale,
 }) {
   final viewportWidth = constraints.hasBoundedWidth ? constraints.maxWidth : 0;
   final viewportHeight = constraints.hasBoundedHeight
@@ -1175,9 +1194,7 @@ Matrix4 _mapTransformForBounds(
   final computedScale = contain
       ? math.min(widthScale, heightScale)
       : math.max(widthScale, heightScale);
-  final initialScale = computedScale
-      .clamp(_minMapScale, _maxMapScale)
-      .toDouble();
+  final initialScale = computedScale.clamp(minScale, _maxMapScale).toDouble();
   final dx =
       (viewportWidth - bounds.width * initialScale) / 2 -
       bounds.left * initialScale;
@@ -1187,6 +1204,27 @@ Matrix4 _mapTransformForBounds(
   return Matrix4.identity()
     ..translateByDouble(dx, dy, 0, 1)
     ..scaleByDouble(initialScale, initialScale, 1, 1);
+}
+
+double _minimumMapScaleForBounds(Rect bounds, BoxConstraints constraints) {
+  final viewportWidth = constraints.hasBoundedWidth ? constraints.maxWidth : 0;
+  final viewportHeight = constraints.hasBoundedHeight
+      ? constraints.maxHeight
+      : 0;
+  if (viewportWidth <= 0 ||
+      viewportHeight <= 0 ||
+      bounds.width <= 0 ||
+      bounds.height <= 0) {
+    return _minMapScale;
+  }
+  final fitScale = math.min(
+    viewportWidth / bounds.width,
+    viewportHeight / bounds.height,
+  );
+  if (!fitScale.isFinite || fitScale <= 0) {
+    return _minMapScale;
+  }
+  return math.min(_minMapScale, fitScale);
 }
 
 Rect _readableBoundsFor(_MapGeometry geometry) {

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -304,16 +304,42 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 Positioned.fill(
                   child: _NetworkMapCanvas(
                     data: data,
+                    selectedLineId: _selectedLineId,
                     onStationTap: _showStationSheet,
                   ),
                 ),
                 Positioned(
                   left: 14,
                   top: 12,
-                  child: _RegionTabs(
-                    regions: data.regions,
-                    selectedRegion: data.selectedRegion,
-                    onSelected: (region) => _reload(region: region),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _RegionTabs(
+                        regions: data.regions,
+                        selectedRegion: data.selectedRegion,
+                        onSelected: (region) => _reload(region: region),
+                      ),
+                      const SizedBox(height: 8),
+                      _LineFilterMenu(
+                        lines: data.lines,
+                        selectedLineId: _selectedLineId,
+                        onSelected: (lineId) => _reload(lineId: lineId),
+                      ),
+                    ],
+                  ),
+                ),
+                Positioned(
+                  left: 14,
+                  bottom: 14,
+                  child: SizedBox(
+                    width: 180,
+                    height: 48,
+                    child: FilledButton.icon(
+                      key: const Key('networkMapListButton'),
+                      onPressed: () => _showMapList(data),
+                      icon: const Icon(Icons.list_alt),
+                      label: const Text('노선 목록으로 보기'),
+                    ),
                   ),
                 ),
               ],
@@ -356,6 +382,23 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
     );
   }
 
+  void _showMapList(NetworkMapData data) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (context) {
+        return _NetworkMapListSheet(
+          data: data,
+          onStationTap: (station, lines) {
+            Navigator.of(context).pop();
+            _showStationSheet(station, lines);
+          },
+        );
+      },
+    );
+  }
+
   void _showStationSheet(
     NetworkMapStation station,
     List<NetworkMapLine> lines,
@@ -386,6 +429,46 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
           },
         );
       },
+    );
+  }
+}
+
+class _LineFilterMenu extends StatelessWidget {
+  const _LineFilterMenu({
+    required this.lines,
+    required this.selectedLineId,
+    required this.onSelected,
+  });
+
+  final List<NetworkMapLine> lines;
+  final String? selectedLineId;
+  final ValueChanged<String?> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    NetworkMapLine? selectedLine;
+    for (final line in lines) {
+      if (line.id == selectedLineId) {
+        selectedLine = line;
+        break;
+      }
+    }
+    final label = selectedLine?.shortName ?? '노선 선택';
+    return SizedBox(
+      key: const Key('networkMapLineFilter'),
+      width: 142,
+      height: 40,
+      child: PopupMenuButton<String>(
+        padding: EdgeInsets.zero,
+        initialValue: selectedLineId ?? '',
+        onSelected: (lineId) => onSelected(lineId.isEmpty ? null : lineId),
+        itemBuilder: (context) => [
+          const PopupMenuItem<String>(value: '', child: Text('전체 노선')),
+          for (final line in lines)
+            PopupMenuItem<String>(value: line.id, child: Text(line.shortName)),
+        ],
+        child: _RegionMenuButton(label: label),
+      ),
     );
   }
 }
@@ -441,33 +524,35 @@ class _RegionMenuButton extends StatelessWidget {
     return Semantics(
       button: true,
       label: label,
-      child: Container(
-        height: 40,
-        padding: const EdgeInsets.only(left: 10, right: 6),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: const Color(0xFFD7E1E3)),
-        ),
-        child: Row(
-          children: [
-            Expanded(
-              child: Text(
-                label,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w800,
-                  color: Color(0xFF102A2C),
+      child: ExcludeSemantics(
+        child: Container(
+          height: 40,
+          padding: const EdgeInsets.only(left: 10, right: 6),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: const Color(0xFFD7E1E3)),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  label,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    color: Color(0xFF102A2C),
+                  ),
                 ),
               ),
-            ),
-            const Icon(
-              Icons.arrow_drop_down,
-              size: 22,
-              color: Color(0xFF4C5759),
-            ),
-          ],
+              const Icon(
+                Icons.arrow_drop_down,
+                size: 22,
+                color: Color(0xFF4C5759),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -608,9 +693,14 @@ _RouteMapAsset? _routeMapAssetForRegion(String region) {
 }
 
 class _NetworkMapCanvas extends StatefulWidget {
-  const _NetworkMapCanvas({required this.data, required this.onStationTap});
+  const _NetworkMapCanvas({
+    required this.data,
+    required this.selectedLineId,
+    required this.onStationTap,
+  });
 
   final NetworkMapData data;
+  final String? selectedLineId;
   final void Function(NetworkMapStation station, List<NetworkMapLine> lines)
   onStationTap;
 
@@ -660,41 +750,233 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
             _layoutKey = layoutKey;
             _controller.value = _initialMapTransform(geometry, constraints);
           }
-          return InteractiveViewer(
-            transformationController: _controller,
-            constrained: false,
-            minScale: 0.08,
-            maxScale: 4.8,
-            boundaryMargin: const EdgeInsets.all(220),
-            child: SizedBox(
-              width: geometry.width,
-              height: geometry.height,
-              child: Stack(
-                children: [
-                  Positioned.fill(
-                    child: mapAsset == null
-                        ? const _OriginalRouteMapUnavailable()
-                        : _OriginalRouteMapView(asset: mapAsset),
-                  ),
-                  for (final station in widget.data.stations)
-                    Positioned.fromRect(
-                      rect: _stationHitRect(station, geometry),
-                      child: _StationHitTarget(
-                        key: Key(
-                          'networkMapStation-${station.id.replaceFirst('station-', '')}-${station.lineId}',
+          return Stack(
+            children: [
+              Positioned.fill(
+                child: InteractiveViewer(
+                  key: const Key('networkMapInteractiveViewer'),
+                  transformationController: _controller,
+                  constrained: false,
+                  minScale: 0.08,
+                  maxScale: 4.8,
+                  boundaryMargin: const EdgeInsets.all(220),
+                  child: SizedBox(
+                    width: geometry.width,
+                    height: geometry.height,
+                    child: Stack(
+                      children: [
+                        Positioned.fill(
+                          child: mapAsset == null
+                              ? const _OriginalRouteMapUnavailable()
+                              : _OriginalRouteMapView(asset: mapAsset),
                         ),
-                        station: station,
-                        onTap: () => widget.onStationTap(
-                          station,
-                          stationLinesById[station.id] ?? const [],
-                        ),
-                      ),
+                        if (widget.selectedLineId != null)
+                          Positioned.fill(
+                            child: IgnorePointer(
+                              child: CustomPaint(
+                                key: const Key('networkMapSelectedLineOverlay'),
+                                painter: _SelectedLineOverlayPainter(
+                                  lineId: widget.selectedLineId!,
+                                  linesById: linesById,
+                                  stationsById: stationsById,
+                                  edges: widget.data.edges,
+                                  geometry: geometry,
+                                ),
+                              ),
+                            ),
+                          ),
+                        for (final station in widget.data.stations)
+                          Positioned.fromRect(
+                            rect: _stationHitRect(station, geometry),
+                            child: _StationHitTarget(
+                              key: Key(
+                                'networkMapStation-${station.id.replaceFirst('station-', '')}-${station.lineId}',
+                              ),
+                              station: station,
+                              onTap: () => widget.onStationTap(
+                                station,
+                                stationLinesById[station.id] ?? const [],
+                              ),
+                            ),
+                          ),
+                      ],
                     ),
-                ],
+                  ),
+                ),
               ),
-            ),
+              Positioned(
+                right: 14,
+                top: 12,
+                child: _MapControls(
+                  onZoomIn: () => _scaleMap(1.25),
+                  onZoomOut: () => _scaleMap(0.8),
+                  onOverview: () {
+                    _controller.value = _mapTransformForBounds(
+                      Rect.fromLTWH(0, 0, geometry.width, geometry.height),
+                      constraints,
+                    );
+                  },
+                  onLocate: () {
+                    _controller.value = _mapTransformForBounds(
+                      _readableBoundsFor(geometry),
+                      constraints,
+                    );
+                  },
+                ),
+              ),
+            ],
           );
         },
+      ),
+    );
+  }
+
+  void _scaleMap(double factor) {
+    _controller.value = Matrix4.copy(_controller.value)
+      ..scaleByDouble(factor, factor, 1, 1);
+  }
+}
+
+class _SelectedLineOverlayPainter extends CustomPainter {
+  const _SelectedLineOverlayPainter({
+    required this.lineId,
+    required this.linesById,
+    required this.stationsById,
+    required this.edges,
+    required this.geometry,
+  });
+
+  final String lineId;
+  final Map<String, NetworkMapLine> linesById;
+  final Map<String, NetworkMapStation> stationsById;
+  final List<NetworkMapEdge> edges;
+  final _MapGeometry geometry;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final line = linesById[lineId];
+    if (line == null) {
+      return;
+    }
+    final lineColor = _colorFromHex(line.color);
+    canvas.drawRect(
+      Offset.zero & size,
+      Paint()..color = Colors.white.withValues(alpha: 0.58),
+    );
+    final pathPaint = Paint()
+      ..color = lineColor
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round
+      ..strokeWidth = 14
+      ..style = PaintingStyle.stroke;
+    for (final edge in edges) {
+      if (edge.lineId != lineId) {
+        continue;
+      }
+      final from = stationsById[edge.fromStationId];
+      final to = stationsById[edge.toStationId];
+      if (from == null || to == null) {
+        continue;
+      }
+      canvas.drawLine(
+        Offset(geometry.x(from), geometry.y(from)),
+        Offset(geometry.x(to), geometry.y(to)),
+        pathPaint,
+      );
+    }
+    final stationBorderPaint = Paint()..color = lineColor;
+    final stationFillPaint = Paint()..color = Colors.white;
+    for (final station in stationsById.values.toSet()) {
+      if (station.lineId != lineId) {
+        continue;
+      }
+      final center = Offset(geometry.x(station), geometry.y(station));
+      canvas.drawCircle(center, 13, stationBorderPaint);
+      canvas.drawCircle(center, 7, stationFillPaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_SelectedLineOverlayPainter oldDelegate) {
+    return oldDelegate.lineId != lineId ||
+        oldDelegate.linesById != linesById ||
+        oldDelegate.stationsById != stationsById ||
+        oldDelegate.edges != edges ||
+        oldDelegate.geometry != geometry;
+  }
+}
+
+class _MapControls extends StatelessWidget {
+  const _MapControls({
+    required this.onZoomIn,
+    required this.onZoomOut,
+    required this.onOverview,
+    required this.onLocate,
+  });
+
+  final VoidCallback onZoomIn;
+  final VoidCallback onZoomOut;
+  final VoidCallback onOverview;
+  final VoidCallback onLocate;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _MapControlButton(
+          key: const Key('networkMapZoomInButton'),
+          tooltip: '확대',
+          icon: Icons.add,
+          onPressed: onZoomIn,
+        ),
+        const SizedBox(height: 8),
+        _MapControlButton(
+          key: const Key('networkMapZoomOutButton'),
+          tooltip: '축소',
+          icon: Icons.remove,
+          onPressed: onZoomOut,
+        ),
+        const SizedBox(height: 8),
+        _MapControlButton(
+          key: const Key('networkMapOverviewButton'),
+          tooltip: '전체 보기',
+          icon: Icons.fit_screen,
+          onPressed: onOverview,
+        ),
+        const SizedBox(height: 8),
+        _MapControlButton(
+          key: const Key('networkMapLocateButton'),
+          tooltip: '내 위치',
+          icon: Icons.my_location,
+          onPressed: onLocate,
+        ),
+      ],
+    );
+  }
+}
+
+class _MapControlButton extends StatelessWidget {
+  const _MapControlButton({
+    required this.tooltip,
+    required this.icon,
+    required this.onPressed,
+    super.key,
+  });
+
+  final String tooltip;
+  final IconData icon;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white,
+      elevation: 2,
+      borderRadius: BorderRadius.circular(8),
+      child: IconButton(
+        tooltip: tooltip,
+        onPressed: onPressed,
+        icon: Icon(icon),
       ),
     );
   }
@@ -790,6 +1072,10 @@ Matrix4 _initialMapTransform(
   _MapGeometry geometry,
   BoxConstraints constraints,
 ) {
+  return _mapTransformForBounds(geometry.initialBounds, constraints);
+}
+
+Matrix4 _mapTransformForBounds(Rect bounds, BoxConstraints constraints) {
   final viewportWidth = constraints.hasBoundedWidth ? constraints.maxWidth : 0;
   final viewportHeight = constraints.hasBoundedHeight
       ? constraints.maxHeight
@@ -797,7 +1083,6 @@ Matrix4 _initialMapTransform(
   if (viewportWidth <= 0 || viewportHeight <= 0) {
     return Matrix4.identity();
   }
-  final bounds = geometry.initialBounds;
   final initialScale = math.max(
     viewportWidth / bounds.width,
     viewportHeight / bounds.height,
@@ -811,6 +1096,22 @@ Matrix4 _initialMapTransform(
   return Matrix4.identity()
     ..translateByDouble(dx, dy, 0, 1)
     ..scaleByDouble(initialScale, initialScale, 1, 1);
+}
+
+Rect _readableBoundsFor(_MapGeometry geometry) {
+  final width = math.min(
+    geometry.width,
+    math.max(320.0, geometry.width * 0.38),
+  );
+  final height = math.min(
+    geometry.height,
+    math.max(320.0, geometry.height * 0.38),
+  );
+  final maxLeft = math.max(0.0, geometry.width - width);
+  final maxTop = math.max(0.0, geometry.height - height);
+  final left = (geometry.focus.dx - width / 2).clamp(0.0, maxLeft).toDouble();
+  final top = (geometry.focus.dy - height / 2).clamp(0.0, maxTop).toDouble();
+  return Rect.fromLTWH(left, top, width, height);
 }
 
 class _MapGeometry {
@@ -852,6 +1153,14 @@ class _MapGeometry {
       focus: Offset(displayWidth / 2, displayHeight / 2),
       width: displayWidth,
       height: displayHeight,
+      initialBounds: _readableBoundsFor(
+        _MapGeometry(
+          origin: Offset.zero,
+          focus: Offset(displayWidth / 2, displayHeight / 2),
+          width: displayWidth,
+          height: displayHeight,
+        ),
+      ),
       scaleX: displayWidth / asset.coordinateWidth,
       scaleY: displayHeight / asset.coordinateHeight,
     );
@@ -902,7 +1211,7 @@ class _MapGeometry {
     }
     const margin = 54.0;
     final origin = Offset(minX - margin, minY - margin);
-    return _MapGeometry(
+    final geometry = _MapGeometry(
       origin: origin,
       focus: Offset(
         _median(stationXs) - origin.dx,
@@ -910,6 +1219,13 @@ class _MapGeometry {
       ),
       width: math.max(860, maxX - minX + margin * 2),
       height: math.max(560, maxY - minY + margin * 2),
+    );
+    return _MapGeometry(
+      origin: geometry.origin,
+      focus: geometry.focus,
+      width: geometry.width,
+      height: geometry.height,
+      initialBounds: _readableBoundsFor(geometry),
     );
   }
 
@@ -997,6 +1313,70 @@ class _StationHitTarget extends StatelessWidget {
         behavior: HitTestBehavior.opaque,
         onTap: onTap,
         child: const SizedBox.expand(),
+      ),
+    );
+  }
+}
+
+class _NetworkMapListSheet extends StatelessWidget {
+  const _NetworkMapListSheet({required this.data, required this.onStationTap});
+
+  final NetworkMapData data;
+  final void Function(NetworkMapStation station, List<NetworkMapLine> lines)
+  onStationTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final linesById = {for (final line in data.lines) line.id: line};
+    final stationsByLine = <String, List<NetworkMapStation>>{};
+    for (final station in data.stations) {
+      stationsByLine.putIfAbsent(station.lineId, () => []).add(station);
+    }
+    return SafeArea(
+      key: const Key('networkMapListSheet'),
+      child: ListView(
+        padding: const EdgeInsets.fromLTRB(20, 6, 20, 24),
+        children: [
+          const Text(
+            '노선과 역 목록',
+            style: TextStyle(fontSize: 24, fontWeight: FontWeight.w900),
+          ),
+          const SizedBox(height: 6),
+          const Text(
+            '지도 조작이 어려울 때 목록에서 역을 선택하세요.',
+            style: TextStyle(fontSize: 15, color: Color(0xFF4D6367)),
+          ),
+          const SizedBox(height: 14),
+          if (data.stations.isEmpty)
+            const Text(
+              '선택한 노선에 표시할 역이 없습니다.',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+            )
+          else
+            for (final line in data.lines)
+              if (stationsByLine[line.id]?.isNotEmpty ?? false)
+                ExpansionTile(
+                  key: Key('networkMapListLine-${line.id}'),
+                  initiallyExpanded: true,
+                  leading: _LineCircleBadge(line: line, size: 34),
+                  title: Text(
+                    line.shortName,
+                    style: const TextStyle(fontWeight: FontWeight.w800),
+                  ),
+                  children: [
+                    for (final station in stationsByLine[line.id]!)
+                      ListTile(
+                        key: Key('networkMapListStation-${station.id}'),
+                        title: Text(station.displayName),
+                        subtitle: Text(line.shortName),
+                        onTap: () => onStationTap(station, [
+                          if (linesById[station.lineId] != null)
+                            linesById[station.lineId]!,
+                        ]),
+                      ),
+                  ],
+                ),
+        ],
       ),
     );
   }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -679,6 +679,24 @@ void main() {
       viewer.transformationController!.value.getMaxScaleOnAxis(),
       lessThan(initialScale),
     );
+
+    for (var index = 0; index < 30; index += 1) {
+      await tester.tap(find.byKey(const Key('networkMapZoomInButton')));
+      await tester.pump();
+    }
+    expect(
+      viewer.transformationController!.value.getMaxScaleOnAxis(),
+      lessThanOrEqualTo(4.8),
+    );
+
+    for (var index = 0; index < 80; index += 1) {
+      await tester.tap(find.byKey(const Key('networkMapZoomOutButton')));
+      await tester.pump();
+    }
+    expect(
+      viewer.transformationController!.value.getMaxScaleOnAxis(),
+      greaterThanOrEqualTo(0.08),
+    );
   });
 
   testWidgets('노선도 지역 메뉴는 선택한 지역으로 지도를 다시 불러온다', (tester) async {
@@ -7454,6 +7472,23 @@ class FakeStationSearchRepository
         ),
       ),
     ];
+    final filteredStations = [
+      for (final station in stations)
+        if (lineId == null || station.lineId == lineId) station,
+    ];
+    final filteredStationKeys = {
+      for (final station in filteredStations) '${station.id}:${station.lineId}',
+    };
+    const edges = [
+      NetworkMapEdge(
+        id: 'map-edge-seoul-4-station-sadang-station-sangnoksu',
+        lineId: 'seoul-4',
+        fromStationId: 'station-sadang:seoul-4',
+        toStationId: 'station-sangnoksu:seoul-4',
+        accessibilityStatus: 'AVAILABLE',
+        reliabilityScore: 100,
+      ),
+    ];
     return NetworkMapData(
       regions: [
         for (final regionName in networkMapRegionNames)
@@ -7461,19 +7496,12 @@ class FakeStationSearchRepository
       ],
       selectedRegion: selectedRegion,
       lines: lines,
-      stations: [
-        for (final station in stations)
-          if (lineId == null || station.lineId == lineId) station,
-      ],
-      edges: const [
-        NetworkMapEdge(
-          id: 'map-edge-seoul-4-station-sadang-station-sangnoksu',
-          lineId: 'seoul-4',
-          fromStationId: 'station-sadang',
-          toStationId: 'station-sangnoksu',
-          accessibilityStatus: 'AVAILABLE',
-          reliabilityScore: 100,
-        ),
+      stations: filteredStations,
+      edges: [
+        for (final edge in edges)
+          if (filteredStationKeys.contains(edge.fromStationId) &&
+              filteredStationKeys.contains(edge.toStationId))
+            edge,
       ],
       positionSources: const [
         NetworkMapPositionSource(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -668,9 +668,16 @@ void main() {
     final viewer = tester.widget<InteractiveViewer>(
       find.byKey(const Key('networkMapInteractiveViewer')),
     );
+    final initialScale = viewer.transformationController!.value
+        .getMaxScaleOnAxis();
+    expect(initialScale, greaterThan(1));
+
+    await tester.tap(find.byKey(const Key('networkMapOverviewButton')));
+    await tester.pump();
+
     expect(
       viewer.transformationController!.value.getMaxScaleOnAxis(),
-      greaterThan(1),
+      lessThan(initialScale),
     );
   });
 
@@ -748,12 +755,14 @@ void main() {
     expect(find.byKey(const Key('networkMapListSheet')), findsOneWidget);
     expect(find.text('노선과 역 목록'), findsOneWidget);
     await tester.tap(
-      find.byKey(const Key('networkMapListStation-station-sadang')),
+      find.byKey(const Key('networkMapListStation-station-sadang-seoul-4')),
     );
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
     expect(find.text('사당역'), findsOneWidget);
+    expect(find.text('2호선'), findsOneWidget);
+    expect(find.text('4호선'), findsOneWidget);
   });
 
   test('공식 노선도 데이터팩 manifest는 앱 번들 asset을 가리킨다', () {
@@ -7369,6 +7378,12 @@ class FakeStationSearchRepository
     final selectedRegion = region ?? networkMapRegionNames.first;
     const lines = [
       NetworkMapLine(
+        id: 'seoul-2',
+        name: '수도권 2호선',
+        color: '#00A84D',
+        region: '테스트권',
+      ),
+      NetworkMapLine(
         id: 'seoul-4',
         name: '수도권 4호선',
         color: '#00A5DE',
@@ -7376,6 +7391,24 @@ class FakeStationSearchRepository
       ),
     ];
     const stations = [
+      NetworkMapStation(
+        id: 'station-sadang',
+        nameKo: '사당',
+        nameEn: 'Sadang',
+        region: '테스트권',
+        lineId: 'seoul-2',
+        stationCode: '226',
+        sequence: 33,
+        position: NetworkMapPosition(
+          x: 390,
+          y: 320,
+          labelDx: 0,
+          labelDy: 0,
+          upPath: '',
+          downPath: '',
+          sourceId: 'fixture-route-map-source-capital-review',
+        ),
+      ),
       NetworkMapStation(
         id: 'station-sadang',
         nameKo: '사당',
@@ -7420,7 +7453,10 @@ class FakeStationSearchRepository
       ],
       selectedRegion: selectedRegion,
       lines: lines,
-      stations: lineId == null || lineId == 'seoul-4' ? stations : const [],
+      stations: [
+        for (final station in stations)
+          if (lineId == null || station.lineId == lineId) station,
+      ],
       edges: const [
         NetworkMapEdge(
           id: 'map-edge-seoul-4-station-sadang-station-sangnoksu',

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -733,6 +733,14 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('4호선'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('networkMapStation-sadang-seoul-4')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
+    expect(find.text('사당역'), findsOneWidget);
+    expect(find.text('2호선'), findsOneWidget);
+    expect(find.text('4호선'), findsWidgets);
   });
 
   testWidgets('노선도 목록 대체 화면에서 역을 선택할 수 있다', (tester) async {
@@ -7472,6 +7480,20 @@ class FakeStationSearchRepository
           id: 'fixture-route-map-source-capital-review',
           name: '수도권 노선도 fixture 좌표 검수',
           licenseStatus: 'fixture-only',
+        ),
+      ],
+      stationLineMemberships: const [
+        NetworkMapStationLineMembership(
+          stationId: 'station-sadang',
+          lineId: 'seoul-2',
+        ),
+        NetworkMapStationLineMembership(
+          stationId: 'station-sadang',
+          lineId: 'seoul-4',
+        ),
+        NetworkMapStationLineMembership(
+          stationId: 'station-sangnoksu',
+          lineId: 'seoul-4',
         ),
       ],
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -656,9 +656,22 @@ void main() {
 
     expect(find.byKey(const Key('networkMapScreen')), findsOneWidget);
     expect(find.byKey(const Key('mapRegionTabs')), findsOneWidget);
+    expect(find.byKey(const Key('networkMapLineFilter')), findsOneWidget);
+    expect(find.byKey(const Key('networkMapZoomInButton')), findsOneWidget);
+    expect(find.byKey(const Key('networkMapZoomOutButton')), findsOneWidget);
+    expect(find.byKey(const Key('networkMapOverviewButton')), findsOneWidget);
+    expect(find.byKey(const Key('networkMapLocateButton')), findsOneWidget);
+    expect(find.byKey(const Key('networkMapListButton')), findsOneWidget);
     expect(find.byKey(const Key('networkMapSurface')), findsOneWidget);
     expect(find.text('테스트권'), findsOneWidget);
     expect(find.text('전국'), findsNothing);
+    final viewer = tester.widget<InteractiveViewer>(
+      find.byKey(const Key('networkMapInteractiveViewer')),
+    );
+    expect(
+      viewer.transformationController!.value.getMaxScaleOnAxis(),
+      greaterThan(1),
+    );
   });
 
   testWidgets('노선도 지역 메뉴는 선택한 지역으로 지도를 다시 불러온다', (tester) async {
@@ -685,6 +698,62 @@ void main() {
 
     expect(repository.requestedNetworkMapRegions, contains('부산'));
     expect(find.text('부산'), findsOneWidget);
+  });
+
+  testWidgets('노선도 노선 필터는 선택한 노선으로 다시 불러온다', (tester) async {
+    final repository = FakeStationSearchRepository();
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('bottomNavMap')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('networkMapLineFilter')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('4호선'));
+    await tester.pumpAndSettle();
+
+    expect(repository.requestedNetworkMapLineIds, contains('seoul-4'));
+    expect(
+      find.byKey(const Key('networkMapSelectedLineOverlay')),
+      findsOneWidget,
+    );
+    expect(find.text('4호선'), findsOneWidget);
+  });
+
+  testWidgets('노선도 목록 대체 화면에서 역을 선택할 수 있다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('bottomNavMap')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('networkMapListButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('networkMapListSheet')), findsOneWidget);
+    expect(find.text('노선과 역 목록'), findsOneWidget);
+    await tester.tap(
+      find.byKey(const Key('networkMapListStation-station-sadang')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
+    expect(find.text('사당역'), findsOneWidget);
   });
 
   test('공식 노선도 데이터팩 manifest는 앱 번들 asset을 가리킨다', () {
@@ -7231,6 +7300,7 @@ class FakeStationSearchRepository
   final requestedExitStationIds = <String>[];
   final requestedFacilityStationIds = <String>[];
   final requestedNetworkMapRegions = <String?>[];
+  final requestedNetworkMapLineIds = <String?>[];
 
   @override
   Future<List<StationSearchResult>> searchStations(String query) async {
@@ -7295,6 +7365,7 @@ class FakeStationSearchRepository
   @override
   Future<NetworkMapData> getNetworkMap({String? region, String? lineId}) async {
     requestedNetworkMapRegions.add(region);
+    requestedNetworkMapLineIds.add(lineId);
     final selectedRegion = region ?? networkMapRegionNames.first;
     const lines = [
       NetworkMapLine(


### PR DESCRIPTION
## 관련 이슈

close #786

## 작업 배경

- 노선도 첫 진입 시 전체 지도가 너무 축소되어 고령자, 유모차 이용자, 휠체어 이용자가 역명과 노선 흐름을 바로 읽기 어렵다.
- 지도 조작이 어려운 상황에서도 역을 선택할 수 있도록 목록형 대체 탐색이 필요하다.

## 작업 내용

- 노선도 초기 viewport를 지도 중심의 읽을 수 있는 확대 상태로 열도록 조정했다.
- 지도 우측에 확대, 축소, 전체 보기, 중심 보기 버튼을 추가하고 각 버튼에 접근성 라벨을 부여했다.
- 노선 필터를 추가해 선택 노선을 다시 불러오고, 선택한 노선은 진하게 표시하며 나머지 원본 노선도는 흐리게 보이도록 했다.
- `노선 목록으로 보기` sheet를 추가해 지도 조작 없이 노선별 역 목록에서 역 상세 sheet로 이동할 수 있게 했다.
- 지역/노선 메뉴의 중복 semantics를 제거해 스크린리더가 같은 문구를 반복하지 않도록 정리했다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/network_map.dart apps/mobile/lib/features/stations/data/drift_station_repository.dart apps/mobile/test/widget_test.dart`: exit 0
  - `flutter analyze`: exit 0, No issues found
  - `flutter test test/widget_test.dart test/map_adapter_test.dart`: exit 0, 122 tests passed
  - `flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `flutter build ios --simulator --debug`: exit 0, `build/ios/iphonesimulator/Runner.app` 생성
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 노선도 기본 확대와 지도 조작 버튼 | Android emulator API 36 | 새 APK 설치 후 노선도 탭 진입, 스크린샷 및 UI tree 확인 | 로컬 전용: `.codex/evidence/786/android-network-map-controls.png`, `.codex/evidence/786/android-network-map-controls-ui.xml` | 초기 화면이 확대 상태로 열리고 `확대`, `축소`, `전체 보기`, `중심 보기`, `노선 목록으로 보기` 접근성 라벨이 확인됨 |
| 노선 필터 강조/흐림 | Android emulator API 36 | `4호선` 필터 선택 후 스크린샷 및 UI tree 확인 | 로컬 전용: `.codex/evidence/786/android-network-map-line-filter.png`, `.codex/evidence/786/android-network-map-line-filter-ui.xml` | 4호선은 진하게 재표시되고 원본 노선도는 흐리게 보이며 필터 라벨이 `4호선`으로 표시됨 |
| 필터 상태 환승역 노선 유지 | Android emulator API 36 | `4호선` 필터 선택 후 `사당역` sheet 진입, 스크린샷 및 UI tree 확인 | 로컬 전용: `.codex/evidence/786/android-network-map-filtered-transfer-sheet.png`, `.codex/evidence/786/android-network-map-filtered-transfer-sheet-ui.xml` | 필터 상태에서도 사당역 sheet에 `2호선`과 `4호선`이 함께 표시됨 |
| 목록 대체 탐색 | Android emulator API 36 | `노선 목록으로 보기` sheet 진입, 스크린샷 및 UI tree 확인 | 로컬 전용: `.codex/evidence/786/android-network-map-list.png`, `.codex/evidence/786/android-network-map-list-ui.xml` | `노선과 역 목록` 제목, 안내문, 노선별 역 버튼이 확인됨 |
| iOS 기본 확대와 지도 조작 버튼 | iOS 26.5 simulator | 새 simulator app 설치 후 XcodeBuildMCP UI snapshot 및 screenshot 확인 | 로컬 전용: `.codex/evidence/786/ios-network-map-controls.jpg` | 노선도 화면에서 지역/노선 필터, 확대/축소/전체/중심 보기 버튼, 목록 버튼이 보임 |
| iOS 목록 대체 탐색 | iOS 26.5 simulator | XcodeBuildMCP로 `노선 목록으로 보기` 버튼 탭 후 screenshot 확인 | 로컬 전용: `.codex/evidence/786/ios-network-map-list.jpg` | `노선과 역 목록` sheet와 역 선택 버튼이 표시됨 |

사진·스크린샷 증거는 저장소 정책상 git에 커밋하지 않고 로컬 전용 evidence 폴더에 보관했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/network_map.dart`의 `_NetworkMapCanvas`, `_SelectedLineOverlayPainter`, `_NetworkMapListSheet`
- 공식 원본 노선도 이미지는 그대로 유지하고, 선택 노선 강조는 기존 station/edge 좌표를 활용한 overlay로 처리했다.

## 리스크

- 선택 노선 overlay는 datapack의 station/edge 좌표 품질에 의존한다. 좌표가 누락된 노선은 필터는 동작하지만 강조 선이 일부 생략될 수 있다.
- 지도 컨트롤은 현재 화면 우측 고정 배치라 일부 역 hit target 위를 덮을 수 있다. 목록 대체 탐색으로 같은 역 선택 흐름을 보완했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
