### PR TITLE
[Fix] 백엔드 health를 실제 의존성 상태로 전환

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
@@ -3,6 +3,7 @@ package com.easysubway.admin.adapter.in.web;
 import com.easysubway.collection.application.port.in.DataCollectionUseCase;
 import com.easysubway.collection.domain.DataCollectionRun;
 import com.easysubway.health.application.port.in.CheckHealthUseCase;
+import com.easysubway.health.domain.HealthComponent;
 import com.easysubway.health.domain.HealthStatus;
 import com.easysubway.notification.application.port.in.PushNotificationDashboardUseCase;
 import com.easysubway.notification.domain.PushNotificationDashboardSummary;
@@ -82,6 +83,7 @@ class AdminOverviewPageController {
 		PushNotificationDashboardSummary push = pushNotificationDashboardUseCase.summarizePushNotifications();
 		UserActivityDashboardSummary usage = userActivityDashboardUseCase.summarizeUserActivity();
 		model.addAttribute("health", health);
+		model.addAttribute("healthComponents", health.components().stream().map(HealthComponentRow::from).toList());
 		model.addAttribute("runs", runs.stream().map(CollectionRunRow::from).toList());
 		model.addAttribute("push", push);
 		model.addAttribute("usage", usage);
@@ -136,6 +138,23 @@ class AdminOverviewPageController {
 				String.valueOf(run.completedAt()),
 				run.collectedCount(),
 				run.failureMessage()
+			);
+		}
+	}
+
+	record HealthComponentRow(
+		String name,
+		String status,
+		String label,
+		String reason
+	) {
+
+		static HealthComponentRow from(HealthComponent component) {
+			return new HealthComponentRow(
+				component.name(),
+				component.status(),
+				component.label(),
+				component.reason()
 			);
 		}
 	}

--- a/backend/src/main/java/com/easysubway/health/adapter/in/web/HealthCheckController.java
+++ b/backend/src/main/java/com/easysubway/health/adapter/in/web/HealthCheckController.java
@@ -2,9 +2,7 @@ package com.easysubway.health.adapter.in.web;
 
 import com.easysubway.common.web.ApiResponse;
 import com.easysubway.health.application.port.in.CheckHealthUseCase;
-import com.easysubway.health.domain.HealthComponent;
 import com.easysubway.health.domain.HealthStatus;
-import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,25 +20,12 @@ class HealthCheckController {
 		return ApiResponse.ok(HealthCheckResponse.from(checkHealthUseCase.checkHealth()));
 	}
 
