### PR TITLE
[Test] Android 출시 UX·접근성·성능 gate 증거 계약 보강

### DIFF
--- a/apps/mobile/release/android-release-quality-gate.json
+++ b/apps/mobile/release/android-release-quality-gate.json
@@ -23,6 +23,18 @@
   },
   "routeSafetyContract": "#571",
   "routeSafetyStatusEnum": ["FOUND", "BLOCKED", "UNKNOWN", "UNSUPPORTED", "ERROR"],
+  "buildIdentityPolicy": {
+    "requiredIssueLinks": ["#1015", "#1016", "#1020"],
+    "acceptedBuildSources": ["rc-aab", "play-generated-apk", "play-installed-build"],
+    "requiredIdentityFields": [
+      "gitSha",
+      "versionCode",
+      "aabSha256",
+      "dataPackManifestSha256",
+      "androidApplicationId"
+    ],
+    "mismatchDisposition": "NO_GO"
+  },
   "deviceEvidencePolicy": {
     "codexQaDevice": "local_android_emulator_only",
     "physicalDeviceEvidence": "not_used_for_codex_pr_evidence",
@@ -111,6 +123,48 @@
       "releaseBlocker": true,
       "evidence": ["logcat-summary", "privacy-review-notes"],
       "passCriteriaKo": "crash/ANR reporting은 민감 위치, 신고 사진, receipt token, signing/credential 값을 노출하지 않는다."
+    }
+  ],
+  "requiredEvidenceSet": [
+    {
+      "id": "home_support_scope",
+      "evidence": ["screenshot", "ui-tree"],
+      "provesKo": "홈에서 지원 범위와 다음 행동을 확인할 수 있다."
+    },
+    {
+      "id": "station_search",
+      "evidence": ["screenshot", "ui-tree"],
+      "provesKo": "역 검색이 큰 글자와 TalkBack 조건에서 탐색 가능하다."
+    },
+    {
+      "id": "station_detail_facility_status",
+      "evidence": ["screenshot", "ui-tree"],
+      "provesKo": "역 상세와 시설 상태가 색상만으로 전달되지 않는다."
+    },
+    {
+      "id": "route_result_found_unknown_unavailable",
+      "evidence": ["screenshot", "ui-tree", "copy-review-notes"],
+      "provesKo": "경로 상태별 안전 문구와 다음 행동이 구분된다."
+    },
+    {
+      "id": "route_map_fallback",
+      "evidence": ["screenshot", "ui-tree", "performance-summary"],
+      "provesKo": "노선도 조작, fallback list, 성능 예산을 확인한다."
+    },
+    {
+      "id": "facility_report_recovery",
+      "evidence": ["screenshot", "ui-tree", "logcat-summary"],
+      "provesKo": "신고 작성과 upload 실패 복구가 데이터 손실 없이 동작한다."
+    },
+    {
+      "id": "help_privacy_data_deletion",
+      "evidence": ["screenshot", "ui-tree"],
+      "provesKo": "도움말, 개인정보, 삭제 요청 경로를 확인할 수 있다."
+    },
+    {
+      "id": "data_baseline_source_realtime_scope",
+      "evidence": ["screenshot", "ui-tree"],
+      "provesKo": "데이터 기준일, 출처, 실시간 범위가 앱과 Play listing copy에 모순되지 않는다."
     }
   ],
   "evidencePolicy": {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -6793,6 +6793,20 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
   assert.equal(gate.scope.platform.ios, "DEFERRED_OUT_OF_SCOPE");
   assert.deepEqual(gate.routeSafetyStatusEnum, ["FOUND", "BLOCKED", "UNKNOWN", "UNSUPPORTED", "ERROR"]);
   assert.equal(gate.routeSafetyContract, "#571");
+  assert.deepEqual(gate.buildIdentityPolicy.requiredIssueLinks, ["#1015", "#1016", "#1020"]);
+  assert.deepEqual(gate.buildIdentityPolicy.acceptedBuildSources, [
+    "rc-aab",
+    "play-generated-apk",
+    "play-installed-build",
+  ]);
+  assert.deepEqual(gate.buildIdentityPolicy.requiredIdentityFields, [
+    "gitSha",
+    "versionCode",
+    "aabSha256",
+    "dataPackManifestSha256",
+    "androidApplicationId",
+  ]);
+  assert.equal(gate.buildIdentityPolicy.mismatchDisposition, "NO_GO");
   assert.equal(gate.deviceEvidencePolicy.codexQaDevice, "local_android_emulator_only");
   assert.equal(gate.deviceEvidencePolicy.physicalDeviceEvidence, "not_used_for_codex_pr_evidence");
   assert.equal(gate.deviceEvidencePolicy.releaseRcEvidence, "play_installed_or_exact_rc_required_before_go");
@@ -6841,6 +6855,26 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
       .get("route_map_performance_budget")
       .evidence.includes("matched-profile-route-map-camera-latency-summary"),
   );
