### PR TITLE
[Feat] iOS 노선도 viewport WKWebView backend 추가

### DIFF
--- a/apps/mobile/ios/Runner/AppDelegate.swift
+++ b/apps/mobile/ios/Runner/AppDelegate.swift
@@ -62,6 +62,12 @@ import WebKit
       OriginalRouteMapAssetViewFactory(),
       withId: "com.easysubway.easysubway_mobile/original_route_map_asset"
     )
+    engineBridge.applicationRegistrar.register(
+      RouteMapViewportWebViewFactory(
+        messenger: engineBridge.applicationRegistrar.messenger()
+      ),
+      withId: "com.easysubway.easysubway_mobile/route_map_viewport_webview"
+    )
   }
 
   private func handleCurrentLocation(_ result: @escaping FlutterResult) {
@@ -275,5 +281,303 @@ private final class OriginalRouteMapAssetPlatformView: NSObject, FlutterPlatform
 
   func view() -> UIView {
     webView
+  }
+}
+
+private final class RouteMapViewportWebViewFactory: NSObject, FlutterPlatformViewFactory {
+  private let messenger: FlutterBinaryMessenger
+
+  init(messenger: FlutterBinaryMessenger) {
+    self.messenger = messenger
+    super.init()
+  }
+
+  func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+    FlutterStandardMessageCodec.sharedInstance()
+  }
+
+  func create(
+    withFrame frame: CGRect,
+    viewIdentifier viewId: Int64,
+    arguments args: Any?
+  ) -> FlutterPlatformView {
+    let params = args as? [String: Any] ?? [:]
+    return RouteMapViewportPlatformView(
+      frame: frame,
+      messenger: messenger,
+      viewId: viewId,
+      assetPath: params["assetPath"] as? String ?? "",
+      mimeType: params["mimeType"] as? String ?? "",
+      sourceWidth: params["sourceWidth"].asDouble(),
+      sourceHeight: params["sourceHeight"].asDouble(),
+      viewBox: params["viewBox"].asDoubleList(),
+      revision: params["revision"].asInt()
+    )
+  }
+}
+
+private final class RouteMapViewportPlatformView: NSObject, FlutterPlatformView, WKNavigationDelegate {
+  private let container: UIView
+  private let channel: FlutterMethodChannel
+  private let assetPath: String
+  private let mimeType: String
+  private let sourceWidth: Double
+  private let sourceHeight: Double
+  private var viewBox: [Double]
+  private var revision: Int
+  private var webView: WKWebView?
+
+  init(
+    frame: CGRect,
+    messenger: FlutterBinaryMessenger,
+    viewId: Int64,
+    assetPath: String,
+    mimeType: String,
+    sourceWidth: Double,
+    sourceHeight: Double,
+    viewBox: [Double],
+    revision: Int
+  ) {
+    container = UIView(frame: frame)
+    channel = FlutterMethodChannel(
+      name: "com.easysubway.easysubway_mobile/route_map_viewport_webview/\(viewId)",
+      binaryMessenger: messenger
+    )
+    self.assetPath = assetPath
+    self.mimeType = mimeType
+    self.sourceWidth = sourceWidth
+    self.sourceHeight = sourceHeight
+    self.viewBox = viewBox
+    self.revision = revision
+    super.init()
+
+    container.backgroundColor = .white
+    channel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call, result: result)
+    }
+    load()
+  }
+
+  func view() -> UIView {
+    container
+  }
+
+  private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "setCamera":
+      let params = call.arguments as? [String: Any] ?? [:]
+      viewBox = params["viewBox"].asDoubleList()
+      revision = params["revision"].asInt()
+      applyViewBox()
+      result(nil)
+    case "reload":
+      load()
+      result(nil)
+    case "trimMemory":
+      result(nil)
+    case "dispose":
+      dispose()
+      result(nil)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func load() {
+    destroyWebView()
+    container.subviews.forEach { $0.removeFromSuperview() }
+
+    let configuration = WKWebViewConfiguration()
+    let svgWebView = WKWebView(frame: container.bounds, configuration: configuration)
+    webView = svgWebView
+    svgWebView.navigationDelegate = self
+    svgWebView.backgroundColor = .white
+    svgWebView.isOpaque = false
+    svgWebView.scrollView.isScrollEnabled = false
+    svgWebView.scrollView.bounces = false
+    svgWebView.scrollView.showsHorizontalScrollIndicator = false
+    svgWebView.scrollView.showsVerticalScrollIndicator = false
+    svgWebView.translatesAutoresizingMaskIntoConstraints = false
+
+    container.addSubview(svgWebView)
+    NSLayoutConstraint.activate([
+      svgWebView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      svgWebView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      svgWebView.topAnchor.constraint(equalTo: container.topAnchor),
+      svgWebView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+    ])
+
+    svgWebView.loadHTMLString(htmlForSvg(), baseURL: Bundle.main.resourceURL)
+  }
+
+  private func htmlForSvg() -> String {
+    guard mimeType == "image/svg+xml", !assetPath.isEmpty else {
+      return emptyHtml()
+    }
+    let lookupKey = FlutterDartProject.lookupKey(forAsset: assetPath)
+    guard let assetURL = Bundle.main.url(forResource: lookupKey, withExtension: nil) else {
+      return emptyHtml()
+    }
+    guard let svg = try? String(contentsOf: assetURL, encoding: .utf8) else {
+      return emptyHtml()
+    }
+    return """
+      <!doctype html>
+      <html>
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+        <style>
+          html, body { margin: 0; width: 100%; height: 100%; overflow: hidden; background: #ffffff; }
+          svg { display: block; width: 100%; height: 100%; }
+        </style>
+      </head>
+      <body>\(svg)</body>
+      </html>
+      """
+  }
+
+  private func emptyHtml() -> String {
+    "<!doctype html><html><body></body></html>"
+  }
+
+  private func applyViewBox() {
+    guard let currentWebView = webView else {
+      return
+    }
+    let values = normalizedViewBox()
+    let frameRevision = revision
+    let script = String(
+      format:
+        "(function(){const svg=document.querySelector('svg');if(!svg){return false;}svg.setAttribute('viewBox','%.4f %.4f %.4f %.4f');svg.setAttribute('width','100%%');svg.setAttribute('height','100%%');svg.setAttribute('preserveAspectRatio','xMidYMid meet');return true;})();",
+      locale: Locale(identifier: "en_US_POSIX"),
+      values[0],
+      values[1],
+      values[2],
+      values[3]
+    )
+    currentWebView.evaluateJavaScript(script) { [weak self, weak currentWebView] result, _ in
+      guard
+        let self,
+        let currentWebView,
+        self.webView === currentWebView,
+        result as? Bool == true
+      else {
+        return
+      }
+      self.channel.invokeMethod("framePresented", arguments: ["revision": frameRevision])
+    }
+  }
+
+  private func normalizedViewBox() -> [Double] {
+    if viewBox.count == 4, viewBox[2] > 0.0, viewBox[3] > 0.0 {
+      return viewBox
+    }
+    return [0.0, 0.0, max(sourceWidth, 1.0), max(sourceHeight, 1.0)]
+  }
+
+  private func showFallback(for terminatedWebView: WKWebView) {
+    guard webView === terminatedWebView else {
+      return
+    }
+    destroyWebView()
+    let label = UILabel()
+    label.text = "노선도를 다시 불러오지 못했습니다."
+    label.textColor = .black
+    label.textAlignment = .center
+    label.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(label)
+    NSLayoutConstraint.activate([
+      label.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      label.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      label.topAnchor.constraint(equalTo: container.topAnchor),
+      label.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+    ])
+  }
+
+  private func dispose() {
+    channel.setMethodCallHandler(nil)
+    destroyWebView()
+    container.subviews.forEach { $0.removeFromSuperview() }
+  }
+
+  private func destroyWebView() {
+    guard let currentWebView = webView else {
+      return
+    }
+    currentWebView.navigationDelegate = nil
+    currentWebView.stopLoading()
+    currentWebView.removeFromSuperview()
+    webView = nil
+  }
+
+  func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    guard self.webView === webView else {
+      return
+    }
+    channel.invokeMethod("assetReady", arguments: nil)
+    applyViewBox()
+  }
+
+  func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+    guard self.webView === webView else {
+      return
+    }
+    channel.invokeMethod("processGone", arguments: ["didCrash": true])
+    showFallback(for: webView)
+  }
+
+  func webView(
+    _ webView: WKWebView,
+    decidePolicyFor navigationAction: WKNavigationAction,
+    decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+  ) {
+    guard let scheme = navigationAction.request.url?.scheme?.lowercased() else {
+      decisionHandler(.allow)
+      return
+    }
+    if scheme == "about" || scheme == "file" {
+      decisionHandler(.allow)
+      return
+    }
+    decisionHandler(.cancel)
+  }
+}
+
+private extension Any? {
+  func asDouble() -> Double {
+    switch self {
+    case let value as Double:
+      return value
+    case let value as Float:
+      return Double(value)
+    case let value as Int:
+      return Double(value)
+    case let value as Int64:
+      return Double(value)
+    default:
+      return 0.0
+    }
+  }
+
+  func asInt() -> Int {
+    switch self {
+    case let value as Int:
+      return value
+    case let value as Int64:
+      return Int(value)
+    case let value as Double:
+      return Int(value)
+    case let value as Float:
+      return Int(value)
+    default:
+      return 0
+    }
+  }
+
+  func asDoubleList() -> [Double] {
+    guard let values = self as? [Any] else {
+      return []
+    }
+    return values.map { ($0 as Any?).asDouble() }
   }
 }

