### PR TITLE
[Test] Play-generated APK device matrix gate 추가

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -183,6 +183,7 @@ jobs:
           cp release/android-16kb-page-size-gate.json release-artifacts/android/android-16kb-page-size-gate.json
           cp release/play-production-access-gate.json release-artifacts/android/play-production-access-gate.json
           cp release/play-store-submission-content.json release-artifacts/android/play-store-submission-content.json
+          cp release/play-generated-apk-device-matrix-gate.json release-artifacts/android/play-generated-apk-device-matrix-gate.json
           cp ../../tools/mobile/check-android-aab-16kb-page-size.sh release-artifacts/android/check-android-aab-16kb-page-size.sh
           cp ../../tools/mobile/check-elf-load-alignment.mjs release-artifacts/android/check-elf-load-alignment.mjs
           if [[ -f build/app/outputs/mapping/release/mapping.txt ]]; then
@@ -201,6 +202,7 @@ jobs:
             echo "page_size_16kb_evidence=blocked_until_tools_mobile_check_android_aab_16kb_page_size_passes_and_runtime_PAGE_SIZE_16384_smoke_passes"
             echo "play_production_access_evidence=blocked_until_play_production_access_gate_console_summary_is_satisfied"
             echo "play_app_content_data_safety_listing_evidence=blocked_until_play_store_submission_content_console_summary_is_satisfied"
