### PR TITLE
[Chore] Android 사용자 지원·데이터 오류·장애 대응 gate 추가

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -185,6 +185,7 @@ jobs:
           cp release/play-store-submission-content.json release-artifacts/android/play-store-submission-content.json
           cp release/play-generated-apk-device-matrix-gate.json release-artifacts/android/play-generated-apk-device-matrix-gate.json
           cp release/post-launch-operations-review-gate.json release-artifacts/android/post-launch-operations-review-gate.json
+          cp release/support-incident-response-gate.json release-artifacts/android/support-incident-response-gate.json
           cp ../../tools/mobile/check-android-aab-16kb-page-size.sh release-artifacts/android/check-android-aab-16kb-page-size.sh
           cp ../../tools/mobile/check-elf-load-alignment.mjs release-artifacts/android/check-elf-load-alignment.mjs
           if [[ -f build/app/outputs/mapping/release/mapping.txt ]]; then
@@ -205,6 +206,7 @@ jobs:
             echo "play_app_content_data_safety_listing_evidence=blocked_until_play_store_submission_content_console_summary_is_satisfied"
             echo "play_generated_apk_device_matrix_evidence=blocked_until_play_generated_apk_device_matrix_gate_is_satisfied"
             echo "post_launch_operations_review_evidence=blocked_until_post_launch_operations_review_gate_is_satisfied"
