### PR TITLE
[Fix] 시설 제보 번호와 용어 정리

### DIFF
--- a/apps/mobile/lib/core/database/user/user_database.dart
+++ b/apps/mobile/lib/core/database/user/user_database.dart
@@ -36,7 +36,7 @@ class UserDatabase extends _$UserDatabase {
   }
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
 
   @override
   MigrationStrategy get migration {
@@ -47,6 +47,11 @@ class UserDatabase extends _$UserDatabase {
       onUpgrade: (_, from, to) async {
         if (from < 1) {
           throw StateError('Unsupported user database schema version: $from');
+        }
+        if (from < 2) {
+          await customStatement(
+            'ALTER TABLE report_receipts ADD COLUMN public_receipt_code TEXT',
+          );
         }
       },
       beforeOpen: (_) async {

--- a/apps/mobile/lib/core/database/user/user_database.g.dart
+++ b/apps/mobile/lib/core/database/user/user_database.g.dart
@@ -2015,6 +2015,18 @@ class $ReportReceiptsTable extends ReportReceipts
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _publicReceiptCodeMeta = const VerificationMeta(
+    'publicReceiptCode',
+  );
+  @override
+  late final GeneratedColumn<String> publicReceiptCode =
+      GeneratedColumn<String>(
+        'public_receipt_code',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
   static const VerificationMeta _statusMeta = const VerificationMeta('status');
   @override
   late final GeneratedColumn<String> status = GeneratedColumn<String>(
@@ -2039,6 +2051,7 @@ class $ReportReceiptsTable extends ReportReceipts
   List<GeneratedColumn> get $columns => [
     receiptId,
     reportId,
+    publicReceiptCode,
     status,
     createdAt,
   ];
@@ -2066,6 +2079,15 @@ class $ReportReceiptsTable extends ReportReceipts
       context.handle(
         _reportIdMeta,
         reportId.isAcceptableOrUnknown(data['report_id']!, _reportIdMeta),
+      );
+    }
+    if (data.containsKey('public_receipt_code')) {
+      context.handle(
+        _publicReceiptCodeMeta,
+        publicReceiptCode.isAcceptableOrUnknown(
+          data['public_receipt_code']!,
+          _publicReceiptCodeMeta,
+        ),
       );
     }
     if (data.containsKey('status')) {
@@ -2101,6 +2123,10 @@ class $ReportReceiptsTable extends ReportReceipts
         DriftSqlType.string,
         data['${effectivePrefix}report_id'],
       ),
+      publicReceiptCode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}public_receipt_code'],
+      ),
       status: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}status'],
@@ -2121,11 +2147,13 @@ class $ReportReceiptsTable extends ReportReceipts
 class ReportReceipt extends DataClass implements Insertable<ReportReceipt> {
   final String receiptId;
   final String? reportId;
+  final String? publicReceiptCode;
   final String status;
   final DateTime createdAt;
   const ReportReceipt({
     required this.receiptId,
     this.reportId,
+    this.publicReceiptCode,
     required this.status,
     required this.createdAt,
   });
@@ -2135,6 +2163,9 @@ class ReportReceipt extends DataClass implements Insertable<ReportReceipt> {
     map['receipt_id'] = Variable<String>(receiptId);
     if (!nullToAbsent || reportId != null) {
       map['report_id'] = Variable<String>(reportId);
+    }
+    if (!nullToAbsent || publicReceiptCode != null) {
+      map['public_receipt_code'] = Variable<String>(publicReceiptCode);
     }
     map['status'] = Variable<String>(status);
     map['created_at'] = Variable<DateTime>(createdAt);
@@ -2147,6 +2178,9 @@ class ReportReceipt extends DataClass implements Insertable<ReportReceipt> {
       reportId: reportId == null && nullToAbsent
           ? const Value.absent()
           : Value(reportId),
+      publicReceiptCode: publicReceiptCode == null && nullToAbsent
+          ? const Value.absent()
+          : Value(publicReceiptCode),
       status: Value(status),
       createdAt: Value(createdAt),
     );
@@ -2160,6 +2194,9 @@ class ReportReceipt extends DataClass implements Insertable<ReportReceipt> {
     return ReportReceipt(
       receiptId: serializer.fromJson<String>(json['receiptId']),
       reportId: serializer.fromJson<String?>(json['reportId']),
+      publicReceiptCode: serializer.fromJson<String?>(
+        json['publicReceiptCode'],
+      ),
       status: serializer.fromJson<String>(json['status']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
     );
@@ -2170,6 +2207,7 @@ class ReportReceipt extends DataClass implements Insertable<ReportReceipt> {
     return <String, dynamic>{
       'receiptId': serializer.toJson<String>(receiptId),
       'reportId': serializer.toJson<String?>(reportId),
+      'publicReceiptCode': serializer.toJson<String?>(publicReceiptCode),
       'status': serializer.toJson<String>(status),
       'createdAt': serializer.toJson<DateTime>(createdAt),
     };
@@ -2178,11 +2216,15 @@ class ReportReceipt extends DataClass implements Insertable<ReportReceipt> {
   ReportReceipt copyWith({
     String? receiptId,
     Value<String?> reportId = const Value.absent(),
+    Value<String?> publicReceiptCode = const Value.absent(),
     String? status,
     DateTime? createdAt,
   }) => ReportReceipt(
     receiptId: receiptId ?? this.receiptId,
     reportId: reportId.present ? reportId.value : this.reportId,
+    publicReceiptCode: publicReceiptCode.present
+        ? publicReceiptCode.value
+        : this.publicReceiptCode,
     status: status ?? this.status,
     createdAt: createdAt ?? this.createdAt,
   );
@@ -2190,6 +2232,9 @@ class ReportReceipt extends DataClass implements Insertable<ReportReceipt> {
     return ReportReceipt(
       receiptId: data.receiptId.present ? data.receiptId.value : this.receiptId,
       reportId: data.reportId.present ? data.reportId.value : this.reportId,
+      publicReceiptCode: data.publicReceiptCode.present
+          ? data.publicReceiptCode.value
+          : this.publicReceiptCode,
       status: data.status.present ? data.status.value : this.status,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
     );
@@ -2200,6 +2245,7 @@ class ReportReceipt extends DataClass implements Insertable<ReportReceipt> {
     return (StringBuffer('ReportReceipt(')
           ..write('receiptId: $receiptId, ')
           ..write('reportId: $reportId, ')
+          ..write('publicReceiptCode: $publicReceiptCode, ')
           ..write('status: $status, ')
           ..write('createdAt: $createdAt')
           ..write(')'))
@@ -2207,13 +2253,15 @@ class ReportReceipt extends DataClass implements Insertable<ReportReceipt> {
   }
 
   @override
-  int get hashCode => Object.hash(receiptId, reportId, status, createdAt);
+  int get hashCode =>
+      Object.hash(receiptId, reportId, publicReceiptCode, status, createdAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is ReportReceipt &&
           other.receiptId == this.receiptId &&
           other.reportId == this.reportId &&
+          other.publicReceiptCode == this.publicReceiptCode &&
           other.status == this.status &&
           other.createdAt == this.createdAt);
 }
@@ -2221,12 +2269,14 @@ class ReportReceipt extends DataClass implements Insertable<ReportReceipt> {
 class ReportReceiptsCompanion extends UpdateCompanion<ReportReceipt> {
   final Value<String> receiptId;
   final Value<String?> reportId;
+  final Value<String?> publicReceiptCode;
   final Value<String> status;
   final Value<DateTime> createdAt;
   final Value<int> rowid;
   const ReportReceiptsCompanion({
     this.receiptId = const Value.absent(),
     this.reportId = const Value.absent(),
+    this.publicReceiptCode = const Value.absent(),
     this.status = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -2234,6 +2284,7 @@ class ReportReceiptsCompanion extends UpdateCompanion<ReportReceipt> {
   ReportReceiptsCompanion.insert({
     required String receiptId,
     this.reportId = const Value.absent(),
+    this.publicReceiptCode = const Value.absent(),
     required String status,
     required DateTime createdAt,
     this.rowid = const Value.absent(),
@@ -2243,6 +2294,7 @@ class ReportReceiptsCompanion extends UpdateCompanion<ReportReceipt> {
   static Insertable<ReportReceipt> custom({
     Expression<String>? receiptId,
     Expression<String>? reportId,
+    Expression<String>? publicReceiptCode,
     Expression<String>? status,
     Expression<DateTime>? createdAt,
     Expression<int>? rowid,
@@ -2250,6 +2302,7 @@ class ReportReceiptsCompanion extends UpdateCompanion<ReportReceipt> {
     return RawValuesInsertable({
       if (receiptId != null) 'receipt_id': receiptId,
       if (reportId != null) 'report_id': reportId,
+      if (publicReceiptCode != null) 'public_receipt_code': publicReceiptCode,
       if (status != null) 'status': status,
       if (createdAt != null) 'created_at': createdAt,
       if (rowid != null) 'rowid': rowid,
@@ -2259,6 +2312,7 @@ class ReportReceiptsCompanion extends UpdateCompanion<ReportReceipt> {
   ReportReceiptsCompanion copyWith({
     Value<String>? receiptId,
     Value<String?>? reportId,
+    Value<String?>? publicReceiptCode,
     Value<String>? status,
     Value<DateTime>? createdAt,
     Value<int>? rowid,
@@ -2266,6 +2320,7 @@ class ReportReceiptsCompanion extends UpdateCompanion<ReportReceipt> {
     return ReportReceiptsCompanion(
       receiptId: receiptId ?? this.receiptId,
       reportId: reportId ?? this.reportId,
+      publicReceiptCode: publicReceiptCode ?? this.publicReceiptCode,
       status: status ?? this.status,
       createdAt: createdAt ?? this.createdAt,
       rowid: rowid ?? this.rowid,
@@ -2280,6 +2335,9 @@ class ReportReceiptsCompanion extends UpdateCompanion<ReportReceipt> {
     }
     if (reportId.present) {
       map['report_id'] = Variable<String>(reportId.value);
+    }
+    if (publicReceiptCode.present) {
+      map['public_receipt_code'] = Variable<String>(publicReceiptCode.value);
     }
     if (status.present) {
       map['status'] = Variable<String>(status.value);
@@ -2298,6 +2356,7 @@ class ReportReceiptsCompanion extends UpdateCompanion<ReportReceipt> {
     return (StringBuffer('ReportReceiptsCompanion(')
           ..write('receiptId: $receiptId, ')
           ..write('reportId: $reportId, ')
+          ..write('publicReceiptCode: $publicReceiptCode, ')
           ..write('status: $status, ')
           ..write('createdAt: $createdAt, ')
           ..write('rowid: $rowid')
@@ -3955,6 +4014,7 @@ typedef $$ReportReceiptsTableCreateCompanionBuilder =
     ReportReceiptsCompanion Function({
       required String receiptId,
       Value<String?> reportId,
+      Value<String?> publicReceiptCode,
       required String status,
       required DateTime createdAt,
       Value<int> rowid,
@@ -3963,6 +4023,7 @@ typedef $$ReportReceiptsTableUpdateCompanionBuilder =
     ReportReceiptsCompanion Function({
       Value<String> receiptId,
       Value<String?> reportId,
+      Value<String?> publicReceiptCode,
       Value<String> status,
       Value<DateTime> createdAt,
       Value<int> rowid,
@@ -3984,6 +4045,11 @@ class $$ReportReceiptsTableFilterComposer
 
   ColumnFilters<String> get reportId => $composableBuilder(
     column: $table.reportId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get publicReceiptCode => $composableBuilder(
+    column: $table.publicReceiptCode,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -4017,6 +4083,11 @@ class $$ReportReceiptsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get publicReceiptCode => $composableBuilder(
+    column: $table.publicReceiptCode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get status => $composableBuilder(
     column: $table.status,
     builder: (column) => ColumnOrderings(column),
@@ -4042,6 +4113,11 @@ class $$ReportReceiptsTableAnnotationComposer
 
   GeneratedColumn<String> get reportId =>
       $composableBuilder(column: $table.reportId, builder: (column) => column);
+
+  GeneratedColumn<String> get publicReceiptCode => $composableBuilder(
+    column: $table.publicReceiptCode,
+    builder: (column) => column,
+  );
 
   GeneratedColumn<String> get status =>
       $composableBuilder(column: $table.status, builder: (column) => column);
@@ -4085,12 +4161,14 @@ class $$ReportReceiptsTableTableManager
               ({
                 Value<String> receiptId = const Value.absent(),
                 Value<String?> reportId = const Value.absent(),
+                Value<String?> publicReceiptCode = const Value.absent(),
                 Value<String> status = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ReportReceiptsCompanion(
                 receiptId: receiptId,
                 reportId: reportId,
+                publicReceiptCode: publicReceiptCode,
                 status: status,
                 createdAt: createdAt,
                 rowid: rowid,
@@ -4099,12 +4177,14 @@ class $$ReportReceiptsTableTableManager
               ({
                 required String receiptId,
                 Value<String?> reportId = const Value.absent(),
+                Value<String?> publicReceiptCode = const Value.absent(),
                 required String status,
                 required DateTime createdAt,
                 Value<int> rowid = const Value.absent(),
               }) => ReportReceiptsCompanion.insert(
                 receiptId: receiptId,
                 reportId: reportId,
+                publicReceiptCode: publicReceiptCode,
                 status: status,
                 createdAt: createdAt,
                 rowid: rowid,

--- a/apps/mobile/lib/core/database/user/user_tables.dart
+++ b/apps/mobile/lib/core/database/user/user_tables.dart
@@ -90,6 +90,8 @@ class ReportReceipts extends Table {
 
   TextColumn get receiptId => text().named('receipt_id')();
   TextColumn get reportId => text().named('report_id').nullable()();
+  TextColumn get publicReceiptCode =>
+      text().named('public_receipt_code').nullable()();
   TextColumn get status => text()();
   DateTimeColumn get createdAt => dateTime().named('created_at')();
 

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -314,7 +314,9 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       return Future.wait(
         receipts.map((receipt) async {
           try {
-            return await getReport(receipt.reportId);
+            final report = await getReport(receipt.reportId);
+            await _refreshReceiptIfPossible(receipt, report);
+            return report;
           } catch (error, stackTrace) {
             reportMobileError(
               error,
@@ -334,6 +336,33 @@ class FacilityReportApiRepository implements FacilityReportRepository {
         context: '내 시설 제보 목록 응답 처리 중 예외가 발생했습니다.',
       );
       throw const FacilityReportException(_facilityReportListErrorMessage);
+    }
+  }
+
+  Future<void> _refreshReceiptIfPossible(
+    FacilityReportReceipt receipt,
+    FacilityReportResult report,
+  ) async {
+    try {
+      await receiptStore
+          ?.saveReceipt(
+            FacilityReportReceipt(
+              receiptId: receipt.receiptId,
+              reportId: receipt.reportId,
+              publicReceiptCode:
+                  report.publicReceiptCode ?? receipt.publicReceiptCode,
+              status: report.status,
+              receiptToken: receipt.receiptToken,
+              createdAt: receipt.createdAt,
+            ),
+          )
+          .timeout(_facilityReportTimeout);
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '시설 제보 receipt 상태 갱신 중 예외가 발생했습니다.',
+      );
     }
   }
 
@@ -842,7 +871,7 @@ class FacilityReportResult {
   String get displayReceiptCode {
     final code = publicReceiptCode?.trim();
     if (code == null || code.isEmpty) {
-      return '제보 번호 준비 중';
+      return '준비 중';
     }
     return code;
   }

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -315,8 +315,12 @@ class FacilityReportApiRepository implements FacilityReportRepository {
         receipts.map((receipt) async {
           try {
             final report = await getReport(receipt.reportId);
-            await _refreshReceiptIfPossible(receipt, report);
-            return report;
+            final reportWithReceiptCode = _reportWithReceiptCodeFallback(
+              report,
+              receipt,
+            );
+            await _refreshReceiptIfPossible(receipt, reportWithReceiptCode);
+            return reportWithReceiptCode;
           } catch (error, stackTrace) {
             reportMobileError(
               error,
@@ -350,7 +354,8 @@ class FacilityReportApiRepository implements FacilityReportRepository {
               receiptId: receipt.receiptId,
               reportId: receipt.reportId,
               publicReceiptCode:
-                  report.publicReceiptCode ?? receipt.publicReceiptCode,
+                  _nonBlankReportString(report.publicReceiptCode) ??
+                  _nonBlankReportString(receipt.publicReceiptCode),
               status: report.status,
               receiptToken: receipt.receiptToken,
               createdAt: receipt.createdAt,
@@ -364,6 +369,30 @@ class FacilityReportApiRepository implements FacilityReportRepository {
         context: '시설 제보 receipt 상태 갱신 중 예외가 발생했습니다.',
       );
     }
+  }
+
+  FacilityReportResult _reportWithReceiptCodeFallback(
+    FacilityReportResult report,
+    FacilityReportReceipt receipt,
+  ) {
+    final publicReceiptCode =
+        _nonBlankReportString(report.publicReceiptCode) ??
+        _nonBlankReportString(receipt.publicReceiptCode);
+    if (publicReceiptCode == null ||
+        publicReceiptCode == report.publicReceiptCode) {
+      return report;
+    }
+    return FacilityReportResult(
+      id: report.id,
+      stationId: report.stationId,
+      facilityId: report.facilityId,
+      reportType: report.reportType,
+      description: report.description,
+      status: report.status,
+      createdAt: report.createdAt,
+      receiptToken: report.receiptToken,
+      publicReceiptCode: publicReceiptCode,
+    );
   }
 
   FacilityReportResult _reportResultFromJson(
@@ -2556,6 +2585,14 @@ String _optionalReportString(Map<String, Object?> json, String key) {
     return value;
   }
   return '';
+}
+
+String? _nonBlankReportString(String? value) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) {
+    return null;
+  }
+  return trimmed;
 }
 
 String _reportDateLabel(String createdAt) {

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -15,24 +15,23 @@ import 'mobile_error_reporter.dart';
 import 'secure_key_value_storage.dart';
 
 const _facilityReportTimeout = Duration(seconds: 8);
-const _facilityReportErrorMessage = '신고를 보내지 못했습니다.';
+const _facilityReportErrorMessage = '제보를 보내지 못했습니다.';
 const _facilityReportStatusErrorMessage = '처리 상태를 확인하지 못했습니다.';
-const _facilityReportListErrorMessage = '신고 내역을 불러오지 못했습니다.';
+const _facilityReportListErrorMessage = '제보 내역을 불러오지 못했습니다.';
 const _facilityReportFailureNextAction = '내용을 확인한 뒤 네트워크 상태를 보고 다시 보내 주세요.';
 const _facilityReportPhotoTooLargeMessage = '사진이 너무 큽니다. 다른 사진을 선택해 주세요.';
 const _facilityReportPhotoUploadMaxAttempts = 2;
 const _facilityReportLocationDisabledMessage =
-    '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
+    '휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
 const _facilityReportLocationRationaleTitle = '현재 위치 사용';
 const _facilityReportLocationRationalePurpose =
-    '가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다.';
+    '가까운 역 찾기와 시설 제보 위치 확인에만 현재 위치를 사용합니다.';
 const _facilityReportLocationRationaleFallback =
     '위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다.';
 const _facilityReportUploadDisclosureTitle = '사진·위치 확인';
-const _facilityReportUploadDisclosurePurpose =
-    '사진과 신고 위치는 시설 신고 확인과 운영 검수에만 사용됩니다.';
+const _facilityReportUploadDisclosurePurpose = '사진과 제보 위치는 시설 제보 확인에만 사용됩니다.';
 const _facilityReportUploadDisclosureScope =
-    '신고 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다.';
+    '제보 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다.';
 const _facilityReportDraftTargetStorageKey =
     'easysubway.facilityReport.draftTarget';
 
@@ -92,7 +91,7 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       reportMobileError(
         error,
         stackTrace,
-        context: '시설 신고 접수 응답 처리 중 예외가 발생했습니다.',
+        context: '시설 제보 접수 응답 처리 중 예외가 발생했습니다.',
       );
       throw const FacilityReportException(_facilityReportErrorMessage);
     }
@@ -236,7 +235,7 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       reportMobileError(
         error,
         stackTrace,
-        context: '시설 신고 receipt token 저장 중 예외가 발생했습니다.',
+        context: '시설 제보 receipt token 저장 중 예외가 발생했습니다.',
       );
     }
   }
@@ -250,6 +249,7 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       FacilityReportReceipt(
         receiptId: result.id,
         reportId: result.id,
+        publicReceiptCode: result.publicReceiptCode,
         status: result.status,
         receiptToken: receiptToken,
         createdAt: DateTime.now(),
@@ -295,7 +295,7 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       reportMobileError(
         error,
         stackTrace,
-        context: '시설 신고 처리 상태 응답 처리 중 예외가 발생했습니다.',
+        context: '시설 제보 처리 상태 응답 처리 중 예외가 발생했습니다.',
       );
       throw const FacilityReportException(_facilityReportStatusErrorMessage);
     }
@@ -319,7 +319,7 @@ class FacilityReportApiRepository implements FacilityReportRepository {
             reportMobileError(
               error,
               stackTrace,
-              context: '시설 신고 receipt 기반 상태 조회 중 예외가 발생했습니다.',
+              context: '시설 제보 receipt 기반 상태 조회 중 예외가 발생했습니다.',
             );
             return _reportResultFromReceipt(receipt);
           }
@@ -331,7 +331,7 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       reportMobileError(
         error,
         stackTrace,
-        context: '내 시설 신고 목록 응답 처리 중 예외가 발생했습니다.',
+        context: '내 시설 제보 목록 응답 처리 중 예외가 발생했습니다.',
       );
       throw const FacilityReportException(_facilityReportListErrorMessage);
     }
@@ -363,6 +363,7 @@ class FacilityReportApiRepository implements FacilityReportRepository {
       status: receipt.status,
       createdAt: receipt.createdAt.toIso8601String(),
       receiptToken: receipt.receiptToken,
+      publicReceiptCode: receipt.publicReceiptCode,
     );
   }
 }
@@ -576,10 +577,12 @@ class FacilityReportReceipt {
     required this.status,
     required this.receiptToken,
     required this.createdAt,
+    this.publicReceiptCode,
   });
 
   final String receiptId;
   final String reportId;
+  final String? publicReceiptCode;
   final String status;
   final String receiptToken;
   final DateTime createdAt;
@@ -612,6 +615,7 @@ class DriftFacilityReportReceiptStore implements FacilityReportReceiptStore {
           user_db.ReportReceiptsCompanion.insert(
             receiptId: receipt.receiptId,
             reportId: Value(receipt.reportId),
+            publicReceiptCode: Value(receipt.publicReceiptCode),
             status: receipt.status,
             createdAt: receipt.createdAt,
           ),
@@ -662,6 +666,7 @@ class DriftFacilityReportReceiptStore implements FacilityReportReceiptStore {
         FacilityReportReceipt(
           receiptId: receipt.receiptId,
           reportId: reportId,
+          publicReceiptCode: receipt.publicReceiptCode,
           status: receipt.status,
           receiptToken: receiptToken,
           createdAt: receipt.createdAt,
@@ -807,6 +812,7 @@ class FacilityReportResult {
     required this.status,
     required this.createdAt,
     this.receiptToken,
+    this.publicReceiptCode,
   });
 
   factory FacilityReportResult.fromJson(Map<String, Object?> json) {
@@ -819,6 +825,7 @@ class FacilityReportResult {
       status: _requiredReportString(json, 'status'),
       createdAt: _requiredReportString(json, 'createdAt'),
       receiptToken: _optionalReportString(json, 'receiptToken'),
+      publicReceiptCode: _optionalReportString(json, 'publicReceiptCode'),
     );
   }
 
@@ -830,6 +837,15 @@ class FacilityReportResult {
   final String status;
   final String createdAt;
   final String? receiptToken;
+  final String? publicReceiptCode;
+
+  String get displayReceiptCode {
+    final code = publicReceiptCode?.trim();
+    if (code == null || code.isEmpty) {
+      return '제보 번호 준비 중';
+    }
+    return code;
+  }
 
   String get statusLabel {
     return switch (status) {
@@ -837,7 +853,7 @@ class FacilityReportResult {
       'UNDER_REVIEW' => '확인 중',
       'ACCEPTED' => '반영됨',
       'REJECTED' => '반려됨',
-      'DUPLICATE' => '중복 신고',
+      'DUPLICATE' => '중복 제보',
       'RESOLVED' => '처리 완료',
       _ => '접수 상태 확인 필요',
     };
@@ -851,7 +867,7 @@ class FacilityReportResult {
       'LOCATION_WRONG' => '위치가 달라요',
       'INFORMATION_WRONG' => '정보가 달라요',
       'RECOVERED' => '다시 정상',
-      _ => '시설 신고',
+      _ => '시설 제보',
     };
   }
 }
@@ -936,7 +952,7 @@ class SecureFacilityReportDraftTargetStore
       reportMobileError(
         error,
         stackTrace,
-        context: '저장된 시설 신고 대상을 읽는 중 예외가 발생했습니다.',
+        context: '저장된 시설 제보 대상을 읽는 중 예외가 발생했습니다.',
       );
       await _clearTargetAfterReadFailure();
       return null;
@@ -963,7 +979,7 @@ class SecureFacilityReportDraftTargetStore
       reportMobileError(
         error,
         stackTrace,
-        context: '손상된 시설 신고 대상을 지우는 중 예외가 발생했습니다.',
+        context: '손상된 시설 제보 대상을 지우는 중 예외가 발생했습니다.',
       );
     }
   }
@@ -1057,7 +1073,7 @@ class FacilityReportController extends ChangeNotifier {
     _emitState(
       const FacilityReportState(
         status: FacilityReportViewStatus.loading,
-        message: '신고 보내는 중',
+        message: '제보 보내는 중',
       ),
     );
 
@@ -1078,7 +1094,7 @@ class FacilityReportController extends ChangeNotifier {
       _emitState(
         FacilityReportState(
           status: FacilityReportViewStatus.success,
-          message: '신고가 접수되었습니다.',
+          message: '제보를 보냈어요.',
           result: result,
         ),
       );
@@ -1093,7 +1109,7 @@ class FacilityReportController extends ChangeNotifier {
       reportMobileError(
         error,
         stackTrace,
-        context: '시설 신고 화면 제출 처리 중 예외가 발생했습니다.',
+        context: '시설 제보 화면 제출 처리 중 예외가 발생했습니다.',
       );
       _emitState(
         const FacilityReportState(
@@ -1130,7 +1146,7 @@ class FacilityReportController extends ChangeNotifier {
         ),
       );
     } on FacilityReportException catch (error) {
-      // 상태 확인이 실패해도 사용자가 접수번호를 잃지 않도록 직전 결과는 유지한다.
+      // 상태 확인이 실패해도 사용자가 제보 번호를 잃지 않도록 직전 결과는 유지한다.
       _emitState(
         FacilityReportState(
           status: FacilityReportViewStatus.failure,
@@ -1142,7 +1158,7 @@ class FacilityReportController extends ChangeNotifier {
       reportMobileError(
         error,
         stackTrace,
-        context: '시설 신고 처리 상태 새로고침 중 예외가 발생했습니다.',
+        context: '시설 제보 처리 상태 새로고침 중 예외가 발생했습니다.',
       );
       // 알 수 없는 오류도 같은 화면에서 다시 확인할 수 있게 접수 결과를 보존한다.
       _emitState(
@@ -1222,7 +1238,7 @@ class _MyFacilityReportListScreenState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('내 신고')),
+      appBar: AppBar(title: const Text('내 제보')),
       body: SafeArea(
         child: FutureBuilder<List<FacilityReportResult>>(
           future: _reportsFuture,
@@ -1266,7 +1282,7 @@ class _MyReportLoading extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Semantics(
-      label: '신고 내역 불러오는 중',
+      label: '제보 내역 불러오는 중',
       liveRegion: true,
       child: const Center(child: CircularProgressIndicator()),
     );
@@ -1282,7 +1298,7 @@ class _MyReportEmpty extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(24),
         child: Text(
-          '접수한 신고가 없습니다.',
+          '접수한 제보가 없습니다.',
           textAlign: TextAlign.center,
           style: Theme.of(context).textTheme.titleLarge?.copyWith(
             color: const Color(0xFF102A2C),
@@ -1353,7 +1369,7 @@ class _MyReportListItem extends StatelessWidget {
 
     return Semantics(
       label:
-          '내 신고, ${report.reportTypeLabel}, 접수번호 ${report.id}, ${report.statusLabel}, $description, 접수일 $createdAtLabel',
+          '내 제보, ${report.reportTypeLabel}, 제보 번호 ${report.displayReceiptCode}, ${report.statusLabel}, $description, 접수일 $createdAtLabel',
       button: true,
       onTap: openReportDetail,
       child: ExcludeSemantics(
@@ -1403,7 +1419,10 @@ class _MyReportListItem extends StatelessWidget {
                     spacing: 12,
                     runSpacing: 6,
                     children: [
-                      _MyReportMetaText(label: '접수번호', value: report.id),
+                      _MyReportMetaText(
+                        label: '제보 번호',
+                        value: report.displayReceiptCode,
+                      ),
                       _MyReportMetaText(label: '접수일', value: createdAtLabel),
                     ],
                   ),
@@ -1430,11 +1449,11 @@ class MyFacilityReportDetailScreen extends StatelessWidget {
     final createdAtLabel = _reportDateLabel(report.createdAt);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('신고 상세')),
+      appBar: AppBar(title: const Text('제보 상세')),
       body: SafeArea(
         child: Semantics(
           label:
-              '내 신고 상세, ${report.reportTypeLabel}, 현재 상태 ${report.statusLabel}, 접수번호 ${report.id}',
+              '내 제보 상세, ${report.reportTypeLabel}, 현재 상태 ${report.statusLabel}, 제보 번호 ${report.displayReceiptCode}',
           child: ListView(
             padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
             children: [
@@ -1449,11 +1468,14 @@ class MyFacilityReportDetailScreen extends StatelessWidget {
               const SizedBox(height: 12),
               _MyReportDetailStatus(label: report.statusLabel),
               const SizedBox(height: 24),
-              _MyReportDetailRow(label: '접수번호', value: report.id),
+              _MyReportDetailRow(
+                label: '제보 번호',
+                value: report.displayReceiptCode,
+              ),
               const Divider(height: 32),
               _MyReportDetailRow(label: '접수일', value: createdAtLabel),
               const Divider(height: 32),
-              _MyReportDetailRow(label: '신고 내용', value: description),
+              _MyReportDetailRow(label: '제보 내용', value: description),
             ],
           ),
         ),
@@ -1630,7 +1652,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
         (widget.locationLoader != null && _attachedLocation == null);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('시설 신고')),
+      appBar: AppBar(title: const Text('시설 상태 제보')),
       body: SafeArea(
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
@@ -1773,7 +1795,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
                       child: CircularProgressIndicator(strokeWidth: 2.5),
                     )
                   : const Icon(Icons.send),
-              label: Text(hasSubmittedReport ? '접수 완료' : '신고 보내기'),
+              label: Text(hasSubmittedReport ? '제보 완료' : '제보 보내기'),
             ),
           ],
         ),
@@ -1848,7 +1870,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('사진은 신고 확인에만 사용됩니다.'),
+            Text('사진은 제보 내용을 확인하는 데만 사용해요.'),
             SizedBox(height: 8),
             Text('얼굴이나 전화번호가 보이면 가려 주세요.'),
           ],
@@ -1877,7 +1899,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       if (mounted) {
         setState(() {
           _attachedLocation = null;
-          _locationMessage = '위치 안내를 확인한 뒤 신고 위치를 첨부해 주세요.';
+          _locationMessage = '위치 안내를 확인한 뒤 제보 위치를 첨부해 주세요.';
           _isLocationFailure = true;
         });
       }
@@ -1898,7 +1920,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       reportMobileError(
         error,
         stackTrace,
-        context: '시설 신고 위치 권한 사전 확인 중 예외가 발생했습니다.',
+        context: '시설 제보 위치 권한 사전 확인 중 예외가 발생했습니다.',
       );
     }
     if (!needsPermissionRequest) {
@@ -1993,7 +2015,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       reportMobileError(
         error,
         stackTrace,
-        context: '시설 신고 사진 첨부 중 예외가 발생했습니다.',
+        context: '시설 제보 사진 첨부 중 예외가 발생했습니다.',
       );
       if (mounted) {
         setState(() {
@@ -2039,7 +2061,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       reportMobileError(
         error,
         stackTrace,
-        context: '시설 신고 사진 선택 복구 중 예외가 발생했습니다.',
+        context: '시설 제보 사진 선택 복구 중 예외가 발생했습니다.',
       );
       if (mounted) {
         setState(() {
@@ -2057,7 +2079,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       reportMobileError(
         error,
         stackTrace,
-        context: '시설 신고 사진 선택 대상 저장 중 예외가 발생했습니다.',
+        context: '시설 제보 사진 선택 대상 저장 중 예외가 발생했습니다.',
       );
     }
   }
@@ -2069,7 +2091,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       reportMobileError(
         error,
         stackTrace,
-        context: '시설 신고 사진 선택 대상 정리 중 예외가 발생했습니다.',
+        context: '시설 제보 사진 선택 대상 정리 중 예외가 발생했습니다.',
       );
     }
   }
@@ -2136,7 +2158,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       reportMobileError(
         error,
         stackTrace,
-        context: '시설 신고 현재 위치 확인 중 예외가 발생했습니다.',
+        context: '시설 제보 현재 위치 확인 중 예외가 발생했습니다.',
       );
       if (!mounted) {
         return;
@@ -2179,14 +2201,18 @@ class _FacilityReportStatusPanel extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Semantics(
-              // 접수번호와 상태를 한 문장으로 묶어 스크린리더가 상태 변화를 읽게 한다.
-              label: '신고 접수번호 ${result.id}, 현재 상태 ${result.statusLabel}',
+              // 제보 번호와 상태를 한 문장으로 묶어 스크린리더가 상태 변화를 읽게 한다.
+              label:
+                  '제보 번호 ${result.displayReceiptCode}, 현재 상태 ${result.statusLabel}',
               liveRegion: true,
               child: ExcludeSemantics(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    _FacilityReportStatusRow(label: '접수번호', value: result.id),
+                    _FacilityReportStatusRow(
+                      label: '제보 번호',
+                      value: result.displayReceiptCode,
+                    ),
                     const SizedBox(height: 10),
                     _FacilityReportStatusRow(
                       label: '처리 상태',

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1754,8 +1754,9 @@ class _NotificationInboxItem {
     return _NotificationInboxItem(
       icon: Icons.report_outlined,
       title: '제보 ${report.statusLabel}',
-      subtitle: '접수번호 ${report.id}',
-      semanticLabel: '제보 ${report.statusLabel}, 접수번호 ${report.id}',
+      subtitle: '제보 번호 ${report.displayReceiptCode}',
+      semanticLabel:
+          '제보 ${report.statusLabel}, 제보 번호 ${report.displayReceiptCode}',
       kind: '제보',
       report: report,
     );
@@ -2976,14 +2977,14 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
                     const _AppSettingsInfoTile(
                       icon: Icons.notifications_off_outlined,
                       title: '알림은 아직 사용할 수 없어요',
-                      subtitle: '시설 상태와 신고 처리 안내는 앱 안에서 확인할 수 있어요',
+                      subtitle: '시설 상태와 제보 처리 안내는 앱 안에서 확인할 수 있어요',
                     )
                   else
                     _AppSettingsActionTile(
                       key: const Key('notificationSettingsButton'),
                       icon: Icons.notifications_active_outlined,
                       title: '알림 설정',
-                      subtitle: '시설 상태, 신고 처리, 정보 갱신 알림을 관리해요',
+                      subtitle: '시설 상태, 제보 처리, 정보 갱신 알림을 관리해요',
                       onTap: () {
                         Navigator.of(context).push(
                           MaterialPageRoute<void>(
@@ -3005,8 +3006,8 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
                   _AppSettingsActionTile(
                     key: const Key('myReportsSettingsButton'),
                     icon: Icons.receipt_long_outlined,
-                    title: '내 신고',
-                    subtitle: '접수한 시설 신고와 처리 상태를 확인해요',
+                    title: '내 제보',
+                    subtitle: '접수한 시설 제보와 처리 상태를 확인해요',
                     onTap: widget.onOpenMyReports,
                   ),
                 ],
@@ -4537,7 +4538,7 @@ class _PrivacyDataUseSummary extends StatelessWidget {
   final UserDataDeletionScope deletionScope;
 
   static const _title = '개인정보 사용 안내';
-  static const _locationPurpose = '현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다.';
+  static const _locationPurpose = '현재 위치는 가까운 역 찾기와 시설 제보 위치 확인에만 사용됩니다.';
   static const _appDataPurpose = '즐겨찾기, 이동 조건, 신고 내용과 사진은 앱 기능 제공에 사용됩니다.';
   static const _requestDeletionScope =
       '데이터 삭제 요청은 지원 메일로 삭제 범위와 처리 절차를 문의할 수 있습니다.';

--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -684,7 +684,7 @@ class _NotificationSettingsScreenState
       builder: (context) => AlertDialog(
         title: const Text('알림 받기'),
         content: const Text(
-          '즐겨찾는 역과 경로의 시설 상태, 내 신고 처리 결과, 정보 갱신을 알려드립니다. 알림 설정에서 언제든 끌 수 있습니다.',
+          '즐겨찾는 역과 경로의 시설 상태, 내 제보 처리 결과, 정보 갱신을 알려드립니다. 알림 설정에서 언제든 끌 수 있습니다.',
         ),
         actions: [
           TextButton(
@@ -830,7 +830,7 @@ class _NotificationSettingsContent extends StatelessWidget {
         ),
         _NotificationSwitchTile(
           key: const Key('notificationSwitch-reportStatusAlerts'),
-          title: '신고 처리 알림',
+          title: '제보 처리 알림',
           value: settings.reportStatusAlerts,
           enabled: !isSaving,
           onChanged: onReportStatusAlertsChanged,

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -18,7 +18,8 @@ import 'mobile_error_reporter.dart';
 
 export 'features/stations/domain/station_line.dart';
 
-const _currentLocationDisabledMessage = '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
+const _currentLocationDisabledMessage =
+    '휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.';
 const _nearbyLocationMaxAge = Duration(minutes: 5);
 const _nearbyLocationMaxAccuracyMeters = 500.0;
 const _locationQualityUnavailableMessage =
@@ -31,7 +32,7 @@ const _locationQualityMockedMessage =
     '모의 위치는 가까운 역 찾기에 사용할 수 없어요. 출발역을 직접 선택해 주세요.';
 const _locationPermissionRationaleTitle = '현재 위치 사용';
 const _locationPermissionRationalePurpose =
-    '가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다.';
+    '가까운 역 찾기와 시설 제보 위치 확인에만 현재 위치를 사용합니다.';
 const _locationPermissionRationaleFallback =
     '위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다.';
 const _stationSearchFailureNextAction = '역명으로 검색하면 위치 권한 없이도 계속 이용할 수 있습니다.';

--- a/apps/mobile/test/current_location_provider_test.dart
+++ b/apps/mobile/test/current_location_provider_test.dart
@@ -99,7 +99,7 @@ void main() {
         isA<CurrentLocationException>().having(
           (error) => error.message,
           'message',
-          '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
+          '휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
         ),
       ),
     );

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -923,6 +923,49 @@ void main() {
     });
   });
 
+  test('내 신고 API 저장소는 빈 공개 번호 응답에서 로컬 제보 번호를 유지한다', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({
+            'success': true,
+            'data': {
+              'id': 'report-1',
+              'stationId': 'station-sangnoksu',
+              'facilityId': 'facility-sangnoksu-elevator-1',
+              'reportType': 'BROKEN',
+              'description': '버튼이 눌리지 않습니다.',
+              'status': 'ACCEPTED',
+              'createdAt': '2026-06-14T09:00:00',
+              'publicReceiptCode': ' ',
+            },
+          }),
+        )
+        ..close();
+    });
+
+    final receiptStore = FakeFacilityReportReceiptStore({
+      'report-1': 'receipt-token-1',
+    });
+    receiptStore.savedPublicReceiptCodes['report-1'] = 'ES-CACHED1';
+    final repository = FacilityReportApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+      receiptStore: receiptStore,
+    );
+
+    final reports = await repository.listMyReports();
+
+    expect(reports.single.publicReceiptCode, 'ES-CACHED1');
+    expect(reports.single.displayReceiptCode, 'ES-CACHED1');
+    expect(receiptStore.savedPublicReceiptCodes['report-1'], 'ES-CACHED1');
+    expect(receiptStore.savedStatuses['report-1'], 'ACCEPTED');
+  });
+
   test('내 신고 API 저장소는 receipt가 없으면 목록 조회 네트워크를 호출하지 않는다', () async {
     var requestCount = 0;
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -174,6 +174,7 @@ void main() {
                   'description': '문이 열리지 않습니다.',
                   'status': 'SUBMITTED',
                   'createdAt': '2026-06-13T10:00:00',
+                  'publicReceiptCode': 'ES-1001',
                   'receiptToken': 'receipt-token-1',
                 },
               }),
@@ -245,6 +246,8 @@ void main() {
     expect(requestBody['longitude'], 126.866221);
     expect(authorizationHeader, isNotNull);
     expect(result.id, 'report-1');
+    expect(result.publicReceiptCode, 'ES-1001');
+    expect(result.displayReceiptCode, 'ES-1001');
     expect(result.receiptToken, 'receipt-token-1');
     expect(result.statusLabel, '접수됨');
   });
@@ -470,6 +473,7 @@ void main() {
               'description': '문이 열리지 않습니다.',
               'status': 'SUBMITTED',
               'createdAt': '2026-06-13T10:00:00',
+              'publicReceiptCode': 'ES-1001',
               'receiptToken': 'receipt-token-1',
             },
           }),
@@ -520,6 +524,7 @@ void main() {
               'description': '문이 열리지 않습니다.',
               'status': 'SUBMITTED',
               'createdAt': '2026-06-13T10:00:00',
+              'publicReceiptCode': 'ES-1001',
               'receiptToken': 'receipt-token-1',
             },
           }),
@@ -546,6 +551,8 @@ void main() {
     expect(requestBody['clientSubmissionId'], isNot(isEmpty));
     expect(requestBody, isNot(contains('photoObjectKey')));
     expect(result.receiptToken, 'receipt-token-1');
+    expect(result.publicReceiptCode, 'ES-1001');
+    expect(receiptStore.savedPublicReceiptCodes['report-1'], 'ES-1001');
     expect(
       await receiptStore.receiptTokenForReport('report-1'),
       'receipt-token-1',
@@ -724,7 +731,7 @@ void main() {
           isA<FacilityReportException>().having(
             (error) => error.message,
             'message',
-            '신고를 보내지 못했습니다.',
+            '제보를 보내지 못했습니다.',
           ),
         ),
       );
@@ -764,7 +771,7 @@ void main() {
           isA<FacilityReportException>().having(
             (error) => error.message,
             'message',
-            '신고를 보내지 못했습니다.',
+            '제보를 보내지 못했습니다.',
           ),
         ),
       );
@@ -806,6 +813,7 @@ void main() {
               'description': '문이 열리지 않습니다.',
               'status': 'ACCEPTED',
               'createdAt': '2026-06-13T10:00:00',
+              'publicReceiptCode': 'ES-1001',
             },
           }),
         )
@@ -861,6 +869,9 @@ void main() {
               'createdAt': reportId == 'report-2'
                   ? '2026-06-15T09:00:00'
                   : '2026-06-14T09:00:00',
+              'publicReceiptCode': reportId == 'report-2'
+                  ? 'ES-1002'
+                  : 'ES-1001',
             },
           }),
         )
@@ -884,6 +895,7 @@ void main() {
     expect(receiptTokens, ['receipt-token-2', 'receipt-token-1']);
     expect(reports, hasLength(2));
     expect(reports.first.id, 'report-2');
+    expect(reports.first.publicReceiptCode, 'ES-1002');
     expect(reports.first.statusLabel, '반영됨');
     expect(reports.last.statusLabel, '접수됨');
   });
@@ -965,7 +977,7 @@ void main() {
 
     expect(repository.requests, hasLength(1));
     expect(controller.state.status, FacilityReportViewStatus.success);
-    expect(controller.state.message, '신고가 접수되었습니다.');
+    expect(controller.state.message, '제보를 보냈어요.');
   });
 
   test('시설 신고 컨트롤러는 접수 후 처리 상태를 다시 확인한다', () async {
@@ -1065,6 +1077,7 @@ class PendingFacilityReportRepository implements FacilityReportRepository {
     _completer.complete(
       const FacilityReportResult(
         id: 'report-1',
+        publicReceiptCode: 'ES-1001',
         stationId: 'station-sangnoksu',
         facilityId: 'facility-sangnoksu-elevator-1',
         reportType: 'BROKEN',
@@ -1087,6 +1100,7 @@ class RefreshableFacilityReportRepository implements FacilityReportRepository {
     return Future.value(
       const FacilityReportResult(
         id: 'report-1',
+        publicReceiptCode: 'ES-1001',
         stationId: 'station-sangnoksu',
         facilityId: 'facility-sangnoksu-elevator-1',
         reportType: 'BROKEN',
@@ -1113,6 +1127,7 @@ class RefreshableFacilityReportRepository implements FacilityReportRepository {
     _refreshCompleter!.complete(
       const FacilityReportResult(
         id: 'report-1',
+        publicReceiptCode: 'ES-1001',
         stationId: 'station-sangnoksu',
         facilityId: 'facility-sangnoksu-elevator-1',
         reportType: 'BROKEN',
@@ -1176,6 +1191,7 @@ class FakeFacilityReportReceiptStore implements FacilityReportReceiptStore {
 
   final Map<String, String> _receiptTokens;
   final Map<String, DateTime> _createdAtByReportId;
+  final Map<String, String> savedPublicReceiptCodes = {};
   final bool throwOnSave;
 
   @override
@@ -1184,6 +1200,9 @@ class FakeFacilityReportReceiptStore implements FacilityReportReceiptStore {
       throw StateError('receipt save failed');
     }
     _receiptTokens[receipt.reportId] = receipt.receiptToken;
+    if (receipt.publicReceiptCode != null) {
+      savedPublicReceiptCodes[receipt.reportId] = receipt.publicReceiptCode!;
+    }
     _createdAtByReportId[receipt.reportId] = receipt.createdAt;
   }
 
@@ -1199,6 +1218,7 @@ class FakeFacilityReportReceiptStore implements FacilityReportReceiptStore {
         FacilityReportReceipt(
           receiptId: entry.key,
           reportId: entry.key,
+          publicReceiptCode: savedPublicReceiptCodes[entry.key],
           status: 'SUBMITTED',
           receiptToken: entry.value,
           createdAt:

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -252,6 +252,20 @@ void main() {
     expect(result.statusLabel, '접수됨');
   });
 
+  test('시설 신고 결과는 공개 번호가 없으면 라벨 없는 준비 중 값을 보여준다', () {
+    const result = FacilityReportResult(
+      id: 'report-1',
+      stationId: 'station-sangnoksu',
+      facilityId: 'facility-sangnoksu-elevator-1',
+      reportType: 'BROKEN',
+      description: '문이 열리지 않습니다.',
+      status: 'SUBMITTED',
+      createdAt: '2026-06-13T10:00:00',
+    );
+
+    expect(result.displayReceiptCode, '준비 중');
+  });
+
   test('시설 신고 요청은 사진 Base64 대신 object metadata를 전송한다', () {
     final request = FacilityReportRequest(
       userId: 'anonymous-mobile-user',
@@ -878,12 +892,13 @@ void main() {
         ..close();
     });
 
+    final receiptStore = FakeFacilityReportReceiptStore({
+      'report-2': 'receipt-token-2',
+      'report-1': 'receipt-token-1',
+    });
     final repository = FacilityReportApiRepository(
       baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
-      receiptStore: FakeFacilityReportReceiptStore({
-        'report-2': 'receipt-token-2',
-        'report-1': 'receipt-token-1',
-      }),
+      receiptStore: receiptStore,
     );
 
     final reports = await repository.listMyReports();
@@ -898,6 +913,14 @@ void main() {
     expect(reports.first.publicReceiptCode, 'ES-1002');
     expect(reports.first.statusLabel, '반영됨');
     expect(reports.last.statusLabel, '접수됨');
+    expect(receiptStore.savedPublicReceiptCodes, {
+      'report-2': 'ES-1002',
+      'report-1': 'ES-1001',
+    });
+    expect(receiptStore.savedStatuses, {
+      'report-2': 'ACCEPTED',
+      'report-1': 'SUBMITTED',
+    });
   });
 
   test('내 신고 API 저장소는 receipt가 없으면 목록 조회 네트워크를 호출하지 않는다', () async {
@@ -1192,6 +1215,7 @@ class FakeFacilityReportReceiptStore implements FacilityReportReceiptStore {
   final Map<String, String> _receiptTokens;
   final Map<String, DateTime> _createdAtByReportId;
   final Map<String, String> savedPublicReceiptCodes = {};
+  final Map<String, String> savedStatuses = {};
   final bool throwOnSave;
 
   @override
@@ -1203,6 +1227,7 @@ class FakeFacilityReportReceiptStore implements FacilityReportReceiptStore {
     if (receipt.publicReceiptCode != null) {
       savedPublicReceiptCodes[receipt.reportId] = receipt.publicReceiptCode!;
     }
+    savedStatuses[receipt.reportId] = receipt.status;
     _createdAtByReportId[receipt.reportId] = receipt.createdAt;
   }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -172,6 +172,7 @@ void main() {
       reports: [
         const FacilityReportResult(
           id: 'report-2',
+          publicReceiptCode: 'ES-1002',
           stationId: 'station-sangnoksu',
           facilityId: 'facility-sangnoksu-elevator-1',
           reportType: 'CLOSED',
@@ -196,12 +197,12 @@ void main() {
 
     await _openMyReportsScreen(tester);
 
-    expect(find.text('내 신고'), findsOneWidget);
+    expect(find.text('내 제보'), findsOneWidget);
     expect(find.text('반영됨'), findsOneWidget);
     expect(find.text('출입문이 막혀 있습니다.'), findsOneWidget);
     expect(
       find.bySemanticsLabel(
-        '내 신고, 폐쇄, 접수번호 report-2, 반영됨, 출입문이 막혀 있습니다., 접수일 2026.06.15',
+        '내 제보, 폐쇄, 제보 번호 ES-1002, 반영됨, 출입문이 막혀 있습니다., 접수일 2026.06.15',
       ),
       findsOneWidget,
     );
@@ -213,6 +214,7 @@ void main() {
       reports: [
         const FacilityReportResult(
           id: 'report-2',
+          publicReceiptCode: 'ES-1002',
           stationId: 'station-sangnoksu',
           facilityId: 'facility-sangnoksu-elevator-1',
           reportType: 'CLOSED',
@@ -238,7 +240,7 @@ void main() {
     await _openMyReportsScreen(tester);
     final reportSemantics = tester.getSemantics(
       find.bySemanticsLabel(
-        '내 신고, 폐쇄, 접수번호 report-2, 반영됨, 출입문이 막혀 있습니다., 접수일 2026.06.15',
+        '내 제보, 폐쇄, 제보 번호 ES-1002, 반영됨, 출입문이 막혀 있습니다., 접수일 2026.06.15',
       ),
     );
     expect(
@@ -249,21 +251,22 @@ void main() {
     await tester.tap(find.byKey(const Key('myReport-report-2')));
     await tester.pumpAndSettle();
 
-    expect(find.text('신고 상세'), findsOneWidget);
+    expect(find.text('제보 상세'), findsOneWidget);
     expect(find.text('폐쇄'), findsOneWidget);
     expect(find.text('반영됨'), findsOneWidget);
-    expect(find.text('접수번호'), findsOneWidget);
-    expect(find.text('report-2'), findsOneWidget);
+    expect(find.text('제보 번호'), findsOneWidget);
+    expect(find.text('ES-1002'), findsOneWidget);
+    expect(find.text('report-2'), findsNothing);
     expect(find.text('접수일'), findsOneWidget);
     expect(find.text('2026.06.15'), findsOneWidget);
     expect(find.text('출입문이 막혀 있습니다.'), findsOneWidget);
     expect(
-      find.bySemanticsLabel('내 신고 상세, 폐쇄, 현재 상태 반영됨, 접수번호 report-2'),
+      find.bySemanticsLabel('내 제보 상세, 폐쇄, 현재 상태 반영됨, 제보 번호 ES-1002'),
       findsOneWidget,
     );
   });
 
-  testWidgets('내 신고 화면은 접수한 신고가 없으면 짧은 빈 상태를 보여준다', (tester) async {
+  testWidgets('내 제보 화면은 접수한 제보가 없으면 짧은 빈 상태를 보여준다', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: MyFacilityReportListScreen(
@@ -273,7 +276,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('접수한 신고가 없습니다.'), findsOneWidget);
+    expect(find.text('접수한 제보가 없습니다.'), findsOneWidget);
     expect(find.byKey(const Key('myReportsRetryButton')), findsNothing);
   });
 
@@ -1735,7 +1738,7 @@ void main() {
       );
       expect(
         settingsActionSemantics(
-          '알림 설정, 시설 상태, 신고 처리, 정보 갱신 알림을 관리해요',
+          '알림 설정, 시설 상태, 제보 처리, 정보 갱신 알림을 관리해요',
         ).getSemanticsData().hasAction(SemanticsAction.tap),
         isTrue,
       );
@@ -2170,7 +2173,7 @@ void main() {
 
       expect(find.text('개인정보 사용 안내'), findsOneWidget);
       expect(
-        find.text('현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다.'),
+        find.text('현재 위치는 가까운 역 찾기와 시설 제보 위치 확인에만 사용됩니다.'),
         findsOneWidget,
       );
       expect(
@@ -2197,7 +2200,7 @@ void main() {
           .getSemanticsData();
       expect(
         summarySemantics.label,
-        contains('개인정보 사용 안내, 현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다.'),
+        contains('개인정보 사용 안내, 현재 위치는 가까운 역 찾기와 시설 제보 위치 확인에만 사용됩니다.'),
       );
       expect(
         summarySemantics.label,
@@ -2745,7 +2748,7 @@ void main() {
       expect(find.text('알림 설정'), findsOneWidget);
       expect(find.text('역 시설 알림'), findsOneWidget);
       expect(find.text('경로 시설 알림'), findsOneWidget);
-      expect(find.text('신고 처리 알림'), findsOneWidget);
+      expect(find.text('제보 처리 알림'), findsOneWidget);
       expect(find.text('정보 갱신 알림'), findsOneWidget);
       expect(find.bySemanticsLabel('역 시설 알림 켜짐'), findsOneWidget);
       expect(find.bySemanticsLabel('경로 시설 알림 꺼짐'), findsOneWidget);
@@ -2804,7 +2807,7 @@ void main() {
     expect(find.text('알림 받기'), findsOneWidget);
     expect(
       find.text(
-        '즐겨찾는 역과 경로의 시설 상태, 내 신고 처리 결과, 정보 갱신을 알려드립니다. 알림 설정에서 언제든 끌 수 있습니다.',
+        '즐겨찾는 역과 경로의 시설 상태, 내 제보 처리 결과, 정보 갱신을 알려드립니다. 알림 설정에서 언제든 끌 수 있습니다.',
       ),
       findsOneWidget,
     );
@@ -3067,7 +3070,7 @@ void main() {
     expect(locationProvider.permissionCheckCount, 1);
     expect(locationProvider.requestCount, 0);
     expect(find.text('현재 위치 사용'), findsOneWidget);
-    expect(find.text('가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다.'), findsOneWidget);
+    expect(find.text('가까운 역 찾기와 시설 제보 위치 확인에만 현재 위치를 사용합니다.'), findsOneWidget);
   });
 
   testWidgets('홈 즐겨찾기 경로는 저장한 경로를 큰 목록으로 보여주고 삭제한다', (tester) async {
@@ -4306,7 +4309,7 @@ void main() {
     expect(locationProvider.permissionCheckCount, 1);
     expect(locationProvider.requestCount, 0);
     expect(find.text('현재 위치 사용'), findsOneWidget);
-    expect(find.text('가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다.'), findsOneWidget);
+    expect(find.text('가까운 역 찾기와 시설 제보 위치 확인에만 현재 위치를 사용합니다.'), findsOneWidget);
     expect(
       find.text('위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다.'),
       findsOneWidget,
@@ -4482,7 +4485,7 @@ void main() {
   testWidgets('역 검색은 GPS가 꺼져 있으면 위치 설정으로 이동할 수 있다', (tester) async {
     final locationProvider = FakeCurrentLocationProvider(
       error: const CurrentLocationException(
-        '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
+        '휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
       ),
       needsPermissionRequest: false,
     );
@@ -4504,7 +4507,7 @@ void main() {
     await tester.tap(find.byKey(const Key('nearbyStationSearchButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
+    expect(find.text('휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
     expect(
       find.byKey(const Key('stationSearchOpenLocationSettingsButton')),
       findsOneWidget,
@@ -4886,7 +4889,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('시설 신고'), findsOneWidget);
+    expect(find.text('시설 상태 제보'), findsOneWidget);
     expect(find.text('2번 출구 엘리베이터'), findsOneWidget);
   });
 
@@ -6952,7 +6955,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('시설 신고'), findsOneWidget);
+      expect(find.text('시설 상태 제보'), findsOneWidget);
       expect(find.text('상록수역'), findsOneWidget);
       expect(find.text('1번 출구 엘리베이터'), findsOneWidget);
       expect(find.text('무엇을 알려드릴까요?'), findsOneWidget);
@@ -6990,16 +6993,14 @@ void main() {
       expect(reportRepository.requests.single.photoFileName, isNull);
       expect(reportRepository.requests.single.photoContentType, isNull);
       expect(reportRepository.requests.single.photoDataBase64, isNull);
-      expect(find.text('신고가 접수되었습니다.'), findsOneWidget);
-      expect(find.bySemanticsLabel('신고가 접수되었습니다.'), findsOneWidget);
-      expect(find.text('접수번호'), findsOneWidget);
-      expect(find.text('report-1'), findsOneWidget);
+      expect(find.text('제보를 보냈어요.'), findsOneWidget);
+      expect(find.bySemanticsLabel('제보를 보냈어요.'), findsOneWidget);
+      expect(find.text('제보 번호'), findsOneWidget);
+      expect(find.text('ES-1001'), findsOneWidget);
+      expect(find.text('report-1'), findsNothing);
       expect(find.text('처리 상태'), findsOneWidget);
       expect(find.text('접수됨'), findsOneWidget);
-      expect(
-        find.bySemanticsLabel('신고 접수번호 report-1, 현재 상태 접수됨'),
-        findsOneWidget,
-      );
+      expect(find.bySemanticsLabel('제보 번호 ES-1001, 현재 상태 접수됨'), findsOneWidget);
       expect(
         find.byKey(const Key('facilityReportPhotoUrlInput')),
         findsNothing,
@@ -7016,10 +7017,7 @@ void main() {
       expect(reportRepository.loadedReportIds, ['report-1']);
       expect(find.text('처리 상태를 확인했습니다.'), findsOneWidget);
       expect(find.text('반영됨'), findsOneWidget);
-      expect(
-        find.bySemanticsLabel('신고 접수번호 report-1, 현재 상태 반영됨'),
-        findsOneWidget,
-      );
+      expect(find.bySemanticsLabel('제보 번호 ES-1001, 현재 상태 반영됨'), findsOneWidget);
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
@@ -7133,7 +7131,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('사진 확인'), findsOneWidget);
-    expect(find.text('사진은 신고 확인에만 사용됩니다.'), findsOneWidget);
+    expect(find.text('사진은 제보 내용을 확인하는 데만 사용해요.'), findsOneWidget);
     expect(find.text('얼굴이나 전화번호가 보이면 가려 주세요.'), findsOneWidget);
     expect(pickerCallCount, 0);
 
@@ -7449,7 +7447,7 @@ void main() {
 
     expect(restoreCount, 1);
     expect(draftTargetStore.clearCount, 1);
-    expect(find.text('시설 신고'), findsOneWidget);
+    expect(find.text('시설 상태 제보'), findsOneWidget);
     expect(
       find.bySemanticsLabel('상록수역, 장애인 화장실, 장애인 화장실, 현재 확인 필요'),
       findsOneWidget,
@@ -7545,7 +7543,7 @@ void main() {
 
     expect(restoreCount, 1);
     expect(draftTargetStore.clearCount, 1);
-    expect(find.text('시설 신고'), findsOneWidget);
+    expect(find.text('시설 상태 제보'), findsOneWidget);
     expect(
       find.bySemanticsLabel('상록수역, 장애인 화장실, 장애인 화장실, 현재 확인 필요'),
       findsOneWidget,
@@ -7597,7 +7595,7 @@ void main() {
     expect(reportedErrors, hasLength(1));
     expect(reportedErrors.single.exception, isA<StateError>());
     expect(draftTargetStore.clearCount, 1);
-    expect(find.text('시설 신고'), findsOneWidget);
+    expect(find.text('시설 상태 제보'), findsOneWidget);
     await tester.dragUntilVisible(
       find.bySemanticsLabel('사진 1장 추가됨'),
       find.byType(Scrollable).first,
@@ -7664,9 +7662,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('사진·위치 확인'), findsOneWidget);
-    expect(find.text('사진과 신고 위치는 시설 신고 확인과 운영 검수에만 사용됩니다.'), findsOneWidget);
+    expect(find.text('사진과 제보 위치는 시설 제보 확인에만 사용됩니다.'), findsOneWidget);
     expect(
-      find.text('신고 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다.'),
+      find.text('제보 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다.'),
       findsOneWidget,
     );
     expect(find.text('사진 확인'), findsNothing);
@@ -7762,7 +7760,7 @@ void main() {
     expect(permissionCheckCount, 1);
     expect(requestCount, 0);
     expect(find.text('현재 위치 사용'), findsOneWidget);
-    expect(find.text('가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다.'), findsOneWidget);
+    expect(find.text('가까운 역 찾기와 시설 제보 위치 확인에만 현재 위치를 사용합니다.'), findsOneWidget);
     expect(
       find.text('위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다.'),
       findsOneWidget,
@@ -7815,7 +7813,7 @@ void main() {
             requestCount++;
             if (requestCount == 1) {
               throw const FacilityReportLocationException(
-                '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
+                '휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
               );
             }
             if (requestCount == 2) {
@@ -7865,7 +7863,7 @@ void main() {
       requestCount++;
       if (requestCount == 1) {
         throw const FacilityReportLocationException(
-          '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
+          '휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
         );
       }
       return const FacilityReportLocation(
@@ -7899,7 +7897,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
+    expect(find.text('휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
     final failedLocationSubmitButton = tester.widget<FilledButton>(
       find.byKey(const Key('facilityReportSubmitButton')),
     );
@@ -7926,7 +7924,7 @@ void main() {
     final reportRepository = FakeFacilityReportRepository();
     final locationProvider = FakeCurrentLocationProvider(
       error: const CurrentLocationException(
-        '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
+        '휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
       ),
       needsPermissionRequest: false,
     );
@@ -7994,7 +7992,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
+    expect(find.text('휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
     expect(find.text('현재 위치 첨부됨'), findsNothing);
     expect(find.text('현재 위치가 첨부되었습니다.'), findsNothing);
     expect(find.text('위치 확인됨'), findsNothing);
@@ -8021,7 +8019,7 @@ void main() {
     final reportRepository = FakeFacilityReportRepository();
     final locationProvider = FakeCurrentLocationProvider(
       error: const CurrentLocationException(
-        '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
+        '휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
       ),
       needsPermissionRequest: false,
     );
@@ -8087,7 +8085,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
+    expect(find.text('휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.'), findsOneWidget);
     expect(
       find.byKey(const Key('facilityReportOpenLocationSettingsButton')),
       findsOneWidget,
@@ -8122,7 +8120,7 @@ void main() {
           locationLoader: () async {
             requestCount++;
             throw const FacilityReportLocationException(
-              '기기 위치(GPS)를 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
+              '휴대전화의 위치 기능을 켜 주세요. 가까운 역을 찾는 데 필요합니다.',
             );
           },
           needsLocationPermissionRequest: () async => false,
@@ -8221,7 +8219,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('시설 신고'), findsOneWidget);
+    expect(find.text('시설 상태 제보'), findsOneWidget);
     await tester.ensureVisible(
       find.byKey(const Key('facilityReportDescriptionInput')),
     );
@@ -8240,9 +8238,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('사진·위치 확인'), findsOneWidget);
-    expect(find.text('사진과 신고 위치는 시설 신고 확인과 운영 검수에만 사용됩니다.'), findsOneWidget);
+    expect(find.text('사진과 제보 위치는 시설 제보 확인에만 사용됩니다.'), findsOneWidget);
     expect(
-      find.text('신고 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다.'),
+      find.text('제보 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다.'),
       findsOneWidget,
     );
     expect(reportRepository.requests, isEmpty);
@@ -8927,6 +8925,7 @@ class FakeFacilityReportRepository implements FacilityReportRepository {
     }
     return FacilityReportResult(
       id: 'report-${requests.length}',
+      publicReceiptCode: 'ES-100${requests.length}',
       stationId: request.stationId,
       facilityId: request.facilityId,
       reportType: request.reportType,
@@ -8945,6 +8944,7 @@ class FakeFacilityReportRepository implements FacilityReportRepository {
     }
     return FacilityReportResult(
       id: reportId,
+      publicReceiptCode: 'ES-1001',
       stationId: 'station-sangnoksu',
       facilityId: 'facility-sangnoksu-elevator-1',
       reportType: 'CLOSED',

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
@@ -366,6 +366,7 @@ class FacilityReportController {
 
 	record FacilityReportListResponse(
 		String id,
+		String publicReceiptCode,
 		String userId,
 		String stationId,
 		String facilityId,
@@ -384,6 +385,7 @@ class FacilityReportController {
 		static FacilityReportListResponse from(FacilityReportSummary report) {
 			return new FacilityReportListResponse(
 				report.id(),
+				report.publicReceiptCode(),
 				report.userId(),
 				report.stationId(),
 				report.facilityId(),
@@ -499,6 +501,7 @@ class FacilityReportController {
 
 	record FacilityReportResponse(
 		String id,
+		String publicReceiptCode,
 		String userId,
 		String stationId,
 		String facilityId,
@@ -522,6 +525,7 @@ class FacilityReportController {
 		static FacilityReportResponse from(FacilityReport report) {
 			return new FacilityReportResponse(
 				report.id(),
+				report.publicReceiptCode(),
 				report.userId(),
 				report.stationId(),
 				report.facilityId(),

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportController.java
@@ -403,6 +403,7 @@ class FacilityReportController {
 
 	record FacilityReportStatusResponse(
 		String id,
+		String publicReceiptCode,
 		String stationId,
 		String facilityId,
 		FacilityReportType reportType,
@@ -416,6 +417,7 @@ class FacilityReportController {
 		static FacilityReportStatusResponse from(FacilityReportSummary report) {
 			return new FacilityReportStatusResponse(
 				report.id(),
+				report.publicReceiptCode(),
 				report.stationId(),
 				report.facilityId(),
 				report.reportType(),
@@ -431,6 +433,7 @@ class FacilityReportController {
 			// 사용자용 상태 조회는 소유자에게도 내부 식별자와 정확한 위치 메타데이터를 숨긴다.
 			return new FacilityReportStatusResponse(
 				report.id(),
+				report.publicReceiptCode(),
 				report.stationId(),
 				report.facilityId(),
 				report.reportType(),
@@ -445,6 +448,7 @@ class FacilityReportController {
 
 	record FacilityReportCreatedResponse(
 		String id,
+		String publicReceiptCode,
 		String stationId,
 		String facilityId,
 		FacilityReportType reportType,
@@ -459,6 +463,7 @@ class FacilityReportController {
 		static FacilityReportCreatedResponse from(FacilityReport report, String receiptToken) {
 			return new FacilityReportCreatedResponse(
 				report.id(),
+				report.publicReceiptCode(),
 				report.stationId(),
 				report.facilityId(),
 				report.reportType(),

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/InMemoryFacilityReportRepository.java
@@ -179,6 +179,7 @@ public class InMemoryFacilityReportRepository implements
 		// 삭제 요청 이후에는 운영 검수 이력만 남기고 사용자가 남긴 본문, 사진, 위치는 제거한다.
 		return new FacilityReport(
 			report.id(),
+			report.publicReceiptCode(),
 			FacilityReport.ANONYMIZED_USER_ID,
 			report.stationId(),
 			report.facilityId(),
@@ -189,11 +190,16 @@ public class InMemoryFacilityReportRepository implements
 			null,
 			null,
 			null,
+			null,
+			null,
+			null,
 			report.duplicateOfReportId(),
 			report.status(),
 			report.createdAt(),
 			report.reviewedAt(),
-			report.reviewedBy()
+			report.reviewedBy(),
+			null,
+			null
 		);
 	}
 

--- a/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepository.java
@@ -69,6 +69,7 @@ public class JdbcFacilityReportRepository implements
 			return Optional.ofNullable(jdbcTemplate.queryForObject(
 				"""
 					SELECT report_id,
+						public_receipt_code,
 						user_id,
 						station_id,
 						facility_id,
@@ -109,6 +110,7 @@ public class JdbcFacilityReportRepository implements
 			return Optional.ofNullable(jdbcTemplate.queryForObject(
 				"""
 					SELECT report_id,
+						public_receipt_code,
 						user_id,
 						station_id,
 						facility_id,
@@ -145,6 +147,7 @@ public class JdbcFacilityReportRepository implements
 		return jdbcTemplate.query(
 			"""
 				SELECT report_id,
+					public_receipt_code,
 					user_id,
 					station_id,
 					facility_id,
@@ -180,6 +183,7 @@ public class JdbcFacilityReportRepository implements
 		List<FacilityReportSummary> summaries = jdbcTemplate.query(
 			"""
 				SELECT report_id,
+					public_receipt_code,
 					user_id,
 					station_id,
 					facility_id,
@@ -225,6 +229,7 @@ public class JdbcFacilityReportRepository implements
 		List<FacilityReportSummary> summaries = jdbcTemplate.query(
 			"""
 				SELECT report_id,
+					public_receipt_code,
 					user_id,
 					station_id,
 					facility_id,
@@ -354,7 +359,8 @@ public class JdbcFacilityReportRepository implements
 		int updatedCount = jdbcTemplate.update(
 			"""
 				UPDATE facility_reports
-				SET user_id = ?,
+				SET public_receipt_code = ?,
+					user_id = ?,
 					station_id = ?,
 					facility_id = ?,
 					report_type = ?,
@@ -376,6 +382,7 @@ public class JdbcFacilityReportRepository implements
 				WHERE report_id = ?
 					AND status = ?
 				""",
+			report.publicReceiptCode(),
 			report.userId(),
 			report.stationId(),
 			report.facilityId(),
@@ -477,6 +484,7 @@ public class JdbcFacilityReportRepository implements
 			"""
 				INSERT INTO facility_reports (
 					report_id,
+					public_receipt_code,
 					user_id,
 					station_id,
 					facility_id,
@@ -498,9 +506,10 @@ public class JdbcFacilityReportRepository implements
 					client_submission_id,
 					receipt_token_hash
 				)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 				ON CONFLICT (report_id) DO UPDATE
-				SET user_id = EXCLUDED.user_id,
+				SET public_receipt_code = EXCLUDED.public_receipt_code,
+					user_id = EXCLUDED.user_id,
 					station_id = EXCLUDED.station_id,
 					facility_id = EXCLUDED.facility_id,
 					report_type = EXCLUDED.report_type,
@@ -528,7 +537,8 @@ public class JdbcFacilityReportRepository implements
 		return jdbcTemplate.update(
 			"""
 				UPDATE facility_reports
-				SET user_id = ?,
+				SET public_receipt_code = ?,
+					user_id = ?,
 					station_id = ?,
 					facility_id = ?,
 					report_type = ?,
@@ -549,6 +559,7 @@ public class JdbcFacilityReportRepository implements
 					receipt_token_hash = ?
 				WHERE report_id = ?
 				""",
+			report.publicReceiptCode(),
 			report.userId(),
 			report.stationId(),
 			report.facilityId(),
@@ -577,6 +588,7 @@ public class JdbcFacilityReportRepository implements
 			"""
 				INSERT INTO facility_reports (
 					report_id,
+					public_receipt_code,
 					user_id,
 					station_id,
 					facility_id,
@@ -598,7 +610,7 @@ public class JdbcFacilityReportRepository implements
 					client_submission_id,
 					receipt_token_hash
 				)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 				""",
 			reportParameters(report)
 		);
@@ -608,6 +620,7 @@ public class JdbcFacilityReportRepository implements
 		List<FacilityReportSummary> summaries = jdbcTemplate.query(
 			"""
 				SELECT report_id,
+					public_receipt_code,
 					user_id,
 					station_id,
 					facility_id,
@@ -652,6 +665,7 @@ public class JdbcFacilityReportRepository implements
 	private Object[] reportParameters(FacilityReport report) {
 		return new Object[] {
 			report.id(),
+			report.publicReceiptCode(),
 			report.userId(),
 			report.stationId(),
 			report.facilityId(),
@@ -678,6 +692,7 @@ public class JdbcFacilityReportRepository implements
 	private FacilityReportSummary mapFacilityReportSummary(ResultSet resultSet, int rowNumber) throws SQLException {
 		return new FacilityReportSummary(
 			resultSet.getString("report_id"),
+			resultSet.getString("public_receipt_code"),
 			resultSet.getString("user_id"),
 			resultSet.getString("station_id"),
 			resultSet.getString("facility_id"),
@@ -697,6 +712,7 @@ public class JdbcFacilityReportRepository implements
 	private FacilityReport mapFacilityReport(ResultSet resultSet, int rowNumber) throws SQLException {
 		return new FacilityReport(
 			resultSet.getString("report_id"),
+			resultSet.getString("public_receipt_code"),
 			resultSet.getString("user_id"),
 			resultSet.getString("station_id"),
 			resultSet.getString("facility_id"),

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -37,6 +37,7 @@ import com.easysubway.transit.application.port.out.SaveAccessibilityFacilityStat
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationNotFoundException;
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -52,6 +53,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,6 +63,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 	private static final Logger log = LoggerFactory.getLogger(FacilityReportService.class);
 	private static final String LOCAL_DEV_RECEIPT_TOKEN_PEPPER = "local-dev-report-receipt-pepper";
 	private static final String UNCLAIMED_UPLOAD_OBJECT_PREFIX = "facility-reports/unclaimed/";
+	private static final int PUBLIC_RECEIPT_CODE_SAVE_ATTEMPTS = 3;
 
 	private final LoadTransitMasterPort loadTransitMasterPort;
 	private final SaveAccessibilityFacilityStatusPort saveAccessibilityFacilityStatusPort;
@@ -381,7 +384,6 @@ public class FacilityReportService implements FacilityReportUseCase {
 		// 신고 대상 시설이 요청한 역에 속해야 다른 역 시설 상태가 잘못 갱신되는 일을 막을 수 있다.
 		requireFacilityInStation(command.stationId(), command.facilityId());
 		String reportId = "report-" + UUID.randomUUID();
-		String publicReceiptCode = newPublicReceiptCode();
 		FacilityReportPhotoAttachment photo = preparePhoto(command);
 		StoredFacilityReportPhoto storedPhoto = photo == null ? null : storePhoto(reportId, photo);
 		String storedUserId = hasText(command.userId())
@@ -404,9 +406,8 @@ public class FacilityReportService implements FacilityReportUseCase {
 			? hasText(command.photoContentType()) ? command.photoContentType().trim() : null
 			: photo.contentType();
 
-		FacilityReport report = new FacilityReport(
+		FacilityReport saved = saveNewReportWithReceiptCodeRetry(
 			reportId,
-			publicReceiptCode,
 			storedUserId,
 			command.stationId(),
 			command.facilityId(),
@@ -420,18 +421,66 @@ public class FacilityReportService implements FacilityReportUseCase {
 			photoSizeBytes,
 			command.latitude(),
 			command.longitude(),
-			null,
-			FacilityReportStatus.SUBMITTED,
 			LocalDateTime.now(clock),
-			null,
-			null,
 			hasText(command.clientSubmissionId()) ? command.clientSubmissionId().trim() : null,
 			receiptTokenHash
 		);
-
-		FacilityReport saved = saveFacilityReportPort.saveReport(report);
 		claimUploadedPhotoObject(command, storedPhoto);
 		return saved;
+	}
+
+	private FacilityReport saveNewReportWithReceiptCodeRetry(
+		String reportId,
+		String storedUserId,
+		String stationId,
+		String facilityId,
+		FacilityReportType reportType,
+		String description,
+		String photoFileName,
+		String photoContentType,
+		String photoObjectKey,
+		String photoThumbnailObjectKey,
+		String photoSha256,
+		Long photoSizeBytes,
+		BigDecimal latitude,
+		BigDecimal longitude,
+		LocalDateTime createdAt,
+		String clientSubmissionId,
+		String receiptTokenHash
+	) {
+		DataIntegrityViolationException lastException = null;
+		for (int attempt = 0; attempt < PUBLIC_RECEIPT_CODE_SAVE_ATTEMPTS; attempt++) {
+			FacilityReport report = new FacilityReport(
+				reportId,
+				newPublicReceiptCode(),
+				storedUserId,
+				stationId,
+				facilityId,
+				reportType,
+				description,
+				photoFileName,
+				photoContentType,
+				photoObjectKey,
+				photoThumbnailObjectKey,
+				photoSha256,
+				photoSizeBytes,
+				latitude,
+				longitude,
+				null,
+				FacilityReportStatus.SUBMITTED,
+				createdAt,
+				null,
+				null,
+				clientSubmissionId,
+				receiptTokenHash
+			);
+			try {
+				return saveFacilityReportPort.saveReport(report);
+			} catch (DataIntegrityViolationException exception) {
+				lastException = exception;
+			}
+		}
+		throw lastException;
 	}
 
 	private void claimUploadedPhotoObject(CreateFacilityReportCommand command, StoredFacilityReportPhoto storedPhoto) {

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -670,7 +670,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 		return "ES-" + UUID.randomUUID()
 			.toString()
 			.replace("-", "")
-			.substring(0, 8)
+			.substring(0, 12)
 			.toUpperCase(java.util.Locale.ROOT);
 	}
 

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -381,6 +381,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 		// 신고 대상 시설이 요청한 역에 속해야 다른 역 시설 상태가 잘못 갱신되는 일을 막을 수 있다.
 		requireFacilityInStation(command.stationId(), command.facilityId());
 		String reportId = "report-" + UUID.randomUUID();
+		String publicReceiptCode = newPublicReceiptCode();
 		FacilityReportPhotoAttachment photo = preparePhoto(command);
 		StoredFacilityReportPhoto storedPhoto = photo == null ? null : storePhoto(reportId, photo);
 		String storedUserId = hasText(command.userId())
@@ -405,6 +406,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 
 		FacilityReport report = new FacilityReport(
 			reportId,
+			publicReceiptCode,
 			storedUserId,
 			command.stationId(),
 			command.facilityId(),
@@ -550,6 +552,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 		String duplicateOfReportId = resolveDuplicateOfReportId(command, report);
 		FacilityReport reviewed = new FacilityReport(
 			report.id(),
+			report.publicReceiptCode(),
 			report.userId(),
 			report.stationId(),
 			report.facilityId(),
@@ -614,6 +617,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 		}
 		return saveFacilityReportPort.saveReport(new FacilityReport(
 			report.id(),
+			report.publicReceiptCode(),
 			report.userId(),
 			report.stationId(),
 			report.facilityId(),
@@ -660,6 +664,14 @@ public class FacilityReportService implements FacilityReportUseCase {
 
 	private boolean hasText(String value) {
 		return value != null && !value.isBlank();
+	}
+
+	private String newPublicReceiptCode() {
+		return "ES-" + UUID.randomUUID()
+			.toString()
+			.replace("-", "")
+			.substring(0, 8)
+			.toUpperCase(java.util.Locale.ROOT);
 	}
 
 	private FacilityReportPhotoAttachment preparePhoto(CreateFacilityReportCommand command) {

--- a/backend/src/main/java/com/easysubway/report/domain/FacilityReport.java
+++ b/backend/src/main/java/com/easysubway/report/domain/FacilityReport.java
@@ -2,9 +2,11 @@ package com.easysubway.report.domain;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Locale;
 
 public record FacilityReport(
 	String id,
+	String publicReceiptCode,
 	String userId,
 	String stationId,
 	String facilityId,
@@ -38,6 +40,55 @@ public record FacilityReport(
 		String description,
 		String photoFileName,
 		String photoContentType,
+		String photoObjectKey,
+		String photoThumbnailObjectKey,
+		String photoSha256,
+		Long photoSizeBytes,
+		BigDecimal latitude,
+		BigDecimal longitude,
+		String duplicateOfReportId,
+		FacilityReportStatus status,
+		LocalDateTime createdAt,
+		LocalDateTime reviewedAt,
+		String reviewedBy,
+		String clientSubmissionId,
+		String receiptTokenHash
+	) {
+		this(
+			id,
+			defaultPublicReceiptCode(id),
+			userId,
+			stationId,
+			facilityId,
+			reportType,
+			description,
+			photoFileName,
+			photoContentType,
+			photoObjectKey,
+			photoThumbnailObjectKey,
+			photoSha256,
+			photoSizeBytes,
+			latitude,
+			longitude,
+			duplicateOfReportId,
+			status,
+			createdAt,
+			reviewedAt,
+			reviewedBy,
+			clientSubmissionId,
+			receiptTokenHash
+		);
+	}
+
+	public FacilityReport(
+		String id,
+		String userId,
+		String stationId,
+		String facilityId,
+		FacilityReportType reportType,
+		String description,
+		String photoFileName,
+		String photoContentType,
 		String legacyPhotoObjectKey,
 		BigDecimal latitude,
 		BigDecimal longitude,
@@ -49,6 +100,7 @@ public record FacilityReport(
 	) {
 		this(
 			id,
+			defaultPublicReceiptCode(id),
 			userId,
 			stationId,
 			facilityId,
@@ -95,6 +147,7 @@ public record FacilityReport(
 	) {
 		this(
 			id,
+			defaultPublicReceiptCode(id),
 			userId,
 			stationId,
 			facilityId,
@@ -130,5 +183,18 @@ public record FacilityReport(
 
 	private boolean hasText(String value) {
 		return value != null && !value.isBlank();
+	}
+
+	private static String defaultPublicReceiptCode(String reportId) {
+		String compact = reportId == null
+			? ""
+			: reportId.replaceFirst("^report-", "")
+				.replaceAll("[^A-Za-z0-9]", "")
+				.toUpperCase(Locale.ROOT);
+		if (compact.length() >= 8) {
+			return "ES-" + compact.substring(0, 8);
+		}
+		return "ES-" + Integer.toUnsignedString(String.valueOf(reportId).hashCode(), 36)
+			.toUpperCase(Locale.ROOT);
 	}
 }

--- a/backend/src/main/java/com/easysubway/report/domain/FacilityReportSummary.java
+++ b/backend/src/main/java/com/easysubway/report/domain/FacilityReportSummary.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 
 public record FacilityReportSummary(
 	String id,
+	String publicReceiptCode,
 	String userId,
 	String stationId,
 	String facilityId,
@@ -23,6 +24,7 @@ public record FacilityReportSummary(
 	public static FacilityReportSummary from(FacilityReport report) {
 		return new FacilityReportSummary(
 			report.id(),
+			report.publicReceiptCode(),
 			report.userId(),
 			report.stationId(),
 			report.facilityId(),

--- a/backend/src/main/resources/db/migration/h2/V7__facility_report_public_receipt_code.sql
+++ b/backend/src/main/resources/db/migration/h2/V7__facility_report_public_receipt_code.sql
@@ -1,0 +1,16 @@
+ALTER TABLE facility_reports
+	ADD COLUMN IF NOT EXISTS public_receipt_code VARCHAR(16);
+
+UPDATE facility_reports
+SET public_receipt_code = 'ES-' || upper(substring(regexp_replace(report_id, '^report-', ''), 1, 8))
+WHERE public_receipt_code IS NULL;
+
+ALTER TABLE facility_reports
+	ALTER COLUMN public_receipt_code SET NOT NULL;
+
+ALTER TABLE facility_reports
+	ADD CONSTRAINT chk_facility_reports_public_receipt_code
+		CHECK (public_receipt_code REGEXP '^ES-[0-9A-Z]{1,12}$');
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_facility_reports_public_receipt_code
+	ON facility_reports (public_receipt_code);

--- a/backend/src/main/resources/db/migration/h2/V7__facility_report_public_receipt_code.sql
+++ b/backend/src/main/resources/db/migration/h2/V7__facility_report_public_receipt_code.sql
@@ -2,7 +2,11 @@ ALTER TABLE facility_reports
 	ADD COLUMN IF NOT EXISTS public_receipt_code VARCHAR(16);
 
 UPDATE facility_reports
-SET public_receipt_code = 'ES-' || upper(substring(regexp_replace(report_id, '^report-', ''), 1, 8))
+SET public_receipt_code = 'ES-' || LPAD(CAST((
+	SELECT COUNT(*)
+	FROM facility_reports existing_report
+	WHERE existing_report.report_id <= facility_reports.report_id
+) AS VARCHAR), 12, '0')
 WHERE public_receipt_code IS NULL;
 
 ALTER TABLE facility_reports

--- a/backend/src/main/resources/db/migration/postgresql/V7__facility_report_public_receipt_code.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V7__facility_report_public_receipt_code.sql
@@ -2,7 +2,11 @@ ALTER TABLE facility_reports
 	ADD COLUMN IF NOT EXISTS public_receipt_code VARCHAR(16);
 
 UPDATE facility_reports
-SET public_receipt_code = 'ES-' || upper(substring(regexp_replace(report_id, '^report-', ''), 1, 8))
+SET public_receipt_code = 'ES-' || lpad((
+	SELECT count(*)
+	FROM facility_reports existing_report
+	WHERE existing_report.report_id <= facility_reports.report_id
+)::text, 12, '0')
 WHERE public_receipt_code IS NULL;
 
 ALTER TABLE facility_reports

--- a/backend/src/main/resources/db/migration/postgresql/V7__facility_report_public_receipt_code.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V7__facility_report_public_receipt_code.sql
@@ -1,0 +1,16 @@
+ALTER TABLE facility_reports
+	ADD COLUMN IF NOT EXISTS public_receipt_code VARCHAR(16);
+
+UPDATE facility_reports
+SET public_receipt_code = 'ES-' || upper(substring(regexp_replace(report_id, '^report-', ''), 1, 8))
+WHERE public_receipt_code IS NULL;
+
+ALTER TABLE facility_reports
+	ALTER COLUMN public_receipt_code SET NOT NULL;
+
+ALTER TABLE facility_reports
+	ADD CONSTRAINT chk_facility_reports_public_receipt_code
+		CHECK (public_receipt_code ~ '^ES-[0-9A-Z]{1,12}$');
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_facility_reports_public_receipt_code
+	ON facility_reports (public_receipt_code);

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -101,6 +101,7 @@ class FacilityReportControllerTest {
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.id").isNotEmpty())
+			.andExpect(jsonPath("$.data.publicReceiptCode").isNotEmpty())
 			.andExpect(jsonPath("$.data.receiptToken").isNotEmpty())
 			.andExpect(jsonPath("$.data.userId").doesNotExist())
 			.andExpect(jsonPath("$.data.photoDataBase64").doesNotExist())
@@ -109,6 +110,7 @@ class FacilityReportControllerTest {
 			.getContentAsString();
 
 		String reportId = JsonPath.read(response, "$.data.id");
+		String publicReceiptCode = JsonPath.read(response, "$.data.publicReceiptCode");
 		String receiptToken = JsonPath.read(response, "$.data.receiptToken");
 
 		mockMvc.perform(get("/api/v1/reports/{reportId}", reportId))
@@ -119,6 +121,7 @@ class FacilityReportControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.id").value(reportId))
+			.andExpect(jsonPath("$.data.publicReceiptCode").value(publicReceiptCode))
 			.andExpect(jsonPath("$.data.receiptToken").doesNotExist())
 			.andExpect(jsonPath("$.data.status").value("SUBMITTED"));
 	}

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -416,6 +416,7 @@ class FacilityReportControllerTest {
 
 		Assertions.assertThat(adminReportsResponse)
 			.contains("hasPhoto")
+			.contains("publicReceiptCode")
 			.doesNotContain("photoFileName")
 			.doesNotContain("photoContentType")
 			.doesNotContain("photoObjectKey")
@@ -829,6 +830,7 @@ class FacilityReportControllerTest {
 			.getContentAsString();
 
 		String reportId = JsonPath.read(response, "$.data.id");
+		String publicReceiptCode = JsonPath.read(response, "$.data.publicReceiptCode");
 		Assertions.assertThat(response)
 			.doesNotContain("photoDataBase64")
 			.doesNotContain("aW1hZ2UtYnl0ZXM=");
@@ -838,6 +840,7 @@ class FacilityReportControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.id").value(reportId))
+			.andExpect(jsonPath("$.data.publicReceiptCode").value(publicReceiptCode))
 			.andExpect(jsonPath("$.data.userId").value("basic-user"))
 			.andExpect(jsonPath("$.data.description").value("엘리베이터 앞 안내문이 떨어져 있습니다."))
 			.andExpect(jsonPath("$.data.photoFileName").value("elevator-notice.png"))

--- a/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java
@@ -34,6 +34,7 @@ class JdbcFacilityReportRepositoryTest {
 		jdbcTemplate.execute("""
 			CREATE TABLE facility_reports (
 				report_id VARCHAR(120) NOT NULL PRIMARY KEY,
+				public_receipt_code VARCHAR(16) NOT NULL UNIQUE,
 				user_id VARCHAR(120) NOT NULL,
 				station_id VARCHAR(120) NOT NULL,
 				facility_id VARCHAR(120) NOT NULL,

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -87,6 +87,9 @@ class FacilityReportServiceTest {
 		assertThat(report.stationId()).isEqualTo("station-sangnoksu");
 		assertThat(report.facilityId()).isEqualTo("facility-sangnoksu-elevator-1");
 		assertThat(report.reportType()).isEqualTo(FacilityReportType.BROKEN);
+		assertThat(report.publicReceiptCode()).startsWith("ES-");
+		assertThat(report.publicReceiptCode()).doesNotContain("report-");
+		assertThat(report.publicReceiptCode()).isNotEqualTo(report.id());
 		assertThat(report.status()).isEqualTo(FacilityReportStatus.SUBMITTED);
 		assertThat(report.createdAt()).isEqualTo(LocalDateTime.of(2026, 6, 12, 9, 0));
 		assertThat(service.getReport(report.id())).isEqualTo(report);

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -88,6 +88,7 @@ class FacilityReportServiceTest {
 		assertThat(report.facilityId()).isEqualTo("facility-sangnoksu-elevator-1");
 		assertThat(report.reportType()).isEqualTo(FacilityReportType.BROKEN);
 		assertThat(report.publicReceiptCode()).startsWith("ES-");
+		assertThat(report.publicReceiptCode()).matches("^ES-[0-9A-F]{12}$");
 		assertThat(report.publicReceiptCode()).doesNotContain("report-");
 		assertThat(report.publicReceiptCode()).isNotEqualTo(report.id());
 		assertThat(report.status()).isEqualTo(FacilityReportStatus.SUBMITTED);

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -44,6 +44,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HexFormat;
 import java.util.List;
@@ -53,6 +54,7 @@ import javax.imageio.ImageIO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.dao.DuplicateKeyException;
 
 @DisplayName("시설 신고 서비스")
 class FacilityReportServiceTest {
@@ -94,6 +96,37 @@ class FacilityReportServiceTest {
 		assertThat(report.status()).isEqualTo(FacilityReportStatus.SUBMITTED);
 		assertThat(report.createdAt()).isEqualTo(LocalDateTime.of(2026, 6, 12, 9, 0));
 		assertThat(service.getReport(report.id())).isEqualTo(report);
+	}
+
+	@Test
+	@DisplayName("시설 신고는 공개 제보 번호 중복 저장을 새 번호로 다시 시도한다")
+	void createReportRetriesPublicReceiptCodeDuplicate() {
+		var retryingRepository = new DuplicateOnceFacilityReportRepository();
+		var retryingService = new FacilityReportService(
+			transitRepository,
+			transitRepository,
+			retryingRepository,
+			retryingRepository,
+			Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+		);
+
+		var report = retryingService.createReport(new CreateFacilityReportCommand(
+			"anonymous-user-1",
+			"station-sangnoksu",
+			"facility-sangnoksu-elevator-1",
+			FacilityReportType.BROKEN,
+			"엘리베이터 문이 열리지 않습니다.",
+			null,
+			null,
+			null,
+			new BigDecimal("37.302421"),
+			new BigDecimal("126.866221")
+		));
+
+		assertThat(retryingRepository.saveAttempts).isEqualTo(2);
+		assertThat(retryingRepository.attemptedPublicReceiptCodes).hasSize(2);
+		assertThat(report.publicReceiptCode()).matches("^ES-[0-9A-F]{12}$");
+		assertThat(retryingService.getReport(report.id())).isEqualTo(report);
 	}
 
 	@Test
@@ -1494,6 +1527,22 @@ class FacilityReportServiceTest {
 		@Override
 		public void alertReportStatusChanged(ReportStatusChangedAlertCommand command) {
 			commands.add(command);
+		}
+	}
+
+	private static class DuplicateOnceFacilityReportRepository extends InMemoryFacilityReportRepository {
+
+		private int saveAttempts;
+		private final List<String> attemptedPublicReceiptCodes = new ArrayList<>();
+
+		@Override
+		public FacilityReport saveReport(FacilityReport report) {
+			saveAttempts++;
+			attemptedPublicReceiptCodes.add(report.publicReceiptCode());
+			if (saveAttempts == 1) {
+				throw new DuplicateKeyException("duplicate public_receipt_code");
+			}
+			return super.saveReport(report);
 		}
 	}
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4801,13 +4801,13 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(facilityReport, /\/api\/v1\/reports\/\$\{Uri\.encodeComponent\(trimmedReportId\)\}/);
   assert.match(facilityReport, /refreshCurrentReport/);
   assert.match(facilityReport, /처리 상태 확인 중/);
-  assert.match(facilityReport, /접수번호/);
+  assert.match(facilityReport, /제보 번호/);
   assert.match(facilityReport, /facilityReportRefreshButton/);
   assert.match(facilityReport, /facilityReportFailureNextAction/);
   assert.match(facilityReport, /내용을 확인한 뒤 네트워크 상태를 보고 다시 보내 주세요\./);
   assert.match(facilityReportTest, /접수번호로 처리 상태를 조회한다/);
   assert.match(facilityReportTest, /접수 후 처리 상태를 다시 확인한다/);
-  assert.match(widgetTest, /신고 접수번호 report-1, 현재 상태 반영됨/);
+  assert.match(widgetTest, /제보 번호 ES-1001, 현재 상태 반영됨/);
   assert.match(widgetTest, /시설 신고 실패는 다음 행동을 쉬운 문구로 안내한다/);
   assert.match(notificationSettings, /class NotificationSettingsApiRepository/);
   assert.match(notificationSettings, /\/api\/v1\/me\/notification-settings/);
@@ -4817,7 +4817,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(notificationSettings, /class NotificationSettingsScreen extends StatefulWidget/);
   assert.match(notificationSettings, /역 시설 알림/);
   assert.match(notificationSettings, /경로 시설 알림/);
-  assert.match(notificationSettings, /신고 처리 알림/);
+  assert.match(notificationSettings, /제보 처리 알림/);
   assert.match(notificationSettings, /정보 갱신 알림/);
   assert.match(notificationSettings, /즐겨찾는 역과 경로의 시설 상태/);
   assert.match(notificationSettings, /알림 설정에서 언제든 끌 수 있습니다/);
@@ -4831,10 +4831,10 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(read("apps/mobile/test/onboarding_test.dart"), /온보딩은 알림 권한 요청 실패 다음 행동을 안내한다/);
   assert.match(onboardingAppFlowTest, /첫 실행 앱은 온보딩 알림 권한 실패 다음 행동을 안내한다/);
   assert.doesNotMatch(widgetTest, /첫 실행 앱은 온보딩 알림 권한 실패 다음 행동을 안내한다/);
-  assert.match(stationSearch, /가까운 역 찾기와 시설 신고 위치 확인에만 현재 위치를 사용합니다/);
+  assert.match(stationSearch, /가까운 역 찾기와 시설 제보 위치 확인에만 현재 위치를 사용합니다/);
   assert.match(stationSearch, /위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다/);
-  assert.match(facilityReport, /사진과 신고 위치는 시설 신고 확인과 운영 검수에만 사용됩니다/);
-  assert.match(facilityReport, /신고 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다/);
+  assert.match(facilityReport, /사진과 제보 위치는 시설 제보 확인에만 사용됩니다/);
+  assert.match(facilityReport, /제보 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다/);
   assert.match(widgetTest, /역 검색은 첫 위치 권한 요청 전에 사용 목적을 안내한다/);
   assert.match(widgetTest, /시설 신고 화면은 첫 위치 권한 요청 전에 사용 목적을 안내한다/);
   assert.match(widgetTest, /시설 신고 화면은 사진과 위치를 보내기 전에 공개 범위를 안내한다/);
@@ -4908,7 +4908,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   );
   assert.match(main, /개인정보 사용 안내/);
   assert.match(main, /안전과 데이터 안내/);
-  assert.match(main, /현재 위치는 가까운 역 찾기와 시설 신고 위치 확인에만 사용됩니다/);
+  assert.match(main, /현재 위치는 가까운 역 찾기와 시설 제보 위치 확인에만 사용됩니다/);
   assert.match(main, /경로와 시설 정보는 이동을 돕는 참고 정보입니다/);
   assert.match(main, /현장 안내, 역무원 안내, 운영기관 공지를 먼저 확인해 주세요/);
   assert.match(main, /실시간 상태나 무조건 안전한 경로를 보장하지 않습니다/);


### PR DESCRIPTION
## 관련 이슈

close #821

## 작업 배경

- 시설 상태 제보 화면과 내역 화면에서 앱 최종 사용자에게 `신고`, `접수번호 report-...`가 그대로 보이면 운영 내부 식별자와 사용자 확인 번호의 역할이 섞입니다.
- QA 요청에 따라 사용자 화면 용어는 `제보`로 맞추고, 백엔드 내부 `reportId`와 별도 공개 제보 번호를 분리했습니다.

## 작업 내용

- 백엔드 `facility_reports.public_receipt_code`를 추가하고 생성/상태 조회 응답에 `publicReceiptCode`를 포함했습니다.
- 모바일 `FacilityReportResult`와 로컬 receipt 저장소에 `publicReceiptCode`를 추가하고, 목록/상세/완료 패널은 `제보 번호`로만 표시하게 변경했습니다.
- 설정, 알림, 위치/사진 안내 문구의 `신고` 표현을 `제보` 기준으로 정리했습니다.
- 기존 로컬 receipt와 v1 사용자 DB가 유지되도록 user DB schema v2 마이그레이션을 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `cd apps/mobile && flutter test test/facility_report_test.dart test/widget_test.dart test/current_location_provider_test.dart`: exit 0, 164 tests passed
- `cd apps/mobile && flutter test test/core/database/mobile_local_database_test.dart`: exit 0, 17 tests passed
- `cd apps/mobile && flutter analyze`: exit 0, No issues found
- `cd backend && ./gradlew test`: exit 0, BUILD SUCCESSFUL
- `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 설정 내 제보 진입점 | Android emulator `maum_on_api36` / `emulator-5554` | adb screenshot + UI tree | 로컬 `.codex/evidence/821/05-more-my-report-entry-scrolled.png`, `.codex/evidence/821/05-more-my-report-entry-scrolled-ui.xml`; UI tree: `내 활동`, `내 제보, 접수한 시설 제보와 처리 상태를 확인해요` | `내 신고`가 아닌 `내 제보`로 표시됨 |
| 내 제보 빈 상태 | Android emulator `maum_on_api36` / `emulator-5554` | adb screenshot + UI tree | 로컬 `.codex/evidence/821/06-my-reports-empty.png`, `.codex/evidence/821/06-my-reports-empty-ui.xml`; UI tree: `내 제보`, `접수한 제보가 없습니다.` | 빈 상태에서도 `신고`/내부 ID 노출 없음 |
| 공개 제보 번호 표시 | Flutter widget test | 내 제보 목록/상세/완료 패널 semantics 검증 | `flutter test test/facility_report_test.dart test/widget_test.dart test/current_location_provider_test.dart` | `제보 번호 ES-1001`, `제보 번호 ES-1002`만 표시되고 `report-...` 텍스트는 숨김 |
| 백엔드 공개 번호 응답 | JVM test | create/status response JSON 검증 | `./gradlew test` | `publicReceiptCode`가 생성/조회 응답에 포함되고 `receiptToken`은 생성 응답에만 포함됨 |
| 로컬 receipt 마이그레이션 | Flutter DB test | v1 user DB migration 및 receipt 보존 검증 | `flutter test test/core/database/mobile_local_database_test.dart` | 기존 receipt 보존, schema v2 통과 |

스크린샷은 프로젝트 정책상 git에 커밋하지 않고 로컬 전용 증거 폴더에 보관했습니다. PR에서 바로 확인 가능한 증거로 동일 화면의 UI tree 핵심 텍스트를 함께 기록했습니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
- 모바일 화면은 `FacilityReportResult.displayReceiptCode`를 통해 공개 코드만 표시합니다.
- `reportId`는 기존 상태 조회 경로와 receipt token 매칭에 계속 필요하므로 저장/네트워크 내부 값으로만 유지했습니다.
- `public_receipt_code`는 기존 row에도 대체 코드를 채우고 신규 row에는 난수 기반 `ES-XXXXXXXX` 코드를 저장합니다.

## 리스크

- 기존 설치 사용자는 user DB schema v2로 올라가며 `report_receipts.public_receipt_code`가 nullable로 추가됩니다.
- 기존 로컬 receipt에는 공개 코드가 없을 수 있어 네트워크 조회 실패 fallback에서는 `제보 번호 준비 중`으로 보입니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
