### PR TITLE
[Test] 노선도 viewport 밖 station semantics 회귀 검증

### DIFF
--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1342,6 +1342,142 @@ void main() {
     expect(painter.visibleStationCount as int, 3);
   });
 
+  testWidgets('노선도 viewport 밖 station semantics는 생성하지 않는다', (tester) async {
+    final semanticsHandle = tester.ensureSemantics();
+    const map = NetworkMapData(
+      regions: [NetworkMapRegion(name: '테스트권')],
+      selectedRegion: '테스트권',
+      lines: [
+        NetworkMapLine(
+          id: 'seoul-4',
+          name: '수도권 4호선',
+          color: '#00A5DE',
+          region: '테스트권',
+        ),
+      ],
+      stations: [
+        NetworkMapStation(
+          id: 'station-visible-a',
+          nameKo: '보이는역A',
+          nameEn: 'Visible A',
+          region: '테스트권',
+          lineId: 'seoul-4',
+          stationCode: '401',
+          sequence: 1,
+          position: NetworkMapPosition(
+            x: 5000,
+            y: 100,
+            labelDx: 0,
+            labelDy: 0,
+            upPath: '',
+            downPath: '',
+            sourceId: 'fixture-route-map-source-capital-review',
+          ),
+        ),
+        NetworkMapStation(
+          id: 'station-geometry-left',
+          nameKo: '왼쪽기준',
+          nameEn: 'Geometry Left',
+          region: '테스트권',
+          lineId: 'geometry-helper',
+          stationCode: '000',
+          sequence: 0,
+          position: NetworkMapPosition(
+            x: 0,
+            y: 100,
+            labelDx: 0,
+            labelDy: 0,
+            upPath: '',
+            downPath: '',
+            sourceId: 'fixture-route-map-source-capital-review',
+          ),
+        ),
+        NetworkMapStation(
+          id: 'station-far-a',
+          nameKo: '먼역A',
+          nameEn: 'Far A',
+          region: '테스트권',
+          lineId: 'seoul-4',
+          stationCode: '499',
+          sequence: 99,
+          position: NetworkMapPosition(
+            x: 10000,
+            y: 100,
+            labelDx: 0,
+            labelDy: 0,
+            upPath: '',
+            downPath: '',
+            sourceId: 'fixture-route-map-source-capital-review',
+          ),
+        ),
+      ],
+      edges: [],
+      positionSources: [
+        NetworkMapPositionSource(
+          id: 'fixture-route-map-source-capital-review',
+          name: '수도권 노선도 fixture 좌표 검수',
+          licenseStatus: 'fixture-only',
+        ),
+      ],
+      stationLineMemberships: [
+        NetworkMapStationLineMembership(
+          stationId: 'station-visible-a',
+          lineId: 'seoul-4',
+        ),
+        NetworkMapStationLineMembership(
+          stationId: 'station-far-a',
+          lineId: 'seoul-4',
+        ),
+      ],
+    );
+
+    try {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(
+            networkMapRegionNames: const ['테스트권'],
+            networkMapData: map,
+          ),
+          reportRepository: FakeFacilityReportRepository(),
+          routeRepository: FakeRouteSearchRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('bottomNavMap')));
+      await tester.pumpAndSettle();
+
+      final visibleStation = find.byKey(
+        const Key('networkMapStation-visible-a-seoul-4'),
+      );
+      expect(visibleStation, findsOneWidget);
+      expect(
+        find.byKey(const Key('networkMapStation-far-a-seoul-4')),
+        findsNothing,
+      );
+      expect(find.bySemanticsLabel('먼역A역'), findsNothing);
+
+      final visibleSemantics = tester.getSemantics(visibleStation);
+      expect(
+        visibleSemantics.getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
+      );
+
+      visibleSemantics.owner!.performAction(
+        visibleSemantics.id,
+        SemanticsAction.tap,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
+      expect(find.text('보이는역A역'), findsOneWidget);
+    } finally {
+      semanticsHandle.dispose();
+    }
+  });
+
   testWidgets('노선도 역을 누르면 출발 도착 설정 sheet를 보여준다', (tester) async {
     await tester.pumpWidget(
       EasySubwayApp(


### PR DESCRIPTION
## 관련 이슈

close #887

## 작업 배경

- #836 Offscreen DoD의 `viewport 밖 semantics 미생성` 항목을 회귀 테스트로 고정한다.
- 현재 노선도 station hit target은 viewport 주변 bounds와 겹치는 station만 `Semantics` 위젯으로 생성하므로, camera/renderer 후속 변경에서 전체 station semantics가 다시 생성되지 않게 테스트 증거를 남긴다.

## 작업 내용

- viewport 안 station은 hit target과 tap semantics를 유지하고, viewport 밖 station은 widget tree와 semantics label에 생성되지 않는 widget test를 추가했다.
- 같은 테스트에서 visible station의 semantics tap이 기존 station sheet를 여는 동작까지 확인했다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/test/widget_test.dart`: exit 0, 0 files changed
  - `flutter test test/widget_test.dart --plain-name "노선도 viewport 밖 station semantics는 생성하지 않는다"`: exit 0, 1 test passed
  - `flutter test test/widget_test.dart --plain-name "노선도"`: exit 0, 16 tests passed
  - `flutter analyze`: exit 0, No issues found
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 104 tests passed
  - `git diff --check`: exit 0
  - `flutter test`: exit 0, 481 tests passed
  - `flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY install -r apps/mobile/build/app/outputs/flutter-apk/app-debug.apk`: exit 0, Success
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY shell monkey -p com.easysubway.app 1`: exit 0, 앱 실행
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY exec-out uiautomator dump /dev/tty`: exit 0, 노선도 UI tree 캡처
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY logcat --pid 21895 -d`: exit 0, app-scoped logcat 캡처
  - GitHub Actions `CI`: success, https://github.com/AquilaXk/easysubway/actions/runs/28207907361
  - GitHub Actions `Release Artifacts`: success, https://github.com/AquilaXk/easysubway/actions/runs/28207907133
  - CodeRabbit 상태 확인: rate limit 및 prepaid credits exhausted, https://github.com/AquilaXk/easysubway/pull/888#issuecomment-4805166891
  - Codex CLI fallback review: actionable 0 / nitpick 0, https://github.com/AquilaXk/easysubway/pull/888#pullrequestreview-4575821114
  - Merge 후 `main` CD: success, https://github.com/AquilaXk/easysubway/actions/runs/28208183730

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| viewport 밖 station semantics 회귀 | Flutter widget test | visible/far station fixture에서 hit target key와 semantics label 생성 여부 확인 | `flutter test test/widget_test.dart --plain-name "노선도 viewport 밖 station semantics는 생성하지 않는다"` 출력 | visible station만 생성되고 semantics tap으로 station sheet 열림, far station key/label 미생성 |
| 노선도 접근성 tree | Android 실기기 SM-A175N, Android 16 | `RFKYA01VMQY`에 debug APK 설치 후 노선도 탭 UI tree/screenshot/logcat 확인 | 로컬 전용 `.codex/evidence/887/android-route-map-ui.xml`, `.codex/evidence/887/android-route-map.png`, `.codex/evidence/887/android-route-map-logcat.txt` | UI tree에 WebView, viewport station buttons, `노선별로 보기` 표시. `routeMapRenderer cameraLatency revision=0 elapsedMs=9`, fatal/ANR/Flutter exception 패턴 없음 |
| PR CI | GitHub Actions | PR head `52ed037c1bac3d9d0e203af795ab00d5803e2381` checks 확인 | https://github.com/AquilaXk/easysubway/actions/runs/28207907361, https://github.com/AquilaXk/easysubway/actions/runs/28207907133 | CI success, Release Artifacts success. Backend Release Image는 변경 없음으로 skipped |
| 코드 리뷰 | GitHub PR | CodeRabbit 상태 확인 후 Codex CLI fallback review 확인 | https://github.com/AquilaXk/easysubway/pull/888#issuecomment-4805166891, https://github.com/AquilaXk/easysubway/pull/888#pullrequestreview-4575821114 | CodeRabbit은 rate limit/credits exhausted로 fallback 전환, Codex CLI review에서 actionable 0 |
| Merge 후 CD | GitHub Actions main | merge commit `e211f194cc99120bd28ece8e4a06ff638035a147` run 상태 확인 | https://github.com/AquilaXk/easysubway/actions/runs/28208183730 | CD success. 같은 commit의 CI/Release Artifacts run은 생성되어 진행 중이며 실패 신호 없음 |

실기기 screenshot/UI tree/logcat은 QA 장비의 전체 화면과 접근성 tree, 로컬 런타임 로그를 포함하므로 GitHub에 직접 첨부하지 않고 로컬 전용 evidence로 보관했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: production code 변경 없이 [apps/mobile/test/widget_test.dart]의 새 fixture가 viewport 밖 station hit target과 semantics label 미생성을 동시에 검증한다.

## 리스크

- 런타임 동작 변경은 없고 회귀 테스트만 추가했다.
- Android 실기기 evidence는 수도권 기본 노선도 화면 기준이며, iOS 실기기는 연결되지 않아 이번 test-only PR에서는 Flutter widget semantics test로 공통 동작을 검증했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
