### PR TITLE
[Fix] 길찾기 역 입력과 이동 조건 표시 정리

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1971,9 +1971,21 @@ class _RouteMobilityTypeSummary extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
           child: Row(
             children: [
-              Icon(option.icon, color: const Color(0xFF006D77), size: 26),
-              const SizedBox(width: 10),
-              Expanded(child: content),
+              Expanded(
+                child: ExcludeSemantics(
+                  child: Row(
+                    children: [
+                      Icon(
+                        option.icon,
+                        color: const Color(0xFF006D77),
+                        size: 26,
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(child: content),
+                    ],
+                  ),
+                ),
+              ),
               const SizedBox(width: 10),
               Semantics(
                 button: true,

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1284,12 +1284,6 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
             ],
             _RouteSectionHeader(
               title: widget.simpleViewEnabled ? '이동 조건' : '검색 조건',
-              trailing: widget.simpleViewEnabled
-                  ? _RouteHeaderActionButton(
-                      label: '변경',
-                      onPressed: _showMobilityTypePicker,
-                    )
-                  : null,
             ),
             const SizedBox(height: 8),
             // 단순 보기에서는 드롭다운 대신 현재 조건을 크게 보여주고, 필요할 때만 바꿀 수 있게 한다.
@@ -1612,11 +1606,8 @@ class _RoutePointPickerCard extends StatelessWidget {
                   icon: const Icon(Icons.swap_vert),
                   color: const Color(0xFF102A2C),
                   style: IconButton.styleFrom(
-                    backgroundColor: const Color(0xFFF3F7F8),
-                    fixedSize: const Size(42, 42),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(13),
-                    ),
+                    fixedSize: const Size(48, 48),
+                    side: const BorderSide(color: Color(0xFF9DB6BA)),
                   ),
                 ),
               ),
@@ -1659,7 +1650,7 @@ class _RoutePointRow extends StatelessWidget {
           onTap: onTap,
           borderRadius: BorderRadius.circular(14),
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 10),
             child: Row(
               children: [
                 Expanded(
@@ -1683,10 +1674,9 @@ class _RoutePointRow extends StatelessWidget {
 }
 
 class _RouteSectionHeader extends StatelessWidget {
-  const _RouteSectionHeader({required this.title, this.trailing});
+  const _RouteSectionHeader({required this.title});
 
   final String title;
-  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
@@ -1702,56 +1692,7 @@ class _RouteSectionHeader extends StatelessWidget {
             ),
           ),
         ),
-        ?trailing,
       ],
-    );
-  }
-}
-
-class _RouteHeaderActionButton extends StatelessWidget {
-  const _RouteHeaderActionButton({
-    required this.label,
-    required this.onPressed,
-  });
-
-  final String label;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Semantics(
-      button: true,
-      label: label,
-      onTap: onPressed,
-      child: ExcludeSemantics(
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: onPressed,
-            borderRadius: BorderRadius.circular(8),
-            child: Ink(
-              decoration: BoxDecoration(
-                color: Colors.white,
-                border: Border.all(color: const Color(0xFF006D77)),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 14,
-                  vertical: 9,
-                ),
-                child: Text(
-                  label,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: const Color(0xFF006D77),
-                    height: 1.2,
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
     );
   }
 }
@@ -1992,19 +1933,9 @@ class _RouteMobilityTypeSummary extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final option = _mobilityOptionFor(mobilityType);
-    final textScale = MediaQuery.textScalerOf(context).scale(1);
     final content = Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          '적용 중인 조건',
-          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-            color: const Color(0xFF29484B),
-            fontWeight: FontWeight.w700,
-            height: 1.25,
-          ),
-        ),
-        const SizedBox(height: 3),
         Text(
           option.title,
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
@@ -2025,58 +1956,39 @@ class _RouteMobilityTypeSummary extends StatelessWidget {
       ],
     );
     return Semantics(
-      button: true,
-      label: '이동 조건 바꾸기, 현재 ${option.title}',
+      container: true,
+      explicitChildNodes: true,
       liveRegion: true,
-      onTap: onChangeRequested,
-      child: ExcludeSemantics(
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            key: const Key('routeSimpleMobilityTypeButton'),
-            onTap: onChangeRequested,
-            borderRadius: BorderRadius.circular(8),
-            child: Ink(
-              decoration: BoxDecoration(
-                color: const Color(0xFFE9F5F6),
-                border: Border.all(color: const Color(0xFFB9D4D8)),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 14,
-                  vertical: 12,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: const Color(0xFFE9F5F6),
+          border: Border.all(color: const Color(0xFFB9D4D8)),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          child: Row(
+            children: [
+              Icon(option.icon, color: const Color(0xFF006D77), size: 26),
+              const SizedBox(width: 10),
+              Expanded(child: content),
+              const SizedBox(width: 10),
+              Semantics(
+                button: true,
+                label: '이동 조건 바꾸기, 현재 ${option.title}',
+                onTap: onChangeRequested,
+                child: ExcludeSemantics(
+                  child: OutlinedButton(
+                    key: const Key('routeSimpleMobilityTypeButton'),
+                    onPressed: onChangeRequested,
+                    style: OutlinedButton.styleFrom(
+                      minimumSize: const Size(64, 48),
+                    ),
+                    child: const Text('변경'),
+                  ),
                 ),
-                child: textScale >= 2
-                    ? Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            children: [
-                              Icon(
-                                option.icon,
-                                color: const Color(0xFF006D77),
-                                size: 26,
-                              ),
-                              const SizedBox(width: 10),
-                              Expanded(child: content),
-                            ],
-                          ),
-                        ],
-                      )
-                    : Row(
-                        children: [
-                          Icon(
-                            option.icon,
-                            color: const Color(0xFF006D77),
-                            size: 26,
-                          ),
-                          const SizedBox(width: 10),
-                          Expanded(child: content),
-                        ],
-                      ),
               ),
-            ),
+            ],
           ),
         ),
       ),
