### PR TITLE
[Fix] 경로 경고 문구와 이동 부담 등급 근거 분리

### DIFF
--- a/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
+++ b/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
@@ -607,7 +607,7 @@ Map<String, Object?> _routeStepToJson(RouteSearchStep step) {
 }
 
 Map<String, Object?> _routeWarningToJson(RouteSearchWarning warning) {
-  return {'code': warning.code, 'message': warning.message};
+  return {'code': warning.code};
 }
 
 String _isoFromSql(DateTime value) => value.toUtc().toIso8601String();

--- a/apps/mobile/lib/features/internal_route/data/local_internal_route_repository.dart
+++ b/apps/mobile/lib/features/internal_route/data/local_internal_route_repository.dart
@@ -113,12 +113,7 @@ class LocalInternalRouteRepository implements InternalRouteRepository {
       totalEstimatedSeconds: result.totalEstimatedSeconds,
       steps: steps,
       warnings: result.warningCodes
-          .map(
-            (code) => InternalRouteWarning(
-              code: code,
-              message: '역 내부 이동 전 현장 안내를 확인해 주세요.',
-            ),
-          )
+          .map((code) => InternalRouteWarning(code: code))
           .toList(growable: false),
       blockedReasons: const [],
     );

--- a/apps/mobile/lib/internal_route.dart
+++ b/apps/mobile/lib/internal_route.dart
@@ -328,7 +328,9 @@ class InternalRouteResult {
       totalBurdenLabel,
     ];
     if (warnings.isNotEmpty) {
-      parts.add('주의 ${warnings.map((warning) => warning.message).join(', ')}');
+      parts.add(
+        '주의 ${warnings.map((warning) => warning.userMessage).join(', ')}',
+      );
     }
     if (steps.isNotEmpty) {
       parts.add('이동 단계 ${steps.map((step) => step.semanticLabel).join(', ')}');
@@ -424,17 +426,30 @@ class InternalRouteStep {
 }
 
 class InternalRouteWarning {
-  const InternalRouteWarning({required this.code, required this.message});
+  const InternalRouteWarning({required this.code, this.rawMessage = ''});
 
   factory InternalRouteWarning.fromJson(Map<String, Object?> json) {
     return InternalRouteWarning(
       code: _requiredInternalRouteString(json, 'code'),
-      message: _requiredInternalRouteString(json, 'message'),
+      rawMessage: _optionalInternalRouteString(json, 'message'),
     );
   }
 
   final String code;
-  final String message;
+  final String rawMessage;
+
+  String get message => userMessage;
+
+  String get userMessage {
+    return switch (code.trim()) {
+      'LOW_DATA_CONFIDENCE' => '일부 시설 정보는 확인이 필요합니다.',
+      'STALE_ACCESSIBILITY_DATA' => '접근성 시설 정보가 최근 확인되지 않았습니다.',
+      'STAIR_ONLY_ACCESS' => '계단 포함 구간이 있습니다.',
+      'STAIR_ONLY_ACCESS_UNKNOWN' => '계단 없는 동선 여부를 확인할 수 없습니다.',
+      'ACCESSIBILITY_STATE_UNKNOWN' => '접근성 시설 이용 가능 여부를 확인할 수 없습니다.',
+      _ => '일부 이동 정보를 확인하지 못했어요.',
+    };
+  }
 }
 
 enum InternalRouteViewStatus { loading, success, failure }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1275,7 +1275,8 @@ class _HomeScreenState extends State<HomeScreen> {
       await refreshHomeState();
     }
 
-    Future<void> openRouteSearch() async {
+    Future<void> openRouteSearch([String? mobilityType]) async {
+      final routeSearchMobilityType = mobilityType ?? initialMobilityType;
       await Navigator.of(context).push(
         MaterialPageRoute<void>(
           builder: (_) => RouteSearchScreen(
@@ -1283,7 +1284,7 @@ class _HomeScreenState extends State<HomeScreen> {
             stationRepository: repository,
             routeFeedbackRepository: routeFeedbackRepository,
             favoriteRouteRepository: favoriteRouteRepository,
-            initialMobilityType: initialMobilityType,
+            initialMobilityType: routeSearchMobilityType,
             initialDraft: _routeDraftController.draft,
             simpleViewEnabled: simpleViewEnabled,
           ),
@@ -3278,7 +3279,7 @@ class FavoriteHomeScreen extends StatefulWidget {
   final InternalRouteRepository internalRouteRepository;
   final RouteDraftController routeDraftController;
   final String initialMobilityType;
-  final Future<void> Function()? onOpenRouteSearch;
+  final Future<void> Function([String? mobilityType])? onOpenRouteSearch;
 
   @override
   State<FavoriteHomeScreen> createState() => _FavoriteHomeScreenState();
@@ -3431,8 +3432,12 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
         nameKo: favorite.destinationStationName,
       ),
     );
+    final openRouteSearch = widget.onOpenRouteSearch;
+    if (openRouteSearch == null) {
+      return;
+    }
     Navigator.of(context).popUntil((route) => route.isFirst);
-    unawaited(widget.onOpenRouteSearch!());
+    unawaited(openRouteSearch(favorite.mobilityType));
   }
 
   void _openFavoriteStations() {

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1309,6 +1309,7 @@ class _HomeScreenState extends State<HomeScreen> {
             internalRouteRepository: internalRouteRepository,
             routeDraftController: _routeDraftController,
             initialMobilityType: initialMobilityType,
+            onOpenRouteSearch: openRouteSearch,
           ),
         ),
       );
@@ -3263,6 +3264,7 @@ class FavoriteHomeScreen extends StatefulWidget {
     required this.internalRouteRepository,
     required this.routeDraftController,
     required this.initialMobilityType,
+    this.onOpenRouteSearch,
     super.key,
   });
 
@@ -3276,6 +3278,7 @@ class FavoriteHomeScreen extends StatefulWidget {
   final InternalRouteRepository internalRouteRepository;
   final RouteDraftController routeDraftController;
   final String initialMobilityType;
+  final Future<void> Function()? onOpenRouteSearch;
 
   @override
   State<FavoriteHomeScreen> createState() => _FavoriteHomeScreenState();
@@ -3405,9 +3408,31 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
     unawaited(
       _openFavoriteListScreen(
         title: '즐겨찾기한 경로',
-        child: FavoriteRouteListContent(repository: repository),
+        child: FavoriteRouteListContent(
+          repository: repository,
+          onSearchAgain: widget.onOpenRouteSearch == null
+              ? null
+              : _openRouteSearchFromFavorite,
+        ),
       ),
     );
+  }
+
+  void _openRouteSearchFromFavorite(FavoriteRoute favorite) {
+    widget.routeDraftController.setOrigin(
+      RouteDraftStation(
+        id: favorite.originStationId,
+        nameKo: favorite.originStationName,
+      ),
+    );
+    widget.routeDraftController.setDestination(
+      RouteDraftStation(
+        id: favorite.destinationStationId,
+        nameKo: favorite.destinationStationName,
+      ),
+    );
+    Navigator.of(context).popUntil((route) => route.isFirst);
+    unawaited(widget.onOpenRouteSearch!());
   }
 
   void _openFavoriteStations() {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -682,8 +682,7 @@ class RouteSearchResult {
     };
   }
 
-  String get scoreLabel =>
-      isBlocked || warnings.isNotEmpty ? '이동 부담 확인 필요' : '이동 부담 낮음';
+  String get scoreLabel => burdenLevelLabel;
 
   String get lineLabel => lineName.isEmpty ? '노선 확인 필요' : lineName;
 
@@ -718,21 +717,24 @@ class RouteSearchResult {
     if (isBlocked) {
       return '다른 경로 필요';
     }
-    return warnings.isEmpty ? '이동 부담 낮음' : '확인 필요 구간 있음';
+    return burdenLevelLabel;
   }
 
   String get guidanceLabel {
     if (isBlocked) {
-      return '다른 경로가 필요합니다';
+      return '현재 조건으로 안내 어려움';
     }
-    return status == 'FOUND' ? '이동할 수 있는 경로' : '확인이 필요합니다';
+    if (status == 'FOUND' && warnings.isEmpty) {
+      return '안내 가능';
+    }
+    return '확인 후 이동';
   }
 
   IconData get guidanceIcon {
     if (isBlocked) {
       return Icons.priority_high;
     }
-    return status == 'FOUND' ? Icons.check_circle : Icons.warning_amber;
+    return guidanceLabel == '안내 가능' ? Icons.check_circle : Icons.warning_amber;
   }
 
   String get attentionLabel {
@@ -787,6 +789,41 @@ class RouteSearchResult {
       parts.add('확인 요청 $_routeBlockedConfirmationNotice');
     }
     return parts.join(', ');
+  }
+
+  String get burdenLevelLabel {
+    if (isBlocked) {
+      return '이동 부담 확인 필요';
+    }
+    if (movementSteps.isEmpty) {
+      return '이동 부담 확인 필요';
+    }
+    if (_hasHighBurdenFact) {
+      return '이동 부담 높음';
+    }
+    if (_hasMediumBurdenFact) {
+      return '이동 부담 보통';
+    }
+    return '이동 부담 낮음';
+  }
+
+  bool get _hasHighBurdenFact {
+    return walkingDistanceMeters >= 1000 ||
+        transferCount >= 2 ||
+        movementSteps.any(
+          (step) =>
+              step.includesStairs || _routeStepStairState(step) == 'stairOnly',
+        );
+  }
+
+  bool get _hasMediumBurdenFact {
+    return walkingDistanceMeters >= 400 ||
+        transferCount >= 1 ||
+        movementSteps.any(
+          (step) =>
+              step.requiresAccessibilityCheck ||
+              _routeStepStairState(step) == 'unknown',
+        );
   }
 }
 
@@ -943,14 +980,14 @@ String _routeDistanceLabel(int distanceMeters) {
   return '${kilometers.toStringAsFixed(1)}km';
 }
 
-String _routeWarningLabel(String code, String message) {
+String _routeWarningLabel(String code) {
   return switch (code.trim()) {
     'LOW_DATA_CONFIDENCE' => '일부 시설 정보는 확인이 필요합니다.',
     'STALE_ACCESSIBILITY_DATA' => '접근성 시설 정보가 최근 확인되지 않았습니다.',
     'STAIR_ONLY_ACCESS' => '계단 포함 구간이 있습니다.',
     'STAIR_ONLY_ACCESS_UNKNOWN' => '계단 없는 동선 여부를 확인할 수 없습니다.',
     'ACCESSIBILITY_STATE_UNKNOWN' => '접근성 시설 이용 가능 여부를 확인할 수 없습니다.',
-    _ => '이동 전 현장 안내를 확인해 주세요.',
+    _ => '일부 이동 정보를 확인하지 못했어요.',
   };
 }
 
@@ -987,19 +1024,19 @@ String _routeStepDetailLabel({required String stepType}) {
 }
 
 class RouteSearchWarning {
-  const RouteSearchWarning({required this.code, required this.message});
+  const RouteSearchWarning({required this.code, this.message = ''});
 
   factory RouteSearchWarning.fromJson(Map<String, Object?> json) {
     return RouteSearchWarning(
       code: _requiredRouteString(json, 'code'),
-      message: _requiredRouteString(json, 'message'),
+      message: _optionalRouteString(json, 'message'),
     );
   }
 
   final String code;
   final String message;
 
-  String get userMessage => _routeWarningLabel(code, message);
+  String get userMessage => _routeWarningLabel(code);
 }
 
 enum RouteSearchViewStatus { idle, loading, success, failure }
@@ -4263,9 +4300,14 @@ class FavoriteRouteListController extends ChangeNotifier {
 }
 
 class FavoriteRouteListScreen extends StatefulWidget {
-  const FavoriteRouteListScreen({required this.repository, super.key});
+  const FavoriteRouteListScreen({
+    required this.repository,
+    this.onSearchAgain,
+    super.key,
+  });
 
   final FavoriteRouteRepository repository;
+  final ValueChanged<FavoriteRoute>? onSearchAgain;
 
   @override
   State<FavoriteRouteListScreen> createState() =>
@@ -4277,15 +4319,23 @@ class _FavoriteRouteListScreenState extends State<FavoriteRouteListScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('즐겨찾기 경로')),
-      body: FavoriteRouteListContent(repository: widget.repository),
+      body: FavoriteRouteListContent(
+        repository: widget.repository,
+        onSearchAgain: widget.onSearchAgain,
+      ),
     );
   }
 }
 
 class FavoriteRouteListContent extends StatefulWidget {
-  const FavoriteRouteListContent({required this.repository, super.key});
+  const FavoriteRouteListContent({
+    required this.repository,
+    this.onSearchAgain,
+    super.key,
+  });
 
   final FavoriteRouteRepository repository;
+  final ValueChanged<FavoriteRoute>? onSearchAgain;
 
   @override
   State<FavoriteRouteListContent> createState() =>
@@ -4317,6 +4367,7 @@ class _FavoriteRouteListContentState extends State<FavoriteRouteListContent> {
           state: _controller.state,
           onRetry: _controller.load,
           onRemove: _controller.remove,
+          onSearchAgain: widget.onSearchAgain,
         ),
       ),
     );
