### PR TITLE
[Fix] 보안·개인정보 release gate와 삭제 E2E 검증

### DIFF
--- a/apps/mobile/release/release-security-gate.json
+++ b/apps/mobile/release/release-security-gate.json
@@ -37,6 +37,16 @@
       "linkedArtifacts": ["apps/mobile/android/app/build.gradle.kts", ".env.example", ".gitignore"]
     },
     {
+      "id": "datapack_signing_key_lifecycle",
+      "area": "mobile",
+      "severity": "release-blocker",
+      "titleKo": "데이터팩 서명 key lifecycle",
+      "ownerKo": "모바일/데이터 담당",
+      "readyWhenKo": "manifest public keyring, signing key rotation, revocation, emergency rollback key 사용 기준과 test vector가 PR 검증 증거에 남고, private signing key는 저장소와 모바일 산출물에 포함되지 않는다.",
+      "evidence": ["manifest-signature-test-vector", "key-rotation-revocation-record", "emergency-rollback-key-approval", "release-artifact-secret-scan-output"],
+      "linkedArtifacts": ["apps/mobile/release/security-privacy-release-evidence.json", "tools/datapack/schema/manifest.schema.json", "tools/datapack/datapack-tools.test.mjs", "apps/mobile/lib/core/datapack/data_pack_manifest.dart"]
+    },
+    {
       "id": "mobile_test_credentials_absent",
       "area": "mobile",
       "severity": "release-blocker",
@@ -45,6 +55,16 @@
       "readyWhenKo": "릴리즈 빌드와 앱 저장소에 심사용 데모 계정, 테스트 API 키, 샘플 비밀번호, 운영 지도 키가 하드코딩되어 있지 않다.",
       "evidence": ["credential-string-search", "release-artifact-review"],
       "linkedArtifacts": ["apps/mobile/lib/main.dart", ".env.example", ".gitignore"]
+    },
+    {
+      "id": "mobile_release_artifact_secret_trace_scan",
+      "area": "mobile",
+      "severity": "release-blocker",
+      "titleKo": "모바일 릴리즈 산출물 비밀값과 network trace 점검",
+      "ownerKo": "모바일/보안 담당",
+      "readyWhenKo": "AAB/IPA 또는 Play-generated APK 후보에서 provider key, signing private key, upload URL, receipt token, local placeholder endpoint가 검색되지 않고, release network trace는 개인정보 인벤토리와 같은 endpoint/데이터 흐름만 보인다.",
+      "evidence": ["release-artifact-secret-scan-output", "release-network-trace-review", "android-emulator-release-smoke-log"],
+      "linkedArtifacts": [".github/workflows/release-artifacts.yml", "apps/mobile/release/security-privacy-release-evidence.json", "apps/mobile/release/store-privacy-inventory.json", "apps/mobile/lib/app/app_endpoints.dart"]
     },
     {
       "id": "mobile_error_stacktrace_sanitized",
@@ -97,6 +117,16 @@
       "linkedArtifacts": ["backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java", "backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java", "apps/mobile/lib/facility_report.dart"]
     },
     {
+      "id": "backend_report_photo_malicious_upload_defense",
+      "area": "backend",
+      "severity": "release-blocker",
+      "titleKo": "악성 신고 사진 업로드 방어",
+      "ownerKo": "백엔드/보안 담당",
+      "readyWhenKo": "시설 신고 사진은 MIME, extension, magic bytes, checksum, image decode, thumbnail 생성 실패를 모두 검증하고, claim 실패나 중복 제출 실패 시 orphan cleanup 경로가 검증된다.",
+      "evidence": ["malicious-photo-upload-tests", "orphan-cleanup-failure-path-test", "facility-report-photo-processor-review", "receipt-token-boundary-review"],
+      "linkedArtifacts": ["backend/src/main/java/com/easysubway/report/application/service/FacilityReportPhotoProcessor.java", "backend/src/test/java/com/easysubway/report/application/service/FacilityReportPhotoProcessorTest.java", "backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java", "backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java", "backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportUploadIntentsTest.java"]
+    },
+    {
       "id": "backend_report_abuse_control_release_gate",
       "area": "backend",
       "severity": "release-blocker",
@@ -135,6 +165,16 @@
       "readyWhenKo": "위치, 사용자 식별자, 신고 사진, 인증 비밀번호가 운영 로그에 불필요하게 남지 않도록 오류 로그와 감사 로그의 목적을 분리한다.",
       "evidence": ["log-field-review", "audit-log-review"],
       "linkedArtifacts": ["backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java", "backend/src/main/java/com/easysubway/report/domain/FacilityReportReviewAudit.java", "backend/src/main/java/com/easysubway/common/web/CommonExceptionHandler.java"]
+    },
+    {
+      "id": "user_data_deletion_retention_e2e",
+      "area": "user-data",
+      "severity": "release-blocker",
+      "titleKo": "사용자 데이터 삭제와 retention E2E",
+      "ownerKo": "모바일/백엔드/개인정보 담당",
+      "readyWhenKo": "데이터 삭제 요청은 local data, report link, photo object, notification preference/device, favorite, search history, mobility profile retention을 같은 사용자 범위로 삭제 또는 익명화하고 Android emulator UI evidence와 백엔드/모바일 자동 테스트 결과를 PR에 남긴다.",
+      "evidence": ["backend-user-data-deletion-service-test", "mobile-user-data-deletion-local-test", "android-emulator-deletion-ui-evidence", "report-photo-object-delete-test", "retention-inventory-cross-check"],
+      "linkedArtifacts": ["backend/src/main/java/com/easysubway/user/application/service/UserDataDeletionService.java", "backend/src/test/java/com/easysubway/user/application/service/UserDataDeletionServiceTest.java", "backend/src/test/java/com/easysubway/report/adapter/out/persistence/JdbcFacilityReportRepositoryTest.java", "apps/mobile/lib/user_data_deletion.dart", "apps/mobile/test/user_data_deletion_test.dart", "apps/mobile/release/security-privacy-release-evidence.json"]
     },
     {
       "id": "repository_secrets_not_tracked",
@@ -182,8 +222,8 @@
       "severity": "release-blocker",
       "titleKo": "개인정보와 보안 고지 일관성",
       "ownerKo": "개인정보/릴리즈 담당",
-      "readyWhenKo": "Data safety, App Privacy, PrivacyInfo, 스토어 심사 정보, 앱 도움말, 보안 문의 경로가 같은 데이터 처리와 삭제 요청 기준을 설명한다.",
-      "evidence": ["privacy-inventory-cross-check", "store-submission-readiness-review", "help-screen-review"],
+      "readyWhenKo": "Data safety, App Privacy, PrivacyInfo, 스토어 심사 정보, 앱 도움말, 보안 문의 경로와 release network trace가 같은 데이터 처리와 삭제 요청 기준을 설명한다.",
+      "evidence": ["privacy-inventory-cross-check", "store-submission-readiness-review", "help-screen-review", "release-network-trace-review"],
       "linkedArtifacts": ["apps/mobile/release/store-privacy-inventory.json", "apps/mobile/release/store-submission-readiness.json", "apps/mobile/ios/Runner/PrivacyInfo.xcprivacy", "README.md"]
     }
   ]

