### PR TITLE
[Perf] 노선도 gesture viewBox commit 축소와 우회 UI 제거

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1086,8 +1086,11 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
     MapCameraState pendingCamera, {
     required bool forceCommit,
   }) {
-    final committedCamera =
-        _presentedRendererCamera ?? _requestedRendererCamera;
+    final committedCamera = networkMapRendererCommitBasisCamera(
+      presentedCamera: _presentedRendererCamera,
+      requestedCamera: _requestedRendererCamera,
+      visualCamera: pendingCamera,
+    );
     final requestedCamera = networkMapOverscannedRendererCamera(pendingCamera);
     final now = DateTime.now();
     final shouldCommit =
@@ -1671,6 +1674,22 @@ bool networkMapRendererCameraCoversVisual({
       rendererRect.top <= visualRect.top + tolerance &&
       rendererRect.right >= visualRect.right - tolerance &&
       rendererRect.bottom >= visualRect.bottom - tolerance;
+}
+
+@visibleForTesting
+MapCameraState? networkMapRendererCommitBasisCamera({
+  required MapCameraState? presentedCamera,
+  required MapCameraState? requestedCamera,
+  required MapCameraState visualCamera,
+}) {
+  if (requestedCamera != null &&
+      networkMapRendererCameraCoversVisual(
+        rendererCamera: requestedCamera,
+        visualCamera: visualCamera,
+      )) {
+    return requestedCamera;
+  }
+  return presentedCamera ?? requestedCamera;
 }
 
 @visibleForTesting

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1109,7 +1109,15 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
               : now.difference(_lastRendererCameraRequestAt!),
         );
     if (!shouldCommit) {
-      return _requestedRendererCamera ?? requestedCamera;
+      final skippedCommitCamera = networkMapRendererCameraForSkippedCommit(
+        requestedCamera: _requestedRendererCamera,
+        candidateCamera: requestedCamera,
+        visualCamera: pendingCamera,
+      );
+      if (!identical(skippedCommitCamera, _requestedRendererCamera)) {
+        _lastRendererCameraRequestAt = now;
+      }
+      return skippedCommitCamera;
     }
     _lastRendererCameraRequestAt = now;
     return requestedCamera;
@@ -1693,6 +1701,22 @@ MapCameraState? networkMapRendererCommitBasisCamera({
     return requestedCamera;
   }
   return presentedCamera ?? requestedCamera;
+}
+
+@visibleForTesting
+MapCameraState networkMapRendererCameraForSkippedCommit({
+  required MapCameraState? requestedCamera,
+  required MapCameraState candidateCamera,
+  required MapCameraState visualCamera,
+}) {
+  if (requestedCamera != null &&
+      networkMapRendererCameraCoversVisual(
+        rendererCamera: requestedCamera,
+        visualCamera: visualCamera,
+      )) {
+    return requestedCamera;
+  }
+  return candidateCamera;
 }
 
 @visibleForTesting

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -718,14 +718,17 @@ const _maxMapScale = 4.8;
 const _routeMapGestureRendererCommitInterval = Duration(milliseconds: 160);
 const _routeMapGestureMaxTranslationDriftFraction = 0.2;
 const _routeMapGestureMaxScaleRatio = 1.25;
+const _routeMapGestureRendererOverscanFactor = 1.5;
 
 class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
     with WidgetsBindingObserver {
   String? _layoutKey;
   MapCameraState? _camera;
   MapCameraState? _pendingCamera;
-  MapCameraState? _rendererCamera;
-  DateTime? _lastRendererCameraCommitAt;
+  MapCameraState? _requestedRendererCamera;
+  MapCameraState? _presentedRendererCamera;
+  final _requestedRendererCamerasByRevision = <int, MapCameraState>{};
+  DateTime? _lastRendererCameraRequestAt;
   bool _cameraFrameCallbackScheduled = false;
   bool _forceRendererCameraCommit = false;
   bool _gestureActive = false;
@@ -744,7 +747,9 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _pendingCamera = null;
-    _rendererCamera = null;
+    _requestedRendererCamera = null;
+    _presentedRendererCamera = null;
+    _requestedRendererCamerasByRevision.clear();
     _releaseRenderer(disposeRenderer: true);
     super.dispose();
   }
@@ -812,8 +817,10 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
           if (_layoutKey != layoutKey) {
             _layoutKey = layoutKey;
             _pendingCamera = null;
-            _rendererCamera = null;
-            _lastRendererCameraCommitAt = null;
+            _requestedRendererCamera = null;
+            _presentedRendererCamera = null;
+            _requestedRendererCamerasByRevision.clear();
+            _lastRendererCameraRequestAt = null;
             _gestureActive = false;
             final initialCamera = _cameraForBounds(
               geometry.initialBounds,
@@ -821,8 +828,12 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
               sourceBounds: fullBounds,
               minScale: minScale,
             );
+            final initialRendererCamera = networkMapOverscannedRendererCamera(
+              initialCamera,
+            );
             _camera = initialCamera;
-            _rendererCamera = initialCamera;
+            _requestedRendererCamera = initialRendererCamera;
+            _presentedRendererCamera = initialRendererCamera;
           }
           final camera =
               _camera ??
@@ -839,7 +850,13 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
                     ? const _OriginalRouteMapUnavailable()
                     : _RouteMapViewportRenderer(
                         asset: mapAsset,
-                        camera: _rendererCamera ?? camera,
+                        camera:
+                            _requestedRendererCamera ??
+                            networkMapOverscannedRendererCamera(camera),
+                        presentedCamera:
+                            _presentedRendererCamera ??
+                            _requestedRendererCamera ??
+                            networkMapOverscannedRendererCamera(camera),
                         visualCamera: camera,
                         onControllerCreated: _attachRendererController,
                       ),
@@ -1046,43 +1063,53 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
       if (!mounted || pendingCamera == null) {
         return;
       }
-      final rendererCamera = _rendererCameraFor(
+      final rendererCamera = _requestedRendererCameraFor(
         pendingCamera,
         forceCommit: forceRendererCameraCommit,
       );
       if (identical(_camera, pendingCamera) &&
-          identical(_rendererCamera, rendererCamera)) {
+          identical(_requestedRendererCamera, rendererCamera)) {
         return;
       }
       setState(() {
         _camera = pendingCamera;
-        _rendererCamera = rendererCamera;
+        if (!identical(_requestedRendererCamera, rendererCamera)) {
+          _requestedRendererCamerasByRevision[rendererCamera.revision] =
+              rendererCamera;
+        }
+        _requestedRendererCamera = rendererCamera;
       });
     });
   }
 
