### PR TITLE
[Fix] 운영 마스터 데이터 쓰기 capability 게이트 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/common/persistence/ProductionPersistenceReadinessConfiguration.java
+++ b/backend/src/main/java/com/easysubway/common/persistence/ProductionPersistenceReadinessConfiguration.java
@@ -1,6 +1,7 @@
 package com.easysubway.common.persistence;
 
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.application.port.out.MasterDataCapabilityPort;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -19,6 +20,7 @@ class ProductionPersistenceReadinessConfiguration {
 	private static final String READY = "ready";
 	private static final String DOWN = "down";
 	private static final String EMPTY = "empty";
+	private static final String READ_ONLY = "read_only";
 
 	@Bean
 	HealthIndicator productionReadinessHealthIndicator(
@@ -29,9 +31,10 @@ class ProductionPersistenceReadinessConfiguration {
 			Map<String, Object> details = new LinkedHashMap<>();
 			boolean databaseReady = databaseReady(dataSource);
 			boolean masterDataReady = masterDataReady(loadTransitMasterPort);
+			boolean masterDataWritable = masterDataWritable(loadTransitMasterPort);
 
 			details.put("database", databaseReady ? READY : DOWN);
-			details.put("masterData", masterDataReady ? READY : EMPTY);
+			details.put("masterData", masterDataReady ? (masterDataWritable ? READY : READ_ONLY) : EMPTY);
 
 			boolean ready = databaseReady && masterDataReady;
 			return health(ready).withDetails(details).build();
@@ -58,5 +61,12 @@ class ProductionPersistenceReadinessConfiguration {
 		} catch (RuntimeException exception) {
 			return false;
 		}
+	}
+
+	private boolean masterDataWritable(LoadTransitMasterPort loadTransitMasterPort) {
+		if (loadTransitMasterPort instanceof MasterDataCapabilityPort capabilityPort) {
+			return capabilityPort.masterDataCapability().writable();
+		}
+		return true;
 	}
 }

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -13,6 +13,7 @@ import com.easysubway.report.domain.FacilityReportReviewDecision;
 import com.easysubway.report.domain.FacilityReportSummary;
 import com.easysubway.report.domain.FacilityReportStatus;
 import com.easysubway.report.domain.ReportProcessingTimeSummary;
+import com.easysubway.transit.domain.MasterDataWriteNotAllowedException;
 import java.math.BigDecimal;
 import java.security.Principal;
 import java.time.Clock;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Controller
@@ -157,11 +159,16 @@ class FacilityReportAdminPageController {
 		@PathVariable String reportId,
 		@RequestParam FacilityReportReviewDecision decision,
 		@RequestParam(required = false) String duplicateOfReportId,
-		Principal principal
+		Principal principal,
+		RedirectAttributes redirectAttributes
 	) {
-		facilityReportUseCase.reviewReport(
-			new ReviewFacilityReportCommand(reportId, decision, principal.getName(), duplicateOfReportId)
-		);
+		try {
+			facilityReportUseCase.reviewReport(
+				new ReviewFacilityReportCommand(reportId, decision, principal.getName(), duplicateOfReportId)
+			);
+		} catch (MasterDataWriteNotAllowedException exception) {
+			redirectAttributes.addFlashAttribute("masterDataError", exception.getMessage());
+		}
 		return "redirect:/admin/reports/%s/page".formatted(reportId);
 	}
 

--- a/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
+++ b/backend/src/main/java/com/easysubway/report/application/service/FacilityReportService.java
@@ -33,8 +33,10 @@ import com.easysubway.notification.application.port.in.FacilityStatusChangedAler
 import com.easysubway.notification.application.port.in.ReportStatusAlertUseCase;
 import com.easysubway.notification.application.port.in.ReportStatusChangedAlertCommand;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.application.port.out.MasterDataCapabilityPort;
 import com.easysubway.transit.application.port.out.SaveAccessibilityFacilityStatusPort;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import com.easysubway.transit.domain.MasterDataWriteNotAllowedException;
 import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationNotFoundException;
 import java.math.BigDecimal;
@@ -624,6 +626,9 @@ public class FacilityReportService implements FacilityReportUseCase {
 			report.receiptTokenHash()
 		);
 
+		if (command.decision() == FacilityReportReviewDecision.ACCEPT && toFacilityStatus(report.reportType()).isPresent()) {
+			requireWritableMasterData();
+		}
 		// 감사 로그 저장 실패가 신고 상태 변경을 남기지 않도록 같은 트랜잭션에서 먼저 기록한다.
 		saveFacilityReportReviewAuditPort.saveAudit(new FacilityReportReviewAudit(
 			"audit-" + UUID.randomUUID(),
@@ -904,6 +909,7 @@ public class FacilityReportService implements FacilityReportUseCase {
 
 		toFacilityStatus(report.reportType()).ifPresent(status -> {
 			boolean statusChanged = isFacilityStatusChanged(report.facilityId(), status);
+			requireWritableMasterData();
 			saveAccessibilityFacilityStatusPort.saveFacilityStatus(
 				report.facilityId(),
 				status,
@@ -927,6 +933,13 @@ public class FacilityReportService implements FacilityReportUseCase {
 			.findFirst()
 			.map(facility -> facility.status() != status)
 			.orElseThrow(FacilityReportTargetNotFoundException::new);
+	}
+
+	private void requireWritableMasterData() {
+		if (loadTransitMasterPort instanceof MasterDataCapabilityPort capabilityPort
+			&& !capabilityPort.masterDataCapability().writable()) {
+			throw new MasterDataWriteNotAllowedException();
+		}
 	}
 
 	private Optional<AccessibilityFacilityStatus> toFacilityStatus(FacilityReportType reportType) {

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
@@ -3,6 +3,7 @@ package com.easysubway.transit.adapter.in.web;
 import com.easysubway.transit.application.port.in.TransitMasterAdminUseCase;
 import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilityStatusCommand;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import com.easysubway.transit.domain.MasterDataWriteNotAllowedException;
 import java.security.Principal;
 import java.util.Arrays;
 import java.util.List;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 class TransitFacilityAdminPageController {
@@ -31,6 +33,7 @@ class TransitFacilityAdminPageController {
 	String facilitiesPage(Model model) {
 		model.addAttribute("facilities", facilityStatusAssembler.assemble());
 		model.addAttribute("statusOptions", statusOptions());
+		model.addAttribute("masterDataWritable", transitMasterAdminUseCase.masterDataCapability().writable());
 		return "admin/facilities/list";
 	}
 
@@ -38,13 +41,18 @@ class TransitFacilityAdminPageController {
 	String updateFacilityStatusFromPage(
 		@PathVariable String facilityId,
 		@RequestParam AccessibilityFacilityStatus status,
-		Principal principal
+		Principal principal,
+		RedirectAttributes redirectAttributes
 	) {
-		transitMasterAdminUseCase.updateFacilityStatus(new UpdateAccessibilityFacilityStatusCommand(
-			facilityId,
-			status,
-			principal.getName()
-		));
+		try {
+			transitMasterAdminUseCase.updateFacilityStatus(new UpdateAccessibilityFacilityStatusCommand(
+				facilityId,
+				status,
+				principal.getName()
+			));
+		} catch (MasterDataWriteNotAllowedException exception) {
+			redirectAttributes.addFlashAttribute("masterDataError", exception.getMessage());
+		}
 		return "redirect:/admin/facilities/page";
 	}
 

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
@@ -12,6 +12,7 @@ import com.easysubway.transit.domain.AccessibilityFacilityType;
 import com.easysubway.transit.domain.DataConfidenceLevel;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.MasterDataWriteNotAllowedException;
 import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.StationExit;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 class TransitStationAdminPageController {
@@ -103,6 +105,7 @@ class TransitStationAdminPageController {
 		model.addAttribute("statusOptions", Arrays.asList(AccessibilityFacilityStatus.values()));
 		model.addAttribute("confidenceOptions", Arrays.asList(DataConfidenceLevel.values()));
 		model.addAttribute("sourceTypeOptions", Arrays.asList(DataSourceType.values()));
+		model.addAttribute("masterDataWritable", transitMasterAdminUseCase.masterDataCapability().writable());
 		return "admin/facilities/editor";
 	}
 
@@ -121,12 +124,32 @@ class TransitStationAdminPageController {
 		@RequestParam AccessibilityFacilityStatus status,
 		@RequestParam DataConfidenceLevel dataConfidence,
 		@RequestParam DataSourceType dataSourceType,
-		Principal principal
+		Principal principal,
+		RedirectAttributes redirectAttributes
 	) {
-		if (facilityId == null || facilityId.isBlank()) {
-			String newFacilityId = "facility-" + stationId + "-" + type.name().toLowerCase() + "-" + System.currentTimeMillis();
-			transitMasterAdminUseCase.createAccessibilityFacility(new CreateAccessibilityFacilityCommand(
-				newFacilityId,
+		try {
+			if (facilityId == null || facilityId.isBlank()) {
+				String newFacilityId = "facility-" + stationId + "-" + type.name().toLowerCase() + "-" + System.currentTimeMillis();
+				transitMasterAdminUseCase.createAccessibilityFacility(new CreateAccessibilityFacilityCommand(
+					newFacilityId,
+					stationId,
+					blankToNull(exitId),
+					type,
+					name,
+					blankToNull(floorFrom),
+					blankToNull(floorTo),
+					latitude,
+					longitude,
+					blankToNull(description),
+					status,
+					dataConfidence,
+					dataSourceType,
+					principal.getName()
+				));
+				return "redirect:/admin/facilities/editor/page?stationId=%s&facilityId=%s".formatted(stationId, newFacilityId);
+			}
+			transitMasterAdminUseCase.updateAccessibilityFacility(new UpdateAccessibilityFacilityCommand(
+				facilityId,
 				stationId,
 				blankToNull(exitId),
 				type,
@@ -141,24 +164,9 @@ class TransitStationAdminPageController {
 				dataSourceType,
 				principal.getName()
 			));
-			return "redirect:/admin/facilities/editor/page?stationId=%s&facilityId=%s".formatted(stationId, newFacilityId);
+		} catch (MasterDataWriteNotAllowedException exception) {
+			redirectAttributes.addFlashAttribute("masterDataError", exception.getMessage());
 		}
-		transitMasterAdminUseCase.updateAccessibilityFacility(new UpdateAccessibilityFacilityCommand(
-			facilityId,
-			stationId,
-			blankToNull(exitId),
-			type,
-			name,
-			blankToNull(floorFrom),
-			blankToNull(floorTo),
-			latitude,
-			longitude,
-			blankToNull(description),
-			status,
-			dataConfidence,
-			dataSourceType,
-			principal.getName()
-		));
 		return "redirect:/admin/facilities/editor/page?stationId=%s&facilityId=%s".formatted(stationId, facilityId);
 	}
 

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageController.java
@@ -18,6 +18,7 @@ import com.easysubway.transit.domain.StationLayoutSourceNotFoundException;
 import com.easysubway.transit.domain.StationLayoutSourceType;
 import com.easysubway.transit.domain.StationLineSummary;
 import com.easysubway.transit.domain.StationWithLines;
+import com.easysubway.transit.domain.MasterDataWriteNotAllowedException;
 import java.security.Principal;
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 class TransitStationLayoutAdminPageController {
@@ -54,6 +56,7 @@ class TransitStationLayoutAdminPageController {
 		model.addAttribute("layoutStatusOptions", layoutStatusOptions());
 		model.addAttribute("routeNodes", routeNodeRows(stationId));
 		model.addAttribute("routeEdges", routeEdgeRows(stationId));
+		model.addAttribute("masterDataWritable", transitMasterAdminUseCase.masterDataCapability().writable());
 		return "admin/stations/layouts";
 	}
 
@@ -62,14 +65,19 @@ class TransitStationLayoutAdminPageController {
 		@PathVariable String stationId,
 		@PathVariable String layoutId,
 		@RequestParam SimplifiedStationLayoutStatus status,
-		Principal principal
+		Principal principal,
+		RedirectAttributes redirectAttributes
 	) {
 		requireLayoutInStation(stationId, layoutId);
-		transitMasterAdminUseCase.updateSimplifiedStationLayoutStatus(new UpdateSimplifiedStationLayoutStatusCommand(
-			layoutId,
-			status,
-			principal.getName()
-		));
+		try {
+			transitMasterAdminUseCase.updateSimplifiedStationLayoutStatus(new UpdateSimplifiedStationLayoutStatusCommand(
+				layoutId,
+				status,
+				principal.getName()
+			));
+		} catch (MasterDataWriteNotAllowedException exception) {
+			redirectAttributes.addFlashAttribute("masterDataError", exception.getMessage());
+		}
 		return "redirect:/admin/stations/%s/layouts/page".formatted(stationId);
 	}
 
@@ -85,22 +93,27 @@ class TransitStationLayoutAdminPageController {
 		@RequestParam boolean attributionRequired,
 		@RequestParam LocalDate capturedAt,
 		@RequestParam(required = false) LocalDate reviewedAt,
-		Principal principal
+		Principal principal,
+		RedirectAttributes redirectAttributes
 	) {
 		requireStationLayoutSourceInStation(stationId, sourceId);
-		transitMasterAdminUseCase.updateStationLayoutSource(new UpdateStationLayoutSourceCommand(
-			stationId,
-			sourceId,
-			sourceType,
-			sourceName,
-			sourceUrl,
-			license,
-			commercialUseAllowed,
-			attributionRequired,
-			capturedAt,
-			reviewedAt,
-			principal.getName()
-		));
+		try {
+			transitMasterAdminUseCase.updateStationLayoutSource(new UpdateStationLayoutSourceCommand(
+				stationId,
+				sourceId,
+				sourceType,
+				sourceName,
+				sourceUrl,
+				license,
+				commercialUseAllowed,
+				attributionRequired,
+				capturedAt,
+				reviewedAt,
+				principal.getName()
+			));
+		} catch (MasterDataWriteNotAllowedException exception) {
+			redirectAttributes.addFlashAttribute("masterDataError", exception.getMessage());
+		}
 		return "redirect:/admin/stations/%s/layouts/page".formatted(stationId);
 	}
 
@@ -112,18 +125,23 @@ class TransitStationLayoutAdminPageController {
 		@RequestParam int displayY,
 		@RequestParam String displayLabel,
 		@RequestParam(required = false) String accessibilityNote,
-		Principal principal
+		Principal principal,
+		RedirectAttributes redirectAttributes
 	) {
 		requireRouteNodeInStation(stationId, nodeId);
-		transitMasterAdminUseCase.updateRouteNodeDisplay(new UpdateRouteNodeDisplayCommand(
-			stationId,
-			nodeId,
-			displayX,
-			displayY,
-			displayLabel,
-			accessibilityNote,
-			principal.getName()
-		));
+		try {
+			transitMasterAdminUseCase.updateRouteNodeDisplay(new UpdateRouteNodeDisplayCommand(
+				stationId,
+				nodeId,
+				displayX,
+				displayY,
+				displayLabel,
+				accessibilityNote,
+				principal.getName()
+			));
+		} catch (MasterDataWriteNotAllowedException exception) {
+			redirectAttributes.addFlashAttribute("masterDataError", exception.getMessage());
+		}
 		return "redirect:/admin/stations/%s/layouts/page".formatted(stationId);
 	}
 
@@ -140,23 +158,28 @@ class TransitStationLayoutAdminPageController {
 		@RequestParam int widthLevel,
 		@RequestParam int reliabilityScore,
 		@RequestParam boolean active,
-		Principal principal
+		Principal principal,
+		RedirectAttributes redirectAttributes
 	) {
 		requireRouteEdgeInStation(stationId, edgeId);
-		transitMasterAdminUseCase.updateRouteEdge(new UpdateRouteEdgeCommand(
-			stationId,
-			edgeId,
-			distanceMeters,
-			estimatedSeconds,
-			hasStairs,
-			requiresElevator,
-			requiresEscalator,
-			slopeLevel,
-			widthLevel,
-			reliabilityScore,
-			active,
-			principal.getName()
-		));
+		try {
+			transitMasterAdminUseCase.updateRouteEdge(new UpdateRouteEdgeCommand(
+				stationId,
+				edgeId,
+				distanceMeters,
+				estimatedSeconds,
+				hasStairs,
+				requiresElevator,
+				requiresEscalator,
+				slopeLevel,
+				widthLevel,
+				reliabilityScore,
+				active,
+				principal.getName()
+			));
+		} catch (MasterDataWriteNotAllowedException exception) {
+			redirectAttributes.addFlashAttribute("masterDataError", exception.getMessage());
+		}
 		return "redirect:/admin/stations/%s/layouts/page".formatted(stationId);
 	}
 

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/UnavailableTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/UnavailableTransitMasterRepository.java
@@ -1,6 +1,9 @@
 package com.easysubway.transit.adapter.out.persistence;
 
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.application.port.out.MasterDataCapability;
+import com.easysubway.transit.application.port.out.MasterDataCapabilityPort;
+import com.easysubway.transit.application.port.out.MasterDataCapabilityStatus;
 import com.easysubway.transit.application.port.out.SaveAccessibilityFacilityStatusPort;
 import com.easysubway.transit.application.port.out.SaveRouteEdgePort;
 import com.easysubway.transit.application.port.out.SaveRouteNodePort;
@@ -27,6 +30,7 @@ import org.springframework.stereotype.Repository;
 @Profile("prod")
 public class UnavailableTransitMasterRepository implements
 	LoadTransitMasterPort,
+	MasterDataCapabilityPort,
 	SaveAccessibilityFacilityStatusPort,
 	SaveStationLayoutSourcePort,
 	SaveSimplifiedStationLayoutStatusPort,
@@ -35,6 +39,11 @@ public class UnavailableTransitMasterRepository implements
 
 	// ponytail: reuse the existing static seed until a real data-pack adapter exists.
 	private final InMemoryTransitMasterRepository seedRepository = new InMemoryTransitMasterRepository();
+
+	@Override
+	public MasterDataCapability masterDataCapability() {
+		return new MasterDataCapability(MasterDataCapabilityStatus.READ_ONLY, true, false, "static-seed", "unavailable", null);
+	}
 
 	@Override
 	public List<TransitOperator> loadOperators() {

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterAdminUseCase.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/TransitMasterAdminUseCase.java
@@ -1,12 +1,15 @@
 package com.easysubway.transit.application.port.in;
 
 import com.easysubway.transit.domain.AccessibilityFacility;
+import com.easysubway.transit.application.port.out.MasterDataCapability;
 import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteNode;
 import com.easysubway.transit.domain.StationLayoutSource;
 import com.easysubway.transit.domain.SimplifiedStationLayout;
 
 public interface TransitMasterAdminUseCase {
+
+	MasterDataCapability masterDataCapability();
 
 	AccessibilityFacility createAccessibilityFacility(CreateAccessibilityFacilityCommand command);
 

--- a/backend/src/main/java/com/easysubway/transit/application/port/out/MasterDataCapability.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/out/MasterDataCapability.java
@@ -1,0 +1,13 @@
+package com.easysubway.transit.application.port.out;
+
+import java.time.Instant;
+
+public record MasterDataCapability(
+	MasterDataCapabilityStatus status,
+	boolean readable,
+	boolean writable,
+	String artifactVersion,
+	String sha256,
+	Instant loadedAt
+) {
+}

--- a/backend/src/main/java/com/easysubway/transit/application/port/out/MasterDataCapabilityPort.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/out/MasterDataCapabilityPort.java
@@ -1,0 +1,6 @@
+package com.easysubway.transit.application.port.out;
+
+public interface MasterDataCapabilityPort {
+
+	MasterDataCapability masterDataCapability();
+}

--- a/backend/src/main/java/com/easysubway/transit/application/port/out/MasterDataCapabilityStatus.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/out/MasterDataCapabilityStatus.java
@@ -1,0 +1,10 @@
+package com.easysubway.transit.application.port.out;
+
+public enum MasterDataCapabilityStatus {
+	UP,
+	READ_ONLY,
+	STALE,
+	DEGRADED,
+	DOWN,
+	UNKNOWN
+}

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -15,6 +15,9 @@ import com.easysubway.transit.application.port.in.UpdateStationLayoutSourceComma
 import com.easysubway.notification.application.port.in.FacilityStatusAlertUseCase;
 import com.easysubway.notification.application.port.in.FacilityStatusChangedAlertCommand;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.application.port.out.MasterDataCapability;
+import com.easysubway.transit.application.port.out.MasterDataCapabilityPort;
+import com.easysubway.transit.application.port.out.MasterDataCapabilityStatus;
 import com.easysubway.transit.application.port.out.SaveAccessibilityFacilityStatusPort;
 import com.easysubway.transit.application.port.out.SaveRouteEdgePort;
 import com.easysubway.transit.application.port.out.SaveRouteNodePort;
@@ -32,6 +35,7 @@ import com.easysubway.transit.domain.InvalidRouteEdgeException;
 import com.easysubway.transit.domain.InvalidRouteNodeException;
 import com.easysubway.transit.domain.InvalidSimplifiedStationLayoutException;
 import com.easysubway.transit.domain.InvalidStationLayoutSourceException;
+import com.easysubway.transit.domain.MasterDataWriteNotAllowedException;
 import com.easysubway.transit.domain.NearbyStation;
 import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteEdgeNotFoundException;
@@ -170,6 +174,14 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		this.saveRouteEdgePort = saveRouteEdgePort;
 		this.facilityStatusAlertUseCase = facilityStatusAlertUseCase;
 		this.clock = clock;
+	}
+
+	@Override
+	public MasterDataCapability masterDataCapability() {
+		if (loadTransitMasterPort instanceof MasterDataCapabilityPort capabilityPort) {
+			return capabilityPort.masterDataCapability();
+		}
+		return new MasterDataCapability(MasterDataCapabilityStatus.UP, true, true, "unknown", "unknown", null);
 	}
 
 	@Override
@@ -345,6 +357,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 			throw new InvalidAccessibilityFacilityException("이미 등록된 시설입니다.");
 		}
 
+		requireWritableMasterData();
 		AccessibilityFacility facility = new AccessibilityFacility(
 			command.id(),
 			command.stationId(),
@@ -382,6 +395,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		loadActiveStation(command.stationId());
 		requireExitInStation(command.stationId(), command.exitId());
 
+		requireWritableMasterData();
 		AccessibilityFacility facility = new AccessibilityFacility(
 			existing.id(),
 			command.stationId(),
@@ -415,6 +429,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		AccessibilityFacility facility = loadAccessibilityFacility(command.facilityId());
 		LocalDate updatedAt = LocalDate.now(clock);
 		// 관리자 직접 수정은 역 상세와 경로 추천이 함께 사용하는 운영 상태의 기준값을 바꾼다.
+		requireWritableMasterData();
 		saveAccessibilityFacilityStatusPort.saveFacilityStatus(facility.id(), command.status(), updatedAt);
 		if (facility.status() != command.status()) {
 			facilityStatusAlertUseCase.alertFacilityStatusChanged(
@@ -434,6 +449,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		}
 
 		StationLayoutSource updated = withStationLayoutSource(source, command);
+		requireWritableMasterData();
 		saveStationLayoutSourcePort.saveStationLayoutSource(updated);
 		return updated;
 	}
@@ -446,6 +462,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		SimplifiedStationLayout layout = loadSimplifiedStationLayout(command.layoutId());
 		LocalDate updatedAt = LocalDate.now(clock);
 		// 검수 상태는 앱 렌더링 데이터가 아니라 운영자가 배포 가능성을 판단하는 메타데이터만 갱신한다.
+		requireWritableMasterData();
 		saveSimplifiedStationLayoutStatusPort.saveSimplifiedStationLayoutStatus(
 			layout.id(),
 			command.status(),
@@ -465,6 +482,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		}
 
 		RouteNode updated = withRouteNodeDisplay(routeNode, command);
+		requireWritableMasterData();
 		saveRouteNodePort.saveRouteNode(updated);
 		return updated;
 	}
@@ -479,6 +497,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		}
 
 		RouteEdge updated = withRouteEdge(routeEdge, command);
+		requireWritableMasterData();
 		saveRouteEdgePort.saveRouteEdge(updated);
 		return updated;
 	}
@@ -499,6 +518,12 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 			stationsInRegion.size(),
 			dataQualityCounts(stationsInRegion)
 		);
+	}
+
+	private void requireWritableMasterData() {
+		if (!masterDataCapability().writable()) {
+			throw new MasterDataWriteNotAllowedException();
+		}
 	}
 
 	private Map<DataQualityLevel, Long> dataQualityCounts(List<Station> stations) {

--- a/backend/src/main/java/com/easysubway/transit/domain/MasterDataWriteNotAllowedException.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/MasterDataWriteNotAllowedException.java
@@ -1,0 +1,10 @@
+package com.easysubway.transit.domain;
+
+import com.easysubway.common.error.ConflictException;
+
+public class MasterDataWriteNotAllowedException extends ConflictException {
+
+	public MasterDataWriteNotAllowedException() {
+		super("운영 마스터 데이터가 읽기 전용입니다.");
+	}
+}

--- a/backend/src/main/resources/templates/admin/facilities/editor.html
+++ b/backend/src/main/resources/templates/admin/facilities/editor.html
@@ -20,6 +20,14 @@
 			<a class="admin-btn" th:href="@{/admin/facilities/page}">상태판</a>
 		</div>
 	</header>
+	<div class="alert warning" th:if="${!masterDataWritable}">
+		<strong>읽기 전용 마스터 데이터</strong>
+		<p>현재 운영 데이터는 저장할 수 없어 시설 등록과 수정 요청이 차단됩니다.</p>
+	</div>
+	<div class="alert warning" th:if="${masterDataError}">
+		<strong>저장 요청 차단</strong>
+		<p th:text="${masterDataError}">운영 마스터 데이터가 읽기 전용입니다.</p>
+	</div>
 
 	<div class="admin-grid-2">
 		<section class="admin-panel">
@@ -136,7 +144,7 @@
 					<span class="meta">사용자 위치 설명</span>
 					<textarea name="description" th:text="${selectedFacility == null ? '' : selectedFacility.description}"></textarea>
 				</label>
-				<button type="submit" th:text="${selectedFacility == null ? '등록' : '저장'}">저장</button>
+				<button type="submit" th:disabled="${!masterDataWritable}" th:text="${selectedFacility == null ? '등록' : '저장'}">저장</button>
 			</form>
 		</section>
 	</div>

--- a/backend/src/main/resources/templates/admin/facilities/list.html
+++ b/backend/src/main/resources/templates/admin/facilities/list.html
@@ -119,6 +119,14 @@
 		</div>
 	</header>
 	<p class="summary">역 상세와 경로 안내에 쓰는 시설 상태를 확인하고 수정합니다.</p>
+	<div class="alert warning" th:if="${!masterDataWritable}">
+		<strong>읽기 전용 마스터 데이터</strong>
+		<p>현재 운영 데이터는 저장할 수 없어 상태 변경 요청이 차단됩니다.</p>
+	</div>
+	<div class="alert warning" th:if="${masterDataError}">
+		<strong>저장 요청 차단</strong>
+		<p th:text="${masterDataError}">운영 마스터 데이터가 읽기 전용입니다.</p>
+	</div>
 
 	<p class="empty" th:if="${facilities.isEmpty()}">등록된 시설이 없습니다.</p>
 	<table th:if="${!facilities.isEmpty()}">
@@ -159,7 +167,7 @@
 							        th:text="${option.label}">정상</option>
 						</select>
 					</label>
-					<button type="submit">저장</button>
+					<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
 				</form>
 			</td>
 		</tr>

--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -119,6 +119,10 @@
 		</div>
 	</header>
 	<h1 class="sr-only">신고 상세</h1>
+	<div class="alert warning" th:if="${masterDataError}">
+		<strong>검수 요청 차단</strong>
+		<p th:text="${masterDataError}">운영 마스터 데이터가 읽기 전용입니다.</p>
+	</div>
 
 	<section>
 		<h2>신고 내용</h2>

--- a/backend/src/main/resources/templates/admin/stations/layouts.html
+++ b/backend/src/main/resources/templates/admin/stations/layouts.html
@@ -135,6 +135,15 @@
 		</div>
 	</header>
 
+	<div class="alert warning" th:if="${!masterDataWritable}">
+		<strong>읽기 전용 마스터 데이터</strong>
+		<p>현재 운영 데이터는 저장할 수 없어 구조도와 내부 이동 정보 수정 요청이 차단됩니다.</p>
+	</div>
+	<div class="alert warning" th:if="${masterDataError}">
+		<strong>저장 요청 차단</strong>
+		<p th:text="${masterDataError}">운영 마스터 데이터가 읽기 전용입니다.</p>
+	</div>
+
 	<section>
 		<h2>구조도 기준 자료</h2>
 		<p class="empty" th:if="${layoutSources.isEmpty()}">등록된 구조도 기준 자료가 없습니다.</p>
@@ -185,7 +194,7 @@
 						<label class="meta" th:for="|reviewed-at-${source.id}|">검수일</label>
 						<input type="date" name="reviewedAt" th:id="|reviewed-at-${source.id}|"
 						       th:value="${source.rawReviewedAt}">
-						<button type="submit">저장</button>
+						<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
 					</form>
 					<span class="meta" th:text="${source.sourceName}">상록수역 역사 안내도</span>
 					<span class="meta" th:text="${source.sourceUrl}">https://www.seoulmetro.co.kr</span>
@@ -235,7 +244,7 @@
 							        th:text="${option.label}"
 							        th:selected="${option.value == layout.statusValue}">DRAFT</option>
 						</select>
-						<button type="submit">변경</button>
+						<button type="submit" th:disabled="${!masterDataWritable}">변경</button>
 					</form>
 				</td>
 				<td th:text="${layout.confidenceLevel}">OFFICIAL_DIAGRAM_REFERENCED</td>
@@ -283,7 +292,7 @@
 						<label class="meta" th:for="|accessibility-note-${node.id}|">접근성 메모</label>
 						<input type="text" name="accessibilityNote" th:id="|accessibility-note-${node.id}|"
 						       th:value="${node.rawAccessibilityNote}">
-						<button type="submit">저장</button>
+						<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
 						<span class="meta" th:text="${node.positionLabel}">x 120, y 240</span>
 						<span class="meta" th:text="${node.layoutId}">layout-sangnoksu-draft</span>
 					</form>
@@ -353,7 +362,7 @@
 							<option value="true" th:selected="${edge.active}">활성</option>
 							<option value="false" th:selected="${!edge.active}">비활성</option>
 						</select>
-						<button type="submit">저장</button>
+						<button type="submit" th:disabled="${!masterDataWritable}">저장</button>
 					</form>
 					<span class="meta" th:text="${edge.distanceLabel}">28m</span>
 					<span class="meta" th:text="${edge.estimatedSecondsLabel}">75초</span>

--- a/backend/src/test/java/com/easysubway/common/persistence/ProductionPersistenceReadinessConfigurationTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/ProductionPersistenceReadinessConfigurationTest.java
@@ -1,7 +1,11 @@
 package com.easysubway.common.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.application.port.out.MasterDataCapability;
+import com.easysubway.transit.application.port.out.MasterDataCapabilityPort;
+import com.easysubway.transit.application.port.out.MasterDataCapabilityStatus;
 import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.DataQualityLevel;
 import com.easysubway.transit.domain.DataSourceType;
@@ -49,6 +53,22 @@ class ProductionPersistenceReadinessConfigurationTest {
 				assertThat(health.getDetails()).containsEntry("masterData", "ready");
 				assertThat(health.getDetails()).doesNotContainKey("redis");
 				assertThat(health.getDetails()).doesNotContainKey("push");
+			});
+	}
+
+	@Test
+	@DisplayName("운영 readiness는 마스터 데이터가 읽기 전용이면 read_only 상태를 노출한다")
+	void prodReadinessReportsReadOnlyMasterDataCapability() {
+		productionContext(ReadOnlyDependencyTestConfiguration.class)
+			.withPropertyValues("spring.profiles.active=prod")
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+
+				Health health = context.getBean(HealthIndicator.class).health();
+
+				assertThat(health.getStatus()).isEqualTo(Status.UP);
+				assertThat(health.getDetails()).containsEntry("database", "ready");
+				assertThat(health.getDetails()).containsEntry("masterData", "read_only");
 			});
 	}
 
@@ -145,6 +165,39 @@ class ProductionPersistenceReadinessConfigurationTest {
 		}
 	}
 
+	@TestConfiguration
+	static class ReadOnlyDependencyTestConfiguration extends ReadyDependencyTestConfiguration {
+
+		@Bean
+		@Override
+		LoadTransitMasterPort loadTransitMasterPort() {
+			return new ReadOnlyStaticTransitMasterPort(
+				List.of(new TransitOperator(
+					"seoul-metro",
+					"서울교통공사",
+					"수도권",
+					"https://www.seoulmetro.co.kr",
+					"https://www.seoulmetro.co.kr",
+					DataSourceType.OFFICIAL_API,
+					true
+				)),
+				List.of(new SubwayLine("line-1", "seoul-metro", "1호선", "#0052A4", "수도권", "1", true)),
+				List.of(new Station(
+					"station-1",
+					"서울역",
+					"Seoul Station",
+					"수도권",
+					BigDecimal.valueOf(37.5547),
+					BigDecimal.valueOf(126.9706),
+					DataQualityLevel.LEVEL_1,
+					DataSourceType.OFFICIAL_API,
+					LocalDate.of(2026, 1, 1),
+					true
+				))
+			);
+		}
+	}
+
 	private record StaticTransitMasterPort(
 		List<TransitOperator> operators,
 		List<SubwayLine> lines,
@@ -198,6 +251,55 @@ class ProductionPersistenceReadinessConfigurationTest {
 
 		@Override
 		public List<RouteEdge> loadRouteEdges() {
+			return List.of();
+		}
+	}
+
+	private record ReadOnlyStaticTransitMasterPort(
+		List<TransitOperator> operators,
+		List<SubwayLine> lines,
+		List<Station> stations
+	) implements LoadTransitMasterPort, MasterDataCapabilityPort {
+
+		@Override
+		public MasterDataCapability masterDataCapability() {
+			return new MasterDataCapability(
+				MasterDataCapabilityStatus.READ_ONLY,
+				true,
+				false,
+				"fixture",
+				"sha256",
+				null
+			);
+		}
+
+		@Override
+		public List<TransitOperator> loadOperators() {
+			return operators;
+		}
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return lines;
+		}
+
+		@Override
+		public List<Station> loadStations() {
+			return stations;
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of();
+		}
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of();
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
 			return List.of();
 		}
 	}

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageReadOnlyControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageReadOnlyControllerTest.java
@@ -1,0 +1,69 @@
+package com.easysubway.report.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.common.web.WebMessageResolver;
+import com.easysubway.report.adapter.out.persistence.InMemoryFacilityReportRepository;
+import com.easysubway.report.application.port.in.CreateFacilityReportCommand;
+import com.easysubway.report.application.service.FacilityReportService;
+import com.easysubway.report.domain.FacilityReportReviewDecision;
+import com.easysubway.report.domain.FacilityReportType;
+import com.easysubway.transit.adapter.out.persistence.UnavailableTransitMasterRepository;
+import java.security.Principal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+@DisplayName("읽기 전용 마스터 데이터 신고 검수 화면")
+class FacilityReportAdminPageReadOnlyControllerTest {
+
+	private static final Principal ADMIN = () -> "admin-user";
+
+	@Test
+	@DisplayName("시설 상태 반영이 필요한 신고 승인은 읽기 전용 오류를 flash로 돌려보낸다")
+	void reportReviewPostRedirectsWithReadOnlyFlash() {
+		var transitRepository = new UnavailableTransitMasterRepository();
+		var reportRepository = new InMemoryFacilityReportRepository();
+		var service = new FacilityReportService(
+			transitRepository,
+			transitRepository,
+			reportRepository,
+			reportRepository,
+			Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+		);
+		var controller = new FacilityReportAdminPageController(
+			service,
+			objectKey -> java.util.Optional.empty(),
+			WebMessageResolver.defaultMessages(),
+			Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+		);
+		var report = service.createReport(new CreateFacilityReportCommand(
+			"anonymous-user-read-only",
+			"station-sangnoksu",
+			"facility-sangnoksu-elevator-1",
+			FacilityReportType.BROKEN,
+			"읽기 전용 마스터 데이터에서 승인할 수 없는 신고입니다.",
+			null,
+			null,
+			null,
+			null,
+			null
+		));
+		var redirectAttributes = new RedirectAttributesModelMap();
+
+		String viewName = controller.reviewReportFromPage(
+			report.id(),
+			FacilityReportReviewDecision.ACCEPT,
+			null,
+			ADMIN,
+			redirectAttributes
+		);
+
+		assertThat(viewName).isEqualTo("redirect:/admin/reports/%s/page".formatted(report.id()));
+		assertThat(redirectAttributes.getFlashAttributes().get("masterDataError"))
+			.isEqualTo("운영 마스터 데이터가 읽기 전용입니다.");
+	}
+}

--- a/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
+++ b/backend/src/test/java/com/easysubway/report/application/service/FacilityReportServiceTest.java
@@ -30,7 +30,9 @@ import com.easysubway.notification.application.port.in.FacilityStatusChangedAler
 import com.easysubway.notification.application.port.in.ReportStatusAlertUseCase;
 import com.easysubway.notification.application.port.in.ReportStatusChangedAlertCommand;
 import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
+import com.easysubway.transit.adapter.out.persistence.UnavailableTransitMasterRepository;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import com.easysubway.transit.domain.MasterDataWriteNotAllowedException;
 import com.easysubway.transit.domain.StationNotFoundException;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -920,6 +922,31 @@ class FacilityReportServiceTest {
 		serviceWithFacilityStatus.reviewReport(reviewCommand(recovered.id(), FacilityReportReviewDecision.ACCEPT));
 		assertThat(facilityStatus(transitRepository, "facility-sangnoksu-elevator-1"))
 			.isEqualTo(AccessibilityFacilityStatus.NORMAL);
+	}
+
+	@Test
+	@DisplayName("읽기 전용 마스터 데이터에서는 시설 상태 신고 승인을 저장 전에 거부한다")
+	void acceptedReportRejectsReadOnlyMasterDataBeforeReviewSave() {
+		var transitRepository = new UnavailableTransitMasterRepository();
+		var repository = new InMemoryFacilityReportRepository();
+		var service = new FacilityReportService(
+			transitRepository,
+			transitRepository,
+			repository,
+			repository,
+			Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+		);
+		var report = service.createReport(reportCommand(
+			"anonymous-user-read-only",
+			FacilityReportType.BROKEN,
+			"읽기 전용 마스터 데이터에서 승인할 수 없는 신고입니다."
+		));
+
+		assertThatThrownBy(() -> service.reviewReport(reviewCommand(report.id(), FacilityReportReviewDecision.ACCEPT)))
+			.isInstanceOf(MasterDataWriteNotAllowedException.class)
+			.hasMessage("운영 마스터 데이터가 읽기 전용입니다.");
+
+		assertThat(service.getReport(report.id()).status()).isEqualTo(FacilityReportStatus.SUBMITTED);
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
@@ -1,0 +1,196 @@
+package com.easysubway.transit.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.transit.adapter.out.persistence.UnavailableTransitMasterRepository;
+import com.easysubway.transit.application.service.TransitMasterService;
+import com.easysubway.transit.domain.AccessibilityFacilityStatus;
+import com.easysubway.transit.domain.AccessibilityFacilityType;
+import com.easysubway.transit.domain.DataConfidenceLevel;
+import com.easysubway.transit.domain.DataSourceType;
+import com.easysubway.transit.domain.SimplifiedStationLayoutStatus;
+import com.easysubway.transit.domain.StationLayoutSourceType;
+import java.security.Principal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+@DisplayName("읽기 전용 마스터 데이터 관리자 화면 모델")
+class TransitReadOnlyAdminPageModelTest {
+
+	private static final Principal ADMIN = () -> "admin-user";
+
+	private final UnavailableTransitMasterRepository repository = new UnavailableTransitMasterRepository();
+	private final TransitMasterService transitMasterService = new TransitMasterService(
+		repository,
+		repository,
+		Clock.fixed(Instant.parse("2026-06-12T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+	);
+
+	@Test
+	@DisplayName("시설 상태 화면은 저장 버튼 비활성화 기준을 전달한다")
+	void facilityStatusPageExposesReadOnlyMasterDataFlag() {
+		var controller = new TransitFacilityAdminPageController(
+			new TransitFacilityStatusAssembler(transitMasterService),
+			transitMasterService
+		);
+		var model = new ExtendedModelMap();
+
+		String viewName = controller.facilitiesPage(model);
+
+		assertThat(viewName).isEqualTo("admin/facilities/list");
+		assertThat(model.get("masterDataWritable")).isEqualTo(false);
+	}
+
+	@Test
+	@DisplayName("시설 상태 직접 저장 요청은 읽기 전용 오류를 flash로 돌려보낸다")
+	void facilityStatusPostRedirectsWithReadOnlyFlash() {
+		var controller = new TransitFacilityAdminPageController(
+			new TransitFacilityStatusAssembler(transitMasterService),
+			transitMasterService
+		);
+		var redirectAttributes = new RedirectAttributesModelMap();
+
+		String viewName = controller.updateFacilityStatusFromPage(
+			"facility-sangnoksu-elevator-1",
+			AccessibilityFacilityStatus.BROKEN,
+			ADMIN,
+			redirectAttributes
+		);
+
+		assertThat(viewName).isEqualTo("redirect:/admin/facilities/page");
+		assertReadOnlyFlash(redirectAttributes);
+	}
+
+	@Test
+	@DisplayName("시설 등록·수정 화면은 저장 버튼 비활성화 기준을 전달한다")
+	void facilityEditorPageExposesReadOnlyMasterDataFlag() {
+		var controller = new TransitStationAdminPageController(transitMasterService, transitMasterService);
+		var model = new ExtendedModelMap();
+
+		String viewName = controller.facilityEditorPage("station-sangnoksu", "facility-sangnoksu-elevator-1", model);
+
+		assertThat(viewName).isEqualTo("admin/facilities/editor");
+		assertThat(model.get("masterDataWritable")).isEqualTo(false);
+	}
+
+	@Test
+	@DisplayName("시설 등록·수정 직접 저장 요청은 읽기 전용 오류를 flash로 돌려보낸다")
+	void facilityEditorPostRedirectsWithReadOnlyFlash() {
+		var controller = new TransitStationAdminPageController(transitMasterService, transitMasterService);
+		var redirectAttributes = new RedirectAttributesModelMap();
+
+		String viewName = controller.saveFacilityFromPage(
+			"facility-sangnoksu-elevator-1",
+			"station-sangnoksu",
+			null,
+			AccessibilityFacilityType.ELEVATOR,
+			"1번 출구 엘리베이터",
+			"B1",
+			"1F",
+			null,
+			null,
+			"휠체어 이동 가능",
+			AccessibilityFacilityStatus.BROKEN,
+			DataConfidenceLevel.HIGH,
+			DataSourceType.OFFICIAL_API,
+			ADMIN,
+			redirectAttributes
+		);
+
+		assertThat(viewName)
+			.isEqualTo("redirect:/admin/facilities/editor/page?stationId=station-sangnoksu&facilityId=facility-sangnoksu-elevator-1");
+		assertReadOnlyFlash(redirectAttributes);
+	}
+
+	@Test
+	@DisplayName("역 구조도 화면은 저장 버튼 비활성화 기준을 전달한다")
+	void stationLayoutPageExposesReadOnlyMasterDataFlag() {
+		var controller = new TransitStationLayoutAdminPageController(transitMasterService, transitMasterService);
+		var model = new ExtendedModelMap();
+
+		String viewName = controller.stationLayoutsPage("station-sangnoksu", model);
+
+		assertThat(viewName).isEqualTo("admin/stations/layouts");
+		assertThat(model.get("masterDataWritable")).isEqualTo(false);
+	}
+
+	@Test
+	@DisplayName("역 구조도 직접 저장 요청은 읽기 전용 오류를 flash로 돌려보낸다")
+	void stationLayoutPostsRedirectWithReadOnlyFlash() {
+		var controller = new TransitStationLayoutAdminPageController(transitMasterService, transitMasterService);
+		var layoutStatusRedirectAttributes = readOnlyFlash();
+		var sourceRedirectAttributes = readOnlyFlash();
+		var nodeRedirectAttributes = readOnlyFlash();
+		var edgeRedirectAttributes = readOnlyFlash();
+
+		assertStationLayoutReadOnlyRedirect(controller.updateLayoutStatusFromPage(
+			"station-sangnoksu",
+			"layout-sangnoksu-draft",
+			SimplifiedStationLayoutStatus.READY_FOR_REVIEW,
+			ADMIN,
+			layoutStatusRedirectAttributes
+		), layoutStatusRedirectAttributes);
+		assertStationLayoutReadOnlyRedirect(controller.updateStationLayoutSourceFromPage(
+			"station-sangnoksu",
+			"layout-source-sangnoksu-station-map",
+			StationLayoutSourceType.OPERATOR_PAGE,
+			"상록수역 운영기관 안내 페이지",
+			"https://www.seoulmetro.co.kr/station/sangnoksu",
+			"운영기관 페이지 확인용",
+			true,
+			false,
+			LocalDate.of(2026, 6, 13),
+			LocalDate.of(2026, 6, 14),
+			ADMIN,
+			sourceRedirectAttributes
+		), sourceRedirectAttributes);
+		assertStationLayoutReadOnlyRedirect(controller.updateRouteNodeDisplayFromPage(
+			"station-sangnoksu",
+			"node-sangnoksu-elevator-1",
+			132,
+			256,
+			"1번 출구 승강기",
+			"휠체어와 유모차 이동 가능",
+			ADMIN,
+			nodeRedirectAttributes
+		), nodeRedirectAttributes);
+		assertStationLayoutReadOnlyRedirect(controller.updateRouteEdgeFromPage(
+			"station-sangnoksu",
+			"edge-sangnoksu-elevator-to-faregate",
+			34,
+			90,
+			false,
+			true,
+			false,
+			1,
+			5,
+			88,
+			true,
+			ADMIN,
+			edgeRedirectAttributes
+		), edgeRedirectAttributes);
+	}
+
+	private static RedirectAttributesModelMap readOnlyFlash() {
+		return new RedirectAttributesModelMap();
+	}
+
+	private static void assertStationLayoutReadOnlyRedirect(
+		String viewName,
+		RedirectAttributesModelMap redirectAttributes
+	) {
+		assertThat(viewName).isEqualTo("redirect:/admin/stations/station-sangnoksu/layouts/page");
+		assertReadOnlyFlash(redirectAttributes);
+	}
+
+	private static void assertReadOnlyFlash(RedirectAttributesModelMap redirectAttributes) {
+		assertThat(redirectAttributes.getFlashAttributes().get("masterDataError"))
+			.isEqualTo("운영 마스터 데이터가 읽기 전용입니다.");
+	}
+}

--- a/backend/src/test/java/com/easysubway/transit/adapter/out/persistence/UnavailableTransitMasterRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/out/persistence/UnavailableTransitMasterRepositoryTest.java
@@ -3,6 +3,7 @@ package com.easysubway.transit.adapter.out.persistence;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.easysubway.transit.application.port.out.MasterDataCapabilityStatus;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
 import com.easysubway.transit.domain.SimplifiedStationLayoutStatus;
 import java.time.LocalDate;
@@ -21,6 +22,18 @@ class UnavailableTransitMasterRepositoryTest {
 		assertThat(repository.loadOperators()).isNotEmpty();
 		assertThat(repository.loadLines()).isNotEmpty();
 		assertThat(repository.loadStations()).isNotEmpty();
+	}
+
+	@Test
+	@DisplayName("운영 seed 저장소는 읽기 가능하지만 쓰기 불가 capability를 노출한다")
+	void exposesReadOnlyCapability() {
+		var capability = repository.masterDataCapability();
+
+		assertThat(capability.status()).isEqualTo(MasterDataCapabilityStatus.READ_ONLY);
+		assertThat(capability.readable()).isTrue();
+		assertThat(capability.writable()).isFalse();
+		assertThat(capability.artifactVersion()).isEqualTo("static-seed");
+		assertThat(capability.sha256()).isEqualTo("unavailable");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
+++ b/backend/src/test/java/com/easysubway/transit/application/service/TransitMasterServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
+import com.easysubway.transit.adapter.out.persistence.UnavailableTransitMasterRepository;
 import com.easysubway.transit.application.port.in.CreateAccessibilityFacilityCommand;
 import com.easysubway.transit.application.port.in.NearbyStationSearchCommand;
 import com.easysubway.transit.application.port.in.StationSearchCommand;
@@ -28,6 +29,7 @@ import com.easysubway.transit.domain.InvalidRouteEdgeException;
 import com.easysubway.transit.domain.InvalidRouteNodeException;
 import com.easysubway.transit.domain.InvalidStationLayoutSourceException;
 import com.easysubway.transit.domain.InvalidSimplifiedStationLayoutException;
+import com.easysubway.transit.domain.MasterDataWriteNotAllowedException;
 import com.easysubway.transit.domain.RouteEdge;
 import com.easysubway.transit.domain.RouteEdgeNotFoundException;
 import com.easysubway.transit.domain.RouteEdgeType;
@@ -480,6 +482,25 @@ class TransitMasterServiceTest {
 		assertThat(updated.lastUpdatedAt()).isEqualTo(LocalDate.of(2026, 6, 14));
 		assertThat(service.listStationFacilities("station-sangnoksu").getFirst().status())
 			.isEqualTo(AccessibilityFacilityStatus.BROKEN);
+	}
+
+	@Test
+	@DisplayName("마스터 데이터가 읽기 전용이면 서비스 직접 호출도 저장소 예외 전에 차단한다")
+	void updateFacilityStatusRejectsReadOnlyMasterDataBeforeSavePortException() {
+		var repository = new UnavailableTransitMasterRepository();
+		var readOnlyService = new TransitMasterService(
+			repository,
+			repository,
+			Clock.fixed(Instant.parse("2026-06-14T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+		);
+
+		assertThatThrownBy(() -> readOnlyService.updateFacilityStatus(new UpdateAccessibilityFacilityStatusCommand(
+			"facility-sangnoksu-elevator-1",
+			AccessibilityFacilityStatus.BROKEN,
+			"admin-user"
+		)))
+			.isInstanceOf(MasterDataWriteNotAllowedException.class)
+			.hasMessage("운영 마스터 데이터가 읽기 전용입니다.");
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

close #949

## 작업 배경

운영 프로필의 마스터 데이터 저장소가 정적 seed 기반 read-only 상태인데도 관리자 화면과 저장 command가 쓰기 가능 여부를 한 기준으로 공유하지 않아, 직접 저장 요청이 저장소 `UnsupportedOperationException`까지 내려갈 수 있었습니다. QA 검토 기준에 맞춰 capability와 application guard를 먼저 두고, HTML 직접 요청은 관리자 화면 flash로 되돌리도록 정리했습니다.

## 작업 내용

- `MasterDataCapability`/상태 enum/port를 추가하고 prod seed repository가 `READ_ONLY`, `readable=true`, `writable=false`를 노출하도록 했습니다.
- 시설 상태, 시설 등록·수정, 구조도 자료, 구조도 상태, route node/edge 저장 command와 신고 승인 후 시설 상태 반영 경로에서 저장 port 호출 전 `MasterDataWriteNotAllowedException`으로 차단합니다.
- 관리자 시설 상태, 시설 등록·수정, 구조도·동선, 신고 상세 화면에 read-only 안내와 직접 POST 차단 flash를 추가했습니다.
- prod readiness detail의 `masterData`가 read-only capability일 때 `read_only`로 표시되도록 연결했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test`: BUILD SUCCESSFUL
  - `node --test tools/ci/*.test.mjs`: 114 passed, 0 failed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| read-only capability | backend JVM test | `UnavailableTransitMasterRepositoryTest.exposesReadOnlyCapability` | `./gradlew test` output | `READ_ONLY`, `readable=true`, `writable=false` 검증 |
| 저장 command guard | backend JVM test | `TransitMasterServiceTest.updateFacilityStatusRejectsReadOnlyMasterDataBeforeSavePortException` | `./gradlew test` output | 저장 port 예외 전에 domain/application 예외로 차단 |
| 신고 승인 guard | backend JVM test | `FacilityReportServiceTest.acceptedReportRejectsReadOnlyMasterDataBeforeReviewSave` | `./gradlew test` output | 승인 저장 전 차단되고 신고 상태는 `SUBMITTED` 유지 |
| 관리자 HTML 직접 POST | backend controller test | `TransitReadOnlyAdminPageModelTest`, `FacilityReportAdminPageReadOnlyControllerTest` | `./gradlew test` output | read-only 오류가 flash로 redirect됨 |
| 관리자 UI 안내 | backend template/controller test | read-only model flag와 template banner/disabled 조건 검증 | `./gradlew test` output | 저장 가능 오해를 줄이는 warning/disabled 조건 연결 |
| readiness | backend JVM test | `ProductionPersistenceReadinessConfigurationTest.prodReadinessReportsReadOnlyMasterDataCapability` | `./gradlew test` output | health detail `masterData=read_only` 확인 |
| CI | GitHub Actions | PR #988 checks | CI run 28250330766 | success |
| Code review | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback | PR review 4580969878 | actionable 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `TransitMasterService.requireWritableMasterData()`, `FacilityReportService.reviewReport()`, 관리자 page controller의 read-only flash 처리입니다.
- JSON API는 기존 `ConflictException` 공통 handler를 통해 실패 응답을 반환합니다. 이 PR은 새로운 API 응답 envelope 변경은 포함하지 않습니다.

## 리스크

- 운영 마스터 데이터의 실제 쓰기 저장소나 override store는 이 PR 범위가 아니며, read-only 상태에서는 계속 저장이 차단됩니다.
- 화면 버튼 비활성화는 편의 장치이고, 최종 차단 기준은 application service guard입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.