### PR TITLE
[Fix] 데이터팩 production manifest 오류 처리 보강

### DIFF
--- a/apps/mobile/lib/core/datapack/data_pack_client.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_client.dart
@@ -61,14 +61,24 @@ class DataPackClient {
     final body = await utf8
         .decodeStream(response)
         .timeout(_manifestFetchTimeout);
-    final decoded = jsonDecode(body);
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(body);
+    } on FormatException {
+      throw const DataPackClientException('데이터팩 정보 형식이 올바르지 않습니다.');
+    }
     if (decoded is! Map<String, Object?>) {
       throw const DataPackClientException('데이터팩 정보 형식이 올바르지 않습니다.');
     }
-    final manifest = DataPackManifest.fromJson(
-      decoded,
-      productionSigningPublicKey: productionSigningPublicKey,
-    );
+    final DataPackManifest manifest;
+    try {
+      manifest = DataPackManifest.fromJson(
+        decoded,
+        productionSigningPublicKey: productionSigningPublicKey,
+      );
+    } on FormatException {
+      throw const DataPackClientException('데이터팩 정보 형식이 올바르지 않습니다.');
+    }
     _ensureExpectedManifestChannel(manifest);
     if (manifest.isExpiredAt(_now())) {
       throw const DataPackClientException('데이터팩 정보가 만료되었습니다.');

--- a/apps/mobile/test/core/datapack/data_pack_update_state_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_update_state_test.dart
@@ -51,6 +51,10 @@ const _representativeRouteRegressions = [
     'requiredEdgeIds': ['edge-a-b-express'],
   },
 ];
+const _productionSigningPublicKey = DataPackSigningPublicKey(
+  modulusBase64Url: 'AQ',
+  exponentBase64Url: 'AQAB',
+);
 
 void main() {
   test('manifest client는 TTL 안에서는 네트워크를 호출하지 않는다', () async {
@@ -237,6 +241,58 @@ void main() {
     final cache = await stateRepository.readManifestCache();
     expect(cache?.etag, 'etag-v18');
   });
+
+  test(
+    'manifest client는 production key에서 fixture manifest를 client 오류로 거부한다',
+    () async {
+      final userDatabase = user_db.UserDatabase.memory();
+      addTearDown(userDatabase.close);
+      final stateRepository = DataPackUpdateStateRepository(
+        userDatabase: userDatabase,
+        now: () => DateTime.utc(2026, 6, 27, 12),
+      );
+      await stateRepository.saveManifestCache(
+        etag: 'etag-v18',
+        checkedAt: DateTime.utc(2026, 6, 27, 10),
+        ttl: const Duration(minutes: 30),
+      );
+      var requestCount = 0;
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      server.listen((request) {
+        requestCount++;
+        request.response
+          ..statusCode = HttpStatus.ok
+          ..headers.set(HttpHeaders.etagHeader, 'etag-v19')
+          ..headers.contentType = ContentType.json
+          ..write(jsonEncode(_v2ManifestJson(sequence: 43, version: '19')))
+          ..close();
+      });
+
+      final client = DataPackClient(
+        manifestUri: Uri.parse(
+          'http://${server.address.host}:${server.port}/manifest.json',
+        ),
+        stateRepository: stateRepository,
+        productionSigningPublicKey: _productionSigningPublicKey,
+        now: () => DateTime.utc(2026, 6, 27, 12),
+      );
+
+      await expectLater(
+        client.fetchManifestIfNeeded(),
+        throwsA(
+          isA<DataPackClientException>().having(
+            (error) => error.message,
+            'message',
+            '데이터팩 정보 형식이 올바르지 않습니다.',
+          ),
+        ),
+      );
+      final cache = await stateRepository.readManifestCache();
+      expect(requestCount, 1);
+      expect(cache?.etag, 'etag-v18');
+    },
+  );
 
   test('manifest client는 v2 manifest cache TTL을 expiresAt으로 제한한다', () async {
     final userDatabase = user_db.UserDatabase.memory();


### PR DESCRIPTION
## 관련 이슈

refs #547

## 작업 배경

- production signing key가 설정된 출시 빌드에서 fixture manifest를 거부하는 보안 동작은 유지해야 한다.
- 다만 해당 거부가 raw `FormatException`으로 노출되면 데이터팩 업데이트 실패 로그와 운영 증거가 manifest client 오류 흐름과 어긋난다.
- QA 요청에 따라 production 데이터팩 gate의 실패 경로를 출시 검증에서 추적 가능한 `DataPackClientException`으로 정규화한다.

## 작업 내용

- manifest JSON decode와 `DataPackManifest.fromJson`의 `FormatException`을 `DataPackClientException`으로 변환했다.
- production key가 설정된 상태에서 fixture manifest를 받으면 client 오류로 거부하고 기존 manifest cache를 유지하는 회귀 테스트를 추가했다.
- fixture manifest를 production 데이터팩으로 허용하는 변경은 하지 않았다.

## 검증

- 실행한 명령과 결과:
- `cd apps/mobile && /Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/core/datapack/data_pack_update_state_test.dart --plain-name "manifest client는 production key에서 fixture manifest를 client 오류로 거부한다"`: exit 0, 1 test passed
- `cd apps/mobile && /Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/core/datapack/data_pack_update_state_test.dart`: exit 0, 9 tests passed
- `cd apps/mobile && /Volumes/MACSSD/Android/flutter/flutter/bin/flutter analyze`: exit 0, No issues found
- GitHub Actions PR checks: CI, Release Artifacts, SonarCloud, CodeRabbit 모두 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| production key fixture manifest 거부 | Flutter unit test | targeted datapack update-state test | command output: `All tests passed!` | 통과 |
| manifest cache 유지 회귀 | Flutter unit test | `data_pack_update_state_test.dart` 전체 실행 | command output: `9 tests passed` | 통과 |
| 정적 분석 | Android Flutter project | `flutter analyze` | command output: `No issues found` | 통과 |
| PR CI | GitHub Actions | PR #1038 checks 확인 | CI, Release Artifacts, SonarCloud, CodeRabbit success | 통과 |
| 화면 증거 | 해당 없음 | 데이터팩 client 예외 정규화와 unit test 변경 | 증거 불필요 사유: UI/문구/접근성 화면 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `DataPackManifest`의 production/fixture 거부 조건은 그대로 두고, client boundary에서만 예외 타입을 바꾼 점을 확인해 주세요.
- 이 PR은 #547의 production vs fixture pack gate 하위 범위만 다루며 #547 전체를 닫지 않는다.

## 리스크

- malformed manifest 응답이 기존보다 더 일관된 client 오류로 처리된다. 업데이트 실패 처리는 기존 safe update 경로를 그대로 사용한다.
- production 데이터팩 서명 검증을 완화하지 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI code review fallback이 필요 없음을 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. PR Release Artifacts 성공, merge 후 CD 실패 여부를 추가 확인한다.