### PR TITLE
[Perf] 노선도 gesture frame 예산 충족

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -288,21 +288,15 @@ class NetworkMapScreen extends StatefulWidget {
 
 class _NetworkMapScreenState extends State<NetworkMapScreen> {
   String? _selectedRegion;
-  String? _selectedLineId;
   late Future<NetworkMapData> _future = _loadMap();
 
   Future<NetworkMapData> _loadMap() {
-    return widget.repository.getNetworkMap(
-      region: _selectedRegion,
-      lineId: _selectedLineId,
-    );
+    return widget.repository.getNetworkMap(region: _selectedRegion);
   }
 
-  void _reload({String? region, String? lineId}) {
+  void _reload({String? region}) {
     setState(() {
-      final isChangingRegion = region != null && region != _selectedRegion;
       _selectedRegion = region ?? _selectedRegion;
-      _selectedLineId = isChangingRegion ? null : lineId;
       _future = _loadMap();
     });
   }
@@ -336,7 +330,6 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                 Positioned.fill(
                   child: _NetworkMapCanvas(
                     data: data,
-                    selectedLineId: _selectedLineId,
                     onStationTap: _showStationSheet,
                   ),
                 ),
@@ -350,12 +343,6 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
                         regions: data.regions,
                         selectedRegion: data.selectedRegion,
                         onSelected: (region) => _reload(region: region),
-                      ),
-                      const SizedBox(height: 8),
-                      _LineFilterMenu(
-                        lines: data.lines,
-                        selectedLineId: _selectedLineId,
-                        onSelected: (lineId) => _reload(lineId: lineId),
                       ),
                     ],
                   ),
@@ -430,46 +417,6 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
           },
         );
       },
-    );
-  }
-}
-
-class _LineFilterMenu extends StatelessWidget {
-  const _LineFilterMenu({
-    required this.lines,
-    required this.selectedLineId,
-    required this.onSelected,
-  });
-
-  final List<NetworkMapLine> lines;
-  final String? selectedLineId;
-  final ValueChanged<String?> onSelected;
-
-  @override
-  Widget build(BuildContext context) {
-    NetworkMapLine? selectedLine;
-    for (final line in lines) {
-      if (line.id == selectedLineId) {
-        selectedLine = line;
-        break;
-      }
-    }
-    final label = selectedLine?.shortName ?? '전체 노선';
-    return SizedBox(
-      key: const Key('networkMapLineFilter'),
-      width: 142,
-      height: EasySubwayTouchTarget.general,
-      child: PopupMenuButton<String>(
-        padding: EdgeInsets.zero,
-        initialValue: selectedLineId ?? '',
-        onSelected: (lineId) => onSelected(lineId.isEmpty ? null : lineId),
-        itemBuilder: (context) => [
-          const PopupMenuItem<String>(value: '', child: Text('전체 노선')),
-          for (final line in lines)
-            PopupMenuItem<String>(value: line.id, child: Text(line.shortName)),
-        ],
-        child: _RegionMenuButton(label: label, semanticLabel: '노선: $label'),
-      ),
     );
   }
 }
