### PR TITLE
[Fix] Android 출시 UX·접근성·성능 release gate 완성

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ CD는 `main`의 CI가 성공한 뒤 `workflow_run`으로 자동 실행됩니다.
 
 Android 출시 100% 범위와 Go/No-Go 계약은 `apps/mobile/release/release-governance-gate.json`으로 검증합니다. 이번 release blocker는 Android Google Play v1이며 iOS는 `DEFERRED_OUT_OF_SCOPE`로 기록해 Android 출시 완료를 차단하지 않습니다. open Android P0가 있거나 RC evidence의 git SHA, AAB hash, backend artifact, data pack manifest, route/realtime contract가 서로 맞지 않으면 최종 Go 판단을 하지 않습니다.
 
+Android 출시 UX·접근성·성능 gate는 `apps/mobile/release/android-release-quality-gate.json`으로 검증합니다. PR 증거는 local Android emulator evidence를 우선 사용하며, 물리 기기 증거는 Codex PR 증거로 사용하지 않습니다. 실제 Google Play Go 판단 전에는 #907의 exact RC 또는 Play-installed build에서 TalkBack, 150%/200% 글자 크기, 작은 화면, 권한/네트워크/업로드 오류 복구, 노선도 fallback과 성능, 지원 범위/출처 화면, crash/ANR privacy-safe reporting 증거를 다시 수집해야 합니다.
+
 ## Privacy Policy
 
 EasySubway collects and stores only the data needed to provide subway accessibility guidance, local route search, favorites, app settings, diagnostics, and facility report submission.

--- a/apps/mobile/release/android-rc-store-evidence.json
+++ b/apps/mobile/release/android-rc-store-evidence.json
@@ -64,11 +64,14 @@
       "play-installed-build-logcat-no-crash"
     ],
     "androidAccessibilityQa": [
+      "android-release-quality-gate-manifest",
       "talkback-rc-build-notes",
       "font-scale-150-200-screenshots",
       "small-screen-layout-screenshots",
+      "local-emulator-ui-tree-screenshots",
       "location-permission-denied-recovery",
-      "network-server-error-recovery"
+      "network-server-error-recovery",
+      "route-map-performance-summary"
     ],
     "playConsoleSubmission": [
       "account-type-production-access-record",

--- a/apps/mobile/release/android-release-quality-gate.json
+++ b/apps/mobile/release/android-release-quality-gate.json
@@ -89,8 +89,16 @@
         "maxCameraLatencyP95Ms": 120,
         "maxTotalPssKb": 250000
       },
