### PR TITLE
[Test] 노선도 label polygon hit simulation 감사 추가

### DIFF
--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -230,12 +230,10 @@ function hitScore(point, position) {
   if (hasValidLabelPolygon(position.labelPolygon)) {
     return Math.min(nodeScore, distanceSquaredToPolygon(point, position.labelPolygon));
   }
-  if (!usesOfficialRouteMapSource(position)) {
-    return nodeScore;
-  }
+  const labelOffset = fallbackLabelOffset(position);
   const labelCenter = {
-    x: position.x + (position.labelDx ?? 0),
-    y: position.y + (position.labelDy ?? 0),
+    x: position.x + labelOffset.x,
+    y: position.y + labelOffset.y,
   };
   return Math.min(nodeScore, distanceSquared(point, labelCenter));
 }
@@ -246,6 +244,148 @@ function usesOfficialRouteMapSource(position) {
     sourceId.endsWith("-cyberstation") ||
     sourceId === "qa-wikimedia-seoul-svg-coordinate"
   );
+}
+
+function fallbackLabelOffset(position) {
+  if (usesOfficialRouteMapSource(position)) {
+    return {
+      x: position.labelDx ?? 0,
+      y: position.labelDy ?? 0,
+    };
+  }
+  const pathData = normalizedText(position.downPath) !== ""
+    ? position.downPath
+    : position.upPath;
+  if (normalizedText(pathData) === "") {
+    return { x: 8, y: 3 };
+  }
+  const bounds = pathBounds(pathData);
+  if (bounds == null) {
+    return { x: 8, y: 3 };
+  }
+  const width = bounds.maxX - bounds.minX;
+  const height = bounds.maxY - bounds.minY;
+  if (width > height * 1.2) {
+    return { x: 0, y: 12 };
+  }
+  if (height > width * 1.2) {
+    return { x: 9, y: 3 };
+  }
+  return { x: 8, y: -8 };
+}
+
+function pathBounds(pathData) {
+  const tokens = [...String(pathData).matchAll(/[A-Za-z]|-?\d+(?:\.\d+)?/g)]
+    .map((match) => match[0]);
+  let index = 0;
+  let command = "";
+  let current = { x: 0, y: 0 };
+  let lastControl = { x: 0, y: 0 };
+  const bounds = { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity };
+  const includePoint = (point) => {
+    bounds.minX = Math.min(bounds.minX, point.x);
+    bounds.minY = Math.min(bounds.minY, point.y);
+    bounds.maxX = Math.max(bounds.maxX, point.x);
+    bounds.maxY = Math.max(bounds.maxY, point.y);
+  };
+  const number = () => Number.parseFloat(tokens[index++]);
+  const point = () => ({ x: number(), y: number() });
+  const relativePoint = () => {
+    const value = point();
+    return { x: current.x + value.x, y: current.y + value.y };
+  };
+  while (index < tokens.length) {
+    if (/^[A-Za-z]$/.test(tokens[index])) {
+      command = tokens[index++];
+    }
+    switch (command) {
+      case "M":
+      case "L":
+        current = point();
+        includePoint(current);
+        break;
+      case "m":
+      case "l":
+        current = relativePoint();
+        includePoint(current);
+        break;
+      case "H":
+        current = { x: number(), y: current.y };
+        includePoint(current);
+        break;
+      case "h":
+        current = { x: current.x + number(), y: current.y };
+        includePoint(current);
+        break;
+      case "V":
+        current = { x: current.x, y: number() };
+        includePoint(current);
+        break;
+      case "v":
+        current = { x: current.x, y: current.y + number() };
+        includePoint(current);
+        break;
+      case "C": {
+        const c1 = point();
+        const c2 = point();
+        current = point();
+        lastControl = c2;
+        includePoint(c1);
+        includePoint(c2);
+        includePoint(current);
+        break;
+      }
+      case "c": {
+        const c1 = relativePoint();
+        const c2 = relativePoint();
+        current = relativePoint();
+        lastControl = c2;
+        includePoint(c1);
+        includePoint(c2);
+        includePoint(current);
+        break;
+      }
+      case "S": {
+        const c1 = { x: current.x * 2 - lastControl.x, y: current.y * 2 - lastControl.y };
+        const c2 = point();
+        current = point();
+        lastControl = c2;
+        includePoint(c1);
+        includePoint(c2);
+        includePoint(current);
+        break;
+      }
+      case "s": {
+        const c1 = { x: current.x * 2 - lastControl.x, y: current.y * 2 - lastControl.y };
+        const c2 = relativePoint();
+        current = relativePoint();
+        lastControl = c2;
+        includePoint(c1);
+        includePoint(c2);
+        includePoint(current);
+        break;
+      }
+      case "Q": {
+        const c = point();
+        current = point();
+        lastControl = c;
+        includePoint(c);
+        includePoint(current);
+        break;
+      }
+      case "q": {
+        const c = relativePoint();
+        current = relativePoint();
+        lastControl = c;
+        includePoint(c);
+        includePoint(current);
+        break;
+      }
+      default:
+        return bounds.minX === Infinity ? null : bounds;
+    }
+  }
+  return bounds.minX === Infinity ? null : bounds;
 }
 
 function labelPolygonError(value) {

--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -230,11 +230,22 @@ function hitScore(point, position) {
   if (hasValidLabelPolygon(position.labelPolygon)) {
     return Math.min(nodeScore, distanceSquaredToPolygon(point, position.labelPolygon));
   }
+  if (!usesOfficialRouteMapSource(position)) {
+    return nodeScore;
+  }
   const labelCenter = {
     x: position.x + (position.labelDx ?? 0),
     y: position.y + (position.labelDy ?? 0),
   };
   return Math.min(nodeScore, distanceSquared(point, labelCenter));
+}
+
+function usesOfficialRouteMapSource(position) {
+  const sourceId = normalizedText(position.sourceId);
+  return (
+    sourceId.endsWith("-cyberstation") ||
+    sourceId === "qa-wikimedia-seoul-svg-coordinate"
+  );
 }
 
 function labelPolygonError(value) {

--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -227,9 +227,14 @@ function distanceSquaredToPolygon(point, polygon) {
 
 function hitScore(point, position) {
   const nodeScore = distanceSquared(point, position);
-  return hasValidLabelPolygon(position.labelPolygon)
-    ? Math.min(nodeScore, distanceSquaredToPolygon(point, position.labelPolygon))
-    : nodeScore;
+  if (hasValidLabelPolygon(position.labelPolygon)) {
+    return Math.min(nodeScore, distanceSquaredToPolygon(point, position.labelPolygon));
+  }
+  const labelCenter = {
+    x: position.x + (position.labelDx ?? 0),
+    y: position.y + (position.labelDy ?? 0),
+  };
+  return Math.min(nodeScore, distanceSquared(point, labelCenter));
 }
 
 function labelPolygonError(value) {

--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -146,8 +146,90 @@ function polygonBounds(points) {
   );
 }
 
+function polygonCenter(points) {
+  const bounds = polygonBounds(points);
+  return {
+    x: (bounds.minX + bounds.maxX) / 2,
+    y: (bounds.minY + bounds.maxY) / 2,
+  };
+}
+
 function boundsOverlap(a, b) {
   return a.minX < b.maxX && a.maxX > b.minX && a.minY < b.maxY && a.maxY > b.minY;
+}
+
+function distanceSquared(a, b) {
+  return ((a.x - b.x) ** 2) + ((a.y - b.y) ** 2);
+}
+
+function distanceSquaredToSegment(point, start, end) {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const lengthSquared = dx * dx + dy * dy;
+  if (lengthSquared === 0) {
+    return distanceSquared(point, start);
+  }
+  const t = Math.max(
+    0,
+    Math.min(
+      1,
+      (((point.x - start.x) * dx) + ((point.y - start.y) * dy)) /
+        lengthSquared,
+    ),
+  );
+  return distanceSquared(point, {
+    x: start.x + dx * t,
+    y: start.y + dy * t,
+  });
+}
+
+function pointInPolygon(point, polygon) {
+  let inside = false;
+  for (
+    let index = 0, previous = polygon.length - 1;
+    index < polygon.length;
+    previous = index, index += 1
+  ) {
+    const current = polygon[index];
+    const previousPoint = polygon[previous];
+    const crossesY = (current.y > point.y) !== (previousPoint.y > point.y);
+    if (!crossesY) {
+      continue;
+    }
+    const intersectionX =
+      ((previousPoint.x - current.x) * (point.y - current.y)) /
+        (previousPoint.y - current.y) +
+      current.x;
+    if (point.x < intersectionX) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+function distanceSquaredToPolygon(point, polygon) {
+  if (pointInPolygon(point, polygon)) {
+    return 0;
+  }
+  let best = Infinity;
+  for (let index = 0; index < polygon.length; index += 1) {
+    best = Math.min(
+      best,
+      distanceSquaredToSegment(
+        point,
+        polygon[index],
+        polygon[(index + 1) % polygon.length],
+      ),
+    );
+  }
+  return best;
+}
+
+function hitScore(point, position) {
+  const nodeScore = distanceSquared(point, position);
+  return hasValidLabelPolygon(position.labelPolygon)
+    ? Math.min(nodeScore, distanceSquaredToPolygon(point, position.labelPolygon))
+    : nodeScore;
 }
 
 function labelPolygonError(value) {
@@ -507,6 +589,32 @@ function auditPack(pack, reviewedAmbiguities) {
         message: "routeMapPositions labelPolygon bounding boxes overlap.",
       });
     }
+  }
+
+  for (const labelPolygon of labelPolygons) {
+    const tapPoint = polygonCenter(labelPolygon.position.labelPolygon);
+    const ownScore = hitScore(tapPoint, labelPolygon.position);
+    const ambiguous = positions
+      .filter((position) =>
+        position !== labelPolygon.position &&
+        normalizedText(position.region) ===
+          normalizedText(labelPolygon.position.region) &&
+        hitScore(tapPoint, position) <= ownScore,
+      )
+      .map((position) => `${position.stationId}:${position.lineId}`)
+      .sort();
+    if (ambiguous.length === 0) {
+      continue;
+    }
+    addFinding(findings, {
+      severity: "MEDIUM",
+      code: "AMBIGUOUS_ROUTE_MAP_LABEL_POLYGON_HIT",
+      packId: pack.id,
+      region: labelPolygon.position.region,
+      lineId: labelPolygon.position.lineId,
+      stationId: labelPolygon.position.stationId,
+      message: `labelPolygon center tap is ambiguous with ${ambiguous.join(", ")}.`,
+    });
   }
 
   for (const membership of stationLines) {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -811,6 +811,64 @@ test("route map position audit reports ambiguous label polygon hit simulation as
   }
 });
 
+test("route map position audit compares fallback label center for hit simulation", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
+  try {
+    const fixturePath = path.join(tmp, "fallback-label-hit-catalog-fixture.json");
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+        "utf8",
+      ),
+    );
+    const pack = fixture.packs[0];
+    const sadangLine2 = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-sadang" && row.lineId === "seoul-2",
+    );
+    const gangnamLine2 = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-gangnam" && row.lineId === "seoul-2",
+    );
+    sadangLine2.labelPolygon = [
+      { x: 100, y: 100 },
+      { x: 140, y: 100 },
+      { x: 140, y: 120 },
+      { x: 100, y: 120 },
+    ];
+    delete gangnamLine2.labelPolygon;
+    gangnamLine2.x = 200;
+    gangnamLine2.y = 200;
+    gangnamLine2.labelDx = -80;
+    gangnamLine2.labelDy = -90;
+    await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "tools/route-map/audit-route-map.mjs",
+        "--fixture",
+        fixturePath,
+        "--fail-on",
+        "BLOCKER,HIGH",
+      ],
+      { cwd: root, maxBuffer: 1024 * 1024 },
+    );
+    const output = JSON.parse(stdout);
+
+    assert.equal(output.summary.findingsBySeverity.BLOCKER, 0);
+    assert.equal(output.summary.findingsBySeverity.HIGH, 0);
+    assert.ok(
+      output.findings.some(
+        (finding) =>
+          finding.code === "AMBIGUOUS_ROUTE_MAP_LABEL_POLYGON_HIT" &&
+          finding.stationId === "station-sadang" &&
+          finding.message.includes("station-gangnam:seoul-2"),
+      ),
+    );
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("route map position audit reports source label mismatch as high", async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
   try {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -840,6 +840,7 @@ test("route map position audit compares fallback label center for hit simulation
     gangnamLine2.y = 200;
     gangnamLine2.labelDx = -80;
     gangnamLine2.labelDy = -90;
+    gangnamLine2.sourceId = "fixture-cyberstation";
     await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
 
     const { stdout } = await execFileAsync(

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -872,6 +872,67 @@ test("route map position audit compares fallback label center for hit simulation
   }
 });
 
+test("route map position audit compares generated fallback label center", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
+  try {
+    const fixturePath = path.join(tmp, "generated-fallback-hit-catalog-fixture.json");
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+        "utf8",
+      ),
+    );
+    const pack = fixture.packs[0];
+    const sadangLine2 = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-sadang" && row.lineId === "seoul-2",
+    );
+    const gangnamLine2 = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-gangnam" && row.lineId === "seoul-2",
+    );
+    sadangLine2.labelPolygon = [
+      { x: 100, y: 100 },
+      { x: 140, y: 100 },
+      { x: 140, y: 120 },
+      { x: 100, y: 120 },
+    ];
+    delete gangnamLine2.labelPolygon;
+    gangnamLine2.x = 112;
+    gangnamLine2.y = 107;
+    gangnamLine2.labelDx = 0;
+    gangnamLine2.labelDy = 0;
+    gangnamLine2.upPath = "";
+    gangnamLine2.downPath = "";
+    await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "tools/route-map/audit-route-map.mjs",
+        "--fixture",
+        fixturePath,
+        "--fail-on",
+        "BLOCKER,HIGH",
+      ],
+      { cwd: root, maxBuffer: 1024 * 1024 },
+    );
+    const output = JSON.parse(stdout);
+
+    assert.equal(output.summary.findingsBySeverity.BLOCKER, 0);
+    assert.equal(output.summary.findingsBySeverity.HIGH, 0);
+    assert.ok(
+      output.findings.some(
+        (finding) =>
+          finding.code === "AMBIGUOUS_ROUTE_MAP_LABEL_POLYGON_HIT" &&
+          finding.severity === "MEDIUM" &&
+          finding.stationId === "station-sadang" &&
+          finding.message.includes("station-gangnam:seoul-2"),
+      ),
+    );
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("route map position audit reports source label mismatch as high", async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
   try {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -753,6 +753,64 @@ test("route map position audit reports overlapping label polygons as medium", as
   }
 });
 