@@ -4328,11 +4379,13 @@ class _FavoriteRouteListBody extends StatelessWidget {
     required this.state,
     required this.onRetry,
     required this.onRemove,
+    required this.onSearchAgain,
   });
 
   final FavoriteRouteListState state;
   final VoidCallback onRetry;
   final ValueChanged<FavoriteRoute> onRemove;
+  final ValueChanged<FavoriteRoute>? onSearchAgain;
 
   @override
   Widget build(BuildContext context) {
@@ -4398,6 +4451,7 @@ class _FavoriteRouteListBody extends StatelessWidget {
                     favorite.favoriteRouteId,
                   ),
                   onRemove: onRemove,
+                  onSearchAgain: onSearchAgain,
                 ),
             ],
           ),
@@ -4412,11 +4466,13 @@ class _FavoriteRouteTile extends StatelessWidget {
     required this.favorite,
     required this.isRemoving,
     required this.onRemove,
+    required this.onSearchAgain,
   });
 
   final FavoriteRoute favorite;
   final bool isRemoving;
   final ValueChanged<FavoriteRoute> onRemove;
+  final ValueChanged<FavoriteRoute>? onSearchAgain;
 
   @override
   Widget build(BuildContext context) {
@@ -4430,8 +4486,21 @@ class _FavoriteRouteTile extends StatelessWidget {
       children: [
         _FavoriteRouteSummaryCard(favorite: favorite),
         Row(
-          mainAxisAlignment: MainAxisAlignment.end,
           children: [
+            if (onSearchAgain != null) ...[
+              Expanded(
+                child: OutlinedButton.icon(
+                  key: Key(
+                    'favoriteRouteSearchAgain-${favorite.favoriteRouteId}',
+                  ),
+                  onPressed: isRemoving ? null : () => onSearchAgain!(favorite),
+                  icon: const Icon(Icons.search),
+                  label: const Text('최신 경로 다시 찾기'),
+                ),
+              ),
+              const SizedBox(width: 8),
+            ] else
+              const Spacer(),
             if (isRemoving) ...[
               const SizedBox.square(
                 dimension: 18,

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -233,7 +233,7 @@ void main() {
     expect(result.summaryTitle, '상록수에서 사당까지');
     expect(result.lineName, '수도권 4호선');
     expect(result.statusLabel, '경로를 찾았습니다');
-    expect(result.scoreLabel, '이동 부담 확인 필요');
+    expect(result.scoreLabel, '이동 부담 보통');
     expect(result.scoreLabel, isNot(contains('92점')));
     expect(result.recommendationReasons, [
       '엘리베이터 동선을 우선했어요',
@@ -255,8 +255,8 @@ void main() {
       containsAll(['LOW_DATA_CONFIDENCE', 'STALE_ACCESSIBILITY_DATA']),
     );
     expect(
-      result.warnings.map((warning) => warning.message),
-      contains('접근성 시설 정보가 최근 30일 이내 확인되지 않았습니다. 이동 전 역 상세 정보를 확인하세요.'),
+      result.warnings.map((warning) => warning.userMessage),
+      contains('접근성 시설 정보가 최근 확인되지 않았습니다.'),
     );
     expect(result.semanticLabel, isNot(contains('시간 확인 필요')));
     expect(result.semanticLabel, isNot(contains('거리 확인 필요')));
@@ -327,9 +327,83 @@ void main() {
     final result = _sampleRouteSearchResult(status: 'REVIEW_REQUIRED');
 
     expect(result.statusLabel, '확인이 필요합니다');
-    expect(result.guidanceLabel, '확인이 필요합니다');
+    expect(result.guidanceLabel, '확인 후 이동');
     expect(result.guidanceIcon, Icons.warning_amber);
     expect(result.semanticLabel, isNot(contains('이동할 수 있는 경로')));
+  });
+
+  test('경로 warning은 code만으로 사용자 문구를 만들고 서버 원문을 읽지 않는다', () {
+    final result = RouteSearchResult.fromJson({
+      'routeSearchId': 'route-unknown-warning',
+      'originStationId': 'station-sangnoksu',
+      'originStationName': '상록수',
+      'destinationStationId': 'station-sadang',
+      'destinationStationName': '사당',
+      'mobilityType': 'SENIOR',
+      'status': 'FOUND',
+      'lineId': 'seoul-4',
+      'lineName': '수도권 4호선',
+      'score': 92,
+      'steps': <Object?>[],
+      'warnings': [
+        {'code': 'SERVER_RAW_WARNING'},
+      ],
+      'recommendationReasons': <Object?>[],
+      'blockedReasons': <Object?>[],
+      'createdAt': '2026-06-13T04:20:00',
+    });
+
+    expect(result.warnings.single.userMessage, '일부 이동 정보를 확인하지 못했어요.');
+    expect(result.semanticLabel, contains('일부 이동 정보를 확인하지 못했어요.'));
+    expect(result.semanticLabel, isNot(contains('SERVER_RAW_WARNING')));
+  });
+
+  test('경로 이동 부담은 warning 없음만으로 낮음이 되지 않는다', () {
+    final longWalkingResult = _sampleRouteSearchResult(
+      warnings: const [],
+      steps: const [
+        RouteSearchStep(
+          sequence: 1,
+          stepType: 'entry',
+          title: '출발역 승강장 접근',
+          description: '승강장까지 길게 이동합니다.',
+          lineId: 'seoul-4',
+          lineName: '수도권 4호선',
+          fromStationId: 'station-sangnoksu',
+          toStationId: 'station-sangnoksu',
+          estimatedMinutes: 18,
+          distanceMeters: 1200,
+          includesStairs: false,
+          stairAccessState: 'stepFree',
+          requiresAccessibilityCheck: false,
+        ),
+      ],
+    );
+    final uncertainResult = _sampleRouteSearchResult(
+      warnings: const [],
+      steps: const [
+        RouteSearchStep(
+          sequence: 1,
+          stepType: 'entry',
+          title: '출발역 승강장 접근',
+          description: '승강장까지 이동합니다.',
+          lineId: 'seoul-4',
+          lineName: '수도권 4호선',
+          fromStationId: 'station-sangnoksu',
+          toStationId: 'station-sangnoksu',
+          estimatedMinutes: 3,
+          distanceMeters: 80,
+          includesStairs: false,
+          stairAccessState: 'unknown',
+          requiresAccessibilityCheck: true,
+        ),
+      ],
+    );
+
+    expect(longWalkingResult.guidanceLabel, '안내 가능');
+    expect(longWalkingResult.scoreLabel, '이동 부담 높음');
+    expect(uncertainResult.guidanceLabel, '안내 가능');
+    expect(uncertainResult.scoreLabel, '이동 부담 보통');
   });
 
   test('경로 검색 결과 음성 안내는 내부 식별자와 운영 출처 값을 읽지 않는다', () {
@@ -699,6 +773,12 @@ RouteSearchResult _sampleRouteSearchResult({
     '계단 없는 출구를 확인했어요',
     '천천히 이동하기 쉬운 동선을 확인했어요',
   ],
+  List<RouteSearchWarning> warnings = const [
+    RouteSearchWarning(
+      code: 'LOW_DATA_CONFIDENCE',
+      message: '일부 시설 정보는 확인이 필요합니다.',
+    ),
+  ],
 }) {
   return RouteSearchResult(
     routeSearchId: 'route-1',
@@ -712,12 +792,7 @@ RouteSearchResult _sampleRouteSearchResult({
     lineName: '수도권 4호선',
     score: 92,
     steps: steps,
-    warnings: const [
-      RouteSearchWarning(
-        code: 'LOW_DATA_CONFIDENCE',
-        message: '일부 시설 정보는 확인이 필요합니다.',
-      ),
-    ],
+    warnings: warnings,
     recommendationReasons: recommendationReasons,
     blockedReasons: [],
     createdAt: '2026-06-13T04:20:00',

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -51,9 +51,15 @@ OnboardingState _completedOnboardingStateWithPreferences({
   );
 }
 
-Future<void> _openFavoriteList(WidgetTester tester, {Key? tabKey}) async {
+Future<void> _openFavoriteList(
+  WidgetTester tester, {
+  Key? tabKey,
+  RouteDraftController? routeDraftController,
+  Future<void> Function(RouteDraft draft)? onOpenRouteSearch,
+}) async {
   final homeContext = tester.element(find.byType(HomeScreen));
   final home = tester.widget<HomeScreen>(find.byType(HomeScreen));
+  final draftController = routeDraftController ?? RouteDraftController();
   unawaited(
     Navigator.of(homeContext).push(
       MaterialPageRoute<void>(
@@ -66,8 +72,11 @@ Future<void> _openFavoriteList(WidgetTester tester, {Key? tabKey}) async {
           locationProvider: home.locationProvider,
           facilityReportDraftTargetStore: home.facilityReportDraftTargetStore,
           internalRouteRepository: home.internalRouteRepository,
-          routeDraftController: RouteDraftController(),
+          routeDraftController: draftController,
           initialMobilityType: home.initialMobilityType,
+          onOpenRouteSearch: onOpenRouteSearch == null
+              ? null
+              : () => onOpenRouteSearch(draftController.draft),
         ),
       ),
     ),
@@ -3181,6 +3190,8 @@ void main() {
     final favoriteRouteRepository = FakeFavoriteRouteRepository(
       favorites: [_favoriteRoute()],
     );
+    final routeDraftController = RouteDraftController();
+    RouteDraft? searchAgainDraft;
 
     try {
       await tester.pumpWidget(
@@ -3196,7 +3207,13 @@ void main() {
         ),
       );
 
-      await _openFavoriteList(tester);
+      await _openFavoriteList(
+        tester,
+        routeDraftController: routeDraftController,
+        onOpenRouteSearch: (draft) async {
+          searchAgainDraft = draft;
+        },
+      );
 
       expect(find.text('즐겨찾기한 경로'), findsOneWidget);
       expect(find.text('상록수에서 사당까지'), findsOneWidget);
@@ -3224,6 +3241,28 @@ void main() {
           isButton: true,
           hasTapAction: true,
         ),
+      );
+      expect(
+        find.byKey(const Key('favoriteRouteSearchAgain-route-1')),
+        findsOneWidget,
+      );
+
+      await tester.tap(
+        find.byKey(const Key('favoriteRouteSearchAgain-route-1')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(searchAgainDraft?.origin?.id, 'station-sangnoksu');
+      expect(searchAgainDraft?.origin?.nameKo, '상록수');
+      expect(searchAgainDraft?.destination?.id, 'station-sadang');
+      expect(searchAgainDraft?.destination?.nameKo, '사당');
+
+      await _openFavoriteList(
+        tester,
+        routeDraftController: routeDraftController,
+        onOpenRouteSearch: (draft) async {
+          searchAgainDraft = draft;
+        },
       );
 
       await tester.tap(find.byKey(const Key('favoriteRouteMore-route-1')));

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -55,7 +55,8 @@ Future<void> _openFavoriteList(
   WidgetTester tester, {
   Key? tabKey,
   RouteDraftController? routeDraftController,
-  Future<void> Function(RouteDraft draft)? onOpenRouteSearch,
+  Future<void> Function(RouteDraft draft, String mobilityType)?
+  onOpenRouteSearch,
 }) async {
   final homeContext = tester.element(find.byType(HomeScreen));
   final home = tester.widget<HomeScreen>(find.byType(HomeScreen));
@@ -76,7 +77,10 @@ Future<void> _openFavoriteList(
           initialMobilityType: home.initialMobilityType,
           onOpenRouteSearch: onOpenRouteSearch == null
               ? null
-              : () => onOpenRouteSearch(draftController.draft),
+              : ([mobilityType]) => onOpenRouteSearch(
+                  draftController.draft,
+                  mobilityType ?? home.initialMobilityType,
+                ),
         ),
       ),
     ),
@@ -3192,6 +3196,7 @@ void main() {
     );
     final routeDraftController = RouteDraftController();
     RouteDraft? searchAgainDraft;
+    String? searchAgainMobilityType;
 
     try {
       await tester.pumpWidget(
@@ -3210,8 +3215,9 @@ void main() {
       await _openFavoriteList(
         tester,
         routeDraftController: routeDraftController,
-        onOpenRouteSearch: (draft) async {
+        onOpenRouteSearch: (draft, mobilityType) async {
           searchAgainDraft = draft;
+          searchAgainMobilityType = mobilityType;
         },
       );
 
@@ -3256,12 +3262,14 @@ void main() {
       expect(searchAgainDraft?.origin?.nameKo, '상록수');
       expect(searchAgainDraft?.destination?.id, 'station-sadang');
       expect(searchAgainDraft?.destination?.nameKo, '사당');
+      expect(searchAgainMobilityType, 'SENIOR');
 
       await _openFavoriteList(
         tester,
         routeDraftController: routeDraftController,
-        onOpenRouteSearch: (draft) async {
+        onOpenRouteSearch: (draft, mobilityType) async {
           searchAgainDraft = draft;
+          searchAgainMobilityType = mobilityType;
         },
       );
 
@@ -3336,6 +3344,44 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('즐겨찾기한 경로가 없습니다.'), findsOneWidget);
+  });
+
+  testWidgets('즐겨찾기 경로 다시 찾기는 저장된 이동 조건으로 연다', (tester) async {
+    final favoriteRouteRepository = FakeFavoriteRouteRepository(
+      favorites: [_favoriteRoute(mobilityType: 'WHEELCHAIR')],
+    );
+    final routeDraftController = RouteDraftController();
+    RouteDraft? searchAgainDraft;
+    String? searchAgainMobilityType;
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: favoriteRouteRepository,
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(profileId: 'elderly'),
+      ),
+    );
+
+    await _openFavoriteList(
+      tester,
+      routeDraftController: routeDraftController,
+      onOpenRouteSearch: (draft, mobilityType) async {
+        searchAgainDraft = draft;
+        searchAgainMobilityType = mobilityType;
+      },
+    );
+
+    await tester.tap(find.byKey(const Key('favoriteRouteSearchAgain-route-1')));
+    await tester.pumpAndSettle();
+
+    expect(searchAgainDraft?.origin?.id, 'station-sangnoksu');
+    expect(searchAgainDraft?.destination?.id, 'station-sadang');
+    expect(searchAgainMobilityType, 'WHEELCHAIR');
   });
 
   testWidgets('즐겨찾기 경로 목록 실패는 다음 행동을 쉬운 문구로 안내한다', (tester) async {
@@ -8666,8 +8712,8 @@ FavoriteFacility _favoriteFacility({
   );
 }
 
-FavoriteRoute _favoriteRoute() {
-  return const FavoriteRoute(
+FavoriteRoute _favoriteRoute({String mobilityType = 'SENIOR'}) {
+  return FavoriteRoute(
     userId: 'anonymous-user-1',
     favoriteRouteId: 'route-1',
     routeSearchId: 'route-1',
@@ -8675,7 +8721,7 @@ FavoriteRoute _favoriteRoute() {
     originStationName: '상록수',
     destinationStationId: 'station-sadang',
     destinationStationName: '사당',
-    mobilityType: 'SENIOR',
+    mobilityType: mobilityType,
     status: 'FOUND',
     lineId: 'seoul-4',
     lineName: '수도권 4호선',

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -369,22 +369,13 @@ public class RouteSearchService implements RouteSearchUseCase {
 		// 출구 데이터가 없거나 신뢰도가 낮으면 사용자가 이동 전 확인할 수 있게 경고를 남긴다.
 		List<RouteWarning> warnings = new ArrayList<>();
 		if (stationIds.stream().anyMatch(this::hasLowAccessibilityData)) {
-			warnings.add(new RouteWarning(
-				RouteWarningCode.LOW_DATA_CONFIDENCE,
-				"이동 경로 중 일부 역의 접근성 정보가 부족합니다. 이동 전 역 상세 정보를 확인하세요."
-			));
+			warnings.add(new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE));
 		}
 		if (stairOnlyAccess) {
-			warnings.add(new RouteWarning(
-				RouteWarningCode.STAIR_ONLY_ACCESS,
-				"이동 경로 중 일부 역에 계단 없는 접근 경로가 확인되지 않았습니다."
-			));
+			warnings.add(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS));
 		}
 		if (stationIds.stream().anyMatch(this::hasStaleAccessibilityData)) {
-			warnings.add(new RouteWarning(
-				RouteWarningCode.STALE_ACCESSIBILITY_DATA,
-				"접근성 시설 정보가 최근 30일 이내 확인되지 않았습니다. 이동 전 역 상세 정보를 확인하세요."
-			));
+			warnings.add(new RouteWarning(RouteWarningCode.STALE_ACCESSIBILITY_DATA));
 		}
 		return List.copyOf(warnings);
 	}
@@ -726,16 +717,10 @@ public class RouteSearchService implements RouteSearchUseCase {
 	private List<RouteWarning> internalRouteWarnings(List<InternalRouteStep> steps) {
 		List<RouteWarning> warnings = new ArrayList<>();
 		if (steps.stream().anyMatch(InternalRouteStep::includesStairs)) {
-			warnings.add(new RouteWarning(
-				RouteWarningCode.STAIR_ONLY_ACCESS,
-				"역 내부 이동 경로에 계단 포함 구간이 있습니다."
-			));
+			warnings.add(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS));
 		}
 		if (steps.stream().anyMatch(step -> step.reliabilityScore() < 80)) {
-			warnings.add(new RouteWarning(
-				RouteWarningCode.LOW_DATA_CONFIDENCE,
-				"역 내부 이동 경로의 일부 구간은 추가 검증이 필요합니다."
-			));
+			warnings.add(new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE));
 		}
 		return List.copyOf(warnings);
 	}
@@ -758,10 +743,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			0,
 			0,
 			List.of(),
-			List.of(new RouteWarning(
-				RouteWarningCode.STAIR_ONLY_ACCESS,
-				"역 내부 이동 경로에 계단 포함 구간이 있습니다."
-			)),
+			List.of(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS)),
 			List.of("계단 없는 내부 이동 경로를 찾을 수 없습니다.")
 		);
 	}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteWarning.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteWarning.java
@@ -1,7 +1,9 @@
 package com.easysubway.route.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record RouteWarning(
-	RouteWarningCode code,
-	String message
+	RouteWarningCode code
 ) {
 }

--- a/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteRouteRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/favorite/adapter/out/persistence/JdbcFavoriteRouteRepositoryTest.java
@@ -164,7 +164,7 @@ class JdbcFavoriteRouteRepositoryTest {
 			"수도권 4호선",
 			90,
 			List.of(new RouteStep(1, "4호선 이동", "열차로 이동합니다.", "line-4", "수도권 4호선", originStationId(originStationName), destinationStationId(destinationStationName), 12, 5200, false, false)),
-			List.of(new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE, "시설 정보를 한 번 확인해 주세요.")),
+			List.of(new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE)),
 			List.of(),
 			LocalDateTime.of(2026, 6, 13, 9, 0)
 		);
@@ -188,7 +188,7 @@ class JdbcFavoriteRouteRepositoryTest {
 				new RouteStep(3, "환승역에서 B 노선 승강장으로 환승", "환승역의 엘리베이터를 확인합니다.", "line-b", "B 노선", "station-transfer", "station-transfer", 6, 260, false, true),
 				new RouteStep(4, "B 노선으로 도착역까지 이동", "2개 역을 이동합니다.", "line-b", "B 노선", "station-transfer", "station-destination", 4, 1800, false, false)
 			),
-			List.of(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS, "일부 구간은 도움을 요청해야 할 수 있습니다.")),
+			List.of(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS)),
 			List.of(),
 			LocalDateTime.of(2026, 6, 13, 9, 0)
 		);

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
@@ -259,7 +259,7 @@ class JdbcRouteSearchRepositoryTest {
 			"수도권 4호선",
 			90,
 			List.of(new RouteStep(1, "4호선 이동", "열차로 이동합니다.", "line-4", "수도권 4호선", originStationId(originStationName), destinationStationId(destinationStationName), 12, 5200, false, false)),
-			List.of(new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE, "시설 정보를 한 번 확인해 주세요.")),
+			List.of(new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE)),
 			List.of(),
 			LocalDateTime.of(2026, 6, 13, 9, 0)
 		);
@@ -282,7 +282,7 @@ class JdbcRouteSearchRepositoryTest {
 				new RouteStep(2, "A 노선으로 환승역까지 이동", "2개 역을 이동한 뒤 환승합니다.", "line-a", "A 노선", "station-origin", "station-transfer", 4, 1800, false, false),
 				new RouteStep(3, "환승역에서 B 노선 승강장으로 환승", "환승역의 엘리베이터를 확인합니다.", "line-b", "B 노선", "station-transfer", "station-transfer", 6, 260, false, true)
 			),
-			List.of(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS, "일부 구간은 도움을 요청해야 할 수 있습니다.")),
+			List.of(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS)),
 			List.of("엘리베이터 검증이 필요한 구간이 있습니다."),
 			LocalDateTime.of(2026, 6, 13, 9, 0)
 		);
@@ -301,7 +301,7 @@ class JdbcRouteSearchRepositoryTest {
 			"수도권 4호선",
 			0,
 			List.of(),
-			List.of(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS, "계단 없는 접근 경로가 확인되지 않았습니다.")),
+			List.of(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS)),
 			List.of("계단 없는 역 접근 경로를 확인할 수 없습니다."),
 			LocalDateTime.of(2026, 6, 17, 10, 0)
 		);

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -3,6 +3,7 @@ package com.easysubway.route.application.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
 import com.easysubway.route.application.port.in.SearchInternalRouteCommand;
@@ -98,6 +99,22 @@ class RouteSearchServiceTest {
 		assertThat(result.warnings())
 			.extracting("code")
 			.contains(RouteWarningCode.LOW_DATA_CONFIDENCE);
+	}
+
+	@Test
+	@DisplayName("경로 warning API 계약은 사용자 문장 없이 code만 직렬화한다")
+	void routeWarningSerializesCodeOnly() throws Exception {
+		var result = service.searchRoute(new SearchRouteCommand(
+			"station-sangnoksu",
+			"station-sadang",
+			MobilityType.STROLLER
+		));
+
+		String warningJson = new ObjectMapper().writeValueAsString(result.warnings().get(0));
+
+		assertThat(warningJson).contains("\"code\":\"LOW_DATA_CONFIDENCE\"");
+		assertThat(warningJson).doesNotContain("message");
+		assertThat(warningJson).doesNotContain("이동 경로");
 	}
 
 	@Test
@@ -550,8 +567,7 @@ class RouteSearchServiceTest {
 			.extracting("code")
 			.contains(RouteWarningCode.STALE_ACCESSIBILITY_DATA);
 		assertThat(result.warnings())
-			.extracting("message")
-			.contains("접근성 시설 정보가 최근 30일 이내 확인되지 않았습니다. 이동 전 역 상세 정보를 확인하세요.");
+			.allSatisfy(warning -> assertThat(warning.toString()).doesNotContain("접근성 시설 정보"));
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

close #822

## 작업 배경

QA 확인에서 경로 안내가 warning 존재 여부와 이동 부담 등급을 섞어 보여 주고 있었다. 서버 warning의 한국어 문장이 모바일 표시 모델에 남을 수 있어, 모바일 문구 QA와 API 계약이 결합되는 문제도 있었다. 저장된 경로는 상세 이동 정보가 부족하다는 문구만 반복하고 최신 경로 재검색 행동으로 이어지지 않았다.

## 작업 내용

- 경로 결과의 안내 가능 여부를 `안내 가능`, `확인 후 이동`, `현재 조건으로 안내 어려움`으로 분리했다.
- 이동 부담 등급을 걷기 거리, 환승 횟수, 계단 포함 여부, 접근성 확인 필요 상태 기반으로 계산하도록 바꿨다.
- 백엔드 `RouteWarning` API 계약에서 사용자 문장 `message`를 제거하고 code만 직렬화하도록 정리했다.
- 모바일 경로 warning은 code만으로 사용자 문구를 매핑하고 unknown code는 안전한 fallback 문구로 표시한다.
- 저장된 즐겨찾기 경로에 `최신 경로 다시 찾기` CTA를 추가해 출발·도착 draft와 저장 당시 이동 조건을 채운 뒤 길찾기로 이어지게 했다.
- 서버 원문 warning message와 raw warning code가 화면/Semantics에 노출되지 않는 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter analyze`: No issues found
  - `cd apps/mobile && flutter test`: 453 tests passed
  - `cd backend && ./gradlew test`: BUILD SUCCESSFUL
  - `codex review --base origin/main --title "[Fix] 경로 경고 문구와 이동 부담 등급 근거 분리"`: 초기 actionable 1건 수정 후 re-review actionable 0건
  - Android emulator API 36 `emulator-5554`에서 3-button navigation overlay 적용 후 저장 경로 CTA, 길찾기 draft 연결, 경로 결과 화면 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Android 3-button navigation 조건 | Android emulator API 36 | `cmd overlay enable-exclusive com.android.internal.systemui.navbar.threebutton` 적용 후 screenshot 확인 | 로컬 `.codex/evidence/822/02-three-button-nav.png` | 뒤로가기/홈/최근 앱 버튼이 표시되는 상태에서 QA 진행 |
| 저장 경로 재검색 CTA | Android emulator API 36 | 즐겨찾기 경로 목록 screenshot/UI tree 확인 | 로컬 `.codex/evidence/822/06-favorite-route-cta-three-button.png`, `.codex/evidence/822/06-favorite-route-cta-three-button.xml` | `최신 경로 다시 찾기` CTA 표시, semantics bounds `[53,972][880,1130]` |
| 저장 경로에서 길찾기 연결 | Android emulator API 36 | CTA tap 후 route draft screenshot/UI tree 확인 | 로컬 `.codex/evidence/822/07-route-search-from-favorite-three-button.png`, `.codex/evidence/822/07-route-search-from-favorite-three-button.xml` | 출발 `상록수역`, 도착 `사당역`이 채워지고 하단 CTA가 3-button nav 위에 표시됨 |
| 이동 부담과 warning 문구 | Android emulator API 36 | 길찾기 결과 screenshot/UI tree 확인 | 로컬 `.codex/evidence/822/08-route-result-warning-burden-three-button.png`, `.codex/evidence/822/08-route-result-warning-burden-three-button.xml` | `이동 부담 보통`, `계단 없는 동선 여부를 확인할 수 없습니다.` 표시, 서버 raw code 노출 없음 |
| 백엔드 warning API 계약 | JVM test | `RouteWarning` 직렬화 테스트 | `cd backend && ./gradlew test`: BUILD SUCCESSFUL | warning JSON에 `code`만 포함되고 `message`와 서버 한국어 문장 없음 |

스크린샷과 UI tree는 GitHub CLI/API에서 로컬 바이너리 첨부 업로드를 제공하지 않아 PR에 직접 첨부하지 않고 로컬 evidence 폴더에 보관했다. 파일은 git에 커밋하지 않았다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteSearchResult.burdenLevelLabel` 계산 기준과 기존 `scoreLabel` 연결
  - `RouteWarning` 백엔드 record의 `message` 제거가 저장소/즐겨찾기 테스트에 반영된 점
  - `FavoriteRouteListContent.onSearchAgain` callback이 저장 경로를 route draft와 저장된 이동 조건으로 옮기는 흐름

## 리스크

- 기존 서버 warning `message`를 기대하던 외부 소비자가 있으면 응답 필드가 줄어든다. 이 앱의 모바일 소비자는 code-only와 unknown fallback을 모두 허용하도록 수정했다.
- 이동 부담 기준값은 현재 로컬/서버 응답 fact로 산정 가능한 보수적 기준이다. 실제 시설 확인 시각 기반 세분화는 별도 데이터 계약 확장 시 더 정밀화할 수 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
