### PR TITLE
[Test] 사용자 문구 금지어와 Semantics 회귀 검사 추가

### DIFF
--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -757,8 +757,8 @@ String _stringOrDefault(
 
 String _dataConfidenceLabel(String dataConfidence) {
   return switch (dataConfidence) {
-    'HIGH' => '정보 신뢰도 높음',
-    'MEDIUM' => '정보 신뢰도 보통',
+    'HIGH' => '확인 수준 높음',
+    'MEDIUM' => '확인 수준 보통',
     'LOW' => '정보 확인 필요',
     _ => '정보 확인 필요',
   };
@@ -789,12 +789,12 @@ String _facilityUserLocationLabel(String description) {
 
 String _dataSourceLabel(String dataSourceType) {
   return switch (dataSourceType) {
-    'OFFICIAL_API' => '출처 공공 API',
-    'OFFICIAL_FILE' => '출처 공식 파일',
-    'OPERATOR_PAGE' => '출처 운영기관 페이지',
+    'OFFICIAL_API' => '공식 정보',
+    'OFFICIAL_FILE' => '공식 정보',
+    'OPERATOR_PAGE' => '운영기관 안내',
     'USER_REPORT' => '출처 사용자 제보',
-    'ADMIN_VERIFIED' => '출처 관리자 검수',
-    'PARTNER_FEED' => '출처 제휴 데이터',
+    'ADMIN_VERIFIED' => '확인된 정보',
+    'PARTNER_FEED' => '연계 정보',
     _ => '출처 확인 필요',
   };
 }

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -935,8 +935,8 @@ String _dataQualityLabel(String dataQualityLevel) {
 
 String _dataConfidenceLabel(String dataConfidence) {
   return switch (dataConfidence) {
-    'HIGH' => '정보 신뢰도 높음',
-    'MEDIUM' => '정보 신뢰도 보통',
+    'HIGH' => '확인 수준 높음',
+    'MEDIUM' => '확인 수준 보통',
     'LOW' => '정보 확인 필요',
     _ => '정보 확인 필요',
   };
@@ -945,10 +945,10 @@ String _dataConfidenceLabel(String dataConfidence) {
 String _fieldValidationLabel(String fieldValidationStatus) {
   final normalizedStatus = fieldValidationStatus.trim().toUpperCase();
   return switch (normalizedStatus) {
-    'VERIFIED' => '현장 검증됨',
-    'STALE' => '현장 재확인 필요',
-    'UNKNOWN' => '현장 검증 전',
-    _ => '현장 검증 전',
+    'VERIFIED' => '최근 확인됨',
+    'STALE' => '최근 재확인 필요',
+    'UNKNOWN' => '최근 확인 정보 없음',
+    _ => '최근 확인 정보 없음',
   };
 }
 
@@ -978,12 +978,12 @@ String _facilityUserLocationLabel(String description) {
 
 String _dataSourceLabel(String dataSourceType) {
   return switch (dataSourceType) {
-    'OFFICIAL_API' => '출처 공공 API',
-    'OFFICIAL_FILE' => '출처 공식 파일',
-    'OPERATOR_PAGE' => '출처 운영기관 페이지',
+    'OFFICIAL_API' => '공식 정보',
+    'OFFICIAL_FILE' => '공식 정보',
+    'OPERATOR_PAGE' => '운영기관 안내',
     'USER_REPORT' => '출처 사용자 제보',
-    'ADMIN_VERIFIED' => '출처 관리자 검수',
-    'PARTNER_FEED' => '출처 제휴 데이터',
+    'ADMIN_VERIFIED' => '확인된 정보',
+    'PARTNER_FEED' => '연계 정보',
     _ => '출처 확인 필요',
   };
 }

--- a/apps/mobile/test/favorite_facility_test.dart
+++ b/apps/mobile/test/favorite_facility_test.dart
@@ -70,8 +70,8 @@ void main() {
     expect(favorites.single.severityLabel, '정상');
     expect(favorites.single.nextActionLabel, '상태 제보');
     expect(favorites.single.statusTitle, '이용 가능');
-    expect(favorites.single.confidenceLabel, '정보 신뢰도 높음');
-    expect(favorites.single.dataSourceLabel, '출처 공식 파일');
+    expect(favorites.single.confidenceLabel, '확인 수준 높음');
+    expect(favorites.single.dataSourceLabel, '공식 정보');
     expect(favorites.single.locationLabel, '1번 출구 앞');
     expect(favorites.single.verificationStatusLabel, '상태 확인 필요');
     expect(

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -158,7 +158,7 @@ void main() {
     expect(results.single.nameKo, '상록수');
     expect(results.single.region, '수도권');
     expect(results.single.dataQualityLabel, '기본 정보만 있음');
-    expect(results.single.dataSourceLabel, '출처 공식 파일');
+    expect(results.single.dataSourceLabel, '공식 정보');
     expect(results.single.lines.single.name, '수도권 4호선');
   });
 
@@ -578,21 +578,21 @@ void main() {
     expect(detail.latitude, 37.302795);
     expect(detail.longitude, 126.866489);
     expect(detail.dataQualityLabel, '기본 정보만 있음');
-    expect(detail.dataSourceLabel, '출처 공식 파일');
+    expect(detail.dataSourceLabel, '공식 정보');
     expect(detail.lines.single.stationCode, '448');
     expect(exits.single.name, '1번 출구');
     expect(exits.single.latitude, 37.302795);
     expect(exits.single.longitude, 126.866489);
     expect(exits.single.elevatorConnectionLabel, '엘리베이터 연결');
     expect(exits.single.stairPathLabel, '계단 없는 이동 가능');
-    expect(exits.single.dataSourceLabel, '출처 공식 파일');
+    expect(exits.single.dataSourceLabel, '공식 정보');
     expect(facilities.single.typeLabel, '엘리베이터');
     expect(facilities.single.latitude, 37.302795);
     expect(facilities.single.longitude, 126.866489);
     expect(facilities.single.statusLabel, '정상');
     expect(facilities.single.statusTitle, '이용 가능');
-    expect(facilities.single.confidenceLabel, '정보 신뢰도 높음');
-    expect(facilities.single.dataSourceLabel, '출처 공식 파일');
+    expect(facilities.single.confidenceLabel, '확인 수준 높음');
+    expect(facilities.single.dataSourceLabel, '공식 정보');
   });
 
   test('즐겨찾기 역 API 저장소는 인증 헤더와 함께 목록을 요청하고 결과를 파싱한다', () async {
@@ -658,7 +658,7 @@ void main() {
     expect(favorites.single.nameKo, '상록수');
     expect(favorites.single.lineLabel, '수도권 4호선');
     expect(favorites.single.dataQualityLabel, '기본 정보만 있음');
-    expect(favorites.single.dataSourceLabel, '출처 공식 파일');
+    expect(favorites.single.dataSourceLabel, '공식 정보');
   });
 
   test('즐겨찾기 역 API 저장소는 인증 제공자가 없으면 인증 헤더를 보내지 않는다', () async {
@@ -1371,7 +1371,7 @@ void main() {
     expect(customerCenter.typeLabel, '고객센터');
     expect(customerCenter.statusLabel, '검수 완료');
     expect(customerCenter.severityLabel, '정상');
-    expect(customerCenter.fieldValidationLabel, '현장 검증됨');
+    expect(customerCenter.fieldValidationLabel, '최근 확인됨');
     expect(customerCenter.statusTitle, '이용 가능');
     expect(customerCenter.semanticLabel, isNot(contains('정보 신뢰도')));
     expect(customerCenter.semanticLabel, isNot(contains('현장 검증')));

--- a/apps/mobile/test/user_copy_guard.dart
+++ b/apps/mobile/test/user_copy_guard.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _forbiddenUserCopy = <String>[
+  '실기기 QA',
+  '데이터팩',
+  '공공 API',
+  '공식 파일',
+  '관리자 검수',
+  '현장 검증',
+  '정보 신뢰도',
+  '정적 추정',
+  '측정값',
+  '로그인 정보',
+  '인증 정보',
+  '계정 접근',
+  '내부 이동 기준점',
+  'routeSearchId',
+  'UUID',
+  'token',
+  'OFFICIAL_',
+  'ADMIN_VERIFIED',
+  'local-user',
+];
+
+void expectNoForbiddenUserCopy(WidgetTester tester) {
+  final visibleCopy = <String>{};
+  for (final widget in tester.allWidgets) {
+    switch (widget) {
+      case Text(:final data, :final textSpan):
+        visibleCopy.add(data ?? textSpan?.toPlainText() ?? '');
+      case Tooltip(:final message):
+        visibleCopy.add(message ?? '');
+      case Semantics(:final properties):
+        visibleCopy.addAll([
+          properties.label ?? '',
+          properties.value ?? '',
+          properties.hint ?? '',
+        ]);
+    }
+  }
+
+  for (final copy in visibleCopy.where((copy) => copy.trim().isNotEmpty)) {
+    for (final forbidden in _forbiddenUserCopy) {
+      expect(copy, isNot(contains(forbidden)));
+    }
+    expect(
+      copy,
+      isNot(matches(RegExp(r'(^|[^A-Za-z])(?:edge|node)([^A-Za-z]|$)'))),
+    );
+  }
+}

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -26,6 +26,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'fake_secure_key_value_storage.dart';
+import 'user_copy_guard.dart';
 
 OnboardingState _completedOnboardingState({String profileId = 'elderly'}) {
   return OnboardingState.completed(
@@ -727,9 +728,10 @@ void main() {
     expect(find.text('점검·제보 · 엘리베이터 제보됨'), findsOneWidget);
     expect(find.text('권장 행동 역무원 도움 요청'), findsOneWidget);
     expect(
-      find.bySemanticsLabel(RegExp('심각도 점검·제보, .*출처 공식 파일, 권장 행동 역무원 도움 요청')),
+      find.bySemanticsLabel(RegExp('심각도 점검·제보, .*공식 정보, 권장 행동 역무원 도움 요청')),
       findsOneWidget,
     );
+    expectNoForbiddenUserCopy(tester);
   });
 
   testWidgets('홈 노선도 버튼은 v3 노선도 화면을 연다', (tester) async {
@@ -751,6 +753,7 @@ void main() {
 
     expect(find.byKey(const Key('networkMapScreen')), findsOneWidget);
     expect(find.byKey(const Key('mapRegionTabs')), findsOneWidget);
+    expectNoForbiddenUserCopy(tester);
     expect(find.byKey(const Key('networkMapLineFilter')), findsOneWidget);
     expect(find.byKey(const Key('networkMapZoomInButton')), findsOneWidget);
     expect(find.byKey(const Key('networkMapZoomOutButton')), findsOneWidget);
@@ -1579,9 +1582,10 @@ void main() {
     expect(find.text('고장·폐쇄 · 엘리베이터 폐쇄'), findsOneWidget);
     expect(find.widgetWithText(OutlinedButton, '저장한 시설 보기'), findsOneWidget);
     expect(
-      find.bySemanticsLabel(RegExp('심각도 고장·폐쇄, .*출처 공식 파일, 다음 행동 대체 출구 보기')),
+      find.bySemanticsLabel(RegExp('심각도 고장·폐쇄, .*공식 정보, 다음 행동 대체 출구 보기')),
       findsOneWidget,
     );
+    expectNoForbiddenUserCopy(tester);
   });
 
   testWidgets('홈 시설 알림은 주의 상태 시설이 없으면 섹션을 숨긴다', (tester) async {
@@ -1998,6 +2002,7 @@ void main() {
         ).getSemanticsData().hasAction(SemanticsAction.tap),
         isTrue,
       );
+      expectNoForbiddenUserCopy(tester);
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
@@ -2735,6 +2740,7 @@ void main() {
       find.byKey(const Key('dataDeletionResultRow-favoriteFacilities')),
     );
     expect(facilityRow.top - stationRow.bottom, greaterThanOrEqualTo(10));
+    expectNoForbiddenUserCopy(tester);
 
     await tester.tap(find.byKey(const Key('dataDeletionResultStartButton')));
     await tester.pumpAndSettle();
@@ -5127,7 +5133,8 @@ void main() {
       await tester.tap(find.widgetWithText(OutlinedButton, '정보 기준 보기'));
       await tester.pumpAndSettle();
       expect(find.text('정보 기준'), findsOneWidget);
-      expect(find.text('출처 공식 파일'), findsOneWidget);
+      expect(find.text('공식 정보'), findsOneWidget);
+      expectNoForbiddenUserCopy(tester);
       await tester.tap(find.widgetWithText(OutlinedButton, '정보 기준 접기'));
       await tester.pumpAndSettle();
       expect(find.text('출처 공식 파일'), findsNothing);
@@ -5346,9 +5353,10 @@ void main() {
     await tester.tap(find.widgetWithText(OutlinedButton, '정보 기준 보기'));
     await tester.pumpAndSettle();
     expect(find.text('정보 기준'), findsOneWidget);
-    expect(find.text('현장 검증됨'), findsOneWidget);
-    expect(find.text('정보 신뢰도 높음'), findsOneWidget);
-    expect(find.text('출처 공식 파일'), findsOneWidget);
+    expect(find.text('최근 확인됨'), findsOneWidget);
+    expect(find.text('확인 수준 높음'), findsOneWidget);
+    expect(find.text('공식 정보'), findsOneWidget);
+    expectNoForbiddenUserCopy(tester);
 
     await tester.scrollUntilVisible(
       find.byKey(
@@ -6202,6 +6210,7 @@ void main() {
 
       expect(find.text('역 안 이동 순서'), findsOneWidget);
       expect(find.bySemanticsLabel(RegExp('이동 점수')), findsNothing);
+      expectNoForbiddenUserCopy(tester);
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
@@ -7543,6 +7552,7 @@ void main() {
       expect(find.text('처리 상태를 확인했습니다.'), findsOneWidget);
       expect(find.text('반영됨'), findsOneWidget);
       expect(find.bySemanticsLabel('제보 번호 ES-1001, 현재 상태 반영됨'), findsOneWidget);
+      expectNoForbiddenUserCopy(tester);
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));


### PR DESCRIPTION
## 관련 이슈

close #825

## 작업 배경

- 사용자 화면과 TalkBack에 `공식 파일`, `정보 신뢰도`, `현장 검증` 같은 내부 운영 문구가 다시 노출되지 않도록 QA 요청에 따라 공통 금지어 검사 helper를 추가했습니다.

## 작업 내용

- `test/user_copy_guard.dart`에 Text, Tooltip, Semantics label/value/hint를 검사하는 금지어 helper를 추가했습니다.
- 알림함, 노선도, 설정, 데이터 삭제, 역 상세 정보 기준, 경로 상세, 시설 제보 결과 흐름에서 helper를 호출해 회귀를 막았습니다.
- 역·시설 정보 기준 문구를 `공식 정보`, `확인 수준 높음`, `최근 확인됨`처럼 사용자 표현으로 바꿨습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "알림함 시설 상태는 심각도와 다음 행동을 함께 보여준다"`: RED 확인, `출처 공식 파일` Semantics 노출로 실패
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "알림함 시설 상태는 심각도와 다음 행동을 함께 보여준다"`: exit 0, `All tests passed!`
  - `cd apps/mobile && flutter test test/widget_test.dart test/station_search_test.dart test/favorite_facility_test.dart`: exit 0, `+185 All tests passed!`
  - rebase 후 `cd apps/mobile && flutter test test/widget_test.dart test/station_search_test.dart test/favorite_facility_test.dart`: exit 0, `+187 All tests passed!`
  - `cd apps/mobile && flutter test test/route_search_test.dart test/facility_report_test.dart test/notification_settings_test.dart test/onboarding_test.dart`: exit 0, `+67 All tests passed!`
  - `cd apps/mobile && flutter analyze`: exit 0, `No issues found!`
  - `cd apps/mobile && flutter build apk --debug`: exit 0, `Built build/app/outputs/flutter-apk/app-debug.apk`
  - `adb -s emulator-5554 install -r apps/mobile/build/app/outputs/flutter-apk/app-debug.apk`: exit 0, `Success`
  - `adb -s emulator-5554 shell settings get secure navigation_mode`: `0`, Android 3-button navigation 상태 확인
  - `rg "실기기 QA|데이터팩|공공 API|공식 파일|관리자 검수|현장 검증|정보 신뢰도|정적 추정|측정값|로그인 정보|인증 정보|계정 접근|내부 이동 기준점|routeSearchId|UUID|token|OFFICIAL_|ADMIN_VERIFIED|local-user" .codex/evidence/issue-825/station-info-basis.xml`: exit 1, 매치 없음

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 금지어 helper RED | Flutter test | 알림함 시설 상태 Semantics에 기존 `출처 공식 파일`이 남은 상태에서 helper 호출 | 로컬 명령 출력 | 기대대로 실패해 helper가 실제 회귀를 잡는 것을 확인 |
| 금지어 helper GREEN | Flutter test | 주요 widget 흐름과 station/favorite 모델 테스트 실행 | 명령 출력 `+185 All tests passed!`, `+67 All tests passed!` | 사용자 문구 금지어 검사 통과 |
| 역 상세 정보 기준 문구 | Android emulator `emulator-5554` | debug APK 설치 후 홈 → 역 검색 → Sangnoksu → 상록수역 상세 → 정보 기준 펼침 | 로컬 전용 `.codex/evidence/issue-825/station-info-basis.png`, `.codex/evidence/issue-825/station-info-basis.xml`; screenshots는 저장소 정책상 commit하지 않음 | `공식 정보`, `마지막 확인 2026-04-02` 표시, 금지어 grep 매치 없음 |
| Android 시스템 내비게이션 조건 | Android emulator `emulator-5554` | `settings get secure navigation_mode` 및 스크린샷 하단 navigation bar 확인 | `.codex/evidence/issue-825/station-info-basis.png` | 3-button navigation mode `0`에서 화면 확인 |
| iOS 대체 확인 | Flutter 공통 테스트 | Flutter widget/Semantics 테스트로 플랫폼 공통 문자열 계약 확인 | Android emulator QA 요청 범위라 iOS Simulator 화면은 별도 캡처하지 않음 | native iOS 전용 변경 없음. 남은 리스크는 실제 iOS 화면 캡처 미수행 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/test/user_copy_guard.dart`
  - `apps/mobile/test/widget_test.dart`의 helper 적용 지점
  - `apps/mobile/lib/station_search.dart`, `apps/mobile/lib/favorite_facility.dart`의 정보 기준 문구

## 리스크

- API 계약과 저장 데이터는 변경하지 않고 사용자 표시 문구와 테스트 guard만 변경했습니다.
- `edge`/`node` 검사는 테스트 helper의 widget 문자열 대상에서만 검사합니다. XML 태그 이름이나 코드 내부 fixture까지 검사하지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
