### PR TITLE
[Refactor] 노선도 viewport gesture와 overlay 전환

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -2,9 +2,11 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 import 'accessible_design.dart';
+import 'features/network_map/domain/map_camera.dart';
+import 'features/network_map/infrastructure/android_route_map_viewport_webview.dart';
+import 'features/network_map/infrastructure/ios_route_map_viewport_webview.dart';
 import 'features/route_draft/application/route_draft_controller.dart';
 import 'features/route_draft/domain/route_draft.dart';
 
@@ -739,15 +741,10 @@ const _minMapScale = 0.08;
 const _maxMapScale = 4.8;
 
 class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
-  final TransformationController _controller = TransformationController();
-  final GlobalKey _mapContentKey = GlobalKey();
   String? _layoutKey;
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
+  MapCameraState? _camera;
+  MapCameraState? _gestureStartCamera;
+  Offset? _gestureStartFocalPoint;
 
   @override
   Widget build(BuildContext context) {
@@ -766,11 +763,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
         builder: (context, constraints) {
           final geometry = mapAsset == null
               ? _MapGeometry.fromStations(widget.data.stations)
-              : _MapGeometry.fromOriginalAsset(
-                  mapAsset,
-                  View.of(context).devicePixelRatio,
-                  defaultTargetPlatform,
-                );
+              : _MapGeometry.fromOriginalAsset(mapAsset);
           final fullBounds = Rect.fromLTWH(
             0,
             0,
@@ -782,133 +775,126 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
               '${widget.data.selectedRegion}:${geometry.width}:${geometry.height}:${constraints.maxWidth}:${constraints.maxHeight}';
           if (_layoutKey != layoutKey) {
             _layoutKey = layoutKey;
-            _controller.value = _initialMapTransform(
-              geometry,
+            _camera = _cameraForBounds(
+              geometry.initialBounds,
               constraints,
+              sourceBounds: fullBounds,
               minScale: minScale,
             );
           }
+          final camera =
+              _camera ??
+              _cameraForBounds(
+                geometry.initialBounds,
+                constraints,
+                sourceBounds: fullBounds,
+                minScale: minScale,
+              );
           return Stack(
             children: [
               Positioned.fill(
-                child: InteractiveViewer(
-                  key: const Key('networkMapInteractiveViewer'),
-                  transformationController: _controller,
-                  constrained: false,
-                  minScale: minScale,
-                  maxScale: _maxMapScale,
-                  boundaryMargin: const EdgeInsets.all(220),
-                  child: SizedBox(
-                    key: _mapContentKey,
-                    width: geometry.width,
-                    height: geometry.height,
-                    child: Stack(
-                      children: [
-                        Positioned.fill(
-                          child: mapAsset == null
-                              ? const _OriginalRouteMapUnavailable()
-                              : Align(
-                                  alignment: Alignment.topLeft,
-                                  child: Transform.scale(
-                                    alignment: Alignment.topLeft,
-                                    scaleX:
-                                        geometry.width / geometry.surfaceWidth,
-                                    scaleY:
-                                        geometry.height /
-                                        geometry.surfaceHeight,
-                                    child: SizedBox(
-                                      width: geometry.surfaceWidth,
-                                      height: geometry.surfaceHeight,
-                                      child: _OriginalRouteMapView(
-                                        asset: mapAsset,
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                        ),
-                        if (widget.selectedLineId != null)
-                          Positioned.fill(
-                            child: IgnorePointer(
-                              child: CustomPaint(
-                                key: const Key('networkMapSelectedLineOverlay'),
-                                painter: _SelectedLineOverlayPainter(
-                                  lineId: widget.selectedLineId!,
-                                  linesById: linesById,
-                                  stationsById: stationsById,
-                                  edges: widget.data.edges,
-                                  geometry: geometry,
-                                  styleScale: geometry.overlayStyleScale,
-                                ),
-                              ),
-                            ),
-                          ),
-                        Positioned.fill(
-                          child: GestureDetector(
-                            behavior: HitTestBehavior.translucent,
-                            onTapUp: (details) {
-                              _openNearestStation(
-                                details.localPosition,
-                                widget.data.stations,
-                                stationLinesById,
-                                geometry,
-                              );
-                            },
-                          ),
-                        ),
-                        for (final station in widget.data.stations)
-                          Positioned.fromRect(
-                            rect: _stationHitRect(station, geometry),
-                            child: _StationHitTarget(
-                              key: Key(
-                                'networkMapStation-${station.id.replaceFirst('station-', '')}-${station.lineId}',
-                              ),
-                              station: station,
-                              onTap: () => widget.onStationTap(
-                                station,
-                                stationLinesById[station.id] ?? const [],
-                              ),
-                              onTapUp: (details) {
-                                final renderObject = _mapContentKey
-                                    .currentContext
-                                    ?.findRenderObject();
-                                if (renderObject is! RenderBox) {
-                                  return;
-                                }
-                                _openNearestStation(
-                                  renderObject.globalToLocal(
-                                    details.globalPosition,
-                                  ),
-                                  widget.data.stations,
-                                  stationLinesById,
-                                  geometry,
-                                );
-                              },
-                            ),
-                          ),
-                      ],
+                child: mapAsset == null
+                    ? const _OriginalRouteMapUnavailable()
+                    : _RouteMapViewportRenderer(
+                        asset: mapAsset,
+                        camera: camera,
+                      ),
+              ),
+              if (widget.selectedLineId != null)
+                Positioned.fill(
+                  child: IgnorePointer(
+                    child: CustomPaint(
+                      key: const Key('networkMapSelectedLineOverlay'),
+                      painter: _SelectedLineOverlayPainter(
+                        lineId: widget.selectedLineId!,
+                        linesById: linesById,
+                        stationsById: stationsById,
+                        edges: widget.data.edges,
+                        geometry: geometry,
+                        camera: camera,
+                        styleScale: geometry.overlayStyleScale,
+                      ),
                     ),
                   ),
                 ),
+              Positioned.fill(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onScaleStart: (details) {
+                    _gestureStartCamera = camera;
+                    _gestureStartFocalPoint = details.localFocalPoint;
+                  },
+                  onScaleUpdate: (details) {
+                    _updateCameraForGesture(details);
+                  },
+                  onScaleEnd: (_) {
+                    _gestureStartCamera = null;
+                    _gestureStartFocalPoint = null;
+                  },
+                  onTapUp: (details) {
+                    _openNearestStation(
+                      camera.viewportToSourcePoint(details.localPosition),
+                      widget.data.stations,
+                      stationLinesById,
+                      geometry,
+                      camera,
+                    );
+                  },
+                ),
               ),
+              for (final station in widget.data.stations)
+                if (_stationHitRect(
+                  station,
+                  geometry,
+                ).overlaps(camera.visibleSourceRect.inflate(96 / camera.scale)))
+                  Positioned.fromRect(
+                    rect: _sourceRectToViewport(
+                      _stationHitRect(
+                        station,
+                        geometry,
+                        nodeRadius: 24 / camera.scale,
+                        labelHeight: 40 / camera.scale,
+                      ),
+                      camera,
+                    ),
+                    child: _StationHitTarget(
+                      key: Key(
+                        'networkMapStation-${station.id.replaceFirst('station-', '')}-${station.lineId}',
+                      ),
+                      station: station,
+                      onTap: () => widget.onStationTap(
+                        station,
+                        stationLinesById[station.id] ?? const [],
+                      ),
+                    ),
+                  ),
               Positioned(
                 right: 14,
                 top: 12,
                 child: _MapControls(
-                  onZoomIn: () => _scaleMap(1.25, minScale, constraints),
-                  onZoomOut: () => _scaleMap(0.8, minScale, constraints),
+                  onZoomIn: () => _scaleMap(1.25),
+                  onZoomOut: () => _scaleMap(0.8),
                   onOverview: () {
-                    _controller.value = _mapTransformForBounds(
-                      fullBounds,
-                      constraints,
-                      contain: true,
-                      minScale: minScale,
+                    _setCamera(
+                      _cameraForBounds(
+                        fullBounds,
+                        constraints,
+                        sourceBounds: fullBounds,
+                        contain: true,
+                        minScale: minScale,
+                        revision: camera.revision + 1,
+                      ),
                     );
                   },
                   onCenter: () {
-                    _controller.value = _mapTransformForBounds(
-                      _readableBoundsFor(geometry),
-                      constraints,
-                      minScale: minScale,
+                    _setCamera(
+                      _cameraForBounds(
+                        _readableBoundsFor(geometry),
+                        constraints,
+                        sourceBounds: fullBounds,
+                        minScale: minScale,
+                        revision: camera.revision + 1,
+                      ),
                     );
                   },
                 ),
@@ -920,40 +906,63 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas> {
     );
   }
 
-  void _scaleMap(double factor, double minScale, BoxConstraints constraints) {
-    final currentScale = _controller.value.getMaxScaleOnAxis();
-    if (currentScale <= 0) {
+  void _scaleMap(double factor) {
+    final camera = _camera;
+    if (camera == null || camera.viewportSize == Size.zero) {
       return;
     }
-    final targetScale = (currentScale * factor)
-        .clamp(minScale, _maxMapScale)
+    _setCamera(
+      camera
+          .zoomBy(factor, focalPoint: camera.viewportSize.center(Offset.zero))
+          .clamped(viewportMargin: 220),
+    );
+  }
+
+  void _updateCameraForGesture(ScaleUpdateDetails details) {
+    final startCamera = _gestureStartCamera;
+    final startFocalPoint = _gestureStartFocalPoint;
+    if (startCamera == null || startFocalPoint == null) {
+      return;
+    }
+    final viewportCenter = startCamera.viewportSize.center(Offset.zero);
+    final sourceBefore = startCamera.viewportToSourcePoint(startFocalPoint);
+    final nextScale = (startCamera.scale * details.scale)
+        .clamp(startCamera.minScale, startCamera.maxScale)
         .toDouble();
-    final viewportCenter = Offset(
-      (constraints.hasBoundedWidth ? constraints.maxWidth : 0) / 2,
-      (constraints.hasBoundedHeight ? constraints.maxHeight : 0) / 2,
+    final nextCenter =
+        sourceBefore - (details.localFocalPoint - viewportCenter) / nextScale;
+    _setCamera(
+      startCamera
+          .copyWith(
+            center: nextCenter,
+            scale: nextScale,
+            revision: startCamera.revision + 1,
+          )
+          .clamped(viewportMargin: 220),
     );
-    final sceneCenter = MatrixUtils.transformPoint(
-      Matrix4.inverted(_controller.value),
-      viewportCenter,
-    );
-    _controller.value = Matrix4.identity()
-      ..translateByDouble(viewportCenter.dx, viewportCenter.dy, 0, 1)
-      ..scaleByDouble(targetScale, targetScale, 1, 1)
-      ..translateByDouble(-sceneCenter.dx, -sceneCenter.dy, 0, 1);
+  }
+
+  void _setCamera(MapCameraState camera) {
+    if (_camera == camera) {
+      return;
+    }
+    setState(() {
+      _camera = camera;
+    });
   }
 
   void _openNearestStation(
-    Offset mapPosition,
+    Offset sourcePosition,
     List<NetworkMapStation> stations,
     Map<String, List<NetworkMapLine>> stationLinesById,
     _MapGeometry geometry,
+    MapCameraState camera,
   ) {
-    final scale = _controller.value.getMaxScaleOnAxis();
     final station = _stationAtMapPosition(
-      mapPosition,
+      sourcePosition,
       stations,
       geometry,
-      sceneHitRadius: 24 / (scale > 0 && scale.isFinite ? scale : 1),
+      sceneHitRadius: 24 / (camera.scale > 0 ? camera.scale : 1),
       selectedLineId: widget.selectedLineId,
     );
     if (station == null) {
@@ -970,6 +979,7 @@ class _SelectedLineOverlayPainter extends CustomPainter {
     required this.stationsById,
     required this.edges,
     required this.geometry,
+    required this.camera,
     required this.styleScale,
   });
 
@@ -978,6 +988,7 @@ class _SelectedLineOverlayPainter extends CustomPainter {
   final Map<String, NetworkMapStation> stationsById;
   final List<NetworkMapEdge> edges;
   final _MapGeometry geometry;
+  final MapCameraState camera;
   final double styleScale;
 
   @override
@@ -991,6 +1002,9 @@ class _SelectedLineOverlayPainter extends CustomPainter {
       Offset.zero & size,
       Paint()..color = Colors.white.withValues(alpha: 0.58),
     );
+    canvas
+      ..save()
+      ..transform(camera.sourceToViewport.storage);
     final pathPaint = Paint()
       ..color = lineColor
       ..strokeCap = StrokeCap.round
@@ -1027,6 +1041,7 @@ class _SelectedLineOverlayPainter extends CustomPainter {
       canvas.drawCircle(center, 13 * styleScale, stationBorderPaint);
       canvas.drawCircle(center, 7 * styleScale, stationFillPaint);
     }
+    canvas.restore();
   }
 
   @override
@@ -1036,6 +1051,7 @@ class _SelectedLineOverlayPainter extends CustomPainter {
         oldDelegate.stationsById != stationsById ||
         oldDelegate.edges != edges ||
         oldDelegate.geometry != geometry ||
+        oldDelegate.camera != camera ||
         oldDelegate.styleScale != styleScale;
   }
 }
@@ -1161,50 +1177,36 @@ class _MapControlButton extends StatelessWidget {
   }
 }
 
-class _OriginalRouteMapView extends StatelessWidget {
-  const _OriginalRouteMapView({required this.asset});
-
-  static const _viewType =
-      'com.easysubway.easysubway_mobile/original_route_map_asset';
+class _RouteMapViewportRenderer extends StatelessWidget {
+  const _RouteMapViewportRenderer({required this.asset, required this.camera});
 
   final _RouteMapAsset asset;
+  final MapCameraState camera;
 
   @override
   Widget build(BuildContext context) {
     if (_isWidgetTest) {
-      return ColoredBox(
-        key: const Key('originalRouteMapView'),
+      return const ColoredBox(
+        key: Key('routeMapViewportRenderer'),
         color: Colors.white,
-        child: Semantics(
-          label: '원본 노선도',
-          image: true,
-          child: const SizedBox.expand(),
-        ),
       );
     }
-    final platformViewKey = ValueKey('originalRouteMapView-${asset.path}');
-    final creationParams = <String, Object?>{
-      'assetPath': asset.path,
-      'mimeType': asset.mimeType,
-    };
-    final nativeView = switch (defaultTargetPlatform) {
-      TargetPlatform.android => AndroidView(
-        key: platformViewKey,
-        viewType: _viewType,
-        creationParams: creationParams,
-        creationParamsCodec: const StandardMessageCodec(),
+    final renderer = switch (defaultTargetPlatform) {
+      TargetPlatform.android => AndroidRouteMapViewportWebView(
+        assetPath: asset.path,
+        mimeType: asset.mimeType,
+        camera: camera,
       ),
-      TargetPlatform.iOS => UiKitView(
-        key: platformViewKey,
-        viewType: _viewType,
-        creationParams: creationParams,
-        creationParamsCodec: const StandardMessageCodec(),
+      TargetPlatform.iOS => IosRouteMapViewportWebView(
+        assetPath: asset.path,
+        mimeType: asset.mimeType,
+        camera: camera,
       ),
       _ => const ColoredBox(color: Colors.white),
     };
     return KeyedSubtree(
-      key: const Key('originalRouteMapView'),
-      child: IgnorePointer(child: nativeView),
+      key: const Key('routeMapViewportRenderer'),
+      child: renderer,
     );
   }
 }
@@ -1247,30 +1249,30 @@ String _displayRegionName(String region) {
   };
 }
 
-Matrix4 _initialMapTransform(
-  _MapGeometry geometry,
-  BoxConstraints constraints, {
-  required double minScale,
-}) {
-  return _mapTransformForBounds(
-    geometry.initialBounds,
-    constraints,
-    minScale: minScale,
-  );
-}
-
-Matrix4 _mapTransformForBounds(
+MapCameraState _cameraForBounds(
   Rect bounds,
   BoxConstraints constraints, {
+  required Rect sourceBounds,
   bool contain = false,
   double minScale = _minMapScale,
+  int revision = 0,
 }) {
-  final viewportWidth = constraints.hasBoundedWidth ? constraints.maxWidth : 0;
+  final viewportWidth = constraints.hasBoundedWidth
+      ? constraints.maxWidth
+      : 0.0;
   final viewportHeight = constraints.hasBoundedHeight
       ? constraints.maxHeight
-      : 0;
+      : 0.0;
   if (viewportWidth <= 0 || viewportHeight <= 0) {
-    return Matrix4.identity();
+    return MapCameraState(
+      sourceBounds: sourceBounds,
+      viewportSize: Size.zero,
+      center: sourceBounds.center,
+      scale: minScale,
+      minScale: minScale,
+      maxScale: _maxMapScale,
+      revision: revision,
+    );
   }
   final widthScale = viewportWidth / bounds.width;
   final heightScale = viewportHeight / bounds.height;
@@ -1278,15 +1280,26 @@ Matrix4 _mapTransformForBounds(
       ? math.min(widthScale, heightScale)
       : math.max(widthScale, heightScale);
   final initialScale = computedScale.clamp(minScale, _maxMapScale).toDouble();
-  final dx =
-      (viewportWidth - bounds.width * initialScale) / 2 -
-      bounds.left * initialScale;
-  final dy =
-      (viewportHeight - bounds.height * initialScale) / 2 -
-      bounds.top * initialScale;
-  return Matrix4.identity()
-    ..translateByDouble(dx, dy, 0, 1)
-    ..scaleByDouble(initialScale, initialScale, 1, 1);
+  return MapCameraState(
+    sourceBounds: sourceBounds,
+    viewportSize: Size(viewportWidth, viewportHeight),
+    center: bounds.center,
+    scale: initialScale,
+    minScale: minScale,
+    maxScale: _maxMapScale,
+    revision: revision,
+  ).clamped(viewportMargin: 220);
+}
+
+Rect _sourceRectToViewport(Rect sourceRect, MapCameraState camera) {
+  final topLeft = camera.sourceToViewportPoint(sourceRect.topLeft);
+  final bottomRight = camera.sourceToViewportPoint(sourceRect.bottomRight);
+  return Rect.fromLTRB(
+    math.min(topLeft.dx, bottomRight.dx),
+    math.min(topLeft.dy, bottomRight.dy),
+    math.max(topLeft.dx, bottomRight.dx),
+    math.max(topLeft.dy, bottomRight.dy),
+  );
 }
 
 double _minimumMapScaleForBounds(Rect bounds, BoxConstraints constraints) {
@@ -1333,40 +1346,17 @@ class _MapGeometry {
     required this.width,
     required this.height,
     Rect? initialBounds,
-    double? surfaceWidth,
-    double? surfaceHeight,
     this.overlayStyleScale = 1.0,
-  }) : initialBounds = initialBounds ?? Rect.fromLTWH(0, 0, width, height),
-       surfaceWidth = surfaceWidth ?? width,
-       surfaceHeight = surfaceHeight ?? height;
+  }) : initialBounds = initialBounds ?? Rect.fromLTWH(0, 0, width, height);
 
   final Offset origin;
   final Offset focus;
   final double width;
   final double height;
   final Rect initialBounds;
-  final double surfaceWidth;
-  final double surfaceHeight;
   final double overlayStyleScale;
 
-  // Android WebView platform view는 큰 Surface에서 GL memory가 급증한다.
-  static const _maxAndroidViewSurfaceExtent = 4096.0;
-
-  factory _MapGeometry.fromOriginalAsset(
-    _RouteMapAsset asset,
-    double devicePixelRatio,
-    TargetPlatform platform,
-  ) {
-    final safeDevicePixelRatio = devicePixelRatio <= 0 ? 1.0 : devicePixelRatio;
-    final maxLogicalExtent =
-        _maxAndroidViewSurfaceExtent / safeDevicePixelRatio;
-    final surfaceScale = platform == TargetPlatform.android
-        ? math.min(
-            1.0,
-            maxLogicalExtent /
-                math.max(asset.coordinateWidth, asset.coordinateHeight),
-          )
-        : 1.0;
+  factory _MapGeometry.fromOriginalAsset(_RouteMapAsset asset) {
     final sourceWidth = asset.coordinateWidth;
     final sourceHeight = asset.coordinateHeight;
     final overlayStyleScale = math.min(
@@ -1386,8 +1376,6 @@ class _MapGeometry {
           height: sourceHeight,
         ),
       ),
-      surfaceWidth: sourceWidth * surfaceScale,
-      surfaceHeight: sourceHeight * surfaceScale,
       overlayStyleScale: overlayStyleScale.isFinite && overlayStyleScale > 0
           ? overlayStyleScale
           : 1.0,
@@ -1578,13 +1566,11 @@ class _StationHitTarget extends StatelessWidget {
   const _StationHitTarget({
     required this.station,
     required this.onTap,
-    required this.onTapUp,
     super.key,
   });
 
   final NetworkMapStation station;
   final VoidCallback onTap;
-  final GestureTapUpCallback onTapUp;
 
   @override
   Widget build(BuildContext context) {
@@ -1592,11 +1578,7 @@ class _StationHitTarget extends StatelessWidget {
       button: true,
       label: station.displayName,
       onTap: onTap,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTapUp: onTapUp,
-        child: const SizedBox.expand(),
-      ),
+      child: const SizedBox.expand(),
     );
   }
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1120,6 +1120,52 @@ void main() {
     expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
   });
 
+  testWidgets('노선도 역은 스크린리더 tap으로도 설정 sheet를 연다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('bottomNavMap')));
+      await tester.pumpAndSettle();
+      await tester.drag(
+        find.byKey(const Key('networkMapSurface')),
+        const Offset(0, 180),
+      );
+      await tester.pumpAndSettle();
+
+      final stationFinder = find.byKey(
+        const Key('networkMapStation-sadang-seoul-4'),
+      );
+      final stationSemantics = tester.getSemantics(stationFinder);
+      expect(
+        stationSemantics.getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
+      );
+
+      stationSemantics.owner!.performAction(
+        stationSemantics.id,
+        SemanticsAction.tap,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
+      expect(find.text('사당역'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '출발로 설정'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, '도착으로 설정'), findsOneWidget);
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('노선도 역 좌표가 겹쳐도 탭한 위치에서 가장 가까운 역을 선택한다', (tester) async {
     final repository = FakeStationSearchRepository(
       networkMapData: const NetworkMapData(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -718,7 +718,9 @@ void main() {
   testWidgets('홈 노선도 버튼은 v3 노선도 화면을 연다', (tester) async {
     await tester.pumpWidget(
       EasySubwayApp(
-        repository: FakeStationSearchRepository(),
+        repository: FakeStationSearchRepository(
+          networkMapRegionNames: const ['수도권'],
+        ),
         reportRepository: FakeFacilityReportRepository(),
         routeRepository: FakeRouteSearchRepository(),
         notificationRepository: FakeNotificationSettingsRepository(),
@@ -741,7 +743,7 @@ void main() {
     expect(find.byKey(const Key('networkMapSurface')), findsOneWidget);
     expect(find.text('즐겨찾기'), findsOneWidget);
     expect(find.text('저장'), findsNothing);
-    expect(find.text('테스트권'), findsOneWidget);
+    expect(find.text('수도권'), findsOneWidget);
     expect(find.text('전국'), findsNothing);
     expect(
       tester.getSize(find.byKey(const Key('mapRegionTabs'))).height,
@@ -751,40 +753,25 @@ void main() {
       tester.getSize(find.byKey(const Key('networkMapLineFilter'))).height,
       greaterThanOrEqualTo(EasySubwayTouchTarget.general),
     );
-    expect(find.bySemanticsLabel('지역: 테스트권'), findsOneWidget);
+    expect(find.bySemanticsLabel('지역: 수도권'), findsOneWidget);
     expect(find.bySemanticsLabel('노선: 전체 노선'), findsOneWidget);
-    final viewer = tester.widget<InteractiveViewer>(
-      find.byKey(const Key('networkMapInteractiveViewer')),
-    );
-    final initialScale = viewer.transformationController!.value
-        .getMaxScaleOnAxis();
-    expect(initialScale, greaterThan(1));
+    expect(find.byKey(const Key('networkMapInteractiveViewer')), findsNothing);
+    expect(find.byKey(const Key('routeMapViewportRenderer')), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('networkMapOverviewButton')));
     await tester.pump();
-
-    expect(
-      viewer.transformationController!.value.getMaxScaleOnAxis(),
-      lessThan(initialScale),
-    );
 
     for (var index = 0; index < 30; index += 1) {
       await tester.tap(find.byKey(const Key('networkMapZoomInButton')));
       await tester.pump();
     }
-    expect(
-      viewer.transformationController!.value.getMaxScaleOnAxis(),
-      lessThanOrEqualTo(4.8),
-    );
 
     for (var index = 0; index < 80; index += 1) {
       await tester.tap(find.byKey(const Key('networkMapZoomOutButton')));
       await tester.pump();
     }
-    expect(
-      viewer.transformationController!.value.getMaxScaleOnAxis(),
-      greaterThanOrEqualTo(0.08),
-    );
+    expect(find.byKey(const Key('networkMapSurface')), findsOneWidget);
+    expect(find.byKey(const Key('routeMapViewportRenderer')), findsOneWidget);
   });
 
   testWidgets('노선도 지역 메뉴는 선택한 지역으로 지도를 다시 불러온다', (tester) async {
@@ -848,7 +835,11 @@ void main() {
     );
     expect(find.text('4호선'), findsOneWidget);
 
-    await tester.tap(find.byKey(const Key('networkMapStation-sadang-seoul-4')));
+    await tester.tapAt(
+      tester.getCenter(
+        find.byKey(const Key('networkMapStation-sadang-seoul-4')),
+      ),
+    );
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
@@ -946,11 +937,11 @@ void main() {
     expect(decoration.color, Colors.white);
     expect(decoration.border, isNull);
     expect(decoration.borderRadius, isNull);
-    expect(find.byKey(const Key('originalRouteMapView')), findsOneWidget);
+    expect(find.byKey(const Key('routeMapViewportRenderer')), findsOneWidget);
     expect(find.byKey(const Key('networkMapPainter')), findsNothing);
   });
 
-  testWidgets('수도권 노선도는 Android에서도 원본 source 좌표계를 유지한다', (tester) async {
+  testWidgets('수도권 노선도는 Android에서도 viewport renderer를 사용한다', (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.android;
     tester.view.devicePixelRatio = 3;
     try {
@@ -970,12 +961,18 @@ void main() {
       await tester.tap(find.byKey(const Key('bottomNavMap')));
       await tester.pumpAndSettle();
 
-      final viewer = tester.widget<InteractiveViewer>(
+      expect(
         find.byKey(const Key('networkMapInteractiveViewer')),
+        findsNothing,
       );
-      final mapContent = viewer.child as SizedBox;
-      expect(mapContent.width, 5724);
-      expect(mapContent.height, 6516);
+      final renderer = tester.getSize(
+        find.byKey(const Key('routeMapViewportRenderer')),
+      );
+      final surface = tester.getSize(
+        find.byKey(const Key('networkMapSurface')),
+      );
+      expect(renderer.width, surface.width);
+      expect(renderer.height, surface.height);
     } finally {
       debugDefaultTargetPlatformOverride = null;
       tester.view.resetDevicePixelRatio();
@@ -1108,7 +1105,11 @@ void main() {
       const Offset(0, 180),
     );
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('networkMapStation-sadang-seoul-4')));
+    await tester.tapAt(
+      tester.getCenter(
+        find.byKey(const Key('networkMapStation-sadang-seoul-4')),
+      ),
+    );
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);


### PR DESCRIPTION
## 관련 이슈

close #854

## 작업 배경

- 노선도 화면이 기존 `InteractiveViewer`와 source 크기 전체 scene에 의존해 Android WebView surface 크기와 production 좌표계가 한 UI 계층에 섞여 있었다.
- #840, #851에서 준비한 Android/iOS viewport WebView backend를 실제 노선도 화면에 연결해 화면 크기 고정 renderer와 source 좌표 camera를 분리한다.

## 작업 내용

- `NetworkMapScreen`의 공식 노선도 렌더링 경로를 source 크기 `InteractiveViewer`에서 viewport 크기 `AndroidRouteMapViewportWebView` / `IosRouteMapViewportWebView`로 전환했다.
- zoom, overview, center, pinch/pan 입력을 `MapCameraState` 기반으로 처리하고 station tap은 viewport 좌표를 source 좌표로 변환해 기존 역 선택 sheet 흐름을 유지했다.
- 선택 노선 overlay와 station semantics hit target을 camera 변환 기준으로 그리도록 조정했다.
- widget test는 새 viewport renderer 계약과 좌표 tap 경로를 검증하도록 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `flutter analyze`: exit 0, No issues found
  - `flutter test test/widget_test.dart`: exit 0, 136 tests passed
  - `flutter test`: exit 0, 432 tests passed
  - `node --test tools/ci/*.test.mjs`: exit 0, 102 tests passed
  - `flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `flutter build ios --debug --simulator`: exit 0, `build/ios/iphonesimulator/Runner.app` 생성
  - `flutter test test/widget_test.dart --plain-name "노선도 역은 스크린리더 tap으로도 설정 sheet를 연다"`: exit 0, 1 test passed
  - Android 실기기 `SM A175N`: debug APK install success, 노선도 진입 및 확대 버튼 동작 확인
  - `flutter devices`: Android 실기기만 연결됨, iOS 실기기 `동이니`는 code -27 unavailable
  - `xcrun devicectl list devices`: iPhone 15 Pro, iPad mini 모두 unavailable
  - GitHub CI: `CI` run `28157425997` pass, `Release Artifacts` run `28157425623` pass
  - CodeRabbit: review completed, actionable comment 1건은 `bb755b8`에서 test 보강 후 원래 inline thread에 해결 답글 작성 및 resolved 처리

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 노선도 viewport WebView 렌더링 | Android real device `SM A175N` | APK 설치 후 하단 `노선도` 탭 진입, screenshot 및 UI tree 캡처 | 로컬 전용: `.codex/evidence/854/android-route-map.png`, `.codex/evidence/854/android-route-map-ui.xml` | 공식 수도권 노선도와 `android.webkit.WebView`, 지역/노선/확대 controls, station semantics 표시 |
| zoom control camera update | Android real device `SM A175N` | `확대` 버튼 좌표 탭 후 screenshot 및 UI tree 재캡처 | 로컬 전용: `.codex/evidence/854/android-route-map-zoomed.png`, `.codex/evidence/854/android-route-map-zoomed-ui.xml` | viewport가 확대된 노선도 상태로 유지되고 controls가 계속 표시됨 |
| Android runtime 로그 | Android real device `SM A175N` | 노선도 진입/확대 후 logcat 저장 및 crash 패턴 grep | 로컬 전용: `.codex/evidence/854/android-route-map-logcat.txt`, `.codex/evidence/854/android-route-map-zoomed-logcat.txt` | `FATAL EXCEPTION`, `E/flutter`, `FlutterError`, `Unhandled Exception`, `ANR` 매칭 없음 |
| iOS 실기기 상태 | iOS physical devices | `flutter devices`, `xcrun devicectl list devices` | 명령 출력: iPhone 15 Pro/iPad mini `unavailable`, Flutter code -27 | 실기기 실행 불가. simulator debug build로 iOS 컴파일과 native bridge 연결성 대체 확인 |
| 자동화 검증 | local macOS / GitHub Actions | Flutter/Node test, Android/iOS debug build, CI/Release Artifact checks | 위 `검증` 명령 출력, GitHub Actions `28157425997`, `28157425623` | local 명령과 GitHub checks 모두 pass |

로컬 전용 증거 사유: 이 저장소 정책상 screenshot/recording은 git에 커밋하지 않고, 외부 업로드는 QA 승인 없이 진행하지 않았다. PR에는 증거 종류, 대상, 결과, 로컬 경로를 남긴다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/network_map.dart`의 `_NetworkMapCanvasState` camera 갱신과 `_RouteMapViewportRenderer` 연결
  - station semantics hit target이 pointer를 직접 처리하지 않고 viewport gesture layer가 좌표 기반으로 역을 선택하는 변경
  - `_SelectedLineOverlayPainter`가 source 좌표 overlay를 camera matrix로 viewport에 맞춰 그리는 변경

## 리스크

- iOS 실기기는 현재 unavailable이라 실제 기기 WebView gesture 확인은 못 했다. iOS native wrapper 단위 테스트는 이전 작업에서 검증됐고, 이번 PR에서는 simulator debug build로 컴파일 경계를 확인했다.
- station hit target은 semantics action을 유지하되 pointer 입력은 viewport 좌표 기반 tap으로 처리한다. TalkBack 탐색은 UI tree에 station button semantics가 노출되는 것으로 확인했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
