### PR TITLE
[Fix] 노선도 확대와 역 좌표 선택 안정화

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -735,6 +735,7 @@ const _maxMapScale = 4.8;
 
 class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
   final TransformationController _controller = TransformationController();
+  final GlobalKey _mapContentKey = GlobalKey();
   String? _layoutKey;
 
   @override
@@ -792,6 +793,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
                   maxScale: _maxMapScale,
                   boundaryMargin: const EdgeInsets.all(220),
                   child: SizedBox(
+                    key: _mapContentKey,
                     width: geometry.width,
                     height: geometry.height,
                     child: Stack(
@@ -816,6 +818,19 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
                               ),
                             ),
                           ),
+                        Positioned.fill(
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.translucent,
+                            onTapUp: (details) {
+                              _openNearestStation(
+                                details.localPosition,
+                                widget.data.stations,
+                                stationLinesById,
+                                geometry,
+                              );
+                            },
+                          ),
+                        ),
                         for (final station in widget.data.stations)
                           Positioned.fromRect(
                             rect: _stationHitRect(station, geometry),
@@ -828,6 +843,22 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
                                 station,
                                 stationLinesById[station.id] ?? const [],
                               ),
+                              onTapUp: (details) {
+                                final renderObject = _mapContentKey
+                                    .currentContext
+                                    ?.findRenderObject();
+                                if (renderObject is! RenderBox) {
+                                  return;
+                                }
+                                _openNearestStation(
+                                  renderObject.globalToLocal(
+                                    details.globalPosition,
+                                  ),
+                                  widget.data.stations,
+                                  stationLinesById,
+                                  geometry,
+                                );
+                              },
                             ),
                           ),
                       ],
