### PR TITLE
[Feat] 관리자 중복 제출과 구조도 충돌 방지

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenInterceptor.java
+++ b/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenInterceptor.java
@@ -21,9 +21,7 @@ class AdminCommandTokenInterceptor implements HandlerInterceptor {
 			return true;
 		}
 		String token = request.getParameter(AdminCommandTokenService.PARAMETER_NAME);
-		if (token != null) {
-			commandTokenService.consume(request, token);
-		}
+		commandTokenService.consume(request, token);
 		return true;
 	}
 

--- a/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenInterceptor.java
+++ b/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenInterceptor.java
@@ -2,7 +2,6 @@ package com.easysubway.admin.web;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -26,13 +25,11 @@ class AdminCommandTokenInterceptor implements HandlerInterceptor {
 	}
 
 	private static boolean isAdminFormPost(HttpServletRequest request) {
-		String uri = request.getRequestURI();
-		String contentType = request.getContentType();
+		String path = AdminHtmlRequest.pathWithinApplication(request);
 		return "POST".equals(request.getMethod())
-			&& uri.startsWith("/admin/")
-			&& !uri.equals("/admin/login")
-			&& !uri.startsWith("/admin/error")
-			&& contentType != null
-			&& contentType.startsWith(MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+			&& path.startsWith("/admin/")
+			&& !path.equals("/admin/login")
+			&& !path.startsWith("/admin/error")
+			&& AdminHtmlRequest.isFormUrlEncoded(request);
 	}
 }

