### PR TITLE
[Fix] 노선도 renderer 화면 이탈 reclaim 보장

### DIFF
--- a/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
@@ -124,6 +124,19 @@ final class RouteMapRendererHealthMonitor {
     return _controller.dispose();
   }
 
+  Future<void> close({bool disposeRenderer = false}) async {
+    if (_closed) {
+      return;
+    }
+    try {
+      if (disposeRenderer) {
+        await _controller.dispose();
+      }
+    } finally {
+      await stop();
+    }
+  }
+
   Future<void> stop() async {
     _closed = true;
     _blankTimer?.cancel();

--- a/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
@@ -128,6 +128,7 @@ final class RouteMapRendererHealthMonitor {
     if (_closed) {
       return;
     }
+    _closed = true;
     try {
       if (disposeRenderer) {
         await _controller.dispose();

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -764,7 +764,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    unawaited(_rendererMonitor?.stop());
+    _releaseRenderer(disposeRenderer: true);
     super.dispose();
   }
 
@@ -774,10 +774,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
       case AppLifecycleState.inactive || AppLifecycleState.paused:
         _ignoreRendererLifecycleFailure(_rendererMonitor?.trimMemory());
       case AppLifecycleState.detached:
-        final monitor = _rendererMonitor;
-        _rendererMonitor = null;
-        _rendererController = null;
-        _ignoreRendererLifecycleFailure(monitor?.disposeRenderer());
+        _releaseRenderer(disposeRenderer: true);
       case AppLifecycleState.resumed || AppLifecycleState.hidden:
         break;
     }
@@ -793,6 +790,15 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
       return;
     }
     unawaited(future.catchError((Object _) {}));
+  }
+
+  void _releaseRenderer({required bool disposeRenderer}) {
+    final monitor = _rendererMonitor;
+    _rendererMonitor = null;
+    _rendererController = null;
+    _ignoreRendererLifecycleFailure(
+      monitor?.close(disposeRenderer: disposeRenderer),
+    );
   }
 
   @override
@@ -1032,7 +1038,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
     if (identical(_rendererController, controller)) {
       return;
     }
-    unawaited(_rendererMonitor?.stop());
+    _releaseRenderer(disposeRenderer: true);
     _rendererController = controller;
     late final RouteMapRendererHealthMonitor monitor;
     monitor = RouteMapRendererHealthMonitor(
@@ -1068,13 +1074,14 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
         debugPrint('routeMapRenderer processGone didCrash=$didCrash');
       case RouteMapRendererMemoryTrimmed():
         debugPrint('routeMapRenderer memoryTrimmed');
+      case RouteMapRendererDisposed():
+        debugPrint('routeMapRenderer disposed');
       case RouteMapRendererCreated() ||
           RouteMapRendererAssetLoading() ||
           RouteMapRendererAssetReady() ||
           RouteMapRendererCameraRequested() ||
           RouteMapRendererFramePresented() ||
-          RouteMapRendererFailed() ||
-          RouteMapRendererDisposed():
+          RouteMapRendererFailed():
         break;
     }
   }

--- a/apps/mobile/test/features/network_map/infrastructure/route_map_renderer_test.dart
+++ b/apps/mobile/test/features/network_map/infrastructure/route_map_renderer_test.dart
@@ -248,6 +248,25 @@ void main() {
     expect(controller.trimMemoryCalls, 0);
   });
 