+            echo "support_incident_response_evidence=blocked_until_support_incident_response_gate_is_satisfied"
             echo "toolchain_policy=apps/mobile/release/signed-release-artifact-gate.json"
           } > release-artifacts/android/release-metadata.txt
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Play-generated APK와 device compatibility matrix gate는 `apps/mobile/release/p
 
 Android 출시 후 2시간/24시간/7일/30일 운영 검토는 `apps/mobile/release/post-launch-operations-review-gate.json`으로 검증합니다. Play review, crash/ANR, 지원 문의, 데이터 오류, provider quota, 신고 backlog, data-pack adoption 신호와 backend/datapack/realtime kill switch owner를 확인해야 하며, P0 앱 문제는 최초 공개에서는 staged rollout halt 대신 새 versionCode의 fixed release로 제출합니다. fixed release regression 증거는 실기기 대신 로컬 Android emulator에서 수집하고 민감한 Console, support, provider 증거는 `.codex/evidence/release/post-launch-operations-review/<rc-or-run>/` 아래 local-only summary로 보관합니다.
 
+사용자 지원, 데이터 오류, 장애 대응 gate는 `apps/mobile/release/support-incident-response-gate.json`으로 검증합니다. support email/site, FAQ, 장애 공지 문구, 문의 분류 기준, P0 안전 오류 triage, 운영기관 연락 경로, emergency datapack release/rollback, 오래된 신고 retention, duplicate 처리, 잘못된 override 회수 절차가 준비되어야 합니다. 도움말/공지 화면 증거는 로컬 Android emulator에서 screenshot 또는 UI tree로 수집하고, support mailbox 개인 정보, receipt token, 운영기관 private contact, provider credential은 GitHub에 올리지 않습니다.
+
 Android 출시 100% 범위와 Go/No-Go 계약은 `apps/mobile/release/release-governance-gate.json`으로 검증합니다. 이번 release blocker는 Android Google Play v1이며 iOS는 `DEFERRED_OUT_OF_SCOPE`로 기록해 Android 출시 완료를 차단하지 않습니다. open Android P0가 있거나 RC evidence의 git SHA, AAB hash, backend artifact, data pack manifest, route/realtime contract가 서로 맞지 않으면 최종 Go 판단을 하지 않습니다.
 
 Android 출시 UX·접근성·성능 gate는 `apps/mobile/release/android-release-quality-gate.json`으로 검증합니다. PR 증거는 local Android emulator evidence를 우선 사용하며, 물리 기기 증거는 Codex PR 증거로 사용하지 않습니다. 실제 Google Play Go 판단 전에는 #907의 exact RC 또는 Play-installed build에서 TalkBack, 150%/200% 글자 크기, 작은 화면, 권한/네트워크/업로드 오류 복구, 노선도 fallback과 성능, 지원 범위/출처 화면, crash/ANR privacy-safe reporting 증거를 다시 수집해야 합니다.

--- a/apps/mobile/release/android-rc-store-evidence.json
+++ b/apps/mobile/release/android-rc-store-evidence.json
@@ -104,6 +104,7 @@
     ],
     "postReleaseReadiness": [
       "post-launch-operations-review-gate-manifest",
+      "support-incident-response-gate-manifest",
       "first-2h-monitoring-owner-schedule",
       "24h-7d-30d-review-owner-schedule",
       "play-review-crash-anr-provider-quota-report-backlog-signals",
@@ -111,6 +112,11 @@
       "fixed-release-submission-procedure-record",
       "second-update-staged-rollout-halt-rollback-procedure",
       "customer-support-intake-ready",
+      "support-faq-and-incident-notice-copy-review",
+      "data-error-triage-dry-run",
+      "operator-contact-route-record",
+      "emergency-datapack-release-rollback-runbook-match",
+      "retention-duplicate-override-recovery-policy",
       "data-error-response-ready",
       "incident-response-ready"
     ]

--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -7,6 +7,7 @@
   "status": "BLOCKED_POST_LAUNCH_EVIDENCE_MISSING",
   "androidRcEvidenceManifest": "apps/mobile/release/android-rc-store-evidence.json",
   "operationsEvidenceManifest": "apps/mobile/release/operations-release-evidence.json",
+  "supportIncidentResponseGate": "apps/mobile/release/support-incident-response-gate.json",
   "evidenceRoot": ".codex/evidence/release/post-launch-operations-review/<rc-or-run>/",
   "reviewWindows": [
     {
@@ -19,7 +20,8 @@
         "android-vitals-anr-rate",
         "backend-readiness",
         "provider-quota-error-rate",
-        "support-intake-open"
+        "support-intake-open",
+        "support-incident-response-gate-ready"
       ],
       "decisionKo": "P0 crash, ANR 급증, Play rejection, backend readiness DOWN, provider quota exhaustion 중 하나라도 확인되면 공개 공지와 fixed release 판단을 시작한다."
     },
@@ -33,7 +35,8 @@
         "support-ticket-summary",
         "data-error-report-backlog",
         "facility-report-backlog",
-        "datapack-adoption-rate"
+        "datapack-adoption-rate",
+        "incident-notice-and-faq-readiness"
       ],
       "decisionKo": "치명 오류 0, 미응답 문의 0, 데이터 오류 P0 0, 신고 backlog owner 지정 완료를 만족하지 못하면 fixed release 또는 datapack rollback을 결정한다."
     },

--- a/apps/mobile/release/signed-release-artifact-gate.json
+++ b/apps/mobile/release/signed-release-artifact-gate.json
@@ -9,6 +9,7 @@
   "playProductionAccessGate": "apps/mobile/release/play-production-access-gate.json",
   "playGeneratedApkDeviceMatrixGate": "apps/mobile/release/play-generated-apk-device-matrix-gate.json",
   "postLaunchOperationsReviewGate": "apps/mobile/release/post-launch-operations-review-gate.json",
+  "supportIncidentResponseGate": "apps/mobile/release/support-incident-response-gate.json",
   "officialRequirements": {
     "android": {
       "targetApiLevelMinimum": 35,
@@ -37,7 +38,8 @@
         "Android 16 KB page-size AAB and runtime smoke evidence",
         "Play production access or closed test requirement satisfaction evidence",
         "Play-generated APK device compatibility matrix evidence",
-        "Post-launch 2h/24h/7d/30d operations review evidence"
+        "Post-launch 2h/24h/7d/30d operations review evidence",
+        "Support, data correction, incident notice, emergency datapack response evidence"
       ]
     },
     "ios": {

--- a/apps/mobile/release/support-incident-response-gate.json
+++ b/apps/mobile/release/support-incident-response-gate.json
@@ -1,0 +1,138 @@
+{
+  "schemaVersion": 1,
+  "applicationId": "easysubway",
+  "androidApplicationId": "com.easysubway.app",
+  "releaseGate": "support-incident-response",
+  "issue": 924,
+  "status": "BLOCKED_SUPPORT_INCIDENT_EVIDENCE_MISSING",
+  "androidRcEvidenceManifest": "apps/mobile/release/android-rc-store-evidence.json",
+  "postLaunchOperationsReviewGate": "apps/mobile/release/post-launch-operations-review-gate.json",
+  "evidenceRoot": ".codex/evidence/release/support-incident-response/<rc-or-run>/",
+  "supportChannels": [
+    {
+      "id": "support_email",
+      "source": "EASYSUBWAY_SUPPORT_EMAIL",
+      "ownerKo": "고객지원 담당자",
+      "readyWhenKo": "스토어 연락처, 앱 도움말, README의 support email이 같은 운영 수신함으로 연결되고 수신 테스트를 통과한다.",
+      "requiredEvidence": ["support-mailbox-receive-test", "store-contact-preview", "app-help-screen-contact-check"]
+    },
+    {
+      "id": "faq_and_status_notice",
+      "source": "public-support-page",
+      "ownerKo": "운영/제품 담당자",
+      "readyWhenKo": "FAQ, 장애 공지, 데이터 기준일, 지원 지역, 문의 전 확인 항목이 공개 지원 페이지 또는 앱 도움말에서 확인된다.",
+      "requiredEvidence": ["faq-copy-review", "incident-notice-copy-review", "local-emulator-help-screen-screenshot-or-ui-tree"]
+    },
+    {
+      "id": "security_privacy_deletion",
+      "source": "EASYSUBWAY_SECURITY_EMAIL and EASYSUBWAY_DATA_DELETION_EMAIL",
+      "ownerKo": "보안/개인정보 담당자",
+      "readyWhenKo": "보안 문의, 개인정보 문의, 데이터 삭제 요청이 일반 문의와 분리되어 접수되고 SLA owner가 지정된다.",
+      "requiredEvidence": ["security-mailbox-test", "data-deletion-mailbox-test", "privacy-request-routing-check"]
+    }
+  ],
+  "intakeCategories": [
+    {
+      "id": "p0_safety_data_error",
+      "severity": "P0",
+      "triageTarget": "PT2H",
+      "ownerKo": "데이터 오류 대응 담당자",
+      "examplesKo": ["휠체어 접근 불가 경로를 가능으로 안내", "엘리베이터 장기 고장 누락", "잘못된 역/출구 위치로 위험 이동 유도"],
+      "requiredNextAction": "operator-contact-or-field-check-and-emergency-datapack-decision"
+    },
+    {
+      "id": "p1_accessibility_blocker",
+      "severity": "P1",
+      "triageTarget": "P1D",
+      "ownerKo": "접근성 품질 담당자",
+      "examplesKo": ["스크린리더 핵심 흐름 이해 불가", "큰 글씨에서 주요 버튼 사용 불가", "신고 제출 반복 실패"],
+      "requiredNextAction": "app-fix-or-support-guidance"
+    },
+    {
+      "id": "p2_support_question",
+      "severity": "P2",
+      "triageTarget": "P3D",
+      "ownerKo": "고객지원 담당자",
+      "examplesKo": ["지원 지역 문의", "데이터 기준일 문의", "기능 사용 문의"],
+      "requiredNextAction": "faq-or-support-reply"
+    }
+  ],
+  "dataCorrectionFlow": {
+    "requiredSteps": [
+      "intake-and-receipt-id-record",
+      "severity-triage",
+      "source-and-operator-contact-check",
+      "override-approval",
+      "emergency-datapack-release-or-rollback",
+      "user-notice-and-support-reply",
+      "post-release-verification"
+    ],
+    "slaTargets": {
+      "p0SafetyErrorTriage": "PT2H",
+      "dataCorrectionApproval": "P1D",
+      "emergencyOverridePublish": "PT4H",
+      "emergencyDatapackRelease": "P1D",
+      "mistakenOverrideRollback": "PT4H"
+    },
+    "goNoGoKo": "P0 안전 오류 triage, correction approval, emergency datapack release/rollback, 사용자 공지 owner 중 하나라도 없으면 출시 후 대응 준비 완료가 아니다."
+  },
+  "operatorContactRoutes": [
+    {
+      "id": "seoul_metro_or_city_provider",
+      "ownerKo": "운영기관 연락 담당자",
+      "requiredEvidence": ["official-contact-url-or-partner-contact-record", "request-template", "response-sla-note"]
+    },
+    {
+      "id": "national_or_regional_datapack_source",
+      "ownerKo": "데이터팩 운영 담당자",
+      "requiredEvidence": ["source-owner-contact-record", "license-and-correction-policy-note", "emergency-source-archive"]
+    }
+  ],
+  "incidentNoticeTemplates": [
+    {
+      "id": "data_error_notice",
+      "channel": "app-help-or-support-page",
+      "copyKo": "일부 역/시설 정보가 현장과 다를 수 있어 확인 중입니다. 이동 전 역 직원 또는 운영기관 안내도 함께 확인해 주세요."
+    },
+    {
+      "id": "provider_outage_notice",
+      "channel": "app-help-or-support-page",
+      "copyKo": "실시간 도착 정보 제공처 응답이 불안정해 최신 정보가 늦게 표시될 수 있습니다. 앱은 확인 필요 상태로 안내합니다."
+    },
+    {
+      "id": "fixed_release_notice",
+      "channel": "store-release-notes-and-support-page",
+      "copyKo": "접수된 문제를 수정한 업데이트를 제출했습니다. 업데이트가 표시되면 최신 버전으로 이용해 주세요."
+    }
+  ],
+  "retentionDuplicateOverridePolicy": {
+    "oldReportRetentionKo": "오래된 신고는 감사와 데이터 품질 분석에 필요한 최소 기간만 보관하고 개인정보 연결은 삭제 요청 시 익명화한다.",
+    "duplicateHandlingKo": "같은 역/시설/증상 신고는 기준 신고에 연결하고 사용자에게 중복 정리 안내를 남긴다.",
+    "mistakenOverrideRecoveryKo": "잘못된 override는 rollback pack 또는 corrected pack으로 회수하고 영향 범위, 회수 시각, 검증 결과를 evidence에 기록한다.",
+    "requiredEvidence": [
+      "retention-policy-review",
+      "duplicate-report-triage-sample",
+      "override-rollback-sample",
+      "audit-log-redaction-check"
+    ]
+  },
+  "dryRunRequiredEvidence": [
+    "support-channel-access-check",
+    "data-error-triage-dry-run",
+    "emergency-datapack-release-rollback-runbook-match",
+    "incident-notice-copy-review",
+    "local-emulator-help-screen-screenshot-or-ui-tree"
+  ],
+  "sensitiveEvidencePolicy": {
+    "localOnly": true,
+    "githubUploadPolicy": "summary-only",
+    "forbiddenInPullRequest": [
+      "support mailbox personal data",
+      "report receipt token",
+      "operator private contact",
+      "provider credential or quota token",
+      "Play Console account data"
+    ],
+    "summaryRequiredKo": "민감 증거는 GitHub에 올리지 않고 PR에는 evidence 종류, 대상, 결과, local-only 경로만 적는다."
+  }
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -853,6 +853,8 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   const playGeneratedApkDeviceMatrixGate = readJson(playGeneratedApkDeviceMatrixPath);
   const postLaunchOperationsReviewPath = "apps/mobile/release/post-launch-operations-review-gate.json";
   const postLaunchOperationsReviewGate = readJson(postLaunchOperationsReviewPath);
+  const supportIncidentResponsePath = "apps/mobile/release/support-incident-response-gate.json";
+  const supportIncidentResponseGate = readJson(supportIncidentResponsePath);
   const workflow = read(".github/workflows/release-artifacts.yml");
   const readme = read("README.md");
 
@@ -866,6 +868,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.equal(gate.playProductionAccessGate, playProductionAccessPath);
   assert.equal(gate.playGeneratedApkDeviceMatrixGate, playGeneratedApkDeviceMatrixPath);
   assert.equal(gate.postLaunchOperationsReviewGate, postLaunchOperationsReviewPath);
+  assert.equal(gate.supportIncidentResponseGate, supportIncidentResponsePath);
 
   assert.equal(gate.officialRequirements.android.targetApiLevelMinimum, 35);
   assert.equal(gate.officialRequirements.android.requiredFrom, "2025-08-31");
@@ -887,6 +890,11 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.ok(gate.artifacts.android.storeReadyRequires.includes("Play production access or closed test requirement satisfaction evidence"));
   assert.ok(gate.artifacts.android.storeReadyRequires.includes("Play-generated APK device compatibility matrix evidence"));
   assert.ok(gate.artifacts.android.storeReadyRequires.includes("Post-launch 2h/24h/7d/30d operations review evidence"));
+  assert.ok(
+    gate.artifacts.android.storeReadyRequires.includes(
+      "Support, data correction, incident notice, emergency datapack response evidence",
+    ),
+  );
   assert.equal(playProductionAccessGate.releaseGate, "play-production-access-closed-test");
   assert.equal(playProductionAccessGate.issue, 920);
   assert.equal(playProductionAccessGate.parentEvidenceManifest, androidRcEvidencePath);
@@ -932,6 +940,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.equal(postLaunchOperationsReviewGate.status, "BLOCKED_POST_LAUNCH_EVIDENCE_MISSING");
   assert.equal(postLaunchOperationsReviewGate.androidRcEvidenceManifest, androidRcEvidencePath);
   assert.equal(postLaunchOperationsReviewGate.operationsEvidenceManifest, "apps/mobile/release/operations-release-evidence.json");
+  assert.equal(postLaunchOperationsReviewGate.supportIncidentResponseGate, supportIncidentResponsePath);
   assert.match(postLaunchOperationsReviewGate.evidenceRoot, /\.codex\/evidence\/release\/post-launch-operations-review\/<rc-or-run>/);
   assert.deepEqual(
     postLaunchOperationsReviewGate.reviewWindows.map((window) => window.id),
@@ -950,6 +959,29 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.equal(postLaunchOperationsReviewGate.stagedRolloutPolicy.initialProductionRelease, "not-available-for-first-public-release");
   assert.ok(postLaunchOperationsReviewGate.stagedRolloutPolicy.secondAndLaterUpdates.includes("halt-rollout-on-p0-or-policy-warning"));
   assert.ok(postLaunchOperationsReviewGate.dryRunRequiredEvidence.includes("alert-route-dry-run-log"));
+  assert.equal(supportIncidentResponseGate.releaseGate, "support-incident-response");
+  assert.equal(supportIncidentResponseGate.issue, 924);
+  assert.equal(supportIncidentResponseGate.status, "BLOCKED_SUPPORT_INCIDENT_EVIDENCE_MISSING");
+  assert.equal(supportIncidentResponseGate.androidRcEvidenceManifest, androidRcEvidencePath);
+  assert.equal(supportIncidentResponseGate.postLaunchOperationsReviewGate, postLaunchOperationsReviewPath);
+  assert.match(supportIncidentResponseGate.evidenceRoot, /\.codex\/evidence\/release\/support-incident-response\/<rc-or-run>/);
+  assert.deepEqual(
+    supportIncidentResponseGate.supportChannels.map((channel) => channel.id).sort(),
+    ["faq_and_status_notice", "security_privacy_deletion", "support_email"],
+  );
+  assert.deepEqual(
+    supportIncidentResponseGate.intakeCategories.map((category) => category.id).sort(),
+    ["p0_safety_data_error", "p1_accessibility_blocker", "p2_support_question"],
+  );
+  assert.equal(supportIncidentResponseGate.dataCorrectionFlow.slaTargets.p0SafetyErrorTriage, "PT2H");
+  assert.equal(supportIncidentResponseGate.dataCorrectionFlow.slaTargets.dataCorrectionApproval, "P1D");
+  assert.equal(supportIncidentResponseGate.dataCorrectionFlow.slaTargets.emergencyOverridePublish, "PT4H");
+  assert.equal(supportIncidentResponseGate.dataCorrectionFlow.slaTargets.emergencyDatapackRelease, "P1D");
+  assert.ok(supportIncidentResponseGate.operatorContactRoutes.map((route) => route.id).includes("seoul_metro_or_city_provider"));
+  assert.ok(supportIncidentResponseGate.incidentNoticeTemplates.map((notice) => notice.id).includes("data_error_notice"));
+  assert.ok(supportIncidentResponseGate.retentionDuplicateOverridePolicy.requiredEvidence.includes("override-rollback-sample"));
+  assert.ok(supportIncidentResponseGate.dryRunRequiredEvidence.includes("data-error-triage-dry-run"));
+  assert.ok(supportIncidentResponseGate.dryRunRequiredEvidence.includes("local-emulator-help-screen-screenshot-or-ui-tree"));
   assert.equal(androidRcEvidence.releaseGate, "android-rc-store-evidence");
   assert.equal(androidRcEvidence.releaseBlockerPolicy, true);
   assert.equal(androidRcEvidence.scope.platform.android, "RELEASE_REQUIRED");
@@ -985,11 +1017,17 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("data-safety-binary-network-trace-match"));
   assert.ok(androidRcEvidence.requiredEvidence.preReviewPreLaunch.includes("pre-launch-report-crash-0"));
   assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("post-launch-operations-review-gate-manifest"));
+  assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("support-incident-response-gate-manifest"));
   assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("first-2h-monitoring-owner-schedule"));
   assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("24h-7d-30d-review-owner-schedule"));
   assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("backend-datapack-realtime-kill-switch-rollback-owner-record"));
   assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("fixed-release-submission-procedure-record"));
   assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("second-update-staged-rollout-halt-rollback-procedure"));
+  assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("support-faq-and-incident-notice-copy-review"));
+  assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("data-error-triage-dry-run"));
+  assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("operator-contact-route-record"));
+  assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("emergency-datapack-release-rollback-runbook-match"));
+  assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("retention-duplicate-override-recovery-policy"));
   assert.ok(androidRcEvidence.evidencePolicy.localOnlyEvidenceRoot.startsWith(".codex/evidence/"));
 
   assert.equal(gate.artifacts.ios.format, "Runner.app.zip");
@@ -1013,6 +1051,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(workflow, /cp release\/play-store-submission-content\.json release-artifacts\/android\/play-store-submission-content\.json/);
   assert.match(workflow, /cp release\/play-generated-apk-device-matrix-gate\.json release-artifacts\/android\/play-generated-apk-device-matrix-gate\.json/);
   assert.match(workflow, /cp release\/post-launch-operations-review-gate\.json release-artifacts\/android\/post-launch-operations-review-gate\.json/);
+  assert.match(workflow, /cp release\/support-incident-response-gate\.json release-artifacts\/android\/support-incident-response-gate\.json/);
   assert.match(workflow, /cp \.\.\/\.\.\/tools\/mobile\/check-android-aab-16kb-page-size\.sh release-artifacts\/android\/check-android-aab-16kb-page-size\.sh/);
   assert.match(workflow, /cp \.\.\/\.\.\/tools\/mobile\/check-elf-load-alignment\.mjs release-artifacts\/android\/check-elf-load-alignment\.mjs/);
   assert.match(workflow, /page_size_16kb_evidence=blocked_until_tools_mobile_check_android_aab_16kb_page_size_passes_and_runtime_PAGE_SIZE_16384_smoke_passes/);
@@ -1020,6 +1059,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(workflow, /play_app_content_data_safety_listing_evidence=blocked_until_play_store_submission_content_console_summary_is_satisfied/);
   assert.match(workflow, /play_generated_apk_device_matrix_evidence=blocked_until_play_generated_apk_device_matrix_gate_is_satisfied/);
   assert.match(workflow, /post_launch_operations_review_evidence=blocked_until_post_launch_operations_review_gate_is_satisfied/);
+  assert.match(workflow, /support_incident_response_evidence=blocked_until_support_incident_response_gate_is_satisfied/);
   assert.match(workflow, /cp release\/signed-release-artifact-gate\.json release-artifacts\/android\/signed-release-artifact-gate\.json/);
   assert.doesNotMatch(workflow, /signing_key_type=no-codesign/);
   assert.doesNotMatch(workflow, /testflight_evidence=blocked_missing_testflight_or_signed_device_install/);
@@ -1045,6 +1085,9 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(readme, /Android 출시 후 2시간\/24시간\/7일\/30일 운영 검토/);
   assert.match(readme, /post-launch-operations-review-gate\.json/);
   assert.match(readme, /로컬 Android emulator/);
+  assert.match(readme, /사용자 지원, 데이터 오류, 장애 대응 gate/);
+  assert.match(readme, /support-incident-response-gate\.json/);
+  assert.match(readme, /emergency datapack release\/rollback/);
 });
 
 test("Android 16 KB page-size gate는 AAB alignment와 16384 runtime smoke 계약을 고정한다", () => {


### PR DESCRIPTION
## 관련 이슈

close #924

## 작업 배경

- 교통약자 대상 서비스에서 데이터 오류와 장애 공지는 안전 문제로 이어질 수 있어 출시 전 지원/triage/공지 절차가 release blocker로 남아야 합니다.
- 사용자 문의, 데이터 오류, 운영기관 정정, emergency datapack release/rollback, 오래된 신고와 override 회수 절차를 같은 evidence 묶음으로 관리해야 합니다.
- support mailbox, 운영기관 private contact, provider quota, report receipt token은 민감 증거라 git에 넣지 않고 local-only summary로 관리해야 합니다.

## 작업 내용

- `apps/mobile/release/support-incident-response-gate.json`을 추가해 support channel, FAQ/장애 공지, 문의 분류, P0 안전 오류 SLA, 운영기관 연락 경로, 데이터 수정 flow를 release blocker로 고정했습니다.
- emergency datapack release/rollback, duplicate 처리, 오래된 신고 retention, 잘못된 override 회수 절차와 dry-run evidence를 명시했습니다.
- Android RC evidence, post-launch operations review gate, signed release artifact gate가 #924 gate를 참조하도록 연결했습니다.
- Release Artifacts workflow가 #924 gate manifest와 blocked metadata를 Android artifact에 포함하도록 했습니다.
- README와 repository contract test에 사용자 지원·데이터 오류·장애 대응 기준을 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/ci/*.test.mjs`: exit 0, 115 tests passed
- `git diff --check`: exit 0
- GitHub Actions CI run `28254266302`: Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan pass
- GitHub Actions Release Artifacts run `28254266002`: Android Release Artifact, Backend Release Image pass
- SonarCloud automatic analysis run `28254266015`: pass
- `gh pr checks 994 --repo AquilaXk/easysubway --watch --interval 20`: all checks pass
- CodeRabbit status check: success, Review completed
- GitHub review threads: 0 unresolved threads

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| support incident response 계약 | Local repository | JSON manifest와 repository contract test | `apps/mobile/release/support-incident-response-gate.json`, `node --test tools/ci/*.test.mjs` | pass, #924 release blocker 계약 고정 |
| Android release artifact 연결 | GitHub Actions config | artifact copy와 metadata 계약 검사 | `.github/workflows/release-artifacts.yml`, repository contract test, Release Artifacts run `28254266002` | pass, artifact에 gate manifest 포함 |
| PR CI/review gate | GitHub Actions / CodeRabbit | PR checks, CodeRabbit status, review thread 조회 | CI run `28254266302`, Release Artifacts run `28254266002`, SonarCloud run `28254266015`, CodeRabbit success, review threads 0 | pass |
| support channel과 data correction dry-run | Ops/support | mailbox receive, FAQ/status notice, data-error triage, operator contact, emergency datapack rollback 대조 | local-only evidence 필요: `.codex/evidence/release/support-incident-response/<rc-or-run>/` | PR에서 수집하지 않음. gate status는 `BLOCKED_SUPPORT_INCIDENT_EVIDENCE_MISSING` |
| 도움말/공지 화면 증거 | Local Android emulator | support/help 화면 screenshot 또는 UI tree | gate required evidence: `local-emulator-help-screen-screenshot-or-ui-tree` | 절차 계약만 추가. 실기기 evidence는 사용하지 않음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `supportChannels`, `intakeCategories`, `dataCorrectionFlow.slaTargets`, `operatorContactRoutes`, `retentionDuplicateOverridePolicy`입니다.
- 이 PR은 실제 support mailbox 접근이나 data-error triage dry-run을 수행한 PR이 아닙니다. 출시 Go 판단 전 QA가 local-only evidence를 채워야 합니다.

## 리스크

- 실제 support channel, 운영기관 연락, emergency datapack release/rollback dry-run 증거가 없으면 gate는 계속 release blocker입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI code review fallback은 사용하지 않았다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