@@ -839,8 +870,8 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
                 right: 14,
                 top: 12,
                 child: _MapControls(
-                  onZoomIn: () => _scaleMap(1.25, minScale),
-                  onZoomOut: () => _scaleMap(0.8, minScale),
+                  onZoomIn: () => _scaleMap(1.25, minScale, constraints),
+                  onZoomOut: () => _scaleMap(0.8, minScale, constraints),
                   onOverview: () {
                     _controller.value = _mapTransformForBounds(
                       fullBounds,
@@ -865,7 +896,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
     );
   }
 
-  void _scaleMap(double factor, double minScale) {
+  void _scaleMap(double factor, double minScale, BoxConstraints constraints) {
     final currentScale = _controller.value.getMaxScaleOnAxis();
     if (currentScale <= 0) {
       return;
@@ -873,9 +904,36 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
     final targetScale = (currentScale * factor)
         .clamp(minScale, _maxMapScale)
         .toDouble();
-    final adjustedFactor = targetScale / currentScale;
-    _controller.value = Matrix4.copy(_controller.value)
-      ..scaleByDouble(adjustedFactor, adjustedFactor, 1, 1);
+    final viewportCenter = Offset(
+      (constraints.hasBoundedWidth ? constraints.maxWidth : 0) / 2,
+      (constraints.hasBoundedHeight ? constraints.maxHeight : 0) / 2,
+    );
+    final sceneCenter = MatrixUtils.transformPoint(
+      Matrix4.inverted(_controller.value),
+      viewportCenter,
+    );
+    _controller.value = Matrix4.identity()
+      ..translateByDouble(viewportCenter.dx, viewportCenter.dy, 0, 1)
+      ..scaleByDouble(targetScale, targetScale, 1, 1)
+      ..translateByDouble(-sceneCenter.dx, -sceneCenter.dy, 0, 1);
+  }
+
+  void _openNearestStation(
+    Offset mapPosition,
+    List<NetworkMapStation> stations,
+    Map<String, List<NetworkMapLine>> stationLinesById,
+    _MapGeometry geometry,
+  ) {
+    final station = _stationAtMapPosition(
+      mapPosition,
+      stations,
+      geometry,
+      selectedLineId: widget.selectedLineId,
+    );
+    if (station == null) {
+      return;
+    }
+    widget.onStationTap(station, stationLinesById[station.id] ?? const []);
   }
 }
 
@@ -1262,7 +1320,8 @@ class _MapGeometry {
   final double scaleX;
   final double scaleY;
 
-  static const _maxAndroidViewSurfaceExtent = 12000.0;
+  // Android WebView platform view는 큰 Surface에서 GL memory가 급증한다.
+  static const _maxAndroidViewSurfaceExtent = 4096.0;
 
   factory _MapGeometry.fromOriginalAsset(
     _RouteMapAsset asset,
@@ -1384,6 +1443,49 @@ Rect _stationHitRect(NetworkMapStation station, _MapGeometry geometry) {
   return node.expandToInclude(label);
 }
 
+NetworkMapStation? _stationAtMapPosition(
+  Offset position,
+  List<NetworkMapStation> stations,
+  _MapGeometry geometry, {
+  String? selectedLineId,
+}) {
+  NetworkMapStation? bestStation;
+  var bestScore = double.infinity;
+  for (final station in stations) {
+    final hitRect = _stationHitRect(station, geometry);
+    if (!hitRect.contains(position)) {
+      continue;
+    }
+    final score =
+        _stationTapScore(position, station, geometry) +
+        (selectedLineId != null && station.lineId != selectedLineId
+            ? 1000000
+            : 0);
+    if (score < bestScore) {
+      bestScore = score;
+      bestStation = station;
+    }
+  }
+  return bestStation;
+}
+
+double _stationTapScore(
+  Offset position,
+  NetworkMapStation station,
+  _MapGeometry geometry,
+) {
+  final nodeCenter = Offset(geometry.x(station), geometry.y(station));
+  final labelOffset = _labelOffsetFor(station);
+  final labelCenter = Offset(
+    nodeCenter.dx + labelOffset.dx * geometry.scaleX,
+    nodeCenter.dy + labelOffset.dy * geometry.scaleY,
+  );
+  return math.min(
+    (position - nodeCenter).distanceSquared,
+    (position - labelCenter).distanceSquared,
+  );
+}
+
 double _median(List<double> values) {
   if (values.isEmpty) {
     return 0;
@@ -1427,20 +1529,23 @@ class _StationHitTarget extends StatelessWidget {
   const _StationHitTarget({
     required this.station,
     required this.onTap,
+    required this.onTapUp,
     super.key,
   });
 
   final NetworkMapStation station;
   final VoidCallback onTap;
+  final GestureTapUpCallback onTapUp;
 
   @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
       label: station.displayName,
+      onTap: onTap,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: onTap,
+        onTapUp: onTapUp,
         child: const SizedBox.expand(),
       ),
     );

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -764,6 +764,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
               : _MapGeometry.fromOriginalAsset(
                   mapAsset,
                   View.of(context).devicePixelRatio,
+                  defaultTargetPlatform,
                 );
           final fullBounds = Rect.fromLTWH(
             0,
@@ -1326,14 +1327,14 @@ class _MapGeometry {
   factory _MapGeometry.fromOriginalAsset(
     _RouteMapAsset asset,
     double devicePixelRatio,
+    TargetPlatform platform,
   ) {
     final safeDevicePixelRatio = devicePixelRatio <= 0 ? 1.0 : devicePixelRatio;
     final maxLogicalExtent =
         _maxAndroidViewSurfaceExtent / safeDevicePixelRatio;
-    final displayScale = math.min(
-      1.0,
-      maxLogicalExtent / math.max(asset.width, asset.height),
-    );
+    final displayScale = platform == TargetPlatform.android
+        ? math.min(1.0, maxLogicalExtent / math.max(asset.width, asset.height))
+        : 1.0;
     final displayWidth = asset.width * displayScale;
     final displayHeight = asset.height * displayScale;
     return _MapGeometry(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -960,6 +960,107 @@ void main() {
     expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
   });
 
+  testWidgets('노선도 역 좌표가 겹쳐도 탭한 위치에서 가장 가까운 역을 선택한다', (tester) async {
+    final repository = FakeStationSearchRepository(
+      networkMapData: const NetworkMapData(
+        regions: [NetworkMapRegion(name: '테스트권')],
+        selectedRegion: '테스트권',
+        lines: [
+          NetworkMapLine(
+            id: 'seoul-6',
+            name: '수도권 6호선',
+            color: '#CD7C2F',
+            region: '테스트권',
+          ),
+          NetworkMapLine(
+            id: 'gtx-a',
+            name: '수도권 GTX-A',
+            color: '#9A4DA3',
+            region: '테스트권',
+          ),
+        ],
+        stations: [
+          NetworkMapStation(
+            id: 'station-gusan',
+            nameKo: '구산',
+            nameEn: 'Gusan',
+            region: '테스트권',
+            lineId: 'seoul-6',
+            stationCode: '615',
+            sequence: 6,
+            position: NetworkMapPosition(
+              x: 390,
+              y: 320,
+              labelDx: 0,
+              labelDy: 0,
+              upPath: '',
+              downPath: '',
+              sourceId: 'qa-wikimedia-seoul-svg-coordinate',
+            ),
+          ),
+          NetworkMapStation(
+            id: 'station-yeonsinnae',
+            nameKo: '연신내',
+            nameEn: 'Yeonsinnae',
+            region: '테스트권',
+            lineId: 'gtx-a',
+            stationCode: 'X615',
+            sequence: 7,
+            position: NetworkMapPosition(
+              x: 410,
+              y: 320,
+              labelDx: 0,
+              labelDy: 0,
+              upPath: '',
+              downPath: '',
+              sourceId: 'qa-wikimedia-seoul-svg-coordinate',
+            ),
+          ),
+        ],
+        edges: [],
+        positionSources: [
+          NetworkMapPositionSource(
+            id: 'qa-wikimedia-seoul-svg-coordinate',
+            name: '수도권 SVG 좌표',
+            licenseStatus: 'reviewed',
+          ),
+        ],
+        stationLineMemberships: [
+          NetworkMapStationLineMembership(
+            stationId: 'station-gusan',
+            lineId: 'seoul-6',
+          ),
+          NetworkMapStationLineMembership(
+            stationId: 'station-yeonsinnae',
+            lineId: 'gtx-a',
+          ),
+        ],
+      ),
+    );
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('bottomNavMap')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('networkMapStation-gusan-seoul-6')),
+      warnIfMissed: false,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
+    expect(find.text('구산역'), findsOneWidget);
+    expect(find.text('연신내역'), findsNothing);
+  });
+
   testWidgets('홈 화면은 v3 기준 큰 행동과 짧은 상태 카드로 구성된다', (tester) async {
     await tester.pumpWidget(
       EasySubwayApp(
@@ -7822,6 +7923,7 @@ class FakeStationSearchRepository
     this.queryResults = const {},
     this.lineOptions = const [],
     this.networkMapRegionNames = const ['테스트권'],
+    this.networkMapData,
     this.searchCompleter,
     StationDetail? stationDetail,
     this.stationExits = const [],
@@ -7835,6 +7937,7 @@ class FakeStationSearchRepository
   final Map<String, List<StationSearchResult>> queryResults;
   final List<SubwayLineOption> lineOptions;
   final List<String> networkMapRegionNames;
+  final NetworkMapData? networkMapData;
   final Completer<List<StationSearchResult>>? searchCompleter;
   final StationDetail stationDetail;
   final List<StationExitInfo> stationExits;
@@ -7912,6 +8015,10 @@ class FakeStationSearchRepository
   Future<NetworkMapData> getNetworkMap({String? region, String? lineId}) async {
     requestedNetworkMapRegions.add(region);
     requestedNetworkMapLineIds.add(lineId);
+    final customMapData = networkMapData;
+    if (customMapData != null) {
+      return customMapData;
+    }
     final selectedRegion = region ?? networkMapRegionNames.first;
     const lines = [
       NetworkMapLine(


### PR DESCRIPTION
## 관련 이슈

close #816

## 작업 배경

Android 실기기에서 수도권 SVG 노선도 진입 시 WebView Surface가 과도하게 커져 Graphics 메모리가 급증했고, 확대 후 앱이 종료되는 문제가 있었다. PNG 변환은 확대 품질과 지역별 노선 색상 보존에 문제가 있어 제외하고, SVG 렌더링은 유지한 채 Surface 크기와 Flutter 확대/역 선택 로직을 조정했다.

## 작업 내용

- Android WebView platform view의 최대 논리 크기를 낮춰 SVG Surface 메모리 폭증을 제한했다.
- 확대/축소 버튼이 화면 중앙을 기준으로 동작하게 바꿔 반복 조작 후 노선도가 화면 밖으로 밀리지 않게 했다.
- 역 hit-test를 Stack 순서가 아니라 터치 좌표에서 가장 가까운 역 기준으로 바꿨다.
- 구산/불광/독바위가 연신내로 열리는 회귀를 막는 widget test를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && dart format lib/network_map.dart test/widget_test.dart`: exit 0
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name '노선도'`: exit 0, 8 tests passed
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `cd apps/mobile && flutter build apk --debug`: exit 0
  - `cd apps/mobile && flutter build ios --simulator --debug`: exit 0
  - `cd apps/mobile && flutter test test/widget_test.dart`: exit 0, 128 tests passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| SVG 노선도 진입 | Android SM A175N | APK 설치 후 노선도 탭 진입 | 로컬: `.codex/evidence/816-svg-hit-test-current/android-map.png` | SVG 선/글자 유지 |
| 확대/축소 안정성 | Android SM A175N | 확대 10회, 축소 10회 후 screenshot/pid/meminfo/logcat 확인 | 로컬: `.codex/evidence/816-svg-hit-test-current/android-after-zoom.png`, `android-after-zoom-pid.txt`, `android-after-zoom-meminfo.txt`, `android-after-zoom-logcat.txt` | pid `28248`, Graphics `439718KB`, WebViews `1`, FATAL/lowmemorykiller 없음 |
| 구산/불광/독바위 좌표 회귀 | Local data audit | 수도권 좌표에서 기존 Stack winner와 nearest winner 비교 | 명령 출력: 구산/불광/독바위는 기존 Stack 기준 `연신내`, 변경 후 nearest 기준 자기 역 | QA 지적 케이스 해결 확인 |
| 전체 widget 회귀 | Flutter test | `flutter test test/widget_test.dart` | command output | 128 tests passed |
| iOS 노선도 진입 | iOS Simulator Maum iPhone 17 | `flutter build ios --simulator --debug`, install, launch, 노선도 탭, screenshot | 로컬: `.codex/evidence/816-svg-hit-test-current/ios/ios-route-map.jpg` | SVG 노선도 표시 및 역 접근성 타겟 노출 |

스크린샷은 repo 정책상 git에 커밋하지 않았다. 현재 CLI 경로에서는 PR에 이미지 바이너리를 직접 첨부할 수 없어 로컬 전용 증거로 보관했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/network_map.dart`의 `_scaleMap`, `_stationAtMapPosition`, `_StationHitTarget`
- 전체 좌표 감사에서 동일 좌표/역명 변형/환승 데이터로 보이는 44개 모호 케이스가 남았다. 이번 변경은 QA가 지적한 구산/불광/독바위의 연신내 오판과 확대 crash를 막는 앱 로직 수정이다.

## 리스크

- Android WebView Surface 상한을 낮춰 메모리를 줄였기 때문에 아주 큰 화면이나 고배율 디스플레이에서 SVG 세부 선명도와 메모리 사이의 균형을 추가 확인할 수 있다.
- 동일 좌표에 다른 station id가 들어간 데이터는 앱 hit-test만으로 완전히 구분할 수 없어 별도 데이터팩 좌표 정리가 필요하다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
