### PR TITLE
[Fix] 역 안 이동 안내 내부 용어 제거

### DIFF
--- a/apps/mobile/lib/features/internal_route/data/local_internal_route_repository.dart
+++ b/apps/mobile/lib/features/internal_route/data/local_internal_route_repository.dart
@@ -140,10 +140,10 @@ class LocalInternalRouteRepository implements InternalRouteRepository {
       blockedReasons: blockedReasonCodes
           .map(
             (code) => switch (code) {
-              'STAIR_ONLY_ACCESS' => '계단 없는 내부 이동 경로가 없습니다.',
-              'ACCESSIBILITY_STATE_UNKNOWN' => '내부 이동 경로 접근성 상태를 확인할 수 없습니다.',
-              'FACILITY_UNAVAILABLE' => '필수 내부 이동 시설을 사용할 수 없습니다.',
-              _ => '내부 이동 경로가 차단되었습니다.',
+              'STAIR_ONLY_ACCESS' => '계단 없는 역 안 이동 경로를 찾지 못했어요.',
+              'ACCESSIBILITY_STATE_UNKNOWN' => '엘리베이터와 통로 상태를 확인하지 못했어요.',
+              'FACILITY_UNAVAILABLE' => '역 안 이동에 필요한 시설을 이용할 수 없어요.',
+              _ => '역 안 이동 경로를 이용할 수 없어요.',
             },
           )
           .toList(growable: false),

--- a/apps/mobile/lib/internal_route.dart
+++ b/apps/mobile/lib/internal_route.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'core/network/api_client.dart';
 import 'mobile_error_reporter.dart';
 
-const _internalRouteErrorMessage = '내부 이동 안내를 불러오지 못했습니다.';
+const _internalRouteErrorMessage = '역 안 이동 안내를 불러오지 못했습니다.';
 
 abstract class InternalRouteRepository {
   Future<List<InternalRouteNode>> listRouteNodes(String stationId);
@@ -283,9 +283,9 @@ class InternalRouteResult {
 
   String get statusLabel {
     return switch (status) {
-      'FOUND' => '내부 이동 경로를 찾았습니다',
-      'BLOCKED' => '계단 없는 내부 이동 경로가 없습니다',
-      _ => '내부 이동 확인이 필요합니다',
+      'FOUND' => '역 안 이동 경로를 찾았어요',
+      'BLOCKED' => '계단 없는 역 안 이동 경로를 찾지 못했어요',
+      _ => '역 안 이동 확인이 필요해요',
     };
   }
 
@@ -392,15 +392,15 @@ class InternalRouteStep {
       _internalRouteDistanceLabel(distanceMeters),
       _internalRouteFieldValidationLabel(fieldValidationStatus),
       if (includesStairs) '계단 포함',
-      if (requiresElevator) '엘리베이터 필요',
-      if (requiresEscalator) '에스컬레이터 확인',
-      if (reliabilityScore < 80) '추가 확인 필요',
+      if (requiresElevator) '엘리베이터를 이용해요',
+      if (requiresEscalator) '에스컬레이터 상태 확인 필요',
+      if (reliabilityScore < 80) '이동 전 역무원 확인 필요',
     ];
     return labels.join(' · ');
   }
 
   String get semanticLabel =>
-      '$sequence번 내부 이동, $title, $burdenLabel, $guidance';
+      '$sequence번 역 안 이동, $title, $burdenLabel, $guidance';
 }
 
 class InternalRouteWarning {
@@ -420,11 +420,11 @@ class InternalRouteWarning {
 
   String get userMessage {
     return switch (code.trim()) {
-      'LOW_DATA_CONFIDENCE' => '일부 시설 정보는 확인이 필요합니다.',
-      'STALE_ACCESSIBILITY_DATA' => '접근성 시설 정보가 최근 확인되지 않았습니다.',
+      'LOW_DATA_CONFIDENCE' => '일부 시설 정보는 이동 전 확인이 필요해요.',
+      'STALE_ACCESSIBILITY_DATA' => '엘리베이터와 통로 상태를 최근에 확인하지 못했어요.',
       'STAIR_ONLY_ACCESS' => '계단 포함 구간이 있습니다.',
-      'STAIR_ONLY_ACCESS_UNKNOWN' => '계단 없는 동선 여부를 확인할 수 없습니다.',
-      'ACCESSIBILITY_STATE_UNKNOWN' => '접근성 시설 이용 가능 여부를 확인할 수 없습니다.',
+      'STAIR_ONLY_ACCESS_UNKNOWN' => '계단 없는 길인지 확인하지 못했어요.',
+      'ACCESSIBILITY_STATE_UNKNOWN' => '엘리베이터와 통로 상태를 확인하지 못했어요.',
       _ => '일부 이동 정보를 확인하지 못했어요.',
     };
   }
@@ -479,7 +479,7 @@ class InternalRouteController extends ChangeNotifier {
         }
         _state = const InternalRouteState(
           status: InternalRouteViewStatus.failure,
-          message: '내부 이동 기준점을 아직 확인하지 못했습니다.',
+          message: '역 안 길 안내에 필요한 정보를 찾지 못했어요.',
         );
         notifyListeners();
         return;
@@ -622,10 +622,10 @@ String _internalRouteDistanceLabel(int distanceMeters) {
 
 String _internalRouteFieldValidationLabel(String fieldValidationStatus) {
   return switch (fieldValidationStatus) {
-    'VERIFIED' => '현장 검증됨',
-    'STALE' => '현장 재확인 필요',
-    'UNKNOWN' => '현장 검증 전',
-    _ => '현장 검증 전',
+    'VERIFIED' => '최근 확인됨',
+    'STALE' => '최근 상태 확인 필요',
+    'UNKNOWN' => '최근 확인 정보 없음',
+    _ => '최근 확인 정보 없음',
   };
 }
 

--- a/apps/mobile/test/features/internal_route/local_internal_route_repository_test.dart
+++ b/apps/mobile/test/features/internal_route/local_internal_route_repository_test.dart
@@ -164,10 +164,10 @@ void main() {
 
     expect(result.status, 'BLOCKED');
     expect(result.steps, isEmpty);
-    expect(result.blockedReasons, contains('내부 이동 경로 접근성 상태를 확인할 수 없습니다.'));
+    expect(result.blockedReasons, contains('엘리베이터와 통로 상태를 확인하지 못했어요.'));
   });
 
-  test('로컬 내부 이동 단계는 현장 검증 상태를 부담 라벨에서 구분한다', () async {
+  test('로컬 내부 이동 단계는 최근 확인 상태를 부담 라벨에서 구분한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
     await database.seedBaselineIfEmpty();
@@ -227,15 +227,15 @@ void main() {
 
     expect(
       await burdenLabelFor('node-verified-from', 'node-verified-to'),
-      contains('현장 검증됨'),
+      contains('최근 확인됨'),
     );
     expect(
       await burdenLabelFor('node-unknown-from', 'node-unknown-to'),
-      contains('현장 검증 전'),
+      contains('최근 확인 정보 없음'),
     );
     expect(
       await burdenLabelFor('node-stale-from', 'node-stale-to'),
-      contains('현장 재확인 필요'),
+      contains('최근 상태 확인 필요'),
     );
   });
 
@@ -312,7 +312,7 @@ void main() {
     expect(wheelchairResult.steps, isEmpty);
     expect(
       wheelchairResult.blockedReasons,
-      contains('내부 이동 경로 접근성 상태를 확인할 수 없습니다.'),
+      contains('엘리베이터와 통로 상태를 확인하지 못했어요.'),
     );
   });
 

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -115,14 +115,14 @@ void main() {
       'toNodeId': 'node-sangnoksu-faregate',
       'mobilityType': 'WHEELCHAIR',
     });
-    expect(result.statusLabel, '내부 이동 경로를 찾았습니다');
+    expect(result.statusLabel, '역 안 이동 경로를 찾았어요');
     expect(result.summaryLabel, '1번 출구 엘리베이터에서 개찰구까지');
     expect(result.totalBurdenLabel, '약 1분 15초 · 28m');
     expect(
       result.steps.single.burdenLabel,
-      '약 1분 15초 · 28m · 현장 검증 전 · 엘리베이터 필요',
+      '약 1분 15초 · 28m · 최근 확인 정보 없음 · 엘리베이터를 이용해요',
     );
-    expect(result.semanticLabel, contains('1번 내부 이동, 1번 출구 엘리베이터에서 개찰구까지'));
+    expect(result.semanticLabel, contains('1번 역 안 이동, 1번 출구 엘리베이터에서 개찰구까지'));
     expect(result.semanticLabel, contains('엘리베이터에서 개찰구까지 이동합니다.'));
   });
 
@@ -148,7 +148,7 @@ void main() {
         isA<InternalRouteException>().having(
           (error) => error.message,
           'message',
-          '내부 이동 안내를 불러오지 못했습니다.',
+          '역 안 이동 안내를 불러오지 못했습니다.',
         ),
       ),
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5374,14 +5374,20 @@ void main() {
 
     expect(internalRouteRepository.requests, hasLength(1));
     expect(find.text('역 안 이동 순서'), findsOneWidget);
-    expect(find.text('내부 이동 경로를 찾았습니다'), findsOneWidget);
+    expect(find.text('역 안 이동 경로를 찾았어요'), findsOneWidget);
     expect(find.text('1번 출구 엘리베이터에서 개찰구까지'), findsWidgets);
     expect(find.text('약 1분 15초 · 28m'), findsOneWidget);
     expect(find.text('엘리베이터에서 개찰구까지 이동합니다.'), findsOneWidget);
-    expect(find.text('약 1분 15초 · 28m · 현장 검증 전 · 엘리베이터 필요'), findsOneWidget);
+    expect(
+      find.text('약 1분 15초 · 28m · 최근 확인 정보 없음 · 엘리베이터를 이용해요'),
+      findsOneWidget,
+    );
+    expect(find.text('내부 이동 경로를 찾았습니다'), findsNothing);
+    expect(find.text('현장 검증 전'), findsNothing);
+    expect(find.text('엘리베이터 필요'), findsNothing);
     expect(
       find.bySemanticsLabel(
-        '역 안 이동 순서, 내부 이동 경로를 찾았습니다, 1번 출구 엘리베이터에서 개찰구까지, 약 1분 15초 · 28m, 이동 단계 1번 내부 이동, 1번 출구 엘리베이터에서 개찰구까지, 약 1분 15초 · 28m · 현장 검증 전 · 엘리베이터 필요, 엘리베이터에서 개찰구까지 이동합니다.',
+        '역 안 이동 순서, 역 안 이동 경로를 찾았어요, 1번 출구 엘리베이터에서 개찰구까지, 약 1분 15초 · 28m, 이동 단계 1번 역 안 이동, 1번 출구 엘리베이터에서 개찰구까지, 약 1분 15초 · 28m · 최근 확인 정보 없음 · 엘리베이터를 이용해요, 엘리베이터에서 개찰구까지 이동합니다.',
       ),
       findsOneWidget,
     );
@@ -5433,7 +5439,36 @@ void main() {
     );
     expect(internalRouteRepository.requests.single.mobilityType, 'WHEELCHAIR');
     expect(find.text('역 안 이동 순서'), findsOneWidget);
-    expect(find.text('내부 이동 경로를 찾았습니다'), findsOneWidget);
+    expect(find.text('역 안 이동 경로를 찾았어요'), findsOneWidget);
+    expect(find.text('내부 이동 경로를 찾았습니다'), findsNothing);
+  });
+
+  testWidgets('역 상세는 역 안 이동 정보가 부족하면 쉬운 안내를 보여준다', (tester) async {
+    final stationRepository = FakeStationSearchRepository(
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+    );
+    final internalRouteRepository = FakeInternalRouteRepository(
+      nodes: const [],
+      result: _internalRouteResult(),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StationDetailScreen(
+          repository: stationRepository,
+          reportRepository: FakeFacilityReportRepository(),
+          stationId: 'station-sangnoksu',
+          internalRouteRepository: internalRouteRepository,
+          internalRouteMobilityType: 'WHEELCHAIR',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(internalRouteRepository.nodeStationIds, ['station-sangnoksu']);
+    expect(find.text('역 안 이동 순서'), findsOneWidget);
+    expect(find.text('역 안 길 안내에 필요한 정보를 찾지 못했어요.'), findsOneWidget);
+    expect(find.textContaining('기준점'), findsNothing);
   });
 
   testWidgets('역 상세는 현재 역을 즐겨찾기에 저장하고 해제한다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

close #824

## 작업 배경

- 역 안 이동 안내가 `내부 이동`, `기준점`, `현장 검증`, `추가 확인 필요`처럼 구현·운영 중심 단어를 화면과 Semantics에 노출해 QA 요청에 따라 최종 사용자가 바로 이해할 수 있는 이동 안내 문구로 정리했습니다.

## 작업 내용

- 역 안 이동 결과 상태, 빈 상태, 차단 사유, 경고, step burden label, Semantics label을 `역 안 이동`, `최근 확인`, `엘리베이터를 이용해요` 계열 문구로 변경했습니다.
- 로컬 내부 경로 repository fallback 문구도 같은 사용자 언어 체계로 맞췄습니다.
- widget/route/internal route 테스트에 새 문구와 기존 내부 용어 미노출 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/features/internal_route test/route_search_test.dart test/widget_test.dart`: exit 0, `+168 All tests passed!`
  - `cd apps/mobile && flutter analyze`: exit 0, `No issues found!`
  - `cd apps/mobile && flutter build apk --debug`: exit 0, `Built build/app/outputs/flutter-apk/app-debug.apk`
  - `adb -s emulator-5554 install -r apps/mobile/build/app/outputs/flutter-apk/app-debug.apk`: exit 0, `Success`
  - `adb -s emulator-5554 shell settings get secure navigation_mode`: `0`, Android 3-button navigation 상태 확인
  - `rg -o "내부 이동|기준점|현장 검증|추가 확인 필요|역 안 이동 순서|역 안 길 안내에 필요한 정보를 찾지 못했어요" .codex/evidence/pr-824/rebased-station-detail-internal-route.xml`: `역 안 이동 순서`, `역 안 길 안내에 필요한 정보를 찾지 못했어요`만 출력

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 안 이동 정보 부족 상태 문구 | Android emulator `emulator-5554` | 최종 debug APK 설치 후 홈 → 역 검색 → `Sangnoksu` 검색 → 상록수역 상세 → 역 안 이동 섹션 스크린샷/UI tree 확인 | 로컬 전용 `.codex/evidence/pr-824/rebased-station-detail-internal-route.png`, `.codex/evidence/pr-824/rebased-station-detail-internal-route.xml`; PR에는 screenshots를 commit하지 않는 저장소 정책 때문에 UI tree 문자열 검증 결과를 함께 기록 | `역 안 이동 순서`, `역 안 길 안내에 필요한 정보를 찾지 못했어요` 표시, `내부 이동`, `기준점`, `현장 검증`, `추가 확인 필요` 미노출 |
| Android 시스템 내비게이션 조건 | Android emulator `emulator-5554` | `settings get secure navigation_mode` 및 최종 스크린샷 하단 navigation bar 확인 | `.codex/evidence/pr-824/rebased-station-detail-internal-route.png` | 3-button navigation mode `0`에서 화면 확인 |
| Semantics/위젯 회귀 | Flutter test | `flutter test test/features/internal_route test/route_search_test.dart test/widget_test.dart` | 명령 출력 `+168 All tests passed!` | 새 문구와 기존 내부 용어 미노출 assertion 통과 |
| iOS 대체 확인 | Flutter 공통 테스트 | 동일 widget/Semantics 테스트로 플랫폼 공통 Flutter UI 문자열 계약 확인 | Android 전용 QA 요청 범위라 iOS Simulator 화면은 별도 캡처하지 않음 | 플랫폼별 native UI 변경 없음. 남은 리스크는 실제 iOS 화면 캡처 미수행 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/internal_route.dart`의 사용자 노출 label/Semantics 매핑
  - `apps/mobile/lib/features/internal_route/data/local_internal_route_repository.dart`의 차단 사유 fallback 문구
  - `apps/mobile/test/widget_test.dart`의 기존 내부 용어 미노출 assertion

## 리스크

- 서버/API 계약은 변경하지 않고 앱 UI 모델의 표시 문구만 변경했습니다.
- 시설 상세의 별도 `정보 기준 보기` 문구와 일반 시설 검증 문구는 #824의 역 안 이동 안내 범위 밖이라 유지했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
