### PR TITLE
[Chore] Google Play App Content listing gate 추가

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -182,6 +182,7 @@ jobs:
           cp release/signed-release-artifact-gate.json release-artifacts/android/signed-release-artifact-gate.json
           cp release/android-16kb-page-size-gate.json release-artifacts/android/android-16kb-page-size-gate.json
           cp release/play-production-access-gate.json release-artifacts/android/play-production-access-gate.json
+          cp release/play-store-submission-content.json release-artifacts/android/play-store-submission-content.json
           cp ../../tools/mobile/check-android-aab-16kb-page-size.sh release-artifacts/android/check-android-aab-16kb-page-size.sh
           cp ../../tools/mobile/check-elf-load-alignment.mjs release-artifacts/android/check-elf-load-alignment.mjs
           if [[ -f build/app/outputs/mapping/release/mapping.txt ]]; then
@@ -199,6 +200,7 @@ jobs:
             echo "play_submission_evidence=blocked_missing_internal_track_or_prelaunch_report"
             echo "page_size_16kb_evidence=blocked_until_tools_mobile_check_android_aab_16kb_page_size_passes_and_runtime_PAGE_SIZE_16384_smoke_passes"
             echo "play_production_access_evidence=blocked_until_play_production_access_gate_console_summary_is_satisfied"
