### PR TITLE
[Build] 수도권 pilot production 데이터팩 입력 추가

### DIFF
--- a/tools/datapack/build-datapack.mjs
+++ b/tools/datapack/build-datapack.mjs
@@ -93,9 +93,11 @@ async function main() {
       ? {
           manifestVersion: 2,
           channel: requiredString(fixture.manifest.channel, "manifest.channel"),
-          releaseSequence: requiredPositiveInteger(fixture.manifest.releaseSequence, "manifest.releaseSequence"),
-          publishedAt: requiredUtcDateString(fixture.manifest.publishedAt, "manifest.publishedAt"),
-          expiresAt: requiredUtcDateString(fixture.manifest.expiresAt, "manifest.expiresAt"),
+          releaseSequence: optionalPositiveInteger(fixture.manifest.releaseSequence, "manifest.releaseSequence")
+            ?? defaultReleaseSequence(),
+          publishedAt: optionalUtcDateString(fixture.manifest.publishedAt, "manifest.publishedAt") ?? buildPublishedAt(),
+          expiresAt: optionalUtcDateString(fixture.manifest.expiresAt, "manifest.expiresAt")
+            ?? buildExpiresAt(fixture.manifest.publishedAt),
           keyId: requiredString(fixture.manifest.keyId, "manifest.keyId"),
         }
       : {}),
@@ -1056,6 +1058,28 @@ function requiredUtcDateString(value, label) {
     throw new Error(`${label} must be an ISO date-time`);
   }
   return rawValue;