--- a/apps/mobile/lib/features/network_map/infrastructure/ios_route_map_viewport_webview.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/ios_route_map_viewport_webview.dart
@@ -1,0 +1,193 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import '../domain/map_camera.dart';
+import 'route_map_renderer.dart';
+
+const iosRouteMapViewportWebViewType =
+    'com.easysubway.easysubway_mobile/route_map_viewport_webview';
+
+@visibleForTesting
+Map<String, Object?> iosRouteMapViewportCreationParams({
+  required String assetPath,
+  required String mimeType,
+  required MapCameraState camera,
+}) {
+  return <String, Object?>{
+    'assetPath': assetPath,
+    'mimeType': mimeType,
+    'sourceWidth': camera.sourceBounds.width,
+    'sourceHeight': camera.sourceBounds.height,
+    'viewBox': _viewBoxFor(camera),
+    'revision': camera.revision,
+  };
+}
+
+class IosRouteMapViewportWebView extends StatefulWidget {
+  const IosRouteMapViewportWebView({
+    super.key,
+    required this.assetPath,
+    required this.mimeType,
+    required this.camera,
+    this.onControllerCreated,
+  });
+
+  final String assetPath;
+  final String mimeType;
+  final MapCameraState camera;
+  final ValueChanged<IosRouteMapViewportController>? onControllerCreated;
+
+  @override
+  State<IosRouteMapViewportWebView> createState() =>
+      _IosRouteMapViewportWebViewState();
+}
+
+class _IosRouteMapViewportWebViewState
+    extends State<IosRouteMapViewportWebView> {
+  IosRouteMapViewportController? _controller;
+
+  @override
+  void didUpdateWidget(IosRouteMapViewportWebView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (iosRouteMapViewportNeedsCameraUpdate(
+      previous: oldWidget.camera,
+      next: widget.camera,
+    )) {
+      _controller?.setCamera(widget.camera);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      return const ColoredBox(color: Color(0xffffffff));
+    }
+    return UiKitView(
+      key: ValueKey<String>(
+        'routeMapViewportWebView:${widget.assetPath}:${widget.mimeType}',
+      ),
+      viewType: iosRouteMapViewportWebViewType,
+      creationParams: iosRouteMapViewportCreationParams(
+        assetPath: widget.assetPath,
+        mimeType: widget.mimeType,
+        camera: widget.camera,
+      ),
+      creationParamsCodec: const StandardMessageCodec(),
+      onPlatformViewCreated: (viewId) {
+        final previousController = _controller;
+        if (previousController != null) {
+          unawaited(previousController.dispose());
+        }
+        final controller = IosRouteMapViewportController(viewId);
+        _controller = controller;
+        widget.onControllerCreated?.call(controller);
+        controller.emitCreated();
+      },
+    );
+  }
+}
+
+class IosRouteMapViewportController implements RouteMapRendererController {
+  IosRouteMapViewportController(int viewId, {BinaryMessenger? binaryMessenger})
+    : _channel = MethodChannel(
+        'com.easysubway.easysubway_mobile/route_map_viewport_webview/$viewId',
+        const StandardMethodCodec(),
+        binaryMessenger,
+      ) {
+    _channel.setMethodCallHandler(_handleNativeCall);
+  }
+
+  final MethodChannel _channel;
+  final _events = StreamController<RouteMapRendererEvent>.broadcast();
+  bool _createdEmitted = false;
+
+  @override
+  Stream<RouteMapRendererEvent> get events => _events.stream;
+
+  void emitCreated() {
+    if (_createdEmitted || _events.isClosed) {
+      return;
+    }
+    _createdEmitted = true;
+    _events.add(const RouteMapRendererCreated());
+  }
+
+  @override
+  Future<void> setCamera(MapCameraState camera) {
+    return _channel.invokeMethod<void>('setCamera', <String, Object?>{
+      'viewBox': _viewBoxFor(camera),
+      'revision': camera.revision,
+    });
+  }
+
+  @override
+  Future<void> retry() => _channel.invokeMethod<void>('reload');
+
+  @override
+  Future<void> trimMemory() => _channel.invokeMethod<void>('trimMemory');
+
+  @override
+  Future<void> dispose() async {
+    if (_events.isClosed) {
+      return;
+    }
+    try {
+      await _channel.invokeMethod<void>('dispose');
+    } on MissingPluginException {
+      // Platform views can already be gone during widget replacement.
+    } finally {
+      _channel.setMethodCallHandler(null);
+      await _events.close();
+    }
+  }
+
+  Future<void> _handleNativeCall(MethodCall call) async {
+    final arguments = (call.arguments as Map?)?.cast<String, Object?>();
+    switch (call.method) {
+      case 'assetReady':
+        _events.add(const RouteMapRendererAssetReady());
+      case 'framePresented':
+        _events.add(
+          RouteMapRendererFramePresented((arguments?['revision'] as int?) ?? 0),
+        );
+      case 'processGone':
+        _events.add(
+          RouteMapRendererProcessGone(
+            didCrash: (arguments?['didCrash'] as bool?) ?? false,
+          ),
+        );
+    }
+  }
+}
+
+List<double> _viewBoxFor(MapCameraState camera) {
+  final rect = camera.visibleSourceRect;
+  return <double>[rect.left, rect.top, rect.width, rect.height];
+}
+
+@visibleForTesting
+bool iosRouteMapViewportNeedsCameraUpdate({
+  required MapCameraState previous,
+  required MapCameraState next,
+}) {
+  if (previous.revision != next.revision) {
+    return true;
+  }
+  final previousViewBox = _viewBoxFor(previous);
+  final nextViewBox = _viewBoxFor(next);
+  for (var index = 0; index < previousViewBox.length; index += 1) {
+    if (previousViewBox[index] != nextViewBox[index]) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/apps/mobile/test/features/network_map/infrastructure/ios_route_map_viewport_webview_test.dart
+++ b/apps/mobile/test/features/network_map/infrastructure/ios_route_map_viewport_webview_test.dart
@@ -1,0 +1,168 @@
+import 'package:easysubway_mobile/features/network_map/domain/map_camera.dart';
+import 'package:easysubway_mobile/features/network_map/infrastructure/ios_route_map_viewport_webview.dart';
+import 'package:easysubway_mobile/features/network_map/infrastructure/route_map_renderer.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const camera = MapCameraState(
+    sourceBounds: Rect.fromLTWH(0, 0, 1000, 500),
+    viewportSize: Size(250, 125),
+    center: Offset(500, 250),
+    scale: 0.5,
+    minScale: 0.1,
+    maxScale: 4,
+    revision: 3,
+  );
+
+  test('creation params send source bounds and initial viewBox', () {
+    expect(
+      iosRouteMapViewportCreationParams(
+        assetPath: 'assets/datapacks/maps/seoul-official-route-map.svg',
+        mimeType: 'image/svg+xml',
+        camera: camera,
+      ),
+      <String, Object?>{
+        'assetPath': 'assets/datapacks/maps/seoul-official-route-map.svg',
+        'mimeType': 'image/svg+xml',
+        'sourceWidth': 1000.0,
+        'sourceHeight': 500.0,
+        'viewBox': <double>[250.0, 125.0, 500.0, 250.0],
+        'revision': 3,
+      },
+    );
+  });
+
+  test(
+    'camera update is needed when viewBox changes without revision change',
+    () {
+      expect(
+        iosRouteMapViewportNeedsCameraUpdate(
+          previous: camera,
+          next: camera.copyWith(viewportSize: const Size(500, 125)),
+        ),
+        isTrue,
+      );
+    },
+  );
+
+  test('controller sends camera updates to the view channel', () async {
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel(
+            'com.easysubway.easysubway_mobile/route_map_viewport_webview/7',
+          ),
+          (call) async {
+            calls.add(call);
+            return null;
+          },
+        );
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel(
+              'com.easysubway.easysubway_mobile/route_map_viewport_webview/7',
+            ),
+            null,
+          );
+    });
+
+    final controller = IosRouteMapViewportController(7);
+    await controller.setCamera(camera);
+    await controller.retry();
+    await controller.dispose();
+
+    expect(calls.map((call) => call.method), <String>[
+      'setCamera',
+      'reload',
+      'dispose',
+    ]);
+    expect(calls.first.arguments, <String, Object?>{
+      'viewBox': <double>[250.0, 125.0, 500.0, 250.0],
+      'revision': 3,
+    });
+  });
+
+  test('controller emits frame acknowledgements from native view', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel(
+            'com.easysubway.easysubway_mobile/route_map_viewport_webview/7',
+          ),
+          (_) async => null,
+        );
+    final controller = IosRouteMapViewportController(7);
+    final frame = expectLater(
+      controller.events,
+      emits(isA<RouteMapRendererFramePresented>()),
+    );
+
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+          'com.easysubway.easysubway_mobile/route_map_viewport_webview/7',
+          const StandardMethodCodec().encodeMethodCall(
+            const MethodCall('framePresented', <String, Object?>{
+              'revision': 9,
+            }),
+          ),
+          (_) {},
+        );
+
+    await frame;
+    await controller.dispose();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel(
+            'com.easysubway.easysubway_mobile/route_map_viewport_webview/7',
+          ),
+          null,
+        );
+  });
+
+  test('controller emits created after listeners subscribe', () async {
+    final controller = IosRouteMapViewportController(8);
+    final created = expectLater(
+      controller.events,
+      emits(isA<RouteMapRendererCreated>()),
+    );
+
+    controller.emitCreated();
+
+    await created;
+    await controller.dispose();
+    await expectLater(controller.events, emitsDone);
+  });
+
+  testWidgets('widget recreates platform view when asset identity changes', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: IosRouteMapViewportWebView(
+          assetPath: 'assets/datapacks/maps/seoul-official-route-map.svg',
+          mimeType: 'image/svg+xml',
+          camera: camera,
+        ),
+      ),
+    );
+
+    final view = tester.widget<UiKitView>(find.byType(UiKitView));
+
+    expect(
+      view.key,
+      const ValueKey<String>(
+        'routeMapViewportWebView:assets/datapacks/maps/seoul-official-route-map.svg:image/svg+xml',
+      ),
+    );
+    debugDefaultTargetPlatformOverride = null;
+  });
+}