+
+  const evidenceSet = new Map(gate.requiredEvidenceSet.map((item) => [item.id, item]));
+  for (const id of [
+    "home_support_scope",
+    "station_search",
+    "station_detail_facility_status",
+    "route_result_found_unknown_unavailable",
+    "route_map_fallback",
+    "facility_report_recovery",
+    "help_privacy_data_deletion",
+    "data_baseline_source_realtime_scope",
+  ]) {
+    const item = evidenceSet.get(id);
+    assert.ok(item, `${id} must be required Android QA evidence`);
+    assert.ok(item.evidence.includes("screenshot"), `${id} must require screenshot evidence`);
+    assert.ok(item.evidence.includes("ui-tree"), `${id} must require UI tree evidence`);
+    assert.equal(typeof item.provesKo, "string", `${id} must explain what evidence proves`);
+  }
+  assert.ok(evidenceSet.get("route_map_fallback").evidence.includes("performance-summary"));
+  assert.ok(evidenceSet.get("facility_report_recovery").evidence.includes("logcat-summary"));
 
   assert.ok(androidRcEvidence.requiredEvidence.androidAccessibilityQa.includes("android-release-quality-gate-manifest"));
   assert.ok(androidRcEvidence.requiredEvidence.androidAccessibilityQa.includes("local-emulator-ui-tree-screenshots"));


### PR DESCRIPTION
## 관련 이슈

AquilaXk/easysubway-mobile#9 일부 보강. 최종 RC/Play-installed build QA 증거가 남아 있어 이 PR은 이슈를 닫지 않는다.

## 작업 배경

- Android 출시 UX·접근성·성능 gate가 어떤 build identity와 어떤 화면 증거 세트를 요구하는지 release contract에서 더 명확히 고정해야 했다.
- 최종 판정은 AquilaXk/easysubway#1015, AquilaXk/easysubway-mobile#8, #1020의 RC identity와 연결되어야 하므로 QA evidence가 임의 build 기준으로 섞이지 않게 막는다.

## 작업 내용

- `android-release-quality-gate.json`에 accepted build source, 필수 identity field, mismatch `NO_GO` 정책을 추가했다.
- 홈, 역 검색, 역 상세, 경로 상태, 노선도 fallback, 시설 신고 복구, 도움말/개인정보, 데이터 기준일/출처 화면을 필수 evidence set으로 고정했다.
- repository contract test가 위 build identity 정책과 evidence set 누락을 잡도록 보강했다.

## 검증

- 실행한 명령과 결과:
  - `node -e "JSON.parse(require('fs').readFileSync('apps/mobile/release/android-release-quality-gate.json','utf8')); console.log('android-release-quality-gate.json ok')"`: exit 0
  - `node --test --test-name-pattern "Android 출시 UX 접근성 성능 gate" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `node --test tools/ci/*.test.mjs`: exit 0, 121 tests passed
  - `flutter analyze` in `apps/mobile`: exit 0, no issues found
  - `flutter test` in `apps/mobile`: exit 0, all tests passed
  - `tools/mobile/run-android-release-quality-emulator-smoke.sh --serial emulator-5554 --artifact-dir .codex/evidence/release/android-quality/issue-1021-contract-smoke --expected-font-scale 1.5 --adb /Volumes/MACSSD/Android/sdk-home/android-commandlinetools/platform-tools/adb`: exit 0
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| release contract | local | JSON parse와 repository contract | command output | 통과 |
| repository CI contract | local | `node --test tools/ci/*.test.mjs` | command output | 121 tests passed |
| mobile static/test | local | `flutter analyze`, `flutter test` | command output | 통과 |
| Android local smoke | Android emulator API 36 | font scale 1.5, compact portrait, screenshot/UI tree/logcat 캡처 | `.codex/evidence/release/android-quality/issue-1021-contract-smoke/summary.txt` local-only | smoke evidence 생성됨 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `requiredEvidenceSet`이 #1021에서 요구한 화면과 상태를 충분히 고정하는지 확인하면 된다.
- local-only smoke evidence는 PR 검증용 emulator 증거이며, 최종 RC/Play-installed build identity 증거는 AquilaXk/easysubway-mobile#9/#1020에서 별도로 수집해야 한다.
- CodeRabbit은 actionable comment 0건으로 완료됐다.

## 리스크

- 이 PR은 gate 계약 보강이다. 실제 최종 RC 화면 캡처와 TalkBack 판정은 닫지 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI code review fallback은 필요하지 않았다.
- [x] 배포 영향은 없으며 merge 후 CD 생성/실패 여부만 확인한다.
