### PR TITLE
[Refactor] eGovFrame control-plane 선택 적용 기준 확정

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The local-first mobile runtime is the default user path. Station search, route s
 
 The backend control-plane runtime is kept for report intake, report review, admin/operator pages, data-pack source control, and release operations. Removed mobile station, route, account, profile, notification, and favorite APIs must not become required for ordinary app launch or offline route guidance.
 
+eGovFrame은 backend control-plane에만 선택 적용한다. 현재 production 허용 영역은 admin/operator pagination, data collection batch control-plane, 운영 logging/property/id 후보 검증이며, Flutter mobile runtime, ordinary mobile API, realtime hot path, token/crypto boundary, domain/application/public JSON contracts에는 eGovFrame type이나 starter를 흘리지 않는다. 이 기준은 `backend/quality/egovframe-control-plane-gate.json`과 repository contract test로 검증한다.
+
 The receipt-token report boundary lets a user check or confirm a submitted report without an account. The plain receipt token is issued once, stored on the device, and must not be logged, returned again, or used in URLs after issuance; the backend stores only a peppered hash.
 
 The data-pack pointer contract is atomic: an installed pack becomes current only after size, hash, gzip, SQLite quick check, schema, table, and production signature validation. Failed updates keep the previous `current.json` pointer and preserve user-owned data.

--- a/backend/quality/egovframe-control-plane-gate.json
+++ b/backend/quality/egovframe-control-plane-gate.json
@@ -1,0 +1,90 @@
+{
+  "schemaVersion": 1,
+  "gateId": "egovframe-control-plane-adoption",
+  "framework": {
+    "egovFrame": "5.0.0",
+    "springBoot": "3.5.x",
+    "java": "21"
+  },
+  "decision": "selective_control_plane_only",
+  "allowedProductionSurface": [
+    "backend_admin_operator_pages",
+    "data_collection_batch_control_plane",
+    "operations_logging_properties_ids"
+  ],
+  "noGoSurface": [
+    "flutter_mobile_runtime",
+    "ordinary_mobile_api",
+    "realtime_hot_path",
+    "token_or_crypto_security_boundary",
+    "domain_application_public_json_contracts"
+  ],
+  "dependencyPolicy": {
+    "directAllowed": [
+      "org.egovframe.rte:egovframe-rte-ptl-mvc"
+    ],
+    "directDeferredUntilPocPasses": [
+      "org.egovframe.rte:egovframe-rte-bat-core",
+      "org.egovframe.rte:egovframe-rte-fdl-property",
+      "org.egovframe.rte:egovframe-rte-fdl-idgnr",
+      "org.egovframe.rte:egovframe-rte-psl-dataaccess",
+      "org.egovframe.boot:egovframe-boot-starter-access",
+      "org.egovframe.rte:egovframe-rte-fdl-excel"
+    ],
+    "directForbidden": [
+      "org.egovframe.boot:egovframe-boot-starter-crypto",
+      "org.egovframe.boot:egovframe-boot-starter-security"
+    ]
+  },
+  "pocDecision": {
+    "pagination": {
+      "status": "adopted_control_plane_only",
+      "currentImplementation": "backend/src/main/java/com/easysubway/common/web/pagination/EgovPaginationView.java",
+      "verification": "backend/src/test/java/com/easysubway/common/web/pagination/EgovPaginationViewTest.java"
+    },
+    "egovframeBatCore": {
+      "status": "deferred_until_dependency_convergence_and_local_mirror",
+      "currentImplementation": "spring_batch_control_plane_job",
+      "reason": "local eGovFrame mirror contains MVC, common, and logging artifacts only; Spring Batch job already verifies restart/idempotency without adding a remote-only runtime dependency"
+    },
+    "fdlLogging": {
+      "status": "classpath_verified_control_plane_only",
+      "currentImplementation": "transitive runtime from egovframe-rte-ptl-mvc",
+      "constraint": "do not import eGovFrame logging types outside backend support runtime verification"
+    },
+    "fdlProperty": {
+      "status": "not_enabled_for_production",
+      "constraint": "Spring Boot configuration remains the source of truth until a control-plane-only PoC proves value"
+    },
+    "fdlIdgnr": {
+      "status": "not_enabled_for_production",
+      "constraint": "UUID, database IDs, receipt tokens, and security identifiers must not move to eGovFrame ID generation"
+    },
+    "pslDataaccess": {
+      "status": "forbidden_until_poc_passes",
+      "constraint": "current production persistence stays on Spring JDBC/JdbcTemplate and Flyway-managed schema"
+    },
+    "fdlAccess": {
+      "status": "forbidden_until_poc_passes",
+      "constraint": "admin/operator auth stays on Spring Security and does not cross token or crypto boundaries"
+    },
+    "fdlExcel": {
+      "status": "forbidden_until_poc_passes",
+      "constraint": "exports must prove memory, privacy, and CI cost before adding Excel-specific runtime dependencies"
+    }
+  },
+  "compatibilityEvidence": {
+    "requiredBeforeExpansion": [
+      "cd backend && ./gradlew check",
+      "cd backend && ./gradlew dependencyInsight --dependency org.egovframe",
+      "node --test tools/ci/*.test.mjs"
+    ],
+    "releaseBlocker": true
+  },
+  "mustNotDo": [
+    "increase eGovFrame usage percentage mechanically",
+    "move mobile or public JSON contracts to eGovFrame types",
+    "replace token, crypto, receipt, or auth boundaries with eGovFrame starters",
+    "add remote-only eGovFrame dependencies without lockfile and local mirror evidence"
+  ]
+}

