### PR TITLE
[Fix] RC manifest backend identity fallback 추가

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1664,6 +1664,41 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   assert.ok(manifest.evidenceEntries.every((entry) => entry.testedAt === "2026-06-26T00:00:00.000Z"));
   assert.ok(manifest.evidenceEntries.every((entry) => entry.expiresWhen === "2026-07-10T00:00:00.000Z"));
 
+  const localImageInspectPath = path.join(tempDir, "local-image-inspect.json");
+  const localImageManifestPath = path.join(tempDir, "local-image-rc-evidence-manifest.json");
+  await writeFile(
+    localImageInspectPath,
+    JSON.stringify([{ RepoDigests: [], Id: "sha256:2076c88dbc6590b239f6762e9c209d7ae189f2bc53725ca94d42c81c5d8e4521" }]),
+  );
+  await execFileAsync(process.execPath, [
+    "tools/release/generate-rc-evidence-manifest.mjs",
+    "--repo-root",
+    ".",
+    "--app-root",
+    "apps/mobile",
+    "--git-sha",
+    "0123456789abcdef0123456789abcdef01234567",
+    "--aab",
+    aabPath,
+    "--backend-image-inspect",
+    localImageInspectPath,
+    "--data-pack-manifest",
+    "apps/mobile/assets/datapacks/metro_map_pack/manifest.json",
+    "--output",
+    localImageManifestPath,
+    "--tested-at",
+    "2026-06-26T00:00:00.000Z",
+  ], { cwd: root });
+  const localImageManifest = JSON.parse(readFileSync(localImageManifestPath, "utf8"));
+  assert.equal(
+    localImageManifest.backendImageDigest,
+    "sha256:2076c88dbc6590b239f6762e9c209d7ae189f2bc53725ca94d42c81c5d8e4521",
+  );
+  assert.equal(localImageManifest.backendArtifactSha256, null);
+  assert.ok(
+    !localImageManifest.readiness.blockers.map((blocker) => blocker.id).includes("missing_backend_identity"),
+  );
+
   await assert.rejects(
     execFileAsync(process.execPath, [
       "tools/release/generate-rc-evidence-manifest.mjs",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile, execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -1697,6 +1698,37 @@ test("RC evidence manifest generator는 RC identity와 No-Go blocker를 생성�
   assert.equal(localImageManifest.backendArtifactSha256, null);
   assert.ok(
     !localImageManifest.readiness.blockers.map((blocker) => blocker.id).includes("missing_backend_identity"),
+  );
+
+  const metadataOnlyInspectPath = path.join(tempDir, "metadata-only-image-inspect.json");
+  const metadataOnlyManifestPath = path.join(tempDir, "metadata-only-rc-evidence-manifest.json");
+  const metadataOnlyInspect = JSON.stringify([{ RepoDigests: [], Size: 367184804 }]);
+  const metadataOnlyInspectSha256 = createHash("sha256").update(metadataOnlyInspect).digest("hex");
+  await writeFile(metadataOnlyInspectPath, metadataOnlyInspect);
+  await execFileAsync(process.execPath, [
+    "tools/release/generate-rc-evidence-manifest.mjs",
+    "--repo-root",
+    ".",
+    "--app-root",
+    "apps/mobile",
+    "--git-sha",
+    "0123456789abcdef0123456789abcdef01234567",
+    "--aab",
+    aabPath,
+    "--backend-image-inspect",
+    metadataOnlyInspectPath,
+    "--data-pack-manifest",
+    "apps/mobile/assets/datapacks/metro_map_pack/manifest.json",
+    "--output",
+    metadataOnlyManifestPath,
+    "--tested-at",
+    "2026-06-26T00:00:00.000Z",
+  ], { cwd: root });
+  const metadataOnlyManifest = JSON.parse(readFileSync(metadataOnlyManifestPath, "utf8"));
+  assert.equal(metadataOnlyManifest.backendImageDigest, null);
+  assert.equal(metadataOnlyManifest.backendArtifactSha256, metadataOnlyInspectSha256);
+  assert.ok(
+    !metadataOnlyManifest.readiness.blockers.map((blocker) => blocker.id).includes("missing_backend_identity"),
   );
 
   await assert.rejects(

--- a/tools/release/generate-rc-evidence-manifest.mjs
+++ b/tools/release/generate-rc-evidence-manifest.mjs
@@ -167,9 +167,12 @@ function readBackendIdentity(parsedArgs) {
   const inspect = JSON.parse(readFileSync(inspectPath, "utf8"));
   const firstImage = Array.isArray(inspect) ? inspect[0] : inspect;
   const repoDigest = firstImage?.RepoDigests?.find((digest) => digest.includes("@sha256:"));
+  const imageId = typeof firstImage?.Id === "string" && firstImage.Id.startsWith("sha256:")
+    ? firstImage.Id
+    : null;
   return {
-    backendImageDigest: repoDigest?.split("@").at(-1) ?? null,
-    backendArtifactSha256: null,
+    backendImageDigest: repoDigest?.split("@").at(-1) ?? imageId,
+    backendArtifactSha256: repoDigest || imageId ? null : sha256FileIfExists(inspectPath),
   };
 }
 


### PR DESCRIPTION
## 관련 이슈

#1020 부분 해결입니다. Play upload, Play-installed smoke, 최종 GO/NO-GO 판정이 아직 남아 있어 이 PR은 이슈를 닫지 않습니다.

## 작업 배경

Release Artifacts workflow run 28303519806의 RC evidence manifest가 backend artifact를 내려받았는데도 `missing_backend_identity` P0 blocker를 생성했습니다. backend `image-inspect.json`에는 `RepoDigests`가 비어 있고 Docker image `Id`만 있었기 때문에 generator가 backend identity를 읽지 못했습니다.

## 작업 내용

- RC evidence manifest generator가 backend image inspect의 identity를 `RepoDigests` 우선, 없으면 `Id` 순서로 읽도록 보강했습니다.
- `RepoDigests`와 `Id`가 모두 없을 때는 inspect artifact 파일 SHA-256을 `backendArtifactSha256`으로 남기도록 fallback을 추가했습니다.
- `RepoDigests=[]`인 local image inspect에서도 `missing_backend_identity` blocker가 생기지 않는 contract test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "RC evidence manifest generator" tools/ci/repository-contract.test.mjs`: 1 test passed, exit 0
  - `node tools/release/generate-rc-evidence-manifest.mjs --repo-root . --app-root apps/mobile --git-sha c05b8e8c6499f4cc420253f296695bd3f20aefff --aab .codex/evidence/release/play-production-access/28303519806/easysubway-android-production-rc-c05b8e8c6499f4cc420253f296695bd3f20aefff/app-release.aab --backend-image-inspect .codex/evidence/security/abuse-penetration-rehearsal/28303519806/backend-release/image-inspect.json --data-pack-manifest apps/mobile/assets/datapacks/metro_map_pack/manifest.json --output .codex/evidence/release/go-no-go/rc-manifest-backend-identity-check/rc-evidence-manifest.json --tested-at 2026-06-28T00:00:00.000Z --device local_android_emulator --android-version "Android 16 API 36" --gate-status androidRcEvidence=BLOCKED_EXTERNAL --gate-status playGeneratedApkDeviceMatrix=BLOCKED_EXTERNAL --gate-status androidReleaseQuality=BLOCKED_EXTERNAL --gate-status abusePenetrationRehearsal=BLOCKED_EXTERNAL`: exit 0
  - generated manifest check: `backendImageDigest=sha256:2076c88dbc6590b239f6762e9c209d7ae189f2bc53725ca94d42c81c5d8e4521`, `missing_backend_identity` blocker 없음
  - `node --test tools/ci/*.test.mjs`: 121 tests passed, exit 0
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| backend identity fallback | repository | `RepoDigests=[]`, `Id=sha256:...` fixture contract test | `node --test --test-name-pattern "RC evidence manifest generator" tools/ci/repository-contract.test.mjs` output | 통과 |
| 실제 RC artifact 재생성 | local-only release evidence | run 28303519806 AAB와 backend `image-inspect.json`으로 manifest 생성 | `.codex/evidence/release/go-no-go/rc-manifest-backend-identity-check/rc-evidence-manifest.json` | `missing_backend_identity` 제거, 다른 외부/증거 blocker는 유지 |
| repository contract | repository | 전체 contract test | `node --test tools/ci/*.test.mjs` output | 121 tests passed |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/release/generate-rc-evidence-manifest.mjs`의 backend identity fallback 순서입니다.
- 이 PR은 backend artifact identity 오탐만 수정합니다. Play Console API 활성화, Play-generated install, TalkBack/16 KB runtime smoke 등은 기존 이슈의 남은 blocker입니다.

## 리스크

- Docker `Id`는 registry `RepoDigest`와 의미가 다르지만, registry push 전 local backend artifact identity를 RC manifest에 고정하는 목적에는 더 낫습니다. registry digest가 생기면 기존처럼 `RepoDigests`를 우선 사용합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. CodeRabbit이 정상 완료되어 fallback은 실행하지 않았다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. PR release artifact workflow의 RC Evidence Manifest까지 통과했다.
