### PR TITLE
[Perf] 노선도 viewport 렌더링과 좌표 판정 기준선 정비

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,7 @@ jobs:
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
+          flutter-version: "3.44.0"
           cache: true
 
       - name: Mobile App CI / Set up Node.js for mobile contracts
@@ -314,6 +315,7 @@ jobs:
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
+          flutter-version: "3.44.0"
           cache: true
 
       - name: Android CI / Build Flutter Android debug APK

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -86,6 +86,7 @@ jobs:
         uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: stable
+          flutter-version: "3.44.0"
           cache: true
 
       - name: Android Release Artifact / Create CI release keystore

--- a/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/OriginalRouteMapAssetView.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/OriginalRouteMapAssetView.kt
@@ -2,9 +2,14 @@ package com.easysubway.easysubway_mobile
 
 import android.content.Context
 import android.graphics.Color
+import android.os.Build
+import android.view.Gravity
 import android.view.View
+import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebView
+import android.webkit.WebViewClient
 import android.widget.FrameLayout
+import android.widget.TextView
 import io.flutter.FlutterInjector
 import io.flutter.plugin.common.StandardMessageCodec
 import io.flutter.plugin.platform.PlatformView
@@ -38,6 +43,32 @@ private class OriginalRouteMapAssetPlatformView(
             svgWebView.setBackgroundColor(Color.WHITE)
             svgWebView.isHorizontalScrollBarEnabled = false
             svgWebView.isVerticalScrollBarEnabled = false
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                svgWebView.webViewClient = object : WebViewClient() {
+                    override fun onRenderProcessGone(
+                        view: WebView,
+                        detail: RenderProcessGoneDetail,
+                    ): Boolean {
+                        if (webView === view) {
+                            container.removeView(view)
+                            view.destroy()
+                            webView = null
+                            container.addView(
+                                TextView(context).apply {
+                                    text = "노선도를 다시 불러오지 못했습니다."
+                                    gravity = Gravity.CENTER
+                                    setTextColor(Color.BLACK)
+                                },
+                                FrameLayout.LayoutParams(
+                                    FrameLayout.LayoutParams.MATCH_PARENT,
+                                    FrameLayout.LayoutParams.MATCH_PARENT,
+                                ),
+                            )
+                        }
+                        return true
+                    }
+                }
+            }
             val html = """
                 <!doctype html>
                 <html>

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -832,6 +832,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
                                   stationsById: stationsById,
                                   edges: widget.data.edges,
                                   geometry: geometry,
+                                  styleScale: geometry.overlayStyleScale,
                                 ),
                               ),
                             ),
@@ -964,6 +965,7 @@ class _SelectedLineOverlayPainter extends CustomPainter {
     required this.stationsById,
     required this.edges,
     required this.geometry,
+    required this.styleScale,
   });
 
   final String lineId;
@@ -971,6 +973,7 @@ class _SelectedLineOverlayPainter extends CustomPainter {
   final Map<String, NetworkMapStation> stationsById;
   final List<NetworkMapEdge> edges;
   final _MapGeometry geometry;
+  final double styleScale;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -987,7 +990,7 @@ class _SelectedLineOverlayPainter extends CustomPainter {
       ..color = lineColor
       ..strokeCap = StrokeCap.round
       ..strokeJoin = StrokeJoin.round
-      ..strokeWidth = 14
+      ..strokeWidth = 14 * styleScale
       ..style = PaintingStyle.stroke;
     for (final edge in edges) {
       if (edge.lineId != lineId) {
@@ -1016,8 +1019,8 @@ class _SelectedLineOverlayPainter extends CustomPainter {
         continue;
       }
       final center = Offset(geometry.x(station), geometry.y(station));
-      canvas.drawCircle(center, 13, stationBorderPaint);
-      canvas.drawCircle(center, 7, stationFillPaint);
+      canvas.drawCircle(center, 13 * styleScale, stationBorderPaint);
+      canvas.drawCircle(center, 7 * styleScale, stationFillPaint);
     }
   }
 
@@ -1027,7 +1030,8 @@ class _SelectedLineOverlayPainter extends CustomPainter {
         oldDelegate.linesById != linesById ||
         oldDelegate.stationsById != stationsById ||
         oldDelegate.edges != edges ||
-        oldDelegate.geometry != geometry;
+        oldDelegate.geometry != geometry ||
+        oldDelegate.styleScale != styleScale;
   }
 }
 
@@ -1326,6 +1330,7 @@ class _MapGeometry {
     Rect? initialBounds,
     double? surfaceWidth,
     double? surfaceHeight,
+    this.overlayStyleScale = 1.0,
   }) : initialBounds = initialBounds ?? Rect.fromLTWH(0, 0, width, height),
        surfaceWidth = surfaceWidth ?? width,
        surfaceHeight = surfaceHeight ?? height;
@@ -1337,6 +1342,7 @@ class _MapGeometry {
   final Rect initialBounds;
   final double surfaceWidth;
   final double surfaceHeight;
+  final double overlayStyleScale;
 
   // Android WebView platform view는 큰 Surface에서 GL memory가 급증한다.
   static const _maxAndroidViewSurfaceExtent = 4096.0;
@@ -1358,6 +1364,10 @@ class _MapGeometry {
         : 1.0;
     final sourceWidth = asset.coordinateWidth;
     final sourceHeight = asset.coordinateHeight;
+    final overlayStyleScale = math.min(
+      sourceWidth / asset.width,
+      sourceHeight / asset.height,
+    );
     return _MapGeometry(
       origin: Offset.zero,
       focus: Offset(sourceWidth / 2, sourceHeight / 2),
@@ -1373,6 +1383,9 @@ class _MapGeometry {
       ),
       surfaceWidth: sourceWidth * surfaceScale,
       surfaceHeight: sourceHeight * surfaceScale,
+      overlayStyleScale: overlayStyleScale.isFinite && overlayStyleScale > 0
+          ? overlayStyleScale
+          : 1.0,
     );
   }
 

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -802,7 +802,24 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
                         Positioned.fill(
                           child: mapAsset == null
                               ? const _OriginalRouteMapUnavailable()
-                              : _OriginalRouteMapView(asset: mapAsset),
+                              : Align(
+                                  alignment: Alignment.topLeft,
+                                  child: Transform.scale(
+                                    alignment: Alignment.topLeft,
+                                    scaleX:
+                                        geometry.width / geometry.surfaceWidth,
+                                    scaleY:
+                                        geometry.height /
+                                        geometry.surfaceHeight,
+                                    child: SizedBox(
+                                      width: geometry.surfaceWidth,
+                                      height: geometry.surfaceHeight,
+                                      child: _OriginalRouteMapView(
+                                        asset: mapAsset,
+                                      ),
+                                    ),
+                                  ),
+                                ),
                         ),
                         if (widget.selectedLineId != null)
                           Positioned.fill(
@@ -925,10 +942,12 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
     Map<String, List<NetworkMapLine>> stationLinesById,
     _MapGeometry geometry,
   ) {
+    final scale = _controller.value.getMaxScaleOnAxis();
     final station = _stationAtMapPosition(
       mapPosition,
       stations,
       geometry,
+      sceneHitRadius: 24 / (scale > 0 && scale.isFinite ? scale : 1),
       selectedLineId: widget.selectedLineId,
     );
     if (station == null) {
@@ -1044,18 +1063,14 @@ void _drawScaledPath(
 ) {
   canvas
     ..save()
-    ..scale(geometry.scaleX, geometry.scaleY)
     ..translate(-geometry.origin.dx, -geometry.origin.dy);
-  final strokeScale = math.max(geometry.scaleX, geometry.scaleY);
   canvas.drawPath(
     path,
     Paint()
       ..color = paint.color
       ..strokeCap = paint.strokeCap
       ..strokeJoin = paint.strokeJoin
-      ..strokeWidth = strokeScale <= 0
-          ? paint.strokeWidth
-          : paint.strokeWidth / strokeScale
+      ..strokeWidth = paint.strokeWidth
       ..style = paint.style,
   );
   canvas.restore();
@@ -1309,17 +1324,19 @@ class _MapGeometry {
     required this.width,
     required this.height,
     Rect? initialBounds,
-    this.scaleX = 1,
-    this.scaleY = 1,
-  }) : initialBounds = initialBounds ?? Rect.fromLTWH(0, 0, width, height);
+    double? surfaceWidth,
+    double? surfaceHeight,
+  }) : initialBounds = initialBounds ?? Rect.fromLTWH(0, 0, width, height),
+       surfaceWidth = surfaceWidth ?? width,
+       surfaceHeight = surfaceHeight ?? height;
 
   final Offset origin;
   final Offset focus;
   final double width;
   final double height;
   final Rect initialBounds;
-  final double scaleX;
-  final double scaleY;
+  final double surfaceWidth;
+  final double surfaceHeight;
 
   // Android WebView platform view는 큰 Surface에서 GL memory가 급증한다.
   static const _maxAndroidViewSurfaceExtent = 4096.0;
@@ -1332,26 +1349,30 @@ class _MapGeometry {
     final safeDevicePixelRatio = devicePixelRatio <= 0 ? 1.0 : devicePixelRatio;
     final maxLogicalExtent =
         _maxAndroidViewSurfaceExtent / safeDevicePixelRatio;
-    final displayScale = platform == TargetPlatform.android
-        ? math.min(1.0, maxLogicalExtent / math.max(asset.width, asset.height))
+    final surfaceScale = platform == TargetPlatform.android
+        ? math.min(
+            1.0,
+            maxLogicalExtent /
+                math.max(asset.coordinateWidth, asset.coordinateHeight),
+          )
         : 1.0;
-    final displayWidth = asset.width * displayScale;
-    final displayHeight = asset.height * displayScale;
+    final sourceWidth = asset.coordinateWidth;
+    final sourceHeight = asset.coordinateHeight;
     return _MapGeometry(
       origin: Offset.zero,
-      focus: Offset(displayWidth / 2, displayHeight / 2),
-      width: displayWidth,
-      height: displayHeight,
+      focus: Offset(sourceWidth / 2, sourceHeight / 2),
+      width: sourceWidth,
+      height: sourceHeight,
       initialBounds: _readableBoundsFor(
         _MapGeometry(
           origin: Offset.zero,
-          focus: Offset(displayWidth / 2, displayHeight / 2),
-          width: displayWidth,
-          height: displayHeight,
+          focus: Offset(sourceWidth / 2, sourceHeight / 2),
+          width: sourceWidth,
+          height: sourceHeight,
         ),
       ),
-      scaleX: displayWidth / asset.coordinateWidth,
-      scaleY: displayHeight / asset.coordinateHeight,
+      surfaceWidth: sourceWidth * surfaceScale,
+      surfaceHeight: sourceHeight * surfaceScale,
     );
   }
 
@@ -1418,28 +1439,31 @@ class _MapGeometry {
     );
   }
 
-  double x(NetworkMapStation station) =>
-      (station.position.x - origin.dx) * scaleX;
+  double x(NetworkMapStation station) => station.position.x - origin.dx;
 
-  double y(NetworkMapStation station) =>
-      (station.position.y - origin.dy) * scaleY;
+  double y(NetworkMapStation station) => station.position.y - origin.dy;
 }
 
-Rect _stationHitRect(NetworkMapStation station, _MapGeometry geometry) {
+Rect _stationHitRect(
+  NetworkMapStation station,
+  _MapGeometry geometry, {
+  double nodeRadius = 24,
+  double labelHeight = 40,
+}) {
   final node = Rect.fromCenter(
     center: Offset(geometry.x(station), geometry.y(station)),
-    width: 48,
-    height: 48,
+    width: nodeRadius * 2,
+    height: nodeRadius * 2,
   );
   final labelOffset = _labelOffsetFor(station);
   final labelCenter = Offset(
-    geometry.x(station) + labelOffset.dx * geometry.scaleX,
-    geometry.y(station) + labelOffset.dy * geometry.scaleY,
+    geometry.x(station) + labelOffset.dx,
+    geometry.y(station) + labelOffset.dy,
   );
   final label = Rect.fromCenter(
     center: labelCenter,
     width: math.max(64, station.nameKo.characters.length * 18 + 32),
-    height: 40,
+    height: labelHeight,
   );
   return node.expandToInclude(label);
 }
@@ -1448,12 +1472,18 @@ NetworkMapStation? _stationAtMapPosition(
   Offset position,
   List<NetworkMapStation> stations,
   _MapGeometry geometry, {
+  required double sceneHitRadius,
   String? selectedLineId,
 }) {
   NetworkMapStation? bestStation;
   var bestScore = double.infinity;
   for (final station in stations) {
-    final hitRect = _stationHitRect(station, geometry);
+    final hitRect = _stationHitRect(
+      station,
+      geometry,
+      nodeRadius: sceneHitRadius,
+      labelHeight: sceneHitRadius * 2,
+    );
     if (!hitRect.contains(position)) {
       continue;
     }
@@ -1478,8 +1508,8 @@ double _stationTapScore(
   final nodeCenter = Offset(geometry.x(station), geometry.y(station));
   final labelOffset = _labelOffsetFor(station);
   final labelCenter = Offset(
-    nodeCenter.dx + labelOffset.dx * geometry.scaleX,
-    nodeCenter.dy + labelOffset.dy * geometry.scaleY,
+    nodeCenter.dx + labelOffset.dx,
+    nodeCenter.dy + labelOffset.dy,
   );
   return math.min(
     (position - nodeCenter).distanceSquared,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -963,6 +963,113 @@ void main() {
     }
   });
 
+  testWidgets('viewBox 좌표 노선도 overlay는 표시 크기 배율을 보정한다', (tester) async {
+    const gwangjuMap = NetworkMapData(
+      regions: [NetworkMapRegion(name: '광주')],
+      selectedRegion: '광주',
+      lines: [
+        NetworkMapLine(
+          id: 'gwangju-1',
+          name: '광주 1호선',
+          color: '#009088',
+          region: '광주',
+        ),
+      ],
+      stations: [
+        NetworkMapStation(
+          id: 'station-gwangju-a',
+          nameKo: '녹동',
+          nameEn: 'Nokdong',
+          region: '광주',
+          lineId: 'gwangju-1',
+          stationCode: '100',
+          sequence: 1,
+          position: NetworkMapPosition(
+            x: 35,
+            y: 33,
+            labelDx: 0,
+            labelDy: 26,
+            upPath: '',
+            downPath: '',
+            sourceId: 'grtc-cyberstation',
+          ),
+        ),
+        NetworkMapStation(
+          id: 'station-gwangju-b',
+          nameKo: '소태',
+          nameEn: 'Sotae',
+          region: '광주',
+          lineId: 'gwangju-1',
+          stationCode: '101',
+          sequence: 2,
+          position: NetworkMapPosition(
+            x: 35,
+            y: 48,
+            labelDx: 0,
+            labelDy: 26,
+            upPath: '',
+            downPath: '',
+            sourceId: 'grtc-cyberstation',
+          ),
+        ),
+      ],
+      edges: [
+        NetworkMapEdge(
+          id: 'gwangju-edge-a-b',
+          lineId: 'gwangju-1',
+          fromStationId: 'station-gwangju-a:gwangju-1',
+          toStationId: 'station-gwangju-b:gwangju-1',
+          accessibilityStatus: 'AVAILABLE',
+          reliabilityScore: 100,
+        ),
+      ],
+      positionSources: [
+        NetworkMapPositionSource(
+          id: 'grtc-cyberstation',
+          name: '광주 공식 사이버스테이션',
+          licenseStatus: 'official',
+        ),
+      ],
+      stationLineMemberships: [
+        NetworkMapStationLineMembership(
+          stationId: 'station-gwangju-a',
+          lineId: 'gwangju-1',
+        ),
+        NetworkMapStationLineMembership(
+          stationId: 'station-gwangju-b',
+          lineId: 'gwangju-1',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(
+          networkMapRegionNames: const ['광주'],
+          networkMapData: gwangjuMap,
+        ),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('bottomNavMap')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('networkMapLineFilter')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('광주 1호선'));
+    await tester.pumpAndSettle();
+
+    final overlay = tester.widget<CustomPaint>(
+      find.byKey(const Key('networkMapSelectedLineOverlay')),
+    );
+    final painter = overlay.painter as dynamic;
+    expect(painter.styleScale as double, closeTo(190.50001 / 720, 0.001));
+  });
+
   testWidgets('노선도 역을 누르면 출발 도착 설정 sheet를 보여준다', (tester) async {
     await tester.pumpWidget(
       EasySubwayApp(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -19,6 +19,7 @@ import 'package:easysubway_mobile/onboarding.dart';
 import 'package:easysubway_mobile/route_search.dart';
 import 'package:easysubway_mobile/station_search.dart';
 import 'package:easysubway_mobile/user_data_deletion.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -928,6 +929,38 @@ void main() {
     expect(decoration.borderRadius, isNull);
     expect(find.byKey(const Key('originalRouteMapView')), findsOneWidget);
     expect(find.byKey(const Key('networkMapPainter')), findsNothing);
+  });
+
+  testWidgets('수도권 노선도는 Android에서도 원본 source 좌표계를 유지한다', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    tester.view.devicePixelRatio = 3;
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(
+            networkMapRegionNames: const ['수도권'],
+          ),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('bottomNavMap')));
+      await tester.pumpAndSettle();
+
+      final viewer = tester.widget<InteractiveViewer>(
+        find.byKey(const Key('networkMapInteractiveViewer')),
+      );
+      final mapContent = viewer.child as SizedBox;
+      expect(mapContent.width, 5724);
+      expect(mapContent.height, 6516);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+      tester.view.resetDevicePixelRatio();
+    }
   });
 
   testWidgets('노선도 역을 누르면 출발 도착 설정 sheet를 보여준다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

Refs #828

## 작업 배경

- Android 실기기에서 수도권 SVG 노선도 진입/확대 시 WebView surface 메모리 부담이 커지고, #819 이후 Android 표시 크기 보정이 station source 좌표계까지 같이 축소해 구산/불광/독바위 주변 hit target이 다른 역으로 판정될 수 있었다.
- 이번 변경은 emergency PNG 전환이 아니라 기존 SVG 경로를 유지하면서 Flutter scene 좌표계와 Android WebView surface 크기를 분리하는 기준선 정비다.
- #828 전체 이슈의 최종 tile/vector renderer 전환 전, 현재 앱이 확대와 좌표 판정을 안정적으로 버틸 수 있는 긴급 안정화 기준선으로 분리한다.

## 작업 내용

- 수도권 공식 노선도 scene은 원본 source 좌표 크기인 `5724 x 6516`을 유지하고, Android WebView surface만 기기 DPR 기준 최대 extent 4096px 안쪽으로 제한했다.
- 역 node/label hit rect는 현재 zoom scale을 반영한 scene radius로 판정해 확대 상태에서 멀리 있는 label/node가 과하게 잡히지 않게 했다.
- Android `OriginalRouteMapAssetView`에 `onRenderProcessGone` 처리를 추가해 WebView renderer가 죽어도 앱 프로세스 crash로 전파하지 않고 대체 문구를 표시하게 했다.
- Flutter CI와 Android release artifact workflow의 Flutter toolchain을 `3.44.0`으로 고정했다.
- Android DPR 3 환경에서도 수도권 노선도 `InteractiveViewer` child가 source 좌표계 크기를 유지하는 회귀 테스트를 추가했다.
- 광주처럼 SVG viewBox 좌표와 표시 pixel 크기가 다른 노선도에서 선택 노선 overlay stroke와 역 marker가 과도하게 커지지 않도록 표시 배율 보정 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/*.test.mjs`: exit 0, 102 passed
  - `node --test tools/datapack/*.test.mjs`: exit 0, 89 passed
  - `cd apps/mobile && flutter pub get`: exit 0
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name '노선도'`: exit 0, 10 passed
  - `cd apps/mobile && flutter test`: exit 0, 414 passed
  - `cd apps/mobile && flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `cd apps/mobile && flutter build ios --simulator --debug`: exit 0, `build/ios/iphonesimulator/Runner.app` 생성
  - `git diff --check origin/main...HEAD`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Android 노선도 진입 | Android 16 실기기 `SM A175N / RFKYA01VMQY` | `adb install -r`, `adb shell am start`, UI tree dump, screenshot | `.codex/evidence/828-route-map-baseline/android-route-map-ui.xml`, `.codex/evidence/828-route-map-baseline/android-route-map.png` | UI tree에 `android.webkit.WebView`, `노선도 Tab 2 of 5 selected=true`, station button targets가 노출됨 |
| Android 확대 안정성 | Android 16 실기기 `SM A175N / RFKYA01VMQY` | `확대` 버튼 2회 tap 후 screenshot, crash buffer, meminfo 확인 | `.codex/evidence/828-route-map-baseline/android-route-map-zoom.png`, `.codex/evidence/828-route-map-baseline/android-route-map-zoom-crash.log`, `.codex/evidence/828-route-map-baseline/android-route-map-zoom-meminfo.txt` | crash log 0 byte, process alive, `Activities: 1`, `WebViews: 1`, `TOTAL PSS: 726484KB`, `Graphics: 370749KB` |
| Android 좌표 기준선 | Flutter widget test | Android platform override + DPR 3에서 수도권 노선도 child size 검증 | `flutter test test/widget_test.dart --plain-name '수도권 노선도는 Android에서도 원본 source 좌표계를 유지한다'` | `5724 x 6516` source 좌표계 유지 |
| 역 hit target 회귀 | Flutter widget test | 노선도 관련 widget test 전체 실행 | `flutter test test/widget_test.dart --plain-name '노선도'` | 10개 통과, 겹친 좌표에서 구산 선택 시 연신내 sheet가 뜨지 않는 기존 회귀 테스트 포함 |
| viewBox overlay 배율 회귀 | Flutter widget test | 광주 viewBox 좌표 노선도에서 선택 노선 overlay painter 배율 확인 | `flutter test test/widget_test.dart --plain-name '노선도'` | `190.50001 / 720` 기준 배율 보정 확인 |
| 전체 모바일 회귀 | Flutter test | 전체 Flutter test 실행 | `flutter test` | 414개 통과 |
| Android 빌드 | Android debug | Flutter debug APK build | `flutter build apk --debug` | `app-debug.apk` 생성 |
| iOS 빌드/실행 | iOS 26.5 Simulator `Maum iPhone 17` | simulator debug build, install, launch, screenshot | `.codex/evidence/828-route-map-baseline/ios-launch.png` | build/install/launch 성공. 이 simctl 버전은 tap 입력을 지원하지 않아 iOS 노선도 화면 직접 tap 증거는 미수집 |
| iOS 빌드 회귀 | iOS simulator debug | Flutter simulator debug build | `flutter build ios --simulator --debug` | `Runner.app` 생성 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/network_map.dart`의 `_MapGeometry.fromOriginalAsset`: source 좌표계와 Android surface 크기 분리
  - `apps/mobile/lib/network_map.dart`의 `_SelectedLineOverlayPainter`: viewBox 좌표계에서 선택 노선 overlay stroke/marker 표시 배율 보정
  - `apps/mobile/lib/network_map.dart`의 `_stationAtMapPosition`: zoom scale 기반 scene hit radius
  - `apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/OriginalRouteMapAssetView.kt`: WebView renderer gone 처리

## 리스크

- Android SVG는 여전히 단일 WebView surface를 사용한다. 이번 변경은 crash와 좌표 오염을 줄이는 기준선이며, 초고배율에서 완전한 벡터 선명도를 보장하는 tile/vector renderer 전환은 별도 작업이다.
- iOS는 build/install/launch와 simulator debug build까지 확인했지만 simulator tap 자동화가 없어 노선도 화면 직접 tap 증거는 Android만 수집했다. 공통 Flutter 좌표계는 widget test로 검증했고, Android 전용 renderer 보호 코드는 iOS path에 영향을 주지 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
