### PR TITLE
[Refactor] 설정 화면 정보 구조와 보기 설정 변경 가능성 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -2766,14 +2766,14 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('화면·접근성 설정')),
+      appBar: AppBar(title: const Text('설정')),
       body: SafeArea(
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
           children: [
             _AppSettingsSection(
               key: const Key('settingsSection-mobility'),
-              title: '내 이동 조건',
+              title: '이동 조건',
               children: [
                 _AppSettingsActionTile(
                   key: const Key('mobilityProfileButton'),
@@ -2794,45 +2794,52 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
             ),
             _AppSettingsSection(
               key: const Key('settingsSection-reading'),
-              title: '화면과 읽기',
+              title: '화면 및 접근성',
               children: [
-                _AppSettingsInfoTile(
+                _AppSettingsPreferenceTile(
+                  key: const Key('largeTextSettingsButton'),
                   icon: Icons.text_fields,
-                  title: widget.viewPreferences.largeTextEnabled
-                      ? '큰 글자 켜짐'
-                      : '기본 글자 크기',
-                  subtitle: widget.viewPreferences.highContrastEnabled
-                      ? '고대비 표시를 사용해요'
-                      : '기본 대비로 표시해요',
+                  title: '큰 글자',
+                  enabled: widget.viewPreferences.largeTextEnabled,
+                  onTap: _showViewPreferenceGuide,
                 ),
-                _AppSettingsInfoTile(
+                _AppSettingsPreferenceTile(
+                  key: const Key('simpleViewSettingsButton'),
                   icon: Icons.visibility_outlined,
-                  title: widget.viewPreferences.simpleViewEnabled
-                      ? '간편 보기 켜짐'
-                      : '전체 보기 켜짐',
-                  subtitle: '핵심 행동을 먼저 보여줘요',
+                  title: '간편 보기',
+                  enabled: widget.viewPreferences.simpleViewEnabled,
+                  onTap: _showViewPreferenceGuide,
                 ),
-              ],
-            ),
-            _AppSettingsSection(
-              key: const Key('settingsSection-route'),
-              title: '경로 찾기',
-              children: [
-                _AppSettingsInfoTile(
-                  icon: Icons.route,
-                  title: '${_profile.title} 조건 적용 중',
-                  subtitle: _profile.summary,
+                _AppSettingsPreferenceTile(
+                  key: const Key('highContrastSettingsButton'),
+                  icon: Icons.contrast,
+                  title: '고대비',
+                  enabled: widget.viewPreferences.highContrastEnabled,
+                  onTap: _showViewPreferenceGuide,
                 ),
               ],
             ),
             _AppSettingsSection(
               key: const Key('settingsSection-region-data'),
-              title: '지역과 데이터',
-              children: const [
-                _AppSettingsInfoTile(
+              title: '기본 지역과 데이터',
+              children: [
+                const _AppSettingsInfoTile(
                   icon: Icons.public,
                   title: '수도권 우선',
                   subtitle: '오프라인 데이터팩과 검증된 출처를 먼저 사용해요',
+                ),
+                _AppSettingsActionTile(
+                  key: const Key('offlineDataSettingsButton'),
+                  icon: Icons.offline_pin_outlined,
+                  title: '인터넷 없이 이용',
+                  subtitle: '노선도와 역 정보 사용 범위를 확인해요',
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const OfflineDataScreen(),
+                      ),
+                    );
+                  },
                 ),
               ],
             ),
@@ -2881,21 +2888,8 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
             ),
             _AppSettingsSection(
               key: const Key('settingsSection-help-privacy'),
-              title: '도움말·문의',
+              title: '개인정보 및 도움말',
               children: [
-                _AppSettingsActionTile(
-                  key: const Key('offlineDataSettingsButton'),
-                  icon: Icons.offline_pin_outlined,
-                  title: '인터넷 없이 이용',
-                  subtitle: '노선도와 역 정보 사용 범위를 확인해요',
-                  onTap: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute<void>(
-                        builder: (_) => const OfflineDataScreen(),
-                      ),
-                    );
-                  },
-                ),
                 _AppSettingsActionTile(
                   key: const Key('settingsSupportPrivacyButton'),
                   icon: Icons.help_outline,
@@ -2909,6 +2903,12 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
         ),
       ),
     );
+  }
+
+  void _showViewPreferenceGuide() {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('보기 설정은 처음 설정에서 변경할 수 있어요.')));
   }
 }
 
