### PR TITLE
[Feat] 관리자 RBAC 권한과 메뉴 registry 도입

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/authorization/AdminAuthorization.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/AdminAuthorization.java
@@ -13,8 +13,15 @@ public final class AdminAuthorization {
 	}
 
 	public static Set<String> authoritiesFor(AdminIdentityRole identityRole) {
+		return authoritiesFor(identityRole, Set.of());
+	}
+
+	public static Set<String> authoritiesFor(AdminIdentityRole identityRole, Set<String> assignedAuthorities) {
 		if (identityRole == AdminIdentityRole.OPERATOR_ADMIN) {
 			return Set.of();
+		}
+		if (assignedAuthorities != null && !assignedAuthorities.isEmpty()) {
+			return Set.copyOf(assignedAuthorities);
 		}
 		AdminRbacRole role = AdminRbacRole.SUPER_ADMIN;
 		return role.permissions().stream()

--- a/backend/src/main/java/com/easysubway/admin/authorization/AdminAuthorization.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/AdminAuthorization.java
@@ -1,0 +1,33 @@
+package com.easysubway.admin.authorization;
+
+import com.easysubway.admin.identity.domain.AdminIdentityRole;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.security.core.Authentication;
+
+public final class AdminAuthorization {
+
+	private static final String ADMIN_ROLE_AUTHORITY = "ROLE_ADMIN";
+
+	private AdminAuthorization() {
+	}
+
+	public static Set<String> authoritiesFor(AdminIdentityRole identityRole) {
+		if (identityRole == AdminIdentityRole.OPERATOR_ADMIN) {
+			return Set.of();
+		}
+		AdminRbacRole role = AdminRbacRole.SUPER_ADMIN;
+		return role.permissions().stream()
+			.map(AdminPermission::authority)
+			.collect(Collectors.toUnmodifiableSet());
+	}
+
+	public static boolean hasPermission(Authentication authentication, AdminPermission permission) {
+		if (authentication == null || permission == null) {
+			return false;
+		}
+		return authentication.getAuthorities().stream()
+			.anyMatch(authority -> permission.authority().equals(authority.getAuthority())
+				|| ADMIN_ROLE_AUTHORITY.equals(authority.getAuthority()));
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/authorization/AdminAuthorization.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/AdminAuthorization.java
@@ -7,8 +7,6 @@ import org.springframework.security.core.Authentication;
 
 public final class AdminAuthorization {
 
-	private static final String ADMIN_ROLE_AUTHORITY = "ROLE_ADMIN";
-
 	private AdminAuthorization() {
 	}
 
@@ -34,7 +32,6 @@ public final class AdminAuthorization {
 			return false;
 		}
 		return authentication.getAuthorities().stream()
-			.anyMatch(authority -> permission.authority().equals(authority.getAuthority())
-				|| ADMIN_ROLE_AUTHORITY.equals(authority.getAuthority()));
+			.anyMatch(authority -> permission.authority().equals(authority.getAuthority()));
 	}
 }

--- a/backend/src/main/java/com/easysubway/admin/authorization/AdminAuthorization.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/AdminAuthorization.java
@@ -18,11 +18,11 @@ public final class AdminAuthorization {
 		if (identityRole == AdminIdentityRole.OPERATOR_ADMIN) {
 			return Set.of();
 		}
-		if (assignedAuthorities != null && !assignedAuthorities.isEmpty()) {
-			return Set.copyOf(assignedAuthorities);
-		}
-		AdminRbacRole role = AdminRbacRole.SUPER_ADMIN;
-		return role.permissions().stream()
+		return assignedAuthorities == null ? Set.of() : Set.copyOf(assignedAuthorities);
+	}
+
+	public static Set<String> superAdminAuthorities() {
+		return AdminRbacRole.SUPER_ADMIN.permissions().stream()
 			.map(AdminPermission::authority)
 			.collect(Collectors.toUnmodifiableSet());
 	}

--- a/backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java
@@ -1,0 +1,21 @@
+package com.easysubway.admin.authorization;
+
+public enum AdminPermission {
+	ADMIN_VIEW("admin.view"),
+	REPORT_REVIEW("admin.report.review"),
+	MASTER_EDIT("admin.master.edit"),
+	FIELD_OPERATE("admin.field.operate"),
+	DATA_OPERATE("admin.data.operate"),
+	SECURITY_AUDIT("admin.security.audit"),
+	SECURITY_ADMIN("admin.security.admin");
+
+	private final String authority;
+
+	AdminPermission(String authority) {
+		this.authority = authority;
+	}
+
+	public String authority() {
+		return authority;
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/authorization/AdminRbacRole.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/AdminRbacRole.java
@@ -1,0 +1,25 @@
+package com.easysubway.admin.authorization;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+
+public enum AdminRbacRole {
+	ADMIN_VIEWER(AdminPermission.ADMIN_VIEW),
+	REPORT_REVIEWER(AdminPermission.ADMIN_VIEW, AdminPermission.REPORT_REVIEW),
+	MASTER_EDITOR(AdminPermission.ADMIN_VIEW, AdminPermission.MASTER_EDIT),
+	FIELD_OPERATOR(AdminPermission.ADMIN_VIEW, AdminPermission.FIELD_OPERATE),
+	DATA_OPERATOR(AdminPermission.ADMIN_VIEW, AdminPermission.DATA_OPERATE),
+	SECURITY_ADMIN(AdminPermission.ADMIN_VIEW, AdminPermission.SECURITY_AUDIT, AdminPermission.SECURITY_ADMIN),
+	SUPER_ADMIN(AdminPermission.values());
+
+	private final Set<AdminPermission> permissions;
+
+	AdminRbacRole(AdminPermission... permissions) {
+		this.permissions = Set.copyOf(EnumSet.copyOf(Arrays.asList(permissions)));
+	}
+
+	public Set<AdminPermission> permissions() {
+		return permissions;
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/authorization/adapter/out/persistence/InMemoryAdminRbacAuthorityRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/adapter/out/persistence/InMemoryAdminRbacAuthorityRepository.java
@@ -1,0 +1,29 @@
+package com.easysubway.admin.authorization.adapter.out.persistence;
+
+import com.easysubway.admin.authorization.application.port.out.AdminRbacAuthorityRepository;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("!prod")
+public class InMemoryAdminRbacAuthorityRepository implements AdminRbacAuthorityRepository {
+
+	private final ConcurrentMap<String, Set<String>> authoritiesByLoginId = new ConcurrentHashMap<>();
+
+	@Override
+	public Set<String> findPermissionAuthorities(String loginId) {
+		return authoritiesByLoginId.getOrDefault(normalize(loginId), Set.of());
+	}
+
+	public void replacePermissionAuthorities(String loginId, Set<String> authorities) {
+		authoritiesByLoginId.put(normalize(loginId), Set.copyOf(authorities));
+	}
+
+	private static String normalize(String loginId) {
+		return loginId == null ? "" : loginId.trim().toLowerCase(Locale.ROOT);
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/authorization/adapter/out/persistence/InMemoryAdminRbacAuthorityRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/adapter/out/persistence/InMemoryAdminRbacAuthorityRepository.java
@@ -1,16 +1,23 @@
 package com.easysubway.admin.authorization.adapter.out.persistence;
 
+import com.easysubway.admin.authorization.AdminPermission;
 import com.easysubway.admin.authorization.application.port.out.AdminRbacAuthorityRepository;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @Profile("!prod")
 public class InMemoryAdminRbacAuthorityRepository implements AdminRbacAuthorityRepository {
+
+	private static final Set<String> VALID_AUTHORITIES = Arrays.stream(AdminPermission.values())
+		.map(AdminPermission::authority)
+		.collect(Collectors.toUnmodifiableSet());
 
 	private final ConcurrentMap<String, Set<String>> authoritiesByLoginId = new ConcurrentHashMap<>();
 
@@ -20,7 +27,11 @@ public class InMemoryAdminRbacAuthorityRepository implements AdminRbacAuthorityR
 	}
 
 	public void replacePermissionAuthorities(String loginId, Set<String> authorities) {
-		authoritiesByLoginId.put(normalize(loginId), Set.copyOf(authorities));
+		Set<String> assignedAuthorities = authorities == null ? Set.of() : Set.copyOf(authorities);
+		if (!VALID_AUTHORITIES.containsAll(assignedAuthorities)) {
+			throw new IllegalArgumentException("선언되지 않은 관리자 permission authority가 포함되어 있습니다.");
+		}
+		authoritiesByLoginId.put(normalize(loginId), assignedAuthorities);
 	}
 
 	private static String normalize(String loginId) {

--- a/backend/src/main/java/com/easysubway/admin/authorization/adapter/out/persistence/JdbcAdminRbacAuthorityRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/adapter/out/persistence/JdbcAdminRbacAuthorityRepository.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -15,6 +16,7 @@ public class JdbcAdminRbacAuthorityRepository implements AdminRbacAuthorityRepos
 
 	private final JdbcTemplate jdbcTemplate;
 
+	@Autowired
 	public JdbcAdminRbacAuthorityRepository(DataSource dataSource) {
 		this.jdbcTemplate = new JdbcTemplate(dataSource);
 	}

--- a/backend/src/main/java/com/easysubway/admin/authorization/adapter/out/persistence/JdbcAdminRbacAuthorityRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/adapter/out/persistence/JdbcAdminRbacAuthorityRepository.java
@@ -1,0 +1,37 @@
+package com.easysubway.admin.authorization.adapter.out.persistence;
+
+import com.easysubway.admin.authorization.application.port.out.AdminRbacAuthorityRepository;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("prod")
+public class JdbcAdminRbacAuthorityRepository implements AdminRbacAuthorityRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public JdbcAdminRbacAuthorityRepository(DataSource dataSource) {
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+
+	@Override
+	public Set<String> findPermissionAuthorities(String loginId) {
+		return jdbcTemplate.queryForList("""
+			SELECT DISTINCT rp.permission_code
+			FROM admin_user_roles ur
+			JOIN admin_role_permissions rp ON rp.role_code = ur.role_code
+			WHERE ur.login_id = ?
+			""", String.class, normalize(loginId))
+			.stream()
+			.collect(Collectors.toUnmodifiableSet());
+	}
+
+	private static String normalize(String loginId) {
+		return loginId == null ? "" : loginId.trim().toLowerCase(Locale.ROOT);
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/authorization/application/port/out/AdminRbacAuthorityRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/application/port/out/AdminRbacAuthorityRepository.java
@@ -1,0 +1,8 @@
+package com.easysubway.admin.authorization.application.port.out;
+
+import java.util.Set;
+
+public interface AdminRbacAuthorityRepository {
+
+	Set<String> findPermissionAuthorities(String loginId);
+}

--- a/backend/src/main/java/com/easysubway/admin/identity/application/service/AdminIdentityUserDetailsService.java
+++ b/backend/src/main/java/com/easysubway/admin/identity/application/service/AdminIdentityUserDetailsService.java
@@ -1,9 +1,11 @@
 package com.easysubway.admin.identity.application.service;
 
+import com.easysubway.admin.authorization.AdminAuthorization;
 import com.easysubway.admin.identity.application.port.out.AdminIdentityRepository;
 import com.easysubway.admin.identity.domain.AdminIdentity;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Locale;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -41,9 +43,12 @@ public class AdminIdentityUserDetailsService implements UserDetailsService, User
 
 	private UserDetails toUserDetails(AdminIdentity identity) {
 		LocalDateTime now = LocalDateTime.now(clock);
+		var authorities = new ArrayList<String>();
+		authorities.add("ROLE_" + identity.role().name().toUpperCase(Locale.ROOT));
+		authorities.addAll(AdminAuthorization.authoritiesFor(identity.role()));
 		return User.withUsername(identity.loginId())
 			.password(identity.passwordHash())
-			.authorities("ROLE_" + identity.role().name().toUpperCase(Locale.ROOT))
+			.authorities(authorities.toArray(String[]::new))
 			.disabled(identity.disabled())
 			.accountLocked(identity.lockedAt(now))
 			.accountExpired(false)

--- a/backend/src/main/java/com/easysubway/admin/identity/application/service/AdminIdentityUserDetailsService.java
+++ b/backend/src/main/java/com/easysubway/admin/identity/application/service/AdminIdentityUserDetailsService.java
@@ -1,6 +1,7 @@
 package com.easysubway.admin.identity.application.service;
 
 import com.easysubway.admin.authorization.AdminAuthorization;
+import com.easysubway.admin.authorization.application.port.out.AdminRbacAuthorityRepository;
 import com.easysubway.admin.identity.application.port.out.AdminIdentityRepository;
 import com.easysubway.admin.identity.domain.AdminIdentity;
 import java.time.Clock;
@@ -16,6 +17,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 public class AdminIdentityUserDetailsService implements UserDetailsService, UserDetailsPasswordService {
 
 	private final AdminIdentityRepository adminIdentityRepository;
+	private final AdminRbacAuthorityRepository adminRbacAuthorityRepository;
 	private final UserDetailsService fallbackUserDetailsService;
 	private final Clock clock;
 
@@ -24,7 +26,17 @@ public class AdminIdentityUserDetailsService implements UserDetailsService, User
 		UserDetailsService fallbackUserDetailsService,
 		Clock clock
 	) {
+		this(adminIdentityRepository, loginId -> java.util.Set.of(), fallbackUserDetailsService, clock);
+	}
+
+	public AdminIdentityUserDetailsService(
+		AdminIdentityRepository adminIdentityRepository,
+		AdminRbacAuthorityRepository adminRbacAuthorityRepository,
+		UserDetailsService fallbackUserDetailsService,
+		Clock clock
+	) {
 		this.adminIdentityRepository = adminIdentityRepository;
+		this.adminRbacAuthorityRepository = adminRbacAuthorityRepository;
 		this.fallbackUserDetailsService = fallbackUserDetailsService;
 		this.clock = clock;
 	}
@@ -45,7 +57,10 @@ public class AdminIdentityUserDetailsService implements UserDetailsService, User
 		LocalDateTime now = LocalDateTime.now(clock);
 		var authorities = new ArrayList<String>();
 		authorities.add("ROLE_" + identity.role().name().toUpperCase(Locale.ROOT));
-		authorities.addAll(AdminAuthorization.authoritiesFor(identity.role()));
+		authorities.addAll(AdminAuthorization.authoritiesFor(
+			identity.role(),
+			adminRbacAuthorityRepository.findPermissionAuthorities(identity.loginId())
+		));
 		return User.withUsername(identity.loginId())
 			.password(identity.passwordHash())
 			.authorities(authorities.toArray(String[]::new))

--- a/backend/src/main/java/com/easysubway/admin/identity/application/service/AdminIdentityUserDetailsService.java
+++ b/backend/src/main/java/com/easysubway/admin/identity/application/service/AdminIdentityUserDetailsService.java
@@ -4,6 +4,7 @@ import com.easysubway.admin.authorization.AdminAuthorization;
 import com.easysubway.admin.authorization.application.port.out.AdminRbacAuthorityRepository;
 import com.easysubway.admin.identity.application.port.out.AdminIdentityRepository;
 import com.easysubway.admin.identity.domain.AdminIdentity;
+import com.easysubway.admin.identity.domain.AdminIdentityRole;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -57,10 +58,14 @@ public class AdminIdentityUserDetailsService implements UserDetailsService, User
 		LocalDateTime now = LocalDateTime.now(clock);
 		var authorities = new ArrayList<String>();
 		authorities.add("ROLE_" + identity.role().name().toUpperCase(Locale.ROOT));
+		var assignedAuthorities = adminRbacAuthorityRepository.findPermissionAuthorities(identity.loginId());
 		authorities.addAll(AdminAuthorization.authoritiesFor(
 			identity.role(),
-			adminRbacAuthorityRepository.findPermissionAuthorities(identity.loginId())
+			assignedAuthorities
 		));
+		if (identity.role() == AdminIdentityRole.ADMIN && identity.bootstrapManaged() && assignedAuthorities.isEmpty()) {
+			authorities.addAll(AdminAuthorization.superAdminAuthorities());
+		}
 		return User.withUsername(identity.loginId())
 			.password(identity.passwordHash())
 			.authorities(authorities.toArray(String[]::new))

--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminNavigationAdvice.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminNavigationAdvice.java
@@ -1,5 +1,6 @@
 package com.easysubway.admin.navigation;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.security.core.Authentication;
@@ -14,5 +15,22 @@ class AdminNavigationAdvice {
 		return AdminProgram.visibleTo(authentication).stream()
 			.map(AdminProgram::id)
 			.collect(Collectors.toUnmodifiableSet());
+	}
+
+	@ModelAttribute("adminProgramGroups")
+	List<AdminProgramGroup> adminProgramGroups(Authentication authentication) {
+		return AdminProgram.visibleTo(authentication).stream()
+			.collect(Collectors.groupingBy(
+				AdminProgram::groupLabel,
+				java.util.LinkedHashMap::new,
+				Collectors.toList()
+			))
+			.entrySet()
+			.stream()
+			.map(entry -> new AdminProgramGroup(entry.getKey(), entry.getValue()))
+			.toList();
+	}
+
+	record AdminProgramGroup(String label, List<AdminProgram> programs) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminNavigationAdvice.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminNavigationAdvice.java
@@ -1,0 +1,18 @@
+package com.easysubway.admin.navigation;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@ControllerAdvice
+class AdminNavigationAdvice {
+
+	@ModelAttribute("adminProgramIds")
+	Set<String> adminProgramIds(Authentication authentication) {
+		return AdminProgram.visibleTo(authentication).stream()
+			.map(AdminProgram::id)
+			.collect(Collectors.toUnmodifiableSet());
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
@@ -1,0 +1,63 @@
+package com.easysubway.admin.navigation;
+
+import com.easysubway.admin.authorization.AdminAuthorization;
+import com.easysubway.admin.authorization.AdminPermission;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.security.core.Authentication;
+
+public enum AdminProgram {
+	DASHBOARD("a-dashboard", "접속·개요", "통합 대시보드", "/admin/dashboard/page", AdminPermission.ADMIN_VIEW),
+	STATIONS("a-stations", "역·시설 마스터", "역 목록", "/admin/stations/page", AdminPermission.ADMIN_VIEW),
+	FACILITIES("a-facilities", "역·시설 마스터", "시설 상태판", "/admin/facilities/page", AdminPermission.ADMIN_VIEW),
+	LAYOUT_EDITOR("a-layout-editor", "역·시설 마스터", "역 구조·동선 편집", "/admin/stations/page", AdminPermission.MASTER_EDIT),
+	REPORTS("a-reports", "제보·품질·검증", "제보 검수 큐", "/admin/reports/page", AdminPermission.REPORT_REVIEW),
+	QUALITY("a-quality", "제보·품질·검증", "데이터 품질", "/admin/data-quality/page", AdminPermission.ADMIN_VIEW),
+	FIELD("a-field-verifications", "제보·품질·검증", "현장 검증", "/admin/field-verifications/page", AdminPermission.FIELD_OPERATE),
+	COLLECTIONS("a-collections", "운영·분석", "데이터 수집", "/admin/data-collections/page", AdminPermission.DATA_OPERATE),
+	ROUTE_SEARCHES("a-route-searches", "운영·분석", "경로 검색 분석", "/admin/routes/searches/page", AdminPermission.ADMIN_VIEW),
+	ROUTE_FEEDBACK("a-route-feedback", "운영·분석", "경로 피드백 분석", "/admin/routes/feedback/page", AdminPermission.ADMIN_VIEW),
+	PUSH("a-push", "운영·분석", "푸시 알림", "/admin/notifications/push/page", AdminPermission.DATA_OPERATE),
+	USAGE("a-usage", "운영·분석", "사용 현황", "/admin/usage/activity/page", AdminPermission.SECURITY_AUDIT),
+	SYSTEM("a-system", "운영·분석", "시스템 상태", "/admin/system/page", AdminPermission.SECURITY_AUDIT);
+
+	private final String id;
+	private final String groupLabel;
+	private final String label;
+	private final String path;
+	private final AdminPermission permission;
+
+	AdminProgram(String id, String groupLabel, String label, String path, AdminPermission permission) {
+		this.id = id;
+		this.groupLabel = groupLabel;
+		this.label = label;
+		this.path = path;
+		this.permission = permission;
+	}
+
+	public String id() {
+		return id;
+	}
+
+	public String groupLabel() {
+		return groupLabel;
+	}
+
+	public String label() {
+		return label;
+	}
+
+	public String path() {
+		return path;
+	}
+
+	public AdminPermission permission() {
+		return permission;
+	}
+
+	public static List<AdminProgram> visibleTo(Authentication authentication) {
+		return Arrays.stream(values())
+			.filter(program -> AdminAuthorization.hasPermission(authentication, program.permission))
+			.toList();
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
@@ -10,7 +10,7 @@ public enum AdminProgram {
 	DASHBOARD("a-dashboard", "접속·개요", "통합 대시보드", "/admin/dashboard/page", AdminPermission.ADMIN_VIEW),
 	STATIONS("a-stations", "역·시설 마스터", "역 목록", "/admin/stations/page", AdminPermission.ADMIN_VIEW),
 	FACILITIES("a-facilities", "역·시설 마스터", "시설 상태판", "/admin/facilities/page", AdminPermission.ADMIN_VIEW),
-	LAYOUT_EDITOR("a-layout-editor", "역·시설 마스터", "역 구조·동선 편집", "/admin/stations/page", AdminPermission.MASTER_EDIT),
+	LAYOUT_EDITOR("a-layout-editor", "역·시설 마스터", "역 구조·동선 편집", "/admin/facilities/editor/page", AdminPermission.MASTER_EDIT),
 	REPORTS("a-reports", "제보·품질·검증", "제보 검수 큐", "/admin/reports/page", AdminPermission.REPORT_REVIEW),
 	QUALITY("a-quality", "제보·품질·검증", "데이터 품질", "/admin/data-quality/page", AdminPermission.ADMIN_VIEW),
 	FIELD("a-field-verifications", "제보·품질·검증", "현장 검증", "/admin/field-verifications/page", AdminPermission.FIELD_OPERATE),

--- a/backend/src/main/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageController.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -36,6 +37,7 @@ class DataCollectionAdminPageController {
 	}
 
 	@PostMapping("/admin/data-collections/page/run")
+	@PreAuthorize("hasAuthority('admin.data.operate') or hasRole('ADMIN')")
 	String runCollectionFromPage(
 		@RequestParam DataCollectionSource source,
 		Principal principal

--- a/backend/src/main/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageController.java
@@ -37,7 +37,7 @@ class DataCollectionAdminPageController {
 	}
 
 	@PostMapping("/admin/data-collections/page/run")
-	@PreAuthorize("hasAuthority('admin.data.operate') or hasRole('ADMIN')")
+	@PreAuthorize("hasAuthority('admin.data.operate')")
 	String runCollectionFromPage(
 		@RequestParam DataCollectionSource source,
 		Principal principal

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.easysubway.common.security;
 
 import com.easysubway.admin.authorization.AdminPermission;
+import com.easysubway.admin.authorization.application.port.out.AdminRbacAuthorityRepository;
 import com.easysubway.admin.identity.application.port.out.AdminIdentityRepository;
 import com.easysubway.admin.identity.application.service.AdminIdentityUserDetailsService;
 import com.easysubway.admin.identity.domain.AdminIdentity;
@@ -59,6 +60,18 @@ public class SecurityConfig {
 				.requestMatchers("/admin/login").permitAll()
 				.requestMatchers(HttpMethod.POST, "/admin/reports/**")
 				.hasAnyAuthority(AdminPermission.REPORT_REVIEW.authority(), "ROLE_ADMIN")
+				.requestMatchers(HttpMethod.GET, "/admin/reports/**")
+				.hasAnyAuthority(AdminPermission.REPORT_REVIEW.authority(), "ROLE_ADMIN")
+				.requestMatchers(
+					HttpMethod.GET,
+					"/admin/facilities/editor/page",
+					"/admin/stations/*/layouts/page",
+					"/admin/stations/*/layout-sources",
+					"/admin/stations/*/layouts",
+					"/admin/stations/*/route-nodes",
+					"/admin/stations/*/route-edges"
+				)
+				.hasAnyAuthority(AdminPermission.MASTER_EDIT.authority(), "ROLE_ADMIN")
 				.requestMatchers(HttpMethod.POST, "/admin/facilities/**", "/admin/stations/**")
 				.hasAnyAuthority(AdminPermission.MASTER_EDIT.authority(), "ROLE_ADMIN")
 				.requestMatchers(HttpMethod.PUT, "/admin/facilities/**", "/admin/stations/**")
@@ -69,8 +82,17 @@ public class SecurityConfig {
 				.hasAnyAuthority(AdminPermission.FIELD_OPERATE.authority(), "ROLE_ADMIN")
 				.requestMatchers(HttpMethod.PATCH, "/admin/field-verifications/**")
 				.hasAnyAuthority(AdminPermission.FIELD_OPERATE.authority(), "ROLE_ADMIN")
+				.requestMatchers(HttpMethod.GET, "/admin/field-verifications/**")
+				.hasAnyAuthority(AdminPermission.FIELD_OPERATE.authority(), "ROLE_ADMIN")
 				.requestMatchers(
 					HttpMethod.POST,
+					"/admin/data-collections/**",
+					"/admin/data-sources/**",
+					"/admin/notifications/**"
+				)
+				.hasAnyAuthority(AdminPermission.DATA_OPERATE.authority(), "ROLE_ADMIN")
+				.requestMatchers(
+					HttpMethod.GET,
 					"/admin/data-collections/**",
 					"/admin/data-sources/**",
 					"/admin/notifications/**"
@@ -196,6 +218,7 @@ public class SecurityConfig {
 		@Value("${easysubway.admin.basic-auth.exception-owner:}") String basicAuthExceptionOwner,
 		@Value("${easysubway.admin.basic-auth.exception-expires-at:}") String basicAuthExceptionExpiresAt,
 		AdminIdentityRepository adminIdentityRepository,
+		AdminRbacAuthorityRepository adminRbacAuthorityRepository,
 		PasswordEncoder passwordEncoder,
 		Environment environment
 	) {
@@ -250,7 +273,49 @@ public class SecurityConfig {
 				.roles("USER")
 				.build());
 		}
-		return new AdminIdentityUserDetailsService(adminIdentityRepository, users, Clock.systemUTC());
+		return new AdminIdentityUserDetailsService(
+			adminIdentityRepository,
+			adminRbacAuthorityRepository,
+			users,
+			Clock.systemUTC()
+		);
+	}
+
+	UserDetailsService userDetailsService(
+		String adminUsername,
+		String adminPassword,
+		String breakGlassUsername,
+		String breakGlassPassword,
+		String breakGlassReason,
+		String operatorUsername,
+		String operatorPassword,
+		String userUsername,
+		String userPassword,
+		boolean basicAuthEnabled,
+		String basicAuthExceptionOwner,
+		String basicAuthExceptionExpiresAt,
+		AdminIdentityRepository adminIdentityRepository,
+		PasswordEncoder passwordEncoder,
+		Environment environment
+	) {
+		return userDetailsService(
+			adminUsername,
+			adminPassword,
+			breakGlassUsername,
+			breakGlassPassword,
+			breakGlassReason,
+			operatorUsername,
+			operatorPassword,
+			userUsername,
+			userPassword,
+			basicAuthEnabled,
+			basicAuthExceptionOwner,
+			basicAuthExceptionExpiresAt,
+			adminIdentityRepository,
+			loginId -> Set.of(),
+			passwordEncoder,
+			environment
+		);
 	}
 
 	@Bean

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.easysubway.common.security;
 
+import com.easysubway.admin.authorization.AdminPermission;
 import com.easysubway.admin.identity.application.port.out.AdminIdentityRepository;
 import com.easysubway.admin.identity.application.service.AdminIdentityUserDetailsService;
 import com.easysubway.admin.identity.domain.AdminIdentity;
@@ -21,11 +22,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -39,6 +42,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
 	@Bean
@@ -53,7 +57,28 @@ public class SecurityConfig {
 			.securityMatcher("/admin/**")
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers("/admin/login").permitAll()
-				.anyRequest().hasRole("ADMIN")
+				.requestMatchers(HttpMethod.POST, "/admin/reports/**")
+				.hasAnyAuthority(AdminPermission.REPORT_REVIEW.authority(), "ROLE_ADMIN")
+				.requestMatchers(HttpMethod.POST, "/admin/facilities/**", "/admin/stations/**")
+				.hasAnyAuthority(AdminPermission.MASTER_EDIT.authority(), "ROLE_ADMIN")
+				.requestMatchers(HttpMethod.PUT, "/admin/facilities/**", "/admin/stations/**")
+				.hasAnyAuthority(AdminPermission.MASTER_EDIT.authority(), "ROLE_ADMIN")
+				.requestMatchers(HttpMethod.PATCH, "/admin/facilities/**", "/admin/stations/**")
+				.hasAnyAuthority(AdminPermission.MASTER_EDIT.authority(), "ROLE_ADMIN")
+				.requestMatchers(HttpMethod.POST, "/admin/field-verifications/**")
+				.hasAnyAuthority(AdminPermission.FIELD_OPERATE.authority(), "ROLE_ADMIN")
+				.requestMatchers(HttpMethod.PATCH, "/admin/field-verifications/**")
+				.hasAnyAuthority(AdminPermission.FIELD_OPERATE.authority(), "ROLE_ADMIN")
+				.requestMatchers(
+					HttpMethod.POST,
+					"/admin/data-collections/**",
+					"/admin/data-sources/**",
+					"/admin/notifications/**"
+				)
+				.hasAnyAuthority(AdminPermission.DATA_OPERATE.authority(), "ROLE_ADMIN")
+				.requestMatchers("/admin/system/**", "/admin/usage/**")
+				.hasAnyAuthority(AdminPermission.SECURITY_AUDIT.authority(), "ROLE_ADMIN")
+				.anyRequest().hasAnyAuthority(AdminPermission.ADMIN_VIEW.authority(), "ROLE_ADMIN")
 			)
 			.exceptionHandling(exception -> exception
 				.defaultAuthenticationEntryPointFor(

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -59,9 +59,9 @@ public class SecurityConfig {
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers("/admin/login").permitAll()
 				.requestMatchers(HttpMethod.POST, "/admin/reports/**")
-				.hasAnyAuthority(AdminPermission.REPORT_REVIEW.authority(), "ROLE_ADMIN")
+				.hasAuthority(AdminPermission.REPORT_REVIEW.authority())
 				.requestMatchers(HttpMethod.GET, "/admin/reports/**")
-				.hasAnyAuthority(AdminPermission.REPORT_REVIEW.authority(), "ROLE_ADMIN")
+				.hasAuthority(AdminPermission.REPORT_REVIEW.authority())
 				.requestMatchers(
 					HttpMethod.GET,
 					"/admin/facilities/editor/page",
@@ -71,36 +71,36 @@ public class SecurityConfig {
 					"/admin/stations/*/route-nodes",
 					"/admin/stations/*/route-edges"
 				)
-				.hasAnyAuthority(AdminPermission.MASTER_EDIT.authority(), "ROLE_ADMIN")
+				.hasAuthority(AdminPermission.MASTER_EDIT.authority())
 				.requestMatchers(HttpMethod.POST, "/admin/facilities/**", "/admin/stations/**")
-				.hasAnyAuthority(AdminPermission.MASTER_EDIT.authority(), "ROLE_ADMIN")
+				.hasAuthority(AdminPermission.MASTER_EDIT.authority())
 				.requestMatchers(HttpMethod.PUT, "/admin/facilities/**", "/admin/stations/**")
-				.hasAnyAuthority(AdminPermission.MASTER_EDIT.authority(), "ROLE_ADMIN")
+				.hasAuthority(AdminPermission.MASTER_EDIT.authority())
 				.requestMatchers(HttpMethod.PATCH, "/admin/facilities/**", "/admin/stations/**")
-				.hasAnyAuthority(AdminPermission.MASTER_EDIT.authority(), "ROLE_ADMIN")
+				.hasAuthority(AdminPermission.MASTER_EDIT.authority())
 				.requestMatchers(HttpMethod.POST, "/admin/field-verifications/**")
-				.hasAnyAuthority(AdminPermission.FIELD_OPERATE.authority(), "ROLE_ADMIN")
+				.hasAuthority(AdminPermission.FIELD_OPERATE.authority())
 				.requestMatchers(HttpMethod.PATCH, "/admin/field-verifications/**")
-				.hasAnyAuthority(AdminPermission.FIELD_OPERATE.authority(), "ROLE_ADMIN")
+				.hasAuthority(AdminPermission.FIELD_OPERATE.authority())
 				.requestMatchers(HttpMethod.GET, "/admin/field-verifications/**")
-				.hasAnyAuthority(AdminPermission.FIELD_OPERATE.authority(), "ROLE_ADMIN")
+				.hasAuthority(AdminPermission.FIELD_OPERATE.authority())
 				.requestMatchers(
 					HttpMethod.POST,
 					"/admin/data-collections/**",
 					"/admin/data-sources/**",
 					"/admin/notifications/**"
 				)
-				.hasAnyAuthority(AdminPermission.DATA_OPERATE.authority(), "ROLE_ADMIN")
+				.hasAuthority(AdminPermission.DATA_OPERATE.authority())
 				.requestMatchers(
 					HttpMethod.GET,
 					"/admin/data-collections/**",
 					"/admin/data-sources/**",
 					"/admin/notifications/**"
 				)
-				.hasAnyAuthority(AdminPermission.DATA_OPERATE.authority(), "ROLE_ADMIN")
+				.hasAuthority(AdminPermission.DATA_OPERATE.authority())
 				.requestMatchers("/admin/system/**", "/admin/usage/**")
-				.hasAnyAuthority(AdminPermission.SECURITY_AUDIT.authority(), "ROLE_ADMIN")
-				.anyRequest().hasAnyAuthority(AdminPermission.ADMIN_VIEW.authority(), "ROLE_ADMIN")
+				.hasAuthority(AdminPermission.SECURITY_AUDIT.authority())
+				.anyRequest().hasAuthority(AdminPermission.ADMIN_VIEW.authority())
 			)
 			.exceptionHandling(exception -> exception
 				.defaultAuthenticationEntryPointFor(

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -155,6 +156,7 @@ class FacilityReportAdminPageController {
 	}
 
 	@PostMapping("/admin/reports/{reportId}/page/review")
+	@PreAuthorize("hasAuthority('admin.report.review') or hasRole('ADMIN')")
 	String reviewReportFromPage(
 		@PathVariable String reportId,
 		@RequestParam FacilityReportReviewDecision decision,

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -156,7 +156,7 @@ class FacilityReportAdminPageController {
 	}
 
 	@PostMapping("/admin/reports/{reportId}/page/review")
-	@PreAuthorize("hasAuthority('admin.report.review') or hasRole('ADMIN')")
+	@PreAuthorize("hasAuthority('admin.report.review')")
 	String reviewReportFromPage(
 		@PathVariable String reportId,
 		@RequestParam FacilityReportReviewDecision decision,

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,6 +39,7 @@ class TransitFacilityAdminPageController {
 	}
 
 	@PostMapping("/admin/facilities/{facilityId}/page/status")
+	@PreAuthorize("hasAuthority('admin.master.edit') or hasRole('ADMIN')")
 	String updateFacilityStatusFromPage(
 		@PathVariable String facilityId,
 		@RequestParam AccessibilityFacilityStatus status,

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
@@ -39,7 +39,7 @@ class TransitFacilityAdminPageController {
 	}
 
 	@PostMapping("/admin/facilities/{facilityId}/page/status")
-	@PreAuthorize("hasAuthority('admin.master.edit') or hasRole('ADMIN')")
+	@PreAuthorize("hasAuthority('admin.master.edit')")
 	String updateFacilityStatusFromPage(
 		@PathVariable String facilityId,
 		@RequestParam AccessibilityFacilityStatus status,

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
@@ -111,7 +111,7 @@ class TransitStationAdminPageController {
 	}
 
 	@PostMapping("/admin/facilities/editor/page")
-	@PreAuthorize("hasAuthority('admin.master.edit') or hasRole('ADMIN')")
+	@PreAuthorize("hasAuthority('admin.master.edit')")
 	String saveFacilityFromPage(
 		@RequestParam(required = false) String facilityId,
 		@RequestParam String stationId,

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -110,6 +111,7 @@ class TransitStationAdminPageController {
 	}
 
 	@PostMapping("/admin/facilities/editor/page")
+	@PreAuthorize("hasAuthority('admin.master.edit') or hasRole('ADMIN')")
 	String saveFacilityFromPage(
 		@RequestParam(required = false) String facilityId,
 		@RequestParam String stationId,

--- a/backend/src/main/resources/db/migration/h2/V10__admin_rbac_menu.sql
+++ b/backend/src/main/resources/db/migration/h2/V10__admin_rbac_menu.sql
@@ -21,6 +21,9 @@ CREATE TABLE admin_user_roles (
 ALTER TABLE admin_user_roles ADD CONSTRAINT ck_h2_admin_user_roles_role
     CHECK (role_code IN ('ADMIN_VIEWER', 'REPORT_REVIEWER', 'MASTER_EDITOR', 'FIELD_OPERATOR', 'DATA_OPERATOR', 'SECURITY_ADMIN', 'SUPER_ADMIN'));
 
+ALTER TABLE admin_user_roles ADD CONSTRAINT ck_h2_admin_user_roles_login_id_canonical
+    CHECK (login_id = LOWER(TRIM(login_id)));
+
 CREATE TABLE admin_menu_items (
     hidden BOOLEAN DEFAULT FALSE NOT NULL,
     display_order INTEGER DEFAULT 0 NOT NULL,
@@ -31,6 +34,9 @@ CREATE TABLE admin_menu_items (
 
 ALTER TABLE admin_menu_items ADD CONSTRAINT ck_h2_admin_menu_items_order
     CHECK (display_order >= 0);
+
+ALTER TABLE admin_menu_items ADD CONSTRAINT fk_h2_admin_menu_items_parent
+    FOREIGN KEY (parent_program_code) REFERENCES admin_menu_items(program_code);
 
 INSERT INTO admin_role_permissions (created_at, permission_code, role_code)
 VALUES

--- a/backend/src/main/resources/db/migration/h2/V10__admin_rbac_menu.sql
+++ b/backend/src/main/resources/db/migration/h2/V10__admin_rbac_menu.sql
@@ -1,0 +1,71 @@
+CREATE TABLE admin_role_permissions (
+    created_at TIMESTAMP NOT NULL,
+    permission_code VARCHAR(80) NOT NULL,
+    role_code VARCHAR(60) NOT NULL,
+    PRIMARY KEY (role_code, permission_code)
+);
+
+ALTER TABLE admin_role_permissions ADD CONSTRAINT ck_h2_admin_role_permissions_role
+    CHECK (role_code IN ('ADMIN_VIEWER', 'REPORT_REVIEWER', 'MASTER_EDITOR', 'FIELD_OPERATOR', 'DATA_OPERATOR', 'SECURITY_ADMIN', 'SUPER_ADMIN'));
+
+ALTER TABLE admin_role_permissions ADD CONSTRAINT ck_h2_admin_role_permissions_permission
+    CHECK (permission_code IN ('admin.view', 'admin.report.review', 'admin.master.edit', 'admin.field.operate', 'admin.data.operate', 'admin.security.audit', 'admin.security.admin'));
+
+CREATE TABLE admin_user_roles (
+    created_at TIMESTAMP NOT NULL,
+    role_code VARCHAR(60) NOT NULL,
+    login_id VARCHAR(120) NOT NULL,
+    PRIMARY KEY (login_id, role_code)
+);
+
+ALTER TABLE admin_user_roles ADD CONSTRAINT ck_h2_admin_user_roles_role
+    CHECK (role_code IN ('ADMIN_VIEWER', 'REPORT_REVIEWER', 'MASTER_EDITOR', 'FIELD_OPERATOR', 'DATA_OPERATOR', 'SECURITY_ADMIN', 'SUPER_ADMIN'));
+
+CREATE TABLE admin_menu_items (
+    hidden BOOLEAN DEFAULT FALSE NOT NULL,
+    display_order INTEGER DEFAULT 0 NOT NULL,
+    display_name VARCHAR(120) NOT NULL,
+    parent_program_code VARCHAR(80),
+    program_code VARCHAR(80) PRIMARY KEY NOT NULL
+);
+
+ALTER TABLE admin_menu_items ADD CONSTRAINT ck_h2_admin_menu_items_order
+    CHECK (display_order >= 0);
+
+INSERT INTO admin_role_permissions (created_at, permission_code, role_code)
+VALUES
+    (CURRENT_TIMESTAMP, 'admin.view', 'ADMIN_VIEWER'),
+    (CURRENT_TIMESTAMP, 'admin.view', 'REPORT_REVIEWER'),
+    (CURRENT_TIMESTAMP, 'admin.report.review', 'REPORT_REVIEWER'),
+    (CURRENT_TIMESTAMP, 'admin.view', 'MASTER_EDITOR'),
+    (CURRENT_TIMESTAMP, 'admin.master.edit', 'MASTER_EDITOR'),
+    (CURRENT_TIMESTAMP, 'admin.view', 'FIELD_OPERATOR'),
+    (CURRENT_TIMESTAMP, 'admin.field.operate', 'FIELD_OPERATOR'),
+    (CURRENT_TIMESTAMP, 'admin.view', 'DATA_OPERATOR'),
+    (CURRENT_TIMESTAMP, 'admin.data.operate', 'DATA_OPERATOR'),
+    (CURRENT_TIMESTAMP, 'admin.view', 'SECURITY_ADMIN'),
+    (CURRENT_TIMESTAMP, 'admin.security.audit', 'SECURITY_ADMIN'),
+    (CURRENT_TIMESTAMP, 'admin.security.admin', 'SECURITY_ADMIN'),
+    (CURRENT_TIMESTAMP, 'admin.view', 'SUPER_ADMIN'),
+    (CURRENT_TIMESTAMP, 'admin.report.review', 'SUPER_ADMIN'),
+    (CURRENT_TIMESTAMP, 'admin.master.edit', 'SUPER_ADMIN'),
+    (CURRENT_TIMESTAMP, 'admin.field.operate', 'SUPER_ADMIN'),
+    (CURRENT_TIMESTAMP, 'admin.data.operate', 'SUPER_ADMIN'),
+    (CURRENT_TIMESTAMP, 'admin.security.audit', 'SUPER_ADMIN'),
+    (CURRENT_TIMESTAMP, 'admin.security.admin', 'SUPER_ADMIN');
+
+INSERT INTO admin_menu_items (hidden, display_order, display_name, parent_program_code, program_code)
+VALUES
+    (FALSE, 10, '통합 대시보드', NULL, 'a-dashboard'),
+    (FALSE, 20, '역 목록', NULL, 'a-stations'),
+    (FALSE, 30, '시설 상태판', NULL, 'a-facilities'),
+    (FALSE, 40, '역 구조·동선 편집', NULL, 'a-layout-editor'),
+    (FALSE, 50, '제보 검수 큐', NULL, 'a-reports'),
+    (FALSE, 60, '데이터 품질', NULL, 'a-quality'),
+    (FALSE, 70, '현장 검증', NULL, 'a-field-verifications'),
+    (FALSE, 80, '데이터 수집', NULL, 'a-collections'),
+    (FALSE, 90, '경로 검색 분석', NULL, 'a-route-searches'),
+    (FALSE, 100, '경로 피드백 분석', NULL, 'a-route-feedback'),
+    (FALSE, 110, '푸시 알림', NULL, 'a-push'),
+    (FALSE, 120, '사용 현황', NULL, 'a-usage'),
+    (FALSE, 130, '시스템 상태', NULL, 'a-system');

--- a/backend/src/main/resources/db/migration/postgresql/V10__admin_rbac_menu.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V10__admin_rbac_menu.sql
@@ -1,0 +1,62 @@
+CREATE TABLE admin_role_permissions (
+    role_code VARCHAR(60) NOT NULL,
+    permission_code VARCHAR(80) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    PRIMARY KEY (role_code, permission_code),
+    CHECK (role_code IN ('ADMIN_VIEWER', 'REPORT_REVIEWER', 'MASTER_EDITOR', 'FIELD_OPERATOR', 'DATA_OPERATOR', 'SECURITY_ADMIN', 'SUPER_ADMIN')),
+    CHECK (permission_code IN ('admin.view', 'admin.report.review', 'admin.master.edit', 'admin.field.operate', 'admin.data.operate', 'admin.security.audit', 'admin.security.admin'))
+);
+
+CREATE TABLE admin_user_roles (
+    login_id VARCHAR(120) NOT NULL,
+    role_code VARCHAR(60) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    PRIMARY KEY (login_id, role_code),
+    CHECK (role_code IN ('ADMIN_VIEWER', 'REPORT_REVIEWER', 'MASTER_EDITOR', 'FIELD_OPERATOR', 'DATA_OPERATOR', 'SECURITY_ADMIN', 'SUPER_ADMIN'))
+);
+
+CREATE TABLE admin_menu_items (
+    program_code VARCHAR(80) NOT NULL PRIMARY KEY,
+    parent_program_code VARCHAR(80),
+    display_name VARCHAR(120) NOT NULL,
+    display_order INTEGER NOT NULL DEFAULT 0 CHECK (display_order >= 0),
+    hidden BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
+VALUES
+    ('ADMIN_VIEWER', 'admin.view', CURRENT_TIMESTAMP),
+    ('REPORT_REVIEWER', 'admin.view', CURRENT_TIMESTAMP),
+    ('REPORT_REVIEWER', 'admin.report.review', CURRENT_TIMESTAMP),
+    ('MASTER_EDITOR', 'admin.view', CURRENT_TIMESTAMP),
+    ('MASTER_EDITOR', 'admin.master.edit', CURRENT_TIMESTAMP),
+    ('FIELD_OPERATOR', 'admin.view', CURRENT_TIMESTAMP),
+    ('FIELD_OPERATOR', 'admin.field.operate', CURRENT_TIMESTAMP),
+    ('DATA_OPERATOR', 'admin.view', CURRENT_TIMESTAMP),
+    ('DATA_OPERATOR', 'admin.data.operate', CURRENT_TIMESTAMP),
+    ('SECURITY_ADMIN', 'admin.view', CURRENT_TIMESTAMP),
+    ('SECURITY_ADMIN', 'admin.security.audit', CURRENT_TIMESTAMP),
+    ('SECURITY_ADMIN', 'admin.security.admin', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.view', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.report.review', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.master.edit', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.field.operate', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.data.operate', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.security.audit', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.security.admin', CURRENT_TIMESTAMP);
+
+INSERT INTO admin_menu_items (program_code, parent_program_code, display_name, display_order, hidden)
+VALUES
+    ('a-dashboard', NULL, '통합 대시보드', 10, FALSE),
+    ('a-stations', NULL, '역 목록', 20, FALSE),
+    ('a-facilities', NULL, '시설 상태판', 30, FALSE),
+    ('a-layout-editor', NULL, '역 구조·동선 편집', 40, FALSE),
+    ('a-reports', NULL, '제보 검수 큐', 50, FALSE),
+    ('a-quality', NULL, '데이터 품질', 60, FALSE),
+    ('a-field-verifications', NULL, '현장 검증', 70, FALSE),
+    ('a-collections', NULL, '데이터 수집', 80, FALSE),
+    ('a-route-searches', NULL, '경로 검색 분석', 90, FALSE),
+    ('a-route-feedback', NULL, '경로 피드백 분석', 100, FALSE),
+    ('a-push', NULL, '푸시 알림', 110, FALSE),
+    ('a-usage', NULL, '사용 현황', 120, FALSE),
+    ('a-system', NULL, '시스템 상태', 130, FALSE);

--- a/backend/src/main/resources/db/migration/postgresql/V10__admin_rbac_menu.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V10__admin_rbac_menu.sql
@@ -12,7 +12,8 @@ CREATE TABLE admin_user_roles (
     role_code VARCHAR(60) NOT NULL,
     created_at TIMESTAMP NOT NULL,
     PRIMARY KEY (login_id, role_code),
-    CHECK (role_code IN ('ADMIN_VIEWER', 'REPORT_REVIEWER', 'MASTER_EDITOR', 'FIELD_OPERATOR', 'DATA_OPERATOR', 'SECURITY_ADMIN', 'SUPER_ADMIN'))
+    CHECK (role_code IN ('ADMIN_VIEWER', 'REPORT_REVIEWER', 'MASTER_EDITOR', 'FIELD_OPERATOR', 'DATA_OPERATOR', 'SECURITY_ADMIN', 'SUPER_ADMIN')),
+    CHECK (login_id = LOWER(TRIM(login_id)))
 );
 
 CREATE TABLE admin_menu_items (
@@ -20,7 +21,8 @@ CREATE TABLE admin_menu_items (
     parent_program_code VARCHAR(80),
     display_name VARCHAR(120) NOT NULL,
     display_order INTEGER NOT NULL DEFAULT 0 CHECK (display_order >= 0),
-    hidden BOOLEAN NOT NULL DEFAULT FALSE
+    hidden BOOLEAN NOT NULL DEFAULT FALSE,
+    FOREIGN KEY (parent_program_code) REFERENCES admin_menu_items(program_code)
 );
 
 INSERT INTO admin_role_permissions (role_code, permission_code, created_at)

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -16,7 +16,7 @@
 			<p>신고·시설·데이터·경로·알림·시스템 이상을 한 화면에 모읍니다.</p>
 		</div>
 		<div class="admin-actions">
-			<a class="admin-btn" th:href="@{/admin/reports/page}">긴급 작업 보기</a>
+			<a th:if="${adminProgramIds.contains('a-reports')}" class="admin-btn" th:href="@{/admin/reports/page}">긴급 작업 보기</a>
 		</div>
 	</header>
 
@@ -28,7 +28,7 @@
 	</div>
 
 	<div class="admin-grid-2">
-		<section class="admin-panel">
+		<section class="admin-panel" th:if="${adminProgramIds.contains('a-reports')}">
 			<h2>우선 검수 제보</h2>
 			<p class="summary">미검수 제보는 제보 검수 큐에서 상태·사진·위치를 함께 확인합니다.</p>
 			<a class="admin-btn" th:href="@{/admin/reports/page}">제보 검수 큐 열기</a>

--- a/backend/src/main/resources/templates/admin/fragments/shell.html
+++ b/backend/src/main/resources/templates/admin/fragments/shell.html
@@ -9,30 +9,12 @@
 			<span>통합 관리자</span>
 		</div>
 	</div>
-	<div class="admin-nav-group">
-		<p>접속·개요</p>
-		<a th:if="${adminProgramIds.contains('a-dashboard')}" th:classappend="${active == 'a-dashboard'} ? ' is-active'" th:href="@{/admin/dashboard/page}">통합 대시보드</a>
-	</div>
-	<div class="admin-nav-group">
-		<p>역·시설 마스터</p>
-		<a th:if="${adminProgramIds.contains('a-stations')}" th:classappend="${active == 'a-stations'} ? ' is-active'" th:href="@{/admin/stations/page}">역 목록</a>
-		<a th:if="${adminProgramIds.contains('a-facilities')}" th:classappend="${active == 'a-facilities'} ? ' is-active'" th:href="@{/admin/facilities/page}">시설 상태판</a>
-		<a th:if="${adminProgramIds.contains('a-layout-editor')}" th:classappend="${active == 'a-layout-editor'} ? ' is-active'" th:href="@{/admin/stations/page}">역 구조·동선 편집</a>
-	</div>
-	<div class="admin-nav-group">
-		<p>제보·품질·검증</p>
-		<a th:if="${adminProgramIds.contains('a-reports')}" th:classappend="${active == 'a-reports'} ? ' is-active'" th:href="@{/admin/reports/page}">제보 검수 큐</a>
-		<a th:if="${adminProgramIds.contains('a-quality')}" th:classappend="${active == 'a-quality'} ? ' is-active'" th:href="@{/admin/data-quality/page}">데이터 품질</a>
-		<a th:if="${adminProgramIds.contains('a-field-verifications')}" th:classappend="${active == 'a-field-verifications'} ? ' is-active'" th:href="@{/admin/field-verifications/page}">현장 검증</a>
-	</div>
-	<div class="admin-nav-group">
-		<p>운영·분석</p>
-		<a th:if="${adminProgramIds.contains('a-collections')}" th:classappend="${active == 'a-collections'} ? ' is-active'" th:href="@{/admin/data-collections/page}">데이터 수집</a>
-		<a th:if="${adminProgramIds.contains('a-route-searches')}" th:classappend="${active == 'a-route-searches'} ? ' is-active'" th:href="@{/admin/routes/searches/page}">경로 검색 분석</a>
-		<a th:if="${adminProgramIds.contains('a-route-feedback')}" th:classappend="${active == 'a-route-feedback'} ? ' is-active'" th:href="@{/admin/routes/feedback/page}">경로 피드백 분석</a>
-		<a th:if="${adminProgramIds.contains('a-push')}" th:classappend="${active == 'a-push'} ? ' is-active'" th:href="@{/admin/notifications/push/page}">푸시 알림</a>
-		<a th:if="${adminProgramIds.contains('a-usage')}" th:classappend="${active == 'a-usage'} ? ' is-active'" th:href="@{/admin/usage/activity/page}">사용 현황</a>
-		<a th:if="${adminProgramIds.contains('a-system')}" th:classappend="${active == 'a-system'} ? ' is-active'" th:href="@{/admin/system/page}">시스템 상태</a>
+	<div class="admin-nav-group" th:each="group : ${adminProgramGroups}">
+		<p th:text="${group.label}">메뉴 그룹</p>
+		<a th:each="program : ${group.programs}"
+		   th:classappend="${active == program.id} ? ' is-active'"
+		   th:href="@{${program.path}}"
+		   th:text="${program.label}">메뉴</a>
 	</div>
 </nav>
 </body>

--- a/backend/src/main/resources/templates/admin/fragments/shell.html
+++ b/backend/src/main/resources/templates/admin/fragments/shell.html
@@ -11,28 +11,28 @@
 	</div>
 	<div class="admin-nav-group">
 		<p>접속·개요</p>
-		<a th:classappend="${active == 'a-dashboard'} ? ' is-active'" th:href="@{/admin/dashboard/page}">통합 대시보드</a>
+		<a th:if="${adminProgramIds.contains('a-dashboard')}" th:classappend="${active == 'a-dashboard'} ? ' is-active'" th:href="@{/admin/dashboard/page}">통합 대시보드</a>
 	</div>
 	<div class="admin-nav-group">
 		<p>역·시설 마스터</p>
-		<a th:classappend="${active == 'a-stations'} ? ' is-active'" th:href="@{/admin/stations/page}">역 목록</a>
-		<a th:classappend="${active == 'a-facilities'} ? ' is-active'" th:href="@{/admin/facilities/page}">시설 상태판</a>
-		<a th:classappend="${active == 'a-layout-editor'} ? ' is-active'" th:href="@{/admin/stations/page}">역 구조·동선 편집</a>
+		<a th:if="${adminProgramIds.contains('a-stations')}" th:classappend="${active == 'a-stations'} ? ' is-active'" th:href="@{/admin/stations/page}">역 목록</a>
+		<a th:if="${adminProgramIds.contains('a-facilities')}" th:classappend="${active == 'a-facilities'} ? ' is-active'" th:href="@{/admin/facilities/page}">시설 상태판</a>
+		<a th:if="${adminProgramIds.contains('a-layout-editor')}" th:classappend="${active == 'a-layout-editor'} ? ' is-active'" th:href="@{/admin/stations/page}">역 구조·동선 편집</a>
 	</div>
 	<div class="admin-nav-group">
 		<p>제보·품질·검증</p>
-		<a th:classappend="${active == 'a-reports'} ? ' is-active'" th:href="@{/admin/reports/page}">제보 검수 큐</a>
-		<a th:classappend="${active == 'a-quality'} ? ' is-active'" th:href="@{/admin/data-quality/page}">데이터 품질</a>
-		<a th:classappend="${active == 'a-field-verifications'} ? ' is-active'" th:href="@{/admin/field-verifications/page}">현장 검증</a>
+		<a th:if="${adminProgramIds.contains('a-reports')}" th:classappend="${active == 'a-reports'} ? ' is-active'" th:href="@{/admin/reports/page}">제보 검수 큐</a>
+		<a th:if="${adminProgramIds.contains('a-quality')}" th:classappend="${active == 'a-quality'} ? ' is-active'" th:href="@{/admin/data-quality/page}">데이터 품질</a>
+		<a th:if="${adminProgramIds.contains('a-field-verifications')}" th:classappend="${active == 'a-field-verifications'} ? ' is-active'" th:href="@{/admin/field-verifications/page}">현장 검증</a>
 	</div>
 	<div class="admin-nav-group">
 		<p>운영·분석</p>
-		<a th:classappend="${active == 'a-collections'} ? ' is-active'" th:href="@{/admin/data-collections/page}">데이터 수집</a>
-		<a th:classappend="${active == 'a-route-searches'} ? ' is-active'" th:href="@{/admin/routes/searches/page}">경로 검색 분석</a>
-		<a th:classappend="${active == 'a-route-feedback'} ? ' is-active'" th:href="@{/admin/routes/feedback/page}">경로 피드백 분석</a>
-		<a th:classappend="${active == 'a-push'} ? ' is-active'" th:href="@{/admin/notifications/push/page}">푸시 알림</a>
-		<a th:classappend="${active == 'a-usage'} ? ' is-active'" th:href="@{/admin/usage/activity/page}">사용 현황</a>
-		<a th:classappend="${active == 'a-system'} ? ' is-active'" th:href="@{/admin/system/page}">시스템 상태</a>
+		<a th:if="${adminProgramIds.contains('a-collections')}" th:classappend="${active == 'a-collections'} ? ' is-active'" th:href="@{/admin/data-collections/page}">데이터 수집</a>
+		<a th:if="${adminProgramIds.contains('a-route-searches')}" th:classappend="${active == 'a-route-searches'} ? ' is-active'" th:href="@{/admin/routes/searches/page}">경로 검색 분석</a>
+		<a th:if="${adminProgramIds.contains('a-route-feedback')}" th:classappend="${active == 'a-route-feedback'} ? ' is-active'" th:href="@{/admin/routes/feedback/page}">경로 피드백 분석</a>
+		<a th:if="${adminProgramIds.contains('a-push')}" th:classappend="${active == 'a-push'} ? ' is-active'" th:href="@{/admin/notifications/push/page}">푸시 알림</a>
+		<a th:if="${adminProgramIds.contains('a-usage')}" th:classappend="${active == 'a-usage'} ? ' is-active'" th:href="@{/admin/usage/activity/page}">사용 현황</a>
+		<a th:if="${adminProgramIds.contains('a-system')}" th:classappend="${active == 'a-system'} ? ' is-active'" th:href="@{/admin/system/page}">시스템 상태</a>
 	</div>
 </nav>
 </body>

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -79,10 +79,18 @@ class AdminV3PageSmokeTest {
 	}
 
 	@Test
-	@DisplayName("기존 ADMIN role 관리자는 전체 관리자 program을 볼 수 있다")
-	void adminRoleKeepsFullProgramVisibility() throws Exception {
+	@DisplayName("전체 permission 관리자는 모든 관리자 program을 볼 수 있다")
+	void fullPermissionAdminSeesAllPrograms() throws Exception {
 		String html = mockMvc.perform(get("/admin/dashboard/page")
-				.with(user("admin").roles("ADMIN")))
+				.with(user("admin").authorities(
+					new SimpleGrantedAuthority("admin.view"),
+					new SimpleGrantedAuthority("admin.report.review"),
+					new SimpleGrantedAuthority("admin.master.edit"),
+					new SimpleGrantedAuthority("admin.field.operate"),
+					new SimpleGrantedAuthority("admin.data.operate"),
+					new SimpleGrantedAuthority("admin.security.audit"),
+					new SimpleGrantedAuthority("admin.security.admin")
+				)))
 			.andExpect(status().isOk())
 			.andReturn()
 			.getResponse()

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -105,6 +105,28 @@ class AdminV3PageSmokeTest {
 	}
 
 	@Test
+	@DisplayName("권한이 없는 관리자는 제한된 읽기 화면에 직접 접근할 수 없다")
+	void adminPermissionBlocksRestrictedReadPages() throws Exception {
+		mockMvc.perform(get("/admin/reports/page")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view"))))
+			.andExpect(status().isForbidden());
+		mockMvc.perform(get("/admin/notifications/push/page")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view"))))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("업무 permission이 있는 관리자는 제한된 읽기 화면에 접근할 수 있다")
+	void adminPermissionAllowsRestrictedReadPages() throws Exception {
+		mockMvc.perform(get("/admin/reports/page")
+				.with(user("reporter").authorities(new SimpleGrantedAuthority("admin.report.review"))))
+			.andExpect(status().isOk());
+		mockMvc.perform(get("/admin/notifications/push/page")
+				.with(user("operator").authorities(new SimpleGrantedAuthority("admin.data.operate"))))
+			.andExpect(status().isOk());
+	}
+
+	@Test
 	@DisplayName("권한이 없는 관리자는 푸시 발송 entrypoint에 접근할 수 없다")
 	void adminPermissionBlocksPushEntrypoint() throws Exception {
 		mockMvc.perform(post("/admin/notifications/push")

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -99,6 +99,7 @@ class AdminV3PageSmokeTest {
 		assertThat(html)
 			.contains("제보 검수 큐")
 			.contains("역 구조·동선 편집")
+			.contains("href=\"/admin/facilities/editor/page\"")
 			.contains("데이터 수집");
 	}
 

--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminV3PageSmokeTest.java
@@ -3,6 +3,7 @@ package com.easysubway.admin.adapter.in.web;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -57,6 +59,58 @@ class AdminV3PageSmokeTest {
 			.contains("마스터 데이터")
 			.contains("데이터베이스")
 			.doesNotContain("prod-object-storage-secret-key");
+	}
+
+	@Test
+	@DisplayName("관리자 sidebar는 permission이 있는 program만 표시한다")
+	void adminSidebarShowsOnlyPermittedPrograms() throws Exception {
+		String html = mockMvc.perform(get("/admin/dashboard/page")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view"))))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("통합 대시보드")
+			.doesNotContain("제보 검수 큐")
+			.doesNotContain("역 구조·동선 편집")
+			.doesNotContain("데이터 수집");
+	}
+
+	@Test
+	@DisplayName("기존 ADMIN role 관리자는 전체 관리자 program을 볼 수 있다")
+	void adminRoleKeepsFullProgramVisibility() throws Exception {
+		String html = mockMvc.perform(get("/admin/dashboard/page")
+				.with(user("admin").roles("ADMIN")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("제보 검수 큐")
+			.contains("역 구조·동선 편집")
+			.contains("데이터 수집");
+	}
+
+	@Test
+	@DisplayName("권한이 없는 관리자는 쓰기 entrypoint에 접근할 수 없다")
+	void adminPermissionBlocksMutatingEntrypoint() throws Exception {
+		mockMvc.perform(post("/admin/reports/report-1/page/review")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view")))
+				.with(csrf())
+				.param("decision", "REJECT"))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("권한이 없는 관리자는 푸시 발송 entrypoint에 접근할 수 없다")
+	void adminPermissionBlocksPushEntrypoint() throws Exception {
+		mockMvc.perform(post("/admin/notifications/push")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view")))
+				.with(csrf()))
+			.andExpect(status().isForbidden());
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
@@ -177,6 +177,19 @@ class SecurityConfigTest {
 	}
 
 	@Test
+	@DisplayName("인메모리 RBAC 저장소는 선언되지 않은 permission authority를 거절한다")
+	void inMemoryAdminRbacRejectsUnknownAuthority() {
+		var rbacRepository = new InMemoryAdminRbacAuthorityRepository();
+
+		assertThatThrownBy(() -> rbacRepository.replacePermissionAuthorities(
+			"admin-user",
+			Set.of("admin.view", "admin.unknown")
+		))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("선언되지 않은 관리자 permission authority");
+	}
+
+	@Test
 	@DisplayName("영속 관리자 계정은 RBAC role 미할당만으로 full permission을 얻지 않는다")
 	void persistentAdminWithoutRbacAssignmentDoesNotReceiveFullPermissions() {
 		contextRunner

--- a/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.easysubway.admin.authorization.adapter.out.persistence.InMemoryAdminRbacAuthorityRepository;
 import com.easysubway.admin.identity.adapter.out.persistence.InMemoryAdminIdentityRepository;
 import com.easysubway.admin.identity.application.port.out.AdminIdentityRepository;
+import com.easysubway.admin.identity.domain.AdminIdentity;
 import com.easysubway.admin.identity.domain.AdminIdentityAuthMethod;
 import com.easysubway.admin.identity.domain.AdminIdentityRole;
 import com.easysubway.admin.identity.domain.AdminIdentityStatus;
@@ -172,6 +173,41 @@ class SecurityConfigTest {
 					.extracting(GrantedAuthority::getAuthority)
 					.contains("ROLE_ADMIN", "admin.view", "admin.report.review")
 					.doesNotContain("admin.data.operate", "admin.master.edit", "admin.security.admin");
+			});
+	}
+
+	@Test
+	@DisplayName("영속 관리자 계정은 RBAC role 미할당만으로 full permission을 얻지 않는다")
+	void persistentAdminWithoutRbacAssignmentDoesNotReceiveFullPermissions() {
+		contextRunner
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				var passwordEncoder = context.getBean(org.springframework.security.crypto.password.PasswordEncoder.class);
+				AdminIdentityRepository repository = context.getBean(AdminIdentityRepository.class);
+				LocalDateTime now = LocalDateTime.of(2026, 6, 27, 0, 0);
+				repository.save(new AdminIdentity(
+					"persistent-admin",
+					"영속 관리자",
+					null,
+					passwordEncoder.encode("admin-password"),
+					AdminIdentityAuthMethod.LOCAL,
+					AdminIdentityRole.ADMIN,
+					AdminIdentityStatus.ACTIVE,
+					0,
+					null,
+					now,
+					null,
+					false,
+					null,
+					false,
+					now,
+					now
+				));
+				UserDetailsService userDetailsService = context.getBean(UserDetailsService.class);
+
+				assertThat(userDetailsService.loadUserByUsername("persistent-admin").getAuthorities())
+					.extracting(GrantedAuthority::getAuthority)
+					.containsExactly("ROLE_ADMIN");
 			});
 	}
 

--- a/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
@@ -3,12 +3,14 @@ package com.easysubway.common.security;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.easysubway.admin.authorization.adapter.out.persistence.InMemoryAdminRbacAuthorityRepository;
 import com.easysubway.admin.identity.adapter.out.persistence.InMemoryAdminIdentityRepository;
 import com.easysubway.admin.identity.application.port.out.AdminIdentityRepository;
 import com.easysubway.admin.identity.domain.AdminIdentityAuthMethod;
 import com.easysubway.admin.identity.domain.AdminIdentityRole;
 import com.easysubway.admin.identity.domain.AdminIdentityStatus;
 import java.time.LocalDateTime;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -148,6 +150,28 @@ class SecurityConfigTest {
 						"admin.security.audit",
 						"admin.security.admin"
 					);
+			});
+	}
+
+	@Test
+	@DisplayName("관리자 RBAC role 할당이 있으면 할당 permission만 authority로 가진다")
+	void adminCredentialsUseAssignedRbacAuthorities() {
+		contextRunner
+			.withPropertyValues(
+				"easysubway.admin.username=admin-user",
+				"easysubway.admin.password=admin-password"
+			)
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				InMemoryAdminRbacAuthorityRepository rbacRepository =
+					context.getBean(InMemoryAdminRbacAuthorityRepository.class);
+				rbacRepository.replacePermissionAuthorities("admin-user", Set.of("admin.view", "admin.report.review"));
+				UserDetailsService userDetailsService = context.getBean(UserDetailsService.class);
+
+				assertThat(userDetailsService.loadUserByUsername("admin-user").getAuthorities())
+					.extracting(GrantedAuthority::getAuthority)
+					.contains("ROLE_ADMIN", "admin.view", "admin.report.review")
+					.doesNotContain("admin.data.operate", "admin.master.edit", "admin.security.admin");
 			});
 	}
 
@@ -718,6 +742,11 @@ class SecurityConfigTest {
 		@Bean
 		InMemoryAdminIdentityRepository adminIdentityRepository() {
 			return new InMemoryAdminIdentityRepository();
+		}
+
+		@Bean
+		InMemoryAdminRbacAuthorityRepository adminRbacAuthorityRepository() {
+			return new InMemoryAdminRbacAuthorityRepository();
 		}
 	}
 

--- a/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
@@ -125,6 +125,33 @@ class SecurityConfigTest {
 	}
 
 	@Test
+	@DisplayName("관리자 계정은 RBAC permission authority를 함께 가진다")
+	void adminCredentialsRegisterPermissionAuthorities() {
+		contextRunner
+			.withPropertyValues(
+				"easysubway.admin.username=admin-user",
+				"easysubway.admin.password=admin-password"
+			)
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				UserDetailsService userDetailsService = context.getBean(UserDetailsService.class);
+
+				assertThat(userDetailsService.loadUserByUsername("admin-user").getAuthorities())
+					.extracting(GrantedAuthority::getAuthority)
+					.contains(
+						"ROLE_ADMIN",
+						"admin.view",
+						"admin.report.review",
+						"admin.master.edit",
+						"admin.field.operate",
+						"admin.data.operate",
+						"admin.security.audit",
+						"admin.security.admin"
+					);
+			});
+	}
+
+	@Test
 	@DisplayName("관리자 계정 설정이 있으면 영속 identity 저장소에 bootstrap한다")
 	void adminCredentialsBootstrapPersistentIdentity() {
 		contextRunner

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3933,7 +3933,7 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(adminReportListTemplate, /page\.hasNext/);
   assert.match(security, /@Order\(1\)[\s\S]*?securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
-  assert.match(security, /anyRequest\(\)\.hasAnyAuthority\(AdminPermission\.ADMIN_VIEW\.authority\(\), "ROLE_ADMIN"\)/);
+  assert.match(security, /anyRequest\(\)\.hasAuthority\(AdminPermission\.ADMIN_VIEW\.authority\(\)\)/);
   assert.match(security, /adminSecurityFilterChain\([\s\S]*HttpSecurity http,[\s\S]*AdminOperatorAuditFilter auditFilter,[\s\S]*basicAuthEnabled/);
   assert.match(security, /adminSecurityFilterChain[\s\S]*addFilterAfter\(auditFilter, BasicAuthenticationFilter\.class\)/);
   assert.match(security, /@Order\(2\)[\s\S]*?securityMatcher\("\/operator\/\*\*"\)/);
@@ -6257,9 +6257,9 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.match(messages, /^common\.error\.invalid-parameter=요청 값을 확인해야 합니다\.$/m);
   assert.doesNotMatch(commonExceptionHandler, /StackTrace|printStackTrace|getStackTrace/);
   assert.match(securityConfig, /securityMatcher\("\/admin\/\*\*"\)/);
-  assert.match(securityConfig, /hasAnyAuthority\(AdminPermission\.ADMIN_VIEW\.authority\(\), "ROLE_ADMIN"\)/);
-  assert.match(securityConfig, /hasAnyAuthority\(AdminPermission\.REPORT_REVIEW\.authority\(\), "ROLE_ADMIN"\)/);
-  assert.match(securityConfig, /hasAnyAuthority\(AdminPermission\.DATA_OPERATE\.authority\(\), "ROLE_ADMIN"\)/);
+  assert.match(securityConfig, /hasAuthority\(AdminPermission\.ADMIN_VIEW\.authority\(\)\)/);
+  assert.match(securityConfig, /hasAuthority\(AdminPermission\.REPORT_REVIEW\.authority\(\)\)/);
+  assert.match(securityConfig, /hasAuthority\(AdminPermission\.DATA_OPERATE\.authority\(\)\)/);
   assert.match(securityConfig, /"\/admin\/notifications\/\*\*"/);
   assert.match(securityConfig, /hasRole\("OPERATOR_ADMIN"\)/);
   assert.match(securityConfig, /validateProdAdminCredentials/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -6144,6 +6144,9 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   const adminRbacPostgresSchema = read("backend/src/main/resources/db/migration/postgresql/V10__admin_rbac_menu.sql");
   const adminProgramRegistry = read("backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java");
   const adminPermission = read("backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java");
+  const jdbcAdminRbacAuthorityRepository = read(
+    "backend/src/main/java/com/easysubway/admin/authorization/adapter/out/persistence/JdbcAdminRbacAuthorityRepository.java",
+  );
   const adminIdentityUserDetailsService = read(
     "backend/src/main/java/com/easysubway/admin/identity/application/service/AdminIdentityUserDetailsService.java",
   );
@@ -6323,6 +6326,8 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.match(adminProgramRegistry, /\/admin\/reports\/page/);
   assert.match(adminProgramRegistry, /AdminPermission\.REPORT_REVIEW/);
   assert.match(adminPermission, /REPORT_REVIEW\("admin\.report\.review"\)/);
+  assert.match(jdbcAdminRbacAuthorityRepository, /JOIN admin_role_permissions/);
+  assert.match(jdbcAdminRbacAuthorityRepository, /FROM admin_user_roles/);
   assert.match(adminIdentityUserDetailsService, /fallbackUserDetailsService/);
   assert.match(adminIdentityUserDetailsService, /credentialsExpired/);
   assert.match(adminIdentityUserDetailsService, /AdminAuthorization\.authoritiesFor/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -6142,8 +6142,13 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   );
   const adminIdentityPostgresSchema = read("backend/src/main/resources/db/migration/postgresql/V9__admin_identity.sql");
   const adminRbacPostgresSchema = read("backend/src/main/resources/db/migration/postgresql/V10__admin_rbac_menu.sql");
+  const adminRbacH2Schema = read("backend/src/main/resources/db/migration/h2/V10__admin_rbac_menu.sql");
   const adminProgramRegistry = read("backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java");
   const adminPermission = read("backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java");
+  const adminRbacRole = read("backend/src/main/java/com/easysubway/admin/authorization/AdminRbacRole.java");
+  const inMemoryAdminRbacAuthorityRepository = read(
+    "backend/src/main/java/com/easysubway/admin/authorization/adapter/out/persistence/InMemoryAdminRbacAuthorityRepository.java",
+  );
   const jdbcAdminRbacAuthorityRepository = read(
     "backend/src/main/java/com/easysubway/admin/authorization/adapter/out/persistence/JdbcAdminRbacAuthorityRepository.java",
   );
@@ -6316,16 +6321,44 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.match(adminIdentityPostgresSchema, /CREATE TABLE admin_login_audits/);
   assert.match(adminIdentityPostgresSchema, /outcome IN \('FAILED', 'LOCKED', 'DISABLED', 'PASSWORD_EXPIRED', 'CREDENTIAL_ROTATION_REQUIRED', 'SUCCESS'\)/);
   assert.match(adminIdentityPostgresSchema, /idx_admin_login_audits_login_occurred_at/);
-  assert.match(adminRbacPostgresSchema, /CREATE TABLE admin_role_permissions/);
-  assert.match(adminRbacPostgresSchema, /CREATE TABLE admin_user_roles/);
-  assert.match(adminRbacPostgresSchema, /CREATE TABLE admin_menu_items/);
-  assert.match(adminRbacPostgresSchema, /role_code IN \('ADMIN_VIEWER', 'REPORT_REVIEWER', 'MASTER_EDITOR', 'FIELD_OPERATOR', 'DATA_OPERATOR', 'SECURITY_ADMIN', 'SUPER_ADMIN'\)/);
-  assert.match(adminRbacPostgresSchema, /permission_code IN \('admin\.view', 'admin\.report\.review', 'admin\.master\.edit', 'admin\.field\.operate', 'admin\.data\.operate', 'admin\.security\.audit', 'admin\.security\.admin'\)/);
-  assert.doesNotMatch(adminRbacPostgresSchema, /\b(url|handler|controller|method)_/i);
+  const adminRbacRoleCodes = [...adminRbacRole.matchAll(/^\s*([A-Z_]+)\(/gm)].map((match) => match[1]);
+  const adminPermissionCodes = [...adminPermission.matchAll(/^\s*[A-Z_]+\("([^"]+)"\)/gm)].map((match) => match[1]);
+  const adminRbacRoleConstraint = `role_code IN (${adminRbacRoleCodes.map((role) => `'${role}'`).join(", ")})`;
+  const adminRbacPermissionConstraint =
+    `permission_code IN (${adminPermissionCodes.map((permission) => `'${permission}'`).join(", ")})`;
+  assert.deepEqual(adminRbacRoleCodes, [
+    "ADMIN_VIEWER",
+    "REPORT_REVIEWER",
+    "MASTER_EDITOR",
+    "FIELD_OPERATOR",
+    "DATA_OPERATOR",
+    "SECURITY_ADMIN",
+    "SUPER_ADMIN",
+  ]);
+  assert.deepEqual(adminPermissionCodes, [
+    "admin.view",
+    "admin.report.review",
+    "admin.master.edit",
+    "admin.field.operate",
+    "admin.data.operate",
+    "admin.security.audit",
+    "admin.security.admin",
+  ]);
+  for (const adminRbacSchema of [adminRbacPostgresSchema, adminRbacH2Schema]) {
+    assert.match(adminRbacSchema, /CREATE TABLE admin_role_permissions/);
+    assert.match(adminRbacSchema, /CREATE TABLE admin_user_roles/);
+    assert.match(adminRbacSchema, /CREATE TABLE admin_menu_items/);
+    assert.ok(adminRbacSchema.includes(adminRbacRoleConstraint));
+    assert.ok(adminRbacSchema.includes(adminRbacPermissionConstraint));
+    assert.match(adminRbacSchema, /login_id = LOWER\(TRIM\(login_id\)\)/);
+    assert.match(adminRbacSchema, /FOREIGN KEY \(parent_program_code\) REFERENCES admin_menu_items\(program_code\)/);
+    assert.doesNotMatch(adminRbacSchema, /\b(url|handler|controller|method)_/i);
+  }
   assert.match(adminProgramRegistry, /enum AdminProgram/);
   assert.match(adminProgramRegistry, /\/admin\/reports\/page/);
   assert.match(adminProgramRegistry, /AdminPermission\.REPORT_REVIEW/);
-  assert.match(adminPermission, /REPORT_REVIEW\("admin\.report\.review"\)/);
+  assert.match(inMemoryAdminRbacAuthorityRepository, /AdminPermission\.values\(\)/);
+  assert.match(inMemoryAdminRbacAuthorityRepository, /VALID_AUTHORITIES\.containsAll/);
   assert.match(jdbcAdminRbacAuthorityRepository, /JOIN admin_role_permissions/);
   assert.match(jdbcAdminRbacAuthorityRepository, /FROM admin_user_roles/);
   assert.match(adminIdentityUserDetailsService, /fallbackUserDetailsService/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3933,7 +3933,7 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(adminReportListTemplate, /page\.hasNext/);
   assert.match(security, /@Order\(1\)[\s\S]*?securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
-  assert.match(security, /anyRequest\(\)\.hasRole\("ADMIN"\)/);
+  assert.match(security, /anyRequest\(\)\.hasAnyAuthority\(AdminPermission\.ADMIN_VIEW\.authority\(\), "ROLE_ADMIN"\)/);
   assert.match(security, /adminSecurityFilterChain\([\s\S]*HttpSecurity http,[\s\S]*AdminOperatorAuditFilter auditFilter,[\s\S]*basicAuthEnabled/);
   assert.match(security, /adminSecurityFilterChain[\s\S]*addFilterAfter\(auditFilter, BasicAuthenticationFilter\.class\)/);
   assert.match(security, /@Order\(2\)[\s\S]*?securityMatcher\("\/operator\/\*\*"\)/);
@@ -6141,6 +6141,9 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
     "backend/src/main/java/com/easysubway/common/security/AdminOperatorLockoutAuthenticationProvider.java",
   );
   const adminIdentityPostgresSchema = read("backend/src/main/resources/db/migration/postgresql/V9__admin_identity.sql");
+  const adminRbacPostgresSchema = read("backend/src/main/resources/db/migration/postgresql/V10__admin_rbac_menu.sql");
+  const adminProgramRegistry = read("backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java");
+  const adminPermission = read("backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java");
   const adminIdentityUserDetailsService = read(
     "backend/src/main/java/com/easysubway/admin/identity/application/service/AdminIdentityUserDetailsService.java",
   );
@@ -6251,7 +6254,10 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.match(messages, /^common\.error\.invalid-parameter=요청 값을 확인해야 합니다\.$/m);
   assert.doesNotMatch(commonExceptionHandler, /StackTrace|printStackTrace|getStackTrace/);
   assert.match(securityConfig, /securityMatcher\("\/admin\/\*\*"\)/);
-  assert.match(securityConfig, /hasRole\("ADMIN"\)/);
+  assert.match(securityConfig, /hasAnyAuthority\(AdminPermission\.ADMIN_VIEW\.authority\(\), "ROLE_ADMIN"\)/);
+  assert.match(securityConfig, /hasAnyAuthority\(AdminPermission\.REPORT_REVIEW\.authority\(\), "ROLE_ADMIN"\)/);
+  assert.match(securityConfig, /hasAnyAuthority\(AdminPermission\.DATA_OPERATE\.authority\(\), "ROLE_ADMIN"\)/);
+  assert.match(securityConfig, /"\/admin\/notifications\/\*\*"/);
   assert.match(securityConfig, /hasRole\("OPERATOR_ADMIN"\)/);
   assert.match(securityConfig, /validateProdAdminCredentials/);
   assert.match(securityConfig, /validateProdBasicAuthPolicy/);
@@ -6307,8 +6313,19 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.match(adminIdentityPostgresSchema, /CREATE TABLE admin_login_audits/);
   assert.match(adminIdentityPostgresSchema, /outcome IN \('FAILED', 'LOCKED', 'DISABLED', 'PASSWORD_EXPIRED', 'CREDENTIAL_ROTATION_REQUIRED', 'SUCCESS'\)/);
   assert.match(adminIdentityPostgresSchema, /idx_admin_login_audits_login_occurred_at/);
+  assert.match(adminRbacPostgresSchema, /CREATE TABLE admin_role_permissions/);
+  assert.match(adminRbacPostgresSchema, /CREATE TABLE admin_user_roles/);
+  assert.match(adminRbacPostgresSchema, /CREATE TABLE admin_menu_items/);
+  assert.match(adminRbacPostgresSchema, /role_code IN \('ADMIN_VIEWER', 'REPORT_REVIEWER', 'MASTER_EDITOR', 'FIELD_OPERATOR', 'DATA_OPERATOR', 'SECURITY_ADMIN', 'SUPER_ADMIN'\)/);
+  assert.match(adminRbacPostgresSchema, /permission_code IN \('admin\.view', 'admin\.report\.review', 'admin\.master\.edit', 'admin\.field\.operate', 'admin\.data\.operate', 'admin\.security\.audit', 'admin\.security\.admin'\)/);
+  assert.doesNotMatch(adminRbacPostgresSchema, /\b(url|handler|controller|method)_/i);
+  assert.match(adminProgramRegistry, /enum AdminProgram/);
+  assert.match(adminProgramRegistry, /\/admin\/reports\/page/);
+  assert.match(adminProgramRegistry, /AdminPermission\.REPORT_REVIEW/);
+  assert.match(adminPermission, /REPORT_REVIEW\("admin\.report\.review"\)/);
   assert.match(adminIdentityUserDetailsService, /fallbackUserDetailsService/);
   assert.match(adminIdentityUserDetailsService, /credentialsExpired/);
+  assert.match(adminIdentityUserDetailsService, /AdminAuthorization\.authoritiesFor/);
   assert.match(jdbcAdminIdentityRepository, /@Profile\("prod"\)/);
   assert.match(jdbcAdminIdentityRepository, /INSERT INTO admin_users/);
   assert.match(jdbcAdminIdentityRepository, /INSERT INTO admin_login_audits/);


### PR DESCRIPTION
## 관련 이슈

close #954

## 작업 배경

관리자 기능이 단일 `ROLE_ADMIN` 기준으로 묶여 있어 신고 검수, 마스터 수정, 현장 검증, 데이터 수집, 감사 조회를 최소 권한으로 나누기 어렵다. 관리자 계정 영속화 이후 업무 행위 기준 permission과 코드 기반 program registry를 먼저 고정해 URL 보안, method security, 메뉴 노출 기준을 같은 모델로 맞춘다.

## 작업 내용

- `AdminPermission`, `AdminRbacRole`, `AdminAuthorization`을 추가해 관리자 업무 권한과 기본 역할 매핑을 정의했다.
- `AdminProgram` registry와 `AdminNavigationAdvice`를 추가하고 sidebar와 대시보드 CTA를 permission 기반으로 표시하도록 변경했다.
- `/admin/**` 보안을 세부 authority 기준으로 나누고, 기존 `ROLE_ADMIN`은 슈퍼 관리자 호환 경로로 유지했다.
- 신고 검수, 데이터 수집, 시설 상태 변경 등 주요 관리자 변경 entrypoint에 method security를 추가했다.
- `admin_role_permissions`, `admin_user_roles`, `admin_menu_items` Flyway migration을 추가하고, DB 메뉴가 임의 URL/handler 실행 기준을 갖지 않도록 contract를 고정했다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests '*SecurityConfig*' --tests '*AdminV3PageSmokeTest*' --rerun-tasks`: BUILD SUCCESSFUL
  - `cd backend && ./gradlew test --tests '*PushNotification*ControllerTest' --tests '*DataCollection*' --tests '*FacilityReportAdmin*' --tests '*Transit*Admin*'`: BUILD SUCCESSFUL
  - `node --test tools/ci/*.test.mjs`: 116 tests passed
  - `cd backend && ./gradlew test --rerun-tasks`: BUILD SUCCESSFUL
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| permission access | backend | `AdminV3PageSmokeTest`, `SecurityConfigTest` | 로컬 테스트 출력: BUILD SUCCESSFUL | `admin.view` 계정의 신고 검수/푸시 POST 접근이 403으로 차단되고 관리자 계정에 permission authority가 부여됨 |
| menu visibility | backend admin UI | HTML assertion | 로컬 테스트 출력: BUILD SUCCESSFUL | `admin.view` 계정은 검수/편집/수집 메뉴가 숨겨지고 `ROLE_ADMIN`은 전체 program을 볼 수 있음 |
| registry boundary | repository | `node --test tools/ci/*.test.mjs` | 116 tests passed | DB 메뉴 schema에 임의 URL/handler 실행 컬럼이 없고 `AdminProgram` registry 기준이 contract로 고정됨 |
| migration | backend DB | `cd backend && ./gradlew test --rerun-tasks` | BUILD SUCCESSFUL | H2 Flyway migration과 Spring context가 전체 테스트에서 로드됨 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `SecurityConfig`의 permission matcher 순서와 `AdminAuthorization`의 `ROLE_ADMIN` 호환 처리.

## 리스크

- `admin_user_roles`는 이번 변경에서 schema와 seed 기준만 추가했고, 계정별 RBAC 관리 화면/저장소 연결은 후속 작업 범위로 남는다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 관리자 화면이 권한별로 세분화되어, 사용자는 본인에게 허용된 메뉴와 기능만 볼 수 있습니다.
  * 대시보드와 관리자 내비게이션이 역할에 따라 동적으로 표시됩니다.
  * 관리자 메뉴와 접근 권한이 새로 정리되어, 더 세밀한 권한 제어가 적용됩니다.

* **Bug Fixes**
  * 관리자 작업 화면들의 접근 제한이 강화되어, 권한 없는 사용자의 직접 접근이 차단됩니다.
  * 일부 관리자 기능은 이제 적절한 권한 또는 관리자 역할이 있어야만 실행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->