### PR TITLE
[Test] Android RC abuse-case와 penetration rehearsal 증거 계약 보강

### DIFF
--- a/apps/mobile/release/abuse-penetration-rehearsal-gate.json
+++ b/apps/mobile/release/abuse-penetration-rehearsal-gate.json
@@ -9,6 +9,19 @@
   "securityPrivacyEvidenceManifest": "apps/mobile/release/security-privacy-release-evidence.json",
   "releaseSecurityGate": "apps/mobile/release/release-security-gate.json",
   "evidenceRoot": ".codex/evidence/security/abuse-penetration-rehearsal/<rc-or-run>/",
+  "buildIdentityPolicy": {
+    "requiredIssueLinks": ["#1015", "#1016", "#1020"],
+    "acceptedArtifactSources": ["rc-aab", "play-generated-apk", "play-installed-build", "backend-release-image"],
+    "requiredIdentityFields": [
+      "gitSha",
+      "versionCode",
+      "androidApplicationId",
+      "aabOrApkSha256",
+      "backendArtifactDigest",
+      "dataPackManifestSha256"
+    ],
+    "mismatchDisposition": "NO_GO"
+  },
   "artifactSecretAndEndpointScan": {
     "requiredArtifacts": [
       "Android AAB or Play-generated APK",
@@ -78,6 +91,15 @@
   "manualRehearsalPolicy": {
     "redactionRequired": true,
     "requestResponseSummaryOnly": true,
+    "githubSummaryFields": [
+      "scenarioId",
+      "artifactIdentity",
+      "commandOrManualCheck",
+      "findingCounts",
+      "result",
+      "redactionNotes",
+      "localEvidencePath"
+    ],
     "forbiddenInEvidence": [
       "raw receipt token",
       "raw signed URL",

--- a/apps/mobile/release/abuse-penetration-rehearsal-gate.json
+++ b/apps/mobile/release/abuse-penetration-rehearsal-gate.json
@@ -16,9 +16,11 @@
       "gitSha",
       "versionCode",
       "androidApplicationId",
-      "aabOrApkSha256",
-      "backendArtifactDigest",
       "dataPackManifestSha256"
+    ],
+    "requiredIdentityAnyOf": [
+      ["aabSha256", "generatedApkSha256"],
+      ["backendImageDigest", "backendArtifactSha256"]
     ],
     "mismatchDisposition": "NO_GO"
   },

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1089,9 +1089,11 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
     "gitSha",
     "versionCode",
     "androidApplicationId",
-    "aabOrApkSha256",
-    "backendArtifactDigest",
     "dataPackManifestSha256",
+  ]);
+  assert.deepEqual(abusePenetrationRehearsalGate.buildIdentityPolicy.requiredIdentityAnyOf, [
+    ["aabSha256", "generatedApkSha256"],
+    ["backendImageDigest", "backendArtifactSha256"],
   ]);
   assert.equal(abusePenetrationRehearsalGate.buildIdentityPolicy.mismatchDisposition, "NO_GO");
   assert.ok(abusePenetrationRehearsalGate.artifactSecretAndEndpointScan.forbiddenFindings.includes("provider secret"));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1078,6 +1078,22 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.equal(abusePenetrationRehearsalGate.androidRcEvidenceManifest, androidRcEvidencePath);
   assert.equal(abusePenetrationRehearsalGate.securityPrivacyEvidenceManifest, "apps/mobile/release/security-privacy-release-evidence.json");
   assert.match(abusePenetrationRehearsalGate.evidenceRoot, /\.codex\/evidence\/security\/abuse-penetration-rehearsal\/<rc-or-run>/);
+  assert.deepEqual(abusePenetrationRehearsalGate.buildIdentityPolicy.requiredIssueLinks, ["#1015", "#1016", "#1020"]);
+  assert.deepEqual(abusePenetrationRehearsalGate.buildIdentityPolicy.acceptedArtifactSources, [
+    "rc-aab",
+    "play-generated-apk",
+    "play-installed-build",
+    "backend-release-image",
+  ]);
+  assert.deepEqual(abusePenetrationRehearsalGate.buildIdentityPolicy.requiredIdentityFields, [
+    "gitSha",
+    "versionCode",
+    "androidApplicationId",
+    "aabOrApkSha256",
+    "backendArtifactDigest",
+    "dataPackManifestSha256",
+  ]);
+  assert.equal(abusePenetrationRehearsalGate.buildIdentityPolicy.mismatchDisposition, "NO_GO");
   assert.ok(abusePenetrationRehearsalGate.artifactSecretAndEndpointScan.forbiddenFindings.includes("provider secret"));
   assert.ok(abusePenetrationRehearsalGate.artifactSecretAndEndpointScan.forbiddenFindings.includes("receipt token"));
   assert.deepEqual(
@@ -1092,6 +1108,17 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
     ],
   );
   assert.equal(abusePenetrationRehearsalGate.manualRehearsalPolicy.localAndroidEmulatorRequiredForMobileEvidence, true);