@@ -2687,8 +2599,6 @@ class _RouteResultsListView extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                _RouteWorkflowSummary(result: result),
-                const SizedBox(height: 12),
                 _RouteSectionHeader(title: '추천 경로'),
                 const SizedBox(height: 8),
               ],
@@ -3188,50 +3098,6 @@ class _RouteFeedbackWorkflowView extends StatelessWidget {
         else
           _RouteFeedbackButtons(result: result, repository: feedbackRepository),
       ],
-    );
-  }
-}
-
-class _RouteWorkflowSummary extends StatelessWidget {
-  const _RouteWorkflowSummary({required this.result});
-
-  final RouteSearchResult result;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: const Color(0xFFE9F5F6),
-        border: Border.all(color: const Color(0xFFB9D4D8)),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(14),
-        child: Row(
-          children: [
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    '${result.originStationName} → ${result.destinationStationName}',
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      color: const Color(0xFF102A2C),
-                      fontWeight: FontWeight.w900,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    _routeMobilityConditionLabel(
-                      _mobilityOptionFor(result.mobilityType),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1958,6 +1958,8 @@ class _RouteMobilityTypeSummary extends StatelessWidget {
     return Semantics(
       container: true,
       explicitChildNodes: true,
+      label:
+          '현재 이동 조건 ${option.title}, ${_routeMobilityConditionLabel(option)}',
       liveRegion: true,
       child: DecoratedBox(
         decoration: BoxDecoration(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -6178,6 +6178,10 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
+        find.bySemanticsLabel('현재 이동 조건 천천히 이동, 계단 피하기 · 환승 줄이기'),
+        findsOneWidget,
+      );
+      expect(
         tester.getSemantics(find.bySemanticsLabel('이동 조건 바꾸기, 현재 천천히 이동')),
         isSemantics(
           label: '이동 조건 바꾸기, 현재 천천히 이동',

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5834,8 +5834,12 @@ void main() {
       expect(find.text('도착역 선택'), findsOneWidget);
       expect(find.text('출발역 ID'), findsNothing);
       expect(find.text('도착역 ID'), findsNothing);
-      expect(find.text('적용 중인 조건'), findsOneWidget);
+      expect(find.text('적용 중인 조건'), findsNothing);
       expect(find.text('천천히 이동'), findsOneWidget);
+      expect(
+        find.byKey(const Key('routeSimpleMobilityTypeButton')),
+        findsOneWidget,
+      );
       expect(find.byType(DropdownButton<String>), findsNothing);
 
       await _openRouteOriginStationInput(tester);
@@ -5877,6 +5881,12 @@ void main() {
       );
       await tester.pumpAndSettle();
 
+      final originButtonLeft = tester.getTopLeft(
+        find.byKey(const Key('routeOriginPointButton')),
+      );
+      final originTextLeft = tester.getTopLeft(find.text('상록수역'));
+      expect(originTextLeft.dx - originButtonLeft.dx, greaterThanOrEqualTo(24));
+
       await tester.drag(find.byType(ListView), const Offset(0, -360));
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
@@ -5898,7 +5908,7 @@ void main() {
       expect(find.text('편한 순'), findsNothing);
       expect(find.text('빠른 순'), findsNothing);
       expect(find.text('환승 적은 순'), findsNothing);
-      expect(find.text('상록수 → 사당'), findsOneWidget);
+      expect(find.text('상록수 → 사당'), findsNothing);
       expect(find.text('계단 피하기 · 환승 줄이기'), findsWidgets);
       expect(find.text('계단 여부 확인 필요'), findsWidgets);
       expect(find.text('계단 없음'), findsNothing);
@@ -7068,7 +7078,7 @@ void main() {
     await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('상록수 → 사당'), findsOneWidget);
+    expect(find.byKey(const Key('routeResultListItem')), findsOneWidget);
 
     await tester.drag(find.byType(ListView), const Offset(0, 700));
     await tester.pumpAndSettle();
@@ -7091,7 +7101,7 @@ void main() {
     await tester.drag(find.byType(ListView), const Offset(0, -500));
     await tester.pumpAndSettle();
 
-    expect(find.text('상록수 → 사당'), findsNothing);
+    expect(find.byKey(const Key('routeResultListItem')), findsNothing);
   });
 
   testWidgets('경로 검색 중에는 버튼을 비활성화하고 안내 불가 이유를 보여준다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

close #864

## 작업 배경

- QA 요청으로 길찾기 화면의 역명 입력 카드와 이동 조건 카드에서 불필요하거나 어색한 표시를 정리했습니다.
- 역명 텍스트가 카드 왼쪽에 붙어 보이고, 출발·도착 전환과 이동 조건 변경 버튼이 커스텀 도형처럼 보여 일관성이 떨어졌습니다.
- 이동 조건 영역의 `적용 중인 조건`과 결과 위 `상록수 → 사당` 블록은 정보가 중복되어 화면을 복잡하게 만들었습니다.

## 작업 내용

- 출발·도착 역명 행의 좌우 여백을 늘려 선택된 역명이 카드 안쪽에서 시작하도록 조정했습니다.
- 출발·도착 전환 버튼을 Flutter 기본 `IconButton.outlined` 기반으로 정리하고, 커스텀 배경과 radius를 제거했습니다.
- 이동 조건 카드에서 `적용 중인 조건` 문구를 제거했습니다.
- 이동 조건 변경 액션을 카드 오른쪽의 Flutter 기본 `OutlinedButton`으로 배치했습니다.
- 결과 목록 상단의 출발·도착 중복 요약 블록을 제거했습니다.
- 변경된 화면 구조와 Semantics를 위젯 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "경로 검색 단순 보기 이동 조건은 스크린리더로도 바꿀 수 있다"`: 1 test passed.
  - `cd apps/mobile && flutter analyze`: No issues found.
  - `cd apps/mobile && flutter test test/widget_test.dart`: 142 tests passed.
  - Android emulator `emulator-5554`에서 3-button navigation overlay를 켜고 길찾기 화면을 수동 확인했습니다.
  - PR CI run `28172901414`: Android CI, Mobile App CI, Backend CI, Repository CI, Dependency Vulnerability Scan 통과.
  - Release Artifacts run `28172900978`: Android Release Artifact 통과, Backend Release Image는 변경 범위상 skipped.
  - CodeRabbit은 review limit reached로 실제 리뷰가 시작되지 않아 Codex CLI fallback review를 실행했고, 최종 re-review에서 actionable comment 0건을 확인했습니다.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역명 입력 카드 여백과 출발·도착 전환 버튼 | Android API 36 emulator | `Sangnoksu` alias로 출발·도착 역을 선택한 뒤 스크린샷 확인 | `.codex/evidence/864/route-selected-three-button.png` | 역명이 카드 안쪽 여백을 두고 표시되고 전환 버튼은 기본 outlined 형태로 보임 |
| 이동 조건 카드 변경 버튼 | Android API 36 emulator | UI tree에서 버튼 Semantics 확인 | `.codex/evidence/864/ui-11-route-selected.xml` | `이동 조건 바꾸기, 현재 천천히 이동` 버튼이 카드 오른쪽에 독립 버튼으로 노출됨 |
| 중복 문구 제거 | Widget test, Android API 36 emulator | 위젯 테스트와 UI tree 확인 | `flutter test test/widget_test.dart`, `.codex/evidence/864/ui-11-route-selected.xml` | `적용 중인 조건`과 결과 위 출발·도착 중복 블록이 표시되지 않음 |
| Android 하단 3-button navigation 간격 | Android API 36 emulator | `com.android.internal.systemui.navbar.threebutton` overlay에서 스크린샷 확인 | `.codex/evidence/864/route-selected-three-button.png` | 하단 CTA가 시스템 내비게이션 바와 붙지 않음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `_RoutePointRow` 여백 변경
  - `_RouteMobilityTypeSummary`의 기본 `OutlinedButton` 배치와 Semantics 유지
  - `_RouteWorkflowSummary` 삭제로 결과 위 중복 출발·도착 블록 제거
- 스크린샷과 UI tree는 저장소 정책에 따라 git에 커밋하지 않고 로컬 evidence 폴더에 보관했습니다.

## 리스크

- 에뮬레이터 내장 데이터에서 `Sadang` alias 검색 결과가 없어 스크린샷은 출발·도착 모두 `상록수역`으로 확인했습니다. 사용자 요청의 `상록수역/사당역` 조합은 위젯 테스트의 fake repository에서 별도로 검증했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
