### PR TITLE
[Test] 노선도 production 좌표 감사 CLI 추가

### DIFF
--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -58,8 +58,12 @@ function parseArgs(argv) {
   return options;
 }
 
-function keyFor(row) {
+function stationLineKeyFor(row) {
   return `${row.stationId ?? ""}\u0000${row.lineId ?? ""}`;
+}
+
+function routeMapPositionKeyFor(row) {
+  return `${row.stationId ?? ""}\u0000${row.lineId ?? ""}\u0000${row.region ?? ""}`;
 }
 
 function normalizedText(value) {
@@ -84,12 +88,14 @@ function auditPack(pack) {
   const positions = Array.isArray(pack.routeMapPositions)
     ? pack.routeMapPositions
     : [];
-  const stationLineKeys = new Set(stationLines.map(keyFor));
+  const stationLineKeys = new Set(stationLines.map(stationLineKeyFor));
   const positionKeys = new Set();
+  const positionedStationLineKeys = new Set();
   const coordinateGroups = new Map();
 
   for (const position of positions) {
-    const key = keyFor(position);
+    const key = routeMapPositionKeyFor(position);
+    const stationLineKey = stationLineKeyFor(position);
     if (positionKeys.has(key)) {
       addFinding(findings, {
         severity: "BLOCKER",
@@ -102,8 +108,9 @@ function auditPack(pack) {
       });
     }
     positionKeys.add(key);
+    positionedStationLineKeys.add(stationLineKey);
 
-    if (!stationLineKeys.has(key)) {
+    if (!stationLineKeys.has(stationLineKey)) {
       addFinding(findings, {
         severity: "BLOCKER",
         code: "ROUTE_MAP_POSITION_WITHOUT_STATION_LINE",
@@ -160,7 +167,7 @@ function auditPack(pack) {
   }
 
   for (const membership of stationLines) {
-    if (positionKeys.has(keyFor(membership))) {
+    if (positionedStationLineKeys.has(stationLineKeyFor(membership))) {
       continue;
     }
     addFinding(findings, {
@@ -208,15 +215,16 @@ function auditPack(pack) {
       stationLineCount: stationLines.length,
       routeMapPositionCount: positions.length,
       coveredStationLineCount: [...stationLineKeys].filter((key) =>
-        positionKeys.has(key),
+        positionedStationLineKeys.has(key),
       ).length,
       coverageRatio:
         stationLines.length === 0
           ? 1
           : Number(
               (
-                [...stationLineKeys].filter((key) => positionKeys.has(key))
-                  .length / stationLines.length
+                [...stationLineKeys].filter((key) =>
+                  positionedStationLineKeys.has(key),
+                ).length / stationLines.length
               ).toFixed(4),
             ),
       findingsBySeverity: findingCounts,

--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const severityRank = new Map([
+  ["BLOCKER", 0],
+  ["HIGH", 1],
+  ["MEDIUM", 2],
+  ["LOW", 3],
+  ["INFO", 4],
+]);
+
+function usage() {
+  return `Usage: node tools/route-map/audit-route-map.mjs --fixture <catalog-fixture.json> [--fail-on BLOCKER,HIGH] [--pretty]
+
+Audits routeMapPositions against stationLines so production route-map coordinate
+coverage can be checked before rebuilding datapacks.`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    fixture: null,
+    failOn: [],
+    pretty: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--fixture":
+        options.fixture = argv[++index];
+        break;
+      case "--fail-on":
+        options.failOn = (argv[++index] ?? "")
+          .split(",")
+          .map((value) => value.trim())
+          .filter(Boolean);
+        break;
+      case "--pretty":
+        options.pretty = true;
+        break;
+      case "--help":
+      case "-h":
+        console.log(usage());
+        process.exit(0);
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!options.fixture) {
+    throw new Error("--fixture is required");
+  }
+  for (const severity of options.failOn) {
+    if (!severityRank.has(severity)) {
+      throw new Error(`Unknown severity in --fail-on: ${severity}`);
+    }
+  }
+  return options;
+}
+
+function keyFor(row) {
+  return `${row.stationId ?? ""}\u0000${row.lineId ?? ""}`;
+}
+
+function normalizedText(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function addFinding(findings, finding) {
+  findings.push({
+    severity: finding.severity,
+    code: finding.code,
+    packId: finding.packId,
+    region: finding.region ?? "",
+    lineId: finding.lineId ?? "",
+    stationId: finding.stationId ?? "",
+    message: finding.message,
+  });
+}
+
+function auditPack(pack) {
+  const findings = [];
+  const stationLines = Array.isArray(pack.stationLines) ? pack.stationLines : [];
+  const positions = Array.isArray(pack.routeMapPositions)
+    ? pack.routeMapPositions
+    : [];
+  const stationLineKeys = new Set(stationLines.map(keyFor));
+  const positionKeys = new Set();
+  const coordinateGroups = new Map();
+
+  for (const position of positions) {
+    const key = keyFor(position);
+    if (positionKeys.has(key)) {
+      addFinding(findings, {
+        severity: "BLOCKER",
+        code: "DUPLICATE_ROUTE_MAP_POSITION",
+        packId: pack.id,
+        region: position.region,
+        lineId: position.lineId,
+        stationId: position.stationId,
+        message: "routeMapPositions has duplicate stationId/lineId rows.",
+      });
+    }
+    positionKeys.add(key);
+
+    if (!stationLineKeys.has(key)) {
+      addFinding(findings, {
+        severity: "BLOCKER",
+        code: "ROUTE_MAP_POSITION_WITHOUT_STATION_LINE",
+        packId: pack.id,
+        region: position.region,
+        lineId: position.lineId,
+        stationId: position.stationId,
+        message:
+          "routeMapPositions row does not match a stationLines membership.",
+      });
+    }
+
+    const sourceFields = [
+      ["sourceId", position.sourceId],
+      ["sourceName", position.sourceName],
+      ["sourceUrl", position.sourceUrl],
+      ["licenseStatus", position.licenseStatus],
+    ].filter(([, value]) => normalizedText(value) === "");
+    if (sourceFields.length > 0) {
+      addFinding(findings, {
+        severity: "HIGH",
+        code: "MISSING_ROUTE_MAP_SOURCE",
+        packId: pack.id,
+        region: position.region,
+        lineId: position.lineId,
+        stationId: position.stationId,
+        message: `routeMapPositions source fields are missing: ${sourceFields
+          .map(([name]) => name)
+          .join(", ")}.`,
+      });
+    }
+
+    if (normalizedText(position.reviewedAt) === "") {
+      addFinding(findings, {
+        severity: "HIGH",
+        code: "MISSING_ROUTE_MAP_REVIEW",
+        packId: pack.id,
+        region: position.region,
+        lineId: position.lineId,
+        stationId: position.stationId,
+        message: "routeMapPositions row has no reviewedAt timestamp.",
+      });
+    }
+
+    const coordinateKey = [
+      normalizedText(position.region),
+      normalizedText(position.lineId),
+      Number(position.x),
+      Number(position.y),
+    ].join("\u0000");
+    const group = coordinateGroups.get(coordinateKey) ?? [];
+    group.push(position);
+    coordinateGroups.set(coordinateKey, group);
+  }
+
+  for (const membership of stationLines) {
+    if (positionKeys.has(keyFor(membership))) {
+      continue;
+    }
+    addFinding(findings, {
+      severity: "BLOCKER",
+      code: "MISSING_ROUTE_MAP_POSITION",
+      packId: pack.id,
+      region: "",
+      lineId: membership.lineId,
+      stationId: membership.stationId,
+      message:
+        "stationLines membership has no matching routeMapPositions coordinate.",
+    });
+  }
+
+  for (const group of coordinateGroups.values()) {
+    const uniqueStationIds = new Set(group.map((row) => row.stationId));
+    if (uniqueStationIds.size < 2) {
+      continue;
+    }
+    const first = group[0];
+    addFinding(findings, {
+      severity: "HIGH",
+      code: "DUPLICATE_SOURCE_COORDINATE",
+      packId: pack.id,
+      region: first.region,
+      lineId: first.lineId,
+      stationId: group.map((row) => row.stationId).join(","),
+      message:
+        "Multiple stations share the same region/line/source coordinate and need explicit review.",
+    });
+  }
+
+  const findingCounts = {};
+  for (const severity of severityRank.keys()) {
+    findingCounts[severity] = 0;
+  }
+  for (const finding of findings) {
+    findingCounts[finding.severity] += 1;
+  }
+
+  return {
+    id: pack.id ?? "",
+    version: pack.version ?? "",
+    summary: {
+      stationLineCount: stationLines.length,
+      routeMapPositionCount: positions.length,
+      coveredStationLineCount: [...stationLineKeys].filter((key) =>
+        positionKeys.has(key),
+      ).length,
+      coverageRatio:
+        stationLines.length === 0
+          ? 1
+          : Number(
+              (
+                [...stationLineKeys].filter((key) => positionKeys.has(key))
+                  .length / stationLines.length
+              ).toFixed(4),
+            ),
+      findingsBySeverity: findingCounts,
+    },
+    findings: findings.sort((a, b) => {
+      const severityDelta =
+        severityRank.get(a.severity) - severityRank.get(b.severity);
+      if (severityDelta !== 0) {
+        return severityDelta;
+      }
+      return `${a.code}:${a.lineId}:${a.stationId}`.localeCompare(
+        `${b.code}:${b.lineId}:${b.stationId}`,
+      );
+    }),
+  };
+}
+
+function auditFixture(fixturePath, fixture) {
+  const packs = Array.isArray(fixture.packs) ? fixture.packs : [];
+  const auditedPacks = packs.map(auditPack);
+  const findings = auditedPacks.flatMap((pack) => pack.findings);
+  const findingCounts = {};
+  for (const severity of severityRank.keys()) {
+    findingCounts[severity] = 0;
+  }
+  for (const finding of findings) {
+    findingCounts[finding.severity] += 1;
+  }
+  return {
+    schemaVersion: 1,
+    artifactKind: "route-map-position-audit",
+    source: path.normalize(fixturePath),
+    summary: {
+      packCount: auditedPacks.length,
+      findingsBySeverity: findingCounts,
+    },
+    packs: auditedPacks,
+    findings,
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const fixtureText = await readFile(options.fixture, "utf8");
+  const fixture = JSON.parse(fixtureText);
+  const report = auditFixture(options.fixture, fixture);
+  console.log(JSON.stringify(report, null, options.pretty ? 2 : 0));
+
+  const failed = options.failOn.some(
+    (severity) => report.summary.findingsBySeverity[severity] > 0,
+  );
+  if (failed) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  console.error(usage());
+  process.exit(1);
+});

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
@@ -47,4 +48,94 @@ test("SVG geometry extractor returns transformed visible text polygons", async (
   const rotated = output.labels.find((label) => label.sourceText === "회전역");
   assert.notEqual(rotated.polygon[0].y, rotated.polygon[1].y);
   assert.notEqual(rotated.polygon[0].x, rotated.polygon[3].x);
+});
+
+test("route map position audit passes clean catalog fixture", async () => {
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "tools/route-map/audit-route-map.mjs",
+      "--fixture",
+      "tools/datapack/fixtures/catalog-fixture.json",
+      "--fail-on",
+      "BLOCKER,HIGH",
+    ],
+    { cwd: root, maxBuffer: 1024 * 1024 },
+  );
+  const output = JSON.parse(stdout);
+
+  assert.equal(output.schemaVersion, 1);
+  assert.equal(output.artifactKind, "route-map-position-audit");
+  assert.equal(output.summary.packCount, 1);
+  assert.equal(output.summary.findingsBySeverity.BLOCKER, 0);
+  assert.equal(output.summary.findingsBySeverity.HIGH, 0);
+  assert.equal(output.packs[0].summary.stationLineCount, 9);
+  assert.equal(output.packs[0].summary.routeMapPositionCount, 9);
+  assert.equal(output.packs[0].summary.coverageRatio, 1);
+});
+
+test("route map position audit reports broken production geometry rows", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
+  try {
+    const fixturePath = path.join(tmp, "broken-catalog-fixture.json");
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+        "utf8",
+      ),
+    );
+    const pack = fixture.packs[0];
+    const removedPosition = pack.routeMapPositions.shift();
+    pack.routeMapPositions.push({
+      ...removedPosition,
+      stationId: "station-ghost",
+    });
+    const sadangLine2 = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-sadang" && row.lineId === "seoul-2",
+    );
+    const gangnamLine2 = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-gangnam" && row.lineId === "seoul-2",
+    );
+    gangnamLine2.x = sadangLine2.x;
+    gangnamLine2.y = sadangLine2.y;
+    const jeongja = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-jeongja",
+    );
+    jeongja.sourceId = "";
+    jeongja.sourceUrl = "";
+    delete jeongja.reviewedAt;
+    await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
+
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          "tools/route-map/audit-route-map.mjs",
+          "--fixture",
+          fixturePath,
+          "--fail-on",
+          "BLOCKER,HIGH",
+        ],
+        { cwd: root, maxBuffer: 1024 * 1024 },
+      ),
+      (error) => {
+        const output = JSON.parse(error.stdout);
+        assert.equal(output.summary.findingsBySeverity.BLOCKER, 2);
+        assert.equal(output.summary.findingsBySeverity.HIGH, 3);
+        assert.deepEqual(
+          output.findings.map((finding) => finding.code).sort(),
+          [
+            "DUPLICATE_SOURCE_COORDINATE",
+            "MISSING_ROUTE_MAP_POSITION",
+            "MISSING_ROUTE_MAP_REVIEW",
+            "MISSING_ROUTE_MAP_SOURCE",
+            "ROUTE_MAP_POSITION_WITHOUT_STATION_LINE",
+          ],
+        );
+        return true;
+      },
+    );
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
 });

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -74,6 +74,51 @@ test("route map position audit passes clean catalog fixture", async () => {
   assert.equal(output.packs[0].summary.coverageRatio, 1);
 });
 
+test("route map position audit allows same station-line in another region", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
+  try {
+    const fixturePath = path.join(tmp, "multi-region-catalog-fixture.json");
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+        "utf8",
+      ),
+    );
+    const pack = fixture.packs[0];
+    const sangnoksu = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-sangnoksu",
+    );
+    pack.routeMapPositions.push({
+      ...sangnoksu,
+      region: "전국",
+      x: sangnoksu.x + 1000,
+      y: sangnoksu.y + 1000,
+    });
+    await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "tools/route-map/audit-route-map.mjs",
+        "--fixture",
+        fixturePath,
+        "--fail-on",
+        "BLOCKER,HIGH",
+      ],
+      { cwd: root, maxBuffer: 1024 * 1024 },
+    );
+    const output = JSON.parse(stdout);
+
+    assert.equal(output.summary.findingsBySeverity.BLOCKER, 0);
+    assert.equal(output.summary.findingsBySeverity.HIGH, 0);
+    assert.equal(output.packs[0].summary.stationLineCount, 9);
+    assert.equal(output.packs[0].summary.routeMapPositionCount, 10);
+    assert.equal(output.packs[0].summary.coverageRatio, 1);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("route map position audit reports broken production geometry rows", async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
   try {


### PR DESCRIPTION
## 관련 이슈

close #889

## 작업 배경

- #836 Data DoD의 production route map 좌표 감사 기준을 반복 가능한 CLI로 고정한다.
- SVG label polygon과 datapack 저장 계약은 준비됐지만, `routeMapPositions` coverage와 좌표 중복/출처 누락을 PR마다 같은 기준으로 확인하는 도구가 없었다.

## 작업 내용

- `tools/route-map/audit-route-map.mjs`를 추가해 catalog fixture의 `stationLines`와 `routeMapPositions`를 비교한다.
- 감사 항목은 누락 좌표, station-line에 없는 좌표, 같은 region/line/source coordinate 중복, source/review 누락이다.
- clean fixture는 BLOCKER/HIGH 0건으로 통과하고, broken fixture는 BLOCKER/HIGH를 실제로 검출하는 route-map tool test를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/route-map/*.test.mjs`: exit 0, 4 tests passed
  - `node tools/route-map/audit-route-map.mjs --fixture tools/datapack/fixtures/catalog-fixture.json --fail-on BLOCKER,HIGH --pretty`: exit 0, packCount 1, stationLineCount 9, routeMapPositionCount 9, coverageRatio 1, BLOCKER 0, HIGH 0
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 104 tests passed
  - `git diff --check`: exit 0
  - GitHub Actions `CI`: success, https://github.com/AquilaXk/easysubway/actions/runs/28208654922
  - GitHub Actions `Release Artifacts`: success, https://github.com/AquilaXk/easysubway/actions/runs/28208654799
  - CodeRabbit 상태 확인: rate limit 및 prepaid credits exhausted, https://github.com/AquilaXk/easysubway/pull/890#issuecomment-4805245049
  - Codex CLI fallback review: actionable 1건을 inline으로 게시 후 `bc43d303`에서 수정, 최신 re-review actionable 0, https://github.com/AquilaXk/easysubway/pull/890#pullrequestreview-4575911662
  - Merge 후 `main` CD: success, https://github.com/AquilaXk/easysubway/actions/runs/28208789994

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| route map 좌표 감사 CLI | macOS / Node.js | clean catalog fixture를 `--fail-on BLOCKER,HIGH`로 감사 | `node tools/route-map/audit-route-map.mjs --fixture tools/datapack/fixtures/catalog-fixture.json --fail-on BLOCKER,HIGH --pretty` 출력 | `capital` pack coverageRatio 1, BLOCKER 0, HIGH 0 |
| broken geometry 검출 | macOS / Node.js test | test에서 누락 좌표, orphan 좌표, 동일 좌표, source/review 누락 fixture를 임시 생성 | `node --test tools/route-map/*.test.mjs` 출력 | 4 tests passed, broken fixture에서 BLOCKER 2/HIGH 3 검출 |
| 다지역 routeMapPositions 회귀 | macOS / Node.js test | 같은 station-line에 다른 region 좌표를 추가한 fixture로 audit 실행 | `node --test tools/route-map/*.test.mjs` 출력 | 같은 station-line의 다른 region 좌표는 BLOCKER/HIGH 없이 통과 |
| repository contract | macOS / Node.js test | repository contract 회귀 확인 | `node --test tools/ci/repository-contract.test.mjs` 출력 | 104 tests passed |
| PR CI | GitHub Actions | PR head `bc43d3038fa0f4bbd3b6c22b43f5819494f09fee` checks 확인 | https://github.com/AquilaXk/easysubway/actions/runs/28208654922, https://github.com/AquilaXk/easysubway/actions/runs/28208654799 | CI success, Release Artifacts success. Android/Backend release artifact는 관련 변경 없음으로 skipped |
| 코드 리뷰 | GitHub PR | CodeRabbit 상태 확인 후 Codex CLI fallback review/re-review 확인 | https://github.com/AquilaXk/easysubway/pull/890#issuecomment-4805245049, https://github.com/AquilaXk/easysubway/pull/890#pullrequestreview-4575900960, https://github.com/AquilaXk/easysubway/pull/890#pullrequestreview-4575911662 | CodeRabbit은 rate limit/credits exhausted. Codex fallback actionable 1건 수정/답글/resolve 후 최신 re-review actionable 0 |
| Merge 후 CD | GitHub Actions main | merge commit `3f3155858c87c1eb0b88da7ef60e3cfcfba027c9` run 상태 확인 | https://github.com/AquilaXk/easysubway/actions/runs/28208789994 | CD success. 같은 commit의 CI/Release Artifacts run은 생성되어 진행 중/queued이며 실패 신호 없음 |
| Android 실기기 화면 | Android | 앱 런타임 화면 변경 없음 | 증거 불필요 사유: 이번 PR은 `tools/route-map` Node CLI와 test만 변경하며 Flutter/Android/iOS 런타임 코드를 변경하지 않는다. #836의 최신 Android 실기기 노선도 smoke는 #887/#888에서 확인했다. | 화면/접근성 동작 영향 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `audit-route-map.mjs`의 BLOCKER/HIGH 기준이 후속 production 지역 감사에서 바로 재사용 가능한지 확인하면 된다.

## 리스크

- 이번 PR은 JSON fixture 감사 기반만 추가한다. 실제 수도권·부산·광주·대구·대전 전체 production 감사와 manual override provenance는 후속 하위 이슈에서 실행해야 한다.
- label polygon coverage 100%는 아직 BLOCKER로 걸지 않는다. 현재 datapack의 단계적 보정 상태와 충돌하지 않도록 좌표 coverage/source/review 기준부터 고정했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