--- a/backend/src/test/java/com/easysubway/collection/adapter/out/batch/TransitMasterCollectionBatchConfigTest.java
+++ b/backend/src/test/java/com/easysubway/collection/adapter/out/batch/TransitMasterCollectionBatchConfigTest.java
@@ -1,6 +1,7 @@
 package com.easysubway.collection.adapter.out.batch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.easysubway.collection.adapter.out.persistence.InMemoryDataCollectionRunRepository;
 import com.easysubway.collection.domain.DataCollectionSource;
@@ -11,6 +12,7 @@ import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -45,6 +47,22 @@ class TransitMasterCollectionBatchConfigTest {
 		assertThat(run.source()).isEqualTo(DataCollectionSource.TRANSIT_MASTER);
 		assertThat(run.status()).isEqualTo(DataCollectionStatus.COMPLETED);
 		assertThat(run.requestedBy()).isEqualTo("admin-batch");
+	}
+
+	@Test
+	@DisplayName("완료된 배치 Job은 같은 파라미터로 중복 실행되지 않는다")
+	void transitMasterCollectionJobIsIdempotentForCompletedParameters() throws Exception {
+		var parameters = new JobParametersBuilder()
+			.addString("runId", "collection-batch-idempotent")
+			.addString("requestedBy", "admin-batch")
+			.toJobParameters();
+
+		var firstExecution = jobLauncher.run(job, parameters);
+
+		assertThat(firstExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+		assertThatThrownBy(() -> jobLauncher.run(job, parameters))
+			.isInstanceOf(JobInstanceAlreadyCompleteException.class);
+		assertThat(repository.loadRun("collection-batch-idempotent")).isPresent();
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/support/EgovFrameRuntimeTest.java
+++ b/backend/src/test/java/com/easysubway/support/EgovFrameRuntimeTest.java
@@ -15,4 +15,12 @@ class EgovFrameRuntimeTest {
 
 		assertThat(paginationInfo.getPackageName()).isEqualTo("org.egovframe.rte.ptl.mvc.tags.ui.pagination");
 	}
+
+	@Test
+	@DisplayName("전자정부프레임워크 FDL logging은 control-plane 검증용 클래스패스에만 존재한다")
+	void egovFrameFdlLoggingRuntimeIsOnClasspathForControlPlaneOnly() throws ClassNotFoundException {
+		Class<?> loggingUtility = Class.forName("org.egovframe.rte.fdl.logging.util.EgovResourceReleaser");
+
+		assertThat(loggingUtility.getPackageName()).isEqualTo("org.egovframe.rte.fdl.logging.util");
+	}
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2617,6 +2617,51 @@ test("eGovFrame pagination import는 common web pagination 경계에만 둔다",
   ]);
 });
 
