### PR TITLE
[Feat] 관리자 배치 운영과 재처리 제어 도입

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/audit/application/service/AdminAuditWriter.java
+++ b/backend/src/main/java/com/easysubway/admin/audit/application/service/AdminAuditWriter.java
@@ -68,6 +68,35 @@ public class AdminAuditWriter {
 		));
 	}
 
+	public void batchOperation(
+		Authentication authentication,
+		HttpServletRequest request,
+		String targetType,
+		String targetId,
+		String action,
+		AdminAuditOutcome outcome,
+		String reason
+	) {
+		if (!enabled || !isAuthenticated(authentication)) {
+			return;
+		}
+		auditEventRepository.save(new AdminAuditEvent(
+			null,
+			AdminAuditEventType.BATCH_OPERATION,
+			authentication.getName(),
+			authorities(authentication),
+			correlationId(request),
+			clientIp(request),
+			userAgent(request),
+			targetType,
+			targetId,
+			action,
+			outcome,
+			reason,
+			LocalDateTime.now(clock)
+		));
+	}
+
 	public String sha256TargetId(String value) {
 		try {
 			return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256")

--- a/backend/src/main/java/com/easysubway/admin/audit/application/service/AdminAuditWriter.java
+++ b/backend/src/main/java/com/easysubway/admin/audit/application/service/AdminAuditWriter.java
@@ -48,24 +48,16 @@ public class AdminAuditWriter {
 		String action,
 		String reason
 	) {
-		if (!enabled || !isAuthenticated(authentication)) {
-			return;
-		}
-		auditEventRepository.save(new AdminAuditEvent(
-			null,
+		writeAudit(
+			authentication,
+			request,
 			AdminAuditEventType.PRIVACY_READ,
-			authentication.getName(),
-			authorities(authentication),
-			correlationId(request),
-			clientIp(request),
-			userAgent(request),
 			targetType,
 			targetId,
 			action,
 			AdminAuditOutcome.SUCCESS,
-			reason,
-			LocalDateTime.now(clock)
-		));
+			reason
+		);
 	}
 
 	public void batchOperation(
@@ -77,12 +69,34 @@ public class AdminAuditWriter {
 		AdminAuditOutcome outcome,
 		String reason
 	) {
+		writeAudit(
+			authentication,
+			request,
+			AdminAuditEventType.BATCH_OPERATION,
+			targetType,
+			targetId,
+			action,
+			outcome,
+			reason
+		);
+	}
+
+	private void writeAudit(
+		Authentication authentication,
+		HttpServletRequest request,
+		AdminAuditEventType eventType,
+		String targetType,
+		String targetId,
+		String action,
+		AdminAuditOutcome outcome,
+		String reason
+	) {
 		if (!enabled || !isAuthenticated(authentication)) {
 			return;
 		}
 		auditEventRepository.save(new AdminAuditEvent(
 			null,
-			AdminAuditEventType.BATCH_OPERATION,
+			eventType,
 			authentication.getName(),
 			authorities(authentication),
 			correlationId(request),

--- a/backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java
@@ -9,7 +9,8 @@ public enum AdminPermission {
 	SECURITY_AUDIT("admin.security.audit"),
 	SECURITY_ADMIN("admin.security.admin"),
 	AUDIT_READ("admin.audit.read"),
-	PRIVACY_LOG_READ("admin.privacy-log.read");
+	PRIVACY_LOG_READ("admin.privacy-log.read"),
+	BATCH_RETRY("admin.batch.retry");
 
 	private final String authority;
 

--- a/backend/src/main/java/com/easysubway/admin/authorization/AdminRbacRole.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/AdminRbacRole.java
@@ -9,7 +9,7 @@ public enum AdminRbacRole {
 	REPORT_REVIEWER(AdminPermission.ADMIN_VIEW, AdminPermission.REPORT_REVIEW),
 	MASTER_EDITOR(AdminPermission.ADMIN_VIEW, AdminPermission.MASTER_EDIT),
 	FIELD_OPERATOR(AdminPermission.ADMIN_VIEW, AdminPermission.FIELD_OPERATE),
-	DATA_OPERATOR(AdminPermission.ADMIN_VIEW, AdminPermission.DATA_OPERATE),
+	DATA_OPERATOR(AdminPermission.ADMIN_VIEW, AdminPermission.DATA_OPERATE, AdminPermission.BATCH_RETRY),
 	SECURITY_ADMIN(
 		AdminPermission.ADMIN_VIEW,
 		AdminPermission.SECURITY_AUDIT,

--- a/backend/src/main/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageController.java
@@ -1,0 +1,148 @@
+package com.easysubway.admin.batch.adapter.in.web;
+
+import com.easysubway.admin.audit.application.service.AdminAuditWriter;
+import com.easysubway.admin.audit.domain.AdminAuditOutcome;
+import com.easysubway.admin.batch.application.service.AdminBatchOperationService;
+import com.easysubway.admin.batch.domain.AdminBatchJob;
+import com.easysubway.collection.domain.DataCollectionRun;
+import com.easysubway.collection.domain.DataCollectionRunStep;
+import com.easysubway.collection.domain.DataCollectionStepStatus;
+import com.easysubway.collection.domain.DataCollectionStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Controller
+class AdminBatchPageController {
+
+	private static final int DEFAULT_RECENT_RUN_LIMIT = 20;
+
+	private final AdminBatchOperationService batchOperationService;
+	private final AdminAuditWriter auditWriter;
+
+	AdminBatchPageController(AdminBatchOperationService batchOperationService, AdminAuditWriter auditWriter) {
+		this.batchOperationService = batchOperationService;
+		this.auditWriter = auditWriter;
+	}
+
+	@GetMapping("/admin/batches/page")
+	String batchPage(Model model) {
+		model.addAttribute("jobs", batchOperationService.listJobs().stream().map(BatchJobRow::from).toList());
+		model.addAttribute("runs", batchOperationService.listExecutions(DEFAULT_RECENT_RUN_LIMIT)
+			.stream()
+			.map(BatchRunRow::from)
+			.toList());
+		return "admin/batches/list";
+	}
+
+	@PostMapping("/admin/batches/{jobId}/runs/{runId}/retry")
+	@PreAuthorize("hasAuthority('admin.batch.retry')")
+	String retry(
+		@PathVariable String jobId,
+		@PathVariable String runId,
+		Principal principal,
+		Authentication authentication,
+		HttpServletRequest request
+	) {
+		DataCollectionRun retried = batchOperationService.retry(jobId, runId, principal.getName());
+		auditWriter.batchOperation(
+			authentication,
+			request,
+			"BATCH_JOB",
+			jobId,
+			"RETRY_BATCH_RUN",
+			AdminAuditOutcome.SUCCESS,
+			"runId=%s retriedRunId=%s".formatted(runId, retried.runId())
+		);
+		return "redirect:/admin/batches/page";
+	}
+
+	record BatchJobRow(String id, String jobName, String label, boolean retryEnabled) {
+
+		static BatchJobRow from(AdminBatchJob job) {
+			return new BatchJobRow(job.id(), job.jobName(), job.label(), job.retryEnabled());
+		}
+	}
+
+	record BatchRunRow(
+		String runId,
+		String jobId,
+		String sourceLabel,
+		String statusLabel,
+		String requestedBy,
+		LocalDateTime startedAt,
+		LocalDateTime completedAt,
+		int collectedCount,
+		String failureMessage,
+		boolean retryable,
+		String operatorAction,
+		List<BatchStepRow> steps
+	) {
+
+		static BatchRunRow from(DataCollectionRun run) {
+			AdminBatchJob job = AdminBatchJob.all()
+				.stream()
+				.filter(candidate -> candidate.source() == run.source())
+				.findFirst()
+				.orElseThrow();
+			return new BatchRunRow(
+				run.runId(),
+				job.id(),
+				job.label(),
+				statusLabel(run.status()),
+				run.requestedBy(),
+				run.startedAt(),
+				run.completedAt(),
+				run.collectedCount(),
+				valueOrDash(run.failureMessage()),
+				run.retryable(),
+				run.operatorAction(),
+				run.steps().stream().map(BatchStepRow::from).toList()
+			);
+		}
+
+		public String completedAtLabel() {
+			return completedAt == null ? "-" : completedAt.toString();
+		}
+
+		public String retryableLabel() {
+			return retryable ? "가능" : "불가";
+		}
+
+		private static String statusLabel(DataCollectionStatus status) {
+			return switch (status) {
+				case RUNNING -> "실행 중";
+				case COMPLETED -> "완료";
+				case FAILED -> "실패";
+			};
+		}
+	}
+
+	record BatchStepRow(String name, String statusLabel, int recordCount, String failureMessage) {
+
+		static BatchStepRow from(DataCollectionRunStep step) {
+			return new BatchStepRow(step.name(), stepStatusLabel(step.status()), step.recordCount(), valueOrDash(step.failureMessage()));
+		}
+
+		private static String stepStatusLabel(DataCollectionStepStatus status) {
+			return switch (status) {
+				case COMPLETED -> "완료";
+				case FAILED -> "실패";
+				case SKIPPED -> "건너뜀";
+				case MANUAL_REQUIRED -> "수동 필요";
+			};
+		}
+	}
+
+	private static String valueOrDash(String value) {
+		return value == null || value.isBlank() ? "-" : value;
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageController.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
@@ -38,7 +39,7 @@ class AdminBatchPageController {
 		model.addAttribute("jobs", batchOperationService.listJobs().stream().map(BatchJobRow::from).toList());
 		model.addAttribute("runs", batchOperationService.listExecutions(DEFAULT_RECENT_RUN_LIMIT)
 			.stream()
-			.map(BatchRunRow::from)
+			.flatMap(run -> BatchRunRow.from(run).stream())
 			.toList());
 		return "admin/batches/list";
 	}
@@ -52,16 +53,29 @@ class AdminBatchPageController {
 		Authentication authentication,
 		HttpServletRequest request
 	) {
-		DataCollectionRun retried = batchOperationService.retry(jobId, runId, principal.getName());
-		auditWriter.batchOperation(
-			authentication,
-			request,
-			"BATCH_JOB",
-			jobId,
-			"RETRY_BATCH_RUN",
-			AdminAuditOutcome.SUCCESS,
-			"runId=%s retriedRunId=%s".formatted(runId, retried.runId())
-		);
+		try {
+			DataCollectionRun retried = batchOperationService.retry(jobId, runId, principal.getName());
+			auditWriter.batchOperation(
+				authentication,
+				request,
+				"BATCH_JOB",
+				jobId,
+				"RETRY_BATCH_RUN",
+				AdminAuditOutcome.SUCCESS,
+				"runId=%s retriedRunId=%s".formatted(runId, retried.runId())
+			);
+		} catch (RuntimeException exception) {
+			auditWriter.batchOperation(
+				authentication,
+				request,
+				"BATCH_JOB",
+				jobId,
+				"RETRY_BATCH_RUN",
+				AdminAuditOutcome.FAILURE,
+				"runId=%s error=%s".formatted(runId, exception.getMessage())
+			);
+			throw exception;
+		}
 		return "redirect:/admin/batches/page";
 	}
 
@@ -87,26 +101,25 @@ class AdminBatchPageController {
 		List<BatchStepRow> steps
 	) {
 
-		static BatchRunRow from(DataCollectionRun run) {
-			AdminBatchJob job = AdminBatchJob.all()
+		static Optional<BatchRunRow> from(DataCollectionRun run) {
+			return AdminBatchJob.all()
 				.stream()
 				.filter(candidate -> candidate.source() == run.source())
 				.findFirst()
-				.orElseThrow();
-			return new BatchRunRow(
-				run.runId(),
-				job.id(),
-				job.label(),
-				statusLabel(run.status()),
-				run.requestedBy(),
-				run.startedAt(),
-				run.completedAt(),
-				run.collectedCount(),
-				valueOrDash(run.failureMessage()),
-				run.retryable(),
-				run.operatorAction(),
-				run.steps().stream().map(BatchStepRow::from).toList()
-			);
+				.map(job -> new BatchRunRow(
+					run.runId(),
+					job.id(),
+					job.label(),
+					statusLabel(run.status()),
+					run.requestedBy(),
+					run.startedAt(),
+					run.completedAt(),
+					run.collectedCount(),
+					valueOrDash(run.failureMessage()),
+					run.retryable(),
+					run.operatorAction(),
+					run.steps().stream().map(BatchStepRow::from).toList()
+				));
 		}
 
 		public String completedAtLabel() {

--- a/backend/src/main/java/com/easysubway/admin/batch/application/service/AdminBatchOperationService.java
+++ b/backend/src/main/java/com/easysubway/admin/batch/application/service/AdminBatchOperationService.java
@@ -1,0 +1,49 @@
+package com.easysubway.admin.batch.application.service;
+
+import com.easysubway.admin.batch.domain.AdminBatchJob;
+import com.easysubway.collection.application.port.in.DataCollectionUseCase;
+import com.easysubway.collection.application.port.in.RunDataCollectionCommand;
+import com.easysubway.collection.application.port.out.LoadDataCollectionRunPort;
+import com.easysubway.collection.domain.DataCollectionRun;
+import com.easysubway.collection.domain.DataCollectionStatus;
+import com.easysubway.collection.domain.InvalidDataCollectionException;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AdminBatchOperationService {
+
+	private final LoadDataCollectionRunPort loadDataCollectionRunPort;
+	private final DataCollectionUseCase dataCollectionUseCase;
+
+	public AdminBatchOperationService(
+		LoadDataCollectionRunPort loadDataCollectionRunPort,
+		DataCollectionUseCase dataCollectionUseCase
+	) {
+		this.loadDataCollectionRunPort = loadDataCollectionRunPort;
+		this.dataCollectionUseCase = dataCollectionUseCase;
+	}
+
+	public List<AdminBatchJob> listJobs() {
+		return AdminBatchJob.all();
+	}
+
+	public List<DataCollectionRun> listExecutions(int limit) {
+		return loadDataCollectionRunPort.loadRecentRuns(limit);
+	}
+
+	public DataCollectionRun retry(String jobId, String runId, String requestedBy) {
+		AdminBatchJob job = AdminBatchJob.require(jobId);
+		DataCollectionRun failedRun = loadDataCollectionRunPort.loadRun(runId)
+			.orElseThrow(() -> new InvalidDataCollectionException("재처리할 배치 실행을 찾을 수 없습니다."));
+		if (failedRun.source() != job.source()) {
+			throw new InvalidDataCollectionException("배치 실행과 작업 registry가 일치하지 않습니다.");
+		}
+		if (!job.retryEnabled()
+			|| failedRun.status() != DataCollectionStatus.FAILED
+			|| !failedRun.retryable()) {
+			throw new InvalidDataCollectionException("재처리할 수 없는 배치 실행입니다.");
+		}
+		return dataCollectionUseCase.runCollection(new RunDataCollectionCommand(job.source(), requestedBy));
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/batch/domain/AdminBatchJob.java
+++ b/backend/src/main/java/com/easysubway/admin/batch/domain/AdminBatchJob.java
@@ -1,0 +1,61 @@
+package com.easysubway.admin.batch.domain;
+
+import com.easysubway.collection.domain.DataCollectionSource;
+import com.easysubway.collection.domain.InvalidDataCollectionException;
+import java.util.Arrays;
+import java.util.List;
+
+public enum AdminBatchJob {
+	TRANSIT_MASTER_COLLECTION(
+		"transit-master-collection",
+		"transitMasterCollectionJob",
+		"도시철도 마스터 수집",
+		DataCollectionSource.TRANSIT_MASTER,
+		true
+	);
+
+	private final String id;
+	private final String jobName;
+	private final String label;
+	private final DataCollectionSource source;
+	private final boolean retryEnabled;
+
+	AdminBatchJob(String id, String jobName, String label, DataCollectionSource source, boolean retryEnabled) {
+		this.id = id;
+		this.jobName = jobName;
+		this.label = label;
+		this.source = source;
+		this.retryEnabled = retryEnabled;
+	}
+
+	public String id() {
+		return id;
+	}
+
+	public String jobName() {
+		return jobName;
+	}
+
+	public String label() {
+		return label;
+	}
+
+	public DataCollectionSource source() {
+		return source;
+	}
+
+	public boolean retryEnabled() {
+		return retryEnabled;
+	}
+
+	public static List<AdminBatchJob> all() {
+		return Arrays.asList(values());
+	}
+
+	public static AdminBatchJob require(String id) {
+		return Arrays.stream(values())
+			.filter(job -> job.id.equals(id))
+			.findFirst()
+			.orElseThrow(() -> new InvalidDataCollectionException("허용되지 않은 배치 작업입니다."));
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
@@ -15,6 +15,7 @@ public enum AdminProgram {
 	QUALITY("a-quality", "제보·품질·검증", "데이터 품질", "/admin/data-quality/page", AdminPermission.ADMIN_VIEW),
 	FIELD("a-field-verifications", "제보·품질·검증", "현장 검증", "/admin/field-verifications/page", AdminPermission.FIELD_OPERATE),
 	COLLECTIONS("a-collections", "운영·분석", "데이터 수집", "/admin/data-collections/page", AdminPermission.DATA_OPERATE),
+	BATCHES("a-batches", "운영·분석", "배치 운영", "/admin/batches/page", AdminPermission.DATA_OPERATE),
 	ROUTE_SEARCHES("a-route-searches", "운영·분석", "경로 검색 분석", "/admin/routes/searches/page", AdminPermission.ADMIN_VIEW),
 	ROUTE_FEEDBACK("a-route-feedback", "운영·분석", "경로 피드백 분석", "/admin/routes/feedback/page", AdminPermission.ADMIN_VIEW),
 	PUSH("a-push", "운영·분석", "푸시 알림", "/admin/notifications/push/page", AdminPermission.DATA_OPERATE),

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -99,6 +99,10 @@ public class SecurityConfig {
 					"/admin/notifications/**"
 				)
 				.hasAuthority(AdminPermission.DATA_OPERATE.authority())
+				.requestMatchers(HttpMethod.POST, "/admin/batches/**")
+				.hasAuthority(AdminPermission.BATCH_RETRY.authority())
+				.requestMatchers(HttpMethod.GET, "/admin/batches/**")
+				.hasAuthority(AdminPermission.DATA_OPERATE.authority())
 				.requestMatchers("/admin/audits/privacy/**")
 				.hasAuthority(AdminPermission.PRIVACY_LOG_READ.authority())
 				.requestMatchers("/admin/audits/**")

--- a/backend/src/main/resources/db/migration/h2/V12__admin_batch_operation_permission.sql
+++ b/backend/src/main/resources/db/migration/h2/V12__admin_batch_operation_permission.sql
@@ -1,0 +1,13 @@
+ALTER TABLE admin_role_permissions DROP CONSTRAINT ck_h2_admin_role_permissions_permission;
+
+ALTER TABLE admin_role_permissions ADD CONSTRAINT ck_h2_admin_role_permissions_permission
+    CHECK (permission_code IN ('admin.view', 'admin.report.review', 'admin.master.edit', 'admin.field.operate', 'admin.data.operate', 'admin.security.audit', 'admin.security.admin', 'admin.audit.read', 'admin.privacy-log.read', 'admin.batch.retry'));
+
+INSERT INTO admin_role_permissions (created_at, permission_code, role_code)
+VALUES
+    (CURRENT_TIMESTAMP, 'admin.batch.retry', 'DATA_OPERATOR'),
+    (CURRENT_TIMESTAMP, 'admin.batch.retry', 'SUPER_ADMIN');
+
+INSERT INTO admin_menu_items (hidden, display_order, display_name, parent_program_code, program_code)
+VALUES
+    (FALSE, 85, '배치 운영', NULL, 'a-batches');

--- a/backend/src/main/resources/db/migration/postgresql/V12__admin_batch_operation_permission.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V12__admin_batch_operation_permission.sql
@@ -1,0 +1,13 @@
+ALTER TABLE admin_role_permissions DROP CONSTRAINT admin_role_permissions_permission_code_check;
+
+ALTER TABLE admin_role_permissions ADD CONSTRAINT admin_role_permissions_permission_code_check
+    CHECK (permission_code IN ('admin.view', 'admin.report.review', 'admin.master.edit', 'admin.field.operate', 'admin.data.operate', 'admin.security.audit', 'admin.security.admin', 'admin.audit.read', 'admin.privacy-log.read', 'admin.batch.retry'));
+
+INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
+VALUES
+    ('DATA_OPERATOR', 'admin.batch.retry', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.batch.retry', CURRENT_TIMESTAMP);
+
+INSERT INTO admin_menu_items (program_code, parent_program_code, display_name, display_order, hidden)
+VALUES
+    ('a-batches', NULL, '배치 운영', 85, FALSE);

--- a/backend/src/main/resources/templates/admin/batches/list.html
+++ b/backend/src/main/resources/templates/admin/batches/list.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>배치 운영</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-batches')}"></div>
+<main class="admin-main">
+	<header class="admin-page-head">
+		<div>
+			<h1>배치 운영</h1>
+			<p>허용된 배치 작업의 실행 이력과 실패 step, 재처리 가능 여부를 확인합니다.</p>
+		</div>
+	</header>
+
+	<section>
+		<h2>허용된 배치 작업</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">작업 ID</th>
+				<th scope="col">Spring Batch job</th>
+				<th scope="col">이름</th>
+				<th scope="col">재처리 정책</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="job : ${jobs}">
+				<td th:text="${job.id}">transit-master-collection</td>
+				<td th:text="${job.jobName}">transitMasterCollectionJob</td>
+				<td th:text="${job.label}">도시철도 마스터 수집</td>
+				<td th:text="${job.retryEnabled ? '실패·retryable 실행만 허용' : '재처리 불가'}">실패·retryable 실행만 허용</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>최근 배치 실행</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">실행 ID</th>
+				<th scope="col">작업</th>
+				<th scope="col">상태</th>
+				<th scope="col">요청자</th>
+				<th scope="col">시작</th>
+				<th scope="col">완료</th>
+				<th scope="col">Step</th>
+				<th scope="col">실패 사유</th>
+				<th scope="col">재처리</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:if="${runs.isEmpty()}">
+				<td colspan="9">최근 배치 실행이 없습니다.</td>
+			</tr>
+			<tr th:each="run : ${runs}">
+				<td th:text="${run.runId}">run-id</td>
+				<td th:text="${run.sourceLabel}">도시철도 마스터 수집</td>
+				<td th:text="${run.statusLabel}">실패</td>
+				<td th:text="${run.requestedBy}">admin</td>
+				<td th:text="${run.startedAt}">2026-06-27T00:00</td>
+				<td th:text="${run.completedAtLabel()}">-</td>
+				<td>
+					<ul>
+						<li th:each="step : ${run.steps}">
+							<strong th:text="${step.name}">FETCH</strong>
+							<span th:text="${step.statusLabel}">실패</span>
+							<span th:text="${'건수 ' + step.recordCount}">건수 0</span>
+							<span th:text="${step.failureMessage}">-</span>
+						</li>
+					</ul>
+				</td>
+				<td th:text="${run.failureMessage}">실패 사유</td>
+				<td>
+					<form th:if="${run.retryable}"
+					      th:action="@{'/admin/batches/' + ${run.jobId} + '/runs/' + ${run.runId} + '/retry'}"
+					      method="post">
+						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+						<button type="submit">재처리</button>
+					</form>
+					<span th:unless="${run.retryable}" th:text="${run.retryableLabel()}">불가</span>
+					<p class="meta" th:text="${run.operatorAction}">다음 행동</p>
+				</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageControllerTest.java
@@ -1,0 +1,124 @@
+package com.easysubway.admin.batch.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.easysubway.admin.audit.adapter.out.persistence.InMemoryAdminAuditEventRepository;
+import com.easysubway.admin.audit.domain.AdminAuditEventType;
+import com.easysubway.collection.application.port.out.SaveDataCollectionRunPort;
+import com.easysubway.collection.domain.DataCollectionRun;
+import com.easysubway.collection.domain.DataCollectionRunStep;
+import com.easysubway.collection.domain.DataCollectionSource;
+import com.easysubway.collection.domain.DataCollectionStatus;
+import com.easysubway.collection.domain.DataCollectionStepStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password"
+})
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DisplayName("관리자 배치 운영 화면")
+class AdminBatchPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private SaveDataCollectionRunPort saveDataCollectionRunPort;
+
+	@Autowired
+	private InMemoryAdminAuditEventRepository auditEventRepository;
+
+	@Test
+	@DisplayName("관리자는 허용 batch registry와 실패 step, 재처리 버튼을 확인한다")
+	void adminViewsBatchRegistryAndFailedSteps() throws Exception {
+		saveDataCollectionRunPort.saveRun(failedRun("failed-run"));
+
+		String html = mockMvc.perform(get("/admin/batches/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("배치 운영")
+			.contains("transit-master-collection")
+			.contains("transitMasterCollectionJob")
+			.contains("도시철도 마스터 수집")
+			.contains("failed-run")
+			.contains("FETCH")
+			.contains("source timeout")
+			.contains("재처리")
+			.contains("/admin/batches/transit-master-collection/runs/failed-run/retry");
+	}
+
+	@Test
+	@DisplayName("BATCH_RETRY 권한이 있는 관리자는 실패 실행을 재처리하고 audit을 남긴다")
+	void adminRetriesFailedRunAndWritesAudit() throws Exception {
+		saveDataCollectionRunPort.saveRun(failedRun("failed-run"));
+
+		mockMvc.perform(post("/admin/batches/transit-master-collection/runs/failed-run/retry")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED))
+			.andExpect(status().is3xxRedirection())
+			.andExpect(header().string("Location", "/admin/batches/page"));
+
+		assertThat(auditEventRepository.findRecent(AdminAuditEventType.BATCH_OPERATION, 1))
+			.singleElement()
+			.satisfies(event -> {
+				assertThat(event.actor()).isEqualTo("admin-user");
+				assertThat(event.targetType()).isEqualTo("BATCH_JOB");
+				assertThat(event.targetId()).isEqualTo("transit-master-collection");
+				assertThat(event.action()).isEqualTo("RETRY_BATCH_RUN");
+				assertThat(event.reason()).contains("failed-run");
+			});
+	}
+
+	@Test
+	@DisplayName("BATCH_RETRY 권한이 없으면 재처리 entrypoint에 접근할 수 없다")
+	void retryRequiresBatchRetryPermission() throws Exception {
+		saveDataCollectionRunPort.saveRun(failedRun("failed-run"));
+
+		mockMvc.perform(post("/admin/batches/transit-master-collection/runs/failed-run/retry")
+				.with(user("operator").authorities(new SimpleGrantedAuthority("admin.data.operate")))
+				.with(csrf()))
+			.andExpect(status().isForbidden());
+	}
+
+	private DataCollectionRun failedRun(String runId) {
+		LocalDateTime now = LocalDateTime.of(2026, 6, 27, 0, 0);
+		return new DataCollectionRun(
+			runId,
+			DataCollectionSource.TRANSIT_MASTER,
+			DataCollectionStatus.FAILED,
+			"batch-test",
+			now,
+			now.plusMinutes(1),
+			0,
+			"FETCH 실패",
+			true,
+			"원인 확인 후 재처리하세요.",
+			List.of(new DataCollectionRunStep("FETCH", DataCollectionStepStatus.FAILED, null, null, null, 0, "source timeout"))
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.easysubway.admin.audit.adapter.out.persistence.InMemoryAdminAuditEventRepository;
 import com.easysubway.admin.audit.domain.AdminAuditEventType;
+import com.easysubway.admin.audit.domain.AdminAuditOutcome;
 import com.easysubway.collection.application.port.out.SaveDataCollectionRunPort;
 import com.easysubway.collection.domain.DataCollectionRun;
 import com.easysubway.collection.domain.DataCollectionRunStep;
@@ -95,6 +96,29 @@ class AdminBatchPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자 재처리 거부도 실패 audit을 남긴다")
+	void rejectedRetryWritesFailureAudit() throws Exception {
+		saveDataCollectionRunPort.saveRun(completedRun("completed-run"));
+
+		mockMvc.perform(post("/admin/batches/transit-master-collection/runs/completed-run/retry")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED))
+			.andExpect(status().isBadRequest());
+
+		assertThat(auditEventRepository.findRecent(AdminAuditEventType.BATCH_OPERATION, 1))
+			.singleElement()
+			.satisfies(event -> {
+				assertThat(event.actor()).isEqualTo("admin-user");
+				assertThat(event.targetType()).isEqualTo("BATCH_JOB");
+				assertThat(event.targetId()).isEqualTo("transit-master-collection");
+				assertThat(event.action()).isEqualTo("RETRY_BATCH_RUN");
+				assertThat(event.outcome()).isEqualTo(AdminAuditOutcome.FAILURE);
+				assertThat(event.reason()).contains("completed-run", "재처리할 수 없는 배치 실행");
+			});
+	}
+
+	@Test
 	@DisplayName("BATCH_RETRY 권한이 없으면 재처리 entrypoint에 접근할 수 없다")
 	void retryRequiresBatchRetryPermission() throws Exception {
 		saveDataCollectionRunPort.saveRun(failedRun("failed-run"));
@@ -119,6 +143,23 @@ class AdminBatchPageControllerTest {
 			true,
 			"원인 확인 후 재처리하세요.",
 			List.of(new DataCollectionRunStep("FETCH", DataCollectionStepStatus.FAILED, null, null, null, 0, "source timeout"))
+		);
+	}
+
+	private DataCollectionRun completedRun(String runId) {
+		LocalDateTime now = LocalDateTime.of(2026, 6, 27, 0, 0);
+		return new DataCollectionRun(
+			runId,
+			DataCollectionSource.TRANSIT_MASTER,
+			DataCollectionStatus.COMPLETED,
+			"batch-test",
+			now,
+			now.plusMinutes(1),
+			1,
+			null,
+			false,
+			"수집 완료",
+			List.of(new DataCollectionRunStep("FETCH", DataCollectionStepStatus.COMPLETED, null, null, null, 1, null))
 		);
 	}
 }

--- a/backend/src/test/java/com/easysubway/admin/batch/application/service/AdminBatchOperationServiceTest.java
+++ b/backend/src/test/java/com/easysubway/admin/batch/application/service/AdminBatchOperationServiceTest.java
@@ -1,0 +1,106 @@
+package com.easysubway.admin.batch.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.collection.adapter.out.persistence.InMemoryDataCollectionRunRepository;
+import com.easysubway.collection.application.port.in.DataCollectionUseCase;
+import com.easysubway.collection.application.port.in.RunDataCollectionCommand;
+import com.easysubway.collection.domain.DataCollectionRun;
+import com.easysubway.collection.domain.DataCollectionRunStep;
+import com.easysubway.collection.domain.DataCollectionSource;
+import com.easysubway.collection.domain.DataCollectionStatus;
+import com.easysubway.collection.domain.DataCollectionStepStatus;
+import com.easysubway.collection.domain.InvalidDataCollectionException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("관리자 배치 운영 서비스")
+class AdminBatchOperationServiceTest {
+
+	private final InMemoryDataCollectionRunRepository repository = new InMemoryDataCollectionRunRepository();
+	private final AtomicReference<RunDataCollectionCommand> retriedCommand = new AtomicReference<>();
+	private final DataCollectionUseCase useCase = new DataCollectionUseCase() {
+		@Override
+		public DataCollectionRun runCollection(RunDataCollectionCommand command) {
+			retriedCommand.set(command);
+			DataCollectionRun retried = completedRun("retry-run");
+			repository.saveRun(retried);
+			return retried;
+		}
+
+		@Override
+		public Optional<DataCollectionRun> getLatestCompletedRun(DataCollectionSource source) {
+			return Optional.empty();
+		}
+
+		@Override
+		public List<DataCollectionRun> listRecentRuns(int limit) {
+			return repository.loadRecentRuns(limit);
+		}
+	};
+	private final AdminBatchOperationService service = new AdminBatchOperationService(repository, useCase);
+
+	@Test
+	@DisplayName("registry에 있는 실패·retryable 실행만 재처리한다")
+	void retryAllowedFailedRun() {
+		repository.saveRun(failedRun("failed-run", true));
+
+		DataCollectionRun retried = service.retry("transit-master-collection", "failed-run", "admin-user");
+
+		assertThat(retried.runId()).isEqualTo("retry-run");
+		assertThat(retriedCommand.get().source()).isEqualTo(DataCollectionSource.TRANSIT_MASTER);
+		assertThat(retriedCommand.get().requestedBy()).isEqualTo("admin-user");
+	}
+
+	@Test
+	@DisplayName("registry 밖 job id와 성공 실행 재처리는 거부한다")
+	void retryRejectsUnknownJobAndCompletedRun() {
+		repository.saveRun(completedRun("completed-run"));
+
+		assertThatThrownBy(() -> service.retry("unknown-job", "completed-run", "admin-user"))
+			.isInstanceOf(InvalidDataCollectionException.class)
+			.hasMessageContaining("허용되지 않은 배치 작업");
+		assertThatThrownBy(() -> service.retry("transit-master-collection", "completed-run", "admin-user"))
+			.isInstanceOf(InvalidDataCollectionException.class)
+			.hasMessageContaining("재처리할 수 없는 배치 실행");
+	}
+
+	private DataCollectionRun completedRun(String runId) {
+		LocalDateTime now = LocalDateTime.of(2026, 6, 27, 0, 0);
+		return new DataCollectionRun(
+			runId,
+			DataCollectionSource.TRANSIT_MASTER,
+			DataCollectionStatus.COMPLETED,
+			"batch-test",
+			now,
+			now.plusMinutes(1),
+			1,
+			null,
+			false,
+			"수집 완료",
+			List.of(new DataCollectionRunStep("FETCH", DataCollectionStepStatus.COMPLETED, null, null, null, 1, null))
+		);
+	}
+
+	private DataCollectionRun failedRun(String runId, boolean retryable) {
+		LocalDateTime now = LocalDateTime.of(2026, 6, 27, 0, 0);
+		return new DataCollectionRun(
+			runId,
+			DataCollectionSource.TRANSIT_MASTER,
+			DataCollectionStatus.FAILED,
+			"batch-test",
+			now,
+			now.plusMinutes(1),
+			0,
+			"FETCH 실패",
+			retryable,
+			"원인 확인 후 재처리하세요.",
+			List.of(new DataCollectionRunStep("FETCH", DataCollectionStepStatus.FAILED, null, null, null, 0, "source timeout"))
+		);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -6144,10 +6144,12 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   const adminRbacPostgresSchema = [
     read("backend/src/main/resources/db/migration/postgresql/V10__admin_rbac_menu.sql"),
     read("backend/src/main/resources/db/migration/postgresql/V11__admin_audit_events.sql"),
+    read("backend/src/main/resources/db/migration/postgresql/V12__admin_batch_operation_permission.sql"),
   ].join("\n");
   const adminRbacH2Schema = [
     read("backend/src/main/resources/db/migration/h2/V10__admin_rbac_menu.sql"),
     read("backend/src/main/resources/db/migration/h2/V11__admin_audit_events.sql"),
+    read("backend/src/main/resources/db/migration/h2/V12__admin_batch_operation_permission.sql"),
   ].join("\n");
   const adminProgramRegistry = read("backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java");
   const adminPermission = read("backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java");
@@ -6351,6 +6353,7 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
     "admin.security.admin",
     "admin.audit.read",
     "admin.privacy-log.read",
+    "admin.batch.retry",
   ]);
   for (const adminRbacSchema of [adminRbacPostgresSchema, adminRbacH2Schema]) {
     assert.match(adminRbacSchema, /CREATE TABLE admin_role_permissions/);
@@ -6369,6 +6372,8 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.match(adminProgramRegistry, /enum AdminProgram/);
   assert.match(adminProgramRegistry, /\/admin\/reports\/page/);
   assert.match(adminProgramRegistry, /AdminPermission\.REPORT_REVIEW/);
+  assert.match(adminProgramRegistry, /\/admin\/batches\/page/);
+  assert.match(adminProgramRegistry, /AdminPermission\.DATA_OPERATE/);
   assert.match(inMemoryAdminRbacAuthorityRepository, /AdminPermission\.values\(\)/);
   assert.match(inMemoryAdminRbacAuthorityRepository, /VALID_AUTHORITIES\.containsAll/);
   assert.match(jdbcAdminRbacAuthorityRepository, /JOIN admin_role_permissions/);


### PR DESCRIPTION
## 관련 이슈

close #956

## 작업 배경

관리자 플랫폼에서 배치 실패를 운영자가 확인하고 제한된 범위에서 재처리할 수 있어야 합니다. 임의 job name이나 parameter를 직접 받지 않고, 서버가 보유한 허용 registry와 기존 수집 실행 이력을 기준으로 재처리 대상을 제한했습니다.

## 작업 내용

- `transit-master-collection` 관리자 배치 registry를 추가하고 허용된 작업만 조회·재처리하도록 제한했습니다.
- `/admin/batches/page` 화면에서 최근 배치 실행, 실패 step, 실패 사유, 재처리 가능 여부를 확인할 수 있게 했습니다.
- `/admin/batches/{jobId}/runs/{runId}/retry` POST entrypoint는 `admin.batch.retry` 권한과 실패·retryable 실행 조건을 모두 만족할 때만 새 수집 실행을 요청합니다.
- DATA_OPERATOR와 SUPER_ADMIN에 `admin.batch.retry` 권한을 부여하고 H2/PostgreSQL V12 마이그레이션과 관리자 메뉴를 추가했습니다.
- 재처리 성공과 거부된 재처리 실패 모두 `BATCH_OPERATION` audit event를 남기고, batch registry/service/controller 테스트와 repository contract를 갱신했습니다.
- registry에 없는 과거 batch source가 실행 이력에 남아 있어도 관리자 목록 화면이 500으로 깨지지 않도록 미등록 source는 렌더링에서 제외합니다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests '*Admin*Batch*' --tests '*DataCollection*' --tests '*SecurityConfig*' --tests '*Audit*'`: BUILD SUCCESSFUL
  - `cd backend && ./gradlew test --tests '*Admin*Batch*' --tests '*Audit*'`: BUILD SUCCESSFUL in 8s
  - `node --test tools/ci/*.test.mjs`: 116 tests passed, 0 failed
  - `cd backend && ./gradlew test`: BUILD SUCCESSFUL in 1m 13s
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 배치 운영 화면 | Backend MVC | MockMvc GET `/admin/batches/page` | `AdminBatchPageControllerTest.adminViewsBatchRegistryAndFailedSteps` | registry, Spring Batch job name, 실패 step, 재처리 form 렌더링 확인 |
| 재처리 권한 gate | Backend Security | MockMvc POST `/admin/batches/.../retry` | `AdminBatchPageControllerTest.retryRequiresBatchRetryPermission` | `admin.batch.retry` 없는 operator는 403 Forbidden |
| 재처리 도메인 guard | Backend Service | service unit test | `AdminBatchOperationServiceTest.retryRejectsUnknownJobAndCompletedRun` | registry 밖 job id와 완료 실행 재처리 거부 |
| 재처리 성공 audit | Backend MVC | MockMvc POST 후 audit repository 확인 | `AdminBatchPageControllerTest.adminRetriesFailedRunAndWritesAudit` | `BATCH_OPERATION` success event와 target/action/reason 기록 확인 |
| 재처리 실패 audit | Backend MVC | 완료 실행 재처리 POST 후 audit repository 확인 | `AdminBatchPageControllerTest.rejectedRetryWritesFailureAudit` | `BATCH_OPERATION` failure event와 거부 사유 기록 확인 |
| DB/RBAC 계약 | Repository CI | `node --test tools/ci/*.test.mjs` | 116 tests passed | H2/PostgreSQL V12 permission, menu, registry 계약 통과 |
| 전체 백엔드 회귀 | Backend Gradle | `cd backend && ./gradlew test` | BUILD SUCCESSFUL in 1m 13s | 전체 테스트 통과 |
| PR CI/review gate | GitHub PR | `gh pr checks 1001`, review thread API 확인 | 모든 PR checks pass, CodeRabbit pass, reviewThreads resolved | merge gate 통과 |
| 시각 증거 | Backend MVC | HTML template과 MockMvc assertion | 증거 불필요 사유: 기존 admin-v3 table shell에 동일 패턴 화면을 추가했고 브라우저 동작보다 권한·POST guard·audit 동작이 핵심 범위입니다. | 화면 주요 문구와 form action은 자동화 테스트로 검증 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `AdminBatchJob` registry와 `AdminBatchOperationService.retry`가 임의 Spring Batch job/parameter 실행을 열지 않고 기존 `DataCollectionUseCase`만 호출하는지 확인해 주세요.
- 실패 실행을 직접 재시작하지 않고 새 수집 실행을 만드는 방식입니다. 운영자가 완료 실행을 재처리하거나 registry 밖 job을 실행하는 경로는 열지 않았습니다.
- CodeRabbit 지적 3건은 후속 커밋 `a592c37`에서 반영했고 원래 inline thread에 해결 답글을 남긴 뒤 resolve했습니다.

## 리스크

- 현재 registry는 `TRANSIT_MASTER` 단일 작업만 포함합니다. 신규 배치를 운영 화면에 노출하려면 `AdminBatchJob`에 명시적으로 추가해야 합니다.
- V12 마이그레이션은 role permission check constraint를 재정의하므로, 후속 권한 추가 시 repository contract와 양쪽 DB migration을 함께 갱신해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (해당 없음: CodeRabbit completed)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (Release Artifacts checks pass, 실패 신호 없음)
