### PR TITLE
[Fix] 경로 score·거리·confidence 계약 서버·로컬 정합화

### DIFF
--- a/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
+++ b/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
@@ -580,6 +580,11 @@ Map<String, Object?> _routeResultToJson(RouteSearchResult result) {
     'lineId': result.lineId,
     'lineName': result.lineName,
     'score': result.score,
+    'burdenCost': result.burdenCost,
+    'estimatedDurationSeconds': result.estimatedDurationSeconds,
+    'walkingDistanceMeters': result.walkingDistanceMeters,
+    'transferCount': result.transferCount,
+    'evidenceSummary': result.evidenceSummary,
     'steps': result.steps.map(_routeStepToJson).toList(growable: false),
     'warnings': result.warnings
         .map(_routeWarningToJson)
@@ -593,6 +598,7 @@ Map<String, Object?> _routeResultToJson(RouteSearchResult result) {
 Map<String, Object?> _routeStepToJson(RouteSearchStep step) {
   return {
     'sequence': step.sequence,
+    'stepType': step.stepType,
     'title': step.title,
     'description': step.description,
     'lineId': step.lineId,

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -42,6 +42,7 @@ class LocalRouteRepository implements RouteSearchRepository {
     final lineIds = result.lineIds;
     final primaryLineId = lineIds.isEmpty ? '' : lineIds.first;
     final primaryLineName = catalog.lineName(primaryLineId);
+    final steps = _toSteps(result, catalog);
 
     return RouteSearchResult(
       routeSearchId:
@@ -55,7 +56,12 @@ class LocalRouteRepository implements RouteSearchRepository {
       lineId: primaryLineId,
       lineName: primaryLineName,
       score: result.totalCost,
-      steps: _toSteps(result, catalog),
+      burdenCost: result.totalCost,
+      estimatedDurationSeconds: _estimatedDurationSeconds(steps),
+      walkingDistanceMeters: _walkingDistanceMeters(steps),
+      transferCount: _transferCount(steps),
+      evidenceSummary: _evidenceSummary(result),
+      steps: steps,
       warnings: result.warnings
           .map(
             (warning) => RouteSearchWarning(
@@ -114,6 +120,66 @@ class LocalRouteRepository implements RouteSearchRepository {
           );
         })
         .toList(growable: false);
+  }
+
+  int _estimatedDurationSeconds(List<RouteSearchStep> steps) {
+    return steps.fold<int>(
+      0,
+      (sum, step) =>
+          sum + (step.estimatedMinutes < 0 ? 0 : step.estimatedMinutes * 60),
+    );
+  }
+
+  int _walkingDistanceMeters(List<RouteSearchStep> steps) {
+    return steps.fold<int>(
+      0,
+      (sum, step) => step.isWalkingStep ? sum + step.distanceMeters : sum,
+    );
+  }
+
+  int _transferCount(List<RouteSearchStep> steps) {
+    final typedTransfers = steps.where((step) => step.stepType == 'transfer');
+    if (typedTransfers.isNotEmpty) {
+      return typedTransfers.length;
+    }
+    var previousLine = '';
+    var changes = 0;
+    for (final step in steps) {
+      final line = step.lineId.isNotEmpty ? step.lineId : step.lineName;
+      if (line.isEmpty) {
+        continue;
+      }
+      if (previousLine.isNotEmpty && previousLine != line) {
+        changes += 1;
+      }
+      previousLine = line;
+    }
+    return changes;
+  }
+
+  List<String> _evidenceSummary(local.LocalRouteResult result) {
+    if (result.steps.isEmpty) {
+      return const [];
+    }
+    final requiresAccessibilityCheck = result.steps.any(
+      (step) =>
+          step.type.name == 'entry' ||
+          step.type.name == 'exit' ||
+          step.stairAccessState == 'unknown',
+    );
+    final hasDurationEstimate = result.steps.every(
+      (step) => step.durationSeconds > 0,
+    );
+    final hasDistanceMeasure = result.steps.every(
+      (step) => step.distanceMeters > 0,
+    );
+    return [
+      requiresAccessibilityCheck
+          ? 'ACCESSIBILITY_CHECK_REQUIRED'
+          : 'ACCESSIBILITY_VERIFIED',
+      hasDurationEstimate ? 'DURATION_ESTIMATED' : 'DURATION_UNKNOWN',
+      hasDistanceMeasure ? 'DISTANCE_MEASURED' : 'DISTANCE_UNKNOWN',
+    ];
   }
 
   String _stepTitle(

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -541,18 +541,38 @@ class RouteSearchResult {
     required this.lineId,
     required this.lineName,
     required this.score,
+    int? burdenCost,
+    int? estimatedDurationSeconds,
+    int? walkingDistanceMeters,
+    int? transferCount,
+    this.evidenceSummary = const [],
     required this.steps,
     required this.warnings,
     this.recommendationReasons = const [],
     required this.blockedReasons,
     required this.createdAt,
-  });
+  }) : // `burdenCost`는 API contract 이름이고 저장 필드는 fallback용 private 값이다.
+       // ignore: prefer_initializing_formals
+       _burdenCost = burdenCost,
+       // ignore: prefer_initializing_formals
+       _estimatedDurationSeconds = estimatedDurationSeconds,
+       // ignore: prefer_initializing_formals
+       _walkingDistanceMeters = walkingDistanceMeters,
+       // ignore: prefer_initializing_formals
+       _transferCount = transferCount;
 
   factory RouteSearchResult.fromJson(Map<String, Object?> json) {
     final rawSteps = json['steps'];
     final rawWarnings = json['warnings'];
     final rawRecommendationReasons = json['recommendationReasons'];
     final rawBlockedReasons = json['blockedReasons'];
+    final legacyScore = _optionalRouteInt(json, 'score');
+    final burdenCost =
+        _optionalRouteInt(json, 'burdenCost') ??
+        legacyScore ??
+        (throw const FormatException(
+          'Missing required route field: burdenCost',
+        ));
     if (rawSteps is! List<Object?> ||
         rawWarnings is! List<Object?> ||
         (rawRecommendationReasons != null &&
@@ -574,7 +594,14 @@ class RouteSearchResult {
       status: _requiredRouteString(json, 'status'),
       lineId: _optionalRouteString(json, 'lineId'),
       lineName: _optionalRouteString(json, 'lineName'),
-      score: _requiredRouteInt(json, 'score'),
+      score: legacyScore ?? burdenCost,
+      burdenCost: burdenCost,
+      estimatedDurationSeconds: _optionalRouteInt(
+        json,
+        'estimatedDurationSeconds',
+      ),
+      walkingDistanceMeters: _optionalRouteInt(json, 'walkingDistanceMeters'),
+      transferCount: _optionalRouteInt(json, 'transferCount'),
       steps: rawSteps
           .map((item) {
             if (item is! Map<String, Object?>) {
@@ -594,6 +621,10 @@ class RouteSearchResult {
       recommendationReasons: _routeStringList(
         rawRecommendationReasons,
         'recommendation reason',
+      ),
+      evidenceSummary: _routeStringList(
+        json['evidenceSummary'],
+        'route evidence summary',
       ),
       blockedReasons: rawBlockedReasons
           .map((item) {
@@ -617,11 +648,28 @@ class RouteSearchResult {
   final String lineId;
   final String lineName;
   final int score;
+  final int? _burdenCost;
+  final int? _estimatedDurationSeconds;
+  final int? _walkingDistanceMeters;
+  final int? _transferCount;
+  final List<String> evidenceSummary;
   final List<RouteSearchStep> steps;
   final List<RouteSearchWarning> warnings;
   final List<String> recommendationReasons;
   final List<String> blockedReasons;
   final String createdAt;
+
+  int get burdenCost => _burdenCost ?? score;
+
+  int get estimatedDurationSeconds {
+    return _estimatedDurationSeconds ??
+        steps.fold<int>(
+          0,
+          (sum, step) =>
+              sum +
+              (step.estimatedMinutes < 0 ? 0 : step.estimatedMinutes * 60),
+        );
+  }
 
   List<String> get recommendationReasonLabels {
     if (recommendationReasons.isEmpty) {
@@ -646,13 +694,17 @@ class RouteSearchResult {
   }
 
   int get walkingDistanceMeters {
-    return steps.fold<int>(
-      0,
-      (sum, step) => step.isWalkingStep ? sum + step.distanceMeters : sum,
-    );
+    return _walkingDistanceMeters ??
+        steps.fold<int>(
+          0,
+          (sum, step) => step.isWalkingStep ? sum + step.distanceMeters : sum,
+        );
   }
 
   int get transferCount {
+    if (_transferCount != null) {
+      return _transferCount;
+    }
     final typedTransfers = steps.where((step) => step.stepType == 'transfer');
     if (typedTransfers.isNotEmpty) {
       return typedTransfers.length;
@@ -4602,6 +4654,14 @@ int _requiredRouteInt(Map<String, Object?> json, String key) {
     return value;
   }
   throw FormatException('Missing required route field: $key');
+}
+
+int? _optionalRouteInt(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is int) {
+    return value;
+  }
+  return null;
 }
 
 bool _requiredRouteBool(Map<String, Object?> json, String key) {

--- a/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
+++ b/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
 import 'package:easysubway_mobile/app/app_dependencies.dart';
 import 'package:easysubway_mobile/core/database/catalog/catalog_database.dart';
 import 'package:easysubway_mobile/core/database/user/user_database.dart'
@@ -138,6 +141,11 @@ void main() {
       lineId: 'seoul-4',
       lineName: '수도권 4호선',
       score: 92,
+      burdenCost: 44,
+      estimatedDurationSeconds: 600,
+      walkingDistanceMeters: 120,
+      transferCount: 1,
+      evidenceSummary: const ['DURATION_ESTIMATED', 'DISTANCE_MEASURED'],
       steps: const [],
       warnings: const [],
       blockedReasons: const [],
@@ -154,6 +162,28 @@ void main() {
     expect(saved.routeSearchId, result.routeSearchId);
     expect(favorites.single.lineName, '수도권 4호선');
     expect(favorites.single.score, 92);
+    final snapshotRows = await userDatabase
+        .customSelect(
+          'SELECT value FROM app_preferences WHERE key = ?',
+          variables: [
+            Variable.withString(
+              'favorite_route_snapshot:${result.routeSearchId}::SENIOR',
+            ),
+          ],
+          readsFrom: {userDatabase.appPreferences},
+        )
+        .get();
+    final snapshot =
+        jsonDecode(snapshotRows.single.read<String>('value'))
+            as Map<String, Object?>;
+    expect(snapshot['burdenCost'], 44);
+    expect(snapshot['estimatedDurationSeconds'], 600);
+    expect(snapshot['walkingDistanceMeters'], 120);
+    expect(snapshot['transferCount'], 1);
+    expect(snapshot['evidenceSummary'], [
+      'DURATION_ESTIMATED',
+      'DISTANCE_MEASURED',
+    ]);
 
     await repository.removeFavoriteRoute(saved.favoriteRouteId);
 

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -57,6 +57,23 @@ void main() {
     expect(result.lineName, '수도권 4호선');
     expect(result.isLocalResult, isTrue);
     expect(result.score, greaterThan(100));
+    expect(result.burdenCost, result.score);
+    expect(
+      result.estimatedDurationSeconds,
+      result.steps.fold<int>(
+        0,
+        (sum, step) => sum + step.estimatedMinutes * 60,
+      ),
+    );
+    expect(
+      result.walkingDistanceMeters,
+      result.steps
+          .where((step) => step.isWalkingStep)
+          .fold<int>(0, (sum, step) => sum + step.distanceMeters),
+    );
+    expect(result.transferCount, 0);
+    expect(result.evidenceSummary, contains('DURATION_ESTIMATED'));
+    expect(result.evidenceSummary, contains('DISTANCE_UNKNOWN'));
     expect(
       result.steps
           .map((step) => step.lineId)

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -157,6 +157,15 @@ void main() {
               'lineId': 'seoul-4',
               'lineName': '수도권 4호선',
               'score': 92,
+              'burdenCost': 41,
+              'estimatedDurationSeconds': 420,
+              'walkingDistanceMeters': 300,
+              'transferCount': 0,
+              'evidenceSummary': [
+                'ACCESSIBILITY_CHECK_REQUIRED',
+                'DURATION_ESTIMATED',
+                'DISTANCE_MEASURED',
+              ],
               'steps': [
                 {
                   'sequence': 1,
@@ -233,6 +242,16 @@ void main() {
     expect(result.summaryTitle, '상록수에서 사당까지');
     expect(result.lineName, '수도권 4호선');
     expect(result.statusLabel, '경로를 찾았습니다');
+    expect(result.score, 92);
+    expect(result.burdenCost, 41);
+    expect(result.estimatedDurationSeconds, 420);
+    expect(result.walkingDistanceMeters, 300);
+    expect(result.transferCount, 0);
+    expect(result.evidenceSummary, [
+      'ACCESSIBILITY_CHECK_REQUIRED',
+      'DURATION_ESTIMATED',
+      'DISTANCE_MEASURED',
+    ]);
     expect(result.scoreLabel, '이동 부담 보통');
     expect(result.scoreLabel, isNot(contains('92점')));
     expect(result.recommendationReasons, [
@@ -356,6 +375,59 @@ void main() {
     expect(result.warnings.single.userMessage, '일부 이동 정보를 확인하지 못했어요.');
     expect(result.semanticLabel, contains('일부 이동 정보를 확인하지 못했어요.'));
     expect(result.semanticLabel, isNot(contains('SERVER_RAW_WARNING')));
+  });
+
+  test('경로 contract는 burdenCost 우선 읽기와 score-only legacy fallback을 지원한다', () {
+    final newContractResult = RouteSearchResult.fromJson({
+      'routeSearchId': 'route-new-contract',
+      'originStationId': 'station-sangnoksu',
+      'originStationName': '상록수',
+      'destinationStationId': 'station-sadang',
+      'destinationStationName': '사당',
+      'mobilityType': 'SENIOR',
+      'status': 'FOUND',
+      'lineId': 'seoul-4',
+      'lineName': '수도권 4호선',
+      'burdenCost': 31,
+      'estimatedDurationSeconds': 420,
+      'walkingDistanceMeters': 250,
+      'transferCount': 1,
+      'evidenceSummary': ['DURATION_ESTIMATED', 'DISTANCE_MEASURED'],
+      'steps': <Object?>[],
+      'warnings': <Object?>[],
+      'recommendationReasons': <Object?>[],
+      'blockedReasons': <Object?>[],
+      'createdAt': '2026-06-13T04:20:00',
+    });
+    final legacyResult = RouteSearchResult.fromJson({
+      'routeSearchId': 'route-legacy-score',
+      'originStationId': 'station-sangnoksu',
+      'originStationName': '상록수',
+      'destinationStationId': 'station-sadang',
+      'destinationStationName': '사당',
+      'mobilityType': 'SENIOR',
+      'status': 'FOUND',
+      'lineId': 'seoul-4',
+      'lineName': '수도권 4호선',
+      'score': 92,
+      'steps': <Object?>[],
+      'warnings': <Object?>[],
+      'recommendationReasons': <Object?>[],
+      'blockedReasons': <Object?>[],
+      'createdAt': '2026-06-13T04:20:00',
+    });
+
+    expect(newContractResult.score, 31);
+    expect(newContractResult.burdenCost, 31);
+    expect(newContractResult.estimatedDurationSeconds, 420);
+    expect(newContractResult.walkingDistanceMeters, 250);
+    expect(newContractResult.transferCount, 1);
+    expect(newContractResult.evidenceSummary, [
+      'DURATION_ESTIMATED',
+      'DISTANCE_MEASURED',
+    ]);
+    expect(legacyResult.score, 92);
+    expect(legacyResult.burdenCost, 92);
   });
 
   test('경로 이동 부담은 warning 없음만으로 낮음이 되지 않는다', () {
@@ -599,6 +671,7 @@ void main() {
 
     expect(result.walkingDistanceMeters, 300);
     expect(result.transferCount, 1);
+    expect(result.estimatedDurationSeconds, 2220);
   });
 
   test('즐겨찾기 경로 API 저장소는 인증 헤더로 저장과 목록과 삭제를 요청한다', () async {

--- a/backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java
@@ -40,6 +40,67 @@ public record RouteSearchResult(
 		return List.copyOf(reasons.stream().distinct().limit(3).toList());
 	}
 
+	@JsonProperty("burdenCost")
+	public int burdenCost() {
+		return score;
+	}
+
+	@JsonProperty("estimatedDurationSeconds")
+	public int estimatedDurationSeconds() {
+		return steps.stream()
+			.mapToInt(step -> Math.max(0, step.estimatedMinutes()) * 60)
+			.sum();
+	}
+
+	@JsonProperty("walkingDistanceMeters")
+	public int walkingDistanceMeters() {
+		return steps.stream()
+			.filter(this::isWalkingStep)
+			.mapToInt(step -> Math.max(0, step.distanceMeters()))
+			.sum();
+	}
+
+	@JsonProperty("transferCount")
+	public int transferCount() {
+		long typedTransfers = steps.stream()
+			.filter(step -> "transfer".equals(step.stepType()))
+			.count();
+		if (typedTransfers > 0) {
+			return Math.toIntExact(typedTransfers);
+		}
+		String previousLine = "";
+		int changes = 0;
+		for (RouteStep step : steps) {
+			String line = !step.lineId().isBlank() ? step.lineId() : step.lineName();
+			if (line.isBlank()) {
+				continue;
+			}
+			if (!previousLine.isBlank() && !previousLine.equals(line)) {
+				changes++;
+			}
+			previousLine = line;
+		}
+		return changes;
+	}
+
+	@JsonProperty("evidenceSummary")
+	public List<String> evidenceSummary() {
+		if (steps.isEmpty()) {
+			return List.of();
+		}
+		boolean requiresAccessibilityCheck = steps.stream()
+			.anyMatch(step -> step.requiresAccessibilityCheck() || "UNKNOWN".equals(step.stairAccessState()));
+		boolean hasDurationEstimate = steps.stream()
+			.allMatch(step -> step.estimatedMinutes() > 0);
+		boolean hasDistanceMeasure = steps.stream()
+			.allMatch(step -> step.distanceMeters() > 0);
+		return List.of(
+			requiresAccessibilityCheck ? "ACCESSIBILITY_CHECK_REQUIRED" : "ACCESSIBILITY_VERIFIED",
+			hasDurationEstimate ? "DURATION_ESTIMATED" : "DURATION_UNKNOWN",
+			hasDistanceMeasure ? "DISTANCE_MEASURED" : "DISTANCE_UNKNOWN"
+		);
+	}
+
 	private boolean hasStepFreeAccessibilityStep() {
 		return steps.stream()
 			.filter(RouteStep::requiresAccessibilityCheck)
@@ -59,6 +120,14 @@ public record RouteSearchResult(
 			case PREGNANT -> "짧게 걷는 동선을 우선했어요";
 			case TEMPORARY_INJURY -> "계단 부담이 적은 조건을 반영해 이동 부담이 낮은 경로를 우선했습니다.";
 			case LUGGAGE -> "큰 짐을 들고 이동하기 쉬운 조건을 반영해 이동 부담이 낮은 경로를 우선했습니다.";
+		};
+	}
+
+	private boolean isWalkingStep(RouteStep step) {
+		return switch (step.stepType()) {
+			case "entry", "exit", "transfer", "internal" -> true;
+			case "ride" -> false;
+			default -> step.requiresAccessibilityCheck();
 		};
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -118,6 +118,32 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("경로 검색 API 계약은 비용과 요약 사실값을 score와 분리해 직렬화한다")
+	void routeSearchSerializesBurdenCostAndSummaryFacts() throws Exception {
+		var result = service.searchRoute(new SearchRouteCommand(
+			"station-sangnoksu",
+			"station-sadang",
+			MobilityType.STROLLER
+		));
+
+		var mapper = new ObjectMapper().findAndRegisterModules();
+		Map<?, ?> payload = mapper.readValue(mapper.writeValueAsString(result), Map.class);
+		int stepDurationSeconds = result.steps()
+			.stream()
+			.mapToInt(step -> step.estimatedMinutes() * 60)
+			.sum();
+
+		assertThat(payload.get("score")).isEqualTo(result.score());
+		assertThat(payload.get("burdenCost")).isEqualTo(result.score());
+		assertThat(payload.get("estimatedDurationSeconds")).isEqualTo(stepDurationSeconds);
+		assertThat(payload.get("walkingDistanceMeters")).isEqualTo(result.walkingDistanceMeters());
+		assertThat(payload.get("transferCount")).isEqualTo(0);
+		assertThat(payload.get("evidenceSummary"))
+			.asList()
+			.contains("ACCESSIBILITY_CHECK_REQUIRED", "DURATION_ESTIMATED", "DISTANCE_MEASURED");
+	}
+
+	@Test
 	@DisplayName("생성된 경로 검색 결과는 식별자로 다시 조회할 수 있다")
 	void getRouteSearchReturnsStoredResult() {
 		var created = service.searchRoute(new SearchRouteCommand(


### PR DESCRIPTION
## 관련 이슈

close #845

## 작업 배경

- 서버와 모바일 local route가 모두 낮을수록 쉬운 내부 비용을 `score`에 담고 있어, 비용과 사용자 판단용 사실값의 의미가 API 계약에서 분리되어 있지 않았다.
- UI 문구 개편은 별도 이슈 범위이므로, 이번 변경은 route response/model 계약과 legacy 저장 호환성에만 한정했다.

## 작업 내용

- 서버 `RouteSearchResult` JSON에 `burdenCost`, `estimatedDurationSeconds`, `walkingDistanceMeters`, `transferCount`, `evidenceSummary`를 추가했다.
- 모바일 `RouteSearchResult`는 새 필드를 우선 읽고, 기존 `score`만 있는 legacy payload도 계속 읽도록 fallback을 유지했다.
- local route repository는 서버와 같은 top-level summary facts를 채우고, 비용은 `burdenCost` low-is-good 값으로 명시했다.
- 로컬 즐겨찾기 route snapshot 저장값에 새 contract 필드를 포함해 이후 복원/검증에 사용할 수 있게 했다.
- UI burden 문구와 사용자-facing label 개편은 #845 범위에서 확장하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests '*RouteSearch*'`: pass
  - `cd apps/mobile && flutter test test/route_search_test.dart test/features/routes`: pass, 71 tests
  - `cd apps/mobile && flutter test test/features/favorites`: pass, 9 tests
  - `cd apps/mobile && flutter analyze`: pass, No issues found
  - `git diff --check`: pass
  - main 병합 후 `cd backend && ./gradlew test --tests '*RouteSearch*'`: pass, BUILD SUCCESSFUL
  - main 병합 후 `cd apps/mobile && flutter test test/route_search_test.dart test/features/routes`: pass, 71 tests
  - main 병합 후 `cd apps/mobile && flutter test test/features/favorites`: pass, 9 tests
  - main 병합 후 `cd apps/mobile && flutter analyze`: pass, No issues found
  - main 병합 후 `git diff --check`: pass
  - GitHub PR checks: Android CI, Android Release Artifact, Backend CI, Backend Release Image, Repository CI, Mobile App CI, Dependency Vulnerability Scan, osv-scanner 모두 pass
  - CodeRabbit: bot comment에서 PR review rate limit으로 실제 리뷰 시작 실패 확인
  - Codex CLI fallback review: actionable comments 0, nitpick comments 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| API contract | Backend test | `cd backend && ./gradlew test --tests '*RouteSearch*'` | Gradle output: BUILD SUCCESSFUL | 통과 |
| Local/server route facts | Flutter test | `cd apps/mobile && flutter test test/route_search_test.dart test/features/routes` | command output: 71 tests, All tests passed | 통과 |
| Legacy route snapshot compatibility | Flutter test | `cd apps/mobile && flutter test test/features/favorites` | command output: 9 tests, All tests passed | 통과 |
| Static analysis | Flutter analyzer | `cd apps/mobile && flutter analyze` | command output: No issues found | 통과 |
| PR CI | GitHub Actions | PR #871 checks | Android CI, Android Release Artifact, Backend CI, Backend Release Image, Repository CI, Mobile App CI, Dependency Vulnerability Scan, osv-scanner pass | 통과 |
| Code review fallback | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback | PR review `4571971353`: Actionable comments posted 0 | 통과 |
| UI/Android evidence | 해당 없음 | route API/model/local repository 계약과 테스트 변경 | 증거 불필요 사유: 모바일 화면, Android runtime flow, 접근성 UI 문구 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java`의 JSON contract 계산 필드
  - `apps/mobile/lib/route_search.dart`의 `burdenCost` 우선 파싱과 legacy `score` fallback
  - `apps/mobile/lib/features/routes/data/local_route_repository.dart`의 local route summary facts 계산

## 리스크

- 기존 `score` 필드는 DB와 legacy payload 호환을 위해 유지된다. 신규 판단 로직은 `burdenCost`와 facts 필드를 우선 사용해야 한다.
- `evidenceSummary`는 사용자 문구가 아니라 contract-level source/fact summary 값이다. 화면 문구 변경은 별도 범위에서 다뤄야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