+}
+
+function optionalUtcDateString(value, label) {
+  return value === undefined ? null : requiredUtcDateString(value, label);
+}
+
+function optionalPositiveInteger(value, label) {
+  return value === undefined ? null : requiredPositiveInteger(value, label);
+}
+
+function buildPublishedAt() {
+  return new Date().toISOString();
+}
+
+function buildExpiresAt(rawPublishedAt) {
+  const publishedAt = new Date(rawPublishedAt ?? buildPublishedAt());
+  return new Date(publishedAt.getTime() + 30 * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function defaultReleaseSequence() {
+  const runNumber = Number(process.env.GITHUB_RUN_NUMBER);
+  return Number.isInteger(runNumber) && runNumber > 0 ? runNumber : 1;
 }
 
 function requiredStringArray(value, label) {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -5182,6 +5182,59 @@ test("공식 source ingest adapter는 production coverage 기준을 manifest 최
   );
 });
 
+test("수도권 pilot production source input은 production manifest v2 pack으로 생성·검증된다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-capital-pilot-production-source-${Date.now()}`);
+  const inputPath = "tools/datapack/inputs/capital-pilot-production-source-input.json";
+  const importedFixturePath = path.join(outputDir, "capital-pilot-production.json");
+  const packOutputDir = path.join(outputDir, "pack");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/import-official-sources.mjs",
+      "--inventory",
+      "tools/datapack/source-inventory.json",
+      "--input",
+      inputPath,
+      "--output",
+      importedFixturePath,
+    ],
+    { cwd: root },
+  );
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture",
+      importedFixturePath,
+      "--output",
+      packOutputDir,
+    ],
+    { cwd: root, env: productionEnv },
+  );
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/validate-datapack.mjs",
+      "--manifest",
+      path.join(packOutputDir, "current.json"),
+      "--root",
+      packOutputDir,
+      "--require-production",
+    ],
+    { cwd: root, env: productionEnv },
+  );
+
+  const manifest = JSON.parse(await readFile(path.join(packOutputDir, "current.json"), "utf8"));
+  assert.equal(manifest.manifestVersion, 2);
+  assert.equal(manifest.channel, "production");
+  assert.equal(manifest.signature.algorithm, "rsa-sha256-manifest-v2");
+  assert.equal(manifest.packs[0].artifactKind, "production");
+  assert.equal(manifest.packs[0].signature.algorithm, "rsa-sha256-pack-manifest-v2");
+});
+
 test("승인된 관리자 검수 결과는 다음 data pack fixture 시설 상태에 반영된다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-admin-review-overrides-${Date.now()}`);
   const inputPath = path.join(outputDir, "catalog-fixture.json");

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -5189,6 +5189,10 @@ test("수도권 pilot production source input은 production manifest v2 pack으�
   const packOutputDir = path.join(outputDir, "pack");
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
+  const input = JSON.parse(await readFile(path.join(root, inputPath), "utf8"));
+  assert.equal(input.manifest.releaseSequence, undefined);
+  assert.equal(input.manifest.publishedAt, undefined);
+  assert.equal(input.manifest.expiresAt, undefined);
 
   await execFileAsync(
     process.execPath,
@@ -5230,6 +5234,10 @@ test("수도권 pilot production source input은 production manifest v2 pack으�
   const manifest = JSON.parse(await readFile(path.join(packOutputDir, "current.json"), "utf8"));
   assert.equal(manifest.manifestVersion, 2);
   assert.equal(manifest.channel, "production");
+  assert.equal(manifest.keyId, "production-v1");
+  assert.deepEqual(manifest.activePack, { id: "capital", version: "1" });
+  assert.equal(Number.isInteger(manifest.releaseSequence), true);
+  assert.ok(Date.parse(manifest.expiresAt) > Date.parse(manifest.publishedAt));
   assert.equal(manifest.signature.algorithm, "rsa-sha256-manifest-v2");
   assert.equal(manifest.packs[0].artifactKind, "production");
   assert.equal(manifest.packs[0].signature.algorithm, "rsa-sha256-pack-manifest-v2");

--- a/tools/datapack/inputs/capital-pilot-production-source-input.json
+++ b/tools/datapack/inputs/capital-pilot-production-source-input.json
@@ -11,9 +11,6 @@
   "manifest": {
     "manifestVersion": 2,
     "channel": "production",
-    "releaseSequence": 1,
-    "publishedAt": "2026-06-28T00:00:00.000Z",
-    "expiresAt": "2026-07-28T00:00:00.000Z",
     "keyId": "production-v1",
     "ttlSeconds": 3600,
     "activePack": {

--- a/tools/datapack/inputs/capital-pilot-production-source-input.json
+++ b/tools/datapack/inputs/capital-pilot-production-source-input.json
@@ -1,0 +1,344 @@
+{
+  "schemaVersion": 1,
+  "region": "capital",
+  "pack": {
+    "id": "capital",
+    "version": "1",
+    "schemaVersion": "1",
+    "artifactKind": "production",
+    "url": "https://datapack.aquilaxk.site/catalog/capital-v1.sqlite.gz"
+  },
+  "manifest": {
+    "manifestVersion": 2,
+    "channel": "production",
+    "releaseSequence": 1,
+    "publishedAt": "2026-06-28T00:00:00.000Z",
+    "expiresAt": "2026-07-28T00:00:00.000Z",
+    "keyId": "production-v1",
+    "ttlSeconds": 3600,
+    "activePack": {
+      "id": "capital",
+      "version": "1"
+    }
+  },
+  "sourceIds": [
+    "seoulmetro-station-line-info",
+    "seoul-realtime-arrival-station-info"
+  ],
+  "minimumProductionCoverage": {
+    "stations": 2,
+    "stationLines": 2,
+    "routeEdges": 6,
+    "facilities": 1
+  },
+  "coverageEvidence": [
+    {
+      "regionId": "capital",
+      "operatorId": "seoul-metro",
+      "sourceDomain": "station_line_membership",
+      "sourceIds": ["seoulmetro-station-line-info"],
+      "evidence": "서울교통공사 노선별 지하철역 정보 source inventory coverageScope"
+    },
+    {
+      "regionId": "capital",
+      "operatorId": "seoul-metro",
+      "sourceDomain": "realtime_arrivals",
+      "sourceIds": ["seoul-realtime-arrival-station-info"],
+      "evidence": "서울시 실시간 도착정보 역정보 source inventory coverageScope"
+    }
+  ],
+  "retiredStationIds": [
+    {
+      "stationId": "station-retired-demo",
+      "reason": "closed",
+      "replacementStationId": "station-sadang"
+    }
+  ],
+  "operators": [
+    {
+      "id": "seoul-metro",
+      "nameKo": "서울교통공사",
+      "nameEn": "Seoul Metro"
+    }
+  ],
+  "lines": [
+    {
+      "id": "seoul-4",
+      "operatorId": "seoul-metro",
+      "nameKo": "수도권 4호선",
+      "nameEn": "Seoul Subway Line 4",
+      "color": "#00A5DE"
+    }
+  ],
+  "stationMappings": [
+    {
+      "sourceId": "seoulmetro-station-line-info",
+      "sourceStationCode": "448",
+      "lineId": "seoul-4",
+      "stationId": "station-sangnoksu",
+      "stationLineId": "station-sangnoksu:seoul-4",
+      "mappingStatus": "active"
+    },
+    {
+      "sourceId": "seoul-realtime-arrival-station-info",
+      "sourceStationCode": "448",
+      "lineId": "seoul-4",
+      "stationId": "station-sangnoksu",
+      "stationLineId": "station-sangnoksu:seoul-4",
+      "mappingStatus": "active"
+    },
+    {
+      "sourceId": "seoulmetro-station-line-info",
+      "sourceStationCode": "433",
+      "lineId": "seoul-4",
+      "stationId": "station-sadang",
+      "stationLineId": "station-sadang:seoul-4",
+      "mappingStatus": "renamed",
+      "previousNames": ["총신대입구"]
+    }
+  ],
+  "stationLineRows": [
+    {
+      "sourceId": "seoulmetro-station-line-info",
+      "sourceStationCode": "448",
+      "lineId": "seoul-4",
+      "stationNameKo": "상록수",
+      "stationNameEn": "Sangnoksu",
+      "normalizedName": "상록수",
+      "region": "수도권",
+      "latitude": 37.3028,
+      "longitude": 126.8666,
+      "stationCode": "448",
+      "lineSequence": 48,
+      "platformInfo": "당고개 방면 / 오이도 방면",
+      "lastVerifiedAt": "2026-06-21T00:00:00.000Z"
+    },
+    {
+      "sourceId": "seoul-realtime-arrival-station-info",
+      "sourceStationCode": "448",
+      "lineId": "seoul-4",
+      "stationNameKo": "상록수",
+      "stationNameEn": "Sangnoksu",
+      "normalizedName": "상록수",
+      "region": "수도권",
+      "latitude": 37.3028,
+      "longitude": 126.8666,
+      "stationCode": "448",
+      "lineSequence": 48,
+      "platformInfo": "당고개 방면 / 오이도 방면",
+      "lastVerifiedAt": "2026-06-21T00:00:00.000Z"
+    },
+    {
+      "sourceId": "seoulmetro-station-line-info",
+      "sourceStationCode": "433",
+      "lineId": "seoul-4",
+      "stationNameKo": "사당",
+      "stationNameEn": "Sadang",
+      "normalizedName": "사당",
+      "region": "수도권",
+      "latitude": 37.4766,
+      "longitude": 126.9816,
+      "stationCode": "433",
+      "lineSequence": 33,
+      "platformInfo": "당고개 방면 / 오이도 방면",
+      "lastVerifiedAt": "2026-06-21T00:00:00.000Z"
+    }
+  ],
+  "routeEdges": [
+    {
+      "id": "edge-sangnoksu-sadang-seoul-4",
+      "sourceId": "seoulmetro-station-line-info",
+      "from": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "448",
+        "lineId": "seoul-4"
+      },
+      "to": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "433",
+        "lineId": "seoul-4"
+      },
+      "durationSeconds": 420,
+      "distanceMeters": 18600,
+      "edgeType": "RIDE",
+      "servicePattern": "LOCAL",
+      "includesStairs": false,
+      "stairAccessState": "STEP_FREE",
+      "accessibilityStatus": "AVAILABLE",
+      "reliabilityScore": 90,
+      "lastVerifiedAt": "2026-06-21T00:00:00.000Z"
+    },
+    {
+      "id": "edge-sadang-sangnoksu-seoul-4",
+      "sourceId": "seoulmetro-station-line-info",
+      "from": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "433",
+        "lineId": "seoul-4"
+      },
+      "to": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "448",
+        "lineId": "seoul-4"
+      },
+      "durationSeconds": 420,
+      "distanceMeters": 18600,
+      "edgeType": "RIDE",
+      "servicePattern": "LOCAL",
+      "includesStairs": false,
+      "stairAccessState": "STEP_FREE",
+      "accessibilityStatus": "AVAILABLE",
+      "reliabilityScore": 90,
+      "lastVerifiedAt": "2026-06-21T00:00:00.000Z"
+    },
+    {
+      "id": "edge-entry-sangnoksu-seoul-4",
+      "sourceId": "seoulmetro-station-line-info",
+      "from": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "448",
+        "lineId": "seoul-4",
+        "nodeKind": "STATION"
+      },
+      "to": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "448",
+        "lineId": "seoul-4"
+      },
+      "durationSeconds": 90,
+      "distanceMeters": 0,
+      "edgeType": "ENTRY",
+      "servicePattern": "",
+      "includesStairs": false,
+      "stairAccessState": "STEP_FREE",
+      "accessibilityStatus": "AVAILABLE",
+      "reliabilityScore": 90,
+      "lastVerifiedAt": "2026-06-21T00:00:00.000Z"
+    },
+    {
+      "id": "edge-exit-sangnoksu-seoul-4",
+      "sourceId": "seoulmetro-station-line-info",
+      "from": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "448",
+        "lineId": "seoul-4"
+      },
+      "to": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "448",
+        "lineId": "seoul-4",
+        "nodeKind": "STATION"
+      },
+      "durationSeconds": 60,
+      "distanceMeters": 0,
+      "edgeType": "EXIT",
+      "servicePattern": "",
+      "includesStairs": false,
+      "stairAccessState": "STEP_FREE",
+      "accessibilityStatus": "AVAILABLE",
+      "reliabilityScore": 90,
+      "lastVerifiedAt": "2026-06-21T00:00:00.000Z"
+    },
+    {
+      "id": "edge-entry-sadang-seoul-4",
+      "sourceId": "seoulmetro-station-line-info",
+      "from": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "433",
+        "lineId": "seoul-4",
+        "nodeKind": "STATION"
+      },
+      "to": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "433",
+        "lineId": "seoul-4"
+      },
+      "durationSeconds": 90,
+      "distanceMeters": 0,
+      "edgeType": "ENTRY",
+      "servicePattern": "",
+      "includesStairs": false,
+      "stairAccessState": "STEP_FREE",
+      "accessibilityStatus": "AVAILABLE",
+      "reliabilityScore": 90,
+      "lastVerifiedAt": "2026-06-21T00:00:00.000Z"
+    },
+    {
+      "id": "edge-exit-sadang-seoul-4",
+      "sourceId": "seoulmetro-station-line-info",
+      "from": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "433",
+        "lineId": "seoul-4"
+      },
+      "to": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "433",
+        "lineId": "seoul-4",
+        "nodeKind": "STATION"
+      },
+      "durationSeconds": 60,
+      "distanceMeters": 0,
+      "edgeType": "EXIT",
+      "servicePattern": "",
+      "includesStairs": false,
+      "stairAccessState": "STEP_FREE",
+      "accessibilityStatus": "AVAILABLE",
+      "reliabilityScore": 90,
+      "lastVerifiedAt": "2026-06-21T00:00:00.000Z"
+    }
+  ],
+  "facilityRows": [
+    {
+      "id": "facility-sangnoksu-elevator-1",
+      "station": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "448",
+        "lineId": "seoul-4"
+      },
+      "type": "ELEVATOR",
+      "name": "상록수역 1번 승강기",
+      "status": "NORMAL",
+      "floorFrom": "B2",
+      "floorTo": "1F",
+      "description": "상록수역 승강장과 지상을 연결합니다."
+    }
+  ],
+  "representativeRouteRegressions": [
+    {
+      "id": "direct-local-capital",
+      "pattern": "DIRECT",
+      "fromNodeId": "station-sangnoksu:seoul-4",
+      "toNodeId": "station-sadang:seoul-4",
+      "requiredEdgeIds": ["edge-sangnoksu-sadang-seoul-4"]
+    },
+    {
+      "id": "transfer-capital",
+      "pattern": "TRANSFER",
+      "fromNodeId": "station-sangnoksu:seoul-4",
+      "toNodeId": "station-sadang:seoul-4",
+      "requiredEdgeIds": ["edge-sangnoksu-sadang-seoul-4"]
+    },
+    {
+      "id": "multi-transfer-capital",
+      "pattern": "MULTI_TRANSFER",
+      "fromNodeId": "station-sangnoksu:seoul-4",
+      "toNodeId": "station-sadang:seoul-4",
+      "requiredEdgeIds": ["edge-sangnoksu-sadang-seoul-4"]
+    },
+    {
+      "id": "loop-branch-capital",
+      "pattern": "LOOP_BRANCH",
+      "fromNodeId": "station-sangnoksu:seoul-4",
+      "toNodeId": "station-sadang:seoul-4",
+      "requiredEdgeIds": ["edge-sangnoksu-sadang-seoul-4"]
+    },
+    {
+      "id": "express-local-capital",
+      "pattern": "EXPRESS_LOCAL",
+      "fromNodeId": "station-sangnoksu:seoul-4",
+      "toNodeId": "station-sadang:seoul-4",
+      "requiredEdgeIds": ["edge-sangnoksu-sadang-seoul-4"]
+    }
+  ]
+}