@@ -698,14 +645,9 @@ _RouteMapAsset? _routeMapAssetForRegion(String region) {
 }
 
 class _NetworkMapCanvas extends StatefulWidget {
-  const _NetworkMapCanvas({
-    required this.data,
-    required this.selectedLineId,
-    required this.onStationTap,
-  });
+  const _NetworkMapCanvas({required this.data, required this.onStationTap});
 
   final NetworkMapData data;
-  final String? selectedLineId;
   final void Function(NetworkMapStation station, List<NetworkMapLine> lines)
   onStationTap;
 
@@ -715,10 +657,10 @@ class _NetworkMapCanvas extends StatefulWidget {
 
 const _minMapScale = 0.08;
 const _maxMapScale = 4.8;
-const _routeMapGestureRendererCommitInterval = Duration(milliseconds: 160);
-const _routeMapGestureMaxTranslationDriftFraction = 0.2;
-const _routeMapGestureMaxScaleRatio = 1.25;
-const _routeMapGestureRendererOverscanFactor = 1.5;
+const _routeMapGestureRendererCommitInterval = Duration(milliseconds: 700);
+const _routeMapGestureMaxTranslationDriftFraction = 0.85;
+const _routeMapGestureMaxScaleRatio = 2.4;
+const _routeMapGestureRendererOverscanFactor = 3.25;
 
 class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
     with WidgetsBindingObserver {
@@ -780,21 +722,24 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
 
   void _releaseRenderer({required bool disposeRenderer}) {
     final monitor = _rendererMonitor;
-    _rendererMonitor = null;
     _rendererController = null;
+    if (monitor == null) {
+      return;
+    }
+    if (!disposeRenderer) {
+      _rendererMonitor = null;
+    }
     _ignoreRendererLifecycleFailure(
-      monitor?.close(disposeRenderer: disposeRenderer),
+      monitor.close(disposeRenderer: disposeRenderer).whenComplete(() {
+        if (identical(_rendererMonitor, monitor)) {
+          _rendererMonitor = null;
+        }
+      }),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    final linesById = {for (final line in widget.data.lines) line.id: line};
-    final stationsById = <String, NetworkMapStation>{};
-    for (final station in widget.data.stations) {
-      stationsById[_mapStationKey(station)] = station;
-      stationsById.putIfAbsent(station.id, () => station);
-    }
     final stationLinesById = _stationLinesById(widget.data);
     final mapAsset = _routeMapAssetForRegion(widget.data.selectedRegion);
     return Container(
@@ -861,23 +806,6 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
                         onControllerCreated: _attachRendererController,
                       ),
               ),
-              if (widget.selectedLineId != null)
-                Positioned.fill(
-                  child: IgnorePointer(
-                    child: CustomPaint(
-                      key: const Key('networkMapSelectedLineOverlay'),
-                      painter: _SelectedLineOverlayPainter(
-                        lineId: widget.selectedLineId!,
-                        linesById: linesById,
-                        stationsById: stationsById,
-                        edges: widget.data.edges,
-                        geometry: geometry,
-                        camera: camera,
-                        styleScale: geometry.overlayStyleScale,
-                      ),
-                    ),
-                  ),
-                ),
               Positioned.fill(
                 child: Listener(
                   onPointerCancel: (_) => _endScaleGesture(),
@@ -1135,7 +1063,6 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
       stations,
       geometry,
       sceneHitRadius: 24 / (camera.scale > 0 ? camera.scale : 1),
-      selectedLineId: widget.selectedLineId,
     );
     if (station == null) {
       return;
@@ -1228,200 +1155,6 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   }
 }
 
-class _SelectedLineOverlayPainter extends CustomPainter {
-  const _SelectedLineOverlayPainter({
-    required this.lineId,
-    required this.linesById,
-    required this.stationsById,
-    required this.edges,
-    required this.geometry,
-    required this.camera,
-    required this.styleScale,
-  });
-
-  final String lineId;
-  final Map<String, NetworkMapLine> linesById;
-  final Map<String, NetworkMapStation> stationsById;
-  final List<NetworkMapEdge> edges;
-  final _MapGeometry geometry;
-  final MapCameraState camera;
-  final double styleScale;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final line = linesById[lineId];
-    if (line == null) {
-      return;
-    }
-    final lineColor = _colorFromHex(line.color);
-    canvas.drawRect(
-      Offset.zero & size,
-      Paint()..color = Colors.white.withValues(alpha: 0.58),
-    );
-    canvas
-      ..save()
-      ..transform(camera.sourceToViewport.storage);
-    final pathPaint = Paint()
-      ..color = lineColor
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round
-      ..strokeWidth = 14 * styleScale
-      ..style = PaintingStyle.stroke;
-    for (final edge in _visibleEdges) {
-      final from = edge.from;
-      final to = edge.to;
-      final segmentPath = edge.segmentPath;
-      if (segmentPath == null) {
-        canvas.drawLine(
-          Offset(geometry.x(from), geometry.y(from)),
-          Offset(geometry.x(to), geometry.y(to)),
-          pathPaint,
-        );
-      } else {
-        _drawScaledPath(canvas, segmentPath, pathPaint, geometry);
-      }
-    }
-    final stationBorderPaint = Paint()..color = lineColor;
-    final stationFillPaint = Paint()..color = Colors.white;
-    for (final station in _visibleStations) {
-      final center = Offset(geometry.x(station), geometry.y(station));
-      canvas.drawCircle(center, 13 * styleScale, stationBorderPaint);
-      canvas.drawCircle(center, 7 * styleScale, stationFillPaint);
-    }
-    canvas.restore();
-  }
-
-  int get visibleEdgeCount => _visibleEdges.length;
-
-  int get visibleStationCount => _visibleStations.length;
-
-  Rect get _visibleSourceBounds =>
-      camera.visibleSourceRect.inflate(96 / camera.scale);
-
-  List<_SelectedLineVisibleEdge> get _visibleEdges {
-    final visibleBounds = _visibleSourceBounds;
-    final visibleEdges = <_SelectedLineVisibleEdge>[];
-    for (final edge in edges) {
-      if (edge.lineId != lineId) {
-        continue;
-      }
-      final from = stationsById[edge.fromStationId];
-      final to = stationsById[edge.toStationId];
-      if (from == null || to == null) {
-        continue;
-      }
-      final segmentPath = _segmentPath(from, to);
-      final bounds = _edgeSourceBounds(from, to, segmentPath);
-      if (!bounds.overlaps(visibleBounds)) {
-        continue;
-      }
-      visibleEdges.add(
-        _SelectedLineVisibleEdge(from: from, to: to, segmentPath: segmentPath),
-      );
-    }
-    return visibleEdges;
-  }
-
-  List<NetworkMapStation> get _visibleStations {
-    final visibleBounds = _visibleSourceBounds;
-    return [
-      for (final station in stationsById.values.toSet())
-        if (station.lineId == lineId &&
-            _stationOverlayBounds(station).overlaps(visibleBounds))
-          station,
-    ];
-  }
-
-  Rect _edgeSourceBounds(
-    NetworkMapStation from,
-    NetworkMapStation to,
-    Path? segmentPath,
-  ) {
-    final bounds = segmentPath == null
-        ? Rect.fromPoints(
-            Offset(geometry.x(from), geometry.y(from)),
-            Offset(geometry.x(to), geometry.y(to)),
-          )
-        : segmentPath.getBounds().shift(-geometry.origin);
-    return bounds.inflate(16 * styleScale);
-  }
-
-  Rect _stationOverlayBounds(NetworkMapStation station) {
-    return Rect.fromCircle(
-      center: Offset(geometry.x(station), geometry.y(station)),
-      radius: 13 * styleScale,
-    );
-  }
-
-  @override
-  bool shouldRepaint(_SelectedLineOverlayPainter oldDelegate) {
-    return oldDelegate.lineId != lineId ||
-        oldDelegate.linesById != linesById ||
-        oldDelegate.stationsById != stationsById ||
-        oldDelegate.edges != edges ||
-        oldDelegate.geometry != geometry ||
-        oldDelegate.camera != camera ||
-        oldDelegate.styleScale != styleScale;
-  }
-}
-
-class _SelectedLineVisibleEdge {
-  const _SelectedLineVisibleEdge({
-    required this.from,
-    required this.to,
-    required this.segmentPath,
-  });
-
-  final NetworkMapStation from;
-  final NetworkMapStation to;
-  final Path? segmentPath;
-}
-
-Path? _segmentPath(NetworkMapStation from, NetworkMapStation to) {
-  for (final pathData in [
-    from.position.downPath,
-    to.position.upPath,
-    from.position.upPath,
-    to.position.downPath,
-  ]) {
-    if (pathData.trim().isEmpty) {
-      continue;
-    }
-    final path = _pathFromSvg(pathData);
-    final bounds = path.getBounds().inflate(2);
-    final fromPoint = Offset(
-      from.position.x.toDouble(),
-      from.position.y.toDouble(),
-    );
-    final toPoint = Offset(to.position.x.toDouble(), to.position.y.toDouble());
-    if (bounds.contains(fromPoint) && bounds.contains(toPoint)) {
-      return path;
-    }
-  }
-  return null;
-}
-
-void _drawScaledPath(
-  Canvas canvas,
-  Path path,
-  Paint paint,
-  _MapGeometry geometry,
-) {
-  canvas
-    ..save()
-    ..translate(-geometry.origin.dx, -geometry.origin.dy);
-  canvas.drawPath(
-    path,
-    Paint()
-      ..color = paint.color
-      ..strokeCap = paint.strokeCap
-      ..strokeJoin = paint.strokeJoin
-      ..strokeWidth = paint.strokeWidth
-      ..style = paint.style,
-  );
-  canvas.restore();
-}
-
 class _MapControls extends StatelessWidget {
   const _MapControls({
     required this.onZoomIn,
@@ -1455,7 +1188,7 @@ class _MapControls extends StatelessWidget {
         const SizedBox(height: 8),
         _MapControlButton(
           key: const Key('networkMapOverviewButton'),
-          tooltip: '전체 노선도',
+          tooltip: '지도 전체 보기',
           icon: Icons.fit_screen,
           onPressed: onOverview,
         ),
@@ -1965,7 +1698,6 @@ NetworkMapStation? _stationAtMapPosition(
   List<NetworkMapStation> stations,
   _MapGeometry geometry, {
   required double sceneHitRadius,
-  String? selectedLineId,
 }) {
   NetworkMapStation? bestStation;
   var bestScore = double.infinity;
@@ -1978,11 +1710,7 @@ NetworkMapStation? _stationAtMapPosition(
     )) {
       continue;
     }
-    final score =
-        _stationTapScore(position, station, geometry) +
-        (selectedLineId != null && station.lineId != selectedLineId
-            ? 1000000
-            : 0);
+    final score = _stationTapScore(position, station, geometry);
     if (score < bestScore) {
       bestScore = score;
       bestStation = station;
@@ -2205,9 +1933,6 @@ Offset _labelOffsetFor(NetworkMapStation station) {
   }
   return const Offset(8, -8);
 }
-
-String _mapStationKey(NetworkMapStation station) =>
-    '${station.id}:${station.lineId}';
 
 class _StationHitTarget extends StatelessWidget {
   const _StationHitTarget({

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -754,13 +754,13 @@ void main() {
     expect(find.byKey(const Key('networkMapScreen')), findsOneWidget);
     expect(find.byKey(const Key('mapRegionTabs')), findsOneWidget);
     expectNoForbiddenUserCopy(tester);
-    expect(find.byKey(const Key('networkMapLineFilter')), findsOneWidget);
+    expect(find.byKey(const Key('networkMapLineFilter')), findsNothing);
     expect(find.byKey(const Key('networkMapZoomInButton')), findsOneWidget);
     expect(find.byKey(const Key('networkMapZoomOutButton')), findsOneWidget);
     expect(find.byKey(const Key('networkMapOverviewButton')), findsOneWidget);
     expect(find.byKey(const Key('networkMapLocateButton')), findsOneWidget);
     expect(find.byKey(const Key('networkMapListButton')), findsNothing);
-    expect(find.byTooltip('전체 노선도'), findsOneWidget);
+    expect(find.byTooltip('지도 전체 보기'), findsOneWidget);
     expect(find.byTooltip('처음 위치로'), findsOneWidget);
     expect(find.text('노선별로 보기'), findsNothing);
     expect(find.text('노선도별로 보기'), findsNothing);
@@ -776,12 +776,9 @@ void main() {
       tester.getSize(find.byKey(const Key('mapRegionTabs'))).height,
       greaterThanOrEqualTo(EasySubwayTouchTarget.general),
     );
-    expect(
-      tester.getSize(find.byKey(const Key('networkMapLineFilter'))).height,
-      greaterThanOrEqualTo(EasySubwayTouchTarget.general),
-    );
     expect(find.bySemanticsLabel('지역: 수도권'), findsOneWidget);
-    expect(find.bySemanticsLabel('노선: 전체 노선'), findsOneWidget);
+    expect(find.bySemanticsLabel('노선: 전체 노선'), findsNothing);
+    expect(find.text('전체 노선'), findsNothing);
     expect(find.byKey(const Key('networkMapInteractiveViewer')), findsNothing);
     expect(find.byKey(const Key('routeMapViewportRenderer')), findsOneWidget);
 
@@ -820,11 +817,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('노선도를 불러오지 못했어요'), findsOneWidget);
     expect(find.text('원본 노선도를 불러올 수 없습니다.'), findsNothing);
-    await tester.tap(find.byKey(const Key('networkMapLineFilter')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('4호선'));
-    await tester.pumpAndSettle();
-    expect(repository.requestedNetworkMapLineIds.last, 'seoul-4');
+    expect(find.byKey(const Key('networkMapLineFilter')), findsNothing);
 
     await tester.tap(find.text('테스트권'));
     await tester.pumpAndSettle();
@@ -832,12 +825,12 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(repository.requestedNetworkMapRegions, contains('부산'));
-    expect(repository.requestedNetworkMapLineIds.last, isNull);
-    expect(find.bySemanticsLabel('노선: 전체 노선'), findsOneWidget);
+    expect(repository.requestedNetworkMapLineIds, isNot(contains('seoul-4')));
+    expect(find.bySemanticsLabel('노선: 전체 노선'), findsNothing);
     expect(find.text('부산'), findsOneWidget);
   });
 
-  testWidgets('노선도 노선 필터는 선택한 노선으로 다시 불러온다', (tester) async {
+  testWidgets('노선도는 노선 필터 없이 전체 지도에서 역을 선택한다', (tester) async {
     final repository = FakeStationSearchRepository();
     await tester.pumpWidget(
       EasySubwayApp(
@@ -852,17 +845,14 @@ void main() {
 
     await tester.tap(find.byKey(const Key('bottomNavMap')));
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('networkMapLineFilter')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('4호선'));
-    await tester.pumpAndSettle();
 
-    expect(repository.requestedNetworkMapLineIds, contains('seoul-4'));
+    expect(find.byKey(const Key('networkMapLineFilter')), findsNothing);
+    expect(find.text('전체 노선'), findsNothing);
     expect(
       find.byKey(const Key('networkMapSelectedLineOverlay')),
-      findsOneWidget,
+      findsNothing,
     );
-    expect(find.text('4호선'), findsOneWidget);
+    expect(repository.requestedNetworkMapLineIds, isNot(contains('seoul-4')));
 
     await tester.tapAt(
       tester.getCenter(
@@ -956,7 +946,7 @@ void main() {
     expect(
       networkMapShouldCommitRendererCamera(
         committed: committed,
-        candidate: committed.copyWith(center: const Offset(620, 250)),
+        candidate: committed.copyWith(center: const Offset(930, 250)),
         elapsedSinceLastCommit: const Duration(milliseconds: 40),
       ),
       isTrue,
@@ -964,7 +954,7 @@ void main() {
     expect(
       networkMapShouldCommitRendererCamera(
         committed: committed,
-        candidate: committed.copyWith(scale: 0.66),
+        candidate: committed.copyWith(scale: 1.21),
         elapsedSinceLastCommit: const Duration(milliseconds: 40),
       ),
       isTrue,
@@ -981,7 +971,7 @@ void main() {
       networkMapShouldCommitRendererCamera(
         committed: committed,
         candidate: committed,
-        elapsedSinceLastCommit: const Duration(milliseconds: 160),
+        elapsedSinceLastCommit: const Duration(milliseconds: 700),
       ),
       isTrue,
     );
@@ -1019,7 +1009,7 @@ void main() {
 
   test('노선도 renderer transform은 overscan 범위 밖 edge 노출을 피한다', () {
     const visualCamera = MapCameraState(
-      sourceBounds: Rect.fromLTWH(0, 0, 1000, 500),
+      sourceBounds: Rect.fromLTWH(0, 0, 2000, 1000),
       viewportSize: Size(250, 125),
       center: Offset(500, 250),
       scale: 0.5,
@@ -1033,7 +1023,7 @@ void main() {
       revision: 4,
     );
     final uncoveredVisualCamera = visualCamera.copyWith(
-      center: const Offset(760, 250),
+      center: const Offset(1200, 250),
       revision: 5,
     );
     final requestedRendererCamera = networkMapOverscannedRendererCamera(
@@ -1080,16 +1070,16 @@ void main() {
 
   test('노선도 renderer는 pan reversal 때 stale requested camera를 교체한다', () {
     const visualCamera = MapCameraState(
-      sourceBounds: Rect.fromLTWH(0, 0, 1000, 500),
+      sourceBounds: Rect.fromLTWH(0, 0, 3000, 1500),
       viewportSize: Size(250, 125),
-      center: Offset(500, 250),
+      center: Offset(1500, 750),
       scale: 0.5,
       minScale: 0.1,
       maxScale: 4,
       revision: 3,
     );
     final staleRequestedCamera = networkMapOverscannedRendererCamera(
-      visualCamera.copyWith(center: const Offset(880, 250), revision: 4),
+      visualCamera.copyWith(center: const Offset(2700, 750), revision: 4),
     );
     final candidateCamera = networkMapOverscannedRendererCamera(
       visualCamera.copyWith(revision: 5),
@@ -1252,315 +1242,6 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
       tester.view.resetDevicePixelRatio();
     }
-  });
-
-  testWidgets('viewBox 좌표 노선도 overlay는 표시 크기 배율을 보정한다', (tester) async {
-    const gwangjuMap = NetworkMapData(
-      regions: [NetworkMapRegion(name: '광주')],
-      selectedRegion: '광주',
-      lines: [
-        NetworkMapLine(
-          id: 'gwangju-1',
-          name: '광주 1호선',
-          color: '#009088',
-          region: '광주',
-        ),
-      ],
-      stations: [
-        NetworkMapStation(
-          id: 'station-gwangju-a',
-          nameKo: '녹동',
-          nameEn: 'Nokdong',
-          region: '광주',
-          lineId: 'gwangju-1',
-          stationCode: '100',
-          sequence: 1,
-          position: NetworkMapPosition(
-            x: 35,
-            y: 33,
-            labelDx: 0,
-            labelDy: 26,
-            upPath: '',
-            downPath: '',
-            sourceId: 'grtc-cyberstation',
-          ),
-        ),
-        NetworkMapStation(
-          id: 'station-gwangju-b',
-          nameKo: '소태',
-          nameEn: 'Sotae',
-          region: '광주',
-          lineId: 'gwangju-1',
-          stationCode: '101',
-          sequence: 2,
-          position: NetworkMapPosition(
-            x: 35,
-            y: 48,
-            labelDx: 0,
-            labelDy: 26,
-            upPath: '',
-            downPath: '',
-            sourceId: 'grtc-cyberstation',
-          ),
-        ),
-      ],
-      edges: [
-        NetworkMapEdge(
-          id: 'gwangju-edge-a-b',
-          lineId: 'gwangju-1',
-          fromStationId: 'station-gwangju-a:gwangju-1',
-          toStationId: 'station-gwangju-b:gwangju-1',
-          accessibilityStatus: 'AVAILABLE',
-          reliabilityScore: 100,
-        ),
-      ],
-      positionSources: [
-        NetworkMapPositionSource(
-          id: 'grtc-cyberstation',
-          name: '광주 공식 사이버스테이션',
-          licenseStatus: 'official',
-        ),
-      ],
-      stationLineMemberships: [
-        NetworkMapStationLineMembership(
-          stationId: 'station-gwangju-a',
-          lineId: 'gwangju-1',
-        ),
-        NetworkMapStationLineMembership(
-          stationId: 'station-gwangju-b',
-          lineId: 'gwangju-1',
-        ),
-      ],
-    );
-
-    await tester.pumpWidget(
-      EasySubwayApp(
-        repository: FakeStationSearchRepository(
-          networkMapRegionNames: const ['광주'],
-          networkMapData: gwangjuMap,
-        ),
-        reportRepository: FakeFacilityReportRepository(),
-        routeRepository: FakeRouteSearchRepository(),
-        notificationRepository: FakeNotificationSettingsRepository(),
-        initialOnboardingState: _completedOnboardingState(),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key('bottomNavMap')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('networkMapLineFilter')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('광주 1호선'));
-    await tester.pumpAndSettle();
-
-    final overlay = tester.widget<CustomPaint>(
-      find.byKey(const Key('networkMapSelectedLineOverlay')),
-    );
-    final painter = overlay.painter as dynamic;
-    expect(painter.styleScale as double, closeTo(190.50001 / 720, 0.001));
-  });
-
-  testWidgets('노선도 선택 노선 overlay는 viewport 밖 edge와 station을 그리지 않는다', (
-    tester,
-  ) async {
-    const map = NetworkMapData(
-      regions: [NetworkMapRegion(name: '테스트권')],
-      selectedRegion: '테스트권',
-      lines: [
-        NetworkMapLine(
-          id: 'seoul-4',
-          name: '수도권 4호선',
-          color: '#00A5DE',
-          region: '테스트권',
-        ),
-      ],
-      stations: [
-        NetworkMapStation(
-          id: 'station-visible-a',
-          nameKo: '보이는역A',
-          nameEn: 'Visible A',
-          region: '테스트권',
-          lineId: 'seoul-4',
-          stationCode: '401',
-          sequence: 1,
-          position: NetworkMapPosition(
-            x: 5000,
-            y: 100,
-            labelDx: 0,
-            labelDy: 0,
-            upPath: '',
-            downPath: '',
-            sourceId: 'fixture-route-map-source-capital-review',
-          ),
-        ),
-        NetworkMapStation(
-          id: 'station-visible-b',
-          nameKo: '보이는역B',
-          nameEn: 'Visible B',
-          region: '테스트권',
-          lineId: 'seoul-4',
-          stationCode: '402',
-          sequence: 2,
-          position: NetworkMapPosition(
-            x: 5040,
-            y: 100,
-            labelDx: 0,
-            labelDy: 0,
-            upPath: '',
-            downPath: '',
-            sourceId: 'fixture-route-map-source-capital-review',
-          ),
-        ),
-        NetworkMapStation(
-          id: 'station-visible-c',
-          nameKo: '보이는역C',
-          nameEn: 'Visible C',
-          region: '테스트권',
-          lineId: 'seoul-4',
-          stationCode: '403',
-          sequence: 3,
-          position: NetworkMapPosition(
-            x: 5080,
-            y: 100,
-            labelDx: 0,
-            labelDy: 0,
-            upPath: '',
-            downPath: '',
-            sourceId: 'fixture-route-map-source-capital-review',
-          ),
-        ),
-        NetworkMapStation(
-          id: 'station-geometry-left',
-          nameKo: '왼쪽기준',
-          nameEn: 'Geometry Left',
-          region: '테스트권',
-          lineId: 'geometry-helper',
-          stationCode: '000',
-          sequence: 0,
-          position: NetworkMapPosition(
-            x: 0,
-            y: 100,
-            labelDx: 0,
-            labelDy: 0,
-            upPath: '',
-            downPath: '',
-            sourceId: 'fixture-route-map-source-capital-review',
-          ),
-        ),
-        NetworkMapStation(
-          id: 'station-far-a',
-          nameKo: '먼역A',
-          nameEn: 'Far A',
-          region: '테스트권',
-          lineId: 'seoul-4',
-          stationCode: '499',
-          sequence: 99,
-          position: NetworkMapPosition(
-            x: 10000,
-            y: 100,
-            labelDx: 0,
-            labelDy: 0,
-            upPath: '',
-            downPath: '',
-            sourceId: 'fixture-route-map-source-capital-review',
-          ),
-        ),
-        NetworkMapStation(
-          id: 'station-far-b',
-          nameKo: '먼역B',
-          nameEn: 'Far B',
-          region: '테스트권',
-          lineId: 'seoul-4',
-          stationCode: '500',
-          sequence: 100,
-          position: NetworkMapPosition(
-            x: 10100,
-            y: 100,
-            labelDx: 0,
-            labelDy: 0,
-            upPath: '',
-            downPath: '',
-            sourceId: 'fixture-route-map-source-capital-review',
-          ),
-        ),
-      ],
-      edges: [
-        NetworkMapEdge(
-          id: 'visible-edge',
-          lineId: 'seoul-4',
-          fromStationId: 'station-visible-a:seoul-4',
-          toStationId: 'station-visible-b:seoul-4',
-          accessibilityStatus: 'AVAILABLE',
-          reliabilityScore: 100,
-        ),
-        NetworkMapEdge(
-          id: 'far-edge',
-          lineId: 'seoul-4',
-          fromStationId: 'station-far-a:seoul-4',
-          toStationId: 'station-far-b:seoul-4',
-          accessibilityStatus: 'AVAILABLE',
-          reliabilityScore: 100,
-        ),
-      ],
-      positionSources: [
-        NetworkMapPositionSource(
-          id: 'fixture-route-map-source-capital-review',
-          name: '수도권 노선도 fixture 좌표 검수',
-          licenseStatus: 'fixture-only',
-        ),
-      ],
-      stationLineMemberships: [
-        NetworkMapStationLineMembership(
-          stationId: 'station-visible-a',
-          lineId: 'seoul-4',
-        ),
-        NetworkMapStationLineMembership(
-          stationId: 'station-visible-b',
-          lineId: 'seoul-4',
-        ),
-        NetworkMapStationLineMembership(
-          stationId: 'station-visible-c',
-          lineId: 'seoul-4',
-        ),
-        NetworkMapStationLineMembership(
-          stationId: 'station-far-a',
-          lineId: 'seoul-4',
-        ),
-        NetworkMapStationLineMembership(
-          stationId: 'station-far-b',
-          lineId: 'seoul-4',
-        ),
-      ],
-    );
-
-    await tester.pumpWidget(
-      EasySubwayApp(
-        repository: FakeStationSearchRepository(
-          networkMapRegionNames: const ['테스트권'],
-          networkMapData: map,
-        ),
-        reportRepository: FakeFacilityReportRepository(),
-        routeRepository: FakeRouteSearchRepository(),
-        notificationRepository: FakeNotificationSettingsRepository(),
-        initialOnboardingState: _completedOnboardingState(),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const Key('bottomNavMap')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('networkMapLineFilter')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.text('4호선'));
-    await tester.pumpAndSettle();
-
-    final overlay = tester.widget<CustomPaint>(
-      find.byKey(const Key('networkMapSelectedLineOverlay')),
-    );
-    final painter = overlay.painter as dynamic;
-    expect(painter.visibleEdgeCount as int, 1);
-    expect(painter.visibleStationCount as int, 3);
   });
 
   testWidgets('노선도 viewport 밖 station semantics는 생성하지 않는다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

close #927

## 작업 배경

#836 노선도 Android profile gesture 측정에서 janky frame과 camera latency는 기준 안으로 들어왔지만, 좌우 패닝 중 frame p95/p99가 남아 있었다. QA 요청으로 노선도 화면의 `노선별로 보기`, `노선도별로 보기`, `전체 노선` 같은 노선 필터/우회 UI도 함께 제거 대상이다.

## 작업 내용

- gesture 중 route-map renderer full viewBox commit 기준을 더 보수적으로 조정하고 overscan을 키워 좌우 패닝 중 platform view camera 재요청을 줄였다.
- renderer dispose monitor를 dispose 완료 전까지 유지해 route-map 이탈 후 `routeMapRenderer disposed` 증거가 남도록 했다.
- 노선도 화면의 `전체 노선` 드롭다운, 선택 노선 overlay, 관련 hit-test boost와 전용 painter를 제거했다.
- widget test를 새 동작 기준으로 갱신해 노선도는 전체 지도에서 바로 역 선택을 유지하고, 노선 필터/우회 sheet는 노출하지 않음을 검증한다.

## 검증

- 실행한 명령과 결과:
- `dart format apps/mobile/lib/network_map.dart apps/mobile/test/widget_test.dart`: exit 0
- `flutter test test/widget_test.dart --plain-name "노선도"`: exit 0, 19 tests passed
- `flutter test test/widget_test.dart`: exit 0, 150 tests passed
- `flutter analyze`: exit 0, No issues found
- `node --test tools/ci/repository-contract.test.mjs`: exit 0, 106 tests passed
- `git diff --check`: exit 0
- `flutter build apk --profile`: exit 0, `app-profile.apk (96.3MB)` 생성
- `/Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb -s RFKYA01VMQY install -r apps/mobile/build/app/outputs/flutter-apk/app-profile.apk`: exit 0, Success
- `tools/mobile/run-route-map-android-evidence.sh --serial RFKYA01VMQY --build-mode profile --artifact-dir .codex/evidence/927/android-gesture-profile-run-3 --measure-after-route-map-settle --settle-seconds 8`: exit 0
- `tools/mobile/run-route-map-android-evidence.sh --serial RFKYA01VMQY --build-mode profile --artifact-dir .codex/evidence/927/android-gesture-profile-run-4 --measure-after-route-map-settle --settle-seconds 8`: exit 0
- `tools/mobile/run-route-map-android-evidence.sh --serial RFKYA01VMQY --build-mode profile --artifact-dir .codex/evidence/927/android-gesture-profile-run-5 --measure-after-route-map-settle --settle-seconds 8`: exit 0
- `node tools/mobile/analyze-route-map-android-evidence.mjs --artifact-dir .codex/evidence/927/android-gesture-profile-run-3 --artifact-dir .codex/evidence/927/android-gesture-profile-run-4 --artifact-dir .codex/evidence/927/android-gesture-profile-run-5 --format markdown`: exit 0, max janky 0.16%, max p95 14ms, max p99 26ms, max camera p95 48ms, dispose true
- `rg -n "노선별로 보기|노선도별로 보기|노선별 역 보기|노선별 목록에서|전체 노선|전체 노선도" .codex/evidence/927/android-gesture-profile-run-3/route-map.xml .codex/evidence/927/android-gesture-profile-run-4/route-map.xml .codex/evidence/927/android-gesture-profile-run-5/route-map.xml`: exit 1, 금지 문구 없음
- GitHub CI: `Android CI`, `Mobile App CI`, `Repository CI`, `Backend CI`, `Dependency Vulnerability Scan / osv-scan`, `Android Release Artifact` 모두 pass
- CodeRabbit: Review completed, actionable comments 0
- Review threads: GraphQL `reviewThreads.nodes` empty

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| gesture frame budget | SM-A175N / Android 16 / profile | route-map settle 이후 좌우 swipe 3회 runner aggregate | local `.codex/evidence/927/android-gesture-profile-run-3`, `run-4`, `run-5`; analyzer output: max janky 0.16%, max p95 14ms, max p99 26ms, max camera p95 48ms | #836 frame/jank/camera 기준 충족 |
| renderer reclaim | SM-A175N / Android 16 / profile | route-map 이탈 후 renderer log 확인 | local `route-map-renderer.log`; 3회 모두 `routeMapRenderer disposed` 관측 | 통과 |
| 노선도 필터 제거 | SM-A175N / Android 16 / profile | route-map UI tree forbidden string search | local `route-map.xml`; `전체 노선`, `전체 노선도`, `노선별로 보기`, `노선도별로 보기` 검색 exit 1 | 통과 |
| widget regression | Flutter test | 노선도/전체 widget test | command output | 19/19, 150/150 통과 |
| CI/release artifact | GitHub Actions | PR checks | PR #928 checks | 통과 |

실기기 screenshot, UI tree, logcat은 QA 장비 화면과 로컬 런타임 로그를 포함해 git에 커밋하지 않고 `.codex/evidence/927/` 아래 로컬 전용으로 보관했다. PR에는 민감하지 않은 aggregate 수치와 command 결과를 기록했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/network_map.dart`의 renderer commit threshold/overscan 조정과 `_releaseRenderer` dispose monitor 유지 방식.
- QA 요청에 따라 노선도 화면의 `전체 노선` 필터와 선택 노선 overlay는 복구하지 않는 방향이 맞다. 역 검색 화면의 노선 필터는 별도 흐름이라 유지했다.

## 리스크

- overscan을 키워 gesture 중 WebView viewBox 갱신을 줄였기 때문에 극단적인 고속 패닝에서는 renderer가 더 넓은 source rect를 들고 transform으로 따라간다. 실기기 3회 측정에서는 frame p95/p99와 camera latency가 모두 기준 안에 들어왔다.
- Flutter CLI는 startup lock을 공유하므로 로컬 검증 중 analyze/test를 병렬 실행하면 ephemeral 파일 충돌이 날 수 있다. 최종 검증은 순차 실행으로 통과했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.