### PR TITLE
[Style] 홈 핵심 행동과 디자인 토큰 위계 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1047,9 +1047,10 @@ class _HomeScreenState extends State<HomeScreen> {
     _mobilityType = widget.initialMobilityType;
     _routeDraftController = RouteDraftController();
     _recentRoutesFuture = _loadRecentRoutes();
-    _favoriteFacilitiesFuture = widget.favoriteFacilityRepository
+    final facilitiesFuture = widget.favoriteFacilityRepository
         ?.listFavoriteFacilities();
-    _hasNotificationItemsFuture = _loadHasNotificationItems();
+    _favoriteFacilitiesFuture = facilitiesFuture;
+    _hasNotificationItemsFuture = _loadHasNotificationItems(facilitiesFuture);
   }
 
   @override
@@ -1071,14 +1072,16 @@ class _HomeScreenState extends State<HomeScreen> {
     }
     if (widget.favoriteFacilityRepository !=
         oldWidget.favoriteFacilityRepository) {
-      _favoriteFacilitiesFuture = widget.favoriteFacilityRepository
+      final facilitiesFuture = widget.favoriteFacilityRepository
           ?.listFavoriteFacilities();
+      _favoriteFacilitiesFuture = facilitiesFuture;
+      _hasNotificationItemsFuture = _loadHasNotificationItems(facilitiesFuture);
     }
-    if (widget.favoriteFacilityRepository !=
-            oldWidget.favoriteFacilityRepository ||
-        widget.reportRepository != oldWidget.reportRepository ||
+    if (widget.reportRepository != oldWidget.reportRepository ||
         widget.notificationRepository != oldWidget.notificationRepository) {
-      _hasNotificationItemsFuture = _loadHasNotificationItems();
+      _hasNotificationItemsFuture = _loadHasNotificationItems(
+        _favoriteFacilitiesFuture,
+      );
     }
   }
 