@@ -3038,6 +3038,73 @@ class _AppSettingsInfoTile extends StatelessWidget {
         shape: Border(
           bottom: BorderSide(
             color: Theme.of(context).colorScheme.outlineVariant,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AppSettingsPreferenceTile extends StatelessWidget {
+  const _AppSettingsPreferenceTile({
+    required this.icon,
+    required this.title,
+    required this.enabled,
+    required this.onTap,
+    super.key,
+  });
+
+  final IconData icon;
+  final String title;
+  final bool enabled;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final value = enabled ? '켜짐' : '꺼짐';
+    return Semantics(
+      button: true,
+      label: '$title, $value, 처음 설정에서 변경할 수 있어요',
+      onTap: onTap,
+      child: ExcludeSemantics(
+        child: ListTile(
+          onTap: onTap,
+          minVerticalPadding: 12,
+          minLeadingWidth: 32,
+          leading: Icon(icon, color: EasySubwayAccessibleColors.primary),
+          title: Text(
+            title,
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: EasySubwayAccessibleColors.text,
+              fontWeight: FontWeight.w800,
+              height: 1.25,
+            ),
+          ),
+          subtitle: Text(
+            '처음 설정에서 변경할 수 있어요',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: EasySubwayAccessibleColors.mutedText,
+              height: 1.3,
+            ),
+          ),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                value,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: EasySubwayAccessibleColors.text,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              const SizedBox(width: 4),
+              const Icon(Icons.chevron_right),
+            ],
+          ),
+          shape: Border(
+            bottom: BorderSide(
+              color: Theme.of(context).colorScheme.outlineVariant,
+            ),
           ),
         ),
       ),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1312,20 +1312,44 @@ void main() {
         );
       }
 
-      expect(find.text('화면·접근성 설정'), findsOneWidget);
-      expect(find.text('내 이동 조건'), findsOneWidget);
-      expect(find.text('화면과 읽기'), findsOneWidget);
-      expect(find.text('경로 찾기'), findsOneWidget);
-      expect(find.text('지역과 데이터'), findsOneWidget);
+      expect(
+        find.descendant(of: find.byType(AppBar), matching: find.text('설정')),
+        findsOneWidget,
+      );
+      expect(find.text('화면·접근성 설정'), findsNothing);
+      expect(find.text('이동 조건'), findsOneWidget);
+      expect(find.text('화면 및 접근성'), findsOneWidget);
+      expect(find.text('경로 찾기'), findsNothing);
+      expect(find.text('기본 지역과 데이터'), findsOneWidget);
       expect(find.text('고령자'), findsOneWidget);
-      expect(find.text('계단을 피하고 쉬운 환승을 우선해요'), findsNWidgets(2));
-      expect(find.text('큰 글자 켜짐'), findsOneWidget);
-      expect(find.text('고대비 표시를 사용해요'), findsOneWidget);
-      expect(find.text('전체 보기 켜짐'), findsOneWidget);
+      expect(find.text('계단을 피하고 쉬운 환승을 우선해요'), findsOneWidget);
+      expect(find.text('큰 글자'), findsOneWidget);
+      expect(find.text('고대비'), findsOneWidget);
+      expect(find.text('간편 보기'), findsOneWidget);
+      expect(find.text('켜짐'), findsNWidgets(2));
+      expect(find.text('꺼짐'), findsOneWidget);
       expect(find.byKey(const Key('mobilityProfileButton')), findsOneWidget);
       expect(
         settingsActionSemantics(
           '고령자, 계단을 피하고 쉬운 환승을 우선해요',
+        ).getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
+      );
+      expect(
+        settingsActionSemantics(
+          '큰 글자, 켜짐, 처음 설정에서 변경할 수 있어요',
+        ).getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
+      );
+      expect(
+        settingsActionSemantics(
+          '간편 보기, 꺼짐, 처음 설정에서 변경할 수 있어요',
+        ).getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
+      );
+      expect(
+        settingsActionSemantics(
+          '고대비, 켜짐, 처음 설정에서 변경할 수 있어요',
         ).getSemanticsData().hasAction(SemanticsAction.tap),
         isTrue,
       );
