### PR TITLE
[Refactor] 노선도 카메라 core와 renderer 계약 분리

### DIFF
--- a/apps/mobile/lib/features/network_map/domain/map_camera.dart
+++ b/apps/mobile/lib/features/network_map/domain/map_camera.dart
@@ -1,0 +1,117 @@
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+
+@immutable
+class MapCameraState {
+  const MapCameraState({
+    required this.sourceBounds,
+    required this.viewportSize,
+    required this.center,
+    required this.scale,
+    required this.minScale,
+    required this.maxScale,
+    required this.revision,
+  }) : assert(scale > 0),
+       assert(minScale > 0),
+       assert(maxScale >= minScale),
+       assert(revision >= 0);
+
+  final Rect sourceBounds;
+  final Size viewportSize;
+  final Offset center;
+  final double scale;
+  final double minScale;
+  final double maxScale;
+  final int revision;
+
+  Rect get visibleSourceRect {
+    final sourceWidth = viewportSize.width / scale;
+    final sourceHeight = viewportSize.height / scale;
+    return Rect.fromCenter(
+      center: center,
+      width: sourceWidth,
+      height: sourceHeight,
+    );
+  }
+
+  Matrix4 get sourceToViewport {
+    final viewportCenter = viewportSize.center(Offset.zero);
+    return Matrix4.identity()
+      ..translateByDouble(viewportCenter.dx, viewportCenter.dy, 0, 1)
+      ..scaleByDouble(scale, scale, 1, 1)
+      ..translateByDouble(-center.dx, -center.dy, 0, 1);
+  }
+
+  Matrix4 get viewportToSource => Matrix4.inverted(sourceToViewport);
+
+  Offset sourceToViewportPoint(Offset sourcePoint) {
+    final viewportCenter = viewportSize.center(Offset.zero);
+    return viewportCenter + (sourcePoint - center) * scale;
+  }
+
+  Offset viewportToSourcePoint(Offset viewportPoint) {
+    final viewportCenter = viewportSize.center(Offset.zero);
+    return center + (viewportPoint - viewportCenter) / scale;
+  }
+
+  MapCameraState zoomBy(double factor, {required Offset focalPoint}) {
+    final sourceBefore = viewportToSourcePoint(focalPoint);
+    final newScale = (scale * factor).clamp(minScale, maxScale).toDouble();
+    final viewportCenter = viewportSize.center(Offset.zero);
+    final newCenter = sourceBefore - (focalPoint - viewportCenter) / newScale;
+    return copyWith(
+      center: newCenter,
+      scale: newScale,
+      revision: revision + 1,
+    ).clamped();
+  }
+
+  MapCameraState clamped({double viewportMargin = 0}) {
+    final visibleWidth = viewportSize.width / scale;
+    final visibleHeight = viewportSize.height / scale;
+    final sourceMargin = viewportMargin / scale;
+    final minCenterX = sourceBounds.left + visibleWidth / 2 - sourceMargin;
+    final maxCenterX = sourceBounds.right - visibleWidth / 2 + sourceMargin;
+    final minCenterY = sourceBounds.top + visibleHeight / 2 - sourceMargin;
+    final maxCenterY = sourceBounds.bottom - visibleHeight / 2 + sourceMargin;
+
+    final clampedCenter = Offset(
+      _clampAxis(center.dx, minCenterX, maxCenterX, sourceBounds.center.dx),
+      _clampAxis(center.dy, minCenterY, maxCenterY, sourceBounds.center.dy),
+    );
+    return center == clampedCenter ? this : copyWith(center: clampedCenter);
+  }
+
+  MapCameraState copyWith({
+    Rect? sourceBounds,
+    Size? viewportSize,
+    Offset? center,
+    double? scale,
+    double? minScale,
+    double? maxScale,
+    int? revision,
+  }) {
+    return MapCameraState(
+      sourceBounds: sourceBounds ?? this.sourceBounds,
+      viewportSize: viewportSize ?? this.viewportSize,
+      center: center ?? this.center,
+      scale: scale ?? this.scale,
+      minScale: minScale ?? this.minScale,
+      maxScale: maxScale ?? this.maxScale,
+      revision: revision ?? this.revision,
+    );
+  }
+}
+
+double _clampAxis(
+  double value,
+  double minValue,
+  double maxValue,
+  double fallback,
+) {
+  if (minValue > maxValue) {
+    return fallback;
+  }
+  return math.min(math.max(value, minValue), maxValue);
+}

