### PR TITLE
[Test] Android 품질 증거 계약 보강

### DIFF
--- a/apps/mobile/release/android-release-quality-gate.json
+++ b/apps/mobile/release/android-release-quality-gate.json
@@ -45,13 +45,21 @@
     "requiredDeviceDiscoveryCommands": [
       "flutter emulators",
       "emulator -list-avds",
+      "ANDROID_HOME or ANDROID_SDK_ROOT emulator path check",
       "flutter devices",
       "adb devices"
     ],
     "emptyAdbDevicesDisposition": "INSUFFICIENT_EVIDENCE"
   },
   "manualEvidenceSummaryPolicy": {
-    "requiredFields": [
+    "commonRequiredFields": [
+      "checkId",
+      "buildIdentity",
+      "evidencePaths",
+      "result",
+      "blockerDisposition"
+    ],
+    "allowedFields": [
       "checkId",
       "buildIdentity",
       "buildSource",

--- a/apps/mobile/release/android-release-quality-gate.json
+++ b/apps/mobile/release/android-release-quality-gate.json
@@ -41,7 +41,34 @@
     "releaseRcEvidence": "play_installed_or_exact_rc_required_before_go",
     "minimumAndroidApi": 35,
     "fontScales": [1.5, 2.0],
-    "smallScreenViewport": "compact_phone_portrait"
+    "smallScreenViewport": "compact_phone_portrait",
+    "requiredDeviceDiscoveryCommands": [
+      "flutter emulators",
+      "emulator -list-avds",
+      "flutter devices",
+      "adb devices"
+    ],
+    "emptyAdbDevicesDisposition": "INSUFFICIENT_EVIDENCE"
+  },
+  "manualEvidenceSummaryPolicy": {
+    "requiredFields": [
+      "checkId",
+      "buildIdentity",
+      "buildSource",
+      "deviceId",
+      "androidApi",
+      "fontScale",
+      "viewport",
+      "evidencePaths",
+      "uiTreePath",
+      "screenshotOrRecordingPath",
+      "logcatSummaryPath",
+      "result",
+      "blockerDisposition"
+    ],
+    "requiredResultValues": ["PASS", "FAIL", "BLOCKED_EXTERNAL", "NOT_APPLICABLE_WITH_REASON"],
+    "forbiddenSummaryValues": ["TBD", "TODO", "unknown", "not checked", "not captured"],
+    "summaryRequiredKo": "PR에는 checkId, build identity, device 조건, evidence path, 결과, blocker 판단을 민감정보 없이 요약하고 실제 파일은 local-only evidence root에 둔다."
   },
   "requiredChecks": [
     {
@@ -165,6 +192,58 @@
       "id": "data_baseline_source_realtime_scope",
       "evidence": ["screenshot", "ui-tree"],
       "provesKo": "데이터 기준일, 출처, 실시간 범위가 앱과 Play listing copy에 모순되지 않는다."
+    }
+  ],
+  "checkEvidenceMatrix": [
+    {
+      "checkId": "route_safety_status_copy",
+      "requiredEvidenceIds": ["route_result_found_unknown_unavailable"],
+      "requiredSummaryFields": ["checkId", "buildIdentity", "evidencePaths", "uiTreePath", "screenshotOrRecordingPath", "result", "blockerDisposition"]
+    },
+    {
+      "checkId": "talkback_primary_journey",
+      "requiredEvidenceIds": ["home_support_scope", "station_search", "route_result_found_unknown_unavailable", "facility_report_recovery", "help_privacy_data_deletion"],
+      "requiredSummaryFields": ["checkId", "buildIdentity", "deviceId", "androidApi", "evidencePaths", "uiTreePath", "screenshotOrRecordingPath", "result", "blockerDisposition"]
+    },
+    {
+      "checkId": "font_scale_150_200_small_screen",
+      "requiredEvidenceIds": ["home_support_scope", "station_search", "route_result_found_unknown_unavailable", "facility_report_recovery", "help_privacy_data_deletion"],
+      "requiredSummaryFields": ["checkId", "buildIdentity", "deviceId", "androidApi", "fontScale", "viewport", "evidencePaths", "uiTreePath", "screenshotOrRecordingPath", "result", "blockerDisposition"]
+    },
+    {
+      "checkId": "high_contrast_state_visibility",
+      "requiredEvidenceIds": ["station_detail_facility_status", "route_result_found_unknown_unavailable", "facility_report_recovery"],
+      "requiredSummaryFields": ["checkId", "buildIdentity", "deviceId", "evidencePaths", "uiTreePath", "screenshotOrRecordingPath", "result", "blockerDisposition"]
+    },
+    {
+      "checkId": "location_permission_denied_recovery",
+      "requiredEvidenceIds": ["station_search", "route_result_found_unknown_unavailable"],
+      "requiredSummaryFields": ["checkId", "buildIdentity", "deviceId", "evidencePaths", "uiTreePath", "screenshotOrRecordingPath", "logcatSummaryPath", "result", "blockerDisposition"]
+    },
+    {
+      "checkId": "network_server_upload_error_recovery",
+      "requiredEvidenceIds": ["station_search", "route_result_found_unknown_unavailable", "facility_report_recovery"],
+      "requiredSummaryFields": ["checkId", "buildIdentity", "deviceId", "evidencePaths", "uiTreePath", "screenshotOrRecordingPath", "logcatSummaryPath", "result", "blockerDisposition"]
+    },
+    {
+      "checkId": "route_map_fallback_zoom_help",
+      "requiredEvidenceIds": ["route_map_fallback"],
+      "requiredSummaryFields": ["checkId", "buildIdentity", "deviceId", "evidencePaths", "uiTreePath", "screenshotOrRecordingPath", "result", "blockerDisposition"]
+    },
+    {
+      "checkId": "route_map_performance_budget",
+      "requiredEvidenceIds": ["route_map_fallback"],
+      "requiredSummaryFields": ["checkId", "buildIdentity", "buildSource", "deviceId", "evidencePaths", "logcatSummaryPath", "result", "blockerDisposition"]
+    },
+    {
+      "checkId": "scope_source_realtime_support_ui",
+      "requiredEvidenceIds": ["home_support_scope", "data_baseline_source_realtime_scope"],
+      "requiredSummaryFields": ["checkId", "buildIdentity", "evidencePaths", "uiTreePath", "screenshotOrRecordingPath", "result", "blockerDisposition"]
+    },
+    {
+      "checkId": "crash_anr_privacy_safe_reporting",
+      "requiredEvidenceIds": ["facility_report_recovery", "help_privacy_data_deletion"],
+      "requiredSummaryFields": ["checkId", "buildIdentity", "buildSource", "deviceId", "evidencePaths", "logcatSummaryPath", "result", "blockerDisposition"]
     }
   ],
   "evidencePolicy": {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7163,7 +7163,47 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
   assert.equal(gate.deviceEvidencePolicy.codexQaDevice, "local_android_emulator_only");
   assert.equal(gate.deviceEvidencePolicy.physicalDeviceEvidence, "not_used_for_codex_pr_evidence");
   assert.equal(gate.deviceEvidencePolicy.releaseRcEvidence, "play_installed_or_exact_rc_required_before_go");
+  assert.deepEqual(gate.deviceEvidencePolicy.requiredDeviceDiscoveryCommands, [
+    "flutter emulators",
+    "emulator -list-avds",
+    "flutter devices",
+    "adb devices",
+  ]);
+  assert.equal(gate.deviceEvidencePolicy.emptyAdbDevicesDisposition, "INSUFFICIENT_EVIDENCE");
   assert.equal(gate.evidencePolicy.localOnlyEvidenceRoot, ".codex/evidence/release/android-quality/<rc-or-run>/");
+  assert.deepEqual(gate.manualEvidenceSummaryPolicy.requiredResultValues, [
+    "PASS",
+    "FAIL",
+    "BLOCKED_EXTERNAL",
+    "NOT_APPLICABLE_WITH_REASON",
+  ]);
+  for (const field of [
+    "checkId",
+    "buildIdentity",
+    "buildSource",
+    "deviceId",
+    "androidApi",
+    "fontScale",
+    "viewport",
+    "evidencePaths",
+    "uiTreePath",
+    "screenshotOrRecordingPath",
+    "logcatSummaryPath",
+    "result",
+    "blockerDisposition",
+  ]) {
+    assert.ok(
+      gate.manualEvidenceSummaryPolicy.requiredFields.includes(field),
+      `manual evidence summary must require ${field}`,
+    );
+  }
+  assert.deepEqual(gate.manualEvidenceSummaryPolicy.forbiddenSummaryValues, [
+    "TBD",
+    "TODO",
+    "unknown",
+    "not checked",
+    "not captured",
+  ]);
 
   const requiredChecks = new Map(gate.requiredChecks.map((check) => [check.id, check]));
   for (const id of [
@@ -7228,6 +7268,48 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
   }
   assert.ok(evidenceSet.get("route_map_fallback").evidence.includes("performance-summary"));
   assert.ok(evidenceSet.get("facility_report_recovery").evidence.includes("logcat-summary"));
+
+  const checkEvidenceMatrix = new Map(gate.checkEvidenceMatrix.map((item) => [item.checkId, item]));
+  assert.deepEqual([...checkEvidenceMatrix.keys()].sort(), [...requiredChecks.keys()].sort());
+  const requiredEvidenceIds = new Set(evidenceSet.keys());
+  for (const [checkId, matrix] of checkEvidenceMatrix) {
+    assert.ok(requiredChecks.has(checkId), `${checkId} matrix must reference a required check`);
+    assert.ok(Array.isArray(matrix.requiredEvidenceIds), `${checkId} matrix must list evidence IDs`);
+    assert.ok(matrix.requiredEvidenceIds.length > 0, `${checkId} matrix must require evidence IDs`);
+    assert.equal(
+      new Set(matrix.requiredEvidenceIds).size,
+      matrix.requiredEvidenceIds.length,
+      `${checkId} matrix must not duplicate evidence IDs`,
+    );
+    for (const evidenceId of matrix.requiredEvidenceIds) {
+      assert.ok(requiredEvidenceIds.has(evidenceId), `${checkId} matrix references unknown evidence ID: ${evidenceId}`);
+    }
+    for (const field of [
+      "checkId",
+      "buildIdentity",
+      "evidencePaths",
+      "result",
+      "blockerDisposition",
+    ]) {
+      assert.ok(matrix.requiredSummaryFields.includes(field), `${checkId} matrix must require summary field ${field}`);
+    }
+  }
+  assert.ok(
+    checkEvidenceMatrix.get("font_scale_150_200_small_screen").requiredSummaryFields.includes("fontScale"),
+    "font scale check must record the Android font scale",
+  );
+  assert.ok(
+    checkEvidenceMatrix.get("font_scale_150_200_small_screen").requiredSummaryFields.includes("viewport"),
+    "font scale check must record the viewport",
+  );
+  assert.ok(
+    checkEvidenceMatrix.get("route_map_performance_budget").requiredSummaryFields.includes("buildSource"),
+    "performance check must record RC or Play-installed build source",
+  );
+  assert.ok(
+    checkEvidenceMatrix.get("crash_anr_privacy_safe_reporting").requiredSummaryFields.includes("logcatSummaryPath"),
+    "crash/ANR privacy check must record logcat or crash summary path",
+  );
 
   assert.ok(androidRcEvidence.requiredEvidence.androidAccessibilityQa.includes("android-release-quality-gate-manifest"));
   assert.ok(androidRcEvidence.requiredEvidence.androidAccessibilityQa.includes("local-emulator-ui-tree-screenshots"));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7166,11 +7166,23 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
   assert.deepEqual(gate.deviceEvidencePolicy.requiredDeviceDiscoveryCommands, [
     "flutter emulators",
     "emulator -list-avds",
+    "ANDROID_HOME or ANDROID_SDK_ROOT emulator path check",
     "flutter devices",
     "adb devices",
   ]);
   assert.equal(gate.deviceEvidencePolicy.emptyAdbDevicesDisposition, "INSUFFICIENT_EVIDENCE");
   assert.equal(gate.evidencePolicy.localOnlyEvidenceRoot, ".codex/evidence/release/android-quality/<rc-or-run>/");
+  assert.match(
+    gate.deviceEvidencePolicy.requiredDeviceDiscoveryCommands.join("\n"),
+    /ANDROID_HOME|ANDROID_SDK_ROOT/,
+  );
+  assert.deepEqual(gate.manualEvidenceSummaryPolicy.commonRequiredFields, [
+    "checkId",
+    "buildIdentity",
+    "evidencePaths",
+    "result",
+    "blockerDisposition",
+  ]);
   assert.deepEqual(gate.manualEvidenceSummaryPolicy.requiredResultValues, [
     "PASS",
     "FAIL",
@@ -7193,8 +7205,8 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
     "blockerDisposition",
   ]) {
     assert.ok(
-      gate.manualEvidenceSummaryPolicy.requiredFields.includes(field),
-      `manual evidence summary must require ${field}`,
+      gate.manualEvidenceSummaryPolicy.allowedFields.includes(field),
+      `manual evidence summary must allow ${field}`,
     );
   }
   assert.deepEqual(gate.manualEvidenceSummaryPolicy.forbiddenSummaryValues, [
@@ -7292,6 +7304,12 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
       "blockerDisposition",
     ]) {
       assert.ok(matrix.requiredSummaryFields.includes(field), `${checkId} matrix must require summary field ${field}`);
+    }
+    for (const field of matrix.requiredSummaryFields) {
+      assert.ok(
+        gate.manualEvidenceSummaryPolicy.allowedFields.includes(field),
+        `${checkId} matrix summary field must be in allowed vocabulary: ${field}`,
+      );
     }
   }
   assert.ok(


### PR DESCRIPTION
## 관련 이슈

AquilaXk/easysubway-mobile#9

이 PR은 Android 출시 UX·접근성·성능 수동 QA를 실행하기 전, PR에 남길 evidence summary와 check별 evidence 연결을 보강한다. 실제 TalkBack, font scale, compact screen, route map performance, permission/error recovery 증거 수집 후 #1021을 닫는다.

## 작업 배경

- QA 요청에 따라 Android release quality evidence는 로컬 emulator 또는 Play-installed build 증거를 민감정보 없이 요약해야 한다.
- 기존 gate는 필수 check와 화면 evidence set을 갖고 있었지만, 빈 `adb devices`만으로 증거 불가를 판단하지 않도록 하는 discovery 절차와 check별 summary 필드가 충분히 고정되어 있지 않았다.

## 작업 내용

- Android device discovery 명령 목록에 Flutter emulator, SDK emulator 경로, Flutter devices, adb devices 확인을 포함하고 빈 `adb devices` 결과의 판정을 `INSUFFICIENT_EVIDENCE`로 고정했다.
- manual evidence summary 공통 필드, 허용 필드 vocabulary, 허용 결과값, 금지 placeholder 값을 추가했다.
- required check별로 연결해야 하는 evidence screen set과 summary 필드를 `checkEvidenceMatrix`로 명시했다.
- repository contract가 check/evidence matrix의 누락, 중복, 알 수 없는 evidence ID, 필수 summary field 누락을 검증하도록 보강했다.

## 검증

- 실행한 명령과 결과:
- `node -e 'JSON.parse(require("fs").readFileSync("apps/mobile/release/android-release-quality-gate.json", "utf8")); console.log("android release quality gate json ok")'`: exit 0, JSON parse 성공
- `node --test --test-name-pattern "Android 출시 UX 접근성 성능 gate" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
- `node --test tools/ci/*.test.mjs`: exit 0, 121 tests passed
- `git diff --check`: exit 0
- GitHub PR checks: Android CI, Backend CI, Mobile App CI, Repository CI, Release Gate Consistency, Dependency Vulnerability Scan, Android Release Artifact, Backend Release Image, RC Evidence Manifest, SonarCloud Code Analysis 통과
- CodeRabbit: rate limit으로 실제 리뷰가 시작되지 않아 Codex CLI fallback review를 게시했고, 최초 2건 지적은 `4e9de0ad`에서 수정 후 원래 inline thread에 해결 답글을 남겼다. re-review는 actionable 0건이다.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Android quality gate JSON | local | JSON parse | `android release quality gate json ok` command output | 통과 |
| Android QA 증거 계약 | local | targeted repository contract | `node --test --test-name-pattern "Android 출시 UX 접근성 성능 gate" tools/ci/repository-contract.test.mjs` output, 1 passed | 통과 |
| 전체 repository contract | local | repository contract 전체 실행 | `node --test tools/ci/*.test.mjs` output, 121 passed | 통과 |
| PR CI | GitHub Actions | PR AquilaXk/easysubway#1034 checks | CI run `28303274271`, Release Artifacts run `28303274170`, SonarCloud PR analysis | 통과 |
| Review gate | GitHub PR | CodeRabbit 상태와 Codex fallback review 확인 | CodeRabbit rate limit comment, Codex review `4586361587`, resolution replies `3486879379`/`3486879380`, re-review `4586372384` | 통과 |
| 시각/접근성 증거 | Android | 실제 UI는 변경하지 않고 evidence contract만 변경 | 증거 불필요 사유: 앱 화면, TalkBack 동작, route map rendering을 변경하지 않았다. 실제 screenshot/UI tree/logcat/perf evidence는 AquilaXk/easysubway-mobile#9 잔여 작업이다. | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `checkEvidenceMatrix`가 #1021의 TalkBack, large text, compact screen, route map, permission/error recovery, crash/ANR privacy 증거 요구를 빠짐없이 연결하는지 확인하면 된다.
- 이 PR은 실제 Android emulator 또는 Play-installed QA 증거 수집 완료를 주장하지 않는다.

## 리스크

- 계약 JSON과 repository contract만 변경하므로 앱 런타임 영향은 없다.
- 실제 emulator evidence 수집 시 추가 화면이나 상태가 필요하면 matrix에 evidence ID를 더 추가해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
