### PR TITLE
[Fix] 경로 결과 정렬·편집 가짜 컨트롤 제거

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2645,11 +2645,7 @@ class _RouteResultsListView extends StatelessWidget {
               children: [
                 _RouteWorkflowSummary(result: result),
                 const SizedBox(height: 12),
-                const _RouteSegmentedLabels(
-                  labels: ['편한 순', '빠른 순', '환승 적은 순'],
-                ),
-                const SizedBox(height: 18),
-                _RouteSectionHeader(title: '추천 경로 목록'),
+                _RouteSectionHeader(title: '추천 경로'),
                 const SizedBox(height: 8),
               ],
             ),
@@ -2683,7 +2679,7 @@ class _RouteDetailWorkflowView extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _RouteWorkflowBackButton(label: '추천 경로', onPressed: onBack),
+        _RouteWorkflowBackButton(label: '경로 목록', onPressed: onBack),
         const SizedBox(height: 8),
         _RouteDarkSummaryCard(
           title: totalMinutes > 0 ? '$totalMinutes분' : result.statusLabel,
@@ -2802,24 +2798,6 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
                                   height: 1.4,
                                 ),
                               ),
-                              const SizedBox(height: 8),
-                              Align(
-                                alignment: Alignment.centerRight,
-                                child: Container(
-                                  width: 39,
-                                  height: 39,
-                                  decoration: BoxDecoration(
-                                    color:
-                                        EasySubwayAccessibleColors.mintBorder,
-                                    borderRadius: BorderRadius.circular(14),
-                                  ),
-                                  child: const Icon(
-                                    Icons.edit_outlined,
-                                    color: EasySubwayAccessibleColors.mintDark,
-                                    size: 17,
-                                  ),
-                                ),
-                              ),
                             ],
                           )
                         : Row(
@@ -2851,35 +2829,16 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
                                   ],
                                 ),
                               ),
-                              Container(
-                                width: 39,
-                                height: 39,
-                                decoration: BoxDecoration(
-                                  color: EasySubwayAccessibleColors.mintBorder,
-                                  borderRadius: BorderRadius.circular(14),
-                                ),
-                                child: const Icon(
-                                  Icons.edit_outlined,
-                                  color: EasySubwayAccessibleColors.mintDark,
-                                  size: 17,
-                                ),
-                              ),
                             ],
                           ),
                   ),
                 ),
                 const SizedBox(height: 22),
                 _RoutePrototypeSection(
-                  title: result.isBlocked
-                      ? '안내 불가 이유'
-                      : _isRecommendedRoute(result)
-                      ? '추천 경로 1개'
-                      : result.statusLabel,
+                  title: result.isBlocked ? '안내 불가 이유' : '추천 경로',
                   subtitle: result.isBlocked
                       ? '현재 조건에서 막힌 이유를 확인하세요'
-                      : _isRecommendedRoute(result)
-                      ? '편함·불편함과 시간·환승·걷기만 비교합니다.'
-                      : '이 경로는 이동 전 확인이 필요합니다',
+                      : '시간·환승·걷기와 편한 정도를 확인하세요.',
                 ),
                 Container(
                   decoration: BoxDecoration(
@@ -2924,13 +2883,6 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
                                   height: 1.4,
                                 ),
                               ),
-                              const SizedBox(height: 8),
-                              if (_isRecommendedRoute(result))
-                                const _RoutePrototypeChip(
-                                  label: '가장 추천',
-                                  icon: Icons.check,
-                                ),
-                              const SizedBox(height: 5),
                               Text(
                                 result.comfortLabel,
                                 style: textTheme.bodyMedium?.copyWith(
@@ -2971,12 +2923,6 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
                               Column(
                                 crossAxisAlignment: CrossAxisAlignment.end,
                                 children: [
-                                  if (_isRecommendedRoute(result))
-                                    const _RoutePrototypeChip(
-                                      label: '가장 추천',
-                                      icon: Icons.check,
-                                    ),
-                                  const SizedBox(height: 5),
                                   Text(
                                     result.comfortLabel,
                                     style: textTheme.bodyMedium?.copyWith(
@@ -3233,50 +3179,9 @@ class _RouteWorkflowSummary extends StatelessWidget {
                 ],
               ),
             ),
-            const Icon(Icons.edit_outlined, color: Color(0xFF006D77)),
           ],
         ),
       ),
-    );
-  }
-}
-
-class _RouteSegmentedLabels extends StatelessWidget {
-  const _RouteSegmentedLabels({required this.labels});
-
-  final List<String> labels;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        for (final label in labels) ...[
-          Expanded(
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                color: label == labels.first
-                    ? const Color(0xFF006D77)
-                    : const Color(0xFFE8F0F1),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 10),
-                child: Text(
-                  label,
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    color: label == labels.first
-                        ? Colors.white
-                        : const Color(0xFF29484B),
-                    fontWeight: FontWeight.w800,
-                  ),
-                ),
-              ),
-            ),
-          ),
-          if (label != labels.last) const SizedBox(width: 6),
-        ],
-      ],
     );
   }
 }
