### PR TITLE
[Fix] 하단 고정 버튼 SafeArea와 데이터 삭제 결과 정렬 개선

### DIFF
--- a/apps/mobile/lib/accessible_design.dart
+++ b/apps/mobile/lib/accessible_design.dart
@@ -33,7 +33,7 @@ EdgeInsets easySubwayBottomActionInsets(
   BuildContext context, {
   double horizontal = 20,
   double top = 8,
-  double bottom = 20,
+  double bottom = 32,
 }) {
   final viewPadding = MediaQuery.viewPaddingOf(context);
   final viewInsets = MediaQuery.viewInsetsOf(context);

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4279,7 +4279,7 @@ class UserDataDeletionResultScreen extends StatelessWidget {
                     color: EasySubwayAccessibleColors.mintDark,
                     size: 56,
                   ),
-                  const SizedBox(height: 12),
+                  const SizedBox(height: 16),
                   Text(
                     '내 데이터가 삭제됐어요',
                     style: Theme.of(context).textTheme.headlineSmall?.copyWith(
@@ -4306,21 +4306,21 @@ class UserDataDeletionResultScreen extends StatelessWidget {
                     title: '즐겨찾기한 역',
                     value: '${result.deletedFavoriteStationCount}개 삭제',
                   ),
-                  const SizedBox(height: 12),
+                  const SizedBox(height: 16),
                   _DataDeletionResultRow(
                     id: 'favoriteFacilities',
                     icon: Icons.elevator_outlined,
                     title: '즐겨찾기한 시설',
                     value: '${result.deletedFavoriteFacilityCount}개 삭제',
                   ),
-                  const SizedBox(height: 12),
+                  const SizedBox(height: 16),
                   _DataDeletionResultRow(
                     id: 'favoriteRoutes',
                     icon: Icons.route_outlined,
                     title: '즐겨찾기한 경로',
                     value: '${result.deletedFavoriteRouteCount}개 삭제',
                   ),
-                  const SizedBox(height: 12),
+                  const SizedBox(height: 16),
                   _DataDeletionResultRow(
                     id: 'notifications',
                     icon: Icons.notifications_none,
@@ -4341,7 +4341,7 @@ class UserDataDeletionResultScreen extends StatelessWidget {
                         : '${result.anonymizedReportCount}건 익명화',
                   ),
                   if (deletionScope != UserDataDeletionScope.deviceOnly)
-                    const SizedBox(height: 12),
+                    const SizedBox(height: 16),
                   if (deletionScope != UserDataDeletionScope.deviceOnly)
                     _DataDeletionResultRow(
                       id: 'routeFeedback',
@@ -4434,14 +4434,14 @@ class _DataDeletionResultRow extends StatelessWidget {
           children: [
             Container(
               key: Key('dataDeletionResultIcon-$id'),
-              width: 56,
-              height: 56,
+              width: 60,
+              height: 60,
               decoration: BoxDecoration(
-                color: const Color(0xFFD3F0E6),
-                borderRadius: BorderRadius.circular(14),
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(16),
                 border: Border.all(
-                  color: EasySubwayAccessibleColors.mint,
-                  width: 1.5,
+                  color: EasySubwayAccessibleColors.mintDark,
+                  width: 2,
                 ),
               ),
               child: Icon(

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -58,6 +58,23 @@ void main() {
     expect(find.text('천천히 이동 · 큰 글씨 · 단순 보기 적용'), findsNothing);
   });
 
+  testWidgets('온보딩 시작 버튼은 Android 시스템 내비게이션 바와 여백을 둔다', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.viewPadding = const FakeViewPadding(bottom: 34);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetViewPadding);
+
+    await tester.pumpWidget(MaterialApp(home: StartScreen(onStart: () {})));
+
+    final screenBottom =
+        tester.view.physicalSize.height / tester.view.devicePixelRatio;
+    final buttonRect = tester.getRect(
+      find.byKey(const Key('startScreenStartButton')),
+    );
+
+    expect(screenBottom - buttonRect.bottom, greaterThanOrEqualTo(66));
+  });
+
   testWidgets('온보딩은 이동 조건과 보기 설정을 선택한 뒤 완료 결과를 반환한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     OnboardingResult? completedResult;

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -2729,17 +2729,19 @@ void main() {
     );
     final stationIconDecoration = stationIconBadge.decoration! as BoxDecoration;
     expect(stationIconDecoration.border, isNotNull);
+    expect(stationIconDecoration.color, Colors.white);
     expect(
-      stationIconDecoration.color,
-      isNot(EasySubwayAccessibleColors.mintSoft),
+      (stationIconDecoration.border! as Border).top.color,
+      EasySubwayAccessibleColors.mintDark,
     );
+    expect((stationIconDecoration.border! as Border).top.width, 2);
     final stationRow = tester.getRect(
       find.byKey(const Key('dataDeletionResultRow-favoriteStations')),
     );
     final facilityRow = tester.getRect(
       find.byKey(const Key('dataDeletionResultRow-favoriteFacilities')),
     );
-    expect(facilityRow.top - stationRow.bottom, greaterThanOrEqualTo(10));
+    expect(facilityRow.top - stationRow.bottom, greaterThanOrEqualTo(16));
     expectNoForbiddenUserCopy(tester);
 
     await tester.tap(find.byKey(const Key('dataDeletionResultStartButton')));
@@ -2791,7 +2793,7 @@ void main() {
       find.byKey(const Key('dataDeletionResultStartButton')),
     );
 
-    expect(screenBottom - buttonRect.bottom, greaterThanOrEqualTo(54));
+    expect(screenBottom - buttonRect.bottom, greaterThanOrEqualTo(66));
   });
 
   testWidgets('도움말은 원격 삭제 저장소에서 서버 삭제 범위를 유지해 안내한다', (tester) async {
@@ -4014,7 +4016,7 @@ void main() {
       find.byKey(const Key('routeSearchSubmitButton')),
     );
 
-    expect(screenBottom - buttonRect.bottom, greaterThanOrEqualTo(54));
+    expect(screenBottom - buttonRect.bottom, greaterThanOrEqualTo(66));
   });
 
   testWidgets('길찾기 하단 버튼은 가로 safe-area 안쪽에 배치된다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

close #884

## 작업 배경

- QA 요청으로 Android 3-button 내비게이션 바가 켜진 기기에서 하단 고정 버튼이 시스템 바와 달라붙는 문제를 수정했습니다.
- QA가 첨부한 데이터 삭제 결과 화면에서 처리 결과 아이콘 배경과 외곽선 대비가 약하고, 처리 결과 행들이 위아래로 붙어 보이는 문제를 함께 정리했습니다.

## 작업 내용

- 공통 하단 CTA inset 기본 bottom 여백을 늘려 `viewPadding.bottom`이 있는 Android 기기에서 고정 버튼과 시스템 내비게이션 바 사이 간격을 확보했습니다.
- 데이터 삭제 결과의 처리 결과 아이콘 박스를 흰 배경, 진한 민트 외곽선, 더 큰 60px 터치 시각 영역으로 바꿔 대비를 높였습니다.
- 데이터 삭제 결과 행 사이 간격을 16px로 늘려 각 처리 항목이 독립적으로 읽히게 했습니다.
- 온보딩 시작 버튼, 길찾기 CTA, 데이터 삭제 결과 CTA의 Android 시스템 내비게이션 바 여백 회귀 테스트를 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --plain-name "데이터 삭제 결과 시작 버튼은 Android 시스템 내비게이션 바와 여백을 둔다"`: 수정 전 실패, 기대값 66px 대비 실제 54px로 재현
  - `flutter test test/widget_test.dart --plain-name "길찾기 하단 버튼은 Android 시스템 내비게이션 바와 여백을 둔다"`: 수정 전 실패, 기대값 66px 대비 실제 54px로 재현
  - `flutter test test/widget_test.dart --plain-name "도움말은 앱 안에서 데이터 삭제를 재확인하고 로컬 상태를 정리한다"`: exit 0
  - `flutter test test/widget_test.dart --plain-name "데이터 삭제 결과 시작 버튼은 Android 시스템 내비게이션 바와 여백을 둔다"`: exit 0
  - `flutter test test/widget_test.dart --plain-name "길찾기 하단 버튼은 Android 시스템 내비게이션 바와 여백을 둔다"`: exit 0
  - `flutter test test/onboarding_test.dart --plain-name "온보딩 시작 버튼은 Android 시스템 내비게이션 바와 여백을 둔다"`: exit 0
  - `flutter test test/widget_test.dart test/onboarding_test.dart`: exit 0, `+163 All tests passed!`
  - `flutter analyze`: exit 0, `No issues found!`
  - `flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 온보딩 시작 CTA SafeArea | Android emulator API 36, 3-button navigation | `adb`로 앱 초기 실행 후 스크린샷과 UI tree 캡처 | 로컬 전용: `.codex/evidence/issue-884/start-screen.png`, `.codex/evidence/issue-884/start-screen.xml` | `쉬운 지하철 시작하기` 버튼이 시스템 내비게이션 바와 분리됨 |
| 길찾기 하단 CTA SafeArea | Android emulator API 36, 3-button navigation | 홈에서 길찾기 화면 진입 후 스크린샷과 UI tree 캡처 | 로컬 전용: `.codex/evidence/issue-884/route-search-bottom.png`, `.codex/evidence/issue-884/route-search-bottom.xml` | 하단 `길찾기` CTA가 시스템 내비게이션 바와 분리됨 |
| 데이터 삭제 결과 정렬과 CTA SafeArea | Android emulator API 36, 3-button navigation | 도움말에서 이 기기의 앱 데이터 삭제를 완료한 뒤 스크린샷과 UI tree 캡처 | 로컬 전용: `.codex/evidence/issue-884/data-deletion-result.png`, `.codex/evidence/issue-884/data-deletion-result.xml` | 처리 결과 아이콘 대비가 높아지고 행 간격과 하단 `처음부터 시작` 버튼 여백이 확보됨 |

스크린샷과 UI tree는 QA 검증용 로컬 증거로 보관했습니다. 저장소 정책상 스크린샷을 git에 커밋하지 않으며, 외부 업로드 승인이 없어 PR에는 로컬 증거 경로와 확인 결과만 남깁니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `easySubwayBottomActionInsets` 기본 bottom 여백 변경이 온보딩, 길찾기, 데이터 삭제 결과 CTA의 공통 SafeArea 동작에 의도대로 적용되는지 확인해 주세요.
  - 데이터 삭제 결과 행의 시각 대비 변경이 기존 큰 글자 레이아웃을 해치지 않는지 확인해 주세요.

## 리스크

- 공통 CTA inset 기본값 변경으로 같은 helper를 쓰는 다른 하단 버튼도 Android 시스템 바와의 간격이 함께 늘어납니다. 의도한 접근성 여백 확대이며, 테스트에서 주요 CTA 경로를 확인했습니다.
- iOS 실기 증거는 이번 PR 범위에서 수집하지 않았습니다. 변경은 `MediaQuery.viewPadding` 기반 공통 여백과 처리 결과 화면 시각 스타일이며, Android 3-button 내비게이션 문제 해결이 핵심 검증 대상입니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
