### PR TITLE
[CI] Google Play API 접근 증거 추가

### DIFF
--- a/.github/workflows/store-distribution-evidence.yml
+++ b/.github/workflows/store-distribution-evidence.yml
@@ -52,6 +52,15 @@ jobs:
             --github-output "${GITHUB_OUTPUT}" \
             --report "${RUNNER_TEMP}/store-distribution-evidence-preflight.txt"
 
+      - name: Store Distribution Evidence / Check Google Play API access
+        id: google-play-api
+        run: |
+          set -euo pipefail
+          node tools/ci/check-google-play-api-access.mjs \
+            --env-file "${EASYSUBWAY_ENV_FILE}" \
+            --github-output "${GITHUB_OUTPUT}" \
+            --report "${RUNNER_TEMP}/google-play-api-access.txt"
+
       - name: Store Distribution Evidence / Validate data pack object storage publish env
         id: datapack-env
         run: |
@@ -66,6 +75,8 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: store-distribution-evidence-preflight-${{ github.sha }}
-          path: ${{ runner.temp }}/store-distribution-evidence-preflight.txt
+          path: |
+            ${{ runner.temp }}/store-distribution-evidence-preflight.txt
+            ${{ runner.temp }}/google-play-api-access.txt
           if-no-files-found: warn
           retention-days: 14

