### PR TITLE
[Fix] Android 노선도 viewport 시각 렌더링 복구

### DIFF
--- a/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
@@ -85,12 +85,15 @@ final class RouteMapRendererHealthMonitor {
   RouteMapRendererHealthMonitor(
     this._controller, {
     this.blankTimeout = const Duration(milliseconds: 1500),
+    this.maxRecoveryAttempts = 2,
     this.onEvent,
     Timer Function(Duration duration, void Function() callback)? timerFactory,
-  }) : _timerFactory = timerFactory ?? Timer.new;
+  }) : assert(maxRecoveryAttempts > 0),
+       _timerFactory = timerFactory ?? Timer.new;
 
   final RouteMapRendererController _controller;
   final Duration blankTimeout;
+  final int maxRecoveryAttempts;
   final void Function(RouteMapRendererEvent event)? onEvent;
   final Timer Function(Duration duration, void Function() callback)
   _timerFactory;
@@ -203,6 +206,14 @@ final class RouteMapRendererHealthMonitor {
   void _recover({int? rewatchRevision}) {
     _clearPendingFrame();
     _retryWatchRevision = rewatchRevision;
+    if (_recoveryAttempt >= maxRecoveryAttempts) {
+      onEvent?.call(
+        RouteMapRendererFailed(
+          'renderer did not present a frame after $maxRecoveryAttempts recovery attempts',
+        ),
+      );
+      return;
+    }
     _recoveryAttempt += 1;
     onEvent?.call(RouteMapRendererRecovering(_recoveryAttempt));
     unawaited(

--- a/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
@@ -158,6 +158,7 @@ final class RouteMapRendererHealthMonitor {
       case RouteMapRendererFramePresented(:final revision):
         if (_pendingRevision != null && revision == _pendingRevision!) {
           _clearPendingFrame();
+          _recoveryAttempt = 0;
         }
       case RouteMapRendererProcessGone():
         _recover();

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1272,6 +1272,7 @@ class _AndroidRouteMapFallbackLayer extends StatelessWidget {
           data: data,
           geometry: geometry,
           camera: camera,
+          textScaler: MediaQuery.textScalerOf(context),
         ),
       ),
     );
@@ -1283,11 +1284,13 @@ class _AndroidRouteMapFallbackPainter extends CustomPainter {
     required this.data,
     required this.geometry,
     required this.camera,
+    required this.textScaler,
   });
 
   final NetworkMapData data;
   final _MapGeometry geometry;
   final MapCameraState camera;
+  final TextScaler textScaler;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -1350,9 +1353,9 @@ class _AndroidRouteMapFallbackPainter extends CustomPainter {
             !paintedSegments.add('${station.lineId}:$pathData')) {
           continue;
         }
-        final path = _pathFromSvg(pathData).shift(-geometry.origin);
-        if (path.getBounds().overlaps(visibleRect)) {
-          canvas.drawPath(path, paint);
+        final cachedPath = _cachedRouteMapPath(pathData, geometry.origin);
+        if (cachedPath.bounds.overlaps(visibleRect)) {
+          canvas.drawPath(cachedPath.path, paint);
         }
       }
     }
@@ -1387,6 +1390,7 @@ class _AndroidRouteMapFallbackPainter extends CustomPainter {
       final labelPainter = TextPainter(
         text: TextSpan(text: station.nameKo, style: labelStyle),
         textDirection: TextDirection.ltr,
+        textScaler: textScaler,
         maxLines: 1,
       )..layout();
       final labelTopLeft = camera.sourceToViewportPoint(center + labelOffset);
@@ -1406,10 +1410,119 @@ class _AndroidRouteMapFallbackPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant _AndroidRouteMapFallbackPainter oldDelegate) {
-    return oldDelegate.data != data ||
-        oldDelegate.geometry != geometry ||
-        oldDelegate.camera != camera;
+    return !_sameNetworkMapData(oldDelegate.data, data) ||
+        !_sameMapGeometry(oldDelegate.geometry, geometry) ||
+        !_sameMapCamera(oldDelegate.camera, camera) ||
+        oldDelegate.textScaler != textScaler;
   }
