### PR TITLE
[CI] 운영 env runtime fallback으로 CD preflight 복구

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -657,6 +657,17 @@ test("CD dotenv 검증은 운영 fallback env 계약을 반영한다", async () 
     /EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER[\s\S]*EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT/
   );
 
+  await writeFile(envFile, [
+    ...deploymentEnvLines,
+    "EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED=true",
+    "EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER=ops-team",
+    "",
+  ].join("\n"));
+  await assert.rejects(
+    execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root }),
+    /EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT/
+  );
+
   await writeFile(envFile, "EASYSUBWAY_POSTGRES_DB=easysubway\n");
   await assert.rejects(
     execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root }),

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -545,7 +545,7 @@ test("GitHub Actions 환경값은 dotenv secret 하나로 관리한다", () => {
 test("CD dotenv 검증은 운영 fallback env 계약을 반영한다", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "easysubway-cd-env-"));
   const envFile = path.join(dir, "deploy.env");
-  await writeFile(envFile, [
+  const deploymentEnvLines = [
     "EASYSUBWAY_POSTGRES_DB=easysubway",
     "EASYSUBWAY_POSTGRES_USER=easysubway",
     "EASYSUBWAY_POSTGRES_PASSWORD=secret",
@@ -583,7 +583,8 @@ test("CD dotenv 검증은 운영 fallback env 계약을 반영한다", async () 
     "EASYSUBWAY_ANDROID_KEY_ALIAS=",
     "EASYSUBWAY_ANDROID_KEY_PASSWORD=",
     "",
-  ].join("\n"));
+  ];
+  await writeFile(envFile, deploymentEnvLines.join("\n"));
 
   const validator = read("tools/ci/validate-deployment-env.sh");
   assert.match(validator, /EASYSUBWAY_REPORT_ABUSE_STORE_MODE/);
@@ -591,6 +592,16 @@ test("CD dotenv 검증은 운영 fallback env 계약을 반영한다", async () 
   assert.match(validator, /EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER/);
   assert.match(validator, /EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT/);
   await execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root });
+
+  await writeFile(envFile, [
+    ...deploymentEnvLines,
+    "EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED=true",
+    "",
+  ].join("\n"));
+  await assert.rejects(
+    execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root }),
+    /EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER[\s\S]*EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT/
+  );
 
   await writeFile(envFile, "EASYSUBWAY_POSTGRES_DB=easysubway\n");
   await assert.rejects(

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -613,6 +613,30 @@ test("CD dotenv 검증은 운영 fallback env 계약을 반영한다", async () 
     /EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER[\s\S]*EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT/
   );
 
+  await writeFile(envFile, [
+    ...deploymentEnvLines,
+    "EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED=true",
+    "EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER=   ",
+    "EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT=   ",
+    "",
+  ].join("\n"));
+  await assert.rejects(
+    execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root }),
+    /EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER[\s\S]*EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT/
+  );
+
+  await writeFile(envFile, [
+    ...deploymentEnvLines,
+    "EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED=true",
+    'EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER=""',
+    'EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT=""',
+    "",
+  ].join("\n"));
+  await assert.rejects(
+    execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root }),
+    /EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER[\s\S]*EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT/
+  );
+
   await writeFile(envFile, "EASYSUBWAY_POSTGRES_DB=easysubway\n");
   await assert.rejects(
     execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root }),

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -603,6 +603,16 @@ test("CD dotenv 검증은 운영 fallback env 계약을 반영한다", async () 
     /EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER[\s\S]*EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT/
   );
 
