### PR TITLE
[Refactor] 설정 보기 옵션과 배포 용어 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -657,6 +657,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         recentRoutesFuture: widget.recentRoutesFuture,
         onUserDataDeleted: _handleUserDataDeleted,
         onMobilityProfileChanged: _saveMobilityProfile,
+        onViewPreferencesChanged: _saveViewPreferences,
       ),
     );
   }
@@ -742,6 +743,26 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
     final nextResult = OnboardingResult(
       profile: profile,
       preferences: currentResult.preferences,
+    );
+    await _saveOnboardingResult(nextResult);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _onboardingState = OnboardingState.completed(result: nextResult);
+    });
+  }
+
+  Future<void> _saveViewPreferences(
+    OnboardingViewPreferences preferences,
+  ) async {
+    final currentResult = _onboardingState.result;
+    if (currentResult == null) {
+      return;
+    }
+    final nextResult = OnboardingResult(
+      profile: currentResult.profile,
+      preferences: preferences,
     );
     await _saveOnboardingResult(nextResult);
     if (!mounted) {
@@ -1006,6 +1027,7 @@ class HomeScreen extends StatefulWidget {
     required this.userDataDeletionRepository,
     required this.onUserDataDeleted,
     required this.onMobilityProfileChanged,
+    required this.onViewPreferencesChanged,
     required this.recentRoutesFuture,
     this.viewPreferences = const OnboardingViewPreferences.defaults(),
     this.simpleViewEnabled = true,
@@ -1034,6 +1056,8 @@ class HomeScreen extends StatefulWidget {
   final Future<void> Function(UserDataDeletionResult result)? onUserDataDeleted;
   final Future<void> Function(MobilityProfileOption profile)?
   onMobilityProfileChanged;
+  final Future<void> Function(OnboardingViewPreferences preferences)
+  onViewPreferencesChanged;
   final Future<List<FavoriteRoute>>? recentRoutesFuture;
   final String initialMobilityType;
   final OnboardingViewPreferences viewPreferences;
@@ -1153,6 +1177,7 @@ class _HomeScreenState extends State<HomeScreen> {
             viewPreferences: widget.viewPreferences,
             notificationRepository: notificationRepository,
             notificationPermissionProvider: notificationPermissionProvider,
+            onViewPreferencesChanged: widget.onViewPreferencesChanged,
             onOpenMobilityProfile: _openMobilityProfile,
             onOpenSupportAccess: openSupportAccess,
             onOpenMyReports: openMyReports,
@@ -2789,6 +2814,7 @@ class AppSettingsScreen extends StatefulWidget {
     required this.viewPreferences,
     required this.notificationRepository,
     required this.notificationPermissionProvider,
+    required this.onViewPreferencesChanged,
     required this.onOpenMobilityProfile,
     required this.onOpenSupportAccess,
     required this.onOpenMyReports,
@@ -2799,6 +2825,8 @@ class AppSettingsScreen extends StatefulWidget {
   final OnboardingViewPreferences viewPreferences;
   final NotificationSettingsRepository? notificationRepository;
   final NotificationPermissionProvider? notificationPermissionProvider;
+  final Future<void> Function(OnboardingViewPreferences preferences)
+  onViewPreferencesChanged;
   final Future<MobilityProfileOption?> Function() onOpenMobilityProfile;
   final VoidCallback onOpenSupportAccess;
   final VoidCallback onOpenMyReports;
@@ -2809,6 +2837,15 @@ class AppSettingsScreen extends StatefulWidget {
 
 class _AppSettingsScreenState extends State<AppSettingsScreen> {
   late MobilityProfileOption _profile = widget.currentProfile;
+  late OnboardingViewPreferences _viewPreferences = widget.viewPreferences;
+
+  @override
+  void didUpdateWidget(AppSettingsScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.viewPreferences != widget.viewPreferences) {
+      _viewPreferences = widget.viewPreferences;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -2847,22 +2884,34 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
                   key: const Key('largeTextSettingsButton'),
                   icon: Icons.text_fields,
                   title: '큰 글자',
-                  enabled: widget.viewPreferences.largeTextEnabled,
-                  onTap: _showViewPreferenceGuide,
+                  enabled: _viewPreferences.largeTextEnabled,
+                  onChanged: (value) {
+                    _updateViewPreferences(
+                      _viewPreferences.copyWith(largeTextEnabled: value),
+                    );
+                  },
                 ),
                 _AppSettingsPreferenceTile(
                   key: const Key('simpleViewSettingsButton'),
                   icon: Icons.visibility_outlined,
                   title: '간편 보기',
-                  enabled: widget.viewPreferences.simpleViewEnabled,
-                  onTap: _showViewPreferenceGuide,
+                  enabled: _viewPreferences.simpleViewEnabled,
+                  onChanged: (value) {
+                    _updateViewPreferences(
+                      _viewPreferences.copyWith(simpleViewEnabled: value),
+                    );
+                  },
                 ),
                 _AppSettingsPreferenceTile(
                   key: const Key('highContrastSettingsButton'),
                   icon: Icons.contrast,
                   title: '고대비',
-                  enabled: widget.viewPreferences.highContrastEnabled,
-                  onTap: _showViewPreferenceGuide,
+                  enabled: _viewPreferences.highContrastEnabled,
+                  onChanged: (value) {
+                    _updateViewPreferences(
+                      _viewPreferences.copyWith(highContrastEnabled: value),
+                    );
+                  },
                 ),
               ],
             ),
@@ -2873,7 +2922,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
                 const _AppSettingsInfoTile(
                   icon: Icons.public,
                   title: '수도권 우선',
-                  subtitle: '오프라인 데이터팩과 검증된 출처를 먼저 사용해요',
+                  subtitle: '인터넷이 불안정해도 주요 역 정보를 먼저 보여줘요',
                 ),
                 _AppSettingsActionTile(
                   key: const Key('offlineDataSettingsButton'),
@@ -2897,8 +2946,8 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
                 if (widget.notificationRepository == null)
                   const _AppSettingsInfoTile(
                     icon: Icons.notifications_off_outlined,
-                    title: '알림 설정 대기 중',
-                    subtitle: '실기기 QA 전에는 푸시 알림을 켜지 않아요',
+                    title: '알림은 아직 사용할 수 없어요',
+                    subtitle: '시설 상태와 신고 처리 안내는 앱 안에서 확인할 수 있어요',
                   )
                 else
                   _AppSettingsActionTile(
@@ -2952,10 +3001,13 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
     );
   }
 
-  void _showViewPreferenceGuide() {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(const SnackBar(content: Text('보기 설정은 처음 설정에서 변경할 수 있어요.')));
+  Future<void> _updateViewPreferences(
+    OnboardingViewPreferences preferences,
+  ) async {
+    setState(() {
+      _viewPreferences = preferences;
+    });
+    await widget.onViewPreferencesChanged(preferences);
   }
 }
 
@@ -3097,25 +3149,26 @@ class _AppSettingsPreferenceTile extends StatelessWidget {
     required this.icon,
     required this.title,
     required this.enabled,
-    required this.onTap,
+    required this.onChanged,
     super.key,
   });
 
   final IconData icon;
   final String title;
   final bool enabled;
-  final VoidCallback onTap;
+  final ValueChanged<bool> onChanged;
 
   @override
   Widget build(BuildContext context) {
     final value = enabled ? '켜짐' : '꺼짐';
+    final action = enabled ? '끄기' : '켜기';
     return Semantics(
-      button: true,
-      label: '$title, $value, 처음 설정에서 변경할 수 있어요',
-      onTap: onTap,
+      label: '$title, $value, 두 번 탭해 $action',
+      toggled: enabled,
+      onTap: () => onChanged(!enabled),
       child: ExcludeSemantics(
         child: ListTile(
-          onTap: onTap,
+          onTap: () => onChanged(!enabled),
           minVerticalPadding: 12,
           minLeadingWidth: 32,
           leading: Icon(icon, color: EasySubwayAccessibleColors.primary),
@@ -3128,7 +3181,7 @@ class _AppSettingsPreferenceTile extends StatelessWidget {
             ),
           ),
           subtitle: Text(
-            '처음 설정에서 변경할 수 있어요',
+            '설정 화면에서 바로 바꿀 수 있어요',
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               color: EasySubwayAccessibleColors.mutedText,
               height: 1.3,
@@ -3144,8 +3197,16 @@ class _AppSettingsPreferenceTile extends StatelessWidget {
                   fontWeight: FontWeight.w800,
                 ),
               ),
-              const SizedBox(width: 4),
-              const Icon(Icons.chevron_right),
+              const SizedBox(width: 8),
+              Switch(
+                value: enabled,
+                onChanged: onChanged,
+                activeThumbColor: Colors.white,
+                activeTrackColor: const Color(0xFF0D8A6D),
+                inactiveThumbColor: Colors.white,
+                inactiveTrackColor: const Color(0xFFC8D3DC),
+                materialTapTargetSize: MaterialTapTargetSize.padded,
+              ),
             ],
           ),
           shape: Border(

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -548,6 +548,8 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
   bool _startScreenDismissed = false;
   bool _introScreenDismissed = false;
   bool _pendingFacilityReportPhotoRecoveryStarted = false;
+  bool _savingViewPreferences = false;
+  OnboardingViewPreferences? _pendingViewPreferences;
   UserDataDeletionResult? _dataDeletionResult;
 
   @override
@@ -756,20 +758,47 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
   Future<void> _saveViewPreferences(
     OnboardingViewPreferences preferences,
   ) async {
+    _pendingViewPreferences = preferences;
+    _applyViewPreferences(preferences);
+    if (_savingViewPreferences) {
+      return;
+    }
+    _savingViewPreferences = true;
+    try {
+      while (mounted) {
+        final nextPreferences = _pendingViewPreferences;
+        _pendingViewPreferences = null;
+        if (nextPreferences == null) {
+          break;
+        }
+        final currentResult = _onboardingState.result;
+        if (currentResult == null) {
+          break;
+        }
+        await _saveOnboardingResult(
+          OnboardingResult(
+            profile: currentResult.profile,
+            preferences: nextPreferences,
+          ),
+        );
+      }
+    } finally {
+      _savingViewPreferences = false;
+    }
+  }
+
+  void _applyViewPreferences(OnboardingViewPreferences preferences) {
     final currentResult = _onboardingState.result;
     if (currentResult == null) {
       return;
     }
-    final nextResult = OnboardingResult(
-      profile: currentResult.profile,
-      preferences: preferences,
-    );
-    await _saveOnboardingResult(nextResult);
-    if (!mounted) {
-      return;
-    }
     setState(() {
-      _onboardingState = OnboardingState.completed(result: nextResult);
+      _onboardingState = OnboardingState.completed(
+        result: OnboardingResult(
+          profile: currentResult.profile,
+          preferences: preferences,
+        ),
+      );
     });
   }
 
@@ -2849,153 +2878,156 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('설정')),
-      body: SafeArea(
-        child: ListView(
-          padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
-          children: [
-            _AppSettingsSection(
-              key: const Key('settingsSection-mobility'),
-              title: '이동 조건',
-              children: [
-                _AppSettingsActionTile(
-                  key: const Key('mobilityProfileButton'),
-                  icon: Icons.directions_walk,
-                  title: _profile.appliedConditionLabel,
-                  subtitle: _profile.summary,
-                  onTap: () async {
-                    final selected = await widget.onOpenMobilityProfile();
-                    if (!mounted || selected == null) {
-                      return;
-                    }
-                    setState(() {
-                      _profile = selected;
-                    });
-                  },
-                ),
-              ],
-            ),
-            _AppSettingsSection(
-              key: const Key('settingsSection-reading'),
-              title: '화면 및 접근성',
-              children: [
-                _AppSettingsPreferenceTile(
-                  key: const Key('largeTextSettingsButton'),
-                  icon: Icons.text_fields,
-                  title: '큰 글자',
-                  enabled: _viewPreferences.largeTextEnabled,
-                  onChanged: (value) {
-                    _updateViewPreferences(
-                      _viewPreferences.copyWith(largeTextEnabled: value),
-                    );
-                  },
-                ),
-                _AppSettingsPreferenceTile(
-                  key: const Key('simpleViewSettingsButton'),
-                  icon: Icons.visibility_outlined,
-                  title: '간편 보기',
-                  enabled: _viewPreferences.simpleViewEnabled,
-                  onChanged: (value) {
-                    _updateViewPreferences(
-                      _viewPreferences.copyWith(simpleViewEnabled: value),
-                    );
-                  },
-                ),
-                _AppSettingsPreferenceTile(
-                  key: const Key('highContrastSettingsButton'),
-                  icon: Icons.contrast,
-                  title: '고대비',
-                  enabled: _viewPreferences.highContrastEnabled,
-                  onChanged: (value) {
-                    _updateViewPreferences(
-                      _viewPreferences.copyWith(highContrastEnabled: value),
-                    );
-                  },
-                ),
-              ],
-            ),
-            _AppSettingsSection(
-              key: const Key('settingsSection-region-data'),
-              title: '기본 지역과 데이터',
-              children: [
-                const _AppSettingsInfoTile(
-                  icon: Icons.public,
-                  title: '수도권 우선',
-                  subtitle: '인터넷이 불안정해도 주요 역 정보를 먼저 보여줘요',
-                ),
-                _AppSettingsActionTile(
-                  key: const Key('offlineDataSettingsButton'),
-                  icon: Icons.offline_pin_outlined,
-                  title: '인터넷 없이 이용',
-                  subtitle: '노선도와 역 정보 사용 범위를 확인해요',
-                  onTap: () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute<void>(
-                        builder: (_) => const OfflineDataScreen(),
-                      ),
-                    );
-                  },
-                ),
-              ],
-            ),
-            _AppSettingsSection(
-              key: const Key('settingsSection-notification'),
-              title: '알림',
-              children: [
-                if (widget.notificationRepository == null)
-                  const _AppSettingsInfoTile(
-                    icon: Icons.notifications_off_outlined,
-                    title: '알림은 아직 사용할 수 없어요',
-                    subtitle: '시설 상태와 신고 처리 안내는 앱 안에서 확인할 수 있어요',
-                  )
-                else
+    return _OnboardingPreferenceScope(
+      preferences: _viewPreferences,
+      child: Scaffold(
+        appBar: AppBar(title: const Text('설정')),
+        body: SafeArea(
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+            children: [
+              _AppSettingsSection(
+                key: const Key('settingsSection-mobility'),
+                title: '이동 조건',
+                children: [
                   _AppSettingsActionTile(
-                    key: const Key('notificationSettingsButton'),
-                    icon: Icons.notifications_active_outlined,
-                    title: '알림 설정',
-                    subtitle: '시설 상태, 신고 처리, 정보 갱신 알림을 관리해요',
+                    key: const Key('mobilityProfileButton'),
+                    icon: Icons.directions_walk,
+                    title: _profile.appliedConditionLabel,
+                    subtitle: _profile.summary,
+                    onTap: () async {
+                      final selected = await widget.onOpenMobilityProfile();
+                      if (!mounted || selected == null) {
+                        return;
+                      }
+                      setState(() {
+                        _profile = selected;
+                      });
+                    },
+                  ),
+                ],
+              ),
+              _AppSettingsSection(
+                key: const Key('settingsSection-reading'),
+                title: '화면 및 접근성',
+                children: [
+                  _AppSettingsPreferenceTile(
+                    key: const Key('largeTextSettingsButton'),
+                    icon: Icons.text_fields,
+                    title: '큰 글자',
+                    enabled: _viewPreferences.largeTextEnabled,
+                    onChanged: (value) {
+                      _updateViewPreferences(
+                        _viewPreferences.copyWith(largeTextEnabled: value),
+                      );
+                    },
+                  ),
+                  _AppSettingsPreferenceTile(
+                    key: const Key('simpleViewSettingsButton'),
+                    icon: Icons.visibility_outlined,
+                    title: '간편 보기',
+                    enabled: _viewPreferences.simpleViewEnabled,
+                    onChanged: (value) {
+                      _updateViewPreferences(
+                        _viewPreferences.copyWith(simpleViewEnabled: value),
+                      );
+                    },
+                  ),
+                  _AppSettingsPreferenceTile(
+                    key: const Key('highContrastSettingsButton'),
+                    icon: Icons.contrast,
+                    title: '고대비',
+                    enabled: _viewPreferences.highContrastEnabled,
+                    onChanged: (value) {
+                      _updateViewPreferences(
+                        _viewPreferences.copyWith(highContrastEnabled: value),
+                      );
+                    },
+                  ),
+                ],
+              ),
+              _AppSettingsSection(
+                key: const Key('settingsSection-region-data'),
+                title: '기본 지역과 데이터',
+                children: [
+                  const _AppSettingsInfoTile(
+                    icon: Icons.public,
+                    title: '수도권 우선',
+                    subtitle: '인터넷이 불안정해도 주요 역 정보를 먼저 보여줘요',
+                  ),
+                  _AppSettingsActionTile(
+                    key: const Key('offlineDataSettingsButton'),
+                    icon: Icons.offline_pin_outlined,
+                    title: '인터넷 없이 이용',
+                    subtitle: '노선도와 역 정보 사용 범위를 확인해요',
                     onTap: () {
                       Navigator.of(context).push(
                         MaterialPageRoute<void>(
-                          builder: (_) => NotificationSettingsScreen(
-                            repository: widget.notificationRepository!,
-                            notificationPermissionProvider:
-                                widget.notificationPermissionProvider,
-                          ),
+                          builder: (_) => const OfflineDataScreen(),
                         ),
                       );
                     },
                   ),
-              ],
-            ),
-            _AppSettingsSection(
-              key: const Key('settingsSection-activity'),
-              title: '내 활동',
-              children: [
-                _AppSettingsActionTile(
-                  key: const Key('myReportsSettingsButton'),
-                  icon: Icons.receipt_long_outlined,
-                  title: '내 신고',
-                  subtitle: '접수한 시설 신고와 처리 상태를 확인해요',
-                  onTap: widget.onOpenMyReports,
-                ),
-              ],
-            ),
-            _AppSettingsSection(
-              key: const Key('settingsSection-help-privacy'),
-              title: '개인정보 및 도움말',
-              children: [
-                _AppSettingsActionTile(
-                  key: const Key('settingsSupportPrivacyButton'),
-                  icon: Icons.help_outline,
-                  title: '도움말·문의',
-                  subtitle: '사용법, 개인정보, 문의 경로를 확인해요',
-                  onTap: widget.onOpenSupportAccess,
-                ),
-              ],
-            ),
-          ],
+                ],
+              ),
+              _AppSettingsSection(
+                key: const Key('settingsSection-notification'),
+                title: '알림',
+                children: [
+                  if (widget.notificationRepository == null)
+                    const _AppSettingsInfoTile(
+                      icon: Icons.notifications_off_outlined,
+                      title: '알림은 아직 사용할 수 없어요',
+                      subtitle: '시설 상태와 신고 처리 안내는 앱 안에서 확인할 수 있어요',
+                    )
+                  else
+                    _AppSettingsActionTile(
+                      key: const Key('notificationSettingsButton'),
+                      icon: Icons.notifications_active_outlined,
+                      title: '알림 설정',
+                      subtitle: '시설 상태, 신고 처리, 정보 갱신 알림을 관리해요',
+                      onTap: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute<void>(
+                            builder: (_) => NotificationSettingsScreen(
+                              repository: widget.notificationRepository!,
+                              notificationPermissionProvider:
+                                  widget.notificationPermissionProvider,
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                ],
+              ),
+              _AppSettingsSection(
+                key: const Key('settingsSection-activity'),
+                title: '내 활동',
+                children: [
+                  _AppSettingsActionTile(
+                    key: const Key('myReportsSettingsButton'),
+                    icon: Icons.receipt_long_outlined,
+                    title: '내 신고',
+                    subtitle: '접수한 시설 신고와 처리 상태를 확인해요',
+                    onTap: widget.onOpenMyReports,
+                  ),
+                ],
+              ),
+              _AppSettingsSection(
+                key: const Key('settingsSection-help-privacy'),
+                title: '개인정보 및 도움말',
+                children: [
+                  _AppSettingsActionTile(
+                    key: const Key('settingsSupportPrivacyButton'),
+                    icon: Icons.help_outline,
+                    title: '도움말·문의',
+                    subtitle: '사용법, 개인정보, 문의 경로를 확인해요',
+                    onTap: widget.onOpenSupportAccess,
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -548,8 +548,8 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
   bool _startScreenDismissed = false;
   bool _introScreenDismissed = false;
   bool _pendingFacilityReportPhotoRecoveryStarted = false;
-  bool _savingViewPreferences = false;
-  OnboardingViewPreferences? _pendingViewPreferences;
+  bool _savingOnboardingResult = false;
+  OnboardingResult? _pendingOnboardingResult;
   UserDataDeletionResult? _dataDeletionResult;
 
   @override
@@ -725,7 +725,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
     _schedulePendingFacilityReportPhotoRecovery();
   }
 
-  Future<void> _saveOnboardingResult(OnboardingResult result) async {
+  Future<void> _persistOnboardingResult(OnboardingResult result) async {
     try {
       await widget.onboardingStore?.saveResult(result);
     } catch (error, stackTrace) {
@@ -734,6 +734,27 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         stackTrace,
         context: '온보딩 설정을 저장하는 중 예외가 발생했습니다.',
       );
+    }
+  }
+
+  Future<void> _saveOnboardingResult(OnboardingResult result) async {
+    _pendingOnboardingResult = result;
+    _applyOnboardingResult(result);
+    if (_savingOnboardingResult) {
+      return;
+    }
+    _savingOnboardingResult = true;
+    try {
+      while (mounted) {
+        final nextResult = _pendingOnboardingResult;
+        _pendingOnboardingResult = null;
+        if (nextResult == null) {
+          break;
+        }
+        await _persistOnboardingResult(nextResult);
+      }
+    } finally {
+      _savingOnboardingResult = false;
     }
   }
 
@@ -747,58 +768,29 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
       preferences: currentResult.preferences,
     );
     await _saveOnboardingResult(nextResult);
-    if (!mounted) {
-      return;
-    }
-    setState(() {
-      _onboardingState = OnboardingState.completed(result: nextResult);
-    });
   }
 
   Future<void> _saveViewPreferences(
     OnboardingViewPreferences preferences,
   ) async {
-    _pendingViewPreferences = preferences;
-    _applyViewPreferences(preferences);
-    if (_savingViewPreferences) {
-      return;
-    }
-    _savingViewPreferences = true;
-    try {
-      while (mounted) {
-        final nextPreferences = _pendingViewPreferences;
-        _pendingViewPreferences = null;
-        if (nextPreferences == null) {
-          break;
-        }
-        final currentResult = _onboardingState.result;
-        if (currentResult == null) {
-          break;
-        }
-        await _saveOnboardingResult(
-          OnboardingResult(
-            profile: currentResult.profile,
-            preferences: nextPreferences,
-          ),
-        );
-      }
-    } finally {
-      _savingViewPreferences = false;
-    }
-  }
-
-  void _applyViewPreferences(OnboardingViewPreferences preferences) {
     final currentResult = _onboardingState.result;
     if (currentResult == null) {
       return;
     }
+    await _saveOnboardingResult(
+      OnboardingResult(
+        profile: currentResult.profile,
+        preferences: preferences,
+      ),
+    );
+  }
+
+  void _applyOnboardingResult(OnboardingResult result) {
+    if (!mounted) {
+      return;
+    }
     setState(() {
-      _onboardingState = OnboardingState.completed(
-        result: OnboardingResult(
-          profile: currentResult.profile,
-          preferences: preferences,
-        ),
-      );
+      _onboardingState = OnboardingState.completed(result: result);
     });
   }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1512,6 +1512,8 @@ void main() {
       expect(find.text('간편 보기'), findsOneWidget);
       expect(find.text('켜짐'), findsNWidgets(2));
       expect(find.text('꺼짐'), findsOneWidget);
+      expect(find.textContaining('데이터팩'), findsNothing);
+      expect(find.textContaining('실기기 QA'), findsNothing);
       expect(find.byKey(const Key('mobilityProfileButton')), findsOneWidget);
       expect(
         settingsActionSemantics(
@@ -1521,19 +1523,19 @@ void main() {
       );
       expect(
         settingsActionSemantics(
-          '큰 글자, 켜짐, 처음 설정에서 변경할 수 있어요',
+          '큰 글자, 켜짐, 두 번 탭해 끄기',
         ).getSemanticsData().hasAction(SemanticsAction.tap),
         isTrue,
       );
       expect(
         settingsActionSemantics(
-          '간편 보기, 꺼짐, 처음 설정에서 변경할 수 있어요',
+          '간편 보기, 꺼짐, 두 번 탭해 켜기',
         ).getSemanticsData().hasAction(SemanticsAction.tap),
         isTrue,
       );
       expect(
         settingsActionSemantics(
-          '고대비, 켜짐, 처음 설정에서 변경할 수 있어요',
+          '고대비, 켜짐, 두 번 탭해 끄기',
         ).getSemanticsData().hasAction(SemanticsAction.tap),
         isTrue,
       );
@@ -1591,6 +1593,115 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('설정 화면 보기 옵션은 변경값을 저장하고 다시 실행해도 유지한다', (tester) async {
+    final onboardingStore = MemoryOnboardingResultStore(
+      initialResult: OnboardingResult(
+        profile: mobilityProfileOptions.first,
+        preferences: const OnboardingViewPreferences(
+          largeTextEnabled: true,
+          highContrastEnabled: false,
+          simpleViewEnabled: true,
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        onboardingStore: onboardingStore,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await _openSettingsScreen(tester);
+    await tester.tap(find.byKey(const Key('largeTextSettingsButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('highContrastSettingsButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('simpleViewSettingsButton')));
+    await tester.pumpAndSettle();
+
+    expect(onboardingStore.saveCount, 3);
+    expect(onboardingStore.savedResult?.preferences.largeTextEnabled, isFalse);
+    expect(
+      onboardingStore.savedResult?.preferences.highContrastEnabled,
+      isTrue,
+    );
+    expect(onboardingStore.savedResult?.preferences.simpleViewEnabled, isFalse);
+    expect(find.bySemanticsLabel('큰 글자, 꺼짐, 두 번 탭해 켜기'), findsOneWidget);
+    expect(find.bySemanticsLabel('고대비, 켜짐, 두 번 탭해 끄기'), findsOneWidget);
+    expect(find.bySemanticsLabel('간편 보기, 꺼짐, 두 번 탭해 켜기'), findsOneWidget);
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    final homeContext = tester.element(find.byType(HomeScreen));
+    expect(MediaQuery.textScalerOf(homeContext).scale(20), closeTo(20, 0.01));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pumpAndSettle();
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        onboardingStore: onboardingStore,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await _openSettingsScreen(tester);
+    expect(find.bySemanticsLabel('큰 글자, 꺼짐, 두 번 탭해 켜기'), findsOneWidget);
+    expect(find.bySemanticsLabel('고대비, 켜짐, 두 번 탭해 끄기'), findsOneWidget);
+    expect(find.bySemanticsLabel('간편 보기, 꺼짐, 두 번 탭해 켜기'), findsOneWidget);
+  });
+
+  testWidgets('설정 화면 보기 옵션은 큰 글자에서도 스위치를 조작할 수 있다', (tester) async {
+    tester.view.physicalSize = const Size(320, 1200);
+    tester.view.devicePixelRatio = 1;
+    tester.platformDispatcher.textScaleFactorTestValue = 2;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      tester.platformDispatcher.clearTextScaleFactorTestValue();
+    });
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        initialOnboardingState: _completedOnboardingStateWithPreferences(
+          preferences: const OnboardingViewPreferences(
+            largeTextEnabled: true,
+            highContrastEnabled: true,
+            simpleViewEnabled: false,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await _openSettingsScreen(tester);
+
+    expect(find.byKey(const Key('largeTextSettingsButton')), findsOneWidget);
+    expect(find.byKey(const Key('highContrastSettingsButton')), findsOneWidget);
+    expect(find.byKey(const Key('simpleViewSettingsButton')), findsOneWidget);
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('settingsSection-notification')),
+      160,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('알림은 아직 사용할 수 없어요'), findsOneWidget);
+    expect(find.textContaining('실기기 QA'), findsNothing);
+    await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+    await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
   });
 
   testWidgets('홈 이동 조건 요약은 현재 profile과 변경 결과를 보여준다', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1719,6 +1719,62 @@ void main() {
     expect(onboardingStore.savedResult?.preferences.simpleViewEnabled, isFalse);
   });
 
+  testWidgets('설정 화면 보기 옵션 저장 중 이동 조건을 바꿔도 마지막 결과를 유지한다', (tester) async {
+    final firstSave = Completer<void>();
+    final latestSave = Completer<void>();
+    final onboardingStore = MemoryOnboardingResultStore(
+      initialResult: OnboardingResult(
+        profile: mobilityProfileOptions.first,
+        preferences: const OnboardingViewPreferences(
+          largeTextEnabled: true,
+          highContrastEnabled: false,
+          simpleViewEnabled: true,
+        ),
+      ),
+      saveCompleters: [firstSave, latestSave],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        onboardingStore: onboardingStore,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await _openSettingsScreen(tester);
+    await tester.tap(find.byKey(const Key('largeTextSettingsButton')));
+    await tester.pump();
+    expect(onboardingStore.saveCount, 1);
+
+    await tester.tap(find.byKey(const Key('mobilityProfileButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('mobilityProfileCard-wheelchair')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('mobilityProfileDoneButton')));
+    await tester.pumpAndSettle();
+
+    expect(onboardingStore.saveCount, 1);
+    expect(find.text('계단 없는 길만 안내해요'), findsOneWidget);
+
+    firstSave.complete();
+    await tester.pump();
+    expect(onboardingStore.saveCount, 2);
+    latestSave.complete();
+    await tester.pumpAndSettle();
+
+    expect(onboardingStore.savedResult?.profile.id, 'wheelchair');
+    expect(onboardingStore.savedResult?.preferences.largeTextEnabled, isFalse);
+    expect(
+      onboardingStore.savedResult?.preferences.highContrastEnabled,
+      isFalse,
+    );
+    expect(onboardingStore.savedResult?.preferences.simpleViewEnabled, isTrue);
+  });
+
   testWidgets('설정 화면 보기 옵션은 큰 글자에서도 스위치를 조작할 수 있다', (tester) async {
     tester.view.physicalSize = const Size(320, 1200);
     tester.view.devicePixelRatio = 1;

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1621,6 +1621,12 @@ void main() {
     await _openSettingsScreen(tester);
     await tester.tap(find.byKey(const Key('largeTextSettingsButton')));
     await tester.pumpAndSettle();
+    expect(
+      MediaQuery.textScalerOf(
+        tester.element(find.byKey(const Key('largeTextSettingsButton'))),
+      ).scale(20),
+      closeTo(20, 0.01),
+    );
     await tester.tap(find.byKey(const Key('highContrastSettingsButton')));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('simpleViewSettingsButton')));
@@ -1658,6 +1664,59 @@ void main() {
     expect(find.bySemanticsLabel('큰 글자, 꺼짐, 두 번 탭해 켜기'), findsOneWidget);
     expect(find.bySemanticsLabel('고대비, 켜짐, 두 번 탭해 끄기'), findsOneWidget);
     expect(find.bySemanticsLabel('간편 보기, 꺼짐, 두 번 탭해 켜기'), findsOneWidget);
+  });
+
+  testWidgets('설정 화면 보기 옵션은 빠른 연속 변경에서도 마지막 값을 저장한다', (tester) async {
+    final firstSave = Completer<void>();
+    final latestSave = Completer<void>();
+    final onboardingStore = MemoryOnboardingResultStore(
+      initialResult: OnboardingResult(
+        profile: mobilityProfileOptions.first,
+        preferences: const OnboardingViewPreferences(
+          largeTextEnabled: true,
+          highContrastEnabled: false,
+          simpleViewEnabled: true,
+        ),
+      ),
+      saveCompleters: [firstSave, latestSave],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        onboardingStore: onboardingStore,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await _openSettingsScreen(tester);
+    await tester.tap(find.byKey(const Key('largeTextSettingsButton')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('highContrastSettingsButton')));
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('simpleViewSettingsButton')));
+    await tester.pump();
+
+    expect(onboardingStore.saveCount, 1);
+    expect(find.bySemanticsLabel('큰 글자, 꺼짐, 두 번 탭해 켜기'), findsOneWidget);
+    expect(find.bySemanticsLabel('고대비, 켜짐, 두 번 탭해 끄기'), findsOneWidget);
+    expect(find.bySemanticsLabel('간편 보기, 꺼짐, 두 번 탭해 켜기'), findsOneWidget);
+
+    firstSave.complete();
+    await tester.pump();
+    expect(onboardingStore.saveCount, 2);
+    latestSave.complete();
+    await tester.pumpAndSettle();
+
+    expect(onboardingStore.savedResult?.preferences.largeTextEnabled, isFalse);
+    expect(
+      onboardingStore.savedResult?.preferences.highContrastEnabled,
+      isTrue,
+    );
+    expect(onboardingStore.savedResult?.preferences.simpleViewEnabled, isFalse);
   });
 
   testWidgets('설정 화면 보기 옵션은 큰 글자에서도 스위치를 조작할 수 있다', (tester) async {
@@ -8799,10 +8858,12 @@ class MemoryOnboardingResultStore implements OnboardingResultStore {
   MemoryOnboardingResultStore({
     OnboardingResult? initialResult,
     this.throwOnRead = false,
+    this.saveCompleters = const [],
   }) : savedResult = initialResult;
 
   OnboardingResult? savedResult;
   final bool throwOnRead;
+  final List<Completer<void>> saveCompleters;
   int readCount = 0;
   int saveCount = 0;
 
@@ -8817,7 +8878,11 @@ class MemoryOnboardingResultStore implements OnboardingResultStore {
 
   @override
   Future<void> saveResult(OnboardingResult result) async {
+    final saveCompleter = saveCount < saveCompleters.length
+        ? saveCompleters[saveCount]
+        : null;
     saveCount++;
+    await saveCompleter?.future;
     savedResult = result;
   }
 


### PR DESCRIPTION
## 관련 이슈

close #812

## 작업 배경

- 설정 화면의 `큰 글자`, `간편 보기`, `고대비` 항목이 변경 가능한 설정처럼 보이지만 실제로는 처음 설정 안내 SnackBar만 띄우고 값을 바꾸지 못했다.
- QA 요청에 따라 설정 화면에서 개발·배포 용어를 제거하고, 접근성 보기 옵션을 설정 화면에서 바로 변경·저장할 수 있게 정리한다.

## 작업 내용

- 설정 화면의 보기 옵션 3개를 chevron tile에서 `Switch` 컨트롤로 바꿨다.
- 보기 옵션 변경 시 기존 온보딩 결과 저장소에 `OnboardingViewPreferences`를 다시 저장하고, 현재 설정 화면과 홈 화면에 큰 글자/고대비 설정이 즉시 반영되도록 했다.
- 이동 조건과 보기 옵션 저장을 같은 `OnboardingResult` 저장 큐로 통합해 빠른 연속 변경에서도 마지막 profile과 preferences 조합이 유지되도록 했다.
- `데이터팩`, `실기기 QA` 같은 운영 용어를 사용자 문구로 바꿨다.
- 설정 화면 semantics가 현재 값과 다음 행동을 `큰 글자, 켜짐, 두 번 탭해 끄기`처럼 읽도록 테스트를 보강했다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "설정 화면 보기 옵션은 변경값"`: exit 0, 1 test passed.
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "설정 화면 보기 옵션은 빠른 연속 변경"`: exit 0, 1 test passed.
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "설정 화면 보기 옵션 저장 중 이동 조건"`: exit 0, 1 test passed.
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "설정 화면"`: exit 0, 9 tests passed.
  - `cd apps/mobile && flutter test`: exit 0, 412 tests passed.
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found.
  - `cd apps/mobile && flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성.
  - `git diff --check`: exit 0.
  - CodeRabbit 상태 확인: PR check는 pass로 표시됐지만 review 제한 안내가 있어 Codex CLI fallback review를 실행했다.
  - `codex review --base origin/main --title "[Refactor] 설정 보기 옵션과 배포 용어 정리"`: 2건 지적을 PR inline review로 게시 후 수정, 재검토 1건 지적을 PR inline review로 게시 후 수정, 최종 재검토에서 actionable regression 없음.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 보기 옵션 변경/저장 | Flutter widget test | 설정에서 `큰 글자`, `고대비`, `간편 보기`를 바꾼 뒤 저장소 값, 현재 route 텍스트 배율, 앱 재시작 후 semantics 확인 | `flutter test test/widget_test.dart --plain-name "설정 화면 보기 옵션은 변경값"`: exit 0 | 통과 |
| 연속 변경 저장 순서 | Flutter widget test | 보기 옵션 빠른 연속 변경과 보기 옵션 저장 중 이동 조건 변경에서 마지막 값만 저장되는지 확인 | `flutter test test/widget_test.dart --plain-name "설정 화면 보기 옵션은 빠른 연속 변경"`: exit 0, `flutter test test/widget_test.dart --plain-name "설정 화면 보기 옵션 저장 중 이동 조건"`: exit 0 | 통과 |
| 큰 글자 설정 접근성 | Flutter widget test | 320px 폭, 200% 글자 크기에서 설정 switch 3개와 Android/iOS tap target guideline 확인 | `flutter test test/widget_test.dart --plain-name "설정 화면"`: exit 0, 9 tests passed | 통과 |
| 설정 화면 switch 노출 | Android 실기 `RFKYA01VMQY` | debug APK 설치 후 설정 화면 UI tree와 스크린샷 확인 | `.codex/evidence/812/android-more-after-fix.xml`, `.codex/evidence/812/android-settings-after-fix-before-toggle.png`; tree에 `android.widget.Switch` 3개와 `큰 글자, 켜짐, 두 번 탭해 끄기`, `간편 보기, 켜짐, 두 번 탭해 끄기`, `고대비, 켜짐, 두 번 탭해 끄기` 노출 | 통과 |
| 설정 변경 전후 | Android 실기 `RFKYA01VMQY` | `고대비` switch 좌표를 UI tree 기준으로 탭한 뒤 변경 후 tree와 스크린샷 확인 | `.codex/evidence/812/android-settings-after-fix-toggle.xml`, `.codex/evidence/812/android-settings-after-fix-toggle.png`; `고대비`가 `켜짐`에서 `꺼짐`으로 변경됨 | 통과 |
| 운영 용어 제거 | Android 실기 `RFKYA01VMQY` | 설정 화면 UI tree에서 문구 검색 | `.codex/evidence/812/android-more-after-fix.xml`, `.codex/evidence/812/android-settings-after-fix-toggle.xml`; `데이터팩`, `실기기 QA` 미노출, `인터넷이 불안정해도 주요 역 정보를 먼저 보여줘요` 노출 | 통과 |
| 코드리뷰 | GitHub PR review | CodeRabbit 제한 상태에서 Codex CLI fallback review를 PR review 형식으로 게시하고 actionable thread 해결 답글 확인 | review `4567732891`, `4567802840`, final clean review `4567829345`; 모든 Codex inline thread resolved | 통과 |
| iOS 대체 검증 | Flutter 공통 widget/semantics test | iOS Simulator native accessibility tree는 이번 확인에서 별도로 수집하지 못했고, 동일 Dart widget/semantics 경로를 widget test로 검증 | `flutter test test/widget_test.dart --plain-name "설정 화면"`: exit 0. 남은 리스크는 iOS native accessibility tree 덤프 미수집 | 통과 |

로컬 전용 증거 사유: Android 스크린샷과 UI tree는 QA 승인 없는 외부 업로드를 피하기 위해 `.codex/evidence/812/`에 보관했다. PR에는 증거 파일명, 확인 대상, UI tree에서 확인한 문구를 기록했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `_saveOnboardingResult`가 이동 조건과 보기 옵션을 같은 저장 큐로 합쳐 마지막 `OnboardingResult`만 저장소에 남긴다.
  - `AppSettingsScreen`의 `_updateViewPreferences`가 기존 `OnboardingResultStore` 저장 경로를 재사용한다.
  - `_AppSettingsPreferenceTile`은 하나의 semantics node로 현재 값과 다음 행동을 읽고, visual switch는 같은 callback을 사용한다.

## 리스크

- 설정 화면에서 바꾼 값은 기존 온보딩 결과 저장소에 다시 저장된다. 별도 설정 저장소를 만들지 않아 구조는 작지만, 온보딩 결과 저장 실패 시 기존 저장 실패 처리와 동일하게 오류 로깅 후 현재 세션 UI만 반영된다.
- iOS 실기/시뮬레이터 접근성 tree는 수집하지 못했다. Flutter 공통 semantics 테스트와 Android 실기 evidence로 대체했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
