### PR TITLE
[Style] 모바일 접근성 색상·터치·타이포 토큰 정리

### DIFF
--- a/apps/mobile/lib/accessible_design.dart
+++ b/apps/mobile/lib/accessible_design.dart
@@ -6,8 +6,8 @@ class EasySubwayAccessibleColors {
   static const primary = Color(0xFF006D77);
   static const brandDark = Color(0xFF071B2F);
   static const brand = Color(0xFF17527C);
-  static const mint = Color(0xFF0D8A6D);
-  static const mintDark = Color(0xFF0A705A);
+  static const mint = Color(0xFF0A705A);
+  static const mintDark = Color(0xFF075D4B);
   static const mintSoft = Color(0xFFF0FBF7);
   static const mintBorder = Color(0xFFCBEADD);
   static const amberSoft = Color(0xFFFFF0D1);

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -475,11 +475,11 @@ class _LineFilterMenu extends StatelessWidget {
         break;
       }
     }
-    final label = selectedLine?.shortName ?? '노선 선택';
+    final label = selectedLine?.shortName ?? '전체 노선';
     return SizedBox(
       key: const Key('networkMapLineFilter'),
       width: 142,
-      height: 40,
+      height: EasySubwayTouchTarget.general,
       child: PopupMenuButton<String>(
         padding: EdgeInsets.zero,
         initialValue: selectedLineId ?? '',
@@ -489,7 +489,7 @@ class _LineFilterMenu extends StatelessWidget {
           for (final line in lines)
             PopupMenuItem<String>(value: line.id, child: Text(line.shortName)),
         ],
-        child: _RegionMenuButton(label: label),
+        child: _RegionMenuButton(label: label, semanticLabel: '노선: $label'),
       ),
     );
   }
