### PR TITLE
[Fix] 확인되지 않은 계단·엘리베이터 상태 확정 표시 제거

### DIFF
--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -57,6 +57,7 @@ class LocalRouteEngine {
           lineId: edge.lineId,
           transferStationId: _transferStationId(edge),
           includesStairs: edge.includesStairs,
+          stairAccessState: edge.stairAccessState.name,
           evidenceSources: _evidenceSources(edge),
           timeSource: edge.durationSeconds > 0 ? 'STATIC_ESTIMATE' : 'UNKNOWN',
           distanceSource: edge.distanceMeters > 0 ? 'MEASURED' : 'UNKNOWN',

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -96,6 +96,7 @@ class LocalRouteRepository implements RouteSearchRepository {
             estimatedMinutes: _estimatedMinutesFor(step.durationSeconds),
             distanceMeters: step.distanceMeters,
             includesStairs: step.includesStairs,
+            stairAccessState: step.stairAccessState,
             requiresAccessibilityCheck:
                 step.type.name == 'entry' || step.type.name == 'exit',
             actionTitle: _stepActionTitle(step.type.name),

--- a/apps/mobile/lib/features/routes/domain/route_step.dart
+++ b/apps/mobile/lib/features/routes/domain/route_step.dart
@@ -13,6 +13,7 @@ class RouteStep {
     this.lineId = '',
     this.transferStationId = '',
     this.includesStairs = false,
+    this.stairAccessState = 'unknown',
     this.evidenceSources = const [],
     this.timeSource = 'UNKNOWN',
     this.distanceSource = 'UNKNOWN',
@@ -30,6 +31,7 @@ class RouteStep {
   final String lineId;
   final String transferStationId;
   final bool includesStairs;
+  final String stairAccessState;
   final List<String> evidenceSources;
   final String timeSource;
   final String distanceSource;

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -634,6 +634,17 @@ class RouteSearchResult {
     return blockedReasons.map(_routeBlockedReasonLabel).toList(growable: false);
   }
 
+  String get stairAccessLabel {
+    if (steps.any((step) => _routeStepStairState(step) == 'stairOnly')) {
+      return '계단 포함';
+    }
+    if (steps.isNotEmpty &&
+        steps.every((step) => _routeStepStairState(step) == 'stepFree')) {
+      return '계단 없음 확인';
+    }
+    return '계단 여부 확인 필요';
+  }
+
   int get walkingDistanceMeters {
     return steps.fold<int>(
       0,
@@ -740,6 +751,7 @@ class RouteSearchResult {
       summaryTitle,
       lineLabel,
       comfortLabel,
+      stairAccessLabel,
     ];
     if (!isBlocked && warnings.isNotEmpty) {
       parts.add(attentionLabel);
@@ -791,6 +803,7 @@ class RouteSearchStep {
     required this.estimatedMinutes,
     required this.distanceMeters,
     required this.includesStairs,
+    this.stairAccessState = '',
     required this.requiresAccessibilityCheck,
     this.actionTitle = '',
     this.actionDetail = '',
@@ -804,6 +817,7 @@ class RouteSearchStep {
   factory RouteSearchStep.fromJson(Map<String, Object?> json) {
     final title = _requiredRouteString(json, 'title');
     final description = _requiredRouteString(json, 'description');
+    final includesStairs = _requiredRouteBool(json, 'includesStairs');
     return RouteSearchStep(
       sequence: _requiredRouteInt(json, 'sequence'),
       stepType: _optionalRouteString(json, 'stepType'),
@@ -815,7 +829,11 @@ class RouteSearchStep {
       toStationId: _optionalRouteString(json, 'toStationId'),
       estimatedMinutes: _requiredRouteInt(json, 'estimatedMinutes'),
       distanceMeters: _requiredRouteInt(json, 'distanceMeters'),
-      includesStairs: _requiredRouteBool(json, 'includesStairs'),
+      includesStairs: includesStairs,
+      stairAccessState: _routeStepStairAccessStateFromJson(
+        json,
+        includesStairs,
+      ),
       requiresAccessibilityCheck: _requiredRouteBool(
         json,
         'requiresAccessibilityCheck',
@@ -846,6 +864,7 @@ class RouteSearchStep {
   final int estimatedMinutes;
   final int distanceMeters;
   final bool includesStairs;
+  final String stairAccessState;
   final bool requiresAccessibilityCheck;
   final String actionTitle;
   final String actionDetail;
@@ -2669,11 +2688,7 @@ class _RouteDetailWorkflowView extends StatelessWidget {
         _RouteDarkSummaryCard(
           title: totalMinutes > 0 ? '$totalMinutes분' : result.statusLabel,
           subtitle: meta,
-          chips: [
-            result.comfortLabel,
-            if (_routeHasNoStairs(result)) '계단 없음',
-            '엘리베이터 이용',
-          ],
+          chips: [result.comfortLabel, result.stairAccessLabel],
         ),
         const SizedBox(height: 16),
         _RouteStepSection(steps: result.movementSteps),
@@ -3074,7 +3089,7 @@ class _RouteInternalWorkflowView extends StatelessWidget {
           title:
               '${result.originStationName} → ${result.lineName.isEmpty ? '승강장' : result.lineName}',
           subtitle: _routeMetaLabel(result),
-          chips: const ['계단 없음', '엘리베이터 이용'],
+          chips: [result.stairAccessLabel],
         ),
         const SizedBox(height: 14),
         _RouteSectionHeader(title: '역 안 이동 순서'),
@@ -3330,10 +3345,8 @@ class _RouteResultListButton extends StatelessWidget {
                           icon: Icons.accessible_forward,
                         ),
                         _RoutePrototypeChip(
-                          label: _routeHasNoStairs(result) ? '계단 없음' : '계단 있음',
-                          icon: _routeHasNoStairs(result)
-                              ? Icons.check
-                              : Icons.stairs_outlined,
+                          label: result.stairAccessLabel,
+                          icon: _routeStairAccessIcon(result),
                         ),
                       ],
                     ),
@@ -3465,8 +3478,38 @@ String _routeWorkflowSummarySubtitle(RouteSearchResult result) {
       : result.statusLabel;
 }
 
-bool _routeHasNoStairs(RouteSearchResult result) {
-  return result.steps.every((step) => !step.includesStairs);
+IconData _routeStairAccessIcon(RouteSearchResult result) {
+  return switch (result.stairAccessLabel) {
+    '계단 없음 확인' => Icons.check,
+    '계단 포함' => Icons.stairs_outlined,
+    _ => Icons.help_outline,
+  };
+}
+
+String _routeStepStairAccessStateFromJson(
+  Map<String, Object?> json,
+  bool includesStairs,
+) {
+  final raw = _optionalRouteString(json, 'stairAccessState');
+  if (raw.isEmpty) {
+    return includesStairs ? 'stairOnly' : 'unknown';
+  }
+  return _normalizeRouteStairState(raw);
+}
+
+String _routeStepStairState(RouteSearchStep step) {
+  if (step.includesStairs) {
+    return 'stairOnly';
+  }
+  return _normalizeRouteStairState(step.stairAccessState);
+}
+
+String _normalizeRouteStairState(String value) {
+  return switch (value.trim().toUpperCase()) {
+    'STEP_FREE' || 'STEPFREE' => 'stepFree',
+    'STAIR_ONLY' || 'STAIRONLY' => 'stairOnly',
+    _ => 'unknown',
+  };
 }
 
 class _RoutePrototypeSection extends StatelessWidget {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2688,7 +2688,13 @@ class _RouteDetailWorkflowView extends StatelessWidget {
         _RouteDarkSummaryCard(
           title: totalMinutes > 0 ? '$totalMinutes분' : result.statusLabel,
           subtitle: meta,
-          chips: [result.comfortLabel, result.stairAccessLabel],
+          chips: [
+            _RouteSummaryChip(label: result.comfortLabel),
+            _RouteSummaryChip(
+              label: result.stairAccessLabel,
+              icon: _routeStairAccessIcon(result),
+            ),
+          ],
         ),
         const SizedBox(height: 16),
         _RouteStepSection(steps: result.movementSteps),
@@ -3089,7 +3095,12 @@ class _RouteInternalWorkflowView extends StatelessWidget {
           title:
               '${result.originStationName} → ${result.lineName.isEmpty ? '승강장' : result.lineName}',
           subtitle: _routeMetaLabel(result),
-          chips: [result.stairAccessLabel],
+          chips: [
+            _RouteSummaryChip(
+              label: result.stairAccessLabel,
+              icon: _routeStairAccessIcon(result),
+            ),
+          ],
         ),
         const SizedBox(height: 14),
         _RouteSectionHeader(title: '역 안 이동 순서'),
@@ -3370,7 +3381,7 @@ class _RouteDarkSummaryCard extends StatelessWidget {
 
   final String title;
   final String subtitle;
-  final List<String> chips;
+  final List<_RouteSummaryChip> chips;
 
   @override
   Widget build(BuildContext context) {
@@ -3399,7 +3410,11 @@ class _RouteDarkSummaryCard extends StatelessWidget {
               runSpacing: 6,
               children: [
                 for (final chip in chips)
-                  _RoutePrototypeChip(label: chip, icon: Icons.check),
+                  _RoutePrototypeChip(
+                    key: Key('routeDarkSummaryChip-${chip.label}'),
+                    label: chip.label,
+                    icon: chip.icon,
+                  ),
               ],
             ),
           ],
@@ -3583,6 +3598,13 @@ class _RoutePrototypeChip extends StatelessWidget {
       ),
     );
   }
+}
+
+class _RouteSummaryChip {
+  const _RouteSummaryChip({required this.label, this.icon = Icons.check});
+
+  final String label;
+  final IconData icon;
 }
 
 class _RoutePrototypeLinePath extends StatelessWidget {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -3293,7 +3293,7 @@ class _RouteResultListButton extends StatelessWidget {
     return Semantics(
       button: true,
       label:
-          '${result.summaryTitle}, ${_routeMetaLabel(result)}, ${result.comfortLabel}',
+          '${result.summaryTitle}, ${_routeMetaLabel(result)}, ${result.comfortLabel}, ${result.stairAccessLabel}',
       onTap: onPressed,
       child: ExcludeSemantics(
         child: Material(

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -449,6 +449,32 @@ void main() {
     expect(step.burdenLabel, '시간 확인 필요 · 180m');
   });
 
+  test('경로 계단 상태는 unknown을 계단 없음으로 올리지 않는다', () {
+    final result = _sampleRouteSearchResult(
+      steps: const [
+        RouteSearchStep(
+          sequence: 1,
+          stepType: 'entry',
+          title: '출발역 승강장 접근',
+          description: '승강장까지 이동합니다.',
+          lineId: 'seoul-4',
+          lineName: '수도권 4호선',
+          fromStationId: 'station-sangnoksu',
+          toStationId: 'station-sangnoksu',
+          estimatedMinutes: 3,
+          distanceMeters: 80,
+          includesStairs: false,
+          stairAccessState: 'unknown',
+          requiresAccessibilityCheck: true,
+        ),
+      ],
+    );
+
+    expect(result.stairAccessLabel, '계단 여부 확인 필요');
+    expect(result.semanticLabel, contains('계단 여부 확인 필요'));
+    expect(result.semanticLabel, isNot(contains('계단 없음')));
+  });
+
   test('경로 요약 사실값은 열차 거리와 환승 문구에 의존하지 않는다', () {
     final result = _sampleRouteSearchResult(
       steps: const [

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5704,13 +5704,14 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('routeResultListItem')), findsOneWidget);
+      final routeItemSemantics = tester
+          .getSemantics(find.byKey(const Key('routeResultListItem')))
+          .getSemanticsData();
       expect(
-        tester
-            .getSemantics(find.byKey(const Key('routeResultListItem')))
-            .getSemanticsData()
-            .hasAction(SemanticsAction.tap),
+        routeItemSemantics.hasAction(SemanticsAction.tap),
         isTrue,
       );
+      expect(routeItemSemantics.label, contains('계단 여부 확인 필요'));
     } finally {
       semanticsHandle.dispose();
     }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -4973,6 +4973,24 @@ void main() {
       expect(find.text('약 4분 · 180m · 접근성 확인'), findsOneWidget);
       expect(find.text('일부 시설 정보는 확인이 필요합니다.'), findsOneWidget);
       expect(find.text('접근성 시설 정보가 최근 확인되지 않았습니다.'), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byKey(
+            const Key('routeDarkSummaryChip-계단 여부 확인 필요'),
+          ),
+          matching: find.byIcon(Icons.help_outline),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: find.byKey(
+            const Key('routeDarkSummaryChip-계단 여부 확인 필요'),
+          ),
+          matching: find.byIcon(Icons.check),
+        ),
+        findsNothing,
+      );
 
       await tester.ensureVisible(
         find.byKey(const Key('routeStartGuidanceButton')),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -4939,6 +4939,9 @@ void main() {
       expect(find.text('환승 적은 순'), findsOneWidget);
       expect(find.text('상록수 → 사당'), findsOneWidget);
       expect(find.text('계단 피하기 · 환승 줄이기'), findsWidgets);
+      expect(find.text('계단 여부 확인 필요'), findsWidgets);
+      expect(find.text('계단 없음'), findsNothing);
+      expect(find.text('엘리베이터 이용'), findsNothing);
       expect(find.text('7분'), findsOneWidget);
       expect(find.text('환승 없음 · 걷기 300m'), findsOneWidget);
       expect(find.text('추천'), findsOneWidget);

--- a/backend/src/main/java/com/easysubway/route/domain/RouteStep.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteStep.java
@@ -12,8 +12,46 @@ public record RouteStep(
 	int estimatedMinutes,
 	int distanceMeters,
 	boolean includesStairs,
+	String stairAccessState,
 	boolean requiresAccessibilityCheck
 ) {
+	public RouteStep {
+		stairAccessState = stairAccessState == null || stairAccessState.isBlank()
+			? stairAccessStateFor(includesStairs)
+			: stairAccessState;
+	}
+
+	public RouteStep(
+		int sequence,
+		String stepType,
+		String title,
+		String description,
+		String lineId,
+		String lineName,
+		String fromStationId,
+		String toStationId,
+		int estimatedMinutes,
+		int distanceMeters,
+		boolean includesStairs,
+		boolean requiresAccessibilityCheck
+	) {
+		this(
+			sequence,
+			stepType,
+			title,
+			description,
+			lineId,
+			lineName,
+			fromStationId,
+			toStationId,
+			estimatedMinutes,
+			distanceMeters,
+			includesStairs,
+			stairAccessStateFor(includesStairs),
+			requiresAccessibilityCheck
+		);
+	}
+
 	public RouteStep(
 		int sequence,
 		String title,
@@ -41,5 +79,9 @@ public record RouteStep(
 			includesStairs,
 			requiresAccessibilityCheck
 		);
+	}
+
+	private static String stairAccessStateFor(boolean includesStairs) {
+		return includesStairs ? "STAIR_ONLY" : "UNKNOWN";
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -91,6 +91,7 @@ class RouteSearchServiceTest {
 		assertThat(result.steps().get(0).estimatedMinutes()).isEqualTo(4);
 		assertThat(result.steps().get(0).distanceMeters()).isEqualTo(180);
 		assertThat(result.steps().get(0).includesStairs()).isFalse();
+		assertThat(result.steps().get(0).stairAccessState()).isEqualTo("UNKNOWN");
 		assertThat(result.steps().get(0).requiresAccessibilityCheck()).isTrue();
 		assertThat(result.steps().get(1).estimatedMinutes()).isGreaterThan(0);
 		assertThat(result.steps().get(1).requiresAccessibilityCheck()).isFalse();
@@ -359,6 +360,9 @@ class RouteSearchServiceTest {
 		assertThat(stairOnlyResult.steps().get(0).includesStairs()).isTrue();
 		assertThat(stairOnlyResult.steps().get(1).includesStairs()).isFalse();
 		assertThat(stairOnlyResult.steps().get(2).includesStairs()).isTrue();
+		assertThat(stairOnlyResult.steps())
+			.extracting("stairAccessState")
+			.containsExactly("STAIR_ONLY", "UNKNOWN", "STAIR_ONLY");
 		assertThat(stairOnlyResult.score()).isGreaterThan(accessibleResult.score());
 	}
 


### PR DESCRIPTION
## 관련 이슈

close #810

## 작업 배경

- 경로 결과에서 계단 여부가 확인되지 않은 구간까지 `계단 없음` 또는 `엘리베이터 이용`처럼 확정된 접근성 상태로 보일 수 있어 QA 요청에 따라 표시 계약을 분리했다.
- `includesStairs=false`는 계단이 없다는 확인값이 아니라 계단 포함 플래그가 없다는 값이므로, 별도 `stairAccessState`가 `STEP_FREE`로 확인된 경우에만 무계단 확인 문구를 표시해야 한다.

## 작업 내용

- 모바일 경로 단계에 `stairAccessState`를 전달하고, 경로 요약/상세/목록 칩과 스크린리더 라벨을 `계단 포함`, `계단 없음 확인`, `계단 여부 확인 필요` 3상태로 표시했다.
- 경로 상세의 고정 긍정 칩 `엘리베이터 이용`을 제거하고, 확인되지 않은 경로는 `계단 여부 확인 필요`로 노출하도록 바꿨다.
- 백엔드 `RouteStep` API 응답에 `stairAccessState`를 추가하고, 기존 `includesStairs=false` 기본값은 `UNKNOWN`, 계단 전용 구간은 `STAIR_ONLY`로 내보내도록 했다.
- 기존 API/저장소 생성자 호출은 유지해 저장소 테스트와 기존 JSON 역직렬화가 깨지지 않도록 했다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests '*RouteSearchServiceTest'`: BUILD SUCCESSFUL
  - `cd backend && ./gradlew test`: BUILD SUCCESSFUL
  - `cd apps/mobile && flutter test test/route_search_test.dart test/features/routes/local_route_repository_test.dart`: 55 tests passed
  - `cd apps/mobile && flutter test test/widget_test.dart`: 128 tests passed
  - `cd apps/mobile && flutter analyze`: No issues found
  - `cd apps/mobile && flutter build apk --debug`: Built `build/app/outputs/flutter-apk/app-debug.apk`
  - `cd apps/mobile && flutter build ios --simulator --debug`: Built `build/ios/iphonesimulator/Runner.app`
  - `git diff --check`: 통과
  - GitHub Actions `CI`: Changes, Repository CI, Dependency Vulnerability Scan / osv-scan, Backend CI, Mobile App CI, Android CI 모두 success
  - GitHub Actions `Release Artifacts`: Changes, Android Release Artifact, Backend Release Image 모두 success
  - CodeRabbit: rate limit/credit exhausted로 실제 리뷰 미시작 확인
  - Codex CLI fallback review: actionable 2건 게시 후 수정/답글/resolve, 최종 재리뷰 actionable 0건

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 미확인 계단 상태 표시 | Flutter widget test | 경로 검색 화면에서 `계단 여부 확인 필요`가 보이고 `계단 없음`, `엘리베이터 이용`이 사라지는지 확인 | `flutter test test/widget_test.dart` 출력, 128 tests passed | 통과 |
| API/로컬 경로 상태 계약 | Backend/Flutter unit test | `UNKNOWN`은 무계단으로 승격하지 않고 `STAIR_ONLY`와 구분되는지 확인 | `./gradlew test`, `flutter test test/route_search_test.dart test/features/routes/local_route_repository_test.dart` 출력 | 통과 |
| Android 앱 실행 | Android 실기기 `RFKYA01VMQY` | debug APK 설치 후 앱 실행, 홈 화면 캡처와 UI tree 저장 | 로컬 전용: `.codex/evidence/810/android-home.png`, `.codex/evidence/810/android-home.xml` | 설치/실행/캡처 성공 |
| Android/AVD 확인 | Android SDK | `flutter emulators`, SDK `emulator -list-avds`, `flutter devices`, `adb devices` 확인 | `maum_on_api36` AVD 및 Android 실기기 `RFKYA01VMQY` 확인 | 통과 |
| iOS 빌드 | iOS Simulator | simulator debug build | `flutter build ios --simulator --debug` 출력 | 통과 |

Android 화면 캡처는 QA 로컬 실기기 상태 표시줄과 기기 상태가 포함되어 git/PR에 직접 첨부하지 않고 로컬 evidence 폴더에 보관했다. 경로 결과 문구 자체는 widget test에서 직접 검증했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteSearchResult.stairAccessLabel`이 `UNKNOWN`을 `계단 없음 확인`으로 올리지 않는지 확인해 주세요.
  - 백엔드 `RouteStep`의 기존 생성자 호환성과 신규 `stairAccessState` 기본값을 확인해 주세요.

## 리스크

- 기존 저장 경로 JSON에 `stairAccessState`가 없으면 이제 보수적으로 `계단 여부 확인 필요`로 표시된다. 확인된 무계단 정보가 없는 데이터에 대한 안전한 후퇴 동작이다.
- Android 실기기에서는 앱 실행 smoke까지 확인했고, 경로 결과 상세 화면은 자동 widget test로 문구를 검증했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
