### PR TITLE
[Feat] 노선도 label polygon hit-test 연결

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
@@ -1541,6 +1542,13 @@ class _MapGeometry {
         maxX = math.max(maxX, bounds.right);
         maxY = math.max(maxY, bounds.bottom);
       }
+      final labelPolygonBounds = _labelPolygonBoundsFor(station);
+      if (labelPolygonBounds != null) {
+        minX = math.min(minX, labelPolygonBounds.left);
+        minY = math.min(minY, labelPolygonBounds.top);
+        maxX = math.max(maxX, labelPolygonBounds.right);
+        maxY = math.max(maxY, labelPolygonBounds.bottom);
+      }
     }
     if (!minX.isFinite || !minY.isFinite) {
       return _MapGeometry(
@@ -1587,6 +1595,10 @@ Rect _stationHitRect(
     height: nodeRadius * 2,
   );
   final labelOffset = _labelOffsetFor(station);
+  final labelPolygon = _labelPolygonFor(station, geometry);
+  if (labelPolygon != null) {
+    return node.expandToInclude(_boundsForPolygon(labelPolygon));
+  }
   final labelCenter = Offset(
     geometry.x(station) + labelOffset.dx,
     geometry.y(station) + labelOffset.dy,
@@ -1609,13 +1621,12 @@ NetworkMapStation? _stationAtMapPosition(
   NetworkMapStation? bestStation;
   var bestScore = double.infinity;
   for (final station in stations) {
-    final hitRect = _stationHitRect(
+    if (!_stationHitTestContains(
+      position,
       station,
       geometry,
-      nodeRadius: sceneHitRadius,
-      labelHeight: sceneHitRadius * 2,
-    );
-    if (!hitRect.contains(position)) {
+      sceneHitRadius: sceneHitRadius,
+    )) {
       continue;
     }
     final score =
@@ -1637,6 +1648,13 @@ double _stationTapScore(
   _MapGeometry geometry,
 ) {
   final nodeCenter = Offset(geometry.x(station), geometry.y(station));
+  final labelPolygon = _labelPolygonFor(station, geometry);
+  if (labelPolygon != null) {
+    return math.min(
+      (position - nodeCenter).distanceSquared,
+      _distanceSquaredToPolygon(position, labelPolygon),
+    );
+  }
   final labelOffset = _labelOffsetFor(station);
   final labelCenter = Offset(
     nodeCenter.dx + labelOffset.dx,
@@ -1646,6 +1664,157 @@ double _stationTapScore(
     (position - nodeCenter).distanceSquared,
     (position - labelCenter).distanceSquared,
   );
+}
+
+bool _stationHitTestContains(
+  Offset position,
+  NetworkMapStation station,
+  _MapGeometry geometry, {
+  required double sceneHitRadius,
+}) {
+  final nodeCenter = Offset(geometry.x(station), geometry.y(station));
+  if ((position - nodeCenter).distanceSquared <=
+      sceneHitRadius * sceneHitRadius) {
+    return true;
+  }
+  final labelPolygon = _labelPolygonFor(station, geometry);
+  if (labelPolygon != null) {
+    return _distanceSquaredToPolygon(position, labelPolygon) <=
+        sceneHitRadius * sceneHitRadius;
+  }
+  return _stationHitRect(
+    station,
+    geometry,
+    nodeRadius: sceneHitRadius,
+    labelHeight: sceneHitRadius * 2,
+  ).contains(position);
+}
+
+Rect? _labelPolygonBoundsFor(NetworkMapStation station) {
+  final polygon = _parseLabelPolygon(station.position.labelPolygon);
+  return polygon == null ? null : _boundsForPolygon(polygon);
+}
+
+List<Offset>? _labelPolygonFor(
+  NetworkMapStation station,
+  _MapGeometry geometry,
+) {
+  final polygon = _parseLabelPolygon(station.position.labelPolygon);
+  if (polygon == null) {
+    return null;
+  }
+  return [
+    for (final point in polygon)
+      Offset(point.dx - geometry.origin.dx, point.dy - geometry.origin.dy),
+  ];
+}
+
+List<Offset>? _parseLabelPolygon(String value) {
+  if (value.trim().isEmpty) {
+    return null;
+  }
+  try {
+    final decoded = jsonDecode(value);
+    if (decoded is! List || decoded.length < 3) {
+      return null;
+    }
+    final points = <Offset>[];
+    for (final rawPoint in decoded) {
+      if (rawPoint is! Map) {
+        return null;
+      }
+      final x = rawPoint['x'];
+      final y = rawPoint['y'];
+      if (x is! num || y is! num) {
+        return null;
+      }
+      final dx = x.toDouble();
+      final dy = y.toDouble();
+      if (!dx.isFinite || !dy.isFinite || dx < 0 || dy < 0) {
+        return null;
+      }
+      points.add(Offset(dx, dy));
+    }
+    return points;
+  } on FormatException {
+    return null;
+  }
+}
+
+Rect _boundsForPolygon(List<Offset> polygon) {
+  var minX = double.infinity;
+  var minY = double.infinity;
+  var maxX = -double.infinity;
+  var maxY = -double.infinity;
+  for (final point in polygon) {
+    minX = math.min(minX, point.dx);
+    minY = math.min(minY, point.dy);
+    maxX = math.max(maxX, point.dx);
+    maxY = math.max(maxY, point.dy);
+  }
+  return Rect.fromLTRB(minX, minY, maxX, maxY);
+}
+
+double _distanceSquaredToPolygon(Offset point, List<Offset> polygon) {
+  if (_pointInPolygon(point, polygon)) {
+    return 0;
+  }
+  var best = double.infinity;
+  for (var index = 0; index < polygon.length; index += 1) {
+    best = math.min(
+      best,
+      _distanceSquaredToSegment(
+        point,
+        polygon[index],
+        polygon[(index + 1) % polygon.length],
+      ),
+    );
+  }
+  return best;
+}
+
+bool _pointInPolygon(Offset point, List<Offset> polygon) {
+  var inside = false;
+  for (
+    var index = 0, previous = polygon.length - 1;
+    index < polygon.length;
+    previous = index, index += 1
+  ) {
+    final currentPoint = polygon[index];
+    final previousPoint = polygon[previous];
+    final crossesY =
+        (currentPoint.dy > point.dy) != (previousPoint.dy > point.dy);
+    if (!crossesY) {
+      continue;
+    }
+    final intersectionX =
+        (previousPoint.dx - currentPoint.dx) *
+            (point.dy - currentPoint.dy) /
+            (previousPoint.dy - currentPoint.dy) +
+        currentPoint.dx;
+    if (point.dx < intersectionX) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+double _distanceSquaredToSegment(Offset point, Offset start, Offset end) {
+  final segment = end - start;
+  final lengthSquared = segment.distanceSquared;
+  if (lengthSquared == 0) {
+    return (point - start).distanceSquared;
+  }
+  final t =
+      (((point.dx - start.dx) * segment.dx) +
+          ((point.dy - start.dy) * segment.dy)) /
+      lengthSquared;
+  final clampedT = t.clamp(0.0, 1.0).toDouble();
+  final projection = Offset(
+    start.dx + segment.dx * clampedT,
+    start.dy + segment.dy * clampedT,
+  );
+  return (point - projection).distanceSquared;
 }
 
 double _median(List<double> values) {

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1673,8 +1673,12 @@ bool _stationHitTestContains(
   required double sceneHitRadius,
 }) {
   final nodeCenter = Offset(geometry.x(station), geometry.y(station));
-  if ((position - nodeCenter).distanceSquared <=
-      sceneHitRadius * sceneHitRadius) {
+  final nodeRect = Rect.fromCenter(
+    center: nodeCenter,
+    width: sceneHitRadius * 2,
+    height: sceneHitRadius * 2,
+  );
+  if (nodeRect.contains(position)) {
     return true;
   }
   final labelPolygon = _labelPolygonFor(station, geometry);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1318,6 +1318,85 @@ void main() {
     expect(find.text('연신내역'), findsNothing);
   });
 
+  testWidgets('노선도 label polygon 역도 기존 marker 사각형 tap 영역을 유지한다', (
+    tester,
+  ) async {
+    final repository = FakeStationSearchRepository(
+      networkMapData: const NetworkMapData(
+        regions: [NetworkMapRegion(name: '테스트권')],
+        selectedRegion: '테스트권',
+        lines: [
+          NetworkMapLine(
+            id: 'seoul-4',
+            name: '수도권 4호선',
+            color: '#00A5DE',
+            region: '테스트권',
+          ),
+        ],
+        stations: [
+          NetworkMapStation(
+            id: 'station-polygon',
+            nameKo: '다각형',
+            nameEn: 'Polygon',
+            region: '테스트권',
+            lineId: 'seoul-4',
+            stationCode: '499',
+            sequence: 99,
+            position: NetworkMapPosition(
+              x: 100,
+              y: 100,
+              labelDx: 0,
+              labelDy: 0,
+              labelPolygon:
+                  '[{"x":180,"y":80},{"x":300,"y":80},{"x":300,"y":120},{"x":180,"y":120}]',
+              upPath: '',
+              downPath: '',
+              sourceId: 'fixture-route-map-source-capital-review',
+            ),
+          ),
+        ],
+        edges: [],
+        positionSources: [
+          NetworkMapPositionSource(
+            id: 'fixture-route-map-source-capital-review',
+            name: '수도권 노선도 fixture 좌표 검수',
+            licenseStatus: 'fixture-only',
+          ),
+        ],
+        stationLineMemberships: [
+          NetworkMapStationLineMembership(
+            stationId: 'station-polygon',
+            lineId: 'seoul-4',
+          ),
+        ],
+      ),
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('bottomNavMap')));
+    await tester.pumpAndSettle();
+
+    final stationTarget = find.byKey(
+      const Key('networkMapStation-polygon-seoul-4'),
+    );
+    final targetRect = tester.getRect(stationTarget);
+    await tester.tapAt(targetRect.topLeft + const Offset(47, 32));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
+    expect(find.text('다각형역'), findsOneWidget);
+  });
+
   testWidgets('노선도 역명 label polygon 영역을 탭하면 해당 역을 선택한다', (tester) async {
     final repository = FakeStationSearchRepository(
       networkMapData: const NetworkMapData(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1318,6 +1318,82 @@ void main() {
     expect(find.text('연신내역'), findsNothing);
   });
 
+  testWidgets('노선도 역명 label polygon 영역을 탭하면 해당 역을 선택한다', (tester) async {
+    final repository = FakeStationSearchRepository(
+      networkMapData: const NetworkMapData(
+        regions: [NetworkMapRegion(name: '테스트권')],
+        selectedRegion: '테스트권',
+        lines: [
+          NetworkMapLine(
+            id: 'seoul-4',
+            name: '수도권 4호선',
+            color: '#00A5DE',
+            region: '테스트권',
+          ),
+        ],
+        stations: [
+          NetworkMapStation(
+            id: 'station-polygon',
+            nameKo: '다각형',
+            nameEn: 'Polygon',
+            region: '테스트권',
+            lineId: 'seoul-4',
+            stationCode: '499',
+            sequence: 99,
+            position: NetworkMapPosition(
+              x: 100,
+              y: 100,
+              labelDx: 0,
+              labelDy: 0,
+              labelPolygon:
+                  '[{"x":180,"y":80},{"x":300,"y":80},{"x":300,"y":120},{"x":180,"y":120}]',
+              upPath: '',
+              downPath: '',
+              sourceId: 'fixture-route-map-source-capital-review',
+            ),
+          ),
+        ],
+        edges: [],
+        positionSources: [
+          NetworkMapPositionSource(
+            id: 'fixture-route-map-source-capital-review',
+            name: '수도권 노선도 fixture 좌표 검수',
+            licenseStatus: 'fixture-only',
+          ),
+        ],
+        stationLineMemberships: [
+          NetworkMapStationLineMembership(
+            stationId: 'station-polygon',
+            lineId: 'seoul-4',
+          ),
+        ],
+      ),
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('bottomNavMap')));
+    await tester.pumpAndSettle();
+    await tester.tapAt(
+      tester.getCenter(
+        find.byKey(const Key('networkMapStation-polygon-seoul-4')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
+    expect(find.text('다각형역'), findsOneWidget);
+  });
+
   testWidgets('홈 화면은 v3 기준 큰 행동과 짧은 상태 카드로 구성된다', (tester) async {
     await tester.pumpWidget(
       EasySubwayApp(


### PR DESCRIPTION
## 관련 이슈

close #878

## 작업 배경

- #836 노선도 viewport renderer 작업에서 production 좌표에 저장한 `label_polygon`이 앱 런타임 hit-test에 연결되어야 한다.
- QA 요청으로 하단 진입 문구는 `노선 목록으로 보기`가 아니라 `노선별로 보기` 흐름을 유지해야 한다.

## 작업 내용

- `NetworkMapPosition.labelPolygon`을 파싱해 역명 polygon 영역을 station hit-test와 tap 우선순위 계산에 반영했다.
- label polygon bounds를 fallback geometry bounds에도 포함해 polygon만 바깥으로 뻗은 역명이 viewport 계산에서 누락되지 않게 했다.
- polygon label 영역을 탭하면 해당 역 bottom sheet가 열리는 위젯 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --plain-name "노선도"`: exit 0, 14 tests passed
  - `flutter analyze`: exit 0, No issues found
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 104 tests passed
  - `flutter test`: exit 0, 478 tests passed
  - `flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY install -r apps/mobile/build/app/outputs/flutter-apk/app-debug.apk`: exit 0, Success
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY shell monkey -p com.easysubway.app 1`: exit 0, 앱 실행
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY exec-out uiautomator dump /dev/tty`: exit 0, 노선도와 노선별 역 보기 UI tree 캡처
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY logcat --pid 3713 -d`: exit 0, app-scoped logcat 캡처
  - GitHub Actions `CI`: success, https://github.com/AquilaXk/easysubway/actions/runs/28183571306
  - GitHub Actions `Release Artifacts`: success, https://github.com/AquilaXk/easysubway/actions/runs/28183570964
  - CodeRabbit: rate limit 및 prepaid credit exhausted로 실제 review 미시작
  - Codex CLI fallback review: PR review #4572799466, actionable comments 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| label polygon hit-test 회귀 | Flutter widget test | polygon이 node fallback label 밖에 있는 fixture station과 기존 marker 사각형 모서리 영역을 탭 | `flutter test test/widget_test.dart --plain-name "노선도"` 출력 | `노선도 역명 label polygon 영역을 탭하면 해당 역을 선택한다`, `노선도 label polygon 역도 기존 marker 사각형 tap 영역을 유지한다` 포함 14건 통과 |
| 노선별 보기 문구 | Android 실기기 SM-A175N, Android 16 | `RFKYA01VMQY`에 debug APK 설치 후 노선도 탭 진입 | 로컬 전용 `.codex/evidence/878/android-real-device-route-map-ui.xml`, `.codex/evidence/878/android-real-device-route-map.png` | UI tree에 `노선별로 보기`가 있고 `노선 목록으로 보기`는 없음 |
| 노선별 역 보기 화면 | Android 실기기 SM-A175N, Android 16 | `노선별로 보기` 버튼을 탭해 bottom sheet 확인 | 로컬 전용 `.codex/evidence/878/android-real-device-route-by-route-ui.xml`, `.codex/evidence/878/android-real-device-route-by-route.png` | UI tree에 `노선별 역 보기`, `노선별 목록에서 역을 선택하세요.`, `1호선` 역 목록 표시 |
| renderer 런타임 로그 | Android 실기기 SM-A175N, Android 16 | app PID 기준 logcat 필터 확인 | 로컬 전용 `.codex/evidence/878/android-real-device-app-logcat.txt` | `routeMapRenderer cameraLatency revision=0 elapsedMs=204`, app-scoped fatal/Flutter exception 없음 |

실기기 screenshot/UI tree/logcat은 QA 장비의 전체 화면과 접근성 tree, 로컬 런타임 로그를 포함하므로 GitHub에 직접 첨부하지 않고 로컬 전용 evidence로 보관했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/network_map.dart`의 `_stationHitTestContains`, `_distanceSquaredToPolygon`, `_pointInPolygon`이 기존 node/label fallback 동작을 유지하면서 `label_polygon`만 우선 사용한다.

## 리스크

- production 데이터팩에 polygon이 없는 역은 기존 label offset 기반 hit-test로 동작한다.
- polygon JSON이 비정상이면 null로 처리해 기존 fallback을 사용한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
