### PR TITLE
[Feat] 관리자 목록과 검색 PaginationInfo 표준화

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/audit/adapter/in/web/AdminAuditPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/audit/adapter/in/web/AdminAuditPageController.java
@@ -3,11 +3,15 @@ package com.easysubway.admin.audit.adapter.in.web;
 import com.easysubway.admin.audit.application.port.out.AdminAuditEventRepository;
 import com.easysubway.admin.audit.domain.AdminAuditEvent;
 import com.easysubway.admin.audit.domain.AdminAuditEventType;
+import com.easysubway.common.web.pagination.AdminPageRequest;
+import com.easysubway.common.web.pagination.EgovPaginationView;
+import java.util.Collections;
 import java.util.List;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 class AdminAuditPageController {
@@ -20,20 +24,56 @@ class AdminAuditPageController {
 
 	@GetMapping("/admin/audits/page")
 	@PreAuthorize("hasAuthority('admin.audit.read')")
-	String auditPage(Model model) {
-		model.addAttribute("title", "관리자 감사");
-		model.addAttribute("activeProgram", "a-audits");
-		model.addAttribute("events", rows(auditEventRepository.findRecent(null, 100)));
+	String auditPage(
+		@RequestParam(required = false) Integer page,
+		@RequestParam(required = false) Integer size,
+		Model model
+	) {
+		populateAuditModel(model, "관리자 감사", "a-audits", "/admin/audits/page", null, page, size);
 		return "admin/audits/list";
 	}
 
 	@GetMapping("/admin/audits/privacy/page")
 	@PreAuthorize("hasAuthority('admin.privacy-log.read')")
-	String privacyAuditPage(Model model) {
-		model.addAttribute("title", "개인정보 조회 로그");
-		model.addAttribute("activeProgram", "a-privacy-audits");
-		model.addAttribute("events", rows(auditEventRepository.findRecent(AdminAuditEventType.PRIVACY_READ, 100)));
+	String privacyAuditPage(
+		@RequestParam(required = false) Integer page,
+		@RequestParam(required = false) Integer size,
+		Model model
+	) {
+		populateAuditModel(
+			model,
+			"개인정보 조회 로그",
+			"a-privacy-audits",
+			"/admin/audits/privacy/page",
+			AdminAuditEventType.PRIVACY_READ,
+			page,
+			size
+		);
 		return "admin/audits/list";
+	}
+
+	private void populateAuditModel(
+		Model model,
+		String title,
+		String activeProgram,
+		String path,
+		AdminAuditEventType eventType,
+		Integer page,
+		Integer size
+	) {
+		AdminPageRequest pageRequest = AdminPageRequest.of(page, size);
+		List<AuditEventRow> events = rows(auditEventRepository.findRecent(
+			eventType,
+			pageRequest.limitForHasNext(),
+			pageRequest.offset()
+		));
+		EgovPaginationView pageView = EgovPaginationView.fromSlice(pageRequest.page(), pageRequest.size(), events.size());
+		model.addAttribute("title", title);
+		model.addAttribute("paginationLabel", title + " 페이지");
+		model.addAttribute("activeProgram", activeProgram);
+		model.addAttribute("events", pageView.visibleItems(events));
+		model.addAttribute("page", pageView);
+		model.addAttribute("paginationLinks", pageView.links(path, Collections.emptyMap()));
 	}
 
 	private static List<AuditEventRow> rows(List<AdminAuditEvent> events) {

--- a/backend/src/main/java/com/easysubway/admin/audit/adapter/out/persistence/InMemoryAdminAuditEventRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/audit/adapter/out/persistence/InMemoryAdminAuditEventRepository.java
@@ -37,10 +37,19 @@ public class InMemoryAdminAuditEventRepository implements AdminAuditEventReposit
 
 	@Override
 	public synchronized List<AdminAuditEvent> findRecent(AdminAuditEventType eventType, int limit) {
+		return findRecent(eventType, limit, 0);
+	}
+
+	@Override
+	public synchronized List<AdminAuditEvent> findRecent(AdminAuditEventType eventType, int limit, int offset) {
 		List<AdminAuditEvent> recent = new ArrayList<>();
+		int skipped = 0;
 		for (int index = events.size() - 1; index >= 0 && recent.size() < Math.max(0, limit); index--) {
 			AdminAuditEvent event = events.get(index);
 			if (eventType == null || event.eventType() == eventType) {
+				if (skipped++ < Math.max(offset, 0)) {
+					continue;
+				}
 				recent.add(event);
 			}
 		}

--- a/backend/src/main/java/com/easysubway/admin/audit/adapter/out/persistence/JdbcAdminAuditEventRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/audit/adapter/out/persistence/JdbcAdminAuditEventRepository.java
@@ -50,14 +50,19 @@ public class JdbcAdminAuditEventRepository implements AdminAuditEventRepository 
 
 	@Override
 	public List<AdminAuditEvent> findRecent(AdminAuditEventType eventType, int limit) {
+		return findRecent(eventType, limit, 0);
+	}
+
+	@Override
+	public List<AdminAuditEvent> findRecent(AdminAuditEventType eventType, int limit, int offset) {
 		if (eventType == null) {
 			return jdbcTemplate.query("""
 				SELECT audit_id, event_type, actor, role_permission, request_id, client_ip, user_agent,
 					target_type, target_id, action, outcome, reason, occurred_at
 				FROM admin_audit_events
 				ORDER BY occurred_at DESC, audit_id DESC
-				LIMIT ?
-				""", this::mapEvent, limit);
+				LIMIT ? OFFSET ?
+				""", this::mapEvent, limit, Math.max(offset, 0));
 		}
 		return jdbcTemplate.query("""
 			SELECT audit_id, event_type, actor, role_permission, request_id, client_ip, user_agent,
@@ -65,8 +70,8 @@ public class JdbcAdminAuditEventRepository implements AdminAuditEventRepository 
 			FROM admin_audit_events
 			WHERE event_type = ?
 			ORDER BY occurred_at DESC, audit_id DESC
-			LIMIT ?
-			""", this::mapEvent, eventType.name(), limit);
+			LIMIT ? OFFSET ?
+			""", this::mapEvent, eventType.name(), limit, Math.max(offset, 0));
 	}
 
 	private AdminAuditEvent mapEvent(ResultSet resultSet, int rowNumber) throws SQLException {

--- a/backend/src/main/java/com/easysubway/admin/audit/application/port/out/AdminAuditEventRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/audit/application/port/out/AdminAuditEventRepository.java
@@ -9,4 +9,8 @@ public interface AdminAuditEventRepository {
 	void save(AdminAuditEvent event);
 
 	List<AdminAuditEvent> findRecent(AdminAuditEventType eventType, int limit);
+
+	default List<AdminAuditEvent> findRecent(AdminAuditEventType eventType, int limit, int offset) {
+		return offset <= 0 ? findRecent(eventType, limit) : List.of();
+	}
 }

--- a/backend/src/main/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageController.java
@@ -5,6 +5,8 @@ import com.easysubway.admin.audit.application.service.AdminAuditWriter;
 import com.easysubway.admin.audit.domain.AdminAuditOutcome;
 import com.easysubway.admin.batch.application.service.AdminBatchOperationService;
 import com.easysubway.admin.batch.domain.AdminBatchJob;
+import com.easysubway.common.web.pagination.AdminPageRequest;
+import com.easysubway.common.web.pagination.EgovPaginationView;
 import com.easysubway.collection.domain.DataCollectionRun;
 import com.easysubway.collection.domain.DataCollectionRunStep;
 import com.easysubway.collection.domain.DataCollectionStepStatus;
@@ -15,6 +17,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import java.security.Principal;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -26,11 +29,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 class AdminBatchPageController {
-
-	private static final int DEFAULT_RECENT_RUN_LIMIT = 20;
 
 	private final AdminBatchOperationService batchOperationService;
 	private final AdminAuditWriter auditWriter;
@@ -41,12 +43,24 @@ class AdminBatchPageController {
 	}
 
 	@GetMapping("/admin/batches/page")
-	String batchPage(Model model) {
-		model.addAttribute("jobs", batchOperationService.listJobs().stream().map(BatchJobRow::from).toList());
-		model.addAttribute("runs", batchOperationService.listExecutions(DEFAULT_RECENT_RUN_LIMIT)
+	String batchPage(
+		@RequestParam(required = false) Integer page,
+		@RequestParam(required = false) Integer size,
+		Model model
+	) {
+		AdminPageRequest pageRequest = AdminPageRequest.of(page, size);
+		List<BatchRunRow> runs = batchOperationService.listExecutions(
+				pageRequest.limitForHasNext(),
+				pageRequest.offset()
+			)
 			.stream()
 			.flatMap(run -> BatchRunRow.from(run).stream())
-			.toList());
+			.toList();
+		EgovPaginationView pageView = EgovPaginationView.fromSlice(pageRequest.page(), pageRequest.size(), runs.size());
+		model.addAttribute("jobs", batchOperationService.listJobs().stream().map(BatchJobRow::from).toList());
+		model.addAttribute("runs", pageView.visibleItems(runs));
+		model.addAttribute("page", pageView);
+		model.addAttribute("paginationLinks", pageView.links("/admin/batches/page", Collections.emptyMap()));
 		return "admin/batches/list";
 	}
 
@@ -65,7 +79,7 @@ class AdminBatchPageController {
 	) {
 		if (bindingResult.hasErrors()) {
 			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-			batchPage(model);
+			batchPage(null, null, model);
 			AdminFormErrorView.expose(model, bindingResult);
 			return "admin/batches/list";
 		}

--- a/backend/src/main/java/com/easysubway/admin/batch/application/service/AdminBatchOperationService.java
+++ b/backend/src/main/java/com/easysubway/admin/batch/application/service/AdminBatchOperationService.java
@@ -32,6 +32,10 @@ public class AdminBatchOperationService {
 		return loadDataCollectionRunPort.loadRecentRuns(limit);
 	}
 
+	public List<DataCollectionRun> listExecutions(int limit, int offset) {
+		return loadDataCollectionRunPort.loadRecentRuns(limit, offset);
+	}
+
 	public DataCollectionRun retry(String jobId, String runId, String requestedBy) {
 		AdminBatchJob job = AdminBatchJob.require(jobId);
 		DataCollectionRun failedRun = loadDataCollectionRunPort.loadRun(runId)

--- a/backend/src/main/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageController.java
@@ -10,10 +10,13 @@ import com.easysubway.admin.code.domain.AdminCommonCodeGroups;
 import com.easysubway.admin.operations.application.service.AdminIncidentService;
 import com.easysubway.admin.operations.application.service.AdminIncidentService.OpenAdminIncidentCommand;
 import com.easysubway.admin.operations.domain.AdminIncident;
+import com.easysubway.common.web.pagination.AdminPageRequest;
+import com.easysubway.common.web.pagination.EgovPaginationView;
 import com.easysubway.health.application.port.in.CheckHealthUseCase;
 import com.easysubway.health.domain.HealthStatus;
 import jakarta.servlet.http.HttpServletRequest;
 import java.security.Principal;
+import java.util.Collections;
 import java.util.List;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
@@ -26,8 +29,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 class AdminOperationsPageController {
-
-	private static final int INCIDENT_LIMIT = 30;
 
 	private final AdminCommonCodeService commonCodeService;
 	private final AdminIncidentService incidentService;
@@ -47,12 +48,25 @@ class AdminOperationsPageController {
 	}
 
 	@GetMapping("/admin/codes/page")
-	String codesPage(@RequestParam(required = false) String groupCode, Model model) {
+	String codesPage(
+		@RequestParam(required = false) String groupCode,
+		@RequestParam(required = false) Integer page,
+		@RequestParam(required = false) Integer size,
+		Model model
+	) {
 		List<AdminCommonCodeGroup> groups = commonCodeService.listGroups();
 		String selectedGroup = selectedGroup(groupCode, groups);
+		AdminPageRequest pageRequest = AdminPageRequest.of(page, size);
+		List<CodeRow> codes = commonCodeService.listCodes(selectedGroup, true).stream().map(CodeRow::from).toList();
+		EgovPaginationView pageView = EgovPaginationView.from(pageRequest.page(), pageRequest.size(), codes.size());
 		model.addAttribute("groups", groups.stream().map(CodeGroupRow::from).toList());
 		model.addAttribute("selectedGroup", selectedGroup);
-		model.addAttribute("codes", commonCodeService.listCodes(selectedGroup, true).stream().map(CodeRow::from).toList());
+		model.addAttribute("codes", pageView.pageItems(codes));
+		model.addAttribute("page", pageView);
+		model.addAttribute("paginationLinks", pageView.links(
+			"/admin/codes/page",
+			Collections.singletonMap("groupCode", selectedGroup)
+		));
 		return "admin/codes/list";
 	}
 
@@ -108,9 +122,22 @@ class AdminOperationsPageController {
 	}
 
 	@GetMapping("/admin/incidents/page")
-	String incidentsPage(Model model) {
+	String incidentsPage(
+		@RequestParam(required = false) Integer page,
+		@RequestParam(required = false) Integer size,
+		Model model
+	) {
+		AdminPageRequest pageRequest = AdminPageRequest.of(page, size);
+		List<IncidentRow> incidents = incidentService
+			.listRecent(pageRequest.limitForHasNext(), pageRequest.offset())
+			.stream()
+			.map(IncidentRow::from)
+			.toList();
+		EgovPaginationView pageView = EgovPaginationView.fromSlice(pageRequest.page(), pageRequest.size(), incidents.size());
 		HealthStatus health = checkHealthUseCase.checkHealth();
-		model.addAttribute("incidents", incidentService.listRecent(INCIDENT_LIMIT).stream().map(IncidentRow::from).toList());
+		model.addAttribute("incidents", pageView.visibleItems(incidents));
+		model.addAttribute("page", pageView);
+		model.addAttribute("paginationLinks", pageView.links("/admin/incidents/page", Collections.emptyMap()));
 		model.addAttribute("severityOptions", optionRows(AdminCommonCodeGroups.INCIDENT_SEVERITY));
 		model.addAttribute("statusOptions", optionRows(AdminCommonCodeGroups.INCIDENT_STATUS)
 			.stream()

--- a/backend/src/main/java/com/easysubway/admin/operations/adapter/out/persistence/InMemoryAdminIncidentRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/operations/adapter/out/persistence/InMemoryAdminIncidentRepository.java
@@ -18,11 +18,17 @@ public class InMemoryAdminIncidentRepository implements AdminIncidentRepository 
 
 	@Override
 	public synchronized List<AdminIncident> findRecent(int limit) {
+		return findRecent(limit, 0);
+	}
+
+	@Override
+	public synchronized List<AdminIncident> findRecent(int limit, int offset) {
 		return incidents.values()
 			.stream()
 			.sorted(Comparator.comparing(AdminIncident::openedAt)
 				.reversed()
 				.thenComparing(AdminIncident::incidentId, Comparator.reverseOrder()))
+			.skip(Math.max(offset, 0))
 			.limit(Math.max(0, limit))
 			.toList();
 	}

--- a/backend/src/main/java/com/easysubway/admin/operations/adapter/out/persistence/JdbcAdminIncidentRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/operations/adapter/out/persistence/JdbcAdminIncidentRepository.java
@@ -26,12 +26,17 @@ public class JdbcAdminIncidentRepository implements AdminIncidentRepository {
 
 	@Override
 	public List<AdminIncident> findRecent(int limit) {
+		return findRecent(limit, 0);
+	}
+
+	@Override
+	public List<AdminIncident> findRecent(int limit, int offset) {
 		return jdbcTemplate.query("""
 			SELECT incident_id, severity, status, source, summary, owner, opened_at, resolved_at, resolution
 			FROM admin_incidents
 			ORDER BY opened_at DESC, incident_id DESC
-			LIMIT ?
-			""", this::mapIncident, Math.max(0, limit));
+			LIMIT ? OFFSET ?
+			""", this::mapIncident, Math.max(0, limit), Math.max(offset, 0));
 	}
 
 	@Override

--- a/backend/src/main/java/com/easysubway/admin/operations/application/port/out/AdminIncidentRepository.java
+++ b/backend/src/main/java/com/easysubway/admin/operations/application/port/out/AdminIncidentRepository.java
@@ -8,6 +8,10 @@ public interface AdminIncidentRepository {
 
 	List<AdminIncident> findRecent(int limit);
 
+	default List<AdminIncident> findRecent(int limit, int offset) {
+		return offset <= 0 ? findRecent(limit) : List.of();
+	}
+
 	Optional<AdminIncident> findById(String incidentId);
 
 	AdminIncident save(AdminIncident incident);

--- a/backend/src/main/java/com/easysubway/admin/operations/application/service/AdminIncidentService.java
+++ b/backend/src/main/java/com/easysubway/admin/operations/application/service/AdminIncidentService.java
@@ -38,6 +38,10 @@ public class AdminIncidentService {
 		return repository.findRecent(limit);
 	}
 
+	public List<AdminIncident> listRecent(int limit, int offset) {
+		return repository.findRecent(limit, offset);
+	}
+
 	public AdminIncident open(OpenAdminIncidentCommand command) {
 		requireEnabled(AdminCommonCodeGroups.INCIDENT_SEVERITY, command.severity());
 		requireEnabled(AdminCommonCodeGroups.INCIDENT_STATUS, command.status());

--- a/backend/src/main/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageController.java
@@ -1,5 +1,7 @@
 package com.easysubway.collection.adapter.in.web;
 
+import com.easysubway.common.web.pagination.AdminPageRequest;
+import com.easysubway.common.web.pagination.EgovPaginationView;
 import com.easysubway.collection.application.port.in.DataCollectionUseCase;
 import com.easysubway.collection.application.port.in.RunDataCollectionCommand;
 import com.easysubway.collection.domain.DataCollectionRun;
@@ -10,6 +12,7 @@ import com.easysubway.collection.domain.DataCollectionStatus;
 import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -21,8 +24,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Controller
 class DataCollectionAdminPageController {
 
-	private static final int DEFAULT_RECENT_RUN_LIMIT = 20;
-
 	private final DataCollectionUseCase dataCollectionUseCase;
 
 	DataCollectionAdminPageController(DataCollectionUseCase dataCollectionUseCase) {
@@ -30,9 +31,18 @@ class DataCollectionAdminPageController {
 	}
 
 	@GetMapping("/admin/data-collections/page")
-	String dataCollectionPage(Model model) {
+	String dataCollectionPage(
+		@RequestParam(required = false) Integer page,
+		@RequestParam(required = false) Integer size,
+		Model model
+	) {
+		AdminPageRequest pageRequest = AdminPageRequest.of(page, size);
+		List<DataCollectionRunRow> runs = recentRunRows(pageRequest);
+		EgovPaginationView pageView = EgovPaginationView.fromSlice(pageRequest.page(), pageRequest.size(), runs.size());
 		model.addAttribute("sourceOptions", sourceOptions());
-		model.addAttribute("runs", recentRunRows());
+		model.addAttribute("runs", pageView.visibleItems(runs));
+		model.addAttribute("page", pageView);
+		model.addAttribute("paginationLinks", pageView.links("/admin/data-collections/page", Collections.emptyMap()));
 		return "admin/collections/list";
 	}
 
@@ -46,8 +56,8 @@ class DataCollectionAdminPageController {
 		return "redirect:/admin/data-collections/page";
 	}
 
-	private List<DataCollectionRunRow> recentRunRows() {
-		return dataCollectionUseCase.listRecentRuns(DEFAULT_RECENT_RUN_LIMIT)
+	private List<DataCollectionRunRow> recentRunRows(AdminPageRequest pageRequest) {
+		return dataCollectionUseCase.listRecentRuns(pageRequest.limitForHasNext(), pageRequest.offset())
 			.stream()
 			.map(DataCollectionRunRow::from)
 			.toList();

--- a/backend/src/main/java/com/easysubway/collection/adapter/out/persistence/InMemoryDataCollectionRunRepository.java
+++ b/backend/src/main/java/com/easysubway/collection/adapter/out/persistence/InMemoryDataCollectionRunRepository.java
@@ -49,9 +49,15 @@ public class InMemoryDataCollectionRunRepository implements
 
 	@Override
 	public List<DataCollectionRun> loadRecentRuns(int limit) {
+		return loadRecentRuns(limit, 0);
+	}
+
+	@Override
+	public List<DataCollectionRun> loadRecentRuns(int limit, int offset) {
 		var recentRuns = new ArrayList<>(runs);
 		Collections.reverse(recentRuns);
 		return recentRuns.stream()
+			.skip(Math.max(offset, 0))
 			.limit(Math.max(limit, 0))
 			.toList();
 	}

--- a/backend/src/main/java/com/easysubway/collection/adapter/out/persistence/JdbcDataCollectionRunRepository.java
+++ b/backend/src/main/java/com/easysubway/collection/adapter/out/persistence/JdbcDataCollectionRunRepository.java
@@ -163,6 +163,11 @@ public class JdbcDataCollectionRunRepository implements
 
 	@Override
 	public List<DataCollectionRun> loadRecentRuns(int limit) {
+		return loadRecentRuns(limit, 0);
+	}
+
+	@Override
+	public List<DataCollectionRun> loadRecentRuns(int limit, int offset) {
 		if (limit <= 0) {
 			return List.of();
 		}
@@ -172,10 +177,11 @@ public class JdbcDataCollectionRunRepository implements
 					failure_message, retryable, operator_action
 				FROM data_collection_runs
 				ORDER BY started_at DESC, run_id DESC
-				LIMIT ?
+				LIMIT ? OFFSET ?
 				""",
 			this::mapRun,
-			limit
+			limit,
+			Math.max(offset, 0)
 		);
 	}
 

--- a/backend/src/main/java/com/easysubway/collection/application/port/in/DataCollectionUseCase.java
+++ b/backend/src/main/java/com/easysubway/collection/application/port/in/DataCollectionUseCase.java
@@ -12,4 +12,8 @@ public interface DataCollectionUseCase {
 	Optional<DataCollectionRun> getLatestCompletedRun(DataCollectionSource source);
 
 	List<DataCollectionRun> listRecentRuns(int limit);
+
+	default List<DataCollectionRun> listRecentRuns(int limit, int offset) {
+		return offset <= 0 ? listRecentRuns(limit) : List.of();
+	}
 }

--- a/backend/src/main/java/com/easysubway/collection/application/port/out/LoadDataCollectionRunPort.java
+++ b/backend/src/main/java/com/easysubway/collection/application/port/out/LoadDataCollectionRunPort.java
@@ -12,4 +12,6 @@ public interface LoadDataCollectionRunPort {
 	Optional<DataCollectionRun> loadLatestCompletedRun(DataCollectionSource source);
 
 	List<DataCollectionRun> loadRecentRuns(int limit);
+
+	List<DataCollectionRun> loadRecentRuns(int limit, int offset);
 }

--- a/backend/src/main/java/com/easysubway/collection/application/service/DataCollectionService.java
+++ b/backend/src/main/java/com/easysubway/collection/application/service/DataCollectionService.java
@@ -46,6 +46,11 @@ public class DataCollectionService implements DataCollectionUseCase {
 	}
 
 	@Override
+	public List<DataCollectionRun> listRecentRuns(int limit, int offset) {
+		return loadDataCollectionRunPort.loadRecentRuns(limit, offset);
+	}
+
+	@Override
 	public Optional<DataCollectionRun> getLatestCompletedRun(DataCollectionSource source) {
 		return loadDataCollectionRunPort.loadLatestCompletedRun(source);
 	}

--- a/backend/src/main/java/com/easysubway/common/web/pagination/AdminPageRequest.java
+++ b/backend/src/main/java/com/easysubway/common/web/pagination/AdminPageRequest.java
@@ -1,0 +1,29 @@
+package com.easysubway.common.web.pagination;
+
+public record AdminPageRequest(int page, int size) {
+
+	public static final int DEFAULT_PAGE = 0;
+	public static final int DEFAULT_SIZE = 20;
+	public static final int MAX_SIZE = 50;
+
+	public AdminPageRequest {
+		size = Math.min(Math.max(size, 1), MAX_SIZE);
+		page = Math.max(page, 0);
+		page = Math.min(page, Integer.MAX_VALUE / size);
+	}
+
+	public static AdminPageRequest of(Integer page, Integer size) {
+		return new AdminPageRequest(
+			page == null ? DEFAULT_PAGE : page,
+			size == null ? DEFAULT_SIZE : size
+		);
+	}
+
+	public int offset() {
+		return page * size;
+	}
+
+	public int limitForHasNext() {
+		return size + 1;
+	}
+}

--- a/backend/src/main/java/com/easysubway/common/web/pagination/EgovPaginationView.java
+++ b/backend/src/main/java/com/easysubway/common/web/pagination/EgovPaginationView.java
@@ -63,7 +63,13 @@ public record EgovPaginationView(
 	}
 
 	public static EgovPaginationView fromSlice(int page, int size, int fetchedCount) {
-		long minimumTotal = (long) Math.max(page, 0) * Math.max(size, 1) + Math.max(fetchedCount, 0);
+		int safePage = Math.max(page, 0);
+		int safeSize = Math.max(size, 1);
+		int safeFetchedCount = Math.max(fetchedCount, 0);
+		long minimumTotal = (long) safePage * safeSize + safeFetchedCount;
+		if (safePage > 0 && safeFetchedCount == 0) {
+			minimumTotal++;
+		}
 		return from(page, size, minimumTotal);
 	}
 

--- a/backend/src/main/java/com/easysubway/common/web/pagination/EgovPaginationView.java
+++ b/backend/src/main/java/com/easysubway/common/web/pagination/EgovPaginationView.java
@@ -1,7 +1,10 @@
 package com.easysubway.common.web.pagination;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.egovframe.rte.ptl.mvc.tags.ui.pagination.PaginationInfo;
+import org.springframework.web.util.UriComponentsBuilder;
 
 public record EgovPaginationView(
 	int page,
@@ -59,6 +62,55 @@ public record EgovPaginationView(
 		);
 	}
 
+	public static EgovPaginationView fromSlice(int page, int size, int fetchedCount) {
+		long minimumTotal = (long) Math.max(page, 0) * Math.max(size, 1) + Math.max(fetchedCount, 0);
+		return from(page, size, minimumTotal);
+	}
+
+	public <T> List<T> visibleItems(List<T> fetchedItems) {
+		return fetchedItems.stream().limit(size).toList();
+	}
+
+	public <T> List<T> pageItems(List<T> allItems) {
+		return allItems.stream()
+			.skip((long) page * size)
+			.limit(size)
+			.toList();
+	}
+
 	public record PageLink(int page, String label, boolean current) {
+	}
+
+	public PaginationLinks links(String path, Map<String, ?> filters) {
+		return new PaginationLinks(
+			href(path, filters, previousPage),
+			href(path, filters, nextPage),
+			pageLinks.stream()
+				.map(link -> new PageHref(link.page(), link.label(), link.current(), href(path, filters, link.page())))
+				.toList()
+		);
+	}
+
+	private String href(String path, Map<String, ?> filters, int targetPage) {
+		Map<String, Object> query = new LinkedHashMap<>();
+		filters.forEach((key, value) -> {
+			if (value != null && !value.toString().isBlank()) {
+				query.put(key, value);
+			}
+		});
+		query.put("page", targetPage);
+		query.put("size", size);
+		UriComponentsBuilder builder = UriComponentsBuilder.fromPath(path);
+		query.forEach(builder::queryParam);
+		return builder.build().toUriString();
+	}
+
+	public record PaginationLinks(String previousHref, String nextHref, List<PageHref> pages) {
+		public PaginationLinks {
+			pages = List.copyOf(pages);
+		}
+	}
+
+	public record PageHref(int page, String label, boolean current, String href) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/common/web/pagination/EgovPaginationView.java
+++ b/backend/src/main/java/com/easysubway/common/web/pagination/EgovPaginationView.java
@@ -108,7 +108,7 @@ public record EgovPaginationView(
 		query.put("size", size);
 		UriComponentsBuilder builder = UriComponentsBuilder.fromPath(path);
 		query.forEach(builder::queryParam);
-		return builder.build().toUriString();
+		return builder.build().encode().toUriString();
 	}
 
 	public record PaginationLinks(String previousHref, String nextHref, List<PageHref> pages) {

--- a/backend/src/main/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminPageController.java
@@ -1,6 +1,8 @@
 package com.easysubway.field.adapter.in.web;
 
 import com.easysubway.admin.web.AdminFormErrorView;
+import com.easysubway.common.web.pagination.AdminPageRequest;
+import com.easysubway.common.web.pagination.EgovPaginationView;
 import com.easysubway.field.application.port.in.FieldVerificationUseCase;
 import com.easysubway.field.application.port.in.UpdateFieldVerificationItemStatusCommand;
 import com.easysubway.field.domain.FieldVerificationChangeHistory;
@@ -14,6 +16,7 @@ import jakarta.validation.constraints.NotNull;
 import java.security.Principal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -22,6 +25,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 class FieldVerificationAdminPageController {
@@ -33,10 +37,19 @@ class FieldVerificationAdminPageController {
 	}
 
 	@GetMapping("/admin/field-verifications/page")
-	String fieldVerificationsPage(Model model) {
-		model.addAttribute("verifications", fieldVerificationUseCase.listStationVerifications().stream()
+	String fieldVerificationsPage(
+		@RequestParam(required = false) Integer page,
+		@RequestParam(required = false) Integer size,
+		Model model
+	) {
+		AdminPageRequest pageRequest = AdminPageRequest.of(page, size);
+		List<SessionRow> verifications = fieldVerificationUseCase.listStationVerifications().stream()
 			.map(SessionRow::from)
-			.toList());
+			.toList();
+		EgovPaginationView pageView = EgovPaginationView.from(pageRequest.page(), pageRequest.size(), verifications.size());
+		model.addAttribute("verifications", pageView.pageItems(verifications));
+		model.addAttribute("page", pageView);
+		model.addAttribute("paginationLinks", pageView.links("/admin/field-verifications/page", Collections.emptyMap()));
 		return "admin/field/list";
 	}
 

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -25,6 +25,7 @@ import java.security.Principal;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -127,6 +128,10 @@ class FacilityReportAdminPageController {
 
 		model.addAttribute("reports", reports);
 		model.addAttribute("page", pageView);
+		model.addAttribute("paginationLinks", pageView.links(
+			"/admin/reports/page",
+			Collections.singletonMap("status", status)
+		));
 		model.addAttribute("selectedStatus", status);
 		model.addAttribute("statusOptions", statusOptions());
 		model.addAttribute("reportSurgeAlert", ReportSurgeAlertView.from(

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageController.java
@@ -1,6 +1,8 @@
 package com.easysubway.transit.adapter.in.web;
 
 import com.easysubway.admin.web.AdminFormErrorView;
+import com.easysubway.common.web.pagination.AdminPageRequest;
+import com.easysubway.common.web.pagination.EgovPaginationView;
 import com.easysubway.transit.application.port.in.TransitMasterAdminUseCase;
 import com.easysubway.transit.application.port.in.UpdateAccessibilityFacilityStatusCommand;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
@@ -10,6 +12,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.security.Principal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
@@ -36,8 +40,17 @@ class TransitFacilityAdminPageController {
 	}
 
 	@GetMapping("/admin/facilities/page")
-	String facilitiesPage(Model model) {
-		model.addAttribute("facilities", facilityStatusAssembler.assemble());
+	String facilitiesPage(
+		@RequestParam(required = false) Integer page,
+		@RequestParam(required = false) Integer size,
+		Model model
+	) {
+		AdminPageRequest pageRequest = AdminPageRequest.of(page, size);
+		List<FacilityStatusRow> facilities = facilityStatusAssembler.assemble();
+		EgovPaginationView pageView = EgovPaginationView.from(pageRequest.page(), pageRequest.size(), facilities.size());
+		model.addAttribute("facilities", pageView.pageItems(facilities));
+		model.addAttribute("page", pageView);
+		model.addAttribute("paginationLinks", pageView.links("/admin/facilities/page", Collections.emptyMap()));
 		model.addAttribute("statusOptions", statusOptions());
 		model.addAttribute("masterDataWritable", transitMasterAdminUseCase.masterDataCapability().writable());
 		return "admin/facilities/list";
@@ -56,7 +69,7 @@ class TransitFacilityAdminPageController {
 	) {
 		if (bindingResult.hasErrors()) {
 			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-			facilitiesPage(model);
+			facilitiesPage(null, null, model);
 			AdminFormErrorView.expose(model, bindingResult);
 			return "admin/facilities/list";
 		}

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
@@ -1,6 +1,8 @@
 package com.easysubway.transit.adapter.in.web;
 
 import com.easysubway.admin.web.AdminFormErrorView;
+import com.easysubway.common.web.pagination.AdminPageRequest;
+import com.easysubway.common.web.pagination.EgovPaginationView;
 import com.easysubway.transit.application.port.in.CreateAccessibilityFacilityCommand;
 import com.easysubway.transit.application.port.in.StationMasterDataCounts;
 import com.easysubway.transit.application.port.in.StationSearchCommand;
@@ -22,6 +24,7 @@ import com.easysubway.transit.domain.StationWithLines;
 import java.math.BigDecimal;
 import java.security.Principal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import jakarta.servlet.http.HttpServletResponse;
@@ -56,8 +59,11 @@ class TransitStationAdminPageController {
 	@GetMapping("/admin/stations/page")
 	String stationsPage(
 		@RequestParam(required = false) String query,
+		@RequestParam(required = false) Integer page,
+		@RequestParam(required = false) Integer size,
 		Model model
 	) {
+		AdminPageRequest pageRequest = AdminPageRequest.of(page, size);
 		Map<String, StationMasterDataCounts> counts = transitMasterQueryUseCase.countStationMasterDataByStationId();
 		List<StationRow> stations = transitMasterQueryUseCase.searchStations(new StationSearchCommand(query, null))
 			.stream()
@@ -66,7 +72,13 @@ class TransitStationAdminPageController {
 				StationMasterDataCounts.empty()
 			)))
 			.toList();
-		model.addAttribute("stations", stations);
+		EgovPaginationView pageView = EgovPaginationView.from(pageRequest.page(), pageRequest.size(), stations.size());
+		model.addAttribute("stations", pageView.pageItems(stations));
+		model.addAttribute("page", pageView);
+		model.addAttribute("paginationLinks", pageView.links(
+			"/admin/stations/page",
+			Collections.singletonMap("query", query)
+		));
 		model.addAttribute("query", query);
 		return "admin/stations/list";
 	}

--- a/backend/src/main/resources/templates/admin/audits/list.html
+++ b/backend/src/main/resources/templates/admin/audits/list.html
@@ -46,6 +46,7 @@
 			</tr>
 			</tbody>
 		</table>
+		<div th:replace="~{admin/fragments/pagination :: pager(${paginationLabel}, ${page}, ${paginationLinks})}"></div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/batches/list.html
+++ b/backend/src/main/resources/templates/admin/batches/list.html
@@ -92,6 +92,7 @@
 			</tr>
 			</tbody>
 		</table>
+		<div th:replace="~{admin/fragments/pagination :: pager('배치 실행 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/codes/list.html
+++ b/backend/src/main/resources/templates/admin/codes/list.html
@@ -60,6 +60,7 @@
 			</tr>
 			</tbody>
 		</table>
+		<div th:replace="~{admin/fragments/pagination :: pager('공통코드 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</section>
 
 	<section>

--- a/backend/src/main/resources/templates/admin/collections/list.html
+++ b/backend/src/main/resources/templates/admin/collections/list.html
@@ -162,6 +162,7 @@
 			</tr>
 			</tbody>
 		</table>
+		<div th:replace="~{admin/fragments/pagination :: pager('데이터 수집 실행 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/facilities/list.html
+++ b/backend/src/main/resources/templates/admin/facilities/list.html
@@ -174,6 +174,7 @@
 		</tr>
 		</tbody>
 	</table>
+	<div th:replace="~{admin/fragments/pagination :: pager('시설 상태 목록 페이지', ${page}, ${paginationLinks})}"></div>
 </main>
 </div>
 </body>

--- a/backend/src/main/resources/templates/admin/field/list.html
+++ b/backend/src/main/resources/templates/admin/field/list.html
@@ -49,6 +49,7 @@
 		</tr>
 		</tbody>
 	</table>
+	<div th:replace="~{admin/fragments/pagination :: pager('현장 검증 목록 페이지', ${page}, ${paginationLinks})}"></div>
 </main>
 </div>
 </body>

--- a/backend/src/main/resources/templates/admin/fragments/pagination.html
+++ b/backend/src/main/resources/templates/admin/fragments/pagination.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<body>
+<nav class="pagination" th:fragment="pager(label, page, links)" th:aria-label="${label}" th:if="${page.hasPages}">
+	<a th:if="${page.hasPrevious}" th:href="${links.previousHref}">이전</a>
+	<a th:each="pageLink : ${links.pages}"
+	   th:href="${pageLink.href}"
+	   th:attr="aria-current=${pageLink.current ? 'page' : null}"
+	   th:text="${pageLink.label}">1</a>
+	<a th:if="${page.hasNext}" th:href="${links.nextHref}">다음</a>
+</nav>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/fragments/pagination.html
+++ b/backend/src/main/resources/templates/admin/fragments/pagination.html
@@ -1,5 +1,8 @@
 <!doctype html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<title>관리자 페이지네이션</title>
+</head>
 <body>
 <nav class="pagination" th:fragment="pager(label, page, links)" th:aria-label="${label}" th:if="${page.hasPages}">
 	<a th:if="${page.hasPrevious}" th:href="${links.previousHref}">이전</a>

--- a/backend/src/main/resources/templates/admin/incidents/list.html
+++ b/backend/src/main/resources/templates/admin/incidents/list.html
@@ -93,6 +93,7 @@
 			</tr>
 			</tbody>
 		</table>
+		<div th:replace="~{admin/fragments/pagination :: pager('Incident 목록 페이지', ${page}, ${paginationLinks})}"></div>
 	</section>
 </main>
 </div>

--- a/backend/src/main/resources/templates/admin/reports/list.html
+++ b/backend/src/main/resources/templates/admin/reports/list.html
@@ -273,16 +273,7 @@
 		</tbody>
 	</table>
 
-	<nav class="pagination" aria-label="신고 목록 페이지" th:if="${page.hasPages}">
-		<a th:if="${page.hasPrevious}"
-		   th:href="@{/admin/reports/page(status=${selectedStatus},page=${page.previousPage},size=${page.size})}">이전</a>
-		<a th:each="pageLink : ${page.pageLinks}"
-		   th:href="@{/admin/reports/page(status=${selectedStatus},page=${pageLink.page},size=${page.size})}"
-		   th:attr="aria-current=${pageLink.current ? 'page' : null}"
-		   th:text="${pageLink.label}">1</a>
-		<a th:if="${page.hasNext}"
-		   th:href="@{/admin/reports/page(status=${selectedStatus},page=${page.nextPage},size=${page.size})}">다음</a>
-	</nav>
+	<div th:replace="~{admin/fragments/pagination :: pager('신고 목록 페이지', ${page}, ${paginationLinks})}"></div>
 </main>
 </div>
 </body>

--- a/backend/src/main/resources/templates/admin/stations/list.html
+++ b/backend/src/main/resources/templates/admin/stations/list.html
@@ -55,6 +55,7 @@
 		</tr>
 		</tbody>
 	</table>
+	<div th:replace="~{admin/fragments/pagination :: pager('역 목록 페이지', ${page}, ${paginationLinks})}"></div>
 </main>
 </div>
 </body>

--- a/backend/src/test/java/com/easysubway/admin/audit/adapter/in/web/AdminAuditPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/audit/adapter/in/web/AdminAuditPageControllerTest.java
@@ -71,6 +71,27 @@ class AdminAuditPageControllerTest {
 			.doesNotContain("POST /admin/reports/{reportId}/page/review");
 	}
 
+	@Test
+	@DisplayName("감사 조회 화면은 page size와 현재 페이지를 링크에 표시한다")
+	void auditPageShowsPaginationLinks() throws Exception {
+		auditEventRepository.save(event(AdminAuditEventType.ADMIN_ACTION, "FIRST_ACTION"));
+		auditEventRepository.save(event(AdminAuditEventType.ADMIN_ACTION, "SECOND_ACTION"));
+
+		String html = mockMvc.perform(get("/admin/audits/page")
+				.param("size", "1")
+				.with(user("auditor").authorities(new SimpleGrantedAuthority("admin.audit.read"))))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("관리자 감사 페이지")
+			.contains("aria-current=\"page\"")
+			.contains("page=1&amp;size=1")
+			.contains("다음");
+	}
+
 	private AdminAuditEvent event(AdminAuditEventType type, String action) {
 		return new AdminAuditEvent(
 			null,

--- a/backend/src/test/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageControllerTest.java
@@ -73,6 +73,27 @@ class AdminBatchPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("배치 실행 목록은 page size와 현재 페이지를 링크에 표시한다")
+	void batchPageShowsPaginationLinks() throws Exception {
+		saveDataCollectionRunPort.saveRun(failedRun("failed-run-1"));
+		saveDataCollectionRunPort.saveRun(failedRun("failed-run-2"));
+
+		String html = mockMvc.perform(get("/admin/batches/page")
+				.param("size", "1")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("배치 실행 목록 페이지")
+			.contains("aria-current=\"page\"")
+			.contains("page=1&amp;size=1")
+			.contains("다음");
+	}
+
+	@Test
 	@DisplayName("BATCH_RETRY 권한이 있는 관리자는 실패 실행을 재처리하고 audit을 남긴다")
 	void adminRetriesFailedRunAndWritesAudit() throws Exception {
 		saveDataCollectionRunPort.saveRun(failedRun("failed-run"));

--- a/backend/src/test/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageControllerTest.java
@@ -53,6 +53,25 @@ class AdminOperationsPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("공통코드 화면은 group filter와 page size를 링크에 표시한다")
+	void codesPageShowsPaginationLinks() throws Exception {
+		String html = mockMvc.perform(get("/admin/codes/page")
+				.param("groupCode", "REPORT_REJECTION_REASON")
+				.param("size", "1")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("공통코드 목록 페이지")
+			.contains("aria-current=\"page\"")
+			.contains("groupCode=REPORT_REJECTION_REASON&amp;page=1&amp;size=1")
+			.contains("다음");
+	}
+
+	@Test
 	@DisplayName("공통코드 화면은 필수 incident code 비활성화 버튼을 숨긴다")
 	void codesPageHidesRequiredIncidentDisableAction() throws Exception {
 		String html = mockMvc.perform(get("/admin/codes/page")
@@ -143,6 +162,27 @@ class AdminOperationsPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("장애관리 목록은 page size와 현재 페이지를 링크에 표시한다")
+	void incidentsPageShowsPaginationLinks() throws Exception {
+		openIncident("database DOWN");
+		openIncident("redis DOWN");
+
+		String html = mockMvc.perform(get("/admin/incidents/page")
+				.param("size", "1")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("Incident 목록 페이지")
+			.contains("aria-current=\"page\"")
+			.contains("page=1&amp;size=1")
+			.contains("다음");
+	}
+
+	@Test
 	@DisplayName("공통코드 audit target은 hashCode 충돌 code도 구분한다")
 	void commonCodeAuditTargetAvoidsHashCodeCollision() throws Exception {
 		saveCode("AAO");
@@ -216,5 +256,18 @@ class AdminOperationsPageControllerTest {
 				.param("enabled", "true"))
 			.andExpect(status().is3xxRedirection())
 			.andExpect(header().string("Location", "/admin/codes/page?groupCode=REPORT_REJECTION_REASON"));
+	}
+
+	private void openIncident(String summary) throws Exception {
+		mockMvc.perform(post("/admin/incidents")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("severity", "MAJOR")
+				.param("status", "OPEN")
+				.param("source", "HEALTH")
+				.param("summary", summary)
+				.param("owner", "ops"))
+			.andExpect(status().is3xxRedirection());
 	}
 }

--- a/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageControllerTest.java
@@ -88,6 +88,27 @@ class DataCollectionAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("데이터 수집 실행 목록은 page size와 현재 페이지를 링크에 표시한다")
+	void dataCollectionPageShowsPaginationLinks() throws Exception {
+		runTransitMasterCollection();
+		runTransitMasterCollection();
+
+		String html = mockMvc.perform(get("/admin/data-collections/page")
+				.param("size", "1")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("데이터 수집 실행 목록 페이지")
+			.contains("aria-current=\"page\"")
+			.contains("page=1&amp;size=1")
+			.contains("다음");
+	}
+
+	@Test
 	@DisplayName("관리자 데이터 수집 화면은 관리자 인증을 요구한다")
 	void dataCollectionPagesRequireAdminAuthentication() throws Exception {
 		mockMvc.perform(get("/admin/data-collections/page"))

--- a/backend/src/test/java/com/easysubway/collection/adapter/out/persistence/JdbcDataCollectionRunRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/collection/adapter/out/persistence/JdbcDataCollectionRunRepositoryTest.java
@@ -106,6 +106,20 @@ class JdbcDataCollectionRunRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("최근 수집 실행 기록은 offset 이후 기록부터 조회한다")
+	void loadRecentRunsSupportsOffset() {
+		repository.saveRun(completedRun("collection-old", LocalDateTime.of(2026, 6, 16, 9, 0)));
+		repository.saveRun(completedRun("collection-new", LocalDateTime.of(2026, 6, 16, 11, 0)));
+		repository.saveRun(failedRun("collection-failed", LocalDateTime.of(2026, 6, 16, 10, 0)));
+
+		var recentRuns = repository.loadRecentRuns(1, 1);
+
+		assertThat(recentRuns)
+			.extracting(DataCollectionRun::runId)
+			.containsExactly("collection-failed");
+	}
+
+	@Test
 	@DisplayName("최신 완료 수집 실행 기록은 실패 기록보다 완료 시간이 늦은 완료 기록을 반환한다")
 	void loadLatestCompletedRunReturnsLatestCompletedRunByCompletedAt() {
 		repository.saveRun(completedRun("collection-old-completed", LocalDateTime.of(2026, 6, 16, 9, 0)));

--- a/backend/src/test/java/com/easysubway/collection/application/service/DataCollectionRunRecorderTest.java
+++ b/backend/src/test/java/com/easysubway/collection/application/service/DataCollectionRunRecorderTest.java
@@ -85,6 +85,19 @@ class DataCollectionRunRecorderTest {
 	}
 
 	@Test
+	@DisplayName("최근 실행 기록은 offset 이후 기록부터 조회한다")
+	void listRecentRunsSupportsOffset() {
+		recorder.recordTransitMasterRun("collection-a", "admin-a");
+		recorder.recordTransitMasterRun("collection-b", "admin-b");
+
+		var recentRuns = repository.loadRecentRuns(1, 1);
+
+		assertThat(recentRuns)
+			.extracting("requestedBy")
+			.containsExactly("admin-a");
+	}
+
+	@Test
 	@DisplayName("같은 실행 식별자를 다시 저장해도 단계 이력은 중복되지 않는다")
 	void saveRunReplacesSameRunId() {
 		recorder.recordTransitMasterRun("collection-retry", "admin-a");

--- a/backend/src/test/java/com/easysubway/common/web/pagination/EgovPaginationViewTest.java
+++ b/backend/src/test/java/com/easysubway/common/web/pagination/EgovPaginationViewTest.java
@@ -109,6 +109,19 @@ class EgovPaginationViewTest {
 	}
 
 	@Test
+	@DisplayName("pagination link는 filter 값을 URL encode한다")
+	void encodesFilterValues() {
+		EgovPaginationView view = EgovPaginationView.from(0, 20, 21);
+
+		EgovPaginationView.PaginationLinks links = view.links(
+			"/admin/stations/page",
+			Collections.singletonMap("query", "A&B 역")
+		);
+
+		assertThat(links.nextHref()).isEqualTo("/admin/stations/page?query=A%26B%20%EC%97%AD&page=1&size=20");
+	}
+
+	@Test
 	@DisplayName("slice 조회는 size보다 많이 가져온 경우 다음 링크를 만든다")
 	void buildsSliceWithNextPage() {
 		EgovPaginationView view = EgovPaginationView.fromSlice(0, 20, 21);

--- a/backend/src/test/java/com/easysubway/common/web/pagination/EgovPaginationViewTest.java
+++ b/backend/src/test/java/com/easysubway/common/web/pagination/EgovPaginationViewTest.java
@@ -118,6 +118,18 @@ class EgovPaginationViewTest {
 	}
 
 	@Test
+	@DisplayName("slice 조회는 범위 밖 빈 page도 요청 page를 유지한다")
+	void keepsRequestedPageForEmptySlice() {
+		EgovPaginationView view = EgovPaginationView.fromSlice(3, 20, 0);
+
+		assertThat(view.page()).isEqualTo(3);
+		assertThat(view.hasPrevious()).isTrue();
+		assertThat(view.hasNext()).isFalse();
+		assertThat(view.previousPage()).isEqualTo(2);
+		assertThat(view.pageLinks().get(view.pageLinks().size() - 1).current()).isTrue();
+	}
+
+	@Test
 	@DisplayName("전체 목록에서 현재 page 항목만 반환한다")
 	void returnsCurrentPageItems() {
 		EgovPaginationView view = EgovPaginationView.from(1, 2, 5);

--- a/backend/src/test/java/com/easysubway/common/web/pagination/EgovPaginationViewTest.java
+++ b/backend/src/test/java/com/easysubway/common/web/pagination/EgovPaginationViewTest.java
@@ -2,6 +2,9 @@ package com.easysubway.common.web.pagination;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -74,5 +77,61 @@ class EgovPaginationViewTest {
 		assertThat(view.page()).isEqualTo(4);
 		assertThat(view.hasNext()).isFalse();
 		assertThat(view.pageLinks().get(view.pageLinks().size() - 1).page()).isEqualTo(4);
+	}
+
+	@Test
+	@DisplayName("pagination link는 filter와 page size를 보존하고 빈 filter를 버린다")
+	void buildsLinksWithFilters() {
+		EgovPaginationView view = EgovPaginationView.from(1, 10, 42);
+
+		EgovPaginationView.PaginationLinks links = view.links(
+			"/admin/reports/page",
+			Map.of("status", "SUBMITTED", "empty", "")
+		);
+
+		assertThat(links.previousHref()).isEqualTo("/admin/reports/page?status=SUBMITTED&page=0&size=10");
+		assertThat(links.nextHref()).isEqualTo("/admin/reports/page?status=SUBMITTED&page=2&size=10");
+		assertThat(links.pages().get(1).href()).isEqualTo("/admin/reports/page?status=SUBMITTED&page=1&size=10");
+		assertThat(links.pages().get(1).current()).isTrue();
+	}
+
+	@Test
+	@DisplayName("pagination link는 null filter를 버린다")
+	void skipsNullFilters() {
+		EgovPaginationView view = EgovPaginationView.from(0, 20, 21);
+
+		EgovPaginationView.PaginationLinks links = view.links(
+			"/admin/reports/page",
+			Collections.singletonMap("status", null)
+		);
+
+		assertThat(links.nextHref()).isEqualTo("/admin/reports/page?page=1&size=20");
+	}
+
+	@Test
+	@DisplayName("slice 조회는 size보다 많이 가져온 경우 다음 링크를 만든다")
+	void buildsSliceWithNextPage() {
+		EgovPaginationView view = EgovPaginationView.fromSlice(0, 20, 21);
+
+		assertThat(view.hasNext()).isTrue();
+		assertThat(view.nextPage()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("전체 목록에서 현재 page 항목만 반환한다")
+	void returnsCurrentPageItems() {
+		EgovPaginationView view = EgovPaginationView.from(1, 2, 5);
+
+		assertThat(view.pageItems(List.of("a", "b", "c", "d", "e")))
+			.containsExactly("c", "d");
+	}
+
+	@Test
+	@DisplayName("관리자 page request는 size 상한과 offset overflow를 막는다")
+	void adminPageRequestCapsSizeAndOffset() {
+		AdminPageRequest request = AdminPageRequest.of(Integer.MAX_VALUE, 999);
+
+		assertThat(request.size()).isEqualTo(AdminPageRequest.MAX_SIZE);
+		assertThat(request.offset()).isGreaterThanOrEqualTo(0);
 	}
 }

--- a/backend/src/test/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminControllerTest.java
+++ b/backend/src/test/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminControllerTest.java
@@ -64,6 +64,24 @@ class FieldVerificationAdminControllerTest {
 	}
 
 	@Test
+	@DisplayName("관리자 현장 검증 목록 화면은 page size와 현재 페이지를 링크에 표시한다")
+	void fieldVerificationPageShowsPaginationLinks() throws Exception {
+		String html = mockMvc.perform(get("/admin/field-verifications/page")
+				.param("size", "1")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("현장 검증 목록 페이지")
+			.contains("aria-current=\"page\"")
+			.contains("page=1&amp;size=1")
+			.contains("다음");
+	}
+
+	@Test
 	@DisplayName("관리자는 역별 현장 검증 세션과 항목을 조회한다")
 	void adminGetsStationFieldVerification() throws Exception {
 		mockMvc.perform(get("/admin/field-verifications/stations/station-sangnoksu")

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageControllerTest.java
@@ -55,6 +55,24 @@ class TransitFacilityAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("시설 상태 화면은 page size와 현재 페이지를 링크에 표시한다")
+	void facilityStatusPageShowsPaginationLinks() throws Exception {
+		String html = mockMvc.perform(get("/admin/facilities/page")
+				.param("size", "1")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("시설 상태 목록 페이지")
+			.contains("aria-current=\"page\"")
+			.contains("page=1&amp;size=1")
+			.contains("다음");
+	}
+
+	@Test
 	@DisplayName("관리자는 시설 상태 화면에서 상태를 변경한 뒤 목록으로 돌아온다")
 	@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
 	void adminUpdatesFacilityStatusFromPageAndRedirectsToList() throws Exception {

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitMasterControllerTest.java
@@ -1,5 +1,6 @@
 package com.easysubway.transit.adapter.in.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -48,6 +49,24 @@ class TransitMasterControllerTest {
 			.andExpect(jsonPath("$.data[0].simplifiedLayoutCount").value(1))
 			.andExpect(jsonPath("$.data[0].routeNodeCount").value(2))
 			.andExpect(jsonPath("$.data[0].routeEdgeCount").value(1));
+	}
+
+	@Test
+	@DisplayName("관리자 역 목록 화면은 page size와 현재 페이지를 링크에 표시한다")
+	void adminStationPageShowsPaginationLinks() throws Exception {
+		String html = mockMvc.perform(get("/admin/stations/page")
+				.param("size", "1")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("역 목록 페이지")
+			.contains("aria-current=\"page\"")
+			.contains("page=1&amp;size=1")
+			.contains("다음");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
@@ -43,7 +43,7 @@ class TransitReadOnlyAdminPageModelTest {
 		);
 		var model = new ExtendedModelMap();
 
-		String viewName = controller.facilitiesPage(model);
+		String viewName = controller.facilitiesPage(null, null, model);
 
 		assertThat(viewName).isEqualTo("admin/facilities/list");
 		assertThat(model.get("masterDataWritable")).isEqualTo(false);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3753,6 +3753,7 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
     "backend/src/main/resources/templates/operator/data-collection-failures.html",
   );
   const adminReportListTemplate = read("backend/src/main/resources/templates/admin/reports/list.html");
+  const adminPaginationFragment = read("backend/src/main/resources/templates/admin/fragments/pagination.html");
   const adminReportDetailTemplate = read("backend/src/main/resources/templates/admin/reports/detail.html");
 
   assert.match(report, /record FacilityReport/);
@@ -3930,7 +3931,7 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(adminReportListTemplate, /신고 처리 시간/);
   assert.match(adminReportListTemplate, /처리 완료 신고 없음/);
   assert.match(adminReportListTemplate, /신고 목록 페이지/);
-  assert.match(adminReportListTemplate, /page\.hasNext/);
+  assert.match(adminPaginationFragment, /page\.hasNext/);
   assert.match(security, /@Order\(1\)[\s\S]*?securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(security, /securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(security, /anyRequest\(\)\.hasAuthority\(AdminPermission\.ADMIN_VIEW\.authority\(\)\)/);


### PR DESCRIPTION
## 관련 이슈

close #959

## 작업 배경

관리자 목록 화면마다 page, size, filter query 보존 방식이 달라 목록 경계와 접근성 검증 기준이 흔들릴 수 있었다. eGovFrame `PaginationInfo` 기반의 기존 `EgovPaginationView`를 공통으로 쓰고, 운영성 실행 로그는 `LIMIT/OFFSET` 조회로 page 이동을 처리한다.

## 작업 내용

- `AdminPageRequest`를 추가해 관리자 목록의 page 기본값, size 상한, offset overflow 방지를 공통화했다.
- `EgovPaginationView`에 slice 조회, 현재 page 항목 선택, filter query를 보존하는 링크 생성을 추가했다.
- 공통 Thymeleaf pagination fragment를 만들고 신고, 역, 시설 상태, 현장 검증, 데이터 수집 실행, 배치 실행, 감사 로그, 개인정보 조회 로그, 공통코드, incident 목록에 적용했다.
- 데이터 수집 실행, 배치 실행, 감사 로그, incident는 저장소/서비스에 offset 조회를 추가해 다음 page 판단용 `size + 1` 조회를 사용한다.
- slice 기반 목록의 범위 밖 빈 page에서도 요청 page와 pager 상태가 어긋나지 않도록 보정했다.
- pagination href 생성 시 filter query 값을 URL encode해 역 검색어의 공백, 한글, `&`를 유지한다.
- 현재 저장소에 별도 관리자 사용자 목록과 역할·권한 목록 화면은 없어 신규 화면을 만들지 않았다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --rerun-tasks --tests 'com.easysubway.common.web.pagination.EgovPaginationViewTest' --tests 'com.easysubway.report.adapter.in.web.FacilityReportAdminPageControllerTest' --tests 'com.easysubway.collection.adapter.in.web.DataCollectionAdminPageControllerTest' --tests 'com.easysubway.admin.batch.adapter.in.web.AdminBatchPageControllerTest' --tests 'com.easysubway.admin.audit.adapter.in.web.AdminAuditPageControllerTest' --tests 'com.easysubway.admin.operations.adapter.in.web.AdminOperationsPageControllerTest' --tests 'com.easysubway.transit.adapter.in.web.TransitMasterControllerTest' --tests 'com.easysubway.transit.adapter.in.web.TransitFacilityAdminPageControllerTest' --tests 'com.easysubway.transit.adapter.in.web.TransitReadOnlyAdminPageModelTest' --tests 'com.easysubway.field.adapter.in.web.FieldVerificationAdminControllerTest' --tests 'com.easysubway.collection.application.service.DataCollectionRunRecorderTest' --tests 'com.easysubway.collection.adapter.out.persistence.JdbcDataCollectionRunRepositoryTest'`: BUILD SUCCESSFUL
  - `cd backend && ./gradlew test`: BUILD SUCCESSFUL
  - `cd backend && ./gradlew clean test --no-daemon`: BUILD SUCCESSFUL
  - `node --test tools/ci/*.test.mjs`: 116 tests passed
  - `git diff --check`: exit 0
  - `codex review --base origin/main --title "[Feat] 관리자 목록과 검색 PaginationInfo 표준화"`: 최종 re-review actionable 0건

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| pagination model | backend | `EgovPaginationViewTest` | Gradle targeted test output | page block, slice next, 빈 slice page 유지, query encode, query 보존, size 상한, offset overflow 방지 통과 |
| 관리자 목록 HTML 접근성 | backend admin UI | MVC HTML assertion | Gradle targeted test output | 각 목록의 `aria-current="page"`와 page/size 링크 확인 |
| 운영성 실행 로그 경계 | backend | repository/service/controller test | Gradle targeted test output | 데이터 수집, 배치, 감사, incident 목록 offset 조회 확인 |
| repository contract | repository | `node --test tools/ci/*.test.mjs` | command output | 116 tests passed |
| CI | GitHub Actions | PR checks | Android CI, Backend CI, Mobile App CI, Repository CI, OSV, SonarCloud, Release Artifacts | all pass |
| code review | GitHub PR review | CodeRabbit 상태 확인 및 Codex CLI fallback | CodeRabbit rate limit comment, Codex CLI fallback reviews | review 지적 2건 수정 후 최종 actionable 0건 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `EgovPaginationView.links(...)`, `AdminPageRequest`, `admin/fragments/pagination.html`
- 데이터 수집 실행, 배치 실행, 감사 로그, incident는 전체 count 쿼리 없이 `size + 1` slice로 다음 page 여부만 판단한다.
- CodeRabbit은 rate limit으로 실제 리뷰를 시작하지 못해 Codex CLI fallback review를 PR review로 남겼다.

## 리스크

- 역, 시설 상태, 현장 검증, 공통코드는 현재 로컬/설정성 목록을 화면 page로 나눠 표시한다. 운영 DB 실행 로그류는 `LIMIT/OFFSET`으로 조회한다.
- 신규 사용자/역할 관리 목록 화면은 이 PR에서 만들지 않았다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