+  test('health monitor close only disposes once when calls overlap', () async {
+    final controller = _FakeRouteMapRendererController()
+      ..disposeCompleter = Completer<void>();
+    final monitor = RouteMapRendererHealthMonitor(controller)..start();
+    addTearDown(monitor.stop);
+
+    final firstClose = monitor.close(disposeRenderer: true);
+    final secondClose = monitor.close(disposeRenderer: true);
+    await pumpEventQueue();
+
+    expect(controller.disposeCalls, 1);
+
+    controller.disposeCompleter!.complete();
+    await Future.wait(<Future<void>>[firstClose, secondClose]);
+    await monitor.disposeRenderer();
+
+    expect(controller.disposeCalls, 1);
+  });
+
   test('health monitor close stops after renderer dispose failure', () async {
     final controller = _FakeRouteMapRendererController()
       ..disposeError = StateError('dispose failed');
@@ -303,6 +322,7 @@ class _FakeRouteMapRendererController implements RouteMapRendererController {
   final _pendingCameraFrames = <int, Stopwatch>{};
   Object? retryError;
   Object? disposeError;
+  Completer<void>? disposeCompleter;
   int retryCalls = 0;
   int trimMemoryCalls = 0;
   int disposeCalls = 0;
@@ -350,6 +370,7 @@ class _FakeRouteMapRendererController implements RouteMapRendererController {
   @override
   Future<void> dispose() async {
     disposeCalls += 1;
+    await disposeCompleter?.future;
     final error = disposeError;
     if (error != null) {
       throw error;

--- a/apps/mobile/test/features/network_map/infrastructure/route_map_renderer_test.dart
+++ b/apps/mobile/test/features/network_map/infrastructure/route_map_renderer_test.dart
@@ -234,6 +234,37 @@ void main() {
     expect(controller.disposeCalls, 0);
   });
 
+  test('health monitor close disposes renderer and stops delegation', () async {
+    final controller = _FakeRouteMapRendererController();
+    final monitor = RouteMapRendererHealthMonitor(controller)..start();
+    addTearDown(monitor.stop);
+
+    await monitor.close(disposeRenderer: true);
+    await monitor.trimMemory();
+    await monitor.disposeRenderer();
+    await monitor.close(disposeRenderer: true);
+
+    expect(controller.disposeCalls, 1);
+    expect(controller.trimMemoryCalls, 0);
+  });
+
+  test('health monitor close stops after renderer dispose failure', () async {
+    final controller = _FakeRouteMapRendererController()
+      ..disposeError = StateError('dispose failed');
+    final monitor = RouteMapRendererHealthMonitor(controller)..start();
+    addTearDown(monitor.stop);
+
+    await expectLater(
+      monitor.close(disposeRenderer: true),
+      throwsA(isA<StateError>()),
+    );
+    await monitor.trimMemory();
+    await monitor.disposeRenderer();
+
+    expect(controller.disposeCalls, 1);
+    expect(controller.trimMemoryCalls, 0);
+  });
+
   test('fake controller mirrors camera request and latency events', () async {
     final controller = _FakeRouteMapRendererController();
     final observed = <RouteMapRendererEvent>[];
@@ -271,6 +302,7 @@ class _FakeRouteMapRendererController implements RouteMapRendererController {
   final _events = StreamController<RouteMapRendererEvent>.broadcast();
   final _pendingCameraFrames = <int, Stopwatch>{};
   Object? retryError;
+  Object? disposeError;
   int retryCalls = 0;
   int trimMemoryCalls = 0;
   int disposeCalls = 0;
@@ -318,6 +350,10 @@ class _FakeRouteMapRendererController implements RouteMapRendererController {
   @override
   Future<void> dispose() async {
     disposeCalls += 1;
+    final error = disposeError;
+    if (error != null) {
+      throw error;
+    }
     await _events.close();
   }
 }


### PR DESCRIPTION
## 관련 이슈

close #895

## 작업 배경

- #836 Offscreen DoD의 `map 이탈 후 reclaim` 기준을 앱 renderer lifecycle에서 보장해야 한다.
- 기존 `_NetworkMapCanvasState.dispose()`는 renderer monitor subscription만 stop하고 platform renderer dispose channel은 호출하지 않아, 화면 이탈 시 WebView reclaim을 앱 코드 계약으로 확인하기 어려웠다.

## 작업 내용

- `RouteMapRendererHealthMonitor.close(disposeRenderer:)`를 추가해 renderer dispose와 monitor stop을 하나의 idempotent close 계약으로 묶었다.
- 노선도 화면 dispose, detached lifecycle, renderer controller 교체 시 기존 renderer를 명시적으로 dispose하도록 `_releaseRenderer` 경로를 통일했다.
- debug/profile 로그에 `routeMapRenderer disposed`를 추가해 실기기 이탈 reclaim 확인이 가능하게 했다.
- monitor unit test로 close 후 trim/dispose 중복 전달 방지, 동시 close 중복 dispose 방지, dispose 실패 시 stop 보장을 고정했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/features/network_map/infrastructure/route_map_renderer_test.dart`: exit 0, 14 tests passed
  - `flutter test test/widget_test.dart --plain-name "노선도"`: exit 0, 16 tests passed
  - `flutter analyze`: exit 0, No issues found
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 104 tests passed
  - `git diff --check`: exit 0
  - `flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - PR CI: pass, https://github.com/AquilaXk/easysubway/actions/runs/28210375623
  - PR Release Artifacts: pass, https://github.com/AquilaXk/easysubway/actions/runs/28210375468
  - CodeRabbit review: actionable 1건 확인 후 `bf09a48`에서 수정, 원래 inline thread에 수정 답글 작성 및 resolved 확인
  - Codex CLI fallback review: CodeRabbit follow-up re-review rate limit으로 실행, actionable 0건, https://github.com/AquilaXk/easysubway/pull/896#pullrequestreview-4576088493
  - post-merge CD: success, https://github.com/AquilaXk/easysubway/actions/runs/28210608576

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| renderer close 계약 | local Flutter test | monitor close/dispose 실패와 동시 close 회귀 테스트 | `flutter test test/features/network_map/infrastructure/route_map_renderer_test.dart` | 14 tests passed |
| 노선도 화면 회귀 | local Flutter widget test | 노선도 관련 widget test subset | `flutter test test/widget_test.dart --plain-name "노선도"` | 16 tests passed |
| 정적 분석 | local Flutter analyzer | analyzer 실행 | `flutter analyze` | No issues found |
| 저장소 계약 | local Node test | repository contract test | `node --test tools/ci/repository-contract.test.mjs` | 104 tests passed |
| Android 실기기 진입/이탈 | SM-A175N / Android 16 / RFKYA01VMQY | debug APK 설치 후 하단 `노선도` 탭 진입, `홈` 탭 이탈, logcat 확인 | `06-26 09:52:35.358 I/flutter (24060): routeMapRenderer disposed` | 화면 이탈 시 renderer dispose 이벤트 확인 |
| Android 화면 증거 | SM-A175N / Android 16 / RFKYA01VMQY | 노선도 화면 screenshot/UI tree/logcat 로컬 보관 | `.codex/evidence/895/android-route-map.png`, `.codex/evidence/895/android-route-map.xml`, `.codex/evidence/895/android-logcat.txt` | 상태바와 QA 실기기 정보가 포함되어 외부 업로드 승인 없이 로컬 전용 보관 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `NetworkMap`의 `_releaseRenderer`가 dispose, detached, controller 교체 모두에서 기존 renderer 참조를 먼저 끊고 monitor close를 호출하는 흐름과 `RouteMapRendererHealthMonitor.close()`가 첫 await 전에 `_closed`를 세워 중복 dispose를 막는 부분.

## 리스크

- 화면 이탈/교체 시 dispose channel 호출이 빨라져 renderer 재사용을 기대하는 코드가 있었다면 영향이 있을 수 있으나, 기존 Android/iOS controller dispose는 idempotent이고 duplicate dispose 테스트가 이미 있다.
- iOS 실기기는 이번 PR에서 실행하지 못했다. Dart lifecycle 계약과 iOS controller unit test의 기존 dispose channel 계약으로 대체 검증했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