--- a/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import '../domain/map_camera.dart';
+
+abstract interface class RouteMapRendererController {
+  Stream<RouteMapRendererEvent> get events;
+
+  Future<void> setCamera(MapCameraState camera);
+  Future<void> retry();
+  Future<void> trimMemory();
+  Future<void> dispose();
+}
+
+sealed class RouteMapRendererEvent {
+  const RouteMapRendererEvent();
+}
+
+final class RouteMapRendererCreated extends RouteMapRendererEvent {
+  const RouteMapRendererCreated();
+}
+
+final class RouteMapRendererAssetLoading extends RouteMapRendererEvent {
+  const RouteMapRendererAssetLoading();
+}
+
+final class RouteMapRendererAssetReady extends RouteMapRendererEvent {
+  const RouteMapRendererAssetReady();
+}
+
+final class RouteMapRendererFramePresented extends RouteMapRendererEvent {
+  const RouteMapRendererFramePresented(this.revision);
+
+  final int revision;
+}
+
+final class RouteMapRendererProcessGone extends RouteMapRendererEvent {
+  const RouteMapRendererProcessGone({required this.didCrash});
+
+  final bool didCrash;
+}
+
+final class RouteMapRendererFrameTimeout extends RouteMapRendererEvent {
+  const RouteMapRendererFrameTimeout(this.revision);
+
+  final int revision;
+}
+
+final class RouteMapRendererRecovering extends RouteMapRendererEvent {
+  const RouteMapRendererRecovering(this.attempt);
+
+  final int attempt;
+}
+
+final class RouteMapRendererFailed extends RouteMapRendererEvent {
+  const RouteMapRendererFailed(this.reason);
+
+  final String reason;
+}
+
+final class RouteMapRendererDisposed extends RouteMapRendererEvent {
+  const RouteMapRendererDisposed();
+}

--- a/apps/mobile/test/features/network_map/domain/map_camera_test.dart
+++ b/apps/mobile/test/features/network_map/domain/map_camera_test.dart
@@ -1,0 +1,97 @@
+import 'package:easysubway_mobile/features/network_map/domain/map_camera.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const sourceBounds = Rect.fromLTWH(100, 200, 1000, 500);
+  const viewportSize = Size(400, 200);
+
+  test('source와 viewport 좌표를 왕복 변환한다', () {
+    const camera = MapCameraState(
+      sourceBounds: sourceBounds,
+      viewportSize: viewportSize,
+      center: Offset(600, 450),
+      scale: 0.4,
+      minScale: 0.2,
+      maxScale: 3,
+      revision: 7,
+    );
+
+    const sourcePoint = Offset(700, 500);
+    final viewportPoint = camera.sourceToViewportPoint(sourcePoint);
+
+    expect(viewportPoint, const Offset(240, 120));
+    expect(
+      camera.viewportToSourcePoint(viewportPoint),
+      closeToOffset(sourcePoint),
+    );
+    expect(camera.visibleSourceRect, sourceBounds);
+  });
+
+  test('focal point 아래 source 좌표를 유지하며 확대한다', () {
+    const camera = MapCameraState(
+      sourceBounds: sourceBounds,
+      viewportSize: viewportSize,
+      center: Offset(600, 450),
+      scale: 0.4,
+      minScale: 0.2,
+      maxScale: 3,
+      revision: 2,
+    );
+    const focalPoint = Offset(320, 140);
+    final before = camera.viewportToSourcePoint(focalPoint);
+
+    final zoomed = camera.zoomBy(2, focalPoint: focalPoint);
+
+    expect(zoomed.scale, 0.8);
+    expect(zoomed.revision, 3);
+    expect(zoomed.viewportToSourcePoint(focalPoint), closeToOffset(before));
+  });
+
+  test('camera center를 source bounds 안으로 clamp한다', () {
+    const camera = MapCameraState(
+      sourceBounds: sourceBounds,
+      viewportSize: viewportSize,
+      center: Offset(600, 450),
+      scale: 1,
+      minScale: 0.2,
+      maxScale: 3,
+      revision: 1,
+    );
+
+    final panned = camera.copyWith(center: const Offset(0, 0)).clamped();
+
+    expect(panned.visibleSourceRect.left, sourceBounds.left);
+    expect(panned.visibleSourceRect.top, sourceBounds.top);
+    expect(
+      panned.visibleSourceRect.right,
+      lessThanOrEqualTo(sourceBounds.right),
+    );
+    expect(
+      panned.visibleSourceRect.bottom,
+      lessThanOrEqualTo(sourceBounds.bottom),
+    );
+  });
+
+  test('bounds가 viewport보다 작으면 해당 축 center를 source 중앙에 고정한다', () {
+    const camera = MapCameraState(
+      sourceBounds: Rect.fromLTWH(0, 0, 100, 80),
+      viewportSize: Size(400, 200),
+      center: Offset(-100, 500),
+      scale: 1,
+      minScale: 0.2,
+      maxScale: 3,
+      revision: 1,
+    );
+
+    final clamped = camera.clamped();
+
+    expect(clamped.center, const Offset(50, 40));
+  });
+}
+
+Matcher closeToOffset(Offset expected) {
+  return isA<Offset>()
+      .having((offset) => offset.dx, 'dx', closeTo(expected.dx, 0.0001))
+      .having((offset) => offset.dy, 'dy', closeTo(expected.dy, 0.0001));
+}


