### PR TITLE
[Fix] 릴리즈 AAB 내부 개발 endpoint 제거

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -5573,8 +5573,15 @@ Uri stationApiBaseUriForEnvironment({
     // 운영 빌드는 로컬 개발 주소로 조용히 떨어지지 않게 빌드 설정 누락을 즉시 드러낸다.
     throw StateError('Release API base URL must be configured.');
   }
-  if (isAndroid) {
-    return Uri.parse('http://10.0.2.2:8080');
+  Uri? developmentBaseUri;
+  assert(() {
+    developmentBaseUri = Uri.parse(
+      isAndroid ? 'http://10.0.2.2:8080' : 'http://127.0.0.1:8080',
+    );
+    return true;
+  }());
+  if (developmentBaseUri == null) {
+    throw StateError('Development API base URL is only available in debug.');
   }
-  return Uri.parse('http://127.0.0.1:8080');
+  return developmentBaseUri!;
 }


### PR DESCRIPTION
## 관련 이슈

#1022 부분 보강

## 작업 배경

release AAB secret/internal endpoint scan 중 앱 산출물에 Android emulator 개발 endpoint `10.0.2.2`가 포함되는 것을 확인했습니다. 운영 빌드는 API base URL 누락 시 실패하거나 optional path에서 서버를 쓰지 않아야 하므로, 개발 fallback 문자열이 release artifact에 남지 않게 조정합니다.

## 작업 내용

- 역 검색 API 개발 fallback URL 생성을 `assert` 블록 안으로 이동했습니다.
- debug/test에서는 기존 Android emulator fallback을 유지합니다.
- release AOT artifact에서는 개발 endpoint literal이 제거되도록 했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/station_search_test.dart`: exit 0, 41 tests passed
  - `flutter analyze`: exit 0, no issues found
  - `flutter build appbundle --release ...`: exit 0, `app-release.aab` 생성
  - `unzip -p apps/mobile/build/app/outputs/bundle/release/app-release.aab | strings | rg -i -c -- 'https?://(localhost|127\\.0\\.0\\.1|10\\.|172\\.(1[6-9]|2[0-9]|3[0-1])\\.|192\\.168\\.|object-storage|minio)'`: no match
  - `unzip -p apps/mobile/build/app/outputs/bundle/release/app-release.aab | strings | rg -c -- '10\\.0\\.2\\.2'`: no match
  - `bundletool build-apks ...`: exit 0
  - `bundletool install-apks ... --device-id=emulator-5556`: exit 0
  - `tools/mobile/run-android-release-quality-emulator-smoke.sh ...`: exit 0, foreground package verified

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| station search endpoint contract | Flutter test | `flutter test test/station_search_test.dart` | command output | 41 tests passed |
| static analysis | Flutter | `flutter analyze` | command output | no issues found |
| release artifact internal endpoint scan | Android AAB | AAB strings scan | `.codex/evidence/security/abuse-penetration-rehearsal/1022-internal-endpoint-fix-20260628/summary.md` | `10.0.2.2` and internal endpoint URL pattern removed |
| release install smoke | Android 16KB emulator | bundletool install + release smoke script | `.codex/evidence/security/abuse-penetration-rehearsal/1022-internal-endpoint-fix-20260628/install-smoke/` | foreground package verified, no app crash marker |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `stationApiBaseUriForEnvironment`의 debug fallback이 release artifact에 남지 않도록 `assert` 안으로 이동한 부분입니다.

## 리스크

- debug/test fallback은 assert가 켜진 환경에 의존합니다. release에서는 API base URL 누락 시 기존처럼 실패하거나 optional endpoint path에서 서버를 쓰지 않습니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 개발 환경에서만 사용할 수 있는 API 기본 URL 처리 방식이 더 명확해졌습니다.
  * 디버그 실행이 아닌 환경에서는 개발용 주소를 사용하려 할 때 오류를 반환해, 잘못된 연결을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->