+}
+
+class _CachedRouteMapPath {
+  const _CachedRouteMapPath(this.path, this.bounds);
+
+  final Path path;
+  final Rect bounds;
+}
+
+final _routeMapPathCache = <String, _CachedRouteMapPath>{};
+
+_CachedRouteMapPath _cachedRouteMapPath(String pathData, Offset origin) {
+  final key = '${origin.dx}:${origin.dy}:$pathData';
+  return _routeMapPathCache.putIfAbsent(key, () {
+    final path = _pathFromSvg(pathData).shift(-origin);
+    return _CachedRouteMapPath(path, path.getBounds());
+  });
+}
+
+bool _sameMapCamera(MapCameraState a, MapCameraState b) {
+  return a.sourceBounds == b.sourceBounds &&
+      a.viewportSize == b.viewportSize &&
+      a.center == b.center &&
+      a.scale == b.scale &&
+      a.minScale == b.minScale &&
+      a.maxScale == b.maxScale &&
+      a.revision == b.revision;
+}
+
+bool _sameMapGeometry(_MapGeometry a, _MapGeometry b) {
+  return a.origin == b.origin &&
+      a.focus == b.focus &&
+      a.width == b.width &&
+      a.height == b.height &&
+      a.initialBounds == b.initialBounds &&
+      a.overlayStyleScale == b.overlayStyleScale;
+}
+
+bool _sameNetworkMapData(NetworkMapData a, NetworkMapData b) {
+  return a.selectedRegion == b.selectedRegion &&
+      _sameNetworkMapLines(a.lines, b.lines) &&
+      _sameNetworkMapStations(a.stations, b.stations) &&
+      _sameNetworkMapEdges(a.edges, b.edges);
+}
+
+bool _sameNetworkMapLines(List<NetworkMapLine> a, List<NetworkMapLine> b) {
+  if (a.length != b.length) {
+    return false;
+  }
+  for (var index = 0; index < a.length; index += 1) {
+    final left = a[index];
+    final right = b[index];
+    if (left.id != right.id ||
+        left.name != right.name ||
+        left.color != right.color ||
+        left.region != right.region) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool _sameNetworkMapStations(
+  List<NetworkMapStation> a,
+  List<NetworkMapStation> b,
+) {
+  if (a.length != b.length) {
+    return false;
+  }
+  for (var index = 0; index < a.length; index += 1) {
+    final left = a[index];
+    final right = b[index];
+    if (left.id != right.id ||
+        left.nameKo != right.nameKo ||
+        left.lineId != right.lineId ||
+        !_sameNetworkMapPosition(left.position, right.position)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool _sameNetworkMapPosition(NetworkMapPosition a, NetworkMapPosition b) {
+  return a.x == b.x &&
+      a.y == b.y &&
+      a.labelDx == b.labelDx &&
+      a.labelDy == b.labelDy &&
+      a.labelPolygon == b.labelPolygon &&
+      a.upPath == b.upPath &&
+      a.downPath == b.downPath &&
+      a.sourceId == b.sourceId;
+}
+
+bool _sameNetworkMapEdges(List<NetworkMapEdge> a, List<NetworkMapEdge> b) {
+  if (a.length != b.length) {
+    return false;
+  }
+  for (var index = 0; index < a.length; index += 1) {
+    final left = a[index];
+    final right = b[index];
+    if (left.id != right.id ||
+        left.lineId != right.lineId ||
+        left.fromStationId != right.fromStationId ||
+        left.toStationId != right.toStationId) {
+      return false;
+    }
+  }
+  return true;
 }
 
 class _RouteMapViewportRenderer extends StatelessWidget {
@@ -1808,7 +1921,7 @@ class _MapGeometry {
         if (pathData.isEmpty) {
           continue;
         }
-        final bounds = _pathFromSvg(pathData).getBounds();
+        final bounds = _cachedRouteMapPath(pathData, Offset.zero).bounds;
         minX = math.min(minX, bounds.left);
         minY = math.min(minY, bounds.top);
         maxX = math.max(maxX, bounds.right);
@@ -2359,7 +2472,7 @@ Offset _labelOffsetFor(NetworkMapStation station) {
   if (pathData.isEmpty) {
     return const Offset(8, 3);
   }
-  final bounds = _pathFromSvg(pathData).getBounds();
+  final bounds = _cachedRouteMapPath(pathData, Offset.zero).bounds;
   if (bounds.width > bounds.height * 1.2) {
     return const Offset(0, 12);
   }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -793,6 +793,12 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
               Positioned.fill(
                 child: mapAsset == null
                     ? const _OriginalRouteMapUnavailable()
+                    : defaultTargetPlatform == TargetPlatform.android
+                    ? _AndroidRouteMapFallbackLayer(
+                        data: widget.data,
+                        geometry: geometry,
+                        camera: camera,
+                      )
                     : _RouteMapViewportRenderer(
                         asset: mapAsset,
                         camera:
@@ -1243,6 +1249,165 @@ class _MapControlButton extends StatelessWidget {
         icon: Icon(icon),
       ),
     );
+  }
+}
+
+class _AndroidRouteMapFallbackLayer extends StatelessWidget {
+  const _AndroidRouteMapFallbackLayer({
+    required this.data,
+    required this.geometry,
+    required this.camera,
+  });
+
+  final NetworkMapData data;
+  final _MapGeometry geometry;
+  final MapCameraState camera;
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      child: CustomPaint(
+        painter: _AndroidRouteMapFallbackPainter(
+          data: data,
+          geometry: geometry,
+          camera: camera,
+        ),
+      ),
+    );
+  }
+}
+
+class _AndroidRouteMapFallbackPainter extends CustomPainter {
+  const _AndroidRouteMapFallbackPainter({
+    required this.data,
+    required this.geometry,
+    required this.camera,
+  });
+
+  final NetworkMapData data;
+  final _MapGeometry geometry;
+  final MapCameraState camera;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final lineById = {for (final line in data.lines) line.id: line};
+    final stationById = {
+      for (final station in data.stations) station.id: station,
+    };
+    final visibleStations = _visibleCanonicalStations(
+      geometry: geometry,
+      camera: camera,
+    );
+    final visibleRect = camera.visibleSourceRect.inflate(180 / camera.scale);
+    final paintedSegments = <String>{};
+
+    canvas.save();
+    canvas.transform(camera.sourceToViewport.storage);
+
+    for (final edge in data.edges) {
+      final fromStation = stationById[edge.fromStationId];
+      final toStation = stationById[edge.toStationId];
+      if (fromStation == null || toStation == null) {
+        continue;
+      }
+      final from = Offset(geometry.x(fromStation), geometry.y(fromStation));
+      final to = Offset(geometry.x(toStation), geometry.y(toStation));
+      if (!Rect.fromPoints(from, to).inflate(24).overlaps(visibleRect)) {
+        continue;
+      }
+      final line = lineById[edge.lineId];
+      final paint = Paint()
+        ..color = line == null
+            ? EasySubwayAccessibleColors.line
+            : _colorFromHex(line.color)
+        ..style = PaintingStyle.stroke
+        ..strokeCap = StrokeCap.round
+        ..strokeJoin = StrokeJoin.round
+        ..strokeWidth = 7 / camera.scale;
+      canvas.drawLine(from, to, paint);
+    }
+
+    for (final station in data.stations) {
+      if (!_stationHitRect(station, geometry).overlaps(visibleRect)) {
+        continue;
+      }
+      final line = lineById[station.lineId];
+      final color = line == null
+          ? EasySubwayAccessibleColors.line
+          : _colorFromHex(line.color);
+      final paint = Paint()
+        ..color = color
+        ..style = PaintingStyle.stroke
+        ..strokeCap = StrokeCap.round
+        ..strokeJoin = StrokeJoin.round
+        ..strokeWidth = 7 / camera.scale;
+      for (final pathData in [
+        station.position.upPath,
+        station.position.downPath,
+      ]) {
+        if (pathData.isEmpty ||
+            !paintedSegments.add('${station.lineId}:$pathData')) {
+          continue;
+        }
+        final path = _pathFromSvg(pathData).shift(-geometry.origin);
+        if (path.getBounds().overlaps(visibleRect)) {
+          canvas.drawPath(path, paint);
+        }
+      }
+    }
+
+    final nodeStroke = Paint()
+      ..color = const Color(0xFF2F3E42)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2 / camera.scale;
+    final nodeFill = Paint()
+      ..color = Colors.white
+      ..style = PaintingStyle.fill;
+    for (final station in visibleStations) {
+      final center = Offset(geometry.x(station), geometry.y(station));
+      final nodeRadius = 5 / camera.scale;
+      canvas.drawCircle(center, nodeRadius, nodeFill);
+      canvas.drawCircle(center, nodeRadius, nodeStroke);
+    }
+    canvas.restore();
+
+    final labelStyle = const TextStyle(
+      color: Color(0xFF102A2C),
+      fontSize: 16,
+      fontWeight: FontWeight.w800,
+    );
+    final labelBackground = Paint()
+      ..color = Colors.white.withValues(alpha: 0.82)
+      ..style = PaintingStyle.fill;
+    final occupiedLabels = <Rect>[];
+    for (final station in visibleStations) {
+      final center = Offset(geometry.x(station), geometry.y(station));
+      final labelOffset = _labelOffsetFor(station);
+      final labelPainter = TextPainter(
+        text: TextSpan(text: station.nameKo, style: labelStyle),
+        textDirection: TextDirection.ltr,
+        maxLines: 1,
+      )..layout();
+      final labelTopLeft = camera.sourceToViewportPoint(center + labelOffset);
+      final labelRect = labelTopLeft & labelPainter.size;
+      final paddedRect = labelRect.inflate(3);
+      if (occupiedLabels.any((existing) => existing.overlaps(paddedRect))) {
+        continue;
+      }
+      occupiedLabels.add(paddedRect);
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(paddedRect, const Radius.circular(3)),
+        labelBackground,
+      );
+      labelPainter.paint(canvas, labelTopLeft);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _AndroidRouteMapFallbackPainter oldDelegate) {
+    return oldDelegate.data != data ||
+        oldDelegate.geometry != geometry ||
+        oldDelegate.camera != camera;
   }
 }
 

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1266,6 +1266,7 @@ class _AndroidRouteMapFallbackLayer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return RepaintBoundary(
+      key: const Key('routeMapViewportRenderer'),
       child: CustomPaint(
         painter: _AndroidRouteMapFallbackPainter(
           data: data,

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -671,6 +671,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   MapCameraState? _presentedRendererCamera;
   final _requestedRendererCamerasByRevision = <int, MapCameraState>{};
   bool _routeMapRendererActive = false;
+  bool _routeMapFallbackActive = false;
   DateTime? _lastRendererCameraRequestAt;
   bool _cameraFrameCallbackScheduled = false;
   bool _forceRendererCameraCommit = false;
@@ -758,18 +759,16 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
             geometry.height,
           );
           final minScale = _minimumMapScaleForBounds(fullBounds, constraints);
-          final routeMapRendererActive =
-              mapAsset != null &&
-              defaultTargetPlatform != TargetPlatform.android;
           final layoutKey =
-              '${widget.data.selectedRegion}:${geometry.width}:${geometry.height}:${constraints.maxWidth}:${constraints.maxHeight}:$routeMapRendererActive';
+              '${widget.data.selectedRegion}:${geometry.width}:${geometry.height}:${constraints.maxWidth}:${constraints.maxHeight}';
           if (_layoutKey != layoutKey) {
             _layoutKey = layoutKey;
             _pendingCamera = null;
             _requestedRendererCamera = null;
             _presentedRendererCamera = null;
             _requestedRendererCamerasByRevision.clear();
-            _routeMapRendererActive = routeMapRendererActive;
+            _routeMapFallbackActive = false;
+            _routeMapRendererActive = mapAsset != null;
             _lastRendererCameraRequestAt = null;
             _gestureActive = false;
             final initialCamera = _cameraForBounds(
@@ -782,7 +781,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
               initialCamera,
             );
             _camera = initialCamera;
-            if (routeMapRendererActive) {
+            if (_routeMapRendererActive) {
               _requestedRendererCamera = initialRendererCamera;
               _presentedRendererCamera = initialRendererCamera;
             }
@@ -800,7 +799,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
               Positioned.fill(
                 child: mapAsset == null
                     ? const _OriginalRouteMapUnavailable()
-                    : defaultTargetPlatform == TargetPlatform.android
+                    : _routeMapFallbackActive
                     ? _AndroidRouteMapFallbackLayer(
                         data: widget.data,
                         geometry: geometry,
@@ -1137,6 +1136,9 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
     if (event is RouteMapRendererFramePresented) {
       _markRendererFramePresented(event.revision);
     }
+    if (event is RouteMapRendererFailed) {
+      _activateRouteMapFallback();
+    }
     if (!kDebugMode && !kProfileMode) {
       return;
     }
@@ -1188,6 +1190,28 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
     }
     setState(() {
       _presentedRendererCamera = camera;
+    });
+  }
+
+  void _activateRouteMapFallback() {
+    if (_routeMapFallbackActive) {
+      return;
+    }
+    _releaseRenderer(disposeRenderer: true);
+    if (!mounted) {
+      _routeMapFallbackActive = true;
+      _routeMapRendererActive = false;
+      _requestedRendererCamera = null;
+      _presentedRendererCamera = null;
+      _requestedRendererCamerasByRevision.clear();
+      return;
+    }
+    setState(() {
+      _routeMapFallbackActive = true;
+      _routeMapRendererActive = false;
+      _requestedRendererCamera = null;
+      _presentedRendererCamera = null;
+      _requestedRendererCamerasByRevision.clear();
     });
   }
 }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1423,7 +1423,8 @@ class _AndroidRouteMapFallbackPainter extends CustomPainter {
         textScaler: textScaler,
         maxLines: 1,
       )..layout();
-      final labelTopLeft = camera.sourceToViewportPoint(center + labelOffset);
+      final labelCenter = camera.sourceToViewportPoint(center + labelOffset);
+      final labelTopLeft = labelCenter - labelPainter.size.center(Offset.zero);
       final labelRect = labelTopLeft & labelPainter.size;
       final paddedRect = labelRect.inflate(3);
       if (occupiedLabels.any((existing) => existing.overlaps(paddedRect))) {

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -670,6 +670,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
   MapCameraState? _requestedRendererCamera;
   MapCameraState? _presentedRendererCamera;
   final _requestedRendererCamerasByRevision = <int, MapCameraState>{};
+  bool _routeMapRendererActive = false;
   DateTime? _lastRendererCameraRequestAt;
   bool _cameraFrameCallbackScheduled = false;
   bool _forceRendererCameraCommit = false;
@@ -757,14 +758,18 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
             geometry.height,
           );
           final minScale = _minimumMapScaleForBounds(fullBounds, constraints);
+          final routeMapRendererActive =
+              mapAsset != null &&
+              defaultTargetPlatform != TargetPlatform.android;
           final layoutKey =
-              '${widget.data.selectedRegion}:${geometry.width}:${geometry.height}:${constraints.maxWidth}:${constraints.maxHeight}';
+              '${widget.data.selectedRegion}:${geometry.width}:${geometry.height}:${constraints.maxWidth}:${constraints.maxHeight}:$routeMapRendererActive';
           if (_layoutKey != layoutKey) {
             _layoutKey = layoutKey;
             _pendingCamera = null;
             _requestedRendererCamera = null;
             _presentedRendererCamera = null;
             _requestedRendererCamerasByRevision.clear();
+            _routeMapRendererActive = routeMapRendererActive;
             _lastRendererCameraRequestAt = null;
             _gestureActive = false;
             final initialCamera = _cameraForBounds(
@@ -777,8 +782,10 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
               initialCamera,
             );
             _camera = initialCamera;
-            _requestedRendererCamera = initialRendererCamera;
-            _presentedRendererCamera = initialRendererCamera;
+            if (routeMapRendererActive) {
+              _requestedRendererCamera = initialRendererCamera;
+              _presentedRendererCamera = initialRendererCamera;
+            }
           }
           final camera =
               _camera ??
@@ -1012,6 +1019,15 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
       _pendingCamera = null;
       _forceRendererCameraCommit = false;
       if (!mounted || pendingCamera == null) {
+        return;
+      }
+      if (!_routeMapRendererActive) {
+        setState(() {
+          _camera = pendingCamera;
+          _requestedRendererCamera = null;
+          _presentedRendererCamera = null;
+          _requestedRendererCamerasByRevision.clear();
+        });
         return;
       }
       final rendererCamera = _requestedRendererCameraFor(
@@ -1295,9 +1311,13 @@ class _AndroidRouteMapFallbackPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final lineById = {for (final line in data.lines) line.id: line};
-    final stationById = {
-      for (final station in data.stations) station.id: station,
-    };
+    final stationsById = <String, List<NetworkMapStation>>{};
+    final stationByLineKey = <String, NetworkMapStation>{};
+    for (final station in data.stations) {
+      stationsById.putIfAbsent(station.id, () => []).add(station);
+      stationByLineKey[_networkMapStationLineKey(station.id, station.lineId)] =
+          station;
+    }
     final visibleStations = _visibleCanonicalStations(
       geometry: geometry,
       camera: camera,
@@ -1309,8 +1329,18 @@ class _AndroidRouteMapFallbackPainter extends CustomPainter {
     canvas.transform(camera.sourceToViewport.storage);
 
     for (final edge in data.edges) {
-      final fromStation = stationById[edge.fromStationId];
-      final toStation = stationById[edge.toStationId];
+      final fromStation = _stationForMapEdgeEndpoint(
+        edge.fromStationId,
+        edge.lineId,
+        stationByLineKey,
+        stationsById,
+      );
+      final toStation = _stationForMapEdgeEndpoint(
+        edge.toStationId,
+        edge.lineId,
+        stationByLineKey,
+        stationsById,
+      );
       if (fromStation == null || toStation == null) {
         continue;
       }
@@ -1415,6 +1445,44 @@ class _AndroidRouteMapFallbackPainter extends CustomPainter {
         !_sameMapCamera(oldDelegate.camera, camera) ||
         oldDelegate.textScaler != textScaler;
   }
+}
+
+String _networkMapStationLineKey(String stationId, String lineId) =>
+    '$stationId:$lineId';
+
+@visibleForTesting
+NetworkMapStation? networkMapStationForMapEdgeEndpoint({
+  required String endpoint,
+  required String lineId,
+  required Iterable<NetworkMapStation> stations,
+}) {
+  final stationsById = <String, List<NetworkMapStation>>{};
+  final stationByLineKey = <String, NetworkMapStation>{};
+  for (final station in stations) {
+    stationsById.putIfAbsent(station.id, () => []).add(station);
+    stationByLineKey[_networkMapStationLineKey(station.id, station.lineId)] =
+        station;
+  }
+  return _stationForMapEdgeEndpoint(
+    endpoint,
+    lineId,
+    stationByLineKey,
+    stationsById,
+  );
+}
+
+NetworkMapStation? _stationForMapEdgeEndpoint(
+  String endpoint,
+  String lineId,
+  Map<String, NetworkMapStation> stationByLineKey,
+  Map<String, List<NetworkMapStation>> stationsById,
+) {
+  final endpointStations = stationsById[endpoint];
+  return stationByLineKey[endpoint] ??
+      stationByLineKey[_networkMapStationLineKey(endpoint, lineId)] ??
+      (endpointStations == null || endpointStations.isEmpty
+          ? null
+          : endpointStations.first);
 }
 
 class _CachedRouteMapPath {

--- a/apps/mobile/test/features/network_map/infrastructure/route_map_renderer_test.dart
+++ b/apps/mobile/test/features/network_map/infrastructure/route_map_renderer_test.dart
@@ -131,6 +131,38 @@ void main() {
     },
   );
 
+  test(
+    'health monitor resets recovery attempts after a frame presents',
+    () async {
+      final controller = _FakeRouteMapRendererController();
+      final timers = _ManualTimerFactory();
+      final observed = <RouteMapRendererEvent>[];
+      final monitor = RouteMapRendererHealthMonitor(
+        controller,
+        blankTimeout: const Duration(milliseconds: 10),
+        maxRecoveryAttempts: 1,
+        onEvent: observed.add,
+        timerFactory: timers.create,
+      )..start();
+      addTearDown(monitor.stop);
+
+      controller.emit(const RouteMapRendererCameraRequested(5));
+      await pumpEventQueue();
+      timers.elapse(const Duration(milliseconds: 10));
+      controller
+        ..emit(const RouteMapRendererAssetReady())
+        ..emit(const RouteMapRendererFramePresented(5));
+      await pumpEventQueue();
+
+      controller.emit(const RouteMapRendererCameraRequested(6));
+      await pumpEventQueue();
+      timers.elapse(const Duration(milliseconds: 10));
+
+      expect(controller.retryCalls, 2);
+      expect(observed.whereType<RouteMapRendererFailed>(), isEmpty);
+    },
+  );
+
   test('health monitor cancels blank watchdog after frame presents', () async {
     final controller = _FakeRouteMapRendererController();
     final timers = _ManualTimerFactory();

--- a/apps/mobile/test/features/network_map/infrastructure/route_map_renderer_test.dart
+++ b/apps/mobile/test/features/network_map/infrastructure/route_map_renderer_test.dart
@@ -95,6 +95,42 @@ void main() {
     },
   );
 
+  test(
+    'health monitor reports failure after repeated blank recoveries',
+    () async {
+      final controller = _FakeRouteMapRendererController();
+      final timers = _ManualTimerFactory();
+      final observed = <RouteMapRendererEvent>[];
+      final monitor = RouteMapRendererHealthMonitor(
+        controller,
+        blankTimeout: const Duration(milliseconds: 10),
+        maxRecoveryAttempts: 1,
+        onEvent: observed.add,
+        timerFactory: timers.create,
+      )..start();
+      addTearDown(monitor.stop);
+
+      controller.emit(const RouteMapRendererCameraRequested(5));
+      await pumpEventQueue();
+      timers.elapse(const Duration(milliseconds: 10));
+      controller.emit(const RouteMapRendererAssetReady());
+      await pumpEventQueue();
+      timers.elapse(const Duration(milliseconds: 10));
+
+      expect(controller.retryCalls, 1);
+      expect(
+        observed,
+        contains(
+          isA<RouteMapRendererFailed>().having(
+            (event) => event.reason,
+            'reason',
+            contains('did not present a frame'),
+          ),
+        ),
+      );
+    },
+  );
+
   test('health monitor cancels blank watchdog after frame presents', () async {
     final controller = _FakeRouteMapRendererController();
     final timers = _ManualTimerFactory();

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1246,6 +1246,64 @@ void main() {
     }
   });
 
+  test('Android 노선도 fallback edge resolver는 station-line endpoint를 해석한다', () {
+    const stations = [
+      NetworkMapStation(
+        id: 'station-a',
+        nameKo: '출발역',
+        nameEn: 'A',
+        region: '수도권',
+        lineId: 'seoul-4',
+        stationCode: '401',
+        sequence: 1,
+        position: NetworkMapPosition(
+          x: 2800,
+          y: 3200,
+          labelDx: 0,
+          labelDy: 40,
+          upPath: '',
+          downPath: '',
+          sourceId: 'fixture-route-map-source-capital-review',
+        ),
+      ),
+      NetworkMapStation(
+        id: 'station-a',
+        nameKo: '다른노선역',
+        nameEn: 'A transfer',
+        region: '수도권',
+        lineId: 'seoul-2',
+        stationCode: '201',
+        sequence: 1,
+        position: NetworkMapPosition(
+          x: 2800,
+          y: 3200,
+          labelDx: 0,
+          labelDy: 40,
+          upPath: '',
+          downPath: '',
+          sourceId: 'fixture-route-map-source-capital-review',
+        ),
+      ),
+    ];
+
+    expect(
+      networkMapStationForMapEdgeEndpoint(
+        endpoint: 'station-a:seoul-4',
+        lineId: 'seoul-4',
+        stations: stations,
+      )?.stationCode,
+      '401',
+    );
+    expect(
+      networkMapStationForMapEdgeEndpoint(
+        endpoint: 'station-a',
+        lineId: 'seoul-4',
+        stations: stations,
+      )?.stationCode,
+      '401',
+    );
+  });
+
   testWidgets('노선도 viewport 밖 station semantics는 생성하지 않는다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     const map = NetworkMapData(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1240,6 +1240,10 @@ void main() {
       );
       expect(renderer.width, surface.width);
       expect(renderer.height, surface.height);
+      expect(
+        tester.widget(find.byKey(const Key('routeMapViewportRenderer'))),
+        isA<ColoredBox>(),
+      );
     } finally {
       debugDefaultTargetPlatformOverride = null;
       tester.view.resetDevicePixelRatio();


### PR DESCRIPTION
## 관련 이슈

close #1036

## 작업 배경

- Android 16KB emulator release AAB 설치본에서 노선도 탭의 toolbar, controls, station semantics는 올라오지만 실제 viewport가 흰 화면으로 남아 Google Play v1 release QA가 차단됐다.
- native WebView SVG viewport는 release AAB 환경에서 visual surface가 안정적으로 표시되지 않아, Android에서는 기존 station coordinate/path 데이터를 Flutter canvas로 렌더링하는 fallback을 사용하도록 했다.

## 작업 내용

- Android 노선도 base layer에서 native WebView renderer 대신 Flutter `CustomPaint` fallback을 선택한다.
- fallback painter는 `NetworkMapData`의 edge, station path, line color, station coordinate를 사용해 노선 선, station node, 충돌 회피 station label을 렌더링한다.
- 기존 station hit target, pan/zoom camera, region selector, bottom navigation 흐름은 유지한다.

## 검증

- 실행한 명령과 결과:
- `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/features/network_map/infrastructure/route_map_renderer_test.dart`: exit 0, 14 tests passed.
- `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/widget_test.dart --plain-name "홈 노선도 버튼은 v3 노선도 화면을 연다"`: exit 0.
- `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/widget_test.dart --plain-name "노선도는 카드가 아니라 공식 지도처럼 전면 캔버스로 보인다"`: exit 0.
- `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/widget_test.dart --plain-name "수도권 노선도는 Android에서도 viewport renderer를 사용한다"`: exit 0.
- `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter analyze`: exit 0, no issues found.
- `set -a; source ../../.env; set +a; /Volumes/MACSSD/Android/flutter/flutter/bin/flutter build appbundle --release ...`: exit 0, `apps/mobile/build/app/outputs/bundle/release/app-release.aab` 생성.
- `bundletool build-apks --bundle=apps/mobile/build/app/outputs/bundle/release/app-release.aab --output=.codex/evidence/release/android-quality/issue-1036-route-map-fix-20260628/app-release-final.apks --mode=universal --overwrite`: exit 0.
- `bundletool install-apks --apks=.codex/evidence/release/android-quality/issue-1036-route-map-fix-20260628/app-release-final.apks --device-id=emulator-5556`: exit 0.
- `adb -s emulator-5556 shell am start -n com.easysubway.app/com.easysubway.easysubway_mobile.MainActivity`: exit 0.
- `adb -s emulator-5556 exec-out screencap -p > .codex/evidence/release/android-quality/issue-1036-route-map-fix-20260628/route-map-final.png`: exit 0.
- `adb -s emulator-5556 shell uiautomator dump /sdcard/easysubway-route-map-final.xml`: exit 0.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 노선도 viewport 시각 렌더링 | Android 16KB emulator `emulator-5556` | release AAB에서 onboarding 완료 후 노선도 탭 진입 및 screenshot 확인 | local-only `.codex/evidence/release/android-quality/issue-1036-route-map-fix-20260628/route-map-final.png` | 흰 화면 대신 station node/label visual content 렌더링 확인 |
| 접근성 tree 유지 | Android 16KB emulator `emulator-5556` | `uiautomator dump` | local-only `.codex/evidence/release/android-quality/issue-1036-route-map-fix-20260628/route-map-final.xml` | 노선도 탭 selected 및 station button semantics 유지 |
| runtime crash 확인 | Android 16KB emulator `emulator-5556` | `logcat-final.txt`에서 crash/ANR pattern 검색 | local-only `.codex/evidence/release/android-quality/issue-1036-route-map-fix-20260628/logcat-final.txt` | `FATAL EXCEPTION`, `AndroidRuntime`, `am_crash`, `ANR` 없음 |
| release artifact 빌드 | Android release | `flutter build appbundle --release` with release dart-defines | local command output | AAB 생성 성공 |

로컬 전용 사유: 이 저장소 정책상 screenshot/log/APK를 git에 커밋하지 않으며, 현재 CLI 경로에서는 GitHub PR binary attachment 업로드를 만들 수 없어 local-only evidence path와 결과를 PR에 기록한다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: Android에서 `_RouteMapViewportRenderer` 대신 `_AndroidRouteMapFallbackLayer`를 선택하는 분기와 `_AndroidRouteMapFallbackPainter`의 edge/path/node/label 렌더링 범위.
- `logcat-final.txt`에는 기존 release data-pack manifest 문제인 `FormatException: Invalid data pack artifact kind.`가 남아 있다. 이 PR에서 새로 만든 crash는 아니며 #547/#1020 release blocker로 별도 추적한다.

## 리스크

- Android fallback은 official SVG WebView와 1:1 동일한 bitmap 렌더링이 아니라, datapack의 edge/station/path coordinate를 Flutter canvas로 그리는 release unblock fallback이다.
- label collision avoidance 때문에 낮은 zoom에서는 일부 station label이 생략될 수 있다. station node와 tap semantics는 유지된다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