+  await writeFile(envFile, [
+    ...deploymentEnvLines,
+    'EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED="true"',
+    "",
+  ].join("\n"));
+  await assert.rejects(
+    execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root }),
+    /EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER[\s\S]*EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT/
+  );
+
   await writeFile(envFile, "EASYSUBWAY_POSTGRES_DB=easysubway\n");
   await assert.rejects(
     execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root }),

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -559,7 +559,6 @@ test("CD dotenv 검증은 운영 fallback env 계약을 반영한다", async () 
     "EASYSUBWAY_REPORT_UPLOAD_BUCKET=easysubway-report-uploads",
     "EASYSUBWAY_REPORT_UPLOAD_MAX_BYTES=921600",
     "EASYSUBWAY_REPORT_UPLOAD_URL_TTL_SECONDS=900",
-    "EASYSUBWAY_REPORT_ABUSE_STORE_MODE=local",
     "EASYSUBWAY_REPORT_UPLOAD_PUBLIC_BASE_URL=https://uploads.example.com",
     "EASYSUBWAY_OBJECT_STORAGE_ENDPOINT=https://object-storage.example.com",
     "EASYSUBWAY_REPORT_OBJECT_STORAGE_INTERNAL_ENDPOINT=http://object-storage:9000",
@@ -575,9 +574,6 @@ test("CD dotenv 검증은 운영 fallback env 계약을 반영한다", async () 
     "EASYSUBWAY_ENABLE_PUSH_NOTIFICATIONS=false",
     "EASYSUBWAY_ADMIN_USERNAME=admin",
     "EASYSUBWAY_ADMIN_PASSWORD=secret",
-    "EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED=false",
-    "EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER=",
-    "EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT=",
     "EASYSUBWAY_PRIVACY_POLICY_URL=https://example.com/privacy",
     "EASYSUBWAY_SUPPORT_EMAIL=support@example.com",
     "EASYSUBWAY_SECURITY_EMAIL=security@example.com",
@@ -589,6 +585,11 @@ test("CD dotenv 검증은 운영 fallback env 계약을 반영한다", async () 
     "",
   ].join("\n"));
 
+  const validator = read("tools/ci/validate-deployment-env.sh");
+  assert.match(validator, /EASYSUBWAY_REPORT_ABUSE_STORE_MODE/);
+  assert.match(validator, /EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED/);
+  assert.match(validator, /EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER/);
+  assert.match(validator, /EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT/);
   await execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root });
 
   await writeFile(envFile, "EASYSUBWAY_POSTGRES_DB=easysubway\n");

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -615,6 +615,26 @@ test("CD dotenv 검증은 운영 fallback env 계약을 반영한다", async () 
 
   await writeFile(envFile, [
     ...deploymentEnvLines,
+    "EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED=TRUE",
+    "",
+  ].join("\n"));
+  await assert.rejects(
+    execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root }),
+    /EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER[\s\S]*EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT/
+  );
+
+  await writeFile(envFile, [
+    ...deploymentEnvLines,
+    "EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED=maybe",
+    "",
+  ].join("\n"));
+  await assert.rejects(
+    execFileAsync("tools/ci/validate-deployment-env.sh", [envFile], { cwd: root }),
+    /EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED/
+  );
+
+  await writeFile(envFile, [
+    ...deploymentEnvLines,
     "EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED=true",
     "EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER=   ",
     "EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT=   ",

--- a/tools/ci/validate-deployment-env.sh
+++ b/tools/ci/validate-deployment-env.sh
@@ -40,6 +40,8 @@ env_value() {
         value="${value:1:${#value}-2}"
       fi
       ;;
+    *)
+      ;;
   esac
   trim_blank "${value}"
 }

--- a/tools/ci/validate-deployment-env.sh
+++ b/tools/ci/validate-deployment-env.sh
@@ -22,8 +22,20 @@ has_non_empty_env_value() {
   grep -Eq "^${name}=.+" "${env_file}"
 }
 
+env_value() {
+  local name="$1"
+  local value
+  value="$(sed -nE "s/^${name}=(.*)$/\\1/p" "${env_file}" | tail -n 1)"
+  case "${value}" in
+    \"*\"|\'*\')
+      value="${value:1:${#value}-2}"
+      ;;
+  esac
+  printf '%s' "${value}"
+}
+
 is_admin_basic_auth_enabled() {
-  grep -Eq "^EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED=true$" "${env_file}"
+  [[ "$(env_value EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED)" == "true" ]]
 }
 
 is_satisfied_by_runtime_fallback() {

--- a/tools/ci/validate-deployment-env.sh
+++ b/tools/ci/validate-deployment-env.sh
@@ -17,6 +17,15 @@ has_env_name() {
   grep -Eq "^${name}=" "${env_file}"
 }
 
+has_non_empty_env_value() {
+  local name="$1"
+  grep -Eq "^${name}=.+" "${env_file}"
+}
+
+is_admin_basic_auth_enabled() {
+  grep -Eq "^EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED=true$" "${env_file}"
+}
+
 is_satisfied_by_runtime_fallback() {
   local name="$1"
   case "${name}" in
@@ -39,10 +48,10 @@ is_satisfied_by_runtime_fallback() {
       true
       ;;
     EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER)
-      true
+      ! is_admin_basic_auth_enabled
       ;;
     EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT)
-      true
+      ! is_admin_basic_auth_enabled
       ;;
     *)
       false
@@ -50,9 +59,25 @@ is_satisfied_by_runtime_fallback() {
   esac
 }
 
+is_required_env_satisfied() {
+  local name="$1"
+  case "${name}" in
+    EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER|EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT)
+      if is_admin_basic_auth_enabled; then
+        has_non_empty_env_value "${name}"
+      else
+        has_env_name "${name}" || is_satisfied_by_runtime_fallback "${name}"
+      fi
+      ;;
+    *)
+      has_env_name "${name}" || is_satisfied_by_runtime_fallback "${name}"
+      ;;
+  esac
+}
+
 missing_names=()
 while IFS= read -r name; do
