### PR TITLE
[Fix] 경로 점수 계약과 즐겨찾기 표시 의미 분리

### DIFF
--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -55,7 +55,7 @@ class LocalRouteRepository implements RouteSearchRepository {
       status: result.status == local.RouteStatus.found ? 'FOUND' : 'BLOCKED',
       lineId: primaryLineId,
       lineName: primaryLineName,
-      score: _scoreFromCost(result.totalCost),
+      score: result.totalCost,
       steps: _toSteps(result, catalog),
       warnings: result.warnings
           .map(
@@ -171,13 +171,6 @@ class LocalRouteRepository implements RouteSearchRepository {
         ? '선택된 경로'
         : '선택된 경로 ${step.evidenceSources.first}';
     return '$source 근거로 안내합니다.';
-  }
-
-  int _scoreFromCost(int cost) {
-    if (cost <= 0) {
-      return 0;
-    }
-    return (100 - (cost / 20).round()).clamp(1, 100);
   }
 
   List<String> _recommendationReasons(local.LocalRouteResult result) {

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -3442,7 +3442,7 @@ class _FavoriteHomeQuickGrid extends StatelessWidget {
           icon: Icons.route_outlined,
           label: '경로',
           countLabel: _countLabel(routeCount),
-          subtitle: '이동 편의도와 저장한 경로를 다시 확인해요',
+          subtitle: '이동 조건과 저장한 경로를 다시 확인해요',
           onTap: onRoutes,
         ),
       ],

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -460,7 +460,7 @@ class FavoriteRoute {
 
   String get lineLabel => lineName.isEmpty ? '노선 확인 필요' : lineName;
 
-  String get scoreLabel => '이동 편의도 $score점';
+  String get scoreLabel => '상세 이동 정보는 다시 검색해 확인';
 
   String get mobilityLabel => _mobilityLabelFor(mobilityType);
 
@@ -633,7 +633,8 @@ class RouteSearchResult {
     };
   }
 
-  String get scoreLabel => '이동 편의도 $score점';
+  String get scoreLabel =>
+      isBlocked || warnings.isNotEmpty ? '이동 부담 확인 필요' : '이동 부담 낮음';
 
   String get lineLabel => lineName.isEmpty ? '노선 확인 필요' : lineName;
 
@@ -668,7 +669,7 @@ class RouteSearchResult {
     if (isBlocked) {
       return '다른 경로 필요';
     }
-    return score >= 80 ? '이동 편함' : '조금 불편';
+    return warnings.isEmpty ? '이동 부담 낮음' : '확인 필요 구간 있음';
   }
 
   String get guidanceLabel {

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -56,6 +56,7 @@ void main() {
     expect(result.lineId, 'seoul-4');
     expect(result.lineName, '수도권 4호선');
     expect(result.isLocalResult, isTrue);
+    expect(result.score, greaterThan(100));
     expect(
       result.steps
           .map((step) => step.lineId)

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -231,7 +231,8 @@ void main() {
     expect(result.summaryTitle, '상록수에서 사당까지');
     expect(result.lineName, '수도권 4호선');
     expect(result.statusLabel, '경로를 찾았습니다');
-    expect(result.scoreLabel, '이동 편의도 92점');
+    expect(result.scoreLabel, '이동 부담 확인 필요');
+    expect(result.scoreLabel, isNot(contains('92점')));
     expect(result.recommendationReasons, [
       '엘리베이터 동선을 우선했어요',
       '계단 없는 출구를 확인했어요',
@@ -481,7 +482,8 @@ void main() {
     expect(favorites.single.summaryTitle, '상록수에서 사당까지');
     expect(saved.favoriteRouteId, 'route-1');
     expect(saved.mobilityLabel, '천천히 이동');
-    expect(saved.scoreLabel, '이동 편의도 92점');
+    expect(saved.scoreLabel, '상세 이동 정보는 다시 검색해 확인');
+    expect(saved.scoreLabel, isNot(contains('92점')));
   });
 
   test('경로 피드백 API 저장소는 익명 사용자 식별자와 평가를 전송한다', () async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2502,7 +2502,8 @@ void main() {
       expect(find.text('상록수에서 사당까지'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
       expect(find.text('천천히 이동'), findsOneWidget);
-      expect(find.text('이동 편의도 92점'), findsOneWidget);
+      expect(find.text('이동 편의도 92점'), findsNothing);
+      expect(find.text('상세 이동 정보는 다시 검색해 확인'), findsOneWidget);
       expect(
         find.text('기준: 천천히 이동, 수도권 4호선, 최근 확인 2026-06-13'),
         findsOneWidget,
@@ -2511,7 +2512,7 @@ void main() {
       expect(find.text('계단 정보 확인 필요 · 엘리베이터 연결 확인 필요'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
-          '즐겨찾기 경로, 상록수에서 사당까지, 수도권 4호선, 천천히 이동, 이동 편의도 92점, 기준 천천히 이동, 수도권 4호선, 최근 확인 2026-06-13, 예상 시간 확인 필요, 환승 확인 필요, 도보 확인 필요, 계단 정보 확인 필요, 엘리베이터 연결 확인 필요',
+          '즐겨찾기 경로, 상록수에서 사당까지, 수도권 4호선, 천천히 이동, 상세 이동 정보는 다시 검색해 확인, 기준 천천히 이동, 수도권 4호선, 최근 확인 2026-06-13, 예상 시간 확인 필요, 환승 확인 필요, 도보 확인 필요, 계단 정보 확인 필요, 엘리베이터 연결 확인 필요',
         ),
         findsOneWidget,
       );


### PR DESCRIPTION
## 관련 이슈

close #807

## 작업 배경

경로 검색 결과와 즐겨찾기 경로가 `score`를 사용자용 편의 점수처럼 표시해 API 비용 점수와 로컬 편의 점수 방향이 섞일 수 있었다. QA 요청에 따라 숫자 점수 노출을 제거하고, 저장된 legacy 경로 점수는 새 부담 등급으로 추정하지 않도록 정리했다.

## 작업 내용

- 로컬 경로 결과의 `score`를 `100 - cost` 변환 없이 내부 부담 비용 방향 그대로 전달하게 했다.
- 경로 결과와 즐겨찾기 경로 표시/시맨틱에서 `이동 편의도 N점`을 제거했다.
- 저장된 즐겨찾기 경로는 legacy score를 등급으로 바꾸지 않고 `상세 이동 정보는 다시 검색해 확인`으로 안내한다.
- 홈 즐겨찾기 경로 카드 문구에서 편의도 표현을 제거했다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/route_search_test.dart test/features/routes/local_route_repository_test.dart test/features/favorites/drift_favorite_repositories_test.dart`: exit 0, 61 tests passed
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "홈 즐겨찾기 경로는 저장한 경로를 큰 목록으로 보여주고 삭제한다"`: exit 0, 1 test passed
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `cd backend && ./gradlew test --tests '*RouteSearchServiceTest'`: exit 0, BUILD SUCCESSFUL
  - `cd apps/mobile && flutter build apk --debug --dart-define=EASYSUBWAY_DEMO_HOME_DATA=true`: exit 0, debug APK 생성
  - `cd apps/mobile && flutter build ios --simulator --debug --dart-define=EASYSUBWAY_DEMO_HOME_DATA=true`: exit 0, simulator app 생성
  - `git diff --check`: exit 0
  - `node --test tools/ci/*.test.mjs`: exit 1, 이번 변경과 무관한 기존 repository contract 2건 실패 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 즐겨찾기 경로 숫자 점수 제거 | Android emulator API 36 | demo data debug APK 설치 후 즐겨찾기 경로 UI tree 확인 | 로컬 전용 `.codex/evidence/807/android-favorite-route-ui.xml` | `이동 편의도 92점` 없이 `상세 이동 정보는 다시 검색해 확인` 시맨틱 노출 |
| 즐겨찾기 경로 화면 | Android emulator API 36 | `adb exec-out screencap -p` | 로컬 전용 `.codex/evidence/807/android-favorite-route.png` | 저장 경로 화면 캡처 완료 |
| iOS 빌드 가능성 | iOS simulator | `flutter build ios --simulator --debug --dart-define=EASYSUBWAY_DEMO_HOME_DATA=true` | 명령 출력 | exit 0, `build/ios/iphonesimulator/Runner.app` 생성 |

Android 화면 증거는 외부 업로드 QA 승인이 없어 PR에 직접 첨부하지 않고 로컬 전용 경로로 보관했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchResult.scoreLabel`, `FavoriteRoute.scoreLabel`, `LocalRouteRepository._toRouteSearchResult`
- wire field `score`는 호환성을 위해 유지했고, 사용자 표시에서만 숫자 점수 의미를 제거했다.

## 리스크

- 저장된 경로의 기존 숫자 점수는 더 이상 화면에 보이지 않는다. 사용자는 경로를 다시 검색해 최신 이동 정보를 확인해야 한다.
- `node --test tools/ci/*.test.mjs`는 이번 diff와 무관한 기존 contract 2건 때문에 로컬에서 실패한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