+            echo "play_app_content_data_safety_listing_evidence=blocked_until_play_store_submission_content_console_summary_is_satisfied"
             echo "toolchain_policy=apps/mobile/release/signed-release-artifact-gate.json"
           } > release-artifacts/android/release-metadata.txt
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Android 16 KB page-size gate는 `apps/mobile/release/android-16kb-page-size-gate
 
 Google Play production access와 신규 personal account closed test gate는 `apps/mobile/release/play-production-access-gate.json`으로 검증합니다. 2023-11-13 이후 생성된 personal developer account라면 production access 신청 전 closed test 12명 이상, 14일 연속 opt-in, tester feedback/issue response, production readiness 답변과 승인 결과를 local-only evidence로 보관해야 합니다. 조직 계정이거나 기존 personal account라 closed test requirement가 적용되지 않더라도 Play Console account type, creation date, identity verification, Console 권한, 2단계 인증, production access 상태 summary는 release blocker 증거로 남깁니다.
 
+Google Play App Content, Data Safety, 한국어 listing gate는 `apps/mobile/release/play-store-submission-content.json`으로 검증합니다. Data Safety 답변은 `apps/mobile/release/store-privacy-inventory.json`의 수집 데이터, 암호화 전송, 삭제 지원, 제3자 공유 없음, tracking 없음 값과 일치해야 하며 listing은 데이터 기준일, 지원 지역, 실시간 지원 범위, 확인 필요 상태를 명시합니다. “반드시 이동 가능”, “100% 안전”, “모든 역 완벽 지원”, “실시간 위치 정확”, “휠체어 경로 보장” 같은 보장 표현은 store copy와 screenshot 설명에서 사용할 수 없습니다.
+
 Android 출시 100% 범위와 Go/No-Go 계약은 `apps/mobile/release/release-governance-gate.json`으로 검증합니다. 이번 release blocker는 Android Google Play v1이며 iOS는 `DEFERRED_OUT_OF_SCOPE`로 기록해 Android 출시 완료를 차단하지 않습니다. open Android P0가 있거나 RC evidence의 git SHA, AAB hash, backend artifact, data pack manifest, route/realtime contract가 서로 맞지 않으면 최종 Go 판단을 하지 않습니다.
 
 Android 출시 UX·접근성·성능 gate는 `apps/mobile/release/android-release-quality-gate.json`으로 검증합니다. PR 증거는 local Android emulator evidence를 우선 사용하며, 물리 기기 증거는 Codex PR 증거로 사용하지 않습니다. 실제 Google Play Go 판단 전에는 #907의 exact RC 또는 Play-installed build에서 TalkBack, 150%/200% 글자 크기, 작은 화면, 권한/네트워크/업로드 오류 복구, 노선도 fallback과 성능, 지원 범위/출처 화면, crash/ANR privacy-safe reporting 증거를 다시 수집해야 합니다.

--- a/apps/mobile/release/android-rc-store-evidence.json
+++ b/apps/mobile/release/android-rc-store-evidence.json
@@ -82,9 +82,13 @@
       "tester-requirement-record",
       "closed-test-12-testers-14-days-continuous-opt-in-record",
       "production-access-application-response-record",
+      "play-store-submission-content-manifest",
       "app-content-declarations",
+      "data-safety-answer-contract",
       "data-safety-binary-network-trace-match",
       "privacy-policy-url-help-screen-match",
+      "korean-store-listing-contract",
+      "store-graphic-screenshot-asset-record",
       "store-listing-scope-copy-review",
       "support-channel-release-notes-review"
     ],

--- a/apps/mobile/release/play-store-submission-content.json
+++ b/apps/mobile/release/play-store-submission-content.json
@@ -1,0 +1,81 @@
+{
+  "schemaVersion": 1,
+  "applicationId": "easysubway",
+  "androidApplicationId": "com.easysubway.app",
+  "releaseGate": "play-store-submission-content",
+  "issue": 921,
+  "androidRcEvidenceManifest": "apps/mobile/release/android-rc-store-evidence.json",
+  "storePrivacyInventory": "apps/mobile/release/store-privacy-inventory.json",
+  "storeSubmissionReadiness": "apps/mobile/release/store-submission-readiness.json",
+  "status": "BLOCKED_CONSOLE_PREVIEW_AND_ASSET_EVIDENCE_MISSING",
+  "appContentDeclarations": {
+    "ads": false,
+    "appAccessRequiresSignIn": false,
+    "publicUserSignIn": false,
+    "accountCreation": false,
+    "backgroundLocation": false,
+    "preciseLocation": "optional_user_triggered_nearby_station_and_report_location_only",
+    "cameraOrPhoto": "optional_user_triggered_report_attachment_only",
+    "restrictedContent": false,
+    "targetAudience": "all_users_not_child_directed",
+    "reviewerAccessNotesKo": "로그인 없는 앱입니다. 위치 권한은 주변 역 찾기와 신고 위치 확인에서만 선택적으로 사용합니다."
+  },
+  "dataSafetyDeclarations": {
+    "tracking": false,
+    "sharesDataWithThirdParties": false,
+    "dataEncryptedInTransit": true,
+    "dataDeletionRequestSupported": true,
+    "requiredCollectedDataTypes": [
+      "Location",
+      "App activity",
+      "Personal info",
+      "User-generated content",
+      "Photos and videos",
+      "Diagnostics"
+    ],
+    "optionalUserTriggeredData": [
+      "precise location for nearby station search",
+      "facility report photo",
+      "facility report location",
+      "mobility profile",
+      "favorites"
+    ],
+    "binaryTraceMatchRequired": true,
+    "linkedInventory": "apps/mobile/release/store-privacy-inventory.json"
+  },
+  "koreanListing": {
+    "appName": "쉬운 지하철",
+    "shortDescription": "교통약자를 위한 지하철 이동 안내",
+    "fullDescriptionKo": "쉬운 지하철은 고령자, 임산부, 장애인 등 이동과 정보 접근에 제약이 있는 사용자가 지하철 역과 시설 정보를 더 쉽게 확인하도록 돕는 앱입니다. 엘리베이터, 에스컬레이터, 출구, 환승 동선, 즐겨찾기, 시설 신고 흐름을 제공하며 일부 기능은 로컬 데이터팩으로 오프라인에서도 확인할 수 있습니다. 정보는 데이터 기준일과 공식 출처를 함께 표시하고, 현장 상황이나 실시간 정보는 운영기관 제공 범위와 갱신 상태에 따라 달라질 수 있음을 안내합니다.",
+    "releaseNotesKo": "접근성 이동 정보, 시설 신고, 도움말과 개인정보 안내를 포함한 Android 출시 후보입니다.",
+    "supportRegionKo": "대한민국 도시철도 우선 지원",
+    "dataBaselineRequired": true,
+    "realtimeSupportScopeKo": "실시간 도착과 열차 위치는 지원 노선과 제공기관 상태가 확인된 범위에서만 표시",
+    "confirmationCopyKo": "경로와 시설 정보는 현장 상황과 다를 수 있어 이동 전 역무원 또는 운영기관 안내 확인이 필요합니다."
+  },
+  "prohibitedClaims": [
+    "반드시 이동 가능",
+    "100% 안전",
+    "모든 역 완벽 지원",
+    "실시간 위치 정확",
+    "휠체어 경로 보장"
+  ],
+  "assetEvidence": {
+    "appIcon": "required_play_console_preview_or_asset_record",
+    "featureGraphic": "required_play_console_preview_or_asset_record",
+    "phoneScreenshots": "required_release_build_screenshots",
+    "tabletPolicy": "tablet_compatible_until_tablet_specific_ui_gate",
+    "listingPreview": "required_play_console_preview_summary"
+  },
+  "evidencePolicy": {
+    "localOnlyEvidenceRoot": ".codex/evidence/release/play-store-submission/<rc-or-run>/",
+    "githubEvidencePolicy": "summary-or-public-console-link",
+    "sensitiveEvidence": [
+      "Google Play Console screenshots",
+      "network trace",
+      "release build screenshots before publication",
+      "support mailbox headers"
+    ],
+    "summaryRequiredKo": "민감 증거는 GitHub에 파일로 올리지 않고 PR에는 evidence 종류, 대상, 결과, local-only 경로 또는 공개 가능한 Console 링크만 적는다."
+  }
+}

--- a/apps/mobile/release/store-submission-readiness.json
+++ b/apps/mobile/release/store-submission-readiness.json
@@ -26,7 +26,7 @@
       "decisionOwnerKo": "개인정보/백엔드 담당",
       "readyWhenKo": "스토어 개인정보 인벤토리의 수집 데이터, 암호화 전송, 삭제 지원, 제3자 공유 없음, tracking 없음 값이 Play Console Data safety 답변과 일치한다.",
       "evidence": ["play-console-data-safety-preview", "privacy-inventory-review"],
-      "linkedArtifacts": ["apps/mobile/release/store-privacy-inventory.json", "apps/mobile/lib/main.dart"],
+      "linkedArtifacts": ["apps/mobile/release/store-privacy-inventory.json", "apps/mobile/release/play-store-submission-content.json", "apps/mobile/lib/main.dart"],
       "configurationSources": ["EASYSUBWAY_PRIVACY_POLICY_URL", "EASYSUBWAY_DATA_DELETION_EMAIL"]
     },
     {
@@ -147,7 +147,7 @@
       "decisionOwnerKo": "제품/마케팅 담당",
       "readyWhenKo": "설명, 스크린샷, 기능 문구가 실제 앱 화면과 일치하고 실시간 안전 경로 보장처럼 과장된 표현을 사용하지 않는다.",
       "evidence": ["screenshot-review", "copy-review"],
-      "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart", "apps/mobile/release/accessibility-release-qa.json"],
+      "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart", "apps/mobile/release/accessibility-release-qa.json", "apps/mobile/release/play-store-submission-content.json"],
       "configurationSources": ["release build screenshots"]
     },
     {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -847,6 +847,8 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   const androidRcEvidence = readJson(androidRcEvidencePath);
   const playProductionAccessPath = "apps/mobile/release/play-production-access-gate.json";
   const playProductionAccessGate = readJson(playProductionAccessPath);
+  const playStoreSubmissionContentPath = "apps/mobile/release/play-store-submission-content.json";
+  const playStoreSubmissionContent = readJson(playStoreSubmissionContentPath);
   const workflow = read(".github/workflows/release-artifacts.yml");
   const readme = read("README.md");
 
@@ -887,6 +889,25 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.ok(playProductionAccessGate.requiredConsoleEvidence.map((item) => item.id).includes("play_production_access_status"));
   assert.ok(playProductionAccessGate.requiredConsoleEvidence.map((item) => item.id).includes("play_closed_test_requirement"));
   assert.match(playProductionAccessGate.evidencePolicy.localOnlyEvidenceRoot, /\.codex\/evidence\/release\/play-production-access/);
+  assert.equal(playStoreSubmissionContent.releaseGate, "play-store-submission-content");
+  assert.equal(playStoreSubmissionContent.issue, 921);
+  assert.equal(playStoreSubmissionContent.androidRcEvidenceManifest, androidRcEvidencePath);
+  assert.equal(playStoreSubmissionContent.storePrivacyInventory, "apps/mobile/release/store-privacy-inventory.json");
+  assert.equal(playStoreSubmissionContent.appContentDeclarations.ads, false);
+  assert.equal(playStoreSubmissionContent.appContentDeclarations.publicUserSignIn, false);
+  assert.equal(playStoreSubmissionContent.appContentDeclarations.accountCreation, false);
+  assert.equal(playStoreSubmissionContent.appContentDeclarations.backgroundLocation, false);
+  assert.equal(playStoreSubmissionContent.dataSafetyDeclarations.tracking, false);
+  assert.equal(playStoreSubmissionContent.dataSafetyDeclarations.sharesDataWithThirdParties, false);
+  assert.equal(playStoreSubmissionContent.dataSafetyDeclarations.dataEncryptedInTransit, true);
+  assert.equal(playStoreSubmissionContent.dataSafetyDeclarations.dataDeletionRequestSupported, true);
+  assert.ok(playStoreSubmissionContent.dataSafetyDeclarations.requiredCollectedDataTypes.includes("Location"));
+  assert.ok(playStoreSubmissionContent.dataSafetyDeclarations.requiredCollectedDataTypes.includes("Photos and videos"));
+  assert.match(playStoreSubmissionContent.koreanListing.fullDescriptionKo, /데이터 기준일|공식 출처|현장 상황|실시간/);
+  for (const claim of playStoreSubmissionContent.prohibitedClaims) {
+    assert.doesNotMatch(playStoreSubmissionContent.koreanListing.fullDescriptionKo, new RegExp(claim));
+    assert.doesNotMatch(playStoreSubmissionContent.koreanListing.shortDescription, new RegExp(claim));
+  }
   assert.equal(androidRcEvidence.releaseGate, "android-rc-store-evidence");
   assert.equal(androidRcEvidence.releaseBlockerPolicy, true);
   assert.equal(androidRcEvidence.scope.platform.android, "RELEASE_REQUIRED");
@@ -911,6 +932,10 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("play-production-access-gate-manifest"));
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("closed-test-12-testers-14-days-continuous-opt-in-record"));
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("production-access-application-response-record"));
+  assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("play-store-submission-content-manifest"));
+  assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("data-safety-answer-contract"));
+  assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("korean-store-listing-contract"));
+  assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("store-graphic-screenshot-asset-record"));
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("data-safety-binary-network-trace-match"));
   assert.ok(androidRcEvidence.requiredEvidence.preReviewPreLaunch.includes("pre-launch-report-crash-0"));
   assert.ok(androidRcEvidence.evidencePolicy.localOnlyEvidenceRoot.startsWith(".codex/evidence/"));
@@ -933,10 +958,12 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(workflow, /play_submission_evidence=blocked_missing_internal_track_or_prelaunch_report/);
   assert.match(workflow, /cp release\/android-16kb-page-size-gate\.json release-artifacts\/android\/android-16kb-page-size-gate\.json/);
   assert.match(workflow, /cp release\/play-production-access-gate\.json release-artifacts\/android\/play-production-access-gate\.json/);
+  assert.match(workflow, /cp release\/play-store-submission-content\.json release-artifacts\/android\/play-store-submission-content\.json/);
   assert.match(workflow, /cp \.\.\/\.\.\/tools\/mobile\/check-android-aab-16kb-page-size\.sh release-artifacts\/android\/check-android-aab-16kb-page-size\.sh/);
   assert.match(workflow, /cp \.\.\/\.\.\/tools\/mobile\/check-elf-load-alignment\.mjs release-artifacts\/android\/check-elf-load-alignment\.mjs/);
   assert.match(workflow, /page_size_16kb_evidence=blocked_until_tools_mobile_check_android_aab_16kb_page_size_passes_and_runtime_PAGE_SIZE_16384_smoke_passes/);
   assert.match(workflow, /play_production_access_evidence=blocked_until_play_production_access_gate_console_summary_is_satisfied/);
+  assert.match(workflow, /play_app_content_data_safety_listing_evidence=blocked_until_play_store_submission_content_console_summary_is_satisfied/);
   assert.match(workflow, /cp release\/signed-release-artifact-gate\.json release-artifacts\/android\/signed-release-artifact-gate\.json/);
   assert.doesNotMatch(workflow, /signing_key_type=no-codesign/);
   assert.doesNotMatch(workflow, /testflight_evidence=blocked_missing_testflight_or_signed_device_install/);
@@ -953,6 +980,9 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(readme, /Google Play production access/);
   assert.match(readme, /12명 이상/);
   assert.match(readme, /14일 연속 opt-in/);
+  assert.match(readme, /Google Play App Content, Data Safety, 한국어 listing gate/);
+  assert.match(readme, /store-privacy-inventory\.json/);
+  assert.match(readme, /휠체어 경로 보장/);
 });
 
 test("Android 16 KB page-size gate는 AAB alignment와 16384 runtime smoke 계약을 고정한다", () => {
@@ -5729,6 +5759,7 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
   }
 
   assert.ok(items.get("play_data_safety").linkedArtifacts.includes("apps/mobile/release/store-privacy-inventory.json"));
+  assert.ok(items.get("play_data_safety").linkedArtifacts.includes("apps/mobile/release/play-store-submission-content.json"));
   assert.match(items.get("play_privacy_policy_url").configurationSources.join("\n"), /EASYSUBWAY_PRIVACY_POLICY_URL/);
   assert.match(items.get("play_app_access").readyWhenKo, /로그인 없음|제한 접근|심사 계정/);
   assert.ok(items.get("play_production_access_closed_test").linkedArtifacts.includes("apps/mobile/release/play-production-access-gate.json"));
@@ -5736,6 +5767,7 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
   assert.match(items.get("play_content_rating").readyWhenKo, /등급/);
   assert.match(items.get("play_target_audience").readyWhenKo, /전체 사용자|어린이 대상 아님/);
   assert.match(items.get("play_permissions_declaration").readyWhenKo, /위치|권한/);
+  assert.ok(items.get("play_listing_assets_truthfulness").linkedArtifacts.includes("apps/mobile/release/play-store-submission-content.json"));
   assert.match(items.get("play_account_data_deletion").configurationSources.join("\n"), /EASYSUBWAY_DATA_DELETION_EMAIL/);
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("app-content-declarations"));
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("store-listing-scope-copy-review"));


### PR DESCRIPTION
## 관련 이슈

close #921

## 작업 배경

- Google Play App Content, Data Safety, 한국어 listing 문구가 실제 Android binary와 제품 범위와 다르면 심사 실패와 개인정보 선언 불일치가 발생합니다.
- 접근성 경로, 지원 지역, 실시간 범위는 보장 표현 없이 앱 내 안내와 같은 계약을 사용해야 합니다.
- Play Console preview, network trace, screenshot, graphic asset은 민감하거나 외부 증거라 git에는 넣지 않고 local-only summary로 관리해야 합니다.

## 작업 내용

- `apps/mobile/release/play-store-submission-content.json`을 추가해 App Content, Data Safety, 한국어 listing, 금지 표현, asset evidence 요구사항을 release blocker로 고정했습니다.
- `android-rc-store-evidence.json`과 `store-submission-readiness.json`이 #921 gate를 참조하도록 연결했습니다.
- Release Artifacts workflow가 Android artifact에 #921 gate manifest와 blocked metadata를 포함하도록 했습니다.
- README와 repository contract test에 Data Safety/listing 기준과 금지 표현 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/ci/*.test.mjs`: exit 0, 115 tests passed
- `git diff --check`: exit 0
- `gh pr checks 991 --repo AquilaXk/easysubway --watch --interval 20`: all checks pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| App Content/Data Safety/listing 계약 | Local repository | JSON manifest와 repository contract test | `apps/mobile/release/play-store-submission-content.json`, `node --test tools/ci/*.test.mjs` | pass, #921 release blocker 계약 고정 |
| Android release artifact 연결 | GitHub Actions config | artifact copy와 metadata 계약 검사 | `.github/workflows/release-artifacts.yml`, repository contract test | pass, artifact에 gate manifest 포함 |
| Play Console preview와 screenshot/graphic asset | Google Play Console | App Content, Data Safety, listing preview 확인 | local-only evidence 필요: `.codex/evidence/release/play-store-submission/<rc-or-run>/` | PR에서 수집하지 않음. 민감 외부 Console/asset 증거이며 gate status는 `BLOCKED_CONSOLE_PREVIEW_AND_ASSET_EVIDENCE_MISSING` |
| PR CI | GitHub Actions | PR checks | CI run `28252370796`, Release Artifacts run `28252370543`, SonarCloud automatic analysis | pass |
| Code review | GitHub PR review | CodeRabbit status와 review thread 확인 | PR #991 review threads | CodeRabbit success, unresolved thread 0개 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `play-store-submission-content.json`의 `appContentDeclarations`, `dataSafetyDeclarations`, `koreanListing`, `prohibitedClaims`입니다.
- 이 PR은 Play Console에 실제 App Content/Data Safety/listing을 제출하는 PR이 아닙니다. 출시 Go 판단 전 QA가 Console preview, network trace, screenshot/graphic asset summary를 local-only evidence로 채워야 합니다.

## 리스크

- 실제 Play Console preview, network trace, store graphic/screenshot asset은 이 PR에서 검증하지 못했습니다. 해당 외부 증거가 없으면 gate는 계속 release blocker입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI code review fallback은 사용하지 않았다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.