### PR DESCRIPTION
## 관련 이슈

close #837

Refs #836

## 작업 배경

#836의 renderer 전환은 Android/iOS가 같은 source 좌표와 camera 규칙을 공유해야 안전하게 진행할 수 있다. 이번 PR은 native viewport renderer나 좌표 데이터는 바꾸지 않고, 후속 PR들이 공통으로 사용할 camera domain 모델과 renderer controller 계약만 먼저 분리한다.

## 작업 내용

- `MapCameraState`를 추가해 source bounds, viewport size, center, scale, min/max scale, revision을 한 snapshot으로 다룬다.
- source↔viewport 좌표 변환, visible source rect, focal point 보존 zoom, source bounds clamp를 domain API로 고정했다.
- 후속 Android/iOS viewport renderer가 구현할 `RouteMapRendererController`와 renderer event 타입을 추가했다.
- 기존 노선도 화면 연결은 하지 않아 현재 UI 동작과 renderer 선택은 바뀌지 않는다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/features/network_map/domain/map_camera_test.dart`: exit 0, 4 tests passed
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `cd apps/mobile && flutter test`: exit 0, 419 tests passed
  - `node --test tools/ci/*.test.mjs`: exit 0, 102 tests passed
  - `cd apps/mobile && flutter build apk --debug`: exit 0, debug APK built
  - `adb -s RFKYA01VMQY install -r apps/mobile/build/app/outputs/flutter-apk/app-debug.apk`: Success
  - `adb -s RFKYA01VMQY shell am start -n com.easysubway.app/com.easysubway.easysubway_mobile.MainActivity`: launched
  - `adb -s RFKYA01VMQY shell input tap 324 2104`: 노선도 탭 진입
  - `adb -s RFKYA01VMQY shell input tap 974 382`: 확대 버튼 조작

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| camera 변환 계약 | local Flutter test | `flutter test test/features/network_map/domain/map_camera_test.dart` | command output: 4 tests passed | 통과 |
| mobile 회귀 | local Flutter test | `flutter test` | command output: 419 tests passed | 통과 |
| 저장소 계약 | local Node test | `node --test tools/ci/*.test.mjs` | command output: 102 tests passed | 통과 |
| Android 실기기 노선도 진입 | SM A175N / Android 16 | debug APK 설치 후 노선도 탭 진입, UI tree와 screenshot 저장 | local evidence: `.codex/evidence/837/network-map-real-device.png`, `.codex/evidence/837/network-map-ui.xml` | 노선도 WebView, 지역/노선 controls, visible station semantics 확인 |
| Android 실기기 확대 조작 | SM A175N / Android 16 | UI tree 좌표로 확대 버튼 tap 후 screenshot/UI tree 저장 | local evidence: `.codex/evidence/837/network-map-after-zoom-real-device.png`, `.codex/evidence/837/network-map-after-zoom-ui.xml`, `.codex/evidence/837/network-map-app-logcat.txt` | 확대 후 노선도 표시 유지, 앱 PID logcat에서 crash/Flutter error 패턴 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `MapCameraState.zoomBy`가 focal point 아래 source 좌표를 보존하는지
  - `MapCameraState.clamped`가 viewport가 source보다 큰 축을 source 중앙으로 고정하는지
  - renderer event 계약이 #836의 후속 Android/iOS viewport backend에 필요한 최소 타입만 포함하는지

## 리스크

- 이번 PR은 새 domain/contract만 추가하고 기존 노선도 UI에 연결하지 않는다. 실제 viewport WebView 전환, overlay culling, polygon hit-test, production 좌표 감사는 #836의 후속 하위 PR에서 별도로 검증해야 한다.
- 실기기 screenshot은 로컬 evidence로 보관했다. UI 변경 PR이 아니며 외부 업로드 승인이 없어 이미지 파일은 git과 PR 첨부에 포함하지 않았다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 없어 CD 완료 대기는 제외하고 Release Artifacts PR gate를 확인했다.