-      "evidence": ["tools/mobile/run-route-map-android-evidence.sh", "tools/mobile/analyze-route-map-android-evidence.mjs", "summary-output"],
-      "passCriteriaKo": "예산 초과는 해당 RC의 P0 blocker로 승격한다."
+      "measurementSource": {
+        "releaseOrPlayInstalled": ["gfxinfo-framestats", "meminfo", "screen-recording-or-screenshot-sequence"],
+        "matchedProfileInstrumentation": ["tools/mobile/run-route-map-android-evidence.sh", "tools/mobile/analyze-route-map-android-evidence.mjs"]
+      },
+      "evidence": [
+        "play-installed-route-map-gfxinfo-framestats-summary",
+        "play-installed-route-map-meminfo-summary",
+        "matched-profile-route-map-camera-latency-summary"
+      ],
+      "passCriteriaKo": "RC 또는 Play-installed build의 frame/memory 예산 초과와 동일 git SHA profile instrumentation의 camera latency 예산 초과는 해당 RC의 P0 blocker로 승격한다."
     },
     {
       "id": "scope_source_realtime_support_ui",

--- a/apps/mobile/release/android-release-quality-gate.json
+++ b/apps/mobile/release/android-release-quality-gate.json
@@ -1,0 +1,122 @@
+{
+  "schemaVersion": 1,
+  "applicationId": "easysubway",
+  "androidApplicationId": "com.easysubway.app",
+  "releaseGate": "android-release-ux-accessibility-performance",
+  "issue": 917,
+  "releaseBlockerPolicy": true,
+  "scope": {
+    "platform": {
+      "android": "RELEASE_REQUIRED",
+      "ios": "DEFERRED_OUT_OF_SCOPE"
+    },
+    "distribution": "google-play",
+    "primaryLocale": "ko-KR",
+    "targetUsers": [
+      "older-adults",
+      "wheelchair-users",
+      "stroller-users",
+      "pregnant-riders",
+      "temporary-injury-riders",
+      "riders-with-large-baggage"
+    ]
+  },
+  "routeSafetyContract": "#901",
+  "routeSafetyStatusEnum": ["FOUND", "BLOCKED", "UNKNOWN", "UNSUPPORTED", "ERROR"],
+  "deviceEvidencePolicy": {
+    "codexQaDevice": "local_android_emulator_only",
+    "physicalDeviceEvidence": "not_used_for_codex_pr_evidence",
+    "releaseRcEvidence": "play_installed_or_exact_rc_required_before_go",
+    "minimumAndroidApi": 35,
+    "fontScales": [1.5, 2.0],
+    "smallScreenViewport": "compact_phone_portrait"
+  },
+  "requiredChecks": [
+    {
+      "id": "route_safety_status_copy",
+      "releaseBlocker": true,
+      "states": ["FOUND", "BLOCKED", "UNKNOWN", "UNSUPPORTED", "ERROR"],
+      "evidence": ["screenshots", "ui-tree", "copy-review-notes"],
+      "passCriteriaKo": "FOUND는 검증된 접근성 edge가 있을 때만 안전하게 표현하고, 정보 부족은 UNKNOWN 또는 확인 필요 문구로 표시한다."
+    },
+    {
+      "id": "talkback_primary_journey",
+      "releaseBlocker": true,
+      "journeys": ["home", "station-search", "route-result", "facility-report", "support-info"],
+      "evidence": ["ui-tree", "talkback-notes", "screen-recording-or-screenshot-sequence"],
+      "passCriteriaKo": "focus order, role, state, action, dynamic update가 이동 흐름을 이해할 수 있게 읽힌다."
+    },
+    {
+      "id": "font_scale_150_200_small_screen",
+      "releaseBlocker": true,
+      "settings": ["font_scale_1_5", "font_scale_2_0", "compact_phone_portrait"],
+      "evidence": ["screenshots", "ui-tree", "font-scale-value"],
+      "passCriteriaKo": "주요 CTA와 경고 문구가 overflow, clipping, hidden 상태가 아니다."
+    },
+    {
+      "id": "high_contrast_state_visibility",
+      "releaseBlocker": true,
+      "evidence": ["screenshots", "contrast-notes"],
+      "passCriteriaKo": "상태 배지, 오류 안내, 다음 행동, 안전 고지가 색상만으로 전달되지 않는다."
+    },
+    {
+      "id": "location_permission_denied_recovery",
+      "releaseBlocker": true,
+      "states": ["denied", "permanently_denied", "settings_return"],
+      "evidence": ["screenshots", "permission-state", "logcat-summary"],
+      "passCriteriaKo": "현재 위치만 제한되고 역 검색, 정적 경로, 역 상세는 계속 사용할 수 있다."
+    },
+    {
+      "id": "network_server_upload_error_recovery",
+      "releaseBlocker": true,
+      "states": ["airplane", "timeout", "backend_down", "upload_failure"],
+      "evidence": ["screenshots", "logcat-summary", "request-response-summary"],
+      "passCriteriaKo": "오류 이유와 다음 행동을 쉬운 한국어로 안내하고 로컬 기능을 차단하지 않는다."
+    },
+    {
+      "id": "route_map_fallback_zoom_help",
+      "releaseBlocker": true,
+      "evidence": ["screenshots", "ui-tree", "gesture-notes"],
+      "passCriteriaKo": "노선도 렌더링 실패 또는 접근성 사용 시 대체 목록, 확대, 도움말 흐름이 제공된다."
+    },
+    {
+      "id": "route_map_performance_budget",
+      "releaseBlocker": true,
+      "budgets": {
+        "maxJankyPercent": 5,
+        "maxP95FrameMs": 32,
+        "maxP99FrameMs": 48,
+        "maxCameraLatencyP95Ms": 120,
+        "maxTotalPssKb": 250000
+      },
+      "evidence": ["tools/mobile/run-route-map-android-evidence.sh", "tools/mobile/analyze-route-map-android-evidence.mjs", "summary-output"],
+      "passCriteriaKo": "예산 초과는 해당 RC의 P0 blocker로 승격한다."
+    },
+    {
+      "id": "scope_source_realtime_support_ui",
+      "releaseBlocker": true,
+      "evidence": ["screenshots", "ui-tree", "store-listing-copy-comparison"],
+      "passCriteriaKo": "지원 지역, 데이터 기준일, 출처, 실시간 지원 범위가 앱 안에서 확인 가능하고 Play listing과 모순되지 않는다."
+    },
+    {
+      "id": "crash_anr_privacy_safe_reporting",
+      "releaseBlocker": true,
+      "evidence": ["logcat-summary", "privacy-review-notes"],
+      "passCriteriaKo": "crash/ANR reporting은 민감 위치, 신고 사진, receipt token, signing/credential 값을 노출하지 않는다."
+    }
+  ],
+  "evidencePolicy": {
+    "localOnlyEvidenceRoot": ".codex/evidence/release/android-quality/<rc-or-run>/",
+    "githubEvidencePolicy": "summary-or-public-link",
+    "sensitiveEvidence": [
+      "screen recordings with personal data",
+      "logcat containing device identifiers",
+      "network traces",
+      "Play-installed APK or AAB binaries",
+      "location coordinates",
+      "receipt tokens",
+      "facility report photos"
+    ],
+    "summaryRequiredKo": "PR에는 evidence 종류, 대상, 결과, local-only 경로 또는 공개 가능한 링크만 기록한다."
+  }
+}

--- a/apps/mobile/release/release-governance-gate.json
+++ b/apps/mobile/release/release-governance-gate.json
@@ -144,7 +144,7 @@
       "status": "NOT_STARTED"
     }
   ],
-  "childIssueLinks": [571, 836, 909, 911, 915, 919, 920, 921, 922, 923, 924, 925, 926],
+  "childIssueLinks": [571, 836, 909, 911, 915, 917, 919, 920, 921, 922, 923, 924, 925, 926],
   "evidencePolicy": {
     "localOnlyEvidenceRoot": ".codex/evidence/release/android-release-100/",
     "githubEvidencePolicy": "summary_or_public_link",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5468,6 +5468,64 @@ test("모바일 접근성 출시 QA 기준선은 Android와 iOS 제출 전 확�
   assert.match(checks.get("ios_safe_area_small_screen_tap_targets").passCriteriaKo, /터치|safe area/);
 });
 
