### PR TITLE
[Fix] 노선도 지역별 좌표 coverage 감사 추가

### DIFF
--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -169,12 +169,17 @@ function coverageRatio(coveredCount, totalCount) {
 function regionCoverageSummaries(stationLines, positions) {
   const lineIdsByRegion = new Map();
   const positionKeysByRegion = new Map();
+  const positionCountsByRegion = new Map();
   for (const position of positions) {
     const region = normalizedText(position.region);
     const lineId = normalizedText(position.lineId);
     if (!region || !lineId) {
       continue;
     }
+    positionCountsByRegion.set(
+      region,
+      (positionCountsByRegion.get(region) ?? 0) + 1,
+    );
     const lineIds = lineIdsByRegion.get(region) ?? new Set();
     lineIds.add(lineId);
     lineIdsByRegion.set(region, lineIds);
@@ -196,7 +201,7 @@ function regionCoverageSummaries(stationLines, positions) {
       return {
         region,
         stationLineCount: stationLineKeys.length,
-        routeMapPositionCount: positionKeys.size,
+        routeMapPositionCount: positionCountsByRegion.get(region) ?? 0,
         coveredStationLineCount: coveredCount,
         coverageRatio: coverageRatio(coveredCount, stationLineKeys.length),
       };

--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -70,6 +70,13 @@ function stationLineRegionKeyFor(row, region) {
   return `${normalizedText(region)}\u0000${row.stationId ?? ""}\u0000${row.lineId ?? ""}`;
 }
 
+function coverageKeyForStationLine(row, stationsById) {
+  const region = normalizedText(
+    stationsById.get(normalizedText(row.stationId))?.region,
+  );
+  return region ? stationLineRegionKeyFor(row, region) : stationLineKeyFor(row);
+}
+
 function routeMapPositionKeyFor(row) {
   return `${row.stationId ?? ""}\u0000${row.lineId ?? ""}\u0000${row.region ?? ""}`;
 }
@@ -297,16 +304,13 @@ function auditPack(pack, reviewedAmbiguities) {
     ? pack.routeMapPositions
     : [];
   const stationLineKeys = new Set(stationLines.map(stationLineKeyFor));
-  const stationLineRegionKeys = new Set(
+  const stationLineCoverageKeys = new Set(
     stationLines.map((stationLine) =>
-      stationLineRegionKeyFor(
-        stationLine,
-        stationsById.get(normalizedText(stationLine.stationId))?.region,
-      ),
+      coverageKeyForStationLine(stationLine, stationsById),
     ),
   );
   const positionKeys = new Set();
-  const positionedStationLineRegionKeys = new Set();
+  const positionedStationLineCoverageKeys = new Set();
   const coordinateGroups = new Map();
   const labelPolygons = [];
 
@@ -325,7 +329,8 @@ function auditPack(pack, reviewedAmbiguities) {
       });
     }
     positionKeys.add(key);
-    positionedStationLineRegionKeys.add(
+    positionedStationLineCoverageKeys.add(stationLineKey);
+    positionedStationLineCoverageKeys.add(
       stationLineRegionKeyFor(position, position.region),
     );
 
@@ -471,10 +476,9 @@ function auditPack(pack, reviewedAmbiguities) {
   }
 
   for (const membership of stationLines) {
-    const station = stationsById.get(normalizedText(membership.stationId));
     if (
-      positionedStationLineRegionKeys.has(
-        stationLineRegionKeyFor(membership, station?.region),
+      positionedStationLineCoverageKeys.has(
+        coverageKeyForStationLine(membership, stationsById),
       )
     ) {
       continue;
@@ -544,12 +548,12 @@ function auditPack(pack, reviewedAmbiguities) {
     summary: {
       stationLineCount: stationLines.length,
       routeMapPositionCount: positions.length,
-      coveredStationLineCount: [...stationLineRegionKeys].filter((key) =>
-        positionedStationLineRegionKeys.has(key),
+      coveredStationLineCount: [...stationLineCoverageKeys].filter((key) =>
+        positionedStationLineCoverageKeys.has(key),
       ).length,
       coverageRatio: coverageRatio(
-        [...stationLineRegionKeys].filter((key) =>
-          positionedStationLineRegionKeys.has(key),
+        [...stationLineCoverageKeys].filter((key) =>
+          positionedStationLineCoverageKeys.has(key),
         ).length,
         stationLines.length,
       ),

--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -160,6 +160,50 @@ function labelPolygonError(value) {
   return "";
 }
 
+function coverageRatio(coveredCount, totalCount) {
+  return totalCount === 0
+    ? 1
+    : Number((coveredCount / totalCount).toFixed(4));
+}
+
+function regionCoverageSummaries(stationLines, positions) {
+  const lineIdsByRegion = new Map();
+  const positionKeysByRegion = new Map();
+  for (const position of positions) {
+    const region = normalizedText(position.region);
+    const lineId = normalizedText(position.lineId);
+    if (!region || !lineId) {
+      continue;
+    }
+    const lineIds = lineIdsByRegion.get(region) ?? new Set();
+    lineIds.add(lineId);
+    lineIdsByRegion.set(region, lineIds);
+
+    const keys = positionKeysByRegion.get(region) ?? new Set();
+    keys.add(stationLineKeyFor(position));
+    positionKeysByRegion.set(region, keys);
+  }
+
+  return [...lineIdsByRegion.entries()]
+    .map(([region, lineIds]) => {
+      const stationLineKeys = stationLines
+        .filter((row) => lineIds.has(normalizedText(row.lineId)))
+        .map(stationLineKeyFor);
+      const positionKeys = positionKeysByRegion.get(region) ?? new Set();
+      const coveredCount = stationLineKeys.filter((key) =>
+        positionKeys.has(key),
+      ).length;
+      return {
+        region,
+        stationLineCount: stationLineKeys.length,
+        routeMapPositionCount: positionKeys.size,
+        coveredStationLineCount: coveredCount,
+        coverageRatio: coverageRatio(coveredCount, stationLineKeys.length),
+      };
+    })
+    .sort((a, b) => a.region.localeCompare(b.region));
+}
+
 function reviewedAmbiguityEntries(raw) {
   if (Array.isArray(raw)) {
     return raw;
@@ -467,16 +511,12 @@ function auditPack(pack, reviewedAmbiguities) {
       coveredStationLineCount: [...stationLineKeys].filter((key) =>
         positionedStationLineKeys.has(key),
       ).length,
-      coverageRatio:
-        stationLines.length === 0
-          ? 1
-          : Number(
-              (
-                [...stationLineKeys].filter((key) =>
-                  positionedStationLineKeys.has(key),
-                ).length / stationLines.length
-              ).toFixed(4),
-            ),
+      coverageRatio: coverageRatio(
+        [...stationLineKeys].filter((key) => positionedStationLineKeys.has(key))
+          .length,
+        stationLines.length,
+      ),
+      regions: regionCoverageSummaries(stationLines, positions),
       findingsBySeverity: findingCounts,
     },
     findings: findings.sort((a, b) => {

--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -66,6 +66,10 @@ function stationLineKeyFor(row) {
   return `${row.stationId ?? ""}\u0000${row.lineId ?? ""}`;
 }
 
+function stationLineRegionKeyFor(row, region) {
+  return `${normalizedText(region)}\u0000${row.stationId ?? ""}\u0000${row.lineId ?? ""}`;
+}
+
 function routeMapPositionKeyFor(row) {
   return `${row.stationId ?? ""}\u0000${row.lineId ?? ""}\u0000${row.region ?? ""}`;
 }
@@ -293,8 +297,16 @@ function auditPack(pack, reviewedAmbiguities) {
     ? pack.routeMapPositions
     : [];
   const stationLineKeys = new Set(stationLines.map(stationLineKeyFor));
+  const stationLineRegionKeys = new Set(
+    stationLines.map((stationLine) =>
+      stationLineRegionKeyFor(
+        stationLine,
+        stationsById.get(normalizedText(stationLine.stationId))?.region,
+      ),
+    ),
+  );
   const positionKeys = new Set();
-  const positionedStationLineKeys = new Set();
+  const positionedStationLineRegionKeys = new Set();
   const coordinateGroups = new Map();
   const labelPolygons = [];
 
@@ -313,7 +325,9 @@ function auditPack(pack, reviewedAmbiguities) {
       });
     }
     positionKeys.add(key);
-    positionedStationLineKeys.add(stationLineKey);
+    positionedStationLineRegionKeys.add(
+      stationLineRegionKeyFor(position, position.region),
+    );
 
     if (!isNonNegativeInteger(position.x) || !isNonNegativeInteger(position.y)) {
       addFinding(findings, {
@@ -457,7 +471,12 @@ function auditPack(pack, reviewedAmbiguities) {
   }
 
   for (const membership of stationLines) {
-    if (positionedStationLineKeys.has(stationLineKeyFor(membership))) {
+    const station = stationsById.get(normalizedText(membership.stationId));
+    if (
+      positionedStationLineRegionKeys.has(
+        stationLineRegionKeyFor(membership, station?.region),
+      )
+    ) {
       continue;
     }
     addFinding(findings, {
@@ -525,12 +544,13 @@ function auditPack(pack, reviewedAmbiguities) {
     summary: {
       stationLineCount: stationLines.length,
       routeMapPositionCount: positions.length,
-      coveredStationLineCount: [...stationLineKeys].filter((key) =>
-        positionedStationLineKeys.has(key),
+      coveredStationLineCount: [...stationLineRegionKeys].filter((key) =>
+        positionedStationLineRegionKeys.has(key),
       ).length,
       coverageRatio: coverageRatio(
-        [...stationLineKeys].filter((key) => positionedStationLineKeys.has(key))
-          .length,
+        [...stationLineRegionKeys].filter((key) =>
+          positionedStationLineRegionKeys.has(key),
+        ).length,
         stationLines.length,
       ),
       regions: regionCoverageSummaries(stationsById, stationLines, positions),

--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -166,10 +166,22 @@ function coverageRatio(coveredCount, totalCount) {
     : Number((coveredCount / totalCount).toFixed(4));
 }
 
-function regionCoverageSummaries(stationLines, positions) {
-  const lineIdsByRegion = new Map();
+function regionCoverageSummaries(stationsById, stationLines, positions) {
+  const stationLineKeysByRegion = new Map();
   const positionKeysByRegion = new Map();
   const positionCountsByRegion = new Map();
+  for (const stationLine of stationLines) {
+    const region = normalizedText(
+      stationsById.get(normalizedText(stationLine.stationId))?.region,
+    );
+    if (!region) {
+      continue;
+    }
+    const keys = stationLineKeysByRegion.get(region) ?? new Set();
+    keys.add(stationLineKeyFor(stationLine));
+    stationLineKeysByRegion.set(region, keys);
+  }
+
   for (const position of positions) {
     const region = normalizedText(position.region);
     const lineId = normalizedText(position.lineId);
@@ -180,20 +192,20 @@ function regionCoverageSummaries(stationLines, positions) {
       region,
       (positionCountsByRegion.get(region) ?? 0) + 1,
     );
-    const lineIds = lineIdsByRegion.get(region) ?? new Set();
-    lineIds.add(lineId);
-    lineIdsByRegion.set(region, lineIds);
 
     const keys = positionKeysByRegion.get(region) ?? new Set();
     keys.add(stationLineKeyFor(position));
     positionKeysByRegion.set(region, keys);
   }
 
-  return [...lineIdsByRegion.entries()]
-    .map(([region, lineIds]) => {
-      const stationLineKeys = stationLines
-        .filter((row) => lineIds.has(normalizedText(row.lineId)))
-        .map(stationLineKeyFor);
+  return [
+    ...new Set([
+      ...stationLineKeysByRegion.keys(),
+      ...positionCountsByRegion.keys(),
+    ]),
+  ]
+    .map((region) => {
+      const stationLineKeys = [...(stationLineKeysByRegion.get(region) ?? [])];
       const positionKeys = positionKeysByRegion.get(region) ?? new Set();
       const coveredCount = stationLineKeys.filter((key) =>
         positionKeys.has(key),
@@ -521,7 +533,7 @@ function auditPack(pack, reviewedAmbiguities) {
           .length,
         stationLines.length,
       ),
-      regions: regionCoverageSummaries(stationLines, positions),
+      regions: regionCoverageSummaries(stationsById, stationLines, positions),
       findingsBySeverity: findingCounts,
     },
     findings: findings.sort((a, b) => {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -128,6 +128,64 @@ test("route map position audit allows same station-line in another region", asyn
   }
 });
 
+test("route map position audit reports wrong-region coverage gaps", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
+  try {
+    const fixturePath = path.join(tmp, "wrong-region-catalog-fixture.json");
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+        "utf8",
+      ),
+    );
+    const routePosition = fixture.packs[0].routeMapPositions.find(
+      (row) => row.stationId === "station-sadang" && row.lineId === "seoul-2",
+    );
+    routePosition.region = "전국";
+    await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
+
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          "tools/route-map/audit-route-map.mjs",
+          "--fixture",
+          fixturePath,
+          "--fail-on",
+          "BLOCKER,HIGH",
+        ],
+        { cwd: root, maxBuffer: 1024 * 1024 },
+      ),
+      (error) => {
+        const output = JSON.parse(error.stdout);
+        assert.equal(output.summary.findingsBySeverity.BLOCKER, 1);
+        assert.equal(output.findings[0].code, "MISSING_ROUTE_MAP_POSITION");
+        assert.equal(output.packs[0].summary.coveredStationLineCount, 8);
+        assert.equal(output.packs[0].summary.coverageRatio, 0.8889);
+        assert.deepEqual(output.packs[0].summary.regions, [
+          {
+            region: "수도권",
+            stationLineCount: 9,
+            routeMapPositionCount: 8,
+            coveredStationLineCount: 8,
+            coverageRatio: 0.8889,
+          },
+          {
+            region: "전국",
+            stationLineCount: 0,
+            routeMapPositionCount: 1,
+            coveredStationLineCount: 0,
+            coverageRatio: 1,
+          },
+        ]);
+        return true;
+      },
+    );
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("route map position audit reports region coverage gaps", async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
   try {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -175,6 +175,53 @@ test("route map position audit reports region coverage gaps", async () => {
   }
 });
 
+test("route map position audit reports whole-line region coverage gaps", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
+  try {
+    const fixturePath = path.join(tmp, "region-line-gap-catalog-fixture.json");
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+        "utf8",
+      ),
+    );
+    fixture.packs[0].routeMapPositions = fixture.packs[0].routeMapPositions.filter(
+      (row) => row.lineId !== "seoul-2-branch",
+    );
+    await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
+
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          "tools/route-map/audit-route-map.mjs",
+          "--fixture",
+          fixturePath,
+          "--fail-on",
+          "BLOCKER,HIGH",
+        ],
+        { cwd: root, maxBuffer: 1024 * 1024 },
+      ),
+      (error) => {
+        const output = JSON.parse(error.stdout);
+        assert.equal(output.summary.findingsBySeverity.BLOCKER, 2);
+        assert.deepEqual(output.packs[0].summary.regions, [
+          {
+            region: "수도권",
+            stationLineCount: 9,
+            routeMapPositionCount: 7,
+            coveredStationLineCount: 7,
+            coverageRatio: 0.7778,
+          },
+        ]);
+        return true;
+      },
+    );
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("route map position audit keeps duplicate rows in region counts", async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
   try {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -186,6 +186,42 @@ test("route map position audit reports wrong-region coverage gaps", async () => 
   }
 });
 
+test("route map position audit falls back for regionless stations", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
+  try {
+    const fixturePath = path.join(tmp, "regionless-station-catalog-fixture.json");
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+        "utf8",
+      ),
+    );
+    delete fixture.packs[0].stations[0].region;
+    await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "tools/route-map/audit-route-map.mjs",
+        "--fixture",
+        fixturePath,
+        "--fail-on",
+        "BLOCKER,HIGH",
+      ],
+      { cwd: root, maxBuffer: 1024 * 1024 },
+    );
+    const output = JSON.parse(stdout);
+
+    assert.equal(output.summary.findingsBySeverity.BLOCKER, 0);
+    assert.equal(output.packs[0].summary.coveredStationLineCount, 9);
+    assert.equal(output.packs[0].summary.coverageRatio, 1);
+    assert.equal(output.packs[0].summary.regions[0].stationLineCount, 8);
+    assert.equal(output.packs[0].summary.regions[0].routeMapPositionCount, 9);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("route map position audit reports region coverage gaps", async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
   try {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -72,6 +72,15 @@ test("route map position audit passes clean catalog fixture", async () => {
   assert.equal(output.packs[0].summary.stationLineCount, 9);
   assert.equal(output.packs[0].summary.routeMapPositionCount, 9);
   assert.equal(output.packs[0].summary.coverageRatio, 1);
+  assert.deepEqual(output.packs[0].summary.regions, [
+    {
+      region: "수도권",
+      stationLineCount: 9,
+      routeMapPositionCount: 9,
+      coveredStationLineCount: 9,
+      coverageRatio: 1,
+    },
+  ]);
 });
 
 test("route map position audit allows same station-line in another region", async () => {
@@ -114,6 +123,53 @@ test("route map position audit allows same station-line in another region", asyn
     assert.equal(output.packs[0].summary.stationLineCount, 9);
     assert.equal(output.packs[0].summary.routeMapPositionCount, 10);
     assert.equal(output.packs[0].summary.coverageRatio, 1);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("route map position audit reports region coverage gaps", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
+  try {
+    const fixturePath = path.join(tmp, "region-gap-catalog-fixture.json");
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+        "utf8",
+      ),
+    );
+    fixture.packs[0].routeMapPositions = fixture.packs[0].routeMapPositions.filter(
+      (row) => !(row.stationId === "station-sadang" && row.lineId === "seoul-2"),
+    );
+    await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
+
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          "tools/route-map/audit-route-map.mjs",
+          "--fixture",
+          fixturePath,
+          "--fail-on",
+          "BLOCKER,HIGH",
+        ],
+        { cwd: root, maxBuffer: 1024 * 1024 },
+      ),
+      (error) => {
+        const output = JSON.parse(error.stdout);
+        assert.equal(output.summary.findingsBySeverity.BLOCKER, 1);
+        assert.deepEqual(output.packs[0].summary.regions, [
+          {
+            region: "수도권",
+            stationLineCount: 9,
+            routeMapPositionCount: 8,
+            coveredStationLineCount: 8,
+            coverageRatio: 0.8889,
+          },
+        ]);
+        return true;
+      },
+    );
   } finally {
     await rm(tmp, { recursive: true, force: true });
   }

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -175,6 +175,53 @@ test("route map position audit reports region coverage gaps", async () => {
   }
 });
 
+test("route map position audit keeps duplicate rows in region counts", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
+  try {
+    const fixturePath = path.join(tmp, "duplicate-region-count-fixture.json");
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+        "utf8",
+      ),
+    );
+    fixture.packs[0].routeMapPositions.push({
+      ...fixture.packs[0].routeMapPositions[0],
+    });
+    await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
+
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          "tools/route-map/audit-route-map.mjs",
+          "--fixture",
+          fixturePath,
+          "--fail-on",
+          "BLOCKER,HIGH",
+        ],
+        { cwd: root, maxBuffer: 1024 * 1024 },
+      ),
+      (error) => {
+        const output = JSON.parse(error.stdout);
+        assert.equal(output.findings[0].code, "DUPLICATE_ROUTE_MAP_POSITION");
+        assert.equal(output.packs[0].summary.routeMapPositionCount, 10);
+        assert.equal(
+          output.packs[0].summary.regions[0].routeMapPositionCount,
+          10,
+        );
+        assert.equal(
+          output.packs[0].summary.regions[0].coveredStationLineCount,
+          9,
+        );
+        return true;
+      },
+    );
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("route map position audit reports missing source snapshot hash", async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
   try {


### PR DESCRIPTION
## 관련 이슈

close #940

## 작업 배경

#836 production 좌표 감사에서 pack 전체 coverage만 보면 특정 지역 노선도의 좌표 누락이나 잘못된 region 좌표를 바로 확인하기 어렵다. audit 산출물에 지역별 station-line coverage를 추가하고, wrong-region 좌표가 기존 `--fail-on BLOCKER,HIGH` gate를 우회하지 않도록 보강한다.

## 작업 내용

- `audit-route-map.mjs` pack summary에 `regions` 배열을 추가했다.
- 각 region summary는 `region`, `stationLineCount`, `routeMapPositionCount`, `coveredStationLineCount`, `coverageRatio`를 포함한다.
- region denominator는 관측된 좌표가 아니라 `stations.region`과 `stationLines` membership 기준으로 계산해, 특정 지역 line 좌표가 통째로 빠져도 coverage gap이 드러나게 했다.
- `routeMapPositionCount`는 raw row 수를 세고, covered count는 Set 기반으로 계산해 duplicate row가 coverage를 부풀리지 않게 했다.
- station region이 있으면 `region + stationId + lineId` 기준으로 coverage를 판정해 wrong-region 좌표를 누락으로 실패시킨다.
- station region이 없는 데이터는 기존 `stationId + lineId` coverage key로 fallback해 정상 좌표를 오탐하지 않는다.
- clean fixture, duplicate row, 일부 region gap, whole-line region gap, wrong-region, regionless station 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
- `node --test --test-name-pattern "route map position audit" tools/route-map/route-map-tools.test.mjs`: exit 0, 13 tests passed
- `node --test tools/route-map/*.test.mjs`: exit 0, 15 tests passed
- `node --test --test-name-pattern "데이터팩 workflow는 pack 검증 이후 manifest 배포 순서를 강제한다" tools/ci/repository-contract.test.mjs`: exit 0, 1 passed
- `git diff --check`: exit 0
- `node tools/route-map/audit-route-map.mjs --fixture /private/tmp/easysubway-940/generated-production-fixture.json --reviewed-ambiguities tools/route-map/fixtures/reviewed-ambiguities.json --fail-on BLOCKER,HIGH --pretty`: exit 0, production 5개 지역 coverageRatio 1, BLOCKER/HIGH 0, INFO 2
- GitHub Actions: Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan, osv-scanner pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| route-map audit 회귀 테스트 | macOS / Node.js | focused route-map audit test 실행 | local command output | 13 tests passed |
| route-map tool suite | macOS / Node.js | route-map tool 전체 테스트 실행 | local command output | 15 tests passed |
| release audit gate 유지 | macOS / Node.js | datapack workflow contract 단일 테스트 실행 | local command output | 1 test passed |
| generated production audit | macOS / Node.js | nationwide fixture audit를 `--fail-on BLOCKER,HIGH`로 실행 | local command output | 수도권/부산권/광주권/대구권/대전권 coverageRatio 1, BLOCKER/HIGH 0 |
| CI | GitHub Actions | PR #941 checks 확인 | https://github.com/AquilaXk/easysubway/actions/runs/28221636968 | Android CI, Backend CI, Mobile App CI, Repository CI pass |
| CodeRabbit 상태 | GitHub PR | 기존 CodeRabbit 상태와 rate limit comment 확인 | https://github.com/AquilaXk/easysubway/pull/941#issuecomment-4806793547 | rate limit으로 Codex CLI fallback 적용 |
| Codex CLI fallback review | GitHub PR review | `codex review --base origin/main --title "[Fix] 노선도 지역별 좌표 coverage 감사 추가"` 실행 후 PR review 게시 | https://github.com/AquilaXk/easysubway/pull/941#pullrequestreview-4577219813 | Actionable comments posted: 0 |

증거 불필요 사유: 이 PR은 route-map audit JSON 산출물과 CI gate 보강만 변경한다. 노선도 화면 성능과 실기기 영상 증거는 선행 PR #928에서 QA 요청 기준으로 확인했고, 현재 PR에는 UI 렌더러 변경이 없다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `coverageKeyForStationLine`과 `stationLineRegionKeyFor`의 분리로 region이 있는 역은 wrong-region 좌표를 실패시키고, region이 없는 역은 기존 coverage key로 fallback한다.
- region별 `routeMapPositionCount`는 raw row count라 duplicate row가 숨지 않는다.
- production fixture audit 결과는 5개 지역 모두 coverageRatio 1이며, 기존 reviewed ambiguity INFO 2건만 남는다.

## 리스크

- station metadata의 region이 비어 있는 데이터는 region별 denominator에서 제외되고 pack 전체 coverage fallback으로만 검증된다. 기존 builder는 production station에 region을 채우며, regionless fallback은 legacy/fixture 오탐 방지용이다.
- 이 PR은 감사 로직 보강이며 앱 UI를 직접 바꾸지 않는다. 노선도 좌우 이동 끊김 개선과 “전체 노선” UI 제거는 #928에서 별도 merged 상태다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
