### PR TITLE
[Fix] Android 노선도 초기 blank 화면 방지

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -775,6 +775,7 @@ class _NetworkMapCanvasState extends State<_NetworkMapCanvas>
               geometry.initialBounds,
               constraints,
               sourceBounds: fullBounds,
+              contain: mapAsset != null,
               minScale: minScale,
             );
             final initialRendererCamera = networkMapOverscannedRendererCamera(
@@ -1934,6 +1935,12 @@ Rect _readableBoundsFor(_MapGeometry geometry) {
   return Rect.fromLTWH(left, top, width, height);
 }
 
+@visibleForTesting
+Rect networkMapInitialOriginalAssetBounds({
+  required double sourceWidth,
+  required double sourceHeight,
+}) => Rect.fromLTWH(0, 0, sourceWidth, sourceHeight);
+
 class _MapGeometry {
   _MapGeometry({
     required this.origin,
@@ -1969,13 +1976,9 @@ class _MapGeometry {
       focus: Offset(sourceWidth / 2, sourceHeight / 2),
       width: sourceWidth,
       height: sourceHeight,
-      initialBounds: _readableBoundsFor(
-        _MapGeometry(
-          origin: Offset.zero,
-          focus: Offset(sourceWidth / 2, sourceHeight / 2),
-          width: sourceWidth,
-          height: sourceHeight,
-        ),
+      initialBounds: networkMapInitialOriginalAssetBounds(
+        sourceWidth: sourceWidth,
+        sourceHeight: sourceHeight,
       ),
       overlayStyleScale: overlayStyleScale.isFinite && overlayStyleScale > 0
           ? overlayStyleScale

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -916,6 +916,16 @@ void main() {
     expect(second.revision, 5);
   });
 
+  test('공식 노선도 초기 화면은 전체 asset bounds에서 시작한다', () {
+    expect(
+      networkMapInitialOriginalAssetBounds(
+        sourceWidth: 5724,
+        sourceHeight: 6516,
+      ),
+      const Rect.fromLTWH(0, 0, 5724, 6516),
+    );
+  });
+
   test('노선도 gesture renderer commit은 interval, drift, scale 기준으로 제한한다', () {
     const committed = MapCameraState(
       sourceBounds: Rect.fromLTWH(0, 0, 1000, 500),


### PR DESCRIPTION
## 관련 이슈

refs AquilaXk/easysubway-mobile#9

## 작업 배경

- 16KB page-size Android emulator에서 노선도 화면의 toolbar, controls, station semantics는 노출됐지만 route-map viewport가 하얗게 비어 보였다.
- 공식 SVG asset은 정상 포함되어 있었고 Android WebView frame도 성공으로 처리됐으나, 초기 camera가 공식 SVG 중심 일부만 보면서 빈 영역을 먼저 표시했다.
- QA 요청 기준으로 출시 후보의 첫 노선도 진입 화면에서 실제 공식 노선도가 바로 보여야 한다.

## 작업 내용

- 공식 route-map asset이 있는 지역은 초기 bounds를 전체 SVG asset bounds로 잡도록 변경했다.
- 공식 asset 초기 진입 camera는 `contain` fit을 사용해 전체 노선도가 화면에 들어오게 했다.
- 초기 bounds 회귀를 막는 widget test를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/network_map.dart apps/mobile/test/widget_test.dart`: exit 0
  - `flutter test test/widget_test.dart --plain-name '공식 노선도 초기 화면은 전체 asset bounds에서 시작한다'`: exit 0, 1 pass
  - `flutter test test/features/network_map/infrastructure/android_route_map_viewport_webview_test.dart`: exit 0, 9 pass
  - `flutter test test/widget_test.dart --plain-name '노선도'`: exit 0, 27 pass
  - `flutter analyze`: exit 0, No issues found
  - `git diff --check`: exit 0
  - `flutter build apk --debug`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 노선도 blank viewport 수정 | Android 16KB emulator | current branch debug APK 설치 후 노선도 screenshot/UI tree 캡처 | local-only `.codex/evidence/issue-1021/android-route-map-initial-bounds-20260628/route-map-after-fix.png`, `route-map-after-fix.xml`, `summary.txt` | 공식 수도권 노선도 시각 표시 PASS |
| Android runtime | Android 16KB emulator | `adb shell getconf PAGE_SIZE` | local-only `.codex/evidence/issue-1021/android-route-map-initial-bounds-20260628/page-size.txt` | `16384` |
| 접근성 tree | Android 16KB emulator | UI tree summary | local-only `.codex/evidence/issue-1021/android-route-map-initial-bounds-20260628/route-map-ui-summary.txt` | `지역: 수도권`, `확대`, `축소`, `지도 전체 보기`, station semantic nodes 확인 |
| crash/privacy log | Android 16KB emulator | app PID logcat pattern scan | local-only `.codex/evidence/issue-1021/android-route-map-initial-bounds-20260628/app-logcat-after-fix.txt` | `FATAL EXCEPTION`, `AndroidRuntime`, `ANR`, `am_crash`, `E/flutter`, `crash` 매칭 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/network_map.dart`에서 공식 route-map asset의 초기 camera가 전체 SVG bounds와 `contain` fit을 함께 쓰는지 확인해 주세요.

## 리스크

- 첫 진입은 전체 노선도를 보여주므로 기존 중심 확대 화면보다 역명이 작게 보인다. 사용자는 기존 확대/축소 버튼과 pinch gesture로 확대할 수 있다.
- 이 PR은 route-map visual smoke만 닫는다. Play-installed build 증거, TalkBack 수동 reading order, permission/network recovery, Play Console crash/ANR summary는 별도 release blocker로 남아 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. 해당 없음: CodeRabbit review completed.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. PR `Release Artifacts` run은 pass이며, merge 후 main CD 실패 여부를 확인한다.
