### PR TITLE
[Perf] 노선도 Android profile frame budget 개선

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 
 import 'accessible_design.dart';
 import 'features/network_map/domain/map_camera.dart';
@@ -750,6 +751,9 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
     with WidgetsBindingObserver {
   String? _layoutKey;
   MapCameraState? _camera;
+  MapCameraState? _pendingCamera;
+  bool _cameraFrameCallbackScheduled = false;
+  bool _gestureActive = false;
   MapCameraState? _gestureStartCamera;
   Offset? _gestureStartFocalPoint;
   RouteMapRendererHealthMonitor? _rendererMonitor;
@@ -764,6 +768,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _pendingCamera = null;
     _releaseRenderer(disposeRenderer: true);
     super.dispose();
   }
@@ -830,6 +835,8 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
               '${widget.data.selectedRegion}:${geometry.width}:${geometry.height}:${constraints.maxWidth}:${constraints.maxHeight}';
           if (_layoutKey != layoutKey) {
             _layoutKey = layoutKey;
+            _pendingCamera = null;
+            _gestureActive = false;
             _camera = _cameraForBounds(
               geometry.initialBounds,
               constraints,
@@ -877,6 +884,11 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
                 child: GestureDetector(
                   behavior: HitTestBehavior.translucent,
                   onScaleStart: (details) {
+                    if (!_gestureActive) {
+                      setState(() {
+                        _gestureActive = true;
+                      });
+                    }
                     _gestureStartCamera = camera;
                     _gestureStartFocalPoint = details.localFocalPoint;
                   },
@@ -884,6 +896,12 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
                     _updateCameraForGesture(details);
                   },
                   onScaleEnd: (_) {
+                    _scheduleCameraCommit();
+                    if (_gestureActive) {
+                      setState(() {
+                        _gestureActive = false;
+                      });
+                    }
                     _gestureStartCamera = null;
                     _gestureStartFocalPoint = null;
                   },
@@ -898,32 +916,32 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
                   },
                 ),
               ),
