### PR TITLE
[Feat] 즐겨찾기 역·시설·경로 상세 행동 보강

### DIFF
--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import 'auth_headers.dart';
+import 'facility_report.dart';
 import 'facility_status.dart';
 import 'mobile_error_reporter.dart';
 
@@ -393,9 +394,16 @@ class FavoriteFacilityListController extends ChangeNotifier {
 }
 
 class FavoriteFacilityListScreen extends StatefulWidget {
-  const FavoriteFacilityListScreen({required this.repository, super.key});
+  const FavoriteFacilityListScreen({
+    required this.repository,
+    this.reportRepository,
+    this.facilityReportDraftTargetStore,
+    super.key,
+  });
 
   final FavoriteFacilityRepository repository;
+  final FacilityReportRepository? reportRepository;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
 
   @override
   State<FavoriteFacilityListScreen> createState() =>
@@ -408,15 +416,26 @@ class _FavoriteFacilityListScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('즐겨찾기 시설')),
-      body: FavoriteFacilityListContent(repository: widget.repository),
+      body: FavoriteFacilityListContent(
+        repository: widget.repository,
+        reportRepository: widget.reportRepository,
+        facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
+      ),
     );
   }
 }
 
 class FavoriteFacilityListContent extends StatefulWidget {
-  const FavoriteFacilityListContent({required this.repository, super.key});
+  const FavoriteFacilityListContent({
+    required this.repository,
+    this.reportRepository,
+    this.facilityReportDraftTargetStore,
+    super.key,
+  });
 
   final FavoriteFacilityRepository repository;
+  final FacilityReportRepository? reportRepository;
+  final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
 
   @override
   State<FavoriteFacilityListContent> createState() =>
@@ -449,18 +468,49 @@ class _FavoriteFacilityListContentState
           return _FavoriteFacilityListBody(
             state: _controller.state,
             onRetry: _controller.load,
+            onReportTap: widget.reportRepository == null
+                ? null
+                : _openFacilityReport,
           );
         },
+      ),
+    );
+  }
+
+  void _openFacilityReport(FavoriteFacility favorite) {
+    final reportRepository = widget.reportRepository;
+    if (reportRepository == null) {
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => FacilityReportScreen(
+          repository: reportRepository,
+          draftTargetStore: widget.facilityReportDraftTargetStore,
+          target: FacilityReportTarget(
+            stationId: favorite.stationId,
+            stationName: favorite.stationNameKo,
+            facilityId: favorite.facilityId,
+            facilityName: favorite.name,
+            facilityTypeLabel: favorite.typeLabel,
+            facilityStatusLabel: favorite.statusLabel,
+          ),
+        ),
       ),
     );
   }
 }
 
 class _FavoriteFacilityListBody extends StatelessWidget {
-  const _FavoriteFacilityListBody({required this.state, required this.onRetry});
+  const _FavoriteFacilityListBody({
+    required this.state,
+    required this.onRetry,
+    required this.onReportTap,
+  });
 
   final FavoriteFacilityListState state;
   final VoidCallback onRetry;
+  final ValueChanged<FavoriteFacility>? onReportTap;
 
   @override
   Widget build(BuildContext context) {
@@ -502,7 +552,12 @@ class _FavoriteFacilityListBody extends StatelessWidget {
             child: const SizedBox.shrink(),
           ),
           for (final favorite in state.favorites)
-            _FavoriteFacilityTile(favorite: favorite),
+            _FavoriteFacilityTile(
+              favorite: favorite,
+              onReportTap: onReportTap == null
+                  ? null
+                  : () => onReportTap!(favorite),
+            ),
         ],
       ),
     };
