### PR TITLE
[Fix] 데이터 삭제와 개인정보 안내 범위 정정

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -551,6 +551,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
   bool _savingOnboardingResult = false;
   OnboardingResult? _pendingOnboardingResult;
   UserDataDeletionResult? _dataDeletionResult;
+  UserDataDeletionScope _dataDeletionScope = UserDataDeletionScope.deviceOnly;
 
   @override
   void initState() {
@@ -574,9 +575,11 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
     if (dataDeletionResult != null) {
       return UserDataDeletionResultScreen(
         result: dataDeletionResult,
+        deletionScope: _dataDeletionScope,
         onRestart: () {
           setState(() {
             _dataDeletionResult = null;
+            _dataDeletionScope = UserDataDeletionScope.deviceOnly;
           });
         },
       );
@@ -685,6 +688,9 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
       _startScreenDismissed = false;
       _introScreenDismissed = false;
       _dataDeletionResult = result;
+      _dataDeletionScope = _userDataDeletionScope(
+        widget.userDataDeletionRepository,
+      );
     });
   }
 
@@ -3844,11 +3850,19 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final deletionScope = _userDataDeletionScope(repository);
+    final title = deletionScope == UserDataDeletionScope.deviceOnly
+        ? '이 기기의 앱 데이터 삭제'
+        : '내 데이터 삭제';
+    final helperText = deletionScope == UserDataDeletionScope.deviceOnly
+        ? '로컬 삭제 범위와 복구 불가 여부를 확인하고 진행합니다.'
+        : '삭제 범위와 복구 불가 여부를 확인하고 진행합니다.';
     void openDeletionScreen() {
       Navigator.of(context).push(
         MaterialPageRoute<void>(
           builder: (_) => UserDataDeletionScreen(
             repository: repository,
+            deletionScope: deletionScope,
             onDeleted: onDeleted,
           ),
         ),
@@ -3858,7 +3872,7 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
     return Semantics(
       key: const Key('dataDeletionAccessItem'),
       button: true,
-      label: '이 기기의 앱 데이터 삭제, 로컬 삭제 범위와 복구 불가 여부를 확인하고 앱 안에서 삭제를 진행합니다.',
+      label: '$title, $helperText',
       onTap: openDeletionScreen,
       child: ExcludeSemantics(
         child: Material(
@@ -3872,33 +3886,33 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
           child: InkWell(
             borderRadius: BorderRadius.circular(8),
             onTap: openDeletionScreen,
-            child: const Padding(
-              padding: EdgeInsets.all(16),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
               child: Row(
                 children: [
-                  Icon(
+                  const Icon(
                     Icons.delete_outline,
                     color: Color(0xFF8B1E1E),
                     size: 28,
                   ),
-                  SizedBox(width: 14),
+                  const SizedBox(width: 14),
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          '이 기기의 앱 데이터 삭제',
-                          style: TextStyle(
+                          title,
+                          style: const TextStyle(
                             color: Color(0xFF102A2C),
                             fontSize: 18,
                             fontWeight: FontWeight.w800,
                             height: 1.25,
                           ),
                         ),
-                        SizedBox(height: 4),
+                        const SizedBox(height: 4),
                         Text(
-                          '로컬 삭제 범위와 복구 불가 여부를 확인하고 진행합니다.',
-                          style: TextStyle(
+                          helperText,
+                          style: const TextStyle(
                             color: Color(0xFF466467),
                             fontSize: 15,
                             fontWeight: FontWeight.w600,
@@ -3908,7 +3922,7 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
                       ],
                     ),
                   ),
-                  Icon(Icons.chevron_right, color: Color(0xFF466467)),
+                  const Icon(Icons.chevron_right, color: Color(0xFF466467)),
                 ],
               ),
             ),
@@ -3919,14 +3933,71 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
   }
 }
 
+enum UserDataDeletionScope { deviceOnly, remoteAndDevice }
+
+UserDataDeletionScope _userDataDeletionScope(
+  UserDataDeletionRepository? repository,
+) {
+  if (repository is UserDataDeletionApiRepository ||
+      repository is UserDataDeletionCompositeRepository) {
+    return UserDataDeletionScope.remoteAndDevice;
+  }
+  return UserDataDeletionScope.deviceOnly;
+}
+
+class _UserDataDeletionCopy {
+  const _UserDataDeletionCopy({
+    required this.title,
+    required this.body,
+    required this.notices,
+    required this.confirmText,
+  });
+
+  factory _UserDataDeletionCopy.forScope(UserDataDeletionScope scope) {
+    return switch (scope) {
+      UserDataDeletionScope.deviceOnly => const _UserDataDeletionCopy(
+        title: '이 기기의 앱 데이터 삭제',
+        body:
+            '즐겨찾기, 최근 검색, 이동 조건, 화면 설정, 이 기기에 저장된 제보 접수 확인 정보와 작성 중인 제보를 삭제합니다.',
+        notices: [
+          '이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.',
+          '삭제가 끝나면 이동 조건과 화면 설정이 초기화되고 처음 설정 화면으로 돌아갑니다.',
+          '삭제한 데이터는 앱에서 복구할 수 없습니다.',
+          '네트워크 오류가 나면 기존 데이터는 지우지 않고 다시 시도할 수 있습니다.',
+          '법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관될 수 있습니다.',
+        ],
+        confirmText: '삭제 후에는 이 기기에 저장된 앱 데이터와 설정이 지워지고 되돌릴 수 없습니다.',
+      ),
+      UserDataDeletionScope.remoteAndDevice => const _UserDataDeletionCopy(
+        title: '내 데이터 삭제',
+        body: '즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.',
+        notices: [
+          '삭제가 끝나면 이 기기와 서버에 연결된 데이터가 함께 정리됩니다.',
+          '삭제한 데이터는 앱에서 복구할 수 없습니다.',
+          '네트워크 오류가 나면 기존 데이터는 지우지 않고 다시 시도할 수 있습니다.',
+          '법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관될 수 있습니다.',
+        ],
+        confirmText: '삭제 후에는 앱에 저장된 데이터와 설정이 지워지고 되돌릴 수 없습니다.',
+      ),
+    };
+  }
+
+  final String title;
+  final String body;
+  final List<String> notices;
+  final String confirmText;
+}
+
 class UserDataDeletionScreen extends StatefulWidget {
   const UserDataDeletionScreen({
     required this.repository,
+    required this.deletionScope,
     required this.onDeleted,
     super.key,
   });
 
   final UserDataDeletionRepository repository;
+  final UserDataDeletionScope deletionScope;
   final Future<void> Function(UserDataDeletionResult result)? onDeleted;
 
   @override
@@ -3939,8 +4010,9 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final copy = _UserDataDeletionCopy.forScope(widget.deletionScope);
     return Scaffold(
-      appBar: AppBar(title: const Text('이 기기의 앱 데이터 삭제')),
+      appBar: AppBar(title: Text(copy.title)),
       bottomNavigationBar: SafeArea(
         minimum: const EdgeInsets.fromLTRB(20, 8, 20, 20),
         child: FilledButton.icon(
@@ -3953,7 +4025,7 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
                   child: CircularProgressIndicator(strokeWidth: 2.5),
                 )
               : const Icon(Icons.delete_forever_outlined),
-          label: Text(_isDeleting ? '삭제 중' : '이 기기의 앱 데이터 삭제'),
+          label: Text(_isDeleting ? '삭제 중' : copy.title),
           style: FilledButton.styleFrom(
             backgroundColor: const Color(0xFF8B1E1E),
             foregroundColor: Colors.white,
@@ -3977,26 +4049,15 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
             ),
             const SizedBox(height: 12),
             Text(
-              '즐겨찾기, 최근 검색, 이동 조건, 화면 설정, 이 기기에 저장된 제보 접수 확인 정보와 작성 중인 제보를 삭제합니다.',
+              copy.body,
               style: textTheme.bodyLarge?.copyWith(
                 color: const Color(0xFF102A2C),
                 height: 1.4,
               ),
             ),
             const SizedBox(height: 16),
-            const _DataDeletionNoticeLine(
-              text: '이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.',
-            ),
-            const _DataDeletionNoticeLine(
-              text: '삭제가 끝나면 이동 조건과 화면 설정이 초기화되고 처음 설정 화면으로 돌아갑니다.',
-            ),
-            const _DataDeletionNoticeLine(text: '삭제한 데이터는 앱에서 복구할 수 없습니다.'),
-            const _DataDeletionNoticeLine(
-              text: '네트워크 오류가 나면 기존 데이터는 지우지 않고 다시 시도할 수 있습니다.',
-            ),
-            const _DataDeletionNoticeLine(
-              text: '법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관될 수 있습니다.',
-            ),
+            for (final notice in copy.notices)
+              _DataDeletionNoticeLine(text: notice),
           ],
         ),
       ),
@@ -4008,7 +4069,9 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('정말 삭제할까요?'),
-        content: const Text('삭제 후에는 이 기기에 저장된 앱 데이터와 설정이 지워지고 되돌릴 수 없습니다.'),
+        content: Text(
+          _UserDataDeletionCopy.forScope(widget.deletionScope).confirmText,
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
@@ -4104,11 +4167,13 @@ class _DataDeletionNoticeLine extends StatelessWidget {
 class UserDataDeletionResultScreen extends StatelessWidget {
   const UserDataDeletionResultScreen({
     required this.result,
+    required this.deletionScope,
     required this.onRestart,
     super.key,
   });
 
   final UserDataDeletionResult result;
+  final UserDataDeletionScope deletionScope;
   final VoidCallback onRestart;
 
   @override
@@ -4186,9 +4251,19 @@ class UserDataDeletionResultScreen extends StatelessWidget {
                   ),
                   _DataDeletionResultRow(
                     icon: Icons.report_outlined,
-                    title: '이 기기의 제보 기록',
-                    value: '${result.anonymizedReportCount}건 삭제',
+                    title: deletionScope == UserDataDeletionScope.deviceOnly
+                        ? '이 기기의 제보 기록'
+                        : '제보 연결 정보',
+                    value: deletionScope == UserDataDeletionScope.deviceOnly
+                        ? '${result.anonymizedReportCount}건 삭제'
+                        : '${result.anonymizedReportCount}건 익명화',
                   ),
+                  if (deletionScope == UserDataDeletionScope.remoteAndDevice)
+                    _DataDeletionResultRow(
+                      icon: Icons.rate_review_outlined,
+                      title: '경로 의견 연결 정보',
+                      value: '${result.anonymizedRouteFeedbackCount}건 익명화',
+                    ),
                 ],
               ),
             ),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -3764,12 +3764,12 @@ class SupportAccessScreen extends StatelessWidget {
               _SupportAccessItem(
                 key: const Key('dataDeletionAccessItem'),
                 icon: Icons.delete_outline,
-                title: '데이터 삭제 요청',
+                title: '이 기기의 앱 데이터 삭제',
                 value: accessInfo.dataDeletionEmail,
-                helperText: '삭제 범위와 복구 불가 여부를 먼저 확인해요',
+                helperText: '로컬 삭제 범위와 복구 불가 여부를 먼저 확인해요',
                 uri: _mailtoUri(
                   accessInfo.dataDeletionEmail,
-                  '쉬운 지하철 데이터 삭제 요청',
+                  '쉬운 지하철 이 기기의 앱 데이터 삭제',
                 ),
                 launcher: launcher,
               )
@@ -3858,7 +3858,7 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
     return Semantics(
       key: const Key('dataDeletionAccessItem'),
       button: true,
-      label: '데이터 삭제 요청, 삭제 범위와 복구 불가 여부를 확인하고 앱 안에서 삭제를 진행합니다.',
+      label: '이 기기의 앱 데이터 삭제, 로컬 삭제 범위와 복구 불가 여부를 확인하고 앱 안에서 삭제를 진행합니다.',
       onTap: openDeletionScreen,
       child: ExcludeSemantics(
         child: Material(
@@ -3887,7 +3887,7 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          '데이터 삭제 요청',
+                          '이 기기의 앱 데이터 삭제',
                           style: TextStyle(
                             color: Color(0xFF102A2C),
                             fontSize: 18,
@@ -3897,7 +3897,7 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
                         ),
                         SizedBox(height: 4),
                         Text(
-                          '삭제 범위와 복구 불가 여부를 확인하고 진행합니다.',
+                          '로컬 삭제 범위와 복구 불가 여부를 확인하고 진행합니다.',
                           style: TextStyle(
                             color: Color(0xFF466467),
                             fontSize: 15,
@@ -3940,7 +3940,7 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     return Scaffold(
-      appBar: AppBar(title: const Text('내 데이터 삭제')),
+      appBar: AppBar(title: const Text('이 기기의 앱 데이터 삭제')),
       bottomNavigationBar: SafeArea(
         minimum: const EdgeInsets.fromLTRB(20, 8, 20, 20),
         child: FilledButton.icon(
@@ -3953,7 +3953,7 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
                   child: CircularProgressIndicator(strokeWidth: 2.5),
                 )
               : const Icon(Icons.delete_forever_outlined),
-          label: Text(_isDeleting ? '삭제 중' : '내 데이터 삭제'),
+          label: Text(_isDeleting ? '삭제 중' : '이 기기의 앱 데이터 삭제'),
           style: FilledButton.styleFrom(
             backgroundColor: const Color(0xFF8B1E1E),
             foregroundColor: Colors.white,
@@ -3977,7 +3977,7 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
             ),
             const SizedBox(height: 12),
             Text(
-              '즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.',
+              '즐겨찾기, 최근 검색, 이동 조건, 화면 설정, 이 기기에 저장된 제보 접수 확인 정보와 작성 중인 제보를 삭제합니다.',
               style: textTheme.bodyLarge?.copyWith(
                 color: const Color(0xFF102A2C),
                 height: 1.4,
@@ -3985,7 +3985,10 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
             ),
             const SizedBox(height: 16),
             const _DataDeletionNoticeLine(
-              text: '삭제가 끝나면 현재 로그인 정보는 지워지고 처음 설정 화면으로 돌아갑니다.',
+              text: '이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.',
+            ),
+            const _DataDeletionNoticeLine(
+              text: '삭제가 끝나면 이동 조건과 화면 설정이 초기화되고 처음 설정 화면으로 돌아갑니다.',
             ),
             const _DataDeletionNoticeLine(text: '삭제한 데이터는 앱에서 복구할 수 없습니다.'),
             const _DataDeletionNoticeLine(
@@ -4005,7 +4008,7 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('정말 삭제할까요?'),
-        content: const Text('삭제 후에는 앱에 저장된 인증 정보와 설정이 지워지고 되돌릴 수 없습니다.'),
+        content: const Text('삭제 후에는 이 기기에 저장된 앱 데이터와 설정이 지워지고 되돌릴 수 없습니다.'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),
@@ -4183,13 +4186,8 @@ class UserDataDeletionResultScreen extends StatelessWidget {
                   ),
                   _DataDeletionResultRow(
                     icon: Icons.report_outlined,
-                    title: '제보 연결 정보',
-                    value: '${result.anonymizedReportCount}건 익명화',
-                  ),
-                  _DataDeletionResultRow(
-                    icon: Icons.rate_review_outlined,
-                    title: '경로 의견 연결 정보',
-                    value: '${result.anonymizedRouteFeedbackCount}건 익명화',
+                    title: '이 기기의 제보 기록',
+                    value: '${result.anonymizedReportCount}건 삭제',
                   ),
                 ],
               ),
@@ -4241,7 +4239,7 @@ class _SecurityContactNotice extends StatelessWidget {
 
   static const _title = '보안 문의 안내';
   static const _contactNotice = '취약점이나 개인정보 보호 우려를 발견하면 보안 문의로 알려주세요.';
-  static const _scopeNotice = '위치, 신고 사진, 알림, 계정 접근 문제를 함께 접수할 수 있습니다.';
+  static const _scopeNotice = '위치, 신고 사진, 알림, 개인정보 보호 우려를 함께 접수할 수 있습니다.';
 
   @override
   Widget build(BuildContext context) {
@@ -4427,7 +4425,8 @@ class _PrivacyDataUseSummary extends StatelessWidget {
   static const _locationPurpose = '현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다.';
   static const _appDataPurpose = '즐겨찾기, 이동 조건, 신고 내용과 사진은 앱 기능 제공에 사용됩니다.';
   static const _deletionScope =
-      '데이터 삭제 요청 시 즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용·사진·위치와 경로 피드백을 삭제하거나 익명화합니다.';
+      '이 기기의 앱 데이터 삭제는 즐겨찾기, 최근 검색, 이동 조건, 화면 설정, 제보 접수 확인 정보와 작성 중인 제보만 지웁니다.';
+  static const _sentReportNotice = '이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.';
   static const _retentionNotice = '법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관합니다.';
 
   @override
@@ -4437,7 +4436,7 @@ class _PrivacyDataUseSummary extends StatelessWidget {
       key: const Key('privacyDataUseSummary'),
       container: true,
       label:
-          '$_title, $_locationPurpose $_appDataPurpose $_deletionScope $_retentionNotice',
+          '$_title, $_locationPurpose $_appDataPurpose $_deletionScope $_sentReportNotice $_retentionNotice',
       child: ExcludeSemantics(
         child: Container(
           decoration: BoxDecoration(
@@ -4462,6 +4461,7 @@ class _PrivacyDataUseSummary extends StatelessWidget {
                 const _PrivacyDataUseLine(text: _locationPurpose),
                 const _PrivacyDataUseLine(text: _appDataPurpose),
                 const _PrivacyDataUseLine(text: _deletionScope),
+                const _PrivacyDataUseLine(text: _sentReportNotice),
                 const _PrivacyDataUseLine(text: _retentionNotice),
               ],
             ),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -3991,7 +3991,7 @@ class _UserDataDeletionCopy {
       UserDataDeletionScope.remoteOnly => const _UserDataDeletionCopy(
         title: '서버 데이터 삭제',
         helperText: '서버 삭제 범위와 앱 초기화 여부를 확인하고 진행합니다.',
-        body: '즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.',
+        body: '즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 사진, 위치, 경로 피드백을 삭제하거나 익명화합니다.',
         notices: [
           '삭제가 끝나면 서버에 연결된 데이터가 정리되고 앱의 임시 설정이 초기화됩니다.',
           '앱은 처음 설정 화면으로 돌아갑니다.',
@@ -4005,7 +4005,7 @@ class _UserDataDeletionCopy {
       UserDataDeletionScope.remoteAndDevice => const _UserDataDeletionCopy(
         title: '내 데이터 삭제',
         helperText: '삭제 범위와 복구 불가 여부를 확인하고 진행합니다.',
-        body: '즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.',
+        body: '즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 사진, 위치, 경로 피드백을 삭제하거나 익명화합니다.',
         notices: [
           '삭제가 끝나면 이 기기와 서버에 연결된 데이터가 함께 정리됩니다.',
           '삭제한 데이터는 앱에서 복구할 수 없습니다.',
@@ -4542,14 +4542,14 @@ class _PrivacyDataUseSummary extends StatelessWidget {
   static const _deviceDeletionScope =
       '이 기기의 앱 데이터 삭제는 즐겨찾기, 최근 검색, 이동 조건, 화면 설정, 제보 접수 확인 정보와 작성 중인 제보만 지웁니다.';
   static const _remoteDeletionScope =
-      '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화하고 앱의 임시 설정을 초기화합니다.';
+      '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 사진, 위치, 경로 피드백을 삭제하거나 익명화하고 앱의 임시 설정을 초기화합니다.';
   static const _combinedDeletionScope =
-      '내 데이터 삭제는 이 기기의 즐겨찾기, 최근 검색, 이동 조건, 화면 설정과 서버에 연결된 제보·경로 피드백 정보를 삭제하거나 익명화합니다.';
+      '내 데이터 삭제는 이 기기의 즐겨찾기, 최근 검색, 이동 조건, 화면 설정과 서버에 연결된 신고 내용·사진·위치, 경로 피드백 정보를 삭제하거나 익명화합니다.';
   static const _requestNotice = '앱 안에서 바로 삭제할 수 없는 데이터는 답변 안내에 따라 처리됩니다.';
   static const _deviceSentReportNotice =
       '이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.';
   static const _remoteSentReportNotice =
-      '이미 보낸 시설 제보, 위치 정보, 경로 피드백은 서버에서 삭제되거나 익명화됩니다.';
+      '이미 보낸 시설 제보, 사진, 위치 정보, 경로 피드백은 서버에서 삭제되거나 익명화됩니다.';
   static const _retentionNotice = '법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관합니다.';
 
   String get _deletionScopeText {

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -3990,15 +3990,17 @@ class _UserDataDeletionCopy {
       ),
       UserDataDeletionScope.remoteOnly => const _UserDataDeletionCopy(
         title: '서버 데이터 삭제',
-        helperText: '서버 삭제 범위와 복구 불가 여부를 확인하고 진행합니다.',
+        helperText: '서버 삭제 범위와 앱 초기화 여부를 확인하고 진행합니다.',
         body: '즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.',
         notices: [
-          '삭제가 끝나면 서버에 연결된 데이터가 정리됩니다.',
+          '삭제가 끝나면 서버에 연결된 데이터가 정리되고 앱의 임시 설정이 초기화됩니다.',
+          '앱은 처음 설정 화면으로 돌아갑니다.',
           '삭제한 데이터는 앱에서 복구할 수 없습니다.',
           '네트워크 오류가 나면 기존 데이터는 지우지 않고 다시 시도할 수 있습니다.',
           '법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관될 수 있습니다.',
         ],
-        confirmText: '삭제 후에는 서버에 연결된 데이터와 설정이 삭제되거나 익명화되고 되돌릴 수 없습니다.',
+        confirmText:
+            '삭제 후에는 서버에 연결된 데이터와 설정이 삭제되거나 익명화되고 앱의 임시 설정이 초기화됩니다. 되돌릴 수 없습니다.',
       ),
       UserDataDeletionScope.remoteAndDevice => const _UserDataDeletionCopy(
         title: '내 데이터 삭제',
@@ -4540,7 +4542,7 @@ class _PrivacyDataUseSummary extends StatelessWidget {
   static const _deviceDeletionScope =
       '이 기기의 앱 데이터 삭제는 즐겨찾기, 최근 검색, 이동 조건, 화면 설정, 제보 접수 확인 정보와 작성 중인 제보만 지웁니다.';
   static const _remoteDeletionScope =
-      '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.';
+      '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화하고 앱의 임시 설정을 초기화합니다.';
   static const _combinedDeletionScope =
       '내 데이터 삭제는 이 기기의 즐겨찾기, 최근 검색, 이동 조건, 화면 설정과 서버에 연결된 제보·경로 피드백 정보를 삭제하거나 익명화합니다.';
   static const _requestNotice = '앱 안에서 바로 삭제할 수 없는 데이터는 답변 안내에 따라 처리됩니다.';

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -3851,12 +3851,7 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final deletionScope = _userDataDeletionScope(repository);
-    final title = deletionScope == UserDataDeletionScope.deviceOnly
-        ? '이 기기의 앱 데이터 삭제'
-        : '내 데이터 삭제';
-    final helperText = deletionScope == UserDataDeletionScope.deviceOnly
-        ? '로컬 삭제 범위와 복구 불가 여부를 확인하고 진행합니다.'
-        : '삭제 범위와 복구 불가 여부를 확인하고 진행합니다.';
+    final copy = _UserDataDeletionCopy.forScope(deletionScope);
     void openDeletionScreen() {
       Navigator.of(context).push(
         MaterialPageRoute<void>(
@@ -3872,7 +3867,7 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
     return Semantics(
       key: const Key('dataDeletionAccessItem'),
       button: true,
-      label: '$title, $helperText',
+      label: '${copy.title}, ${copy.helperText}',
       onTap: openDeletionScreen,
       child: ExcludeSemantics(
         child: Material(
@@ -3901,7 +3896,7 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          title,
+                          copy.title,
                           style: const TextStyle(
                             color: Color(0xFF102A2C),
                             fontSize: 18,
@@ -3911,7 +3906,7 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
                         ),
                         const SizedBox(height: 4),
                         Text(
-                          helperText,
+                          copy.helperText,
                           style: const TextStyle(
                             color: Color(0xFF466467),
                             fontSize: 15,
@@ -3933,14 +3928,16 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
   }
 }
 
-enum UserDataDeletionScope { deviceOnly, remoteAndDevice }
+enum UserDataDeletionScope { deviceOnly, remoteOnly, remoteAndDevice }
 
 UserDataDeletionScope _userDataDeletionScope(
   UserDataDeletionRepository? repository,
 ) {
-  if (repository is UserDataDeletionApiRepository ||
-      repository is UserDataDeletionCompositeRepository) {
+  if (repository is UserDataDeletionCompositeRepository) {
     return UserDataDeletionScope.remoteAndDevice;
+  }
+  if (repository is UserDataDeletionApiRepository) {
+    return UserDataDeletionScope.remoteOnly;
   }
   return UserDataDeletionScope.deviceOnly;
 }
@@ -3948,6 +3945,7 @@ UserDataDeletionScope _userDataDeletionScope(
 class _UserDataDeletionCopy {
   const _UserDataDeletionCopy({
     required this.title,
+    required this.helperText,
     required this.body,
     required this.notices,
     required this.confirmText,
@@ -3957,19 +3955,33 @@ class _UserDataDeletionCopy {
     return switch (scope) {
       UserDataDeletionScope.deviceOnly => const _UserDataDeletionCopy(
         title: '이 기기의 앱 데이터 삭제',
+        helperText: '로컬 삭제 범위와 복구 불가 여부를 확인하고 진행합니다.',
         body:
             '즐겨찾기, 최근 검색, 이동 조건, 화면 설정, 이 기기에 저장된 제보 접수 확인 정보와 작성 중인 제보를 삭제합니다.',
         notices: [
           '이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.',
           '삭제가 끝나면 이동 조건과 화면 설정이 초기화되고 처음 설정 화면으로 돌아갑니다.',
           '삭제한 데이터는 앱에서 복구할 수 없습니다.',
-          '네트워크 오류가 나면 기존 데이터는 지우지 않고 다시 시도할 수 있습니다.',
+          '삭제를 완료하지 못하면 오류 안내를 보고 다시 시도할 수 있습니다.',
           '법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관될 수 있습니다.',
         ],
         confirmText: '삭제 후에는 이 기기에 저장된 앱 데이터와 설정이 지워지고 되돌릴 수 없습니다.',
       ),
+      UserDataDeletionScope.remoteOnly => const _UserDataDeletionCopy(
+        title: '서버 데이터 삭제',
+        helperText: '서버 삭제 범위와 복구 불가 여부를 확인하고 진행합니다.',
+        body: '즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.',
+        notices: [
+          '삭제가 끝나면 서버에 연결된 데이터가 정리됩니다.',
+          '삭제한 데이터는 앱에서 복구할 수 없습니다.',
+          '네트워크 오류가 나면 기존 데이터는 지우지 않고 다시 시도할 수 있습니다.',
+          '법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관될 수 있습니다.',
+        ],
+        confirmText: '삭제 후에는 서버에 연결된 데이터와 설정이 삭제되거나 익명화되고 되돌릴 수 없습니다.',
+      ),
       UserDataDeletionScope.remoteAndDevice => const _UserDataDeletionCopy(
         title: '내 데이터 삭제',
+        helperText: '삭제 범위와 복구 불가 여부를 확인하고 진행합니다.',
         body: '즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.',
         notices: [
           '삭제가 끝나면 이 기기와 서버에 연결된 데이터가 함께 정리됩니다.',
@@ -3977,12 +3989,13 @@ class _UserDataDeletionCopy {
           '네트워크 오류가 나면 기존 데이터는 지우지 않고 다시 시도할 수 있습니다.',
           '법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관될 수 있습니다.',
         ],
-        confirmText: '삭제 후에는 앱에 저장된 데이터와 설정이 지워지고 되돌릴 수 없습니다.',
+        confirmText: '삭제 후에는 이 기기와 서버에 연결된 데이터와 설정이 삭제되거나 익명화되고 되돌릴 수 없습니다.',
       ),
     };
   }
 
   final String title;
+  final String helperText;
   final String body;
   final List<String> notices;
   final String confirmText;
@@ -4258,7 +4271,7 @@ class UserDataDeletionResultScreen extends StatelessWidget {
                         ? '${result.anonymizedReportCount}건 삭제'
                         : '${result.anonymizedReportCount}건 익명화',
                   ),
-                  if (deletionScope == UserDataDeletionScope.remoteAndDevice)
+                  if (deletionScope != UserDataDeletionScope.deviceOnly)
                     _DataDeletionResultRow(
                       icon: Icons.rate_review_outlined,
                       title: '경로 의견 연결 정보',

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -3748,6 +3748,7 @@ class SupportAccessScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final deletionScope = _userDataDeletionScope(userDataDeletionRepository);
     return Scaffold(
       appBar: AppBar(title: const Text('도움말·문의')),
       body: SafeArea(
@@ -3755,7 +3756,7 @@ class SupportAccessScreen extends StatelessWidget {
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
           children: [
             const _SupportSectionTitle(title: '개인정보 및 데이터'),
-            const _PrivacyDataUseSummary(),
+            _PrivacyDataUseSummary(deletionScope: deletionScope),
             const SizedBox(height: 12),
             _SupportAccessItem(
               key: const Key('privacyPolicyAccessItem'),
@@ -3782,6 +3783,7 @@ class SupportAccessScreen extends StatelessWidget {
             else
               _UserDataDeletionAccessItem(
                 repository: userDataDeletionRepository!,
+                deletionScope: deletionScope,
                 onDeleted: onUserDataDeleted,
               ),
             const SizedBox(height: 20),
@@ -3842,15 +3844,16 @@ class _SupportSectionTitle extends StatelessWidget {
 class _UserDataDeletionAccessItem extends StatelessWidget {
   const _UserDataDeletionAccessItem({
     required this.repository,
+    required this.deletionScope,
     required this.onDeleted,
   });
 
   final UserDataDeletionRepository repository;
+  final UserDataDeletionScope deletionScope;
   final Future<void> Function(UserDataDeletionResult result)? onDeleted;
 
   @override
   Widget build(BuildContext context) {
-    final deletionScope = _userDataDeletionScope(repository);
     final copy = _UserDataDeletionCopy.forScope(deletionScope);
     void openDeletionScreen() {
       Navigator.of(context).push(
@@ -4507,24 +4510,51 @@ class _SafetyDataNoticeLine extends StatelessWidget {
 }
 
 class _PrivacyDataUseSummary extends StatelessWidget {
-  const _PrivacyDataUseSummary();
+  const _PrivacyDataUseSummary({required this.deletionScope});
+
+  final UserDataDeletionScope deletionScope;
 
   static const _title = '개인정보 사용 안내';
   static const _locationPurpose = '현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다.';
   static const _appDataPurpose = '즐겨찾기, 이동 조건, 신고 내용과 사진은 앱 기능 제공에 사용됩니다.';
-  static const _deletionScope =
+  static const _deviceDeletionScope =
       '이 기기의 앱 데이터 삭제는 즐겨찾기, 최근 검색, 이동 조건, 화면 설정, 제보 접수 확인 정보와 작성 중인 제보만 지웁니다.';
-  static const _sentReportNotice = '이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.';
+  static const _remoteDeletionScope =
+      '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.';
+  static const _combinedDeletionScope =
+      '내 데이터 삭제는 이 기기의 즐겨찾기, 최근 검색, 이동 조건, 화면 설정과 서버에 연결된 제보·경로 피드백 정보를 삭제하거나 익명화합니다.';
+  static const _deviceSentReportNotice =
+      '이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.';
+  static const _remoteSentReportNotice =
+      '이미 보낸 시설 제보, 위치 정보, 경로 피드백은 서버에서 삭제되거나 익명화됩니다.';
   static const _retentionNotice = '법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관합니다.';
+
+  String get _deletionScopeText {
+    return switch (deletionScope) {
+      UserDataDeletionScope.deviceOnly => _deviceDeletionScope,
+      UserDataDeletionScope.remoteOnly => _remoteDeletionScope,
+      UserDataDeletionScope.remoteAndDevice => _combinedDeletionScope,
+    };
+  }
+
+  String get _sentReportNoticeText {
+    return switch (deletionScope) {
+      UserDataDeletionScope.deviceOnly => _deviceSentReportNotice,
+      UserDataDeletionScope.remoteOnly ||
+      UserDataDeletionScope.remoteAndDevice => _remoteSentReportNotice,
+    };
+  }
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final deletionScopeText = _deletionScopeText;
+    final sentReportNoticeText = _sentReportNoticeText;
     return Semantics(
       key: const Key('privacyDataUseSummary'),
       container: true,
       label:
-          '$_title, $_locationPurpose $_appDataPurpose $_deletionScope $_sentReportNotice $_retentionNotice',
+          '$_title, $_locationPurpose $_appDataPurpose $deletionScopeText $sentReportNoticeText $_retentionNotice',
       child: ExcludeSemantics(
         child: Container(
           decoration: BoxDecoration(
@@ -4548,8 +4578,8 @@ class _PrivacyDataUseSummary extends StatelessWidget {
                 const SizedBox(height: 10),
                 const _PrivacyDataUseLine(text: _locationPurpose),
                 const _PrivacyDataUseLine(text: _appDataPurpose),
-                const _PrivacyDataUseLine(text: _deletionScope),
-                const _PrivacyDataUseLine(text: _sentReportNotice),
+                _PrivacyDataUseLine(text: deletionScopeText),
+                _PrivacyDataUseLine(text: sentReportNoticeText),
                 const _PrivacyDataUseLine(text: _retentionNotice),
               ],
             ),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -3771,12 +3771,12 @@ class SupportAccessScreen extends StatelessWidget {
               _SupportAccessItem(
                 key: const Key('dataDeletionAccessItem'),
                 icon: Icons.delete_outline,
-                title: '이 기기의 앱 데이터 삭제',
+                title: '데이터 삭제 요청',
                 value: accessInfo.dataDeletionEmail,
-                helperText: '로컬 삭제 범위와 복구 불가 여부를 먼저 확인해요',
+                helperText: '삭제 범위와 처리 절차를 메일로 문의해요',
                 uri: _mailtoUri(
                   accessInfo.dataDeletionEmail,
-                  '쉬운 지하철 이 기기의 앱 데이터 삭제',
+                  '쉬운 지하철 데이터 삭제 요청',
                 ),
                 launcher: launcher,
               )
@@ -3931,11 +3931,19 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
   }
 }
 
-enum UserDataDeletionScope { deviceOnly, remoteOnly, remoteAndDevice }
+enum UserDataDeletionScope {
+  requestOnly,
+  deviceOnly,
+  remoteOnly,
+  remoteAndDevice,
+}
 
 UserDataDeletionScope _userDataDeletionScope(
   UserDataDeletionRepository? repository,
 ) {
+  if (repository == null) {
+    return UserDataDeletionScope.requestOnly;
+  }
   if (repository is UserDataDeletionCompositeRepository) {
     return UserDataDeletionScope.remoteAndDevice;
   }
@@ -3956,6 +3964,16 @@ class _UserDataDeletionCopy {
 
   factory _UserDataDeletionCopy.forScope(UserDataDeletionScope scope) {
     return switch (scope) {
+      UserDataDeletionScope.requestOnly => const _UserDataDeletionCopy(
+        title: '데이터 삭제 요청',
+        helperText: '삭제 범위와 처리 절차를 메일로 문의합니다.',
+        body: '삭제가 필요한 데이터와 처리 절차를 지원 메일로 문의합니다.',
+        notices: [
+          '앱 안에서 바로 삭제할 수 없는 데이터는 답변 안내에 따라 처리됩니다.',
+          '요청 전 개인정보처리방침에서 보관 범위와 기간을 확인할 수 있습니다.',
+        ],
+        confirmText: '데이터 삭제 요청 메일을 보낼까요?',
+      ),
       UserDataDeletionScope.deviceOnly => const _UserDataDeletionCopy(
         title: '이 기기의 앱 데이터 삭제',
         helperText: '로컬 삭제 범위와 복구 불가 여부를 확인하고 진행합니다.',
@@ -4517,12 +4535,15 @@ class _PrivacyDataUseSummary extends StatelessWidget {
   static const _title = '개인정보 사용 안내';
   static const _locationPurpose = '현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다.';
   static const _appDataPurpose = '즐겨찾기, 이동 조건, 신고 내용과 사진은 앱 기능 제공에 사용됩니다.';
+  static const _requestDeletionScope =
+      '데이터 삭제 요청은 지원 메일로 삭제 범위와 처리 절차를 문의할 수 있습니다.';
   static const _deviceDeletionScope =
       '이 기기의 앱 데이터 삭제는 즐겨찾기, 최근 검색, 이동 조건, 화면 설정, 제보 접수 확인 정보와 작성 중인 제보만 지웁니다.';
   static const _remoteDeletionScope =
       '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.';
   static const _combinedDeletionScope =
       '내 데이터 삭제는 이 기기의 즐겨찾기, 최근 검색, 이동 조건, 화면 설정과 서버에 연결된 제보·경로 피드백 정보를 삭제하거나 익명화합니다.';
+  static const _requestNotice = '앱 안에서 바로 삭제할 수 없는 데이터는 답변 안내에 따라 처리됩니다.';
   static const _deviceSentReportNotice =
       '이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.';
   static const _remoteSentReportNotice =
@@ -4531,6 +4552,7 @@ class _PrivacyDataUseSummary extends StatelessWidget {
 
   String get _deletionScopeText {
     return switch (deletionScope) {
+      UserDataDeletionScope.requestOnly => _requestDeletionScope,
       UserDataDeletionScope.deviceOnly => _deviceDeletionScope,
       UserDataDeletionScope.remoteOnly => _remoteDeletionScope,
       UserDataDeletionScope.remoteAndDevice => _combinedDeletionScope,
@@ -4539,6 +4561,7 @@ class _PrivacyDataUseSummary extends StatelessWidget {
 
   String get _sentReportNoticeText {
     return switch (deletionScope) {
+      UserDataDeletionScope.requestOnly => _requestNotice,
       UserDataDeletionScope.deviceOnly => _deviceSentReportNotice,
       UserDataDeletionScope.remoteOnly ||
       UserDataDeletionScope.remoteAndDevice => _remoteSentReportNotice,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2500,7 +2500,7 @@ void main() {
 
       expect(
         find.text(
-          '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.',
+          '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화하고 앱의 임시 설정을 초기화합니다.',
         ),
         findsOneWidget,
       );
@@ -2514,7 +2514,9 @@ void main() {
           .getSemanticsData();
       expect(
         summarySemantics.label,
-        contains('서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.'),
+        contains(
+          '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화하고 앱의 임시 설정을 초기화합니다.',
+        ),
       );
       expect(
         summarySemantics.label,
@@ -2535,14 +2537,20 @@ void main() {
         findsOneWidget,
       );
       expect(find.textContaining('이미 보낸 시설 제보'), findsNothing);
-      expect(find.text('삭제가 끝나면 서버에 연결된 데이터가 정리됩니다.'), findsOneWidget);
+      expect(
+        find.text('삭제가 끝나면 서버에 연결된 데이터가 정리되고 앱의 임시 설정이 초기화됩니다.'),
+        findsOneWidget,
+      );
+      expect(find.text('앱은 처음 설정 화면으로 돌아갑니다.'), findsOneWidget);
 
       await tester.tap(find.byKey(const Key('dataDeletionStartButton')));
       await tester.pumpAndSettle();
 
       expect(find.byType(AlertDialog), findsOneWidget);
       expect(
-        find.text('삭제 후에는 서버에 연결된 데이터와 설정이 삭제되거나 익명화되고 되돌릴 수 없습니다.'),
+        find.text(
+          '삭제 후에는 서버에 연결된 데이터와 설정이 삭제되거나 익명화되고 앱의 임시 설정이 초기화됩니다. 되돌릴 수 없습니다.',
+        ),
         findsOneWidget,
       );
     } finally {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2500,12 +2500,12 @@ void main() {
 
       expect(
         find.text(
-          '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화하고 앱의 임시 설정을 초기화합니다.',
+          '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 사진, 위치, 경로 피드백을 삭제하거나 익명화하고 앱의 임시 설정을 초기화합니다.',
         ),
         findsOneWidget,
       );
       expect(
-        find.text('이미 보낸 시설 제보, 위치 정보, 경로 피드백은 서버에서 삭제되거나 익명화됩니다.'),
+        find.text('이미 보낸 시설 제보, 사진, 위치 정보, 경로 피드백은 서버에서 삭제되거나 익명화됩니다.'),
         findsOneWidget,
       );
 
@@ -2515,12 +2515,12 @@ void main() {
       expect(
         summarySemantics.label,
         contains(
-          '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화하고 앱의 임시 설정을 초기화합니다.',
+          '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 사진, 위치, 경로 피드백을 삭제하거나 익명화하고 앱의 임시 설정을 초기화합니다.',
         ),
       );
       expect(
         summarySemantics.label,
-        contains('이미 보낸 시설 제보, 위치 정보, 경로 피드백은 서버에서 삭제되거나 익명화됩니다.'),
+        contains('이미 보낸 시설 제보, 사진, 위치 정보, 경로 피드백은 서버에서 삭제되거나 익명화됩니다.'),
       );
 
       await tester.scrollUntilVisible(
@@ -2533,7 +2533,9 @@ void main() {
 
       expect(find.text('서버 데이터 삭제'), findsWidgets);
       expect(
-        find.text('즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.'),
+        find.text(
+          '즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 사진, 위치, 경로 피드백을 삭제하거나 익명화합니다.',
+        ),
         findsOneWidget,
       );
       expect(find.textContaining('이미 보낸 시설 제보'), findsNothing);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2110,7 +2110,7 @@ void main() {
         scrollable: find.byType(Scrollable).last,
       );
       await tester.pumpAndSettle();
-      expect(find.text('이 기기의 앱 데이터 삭제'), findsOneWidget);
+      expect(find.text('데이터 삭제 요청'), findsOneWidget);
 
       final deletionButtonSize = tester.getSize(
         find.byKey(const Key('dataDeletionAccessItem')),
@@ -2122,7 +2122,7 @@ void main() {
           .getSemanticsData();
       expect(
         deletionSemantics.label,
-        '이 기기의 앱 데이터 삭제, privacy@easysubway.example, 로컬 삭제 범위와 복구 불가 여부를 먼저 확인해요',
+        '데이터 삭제 요청, privacy@easysubway.example, 삭제 범위와 처리 절차를 메일로 문의해요',
       );
       expect(deletionSemantics.hasAction(SemanticsAction.tap), isTrue);
 
@@ -2178,13 +2178,11 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.text(
-          '이 기기의 앱 데이터 삭제는 즐겨찾기, 최근 검색, 이동 조건, 화면 설정, 제보 접수 확인 정보와 작성 중인 제보만 지웁니다.',
-        ),
+        find.text('데이터 삭제 요청은 지원 메일로 삭제 범위와 처리 절차를 문의할 수 있습니다.'),
         findsOneWidget,
       );
       expect(
-        find.text('이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.'),
+        find.text('앱 안에서 바로 삭제할 수 없는 데이터는 답변 안내에 따라 처리됩니다.'),
         findsOneWidget,
       );
       expect(find.text('법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관합니다.'), findsOneWidget);
@@ -2203,7 +2201,7 @@ void main() {
       );
       expect(
         summarySemantics.label,
-        contains('이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.'),
+        contains('앱 안에서 바로 삭제할 수 없는 데이터는 답변 안내에 따라 처리됩니다.'),
       );
       expect(summarySemantics.label, isNot(contains('익명화')));
     } finally {
@@ -2653,7 +2651,7 @@ void main() {
           .getSemantics(find.byKey(const Key('dataDeletionAccessItem')))
           .getSemanticsData()
           .label,
-      '이 기기의 앱 데이터 삭제, 현재 이용할 수 없음 · 준비 중, 로컬 삭제 범위와 복구 불가 여부를 먼저 확인해요',
+      '데이터 삭제 요청, 현재 이용할 수 없음 · 준비 중, 삭제 범위와 처리 절차를 메일로 문의해요',
     );
     await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
     await tester.scrollUntilVisible(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'dart:ui';
 
 import 'package:easysubway_mobile/accessible_design.dart';
+import 'package:easysubway_mobile/auth_headers.dart';
 import 'package:easysubway_mobile/main.dart';
 import 'package:easysubway_mobile/facility_report.dart';
 import 'package:easysubway_mobile/favorite_facility.dart';
@@ -2471,6 +2472,51 @@ void main() {
     expect(onboardingStore.savedResult, isNull);
     expect(draftTargetStore.target, isNull);
     expect(find.byKey(const Key('startScreenStartButton')), findsOneWidget);
+  });
+
+  testWidgets('도움말은 원격 삭제 저장소에서 서버 삭제 범위를 유지해 안내한다', (tester) async {
+    final deletionRepository = UserDataDeletionApiRepository(
+      baseUri: Uri.parse('https://api.easysubway.example'),
+      authProvider: const NoAuthorizationHeaderProvider(),
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        userDataDeletionRepository: deletionRepository,
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await _openSupportAccessScreen(tester);
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('dataDeletionAccessItem')),
+      120,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('내 데이터 삭제'), findsWidgets);
+    expect(
+      find.text('즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('이미 보낸 시설 제보'), findsNothing);
+    expect(find.text('삭제가 끝나면 이 기기와 서버에 연결된 데이터가 함께 정리됩니다.'), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('dataDeletionStartButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(
+      find.text('삭제 후에는 앱에 저장된 데이터와 설정이 지워지고 되돌릴 수 없습니다.'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('데이터 삭제 실패 시 로컬 상태를 유지하고 오류를 안내한다', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2109,7 +2109,7 @@ void main() {
         scrollable: find.byType(Scrollable).last,
       );
       await tester.pumpAndSettle();
-      expect(find.text('데이터 삭제 요청'), findsOneWidget);
+      expect(find.text('이 기기의 앱 데이터 삭제'), findsOneWidget);
 
       final deletionButtonSize = tester.getSize(
         find.byKey(const Key('dataDeletionAccessItem')),
@@ -2121,7 +2121,7 @@ void main() {
           .getSemanticsData();
       expect(
         deletionSemantics.label,
-        '데이터 삭제 요청, privacy@easysubway.example, 삭제 범위와 복구 불가 여부를 먼저 확인해요',
+        '이 기기의 앱 데이터 삭제, privacy@easysubway.example, 로컬 삭제 범위와 복구 불가 여부를 먼저 확인해요',
       );
       expect(deletionSemantics.hasAction(SemanticsAction.tap), isTrue);
 
@@ -2178,8 +2178,12 @@ void main() {
       );
       expect(
         find.text(
-          '데이터 삭제 요청 시 즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용·사진·위치와 경로 피드백을 삭제하거나 익명화합니다.',
+          '이 기기의 앱 데이터 삭제는 즐겨찾기, 최근 검색, 이동 조건, 화면 설정, 제보 접수 확인 정보와 작성 중인 제보만 지웁니다.',
         ),
+        findsOneWidget,
+      );
+      expect(
+        find.text('이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.'),
         findsOneWidget,
       );
       expect(find.text('법적·보안상 필요한 최소 기록은 정해진 기간 동안만 보관합니다.'), findsOneWidget);
@@ -2196,6 +2200,7 @@ void main() {
         summarySemantics.label,
         contains('개인정보 사용 안내, 현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다.'),
       );
+      expect(summarySemantics.label, isNot(contains('익명화')));
     } finally {
       semanticsHandle.dispose();
     }
@@ -2279,6 +2284,7 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text('보안 문의 안내'), findsOneWidget);
       expect(find.text('취약점이나 개인정보 보호 우려를 발견하면 보안 문의로 알려주세요.'), findsOneWidget);
+      expect(find.textContaining('계정 접근'), findsNothing);
       await tester.scrollUntilVisible(
         find.byKey(const Key('securityContactAccessItem')),
         120,
@@ -2417,13 +2423,25 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('dataDeletionStartButton')), findsOneWidget);
-    expect(find.textContaining('즐겨찾기, 이동 조건, 신고 접수 기록'), findsOneWidget);
+    expect(find.text('이 기기의 앱 데이터 삭제'), findsWidgets);
+    expect(find.textContaining('즐겨찾기, 최근 검색, 이동 조건, 화면 설정'), findsOneWidget);
+    expect(
+      find.text('이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.'),
+      findsOneWidget,
+    );
     expect(find.text('삭제한 데이터는 앱에서 복구할 수 없습니다.'), findsOneWidget);
+    expect(find.textContaining('로그인 정보'), findsNothing);
+    expect(find.textContaining('익명화'), findsNothing);
 
     await tester.tap(find.byKey(const Key('dataDeletionStartButton')));
     await tester.pumpAndSettle();
     expect(find.byType(AlertDialog), findsOneWidget);
     expect(find.text('정말 삭제할까요?'), findsOneWidget);
+    expect(find.textContaining('인증 정보'), findsNothing);
+    expect(
+      find.text('삭제 후에는 이 기기에 저장된 앱 데이터와 설정이 지워지고 되돌릴 수 없습니다.'),
+      findsOneWidget,
+    );
 
     await tester.tap(find.byKey(const Key('dataDeletionConfirmButton')));
     await tester.pumpAndSettle();
@@ -2433,8 +2451,11 @@ void main() {
     expect(find.text('내 데이터가 삭제됐어요'), findsOneWidget);
     expect(find.text('즐겨찾기한 역'), findsOneWidget);
     expect(find.text('1개 삭제'), findsWidgets);
-    expect(find.text('제보 연결 정보'), findsOneWidget);
-    expect(find.text('1건 익명화'), findsWidgets);
+    expect(find.text('이 기기의 제보 기록'), findsOneWidget);
+    expect(find.text('1건 삭제'), findsOneWidget);
+    expect(find.textContaining('연결 정보'), findsNothing);
+    expect(find.textContaining('익명화'), findsNothing);
+    expect(find.textContaining('local-user'), findsNothing);
 
     await tester.tap(find.byKey(const Key('dataDeletionResultStartButton')));
     await tester.pumpAndSettle();
@@ -2553,7 +2574,7 @@ void main() {
           .getSemantics(find.byKey(const Key('dataDeletionAccessItem')))
           .getSemanticsData()
           .label,
-      '데이터 삭제 요청, 현재 이용할 수 없음 · 준비 중, 삭제 범위와 복구 불가 여부를 먼저 확인해요',
+      '이 기기의 앱 데이터 삭제, 현재 이용할 수 없음 · 준비 중, 로컬 삭제 범위와 복구 불가 여부를 먼저 확인해요',
     );
     await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
     await tester.scrollUntilVisible(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2479,48 +2479,77 @@ void main() {
   });
 
   testWidgets('도움말은 원격 삭제 저장소에서 서버 삭제 범위를 유지해 안내한다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
     final deletionRepository = UserDataDeletionApiRepository(
       baseUri: Uri.parse('https://api.easysubway.example'),
       authProvider: const NoAuthorizationHeaderProvider(),
     );
 
-    await tester.pumpWidget(
-      EasySubwayApp(
-        repository: FakeStationSearchRepository(),
-        reportRepository: FakeFacilityReportRepository(),
-        routeRepository: FakeRouteSearchRepository(),
-        favoriteRepository: FakeFavoriteStationRepository(),
-        notificationRepository: FakeNotificationSettingsRepository(),
-        userDataDeletionRepository: deletionRepository,
-        initialOnboardingState: _completedOnboardingState(),
-      ),
-    );
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
+          userDataDeletionRepository: deletionRepository,
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
 
-    await _openSupportAccessScreen(tester);
-    await tester.scrollUntilVisible(
-      find.byKey(const Key('dataDeletionAccessItem')),
-      120,
-      scrollable: find.byType(Scrollable).last,
-    );
-    await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
-    await tester.pumpAndSettle();
+      await _openSupportAccessScreen(tester);
 
-    expect(find.text('서버 데이터 삭제'), findsWidgets);
-    expect(
-      find.text('즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.'),
-      findsOneWidget,
-    );
-    expect(find.textContaining('이미 보낸 시설 제보'), findsNothing);
-    expect(find.text('삭제가 끝나면 서버에 연결된 데이터가 정리됩니다.'), findsOneWidget);
+      expect(
+        find.text(
+          '서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.',
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.text('이미 보낸 시설 제보, 위치 정보, 경로 피드백은 서버에서 삭제되거나 익명화됩니다.'),
+        findsOneWidget,
+      );
 
-    await tester.tap(find.byKey(const Key('dataDeletionStartButton')));
-    await tester.pumpAndSettle();
+      final summarySemantics = tester
+          .getSemantics(find.byKey(const Key('privacyDataUseSummary')))
+          .getSemanticsData();
+      expect(
+        summarySemantics.label,
+        contains('서버 데이터 삭제는 즐겨찾기, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.'),
+      );
+      expect(
+        summarySemantics.label,
+        contains('이미 보낸 시설 제보, 위치 정보, 경로 피드백은 서버에서 삭제되거나 익명화됩니다.'),
+      );
 
-    expect(find.byType(AlertDialog), findsOneWidget);
-    expect(
-      find.text('삭제 후에는 서버에 연결된 데이터와 설정이 삭제되거나 익명화되고 되돌릴 수 없습니다.'),
-      findsOneWidget,
-    );
+      await tester.scrollUntilVisible(
+        find.byKey(const Key('dataDeletionAccessItem')),
+        120,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('서버 데이터 삭제'), findsWidgets);
+      expect(
+        find.text('즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('이미 보낸 시설 제보'), findsNothing);
+      expect(find.text('삭제가 끝나면 서버에 연결된 데이터가 정리됩니다.'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('dataDeletionStartButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+      expect(
+        find.text('삭제 후에는 서버에 연결된 데이터와 설정이 삭제되거나 익명화되고 되돌릴 수 없습니다.'),
+        findsOneWidget,
+      );
+    } finally {
+      semanticsHandle.dispose();
+    }
   });
 
   testWidgets('데이터 삭제 실패 시 로컬 상태를 유지하고 오류를 안내한다', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2201,6 +2201,10 @@ void main() {
         summarySemantics.label,
         contains('개인정보 사용 안내, 현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다.'),
       );
+      expect(
+        summarySemantics.label,
+        contains('이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.'),
+      );
       expect(summarySemantics.label, isNot(contains('익명화')));
     } finally {
       semanticsHandle.dispose();
@@ -2501,20 +2505,20 @@ void main() {
     await tester.tap(find.byKey(const Key('dataDeletionAccessItem')));
     await tester.pumpAndSettle();
 
-    expect(find.text('내 데이터 삭제'), findsWidgets);
+    expect(find.text('서버 데이터 삭제'), findsWidgets);
     expect(
       find.text('즐겨찾기, 이동 조건, 신고 접수 기록, 신고 내용과 위치, 경로 피드백을 삭제하거나 익명화합니다.'),
       findsOneWidget,
     );
     expect(find.textContaining('이미 보낸 시설 제보'), findsNothing);
-    expect(find.text('삭제가 끝나면 이 기기와 서버에 연결된 데이터가 함께 정리됩니다.'), findsOneWidget);
+    expect(find.text('삭제가 끝나면 서버에 연결된 데이터가 정리됩니다.'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('dataDeletionStartButton')));
     await tester.pumpAndSettle();
 
     expect(find.byType(AlertDialog), findsOneWidget);
     expect(
-      find.text('삭제 후에는 앱에 저장된 데이터와 설정이 지워지고 되돌릴 수 없습니다.'),
+      find.text('삭제 후에는 서버에 연결된 데이터와 설정이 삭제되거나 익명화되고 되돌릴 수 없습니다.'),
       findsOneWidget,
     );
   });


### PR DESCRIPTION
## 관련 이슈

close #820

## 작업 배경

- 로그인 없는 기본 앱 흐름에서 데이터 삭제 화면이 `로그인 정보`, `인증 정보`, `익명화`, `연결 정보`처럼 실제 로컬 삭제 범위를 넘어서는 문구를 보여주고 있었다.
- QA 요청에 따라 삭제 진입, 확인, 완료, 개인정보 안내 문구를 Android 에뮬레이터 기준으로 확인하며 수정했다.

## 작업 내용

- 삭제 진입 제목과 Semantics를 `이 기기의 앱 데이터 삭제`로 바꾸고, 도움말 카드의 보조 문구를 로컬 삭제 범위 중심으로 정리했다.
- 삭제 화면과 확인 다이얼로그가 즐겨찾기, 최근 검색, 이동 조건, 화면 설정, 제보 접수 확인 정보, 작성 중인 제보만 삭제한다고 안내하도록 바꿨다.
- 이미 보낸 시설 제보, 사진, 위치 정보는 로컬 삭제로 지워지지 않는다는 안내를 개인정보 요약과 삭제 화면에 추가했다.
- 원격 삭제 저장소와 이 기기+서버 삭제 저장소는 신고 내용, 사진, 위치, 경로 피드백 삭제·익명화 범위를 유지하도록 분기했다.
- 원격 삭제 성공 뒤 앱 임시 설정 초기화와 처음 설정 화면 복귀가 일어나는 점을 원격 삭제 안내와 확인 문구에 명시했다.
- 앱 안 삭제 저장소가 없는 fallback은 `데이터 삭제 요청`으로 분리해 메일 문의 절차를 안내하도록 바꿨다.
- 삭제 완료 화면에서 `제보 연결 정보`, `경로 의견 연결 정보`, `익명화`, `local-user` 같은 내부 처리 표현이 로컬 삭제 결과에 보이지 않도록 결과 문구를 정리했다.
- 보안 문의 안내에서 로그인 없는 앱에 맞지 않는 `계정 접근 문제` 범위를 제거했다.
- widget test가 visible text와 Semantics에서 오해 가능한 문구가 사라졌는지 고정하도록 보강했다.

## 검증

- 실행한 명령과 결과:
- `cd apps/mobile && flutter test test/widget_test.dart --plain-name "도움말은 앱 안에서 데이터 삭제를 재확인하고 로컬 상태를 정리한다"`: 변경 전 RED, `이 기기의 앱 데이터 삭제` 문구를 찾지 못해 실패 확인
- `cd apps/mobile && flutter test test/widget_test.dart --plain-name "도움말은 앱 안에서 데이터 삭제를 재확인하고 로컬 상태를 정리한다"`: 변경 후 exit 0
- `cd apps/mobile && flutter test test/widget_test.dart --plain-name "도움말은 원격 삭제 저장소에서 서버 삭제 범위를 유지해 안내한다"`: exit 0
- `cd apps/mobile && flutter test test/widget_test.dart --plain-name "홈은 도움말에서 개인정보와 삭제 요청 경로를 보여준다"`: exit 0
- `cd apps/mobile && flutter test test/widget_test.dart --plain-name "도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다"`: exit 0
- `cd apps/mobile && flutter test test/widget_test.dart --plain-name "도움말은 보안 문의와 취약점 접수 경로를 안내한다"`: exit 0
- `cd apps/mobile && flutter test test/user_data_deletion_test.dart test/widget_test.dart`: exit 0, 142 tests passed
- `cd apps/mobile && flutter test test/widget_test.dart`: exit 0, 135 tests passed
- `cd apps/mobile && flutter analyze`: exit 0, No issues found
- `cd apps/mobile && flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
- `git diff --check`: exit 0
- `codex review --base origin/main --title "[Fix] 데이터 삭제와 개인정보 안내 범위 정정"`: 최종 head `6f0df036`, actionable 0건
- GitHub Actions `CI` run 28152605700: success
- GitHub Actions `Release Artifacts` run 28152605489: success

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 개인정보 안내와 삭제 진입 | Android emulator `maum_on_api36`, `emulator-5554` | 도움말 화면 진입 후 스크린샷과 UI tree 확인 | 로컬 증거: `.codex/evidence/820/android-support-privacy.png`, `.codex/evidence/820/android-support-privacy.xml` | `이 기기의 앱 데이터 삭제`와 서버로 이미 보낸 제보 미삭제 안내가 보이고, `로그인 정보`, `인증 정보`, `익명화`, `연결 정보`, `계정 접근`, `local-user` 노출 없음 |
| 삭제 화면 | Android emulator `maum_on_api36`, `emulator-5554` | 삭제 화면 스크린샷과 UI tree 확인 | 로컬 증거: `.codex/evidence/820/android-deletion-screen.png`, `.codex/evidence/820/android-deletion-screen.xml` | 로컬 삭제 대상과 이미 보낸 시설 제보/사진/위치 정보 제외 안내가 보이고 문구 겹침 없음 |
| 삭제 확인 다이얼로그 | Android emulator `maum_on_api36`, `emulator-5554` | 삭제 버튼 탭 후 스크린샷과 UI tree 확인 | 로컬 증거: `.codex/evidence/820/android-deletion-confirm-dialog.png`, `.codex/evidence/820/android-deletion-confirm-dialog.xml` | `이 기기에 저장된 앱 데이터와 설정` 삭제 경고만 표시되고 `인증 정보` 노출 없음 |
| 삭제 완료 화면 | Android emulator `maum_on_api36`, `emulator-5554` | 확인 버튼 탭 후 스크린샷과 UI tree 확인 | 로컬 증거: `.codex/evidence/820/android-deletion-result.png`, `.codex/evidence/820/android-deletion-result.xml` | `이 기기의 제보 기록 0건 삭제`로 표시되고 `제보 연결 정보`, `경로 의견 연결 정보`, `익명화`, `local-user` 노출 없음 |
| 앱 로그 | Android emulator `maum_on_api36`, `emulator-5554` | 삭제 플로우 확인 뒤 logcat tail 저장 | 로컬 증거: `.codex/evidence/820/android-logcat-tail.txt` | 삭제 플로우 확인 중 앱 크래시 로그 없음 |
| 저장소 없는 삭제 요청 fallback | Flutter widget test | 도움말 텍스트와 Semantics 검증 | `flutter test test/widget_test.dart --plain-name "도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다"`: exit 0 | 앱 안 삭제가 없는 구성은 `이 기기의 앱 데이터 삭제`가 아니라 `데이터 삭제 요청`과 메일 처리 절차를 안내함 |
| 원격 삭제 저장소 안내 | Flutter widget test | 서버 삭제 범위 텍스트와 Semantics 검증 | `flutter test test/widget_test.dart --plain-name "도움말은 원격 삭제 저장소에서 서버 삭제 범위를 유지해 안내한다"`: exit 0 | 신고 내용, 사진, 위치, 경로 피드백 삭제·익명화와 앱 임시 설정 초기화 안내를 함께 표시함 |
| iOS 대체 검증 | Flutter widget test | 공통 Flutter 위젯 텍스트와 Semantics 검증 | `flutter test test/user_data_deletion_test.dart test/widget_test.dart`: 142 tests passed | QA 요청이 Android 에뮬레이터 스크린샷 기준이라 iOS 시각 증거는 이번 PR에서 수집하지 않았다. 같은 Flutter UI 테스트로 문구와 Semantics 계약을 확인했으며, iOS 고유 시각 차이 리스크는 남는다. |

스크린샷과 UI tree는 저장소 정책상 git에 커밋하지 않았다. 외부 업로드 승인이 없어 PR에는 로컬 전용 경로와 확인 결과를 기록한다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: [apps/mobile/lib/main.dart]의 `SupportAccessScreen`, `UserDataDeletionScreen`, `UserDataDeletionResultScreen`, `_PrivacyDataUseSummary` 문구와 Semantics 변경
- 기본 앱 의존성은 인증 공급자가 없으면 `UserDataDeletionLocalRepository`를 사용하므로, 이번 PR은 기본 앱에서 실제 동작하는 로컬 삭제 범위와 화면 안내를 맞추는 변경이다.
- 테스트나 비정상 구성처럼 삭제 저장소가 없는 도움말 fallback은 앱 안 삭제로 오해되지 않도록 메일 요청 문구를 사용한다.

## 리스크

- 서버로 이미 보낸 제보 삭제 요청 경로는 아직 제공하지 않는다. 이번 PR은 해당 범위를 삭제된 것처럼 오해시키는 문구를 제거하는 데 한정했다.
- iOS 실기/시뮬레이터 화면 증거는 수집하지 않았다. 공통 Flutter widget test로 문구와 Semantics는 검증했지만, iOS 고유 레이아웃 차이는 별도 확인이 필요하다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. 배포 설정 변경은 없으며, merge 후 main CD 실패 여부를 별도 확인한다.