--- a/apps/mobile/release/security-privacy-release-evidence.json
+++ b/apps/mobile/release/security-privacy-release-evidence.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": 1,
+  "applicationId": "easysubway",
+  "releaseBlockerPolicy": true,
+  "sensitiveEvidenceLocalOnlyPath": ".codex/evidence/security-privacy-release/<pr-or-rc>/",
+  "datapackSigningKeyLifecycle": {
+    "requiredEvidence": [
+      "manifest public keyring snapshot",
+      "signature verification test vector",
+      "rotation approval record",
+      "revocation drill result",
+      "emergency rollback key approval"
+    ],
+    "privateKeyPolicyKo": "signing private key는 저장소, release artifact, PR 본문에 포함하지 않고 local-only evidence에는 fingerprint와 검증 결과만 남긴다."
+  },
+  "releaseArtifactSecretScan": {
+    "forbiddenClasses": [
+      "provider-key",
+      "signing-private-key",
+      "upload-url",
+      "receipt-token",
+      "local-placeholder-endpoint"
+    ],
+    "requiredArtifacts": [
+      "Android AAB or Play-generated APK scan log",
+      "iOS IPA or archive scan log when iOS release candidate exists",
+      "release network trace endpoint summary"
+    ],
+    "androidEvidenceSourceKo": "QA 요청에 따라 실기기가 아니라 로컬 Android emulator에서 앱 실행, UI tree, logcat, network endpoint trace 요약을 수집한다."
+  },
+  "maliciousPhotoUploadDefense": {
+    "requiredChecks": [
+      "MIME type allowlist",
+      "file extension match",
+      "magic bytes match",
+      "checksum generation",
+      "image decode success",
+      "thumbnail generation success",
+      "orphan cleanup on failed claim"
+    ]
+  },
+  "userDataDeletionE2E": {
+    "targets": [
+      "local data 삭제",
+      "report link 익명화",
+      "report photo object 삭제",
+      "notification preference 삭제",
+      "favorite 삭제",
+      "search history 삭제",
+      "profile 삭제"
+    ],
+    "requiredEvidence": [
+      "backend UserDataDeletionService test output",
+      "backend JdbcFacilityReportRepository photo object deletion test output",
+      "mobile user_data_deletion_test output",
+      "Android emulator deletion screen screenshot or UI tree"
+    ]
+  }
+}

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportPhotoProcessorTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportPhotoProcessorTest.java
@@ -4,9 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.easysubway.report.domain.InvalidFacilityReportException;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import javax.imageio.ImageIO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +21,26 @@ class FacilityReportPhotoProcessorTest {
 		.decode("UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA");
 
 	private final FacilityReportPhotoProcessor processor = new FacilityReportPhotoProcessor();
+
+	@Test
+	@DisplayName("JPEG 신고 사진은 원본을 재작성하고 checksum과 thumbnail을 생성한다")
+	void processJpegPhotoAndCreateChecksumAndThumbnail() throws IOException {
+		byte[] jpegBytes = encodedImage("jpg", 640, 360);
+
+		FacilityReportPhotoAttachment attachment = processor.process(
+			"elevator.jpg",
+			"image/jpeg",
+			Base64.getEncoder().encodeToString(jpegBytes)
+		);
+
+		assertThat(attachment.fileName()).isEqualTo("elevator.jpg");
+		assertThat(attachment.contentType()).isEqualTo("image/jpeg");
+		assertThat(attachment.storedBytes()).isNotEmpty();
+		assertThat(attachment.thumbnailBytes()).isNotEmpty();
+		assertThat(attachment.thumbnailBytes().length).isLessThan(attachment.storedBytes().length);
+		assertThat(attachment.sha256()).matches("[0-9a-f]{64}");
+		assertThat(attachment.sizeBytes()).isEqualTo(attachment.storedBytes().length);
+	}
 
 	@Test
 	@DisplayName("WebP 신고 사진은 기존 모바일 호환성을 위해 허용하고 metadata chunk를 제거한다")
@@ -48,6 +72,59 @@ class FacilityReportPhotoProcessorTest {
 		))
 			.isInstanceOf(InvalidFacilityReportException.class)
 			.hasMessage("사진 이미지 크기를 줄여야 합니다.");
