### PR TITLE
[Fix] 길찾기 출발·도착 입력 구조 단순화

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1063,16 +1063,30 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
           builder: (context, _) {
             final isLoading =
                 _controller.state.status == RouteSearchViewStatus.loading;
-            return FilledButton(
-              key: const Key('routeSearchSubmitButton'),
-              onPressed: isLoading ? null : _submit,
-              style: FilledButton.styleFrom(
-                minimumSize: const Size.fromHeight(60),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(8),
+            final canSubmit =
+                _originStation != null && _destinationStation != null;
+            final submitLabel = isLoading
+                ? '경로 검색 중'
+                : canSubmit
+                ? '길찾기'
+                : '길찾기, 출발역과 도착역을 먼저 선택해 주세요';
+            return Semantics(
+              button: true,
+              enabled: canSubmit && !isLoading,
+              label: submitLabel,
+              child: ExcludeSemantics(
+                child: FilledButton(
+                  key: const Key('routeSearchSubmitButton'),
+                  onPressed: canSubmit && !isLoading ? _submit : null,
+                  style: FilledButton.styleFrom(
+                    minimumSize: const Size.fromHeight(60),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  child: Text(isLoading ? '경로 검색 중' : '길찾기'),
                 ),
               ),
-              child: Text(isLoading ? '경로 검색 중' : '길찾기'),
             );
           },
         ),
@@ -1117,6 +1131,10 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
               ),
             ],
             const SizedBox(height: 18),
+            _RouteRecentDestinationList(
+              repository: widget.favoriteRouteRepository,
+              onSelected: _updateDestinationStation,
+            ),
             if (_validationMessage.isNotEmpty) ...[
               _RouteSearchMessage(
                 message: _validationMessage,
@@ -1171,11 +1189,6 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
                   ),
                 ),
               ),
-            const SizedBox(height: 18),
-            _RouteRecentDestinationList(
-              repository: widget.favoriteRouteRepository,
-              onSelected: _updateDestinationStation,
-            ),
             AnimatedBuilder(
               animation: _controller,
               builder: (context, _) => _RouteSearchBody(
@@ -1982,57 +1995,42 @@ class _RouteStationPickerState extends State<_RouteStationPicker> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: Semantics(
-                label: selectedStation == null
-                    ? '${widget.labelText} 입력'
-                    : '${widget.labelText} 선택됨, ${selectedStation.nameKo}',
-                textField: true,
-                liveRegion: selectedStation != null,
-                child: TextField(
-                  key: widget.inputKey,
-                  controller: _textController,
-                  minLines: 1,
-                  textInputAction: TextInputAction.search,
-                  style: const TextStyle(fontSize: 20, height: 1.35),
-                  decoration: InputDecoration(
-                    labelText: labelText,
-                    hintText: '역 이름을 입력해 주세요',
-                    floatingLabelBehavior: FloatingLabelBehavior.always,
-                    border: const OutlineInputBorder(
-                      borderRadius: BorderRadius.all(Radius.circular(8)),
-                    ),
-                  ),
-                  onSubmitted: (_) => _search(),
-                ),
+        Semantics(
+          label: selectedStation == null
+              ? '${widget.labelText} 입력'
+              : '${widget.labelText} 선택됨, ${selectedStation.nameKo}',
+          textField: true,
+          liveRegion: selectedStation != null,
+          child: TextField(
+            key: widget.inputKey,
+            controller: _textController,
+            minLines: 1,
+            textInputAction: TextInputAction.search,
+            style: const TextStyle(fontSize: 20, height: 1.35),
+            decoration: InputDecoration(
+              labelText: labelText,
+              hintText: '역 이름을 입력해 주세요',
+              floatingLabelBehavior: FloatingLabelBehavior.always,
+              border: const OutlineInputBorder(
+                borderRadius: BorderRadius.all(Radius.circular(8)),
+              ),
+              suffixIcon: AnimatedBuilder(
+                animation: _controller,
+                builder: (context, _) {
+                  final isLoading =
+                      _controller.state.status == StationSearchStatus.loading;
+                  return IconButton(
+                    key: widget.searchButtonKey,
+                    tooltip: '${widget.labelText} 검색',
+                    onPressed: isLoading ? null : _search,
+                    icon: const Icon(Icons.search),
+                  );
+                },
               ),
             ),
-            const SizedBox(width: 8),
-            AnimatedBuilder(
-              animation: _controller,
-              builder: (context, _) {
-                final isLoading =
-                    _controller.state.status == StationSearchStatus.loading;
-                return IconButton.outlined(
-                  key: widget.searchButtonKey,
-                  tooltip: '${widget.labelText} 검색',
-                  onPressed: isLoading ? null : _search,
-                  icon: const Icon(Icons.search),
-                  style: IconButton.styleFrom(
-                    minimumSize: const Size(56, 56),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                  ),
-                );
-              },
-            ),
-          ],
+            onSubmitted: (_) => _search(),
+          ),
         ),
-        const SizedBox(height: 8),
         const SizedBox(height: 8),
         AnimatedBuilder(
           animation: _controller,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2732,6 +2732,43 @@ void main() {
     }
   });
 
+  testWidgets('경로 검색은 출발 도착 선택 전 CTA 사유와 입력창 검색 아이콘을 보여준다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    try {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouteSearchScreen(
+            repository: FakeRouteSearchRepository(),
+            stationRepository: FakeStationSearchRepository(),
+            favoriteRouteRepository: FakeFavoriteRouteRepository(),
+            initialMobilityType: 'SENIOR',
+          ),
+        ),
+      );
+
+      final submitButton = tester.widget<FilledButton>(
+        find.byKey(const Key('routeSearchSubmitButton')),
+      );
+      expect(submitButton.onPressed, isNull);
+      expect(
+        find.bySemanticsLabel('길찾기, 출발역과 도착역을 먼저 선택해 주세요'),
+        findsOneWidget,
+      );
+
+      await _openRouteOriginStationInput(tester);
+      final originInput = tester.widget<TextField>(
+        find.byKey(const Key('routeOriginStationInput')),
+      );
+      expect(originInput.decoration?.suffixIcon, isNotNull);
+      expect(
+        find.byKey(const Key('routeOriginStationSearchButton')),
+        findsOneWidget,
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('역 검색 화면은 최근 검색어를 탭해 빠르게 다시 검색한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final repository = FakeStationSearchRepository(
@@ -5408,7 +5445,11 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(routeRepository.requests, isEmpty);
-    expect(find.text('출발역과 도착역을 검색 결과에서 선택해 주세요.'), findsOneWidget);
+    final submitButton = tester.widget<FilledButton>(
+      find.byKey(const Key('routeSearchSubmitButton')),
+    );
+    expect(submitButton.onPressed, isNull);
+    expect(find.text('출발역과 도착역을 검색 결과에서 선택해 주세요.'), findsNothing);
     expect(find.text('역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'), findsNothing);
   });
 
