### PR TITLE
[Test] Android/backend abuse-case·penetration rehearsal gate 추가

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -186,6 +186,7 @@ jobs:
           cp release/play-generated-apk-device-matrix-gate.json release-artifacts/android/play-generated-apk-device-matrix-gate.json
           cp release/post-launch-operations-review-gate.json release-artifacts/android/post-launch-operations-review-gate.json
           cp release/support-incident-response-gate.json release-artifacts/android/support-incident-response-gate.json
+          cp release/abuse-penetration-rehearsal-gate.json release-artifacts/android/abuse-penetration-rehearsal-gate.json
           cp ../../tools/mobile/check-android-aab-16kb-page-size.sh release-artifacts/android/check-android-aab-16kb-page-size.sh
           cp ../../tools/mobile/check-elf-load-alignment.mjs release-artifacts/android/check-elf-load-alignment.mjs
           if [[ -f build/app/outputs/mapping/release/mapping.txt ]]; then
@@ -207,6 +208,7 @@ jobs:
             echo "play_generated_apk_device_matrix_evidence=blocked_until_play_generated_apk_device_matrix_gate_is_satisfied"
             echo "post_launch_operations_review_evidence=blocked_until_post_launch_operations_review_gate_is_satisfied"
             echo "support_incident_response_evidence=blocked_until_support_incident_response_gate_is_satisfied"
