### PR TITLE
[Test] 노선도 reviewed ambiguity 감사 계약 추가

### DIFF
--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -12,7 +12,7 @@ const severityRank = new Map([
 ]);
 
 function usage() {
-  return `Usage: node tools/route-map/audit-route-map.mjs --fixture <catalog-fixture.json> [--fail-on BLOCKER,HIGH] [--pretty]
+  return `Usage: node tools/route-map/audit-route-map.mjs --fixture <catalog-fixture.json> [--reviewed-ambiguities reviewed.json] [--fail-on BLOCKER,HIGH] [--pretty]
 
 Audits routeMapPositions against stationLines so production route-map coordinate
 coverage can be checked before rebuilding datapacks.`;
@@ -21,6 +21,7 @@ coverage can be checked before rebuilding datapacks.`;
 function parseArgs(argv) {
   const options = {
     fixture: null,
+    reviewedAmbiguities: null,
     failOn: [],
     pretty: false,
   };
@@ -29,6 +30,9 @@ function parseArgs(argv) {
     switch (arg) {
       case "--fixture":
         options.fixture = argv[++index];
+        break;
+      case "--reviewed-ambiguities":
+        options.reviewedAmbiguities = argv[++index];
         break;
       case "--fail-on":
         options.failOn = (argv[++index] ?? "")
@@ -66,6 +70,16 @@ function routeMapPositionKeyFor(row) {
   return `${row.stationId ?? ""}\u0000${row.lineId ?? ""}\u0000${row.region ?? ""}`;
 }
 
+function duplicateCoordinateKeyFor({ region, lineId, x, y, stationIds }) {
+  return [
+    normalizedText(region),
+    normalizedText(lineId),
+    Number(x),
+    Number(y),
+    ...stationIds.map(normalizedText).sort(),
+  ].join("\u0000");
+}
+
 function normalizedText(value) {
   return typeof value === "string" ? value.trim() : "";
 }
@@ -82,7 +96,62 @@ function addFinding(findings, finding) {
   });
 }
 
-function auditPack(pack) {
+function reviewedAmbiguityEntries(raw) {
+  if (Array.isArray(raw)) {
+    return raw;
+  }
+  if (Array.isArray(raw?.reviewedAmbiguities)) {
+    return raw.reviewedAmbiguities;
+  }
+  throw new Error(
+    "reviewed ambiguities must be an array or contain reviewedAmbiguities array",
+  );
+}
+
+function parseReviewedAmbiguities(raw) {
+  const reviewed = new Map();
+  for (const [index, entry] of reviewedAmbiguityEntries(raw).entries()) {
+    const region = normalizedText(entry?.region);
+    const lineId = normalizedText(entry?.lineId);
+    const reason = normalizedText(entry?.reason);
+    const reviewedAt = normalizedText(entry?.reviewedAt);
+    const stationIds = Array.isArray(entry?.stationIds)
+      ? entry.stationIds.map(normalizedText).filter(Boolean)
+      : [];
+    const x = Number(entry?.x);
+    const y = Number(entry?.y);
+    if (!region || !lineId || !Number.isFinite(x) || !Number.isFinite(y)) {
+      throw new Error(
+        `reviewedAmbiguities[${index}] must include region, lineId, x, and y`,
+      );
+    }
+    if (stationIds.length < 2) {
+      throw new Error(
+        `reviewedAmbiguities[${index}].stationIds must include at least two station ids`,
+      );
+    }
+    if (!reason || !reviewedAt) {
+      throw new Error(
+        `reviewedAmbiguities[${index}] must include reason and reviewedAt`,
+      );
+    }
+    reviewed.set(
+      duplicateCoordinateKeyFor({ region, lineId, x, y, stationIds }),
+      {
+        region,
+        lineId,
+        x,
+        y,
+        stationIds: stationIds.sort(),
+        reason,
+        reviewedAt,
+      },
+    );
+  }
+  return reviewed;
+}
+
+function auditPack(pack, reviewedAmbiguities) {
   const findings = [];
   const stationLines = Array.isArray(pack.stationLines) ? pack.stationLines : [];
   const positions = Array.isArray(pack.routeMapPositions)
@@ -188,13 +257,34 @@ function auditPack(pack) {
       continue;
     }
     const first = group[0];
+    const stationIds = [...uniqueStationIds].sort();
+    const ambiguityKey = duplicateCoordinateKeyFor({
+      region: first.region,
+      lineId: first.lineId,
+      x: first.x,
+      y: first.y,
+      stationIds,
+    });
+    const reviewed = reviewedAmbiguities.get(ambiguityKey);
+    if (reviewed != null) {
+      addFinding(findings, {
+        severity: "INFO",
+        code: "REVIEWED_AMBIGUITY",
+        packId: pack.id,
+        region: first.region,
+        lineId: first.lineId,
+        stationId: stationIds.join(","),
+        message: `Reviewed duplicate source coordinate: ${reviewed.reason} (${reviewed.reviewedAt}).`,
+      });
+      continue;
+    }
     addFinding(findings, {
       severity: "HIGH",
       code: "DUPLICATE_SOURCE_COORDINATE",
       packId: pack.id,
       region: first.region,
       lineId: first.lineId,
-      stationId: group.map((row) => row.stationId).join(","),
+      stationId: stationIds.join(","),
       message:
         "Multiple stations share the same region/line/source coordinate and need explicit review.",
     });
@@ -242,9 +332,11 @@ function auditPack(pack) {
   };
 }
 
-function auditFixture(fixturePath, fixture) {
+function auditFixture(fixturePath, fixture, reviewedAmbiguities) {
   const packs = Array.isArray(fixture.packs) ? fixture.packs : [];
-  const auditedPacks = packs.map(auditPack);
+  const auditedPacks = packs.map((pack) =>
+    auditPack(pack, reviewedAmbiguities),
+  );
   const findings = auditedPacks.flatMap((pack) => pack.findings);
   const findingCounts = {};
   for (const severity of severityRank.keys()) {
@@ -270,7 +362,12 @@ async function main() {
   const options = parseArgs(process.argv.slice(2));
   const fixtureText = await readFile(options.fixture, "utf8");
   const fixture = JSON.parse(fixtureText);
-  const report = auditFixture(options.fixture, fixture);
+  const reviewedAmbiguities = options.reviewedAmbiguities
+    ? parseReviewedAmbiguities(
+        JSON.parse(await readFile(options.reviewedAmbiguities, "utf8")),
+      )
+    : new Map();
+  const report = auditFixture(options.fixture, fixture, reviewedAmbiguities);
   console.log(JSON.stringify(report, null, options.pretty ? 2 : 0));
 
   const failed = options.failOn.some(

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -119,6 +119,89 @@ test("route map position audit allows same station-line in another region", asyn
   }
 });
 
+test("route map position audit downgrades reviewed duplicate coordinates", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
+  try {
+    const fixturePath = path.join(tmp, "duplicate-coordinate-fixture.json");
+    const reviewedPath = path.join(tmp, "reviewed-ambiguities.json");
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+        "utf8",
+      ),
+    );
+    const pack = fixture.packs[0];
+    const sadangLine2 = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-sadang" && row.lineId === "seoul-2",
+    );
+    const gangnamLine2 = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-gangnam" && row.lineId === "seoul-2",
+    );
+    gangnamLine2.x = sadangLine2.x;
+    gangnamLine2.y = sadangLine2.y;
+    await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
+
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          "tools/route-map/audit-route-map.mjs",
+          "--fixture",
+          fixturePath,
+          "--fail-on",
+          "BLOCKER,HIGH",
+        ],
+        { cwd: root, maxBuffer: 1024 * 1024 },
+      ),
+      (error) => {
+        const output = JSON.parse(error.stdout);
+        assert.equal(output.summary.findingsBySeverity.HIGH, 1);
+        assert.equal(output.findings[0].code, "DUPLICATE_SOURCE_COORDINATE");
+        return true;
+      },
+    );
+
+    await writeFile(
+      reviewedPath,
+      JSON.stringify({
+        reviewedAmbiguities: [
+          {
+            region: "수도권",
+            lineId: "seoul-2",
+            x: sadangLine2.x,
+            y: sadangLine2.y,
+            stationIds: ["station-gangnam", "station-sadang"],
+            reason: "fixture 검수에서 같은 source 좌표가 의도된 경우로 확인",
+            reviewedAt: "2026-06-26T00:00:00.000Z",
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "tools/route-map/audit-route-map.mjs",
+        "--fixture",
+        fixturePath,
+        "--reviewed-ambiguities",
+        reviewedPath,
+        "--fail-on",
+        "BLOCKER,HIGH",
+      ],
+      { cwd: root, maxBuffer: 1024 * 1024 },
+    );
+    const output = JSON.parse(stdout);
+
+    assert.equal(output.summary.findingsBySeverity.HIGH, 0);
+    assert.equal(output.summary.findingsBySeverity.INFO, 1);
+    assert.equal(output.findings[0].code, "REVIEWED_AMBIGUITY");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("route map position audit reports broken production geometry rows", async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
   try {


### PR DESCRIPTION
## 관련 이슈

close #891

## 작업 배경

- #836 Data DoD의 `reviewed ambiguity only` 기준을 route map 좌표 감사 CLI에 추가한다.
- #889 감사 CLI로 generated production fixture를 확인하면 coverageRatio 1, BLOCKER 0이지만 동일 source coordinate HIGH 후보 2건이 남는다.
- 이 중복을 단순히 숨기지 않고 station ids, region, line, coordinate, reason, reviewedAt이 일치할 때만 `REVIEWED_AMBIGUITY`로 분리한다.

## 작업 내용

- `tools/route-map/audit-route-map.mjs`에 `--reviewed-ambiguities` 옵션을 추가했다.
- reviewed ambiguity 입력은 배열 또는 `{ reviewedAmbiguities: [...] }` 형태를 지원하며 `region`, `lineId`, `x`, `y`, `stationIds`, `reason`, `reviewedAt`을 검증한다.
- 일치하는 duplicate source coordinate는 HIGH가 아니라 INFO `REVIEWED_AMBIGUITY`로 보고한다.
- unreviewed duplicate는 기존처럼 HIGH `DUPLICATE_SOURCE_COORDINATE`로 남는 test를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/route-map/*.test.mjs`: exit 0, 5 tests passed
  - `node tools/datapack/build-molit-nationwide-fixture.mjs ... --output .codex/evidence/891/generated-production-fixture.json`: exit 0
  - `node tools/route-map/audit-route-map.mjs --fixture .codex/evidence/891/generated-production-fixture.json --reviewed-ambiguities .codex/evidence/891/reviewed-ambiguities.json --fail-on BLOCKER,HIGH --pretty`: exit 0, stationLineCount 1103, routeMapPositionCount 1103, coverageRatio 1, BLOCKER 0, HIGH 0, INFO 2
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 104 tests passed
  - `git diff --check`: exit 0
  - GitHub Actions CI: pass, https://github.com/AquilaXk/easysubway/actions/runs/28208975798
  - GitHub Actions Release Artifacts: pass, https://github.com/AquilaXk/easysubway/actions/runs/28208975783

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| reviewed ambiguity 계약 | macOS / Node.js test | unreviewed duplicate와 reviewed duplicate fixture를 각각 audit | `node --test tools/route-map/*.test.mjs` 출력 | 5 tests passed. unreviewed duplicate는 HIGH, reviewed duplicate는 INFO |
| generated production audit | macOS / Node.js CLI | nationwide fixture 생성 후 로컬 reviewed ambiguity 2건 적용 | 로컬 전용 `.codex/evidence/891/generated-production-fixture.json`, `.codex/evidence/891/reviewed-ambiguities.json` 및 audit 출력 | coverageRatio 1, BLOCKER 0, HIGH 0, INFO 2 |
| repository contract | macOS / Node.js test | repository contract 회귀 확인 | `node --test tools/ci/repository-contract.test.mjs` 출력 | 104 tests passed |
| PR CI | GitHub Actions | PR head `7b24fb613aa15d276560276eabed3f7819ae911e` 검사 | CI https://github.com/AquilaXk/easysubway/actions/runs/28208975798, Release Artifacts https://github.com/AquilaXk/easysubway/actions/runs/28208975783 | required checks pass, release artifact workflow pass |
| code review | GitHub PR review | CodeRabbit 상태 확인 후 Codex CLI fallback review 게시 | CodeRabbit rate limit/credit exhausted comment https://github.com/AquilaXk/easysubway/pull/892#issuecomment-4805320039, Codex fallback review https://github.com/AquilaXk/easysubway/pull/892#pullrequestreview-4575942452 | actionable 0, nitpick 0 |
| post-merge CD | GitHub Actions / main | merge commit `fef6c0f0cd36749b00d44ffa9ad60a1f8177f25d`의 CD 실패 여부 확인 | CD https://github.com/AquilaXk/easysubway/actions/runs/28209120861, Release Artifacts https://github.com/AquilaXk/easysubway/actions/runs/28209120816, CI https://github.com/AquilaXk/easysubway/actions/runs/28209120947 | CD success, Release Artifacts success, CI in progress with no failure signal at 확인 시점 |
| Android 실기기 화면 | Android | 앱 런타임 화면 변경 없음 | 증거 불필요 사유: 이번 PR은 `tools/route-map` Node CLI와 test만 변경하며 Flutter/Android/iOS 런타임 코드를 변경하지 않는다. #836의 최신 Android 실기기 노선도 smoke는 #887/#888에서 확인했다. | 화면/접근성 동작 영향 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `DUPLICATE_SOURCE_COORDINATE`가 reviewed ambiguity 파일과 정확히 일치할 때만 INFO로 내려가는지 확인하면 된다.

## 리스크

- reviewed ambiguity 파일 자체를 production datapack에 포함하는 작업은 후속이다. 이번 PR은 CLI 계약과 검증 경로만 추가한다.
- generated production fixture의 INFO 2건은 임시 local evidence이며, 후속 수동 보정 또는 추적 가능한 override 산출물로 승격해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
