### PR TITLE
[Chore] Play 제출 증거 계약 보강

### DIFF
--- a/apps/mobile/release/play-store-submission-content.json
+++ b/apps/mobile/release/play-store-submission-content.json
@@ -77,6 +77,117 @@
       "Photos and videos",
       "Diagnostics"
     ],
+    "answerMatrix": [
+      {
+        "dataType": "Location",
+        "inventoryDataIds": ["precise_location", "facility_report_location"],
+        "containsCollectedData": true,
+        "containsRequiredData": false,
+        "containsOptionalData": true,
+        "requiredConsoleFields": [
+          "collected",
+          "collectionType",
+          "optional",
+          "required",
+          "purpose",
+          "linkedToUser",
+          "encryptedInTransit",
+          "deletionSupported"
+        ],
+        "evidenceSummaryFields": ["inventoryDataIds", "consolePreviewEvidence", "networkTraceMatchResult", "localEvidencePath"]
+      },
+      {
+        "dataType": "App activity",
+        "inventoryDataIds": ["search_queries", "favorite_stations_routes_facilities"],
+        "containsCollectedData": true,
+        "containsRequiredData": true,
+        "containsOptionalData": true,
+        "requiredConsoleFields": [
+          "collected",
+          "collectionType",
+          "optional",
+          "required",
+          "purpose",
+          "linkedToUser",
+          "encryptedInTransit",
+          "deletionSupported"
+        ],
+        "evidenceSummaryFields": ["inventoryDataIds", "consolePreviewEvidence", "networkTraceMatchResult", "localEvidencePath"]
+      },
+      {
+        "dataType": "Personal info",
+        "inventoryDataIds": ["mobility_profile"],
+        "containsCollectedData": true,
+        "containsRequiredData": false,
+        "containsOptionalData": true,
+        "requiredConsoleFields": [
+          "collected",
+          "collectionType",
+          "optional",
+          "required",
+          "purpose",
+          "linkedToUser",
+          "encryptedInTransit",
+          "deletionSupported"
+        ],
+        "evidenceSummaryFields": ["inventoryDataIds", "consolePreviewEvidence", "networkTraceMatchResult", "localEvidencePath"]
+      },
+      {
+        "dataType": "User-generated content",
+        "inventoryDataIds": ["facility_report_content"],
+        "containsCollectedData": true,
+        "containsRequiredData": false,
+        "containsOptionalData": true,
+        "requiredConsoleFields": [
+          "collected",
+          "collectionType",
+          "optional",
+          "required",
+          "purpose",
+          "linkedToUser",
+          "encryptedInTransit",
+          "deletionSupported"
+        ],
+        "evidenceSummaryFields": ["inventoryDataIds", "consolePreviewEvidence", "networkTraceMatchResult", "localEvidencePath"]
+      },
+      {
+        "dataType": "Photos and videos",
+        "inventoryDataIds": ["facility_report_photo"],
+        "containsCollectedData": true,
+        "containsRequiredData": false,
+        "containsOptionalData": true,
+        "requiredConsoleFields": [
+          "collected",
+          "collectionType",
+          "optional",
+          "required",
+          "purpose",
+          "linkedToUser",
+          "encryptedInTransit",
+          "deletionSupported"
+        ],
+        "evidenceSummaryFields": ["inventoryDataIds", "consolePreviewEvidence", "networkTraceMatchResult", "localEvidencePath"]
+      },
+      {
+        "dataType": "Diagnostics",
+        "inventoryDataIds": ["diagnostics_crash_logs", "diagnostics_performance_logs"],
+        "containsCollectedData": true,
+        "containsRequiredData": true,
+        "containsOptionalData": false,
+        "containsLocalOnlyDiagnostics": true,
+        "requiredConsoleFields": [
+          "collected",
+          "collectionType",
+          "optional",
+          "required",
+          "purpose",
+          "linkedToUser",
+          "encryptedInTransit",
+          "deletionSupported"
+        ],
+        "evidenceSummaryFields": ["inventoryDataIds", "consolePreviewEvidence", "networkTraceMatchResult", "localEvidencePath"]
+      }
+    ],
     "optionalUserTriggeredData": [
       "precise location for nearby station search",
       "facility report photo",
@@ -87,6 +198,86 @@
     "binaryTraceMatchRequired": true,
     "linkedInventory": "apps/mobile/release/store-privacy-inventory.json"
   },