-  MapCameraState _rendererCameraFor(
+  MapCameraState _requestedRendererCameraFor(
     MapCameraState pendingCamera, {
     required bool forceCommit,
   }) {
-    final committedCamera = _rendererCamera;
+    final committedCamera =
+        _presentedRendererCamera ?? _requestedRendererCamera;
     final now = DateTime.now();
     final shouldCommit =
         forceCommit ||
         !_gestureActive ||
         committedCamera == null ||
+        !networkMapRendererCameraCoversVisual(
+          rendererCamera: committedCamera,
+          visualCamera: pendingCamera,
+        ) ||
         networkMapShouldCommitRendererCamera(
           committed: committedCamera,
           candidate: pendingCamera,
-          elapsedSinceLastCommit: _lastRendererCameraCommitAt == null
+          elapsedSinceLastCommit: _lastRendererCameraRequestAt == null
               ? _routeMapGestureRendererCommitInterval
-              : now.difference(_lastRendererCameraCommitAt!),
+              : now.difference(_lastRendererCameraRequestAt!),
         );
     if (!shouldCommit) {
-      return committedCamera;
+      return _requestedRendererCamera ??
+          networkMapOverscannedRendererCamera(pendingCamera);
     }
-    _lastRendererCameraCommitAt = now;
-    return pendingCamera;
+    _lastRendererCameraRequestAt = now;
+    return networkMapOverscannedRendererCamera(pendingCamera);
   }
 
   void _openNearestStation(
@@ -1129,6 +1156,9 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
       _rendererMonitor = null;
       _rendererController = null;
     }
+    if (event is RouteMapRendererFramePresented) {
+      _markRendererFramePresented(event.revision);
+    }
     if (!kDebugMode && !kProfileMode) {
       return;
     }
@@ -1155,6 +1185,24 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
           RouteMapRendererFailed():
         break;
     }
+  }
+
+  void _markRendererFramePresented(int revision) {
+    final camera =
+        _requestedRendererCamerasByRevision.remove(revision) ??
+        (_requestedRendererCamera?.revision == revision
+            ? _requestedRendererCamera
+            : null);
+    if (camera == null || identical(_presentedRendererCamera, camera)) {
+      return;
+    }
+    if (!mounted) {
+      _presentedRendererCamera = camera;
+      return;
+    }
+    setState(() {
+      _presentedRendererCamera = camera;
+    });
   }
 }
 
