### PR TITLE
[Build] 노선도 label polygon geometry join 도구 추가

### DIFF
--- a/tools/route-map/join-svg-label-polygons.mjs
+++ b/tools/route-map/join-svg-label-polygons.mjs
@@ -110,6 +110,15 @@ function labelName(label) {
   return stationLabelKey(label.normalizedText || label.sourceText);
 }
 
+function stationLabelsByKey(geometry) {
+  const byKey = new Map();
+  for (const label of stationLabels(geometry)) {
+    const key = positionKey(geometry.region, labelName(label));
+    byKey.set(key, [...(byKey.get(key) ?? []), label]);
+  }
+  return byKey;
+}
+
 function sortedUnique(values) {
   return [...new Set(values.map(normalizedText).filter(Boolean))].sort();
 }
@@ -120,8 +129,21 @@ function joinPack(pack, geometry) {
   const unmatched = [];
   const ambiguous = [];
 
-  for (const label of stationLabels(geometry)) {
-    const candidates = byLabel.get(positionKey(geometry.region, labelName(label))) ?? [];
+  for (const [labelKey, labels] of stationLabelsByKey(geometry)) {
+    const [label] = labels;
+    const candidates = byLabel.get(labelKey) ?? [];
+    if (labels.length > 1) {
+      ambiguous.push({
+        sourceText: sortedUnique(labels.map((row) => row.sourceText)).join(" / "),
+        normalizedText: labelName(label),
+        stationIds: sortedUnique(candidates.map((row) => row.stationId)),
+        lineIds: sortedUnique(candidates.map((row) => row.lineId)),
+        polygonIndexes: labels.map((row) => row.polygonIndex ?? null),
+        sourceElementKeys: sortedUnique(labels.map((row) => row.sourceElementKey)),
+        duplicateLabelCount: labels.length,
+      });
+      continue;
+    }
     if (candidates.length === 0) {
       unmatched.push({
         sourceText: label.sourceText ?? "",

--- a/tools/route-map/join-svg-label-polygons.mjs
+++ b/tools/route-map/join-svg-label-polygons.mjs
@@ -159,7 +159,11 @@ function joinPack(pack, geometry) {
 
   const missingRouteMapPositions = (Array.isArray(pack.routeMapPositions)
     ? pack.routeMapPositions
-    : []).filter((position) => !hasPolygon(position.labelPolygon));
+    : []).filter(
+      (position) =>
+        normalizedText(position.region) === normalizedText(geometry.region) &&
+        !hasPolygon(position.labelPolygon),
+    );
 
   return {
     matched,

--- a/tools/route-map/join-svg-label-polygons.mjs
+++ b/tools/route-map/join-svg-label-polygons.mjs
@@ -37,10 +37,23 @@ function parseArgs(argv) {
   for (const name of ["fixture", "geometry", "output"]) {
     if (!options[name]) throw new Error(`--${name} is required`);
   }
-  if (path.resolve(options.fixture) === path.resolve(options.output)) {
-    throw new Error("--output must not overwrite --fixture");
-  }
+  rejectPathCollisions(options);
   return options;
+}
+
+function rejectPathCollisions(options) {
+  const paths = Object.entries(options)
+    .filter(([, value]) => value)
+    .map(([name, value]) => [name, path.resolve(value)]);
+  for (let leftIndex = 0; leftIndex < paths.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < paths.length; rightIndex += 1) {
+      const [leftName, leftPath] = paths[leftIndex];
+      const [rightName, rightPath] = paths[rightIndex];
+      if (leftPath === rightPath) {
+        throw new Error(`--${leftName} and --${rightName} must not use the same path`);
+      }
+    }
+  }
 }
 
 function normalizedText(value) {
@@ -48,7 +61,11 @@ function normalizedText(value) {
 }
 
 function stationLabelKey(value) {
-  return normalizedText(value).replace(/역$/, "");
+  return normalizedText(value)
+    .replace(/\([^)]*\)/gu, "")
+    .replace(/\[[^\]]*\]/gu, "")
+    .replace(/[·ㆍ･.\s]/gu, "")
+    .replace(/역$/u, "");
 }
 
 function hasPolygon(value) {

--- a/tools/route-map/join-svg-label-polygons.mjs
+++ b/tools/route-map/join-svg-label-polygons.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+function usage() {
+  return `Usage: node tools/route-map/join-svg-label-polygons.mjs --fixture <catalog-fixture.json> --geometry <svg-geometry.json> --output <joined-fixture.json> [--report report.json]
+
+Joins extracted SVG station label polygons into routeMapPositions when a
+region/name match maps to exactly one station-line position.`;
+}
+
+function parseArgs(argv) {
+  const options = { fixture: "", geometry: "", output: "", report: "" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--fixture":
+        options.fixture = argv[++index] ?? "";
+        break;
+      case "--geometry":
+        options.geometry = argv[++index] ?? "";
+        break;
+      case "--output":
+        options.output = argv[++index] ?? "";
+        break;
+      case "--report":
+        options.report = argv[++index] ?? "";
+        break;
+      case "--help":
+      case "-h":
+        process.stdout.write(usage());
+        process.exit(0);
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  for (const name of ["fixture", "geometry", "output"]) {
+    if (!options[name]) throw new Error(`--${name} is required`);
+  }
+  if (path.resolve(options.fixture) === path.resolve(options.output)) {
+    throw new Error("--output must not overwrite --fixture");
+  }
+  return options;
+}
+
+function normalizedText(value) {
+  return String(value ?? "").normalize("NFKC").trim().replace(/\s+/g, " ");
+}
+
+function stationLabelKey(value) {
+  return normalizedText(value).replace(/역$/, "");
+}
+
+function hasPolygon(value) {
+  return Array.isArray(value) && value.length >= 3;
+}
+
+function stationNameById(pack) {
+  return new Map(
+    (Array.isArray(pack.stations) ? pack.stations : []).map((station) => [
+      normalizedText(station.id),
+      stationLabelKey(station.nameKo),
+    ]),
+  );
+}
+
+function positionKey(region, stationName) {
+  return `${normalizedText(region)}\u0000${stationLabelKey(stationName)}`;
+}
+
+function routePositionsByLabel(pack) {
+  const stationNames = stationNameById(pack);
+  const byLabel = new Map();
+  for (const position of Array.isArray(pack.routeMapPositions)
+    ? pack.routeMapPositions
+    : []) {
+    const key = positionKey(
+      position.region,
+      stationNames.get(normalizedText(position.stationId)) ?? position.sourceLabel,
+    );
+    byLabel.set(key, [...(byLabel.get(key) ?? []), position]);
+  }
+  return byLabel;
+}
+
+function stationLabels(geometry) {
+  return (Array.isArray(geometry.labels) ? geometry.labels : []).filter(
+    (label) => normalizedText(label.classification) === "STATION_LABEL",
+  );
+}
+
+function labelName(label) {
+  return stationLabelKey(label.normalizedText || label.sourceText);
+}
+
+function sortedUnique(values) {
+  return [...new Set(values.map(normalizedText).filter(Boolean))].sort();
+}
+
+function joinPack(pack, geometry) {
+  const byLabel = routePositionsByLabel(pack);
+  const matched = [];
+  const unmatched = [];
+  const ambiguous = [];
+
+  for (const label of stationLabels(geometry)) {
+    const candidates = byLabel.get(positionKey(geometry.region, labelName(label))) ?? [];
+    if (candidates.length === 0) {
+      unmatched.push({
+        sourceText: label.sourceText ?? "",
+        normalizedText: labelName(label),
+        polygonIndex: label.polygonIndex ?? null,
+        sourceElementKey: label.sourceElementKey ?? "",
+      });
+      continue;
+    }
+    if (candidates.length > 1) {
+      ambiguous.push({
+        sourceText: label.sourceText ?? "",
+        normalizedText: labelName(label),
+        stationIds: sortedUnique(candidates.map((row) => row.stationId)),
+        lineIds: sortedUnique(candidates.map((row) => row.lineId)),
+        polygonIndex: label.polygonIndex ?? null,
+        sourceElementKey: label.sourceElementKey ?? "",
+      });
+      continue;
+    }
+    const [position] = candidates;
+    position.labelPolygon = label.polygon;
+    position.labelPolygonSourceSvgSha256 = geometry.sourceSvgSha256 ?? "";
+    position.labelPolygonSourceElementKey = label.sourceElementKey ?? "";
+    position.labelPolygonIndex = label.polygonIndex ?? 0;
+    matched.push({
+      stationId: position.stationId ?? "",
+      lineId: position.lineId ?? "",
+      region: position.region ?? "",
+      sourceText: label.sourceText ?? "",
+      polygonIndex: label.polygonIndex ?? null,
+      sourceElementKey: label.sourceElementKey ?? "",
+    });
+  }
+
+  const missingRouteMapPositions = (Array.isArray(pack.routeMapPositions)
+    ? pack.routeMapPositions
+    : []).filter((position) => !hasPolygon(position.labelPolygon));
+
+  return {
+    matched,
+    unmatched,
+    ambiguous,
+    missingRouteMapPositions: missingRouteMapPositions.map((position) => ({
+      stationId: position.stationId ?? "",
+      lineId: position.lineId ?? "",
+      region: position.region ?? "",
+    })),
+  };
+}
+
+function buildReport(fixturePath, geometryPath, geometry, packReports) {
+  const matched = packReports.flatMap((report) => report.matched);
+  const unmatched = packReports.flatMap((report) => report.unmatched);
+  const ambiguous = packReports.flatMap((report) => report.ambiguous);
+  const missingRouteMapPositions = packReports.flatMap(
+    (report) => report.missingRouteMapPositions,
+  );
+  return {
+    schemaVersion: 1,
+    artifactKind: "route-map-label-polygon-join-report",
+    fixture: path.normalize(fixturePath),
+    geometry: path.normalize(geometryPath),
+    region: geometry.region ?? "",
+    sourceSvgSha256: geometry.sourceSvgSha256 ?? "",
+    summary: {
+      matched: matched.length,
+      unmatched: unmatched.length,
+      ambiguous: ambiguous.length,
+      missingRouteMapPositions: missingRouteMapPositions.length,
+    },
+    matched,
+    unmatched,
+    ambiguous,
+    missingRouteMapPositions,
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const fixture = JSON.parse(await readFile(options.fixture, "utf8"));
+  const geometry = JSON.parse(await readFile(options.geometry, "utf8"));
+  const packs = Array.isArray(fixture.packs) ? fixture.packs : [];
+  const packReports = packs.map((pack) => joinPack(pack, geometry));
+  const report = buildReport(options.fixture, options.geometry, geometry, packReports);
+
+  await writeFile(options.output, `${JSON.stringify(fixture, null, 2)}\n`);
+  if (options.report) {
+    await writeFile(options.report, `${JSON.stringify(report, null, 2)}\n`);
+  }
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  console.error(usage());
+  process.exit(1);
+});

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -50,6 +50,121 @@ test("SVG geometry extractor returns transformed visible text polygons", async (
   assert.notEqual(rotated.polygon[0].x, rotated.polygon[3].x);
 });
 
+test("SVG label polygon join applies only unambiguous station labels", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-join-"));
+  try {
+    const geometryPath = path.join(tmp, "geometry.json");
+    const outputPath = path.join(tmp, "joined-fixture.json");
+    const reportPath = path.join(tmp, "join-report.json");
+    const jeongjaPolygon = [
+      { x: 610, y: 286 },
+      { x: 662, y: 286 },
+      { x: 662, y: 306 },
+      { x: 610, y: 306 },
+    ];
+    await writeFile(
+      geometryPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        region: "수도권",
+        sourceSvgSha256: "b".repeat(64),
+        extractorVersion: "route-map-svg-geometry-v1",
+        labels: [
+          {
+            sourceText: "정자역",
+            normalizedText: "정자",
+            classification: "STATION_LABEL",
+            polygon: jeongjaPolygon,
+            polygonIndex: 0,
+            sourceElementKey: "c".repeat(64),
+          },
+          {
+            sourceText: "사당역",
+            normalizedText: "사당",
+            classification: "STATION_LABEL",
+            polygon: [
+              { x: 410, y: 186 },
+              { x: 462, y: 186 },
+              { x: 462, y: 206 },
+              { x: 410, y: 206 },
+            ],
+            polygonIndex: 1,
+            sourceElementKey: "d".repeat(64),
+          },
+          {
+            sourceText: "없는역",
+            normalizedText: "없는",
+            classification: "STATION_LABEL",
+            polygon: [
+              { x: 1, y: 1 },
+              { x: 2, y: 1 },
+              { x: 2, y: 2 },
+              { x: 1, y: 2 },
+            ],
+            polygonIndex: 2,
+            sourceElementKey: "e".repeat(64),
+          },
+          {
+            sourceText: "2호선",
+            normalizedText: "2호선",
+            classification: "LINE_LABEL",
+            polygon: [
+              { x: 1, y: 1 },
+              { x: 2, y: 1 },
+              { x: 2, y: 2 },
+              { x: 1, y: 2 },
+            ],
+            polygonIndex: 3,
+            sourceElementKey: "f".repeat(64),
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "tools/route-map/join-svg-label-polygons.mjs",
+        "--fixture",
+        "tools/datapack/fixtures/catalog-fixture.json",
+        "--geometry",
+        geometryPath,
+        "--output",
+        outputPath,
+        "--report",
+        reportPath,
+      ],
+      { cwd: root, maxBuffer: 1024 * 1024 },
+    );
+    const report = JSON.parse(stdout);
+    const reportFile = JSON.parse(await readFile(reportPath, "utf8"));
+    const joined = JSON.parse(await readFile(outputPath, "utf8"));
+    const jeongja = joined.packs[0].routeMapPositions.find(
+      (row) => row.stationId === "station-jeongja",
+    );
+    const sadangRows = joined.packs[0].routeMapPositions.filter(
+      (row) => row.stationId === "station-sadang",
+    );
+
+    assert.deepEqual(report, reportFile);
+    assert.equal(report.summary.matched, 1);
+    assert.equal(report.summary.ambiguous, 1);
+    assert.equal(report.summary.unmatched, 1);
+    assert.equal(report.summary.missingRouteMapPositions, 7);
+    assert.deepEqual(jeongja.labelPolygon, jeongjaPolygon);
+    assert.equal(jeongja.labelPolygonSourceSvgSha256, "b".repeat(64));
+    assert.equal(jeongja.labelPolygonSourceElementKey, "c".repeat(64));
+    assert.equal(jeongja.labelPolygonIndex, 0);
+    assert.ok(sadangRows.every((row) => row.labelPolygon == null));
+    assert.deepEqual(report.ambiguous[0].stationIds, ["station-sadang"]);
+    assert.deepEqual(report.ambiguous[0].lineIds, ["seoul-2", "seoul-4"]);
+    assert.equal(report.unmatched[0].sourceText, "없는역");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("route map position audit passes clean catalog fixture", async () => {
   const { stdout } = await execFileAsync(
     process.execPath,

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -54,8 +54,19 @@ test("SVG label polygon join applies only unambiguous station labels", async () 
   const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-join-"));
   try {
     const geometryPath = path.join(tmp, "geometry.json");
+    const fixturePath = path.join(tmp, "catalog-fixture.json");
     const outputPath = path.join(tmp, "joined-fixture.json");
     const reportPath = path.join(tmp, "join-report.json");
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+        "utf8",
+      ),
+    );
+    fixture.packs[0].stations.find(
+      (station) => station.id === "station-jeongja",
+    ).nameKo = "정자(신분당선)";
+    await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
     const jeongjaPolygon = [
       { x: 610, y: 286 },
       { x: 662, y: 286 },
@@ -71,8 +82,8 @@ test("SVG label polygon join applies only unambiguous station labels", async () 
         extractorVersion: "route-map-svg-geometry-v1",
         labels: [
           {
-            sourceText: "정자역",
-            normalizedText: "정자",
+            sourceText: "정 자역",
+            normalizedText: "정 자",
             classification: "STATION_LABEL",
             polygon: jeongjaPolygon,
             polygonIndex: 0,
@@ -127,7 +138,7 @@ test("SVG label polygon join applies only unambiguous station labels", async () 
       [
         "tools/route-map/join-svg-label-polygons.mjs",
         "--fixture",
-        "tools/datapack/fixtures/catalog-fixture.json",
+        fixturePath,
         "--geometry",
         geometryPath,
         "--output",
@@ -160,6 +171,49 @@ test("SVG label polygon join applies only unambiguous station labels", async () 
     assert.deepEqual(report.ambiguous[0].stationIds, ["station-sadang"]);
     assert.deepEqual(report.ambiguous[0].lineIds, ["seoul-2", "seoul-4"]);
     assert.equal(report.unmatched[0].sourceText, "없는역");
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("SVG label polygon join rejects input and output path collisions", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-join-path-"));
+  try {
+    const fixturePath = path.join(root, "tools/datapack/fixtures/catalog-fixture.json");
+    const geometryPath = path.join(tmp, "geometry.json");
+    const outputPath = path.join(tmp, "joined-fixture.json");
+    await writeFile(
+      geometryPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        region: "수도권",
+        labels: [],
+      }),
+      "utf8",
+    );
+
+    for (const args of [
+      ["--output", geometryPath],
+      ["--output", outputPath, "--report", fixturePath],
+      ["--output", outputPath, "--report", outputPath],
+    ]) {
+      await assert.rejects(
+        () =>
+          execFileAsync(
+            process.execPath,
+            [
+              "tools/route-map/join-svg-label-polygons.mjs",
+              "--fixture",
+              fixturePath,
+              "--geometry",
+              geometryPath,
+              ...args,
+            ],
+            { cwd: root, maxBuffer: 1024 * 1024 },
+          ),
+        /must not use the same path/,
+      );
+    }
   } finally {
     await rm(tmp, { recursive: true, force: true });
   }

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -227,6 +227,78 @@ test("SVG label polygon join rejects input and output path collisions", async ()
   }
 });
 
+test("SVG label polygon join reports duplicate source labels as ambiguous", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-join-duplicate-"));
+  try {
+    const geometryPath = path.join(tmp, "geometry.json");
+    const outputPath = path.join(tmp, "joined-fixture.json");
+    await writeFile(
+      geometryPath,
+      JSON.stringify({
+        schemaVersion: 1,
+        region: "수도권",
+        labels: [
+          {
+            sourceText: "정자역",
+            normalizedText: "정자",
+            classification: "STATION_LABEL",
+            polygon: [
+              { x: 10, y: 10 },
+              { x: 20, y: 10 },
+              { x: 20, y: 20 },
+            ],
+            polygonIndex: 0,
+            sourceElementKey: "a".repeat(64),
+          },
+          {
+            sourceText: "정자역",
+            normalizedText: "정자",
+            classification: "STATION_LABEL",
+            polygon: [
+              { x: 30, y: 30 },
+              { x: 40, y: 30 },
+              { x: 40, y: 40 },
+            ],
+            polygonIndex: 1,
+            sourceElementKey: "b".repeat(64),
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "tools/route-map/join-svg-label-polygons.mjs",
+        "--fixture",
+        "tools/datapack/fixtures/catalog-fixture.json",
+        "--geometry",
+        geometryPath,
+        "--output",
+        outputPath,
+      ],
+      { cwd: root, maxBuffer: 1024 * 1024 },
+    );
+    const report = JSON.parse(stdout);
+    const joined = JSON.parse(await readFile(outputPath, "utf8"));
+    const jeongja = joined.packs[0].routeMapPositions.find(
+      (row) => row.stationId === "station-jeongja",
+    );
+
+    assert.equal(report.summary.matched, 0);
+    assert.equal(report.summary.ambiguous, 1);
+    assert.equal(report.summary.unmatched, 0);
+    assert.equal(report.summary.missingRouteMapPositions, 8);
+    assert.equal(report.ambiguous[0].duplicateLabelCount, 2);
+    assert.deepEqual(report.ambiguous[0].polygonIndexes, [0, 1]);
+    assert.deepEqual(report.ambiguous[0].stationIds, ["station-jeongja"]);
+    assert.equal(jeongja.labelPolygon, undefined);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("route map position audit passes clean catalog fixture", async () => {
   const { stdout } = await execFileAsync(
     process.execPath,

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -66,6 +66,13 @@ test("SVG label polygon join applies only unambiguous station labels", async () 
     fixture.packs[0].stations.find(
       (station) => station.id === "station-jeongja",
     ).nameKo = "정자(신분당선)";
+    fixture.packs[0].routeMapPositions.push({
+      stationId: "station-jeongja",
+      lineId: "shinbundang",
+      region: "부산",
+      x: 620,
+      y: 310,
+    });
     await writeFile(fixturePath, JSON.stringify(fixture), "utf8");
     const jeongjaPolygon = [
       { x: 610, y: 286 },
@@ -163,6 +170,7 @@ test("SVG label polygon join applies only unambiguous station labels", async () 
     assert.equal(report.summary.ambiguous, 1);
     assert.equal(report.summary.unmatched, 1);
     assert.equal(report.summary.missingRouteMapPositions, 7);
+    assert.ok(report.missingRouteMapPositions.every((row) => row.region === "수도권"));
     assert.deepEqual(jeongja.labelPolygon, jeongjaPolygon);
     assert.equal(jeongja.labelPolygonSourceSvgSha256, "b".repeat(64));
     assert.equal(jeongja.labelPolygonSourceElementKey, "c".repeat(64));


### PR DESCRIPTION
## 관련 이슈

close #970

Parent: #836

## 작업 배경

SVG geometry extractor는 station label polygon과 source metadata를 산출하지만, 이를 `routeMapPositions.labelPolygon`에 적용하는 독립 join 단계가 없었다. #836의 label polygon coverage를 release gate로 켜기 전, 먼저 안전하게 적용 후보와 미적용 사유를 보고하는 CLI가 필요하다.

## 작업 내용

- `tools/route-map/join-svg-label-polygons.mjs` CLI를 추가했다.
- fixture JSON과 geometry JSON을 입력받아 region + normalized station label이 단일 source label polygon과 단일 routeMapPosition 후보로 매칭될 때만 `labelPolygon`과 source metadata를 output fixture에 추가한다.
- 후보가 없는 label은 `unmatched`, routeMapPosition 후보가 여러 개이거나 source label polygon이 중복된 label은 `ambiguous`로 report에 남기고 자동 적용하지 않는다.
- 입력 fixture/geometry/output/report 경로 충돌을 거부하고, 입력 fixture는 덮어쓰지 않고 `--output` 경로로만 쓴다.
- 단일 region geometry 실행의 `missingRouteMapPositions`는 해당 region만 집계한다.
- Data Pack Release workflow, production builder, 앱 runtime은 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "SVG label polygon join" tools/route-map/route-map-tools.test.mjs`: exit 0, 3 passed
  - `node --test tools/route-map/*.test.mjs`: exit 0, 23 passed
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 107 passed
  - `git diff --check`: exit 0
  - GitHub PR checks: Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan, osv-scanner pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| geometry join CLI | local Node.js | 단일 label, ambiguous label, unmatched label fixture 테스트 | `SVG label polygon join applies only unambiguous station labels` | matched 1, ambiguous 1, unmatched 1, missingRouteMapPositions 7 |
| 입력/출력 경로 보호 | local Node.js | output/geometry, report/fixture, report/output 충돌 테스트 | `SVG label polygon join rejects input and output path collisions` | 충돌 조합 모두 거부 |
| 중복 source label 보호 | local Node.js | 같은 station label polygon 2개가 단일 후보를 덮어쓰지 않는지 테스트 | `SVG label polygon join reports duplicate source labels as ambiguous` | matched 0, ambiguous 1, output labelPolygon 미작성 |
| route-map tooling 회귀 | local Node.js | `node --test tools/route-map/*.test.mjs` | 23 passed | 통과 |
| repository contract | local Node.js | `node --test tools/ci/repository-contract.test.mjs` | 107 passed | 통과 |
| CI | GitHub Actions | PR #971 checks | Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan, osv-scanner pass | 통과 |
| 화면 증거 | 해당 없음 | CLI/test 변경만 포함 | 증거 불필요 사유: 앱 UI/runtime 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 환승역처럼 같은 region/name 후보가 여러 개인 경우와 SVG 안에 같은 label polygon이 여러 개인 경우 자동 적용하지 않고 `ambiguous`로만 남기는지 확인해 주세요.
- production builder 연결과 workflow gate 적용은 후속 PR 범위입니다.

## 리스크

- 현재 join 기준은 region + station label 단일 후보만 자동 적용한다. 환승역/동명이역/반복 라벨은 자동 적용하지 않으므로 coverage를 모두 채우려면 후속 ambiguity review 또는 line-aware 매칭이 필요하다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
