### PR TITLE
[Perf] 노선도 선택 노선 overlay viewport culling

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1119,10 +1119,7 @@ class _SelectedLineOverlayPainter extends CustomPainter {
       ..strokeJoin = StrokeJoin.round
       ..strokeWidth = 14 * styleScale
       ..style = PaintingStyle.stroke;
-    for (final edge in edges) {
-      if (edge.lineId != lineId) {
-        continue;
-      }
+    for (final edge in _visibleEdges) {
       final from = stationsById[edge.fromStationId];
       final to = stationsById[edge.toStationId];
       if (from == null || to == null) {
@@ -1141,15 +1138,62 @@ class _SelectedLineOverlayPainter extends CustomPainter {
     }
     final stationBorderPaint = Paint()..color = lineColor;
     final stationFillPaint = Paint()..color = Colors.white;
-    for (final station in stationsById.values.toSet()) {
-      if (station.lineId != lineId) {
-        continue;
-      }
+    for (final station in _visibleStations) {
       final center = Offset(geometry.x(station), geometry.y(station));
       canvas.drawCircle(center, 13 * styleScale, stationBorderPaint);
       canvas.drawCircle(center, 7 * styleScale, stationFillPaint);
     }
     canvas.restore();
+  }
+
+  int get visibleEdgeCount => _visibleEdges.length;
+
+  int get visibleStationCount => _visibleStations.length;
+
+  Rect get _visibleSourceBounds =>
+      camera.visibleSourceRect.inflate(96 / camera.scale);
+
+  List<NetworkMapEdge> get _visibleEdges {
+    final visibleBounds = _visibleSourceBounds;
+    return [
+      for (final edge in edges)
+        if (edge.lineId == lineId &&
+            _edgeSourceBounds(edge)?.overlaps(visibleBounds) == true)
+          edge,
+    ];
+  }
+
+  List<NetworkMapStation> get _visibleStations {
+    final visibleBounds = _visibleSourceBounds;
+    return [
+      for (final station in stationsById.values.toSet())
+        if (station.lineId == lineId &&
+            _stationOverlayBounds(station).overlaps(visibleBounds))
+          station,
+    ];
+  }
+
+  Rect? _edgeSourceBounds(NetworkMapEdge edge) {
+    final from = stationsById[edge.fromStationId];
+    final to = stationsById[edge.toStationId];
+    if (from == null || to == null) {
+      return null;
+    }
+    final segmentPath = _segmentPath(from, to);
+    final bounds = segmentPath == null
+        ? Rect.fromPoints(
+            Offset(geometry.x(from), geometry.y(from)),
+            Offset(geometry.x(to), geometry.y(to)),
+          )
+        : segmentPath.getBounds().shift(-geometry.origin);
+    return bounds.inflate(16 * styleScale);
+  }
+
+  Rect _stationOverlayBounds(NetworkMapStation station) {
+    return Rect.fromCircle(
+      center: Offset(geometry.x(station), geometry.y(station)),
+      radius: 13 * styleScale,
+    );
   }
 
   @override

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1120,12 +1120,9 @@ class _SelectedLineOverlayPainter extends CustomPainter {
       ..strokeWidth = 14 * styleScale
       ..style = PaintingStyle.stroke;
     for (final edge in _visibleEdges) {
-      final from = stationsById[edge.fromStationId];
-      final to = stationsById[edge.toStationId];
-      if (from == null || to == null) {
-        continue;
-      }
-      final segmentPath = _segmentPath(from, to);
+      final from = edge.from;
+      final to = edge.to;
+      final segmentPath = edge.segmentPath;
       if (segmentPath == null) {
         canvas.drawLine(
           Offset(geometry.x(from), geometry.y(from)),
@@ -1153,14 +1150,28 @@ class _SelectedLineOverlayPainter extends CustomPainter {
   Rect get _visibleSourceBounds =>
       camera.visibleSourceRect.inflate(96 / camera.scale);
 
-  List<NetworkMapEdge> get _visibleEdges {
+  List<_SelectedLineVisibleEdge> get _visibleEdges {
     final visibleBounds = _visibleSourceBounds;
-    return [
-      for (final edge in edges)
-        if (edge.lineId == lineId &&
-            _edgeSourceBounds(edge)?.overlaps(visibleBounds) == true)
-          edge,
-    ];
+    final visibleEdges = <_SelectedLineVisibleEdge>[];
+    for (final edge in edges) {
+      if (edge.lineId != lineId) {
+        continue;
+      }
+      final from = stationsById[edge.fromStationId];
+      final to = stationsById[edge.toStationId];
+      if (from == null || to == null) {
+        continue;
+      }
+      final segmentPath = _segmentPath(from, to);
+      final bounds = _edgeSourceBounds(from, to, segmentPath);
+      if (!bounds.overlaps(visibleBounds)) {
+        continue;
+      }
+      visibleEdges.add(
+        _SelectedLineVisibleEdge(from: from, to: to, segmentPath: segmentPath),
+      );
+    }
+    return visibleEdges;
   }
 
   List<NetworkMapStation> get _visibleStations {
@@ -1173,13 +1184,11 @@ class _SelectedLineOverlayPainter extends CustomPainter {
     ];
   }
 
-  Rect? _edgeSourceBounds(NetworkMapEdge edge) {
-    final from = stationsById[edge.fromStationId];
-    final to = stationsById[edge.toStationId];
-    if (from == null || to == null) {
-      return null;
-    }
-    final segmentPath = _segmentPath(from, to);
+  Rect _edgeSourceBounds(
+    NetworkMapStation from,
+    NetworkMapStation to,
+    Path? segmentPath,
+  ) {
     final bounds = segmentPath == null
         ? Rect.fromPoints(
             Offset(geometry.x(from), geometry.y(from)),
@@ -1206,6 +1215,18 @@ class _SelectedLineOverlayPainter extends CustomPainter {
         oldDelegate.camera != camera ||
         oldDelegate.styleScale != styleScale;
   }
+}
+
+class _SelectedLineVisibleEdge {
+  const _SelectedLineVisibleEdge({
+    required this.from,
+    required this.to,
+    required this.segmentPath,
+  });
+
+  final NetworkMapStation from;
+  final NetworkMapStation to;
+  final Path? segmentPath;
 }
 
 Path? _segmentPath(NetworkMapStation from, NetworkMapStation to) {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1140,6 +1140,208 @@ void main() {
     expect(painter.styleScale as double, closeTo(190.50001 / 720, 0.001));
   });
 
+  testWidgets('노선도 선택 노선 overlay는 viewport 밖 edge와 station을 그리지 않는다', (
+    tester,
+  ) async {
+    const map = NetworkMapData(
+      regions: [NetworkMapRegion(name: '테스트권')],
+      selectedRegion: '테스트권',
+      lines: [
+        NetworkMapLine(
+          id: 'seoul-4',
+          name: '수도권 4호선',
+          color: '#00A5DE',
+          region: '테스트권',
+        ),
+      ],
+      stations: [
+        NetworkMapStation(
+          id: 'station-visible-a',
+          nameKo: '보이는역A',
+          nameEn: 'Visible A',
+          region: '테스트권',
+          lineId: 'seoul-4',
+          stationCode: '401',
+          sequence: 1,
+          position: NetworkMapPosition(
+            x: 5000,
+            y: 100,
+            labelDx: 0,
+            labelDy: 0,
+            upPath: '',
+            downPath: '',
+            sourceId: 'fixture-route-map-source-capital-review',
+          ),
+        ),
+        NetworkMapStation(
+          id: 'station-visible-b',
+          nameKo: '보이는역B',
+          nameEn: 'Visible B',
+          region: '테스트권',
+          lineId: 'seoul-4',
+          stationCode: '402',
+          sequence: 2,
+          position: NetworkMapPosition(
+            x: 5040,
+            y: 100,
+            labelDx: 0,
+            labelDy: 0,
+            upPath: '',
+            downPath: '',
+            sourceId: 'fixture-route-map-source-capital-review',
+          ),
+        ),
+        NetworkMapStation(
+          id: 'station-visible-c',
+          nameKo: '보이는역C',
+          nameEn: 'Visible C',
+          region: '테스트권',
+          lineId: 'seoul-4',
+          stationCode: '403',
+          sequence: 3,
+          position: NetworkMapPosition(
+            x: 5080,
+            y: 100,
+            labelDx: 0,
+            labelDy: 0,
+            upPath: '',
+            downPath: '',
+            sourceId: 'fixture-route-map-source-capital-review',
+          ),
+        ),
+        NetworkMapStation(
+          id: 'station-geometry-left',
+          nameKo: '왼쪽기준',
+          nameEn: 'Geometry Left',
+          region: '테스트권',
+          lineId: 'geometry-helper',
+          stationCode: '000',
+          sequence: 0,
+          position: NetworkMapPosition(
+            x: 0,
+            y: 100,
+            labelDx: 0,
+            labelDy: 0,
+            upPath: '',
+            downPath: '',
+            sourceId: 'fixture-route-map-source-capital-review',
+          ),
+        ),
+        NetworkMapStation(
+          id: 'station-far-a',
+          nameKo: '먼역A',
+          nameEn: 'Far A',
+          region: '테스트권',
+          lineId: 'seoul-4',
+          stationCode: '499',
+          sequence: 99,
+          position: NetworkMapPosition(
+            x: 10000,
+            y: 100,
+            labelDx: 0,
+            labelDy: 0,
+            upPath: '',
+            downPath: '',
+            sourceId: 'fixture-route-map-source-capital-review',
+          ),
+        ),
+        NetworkMapStation(
+          id: 'station-far-b',
+          nameKo: '먼역B',
+          nameEn: 'Far B',
+          region: '테스트권',
+          lineId: 'seoul-4',
+          stationCode: '500',
+          sequence: 100,
+          position: NetworkMapPosition(
+            x: 10100,
+            y: 100,
+            labelDx: 0,
+            labelDy: 0,
+            upPath: '',
+            downPath: '',
+            sourceId: 'fixture-route-map-source-capital-review',
+          ),
+        ),
+      ],
+      edges: [
+        NetworkMapEdge(
+          id: 'visible-edge',
+          lineId: 'seoul-4',
+          fromStationId: 'station-visible-a:seoul-4',
+          toStationId: 'station-visible-b:seoul-4',
+          accessibilityStatus: 'AVAILABLE',
+          reliabilityScore: 100,
+        ),
+        NetworkMapEdge(
+          id: 'far-edge',
+          lineId: 'seoul-4',
+          fromStationId: 'station-far-a:seoul-4',
+          toStationId: 'station-far-b:seoul-4',
+          accessibilityStatus: 'AVAILABLE',
+          reliabilityScore: 100,
+        ),
+      ],
+      positionSources: [
+        NetworkMapPositionSource(
+          id: 'fixture-route-map-source-capital-review',
+          name: '수도권 노선도 fixture 좌표 검수',
+          licenseStatus: 'fixture-only',
+        ),
+      ],
+      stationLineMemberships: [
+        NetworkMapStationLineMembership(
+          stationId: 'station-visible-a',
+          lineId: 'seoul-4',
+        ),
+        NetworkMapStationLineMembership(
+          stationId: 'station-visible-b',
+          lineId: 'seoul-4',
+        ),
+        NetworkMapStationLineMembership(
+          stationId: 'station-visible-c',
+          lineId: 'seoul-4',
+        ),
+        NetworkMapStationLineMembership(
+          stationId: 'station-far-a',
+          lineId: 'seoul-4',
+        ),
+        NetworkMapStationLineMembership(
+          stationId: 'station-far-b',
+          lineId: 'seoul-4',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(
+          networkMapRegionNames: const ['테스트권'],
+          networkMapData: map,
+        ),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('bottomNavMap')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('networkMapLineFilter')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('4호선'));
+    await tester.pumpAndSettle();
+
+    final overlay = tester.widget<CustomPaint>(
+      find.byKey(const Key('networkMapSelectedLineOverlay')),
+    );
+    final painter = overlay.painter as dynamic;
+    expect(painter.visibleEdgeCount as int, 1);
+    expect(painter.visibleStationCount as int, 3);
+  });
+
   testWidgets('노선도 역을 누르면 출발 도착 설정 sheet를 보여준다', (tester) async {
     await tester.pumpWidget(
       EasySubwayApp(


### PR DESCRIPTION
## 관련 이슈

close #883

## 작업 배경

- #836 노선도 viewport renderer 전환에서 WebView와 station hit target은 viewport 기준으로 줄어들었지만, 선택 노선 overlay painter는 선택 노선의 모든 edge와 station을 계속 순회했다.
- 화면 밖 overlay paint를 줄여 Offscreen DoD의 `viewport 밖 overlay culling` 항목을 좁게 완료한다.

## 작업 내용

- 선택 노선 overlay painter가 `camera.visibleSourceRect` 주변 bounds와 겹치는 edge만 그리도록 변경했다.
- 선택 노선 station marker도 viewport 주변 bounds와 겹치는 station만 그리도록 변경했다.
- 화면 밖 edge/station이 painter visible count에서 제외되는 widget 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --plain-name "노선도 선택 노선 overlay는 viewport 밖 edge와 station을 그리지 않는다"`: exit 0, 1 test passed
  - `flutter test test/widget_test.dart --plain-name "노선도"`: exit 0, 15 tests passed
  - `flutter analyze`: exit 0, No issues found
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 104 tests passed
  - `flutter test`: exit 0, 479 tests passed
  - `git diff --check`: exit 0
  - `flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY install -r apps/mobile/build/app/outputs/flutter-apk/app-debug.apk`: exit 0, Success
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY shell monkey -p com.easysubway.app 1`: exit 0, 앱 실행
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY exec-out uiautomator dump /dev/tty`: exit 0, 노선도 및 4호선 선택 UI tree 캡처
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY logcat --pid 6027 -d`: exit 0, app-scoped logcat 캡처
  - GitHub Actions `CI`: success, https://github.com/AquilaXk/easysubway/actions/runs/28207304552
  - GitHub Actions `Release Artifacts`: success, https://github.com/AquilaXk/easysubway/actions/runs/28207304352
  - CodeRabbit: rate limit 및 prepaid credit exhausted로 실제 review 미시작, https://github.com/AquilaXk/easysubway/pull/885#issuecomment-4801855265
  - Codex CLI fallback review: actionable 1건 게시 후 fix commit `76360f95`으로 수정, thread resolved, https://github.com/AquilaXk/easysubway/pull/885#pullrequestreview-4573027092
  - Codex CLI fallback re-review: actionable 0건, https://github.com/AquilaXk/easysubway/pull/885#pullrequestreview-4575752305
  - Post-merge `CD`: success, https://github.com/AquilaXk/easysubway/actions/runs/28207568707
  - Post-merge `CI` / `Release Artifacts`: run 생성 및 진행 중, 확인 시점 실패 신호 없음, https://github.com/AquilaXk/easysubway/actions/runs/28207568905 / https://github.com/AquilaXk/easysubway/actions/runs/28207568725

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| overlay culling 회귀 | Flutter widget test | viewport 밖 edge/station fixture로 painter visible count 확인 | `flutter test test/widget_test.dart --plain-name "노선도 선택 노선 overlay는 viewport 밖 edge와 station을 그리지 않는다"` 출력 | visible edge 1건, station 3건만 남아 테스트 통과 |
| 노선도 4호선 overlay 흐름 | Android 실기기 SM-A175N, Android 16 | `RFKYA01VMQY`에 debug APK 설치 후 노선도 탭, line filter에서 4호선 선택 | 로컬 전용 `.codex/evidence/883/android-route-map-line-4-ui.xml`, `.codex/evidence/883/android-route-map-line-4.png` | UI tree에 WebView, `노선: 4호선`, `노선별로 보기` 표시 |
| renderer 런타임 로그 | Android 실기기 SM-A175N, Android 16 | app PID 기준 logcat 필터 확인 | 로컬 전용 `.codex/evidence/883/android-route-map-line-4-logcat.txt` | `routeMapRenderer cameraLatency revision=0 elapsedMs=9`, app-scoped fatal/Flutter exception 없음 |
| PR CI | GitHub Actions | `CI` workflow와 `Release Artifacts` workflow 확인 | `CI` run 28207304552, `Release Artifacts` run 28207304352 | required mobile/backend/repository/Android/release artifact checks success |
| 코드리뷰 | GitHub PR review | CodeRabbit 상태 확인 후 Codex CLI fallback review/re-review | CodeRabbit rate limit comment, Codex reviews 4573027092, 4575752305 | actionable 1건 수정 완료, re-review actionable 0건, review thread resolved |
| Post-merge CD | GitHub Actions main | merge commit `54a619ed` 기준 main workflow 확인 | `CD` run 28207568707, `CI` run 28207568905, `Release Artifacts` run 28207568725 | CD success, CI/Release Artifacts 생성 및 확인 시점 실패 신호 없음 |

실기기 screenshot/UI tree/logcat은 QA 장비의 전체 화면과 접근성 tree, 로컬 런타임 로그를 포함하므로 GitHub에 직접 첨부하지 않고 로컬 전용 evidence로 보관했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `_SelectedLineOverlayPainter`의 `_visibleEdges`, `_visibleStations`, `_edgeSourceBounds`가 camera source 좌표와 `geometry.origin` 보정을 같은 기준으로 쓰는지 확인하면 된다.

## 리스크

- 선택 노선 overlay paint 대상만 줄이며, station hit target과 semantics culling은 기존 동작을 유지한다.
- path bounds와 직선 edge bounds 주변에 16 source unit 여유를 둬 stroke 가장자리 clipping 위험을 줄였다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
