### PR TITLE
[Feat] 역 검색 필터와 이동 조건 바텀시트 개선

### DIFF
--- a/apps/mobile/lib/features/stations/data/drift_station_repository.dart
+++ b/apps/mobile/lib/features/stations/data/drift_station_repository.dart
@@ -61,7 +61,7 @@ class DriftStationRepository
             id: row.read<String>('id'),
             name: row.read<String>('name_ko'),
             color: row.read<String>('color'),
-            region: '수도권',
+            region: _lineRegion(row.read<String>('name_ko')),
             lineCode: _lineCode(row.read<String>('name_ko')),
             active: true,
           ),
@@ -647,6 +647,15 @@ String _lineCode(String lineName) {
     return numberedLine.group(1) ?? '';
   }
   return _lineSearchName(lineName).replaceAll('선', '');
+}
+
+String _lineRegion(String lineName) {
+  for (final region in const ['수도권', '부산', '대구', '대전', '광주']) {
+    if (lineName.startsWith(region)) {
+      return region;
+    }
+  }
+  return '수도권';
 }
 
 String _dateLabelFromEpoch(int? value) {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1273,29 +1273,79 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
       context: context,
       showDragHandle: true,
       builder: (context) {
+        var pendingMobilityType = _selectedMobilityType;
         return SafeArea(
-          child: ListView(
-            shrinkWrap: true,
-            padding: const EdgeInsets.fromLTRB(20, 8, 20, 24),
-            children: [
-              Text(
-                '이동 조건',
-                style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                  color: const Color(0xFF102A2C),
-                  fontWeight: FontWeight.w900,
-                  height: 1.25,
+          child: StatefulBuilder(
+            builder: (context, setSheetState) {
+              return FractionallySizedBox(
+                heightFactor: 0.78,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 8, 20, 0),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Text(
+                            '이동 조건',
+                            style: Theme.of(context).textTheme.titleLarge
+                                ?.copyWith(
+                                  color: const Color(0xFF102A2C),
+                                  fontWeight: FontWeight.w900,
+                                  height: 1.25,
+                                ),
+                          ),
+                          const SizedBox(height: 6),
+                          Text(
+                            '상황에 맞는 이동 조건을 고른 뒤 적용해 주세요.',
+                            style: Theme.of(context).textTheme.bodyMedium
+                                ?.copyWith(
+                                  color: const Color(0xFF50656F),
+                                  fontWeight: FontWeight.w700,
+                                  height: 1.35,
+                                ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Expanded(
+                      child: ListView(
+                        key: const Key('routeMobilityOptionsList'),
+                        padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+                        children: [
+                          for (final option in mobilityProfileOptions)
+                            _RouteMobilityTypeOptionButton(
+                              key: Key(
+                                'routeMobilityOption-${option.mobilityType}',
+                              ),
+                              option: option,
+                              selected:
+                                  option.mobilityType == pendingMobilityType,
+                              onSelected: () {
+                                setSheetState(() {
+                                  pendingMobilityType = option.mobilityType;
+                                });
+                              },
+                            ),
+                        ],
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+                      child: FilledButton.icon(
+                        key: const Key('routeMobilityApplyButton'),
+                        onPressed: () =>
+                            Navigator.of(context).pop(pendingMobilityType),
+                        icon: const Icon(Icons.check),
+                        label: const Text('적용'),
+                      ),
+                    ),
+                  ],
                 ),
-              ),
-              const SizedBox(height: 12),
-              for (final option in mobilityProfileOptions)
-                _RouteMobilityTypeOptionButton(
-                  key: Key('routeMobilityOption-${option.mobilityType}'),
-                  option: option,
-                  selected: option.mobilityType == _selectedMobilityType,
-                  onSelected: () =>
-                      Navigator.of(context).pop(option.mobilityType),
-                ),
-            ],
+              );
+            },
           ),
         );
       },
@@ -1890,9 +1940,30 @@ class _RouteMobilityTypeOptionButton extends StatelessWidget {
         Icon(option.icon),
         const SizedBox(width: 10),
         Expanded(
-          child: Text(
-            option.title,
-            style: const TextStyle(fontWeight: FontWeight.w800),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                option.title,
+                style: const TextStyle(fontWeight: FontWeight.w800),
+              ),
+              const SizedBox(height: 3),
+              Text(
+                option.summary,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  height: 1.3,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                _routeMobilityConditionLabel(option),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                  height: 1.25,
+                ),
+              ),
+            ],
           ),
         ),
         if (selected)
