### PR TITLE
[Feat] 노선도 노선별 보기 진입점 개선

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -365,7 +365,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                       key: const Key('networkMapListButton'),
                       onPressed: () => _showMapList(data),
                       icon: const Icon(Icons.list_alt),
-                      label: const Text('노선 목록으로 보기'),
+                      label: const Text('노선별로 보기'),
                     ),
                   ),
                 ),
@@ -1725,12 +1725,12 @@ class _NetworkMapListSheet extends StatelessWidget {
         padding: const EdgeInsets.fromLTRB(20, 6, 20, 24),
         children: [
           const Text(
-            '노선과 역 목록',
+            '노선별 역 보기',
             style: TextStyle(fontSize: 24, fontWeight: FontWeight.w900),
           ),
           const SizedBox(height: 6),
           const Text(
-            '지도 조작이 어려울 때 목록에서 역을 선택하세요.',
+            '노선별 목록에서 역을 선택하세요.',
             style: TextStyle(fontSize: 15, color: Color(0xFF4D6367)),
           ),
           const SizedBox(height: 14),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -865,7 +865,7 @@ void main() {
     expect(find.text('4호선'), findsWidgets);
   });
 
-  testWidgets('노선도 목록 대체 화면에서 역을 선택할 수 있다', (tester) async {
+  testWidgets('노선도 노선별 보기 화면에서 역을 선택할 수 있다', (tester) async {
     await tester.pumpWidget(
       EasySubwayApp(
         repository: FakeStationSearchRepository(),
@@ -882,8 +882,10 @@ void main() {
     await tester.tap(find.byKey(const Key('networkMapListButton')));
     await tester.pumpAndSettle();
 
+    expect(find.text('노선별로 보기'), findsOneWidget);
     expect(find.byKey(const Key('networkMapListSheet')), findsOneWidget);
-    expect(find.text('노선과 역 목록'), findsOneWidget);
+    expect(find.text('노선별 역 보기'), findsOneWidget);
+    expect(find.text('노선별 목록에서 역을 선택하세요.'), findsOneWidget);
     await tester.tap(
       find.byKey(const Key('networkMapListStation-station-sadang-seoul-4')),
     );


### PR DESCRIPTION
## 관련 이슈

close #860

## 작업 배경

노선도 화면 하단 CTA가 `노선 목록으로 보기`로 표시되어 전체 역 목록 대체 화면처럼 읽혔다. QA 요청에 맞춰 이 진입점을 `노선별로 보기` 기준으로 바꾸고, 연결된 bottom sheet도 노선별 역 탐색 흐름으로 이해되도록 문구를 정리한다.

## 작업 내용

- 노선도 하단 CTA 문구와 접근성 label을 `노선별로 보기`로 변경했다.
- CTA로 열리는 sheet 제목을 `노선별 역 보기`로 변경했다.
- sheet 안내 문구를 `노선별 목록에서 역을 선택하세요.`로 변경했다.
- 기존 노선별 expansion, 역 선택, 출발/도착 설정 sheet 연결 동작은 유지했다.
- widget test가 새 문구와 기존 역 선택 동작을 함께 검증하도록 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/network_map.dart test/widget_test.dart`: exit 0, 2 files checked, 0 changed
  - `flutter analyze`: exit 0, No issues found
  - `flutter test test/widget_test.dart --name '노선도 노선별 보기 화면에서 역을 선택할 수 있다'`: exit 0, targeted test passed
  - `flutter test test/widget_test.dart`: exit 0, 142 tests passed
  - `flutter test`: exit 0, 471 tests passed
  - `node --test tools/ci/*.test.mjs`: exit 0, 102 tests passed
  - `flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `adb -s RFKYA01VMQY install -r build/app/outputs/flutter-apk/app-debug.apk`: exit 0, `Success`
  - `flutter devices`: Android 실기기 `SM A175N` 연결 확인, iOS 실기기 없음
  - rebase 후 `flutter analyze`: exit 0, No issues found
  - rebase 후 `flutter test test/widget_test.dart --name '노선도 노선별 보기 화면에서 역을 선택할 수 있다'`: exit 0, targeted test passed
  - GitHub Actions CI: success, https://github.com/AquilaXk/easysubway/actions/runs/28173426170
  - GitHub Actions Release Artifacts: success, https://github.com/AquilaXk/easysubway/actions/runs/28173425407
  - CodeRabbit: review limit/credit exhausted comment 확인, https://github.com/AquilaXk/easysubway/pull/867#issuecomment-4799679701
  - Codex CLI fallback review: actionable 0건, nitpick 0건, https://github.com/AquilaXk/easysubway/pull/867#pullrequestreview-4571565540
  - GitHub review threads: unresolved 0건
  - merge commit: `26e2d1505598610e04582b18ce4c22785f87bc1c`
  - post-merge CD: run 생성 및 in_progress 확인, 실패 신호 없음, https://github.com/AquilaXk/easysubway/actions/runs/28175126855
  - post-merge CI: run 생성 확인, https://github.com/AquilaXk/easysubway/actions/runs/28175127641
  - post-merge Release Artifacts: run 생성 및 in_progress 확인, 실패 신호 없음, https://github.com/AquilaXk/easysubway/actions/runs/28175126984

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| CTA 문구와 접근성 label | Android 실기기 `SM A175N`, serial `RFKYA01VMQY` | 최신 debug APK 설치 후 노선도 탭 진입 | 로컬 전용 `.codex/evidence/860/android-route-map-cta.png`, `.codex/evidence/860/android-route-map-cta-ui.xml` | 화면과 UI tree 모두 `노선별로 보기`로 표시됨 |
| 노선별 sheet | Android 실기기 `SM A175N`, serial `RFKYA01VMQY` | `노선별로 보기` CTA tap | 로컬 전용 `.codex/evidence/860/android-route-by-line-sheet.png`, `.codex/evidence/860/android-route-by-line-sheet-ui.xml` | `노선별 역 보기` 제목, `노선별 목록에서 역을 선택하세요.` 안내, 1호선 expansion과 역 목록 표시 |
| fatal/error 로그 | Android 실기기 `SM A175N`, serial `RFKYA01VMQY` | logcat에서 `FATAL EXCEPTION`, `FlutterError`, `Unhandled Exception`, `AndroidRuntime.*FATAL`, `ANR` 패턴 검색 | 로컬 전용 `.codex/evidence/860/android-route-by-line-logcat.txt` | 일치 항목 없음 |
| 기존 역 선택 동작 | Flutter widget test | CTA tap 후 `station-sadang-seoul-4` 선택 | `flutter test test/widget_test.dart --name '노선도 노선별 보기 화면에서 역을 선택할 수 있다'` | station sheet가 열리고 `사당역`, `2호선`, `4호선` 표시 |
| iOS 대체 검증 | Flutter shared widget | platform 분기 없는 문구 변경과 widget test 확인 | `flutter devices`에 iOS 실기기 없음, `flutter test` exit 0 | iOS 실기기 화면 증거는 없음. 변경은 shared Flutter text/widget test 범위이며 platform channel 변경 없음 |

Android 화면/로그 증거는 QA 요청 기준 실기기 검증 자료이며, 스크린샷과 logcat에 로컬 기기 상태와 앱 화면이 포함되어 있어 GitHub에 직접 첨부하지 않고 로컬 전용 evidence 폴더에 보관했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - [apps/mobile/lib/network_map.dart]의 CTA/sheet 문구 변경이 의도한 범위로만 제한됐는지
  - [apps/mobile/test/widget_test.dart]의 노선별 보기 테스트가 기존 역 선택 동작을 유지하는지

## 리스크

- 기능 구조는 그대로 두고 문구만 바꿨기 때문에 기술 리스크는 낮다.
- iOS 실기기는 현재 연결되지 않아 Android 실기기와 shared widget test로 대체했다.
- 기존 key 이름 `networkMapListButton`/`networkMapListSheet`는 테스트와 내부 식별자 안정성을 위해 유지했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.