### PR TITLE
[Fix] 데이터 삭제 결과 카드 대비와 하단 버튼 여백 개선

### DIFF
--- a/apps/mobile/lib/accessible_design.dart
+++ b/apps/mobile/lib/accessible_design.dart
@@ -29,6 +29,20 @@ class EasySubwayTouchTarget {
   static const primary = 60.0;
 }
 
+EdgeInsets easySubwayBottomActionInsets(
+  BuildContext context, {
+  double horizontal = 20,
+  double top = 8,
+  double bottom = 20,
+}) {
+  return EdgeInsets.fromLTRB(
+    horizontal,
+    top,
+    horizontal,
+    bottom + MediaQuery.viewPaddingOf(context).bottom,
+  );
+}
+
 class AccessibleShortcutButton extends StatelessWidget {
   const AccessibleShortcutButton({
     required this.onPressed,

--- a/apps/mobile/lib/accessible_design.dart
+++ b/apps/mobile/lib/accessible_design.dart
@@ -35,12 +35,10 @@ EdgeInsets easySubwayBottomActionInsets(
   double top = 8,
   double bottom = 20,
 }) {
-  return EdgeInsets.fromLTRB(
-    horizontal,
-    top,
-    horizontal,
-    bottom + MediaQuery.viewPaddingOf(context).bottom,
-  );
+  final viewPadding = MediaQuery.viewPaddingOf(context);
+  final left = viewPadding.left > horizontal ? viewPadding.left : horizontal;
+  final right = viewPadding.right > horizontal ? viewPadding.right : horizontal;
+  return EdgeInsets.fromLTRB(left, top, right, bottom + viewPadding.bottom);
 }
 
 class AccessibleShortcutButton extends StatelessWidget {

--- a/apps/mobile/lib/accessible_design.dart
+++ b/apps/mobile/lib/accessible_design.dart
@@ -36,9 +36,13 @@ EdgeInsets easySubwayBottomActionInsets(
   double bottom = 20,
 }) {
   final viewPadding = MediaQuery.viewPaddingOf(context);
+  final viewInsets = MediaQuery.viewInsetsOf(context);
   final left = viewPadding.left > horizontal ? viewPadding.left : horizontal;
   final right = viewPadding.right > horizontal ? viewPadding.right : horizontal;
-  return EdgeInsets.fromLTRB(left, top, right, bottom + viewPadding.bottom);
+  final bottomInset = viewInsets.bottom > viewPadding.bottom
+      ? viewInsets.bottom
+      : viewPadding.bottom;
+  return EdgeInsets.fromLTRB(left, top, right, bottom + bottomInset);
 }
 
 class AccessibleShortcutButton extends StatelessWidget {

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4052,8 +4052,8 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
     final copy = _UserDataDeletionCopy.forScope(widget.deletionScope);
     return Scaffold(
       appBar: AppBar(title: Text(copy.title)),
-      bottomNavigationBar: SafeArea(
-        minimum: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+      bottomNavigationBar: Padding(
+        padding: easySubwayBottomActionInsets(context),
         child: FilledButton.icon(
           key: const Key('dataDeletionStartButton'),
           onPressed: _isDeleting ? null : _confirmAndDelete,
@@ -4222,8 +4222,8 @@ class UserDataDeletionResultScreen extends StatelessWidget {
         title: const Text('삭제 완료'),
         automaticallyImplyLeading: false,
       ),
-      bottomNavigationBar: SafeArea(
-        minimum: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+      bottomNavigationBar: Padding(
+        padding: easySubwayBottomActionInsets(context),
         child: FilledButton.icon(
           key: const Key('dataDeletionResultStartButton'),
           onPressed: onRestart,
@@ -4267,28 +4267,37 @@ class UserDataDeletionResultScreen extends StatelessWidget {
               child: Column(
                 children: [
                   _DataDeletionResultRow(
+                    id: 'favoriteStations',
                     icon: Icons.train_outlined,
                     title: '즐겨찾기한 역',
                     value: '${result.deletedFavoriteStationCount}개 삭제',
                   ),
+                  const SizedBox(height: 12),
                   _DataDeletionResultRow(
+                    id: 'favoriteFacilities',
                     icon: Icons.elevator_outlined,
                     title: '즐겨찾기한 시설',
                     value: '${result.deletedFavoriteFacilityCount}개 삭제',
                   ),
+                  const SizedBox(height: 12),
                   _DataDeletionResultRow(
+                    id: 'favoriteRoutes',
                     icon: Icons.route_outlined,
                     title: '즐겨찾기한 경로',
                     value: '${result.deletedFavoriteRouteCount}개 삭제',
                   ),
+                  const SizedBox(height: 12),
                   _DataDeletionResultRow(
+                    id: 'notifications',
                     icon: Icons.notifications_none,
                     title: '알림 설정',
                     value: result.notificationSettingsDeleted
                         ? '삭제'
                         : '삭제할 항목 없음',
                   ),
+                  const SizedBox(height: 12),
                   _DataDeletionResultRow(
+                    id: 'reportReceipts',
                     icon: Icons.report_outlined,
                     title: deletionScope == UserDataDeletionScope.deviceOnly
                         ? '이 기기의 제보 기록'
@@ -4298,7 +4307,10 @@ class UserDataDeletionResultScreen extends StatelessWidget {
                         : '${result.anonymizedReportCount}건 익명화',
                   ),
                   if (deletionScope != UserDataDeletionScope.deviceOnly)
+                    const SizedBox(height: 12),
+                  if (deletionScope != UserDataDeletionScope.deviceOnly)
                     _DataDeletionResultRow(
+                      id: 'routeFeedback',
                       icon: Icons.rate_review_outlined,
                       title: '경로 의견 연결 정보',
                       value: '${result.anonymizedRouteFeedbackCount}건 익명화',
@@ -4326,24 +4338,106 @@ class UserDataDeletionResultScreen extends StatelessWidget {
 
 class _DataDeletionResultRow extends StatelessWidget {
   const _DataDeletionResultRow({
+    required this.id,
     required this.icon,
     required this.title,
     required this.value,
   });
 
+  final String id;
   final IconData icon;
   final String title;
   final String value;
 
   @override
   Widget build(BuildContext context) {
-    return _PrototypeInfoRow(
-      icon: icon,
-      iconBackground: EasySubwayAccessibleColors.mintSoft,
-      iconColor: EasySubwayAccessibleColors.mintDark,
-      title: title,
-      subtitle: value,
-      trailing: '완료',
+    final textTheme = Theme.of(context).textTheme;
+    final textScaler = MediaQuery.textScalerOf(context).scale(1);
+    final content = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: textTheme.titleMedium?.copyWith(
+            color: EasySubwayAccessibleColors.text,
+            fontWeight: FontWeight.w900,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          value,
+          style: textTheme.bodyMedium?.copyWith(
+            color: EasySubwayAccessibleColors.mutedText,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+      ],
+    );
+    final statusBadge = Container(
+      key: Key('dataDeletionResultStatus-$id'),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: const Color(0xFFDFF4EC),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: const Color(0xFF8AC7B7)),
+      ),
+      child: const Text(
+        '완료',
+        style: TextStyle(
+          color: EasySubwayAccessibleColors.text,
+          fontWeight: FontWeight.w900,
+        ),
+      ),
+    );
+
+    return Semantics(
+      key: Key('dataDeletionResultRow-$id'),
+      container: true,
+      label: '$title, $value, 완료',
+      child: ExcludeSemantics(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Container(
+              key: Key('dataDeletionResultIcon-$id'),
+              width: 56,
+              height: 56,
+              decoration: BoxDecoration(
+                color: const Color(0xFFD3F0E6),
+                borderRadius: BorderRadius.circular(14),
+                border: Border.all(
+                  color: EasySubwayAccessibleColors.mint,
+                  width: 1.5,
+                ),
+              ),
+              child: Icon(
+                icon,
+                color: EasySubwayAccessibleColors.mintDark,
+                size: 30,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: textScaler >= 1.5
+                  ? Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        content,
+                        const SizedBox(height: 8),
+                        statusBadge,
+                      ],
+                    )
+                  : Row(
+                      children: [
+                        Expanded(child: content),
+                        const SizedBox(width: 12),
+                        statusBadge,
+                      ],
+                    ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile/lib/mobility_profile.dart
+++ b/apps/mobile/lib/mobility_profile.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'accessible_design.dart';
+
 class MobilityProfileOption {
   const MobilityProfileOption({
     required this.id,
@@ -148,8 +150,8 @@ class _MobilityProfileScreenState extends State<MobilityProfileScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('이동 조건')),
-      bottomNavigationBar: SafeArea(
-        minimum: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+      bottomNavigationBar: Padding(
+        padding: easySubwayBottomActionInsets(context),
         child: FilledButton.icon(
           key: const Key('mobilityProfileDoneButton'),
           onPressed: _selectedOption == null

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -197,12 +197,13 @@ class StartScreen extends StatelessWidget {
           child: LayoutBuilder(
             builder: (context, constraints) {
               final topGap = (constraints.maxHeight * 0.34).clamp(84.0, 212.0);
+              final bottomGap = 35 + MediaQuery.viewPaddingOf(context).bottom;
               return SingleChildScrollView(
                 child: ConstrainedBox(
                   constraints: BoxConstraints(minHeight: constraints.maxHeight),
                   child: IntrinsicHeight(
                     child: Padding(
-                      padding: const EdgeInsets.fromLTRB(24, 48, 24, 35),
+                      padding: EdgeInsets.fromLTRB(24, 48, 24, bottomGap),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
@@ -324,16 +325,6 @@ class OnboardingIntroScreen extends StatelessWidget {
                 ),
               ),
               child: const Text('기본 설정으로 시작'),
-            ),
-            const SizedBox(height: 7),
-            Text(
-              '천천히 이동 · 큰 글씨 · 단순 보기 적용',
-              textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: const Color(0xFF647686),
-                fontWeight: FontWeight.w700,
-                height: 1.3,
-              ),
             ),
           ],
         ),

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1178,8 +1178,8 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('길찾기')),
-      bottomNavigationBar: SafeArea(
-        minimum: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+      bottomNavigationBar: Padding(
+        padding: easySubwayBottomActionInsets(context),
         child: AnimatedBuilder(
           animation: _controller,
           builder: (context, _) {

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -42,6 +42,22 @@ void main() {
     expect(storage.deletedKeys, isEmpty);
   });
 
+  testWidgets('온보딩 소개는 기본 시작 버튼 아래 보조 문구를 표시하지 않는다', (tester) async {
+    tester.view.physicalSize = const Size(1080, 2400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OnboardingIntroScreen(onConfigure: () {}, onSkip: () {}),
+      ),
+    );
+
+    expect(find.byKey(const Key('onboardingIntroSkipButton')), findsOneWidget);
+    expect(find.text('천천히 이동 · 큰 글씨 · 단순 보기 적용'), findsNothing);
+  });
+
   testWidgets('온보딩은 이동 조건과 보기 설정을 선택한 뒤 완료 결과를 반환한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     OnboardingResult? completedResult;

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2509,6 +2509,26 @@ void main() {
     expect(find.textContaining('연결 정보'), findsNothing);
     expect(find.textContaining('익명화'), findsNothing);
     expect(find.textContaining('local-user'), findsNothing);
+    expect(
+      find.byKey(const Key('dataDeletionResultStatus-favoriteStations')),
+      findsOneWidget,
+    );
+    final stationIconBadge = tester.widget<Container>(
+      find.byKey(const Key('dataDeletionResultIcon-favoriteStations')),
+    );
+    final stationIconDecoration = stationIconBadge.decoration! as BoxDecoration;
+    expect(stationIconDecoration.border, isNotNull);
+    expect(
+      stationIconDecoration.color,
+      isNot(EasySubwayAccessibleColors.mintSoft),
+    );
+    final stationRow = tester.getRect(
+      find.byKey(const Key('dataDeletionResultRow-favoriteStations')),
+    );
+    final facilityRow = tester.getRect(
+      find.byKey(const Key('dataDeletionResultRow-favoriteFacilities')),
+    );
+    expect(facilityRow.top - stationRow.bottom, greaterThanOrEqualTo(10));
 
     await tester.tap(find.byKey(const Key('dataDeletionResultStartButton')));
     await tester.pumpAndSettle();
@@ -2524,6 +2544,42 @@ void main() {
     expect(onboardingStore.savedResult, isNull);
     expect(draftTargetStore.target, isNull);
     expect(find.byKey(const Key('startScreenStartButton')), findsOneWidget);
+  });
+
+  testWidgets('데이터 삭제 결과 시작 버튼은 Android 시스템 내비게이션 바와 여백을 둔다', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.viewPadding = const FakeViewPadding(bottom: 34);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetViewPadding);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: UserDataDeletionResultScreen(
+          result: const UserDataDeletionResult(
+            userId: 'anonymous-user-1',
+            deletedFavoriteStationCount: 1,
+            deletedFavoriteFacilityCount: 1,
+            deletedFavoriteRouteCount: 1,
+            anonymizedRouteFeedbackCount: 1,
+            notificationSettingsDeleted: true,
+            deletedRegisteredDeviceCount: 1,
+            deletedPushNotificationCount: 1,
+            mobilityProfileDeleted: true,
+            anonymizedReportCount: 1,
+          ),
+          deletionScope: UserDataDeletionScope.deviceOnly,
+          onRestart: () {},
+        ),
+      ),
+    );
+
+    final screenBottom =
+        tester.view.physicalSize.height / tester.view.devicePixelRatio;
+    final buttonRect = tester.getRect(
+      find.byKey(const Key('dataDeletionResultStartButton')),
+    );
+
+    expect(screenBottom - buttonRect.bottom, greaterThanOrEqualTo(54));
   });
 
   testWidgets('도움말은 원격 삭제 저장소에서 서버 삭제 범위를 유지해 안내한다', (tester) async {
@@ -3640,6 +3696,31 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('길찾기 하단 버튼은 Android 시스템 내비게이션 바와 여백을 둔다', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.viewPadding = const FakeViewPadding(bottom: 34);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetViewPadding);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(),
+          stationRepository: FakeStationSearchRepository(),
+          initialMobilityType: 'SENIOR',
+        ),
+      ),
+    );
+
+    final screenBottom =
+        tester.view.physicalSize.height / tester.view.devicePixelRatio;
+    final buttonRect = tester.getRect(
+      find.byKey(const Key('routeSearchSubmitButton')),
+    );
+
+    expect(screenBottom - buttonRect.bottom, greaterThanOrEqualTo(54));
   });
 
   testWidgets('역 검색 화면은 최근 검색어를 탭해 빠르게 다시 검색한다', (tester) async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3753,6 +3753,36 @@ void main() {
     expect(390 - buttonRect.right, greaterThanOrEqualTo(56));
   });
 
+  testWidgets('길찾기 하단 버튼은 키보드가 열려도 가려지지 않는다', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    tester.view.viewPadding = const FakeViewPadding(bottom: 34);
+    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetViewPadding);
+    addTearDown(tester.view.resetViewInsets);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(),
+          stationRepository: FakeStationSearchRepository(),
+          initialMobilityType: 'SENIOR',
+        ),
+      ),
+    );
+
+    final visibleBottom =
+        tester.view.physicalSize.height / tester.view.devicePixelRatio -
+        tester.view.viewInsets.bottom;
+    final buttonRect = tester.getRect(
+      find.byKey(const Key('routeSearchSubmitButton')),
+    );
+
+    expect(visibleBottom - buttonRect.bottom, greaterThanOrEqualTo(20));
+  });
+
   testWidgets('역 검색 화면은 최근 검색어를 탭해 빠르게 다시 검색한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final repository = FakeStationSearchRepository(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3723,6 +3723,36 @@ void main() {
     expect(screenBottom - buttonRect.bottom, greaterThanOrEqualTo(54));
   });
 
+  testWidgets('길찾기 하단 버튼은 가로 safe-area 안쪽에 배치된다', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    tester.view.viewPadding = const FakeViewPadding(
+      left: 44,
+      right: 56,
+      bottom: 34,
+    );
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetViewPadding);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(),
+          stationRepository: FakeStationSearchRepository(),
+          initialMobilityType: 'SENIOR',
+        ),
+      ),
+    );
+
+    final buttonRect = tester.getRect(
+      find.byKey(const Key('routeSearchSubmitButton')),
+    );
+
+    expect(buttonRect.left, greaterThanOrEqualTo(44));
+    expect(390 - buttonRect.right, greaterThanOrEqualTo(56));
+  });
+
   testWidgets('역 검색 화면은 최근 검색어를 탭해 빠르게 다시 검색한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final repository = FakeStationSearchRepository(


### PR DESCRIPTION
## 관련 이슈

close #858

## 작업 배경

QA 확인에서 데이터 삭제 결과 화면의 처리 결과 아이콘 배지가 너무 연하고, 각 처리 결과 행이 세로로 붙어 보여 항목 구분이 약했다. Android 시스템 내비게이션 바가 있는 기기에서는 `길찾기`, `처음부터 시작`, `쉬운 지하철 시작하기` 같은 하단 CTA가 시스템 바와 가까워 보였고, 온보딩 소개의 기본 시작 버튼 아래 보조 문구는 의미가 불명확했다.

## 작업 내용

- 데이터 삭제 결과 전용 row 레이아웃을 만들고 아이콘 배지 테두리, 상태 badge, 행 간격을 고정했다.
- 하단 CTA 패딩 helper를 추가해 Android `viewPadding.bottom`, `viewInsets.bottom`, 가로 safe-area와 앱 자체 하단 여백을 함께 반영하도록 정리했다.
- 길찾기, 데이터 삭제 시작/결과, 이동 조건 완료 CTA에 동일한 하단 여백 기준을 적용했다.
- 시작 화면 하단 여백을 시스템 바 높이만큼 추가하고, 온보딩 소개의 불명확한 기본 시작 보조 문구를 제거했다.
- widget test로 처리 결과 row 대비/간격, 하단 CTA 여백, 가로 safe-area, keyboard inset, 온보딩 보조 문구 제거를 고정했다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/onboarding_test.dart`: 17 tests passed
  - `cd apps/mobile && flutter test test/widget_test.dart`: 140 tests passed
  - `cd apps/mobile && flutter test`: 440 tests passed
  - `cd apps/mobile && flutter analyze`: No issues found
  - Android emulator `emulator-5554`에서 `flutter run -d emulator-5554`로 설치 후 화면 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 길찾기 하단 CTA | Android emulator API 36 | UI tree bounds와 screenshot 확인 | 로컬 `.codex/evidence/858/02-route-search-bottom-button.png`, `.codex/evidence/858/02-route-search-bottom-button.xml` | `길찾기` CTA bounds `[53,2127][1028,2285]`로 시스템 바 위 여백 확보 |
| 데이터 삭제 결과 카드 | Android emulator API 36 | 실제 삭제 완료 흐름 후 screenshot/UI tree 확인 | 로컬 `.codex/evidence/858/03-data-deletion-result.png`, `.codex/evidence/858/03-data-deletion-result.xml` | 처리 결과 row가 독립 bounds로 분리되고 상태가 각 row semantics에 포함됨 |
| 시작 화면 하단 CTA | Android emulator API 36 | 데이터 삭제 후 초기 화면 screenshot/UI tree 확인 | 로컬 `.codex/evidence/858/04-start-after-reset.png`, `.codex/evidence/858/04-start-after-reset.xml` | `쉬운 지하철 시작하기` CTA bounds `[63,2088][1017,2245]`로 하단 시스템 바와 분리됨 |
| 온보딩 소개 보조 문구 제거 | Android emulator API 36 | 소개 화면 screenshot/UI tree와 문자열 검색 확인 | 로컬 `.codex/evidence/858/05-onboarding-intro-no-caption.png`, `.codex/evidence/858/05-onboarding-intro-no-caption.xml` | `천천히 이동 · 큰 글씨 · 단순 보기 적용` 문구가 UI tree에 없음 |

스크린샷과 UI tree는 GitHub CLI/API에서 로컬 바이너리 첨부 업로드를 제공하지 않아 PR에 직접 첨부하지 않고 로컬 evidence 폴더에 보관했다. 파일은 git에 커밋하지 않았다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `easySubwayBottomActionInsets`가 시스템 바, 키보드, 가로 safe-area를 하단 CTA 여백에 반영하는 점
  - `_DataDeletionResultRow`가 삭제 결과 화면 전용 row로 바뀐 점
  - 온보딩 소개의 기본 시작 보조 문구 제거가 QA 요청 범위에 포함된 점

## 리스크

- 하단 CTA가 시스템 바 높이만큼 더 올라가므로 일부 작은 화면에서는 본문 하단 노출 영역이 줄어든다. 버튼 겹침 방지를 우선했고, 관련 widget test와 emulator screenshot으로 확인했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