@@ -1906,7 +1977,9 @@ class _RouteMobilityTypeOptionButton extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: Semantics(
-        label: option.semanticsLabel(selected),
+        label: selected
+            ? '${option.title} 현재 선택, ${option.summary}'
+            : option.semanticsLabel(false),
         button: true,
         selected: selected,
         child: selected

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1977,9 +1977,7 @@ class _RouteMobilityTypeOptionButton extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: Semantics(
-        label: selected
-            ? '${option.title} 현재 선택, ${option.summary}, ${_routeMobilityConditionLabel(option)}'
-            : option.semanticsLabel(false),
+        label: _routeMobilityOptionSemanticsLabel(option, selected),
         button: true,
         selected: selected,
         child: selected
@@ -1999,6 +1997,14 @@ MobilityProfileOption _mobilityOptionFor(String mobilityType) {
 
 String _routeMobilityConditionLabel(MobilityProfileOption option) {
   return option.conditionSummary;
+}
+
+String _routeMobilityOptionSemanticsLabel(
+  MobilityProfileOption option,
+  bool selected,
+) {
+  final state = selected ? '현재 선택' : '선택 가능';
+  return '${option.title} $state, ${option.summary}, ${_routeMobilityConditionLabel(option)}';
 }
 
 class _RouteStationPicker extends StatefulWidget {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1978,7 +1978,7 @@ class _RouteMobilityTypeOptionButton extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: 8),
       child: Semantics(
         label: selected
-            ? '${option.title} 현재 선택, ${option.summary}'
+            ? '${option.title} 현재 선택, ${option.summary}, ${_routeMobilityConditionLabel(option)}'
             : option.semanticsLabel(false),
         button: true,
         selected: selected,

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1641,6 +1641,8 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   Future<List<SubwayLineOption>>? _lineOptionsFuture;
   List<String> _recentQueries = const [];
   SubwayLineOption? _selectedLine;
+  String? _selectedLineRegion;
+  bool _isLineFilterExpanded = true;
   bool _isNearbySearchRunning = false;
   bool _isOpeningLocationSettings = false;
 
@@ -1723,10 +1725,11 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
         }),
         actions: [
           if (!isRecentEntry && !isNearbyEntry)
-            IconButton(
-              tooltip: '가까운 역',
+            TextButton.icon(
+              key: const Key('nearbyStationAppBarButton'),
               onPressed: _isNearbySearchRunning ? null : _searchNearby,
               icon: const Icon(Icons.my_location),
+              label: const Text('가까운 역'),
             ),
         ],
       ),
@@ -1777,22 +1780,6 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
                 onSubmitted: _submit,
               ),
               const SizedBox(height: 12),
-            ],
-            if (showSearchInput && _lineOptionsFuture != null) ...[
-              AnimatedBuilder(
-                animation: _controller,
-                builder: (context, _) {
-                  final isSearching =
-                      _controller.state.status == StationSearchStatus.loading;
-                  return _StationLineFilterSection(
-                    linesFuture: _lineOptionsFuture!,
-                    selectedLine: _selectedLine,
-                    enabled: !isSearching && !_isNearbySearchRunning,
-                    onLineSelected: _selectLine,
-                  );
-                },
-              ),
-              const SizedBox(height: 16),
             ],
             AnimatedBuilder(
               animation: _controller,
@@ -1867,6 +1854,37 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
                 );
               },
             ),
