### PR TITLE
[Refactor] 모바일 API repository 공유 ApiClient 잔여 전환

### DIFF
--- a/apps/mobile/lib/core/network/api_client.dart
+++ b/apps/mobile/lib/core/network/api_client.dart
@@ -175,6 +175,24 @@ class ApiResponse {
   bool get isUnauthorized => statusCode == HttpStatus.unauthorized;
   bool get isOk => statusCode == HttpStatus.ok;
   bool get isSuccess => _isSuccessStatus(statusCode);
+
+  Object? requireSuccessData({
+    required Object Function() errorFactory,
+    int? expectedStatusCode,
+  }) {
+    final statusMatches = expectedStatusCode == null
+        ? isSuccess
+        : statusCode == expectedStatusCode;
+    if (!statusMatches) {
+      throw errorFactory();
+    }
+
+    final decoded = jsonBody;
+    if (decoded is! Map<String, Object?> || decoded['success'] != true) {
+      throw errorFactory();
+    }
+    return decoded['data'];
+  }
 }
 
 enum HttpMethod { get, delete, post, put }

--- a/apps/mobile/lib/internal_route.dart
+++ b/apps/mobile/lib/internal_route.dart
@@ -1,12 +1,10 @@
-import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+import 'core/network/api_client.dart';
 import 'mobile_error_reporter.dart';
 
