### PR TITLE
[Fix] 길찾기 출발·도착 입력 구조 단순화

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1218,40 +1218,21 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
           children: [
             _RoutePointPickerCard(
+              key: const Key('routePointPickerCard'),
               originStation: _originStation,
               destinationStation: _destinationStation,
+              originPicker: _activeStationPicker == _RouteStationRole.origin
+                  ? _buildRouteStationPicker(_RouteStationRole.origin)
+                  : null,
+              destinationPicker:
+                  _activeStationPicker == _RouteStationRole.destination
+                  ? _buildRouteStationPicker(_RouteStationRole.destination)
+                  : null,
               onOriginTap: () => _openStationPicker(_RouteStationRole.origin),
               onDestinationTap: () =>
                   _openStationPicker(_RouteStationRole.destination),
               onSwap: _swapStations,
             ),
-            if (_activeStationPicker != null) ...[
-              const SizedBox(height: 12),
-              _RouteStationPicker(
-                labelText: _activeStationPicker == _RouteStationRole.origin
-                    ? '출발역'
-                    : '도착역',
-                inputKey: _activeStationPicker == _RouteStationRole.origin
-                    ? const Key('routeOriginStationInput')
-                    : const Key('routeDestinationStationInput'),
-                searchButtonKey:
-                    _activeStationPicker == _RouteStationRole.origin
-                    ? const Key('routeOriginStationSearchButton')
-                    : const Key('routeDestinationStationSearchButton'),
-                optionKeyPrefix:
-                    _activeStationPicker == _RouteStationRole.origin
-                    ? 'routeOriginStationOption'
-                    : 'routeDestinationStationOption',
-                selectedStation:
-                    _activeStationPicker == _RouteStationRole.origin
-                    ? _originStation
-                    : _destinationStation,
-                repository: widget.stationRepository,
-                onSelected: _activeStationPicker == _RouteStationRole.origin
-                    ? _updateOriginStation
-                    : _updateDestinationStation,
-              ),
-            ],
             const SizedBox(height: 18),
             _RouteRecentDestinationList(
               repository: widget.favoriteRouteRepository,
@@ -1347,6 +1328,25 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
         destinationStationId: _destinationStation!.id,
         mobilityType: _selectedMobilityType,
       ),
+    );
+  }
+
+  Widget _buildRouteStationPicker(_RouteStationRole role) {
+    final isOrigin = role == _RouteStationRole.origin;
+    return _RouteStationPicker(
+      labelText: isOrigin ? '출발역' : '도착역',
+      inputKey: isOrigin
+          ? const Key('routeOriginStationInput')
+          : const Key('routeDestinationStationInput'),
+      searchButtonKey: isOrigin
+          ? const Key('routeOriginStationSearchButton')
+          : const Key('routeDestinationStationSearchButton'),
+      optionKeyPrefix: isOrigin
+          ? 'routeOriginStationOption'
+          : 'routeDestinationStationOption',
+      selectedStation: isOrigin ? _originStation : _destinationStation,
+      repository: widget.stationRepository,
+      onSelected: isOrigin ? _updateOriginStation : _updateDestinationStation,
     );
   }
 
