### PR TITLE
[Test] abuse rehearsal 증거 계약 보강

### DIFF
--- a/apps/mobile/release/abuse-penetration-rehearsal-gate.json
+++ b/apps/mobile/release/abuse-penetration-rehearsal-gate.json
@@ -90,6 +90,74 @@
       "requiredEvidence": ["tracked-secret-search", "release-artifact-secret-scan-output", "backend-image-env-redaction-summary"]
     }
   ],
+  "rehearsalMatrices": {
+    "receiptTokenAbuse": {
+      "requiredEvidence": ["receipt-token-negative-tests", "redacted-request-response-summary", "log-redaction-check"],
+      "requiredCases": [
+        "brute_force_guessing",
+        "replay_after_status_lookup",
+        "cross_report_enumeration",
+        "confirm_endpoint_abuse",
+        "url_header_log_redaction"
+      ],
+      "summaryFields": ["caseId", "endpoint", "attemptCount", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"],
+      "forbiddenSummaryValues": ["raw receipt token", "receipt token hash", "authorization header", "session cookie"]
+    },
+    "signedUploadUrlBoundary": {
+      "requiredEvidence": ["signed-url-expiry-test", "storage-log-redaction-check", "redacted-request-response-summary"],
+      "requiredCases": [
+        "method_mismatch",
+        "content_type_mismatch",
+        "size_limit_exceeded",
+        "ttl_expired",
+        "object_key_prefix_traversal",
+        "signed_url_reuse"
+      ],
+      "summaryFields": ["caseId", "method", "contentType", "sizeBytes", "ttlSeconds", "expectedStatus", "observedStatus", "localEvidencePath"],
+      "forbiddenSummaryValues": ["raw signed URL", "object storage credential", "object key with user identifier", "photo binary"]
+    },
+    "reportUploadLifecycle": {
+      "requiredEvidence": ["malicious-photo-upload-test-output", "orphan-cleanup-request-response-summary", "redacted-request-response-summary"],
+      "requiredCases": [
+        "upload_intent_abuse",
+        "duplicate_claim",
+        "submit_without_valid_claim",
+        "status_lookup_without_valid_receipt",
+        "confirm_without_valid_receipt",
+        "orphan_cleanup_after_failed_claim",
+        "malicious_photo_upload"
+      ],
+      "summaryFields": ["caseId", "apiStep", "expectedStatus", "observedStatus", "cleanupResult", "redactionResult", "localEvidencePath"],
+      "forbiddenSummaryValues": ["raw receipt token", "raw signed URL", "photo binary", "precise coordinates"]
+    },
+    "adminOperatorSecurity": {
+      "requiredEvidence": ["admin-auth-tests", "operator-role-negative-tests", "csrf-negative-test-summary", "admin-operator-lockout-test-output"],
+      "requiredCases": [
+        "login_failure_lockout",
+        "logout_session_invalidation",
+        "session_expiry",
+        "csrf_missing_mutation",
+        "role_denied_personal_data",
+        "role_denied_photo_read",
+        "tenant_authorization_bypass",
+        "break_glass_audit_redaction"
+      ],
+      "summaryFields": ["caseId", "role", "tenantScope", "endpoint", "expectedStatus", "observedStatus", "auditRedactionResult", "localEvidencePath"],
+      "forbiddenSummaryValues": ["operator password", "session cookie", "csrf token", "raw personal data", "raw photo metadata"]
+    },
+    "objectStorageLifecycle": {
+      "requiredEvidence": ["object-lifecycle-cleanup-summary", "storage-log-redaction-check", "object-retention-delete-policy-summary"],
+      "requiredCases": [
+        "orphan_object_cleanup",
+        "retention_policy_record",
+        "delete_after_report_deletion",
+        "signed_url_expiry_enforced",
+        "storage_audit_redaction"
+      ],
+      "summaryFields": ["caseId", "bucketOrPolicyAlias", "retentionRule", "deleteOrCleanupResult", "expectedStatus", "observedStatus", "localEvidencePath"],
+      "forbiddenSummaryValues": ["raw signed URL", "object storage credential", "photo binary", "full object key"]
+    }
+  },
   "manualRehearsalPolicy": {
     "redactionRequired": true,
     "requestResponseSummaryOnly": true,
@@ -102,6 +170,8 @@
       "redactionNotes",
       "localEvidencePath"
     ],
+    "perCaseSummaryRequired": true,
+    "minimumSummaryFields": ["caseId", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"],
     "forbiddenInEvidence": [
       "raw receipt token",
       "raw signed URL",

--- a/apps/mobile/release/abuse-penetration-rehearsal-gate.json
+++ b/apps/mobile/release/abuse-penetration-rehearsal-gate.json
@@ -92,6 +92,7 @@
   ],
   "rehearsalMatrices": {
     "receiptTokenAbuse": {
+      "scenarioId": "receipt_token_replay_and_status_abuse",
       "requiredEvidence": ["receipt-token-negative-tests", "redacted-request-response-summary", "log-redaction-check"],
       "requiredCases": [
         "brute_force_guessing",
@@ -104,6 +105,7 @@
       "forbiddenSummaryValues": ["raw receipt token", "receipt token hash", "authorization header", "session cookie"]
     },
     "signedUploadUrlBoundary": {
+      "scenarioId": "signed_url_lifecycle_abuse",
       "requiredEvidence": ["signed-url-expiry-test", "storage-log-redaction-check", "redacted-request-response-summary"],
       "requiredCases": [
         "method_mismatch",
@@ -117,6 +119,7 @@
       "forbiddenSummaryValues": ["raw signed URL", "object storage credential", "object key with user identifier", "photo binary"]
     },
     "reportUploadLifecycle": {
+      "scenarioId": "report_photo_upload_abuse",
       "requiredEvidence": ["malicious-photo-upload-test-output", "orphan-cleanup-request-response-summary", "redacted-request-response-summary"],
       "requiredCases": [
         "upload_intent_abuse",
@@ -131,6 +134,7 @@
       "forbiddenSummaryValues": ["raw receipt token", "raw signed URL", "photo binary", "precise coordinates"]
     },
     "adminOperatorSecurity": {
+      "scenarioId": "admin_operator_auth_session_csrf",
       "requiredEvidence": ["admin-auth-tests", "operator-role-negative-tests", "csrf-negative-test-summary", "admin-operator-lockout-test-output"],
       "requiredCases": [
         "login_failure_lockout",
@@ -146,6 +150,7 @@
       "forbiddenSummaryValues": ["operator password", "session cookie", "csrf token", "raw personal data", "raw photo metadata"]
     },
     "objectStorageLifecycle": {
+      "scenarioId": "signed_url_lifecycle_abuse",
       "requiredEvidence": ["object-lifecycle-cleanup-summary", "storage-log-redaction-check", "object-retention-delete-policy-summary"],
       "requiredCases": [
         "orphan_object_cleanup",
@@ -156,6 +161,32 @@
       ],
       "summaryFields": ["caseId", "bucketOrPolicyAlias", "retentionRule", "deleteOrCleanupResult", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"],
       "forbiddenSummaryValues": ["raw signed URL", "object storage credential", "photo binary", "full object key"]
+    },
+    "distributedRateLimitAbuse": {
+      "scenarioId": "distributed_rate_limit_abuse",
+      "requiredEvidence": ["distributed-abuse-control-test-output", "trusted-proxy-negative-test", "abuse-store-mode-record"],
+      "requiredCases": [
+        "multi_node_upload_intent_flooding",
+        "claim_submit_status_confirm_flooding",
+        "trusted_proxy_spoofing",
+        "abuse_store_mode_record",
+        "single_instance_exception_link"
+      ],
+      "summaryFields": ["caseId", "nodeOrStoreMode", "endpoint", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"],
+      "forbiddenSummaryValues": ["raw receipt token", "raw signed URL", "client IP full address", "trusted proxy credential"]
+    },
+    "providerReleaseSecretExposure": {
+      "scenarioId": "provider_and_release_secret_exposure",
+      "requiredEvidence": ["tracked-secret-search", "release-artifact-secret-scan-output", "backend-image-env-redaction-summary"],
+      "requiredCases": [
+        "tracked_secret_search",
+        "android_artifact_secret_scan",
+        "backend_image_env_redaction",
+        "release_endpoint_allowlist_diff",
+        "pr_evidence_redaction"
+      ],
+      "summaryFields": ["caseId", "artifactType", "scanTarget", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"],
+      "forbiddenSummaryValues": ["provider secret", "object storage credential", "production password", "signing private key", "local or internal endpoint"]
     }
   },
   "manualRehearsalPolicy": {

--- a/apps/mobile/release/abuse-penetration-rehearsal-gate.json
+++ b/apps/mobile/release/abuse-penetration-rehearsal-gate.json
@@ -113,7 +113,7 @@
         "object_key_prefix_traversal",
         "signed_url_reuse"
       ],
-      "summaryFields": ["caseId", "method", "contentType", "sizeBytes", "ttlSeconds", "expectedStatus", "observedStatus", "localEvidencePath"],
+      "summaryFields": ["caseId", "method", "contentType", "sizeBytes", "ttlSeconds", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"],
       "forbiddenSummaryValues": ["raw signed URL", "object storage credential", "object key with user identifier", "photo binary"]
     },
     "reportUploadLifecycle": {
@@ -142,7 +142,7 @@
         "tenant_authorization_bypass",
         "break_glass_audit_redaction"
       ],
-      "summaryFields": ["caseId", "role", "tenantScope", "endpoint", "expectedStatus", "observedStatus", "auditRedactionResult", "localEvidencePath"],
+      "summaryFields": ["caseId", "role", "tenantScope", "endpoint", "expectedStatus", "observedStatus", "redactionResult", "auditRedactionResult", "localEvidencePath"],
       "forbiddenSummaryValues": ["operator password", "session cookie", "csrf token", "raw personal data", "raw photo metadata"]
     },
     "objectStorageLifecycle": {
@@ -154,7 +154,7 @@
         "signed_url_expiry_enforced",
         "storage_audit_redaction"
       ],
-      "summaryFields": ["caseId", "bucketOrPolicyAlias", "retentionRule", "deleteOrCleanupResult", "expectedStatus", "observedStatus", "localEvidencePath"],
+      "summaryFields": ["caseId", "bucketOrPolicyAlias", "retentionRule", "deleteOrCleanupResult", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"],
       "forbiddenSummaryValues": ["raw signed URL", "object storage credential", "photo binary", "full object key"]
     }
   },

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1286,7 +1286,7 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   for (const [matrixId, requiredCases] of Object.entries(requiredMatrixCases)) {
     const matrix = rehearsalMatrices[matrixId];
     assert.deepEqual(matrix.requiredCases, requiredCases, `${matrixId} must require all #1022 abuse cases`);
-    for (const field of ["caseId", "expectedStatus", "observedStatus", "localEvidencePath"]) {
+    for (const field of ["caseId", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"]) {
       assert.ok(matrix.summaryFields.includes(field), `${matrixId} must include PR summary field ${field}`);
     }
     assert.ok(Array.isArray(matrix.requiredEvidence), `${matrixId} must define evidence`);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1235,11 +1235,19 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   const rehearsalMatrices = abusePenetrationRehearsalGate.rehearsalMatrices;
   assert.deepEqual(Object.keys(rehearsalMatrices).sort(), [
     "adminOperatorSecurity",
+    "distributedRateLimitAbuse",
     "objectStorageLifecycle",
+    "providerReleaseSecretExposure",
     "receiptTokenAbuse",
     "reportUploadLifecycle",
     "signedUploadUrlBoundary",
   ]);
+  assert.deepEqual(
+    [...new Set(Object.values(rehearsalMatrices).map((matrix) => matrix.scenarioId))].sort(),
+    abusePenetrationRehearsalGate.abuseScenarios.map((scenario) => scenario.id).sort(),
+    "every #1022 abuse scenario must have per-case rehearsal matrix coverage",
+  );
+  const abuseScenarioIds = new Set(abusePenetrationRehearsalGate.abuseScenarios.map((scenario) => scenario.id));
   const requiredMatrixCases = {
     receiptTokenAbuse: [
       "brute_force_guessing",
@@ -1282,9 +1290,24 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
       "signed_url_expiry_enforced",
       "storage_audit_redaction",
     ],
+    distributedRateLimitAbuse: [
+      "multi_node_upload_intent_flooding",
+      "claim_submit_status_confirm_flooding",
+      "trusted_proxy_spoofing",
+      "abuse_store_mode_record",
+      "single_instance_exception_link",
+    ],
+    providerReleaseSecretExposure: [
+      "tracked_secret_search",
+      "android_artifact_secret_scan",
+      "backend_image_env_redaction",
+      "release_endpoint_allowlist_diff",
+      "pr_evidence_redaction",
+    ],
   };
   for (const [matrixId, requiredCases] of Object.entries(requiredMatrixCases)) {
     const matrix = rehearsalMatrices[matrixId];
+    assert.ok(abuseScenarioIds.has(matrix.scenarioId), `${matrixId} must reference an existing #1022 scenario`);
     assert.deepEqual(matrix.requiredCases, requiredCases, `${matrixId} must require all #1022 abuse cases`);
     for (const field of ["caseId", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"]) {
       assert.ok(matrix.summaryFields.includes(field), `${matrixId} must include PR summary field ${field}`);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1232,6 +1232,84 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
       "signed_url_lifecycle_abuse",
     ],
   );
+  const rehearsalMatrices = abusePenetrationRehearsalGate.rehearsalMatrices;
+  assert.deepEqual(Object.keys(rehearsalMatrices).sort(), [
+    "adminOperatorSecurity",
+    "objectStorageLifecycle",
+    "receiptTokenAbuse",
+    "reportUploadLifecycle",
+    "signedUploadUrlBoundary",
+  ]);
+  const requiredMatrixCases = {
+    receiptTokenAbuse: [
+      "brute_force_guessing",
+      "replay_after_status_lookup",
+      "cross_report_enumeration",
+      "confirm_endpoint_abuse",
+      "url_header_log_redaction",
+    ],
+    signedUploadUrlBoundary: [
+      "method_mismatch",
+      "content_type_mismatch",
+      "size_limit_exceeded",
+      "ttl_expired",
+      "object_key_prefix_traversal",
+      "signed_url_reuse",
+    ],
+    reportUploadLifecycle: [
+      "upload_intent_abuse",
+      "duplicate_claim",
+      "submit_without_valid_claim",
+      "status_lookup_without_valid_receipt",
+      "confirm_without_valid_receipt",
+      "orphan_cleanup_after_failed_claim",
+      "malicious_photo_upload",
+    ],
+    adminOperatorSecurity: [
+      "login_failure_lockout",
+      "logout_session_invalidation",
+      "session_expiry",
+      "csrf_missing_mutation",
+      "role_denied_personal_data",
+      "role_denied_photo_read",
+      "tenant_authorization_bypass",
+      "break_glass_audit_redaction",
+    ],
+    objectStorageLifecycle: [
+      "orphan_object_cleanup",
+      "retention_policy_record",
+      "delete_after_report_deletion",
+      "signed_url_expiry_enforced",
+      "storage_audit_redaction",
+    ],
+  };
+  for (const [matrixId, requiredCases] of Object.entries(requiredMatrixCases)) {
+    const matrix = rehearsalMatrices[matrixId];
+    assert.deepEqual(matrix.requiredCases, requiredCases, `${matrixId} must require all #1022 abuse cases`);
+    for (const field of ["caseId", "expectedStatus", "observedStatus", "localEvidencePath"]) {
+      assert.ok(matrix.summaryFields.includes(field), `${matrixId} must include PR summary field ${field}`);
+    }
+    assert.ok(Array.isArray(matrix.requiredEvidence), `${matrixId} must define evidence`);
+    assert.ok(matrix.requiredEvidence.length > 0, `${matrixId} must require evidence`);
+    assert.ok(Array.isArray(matrix.forbiddenSummaryValues), `${matrixId} must forbid sensitive summary values`);
+    assert.ok(matrix.forbiddenSummaryValues.length > 0, `${matrixId} must have forbidden summary values`);
+  }
+  assert.ok(
+    rehearsalMatrices.receiptTokenAbuse.forbiddenSummaryValues.includes("raw receipt token"),
+    "receipt token rehearsal summary must not expose raw tokens",
+  );
+  assert.ok(
+    rehearsalMatrices.signedUploadUrlBoundary.forbiddenSummaryValues.includes("raw signed URL"),
+    "signed URL rehearsal summary must not expose raw URLs",
+  );
+  assert.ok(
+    rehearsalMatrices.adminOperatorSecurity.forbiddenSummaryValues.includes("session cookie"),
+    "admin/operator rehearsal summary must not expose session cookies",
+  );
+  assert.ok(
+    rehearsalMatrices.objectStorageLifecycle.requiredEvidence.includes("object-retention-delete-policy-summary"),
+    "storage lifecycle rehearsal must require retention/delete evidence",
+  );
   assert.equal(abusePenetrationRehearsalGate.manualRehearsalPolicy.localAndroidEmulatorRequiredForMobileEvidence, true);
   assert.deepEqual(abusePenetrationRehearsalGate.manualRehearsalPolicy.githubSummaryFields, [
     "scenarioId",
@@ -1240,6 +1318,14 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
     "findingCounts",
     "result",
     "redactionNotes",
+    "localEvidencePath",
+  ]);
+  assert.equal(abusePenetrationRehearsalGate.manualRehearsalPolicy.perCaseSummaryRequired, true);
+  assert.deepEqual(abusePenetrationRehearsalGate.manualRehearsalPolicy.minimumSummaryFields, [
+    "caseId",
+    "expectedStatus",
+    "observedStatus",
+    "redactionResult",
     "localEvidencePath",
   ]);
   assert.ok(abusePenetrationRehearsalGate.manualRehearsalPolicy.forbiddenInEvidence.includes("raw receipt token"));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1317,6 +1317,19 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
     assert.ok(Array.isArray(matrix.forbiddenSummaryValues), `${matrixId} must forbid sensitive summary values`);
     assert.ok(matrix.forbiddenSummaryValues.length > 0, `${matrixId} must have forbidden summary values`);
   }
+  for (const scenario of abusePenetrationRehearsalGate.abuseScenarios) {
+    const matrixEvidence = new Set(
+      Object.values(rehearsalMatrices)
+        .filter((matrix) => matrix.scenarioId === scenario.id)
+        .flatMap((matrix) => matrix.requiredEvidence),
+    );
+    for (const evidenceId of scenario.requiredEvidence) {
+      assert.ok(
+        matrixEvidence.has(evidenceId),
+        `${scenario.id} rehearsal matrices must include scenario evidence ${evidenceId}`,
+      );
+    }
+  }
   assert.ok(
     rehearsalMatrices.receiptTokenAbuse.forbiddenSummaryValues.includes("raw receipt token"),
     "receipt token rehearsal summary must not expose raw tokens",


### PR DESCRIPTION
## 관련 이슈

#1022

이 PR은 #1022의 abuse-case 증거 계약을 보강하지만, 실제 RC artifact scan, Play-generated/installed build rehearsal, object storage 운영 설정 확인이 남아 있어 이슈를 자동 종료하지 않습니다.

## 작업 배경

#1022는 receipt token, signed upload URL, report upload lifecycle, admin/operator 권한, object storage lifecycle abuse rehearsal을 출시 차단 조건으로 둡니다. 기존 gate는 시나리오 ID와 민감값 금지 정책은 있었지만, PR에 어떤 case 단위 summary와 증거를 남겨야 하는지 기계적으로 강제하지 못했습니다.

## 작업 내용

- `apps/mobile/release/abuse-penetration-rehearsal-gate.json`에 `rehearsalMatrices`를 추가해 receipt token, signed URL, report upload lifecycle, admin/operator security, object storage lifecycle의 필수 negative case와 증거 ID를 분리했습니다.
- GitHub summary에는 caseId, expected/observed status, redaction result, local evidence path 같은 redacted 필드만 남기도록 `manualRehearsalPolicy`를 보강했습니다.
- `tools/ci/repository-contract.test.mjs`에서 matrix ID, 필수 case, evidence, summary field, forbidden summary value를 검증하도록 release contract test를 강화했습니다.

## 검증

- 실행한 명령과 결과:
  - `node -e 'JSON.parse(require("fs").readFileSync("apps/mobile/release/abuse-penetration-rehearsal-gate.json", "utf8")); console.log("abuse rehearsal gate json ok")'`: exit 0, JSON parse 성공
  - `node --test --test-name-pattern "모바일 signed release artifact gate" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `node --test tools/ci/*.test.mjs`: exit 0, 121 tests passed
  - `cd backend && ./gradlew check --no-daemon`: exit 0, BUILD SUCCESSFUL
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| abuse rehearsal gate JSON | local | Node JSON parse | 명령 출력: `abuse rehearsal gate json ok` | 통과 |
| release contract target test | local | `node --test --test-name-pattern "모바일 signed release artifact gate" tools/ci/repository-contract.test.mjs` | 명령 출력: 1 test passed | 통과 |
| repository contract 전체 | local | `node --test tools/ci/*.test.mjs` | 명령 출력: 121 tests passed | 통과 |
| backend security/report 회귀 | local | `cd backend && ./gradlew check --no-daemon` | 명령 출력: BUILD SUCCESSFUL | 통과 |
| diff whitespace | local | `git diff --check` | 명령 출력 없음 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `rehearsalMatrices`의 requiredCases가 #1022의 완료 기준을 빠짐없이 대표하는지 확인해 주세요.
- CodeRabbit review는 최종적으로 actionable 1건을 남겼고, `5fd28fd`에서 scenario requiredEvidence와 matrix evidence union 검증을 추가해 원래 inline thread에 해결 답글을 남겼습니다.
- 이 PR은 실제 penetration rehearsal 결과를 생성하지 않습니다. 민감한 request/response, receipt token, signed URL, 사진 binary 증거는 후속 실행 시 `.codex/evidence/security/abuse-penetration-rehearsal/<rc-or-run>/`에 local-only로 보관하고 PR에는 redacted summary만 남겨야 합니다.

## 리스크

- release gate 계약이 더 엄격해져 후속 RC 검증에서 누락된 case가 즉시 blocker로 드러납니다.
- 실제 Play-generated build, 운영 object storage, admin/operator 실환경 rehearsal은 아직 남아 있으므로 #1022는 계속 open 상태로 유지합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