-const _internalRouteTimeout = Duration(seconds: 8);
 const _internalRouteErrorMessage = '내부 이동 안내를 불러오지 못했습니다.';
 
 abstract class InternalRouteRepository {
@@ -16,20 +14,19 @@ abstract class InternalRouteRepository {
 }
 
 class InternalRouteApiRepository implements InternalRouteRepository {
-  InternalRouteApiRepository({required this.baseUri, HttpClient? httpClient})
-    : _httpClient = httpClient ?? HttpClient();
+  InternalRouteApiRepository({required Uri baseUri, ApiClient? apiClient})
+    : _apiClient = apiClient ?? ApiClient(baseUri: baseUri);
 
-  final Uri baseUri;
-  final HttpClient _httpClient;
+  final ApiClient _apiClient;
 
   @override
   Future<List<InternalRouteNode>> listRouteNodes(String stationId) async {
-    final uri = baseUri.resolve(
-      '/api/v1/stations/${Uri.encodeComponent(stationId.trim())}/route-nodes',
-    );
-
     try {
-      final data = await _getData(uri);
+      final data = await _requestData(
+        () => _apiClient.getJson(
+          '/api/v1/stations/${Uri.encodeComponent(stationId.trim())}/route-nodes',
+        ),
+      );
       if (data is! List<Object?>) {
         throw const InternalRouteException(_internalRouteErrorMessage);
       }
@@ -57,16 +54,13 @@ class InternalRouteApiRepository implements InternalRouteRepository {
   Future<InternalRouteResult> searchInternalRoute(
     InternalRouteRequest routeRequest,
   ) async {
-    final uri = baseUri.resolve('/api/v1/routes/internal');
-
     try {
-      final request = await _httpClient
-          .postUrl(uri)
-          .timeout(_internalRouteTimeout);
-      request.headers.contentType = ContentType.json;
-      request.write(jsonEncode(routeRequest.toJson()));
-
-      final data = await _readResponseData(request);
+      final data = await _requestData(
+        () => _apiClient.postJson(
+          '/api/v1/routes/internal',
+          body: routeRequest.toJson(),
+        ),
+      );
       if (data is! Map<String, Object?>) {
         throw const InternalRouteException(_internalRouteErrorMessage);
       }
@@ -84,29 +78,13 @@ class InternalRouteApiRepository implements InternalRouteRepository {
     }
   }
 
-  Future<Object?> _getData(Uri uri) async {
-    final request = await _httpClient
-        .getUrl(uri)
-        .timeout(_internalRouteTimeout);
-    return _readResponseData(request);
-  }
-
-  Future<Object?> _readResponseData(HttpClientRequest request) async {
-    final response = await request.close().timeout(_internalRouteTimeout);
-    final body = await utf8
-        .decodeStream(response)
-        .timeout(_internalRouteTimeout);
-
-    if (response.statusCode != HttpStatus.ok) {
-      throw const InternalRouteException(_internalRouteErrorMessage);
-    }
-
-    final decoded = jsonDecode(body);
-    if (decoded is! Map<String, Object?> || decoded['success'] != true) {
-      throw const InternalRouteException(_internalRouteErrorMessage);
-    }
-
-    return decoded['data'];
+  Future<Object?> _requestData(Future<ApiResponse> Function() send) async {
+    final response = await send();
+    return response.requireSuccessData(
+      expectedStatusCode: HttpStatus.ok,
+      errorFactory: () =>
+          const InternalRouteException(_internalRouteErrorMessage),
+    );
   }
 }
 

--- a/apps/mobile/test/core/network/api_client_test.dart
+++ b/apps/mobile/test/core/network/api_client_test.dart
@@ -255,6 +255,46 @@ void main() {
     });
   });
 
+  test('ApiResponse는 success/data envelope만 추출한다', () {
+    final response = ApiResponse(
+      statusCode: HttpStatus.ok,
+      jsonBody: {
+        'success': true,
+        'data': {'id': 'route-1'},
+      },
+    );
+
+    expect(
+      response.requireSuccessData(
+        expectedStatusCode: HttpStatus.ok,
+        errorFactory: () => const FormatException('invalid envelope'),
+      ),
+      {'id': 'route-1'},
+    );
+    expect(
+      () =>
+          ApiResponse(
+            statusCode: HttpStatus.created,
+            jsonBody: const {'success': true, 'data': null},
+          ).requireSuccessData(
+            expectedStatusCode: HttpStatus.ok,
+            errorFactory: () => const FormatException('invalid envelope'),
+          ),
+      throwsFormatException,
+    );
+    expect(
+      () =>
+          ApiResponse(
+            statusCode: HttpStatus.ok,
+            jsonBody: const {'success': false},
+          ).requireSuccessData(
+            expectedStatusCode: HttpStatus.ok,
+            errorFactory: () => const FormatException('invalid envelope'),
+          ),
+      throwsFormatException,
+    );
+  });
+
   test('ApiClient 예외는 인증 토큰을 노출하지 않는다', () async {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     addTearDown(server.close);

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -126,6 +126,34 @@ void main() {
     expect(result.semanticLabel, contains('엘리베이터에서 개찰구까지 이동합니다.'));
   });
 
+  test('내부 경로 API 저장소는 잘못된 envelope를 기능 오류로 바꾼다', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+
+    server.listen((request) {
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(jsonEncode({'success': false}))
+        ..close();
+    });
+
+    final repository = InternalRouteApiRepository(
+      baseUri: Uri.parse('http://${server.address.host}:${server.port}'),
+    );
+
+    await expectLater(
+      repository.listRouteNodes('station-sangnoksu'),
+      throwsA(
+        isA<InternalRouteException>().having(
+          (error) => error.message,
+          'message',
+          '내부 이동 안내를 불러오지 못했습니다.',
+        ),
+      ),
+    );
+  });
+
   test('경로 API 저장소는 백엔드 경로 검색을 요청하고 결과를 파싱한다', () async {
     late Uri requestedUri;
     late String requestedBody;


### PR DESCRIPTION
## 관련 이슈

close #847

## 작업 배경

- 모바일 feature API repository 일부가 여전히 직접 `HttpClient`와 `success/data` envelope 파싱을 함께 들고 있어 transport와 feature 오류 정책이 섞여 있었다.
- 이번 변경은 인증 refresh 정책이 없는 internal route API부터 공유 `ApiClient`로 전환해 범위를 작게 제한한다.
- favorite facility, notification settings, device registration은 인증 재시도 정책이 있어 이번 PR에서 공통화하지 않고 잔여 inventory로 남긴다.

## 작업 내용

- `ApiResponse.requireSuccessData()`를 추가해 HTTP status와 `success/data` envelope 추출만 공통 처리한다.
- `InternalRouteApiRepository`의 직접 `HttpClient` 요청, JSON body 작성, JSON decode를 제거하고 `ApiClient.getJson()`/`postJson()`을 사용하도록 전환했다.
- internal route의 사용자 오류 문구와 `InternalRouteException`, `reportMobileError` context는 feature repository에 유지했다.
- `ApiResponse` helper 단위 테스트와 internal route malformed envelope 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/core/network/api_client_test.dart`: pass, 7 tests
  - `flutter test test/route_search_test.dart`: pass, 17 tests
  - `flutter test test/station_search_test.dart`: pass, 37 tests
  - `flutter test test/facility_report_test.dart`: pass, 26 tests
  - `flutter test test/notification_settings_test.dart`: pass, 7 tests
  - `flutter test test/widget_test.dart`: pass, 142 tests
  - `flutter analyze`: No issues found
  - `rg -n "_httpClient|HttpClient\\(" apps/mobile/lib/internal_route.dart apps/mobile/lib/favorite_facility.dart apps/mobile/lib/notification_settings.dart apps/mobile/lib/core/network/api_client.dart`: internal route 직접 `_httpClient` 없음, 잔여 직접 client는 notification settings/favorite facility와 공통 ApiClient
  - `git diff --check`: pass
  - `git ls-files '*.md'`: `.github/pull_request_template.md`, `README.md`
  - GitHub PR checks: Android CI, Android Release Artifact, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan, osv-scanner pass
  - origin/main 병합 후 `flutter test test/core/network/api_client_test.dart test/route_search_test.dart test/notification_settings_test.dart test/widget_test.dart`: pass, 173 tests
  - origin/main 병합 후 `flutter analyze`: No issues found
  - CodeRabbit 상태 확인: rate limit comment 확인, 새 head 기준 Codex CLI fallback review #4572284079 게시, actionable comments 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Envelope helper | Flutter test | `flutter test test/core/network/api_client_test.dart` | 7 tests, pass | 통과 |
| Internal route 전환 | Flutter test | `flutter test test/route_search_test.dart` | 17 tests, pass | 통과 |
| 기존 station/route/facility/notification 회귀 | Flutter test | `station_search`, `facility_report`, `notification_settings`, `widget_test` | 37, 26, 7, 142 tests pass | 통과 |
| 정적 분석 | Flutter analyze | `flutter analyze` | No issues found | 통과 |
| 직접 HTTP inventory | Repository grep | `rg -n "_httpClient|HttpClient\\(" ...` | internal route 직접 `_httpClient` 없음, notification/favorite facility 잔여 확인 | 통과 |
| GitHub CI | GitHub Actions | PR #875 checks | Android CI, Android Release Artifact, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan, osv-scanner pass | 통과 |
| main 병합 후 회귀 | Flutter test/analyze | `flutter test ...api_client...route_search...notification_settings...widget_test`, `flutter analyze` | 173 tests pass, No issues found | 통과 |
| Code review gate | GitHub PR review | CodeRabbit 상태와 Codex CLI fallback review 확인 | CodeRabbit rate limit comment 확인, Codex fallback review #4572284079, actionable comments 0 | 통과 |
| UI/Android evidence | 해당 없음 | transport/envelope refactor와 단위/widget regression | 증거 불필요 사유: 화면 레이아웃, Android runtime flow, 접근성 문구 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/core/network/api_client.dart`의 `requireSuccessData()`가 transport와 envelope extraction만 담당하는지
  - `apps/mobile/lib/internal_route.dart`에서 feature별 오류 문구와 report context가 유지되는지
  - `apps/mobile/test/route_search_test.dart`의 malformed envelope 회귀 테스트

## 리스크

- `requireSuccessData()`는 auth refresh/retry를 다루지 않는다. 인증 정책이 있는 notification settings, device registration, favorite facility 전환은 별도 변경에서 feature 정책을 보존하며 처리해야 한다.
- `InternalRouteApiRepository` 생성자에서 직접 `HttpClient` 주입은 제거했다. 필요한 테스트 주입은 `ApiClient` 주입으로 대체한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
