### PR TITLE
[Style] 이동 조건 명칭과 하단 내비게이션 표기 통일

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1809,7 +1809,13 @@ class _HomePrototypeHero extends StatelessWidget {
                       ),
                     ),
                   ),
-                  _HomeProfilePill(profile: profile, onTap: onProfileTap),
+                  Flexible(
+                    fit: FlexFit.loose,
+                    child: _HomeProfilePill(
+                      profile: profile,
+                      onTap: onProfileTap,
+                    ),
+                  ),
                 ],
               ),
               const SizedBox(height: 18),
@@ -1985,7 +1991,11 @@ class _HomeProfilePill extends StatelessWidget {
             ),
           ),
           icon: Icon(profile.icon, size: 16),
-          label: Text(profile.title),
+          label: Text(
+            profile.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
         ),
       ),
     );
@@ -2778,7 +2788,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
                 _AppSettingsActionTile(
                   key: const Key('mobilityProfileButton'),
                   icon: Icons.directions_walk,
-                  title: _profile.title,
+                  title: _profile.appliedConditionLabel,
                   subtitle: _profile.summary,
                   onTap: () async {
                     final selected = await widget.onOpenMobilityProfile();

--- a/apps/mobile/lib/mobility_profile.dart
+++ b/apps/mobile/lib/mobility_profile.dart
@@ -30,11 +30,11 @@ class MobilityProfileOption {
     if (avoidStairs) {
       conditions.add('계단 피하기');
     }
-    if (minimizeTransfers) {
-      conditions.add('환승 줄이기');
-    }
     if (requireElevator) {
       conditions.add('엘리베이터 이동');
+    }
+    if (minimizeTransfers) {
+      conditions.add('환승 줄이기');
     }
     if (avoidLongWalks && !minimizeTransfers) {
       conditions.add('긴 보행 줄이기');

--- a/apps/mobile/lib/mobility_profile.dart
+++ b/apps/mobile/lib/mobility_profile.dart
@@ -25,6 +25,25 @@ class MobilityProfileOption {
   final bool minimizeTransfers;
   final bool avoidLongWalks;
 
+  String get conditionSummary {
+    final conditions = <String>[];
+    if (avoidStairs) {
+      conditions.add('계단 피하기');
+    }
+    if (minimizeTransfers) {
+      conditions.add('환승 줄이기');
+    }
+    if (requireElevator) {
+      conditions.add('엘리베이터 이동');
+    }
+    if (avoidLongWalks && !minimizeTransfers) {
+      conditions.add('긴 보행 줄이기');
+    }
+    return conditions.take(2).join(' · ');
+  }
+
+  String get appliedConditionLabel => '$conditionSummary 적용 중';
+
   String semanticsLabel(bool isSelected) {
     final state = isSelected ? '선택됨' : '선택 가능';
     return '$title $state, $summary';
@@ -35,7 +54,7 @@ class MobilityProfileOption {
 const mobilityProfileOptions = <MobilityProfileOption>[
   MobilityProfileOption(
     id: 'elderly',
-    title: '고령자',
+    title: '천천히 이동',
     summary: '계단을 피하고 쉬운 환승을 우선해요',
     icon: Icons.elderly,
     mobilityType: 'SENIOR',
@@ -47,7 +66,7 @@ const mobilityProfileOptions = <MobilityProfileOption>[
   ),
   MobilityProfileOption(
     id: 'stroller',
-    title: '유모차',
+    title: '유모차 이용',
     summary: '엘리베이터와 넓은 길을 우선해요',
     icon: Icons.child_friendly,
     mobilityType: 'STROLLER',
@@ -59,7 +78,7 @@ const mobilityProfileOptions = <MobilityProfileOption>[
   ),
   MobilityProfileOption(
     id: 'wheelchair',
-    title: '휠체어',
+    title: '휠체어 이용',
     summary: '계단 없는 길만 안내해요',
     icon: Icons.accessible_forward,
     mobilityType: 'WHEELCHAIR',
@@ -71,7 +90,7 @@ const mobilityProfileOptions = <MobilityProfileOption>[
   ),
   MobilityProfileOption(
     id: 'pregnant',
-    title: '임산부',
+    title: '임신 중',
     summary: '짧게 걷고 적게 갈아타요',
     icon: Icons.pregnant_woman,
     mobilityType: 'PREGNANT',
@@ -83,7 +102,7 @@ const mobilityProfileOptions = <MobilityProfileOption>[
   ),
   MobilityProfileOption(
     id: 'injured',
-    title: '일시 부상',
+    title: '부상·회복 중',
     summary: '계단과 긴 보행을 줄여요',
     icon: Icons.healing,
     mobilityType: 'TEMPORARY_INJURY',
@@ -95,7 +114,7 @@ const mobilityProfileOptions = <MobilityProfileOption>[
   ),
   MobilityProfileOption(
     id: 'luggage',
-    title: '큰 짐',
+    title: '큰 짐이 있음',
     summary: '짐을 들고 이동하기 쉬운 길을 우선해요',
     icon: Icons.luggage,
     mobilityType: 'LUGGAGE',

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -397,7 +397,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
           NavigationDestination(icon: Icon(Icons.home_outlined), label: '홈'),
           NavigationDestination(icon: Icon(Icons.map), label: '노선도'),
           NavigationDestination(icon: Icon(Icons.route_outlined), label: '길찾기'),
-          NavigationDestination(icon: Icon(Icons.bookmark_border), label: '저장'),
+          NavigationDestination(icon: Icon(Icons.star_border), label: '즐겨찾기'),
           NavigationDestination(icon: Icon(Icons.more_horiz), label: '더보기'),
         ],
       ),

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -1214,15 +1214,7 @@ class _OnboardingProfileCard extends StatelessWidget {
   }
 
   String _profileDisplayTitle(MobilityProfileOption profile) {
-    return switch (profile.id) {
-      'elderly' => '천천히 이동',
-      'wheelchair' => '휠체어 이용',
-      'stroller' => '유모차 이용',
-      'pregnant' => '임신 중',
-      'injured' => '몸이 불편함',
-      'luggage' => '큰 짐이 있음',
-      _ => profile.title,
-    };
+    return profile.title;
   }
 
   String _profileDisplaySummary(MobilityProfileOption profile) {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1925,15 +1925,7 @@ MobilityProfileOption _mobilityOptionFor(String mobilityType) {
 }
 
 String _routeMobilityConditionLabel(MobilityProfileOption option) {
-  final conditions = <String>[];
-  if (option.avoidStairs) {
-    conditions.add('계단 피하기');
-  }
-  conditions.add('엘리베이터 이동');
-  if (option.minimizeTransfers) {
-    conditions.add('환승 줄이기');
-  }
-  return conditions.take(2).join(' · ');
+  return option.conditionSummary;
 }
 
 class _RouteStationPicker extends StatefulWidget {

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -71,7 +71,10 @@ void main() {
         find.byKey(const Key('onboardingProfileCard-wheelchair')),
       );
       await tester.pumpAndSettle();
-      expect(find.bySemanticsLabel('휠체어 선택됨, 계단 없는 길만 안내해요'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('휠체어 이용 선택됨, 계단 없는 길만 안내해요'),
+        findsOneWidget,
+      );
 
       await tester.tap(find.byKey(const Key('onboardingDoneButton')));
       await tester.pumpAndSettle();
@@ -372,7 +375,7 @@ void main() {
       ),
     );
 
-    expect(result.profile.title, '임산부');
+    expect(result.profile.title, '임신 중');
     expect(result.preferences.largeTextEnabled, isFalse);
     expect(result.preferences.highContrastEnabled, isTrue);
     expect(result.preferences.simpleViewEnabled, isFalse);

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -480,7 +480,7 @@ void main() {
     expect(requestedAuthorizations, everyElement(startsWith('Basic ')));
     expect(favorites.single.summaryTitle, '상록수에서 사당까지');
     expect(saved.favoriteRouteId, 'route-1');
-    expect(saved.mobilityLabel, '고령자');
+    expect(saved.mobilityLabel, '천천히 이동');
     expect(saved.scoreLabel, '이동 점수 92점');
   });
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1365,7 +1365,7 @@ void main() {
       await tester.tap(find.byKey(const Key('mobilityProfileDoneButton')));
       await tester.pumpAndSettle();
 
-      expect(find.text('계단 피하기 · 환승 줄이기 적용 중'), findsOneWidget);
+      expect(find.text('계단 피하기 · 엘리베이터 이동 적용 중'), findsOneWidget);
       expect(find.text('계단 없는 길만 안내해요'), findsOneWidget);
 
       await tester.scrollUntilVisible(
@@ -4709,6 +4709,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('휠체어 이용'), findsOneWidget);
+    expect(find.text('계단 피하기 · 엘리베이터 이동'), findsOneWidget);
     await _openRouteOriginStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeOriginStationInput')),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -543,8 +543,11 @@ void main() {
       expect(find.text('즐겨찾기 역'), findsNothing);
       expect(find.text('즐겨찾기 시설'), findsNothing);
       expect(find.textContaining('빠른 길보다'), findsNothing);
-      expect(find.text('고령자'), findsOneWidget);
-      expect(find.bySemanticsLabel('길찾기와 역검색, 현재 이동 조건 고령자'), findsOneWidget);
+      expect(find.text('천천히 이동'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('길찾기와 역검색, 현재 이동 조건 천천히 이동'),
+        findsOneWidget,
+      );
       expect(find.textContaining('휠체어'), findsNothing);
 
       final heroStationButtonSize = tester.getSize(
@@ -663,6 +666,8 @@ void main() {
     expect(find.byKey(const Key('networkMapLocateButton')), findsOneWidget);
     expect(find.byKey(const Key('networkMapListButton')), findsOneWidget);
     expect(find.byKey(const Key('networkMapSurface')), findsOneWidget);
+    expect(find.text('즐겨찾기'), findsOneWidget);
+    expect(find.text('저장'), findsNothing);
     expect(find.text('테스트권'), findsOneWidget);
     expect(find.text('전국'), findsNothing);
     final viewer = tester.widget<InteractiveViewer>(
@@ -1321,7 +1326,7 @@ void main() {
       expect(find.text('화면 및 접근성'), findsOneWidget);
       expect(find.text('경로 찾기'), findsNothing);
       expect(find.text('기본 지역과 데이터'), findsOneWidget);
-      expect(find.text('고령자'), findsOneWidget);
+      expect(find.text('계단 피하기 · 환승 줄이기 적용 중'), findsOneWidget);
       expect(find.text('계단을 피하고 쉬운 환승을 우선해요'), findsOneWidget);
       expect(find.text('큰 글자'), findsOneWidget);
       expect(find.text('고대비'), findsOneWidget);
@@ -1331,7 +1336,7 @@ void main() {
       expect(find.byKey(const Key('mobilityProfileButton')), findsOneWidget);
       expect(
         settingsActionSemantics(
-          '고령자, 계단을 피하고 쉬운 환승을 우선해요',
+          '계단 피하기 · 환승 줄이기 적용 중, 계단을 피하고 쉬운 환승을 우선해요',
         ).getSemanticsData().hasAction(SemanticsAction.tap),
         isTrue,
       );
@@ -1360,7 +1365,7 @@ void main() {
       await tester.tap(find.byKey(const Key('mobilityProfileDoneButton')));
       await tester.pumpAndSettle();
 
-      expect(find.text('휠체어'), findsOneWidget);
+      expect(find.text('계단 피하기 · 환승 줄이기 적용 중'), findsOneWidget);
       expect(find.text('계단 없는 길만 안내해요'), findsOneWidget);
 
       await tester.scrollUntilVisible(
@@ -1427,8 +1432,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('homeTripControlPanel')), findsNothing);
-    expect(find.text('고령자'), findsOneWidget);
-    expect(find.bySemanticsLabel('길찾기와 역검색, 현재 이동 조건 고령자'), findsOneWidget);
+    expect(find.text('천천히 이동'), findsOneWidget);
+    expect(find.bySemanticsLabel('길찾기와 역검색, 현재 이동 조건 천천히 이동'), findsOneWidget);
 
     await _openMobilityProfileFromSettings(tester);
     await tester.tap(find.byKey(const Key('mobilityProfileCard-wheelchair')));
@@ -1444,8 +1449,8 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('휠체어'), findsOneWidget);
-    expect(find.bySemanticsLabel('길찾기와 역검색, 현재 이동 조건 휠체어'), findsOneWidget);
+    expect(find.text('휠체어 이용'), findsOneWidget);
+    expect(find.bySemanticsLabel('길찾기와 역검색, 현재 이동 조건 휠체어 이용'), findsOneWidget);
     semanticsHandle.dispose();
   });
 
@@ -2339,10 +2344,12 @@ void main() {
       expect(find.text('즐겨찾기한 경로'), findsOneWidget);
       expect(find.text('상록수에서 사당까지'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
-      expect(find.text('고령자'), findsOneWidget);
+      expect(find.text('천천히 이동'), findsOneWidget);
       expect(find.text('이동 점수 92점'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('즐겨찾기 경로, 상록수에서 사당까지, 수도권 4호선, 고령자, 이동 점수 92점'),
+        find.bySemanticsLabel(
+          '즐겨찾기 경로, 상록수에서 사당까지, 수도권 4호선, 천천히 이동, 이동 점수 92점',
+        ),
         findsOneWidget,
       );
       expect(find.bySemanticsLabel('상록수에서 사당까지 삭제'), findsOneWidget);
@@ -2746,7 +2753,7 @@ void main() {
       );
       expect(find.bySemanticsLabel('출발 도착 바꾸기'), findsOneWidget);
       expect(find.text('이동 조건'), findsOneWidget);
-      expect(find.text('계단 피하기 · 엘리베이터 이동'), findsWidgets);
+      expect(find.text('계단 피하기 · 환승 줄이기'), findsWidgets);
       expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
 
       await tester.drag(find.byType(ListView), const Offset(0, -260));
@@ -4285,20 +4292,22 @@ void main() {
       await _openMobilityProfileFromSettings(tester);
 
       expect(find.text('이동 조건'), findsOneWidget);
-      expect(find.text('고령자'), findsOneWidget);
-      expect(find.text('유모차'), findsOneWidget);
-      expect(find.text('휠체어'), findsOneWidget);
-      expect(find.text('임산부'), findsOneWidget);
-      expect(find.text('일시 부상'), findsOneWidget);
-      expect(find.text('큰 짐'), findsOneWidget);
+      expect(find.text('천천히 이동'), findsOneWidget);
+      expect(find.text('유모차 이용'), findsOneWidget);
+      expect(find.text('휠체어 이용'), findsOneWidget);
+      expect(find.text('임신 중'), findsOneWidget);
+      expect(find.text('부상·회복 중'), findsOneWidget);
+      expect(find.text('큰 짐이 있음'), findsOneWidget);
       expect(find.text('계단을 피하고 쉬운 환승을 우선해요'), findsOneWidget);
       expect(find.text('엘리베이터와 넓은 길을 우선해요'), findsOneWidget);
       expect(find.text('계단 없는 길만 안내해요'), findsOneWidget);
 
       expect(
-        tester.getSemantics(find.bySemanticsLabel('휠체어 선택 가능, 계단 없는 길만 안내해요')),
+        tester.getSemantics(
+          find.bySemanticsLabel('휠체어 이용 선택 가능, 계단 없는 길만 안내해요'),
+        ),
         isSemantics(
-          label: '휠체어 선택 가능, 계단 없는 길만 안내해요',
+          label: '휠체어 이용 선택 가능, 계단 없는 길만 안내해요',
           isButton: true,
           hasTapAction: true,
         ),
@@ -4317,8 +4326,11 @@ void main() {
       await tester.tap(wheelchairCard);
       await tester.pumpAndSettle();
 
-      expect(find.bySemanticsLabel('휠체어 선택됨, 계단 없는 길만 안내해요'), findsOneWidget);
-      expect(find.text('휠체어 조건을 선택했습니다'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('휠체어 이용 선택됨, 계단 없는 길만 안내해요'),
+        findsOneWidget,
+      );
+      expect(find.text('휠체어 이용 조건을 선택했습니다'), findsOneWidget);
       expect(find.bySemanticsLabel('선택 완료'), findsOneWidget);
     } finally {
       semanticsHandle.dispose();
@@ -4343,8 +4355,11 @@ void main() {
 
       await _openMobilityProfileFromSettings(tester);
 
-      expect(find.bySemanticsLabel('휠체어 선택됨, 계단 없는 길만 안내해요'), findsOneWidget);
-      expect(find.text('휠체어 조건을 선택했습니다'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('휠체어 이용 선택됨, 계단 없는 길만 안내해요'),
+        findsOneWidget,
+      );
+      expect(find.text('휠체어 이용 조건을 선택했습니다'), findsOneWidget);
     } finally {
       semanticsHandle.dispose();
     }
@@ -4396,7 +4411,7 @@ void main() {
 
     await tester.tap(find.byKey(const Key('routeSearchButton')));
     await tester.pumpAndSettle();
-    expect(find.text('휠체어'), findsOneWidget);
+    expect(find.text('휠체어 이용'), findsOneWidget);
     await _openRouteOriginStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeOriginStationInput')),
@@ -4463,7 +4478,7 @@ void main() {
       expect(find.text('출발역 ID'), findsNothing);
       expect(find.text('도착역 ID'), findsNothing);
       expect(find.text('적용 중인 조건'), findsOneWidget);
-      expect(find.text('고령자'), findsOneWidget);
+      expect(find.text('천천히 이동'), findsOneWidget);
       expect(find.byType(DropdownButton<String>), findsNothing);
 
       await _openRouteOriginStationInput(tester);
@@ -4526,7 +4541,7 @@ void main() {
       expect(find.text('빠른 순'), findsOneWidget);
       expect(find.text('환승 적은 순'), findsOneWidget);
       expect(find.text('상록수 → 사당'), findsOneWidget);
-      expect(find.text('계단 피하기 · 엘리베이터 이동'), findsWidgets);
+      expect(find.text('계단 피하기 · 환승 줄이기'), findsWidgets);
       expect(find.text('7분'), findsOneWidget);
       expect(find.text('환승 없음 · 걷기 300m'), findsOneWidget);
       expect(find.text('추천'), findsOneWidget);
@@ -4628,7 +4643,7 @@ void main() {
 
     await tester.tap(find.byType(DropdownButton<String>));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('휠체어').last);
+    await tester.tap(find.text('휠체어 이용').last);
     await tester.pumpAndSettle();
     await _openRouteOriginStationInput(tester);
     await tester.enterText(
@@ -4686,14 +4701,14 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(DropdownButton<String>), findsNothing);
-    expect(find.text('고령자'), findsOneWidget);
+    expect(find.text('천천히 이동'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('routeSimpleMobilityTypeButton')));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('routeMobilityOption-WHEELCHAIR')));
     await tester.pumpAndSettle();
 
-    expect(find.text('휠체어'), findsOneWidget);
+    expect(find.text('휠체어 이용'), findsOneWidget);
     await _openRouteOriginStationInput(tester);
     await tester.enterText(
       find.byKey(const Key('routeOriginStationInput')),
@@ -4745,9 +4760,9 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        tester.getSemantics(find.bySemanticsLabel('이동 조건 바꾸기, 현재 고령자')),
+        tester.getSemantics(find.bySemanticsLabel('이동 조건 바꾸기, 현재 천천히 이동')),
         isSemantics(
-          label: '이동 조건 바꾸기, 현재 고령자',
+          label: '이동 조건 바꾸기, 현재 천천히 이동',
           isButton: true,
           hasTapAction: true,
         ),


### PR DESCRIPTION
## 관련 이슈

close #789

## 작업 배경

- QA 검토에서 온보딩, 홈, 길찾기, 설정, 노선도 화면의 이동 조건 명칭과 하단 내비게이션 표기가 서로 달라 출시 전 혼란을 줄여야 한다는 지적이 있었다.
- 서버 API로 전달하는 mobilityType 값은 유지하고, 앱에서 사용자에게 보이는 명칭과 스크린리더 라벨만 통일한다.

## 작업 내용

- 이동 조건 표시명을 사용자 상황 중심 문구로 통일했다: 천천히 이동, 유모차 이용, 휠체어 이용, 임신 중, 부상·회복 중, 큰 짐이 있음.
- 설정과 길찾기 화면에서 이동 조건의 적용 상태를 계단 피하기, 환승 줄이기, 엘리베이터 이동 같은 실제 조건 요약으로 보여주도록 공통 계산값을 추가했다.
- 엘리베이터가 필수인 이동 조건은 조건 요약에서 엘리베이터 이동을 환승 줄이기보다 먼저 보여주도록 보정했다.
- 홈 상단 이동 조건 pill이 긴 문구와 큰 글자 환경에서도 넘치지 않도록 폭 제약과 말줄임을 적용했다.
- 노선도 하단 내비게이션의 저장 탭을 홈과 같은 즐겨찾기 라벨과 star 아이콘으로 통일했다.
- 온보딩, 홈, 설정, 길찾기, 즐겨찾기 경로, 노선도 위젯 테스트 기대값을 새 표기 기준으로 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/onboarding_test.dart test/widget_test.dart test/route_search_test.dart`: exit 0, 147 tests passed
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `cd apps/mobile && flutter build apk --debug`: exit 0, app-debug.apk 생성
  - `cd apps/mobile && flutter build ios --simulator --debug`: exit 0, Runner.app 생성
  - `git diff --check`: exit 0
  - CI / Android CI: pass, 4m40s, https://github.com/AquilaXk/easysubway/actions/runs/28123452755/job/83281126428
  - CI / Mobile App CI: pass, 3m41s, https://github.com/AquilaXk/easysubway/actions/runs/28123452755/job/83281126385

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 온보딩 기본 조건 표기 | Android emulator API 36 | 클린 설치 후 온보딩 시작 화면 캡처와 UI tree 확인 | 로컬: `.codex/evidence/789/android-02-onboarding-profiles.png`, `.codex/evidence/789/android-02-onboarding-profiles-ui.xml` | 기본 조건 안내가 `천천히 이동` 기준으로 표시됨 |
| 홈 이동 조건 pill 및 하단 내비게이션 | Android emulator API 36 | 기본 설정 완료 후 홈 캡처와 UI tree 확인 | 로컬: `.codex/evidence/789/android-03-home.png`, `.codex/evidence/789/android-03-home-ui.xml` | 홈 pill이 `천천히 이동`으로 표시되고 하단 탭이 `즐겨찾기`로 표시됨 |
| 설정 이동 조건 요약 | Android emulator API 36 | 더보기 설정 화면 캡처와 UI tree 확인 | 로컬: `.codex/evidence/789/android-04-settings.png`, `.codex/evidence/789/android-04-settings-ui.xml` | 설정의 이동 조건 제목이 `계단 피하기 · 환승 줄이기 적용 중`으로 표시됨 |
| 길찾기 적용 조건 | Android emulator API 36 | 길찾기 화면 캡처와 UI tree 확인 | 로컬: `.codex/evidence/789/android-05-route-search.png`, `.codex/evidence/789/android-05-route-search-ui.xml` | 길찾기 화면이 `천천히 이동`, `계단 피하기 · 환승 줄이기`를 함께 표시함 |
| 노선도 하단 탭 | Android emulator API 36 | 노선도 화면 캡처와 UI tree 확인 | 로컬: `.codex/evidence/789/android-06-network-map.png`, `.codex/evidence/789/android-06-network-map-ui.xml` | 노선도 하단 탭도 `즐겨찾기`로 표시되고 `저장` 탭이 보이지 않음 |
| iOS 홈 표기 | iOS 26.5 simulator | simulator build 설치 후 홈 화면 캡처 | 로컬: `.codex/evidence/789/ios-01-launch.png` | iOS 홈에서도 새 이동 조건명과 하단 `즐겨찾기` 라벨이 표시됨 |
| 스크린샷 첨부 제한 | PR 환경 | 증거 보관 방식 확인 | 외부 이미지 업로드 QA 승인이 없어 로컬 전용 evidence로 보관 | PR에는 파일 경로와 검증 결과를 기록하고, 업로드 승인 시 같은 파일을 댓글에 첨부 가능 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `MobilityProfileOption.conditionSummary`가 설정과 길찾기에서 공통으로 쓰이므로, 각 프로필의 API mobilityType 값이 바뀌지 않았는지 확인해 주세요.
- CodeRabbit은 rate limit으로 실제 리뷰를 시작하지 못해 Codex CLI fallback 리뷰를 PR review로 게시했다. 첫 리뷰의 actionable 1건은 별도 fix commit으로 수정하고 원래 inline thread에 해결 답글을 남겼으며, 재검토는 actionable 0건이다.

## 리스크

- 이동 조건 제목 문구가 바뀌면서 기존 스크린샷 기반 QA 기준은 새 문구로 갱신이 필요하다.
- 설정 화면은 상황명 대신 적용 조건 요약을 제목으로 보여주므로, 같은 조건 조합을 가진 프로필은 제목만으로 구분하지 않고 설명 문구까지 함께 확인해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.