+            if (showSearchInput && _lineOptionsFuture != null) ...[
+              const SizedBox(height: 16),
+              AnimatedBuilder(
+                animation: _controller,
+                builder: (context, _) {
+                  final isSearching =
+                      _controller.state.status == StationSearchStatus.loading;
+                  final hasSearchResults =
+                      _controller.state.status == StationSearchStatus.success &&
+                      _controller.state.source ==
+                          StationSearchResultSource.search;
+                  return _StationLineFilterPanel(
+                    expanded: !hasSearchResults || _isLineFilterExpanded,
+                    collapsible: hasSearchResults,
+                    onToggleExpanded: () {
+                      setState(() {
+                        _isLineFilterExpanded = !_isLineFilterExpanded;
+                      });
+                    },
+                    child: _StationLineFilterSection(
+                      linesFuture: _lineOptionsFuture!,
+                      selectedLine: _selectedLine,
+                      selectedRegion: _selectedLineRegion,
+                      enabled: !isSearching && !_isNearbySearchRunning,
+                      onRegionSelected: _selectLineRegion,
+                      onLineSelected: _selectLine,
+                    ),
+                  );
+                },
+              ),
+            ],
           ],
         ),
       ),
@@ -1883,6 +1901,11 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   Future<void> _runSearch(String query) async {
     await _controller.search(query, lineId: _selectedLine?.id);
     await _loadRecentQueries();
+    if (mounted &&
+        _controller.state.status == StationSearchStatus.success &&
+        _controller.state.source == StationSearchResultSource.search) {
+      setState(() => _isLineFilterExpanded = false);
+    }
   }
 
   void _searchRecentQuery(String query) {
@@ -1918,7 +1941,21 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
   }
 
   void _selectLine(SubwayLineOption? line) {
-    setState(() => _selectedLine = line);
+    setState(() {
+      _selectedLine = line;
+      if (line != null) {
+        _selectedLineRegion = line.region;
+      }
+    });
+  }
+
+  void _selectLineRegion(String region) {
+    setState(() {
+      _selectedLineRegion = region;
+      if (_selectedLine?.region != region) {
+        _selectedLine = null;
+      }
+    });
   }
 
   void _setRouteOrigin(StationSearchResult result) {
@@ -2102,17 +2139,55 @@ class _StationRecentSearchSection extends StatelessWidget {
   }
 }
 