@@ -1504,13 +1504,18 @@ class _RoutePointPickerCard extends StatelessWidget {
   const _RoutePointPickerCard({
     required this.originStation,
     required this.destinationStation,
+    required this.originPicker,
+    required this.destinationPicker,
     required this.onOriginTap,
     required this.onDestinationTap,
     required this.onSwap,
+    super.key,
   });
 
   final StationSearchResult? originStation;
   final StationSearchResult? destinationStation;
+  final Widget? originPicker;
+  final Widget? destinationPicker;
   final VoidCallback onOriginTap;
   final VoidCallback onDestinationTap;
   final VoidCallback onSwap;
@@ -1537,21 +1542,23 @@ class _RoutePointPickerCard extends StatelessWidget {
             padding: const EdgeInsets.fromLTRB(8, 8, 58, 8),
             child: Column(
               children: [
-                _RoutePointRow(
-                  key: const Key('routeOriginPointButton'),
-                  label: '출발',
-                  station: originStation,
-                  fallback: '출발역 선택',
-                  onTap: onOriginTap,
-                ),
+                originPicker ??
+                    _RoutePointRow(
+                      key: const Key('routeOriginPointButton'),
+                      label: '출발',
+                      station: originStation,
+                      fallback: '출발역 선택',
+                      onTap: onOriginTap,
+                    ),
                 const Divider(height: 1, color: Color(0xFFE0E7EC)),
-                _RoutePointRow(
-                  key: const Key('routeDestinationPointButton'),
-                  label: '도착',
-                  station: destinationStation,
-                  fallback: '도착역 선택',
-                  onTap: onDestinationTap,
-                ),
+                destinationPicker ??
+                    _RoutePointRow(
+                      key: const Key('routeDestinationPointButton'),
+                      label: '도착',
+                      station: destinationStation,
+                      fallback: '도착역 선택',
+                      onTap: onDestinationTap,
+                    ),
               ],
             ),
           ),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3303,12 +3303,22 @@ void main() {
       );
 
       await _openRouteOriginStationInput(tester);
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('routePointPickerCard')),
+          matching: find.byKey(const Key('routeOriginStationInput')),
+        ),
+        findsOneWidget,
+      );
       final originInput = tester.widget<TextField>(
         find.byKey(const Key('routeOriginStationInput')),
       );
       expect(originInput.decoration?.suffixIcon, isNotNull);
       expect(
-        find.byKey(const Key('routeOriginStationSearchButton')),
+        find.descendant(
+          of: find.byKey(const Key('routePointPickerCard')),
+          matching: find.byKey(const Key('routeOriginStationSearchButton')),
+        ),
         findsOneWidget,
       );
     } finally {


### PR DESCRIPTION
## 관련 이슈

close #787

## 작업 배경

- QA 요청으로 출발역 선택과 도착역 선택 행을 누른 뒤, 화면 아래에 따로 열린 입력칸에 다시 역 이름을 입력해야 하는 흐름이 혼란스럽다는 점을 확인했다.
- 길찾기 첫 화면의 핵심 행동은 출발·도착역 선택이므로, 선택 행 자체에서 바로 역 이름을 조회할 수 있어야 한다.

## 작업 내용

- 출발역 또는 도착역 행을 누르면 기존 별도 하단 입력 영역 대신 같은 출발·도착 선택 카드 안에서 역 이름 입력 필드가 열린다.
- 활성 입력 필드의 검색 아이콘과 접근성 label은 기존 출발역/도착역 검색 의미를 유지했다.
- 출발·도착역이 모두 선택되기 전 길찾기 CTA의 비활성 안내 의미는 그대로 유지했다.
- 위젯 테스트에 출발역 입력 필드와 검색 버튼이 `routePointPickerCard` 안에서 렌더링되는 검증을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/route_search.dart apps/mobile/test/widget_test.dart`: exit 0
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "경로 검색은 출발 도착 선택 전 CTA 사유와 입력창 검색 아이콘을 보여준다"`: exit 0, 1 test passed
  - `cd apps/mobile && flutter test test/route_search_test.dart test/widget_test.dart`: exit 0, 145 tests passed
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `cd apps/mobile && flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 출발역 선택 행 안 입력 | Android 실기 `RFKYA01VMQY` | debug APK 설치 후 길찾기 화면에서 출발역 선택을 탭하고 UI tree와 screenshot 확인 | 로컬 전용 `.codex/evidence/787/android-inline-origin.xml`, `.codex/evidence/787/android-inline-origin.png` | `출발역 입력` 필드와 `출발역 검색` 버튼이 출발·도착 선택 카드 영역 `[56,336][1024,705]` 안에 있고 `도착역 선택` 행이 바로 아래 같은 카드에 남는 것을 확인 |
| CTA 비활성 안내 | Android 실기 `RFKYA01VMQY` | 같은 UI tree에서 CTA accessibility label 확인 | 로컬 전용 `.codex/evidence/787/android-inline-origin.xml` | `길찾기, 출발역과 도착역을 먼저 선택해 주세요`가 비활성 CTA에 유지됨 |
| iOS 공통 UI 리스크 | iOS 미실행 | Flutter 공통 위젯 테스트와 Android 실기 검증으로 대체 | iOS simulator 증거 없음 | iOS 렌더링은 Flutter 공통 코드 경로이나, 이번 PR에서는 별도 iOS 시각 증거를 수집하지 못함 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `_RoutePointPickerCard`가 활성 출발/도착 입력 위젯을 카드 내부 행 위치에 직접 렌더링하는지 확인하면 된다.
- 스크린샷과 UI tree는 앱 화면 증거라 git에 커밋하지 않고 로컬 전용 경로에 보관했다.

## 리스크

- 출발역/도착역 입력 UI를 카드 안으로 옮겼기 때문에 좁은 화면에서 카드 높이가 늘어난다. Android 실기 화면과 위젯 테스트로 기본 배치를 확인했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