@@ -5416,6 +5457,7 @@ void main() {
     final semanticsHandle = tester.ensureSemantics();
     final stationRepository = FakeStationSearchRepository(
       queryResults: {
+        '상록': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
         '상록수': [_stationResult(id: 'station-sangnoksu', name: '상록수')],
         '사당': [_stationResult(id: 'station-sadang', name: '사당')],
       },
@@ -5551,18 +5593,16 @@ void main() {
       find.byKey(const Key('routeOriginStationInput')),
       '상록',
     );
+    await tester.pumpAndSettle();
     await tester.drag(find.byType(ListView), const Offset(0, -360));
-    await tester.pumpAndSettle();
-    final submitButton = tester.widget<FilledButton>(
-      find.byKey(const Key('routeSearchSubmitButton')),
-    );
-    submitButton.onPressed!();
-    await tester.pumpAndSettle();
-    await tester.drag(find.byType(ListView), const Offset(0, -240));
     await tester.pumpAndSettle();
 
     expect(routeRepository.requests, hasLength(1));
-    expect(find.text('출발역과 도착역을 검색 결과에서 선택해 주세요.'), findsOneWidget);
+    final submitButton = tester.widget<FilledButton>(
+      find.byKey(const Key('routeSearchSubmitButton')),
+    );
+    expect(submitButton.onPressed, isNull);
+    expect(find.text('출발역과 도착역을 검색 결과에서 선택해 주세요.'), findsNothing);
 
     await tester.drag(find.byType(ListView), const Offset(0, -500));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## 관련 이슈

close #787

## 작업 배경

- 길찾기 화면에서 출발역·도착역을 직접 선택하기 전에도 하단 CTA가 눌릴 수 있어 입력 상태와 실행 가능 상태가 분리되어 보였습니다.
- 검색 버튼이 입력칸 바깥에 별도 사각 버튼으로 배치되어 큰 글자 크기와 키보드 진입 상태에서 출발·도착 입력 흐름이 복잡하게 느껴질 수 있었습니다.

## 작업 내용

- 출발역과 도착역이 모두 선택된 경우에만 `길찾기` CTA가 활성화되도록 변경했습니다.
- 비활성 CTA에 `길찾기, 출발역과 도착역을 먼저 선택해 주세요` 접근성 라벨을 제공해 실행 불가 사유를 스크린리더가 읽을 수 있게 했습니다.
- 출발역·도착역 검색 버튼을 각 입력창의 trailing 검색 아이콘으로 통합했습니다.
- 최근 목적지 영역이 이동 조건보다 먼저 보이도록 배치해 목적지 재선택 흐름을 앞쪽으로 옮겼습니다.
- 입력 텍스트가 바뀌어 기존 선택 역이 무효화되면 이전 경로 결과를 숨기고 CTA를 비활성 상태로 되돌리는 동작을 widget test로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name '경로 검색은 출발 도착 선택 전 CTA 사유와 입력창 검색 아이콘을 보여준다'`: 최초 실패 확인 후 구현 완료 뒤 exit 0
  - `dart format apps/mobile/lib/route_search.dart apps/mobile/test/widget_test.dart`: exit 0
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name '경로 검색'`: exit 0, 13개 경로 검색 widget test 통과
  - `cd apps/mobile && flutter test test/route_search_test.dart test/widget_test.dart`: exit 0, 131개 test 통과
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `git diff --check`: exit 0
  - `cd apps/mobile && flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `cd apps/mobile && flutter build ios --simulator --debug`: exit 0, `build/ios/iphonesimulator/Runner.app` 생성
  - XcodeBuildMCP `build_run_sim`: exit 0, iOS Simulator 실행 성공

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 출발·도착 미선택 기본 화면 | Android emulator | debug APK 설치 후 1.0 글자 크기에서 길찾기 화면 캡처 | 로컬 전용: `.codex/evidence/787/android-route-flow-100.png` | 출발·도착 선택 영역과 하단 비활성 CTA가 함께 표시됨 |
| 출발역 입력 포커스 | Android emulator | 출발역 선택 후 입력창 캡처 | 로컬 전용: `.codex/evidence/787/android-route-keyboard-100.png` | 입력창 내부 trailing 검색 아이콘과 하단 비활성 CTA가 같은 화면에 유지됨 |
| 큰 글자 크기 기본 화면 | Android emulator | `font_scale=2.0` 적용 후 길찾기 화면 캡처 | 로컬 전용: `.codex/evidence/787/android-route-flow-200.png` | 주요 문구가 잘리지 않고 CTA가 화면 하단에 유지됨 |
| 큰 글자 크기 입력 포커스 | Android emulator | `font_scale=2.0`에서 출발역 입력창 캡처 | 로컬 전용: `.codex/evidence/787/android-route-keyboard-200.png` | 검색 아이콘이 입력창 안에 유지되고 CTA가 비활성 상태로 표시됨 |
| 출발·도착 미선택 기본 화면 | iOS Simulator | XcodeBuildMCP 빌드·실행 후 길찾기 화면 캡처 | 로컬 전용: `.codex/evidence/787/ios-route-flow.jpg` | 출발·도착 선택 영역, 이동 조건, 비활성 CTA가 정상 표시됨 |
| 출발역 입력 포커스 | iOS Simulator | XcodeBuildMCP UI tap으로 출발역 선택 후 캡처 | 로컬 전용: `.codex/evidence/787/ios-route-keyboard.jpg` | 입력창 내부 검색 아이콘과 하단 비활성 CTA가 정상 표시됨 |

스크린샷은 저장소 정책상 git에 커밋하지 않았고, 외부 업로드 승인을 받지 않아 로컬 전용 증거 경로로만 기록했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/route_search.dart`의 하단 CTA 활성 조건과 Semantics 라벨
  - 출발역·도착역 입력창 검색 버튼이 `suffixIcon`으로 이동한 부분
  - 입력 변경 시 기존 선택 역과 이전 경로 결과를 무효화하는 widget test

## 리스크

- Android emulator에서 소프트 키보드가 전체 높이로 열리지 않고 입력 포커스와 Gboard floating toolbar만 노출되어, 키보드 점유 높이까지 포함한 화면 압박은 물리 키보드 설정 영향으로 직접 확인하지 못했습니다.
- 검색 아이콘이 입력창 내부로 이동하면서 trailing 영역의 터치 대상은 Flutter 기본 `IconButton` 크기를 따릅니다.

## 체크리스트

- [x] CI 결과를 확인했다. Required CI 통과: Repository CI, Backend CI, Mobile App CI, Android CI, Changes.
- [x] CodeRabbit 리뷰를 확인했다. CodeRabbit review 완료, actionable comment 0.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. 해당 없음: CodeRabbit이 정상 완료됨.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. Release Artifacts의 Android Release Artifact는 진행 중이며 실패 신호 없음.