+test("eGovFrame control-plane 선택 적용 gate는 허용 영역과 no-go 경계를 고정한다", () => {
+  const gate = readJson("backend/quality/egovframe-control-plane-gate.json");
+  const build = read("backend/build.gradle");
+  const lockfile = read("backend/gradle.lockfile");
+  const readme = read("README.md");
+
+  assert.equal(gate.schemaVersion, 1);
+  assert.equal(gate.gateId, "egovframe-control-plane-adoption");
+  assert.equal(gate.framework.egovFrame, "5.0.0");
+  assert.match(gate.framework.springBoot, /^3\.5\./);
+  assert.deepEqual(gate.allowedProductionSurface, [
+    "backend_admin_operator_pages",
+    "data_collection_batch_control_plane",
+    "operations_logging_properties_ids",
+  ]);
+  assert.deepEqual(gate.noGoSurface, [
+    "flutter_mobile_runtime",
+    "ordinary_mobile_api",
+    "realtime_hot_path",
+    "token_or_crypto_security_boundary",
+    "domain_application_public_json_contracts",
+  ]);
+  assert.equal(gate.pocDecision.egovframeBatCore.status, "deferred_until_dependency_convergence_and_local_mirror");
+  assert.equal(gate.pocDecision.egovframeBatCore.currentImplementation, "spring_batch_control_plane_job");
+  assert.equal(gate.pocDecision.fdlLogging.status, "classpath_verified_control_plane_only");
+  assert.equal(gate.pocDecision.fdlProperty.status, "not_enabled_for_production");
+  assert.equal(gate.pocDecision.fdlIdgnr.status, "not_enabled_for_production");
+  assert.equal(gate.pocDecision.pslDataaccess.status, "forbidden_until_poc_passes");
+  assert.equal(gate.pocDecision.fdlAccess.status, "forbidden_until_poc_passes");
+  assert.equal(gate.pocDecision.fdlExcel.status, "forbidden_until_poc_passes");
+
+  assert.match(build, /implementation 'org\.egovframe\.rte:egovframe-rte-ptl-mvc'/);
+  assert.match(build, /implementation 'org\.springframework\.boot:spring-boot-starter-batch'/);
+  assert.doesNotMatch(build, /egovframe-rte-bat-core/);
+  assert.doesNotMatch(build, /egovframe-rte-fdl-property/);
+  assert.doesNotMatch(build, /egovframe-rte-fdl-idgnr/);
+  assert.doesNotMatch(build, /egovframe-rte-psl-dataaccess/);
+  assert.doesNotMatch(build, /egovframe-boot-starter-(access|crypto|security)/);
+  assert.doesNotMatch(build, /egovframe-rte-fdl-excel/);
+  assert.match(lockfile, /^org\.egovframe\.rte:egovframe-rte-fdl-logging:5\.0\.0=/m);
+
+  assert.match(readme, /eGovFrame은 backend control-plane에만 선택 적용한다/);
+  assert.match(readme, /Flutter mobile runtime, ordinary mobile API, realtime hot path, token\/crypto boundary/);
+});
+
 test("백엔드 web message source는 기본 한국어 bundle과 code 기반 validation을 사용한다", () => {
   const applicationYml = read("backend/src/main/resources/application.yml");
   const messages = read("backend/src/main/resources/messages.properties");


### PR DESCRIPTION
## 관련 이슈

close #909

## 작업 배경

- eGovFrame 5.0은 backend control-plane에 운영 가치가 있는 범위로만 적용해야 하며, Flutter mobile runtime, realtime hot path, token/crypto 경계, public JSON contract로 새면 안 됩니다.
- 현재 main은 `egovframe-rte-ptl-mvc`와 `PaginationInfo`, Spring Batch 수집 Job을 이미 사용하지만, 허용/금지 기준과 PoC 보류 조건이 기계 검증 가능한 gate로 고정되어 있지 않았습니다.

## 작업 내용

- `backend/quality/egovframe-control-plane-gate.json`을 추가해 eGovFrame 허용 영역, no-go 영역, 직접 허용/보류/금지 dependency, PoC 상태를 고정했습니다.
- README Runtime Architecture에 backend control-plane 선택 적용 원칙과 금지 경계를 공개 문구로 추가했습니다.
- repository contract test가 control-plane gate, README 문구, 직접 dependency 금지, fdl-logging classpath 상태를 검증하도록 확장했습니다.
- eGovFrame runtime test에 FDL logging classpath 확인을 추가하되 production import 확장은 하지 않았습니다.
- data collection Spring Batch test에 같은 Job parameters의 완료 Job 재실행 차단 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/ci/repository-contract.test.mjs --test-name-pattern 'eGovFrame control-plane 선택 적용 gate'`: 처음에는 gate 파일 부재로 실패 확인
- `node --test tools/ci/repository-contract.test.mjs --test-name-pattern 'eGovFrame control-plane 선택 적용 gate|eGovFrame pagination import|백엔드 데이터 수집 배치'`: exit 0, 109 tests passed
- `cd backend && ./gradlew test --tests 'com.easysubway.support.EgovFrameRuntimeTest' --tests 'com.easysubway.collection.adapter.out.batch.TransitMasterCollectionBatchConfigTest'`: exit 0, BUILD SUCCESSFUL
- `node --test tools/ci/*.test.mjs`: exit 0, 113 tests passed
- `cd backend && ./gradlew check`: exit 0, BUILD SUCCESSFUL
- `cd backend && ./gradlew dependencyInsight --dependency org.egovframe`: exit 0, `egovframe-rte-ptl-mvc`, `egovframe-rte-fdl-cmmn`, `egovframe-rte-fdl-logging` all 5.0.0
- `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| eGovFrame control-plane gate | repository contract | gate JSON/README/build/lockfile 검사 | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern 'eGovFrame control-plane 선택 적용 gate|eGovFrame pagination import|백엔드 데이터 수집 배치'` | 통과 |
| backend runtime compatibility | backend JVM | eGovFrame runtime + Spring Batch tests | `cd backend && ./gradlew test --tests ...` BUILD SUCCESSFUL | 통과 |
| dependency convergence | backend Gradle | eGovFrame dependencyInsight | ptl-mvc/fdl-cmmn/fdl-logging 5.0.0, lockfile enforced | 통과 |
| 전체 repository contract | local Node.js | `node --test tools/ci/*.test.mjs` | command output: 113 tests passed | 통과 |
| backend 전체 검증 | backend Gradle | `cd backend && ./gradlew check` | BUILD SUCCESSFUL | 통과 |
| GitHub required checks | GitHub Actions | PR #985 checks 확인 | Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan, Android Release Artifact, Backend Release Image, SonarCloud all pass | 통과 |
| CodeRabbit / fallback review | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review 게시 | CodeRabbit comment: review limit reached, Codex review `4580281954` actionable 0 | 통과 |
| Post-merge CI/CD 상태 | GitHub Actions main | merge SHA `05bfd3289df9ee5d8c3f7b98029f49261dd337a6` run 조회 | SonarCloud success, CI/Release Artifacts in progress, CD failure run 없음 | 실패 신호 없음 |
| UI/시각 증거 | 해당 없음 | backend contract/test/gate 변경이며 화면 동작 변경 없음 | 증거 불필요 사유: admin/operator 화면 렌더링 로직과 CSS/템플릿을 변경하지 않음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `backend/quality/egovframe-control-plane-gate.json`의 `directAllowed`, `directDeferredUntilPocPasses`, `directForbidden` 분류입니다.
- `egovframe-rte-bat-core`는 로컬 mirror와 dependency convergence 증거가 없어서 이번 PR에서 production dependency로 추가하지 않고, Spring Batch control-plane Job 검증과 보류 gate로 고정했습니다.

## 리스크

- 이 PR은 eGovFrame 적용률을 올리지 않습니다. 대신 무리한 확장을 차단하는 기준을 강화합니다.
- fdl-property/idgnr/dataaccess/access/excel은 PoC 통과 전 production 금지 상태입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