@@ -1337,7 +1361,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('휠체어'), findsOneWidget);
-      expect(find.text('계단 없는 길만 안내해요'), findsNWidgets(2));
+      expect(find.text('계단 없는 길만 안내해요'), findsOneWidget);
 
       await tester.scrollUntilVisible(
         find.byKey(const Key('notificationSettingsButton')),
@@ -1346,12 +1370,18 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('알림'), findsOneWidget);
+      expect(find.text('내 활동'), findsOneWidget);
+      expect(find.text('개인정보 및 도움말'), findsOneWidget);
       expect(
         find.byKey(const Key('settingsSection-help-privacy')),
         findsOneWidget,
       );
       expect(
         find.byKey(const Key('notificationSettingsButton')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('offlineDataSettingsButton')),
         findsOneWidget,
       );
       expect(


### PR DESCRIPTION
## 관련 이슈

close #788

## 작업 배경

- 기존 설정 화면은 앱바 제목이 `화면·접근성 설정`이지만 이동 조건, 경로 조건, 데이터, 알림, 도움말이 한 화면에 섞여 있어 실제 역할과 제목이 맞지 않았습니다.
- `내 이동 조건`과 `경로 찾기` 섹션이 같은 이동 조건 상태를 반복해 화면을 길게 만들고, 보기 설정은 값만 보여 변경 가능한 항목인지 알기 어려웠습니다.

## 작업 내용

- 앱바 제목을 `설정`으로 바꾸고 섹션을 `이동 조건`, `화면 및 접근성`, `기본 지역과 데이터`, `알림`, `내 활동`, `개인정보 및 도움말` 순서로 정리했습니다.
- `경로 찾기` 중복 섹션을 제거하고 이동 조건 상태는 `이동 조건` 섹션의 단일 항목으로 유지했습니다.
- `큰 글자`, `간편 보기`, `고대비`를 우측 상태값과 화살표가 있는 변경 가능 항목으로 바꾸고, 스크린리더 label에 현재 값과 변경 가능 안내를 포함했습니다.
- `인터넷 없이 이용`을 `기본 지역과 데이터` 섹션으로 이동해 오프라인 데이터 진입점을 데이터 성격에 맞게 배치했습니다.
- 기존 이동 조건 변경, 알림 설정, 내 신고, 오프라인 데이터, 도움말·문의 진입 경로는 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name '설정 화면은 교통약자 사용 맥락별 섹션과 기존 설정 진입점을 제공한다'`: 최초 실패 확인 후 구현 완료 뒤 exit 0
  - `dart format apps/mobile/lib/main.dart apps/mobile/test/widget_test.dart`: exit 0
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name '설정'`: exit 0, 10개 관련 test 통과
  - `cd apps/mobile && flutter test test/widget_test.dart`: exit 0, 120개 widget test 통과
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `git diff --check`: exit 0
  - `cd apps/mobile && flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `cd apps/mobile && flutter build ios --simulator --debug`: exit 0, `build/ios/iphonesimulator/Runner.app` 생성
  - XcodeBuildMCP `build_run_sim`: exit 0, iOS Simulator 실행 성공

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 설정 화면 상단 정보 구조 | Android emulator | 최신 debug APK 설치 후 1.0 글자 크기에서 설정 화면 캡처 | 로컬 전용: `.codex/evidence/788/android-settings-100.png` | `설정`, `이동 조건`, `화면 및 접근성`, `기본 지역과 데이터`와 보기 설정 상태/화살표가 표시됨 |
| 설정 화면 접근성 트리 | Android emulator | `uiautomator dump`로 설정 화면 content-desc 확인 | 로컬 전용: `.codex/evidence/788/android-settings-100-ui.xml` | 보기 설정 항목이 `큰 글자, 켜짐, 처음 설정에서 변경할 수 있어요` 같은 버튼 label로 노출됨 |
| 큰 글자 상단 구조 | Android emulator | `font_scale=2.0` 적용 후 설정 화면 캡처 | 로컬 전용: `.codex/evidence/788/android-settings-200.png` | 이동 조건과 보기 설정 항목이 겹침 없이 읽힘 |
| 큰 글자 하단 섹션 | Android emulator | `font_scale=2.0`에서 아래쪽으로 스크롤 후 캡처 | 로컬 전용: `.codex/evidence/788/android-settings-bottom-200.png` | `기본 지역과 데이터`, `알림`, `내 활동`, `개인정보 및 도움말` 섹션에 접근 가능함 |
| iOS 설정 화면 상단 | iOS Simulator | XcodeBuildMCP 실행 후 설정 진입 및 screenshot | 로컬 전용: `.codex/evidence/788/ios-settings-top.jpg` | 상단 섹션 구조와 보기 설정 상태/화살표가 표시됨 |
| iOS 설정 화면 하단 | iOS Simulator | XcodeBuildMCP swipe 후 screenshot | 로컬 전용: `.codex/evidence/788/ios-settings-bottom.jpg` | 내 활동과 개인정보 및 도움말 섹션이 표시되고 기존 진입점이 유지됨 |

스크린샷은 저장소 정책상 git에 커밋하지 않았고, 외부 업로드 승인을 받지 않아 로컬 전용 증거 경로로만 기록했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `AppSettingsScreen`의 섹션 순서와 `경로 찾기` 중복 섹션 제거
  - `_AppSettingsPreferenceTile`의 semantics label과 tap action
  - 기존 설정 진입점 key가 유지되는지 확인하는 widget test

## 리스크

- 보기 설정 항목은 현재 저장된 온보딩 값을 표시하고 변경 가능성을 안내하지만, 이번 PR은 새 저장 API나 즉시 토글 저장 흐름을 추가하지 않습니다.
- Android 실제 TalkBack 음성 청취는 수행하지 않았고, widget semantics test와 Android UI tree dump로 label/버튼 역할을 대체 확인했습니다.

## 체크리스트

- [x] CI 결과를 확인했다. Required CI 통과: Repository CI, Backend CI, Mobile App CI, Android CI, Changes.
- [x] CodeRabbit 리뷰를 확인했다. CodeRabbit은 PR review rate limit으로 실제 리뷰를 시작하지 못함.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. Codex CLI fallback review 완료, actionable comment 0.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. Release Artifacts Android Release Artifact 통과, Backend Release Image skipped.
