### PR TITLE
[CI] SonarCloud 코드리뷰 설정

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -24,10 +24,6 @@ on:
       - "sonar-project.properties"
       - ".github/workflows/sonarcloud.yml"
 
-permissions:
-  contents: read
-  pull-requests: read
-
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
@@ -35,6 +31,7 @@ jobs:
   automatic-analysis:
     if: vars.SONARCLOUD_CI_ENABLED != 'true'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Keep SonarCloud automatic analysis
         run: echo "SonarCloud CI scanner is skipped because SONARCLOUD_CI_ENABLED is not true."
@@ -42,6 +39,9 @@ jobs:
   sonarcloud:
     if: vars.SONARCLOUD_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,67 @@
+name: SonarCloud
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - "backend/**"
+      - "apps/mobile/**"
+      - "tools/**"
+      - "sonar-project.properties"
+      - ".github/workflows/sonarcloud.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/**"
+      - "apps/mobile/**"
+      - "tools/**"
+      - "sonar-project.properties"
+      - ".github/workflows/sonarcloud.yml"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  automatic-analysis:
+    if: vars.SONARCLOUD_CI_ENABLED != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Keep SonarCloud automatic analysis
+        run: echo "SonarCloud CI scanner is skipped because SONARCLOUD_CI_ENABLED is not true."
+
+  sonarcloud:
+    if: vars.SONARCLOUD_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Build backend classes
+        working-directory: backend
+        run: ./gradlew check --no-daemon
+
+      - name: SonarCloud scan
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,7 +12,9 @@ sonar.exclusions=\
   **/node_modules/**,\
   **/.dart_tool/**,\
   **/coverage/**,\
-  apps/mobile/lib/**/*.g.dart
+  apps/mobile/lib/**/*.g.dart,\
+  tools/**/fixtures/**,\
+  tools/datapack/sources/**
 
 sonar.coverage.exclusions=\
   apps/mobile/**,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,22 @@
+sonar.organization=aquilaxk
+sonar.projectKey=AquilaXk_easysubway
+sonar.projectName=easysubway
+sonar.host.url=https://sonarcloud.io
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=backend/src/main,apps/mobile/lib,tools
+sonar.tests=backend/src/test,apps/mobile/test
+
+sonar.exclusions=\
+  **/build/**,\
+  **/node_modules/**,\
+  **/.dart_tool/**,\
+  **/coverage/**,\
+  apps/mobile/lib/**/*.g.dart
+
+sonar.coverage.exclusions=\
+  apps/mobile/**,\
+  backend/src/main/resources/**,\
+  tools/**
+
+sonar.java.binaries=backend/build/classes/java/main


### PR DESCRIPTION
## 관련 이슈

close #982

## 작업 배경

PR에서 SonarCloud 분석 결과를 코드 품질 리뷰 신호로 확인할 수 있도록 GitHub Actions 기반 분석 설정이 필요하다. Automatic Analysis와 CI scanner가 동시에 동작할 수 있는 위험은 repository variable 게이트로 제어한다.

## 작업 내용

- `sonar-project.properties`에 `easysubway` SonarCloud 프로젝트 식별자와 backend/mobile/tools 분석 경로를 추가했다.
- tool data와 fixture가 first-party code로 분석되지 않도록 `tools/**/fixtures/**`, `tools/datapack/sources/**`를 SonarCloud 제외 경로에 추가했다.
- PR 및 `main` push에서 동작하는 `SonarCloud` workflow를 추가했다.
- scanner는 `SONARCLOUD_CI_ENABLED=true`이고 fork PR이 아닐 때만 실행하도록 제한했다.
- `SONAR_TOKEN`은 로컬 `.env`와 GitHub Actions repository secret에 설정했다.
- SonarCloud Automatic Analysis가 이미 켜져 있어 `SONARCLOUD_CI_ENABLED` repository variable은 `false`로 유지했다.

## 검증

- 실행한 명령과 결과:
  - `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/sonarcloud.yml`: exit 0
  - `node --test tools/ci/*.test.mjs`: exit 0, 111/111 tests passed
  - `./gradlew check --no-daemon` in `backend`: exit 0, BUILD SUCCESSFUL
  - `git diff --check`: exit 0
  - `gh secret list --repo AquilaXk/easysubway | awk '$1 == "SONAR_TOKEN" {print $1}'`: `SONAR_TOKEN`
  - `gh variable list --repo AquilaXk/easysubway | awk '$1 == "SONARCLOUD_CI_ENABLED" {print $1 "=" $2}'`: `SONARCLOUD_CI_ENABLED=false`
  - `codex review --base origin/main --title "[CI] SonarCloud 코드리뷰 설정"`: actionable 1건 확인 후 `f440922`에서 수정, 원래 inline thread에 해결 답글 작성 및 resolve
  - PR checks: CI, Release Artifacts, SonarCloud Code Analysis 모두 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| SonarCloud workflow YAML | local | Ruby YAML parser | command output | exit 0 |
| Repository contract | local | Node test runner | `111/111 tests passed` | 통과 |
| Backend classes for scanner | local | Gradle check | `BUILD SUCCESSFUL` | 통과 |
| Actions secret | GitHub Actions | `gh secret list` | `SONAR_TOKEN` key presence | 설정됨 |
| Scanner gate variable | GitHub Actions | `gh variable list` | `SONARCLOUD_CI_ENABLED=false` | Automatic Analysis 충돌 방지 |
| SonarCloud Automatic Analysis | SonarCloud/GitHub | PR check | `SonarCloud Code Analysis` check | 통과 |
| SonarCloud workflow gate | GitHub Actions | PR check | `automatic-analysis` pass, `sonarcloud` skipped | 통과 |
| CI checks | GitHub Actions | PR checks | CI run `28242155007` | 통과 |
| Release artifact checks | GitHub Actions | PR checks | Release Artifacts run `28242154516` | 통과 |
| Review fallback | GitHub PR review | Codex CLI fallback review | PR review `4579921273`, discussion `3481779215` | actionable 1건 수정 및 resolve |
| UI evidence | 해당 없음 | CI 설정 변경 | 증거 불필요 사유: 화면/접근성 동작 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: Automatic Analysis가 켜진 현재 상태에서 `SONARCLOUD_CI_ENABLED=false`가 scanner 실행을 막고, 필요 시 `true`로 전환할 수 있는지 확인하면 된다.

## 리스크

- SonarCloud CI scanner를 실제로 켜려면 SonarCloud 쪽 Automatic Analysis를 먼저 끈 뒤 `SONARCLOUD_CI_ENABLED=true`로 전환해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. 배포 workflow 변경은 없고 PR release artifact checks만 확인했다.
