### PR TITLE
[Fix] 알림·온보딩·노선도 사용자 문구 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4801,11 +4801,15 @@ class _SupportAccessItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final targetUri = uri;
+    final fallbackTarget = value.trim();
     final displayValue = targetUri == null
         ? '현재 이용할 수 없음 · 준비 중'
-        : this.displayValue ?? value.trim();
+        : this.displayValue ?? fallbackTarget;
     final secondaryText = helperText;
     final semanticLabelParts = [title, displayValue];
+    if (targetUri != null && displayValue != fallbackTarget) {
+      semanticLabelParts.add(fallbackTarget);
+    }
     if (secondaryText != null) {
       semanticLabelParts.add(secondaryText);
     }
@@ -4815,12 +4819,13 @@ class _SupportAccessItem extends StatelessWidget {
       label: semanticLabelParts.join(', '),
       onTap: targetUri == null
           ? null
-          : () => unawaited(_openTarget(context, targetUri)),
+          : () => unawaited(_openTarget(context, targetUri, fallbackTarget)),
       child: ExcludeSemantics(
         child: OutlinedButton.icon(
           onPressed: targetUri == null
               ? null
-              : () => unawaited(_openTarget(context, targetUri)),
+              : () =>
+                    unawaited(_openTarget(context, targetUri, fallbackTarget)),
           icon: Icon(icon),
           label: Align(
             alignment: Alignment.centerLeft,
@@ -4859,7 +4864,11 @@ class _SupportAccessItem extends StatelessWidget {
     );
   }
 
-  Future<void> _openTarget(BuildContext context, Uri uri) async {
+  Future<void> _openTarget(
+    BuildContext context,
+    Uri uri,
+    String fallbackTarget,
+  ) async {
     bool opened = false;
     try {
       opened = await launcher.open(uri);
@@ -4876,7 +4885,7 @@ class _SupportAccessItem extends StatelessWidget {
     }
 
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('연결할 수 없습니다. 잠시 후 다시 시도해 주세요.')),
+      SnackBar(content: Text('연결할 수 없습니다. 직접 확인해 주세요: $fallbackTarget')),
     );
   }
 }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -2986,7 +2986,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
                       key: const Key('notificationSettingsButton'),
                       icon: Icons.notifications_active_outlined,
                       title: '알림 설정',
-                      subtitle: '시설 상태, 제보 처리, 정보 갱신 알림을 관리해요',
+                      subtitle: '시설 상태, 제보 처리, 최신 안내 알림을 관리해요',
                       onTap: () {
                         Navigator.of(context).push(
                           MaterialPageRoute<void>(
@@ -3794,6 +3794,7 @@ class SupportAccessScreen extends StatelessWidget {
               icon: Icons.privacy_tip_outlined,
               title: '개인정보처리방침',
               value: accessInfo.privacyPolicyUrl,
+              displayValue: '웹에서 확인',
               uri: _httpsUri(accessInfo.privacyPolicyUrl),
               launcher: launcher,
             ),
@@ -3804,6 +3805,7 @@ class SupportAccessScreen extends StatelessWidget {
                 icon: Icons.delete_outline,
                 title: '데이터 삭제 요청',
                 value: accessInfo.dataDeletionEmail,
+                displayValue: '이메일 보내기',
                 helperText: '삭제 범위와 처리 절차를 메일로 문의해요',
                 uri: _mailtoUri(
                   accessInfo.dataDeletionEmail,
@@ -3827,6 +3829,7 @@ class SupportAccessScreen extends StatelessWidget {
               icon: Icons.support_agent,
               title: '고객지원',
               value: accessInfo.supportEmail,
+              displayValue: '이메일 보내기',
               uri: _mailtoUri(accessInfo.supportEmail, '쉬운 지하철 고객지원 문의'),
               launcher: launcher,
             ),
@@ -3838,6 +3841,7 @@ class SupportAccessScreen extends StatelessWidget {
               icon: Icons.security_outlined,
               title: '보안 문의',
               value: accessInfo.securityEmail,
+              displayValue: '보안 문제 알리기',
               uri: _mailtoUri(accessInfo.securityEmail, '쉬운 지하철 보안 문의'),
               launcher: launcher,
             ),
@@ -4781,6 +4785,7 @@ class _SupportAccessItem extends StatelessWidget {
     required this.value,
     required this.uri,
     required this.launcher,
+    this.displayValue,
     this.helperText,
     super.key,
   });
@@ -4790,6 +4795,7 @@ class _SupportAccessItem extends StatelessWidget {
   final String value;
   final Uri? uri;
   final SupportAccessLauncher launcher;
+  final String? displayValue;
   final String? helperText;
 
   @override
@@ -4797,7 +4803,7 @@ class _SupportAccessItem extends StatelessWidget {
     final targetUri = uri;
     final displayValue = targetUri == null
         ? '현재 이용할 수 없음 · 준비 중'
-        : value.trim();
+        : this.displayValue ?? value.trim();
     final secondaryText = helperText;
     final semanticLabelParts = [title, displayValue];
     if (secondaryText != null) {

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1238,14 +1238,14 @@ class _MapControls extends StatelessWidget {
         const SizedBox(height: 8),
         _MapControlButton(
           key: const Key('networkMapOverviewButton'),
-          tooltip: '전체 보기',
+          tooltip: '전체 노선도',
           icon: Icons.fit_screen,
           onPressed: onOverview,
         ),
         const SizedBox(height: 8),
         _MapControlButton(
           key: const Key('networkMapLocateButton'),
-          tooltip: '중심 보기',
+          tooltip: '처음 위치로',
           icon: Icons.center_focus_strong,
           onPressed: onCenter,
         ),
@@ -1331,7 +1331,7 @@ class _OriginalRouteMapUnavailable extends StatelessWidget {
       color: Colors.white,
       child: Center(
         child: Text(
-          '원본 노선도를 불러올 수 없습니다.',
+          '노선도를 불러오지 못했어요',
           style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
         ),
       ),

--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -11,10 +11,10 @@ import 'mobile_error_reporter.dart';
 const _notificationSettingsTimeout = Duration(seconds: 8);
 const _notificationSettingsLoadErrorMessage = '알림 설정을 불러오지 못했습니다.';
 const _notificationSettingsSaveErrorMessage = '알림 설정을 저장하지 못했습니다.';
-const _deviceRegistrationErrorMessage = '기기 알림 등록을 마치지 못했습니다.';
-const _notificationPermissionErrorMessage = '알림 권한을 확인하지 못했습니다.';
+const _deviceRegistrationErrorMessage = '알림을 켜지 못했어요.';
+const _notificationPermissionErrorMessage = '알림을 켤 수 있는지 확인하지 못했어요.';
 const _notificationRegistrationFailureNextAction =
-    '기기 알림 설정과 네트워크 상태를 확인한 뒤 다시 시도해 주세요.';
+    '휴대전화 알림 설정과 인터넷 연결을 확인한 뒤 다시 시도해 주세요.';
 
 abstract class NotificationSettingsRepository {
   Future<NotificationSettings> getNotificationSettings();
@@ -53,7 +53,7 @@ class MethodChannelNotificationPermissionProvider
           ? NotificationPermissionStatus.granted
           : NotificationPermissionStatus.denied;
     } on PlatformException catch (error, stackTrace) {
-      reportMobileError(error, stackTrace, context: '알림 권한 요청 중 예외가 발생했습니다.');
+      reportMobileError(error, stackTrace, context: '알림 켜기 요청 중 예외가 발생했습니다.');
       throw const NotificationSettingsException(
         _notificationPermissionErrorMessage,
       );
@@ -220,7 +220,7 @@ class DeviceRegistrationApiRepository implements DeviceRegistrationRepository {
       reportMobileError(
         error,
         stackTrace,
-        context: '기기 알림 등록 응답 처리 중 예외가 발생했습니다.',
+        context: '알림 등록 응답 처리 중 예외가 발생했습니다.',
       );
       throw const NotificationSettingsException(
         _deviceRegistrationErrorMessage,
@@ -299,7 +299,7 @@ class DeviceRegistrationApiRepository implements DeviceRegistrationRepository {
       reportMobileError(
         error,
         stackTrace,
-        context: '기기 알림 등록 응답 파싱 중 예외가 발생했습니다.',
+        context: '알림 등록 응답 파싱 중 예외가 발생했습니다.',
       );
       throw const NotificationSettingsException(
         _deviceRegistrationErrorMessage,
@@ -684,7 +684,7 @@ class _NotificationSettingsScreenState
       builder: (context) => AlertDialog(
         title: const Text('알림 받기'),
         content: const Text(
-          '즐겨찾는 역과 경로의 시설 상태, 내 제보 처리 결과, 정보 갱신을 알려드립니다. 알림 설정에서 언제든 끌 수 있습니다.',
+          '즐겨찾는 역과 경로의 시설 변경, 제보 처리 상황, 최신 안내를 알려드려요. 알림 설정에서 언제든 끌 수 있습니다.',
         ),
         actions: [
           TextButton(
@@ -715,8 +715,8 @@ class _NotificationSettingsScreenState
       setState(() {
         _notificationPermissionMessage =
             status == NotificationPermissionStatus.granted
-            ? '기기 알림이 켜졌습니다.'
-            : '기기 알림 권한을 켜 주세요.';
+            ? '알림이 켜졌어요.'
+            : '휴대전화 설정에서 알림을 허용해 주세요.';
       });
     } on NotificationSettingsException catch (error) {
       if (!mounted) {
@@ -729,7 +729,7 @@ class _NotificationSettingsScreenState
       reportMobileError(
         error,
         stackTrace,
-        context: '알림 권한 요청 화면 처리 중 예외가 발생했습니다.',
+        context: '알림 켜기 화면 처리 중 예외가 발생했습니다.',
       );
       if (!mounted) {
         return;
@@ -782,9 +782,7 @@ class _NotificationSettingsContent extends StatelessWidget {
       children: [
         if (notificationPermissionProvider != null) ...[
           Semantics(
-            label: isRequestingNotificationPermission
-                ? '기기 알림 권한 확인 중'
-                : '기기 알림 켜기',
+            label: isRequestingNotificationPermission ? '알림 확인 중' : '알림 켜기',
             child: OutlinedButton.icon(
               key: const Key('notificationPermissionButton'),
               onPressed: isRequestingNotificationPermission
@@ -798,7 +796,7 @@ class _NotificationSettingsContent extends StatelessWidget {
                     )
                   : const Icon(Icons.notifications_active_outlined),
               label: Text(
-                isRequestingNotificationPermission ? '확인 중' : '기기 알림 켜기',
+                isRequestingNotificationPermission ? '확인 중' : '알림 켜기',
               ),
             ),
           ),
@@ -837,7 +835,7 @@ class _NotificationSettingsContent extends StatelessWidget {
         ),
         _NotificationSwitchTile(
           key: const Key('notificationSwitch-dataQualityAlerts'),
-          title: '정보 갱신 알림',
+          title: '최신 안내 알림',
           value: settings.dataQualityAlerts,
           enabled: !isSaving,
           onChanged: onDataQualityAlertsChanged,

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -889,7 +889,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                     children: [
                       _OnboardingViewPreferenceSwitch(
                         key: const Key('onboardingPreference-largeText'),
-                        title: '큰 글씨',
+                        title: '큰 글자',
                         subtitle: '글자를 더 크게 표시',
                         value: _preferences.largeTextEnabled,
                         onChanged: (value) {
@@ -917,7 +917,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                       const _OnboardingPreferenceDivider(),
                       _OnboardingViewPreferenceSwitch(
                         key: const Key('onboardingPreference-simpleView'),
-                        title: '단순 보기',
+                        title: '간편 보기',
                         subtitle: '중요한 정보만 먼저 표시',
                         value: _preferences.simpleViewEnabled,
                         onChanged: (value) {
@@ -937,7 +937,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                   Semantics(
                     header: true,
                     child: Text(
-                      '필요한 권한을 나중에 켤 수 있어요',
+                      '위치와 알림은 나중에도 켤 수 있어요',
                       style: textTheme.headlineSmall?.copyWith(
                         color: const Color(0xFF102A2C),
                         fontWeight: FontWeight.w900,
@@ -986,7 +986,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                         borderRadius: BorderRadius.circular(8),
                       ),
                     ),
-                    child: const Text('선택한 권한 허용하고 시작'),
+                    child: const Text('선택한 기능 설정하고 시작'),
                   ),
                   const SizedBox(height: 9),
                   OutlinedButton(
@@ -1085,13 +1085,13 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       reportMobileError(
         error,
         stackTrace,
-        context: '온보딩 알림 권한 준비 중 예외가 발생했습니다.',
+        context: '온보딩 알림 켜기 준비 중 예외가 발생했습니다.',
       );
     } catch (error, stackTrace) {
       reportMobileError(
         error,
         stackTrace,
-        context: '온보딩 알림 권한 준비 중 알 수 없는 예외가 발생했습니다.',
+        context: '온보딩 알림 켜기 준비 중 알 수 없는 예외가 발생했습니다.',
       );
     }
     if (mounted) {

--- a/apps/mobile/test/notification_permission_provider_test.dart
+++ b/apps/mobile/test/notification_permission_provider_test.dart
@@ -64,7 +64,7 @@ void main() {
         isA<NotificationSettingsException>().having(
           (error) => error.message,
           'message',
-          '알림 권한을 확인하지 못했습니다.',
+          '알림을 켤 수 있는지 확인하지 못했어요.',
         ),
       ),
     );

--- a/apps/mobile/test/notification_settings_test.dart
+++ b/apps/mobile/test/notification_settings_test.dart
@@ -156,7 +156,7 @@ void main() {
         isA<NotificationSettingsException>().having(
           (error) => error.message,
           'message',
-          '기기 알림 등록을 마치지 못했습니다.',
+          '알림을 켜지 못했어요.',
         ),
       ),
     );

--- a/apps/mobile/test/onboarding_app_flow_test.dart
+++ b/apps/mobile/test/onboarding_app_flow_test.dart
@@ -59,7 +59,8 @@ void main() {
     expect(find.text('적용할 조건을 확인하세요'), findsOneWidget);
     await tester.tap(find.byKey(const Key('onboardingDoneButton')));
     await tester.pumpAndSettle();
-    expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsOneWidget);
+    expect(find.text('위치와 알림은 나중에도 켤 수 있어요'), findsOneWidget);
+    expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsNothing);
     await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
     await tester.pumpAndSettle();
 
@@ -105,7 +106,8 @@ void main() {
     await _openOnboarding(tester);
     await _continueFromProfileToPermission(tester);
 
-    expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsOneWidget);
+    expect(find.text('위치와 알림은 나중에도 켤 수 있어요'), findsOneWidget);
+    expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsNothing);
     expect(find.text('현재 위치'), findsOneWidget);
     expect(find.text('알림'), findsOneWidget);
     expect(

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -100,6 +100,10 @@ void main() {
       expect(find.text('엘리베이터 이용'), findsOneWidget);
       expect(find.text('우선 적용'), findsWidgets);
       expect(find.text('보기 설정'), findsOneWidget);
+      expect(find.text('큰 글씨'), findsNothing);
+      expect(find.text('큰 글자'), findsOneWidget);
+      expect(find.text('단순 보기'), findsNothing);
+      expect(find.text('간편 보기'), findsOneWidget);
       expect(
         tester.getSemantics(find.bySemanticsLabel('계단 피하기 우선 적용, 계단 없는 길')),
         isSemantics(label: '계단 피하기 우선 적용, 계단 없는 길'),
@@ -128,7 +132,8 @@ void main() {
       await tester.tap(find.byKey(const Key('onboardingDoneButton')));
       await tester.pumpAndSettle();
 
-      expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsOneWidget);
+      expect(find.text('위치와 알림은 나중에도 켤 수 있어요'), findsOneWidget);
+      expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsNothing);
       expect(find.text('현재 위치'), findsOneWidget);
       expect(find.text('알림'), findsOneWidget);
       expect(find.bySemanticsLabel('현재 위치 꺼짐'), findsOneWidget);
@@ -173,7 +178,8 @@ void main() {
     await tester.tap(find.byKey(const Key('onboardingDoneButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsOneWidget);
+    expect(find.text('위치와 알림은 나중에도 켤 수 있어요'), findsOneWidget);
+    expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsNothing);
     await tester.tap(find.byKey(const Key('onboardingPermissionSkipButton')));
     await tester.pumpAndSettle();
 
@@ -332,7 +338,8 @@ void main() {
     await tester.tap(find.byKey(const Key('onboardingDoneButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsOneWidget);
+    expect(find.text('위치와 알림은 나중에도 켤 수 있어요'), findsOneWidget);
+    expect(find.text('필요한 권한을 나중에 켤 수 있어요'), findsNothing);
     await tester.tap(find.byTooltip('이전 단계'));
     await tester.pumpAndSettle();
     expect(find.text('적용할 조건을 확인하세요'), findsOneWidget);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -757,6 +757,12 @@ void main() {
     expect(find.byKey(const Key('networkMapOverviewButton')), findsOneWidget);
     expect(find.byKey(const Key('networkMapLocateButton')), findsOneWidget);
     expect(find.byKey(const Key('networkMapListButton')), findsOneWidget);
+    expect(find.byTooltip('전체 노선도'), findsOneWidget);
+    expect(find.byTooltip('처음 위치로'), findsOneWidget);
+    expect(find.text('노선별로 보기'), findsOneWidget);
+    expect(find.byTooltip('전체 보기'), findsNothing);
+    expect(find.byTooltip('중심 보기'), findsNothing);
+    expect(find.text('노선 목록으로 보기'), findsNothing);
     expect(find.byKey(const Key('networkMapSurface')), findsOneWidget);
     expect(find.text('즐겨찾기'), findsOneWidget);
     expect(find.text('저장'), findsNothing);
@@ -808,6 +814,8 @@ void main() {
 
     await tester.tap(find.byKey(const Key('bottomNavMap')));
     await tester.pumpAndSettle();
+    expect(find.text('노선도를 불러오지 못했어요'), findsOneWidget);
+    expect(find.text('원본 노선도를 불러올 수 없습니다.'), findsNothing);
     await tester.tap(find.byKey(const Key('networkMapLineFilter')));
     await tester.pumpAndSettle();
     await tester.tap(find.text('4호선'));
@@ -1825,7 +1833,7 @@ void main() {
       );
       expect(
         settingsActionSemantics(
-          '알림 설정, 시설 상태, 제보 처리, 정보 갱신 알림을 관리해요',
+          '알림 설정, 시설 상태, 제보 처리, 최신 안내 알림을 관리해요',
         ).getSemanticsData().hasAction(SemanticsAction.tap),
         isTrue,
       );
@@ -2180,7 +2188,8 @@ void main() {
 
       expect(find.text('도움말·문의'), findsOneWidget);
       expect(find.text('개인정보처리방침'), findsOneWidget);
-      expect(find.text('https://easysubway.example/privacy'), findsOneWidget);
+      expect(find.text('https://easysubway.example/privacy'), findsNothing);
+      expect(find.text('웹에서 확인'), findsOneWidget);
       final privacyButtonSize = tester.getSize(
         find.byKey(const Key('privacyPolicyAccessItem')),
       );
@@ -2188,10 +2197,7 @@ void main() {
       final privacySemantics = tester
           .getSemantics(find.byKey(const Key('privacyPolicyAccessItem')))
           .getSemanticsData();
-      expect(
-        privacySemantics.label,
-        '개인정보처리방침, https://easysubway.example/privacy',
-      );
+      expect(privacySemantics.label, '개인정보처리방침, 웹에서 확인');
       expect(privacySemantics.hasAction(SemanticsAction.tap), isTrue);
 
       await tester.scrollUntilVisible(
@@ -2212,7 +2218,7 @@ void main() {
           .getSemanticsData();
       expect(
         deletionSemantics.label,
-        '데이터 삭제 요청, privacy@easysubway.example, 삭제 범위와 처리 절차를 메일로 문의해요',
+        '데이터 삭제 요청, 이메일 보내기, 삭제 범위와 처리 절차를 메일로 문의해요',
       );
       expect(deletionSemantics.hasAction(SemanticsAction.tap), isTrue);
 
@@ -2223,7 +2229,8 @@ void main() {
       );
       await tester.pumpAndSettle();
       expect(find.text('고객지원'), findsOneWidget);
-      expect(find.text('support@easysubway.example'), findsOneWidget);
+      expect(find.text('support@easysubway.example'), findsNothing);
+      expect(find.text('이메일 보내기'), findsWidgets);
       await tester.scrollUntilVisible(
         find.byKey(const Key('securityContactAccessItem')),
         120,
@@ -2386,13 +2393,14 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('보안 문의'), findsOneWidget);
-      expect(find.text('security@easysubway.example'), findsOneWidget);
+      expect(find.text('security@easysubway.example'), findsNothing);
+      expect(find.text('보안 문제 알리기'), findsOneWidget);
       expect(
         tester
             .getSemantics(find.byKey(const Key('securityContactAccessItem')))
             .getSemanticsData()
             .label,
-        '보안 문의, security@easysubway.example',
+        '보안 문의, 보안 문제 알리기',
       );
 
       await tester.tap(find.byKey(const Key('securityContactAccessItem')));
@@ -2892,7 +2900,8 @@ void main() {
       expect(find.text('역 시설 알림'), findsOneWidget);
       expect(find.text('경로 시설 알림'), findsOneWidget);
       expect(find.text('제보 처리 알림'), findsOneWidget);
-      expect(find.text('정보 갱신 알림'), findsOneWidget);
+      expect(find.text('정보 갱신 알림'), findsNothing);
+      expect(find.text('최신 안내 알림'), findsOneWidget);
       expect(find.bySemanticsLabel('역 시설 알림 켜짐'), findsOneWidget);
       expect(find.bySemanticsLabel('경로 시설 알림 꺼짐'), findsOneWidget);
 
@@ -2950,7 +2959,7 @@ void main() {
     expect(find.text('알림 받기'), findsOneWidget);
     expect(
       find.text(
-        '즐겨찾는 역과 경로의 시설 상태, 내 제보 처리 결과, 정보 갱신을 알려드립니다. 알림 설정에서 언제든 끌 수 있습니다.',
+        '즐겨찾는 역과 경로의 시설 변경, 제보 처리 상황, 최신 안내를 알려드려요. 알림 설정에서 언제든 끌 수 있습니다.',
       ),
       findsOneWidget,
     );
@@ -2960,8 +2969,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(notificationPermissionProvider.requestCount, 1);
-    expect(find.text('기기 알림이 켜졌습니다.'), findsOneWidget);
-    expect(find.bySemanticsLabel('기기 알림이 켜졌습니다.'), findsOneWidget);
+    expect(find.text('기기 알림이 켜졌습니다.'), findsNothing);
+    expect(find.text('알림이 켜졌어요.'), findsOneWidget);
+    expect(find.bySemanticsLabel('알림이 켜졌어요.'), findsOneWidget);
   });
 
   testWidgets('알림 설정 화면은 기기 알림 권한 거부를 짧게 안내한다', (tester) async {
@@ -2988,8 +2998,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(notificationPermissionProvider.requestCount, 1);
-    expect(find.text('기기 알림 권한을 켜 주세요.'), findsOneWidget);
-    expect(find.bySemanticsLabel('기기 알림 권한을 켜 주세요.'), findsOneWidget);
+    expect(find.text('기기 알림 권한을 켜 주세요.'), findsNothing);
+    expect(find.text('휴대전화 설정에서 알림을 허용해 주세요.'), findsOneWidget);
+    expect(find.bySemanticsLabel('휴대전화 설정에서 알림을 허용해 주세요.'), findsOneWidget);
     expect(find.text('기기 알림 설정과 네트워크 상태를 확인한 뒤 다시 시도해 주세요.'), findsNothing);
   });
 
@@ -2997,7 +3008,7 @@ void main() {
     final semanticsHandle = tester.ensureSemantics();
     final notificationPermissionProvider = FakeNotificationPermissionProvider(
       nextStatus: NotificationPermissionStatus.denied,
-      error: const NotificationSettingsException('기기 알림 등록을 마치지 못했습니다.'),
+      error: const NotificationSettingsException('알림을 켜지 못했어요.'),
     );
 
     try {
@@ -3020,10 +3031,14 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(notificationPermissionProvider.requestCount, 1);
-      expect(find.text('기기 알림 등록을 마치지 못했습니다.'), findsOneWidget);
-      expect(find.text('기기 알림 설정과 네트워크 상태를 확인한 뒤 다시 시도해 주세요.'), findsOneWidget);
+      expect(find.text('기기 알림 등록을 마치지 못했습니다.'), findsNothing);
+      expect(find.text('알림을 켜지 못했어요.'), findsOneWidget);
       expect(
-        find.bySemanticsLabel('다음 행동, 기기 알림 설정과 네트워크 상태를 확인한 뒤 다시 시도해 주세요.'),
+        find.text('휴대전화 알림 설정과 인터넷 연결을 확인한 뒤 다시 시도해 주세요.'),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel('다음 행동, 휴대전화 알림 설정과 인터넷 연결을 확인한 뒤 다시 시도해 주세요.'),
         findsOneWidget,
       );
       expect(
@@ -3031,7 +3046,7 @@ void main() {
           find.byKey(const Key('notificationRegistrationFailureNextAction')),
         ),
         isSemantics(
-          label: '다음 행동, 기기 알림 설정과 네트워크 상태를 확인한 뒤 다시 시도해 주세요.',
+          label: '다음 행동, 휴대전화 알림 설정과 인터넷 연결을 확인한 뒤 다시 시도해 주세요.',
           isLiveRegion: true,
         ),
       );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2197,7 +2197,10 @@ void main() {
       final privacySemantics = tester
           .getSemantics(find.byKey(const Key('privacyPolicyAccessItem')))
           .getSemanticsData();
-      expect(privacySemantics.label, '개인정보처리방침, 웹에서 확인');
+      expect(
+        privacySemantics.label,
+        '개인정보처리방침, 웹에서 확인, https://easysubway.example/privacy',
+      );
       expect(privacySemantics.hasAction(SemanticsAction.tap), isTrue);
 
       await tester.scrollUntilVisible(
@@ -2218,7 +2221,7 @@ void main() {
           .getSemanticsData();
       expect(
         deletionSemantics.label,
-        '데이터 삭제 요청, 이메일 보내기, 삭제 범위와 처리 절차를 메일로 문의해요',
+        '데이터 삭제 요청, 이메일 보내기, privacy@easysubway.example, 삭제 범위와 처리 절차를 메일로 문의해요',
       );
       expect(deletionSemantics.hasAction(SemanticsAction.tap), isTrue);
 
@@ -2400,7 +2403,7 @@ void main() {
             .getSemantics(find.byKey(const Key('securityContactAccessItem')))
             .getSemanticsData()
             .label,
-        '보안 문의, 보안 문제 알리기',
+        '보안 문의, 보안 문제 알리기, security@easysubway.example',
       );
 
       await tester.tap(find.byKey(const Key('securityContactAccessItem')));
@@ -2875,7 +2878,10 @@ void main() {
     await tester.tap(find.byKey(const Key('privacyPolicyAccessItem')));
     await tester.pump();
 
-    expect(find.text('연결할 수 없습니다. 잠시 후 다시 시도해 주세요.'), findsOneWidget);
+    expect(
+      find.text('연결할 수 없습니다. 직접 확인해 주세요: https://easysubway.example/privacy'),
+      findsOneWidget,
+    );
   });
 
   testWidgets('알림 설정 화면은 현재 설정을 불러오고 바꾼 값을 저장한다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

close #823

## 작업 배경

- QA 요청에 따라 알림, 온보딩, 노선도, 도움말·문의 화면에 남아 있던 기술 중심 표현을 실제 사용자가 이해하기 쉬운 문구로 정리했습니다.
- 알림 권한과 기기 등록 실패 문구가 서로 섞여 보여 원인과 다음 행동을 빠르게 이해하기 어려웠고, 일부 링크/이메일 값은 화면에 그대로 노출되어 지원 행동이 명확하지 않았습니다.

## 작업 내용

- 알림 설정 화면의 권한 요청, 등록 실패, 데이터 품질 알림 문구를 `알림 켜기`, `최신 안내 알림`, `휴대전화 알림 설정과 인터넷 연결` 기준으로 정리했습니다.
- 온보딩의 보기 설정과 권한 단계 문구를 `큰 글자`, `간편 보기`, `위치와 알림은 나중에도 켤 수 있어요`로 바꿨습니다.
- 노선도 컨트롤과 fallback 문구를 `전체 노선도`, `처음 위치로`, `노선별로 보기`, `노선도를 불러오지 못했어요`로 정리했습니다.
- 도움말·문의 화면은 URL과 이메일 주소를 그대로 노출하지 않고 `웹에서 확인`, `이메일 보내기`, `보안 문제 알리기` 같은 행동 중심 라벨을 표시하도록 했습니다.
- 변경된 문구와 Semantics 라벨을 widget/unit 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과:
- `cd apps/mobile && flutter test test/notification_settings_test.dart test/onboarding_test.dart test/widget_test.dart test/map_adapter_test.dart`: exit 0, 169 tests passed
- `cd apps/mobile && flutter test test/notification_permission_provider_test.dart test/onboarding_app_flow_test.dart`: exit 0, 8 tests passed
- `cd apps/mobile && flutter analyze`: exit 0, No issues found
- `rg -n "기기 알림|알림 권한|내 신고 처리 결과|정보 갱신|큰 글씨|단순 보기|선택한 권한 허용|필요한 권한|중심 보기|원본 노선도|원본 노선도를" apps/mobile/lib/notification_settings.dart apps/mobile/lib/onboarding.dart apps/mobile/lib/network_map.dart apps/mobile/lib/main.dart`: exit 1, target lib files에서 이전 표현 no matches

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 알림·온보딩·노선도·도움말 문구 회귀 | Flutter widget/unit test | 관련 widget/unit 테스트 실행 | `flutter test` command output | 177 tests passed |
| 정적 분석 | Flutter analyzer | `flutter analyze` 실행 | command output | No issues found |
| 이전 표현 잔존 여부 | local source check | target lib 파일 `rg` 검색 | command output | 이전 표현 no matches |
| Android 에뮬레이터 화면 증거 | Android emulator `emulator-5554` | 3-button navigation 상태에서 스크린샷·UI tree·crash log 캡처 | PR comment의 UI tree 발췌, local `.codex/evidence/pr-869/01-home-or-current.png`, `02-more.png`, `04-support-top.png`, `05-network-map.png` | 하단 시스템 내비게이션 여백, 보기 설정 문구, 도움말 안내, 노선도 컨트롤 문구 확인 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/notification_settings.dart`의 알림 권한/등록 실패 문구와 `apps/mobile/lib/main.dart`의 지원 링크 표시 라벨입니다.
- Android 에뮬레이터 스크린샷은 local evidence 폴더에 보관했고, PR에는 UI tree 발췌를 visible evidence로 남겼습니다.

## 리스크

- 제품 동작은 바꾸지 않고 표시 문구와 Semantics 라벨을 정리했습니다.
- debug 빌드에는 지원 URL과 알림 provider가 주입되지 않아 알림 권한 버튼과 외부 링크 활성 상태는 widget 테스트로 검증했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 알림, 온보딩, 도움말, 지도 화면의 안내 문구를 더 자연스럽고 일관된 표현으로 개선했습니다.
  * 외부 연결 실패 시 사용자가 다음 행동을 더 쉽게 알 수 있도록 안내 메시지를 업데이트했습니다.
  * 알림 권한 요청 및 실패 상황에서 보이는 오류 안내를 더 명확하게 바꿨습니다.

* **Style**
  * 설정 화면, 접근성 레이블, 버튼/툴팁 문구를 전반적으로 다듬었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->