### PR TITLE
[CI] RC evidence manifest 자동 생성

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -187,6 +187,7 @@ jobs:
           cp release/post-launch-operations-review-gate.json release-artifacts/android/post-launch-operations-review-gate.json
           cp release/support-incident-response-gate.json release-artifacts/android/support-incident-response-gate.json
           cp release/abuse-penetration-rehearsal-gate.json release-artifacts/android/abuse-penetration-rehearsal-gate.json
+          cp release/rc-evidence-manifest-contract.json release-artifacts/android/rc-evidence-manifest-contract.json
           cp ../../tools/mobile/check-android-aab-16kb-page-size.sh release-artifacts/android/check-android-aab-16kb-page-size.sh
           cp ../../tools/mobile/check-elf-load-alignment.mjs release-artifacts/android/check-elf-load-alignment.mjs
           if [[ -f build/app/outputs/mapping/release/mapping.txt ]]; then
@@ -194,11 +195,25 @@ jobs:
           else
             printf 'mapping=not-generated\n' > release-artifacts/android/mapping.txt
           fi
+          node ../../tools/release/generate-rc-evidence-manifest.mjs \
+            --repo-root ../.. \
+            --app-root . \
+            --aab release-artifacts/android/app-release.aab \
+            --data-pack-manifest assets/datapacks/metro_map_pack/manifest.json \
+            --output release-artifacts/android/rc-evidence-manifest.json \
+            --evidence-root ".codex/evidence/release/rc-evidence-manifest/${GITHUB_SHA}/" \
+            --device local_android_emulator \
+            --android-version android-15-or-16 \
+            --gate-status androidRcEvidence=BLOCKED_EXTERNAL \
+            --gate-status playGeneratedApkDeviceMatrix=BLOCKED_EXTERNAL \
+            --gate-status androidReleaseQuality=BLOCKED_EXTERNAL \
+            --gate-status abusePenetrationRehearsal=BLOCKED_EXTERNAL
           {
             echo "commit=${GITHUB_SHA}"
             echo "artifact=app-release.aab"
             echo "store_ready=false"
             echo "signing_key_type=temporary-self-signed"
+            echo "rc_evidence_manifest=release-artifacts/android/rc-evidence-manifest.json"
             echo "mapping=build/app/outputs/mapping/release/mapping.txt"
             echo "mapping_retention_days=90"
             echo "play_submission_evidence=blocked_missing_internal_track_or_prelaunch_report"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -195,25 +195,12 @@ jobs:
           else
             printf 'mapping=not-generated\n' > release-artifacts/android/mapping.txt
           fi
-          node ../../tools/release/generate-rc-evidence-manifest.mjs \
-            --repo-root ../.. \
-            --app-root . \
-            --aab release-artifacts/android/app-release.aab \
-            --data-pack-manifest assets/datapacks/metro_map_pack/manifest.json \
-            --output release-artifacts/android/rc-evidence-manifest.json \
-            --evidence-root ".codex/evidence/release/rc-evidence-manifest/${GITHUB_SHA}/" \
-            --device local_android_emulator \
-            --android-version android-15-or-16 \
-            --gate-status androidRcEvidence=BLOCKED_EXTERNAL \
-            --gate-status playGeneratedApkDeviceMatrix=BLOCKED_EXTERNAL \
-            --gate-status androidReleaseQuality=BLOCKED_EXTERNAL \
-            --gate-status abusePenetrationRehearsal=BLOCKED_EXTERNAL
           {
             echo "commit=${GITHUB_SHA}"
             echo "artifact=app-release.aab"
             echo "store_ready=false"
             echo "signing_key_type=temporary-self-signed"
-            echo "rc_evidence_manifest=release-artifacts/android/rc-evidence-manifest.json"
+            echo "rc_evidence_manifest=easysubway-rc-evidence-manifest-${GITHUB_SHA}"
             echo "mapping=build/app/outputs/mapping/release/mapping.txt"
             echo "mapping_retention_days=90"
             echo "play_submission_evidence=blocked_missing_internal_track_or_prelaunch_report"
@@ -292,3 +279,73 @@ jobs:
           path: release-artifacts/backend
           if-no-files-found: error
           retention-days: 14
+
+  rc-evidence-manifest:
+    name: RC Evidence Manifest
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - android-release
+      - backend-release
+    if: ${{ always() && (needs.android-release.result == 'success' || needs.backend-release.result == 'success') }}
+
+    steps:
+      - name: RC Evidence Manifest / Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: RC Evidence Manifest / Download Android artifact
+        if: ${{ needs.android-release.result == 'success' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: easysubway-android-release-${{ github.sha }}
+          path: release-artifacts/downloaded/android
+
+      - name: RC Evidence Manifest / Download backend artifact
+        if: ${{ needs.backend-release.result == 'success' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: easysubway-backend-release-${{ github.sha }}
+          path: release-artifacts/downloaded/backend
+
+      - name: RC Evidence Manifest / Generate manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-artifacts/rc
+          generator_args=(
+            --repo-root .
+            --app-root apps/mobile
+            --data-pack-manifest apps/mobile/assets/datapacks/metro_map_pack/manifest.json
+            --output release-artifacts/rc/rc-evidence-manifest.json
+            --evidence-root ".codex/evidence/release/rc-evidence-manifest/${GITHUB_SHA}/"
+            --device local_android_emulator
+            --android-version android-15-or-16
+            --gate-status androidRcEvidence=BLOCKED_EXTERNAL
+            --gate-status playGeneratedApkDeviceMatrix=BLOCKED_EXTERNAL
+            --gate-status androidReleaseQuality=BLOCKED_EXTERNAL
+            --gate-status abusePenetrationRehearsal=BLOCKED_EXTERNAL
+          )
+          if [[ -f release-artifacts/downloaded/android/app-release.aab ]]; then
+            generator_args+=(--aab release-artifacts/downloaded/android/app-release.aab)
+          fi
+          if [[ -f release-artifacts/downloaded/backend/image-inspect.json ]]; then
+            generator_args+=(--backend-image-inspect release-artifacts/downloaded/backend/image-inspect.json)
+          fi
+          node tools/release/generate-rc-evidence-manifest.mjs "${generator_args[@]}"
+          cp apps/mobile/release/rc-evidence-manifest-contract.json release-artifacts/rc/rc-evidence-manifest-contract.json
+          {
+            echo "commit=${GITHUB_SHA}"
+            echo "manifest=rc-evidence-manifest.json"
+            echo "android_artifact_source=easysubway-android-release-${GITHUB_SHA}"
+            echo "backend_artifact_source=easysubway-backend-release-${GITHUB_SHA}"
+          } > release-artifacts/rc/release-metadata.txt
+
+      - name: RC Evidence Manifest / Upload manifest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: easysubway-rc-evidence-manifest-${{ github.sha }}
+          path: release-artifacts/rc
+          if-no-files-found: error
+          retention-days: 90

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Abuse-case와 penetration rehearsal gate는 `apps/mobile/release/abuse-penetrati
 
 Android 출시 100% 범위와 Go/No-Go 계약은 `apps/mobile/release/release-governance-gate.json`으로 검증합니다. 이번 release blocker는 Android Google Play v1이며 iOS는 `DEFERRED_OUT_OF_SCOPE`로 기록해 Android 출시 완료를 차단하지 않습니다. open Android P0가 있거나 RC evidence의 git SHA, AAB hash, backend artifact, data pack manifest, route/realtime contract가 서로 맞지 않으면 최종 Go 판단을 하지 않습니다.
 
+RC evidence manifest는 `apps/mobile/release/rc-evidence-manifest-contract.json`과 `tools/release/generate-rc-evidence-manifest.mjs`로 생성합니다. manifest는 git SHA, app version, versionCode, AAB SHA-256, backend image digest 또는 artifact SHA-256, data pack manifest SHA-256, release sequence, route/realtime contract version, #571/#907/#917 evidence entry를 같은 RC 식별자로 묶습니다. open Android P0, gate status, identity mismatch, evidence entry 누락이 있으면 readiness는 `NO_GO`로 계산되며, Android PR evidence는 물리 기기 대신 로컬 Android emulator 기준으로 남깁니다.
+
 Android 출시 UX·접근성·성능 gate는 `apps/mobile/release/android-release-quality-gate.json`으로 검증합니다. PR 증거는 local Android emulator evidence를 우선 사용하며, 물리 기기 증거는 Codex PR 증거로 사용하지 않습니다. 실제 Google Play Go 판단 전에는 #907의 exact RC 또는 Play-installed build에서 TalkBack, 150%/200% 글자 크기, 작은 화면, 권한/네트워크/업로드 오류 복구, 노선도 fallback과 성능, 지원 범위/출처 화면, crash/ANR privacy-safe reporting 증거를 다시 수집해야 합니다.
 
 ## Privacy Policy

--- a/apps/mobile/release/android-rc-store-evidence.json
+++ b/apps/mobile/release/android-rc-store-evidence.json
@@ -34,6 +34,7 @@
   },
   "requiredEvidence": {
     "signingAndIdentity": [
+      "rc-evidence-manifest",
       "package-id-app-name-versionName-versionCode-record",
       "production-upload-key-material-owner-record",
       "play-app-signing-enrollment",

--- a/apps/mobile/release/rc-evidence-manifest-contract.json
+++ b/apps/mobile/release/rc-evidence-manifest-contract.json
@@ -1,0 +1,65 @@
+{
+  "schemaVersion": 1,
+  "applicationId": "easysubway",
+  "androidApplicationId": "com.easysubway.app",
+  "releaseGate": "rc-evidence-manifest",
+  "issue": 926,
+  "parentIssues": [900, 907],
+  "linkedEvidenceIssues": [571, 907, 917],
+  "androidRcEvidenceManifest": "apps/mobile/release/android-rc-store-evidence.json",
+  "signedReleaseArtifactGate": "apps/mobile/release/signed-release-artifact-gate.json",
+  "releaseGovernanceGate": "apps/mobile/release/release-governance-gate.json",
+  "generator": "tools/release/generate-rc-evidence-manifest.mjs",
+  "requiredRcIdentityFields": [
+    "gitSha",
+    "appVersionName",
+    "versionCode",
+    "aabSha256",
+    "dataPackManifestSha256",
+    "releaseSequence",
+    "routeContractVersion",
+    "realtimeContractVersion"
+  ],
+  "backendIdentityFieldsAnyOf": ["backendImageDigest", "backendArtifactSha256"],
+  "requiredEvidenceEntryFields": [
+    "id",
+    "sourceIssue",
+    "device",
+    "androidVersion",
+    "testedAt",
+    "evidencePaths",
+    "expiresWhen"
+  ],
+  "requiredEvidenceEntries": [
+    {
+      "id": "rc_device_qa",
+      "sourceIssue": 571,
+      "expiresAfterDays": 14
+    },
+    {
+      "id": "signed_rc_store_submission",
+      "sourceIssue": 907,
+      "expiresAfterDays": 14
+    },
+    {
+      "id": "android_release_quality",
+      "sourceIssue": 917,
+      "expiresAfterDays": 14
+    }
+  ],
+  "readinessPolicy": {
+    "openAndroidP0BlocksGo": true,
+    "nonSatisfiedGateBlocksGo": true,
+    "identityMismatchBlocksGo": true,
+    "missingRequiredIdentityBlocksGo": true,
+    "missingRequiredEvidenceEntryBlocksGo": true,
+    "goStatus": "GO",
+    "noGoStatus": "NO_GO"
+  },
+  "evidencePolicy": {
+    "localOnlyEvidenceRoot": ".codex/evidence/release/rc-evidence-manifest/<rc-or-run>/",
+    "githubUploadPolicy": "summary-or-public-workflow-link",
+    "sensitiveEvidencePolicy": "local_path_with_reason",
+    "androidDeviceEvidence": "local_android_emulator_only_for_codex_pr_evidence"
+  }
+}

--- a/apps/mobile/release/release-governance-gate.json
+++ b/apps/mobile/release/release-governance-gate.json
@@ -40,7 +40,6 @@
     "appVersionName",
     "versionCode",
     "aabSha256",
-    "backendArtifactSha256",
     "dataPackManifestSha256",
     "releaseSequence",
     "routeContractVersion",
@@ -51,6 +50,7 @@
     "evidencePaths",
     "expiresWhen"
   ],
+  "requiredRcEvidenceBackendIdentityFieldsAnyOf": ["backendImageDigest", "backendArtifactSha256"],
   "rcEvidenceManifestContract": "apps/mobile/release/rc-evidence-manifest-contract.json",
   "releaseReadiness": {
     "openAndroidP0BlocksGo": true,

--- a/apps/mobile/release/release-governance-gate.json
+++ b/apps/mobile/release/release-governance-gate.json
@@ -51,6 +51,7 @@
     "evidencePaths",
     "expiresWhen"
   ],
+  "rcEvidenceManifestContract": "apps/mobile/release/rc-evidence-manifest-contract.json",
   "releaseReadiness": {
     "openAndroidP0BlocksGo": true,
     "iosBlocksAndroidRelease": false,

--- a/apps/mobile/release/signed-release-artifact-gate.json
+++ b/apps/mobile/release/signed-release-artifact-gate.json
@@ -5,6 +5,7 @@
   "releaseGate": "mobile-signed-release-artifacts",
   "storeReadyStatus": "blocked_external_distribution_evidence_missing",
   "androidRcEvidenceManifest": "apps/mobile/release/android-rc-store-evidence.json",
+  "rcEvidenceManifestContract": "apps/mobile/release/rc-evidence-manifest-contract.json",
   "androidPageSize16kbGate": "apps/mobile/release/android-16kb-page-size-gate.json",
   "playProductionAccessGate": "apps/mobile/release/play-production-access-gate.json",
   "playGeneratedApkDeviceMatrixGate": "apps/mobile/release/play-generated-apk-device-matrix-gate.json",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -857,6 +857,8 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   const supportIncidentResponseGate = readJson(supportIncidentResponsePath);
   const abusePenetrationRehearsalPath = "apps/mobile/release/abuse-penetration-rehearsal-gate.json";
   const abusePenetrationRehearsalGate = readJson(abusePenetrationRehearsalPath);
+  const rcEvidenceManifestContractPath = "apps/mobile/release/rc-evidence-manifest-contract.json";
+  const rcEvidenceManifestContract = readJson(rcEvidenceManifestContractPath);
   const workflow = read(".github/workflows/release-artifacts.yml");
   const readme = read("README.md");
 
@@ -866,6 +868,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.equal(gate.releaseGate, "mobile-signed-release-artifacts");
   assert.equal(gate.storeReadyStatus, "blocked_external_distribution_evidence_missing");
   assert.equal(gate.androidRcEvidenceManifest, androidRcEvidencePath);
+  assert.equal(gate.rcEvidenceManifestContract, rcEvidenceManifestContractPath);
   assert.equal(gate.androidPageSize16kbGate, "apps/mobile/release/android-16kb-page-size-gate.json");
   assert.equal(gate.playProductionAccessGate, playProductionAccessPath);
   assert.equal(gate.playGeneratedApkDeviceMatrixGate, playGeneratedApkDeviceMatrixPath);
@@ -1010,6 +1013,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.equal(abusePenetrationRehearsalGate.findingPolicy.waiverIssue, 900);
   assert.equal(androidRcEvidence.releaseGate, "android-rc-store-evidence");
   assert.equal(androidRcEvidence.releaseBlockerPolicy, true);
+  assert.ok(androidRcEvidence.requiredEvidence.signingAndIdentity.includes("rc-evidence-manifest"));
   assert.equal(androidRcEvidence.scope.platform.android, "RELEASE_REQUIRED");
   assert.equal(androidRcEvidence.scope.platform.ios, "DEFERRED_OUT_OF_SCOPE");
   assert.deepEqual(androidRcEvidence.scope.distributionFlow, [
@@ -1060,6 +1064,37 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("emergency-datapack-release-rollback-runbook-match"));
   assert.ok(androidRcEvidence.requiredEvidence.postReleaseReadiness.includes("retention-duplicate-override-recovery-policy"));
   assert.ok(androidRcEvidence.evidencePolicy.localOnlyEvidenceRoot.startsWith(".codex/evidence/"));
+  assert.equal(rcEvidenceManifestContract.releaseGate, "rc-evidence-manifest");
+  assert.equal(rcEvidenceManifestContract.issue, 926);
+  assert.deepEqual(rcEvidenceManifestContract.parentIssues, [900, 907]);
+  assert.deepEqual(rcEvidenceManifestContract.linkedEvidenceIssues, [571, 907, 917]);
+  assert.equal(rcEvidenceManifestContract.androidRcEvidenceManifest, androidRcEvidencePath);
+  assert.equal(rcEvidenceManifestContract.signedReleaseArtifactGate, gatePath);
+  assert.equal(rcEvidenceManifestContract.releaseGovernanceGate, "apps/mobile/release/release-governance-gate.json");
+  assert.equal(rcEvidenceManifestContract.generator, "tools/release/generate-rc-evidence-manifest.mjs");
+  for (const field of [
+    "gitSha",
+    "appVersionName",
+    "versionCode",
+    "aabSha256",
+    "dataPackManifestSha256",
+    "releaseSequence",
+    "routeContractVersion",
+    "realtimeContractVersion",
+  ]) {
+    assert.ok(rcEvidenceManifestContract.requiredRcIdentityFields.includes(field), `${field} must be required`);
+  }
+  assert.deepEqual(rcEvidenceManifestContract.backendIdentityFieldsAnyOf, ["backendImageDigest", "backendArtifactSha256"]);
+  for (const field of ["device", "androidVersion", "testedAt", "evidencePaths", "expiresWhen"]) {
+    assert.ok(rcEvidenceManifestContract.requiredEvidenceEntryFields.includes(field), `${field} must be required`);
+  }
+  assert.deepEqual(
+    rcEvidenceManifestContract.requiredEvidenceEntries.map((entry) => entry.sourceIssue).sort(),
+    [571, 907, 917],
+  );
+  assert.equal(rcEvidenceManifestContract.readinessPolicy.openAndroidP0BlocksGo, true);
+  assert.equal(rcEvidenceManifestContract.readinessPolicy.identityMismatchBlocksGo, true);
+  assert.equal(rcEvidenceManifestContract.evidencePolicy.androidDeviceEvidence, "local_android_emulator_only_for_codex_pr_evidence");
 
   assert.equal(gate.artifacts.ios.format, "Runner.app.zip");
   assert.equal(gate.artifacts.ios.ciArtifactStoreReady, false);
@@ -1084,6 +1119,10 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(workflow, /cp release\/post-launch-operations-review-gate\.json release-artifacts\/android\/post-launch-operations-review-gate\.json/);
   assert.match(workflow, /cp release\/support-incident-response-gate\.json release-artifacts\/android\/support-incident-response-gate\.json/);
   assert.match(workflow, /cp release\/abuse-penetration-rehearsal-gate\.json release-artifacts\/android\/abuse-penetration-rehearsal-gate\.json/);
+  assert.match(workflow, /cp release\/rc-evidence-manifest-contract\.json release-artifacts\/android\/rc-evidence-manifest-contract\.json/);
+  assert.match(workflow, /node \.\.\/\.\.\/tools\/release\/generate-rc-evidence-manifest\.mjs/);
+  assert.match(workflow, /--output release-artifacts\/android\/rc-evidence-manifest\.json/);
+  assert.match(workflow, /--evidence-root "\.codex\/evidence\/release\/rc-evidence-manifest\/\$\{GITHUB_SHA\}\/"/);
   assert.match(workflow, /cp \.\.\/\.\.\/tools\/mobile\/check-android-aab-16kb-page-size\.sh release-artifacts\/android\/check-android-aab-16kb-page-size\.sh/);
   assert.match(workflow, /cp \.\.\/\.\.\/tools\/mobile\/check-elf-load-alignment\.mjs release-artifacts\/android\/check-elf-load-alignment\.mjs/);
   assert.match(workflow, /page_size_16kb_evidence=blocked_until_tools_mobile_check_android_aab_16kb_page_size_passes_and_runtime_PAGE_SIZE_16384_smoke_passes/);
@@ -1093,6 +1132,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(workflow, /post_launch_operations_review_evidence=blocked_until_post_launch_operations_review_gate_is_satisfied/);
   assert.match(workflow, /support_incident_response_evidence=blocked_until_support_incident_response_gate_is_satisfied/);
   assert.match(workflow, /abuse_penetration_rehearsal_evidence=blocked_until_abuse_penetration_rehearsal_gate_is_satisfied/);
+  assert.match(workflow, /rc_evidence_manifest=release-artifacts\/android\/rc-evidence-manifest\.json/);
   assert.match(workflow, /cp release\/signed-release-artifact-gate\.json release-artifacts\/android\/signed-release-artifact-gate\.json/);
   assert.doesNotMatch(workflow, /signing_key_type=no-codesign/);
   assert.doesNotMatch(workflow, /testflight_evidence=blocked_missing_testflight_or_signed_device_install/);
@@ -1124,6 +1164,97 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(readme, /Abuse-case와 penetration rehearsal gate/);
   assert.match(readme, /abuse-penetration-rehearsal-gate\.json/);
   assert.match(readme, /critical\/high finding/);
+  assert.match(readme, /RC evidence manifest/);
+  assert.match(readme, /generate-rc-evidence-manifest\.mjs/);
+  assert.match(readme, /#571\/#907\/#917 evidence entry/);
+  assert.match(readme, /로컬 Android emulator 기준/);
+});
+
+test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성한다", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "easysubway-rc-manifest-"));
+  const aabPath = path.join(tempDir, "app-release.aab");
+  const backendInspectPath = path.join(tempDir, "image-inspect.json");
+  const outputPath = path.join(tempDir, "rc-evidence-manifest.json");
+
+  await writeFile(aabPath, "fake-aab");
+  await writeFile(
+    backendInspectPath,
+    JSON.stringify([{ RepoDigests: ["ghcr.io/aquilaxk/easysubway-backend@sha256:abcdef"] }]),
+  );
+
+  await execFileAsync(process.execPath, [
+    "tools/release/generate-rc-evidence-manifest.mjs",
+    "--repo-root",
+    ".",
+    "--app-root",
+    "apps/mobile",
+    "--git-sha",
+    "0123456789abcdef0123456789abcdef01234567",
+    "--aab",
+    aabPath,
+    "--backend-image-inspect",
+    backendInspectPath,
+    "--data-pack-manifest",
+    "apps/mobile/assets/datapacks/metro_map_pack/manifest.json",
+    "--output",
+    outputPath,
+    "--tested-at",
+    "2026-06-26T00:00:00.000Z",
+    "--device",
+    "local_android_emulator",
+    "--android-version",
+    "Android 16 API 36",
+    "--gate-status",
+    "androidRcEvidence=BLOCKED_EXTERNAL",
+  ], { cwd: root });
+
+  const manifest = JSON.parse(readFileSync(outputPath, "utf8"));
+  assert.equal(manifest.releaseGate, "rc-evidence-manifest");
+  assert.equal(manifest.issue, 926);
+  assert.equal(manifest.gitSha, "0123456789abcdef0123456789abcdef01234567");
+  assert.equal(manifest.appVersionName, "1.0.0");
+  assert.equal(manifest.versionCode, "1");
+  assert.match(manifest.aabSha256, /^[a-f0-9]{64}$/);
+  assert.equal(manifest.backendImageDigest, "sha256:abcdef");
+  assert.match(manifest.backendArtifactSha256, /^[a-f0-9]{64}$/);
+  assert.match(manifest.dataPackManifestSha256, /^[a-f0-9]{64}$/);
+  assert.equal(manifest.routeContractVersion, "route-map-contract-v1");
+  assert.equal(manifest.realtimeContractVersion, "seoul-topis-schema-v1");
+  assert.equal(manifest.readiness.status, "NO_GO");
+  assert.ok(manifest.readiness.blockers.map((blocker) => blocker.id).includes("gate_androidrcevidence_blocked_external"));
+  assert.deepEqual(
+    manifest.evidenceEntries.map((entry) => entry.sourceIssue).sort(),
+    [571, 907, 917],
+  );
+  assert.ok(manifest.evidenceEntries.every((entry) => entry.device === "local_android_emulator"));
+  assert.ok(manifest.evidenceEntries.every((entry) => entry.androidVersion === "Android 16 API 36"));
+  assert.ok(manifest.evidenceEntries.every((entry) => entry.testedAt === "2026-06-26T00:00:00.000Z"));
+  assert.ok(manifest.evidenceEntries.every((entry) => entry.expiresWhen === "2026-07-10T00:00:00.000Z"));
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "tools/release/generate-rc-evidence-manifest.mjs",
+      "--repo-root",
+      ".",
+      "--app-root",
+      "apps/mobile",
+      "--git-sha",
+      "0123456789abcdef0123456789abcdef01234567",
+      "--aab",
+      aabPath,
+      "--backend-image-inspect",
+      backendInspectPath,
+      "--data-pack-manifest",
+      "apps/mobile/assets/datapacks/metro_map_pack/manifest.json",
+      "--output",
+      path.join(tempDir, "mismatch.json"),
+      "--expect",
+      "gitSha=ffffffffffffffffffffffffffffffffffffffff",
+      "--fail-on-blocked",
+      "true",
+    ], { cwd: root }),
+    /mismatch_gitSha/,
+  );
 });
 
 test("Android 16 KB page-size gate는 AAB alignment와 16384 runtime smoke 계약을 고정한다", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1120,8 +1120,14 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(workflow, /cp release\/support-incident-response-gate\.json release-artifacts\/android\/support-incident-response-gate\.json/);
   assert.match(workflow, /cp release\/abuse-penetration-rehearsal-gate\.json release-artifacts\/android\/abuse-penetration-rehearsal-gate\.json/);
   assert.match(workflow, /cp release\/rc-evidence-manifest-contract\.json release-artifacts\/android\/rc-evidence-manifest-contract\.json/);
-  assert.match(workflow, /node \.\.\/\.\.\/tools\/release\/generate-rc-evidence-manifest\.mjs/);
-  assert.match(workflow, /--output release-artifacts\/android\/rc-evidence-manifest\.json/);
+  assert.match(workflow, /rc-evidence-manifest:/);
+  assert.match(workflow, /name: RC Evidence Manifest/);
+  assert.match(workflow, /uses: actions\/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093/);
+  assert.match(workflow, /name: easysubway-android-release-\$\{\{ github\.sha \}\}/);
+  assert.match(workflow, /name: easysubway-backend-release-\$\{\{ github\.sha \}\}/);
+  assert.match(workflow, /node tools\/release\/generate-rc-evidence-manifest\.mjs "\$\{generator_args\[@\]\}"/);
+  assert.match(workflow, /--output release-artifacts\/rc\/rc-evidence-manifest\.json/);
+  assert.match(workflow, /--backend-image-inspect release-artifacts\/downloaded\/backend\/image-inspect\.json/);
   assert.match(workflow, /--evidence-root "\.codex\/evidence\/release\/rc-evidence-manifest\/\$\{GITHUB_SHA\}\/"/);
   assert.match(workflow, /cp \.\.\/\.\.\/tools\/mobile\/check-android-aab-16kb-page-size\.sh release-artifacts\/android\/check-android-aab-16kb-page-size\.sh/);
   assert.match(workflow, /cp \.\.\/\.\.\/tools\/mobile\/check-elf-load-alignment\.mjs release-artifacts\/android\/check-elf-load-alignment\.mjs/);
@@ -1132,7 +1138,8 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.match(workflow, /post_launch_operations_review_evidence=blocked_until_post_launch_operations_review_gate_is_satisfied/);
   assert.match(workflow, /support_incident_response_evidence=blocked_until_support_incident_response_gate_is_satisfied/);
   assert.match(workflow, /abuse_penetration_rehearsal_evidence=blocked_until_abuse_penetration_rehearsal_gate_is_satisfied/);
-  assert.match(workflow, /rc_evidence_manifest=release-artifacts\/android\/rc-evidence-manifest\.json/);
+  assert.match(workflow, /rc_evidence_manifest=easysubway-rc-evidence-manifest-\$\{GITHUB_SHA\}/);
+  assert.match(workflow, /name: easysubway-rc-evidence-manifest-\$\{\{ github\.sha \}\}/);
   assert.match(workflow, /cp release\/signed-release-artifact-gate\.json release-artifacts\/android\/signed-release-artifact-gate\.json/);
   assert.doesNotMatch(workflow, /signing_key_type=no-codesign/);
   assert.doesNotMatch(workflow, /testflight_evidence=blocked_missing_testflight_or_signed_device_install/);
@@ -1175,6 +1182,8 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   const aabPath = path.join(tempDir, "app-release.aab");
   const backendInspectPath = path.join(tempDir, "image-inspect.json");
   const outputPath = path.join(tempDir, "rc-evidence-manifest.json");
+  const appVersion = read("apps/mobile/pubspec.yaml").match(/^version:\s*([^+\s]+)\+([0-9]+)\s*$/m);
+  assert.ok(appVersion, "mobile pubspec must contain versionName+versionCode");
 
   await writeFile(aabPath, "fake-aab");
   await writeFile(
@@ -1212,11 +1221,11 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   assert.equal(manifest.releaseGate, "rc-evidence-manifest");
   assert.equal(manifest.issue, 926);
   assert.equal(manifest.gitSha, "0123456789abcdef0123456789abcdef01234567");
-  assert.equal(manifest.appVersionName, "1.0.0");
-  assert.equal(manifest.versionCode, "1");
+  assert.equal(manifest.appVersionName, appVersion[1]);
+  assert.equal(manifest.versionCode, appVersion[2]);
   assert.match(manifest.aabSha256, /^[a-f0-9]{64}$/);
   assert.equal(manifest.backendImageDigest, "sha256:abcdef");
-  assert.match(manifest.backendArtifactSha256, /^[a-f0-9]{64}$/);
+  assert.equal(manifest.backendArtifactSha256, null);
   assert.match(manifest.dataPackManifestSha256, /^[a-f0-9]{64}$/);
   assert.equal(manifest.routeContractVersion, "route-map-contract-v1");
   assert.equal(manifest.realtimeContractVersion, "seoul-topis-schema-v1");
@@ -1354,7 +1363,6 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "appVersionName",
     "versionCode",
     "aabSha256",
-    "backendArtifactSha256",
     "dataPackManifestSha256",
     "releaseSequence",
     "routeContractVersion",
@@ -1365,6 +1373,7 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "evidencePaths",
     "expiresWhen",
   ]);
+  assert.deepEqual(gate.requiredRcEvidenceBackendIdentityFieldsAnyOf, ["backendImageDigest", "backendArtifactSha256"]);
 
   assert.equal(gate.releaseReadiness.openAndroidP0BlocksGo, true);
   assert.equal(gate.releaseReadiness.iosBlocksAndroidRelease, false);

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -27,7 +26,7 @@ const dataPackManifest = readJsonIfExists(dataPackManifestPath);
 const backendIdentity = readBackendIdentity(args);
 const gateStatuses = parsePairs(arg("gateStatus", "gate-status"));
 const expectedValues = parsePairs(args.expect);
-const gitSha = arg("gitSha", "git-sha") ?? process.env.GITHUB_SHA ?? gitRevParse(repoRoot);
+const gitSha = arg("gitSha", "git-sha") ?? process.env.GITHUB_SHA ?? requiredGitSha();
 
 const identity = {
   gitSha,
@@ -288,8 +287,8 @@ function evidenceBlockers(entries) {
     }));
 }
 
-function gitRevParse(rootDir) {
-  return execFileSync("git", ["rev-parse", "HEAD"], { cwd: rootDir, encoding: "utf8" }).trim();
+function requiredGitSha() {
+  fail("--git-sha or GITHUB_SHA is required");
 }
 
 function fail(message) {

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -169,7 +169,7 @@ function readBackendIdentity(parsedArgs) {
   const repoDigest = firstImage?.RepoDigests?.find((digest) => digest.includes("@sha256:"));
   return {
     backendImageDigest: repoDigest?.split("@").at(-1) ?? null,
-    backendArtifactSha256: createHash("sha256").update(readFileSync(inspectPath)).digest("hex"),
+    backendArtifactSha256: null,
   };
 }
 

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+const cwd = process.cwd();
+const repoRoot = resolvePath(arg("repoRoot", "repo-root") ?? ".");
+const appRoot = resolvePath(arg("appRoot", "app-root") ?? path.join(repoRoot, "apps/mobile"));
+const outputPath = args.output ? resolvePath(args.output) : null;
+
+if (!outputPath) {
+  fail("--output is required");
+}
+
+const testedAt = arg("testedAt", "tested-at") ?? new Date().toISOString();
+const evidenceRoot = normalizeEvidenceRoot(
+  arg("evidenceRoot", "evidence-root") ?? ".codex/evidence/release/rc-evidence-manifest/<rc-or-run>/",
+);
+const appVersion = readFlutterVersion(path.join(appRoot, "pubspec.yaml"));
+const dataPackManifestPath = resolvePath(
+  arg("dataPackManifest", "data-pack-manifest") ?? path.join(appRoot, "assets/datapacks/metro_map_pack/manifest.json"),
+);
+const dataPackManifest = readJsonIfExists(dataPackManifestPath);
+const backendIdentity = readBackendIdentity(args);
+const gateStatuses = parsePairs(arg("gateStatus", "gate-status"));
+const expectedValues = parsePairs(args.expect);
+const gitSha = arg("gitSha", "git-sha") ?? process.env.GITHUB_SHA ?? gitRevParse(repoRoot);
+
+const identity = {
+  gitSha,
+  appVersionName: appVersion.name,
+  versionCode: appVersion.code,
+  aabSha256: sha256FileIfExists(args.aab),
+  backendImageDigest: backendIdentity.backendImageDigest,
+  backendArtifactSha256: backendIdentity.backendArtifactSha256,
+  dataPackManifestSha256: sha256FileIfExists(dataPackManifestPath),
+  releaseSequence: arg("releaseSequence", "release-sequence") ?? dataPackManifest?.releaseSequence ?? dataPackManifest?.pack_version ?? null,
+  routeContractVersion: arg("routeContractVersion", "route-contract-version") ?? "route-map-contract-v1",
+  realtimeContractVersion: arg("realtimeContractVersion", "realtime-contract-version") ?? readRealtimeContractVersion(repoRoot),
+};
+
+const evidenceEntries = requiredEvidenceEntries(testedAt, evidenceRoot, args.device, arg("androidVersion", "android-version"));
+const blockers = [
+  ...identityBlockers(identity),
+  ...expectedMismatchBlockers(identity, expectedValues),
+  ...gateStatusBlockers(gateStatuses),
+  ...openP0Blockers(arg("openAndroidP0Count", "open-android-p0-count")),
+  ...evidenceBlockers(evidenceEntries),
+];
+
+const manifest = {
+  schemaVersion: 1,
+  releaseGate: "rc-evidence-manifest",
+  issue: 926,
+  applicationId: "easysubway",
+  androidApplicationId: "com.easysubway.app",
+  generatedAt: new Date().toISOString(),
+  ...identity,
+  rcIdentity: identity,
+  evidenceEntries,
+  readiness: {
+    status: blockers.length === 0 ? "GO" : "NO_GO",
+    gateStatus: blockers.length === 0 ? "SATISFIED" : "BLOCKED_RC_EVIDENCE",
+    blockers,
+    openAndroidP0Count: Number.parseInt(arg("openAndroidP0Count", "open-android-p0-count") ?? "0", 10),
+    gateStatuses,
+  },
+  sourceManifests: {
+    androidRcEvidenceManifest: "apps/mobile/release/android-rc-store-evidence.json",
+    signedReleaseArtifactGate: "apps/mobile/release/signed-release-artifact-gate.json",
+    releaseGovernanceGate: "apps/mobile/release/release-governance-gate.json",
+    dataPackManifest: path.relative(repoRoot, dataPackManifestPath),
+  },
+};
+
+mkdirSync(path.dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+if (arg("failOnBlocked", "fail-on-blocked") === "true" && blockers.length > 0) {
+  fail(`RC evidence manifest is blocked: ${blockers.map((blocker) => blocker.id).join(", ")}`);
+}
+
+function parseArgs(values) {
+  const parsed = {};
+  for (let index = 0; index < values.length; index += 1) {
+    const raw = values[index];
+    if (!raw.startsWith("--")) {
+      fail(`Unexpected argument: ${raw}`);
+    }
+    const withoutPrefix = raw.slice(2);
+    const equalsIndex = withoutPrefix.indexOf("=");
+    const key = equalsIndex === -1 ? withoutPrefix : withoutPrefix.slice(0, equalsIndex);
+    const value = equalsIndex === -1 ? values[++index] : withoutPrefix.slice(equalsIndex + 1);
+    if (value === undefined || value.startsWith("--")) {
+      fail(`Missing value for --${key}`);
+    }
+    if (parsed[key] === undefined) {
+      parsed[key] = value;
+    } else if (Array.isArray(parsed[key])) {
+      parsed[key].push(value);
+    } else {
+      parsed[key] = [parsed[key], value];
+    }
+  }
+  return parsed;
+}
+
+function resolvePath(value) {
+  return path.resolve(cwd, value);
+}
+
+function arg(camelName, kebabName) {
+  return args[camelName] ?? args[kebabName];
+}
+
+function readFlutterVersion(pubspecPath) {
+  const pubspec = readFileSync(pubspecPath, "utf8");
+  const match = pubspec.match(/^version:\s*([0-9A-Za-z.+-]+)\s*$/m);
+  if (!match) {
+    fail(`version not found in ${pubspecPath}`);
+  }
+  const [name, code] = match[1].split("+");
+  if (!name || !code) {
+    fail(`Flutter version must include build number: ${match[1]}`);
+  }
+  return { name, code };
+}
+
+function sha256FileIfExists(filePath) {
+  if (!filePath) {
+    return null;
+  }
+  const resolved = resolvePath(filePath);
+  if (!existsSync(resolved)) {
+    return null;
+  }
+  return createHash("sha256").update(readFileSync(resolved)).digest("hex");
+}
+
+function readJsonIfExists(filePath) {
+  if (!filePath || !existsSync(filePath)) {
+    return null;
+  }
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function readBackendIdentity(parsedArgs) {
+  const backendImageDigest = arg("backendImageDigest", "backend-image-digest");
+  const backendArtifact = arg("backendArtifact", "backend-artifact");
+  const backendImageInspect = arg("backendImageInspect", "backend-image-inspect");
+  if (backendImageDigest) {
+    return { backendImageDigest, backendArtifactSha256: null };
+  }
+  if (backendArtifact) {
+    return { backendImageDigest: null, backendArtifactSha256: sha256FileIfExists(backendArtifact) };
+  }
+  if (!backendImageInspect) {
+    return { backendImageDigest: null, backendArtifactSha256: null };
+  }
+
+  const inspectPath = resolvePath(backendImageInspect);
+  if (!existsSync(inspectPath)) {
+    return { backendImageDigest: null, backendArtifactSha256: null };
+  }
+  const inspect = JSON.parse(readFileSync(inspectPath, "utf8"));
+  const firstImage = Array.isArray(inspect) ? inspect[0] : inspect;
+  const repoDigest = firstImage?.RepoDigests?.find((digest) => digest.includes("@sha256:"));
+  return {
+    backendImageDigest: repoDigest?.split("@").at(-1) ?? null,
+    backendArtifactSha256: createHash("sha256").update(readFileSync(inspectPath)).digest("hex"),
+  };
+}
+
+function readRealtimeContractVersion(rootDir) {
+  const contract = readJsonIfExists(path.join(rootDir, "tools/realtime/seoul-topis-provider-contract.json"));
+  if (!contract) {
+    return "realtime-contract-v1";
+  }
+  return `${contract.providerId ?? "realtime"}-schema-v${contract.schemaVersion ?? 1}`;
+}
+
+function parsePairs(value) {
+  const values = value === undefined ? [] : Array.isArray(value) ? value : [value];
+  return Object.fromEntries(values.map((entry) => {
+    const separatorIndex = entry.indexOf("=");
+    if (separatorIndex === -1) {
+      fail(`Expected key=value pair: ${entry}`);
+    }
+    return [entry.slice(0, separatorIndex), entry.slice(separatorIndex + 1)];
+  }));
+}
+
+function requiredEvidenceEntries(baseTestedAt, rootPath, device, androidVersion) {
+  const sourceEntries = [
+    ["rc_device_qa", 571],
+    ["signed_rc_store_submission", 907],
+    ["android_release_quality", 917],
+  ];
+  return sourceEntries.map(([id, sourceIssue]) => ({
+    id,
+    sourceIssue,
+    device: device ?? "local_android_emulator",
+    androidVersion: androidVersion ?? "android-15-or-16",
+    testedAt: baseTestedAt,
+    evidencePaths: [`${rootPath}${id}/`],
+    expiresWhen: addDays(baseTestedAt, 14),
+    status: "PENDING_LOCAL_EVIDENCE",
+  }));
+}
+
+function normalizeEvidenceRoot(rootPath) {
+  return rootPath.endsWith("/") ? rootPath : `${rootPath}/`;
+}
+
+function addDays(isoDate, days) {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) {
+    fail(`Invalid testedAt value: ${isoDate}`);
+  }
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString();
+}
+
+function identityBlockers(values) {
+  const required = [
+    "gitSha",
+    "appVersionName",
+    "versionCode",
+    "aabSha256",
+    "dataPackManifestSha256",
+    "releaseSequence",
+    "routeContractVersion",
+    "realtimeContractVersion",
+  ];
+  const blockers = required
+    .filter((field) => !values[field])
+    .map((field) => ({ id: `missing_${field}`, severity: "P0", reason: `${field} is required for RC identity` }));
+  if (!values.backendImageDigest && !values.backendArtifactSha256) {
+    blockers.push({
+      id: "missing_backend_identity",
+      severity: "P0",
+      reason: "backendImageDigest or backendArtifactSha256 is required for RC identity",
+    });
+  }
+  return blockers;
+}
+
+function expectedMismatchBlockers(values, expected) {
+  return Object.entries(expected)
+    .filter(([key, expectedValue]) => `${values[key] ?? ""}` !== expectedValue)
+    .map(([key, expectedValue]) => ({
+      id: `mismatch_${key}`,
+      severity: "P0",
+      reason: `${key} expected ${expectedValue} but got ${values[key] ?? "missing"}`,
+    }));
+}
+
+function gateStatusBlockers(statuses) {
+  return Object.entries(statuses)
+    .filter(([, status]) => status !== "SATISFIED" && status !== "DEFERRED_OUT_OF_SCOPE")
+    .map(([gate, status]) => ({
+      id: `gate_${gate}_${status}`.toLowerCase(),
+      severity: "P0",
+      reason: `${gate} gate status is ${status}`,
+    }));
+}
+
+function openP0Blockers(value) {
+  const count = Number.parseInt(value ?? "0", 10);
+  if (Number.isNaN(count) || count < 0) {
+    fail("--open-android-p0-count must be a non-negative integer");
+  }
+  return count > 0
+    ? [{ id: "open_android_p0", severity: "P0", reason: `${count} Android P0 issue(s) are open` }]
+    : [];
+}
+
+function evidenceBlockers(entries) {
+  return entries
+    .filter((entry) => entry.status !== "SATISFIED")
+    .map((entry) => ({
+      id: `pending_${entry.id}`,
+      severity: "P0",
+      reason: `Evidence entry ${entry.id} from #${entry.sourceIssue} is not satisfied`,
+    }));
+}
+
+function gitRevParse(rootDir) {
+  return execFileSync("git", ["rev-parse", "HEAD"], { cwd: rootDir, encoding: "utf8" }).trim();
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}


### PR DESCRIPTION
## 관련 이슈

close AquilaXk/easysubway#926

## 작업 배경

- 출시 Go/No-Go 판단에서 AAB, backend artifact, data pack manifest, route/realtime contract, 수동 evidence가 서로 다른 RC를 가리키면 검증 결과를 신뢰할 수 없습니다.
- AquilaXk/easysubway-mobile#7, AquilaXk/easysubway#907, AquilaXk/easysubway#917 evidence를 하나의 RC identity로 묶고, open Android P0와 gate status를 기준으로 `GO`/`NO_GO`를 계산하는 manifest가 필요합니다.
- Android PR evidence는 QA 요청에 따라 물리 기기 대신 로컬 Android emulator 기준으로 기록해야 합니다.

## 작업 내용

- `apps/mobile/release/rc-evidence-manifest-contract.json`으로 AquilaXk/easysubway#926 manifest schema, linked evidence issue, readiness blocker 정책, local emulator evidence 정책을 고정했습니다.
- `tools/release/generate-rc-evidence-manifest.mjs`를 추가해 git SHA, Flutter version, AAB SHA-256, backend image digest 또는 artifact SHA-256, data pack manifest SHA-256, release sequence, route/realtime contract version, evidence entry, readiness blocker를 생성합니다.
- Release Artifacts workflow가 Android/backend artifact 업로드 후 별도 `RC Evidence Manifest` job에서 두 artifact를 다운로드하고 `rc-evidence-manifest.json`을 생성하도록 연결했습니다.
- 기존 Android RC evidence, release governance, signed artifact gate가 RC evidence manifest 계약을 참조하도록 연결했습니다.
- CodeRabbit 지적에 따라 backend identity any-of 계약을 governance gate와 맞추고, image inspect JSON 해시를 artifact SHA로 쓰지 않도록 수정했습니다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/ci/repository-contract.test.mjs`: exit 0, 112 tests passed
- `node --test tools/ci/*.test.mjs`: exit 0, 116 tests passed
- `git diff --check origin/main`: exit 0
- GitHub Actions CI run `28257561625`: Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan pass
- GitHub Actions Release Artifacts run `28257561397`: Android Release Artifact, Backend Release Image, RC Evidence Manifest pass
- SonarCloud run `28257561395`: automatic-analysis pass, SonarCloud Code Analysis pass
- CodeRabbit: Review completed, check pass
- CodeRabbit review threads: 4개 해결 답글 작성 후 resolved

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| RC manifest schema | Local repository | 계약 JSON과 repository contract test | `apps/mobile/release/rc-evidence-manifest-contract.json`, `node --test tools/ci/*.test.mjs` | pass |
| RC identity 생성 | Local repository | generator fixture 실행 | `tools/release/generate-rc-evidence-manifest.mjs`, repository contract test temp output | pass, git SHA/AAB/backend/datapack/route/realtime identity 생성 |
| mismatch Go/No-Go 차단 | Local repository | `--expect gitSha=... --fail-on-blocked true` 실패 검증 | repository contract test | pass, mismatch blocker 생성 |
| Release Artifacts 연결 | GitHub Actions | workflow run 확인 | Release Artifacts run `28257561397`, `RC Evidence Manifest` job | pass |
| Android emulator evidence 정책 | Release contract | manifest contract와 README 확인 | `androidDeviceEvidence=local_android_emulator_only_for_codex_pr_evidence`, README | pass, 물리 기기 증거 사용 안 함 |
| CodeRabbit review gate | GitHub PR | check와 review thread 확인 | CodeRabbit pass, review thread 4개 resolved | pass |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `readBackendIdentity`, `expectedMismatchBlockers`, Release Artifacts의 `RC Evidence Manifest` job입니다.
- 이 PR은 실제 RC 수동 evidence를 수집하지 않습니다. 실제 Go 판단 전에는 생성된 manifest의 pending evidence entry를 AquilaXk/easysubway-mobile#7/#907/#917 evidence로 채워야 합니다.

## 리스크

- Android/backend artifact 중 하나가 없는 run에서는 manifest가 생성되더라도 해당 identity blocker가 남습니다. 최종 Go 판단에서는 Android AAB와 backend image digest 또는 backend artifact SHA-256이 모두 들어간 manifest를 사용해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI code review fallback은 사용하지 않았다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
