### PR TITLE
[Build] 노선도 label polygon join 실패 게이트 추가

### DIFF
--- a/tools/route-map/join-svg-label-polygons.mjs
+++ b/tools/route-map/join-svg-label-polygons.mjs
@@ -3,14 +3,20 @@ import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 function usage() {
-  return `Usage: node tools/route-map/join-svg-label-polygons.mjs --fixture <catalog-fixture.json> --geometry <svg-geometry.json> --output <joined-fixture.json> [--report report.json]
+  return `Usage: node tools/route-map/join-svg-label-polygons.mjs --fixture <catalog-fixture.json> --geometry <svg-geometry.json> --output <joined-fixture.json> [--report report.json] [--fail-on AMBIGUOUS,UNMATCHED,MISSING_ROUTE_MAP_POSITIONS]
 
 Joins extracted SVG station label polygons into routeMapPositions when a
 region/name match maps to exactly one station-line position.`;
 }
 
 function parseArgs(argv) {
-  const options = { fixture: "", geometry: "", output: "", report: "" };
+  const options = {
+    fixture: "",
+    geometry: "",
+    output: "",
+    report: "",
+    failOn: new Set(),
+  };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     switch (arg) {
@@ -25,6 +31,9 @@ function parseArgs(argv) {
         break;
       case "--report":
         options.report = argv[++index] ?? "";
+        break;
+      case "--fail-on":
+        options.failOn = parseFailOn(argv[++index] ?? "");
         break;
       case "--help":
       case "-h":
@@ -41,9 +50,30 @@ function parseArgs(argv) {
   return options;
 }
 
+function parseFailOn(value) {
+  const keysByInput = new Map([
+    ["AMBIGUOUS", "ambiguous"],
+    ["UNMATCHED", "unmatched"],
+    ["MISSING_ROUTE_MAP_POSITIONS", "missingRouteMapPositions"],
+  ]);
+  const tokens = value.split(",").map((token) => token.trim()).filter(Boolean);
+  if (tokens.length === 0) {
+    throw new Error("--fail-on requires at least one condition");
+  }
+  const failOn = new Set();
+  for (const token of tokens) {
+    const key = keysByInput.get(token.toUpperCase());
+    if (!key) {
+      throw new Error(`Unknown --fail-on condition: ${token}`);
+    }
+    failOn.add(key);
+  }
+  return failOn;
+}
+
 function rejectPathCollisions(options) {
   const paths = Object.entries(options)
-    .filter(([, value]) => value)
+    .filter(([, value]) => typeof value === "string" && value)
     .map(([name, value]) => [name, path.resolve(value)]);
   for (let leftIndex = 0; leftIndex < paths.length; leftIndex += 1) {
     for (let rightIndex = leftIndex + 1; rightIndex < paths.length; rightIndex += 1) {
@@ -226,6 +256,16 @@ function buildReport(fixturePath, geometryPath, geometry, packReports) {
   };
 }
 
+function failureMessage(report, failOn) {
+  const failed = [...failOn]
+    .filter((key) => (report.summary[key] ?? 0) > 0)
+    .map((key) => `${key}=${report.summary[key]}`);
+  if (failed.length === 0) {
+    return "";
+  }
+  return `SVG label polygon join failed: ${failed.join(", ")}`;
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const fixture = JSON.parse(await readFile(options.fixture, "utf8"));
@@ -239,6 +279,11 @@ async function main() {
     await writeFile(options.report, `${JSON.stringify(report, null, 2)}\n`);
   }
   process.stdout.write(`${JSON.stringify(report)}\n`);
+  const message = failureMessage(report, options.failOn);
+  if (message) {
+    console.error(message);
+    process.exitCode = 1;
+  }
 }
 
 main().catch((error) => {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -57,6 +57,8 @@ test("SVG label polygon join applies only unambiguous station labels", async () 
     const fixturePath = path.join(tmp, "catalog-fixture.json");
     const outputPath = path.join(tmp, "joined-fixture.json");
     const reportPath = path.join(tmp, "join-report.json");
+    const failedOutputPath = path.join(tmp, "failed-joined-fixture.json");
+    const failedReportPath = path.join(tmp, "failed-join-report.json");
     const fixture = JSON.parse(
       await readFile(
         path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
@@ -179,6 +181,49 @@ test("SVG label polygon join applies only unambiguous station labels", async () 
     assert.deepEqual(report.ambiguous[0].stationIds, ["station-sadang"]);
     assert.deepEqual(report.ambiguous[0].lineIds, ["seoul-2", "seoul-4"]);
     assert.equal(report.unmatched[0].sourceText, "없는역");
+
+    let failedStdout = "";
+    await assert.rejects(
+      () =>
+        execFileAsync(
+          process.execPath,
+          [
+            "tools/route-map/join-svg-label-polygons.mjs",
+            "--fixture",
+            fixturePath,
+            "--geometry",
+            geometryPath,
+            "--output",
+            failedOutputPath,
+            "--report",
+            failedReportPath,
+            "--fail-on",
+            "AMBIGUOUS,UNMATCHED,MISSING_ROUTE_MAP_POSITIONS",
+          ],
+          { cwd: root, maxBuffer: 1024 * 1024 },
+        ),
+      (error) => {
+        failedStdout = error.stdout;
+        assert.match(error.stderr, /ambiguous=1/);
+        assert.match(error.stderr, /unmatched=1/);
+        assert.match(error.stderr, /missingRouteMapPositions=7/);
+        return true;
+      },
+    );
+    const failedReport = JSON.parse(failedStdout);
+    const failedReportFile = JSON.parse(await readFile(failedReportPath, "utf8"));
+    const failedJoined = JSON.parse(await readFile(failedOutputPath, "utf8"));
+    assert.deepEqual(failedReport, failedReportFile);
+    assert.equal(failedReport.summary.matched, 1);
+    assert.equal(failedReport.summary.ambiguous, 1);
+    assert.equal(failedReport.summary.unmatched, 1);
+    assert.equal(failedReport.summary.missingRouteMapPositions, 7);
+    assert.equal(
+      failedJoined.packs[0].routeMapPositions.find(
+        (row) => row.stationId === "station-jeongja",
+      ).labelPolygonSourceSvgSha256,
+      "b".repeat(64),
+    );
   } finally {
     await rm(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 관련 이슈

close #972

상위 작업: #836

## 작업 배경

#971에서 SVG label polygon join 도구가 추가됐지만, `ambiguous`, `unmatched`, `missingRouteMapPositions`가 남아도 항상 성공 종료했다. 이 상태로는 production 후보 fixture나 Data Pack Release 검증에서 조인 산출물이 완전한지 자동으로 차단하기 어렵다.

## 작업 내용

- `join-svg-label-polygons.mjs`에 `--fail-on AMBIGUOUS,UNMATCHED,MISSING_ROUTE_MAP_POSITIONS` 옵션을 추가했다.
- 실패 조건에 걸려도 기존처럼 joined fixture, report 파일, stdout JSON report를 먼저 남기고 non-zero 종료하도록 했다.
- 기본 실행은 기존과 동일하게 report만 생성하고 성공 종료한다.
- join 테스트에 실패 게이트 검증을 추가해 stderr 원인, stdout/report 일치, 실패 시 output 파일 유지까지 확인했다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "SVG label polygon join" tools/route-map/route-map-tools.test.mjs`: exit 0, 3 tests passed
  - `node --test tools/route-map/*.test.mjs`: exit 0, 23 tests passed
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 107 tests passed
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| join 실패 게이트 | local Node.js | `node --test --test-name-pattern "SVG label polygon join" tools/route-map/route-map-tools.test.mjs` | command output: 3 tests passed | 통과 |
| route-map 도구 회귀 | local Node.js | `node --test tools/route-map/*.test.mjs` | command output: 23 tests passed | 통과 |
| 저장소 계약 | local Node.js | `node --test tools/ci/repository-contract.test.mjs` | command output: 107 tests passed | 통과 |
| 화면 증거 | 해당 없음 | CLI 도구 동작 변경 | 증거 불필요 사유: 앱 UI/접근성/시각 흐름 변경이 없고 실패 조건은 자동 테스트 출력으로 검증됨 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `--fail-on`은 기본 동작을 바꾸지 않고 명시적으로 켰을 때만 exit code를 실패로 바꾼다.
  - 실패 시에도 stdout/report/output을 남겨 Data Pack Release 로그에서 원인을 확인할 수 있다.

## 리스크

- CLI option 이름이 release workflow에 연결되기 전까지 production gate에는 영향이 없다.
- `missingRouteMapPositions`는 region-scoped summary라 공식 SVG 지역별 조인 검증에 맞춰 단계적으로 사용할 수 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