+            echo "abuse_penetration_rehearsal_evidence=blocked_until_abuse_penetration_rehearsal_gate_is_satisfied"
             echo "toolchain_policy=apps/mobile/release/signed-release-artifact-gate.json"
           } > release-artifacts/android/release-metadata.txt
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Android 출시 후 2시간/24시간/7일/30일 운영 검토는 `apps/mobile/rel
 
 사용자 지원, 데이터 오류, 장애 대응 gate는 `apps/mobile/release/support-incident-response-gate.json`으로 검증합니다. support email/site, FAQ, 장애 공지 문구, 문의 분류 기준, P0 안전 오류 triage, 운영기관 연락 경로, emergency datapack release/rollback, 오래된 신고 retention, duplicate 처리, 잘못된 override 회수 절차가 준비되어야 합니다. 도움말/공지 화면 증거는 로컬 Android emulator에서 screenshot 또는 UI tree로 수집하고, support mailbox 개인 정보, receipt token, 운영기관 private contact, provider credential은 GitHub에 올리지 않습니다.
 
+Abuse-case와 penetration rehearsal gate는 `apps/mobile/release/abuse-penetration-rehearsal-gate.json`으로 검증합니다. Android AAB 또는 Play-generated APK secret/endpoint scan, report photo upload, receipt token, signed URL lifecycle, admin/operator auth, session/CSRF, tenant authorization, distributed rate limit, object storage lifecycle abuse를 확인해야 합니다. rehearsal 증거는 raw receipt token, signed URL, photo binary, provider credential, operator password, session cookie를 제거한 local-only summary로 보관하고 critical/high finding은 0이거나 #900 waiver와 fix plan이 있어야 합니다.
+
 Android 출시 100% 범위와 Go/No-Go 계약은 `apps/mobile/release/release-governance-gate.json`으로 검증합니다. 이번 release blocker는 Android Google Play v1이며 iOS는 `DEFERRED_OUT_OF_SCOPE`로 기록해 Android 출시 완료를 차단하지 않습니다. open Android P0가 있거나 RC evidence의 git SHA, AAB hash, backend artifact, data pack manifest, route/realtime contract가 서로 맞지 않으면 최종 Go 판단을 하지 않습니다.
 
 Android 출시 UX·접근성·성능 gate는 `apps/mobile/release/android-release-quality-gate.json`으로 검증합니다. PR 증거는 local Android emulator evidence를 우선 사용하며, 물리 기기 증거는 Codex PR 증거로 사용하지 않습니다. 실제 Google Play Go 판단 전에는 #907의 exact RC 또는 Play-installed build에서 TalkBack, 150%/200% 글자 크기, 작은 화면, 권한/네트워크/업로드 오류 복구, 노선도 fallback과 성능, 지원 범위/출처 화면, crash/ANR privacy-safe reporting 증거를 다시 수집해야 합니다.

--- a/apps/mobile/release/abuse-penetration-rehearsal-gate.json
+++ b/apps/mobile/release/abuse-penetration-rehearsal-gate.json
@@ -1,0 +1,109 @@
+{
+  "schemaVersion": 1,
+  "applicationId": "easysubway",
+  "androidApplicationId": "com.easysubway.app",
+  "releaseGate": "abuse-penetration-rehearsal",
+  "issue": 925,
+  "status": "BLOCKED_ABUSE_REHEARSAL_EVIDENCE_MISSING",
+  "androidRcEvidenceManifest": "apps/mobile/release/android-rc-store-evidence.json",
+  "securityPrivacyEvidenceManifest": "apps/mobile/release/security-privacy-release-evidence.json",
+  "releaseSecurityGate": "apps/mobile/release/release-security-gate.json",
+  "evidenceRoot": ".codex/evidence/security/abuse-penetration-rehearsal/<rc-or-run>/",
+  "artifactSecretAndEndpointScan": {
+    "requiredArtifacts": [
+      "Android AAB or Play-generated APK",
+      "release merged manifest",
+      "release network endpoint trace",
+      "dependency vulnerability scan result"
+    ],
+    "forbiddenFindings": [
+      "provider secret",
+      "object storage credential",
+      "production password",
+      "signing private key",
+      "receipt token",
+      "signed upload URL",
+      "local or internal endpoint"
+    ],
+    "requiredEvidence": [
+      "android-aab-or-play-apk-secret-scan-output",
+      "release-endpoint-allowlist-diff",
+      "network-trace-redaction-summary"
+    ]
+  },
+  "abuseScenarios": [
+    {
+      "id": "report_photo_upload_abuse",
+      "area": "report-photo",
+      "severity": "release-blocker",
+      "targetKo": "MIME/extension/magic bytes mismatch, oversized image, decompression bomb, duplicate claim, failed claim orphan cleanup",
+      "requiredEvidence": ["malicious-photo-upload-test-output", "orphan-cleanup-request-response-summary"]
+    },
+    {
+      "id": "receipt_token_replay_and_status_abuse",
+      "area": "report-receipt",
+      "severity": "release-blocker",
+      "targetKo": "receipt token guessing, replay, URL/log exposure, cross-report status lookup, confirm endpoint abuse",
+      "requiredEvidence": ["receipt-token-negative-tests", "redacted-request-response-summary", "log-redaction-check"]
+    },
+    {
+      "id": "signed_url_lifecycle_abuse",
+      "area": "object-storage",
+      "severity": "release-blocker",
+      "targetKo": "signed URL reuse, expiry bypass, object key traversal, orphan object persistence, lifecycle cleanup failure",
+      "requiredEvidence": ["signed-url-expiry-test", "object-lifecycle-cleanup-summary", "storage-log-redaction-check"]
+    },
+    {
+      "id": "admin_operator_auth_session_csrf",
+      "area": "admin",
+      "severity": "release-blocker",
+      "targetKo": "admin/operator auth bypass, weak Basic auth exception, session fixation, CSRF on mutating form, tenant authorization confusion",
+      "requiredEvidence": ["admin-auth-tests", "operator-role-negative-tests", "csrf-negative-test-summary"]
+    },
+    {
+      "id": "distributed_rate_limit_abuse",
+      "area": "backend",
+      "severity": "release-blocker",
+      "targetKo": "multi-node report upload/claim/submit/status/confirm flooding and trusted proxy spoofing",
+      "requiredEvidence": ["distributed-abuse-control-test-output", "trusted-proxy-negative-test", "abuse-store-mode-record"]
+    },
+    {
+      "id": "provider_and_release_secret_exposure",
+      "area": "release",
+      "severity": "release-blocker",
+      "targetKo": "provider key, object credential, production password, local/internal endpoint exposure in app artifact, backend image, logs, PR evidence",
+      "requiredEvidence": ["tracked-secret-search", "release-artifact-secret-scan-output", "backend-image-env-redaction-summary"]
+    }
+  ],
+  "manualRehearsalPolicy": {
+    "redactionRequired": true,
+    "requestResponseSummaryOnly": true,
+    "forbiddenInEvidence": [
+      "raw receipt token",
+      "raw signed URL",
+      "photo binary",
+      "provider credential",
+      "operator password",
+      "session cookie"
+    ],
+    "localAndroidEmulatorRequiredForMobileEvidence": true
+  },
+  "findingPolicy": {
+    "criticalHighAllowed": 0,
+    "mediumAllowedOnlyWithOwnerAndFixPlan": true,
+    "waiverIssue": 900,
+    "waiverRequiredFields": ["severity", "owner", "expiry", "compensating-control", "fix-plan"],
+    "goNoGoKo": "critical/high finding이 1건이라도 남아 있으면 release blocker이며, 예외는 #900 waiver와 fix plan이 있어야 한다."
+  },
+  "linkedReleaseGates": [
+    "apps/mobile/release/security-privacy-release-evidence.json",
+    "apps/mobile/release/release-security-gate.json",
+    "apps/mobile/release/signed-release-artifact-gate.json",
+    "apps/mobile/release/android-rc-store-evidence.json"
+  ],
+  "sensitiveEvidencePolicy": {
+    "localOnly": true,
+    "githubUploadPolicy": "summary-only",
+    "summaryRequiredKo": "abuse rehearsal 증거는 민감값을 제거한 command, request/response summary, finding count, local-only evidence path만 PR에 적는다."
+  }
+}

--- a/apps/mobile/release/android-rc-store-evidence.json
+++ b/apps/mobile/release/android-rc-store-evidence.json
@@ -97,6 +97,11 @@
       "support-channel-release-notes-review"
     ],
     "preReviewPreLaunch": [
+      "abuse-penetration-rehearsal-gate-manifest",
+      "android-aab-or-play-apk-secret-scan-output",
+      "report-photo-receipt-signed-url-abuse-summary",
+      "admin-operator-session-csrf-rate-limit-abuse-summary",
+      "critical-high-finding-zero-or-waiver-record",
       "pre-review-critical-issue-0",
       "pre-launch-report-crash-0",
       "policy-warning-0",

--- a/apps/mobile/release/release-security-gate.json
+++ b/apps/mobile/release/release-security-gate.json
@@ -207,6 +207,16 @@
       "linkedArtifacts": ["apps/mobile/pubspec.lock", "apps/mobile/android/app/gradle.lockfile", "apps/mobile/android/app/osv-scanner.toml", "apps/mobile/android/app/build.gradle.kts", "apps/mobile/android/build.gradle.kts", "backend/gradle.lockfile", "backend/osv-scanner.toml", "backend/build.gradle", ".github/workflows/ci.yml"]
     },
     {
+      "id": "repository_abuse_penetration_rehearsal",
+      "area": "repository",
+      "severity": "release-blocker",
+      "titleKo": "출시 전 abuse-case와 penetration rehearsal",
+      "ownerKo": "보안/릴리즈 담당",
+      "readyWhenKo": "Android AAB 또는 Play-generated APK secret scan, report photo/receipt/signed URL abuse, admin/operator auth/session/CSRF, tenant authorization, distributed rate limit, object lifecycle rehearsal 결과가 있고 critical/high finding이 0이거나 #900 waiver와 fix plan이 있다.",
+      "evidence": ["abuse-penetration-rehearsal-gate-manifest", "android-artifact-secret-scan-output", "redacted-abuse-request-response-summary", "critical-high-finding-zero-or-waiver"],
+      "linkedArtifacts": ["apps/mobile/release/abuse-penetration-rehearsal-gate.json", "apps/mobile/release/security-privacy-release-evidence.json", "backend/src/main/java/com/easysubway/common/security/SecurityConfig.java", "backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControl.java", "backend/src/main/java/com/easysubway/report/application/service/FacilityReportPhotoProcessor.java"]
+    },
+    {
       "id": "repository_codex_security_scan_before_release",
       "area": "repository",
       "severity": "release-blocker",

--- a/apps/mobile/release/security-privacy-release-evidence.json
+++ b/apps/mobile/release/security-privacy-release-evidence.json
@@ -28,6 +28,25 @@
     ],
     "androidEvidenceSourceKo": "QA 요청에 따라 실기기가 아니라 로컬 Android emulator에서 앱 실행, UI tree, logcat, network endpoint trace 요약을 수집한다."
   },
+  "abusePenetrationRehearsalGate": "apps/mobile/release/abuse-penetration-rehearsal-gate.json",
+  "abusePenetrationRehearsal": {
+    "requiredScenarios": [
+      "report_photo_upload_abuse",
+      "receipt_token_replay_and_status_abuse",
+      "signed_url_lifecycle_abuse",
+      "admin_operator_auth_session_csrf",
+      "distributed_rate_limit_abuse",
+      "provider_and_release_secret_exposure"
+    ],
+    "criticalHighAllowed": 0,
+    "requiredEvidence": [
+      "android-aab-or-play-apk-secret-scan-output",
+      "redacted-request-response-summary",
+      "admin-auth-csrf-rate-limit-negative-test-output",
+      "object-storage-lifecycle-abuse-summary",
+      "finding-triage-zero-critical-high-or-waiver"
+    ]
+  },
   "maliciousPhotoUploadDefense": {
     "requiredChecks": [
       "MIME type allowlist",

--- a/apps/mobile/release/signed-release-artifact-gate.json
+++ b/apps/mobile/release/signed-release-artifact-gate.json
@@ -10,6 +10,7 @@
   "playGeneratedApkDeviceMatrixGate": "apps/mobile/release/play-generated-apk-device-matrix-gate.json",
   "postLaunchOperationsReviewGate": "apps/mobile/release/post-launch-operations-review-gate.json",
   "supportIncidentResponseGate": "apps/mobile/release/support-incident-response-gate.json",
+  "abusePenetrationRehearsalGate": "apps/mobile/release/abuse-penetration-rehearsal-gate.json",
   "officialRequirements": {
     "android": {
       "targetApiLevelMinimum": 35,
@@ -39,7 +40,8 @@
         "Play production access or closed test requirement satisfaction evidence",
         "Play-generated APK device compatibility matrix evidence",
         "Post-launch 2h/24h/7d/30d operations review evidence",
-        "Support, data correction, incident notice, emergency datapack response evidence"
+        "Support, data correction, incident notice, emergency datapack response evidence",
+        "Abuse-case and penetration rehearsal evidence"
       ]
     },
     "ios": {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -855,6 +855,8 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   const postLaunchOperationsReviewGate = readJson(postLaunchOperationsReviewPath);
   const supportIncidentResponsePath = "apps/mobile/release/support-incident-response-gate.json";
   const supportIncidentResponseGate = readJson(supportIncidentResponsePath);
+  const abusePenetrationRehearsalPath = "apps/mobile/release/abuse-penetration-rehearsal-gate.json";
+  const abusePenetrationRehearsalGate = readJson(abusePenetrationRehearsalPath);
   const workflow = read(".github/workflows/release-artifacts.yml");
   const readme = read("README.md");
 
@@ -869,6 +871,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.equal(gate.playGeneratedApkDeviceMatrixGate, playGeneratedApkDeviceMatrixPath);
   assert.equal(gate.postLaunchOperationsReviewGate, postLaunchOperationsReviewPath);
   assert.equal(gate.supportIncidentResponseGate, supportIncidentResponsePath);
+  assert.equal(gate.abusePenetrationRehearsalGate, abusePenetrationRehearsalPath);
 
   assert.equal(gate.officialRequirements.android.targetApiLevelMinimum, 35);
   assert.equal(gate.officialRequirements.android.requiredFrom, "2025-08-31");
@@ -895,6 +898,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
       "Support, data correction, incident notice, emergency datapack response evidence",
     ),
   );
+  assert.ok(gate.artifacts.android.storeReadyRequires.includes("Abuse-case and penetration rehearsal evidence"));
   assert.equal(playProductionAccessGate.releaseGate, "play-production-access-closed-test");
   assert.equal(playProductionAccessGate.issue, 920);
   assert.equal(playProductionAccessGate.parentEvidenceManifest, androidRcEvidencePath);
@@ -982,6 +986,28 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.ok(supportIncidentResponseGate.retentionDuplicateOverridePolicy.requiredEvidence.includes("override-rollback-sample"));
   assert.ok(supportIncidentResponseGate.dryRunRequiredEvidence.includes("data-error-triage-dry-run"));
   assert.ok(supportIncidentResponseGate.dryRunRequiredEvidence.includes("local-emulator-help-screen-screenshot-or-ui-tree"));
+  assert.equal(abusePenetrationRehearsalGate.releaseGate, "abuse-penetration-rehearsal");
+  assert.equal(abusePenetrationRehearsalGate.issue, 925);
+  assert.equal(abusePenetrationRehearsalGate.status, "BLOCKED_ABUSE_REHEARSAL_EVIDENCE_MISSING");
+  assert.equal(abusePenetrationRehearsalGate.androidRcEvidenceManifest, androidRcEvidencePath);
+  assert.equal(abusePenetrationRehearsalGate.securityPrivacyEvidenceManifest, "apps/mobile/release/security-privacy-release-evidence.json");
+  assert.match(abusePenetrationRehearsalGate.evidenceRoot, /\.codex\/evidence\/security\/abuse-penetration-rehearsal\/<rc-or-run>/);
+  assert.ok(abusePenetrationRehearsalGate.artifactSecretAndEndpointScan.forbiddenFindings.includes("provider secret"));
+  assert.ok(abusePenetrationRehearsalGate.artifactSecretAndEndpointScan.forbiddenFindings.includes("receipt token"));
+  assert.deepEqual(
+    abusePenetrationRehearsalGate.abuseScenarios.map((scenario) => scenario.id).sort(),
+    [
+      "admin_operator_auth_session_csrf",
+      "distributed_rate_limit_abuse",
+      "provider_and_release_secret_exposure",
+      "receipt_token_replay_and_status_abuse",
+      "report_photo_upload_abuse",
+      "signed_url_lifecycle_abuse",
+    ],
+  );
+  assert.equal(abusePenetrationRehearsalGate.manualRehearsalPolicy.localAndroidEmulatorRequiredForMobileEvidence, true);
+  assert.equal(abusePenetrationRehearsalGate.findingPolicy.criticalHighAllowed, 0);
+  assert.equal(abusePenetrationRehearsalGate.findingPolicy.waiverIssue, 900);
   assert.equal(androidRcEvidence.releaseGate, "android-rc-store-evidence");
   assert.equal(androidRcEvidence.releaseBlockerPolicy, true);
   assert.equal(androidRcEvidence.scope.platform.android, "RELEASE_REQUIRED");
@@ -1015,6 +1041,11 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("korean-store-listing-contract"));
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("store-graphic-screenshot-asset-record"));
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("data-safety-binary-network-trace-match"));
+  assert.ok(androidRcEvidence.requiredEvidence.preReviewPreLaunch.includes("abuse-penetration-rehearsal-gate-manifest"));
+  assert.ok(androidRcEvidence.requiredEvidence.preReviewPreLaunch.includes("android-aab-or-play-apk-secret-scan-output"));
+  assert.ok(androidRcEvidence.requiredEvidence.preReviewPreLaunch.includes("report-photo-receipt-signed-url-abuse-summary"));
+  assert.ok(androidRcEvidence.requiredEvidence.preReviewPreLaunch.includes("admin-operator-session-csrf-rate-limit-abuse-summary"));
+  assert.ok(androidRcEvidence.requiredEvidence.preReviewPreLaunch.includes("critical-high-finding-zero-or-waiver-record"));
   assert.ok(androidRcEvidence.requiredEvidence.preReviewPreLaunch.includes("pre-launch-report-crash-0"));
   assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("post-launch-operations-review-gate-manifest"));
   assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("support-incident-response-gate-manifest"));
@@ -1052,6 +1083,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(workflow, /cp release\/play-generated-apk-device-matrix-gate\.json release-artifacts\/android\/play-generated-apk-device-matrix-gate\.json/);
   assert.match(workflow, /cp release\/post-launch-operations-review-gate\.json release-artifacts\/android\/post-launch-operations-review-gate\.json/);
   assert.match(workflow, /cp release\/support-incident-response-gate\.json release-artifacts\/android\/support-incident-response-gate\.json/);
+  assert.match(workflow, /cp release\/abuse-penetration-rehearsal-gate\.json release-artifacts\/android\/abuse-penetration-rehearsal-gate\.json/);
   assert.match(workflow, /cp \.\.\/\.\.\/tools\/mobile\/check-android-aab-16kb-page-size\.sh release-artifacts\/android\/check-android-aab-16kb-page-size\.sh/);
   assert.match(workflow, /cp \.\.\/\.\.\/tools\/mobile\/check-elf-load-alignment\.mjs release-artifacts\/android\/check-elf-load-alignment\.mjs/);
   assert.match(workflow, /page_size_16kb_evidence=blocked_until_tools_mobile_check_android_aab_16kb_page_size_passes_and_runtime_PAGE_SIZE_16384_smoke_passes/);
@@ -1060,6 +1092,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(workflow, /play_generated_apk_device_matrix_evidence=blocked_until_play_generated_apk_device_matrix_gate_is_satisfied/);
   assert.match(workflow, /post_launch_operations_review_evidence=blocked_until_post_launch_operations_review_gate_is_satisfied/);
   assert.match(workflow, /support_incident_response_evidence=blocked_until_support_incident_response_gate_is_satisfied/);
+  assert.match(workflow, /abuse_penetration_rehearsal_evidence=blocked_until_abuse_penetration_rehearsal_gate_is_satisfied/);
   assert.match(workflow, /cp release\/signed-release-artifact-gate\.json release-artifacts\/android\/signed-release-artifact-gate\.json/);
   assert.doesNotMatch(workflow, /signing_key_type=no-codesign/);
   assert.doesNotMatch(workflow, /testflight_evidence=blocked_missing_testflight_or_signed_device_install/);
@@ -1088,6 +1121,9 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(readme, /사용자 지원, 데이터 오류, 장애 대응 gate/);
   assert.match(readme, /support-incident-response-gate\.json/);
   assert.match(readme, /emergency datapack release\/rollback/);
+  assert.match(readme, /Abuse-case와 penetration rehearsal gate/);
+  assert.match(readme, /abuse-penetration-rehearsal-gate\.json/);
+  assert.match(readme, /critical\/high finding/);
 });
 
 test("Android 16 KB page-size gate는 AAB alignment와 16384 runtime smoke 계약을 고정한다", () => {
@@ -5916,6 +5952,7 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   const prodConfig = read("backend/src/main/resources/application-prod.yml");
   const backendAppEnvAllowlist = read("tools/deploy/backend-app-env.allowlist");
   const securityPrivacyEvidence = readJson("apps/mobile/release/security-privacy-release-evidence.json");
+  const abusePenetrationRehearsalGate = readJson("apps/mobile/release/abuse-penetration-rehearsal-gate.json");
 
   assert.equal(gate.schemaVersion, 1);
   assert.equal(gate.applicationId, "easysubway");
@@ -5948,6 +5985,7 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
     "repository_secrets_not_tracked",
     "repository_provider_storage_exposure_guard",
     "repository_dependency_review",
+    "repository_abuse_penetration_rehearsal",
     "repository_codex_security_scan_before_release",
     "cross_store_privacy_security_consistency",
   ];
@@ -5988,6 +6026,17 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.ok(releaseArtifactScanGate.evidence.includes("release-network-trace-review"));
   assert.ok(releaseArtifactScanGate.linkedArtifacts.includes(".github/workflows/release-artifacts.yml"));
   assert.ok(releaseArtifactScanGate.linkedArtifacts.includes("apps/mobile/release/security-privacy-release-evidence.json"));
+  const abuseRehearsalItem = items.get("repository_abuse_penetration_rehearsal");
+  assert.match(abuseRehearsalItem.readyWhenKo, /Android AAB|Play-generated APK|receipt|signed URL|CSRF|distributed rate limit|#900/i);
+  assert.ok(abuseRehearsalItem.evidence.includes("abuse-penetration-rehearsal-gate-manifest"));
+  assert.ok(abuseRehearsalItem.evidence.includes("critical-high-finding-zero-or-waiver"));
+  assert.ok(abuseRehearsalItem.linkedArtifacts.includes("apps/mobile/release/abuse-penetration-rehearsal-gate.json"));
+  assert.equal(securityPrivacyEvidence.abusePenetrationRehearsalGate, "apps/mobile/release/abuse-penetration-rehearsal-gate.json");
+  assert.equal(securityPrivacyEvidence.abusePenetrationRehearsal.criticalHighAllowed, 0);
+  assert.ok(securityPrivacyEvidence.abusePenetrationRehearsal.requiredScenarios.includes("receipt_token_replay_and_status_abuse"));
+  assert.ok(securityPrivacyEvidence.abusePenetrationRehearsal.requiredScenarios.includes("distributed_rate_limit_abuse"));
+  assert.equal(abusePenetrationRehearsalGate.findingPolicy.criticalHighAllowed, 0);
+  assert.equal(abusePenetrationRehearsalGate.findingPolicy.waiverIssue, 900);
   assert.match(commonExceptionHandler, /messages\.message\("common\.error\.invalid-parameter"\)/);
   assert.match(messages, /^common\.error\.invalid-parameter=요청 값을 확인해야 합니다\.$/m);
   assert.doesNotMatch(commonExceptionHandler, /StackTrace|printStackTrace|getStackTrace/);


### PR DESCRIPTION
## 관련 이슈

close #925

## 작업 배경

- 정적 scan과 단위 테스트만으로는 report photo, receipt token, signed URL, admin/operator, distributed rate limit, object lifecycle abuse 가능성을 충분히 확인하기 어렵습니다.
- 출시 전 Android AAB 또는 Play-generated APK와 backend public/admin/report API를 위협 시나리오 기준으로 rehearsal하고, critical/high finding이 남아 있으면 release blocker로 처리해야 합니다.
- raw receipt token, signed URL, photo binary, provider credential, operator password, session cookie는 PR에 올리지 않고 local-only summary로 관리해야 합니다.

## 작업 내용

- `apps/mobile/release/abuse-penetration-rehearsal-gate.json`을 추가해 artifact secret/endpoint scan, report photo, receipt token, signed URL, admin/operator auth/session/CSRF, distributed rate limit, provider/release secret exposure 시나리오를 release blocker로 고정했습니다.
- `security-privacy-release-evidence.json`, `release-security-gate.json`, Android RC evidence, signed release artifact gate가 #925 gate를 참조하도록 연결했습니다.
- Release Artifacts workflow가 #925 gate manifest와 blocked metadata를 Android artifact에 포함하도록 했습니다.
- README와 repository contract test에 finding policy와 local-only evidence 원칙을 추가했습니다.
- codex-security threat model은 local-only로 `/private/tmp/codex-security-scans/swieun-jihacheol/threat_model.md`에 남겼습니다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/ci/*.test.mjs`: exit 0, 115 tests passed
- `git diff --check origin/main`: exit 0
- `gh pr checks 995 --repo AquilaXk/easysubway --watch --interval 20`: CodeRabbit 포함 PR checks 재실행 확인 후 직접 run 조회로 all checks pass 확인
- GitHub Actions CI run `28255576159`: Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan pass
- GitHub Actions Release Artifacts run `28255575715`: Android Release Artifact, Backend Release Image pass
- SonarCloud Code Analysis run `28255575633`: pass
- CodeRabbit: Review completed, check pass
- GitHub review threads: unresolved thread 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| abuse penetration rehearsal 계약 | Local repository | JSON manifest와 repository contract test | `apps/mobile/release/abuse-penetration-rehearsal-gate.json`, `node --test tools/ci/*.test.mjs` | pass, #925 release blocker 계약 고정 |
| Android release artifact 연결 | GitHub Actions config | artifact copy와 metadata 계약 검사 | `.github/workflows/release-artifacts.yml`, Release Artifacts run `28255575715` | pass, artifact에 gate manifest 포함 |
| PR CI와 정적 품질 gate | GitHub Actions | PR checks watch와 workflow run 확인 | CI run `28255576159`, SonarCloud run `28255575633` | pass |
| CodeRabbit review gate | GitHub PR | CodeRabbit check와 review thread 확인 | CodeRabbit check pass, unresolved thread 0 | pass |
| threat model | Local security artifact | codex-security threat-model local artifact | `/private/tmp/codex-security-scans/swieun-jihacheol/threat_model.md` | local-only 작성, git/PR 첨부 없음 |
| artifact scan과 manual abuse rehearsal | Android/backend | AAB/Play APK scan, redacted request/response, admin/rate-limit/object lifecycle rehearsal | local-only evidence 필요: `.codex/evidence/security/abuse-penetration-rehearsal/<rc-or-run>/` | PR에서 수행하지 않음. gate status는 `BLOCKED_ABUSE_REHEARSAL_EVIDENCE_MISSING` |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `artifactSecretAndEndpointScan`, `abuseScenarios`, `manualRehearsalPolicy`, `findingPolicy`입니다.
- 이 PR은 실제 penetration rehearsal를 완료한 PR이 아닙니다. 출시 Go 판단 전 QA가 redacted local-only evidence를 채워야 합니다.

## 리스크

- 실제 Android artifact scan, report/photo/receipt/admin/rate-limit/object lifecycle abuse rehearsal 증거가 없으면 gate는 계속 release blocker입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI code review fallback은 사용하지 않았다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
