### PR TITLE
[Fix] 최근 검색과 도움말·개인정보 안내 구조 정리

### DIFF
--- a/apps/mobile/lib/features/search_history/data/drift_search_history_repository.dart
+++ b/apps/mobile/lib/features/search_history/data/drift_search_history_repository.dart
@@ -63,4 +63,21 @@ class DriftSearchHistoryRepository implements SearchHistoryRepository {
         .get();
     return rows.map((row) => row.read<String>('query')).toList(growable: false);
   }
+
+  @override
+  Future<void> removeSearch(String query) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) {
+      return;
+    }
+    await userDatabase.customStatement(
+      'DELETE FROM search_history WHERE query = ?',
+      [trimmed],
+    );
+  }
+
+  @override
+  Future<void> clearSearches() async {
+    await userDatabase.delete(userDatabase.searchHistory).go();
+  }
 }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -195,6 +195,16 @@ class _DemoSearchHistoryRepository implements SearchHistoryRepository {
   Future<List<String>> listRecentQueries() async {
     return List.unmodifiable(_queries);
   }
+
+  @override
+  Future<void> removeSearch(String query) async {
+    _queries.remove(query.trim());
+  }
+
+  @override
+  Future<void> clearSearches() async {
+    _queries.clear();
+  }
 }
 
 class EasySubwayApp extends StatelessWidget {
@@ -3653,9 +3663,8 @@ class SupportAccessScreen extends StatelessWidget {
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
           children: [
+            const _SupportSectionTitle(title: '개인정보 및 데이터'),
             const _PrivacyDataUseSummary(),
-            const SizedBox(height: 12),
-            const _SafetyDataNotice(),
             const SizedBox(height: 12),
             _SupportAccessItem(
               key: const Key('privacyPolicyAccessItem'),
@@ -3666,6 +3675,29 @@ class SupportAccessScreen extends StatelessWidget {
               launcher: launcher,
             ),
             const SizedBox(height: 12),
+            if (userDataDeletionRepository == null)
+              _SupportAccessItem(
+                key: const Key('dataDeletionAccessItem'),
+                icon: Icons.delete_outline,
+                title: '데이터 삭제 요청',
+                value: accessInfo.dataDeletionEmail,
+                helperText: '삭제 범위와 복구 불가 여부를 먼저 확인해요',
+                uri: _mailtoUri(
+                  accessInfo.dataDeletionEmail,
+                  '쉬운 지하철 데이터 삭제 요청',
+                ),
+                launcher: launcher,
+              )
+            else
+              _UserDataDeletionAccessItem(
+                repository: userDataDeletionRepository!,
+                onDeleted: onUserDataDeleted,
+              ),
+            const SizedBox(height: 20),
+            const _SupportSectionTitle(title: '안전 안내'),
+            const _SafetyDataNotice(),
+            const SizedBox(height: 20),
+            const _SupportSectionTitle(title: '문의'),
             _SupportAccessItem(
               key: const Key('supportAccessItem'),
               icon: Icons.support_agent,
@@ -3685,25 +3717,31 @@ class SupportAccessScreen extends StatelessWidget {
               uri: _mailtoUri(accessInfo.securityEmail, '쉬운 지하철 보안 문의'),
               launcher: launcher,
             ),
-            const SizedBox(height: 12),
-            if (userDataDeletionRepository == null)
-              _SupportAccessItem(
-                key: const Key('dataDeletionAccessItem'),
-                icon: Icons.delete_outline,
-                title: '데이터 삭제 요청',
-                value: accessInfo.dataDeletionEmail,
-                uri: _mailtoUri(
-                  accessInfo.dataDeletionEmail,
-                  '쉬운 지하철 데이터 삭제 요청',
-                ),
-                launcher: launcher,
-              )
-            else
-              _UserDataDeletionAccessItem(
-                repository: userDataDeletionRepository!,
-                onDeleted: onUserDataDeleted,
-              ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SupportSectionTitle extends StatelessWidget {
+  const _SupportSectionTitle({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Semantics(
+        header: true,
+        child: Text(
+          title,
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+            color: EasySubwayAccessibleColors.text,
+            fontWeight: FontWeight.w900,
+            height: 1.25,
+          ),
         ),
       ),
     );
@@ -3735,7 +3773,7 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
     return Semantics(
       key: const Key('dataDeletionAccessItem'),
       button: true,
-      label: '데이터 삭제 요청, 앱 안에서 삭제를 진행합니다.',
+      label: '데이터 삭제 요청, 삭제 범위와 복구 불가 여부를 확인하고 앱 안에서 삭제를 진행합니다.',
       onTap: openDeletionScreen,
       child: ExcludeSemantics(
         child: Material(
@@ -3774,7 +3812,7 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
                         ),
                         SizedBox(height: 4),
                         Text(
-                          '앱 안에서 삭제 대상을 확인하고 직접 요청합니다.',
+                          '삭제 범위와 복구 불가 여부를 확인하고 진행합니다.',
                           style: TextStyle(
                             color: Color(0xFF466467),
                             fontSize: 15,
@@ -3864,6 +3902,7 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
             const _DataDeletionNoticeLine(
               text: '삭제가 끝나면 현재 로그인 정보는 지워지고 처음 설정 화면으로 돌아갑니다.',
             ),
+            const _DataDeletionNoticeLine(text: '삭제한 데이터는 앱에서 복구할 수 없습니다.'),
             const _DataDeletionNoticeLine(
               text: '네트워크 오류가 나면 기존 데이터는 지우지 않고 다시 시도할 수 있습니다.',
             ),
@@ -4206,7 +4245,7 @@ class _SecurityContactNoticeLine extends StatelessWidget {
 class _SafetyDataNotice extends StatelessWidget {
   const _SafetyDataNotice();
 
-  static const _title = '안전과 데이터 안내';
+  static const _title = '안전 안내';
   static const _referenceNotice = '경로와 시설 정보는 이동을 돕는 참고 정보입니다.';
   static const _fieldNotice = '실제 이동 전에는 현장 안내, 역무원 안내, 운영기관 공지를 먼저 확인해 주세요.';
   static const _limitationNotice = '실시간 상태나 무조건 안전한 경로를 보장하지 않습니다.';
@@ -4387,6 +4426,7 @@ class _SupportAccessItem extends StatelessWidget {
     required this.value,
     required this.uri,
     required this.launcher,
+    this.helperText,
     super.key,
   });
 
@@ -4395,15 +4435,23 @@ class _SupportAccessItem extends StatelessWidget {
   final String value;
   final Uri? uri;
   final SupportAccessLauncher launcher;
+  final String? helperText;
 
   @override
   Widget build(BuildContext context) {
-    final displayValue = value.trim().isEmpty ? '준비 중입니다.' : value.trim();
     final targetUri = uri;
+    final displayValue = targetUri == null
+        ? '현재 이용할 수 없음 · 준비 중'
+        : value.trim();
+    final secondaryText = helperText;
+    final semanticLabelParts = [title, displayValue];
+    if (secondaryText != null) {
+      semanticLabelParts.add(secondaryText);
+    }
     return Semantics(
       button: true,
       enabled: targetUri != null,
-      label: '$title, $displayValue',
+      label: semanticLabelParts.join(', '),
       onTap: targetUri == null
           ? null
           : () => unawaited(_openTarget(context, targetUri)),
@@ -4430,6 +4478,17 @@ class _SupportAccessItem extends StatelessWidget {
                       height: 1.25,
                     ),
                   ),
+                  if (secondaryText != null) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      secondaryText,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: const Color(0xFF466467),
+                        fontWeight: FontWeight.w700,
+                        height: 1.25,
+                      ),
+                    ),
+                  ],
                 ],
               ),
             ),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2258,6 +2258,7 @@ class _StationRecentSearchSection extends StatelessWidget {
           children: [
             Expanded(
               child: Semantics(
+                excludeSemantics: true,
                 label: '최근 사용 순서로 ${queries.length}개 표시',
                 child: Text(
                   '최근 사용 순서 · ${queries.length}개',

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -39,6 +39,7 @@ const _stationSafetyGuidanceNotice = '이동 전 현장 안내와 역무원 안�
 const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했습니다.';
 const _favoriteStationStatusErrorMessage = '즐겨찾기를 확인하지 못했습니다.';
 const _favoriteStationChangeErrorMessage = '즐겨찾기를 바꾸지 못했습니다.';
+const _searchHistoryChangeErrorMessage = '최근 검색을 지우지 못했습니다.';
 
 abstract class StationSearchRepository {
   Future<List<StationSearchResult>> searchStations(String query);
@@ -60,6 +61,10 @@ abstract class SearchHistoryRepository {
   Future<void> recordSearch(String query);
 
   Future<List<String>> listRecentQueries();
+
+  Future<void> removeSearch(String query);
+
+  Future<void> clearSearches();
 }
 
 abstract class StationLineFilterRepository {
@@ -1858,17 +1863,28 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
               builder: (context, _) {
                 final isSearching =
                     _controller.state.status == StationSearchStatus.loading;
-                if (isNearbyEntry ||
-                    _hasSearchQuery ||
-                    _recentQueries.isEmpty) {
+                if (isNearbyEntry || _hasSearchQuery) {
                   return const SizedBox.shrink();
+                }
+                if (_recentQueries.isEmpty) {
+                  return isRecentEntry
+                      ? Padding(
+                          padding: const EdgeInsets.only(bottom: 12),
+                          child: _StationRecentSearchEmptyState(
+                            onSearchTap: _openStationSearch,
+                          ),
+                        )
+                      : const SizedBox.shrink();
                 }
                 return Padding(
                   padding: const EdgeInsets.only(bottom: 12),
                   child: _StationRecentSearchSection(
                     queries: _recentQueries,
+                    showTitle: !isRecentEntry,
                     enabled: !isSearching && !_isNearbySearchRunning,
                     onQuerySelected: _searchRecentQuery,
+                    onQueryRemoved: _removeRecentQuery,
+                    onClearAll: _clearRecentQueries,
                   ),
                 );
               },
@@ -1986,6 +2002,64 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
       selection: TextSelection.collapsed(offset: query.length),
     );
     _submit(query);
+  }
+
+  void _openStationSearch() {
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute<void>(
+        builder: (_) => StationSearchScreen(
+          repository: widget.repository,
+          locationProvider: widget.locationProvider,
+          reportRepository: widget.reportRepository,
+          favoriteRepository: widget.favoriteRepository,
+          searchHistoryRepository: widget.searchHistoryRepository,
+          routeDraftController: widget.routeDraftController,
+          facilityReportDraftTargetStore: widget.facilityReportDraftTargetStore,
+          internalRouteRepository: widget.internalRouteRepository,
+          internalRouteMobilityType: widget.internalRouteMobilityType,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _removeRecentQuery(String query) async {
+    final repository = widget.searchHistoryRepository;
+    if (repository == null) {
+      return;
+    }
+    try {
+      await repository.removeSearch(query);
+      await _loadRecentQueries();
+    } catch (error, stackTrace) {
+      reportMobileError(error, stackTrace, context: '최근 검색어 삭제 중 예외가 발생했습니다.');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text(_searchHistoryChangeErrorMessage)),
+        );
+      }
+    }
+  }
+
+  Future<void> _clearRecentQueries() async {
+    final repository = widget.searchHistoryRepository;
+    if (repository == null) {
+      return;
+    }
+    try {
+      await repository.clearSearches();
+      await _loadRecentQueries();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '최근 검색어 전체 삭제 중 예외가 발생했습니다.',
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text(_searchHistoryChangeErrorMessage)),
+        );
+      }
+    }
   }
 
   Future<void> _loadRecentQueries() async {
@@ -2149,13 +2223,19 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
 class _StationRecentSearchSection extends StatelessWidget {
   const _StationRecentSearchSection({
     required this.queries,
+    required this.showTitle,
     required this.enabled,
     required this.onQuerySelected,
+    required this.onQueryRemoved,
+    required this.onClearAll,
   });
 
   final List<String> queries;
+  final bool showTitle;
   final bool enabled;
   final ValueChanged<String> onQuerySelected;
+  final ValueChanged<String> onQueryRemoved;
+  final VoidCallback onClearAll;
 
   @override
   Widget build(BuildContext context) {
@@ -2163,48 +2243,181 @@ class _StationRecentSearchSection extends StatelessWidget {
       key: const Key('stationRecentSearchSection'),
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          '최근 검색',
-          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-            color: EasySubwayAccessibleColors.text,
-            fontWeight: FontWeight.w900,
-            height: 1.25,
+        if (showTitle) ...[
+          Text(
+            '최근 검색',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              color: EasySubwayAccessibleColors.text,
+              fontWeight: FontWeight.w900,
+              height: 1.25,
+            ),
           ),
-        ),
-        const SizedBox(height: 10),
-        Wrap(
-          spacing: 10,
-          runSpacing: 10,
+          const SizedBox(height: 8),
+        ],
+        Row(
           children: [
-            for (final query in queries)
-              Semantics(
-                label: '최근 검색어 $query 검색',
-                button: true,
+            Expanded(
+              child: Semantics(
+                label: '최근 사용 순서로 ${queries.length}개 표시',
+                child: Text(
+                  '최근 사용 순서 · ${queries.length}개',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: EasySubwayAccessibleColors.mutedText,
+                    fontWeight: FontWeight.w700,
+                    height: 1.3,
+                  ),
+                ),
+              ),
+            ),
+            TextButton.icon(
+              key: const Key('stationRecentSearchClearAllButton'),
+              onPressed: enabled ? onClearAll : null,
+              icon: const Icon(Icons.delete_sweep_outlined),
+              label: const Text('전체 삭제'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Column(
+          children: [
+            for (final entry in queries.indexed)
+              _StationRecentSearchItem(
+                query: entry.$2,
+                order: entry.$1 + 1,
                 enabled: enabled,
-                onTap: enabled ? () => onQuerySelected(query) : null,
-                child: ExcludeSemantics(
-                  child: OutlinedButton.icon(
-                    key: Key('stationRecentSearchQuery-$query'),
-                    onPressed: enabled ? () => onQuerySelected(query) : null,
-                    icon: const Icon(Icons.history),
-                    label: Text(query),
-                    style: OutlinedButton.styleFrom(
-                      minimumSize: const Size(
-                        EasySubwayTouchTarget.general,
-                        EasySubwayTouchTarget.general,
-                      ),
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 14,
-                        vertical: 12,
-                      ),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
+                onQuerySelected: onQuerySelected,
+                onQueryRemoved: onQueryRemoved,
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _StationRecentSearchItem extends StatelessWidget {
+  const _StationRecentSearchItem({
+    required this.query,
+    required this.order,
+    required this.enabled,
+    required this.onQuerySelected,
+    required this.onQueryRemoved,
+  });
+
+  final String query;
+  final int order;
+  final bool enabled;
+  final ValueChanged<String> onQuerySelected;
+  final ValueChanged<String> onQueryRemoved;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Material(
+        color: Colors.white,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+          side: const BorderSide(color: EasySubwayAccessibleColors.line),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          child: Row(
+            children: [
+              Expanded(
+                child: Semantics(
+                  label: '최근 검색어 $query 검색, 최근 사용 $order번째',
+                  button: true,
+                  enabled: enabled,
+                  onTap: enabled ? () => onQuerySelected(query) : null,
+                  child: ExcludeSemantics(
+                    child: InkWell(
+                      key: Key('stationRecentSearchQuery-$query'),
+                      borderRadius: BorderRadius.circular(8),
+                      onTap: enabled ? () => onQuerySelected(query) : null,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 6),
+                        child: Row(
+                          children: [
+                            const Icon(
+                              Icons.history,
+                              color: EasySubwayAccessibleColors.brand,
+                            ),
+                            const SizedBox(width: 10),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    query,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .titleMedium
+                                        ?.copyWith(
+                                          color:
+                                              EasySubwayAccessibleColors.text,
+                                          fontWeight: FontWeight.w800,
+                                          height: 1.25,
+                                        ),
+                                  ),
+                                  const SizedBox(height: 3),
+                                  Text(
+                                    '최근 사용 $order번째',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .bodyMedium
+                                        ?.copyWith(
+                                          color: EasySubwayAccessibleColors
+                                              .mutedText,
+                                          fontWeight: FontWeight.w700,
+                                          height: 1.3,
+                                        ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   ),
                 ),
               ),
-          ],
+              IconButton(
+                key: Key('stationRecentSearchRemove-$query'),
+                tooltip: '$query 최근 검색 삭제',
+                onPressed: enabled ? () => onQueryRemoved(query) : null,
+                icon: const Icon(Icons.close),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StationRecentSearchEmptyState extends StatelessWidget {
+  const _StationRecentSearchEmptyState({required this.onSearchTap});
+
+  final VoidCallback onSearchTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      key: const Key('stationRecentSearchEmptyState'),
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const _StationSearchMessage(
+          message: '최근 검색한 역이 없습니다.',
+          liveRegion: false,
+        ),
+        const SizedBox(height: 12),
+        FilledButton.icon(
+          key: const Key('stationRecentSearchEmptySearchButton'),
+          onPressed: onSearchTap,
+          icon: const Icon(Icons.search),
+          label: const Text('역 검색하기'),
         ),
       ],
     );

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -1587,6 +1587,16 @@ class FakeSearchHistoryRepository implements SearchHistoryRepository {
   Future<List<String>> listRecentQueries() async {
     return recordedQueries.reversed.toList(growable: false);
   }
+
+  @override
+  Future<void> removeSearch(String query) async {
+    recordedQueries.remove(query.trim());
+  }
+
+  @override
+  Future<void> clearSearches() async {
+    recordedQueries.clear();
+  }
 }
 
 class ControlledNearbyStationSearchRepository

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1605,6 +1605,47 @@ void main() {
       expect(find.text('도움말·문의'), findsOneWidget);
       expect(find.text('개인정보처리방침'), findsOneWidget);
       expect(find.text('https://easysubway.example/privacy'), findsOneWidget);
+      final privacyButtonSize = tester.getSize(
+        find.byKey(const Key('privacyPolicyAccessItem')),
+      );
+      expect(privacyButtonSize.height, greaterThanOrEqualTo(60));
+      final privacySemantics = tester
+          .getSemantics(find.byKey(const Key('privacyPolicyAccessItem')))
+          .getSemanticsData();
+      expect(
+        privacySemantics.label,
+        '개인정보처리방침, https://easysubway.example/privacy',
+      );
+      expect(privacySemantics.hasAction(SemanticsAction.tap), isTrue);
+
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('dataDeletionAccessItem')),
+        120,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('데이터 삭제 요청'), findsOneWidget);
+
+      final deletionButtonSize = tester.getSize(
+        find.byKey(const Key('dataDeletionAccessItem')),
+      );
+
+      expect(deletionButtonSize.height, greaterThanOrEqualTo(60));
+      final deletionSemantics = tester
+          .getSemantics(find.byKey(const Key('dataDeletionAccessItem')))
+          .getSemanticsData();
+      expect(
+        deletionSemantics.label,
+        '데이터 삭제 요청, privacy@easysubway.example, 삭제 범위와 복구 불가 여부를 먼저 확인해요',
+      );
+      expect(deletionSemantics.hasAction(SemanticsAction.tap), isTrue);
+
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('supportAccessItem')),
+        120,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.pumpAndSettle();
       expect(find.text('고객지원'), findsOneWidget);
       expect(find.text('support@easysubway.example'), findsOneWidget);
       await tester.scrollUntilVisible(
@@ -1614,37 +1655,7 @@ void main() {
       );
       await tester.pumpAndSettle();
       expect(find.text('보안 문의'), findsOneWidget);
-      expect(find.text('준비 중입니다.'), findsOneWidget);
-      await tester.scrollUntilVisible(
-        find.byKey(const Key('dataDeletionAccessItem')),
-        120,
-        scrollable: find.byType(Scrollable).last,
-      );
-      await tester.pumpAndSettle();
-      expect(find.text('데이터 삭제 요청'), findsOneWidget);
-
-      final privacyButtonSize = tester.getSize(
-        find.byKey(const Key('privacyPolicyAccessItem')),
-      );
-      final deletionButtonSize = tester.getSize(
-        find.byKey(const Key('dataDeletionAccessItem')),
-      );
-
-      expect(privacyButtonSize.height, greaterThanOrEqualTo(60));
-      expect(deletionButtonSize.height, greaterThanOrEqualTo(60));
-      final privacySemantics = tester
-          .getSemantics(find.byKey(const Key('privacyPolicyAccessItem')))
-          .getSemanticsData();
-      expect(
-        privacySemantics.label,
-        '개인정보처리방침, https://easysubway.example/privacy',
-      );
-      expect(privacySemantics.hasAction(SemanticsAction.tap), isTrue);
-      final deletionSemantics = tester
-          .getSemantics(find.byKey(const Key('dataDeletionAccessItem')))
-          .getSemanticsData();
-      expect(deletionSemantics.label, '데이터 삭제 요청, privacy@easysubway.example');
-      expect(deletionSemantics.hasAction(SemanticsAction.tap), isTrue);
+      expect(find.text('현재 이용할 수 없음 · 준비 중'), findsOneWidget);
     } finally {
       semanticsHandle.dispose();
     }
@@ -1726,7 +1737,7 @@ void main() {
 
       await _openSupportAccessScreen(tester);
 
-      expect(find.text('안전과 데이터 안내'), findsOneWidget);
+      expect(find.text('안전 안내'), findsWidgets);
       expect(find.text('경로와 시설 정보는 이동을 돕는 참고 정보입니다.'), findsOneWidget);
       expect(
         find.text('실제 이동 전에는 현장 안내, 역무원 안내, 운영기관 공지를 먼저 확인해 주세요.'),
@@ -1744,7 +1755,7 @@ void main() {
           .getSemanticsData();
       expect(
         noticeSemantics.label,
-        '안전과 데이터 안내, 경로와 시설 정보는 이동을 돕는 참고 정보입니다. 실제 이동 전에는 현장 안내, 역무원 안내, 운영기관 공지를 먼저 확인해 주세요. 실시간 상태나 무조건 안전한 경로를 보장하지 않습니다.',
+        '안전 안내, 경로와 시설 정보는 이동을 돕는 참고 정보입니다. 실제 이동 전에는 현장 안내, 역무원 안내, 운영기관 공지를 먼저 확인해 주세요. 실시간 상태나 무조건 안전한 경로를 보장하지 않습니다.',
       );
     } finally {
       semanticsHandle.dispose();
@@ -1922,6 +1933,7 @@ void main() {
 
     expect(find.byKey(const Key('dataDeletionStartButton')), findsOneWidget);
     expect(find.textContaining('즐겨찾기, 이동 조건, 신고 접수 기록'), findsOneWidget);
+    expect(find.text('삭제한 데이터는 앱에서 복구할 수 없습니다.'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('dataDeletionStartButton')));
     await tester.pumpAndSettle();
@@ -2041,10 +2053,24 @@ void main() {
           .getSemantics(find.byKey(const Key('privacyPolicyAccessItem')))
           .getSemanticsData()
           .label,
-      '개인정보처리방침, 준비 중입니다.',
+      '개인정보처리방침, 현재 이용할 수 없음 · 준비 중',
     );
 
     await tester.tap(find.byKey(const Key('privacyPolicyAccessItem')));
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('dataDeletionAccessItem')),
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.pumpAndSettle();
+    expect(
+      tester
+          .getSemantics(find.byKey(const Key('dataDeletionAccessItem')))
+          .getSemanticsData()
+          .label,
+      '데이터 삭제 요청, 현재 이용할 수 없음 · 준비 중, 삭제 범위와 복구 불가 여부를 먼저 확인해요',
+    );
+    await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
     await tester.scrollUntilVisible(
       find.byKey(const Key('supportAccessItem')),
       120,
@@ -2056,7 +2082,7 @@ void main() {
           .getSemantics(find.byKey(const Key('supportAccessItem')))
           .getSemanticsData()
           .label,
-      '고객지원, 준비 중입니다.',
+      '고객지원, 현재 이용할 수 없음 · 준비 중',
     );
     await tester.tap(find.byKey(const Key('supportAccessItem')));
     await tester.scrollUntilVisible(
@@ -2070,23 +2096,9 @@ void main() {
           .getSemantics(find.byKey(const Key('securityContactAccessItem')))
           .getSemanticsData()
           .label,
-      '보안 문의, 준비 중입니다.',
+      '보안 문의, 현재 이용할 수 없음 · 준비 중',
     );
     await tester.tap(find.byKey(const Key('securityContactAccessItem')));
-    await tester.scrollUntilVisible(
-      find.byKey(const Key('dataDeletionAccessItem')),
-      120,
-      scrollable: find.byType(Scrollable).last,
-    );
-    await tester.pumpAndSettle();
-    expect(
-      tester
-          .getSemantics(find.byKey(const Key('dataDeletionAccessItem')))
-          .getSemanticsData()
-          .label,
-      '데이터 삭제 요청, 준비 중입니다.',
-    );
-    await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
     await tester.pumpAndSettle();
 
     expect(launcher.openedUris, isEmpty);
@@ -3001,20 +3013,22 @@ void main() {
       await tester.tap(find.byKey(const Key('recentSearchButton')));
       await tester.pumpAndSettle();
 
-      expect(find.text('최근 검색'), findsWidgets);
+      expect(find.text('최근 검색'), findsOneWidget);
       expect(find.byKey(const Key('stationSearchInput')), findsNothing);
       expect(
         find.byKey(const Key('stationRecentSearchSection')),
         findsOneWidget,
       );
+      expect(find.text('최근 사용 순서 · 2개'), findsOneWidget);
+      expect(find.text('최근 사용 1번째'), findsOneWidget);
       expect(
         find.byKey(const Key('stationRecentSearchQuery-상록수')),
         findsOneWidget,
       );
-      expect(find.bySemanticsLabel('최근 검색어 상록수 검색'), findsOneWidget);
+      expect(find.bySemanticsLabel('최근 검색어 상록수 검색, 최근 사용 1번째'), findsOneWidget);
       expect(
         tester
-            .getSemantics(find.bySemanticsLabel('최근 검색어 상록수 검색'))
+            .getSemantics(find.bySemanticsLabel('최근 검색어 상록수 검색, 최근 사용 1번째'))
             .getSemanticsData()
             .hasAction(SemanticsAction.tap),
         isTrue,
@@ -3044,6 +3058,51 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('역 검색 최근 검색은 개별 삭제와 전체 삭제 및 빈 상태 CTA를 제공한다', (tester) async {
+    final searchHistoryRepository = FakeSearchHistoryRepository(['상록수', '사당']);
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        searchHistoryRepository: searchHistoryRepository,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('recentSearchButton')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('stationRecentSearchRemove-상록수')));
+    await tester.pumpAndSettle();
+
+    expect(searchHistoryRepository.removedQueries, ['상록수']);
+    expect(find.byKey(const Key('stationRecentSearchQuery-상록수')), findsNothing);
+    expect(find.text('최근 사용 순서 · 1개'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const Key('stationRecentSearchClearAllButton')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(searchHistoryRepository.clearCount, 1);
+    expect(
+      find.byKey(const Key('stationRecentSearchEmptyState')),
+      findsOneWidget,
+    );
+    expect(find.text('최근 검색한 역이 없습니다.'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, '역 검색하기'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const Key('stationRecentSearchEmptySearchButton')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('stationSearchInput')), findsOneWidget);
   });
 
   testWidgets('역 검색 결과는 환승 노선 배지를 대표 노선과 추가 개수로 줄인다', (tester) async {
@@ -7984,6 +8043,8 @@ class FakeSearchHistoryRepository implements SearchHistoryRepository {
 
   final List<String> queries;
   final recordedQueries = <String>[];
+  final removedQueries = <String>[];
+  int clearCount = 0;
   int listRequestCount = 0;
 
   @override
@@ -8002,6 +8063,19 @@ class FakeSearchHistoryRepository implements SearchHistoryRepository {
   Future<List<String>> listRecentQueries() async {
     listRequestCount++;
     return [...queries];
+  }
+
+  @override
+  Future<void> removeSearch(String query) async {
+    final trimmed = query.trim();
+    removedQueries.add(trimmed);
+    queries.remove(trimmed);
+  }
+
+  @override
+  Future<void> clearSearches() async {
+    clearCount++;
+    queries.clear();
   }
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3020,6 +3020,7 @@ void main() {
         findsOneWidget,
       );
       expect(find.text('최근 사용 순서 · 2개'), findsOneWidget);
+      expect(find.bySemanticsLabel('최근 사용 순서로 2개 표시'), findsOneWidget);
       expect(find.text('최근 사용 1번째'), findsOneWidget);
       expect(
         find.byKey(const Key('stationRecentSearchQuery-상록수')),


### PR DESCRIPTION
## 관련 이슈

close #793

## 작업 배경

최근 검색 화면이 항목 순서와 삭제 행동을 충분히 보여주지 못했고, 도움말 화면의 개인정보·삭제·안전·문의 안내가 한 흐름 안에서 구분되기 어려웠다. 출시 전 QA 요청 기준에 맞춰 최근 검색 관리 행동과 개인정보/삭제 안내 구조를 정리했다.

## 작업 내용

- 최근 검색 전용 진입 화면에서 `최근 사용 순서 · N개`, 개별 삭제, 전체 삭제, 빈 상태 CTA를 제공하도록 정리했다.
- 검색 기록 저장소 계약에 개별 삭제와 전체 삭제 API를 추가하고 Drift 구현 및 테스트 fake를 맞췄다.
- 도움말·문의 화면을 개인정보 및 데이터, 안전 안내, 문의 섹션으로 나누고 데이터 삭제 요청 문구에 삭제 범위와 복구 불가 확인을 명시했다.
- 데이터 삭제 확인 화면에 삭제 후 복구할 수 없다는 안내를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/main.dart apps/mobile/lib/station_search.dart apps/mobile/lib/features/search_history/data/drift_search_history_repository.dart apps/mobile/test/widget_test.dart apps/mobile/test/station_search_test.dart`: exit 0, 5 files formatted, 0 changed
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `cd apps/mobile && flutter test test/widget_test.dart test/station_search_test.dart test/user_data_deletion_test.dart`: exit 0, 171 tests passed
  - Android emulator `emulator-5554` 수동 확인: 최근 검색 목록/빈 상태, 도움말, 데이터 삭제 안내 화면 캡처 및 UI tree dump 완료
  - iOS simulator `Maum iPhone 17` 수동 확인: 최근 검색 목록/빈 상태, 도움말, 데이터 삭제 안내 화면 캡처 완료

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 최근 검색 목록 | Android emulator-5554 | 홈 > 최근 검색 진입 후 UI tree와 스크린샷 확인 | 로컬 전용 `.codex/evidence/793/android-recent-list.png`, `.codex/evidence/793/android-recent-ui.xml` | `최근 사용 순서 · 2개`, 개별 삭제, 전체 삭제 버튼 확인 |
| 최근 검색 빈 상태 | Android emulator-5554 | 전체 삭제 후 UI tree와 스크린샷 확인 | 로컬 전용 `.codex/evidence/793/android-recent-empty.png`, `.codex/evidence/793/android-recent-empty-ui.xml` | `최근 검색한 역이 없습니다.`, `역 검색하기` CTA 확인 |
| 도움말 개인정보·안전·문의 구조 | Android emulator-5554 | 더보기 > 개인정보 및 도움말 진입 후 UI tree와 스크린샷 확인 | 로컬 전용 `.codex/evidence/793/android-help.png`, `.codex/evidence/793/android-help-lower.png`, 관련 XML dump | 개인정보 및 데이터, 안전 안내, 문의 섹션과 준비 중 문구 확인 |
| 데이터 삭제 복구 불가 안내 | Android emulator-5554 | 데이터 삭제 요청 진입 후 UI tree와 스크린샷 확인 | 로컬 전용 `.codex/evidence/793/android-data-deletion.png`, `.codex/evidence/793/android-data-deletion-ui.xml` | 삭제 범위와 `삭제한 데이터는 앱에서 복구할 수 없습니다.` 문구 확인 |
| 최근 검색 목록·빈 상태 | iOS simulator Maum iPhone 17 | XcodeBuildMCP snapshot/tap/screenshot으로 최근 검색 목록과 전체 삭제 후 빈 상태 확인 | 로컬 전용 `.codex/evidence/793/ios-recent-list.jpg`, `.codex/evidence/793/ios-recent-empty.jpg` | iOS에서도 목록 순서/삭제 버튼과 빈 상태 CTA 확인 |
| 도움말·데이터 삭제 안내 | iOS simulator Maum iPhone 17 | XcodeBuildMCP snapshot/tap/screenshot으로 도움말과 삭제 안내 확인 | 로컬 전용 `.codex/evidence/793/ios-help.png`, `.codex/evidence/793/ios-data-deletion.png` | 개인정보 사용 안내, 안전 안내, 복구 불가 문구 확인 |

스크린샷과 UI dump는 외부 업로드에 대한 QA 승인이 없어 git에 커밋하지 않고 로컬 전용 증거 폴더에 보관했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `SearchHistoryRepository` 계약 확장과 Drift 삭제 구현
  - 최근 검색 전용 진입 화면의 목록/빈 상태 전환
  - 도움말 섹션 순서와 데이터 삭제 복구 불가 문구

## 리스크

- 기존 검색 기록 테이블을 그대로 사용하므로 데이터 마이그레이션은 없다.
- 최근 검색 전체 삭제는 확인 dialog 없이 즉시 적용된다. 항목 수가 작고 개인 검색 기록 관리 행동이라 단순 삭제로 유지했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. 해당 없음: CodeRabbit 리뷰가 완료됐다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