+test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 blocker 기준을 고정한다", () => {
+  const gate = readJson("apps/mobile/release/android-release-quality-gate.json");
+  const androidRcEvidence = readJson("apps/mobile/release/android-rc-store-evidence.json");
+  const governance = readJson("apps/mobile/release/release-governance-gate.json");
+  const readme = read("README.md");
+  const smokeScript = read("tools/mobile/run-android-release-quality-emulator-smoke.sh");
+
+  assert.equal(gate.schemaVersion, 1);
+  assert.equal(gate.applicationId, "easysubway");
+  assert.equal(gate.androidApplicationId, "com.easysubway.app");
+  assert.equal(gate.releaseGate, "android-release-ux-accessibility-performance");
+  assert.equal(gate.issue, 917);
+  assert.equal(gate.releaseBlockerPolicy, true);
+  assert.equal(gate.scope.platform.android, "RELEASE_REQUIRED");
+  assert.equal(gate.scope.platform.ios, "DEFERRED_OUT_OF_SCOPE");
+  assert.deepEqual(gate.routeSafetyStatusEnum, ["FOUND", "BLOCKED", "UNKNOWN", "UNSUPPORTED", "ERROR"]);
+  assert.equal(gate.routeSafetyContract, "#901");
+  assert.equal(gate.deviceEvidencePolicy.codexQaDevice, "local_android_emulator_only");
+  assert.equal(gate.deviceEvidencePolicy.physicalDeviceEvidence, "not_used_for_codex_pr_evidence");
+  assert.equal(gate.deviceEvidencePolicy.releaseRcEvidence, "play_installed_or_exact_rc_required_before_go");
+  assert.equal(gate.evidencePolicy.localOnlyEvidenceRoot, ".codex/evidence/release/android-quality/<rc-or-run>/");
+
+  const requiredChecks = new Map(gate.requiredChecks.map((check) => [check.id, check]));
+  for (const id of [
+    "route_safety_status_copy",
+    "talkback_primary_journey",
+    "font_scale_150_200_small_screen",
+    "high_contrast_state_visibility",
+    "location_permission_denied_recovery",
+    "network_server_upload_error_recovery",
+    "route_map_fallback_zoom_help",
+    "route_map_performance_budget",
+    "scope_source_realtime_support_ui",
+    "crash_anr_privacy_safe_reporting",
+  ]) {
+    assert.ok(requiredChecks.has(id), `${id} must be tracked`);
+    assert.equal(requiredChecks.get(id).releaseBlocker, true, `${id} must block release`);
+  }
+  assert.deepEqual(requiredChecks.get("route_map_performance_budget").budgets, {
+    maxJankyPercent: 5,
+    maxP95FrameMs: 32,
+    maxP99FrameMs: 48,
+    maxCameraLatencyP95Ms: 120,
+    maxTotalPssKb: 250000,
+  });
+
+  assert.ok(androidRcEvidence.requiredEvidence.androidAccessibilityQa.includes("android-release-quality-gate-manifest"));
+  assert.ok(androidRcEvidence.requiredEvidence.androidAccessibilityQa.includes("local-emulator-ui-tree-screenshots"));
+  assert.ok(androidRcEvidence.requiredEvidence.androidAccessibilityQa.includes("route-map-performance-summary"));
+  assert.ok(governance.childIssueLinks.includes(917));
+  assert.match(readme, /Android 출시 UX·접근성·성능 gate/);
+  assert.match(readme, /local Android emulator evidence/);
+  assert.match(smokeScript, /ro\.kernel\.qemu/);
+  assert.match(smokeScript, /font_scale/);
+  assert.match(smokeScript, /uiautomator dump/);
+  assert.match(smokeScript, /dumpsys gfxinfo/);
+});
+
 test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을 고정한다", () => {
   const readinessPath = "apps/mobile/release/store-submission-readiness.json";
   assert.ok(existsSync(path.join(root, readinessPath)));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5527,8 +5527,13 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
   assert.match(smokeScript, /width_dp=\$\(\(width_px \* 160 \/ density_dpi\)\)/);
   assert.match(smokeScript, /"\$width_px" -ge "\$height_px"/);
   assert.match(smokeScript, /viewport_orientation=portrait/);
+  assert.match(smokeScript, /wm_size_raw=/);
+  assert.match(smokeScript, /Override size:/);
+  assert.match(smokeScript, /wm_size_source="override"/);
   assert.match(smokeScript, /pm path "\$PACKAGE"/);