-  if [[ -n "${name}" ]] && ! has_env_name "${name}" && ! is_satisfied_by_runtime_fallback "${name}"; then
+  if [[ -n "${name}" ]] && ! is_required_env_satisfied "${name}"; then
     missing_names+=("${name}")
   fi
 done < <(sed -nE 's/^([A-Z0-9_]+)=.*/\1/p' .env.example)

--- a/tools/ci/validate-deployment-env.sh
+++ b/tools/ci/validate-deployment-env.sh
@@ -44,8 +44,32 @@ env_value() {
   trim_blank "${value}"
 }
 
+normalized_env_value() {
+  local name="$1"
+  env_value "${name}" | tr '[:upper:]' '[:lower:]'
+}
+
+is_bool_env_value() {
+  local name="$1"
+  case "$(normalized_env_value "${name}")" in
+    true|false|on|off|yes|no|1|0)
+      true
+      ;;
+    *)
+      false
+      ;;
+  esac
+}
+
 is_admin_basic_auth_enabled() {
-  [[ "$(env_value EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED)" == "true" ]]
+  case "$(normalized_env_value EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED)" in
+    true|on|yes|1)
+      true
+      ;;
+    *)
+      false
+      ;;
+  esac
 }
 
 is_satisfied_by_runtime_fallback() {
@@ -84,6 +108,13 @@ is_satisfied_by_runtime_fallback() {
 is_required_env_satisfied() {
   local name="$1"
   case "${name}" in
+    EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED)
+      if has_env_name "${name}"; then
+        is_bool_env_value "${name}"
+      else
+        is_satisfied_by_runtime_fallback "${name}"
+      fi
+      ;;
     EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER|EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT)
       if is_admin_basic_auth_enabled; then
         has_non_empty_env_value "${name}"

--- a/tools/ci/validate-deployment-env.sh
+++ b/tools/ci/validate-deployment-env.sh
@@ -32,6 +32,18 @@ is_satisfied_by_runtime_fallback() {
     EASYSUBWAY_OBJECT_STORAGE_PREAUTH_BASE_URL)
       true
       ;;
+    EASYSUBWAY_REPORT_ABUSE_STORE_MODE)
+      true
+      ;;
+    EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED)
+      true
+      ;;
+    EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER)
+      true
+      ;;
+    EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT)
+      true
+      ;;
     *)
       false
       ;;