+            echo "play_generated_apk_device_matrix_evidence=blocked_until_play_generated_apk_device_matrix_gate_is_satisfied"
             echo "toolchain_policy=apps/mobile/release/signed-release-artifact-gate.json"
           } > release-artifacts/android/release-metadata.txt
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Google Play production access와 신규 personal account closed test gate는 `ap
 
 Google Play App Content, Data Safety, 한국어 listing gate는 `apps/mobile/release/play-store-submission-content.json`으로 검증합니다. Data Safety 답변은 `apps/mobile/release/store-privacy-inventory.json`의 수집 데이터, 암호화 전송, 삭제 지원, 제3자 공유 없음, tracking 없음 값과 일치해야 하며 listing은 데이터 기준일, 지원 지역, 실시간 지원 범위, 확인 필요 상태를 명시합니다. “반드시 이동 가능”, “100% 안전”, “모든 역 완벽 지원”, “실시간 위치 정확”, “휠체어 경로 보장” 같은 보장 표현은 store copy와 screenshot 설명에서 사용할 수 없습니다.
 
+Play-generated APK와 device compatibility matrix gate는 `apps/mobile/release/play-generated-apk-device-matrix-gate.json`으로 검증합니다. 로컬 AAB만으로는 Go evidence가 될 수 없고 Internal App Sharing, internal/closed testing, App Bundle Explorer generated APK, Play-installed build 중 하나로 설치한 뒤 split APK manifest, Play App Signing certificate, permission/network security config, Android 15/16, 16 KB page-size, 작은 화면, 큰 글씨, TalkBack, network block, low storage, low memory/process death smoke summary를 남겨야 합니다.
+
 Android 출시 100% 범위와 Go/No-Go 계약은 `apps/mobile/release/release-governance-gate.json`으로 검증합니다. 이번 release blocker는 Android Google Play v1이며 iOS는 `DEFERRED_OUT_OF_SCOPE`로 기록해 Android 출시 완료를 차단하지 않습니다. open Android P0가 있거나 RC evidence의 git SHA, AAB hash, backend artifact, data pack manifest, route/realtime contract가 서로 맞지 않으면 최종 Go 판단을 하지 않습니다.
 
 Android 출시 UX·접근성·성능 gate는 `apps/mobile/release/android-release-quality-gate.json`으로 검증합니다. PR 증거는 local Android emulator evidence를 우선 사용하며, 물리 기기 증거는 Codex PR 증거로 사용하지 않습니다. 실제 Google Play Go 판단 전에는 #907의 exact RC 또는 Play-installed build에서 TalkBack, 150%/200% 글자 크기, 작은 화면, 권한/네트워크/업로드 오류 복구, 노선도 fallback과 성능, 지원 범위/출처 화면, crash/ANR privacy-safe reporting 증거를 다시 수집해야 합니다.

--- a/apps/mobile/release/android-rc-store-evidence.json
+++ b/apps/mobile/release/android-rc-store-evidence.json
@@ -61,8 +61,12 @@
       "photo-picker-route-map-report-upload-smoke"
     ],
     "playGeneratedArtifact": [
+      "play-generated-apk-device-matrix-gate-manifest",
       "internal-app-sharing-or-track-upload-record",
       "app-bundle-explorer-generated-apk-record",
+      "play-app-signing-certificate-record",
+      "split-apk-manifest-permission-network-config-record",
+      "device-matrix-smoke-summary",
       "play-generated-apk-or-installed-build-smoke",
       "play-installed-build-logcat-no-crash"
     ],

--- a/apps/mobile/release/play-generated-apk-device-matrix-gate.json
+++ b/apps/mobile/release/play-generated-apk-device-matrix-gate.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "applicationId": "easysubway",
+  "androidApplicationId": "com.easysubway.app",
+  "releaseGate": "play-generated-apk-device-matrix",
+  "issue": 922,
+  "androidRcEvidenceManifest": "apps/mobile/release/android-rc-store-evidence.json",
+  "androidReleaseQualityGate": "apps/mobile/release/android-release-quality-gate.json",
+  "androidPageSize16kbGate": "apps/mobile/release/android-16kb-page-size-gate.json",
+  "status": "BLOCKED_PLAY_GENERATED_ARTIFACT_EVIDENCE_MISSING",
+  "acceptedArtifactSources": [
+    "internal-app-sharing",
+    "internal-testing-track",
+    "closed-testing-track",
+    "app-bundle-explorer-generated-apk",
+    "play-installed-build"
+  ],
+  "requiredArtifactEvidence": [
+    "play-app-signing-certificate-record",
+    "upload-key-vs-app-signing-key-separation-record",
+    "play-generated-split-apk-install-log",
+    "device-specific-manifest-dump",
+    "package-versioncode-minsdk-targetsdk-record",
+    "permission-network-security-config-review",
+    "native-library-delivery-and-16kb-page-size-record"
+  ],
+  "deviceMatrix": [
+    {
+      "id": "android_15_phone_small_screen_large_font",
+      "releaseBlocker": true,
+      "platform": "Android 15+ local emulator or Play-installed device",
+      "conditions": ["small-screen", "font-scale-150-200", "TalkBack"],
+      "smoke": ["app-start", "datapack-install", "station-search", "route-search", "route-map"]
+    },
+    {
+      "id": "android_16_16kb_page_size",
+      "releaseBlocker": true,
+      "platform": "Android 16 16 KB page-size emulator or Play-installed device",
+      "conditions": ["PAGE_SIZE=16384", "split-apk-native-library-delivery"],
+      "smoke": ["app-start", "datapack-install", "station-search", "route-search", "facility-report-photo"]
+    },
+    {
+      "id": "network_block_low_storage_low_memory",
+      "releaseBlocker": true,
+      "platform": "Android local emulator or Play-installed device",
+      "conditions": ["network-block", "low-storage", "low-memory-or-process-death"],
+      "smoke": ["offline-datapack-fallback", "error-message-recovery", "app-relaunch-state-restore"]
+    }
+  ],
+  "goNoGoRules": {
+    "localAabOnly": "BLOCKED_EXTERNAL",
+    "missingPlayGeneratedArtifact": "BLOCKED_EXTERNAL",
+    "manifestMismatch": "BLOCKED_TECHNICAL",
+    "playInstalledSmokeCrash": "BLOCKED_TECHNICAL",
+    "deviceMatrixP0Failure": "BLOCKED_TECHNICAL"
+  },
+  "evidencePolicy": {
+    "localOnlyEvidenceRoot": ".codex/evidence/release/play-generated-apk-device-matrix/<rc-or-run>/",
+    "githubEvidencePolicy": "summary-or-public-console-link",
+    "sensitiveEvidence": [
+      "Google Play Console screenshots",
+      "AAB/APK files",
+      "device identifiers",
+      "network traces",
+      "tester personal data"
+    ],
+    "summaryRequiredKo": "민감 증거는 GitHub에 파일로 올리지 않고 PR에는 evidence 종류, 대상, 결과, local-only 경로 또는 공개 가능한 Console 링크만 적는다."
+  }
+}

--- a/apps/mobile/release/signed-release-artifact-gate.json
+++ b/apps/mobile/release/signed-release-artifact-gate.json
@@ -7,6 +7,7 @@
   "androidRcEvidenceManifest": "apps/mobile/release/android-rc-store-evidence.json",
   "androidPageSize16kbGate": "apps/mobile/release/android-16kb-page-size-gate.json",
   "playProductionAccessGate": "apps/mobile/release/play-production-access-gate.json",
+  "playGeneratedApkDeviceMatrixGate": "apps/mobile/release/play-generated-apk-device-matrix-gate.json",
   "officialRequirements": {
     "android": {
       "targetApiLevelMinimum": 35,
@@ -33,7 +34,8 @@
         "Play internal track upload or pre-launch report evidence",
         "Play-generated APK or Play-installed build smoke evidence",
         "Android 16 KB page-size AAB and runtime smoke evidence",
-        "Play production access or closed test requirement satisfaction evidence"
+        "Play production access or closed test requirement satisfaction evidence",
+        "Play-generated APK device compatibility matrix evidence"
       ]
     },
     "ios": {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -849,6 +849,8 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   const playProductionAccessGate = readJson(playProductionAccessPath);
   const playStoreSubmissionContentPath = "apps/mobile/release/play-store-submission-content.json";
   const playStoreSubmissionContent = readJson(playStoreSubmissionContentPath);
+  const playGeneratedApkDeviceMatrixPath = "apps/mobile/release/play-generated-apk-device-matrix-gate.json";
+  const playGeneratedApkDeviceMatrixGate = readJson(playGeneratedApkDeviceMatrixPath);
   const workflow = read(".github/workflows/release-artifacts.yml");
   const readme = read("README.md");
 
@@ -860,6 +862,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.equal(gate.androidRcEvidenceManifest, androidRcEvidencePath);
   assert.equal(gate.androidPageSize16kbGate, "apps/mobile/release/android-16kb-page-size-gate.json");
   assert.equal(gate.playProductionAccessGate, playProductionAccessPath);
+  assert.equal(gate.playGeneratedApkDeviceMatrixGate, playGeneratedApkDeviceMatrixPath);
 
   assert.equal(gate.officialRequirements.android.targetApiLevelMinimum, 35);
   assert.equal(gate.officialRequirements.android.requiredFrom, "2025-08-31");
@@ -879,6 +882,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.ok(gate.artifacts.android.storeReadyRequires.includes("Play-generated APK or Play-installed build smoke evidence"));
   assert.ok(gate.artifacts.android.storeReadyRequires.includes("Android 16 KB page-size AAB and runtime smoke evidence"));
   assert.ok(gate.artifacts.android.storeReadyRequires.includes("Play production access or closed test requirement satisfaction evidence"));
+  assert.ok(gate.artifacts.android.storeReadyRequires.includes("Play-generated APK device compatibility matrix evidence"));
   assert.equal(playProductionAccessGate.releaseGate, "play-production-access-closed-test");
   assert.equal(playProductionAccessGate.issue, 920);
   assert.equal(playProductionAccessGate.parentEvidenceManifest, androidRcEvidencePath);
@@ -908,6 +912,17 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
     assert.doesNotMatch(playStoreSubmissionContent.koreanListing.fullDescriptionKo, new RegExp(claim));
     assert.doesNotMatch(playStoreSubmissionContent.koreanListing.shortDescription, new RegExp(claim));
   }
+  assert.equal(playGeneratedApkDeviceMatrixGate.releaseGate, "play-generated-apk-device-matrix");
+  assert.equal(playGeneratedApkDeviceMatrixGate.issue, 922);
+  assert.equal(playGeneratedApkDeviceMatrixGate.androidRcEvidenceManifest, androidRcEvidencePath);
+  assert.ok(playGeneratedApkDeviceMatrixGate.acceptedArtifactSources.includes("internal-app-sharing"));
+  assert.ok(playGeneratedApkDeviceMatrixGate.acceptedArtifactSources.includes("play-installed-build"));
+  assert.ok(playGeneratedApkDeviceMatrixGate.requiredArtifactEvidence.includes("play-generated-split-apk-install-log"));
+  assert.ok(playGeneratedApkDeviceMatrixGate.requiredArtifactEvidence.includes("device-specific-manifest-dump"));
+  assert.ok(playGeneratedApkDeviceMatrixGate.requiredArtifactEvidence.includes("native-library-delivery-and-16kb-page-size-record"));
+  assert.ok(playGeneratedApkDeviceMatrixGate.deviceMatrix.every((item) => item.releaseBlocker === true));
+  assert.ok(playGeneratedApkDeviceMatrixGate.deviceMatrix.map((item) => item.id).includes("android_16_16kb_page_size"));
+  assert.equal(playGeneratedApkDeviceMatrixGate.goNoGoRules.localAabOnly, "BLOCKED_EXTERNAL");
   assert.equal(androidRcEvidence.releaseGate, "android-rc-store-evidence");
   assert.equal(androidRcEvidence.releaseBlockerPolicy, true);
   assert.equal(androidRcEvidence.scope.platform.android, "RELEASE_REQUIRED");
@@ -928,6 +943,10 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.ok(androidRcEvidence.requiredEvidence.pageSize16kb.includes("adb-getconf-page-size-16384"));
   assert.ok(androidRcEvidence.requiredEvidence.pageSize16kb.includes("android-15-or-16-page-size-smoke"));
   assert.ok(androidRcEvidence.requiredEvidence.playGeneratedArtifact.includes("play-generated-apk-or-installed-build-smoke"));
+  assert.ok(androidRcEvidence.requiredEvidence.playGeneratedArtifact.includes("play-generated-apk-device-matrix-gate-manifest"));
+  assert.ok(androidRcEvidence.requiredEvidence.playGeneratedArtifact.includes("play-app-signing-certificate-record"));
+  assert.ok(androidRcEvidence.requiredEvidence.playGeneratedArtifact.includes("split-apk-manifest-permission-network-config-record"));
+  assert.ok(androidRcEvidence.requiredEvidence.playGeneratedArtifact.includes("device-matrix-smoke-summary"));
   assert.ok(androidRcEvidence.requiredEvidence.androidAccessibilityQa.includes("talkback-rc-build-notes"));
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("play-production-access-gate-manifest"));
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("closed-test-12-testers-14-days-continuous-opt-in-record"));
@@ -959,11 +978,13 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(workflow, /cp release\/android-16kb-page-size-gate\.json release-artifacts\/android\/android-16kb-page-size-gate\.json/);
   assert.match(workflow, /cp release\/play-production-access-gate\.json release-artifacts\/android\/play-production-access-gate\.json/);
   assert.match(workflow, /cp release\/play-store-submission-content\.json release-artifacts\/android\/play-store-submission-content\.json/);
+  assert.match(workflow, /cp release\/play-generated-apk-device-matrix-gate\.json release-artifacts\/android\/play-generated-apk-device-matrix-gate\.json/);
   assert.match(workflow, /cp \.\.\/\.\.\/tools\/mobile\/check-android-aab-16kb-page-size\.sh release-artifacts\/android\/check-android-aab-16kb-page-size\.sh/);
   assert.match(workflow, /cp \.\.\/\.\.\/tools\/mobile\/check-elf-load-alignment\.mjs release-artifacts\/android\/check-elf-load-alignment\.mjs/);
   assert.match(workflow, /page_size_16kb_evidence=blocked_until_tools_mobile_check_android_aab_16kb_page_size_passes_and_runtime_PAGE_SIZE_16384_smoke_passes/);
   assert.match(workflow, /play_production_access_evidence=blocked_until_play_production_access_gate_console_summary_is_satisfied/);
   assert.match(workflow, /play_app_content_data_safety_listing_evidence=blocked_until_play_store_submission_content_console_summary_is_satisfied/);
+  assert.match(workflow, /play_generated_apk_device_matrix_evidence=blocked_until_play_generated_apk_device_matrix_gate_is_satisfied/);
   assert.match(workflow, /cp release\/signed-release-artifact-gate\.json release-artifacts\/android\/signed-release-artifact-gate\.json/);
   assert.doesNotMatch(workflow, /signing_key_type=no-codesign/);
   assert.doesNotMatch(workflow, /testflight_evidence=blocked_missing_testflight_or_signed_device_install/);
@@ -983,6 +1004,9 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(readme, /Google Play App Content, Data Safety, 한국어 listing gate/);
   assert.match(readme, /store-privacy-inventory\.json/);
   assert.match(readme, /휠체어 경로 보장/);
+  assert.match(readme, /Play-generated APK와 device compatibility matrix gate/);
+  assert.match(readme, /로컬 AAB만으로는 Go evidence가 될 수 없고/);
+  assert.match(readme, /16 KB page-size/);
 });
 
 test("Android 16 KB page-size gate는 AAB alignment와 16384 runtime smoke 계약을 고정한다", () => {


### PR DESCRIPTION
## 관련 이슈

close #922

## 작업 배경

- 로컬 AAB build만으로는 Play App Signing, split APK, device-specific manifest, 실제 native library 전달 결과를 보장할 수 없습니다.
- Play가 생성하거나 배포하는 artifact로 설치와 device compatibility smoke를 확인해야 Android production Go 판단이 가능합니다.
- Play Console screenshot, AAB/APK binary, device id, network trace는 민감 증거라 git에는 넣지 않고 local-only summary로 관리해야 합니다.

## 작업 내용

- `apps/mobile/release/play-generated-apk-device-matrix-gate.json`을 추가해 Play-generated artifact source, split APK/manifest evidence, Android device matrix smoke를 release blocker로 고정했습니다.
- `android-rc-store-evidence.json`과 `signed-release-artifact-gate.json`이 #922 gate를 참조하도록 연결했습니다.
- Release Artifacts workflow가 Android artifact에 #922 gate manifest와 blocked metadata를 포함하도록 했습니다.
- README와 repository contract test에 Play-generated APK/device matrix 기준을 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/ci/*.test.mjs`: exit 0, 115 tests passed
- `git diff --check`: exit 0
- GitHub Actions CI run `28252878140`: Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan pass
- GitHub Actions Release Artifacts run `28252877808`: Android Release Artifact, Backend Release Image pass
- SonarCloud automatic analysis run `28252877798`: pass
- `gh pr checks 992 --repo AquilaXk/easysubway --watch --interval 20`: all checks pass
- CodeRabbit status check: success, Review completed
- GitHub review threads: 0 unresolved threads

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Play-generated APK device matrix 계약 | Local repository | JSON manifest와 repository contract test | `apps/mobile/release/play-generated-apk-device-matrix-gate.json`, `node --test tools/ci/*.test.mjs` | pass, #922 release blocker 계약 고정 |
| Android release artifact 연결 | GitHub Actions config | artifact copy와 metadata 계약 검사 | `.github/workflows/release-artifacts.yml`, repository contract test, Release Artifacts run `28252877808` | pass, artifact에 gate manifest 포함 |
| PR CI/review gate | GitHub Actions / CodeRabbit | PR checks, CodeRabbit status, review thread 조회 | CI run `28252878140`, Release Artifacts run `28252877808`, SonarCloud run `28252877798`, CodeRabbit success, review threads 0 | pass |
| Play-generated APK 또는 Play-installed build 실제 설치 | Local Android emulator / Google Play artifact | Internal App Sharing, internal/closed track, App Bundle Explorer generated APK, Play-installed build 중 하나로 로컬 에뮬레이터에 설치 | local-only evidence 필요: `.codex/evidence/release/play-generated-apk-device-matrix/<rc-or-run>/` | PR에서 수집하지 않음. 민감 외부 Play artifact/device 증거이며 gate status는 `BLOCKED_PLAY_GENERATED_ARTIFACT_EVIDENCE_MISSING` |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `play-generated-apk-device-matrix-gate.json`의 `acceptedArtifactSources`, `requiredArtifactEvidence`, `deviceMatrix`, `goNoGoRules`입니다.
- 이 PR은 Play-generated APK를 실제로 설치한 PR이 아닙니다. 출시 Go 판단 전 QA가 Play artifact 설치, split manifest, device matrix smoke summary를 local-only evidence로 채워야 합니다.
- Android device evidence는 실기기가 아니라 로컬 에뮬레이터 기준으로만 수집합니다.

## 리스크

- 실제 Play artifact 설치와 device matrix smoke는 이 PR에서 검증하지 못했습니다. 해당 외부 증거가 없으면 gate는 계속 release blocker입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI code review fallback은 사용하지 않았다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