@@ -3324,10 +3229,6 @@ class _RouteResultListButton extends StatelessWidget {
                                   fontWeight: FontWeight.w900,
                                 ),
                           ),
-                        ),
-                        const _RoutePrototypeChip(
-                          label: '추천',
-                          icon: Icons.check,
                         ),
                       ],
                     ),

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2835,10 +2835,16 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
                 ),
                 const SizedBox(height: 22),
                 _RoutePrototypeSection(
-                  title: result.isBlocked ? '안내 불가 이유' : '추천 경로',
+                  title: result.isBlocked
+                      ? '안내 불가 이유'
+                      : _isRecommendedRoute(result)
+                      ? '추천 경로'
+                      : result.statusLabel,
                   subtitle: result.isBlocked
                       ? '현재 조건에서 막힌 이유를 확인하세요'
-                      : '시간·환승·걷기와 편한 정도를 확인하세요.',
+                      : _isRecommendedRoute(result)
+                      ? '시간·환승·걷기와 편한 정도를 확인하세요.'
+                      : '이 경로는 이동 전 확인이 필요합니다',
                 ),
                 Container(
                   decoration: BoxDecoration(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5316,10 +5316,11 @@ void main() {
         'station-sadang',
       );
       expect(routeRepository.requests.single.mobilityType, 'SENIOR');
-      expect(find.text('추천 경로 목록'), findsOneWidget);
-      expect(find.text('편한 순'), findsOneWidget);
-      expect(find.text('빠른 순'), findsOneWidget);
-      expect(find.text('환승 적은 순'), findsOneWidget);
+      expect(find.text('추천 경로'), findsOneWidget);
+      expect(find.text('추천 경로 목록'), findsNothing);
+      expect(find.text('편한 순'), findsNothing);
+      expect(find.text('빠른 순'), findsNothing);
+      expect(find.text('환승 적은 순'), findsNothing);
       expect(find.text('상록수 → 사당'), findsOneWidget);
       expect(find.text('계단 피하기 · 환승 줄이기'), findsWidgets);
       expect(find.text('계단 여부 확인 필요'), findsWidgets);
@@ -5327,7 +5328,8 @@ void main() {
       expect(find.text('엘리베이터 이용'), findsNothing);
       expect(find.text('7분'), findsOneWidget);
       expect(find.text('환승 없음 · 걷기 300m'), findsOneWidget);
-      expect(find.text('추천'), findsOneWidget);
+      expect(find.text('추천'), findsNothing);
+      expect(find.byIcon(Icons.edit_outlined), findsNothing);
       expect(find.textContaining('이동 점수'), findsNothing);
       expect(find.text('추천 이유'), findsNothing);
       expect(find.text('엘리베이터 동선을 우선했어요'), findsNothing);
@@ -5341,8 +5343,13 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('routeResultListItem')));
       await tester.pumpAndSettle();
+      await tester.drag(find.byType(ListView), const Offset(0, 600));
+      await tester.pumpAndSettle();
 
-      expect(find.text('추천 경로'), findsOneWidget);
+      expect(find.text('경로 목록'), findsOneWidget);
+      expect(find.text('추천 경로 1개'), findsNothing);
+      expect(find.text('가장 추천'), findsNothing);
+      expect(find.byIcon(Icons.edit_outlined), findsNothing);
       expect(find.text('이동 순서'), findsOneWidget);
       expect(find.text('도착 안내'), findsOneWidget);
       expect(find.text('도착역에서 계단 없는 출구 동선을 확인합니다.'), findsOneWidget);
@@ -5939,6 +5946,7 @@ void main() {
     await _openFirstRouteResultDetail(tester);
 
     expect(find.byKey(const Key('routeOpenFeedbackButton')), findsNothing);
+    expect(find.byIcon(Icons.edit_outlined), findsNothing);
 
     await tester.ensureVisible(
       find.byKey(const Key('routeStartGuidanceButton')),
@@ -5949,6 +5957,7 @@ void main() {
 
     expect(find.byKey(const Key('routeGuidanceFeedbackButton')), findsNothing);
     expect(find.byKey(const Key('routeOpenBlockedButton')), findsNothing);
+    expect(find.byIcon(Icons.edit_outlined), findsNothing);
     expect(
       find.byKey(const Key('routeOpenInternalRouteButton')),
       findsOneWidget,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -6306,6 +6306,21 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(find.byKey(const Key('routeGuidanceMobilityChip')), findsOneWidget);
     expect(find.text('이동 조건 확인 필요'), findsOneWidget);
+
+    await tester.ensureVisible(find.byKey(const Key('routeResultListItem')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeResultListItem')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(const Key('routeStartGuidanceButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeStartGuidanceButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('확인이 필요합니다'), findsWidgets);
+    expect(find.text('이 경로는 이동 전 확인이 필요합니다'), findsOneWidget);
+    expect(find.text('추천 경로'), findsNothing);
   });
 
   testWidgets('경로 검색은 입력만 하고 선택하지 않은 역을 쉬운 문구로 안내한다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

close #813

## 작업 배경

경로 결과 화면에 실제 정렬 동작이 없는 `편한 순`, `빠른 순`, `환승 적은 순` 라벨과 장식용 편집 아이콘이 함께 노출되어 있었습니다. 단일 추천 경로 화면에서는 사용자가 누를 수 있는 컨트롤로 오해할 수 있어, 실제 행동이 없는 요소를 제거하고 추천 경로 문구를 한 줄로 정리했습니다.

## 작업 내용

- 단일 경로 결과 상단의 정적 정렬 라벨을 제거했습니다.
- 경로 요약, 상세, 안내 화면의 장식용 `edit` 아이콘을 제거했습니다.
- `추천`, `가장 추천`, `추천 경로 1개`, `추천 경로 목록`처럼 반복되던 제목을 `추천 경로`와 `경로 목록` 중심으로 줄였습니다.
- widget test에서 정렬 라벨과 장식용 편집 아이콘이 노출되지 않는지 확인하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/route_search_test.dart test/widget_test.dart`: 145 tests passed
  - `cd apps/mobile && flutter analyze`: No issues found
  - `cd apps/mobile && flutter build apk --debug`: `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 단일 경로 결과의 가짜 정렬·편집 컨트롤 제거 | Flutter widget test | `경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다`, `로컬 경로 결과는 서버 피드백 행동을 숨긴다`에서 정렬 라벨과 `Icons.edit_outlined` 미노출 확인 | `cd apps/mobile && flutter test test/route_search_test.dart test/widget_test.dart` output | 통과, 145 tests passed |
| Android 경로 입력 수동 시도 | Android 실기 `RFKYA01VMQY` | debug APK 실행 후 길찾기에서 출발역/도착역 검색 흐름 확인 | local-only: `.codex/evidence/813/android-origin-picker.xml`, `.codex/evidence/813/android-origin-results.xml`, `.codex/evidence/813/android-destination-results-3.xml` | 출발역 `sangnoksu`는 `상록수`로 검색됨. 도착역 `Sadang`은 결과 없음, ADB 한글 입력은 `input text 사당`에서 Android input NPE가 발생해 결과 화면 스크린샷은 수집하지 못함 |
| Android 빌드 | Android debug | APK 빌드 | `cd apps/mobile && flutter build apk --debug` output | 성공, debug APK 생성 |
| iOS 수동 화면 증거 | iOS | 이번 변경은 Flutter 공통 widget 표현 제거이며 iOS Simulator 화면 증거는 수집하지 못함 | 대체 증거: Flutter widget test와 Android 수동 시도 기록 | 플랫폼별 네이티브 분기 변경은 없지만 iOS 실기/Simulator 시각 확인은 남은 리스크 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/route_search.dart`의 경로 결과 목록, 상세, 안내 화면에서 실제 동작 없는 정렬·편집 표시가 제거됐는지 확인해 주세요.
- QA 요청으로 확인한 출발역/도착역 입력 구조 혼란은 #813 범위가 아니라 #787 follow-up에서 `출발역 선택`/`도착역 선택` 행 자체를 바로 검색 가능한 입력 구조로 정리할 예정입니다.

## 리스크

- 복수 경로 정렬은 이번 범위에서 새로 구현하지 않았습니다. 현재 앱은 단일 추천 경로를 보여주므로 정렬 UI를 숨기는 쪽이 더 명확합니다.
- Android 수동 결과 화면 캡처는 현재 입력 구조와 ADB 한글 입력 제약 때문에 확보하지 못했습니다. 결과 화면의 UI 요소 제거는 widget test로 검증했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