-  assert.match(smokeScript, /resolve-activity --brief "\$PACKAGE"/);
+  assert.match(smokeScript, /android\.intent\.action\.MAIN/);
+  assert.match(smokeScript, /android\.intent\.category\.LAUNCHER/);
+  assert.match(smokeScript, /-p "\$PACKAGE"/);
   assert.match(smokeScript, /am start -n "\$launch_activity"/);
   assert.match(smokeScript, /current-focus\.txt/);
   assert.match(smokeScript, /font_scale/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5527,6 +5527,11 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
   assert.match(smokeScript, /width_dp=\$\(\(width_px \* 160 \/ density_dpi\)\)/);
   assert.match(smokeScript, /"\$width_px" -ge "\$height_px"/);
   assert.match(smokeScript, /viewport_orientation=portrait/);
+  assert.match(smokeScript, /dumpsys input/);
+  assert.match(smokeScript, /orientation=\\\(\[0-3\]\\\)/);
+  assert.match(smokeScript, /screen_rotation_source=/);
+  assert.match(smokeScript, /screen_rotation=/);
+  assert.match(smokeScript, /"\$screen_rotation" != "0"/);
   assert.match(smokeScript, /wm_size_raw=/);
   assert.match(smokeScript, /Override size:/);
   assert.match(smokeScript, /wm_size_source="override"/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5521,6 +5521,13 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
   assert.match(readme, /Android 출시 UX·접근성·성능 gate/);
   assert.match(readme, /local Android emulator evidence/);
   assert.match(smokeScript, /ro\.kernel\.qemu/);
+  assert.match(smokeScript, /--expected-font-scale/);
+  assert.match(smokeScript, /MIN_ANDROID_API=35/);
+  assert.match(smokeScript, /MAX_COMPACT_WIDTH_DP=599/);
+  assert.match(smokeScript, /pm path "\$PACKAGE"/);
+  assert.match(smokeScript, /resolve-activity --brief "\$PACKAGE"/);
+  assert.match(smokeScript, /am start -n "\$launch_activity"/);
+  assert.match(smokeScript, /current-focus\.txt/);
   assert.match(smokeScript, /font_scale/);
   assert.match(smokeScript, /uiautomator dump/);
   assert.match(smokeScript, /dumpsys gfxinfo/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5524,6 +5524,9 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
   assert.match(smokeScript, /--expected-font-scale/);
   assert.match(smokeScript, /MIN_ANDROID_API=35/);
   assert.match(smokeScript, /MAX_COMPACT_WIDTH_DP=599/);
+  assert.match(smokeScript, /width_dp=\$\(\(width_px \* 160 \/ density_dpi\)\)/);
+  assert.match(smokeScript, /"\$width_px" -ge "\$height_px"/);
+  assert.match(smokeScript, /viewport_orientation=portrait/);
   assert.match(smokeScript, /pm path "\$PACKAGE"/);
   assert.match(smokeScript, /resolve-activity --brief "\$PACKAGE"/);
   assert.match(smokeScript, /am start -n "\$launch_activity"/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5513,6 +5513,26 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
     maxCameraLatencyP95Ms: 120,
     maxTotalPssKb: 250000,
   });
+  assert.deepEqual(requiredChecks.get("route_map_performance_budget").measurementSource.releaseOrPlayInstalled, [
+    "gfxinfo-framestats",
+    "meminfo",
+    "screen-recording-or-screenshot-sequence",
+  ]);
+  assert.ok(
+    requiredChecks
+      .get("route_map_performance_budget")
+      .measurementSource.matchedProfileInstrumentation.includes("tools/mobile/run-route-map-android-evidence.sh"),
+  );
+  assert.ok(
+    requiredChecks
+      .get("route_map_performance_budget")
+      .evidence.includes("play-installed-route-map-gfxinfo-framestats-summary"),
+  );
+  assert.ok(
+    requiredChecks
+      .get("route_map_performance_budget")
+      .evidence.includes("matched-profile-route-map-camera-latency-summary"),
+  );
 
   assert.ok(androidRcEvidence.requiredEvidence.androidAccessibilityQa.includes("android-release-quality-gate-manifest"));
   assert.ok(androidRcEvidence.requiredEvidence.androidAccessibilityQa.includes("local-emulator-ui-tree-screenshots"));

--- a/tools/mobile/run-android-release-quality-emulator-smoke.sh
+++ b/tools/mobile/run-android-release-quality-emulator-smoke.sh
@@ -153,13 +153,14 @@ if [[ ! "$wm_density" =~ ([0-9]+)$ ]]; then
   exit 1
 fi
 density_dpi="${BASH_REMATCH[1]}"
-short_px="$width_px"
-if [[ "$height_px" -lt "$short_px" ]]; then
-  short_px="$height_px"
+width_dp=$((width_px * 160 / density_dpi))
+height_dp=$((height_px * 160 / density_dpi))
+if [[ "$width_px" -ge "$height_px" ]]; then
+  echo "Emulator viewport must be compact phone portrait: ${width_px}x${height_px}px." >&2
+  exit 1
 fi
-short_width_dp=$((short_px * 160 / density_dpi))
-if [[ "$short_width_dp" -gt "$MAX_COMPACT_WIDTH_DP" ]]; then
-  echo "Emulator short width ${short_width_dp}dp is not compact phone width." >&2
+if [[ "$width_dp" -gt "$MAX_COMPACT_WIDTH_DP" ]]; then
+  echo "Emulator width ${width_dp}dp is not compact phone width." >&2
   exit 1
 fi
 
@@ -175,7 +176,9 @@ fi
   echo "android_sdk=$sdk"
   echo "wm_size=$wm_size"
   echo "wm_density=$wm_density"
-  echo "short_width_dp=$short_width_dp"
+  echo "width_dp=$width_dp"
+  echo "height_dp=$height_dp"
+  echo "viewport_orientation=portrait"
   echo "font_scale=${font_scale:-unknown}"
   echo "expected_font_scale=$EXPECTED_FONT_SCALE"
   echo "high_text_contrast_enabled=${high_text_contrast:-unknown}"

--- a/tools/mobile/run-android-release-quality-emulator-smoke.sh
+++ b/tools/mobile/run-android-release-quality-emulator-smoke.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  tools/mobile/run-android-release-quality-emulator-smoke.sh --serial <adb-serial> --artifact-dir <dir> [options]
+
+Options:
+  --serial <adb-serial>       Required Android emulator serial.
+  --artifact-dir <dir>        Required output directory for local-only evidence.
+  --package <package>         App package. Defaults to com.easysubway.app.
+  --adb <path>                adb executable. Defaults to $ADB or PATH lookup.
+  --settle-seconds <seconds>  Wait after launch/settings changes. Defaults to 2.
+  -h, --help                  Show this help.
+
+This smoke is for Codex PR evidence and intentionally requires a local Android
+emulator. It writes screenshots, UI trees, settings, package, gfxinfo, and
+logcat summaries under the artifact directory. It does not use physical devices.
+USAGE
+}
+
+SERIAL=""
+ARTIFACT_DIR=""
+PACKAGE="com.easysubway.app"
+ADB="${ADB:-}"
+SETTLE_SECONDS=2
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --serial)
+      SERIAL="${2:-}"
+      shift 2
+      ;;
+    --artifact-dir)
+      ARTIFACT_DIR="${2:-}"
+      shift 2
+      ;;
+    --package)
+      PACKAGE="${2:-}"
+      shift 2
+      ;;
+    --adb)
+      ADB="${2:-}"
+      shift 2
+      ;;
+    --settle-seconds)
+      SETTLE_SECONDS="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$SERIAL" || -z "$ARTIFACT_DIR" ]]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ -z "$ADB" ]]; then
+  ADB="$(command -v adb || true)"
+fi
+
+if [[ -z "$ADB" || ! -x "$ADB" ]]; then
+  echo "adb executable not found. Pass --adb or set ADB." >&2
+  exit 2
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+
+adb_device() {
+  "$ADB" -s "$SERIAL" "$@"
+}
+
+require_non_empty() {
+  local file="$1"
+  if [[ ! -s "$file" ]]; then
+    echo "Expected non-empty evidence file: $file" >&2
+    exit 1
+  fi
+}
+
+capture_screen() {
+  local name="$1"
+  adb_device exec-out screencap -p > "$ARTIFACT_DIR/$name.png"
+  require_non_empty "$ARTIFACT_DIR/$name.png"
+}
+
+capture_ui_tree() {
+  local name="$1"
+  local device_path="/sdcard/easysubway-${name}.xml"
+  adb_device shell uiautomator dump "$device_path" >/dev/null
+  adb_device pull "$device_path" "$ARTIFACT_DIR/$name.xml" >/dev/null
+  require_non_empty "$ARTIFACT_DIR/$name.xml"
+}
+
+if ! adb_device get-state | grep -qx "device"; then
+  echo "adb target is not ready: $SERIAL" >&2
+  exit 1
+fi
+
+kernel_qemu="$(adb_device shell getprop ro.kernel.qemu | tr -d '\r')"
+if [[ "$kernel_qemu" != "1" ]]; then
+  echo "adb target is not a local Android emulator: $SERIAL" >&2
+  exit 1
+fi
+
+wm_size="$(adb_device shell wm size | tr -d '\r')"
+wm_density="$(adb_device shell wm density | tr -d '\r')"
+font_scale="$(adb_device shell settings get system font_scale | tr -d '\r')"
+high_text_contrast="$(adb_device shell settings get secure high_text_contrast_enabled | tr -d '\r' || true)"
+page_size="$(adb_device shell getconf PAGE_SIZE | tr -d '\r' || true)"
+sdk="$(adb_device shell getprop ro.build.version.sdk | tr -d '\r')"
+
+{
+  echo "serial=$SERIAL"
+  echo "package=$PACKAGE"
+  echo "ro.kernel.qemu=$kernel_qemu"
+  echo "android_sdk=$sdk"
+  echo "wm_size=$wm_size"
+  echo "wm_density=$wm_density"
+  echo "font_scale=${font_scale:-unknown}"
+  echo "high_text_contrast_enabled=${high_text_contrast:-unknown}"
+  echo "page_size=${page_size:-unknown}"
+  echo "adb=$ADB"
+  date -u +"captured_at_utc=%Y-%m-%dT%H:%M:%SZ"
+} > "$ARTIFACT_DIR/metadata.env"
+
+adb_device shell dumpsys package "$PACKAGE" > "$ARTIFACT_DIR/package.txt" || true
+adb_device logcat -c || true
+adb_device shell am force-stop "$PACKAGE" >/dev/null 2>&1 || true
+adb_device shell monkey -p "$PACKAGE" 1 > "$ARTIFACT_DIR/launch.txt" 2>&1 || true
+sleep "$SETTLE_SECONDS"
+
+capture_screen "current-screen"
+capture_ui_tree "current-screen"
+
+adb_device shell dumpsys gfxinfo "$PACKAGE" > "$ARTIFACT_DIR/gfxinfo.txt" || true
+adb_device shell dumpsys meminfo "$PACKAGE" > "$ARTIFACT_DIR/meminfo.txt" || true
+adb_device logcat -d -v time > "$ARTIFACT_DIR/logcat.txt" || true
+
+{
+  echo "android_release_quality_emulator_smoke"
+  cat "$ARTIFACT_DIR/metadata.env"
+  echo "screenshot=current-screen.png"
+  echo "ui_tree=current-screen.xml"
+  if grep -q "Unable to find instrumentation info" "$ARTIFACT_DIR/launch.txt"; then
+    echo "launch_status=package_not_started"
+  else
+    echo "launch_status=attempted"
+  fi
+} > "$ARTIFACT_DIR/summary.txt"
+
+require_non_empty "$ARTIFACT_DIR/summary.txt"
+printf 'android release quality emulator smoke evidence written: %s\n' "$ARTIFACT_DIR"