+test("route map position audit reports ambiguous label polygon hit simulation as medium", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
+  try {
+    const fixturePath = path.join(tmp, "ambiguous-hit-catalog-fixture.json");
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+        "utf8",
+      ),
+    );
+    const pack = fixture.packs[0];
+    const sadangLine2 = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-sadang" && row.lineId === "seoul-2",
+    );
+    const gangnamLine2 = pack.routeMapPositions.find(
+      (row) => row.stationId === "station-gangnam" && row.lineId === "seoul-2",
+    );
+    sadangLine2.labelPolygon = [
+      { x: 100, y: 100 },
+      { x: 140, y: 100 },
+      { x: 140, y: 120 },
+      { x: 100, y: 120 },
+    ];
+    gangnamLine2.labelPolygon = [
+      { x: 110, y: 105 },
+      { x: 130, y: 105 },
+      { x: 130, y: 115 },
+      { x: 110, y: 115 },
+    ];
+    await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "tools/route-map/audit-route-map.mjs",
+        "--fixture",
+        fixturePath,
+        "--fail-on",
+        "BLOCKER,HIGH",
+      ],
+      { cwd: root, maxBuffer: 1024 * 1024 },
+    );
+    const output = JSON.parse(stdout);
+
+    assert.equal(output.summary.findingsBySeverity.BLOCKER, 0);
+    assert.equal(output.summary.findingsBySeverity.HIGH, 0);
+    assert.ok(
+      output.findings.some(
+        (finding) =>
+          finding.code === "AMBIGUOUS_ROUTE_MAP_LABEL_POLYGON_HIT" &&
+          finding.stationId === "station-sadang",
+      ),
+    );
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("route map position audit reports source label mismatch as high", async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
   try {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -803,6 +803,7 @@ test("route map position audit reports ambiguous label polygon hit simulation as
       output.findings.some(
         (finding) =>
           finding.code === "AMBIGUOUS_ROUTE_MAP_LABEL_POLYGON_HIT" &&
+          finding.severity === "MEDIUM" &&
           finding.stationId === "station-sadang",
       ),
     );
@@ -860,6 +861,7 @@ test("route map position audit compares fallback label center for hit simulation
       output.findings.some(
         (finding) =>
           finding.code === "AMBIGUOUS_ROUTE_MAP_LABEL_POLYGON_HIT" &&
+          finding.severity === "MEDIUM" &&
           finding.stationId === "station-sadang" &&
           finding.message.includes("station-gangnam:seoul-2"),
       ),


### PR DESCRIPTION
## 관련 이슈

close #948
refs #836

## 작업 배경

#836의 남은 범위 중 `labelPolygon` 데이터는 shape, coverage, overlap까지 audit하고 있지만 실제 hit-test 시뮬레이션은 audit하지 않고 있었다. 앱은 label polygon을 tap 후보 score에 사용하므로, polygon 중심 tap이 다른 station-line과 모호해지는 데이터를 release 전 검수 신호로 잡아야 한다.

## 작업 내용

- `routeMapPositions.labelPolygon` 중심 tap point를 계산해 같은 region의 다른 station-line 후보와 hit score를 비교한다.
- `labelPolygon`이 없는 후보도 앱의 `_stationTapScore` fallback label center 규칙에 맞춰 official `labelDx/labelDy`, non-official path/default offset을 반영한다.
- 자기 station-line이 단독 최저 score가 아니면 `AMBIGUOUS_ROUTE_MAP_LABEL_POLYGON_HIT` MEDIUM finding으로 보고한다.
- 기존 release gate는 `BLOCKER,HIGH`만 차단하므로 새 finding은 배포 차단이 아니라 검수 신호로 남긴다.
- 회귀 fixture test를 추가했다.

## 검증

- 실행한 명령과 결과:
- `node --test --test-name-pattern "route map position audit" tools/route-map/route-map-tools.test.mjs`: exit 0, 17 tests passed
- `node --test tools/route-map/*.test.mjs`: exit 0, 19 tests passed
- `node --test tools/ci/repository-contract.test.mjs`: exit 0, 107 tests passed
- `git diff --check`: exit 0
- GitHub CI: https://github.com/AquilaXk/easysubway/actions/runs/28226748407
- Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/28226748149

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| label polygon hit simulation audit | macOS / Node.js | route map audit targeted tests | local command output | 17 tests passed |
| route map tools | macOS / Node.js | route map tool tests | local command output | 19 tests passed |
| repository contracts | macOS / Node.js | repository contract tests | local command output | 107 tests passed |
| whitespace | macOS / git | `git diff --check` | local command output | exit 0 |
| CI | GitHub Actions | required PR checks | https://github.com/AquilaXk/easysubway/actions/runs/28226748407 | pass |
| release artifact scope | GitHub Actions | Release Artifacts workflow | https://github.com/AquilaXk/easysubway/actions/runs/28226748149 | pass / unchanged artifact jobs skipped |

증거 불필요 사유: audit 도구와 fixture test 변경이며 앱 runtime 화면, 접근성 tree, 배포 설정을 변경하지 않는다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `AMBIGUOUS_ROUTE_MAP_LABEL_POLYGON_HIT`가 `MEDIUM`이라 기존 `--fail-on BLOCKER,HIGH` release gate를 깨지 않는지 여부다.
- CodeRabbit은 rate limit 상태를 남겼고 check는 pass다. Codex CLI fallback review에서 나온 3건은 inline thread에 게시 후 수정 답글과 함께 resolved 처리했다.

## 리스크

- polygon 중심만 시뮬레이션하므로 모든 label 영역 tap을 증명하지는 않는다. 넓은 샘플링은 실제 production labelPolygon 데이터가 채워진 뒤 필요하면 추가한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