--- a/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenInterceptor.java
+++ b/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenInterceptor.java
@@ -1,0 +1,40 @@
+package com.easysubway.admin.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+class AdminCommandTokenInterceptor implements HandlerInterceptor {
+
+	private final AdminCommandTokenService commandTokenService;
+
+	AdminCommandTokenInterceptor(AdminCommandTokenService commandTokenService) {
+		this.commandTokenService = commandTokenService;
+	}
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		if (!isAdminFormPost(request)) {
+			return true;
+		}
+		String token = request.getParameter(AdminCommandTokenService.PARAMETER_NAME);
+		if (token != null) {
+			commandTokenService.consume(request, token);
+		}
+		return true;
+	}
+
+	private static boolean isAdminFormPost(HttpServletRequest request) {
+		String uri = request.getRequestURI();
+		String contentType = request.getContentType();
+		return "POST".equals(request.getMethod())
+			&& uri.startsWith("/admin/")
+			&& !uri.equals("/admin/login")
+			&& !uri.startsWith("/admin/error")
+			&& contentType != null
+			&& contentType.startsWith(MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenModelAdvice.java
+++ b/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenModelAdvice.java
@@ -18,7 +18,7 @@ class AdminCommandTokenModelAdvice {
 	@ModelAttribute
 	void exposeAdminCommandToken(HttpServletRequest request, Model model) {
 		if (isAdminHtmlPage(request)) {
-			model.addAttribute(AdminCommandTokenService.PARAMETER_NAME, commandTokenService.issue(request));
+			model.addAttribute("commandTokens", new AdminCommandTokens(commandTokenService, request));
 		}
 	}
 
@@ -26,6 +26,21 @@ class AdminCommandTokenModelAdvice {
 		String uri = request.getRequestURI();
 		return AdminHtmlRequest.matches(request)
 			&& !uri.startsWith("/admin/error")
-			&& !uri.equals("/admin/login");
+				&& !uri.equals("/admin/login");
+	}
+
+	static final class AdminCommandTokens {
+
+		private final AdminCommandTokenService commandTokenService;
+		private final HttpServletRequest request;
+
+		AdminCommandTokens(AdminCommandTokenService commandTokenService, HttpServletRequest request) {
+			this.commandTokenService = commandTokenService;
+			this.request = request;
+		}
+
+		public String next() {
+			return commandTokenService.issue(request);
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenModelAdvice.java
+++ b/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenModelAdvice.java
@@ -1,0 +1,31 @@
+package com.easysubway.admin.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@ControllerAdvice(annotations = Controller.class)
+class AdminCommandTokenModelAdvice {
+
+	private final AdminCommandTokenService commandTokenService;
+
+	AdminCommandTokenModelAdvice(AdminCommandTokenService commandTokenService) {
+		this.commandTokenService = commandTokenService;
+	}
+
+	@ModelAttribute
+	void exposeAdminCommandToken(HttpServletRequest request, Model model) {
+		if (isAdminHtmlPage(request)) {
+			model.addAttribute(AdminCommandTokenService.PARAMETER_NAME, commandTokenService.issue(request));
+		}
+	}
+
+	private static boolean isAdminHtmlPage(HttpServletRequest request) {
+		String uri = request.getRequestURI();
+		return AdminHtmlRequest.matches(request)
+			&& !uri.startsWith("/admin/error")
+			&& !uri.equals("/admin/login");
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenModelAdvice.java
+++ b/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenModelAdvice.java
@@ -23,10 +23,10 @@ class AdminCommandTokenModelAdvice {
 	}
 
 	private static boolean isAdminHtmlPage(HttpServletRequest request) {
-		String uri = request.getRequestURI();
+		String path = AdminHtmlRequest.pathWithinApplication(request);
 		return AdminHtmlRequest.matches(request)
-			&& !uri.startsWith("/admin/error")
-				&& !uri.equals("/admin/login");
+			&& !path.startsWith("/admin/error")
+			&& !path.equals("/admin/login");
 	}
 
 	static final class AdminCommandTokens {

--- a/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenService.java
+++ b/backend/src/main/java/com/easysubway/admin/web/AdminCommandTokenService.java
@@ -1,0 +1,62 @@
+package com.easysubway.admin.web;
+
+import com.easysubway.common.error.ConflictException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+public class AdminCommandTokenService {
+
+	public static final String PARAMETER_NAME = "commandToken";
+	private static final String SESSION_ATTRIBUTE = AdminCommandTokenService.class.getName() + ".TOKENS";
+	private static final int MAX_TOKENS_PER_SESSION = 64;
+
+	public String issue(HttpServletRequest request) {
+		HttpSession session = request.getSession();
+		synchronized (session) {
+			LinkedHashSet<String> tokens = tokens(session);
+			String token = UUID.randomUUID().toString();
+			tokens.add(token);
+			while (tokens.size() > MAX_TOKENS_PER_SESSION) {
+				tokens.remove(tokens.iterator().next());
+			}
+			return token;
+		}
+	}
+
+	public void consume(HttpServletRequest request, String token) {
+		if (!StringUtils.hasText(token)) {
+			throw duplicateSubmit();
+		}
+		HttpSession session = request.getSession(false);
+		if (session == null) {
+			throw duplicateSubmit();
+		}
+		synchronized (session) {
+			Object value = session.getAttribute(SESSION_ATTRIBUTE);
+			if (!(value instanceof Set<?> tokens) || !tokens.remove(token)) {
+				throw duplicateSubmit();
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private LinkedHashSet<String> tokens(HttpSession session) {
+		Object value = session.getAttribute(SESSION_ATTRIBUTE);
+		if (value instanceof LinkedHashSet<?> existing) {
+			return (LinkedHashSet<String>) existing;
+		}
+		LinkedHashSet<String> tokens = new LinkedHashSet<>();
+		session.setAttribute(SESSION_ATTRIBUTE, tokens);
+		return tokens;
+	}
+
+	private static ConflictException duplicateSubmit() {
+		return new ConflictException("이미 처리되었거나 만료된 관리자 요청입니다. 화면을 새로고침한 뒤 다시 시도해 주세요.");
+	}
+}

--- a/backend/src/main/java/com/easysubway/admin/web/AdminHtmlRequest.java
+++ b/backend/src/main/java/com/easysubway/admin/web/AdminHtmlRequest.java
@@ -1,6 +1,7 @@
 package com.easysubway.admin.web;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 
 public final class AdminHtmlRequest {
@@ -9,12 +10,11 @@ public final class AdminHtmlRequest {
 	}
 
 	public static boolean matches(HttpServletRequest request) {
-		String uri = request.getRequestURI();
+		String uri = pathWithinApplication(request);
 		if (uri == null || !uri.startsWith("/admin/")) {
 			return false;
 		}
 		String accept = request.getHeader("Accept");
-		String contentType = request.getContentType();
 		if (accept != null
 			&& accept.contains(MediaType.APPLICATION_JSON_VALUE)
 			&& !accept.contains(MediaType.TEXT_HTML_VALUE)) {
@@ -23,6 +23,30 @@ public final class AdminHtmlRequest {
 		return (accept != null && accept.contains(MediaType.TEXT_HTML_VALUE))
 			|| uri.contains("/page")
 			|| uri.startsWith("/admin/batches/")
-			|| (contentType != null && contentType.contains(MediaType.APPLICATION_FORM_URLENCODED_VALUE));
+			|| isFormUrlEncoded(request);
+	}
+
+	public static String pathWithinApplication(HttpServletRequest request) {
+		String uri = request.getRequestURI();
+		if (uri == null) {
+			return "";
+		}
+		String contextPath = request.getContextPath();
+		if (contextPath != null && !contextPath.isBlank() && uri.startsWith(contextPath)) {
+			return uri.substring(contextPath.length());
+		}
+		return uri;
+	}
+
+	public static boolean isFormUrlEncoded(HttpServletRequest request) {
+		String contentType = request.getContentType();
+		if (contentType == null) {
+			return false;
+		}
+		try {
+			return MediaType.APPLICATION_FORM_URLENCODED.isCompatibleWith(MediaType.parseMediaType(contentType));
+		} catch (InvalidMediaTypeException exception) {
+			return false;
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/admin/web/AdminWebMvcConfiguration.java
+++ b/backend/src/main/java/com/easysubway/admin/web/AdminWebMvcConfiguration.java
@@ -1,0 +1,20 @@
+package com.easysubway.admin.web;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+class AdminWebMvcConfiguration implements WebMvcConfigurer {
+
+	private final AdminCommandTokenInterceptor commandTokenInterceptor;
+
+	AdminWebMvcConfiguration(AdminCommandTokenInterceptor commandTokenInterceptor) {
+		this.commandTokenInterceptor = commandTokenInterceptor;
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(commandTokenInterceptor);
+	}
+}

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageController.java
@@ -96,7 +96,8 @@ class TransitStationLayoutAdminPageController {
 			transitMasterAdminUseCase.updateSimplifiedStationLayoutStatus(new UpdateSimplifiedStationLayoutStatusCommand(
 				layoutId,
 				form.status(),
-				principal.getName()
+				principal.getName(),
+				form.expectedVersion()
 			));
 		} catch (MasterDataWriteNotAllowedException exception) {
 			redirectAttributes.addFlashAttribute("masterDataError", exception.getMessage());
@@ -288,8 +289,13 @@ class TransitStationLayoutAdminPageController {
 
 	record LayoutStatusForm(
 		@NotNull(message = "{validation.transit.layout-status.required}")
-		SimplifiedStationLayoutStatus status
+		SimplifiedStationLayoutStatus status,
+		Integer expectedVersion
 	) {
+
+		LayoutStatusForm(SimplifiedStationLayoutStatus status) {
+			this(status, null);
+		}
 	}
 
 	record LayoutSourceForm(

--- a/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/out/persistence/InMemoryTransitMasterRepository.java
@@ -342,7 +342,7 @@ public class InMemoryTransitMasterRepository implements
 		simplifiedStationLayouts.put(layoutId, new SimplifiedStationLayout(
 			layout.id(),
 			layout.stationId(),
-			layout.version(),
+			layout.version() + 1,
 			status,
 			layout.sourceIds(),
 			layout.confidenceLevel(),

--- a/backend/src/main/java/com/easysubway/transit/application/port/in/UpdateSimplifiedStationLayoutStatusCommand.java
+++ b/backend/src/main/java/com/easysubway/transit/application/port/in/UpdateSimplifiedStationLayoutStatusCommand.java
@@ -5,6 +5,15 @@ import com.easysubway.transit.domain.SimplifiedStationLayoutStatus;
 public record UpdateSimplifiedStationLayoutStatusCommand(
 	String layoutId,
 	SimplifiedStationLayoutStatus status,
-	String reviewedBy
+	String reviewedBy,
+	Integer expectedVersion
 ) {
+
+	public UpdateSimplifiedStationLayoutStatusCommand(
+		String layoutId,
+		SimplifiedStationLayoutStatus status,
+		String reviewedBy
+	) {
+		this(layoutId, status, reviewedBy, null);
+	}
 }

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -52,6 +52,7 @@ import com.easysubway.transit.domain.StationWithLines;
 import com.easysubway.transit.domain.SimplifiedStationLayout;
 import com.easysubway.transit.domain.SimplifiedStationLayoutNotFoundException;
 import com.easysubway.transit.domain.SimplifiedStationLayoutStatus;
+import com.easysubway.transit.domain.SimplifiedStationLayoutVersionConflictException;
 import com.easysubway.transit.domain.SubwayLine;
 import com.easysubway.transit.domain.TransitOperator;
 import com.easysubway.transit.domain.TransitRegionSummary;
@@ -460,6 +461,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		requireReviewer(command);
 
 		SimplifiedStationLayout layout = loadSimplifiedStationLayout(command.layoutId());
+		requireExpectedLayoutVersion(command, layout);
 		LocalDate updatedAt = LocalDate.now(clock);
 		// 검수 상태는 앱 렌더링 데이터가 아니라 운영자가 배포 가능성을 판단하는 메타데이터만 갱신한다.
 		requireWritableMasterData();
@@ -720,6 +722,15 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		}
 	}
 
+	private void requireExpectedLayoutVersion(
+		UpdateSimplifiedStationLayoutStatusCommand command,
+		SimplifiedStationLayout layout
+	) {
+		if (command.expectedVersion() != null && command.expectedVersion() != layout.version()) {
+			throw new SimplifiedStationLayoutVersionConflictException();
+		}
+	}
+
 	private void requireStationLayoutSource(UpdateStationLayoutSourceCommand command) {
 		if (command.stationId() == null || command.stationId().isBlank()) {
 			throw new InvalidStationLayoutSourceException("역 식별자가 필요합니다.");
@@ -875,7 +886,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 		return new SimplifiedStationLayout(
 			layout.id(),
 			layout.stationId(),
-			layout.version(),
+			layout.version() + 1,
 			status,
 			layout.sourceIds(),
 			layout.confidenceLevel(),

--- a/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
+++ b/backend/src/main/java/com/easysubway/transit/application/service/TransitMasterService.java
@@ -456,7 +456,7 @@ public class TransitMasterService implements TransitMasterQueryUseCase, TransitM
 	}
 
 	@Override
-	public SimplifiedStationLayout updateSimplifiedStationLayoutStatus(UpdateSimplifiedStationLayoutStatusCommand command) {
+	public synchronized SimplifiedStationLayout updateSimplifiedStationLayoutStatus(UpdateSimplifiedStationLayoutStatusCommand command) {
 		requireLayoutStatus(command);
 		requireReviewer(command);
 

--- a/backend/src/main/java/com/easysubway/transit/domain/SimplifiedStationLayoutVersionConflictException.java
+++ b/backend/src/main/java/com/easysubway/transit/domain/SimplifiedStationLayoutVersionConflictException.java
@@ -1,0 +1,10 @@
+package com.easysubway.transit.domain;
+
+import com.easysubway.common.error.ConflictException;
+
+public class SimplifiedStationLayoutVersionConflictException extends ConflictException {
+
+	public SimplifiedStationLayoutVersionConflictException() {
+		super("역 구조도 정보가 이미 변경되었습니다.");
+	}
+}

--- a/backend/src/main/resources/templates/admin/batches/list.html
+++ b/backend/src/main/resources/templates/admin/batches/list.html
@@ -83,6 +83,7 @@
 					      th:action="@{'/admin/batches/' + ${run.jobId} + '/runs/' + ${run.runId} + '/retry'}"
 					      method="post">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+						<input type="hidden" name="commandToken" th:value="${commandToken}">
 						<input type="hidden" name="retryRequested" value="true">
 						<button type="submit">재처리</button>
 					</form>

--- a/backend/src/main/resources/templates/admin/batches/list.html
+++ b/backend/src/main/resources/templates/admin/batches/list.html
@@ -83,7 +83,7 @@
 					      th:action="@{'/admin/batches/' + ${run.jobId} + '/runs/' + ${run.runId} + '/retry'}"
 					      method="post">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-						<input type="hidden" name="commandToken" th:value="${commandToken}">
+						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="retryRequested" value="true">
 						<button type="submit">재처리</button>
 					</form>

--- a/backend/src/main/resources/templates/admin/codes/list.html
+++ b/backend/src/main/resources/templates/admin/codes/list.html
@@ -54,6 +54,7 @@
 				<td>
 					<form th:if="${code.enabled and !code.requiredIncidentCode}" th:action="@{'/admin/codes/' + ${code.groupCode} + '/' + ${code.code} + '/disable'}" method="post">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+						<input type="hidden" name="commandToken" th:value="${commandToken}">
 						<button type="submit">비활성화</button>
 					</form>
 				</td>
@@ -67,6 +68,7 @@
 		<h2>Code 추가·수정</h2>
 		<form method="post" th:action="@{/admin/codes}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+			<input type="hidden" name="commandToken" th:value="${commandToken}">
 			<input type="hidden" name="groupCode" th:value="${selectedGroup}">
 			<label>Code <input name="code" required></label>
 			<label>이름 <input name="displayName" required></label>

--- a/backend/src/main/resources/templates/admin/codes/list.html
+++ b/backend/src/main/resources/templates/admin/codes/list.html
@@ -54,7 +54,7 @@
 				<td>
 					<form th:if="${code.enabled and !code.requiredIncidentCode}" th:action="@{'/admin/codes/' + ${code.groupCode} + '/' + ${code.code} + '/disable'}" method="post">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-						<input type="hidden" name="commandToken" th:value="${commandToken}">
+						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<button type="submit">비활성화</button>
 					</form>
 				</td>
@@ -68,7 +68,7 @@
 		<h2>Code 추가·수정</h2>
 		<form method="post" th:action="@{/admin/codes}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-			<input type="hidden" name="commandToken" th:value="${commandToken}">
+			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<input type="hidden" name="groupCode" th:value="${selectedGroup}">
 			<label>Code <input name="code" required></label>
 			<label>이름 <input name="displayName" required></label>

--- a/backend/src/main/resources/templates/admin/collections/list.html
+++ b/backend/src/main/resources/templates/admin/collections/list.html
@@ -108,6 +108,7 @@
 
 	<form class="run-form" th:action="@{/admin/data-collections/page/run}" method="post">
 		<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+		<input type="hidden" name="commandToken" th:value="${commandToken}">
 		<label th:each="sourceOption : ${sourceOptions}">
 			<input type="radio"
 			       name="source"

--- a/backend/src/main/resources/templates/admin/collections/list.html
+++ b/backend/src/main/resources/templates/admin/collections/list.html
@@ -108,7 +108,7 @@
 
 	<form class="run-form" th:action="@{/admin/data-collections/page/run}" method="post">
 		<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-		<input type="hidden" name="commandToken" th:value="${commandToken}">
+		<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 		<label th:each="sourceOption : ${sourceOptions}">
 			<input type="radio"
 			       name="source"

--- a/backend/src/main/resources/templates/admin/facilities/editor.html
+++ b/backend/src/main/resources/templates/admin/facilities/editor.html
@@ -71,6 +71,7 @@
 			<h2 th:text="${selectedFacility == null ? '시설 등록' : '시설 수정'}">시설 수정</h2>
 			<form class="admin-form" th:action="@{/admin/facilities/editor/page}" method="post">
 				<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+				<input type="hidden" name="commandToken" th:value="${commandToken}">
 				<input type="hidden" name="facilityId" th:value="${facilityForm.facilityId}">
 				<label>
 					<span class="meta">역</span>

--- a/backend/src/main/resources/templates/admin/facilities/editor.html
+++ b/backend/src/main/resources/templates/admin/facilities/editor.html
@@ -71,7 +71,7 @@
 			<h2 th:text="${selectedFacility == null ? '시설 등록' : '시설 수정'}">시설 수정</h2>
 			<form class="admin-form" th:action="@{/admin/facilities/editor/page}" method="post">
 				<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-				<input type="hidden" name="commandToken" th:value="${commandToken}">
+				<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 				<input type="hidden" name="facilityId" th:value="${facilityForm.facilityId}">
 				<label>
 					<span class="meta">역</span>

--- a/backend/src/main/resources/templates/admin/facilities/list.html
+++ b/backend/src/main/resources/templates/admin/facilities/list.html
@@ -159,7 +159,7 @@
 				<form th:action="@{/admin/facilities/{facilityId}/page/status(facilityId=${facility.facilityId})}"
 				      method="post">
 					<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-					<input type="hidden" name="commandToken" th:value="${commandToken}">
+					<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 					<label>
 						<span class="meta">변경할 상태</span>
 						<select name="status">

--- a/backend/src/main/resources/templates/admin/facilities/list.html
+++ b/backend/src/main/resources/templates/admin/facilities/list.html
@@ -159,6 +159,7 @@
 				<form th:action="@{/admin/facilities/{facilityId}/page/status(facilityId=${facility.facilityId})}"
 				      method="post">
 					<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+					<input type="hidden" name="commandToken" th:value="${commandToken}">
 					<label>
 						<span class="meta">변경할 상태</span>
 						<select name="status">

--- a/backend/src/main/resources/templates/admin/field/detail.html
+++ b/backend/src/main/resources/templates/admin/field/detail.html
@@ -59,7 +59,7 @@
 						<form th:action="@{/admin/field-verifications/{stationId}/items/{itemId}/page/status(stationId=${verification.stationId},itemId=${item.itemId})}"
 						      method="post">
 							<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-							<input type="hidden" name="commandToken" th:value="${commandToken}">
+							<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 							<label>
 								<span class="meta">검증 상태</span>
 								<select name="status">

--- a/backend/src/main/resources/templates/admin/field/detail.html
+++ b/backend/src/main/resources/templates/admin/field/detail.html
@@ -59,6 +59,7 @@
 						<form th:action="@{/admin/field-verifications/{stationId}/items/{itemId}/page/status(stationId=${verification.stationId},itemId=${item.itemId})}"
 						      method="post">
 							<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+							<input type="hidden" name="commandToken" th:value="${commandToken}">
 							<label>
 								<span class="meta">검증 상태</span>
 								<select name="status">

--- a/backend/src/main/resources/templates/admin/incidents/list.html
+++ b/backend/src/main/resources/templates/admin/incidents/list.html
@@ -22,6 +22,7 @@
 		<p th:text="${'현재 health: ' + healthStatus}">현재 health: UP</p>
 		<form th:if="${healthStatus != 'UP'}" method="post" th:action="@{/admin/incidents/health}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+			<input type="hidden" name="commandToken" th:value="${commandToken}">
 			<button type="submit">Health incident 생성</button>
 		</form>
 	</section>
@@ -30,6 +31,7 @@
 		<h2>Incident 생성</h2>
 		<form method="post" th:action="@{/admin/incidents}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+			<input type="hidden" name="commandToken" th:value="${commandToken}">
 			<label>심각도
 				<select name="severity">
 					<option th:each="option : ${severityOptions}" th:value="${option.code}" th:text="${option.displayName}">Major</option>
@@ -84,6 +86,7 @@
 				<td>
 					<form th:if="${incident.open}" th:action="@{'/admin/incidents/' + ${incident.incidentId} + '/resolve'}" method="post">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+						<input type="hidden" name="commandToken" th:value="${commandToken}">
 						<label for="incident-resolution" th:for="${'incident-resolution-' + incident.incidentId}">해결 기록</label>
 						<input id="incident-resolution" th:id="${'incident-resolution-' + incident.incidentId}" name="resolution" required placeholder="해결 기록">
 						<button type="submit">해결</button>

--- a/backend/src/main/resources/templates/admin/incidents/list.html
+++ b/backend/src/main/resources/templates/admin/incidents/list.html
@@ -22,7 +22,7 @@
 		<p th:text="${'현재 health: ' + healthStatus}">현재 health: UP</p>
 		<form th:if="${healthStatus != 'UP'}" method="post" th:action="@{/admin/incidents/health}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-			<input type="hidden" name="commandToken" th:value="${commandToken}">
+			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<button type="submit">Health incident 생성</button>
 		</form>
 	</section>
@@ -31,7 +31,7 @@
 		<h2>Incident 생성</h2>
 		<form method="post" th:action="@{/admin/incidents}">
 			<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-			<input type="hidden" name="commandToken" th:value="${commandToken}">
+			<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 			<label>심각도
 				<select name="severity">
 					<option th:each="option : ${severityOptions}" th:value="${option.code}" th:text="${option.displayName}">Major</option>
@@ -86,7 +86,7 @@
 				<td>
 					<form th:if="${incident.open}" th:action="@{'/admin/incidents/' + ${incident.incidentId} + '/resolve'}" method="post">
 						<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-						<input type="hidden" name="commandToken" th:value="${commandToken}">
+						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<label for="incident-resolution" th:for="${'incident-resolution-' + incident.incidentId}">해결 기록</label>
 						<input id="incident-resolution" th:id="${'incident-resolution-' + incident.incidentId}" name="resolution" required placeholder="해결 기록">
 						<button type="submit">해결</button>

--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -208,6 +208,7 @@
 	      th:action="@{/admin/reports/{reportId}/page/review(reportId=${report.id})}"
 	      method="post">
 		<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+		<input type="hidden" name="commandToken" th:value="${commandToken}">
 		<label>
 			기준 신고 ID
 			<input name="duplicateOfReportId" type="text" autocomplete="off" placeholder="중복 처리할 때 입력" th:value="${reviewForm.duplicateOfReportId}">

--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -208,7 +208,7 @@
 	      th:action="@{/admin/reports/{reportId}/page/review(reportId=${report.id})}"
 	      method="post">
 		<input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-		<input type="hidden" name="commandToken" th:value="${commandToken}">
+		<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 		<label>
 			기준 신고 ID
 			<input name="duplicateOfReportId" type="text" autocomplete="off" placeholder="중복 처리할 때 입력" th:value="${reviewForm.duplicateOfReportId}">

--- a/backend/src/main/resources/templates/admin/stations/layouts.html
+++ b/backend/src/main/resources/templates/admin/stations/layouts.html
@@ -163,6 +163,7 @@
 				<td>
 					<form th:action="@{/admin/stations/{stationId}/layout-sources/{sourceId}/page(stationId=${station.stationId}, sourceId=${source.id})}"
 					      method="post">
+						<input type="hidden" name="commandToken" th:value="${commandToken}">
 						<label class="meta" th:for="|source-type-${source.id}|">자료 유형</label>
 						<select name="sourceType" th:id="|source-type-${source.id}|">
 							<option th:each="option : ${sourceTypeOptions}"
@@ -238,6 +239,8 @@
 				<td>
 					<form th:action="@{/admin/stations/{stationId}/layouts/{layoutId}/page/status(stationId=${station.stationId}, layoutId=${layout.id})}"
 					      method="post">
+						<input type="hidden" name="commandToken" th:value="${commandToken}">
+						<input type="hidden" name="expectedVersion" th:value="${layout.version}">
 						<label class="meta" th:for="|status-${layout.id}|">검수 상태</label>
 						<select name="status" th:id="|status-${layout.id}|">
 							<option th:each="option : ${layoutStatusOptions}"
@@ -281,6 +284,7 @@
 				<td>
 					<form th:action="@{/admin/stations/{stationId}/route-nodes/{nodeId}/page(stationId=${station.stationId}, nodeId=${node.id})}"
 					      method="post">
+						<input type="hidden" name="commandToken" th:value="${commandToken}">
 						<label class="meta" th:for="|display-label-${node.id}|">표시 라벨</label>
 						<input type="text" name="displayLabel" th:id="|display-label-${node.id}|"
 						       th:value="${node.displayLabel}" required>
@@ -328,6 +332,7 @@
 				<td>
 					<form th:action="@{/admin/stations/{stationId}/route-edges/{edgeId}/page(stationId=${station.stationId}, edgeId=${edge.id})}"
 					      method="post">
+						<input type="hidden" name="commandToken" th:value="${commandToken}">
 						<label class="meta" th:for="|distance-meters-${edge.id}|">거리 m</label>
 						<input type="number" name="distanceMeters" th:id="|distance-meters-${edge.id}|"
 						       th:value="${edge.distanceMeters}" min="0" required>

--- a/backend/src/main/resources/templates/admin/stations/layouts.html
+++ b/backend/src/main/resources/templates/admin/stations/layouts.html
@@ -163,7 +163,7 @@
 				<td>
 					<form th:action="@{/admin/stations/{stationId}/layout-sources/{sourceId}/page(stationId=${station.stationId}, sourceId=${source.id})}"
 					      method="post">
-						<input type="hidden" name="commandToken" th:value="${commandToken}">
+						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<label class="meta" th:for="|source-type-${source.id}|">자료 유형</label>
 						<select name="sourceType" th:id="|source-type-${source.id}|">
 							<option th:each="option : ${sourceTypeOptions}"
@@ -239,7 +239,7 @@
 				<td>
 					<form th:action="@{/admin/stations/{stationId}/layouts/{layoutId}/page/status(stationId=${station.stationId}, layoutId=${layout.id})}"
 					      method="post">
-						<input type="hidden" name="commandToken" th:value="${commandToken}">
+						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<input type="hidden" name="expectedVersion" th:value="${layout.version}">
 						<label class="meta" th:for="|status-${layout.id}|">검수 상태</label>
 						<select name="status" th:id="|status-${layout.id}|">
@@ -284,7 +284,7 @@
 				<td>
 					<form th:action="@{/admin/stations/{stationId}/route-nodes/{nodeId}/page(stationId=${station.stationId}, nodeId=${node.id})}"
 					      method="post">
-						<input type="hidden" name="commandToken" th:value="${commandToken}">
+						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<label class="meta" th:for="|display-label-${node.id}|">표시 라벨</label>
 						<input type="text" name="displayLabel" th:id="|display-label-${node.id}|"
 						       th:value="${node.displayLabel}" required>
@@ -332,7 +332,7 @@
 				<td>
 					<form th:action="@{/admin/stations/{stationId}/route-edges/{edgeId}/page(stationId=${station.stationId}, edgeId=${edge.id})}"
 					      method="post">
-						<input type="hidden" name="commandToken" th:value="${commandToken}">
+						<input type="hidden" name="commandToken" th:value="${commandTokens.next()}">
 						<label class="meta" th:for="|distance-meters-${edge.id}|">거리 m</label>
 						<input type="number" name="distanceMeters" th:id="|distance-meters-${edge.id}|"
 						       th:value="${edge.distanceMeters}" min="0" required>

--- a/backend/src/test/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageControllerTest.java
@@ -20,12 +20,15 @@ import com.easysubway.collection.domain.DataCollectionStatus;
 import com.easysubway.collection.domain.DataCollectionStepStatus;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
@@ -114,6 +117,51 @@ class AdminBatchPageControllerTest {
 				assertThat(event.targetId()).isEqualTo("transit-master-collection");
 				assertThat(event.action()).isEqualTo("RETRY_BATCH_RUN");
 				assertThat(event.reason()).contains("failed-run");
+			});
+	}
+
+	@Test
+	@DisplayName("배치 재처리 폼은 같은 command token 재전송을 409로 차단한다")
+	void retryRejectsRepeatedCommandToken() throws Exception {
+		saveDataCollectionRunPort.saveRun(failedRun("failed-run"));
+		MockHttpSession session = new MockHttpSession();
+		String token = commandTokenFrom(getAdminHtml("/admin/batches/page", session));
+
+		mockMvc.perform(post("/admin/batches/transit-master-collection/runs/failed-run/retry")
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("commandToken", token)
+				.param("retryRequested", "true"))
+			.andExpect(status().is3xxRedirection());
+
+		String conflictHtml = mockMvc.perform(post("/admin/batches/transit-master-collection/runs/failed-run/retry")
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("commandToken", token)
+				.param("retryRequested", "true"))
+			.andExpect(status().isConflict())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(conflictHtml)
+			.contains("요청이 최신 상태와 충돌했습니다")
+			.contains("이미 처리되었거나 만료된 관리자 요청입니다");
+		assertThat(auditEventRepository.findRecent(AdminAuditEventType.BATCH_OPERATION, 2))
+			.singleElement()
+			.satisfies(event -> {
+				assertThat(event.outcome()).isEqualTo(AdminAuditOutcome.SUCCESS);
+				assertThat(event.reason()).contains("failed-run");
+			});
+		assertThat(auditEventRepository.findRecent(AdminAuditEventType.ADMIN_ACTION, 1))
+			.singleElement()
+			.satisfies(event -> {
+				assertThat(event.outcome()).isEqualTo(AdminAuditOutcome.FAILURE);
+				assertThat(event.action()).isEqualTo("POST /admin/batches/{jobId}/runs/{runId}/retry");
 			});
 	}
 
@@ -238,5 +286,21 @@ class AdminBatchPageControllerTest {
 			"수집 완료",
 			List.of(new DataCollectionRunStep("FETCH", DataCollectionStepStatus.COMPLETED, null, null, null, 1, null))
 		);
+	}
+
+	private String getAdminHtml(String path, MockHttpSession session) throws Exception {
+		return mockMvc.perform(get(path)
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+	}
+
+	private static String commandTokenFrom(String html) {
+		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
+		assertThat(matcher.find()).isTrue();
+		return matcher.group(1);
 	}
 }

--- a/backend/src/test/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/batch/adapter/in/web/AdminBatchPageControllerTest.java
@@ -18,6 +18,7 @@ import com.easysubway.collection.domain.DataCollectionRunStep;
 import com.easysubway.collection.domain.DataCollectionSource;
 import com.easysubway.collection.domain.DataCollectionStatus;
 import com.easysubway.collection.domain.DataCollectionStepStatus;
+import jakarta.servlet.http.HttpSession;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -28,10 +29,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 @SpringBootTest(properties = {
 	"easysubway.admin.username=admin-user",
@@ -104,6 +107,7 @@ class AdminBatchPageControllerTest {
 		mockMvc.perform(post("/admin/batches/transit-master-collection/runs/failed-run/retry")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/incidents/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("retryRequested", "true"))
 			.andExpect(status().is3xxRedirection())
@@ -173,6 +177,7 @@ class AdminBatchPageControllerTest {
 		mockMvc.perform(post("/admin/batches/transit-master-collection/runs/completed-run/retry")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/incidents/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("retryRequested", "true"))
 			.andExpect(status().isBadRequest());
@@ -196,7 +201,8 @@ class AdminBatchPageControllerTest {
 
 		mockMvc.perform(post("/admin/batches/transit-master-collection/runs/failed-run/retry")
 				.with(user("operator").authorities(new SimpleGrantedAuthority("admin.data.operate")))
-				.with(csrf()))
+				.with(csrf())
+				.with(commandToken("/admin/batches/page")))
 			.andExpect(status().isForbidden());
 	}
 
@@ -302,5 +308,26 @@ class AdminBatchPageControllerTest {
 		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
 		assertThat(matcher.find()).isTrue();
 		return matcher.group(1);
+	}
+
+	private RequestPostProcessor commandToken(String pagePath) {
+		return request -> {
+			MockHttpSession session = sessionFrom(request);
+			try {
+				request.setSession(session);
+				request.addParameter("commandToken", commandTokenFrom(getAdminHtml(pagePath, session)));
+				return request;
+			} catch (Exception exception) {
+				throw new AssertionError(exception);
+			}
+		};
+	}
+
+	private static MockHttpSession sessionFrom(MockHttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session instanceof MockHttpSession mockHttpSession) {
+			return mockHttpSession;
+		}
+		return new MockHttpSession();
 	}
 }

--- a/backend/src/test/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.easysubway.admin.audit.adapter.out.persistence.InMemoryAdminAuditEventRepository;
 import com.easysubway.admin.audit.domain.AdminAuditOutcome;
 import com.easysubway.admin.audit.domain.AdminAuditEventType;
+import jakarta.servlet.http.HttpSession;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -20,9 +21,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 @SpringBootTest(properties = {
 	"easysubway.admin.username=admin-user",
@@ -97,6 +100,7 @@ class AdminOperationsPageControllerTest {
 		mockMvc.perform(post("/admin/codes")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/codes/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("groupCode", "REPORT_REJECTION_REASON")
 				.param("code", "PROVIDER_SECRET_MISSING")
@@ -125,6 +129,7 @@ class AdminOperationsPageControllerTest {
 		mockMvc.perform(post("/admin/codes")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/codes/page?groupCode=INCIDENT_STATUS"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("groupCode", "INCIDENT_STATUS")
 				.param("code", "OPEN")
@@ -209,6 +214,7 @@ class AdminOperationsPageControllerTest {
 		mockMvc.perform(post("/admin/incidents")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/incidents/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("severity", "MAJOR")
 				.param("status", "OPEN")
@@ -227,6 +233,7 @@ class AdminOperationsPageControllerTest {
 		mockMvc.perform(post("/admin/incidents/{incidentId}/resolve", incidentId)
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/incidents/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("resolution", "provider secret upload url rotated"))
 			.andExpect(status().is3xxRedirection())
@@ -296,10 +303,33 @@ class AdminOperationsPageControllerTest {
 			});
 	}
 
+	@Test
+	@DisplayName("관리자 form POST는 command token 누락을 409로 차단한다")
+	void adminFormPostRejectsMissingCommandToken() throws Exception {
+		String html = mockMvc.perform(post("/admin/incidents")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("severity", "MAJOR")
+				.param("status", "OPEN")
+				.param("source", "HEALTH")
+				.param("summary", "database DOWN")
+				.param("owner", "ops"))
+			.andExpect(status().isConflict())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("요청이 최신 상태와 충돌했습니다")
+			.contains("이미 처리되었거나 만료된 관리자 요청입니다");
+	}
+
 	private void saveCode(String code) throws Exception {
 		mockMvc.perform(post("/admin/codes")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/codes/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("groupCode", "REPORT_REJECTION_REASON")
 				.param("code", code)
@@ -315,6 +345,7 @@ class AdminOperationsPageControllerTest {
 		mockMvc.perform(post("/admin/incidents")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/incidents/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("severity", "MAJOR")
 				.param("status", "OPEN")
@@ -338,5 +369,26 @@ class AdminOperationsPageControllerTest {
 		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
 		assertThat(matcher.find()).isTrue();
 		return matcher.group(1);
+	}
+
+	private RequestPostProcessor commandToken(String pagePath) {
+		return request -> {
+			MockHttpSession session = sessionFrom(request);
+			try {
+				request.setSession(session);
+				request.addParameter("commandToken", commandTokenFrom(getAdminHtml(pagePath, session)));
+				return request;
+			} catch (Exception exception) {
+				throw new AssertionError(exception);
+			}
+		};
+	}
+
+	private static MockHttpSession sessionFrom(MockHttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session instanceof MockHttpSession mockHttpSession) {
+			return mockHttpSession;
+		}
+		return new MockHttpSession();
 	}
 }

--- a/backend/src/test/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/admin/operations/adapter/in/web/AdminOperationsPageControllerTest.java
@@ -9,14 +9,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.easysubway.admin.audit.adapter.out.persistence.InMemoryAdminAuditEventRepository;
+import com.easysubway.admin.audit.domain.AdminAuditOutcome;
 import com.easysubway.admin.audit.domain.AdminAuditEventType;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -243,6 +247,55 @@ class AdminOperationsPageControllerTest {
 			});
 	}
 
+	@Test
+	@DisplayName("incident 생성 폼은 같은 command token 재전송을 409로 차단한다")
+	void incidentOpenRejectsRepeatedCommandToken() throws Exception {
+		MockHttpSession session = new MockHttpSession();
+		String token = commandTokenFrom(getAdminHtml("/admin/incidents/page", session));
+
+		mockMvc.perform(post("/admin/incidents")
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("commandToken", token)
+				.param("severity", "MAJOR")
+				.param("status", "OPEN")
+				.param("source", "HEALTH")
+				.param("summary", "database DOWN")
+				.param("owner", "ops"))
+			.andExpect(status().is3xxRedirection());
+
+		String conflictHtml = mockMvc.perform(post("/admin/incidents")
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("commandToken", token)
+				.param("severity", "MAJOR")
+				.param("status", "OPEN")
+				.param("source", "HEALTH")
+				.param("summary", "database DOWN")
+				.param("owner", "ops"))
+			.andExpect(status().isConflict())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		String incidentsHtml = getAdminHtml("/admin/incidents/page", session);
+
+		assertThat(conflictHtml)
+			.contains("요청이 최신 상태와 충돌했습니다")
+			.contains("이미 처리되었거나 만료된 관리자 요청입니다");
+		assertThat(incidentsHtml).containsOnlyOnce("database DOWN");
+		assertThat(auditEventRepository.findRecent(AdminAuditEventType.ADMIN_ACTION, 1))
+			.singleElement()
+			.satisfies(event -> {
+				assertThat(event.outcome()).isEqualTo(AdminAuditOutcome.FAILURE);
+				assertThat(event.action()).isEqualTo("POST /admin/incidents");
+			});
+	}
+
 	private void saveCode(String code) throws Exception {
 		mockMvc.perform(post("/admin/codes")
 				.with(httpBasic("admin-user", "admin-test-password"))
@@ -269,5 +322,21 @@ class AdminOperationsPageControllerTest {
 				.param("summary", summary)
 				.param("owner", "ops"))
 			.andExpect(status().is3xxRedirection());
+	}
+
+	private String getAdminHtml(String path, MockHttpSession session) throws Exception {
+		return mockMvc.perform(get(path)
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+	}
+
+	private static String commandTokenFrom(String html) {
+		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
+		assertThat(matcher.find()).isTrue();
+		return matcher.group(1);
 	}
 }

--- a/backend/src/test/java/com/easysubway/admin/web/AdminHtmlRequestTest.java
+++ b/backend/src/test/java/com/easysubway/admin/web/AdminHtmlRequestTest.java
@@ -28,4 +28,24 @@ class AdminHtmlRequestTest {
 
 		assertThat(AdminHtmlRequest.matches(request)).isTrue();
 	}
+
+	@Test
+	@DisplayName("context path가 붙은 관리자 page 요청도 내부 admin HTML 경로로 분류한다")
+	void adminPageRequestWithContextPathMatchesHtml() {
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/subway/admin/facilities/page");
+		request.setContextPath("/subway");
+
+		assertThat(AdminHtmlRequest.pathWithinApplication(request)).isEqualTo("/admin/facilities/page");
+		assertThat(AdminHtmlRequest.matches(request)).isTrue();
+	}
+
+	@Test
+	@DisplayName("form content type은 대소문자와 charset 파라미터가 달라도 인식한다")
+	void formContentTypeMatchesWithParametersAndCaseDifferences() {
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/admin/incidents");
+		request.setContentType("Application/X-WWW-Form-Urlencoded; charset=UTF-8");
+
+		assertThat(AdminHtmlRequest.isFormUrlEncoded(request)).isTrue();
+		assertThat(AdminHtmlRequest.matches(request)).isTrue();
+	}
 }

--- a/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/collection/adapter/in/web/DataCollectionAdminPageControllerTest.java
@@ -8,13 +8,19 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import jakarta.servlet.http.HttpSession;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 @SpringBootTest(properties = {
 	"easysubway.admin.username=admin-user",
@@ -69,6 +75,7 @@ class DataCollectionAdminPageControllerTest {
 		mockMvc.perform(post("/admin/data-collections/page/run")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/data-collections/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("source", "TRANSIT_MASTER"))
 			.andExpect(status().is3xxRedirection())
@@ -143,5 +150,42 @@ class DataCollectionAdminPageControllerTest {
 					}
 					"""))
 			.andExpect(status().isOk());
+	}
+
+	private String getAdminHtml(String path, MockHttpSession session) throws Exception {
+		return mockMvc.perform(get(path)
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+	}
+
+	private static String commandTokenFrom(String html) {
+		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
+		assertThat(matcher.find()).isTrue();
+		return matcher.group(1);
+	}
+
+	private RequestPostProcessor commandToken(String pagePath) {
+		return request -> {
+			MockHttpSession session = sessionFrom(request);
+			try {
+				request.setSession(session);
+				request.addParameter("commandToken", commandTokenFrom(getAdminHtml(pagePath, session)));
+				return request;
+			} catch (Exception exception) {
+				throw new AssertionError(exception);
+			}
+		};
+	}
+
+	private static MockHttpSession sessionFrom(MockHttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session instanceof MockHttpSession mockHttpSession) {
+			return mockHttpSession;
+		}
+		return new MockHttpSession();
 	}
 }

--- a/backend/src/test/java/com/easysubway/common/security/AdminOperatorAuditFilterTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/AdminOperatorAuditFilterTest.java
@@ -4,12 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.easysubway.admin.audit.adapter.out.persistence.InMemoryAdminAuditEventRepository;
 import com.easysubway.admin.audit.domain.AdminAuditEventType;
 import com.jayway.jsonpath.JsonPath;
+import jakarta.servlet.http.HttpSession;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +25,10 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -70,6 +77,7 @@ class AdminOperatorAuditFilterTest {
 				.queryParam("latitude", "37.302421")
 				.with(httpBasic("admin-test", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/reports/%s/page".formatted(reportId)))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("decision", "ACCEPT")
 				.param("privateNote", "do-not-log-private-note")
@@ -155,5 +163,42 @@ class AdminOperatorAuditFilterTest {
 			.getResponse()
 			.getContentAsString();
 		return JsonPath.read(response, "$.data.id");
+	}
+
+	private String getAdminHtml(String path, MockHttpSession session) throws Exception {
+		return mockMvc.perform(get(path)
+				.session(session)
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+	}
+
+	private static String commandTokenFrom(String html) {
+		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
+		assertThat(matcher.find()).isTrue();
+		return matcher.group(1);
+	}
+
+	private RequestPostProcessor commandToken(String pagePath) {
+		return request -> {
+			MockHttpSession session = sessionFrom(request);
+			try {
+				request.setSession(session);
+				request.addParameter("commandToken", commandTokenFrom(getAdminHtml(pagePath, session)));
+				return request;
+			} catch (Exception exception) {
+				throw new AssertionError(exception);
+			}
+		};
+	}
+
+	private static MockHttpSession sessionFrom(MockHttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session instanceof MockHttpSession mockHttpSession) {
+			return mockHttpSession;
+		}
+		return new MockHttpSession();
 	}
 }

--- a/backend/src/test/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminControllerTest.java
+++ b/backend/src/test/java/com/easysubway/field/adapter/in/web/FieldVerificationAdminControllerTest.java
@@ -19,8 +19,11 @@ import com.easysubway.field.domain.FieldVerificationItem;
 import com.easysubway.field.domain.FieldVerificationItemType;
 import com.easysubway.field.domain.FieldVerificationSession;
 import com.easysubway.field.domain.FieldVerificationStatus;
+import jakarta.servlet.http.HttpSession;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,8 +31,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 @SpringBootTest(properties = {
 	"easysubway.admin.username=admin-user",
@@ -258,6 +264,7 @@ class FieldVerificationAdminControllerTest {
 		String html = mockMvc.perform(post("/admin/field-verifications/station-sadang/items/field-verification-sadang-elevator/page/status")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/field-verifications/station-sadang/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("note", "상태 누락 현장 메모"))
 			.andExpect(status().isBadRequest())
@@ -279,6 +286,7 @@ class FieldVerificationAdminControllerTest {
 		String html = mockMvc.perform(post("/admin/field-verifications/station-sadang/items/field-verification-sadang-elevator/page/status")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/field-verifications/station-sadang/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("status", "PLANNED")
 				.param("note", "허용되지 않는 상태"))
@@ -452,5 +460,42 @@ class FieldVerificationAdminControllerTest {
 		mockMvc.perform(get("/admin/field-verifications/stations/station-sadang/history")
 				.with(httpBasic("anonymous-user-1", "user-test-password")))
 			.andExpect(status().isForbidden());
+	}
+
+	private String getAdminHtml(String path, MockHttpSession session) throws Exception {
+		return mockMvc.perform(get(path)
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+	}
+
+	private static String commandTokenFrom(String html) {
+		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
+		assertThat(matcher.find()).isTrue();
+		return matcher.group(1);
+	}
+
+	private RequestPostProcessor commandToken(String pagePath) {
+		return request -> {
+			MockHttpSession session = sessionFrom(request);
+			try {
+				request.setSession(session);
+				request.addParameter("commandToken", commandTokenFrom(getAdminHtml(pagePath, session)));
+				return request;
+			} catch (Exception exception) {
+				throw new AssertionError(exception);
+			}
+		};
+	}
+
+	private static MockHttpSession sessionFrom(MockHttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session instanceof MockHttpSession mockHttpSession) {
+			return mockHttpSession;
+		}
+		return new MockHttpSession();
 	}
 }

--- a/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageControllerTest.java
@@ -25,18 +25,24 @@ import com.easysubway.transit.domain.Station;
 import com.easysubway.transit.domain.StationNotFoundException;
 import com.easysubway.transit.domain.StationWithLines;
 import com.jayway.jsonpath.JsonPath;
+import jakarta.servlet.http.HttpSession;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 @SpringBootTest(properties = {
 	"easysubway.admin.username=admin-user",
@@ -195,9 +201,47 @@ class DataQualityAdminPageControllerTest {
 		mockMvc.perform(post("/admin/reports/{reportId}/page/review", reportId)
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/reports/%s/page".formatted(reportId)))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("decision", "ACCEPT"))
 			.andExpect(status().is3xxRedirection());
+	}
+
+	private String getAdminHtml(String path, MockHttpSession session) throws Exception {
+		return mockMvc.perform(get(path)
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+	}
+
+	private static String commandTokenFrom(String html) {
+		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
+		assertThat(matcher.find()).isTrue();
+		return matcher.group(1);
+	}
+
+	private RequestPostProcessor commandToken(String pagePath) {
+		return request -> {
+			MockHttpSession session = sessionFrom(request);
+			try {
+				request.setSession(session);
+				request.addParameter("commandToken", commandTokenFrom(getAdminHtml(pagePath, session)));
+				return request;
+			} catch (Exception exception) {
+				throw new AssertionError(exception);
+			}
+		};
+	}
+
+	private static MockHttpSession sessionFrom(MockHttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session instanceof MockHttpSession mockHttpSession) {
+			return mockHttpSession;
+		}
+		return new MockHttpSession();
 	}
 
 	private static DataQualitySummary emptySummary() {

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -12,6 +12,7 @@ import com.easysubway.admin.audit.adapter.out.persistence.InMemoryAdminAuditEven
 import com.easysubway.admin.audit.domain.AdminAuditOutcome;
 import com.easysubway.admin.audit.domain.AdminAuditEventType;
 import com.jayway.jsonpath.JsonPath;
+import jakarta.servlet.http.HttpSession;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
@@ -20,8 +21,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 @SpringBootTest(properties = {
 	"easysubway.admin.username=admin-test",
@@ -200,6 +203,7 @@ class FacilityReportAdminPageControllerTest {
 		mockMvc.perform(post("/admin/reports/{reportId}/page/review", reportId)
 				.with(httpBasic("admin-test", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/reports/%s/page".formatted(reportId)))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("decision", "ACCEPT"))
 			.andExpect(status().is3xxRedirection())
@@ -270,6 +274,7 @@ class FacilityReportAdminPageControllerTest {
 		String html = mockMvc.perform(post("/admin/reports/{reportId}/page/review", reportId)
 				.with(httpBasic("admin-test", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/reports/%s/page".formatted(reportId)))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("duplicateOfReportId", originalReportId))
 			.andExpect(status().isBadRequest())
@@ -301,6 +306,7 @@ class FacilityReportAdminPageControllerTest {
 		mockMvc.perform(post("/admin/reports/{reportId}/page/review", reportId)
 				.with(httpBasic("admin-test", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/reports/%s/page".formatted(reportId)))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("decision", "REJECT"))
 			.andExpect(status().is3xxRedirection());
@@ -329,6 +335,7 @@ class FacilityReportAdminPageControllerTest {
 		mockMvc.perform(post("/admin/reports/{reportId}/page/review", duplicatedReportId)
 				.with(httpBasic("admin-test", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/reports/%s/page".formatted(duplicatedReportId)))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("decision", "MARK_DUPLICATE")
 				.param("duplicateOfReportId", originalReportId))
@@ -399,6 +406,27 @@ class FacilityReportAdminPageControllerTest {
 		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
 		assertThat(matcher.find()).isTrue();
 		return matcher.group(1);
+	}
+
+	private RequestPostProcessor commandToken(String pagePath) {
+		return request -> {
+			MockHttpSession session = sessionFrom(request);
+			try {
+				request.setSession(session);
+				request.addParameter("commandToken", commandTokenFrom(getAdminHtml(pagePath, session)));
+				return request;
+			} catch (Exception exception) {
+				throw new AssertionError(exception);
+			}
+		};
+	}
+
+	private static MockHttpSession sessionFrom(MockHttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session instanceof MockHttpSession mockHttpSession) {
+			return mockHttpSession;
+		}
+		return new MockHttpSession();
 	}
 
 	private String createReportWithPhotoAndLocation(String description) throws Exception {

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -9,14 +9,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.easysubway.admin.audit.adapter.out.persistence.InMemoryAdminAuditEventRepository;
+import com.easysubway.admin.audit.domain.AdminAuditOutcome;
 import com.easysubway.admin.audit.domain.AdminAuditEventType;
 import com.jayway.jsonpath.JsonPath;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(properties = {
@@ -214,6 +218,50 @@ class FacilityReportAdminPageControllerTest {
 	}
 
 	@Test
+	@DisplayName("신고 검수 폼은 같은 command token 재전송을 409로 차단한다")
+	void reportReviewRejectsRepeatedCommandToken() throws Exception {
+		String reportId = createReport("중복 제출을 막을 신고");
+		MockHttpSession session = new MockHttpSession();
+		String token = commandTokenFrom(getAdminHtml("/admin/reports/%s/page".formatted(reportId), session));
+
+		mockMvc.perform(post("/admin/reports/{reportId}/page/review", reportId)
+				.session(session)
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("commandToken", token)
+				.param("decision", "ACCEPT"))
+			.andExpect(status().is3xxRedirection());
+
+		String conflictHtml = mockMvc.perform(post("/admin/reports/{reportId}/page/review", reportId)
+				.session(session)
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("commandToken", token)
+				.param("decision", "REJECT"))
+			.andExpect(status().isConflict())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		String detailHtml = getAdminHtml("/admin/reports/%s/page".formatted(reportId), session);
+
+		assertThat(conflictHtml)
+			.contains("요청이 최신 상태와 충돌했습니다")
+			.contains("이미 처리되었거나 만료된 관리자 요청입니다");
+		assertThat(detailHtml)
+			.contains("반영됨")
+			.doesNotContain("반려됨");
+		assertThat(auditEventRepository.findRecent(AdminAuditEventType.ADMIN_ACTION, 1))
+			.singleElement()
+			.satisfies(event -> {
+				assertThat(event.outcome()).isEqualTo(AdminAuditOutcome.FAILURE);
+				assertThat(event.action()).isEqualTo("POST /admin/reports/{reportId}/page/review");
+			});
+	}
+
+	@Test
 	@DisplayName("신고 검수 폼은 판정 누락 오류와 입력값을 상세 화면에 표시한다")
 	void reportReviewValidationErrorRendersAdminHtml() throws Exception {
 		String originalReportId = createReport("기준 신고");
@@ -335,6 +383,22 @@ class FacilityReportAdminPageControllerTest {
 
 	private String createReport(String description) throws Exception {
 		return createReport(description, "");
+	}
+
+	private String getAdminHtml(String path, MockHttpSession session) throws Exception {
+		return mockMvc.perform(get(path)
+				.session(session)
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+	}
+
+	private static String commandTokenFrom(String html) {
+		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
+		assertThat(matcher.find()).isTrue();
+		return matcher.group(1);
 	}
 
 	private String createReportWithPhotoAndLocation(String description) throws Exception {

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitFacilityAdminPageControllerTest.java
@@ -9,14 +9,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import jakarta.servlet.http.HttpSession;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 @SpringBootTest(properties = {
 	"easysubway.admin.username=admin-user",
@@ -79,6 +85,7 @@ class TransitFacilityAdminPageControllerTest {
 		mockMvc.perform(post("/admin/facilities/facility-sangnoksu-elevator-1/page/status")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/facilities/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("status", "BROKEN"))
 			.andExpect(status().is3xxRedirection())
@@ -102,6 +109,7 @@ class TransitFacilityAdminPageControllerTest {
 		String html = mockMvc.perform(post("/admin/facilities/facility-sangnoksu-elevator-1/page/status")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/facilities/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED))
 			.andExpect(status().isBadRequest())
 			.andReturn()
@@ -121,6 +129,7 @@ class TransitFacilityAdminPageControllerTest {
 		String html = mockMvc.perform(post("/admin/facilities/editor/page")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/facilities/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("stationId", "station-sangnoksu")
 				.param("type", "ELEVATOR")
@@ -148,6 +157,7 @@ class TransitFacilityAdminPageControllerTest {
 		String html = mockMvc.perform(post("/admin/facilities/editor/page")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/facilities/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("stationId", "station-sangnoksu")
 				.param("type", "ELEVATOR")
@@ -188,12 +198,49 @@ class TransitFacilityAdminPageControllerTest {
 				.param("status", "BROKEN"))
 			.andExpect(status().isUnauthorized());
 
-			mockMvc.perform(post("/admin/facilities/facility-sangnoksu-elevator-1/page/status")
-					.with(httpBasic("basic-user", "user-test-password"))
-					.with(csrf())
-					.contentType(MediaType.APPLICATION_FORM_URLENCODED)
-					.param("status", "BROKEN"))
-				.andExpect(status().isForbidden())
-				.andExpect(forwardedUrl("/admin/error/page"));
-		}
+		mockMvc.perform(post("/admin/facilities/facility-sangnoksu-elevator-1/page/status")
+				.with(httpBasic("basic-user", "user-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("status", "BROKEN"))
+			.andExpect(status().isForbidden())
+			.andExpect(forwardedUrl("/admin/error/page"));
 	}
+
+	private String getAdminHtml(String path, MockHttpSession session) throws Exception {
+		return mockMvc.perform(get(path)
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+	}
+
+	private static String commandTokenFrom(String html) {
+		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
+		assertThat(matcher.find()).isTrue();
+		return matcher.group(1);
+	}
+
+	private RequestPostProcessor commandToken(String pagePath) {
+		return request -> {
+			MockHttpSession session = sessionFrom(request);
+			try {
+				request.setSession(session);
+				request.addParameter("commandToken", commandTokenFrom(getAdminHtml(pagePath, session)));
+				return request;
+			} catch (Exception exception) {
+				throw new AssertionError(exception);
+			}
+		};
+	}
+
+	private static MockHttpSession sessionFrom(MockHttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session instanceof MockHttpSession mockHttpSession) {
+			return mockHttpSession;
+		}
+		return new MockHttpSession();
+	}
+}

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import jakarta.servlet.http.HttpSession;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
@@ -17,9 +18,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 @SpringBootTest(properties = {
 	"easysubway.admin.username=admin-user",
@@ -104,6 +107,7 @@ class TransitStationLayoutAdminPageControllerTest {
 		mockMvc.perform(post("/admin/stations/station-sangnoksu/layouts/layout-sangnoksu-draft/page/status")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/stations/station-sangnoksu/layouts/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("status", "READY_FOR_REVIEW"))
 			.andExpect(status().is3xxRedirection())
@@ -210,6 +214,7 @@ class TransitStationLayoutAdminPageControllerTest {
 		mockMvc.perform(post("/admin/stations/station-sangnoksu/layout-sources/layout-source-sangnoksu-station-map/page")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/stations/station-sangnoksu/layouts/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("sourceType", "OPERATOR_PAGE")
 				.param("sourceName", "상록수역 운영기관 안내 페이지")
@@ -243,6 +248,7 @@ class TransitStationLayoutAdminPageControllerTest {
 		String html = mockMvc.perform(post("/admin/stations/station-sangnoksu/layout-sources/layout-source-sangnoksu-station-map/page")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/stations/station-sangnoksu/layouts/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("sourceType", "OPERATOR_PAGE")
 				.param("sourceName", "상록수역 운영기관 안내 페이지")
@@ -267,6 +273,7 @@ class TransitStationLayoutAdminPageControllerTest {
 		mockMvc.perform(post("/admin/stations/station-sangnoksu/route-nodes/node-sangnoksu-elevator-1/page")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/stations/station-sangnoksu/layouts/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("displayX", "132")
 				.param("displayY", "256")
@@ -295,6 +302,7 @@ class TransitStationLayoutAdminPageControllerTest {
 		mockMvc.perform(post("/admin/stations/station-sangnoksu/route-nodes/node-sangnoksu-faregate/page")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/stations/station-sangnoksu/layouts/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("displayX", "288")
 				.param("displayY", "244")
@@ -322,6 +330,7 @@ class TransitStationLayoutAdminPageControllerTest {
 		String html = mockMvc.perform(post("/admin/stations/station-sangnoksu/route-nodes/node-sangnoksu-elevator-1/page")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/stations/station-sangnoksu/layouts/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("displayX", "132")
 				.param("displayY", "256")
@@ -345,6 +354,7 @@ class TransitStationLayoutAdminPageControllerTest {
 		mockMvc.perform(post("/admin/stations/station-sangnoksu/route-edges/edge-sangnoksu-elevator-to-faregate/page")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/stations/station-sangnoksu/layouts/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("distanceMeters", "34")
 				.param("estimatedSeconds", "90")
@@ -381,6 +391,7 @@ class TransitStationLayoutAdminPageControllerTest {
 		String html = mockMvc.perform(post("/admin/stations/station-sangnoksu/route-edges/edge-sangnoksu-elevator-to-faregate/page")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/stations/station-sangnoksu/layouts/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("distanceMeters", "34")
 				.param("estimatedSeconds", "90")
@@ -519,6 +530,7 @@ class TransitStationLayoutAdminPageControllerTest {
 		mockMvc.perform(post("/admin/stations/station-sadang/route-nodes/node-sangnoksu-elevator-1/page")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/stations/station-sangnoksu/layouts/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("displayX", "132")
 				.param("displayY", "256")
@@ -534,6 +546,7 @@ class TransitStationLayoutAdminPageControllerTest {
 		mockMvc.perform(post("/admin/stations/station-sadang/layout-sources/layout-source-sangnoksu-station-map/page")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/stations/station-sangnoksu/layouts/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("sourceType", "OPERATOR_PAGE")
 				.param("sourceName", "상록수역 운영기관 안내 페이지")
@@ -554,6 +567,7 @@ class TransitStationLayoutAdminPageControllerTest {
 		mockMvc.perform(post("/admin/stations/station-sadang/route-edges/edge-sangnoksu-elevator-to-faregate/page")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/stations/station-sangnoksu/layouts/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("distanceMeters", "34")
 				.param("estimatedSeconds", "90")
@@ -575,6 +589,7 @@ class TransitStationLayoutAdminPageControllerTest {
 		mockMvc.perform(post("/admin/stations/station-sadang/layouts/layout-sangnoksu-draft/page/status")
 				.with(httpBasic("admin-user", "admin-test-password"))
 				.with(csrf())
+				.with(commandToken("/admin/stations/station-sangnoksu/layouts/page"))
 				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 				.param("status", "READY_FOR_REVIEW"))
 			.andExpect(status().isNotFound())
@@ -602,5 +617,26 @@ class TransitStationLayoutAdminPageControllerTest {
 		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
 		assertThat(matcher.find()).isTrue();
 		return matcher.group(1);
+	}
+
+	private RequestPostProcessor commandToken(String pagePath) {
+		return request -> {
+			MockHttpSession session = sessionFrom(request);
+			try {
+				request.setSession(session);
+				request.addParameter("commandToken", commandTokenFrom(getAdminHtml(pagePath, session)));
+				return request;
+			} catch (Exception exception) {
+				throw new AssertionError(exception);
+			}
+		};
+	}
+
+	private static MockHttpSession sessionFrom(MockHttpServletRequest request) {
+		HttpSession session = request.getSession(false);
+		if (session instanceof MockHttpSession mockHttpSession) {
+			return mockHttpSession;
+		}
+		return new MockHttpSession();
 	}
 }

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageControllerTest.java
@@ -10,6 +10,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import jakarta.servlet.http.HttpSession;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
@@ -96,8 +98,30 @@ class TransitStationLayoutAdminPageControllerTest {
 			.contains("name=\"widthLevel\"")
 			.contains("name=\"reliabilityScore\"")
 			.contains("name=\"active\"")
-			.doesNotContain("{\"nodes\":[],\"edges\":[]}")
-			.doesNotContain("<img");
+				.doesNotContain("{\"nodes\":[],\"edges\":[]}")
+				.doesNotContain("<img");
+	}
+
+	@Test
+	@DisplayName("역 구조도 화면은 각 관리자 form마다 서로 다른 command token을 발급한다")
+	void stationLayoutPageIssuesDistinctCommandTokenPerForm() throws Exception {
+		String html = mockMvc.perform(get("/admin/stations/station-sangnoksu/layouts/page")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
+		Set<String> tokens = new HashSet<>();
+		int tokenCount = 0;
+		while (matcher.find()) {
+			tokenCount++;
+			tokens.add(matcher.group(1));
+		}
+
+		assertThat(tokenCount).isGreaterThan(1);
+		assertThat(tokens).hasSize(tokenCount);
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitStationLayoutAdminPageControllerTest.java
@@ -9,12 +9,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -116,6 +119,88 @@ class TransitStationLayoutAdminPageControllerTest {
 		assertThat(html)
 			.contains("layout-sangnoksu-draft")
 			.contains("READY_FOR_REVIEW");
+	}
+
+	@Test
+	@DisplayName("역 구조도 상태 변경 폼은 같은 command token 재전송을 409로 차단한다")
+	@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+	void stationLayoutStatusRejectsRepeatedCommandToken() throws Exception {
+		MockHttpSession session = new MockHttpSession();
+		String token = commandTokenFrom(getAdminHtml("/admin/stations/station-sangnoksu/layouts/page", session));
+
+		mockMvc.perform(post("/admin/stations/station-sangnoksu/layouts/layout-sangnoksu-draft/page/status")
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("commandToken", token)
+				.param("expectedVersion", "1")
+				.param("status", "READY_FOR_REVIEW"))
+			.andExpect(status().is3xxRedirection());
+
+		String conflictHtml = mockMvc.perform(post("/admin/stations/station-sangnoksu/layouts/layout-sangnoksu-draft/page/status")
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("commandToken", token)
+				.param("expectedVersion", "1")
+				.param("status", "PUBLISHED"))
+			.andExpect(status().isConflict())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		String html = getAdminHtml("/admin/stations/station-sangnoksu/layouts/page", session);
+
+		assertThat(conflictHtml)
+			.contains("요청이 최신 상태와 충돌했습니다")
+			.contains("이미 처리되었거나 만료된 관리자 요청입니다");
+		assertThat(html)
+			.contains("READY_FOR_REVIEW")
+			.doesNotContain("option value=\"PUBLISHED\" selected");
+	}
+
+	@Test
+	@DisplayName("역 구조도 상태 변경은 오래된 version 제출을 409로 차단한다")
+	@DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+	void stationLayoutStatusRejectsStaleExpectedVersion() throws Exception {
+		MockHttpSession session = new MockHttpSession();
+		String firstToken = commandTokenFrom(getAdminHtml("/admin/stations/station-sangnoksu/layouts/page", session));
+		String staleToken = commandTokenFrom(getAdminHtml("/admin/stations/station-sangnoksu/layouts/page", session));
+
+		mockMvc.perform(post("/admin/stations/station-sangnoksu/layouts/layout-sangnoksu-draft/page/status")
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("commandToken", firstToken)
+				.param("expectedVersion", "1")
+				.param("status", "READY_FOR_REVIEW"))
+			.andExpect(status().is3xxRedirection());
+
+		String conflictHtml = mockMvc.perform(post("/admin/stations/station-sangnoksu/layouts/layout-sangnoksu-draft/page/status")
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("commandToken", staleToken)
+				.param("expectedVersion", "1")
+				.param("status", "PUBLISHED"))
+			.andExpect(status().isConflict())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		String html = getAdminHtml("/admin/stations/station-sangnoksu/layouts/page", session);
+
+		assertThat(conflictHtml)
+			.contains("요청이 최신 상태와 충돌했습니다")
+			.contains("역 구조도 정보가 이미 변경되었습니다.");
+		assertThat(html)
+			.contains("v2")
+			.contains("READY_FOR_REVIEW")
+			.doesNotContain("option value=\"PUBLISHED\" selected");
 	}
 
 	@Test
@@ -501,5 +586,21 @@ class TransitStationLayoutAdminPageControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data[0].id").value("layout-sangnoksu-draft"))
 			.andExpect(jsonPath("$.data[0].status").value("DRAFT"));
+	}
+
+	private String getAdminHtml(String path, MockHttpSession session) throws Exception {
+		return mockMvc.perform(get(path)
+				.session(session)
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+	}
+
+	private static String commandTokenFrom(String html) {
+		Matcher matcher = Pattern.compile("name=\"commandToken\" value=\"([^\"]+)\"").matcher(html);
+		assertThat(matcher.find()).isTrue();
+		return matcher.group(1);
 	}
 }


### PR DESCRIPTION
## 관련 이슈

close #960

## 작업 배경

관리자 HTML 폼에서 더블클릭, 브라우저 뒤로가기 후 재전송, 여러 탭의 오래된 상태 제출이 발생하면 신고 검수, incident 생성, batch 재처리, 역 구조도 상태 변경 같은 운영 mutation이 중복 처리될 수 있습니다. QA 요청 기준으로 main의 기존 409 HTML 오류 화면과 관리자 audit 필터를 재사용하면서, 폼 기반 요청에 command token과 version 충돌 방지를 적용했습니다.

## 작업 내용

- 관리자 HTML 화면의 각 form 렌더링마다 세션 기반 `commandToken`을 발급하고, form-urlencoded `/admin/**` POST에서 token을 1회만 소비하도록 공통 interceptor를 추가했습니다.
- token 누락, 만료, 중복 제출은 409 conflict로 차단하고, JSON/API 호출은 content type 기준으로 기존 흐름을 유지했습니다.
- context path가 붙은 배포에서도 `/admin/**`, `/admin/login`, `/admin/error` 판정이 일관되도록 내부 경로 정규화 helper를 추가했습니다.
- 신고 검수, 공통코드, incident, batch 재처리, 데이터 수집, 시설 상태/편집, 현장 검증, 역 구조도 기준 자료·상태·노드·간선 폼에 hidden `commandToken`을 추가했습니다.
- 역 구조도 상태 변경 폼은 `expectedVersion`을 함께 제출하고, 현재 version과 다르면 409 conflict로 차단하도록 optimistic lock 검증을 추가했습니다.
- 역 구조도 상태 변경 저장 시 version을 증가시켜 stale form 제출을 감지할 수 있게 했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests 'com.easysubway.admin.web.AdminHtmlRequestTest' --tests 'com.easysubway.admin.operations.adapter.in.web.AdminOperationsPageControllerTest' --tests 'com.easysubway.transit.adapter.in.web.TransitStationLayoutAdminPageControllerTest'`: exit 0
  - `cd backend && ./gradlew test --tests 'com.easysubway.transit.adapter.in.web.TransitStationLayoutAdminPageControllerTest' --tests 'com.easysubway.admin.operations.adapter.in.web.AdminOperationsPageControllerTest' --tests 'com.easysubway.admin.batch.adapter.in.web.AdminBatchPageControllerTest' --tests 'com.easysubway.report.adapter.in.web.FacilityReportAdminPageControllerTest' --tests 'com.easysubway.transit.adapter.in.web.TransitFacilityAdminPageControllerTest' --tests 'com.easysubway.collection.adapter.in.web.DataCollectionAdminPageControllerTest' --tests 'com.easysubway.common.security.AdminOperatorAuditFilterTest' --tests 'com.easysubway.field.adapter.in.web.FieldVerificationAdminControllerTest' --tests 'com.easysubway.quality.adapter.in.web.DataQualityAdminPageControllerTest'`: exit 0
  - `cd backend && ./gradlew test --tests '*Concurrency*' --tests '*FacilityReport*' --tests '*Transit*Admin*'`: exit 0
  - `cd backend && ./gradlew test`: exit 0
  - `node --test tools/ci/*.test.mjs`: exit 0, 116 tests passed
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 신고 검수 중복 제출 | local backend test | 같은 세션의 같은 `commandToken`으로 검수 POST 2회 제출 | `FacilityReportAdminPageControllerTest.reportReviewRejectsRepeatedCommandToken` | 두 번째 요청 409, 최초 승인 상태 유지, 실패 audit 기록 |
| incident 중복 생성 | local backend test | 같은 세션의 같은 `commandToken`으로 incident 생성 POST 2회 제출 | `AdminOperationsPageControllerTest.incidentOpenRejectsRepeatedCommandToken` | 두 번째 요청 409, incident 1건만 표시, 실패 audit 기록 |
| 관리자 form token 누락 | local backend test | form-urlencoded `/admin/incidents` POST에서 `commandToken` 미제출 | `AdminOperationsPageControllerTest.adminFormPostRejectsMissingCommandToken` | 요청 409, 관리자 오류 HTML 표시 |
| batch 재처리 중복 제출 | local backend test | 같은 세션의 같은 `commandToken`으로 retry POST 2회 제출 | `AdminBatchPageControllerTest.retryRejectsRepeatedCommandToken` | 두 번째 요청 409, batch retry audit은 최초 성공 1건만 기록 |
| form별 token 발급 | local backend test | 역 구조도 페이지의 여러 form hidden token 수집 | `TransitStationLayoutAdminPageControllerTest.stationLayoutPageIssuesDistinctCommandTokenPerForm` | form token이 2개 이상이고 모두 고유함 |
| 역 구조도 stale version | local backend test | v1 화면 token 2개 발급 후 첫 요청으로 v2 갱신, 두 번째 요청은 `expectedVersion=1` 제출 | `TransitStationLayoutAdminPageControllerTest.stationLayoutStatusRejectsStaleExpectedVersion` | 두 번째 요청 409, v2 READY_FOR_REVIEW 유지 |
| 관리자 HTML 경로 판정 | local backend test | context path 포함 경로와 대소문자/charset 포함 form content type 판정 | `AdminHtmlRequestTest` | 내부 `/admin/**` 경로와 form-urlencoded 요청을 정상 분류 |
| 전체 회귀 | local backend/repository | Gradle 전체 테스트와 repository contract 테스트 실행 | `cd backend && ./gradlew test`, `node --test tools/ci/*.test.mjs` | 모두 exit 0 |
| 원격 CI | GitHub Actions | PR #1007 최신 head `73f99880` checks 확인 | [CI run](https://github.com/AquilaXk/easysubway/actions/runs/28279154678), [Release Artifacts run](https://github.com/AquilaXk/easysubway/actions/runs/28279154569) | Backend CI, Repository CI, Android CI, Mobile App CI, OSV, SonarCloud, Backend Release Image 모두 통과 |
| 코드 리뷰 | GitHub PR review | CodeRabbit, Codex fallback, inline thread 확인 | PR #1007 conversation | CodeRabbit completed, Codex fallback 지적 3건 및 CodeRabbit actionable 2건 답글/수정/resolve 완료 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `AdminCommandTokenInterceptor`는 HTML form-urlencoded `/admin/**` POST만 token 소비 대상으로 보고, JSON/API 호출은 기존 흐름을 유지합니다.
  - `AdminCommandTokenModelAdvice`는 페이지 단일 token이 아니라 `commandTokens.next()` helper를 노출해 같은 화면의 여러 form이 서로 다른 token을 갖도록 했습니다.
  - 역 구조도 외 도메인은 command token으로 중복 제출을 막고, version 필드가 존재하는 역 구조도 상태 변경에는 optimistic lock 검증을 적용했습니다.

## 리스크

- command token은 세션 저장소 기반이므로 브라우저 세션을 공유하는 여러 탭에서는 각 form이 렌더링 당시 받은 token만 1회 사용할 수 있습니다. 정상적인 독립 form 제출은 form별 token으로 허용하고, 동일 token 재전송만 409로 차단합니다.
- 이번 PR은 역 구조도 상태 변경의 version 충돌 차단까지 포함합니다. 계정·권한·메뉴 등 아직 version 필드가 없는 다른 관리자 도메인의 세부 optimistic locking 확대는 별도 작업으로 분리해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