+class _StationLineFilterPanel extends StatelessWidget {
+  const _StationLineFilterPanel({
+    required this.expanded,
+    required this.collapsible,
+    required this.onToggleExpanded,
+    required this.child,
+  });
+
+  final bool expanded;
+  final bool collapsible;
+  final VoidCallback onToggleExpanded;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      key: const Key('stationLineFilterPanel'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (collapsible) ...[
+          OutlinedButton.icon(
+            key: const Key('stationLineFilterToggle'),
+            onPressed: onToggleExpanded,
+            icon: Icon(expanded ? Icons.expand_less : Icons.tune),
+            label: Text(expanded ? '노선 필터 접기' : '노선 필터 펼치기'),
+          ),
+          if (expanded) const SizedBox(height: 12),
+        ],
+        if (expanded) child,
+      ],
+    );
+  }
+}
+
 class _StationLineFilterSection extends StatelessWidget {
   const _StationLineFilterSection({
     required this.linesFuture,
     required this.selectedLine,
+    required this.selectedRegion,
     required this.enabled,
+    required this.onRegionSelected,
     required this.onLineSelected,
   });
 
   final Future<List<SubwayLineOption>> linesFuture;
   final SubwayLineOption? selectedLine;
+  final String? selectedRegion;
   final bool enabled;
+  final ValueChanged<String> onRegionSelected;
   final ValueChanged<SubwayLineOption?> onLineSelected;
 
   @override
@@ -2148,33 +2223,187 @@ class _StationLineFilterSection extends StatelessWidget {
           return const SizedBox.shrink();
         }
 
-        return Wrap(
-          spacing: 8,
-          runSpacing: 8,
+        final seenRegions = <String>{};
+        final regions = <String>[
+          for (final line in lines)
+            if (seenRegions.add(line.region)) line.region,
+        ]..sort(_compareStationLineRegions);
+        final currentRegion =
+            selectedRegion ?? selectedLine?.region ?? regions.first;
+        final visibleLines = lines
+            .where((line) => line.region == currentRegion)
+            .toList(growable: false);
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _StationLineFilterButton(
-              key: const Key('stationLineFilter-all'),
-              label: '전체 노선',
-              semanticLabel: '전체 노선',
-              selected: selectedLine == null,
-              onPressed: enabled ? () => onLineSelected(null) : null,
-            ),
-            for (final line in lines)
-              _StationLineFilterButton(
-                key: Key('stationLineFilter-${line.id}'),
-                label: line.name,
-                semanticLabel: line.semanticLabel,
-                selected: selectedLine?.id == line.id,
-                badgeText: line.shortLabel,
-                badgeColor: line.badgeColor,
-                badgeAssetPath: line.badgeAssetPath,
-                onPressed: enabled ? () => onLineSelected(line) : null,
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: [
+                  for (final region in regions) ...[
+                    Padding(
+                      padding: const EdgeInsets.only(right: 8),
+                      child: _StationLineRegionButton(
+                        key: Key('stationLineRegion-$region'),
+                        label: region,
+                        selected: region == currentRegion,
+                        onPressed: enabled
+                            ? () => onRegionSelected(region)
+                            : null,
+                      ),
+                    ),
+                  ],
+                ],
               ),
+            ),
+            const SizedBox(height: 10),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                _StationLineFilterButton(
+                  key: const Key('stationLineFilter-all'),
+                  label: '전체 노선',
+                  semanticLabel: '전체 노선',
+                  selected: selectedLine == null,
+                  onPressed: enabled ? () => onLineSelected(null) : null,
+                ),
+                for (final line in visibleLines)
+                  _StationLineFilterButton(
+                    key: Key('stationLineFilter-${line.id}'),
+                    label: line.name,
+                    semanticLabel: line.semanticLabel,
+                    selected: selectedLine?.id == line.id,
+                    badgeText: line.shortLabel,
+                    badgeColor: line.badgeColor,
+                    badgeAssetPath: line.badgeAssetPath,
+                    onPressed: enabled ? () => onLineSelected(line) : null,
+                  ),
+                OutlinedButton.icon(
+                  key: const Key('stationLineFilterMoreButton'),
+                  onPressed: enabled
+                      ? () => _showAllLineSheet(context, lines)
+                      : null,
+                  icon: const Icon(Icons.list_alt),
+                  label: const Text('전체 노선 보기'),
+                ),
+              ],
+            ),
           ],
         );
       },
     );
   }
