### PR TITLE
[Fix] 노선도 좌표 shape 감사 보강

### DIFF
--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -96,6 +96,45 @@ function addFinding(findings, finding) {
   });
 }
 
+function isNonNegativeInteger(value) {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function isNonNegativeFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function polygonArea(points) {
+  let area = 0;
+  for (let index = 0; index < points.length; index += 1) {
+    const current = points[index];
+    const next = points[(index + 1) % points.length];
+    area += current.x * next.y - next.x * current.y;
+  }
+  return Math.abs(area / 2);
+}
+
+function labelPolygonError(value) {
+  if (value === undefined || value === null || value === "") {
+    return "";
+  }
+  if (!Array.isArray(value) || value.length < 3) {
+    return "labelPolygon must be a polygon with at least three points.";
+  }
+  for (const [index, point] of value.entries()) {
+    if (!point || typeof point !== "object" || Array.isArray(point)) {
+      return `labelPolygon[${index}] must be an object point.`;
+    }
+    if (!isNonNegativeFiniteNumber(point.x) || !isNonNegativeFiniteNumber(point.y)) {
+      return `labelPolygon[${index}] must contain finite non-negative x/y.`;
+    }
+  }
+  if (polygonArea(value) <= 0) {
+    return "labelPolygon area must be greater than 0.";
+  }
+  return "";
+}
+
 function reviewedAmbiguityEntries(raw) {
   if (Array.isArray(raw)) {
     return raw;
@@ -182,6 +221,31 @@ function auditPack(pack, reviewedAmbiguities) {
     }
     positionKeys.add(key);
     positionedStationLineKeys.add(stationLineKey);
+
+    if (!isNonNegativeInteger(position.x) || !isNonNegativeInteger(position.y)) {
+      addFinding(findings, {
+        severity: "BLOCKER",
+        code: "INVALID_ROUTE_MAP_COORDINATE",
+        packId: pack.id,
+        region: position.region,
+        lineId: position.lineId,
+        stationId: position.stationId,
+        message: "routeMapPositions x/y must be finite non-negative integers.",
+      });
+    }
+
+    const polygonError = labelPolygonError(position.labelPolygon);
+    if (polygonError) {
+      addFinding(findings, {
+        severity: "BLOCKER",
+        code: "INVALID_ROUTE_MAP_LABEL_POLYGON",
+        packId: pack.id,
+        region: position.region,
+        lineId: position.lineId,
+        stationId: position.stationId,
+        message: polygonError,
+      });
+    }
 
     if (!stationLineKeys.has(stationLineKey)) {
       addFinding(findings, {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -336,9 +336,14 @@ test("route map position audit reports broken production geometry rows", async (
     const jeongja = pack.routeMapPositions.find(
       (row) => row.stationId === "station-jeongja",
     );
+    jeongja.x = -1;
     jeongja.sourceId = "";
     jeongja.sourceUrl = "";
     delete jeongja.reviewedAt;
+    gangnamLine2.labelPolygon = [
+      { x: 1, y: 1 },
+      { x: 2, y: 2 },
+    ];
     await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
 
     await assert.rejects(
@@ -355,12 +360,14 @@ test("route map position audit reports broken production geometry rows", async (
       ),
       (error) => {
         const output = JSON.parse(error.stdout);
-        assert.equal(output.summary.findingsBySeverity.BLOCKER, 2);
+        assert.equal(output.summary.findingsBySeverity.BLOCKER, 4);
         assert.equal(output.summary.findingsBySeverity.HIGH, 3);
         assert.deepEqual(
           output.findings.map((finding) => finding.code).sort(),
           [
             "DUPLICATE_SOURCE_COORDINATE",
+            "INVALID_ROUTE_MAP_COORDINATE",
+            "INVALID_ROUTE_MAP_LABEL_POLYGON",
             "MISSING_ROUTE_MAP_POSITION",
             "MISSING_ROUTE_MAP_REVIEW",
             "MISSING_ROUTE_MAP_SOURCE",


### PR DESCRIPTION
## 관련 이슈

close #934

## 작업 배경

#836 production 좌표 감사 기준은 좌표 누락뿐 아니라 NaN/Infinity, 음수 좌표, invalid label polygon 같은 app crash 가능 geometry 오류를 BLOCKER로 분류한다. Data Pack Release audit gate는 build 전에 실행되므로, 좌표 shape 오류도 build 단계보다 먼저 audit report에서 확인할 수 있어야 한다.

## 작업 내용

- `audit-route-map.mjs`가 `routeMapPositions.x/y`를 finite non-negative integer로 검사하도록 했다.
- `labelPolygon`이 제공된 row는 3점 이상, finite non-negative point, area > 0 조건을 검사하도록 했다.
- broken production geometry test가 `INVALID_ROUTE_MAP_COORDINATE`, `INVALID_ROUTE_MAP_LABEL_POLYGON` finding code를 확인하도록 보강했다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/route-map/*.test.mjs`: exit 0, 8 passed
- `node --test --test-name-pattern "데이터팩 workflow는 pack 검증 이후 manifest 배포 순서를 강제한다" tools/ci/repository-contract.test.mjs`: exit 0, 1 passed
- `git diff --check`: exit 0
- `node tools/route-map/audit-route-map.mjs --fixture tools/datapack/fixtures/catalog-fixture.json --reviewed-ambiguities tools/route-map/fixtures/reviewed-ambiguities.json --fail-on BLOCKER,HIGH --pretty`: exit 0, BLOCKER/HIGH 0
- GitHub Actions CI run `28219062113`: Changes, Repository CI, Backend CI, Mobile App CI, Android CI, Dependency Vulnerability Scan 모두 pass
- GitHub Actions Release Artifacts run `28219061980`: Changes pass, Android Release Artifact/Backend Release Image skipped
- CodeRabbit: rate limit으로 실제 review 시작 불가 확인
- Codex CLI fallback review: actionable 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| coordinate shape audit | Node.js | route-map tool tests | command output | 8 passed |
| release audit gate 유지 | Node.js | repository contract single test | command output | 1 passed |
| clean fixture audit | Node.js | release workflow와 같은 audit command | command output | BLOCKER 0, HIGH 0 |
| PR CI | GitHub Actions | CI workflow | https://github.com/AquilaXk/easysubway/actions/runs/28219062113 | pass |
| release artifact gate | GitHub Actions | Release Artifacts workflow | https://github.com/AquilaXk/easysubway/actions/runs/28219061980 | non-release scope jobs skipped |
| fallback review | GitHub PR review | Codex CLI review | PR review `4576901001` | actionable 0 |

증거 불필요 사유: UI 변경이 아니며 route-map audit script와 test 변경이라 화면 캡처는 필요하지 않다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `labelPolygon`은 현재 모든 row 필수가 아니라, 값이 제공된 경우만 shape를 검증한다.
- 새 파일이나 새 workflow는 만들지 않고 기존 release audit command가 그대로 새 검사를 포함한다.

## 리스크

- 앞으로 production fixture에 음수/비정수 node 좌표 또는 invalid `labelPolygon`이 들어오면 Data Pack Release audit gate에서 build 전에 실패한다. 의도된 차단이다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