--- a/tools/mobile/run-android-release-quality-emulator-smoke.sh
+++ b/tools/mobile/run-android-release-quality-emulator-smoke.sh
@@ -9,6 +9,7 @@ Usage:
 Options:
   --serial <adb-serial>       Required Android emulator serial.
   --artifact-dir <dir>        Required output directory for local-only evidence.
+  --expected-font-scale <n>   Required current Android font scale, such as 1.5 or 2.0.
   --package <package>         App package. Defaults to com.easysubway.app.
   --adb <path>                adb executable. Defaults to $ADB or PATH lookup.
   --settle-seconds <seconds>  Wait after launch/settings changes. Defaults to 2.
@@ -22,9 +23,12 @@ USAGE
 
 SERIAL=""
 ARTIFACT_DIR=""
+EXPECTED_FONT_SCALE=""
 PACKAGE="com.easysubway.app"
 ADB="${ADB:-}"
 SETTLE_SECONDS=2
+MIN_ANDROID_API=35
+MAX_COMPACT_WIDTH_DP=599
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -34,6 +38,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --artifact-dir)
       ARTIFACT_DIR="${2:-}"
+      shift 2
+      ;;
+    --expected-font-scale)
+      EXPECTED_FONT_SCALE="${2:-}"
       shift 2
       ;;
     --package)