@@ -518,7 +518,7 @@ class _RegionTabs extends StatelessWidget {
     return SizedBox(
       key: const Key('mapRegionTabs'),
       width: 108,
-      height: 40,
+      height: EasySubwayTouchTarget.general,
       child: PopupMenuButton<String>(
         padding: EdgeInsets.zero,
         initialValue: selected,
@@ -530,25 +530,29 @@ class _RegionTabs extends StatelessWidget {
               child: Text(region.displayName),
             ),
         ],
-        child: _RegionMenuButton(label: _displayRegionName(selected)),
+        child: _RegionMenuButton(
+          label: _displayRegionName(selected),
+          semanticLabel: '지역: ${_displayRegionName(selected)}',
+        ),
       ),
     );
   }
 }
 
 class _RegionMenuButton extends StatelessWidget {
-  const _RegionMenuButton({required this.label});
+  const _RegionMenuButton({required this.label, required this.semanticLabel});
 
   final String label;
+  final String semanticLabel;
 
   @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
-      label: label,
+      label: semanticLabel,
       child: ExcludeSemantics(
         child: Container(
-          height: 40,
+          height: EasySubwayTouchTarget.general,
           padding: const EdgeInsets.only(left: 10, right: 6),
           decoration: BoxDecoration(
             color: Colors.white,

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -291,8 +291,9 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
 
   void _reload({String? region, String? lineId}) {
     setState(() {
+      final isChangingRegion = region != null && region != _selectedRegion;
       _selectedRegion = region ?? _selectedRegion;
-      _selectedLineId = lineId;
+      _selectedLineId = isChangingRegion ? null : lineId;
       _future = _loadMap();
     });
   }

--- a/apps/mobile/test/accessibility_baseline_test.dart
+++ b/apps/mobile/test/accessibility_baseline_test.dart
@@ -1,5 +1,7 @@
+import 'dart:math' as math;
 import 'dart:ui';
 
+import 'package:easysubway_mobile/accessible_design.dart';
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/main.dart';
 import 'package:easysubway_mobile/mobility_profile.dart';
@@ -10,6 +12,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('접근성 색상 토큰은 일반 텍스트 대비 기준을 넘는다', () {
+    const appBackground = Color(0xFFF6F8F9);
+
+    expect(
+      _contrastRatio(EasySubwayAccessibleColors.mint, Colors.white),
+      greaterThanOrEqualTo(4.5),
+    );
+    expect(
+      _contrastRatio(EasySubwayAccessibleColors.mutedText, appBackground),
+      greaterThanOrEqualTo(4.5),
+    );
+  });
+
   testWidgets('모바일 접근성 QA 기준선은 큰 글씨와 고대비 홈 화면을 검증한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     tester.platformDispatcher.accessibilityFeaturesTestValue =
@@ -87,6 +102,31 @@ void main() {
       semanticsHandle.dispose();
     }
   });
+}
+
+double _contrastRatio(Color foreground, Color background) {
+  final light = math.max(
+    _relativeLuminance(foreground),
+    _relativeLuminance(background),
+  );
+  final dark = math.min(
+    _relativeLuminance(foreground),
+    _relativeLuminance(background),
+  );
+  return (light + 0.05) / (dark + 0.05);
+}
+
+double _relativeLuminance(Color color) {
+  final red = _linearRgb(color.r);
+  final green = _linearRgb(color.g);
+  final blue = _linearRgb(color.b);
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+double _linearRgb(double channel) {
+  return channel <= 0.03928
+      ? channel / 12.92
+      : math.pow((channel + 0.055) / 1.055, 2.4).toDouble();
 }
 
 OnboardingState _completedOnboardingState({

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -803,12 +803,20 @@ void main() {
 
     await tester.tap(find.byKey(const Key('bottomNavMap')));
     await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('networkMapLineFilter')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('4호선'));
+    await tester.pumpAndSettle();
+    expect(repository.requestedNetworkMapLineIds.last, 'seoul-4');
+
     await tester.tap(find.text('테스트권'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('부산'));
     await tester.pumpAndSettle();
 
     expect(repository.requestedNetworkMapRegions, contains('부산'));
+    expect(repository.requestedNetworkMapLineIds.last, isNull);
+    expect(find.bySemanticsLabel('노선: 전체 노선'), findsOneWidget);
     expect(find.text('부산'), findsOneWidget);
   });
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -742,6 +742,16 @@ void main() {
     expect(find.text('저장'), findsNothing);
     expect(find.text('테스트권'), findsOneWidget);
     expect(find.text('전국'), findsNothing);
+    expect(
+      tester.getSize(find.byKey(const Key('mapRegionTabs'))).height,
+      greaterThanOrEqualTo(EasySubwayTouchTarget.general),
+    );
+    expect(
+      tester.getSize(find.byKey(const Key('networkMapLineFilter'))).height,
+      greaterThanOrEqualTo(EasySubwayTouchTarget.general),
+    );
+    expect(find.bySemanticsLabel('지역: 테스트권'), findsOneWidget);
+    expect(find.bySemanticsLabel('노선: 전체 노선'), findsOneWidget);
     final viewer = tester.widget<InteractiveViewer>(
       find.byKey(const Key('networkMapInteractiveViewer')),
     );


### PR DESCRIPTION
## 관련 이슈

close #814

## 작업 배경

- QA 검토에서 접근성 색상 토큰 `mint`의 흰색 대비가 일반 텍스트 기준 4.5:1에 미달하고, 노선도 지역·노선 필터가 40dp라 앱의 터치 영역 기준보다 작다는 문제가 확인됐다.
- 노선도 필터는 지도 위에서 반복 조작하는 컨트롤이므로 큰 터치 영역과 `지역:`, `노선:`처럼 맥락이 드러나는 스크린리더 label이 필요하다.

## 작업 내용

- `EasySubwayAccessibleColors.mint`와 `mintDark`를 기존 hue를 유지하는 더 어두운 값으로 조정해 일반 텍스트 대비 기준을 넘기도록 했다.
- 노선도 지역·노선 필터 높이를 `EasySubwayTouchTarget.general` 기준으로 키웠다.
- 노선도 필터의 TalkBack label을 `지역: 수도권`, `노선: 전체 노선`처럼 맥락 포함 문구로 정리했다.
- 지역 변경 시 이전 노선 필터를 명시적으로 초기화해 `전체 노선` label과 지도 요청 상태가 어긋나지 않게 했다.
- 접근성 baseline test에 WCAG contrast 계산을 추가하고, 노선도 widget test에서 필터 높이, semantics label, 지역 변경 후 노선 필터 초기화를 검증한다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/accessible_design.dart apps/mobile/lib/network_map.dart apps/mobile/test/accessibility_baseline_test.dart apps/mobile/test/widget_test.dart`: exit 0
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "홈 노선도 버튼은 v3 노선도 화면을 연다"`: RED 확인 후 구현 뒤 exit 0, 1 test passed
  - `cd apps/mobile && flutter test test/accessibility_baseline_test.dart --plain-name "접근성 색상 토큰은 일반 텍스트 대비 기준을 넘는다"`: RED 확인 후 구현 뒤 exit 0, 1 test passed
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "노선도 지역 메뉴는 선택한 지역으로 지도를 다시 불러온다"`: exit 0, All tests passed
  - `cd apps/mobile && flutter test test/accessibility_baseline_test.dart test/widget_test.dart`: exit 0, 136 tests passed
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `cd apps/mobile && flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `codex review --base origin/main --title "[Style] 모바일 접근성 색상·터치·타이포 토큰 정리"`: CodeRabbit rate limit fallback, 최종 re-review actionable 0
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 색상 대비 | 로컬 계산 | WCAG relative luminance 계산과 widget test | `mint_on_white=6.038`, `muted_on_bg=6.012` | 일반 텍스트 기준 4.5:1 이상 |
| 노선도 필터 터치 영역 | Android 실기 `RFKYA01VMQY` | debug APK 설치 후 노선도 화면 UI tree 확인 | 로컬 전용 `.codex/evidence/814/android-map-filter.xml`, `.codex/evidence/814/android-map-filter.png` | `지역: 수도권` bounds `[39,314][343,471]`, `노선: 전체 노선` bounds `[39,494][439,651]`로 56dp 이상 영역 확인 |
| iOS 공통 UI 리스크 | iOS 미실행 | Flutter 공통 위젯 테스트로 대체 | iOS simulator 증거 없음 | 플랫폼별 분기 없는 Flutter widget 변경이나, 이번 PR에서는 iOS 시각 증거를 수집하지 못함 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 노선도 필터의 `EasySubwayTouchTarget.general` 적용과 `지역:`/`노선:` semantics label 변경이다.
- 화면 증거는 앱 화면 캡처라 git에 커밋하지 않고 로컬 전용 경로에 보관했다.

## 리스크

- 필터 높이가 40dp에서 56dp로 커져 지도 위 컨트롤 영역이 조금 더 넓어진다. Android 실기 스크린샷에서 지도 조작 버튼과 겹치지 않는 것을 확인했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
