### PR TITLE
[Fix] 경로 내부 식별자와 서버 문장 사용자 노출 차단

### DIFF
--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -4,7 +4,6 @@ import '../application/network_graph.dart' as graph;
 import '../application/route_engine.dart';
 import '../domain/route_request.dart' as local;
 import '../domain/route_result.dart' as local;
-import '../domain/route_step.dart' as local;
 
 class LocalRouteRepository implements RouteSearchRepository {
   LocalRouteRepository({required this.catalogDatabase});
@@ -106,8 +105,8 @@ class LocalRouteRepository implements RouteSearchRepository {
               toName,
               lineName,
             ),
-            reason: _stepReason(step),
-            evidenceSources: step.evidenceSources,
+            reason: _stepReason(),
+            evidenceSources: const [],
             timeSource: step.timeSource,
             distanceSource: step.distanceSource,
             confidenceLabel: step.confidenceLabel,
@@ -167,11 +166,8 @@ class LocalRouteRepository implements RouteSearchRepository {
     };
   }
 
-  String _stepReason(local.RouteStep step) {
-    final source = step.evidenceSources.isEmpty
-        ? '선택된 경로'
-        : '선택된 경로 ${step.evidenceSources.first}';
-    return '$source 근거로 안내합니다.';
+  String _stepReason() {
+    return '선택한 경로 기준으로 안내합니다.';
   }
 
   List<String> _recommendationReasons(local.LocalRouteResult result) {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -857,8 +857,7 @@ class RouteSearchStep {
 
   String get userReason => _routeStepReasonLabel(reason);
 
-  String get userDescription =>
-      _routeStepDetailLabel(stepType: stepType, detail: description);
+  String get userDescription => _routeStepDetailLabel(stepType: stepType);
 
   String get burdenLabel {
     final labels = <String>[
@@ -874,10 +873,7 @@ class RouteSearchStep {
     final safeReason = _routeStepReasonLabel(reason);
     final labels = <String>[
       '$sequence번 ${actionTitle.isEmpty ? title : actionTitle}',
-      _routeStepDetailLabel(
-        stepType: stepType,
-        detail: actionDetail.isEmpty ? description : actionDetail,
-      ),
+      _routeStepDetailLabel(stepType: stepType),
       if (safeReason.isNotEmpty) safeReason,
       burdenLabel,
       if (hasMetricSourceMetadata) '시간과 거리는 앱 경로 데이터 기준',
@@ -958,41 +954,17 @@ String _routeStepReasonLabel(String reason) {
   if (reason.trim().isEmpty) {
     return '';
   }
-  return _routeSafeUserCopy(reason, fallback: '선택한 경로 기준으로 안내합니다.');
+  return '선택한 경로 기준으로 안내합니다.';
 }
 
-String _routeStepDetailLabel({
-  required String stepType,
-  required String detail,
-}) {
-  final fallback = switch (stepType) {
+String _routeStepDetailLabel({required String stepType}) {
+  return switch (stepType) {
     'entry' => '계단 없는 승강장 접근 동선을 확인해 이동합니다.',
     'exit' => '도착역에서 계단 없는 출구 동선을 확인합니다.',
     'transfer' => '다음 노선으로 갈아탈 준비를 합니다.',
     'ride' => '열차를 이용해 이동합니다.',
     _ => '안내된 순서대로 이동합니다.',
   };
-  return _routeSafeUserCopy(detail, fallback: fallback);
-}
-
-String _routeSafeUserCopy(String value, {required String fallback}) {
-  final trimmed = value.trim();
-  if (trimmed.isEmpty || _routeLooksInternalCopy(trimmed)) {
-    return fallback;
-  }
-  return trimmed;
-}
-
-bool _routeLooksInternalCopy(String value) {
-  if (value.contains('edge:') ||
-      value.contains('line:') ||
-      value.contains('OFFICIAL_') ||
-      value.contains('STATIC_ESTIMATE') ||
-      value.contains('REALTIME_ADJUSTED') ||
-      value.contains('MEASURED')) {
-    return true;
-  }
-  return RegExp(r'^[A-Z][A-Z0-9_]+$').hasMatch(value);
 }
 
 class RouteSearchWarning {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -750,7 +750,7 @@ class RouteSearchResult {
     }
     final arrivalStep = arrivalGuidanceStep;
     if (arrivalStep != null) {
-      parts.add('도착 안내 ${arrivalStep.description}');
+      parts.add('도착 안내 ${arrivalStep.userDescription}');
     }
     final safeBlockedReasons = blockedReasonLabels;
     if (safeBlockedReasons.isNotEmpty) {
@@ -3680,7 +3680,7 @@ class _RouteArrivalGuidance extends StatelessWidget {
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    step.description,
+                    step.userDescription,
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                       color: const Color(0xFF102A2C),
                       fontWeight: FontWeight.w800,

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -623,6 +623,17 @@ class RouteSearchResult {
   final List<String> blockedReasons;
   final String createdAt;
 
+  List<String> get recommendationReasonLabels {
+    if (recommendationReasons.isEmpty) {
+      return const [];
+    }
+    return const ['선택한 경로 기준으로 안내합니다.'];
+  }
+
+  List<String> get blockedReasonLabels {
+    return blockedReasons.map(_routeBlockedReasonLabel).toList(growable: false);
+  }
+
   int get walkingDistanceMeters {
     return steps.fold<int>(
       0,
@@ -733,21 +744,25 @@ class RouteSearchResult {
     if (!isBlocked && warnings.isNotEmpty) {
       parts.add(attentionLabel);
     }
-    if (!isBlocked && recommendationReasons.isNotEmpty) {
-      parts.add('추천 이유 ${recommendationReasons.join(', ')}');
+    final safeRecommendationReasons = recommendationReasonLabels;
+    if (!isBlocked && safeRecommendationReasons.isNotEmpty) {
+      parts.add('추천 이유 ${safeRecommendationReasons.join(', ')}');
     }
     final arrivalStep = arrivalGuidanceStep;
     if (arrivalStep != null) {
       parts.add('도착 안내 ${arrivalStep.description}');
     }
-    if (blockedReasons.isNotEmpty) {
-      parts.add('안내 불가 이유 ${blockedReasons.join(', ')}');
+    final safeBlockedReasons = blockedReasonLabels;
+    if (safeBlockedReasons.isNotEmpty) {
+      parts.add('안내 불가 이유 ${safeBlockedReasons.join(', ')}');
     }
     if (isBlocked) {
       parts.add('다음 행동 $_routeSearchFailureNextAction');
     }
     if (warnings.isNotEmpty) {
-      parts.add('주의 ${warnings.map((warning) => warning.message).join(', ')}');
+      parts.add(
+        '주의 ${warnings.map((warning) => warning.userMessage).join(', ')}',
+      );
     }
     final stepsForGuidance = movementSteps;
     if (stepsForGuidance.isNotEmpty) {
@@ -840,6 +855,11 @@ class RouteSearchStep {
   final String distanceSource;
   final String confidenceLabel;
 
+  String get userReason => _routeStepReasonLabel(reason);
+
+  String get userDescription =>
+      _routeStepDetailLabel(stepType: stepType, detail: description);
+
   String get burdenLabel {
     final labels = <String>[
       _routeDurationLabel(estimatedMinutes),
@@ -851,16 +871,16 @@ class RouteSearchStep {
   }
 
   String get semanticGuidanceLabel {
+    final safeReason = _routeStepReasonLabel(reason);
     final labels = <String>[
       '$sequence번 ${actionTitle.isEmpty ? title : actionTitle}',
-      actionDetail.isEmpty ? description : actionDetail,
-      if (reason.isNotEmpty) reason,
+      _routeStepDetailLabel(
+        stepType: stepType,
+        detail: actionDetail.isEmpty ? description : actionDetail,
+      ),
+      if (safeReason.isNotEmpty) safeReason,
       burdenLabel,
-      if (hasMetricSourceMetadata) '시간 ${_routeTimeSourceLabel(timeSource)}',
-      if (hasMetricSourceMetadata)
-        '거리 ${_routeDistanceSourceLabel(distanceSource)}',
-      if (hasMetricSourceMetadata) confidenceLabel,
-      if (evidenceSources.isNotEmpty) '근거 ${evidenceSources.join(', ')}',
+      if (hasMetricSourceMetadata) '시간과 거리는 앱 경로 데이터 기준',
     ];
     return labels.join(', ');
   }
@@ -882,11 +902,7 @@ class RouteSearchStep {
     if (!hasMetricSourceMetadata) {
       return '';
     }
-    return [
-      '시간 ${_routeTimeSourceLabel(timeSource)}',
-      '거리 ${_routeDistanceSourceLabel(distanceSource)}',
-      confidenceLabel,
-    ].join(' · ');
+    return '앱 경로 데이터 기준';
   }
 }
 
@@ -912,21 +928,71 @@ String _routeDistanceLabel(int distanceMeters) {
   return '${kilometers.toStringAsFixed(1)}km';
 }
 
-String _routeTimeSourceLabel(String source) {
-  return switch (source) {
-    'STATIC_ESTIMATE' => '정적 추정',
-    'REALTIME_ADJUSTED' => '실시간 보정',
-    'MEASURED' => '측정값',
-    _ => '확인 필요',
+String _routeWarningLabel(String code, String message) {
+  return switch (code.trim()) {
+    'LOW_DATA_CONFIDENCE' => '일부 시설 정보는 확인이 필요합니다.',
+    'STALE_ACCESSIBILITY_DATA' => '접근성 시설 정보가 최근 확인되지 않았습니다.',
+    'STAIR_ONLY_ACCESS' => '계단 포함 구간이 있습니다.',
+    'STAIR_ONLY_ACCESS_UNKNOWN' => '계단 없는 동선 여부를 확인할 수 없습니다.',
+    'ACCESSIBILITY_STATE_UNKNOWN' => '접근성 시설 이용 가능 여부를 확인할 수 없습니다.',
+    _ => '이동 전 현장 안내를 확인해 주세요.',
   };
 }
 
-String _routeDistanceSourceLabel(String source) {
-  return switch (source) {
-    'MEASURED' => '측정값',
-    'STATIC_ESTIMATE' => '정적 추정',
-    _ => '확인 필요',
+String _routeBlockedReasonLabel(String reason) {
+  return switch (reason.trim()) {
+    'STAIR_ONLY_ACCESS' => '계단 없는 경로를 찾지 못했습니다.',
+    'STAIR_ONLY_ACCESS_UNKNOWN' => '계단 없는 동선 여부를 확인할 수 없습니다.',
+    'GENERATED_CONNECTOR_UNVERIFIED' => '계단 없는 동선 여부를 확인할 수 없습니다.',
+    'FACILITY_UNAVAILABLE' => '필수 접근성 시설을 사용할 수 없습니다.',
+    'ACCESSIBILITY_STATE_UNKNOWN' => '접근성 시설 이용 가능 여부를 확인할 수 없습니다.',
+    '계단 없는 경로를 찾지 못했습니다.' => '계단 없는 경로를 찾지 못했습니다.',
+    '계단 없는 동선 여부를 확인할 수 없습니다.' => '계단 없는 동선 여부를 확인할 수 없습니다.',
+    '필수 접근성 시설을 사용할 수 없습니다.' => '필수 접근성 시설을 사용할 수 없습니다.',
+    '접근성 시설 이용 가능 여부를 확인할 수 없습니다.' => '접근성 시설 이용 가능 여부를 확인할 수 없습니다.',
+    _ => '안내 가능한 경로를 찾지 못했습니다.',
   };
+}
+
+String _routeStepReasonLabel(String reason) {
+  if (reason.trim().isEmpty) {
+    return '';
+  }
+  return _routeSafeUserCopy(reason, fallback: '선택한 경로 기준으로 안내합니다.');
+}
+
+String _routeStepDetailLabel({
+  required String stepType,
+  required String detail,
+}) {
+  final fallback = switch (stepType) {
+    'entry' => '계단 없는 승강장 접근 동선을 확인해 이동합니다.',
+    'exit' => '도착역에서 계단 없는 출구 동선을 확인합니다.',
+    'transfer' => '다음 노선으로 갈아탈 준비를 합니다.',
+    'ride' => '열차를 이용해 이동합니다.',
+    _ => '안내된 순서대로 이동합니다.',
+  };
+  return _routeSafeUserCopy(detail, fallback: fallback);
+}
+
+String _routeSafeUserCopy(String value, {required String fallback}) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty || _routeLooksInternalCopy(trimmed)) {
+    return fallback;
+  }
+  return trimmed;
+}
+
+bool _routeLooksInternalCopy(String value) {
+  if (value.contains('edge:') ||
+      value.contains('line:') ||
+      value.contains('OFFICIAL_') ||
+      value.contains('STATIC_ESTIMATE') ||
+      value.contains('REALTIME_ADJUSTED') ||
+      value.contains('MEASURED')) {
+    return true;
+  }
+  return RegExp(r'^[A-Z][A-Z0-9_]+$').hasMatch(value);
 }
 
 class RouteSearchWarning {
@@ -941,6 +1007,8 @@ class RouteSearchWarning {
 
   final String code;
   final String message;
+
+  String get userMessage => _routeWarningLabel(code, message);
 }
 
 enum RouteSearchViewStatus { idle, loading, success, failure }
@@ -2646,7 +2714,7 @@ class _RouteDetailWorkflowView extends StatelessWidget {
           for (final warning in result.warnings)
             _RouteNotice(
               title: '주의 확인',
-              text: warning.message,
+              text: warning.userMessage,
               icon: Icons.warning_amber,
             ),
         ],
@@ -2692,6 +2760,7 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
     final textScale = MediaQuery.textScalerOf(context).scale(1);
     final steps = result.movementSteps;
     final nextStep = steps.length > 1 ? steps[1] : result.arrivalGuidanceStep;
+    final blockedReasonLabels = result.blockedReasonLabels;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -2932,9 +3001,9 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
                           const SizedBox(height: 15),
                           const _RoutePrototypeLinePath(),
                         ],
-                        if (result.blockedReasons.isNotEmpty) ...[
+                        if (blockedReasonLabels.isNotEmpty) ...[
                           const SizedBox(height: 13),
-                          for (final reason in result.blockedReasons)
+                          for (final reason in blockedReasonLabels)
                             _RoutePrototypeReason(text: reason, blocked: true),
                         ],
                         if (result.arrivalGuidanceStep != null) ...[
@@ -2948,7 +3017,7 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
                           for (final warning in result.warnings)
                             _RouteNotice(
                               title: '주의 확인',
-                              text: warning.message,
+                              text: warning.userMessage,
                               icon: Icons.warning_amber,
                             ),
                         ],
@@ -3051,9 +3120,9 @@ class _RouteBlockedWorkflow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final reasons = result.blockedReasons.isNotEmpty
-        ? result.blockedReasons
-        : result.warnings.map((warning) => warning.message);
+    final reasons = result.blockedReasonLabels.isNotEmpty
+        ? result.blockedReasonLabels
+        : result.warnings.map((warning) => warning.userMessage);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -3785,17 +3854,17 @@ class _RouteStepTile extends StatelessWidget {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  step.description,
+                  step.userDescription,
                   style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                     color: const Color(0xFF405A5D),
                     fontWeight: FontWeight.w600,
                     height: 1.35,
                   ),
                 ),
-                if (step.reason.isNotEmpty) ...[
+                if (step.userReason.isNotEmpty) ...[
                   const SizedBox(height: 4),
                   Text(
-                    step.reason,
+                    step.userReason,
                     style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       color: const Color(0xFF405A5D),
                       fontWeight: FontWeight.w700,

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -95,9 +95,10 @@ void main() {
     expect(result.status, 'FOUND');
     expect(result.blockedReasons, isEmpty);
     expect(
-      result.steps.expand((step) => step.evidenceSources),
-      containsAll(['edge:entry-sangnoksu-seoul-4', 'edge:exit-sadang-seoul-4']),
+      result.steps.map((step) => step.stepType),
+      containsAll(['entry', 'exit']),
     );
+    expect(result.steps.expand((step) => step.evidenceSources), isEmpty);
   });
 
   test('기존 baseline access edge 값은 보강 과정에서 덮어쓰지 않는다', () async {
@@ -175,12 +176,12 @@ void main() {
     );
 
     final rideStep = result.steps.singleWhere(
-      (step) => step.evidenceSources.contains('edge:edge-a-b-local'),
+      (step) => step.stepType == 'ride',
     );
     expect(rideStep.actionTitle, '열차 이동');
     expect(rideStep.actionDetail, contains('출발역에서 중간역까지'));
-    expect(rideStep.reason, contains('선택된 경로 edge'));
-    expect(rideStep.evidenceSources, contains('edge:edge-a-b-local'));
+    expect(rideStep.reason, '선택한 경로 기준으로 안내합니다.');
+    expect(rideStep.evidenceSources, isEmpty);
     expect(rideStep.timeSource, 'STATIC_ESTIMATE');
     expect(rideStep.distanceSource, 'MEASURED');
     expect(rideStep.confidenceLabel, '높은 신뢰도');
@@ -1414,7 +1415,7 @@ void main() {
     );
 
     final rideStep = result.steps.singleWhere(
-      (step) => step.evidenceSources.contains('edge:edge-a-b-low-confidence'),
+      (step) => step.stepType == 'ride',
     );
     expect(result.status, 'FOUND');
     expect(result.warnings.map((warning) => warning.code), {
@@ -1460,7 +1461,7 @@ void main() {
     );
 
     final rideStep = result.steps.singleWhere(
-      (step) => step.evidenceSources.contains('edge:edge-a-b-duration-unknown'),
+      (step) => step.stepType == 'ride',
     );
     expect(result.status, 'FOUND');
     expect(rideStep.estimatedMinutes, 0);
@@ -1501,9 +1502,7 @@ void main() {
     );
 
     final rideStep = result.steps.singleWhere(
-      (step) => step.evidenceSources.contains(
-        'edge:edge-a-b-low-confidence-distance-unknown',
-      ),
+      (step) => step.stepType == 'ride',
     );
     expect(result.status, 'FOUND');
     expect(rideStep.estimatedMinutes, 2);
@@ -1546,8 +1545,7 @@ void main() {
     );
 
     final rideStep = result.steps.singleWhere(
-      (step) =>
-          step.evidenceSources.contains('edge:edge-a-b-measured-distance'),
+      (step) => step.stepType == 'ride',
     );
     expect(result.status, 'FOUND');
     expect(rideStep.estimatedMinutes, 2);

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -332,9 +332,12 @@ void main() {
     expect(result.semanticLabel, isNot(contains('이동할 수 있는 경로')));
   });
 
-  test('경로 검색 결과 음성 안내는 단계 행동 이유와 근거 출처를 같은 순서로 읽는다', () {
+  test('경로 검색 결과 음성 안내는 내부 식별자와 운영 출처 값을 읽지 않는다', () {
     final result = _sampleRouteSearchResult(
-      recommendationReasons: const ['선택된 경로 edge:edge-a-b-local 근거로 안내합니다.'],
+      recommendationReasons: const [
+        '선택된 경로 edge:edge-a-b-local 근거로 안내합니다.',
+        'OFFICIAL_FILE',
+      ],
       steps: const [
         RouteSearchStep(
           sequence: 1,
@@ -360,15 +363,14 @@ void main() {
     );
 
     final semanticLabel = result.semanticLabel;
-    expect(
-      semanticLabel,
-      contains(
-        '1번 열차 이동, 출발역에서 중간역까지 테스트 노선을 이용합니다., '
-        '선택된 경로 edge:edge-a-b-local 근거로 안내합니다., '
-        '약 2분 · 830m, '
-        '시간 정적 추정, 거리 측정값, 높은 신뢰도, 근거 edge:edge-a-b-local',
-      ),
-    );
+    expect(semanticLabel, contains('선택한 경로 기준으로 안내합니다.'));
+    expect(semanticLabel, isNot(contains('edge:')));
+    expect(semanticLabel, isNot(contains('line:')));
+    expect(semanticLabel, isNot(contains('OFFICIAL_')));
+    expect(semanticLabel, isNot(contains('STATIC_ESTIMATE')));
+    expect(semanticLabel, isNot(contains('MEASURED')));
+    expect(semanticLabel, isNot(contains('정적 추정')));
+    expect(semanticLabel, isNot(contains('측정값')));
   });
 
   test('경로 단계 이동 부담은 긴 거리를 킬로미터로 표시한다', () {

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -359,11 +359,33 @@ void main() {
           distanceSource: 'MEASURED',
           confidenceLabel: '높은 신뢰도',
         ),
+        RouteSearchStep(
+          sequence: 2,
+          title: '도착역 출구 이동',
+          description: 'edge:exit-b line:test STATIC_ESTIMATE',
+          lineId: 'line-test',
+          lineName: '테스트 노선',
+          fromStationId: 'station-sadang',
+          toStationId: 'station-sadang',
+          estimatedMinutes: 1,
+          distanceMeters: 40,
+          includesStairs: false,
+          requiresAccessibilityCheck: true,
+          actionTitle: '출구 이동',
+          actionDetail: 'edge:exit-b line:test STATIC_ESTIMATE',
+          reason: 'OFFICIAL_FILE',
+          evidenceSources: ['edge:exit-b'],
+          timeSource: 'STATIC_ESTIMATE',
+          distanceSource: 'MEASURED',
+          confidenceLabel: '측정값',
+          stepType: 'exit',
+        ),
       ],
     );
 
     final semanticLabel = result.semanticLabel;
     expect(semanticLabel, contains('선택한 경로 기준으로 안내합니다.'));
+    expect(semanticLabel, contains('도착역에서 계단 없는 출구 동선을 확인합니다.'));
     expect(semanticLabel, isNot(contains('edge:')));
     expect(semanticLabel, isNot(contains('line:')));
     expect(semanticLabel, isNot(contains('OFFICIAL_')));

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -4969,10 +4969,7 @@ void main() {
       expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
       expect(find.text('약 4분 · 180m · 접근성 확인'), findsOneWidget);
       expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
-      expect(
-        find.text('접근성 시설 정보가 최근 확인되지 않았습니다.'),
-        findsOneWidget,
-      );
+      expect(find.text('접근성 시설 정보가 최근 확인되지 않았습니다.'), findsOneWidget);
 
       await tester.ensureVisible(
         find.byKey(const Key('routeStartGuidanceButton')),
@@ -6164,7 +6161,7 @@ void main() {
       expect(find.text('계단 없는 경로가 없습니다'), findsOneWidget);
       expect(find.text('추천 이유'), findsNothing);
       expect(find.text('엘리베이터 동선을 우선했어요'), findsNothing);
-      expect(find.text('휠체어로 이동 가능한 엘리베이터가 없습니다.'), findsOneWidget);
+      expect(find.text('안내 가능한 경로를 찾지 못했습니다.'), findsOneWidget);
       expect(find.text('이동 전 현장 안내와 역무원 안내를 확인해 주세요.'), findsOneWidget);
       expect(
         find.text('역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -4962,15 +4962,15 @@ void main() {
       expect(find.text('2번 출구의 엘리베이터를 먼저 확인하세요.'), findsOneWidget);
       expect(find.byKey(const Key('routeStepNumber-1')), findsOneWidget);
       expect(find.text('열차 이동'), findsOneWidget);
-      expect(
-        find.text('선택된 경로 edge:edge-sangnoksu-sadang 근거로 안내합니다.'),
-        findsOneWidget,
-      );
+      expect(find.text('선택한 경로 기준으로 안내합니다.'), findsOneWidget);
+      expect(find.textContaining('edge:'), findsNothing);
+      expect(find.textContaining('STATIC_ESTIMATE'), findsNothing);
+      expect(find.textContaining('MEASURED'), findsNothing);
       expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
       expect(find.text('약 4분 · 180m · 접근성 확인'), findsOneWidget);
       expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
       expect(
-        find.text('접근성 시설 정보가 최근 30일 이내 확인되지 않았습니다. 이동 전 역 상세 정보를 확인하세요.'),
+        find.text('접근성 시설 정보가 최근 확인되지 않았습니다.'),
         findsOneWidget,
       );
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -4959,14 +4959,14 @@ void main() {
       expect(find.text('추천 경로'), findsOneWidget);
       expect(find.text('이동 순서'), findsOneWidget);
       expect(find.text('도착 안내'), findsOneWidget);
-      expect(find.text('2번 출구의 엘리베이터를 먼저 확인하세요.'), findsOneWidget);
+      expect(find.text('도착역에서 계단 없는 출구 동선을 확인합니다.'), findsOneWidget);
       expect(find.byKey(const Key('routeStepNumber-1')), findsOneWidget);
       expect(find.text('열차 이동'), findsOneWidget);
       expect(find.text('선택한 경로 기준으로 안내합니다.'), findsOneWidget);
       expect(find.textContaining('edge:'), findsNothing);
       expect(find.textContaining('STATIC_ESTIMATE'), findsNothing);
       expect(find.textContaining('MEASURED'), findsNothing);
-      expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
+      expect(find.text('계단 없는 승강장 접근 동선을 확인해 이동합니다.'), findsOneWidget);
       expect(find.text('약 4분 · 180m · 접근성 확인'), findsOneWidget);
       expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
       expect(find.text('접근성 시설 정보가 최근 확인되지 않았습니다.'), findsOneWidget);
@@ -4979,7 +4979,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('단계별 안내'), findsOneWidget);
-      expect(find.text('상록수역에서 4호선 승강장으로 이동'), findsOneWidget);
+      expect(find.text('계단 없는 승강장 접근 동선을 확인해 이동합니다.'), findsOneWidget);
       expect(find.text('다음'), findsOneWidget);
       expect(
         find.byKey(const Key('routeOpenInternalRouteButton')),
@@ -8759,6 +8759,7 @@ RouteSearchResult _sampleRouteSearchResult({
             timeSource: 'STATIC_ESTIMATE',
             distanceSource: 'MEASURED',
             confidenceLabel: '높은 신뢰도',
+            stepType: 'entry',
           ),
           RouteSearchStep(
             sequence: 2,
@@ -8772,6 +8773,7 @@ RouteSearchResult _sampleRouteSearchResult({
             distanceMeters: 120,
             includesStairs: false,
             requiresAccessibilityCheck: true,
+            stepType: 'exit',
           ),
         ],
     warnings: const [


### PR DESCRIPTION
## 관련 이슈

close #809

## 작업 배경

- 경로 안내 화면과 음성 안내에서 `edge:`, `line:`, `STATIC_ESTIMATE`, `MEASURED` 같은 내부 식별자와 운영 출처 값이 그대로 노출될 수 있어 교통약자 사용자가 안내 의미를 이해하기 어렵다.
- 서버나 로컬 엔진이 가진 진단 값은 유지하되, 화면과 접근성 문구는 앱이 관리하는 사용자 문구로 변환해야 한다.

## 작업 내용

- 경로 추천 이유, 차단 사유, 경고 문구, 단계 설명을 화면/스크린리더용 안전 문구로 매핑했다.
- 내부 식별자나 운영 출처로 보이는 문자열은 `선택한 경로 기준으로 안내합니다.` 같은 사용자 문구로 대체했다.
- 로컬 경로 repository가 presentation 단계에 `edge:` 근거 값을 넘기지 않도록 정리했다.
- route/widget/local repository 테스트를 내부 식별자 미노출 기준으로 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/route_search_test.dart --plain-name "경로 검색 결과 음성 안내는 내부 식별자와 운영 출처 값을 읽지 않는다"`: 통과
  - `dart format apps/mobile/lib/route_search.dart apps/mobile/lib/features/routes/data/local_route_repository.dart apps/mobile/test/route_search_test.dart`: 통과
  - `flutter test test/route_search_test.dart test/features/routes/local_route_repository_test.dart`: 54 tests passed
  - `flutter test test/widget_test.dart`: 127 tests passed
  - `flutter test test/widget_test.dart --plain-name "경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다"`: 1 test passed
  - `flutter test test/widget_test.dart --plain-name "경로 검색 중에는 버튼을 비활성화하고 안내 불가 이유를 보여준다"`: 1 test passed
  - `flutter analyze`: No issues found
  - `cd backend && ./gradlew test --tests '*RouteSearchServiceTest'`: BUILD SUCCESSFUL
  - `flutter build apk --debug`: Built `build/app/outputs/flutter-apk/app-debug.apk`
  - `flutter build ios --simulator --debug`: Built `build/ios/iphonesimulator/Runner.app`
  - `git diff --check`: 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 경로 음성 안내 내부 식별자 차단 | Flutter test | `flutter test test/route_search_test.dart --plain-name "경로 검색 결과 음성 안내는 내부 식별자와 운영 출처 값을 읽지 않는다"` | 테스트 출력에서 `edge:`, `line:`, `OFFICIAL_`, `STATIC_ESTIMATE`, `MEASURED`, `정적 추정`, `측정값` 미포함 assertion 통과 | 통과 |
| 경로 상세 화면 내부 식별자 차단 | Flutter widget test | `flutter test test/widget_test.dart --plain-name "경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다"` | 상세 화면 텍스트에서 `edge:`, `STATIC_ESTIMATE`, `MEASURED` 미표시 assertion 통과 | 통과 |
| Android 빌드 | Android | `flutter build apk --debug` | `build/app/outputs/flutter-apk/app-debug.apk` 생성 | 통과 |
| iOS 빌드 | iOS simulator | `flutter build ios --simulator --debug` | `build/ios/iphonesimulator/Runner.app` 생성 | 통과 |
| Android 실기/에뮬레이터 UI 증거 | Android | `flutter emulators`, `adb devices`, `flutter devices` 확인 시도 | `flutter emulators`에서 `maum_on_api36` AVD를 확인했으나, `adb devices`와 `flutter devices` 실행은 승인 서비스 401로 차단되어 기기 UI 캡처를 진행하지 못했다. 대체 증거로 widget test와 Android debug build를 확인했다. | 대체 검증 완료, 실제 기기 UI 증거는 환경 승인 문제로 미수집 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteSearchResult.semanticLabel`과 `_RouteStepTile`이 raw `recommendationReasons`, `blockedReasons`, `warning.message`, `step.reason`, `evidenceSources`를 직접 표시하지 않는지 확인해 주세요.
  - 로컬 repository는 진단용 edge 근거를 UI 모델의 `evidenceSources`로 넘기지 않습니다.

## 리스크

- 추천 이유를 세부 서버 문장 대신 공통 사용자 문구로 축약해 안내 설명이 단순해진다. 내부 값 노출 차단을 우선하고, 세부 설명은 별도 사용자 문구 체계가 준비된 뒤 확장하는 것이 안전하다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
