### PR TITLE
[Perf] 노선도 gesture-only Android profile budget 분리

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5724,8 +5724,11 @@ test("노선도 Android 실기기 evidence runner는 frame, memory, renderer rec
   assert.match(script, /--serial <adb-serial>/);
   assert.match(script, /--artifact-dir <dir>/);
   assert.match(script, /--build-mode <mode>/);
+  assert.match(script, /--measure-after-route-map-settle/);
   assert.match(script, /Install a debug or profile APK first/);
   assert.match(script, /Unsupported build mode/);
+  assert.match(script, /measurement_scope=/);
+  assert.match(script, /gfxinfo_reset_after_route_map_settle=/);
   assert.match(script, /dumpsys gfxinfo "\$PACKAGE" reset/);
   assert.match(script, /dumpsys gfxinfo "\$PACKAGE" > "\$ARTIFACT_DIR\/gfxinfo\.txt"/);
   assert.match(script, /dumpsys gfxinfo "\$PACKAGE" framestats > "\$ARTIFACT_DIR\/gfxinfo-framestats\.txt"/);
@@ -5754,6 +5757,8 @@ test("노선도 Android evidence analyzer는 profile frame, memory, camera laten
       "height=2340",
       "build_mode=profile",
       "pan_count=3",
+      "measurement_scope=gesture_after_route_map_settle",
+      "gfxinfo_reset_after_route_map_settle=true",
       "captured_at_utc=2026-06-26T01:00:00Z",
     ].join("\n"),
   );
@@ -5801,10 +5806,14 @@ test("노선도 Android evidence analyzer는 profile frame, memory, camera laten
 
   assert.equal(output.artifactKind, "route-map-android-evidence-summary");
   assert.equal(output.runs[0].buildMode, "profile");
+  assert.equal(output.runs[0].measurementScope, "gesture_after_route_map_settle");
+  assert.equal(output.runs[0].gfxinfoResetAfterRouteMapSettle, true);
   assert.equal(output.runs[0].gfxinfo.jankyPercent, 5.36);
   assert.equal(output.runs[0].gfxinfo.p99Ms, 33);
   assert.equal(output.runs[0].meminfo.totalPssKb, 591090);
   assert.equal(output.runs[0].renderer.cameraLatencyP95Ms, 48);
+  assert.deepEqual(output.aggregate.measurementScopes, ["gesture_after_route_map_settle"]);
+  assert.equal(output.aggregate.maxP95FrameMs, 25);
   assert.equal(output.aggregate.disposeObservedInAllRuns, true);
 });
 