+  assert.deepEqual(abusePenetrationRehearsalGate.manualRehearsalPolicy.githubSummaryFields, [
+    "scenarioId",
+    "artifactIdentity",
+    "commandOrManualCheck",
+    "findingCounts",
+    "result",
+    "redactionNotes",
+    "localEvidencePath",
+  ]);
+  assert.ok(abusePenetrationRehearsalGate.manualRehearsalPolicy.forbiddenInEvidence.includes("raw receipt token"));
+  assert.ok(abusePenetrationRehearsalGate.manualRehearsalPolicy.forbiddenInEvidence.includes("raw signed URL"));
   assert.equal(abusePenetrationRehearsalGate.findingPolicy.criticalHighAllowed, 0);
   assert.equal(abusePenetrationRehearsalGate.findingPolicy.waiverIssue, 1020);
   assert.deepEqual(


### PR DESCRIPTION
## 관련 이슈

#1022 일부 보강. 실제 RC AAB/Play-generated APK scan과 backend abuse rehearsal 증거가 남아 있어 이 PR은 이슈를 닫지 않는다.

## 작업 배경

- Abuse-case와 penetration rehearsal 증거가 어떤 RC/backend artifact identity에 묶여야 하는지 gate manifest에서 더 명확히 고정해야 했다.
- 민감한 receipt token, signed URL, session cookie, 사진 원본을 GitHub에 올리지 않도록 PR summary에 허용되는 필드만 제한한다.

## 작업 내용

- `abuse-penetration-rehearsal-gate.json`에 accepted artifact source와 필수 identity field, Android/backend artifact any-of identity field, mismatch `NO_GO` 정책을 추가했다.
- manual rehearsal evidence의 GitHub summary 허용 필드를 `scenarioId`, `artifactIdentity`, `findingCounts`, `localEvidencePath` 등으로 고정했다.
- repository contract test가 identity policy와 redacted summary field 누락을 잡도록 보강했다.

## 검증

- 실행한 명령과 결과:
  - `node -e "JSON.parse(require('fs').readFileSync('apps/mobile/release/abuse-penetration-rehearsal-gate.json','utf8')); console.log('abuse-penetration-rehearsal-gate.json ok')"`: exit 0
  - `node --test --test-name-pattern "모바일 signed release artifact gate" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `node --test tools/ci/*.test.mjs`: exit 0, 121 tests passed
  - `./gradlew check --no-daemon` in `backend`: exit 0, BUILD SUCCESSFUL
  - `git diff --check`: exit 0
  - GitHub PR checks: Android CI, Backend CI, Mobile App CI, Repository CI, Release Gate Consistency, Android Release Artifact, Backend Release Image, RC Evidence Manifest, SonarCloud Code Analysis, osv-scanner 통과
  - Codex CLI fallback review: 1건 지적 후 `cbb8c98`에서 수정, 원래 inline thread에 해결 답글 작성 및 resolved 확인, 재리뷰 actionable 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| abuse rehearsal gate JSON | local | JSON parse | command output | 통과 |
| release contract | local | targeted repository contract | command output | 1 test passed |
| repository contract | local | `node --test tools/ci/*.test.mjs` | command output | 121 tests passed |
| backend security boundary | local | `./gradlew check --no-daemon` | command output | BUILD SUCCESSFUL |
| PR CI | GitHub Actions | PR checks | https://github.com/AquilaXk/easysubway/pull/1029 | 통과 |
| Codex fallback review | GitHub PR review | CodeRabbit rate limit 후 Codex CLI review/re-review | https://github.com/AquilaXk/easysubway/pull/1029#pullrequestreview-4585962589 | 재리뷰 actionable 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `buildIdentityPolicy`가 Android artifact와 backend image identity를 충분히 묶는지, `githubSummaryFields`가 민감값을 남길 여지를 주지 않는지 확인하면 된다.
- 실제 secret scan, signed URL abuse, receipt replay, admin/operator CSRF rehearsal 결과는 #1022/#1020의 최종 evidence로 따로 수집해야 한다.

## 리스크

- 이 PR은 gate 계약 보강이다. 실제 penetration rehearsal을 완료하지 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [x] CodeRabbit rate limit으로 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향은 없으며 merge 후 CD 생성/실패 여부만 확인한다.