--- a/tools/ci/validate-deployment-env.sh
+++ b/tools/ci/validate-deployment-env.sh
@@ -19,19 +19,29 @@ has_env_name() {
 
 has_non_empty_env_value() {
   local name="$1"
-  grep -Eq "^${name}=.+" "${env_file}"
+  [[ -n "$(env_value "${name}")" ]]
+}
+
+trim_blank() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "${value}"
 }
 
 env_value() {
   local name="$1"
   local value
   value="$(sed -nE "s/^${name}=(.*)$/\\1/p" "${env_file}" | tail -n 1)"
+  value="$(trim_blank "${value}")"
   case "${value}" in
     \"*\"|\'*\')
-      value="${value:1:${#value}-2}"
+      if (( ${#value} >= 2 )); then
+        value="${value:1:${#value}-2}"
+      fi
       ;;
   esac
-  printf '%s' "${value}"
+  trim_blank "${value}"
 }
 
 is_admin_basic_auth_enabled() {


### PR DESCRIPTION
## 관련 이슈

close #906

## 작업 배경

- #980 merge commit `cdc8a220c7cceced06faa90b8f531b1f6e9751a8`의 post-merge CD가 `Validate deployment dotenv contract` 단계에서 실패했습니다.
- 실패 로그의 누락 변수는 `EASYSUBWAY_REPORT_ABUSE_STORE_MODE`, `EASYSUBWAY_ADMIN_BASIC_AUTH_ENABLED`, `EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_OWNER`, `EASYSUBWAY_ADMIN_BASIC_AUTH_EXCEPTION_EXPIRES_AT`입니다.
- 네 항목은 `application-prod.yml`에 안전한 runtime 기본값이 있고, 기존 `EASYSUBWAY_ENV` secret 갱신 전에도 CD preflight가 불필요하게 실패하지 않아야 합니다.

## 작업 내용

- `tools/ci/validate-deployment-env.sh`에 abuse store mode와 admin Basic auth 전환 항목의 runtime fallback 허용을 추가했습니다.
- admin Basic auth가 활성화된 경우 exception owner/expiry는 계속 필수로 검증하고, `true/on/yes/1`, quoted value, uppercase value, blank value를 backend 운영 정책과 맞춰 정규화했습니다.
- repository contract test에서 네 fallback 변수를 생략한 배포 dotenv, Basic auth partial exception 누락, invalid boolean, blank/quoted-empty exception 거부를 고정했습니다.
- CodeRabbit 지적에 따라 quote stripping `case`에 명시적 default 분기를 추가하고 owner만 존재하는 partial exception 테스트를 보강했습니다.

## 검증

- 실행한 명령과 결과:
- `node --test --test-name-pattern "CD dotenv 검증" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
- `tools/ci/validate-deployment-env.sh tools/ci/fixtures/deployment-prod-valid.env`: exit 0
- `git diff --check`: exit 0
- `node --test tools/ci/*.test.mjs`: exit 0, 111 tests passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| CD 실패 원인 | GitHub Actions | failed CD run 로그 확인 | https://github.com/AquilaXk/easysubway/actions/runs/28238931066 | deployment dotenv contract에서 네 fallback 변수 누락으로 실패 |
| Runtime fallback contract | local Node.js | `node --test --test-name-pattern "CD dotenv 검증" tools/ci/repository-contract.test.mjs` | command output: 1 test passed | 통과 |
| Deployment env fixture | local shell | `tools/ci/validate-deployment-env.sh tools/ci/fixtures/deployment-prod-valid.env` | command output: exit 0 | 통과 |
| Repository CI contract | local Node.js | `node --test tools/ci/*.test.mjs` | command output: 111 tests passed | 통과 |
| GitHub required checks | GitHub Actions | PR #981 checks 확인 | Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan, Android Release Artifact, Backend Release Image, SonarCloud, CodeRabbit all pass | 통과 |
| CodeRabbit review fix | GitHub PR review threads | CodeRabbit inline thread 확인 | `discussion_r3481643363`, `discussion_r3481643380`에 해결 답글과 commit `aa9783ca` 연결 | resolved |
| Codex CLI fallback review | GitHub PR review | CodeRabbit 지연 중 fallback review 실행 및 결과 게시 | PR review `4579759092`, actionable 0 | 통과 |
| Post-merge CD | GitHub Actions main | merge commit `e87c56e4d8653f628bde0830af38fd1e9ae725a1` workflow 확인 | CD run https://github.com/AquilaXk/easysubway/actions/runs/28241909257 | success |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/ci/validate-deployment-env.sh`의 fallback 목록은 `application-prod.yml` 기본값과 맞추되, Basic auth enabled가 true-ish이면 exception owner/expiry를 계속 release blocker로 유지하는 분기입니다.

## 리스크

- 이 PR은 secret 값을 완화하지 않고, 앱 런타임에 이미 기본값이 있는 운영 전환 항목만 validator fallback으로 허용합니다.
- `EASYSUBWAY_ADMIN_USERNAME`, `EASYSUBWAY_ADMIN_PASSWORD`, DB, object storage, data pack signing 값은 계속 필수입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