@@ -60,7 +68,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$SERIAL" || -z "$ARTIFACT_DIR" ]]; then
+if [[ -z "$SERIAL" || -z "$ARTIFACT_DIR" || -z "$EXPECTED_FONT_SCALE" ]]; then
   usage >&2
   exit 2
 fi
@@ -102,6 +110,14 @@ capture_ui_tree() {
   require_non_empty "$ARTIFACT_DIR/$name.xml"
 }
 
+current_focus() {
+  adb_device shell dumpsys activity activities | grep -E "topResumedActivity|ResumedActivity" | tr -d '\r' || true
+}
+
+resolve_launch_activity() {
+  adb_device shell cmd package resolve-activity --brief "$PACKAGE" | tr -d '\r' | tail -n 1
+}
+
 if ! adb_device get-state | grep -qx "device"; then
   echo "adb target is not ready: $SERIAL" >&2
   exit 1
@@ -120,6 +136,38 @@ high_text_contrast="$(adb_device shell settings get secure high_text_contrast_en
 page_size="$(adb_device shell getconf PAGE_SIZE | tr -d '\r' || true)"
 sdk="$(adb_device shell getprop ro.build.version.sdk | tr -d '\r')"
 
+if [[ ! "$sdk" =~ ^[0-9]+$ || "$sdk" -lt "$MIN_ANDROID_API" ]]; then
+  echo "Android SDK $sdk does not satisfy minimum API $MIN_ANDROID_API." >&2
+  exit 1
+fi
+
+if [[ ! "$wm_size" =~ ([0-9]+)x([0-9]+) ]]; then
+  echo "Unable to parse device size from: $wm_size" >&2
+  exit 1
+fi
+width_px="${BASH_REMATCH[1]}"
+height_px="${BASH_REMATCH[2]}"
+
+if [[ ! "$wm_density" =~ ([0-9]+)$ ]]; then
+  echo "Unable to parse device density from: $wm_density" >&2
+  exit 1
+fi
+density_dpi="${BASH_REMATCH[1]}"
+short_px="$width_px"
+if [[ "$height_px" -lt "$short_px" ]]; then
+  short_px="$height_px"
+fi
+short_width_dp=$((short_px * 160 / density_dpi))
+if [[ "$short_width_dp" -gt "$MAX_COMPACT_WIDTH_DP" ]]; then
+  echo "Emulator short width ${short_width_dp}dp is not compact phone width." >&2
+  exit 1
+fi
+
+if [[ "$font_scale" != "$EXPECTED_FONT_SCALE" ]]; then
+  echo "Android font_scale $font_scale does not match expected $EXPECTED_FONT_SCALE." >&2
+  exit 1
+fi
+
 {
   echo "serial=$SERIAL"
   echo "package=$PACKAGE"
@@ -127,36 +175,51 @@ sdk="$(adb_device shell getprop ro.build.version.sdk | tr -d '\r')"
   echo "android_sdk=$sdk"
   echo "wm_size=$wm_size"
   echo "wm_density=$wm_density"
+  echo "short_width_dp=$short_width_dp"
   echo "font_scale=${font_scale:-unknown}"
+  echo "expected_font_scale=$EXPECTED_FONT_SCALE"
   echo "high_text_contrast_enabled=${high_text_contrast:-unknown}"
   echo "page_size=${page_size:-unknown}"
   echo "adb=$ADB"
   date -u +"captured_at_utc=%Y-%m-%dT%H:%M:%SZ"
 } > "$ARTIFACT_DIR/metadata.env"
 
-adb_device shell dumpsys package "$PACKAGE" > "$ARTIFACT_DIR/package.txt" || true
-adb_device logcat -c || true
+adb_device shell pm path "$PACKAGE" > "$ARTIFACT_DIR/package-path.txt"
+require_non_empty "$ARTIFACT_DIR/package-path.txt"
+adb_device shell dumpsys package "$PACKAGE" > "$ARTIFACT_DIR/package.txt"
+require_non_empty "$ARTIFACT_DIR/package.txt"
+
+adb_device logcat -c
 adb_device shell am force-stop "$PACKAGE" >/dev/null 2>&1 || true
-adb_device shell monkey -p "$PACKAGE" 1 > "$ARTIFACT_DIR/launch.txt" 2>&1 || true
+launch_activity="$(resolve_launch_activity)"
+if [[ "$launch_activity" != "$PACKAGE/"* ]]; then
+  echo "Unable to resolve launch activity for $PACKAGE: $launch_activity" >&2
+  exit 1
+fi
+adb_device shell am start -n "$launch_activity" > "$ARTIFACT_DIR/launch.txt"
+require_non_empty "$ARTIFACT_DIR/launch.txt"
 sleep "$SETTLE_SECONDS"
+
+current_focus > "$ARTIFACT_DIR/current-focus.txt"
+require_non_empty "$ARTIFACT_DIR/current-focus.txt"
+if ! grep -q "$PACKAGE" "$ARTIFACT_DIR/current-focus.txt"; then
+  echo "App package $PACKAGE is not foreground after launch." >&2
+  exit 1
+fi
 
 capture_screen "current-screen"
 capture_ui_tree "current-screen"
 