-              for (final station in widget.data.stations)
-                if (_stationHitRect(
-                  station,
-                  geometry,
-                ).overlaps(camera.visibleSourceRect.inflate(96 / camera.scale)))
-                  Positioned.fromRect(
-                    rect: _sourceRectToViewport(
-                      _stationHitRect(
-                        station,
-                        geometry,
-                        nodeRadius: 24 / camera.scale,
-                        labelHeight: 40 / camera.scale,
+              if (!_gestureActive)
+                for (final station in widget.data.stations)
+                  if (_stationHitRect(station, geometry).overlaps(
+                    camera.visibleSourceRect.inflate(96 / camera.scale),
+                  ))
+                    Positioned.fromRect(
+                      rect: _sourceRectToViewport(
+                        _stationHitRect(
+                          station,
+                          geometry,
+                          nodeRadius: 24 / camera.scale,
+                          labelHeight: 40 / camera.scale,
+                        ),
+                        camera,
                       ),
-                      camera,
+                      child: _StationHitTarget(
+                        key: Key(
+                          'networkMapStation-${station.id.replaceFirst('station-', '')}-${station.lineId}',
+                        ),
+                        station: station,
+                        onTap: () => widget.onStationTap(
+                          station,
+                          stationLinesById[station.id] ?? const [],
+                        ),
+                      ),
                     ),
-                    child: _StationHitTarget(
-                      key: Key(
-                        'networkMapStation-${station.id.replaceFirst('station-', '')}-${station.lineId}',
-                      ),
-                      station: station,
-                      onTap: () => widget.onStationTap(
-                        station,
-                        stationLinesById[station.id] ?? const [],
-                      ),
-                    ),
-                  ),
               Positioned(
                 right: 14,
                 top: 12,
@@ -963,7 +981,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   }
 
   void _scaleMap(double factor) {
-    final camera = _camera;
+    final camera = _pendingCamera ?? _camera;
     if (camera == null || camera.viewportSize == Size.zero) {
       return;
     }
@@ -999,18 +1017,42 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   }
 
   void _setCamera(MapCameraState camera) {
-    final currentCamera = _camera;
+    final currentCamera = _pendingCamera ?? _camera;
     final nextCamera = currentCamera == null
         ? camera
         : networkMapCameraWithMonotonicRevision(
             current: currentCamera,
             next: camera,
           );
-    if (_camera == nextCamera) {
+    if (identical(_pendingCamera, nextCamera) ||
+        (_pendingCamera == null && identical(_camera, nextCamera))) {
       return;
     }
-    setState(() {
-      _camera = nextCamera;
+    _pendingCamera = nextCamera;
+    _scheduleCameraCommit();
+  }
+
+  void _scheduleCameraCommit() {
+    if (_pendingCamera == null) {
+      return;
+    }
+    if (_cameraFrameCallbackScheduled) {
+      return;
+    }
+    _cameraFrameCallbackScheduled = true;
+    SchedulerBinding.instance.scheduleFrameCallback((_) {
+      _cameraFrameCallbackScheduled = false;
+      final pendingCamera = _pendingCamera;
+      _pendingCamera = null;
+      if (!mounted || pendingCamera == null) {
+        return;
+      }
+      if (identical(_camera, pendingCamera)) {
+        return;
+      }
+      setState(() {
+        _camera = pendingCamera;
+      });
     });
   }
 

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -881,39 +881,35 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
                   ),
                 ),
               Positioned.fill(
-                child: GestureDetector(
-                  behavior: HitTestBehavior.translucent,
-                  onScaleStart: (details) {
-                    if (!_gestureActive) {
-                      setState(() {
-                        _gestureActive = true;
-                      });
-                    }
-                    _gestureStartCamera = camera;
-                    _gestureStartFocalPoint = details.localFocalPoint;
-                  },
-                  onScaleUpdate: (details) {
-                    _updateCameraForGesture(details);
-                  },
-                  onScaleEnd: (_) {
-                    _scheduleCameraCommit();
-                    if (_gestureActive) {
-                      setState(() {
-                        _gestureActive = false;
-                      });
-                    }
-                    _gestureStartCamera = null;
-                    _gestureStartFocalPoint = null;
-                  },
-                  onTapUp: (details) {
-                    _openNearestStation(
-                      camera.viewportToSourcePoint(details.localPosition),
-                      widget.data.stations,
-                      stationLinesById,
-                      geometry,
-                      camera,
-                    );
-                  },
+                child: Listener(
+                  onPointerCancel: (_) => _endScaleGesture(),
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.translucent,
+                    onScaleStart: (details) {
+                      if (!_gestureActive) {
+                        setState(() {
+                          _gestureActive = true;
+                        });
+                      }
+                      _gestureStartCamera = camera;
+                      _gestureStartFocalPoint = details.localFocalPoint;
+                    },
+                    onScaleUpdate: (details) {
+                      _updateCameraForGesture(details);
+                    },
+                    onScaleEnd: (_) {
+                      _endScaleGesture();
+                    },
+                    onTapUp: (details) {
+                      _openNearestStation(
+                        camera.viewportToSourcePoint(details.localPosition),
+                        widget.data.stations,
+                        stationLinesById,
+                        geometry,
+                        camera,
+                      );
+                    },
+                  ),
                 ),
               ),
               if (!_gestureActive)
@@ -1014,6 +1010,22 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
           )
           .clamped(viewportMargin: 220),
     );
+  }
+
+  void _endScaleGesture() {
+    _scheduleCameraCommit();
+    _gestureStartCamera = null;
+    _gestureStartFocalPoint = null;
+    if (!_gestureActive) {
+      return;
+    }
+    if (!mounted) {
+      _gestureActive = false;
+      return;
+    }
+    setState(() {
+      _gestureActive = false;
+    });
   }
 
   void _setCamera(MapCameraState camera) {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1465,8 +1465,35 @@ void main() {
         isTrue,
       );
 
-      visibleSemantics.owner!.performAction(
-        visibleSemantics.id,
+      final surfaceCenter = tester.getCenter(
+        find.byKey(const Key('networkMapSurface')),
+      );
+      final firstGesture = await tester.startGesture(
+        surfaceCenter - const Offset(24, 0),
+        pointer: 1,
+      );
+      final secondGesture = await tester.startGesture(
+        surfaceCenter + const Offset(24, 0),
+        pointer: 2,
+      );
+      await firstGesture.moveBy(const Offset(-80, 0));
+      await secondGesture.moveBy(const Offset(80, 0));
+      await tester.pump();
+      expect(visibleStation, findsNothing);
+
+      await firstGesture.cancel();
+      await secondGesture.cancel();
+      await tester.pumpAndSettle();
+      expect(visibleStation, findsOneWidget);
+
+      final restoredSemantics = tester.getSemantics(visibleStation);
+      expect(
+        restoredSemantics.getSemanticsData().hasAction(SemanticsAction.tap),
+        isTrue,
+      );
+
+      restoredSemantics.owner!.performAction(
+        restoredSemantics.id,
         SemanticsAction.tap,
       );
       await tester.pumpAndSettle();


### PR DESCRIPTION
## 관련 이슈

close #910

## 작업 배경

- #899 Android profile evidence에서 노선도 pan 중 frame budget 초과가 확인됐다.
- QA 요청에 따라 emulator가 아니라 SM-A175N 실기기 profile APK 기준으로 개선 여부를 확인했다.
- 큰 renderer 교체 대신 Flutter camera update와 gesture 중 station hit-target 생성 비용을 먼저 줄였다.

## 작업 내용

- gesture 중 camera update를 즉시 `setState`하지 않고 frame callback에서 최신 camera 1건만 commit하도록 바꿨다.
- 연속 gesture update가 들어와도 `_pendingCamera`를 기준으로 revision 단조 증가를 유지한다.
- drag 중에는 invisible station hit-target/semantics widget 생성을 잠시 멈추고, gesture 종료 또는 pointer cancel 뒤 즉시 복원한다.
- zoom button은 pending camera가 있으면 그 값을 기준으로 동작해 coalescing 중에도 scale 기준이 뒤로 밀리지 않게 했다.
- CodeRabbit 지적에 따라 scale gesture cancel 이후 station semantics가 복원되는 widget 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/network_map.dart apps/mobile/test/widget_test.dart`: exit 0
  - `flutter test test/widget_test.dart --plain-name "노선도"`: exit 0, 16 tests passed
  - `flutter analyze`: exit 0, No issues found
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 106 tests passed
  - `git diff --check`: exit 0
  - `tools/ci/detect-changed-paths.sh /tmp/easysubway-910-changed-files.txt`: `mobile=true`, `android=true`, `ios=true`, `deploy=false`
  - `flutter build apk --profile`: exit 0, `build/app/outputs/flutter-apk/app-profile.apk`
  - `adb -s RFKYA01VMQY install -r apps/mobile/build/app/outputs/flutter-apk/app-profile.apk`: Success
  - Android profile runner 3회: 모두 exit 0
  - `node tools/mobile/analyze-route-map-android-evidence.mjs --artifact-dir ... --format markdown/json`: exit 0
  - Codex CLI fallback 격리 확인: `flutter test test/widget_test.dart` exit 0, 484 tests passed; `flutter analyze` exit 0; `git diff --check e17900549e2f560460d8f7b9d7a56934283313c3` exit 0
  - CI: https://github.com/AquilaXk/easysubway/actions/runs/28213421628 success
  - Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/28213421360 success
  - Post-merge CD: https://github.com/AquilaXk/easysubway/actions/runs/28213792954 success

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 노선도 회귀 | local Flutter | widget subset 실행 | `flutter test test/widget_test.dart --plain-name "노선도"` | exit 0, 16 tests passed |
| scale cancel 접근성 복구 | local Flutter | 두 손가락 scale cancel 후 station semantics tap action 복원 확인 | `apps/mobile/test/widget_test.dart`의 `노선도 viewport 밖 station semantics는 생성하지 않는다` | cancel 후 station hit target/semantics 복원 |
| 정적 검증 | local Flutter/Node | analyze, repository contract, diff check | `flutter analyze`, `node --test tools/ci/repository-contract.test.mjs`, `git diff --check` | 모두 exit 0 |
| Android profile build/install | SM-A175N / Android 16 / RFKYA01VMQY | 최신 head profile APK 빌드 및 설치 | `flutter build apk --profile`, `adb -s RFKYA01VMQY install -r apps/mobile/build/app/outputs/flutter-apk/app-profile.apk` | build exit 0, install Success |
| Android profile evidence | SM-A175N / Android 16 / RFKYA01VMQY | 최신 head runner 3회 후 analyzer summary 생성 | `.codex/evidence/910/android-profile-head-summary.md`, `.codex/evidence/910/android-profile-head-summary.json` | 3 runs, dispose all true, max janky 32.85%, max p95 frame 61ms, max p99 frame 101ms, max camera latency p95 105ms |
| Android 화면/접근성 흐름 | SM-A175N / Android 16 / RFKYA01VMQY | 최신 head route map UI tree와 screenshot 확인 | `.codex/evidence/910/android-profile-head-run-1/route-map.xml`, `.codex/evidence/910/android-profile-head-run-1/route-map.png` | `노선도`, `노선별로 보기`, `사당역` station button 확인 |
| CI | GitHub Actions | PR 최신 head CI run 확인 | https://github.com/AquilaXk/easysubway/actions/runs/28213421628 | success |
| Release artifact | GitHub Actions | PR 최신 head Android app bundle artifact run 확인 | https://github.com/AquilaXk/easysubway/actions/runs/28213421360 | success |
| CodeRabbit review | GitHub PR review | actionable 1건 확인 후 원래 inline thread에 수정 답글 및 resolve | https://github.com/AquilaXk/easysubway/pull/912#discussion_r3478813689 | gesture cancel 복구 수정 답글 게시, thread resolved |
| Codex CLI fallback | GitHub PR review | CodeRabbit incremental rate limit 대체 review | https://github.com/AquilaXk/easysubway/pull/912#pullrequestreview-4576326706 | Actionable comments posted: 0 |
| Post-merge CD | GitHub Actions main | merge commit `d08d9a4`의 CD run 확인 | https://github.com/AquilaXk/easysubway/actions/runs/28213792954 | success |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `_setCamera`가 `_pendingCamera`를 통해 frame당 최신 camera만 commit하고, gesture 중 station hit-target 생성을 멈췄다가 종료 또는 pointer cancel 뒤 복원하는 흐름이다.
- #899 기준 max janky 33.6% → 32.85%, max p99 frame 105ms → 101ms, max camera latency p95 187ms → 105ms로 개선됐다.
- 최신 head 실기기 3회 기준 max p95 frame은 61ms로 측정됐지만, max janky가 32.85%라 #836 Performance DoD 전체 통과 상태는 아니다. 이번 PR은 budget 개선의 축소 변경이며, jank budget 완전 충족은 후속 작업이 필요하다.
- screenshot/logcat/UI tree는 QA 실기기 화면, 접근성 tree, 로컬 런타임 로그를 포함하므로 git에 커밋하지 않고 `.codex/evidence/910/`에 로컬 전용으로 보관했다.

## 리스크

- gesture 중에는 station hit-target/semantics widget이 잠시 빠지므로, gesture 종료와 pointer cancel 후 즉시 복원되는 회귀를 widget test와 실기기 UI tree로 확인했다.
- profile 수치는 단일 SM-A175N 실기기 3회 반복 기준이며 WebView/GPU 조합에 따라 달라질 수 있다.
- #836 Performance DoD의 jank budget을 완전히 만족하지 못한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
