### PR TITLE
[Test] 노선도 label polygon 필수 감사 옵션 추가

### DIFF
--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -12,7 +12,7 @@ const severityRank = new Map([
 ]);
 
 function usage() {
-  return `Usage: node tools/route-map/audit-route-map.mjs --fixture <catalog-fixture.json> [--reviewed-ambiguities reviewed.json] [--fail-on BLOCKER,HIGH] [--pretty]
+  return `Usage: node tools/route-map/audit-route-map.mjs --fixture <catalog-fixture.json> [--reviewed-ambiguities reviewed.json] [--require-label-polygons] [--fail-on BLOCKER,HIGH] [--pretty]
 
 Audits routeMapPositions against stationLines so production route-map coordinate
 coverage can be checked before rebuilding datapacks.`;
@@ -22,6 +22,7 @@ function parseArgs(argv) {
   const options = {
     fixture: null,
     reviewedAmbiguities: null,
+    requireLabelPolygons: false,
     failOn: [],
     pretty: false,
   };
@@ -33,6 +34,9 @@ function parseArgs(argv) {
         break;
       case "--reviewed-ambiguities":
         options.reviewedAmbiguities = argv[++index];
+        break;
+      case "--require-label-polygons":
+        options.requireLabelPolygons = true;
         break;
       case "--fail-on":
         options.failOn = (argv[++index] ?? "")
@@ -558,7 +562,7 @@ function parseReviewedAmbiguities(raw) {
   return reviewed;
 }
 
-function auditPack(pack, reviewedAmbiguities) {
+function auditPack(pack, reviewedAmbiguities, options = {}) {
   const findings = [];
   const stationsById = new Map(
     (Array.isArray(pack.stations) ? pack.stations : []).map((station) => [
@@ -819,7 +823,7 @@ function auditPack(pack, reviewedAmbiguities) {
       continue;
     }
     addFinding(findings, {
-      severity: "INFO",
+      severity: options.requireLabelPolygons ? "HIGH" : "INFO",
       code: "MISSING_ROUTE_MAP_LABEL_POLYGON",
       packId: pack.id,
       region,
@@ -916,10 +920,10 @@ function auditPack(pack, reviewedAmbiguities) {
   };
 }
 
-function auditFixture(fixturePath, fixture, reviewedAmbiguities) {
+function auditFixture(fixturePath, fixture, reviewedAmbiguities, options = {}) {
   const packs = Array.isArray(fixture.packs) ? fixture.packs : [];
   const auditedPacks = packs.map((pack) =>
-    auditPack(pack, reviewedAmbiguities),
+    auditPack(pack, reviewedAmbiguities, options),
   );
   const findings = auditedPacks.flatMap((pack) => pack.findings);
   const findingCounts = {};
@@ -951,7 +955,9 @@ async function main() {
         JSON.parse(await readFile(options.reviewedAmbiguities, "utf8")),
       )
     : new Map();
-  const report = auditFixture(options.fixture, fixture, reviewedAmbiguities);
+  const report = auditFixture(options.fixture, fixture, reviewedAmbiguities, {
+    requireLabelPolygons: options.requireLabelPolygons,
+  });
   console.log(JSON.stringify(report, null, options.pretty ? 2 : 0));
 
   const failed = options.failOn.some(

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -89,6 +89,35 @@ test("route map position audit passes clean catalog fixture", async () => {
   ]);
 });
 
+test("route map position audit can require label polygons", async () => {
+  await assert.rejects(
+    () =>
+      execFileAsync(
+        process.execPath,
+        [
+          "tools/route-map/audit-route-map.mjs",
+          "--fixture",
+          "tools/datapack/fixtures/catalog-fixture.json",
+          "--require-label-polygons",
+          "--fail-on",
+          "HIGH",
+        ],
+        { cwd: root, maxBuffer: 1024 * 1024 },
+      ),
+    (error) => {
+      const output = JSON.parse(error.stdout);
+      assert.equal(output.summary.findingsBySeverity.BLOCKER, 0);
+      assert.equal(output.summary.findingsBySeverity.HIGH, 1);
+      assert.equal(output.summary.findingsBySeverity.INFO, 0);
+      assert.equal(output.packs[0].summary.labelPolygonCount, 1);
+      assert.equal(output.packs[0].summary.labelPolygonCoverageRatio, 0.1111);
+      assert.equal(output.findings[0].code, "MISSING_ROUTE_MAP_LABEL_POLYGON");
+      assert.equal(output.findings[0].severity, "HIGH");
+      return true;
+    },
+  );
+});
+
 test("route map position audit reports label polygon coverage", async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-audit-"));
   try {


### PR DESCRIPTION
## 관련 이슈

close #968

Parent: #836

## 작업 배경

#836의 route-map 좌표 감사에서 label polygon 누락은 현재 INFO로만 남는다. production coverage를 채우기 전 Data Pack Release workflow를 바로 깨면 안 되므로, 기본 동작은 유지하고 후속 PR에서 켤 수 있는 opt-in 감사 옵션을 먼저 추가한다.

## 작업 내용

- `tools/route-map/audit-route-map.mjs`에 `--require-label-polygons` 옵션을 추가했다.
- 옵션이 없으면 `MISSING_ROUTE_MAP_LABEL_POLYGON`은 기존처럼 INFO로 유지된다.
- 옵션이 있으면 같은 finding을 HIGH로 승격해 `--fail-on HIGH`와 함께 실패시킬 수 있다.
- Data Pack Release workflow와 앱 runtime hit-test fallback은 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "route map position audit can require label polygons" tools/route-map/route-map-tools.test.mjs`: exit 0, 1 passed
  - `node --test --test-name-pattern "route map position audit" tools/route-map/route-map-tools.test.mjs`: exit 0, 18 passed
  - `node tools/route-map/audit-route-map.mjs --fixture tools/datapack/fixtures/catalog-fixture.json --fail-on BLOCKER,HIGH`: exit 0, `MISSING_ROUTE_MAP_LABEL_POLYGON` INFO 1 유지
  - `node --test tools/route-map/*.test.mjs`: exit 0, 20 passed
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 107 passed
  - `git diff --check`: exit 0
  - PR checks: Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| opt-in label polygon gate | local Node.js | `--require-label-polygons --fail-on HIGH` 테스트 | `route map position audit can require label polygons` | HIGH 1로 승격되고 CLI 실패 동작 확인 |
| 기존 Data Pack Release 호환성 | local Node.js | 옵션 없이 fixture audit 실행 | `MISSING_ROUTE_MAP_LABEL_POLYGON` INFO 1, exit 0 | 기존 release gate 동작 유지 |
| route-map audit 회귀 | local Node.js | `node --test tools/route-map/*.test.mjs` | 20 passed | 통과 |
| repository contract | local Node.js | `node --test tools/ci/repository-contract.test.mjs` | 107 passed | 통과 |
| PR CI | GitHub Actions | PR #969 checks | CI run `28231633945`, Release Artifacts changes run `28231633647` | 필수 check pass, release artifact jobs skipped as expected |
| CodeRabbit review | GitHub PR | CodeRabbit bot review comment/check | Review completed, actionable comments 0 | 통과 |
| 화면 증거 | 해당 없음 | CLI/test 변경만 포함 | 증거 불필요 사유: 앱 UI/runtime 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `--require-label-polygons`가 기본 workflow를 바꾸지 않고, 후속 production coverage PR에서만 켤 수 있는 opt-in인지 확인해 주세요.
- CodeRabbit docstring coverage warning은 이 저장소의 Node CLI 스타일과 무관한 일반 warning이며 actionable comment는 없습니다.

## 리스크

- 옵션을 release workflow에 붙이는 작업은 이번 PR 범위가 아니다. coverage가 채워지기 전에 workflow에 적용하면 release가 실패한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (해당 없음: CodeRabbit review completed, actionable 0)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (해당 없음: CLI/test opt-in 변경, release workflow/runtime 미변경)