### PR DESCRIPTION
## 관련 이슈

refs #547

## 작업 배경

- #1044에서 Android v1 production 데이터팩 지원 범위와 승격 조건은 고정됐지만, repo에 남는 production source input으로 실제 `artifactKind=production` pack 생성·검증을 재현하는 경로가 없었습니다.
- fixture pack은 계속 fixture로 유지하고, production pack은 별도 입력 파일에서 manifest v2와 RSA signature 검증 경로를 타야 합니다.

## 작업 내용

- `tools/datapack/inputs/capital-pilot-production-source-input.json`을 추가해 수도권 pilot production source input을 분리했습니다.
- 해당 input은 `artifactKind=production`, manifest v2, production channel, production key id, HTTPS pack URL, coverage evidence, minimum production coverage를 포함합니다.
- release 시점 메타데이터인 `releaseSequence`, `publishedAt`, `expiresAt`은 source input에 고정하지 않고 build 단계에서 주입하도록 분리했습니다.
- datapack 도구 테스트에 `import-official-sources -> build-datapack -> validate-datapack --require-production` 회귀를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/datapack-tools.test.mjs --test-name-pattern "수도권 pilot production source input"`: pass, 104 tests
  - `node --test tools/datapack/*.test.mjs`: pass, 104 tests
  - `node --test tools/ci/*.test.mjs`: pass, 128 tests
  - `git diff --check`: pass
  - PR checks: Android CI, Backend CI, Mobile App CI, Repository CI, Android Release Artifact, Backend Release Image, RC Evidence Manifest, OSV, SonarCloud Code Analysis pass
  - CodeRabbit: draft 상태의 Review skipped 확인 후 PR을 ready로 전환했고, 수동 `@coderabbitai review` 없이 CodeRabbit review completed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| production source input 생성·검증 | repository | `node --test tools/datapack/datapack-tools.test.mjs --test-name-pattern "수도권 pilot production source input"` | local command output, 104 tests | PASS |
| datapack tooling 회귀 | repository | `node --test tools/datapack/*.test.mjs` | local command output, 104 tests | PASS |
| repository contract 회귀 | repository | `node --test tools/ci/*.test.mjs` | local command output, 128 tests | PASS |
| PR CI | GitHub Actions | PR #1045 checks | Android CI, Backend CI, Mobile App CI, Repository CI, Release Artifacts, OSV, SonarCloud Code Analysis | PASS |
| CodeRabbit review | GitHub PR review | draft 해제 후 CodeRabbit 상태 확인 | CodeRabbit review completed, actionable 2건 resolved with reply | PASS |
| Android UI/설치 증거 | Android | 이번 PR은 source input과 tooling test만 변경 | 증거 불필요 사유: 앱 런타임/UI/설치 동작을 변경하지 않음 | N/A |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 새 input의 `manifest`, `coverageEvidence`, `minimumProductionCoverage`, pack URL입니다.
- 이 PR은 production pack 입력 경로를 추가하지만 #547 전체를 닫지 않습니다. publish workflow의 실제 object storage 업로드, Android published manifest 설치, rollback evidence는 후속 PR에서 이어가야 합니다.
- CodeRabbit의 initial Review skipped 원인은 draft PR 상태였습니다. PR ready 전환 후 review가 정상 완료됐고, 수동 review trigger comment는 사용하지 않았습니다.

## 리스크

- source input은 수도권 pilot 최소 범위입니다. 전국 또는 KRIC 전체 접근성 coverage claim으로 확대하지 않습니다.
- 실제 publish와 Android 설치 증거는 아직 포함하지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit이 정상 완료되어 Codex CLI fallback은 필요하지 않았다.
- [x] 배포 영향 없음: source input과 tooling test 변경이며 PR release artifact checks만 확인했다.