+
+  Future<void> _showAllLineSheet(
+    BuildContext context,
+    List<SubwayLineOption> lines,
+  ) async {
+    final selected = await showModalBottomSheet<Object?>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) {
+        return SafeArea(
+          child: ListView(
+            key: const Key('stationLineAllSheet'),
+            padding: const EdgeInsets.fromLTRB(20, 8, 20, 24),
+            children: [
+              Text(
+                '전체 노선 보기',
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  color: const Color(0xFF102A2C),
+                  fontWeight: FontWeight.w900,
+                  height: 1.25,
+                ),
+              ),
+              const SizedBox(height: 12),
+              _StationLineFilterButton(
+                key: const Key('stationLineFilter-all'),
+                label: '전체 노선',
+                semanticLabel: '전체 노선',
+                selected: selectedLine == null,
+                onPressed: () => Navigator.of(context).pop(false),
+              ),
+              const SizedBox(height: 8),
+              for (final line in lines) ...[
+                _StationLineFilterButton(
+                  key: Key('stationLineFilter-${line.id}'),
+                  label: line.name,
+                  semanticLabel: line.semanticLabel,
+                  selected: selectedLine?.id == line.id,
+                  badgeText: line.shortLabel,
+                  badgeColor: line.badgeColor,
+                  badgeAssetPath: line.badgeAssetPath,
+                  onPressed: () => Navigator.of(context).pop(line),
+                ),
+                const SizedBox(height: 8),
+              ],
+            ],
+          ),
+        );
+      },
+    );
+    if (selected is SubwayLineOption) {
+      onLineSelected(selected);
+    } else if (selected == false) {
+      onLineSelected(null);
+    }
+  }
+}
+
+class _StationLineRegionButton extends StatelessWidget {
+  const _StationLineRegionButton({
+    required this.label,
+    required this.selected,
+    required this.onPressed,
+    super.key,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: '$label 지역 ${selected ? '선택됨' : '선택 안 됨'}',
+      button: true,
+      selected: selected,
+      enabled: onPressed != null,
+      onTap: onPressed,
+      child: ExcludeSemantics(
+        child: ChoiceChip(
+          label: Text(label),
+          selected: selected,
+          onSelected: onPressed == null ? null : (_) => onPressed?.call(),
+          labelStyle: TextStyle(
+            color: selected ? Colors.white : const Color(0xFF102A2C),
+            fontWeight: FontWeight.w800,
+          ),
+          selectedColor: const Color(0xFF007A80),
+          backgroundColor: Colors.white,
+          side: const BorderSide(color: Color(0xFF93C7C2)),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        ),
+      ),
+    );
+  }
+}
+
+int _compareStationLineRegions(String left, String right) {
+  final leftRank = _stationLineRegionRank(left);
+  final rightRank = _stationLineRegionRank(right);
+  if (leftRank != rightRank) {
+    return leftRank.compareTo(rightRank);
+  }
+  return left.compareTo(right);
+}
+
+int _stationLineRegionRank(String region) {
+  const preferredRegions = ['수도권', '부산', '대구', '광주', '대전'];
+  final index = preferredRegions.indexOf(region);
+  return index == -1 ? preferredRegions.length : index;
 }
 
 class _StationLineFilterButton extends StatelessWidget {

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -2,6 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:drift/drift.dart' show Value;
+import 'package:easysubway_mobile/core/database/catalog/catalog_database.dart';
+import 'package:easysubway_mobile/features/stations/data/drift_station_repository.dart';
 import 'package:easysubway_mobile/features/stations/data/station_api_repository.dart';
 import 'package:easysubway_mobile/mobile_error_reporter.dart';
 import 'package:easysubway_mobile/station_search.dart';
@@ -309,6 +312,35 @@ void main() {
     expect(requestedUri.path, '/api/v1/lines');
     expect(lines.map((line) => line.shortLabel), ['4', '경의중앙']);
     expect(lines.first.semanticLabel, '수도권 4호선');
+  });
+
+  test('로컬 역 저장소는 노선명에서 지역 필터 값을 만든다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.batch((batch) {
+      batch.insertAll(database.lines, [
+        LinesCompanion.insert(
+          id: 'busan-1',
+          operatorId: 'humetro',
+          nameKo: '부산 1호선',
+          color: const Value('#F06A00'),
+        ),
+        LinesCompanion.insert(
+          id: 'seoul-4',
+          operatorId: 'seoul-metro',
+          nameKo: '수도권 4호선',
+          color: const Value('#00A5DE'),
+        ),
+      ]);
+    });
+    final repository = DriftStationRepository(database: database);
+
+    final lines = await repository.listLines();
+
+    expect(lines.map((line) => '${line.id}:${line.region}'), [
+      'busan-1:부산',
+      'seoul-4:수도권',
+    ]);
   });
 
   test('역 API 저장소는 현재 위치 기준 가까운 역을 요청하고 거리를 파싱한다', () async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -4962,6 +4962,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('계단 없는 길만 안내해요'), findsOneWidget);
