### PR TITLE
[Chore] 관리자 플랫폼 전환과 legacy 계정 제거 계획 수립

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/transition/AdminPlatformTransitionConfiguration.java
+++ b/backend/src/main/java/com/easysubway/admin/transition/AdminPlatformTransitionConfiguration.java
@@ -1,0 +1,9 @@
+package com.easysubway.admin.transition;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(AdminPlatformTransitionProperties.class)
+class AdminPlatformTransitionConfiguration {
+}

--- a/backend/src/main/java/com/easysubway/admin/transition/AdminPlatformTransitionProperties.java
+++ b/backend/src/main/java/com/easysubway/admin/transition/AdminPlatformTransitionProperties.java
@@ -19,11 +19,11 @@ public record AdminPlatformTransitionProperties(
 	public AdminPlatformTransitionProperties {
 		stage = stage == null ? Stage.SHADOW : stage;
 		flags = flags == null ? Flags.defaults() : flags;
-		rbacShadow = rbacShadow == null ? ShadowMode.rbacDefaults() : rbacShadow;
-		auditShadow = auditShadow == null ? ShadowMode.auditDefaults() : auditShadow;
+		rbacShadow = rbacShadow == null ? ShadowMode.rbacDefaults() : rbacShadow.withDefaults(ShadowMode.rbacDefaults());
+		auditShadow = auditShadow == null ? ShadowMode.auditDefaults() : auditShadow.withDefaults(ShadowMode.auditDefaults());
 		legacyEnvAdminFallback = legacyEnvAdminFallback == null
 			? LegacyEnvAdminFallback.defaults()
-			: legacyEnvAdminFallback;
+			: legacyEnvAdminFallback.withDefaults(LegacyEnvAdminFallback.defaults());
 		breakGlass = breakGlass == null ? BreakGlass.defaults() : breakGlass;
 		seed = seed == null ? Seed.defaults() : seed;
 		rollback = rollback == null ? Rollback.defaults() : rollback;
@@ -42,18 +42,29 @@ public record AdminPlatformTransitionProperties(
 	}
 
 	public record Flags(
-		boolean identityStore,
-		boolean rbacShadow,
-		boolean rbacEnforcement,
-		boolean auditShadow,
-		boolean auditEnforcement,
-		boolean legacyEnvAdminFallback,
-		boolean breakGlassBootstrap,
-		boolean roleSeedRequired
+		Boolean identityStore,
+		Boolean rbacShadow,
+		Boolean rbacEnforcement,
+		Boolean auditShadow,
+		Boolean auditEnforcement,
+		Boolean legacyEnvAdminFallback,
+		Boolean breakGlassBootstrap,
+		Boolean roleSeedRequired
 	) {
 
+		public Flags {
+			identityStore = identityStore == null ? true : identityStore;
+			rbacShadow = rbacShadow == null ? true : rbacShadow;
+			rbacEnforcement = rbacEnforcement == null ? false : rbacEnforcement;
+			auditShadow = auditShadow == null ? true : auditShadow;
+			auditEnforcement = auditEnforcement == null ? false : auditEnforcement;
+			legacyEnvAdminFallback = legacyEnvAdminFallback == null ? true : legacyEnvAdminFallback;
+			breakGlassBootstrap = breakGlassBootstrap == null ? true : breakGlassBootstrap;
+			roleSeedRequired = roleSeedRequired == null ? true : roleSeedRequired;
+		}
+
 		static Flags defaults() {
-			return new Flags(true, true, false, true, false, true, true, true);
+			return new Flags(null, null, null, null, null, null, null, null);
 		}
 	}
 
@@ -62,6 +73,14 @@ public record AdminPlatformTransitionProperties(
 		String metric,
 		List<String> promotionCriteria
 	) {
+
+		ShadowMode withDefaults(ShadowMode defaults) {
+			return new ShadowMode(
+				mode == null ? defaults.mode() : mode,
+				metric == null ? defaults.metric() : metric,
+				promotionCriteria == null ? defaults.promotionCriteria() : promotionCriteria
+			);
+		}
 
 		static ShadowMode rbacDefaults() {
 			return new ShadowMode(
@@ -93,6 +112,13 @@ public record AdminPlatformTransitionProperties(
 		String rollbackAction
 	) {
 
+		LegacyEnvAdminFallback withDefaults(LegacyEnvAdminFallback defaults) {
+			return new LegacyEnvAdminFallback(
+				removalCriteria == null ? defaults.removalCriteria() : removalCriteria,
+				rollbackAction == null ? defaults.rollbackAction() : rollbackAction
+			);
+		}
+
 		static LegacyEnvAdminFallback defaults() {
 			return new LegacyEnvAdminFallback(
 				List.of(
@@ -110,11 +136,17 @@ public record AdminPlatformTransitionProperties(
 		String rotationProcedure
 	) {
 
+		public BreakGlass {
+			issueProcedure = issueProcedure == null
+				? "create short-lived EASYSUBWAY_ADMIN_BREAK_GLASS_USERNAME, PASSWORD, and REASON secrets for the incident owner"
+				: issueProcedure;
+			rotationProcedure = rotationProcedure == null
+				? "rotate password and reason immediately after first successful login because the identity enters CREDENTIAL_ROTATION_REQUIRED"
+				: rotationProcedure;
+		}
+
 		static BreakGlass defaults() {
-			return new BreakGlass(
-				"create short-lived EASYSUBWAY_ADMIN_BREAK_GLASS_USERNAME, PASSWORD, and REASON secrets for the incident owner",
-				"rotate password and reason immediately after first successful login because the identity enters CREDENTIAL_ROTATION_REQUIRED"
-			);
+			return new BreakGlass(null, null);
 		}
 	}
 
@@ -123,20 +155,30 @@ public record AdminPlatformTransitionProperties(
 		String accountProcedure
 	) {
 
+		public Seed {
+			roleProcedure = roleProcedure == null
+				? "migrate admin_role_permissions first, then assign admin_user_roles before RBAC enforcement"
+				: roleProcedure;
+			accountProcedure = accountProcedure == null
+				? "bootstrap env admin and operator accounts until persistent admin_users seed is verified"
+				: accountProcedure;
+		}
+
 		static Seed defaults() {
-			return new Seed(
-				"migrate admin_role_permissions first, then assign admin_user_roles before RBAC enforcement",
-				"bootstrap env admin and operator accounts until persistent admin_users seed is verified"
-			);
+			return new Seed(null, null);
 		}
 	}
 
 	public record Rollback(String runbook) {
 
+		public Rollback {
+			runbook = runbook == null
+				? "disable rbac-enforcement and audit-enforcement, keep shadow logging, restore legacy env admin fallback, and redeploy the previous artifact"
+				: runbook;
+		}
+
 		static Rollback defaults() {
-			return new Rollback(
-				"disable rbac-enforcement and audit-enforcement, keep shadow logging, restore legacy env admin fallback, and redeploy the previous artifact"
-			);
+			return new Rollback(null);
 		}
 	}
 
@@ -145,17 +187,21 @@ public record AdminPlatformTransitionProperties(
 		List<String> blockers
 	) {
 
-		static ReleaseGate defaults() {
-			return new ReleaseGate(
-				BlockerMode.WARN,
-				List.of(
+		public ReleaseGate {
+			blockerMode = blockerMode == null ? BlockerMode.WARN : blockerMode;
+			blockers = blockers == null
+				? List.of(
 					"RBAC shadow denials are untriaged",
 					"audit shadow misses privileged admin action",
 					"legacy env admin fallback removal criteria are incomplete",
 					"break-glass credential rotation is overdue",
 					"role or account seed is missing in prod"
 				)
-			);
+				: blockers;
+		}
+
+		static ReleaseGate defaults() {
+			return new ReleaseGate(null, null);
 		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/admin/transition/AdminPlatformTransitionProperties.java
+++ b/backend/src/main/java/com/easysubway/admin/transition/AdminPlatformTransitionProperties.java
@@ -1,0 +1,161 @@
+package com.easysubway.admin.transition;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "easysubway.admin.platform-transition")
+public record AdminPlatformTransitionProperties(
+	Stage stage,
+	Flags flags,
+	ShadowMode rbacShadow,
+	ShadowMode auditShadow,
+	LegacyEnvAdminFallback legacyEnvAdminFallback,
+	BreakGlass breakGlass,
+	Seed seed,
+	Rollback rollback,
+	ReleaseGate releaseGate
+) {
+
+	public AdminPlatformTransitionProperties {
+		stage = stage == null ? Stage.SHADOW : stage;
+		flags = flags == null ? Flags.defaults() : flags;
+		rbacShadow = rbacShadow == null ? ShadowMode.rbacDefaults() : rbacShadow;
+		auditShadow = auditShadow == null ? ShadowMode.auditDefaults() : auditShadow;
+		legacyEnvAdminFallback = legacyEnvAdminFallback == null
+			? LegacyEnvAdminFallback.defaults()
+			: legacyEnvAdminFallback;
+		breakGlass = breakGlass == null ? BreakGlass.defaults() : breakGlass;
+		seed = seed == null ? Seed.defaults() : seed;
+		rollback = rollback == null ? Rollback.defaults() : rollback;
+		releaseGate = releaseGate == null ? ReleaseGate.defaults() : releaseGate;
+	}
+
+	public enum Stage {
+		SHADOW,
+		ENFORCE,
+		LEGACY_DISABLED
+	}
+
+	public enum BlockerMode {
+		WARN,
+		FAIL
+	}
+
+	public record Flags(
+		boolean identityStore,
+		boolean rbacShadow,
+		boolean rbacEnforcement,
+		boolean auditShadow,
+		boolean auditEnforcement,
+		boolean legacyEnvAdminFallback,
+		boolean breakGlassBootstrap,
+		boolean roleSeedRequired
+	) {
+
+		static Flags defaults() {
+			return new Flags(true, true, false, true, false, true, true, true);
+		}
+	}
+
+	public record ShadowMode(
+		String mode,
+		String metric,
+		List<String> promotionCriteria
+	) {
+
+		static ShadowMode rbacDefaults() {
+			return new ShadowMode(
+				"compare-and-log",
+				"admin_rbac_shadow_denial_total",
+				List.of(
+					"admin_role_permissions seed includes every AdminPermission",
+					"admin_user_roles seed covers each production administrator",
+					"shadow denial metric is zero for one release cycle"
+				)
+			);
+		}
+
+		static ShadowMode auditDefaults() {
+			return new ShadowMode(
+				"write-and-compare",
+				"admin_audit_shadow_missing_total",
+				List.of(
+					"admin_audit_events records login and privileged admin actions",
+					"privacy reads and break-glass use include actor, permission, request id",
+					"missing audit metric is zero for one release cycle"
+				)
+			);
+		}
+	}
+
+	public record LegacyEnvAdminFallback(
+		List<String> removalCriteria,
+		String rollbackAction
+	) {
+
+		static LegacyEnvAdminFallback defaults() {
+			return new LegacyEnvAdminFallback(
+				List.of(
+					"all production admins have admin_users rows with role seed",
+					"break-glass bootstrap account was rotated after first use",
+					"rollback has been tested with the previous env admin secret"
+				),
+				"restore EASYSUBWAY_ADMIN_USERNAME and EASYSUBWAY_ADMIN_PASSWORD, keep RBAC enforcement disabled, and redeploy previous release"
+			);
+		}
+	}
+
+	public record BreakGlass(
+		String issueProcedure,
+		String rotationProcedure
+	) {
+
+		static BreakGlass defaults() {
+			return new BreakGlass(
+				"create short-lived EASYSUBWAY_ADMIN_BREAK_GLASS_USERNAME, PASSWORD, and REASON secrets for the incident owner",
+				"rotate password and reason immediately after first successful login because the identity enters CREDENTIAL_ROTATION_REQUIRED"
+			);
+		}
+	}
+
+	public record Seed(
+		String roleProcedure,
+		String accountProcedure
+	) {
+
+		static Seed defaults() {
+			return new Seed(
+				"migrate admin_role_permissions first, then assign admin_user_roles before RBAC enforcement",
+				"bootstrap env admin and operator accounts until persistent admin_users seed is verified"
+			);
+		}
+	}
+
+	public record Rollback(String runbook) {
+
+		static Rollback defaults() {
+			return new Rollback(
+				"disable rbac-enforcement and audit-enforcement, keep shadow logging, restore legacy env admin fallback, and redeploy the previous artifact"
+			);
+		}
+	}
+
+	public record ReleaseGate(
+		BlockerMode blockerMode,
+		List<String> blockers
+	) {
+
+		static ReleaseGate defaults() {
+			return new ReleaseGate(
+				BlockerMode.WARN,
+				List.of(
+					"RBAC shadow denials are untriaged",
+					"audit shadow misses privileged admin action",
+					"legacy env admin fallback removal criteria are incomplete",
+					"break-glass credential rotation is overdue",
+					"role or account seed is missing in prod"
+				)
+			);
+		}
+	}
+}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -54,6 +54,10 @@ easysubway:
   admin:
     username: ${EASYSUBWAY_ADMIN_USERNAME}
     password: ${EASYSUBWAY_ADMIN_PASSWORD}
+    platform-transition:
+      stage: ${EASYSUBWAY_ADMIN_PLATFORM_TRANSITION_STAGE:shadow}
+      release-gate:
+        blocker-mode: ${EASYSUBWAY_ADMIN_PLATFORM_RELEASE_BLOCKER_MODE:fail}
     break-glass:
       username: ${EASYSUBWAY_ADMIN_BREAK_GLASS_USERNAME:}
       password: ${EASYSUBWAY_ADMIN_BREAK_GLASS_PASSWORD:}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,6 +25,54 @@ management:
         order: "down,out-of-service,degraded,stale,up,unknown"
 
 easysubway:
+  admin:
+    platform-transition:
+      stage: ${EASYSUBWAY_ADMIN_PLATFORM_TRANSITION_STAGE:shadow}
+      flags:
+        identity-store: ${EASYSUBWAY_ADMIN_IDENTITY_STORE_ENABLED:true}
+        rbac-shadow: ${EASYSUBWAY_ADMIN_RBAC_SHADOW_ENABLED:true}
+        rbac-enforcement: ${EASYSUBWAY_ADMIN_RBAC_ENFORCEMENT_ENABLED:false}
+        audit-shadow: ${EASYSUBWAY_ADMIN_AUDIT_SHADOW_ENABLED:true}
+        audit-enforcement: ${EASYSUBWAY_ADMIN_AUDIT_ENFORCEMENT_ENABLED:false}
+        legacy-env-admin-fallback: ${EASYSUBWAY_ADMIN_LEGACY_ENV_FALLBACK_ENABLED:true}
+        break-glass-bootstrap: ${EASYSUBWAY_ADMIN_BREAK_GLASS_BOOTSTRAP_ENABLED:true}
+        role-seed-required: ${EASYSUBWAY_ADMIN_ROLE_SEED_REQUIRED:true}
+      rbac-shadow:
+        mode: compare-and-log
+        metric: admin_rbac_shadow_denial_total
+        promotion-criteria:
+          - admin_role_permissions seed includes every AdminPermission
+          - admin_user_roles seed covers each production administrator
+          - shadow denial metric is zero for one release cycle
+      audit-shadow:
+        mode: write-and-compare
+        metric: admin_audit_shadow_missing_total
+        promotion-criteria:
+          - admin_audit_events records login and privileged admin actions
+          - privacy reads and break-glass use include actor, permission, request id
+          - missing audit metric is zero for one release cycle
+      legacy-env-admin-fallback:
+        removal-criteria:
+          - all production admins have admin_users rows with role seed
+          - break-glass bootstrap account was rotated after first use
+          - rollback has been tested with the previous env admin secret
+        rollback-action: restore EASYSUBWAY_ADMIN_USERNAME and EASYSUBWAY_ADMIN_PASSWORD, keep RBAC enforcement disabled, and redeploy previous release
+      break-glass:
+        issue-procedure: create short-lived EASYSUBWAY_ADMIN_BREAK_GLASS_USERNAME, PASSWORD, and REASON secrets for the incident owner
+        rotation-procedure: rotate password and reason immediately after first successful login because the identity enters CREDENTIAL_ROTATION_REQUIRED
+      seed:
+        role-procedure: migrate admin_role_permissions first, then assign admin_user_roles before RBAC enforcement
+        account-procedure: bootstrap env admin and operator accounts until persistent admin_users seed is verified
+      rollback:
+        runbook: disable rbac-enforcement and audit-enforcement, keep shadow logging, restore legacy env admin fallback, and redeploy the previous artifact
+      release-gate:
+        blocker-mode: warn
+        blockers:
+          - RBAC shadow denials are untriaged
+          - audit shadow misses privileged admin action
+          - legacy env admin fallback removal criteria are incomplete
+          - break-glass credential rotation is overdue
+          - role or account seed is missing in prod
   notifications:
     push:
       delivery:

--- a/backend/src/test/java/com/easysubway/admin/transition/AdminPlatformTransitionPropertiesTest.java
+++ b/backend/src/test/java/com/easysubway/admin/transition/AdminPlatformTransitionPropertiesTest.java
@@ -1,0 +1,76 @@
+package com.easysubway.admin.transition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+@DisplayName("관리자 플랫폼 전환 설정")
+class AdminPlatformTransitionPropertiesTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withConfiguration(AutoConfigurations.of(ConfigurationPropertiesAutoConfiguration.class))
+		.withUserConfiguration(AdminPlatformTransitionConfiguration.class);
+
+	@Test
+	@DisplayName("기본값은 shadow 검증과 legacy env admin fallback 유지로 둔다")
+	void defaultsKeepShadowModeAndLegacyFallback() {
+		contextRunner.run(context -> {
+			AdminPlatformTransitionProperties properties =
+				context.getBean(AdminPlatformTransitionProperties.class);
+
+			assertThat(properties.stage()).isEqualTo(AdminPlatformTransitionProperties.Stage.SHADOW);
+			assertThat(properties.flags().identityStore()).isTrue();
+			assertThat(properties.flags().rbacShadow()).isTrue();
+			assertThat(properties.flags().rbacEnforcement()).isFalse();
+			assertThat(properties.flags().auditShadow()).isTrue();
+			assertThat(properties.flags().auditEnforcement()).isFalse();
+			assertThat(properties.flags().legacyEnvAdminFallback()).isTrue();
+			assertThat(properties.flags().breakGlassBootstrap()).isTrue();
+			assertThat(properties.flags().roleSeedRequired()).isTrue();
+			assertThat(properties.rbacShadow().metric()).isEqualTo("admin_rbac_shadow_denial_total");
+			assertThat(properties.auditShadow().metric()).isEqualTo("admin_audit_shadow_missing_total");
+			assertThat(properties.legacyEnvAdminFallback().removalCriteria())
+				.contains("all production admins have admin_users rows with role seed");
+			assertThat(properties.breakGlass().rotationProcedure())
+				.contains("CREDENTIAL_ROTATION_REQUIRED");
+			assertThat(properties.seed().roleProcedure())
+				.contains("admin_role_permissions");
+			assertThat(properties.seed().accountProcedure())
+				.contains("admin_users seed");
+			assertThat(properties.rollback().runbook())
+				.contains("restore legacy env admin fallback");
+			assertThat(properties.releaseGate().blockerMode())
+				.isEqualTo(AdminPlatformTransitionProperties.BlockerMode.WARN);
+			assertThat(properties.releaseGate().blockers())
+				.contains("role or account seed is missing in prod");
+		});
+	}
+
+	@Test
+	@DisplayName("운영 전환 단계와 enforcement flag는 환경값으로 덮어쓸 수 있다")
+	void transitionStageAndEnforcementFlagsCanBeOverridden() {
+		contextRunner
+			.withPropertyValues(
+				"easysubway.admin.platform-transition.stage=enforce",
+				"easysubway.admin.platform-transition.flags.rbac-enforcement=true",
+				"easysubway.admin.platform-transition.flags.audit-enforcement=true",
+				"easysubway.admin.platform-transition.flags.legacy-env-admin-fallback=false",
+				"easysubway.admin.platform-transition.release-gate.blocker-mode=fail"
+			)
+			.run(context -> {
+				AdminPlatformTransitionProperties properties =
+					context.getBean(AdminPlatformTransitionProperties.class);
+
+				assertThat(properties.stage()).isEqualTo(AdminPlatformTransitionProperties.Stage.ENFORCE);
+				assertThat(properties.flags().rbacEnforcement()).isTrue();
+				assertThat(properties.flags().auditEnforcement()).isTrue();
+				assertThat(properties.flags().legacyEnvAdminFallback()).isFalse();
+				assertThat(properties.releaseGate().blockerMode())
+					.isEqualTo(AdminPlatformTransitionProperties.BlockerMode.FAIL);
+			});
+	}
+}

--- a/backend/src/test/java/com/easysubway/admin/transition/AdminPlatformTransitionPropertiesTest.java
+++ b/backend/src/test/java/com/easysubway/admin/transition/AdminPlatformTransitionPropertiesTest.java
@@ -66,11 +66,16 @@ class AdminPlatformTransitionPropertiesTest {
 					context.getBean(AdminPlatformTransitionProperties.class);
 
 				assertThat(properties.stage()).isEqualTo(AdminPlatformTransitionProperties.Stage.ENFORCE);
+				assertThat(properties.flags().identityStore()).isTrue();
+				assertThat(properties.flags().rbacShadow()).isTrue();
 				assertThat(properties.flags().rbacEnforcement()).isTrue();
+				assertThat(properties.flags().auditShadow()).isTrue();
 				assertThat(properties.flags().auditEnforcement()).isTrue();
 				assertThat(properties.flags().legacyEnvAdminFallback()).isFalse();
 				assertThat(properties.releaseGate().blockerMode())
 					.isEqualTo(AdminPlatformTransitionProperties.BlockerMode.FAIL);
+				assertThat(properties.releaseGate().blockers())
+					.contains("role or account seed is missing in prod");
 			});
 	}
 }

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3346,6 +3346,96 @@ test("백엔드 운영 프로필은 인메모리 bean을 제외하고 임시 mas
   assert.match(applicationProdYml, /external-enabled: \$\{EASYSUBWAY_PUSH_EXTERNAL_ENABLED:false\}/);
 });
 
+test("관리자 플랫폼 전환 계약은 shadow rollout과 legacy fallback 제거 조건을 고정한다", () => {
+  const applicationYml = read("backend/src/main/resources/application.yml");
+  const applicationProdYml = read("backend/src/main/resources/application-prod.yml");
+  const transitionProperties = read(
+    "backend/src/main/java/com/easysubway/admin/transition/AdminPlatformTransitionProperties.java",
+  );
+  const transitionConfiguration = read(
+    "backend/src/main/java/com/easysubway/admin/transition/AdminPlatformTransitionConfiguration.java",
+  );
+  const transitionTest = read(
+    "backend/src/test/java/com/easysubway/admin/transition/AdminPlatformTransitionPropertiesTest.java",
+  );
+  const security = read("backend/src/main/java/com/easysubway/common/security/SecurityConfig.java");
+  const securityTest = read("backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java");
+  const postgresAdminMigrations = [
+    "backend/src/main/resources/db/migration/postgresql/V10__admin_rbac_menu.sql",
+    "backend/src/main/resources/db/migration/postgresql/V11__admin_audit_events.sql",
+    "backend/src/main/resources/db/migration/postgresql/V12__admin_batch_operation_permission.sql",
+    "backend/src/main/resources/db/migration/postgresql/V13__admin_common_code_incident.sql",
+    "backend/src/main/resources/db/migration/postgresql/V15__admin_report_photo_read_permission.sql",
+  ].map(read).join("\n");
+  const h2AdminMigrations = [
+    "backend/src/main/resources/db/migration/h2/V10__admin_rbac_menu.sql",
+    "backend/src/main/resources/db/migration/h2/V11__admin_audit_events.sql",
+    "backend/src/main/resources/db/migration/h2/V12__admin_batch_operation_permission.sql",
+    "backend/src/main/resources/db/migration/h2/V13__admin_common_code_incident.sql",
+    "backend/src/main/resources/db/migration/h2/V15__admin_report_photo_read_permission.sql",
+  ].map(read).join("\n");
+
+  assert.match(applicationYml, /platform-transition:\s*\n\s*stage: \$\{EASYSUBWAY_ADMIN_PLATFORM_TRANSITION_STAGE:shadow\}/);
+  assert.match(applicationYml, /identity-store: \$\{EASYSUBWAY_ADMIN_IDENTITY_STORE_ENABLED:true\}/);
+  assert.match(applicationYml, /rbac-shadow: \$\{EASYSUBWAY_ADMIN_RBAC_SHADOW_ENABLED:true\}/);
+  assert.match(applicationYml, /rbac-enforcement: \$\{EASYSUBWAY_ADMIN_RBAC_ENFORCEMENT_ENABLED:false\}/);
+  assert.match(applicationYml, /audit-shadow: \$\{EASYSUBWAY_ADMIN_AUDIT_SHADOW_ENABLED:true\}/);
+  assert.match(applicationYml, /audit-enforcement: \$\{EASYSUBWAY_ADMIN_AUDIT_ENFORCEMENT_ENABLED:false\}/);
+  assert.match(applicationYml, /legacy-env-admin-fallback: \$\{EASYSUBWAY_ADMIN_LEGACY_ENV_FALLBACK_ENABLED:true\}/);
+  assert.match(applicationYml, /break-glass-bootstrap: \$\{EASYSUBWAY_ADMIN_BREAK_GLASS_BOOTSTRAP_ENABLED:true\}/);
+  assert.match(applicationYml, /role-seed-required: \$\{EASYSUBWAY_ADMIN_ROLE_SEED_REQUIRED:true\}/);
+  assert.match(applicationYml, /admin_rbac_shadow_denial_total/);
+  assert.match(applicationYml, /admin_audit_shadow_missing_total/);
+  assert.match(applicationYml, /all production admins have admin_users rows with role seed/);
+  assert.match(applicationYml, /break-glass bootstrap account was rotated after first use/);
+  assert.match(applicationYml, /restore EASYSUBWAY_ADMIN_USERNAME and EASYSUBWAY_ADMIN_PASSWORD/);
+  assert.match(applicationYml, /CREDENTIAL_ROTATION_REQUIRED/);
+  assert.match(applicationYml, /admin_role_permissions first/);
+  assert.match(applicationYml, /persistent admin_users seed is verified/);
+  assert.match(applicationYml, /disable rbac-enforcement and audit-enforcement/);
+  assert.match(applicationYml, /RBAC shadow denials are untriaged/);
+  assert.match(applicationYml, /role or account seed is missing in prod/);
+  assert.match(applicationProdYml, /blocker-mode: \$\{EASYSUBWAY_ADMIN_PLATFORM_RELEASE_BLOCKER_MODE:fail\}/);
+
+  assert.match(transitionConfiguration, /@EnableConfigurationProperties\(AdminPlatformTransitionProperties\.class\)/);
+  assert.match(transitionProperties, /@ConfigurationProperties\(prefix = "easysubway\.admin\.platform-transition"\)/);
+  assert.match(transitionProperties, /enum Stage[\s\S]*SHADOW,[\s\S]*ENFORCE,[\s\S]*LEGACY_DISABLED/);
+  assert.match(transitionProperties, /enum BlockerMode[\s\S]*WARN,[\s\S]*FAIL/);
+  assert.match(transitionProperties, /new Flags\(true, true, false, true, false, true, true, true\)/);
+  assert.match(transitionProperties, /record LegacyEnvAdminFallback/);
+  assert.match(transitionProperties, /record BreakGlass/);
+  assert.match(transitionProperties, /record Seed/);
+  assert.match(transitionProperties, /record Rollback/);
+  assert.match(transitionProperties, /record ReleaseGate/);
+  assert.match(transitionTest, /defaultsKeepShadowModeAndLegacyFallback/);
+  assert.match(transitionTest, /transitionStageAndEnforcementFlagsCanBeOverridden/);
+
+  assert.match(security, /validateProdAdminCredentials/);
+  assert.match(security, /validateBreakGlassCredentials/);
+  assert.match(security, /disableStaleBootstrapIdentities/);
+  assert.match(securityTest, /prodProfileFailsWhenAdminCredentialsAreMissing/);
+  assert.match(securityTest, /removedBootstrapIdentitiesAreDisabledOnStartup/);
+  assert.match(securityTest, /breakGlassAuthRecordsReasonAndRequiresCredentialRotation/);
+
+  for (const permission of [
+    "admin.view",
+    "admin.report.review",
+    "admin.report.photo.read",
+    "admin.master.edit",
+    "admin.field.operate",
+    "admin.data.operate",
+    "admin.security.audit",
+    "admin.security.admin",
+    "admin.audit.read",
+    "admin.privacy-log.read",
+    "admin.batch.retry",
+    "admin.operations.manage",
+  ]) {
+    assert.match(postgresAdminMigrations, new RegExp(permission.replace(".", "\\.")));
+    assert.match(h2AdminMigrations, new RegExp(permission.replace(".", "\\.")));
+  }
+});
+
 test("백엔드 사용자 데이터 삭제는 헥사고날 API 경계를 따른다", () => {
   const result = read("backend/src/main/java/com/easysubway/user/domain/UserDataDeletionResult.java");
   const invalidDeletion = read("backend/src/main/java/com/easysubway/user/domain/InvalidUserDataDeletionException.java");

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -19,6 +19,10 @@ function readJson(relativePath) {
   return JSON.parse(read(relativePath));
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function ignoredVulnBlocks(osvConfig) {
   return osvConfig.split(/\[\[IgnoredVulns\]\]\n/).slice(1);
 }
@@ -3401,7 +3405,7 @@ test("관리자 플랫폼 전환 계약은 shadow rollout과 legacy fallback 제
   assert.match(transitionProperties, /@ConfigurationProperties\(prefix = "easysubway\.admin\.platform-transition"\)/);
   assert.match(transitionProperties, /enum Stage[\s\S]*SHADOW,[\s\S]*ENFORCE,[\s\S]*LEGACY_DISABLED/);
   assert.match(transitionProperties, /enum BlockerMode[\s\S]*WARN,[\s\S]*FAIL/);
-  assert.match(transitionProperties, /new Flags\(true, true, false, true, false, true, true, true\)/);
+  assert.match(transitionProperties, /new Flags\(null, null, null, null, null, null, null, null\)/);
   assert.match(transitionProperties, /record LegacyEnvAdminFallback/);
   assert.match(transitionProperties, /record BreakGlass/);
   assert.match(transitionProperties, /record Seed/);
@@ -3431,8 +3435,8 @@ test("관리자 플랫폼 전환 계약은 shadow rollout과 legacy fallback 제
     "admin.batch.retry",
     "admin.operations.manage",
   ]) {
-    assert.match(postgresAdminMigrations, new RegExp(permission.replace(".", "\\.")));
-    assert.match(h2AdminMigrations, new RegExp(permission.replace(".", "\\.")));
+    assert.match(postgresAdminMigrations, new RegExp(escapeRegExp(permission)));
+    assert.match(h2AdminMigrations, new RegExp(escapeRegExp(permission)));
   }
 });
 


### PR DESCRIPTION
## 관련 이슈

close #965

## 작업 배경

관리자 identity, RBAC, audit, batch, 공통코드, incident 기능이 누적된 상태에서 legacy env 관리자 계정과 단일 관리자 권한 모델을 즉시 제거하면 운영 복구 경로가 약해진다. 전환 단계, shadow 검증, release blocker, break-glass, seed, rollback 기준을 설정과 contract test로 고정해 기능 PR이 쌓여도 운영 전환 조건이 흐려지지 않게 한다.

## 작업 내용

- `easysubway.admin.platform-transition` 설정을 추가해 identity store, RBAC shadow/enforcement, audit shadow/enforcement, legacy env admin fallback, break-glass bootstrap, role seed flag 기본값을 정의했습니다.
- RBAC shadow, audit shadow, legacy fallback 제거 조건, break-glass 발급/회전, role/account seed, rollback, release blocker 기준을 typed properties로 고정했습니다.
- prod profile은 release blocker mode 기본값을 `fail`로 두고, 일반 기본값은 shadow rollout과 legacy fallback 유지로 둡니다.
- repository contract가 전환 설정, seed permission, 기존 prod admin/break-glass 안전장치, 전환 properties 테스트를 함께 확인하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 114 tests passed
  - `cd backend && ./gradlew test --tests 'com.easysubway.admin.transition.AdminPlatformTransitionPropertiesTest' --tests 'com.easysubway.common.security.SecurityConfigTest'`: exit 0
  - `node --test tools/ci/*.test.mjs`: exit 0, 118 tests passed
  - `cd backend && ./gradlew test`: exit 0
  - `git diff --check`: exit 0
  - GitHub CI: Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan, Release Artifacts, SonarCloud Code Analysis 모두 pass
  - CodeRabbit: actionable 2건 확인, `d7bfb368`에서 수정 후 원래 inline thread 답글 및 resolved 확인. 후속 incremental review는 rate limit으로 시작되지 않았으나 CodeRabbit status check는 success

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| feature flag | backend config | properties binding test | `AdminPlatformTransitionPropertiesTest` | shadow 기본값과 enforcement override 확인 |
| shadow mode | backend config/contract | repository contract | `repository-contract.test.mjs` | RBAC/audit shadow metric과 promotion criteria 고정 |
| fallback 제거 | backend prod profile/security | SecurityConfig/repository contract | `SecurityConfigTest`, `repository-contract.test.mjs` | legacy env fallback 유지와 제거 조건, prod blocker mode 확인 |
| break-glass/seed | backend security/migration | unit/contract test | `SecurityConfigTest`, admin migration contract | break-glass rotation 요구와 permission seed coverage 확인 |
| rollback | repository tooling | repository contract | `repository-contract.test.mjs` | rollback runbook 문구와 release blocker 기준 고정 |
| PR CI | GitHub Actions | PR check | CI run `28283337100`, Release Artifacts run `28283336974`, SonarCloud PR analysis | required check와 release artifact check pass |
| 코드 리뷰 | GitHub PR review | CodeRabbit review/thread 확인 | CodeRabbit actionable comments `3485629676`, `3485629678`, fix commit `d7bfb368` | 2건 수정, 해결 답글 게시, thread resolved |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `AdminPlatformTransitionProperties`, `application.yml`, `application-prod.yml`, `repository-contract.test.mjs`

## 리스크

- 이번 PR은 실제 RBAC/audit enforcement를 켜지 않는다. 운영 차단 동작은 후속 PR에서 flag를 전환할 때 별도 검증해야 한다.
- 전환 runbook은 Markdown 파일이 아니라 설정/contract와 PR 본문으로 남긴다. 이 저장소 정책상 README와 GitHub 템플릿 외 Markdown 문서는 git 추적하지 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (해당 없음: 초회 CodeRabbit review 완료, 후속 incremental review는 rate limit, 기존 actionable 2건은 CodeRabbit thread resolved)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 설정 변경 없음, Release Artifacts check pass 확인)