@@ -1432,12 +1480,14 @@ class _RouteMapViewportRenderer extends StatelessWidget {
   const _RouteMapViewportRenderer({
     required this.asset,
     required this.camera,
+    required this.presentedCamera,
     required this.visualCamera,
     required this.onControllerCreated,
   });
 
   final _RouteMapAsset asset;
   final MapCameraState camera;
+  final MapCameraState presentedCamera;
   final MapCameraState visualCamera;
   final ValueChanged<RouteMapRendererController> onControllerCreated;
 
@@ -1467,8 +1517,11 @@ class _RouteMapViewportRenderer extends StatelessWidget {
     return ClipRect(
       child: Transform(
         transform: networkMapRendererFrameTransform(
-          rendererCamera: camera,
-          visualCamera: visualCamera,
+          rendererCamera: presentedCamera,
+          visualCamera: networkMapRendererTransformVisualCamera(
+            rendererCamera: presentedCamera,
+            visualCamera: visualCamera,
+          ),
         ),
         child: KeyedSubtree(
           key: const Key('routeMapViewportRenderer'),
@@ -1595,6 +1648,42 @@ bool networkMapShouldCommitRendererCamera({
       drift.dy.abs() >=
           candidate.viewportSize.height *
               _routeMapGestureMaxTranslationDriftFraction;
+}
+
+@visibleForTesting
+MapCameraState networkMapOverscannedRendererCamera(MapCameraState camera) {
+  final overscanScale = math.max(
+    camera.minScale,
+    camera.scale / _routeMapGestureRendererOverscanFactor,
+  );
+  return camera.copyWith(scale: overscanScale).clamped(viewportMargin: 220);
+}
+
+@visibleForTesting
+bool networkMapRendererCameraCoversVisual({
+  required MapCameraState rendererCamera,
+  required MapCameraState visualCamera,
+}) {
+  const tolerance = 0.001;
+  final rendererRect = rendererCamera.visibleSourceRect;
+  final visualRect = visualCamera.visibleSourceRect;
+  return rendererRect.left <= visualRect.left + tolerance &&
+      rendererRect.top <= visualRect.top + tolerance &&
+      rendererRect.right >= visualRect.right - tolerance &&
+      rendererRect.bottom >= visualRect.bottom - tolerance;
+}
+
+@visibleForTesting
+MapCameraState networkMapRendererTransformVisualCamera({
+  required MapCameraState rendererCamera,
+  required MapCameraState visualCamera,
+}) {
+  return networkMapRendererCameraCoversVisual(
+        rendererCamera: rendererCamera,
+        visualCamera: visualCamera,
+      )
+      ? visualCamera
+      : rendererCamera;
 }
 
 @visibleForTesting

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1202,6 +1202,14 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   }
 
   void _markRendererFramePresented(int revision) {
+    if (!networkMapShouldAcceptPresentedRendererRevision(
+      revision: revision,
+      presentedCamera: _presentedRendererCamera,
+      requestedCamera: _requestedRendererCamera,
+    )) {
+      _requestedRendererCamerasByRevision.remove(revision);
+      return;
+    }
     final camera =
         _requestedRendererCamerasByRevision.remove(revision) ??
         (_requestedRendererCamera?.revision == revision
@@ -1717,6 +1725,23 @@ MapCameraState networkMapRendererCameraForSkippedCommit({
     return requestedCamera;
   }
   return candidateCamera;
+}
+
+@visibleForTesting
+bool networkMapShouldAcceptPresentedRendererRevision({
+  required int revision,
+  required MapCameraState? presentedCamera,
+  required MapCameraState? requestedCamera,
+}) {
+  final presentedRevision = presentedCamera?.revision;
+  if (presentedRevision != null && revision < presentedRevision) {
+    return false;
+  }
+  final requestedRevision = requestedCamera?.revision;
+  if (requestedRevision != null && revision < requestedRevision) {
+    return false;
+  }
+  return true;
 }
 
 @visibleForTesting

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1088,6 +1088,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   }) {
     final committedCamera =
         _presentedRendererCamera ?? _requestedRendererCamera;
+    final requestedCamera = networkMapOverscannedRendererCamera(pendingCamera);
     final now = DateTime.now();
     final shouldCommit =
         forceCommit ||
@@ -1099,17 +1100,16 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
         ) ||
         networkMapShouldCommitRendererCamera(
           committed: committedCamera,
-          candidate: pendingCamera,
+          candidate: requestedCamera,
           elapsedSinceLastCommit: _lastRendererCameraRequestAt == null
               ? _routeMapGestureRendererCommitInterval
               : now.difference(_lastRendererCameraRequestAt!),
         );
     if (!shouldCommit) {
-      return _requestedRendererCamera ??
-          networkMapOverscannedRendererCamera(pendingCamera);
+      return _requestedRendererCamera ?? requestedCamera;
     }
     _lastRendererCameraRequestAt = now;
-    return networkMapOverscannedRendererCamera(pendingCamera);
+    return requestedCamera;
   }
 
   void _openNearestStation(

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -746,13 +746,19 @@ class _NetworkMapCanvas extends StatefulWidget {
 
 const _minMapScale = 0.08;
 const _maxMapScale = 4.8;
+const _routeMapGestureRendererCommitInterval = Duration(milliseconds: 160);
+const _routeMapGestureMaxTranslationDriftFraction = 0.2;
+const _routeMapGestureMaxScaleRatio = 1.25;
 
 class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
     with WidgetsBindingObserver {
   String? _layoutKey;
   MapCameraState? _camera;
   MapCameraState? _pendingCamera;
+  MapCameraState? _rendererCamera;
+  DateTime? _lastRendererCameraCommitAt;
   bool _cameraFrameCallbackScheduled = false;
+  bool _forceRendererCameraCommit = false;
   bool _gestureActive = false;
   MapCameraState? _gestureStartCamera;
   Offset? _gestureStartFocalPoint;
@@ -769,6 +775,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _pendingCamera = null;
+    _rendererCamera = null;
     _releaseRenderer(disposeRenderer: true);
     super.dispose();
   }
@@ -836,13 +843,17 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
           if (_layoutKey != layoutKey) {
             _layoutKey = layoutKey;
             _pendingCamera = null;
+            _rendererCamera = null;
+            _lastRendererCameraCommitAt = null;
             _gestureActive = false;
-            _camera = _cameraForBounds(
+            final initialCamera = _cameraForBounds(
               geometry.initialBounds,
               constraints,
               sourceBounds: fullBounds,
               minScale: minScale,
             );
+            _camera = initialCamera;
+            _rendererCamera = initialCamera;
           }
           final camera =
               _camera ??
@@ -859,7 +870,8 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
                     ? const _OriginalRouteMapUnavailable()
                     : _RouteMapViewportRenderer(
                         asset: mapAsset,
-                        camera: camera,
+                        camera: _rendererCamera ?? camera,
+                        visualCamera: camera,
                         onControllerCreated: _attachRendererController,
                       ),
               ),
@@ -1013,6 +1025,10 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   }
 
   void _endScaleGesture() {
+    _forceRendererCameraCommit = true;
+    if (_pendingCamera == null && _camera != null) {
+      _pendingCamera = _camera;
+    }
     _scheduleCameraCommit();
     _gestureStartCamera = null;
     _gestureStartFocalPoint = null;
@@ -1055,17 +1071,49 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
     SchedulerBinding.instance.scheduleFrameCallback((_) {
       _cameraFrameCallbackScheduled = false;
       final pendingCamera = _pendingCamera;
+      final forceRendererCameraCommit = _forceRendererCameraCommit;
       _pendingCamera = null;
+      _forceRendererCameraCommit = false;
       if (!mounted || pendingCamera == null) {
         return;
       }
-      if (identical(_camera, pendingCamera)) {
+      final rendererCamera = _rendererCameraFor(
+        pendingCamera,
+        forceCommit: forceRendererCameraCommit,
+      );
+      if (identical(_camera, pendingCamera) &&
+          identical(_rendererCamera, rendererCamera)) {
         return;
       }
       setState(() {
         _camera = pendingCamera;
+        _rendererCamera = rendererCamera;
       });
     });
+  }
+
+  MapCameraState _rendererCameraFor(
+    MapCameraState pendingCamera, {
+    required bool forceCommit,
+  }) {
+    final committedCamera = _rendererCamera;
+    final now = DateTime.now();
+    final shouldCommit =
+        forceCommit ||
+        !_gestureActive ||
+        committedCamera == null ||
+        networkMapShouldCommitRendererCamera(
+          committed: committedCamera,
+          candidate: pendingCamera,
+          elapsedSinceLastCommit: _lastRendererCameraCommitAt == null
+              ? _routeMapGestureRendererCommitInterval
+              : now.difference(_lastRendererCameraCommitAt!),
+        );
+    if (!shouldCommit) {
+      return committedCamera;
+    }
+    _lastRendererCameraCommitAt = now;
+    return pendingCamera;
   }
 
   void _openNearestStation(
@@ -1415,11 +1463,13 @@ class _RouteMapViewportRenderer extends StatelessWidget {
   const _RouteMapViewportRenderer({
     required this.asset,
     required this.camera,
+    required this.visualCamera,
     required this.onControllerCreated,
   });
 
   final _RouteMapAsset asset;
   final MapCameraState camera;
+  final MapCameraState visualCamera;
   final ValueChanged<RouteMapRendererController> onControllerCreated;
 
   @override
@@ -1445,9 +1495,17 @@ class _RouteMapViewportRenderer extends StatelessWidget {
       ),
       _ => const ColoredBox(color: Colors.white),
     };
-    return KeyedSubtree(
-      key: const Key('routeMapViewportRenderer'),
-      child: renderer,
+    return ClipRect(
+      child: Transform(
+        transform: networkMapRendererFrameTransform(
+          rendererCamera: camera,
+          visualCamera: visualCamera,
+        ),
+        child: KeyedSubtree(
+          key: const Key('routeMapViewportRenderer'),
+          child: renderer,
+        ),
+      ),
     );
   }
 }
@@ -1541,6 +1599,42 @@ MapCameraState networkMapCameraWithMonotonicRevision({
     return next;
   }
   return next.copyWith(revision: current.revision + 1);
+}
+
+@visibleForTesting
+bool networkMapShouldCommitRendererCamera({
+  required MapCameraState committed,
+  required MapCameraState candidate,
+  required Duration elapsedSinceLastCommit,
+}) {
+  if (elapsedSinceLastCommit >= _routeMapGestureRendererCommitInterval) {
+    return true;
+  }
+  final scaleRatio = candidate.scale / committed.scale;
+  if (scaleRatio >= _routeMapGestureMaxScaleRatio ||
+      scaleRatio <= 1 / _routeMapGestureMaxScaleRatio) {
+    return true;
+  }
+  final viewportCenter = candidate.viewportSize.center(Offset.zero);
+  final committedCandidateCenter = committed.sourceToViewportPoint(
+    candidate.center,
+  );
+  final drift = committedCandidateCenter - viewportCenter;
+  return drift.dx.abs() >=
+          candidate.viewportSize.width *
+              _routeMapGestureMaxTranslationDriftFraction ||
+      drift.dy.abs() >=
+          candidate.viewportSize.height *
+              _routeMapGestureMaxTranslationDriftFraction;
+}
+
+@visibleForTesting
+Matrix4 networkMapRendererFrameTransform({
+  required MapCameraState rendererCamera,
+  required MapCameraState visualCamera,
+}) {
+  return visualCamera.sourceToViewport
+    ..multiply(rendererCamera.viewportToSource);
 }
 
 Rect _sourceRectToViewport(Rect sourceRect, MapCameraState camera) {

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -360,20 +360,6 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                     ],
                   ),
                 ),
-                Positioned(
-                  left: 14,
-                  bottom: 14,
-                  child: SizedBox(
-                    width: 180,
-                    height: 48,
-                    child: FilledButton.icon(
-                      key: const Key('networkMapListButton'),
-                      onPressed: () => _showMapList(data),
-                      icon: const Icon(Icons.list_alt),
-                      label: const Text('노선별로 보기'),
-                    ),
-                  ),
-                ),
               ],
             );
           },
@@ -411,23 +397,6 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
           NavigationDestination(icon: Icon(Icons.more_horiz), label: '더보기'),
         ],
       ),