+    expect(
+      find.bySemanticsLabel('휠체어 이용 선택 가능, 계단 없는 길만 안내해요, 계단 피하기 · 엘리베이터 이동'),
+      findsOneWidget,
+    );
     await tester.tap(find.byKey(const Key('routeMobilityOption-WHEELCHAIR')));
     await tester.pumpAndSettle();
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -4967,7 +4967,7 @@ void main() {
 
     expect(find.byKey(const Key('routeMobilityApplyButton')), findsOneWidget);
     expect(
-      find.bySemanticsLabel('휠체어 이용 현재 선택, 계단 없는 길만 안내해요'),
+      find.bySemanticsLabel('휠체어 이용 현재 선택, 계단 없는 길만 안내해요, 계단 피하기 · 엘리베이터 이동'),
       findsOneWidget,
     );
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3020,6 +3020,161 @@ void main() {
     await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
   });
 
+  testWidgets('역 검색 노선 필터는 지역을 먼저 고르고 전체 노선은 바텀시트로 연다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    final repository = FakeStationSearchRepository(
+      lineOptions: const [
+        SubwayLineOption(
+          id: 'busan-1',
+          name: '부산 1호선',
+          color: '#F06A00',
+          region: '부산',
+          lineCode: '1',
+          active: true,
+        ),
+        SubwayLineOption(
+          id: 'seoul-4',
+          name: '수도권 4호선',
+          color: '#00A5DE',
+          region: '수도권',
+          lineCode: '4',
+          active: true,
+        ),
+        SubwayLineOption(
+          id: 'inactive-line',
+          name: '운행 중지 노선',
+          color: '#777777',
+          region: '수도권',
+          lineCode: '중지',
+          active: false,
+        ),
+      ],
+    );
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: repository,
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('stationSearchButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('stationLineFilterPanel')), findsOneWidget);
+      expect(find.byKey(const Key('stationLineRegion-수도권')), findsOneWidget);
+      expect(find.byKey(const Key('stationLineRegion-부산')), findsOneWidget);
+      expect(
+        find.byKey(const Key('stationLineFilter-seoul-4')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('stationLineFilter-busan-1')), findsNothing);
+      expect(find.text('운행 중지 노선'), findsNothing);
+
+      await tester.tap(find.byKey(const Key('stationLineRegion-부산')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('stationLineFilter-busan-1')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('stationLineFilter-seoul-4')), findsNothing);
+      expect(find.bySemanticsLabel('부산 1호선 선택 안 됨'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('stationLineFilterMoreButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('stationLineAllSheet')), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('stationLineAllSheet')),
+          matching: find.text('전체 노선 보기'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('stationLineFilter-seoul-4')),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('stationLineFilter-busan-1')), findsWidgets);
+      expect(find.text('운행 중지 노선'), findsNothing);
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
+  testWidgets('역 검색 결과는 입력창 바로 아래에 먼저 보이고 필터는 접을 수 있다', (tester) async {
+    final repository = FakeStationSearchRepository(
+      lineOptions: const [
+        SubwayLineOption(
+          id: 'seoul-4',
+          name: '수도권 4호선',
+          color: '#00A5DE',
+          region: '수도권',
+          lineCode: '4',
+          active: true,
+        ),
+      ],
+      nextResults: [
+        const StationSearchResult(
+          id: 'station-sangnoksu',
+          nameKo: '상록수',
+          nameEn: 'Sangnoksu',
+          region: '수도권',
+          dataQualityLevel: 'LEVEL_1',
+          lastVerifiedAt: '2026-06-12',
+          lines: [
+            StationSearchLine(
+              id: 'seoul-4',
+              name: '수도권 4호선',
+              color: '#00A5DE',
+              stationCode: '448',
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    final resultTop = tester
+        .getTopLeft(
+          find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+        )
+        .dy;
+    final filterTop = tester
+        .getTopLeft(find.byKey(const Key('stationLineFilterPanel')))
+        .dy;
+    expect(resultTop, lessThan(filterTop));
+    expect(find.text('노선 필터 펼치기'), findsOneWidget);
+    expect(find.byKey(const Key('stationLineFilter-seoul-4')), findsNothing);
+
+    await tester.tap(find.byKey(const Key('stationLineFilterToggle')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('노선 필터 접기'), findsOneWidget);
+    expect(find.byKey(const Key('stationLineFilter-seoul-4')), findsOneWidget);
+  });
+
   testWidgets('역 검색은 노선을 선택해 결과를 좁힌다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final repository = FakeStationSearchRepository(
@@ -3125,7 +3280,17 @@ void main() {
         findsOneWidget,
       );
 
+      await tester.tap(find.byKey(const Key('stationLineFilterToggle')));
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(
+        find.byKey(const Key('stationLineFilter-all')),
+      );
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('stationLineFilter-all')));
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(
+        find.byKey(const Key('stationSearchSubmitButton')),
+      );
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
       await tester.pumpAndSettle();
@@ -4781,7 +4946,32 @@ void main() {
 
     await tester.tap(find.byKey(const Key('routeSimpleMobilityTypeButton')));
     await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('routeMobilityOptionsList')), findsOneWidget);
+    expect(find.text('계단을 피하고 쉬운 환승을 우선해요'), findsOneWidget);
+    expect(find.byKey(const Key('routeMobilityApplyButton')), findsOneWidget);
+
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('routeMobilityOption-WHEELCHAIR')),
+      120,
+      scrollable: find.descendant(
+        of: find.byKey(const Key('routeMobilityOptionsList')),
+        matching: find.byType(Scrollable),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('계단 없는 길만 안내해요'), findsOneWidget);
     await tester.tap(find.byKey(const Key('routeMobilityOption-WHEELCHAIR')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('routeMobilityApplyButton')), findsOneWidget);
+    expect(
+      find.bySemanticsLabel('휠체어 이용 현재 선택, 계단 없는 길만 안내해요'),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('routeMobilityApplyButton')));
     await tester.pumpAndSettle();
 
     expect(find.text('휠체어 이용'), findsOneWidget);


### PR DESCRIPTION
## 관련 이슈

close #791

## 작업 배경

- 역 검색에서 전국 노선을 한 화면에 모두 보여 탐색 부담이 크고, 검색 결과보다 필터가 먼저 보여 역 선택 흐름이 늦어졌습니다.
- 이동 조건 바텀시트는 옵션을 누르는 즉시 닫혀 설명을 비교하거나 현재 선택을 확인하기 어려웠습니다.

## 작업 내용

- 역 검색 노선 필터를 지역 우선 칩으로 나누고, 선택 지역 노선만 기본 표시하며 전체 노선은 별도 바텀시트에서 열도록 정리했습니다.
- 검색 결과를 입력창과 검색 버튼 바로 아래에 먼저 배치하고, 결과가 나온 뒤 노선 필터는 접힌 상태에서 필요할 때 펼칠 수 있게 했습니다.
- 가까운 역 AppBar 조작을 텍스트 포함 버튼으로 바꿔 터치 대상과 의미를 더 분명하게 했습니다.
- 이동 조건 바텀시트에 옵션 설명, 현재 선택 상태, 스크롤 영역, 적용 버튼을 추가하고 적용 전까지 경로 조건을 확정하지 않도록 했습니다.
- 로컬 Drift 노선 목록이 노선명 prefix에서 지역 필터 값을 만들도록 해 전국 데이터팩에서도 지역 필터가 동작하게 했습니다.
- 리뷰 지적에 따라 선택/미선택 이동 조건 모두 TalkBack 라벨에서 조건 문구까지 읽도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/station_search_test.dart test/route_search_test.dart test/widget_test.dart`: exit 0, 172 tests passed
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "경로 검색 단순 보기에서도 이동 조건을 바꿀 수 있다"`: exit 0, targeted widget test passed
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `cd apps/mobile && flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `cd apps/mobile && flutter build ios --simulator --debug`: exit 0, `build/ios/iphonesimulator/Runner.app` 생성
  - `git diff --check`: exit 0
  - GitHub Actions `CI`: pass, `Mobile App CI`, `Android CI`, `Dependency Vulnerability Scan / osv-scan` 포함
  - GitHub Actions `Release Artifacts`: pass, `Android Release Artifact` 포함
  - CodeRabbit review: actionable 1건 확인 후 수정 답글 작성 및 thread resolved
  - Codex CLI fallback review: CodeRabbit rate limit 이후 actionable 1건 확인, 수정 후 최종 re-review actionable 0건

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 검색 지역 필터 | Android emulator API 36 | UI tree/screenshot | `.codex/evidence/791/android-station-filter-region-final.xml`, `.codex/evidence/791/android-station-filter-region-final.png` | 기본 지역이 `수도권 지역 선택됨`으로 시작하고 수도권 노선만 먼저 표시됨 |
| 전체 노선 바텀시트 | Android emulator API 36 | UI tree/screenshot | `.codex/evidence/791/android-station-all-lines-sheet.xml`, `.codex/evidence/791/android-station-all-lines-sheet.png` | `전체 노선 보기` 바텀시트에서 전체 활성 노선을 확인할 수 있음 |
| 검색 결과 우선/필터 접기 | Android emulator API 36 | UI tree/screenshot | `.codex/evidence/791/android-station-search-results.xml`, `.codex/evidence/791/android-station-search-results.png` | 검색 결과가 입력 영역 바로 아래에 먼저 보이고 `노선 필터 펼치기`로 접힌 필터를 다시 열 수 있음 |
| 이동 조건 바텀시트 | Android emulator API 36 | UI tree/screenshot | `.codex/evidence/791/android-route-mobility-sheet.xml`, `.codex/evidence/791/android-route-mobility-sheet.png` | 옵션 설명, 현재 선택 상태, `적용` 버튼이 함께 표시됨 |
| iOS 설치/기본 실행 | iOS Simulator Maum iPhone 17 | simulator screenshot | `.codex/evidence/791/ios-home.png` | simulator build 후 앱이 홈 화면까지 실행됨 |
| 화면 증거 로컬 보관 | Android/iOS | local-only evidence | `.codex/evidence/791/` | 스크린샷과 UI tree는 검증용 로컬 증거라 git에 커밋하지 않음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/station_search.dart`의 결과 우선 배치와 지역별 필터 접기 동작
  - `apps/mobile/lib/route_search.dart`의 pending mobility selection/apply flow와 선택/미선택 접근성 라벨
  - `apps/mobile/lib/features/stations/data/drift_station_repository.dart`의 지역 파생 로직

## 리스크

- Drift line table에 별도 region column이 없어 현재는 노선명 prefix 기반으로 지역을 파생합니다. 향후 데이터팩 schema에 line region이 생기면 저장소 매핑을 field 기반으로 바꾸는 것이 더 정확합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 역 검색에서 노선 필터가 지역별로 나뉘어 표시되며, 지역 선택과 전체 노선 선택을 함께 지원합니다.
  * 경로 검색의 이동 조건 선택이 즉시 반영되지 않고, **적용** 버튼으로 확정되도록 개선되었습니다.

* **Bug Fixes**
  * 노선 지역이 고정값으로 표시되던 문제를 개선해, 노선명에 맞는 지역이 더 정확하게 표시됩니다.
  * 검색 결과와 필터 패널의 표시/접힘 상태가 더 자연스럽게 동작하도록 조정했습니다.

* **Style**
  * 이동 조건 및 노선 선택 화면의 안내 문구와 접근성 표시가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