@@ -1165,7 +1168,9 @@ class _HomeScreenState extends State<HomeScreen> {
       final facilitiesFuture = widget.favoriteFacilityRepository
           ?.listFavoriteFacilities();
       final routesFuture = _loadRecentRoutes();
-      final hasNotificationItemsFuture = _loadHasNotificationItems();
+      final hasNotificationItemsFuture = _loadHasNotificationItems(
+        facilitiesFuture,
+      );
       setState(() {
         _favoriteFacilitiesFuture = facilitiesFuture;
         _recentRoutesFuture = routesFuture;
@@ -1404,16 +1409,16 @@ class _HomeScreenState extends State<HomeScreen> {
         widget.favoriteRouteRepository?.listFavoriteRoutes();
   }
 
-  Future<bool> _loadHasNotificationItems() async {
+  Future<bool> _loadHasNotificationItems(
+    Future<List<FavoriteFacility>>? facilitiesFuture,
+  ) async {
     if (widget.notificationRepository == null) {
       return false;
     }
 
-    final favoriteFacilityRepository = widget.favoriteFacilityRepository;
-    if (favoriteFacilityRepository != null) {
+    if (facilitiesFuture != null) {
       try {
-        final facilities = await favoriteFacilityRepository
-            .listFavoriteFacilities();
+        final facilities = await facilitiesFuture;
         if (facilities.any(_isFacilityAlert)) {
           return true;
         }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1039,6 +1039,7 @@ class _HomeScreenState extends State<HomeScreen> {
   late final RouteDraftController _routeDraftController;
   Future<List<FavoriteRoute>>? _recentRoutesFuture;
   Future<List<FavoriteFacility>>? _favoriteFacilitiesFuture;
+  late Future<bool> _hasNotificationItemsFuture;
 
   @override
   void initState() {
@@ -1048,6 +1049,7 @@ class _HomeScreenState extends State<HomeScreen> {
     _recentRoutesFuture = _loadRecentRoutes();
     _favoriteFacilitiesFuture = widget.favoriteFacilityRepository
         ?.listFavoriteFacilities();
+    _hasNotificationItemsFuture = _loadHasNotificationItems();
   }
 
   @override
@@ -1071,6 +1073,12 @@ class _HomeScreenState extends State<HomeScreen> {
         oldWidget.favoriteFacilityRepository) {
       _favoriteFacilitiesFuture = widget.favoriteFacilityRepository
           ?.listFavoriteFacilities();
+    }
+    if (widget.favoriteFacilityRepository !=
+            oldWidget.favoriteFacilityRepository ||
+        widget.reportRepository != oldWidget.reportRepository ||
+        widget.notificationRepository != oldWidget.notificationRepository) {
+      _hasNotificationItemsFuture = _loadHasNotificationItems();
     }
   }
 
@@ -1213,14 +1221,17 @@ class _HomeScreenState extends State<HomeScreen> {
       final facilitiesFuture = widget.favoriteFacilityRepository
           ?.listFavoriteFacilities();
       final routesFuture = _loadRecentRoutes();
+      final hasNotificationItemsFuture = _loadHasNotificationItems();
       setState(() {
         _favoriteFacilitiesFuture = facilitiesFuture;
         _recentRoutesFuture = routesFuture;
+        _hasNotificationItemsFuture = hasNotificationItemsFuture;
       });
       try {
         await Future.wait<void>([
           if (facilitiesFuture != null) facilitiesFuture.then((_) {}),
           if (routesFuture != null) routesFuture.then((_) {}),
+          hasNotificationItemsFuture.then((_) {}),
         ]);
       } catch (error, stackTrace) {
         (error, stackTrace);
@@ -1299,12 +1310,17 @@ class _HomeScreenState extends State<HomeScreen> {
       appBar: AppBar(
         title: const Text('쉬운 지하철'),
         actions: [
-          _HomeNotificationButton(
-            key: const Key('homeNotificationActionButton'),
-            hasUnread: false,
-            onPressed: notificationRepository == null
-                ? openSettings
-                : openNotificationInbox,
+          FutureBuilder<bool>(
+            future: _hasNotificationItemsFuture,
+            builder: (context, snapshot) {
+              return _HomeNotificationButton(
+                key: const Key('homeNotificationActionButton'),
+                hasUnread: snapshot.data ?? false,
+                onPressed: notificationRepository == null
+                    ? openSettings
+                    : openNotificationInbox,
+              );
+            },
           ),
           const SizedBox(width: 8),
         ],
@@ -1415,6 +1431,41 @@ class _HomeScreenState extends State<HomeScreen> {
   Future<List<FavoriteRoute>>? _loadRecentRoutes() {
     return widget.recentRoutesFuture ??
         widget.favoriteRouteRepository?.listFavoriteRoutes();
+  }
+
+  Future<bool> _loadHasNotificationItems() async {
+    if (widget.notificationRepository == null) {
+      return false;
+    }
+
+    final favoriteFacilityRepository = widget.favoriteFacilityRepository;
+    if (favoriteFacilityRepository != null) {
+      try {
+        final facilities = await favoriteFacilityRepository
+            .listFavoriteFacilities();
+        if (facilities.any(_isFacilityAlert)) {
+          return true;
+        }
+      } catch (error, stackTrace) {
+        reportMobileError(
+          error,
+          stackTrace,
+          context: '홈 알림 시설 상태를 불러오는 중 예외가 발생했습니다.',
+        );
+      }
+    }
+
+    try {
+      final reports = await widget.reportRepository.listMyReports();
+      return reports.isNotEmpty;
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '홈 알림 제보 상태를 불러오는 중 예외가 발생했습니다.',
+      );
+    }
+    return false;
   }
 
   Future<MobilityProfileOption?> _openMobilityProfile() async {

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1161,62 +1161,6 @@ class _HomeScreenState extends State<HomeScreen> {
       );
     }
 
-    void openStationSearch() {
-      Navigator.of(context).push(
-        MaterialPageRoute<void>(
-          builder: (_) => StationSearchScreen(
-            repository: repository,
-            reportRepository: reportRepository,
-            favoriteRepository: favoriteRepository,
-            searchHistoryRepository: searchHistoryRepository,
-            locationProvider: locationProvider,
-            facilityReportDraftTargetStore: facilityReportDraftTargetStore,
-            internalRouteRepository: internalRouteRepository,
-            internalRouteMobilityType: initialMobilityType,
-            routeDraftController: _routeDraftController,
-          ),
-        ),
-      );
-    }
-
-    void openRecentSearch() {
-      Navigator.of(context).push(
-        MaterialPageRoute<void>(
-          builder: (_) => StationSearchScreen(
-            repository: repository,
-            reportRepository: reportRepository,
-            favoriteRepository: favoriteRepository,
-            searchHistoryRepository: searchHistoryRepository,
-            locationProvider: locationProvider,
-            facilityReportDraftTargetStore: facilityReportDraftTargetStore,
-            internalRouteRepository: internalRouteRepository,
-            internalRouteMobilityType: initialMobilityType,
-            routeDraftController: _routeDraftController,
-            entryMode: StationSearchEntryMode.recent,
-          ),
-        ),
-      );
-    }
-
-    void openNearbyStations() {
-      Navigator.of(context).push(
-        MaterialPageRoute<void>(
-          builder: (_) => StationSearchScreen(
-            repository: repository,
-            reportRepository: reportRepository,
-            favoriteRepository: favoriteRepository,
-            searchHistoryRepository: searchHistoryRepository,
-            locationProvider: locationProvider,
-            facilityReportDraftTargetStore: facilityReportDraftTargetStore,
-            internalRouteRepository: internalRouteRepository,
-            internalRouteMobilityType: initialMobilityType,
-            routeDraftController: _routeDraftController,
-            entryMode: StationSearchEntryMode.nearby,
-          ),
-        ),
-      );
-    }
-
     Future<void> refreshHomeState() async {
       final facilitiesFuture = widget.favoriteFacilityRepository
           ?.listFavoriteFacilities();
@@ -1237,6 +1181,31 @@ class _HomeScreenState extends State<HomeScreen> {
         (error, stackTrace);
         // FutureBuilder가 오류 상태를 표시하므로 refresh callback은 정상 종료한다.
       }
+    }
+
+    Future<void> openStationSearch([
+      StationSearchEntryMode entryMode = StationSearchEntryMode.search,
+    ]) async {
+      await Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => StationSearchScreen(
+            repository: repository,
+            reportRepository: reportRepository,
+            favoriteRepository: favoriteRepository,
+            searchHistoryRepository: searchHistoryRepository,
+            locationProvider: locationProvider,
+            facilityReportDraftTargetStore: facilityReportDraftTargetStore,
+            internalRouteRepository: internalRouteRepository,
+            internalRouteMobilityType: initialMobilityType,
+            routeDraftController: _routeDraftController,
+            entryMode: entryMode,
+          ),
+        ),
+      );
+      if (!context.mounted) {
+        return;
+      }
+      await refreshHomeState();
     }
 
     Future<void> openRouteSearch() async {
@@ -1298,7 +1267,7 @@ class _HomeScreenState extends State<HomeScreen> {
             repository: networkMapRepository,
             routeDraftController: _routeDraftController,
             onOpenRouteSearch: openRouteSearch,
-            onOpenStationSearch: openStationSearch,
+            onOpenStationSearch: () => unawaited(openStationSearch()),
             onOpenSaved: openSavedItems,
             onOpenSettings: openSettings,
           ),
@@ -1315,7 +1284,7 @@ class _HomeScreenState extends State<HomeScreen> {
             builder: (context, snapshot) {
               return _HomeNotificationButton(
                 key: const Key('homeNotificationActionButton'),
-                hasUnread: snapshot.data ?? false,
+                hasNotificationItems: snapshot.data ?? false,
                 onPressed: notificationRepository == null
                     ? openSettings
                     : openNotificationInbox,
@@ -1337,7 +1306,7 @@ class _HomeScreenState extends State<HomeScreen> {
               _HomePrototypeHero(
                 profile: currentProfile,
                 onRouteSearch: openRouteSearch,
-                onStationSearch: openStationSearch,
+                onStationSearch: () => unawaited(openStationSearch()),
                 onProfileTap: openSettings,
               ),
               AnimatedBuilder(
@@ -1354,8 +1323,10 @@ class _HomeScreenState extends State<HomeScreen> {
                 },
               ),
               _HomeStationActionRow(
-                onRecentSearch: openRecentSearch,
-                onNearbyStations: openNearbyStations,
+                onRecentSearch: () =>
+                    unawaited(openStationSearch(StationSearchEntryMode.recent)),
+                onNearbyStations: () =>
+                    unawaited(openStationSearch(StationSearchEntryMode.nearby)),
               ),
               _HomeFacilityAlertSection(
                 facilitiesFuture: _favoriteFacilitiesFuture,
@@ -1497,25 +1468,25 @@ class _HomeScreenState extends State<HomeScreen> {
 
 class _HomeNotificationButton extends StatelessWidget {
   const _HomeNotificationButton({
-    required this.hasUnread,
+    required this.hasNotificationItems,
     required this.onPressed,
     super.key,
   });
 
-  final bool hasUnread;
+  final bool hasNotificationItems;
   final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
-      label: hasUnread ? '알림, 확인하지 않은 알림 있음' : '알림, 새 알림 없음',
+      label: hasNotificationItems ? '알림, 확인할 알림 있음' : '알림, 새 알림 없음',
       onTap: onPressed,
       child: ExcludeSemantics(
         child: Tooltip(
           message: '알림',
           child: Badge(
-            isLabelVisible: hasUnread,
+            isLabelVisible: hasNotificationItems,
             smallSize: 10,
             backgroundColor: EasySubwayAccessibleColors.red,
             offset: const Offset(-10, 10),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1323,10 +1323,6 @@ class _HomeScreenState extends State<HomeScreen> {
                 onStationSearch: openStationSearch,
                 onProfileTap: openSettings,
               ),
-              _HomeStationActionRow(
-                onRecentSearch: openRecentSearch,
-                onNearbyStations: openNearbyStations,
-              ),
               AnimatedBuilder(
                 animation: _routeDraftController,
                 builder: (context, _) {
@@ -1339,6 +1335,10 @@ class _HomeScreenState extends State<HomeScreen> {
                     onTap: openRouteSearch,
                   );
                 },
+              ),
+              _HomeStationActionRow(
+                onRecentSearch: openRecentSearch,
+                onNearbyStations: openNearbyStations,
               ),
               _HomeFacilityAlertSection(
                 facilitiesFuture: _favoriteFacilitiesFuture,
@@ -1452,7 +1452,7 @@ class _HomeNotificationButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
-      label: '알림',
+      label: '알림, 확인하지 않은 알림 있음',
       onTap: onPressed,
       child: ExcludeSemantics(
         child: Tooltip(
@@ -1777,111 +1777,103 @@ class _HomePrototypeHero extends StatelessWidget {
   final VoidCallback onStationSearch;
   final VoidCallback onProfileTap;
 
+  static const double _cardRadius = 18;
+  static const double _buttonRadius = 12;
+  static const FontWeight _heroTitleWeight = FontWeight.w800;
+  static const FontWeight _primaryActionWeight = FontWeight.w800;
+  static const FontWeight _secondaryActionWeight = FontWeight.w700;
+
   @override
   Widget build(BuildContext context) {
     return Semantics(
       container: true,
       explicitChildNodes: true,
-      label: '길찾기와 역검색, 현재 이동 조건 ${profile.title}',
+      label: '길찾기와 역 검색, 현재 이동 조건 ${profile.title}',
       child: Material(
         key: const Key('homeHeroCard'),
         color: EasySubwayAccessibleColors.brand,
         elevation: 0,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(25)),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(_cardRadius),
+        ),
         clipBehavior: Clip.antiAlias,
         child: Padding(
           padding: const EdgeInsets.fromLTRB(20, 24, 20, 24),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Row(
-                children: [
-                  Expanded(
-                    child: ExcludeSemantics(
-                      child: Text(
-                        '어디로 가시나요?',
-                        style: Theme.of(context).textTheme.headlineSmall
-                            ?.copyWith(
-                              color: Colors.white,
-                              fontWeight: FontWeight.w700,
-                              height: 1.28,
-                            ),
-                      ),
-                    ),
+              ExcludeSemantics(
+                child: Text(
+                  '어디로 가시나요?',
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    color: Colors.white,
+                    fontWeight: _heroTitleWeight,
+                    height: 1.28,
                   ),
-                  Flexible(
-                    fit: FlexFit.loose,
-                    child: _HomeProfilePill(
-                      profile: profile,
-                      onTap: onProfileTap,
-                    ),
-                  ),
-                ],
+                ),
+              ),
+              const SizedBox(height: 12),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: _HomeProfilePill(profile: profile, onTap: onProfileTap),
               ),
               const SizedBox(height: 18),
-              Row(
-                children: [
-                  Expanded(
-                    child: Semantics(
-                      key: const Key('routeSearchButton'),
-                      button: true,
-                      label: '길찾기',
-                      onTap: onRouteSearch,
-                      child: ExcludeSemantics(
-                        child: FilledButton.icon(
-                          onPressed: onRouteSearch,
-                          style: FilledButton.styleFrom(
-                            backgroundColor:
-                                EasySubwayAccessibleColors.brandDark,
-                            foregroundColor: Colors.white,
-                            minimumSize: const Size.fromHeight(104),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(15),
-                            ),
-                            textStyle: const TextStyle(
-                              fontSize: 21,
-                              fontWeight: FontWeight.w700,
-                            ),
-                          ),
-                          icon: const Icon(Icons.route),
-                          label: const Text('길찾기'),
-                        ),
+              Semantics(
+                key: const Key('routeSearchButton'),
+                button: true,
+                label: '길찾기',
+                onTap: onRouteSearch,
+                child: ExcludeSemantics(
+                  child: FilledButton.icon(
+                    onPressed: onRouteSearch,
+                    style: FilledButton.styleFrom(
+                      backgroundColor: EasySubwayAccessibleColors.brandDark,
+                      foregroundColor: Colors.white,
+                      minimumSize: const Size.fromHeight(104),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(_buttonRadius),
+                      ),
+                      textStyle: const TextStyle(
+                        fontSize: 22,
+                        fontWeight: _primaryActionWeight,
                       ),
                     ),
+                    icon: const Icon(Icons.route),
+                    label: const Text('길찾기'),
                   ),
-                  const SizedBox(width: 9),
-                  Expanded(
-                    child: KeyedSubtree(
-                      key: const Key('heroStationSearchButton'),
-                      child: Semantics(
-                        key: const Key('stationSearchButton'),
-                        button: true,
-                        label: '역 검색',
-                        onTap: onStationSearch,
-                        child: ExcludeSemantics(
-                          child: FilledButton.icon(
-                            onPressed: onStationSearch,
-                            style: OutlinedButton.styleFrom(
-                              backgroundColor: Colors.white,
-                              foregroundColor:
-                                  EasySubwayAccessibleColors.brandDark,
-                              minimumSize: const Size.fromHeight(104),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(15),
-                              ),
-                              textStyle: const TextStyle(
-                                fontSize: 21,
-                                fontWeight: FontWeight.w700,
-                              ),
-                            ),
-                            icon: const Icon(Icons.search),
-                            label: const Text('역검색'),
-                          ),
+                ),
+              ),
+              const SizedBox(height: 10),
+              KeyedSubtree(
+                key: const Key('heroStationSearchButton'),
+                child: Semantics(
+                  key: const Key('stationSearchButton'),
+                  button: true,
+                  label: '역 검색',
+                  onTap: onStationSearch,
+                  child: ExcludeSemantics(
+                    child: OutlinedButton.icon(
+                      onPressed: onStationSearch,
+                      style: OutlinedButton.styleFrom(
+                        backgroundColor: Colors.white,
+                        foregroundColor: EasySubwayAccessibleColors.brandDark,
+                        side: const BorderSide(
+                          color: EasySubwayAccessibleColors.line,
+                        ),
+                        minimumSize: const Size.fromHeight(68),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(_buttonRadius),
+                        ),
+                        textStyle: const TextStyle(
+                          fontSize: 20,
+                          fontWeight: _secondaryActionWeight,
                         ),
                       ),
+                      icon: const Icon(Icons.search),
+                      label: const Text('역 검색'),
                     ),
                   ),
-                ],
+                ),
               ),
             ],
           ),
@@ -1953,7 +1945,7 @@ class _HomeStationActionButton extends StatelessWidget {
         foregroundColor: EasySubwayAccessibleColors.brandDark,
         side: const BorderSide(color: EasySubwayAccessibleColors.line),
         minimumSize: const Size.fromHeight(72),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         textStyle: const TextStyle(fontSize: 19, fontWeight: FontWeight.w600),
       ),
       icon: Icon(icon, size: 28),
@@ -1972,7 +1964,7 @@ class _HomeProfilePill extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
-      label: '현재 이동 조건 ${profile.title}',
+      label: '이동 조건: ${profile.title}, 변경',
       onTap: onTap,
       child: ExcludeSemantics(
         child: OutlinedButton.icon(
@@ -1992,7 +1984,7 @@ class _HomeProfilePill extends StatelessWidget {
           ),
           icon: Icon(profile.icon, size: 16),
           label: Text(
-            profile.title,
+            '이동 조건: ${profile.title} 〉',
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
           ),
@@ -2018,12 +2010,12 @@ class _HomeRouteDraftCard extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(top: 12),
       child: Semantics(
-        key: const Key('homeRouteDraftPanel'),
         button: true,
         label: '출발 도착 정하기, $summary',
         onTap: onTap,
         child: ExcludeSemantics(
           child: InkWell(
+            key: const Key('homeRouteDraftPanel'),
             onTap: onTap,
             borderRadius: BorderRadius.circular(18),
             child: _PrototypeCard(

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1301,6 +1301,7 @@ class _HomeScreenState extends State<HomeScreen> {
         actions: [
           _HomeNotificationButton(
             key: const Key('homeNotificationActionButton'),
+            hasUnread: false,
             onPressed: notificationRepository == null
                 ? openSettings
                 : openNotificationInbox,
@@ -1444,20 +1445,26 @@ class _HomeScreenState extends State<HomeScreen> {
 }
 
 class _HomeNotificationButton extends StatelessWidget {
-  const _HomeNotificationButton({required this.onPressed, super.key});
+  const _HomeNotificationButton({
+    required this.hasUnread,
+    required this.onPressed,
+    super.key,
+  });
 
+  final bool hasUnread;
   final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
-      label: '알림, 확인하지 않은 알림 있음',
+      label: hasUnread ? '알림, 확인하지 않은 알림 있음' : '알림, 새 알림 없음',
       onTap: onPressed,
       child: ExcludeSemantics(
         child: Tooltip(
           message: '알림',
           child: Badge(
+            isLabelVisible: hasUnread,
             smallSize: 10,
             backgroundColor: EasySubwayAccessibleColors.red,
             offset: const Offset(-10, 10),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -609,9 +609,17 @@ void main() {
     final notificationButtonSide = notificationButton.style?.side?.resolve(
       <WidgetState>{},
     );
+    final notificationBadge = tester.widget<Badge>(
+      find.descendant(
+        of: find.byKey(const Key('homeNotificationActionButton')),
+        matching: find.byType(Badge),
+      ),
+    );
     expect(notificationButtonSide?.color, EasySubwayAccessibleColors.line);
     expect(notificationButtonSide?.width, 1.5);
-    expect(find.bySemanticsLabel('알림, 확인하지 않은 알림 있음'), findsOneWidget);
+    expect(notificationBadge.isLabelVisible, isFalse);
+    expect(find.bySemanticsLabel('알림, 새 알림 없음'), findsOneWidget);
+    expect(find.bySemanticsLabel('알림, 확인하지 않은 알림 있음'), findsNothing);
 
     await tester.tap(find.byKey(const Key('homeNotificationActionButton')));
     await tester.pumpAndSettle();

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -619,7 +619,7 @@ void main() {
     expect(notificationButtonSide?.width, 1.5);
     expect(notificationBadge.isLabelVisible, isFalse);
     expect(find.bySemanticsLabel('알림, 새 알림 없음'), findsOneWidget);
-    expect(find.bySemanticsLabel('알림, 확인하지 않은 알림 있음'), findsNothing);
+    expect(find.bySemanticsLabel('알림, 확인할 알림 있음'), findsNothing);
 
     await tester.tap(find.byKey(const Key('homeNotificationActionButton')));
     await tester.pumpAndSettle();
@@ -651,8 +651,33 @@ void main() {
       ),
     );
     expect(notificationBadge.isLabelVisible, isTrue);
-    expect(find.bySemanticsLabel('알림, 확인하지 않은 알림 있음'), findsOneWidget);
+    expect(find.bySemanticsLabel('알림, 확인할 알림 있음'), findsOneWidget);
     expect(find.bySemanticsLabel('알림, 새 알림 없음'), findsNothing);
+  });
+
+  testWidgets('홈은 역 검색에서 돌아오면 알림 상태를 다시 불러온다', (tester) async {
+    final reportRepository = FakeFacilityReportRepository();
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: reportRepository,
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(reportRepository.listMyReportsCount, 1);
+
+    await tester.tap(find.byKey(const Key('heroStationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    expect(reportRepository.listMyReportsCount, greaterThanOrEqualTo(2));
   });
 
   testWidgets('알림함 시설 상태는 심각도와 다음 행동을 함께 보여준다', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -629,15 +629,17 @@ void main() {
   });
 
   testWidgets('홈 알림 버튼은 확인할 알림이 있으면 배지와 상태를 알려준다', (tester) async {
+    final favoriteFacilityRepository = FakeFavoriteFacilityRepository(
+      favorites: [_favoriteFacility(status: 'USER_REPORTED')],
+    );
+
     await tester.pumpWidget(
       EasySubwayApp(
         repository: FakeStationSearchRepository(),
         reportRepository: FakeFacilityReportRepository(),
         routeRepository: FakeRouteSearchRepository(),
         favoriteRepository: FakeFavoriteStationRepository(),
-        favoriteFacilityRepository: FakeFavoriteFacilityRepository(
-          favorites: [_favoriteFacility(status: 'USER_REPORTED')],
-        ),
+        favoriteFacilityRepository: favoriteFacilityRepository,
         notificationRepository: FakeNotificationSettingsRepository(),
         initialOnboardingState: _completedOnboardingState(),
       ),
@@ -653,6 +655,7 @@ void main() {
     expect(notificationBadge.isLabelVisible, isTrue);
     expect(find.bySemanticsLabel('알림, 확인할 알림 있음'), findsOneWidget);
     expect(find.bySemanticsLabel('알림, 새 알림 없음'), findsNothing);
+    expect(favoriteFacilityRepository.listCount, 1);
   });
 
   testWidgets('홈은 역 검색에서 돌아오면 알림 상태를 다시 불러온다', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -515,7 +515,7 @@ void main() {
       expect(find.byKey(const Key('homeTripControlPanel')), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '최근 검색'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
-      expect(find.widgetWithText(FilledButton, '역검색'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '역 검색'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '설정'), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '이동 조건'), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '알림 설정'), findsNothing);
@@ -543,9 +543,9 @@ void main() {
       expect(find.text('즐겨찾기 역'), findsNothing);
       expect(find.text('즐겨찾기 시설'), findsNothing);
       expect(find.textContaining('빠른 길보다'), findsNothing);
-      expect(find.text('천천히 이동'), findsOneWidget);
+      expect(find.text('이동 조건: 천천히 이동 〉'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('길찾기와 역검색, 현재 이동 조건 천천히 이동'),
+        find.bySemanticsLabel('길찾기와 역 검색, 현재 이동 조건 천천히 이동'),
         findsOneWidget,
       );
       expect(find.textContaining('휠체어'), findsNothing);
@@ -557,11 +557,16 @@ void main() {
         find.byKey(const Key('routeSearchButton')),
       );
 
-      expect(heroStationButtonSize.height, greaterThanOrEqualTo(104));
+      expect(heroStationButtonSize.height, greaterThanOrEqualTo(64));
       expect(routeButtonSize.height, greaterThanOrEqualTo(104));
+      expect(routeButtonSize.height, greaterThan(heroStationButtonSize.height));
       expect(
-        routeButtonSize.width,
-        moreOrLessEquals(heroStationButtonSize.width),
+        tester.getTopLeft(find.byKey(const Key('routeSearchButton'))).dy,
+        lessThan(
+          tester
+              .getTopLeft(find.byKey(const Key('heroStationSearchButton')))
+              .dy,
+        ),
       );
 
       expect(find.text('최근 경로'), findsNothing);
@@ -606,6 +611,7 @@ void main() {
     );
     expect(notificationButtonSide?.color, EasySubwayAccessibleColors.line);
     expect(notificationButtonSide?.width, 1.5);
+    expect(find.bySemanticsLabel('알림, 확인하지 않은 알림 있음'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('homeNotificationActionButton')));
     await tester.pumpAndSettle();
@@ -918,7 +924,7 @@ void main() {
     expect(find.byKey(const Key('routeSearchButton')), findsOneWidget);
     expect(find.byKey(const Key('heroStationSearchButton')), findsOneWidget);
     expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
-    expect(find.widgetWithText(FilledButton, '역검색'), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, '역 검색'), findsOneWidget);
     expect(find.widgetWithText(OutlinedButton, '최근 검색'), findsOneWidget);
     expect(find.widgetWithText(OutlinedButton, '가까운 역'), findsOneWidget);
     expect(find.byKey(const Key('nearbyStationHomeButton')), findsOneWidget);
@@ -937,7 +943,8 @@ void main() {
       find.byKey(const Key('heroStationSearchButton')),
     );
     expect(routeButtonSize.height, greaterThanOrEqualTo(104));
-    expect(stationHeroButtonSize.height, greaterThanOrEqualTo(104));
+    expect(stationHeroButtonSize.height, greaterThanOrEqualTo(64));
+    expect(routeButtonSize.height, greaterThan(stationHeroButtonSize.height));
 
     await tester.dragUntilVisible(
       find.text('최근 경로'),
@@ -1167,7 +1174,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text(option.title), findsOneWidget);
+      expect(find.text('이동 조건: ${option.title} 〉'), findsOneWidget);
       expect(find.byIcon(option.icon), findsOneWidget);
       expect(find.byIcon(Icons.directions_walk), findsNothing);
     }
@@ -1208,7 +1215,13 @@ void main() {
     );
     expect(
       tester.getSize(find.byKey(const Key('heroStationSearchButton'))).height,
-      greaterThanOrEqualTo(104),
+      greaterThanOrEqualTo(64),
+    );
+    expect(
+      tester.getTopLeft(find.byKey(const Key('routeSearchButton'))).dy,
+      lessThan(
+        tester.getTopLeft(find.byKey(const Key('heroStationSearchButton'))).dy,
+      ),
     );
     await tester.dragUntilVisible(
       find.byKey(const Key('recentSearchButton')),
@@ -1432,8 +1445,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('homeTripControlPanel')), findsNothing);
-    expect(find.text('천천히 이동'), findsOneWidget);
-    expect(find.bySemanticsLabel('길찾기와 역검색, 현재 이동 조건 천천히 이동'), findsOneWidget);
+    expect(find.text('이동 조건: 천천히 이동 〉'), findsOneWidget);
+    expect(find.bySemanticsLabel('길찾기와 역 검색, 현재 이동 조건 천천히 이동'), findsOneWidget);
 
     await _openMobilityProfileFromSettings(tester);
     await tester.tap(find.byKey(const Key('mobilityProfileCard-wheelchair')));
@@ -1449,8 +1462,8 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('휠체어 이용'), findsOneWidget);
-    expect(find.bySemanticsLabel('길찾기와 역검색, 현재 이동 조건 휠체어 이용'), findsOneWidget);
+    expect(find.text('이동 조건: 휠체어 이용 〉'), findsOneWidget);
+    expect(find.bySemanticsLabel('길찾기와 역 검색, 현재 이동 조건 휠체어 이용'), findsOneWidget);
     semanticsHandle.dispose();
   });
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -201,7 +201,7 @@ void main() {
       ),
       findsOneWidget,
     );
-    expect(reportRepository.listMyReportsCount, 1);
+    expect(reportRepository.listMyReportsCount, greaterThanOrEqualTo(1));
   });
 
   testWidgets('내 신고 항목을 누르면 상세 상태 화면으로 이동한다', (tester) async {
@@ -626,6 +626,33 @@ void main() {
 
     expect(find.text('알림'), findsOneWidget);
     expect(find.text('새 알림이 없습니다'), findsOneWidget);
+  });
+
+  testWidgets('홈 알림 버튼은 확인할 알림이 있으면 배지와 상태를 알려준다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(
+          favorites: [_favoriteFacility(status: 'USER_REPORTED')],
+        ),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final notificationBadge = tester.widget<Badge>(
+      find.descendant(
+        of: find.byKey(const Key('homeNotificationActionButton')),
+        matching: find.byType(Badge),
+      ),
+    );
+    expect(notificationBadge.isLabelVisible, isTrue);
+    expect(find.bySemanticsLabel('알림, 확인하지 않은 알림 있음'), findsOneWidget);
+    expect(find.bySemanticsLabel('알림, 새 알림 없음'), findsNothing);
   });
 
   testWidgets('알림함 시설 상태는 심각도와 다음 행동을 함께 보여준다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

close #790

## 작업 배경

- 홈 첫 화면에서 `길찾기`와 `역검색`이 같은 수준의 버튼으로 보여 핵심 행동 우선순위가 약했다.
- 이동 조건 pill이 현재 조건만 짧게 보여 변경 가능한 설정인지 분명하지 않았고, 알림 버튼은 스크린리더에서 미확인 알림 상태를 설명하지 않았다.
- QA 요청 기준에 맞춰 홈의 핵심 행동, 보조 행동, 이동 조건, 알림 접근성 상태를 한 화면에서 더 명확하게 구분한다.

## 작업 내용

- 홈 히어로의 `길찾기`를 104px 이상 full-width primary CTA로 올리고 `역 검색`을 secondary outlined CTA로 낮췄다.
- `최근 검색`, `가까운 역`은 히어로 아래 보조 행동으로 유지하고, 진행 중인 출발/도착 draft 카드는 핵심 CTA 직후에 보여 탭 가능 영역이 하단 내비게이션과 겹치지 않게 했다.
- 이동 조건 pill 문구를 `이동 조건: <조건> 〉`로 바꾸고 TalkBack/VoiceOver용 semantics를 `이동 조건: <조건>, 변경`으로 제공한다.
- 알림 버튼은 알림함과 같은 즐겨찾기 시설/내 신고 기준으로 배지 표시 여부를 계산하고, 상태에 따라 `알림, 확인할 알림 있음` 또는 `알림, 새 알림 없음`을 스크린리더에 제공한다.
- 홈 카드/버튼 radius와 핵심/보조 행동 font weight를 홈 히어로 내부 상수로 분리하고, 관련 위젯 테스트 기대값을 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart test/accessibility_baseline_test.dart`: exit 0, 123 tests passed
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `cd apps/mobile && flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `cd apps/mobile && flutter build ios --simulator --debug`: exit 0, `build/ios/iphonesimulator/Runner.app` 생성
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 홈 CTA 위계 100% 글자 크기 | Android emulator `emulator-5554` | debug APK 설치 후 font scale 1.0, 홈 스크린샷 확인 | 로컬 전용 `.codex/evidence/790/android-home-font-100.png` | `길찾기`가 full-width primary CTA, `역 검색`이 secondary CTA, `최근 검색`/`가까운 역`이 보조 행동으로 표시됨 |
| 홈 CTA 위계 200% 글자 크기 | Android emulator `emulator-5554` | font scale 2.0 적용 후 홈 스크린샷 확인 | 로컬 전용 `.codex/evidence/790/android-home-font-200.png` | 큰 글자에서도 핵심/보조 행동이 겹치지 않고 터치 영역이 유지됨 |
| TalkBack용 상태 라벨 | Android emulator `emulator-5554` | `uiautomator dump`로 UI tree 확인 | 로컬 전용 `.codex/evidence/790/android-home-font-100.xml`, `.codex/evidence/790/android-home-font-200.xml` | 빈 알림 상태에서 `알림, 새 알림 없음`, `이동 조건: 천천히 이동, 변경`, `길찾기`, `역 검색` content-desc 확인 |
| 알림 배지 상태 분기 | Flutter widget test | 즐겨찾기 시설에 `USER_REPORTED` 상태를 주입하고 홈 알림 버튼 검사 | `test/widget_test.dart`의 `홈 알림 버튼은 확인할 알림이 있으면 배지와 상태를 알려준다` | 확인할 알림이 있으면 배지가 보이고 `알림, 확인할 알림 있음` semantics가 제공되며 시설 목록은 홈 섹션과 공유되어 1회만 조회됨 |
| 역 검색 복귀 후 알림 갱신 | Flutter widget test | 홈에서 역 검색을 열었다가 뒤로 돌아온 뒤 내 신고 목록 재조회 여부 검사 | `test/widget_test.dart`의 `홈은 역 검색에서 돌아오면 알림 상태를 다시 불러온다` | 역 검색 계열 화면 복귀 후 홈 알림 상태 future가 다시 로드됨 |
| iOS 홈 공통 UI | iOS simulator `Maum iPhone 17` | simulator build 설치 후 홈 스크린샷 확인 | 로컬 전용 `.codex/evidence/790/ios-home.png` | iOS에서도 홈 CTA 위계와 이동 조건 pill 문구가 같은 구조로 표시됨 |
| 화면 증거 보관 방식 | 로컬 | 외부 업로드 없이 정책상 git 미커밋 | `.codex/evidence/790/` | 스크린샷/녹화 증거는 git에 커밋하지 않는 프로젝트 정책과 외부 업로드 미승인 상태 때문에 로컬 전용으로 보관함 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/main.dart`의 `_HomePrototypeHero`에서 `길찾기`와 `역 검색`의 위계가 달라진 부분
  - `_HomeProfilePill`과 `_HomeNotificationButton`의 semantics label 변경
  - draft route card가 보조 행동보다 위에 표시되도록 순서를 바꾼 부분

## 리스크

- 알림 배지 상태는 별도 read/unread 모델이 없어 알림함에 표시할 항목 존재 여부를 기준으로 표현한다. 실제 unread count 연동은 알림 데이터 모델이 생길 때 별도 작업이 필요하다.
- 홈 히어로 높이가 이전보다 커져 작은 화면에서는 시설 알림/최근 경로가 더 아래로 밀린다. 핵심 행동 접근성을 우선한 의도된 변경이다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