--- a/apps/mobile/release/play-production-access-gate.json
+++ b/apps/mobile/release/play-production-access-gate.json
@@ -36,7 +36,8 @@
       "evidence": [
         "production-access-status-summary",
         "production-menu-access-screenshot-or-summary",
-        "production-access-approval-or-rejection-record"
+        "production-access-approval-or-rejection-record",
+        "android-publisher-api-edit-track-list-summary"
       ]
     },
     {
@@ -83,6 +84,7 @@
       "evidence": [
         "latest-play-uploaded-versioncode-record",
         "rc-versioncode-comparison-record",
+        "android-publisher-api-track-versioncode-summary",
         "failed-rc-versioncode-reuse-policy",
         "fixed-release-versioncode-increase-procedure"
       ]

--- a/tools/ci/check-google-play-api-access.mjs
+++ b/tools/ci/check-google-play-api-access.mjs
@@ -80,7 +80,7 @@ export async function runGooglePlayApiAccess({
 
     await requestJson(
       `${normalizedApiBaseUrl}/applications/${encodePath(packageName)}/edits/${encodePath(editId)}:validate`,
-      { method: "POST", token, body: {} },
+      { method: "POST", token },
       fetchImpl,
     );
     report.push("edit_validate.ready=true");

--- a/tools/ci/check-google-play-api-access.mjs
+++ b/tools/ci/check-google-play-api-access.mjs
@@ -29,7 +29,7 @@ export async function runGooglePlayApiAccess({
   const packageName = requireEnv(env, "EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME");
   const latestVersionCode = env.EASYSUBWAY_GOOGLE_PLAY_LATEST_VERSION_CODE?.trim() || "unknown";
   const { serviceAccount, source } = readServiceAccount(env);
-  const token = await fetchAccessToken(serviceAccount, fetchImpl);
+  let token;
   let editId;
   let editDeleted = false;
   let ready = true;
@@ -43,6 +43,7 @@ export async function runGooglePlayApiAccess({
   ];
 
   try {
+    token = await fetchAccessToken(serviceAccount, fetchImpl);
     const edit = await requestJson(`${normalizedApiBaseUrl}/applications/${encodePath(packageName)}/edits`, {
       method: "POST",
       token,
@@ -79,14 +80,25 @@ export async function runGooglePlayApiAccess({
       fetchImpl,
     );
     report.push("edit_validate.ready=true");
+  } catch (error) {
+    ready = false;
+    failureMessage = error instanceof Error ? error.message : "google play api access failed";
+    report.push(`failure=${redactReportValue(failureMessage)}`);
   } finally {
-    if (editId) {
-      await requestJson(
-        `${normalizedApiBaseUrl}/applications/${encodePath(packageName)}/edits/${encodePath(editId)}`,
-        { method: "DELETE", token },
-        fetchImpl,
-      );
-      editDeleted = true;
+    if (editId && token) {
+      try {
+        await requestJson(
+          `${normalizedApiBaseUrl}/applications/${encodePath(packageName)}/edits/${encodePath(editId)}`,
+          { method: "DELETE", token },
+          fetchImpl,
+        );
+        editDeleted = true;
+      } catch (error) {
+        ready = false;
+        failureMessage ??= error instanceof Error ? error.message : "google play edit delete failed";
+        const deleteFailure = error instanceof Error ? error.message : "google play edit delete failed";
+        report.push(`edit_delete.failure=${redactReportValue(deleteFailure)}`);
+      }
     }
   }
 
@@ -157,6 +169,10 @@ function apiErrorSummary(parsed) {
   const status = typeof error.status === "string" ? error.status : "unknown";
   const message = typeof error.message === "string" ? error.message.replace(/\s+/g, " ").slice(0, 180) : "none";
   return `status=${status} message=${message}`;
+}
+
+function redactReportValue(value) {
+  return value.replace(/\s+/g, " ").slice(0, 220);
 }
 
 function readServiceAccount(env) {

--- a/tools/ci/check-google-play-api-access.mjs
+++ b/tools/ci/check-google-play-api-access.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+import { appendFile, readFile, writeFile } from "node:fs/promises";
+import { createSign } from "node:crypto";
+
+const androidPublisherScope = "https://www.googleapis.com/auth/androidpublisher";
+const defaultTokenUri = "https://oauth2.googleapis.com/token";
+const defaultApiBaseUrl = "https://androidpublisher.googleapis.com/androidpublisher/v3";
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const envFile = requireArg(args, "env-file");
+  const githubOutput = requireArg(args, "github-output");
+  const reportPath = requireArg(args, "report");
+  const apiBaseUrl = (args.get("api-base-url") ?? defaultApiBaseUrl).replace(/\/$/, "");
+  const env = parseDotenv(await readFile(envFile, "utf8"));
+  const packageName = requireEnv(env, "EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME");
+  const latestVersionCode = env.EASYSUBWAY_GOOGLE_PLAY_LATEST_VERSION_CODE?.trim() || "unknown";
+  const { serviceAccount, source } = readServiceAccount(env);
+  const token = await fetchAccessToken(serviceAccount);
+  let editId;
+  let editDeleted = false;
+  const report = [
+    "google_play_api_access",
+    `package_name=${packageName}`,
+    `service_account_json_source=${source}`,
+    "oauth_scope=androidpublisher",
+    `latest_version_code_env=${latestVersionCode}`,
+  ];
+
+  try {
+    const edit = await requestJson(`${apiBaseUrl}/applications/${encodePath(packageName)}/edits`, {
+      method: "POST",
+      token,
+      body: {},
+    });
+    editId = requireJsonString(edit, "id");
+    report.push("edit_insert.ready=true");
+
+    const tracks = await requestJson(
+      `${apiBaseUrl}/applications/${encodePath(packageName)}/edits/${encodePath(editId)}/tracks`,
+      { method: "GET", token },
+    );
+    const trackList = Array.isArray(tracks.tracks) ? tracks.tracks : [];
+    const trackIds = trackList
+      .map((track) => track.trackId ?? track.track)
+      .filter((track) => typeof track === "string" && track.length > 0)
+      .toSorted();
+    const maxTrackVersionCode = maxVersionCode(trackList);
+    report.push("tracks_list.ready=true");
+    report.push(`tracks.count=${trackList.length}`);
+    report.push(`tracks.ids=${trackIds.join(",") || "none"}`);
+    report.push(`tracks.max_version_code=${maxTrackVersionCode ?? "none"}`);
+    report.push(`latest_version_code_matches_track_max=${versionCodeMatch(latestVersionCode, maxTrackVersionCode)}`);
+
+    await requestJson(
+      `${apiBaseUrl}/applications/${encodePath(packageName)}/edits/${encodePath(editId)}:validate`,
+      { method: "POST", token, body: {} },
+    );
+    report.push("edit_validate.ready=true");
+  } finally {
+    if (editId) {
+      await requestJson(
+        `${apiBaseUrl}/applications/${encodePath(packageName)}/edits/${encodePath(editId)}`,
+        { method: "DELETE", token },
+      );
+      editDeleted = true;
+    }
+  }
+
+  report.push(`edit_delete.ready=${editDeleted}`);
+  report.push("secret_values_printed=false");
+  report.push("");
+  await appendFile(githubOutput, "google_play_api_access_ready=true\n");
+  await writeFile(reportPath, report.join("\n"));
+}
+
+async function fetchAccessToken(serviceAccount) {
+  const tokenUri = serviceAccount.token_uri || defaultTokenUri;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const header = base64UrlJson({ alg: "RS256", typ: "JWT" });
+  const claim = base64UrlJson({
+    iss: requireJsonString(serviceAccount, "client_email"),
+    scope: androidPublisherScope,
+    aud: tokenUri,
+    iat: nowSeconds,
+    exp: nowSeconds + 3600,
+  });
+  const unsignedToken = `${header}.${claim}`;
+  const signature = createSign("RSA-SHA256").update(unsignedToken).sign(requireJsonString(serviceAccount, "private_key"));
+  const assertion = `${unsignedToken}.${signature.toString("base64url")}`;
+  const response = await fetch(tokenUri, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion,
+    }),
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok || typeof body.access_token !== "string") {
+    throw new Error(`google play oauth failed: ${response.status}`);
+  }
+  return body.access_token;
+}
+
+async function requestJson(url, { method, token, body }) {
+  const response = await fetch(url, {
+    method,
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...(body === undefined ? {} : { "content-type": "application/json" }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (response.status === 204) {
+    return {};
+  }
+  const text = await response.text();
+  const parsed = text.length === 0 ? {} : JSON.parse(text);
+  if (!response.ok) {
+    throw new Error(`google play api ${method} failed: ${response.status} ${apiErrorSummary(parsed)}`);
+  }
+  return parsed;
+}
+
+function apiErrorSummary(parsed) {
+  const error = parsed.error;
+  if (!error || typeof error !== "object") {
+    return "status=unknown";
+  }
+  const status = typeof error.status === "string" ? error.status : "unknown";
+  const message = typeof error.message === "string" ? error.message.replace(/\s+/g, " ").slice(0, 180) : "none";
+  return `status=${status} message=${message}`;
+}
+
+function readServiceAccount(env) {
+  if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")) {
+    return {
+      serviceAccount: JSON.parse(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON),
+      source: "json",
+    };
+  }
+  if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64")) {
+    return {
+      serviceAccount: JSON.parse(Buffer.from(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64.trim(), "base64").toString("utf8")),
+      source: "base64",
+    };
+  }
+  throw new Error("missing google play service account json");
+}
+
+function parseDotenv(source) {
+  const values = {};
+  for (const line of source.split(/\r?\n/)) {
+    if (!line || line.trimStart().startsWith("#")) {
+      continue;
+    }
+    const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (match) {
+      values[match[1]] = unquote(match[2]);
+    }
+  }
+  return values;
+}
+
+function unquote(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith("\"") && trimmed.endsWith("\""))
+    || (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return value;
+}
+
+function hasValue(env, name) {
+  return typeof env[name] === "string" && env[name].trim().length > 0;
+}
+
+function requireEnv(env, name) {
+  if (!hasValue(env, name)) {
+    throw new Error(`missing required env: ${name}`);
+  }
+  return env[name].trim();
+}
+
+function requireJsonString(value, field) {
+  if (typeof value[field] !== "string" || value[field].trim().length === 0) {
+    throw new Error(`missing service account field: ${field}`);
+  }
+  return value[field];
+}
+
+function base64UrlJson(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function encodePath(value) {
+  return encodeURIComponent(value).replaceAll("%2E", ".");
+}
+
+function maxVersionCode(tracks) {
+  const versions = tracks.flatMap((track) =>
+    (track.releases ?? []).flatMap((release) => release.versionCodes ?? []),
+  );
+  let max;
+  for (const version of versions) {
+    if (!/^(0|[1-9]\d*)$/.test(String(version))) {
+      continue;
+    }
+    const parsed = BigInt(version);
+    if (max === undefined || parsed > max) {
+      max = parsed;
+    }
+  }
+  return max?.toString();
+}
+
+function versionCodeMatch(latestVersionCode, maxTrackVersionCode) {
+  if (latestVersionCode === "unknown" || maxTrackVersionCode === undefined) {
+    return "unknown";
+  }
+  return latestVersionCode === maxTrackVersionCode ? "true" : "false";
+}
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined || value.startsWith("--")) {
+      throw new Error(`invalid argument near ${key ?? "<end>"}`);
+    }
+    args.set(key.slice(2), value);
+    index += 1;
+  }
+  return args;
+}
+
+function requireArg(args, name) {
+  const value = args.get(name);
+  if (!value) {
+    throw new Error(`missing required argument: --${name}`);
+  }
+  return value;
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/tools/ci/check-google-play-api-access.mjs
+++ b/tools/ci/check-google-play-api-access.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { appendFile, readFile, writeFile } from "node:fs/promises";
 import { createSign } from "node:crypto";
+import { pathToFileURL } from "node:url";
 
 const androidPublisherScope = "https://www.googleapis.com/auth/androidpublisher";
 const defaultTokenUri = "https://oauth2.googleapis.com/token";
@@ -8,17 +9,31 @@ const defaultApiBaseUrl = "https://androidpublisher.googleapis.com/androidpublis
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const envFile = requireArg(args, "env-file");
-  const githubOutput = requireArg(args, "github-output");
-  const reportPath = requireArg(args, "report");
-  const apiBaseUrl = (args.get("api-base-url") ?? defaultApiBaseUrl).replace(/\/$/, "");
+  await runGooglePlayApiAccess({
+    envFile: requireArg(args, "env-file"),
+    githubOutput: requireArg(args, "github-output"),
+    reportPath: requireArg(args, "report"),
+    apiBaseUrl: args.get("api-base-url") ?? defaultApiBaseUrl,
+  });
+}
+
+export async function runGooglePlayApiAccess({
+  envFile,
+  githubOutput,
+  reportPath,
+  apiBaseUrl = defaultApiBaseUrl,
+  fetchImpl = fetch,
+}) {
+  const normalizedApiBaseUrl = apiBaseUrl.replace(/\/$/, "");
   const env = parseDotenv(await readFile(envFile, "utf8"));
   const packageName = requireEnv(env, "EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME");
   const latestVersionCode = env.EASYSUBWAY_GOOGLE_PLAY_LATEST_VERSION_CODE?.trim() || "unknown";
   const { serviceAccount, source } = readServiceAccount(env);
-  const token = await fetchAccessToken(serviceAccount);
+  const token = await fetchAccessToken(serviceAccount, fetchImpl);
   let editId;
   let editDeleted = false;
+  let ready = true;
+  let failureMessage;
   const report = [
     "google_play_api_access",
     `package_name=${packageName}`,
@@ -28,17 +43,18 @@ async function main() {
   ];
 
   try {
-    const edit = await requestJson(`${apiBaseUrl}/applications/${encodePath(packageName)}/edits`, {
+    const edit = await requestJson(`${normalizedApiBaseUrl}/applications/${encodePath(packageName)}/edits`, {
       method: "POST",
       token,
       body: {},
-    });
+    }, fetchImpl);
     editId = requireJsonString(edit, "id");
     report.push("edit_insert.ready=true");
 
     const tracks = await requestJson(
-      `${apiBaseUrl}/applications/${encodePath(packageName)}/edits/${encodePath(editId)}/tracks`,
+      `${normalizedApiBaseUrl}/applications/${encodePath(packageName)}/edits/${encodePath(editId)}/tracks`,
       { method: "GET", token },
+      fetchImpl,
     );
     const trackList = Array.isArray(tracks.tracks) ? tracks.tracks : [];
     const trackIds = trackList
@@ -50,18 +66,25 @@ async function main() {
     report.push(`tracks.count=${trackList.length}`);
     report.push(`tracks.ids=${trackIds.join(",") || "none"}`);
     report.push(`tracks.max_version_code=${maxTrackVersionCode ?? "none"}`);
-    report.push(`latest_version_code_matches_track_max=${versionCodeMatch(latestVersionCode, maxTrackVersionCode)}`);
+    const latestVersionCodeMatch = versionCodeMatch(latestVersionCode, maxTrackVersionCode);
+    report.push(`latest_version_code_matches_track_max=${latestVersionCodeMatch}`);
+    if (latestVersionCodeMatch === "false") {
+      ready = false;
+      failureMessage = "google play latest versionCode does not match track max versionCode";
+    }
 
     await requestJson(
-      `${apiBaseUrl}/applications/${encodePath(packageName)}/edits/${encodePath(editId)}:validate`,
+      `${normalizedApiBaseUrl}/applications/${encodePath(packageName)}/edits/${encodePath(editId)}:validate`,
       { method: "POST", token, body: {} },
+      fetchImpl,
     );
     report.push("edit_validate.ready=true");
   } finally {
     if (editId) {
       await requestJson(
-        `${apiBaseUrl}/applications/${encodePath(packageName)}/edits/${encodePath(editId)}`,
+        `${normalizedApiBaseUrl}/applications/${encodePath(packageName)}/edits/${encodePath(editId)}`,
         { method: "DELETE", token },
+        fetchImpl,
       );
       editDeleted = true;
     }
@@ -70,11 +93,14 @@ async function main() {
   report.push(`edit_delete.ready=${editDeleted}`);
   report.push("secret_values_printed=false");
   report.push("");
-  await appendFile(githubOutput, "google_play_api_access_ready=true\n");
+  await appendFile(githubOutput, `google_play_api_access_ready=${ready}\n`);
   await writeFile(reportPath, report.join("\n"));
+  if (!ready) {
+    throw new Error(failureMessage);
+  }
 }
 
-async function fetchAccessToken(serviceAccount) {
+async function fetchAccessToken(serviceAccount, fetchImpl) {
   const tokenUri = serviceAccount.token_uri || defaultTokenUri;
   const nowSeconds = Math.floor(Date.now() / 1000);
   const header = base64UrlJson({ alg: "RS256", typ: "JWT" });
@@ -88,7 +114,7 @@ async function fetchAccessToken(serviceAccount) {
   const unsignedToken = `${header}.${claim}`;
   const signature = createSign("RSA-SHA256").update(unsignedToken).sign(requireJsonString(serviceAccount, "private_key"));
   const assertion = `${unsignedToken}.${signature.toString("base64url")}`;
-  const response = await fetch(tokenUri, {
+  const response = await fetchImpl(tokenUri, {
     method: "POST",
     headers: { "content-type": "application/x-www-form-urlencoded" },
     body: new URLSearchParams({
@@ -103,8 +129,8 @@ async function fetchAccessToken(serviceAccount) {
   return body.access_token;
 }
 
-async function requestJson(url, { method, token, body }) {
-  const response = await fetch(url, {
+async function requestJson(url, { method, token, body }, fetchImpl) {
+  const response = await fetchImpl(url, {
     method,
     headers: {
       authorization: `Bearer ${token}`,
@@ -246,7 +272,9 @@ function requireArg(args, name) {
   return value;
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exitCode = 1;
-});
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/tools/ci/check-google-play-api-access.mjs
+++ b/tools/ci/check-google-play-api-access.mjs
@@ -190,11 +190,15 @@ function detectServiceAccountSource(env) {
 }
 
 function readServiceAccount(env) {
-  if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")) {
-    return JSON.parse(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON);
-  }
-  if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64")) {
-    return JSON.parse(Buffer.from(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64.trim(), "base64").toString("utf8"));
+  try {
+    if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")) {
+      return JSON.parse(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON);
+    }
+    if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64")) {
+      return JSON.parse(Buffer.from(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64.trim(), "base64").toString("utf8"));
+    }
+  } catch {
+    throw new Error("invalid google play service account json");
   }
   throw new Error("missing google play service account json");
 }

--- a/tools/ci/check-google-play-api-access.mjs
+++ b/tools/ci/check-google-play-api-access.mjs
@@ -26,9 +26,9 @@ export async function runGooglePlayApiAccess({
 }) {
   const normalizedApiBaseUrl = apiBaseUrl.replace(/\/$/, "");
   const env = parseDotenv(await readFile(envFile, "utf8"));
-  const packageName = requireEnv(env, "EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME");
+  const packageName = env.EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME?.trim() || "unknown";
   const latestVersionCode = env.EASYSUBWAY_GOOGLE_PLAY_LATEST_VERSION_CODE?.trim() || "unknown";
-  const { serviceAccount, source } = readServiceAccount(env);
+  const serviceAccountSource = detectServiceAccountSource(env);
   let token;
   let editId;
   let editDeleted = false;
@@ -37,12 +37,16 @@ export async function runGooglePlayApiAccess({
   const report = [
     "google_play_api_access",
     `package_name=${packageName}`,
-    `service_account_json_source=${source}`,
+    `service_account_json_source=${serviceAccountSource}`,
     "oauth_scope=androidpublisher",
     `latest_version_code_env=${latestVersionCode}`,
   ];
 
   try {
+    if (packageName === "unknown") {
+      throw new Error("missing required env: EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME");
+    }
+    const serviceAccount = readServiceAccount(env);
     token = await fetchAccessToken(serviceAccount, fetchImpl);
     const edit = await requestJson(`${normalizedApiBaseUrl}/applications/${encodePath(packageName)}/edits`, {
       method: "POST",
@@ -67,11 +71,11 @@ export async function runGooglePlayApiAccess({
     report.push(`tracks.count=${trackList.length}`);
     report.push(`tracks.ids=${trackIds.join(",") || "none"}`);
     report.push(`tracks.max_version_code=${maxTrackVersionCode ?? "none"}`);
-    const latestVersionCodeMatch = versionCodeMatch(latestVersionCode, maxTrackVersionCode);
-    report.push(`latest_version_code_matches_track_max=${latestVersionCodeMatch}`);
-    if (latestVersionCodeMatch === "false") {
+    const latestVersionCodeCoversTrackMax = versionCodeCoversTrackMax(latestVersionCode, maxTrackVersionCode);
+    report.push(`latest_version_code_covers_track_max=${latestVersionCodeCoversTrackMax}`);
+    if (latestVersionCodeCoversTrackMax === "false") {
       ready = false;
-      failureMessage = "google play latest versionCode does not match track max versionCode";
+      failureMessage = "google play latest versionCode is lower than track max versionCode";
     }
 
     await requestJson(
@@ -175,18 +179,22 @@ function redactReportValue(value) {
   return value.replace(/\s+/g, " ").slice(0, 220);
 }
 
-function readServiceAccount(env) {
+function detectServiceAccountSource(env) {
   if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")) {
-    return {
-      serviceAccount: JSON.parse(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON),
-      source: "json",
-    };
+    return "json";
   }
   if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64")) {
-    return {
-      serviceAccount: JSON.parse(Buffer.from(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64.trim(), "base64").toString("utf8")),
-      source: "base64",
-    };
+    return "base64";
+  }
+  return "missing";
+}
+
+function readServiceAccount(env) {
+  if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON")) {
+    return JSON.parse(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON);
+  }
+  if (hasValue(env, "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64")) {
+    return JSON.parse(Buffer.from(env.EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64.trim(), "base64").toString("utf8"));
   }
   throw new Error("missing google play service account json");
 }
@@ -259,11 +267,14 @@ function maxVersionCode(tracks) {
   return max?.toString();
 }
 
-function versionCodeMatch(latestVersionCode, maxTrackVersionCode) {
+function versionCodeCoversTrackMax(latestVersionCode, maxTrackVersionCode) {
   if (latestVersionCode === "unknown" || maxTrackVersionCode === undefined) {
     return "unknown";
   }
-  return latestVersionCode === maxTrackVersionCode ? "true" : "false";
+  if (!/^(0|[1-9]\d*)$/.test(latestVersionCode)) {
+    return "unknown";
+  }
+  return BigInt(latestVersionCode) >= BigInt(maxTrackVersionCode) ? "true" : "false";
 }
 
 function parseArgs(argv) {

--- a/tools/ci/check-google-play-api-access.test.mjs
+++ b/tools/ci/check-google-play-api-access.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { generateKeyPairSync } from "node:crypto";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const root = process.cwd();
+
+test("Google Play API access checker는 edit를 삭제하고 redacted report를 만든다", async (t) => {
+  const requests = [];
+  const server = createServer((request, response) => {
+    requests.push(`${request.method} ${request.url}`);
+    request.resume();
+    if (request.url === "/token") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ access_token: "access-token", token_type: "Bearer", expires_in: 3600 }));
+      return;
+    }
+    if (request.method === "POST" && request.url === "/androidpublisher/v3/applications/com.easysubway.app/edits") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ id: "edit-1", expiryTimeSeconds: "1800000000" }));
+      return;
+    }
+    if (request.method === "GET" && request.url === "/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1/tracks") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        tracks: [
+          { trackId: "internal", releases: [{ versionCodes: ["7"] }] },
+          { trackId: "production", releases: [] },
+        ],
+      }));
+      return;
+    }
+    if (request.method === "POST" && request.url === "/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1:validate") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ id: "edit-1" }));
+      return;
+    }
+    if (request.method === "DELETE" && request.url === "/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1") {
+      response.setHeader("content-type", "application/json");
+      response.end("{}");
+      return;
+    }
+    response.statusCode = 404;
+    response.end("{}");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => new Promise((resolve) => server.close(resolve)));
+
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const baseUrl = `http://127.0.0.1:${server.address().port}`;
+  const serviceAccount = {
+    client_email: "play-service@example.invalid",
+    private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
+    token_uri: `${baseUrl}/token`,
+  };
+  const dir = await mkdtemp(path.join(tmpdir(), "easysubway-google-play-api-"));
+  const envFile = path.join(dir, "store.env");
+  const outputFile = path.join(dir, "github-output.txt");
+  const reportFile = path.join(dir, "report.txt");
+  await writeFile(
+    envFile,
+    [
+      `EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64=${Buffer.from(JSON.stringify(serviceAccount)).toString("base64")}`,
+      "EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME=com.easysubway.app",
+      "EASYSUBWAY_GOOGLE_PLAY_LATEST_VERSION_CODE=7",
+      "",
+    ].join("\n"),
+  );
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/ci/check-google-play-api-access.mjs",
+      "--env-file",
+      envFile,
+      "--github-output",
+      outputFile,
+      "--report",
+      reportFile,
+      "--api-base-url",
+      `${baseUrl}/androidpublisher/v3`,
+    ],
+    { cwd: root },
+  );
+
+  const output = readFileSync(outputFile, "utf8");
+  const report = readFileSync(reportFile, "utf8");
+  assert.match(output, /^google_play_api_access_ready=true$/m);
+  assert.match(report, /^edit_insert\.ready=true$/m);
+  assert.match(report, /^tracks\.ids=internal,production$/m);
+  assert.match(report, /^tracks\.max_version_code=7$/m);
+  assert.match(report, /^latest_version_code_matches_track_max=true$/m);
+  assert.match(report, /^edit_delete\.ready=true$/m);
+  assert.doesNotMatch(report, /play-service@example\.invalid/);
+  assert.ok(requests.includes("DELETE /androidpublisher/v3/applications/com.easysubway.app/edits/edit-1"));
+});

--- a/tools/ci/check-google-play-api-access.test.mjs
+++ b/tools/ci/check-google-play-api-access.test.mjs
@@ -276,6 +276,8 @@ function mockGooglePlayFetch(requests, maxVersionCode, config = {}) {
       });
     }
     if (method === "POST" && url === "https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1:validate") {
+      assert.equal(requestOptions.body, undefined);
+      assert.equal(requestOptions.headers?.["content-type"], undefined);
       return jsonResponse(config.validateBody ?? { id: "edit-1" }, config.validateStatus ?? 200);
     }
     if (method === "DELETE" && url === "https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1") {

--- a/tools/ci/check-google-play-api-access.test.mjs
+++ b/tools/ci/check-google-play-api-access.test.mjs
@@ -49,13 +49,13 @@ test("Google Play API access checker는 edit를 삭제하고 redacted report를 
   assert.match(report, /^edit_insert\.ready=true$/m);
   assert.match(report, /^tracks\.ids=internal,production$/m);
   assert.match(report, /^tracks\.max_version_code=7$/m);
-  assert.match(report, /^latest_version_code_matches_track_max=true$/m);
+  assert.match(report, /^latest_version_code_covers_track_max=true$/m);
   assert.match(report, /^edit_delete\.ready=true$/m);
   assert.doesNotMatch(report, /play-service@example\.invalid/);
   assert.ok(requests.includes("DELETE https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1"));
 });
 
-test("Google Play API access checker는 env versionCode가 Play track max와 다르면 실패한다", async () => {
+test("Google Play API access checker는 env versionCode가 Play track max보다 낮으면 실패한다", async () => {
   const requests = [];
   const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
   const serviceAccount = {
@@ -85,15 +85,53 @@ test("Google Play API access checker는 env versionCode가 Play track max와 다
       apiBaseUrl: "https://androidpublisher.example.invalid/androidpublisher/v3",
       fetchImpl: mockGooglePlayFetch(requests, "7"),
     }),
-    /latest versionCode does not match/,
+    /latest versionCode is lower than track max/,
   );
 
   const output = readFileSync(outputFile, "utf8");
   const report = readFileSync(reportFile, "utf8");
   assert.match(output, /^google_play_api_access_ready=false$/m);
-  assert.match(report, /^latest_version_code_matches_track_max=false$/m);
+  assert.match(report, /^latest_version_code_covers_track_max=false$/m);
   assert.match(report, /^edit_delete\.ready=true$/m);
   assert.ok(requests.includes("DELETE https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1"));
+});
+
+test("Google Play API access checker는 env versionCode가 track max 이상이면 통과한다", async () => {
+  const requests = [];
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const serviceAccount = {
+    client_email: "play-service@example.invalid",
+    private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
+    token_uri: "https://androidpublisher.example.invalid/token",
+  };
+  const dir = await mkdtemp(path.join(tmpdir(), "easysubway-google-play-api-lower-bound-"));
+  const envFile = path.join(dir, "store.env");
+  const outputFile = path.join(dir, "github-output.txt");
+  const reportFile = path.join(dir, "report.txt");
+  await writeFile(
+    envFile,
+    [
+      `EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64=${Buffer.from(JSON.stringify(serviceAccount)).toString("base64")}`,
+      "EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME=com.easysubway.app",
+      "EASYSUBWAY_GOOGLE_PLAY_LATEST_VERSION_CODE=9",
+      "",
+    ].join("\n"),
+  );
+
+  await runGooglePlayApiAccess({
+    envFile,
+    githubOutput: outputFile,
+    reportPath: reportFile,
+    apiBaseUrl: "https://androidpublisher.example.invalid/androidpublisher/v3",
+    fetchImpl: mockGooglePlayFetch(requests, "7"),
+  });
+
+  const output = readFileSync(outputFile, "utf8");
+  const report = readFileSync(reportFile, "utf8");
+  assert.match(output, /^google_play_api_access_ready=true$/m);
+  assert.match(report, /^tracks\.max_version_code=7$/m);
+  assert.match(report, /^latest_version_code_env=9$/m);
+  assert.match(report, /^latest_version_code_covers_track_max=true$/m);
 });
 
 test("Google Play API access checker는 Play API 실패도 redacted report로 남긴다", async () => {
@@ -144,6 +182,43 @@ test("Google Play API access checker는 Play API 실패도 redacted report로 �
   assert.match(report, /^edit_delete\.ready=true$/m);
   assert.doesNotMatch(report, /play-service@example\.invalid/);
   assert.ok(requests.includes("DELETE https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1"));
+});
+
+test("Google Play API access checker는 malformed credential도 redacted report로 남긴다", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "easysubway-google-play-api-malformed-"));
+  const envFile = path.join(dir, "store.env");
+  const outputFile = path.join(dir, "github-output.txt");
+  const reportFile = path.join(dir, "report.txt");
+  await writeFile(
+    envFile,
+    [
+      "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64=not-json",
+      "EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME=com.easysubway.app",
+      "EASYSUBWAY_GOOGLE_PLAY_LATEST_VERSION_CODE=7",
+      "",
+    ].join("\n"),
+  );
+
+  await assert.rejects(
+    runGooglePlayApiAccess({
+      envFile,
+      githubOutput: outputFile,
+      reportPath: reportFile,
+      apiBaseUrl: "https://androidpublisher.example.invalid/androidpublisher/v3",
+      fetchImpl: async () => {
+        throw new Error("fetch must not be called");
+      },
+    }),
+    /Unexpected token|not valid JSON/,
+  );
+
+  const output = readFileSync(outputFile, "utf8");
+  const report = readFileSync(reportFile, "utf8");
+  assert.match(output, /^google_play_api_access_ready=false$/m);
+  assert.match(report, /^service_account_json_source=base64$/m);
+  assert.match(report, /^failure=/m);
+  assert.match(report, /^edit_delete\.ready=false$/m);
+  assert.doesNotMatch(report, /not-json/);
 });
 
 function mockGooglePlayFetch(requests, maxVersionCode, config = {}) {

--- a/tools/ci/check-google-play-api-access.test.mjs
+++ b/tools/ci/check-google-play-api-access.test.mjs
@@ -209,16 +209,52 @@ test("Google Play API access checker는 malformed credential도 redacted report�
         throw new Error("fetch must not be called");
       },
     }),
-    /Unexpected token|not valid JSON/,
+    /invalid google play service account json/,
   );
 
   const output = readFileSync(outputFile, "utf8");
   const report = readFileSync(reportFile, "utf8");
   assert.match(output, /^google_play_api_access_ready=false$/m);
   assert.match(report, /^service_account_json_source=base64$/m);
-  assert.match(report, /^failure=/m);
+  assert.match(report, /^failure=invalid google play service account json$/m);
   assert.match(report, /^edit_delete\.ready=false$/m);
   assert.doesNotMatch(report, /not-json/);
+});
+
+test("Google Play API access checker는 malformed JSON credential 원문을 report에 남기지 않는다", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "easysubway-google-play-api-malformed-json-"));
+  const envFile = path.join(dir, "store.env");
+  const outputFile = path.join(dir, "github-output.txt");
+  const reportFile = path.join(dir, "report.txt");
+  await writeFile(
+    envFile,
+    [
+      "EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON=abc123secret",
+      "EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME=com.easysubway.app",
+      "EASYSUBWAY_GOOGLE_PLAY_LATEST_VERSION_CODE=7",
+      "",
+    ].join("\n"),
+  );
+
+  await assert.rejects(
+    runGooglePlayApiAccess({
+      envFile,
+      githubOutput: outputFile,
+      reportPath: reportFile,
+      apiBaseUrl: "https://androidpublisher.example.invalid/androidpublisher/v3",
+      fetchImpl: async () => {
+        throw new Error("fetch must not be called");
+      },
+    }),
+    /invalid google play service account json/,
+  );
+
+  const output = readFileSync(outputFile, "utf8");
+  const report = readFileSync(reportFile, "utf8");
+  assert.match(output, /^google_play_api_access_ready=false$/m);
+  assert.match(report, /^service_account_json_source=json$/m);
+  assert.match(report, /^failure=invalid google play service account json$/m);
+  assert.doesNotMatch(report, /abc123secret/);
 });
 
 function mockGooglePlayFetch(requests, maxVersionCode, config = {}) {

--- a/tools/ci/check-google-play-api-access.test.mjs
+++ b/tools/ci/check-google-play-api-access.test.mjs
@@ -1,60 +1,21 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
 import { generateKeyPairSync } from "node:crypto";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { readFileSync } from "node:fs";
-import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { promisify } from "node:util";
 
-const execFileAsync = promisify(execFile);
-const root = process.cwd();
+import { runGooglePlayApiAccess } from "./check-google-play-api-access.mjs";
 
 test("Google Play API access checker는 edit를 삭제하고 redacted report를 만든다", async (t) => {
   const requests = [];
-  const server = createServer((request, response) => {
-    requests.push(`${request.method} ${request.url}`);
-    request.resume();
-    if (request.url === "/token") {
-      response.setHeader("content-type", "application/json");
-      response.end(JSON.stringify({ access_token: "access-token", token_type: "Bearer", expires_in: 3600 }));
-      return;
-    }
-    if (request.method === "POST" && request.url === "/androidpublisher/v3/applications/com.easysubway.app/edits") {
-      response.setHeader("content-type", "application/json");
-      response.end(JSON.stringify({ id: "edit-1", expiryTimeSeconds: "1800000000" }));
-      return;
-    }
-    if (request.method === "GET" && request.url === "/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1/tracks") {
-      response.setHeader("content-type", "application/json");
-      response.end(JSON.stringify({
-        tracks: [
-          { trackId: "internal", releases: [{ versionCodes: ["7"] }] },
-          { trackId: "production", releases: [] },
-        ],
-      }));
-      return;
-    }
-    if (request.method === "POST" && request.url === "/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1:validate") {
-      response.setHeader("content-type", "application/json");
-      response.end(JSON.stringify({ id: "edit-1" }));
-      return;
-    }
-    if (request.method === "DELETE" && request.url === "/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1") {
-      response.setHeader("content-type", "application/json");
-      response.end("{}");
-      return;
-    }
-    response.statusCode = 404;
-    response.end("{}");
+  t.after(() => {
+    requests.length = 0;
   });
-  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
-  t.after(() => new Promise((resolve) => server.close(resolve)));
 
   const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
-  const baseUrl = `http://127.0.0.1:${server.address().port}`;
+  const baseUrl = "https://androidpublisher.example.invalid";
   const serviceAccount = {
     client_email: "play-service@example.invalid",
     private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
@@ -74,21 +35,13 @@ test("Google Play API access checker는 edit를 삭제하고 redacted report를 
     ].join("\n"),
   );
 
-  await execFileAsync(
-    process.execPath,
-    [
-      "tools/ci/check-google-play-api-access.mjs",
-      "--env-file",
-      envFile,
-      "--github-output",
-      outputFile,
-      "--report",
-      reportFile,
-      "--api-base-url",
-      `${baseUrl}/androidpublisher/v3`,
-    ],
-    { cwd: root },
-  );
+  await runGooglePlayApiAccess({
+    envFile,
+    githubOutput: outputFile,
+    reportPath: reportFile,
+    apiBaseUrl: `${baseUrl}/androidpublisher/v3`,
+    fetchImpl: mockGooglePlayFetch(requests, "7"),
+  });
 
   const output = readFileSync(outputFile, "utf8");
   const report = readFileSync(reportFile, "utf8");
@@ -99,5 +52,81 @@ test("Google Play API access checker는 edit를 삭제하고 redacted report를 
   assert.match(report, /^latest_version_code_matches_track_max=true$/m);
   assert.match(report, /^edit_delete\.ready=true$/m);
   assert.doesNotMatch(report, /play-service@example\.invalid/);
-  assert.ok(requests.includes("DELETE /androidpublisher/v3/applications/com.easysubway.app/edits/edit-1"));
+  assert.ok(requests.includes("DELETE https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1"));
 });
+
+test("Google Play API access checker는 env versionCode가 Play track max와 다르면 실패한다", async () => {
+  const requests = [];
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const serviceAccount = {
+    client_email: "play-service@example.invalid",
+    private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
+    token_uri: "https://androidpublisher.example.invalid/token",
+  };
+  const dir = await mkdtemp(path.join(tmpdir(), "easysubway-google-play-api-mismatch-"));
+  const envFile = path.join(dir, "store.env");
+  const outputFile = path.join(dir, "github-output.txt");
+  const reportFile = path.join(dir, "report.txt");
+  await writeFile(
+    envFile,
+    [
+      `EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64=${Buffer.from(JSON.stringify(serviceAccount)).toString("base64")}`,
+      "EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME=com.easysubway.app",
+      "EASYSUBWAY_GOOGLE_PLAY_LATEST_VERSION_CODE=6",
+      "",
+    ].join("\n"),
+  );
+
+  await assert.rejects(
+    runGooglePlayApiAccess({
+      envFile,
+      githubOutput: outputFile,
+      reportPath: reportFile,
+      apiBaseUrl: "https://androidpublisher.example.invalid/androidpublisher/v3",
+      fetchImpl: mockGooglePlayFetch(requests, "7"),
+    }),
+    /latest versionCode does not match/,
+  );
+
+  const output = readFileSync(outputFile, "utf8");
+  const report = readFileSync(reportFile, "utf8");
+  assert.match(output, /^google_play_api_access_ready=false$/m);
+  assert.match(report, /^latest_version_code_matches_track_max=false$/m);
+  assert.match(report, /^edit_delete\.ready=true$/m);
+  assert.ok(requests.includes("DELETE https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1"));
+});
+
+function mockGooglePlayFetch(requests, maxVersionCode) {
+  return async (url, options = {}) => {
+    const method = options.method ?? "GET";
+    requests.push(`${method} ${url}`);
+    if (url === "https://androidpublisher.example.invalid/token") {
+      return jsonResponse({ access_token: "access-token", token_type: "Bearer", expires_in: 3600 });
+    }
+    if (method === "POST" && url === "https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits") {
+      return jsonResponse({ id: "edit-1", expiryTimeSeconds: "1800000000" });
+    }
+    if (method === "GET" && url === "https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1/tracks") {
+      return jsonResponse({
+        tracks: [
+          { trackId: "internal", releases: [{ versionCodes: [maxVersionCode] }] },
+          { trackId: "production", releases: [] },
+        ],
+      });
+    }
+    if (method === "POST" && url === "https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1:validate") {
+      return jsonResponse({ id: "edit-1" });
+    }
+    if (method === "DELETE" && url === "https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1") {
+      return jsonResponse({});
+    }
+    return jsonResponse({}, 404);
+  };
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/tools/ci/check-google-play-api-access.test.mjs
+++ b/tools/ci/check-google-play-api-access.test.mjs
@@ -96,9 +96,59 @@ test("Google Play API access checker는 env versionCode가 Play track max와 다
   assert.ok(requests.includes("DELETE https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1"));
 });
 
-function mockGooglePlayFetch(requests, maxVersionCode) {
-  return async (url, options = {}) => {
-    const method = options.method ?? "GET";
+test("Google Play API access checker는 Play API 실패도 redacted report로 남긴다", async () => {
+  const requests = [];
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const serviceAccount = {
+    client_email: "play-service@example.invalid",
+    private_key: privateKey.export({ type: "pkcs8", format: "pem" }),
+    token_uri: "https://androidpublisher.example.invalid/token",
+  };
+  const dir = await mkdtemp(path.join(tmpdir(), "easysubway-google-play-api-failure-"));
+  const envFile = path.join(dir, "store.env");
+  const outputFile = path.join(dir, "github-output.txt");
+  const reportFile = path.join(dir, "report.txt");
+  await writeFile(
+    envFile,
+    [
+      `EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_BASE64=${Buffer.from(JSON.stringify(serviceAccount)).toString("base64")}`,
+      "EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME=com.easysubway.app",
+      "EASYSUBWAY_GOOGLE_PLAY_LATEST_VERSION_CODE=7",
+      "",
+    ].join("\n"),
+  );
+
+  await assert.rejects(
+    runGooglePlayApiAccess({
+      envFile,
+      githubOutput: outputFile,
+      reportPath: reportFile,
+      apiBaseUrl: "https://androidpublisher.example.invalid/androidpublisher/v3",
+      fetchImpl: mockGooglePlayFetch(requests, "7", {
+        validateStatus: 403,
+        validateBody: {
+          error: {
+            status: "PERMISSION_DENIED",
+            message: "Android Publisher API is disabled for project secret-project-id",
+          },
+        },
+      }),
+    }),
+    /google play api POST failed: 403/,
+  );
+
+  const output = readFileSync(outputFile, "utf8");
+  const report = readFileSync(reportFile, "utf8");
+  assert.match(output, /^google_play_api_access_ready=false$/m);
+  assert.match(report, /^failure=google play api POST failed: 403 status=PERMISSION_DENIED/m);
+  assert.match(report, /^edit_delete\.ready=true$/m);
+  assert.doesNotMatch(report, /play-service@example\.invalid/);
+  assert.ok(requests.includes("DELETE https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1"));
+});
+
+function mockGooglePlayFetch(requests, maxVersionCode, config = {}) {
+  return async (url, requestOptions = {}) => {
+    const method = requestOptions.method ?? "GET";
     requests.push(`${method} ${url}`);
     if (url === "https://androidpublisher.example.invalid/token") {
       return jsonResponse({ access_token: "access-token", token_type: "Bearer", expires_in: 3600 });
@@ -115,7 +165,7 @@ function mockGooglePlayFetch(requests, maxVersionCode) {
       });
     }
     if (method === "POST" && url === "https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1:validate") {
-      return jsonResponse({ id: "edit-1" });
+      return jsonResponse(config.validateBody ?? { id: "edit-1" }, config.validateStatus ?? 200);
     }
     if (method === "DELETE" && url === "https://androidpublisher.example.invalid/androidpublisher/v3/applications/com.easysubway.app/edits/edit-1") {
       return jsonResponse({});

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -989,6 +989,16 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.ok(playProductionAccessGate.requiredConsoleEvidence.map((item) => item.id).includes("play_closed_test_requirement"));
   assert.ok(playProductionAccessGate.requiredConsoleEvidence.map((item) => item.id).includes("play_app_signing_enrollment"));
   assert.ok(playProductionAccessGate.requiredConsoleEvidence.map((item) => item.id).includes("play_version_code_monotonicity"));
+  assert.ok(
+    playProductionAccessGate.requiredConsoleEvidence
+      .find((item) => item.id === "play_production_access_status")
+      .evidence.includes("android-publisher-api-edit-track-list-summary"),
+  );
+  assert.ok(
+    playProductionAccessGate.requiredConsoleEvidence
+      .find((item) => item.id === "play_version_code_monotonicity")
+      .evidence.includes("android-publisher-api-track-versioncode-summary"),
+  );
   assert.equal(playProductionAccessGate.goNoGoRules.missingPlayAppSigningEnrollment, "BLOCKED_EXTERNAL");
   assert.equal(playProductionAccessGate.goNoGoRules.versionCodeNotGreaterThanLatestPlayArtifact, "BLOCKED_EXTERNAL");
   assert.equal(playProductionAccessGate.goNoGoRules.failedRcVersionCodeReuse, "BLOCKED_TECHNICAL");
@@ -2732,9 +2742,14 @@ test("스토어 배포 증거 workflow는 단일 dotenv secret과 명시적 cred
     existsSync(path.join(root, "tools/ci/check-store-distribution-evidence-env.mjs")),
     "store distribution evidence env preflight must exist",
   );
+  assert.ok(
+    existsSync(path.join(root, "tools/ci/check-google-play-api-access.mjs")),
+    "Google Play API access checker must exist",
+  );
 
   const workflow = read(".github/workflows/store-distribution-evidence.yml");
   const preflight = read("tools/ci/check-store-distribution-evidence-env.mjs");
+  const playApiAccess = read("tools/ci/check-google-play-api-access.mjs");
 
   assert.match(workflow, /^name: Store Distribution Evidence$/m);
   assert.match(workflow, /workflow_dispatch:/);
@@ -2747,9 +2762,12 @@ test("스토어 배포 증거 workflow는 단일 dotenv secret과 명시적 cred
   assert.match(workflow, /--mobile-pubspec apps\/mobile\/pubspec\.yaml/);
   assert.match(workflow, /--github-output "\$\{GITHUB_OUTPUT\}"/);
   assert.match(workflow, /--report "\$\{RUNNER_TEMP\}\/store-distribution-evidence-preflight\.txt"/);
+  assert.match(workflow, /node tools\/ci\/check-google-play-api-access\.mjs/);
+  assert.match(workflow, /--report "\$\{RUNNER_TEMP\}\/google-play-api-access\.txt"/);
   assert.match(workflow, /node tools\/datapack\/export-publish-env\.mjs/);
   assert.doesNotMatch(workflow, /--allow-invalid-disabled/);
   assert.match(workflow, /store-distribution-evidence-preflight-\$\{\{ github\.sha \}\}/);
+  assert.match(workflow, /\$\{\{ runner\.temp \}\}\/google-play-api-access\.txt/);
 
   assert.match(preflight, /EASYSUBWAY_GOOGLE_PLAY_SERVICE_ACCOUNT_JSON/);
   assert.match(preflight, /EASYSUBWAY_GOOGLE_PLAY_PACKAGE_NAME/);
@@ -2767,6 +2785,13 @@ test("스토어 배포 증거 workflow는 단일 dotenv secret과 명시적 cred
   assert.match(preflight, /EASYSUBWAY_DATAPACK_REMOTE_PUBLISH_ENABLED/);
   assert.match(preflight, /EASYSUBWAY_OBJECT_STORAGE_PREAUTH_BASE_URL/);
   assert.doesNotMatch(preflight, /console\.log\(.*env\[/, "preflight must not print secret values");
+
+  assert.match(playApiAccess, /https:\/\/www\.googleapis\.com\/auth\/androidpublisher/);
+  assert.match(playApiAccess, /\/applications\/\$\{encodePath\(packageName\)\}\/edits/);
+  assert.match(playApiAccess, /\/tracks/);
+  assert.match(playApiAccess, /:validate/);
+  assert.match(playApiAccess, /method: "DELETE"/);
+  assert.doesNotMatch(playApiAccess, /client_email=.*\$\{/, "API access report must not print service account email");
 });
 
 test("스토어 배포 증거 preflight는 iOS 누락을 Android 출시 blocker로 보지 않는다", async () => {


### PR DESCRIPTION
## 관련 이슈

refs AquilaXk/easysubway-mobile#8

## 작업 배경

- #1016은 Play Console 계정/production access와 Play-generated 또는 Play-installed artifact 증거를 요구한다.
- 기존 Store Distribution Evidence workflow는 dotenv/env readiness까지만 확인해, Google Play service account가 실제 Android Publisher API에 접근 가능한지 증명하지 못했다.
- QA 요청에 따라 release를 업로드하거나 commit하지 않는 안전한 API dry-run 증거를 추가한다.

## 작업 내용

- `tools/ci/check-google-play-api-access.mjs`를 추가해 service account OAuth, 임시 edit 생성, track 목록 조회, edit validate, edit delete를 수행한다.
- workflow_dispatch용 `store-distribution-evidence.yml`에 Google Play API access report 업로드를 추가했다.
- Play production access gate에 Android Publisher API track list/versionCode summary 증거 항목을 추가했다.
- API 실패, versionCode 하한 비교, credential redaction, `edits.validate` empty body 계약을 mock Android Publisher API 테스트와 repository contract로 고정했다.

## 검증

- 실행한 명령과 결과:
- `node --test tools/ci/check-google-play-api-access.test.mjs`: exit 0, 6 tests passed
- `node --test tools/ci/*.test.mjs`: exit 0, 127 tests passed
- `git diff --check f7f6120c7ed1cd59602bbefb2ed2a0b626b93ec7`: exit 0
- `codex review --base origin/main --title "[CI] Google Play API 접근 증거 추가"`: 추가 actionable finding 없음, PR review https://github.com/AquilaXk/easysubway/pull/1039#pullrequestreview-4586918457
- `gh pr checks 1039 --repo AquilaXk/easysubway`: required CI pass, `Android Production RC Artifact`와 `sonarcloud`는 조건부 skip
- `gh workflow run store-distribution-evidence.yml --repo AquilaXk/easysubway --ref main`: run https://github.com/AquilaXk/easysubway/actions/runs/28308501174 success, 기존 preflight 기준 Android Play env READY 확인
- `node tools/ci/check-google-play-api-access.mjs --env-file .env --github-output .codex/evidence/issue-1016/google-play-api-access-local/github-output-after-empty-body-fix.txt --report .codex/evidence/issue-1016/google-play-api-access-local/google-play-api-access-after-empty-body-fix.txt`: exit 1, OAuth 이후 Android Publisher `edits.insert`에서 `403 PERMISSION_DENIED`; Google Play Android Developer API가 Google Cloud project `102518617749`에서 아직 enable되지 않았다는 메시지를 민감값 없이 기록

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Play API checker unit | Node.js | mock OAuth/Android Publisher API 테스트 | command output: `6 tests passed` | 통과 |
| repository contract | Node.js | workflow/gate/script 계약 테스트 | command output: `127 tests passed` | 통과 |
| PR CI | GitHub Actions | PR AquilaXk/easysubway#1039 checks | Android CI, Mobile App CI, Backend CI, Repository CI, Release Gate Consistency, Android Release Artifact, Backend Release Image, RC Evidence Manifest pass | 통과 |
| Code review fallback | Codex CLI | CodeRabbit rate limit 보완 리뷰 | https://github.com/AquilaXk/easysubway/pull/1039#pullrequestreview-4586918457 | actionable finding 없음 |
| Store Distribution preflight | GitHub Actions | 기존 main workflow_dispatch 실행 | https://github.com/AquilaXk/easysubway/actions/runs/28308501174 | 통과 |
| Android Play env readiness | GitHub Actions artifact | preflight report download | local-only: `.codex/evidence/issue-1016/store-distribution-evidence-28308501174/` | `android_play_internal_track.status=READY` |
| 실제 Play API dry-run | local secret env | service account OAuth 후 edit insert 시도 | local-only: `.codex/evidence/issue-1016/google-play-api-access-local/google-play-api-access-after-empty-body-fix.txt` | `403 PERMISSION_DENIED`, Google Play Android Developer API enable 필요 |
| 화면 증거 | 해당 없음 | CI/API evidence workflow 변경 | 증거 불필요 사유: UI/접근성 화면 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 이 PR은 Play API 접근 증거 자동화를 추가하지만, Play Console production access나 Play-generated APK 설치 증거 자체를 완료하지는 않는다.
- 실제 dry-run이 막힌 원인은 코드가 아니라 Google Cloud project `102518617749`에서 Google Play Android Developer API가 enable되지 않은 외부 상태다.
- bundle upload나 track commit은 수행하지 않는다. 임시 edit는 validate 후 delete한다.

## 리스크

- workflow_dispatch 실행 시 Android Publisher API가 disable되어 있거나 service account 권한이 없으면 release blocker로 실패한다.
- API enable 이후에도 service account가 Play Console 앱 권한을 갖지 않으면 동일하게 실패한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