### PR DESCRIPTION
## 관련 이슈

close #851

## 작업 배경

- 노선도 viewport renderer가 Android WebView backend와 같은 MethodChannel 계약으로 iOS에서도 동작할 수 있도록 WKWebView 기반 PlatformView backend가 필요하다.
- 이번 범위는 화면 연결 전 iOS native backend와 Dart wrapper를 준비하는 작업이며, renderer orchestration과 production 좌표 감사는 후속 issue에서 진행한다.

## 작업 내용

- iOS Runner에 `com.easysubway.easysubway_mobile/route_map_viewport_webview` PlatformView factory를 등록했다.
- WKWebView가 Flutter asset SVG를 inline HTML로 로드하고 `setCamera`의 viewBox를 SVG에 적용하도록 구현했다.
- `assetReady`, `framePresented`, `processGone` 이벤트와 `reload`, `trimMemory`, `dispose` 명령을 Android backend와 같은 채널 계약으로 맞췄다.
- Dart iOS wrapper/controller와 contract test를 추가해 생성 파라미터, 카메라 갱신, native event 수신, UiKitView identity를 고정했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/features/network_map/infrastructure/ios_route_map_viewport_webview_test.dart`: exit 0, 6 tests passed
  - `flutter analyze`: exit 0, No issues found
  - `flutter test`: exit 0, 432 tests passed
  - `flutter build ios --debug --simulator`: exit 0, `build/ios/iphonesimulator/Runner.app` 생성
  - `flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `node --test tools/ci/*.test.mjs`: exit 0, 102 tests passed
  - `adb install -r build/app/outputs/flutter-apk/app-debug.apk`: exit 0, `SM A175N` 실기기 설치 성공
  - `adb shell monkey -p com.easysubway.app -c android.intent.category.LAUNCHER 1`: exit 0, 실기기 앱 실행 성공

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| iOS WKWebView backend compile | iOS simulator | `flutter build ios --debug --simulator` | 터미널 출력: `✓ Built build/ios/iphonesimulator/Runner.app` | 성공 |
| iOS Dart channel contract | Flutter test | `flutter test test/features/network_map/infrastructure/ios_route_map_viewport_webview_test.dart` | 터미널 출력: 6 tests passed | 성공 |
| 전체 모바일 회귀 | Flutter test/analyze | `flutter analyze`, `flutter test` | 터미널 출력: analyze 이슈 없음, 432 tests passed | 성공 |
| Android 실기기 회귀 | SM A175N / Android 16 | debug APK 설치 후 앱 실행, screenshot/UI tree/logcat 확인 | local-only: `.codex/evidence/851/android-home.png`, `.codex/evidence/851/android-home-ui.xml`, `.codex/evidence/851/android-logcat.txt` | 홈 화면 표시, UI tree에 `쉬운 지하철`, `노선도` 탭 확인, fatal/Flutter/RouteMap/WebView 오류 패턴 없음 |
| iOS 실기기 가용성 | iPhone 15 Pro, iPad mini | `flutter devices`, `xcrun devicectl list devices` | 터미널 출력: iOS 기기 2대가 `unavailable`, Flutter가 Developer Mode/케이블/무선 연결 오류 code -27 보고 | 실기기 실행 불가, simulator build로 컴파일 검증 대체 |
| 화면 증거 불필요 사유 | iOS | 이번 PR은 backend와 wrapper 추가만 포함하고 사용자 화면에 renderer를 연결하지 않음 | iOS 시각 캡처는 실제 사용자 흐름 변화를 증명하지 못하므로 후속 화면 연결 PR에서 캡처 예정 | 대체 증거로 build/test/Android 실기기 회귀 확인 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/ios/Runner/AppDelegate.swift`의 새 `RouteMapViewportPlatformView`
  - `apps/mobile/lib/features/network_map/infrastructure/ios_route_map_viewport_webview.dart`의 Android backend와 동일한 MethodChannel 계약
  - `apps/mobile/test/features/network_map/infrastructure/ios_route_map_viewport_webview_test.dart`의 생성 파라미터/이벤트 contract

## 리스크

- iOS 실기기가 현재 unavailable 상태라 simulator build로 native compile을 검증했다. 실제 iOS 기기 렌더링과 WKWebView process termination 동작은 후속 화면 연결 PR에서 실기기 연결 가능 시 재검증해야 한다.
- 이번 PR은 renderer를 실제 노선도 화면에 연결하지 않으므로 사용자 화면 동작은 바뀌지 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