@@ -510,102 +565,120 @@ class _FavoriteFacilityListBody extends StatelessWidget {
 }
 
 class _FavoriteFacilityTile extends StatelessWidget {
-  const _FavoriteFacilityTile({required this.favorite});
+  const _FavoriteFacilityTile({
+    required this.favorite,
+    required this.onReportTap,
+  });
 
   final FavoriteFacility favorite;
+  final VoidCallback? onReportTap;
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
 
-    return MergeSemantics(
-      child: Semantics(
-        label: favorite.semanticLabel,
-        child: ExcludeSemantics(
-          child: Card(
-            key: Key('favoriteFacilityTile-${favorite.facilityId}'),
-            margin: const EdgeInsets.only(bottom: 12),
-            color: Colors.white,
-            elevation: 0,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-              side: const BorderSide(color: Color(0xFFD5E2E4)),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    favorite.name,
-                    style: textTheme.titleLarge?.copyWith(
-                      color: const Color(0xFF102A2C),
-                      fontWeight: FontWeight.w900,
-                      height: 1.25,
-                    ),
+    return Card(
+      key: Key('favoriteFacilityTile-${favorite.facilityId}'),
+      margin: const EdgeInsets.only(bottom: 12),
+      color: Colors.white,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: const BorderSide(color: Color(0xFFD5E2E4)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            MergeSemantics(
+              child: Semantics(
+                label: favorite.semanticLabel,
+                child: ExcludeSemantics(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        favorite.name,
+                        style: textTheme.titleLarge?.copyWith(
+                          color: const Color(0xFF102A2C),
+                          fontWeight: FontWeight.w900,
+                          height: 1.25,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        favorite.stationLabel,
+                        style: textTheme.bodyLarge?.copyWith(
+                          color: const Color(0xFF29484B),
+                          fontWeight: FontWeight.w800,
+                          height: 1.3,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        favorite.statusLabel,
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: const Color(0xFF405A5D),
+                          height: 1.3,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        '${favorite.severityLabel} · 다음 행동 ${favorite.nextActionLabel}',
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: const Color(0xFF405A5D),
+                          fontWeight: FontWeight.w700,
+                          height: 1.3,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        favorite.locationLabel,
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: const Color(0xFF405A5D),
+                          height: 1.3,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        favorite.updatedLabel,
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: const Color(0xFF405A5D),
+                          height: 1.3,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        favorite.confidenceLabel,
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: const Color(0xFF405A5D),
+                          height: 1.3,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        favorite.dataSourceLabel,
+                        style: textTheme.bodyMedium?.copyWith(
+                          color: const Color(0xFF405A5D),
+                          height: 1.3,
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(height: 8),
-                  Text(
-                    favorite.stationLabel,
-                    style: textTheme.bodyLarge?.copyWith(
-                      color: const Color(0xFF29484B),
-                      fontWeight: FontWeight.w800,
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    favorite.statusLabel,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: const Color(0xFF405A5D),
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    '${favorite.severityLabel} · 다음 행동 ${favorite.nextActionLabel}',
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: const Color(0xFF405A5D),
-                      fontWeight: FontWeight.w700,
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    favorite.locationLabel,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: const Color(0xFF405A5D),
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    favorite.updatedLabel,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: const Color(0xFF405A5D),
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    favorite.confidenceLabel,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: const Color(0xFF405A5D),
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    favorite.dataSourceLabel,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: const Color(0xFF405A5D),
-                      height: 1.3,
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
-          ),
+            if (onReportTap != null) ...[
+              const SizedBox(height: 12),
+              OutlinedButton.icon(
+                key: Key('favoriteFacilityReport-${favorite.facilityId}'),
+                onPressed: onReportTap,
+                icon: const Icon(Icons.report_outlined),
+                label: const Text('상태 제보'),
+              ),
+            ],
+          ],
         ),
       ),
     );

--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -397,12 +397,19 @@ class FavoriteFacilityListScreen extends StatefulWidget {
   const FavoriteFacilityListScreen({
     required this.repository,
     this.reportRepository,
+    this.locationLoader,
+    this.needsLocationPermissionRequest,
+    this.openLocationSettings,
     this.facilityReportDraftTargetStore,
     super.key,
   });
 
   final FavoriteFacilityRepository repository;
   final FacilityReportRepository? reportRepository;
+  final FacilityReportLocationLoader? locationLoader;
+  final FacilityReportLocationPermissionRequestChecker?
+  needsLocationPermissionRequest;
+  final FacilityReportLocationSettingsOpener? openLocationSettings;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
 
   @override
@@ -419,6 +426,9 @@ class _FavoriteFacilityListScreenState
       body: FavoriteFacilityListContent(
         repository: widget.repository,
         reportRepository: widget.reportRepository,
+        locationLoader: widget.locationLoader,
+        needsLocationPermissionRequest: widget.needsLocationPermissionRequest,
+        openLocationSettings: widget.openLocationSettings,
         facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
       ),
     );
@@ -429,12 +439,19 @@ class FavoriteFacilityListContent extends StatefulWidget {
   const FavoriteFacilityListContent({
     required this.repository,
     this.reportRepository,
+    this.locationLoader,
+    this.needsLocationPermissionRequest,
+    this.openLocationSettings,
     this.facilityReportDraftTargetStore,
     super.key,
   });
 
   final FavoriteFacilityRepository repository;
   final FacilityReportRepository? reportRepository;
+  final FacilityReportLocationLoader? locationLoader;
+  final FacilityReportLocationPermissionRequestChecker?
+  needsLocationPermissionRequest;
+  final FacilityReportLocationSettingsOpener? openLocationSettings;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
 
   @override
@@ -486,6 +503,9 @@ class _FavoriteFacilityListContentState
       MaterialPageRoute<void>(
         builder: (_) => FacilityReportScreen(
           repository: reportRepository,
+          locationLoader: widget.locationLoader,
+          needsLocationPermissionRequest: widget.needsLocationPermissionRequest,
+          openLocationSettings: widget.openLocationSettings,
           draftTargetStore: widget.facilityReportDraftTargetStore,
           target: FacilityReportTarget(
             stationId: favorite.stationId,

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1245,6 +1245,7 @@ class _HomeScreenState extends State<HomeScreen> {
             locationProvider: locationProvider,
             facilityReportDraftTargetStore: facilityReportDraftTargetStore,
             internalRouteRepository: internalRouteRepository,
+            routeDraftController: _routeDraftController,
             initialMobilityType: initialMobilityType,
           ),
         ),
@@ -3158,6 +3159,7 @@ class FavoriteHomeScreen extends StatefulWidget {
     required this.locationProvider,
     required this.facilityReportDraftTargetStore,
     required this.internalRouteRepository,
+    required this.routeDraftController,
     required this.initialMobilityType,
     super.key,
   });
@@ -3170,6 +3172,7 @@ class FavoriteHomeScreen extends StatefulWidget {
   final CurrentLocationProvider locationProvider;
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
   final InternalRouteRepository internalRouteRepository;
+  final RouteDraftController routeDraftController;
   final String initialMobilityType;
 
   @override
@@ -3320,6 +3323,7 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
           locationProvider: widget.locationProvider,
           facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
           internalRouteRepository: widget.internalRouteRepository,
+          routeDraftController: widget.routeDraftController,
           internalRouteMobilityType: widget.initialMobilityType,
         ),
       ),
@@ -3334,7 +3338,11 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
     unawaited(
       _openFavoriteListScreen(
         title: '즐겨찾기한 시설',
-        child: FavoriteFacilityListContent(repository: repository),
+        child: FavoriteFacilityListContent(
+          repository: repository,
+          reportRepository: widget.reportRepository,
+          facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
+        ),
       ),
     );
   }
@@ -3392,30 +3400,33 @@ class _FavoriteHomeQuickGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GridView.count(
-      crossAxisCount: 2,
-      crossAxisSpacing: 10,
-      mainAxisSpacing: 10,
-      childAspectRatio: 1.45,
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _FavoriteHomeQuickCard(
           key: const Key('favoriteHomeStationsButton'),
           icon: Icons.train_outlined,
-          label: '역 ${_countLabel(stationCount)}',
+          label: '역',
+          countLabel: _countLabel(stationCount),
+          subtitle: '출발지·도착지 설정과 시설 상태를 확인해요',
           onTap: onStations,
         ),
+        const SizedBox(height: 10),
         _FavoriteHomeQuickCard(
           key: const Key('favoriteHomeFacilitiesButton'),
           icon: Icons.elevator_outlined,
-          label: '시설 ${_countLabel(facilityCount)}',
+          label: '시설',
+          countLabel: _countLabel(facilityCount),
+          subtitle: '고장·공사 상태와 최근 확인 시각을 봐요',
           onTap: onFacilities,
         ),
+        const SizedBox(height: 10),
         _FavoriteHomeQuickCard(
           key: const Key('favoriteHomeRoutesButton'),
           icon: Icons.route_outlined,
-          label: '경로 ${_countLabel(routeCount)}',
+          label: '경로',
+          countLabel: _countLabel(routeCount),
+          subtitle: '이동 편의도와 저장한 경로를 다시 확인해요',
           onTap: onRoutes,
         ),
       ],
@@ -3427,35 +3438,42 @@ class _FavoriteHomeQuickCard extends StatelessWidget {
   const _FavoriteHomeQuickCard({
     required this.icon,
     required this.label,
+    required this.countLabel,
+    required this.subtitle,
     required this.onTap,
     super.key,
   });
 
   final IconData icon;
   final String label;
+  final String countLabel;
+  final String subtitle;
   final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
+    final semanticLabel = '$label $countLabel, $subtitle';
     return Semantics(
       button: true,
       enabled: onTap != null,
-      label: label,
+      label: semanticLabel,
       onTap: onTap,
       child: ExcludeSemantics(
         child: InkWell(
           onTap: onTap,
-          borderRadius: BorderRadius.circular(18),
+          borderRadius: BorderRadius.circular(8),
           child: _PrototypeCard(
             backgroundColor: Colors.white,
-            borderRadius: 18,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
+            borderRadius: 8,
+            showBorder: true,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 DecoratedBox(
                   decoration: BoxDecoration(
                     color: EasySubwayAccessibleColors.mintSoft,
-                    borderRadius: BorderRadius.circular(14),
+                    borderRadius: BorderRadius.circular(8),
                   ),
                   child: SizedBox(
                     width: 44,
@@ -3466,14 +3484,37 @@ class _FavoriteHomeQuickCard extends StatelessWidget {
                     ),
                   ),
                 ),
-                const SizedBox(height: 9),
-                Text(
-                  label,
-                  style: const TextStyle(
-                    color: EasySubwayAccessibleColors.text,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w900,
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '$label $countLabel',
+                        style: const TextStyle(
+                          color: EasySubwayAccessibleColors.text,
+                          fontSize: 18,
+                          fontWeight: FontWeight.w900,
+                          height: 1.25,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        subtitle,
+                        style: const TextStyle(
+                          color: EasySubwayAccessibleColors.mutedText,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w700,
+                          height: 1.3,
+                        ),
+                      ),
+                    ],
                   ),
+                ),
+                const SizedBox(width: 8),
+                const Icon(
+                  Icons.chevron_right,
+                  color: EasySubwayAccessibleColors.brand,
                 ),
               ],
             ),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -3341,6 +3341,12 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
         child: FavoriteFacilityListContent(
           repository: repository,
           reportRepository: widget.reportRepository,
+          locationLoader: _facilityReportLocationLoader(
+            widget.locationProvider,
+          ),
+          needsLocationPermissionRequest:
+              widget.locationProvider.needsLocationPermissionRequest,
+          openLocationSettings: widget.locationProvider.openLocationSettings,
           facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
         ),
       ),

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -4391,6 +4391,8 @@ class _FavoriteRouteTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final menuButtonKey =
+        GlobalKey<PopupMenuButtonState<_FavoriteRouteMenuAction>>();
     final moreSemanticLabel =
         '${favorite.summaryTitle} 더 보기${isRemoving ? ', 삭제 중' : ''}';
 
@@ -4417,13 +4419,17 @@ class _FavoriteRouteTile extends StatelessWidget {
               const SizedBox(width: 8),
             ],
             Semantics(
+              key: Key('favoriteRouteMore-${favorite.favoriteRouteId}'),
               container: true,
               label: moreSemanticLabel,
               button: true,
               enabled: !isRemoving,
+              onTap: isRemoving
+                  ? null
+                  : () => menuButtonKey.currentState?.showButtonMenu(),
               child: ExcludeSemantics(
                 child: PopupMenuButton<_FavoriteRouteMenuAction>(
-                  key: Key('favoriteRouteMore-${favorite.favoriteRouteId}'),
+                  key: menuButtonKey,
                   enabled: !isRemoving,
                   tooltip: '경로 더 보기',
                   onSelected: (action) {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -35,6 +35,14 @@ String _mobilityLabelFor(String mobilityType) {
   return '이동 조건 확인 필요';
 }
 
+String _routeDateLabel(String value) {
+  final trimmed = value.trim();
+  if (trimmed.length >= 10) {
+    return trimmed.substring(0, 10);
+  }
+  return '확인 필요';
+}
+
 abstract class RouteSearchRepository {
   Future<RouteSearchResult> searchRoute(RouteSearchRequest request);
 }
@@ -452,9 +460,19 @@ class FavoriteRoute {
 
   String get lineLabel => lineName.isEmpty ? '노선 확인 필요' : lineName;
 
-  String get scoreLabel => '이동 점수 $score점';
+  String get scoreLabel => '이동 편의도 $score점';
 
   String get mobilityLabel => _mobilityLabelFor(mobilityType);
+
+  String get scoreBasisText =>
+      '기준: $mobilityLabel, $lineLabel, 최근 확인 ${_routeDateLabel(routeCreatedAt)}';
+
+  String get scoreBasisSemanticLabel =>
+      '기준 $mobilityLabel, $lineLabel, 최근 확인 ${_routeDateLabel(routeCreatedAt)}';
+
+  String get movementMetricLabel => '예상 시간 확인 필요 · 환승 확인 필요 · 도보 확인 필요';
+
+  String get accessibilityMetricLabel => '계단 정보 확인 필요 · 엘리베이터 연결 확인 필요';
 
   String get semanticLabel {
     return [
@@ -463,6 +481,12 @@ class FavoriteRoute {
       lineLabel,
       mobilityLabel,
       scoreLabel,
+      scoreBasisSemanticLabel,
+      '예상 시간 확인 필요',
+      '환승 확인 필요',
+      '도보 확인 필요',
+      '계단 정보 확인 필요',
+      '엘리베이터 연결 확인 필요',
     ].join(', ');
   }
 }
@@ -609,7 +633,7 @@ class RouteSearchResult {
     };
   }
 
-  String get scoreLabel => '이동 점수 $score점';
+  String get scoreLabel => '이동 편의도 $score점';
 
   String get lineLabel => lineName.isEmpty ? '노선 확인 필요' : lineName;
 
@@ -4367,39 +4391,97 @@ class _FavoriteRouteTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final removeSemanticLabel =
-        '${favorite.summaryTitle} ${isRemoving ? '삭제 중' : '삭제'}';
+    final moreSemanticLabel =
+        '${favorite.summaryTitle} 더 보기${isRemoving ? ', 삭제 중' : ''}';
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _FavoriteRouteSummaryCard(favorite: favorite),
-        const SizedBox(height: 12),
-        Semantics(
-          container: true,
-          label: removeSemanticLabel,
-          button: true,
-          enabled: !isRemoving,
-          onTap: isRemoving ? null : () => onRemove(favorite),
-          child: ExcludeSemantics(
-            child: OutlinedButton.icon(
-              key: Key('favoriteRouteRemove-${favorite.favoriteRouteId}'),
-              onPressed: isRemoving ? null : () => onRemove(favorite),
-              icon: isRemoving
-                  ? const SizedBox.square(
-                      dimension: 18,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Icon(Icons.delete_outline),
-              label: Text(isRemoving ? '삭제 중' : '삭제'),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            if (isRemoving) ...[
+              const SizedBox.square(
+                dimension: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '삭제 중',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: const Color(0xFF405A5D),
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(width: 8),
+            ],
+            Semantics(
+              container: true,
+              label: moreSemanticLabel,
+              button: true,
+              enabled: !isRemoving,
+              child: ExcludeSemantics(
+                child: PopupMenuButton<_FavoriteRouteMenuAction>(
+                  key: Key('favoriteRouteMore-${favorite.favoriteRouteId}'),
+                  enabled: !isRemoving,
+                  tooltip: '경로 더 보기',
+                  onSelected: (action) {
+                    switch (action) {
+                      case _FavoriteRouteMenuAction.remove:
+                        unawaited(_confirmRemove(context));
+                    }
+                  },
+                  itemBuilder: (context) => [
+                    PopupMenuItem<_FavoriteRouteMenuAction>(
+                      key: Key(
+                        'favoriteRouteRemove-${favorite.favoriteRouteId}',
+                      ),
+                      value: _FavoriteRouteMenuAction.remove,
+                      child: const Text('삭제'),
+                    ),
+                  ],
+                  icon: const Icon(Icons.more_vert),
+                ),
+              ),
             ),
-          ),
+          ],
         ),
         const SizedBox(height: 12),
       ],
     );
   }
+
+  Future<void> _confirmRemove(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('즐겨찾기 경로 삭제'),
+          content: Text('${favorite.summaryTitle} 경로를 즐겨찾기에서 삭제할까요?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('취소'),
+            ),
+            FilledButton(
+              key: Key(
+                'favoriteRouteRemoveConfirm-${favorite.favoriteRouteId}',
+              ),
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('삭제'),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirmed == true && context.mounted) {
+      onRemove(favorite);
+    }
+  }
 }
+
+enum _FavoriteRouteMenuAction { remove }
 
 class _FavoriteRouteSummaryCard extends StatelessWidget {
   const _FavoriteRouteSummaryCard({required this.favorite});
@@ -4459,6 +4541,31 @@ class _FavoriteRouteSummaryCard extends StatelessWidget {
                     style: textTheme.bodyLarge?.copyWith(
                       color: const Color(0xFF29484B),
                       fontWeight: FontWeight.w800,
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    favorite.scoreBasisText,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: const Color(0xFF405A5D),
+                      fontWeight: FontWeight.w700,
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    favorite.movementMetricLabel,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: const Color(0xFF405A5D),
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    favorite.accessibilityMetricLabel,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: const Color(0xFF405A5D),
                       height: 1.3,
                     ),
                   ),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -1363,16 +1363,33 @@ class FavoriteStationListState {
     required this.status,
     this.favorites = const [],
     this.message = '',
+    this.removingIds = const {},
   });
 
   const FavoriteStationListState.loading()
     : status = FavoriteStationListStatus.loading,
       favorites = const [],
-      message = '';
+      message = '',
+      removingIds = const {};
 
   final FavoriteStationListStatus status;
   final List<FavoriteStation> favorites;
   final String message;
+  final Set<String> removingIds;
+
+  FavoriteStationListState copyWith({
+    FavoriteStationListStatus? status,
+    List<FavoriteStation>? favorites,
+    String? message,
+    Set<String>? removingIds,
+  }) {
+    return FavoriteStationListState(
+      status: status ?? this.status,
+      favorites: favorites ?? this.favorites,
+      message: message ?? this.message,
+      removingIds: removingIds ?? this.removingIds,
+    );
+  }
 }
 
 class FavoriteStationListController extends ChangeNotifier {
@@ -1425,6 +1442,61 @@ class FavoriteStationListController extends ChangeNotifier {
         ),
       );
     }
+  }
+
+  Future<void> remove(FavoriteStation favorite) async {
+    final stationId = favorite.stationId;
+    if (_state.removingIds.contains(stationId)) {
+      return;
+    }
+
+    _emitState(
+      _state.copyWith(removingIds: {..._state.removingIds, stationId}),
+    );
+
+    try {
+      await repository.removeFavoriteStation(stationId);
+      final nextFavorites = _state.favorites
+          .where((item) => item.stationId != stationId)
+          .toList(growable: false);
+      final nextRemovingIds = {..._state.removingIds}..remove(stationId);
+      _emitState(
+        nextFavorites.isEmpty
+            ? FavoriteStationListState(
+                status: FavoriteStationListStatus.empty,
+                message: '즐겨찾기한 역이 없습니다.',
+                removingIds: nextRemovingIds,
+              )
+            : FavoriteStationListState(
+                status: FavoriteStationListStatus.success,
+                favorites: nextFavorites,
+                removingIds: nextRemovingIds,
+              ),
+      );
+    } on FavoriteStationException catch (error) {
+      _emitFailure(error.message, removingIdToClear: stationId);
+    } catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '즐겨찾기 역 해제 중 예외가 발생했습니다.');
+      _emitFailure(
+        _favoriteStationChangeErrorMessage,
+        removingIdToClear: stationId,
+      );
+    }
+  }
+
+  void _emitFailure(String message, {String? removingIdToClear}) {
+    final nextRemovingIds = {..._state.removingIds};
+    if (removingIdToClear != null) {
+      nextRemovingIds.remove(removingIdToClear);
+    }
+    _emitState(
+      FavoriteStationListState(
+        status: FavoriteStationListStatus.failure,
+        favorites: _state.favorites,
+        message: message,
+        removingIds: nextRemovingIds,
+      ),
+    );
   }
 
   void _emitState(FavoriteStationListState nextState) {
@@ -3057,6 +3129,7 @@ class FavoriteStationListScreen extends StatefulWidget {
     this.facilityReportDraftTargetStore,
     this.internalRouteRepository,
     this.internalRouteMobilityType = 'SENIOR',
+    this.routeDraftController,
     super.key,
   });
 
@@ -3067,6 +3140,7 @@ class FavoriteStationListScreen extends StatefulWidget {
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
   final InternalRouteRepository? internalRouteRepository;
   final String internalRouteMobilityType;
+  final RouteDraftController? routeDraftController;
 
   @override
   State<FavoriteStationListScreen> createState() =>
@@ -3086,6 +3160,7 @@ class _FavoriteStationListScreenState extends State<FavoriteStationListScreen> {
         facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
         internalRouteRepository: widget.internalRouteRepository,
         internalRouteMobilityType: widget.internalRouteMobilityType,
+        routeDraftController: widget.routeDraftController,
       ),
     );
   }
@@ -3100,6 +3175,7 @@ class FavoriteStationListContent extends StatefulWidget {
     this.facilityReportDraftTargetStore,
     this.internalRouteRepository,
     this.internalRouteMobilityType = 'SENIOR',
+    this.routeDraftController,
     super.key,
   });
 
@@ -3110,6 +3186,7 @@ class FavoriteStationListContent extends StatefulWidget {
   final FacilityReportDraftTargetStore? facilityReportDraftTargetStore;
   final InternalRouteRepository? internalRouteRepository;
   final String internalRouteMobilityType;
+  final RouteDraftController? routeDraftController;
 
   @override
   State<FavoriteStationListContent> createState() =>
@@ -3143,6 +3220,10 @@ class _FavoriteStationListContentState
             state: _controller.state,
             onRetry: _controller.load,
             onFavoriteTap: _openStationDetail,
+            onFacilityStatusTap: _openStationDetail,
+            onSetOrigin: _setRouteOrigin,
+            onSetDestination: _setRouteDestination,
+            onRemove: _controller.remove,
           );
         },
       ),
@@ -3161,6 +3242,7 @@ class _FavoriteStationListContentState
           facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
           internalRouteRepository: widget.internalRouteRepository,
           internalRouteMobilityType: widget.internalRouteMobilityType,
+          routeDraftController: widget.routeDraftController,
           // 목록에서 들어온 역은 이미 저장된 상태로 보여 해제 동작을 바로 할 수 있게 한다.
           initiallyFavorite: true,
         ),
@@ -3171,6 +3253,30 @@ class _FavoriteStationListContentState
     }
     unawaited(_controller.load());
   }
+
+  void _setRouteOrigin(FavoriteStation favorite) {
+    final station = RouteDraftStation(
+      id: favorite.stationId,
+      nameKo: favorite.nameKo,
+    );
+    widget.routeDraftController?.setOrigin(station);
+    _showRouteDraftSnack('${station.displayName}을 출발역으로 설정했습니다');
+  }
+
+  void _setRouteDestination(FavoriteStation favorite) {
+    final station = RouteDraftStation(
+      id: favorite.stationId,
+      nameKo: favorite.nameKo,
+    );
+    widget.routeDraftController?.setDestination(station);
+    _showRouteDraftSnack('${station.displayName}을 도착역으로 설정했습니다');
+  }
+
+  void _showRouteDraftSnack(String message) {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
 }
 
 class _FavoriteStationListBody extends StatelessWidget {
@@ -3178,11 +3284,19 @@ class _FavoriteStationListBody extends StatelessWidget {
     required this.state,
     required this.onRetry,
     required this.onFavoriteTap,
+    required this.onFacilityStatusTap,
+    required this.onSetOrigin,
+    required this.onSetDestination,
+    required this.onRemove,
   });
 
   final FavoriteStationListState state;
   final VoidCallback onRetry;
   final ValueChanged<FavoriteStation> onFavoriteTap;
+  final ValueChanged<FavoriteStation> onFacilityStatusTap;
+  final ValueChanged<FavoriteStation> onSetOrigin;
+  final ValueChanged<FavoriteStation> onSetDestination;
+  final ValueChanged<FavoriteStation> onRemove;
 
   @override
   Widget build(BuildContext context) {
@@ -3223,7 +3337,12 @@ class _FavoriteStationListBody extends StatelessWidget {
           for (final favorite in state.favorites)
             _FavoriteStationTile(
               favorite: favorite,
-              onTap: () => onFavoriteTap(favorite),
+              isRemoving: state.removingIds.contains(favorite.stationId),
+              onOpenDetail: () => onFavoriteTap(favorite),
+              onOpenFacilityStatus: () => onFacilityStatusTap(favorite),
+              onSetOrigin: () => onSetOrigin(favorite),
+              onSetDestination: () => onSetDestination(favorite),
+              onRemove: () => onRemove(favorite),
             ),
         ],
       ),
@@ -3232,86 +3351,143 @@ class _FavoriteStationListBody extends StatelessWidget {
 }
 
 class _FavoriteStationTile extends StatelessWidget {
-  const _FavoriteStationTile({required this.favorite, required this.onTap});
+  const _FavoriteStationTile({
+    required this.favorite,
+    required this.isRemoving,
+    required this.onOpenDetail,
+    required this.onOpenFacilityStatus,
+    required this.onSetOrigin,
+    required this.onSetDestination,
+    required this.onRemove,
+  });
 
   final FavoriteStation favorite;
-  final VoidCallback onTap;
+  final bool isRemoving;
+  final VoidCallback onOpenDetail;
+  final VoidCallback onOpenFacilityStatus;
+  final VoidCallback onSetOrigin;
+  final VoidCallback onSetDestination;
+  final VoidCallback onRemove;
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
 
-    return MergeSemantics(
-      child: Semantics(
-        label: favorite.semanticLabel,
-        button: true,
-        onTap: onTap,
-        child: ExcludeSemantics(
-          child: Card(
-            margin: const EdgeInsets.only(bottom: 12),
-            color: Colors.white,
-            elevation: 0,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-              side: const BorderSide(color: Color(0xFFD5E2E4)),
-            ),
-            child: InkWell(
-              key: Key('favoriteStationTile-${favorite.stationId}'),
-              borderRadius: BorderRadius.circular(8),
-              onTap: onTap,
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      favorite.nameKo,
-                      style: textTheme.titleLarge?.copyWith(
-                        color: const Color(0xFF102A2C),
-                        fontWeight: FontWeight.w900,
-                        height: 1.25,
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      color: Colors.white,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: const BorderSide(color: Color(0xFFD5E2E4)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            MergeSemantics(
+              child: Semantics(
+                label: favorite.semanticLabel,
+                button: true,
+                onTap: onOpenDetail,
+                child: ExcludeSemantics(
+                  child: InkWell(
+                    key: Key('favoriteStationTile-${favorite.stationId}'),
+                    borderRadius: BorderRadius.circular(8),
+                    onTap: onOpenDetail,
+                    child: Padding(
+                      padding: const EdgeInsets.only(bottom: 12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            favorite.nameKo,
+                            style: textTheme.titleLarge?.copyWith(
+                              color: const Color(0xFF102A2C),
+                              fontWeight: FontWeight.w900,
+                              height: 1.25,
+                            ),
+                          ),
+                          const SizedBox(height: 10),
+                          StationLineBadges(lines: favorite.lines),
+                          const SizedBox(height: 8),
+                          Text(
+                            favorite.lineLabel,
+                            style: textTheme.bodyLarge?.copyWith(
+                              color: const Color(0xFF29484B),
+                              fontWeight: FontWeight.w800,
+                              height: 1.3,
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          Text(
+                            favorite.region,
+                            style: textTheme.bodyMedium?.copyWith(
+                              color: const Color(0xFF405A5D),
+                              height: 1.3,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            favorite.dataQualityLabel,
+                            style: textTheme.bodyMedium?.copyWith(
+                              color: const Color(0xFF405A5D),
+                              height: 1.3,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            favorite.dataSourceLabel,
+                            style: textTheme.bodyMedium?.copyWith(
+                              color: const Color(0xFF405A5D),
+                              height: 1.3,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                    const SizedBox(height: 10),
-                    StationLineBadges(lines: favorite.lines),
-                    const SizedBox(height: 8),
-                    Text(
-                      favorite.lineLabel,
-                      style: textTheme.bodyLarge?.copyWith(
-                        color: const Color(0xFF29484B),
-                        fontWeight: FontWeight.w800,
-                        height: 1.3,
-                      ),
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      favorite.region,
-                      style: textTheme.bodyMedium?.copyWith(
-                        color: const Color(0xFF405A5D),
-                        height: 1.3,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      favorite.dataQualityLabel,
-                      style: textTheme.bodyMedium?.copyWith(
-                        color: const Color(0xFF405A5D),
-                        height: 1.3,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      favorite.dataSourceLabel,
-                      style: textTheme.bodyMedium?.copyWith(
-                        color: const Color(0xFF405A5D),
-                        height: 1.3,
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
               ),
             ),
-          ),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                OutlinedButton.icon(
+                  onPressed: onSetOrigin,
+                  icon: const Icon(Icons.trip_origin),
+                  label: const Text('출발지로 설정'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: onSetDestination,
+                  icon: const Icon(Icons.flag_outlined),
+                  label: const Text('도착지로 설정'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: onOpenDetail,
+                  icon: const Icon(Icons.info_outline),
+                  label: const Text('역 상세 보기'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: onOpenFacilityStatus,
+                  icon: const Icon(Icons.elevator_outlined),
+                  label: const Text('시설 상태 확인'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: isRemoving ? null : onRemove,
+                  icon: isRemoving
+                      ? const SizedBox.square(
+                          dimension: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.bookmark_remove_outlined),
+                  label: Text(isRemoving ? '해제 중' : '즐겨찾기 해제'),
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -3221,8 +3221,12 @@ class _FavoriteStationListContentState
             onRetry: _controller.load,
             onFavoriteTap: _openStationDetail,
             onFacilityStatusTap: _openStationDetail,
-            onSetOrigin: _setRouteOrigin,
-            onSetDestination: _setRouteDestination,
+            onSetOrigin: widget.routeDraftController == null
+                ? null
+                : _setRouteOrigin,
+            onSetDestination: widget.routeDraftController == null
+                ? null
+                : _setRouteDestination,
             onRemove: _controller.remove,
           );
         },
@@ -3255,20 +3259,28 @@ class _FavoriteStationListContentState
   }
 
   void _setRouteOrigin(FavoriteStation favorite) {
+    final routeDraftController = widget.routeDraftController;
+    if (routeDraftController == null) {
+      return;
+    }
     final station = RouteDraftStation(
       id: favorite.stationId,
       nameKo: favorite.nameKo,
     );
-    widget.routeDraftController?.setOrigin(station);
+    routeDraftController.setOrigin(station);
     _showRouteDraftSnack('${station.displayName}을 출발역으로 설정했습니다');
   }
 
   void _setRouteDestination(FavoriteStation favorite) {
+    final routeDraftController = widget.routeDraftController;
+    if (routeDraftController == null) {
+      return;
+    }
     final station = RouteDraftStation(
       id: favorite.stationId,
       nameKo: favorite.nameKo,
     );
-    widget.routeDraftController?.setDestination(station);
+    routeDraftController.setDestination(station);
     _showRouteDraftSnack('${station.displayName}을 도착역으로 설정했습니다');
   }
 
@@ -3294,8 +3306,8 @@ class _FavoriteStationListBody extends StatelessWidget {
   final VoidCallback onRetry;
   final ValueChanged<FavoriteStation> onFavoriteTap;
   final ValueChanged<FavoriteStation> onFacilityStatusTap;
-  final ValueChanged<FavoriteStation> onSetOrigin;
-  final ValueChanged<FavoriteStation> onSetDestination;
+  final ValueChanged<FavoriteStation>? onSetOrigin;
+  final ValueChanged<FavoriteStation>? onSetDestination;
   final ValueChanged<FavoriteStation> onRemove;
 
   @override
@@ -3340,8 +3352,12 @@ class _FavoriteStationListBody extends StatelessWidget {
               isRemoving: state.removingIds.contains(favorite.stationId),
               onOpenDetail: () => onFavoriteTap(favorite),
               onOpenFacilityStatus: () => onFacilityStatusTap(favorite),
-              onSetOrigin: () => onSetOrigin(favorite),
-              onSetDestination: () => onSetDestination(favorite),
+              onSetOrigin: onSetOrigin == null
+                  ? null
+                  : () => onSetOrigin!(favorite),
+              onSetDestination: onSetDestination == null
+                  ? null
+                  : () => onSetDestination!(favorite),
               onRemove: () => onRemove(favorite),
             ),
         ],
@@ -3365,8 +3381,8 @@ class _FavoriteStationTile extends StatelessWidget {
   final bool isRemoving;
   final VoidCallback onOpenDetail;
   final VoidCallback onOpenFacilityStatus;
-  final VoidCallback onSetOrigin;
-  final VoidCallback onSetDestination;
+  final VoidCallback? onSetOrigin;
+  final VoidCallback? onSetDestination;
   final VoidCallback onRemove;
 
   @override
@@ -3455,16 +3471,18 @@ class _FavoriteStationTile extends StatelessWidget {
               spacing: 8,
               runSpacing: 8,
               children: [
-                OutlinedButton.icon(
-                  onPressed: onSetOrigin,
-                  icon: const Icon(Icons.trip_origin),
-                  label: const Text('출발지로 설정'),
-                ),
-                OutlinedButton.icon(
-                  onPressed: onSetDestination,
-                  icon: const Icon(Icons.flag_outlined),
-                  label: const Text('도착지로 설정'),
-                ),
+                if (onSetOrigin != null)
+                  OutlinedButton.icon(
+                    onPressed: onSetOrigin,
+                    icon: const Icon(Icons.trip_origin),
+                    label: const Text('출발지로 설정'),
+                  ),
+                if (onSetDestination != null)
+                  OutlinedButton.icon(
+                    onPressed: onSetDestination,
+                    icon: const Icon(Icons.flag_outlined),
+                    label: const Text('도착지로 설정'),
+                  ),
                 OutlinedButton.icon(
                   onPressed: onOpenDetail,
                   icon: const Icon(Icons.info_outline),

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -231,7 +231,7 @@ void main() {
     expect(result.summaryTitle, '상록수에서 사당까지');
     expect(result.lineName, '수도권 4호선');
     expect(result.statusLabel, '경로를 찾았습니다');
-    expect(result.scoreLabel, '이동 점수 92점');
+    expect(result.scoreLabel, '이동 편의도 92점');
     expect(result.recommendationReasons, [
       '엘리베이터 동선을 우선했어요',
       '계단 없는 출구를 확인했어요',
@@ -481,7 +481,7 @@ void main() {
     expect(favorites.single.summaryTitle, '상록수에서 사당까지');
     expect(saved.favoriteRouteId, 'route-1');
     expect(saved.mobilityLabel, '천천히 이동');
-    expect(saved.scoreLabel, '이동 점수 92점');
+    expect(saved.scoreLabel, '이동 편의도 92점');
   });
 
   test('경로 피드백 API 저장소는 익명 사용자 식별자와 평가를 전송한다', () async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2344,6 +2344,33 @@ void main() {
     }
   });
 
+  testWidgets('즐겨찾기 역 목록은 경로 draft controller가 없으면 경로 설정 버튼을 숨긴다', (
+    tester,
+  ) async {
+    final favoriteRepository = FakeFavoriteStationRepository(
+      favorites: [_favoriteStation(id: 'station-sangnoksu', name: '상록수')],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: FavoriteStationListContent(
+            repository: favoriteRepository,
+            stationRepository: FakeStationSearchRepository(),
+            reportRepository: FakeFacilityReportRepository(),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('상록수'), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, '출발지로 설정'), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, '도착지로 설정'), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, '역 상세 보기'), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, '시설 상태 확인'), findsOneWidget);
+  });
+
   testWidgets('홈 즐겨찾기 시설은 저장한 시설을 큰 목록으로 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final favoriteFacilityRepository = FakeFavoriteFacilityRepository(
@@ -2403,6 +2430,40 @@ void main() {
     }
   });
 
+  testWidgets('홈 즐겨찾기 시설 제보는 위치 권한 확인 흐름을 유지한다', (tester) async {
+    final favoriteFacilityRepository = FakeFavoriteFacilityRepository(
+      favorites: [_favoriteFacility()],
+    );
+    final locationProvider = FakeCurrentLocationProvider(
+      needsPermissionRequest: true,
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: favoriteFacilityRepository,
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        locationProvider: locationProvider,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await _openFavoriteList(
+      tester,
+      tabKey: const Key('favoriteFacilitiesTabButton'),
+    );
+    await tester.tap(find.widgetWithText(OutlinedButton, '상태 제보'));
+    await tester.pumpAndSettle();
+
+    expect(locationProvider.permissionCheckCount, 1);
+    expect(locationProvider.requestCount, 0);
+    expect(find.text('현재 위치 사용'), findsOneWidget);
+    expect(find.text('가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다.'), findsOneWidget);
+  });
+
   testWidgets('홈 즐겨찾기 경로는 저장한 경로를 큰 목록으로 보여주고 삭제한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final favoriteRouteRepository = FakeFavoriteRouteRepository(
@@ -2443,6 +2504,14 @@ void main() {
         findsOneWidget,
       );
       expect(find.bySemanticsLabel('상록수에서 사당까지 더 보기'), findsOneWidget);
+      expect(
+        tester.getSemantics(find.bySemanticsLabel('상록수에서 사당까지 더 보기')),
+        isSemantics(
+          label: '상록수에서 사당까지 더 보기',
+          isButton: true,
+          hasTapAction: true,
+        ),
+      );
 
       await tester.tap(find.byKey(const Key('favoriteRouteMore-route-1')));
       await tester.pumpAndSettle();

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -7,6 +7,7 @@ import 'package:easysubway_mobile/accessible_design.dart';
 import 'package:easysubway_mobile/main.dart';
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/favorite_facility.dart';
+import 'package:easysubway_mobile/features/route_draft/application/route_draft_controller.dart';
 import 'package:easysubway_mobile/features/route_draft/domain/route_draft.dart';
 import 'package:easysubway_mobile/internal_route.dart';
 import 'package:easysubway_mobile/legacy_credential_cleanup.dart';
@@ -63,6 +64,7 @@ Future<void> _openFavoriteList(WidgetTester tester, {Key? tabKey}) async {
           locationProvider: home.locationProvider,
           facilityReportDraftTargetStore: home.facilityReportDraftTargetStore,
           internalRouteRepository: home.internalRouteRepository,
+          routeDraftController: RouteDraftController(),
           initialMobilityType: home.initialMobilityType,
         ),
       ),
@@ -2314,6 +2316,11 @@ void main() {
       expect(find.text('상록수'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
       expect(find.text('기본 정보만 있음'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '출발지로 설정'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '도착지로 설정'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '역 상세 보기'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '시설 상태 확인'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '즐겨찾기 해제'), findsOneWidget);
       expect(
         find.byKey(const Key('favoriteStationTile-station-sangnoksu')),
         findsOneWidget,
@@ -2367,6 +2374,7 @@ void main() {
       expect(find.text('정상'), findsOneWidget);
       expect(find.text('정보 신뢰도 높음'), findsOneWidget);
       expect(find.text('출처 공식 파일'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '상태 제보'), findsOneWidget);
       expect(
         find.byKey(
           const Key('favoriteFacilityTile-facility-sangnoksu-elevator-1'),
@@ -2421,16 +2429,29 @@ void main() {
       expect(find.text('상록수에서 사당까지'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
       expect(find.text('천천히 이동'), findsOneWidget);
-      expect(find.text('이동 점수 92점'), findsOneWidget);
+      expect(find.text('이동 편의도 92점'), findsOneWidget);
+      expect(
+        find.text('기준: 천천히 이동, 수도권 4호선, 최근 확인 2026-06-13'),
+        findsOneWidget,
+      );
+      expect(find.text('예상 시간 확인 필요 · 환승 확인 필요 · 도보 확인 필요'), findsOneWidget);
+      expect(find.text('계단 정보 확인 필요 · 엘리베이터 연결 확인 필요'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
-          '즐겨찾기 경로, 상록수에서 사당까지, 수도권 4호선, 천천히 이동, 이동 점수 92점',
+          '즐겨찾기 경로, 상록수에서 사당까지, 수도권 4호선, 천천히 이동, 이동 편의도 92점, 기준 천천히 이동, 수도권 4호선, 최근 확인 2026-06-13, 예상 시간 확인 필요, 환승 확인 필요, 도보 확인 필요, 계단 정보 확인 필요, 엘리베이터 연결 확인 필요',
         ),
         findsOneWidget,
       );
-      expect(find.bySemanticsLabel('상록수에서 사당까지 삭제'), findsOneWidget);
+      expect(find.bySemanticsLabel('상록수에서 사당까지 더 보기'), findsOneWidget);
 
+      await tester.tap(find.byKey(const Key('favoriteRouteMore-route-1')));
+      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('favoriteRouteRemove-route-1')));
+      await tester.pumpAndSettle();
+      expect(find.text('즐겨찾기 경로 삭제'), findsOneWidget);
+      await tester.tap(
+        find.byKey(const Key('favoriteRouteRemoveConfirm-route-1')),
+      );
       await tester.pumpAndSettle();
 
       expect(favoriteRouteRepository.removedFavoriteRouteIds, ['route-1']);
@@ -2472,15 +2493,20 @@ void main() {
 
     await _openFavoriteList(tester);
 
-    final removeButton = find.byKey(const Key('favoriteRouteRemove-route-1'));
-    await tester.tap(removeButton);
+    await tester.tap(find.byKey(const Key('favoriteRouteMore-route-1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('favoriteRouteRemove-route-1')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('favoriteRouteRemoveConfirm-route-1')),
+    );
     await tester.pump();
 
     expect(favoriteRouteRepository.removedFavoriteRouteIds, ['route-1']);
     expect(find.text('삭제 중'), findsOneWidget);
-    expect(find.bySemanticsLabel('상록수에서 사당까지 삭제 중'), findsOneWidget);
+    expect(find.bySemanticsLabel('상록수에서 사당까지 더 보기, 삭제 중'), findsOneWidget);
 
-    await tester.tap(removeButton);
+    await tester.tap(find.byKey(const Key('favoriteRouteMore-route-1')));
     await tester.pump();
 
     expect(favoriteRouteRepository.removedFavoriteRouteIds, ['route-1']);


### PR DESCRIPTION
## 관련 이슈

close #792

## 작업 배경

- 즐겨찾기 홈이 2열 카드형 진입점에 머물러 역·시설·경로에서 바로 해야 할 다음 행동을 충분히 드러내지 못했다.
- 저장한 경로는 `이동 점수`만 보여 점수 의미와 확인 필요 항목을 알기 어려웠고, 삭제가 큰 보조 버튼으로 노출되어 실수 삭제 위험이 있었다.

## 작업 내용

- 즐겨찾기 홈의 역·시설·경로 진입점을 세로 목록형 카드로 바꾸고 각 항목의 다음 행동 설명을 추가했다.
- 즐겨찾기 역 목록에 출발지 설정, 도착지 설정, 역 상세 보기, 시설 상태 확인, 즐겨찾기 해제 버튼을 추가했다.
- 즐겨찾기 시설 목록에 상태 제보 버튼을 추가하고 기존 상태·위치·최근 확인·출처 정보와 분리된 접근성 버튼으로 노출했다.
- 즐겨찾기 경로의 `이동 점수` 문구를 `이동 편의도`로 바꾸고 점수 기준, 예상 시간·환승·도보·계단·엘리베이터 확인 필요 정보를 함께 표시했다.
- 즐겨찾기 경로 삭제를 더보기 메뉴와 확인 다이얼로그 흐름으로 옮겼다.

## 검증

- 실행한 명령과 결과:
- `cd apps/mobile && flutter test test/widget_test.dart --plain-name '즐겨찾기'`: exit 0, 15 tests passed
- `cd apps/mobile && flutter test test/widget_test.dart test/favorite_facility_test.dart test/station_search_test.dart test/route_search_test.dart`: exit 0, 179 tests passed
- `cd apps/mobile && flutter analyze`: exit 0, No issues found
- `cd apps/mobile && flutter run -d emulator-5554 --dart-define=EASYSUBWAY_DEMO_HOME_DATA=true`: Android emulator debug build/install/launch 성공
- `XcodeBuildMCP build_run_sim` with `DART_DEFINES=RUFTWVNVQldBWV9ERU1PX0hPTUVfREFUQT10cnVl`: iOS Simulator build/install/launch 성공
- PR CI: `CI` run 28131898835 pass, `Release Artifacts` run 28131898570 pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 즐겨찾기 홈 목록형 진입점 | Android emulator | screenshot + UI tree | `.codex/evidence/792/01-favorites-home.png`, `.codex/evidence/792/01-favorites-home-ui.xml` | 역·시설·경로가 세로 목록으로 보이고 각 항목이 다음 행동 설명을 읽는다. |
| 즐겨찾기 역 행동 | Android emulator | screenshot + UI tree | `.codex/evidence/792/02-favorite-station-actions.png`, `.codex/evidence/792/02-favorite-station-actions-ui.xml` | 출발지 설정, 도착지 설정, 역 상세 보기, 시설 상태 확인, 즐겨찾기 해제가 버튼으로 노출된다. |
| 즐겨찾기 시설 상태 제보 | Android emulator | screenshot + UI tree | `.codex/evidence/792/03-favorite-facility-action.png`, `.codex/evidence/792/03-favorite-facility-action-ui.xml` | 시설 상태·최근 확인·출처 정보와 독립 `상태 제보` 버튼이 확인된다. |
| 즐겨찾기 경로 상세 정보 | Android emulator | screenshot + UI tree | `.codex/evidence/792/04-favorite-route-detail.png`, `.codex/evidence/792/04-favorite-route-detail-ui.xml` | `이동 편의도`, 기준, 예상 시간·환승·도보·계단·엘리베이터 확인 필요 항목이 읽힌다. |
| 즐겨찾기 경로 삭제 흐름 | Android emulator | screenshot + UI tree | `.codex/evidence/792/05-favorite-route-menu.png`, `.codex/evidence/792/06-favorite-route-delete-dialog.png`, paired `*-ui.xml` | 삭제가 더보기 메뉴 안에 있고, 확인 다이얼로그에서만 최종 삭제할 수 있다. |
| 즐겨찾기 홈/역/시설/경로 | iOS Simulator | XcodeBuildMCP runtime snapshot + screenshot | `.codex/evidence/792/ios-01-favorites-home.jpg`, `ios-02-favorite-station-actions.jpg`, `ios-03-favorite-facility-action.jpg`, `ios-04-favorite-route-detail.jpg` | iOS에서도 목록형 홈, 역 행동 버튼, 시설 상태 제보, 경로 편의도 정보가 확인된다. |

로컬 전용 증거 사유: 스크린샷과 UI tree는 PR 검증용 로컬 캡처이며, 외부 업로드에 대한 QA 승인이 아직 없어 git에는 커밋하지 않고 `.codex/evidence/792/`에 보관했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `FavoriteStationListContent`에서 홈의 `RouteDraftController`를 받아 즐겨찾기 역의 출발/도착 설정을 실제 경로 초안에 반영하는 부분.
- 경로 삭제는 `PopupMenuButton`과 확인 다이얼로그로 이동했으므로 기존 삭제 버튼을 찾던 테스트 기대값을 함께 갱신했다.
- CodeRabbit은 review limit과 prepaid credit exhausted로 실제 리뷰가 시작되지 않아 Codex CLI fallback review를 PR review로 남겼다. 최초 review actionable 3건은 `2115e9c9`에서 수정하고 원래 inline thread에 해결 답글 후 resolved 처리했으며, re-review는 actionable 0건이었다.

## 리스크

- 즐겨찾기 역 타일의 행동 버튼 수가 늘어 화면 높이가 커졌다. Android/iOS 캡처와 tap target 테스트로 접근 가능성은 확인했다.
- 경로 API가 아직 예상 시간·환승·도보·계단·엘리베이터 값을 즐겨찾기 응답에 주지 않아 해당 항목은 `확인 필요`로 명시했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
