### PR TITLE
[Fix] 역·시설 상태 문구 사용자 행동 중심 정리

### DIFF
--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -279,13 +279,16 @@ class FavoriteFacility {
 
   int get statusPriority => statusPresentation.priority;
 
+  String get verificationStatusLabel =>
+      _facilityVerificationStatusLabel(dataConfidence);
+
   String get confidenceLabel => _dataConfidenceLabel(dataConfidence);
 
   String get dataSourceLabel => _dataSourceLabel(dataSourceType);
 
   String get locationLabel {
     if (description.trim().isNotEmpty) {
-      return description;
+      return _facilityUserLocationLabel(description);
     }
     if (floorFrom.trim().isNotEmpty && floorTo.trim().isNotEmpty) {
       return '$floorFrom-$floorTo';
@@ -295,13 +298,8 @@ class FavoriteFacility {
 
   String get updatedLabel => '최근 확인 $lastUpdatedAt';
 
-  String get semanticLabel {
-    final statusSemanticLabel = facilityStatusSemanticLabel(
-      statusLabel: statusLabel,
-      severityLabel: severityLabel,
-    );
-    return '즐겨찾기 시설, $name, $stationLabel, $typeLabel, $statusSemanticLabel, $locationLabel, $updatedLabel, $confidenceLabel, $dataSourceLabel, 다음 행동 $nextActionLabel';
-  }
+  String get semanticLabel =>
+      '즐겨찾기 시설, $name, $stationLabel, $typeLabel, $statusTitle, $locationLabel, $updatedLabel, $verificationStatusLabel, 다음 행동 $nextActionLabel';
 }
 
 enum FavoriteFacilityListStatus { loading, success, empty, failure }
@@ -637,7 +635,7 @@ class _FavoriteFacilityTile extends StatelessWidget {
                       ),
                       const SizedBox(height: 6),
                       Text(
-                        favorite.statusLabel,
+                        favorite.statusTitle,
                         style: textTheme.bodyMedium?.copyWith(
                           color: const Color(0xFF405A5D),
                           height: 1.3,
@@ -670,15 +668,7 @@ class _FavoriteFacilityTile extends StatelessWidget {
                       ),
                       const SizedBox(height: 4),
                       Text(
-                        favorite.confidenceLabel,
-                        style: textTheme.bodyMedium?.copyWith(
-                          color: const Color(0xFF405A5D),
-                          height: 1.3,
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        favorite.dataSourceLabel,
+                        favorite.verificationStatusLabel,
                         style: textTheme.bodyMedium?.copyWith(
                           color: const Color(0xFF405A5D),
                           height: 1.3,
@@ -750,6 +740,28 @@ String _dataConfidenceLabel(String dataConfidence) {
     'LOW' => '정보 확인 필요',
     _ => '정보 확인 필요',
   };
+}
+
+String _facilityVerificationStatusLabel(String dataConfidence) {
+  return switch (dataConfidence.trim().toUpperCase()) {
+    'HIGH' || 'MEDIUM' => '시설 상태 확인됨',
+    _ => '상태 확인 필요',
+  };
+}
+
+String _facilityUserLocationLabel(String description) {
+  var label = description.trim();
+  const internalValidationPhrases = [
+    '현장 검증됨',
+    '현장 검증 전',
+    '현장 재확인 필요',
+    '관리자 검수',
+  ];
+  for (final phrase in internalValidationPhrases) {
+    label = label.replaceAll(phrase, '');
+  }
+  label = label.replaceAll(RegExp(r'\s+'), ' ').trim();
+  return label.isEmpty ? '위치 확인 필요' : label;
 }
 
 String _dataSourceLabel(String dataSourceType) {

--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -295,7 +295,10 @@ class FavoriteFacility {
 
   String get locationLabel {
     if (description.trim().isNotEmpty) {
-      return _facilityUserLocationLabel(description);
+      final descriptionLabel = _facilityUserLocationLabel(description);
+      if (descriptionLabel.isNotEmpty) {
+        return descriptionLabel;
+      }
     }
     if (floorFrom.trim().isNotEmpty && floorTo.trim().isNotEmpty) {
       return '$floorFrom-$floorTo';
@@ -781,7 +784,7 @@ String _facilityUserLocationLabel(String description) {
     label = label.replaceAll(phrase, '');
   }
   label = label.replaceAll(RegExp(r'\s+'), ' ').trim();
-  return label.isEmpty ? '위치 확인 필요' : label;
+  return label;
 }
 
 String _dataSourceLabel(String dataSourceType) {

--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -189,6 +189,7 @@ class FavoriteFacility {
     required this.status,
     required this.dataConfidence,
     this.dataSourceType = '',
+    this.fieldValidationStatus = 'UNKNOWN',
     required this.lastUpdatedAt,
     required this.addedAt,
   });
@@ -209,6 +210,11 @@ class FavoriteFacility {
       status: _requiredString(json, 'status'),
       dataConfidence: _requiredString(json, 'dataConfidence'),
       dataSourceType: _stringOrEmpty(json, 'dataSourceType'),
+      fieldValidationStatus: _stringOrDefault(
+        json,
+        'fieldValidationStatus',
+        'UNKNOWN',
+      ),
       lastUpdatedAt: _requiredString(json, 'lastUpdatedAt'),
       addedAt: _requiredString(json, 'addedAt'),
     );
@@ -228,6 +234,7 @@ class FavoriteFacility {
   final String status;
   final String dataConfidence;
   final String dataSourceType;
+  final String fieldValidationStatus;
   final String lastUpdatedAt;
   final String addedAt;
 
@@ -280,7 +287,7 @@ class FavoriteFacility {
   int get statusPriority => statusPresentation.priority;
 
   String get verificationStatusLabel =>
-      _facilityVerificationStatusLabel(dataConfidence);
+      _facilityVerificationStatusLabel(fieldValidationStatus);
 
   String get confidenceLabel => _dataConfidenceLabel(dataConfidence);
 
@@ -733,6 +740,18 @@ String _stringOrEmpty(Map<String, Object?> json, String key) {
   return value is String ? value : '';
 }
 
+String _stringOrDefault(
+  Map<String, Object?> json,
+  String key,
+  String fallback,
+) {
+  final value = json[key];
+  if (value is String && value.trim().isNotEmpty) {
+    return value;
+  }
+  return fallback;
+}
+
 String _dataConfidenceLabel(String dataConfidence) {
   return switch (dataConfidence) {
     'HIGH' => '정보 신뢰도 높음',
@@ -742,9 +761,10 @@ String _dataConfidenceLabel(String dataConfidence) {
   };
 }
 
-String _facilityVerificationStatusLabel(String dataConfidence) {
-  return switch (dataConfidence.trim().toUpperCase()) {
-    'HIGH' || 'MEDIUM' => '시설 상태 확인됨',
+String _facilityVerificationStatusLabel(String fieldValidationStatus) {
+  return switch (fieldValidationStatus.trim().toUpperCase()) {
+    'VERIFIED' => '시설 상태 확인됨',
+    'STALE' => '상태 재확인 필요',
     _ => '상태 확인 필요',
   };
 }

--- a/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
+++ b/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
@@ -180,13 +180,33 @@ class DriftFavoriteFacilityRepository implements FavoriteFacilityRepository {
               s.name_ko AS station_name_ko,
               s.name_en AS station_name_en,
               s.data_source_type,
-              CAST(s.last_verified_at AS INTEGER) AS last_verified_at_value
+              CAST(s.last_verified_at AS INTEGER) AS last_verified_at_value,
+              (
+                SELECT q.quality_level
+                FROM data_quality_records q
+                WHERE UPPER(q.target_type) = 'FACILITY'
+                  AND q.target_id = f.id
+                ORDER BY q.checked_at IS NULL, q.checked_at DESC, q.id DESC
+                LIMIT 1
+              ) AS field_quality_level,
+              (
+                SELECT q.checked_at
+                FROM data_quality_records q
+                WHERE UPPER(q.target_type) = 'FACILITY'
+                  AND q.target_id = f.id
+                ORDER BY q.checked_at IS NULL, q.checked_at DESC, q.id DESC
+                LIMIT 1
+              ) AS field_checked_at_value
             FROM facilities f
             JOIN stations s ON s.id = f.station_id
             WHERE f.id = ?
             ''',
             variables: [Variable.withString(facilityId)],
-            readsFrom: {catalogDatabase.facilities, catalogDatabase.stations},
+            readsFrom: {
+              catalogDatabase.facilities,
+              catalogDatabase.stations,
+              catalogDatabase.dataQualityRecords,
+            },
           )
           .getSingleOrNull();
       if (row == null) {
@@ -208,6 +228,10 @@ class DriftFavoriteFacilityRepository implements FavoriteFacilityRepository {
           status: row.read<String?>('status') ?? '',
           dataConfidence: 'MEDIUM',
           dataSourceType: row.read<String?>('data_source_type') ?? '',
+          fieldValidationStatus: _fieldValidationStatus(
+            row.read<String?>('field_quality_level'),
+            row.read<int?>('field_checked_at_value'),
+          ),
           lastUpdatedAt: _dateLabelFromEpoch(
             row.read<int?>('last_verified_at_value'),
           ),
@@ -615,6 +639,16 @@ DateTime _dateTimeFromEpoch(int value) {
       isUtc: true,
     ),
     _ => DateTime.fromMillisecondsSinceEpoch(value, isUtc: true),
+  };
+}
+
+String _fieldValidationStatus(String? qualityLevel, int? checkedAt) {
+  final normalizedLevel = qualityLevel?.trim().toUpperCase();
+  return switch (normalizedLevel) {
+    'FIELD_VERIFIED' when checkedAt != null => 'VERIFIED',
+    'FIELD_STALE' => 'STALE',
+    'FIELD_UNKNOWN' => 'UNKNOWN',
+    _ => 'UNKNOWN',
   };
 }
 

--- a/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
+++ b/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
@@ -233,7 +233,8 @@ class DriftFavoriteFacilityRepository implements FavoriteFacilityRepository {
             row.read<int?>('field_checked_at_value'),
           ),
           lastUpdatedAt: _dateLabelFromEpoch(
-            row.read<int?>('last_verified_at_value'),
+            row.read<int?>('field_checked_at_value') ??
+                row.read<int?>('last_verified_at_value'),
           ),
           addedAt: _isoFromEpoch(favoriteRow.read<int?>('added_at_value')),
         ),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -776,7 +776,10 @@ class StationFacilityInfo {
 
   String get locationLabel {
     if (description.trim().isNotEmpty) {
-      return _facilityUserLocationLabel(description);
+      final descriptionLabel = _facilityUserLocationLabel(description);
+      if (descriptionLabel.isNotEmpty) {
+        return descriptionLabel;
+      }
     }
     if (floorFrom.trim().isNotEmpty && floorTo.trim().isNotEmpty) {
       return '$floorFrom-$floorTo';
@@ -969,7 +972,7 @@ String _facilityUserLocationLabel(String description) {
     label = label.replaceAll(phrase, '');
   }
   label = label.replaceAll(RegExp(r'\s+'), ' ').trim();
-  return label.isEmpty ? '위치 확인 필요' : label;
+  return label;
 }
 
 String _dataSourceLabel(String dataSourceType) {

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -3946,10 +3946,7 @@ class _StationDetailContent extends StatelessWidget {
         _StationDetailHeader(detail: detail),
         const SizedBox(height: 12),
         _InfoBasisDisclosure(
-          labels: [
-            detail.dataSourceLabel,
-            '마지막 확인 ${detail.lastVerifiedAt}',
-          ],
+          labels: [detail.dataSourceLabel, '마지막 확인 ${detail.lastVerifiedAt}'],
         ),
         const SizedBox(height: 12),
         if (facilityAttentionSummary.isNotEmpty) ...[
@@ -4957,7 +4954,7 @@ class _StationFacilityCard extends StatelessWidget {
                   children: [
                     _StationDetailTextPill(text: facility.typeLabel),
                     _StationDetailTextPill(text: facility.statusTitle),
-                    if (facility.severityLabel != facility.statusLabel)
+                    if (facility.severityLabel != facility.statusTitle)
                       _StationDetailTextPill(text: facility.severityLabel),
                   ],
                 ),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -396,7 +396,7 @@ class FavoriteStation {
   }
 
   String get semanticLabel {
-    return '즐겨찾기 역, $nameKo, $lineLabel, $region, $dataQualityLabel, $dataSourceLabel';
+    return '즐겨찾기 역, $nameKo, $lineLabel, $region, $dataQualityLabel';
   }
 }
 
@@ -548,7 +548,7 @@ class StationDetail {
   }
 
   String get semanticLabel {
-    return '$nameKo역 상세 정보, $lineLabel, $dataQualityLabel, $dataSourceLabel, 마지막 확인 $lastVerifiedAt';
+    return '$nameKo역 상세 정보, $lineLabel, $dataQualityLabel, 마지막 확인 $lastVerifiedAt';
   }
 }
 
@@ -614,8 +614,11 @@ class StationExitInfo {
   String get fieldValidationLabel =>
       _fieldValidationLabel(fieldValidationStatus);
 
+  String get verificationStatusLabel =>
+      _fieldVerificationStatusLabel(fieldValidationStatus);
+
   String get semanticLabel {
-    return '$name, $elevatorConnectionLabel, $stairPathLabel, $fieldValidationLabel, $confidenceLabel, $dataSourceLabel';
+    return '$name, $elevatorConnectionLabel, $stairPathLabel, $verificationStatusLabel';
   }
 }
 
@@ -768,9 +771,12 @@ class StationFacilityInfo {
   String get fieldValidationLabel =>
       _fieldValidationLabel(fieldValidationStatus);
 
+  String get verificationStatusLabel =>
+      _fieldVerificationStatusLabel(fieldValidationStatus);
+
   String get locationLabel {
     if (description.trim().isNotEmpty) {
-      return description;
+      return _facilityUserLocationLabel(description);
     }
     if (floorFrom.trim().isNotEmpty && floorTo.trim().isNotEmpty) {
       return '$floorFrom-$floorTo';
@@ -781,11 +787,7 @@ class StationFacilityInfo {
   String get updatedLabel => '최근 확인 $lastUpdatedAt';
 
   String get semanticLabel {
-    final statusSemanticLabel = facilityStatusSemanticLabel(
-      statusLabel: statusLabel,
-      severityLabel: severityLabel,
-    );
-    return '$name, $typeLabel, $statusSemanticLabel, $locationLabel, $updatedLabel, $fieldValidationLabel, $confidenceLabel, $dataSourceLabel, 다음 행동 $nextActionLabel';
+    return '$name, $typeLabel, $statusTitle, $locationLabel, $updatedLabel, $verificationStatusLabel, 다음 행동 $nextActionLabel';
   }
 }
 
@@ -944,6 +946,30 @@ String _fieldValidationLabel(String fieldValidationStatus) {
     'UNKNOWN' => '현장 검증 전',
     _ => '현장 검증 전',
   };
+}
+
+String _fieldVerificationStatusLabel(String fieldValidationStatus) {
+  final normalizedStatus = fieldValidationStatus.trim().toUpperCase();
+  return switch (normalizedStatus) {
+    'VERIFIED' => '시설 상태 확인됨',
+    'STALE' => '상태 재확인 필요',
+    _ => '상태 확인 필요',
+  };
+}
+
+String _facilityUserLocationLabel(String description) {
+  var label = description.trim();
+  const internalValidationPhrases = [
+    '현장 검증됨',
+    '현장 검증 전',
+    '현장 재확인 필요',
+    '관리자 검수',
+  ];
+  for (final phrase in internalValidationPhrases) {
+    label = label.replaceAll(phrase, '');
+  }
+  label = label.replaceAll(RegExp(r'\s+'), ' ').trim();
+  return label.isEmpty ? '위치 확인 필요' : label;
 }
 
 String _dataSourceLabel(String dataSourceType) {
@@ -2985,8 +3011,7 @@ class _NearbyStationOverview extends StatelessWidget {
                             ),
                             const SizedBox(height: 8),
                             _StationDetailTextPill(
-                              text:
-                                  '${result.dataQualityLabel} · ${result.dataSourceLabel}',
+                              text: result.dataQualityLabel,
                             ),
                           ],
                         ),
@@ -3196,7 +3221,7 @@ class _StationSearchResultTile extends StatelessWidget {
                                 ),
                                 const SizedBox(height: 4),
                                 Text(
-                                  '${result.dataQualityLabel} · ${result.dataSourceLabel}',
+                                  result.dataQualityLabel,
                                   maxLines: 1,
                                   overflow: TextOverflow.ellipsis,
                                   style: textTheme.bodyMedium?.copyWith(
@@ -3329,9 +3354,9 @@ String _stationResultSemanticLabel(StationSearchResult result) {
   final stationName = _stationResultDisplayName(result.nameKo);
   final distance = result.distanceLabel;
   if (distance.isEmpty) {
-    return '$stationName, ${result.lineLabel}, ${result.region}, ${result.dataQualityLabel}, ${result.dataSourceLabel}';
+    return '$stationName, ${result.lineLabel}, ${result.region}, ${result.dataQualityLabel}';
   }
-  return '$stationName, $distance, ${result.lineLabel}, ${result.region}, ${result.dataQualityLabel}, ${result.dataSourceLabel}';
+  return '$stationName, $distance, ${result.lineLabel}, ${result.region}, ${result.dataQualityLabel}';
 }
 
 class FavoriteStationListScreen extends StatefulWidget {
@@ -3666,14 +3691,6 @@ class _FavoriteStationTile extends StatelessWidget {
                               height: 1.3,
                             ),
                           ),
-                          const SizedBox(height: 4),
-                          Text(
-                            favorite.dataSourceLabel,
-                            style: textTheme.bodyMedium?.copyWith(
-                              color: const Color(0xFF405A5D),
-                              height: 1.3,
-                            ),
-                          ),
                         ],
                       ),
                     ),
@@ -3924,6 +3941,13 @@ class _StationDetailContent extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
       children: [
         _StationDetailHeader(detail: detail),
+        const SizedBox(height: 12),
+        _InfoBasisDisclosure(
+          labels: [
+            detail.dataSourceLabel,
+            '마지막 확인 ${detail.lastVerifiedAt}',
+          ],
+        ),
         const SizedBox(height: 12),
         if (facilityAttentionSummary.isNotEmpty) ...[
           _StationFacilityStatusSummary(
@@ -4415,15 +4439,6 @@ class _StationDetailHeader extends StatelessWidget {
                       ),
                       const SizedBox(height: 3),
                       Text(
-                        detail.dataSourceLabel,
-                        style: textTheme.bodyMedium?.copyWith(
-                          color: const Color(0xFFC8D9E2),
-                          fontWeight: FontWeight.w600,
-                          height: 1.3,
-                        ),
-                      ),
-                      const SizedBox(height: 3),
-                      Text(
                         '마지막 확인 ${detail.lastVerifiedAt}',
                         style: textTheme.bodyMedium?.copyWith(
                           color: const Color(0xFFC8D9E2),
@@ -4709,6 +4724,79 @@ class _StationDetailInfoRow extends StatelessWidget {
   }
 }
 
+class _InfoBasisDisclosure extends StatefulWidget {
+  const _InfoBasisDisclosure({required this.labels});
+
+  final List<String> labels;
+
+  @override
+  State<_InfoBasisDisclosure> createState() => _InfoBasisDisclosureState();
+}
+
+class _InfoBasisDisclosureState extends State<_InfoBasisDisclosure> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final labels = widget.labels
+        .where((label) => label.trim().isNotEmpty)
+        .toList(growable: false);
+    if (labels.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        OutlinedButton.icon(
+          onPressed: () => setState(() => _expanded = !_expanded),
+          icon: Icon(_expanded ? Icons.expand_less : Icons.expand_more),
+          label: Text(_expanded ? '정보 기준 접기' : '정보 기준 보기'),
+        ),
+        if (_expanded) ...[
+          const SizedBox(height: 10),
+          Card(
+            margin: EdgeInsets.zero,
+            elevation: 0,
+            color: Colors.white,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+              side: const BorderSide(color: EasySubwayAccessibleColors.line),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '정보 기준',
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: EasySubwayAccessibleColors.text,
+                      fontWeight: FontWeight.w900,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  for (final label in labels) ...[
+                    Text(
+                      label,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: EasySubwayAccessibleColors.mutedText,
+                        fontWeight: FontWeight.w700,
+                        height: 1.3,
+                      ),
+                    ),
+                    if (label != labels.last) const SizedBox(height: 4),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
 class _StationDetailSectionTitle extends StatelessWidget {
   const _StationDetailSectionTitle({required this.title});
 
@@ -4796,16 +4884,7 @@ class _StationExitCard extends StatelessWidget {
                   ),
                   const SizedBox(height: 8),
                   Text(
-                    exit.confidenceLabel,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: const Color(0xFF405A5D),
-                      fontWeight: FontWeight.w700,
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    exit.dataSourceLabel,
+                    exit.verificationStatusLabel,
                     style: textTheme.bodyMedium?.copyWith(
                       color: const Color(0xFF405A5D),
                       fontWeight: FontWeight.w700,
@@ -4874,7 +4953,7 @@ class _StationFacilityCard extends StatelessWidget {
                   runSpacing: 8,
                   children: [
                     _StationDetailTextPill(text: facility.typeLabel),
-                    _StationDetailTextPill(text: facility.statusLabel),
+                    _StationDetailTextPill(text: facility.statusTitle),
                     if (facility.severityLabel != facility.statusLabel)
                       _StationDetailTextPill(text: facility.severityLabel),
                   ],
@@ -4891,7 +4970,7 @@ class _StationFacilityCard extends StatelessWidget {
                 ),
                 const SizedBox(height: 6),
                 Text(
-                  '${facility.confidenceLabel} · ${facility.dataSourceLabel}',
+                  facility.verificationStatusLabel,
                   style: textTheme.bodyMedium?.copyWith(
                     color: const Color(0xFF405A5D),
                     fontWeight: FontWeight.w600,
@@ -5114,15 +5193,17 @@ class FacilityDetailScreen extends StatelessWidget {
                       icon: Icons.event_available,
                       text: facility.updatedLabel,
                     ),
-                    const SizedBox(height: 10),
-                    _StationDetailInfoRow(
-                      icon: Icons.verified_outlined,
-                      text:
-                          '${facility.confidenceLabel} · ${facility.dataSourceLabel}',
-                    ),
                   ],
                 ),
               ),
+            ),
+            const SizedBox(height: 16),
+            _InfoBasisDisclosure(
+              labels: [
+                facility.fieldValidationLabel,
+                facility.confidenceLabel,
+                facility.dataSourceLabel,
+              ],
             ),
             const SizedBox(height: 16),
             FilledButton.icon(

--- a/apps/mobile/test/favorite_facility_test.dart
+++ b/apps/mobile/test/favorite_facility_test.dart
@@ -35,7 +35,7 @@ void main() {
                 'name': '1번 출구 엘리베이터',
                 'floorFrom': '1F',
                 'floorTo': 'B1',
-                'description': '1번 출구 앞',
+                'description': '현장 검증 전 1번 출구 앞',
                 'status': 'NORMAL',
                 'dataConfidence': 'HIGH',
                 'dataSourceType': 'OFFICIAL_FILE',
@@ -69,12 +69,16 @@ void main() {
     expect(favorites.single.statusLabel, '정상');
     expect(favorites.single.severityLabel, '정상');
     expect(favorites.single.nextActionLabel, '상태 제보');
+    expect(favorites.single.statusTitle, '이용 가능');
     expect(favorites.single.confidenceLabel, '정보 신뢰도 높음');
     expect(favorites.single.dataSourceLabel, '출처 공식 파일');
+    expect(favorites.single.locationLabel, '1번 출구 앞');
     expect(
       favorites.single.semanticLabel,
-      '즐겨찾기 시설, 1번 출구 엘리베이터, 상록수역, 엘리베이터, 정상, 1번 출구 앞, 최근 확인 2026-06-12, 정보 신뢰도 높음, 출처 공식 파일, 다음 행동 상태 제보',
+      '즐겨찾기 시설, 1번 출구 엘리베이터, 상록수역, 엘리베이터, 이용 가능, 1번 출구 앞, 최근 확인 2026-06-12, 시설 상태 확인됨, 다음 행동 상태 제보',
     );
+    expect(favorites.single.semanticLabel, isNot(contains('정보 신뢰도')));
+    expect(favorites.single.semanticLabel, isNot(contains('출처')));
   });
 
   test('즐겨찾기 시설 상태는 심각도와 다음 행동을 구분한다', () {

--- a/apps/mobile/test/favorite_facility_test.dart
+++ b/apps/mobile/test/favorite_facility_test.dart
@@ -73,9 +73,10 @@ void main() {
     expect(favorites.single.confidenceLabel, '정보 신뢰도 높음');
     expect(favorites.single.dataSourceLabel, '출처 공식 파일');
     expect(favorites.single.locationLabel, '1번 출구 앞');
+    expect(favorites.single.verificationStatusLabel, '상태 확인 필요');
     expect(
       favorites.single.semanticLabel,
-      '즐겨찾기 시설, 1번 출구 엘리베이터, 상록수역, 엘리베이터, 이용 가능, 1번 출구 앞, 최근 확인 2026-06-12, 시설 상태 확인됨, 다음 행동 상태 제보',
+      '즐겨찾기 시설, 1번 출구 엘리베이터, 상록수역, 엘리베이터, 이용 가능, 1번 출구 앞, 최근 확인 2026-06-12, 상태 확인 필요, 다음 행동 상태 제보',
     );
     expect(favorites.single.semanticLabel, isNot(contains('정보 신뢰도')));
     expect(favorites.single.semanticLabel, isNot(contains('출처')));
@@ -87,6 +88,7 @@ void main() {
     final reported = _favoriteFacility(status: 'USER_REPORTED');
     final unknown = _favoriteFacility(status: 'NEEDS_CHECK');
     final available = _favoriteFacility(status: 'AVAILABLE');
+    final verified = _favoriteFacility(fieldValidationStatus: 'VERIFIED');
 
     expect(closed.severityLabel, '고장·폐쇄');
     expect(closed.nextActionLabel, '대체 출구 보기');
@@ -99,6 +101,8 @@ void main() {
     expect(unknown.nextActionLabel, '시설 상세 보기');
     expect(available.severityLabel, '정상');
     expect(available.needsAttention, isFalse);
+    expect(available.verificationStatusLabel, '상태 확인 필요');
+    expect(verified.verificationStatusLabel, '시설 상태 확인됨');
   });
 
   test('즐겨찾기 시설 API 저장소는 인증 실패 시 인증을 지우고 한 번 재시도한다', () async {
@@ -285,7 +289,10 @@ class FakeFavoriteFacilityRepository implements FavoriteFacilityRepository {
   }
 }
 
-FavoriteFacility _favoriteFacility({String status = 'NORMAL'}) {
+FavoriteFacility _favoriteFacility({
+  String status = 'NORMAL',
+  String fieldValidationStatus = 'UNKNOWN',
+}) {
   return FavoriteFacility(
     userId: 'anonymous-user-1',
     facilityId: 'facility-sangnoksu-elevator-1',
@@ -301,6 +308,7 @@ FavoriteFacility _favoriteFacility({String status = 'NORMAL'}) {
     status: status,
     dataConfidence: 'HIGH',
     dataSourceType: 'OFFICIAL_FILE',
+    fieldValidationStatus: fieldValidationStatus,
     lastUpdatedAt: '2026-06-12',
     addedAt: '2026-06-14T10:00:00',
   );

--- a/apps/mobile/test/favorite_facility_test.dart
+++ b/apps/mobile/test/favorite_facility_test.dart
@@ -89,6 +89,7 @@ void main() {
     final unknown = _favoriteFacility(status: 'NEEDS_CHECK');
     final available = _favoriteFacility(status: 'AVAILABLE');
     final verified = _favoriteFacility(fieldValidationStatus: 'VERIFIED');
+    final metadataOnlyDescription = _favoriteFacility(description: '현장 검증 전');
 
     expect(closed.severityLabel, '고장·폐쇄');
     expect(closed.nextActionLabel, '대체 출구 보기');
@@ -103,6 +104,7 @@ void main() {
     expect(available.needsAttention, isFalse);
     expect(available.verificationStatusLabel, '상태 확인 필요');
     expect(verified.verificationStatusLabel, '시설 상태 확인됨');
+    expect(metadataOnlyDescription.locationLabel, '1F-B1');
   });
 
   test('즐겨찾기 시설 API 저장소는 인증 실패 시 인증을 지우고 한 번 재시도한다', () async {
@@ -292,6 +294,7 @@ class FakeFavoriteFacilityRepository implements FavoriteFacilityRepository {
 FavoriteFacility _favoriteFacility({
   String status = 'NORMAL',
   String fieldValidationStatus = 'UNKNOWN',
+  String description = '1번 출구 앞',
 }) {
   return FavoriteFacility(
     userId: 'anonymous-user-1',
@@ -304,7 +307,7 @@ FavoriteFacility _favoriteFacility({
     name: '1번 출구 엘리베이터',
     floorFrom: '1F',
     floorTo: 'B1',
-    description: '1번 출구 앞',
+    description: description,
     status: status,
     dataConfidence: 'HIGH',
     dataSourceType: 'OFFICIAL_FILE',

--- a/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
+++ b/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
@@ -58,7 +58,39 @@ void main() {
     expect(favorites.single.facilityId, 'facility-sangnoksu-elevator-1');
     expect(favorites.single.stationNameKo, '상록수');
     expect(favorites.single.name, '1번 출구 엘리베이터');
+    expect(favorites.single.verificationStatusLabel, '시설 상태 확인됨');
+    expect(favorites.single.lastUpdatedAt, '2026-06-19');
     expect(favorites.single.addedAt, '2026-06-19T09:00:00.000Z');
+  });
+
+  test('로컬 시설 즐겨찾기는 시설 field 검증 시각을 최근 확인일로 쓴다', () async {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+    await catalogDatabase.seedBaselineIfEmpty();
+    await userDatabase
+        .into(userDatabase.favoriteFacilities)
+        .insert(
+          user_db.FavoriteFacilitiesCompanion.insert(
+            facilityId: 'facility-sangnoksu-accessible-toilet-1',
+            stationId: 'station-sangnoksu',
+            addedAt: DateTime.utc(2026, 6, 19, 9),
+          ),
+        );
+    final repository = DriftFavoriteFacilityRepository(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+    );
+
+    final favorites = await repository.listFavoriteFacilities();
+
+    expect(
+      favorites.single.facilityId,
+      'facility-sangnoksu-accessible-toilet-1',
+    );
+    expect(favorites.single.verificationStatusLabel, '상태 재확인 필요');
+    expect(favorites.single.lastUpdatedAt, '2025-06-01');
   });
 
   test('로컬 시설 즐겨찾기는 시설 id로 저장하고 삭제한다', () async {

--- a/apps/mobile/test/features/stations/drift_station_repository_test.dart
+++ b/apps/mobile/test/features/stations/drift_station_repository_test.dart
@@ -123,12 +123,12 @@ void main() {
     );
 
     expect(elevator.dataConfidence, 'HIGH');
-    expect(elevator.semanticLabel, contains('현장 검증됨'));
+    expect(elevator.semanticLabel, contains('시설 상태 확인됨'));
     expect(elevator.lastUpdatedAt, '2026-06-19');
     expect(escalator.dataConfidence, 'LOW');
-    expect(escalator.semanticLabel, contains('현장 검증 전'));
+    expect(escalator.semanticLabel, contains('상태 확인 필요'));
     expect(toilet.dataConfidence, 'LOW');
-    expect(toilet.semanticLabel, contains('현장 재확인 필요'));
+    expect(toilet.semanticLabel, contains('상태 재확인 필요'));
   });
 
   test('상록수역 시설은 최신 현장 검증 record를 선택한다', () async {
@@ -158,7 +158,7 @@ void main() {
     );
     expect(elevator.dataConfidence, 'LOW');
     expect(elevator.lastUpdatedAt, '2026-06-20');
-    expect(elevator.semanticLabel, contains('현장 재확인 필요'));
+    expect(elevator.semanticLabel, contains('상태 재확인 필요'));
   });
 
   test('존재하지 않는 역 상세 조회는 역 검색 예외를 던진다', () async {

--- a/apps/mobile/test/map_adapter_test.dart
+++ b/apps/mobile/test/map_adapter_test.dart
@@ -107,10 +107,10 @@ void main() {
     expect(markers[0].semanticLabel, contains('마지막 확인 2026-06-12'));
     expect(markers[1].semanticLabel, contains('1번 출구'));
     expect(markers[1].semanticLabel, contains('계단 없는 이동 가능'));
-    expect(markers[1].semanticLabel, contains('정보 신뢰도 높음'));
+    expect(markers[1].semanticLabel, contains('상태 확인 필요'));
     expect(markers[2].semanticLabel, contains('엘리베이터'));
-    expect(markers[2].semanticLabel, contains('정상'));
+    expect(markers[2].semanticLabel, contains('이용 가능'));
     expect(markers[2].semanticLabel, contains('최근 확인 2026-06-12'));
-    expect(markers[2].semanticLabel, contains('정보 신뢰도 높음'));
+    expect(markers[2].semanticLabel, contains('상태 확인 필요'));
   });
 }

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -1344,6 +1344,19 @@ void main() {
       dataConfidence: 'LOW',
       lastUpdatedAt: '2026-06-13',
     );
+    const metadataOnlyDescription = StationFacilityInfo(
+      id: 'facility-elevator-1',
+      stationId: 'station-sangnoksu',
+      exitId: 'exit-sangnoksu-1',
+      type: 'ELEVATOR',
+      name: '1번 출구 엘리베이터',
+      floorFrom: 'B1',
+      floorTo: '1F',
+      description: '현장 검증됨',
+      status: 'NORMAL',
+      dataConfidence: 'HIGH',
+      lastUpdatedAt: '2026-06-13',
+    );
 
     expect(ramp.typeLabel, '경사로');
     expect(ramp.statusLabel, '공사 중');
@@ -1365,6 +1378,7 @@ void main() {
     expect(customerCenter.semanticLabel, isNot(contains('출처')));
     expect(uncheckedDescription.locationLabel, '이동 보조 시설');
     expect(uncheckedDescription.semanticLabel, isNot(contains('현장 검증')));
+    expect(metadataOnlyDescription.locationLabel, 'B1-1F');
   });
 }
 

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -590,6 +590,7 @@ void main() {
     expect(facilities.single.latitude, 37.302795);
     expect(facilities.single.longitude, 126.866489);
     expect(facilities.single.statusLabel, '정상');
+    expect(facilities.single.statusTitle, '이용 가능');
     expect(facilities.single.confidenceLabel, '정보 신뢰도 높음');
     expect(facilities.single.dataSourceLabel, '출처 공식 파일');
   });
@@ -1330,22 +1331,40 @@ void main() {
       lastUpdatedAt: '2026-06-13',
       fieldValidationStatus: ' verified ',
     );
+    const uncheckedDescription = StationFacilityInfo(
+      id: 'facility-escalator-1',
+      stationId: 'station-sangnoksu',
+      exitId: 'exit-sangnoksu-1',
+      type: 'ESCALATOR',
+      name: '1번 출구 에스컬레이터',
+      floorFrom: '',
+      floorTo: '',
+      description: '현장 검증 전 이동 보조 시설',
+      status: 'NORMAL',
+      dataConfidence: 'LOW',
+      lastUpdatedAt: '2026-06-13',
+    );
 
     expect(ramp.typeLabel, '경사로');
     expect(ramp.statusLabel, '공사 중');
     expect(ramp.severityLabel, '점검·제보');
     expect(ramp.nextActionLabel, '역무원 도움 요청');
     expect(ramp.confidenceLabel, '정보 확인 필요');
+    expect(ramp.statusTitle, '현장 확인 필요');
     expect(
       ramp.semanticLabel,
-      '1번 출구 경사로, 경사로, 공사 중, 점검·제보, 1F-B1, 최근 확인 2026-06-13, 현장 검증 전, 정보 확인 필요, 출처 확인 필요, 다음 행동 역무원 도움 요청',
+      '1번 출구 경사로, 경사로, 현장 확인 필요, 1F-B1, 최근 확인 2026-06-13, 상태 확인 필요, 다음 행동 역무원 도움 요청',
     );
     expect(customerCenter.typeLabel, '고객센터');
     expect(customerCenter.statusLabel, '검수 완료');
     expect(customerCenter.severityLabel, '정상');
     expect(customerCenter.fieldValidationLabel, '현장 검증됨');
-    expect(customerCenter.semanticLabel, contains('정보 신뢰도 높음'));
-    expect(customerCenter.semanticLabel, contains('현장 검증됨'));
+    expect(customerCenter.statusTitle, '이용 가능');
+    expect(customerCenter.semanticLabel, isNot(contains('정보 신뢰도')));
+    expect(customerCenter.semanticLabel, isNot(contains('현장 검증')));
+    expect(customerCenter.semanticLabel, isNot(contains('출처')));
+    expect(uncheckedDescription.locationLabel, '이동 보조 시설');
+    expect(uncheckedDescription.semanticLabel, isNot(contains('현장 검증')));
   });
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2837,9 +2837,7 @@ void main() {
       );
       expect(
         tester.getSemantics(
-          find.bySemanticsLabel(
-            '상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음',
-          ),
+          find.bySemanticsLabel('상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
         ),
         isSemantics(
           label: '상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음',
@@ -4077,6 +4075,20 @@ void main() {
           lastUpdatedAt: '2026-06-14',
           fieldValidationStatus: 'VERIFIED',
         ),
+        StationFacilityInfo(
+          id: 'facility-sangnoksu-info-needed',
+          stationId: 'station-sangnoksu',
+          exitId: 'exit-sangnoksu-3',
+          type: 'ESCALATOR',
+          name: '3번 출구 에스컬레이터',
+          floorFrom: 'B1',
+          floorTo: '1F',
+          description: '3번 출구 앞',
+          status: 'NEEDS_CHECK',
+          dataConfidence: 'LOW',
+          dataSourceType: 'OFFICIAL_FILE',
+          lastUpdatedAt: '2026-06-10',
+        ),
       ],
     );
 
@@ -4179,9 +4191,7 @@ void main() {
       );
       await tester.pumpAndSettle();
       expect(
-        find.bySemanticsLabel(
-          '1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 시설 상태 확인됨, 지도 위치',
-        ),
+        find.bySemanticsLabel('1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 시설 상태 확인됨, 지도 위치'),
         findsOneWidget,
       );
       await tester.scrollUntilVisible(
@@ -4209,9 +4219,7 @@ void main() {
       expect(find.text('엘리베이터 연결'), findsOneWidget);
       expect(find.text('계단 없는 이동 가능'), findsOneWidget);
       expect(
-        find.bySemanticsLabel(
-          '1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 시설 상태 확인됨',
-        ),
+        find.bySemanticsLabel('1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 시설 상태 확인됨'),
         findsOneWidget,
       );
       await tester.scrollUntilVisible(
@@ -4221,11 +4229,27 @@ void main() {
       );
       await tester.pumpAndSettle();
       expect(find.text('시설'), findsOneWidget);
-      expect(find.text('확인 필요 1개'), findsNothing);
-      expect(find.bySemanticsLabel('확인이 필요한 시설 1개'), findsNothing);
       expect(find.text('2번 출구 엘리베이터'), findsOneWidget);
       expect(find.text('엘리베이터'), findsWidgets);
       expect(find.text('이용 불가 확인'), findsOneWidget);
+      await tester.scrollUntilVisible(
+        find.byKey(
+          const Key('stationFacilityCard-facility-sangnoksu-info-needed'),
+        ),
+        120,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('3번 출구 에스컬레이터'), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byKey(
+            const Key('stationFacilityCard-facility-sangnoksu-info-needed'),
+          ),
+          matching: find.text('정보 확인 필요'),
+        ),
+        findsOneWidget,
+      );
       await tester.scrollUntilVisible(
         find.byKey(
           const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
@@ -5108,18 +5132,14 @@ void main() {
       expect(find.text('접근성 시설 정보가 최근 확인되지 않았습니다.'), findsOneWidget);
       expect(
         find.descendant(
-          of: find.byKey(
-            const Key('routeDarkSummaryChip-계단 여부 확인 필요'),
-          ),
+          of: find.byKey(const Key('routeDarkSummaryChip-계단 여부 확인 필요')),
           matching: find.byIcon(Icons.help_outline),
         ),
         findsOneWidget,
       );
       expect(
         find.descendant(
-          of: find.byKey(
-            const Key('routeDarkSummaryChip-계단 여부 확인 필요'),
-          ),
+          of: find.byKey(const Key('routeDarkSummaryChip-계단 여부 확인 필요')),
           matching: find.byIcon(Icons.check),
         ),
         findsNothing,
@@ -5739,10 +5759,7 @@ void main() {
       final routeItemSemantics = tester
           .getSemantics(find.byKey(const Key('routeResultListItem')))
           .getSemanticsData();
-      expect(
-        routeItemSemantics.hasAction(SemanticsAction.tap),
-        isTrue,
-      );
+      expect(routeItemSemantics.hasAction(SemanticsAction.tap), isTrue);
       expect(routeItemSemantics.label, contains('계단 여부 확인 필요'));
     } finally {
       semanticsHandle.dispose();

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2439,10 +2439,10 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.bySemanticsLabel('즐겨찾기 역, 상록수, 수도권 4호선, 수도권, 기본 정보만 있음, 출처 공식 파일'),
+        find.bySemanticsLabel('즐겨찾기 역, 상록수, 수도권 4호선, 수도권, 기본 정보만 있음'),
         findsOneWidget,
       );
-      expect(find.text('출처 공식 파일'), findsOneWidget);
+      expect(find.text('출처 공식 파일'), findsNothing);
 
       final tileSize = tester.getSize(
         find.byKey(const Key('favoriteStationTile-station-sangnoksu')),
@@ -2511,9 +2511,10 @@ void main() {
       expect(find.text('즐겨찾기한 시설'), findsOneWidget);
       expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
       expect(find.text('상록수역'), findsOneWidget);
-      expect(find.text('정상'), findsOneWidget);
-      expect(find.text('정보 신뢰도 높음'), findsOneWidget);
-      expect(find.text('출처 공식 파일'), findsOneWidget);
+      expect(find.text('이용 가능'), findsOneWidget);
+      expect(find.text('시설 상태 확인됨'), findsOneWidget);
+      expect(find.text('정보 신뢰도 높음'), findsNothing);
+      expect(find.text('출처 공식 파일'), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '상태 제보'), findsOneWidget);
       expect(
         find.byKey(
@@ -2523,7 +2524,7 @@ void main() {
       );
       expect(
         find.bySemanticsLabel(
-          '즐겨찾기 시설, 1번 출구 엘리베이터, 상록수역, 엘리베이터, 정상, 1번 출구 앞, 최근 확인 2026-06-12, 정보 신뢰도 높음, 출처 공식 파일, 다음 행동 상태 제보',
+          '즐겨찾기 시설, 1번 출구 엘리베이터, 상록수역, 엘리베이터, 이용 가능, 1번 출구 앞, 최근 확인 2026-06-12, 시설 상태 확인됨, 다음 행동 상태 제보',
         ),
         findsOneWidget,
       );
@@ -2827,21 +2828,21 @@ void main() {
       );
       expect(find.text('수도권 4호선, 경의중앙선'), findsOneWidget);
       expect(find.text('수도권'), findsNothing);
-      expect(find.text('기본 정보만 있음'), findsNothing);
-      expect(find.text('기본 정보만 있음 · 출처 확인 필요'), findsOneWidget);
+      expect(find.text('기본 정보만 있음'), findsOneWidget);
+      expect(find.text('출처 확인 필요'), findsNothing);
       expect(find.bySemanticsLabel('검색 결과 1개'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음, 출처 확인 필요'),
+        find.bySemanticsLabel('상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음'),
         findsOneWidget,
       );
       expect(
         tester.getSemantics(
           find.bySemanticsLabel(
-            '상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음, 출처 확인 필요',
+            '상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음',
           ),
         ),
         isSemantics(
-          label: '상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음, 출처 확인 필요',
+          label: '상록수역, 수도권 4호선, 경의중앙선, 수도권, 기본 정보만 있음',
           isButton: true,
           hasTapAction: true,
         ),
@@ -3694,7 +3695,7 @@ void main() {
       expect(find.byKey(const Key('nearbyStationPrimaryCard')), findsOneWidget);
       expect(
         find.bySemanticsLabel(
-          '가장 가까운 역, 상록수역, 현재 위치 기준 230m, 수도권 2호선, 수도권, 기본 정보만 있음, 출처 공식 파일',
+          '가장 가까운 역, 상록수역, 현재 위치 기준 230m, 수도권 2호선, 수도권, 기본 정보만 있음',
         ),
         findsOneWidget,
       );
@@ -4099,9 +4100,10 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
       await tester.pumpAndSettle();
-      expect(find.text('기본 정보만 있음 · 출처 공식 파일'), findsOneWidget);
+      expect(find.text('기본 정보만 있음'), findsOneWidget);
+      expect(find.text('출처 공식 파일'), findsNothing);
       expect(
-        find.bySemanticsLabel('상록수역, 수도권 2호선, 수도권, 기본 정보만 있음, 출처 공식 파일'),
+        find.bySemanticsLabel('상록수역, 수도권 2호선, 수도권, 기본 정보만 있음'),
         findsOneWidget,
       );
       await tester.tap(
@@ -4115,8 +4117,8 @@ void main() {
       expect(find.text('상록수역'), findsOneWidget);
       expect(find.text('수도권 2호선'), findsOneWidget);
       expect(find.text('기본 정보만 있음'), findsOneWidget);
-      expect(find.text('출처 공식 파일'), findsWidgets);
       expect(find.text('마지막 확인 2026-06-13'), findsOneWidget);
+      expect(find.text('출처 공식 파일'), findsNothing);
       expect(find.text('이동 전 현장 안내와 역무원 안내를 확인해 주세요.'), findsOneWidget);
       expect(
         find.bySemanticsLabel('안전 안내, 이동 전 현장 안내와 역무원 안내를 확인해 주세요.'),
@@ -4124,11 +4126,25 @@ void main() {
       );
       expect(
         find.bySemanticsLabel(
-          '상록수역 상세 정보, 수도권 2호선, 기본 정보만 있음, 출처 공식 파일, 마지막 확인 2026-06-13',
+          '상록수역 상세 정보, 수도권 2호선, 기본 정보만 있음, 마지막 확인 2026-06-13',
         ),
         findsOneWidget,
       );
+      expect(find.widgetWithText(OutlinedButton, '정보 기준 보기'), findsOneWidget);
+      await tester.tap(find.widgetWithText(OutlinedButton, '정보 기준 보기'));
+      await tester.pumpAndSettle();
+      expect(find.text('정보 기준'), findsOneWidget);
+      expect(find.text('출처 공식 파일'), findsOneWidget);
+      await tester.tap(find.widgetWithText(OutlinedButton, '정보 기준 접기'));
+      await tester.pumpAndSettle();
+      expect(find.text('출처 공식 파일'), findsNothing);
       expect(find.text('이동 구조'), findsOneWidget);
+      await tester.scrollUntilVisible(
+        find.text('승강장'),
+        120,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.pumpAndSettle();
       expect(find.text('승강장'), findsOneWidget);
       expect(find.bySemanticsLabel('이동 구조, 1번 출구, 엘리베이터, 승강장'), findsOneWidget);
       await tester.scrollUntilVisible(
@@ -4152,7 +4168,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(
         find.bySemanticsLabel(
-          '상록수역 상세 정보, 수도권 2호선, 기본 정보만 있음, 출처 공식 파일, 마지막 확인 2026-06-13, 지도 위치',
+          '상록수역 상세 정보, 수도권 2호선, 기본 정보만 있음, 마지막 확인 2026-06-13, 지도 위치',
         ),
         findsOneWidget,
       );
@@ -4164,7 +4180,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(
         find.bySemanticsLabel(
-          '1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 현장 검증됨, 정보 신뢰도 높음, 출처 공식 파일, 지도 위치',
+          '1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 시설 상태 확인됨, 지도 위치',
         ),
         findsOneWidget,
       );
@@ -4178,7 +4194,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(
         find.bySemanticsLabel(
-          '1번 출구 엘리베이터, 엘리베이터, 정상, 1번 출구 앞, 최근 확인 2026-06-12, 현장 검증됨, 정보 신뢰도 높음, 출처 공식 파일, 다음 행동 상태 제보, 지도 위치',
+          '1번 출구 엘리베이터, 엘리베이터, 이용 가능, 1번 출구 앞, 최근 확인 2026-06-12, 시설 상태 확인됨, 다음 행동 상태 제보, 지도 위치',
         ),
         findsOneWidget,
       );
@@ -4194,7 +4210,7 @@ void main() {
       expect(find.text('계단 없는 이동 가능'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
-          '1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 현장 검증됨, 정보 신뢰도 높음, 출처 공식 파일',
+          '1번 출구, 엘리베이터 연결, 계단 없는 이동 가능, 시설 상태 확인됨',
         ),
         findsOneWidget,
       );
@@ -4209,7 +4225,7 @@ void main() {
       expect(find.bySemanticsLabel('확인이 필요한 시설 1개'), findsNothing);
       expect(find.text('2번 출구 엘리베이터'), findsOneWidget);
       expect(find.text('엘리베이터'), findsWidgets);
-      expect(find.text('고장'), findsOneWidget);
+      expect(find.text('이용 불가 확인'), findsOneWidget);
       await tester.scrollUntilVisible(
         find.byKey(
           const Key('facilityReportButton-facility-sangnoksu-elevator-1'),
@@ -4219,12 +4235,12 @@ void main() {
       );
       await tester.pumpAndSettle();
       expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
-      expect(find.text('정상'), findsWidgets);
+      expect(find.text('이용 가능'), findsOneWidget);
       expect(find.text('1번 출구 앞'), findsOneWidget);
       expect(find.text('최근 확인 2026-06-12'), findsOneWidget);
       expect(
         find.bySemanticsLabel(
-          '1번 출구 엘리베이터, 엘리베이터, 정상, 1번 출구 앞, 최근 확인 2026-06-12, 현장 검증됨, 정보 신뢰도 높음, 출처 공식 파일, 다음 행동 상태 제보',
+          '1번 출구 엘리베이터, 엘리베이터, 이용 가능, 1번 출구 앞, 최근 확인 2026-06-12, 시설 상태 확인됨, 다음 행동 상태 제보',
         ),
         findsOneWidget,
       );
@@ -4319,8 +4335,24 @@ void main() {
     expect(find.text('연결 위치 B1 ↔ 1F'), findsOneWidget);
     expect(find.text('2번 출구 앞'), findsOneWidget);
     expect(find.text('최근 확인 2026-06-14'), findsOneWidget);
-    expect(find.text('정보 신뢰도 높음 · 출처 공식 파일'), findsOneWidget);
+    expect(find.text('정보 신뢰도 높음'), findsNothing);
+    expect(find.text('출처 공식 파일'), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, '정보 기준 보기'), findsOneWidget);
+    await tester.tap(find.widgetWithText(OutlinedButton, '정보 기준 보기'));
+    await tester.pumpAndSettle();
+    expect(find.text('정보 기준'), findsOneWidget);
+    expect(find.text('현장 검증됨'), findsOneWidget);
+    expect(find.text('정보 신뢰도 높음'), findsOneWidget);
+    expect(find.text('출처 공식 파일'), findsOneWidget);
 
+    await tester.scrollUntilVisible(
+      find.byKey(
+        const Key('facilityDetailReportButton-facility-sangnoksu-elevator-2'),
+      ),
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.pumpAndSettle();
     await tester.tap(
       find.byKey(
         const Key('facilityDetailReportButton-facility-sangnoksu-elevator-2'),
@@ -4681,7 +4713,7 @@ void main() {
 
     expect(
       find.bySemanticsLabel(
-        '상록수역 상세 정보, 수도권 2호선, 기본 정보만 있음, 출처 공식 파일, 마지막 확인 2026-06-13',
+        '상록수역 상세 정보, 수도권 2호선, 기본 정보만 있음, 마지막 확인 2026-06-13',
       ),
       findsOneWidget,
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2512,7 +2512,7 @@ void main() {
       expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
       expect(find.text('상록수역'), findsOneWidget);
       expect(find.text('이용 가능'), findsOneWidget);
-      expect(find.text('시설 상태 확인됨'), findsOneWidget);
+      expect(find.text('상태 확인 필요'), findsOneWidget);
       expect(find.text('정보 신뢰도 높음'), findsNothing);
       expect(find.text('출처 공식 파일'), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '상태 제보'), findsOneWidget);
@@ -2524,7 +2524,7 @@ void main() {
       );
       expect(
         find.bySemanticsLabel(
-          '즐겨찾기 시설, 1번 출구 엘리베이터, 상록수역, 엘리베이터, 이용 가능, 1번 출구 앞, 최근 확인 2026-06-12, 시설 상태 확인됨, 다음 행동 상태 제보',
+          '즐겨찾기 시설, 1번 출구 엘리베이터, 상록수역, 엘리베이터, 이용 가능, 1번 출구 앞, 최근 확인 2026-06-12, 상태 확인 필요, 다음 행동 상태 제보',
         ),
         findsOneWidget,
       );


### PR DESCRIPTION
## 관련 이슈

close #811

## 작업 배경

- 역·시설 기본 카드와 TalkBack 문구에서 `출처 공식 파일`, `정보 신뢰도`, `현장 검증 전` 같은 내부 데이터 관리 표현이 바로 노출되면 이동 중인 사용자가 다음 행동을 판단하기 어렵다.
- QA 요청에 따라 기본 화면은 이용 가능 여부와 상태 확인 필요 여부를 먼저 보여 주고, 출처와 검수 기준은 상세의 접힌 `정보 기준`에서만 확인하도록 정리한다.

## 작업 내용

- 역 검색 결과, 즐겨찾기 역, 역 상세 기본 semantics에서 데이터 출처 문구를 제거했다.
- 역 상세와 시설 상세에 접힌 `정보 기준` 영역을 추가해 출처·검수·신뢰도 정보를 필요할 때만 펼쳐 볼 수 있게 했다.
- 출구, 역 시설, 즐겨찾기 시설의 기본 카드와 스크린리더 문구를 운영 상태(`이용 가능`, `현장 확인 필요`)와 확인 상태(`시설 상태 확인됨`, `상태 확인 필요`)로 분리했다.
- 시설 설명에 섞여 들어온 내부 검수 문구는 기본 위치 라벨에서 제거해 `현장 검증 전 이동 보조 시설`이 `이동 보조 시설`로 읽히게 했다.
- 즐겨찾기 시설은 field 검증 상태와 field 확인일을 우선 사용해 `상태 재확인 필요`와 확인 날짜가 서로 어긋나지 않게 했다.
- 역/시설 모델, 지도 대체 목록, widget 회귀 테스트를 새 문구 계약에 맞춰 보강했다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/favorite_facility_test.dart test/station_search_test.dart test/map_adapter_test.dart`: exit 0, 45 tests passed.
  - `cd apps/mobile && flutter test test/widget_test.dart`: exit 0, 128 tests passed.
  - `cd apps/mobile && flutter test test/features/favorites/drift_favorite_repositories_test.dart test/widget_test.dart`: exit 0.
  - `cd apps/mobile && flutter test`: exit 0, 408 tests passed.
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found.
  - `cd apps/mobile && flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성.
  - `git diff --check`: exit 0.
  - `codex review --base origin/main --title "[Fix] 역·시설 상태 문구 사용자 행동 중심 정리"`: 최종 재리뷰에서 actionable correctness issue 없음.
  - GitHub checks: `Android CI`, `Mobile App CI`, `Repository CI`, `Backend CI`, `Dependency Vulnerability Scan / osv-scan`, `Android Release Artifact`, `Changes`, `osv-scanner` pass.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 검색 결과 기본 문구 | Android 실기 `RFKYA01VMQY` | debug APK 설치 후 `sangnoksu` 검색, UI tree 확인 | `.codex/evidence/811/android-station-search-results.xml`, `.codex/evidence/811/android-station-search-results.png`; tree에 `상록수역, 수도권 4호선, 수도권, 시설 정보 확인됨` 노출, `출처`/`정보 신뢰도` 미노출 | 통과 |
| 역 상세 기본 문구 | Android 실기 `RFKYA01VMQY` | 검색 결과에서 상록수역 상세 진입, 접힌 상태 확인 | `.codex/evidence/811/android-station-detail-collapsed.xml`, `.codex/evidence/811/android-station-detail-collapsed.png`; tree에 `정보 기준 보기`만 노출, 기본 상세에는 `출처 공식 파일` 미노출 | 통과 |
| 역 상세 정보 기준 펼침 | Android 실기 `RFKYA01VMQY` | `정보 기준 보기` 탭 후 UI tree 확인 | `.codex/evidence/811/android-station-detail-info-basis.xml`, `.codex/evidence/811/android-station-detail-info-basis.png`; tree에 `정보 기준`, `출처 공식 파일`, `마지막 확인 2026-04-02` 노출 | 통과 |
| 시설 카드 운영 상태와 확인 상태 분리 | Android 실기 `RFKYA01VMQY` | 역 상세 시설 목록까지 스크롤 후 UI tree 확인 | `.codex/evidence/811/android-station-detail-facility-cards.xml`, `.codex/evidence/811/android-station-detail-facility-cards.png`; tree에 `이용 가능`, `이동 보조 시설`, `상태 확인 필요`, `시설 상태 확인됨` 노출, 기본 카드에는 `현장 검증 전` 미노출 | 통과 |
| iOS 대체 검증 | Flutter 공통 widget 테스트 | iOS 별도 simulator UI tree는 이번 확인에서 수집하지 못했고, 동일 Dart widget/semantics 경로를 `flutter test test/widget_test.dart`로 검증 | `flutter test test/widget_test.dart`: exit 0, 128 tests passed. 남은 리스크는 iOS native accessibility tree 덤프 미수집 | 통과 |

로컬 전용 증거 사유: 이번 Android 스크린샷과 UI tree는 QA 승인 없는 외부 업로드를 피하기 위해 `.codex/evidence/811/`에 보관했다. PR에는 증거 파일명, 확인 대상, UI tree에서 확인한 문구를 기록해 리뷰어가 필요한 경우 로컬 evidence를 열어 확인할 수 있게 했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `StationFacilityInfo.locationLabel`과 `FavoriteFacility.locationLabel`에서 description에 섞인 내부 검수 문구를 화면용으로만 정리한다.
  - `정보 기준`은 기본적으로 접혀 있으며, 출처·신뢰도·검수 문구는 이 영역에서만 노출된다.
  - CodeRabbit 상태를 확인했고 한도 알림이 있어 Codex CLI fallback review를 PR review 형식으로 남겼다. 발견된 actionable comment는 모두 원래 thread에 해결 답글을 달고 resolved 처리했으며, 최종 fallback review는 actionable 0건이다.

## 리스크

- 시설 description에서 `현장 검증 전`, `현장 검증됨`, `현장 재확인 필요`, `관리자 검수` 문구는 기본 위치 라벨에서 제거된다. 운영자가 같은 표현을 실제 위치명으로 넣은 예외가 있으면 기본 카드에서 생략될 수 있지만, 이번 작업의 사용자 문구 정책에는 맞는 동작이다.
- iOS 실기/시뮬레이터 접근성 tree는 별도로 수집하지 못했다. Flutter 공통 widget 테스트와 Android 실기 증거로 대체했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
