### PR TITLE
[Perf] 노선도 Android profile 성능 증거 수집

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5741,6 +5741,73 @@ test("노선도 Android 실기기 evidence runner는 frame, memory, renderer rec
   assert.match(script, /summary\.md/);
 });
 
+test("노선도 Android evidence analyzer는 profile frame, memory, camera latency를 요약한다", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-evidence-"));
+  const artifactDir = path.join(dir, "run-1");
+  await mkdir(artifactDir, { recursive: true });
+  await writeFile(
+    path.join(artifactDir, "metadata.env"),
+    [
+      "serial=RFKYA01VMQY",
+      "package=com.easysubway.app",
+      "width=1080",
+      "height=2340",
+      "build_mode=profile",
+      "pan_count=3",
+      "captured_at_utc=2026-06-26T01:00:00Z",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(artifactDir, "gfxinfo.txt"),
+    [
+      "Total frames rendered: 56",
+      "Janky frames: 3 (5.36%)",
+      "50th percentile: 10ms",
+      "90th percentile: 18ms",
+      "95th percentile: 25ms",
+      "99th percentile: 33ms",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(artifactDir, "meminfo.txt"),
+    [
+      "Java Heap:    15256",
+      "Native Heap:    92580",
+      "Graphics:   183577",
+      "TOTAL PSS:   591090            TOTAL RSS:   723053       TOTAL SWAP PSS:      272",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(artifactDir, "route-map-renderer.log"),
+    [
+      "06-26 10:25:37.509 I/flutter: routeMapRenderer cameraLatency revision=0 elapsedMs=12",
+      "06-26 10:25:42.432 I/flutter: routeMapRenderer cameraLatency revision=1 elapsedMs=48",
+      "06-26 10:25:46.185 I/flutter: routeMapRenderer disposed",
+    ].join("\n"),
+  );
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "tools/mobile/analyze-route-map-android-evidence.mjs",
+      "--artifact-dir",
+      artifactDir,
+      "--format",
+      "json",
+    ],
+    { cwd: root },
+  );
+  const output = JSON.parse(stdout);
+
+  assert.equal(output.artifactKind, "route-map-android-evidence-summary");
+  assert.equal(output.runs[0].buildMode, "profile");
+  assert.equal(output.runs[0].gfxinfo.jankyPercent, 5.36);
+  assert.equal(output.runs[0].gfxinfo.p99Ms, 33);
+  assert.equal(output.runs[0].meminfo.totalPssKb, 591090);
+  assert.equal(output.runs[0].renderer.cameraLatencyP95Ms, 48);
+  assert.equal(output.aggregate.disposeObservedInAllRuns, true);
+});
+
 async function classifyChangedFiles(files) {
   const dir = await mkdtemp(path.join(tmpdir(), "easysubway-ci-"));
   const changedFilesPath = path.join(dir, "changed-files.txt");

--- a/tools/mobile/analyze-route-map-android-evidence.mjs
+++ b/tools/mobile/analyze-route-map-android-evidence.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+function usage() {
+  return `Usage:
+  node tools/mobile/analyze-route-map-android-evidence.mjs --artifact-dir <dir> [--artifact-dir <dir> ...] [--format json|markdown]
+
+Options:
+  --artifact-dir <dir>  Evidence directory created by run-route-map-android-evidence.sh.
+  --format <format>     Output format. Defaults to markdown.
+  -h, --help            Show this help.
+`;
+}
+
+function parseArgs(argv) {
+  const artifactDirs = [];
+  let format = "markdown";
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--artifact-dir":
+        artifactDirs.push(argv[index + 1] ?? "");
+        index += 1;
+        break;
+      case "--format":
+        format = argv[index + 1] ?? "";
+        index += 1;
+        break;
+      case "-h":
+      case "--help":
+        return { help: true, artifactDirs, format };
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (artifactDirs.length === 0 || artifactDirs.some((dir) => dir.length === 0)) {
+    throw new Error("At least one --artifact-dir value is required.");
+  }
+  if (!["json", "markdown"].includes(format)) {
+    throw new Error(`Unsupported format: ${format}`);
+  }
+  return { help: false, artifactDirs, format };
+}
+
+function readRequired(filePath) {
+  const stat = statSync(filePath);
+  if (!stat.isFile() || stat.size === 0) {
+    throw new Error(`Expected non-empty file: ${filePath}`);
+  }
+  return readFileSync(filePath, "utf8");
+}
+
+function parseMetadata(text) {
+  return Object.fromEntries(
+    text
+      .split(/\r?\n/)
+      .filter((line) => line.includes("="))
+      .map((line) => {
+        const separator = line.indexOf("=");
+        return [line.slice(0, separator), line.slice(separator + 1)];
+      }),
+  );
+}
+
+function parseNumber(value) {
+  return Number.parseInt(value.replace(/,/g, ""), 10);
+}
+
+function parseGfxinfo(text) {
+  const total = text.match(/Total frames rendered:\s*([\d,]+)/);
+  const janky = text.match(/Janky frames:\s*([\d,]+)\s*\(([\d.]+)%\)/);
+  const percentiles = {};
+  for (const match of text.matchAll(/(50th|90th|95th|99th) percentile:\s*([\d,]+)ms/g)) {
+    percentiles[match[1]] = parseNumber(match[2]);
+  }
+  return {
+    totalFrames: total ? parseNumber(total[1]) : null,
+    jankyFrames: janky ? parseNumber(janky[1]) : null,
+    jankyPercent: janky ? Number.parseFloat(janky[2]) : null,
+    p50Ms: percentiles["50th"] ?? null,
+    p90Ms: percentiles["90th"] ?? null,
+    p95Ms: percentiles["95th"] ?? null,
+    p99Ms: percentiles["99th"] ?? null,
+  };
+}
+
+function parseMeminfo(text) {
+  const total = text.match(/TOTAL PSS:\s*([\d,]+)\s+TOTAL RSS:\s*([\d,]+)/);
+  const javaHeap = text.match(/Java Heap:\s*([\d,]+)/);
+  const nativeHeap = text.match(/Native Heap:\s*([\d,]+)/);
+  const graphics = text.match(/Graphics:\s*([\d,]+)/);
+  return {
+    totalPssKb: total ? parseNumber(total[1]) : null,
+    totalRssKb: total ? parseNumber(total[2]) : null,
+    javaHeapKb: javaHeap ? parseNumber(javaHeap[1]) : null,
+    nativeHeapKb: nativeHeap ? parseNumber(nativeHeap[1]) : null,
+    graphicsKb: graphics ? parseNumber(graphics[1]) : null,
+  };
+}
+
+function percentile(values, percentileValue) {
+  if (values.length === 0) {
+    return null;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.ceil((percentileValue / 100) * sorted.length) - 1,
+  );
+  return sorted[index];
+}
+
+function parseRendererLog(text) {
+  const latencies = [...text.matchAll(/cameraLatency revision=\d+ elapsedMs=(\d+)/g)].map((match) =>
+    parseNumber(match[1]),
+  );
+  return {
+    cameraLatencyCount: latencies.length,
+    cameraLatencyMinMs: latencies.length > 0 ? Math.min(...latencies) : null,
+    cameraLatencyP50Ms: percentile(latencies, 50),
+    cameraLatencyP95Ms: percentile(latencies, 95),
+    cameraLatencyP99Ms: percentile(latencies, 99),
+    cameraLatencyMaxMs: latencies.length > 0 ? Math.max(...latencies) : null,
+    disposedObserved: /routeMapRenderer disposed/.test(text),
+  };
+}
+
+function analyzeRun(artifactDir) {
+  const dir = path.resolve(artifactDir);
+  const metadata = parseMetadata(readRequired(path.join(dir, "metadata.env")));
+  const gfxinfo = parseGfxinfo(readRequired(path.join(dir, "gfxinfo.txt")));
+  const meminfo = parseMeminfo(readRequired(path.join(dir, "meminfo.txt")));
+  const renderer = parseRendererLog(readRequired(path.join(dir, "route-map-renderer.log")));
+  return {
+    artifactDir: dir,
+    serial: metadata.serial ?? "",
+    package: metadata.package ?? "",
+    buildMode: metadata.build_mode ?? "",
+    viewport: `${metadata.width ?? ""}x${metadata.height ?? ""}`,
+    capturedAtUtc: metadata.captured_at_utc ?? "",
+    panCount: Number.parseInt(metadata.pan_count ?? "0", 10),
+    gfxinfo,
+    meminfo,
+    renderer,
+  };
+}
+
+function aggregate(runs) {
+  return {
+    runCount: runs.length,
+    maxJankyPercent: Math.max(...runs.map((run) => run.gfxinfo.jankyPercent ?? 0)),
+    maxP99FrameMs: Math.max(...runs.map((run) => run.gfxinfo.p99Ms ?? 0)),
+    maxCameraLatencyP95Ms: Math.max(...runs.map((run) => run.renderer.cameraLatencyP95Ms ?? 0)),
+    maxTotalPssKb: Math.max(...runs.map((run) => run.meminfo.totalPssKb ?? 0)),
+    disposeObservedInAllRuns: runs.every((run) => run.renderer.disposedObserved),
+  };
+}
+
+function markdownReport(result) {
+  const lines = [
+    "# Android route map profile evidence summary",
+    "",
+    `- runs: ${result.aggregate.runCount}`,
+    `- max_janky_percent: ${result.aggregate.maxJankyPercent}`,
+    `- max_p99_frame_ms: ${result.aggregate.maxP99FrameMs}`,
+    `- max_camera_latency_p95_ms: ${result.aggregate.maxCameraLatencyP95Ms}`,
+    `- max_total_pss_kb: ${result.aggregate.maxTotalPssKb}`,
+    `- dispose_observed_in_all_runs: ${result.aggregate.disposeObservedInAllRuns}`,
+    "",
+    "| run | build | viewport | frames | janky | p95 frame | p99 frame | camera p95 | total PSS | dispose | evidence |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+  ];
+  for (const [index, run] of result.runs.entries()) {
+    const cells = [
+      index + 1,
+      run.buildMode,
+      run.viewport,
+      run.gfxinfo.totalFrames ?? "",
+      run.gfxinfo.jankyPercent == null
+        ? ""
+        : `${run.gfxinfo.jankyFrames} (${run.gfxinfo.jankyPercent}%)`,
+      run.gfxinfo.p95Ms == null ? "" : `${run.gfxinfo.p95Ms}ms`,
+      run.gfxinfo.p99Ms == null ? "" : `${run.gfxinfo.p99Ms}ms`,
+      run.renderer.cameraLatencyP95Ms == null ? "" : `${run.renderer.cameraLatencyP95Ms}ms`,
+      run.meminfo.totalPssKb ?? "",
+      run.renderer.disposedObserved,
+      run.artifactDir,
+    ];
+    lines.push(`| ${cells.join(" | ")} |`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function main() {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+      process.stdout.write(usage());
+      return;
+    }
+    const runs = args.artifactDirs.map(analyzeRun);
+    const result = {
+      schemaVersion: 1,
+      artifactKind: "route-map-android-evidence-summary",
+      runs,
+      aggregate: aggregate(runs),
+    };
+    process.stdout.write(
+      args.format === "json"
+        ? `${JSON.stringify(result, null, 2)}\n`
+        : markdownReport(result),
+    );
+  } catch (error) {
+    process.stderr.write(`${error.message}\n\n${usage()}`);
+    process.exitCode = 2;
+  }
+}
+
+main();


### PR DESCRIPTION
## 관련 이슈

close #899

## 작업 배경

- #897에서 Android 실기기 evidence runner를 추가했지만, profile build 반복 측정 결과를 기계적으로 요약하는 도구는 없었다.
- #836 Performance DoD의 frame/memory/camera latency 판단에는 raw log뿐 아니라 run 간 aggregate가 필요하다.
- QA 요청에 따라 emulator가 아닌 SM-A175N 실기기 profile APK로 수집했다.

## 작업 내용

- `tools/mobile/analyze-route-map-android-evidence.mjs`를 추가해 runner 산출물 폴더 여러 개를 JSON 또는 Markdown summary로 변환한다.
- analyzer는 `metadata.env`, `gfxinfo.txt`, `meminfo.txt`, `route-map-renderer.log`를 읽어 frame, jank, memory, camera latency, dispose 관찰 여부를 요약한다.
- repository contract test에 임시 evidence fixture 기반 analyzer 실행 검증을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node tools/mobile/analyze-route-map-android-evidence.mjs --help`: exit 0
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 106 tests passed
  - `git diff --check`: exit 0
  - `tools/ci/detect-changed-paths.sh /tmp/easysubway-899-changed-files.txt`: `repository=true`, `mobile=true`, `android=true`, `ios=true`, `ci=true`, `deploy=false`
  - `flutter build apk --profile`: exit 0, `build/app/outputs/flutter-apk/app-profile.apk`
  - `adb -s RFKYA01VMQY install -r apps/mobile/build/app/outputs/flutter-apk/app-profile.apk`: exit 0
  - Android profile runner 3회: 모두 exit 0
  - analyzer Markdown/JSON summary 생성: exit 0
  - GitHub Actions CI: success, https://github.com/AquilaXk/easysubway/actions/runs/28211858115
  - GitHub Actions Release Artifacts: success, https://github.com/AquilaXk/easysubway/actions/runs/28211857911
  - CodeRabbit: review limit reached comment 확인, https://github.com/AquilaXk/easysubway/pull/908#issuecomment-4805697424
  - Codex CLI fallback review: actionable 0, https://github.com/AquilaXk/easysubway/pull/908#pullrequestreview-4576216726
  - post-merge CD: success, https://github.com/AquilaXk/easysubway/actions/runs/28212100939

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| analyzer 계약 | local Node | help와 repository contract 실행 | `node tools/mobile/analyze-route-map-android-evidence.mjs --help`, `node --test tools/ci/repository-contract.test.mjs` | exit 0, 106 tests passed |
| Android profile build | local Flutter/Gradle | profile APK 빌드 | `flutter build apk --profile` | exit 0, APK 85.2MB 생성 |
| Android profile 설치 | SM-A175N / Android 16 / RFKYA01VMQY | profile APK 설치 | `adb -s RFKYA01VMQY install -r apps/mobile/build/app/outputs/flutter-apk/app-profile.apk` | Success |
| Android profile evidence | SM-A175N / Android 16 / RFKYA01VMQY | runner 3회 실행 후 analyzer summary 생성 | `.codex/evidence/899/android-profile-summary.md`, `.codex/evidence/899/android-profile-summary.json` | 3 runs, dispose all true, max janky 33.6%, max p99 frame 105ms, max camera latency p95 187ms, max total PSS 378083KB |
| Android 화면 증거 | SM-A175N / Android 16 / RFKYA01VMQY | run 1 route map screenshot 확인 | `.codex/evidence/899/android-profile-run-1/route-map.png` | profile build에서 노선도와 `노선별로 보기` CTA 확인 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 이 PR은 profile evidence를 반복 수집·요약하는 도구와 실측 증거를 추가한다. frame budget 최적화 자체는 포함하지 않는다.
- 측정 결과상 현재 profile run은 #836 Performance DoD의 p95/p99/jank 예산을 만족하지 못한다. 이 결과는 후속 최적화 하위 이슈로 이어져야 한다.
- screenshot/logcat/UI tree는 QA 실기기 로컬 로그와 화면을 포함하므로 git에 커밋하지 않고 `.codex/evidence/899/`에 로컬 전용으로 보관했다.

## 리스크

- profile 측정은 SM-A175N 단일 기기, 3회 반복 기준이다.
- analyzer는 Android `dumpsys gfxinfo` 텍스트 형식에 의존하므로 Android 출력 형식이 바뀌면 parser 갱신이 필요하다.
- 이번 PR은 iOS/VoiceOver evidence를 포함하지 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