--- a/tools/mobile/analyze-route-map-android-evidence.mjs
+++ b/tools/mobile/analyze-route-map-android-evidence.mjs
@@ -138,6 +138,9 @@ function analyzeRun(artifactDir) {
     serial: metadata.serial ?? "",
     package: metadata.package ?? "",
     buildMode: metadata.build_mode ?? "",
+    measurementScope: metadata.measurement_scope ?? "route_map_entry_and_pan",
+    gfxinfoResetAfterRouteMapSettle:
+      metadata.gfxinfo_reset_after_route_map_settle === "true",
     viewport: `${metadata.width ?? ""}x${metadata.height ?? ""}`,
     capturedAtUtc: metadata.captured_at_utc ?? "",
     panCount: Number.parseInt(metadata.pan_count ?? "0", 10),
@@ -150,7 +153,9 @@ function analyzeRun(artifactDir) {
 function aggregate(runs) {
   return {
     runCount: runs.length,
+    measurementScopes: [...new Set(runs.map((run) => run.measurementScope))],
     maxJankyPercent: Math.max(...runs.map((run) => run.gfxinfo.jankyPercent ?? 0)),
+    maxP95FrameMs: Math.max(...runs.map((run) => run.gfxinfo.p95Ms ?? 0)),
     maxP99FrameMs: Math.max(...runs.map((run) => run.gfxinfo.p99Ms ?? 0)),
     maxCameraLatencyP95Ms: Math.max(...runs.map((run) => run.renderer.cameraLatencyP95Ms ?? 0)),
     maxTotalPssKb: Math.max(...runs.map((run) => run.meminfo.totalPssKb ?? 0)),
@@ -163,18 +168,21 @@ function markdownReport(result) {
     "# Android route map profile evidence summary",
     "",
     `- runs: ${result.aggregate.runCount}`,
+    `- measurement_scopes: ${result.aggregate.measurementScopes.join(", ")}`,
     `- max_janky_percent: ${result.aggregate.maxJankyPercent}`,
+    `- max_p95_frame_ms: ${result.aggregate.maxP95FrameMs}`,
     `- max_p99_frame_ms: ${result.aggregate.maxP99FrameMs}`,
     `- max_camera_latency_p95_ms: ${result.aggregate.maxCameraLatencyP95Ms}`,
     `- max_total_pss_kb: ${result.aggregate.maxTotalPssKb}`,
     `- dispose_observed_in_all_runs: ${result.aggregate.disposeObservedInAllRuns}`,
     "",
-    "| run | build | viewport | frames | janky | p95 frame | p99 frame | camera p95 | total PSS | dispose | evidence |",
-    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    "| run | scope | build | viewport | frames | janky | p95 frame | p99 frame | camera p95 | total PSS | dispose | evidence |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
   ];
   for (const [index, run] of result.runs.entries()) {
     const cells = [
       index + 1,
+      run.measurementScope,
       run.buildMode,
       run.viewport,
       run.gfxinfo.totalFrames ?? "",

--- a/tools/mobile/run-route-map-android-evidence.sh
+++ b/tools/mobile/run-route-map-android-evidence.sh
@@ -14,6 +14,9 @@ Options:
   --build-mode <mode>       Installed APK mode: debug or profile. Defaults to debug.
   --pan-count <count>       Number of map pan gestures after route map entry. Defaults to 5.
   --settle-seconds <sec>    Wait after app launch and tab changes. Defaults to 3.
+  --measure-after-route-map-settle
+                            Reset frame/log evidence after route map settles, so gfxinfo and
+                            renderer latency focus on gestures instead of initial map entry.
   -h, --help                Show this help.
 
 The script installs nothing. Install a debug or profile APK first, then run this
@@ -32,6 +35,7 @@ ADB="${ADB:-}"
 BUILD_MODE="debug"
 PAN_COUNT=5
 SETTLE_SECONDS=3
+MEASURE_AFTER_ROUTE_MAP_SETTLE="false"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -63,6 +67,10 @@ while [[ $# -gt 0 ]]; do
       SETTLE_SECONDS="${2:-}"
       shift 2
       ;;
+    --measure-after-route-map-settle)
+      MEASURE_AFTER_ROUTE_MAP_SETTLE="true"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -78,6 +86,12 @@ done
 if [[ -z "$SERIAL" || -z "$ARTIFACT_DIR" ]]; then
   usage >&2
   exit 2
+fi
+
+if [[ "$MEASURE_AFTER_ROUTE_MAP_SETTLE" == "true" ]]; then
+  MEASUREMENT_SCOPE="gesture_after_route_map_settle"
+else
+  MEASUREMENT_SCOPE="route_map_entry_and_pan"
 fi
 
 case "$BUILD_MODE" in
@@ -154,6 +168,8 @@ PAN_RIGHT_X=$((WIDTH * 7 / 10))
   echo "build_mode=$BUILD_MODE"
   echo "pan_count=$PAN_COUNT"
   echo "settle_seconds=$SETTLE_SECONDS"
+  echo "measurement_scope=$MEASUREMENT_SCOPE"
+  echo "gfxinfo_reset_after_route_map_settle=$MEASURE_AFTER_ROUTE_MAP_SETTLE"
   echo "adb=$ADB"
   date -u +"captured_at_utc=%Y-%m-%dT%H:%M:%SZ"
 } > "$ARTIFACT_DIR/metadata.env"
@@ -169,12 +185,19 @@ sleep "$SETTLE_SECONDS"
 capture_screen "home"
 capture_ui_tree "home"
 
-adb_device shell dumpsys gfxinfo "$PACKAGE" reset >/dev/null
+if [[ "$MEASURE_AFTER_ROUTE_MAP_SETTLE" != "true" ]]; then
+  adb_device shell dumpsys gfxinfo "$PACKAGE" reset >/dev/null
+fi
 adb_device shell input tap "$ROUTE_TAB_X" "$BOTTOM_NAV_Y"
 sleep "$SETTLE_SECONDS"
 
 capture_screen "route-map"
 capture_ui_tree "route-map"
+
+if [[ "$MEASURE_AFTER_ROUTE_MAP_SETTLE" == "true" ]]; then
+  adb_device shell dumpsys gfxinfo "$PACKAGE" reset >/dev/null
+  adb_device logcat -c
+fi
 
 for ((i = 0; i < PAN_COUNT; i += 1)); do
   adb_device shell input swipe "$PAN_RIGHT_X" "$PAN_Y" "$PAN_LEFT_X" "$PAN_Y" 350
@@ -213,6 +236,7 @@ fi
   echo "- viewport: ${WIDTH}x${HEIGHT}"
   echo "- build_mode: $BUILD_MODE"
   echo "- pan_count: $PAN_COUNT"
+  echo "- measurement_scope: $MEASUREMENT_SCOPE"
   echo
   echo "## Renderer logs"
   grep "routeMapRenderer" "$ARTIFACT_DIR/route-map-renderer.log" || true


### PR DESCRIPTION
## 관련 이슈

close #913

## 작업 배경

- #899/#912 Android profile evidence는 노선도 탭 진입 전 `gfxinfo`를 reset해 WebView 초기 로드와 pan gesture 비용이 같은 jank 수치에 섞였다.
- #836 Performance DoD의 `gesture 중 p95 frame`, `janky frame`, `camera latency`를 판단하려면 route map settle 이후 gesture-only 측정이 필요하다.
- QA 요청에 따라 emulator가 아니라 SM-A175N 실기기 profile APK에서 새 측정 scope를 확인했다.

## 작업 내용

- `tools/mobile/run-route-map-android-evidence.sh`에 `--measure-after-route-map-settle` 옵션을 추가했다.
- 옵션을 켜면 route map 화면과 UI tree를 캡처한 뒤 `gfxinfo`와 `logcat`을 reset해 이후 pan gesture의 frame/camera latency를 별도 측정한다.
- runner metadata에 `measurement_scope`와 `gfxinfo_reset_after_route_map_settle`을 기록한다.
- analyzer JSON/Markdown summary가 measurement scope와 aggregate max p95 frame을 표시하도록 확장했다.
- repository contract test가 새 runner 옵션과 analyzer metadata/aggregate 계약을 검증한다.

## 검증

- 실행한 명령과 결과:
  - `bash -n tools/mobile/run-route-map-android-evidence.sh`: exit 0
  - `tools/mobile/run-route-map-android-evidence.sh --help`: exit 0
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 106 tests passed
  - `git diff --check`: exit 0
  - `flutter build apk --profile`: exit 0, `build/app/outputs/flutter-apk/app-profile.apk`
  - `adb -s RFKYA01VMQY install -r apps/mobile/build/app/outputs/flutter-apk/app-profile.apk`: Success
  - Android gesture-only profile runner 3회: 모두 exit 0
  - `node tools/mobile/analyze-route-map-android-evidence.mjs --artifact-dir ... --format markdown/json`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| runner contract | local shell | syntax/help 확인 | `bash -n tools/mobile/run-route-map-android-evidence.sh`, `tools/mobile/run-route-map-android-evidence.sh --help` | exit 0 |
| analyzer contract | local Node | repository contract test | `node --test tools/ci/repository-contract.test.mjs` | exit 0, 106 tests passed |
| Android profile build/install | SM-A175N / Android 16 / RFKYA01VMQY | profile APK 빌드 및 설치 | `flutter build apk --profile`, `adb -s RFKYA01VMQY install -r apps/mobile/build/app/outputs/flutter-apk/app-profile.apk` | build exit 0, install Success |
| Android gesture-only profile evidence | SM-A175N / Android 16 / RFKYA01VMQY | `--measure-after-route-map-settle` runner 3회 후 analyzer summary 생성 | `.codex/evidence/913/android-gesture-profile-summary.md`, `.codex/evidence/913/android-gesture-profile-summary.json` | scope `gesture_after_route_map_settle`, 3 runs, dispose all true, max janky 33.33%, max p95 frame 32ms, max p99 frame 85ms, max camera latency p95 122ms |
| Android 화면/접근성 흐름 | SM-A175N / Android 16 / RFKYA01VMQY | route map UI tree와 screenshot 확인 | `.codex/evidence/913/android-gesture-profile-run-1/route-map.xml`, `.codex/evidence/913/android-gesture-profile-run-1/route-map.png` | `노선도`, `노선별로 보기`, `사당역` station button 확인 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 기존 기본 측정 scope는 유지하고, 새 옵션을 켠 경우에만 route map settle 이후 frame/log evidence를 reset한다.
- gesture-only로 분리해도 max p95 frame 32ms, max p99 frame 85ms, max janky 33.33%, camera latency p95 122ms라 #836 Performance DoD는 아직 미충족이다.
- 이 PR은 최적화가 아니라 측정 분리와 근거 고정이다. 다음 성능 PR은 WebView viewBox commit 빈도 또는 interaction 중 renderer update 정책을 직접 줄여야 한다.
- screenshot/logcat/UI tree는 QA 실기기 화면, 접근성 tree, 로컬 런타임 로그를 포함하므로 git에 커밋하지 않고 `.codex/evidence/913/`에 로컬 전용으로 보관했다.

## 리스크

- `--measure-after-route-map-settle` 옵션은 초기 route map load jank를 제외하므로 기존 `route_map_entry_and_pan` 측정과 직접 비교하면 안 된다. summary의 `measurement_scope`로 구분한다.
- logcat reset이 route map 초기 renderer event를 제외하므로, gesture-only camera latency와 dispose 관찰에는 적합하지만 초기 load 진단에는 기존 scope를 사용해야 한다.
- #836 Performance DoD의 frame/camera latency budget은 아직 만족하지 못한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
