### PR TITLE
[Fix] 노선도 label polygon 중첩 감사 추가

### DIFF
--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -114,6 +114,22 @@ function polygonArea(points) {
   return Math.abs(area / 2);
 }
 
+function polygonBounds(points) {
+  return points.reduce(
+    (bounds, point) => ({
+      minX: Math.min(bounds.minX, point.x),
+      minY: Math.min(bounds.minY, point.y),
+      maxX: Math.max(bounds.maxX, point.x),
+      maxY: Math.max(bounds.maxY, point.y),
+    }),
+    { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity },
+  );
+}
+
+function boundsOverlap(a, b) {
+  return a.minX < b.maxX && a.maxX > b.minX && a.minY < b.maxY && a.maxY > b.minY;
+}
+
 function labelPolygonError(value) {
   if (value === undefined || value === null || value === "") {
     return "";
@@ -204,6 +220,7 @@ function auditPack(pack, reviewedAmbiguities) {
   const positionKeys = new Set();
   const positionedStationLineKeys = new Set();
   const coordinateGroups = new Map();
+  const labelPolygons = [];
 
   for (const position of positions) {
     const key = routeMapPositionKeyFor(position);
@@ -244,6 +261,11 @@ function auditPack(pack, reviewedAmbiguities) {
         lineId: position.lineId,
         stationId: position.stationId,
         message: polygonError,
+      });
+    } else if (Array.isArray(position.labelPolygon) && position.labelPolygon.length >= 3) {
+      labelPolygons.push({
+        position,
+        bounds: polygonBounds(position.labelPolygon),
       });
     }
 
@@ -314,6 +336,28 @@ function auditPack(pack, reviewedAmbiguities) {
     const group = coordinateGroups.get(coordinateKey) ?? [];
     group.push(position);
     coordinateGroups.set(coordinateKey, group);
+  }
+
+  for (let leftIndex = 0; leftIndex < labelPolygons.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < labelPolygons.length; rightIndex += 1) {
+      const left = labelPolygons[leftIndex];
+      const right = labelPolygons[rightIndex];
+      if (normalizedText(left.position.region) !== normalizedText(right.position.region)) {
+        continue;
+      }
+      if (!boundsOverlap(left.bounds, right.bounds)) {
+        continue;
+      }
+      addFinding(findings, {
+        severity: "MEDIUM",
+        code: "OVERLAPPING_ROUTE_MAP_LABEL_POLYGON",
+        packId: pack.id,
+        region: left.position.region,
+        lineId: left.position.lineId,
+        stationId: `${left.position.stationId},${right.position.stationId}`,
+        message: "routeMapPositions labelPolygon bounding boxes overlap.",
+      });
+    }
   }
 
   for (const membership of stationLines) {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -382,6 +382,59 @@ test("route map position audit reports broken production geometry rows", async (
   }
 });
 
+test("route map position audit reports overlapping label polygons as medium", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
+  try {
+    const fixturePath = path.join(tmp, "overlap-catalog-fixture.json");
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+        "utf8",
+      ),
+    );
+    const pack = fixture.packs[0];
+    const sadangLine2 = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-sadang" && row.lineId === "seoul-2",
+    );
+    const gangnamLine2 = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-gangnam" && row.lineId === "seoul-2",
+    );
+    sadangLine2.labelPolygon = [
+      { x: 100, y: 100 },
+      { x: 140, y: 100 },
+      { x: 140, y: 120 },
+      { x: 100, y: 120 },
+    ];
+    gangnamLine2.labelPolygon = [
+      { x: 130, y: 110 },
+      { x: 170, y: 110 },
+      { x: 170, y: 130 },
+      { x: 130, y: 130 },
+    ];
+    await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "tools/route-map/audit-route-map.mjs",
+        "--fixture",
+        fixturePath,
+        "--fail-on",
+        "BLOCKER,HIGH",
+      ],
+      { cwd: root, maxBuffer: 1024 * 1024 },
+    );
+    const output = JSON.parse(stdout);
+
+    assert.equal(output.summary.findingsBySeverity.BLOCKER, 0);
+    assert.equal(output.summary.findingsBySeverity.HIGH, 0);
+    assert.equal(output.summary.findingsBySeverity.MEDIUM, 1);
+    assert.equal(output.findings[0].code, "OVERLAPPING_ROUTE_MAP_LABEL_POLYGON");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("MOLIT nationwide fixture builder emits route map source hashes", async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-source-sha-"));
   try {


### PR DESCRIPTION
## 관련 이슈

close #936

## 작업 배경

#836 production 좌표 감사 계획은 label polygon overlap을 감사 항목으로 둔다. 기존 audit는 coverage/source/중복 좌표/shape 오류를 잡지만, 두 역 label polygon이 서로 겹쳐 hit-test ambiguity 후보가 되는 상황은 보고하지 않았다.

## 작업 내용

- `audit-route-map.mjs`가 유효한 `labelPolygon`의 bbox를 수집한다.
- 같은 region 안에서 서로 다른 route map label polygon bbox가 겹치면 `OVERLAPPING_ROUTE_MAP_LABEL_POLYGON` MEDIUM finding을 남긴다.
- MEDIUM finding은 `--fail-on BLOCKER,HIGH` release gate를 차단하지 않도록 유지했다.
- route-map tool test가 overlap finding code와 severity를 검증하도록 보강했다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/route-map/*.test.mjs`: exit 0, 9 passed
- `node tools/route-map/audit-route-map.mjs --fixture tools/datapack/fixtures/catalog-fixture.json --reviewed-ambiguities tools/route-map/fixtures/reviewed-ambiguities.json --fail-on BLOCKER,HIGH --pretty`: exit 0, BLOCKER/HIGH/MEDIUM 0
- `node --test --test-name-pattern "데이터팩 workflow는 pack 검증 이후 manifest 배포 순서를 강제한다" tools/ci/repository-contract.test.mjs`: exit 0, 1 passed
- `git diff --check`: exit 0
- GitHub CI: CI run 28219301908 pass, Release Artifacts run 28219301748 pass/skipped as expected
- CodeRabbit: rate limit으로 실제 review 시작 불가
- Codex CLI fallback review: actionable 0, nitpick 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| label polygon overlap audit | Node.js | route-map tool tests | local command output | 9 passed |
| clean fixture audit | Node.js | release workflow와 같은 audit command | local command output | BLOCKER 0, HIGH 0, MEDIUM 0 |
| release audit gate 유지 | Node.js | repository contract single test | local command output | 1 passed |
| PR CI | GitHub Actions | PR checks | https://github.com/AquilaXk/easysubway/actions/runs/28219301908 | pass |
| Release Artifacts 영향 | GitHub Actions | path filter와 release artifact checks | https://github.com/AquilaXk/easysubway/actions/runs/28219301748 | Changes pass, artifact jobs skipped as expected |
| CodeRabbit 상태 | GitHub PR comment/status | existing CodeRabbit bot comment 확인 | https://github.com/AquilaXk/easysubway/pull/937#issuecomment-4806653079 | rate limit으로 review 미시작 |
| Codex CLI fallback review | GitHub PR review | summary-only review 게시 | https://github.com/AquilaXk/easysubway/pull/937#pullrequestreview-4576929551 | actionable 0, nitpick 0 |

증거 불필요 사유: UI 변경이 아니며 route-map audit script와 test 변경이라 화면 캡처는 필요하지 않다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: overlap은 bbox 기반 후보 보고이며 MEDIUM으로만 기록한다.
- 정밀 polygon intersection은 지금 추가하지 않았다. 감사 후보 노출에는 bbox가 충분하고, release 차단 기준을 올리지 않는다.

## 리스크

- 실제 polygon이 겹치지 않아도 bbox가 겹치면 MEDIUM 후보가 나올 수 있다. release gate는 BLOCKER/HIGH만 실패하므로 검수 신호로만 사용한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 없으며 merge 후 CD 실패 여부만 확인한다.