-	record HealthCheckResponse(String status, String service, List<HealthComponentResponse> components) {
+	record HealthCheckResponse(String status, String service) {
 
 		static HealthCheckResponse from(HealthStatus status) {
 			return new HealthCheckResponse(
 				status.status(),
-				status.service(),
-				status.components().stream().map(HealthComponentResponse::from).toList()
-			);
-		}
-	}
-
-	record HealthComponentResponse(String name, String status, String label, String reason) {
-
-		static HealthComponentResponse from(HealthComponent component) {
-			return new HealthComponentResponse(
-				component.name(),
-				component.status(),
-				component.label(),
-				component.reason()
+				status.service()
 			);
 		}
 	}

--- a/backend/src/main/java/com/easysubway/health/adapter/in/web/HealthCheckController.java
+++ b/backend/src/main/java/com/easysubway/health/adapter/in/web/HealthCheckController.java
@@ -2,7 +2,9 @@ package com.easysubway.health.adapter.in.web;
 
 import com.easysubway.common.web.ApiResponse;
 import com.easysubway.health.application.port.in.CheckHealthUseCase;
+import com.easysubway.health.domain.HealthComponent;
 import com.easysubway.health.domain.HealthStatus;
+import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,10 +22,26 @@ class HealthCheckController {
 		return ApiResponse.ok(HealthCheckResponse.from(checkHealthUseCase.checkHealth()));
 	}
 
-	record HealthCheckResponse(String status, String service) {
+	record HealthCheckResponse(String status, String service, List<HealthComponentResponse> components) {
 
 		static HealthCheckResponse from(HealthStatus status) {
-			return new HealthCheckResponse(status.status(), status.service());
+			return new HealthCheckResponse(
+				status.status(),
+				status.service(),
+				status.components().stream().map(HealthComponentResponse::from).toList()
+			);
+		}
+	}
+
+	record HealthComponentResponse(String name, String status, String label, String reason) {
+
+		static HealthComponentResponse from(HealthComponent component) {
+			return new HealthComponentResponse(
+				component.name(),
+				component.status(),
+				component.label(),
+				component.reason()
+			);
 		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/health/adapter/out/actuator/BackendComponentHealthIndicator.java
+++ b/backend/src/main/java/com/easysubway/health/adapter/out/actuator/BackendComponentHealthIndicator.java
@@ -19,7 +19,7 @@ class BackendComponentHealthIndicator implements HealthIndicator {
 	@Override
 	public Health health() {
 		HealthStatus health = checkHealthUseCase.checkHealth();
-		return Health.status(actuatorStatus(health.status()))
+		return Health.status(health.status())
 			.withDetail("summaryStatus", health.status())
 			.withDetail("components", health.components().stream()
 				.map(component -> Map.of(
@@ -29,9 +29,5 @@ class BackendComponentHealthIndicator implements HealthIndicator {
 				))
 				.toList())
 			.build();
-	}
-
-	private static String actuatorStatus(String status) {
-		return "DOWN".equals(status) ? "DOWN" : "UP";
 	}
 }

--- a/backend/src/main/java/com/easysubway/health/adapter/out/actuator/BackendComponentHealthIndicator.java
+++ b/backend/src/main/java/com/easysubway/health/adapter/out/actuator/BackendComponentHealthIndicator.java
@@ -1,0 +1,37 @@
+package com.easysubway.health.adapter.out.actuator;
+
+import com.easysubway.health.application.port.in.CheckHealthUseCase;
+import com.easysubway.health.domain.HealthStatus;
+import java.util.Map;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+class BackendComponentHealthIndicator implements HealthIndicator {
+
+	private final CheckHealthUseCase checkHealthUseCase;
+
+	BackendComponentHealthIndicator(CheckHealthUseCase checkHealthUseCase) {
+		this.checkHealthUseCase = checkHealthUseCase;
+	}
+
+	@Override
+	public Health health() {
+		HealthStatus health = checkHealthUseCase.checkHealth();
+		return Health.status(actuatorStatus(health.status()))
+			.withDetail("summaryStatus", health.status())
+			.withDetail("components", health.components().stream()
+				.map(component -> Map.of(
+					"name", component.name(),
+					"status", component.status(),
+					"reason", component.reason()
+				))
+				.toList())
+			.build();
+	}
+
+	private static String actuatorStatus(String status) {
+		return "DOWN".equals(status) ? "DOWN" : "UP";
+	}
+}

--- a/backend/src/main/java/com/easysubway/health/application/service/HealthCheckService.java
+++ b/backend/src/main/java/com/easysubway/health/application/service/HealthCheckService.java
@@ -56,7 +56,7 @@ public class HealthCheckService implements CheckHealthUseCase {
 
 	private HealthComponent databaseHealth() {
 		if (dataSource == null) {
-			return unknown("database", "데이터베이스", "DataSource가 구성되지 않았습니다.");
+			return new HealthComponent("database", "DOWN", "데이터베이스", "DataSource가 구성되지 않았습니다.");
 		}
 		try (Connection connection = dataSource.getConnection()) {
 			boolean valid = connection.isValid(2);
@@ -73,7 +73,7 @@ public class HealthCheckService implements CheckHealthUseCase {
 
 	private HealthComponent masterDataHealth() {
 		if (loadTransitMasterPort == null) {
-			return unknown("masterData", "마스터 데이터", "마스터 데이터 port가 구성되지 않았습니다.");
+			return new HealthComponent("masterData", "DOWN", "마스터 데이터", "마스터 데이터 port가 구성되지 않았습니다.");
 		}
 		try {
 			boolean hasMasterData = !loadTransitMasterPort.loadOperators().isEmpty()

--- a/backend/src/main/java/com/easysubway/health/application/service/HealthCheckService.java
+++ b/backend/src/main/java/com/easysubway/health/application/service/HealthCheckService.java
@@ -1,7 +1,17 @@
 package com.easysubway.health.application.service;
 
 import com.easysubway.health.application.port.in.CheckHealthUseCase;
+import com.easysubway.health.domain.HealthComponent;
 import com.easysubway.health.domain.HealthStatus;
+import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
+import com.easysubway.transit.application.port.out.MasterDataCapability;
+import com.easysubway.transit.application.port.out.MasterDataCapabilityPort;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -9,8 +19,105 @@ public class HealthCheckService implements CheckHealthUseCase {
 
 	private static final String SERVICE_NAME = "easysubway-backend";
 
+	private final DataSource dataSource;
+	private final LoadTransitMasterPort loadTransitMasterPort;
+
+	@Autowired
+	public HealthCheckService(
+		ObjectProvider<DataSource> dataSourceProvider,
+		ObjectProvider<LoadTransitMasterPort> loadTransitMasterPortProvider
+	) {
+		this(dataSourceProvider.getIfAvailable(), loadTransitMasterPortProvider.getIfAvailable());
+	}
+
+	public HealthCheckService(DataSource dataSource, LoadTransitMasterPort loadTransitMasterPort) {
+		this.dataSource = dataSource;
+		this.loadTransitMasterPort = loadTransitMasterPort;
+	}
+
 	@Override
 	public HealthStatus checkHealth() {
-		return HealthStatus.up(SERVICE_NAME);
+		List<HealthComponent> components = new ArrayList<>();
+		components.add(new HealthComponent(
+			"application",
+			"UP",
+			"애플리케이션",
+			"서비스 프로세스가 요청을 처리할 수 있습니다."
+		));
+		components.add(databaseHealth());
+		components.add(masterDataHealth());
+		components.add(unknown("flyway", "Flyway", "마이그레이션 상태는 actuator DB/readiness와 배포 로그에서 확인합니다."));
+		components.add(unknown("objectStorage", "객체 저장소", "신고 사진 저장소 실시간 점검은 아직 구성되지 않았습니다."));
+		components.add(unknown("batch", "배치", "최근 실행 이력은 관리자 수집 화면에서 확인합니다."));
+		components.add(unknown("pushOutbox", "푸시 outbox", "대기/실패 수는 관리자 시스템 화면의 푸시 지표에서 확인합니다."));
+		components.add(unknown("backup", "백업", "백업 리허설 상태는 배포/운영 run 증거에서 확인합니다."));
+		return HealthStatus.of(summaryStatus(components), SERVICE_NAME, components);
+	}
+
+	private HealthComponent databaseHealth() {
+		if (dataSource == null) {
+			return unknown("database", "데이터베이스", "DataSource가 구성되지 않았습니다.");
+		}
+		try (Connection connection = dataSource.getConnection()) {
+			boolean valid = connection.isValid(2);
+			return new HealthComponent(
+				"database",
+				valid ? "UP" : "DOWN",
+				"데이터베이스",
+				valid ? "DB 연결이 유효합니다." : "DB 연결 validation에 실패했습니다."
+			);
+		} catch (Exception exception) {
+			return new HealthComponent("database", "DOWN", "데이터베이스", "DB 연결을 확인할 수 없습니다.");
+		}
+	}
+
+	private HealthComponent masterDataHealth() {
+		if (loadTransitMasterPort == null) {
+			return unknown("masterData", "마스터 데이터", "마스터 데이터 port가 구성되지 않았습니다.");
+		}
+		try {
+			boolean hasMasterData = !loadTransitMasterPort.loadOperators().isEmpty()
+				&& !loadTransitMasterPort.loadLines().isEmpty()
+				&& !loadTransitMasterPort.loadStations().isEmpty();
+			if (!hasMasterData) {
+				return new HealthComponent("masterData", "DOWN", "마스터 데이터", "운영 마스터 데이터가 비어 있습니다.");
+			}
+			if (loadTransitMasterPort instanceof MasterDataCapabilityPort capabilityPort) {
+				MasterDataCapability capability = capabilityPort.masterDataCapability();
+				if (!capability.readable()) {
+					return new HealthComponent("masterData", "DOWN", "마스터 데이터", "마스터 데이터를 읽을 수 없습니다.");
+				}
+				if (!capability.writable()) {
+					return new HealthComponent("masterData", "READ_ONLY", "마스터 데이터", "마스터 데이터가 읽기 전용입니다.");
+				}
+			}
+			return new HealthComponent("masterData", "UP", "마스터 데이터", "마스터 데이터를 읽고 쓸 수 있습니다.");
+		} catch (Exception exception) {
+			return new HealthComponent("masterData", "DOWN", "마스터 데이터", "마스터 데이터를 확인할 수 없습니다.");
+		}
+	}
+
+	private static HealthComponent unknown(String name, String label, String reason) {
+		return new HealthComponent(name, "UNKNOWN", label, reason);
+	}
+
+	private static String summaryStatus(List<HealthComponent> components) {
+		if (hasStatus(components, "DOWN")) {
+			return "DOWN";
+		}
+		if (hasStatus(components, "DEGRADED")) {
+			return "DEGRADED";
+		}
+		if (hasStatus(components, "STALE")) {
+			return "STALE";
+		}
+		if (hasStatus(components, "READ_ONLY")) {
+			return "READ_ONLY";
+		}
+		return "UP";
+	}
+
+	private static boolean hasStatus(List<HealthComponent> components, String status) {
+		return components.stream().anyMatch(component -> component.status().equals(status));
 	}
 }

--- a/backend/src/main/java/com/easysubway/health/application/service/HealthCheckService.java
+++ b/backend/src/main/java/com/easysubway/health/application/service/HealthCheckService.java
@@ -111,9 +111,6 @@ public class HealthCheckService implements CheckHealthUseCase {
 		if (hasStatus(components, "STALE")) {
 			return "STALE";
 		}
-		if (hasStatus(components, "READ_ONLY")) {
-			return "READ_ONLY";
-		}
 		return "UP";
 	}
 

--- a/backend/src/main/java/com/easysubway/health/domain/HealthComponent.java
+++ b/backend/src/main/java/com/easysubway/health/domain/HealthComponent.java
@@ -1,0 +1,9 @@
+package com.easysubway.health.domain;
+
+public record HealthComponent(
+	String name,
+	String status,
+	String label,
+	String reason
+) {
+}

--- a/backend/src/main/java/com/easysubway/health/domain/HealthStatus.java
+++ b/backend/src/main/java/com/easysubway/health/domain/HealthStatus.java
@@ -1,8 +1,23 @@
 package com.easysubway.health.domain;
 
-public record HealthStatus(String status, String service) {
+import java.util.List;
+
+public record HealthStatus(String status, String service, List<HealthComponent> components) {
+
+	public HealthStatus {
+		components = List.copyOf(components);
+	}
+
+	public static HealthStatus of(String status, String service, List<HealthComponent> components) {
+		return new HealthStatus(status, service, components);
+	}
 
 	public static HealthStatus up(String service) {
-		return new HealthStatus("UP", service);
+		return new HealthStatus("UP", service, List.of(new HealthComponent(
+			"application",
+			"UP",
+			"애플리케이션 기동",
+			"서비스 프로세스가 요청을 처리할 수 있습니다."
+		)));
 	}
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -21,6 +21,8 @@ management:
     health:
       probes:
         enabled: true
+      status:
+        order: "down,out-of-service,degraded,stale,up,unknown"
 
 easysubway:
   notifications:

--- a/backend/src/main/resources/templates/admin/system.html
+++ b/backend/src/main/resources/templates/admin/system.html
@@ -25,6 +25,29 @@
 	</div>
 
 	<section>
+		<h2>컴포넌트 상태</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">컴포넌트</th>
+				<th scope="col">상태</th>
+				<th scope="col">원인</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="component : ${healthComponents}">
+				<td>
+					<span th:text="${component.label}">애플리케이션</span>
+					<span class="meta" th:text="${component.name}">application</span>
+				</td>
+				<td th:text="${component.status}">UP</td>
+				<td th:text="${component.reason}">서비스 프로세스가 요청을 처리할 수 있습니다.</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
 		<h2>최근 데이터 수집</h2>
 		<table>
 			<thead>

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -42,6 +42,24 @@ class AdminV3PageSmokeTest {
 	}
 
 	@Test
+	@DisplayName("관리자 시스템 화면은 health component 표를 표시한다")
+	void adminSystemPageShowsHealthComponents() throws Exception {
+		String html = mockMvc.perform(get("/admin/system/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("컴포넌트 상태")
+			.contains("애플리케이션")
+			.contains("마스터 데이터")
+			.contains("데이터베이스")
+			.doesNotContain("prod-object-storage-secret-key");
+	}
+
+	@Test
 	@DisplayName("관리자 로그인 화면은 Spring Security form login으로 대시보드에 진입한다")
 	void adminLoginUsesSecurityFormLogin() throws Exception {
 		mockMvc.perform(get("/admin/dashboard/page")

--- a/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
+++ b/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
@@ -5,8 +5,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.actuate.health.StatusAggregator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
@@ -29,6 +32,9 @@ class HealthCheckControllerTest {
 
 	@Autowired
 	private WebEndpointsSupplier webEndpointsSupplier;
+
+	@Autowired
+	private StatusAggregator statusAggregator;
 
 	@Test
 	@DisplayName("공통 응답 형식으로 API 헬스체크를 반환한다")
@@ -66,6 +72,15 @@ class HealthCheckControllerTest {
 			.andExpect(jsonPath("$.components.backendComponent.status").value("UP"))
 			.andExpect(jsonPath("$.components.backendComponent.details.summaryStatus").value("UP"))
 			.andExpect(jsonPath("$.components.backendComponent.details.components[0].name").value("application"));
+	}
+
+	@Test
+	@DisplayName("액추에이터 status aggregator는 degraded와 stale을 UP보다 우선한다")
+	void actuatorStatusAggregatorPrioritizesCustomSummaryStates() {
+		assertThat(statusAggregator.getAggregateStatus(Set.of(Status.UP, new Status("DEGRADED"))).getCode())
+			.isEqualTo("DEGRADED");
+		assertThat(statusAggregator.getAggregateStatus(Set.of(Status.UP, new Status("STALE"))).getCode())
+			.isEqualTo("STALE");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
+++ b/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
@@ -15,7 +15,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+	webEnvironment = WebEnvironment.RANDOM_PORT,
+	properties = "management.endpoint.health.show-details=always"
+)
 @AutoConfigureObservability
 @AutoConfigureMockMvc
 @DisplayName("헬스체크 API")
@@ -34,7 +37,9 @@ class HealthCheckControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.status").value("UP"))
-			.andExpect(jsonPath("$.data.service").value("easysubway-backend"));
+			.andExpect(jsonPath("$.data.service").value("easysubway-backend"))
+			.andExpect(jsonPath("$.data.components[0].name").value("application"))
+			.andExpect(jsonPath("$.data.components[0].status").value("UP"));
 	}
 
 	@Test
@@ -51,6 +56,17 @@ class HealthCheckControllerTest {
 		mockMvc.perform(get("/actuator/health/readiness"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.status").value("UP"));
+	}
+
+	@Test
+	@DisplayName("액추에이터는 backend component health detail을 노출한다")
+	void actuatorBackendComponentHealthIsAvailable() throws Exception {
+		mockMvc.perform(get("/actuator/health"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value("UP"))
+			.andExpect(jsonPath("$.components.backendComponent.status").value("UP"))
+			.andExpect(jsonPath("$.components.backendComponent.details.summaryStatus").value("UP"))
+			.andExpect(jsonPath("$.components.backendComponent.details.components[0].name").value("application"));
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
+++ b/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
@@ -38,8 +38,7 @@ class HealthCheckControllerTest {
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.status").value("UP"))
 			.andExpect(jsonPath("$.data.service").value("easysubway-backend"))
-			.andExpect(jsonPath("$.data.components[0].name").value("application"))
-			.andExpect(jsonPath("$.data.components[0].status").value("UP"));
+			.andExpect(jsonPath("$.data.components").doesNotExist());
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/health/adapter/out/actuator/BackendComponentHealthIndicatorTest.java
+++ b/backend/src/test/java/com/easysubway/health/adapter/out/actuator/BackendComponentHealthIndicatorTest.java
@@ -1,0 +1,29 @@
+package com.easysubway.health.adapter.out.actuator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.health.domain.HealthComponent;
+import com.easysubway.health.domain.HealthStatus;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+
+@DisplayName("백엔드 컴포넌트 actuator health indicator")
+class BackendComponentHealthIndicatorTest {
+
+	@Test
+	@DisplayName("top-level health status를 actuator status에 그대로 반영한다")
+	void healthPreservesSummaryStatus() {
+		BackendComponentHealthIndicator indicator = new BackendComponentHealthIndicator(() -> HealthStatus.of(
+			"DEGRADED",
+			"easysubway-backend",
+			List.of(new HealthComponent("database", "DEGRADED", "데이터베이스", "응답 지연"))
+		));
+
+		Health health = indicator.health();
+
+		assertThat(health.getStatus().getCode()).isEqualTo("DEGRADED");
+		assertThat(health.getDetails()).containsEntry("summaryStatus", "DEGRADED");
+	}
+}

--- a/backend/src/test/java/com/easysubway/health/application/service/HealthCheckServiceTest.java
+++ b/backend/src/test/java/com/easysubway/health/application/service/HealthCheckServiceTest.java
@@ -2,7 +2,10 @@ package com.easysubway.health.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.easysubway.transit.adapter.out.persistence.UnavailableTransitMasterRepository;
+import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.health.domain.HealthStatus;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -10,11 +13,29 @@ import org.junit.jupiter.api.Test;
 class HealthCheckServiceTest {
 
 	@Test
-	@DisplayName("백엔드 상태와 서비스 이름을 반환한다")
+	@DisplayName("백엔드 상태와 서비스 이름, 기본 컴포넌트를 반환한다")
 	void checkHealthReturnsBackendStatus() {
-		HealthStatus status = new HealthCheckService().checkHealth();
+		HealthStatus status = new HealthCheckService((DataSource) null, (LoadTransitMasterPort) null).checkHealth();
 
 		assertThat(status.status()).isEqualTo("UP");
 		assertThat(status.service()).isEqualTo("easysubway-backend");
+		assertThat(status.components())
+			.extracting("name")
+			.contains("application", "database", "masterData", "objectStorage", "batch", "pushOutbox", "backup");
+	}
+
+	@Test
+	@DisplayName("읽기 전용 마스터 데이터는 health summary와 component 상태에 반영된다")
+	void checkHealthReportsReadOnlyMasterData() {
+		HealthStatus status = new HealthCheckService(null, new UnavailableTransitMasterRepository()).checkHealth();
+
+		assertThat(status.status()).isEqualTo("READ_ONLY");
+		assertThat(status.components())
+			.filteredOn(component -> component.name().equals("masterData"))
+			.singleElement()
+			.satisfies(component -> {
+				assertThat(component.status()).isEqualTo("READ_ONLY");
+				assertThat(component.reason()).isEqualTo("마스터 데이터가 읽기 전용입니다.");
+			});
 	}
 }

--- a/backend/src/test/java/com/easysubway/health/application/service/HealthCheckServiceTest.java
+++ b/backend/src/test/java/com/easysubway/health/application/service/HealthCheckServiceTest.java
@@ -1,10 +1,14 @@
 package com.easysubway.health.application.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.easysubway.health.domain.HealthStatus;
+import com.easysubway.transit.adapter.out.persistence.InMemoryTransitMasterRepository;
 import com.easysubway.transit.adapter.out.persistence.UnavailableTransitMasterRepository;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
-import com.easysubway.health.domain.HealthStatus;
+import java.sql.Connection;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,20 +18,31 @@ class HealthCheckServiceTest {
 
 	@Test
 	@DisplayName("백엔드 상태와 서비스 이름, 기본 컴포넌트를 반환한다")
-	void checkHealthReturnsBackendStatus() {
-		HealthStatus status = new HealthCheckService((DataSource) null, (LoadTransitMasterPort) null).checkHealth();
+	void checkHealthReturnsBackendStatus() throws Exception {
+		HealthStatus status = new HealthCheckService(availableDataSource(), new InMemoryTransitMasterRepository())
+			.checkHealth();
 
 		assertThat(status.status()).isEqualTo("UP");
 		assertThat(status.service()).isEqualTo("easysubway-backend");
 		assertThat(status.components())
 			.extracting("name")
-			.contains("application", "database", "masterData", "objectStorage", "batch", "pushOutbox", "backup");
+			.containsExactlyInAnyOrder(
+				"application",
+				"database",
+				"masterData",
+				"flyway",
+				"objectStorage",
+				"batch",
+				"pushOutbox",
+				"backup"
+			);
 	}
 
 	@Test
 	@DisplayName("읽기 전용 마스터 데이터는 top-level UP과 component READ_ONLY로 반영된다")
-	void checkHealthReportsReadOnlyMasterData() {
-		HealthStatus status = new HealthCheckService(null, new UnavailableTransitMasterRepository()).checkHealth();
+	void checkHealthReportsReadOnlyMasterData() throws Exception {
+		HealthStatus status = new HealthCheckService(availableDataSource(), new UnavailableTransitMasterRepository())
+			.checkHealth();
 
 		assertThat(status.status()).isEqualTo("UP");
 		assertThat(status.components())
@@ -37,5 +52,25 @@ class HealthCheckServiceTest {
 				assertThat(component.status()).isEqualTo("READ_ONLY");
 				assertThat(component.reason()).isEqualTo("마스터 데이터가 읽기 전용입니다.");
 			});
+	}
+
+	@Test
+	@DisplayName("필수 의존성이 없으면 top-level DOWN과 component DOWN으로 반영된다")
+	void checkHealthReportsMissingRequiredDependenciesAsDown() {
+		HealthStatus status = new HealthCheckService((DataSource) null, (LoadTransitMasterPort) null).checkHealth();
+
+		assertThat(status.status()).isEqualTo("DOWN");
+		assertThat(status.components())
+			.filteredOn(component -> component.name().equals("database") || component.name().equals("masterData"))
+			.extracting("status")
+			.containsOnly("DOWN");
+	}
+
+	private static DataSource availableDataSource() throws Exception {
+		DataSource dataSource = mock(DataSource.class);
+		Connection connection = mock(Connection.class);
+		when(dataSource.getConnection()).thenReturn(connection);
+		when(connection.isValid(2)).thenReturn(true);
+		return dataSource;
 	}
 }

--- a/backend/src/test/java/com/easysubway/health/application/service/HealthCheckServiceTest.java
+++ b/backend/src/test/java/com/easysubway/health/application/service/HealthCheckServiceTest.java
@@ -25,11 +25,11 @@ class HealthCheckServiceTest {
 	}
 
 	@Test
-	@DisplayName("읽기 전용 마스터 데이터는 health summary와 component 상태에 반영된다")
+	@DisplayName("읽기 전용 마스터 데이터는 top-level UP과 component READ_ONLY로 반영된다")
 	void checkHealthReportsReadOnlyMasterData() {
 		HealthStatus status = new HealthCheckService(null, new UnavailableTransitMasterRepository()).checkHealth();
 
-		assertThat(status.status()).isEqualTo("READ_ONLY");
+		assertThat(status.status()).isEqualTo("UP");
 		assertThat(status.components())
 			.filteredOn(component -> component.name().equals("masterData"))
 			.singleElement()


### PR DESCRIPTION
## 관련 이슈

close #950

## 작업 배경

기존 `/api/health`는 서비스 이름과 고정 `UP` 성격의 상태만 반환해 DB, 마스터 데이터 capability, 아직 점검되지 않은 운영 컴포넌트 상태를 관리자 화면에서 구분하기 어려웠습니다. QA 검토 기준에 맞춰 domain health를 component 요약 모델로 전환하고 actuator와 관리자 system 화면에 같은 기준을 노출합니다.

## 작업 내용

- `HealthComponent` 모델을 추가하고 내부 health summary가 component list를 계산하도록 했습니다.
- 공개 `/api/health` 응답은 인증 없는 내부 상태 노출을 피하기 위해 `status`와 `service`만 유지했습니다.
- `HealthCheckService`가 application, database, masterData, flyway, objectStorage, batch, pushOutbox, backup 상태를 계산합니다.
- master data는 #949 capability를 반영해 read-only 상태를 component detail의 `READ_ONLY`로 노출하되, top-level summary는 readiness 계약과 맞춰 `UP`을 유지합니다.
- 필수 의존성인 `DataSource` 또는 `LoadTransitMasterPort`가 없으면 해당 component와 top-level summary를 `DOWN`으로 계산합니다.
- 아직 실시간 점검 adapter가 없는 컴포넌트는 secret이나 내부 URL 없이 `UNKNOWN` 사유만 노출합니다.
- actuator `backendComponent` health indicator를 추가하고 `DEGRADED`/`STALE` custom status가 aggregate에서 `UP`보다 우선되도록 health status order를 등록했습니다.
- 관리자 system 화면에 component 상태 표를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check origin/main`: exit 0
  - `cd backend && ./gradlew test --tests "*HealthCheckControllerTest" --tests "*BackendComponentHealthIndicatorTest" --tests "*HealthCheckServiceTest" --tests "*AdminV3PageSmokeTest"`: BUILD SUCCESSFUL
  - `cd backend && ./gradlew test`: BUILD SUCCESSFUL
  - `node --test tools/ci/*.test.mjs`: 115 passed, 0 failed
  - GitHub Actions CI: Backend CI, Android CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan 성공
  - Release Artifacts: Backend Release Image 성공, Android Release Artifact skipped
  - SonarCloud: Quality Gate passed, 0 new issues

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 공개 `/api/health` coarse response | backend MVC test | `HealthCheckControllerTest.apiHealthReturnsCommonResponse` | `cd backend && ./gradlew test` output | `status/service`만 반환하고 `components` 미노출 확인 |
| actuator component health | backend actuator test | `HealthCheckControllerTest.actuatorBackendComponentHealthIsAvailable` | `cd backend && ./gradlew test` output | `backendComponent.details.summaryStatus`와 component detail 확인 |
| actuator custom status aggregation | backend actuator test | `HealthCheckControllerTest.actuatorStatusAggregatorPrioritizesCustomSummaryStates` | `cd backend && ./gradlew test --tests ...` output | `UP + DEGRADED`, `UP + STALE`에서 custom status 우선 확인 |
| masterData READ_ONLY detail | backend JVM test | `HealthCheckServiceTest.checkHealthReportsReadOnlyMasterData` | `cd backend && ./gradlew test` output | top-level `UP`, `masterData` component `READ_ONLY` 확인 |
| 필수 의존성 누락 상태 | backend JVM test | `HealthCheckServiceTest.checkHealthReportsMissingRequiredDependenciesAsDown` | `cd backend && ./gradlew test` output | database/masterData 누락 시 top-level `DOWN` 확인 |
| 관리자 system 화면 | backend admin MVC test | `AdminV3PageSmokeTest.adminSystemPageShowsHealthComponents` | `cd backend && ./gradlew test` output | component 표와 redaction 확인 |
| repository contracts | Node.js | `node --test tools/ci/*.test.mjs` | local command output | 115 passed |
| PR CI | GitHub Actions | PR #989 checks | https://github.com/AquilaXk/easysubway/actions/runs/28254851137 | Backend/Android/Mobile/Repository/OSV checks passed |
| release artifact signal | GitHub Actions | PR #989 Release Artifacts | https://github.com/AquilaXk/easysubway/actions/runs/28254850908 | Backend Release Image passed, Android artifact skipped |
| static analysis | SonarCloud | PR #989 Quality Gate | https://sonarcloud.io/dashboard?id=AquilaXk_easysubway&pullRequest=989 | Quality Gate passed, 0 new issues |
| CodeRabbit review | GitHub PR review | CodeRabbit completed review | https://github.com/AquilaXk/easysubway/pull/989#discussion_r3482959436 | actionable 3건 확인 후 수정 |
| CodeRabbit actuator status resolution | GitHub inline thread | 원래 inline thread 해결 답글 및 resolve | https://github.com/AquilaXk/easysubway/pull/989#discussion_r3482982995 | `2edccb38`로 수정, thread resolved |
| CodeRabbit required dependency resolution | GitHub inline thread | 원래 inline thread 해결 답글 및 resolve | https://github.com/AquilaXk/easysubway/pull/989#discussion_r3482983099 | `2edccb38`로 수정, thread resolved |
| CodeRabbit flyway component test resolution | GitHub inline thread | 원래 inline thread 해결 답글 및 resolve | https://github.com/AquilaXk/easysubway/pull/989#discussion_r3482983096 | `2edccb38`로 수정, thread resolved |
| Codex fallback custom status finding | GitHub PR review | final rebase fallback review | https://github.com/AquilaXk/easysubway/pull/989#pullrequestreview-4581396927 | actionable 1건 확인 후 수정 |
| Codex fallback custom status resolution | GitHub inline thread | 원래 inline thread 해결 답글 및 resolve | https://github.com/AquilaXk/easysubway/pull/989#discussion_r3483048771 | `26bae451`로 수정, thread resolved |
| final fallback re-review | GitHub PR review | 최신 main 동기화 후 Codex CLI re-review | https://github.com/AquilaXk/easysubway/pull/989#pullrequestreview-4581512179 | actionable 0, nitpick 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `HealthCheckService.checkHealth()`의 summary 계산, `BackendComponentHealthIndicator`의 actuator status 전달, `application.yml`의 health status order입니다.
- readiness/CD curl을 깨지 않도록 `READ_ONLY`/`UNKNOWN`은 component detail에만 남기고, `DOWN`/`DEGRADED`/`STALE`만 top-level summary에 반영합니다.
- 공개 `/api/health`는 인증 없는 상태 확인용으로 coarse response만 유지하고, component detail은 actuator/admin 화면에서 확인합니다.

## 리스크

- object storage, batch, push outbox, backup은 아직 실시간 probe가 아니라 `UNKNOWN`으로 명시합니다. 실제 adapter별 probe는 각 운영 기능 이슈에서 확장해야 합니다.
- 관리자 화면과 actuator detail은 상태 원인 텍스트를 노출하지만 외부 URL, credential, secret은 노출하지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