-    );
-  }
-
-  void _showMapList(NetworkMapData data) {
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      showDragHandle: true,
-      builder: (context) {
-        return _NetworkMapListSheet(
-          data: data,
-          onStationTap: (station, lines) {
-            Navigator.of(context).pop();
-            _showStationSheet(station, lines);
-          },
-        );
-      },
     );
   }
 
@@ -2097,72 +2066,6 @@ class _StationHitTarget extends StatelessWidget {
       label: station.displayName,
       onTap: onTap,
       child: const SizedBox.expand(),
-    );
-  }
-}
-
-class _NetworkMapListSheet extends StatelessWidget {
-  const _NetworkMapListSheet({required this.data, required this.onStationTap});
-
-  final NetworkMapData data;
-  final void Function(NetworkMapStation station, List<NetworkMapLine> lines)
-  onStationTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final stationsByLine = <String, List<NetworkMapStation>>{};
-    for (final station in data.stations) {
-      stationsByLine.putIfAbsent(station.lineId, () => []).add(station);
-    }
-    final stationLinesById = _stationLinesById(data);
-    return SafeArea(
-      key: const Key('networkMapListSheet'),
-      child: ListView(
-        padding: const EdgeInsets.fromLTRB(20, 6, 20, 24),
-        children: [
-          const Text(
-            '노선별 역 보기',
-            style: TextStyle(fontSize: 24, fontWeight: FontWeight.w900),
-          ),
-          const SizedBox(height: 6),
-          const Text(
-            '노선별 목록에서 역을 선택하세요.',
-            style: TextStyle(fontSize: 15, color: Color(0xFF4D6367)),
-          ),
-          const SizedBox(height: 14),
-          if (data.stations.isEmpty)
-            const Text(
-              '선택한 노선에 표시할 역이 없습니다.',
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
-            )
-          else
-            for (final line in data.lines)
-              if (stationsByLine[line.id]?.isNotEmpty ?? false)
-                ExpansionTile(
-                  key: Key('networkMapListLine-${line.id}'),
-                  initiallyExpanded: true,
-                  leading: _LineCircleBadge(line: line, size: 34),
-                  title: Text(
-                    line.shortName,
-                    style: const TextStyle(fontWeight: FontWeight.w800),
-                  ),
-                  children: [
-                    for (final station in stationsByLine[line.id]!)
-                      ListTile(
-                        key: Key(
-                          'networkMapListStation-${station.id}-${station.lineId}',
-                        ),
-                        title: Text(station.displayName),
-                        subtitle: Text(line.shortName),
-                        onTap: () => onStationTap(
-                          station,
-                          stationLinesById[station.id] ?? const [],
-                        ),
-                      ),
-                  ],
-                ),
-        ],
-      ),
     );
   }
 }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1154,10 +1154,13 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
     RouteMapRendererHealthMonitor monitor,
     RouteMapRendererEvent event,
   ) {
-    if (event is RouteMapRendererDisposed &&
-        identical(_rendererMonitor, monitor)) {
+    final isCurrentMonitor = identical(_rendererMonitor, monitor);
+    if (event is RouteMapRendererDisposed && isCurrentMonitor) {
       _rendererMonitor = null;
       _rendererController = null;
+    }
+    if (!isCurrentMonitor) {
+      return;
     }
     if (event is RouteMapRendererFramePresented) {
       _markRendererFramePresented(event.revision);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1007,6 +1007,56 @@ void main() {
     expect(transformed.dy, moreOrLessEquals(62.5));
   });
 
+  test('노선도 renderer transform은 overscan 범위 밖 edge 노출을 피한다', () {
+    const visualCamera = MapCameraState(
+      sourceBounds: Rect.fromLTWH(0, 0, 1000, 500),
+      viewportSize: Size(250, 125),
+      center: Offset(500, 250),
+      scale: 0.5,
+      minScale: 0.1,
+      maxScale: 4,
+      revision: 3,
+    );
+    final rendererCamera = networkMapOverscannedRendererCamera(visualCamera);
+    final coveredVisualCamera = visualCamera.copyWith(
+      center: const Offset(560, 250),
+      revision: 4,
+    );
+    final uncoveredVisualCamera = visualCamera.copyWith(
+      center: const Offset(760, 250),
+      revision: 5,
+    );
+
+    expect(
+      networkMapRendererCameraCoversVisual(
+        rendererCamera: rendererCamera,
+        visualCamera: coveredVisualCamera,
+      ),
+      isTrue,
+    );
+    expect(
+      networkMapRendererTransformVisualCamera(
+        rendererCamera: rendererCamera,
+        visualCamera: coveredVisualCamera,
+      ),
+      same(coveredVisualCamera),
+    );
+    expect(
+      networkMapRendererCameraCoversVisual(
+        rendererCamera: rendererCamera,
+        visualCamera: uncoveredVisualCamera,
+      ),
+      isFalse,
+    );
+    expect(
+      networkMapRendererTransformVisualCamera(
+        rendererCamera: rendererCamera,
+        visualCamera: uncoveredVisualCamera,
+      ),
+      same(rendererCamera),
+    );
+  });
+
   test('공식 노선도 데이터팩 manifest는 앱 번들 asset을 가리킨다', () {
     final manifestFile = File('assets/datapacks/metro_map_pack/manifest.json');
     final manifest =

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -759,10 +759,11 @@ void main() {
     expect(find.byKey(const Key('networkMapZoomOutButton')), findsOneWidget);
     expect(find.byKey(const Key('networkMapOverviewButton')), findsOneWidget);
     expect(find.byKey(const Key('networkMapLocateButton')), findsOneWidget);
-    expect(find.byKey(const Key('networkMapListButton')), findsOneWidget);
+    expect(find.byKey(const Key('networkMapListButton')), findsNothing);
     expect(find.byTooltip('전체 노선도'), findsOneWidget);
     expect(find.byTooltip('처음 위치로'), findsOneWidget);
-    expect(find.text('노선별로 보기'), findsOneWidget);
+    expect(find.text('노선별로 보기'), findsNothing);
+    expect(find.text('노선도별로 보기'), findsNothing);
     expect(find.byTooltip('전체 보기'), findsNothing);
     expect(find.byTooltip('중심 보기'), findsNothing);
     expect(find.text('노선 목록으로 보기'), findsNothing);
@@ -876,7 +877,7 @@ void main() {
     expect(find.text('4호선'), findsWidgets);
   });
 
-  testWidgets('노선도 노선별 보기 화면에서 역을 선택할 수 있다', (tester) async {
+  testWidgets('노선도는 노선별 보기 우회 sheet를 노출하지 않는다', (tester) async {
     await tester.pumpWidget(
       EasySubwayApp(
         repository: FakeStationSearchRepository(),
@@ -890,22 +891,13 @@ void main() {
 
     await tester.tap(find.byKey(const Key('bottomNavMap')));
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('networkMapListButton')));
-    await tester.pumpAndSettle();
 
-    expect(find.text('노선별로 보기'), findsOneWidget);
-    expect(find.byKey(const Key('networkMapListSheet')), findsOneWidget);
-    expect(find.text('노선별 역 보기'), findsOneWidget);
-    expect(find.text('노선별 목록에서 역을 선택하세요.'), findsOneWidget);
-    await tester.tap(
-      find.byKey(const Key('networkMapListStation-station-sadang-seoul-4')),
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
-    expect(find.text('사당역'), findsOneWidget);
-    expect(find.text('2호선'), findsOneWidget);
-    expect(find.text('4호선'), findsOneWidget);
+    expect(find.byKey(const Key('networkMapListButton')), findsNothing);
+    expect(find.byKey(const Key('networkMapListSheet')), findsNothing);
+    expect(find.text('노선별로 보기'), findsNothing);
+    expect(find.text('노선도별로 보기'), findsNothing);
+    expect(find.text('노선별 역 보기'), findsNothing);
+    expect(find.text('노선별 목록에서 역을 선택하세요.'), findsNothing);
   });
 
   test('노선도 camera revision은 같은 gesture update에서도 단조 증가한다', () {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1078,6 +1078,40 @@ void main() {
     );
   });
 
+  test('노선도 renderer는 pan reversal 때 stale requested camera를 교체한다', () {
+    const visualCamera = MapCameraState(
+      sourceBounds: Rect.fromLTWH(0, 0, 1000, 500),
+      viewportSize: Size(250, 125),
+      center: Offset(500, 250),
+      scale: 0.5,
+      minScale: 0.1,
+      maxScale: 4,
+      revision: 3,
+    );
+    final staleRequestedCamera = networkMapOverscannedRendererCamera(
+      visualCamera.copyWith(center: const Offset(880, 250), revision: 4),
+    );
+    final candidateCamera = networkMapOverscannedRendererCamera(
+      visualCamera.copyWith(revision: 5),
+    );
+
+    expect(
+      networkMapRendererCameraCoversVisual(
+        rendererCamera: staleRequestedCamera,
+        visualCamera: visualCamera,
+      ),
+      isFalse,
+    );
+    expect(
+      networkMapRendererCameraForSkippedCommit(
+        requestedCamera: staleRequestedCamera,
+        candidateCamera: candidateCamera,
+        visualCamera: visualCamera,
+      ),
+      same(candidateCamera),
+    );
+  });
+
   test('공식 노선도 데이터팩 manifest는 앱 번들 asset을 가리킨다', () {
     final manifestFile = File('assets/datapacks/metro_map_pack/manifest.json');
     final manifest =

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1112,6 +1112,47 @@ void main() {
     );
   });
 
+  test('노선도 renderer는 out-of-order presented revision을 무시한다', () {
+    const presentedCamera = MapCameraState(
+      sourceBounds: Rect.fromLTWH(0, 0, 1000, 500),
+      viewportSize: Size(250, 125),
+      center: Offset(500, 250),
+      scale: 0.5,
+      minScale: 0.1,
+      maxScale: 4,
+      revision: 3,
+    );
+    final requestedCamera = presentedCamera.copyWith(
+      center: const Offset(560, 250),
+      revision: 5,
+    );
+
+    expect(
+      networkMapShouldAcceptPresentedRendererRevision(
+        revision: 4,
+        presentedCamera: presentedCamera,
+        requestedCamera: requestedCamera,
+      ),
+      isFalse,
+    );
+    expect(
+      networkMapShouldAcceptPresentedRendererRevision(
+        revision: 5,
+        presentedCamera: presentedCamera,
+        requestedCamera: requestedCamera,
+      ),
+      isTrue,
+    );
+    expect(
+      networkMapShouldAcceptPresentedRendererRevision(
+        revision: 2,
+        presentedCamera: presentedCamera,
+        requestedCamera: null,
+      ),
+      isFalse,
+    );
+  });
+
   test('공식 노선도 데이터팩 manifest는 앱 번들 asset을 가리킨다', () {
     final manifestFile = File('assets/datapacks/metro_map_pack/manifest.json');
     final manifest =

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -932,6 +932,89 @@ void main() {
     expect(second.revision, 5);
   });
 
+  test('노선도 gesture renderer commit은 interval, drift, scale 기준으로 제한한다', () {
+    const committed = MapCameraState(
+      sourceBounds: Rect.fromLTWH(0, 0, 1000, 500),
+      viewportSize: Size(250, 125),
+      center: Offset(500, 250),
+      scale: 0.5,
+      minScale: 0.1,
+      maxScale: 4,
+      revision: 3,
+    );
+
+    expect(
+      networkMapShouldCommitRendererCamera(
+        committed: committed,
+        candidate: committed.copyWith(center: const Offset(580, 250)),
+        elapsedSinceLastCommit: const Duration(milliseconds: 40),
+      ),
+      isFalse,
+    );
+    expect(
+      networkMapShouldCommitRendererCamera(
+        committed: committed,
+        candidate: committed.copyWith(center: const Offset(620, 250)),
+        elapsedSinceLastCommit: const Duration(milliseconds: 40),
+      ),
+      isTrue,
+    );
+    expect(
+      networkMapShouldCommitRendererCamera(
+        committed: committed,
+        candidate: committed.copyWith(scale: 0.66),
+        elapsedSinceLastCommit: const Duration(milliseconds: 40),
+      ),
+      isTrue,
+    );
+    expect(
+      networkMapShouldCommitRendererCamera(
+        committed: committed,
+        candidate: committed,
+        elapsedSinceLastCommit: const Duration(milliseconds: 80),
+      ),
+      isFalse,
+    );
+    expect(
+      networkMapShouldCommitRendererCamera(
+        committed: committed,
+        candidate: committed,
+        elapsedSinceLastCommit: const Duration(milliseconds: 160),
+      ),
+      isTrue,
+    );
+  });
+
+  test('노선도 renderer transform은 stale viewBox frame을 최신 camera 위치로 보정한다', () {
+    const rendererCamera = MapCameraState(
+      sourceBounds: Rect.fromLTWH(0, 0, 1000, 500),
+      viewportSize: Size(250, 125),
+      center: Offset(500, 250),
+      scale: 0.5,
+      minScale: 0.1,
+      maxScale: 4,
+      revision: 3,
+    );
+    final visualCamera = rendererCamera.copyWith(
+      center: const Offset(550, 250),
+      revision: 4,
+    );
+
+    final rendererPoint = rendererCamera.sourceToViewportPoint(
+      visualCamera.center,
+    );
+    final transformed = MatrixUtils.transformPoint(
+      networkMapRendererFrameTransform(
+        rendererCamera: rendererCamera,
+        visualCamera: visualCamera,
+      ),
+      rendererPoint,
+    );
+
+    expect(transformed.dx, moreOrLessEquals(125));
+    expect(transformed.dy, moreOrLessEquals(62.5));
+  });
+
   test('공식 노선도 데이터팩 manifest는 앱 번들 asset을 가리킨다', () {
     final manifestFile = File('assets/datapacks/metro_map_pack/manifest.json');
     final manifest =

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -945,6 +945,16 @@ void main() {
     );
     expect(
       networkMapShouldCommitRendererCamera(
+        committed: networkMapOverscannedRendererCamera(committed),
+        candidate: networkMapOverscannedRendererCamera(
+          committed.copyWith(center: const Offset(560, 250), revision: 4),
+        ),
+        elapsedSinceLastCommit: const Duration(milliseconds: 40),
+      ),
+      isFalse,
+    );
+    expect(
+      networkMapShouldCommitRendererCamera(
         committed: committed,
         candidate: committed.copyWith(center: const Offset(620, 250)),
         elapsedSinceLastCommit: const Duration(milliseconds: 40),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1036,6 +1036,9 @@ void main() {
       center: const Offset(760, 250),
       revision: 5,
     );
+    final requestedRendererCamera = networkMapOverscannedRendererCamera(
+      uncoveredVisualCamera,
+    );
 
     expect(
       networkMapRendererCameraCoversVisual(
@@ -1064,6 +1067,14 @@ void main() {
         visualCamera: uncoveredVisualCamera,
       ),
       same(rendererCamera),
+    );
+    expect(
+      networkMapRendererCommitBasisCamera(
+        presentedCamera: rendererCamera,
+        requestedCamera: requestedRendererCamera,
+        visualCamera: uncoveredVisualCamera,
+      ),
+      same(requestedRendererCamera),
     );
   });
 


### PR DESCRIPTION
## 관련 이슈

close #915
close #916

## 작업 배경

- #836 노선도 viewport renderer 감사에서 Android 실기기 gesture 중 WebView `viewBox` commit 비용이 frame jank와 camera latency로 남아 있었다.
- 논리 camera는 gesture를 즉시 따라가되, WebView full `viewBox` commit은 낮은 빈도로 제한해야 한다.
- QA 요청에 따라 성능 작업과 동시에 현 노선도의 `노선별로 보기`, `노선도별로 보기` 같은 별도 목록 우회 UI를 제거했다.

## 작업 내용

- 노선도 canvas의 logical camera, requested renderer camera, presented renderer camera를 분리했다.
- gesture 중 renderer full commit은 160ms interval, translation drift 20%, scale ratio 1.25 조건과 viewport coverage 기준으로 제한한다.
- stale WebView frame은 presented renderer camera에서 최신 visual camera로 transform해 gesture 반응을 유지한다.
- requested/presented revision이 늦게 도착하는 경우를 막기 위해 stale monitor event, pan reversal stale request, out-of-order `framePresented` revision을 방어했다.
- `노선별로 보기` CTA와 `_NetworkMapListSheet` 우회 bottom sheet를 제거하고, widget test가 해당 UI 미노출을 검증하도록 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/network_map.dart apps/mobile/test/widget_test.dart`: exit 0
  - `flutter test test/widget_test.dart --plain-name "노선도"`: exit 0, 21 tests passed
  - `flutter test test/widget_test.dart`: exit 0, 152 tests passed
  - `flutter analyze`: exit 0, No issues found
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 106 tests passed
  - `git diff --check`: exit 0
  - `flutter build apk --profile`: exit 0, `app-profile.apk` 96.3MB
  - `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY install -r apps/mobile/build/app/outputs/flutter-apk/app-profile.apk`: Success
  - `tools/mobile/run-route-map-android-evidence.sh --serial RFKYA01VMQY --build-mode profile --artifact-dir .codex/evidence/918-requested-basis-fix/android-gesture-profile-run-1 --measure-after-route-map-settle`: exit 0
  - Android gesture-only profile runner 3회 및 analyzer summary 생성: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| renderer scheduling regression | local Flutter test | 노선도 집중 widget/unit test | `flutter test test/widget_test.dart --plain-name "노선도"` | exit 0, 21 tests passed |
| mobile widget regression | local Flutter test | 전체 `widget_test.dart` | `flutter test test/widget_test.dart` | exit 0, 152 tests passed |
| static/repository checks | local | analyzer, repository contract, whitespace check | `flutter analyze`, `node --test tools/ci/repository-contract.test.mjs`, `git diff --check` | analyzer no issues, 106 tests passed, diff check exit 0 |
| Android profile build/install | SM-A175N / Android 16 / RFKYA01VMQY | profile APK 빌드 및 실기기 설치 | `flutter build apk --profile`, `adb -s RFKYA01VMQY install -r .../app-profile.apk` | build exit 0, install Success |
| Android gesture-only profile evidence | SM-A175N / Android 16 / RFKYA01VMQY | `--measure-after-route-map-settle` runner 3회 후 analyzer summary 생성 | `.codex/evidence/918-requested-basis-fix/android-gesture-profile-summary.md`, `.codex/evidence/918-requested-basis-fix/android-gesture-profile-summary.json` | scope `gesture_after_route_map_settle`, 3 runs, dispose all true, max janky 4.37%, max p95 frame 23ms, max p99 frame 42ms, max camera latency p95 44ms |
| Android 우회 UI 제거 | SM-A175N / Android 16 / RFKYA01VMQY | route map UI tree에서 제거 대상 문구 검색 | `.codex/evidence/918-requested-basis-fix/android-gesture-profile-run-1/route-map.xml`, `rg "노선별로 보기|노선도별로 보기|노선별 역 보기|노선별 목록에서"` | exit 1, 제거 대상 문구 미노출 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `_camera`는 hit-test/overlay/control 기준 logical camera로 유지하고, requested/presented renderer camera만 WebView full `viewBox` commit 기준으로 분리했다.
- Android 실기기 기준 #913 gesture-only baseline 대비 max janky 33.33% → 4.37%, max p95 32ms → 23ms, max p99 85ms → 42ms, max camera latency p95 122ms → 44ms로 개선됐다.
- CodeRabbit은 credit/rate limit 상태라 기존 bot 상태만 확인했고, Codex CLI fallback review를 PR review로 남겼다.
- Codex fallback의 마지막 CTA 복원 제안은 오래된 로컬 acceptance note와 QA 요청/#916 범위가 충돌한 false positive라 코드 변경 없이 non-actionable으로 triage했다.
- screenshot/UI tree/logcat은 QA 실기기 화면과 접근성 tree를 포함하므로 git에 커밋하지 않고 `.codex/evidence/918-requested-basis-fix/`에 로컬 전용으로 보관했다.

## 리스크

- gesture 중 WebView full `viewBox` commit은 의도적으로 늦게 따라오므로 빠른 pan 중에는 transform된 frame이 잠시 보이고, idle/gesture 종료 시 정확한 vector frame으로 복구된다.
- Android 실기기 profile evidence는 SM-A175N Android 16 기준 3회 측정이며, iOS 실기기는 QA 요청 범위 밖이라 이번 PR에서 직접 실행하지 않았다.
- Flutter 도구를 병렬 실행하면 startup lock 충돌이 발생할 수 있어 이후 Flutter 검증은 순차 실행했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
