### PR TITLE
[Fix] 신고 사진 report-bound 조회 endpoint 도입

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java
@@ -3,6 +3,7 @@ package com.easysubway.admin.authorization;
 public enum AdminPermission {
 	ADMIN_VIEW("admin.view"),
 	REPORT_REVIEW("admin.report.review"),
+	REPORT_PHOTO_READ("admin.report.photo.read"),
 	MASTER_EDIT("admin.master.edit"),
 	FIELD_OPERATE("admin.field.operate"),
 	DATA_OPERATE("admin.data.operate"),

--- a/backend/src/main/java/com/easysubway/admin/authorization/AdminRbacRole.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/AdminRbacRole.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 public enum AdminRbacRole {
 	ADMIN_VIEWER(AdminPermission.ADMIN_VIEW),
-	REPORT_REVIEWER(AdminPermission.ADMIN_VIEW, AdminPermission.REPORT_REVIEW),
+	REPORT_REVIEWER(AdminPermission.ADMIN_VIEW, AdminPermission.REPORT_REVIEW, AdminPermission.REPORT_PHOTO_READ),
 	MASTER_EDITOR(AdminPermission.ADMIN_VIEW, AdminPermission.MASTER_EDIT),
 	FIELD_OPERATOR(AdminPermission.ADMIN_VIEW, AdminPermission.FIELD_OPERATE),
 	DATA_OPERATOR(

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -69,6 +69,12 @@ public class SecurityConfig {
 				.requestMatchers("/admin/error/page").permitAll()
 				.requestMatchers(HttpMethod.POST, "/admin/reports/**")
 				.hasAuthority(AdminPermission.REPORT_REVIEW.authority())
+				.requestMatchers(
+					HttpMethod.GET,
+					"/admin/reports/*/photo/thumbnail",
+					"/admin/reports/*/photo/original"
+				)
+				.hasAuthority(AdminPermission.REPORT_PHOTO_READ.authority())
 				.requestMatchers(HttpMethod.GET, "/admin/reports/**")
 				.hasAuthority(AdminPermission.REPORT_REVIEW.authority())
 				.requestMatchers(

--- a/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageController.java
@@ -28,6 +28,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import org.springframework.http.CacheControl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.MediaType;
@@ -185,23 +187,50 @@ class FacilityReportAdminPageController {
 		model.addAttribute("reviewForm", submittedForm == null ? new ReviewReportForm(null, "") : submittedForm);
 	}
 
-	@GetMapping("/admin/reports/photos")
-	ResponseEntity<byte[]> reportPhoto(
-		@RequestParam String objectKey,
+	@GetMapping("/admin/reports/{reportId}/photo/thumbnail")
+	@PreAuthorize("hasAuthority('admin.report.photo.read')")
+	ResponseEntity<byte[]> reportPhotoThumbnail(
+		@PathVariable String reportId,
 		Authentication authentication,
 		HttpServletRequest request
 	) {
-		return loadFacilityReportPhotoPort.loadFacilityReportPhoto(objectKey)
+		return reportPhoto(reportId, FacilityReport::photoThumbnailObjectKey, "VIEW_REPORT_PHOTO_THUMBNAIL", "업무 맥락: 신고 사진 미리보기 조회", authentication, request);
+	}
+
+	@GetMapping("/admin/reports/{reportId}/photo/original")
+	@PreAuthorize("hasAuthority('admin.report.photo.read')")
+	ResponseEntity<byte[]> reportPhotoOriginal(
+		@PathVariable String reportId,
+		Authentication authentication,
+		HttpServletRequest request
+	) {
+		return reportPhoto(reportId, FacilityReport::photoObjectKey, "VIEW_REPORT_PHOTO_ORIGINAL", "업무 맥락: 신고 원본 사진 조회", authentication, request);
+	}
+
+	private ResponseEntity<byte[]> reportPhoto(
+		String reportId,
+		Function<FacilityReport, String> objectKey,
+		String action,
+		String reason,
+		Authentication authentication,
+		HttpServletRequest request
+	) {
+		String key = objectKey.apply(facilityReportUseCase.getReport(reportId));
+		if (!hasText(key)) {
+			return ResponseEntity.notFound().build();
+		}
+		return loadFacilityReportPhotoPort.loadFacilityReportPhoto(key)
 			.map(photo -> {
 				auditWriter.privacyRead(
 					authentication,
 					request,
 					"FACILITY_REPORT_PHOTO",
-					auditWriter.sha256TargetId(objectKey),
-					"VIEW_REPORT_PHOTO",
-					"업무 맥락: 신고 사진 조회"
+					reportId,
+					action,
+					reason
 				);
 				return ResponseEntity.ok()
+					.cacheControl(CacheControl.noStore().cachePrivate())
 					.contentType(MediaType.parseMediaType(photo.contentType()))
 					.body(photo.bytes());
 			})
@@ -366,10 +395,6 @@ class FacilityReportAdminPageController {
 			return FacilityReportAdminPageController.hasText(photoFileName)
 				&& FacilityReportAdminPageController.hasText(photoContentType)
 				&& FacilityReportAdminPageController.hasText(photoObjectKey);
-		}
-
-		public String photoPreviewPath() {
-			return hasPhoto() ? "/admin/reports/photos/" + photoObjectKey : null;
 		}
 	}
 

--- a/backend/src/main/resources/db/migration/h2/V15__admin_report_photo_read_permission.sql
+++ b/backend/src/main/resources/db/migration/h2/V15__admin_report_photo_read_permission.sql
@@ -1,0 +1,10 @@
+ALTER TABLE admin_role_permissions DROP CONSTRAINT ck_h2_admin_role_permissions_permission;
+
+ALTER TABLE admin_role_permissions ADD CONSTRAINT ck_h2_admin_role_permissions_permission
+    CHECK (permission_code IN ('admin.view', 'admin.report.review', 'admin.report.photo.read', 'admin.master.edit', 'admin.field.operate', 'admin.data.operate', 'admin.security.audit', 'admin.security.admin', 'admin.audit.read', 'admin.privacy-log.read', 'admin.batch.retry', 'admin.operations.manage'));
+
+MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
+KEY (role_code, permission_code)
+VALUES
+    ('REPORT_REVIEWER', 'admin.report.photo.read', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.report.photo.read', CURRENT_TIMESTAMP);

--- a/backend/src/main/resources/db/migration/postgresql/V15__admin_report_photo_read_permission.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V15__admin_report_photo_read_permission.sql
@@ -1,0 +1,10 @@
+ALTER TABLE admin_role_permissions DROP CONSTRAINT admin_role_permissions_permission_code_check;
+
+ALTER TABLE admin_role_permissions ADD CONSTRAINT admin_role_permissions_permission_code_check
+    CHECK (permission_code IN ('admin.view', 'admin.report.review', 'admin.report.photo.read', 'admin.master.edit', 'admin.field.operate', 'admin.data.operate', 'admin.security.audit', 'admin.security.admin', 'admin.audit.read', 'admin.privacy-log.read', 'admin.batch.retry', 'admin.operations.manage'));
+
+INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
+VALUES
+    ('REPORT_REVIEWER', 'admin.report.photo.read', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.report.photo.read', CURRENT_TIMESTAMP)
+ON CONFLICT (role_code, permission_code) DO NOTHING;

--- a/backend/src/main/resources/templates/admin/reports/detail.html
+++ b/backend/src/main/resources/templates/admin/reports/detail.html
@@ -154,14 +154,12 @@
 		<dl>
 			<dt>파일명</dt>
 			<dd th:text="${report.hasPhoto() ? report.photoFileName : '없음'}">없음</dd>
-			<dt>객체 키</dt>
-			<dd th:text="${report.hasPhoto() ? report.photoObjectKey : '없음'}">없음</dd>
 			<dt>미리보기</dt>
 			<dd>
 				<span th:if="${!report.hasPhoto()}">없음</span>
 				<img th:if="${report.hasPhoto()}"
 				     class="photo-preview"
-				     th:src="@{/admin/reports/photos(objectKey=${report.photoObjectKey})}"
+				     th:src="@{/admin/reports/{reportId}/photo/thumbnail(reportId=${report.id})}"
 				     alt="첨부 사진">
 			</dd>
 		</dl>

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -177,8 +177,9 @@ class FacilityReportAdminPageControllerTest {
 			.contains("신고 상세")
 			.contains("상세에서 확인할 신고")
 			.contains("elevator-notice.png")
-			.contains("객체 키")
-			.contains("/admin/reports/photos?objectKey=facility-reports/")
+			.contains("/admin/reports/%s/photo/thumbnail".formatted(reportId))
+			.doesNotContain("객체 키")
+			.doesNotContain("facility-reports/")
 			.contains("37.302421")
 			.contains("126.866221")
 			.contains("name=\"decision\" value=\"ACCEPT\"")
@@ -193,6 +194,42 @@ class FacilityReportAdminPageControllerTest {
 				assertThat(event.action()).isEqualTo("VIEW_REPORT_DETAIL");
 				assertThat(event.reason()).contains("신고 상세 조회");
 			});
+	}
+
+	@Test
+	@DisplayName("관리자는 신고 번호 기준 endpoint로 신고 사진 thumbnail과 원본을 조회한다")
+	void adminReportPhotoEndpointsLoadReportBoundPhotoAndWritePrivacyAudit() throws Exception {
+		String reportId = createReportWithPhotoAndLocation("사진 endpoint로 확인할 신고");
+
+		mockMvc.perform(get("/admin/reports/{reportId}/photo/thumbnail", reportId)
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(header().string("Cache-Control", "no-store, private"))
+			.andExpect(header().string("Content-Type", "image/png"));
+
+		mockMvc.perform(get("/admin/reports/{reportId}/photo/original", reportId)
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(header().string("Cache-Control", "no-store, private"))
+			.andExpect(header().string("Content-Type", "image/png"));
+
+		assertThat(auditEventRepository.findRecent(AdminAuditEventType.PRIVACY_READ, 2))
+			.extracting(event -> event.action() + ":" + event.targetType() + ":" + event.targetId() + ":" + event.reason())
+			.containsExactly(
+				"VIEW_REPORT_PHOTO_ORIGINAL:FACILITY_REPORT_PHOTO:" + reportId + ":업무 맥락: 신고 원본 사진 조회",
+				"VIEW_REPORT_PHOTO_THUMBNAIL:FACILITY_REPORT_PHOTO:" + reportId + ":업무 맥락: 신고 사진 미리보기 조회"
+			);
+	}
+
+	@Test
+	@DisplayName("관리자 신고 사진 조회는 object key query endpoint를 열지 않는다")
+	void adminReportPhotoQueryEndpointIsNotExposed() throws Exception {
+		createReportWithPhotoAndLocation("object key 조회를 막을 신고");
+
+		mockMvc.perform(get("/admin/reports/photos")
+				.param("objectKey", "facility-reports/other-report/original.png")
+				.with(httpBasic("admin-test", "admin-test-password")))
+			.andExpect(status().isNotFound());
 	}
 
 	@Test
@@ -371,6 +408,10 @@ class FacilityReportAdminPageControllerTest {
 			.andExpect(status().isUnauthorized());
 
 		mockMvc.perform(get("/admin/reports/{reportId}/page", reportId)
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/admin/reports/{reportId}/photo/thumbnail", reportId)
 				.with(httpBasic("basic-user", "user-test-password")))
 			.andExpect(status().isForbidden());
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3937,7 +3937,8 @@ test("백엔드 시설 신고는 헥사고날 API 경계를 따른다", () => {
   assert.match(adminPageController, /ReportProcessingTimeSummary/);
   assert.match(adminReportListTemplate, /신고 급증/);
   assert.doesNotMatch(adminReportDetailTemplate, /data:\s*'\s*\+|photoDataBase64/);
-  assert.match(adminReportDetailTemplate, /photoObjectKey/);
+  assert.doesNotMatch(adminReportDetailTemplate, /photoObjectKey|objectKey/);
+  assert.match(adminReportDetailTemplate, /\/admin\/reports\/\{reportId\}\/photo\/thumbnail/);
   assert.match(adminReportListTemplate, /최근 24시간 신고/);
   assert.match(adminReportListTemplate, /신고 처리 시간/);
   assert.match(adminReportListTemplate, /처리 완료 신고 없음/);
@@ -6158,12 +6159,14 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
     read("backend/src/main/resources/db/migration/postgresql/V11__admin_audit_events.sql"),
     read("backend/src/main/resources/db/migration/postgresql/V12__admin_batch_operation_permission.sql"),
     read("backend/src/main/resources/db/migration/postgresql/V13__admin_common_code_incident.sql"),
+    read("backend/src/main/resources/db/migration/postgresql/V15__admin_report_photo_read_permission.sql"),
   ].join("\n");
   const adminRbacH2Schema = [
     read("backend/src/main/resources/db/migration/h2/V10__admin_rbac_menu.sql"),
     read("backend/src/main/resources/db/migration/h2/V11__admin_audit_events.sql"),
     read("backend/src/main/resources/db/migration/h2/V12__admin_batch_operation_permission.sql"),
     read("backend/src/main/resources/db/migration/h2/V13__admin_common_code_incident.sql"),
+    read("backend/src/main/resources/db/migration/h2/V15__admin_report_photo_read_permission.sql"),
   ].join("\n");
   const adminProgramRegistry = read("backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java");
   const adminPermission = read("backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java");
@@ -6286,6 +6289,7 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.match(securityConfig, /securityMatcher\("\/admin\/\*\*"\)/);
   assert.match(securityConfig, /hasAuthority\(AdminPermission\.ADMIN_VIEW\.authority\(\)\)/);
   assert.match(securityConfig, /hasAuthority\(AdminPermission\.REPORT_REVIEW\.authority\(\)\)/);
+  assert.match(securityConfig, /hasAuthority\(AdminPermission\.REPORT_PHOTO_READ\.authority\(\)\)/);
   assert.match(securityConfig, /hasAuthority\(AdminPermission\.DATA_OPERATE\.authority\(\)\)/);
   assert.match(securityConfig, /"\/admin\/notifications\/\*\*"/);
   assert.match(securityConfig, /hasRole\("OPERATOR_ADMIN"\)/);
@@ -6360,6 +6364,7 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
   assert.deepEqual(adminPermissionCodes, [
     "admin.view",
     "admin.report.review",
+    "admin.report.photo.read",
     "admin.master.edit",
     "admin.field.operate",
     "admin.data.operate",


### PR DESCRIPTION
## 관련 이슈

close #962

## 작업 배경

관리자 신고 상세 화면은 사진 미리보기에서 object key query parameter를 사용했고, 화면에도 원본 object key를 표시했습니다. 신고 사진은 위치와 현장 맥락을 포함할 수 있어 report id, 권한, 개인정보 조회 감사 목적과 묶인 조회 경계가 필요합니다.

## 작업 내용

- `GET /admin/reports/{reportId}/photo/thumbnail`, `GET /admin/reports/{reportId}/photo/original` endpoint를 추가했습니다.
- 기존 `/admin/reports/photos?objectKey=...` 조회 endpoint는 노출하지 않도록 제거했습니다.
- 사진 조회는 report id로 신고를 먼저 조회한 뒤 report에 저장된 thumbnail/original object key만 서버 내부에서 사용합니다.
- `REPORT_PHOTO_READ` 권한을 추가하고 `REPORT_REVIEWER`, `SUPER_ADMIN` seed에 부여하는 V15 migration을 추가했습니다.
- 사진 응답에 `Cache-Control: no-store, private`를 고정했습니다.
- thumbnail/original 조회마다 `PRIVACY_READ` audit을 report id 기준으로 남기고, 원본 조회는 `VIEW_REPORT_PHOTO_ORIGINAL`로 구분했습니다.
- 관리자 신고 상세 HTML에서 object key 표시와 objectKey query URL을 제거했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests 'com.easysubway.report.adapter.in.web.FacilityReportAdminPageControllerTest'`: exit 0
  - `cd backend && ./gradlew test --tests '*FacilityReportAdmin*' --tests '*Audit*'`: exit 0
  - `cd backend && ./gradlew test --tests 'com.easysubway.common.persistence.DatabaseMigrationContainerTest' --tests 'com.easysubway.report.adapter.in.web.FacilityReportAdminPageControllerTest'`: exit 0
  - `cd backend && ./gradlew test`: exit 0
  - `node --test tools/ci/*.test.mjs`: exit 0, 116 tests passed
  - `git diff --check`: exit 0
  - GitHub PR checks: Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan, Android Release Artifact, Backend Release Image, RC Evidence Manifest, SonarCloud Code Analysis 모두 pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| report-bound thumbnail/original | backend MVC | report id endpoint로 thumbnail/original 조회 | `FacilityReportAdminPageControllerTest.adminReportPhotoEndpointsLoadReportBoundPhotoAndWritePrivacyAudit` | 두 endpoint 모두 연결된 report 사진만 반환 |
| objectKey query 차단 | backend MVC | 기존 objectKey query endpoint 호출 | `FacilityReportAdminPageControllerTest.adminReportPhotoQueryEndpointIsNotExposed` | `/admin/reports/photos?objectKey=...`는 404 |
| 권한 | backend security | 일반 사용자로 thumbnail 조회 | `FacilityReportAdminPageControllerTest.adminReportPagesRequireAdminAuthentication` | 무권한 사용자는 403 |
| privacy audit | backend audit | thumbnail/original 조회 후 audit event 확인 | `FacilityReportAdminPageControllerTest.adminReportPhotoEndpointsLoadReportBoundPhotoAndWritePrivacyAudit` | thumbnail/original 목적이 분리되어 기록됨 |
| redaction | backend/admin HTML | 신고 상세 HTML 검사 | `FacilityReportAdminPageControllerTest.adminReportDetailPageShowsPhotoLocationAndReviewActions` | object key와 내부 storage 경로 미노출 |
| migration | PostgreSQL/H2 | clean schema migration 실행 | `DatabaseMigrationContainerTest`, `./gradlew test` | V15 권한 constraint와 seed 적용 |
| Android evidence | Android | backend admin 사진 조회 경계 변경 | 증거 불필요 사유: 모바일 앱 런타임/화면 변경 없음 | backend MVC/security/audit 검증으로 대체 |

## 리뷰어 메모

- 새 사진 조회 endpoint는 별도 storage abstraction을 만들지 않고 기존 `LoadFacilityReportPhotoPort`를 재사용합니다.
- audit target id는 object key hash가 아니라 report id입니다. 감사 화면에서 실제 업무 대상 신고를 바로 추적하기 위함입니다.
- 기존 object key query endpoint는 호환 유지하지 않았습니다. 현재 template 사용처를 report-bound URL로 교체했고 외부 공개 API가 아니기 때문입니다.

## 리스크

- 기존 관리자 화면을 직접 bookmark한 `/admin/reports/photos?objectKey=...` URL은 더 이상 동작하지 않습니다.
- `REPORT_REVIEWER`에는 사진 조회 권한이 함께 부여됩니다. 신고 검수자가 사진을 확인해야 하는 현재 운영 흐름을 반영했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.

CD 확인 메모: PR 단계에서는 Release Artifacts와 RC Evidence Manifest가 통과했습니다. merge 후 main CD run 생성 및 실패 신호를 별도로 확인합니다.
