### PR TITLE
[Fix] 경로 걷기 거리와 환승 집계 사실값 분리

### DIFF
--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -87,6 +87,7 @@ class LocalRouteRepository implements RouteSearchRepository {
 
           return RouteSearchStep(
             sequence: step.sequence,
+            stepType: step.type.name,
             title: _stepTitle(step.type.name, fromName, toName, lineName),
             description: _stepDescription(step.type.name, fromName, toName),
             lineId: step.lineId,

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -623,6 +623,33 @@ class RouteSearchResult {
   final List<String> blockedReasons;
   final String createdAt;
 
+  int get walkingDistanceMeters {
+    return steps.fold<int>(
+      0,
+      (sum, step) => step.isWalkingStep ? sum + step.distanceMeters : sum,
+    );
+  }
+
+  int get transferCount {
+    final typedTransfers = steps.where((step) => step.stepType == 'transfer');
+    if (typedTransfers.isNotEmpty) {
+      return typedTransfers.length;
+    }
+    var previousLine = '';
+    var changes = 0;
+    for (final step in movementSteps) {
+      final line = step.lineId.isNotEmpty ? step.lineId : step.lineName;
+      if (line.isEmpty) {
+        continue;
+      }
+      if (previousLine.isNotEmpty && previousLine != line) {
+        changes += 1;
+      }
+      previousLine = line;
+    }
+    return changes;
+  }
+
   String get summaryTitle => '$originStationName에서 $destinationStationName까지';
 
   String get statusLabel {
@@ -739,6 +766,7 @@ class RouteSearchResult {
 class RouteSearchStep {
   const RouteSearchStep({
     required this.sequence,
+    this.stepType = '',
     required this.title,
     required this.description,
     required this.lineId,
@@ -763,6 +791,7 @@ class RouteSearchStep {
     final description = _requiredRouteString(json, 'description');
     return RouteSearchStep(
       sequence: _requiredRouteInt(json, 'sequence'),
+      stepType: _optionalRouteString(json, 'stepType'),
       title: title,
       description: description,
       lineId: _optionalRouteString(json, 'lineId'),
@@ -792,6 +821,7 @@ class RouteSearchStep {
   }
 
   final int sequence;
+  final String stepType;
   final String title;
   final String description;
   final String lineId;
@@ -839,6 +869,14 @@ class RouteSearchStep {
       timeSource.isNotEmpty ||
       distanceSource.isNotEmpty ||
       confidenceLabel.isNotEmpty;
+
+  bool get isWalkingStep {
+    return switch (stepType) {
+      'entry' || 'exit' || 'transfer' || 'internal' => true,
+      'ride' => false,
+      _ => requiresAccessibilityCheck,
+    };
+  }
 
   String get metricSourceLabel {
     if (!hasMetricSourceMetadata) {
@@ -2564,16 +2602,6 @@ class _RouteResultsListView extends StatelessWidget {
   }
 }
 
-bool _routeStepIsExplicitTransfer(RouteSearchStep step) {
-  return step.actionTitle.contains('환승') ||
-      step.title.contains('환승') ||
-      step.description.contains('환승');
-}
-
-int _routeExplicitTransferCount(List<RouteSearchStep> steps) {
-  return steps.where(_routeStepIsExplicitTransfer).length;
-}
-
 class _RouteDetailWorkflowView extends StatelessWidget {
   const _RouteDetailWorkflowView({
     required this.result,
@@ -3353,33 +3381,13 @@ int _routeTotalMinutes(RouteSearchResult result) {
   return result.steps.fold<int>(0, (sum, step) => sum + step.estimatedMinutes);
 }
 
-int _routeTotalDistanceMeters(RouteSearchResult result) {
-  return result.steps.fold<int>(0, (sum, step) => sum + step.distanceMeters);
-}
-
 String _routeTransferLabel(RouteSearchResult result) {
-  final movementSteps = result.movementSteps;
-  final explicitTransfers = _routeExplicitTransferCount(movementSteps);
-  if (explicitTransfers > 0) {
-    return '환승 $explicitTransfers회';
-  }
-  var previousLine = '';
-  var changes = 0;
-  for (final step in movementSteps) {
-    final line = step.lineId.isNotEmpty ? step.lineId : step.lineName;
-    if (line.isEmpty) {
-      continue;
-    }
-    if (previousLine.isNotEmpty && previousLine != line) {
-      changes += 1;
-    }
-    previousLine = line;
-  }
-  return changes == 0 ? '환승 없음' : '환승 $changes회';
+  final transfers = result.transferCount;
+  return transfers == 0 ? '환승 없음' : '환승 $transfers회';
 }
 
 String _routeWalkingDistanceLabel(RouteSearchResult result) {
-  return _routeDistanceLabel(_routeTotalDistanceMeters(result));
+  return _routeDistanceLabel(result.walkingDistanceMeters);
 }
 
 String _routeMetaLabel(RouteSearchResult result) {

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -160,6 +160,7 @@ void main() {
               'steps': [
                 {
                   'sequence': 1,
+                  'stepType': 'entry',
                   'title': '상록수역에서 4호선 승강장으로 이동',
                   'description': '엘리베이터를 이용해 승강장으로 이동합니다.',
                   'lineId': 'seoul-4',
@@ -173,6 +174,7 @@ void main() {
                 },
                 {
                   'sequence': 2,
+                  'stepType': 'exit',
                   'title': '사당역에서 출구 접근성 정보를 확인',
                   'description': '2번 출구의 엘리베이터를 먼저 확인하세요.',
                   'lineId': 'seoul-4',
@@ -243,6 +245,7 @@ void main() {
     expect(result.steps.first.hasMetricSourceMetadata, isFalse);
     expect(result.steps.first.estimatedMinutes, 4);
     expect(result.steps.first.distanceMeters, 180);
+    expect(result.steps.first.stepType, 'entry');
     expect(result.steps.first.includesStairs, isFalse);
     expect(result.steps.first.requiresAccessibilityCheck, isTrue);
     expect(result.steps.first.burdenLabel, '약 4분 · 180m · 접근성 확인');
@@ -420,6 +423,58 @@ void main() {
     );
 
     expect(step.burdenLabel, '시간 확인 필요 · 180m');
+  });
+
+  test('경로 요약 사실값은 열차 거리와 환승 문구에 의존하지 않는다', () {
+    final result = _sampleRouteSearchResult(
+      steps: const [
+        RouteSearchStep(
+          sequence: 1,
+          stepType: 'entry',
+          title: '출발역 승강장 접근',
+          description: '엘리베이터로 승강장까지 이동합니다.',
+          lineId: 'seoul-4',
+          lineName: '수도권 4호선',
+          fromStationId: 'station-sangnoksu',
+          toStationId: 'station-sangnoksu',
+          estimatedMinutes: 3,
+          distanceMeters: 180,
+          includesStairs: false,
+          requiresAccessibilityCheck: true,
+        ),
+        RouteSearchStep(
+          sequence: 2,
+          stepType: 'ride',
+          title: '수도권 4호선 이동',
+          description: '열차로 이동합니다.',
+          lineId: 'seoul-4',
+          lineName: '수도권 4호선',
+          fromStationId: 'station-sangnoksu',
+          toStationId: 'station-sadang',
+          estimatedMinutes: 30,
+          distanceMeters: 10000,
+          includesStairs: false,
+          requiresAccessibilityCheck: false,
+        ),
+        RouteSearchStep(
+          sequence: 3,
+          stepType: 'transfer',
+          title: '노선 변경 준비',
+          description: '다음 열차 승강장으로 이동합니다.',
+          lineId: 'seoul-2',
+          lineName: '수도권 2호선',
+          fromStationId: 'station-sadang',
+          toStationId: 'station-sadang',
+          estimatedMinutes: 4,
+          distanceMeters: 120,
+          includesStairs: false,
+          requiresAccessibilityCheck: true,
+        ),
+      ],
+    );
+
+    expect(result.walkingDistanceMeters, 300);
+    expect(result.transferCount, 1);
   });
 
   test('즐겨찾기 경로 API 저장소는 인증 헤더로 저장과 목록과 삭제를 요청한다', () async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5597,7 +5597,7 @@ void main() {
     }
   });
 
-  testWidgets('같은 노선의 명시적 환승 단계는 환승 횟수에 포함된다', (tester) async {
+  testWidgets('경로 요약은 stepType 기반 환승과 보행 거리만 표시한다', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: RouteSearchScreen(
@@ -5606,20 +5606,21 @@ void main() {
               steps: const [
                 RouteSearchStep(
                   sequence: 1,
-                  title: '상록수역에서 대기',
-                  description: '승강장에서 다음 열차를 기다립니다.',
+                  stepType: 'entry',
+                  title: '출발역 승강장 접근',
+                  description: '엘리베이터로 승강장까지 이동합니다.',
                   lineId: 'seoul-4',
                   lineName: '수도권 4호선',
                   fromStationId: 'station-sangnoksu',
                   toStationId: 'station-sangnoksu',
                   estimatedMinutes: 2,
-                  distanceMeters: 0,
+                  distanceMeters: 180,
                   includesStairs: false,
-                  requiresAccessibilityCheck: false,
-                  actionTitle: '환승',
+                  requiresAccessibilityCheck: true,
                 ),
                 RouteSearchStep(
                   sequence: 2,
+                  stepType: 'ride',
                   title: '사당역까지 이동',
                   description: '같은 4호선 열차로 이동합니다.',
                   lineId: 'seoul-4',
@@ -5627,10 +5628,24 @@ void main() {
                   fromStationId: 'station-sangnoksu',
                   toStationId: 'station-sadang',
                   estimatedMinutes: 20,
-                  distanceMeters: 0,
+                  distanceMeters: 10000,
                   includesStairs: false,
                   requiresAccessibilityCheck: false,
                   actionTitle: '열차 이동',
+                ),
+                RouteSearchStep(
+                  sequence: 3,
+                  stepType: 'transfer',
+                  title: '노선 변경 준비',
+                  description: '다음 열차 승강장으로 이동합니다.',
+                  lineId: 'seoul-4',
+                  lineName: '수도권 4호선',
+                  fromStationId: 'station-sadang',
+                  toStationId: 'station-sadang',
+                  estimatedMinutes: 4,
+                  distanceMeters: 120,
+                  includesStairs: false,
+                  requiresAccessibilityCheck: true,
                 ),
               ],
             ),
@@ -5654,7 +5669,8 @@ void main() {
     await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
     await tester.pumpAndSettle();
 
-    expect(find.textContaining('환승 1회'), findsWidgets);
+    expect(find.text('환승 1회 · 걷기 300m'), findsOneWidget);
+    expect(find.textContaining('걷기 10.3km'), findsNothing);
   });
 
   testWidgets('길이 막혔어요는 성공 경로를 blocked 화면으로 바꾸지 않는다', (tester) async {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -805,6 +805,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 		return List.of(
 			new RouteStep(
 				1,
+				"entry",
 				origin.nameKo() + "역에서 " + displayLine + " 승강장으로 이동",
 				profileWeight.entryGuidance(),
 				directLine.line().id(),
@@ -818,6 +819,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			),
 			new RouteStep(
 				2,
+				"ride",
 				directLine.line().name() + "으로 " + destination.nameKo() + "역까지 이동",
 				directLine.stopCount() + "개 역을 이동합니다. 환승은 없습니다.",
 				directLine.line().id(),
@@ -831,6 +833,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			),
 			new RouteStep(
 				3,
+				"exit",
 				destination.nameKo() + "역에서 출구 접근성 정보를 확인",
 				exitGuidance(destination.id(), profileWeight.exitGuidance()),
 				directLine.line().id(),
@@ -859,6 +862,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 		return List.of(
 			new RouteStep(
 				1,
+				"entry",
 				origin.nameKo() + "역에서 " + firstDisplayLine + " 승강장으로 이동",
 				profileWeight.entryGuidance(),
 				route.firstLine().id(),
@@ -872,6 +876,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			),
 			new RouteStep(
 				2,
+				"ride",
 				route.firstLine().name() + "으로 " + route.transferStation().nameKo() + "역까지 이동",
 				route.firstSegmentStopCount() + "개 역을 이동한 뒤 환승합니다.",
 				route.firstLine().id(),
@@ -885,6 +890,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			),
 			new RouteStep(
 				3,
+				"transfer",
 				route.transferStation().nameKo() + "역에서 " + secondDisplayLine + " 승강장으로 환승",
 				route.transferStation().nameKo() + "의 엘리베이터와 계단 없는 연결 동선을 먼저 확인합니다.",
 				route.secondLine().id(),
@@ -898,6 +904,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			),
 			new RouteStep(
 				4,
+				"ride",
 				route.secondLine().name() + "으로 " + destination.nameKo() + "역까지 이동",
 				route.secondSegmentStopCount() + "개 역을 이동합니다.",
 				route.secondLine().id(),
@@ -911,6 +918,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			),
 			new RouteStep(
 				5,
+				"exit",
 				destination.nameKo() + "역에서 출구 접근성 정보를 확인",
 				exitGuidance(destination.id(), profileWeight.exitGuidance()),
 				route.secondLine().id(),

--- a/backend/src/main/java/com/easysubway/route/domain/RouteStep.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteStep.java
@@ -2,6 +2,7 @@ package com.easysubway.route.domain;
 
 public record RouteStep(
 	int sequence,
+	String stepType,
 	String title,
 	String description,
 	String lineId,
@@ -13,4 +14,32 @@ public record RouteStep(
 	boolean includesStairs,
 	boolean requiresAccessibilityCheck
 ) {
+	public RouteStep(
+		int sequence,
+		String title,
+		String description,
+		String lineId,
+		String lineName,
+		String fromStationId,
+		String toStationId,
+		int estimatedMinutes,
+		int distanceMeters,
+		boolean includesStairs,
+		boolean requiresAccessibilityCheck
+	) {
+		this(
+			sequence,
+			"",
+			title,
+			description,
+			lineId,
+			lineName,
+			fromStationId,
+			toStationId,
+			estimatedMinutes,
+			distanceMeters,
+			includesStairs,
+			requiresAccessibilityCheck
+		);
+	}
 }

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -85,6 +85,9 @@ class RouteSearchServiceTest {
 				"수도권 4호선으로 사당역까지 이동",
 				"사당역에서 출구 접근성 정보를 확인"
 			);
+		assertThat(result.steps())
+			.extracting("stepType")
+			.containsExactly("entry", "ride", "exit");
 		assertThat(result.steps().get(0).estimatedMinutes()).isEqualTo(4);
 		assertThat(result.steps().get(0).distanceMeters()).isEqualTo(180);
 		assertThat(result.steps().get(0).includesStairs()).isFalse();


### PR DESCRIPTION
## 관련 이슈

close #808

## 작업 배경

경로 요약의 `걷기` 거리가 모든 step 거리 합계에 의존하면 열차 주행 거리까지 보행 부담처럼 보일 수 있다. 환승 수도 제목/설명 문구에 `환승`이 있는지 찾는 방식이면 문구 변경만으로 값이 흔들린다. QA 요청에 따라 API와 로컬 경로 step에 이동 방식 계약을 추가하고, 사용자 화면의 요약은 보행 step과 환승 step 사실값만 사용하도록 정리했다.

## 작업 내용

- `RouteSearchStep.stepType`을 추가하고 API 응답과 로컬 경로 변환에서 `entry`, `ride`, `transfer`, `exit` 타입을 내려준다.
- 모바일 경로 요약의 걷기 거리는 `entry`, `exit`, `transfer`, `internal` step만 합산하고 `ride` 거리는 제외한다.
- 환승 수는 `stepType == transfer`를 우선 사용하고, 구형 데이터는 노선 변경 수로만 fallback한다.
- 백엔드 `RouteStep` 응답에 `stepType`을 추가하고 기존 생성자 호출은 빈 타입으로 유지되게 호환 생성자를 둔다.
- 열차 10km와 보행 300m fixture에서 `환승 1회 · 걷기 300m`만 표시되는 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/route_search_test.dart test/features/routes/local_route_repository_test.dart`: 통과, 54 tests passed.
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "경로 요약은 stepType 기반 환승과 보행 거리만 표시한다"`: 통과, 1 test passed.
  - `cd apps/mobile && flutter analyze`: 통과, No issues found.
  - `cd backend && ./gradlew test --tests '*RouteSearchServiceTest'`: 통과, BUILD SUCCESSFUL.
  - `cd apps/mobile && flutter build apk --debug`: 통과, `build/app/outputs/flutter-apk/app-debug.apk` 생성.
  - `cd apps/mobile && flutter build ios --simulator --debug`: 통과, `build/ios/iphonesimulator/Runner.app` 생성.
  - `rg -n "routeStepIsExplicitTransfer|routeExplicitTransferCount|title\\.contains\\('환승'\\)|description\\.contains\\('환승'\\)|actionTitle\\.contains\\('환승'\\)|_routeTotalDistanceMeters" apps/mobile/lib apps/mobile/test`: 일치 없음.
  - `git diff --check`: 통과.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 경로 요약 사실값 | Flutter widget test | 열차 10km, entry 180m, transfer 120m fixture에서 결과 카드 문구 확인 | `flutter test test/widget_test.dart --plain-name "경로 요약은 stepType 기반 환승과 보행 거리만 표시한다"` 출력 | `환승 1회 · 걷기 300m` 표시, `걷기 10.3km` 미표시 |
| 경로 모델/로컬 변환 | Flutter unit test | API fixture와 로컬 catalog 경로 step 계약 확인 | `flutter test test/route_search_test.dart test/features/routes/local_route_repository_test.dart` 출력 | 54 tests passed |
| 백엔드 step 계약 | Backend test | 추천 경로 stepType 순서 확인 | `./gradlew test --tests '*RouteSearchServiceTest'` 출력 | BUILD SUCCESSFUL |
| Android 길찾기 화면 | Android emulator `emulator-5554` | APK 설치 후 길찾기 화면과 출발역 검색 UI tree 저장 | `.codex/evidence/808/android-route-screen.xml`, `.codex/evidence/808/android-origin-results.xml`, `.codex/evidence/808/android-route-input-attempt.png` | 길찾기 화면과 `출발역 선택, 상록수...` 검색 결과 확인 |
| Android 결과 화면 대체 증거 | Android emulator `emulator-5554` + Flutter widget test | `Sangnoksu` 영문 검색은 성공했지만 `Sadang` 영문 검색은 로컬 데이터 결과가 없고, `adb shell input text 사당`은 Android 16에서 `NullPointerException`으로 실패해 결과 화면 실기 캡처를 대체 | `.codex/evidence/808/android-destination-results2.xml`, adb 실패 로그, widget test 출력 | 실기 결과 화면 캡처는 불가. 결과 화면 문구는 위젯 테스트로 검증 |
| iOS 빌드 | iOS simulator build | 시뮬레이터 디버그 빌드 | `flutter build ios --simulator --debug` 출력 | Runner.app 생성 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchResult.walkingDistanceMeters`, `RouteSearchResult.transferCount`, `RouteSearchStep.isWalkingStep`의 집계 기준과 백엔드 `stepType` 응답 계약.

## 리스크

- 구형 API/저장 데이터처럼 `stepType`이 비어 있는 step은 기존 접근성 확인 플래그 기반으로 보행 step을 추정한다. 새 API와 로컬 경로는 명시 타입을 내려주므로 정상 경로는 타입 기반으로 계산된다.
- Android 실기 결과 화면은 한글 adb 입력 실패와 `Sadang` 영문 검색 데이터 미매칭 때문에 캡처하지 못했다. 결과 화면 표시 자체는 widget test로 고정했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
