### PR TITLE
[Feat] 노선도 SVG geometry extractor 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,12 @@ jobs:
           NODE_OPTIONS: --disable-warning=ExperimentalWarning
         run: node --test tools/datapack/*.test.mjs
 
+      - name: Repository CI / Run route map tool tests
+        if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.ci == 'true' }}
+        env:
+          NODE_OPTIONS: --disable-warning=ExperimentalWarning
+        run: node --test tools/route-map/*.test.mjs
+
       - name: Repository CI / Validate Docker Compose config
         if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         run: docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet

--- a/tools/ci/detect-changed-paths.sh
+++ b/tools/ci/detect-changed-paths.sh
@@ -55,6 +55,9 @@ while IFS= read -r file; do
       ios=true
       deploy=true
       ;;
+    tools/route-map/**)
+      repository=true
+      ;;
     apps/mobile/release/**)
       mobile=true
       android=true

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -305,6 +305,7 @@ test("지속적 통합 작업과 스텝 이름은 실패 영역을 구분할 수
   assert.doesNotMatch(workflow, /name: iOS CI/);
   assert.doesNotMatch(workflow, /runs-on: macos-latest/);
   assert.match(workflow, /Repository CI \/ Run contract tests/);
+  assert.match(workflow, /Repository CI \/ Run route map tool tests/);
   assert.match(workflow, /Backend CI \/ Detect backend scaffold/);
   assert.match(workflow, /Mobile App CI \/ Run Flutter analyzer and tests/);
   assert.match(workflow, /Mobile App CI \/ Run mobile contracts/);
@@ -5566,6 +5567,13 @@ test("경로 분류기는 저장소, 백엔드, 모바일, Android, iOS 변경�
   assert.equal(datapack.android, "true");
   assert.equal(datapack.ios, "true");
   assert.equal(datapack.deploy, "true");
+
+  const routeMapTool = await classifyChangedFiles(["tools/route-map/extract-svg-geometry.mjs"]);
+  assert.equal(routeMapTool.repository, "true");
+  assert.equal(routeMapTool.mobile, "false");
+  assert.equal(routeMapTool.android, "false");
+  assert.equal(routeMapTool.ios, "false");
+  assert.equal(routeMapTool.deploy, "false");
 });
 
 test("경로 분류기는 백엔드 품질 gate 변경을 repository contract 대상으로 처리한다", async () => {

--- a/tools/route-map/extract-svg-geometry.mjs
+++ b/tools/route-map/extract-svg-geometry.mjs
@@ -132,11 +132,14 @@ function browserExtractorExpression(svg) {
         },
       };
     }
-    function isVisibleText(element) {
+    function isVisibleText(element, root) {
       if (element.closest("defs")) return false;
-      const style = getComputedStyle(element);
-      if (style.display === "none" || style.visibility === "hidden") return false;
-      if (Number.parseFloat(style.opacity || "1") === 0) return false;
+      for (let current = element; current; current = current.parentElement) {
+        const style = getComputedStyle(current);
+        if (style.display === "none" || style.visibility === "hidden") return false;
+        if (Number.parseFloat(style.opacity || "1") <= 0) return false;
+        if (current === root) break;
+      }
       return true;
     }
     function sourceViewBox(root) {
@@ -165,7 +168,7 @@ function browserExtractorExpression(svg) {
 
     for (const element of root.querySelectorAll("text")) {
       const sourceText = normalizeText(element.textContent || "");
-      if (!sourceText || !isVisibleText(element)) continue;
+      if (!sourceText || !isVisibleText(element, root)) continue;
       let bbox;
       try {
         bbox = element.getBBox();

--- a/tools/route-map/extract-svg-geometry.mjs
+++ b/tools/route-map/extract-svg-geometry.mjs
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { execFile, execFileSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const extractorVersion = "route-map-svg-geometry-v1";
+
+function usage() {
+  return `Usage: node tools/route-map/extract-svg-geometry.mjs <svg-file> --region <name> [--browser <path>] [--pretty]
+
+Extract visible SVG <text> bounding polygons in root SVG coordinates.
+`;
+}
+
+function parseArgs(argv) {
+  const options = { pretty: false, browser: "", region: "" };
+  const positionals = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") return { help: true };
+    if (arg === "--pretty") {
+      options.pretty = true;
+    } else if (arg === "--browser") {
+      options.browser = argv[++index] ?? "";
+    } else if (arg === "--region") {
+      options.region = argv[++index] ?? "";
+    } else if (arg.startsWith("--")) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else {
+      positionals.push(arg);
+    }
+  }
+  if (positionals.length !== 1) throw new Error("Exactly one SVG file is required.");
+  if (!options.region.trim()) throw new Error("--region is required.");
+  return { ...options, svgFile: positionals[0] };
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function findBrowser(explicitBrowser) {
+  if (explicitBrowser) {
+    if (!existsSync(explicitBrowser)) throw new Error(`Browser not found: ${explicitBrowser}`);
+    return explicitBrowser;
+  }
+  const candidates = [
+    process.env.CHROME_PATH,
+    process.env.BROWSER_PATH,
+    "google-chrome-stable",
+    "google-chrome",
+    "chromium-browser",
+    "chromium",
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    if (candidate.includes(path.sep) && existsSync(candidate)) return candidate;
+    try {
+      execFileSync(candidate, ["--version"], { timeout: 2000, stdio: "ignore" });
+      return candidate;
+    } catch {
+      // Try the next common binary name.
+    }
+  }
+  throw new Error("Chrome/Chromium binary not found. Pass --browser <path> or set CHROME_PATH.");
+}
+
+function stripSvgPreamble(svg) {
+  return svg.replace(/^\s*<\?xml[\s\S]*?\?>/i, "").replace(/^\s*<!doctype[\s\S]*?>/i, "");
+}
+
+function browserExtractorExpression(svg) {
+  const svgBase64 = Buffer.from(stripSvgPreamble(svg), "utf8").toString("base64");
+  return `(${async function extract(value) {
+    function decodeBase64Utf8(base64) {
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+      return new TextDecoder().decode(bytes);
+    }
+    function normalizeText(value) {
+      return value.normalize("NFKC").trim().replace(/\s+/g, " ");
+    }
+    function classifyText(element, text) {
+      const explicit = element.getAttribute("data-route-map-classification");
+      if (explicit) return explicit.toUpperCase();
+      if (/not to scale|축척/i.test(text)) return "NOTICE";
+      if (/^[0-9A-Za-z가-힣]+호선$/.test(text) || /Line$/i.test(text)) return "LINE_LABEL";
+      return "STATION_LABEL";
+    }
+    function number(value) {
+      return Math.round(value * 1000) / 1000;
+    }
+    function matrixPoint(matrix, x, y) {
+      const point = new DOMPoint(x, y).matrixTransform(matrix);
+      return { x: number(point.x), y: number(point.y) };
+    }
+    function elementClasses(element) {
+      if (typeof element.className === "string") return element.className;
+      return element.className?.baseVal ?? "";
+    }
+    function descriptorFor(element, text, bbox) {
+      const ancestors = [];
+      let current = element.parentElement;
+      while (current && current.tagName.toLowerCase() !== "svg") {
+        ancestors.push({
+          tag: current.tagName.toLowerCase(),
+          id: current.id || "",
+          className: elementClasses(current),
+          transform: current.getAttribute("transform") || "",
+        });
+        current = current.parentElement;
+      }
+      return {
+        text,
+        tag: element.tagName.toLowerCase(),
+        id: element.id || "",
+        className: elementClasses(element),
+        transform: element.getAttribute("transform") || "",
+        ancestors,
+        bbox: {
+          x: number(bbox.x),
+          y: number(bbox.y),
+          width: number(bbox.width),
+          height: number(bbox.height),
+        },
+      };
+    }
+    function isVisibleText(element) {
+      if (element.closest("defs")) return false;
+      const style = getComputedStyle(element);
+      if (style.display === "none" || style.visibility === "hidden") return false;
+      if (Number.parseFloat(style.opacity || "1") === 0) return false;
+      return true;
+    }
+    function sourceViewBox(root) {
+      const viewBox = root.viewBox?.baseVal;
+      if (viewBox && viewBox.width > 0 && viewBox.height > 0) {
+        return [number(viewBox.x), number(viewBox.y), number(viewBox.width), number(viewBox.height)];
+      }
+      const width = root.width?.baseVal?.value || root.getBoundingClientRect().width;
+      const height = root.height?.baseVal?.value || root.getBoundingClientRect().height;
+      return [0, 0, number(width), number(height)];
+    }
+
+    document.body.innerHTML = "<div id='host' style='width:1200px;height:900px;margin:0'></div>";
+    document.getElementById("host").innerHTML = decodeBase64Utf8(value);
+    if (document.fonts?.ready) {
+      await Promise.race([document.fonts.ready, new Promise((resolve) => setTimeout(resolve, 250))]);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const root = document.querySelector("#host > svg");
+    if (!root) throw new Error("Root <svg> not found.");
+    const rootScreenMatrix = root.getScreenCTM();
+    if (!rootScreenMatrix) throw new Error("Root SVG screen matrix not available.");
+    const rootInverse = rootScreenMatrix.inverse();
+    const labels = [];
+
+    for (const element of root.querySelectorAll("text")) {
+      const sourceText = normalizeText(element.textContent || "");
+      if (!sourceText || !isVisibleText(element)) continue;
+      let bbox;
+      try {
+        bbox = element.getBBox();
+      } catch {
+        continue;
+      }
+      if (bbox.width <= 0 || bbox.height <= 0) continue;
+      const elementMatrix = element.getScreenCTM();
+      if (!elementMatrix) continue;
+      const matrix = rootInverse.multiply(elementMatrix);
+      const polygon = [
+        matrixPoint(matrix, bbox.x, bbox.y),
+        matrixPoint(matrix, bbox.x + bbox.width, bbox.y),
+        matrixPoint(matrix, bbox.x + bbox.width, bbox.y + bbox.height),
+        matrixPoint(matrix, bbox.x, bbox.y + bbox.height),
+      ];
+      const xs = polygon.map((point) => point.x);
+      const ys = polygon.map((point) => point.y);
+      labels.push({
+        sourceText,
+        normalizedText: sourceText.replace(/역$/, ""),
+        classification: classifyText(element, sourceText),
+        polygon,
+        bounds: {
+          minX: Math.min(...xs),
+          minY: Math.min(...ys),
+          maxX: Math.max(...xs),
+          maxY: Math.max(...ys),
+        },
+        descriptor: descriptorFor(element, sourceText, bbox),
+      });
+    }
+
+    return { sourceViewBox: sourceViewBox(root), labels };
+  }})(${JSON.stringify(svgBase64)})`;
+}
+
+async function browserVersion(browser) {
+  const { stdout } = await execFileAsync(browser, ["--version"], { timeout: 5000 });
+  return stdout.trim();
+}
+
+async function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+async function waitForTarget(port) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10000) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/json/new`, { method: "PUT" });
+      if (response.ok) return await response.json();
+    } catch {
+      // Chrome is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error("Timed out waiting for Chrome DevTools target.");
+}
+
+function openWebSocket(url) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url);
+    socket.addEventListener("open", () => resolve(socket), { once: true });
+    socket.addEventListener("error", reject, { once: true });
+  });
+}
+
+function cdpCall(socket, id, method, params = {}) {
+  return new Promise((resolve, reject) => {
+    function onMessage(event) {
+      const message = JSON.parse(event.data);
+      if (message.id !== id) return;
+      socket.removeEventListener("message", onMessage);
+      if (message.error) reject(new Error(`${method} failed: ${message.error.message}`));
+      else resolve(message.result);
+    }
+    socket.addEventListener("message", onMessage);
+    socket.send(JSON.stringify({ id, method, params }));
+  });
+}
+
+async function runBrowserExtraction({ browser, svg, tempDir }) {
+  const port = await freePort();
+  const child = spawn(browser, [
+    "--headless=new",
+    "--disable-gpu",
+    "--disable-dev-shm-usage",
+    "--no-first-run",
+    "--no-default-browser-check",
+    `--user-data-dir=${path.join(tempDir, "profile")}`,
+    `--remote-debugging-port=${port}`,
+    "about:blank",
+  ], { stdio: ["ignore", "ignore", "pipe"] });
+  let stderr = "";
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  try {
+    const target = await waitForTarget(port);
+    const socket = await openWebSocket(target.webSocketDebuggerUrl);
+    try {
+      let id = 1;
+      await cdpCall(socket, id++, "Runtime.enable");
+      const result = await cdpCall(socket, id++, "Runtime.evaluate", {
+        expression: browserExtractorExpression(svg),
+        awaitPromise: true,
+        returnByValue: true,
+        timeout: 20000,
+      });
+      if (result.exceptionDetails) {
+        throw new Error(result.exceptionDetails.text || "Browser Runtime.evaluate failed.");
+      }
+      return result.result.value;
+    } finally {
+      socket.close();
+    }
+  } catch (error) {
+    throw new Error([error.message, stderr.trim() && `stderr: ${stderr.trim()}`].filter(Boolean).join("\n"));
+  } finally {
+    child.kill("SIGTERM");
+  }
+}
+
+async function extractSvgGeometry({ svgFile, region, browser }) {
+  const svg = await readFile(path.resolve(svgFile), "utf8");
+  const sourceSvgSha256 = sha256(svg);
+  const tempDir = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-"));
+  try {
+    const extracted = await runBrowserExtraction({ browser, svg, tempDir });
+    const version = await browserVersion(browser);
+    return {
+      schemaVersion: 1,
+      region,
+      sourceSvgSha256,
+      extractorVersion,
+      browser: {
+        name: version.split(/\s+/)[0] || "Chromium",
+        version,
+      },
+      sourceViewBox: extracted.sourceViewBox,
+      labels: extracted.labels.map((label, polygonIndex) => {
+        const descriptor = { ...label.descriptor, sourceSvgSha256 };
+        const sourceElementKey = sha256(JSON.stringify(descriptor));
+        const { descriptor: _descriptor, ...publicLabel } = label;
+        return { ...publicLabel, polygonIndex, sourceElementKey };
+      }),
+    };
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  const browser = findBrowser(options.browser);
+  const result = await extractSvgGeometry({
+    svgFile: options.svgFile,
+    region: options.region.trim(),
+    browser,
+  });
+  process.stdout.write(`${JSON.stringify(result, null, options.pretty ? 2 : 0)}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/tools/route-map/fixtures/geometry-fixture.svg
+++ b/tools/route-map/fixtures/geometry-fixture.svg
@@ -9,6 +9,15 @@
     <text id="notice" x="100" y="100" font-size="8">Not to scale</text>
     <text id="hidden" class="hidden" x="5" y="100">숨김역</text>
   </g>
+  <g id="transparent-layer" opacity="0">
+    <text x="20" y="20">투명역</text>
+  </g>
+  <g id="hidden-layer" visibility="hidden">
+    <text x="20" y="40">비가시역</text>
+  </g>
+  <g id="display-none-layer" display="none">
+    <text x="20" y="60">레이어숨김역</text>
+  </g>
   <defs>
     <text id="template" x="0" y="0">템플릿역</text>
   </defs>

--- a/tools/route-map/fixtures/geometry-fixture.svg
+++ b/tools/route-map/fixtures/geometry-fixture.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 120">
+  <style>
+    .hidden { display: none; }
+  </style>
+  <g id="station-labels" class="labels" transform="translate(10 5)">
+    <text id="alpha" x="20" y="30" font-size="12" data-route-map-classification="station_label">알파역</text>
+    <text id="rotated" x="60" y="40" font-size="10" transform="rotate(30 60 40)">회전역</text>
+    <text id="line-label" x="20" y="80" font-size="9">1호선</text>
+    <text id="notice" x="100" y="100" font-size="8">Not to scale</text>
+    <text id="hidden" class="hidden" x="5" y="100">숨김역</text>
+  </g>
+  <defs>
+    <text id="template" x="0" y="0">템플릿역</text>
+  </defs>
+</svg>

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -28,8 +28,9 @@ test("SVG geometry extractor returns transformed visible text polygons", async (
 
   const texts = output.labels.map((label) => label.sourceText).sort();
   assert.deepEqual(texts, ["1호선", "Not to scale", "알파역", "회전역"]);
-  assert.equal(output.labels.find((label) => label.sourceText === "숨김역"), undefined);
-  assert.equal(output.labels.find((label) => label.sourceText === "템플릿역"), undefined);
+  for (const hiddenText of ["숨김역", "투명역", "비가시역", "레이어숨김역", "템플릿역"]) {
+    assert.equal(output.labels.find((label) => label.sourceText === hiddenText), undefined);
+  }
 
   const line = output.labels.find((label) => label.sourceText === "1호선");
   assert.equal(line.classification, "LINE_LABEL");

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(import.meta.dirname, "../..");
+
+test("SVG geometry extractor returns transformed visible text polygons", async () => {
+  const fixture = "tools/route-map/fixtures/geometry-fixture.svg";
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    ["tools/route-map/extract-svg-geometry.mjs", fixture, "--region", "fixture"],
+    { cwd: root, maxBuffer: 1024 * 1024 },
+  );
+  const output = JSON.parse(stdout);
+  const source = await readFile(path.join(root, fixture), "utf8");
+
+  assert.equal(output.schemaVersion, 1);
+  assert.equal(output.region, "fixture");
+  assert.equal(output.extractorVersion, "route-map-svg-geometry-v1");
+  assert.equal(output.sourceSvgSha256, createHash("sha256").update(source).digest("hex"));
+  assert.deepEqual(output.sourceViewBox, [0, 0, 200, 120]);
+  assert.match(output.browser.version, /Chrome|Chromium/i);
+
+  const texts = output.labels.map((label) => label.sourceText).sort();
+  assert.deepEqual(texts, ["1호선", "Not to scale", "알파역", "회전역"]);
+  assert.equal(output.labels.find((label) => label.sourceText === "숨김역"), undefined);
+  assert.equal(output.labels.find((label) => label.sourceText === "템플릿역"), undefined);
+
+  const line = output.labels.find((label) => label.sourceText === "1호선");
+  assert.equal(line.classification, "LINE_LABEL");
+  const notice = output.labels.find((label) => label.sourceText === "Not to scale");
+  assert.equal(notice.classification, "NOTICE");
+
+  const alpha = output.labels.find((label) => label.sourceText === "알파역");
+  assert.equal(alpha.classification, "STATION_LABEL");
+  assert.match(alpha.sourceElementKey, /^[a-f0-9]{64}$/);
+  assert.equal(alpha.polygon.length, 4);
+  assert.ok(alpha.bounds.maxX > alpha.bounds.minX);
+  assert.ok(alpha.bounds.maxY > alpha.bounds.minY);
+
+  const rotated = output.labels.find((label) => label.sourceText === "회전역");
+  assert.notEqual(rotated.polygon[0].y, rotated.polygon[1].y);
+  assert.notEqual(rotated.polygon[0].x, rotated.polygon[3].x);
+});


### PR DESCRIPTION
## 관련 이슈

close #868

## 작업 배경

#836의 실제 SVG label polygon 기반 hit-test와 production 좌표 감사로 넘어가기 위해, 먼저 bundled SVG의 `<text>` bbox polygon을 재현 가능하게 추출하는 CLI 계약이 필요하다. 이번 PR은 production 좌표 보정이나 datapack migration 없이 extractor와 fixture 검증만 추가한다.

## 작업 내용

- `tools/route-map/extract-svg-geometry.mjs` CLI를 추가했다.
- Chrome/Chromium DevTools Protocol을 사용해 SVG를 브라우저 DOM에 주입하고 `<text>` `getBBox()`와 transform matrix를 root SVG source 좌표계 polygon으로 변환한다.
- output metadata에 schema version, region, source SVG SHA-256, extractor version, browser version, source viewBox를 포함한다.
- visible text만 추출하고 `defs`, hidden, zero-size text는 제외한다.
- source element key는 normalized descriptor와 source SVG SHA를 SHA-256으로 묶어 생성한다.
- fixture SVG와 Node test로 transform polygon, ancestor hidden text 제외, NOTICE/LINE_LABEL/STATION_LABEL 분류를 검증한다.
- Repository CI가 `tools/route-map/*.test.mjs`를 실행하도록 배선하고, `tools/route-map/**` 변경을 repository gate로 분류한다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/route-map/*.test.mjs tools/ci/*.test.mjs`: exit 0, 103 tests passed
  - `node tools/route-map/extract-svg-geometry.mjs apps/mobile/assets/datapacks/maps/seoul-official-route-map.svg --region 수도권`: exit 0, sourceViewBox `[0,0,5724,6516]`, labelCount `712`, NOTICE `1`
  - GitHub Actions `CI`: success, https://github.com/AquilaXk/easysubway/actions/runs/28176741483
  - GitHub Actions `Release Artifacts`: success, https://github.com/AquilaXk/easysubway/actions/runs/28176740251
  - CodeRabbit: credit exhausted comment 확인, Codex CLI fallback review로 대체
  - Codex CLI fallback review: 1건 지적 수정 후 최신 head 재검토 결과 actionable 0건
  - Merge 후 GitHub Actions `CD`: success, https://github.com/AquilaXk/easysubway/actions/runs/28177189890
  - Merge 후 GitHub Actions `CI`: in_progress, https://github.com/AquilaXk/easysubway/actions/runs/28177191667
  - Merge 후 GitHub Actions `Release Artifacts`: in_progress, https://github.com/AquilaXk/easysubway/actions/runs/28177189754

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| fixture polygon 추출 | macOS / Node 24 / Chrome DevTools | `node --test tools/route-map/*.test.mjs tools/ci/*.test.mjs` | command output | rotated text polygon, hidden/defs/ancestor hidden 제외, classification, source key 검증 통과 |
| 실제 서울 SVG smoke | macOS / Node 24 / Chrome DevTools | `node tools/route-map/extract-svg-geometry.mjs apps/mobile/assets/datapacks/maps/seoul-official-route-map.svg --region 수도권` | command output 요약 | schemaVersion 1, sourceViewBox `[0,0,5724,6516]`, labelCount 712, NOTICE 1 |
| CI | GitHub Actions | `CI` workflow | https://github.com/AquilaXk/easysubway/actions/runs/28176741483 | success |
| Release artifact failure check | GitHub Actions | `Release Artifacts` workflow | https://github.com/AquilaXk/easysubway/actions/runs/28176740251 | success |
| Merge 후 CD failure check | GitHub Actions | `CD` workflow | https://github.com/AquilaXk/easysubway/actions/runs/28177189890 | success |
| Merge 후 CI/CD 생성 확인 | GitHub Actions | main branch workflow list | https://github.com/AquilaXk/easysubway/actions/runs/28177191667, https://github.com/AquilaXk/easysubway/actions/runs/28177189754 | CI와 Release Artifacts run 생성, 진행 중이며 실패 신호 없음 |
| Android/iOS 화면 증거 | 해당 없음 | CLI/data tooling만 변경 | 증거 불필요 사유: 앱 런타임 화면, hit-test, renderer 동작을 바꾸지 않음 | 런타임 실기기 검증은 polygon hit-test 연결 PR에서 수행 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `tools/route-map/extract-svg-geometry.mjs`가 새 dependency 없이 Chrome CDP만 사용하는지
  - `tools/route-map/route-map-tools.test.mjs`가 transform과 ancestor hidden text 제외를 고정하는지
  - CI가 route-map tool test를 누락하지 않는지

## 리스크

- Chrome/Chromium binary가 없는 환경에서는 extractor가 실패한다. CLI는 `--browser` 또는 `CHROME_PATH`로 경로를 지정할 수 있다.
- classification은 extractor seed 수준의 최소 heuristic이다. production station-line 매칭, ambiguity, manual override는 후속 PR 범위다.
- 이 PR은 geometry를 datapack에 반영하지 않으므로 앱 동작 변화는 없다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