+  "evidenceSummarySchemas": {
+    "dataSafetyConsoleSummary": {
+      "requiredFields": [
+        "dataType",
+        "inventoryDataIds",
+        "collected",
+        "collectionType",
+        "optional",
+        "required",
+        "purpose",
+        "linkedToUser",
+        "encryptedInTransit",
+        "deletionSupported",
+        "consolePreviewEvidence",
+        "networkTraceMatchResult",
+        "localEvidencePath",
+        "result"
+      ]
+    },
+    "privacyPolicyUrlSummary": {
+      "requiredFields": [
+        "url",
+        "publicHttpsResult",
+        "unauthenticatedResult",
+        "playConsoleUrl",
+        "appHelpUrl",
+        "readmeOrPublicPolicyUrl",
+        "sameUrlResult",
+        "requiredContentResult",
+        "localEvidencePath",
+        "result"
+      ]
+    },
+    "mailboxReceiptSummary": {
+      "requiredFields": [
+        "mailbox",
+        "testMessageId",
+        "sentAt",
+        "receivedAt",
+        "deliveryResult",
+        "redactionResult",
+        "localEvidencePath",
+        "result"
+      ]
+    },
+    "storeScreenshotSummary": {
+      "requiredFields": [
+        "screenshotId",
+        "buildIdentity",
+        "sourceBuildType",
+        "screenTitleKo",
+        "forbiddenClaimsAbsent",
+        "matchesFeatureScope",
+        "localEvidencePath",
+        "result"
+      ]
+    },
+    "crashAnrPrivacySummary": {
+      "requiredFields": [
+        "separateCrashProvider",
+        "noCrashSdkDependencyScan",
+        "androidVitalsOrPrelaunchEvidence",
+        "redactedLogcatOrCrashSummary",
+        "forbiddenPayloadAbsent",
+        "localEvidencePath",
+        "result"
+      ]
+    },
+    "networkTraceMatchSummary": {
+      "requiredFields": [
+        "traceTarget",
+        "declaredDataTypes",
+        "undeclaredDataTransferCount",
+        "sensitivePayloadAbsent",
+        "localEvidencePath",
+        "result"
+      ]
+    }
+  },
+  "forbiddenEvidenceSummaryValues": ["TBD", "TODO", "unknown", "not checked", "not captured"],
   "privacyPolicyRequirements": {
     "urlMustBePublicHttps": true,
     "urlMustBeUnauthenticated": true,

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7268,6 +7268,7 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
   const readiness = readJson(readinessPath);
   const androidRcEvidence = readJson("apps/mobile/release/android-rc-store-evidence.json");
   const playStoreContent = readJson("apps/mobile/release/play-store-submission-content.json");
+  const storePrivacyInventory = readJson("apps/mobile/release/store-privacy-inventory.json");
 
   assert.equal(readiness.schemaVersion, 1);
   assert.equal(readiness.applicationId, "easysubway");
@@ -7370,6 +7371,63 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
     "encryptedInTransit",
     "deletionSupported",
   ]);
