### PR TITLE
[CI] SonarCloud scanner 비활성 상태 표시 개선

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -29,12 +29,16 @@ env:
 
 jobs:
   automatic-analysis:
+    name: SonarCloud CI scanner disabled
     if: vars.SONARCLOUD_CI_ENABLED != 'true'
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - name: Keep SonarCloud automatic analysis
-        run: echo "SonarCloud CI scanner is skipped because SONARCLOUD_CI_ENABLED is not true."
+      - name: Explain SonarCloud analysis method
+        run: |
+          echo "SonarCloud CI scanner is disabled because SONARCLOUD_CI_ENABLED is not true."
+          echo "SonarQube Cloud Automatic Analysis is expected to provide the actual code-analysis check."
+          echo "Do not enable the CI scanner unless Automatic Analysis is disabled in SonarQube Cloud."
 
   sonarcloud:
     if: vars.SONARCLOUD_CI_ENABLED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)


### PR DESCRIPTION
## 관련 이슈

close #1003

## 작업 배경

`SONARCLOUD_CI_ENABLED=false` 운영에서는 GitHub Actions scanner job이 실제 분석을 수행하지 않고, SonarQube Cloud Automatic Analysis check가 코드 분석을 담당한다. 기존 placeholder job 이름과 로그가 실제 scanner 실행처럼 보일 수 있어 check 의미를 명확히 한다.

## 작업 내용

- `automatic-analysis` job 표시명을 `SonarCloud CI scanner disabled`로 지정했다.
- placeholder step 이름과 로그를 scanner 비활성 상태, Automatic Analysis 기대 동작, CI scanner 전환 조건으로 정리했다.
- CI scanner 전환, Flutter 준비 단계, JaCoCo, Sonar scope 변경은 포함하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/sonarcloud.yml`: exit 0
  - `node --test tools/ci/*.test.mjs`: exit 0, 116/116 tests passed
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| SonarCloud workflow YAML | local | Ruby YAML parser | command output | exit 0 |
| Repository contract | local | Node test runner | `116/116 tests passed` | 통과 |
| Whitespace check | local | Git diff check | command output | exit 0 |
| PR checks | GitHub Actions | PR checks | CI run `28271236819`, Release Artifacts run `28271236618`, SonarCloud run `28271236614` | 통과 |
| Review fallback | GitHub PR review | Codex CLI fallback review | PR review `4583272822` | actionable 0건 |
| UI evidence | 해당 없음 | CI workflow 문구 변경 | 증거 불필요 사유: 앱 화면, 접근성, 사용자 흐름 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 이 PR은 Automatic Analysis 유지 상태에서 placeholder job의 의미만 명확히 한다.

## 리스크

- job 표시명이 바뀌므로 branch protection에서 기존 표시명을 required check로 직접 지정했다면 required check 이름 갱신이 필요할 수 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. 배포 workflow 변경은 없고 PR release artifact checks만 확인했다.