-adb_device shell dumpsys gfxinfo "$PACKAGE" > "$ARTIFACT_DIR/gfxinfo.txt" || true
-adb_device shell dumpsys meminfo "$PACKAGE" > "$ARTIFACT_DIR/meminfo.txt" || true
-adb_device logcat -d -v time > "$ARTIFACT_DIR/logcat.txt" || true
+adb_device shell dumpsys gfxinfo "$PACKAGE" > "$ARTIFACT_DIR/gfxinfo.txt"
+adb_device shell dumpsys meminfo "$PACKAGE" > "$ARTIFACT_DIR/meminfo.txt"
+adb_device logcat -d -v time > "$ARTIFACT_DIR/logcat.txt"
 
 {
   echo "android_release_quality_emulator_smoke"
   cat "$ARTIFACT_DIR/metadata.env"
   echo "screenshot=current-screen.png"
   echo "ui_tree=current-screen.xml"
-  if grep -q "Unable to find instrumentation info" "$ARTIFACT_DIR/launch.txt"; then
-    echo "launch_status=package_not_started"
-  else
-    echo "launch_status=attempted"
-  fi
+  echo "foreground_package_verified=true"
 } > "$ARTIFACT_DIR/summary.txt"
 
 require_non_empty "$ARTIFACT_DIR/summary.txt"

--- a/tools/mobile/run-android-release-quality-emulator-smoke.sh
+++ b/tools/mobile/run-android-release-quality-emulator-smoke.sh
@@ -114,6 +114,20 @@ current_focus() {
   adb_device shell dumpsys activity activities | grep -E "topResumedActivity|ResumedActivity" | tr -d '\r' || true
 }
 