+  const inventoryDataTypesById = new Map(storePrivacyInventory.dataTypes.map((item) => [item.id, item]));
+  const expectedPlayDataTypes = [
+    ...new Set(storePrivacyInventory.dataTypes.map((item) => item.googlePlayDataSafety.dataType)),
+  ].sort();
+  assert.deepEqual(playStoreContent.dataSafetyDeclarations.requiredCollectedDataTypes.toSorted(), expectedPlayDataTypes);
+  const dataSafetyAnswerMatrix = new Map(
+    playStoreContent.dataSafetyDeclarations.answerMatrix.map((item) => [item.dataType, item]),
+  );
+  assert.deepEqual([...dataSafetyAnswerMatrix.keys()].sort(), expectedPlayDataTypes);
+  for (const dataType of expectedPlayDataTypes) {
+    const matrix = dataSafetyAnswerMatrix.get(dataType);
+    assert.ok(Array.isArray(matrix.inventoryDataIds), `${dataType} matrix must list inventory IDs`);
+    assert.ok(matrix.inventoryDataIds.length > 0, `${dataType} matrix must include at least one inventory ID`);
+    assert.deepEqual(
+      matrix.requiredConsoleFields,
+      playStoreContent.dataSafetyDeclarations.requiredFieldsPerDataType,
+      `${dataType} matrix must require every Play Console field`,
+    );
+    assert.ok(
+      matrix.evidenceSummaryFields.includes("consolePreviewEvidence"),
+      `${dataType} matrix must require Console preview evidence`,
+    );
+    assert.ok(
+      matrix.evidenceSummaryFields.includes("networkTraceMatchResult"),
+      `${dataType} matrix must require network trace matching result`,
+    );
+    assert.ok(
+      matrix.evidenceSummaryFields.includes("localEvidencePath"),
+      `${dataType} matrix must require local-only evidence path`,
+    );
+    for (const inventoryId of matrix.inventoryDataIds) {
+      const inventoryItem = inventoryDataTypesById.get(inventoryId);
+      assert.ok(inventoryItem, `${dataType} matrix references unknown inventory item: ${inventoryId}`);
+      assert.equal(
+        inventoryItem.googlePlayDataSafety.dataType,
+        dataType,
+        `${inventoryId} must map back to the same Play data type`,
+      );
+    }
+    const matrixItems = matrix.inventoryDataIds.map((id) => inventoryDataTypesById.get(id));
+    assert.equal(
+      matrix.containsCollectedData,
+      matrixItems.some((item) => item.googlePlayDataSafety.collected),
+      `${dataType} matrix collected flag must match inventory`,
+    );
+    assert.equal(
+      matrix.containsRequiredData,
+      matrixItems.some((item) => item.googlePlayDataSafety.required),
+      `${dataType} matrix required flag must match inventory`,
+    );
+    assert.equal(
+      matrix.containsOptionalData,
+      matrixItems.some((item) => item.googlePlayDataSafety.optional),
+      `${dataType} matrix optional flag must match inventory`,
+    );
+  }
+  assert.equal(dataSafetyAnswerMatrix.get("Diagnostics").containsLocalOnlyDiagnostics, true);
   assert.equal(playStoreContent.privacyPolicyRequirements.urlMustBePublicHttps, true);
   assert.equal(playStoreContent.privacyPolicyRequirements.urlMustBeUnauthenticated, true);
   assert.deepEqual(playStoreContent.privacyPolicyRequirements.sameUrlRequiredIn, [
@@ -7388,6 +7446,47 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
   assert.ok(playStoreContent.crashAnrProviderDecision.sourceOfTruth.includes("Android vitals"));
   assert.ok(playStoreContent.crashAnrProviderDecision.sourceOfTruth.includes("Google Play pre-launch report"));
   assert.equal(playStoreContent.crashAnrProviderDecision.dependencyEvidenceRequired, "no-crash-sdk-dependency-scan");
+  assert.deepEqual(Object.keys(playStoreContent.evidenceSummarySchemas).sort(), [
+    "crashAnrPrivacySummary",
+    "dataSafetyConsoleSummary",
+    "mailboxReceiptSummary",
+    "networkTraceMatchSummary",
+    "privacyPolicyUrlSummary",
+    "storeScreenshotSummary",
+  ]);
+  for (const [schemaId, schema] of Object.entries(playStoreContent.evidenceSummarySchemas)) {
+    assert.ok(Array.isArray(schema.requiredFields), `${schemaId} must define required fields`);
+    assert.ok(schema.requiredFields.includes("localEvidencePath"), `${schemaId} must require local evidence path`);
+    assert.ok(schema.requiredFields.includes("result"), `${schemaId} must require an explicit result`);
+  }
+  assert.ok(
+    playStoreContent.evidenceSummarySchemas.dataSafetyConsoleSummary.requiredFields.includes("consolePreviewEvidence"),
+  );
+  assert.ok(
+    playStoreContent.evidenceSummarySchemas.dataSafetyConsoleSummary.requiredFields.includes("networkTraceMatchResult"),
+  );
+  assert.ok(
+    playStoreContent.evidenceSummarySchemas.privacyPolicyUrlSummary.requiredFields.includes("sameUrlResult"),
+  );
+  assert.ok(
+    playStoreContent.evidenceSummarySchemas.mailboxReceiptSummary.requiredFields.includes("redactionResult"),
+  );
+  assert.ok(
+    playStoreContent.evidenceSummarySchemas.storeScreenshotSummary.requiredFields.includes("forbiddenClaimsAbsent"),
+  );
+  assert.ok(
+    playStoreContent.evidenceSummarySchemas.crashAnrPrivacySummary.requiredFields.includes("forbiddenPayloadAbsent"),
+  );
+  assert.ok(
+    playStoreContent.evidenceSummarySchemas.networkTraceMatchSummary.requiredFields.includes("undeclaredDataTransferCount"),
+  );
+  assert.deepEqual(playStoreContent.forbiddenEvidenceSummaryValues, [
+    "TBD",
+    "TODO",
+    "unknown",
+    "not checked",
+    "not captured",
+  ]);
   assert.ok(items.get("appstore_app_privacy").linkedArtifacts.includes("apps/mobile/ios/Runner/PrivacyInfo.xcprivacy"));
   assert.match(items.get("appstore_review_notes_or_demo_access").readyWhenKo, /심사 메모|데모|로그인 없음/);
   assert.match(items.get("appstore_backend_api_availability").readyWhenKo, /심사 기간|API/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7375,6 +7375,12 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
   const expectedPlayDataTypes = [
     ...new Set(storePrivacyInventory.dataTypes.map((item) => item.googlePlayDataSafety.dataType)),
   ].sort();
+  const expectedInventoryIdsByDataType = new Map();
+  for (const item of storePrivacyInventory.dataTypes) {
+    const dataType = item.googlePlayDataSafety.dataType;
+    const existingIds = expectedInventoryIdsByDataType.get(dataType) ?? [];
+    expectedInventoryIdsByDataType.set(dataType, [...existingIds, item.id]);
+  }
   assert.deepEqual(playStoreContent.dataSafetyDeclarations.requiredCollectedDataTypes.toSorted(), expectedPlayDataTypes);
   const dataSafetyAnswerMatrix = new Map(
     playStoreContent.dataSafetyDeclarations.answerMatrix.map((item) => [item.dataType, item]),
@@ -7384,6 +7390,16 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
     const matrix = dataSafetyAnswerMatrix.get(dataType);
     assert.ok(Array.isArray(matrix.inventoryDataIds), `${dataType} matrix must list inventory IDs`);
     assert.ok(matrix.inventoryDataIds.length > 0, `${dataType} matrix must include at least one inventory ID`);
+    assert.equal(
+      new Set(matrix.inventoryDataIds).size,
+      matrix.inventoryDataIds.length,
+      `${dataType} matrix must not duplicate inventory IDs`,
+    );
+    assert.deepEqual(
+      matrix.inventoryDataIds.toSorted(),
+      expectedInventoryIdsByDataType.get(dataType).toSorted(),
+      `${dataType} matrix must cover every inventory ID for the Play data type`,
+    );
     assert.deepEqual(
       matrix.requiredConsoleFields,
       playStoreContent.dataSafetyDeclarations.requiredFieldsPerDataType,


### PR DESCRIPTION
## 관련 이슈

#1018

이 PR은 Google Play Console 실제 제출 증거를 수집하기 전, 제출 summary가 빠뜨리면 안 되는 필드와 privacy inventory 대조 계약을 보강한다. #1018은 실제 Console preview, mailbox 수신, RC/Play-installed screenshot, network trace 증거 수집 후 별도로 닫는다.

## 작업 배경

- QA 요청에 따라 Play Data Safety, 개인정보 URL, 삭제/support mailbox, screenshot, crash/ANR privacy, network trace 증거를 PR에 민감정보 없이 요약할 수 있는 기준이 필요하다.
- 기존 privacy inventory 검증은 데이터 타입 자체를 잘 고정하지만, Play 제출 summary가 inventory ID, Console preview, network trace match, local-only evidence 경로를 빠뜨리는 경우를 CI가 충분히 잡지 못했다.

## 작업 내용

- `play-store-submission-content.json`에 Data Safety answer matrix를 추가해 Play data type별 inventory ID, required/optional/collected 여부, Console 필수 필드, evidence summary 필드를 명시했다.
- Data Safety, privacy URL, mailbox receipt, screenshot, crash/ANR privacy, network trace summary 스키마를 추가했다.
- repository contract 테스트가 Play 제출 content와 `store-privacy-inventory.json`의 data type, inventory ID, collected/required/optional 플래그 정합성을 검증하도록 보강했다.

## 검증

- 실행한 명령과 결과:
- `node -e 'JSON.parse(require("fs").readFileSync("apps/mobile/release/play-store-submission-content.json", "utf8")); console.log("play store submission json ok")'`: exit 0, JSON parse 성공
- `node --test --test-name-pattern "모바일 스토어 심사 정보 기준선" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
- `node --test tools/ci/*.test.mjs`: exit 0, 121 tests passed
- `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Play 제출 content JSON | local | JSON parse | `play store submission json ok` command output | 통과 |
| Play/Data Safety 계약 | local | targeted repository contract | `node --test --test-name-pattern "모바일 스토어 심사 정보 기준선" tools/ci/repository-contract.test.mjs` output, 1 passed | 통과 |
| 전체 repository contract | local | repository contract 전체 실행 | `node --test tools/ci/*.test.mjs` output, 121 passed | 통과 |
| 시각 증거 | 해당 없음 | JSON/test 계약만 변경 | 증거 불필요 사유: 앱 UI, Play Console 화면, 스크린샷 asset을 변경하지 않았다. 실제 Console/screenshot 증거 수집은 #1018 잔여 작업이다. | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `answerMatrix`가 `store-privacy-inventory.json`의 Play data type과 정확히 대응하는지 확인하면 된다.
- 이 PR은 실제 Data Safety 답변 제출, Play Console preview 캡처, mailbox receipt, network trace 수집을 완료했다고 주장하지 않는다.

## 리스크

- 계약 보강만 포함하므로 런타임 영향은 없다.
- Play Console 실제 UI 항목명이 바뀌면 #1018 증거 수집 시 summary 필드명을 조정해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