+	}
+
+	@Test
+	@DisplayName("MIME type과 파일 확장자가 맞지 않는 사진은 거부한다")
+	void rejectMismatchedExtension() {
+		assertThatThrownBy(() -> processor.process(
+			"restored-photo.jpg",
+			"image/webp",
+			Base64.getEncoder().encodeToString(VALID_WEBP_BYTES)
+		))
+			.isInstanceOf(InvalidFacilityReportException.class)
+			.hasMessage("사진 파일 형식을 확인해야 합니다.");
+	}
+
+	@Test
+	@DisplayName("선언된 MIME type과 magic bytes가 맞지 않는 사진은 거부한다")
+	void rejectMismatchedMagicBytes() {
+		assertThatThrownBy(() -> processor.process(
+			"restored-photo.png",
+			"image/png",
+			Base64.getEncoder().encodeToString(VALID_WEBP_BYTES)
+		))
+			.isInstanceOf(InvalidFacilityReportException.class)
+			.hasMessage("사진 첨부 정보를 확인해야 합니다.");
+	}
+
+	@Test
+	@DisplayName("magic bytes만 맞고 image decode가 실패하는 사진은 거부한다")
+	void rejectCorruptImageAfterMagicBytes() {
+		byte[] corruptPng = new byte[] {
+			(byte) 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+			0, 0, 0, 0
+		};
+
+		assertThatThrownBy(() -> processor.process(
+			"corrupt.png",
+			"image/png",
+			Base64.getEncoder().encodeToString(corruptPng)
+		))
+			.isInstanceOf(InvalidFacilityReportException.class)
+			.hasMessage("사진 첨부 정보를 확인해야 합니다.");
+	}
+
+	private byte[] encodedImage(String formatName, int width, int height) throws IOException {
+		BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+		for (int y = 0; y < height; y++) {
+			for (int x = 0; x < width; x++) {
+				image.setRGB(x, y, (x + y) % 2 == 0 ? Color.WHITE.getRGB() : Color.LIGHT_GRAY.getRGB());
+			}
+		}
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+		ImageIO.write(image, formatName, output);
+		return output.toByteArray();
 	}
 
 	private byte[] appendChunk(byte[] webpBytes, String chunkType, byte[] chunkData) {

--- a/backend/src/test/java/com/easysubway/user/application/service/UserDataDeletionServiceTest.java
+++ b/backend/src/test/java/com/easysubway/user/application/service/UserDataDeletionServiceTest.java
@@ -53,7 +53,13 @@ class UserDataDeletionServiceTest {
 		assertThat(result.mobilityProfileDeleted()).isTrue();
 		assertThat(result.anonymizedReportCount()).isEqualTo(5);
 		assertThat(favoriteStations.requestedUserId).isEqualTo("anonymous-user-1");
+		assertThat(favoriteFacilities.requestedUserId).isEqualTo("anonymous-user-1");
+		assertThat(favoriteRoutes.requestedUserId).isEqualTo("anonymous-user-1");
 		assertThat(routeFeedbacks.requestedUserId).isEqualTo("anonymous-user-1");
+		assertThat(notificationPreferences.settingsRequestedUserId).isEqualTo("anonymous-user-1");
+		assertThat(notificationPreferences.devicesRequestedUserId).isEqualTo("anonymous-user-1");
+		assertThat(pushNotifications.requestedUserId).isEqualTo("anonymous-user-1");
+		assertThat(mobilityProfile.requestedUserId).isEqualTo("anonymous-user-1");
 		assertThat(reports.requestedUserId).isEqualTo("anonymous-user-1");
 	}
 
@@ -98,6 +104,7 @@ class UserDataDeletionServiceTest {
 	private static final class RecordingDeleteUserFavoriteFacilityPort implements DeleteUserFavoriteFacilityPort {
 
 		private final int count;
+		private String requestedUserId;
 
 		private RecordingDeleteUserFavoriteFacilityPort(int count) {
 			this.count = count;
@@ -105,6 +112,7 @@ class UserDataDeletionServiceTest {
 
 		@Override
 		public int deleteFavoriteFacilitiesByUserId(String userId) {
+			requestedUserId = userId;
 			return count;
 		}
 	}
@@ -112,6 +120,7 @@ class UserDataDeletionServiceTest {
 	private static final class RecordingDeleteUserFavoriteRoutePort implements DeleteUserFavoriteRoutePort {
 
 		private final int count;
+		private String requestedUserId;
 
 		private RecordingDeleteUserFavoriteRoutePort(int count) {
 			this.count = count;
@@ -119,6 +128,7 @@ class UserDataDeletionServiceTest {
 
 		@Override
 		public int deleteFavoriteRoutesByUserId(String userId) {
+			requestedUserId = userId;
 			return count;
 		}
 	}
@@ -144,6 +154,8 @@ class UserDataDeletionServiceTest {
 
 		private final boolean settingsDeleted;
 		private final int deviceCount;
+		private String settingsRequestedUserId;
+		private String devicesRequestedUserId;
 
 		private RecordingDeleteUserNotificationPreferencePort(boolean settingsDeleted, int deviceCount) {
 			this.settingsDeleted = settingsDeleted;
@@ -152,11 +164,13 @@ class UserDataDeletionServiceTest {
 
 		@Override
 		public boolean deleteNotificationSettings(String userId) {
+			settingsRequestedUserId = userId;
 			return settingsDeleted;
 		}
 
 		@Override
 		public int deleteRegisteredDevices(String userId) {
+			devicesRequestedUserId = userId;
 			return deviceCount;
 		}
 	}
@@ -164,6 +178,7 @@ class UserDataDeletionServiceTest {
 	private static final class RecordingDeleteUserPushNotificationPort implements DeleteUserPushNotificationPort {
 
 		private final int count;
+		private String requestedUserId;
 
 		private RecordingDeleteUserPushNotificationPort(int count) {
 			this.count = count;
@@ -171,6 +186,7 @@ class UserDataDeletionServiceTest {
 
 		@Override
 		public int deletePushNotifications(String userId) {
+			requestedUserId = userId;
 			return count;
 		}
 	}
@@ -178,6 +194,7 @@ class UserDataDeletionServiceTest {
 	private static final class RecordingDeleteUserMobilityProfilePort implements DeleteUserMobilityProfilePort {
 
 		private final boolean deleted;
+		private String requestedUserId;
 
 		private RecordingDeleteUserMobilityProfilePort(boolean deleted) {
 			this.deleted = deleted;
@@ -185,6 +202,7 @@ class UserDataDeletionServiceTest {
 
 		@Override
 		public boolean deleteMobilityProfile(String userId) {
+			requestedUserId = userId;
 			return deleted;
 		}
 	}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5357,8 +5357,15 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   const facilityReportPhotoProcessor = read(
     "backend/src/main/java/com/easysubway/report/application/service/FacilityReportPhotoProcessor.java",
   );
+  const userDataDeletionService = read(
+    "backend/src/main/java/com/easysubway/user/application/service/UserDataDeletionService.java",
+  );
+  const userDataDeletionTest = read(
+    "backend/src/test/java/com/easysubway/user/application/service/UserDataDeletionServiceTest.java",
+  );
   const prodConfig = read("backend/src/main/resources/application-prod.yml");
   const backendAppEnvAllowlist = read("tools/deploy/backend-app-env.allowlist");
+  const securityPrivacyEvidence = readJson("apps/mobile/release/security-privacy-release-evidence.json");
 
   assert.equal(gate.schemaVersion, 1);
   assert.equal(gate.applicationId, "easysubway");
@@ -5374,16 +5381,20 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
     "mobile_cleartext_disabled",
     "mobile_debug_network_overrides_limited",
     "mobile_release_signing_externalized",
+    "datapack_signing_key_lifecycle",
     "mobile_test_credentials_absent",
+    "mobile_release_artifact_secret_trace_scan",
     "mobile_error_stacktrace_sanitized",
     "backend_admin_auth_required",
     "backend_admin_basic_auth_transition_gate",
     "backend_role_authorization",
     "backend_report_photo_upload_limits",
+    "backend_report_photo_malicious_upload_defense",
     "backend_report_abuse_control_release_gate",
     "backend_error_response_sanitized",
     "backend_api_traffic_monitoring",
     "backend_sensitive_log_minimization",
+    "user_data_deletion_retention_e2e",
     "repository_secrets_not_tracked",
     "repository_provider_storage_exposure_guard",
     "repository_dependency_review",
@@ -5393,11 +5404,11 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.deepEqual([...items.keys()].sort(), requiredIds.toSorted());
 
   const areas = new Set(gate.items.map((item) => item.area));
-  assert.deepEqual([...areas].sort(), ["backend", "cross-store", "mobile", "repository"]);
+  assert.deepEqual([...areas].sort(), ["backend", "cross-store", "mobile", "repository", "user-data"]);
 
   for (const id of requiredIds) {
     const item = items.get(id);
-    assert.match(item.area, /^(mobile|backend|repository|cross-store)$/);
+    assert.match(item.area, /^(mobile|backend|repository|cross-store|user-data)$/);
     assert.equal(item.severity, "release-blocker", `${id} must be release-blocker`);
     assert.equal(typeof item.titleKo, "string", `${id} must have Korean title`);
     assert.ok(item.titleKo.length > 0, `${id} title must not be empty`);
@@ -5416,6 +5427,17 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.match(androidProfileManifest, /android:usesCleartextTraffic="true"/);
   assert.match(androidBuildGradle, /throw GradleException\([\s\S]*Android release signing values are missing:/);
   assert.doesNotMatch(androidBuildGradle, /signingConfig\s*=\s*signingConfigs\.getByName\("debug"\)/);
+  const datapackSigningGate = items.get("datapack_signing_key_lifecycle");
+  assert.match(datapackSigningGate.readyWhenKo, /public keyring|rotation|revocation|rollback/i);
+  assert.ok(datapackSigningGate.evidence.includes("manifest-signature-test-vector"));
+  assert.ok(datapackSigningGate.evidence.includes("key-rotation-revocation-record"));
+  assert.ok(datapackSigningGate.linkedArtifacts.includes("apps/mobile/release/security-privacy-release-evidence.json"));
+  const releaseArtifactScanGate = items.get("mobile_release_artifact_secret_trace_scan");
+  assert.match(releaseArtifactScanGate.readyWhenKo, /provider key|signing private key|upload URL|receipt token|placeholder endpoint/i);
+  assert.ok(releaseArtifactScanGate.evidence.includes("release-artifact-secret-scan-output"));
+  assert.ok(releaseArtifactScanGate.evidence.includes("release-network-trace-review"));
+  assert.ok(releaseArtifactScanGate.linkedArtifacts.includes(".github/workflows/release-artifacts.yml"));
+  assert.ok(releaseArtifactScanGate.linkedArtifacts.includes("apps/mobile/release/security-privacy-release-evidence.json"));
   assert.match(commonExceptionHandler, /messages\.message\("common\.error\.invalid-parameter"\)/);
   assert.match(messages, /^common\.error\.invalid-parameter=요청 값을 확인해야 합니다\.$/m);
   assert.doesNotMatch(commonExceptionHandler, /StackTrace|printStackTrace|getStackTrace/);
@@ -5467,6 +5489,25 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.match(facilityReportPhotoProcessor, /requireSupportedMagic/);
   assert.match(facilityReportPhotoProcessor, /readDimensions/);
   assert.match(facilityReportPhotoProcessor, /ImageIO\.read/);
+  const maliciousUploadGate = items.get("backend_report_photo_malicious_upload_defense");
+  assert.match(maliciousUploadGate.readyWhenKo, /MIME|extension|magic bytes|checksum|image decode|thumbnail|orphan cleanup/i);
+  assert.ok(maliciousUploadGate.evidence.includes("malicious-photo-upload-tests"));
+  assert.ok(maliciousUploadGate.evidence.includes("orphan-cleanup-failure-path-test"));
+  assert.ok(maliciousUploadGate.linkedArtifacts.includes("backend/src/test/java/com/easysubway/report/application/service/FacilityReportPhotoProcessorTest.java"));
+  assert.ok(maliciousUploadGate.linkedArtifacts.includes("backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java"));
+  const deletionGate = items.get("user_data_deletion_retention_e2e");
+  assert.match(deletionGate.readyWhenKo, /local data|report link|photo object|notification|favorite|search|profile/i);
+  assert.ok(deletionGate.evidence.includes("backend-user-data-deletion-service-test"));
+  assert.ok(deletionGate.evidence.includes("mobile-user-data-deletion-local-test"));
+  assert.ok(deletionGate.evidence.includes("android-emulator-deletion-ui-evidence"));
+  assert.ok(deletionGate.linkedArtifacts.includes("apps/mobile/test/user_data_deletion_test.dart"));
+  assert.match(userDataDeletionService, /deleteUserFavoriteStationPort\.deleteFavoriteStationsByUserId\(normalizedUserId\)/);
+  assert.match(userDataDeletionService, /deleteUserNotificationPreferencePort\.deleteNotificationSettings\(normalizedUserId\)/);
+  assert.match(userDataDeletionService, /deleteUserMobilityProfilePort\.deleteMobilityProfile\(normalizedUserId\)/);
+  assert.match(userDataDeletionService, /anonymizeUserFacilityReportPort\.anonymizeFacilityReportsByUserId\(normalizedUserId\)/);
+  assert.match(userDataDeletionTest, /favoriteFacilities\.requestedUserId/);
+  assert.match(userDataDeletionTest, /notificationPreferences\.settingsRequestedUserId/);
+  assert.match(userDataDeletionTest, /mobilityProfile\.requestedUserId/);
   assert.match(gitignore, /^\*.pem$/m);
   assert.match(gitignore, /^\*.key$/m);
   assert.match(gitignore, /^google-services\.json$/m);
@@ -5493,6 +5534,14 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.ok(dependencyReview.linkedArtifacts.includes("apps/mobile/android/build.gradle.kts"));
   assert.ok(items.get("cross_store_privacy_security_consistency").linkedArtifacts.includes("apps/mobile/release/store-privacy-inventory.json"));
   assert.ok(items.get("cross_store_privacy_security_consistency").linkedArtifacts.includes("apps/mobile/release/store-submission-readiness.json"));
+  assert.match(items.get("cross_store_privacy_security_consistency").readyWhenKo, /network trace|Data safety|App Privacy|PrivacyInfo/i);
+  assert.equal(securityPrivacyEvidence.releaseBlockerPolicy, true);
+  assert.ok(securityPrivacyEvidence.sensitiveEvidenceLocalOnlyPath.startsWith(".codex/evidence/"));
+  assert.deepEqual(
+    securityPrivacyEvidence.releaseArtifactSecretScan.forbiddenClasses.toSorted(),
+    ["local-placeholder-endpoint", "provider-key", "receipt-token", "signing-private-key", "upload-url"].toSorted(),
+  );
+  assert.ok(securityPrivacyEvidence.userDataDeletionE2E.targets.includes("report photo object 삭제"));
 });
 
 test("관리자 사용자 활동 화면은 API 오류율 운영 지표를 표시한다", () => {


### PR DESCRIPTION
## 관련 이슈

close #905

## 작업 배경

- 출시 100% 보안·개인정보 gate에서 데이터팩 서명 key lifecycle, 릴리즈 산출물 secret/network trace scan, 악성 사진 업로드 방어, 사용자 데이터 삭제·retention E2E 증거 요구가 한 곳에 고정되어 있지 않았다.
- QA 요청에 따라 Android 수동 증거는 실기기가 아니라 로컬 에뮬레이터 `emulator-5554`에서 확인했다.

## 작업 내용

- `release-security-gate.json`에 데이터팩 서명 key lifecycle, 모바일 릴리즈 secret/network trace scan, 악성 신고 사진 업로드 방어, 사용자 데이터 삭제·retention E2E release blocker를 추가했다.
- `security-privacy-release-evidence.json`을 추가해 민감 증거 local-only 보관 위치, 금지 secret class, 악성 업로드 방어 체크, 삭제 E2E 대상과 필수 증거를 기계 검증 가능한 계약으로 고정했다.
- 신고 사진 처리 테스트에 JPEG checksum/thumbnail 생성, MIME-extension mismatch, magic bytes mismatch, corrupt image decode 거부 케이스를 추가했다.
- 사용자 데이터 삭제 서비스 테스트가 즐겨찾기, 알림 설정/기기, push, mobility profile, report anonymization을 같은 정규화 userId로 처리하는지 모두 확인하도록 보강했다.
- repository contract가 새 release gate 항목, linked artifact, evidence 계약, Android emulator evidence 요구를 검증하도록 확장했다.

## 검증

- 실행한 명령과 결과:
- `python3 -m json.tool apps/mobile/release/release-security-gate.json >/tmp/release-security-gate-905.json`: exit 0
- `python3 -m json.tool apps/mobile/release/security-privacy-release-evidence.json >/tmp/security-privacy-release-evidence-905.json`: exit 0
- `git diff --check`: exit 0
- `node --test tools/ci/*.test.mjs`: 111 tests passed, exit 0
- `cd backend && ./gradlew test --tests '*FacilityReport*' --tests '*UserDataDeletion*'`: BUILD SUCCESSFUL
- `cd apps/mobile && /Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/user_data_deletion_test.dart test/facility_report_test.dart`: 33 tests passed, exit 0
- `cd apps/mobile && /Volumes/MACSSD/Android/flutter/flutter/bin/flutter build apk --debug`: built `build/app/outputs/flutter-apk/app-debug.apk`, exit 0
- `cd apps/mobile && /Volumes/MACSSD/Android/flutter/flutter/bin/flutter test`: 516 tests passed, exit 0
- `cd backend && ./gradlew test`: BUILD SUCCESSFUL

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| release security/privacy gate 계약 | Repository | `node --test tools/ci/*.test.mjs` | repository contract 111 tests passed | 통과 |
| 악성 신고 사진 업로드 방어 | Backend | `./gradlew test --tests '*FacilityReport*' --tests '*UserDataDeletion*'` | `FacilityReportPhotoProcessorTest` checksum/thumbnail, MIME/extension, magic bytes, decode failure 검증 | 통과 |
| 사용자 데이터 삭제·retention | Backend/Mobile | backend targeted test, Flutter targeted/full test | backend BUILD SUCCESSFUL, mobile targeted 33 tests passed, full 516 tests passed | 통과 |
| Android 삭제 안내 UI | Android emulator | `flutter emulators`, `flutter devices`, `adb -s emulator-5554 ...`, UI tree/screenshot/logcat capture | local-only: `.codex/evidence/905/android-emulator/local-deletion-ui.xml`, `local-deletion.png`, `app-pid-4394-logcat.txt`; UI tree에서 `즐겨찾기, 최근 검색, 이동 조건... 삭제`, `이미 보낸 시설 제보, 사진, 위치 정보는 이 작업으로 삭제되지 않습니다.`, `법적·보안상 필요한 최소 기록...` 확인 | 통과 |
| 로컬 에뮬레이터 대상 확인 | Android emulator | `flutter emulators`, `flutter devices`, `adb -s emulator-5554 shell getprop ro.kernel.qemu`, `adb -s emulator-5554 shell getprop ro.product.model` | `maum_on_api36`, `emulator-5554`, `ro.kernel.qemu=1`, `sdk_gphone64_arm64`; 실기기 `RFKYA01VMQY`는 검증 대상에서 제외 | 통과 |

Local-only evidence 사유: 스크린샷과 logcat에는 로컬 emulator/session/process 식별자가 포함되고 외부 업로드 승인이 없어 git에 커밋하거나 PR에 직접 업로드하지 않았다. 대신 UI tree 핵심 문구와 실행 명령 결과를 PR에 기록했다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/release/release-security-gate.json`의 새 release blocker 범위와 `tools/ci/repository-contract.test.mjs`의 기계 검증 계약.
- 실제 secret, key fingerprint, network trace 원문은 release/RC 시점에 `.codex/evidence/security-privacy-release/<pr-or-rc>/` 아래 local-only로 보관하는 계약만 추가했다.

## 리스크

- 이번 PR은 runtime 경로를 새로 만들지 않고 release gate와 테스트 증거를 강화한다. 실제 Play-generated APK/IPA secret scan과 운영 network trace는 RC 산출물이 생긴 뒤 별도 증거로 채워야 한다.

## 체크리스트

- [x] CI 결과를 확인했다. Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan, Release Artifacts 모두 pass.
- [x] CodeRabbit 리뷰를 확인했다. `No actionable comments were generated in the recent review.`
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. CodeRabbit이 완료되어 fallback 불필요.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. CD 직접 변경은 없고 Release Artifacts check pass를 확인했다.