+read_screen_rotation() {
+  local rotation
+  rotation="$(adb_device shell dumpsys input | tr -d '\r' |
+    sed -n 's/.*Viewport INTERNAL: displayId=0,.*orientation=\([0-3]\).*/\1/p' |
+    head -n 1)"
+  if [[ -n "$rotation" ]]; then
+    echo "dumpsys_input_viewport:$rotation"
+    return 0
+  fi
+
+  rotation="$(adb_device shell settings get system user_rotation | tr -d '\r' || true)"
+  echo "system_user_rotation:$rotation"
+}
+
 resolve_launch_activity() {
   adb_device shell cmd package resolve-activity \
     --brief \
@@ -146,6 +160,9 @@ font_scale="$(adb_device shell settings get system font_scale | tr -d '\r')"
 high_text_contrast="$(adb_device shell settings get secure high_text_contrast_enabled | tr -d '\r' || true)"
 page_size="$(adb_device shell getconf PAGE_SIZE | tr -d '\r' || true)"
 sdk="$(adb_device shell getprop ro.build.version.sdk | tr -d '\r')"
+rotation_reading="$(read_screen_rotation)"
+screen_rotation_source="${rotation_reading%%:*}"
+screen_rotation="${rotation_reading#*:}"
 
 if [[ ! "$sdk" =~ ^[0-9]+$ || "$sdk" -lt "$MIN_ANDROID_API" ]]; then
   echo "Android SDK $sdk does not satisfy minimum API $MIN_ANDROID_API." >&2
@@ -170,6 +187,10 @@ if [[ "$width_px" -ge "$height_px" ]]; then
   echo "Emulator viewport must be compact phone portrait: ${width_px}x${height_px}px." >&2
   exit 1
 fi
+if [[ ! "$screen_rotation" =~ ^[0-3]$ || "$screen_rotation" != "0" ]]; then
+  echo "Emulator screen rotation must be portrait before evidence capture: $screen_rotation." >&2
+  exit 1
+fi
 if [[ "$width_dp" -gt "$MAX_COMPACT_WIDTH_DP" ]]; then
   echo "Emulator width ${width_dp}dp is not compact phone width." >&2
   exit 1
@@ -191,6 +212,8 @@ fi
   echo "width_dp=$width_dp"
   echo "height_dp=$height_dp"
   echo "viewport_orientation=portrait"
+  echo "screen_rotation=$screen_rotation"
+  echo "screen_rotation_source=$screen_rotation_source"
   echo "font_scale=${font_scale:-unknown}"
   echo "expected_font_scale=$EXPECTED_FONT_SCALE"
   echo "high_text_contrast_enabled=${high_text_contrast:-unknown}"

--- a/tools/mobile/run-android-release-quality-emulator-smoke.sh
+++ b/tools/mobile/run-android-release-quality-emulator-smoke.sh
@@ -115,7 +115,11 @@ current_focus() {
 }
 
 resolve_launch_activity() {
-  adb_device shell cmd package resolve-activity --brief "$PACKAGE" | tr -d '\r' | tail -n 1
+  adb_device shell cmd package resolve-activity \
+    --brief \
+    -a android.intent.action.MAIN \
+    -c android.intent.category.LAUNCHER \
+    -p "$PACKAGE" | tr -d '\r' | tail -n 1
 }
 
 if ! adb_device get-state | grep -qx "device"; then
@@ -129,7 +133,14 @@ if [[ "$kernel_qemu" != "1" ]]; then
   exit 1
 fi
 
-wm_size="$(adb_device shell wm size | tr -d '\r')"
+wm_size_raw="$(adb_device shell wm size | tr -d '\r')"
+wm_size_source="physical"
+wm_size="$(printf '%s\n' "$wm_size_raw" | sed -n 's/^Physical size: //p' | tail -n 1)"
+wm_size_override="$(printf '%s\n' "$wm_size_raw" | sed -n 's/^Override size: //p' | tail -n 1)"
+if [[ -n "$wm_size_override" ]]; then
+  wm_size="$wm_size_override"
+  wm_size_source="override"
+fi
 wm_density="$(adb_device shell wm density | tr -d '\r')"
 font_scale="$(adb_device shell settings get system font_scale | tr -d '\r')"
 high_text_contrast="$(adb_device shell settings get secure high_text_contrast_enabled | tr -d '\r' || true)"
@@ -175,6 +186,7 @@ fi
   echo "ro.kernel.qemu=$kernel_qemu"
   echo "android_sdk=$sdk"
   echo "wm_size=$wm_size"
+  echo "wm_size_source=$wm_size_source"
   echo "wm_density=$wm_density"
   echo "width_dp=$width_dp"
   echo "height_dp=$height_dp"


### PR DESCRIPTION
## 관련 이슈

close #917

## 작업 배경

- Android Google Play v1 출시 전 UX, 접근성, 성능 검증 항목이 release blocker인지 한 곳에서 판정할 수 있어야 합니다.
- QA 요청에 따라 Codex PR 증거는 실기기가 아니라 로컬에 설치된 Android emulator에서만 수집하도록 범위를 고정했습니다.
- 실제 Go 판단 전에는 #907의 exact RC 또는 Play-installed build에서 동일 항목을 다시 수집해야 합니다.

## 작업 내용

- `apps/mobile/release/android-release-quality-gate.json`을 추가해 Android 출시 UX·접근성·성능 gate와 P0 blocker 항목을 고정했습니다.
- TalkBack 주요 여정, 150%/200% 글자 크기, 작은 화면, 고대비 상태 전달, 위치 권한 거부 복구, 네트워크·서버·업로드 오류 복구, 노선도 fallback/zoom/help, 노선도 성능 예산, 지원 범위·출처·실시간 범위 UI, crash/ANR privacy-safe reporting을 필수 evidence 대상으로 지정했습니다.
- 노선도 성능 gate는 RC 또는 Play-installed build의 `gfxinfo-framestats`/`meminfo`/화면 증거와 동일 git SHA profile instrumentation의 camera latency summary를 분리했습니다.
- `tools/mobile/run-android-release-quality-emulator-smoke.sh`를 추가해 `ro.kernel.qemu=1`인 로컬 Android emulator에서만 screenshot, UI tree, package, gfxinfo, meminfo, logcat 요약을 수집하게 했습니다.
- smoke runner가 Android API 35 이상, compact phone portrait viewport, 현재 rotation 0, 지정 font scale, 실제 foreground package를 실패 조건으로 검증하게 했습니다.
- #907 RC/store evidence와 release governance gate가 #917 Android 품질 gate를 참조하도록 갱신했습니다.
- README에 Android 출시 UX·접근성·성능 gate와 local Android emulator evidence 정책을 기록했습니다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/ci/*.test.mjs`: exit 0, 114 tests passed
- `cd apps/mobile && flutter analyze`: exit 0, No issues found
- `cd apps/mobile && flutter test`: exit 0, 522 tests passed
- `git diff --check`: exit 0
- `tools/mobile/run-android-release-quality-emulator-smoke.sh --serial emulator-5554 --artifact-dir /private/tmp/easysubway-917-emulator-smoke-font-1-5 --expected-font-scale 1.5 --adb /Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Android release quality gate 계약 | Local | Repository contract 전체 실행 | `node --test tools/ci/*.test.mjs` | exit 0, 114 tests passed |
| Mobile static analysis | Local Flutter | Flutter analyzer | `cd apps/mobile && flutter analyze` | exit 0, No issues found |
| Mobile widget/unit test | Local Flutter | Flutter test | `cd apps/mobile && flutter test` | exit 0, 522 tests passed |
| Local emulator discovery | Android emulator | `adb devices`, `emulator -list-avds`, `flutter devices`로 로컬 emulator와 device 목록 확인 | AVD `maum_on_api36`, serial `emulator-5554`; physical device도 보였지만 QA 요청에 따라 증거 수집에서 제외 | local emulator만 smoke에 사용 |
| Local emulator smoke evidence | Android emulator `emulator-5554` | Smoke script with explicit local emulator guard | `/private/tmp/easysubway-917-emulator-smoke-font-1-5/summary.txt` plus `current-screen.png`, `current-screen.xml`, `logcat.txt`, `gfxinfo.txt`, `meminfo.txt`; local-only because screenshot/logcat can include device state | exit 0, `ro.kernel.qemu=1`, `android_sdk=36`, `wm_size=1080x2400`, `wm_size_source=physical`, `width_dp=411`, `height_dp=914`, `viewport_orientation=portrait`, `screen_rotation=0`, `screen_rotation_source=dumpsys_input_viewport`, `font_scale=1.5`, `foreground_package_verified=true` |
| CodeRabbit/Codex fallback review | GitHub PR | CodeRabbit 상태 확인 후 Codex CLI fallback review 실행 | `codex review --base origin/main --title "[Fix] Android 출시 UX·접근성·성능 release gate 완성"` | 최종 fallback review에서 actionable issue 0건 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/release/android-release-quality-gate.json`의 requiredChecks가 #917 release blocker 범위를 충분히 대표하는지, 그리고 smoke script가 실기기 증거를 차단하는지 확인해 주세요.
- 이 PR은 release gate와 evidence collection 계약을 고정합니다. 실제 TalkBack 150%/200% 전체 수동 회귀는 exact RC 또는 Play-installed build에서 Go 판단 전에 다시 수집해야 합니다.
- 로컬 emulator screenshot/logcat 증거는 민감 가능성이 있어 GitHub에 파일 첨부하지 않고 local-only 경로와 요약값만 남깁니다.

## 리스크

- 현재 local emulator smoke는 기준 증거 수집 자동화이며, 모든 수동 TalkBack 여정을 자동 판정하지 않습니다. 이 한계는 gate manifest의 exact RC 재수집 조건으로 남겼습니다.
- RC 또는 Play-installed build 성능 측정은 #907 RC evidence 단계에서 다시 수행해야 하며, 이 PR은 release gate 계약과 local emulator 증거 수집 경계를 고정합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
