### PR TITLE
[Chore] 개인정보처리방침 공개 URL 전환

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Data is transmitted over HTTPS when network submission is required. Local favori
 
 Store submission and release contact points:
 
-- Privacy policy URL: `https://github.com/AquilaXk/easysubway#privacy-policy`
+- Privacy policy URL: `https://easysubway-api.aquilaxk.site/easysubway/privacy`
 - Support: `support@aquilaxk.site`
 - Security: `security@aquilaxk.site`
 - Data deletion and privacy requests: `privacy@aquilaxk.site`

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -224,6 +224,8 @@ public class SecurityConfig {
 					"/actuator/health/liveness",
 					"/actuator/health/readiness",
 					"/actuator/prometheus",
+					"/privacy",
+					"/easysubway/privacy",
 					"/api/v1/realtime/**",
 					"/favicon.ico",
 					"/css/**",

--- a/backend/src/main/java/com/easysubway/legal/adapter/in/web/PrivacyPolicyPageController.java
+++ b/backend/src/main/java/com/easysubway/legal/adapter/in/web/PrivacyPolicyPageController.java
@@ -1,0 +1,13 @@
+package com.easysubway.legal.adapter.in.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class PrivacyPolicyPageController {
+
+	@GetMapping({ "/privacy", "/easysubway/privacy" })
+	String privacyPolicy() {
+		return "legal/privacy";
+	}
+}

--- a/backend/src/main/resources/templates/legal/privacy.html
+++ b/backend/src/main/resources/templates/legal/privacy.html
@@ -1,0 +1,207 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>쉬운 지하철 개인정보처리방침</title>
+	<meta name="description" content="쉬운 지하철 앱의 개인정보 수집 항목, 이용 목적, 보관 기간, 삭제 요청 방법을 안내합니다.">
+	<style>
+		body {
+			margin: 0;
+			background: #f7f8fb;
+			color: #162033;
+			font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+			line-height: 1.65;
+		}
+		main {
+			max-width: 860px;
+			margin: 0 auto;
+			padding: 48px 20px 72px;
+		}
+		h1 {
+			margin: 0 0 8px;
+			font-size: clamp(2rem, 5vw, 3rem);
+			line-height: 1.15;
+		}
+		h2 {
+			margin-top: 40px;
+			font-size: 1.35rem;
+		}
+		.meta,
+		footer {
+			color: #526071;
+		}
+		section {
+			margin-top: 28px;
+			padding-top: 4px;
+		}
+		ul {
+			padding-left: 1.25rem;
+		}
+		table {
+			width: 100%;
+			border-collapse: collapse;
+			background: #ffffff;
+		}
+		th,
+		td {
+			border: 1px solid #d8dee9;
+			padding: 12px;
+			text-align: left;
+			vertical-align: top;
+		}
+		th {
+			background: #edf2f7;
+		}
+		a {
+			color: #0b5cad;
+		}
+		@media (max-width: 640px) {
+			table,
+			thead,
+			tbody,
+			tr,
+			th,
+			td {
+				display: block;
+			}
+			thead {
+				position: absolute;
+				width: 1px;
+				height: 1px;
+				overflow: hidden;
+			}
+			tr {
+				border: 1px solid #d8dee9;
+				margin-bottom: 12px;
+				background: #ffffff;
+			}
+			th,
+			td {
+				border: 0;
+			}
+		}
+	</style>
+</head>
+<body>
+<main>
+	<header>
+		<h1>쉬운 지하철 개인정보처리방침</h1>
+		<p class="meta">시행일: 2026년 6월 28일</p>
+		<p>
+			쉬운 지하철(easysubway)은 교통약자가 도시철도를 더 쉽게 이용할 수 있도록 역, 시설, 경로, 신고 기능을 제공합니다.
+			이 문서는 앱에서 처리하는 개인정보, 보관 기준, 삭제 요청 방법, 문의 창구를 설명합니다.
+		</p>
+	</header>
+
+	<section>
+		<h2>처리하는 개인정보 항목과 목적</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">항목</th>
+				<th scope="col">처리 목적</th>
+				<th scope="col">보관 기준</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr>
+				<td>현재 위치</td>
+				<td>가까운 역 검색, 시설 신고 위치 확인</td>
+				<td>주변 역 검색 위치는 저장하지 않고, 신고 위치는 신고 처리와 운영 검수에 필요한 기간 동안 보관</td>
+			</tr>
+			<tr>
+				<td>역·경로 검색어, 최근 검색, 즐겨찾기</td>
+				<td>역 검색, 경로 안내, 자주 보는 역·시설·경로 표시</td>
+				<td>기기 또는 서버에 저장된 값은 사용자가 삭제하거나 데이터 삭제를 요청할 때까지 보관</td>
+			</tr>
+			<tr>
+				<td>이동 조건 선택값</td>
+				<td>계단 회피, 엘리베이터 우선 등 접근성 경로 안내</td>
+				<td>사용자가 변경, 초기화, 삭제 요청할 때까지 보관</td>
+			</tr>
+			<tr>
+				<td>시설 신고 내용, 사진, 접수 식별 정보</td>
+				<td>시설 고장, 공사, 위치 오류 신고 검토와 처리 상태 안내</td>
+				<td>신고 처리, 중복·악용 방지, 운영 검수에 필요한 기간 동안 보관 후 삭제 또는 익명화</td>
+			</tr>
+			<tr>
+				<td>충돌, ANR, 성능 진단 정보</td>
+				<td>앱 오류 분석, 서비스 안정성 개선, 보안·악용 대응</td>
+				<td>운영 장애 분석에 필요한 최소 기간 동안 보관 후 삭제 또는 익명화</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>민감한 상태 정보</h2>
+		<p>
+			쉬운 지하철은 장애, 임신, 질병, 부상 여부를 증명하는 서류나 진단정보를 요구하지 않습니다.
+			앱은 사용자가 직접 선택한 이동 조건을 경로 안내에만 사용하며, 광고나 추적 목적으로 사용하지 않습니다.
+		</p>
+	</section>
+
+	<section>
+		<h2>보관, 전송, 파기</h2>
+		<p>
+			즐겨찾기, 최근 검색, 앱 설정, 신고 초안, 설치된 데이터팩 기록은 기본적으로 사용자 기기에 보관됩니다.
+			신고 제출이나 삭제 요청처럼 네트워크 전송이 필요한 경우 HTTPS를 사용합니다.
+			보관 목적이 끝나거나 삭제 요청 처리가 완료된 개인정보는 복구하기 어렵게 삭제하거나 식별 가능성을 줄입니다.
+		</p>
+	</section>
+
+	<section>
+		<h2>제3자 제공, 처리 위탁, 추적</h2>
+		<p>
+			쉬운 지하철은 개인정보나 민감정보를 판매하지 않습니다.
+			광고 목적의 tracking을 하지 않으며, 신고 사진과 위치 정보는 앱 기능 제공과 신고 검토 목적에만 사용합니다.
+			서비스 운영에 필요한 범위에서만 Cloudflare, Oracle Cloud Infrastructure, Google Play Console 같은 인프라와 스토어 운영 도구를 사용할 수 있으며,
+			이 경우 해당 사업자는 서비스 제공, 보안, 저장, 배포, 진단 목적의 처리만 수행합니다.
+		</p>
+	</section>
+
+	<section>
+		<h2>권리 행사와 삭제 요청</h2>
+		<p>
+			사용자는 개인정보 열람, 정정, 삭제, 처리 정지를 요청할 수 있습니다.
+			신고 데이터 삭제, 개인정보 문의, 보안 신고는 아래 주소로 요청할 수 있으며, 요청 확인에 필요한 최소 정보만 확인한 뒤 처리합니다.
+		</p>
+		<ul>
+			<li>개인정보 및 삭제 요청: <a href="mailto:privacy@aquilaxk.site">privacy@aquilaxk.site</a></li>
+			<li>고객지원: <a href="mailto:support@aquilaxk.site">support@aquilaxk.site</a></li>
+			<li>보안 문의: <a href="mailto:security@aquilaxk.site">security@aquilaxk.site</a></li>
+		</ul>
+	</section>
+
+	<section>
+		<h2>아동의 개인정보</h2>
+		<p>
+			쉬운 지하철은 만 14세 미만 아동을 주 대상으로 하지 않습니다.
+			만 14세 미만 아동의 개인정보 처리 요청이 확인되면 법정대리인 확인 등 필요한 절차에 따라 처리합니다.
+		</p>
+	</section>
+
+	<section>
+		<h2>안전성 확보 조치</h2>
+		<p>
+			개인정보는 접근 권한을 제한하고, 운영 로그에는 신고 receipt token, 사진 원본, 서명된 업로드 URL, 저장소 자격 증명을 남기지 않도록 관리합니다.
+			관리자 화면은 인증된 운영자만 접근할 수 있으며, 네트워크 전송에는 HTTPS를 사용합니다.
+		</p>
+	</section>
+
+	<section>
+		<h2>변경 안내</h2>
+		<p>
+			개인정보 처리 내용이 바뀌면 이 페이지의 시행일과 내용을 갱신합니다.
+			중요한 변경은 앱 또는 스토어 안내에 반영합니다.
+		</p>
+	</section>
+
+	<footer>
+		<p>서비스명: 쉬운 지하철(easysubway)</p>
+		<p>개인정보 보호책임자 및 처리자: AquilaXk, <a href="mailto:privacy@aquilaxk.site">privacy@aquilaxk.site</a></p>
+	</footer>
+</main>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
+++ b/backend/src/test/java/com/easysubway/health/adapter/in/web/HealthCheckControllerTest.java
@@ -95,6 +95,22 @@ class HealthCheckControllerTest {
 	}
 
 	@Test
+	@DisplayName("개인정보처리방침 공개 페이지를 인증 없이 노출한다")
+	void privacyPolicyPageIsPublic() throws Exception {
+		mockMvc.perform(get("/easysubway/privacy"))
+			.andExpect(status().isOk())
+			.andExpect(result -> assertThat(result.getResponse().getContentAsString())
+				.contains(
+					"쉬운 지하철 개인정보처리방침",
+					"처리하는 개인정보 항목과 목적",
+					"제3자 제공, 처리 위탁, 추적",
+					"권리 행사와 삭제 요청",
+					"개인정보 보호책임자",
+					"privacy@aquilaxk.site"
+				));
+	}
+
+	@Test
 	@DisplayName("명시적으로 허용되지 않은 백엔드 경로는 기본 차단된다")
 	void unknownBackendPathIsDeniedByDefault() throws Exception {
 		mockMvc.perform(get("/api/v1/internal-unlisted-resource"))

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2056,7 +2056,7 @@ test("스토어 개인정보 제출 기준선은 release artifact placeholder �
   assert.match(readme, /EASYSUBWAY_PRIVACY_POLICY_URL/);
   assert.match(readme, /EASYSUBWAY_DATA_DELETION_EMAIL/);
   assert.match(readme, /## Privacy Policy/);
-  assert.match(readme, /https:\/\/github\.com\/AquilaXk\/easysubway#privacy-policy/);
+  assert.match(readme, /https:\/\/easysubway-api\.aquilaxk\.site\/easysubway\/privacy/);
   assert.match(readme, /EasySubway does not sell personal or sensitive user data\./);
   assert.match(readme, /support@aquilaxk\.site/);
   assert.match(readme, /security@aquilaxk\.site/);
@@ -2066,7 +2066,7 @@ test("스토어 개인정보 제출 기준선은 release artifact placeholder �
   const dir = await mkdtemp(path.join(tmpdir(), "easysubway-store-privacy-env-"));
   const validEnv = path.join(dir, "valid.env");
   await writeFile(validEnv, [
-    "EASYSUBWAY_PRIVACY_POLICY_URL=https://github.com/AquilaXk/easysubway#privacy-policy",
+    "EASYSUBWAY_PRIVACY_POLICY_URL=https://easysubway-api.aquilaxk.site/easysubway/privacy",
     "EASYSUBWAY_SUPPORT_EMAIL=support@aquilaxk.site",
     "EASYSUBWAY_SECURITY_EMAIL=security@aquilaxk.site",
     "EASYSUBWAY_DATA_DELETION_EMAIL=privacy@aquilaxk.site",
@@ -2081,14 +2081,14 @@ test("스토어 개인정보 제출 기준선은 release artifact placeholder �
     },
   );
   const githubEnvOutput = readFileSync(githubEnv, "utf8");
-  assert.match(githubEnvOutput, /^EASYSUBWAY_PRIVACY_POLICY_URL=https:\/\/github\.com\/AquilaXk\/easysubway#privacy-policy$/m);
+  assert.match(githubEnvOutput, /^EASYSUBWAY_PRIVACY_POLICY_URL=https:\/\/easysubway-api\.aquilaxk\.site\/easysubway\/privacy$/m);
   assert.match(githubEnvOutput, /^EASYSUBWAY_SUPPORT_EMAIL=support@aquilaxk\.site$/m);
   assert.match(githubEnvOutput, /^EASYSUBWAY_SECURITY_EMAIL=security@aquilaxk\.site$/m);
   assert.match(githubEnvOutput, /^EASYSUBWAY_DATA_DELETION_EMAIL=privacy@aquilaxk\.site$/m);
 
   const rcEnv = path.join(dir, "android-rc.env");
   await writeFile(rcEnv, [
-    "EASYSUBWAY_PRIVACY_POLICY_URL=https://github.com/AquilaXk/easysubway#privacy-policy",
+    "EASYSUBWAY_PRIVACY_POLICY_URL=https://easysubway-api.aquilaxk.site/easysubway/privacy",
     "EASYSUBWAY_SUPPORT_EMAIL=support@aquilaxk.site",
     "EASYSUBWAY_SECURITY_EMAIL=security@aquilaxk.site",
     "EASYSUBWAY_DATA_DELETION_EMAIL=privacy@aquilaxk.site",
@@ -2141,7 +2141,7 @@ test("스토어 개인정보 제출 기준선은 release artifact placeholder �
 
   const invalidRcEnv = path.join(dir, "invalid-android-rc.env");
   await writeFile(invalidRcEnv, [
-    "EASYSUBWAY_PRIVACY_POLICY_URL=https://github.com/AquilaXk/easysubway#privacy-policy",
+    "EASYSUBWAY_PRIVACY_POLICY_URL=https://easysubway-api.aquilaxk.site/easysubway/privacy",
     "EASYSUBWAY_SUPPORT_EMAIL=support@aquilaxk.site",
     "EASYSUBWAY_SECURITY_EMAIL=security@aquilaxk.site",
     "EASYSUBWAY_DATA_DELETION_EMAIL=privacy@aquilaxk.site",
@@ -2167,7 +2167,7 @@ test("스토어 개인정보 제출 기준선은 release artifact placeholder �
 
   const invalidRcKeyEnv = path.join(dir, "invalid-android-rc-key.env");
   await writeFile(invalidRcKeyEnv, [
-    "EASYSUBWAY_PRIVACY_POLICY_URL=https://github.com/AquilaXk/easysubway#privacy-policy",
+    "EASYSUBWAY_PRIVACY_POLICY_URL=https://easysubway-api.aquilaxk.site/easysubway/privacy",
     "EASYSUBWAY_SUPPORT_EMAIL=support@aquilaxk.site",
     "EASYSUBWAY_SECURITY_EMAIL=security@aquilaxk.site",
     "EASYSUBWAY_DATA_DELETION_EMAIL=privacy@aquilaxk.site",
@@ -2193,7 +2193,7 @@ test("스토어 개인정보 제출 기준선은 release artifact placeholder �
 
   const invalidRcFingerprintEnv = path.join(dir, "invalid-android-rc-fingerprint.env");
   await writeFile(invalidRcFingerprintEnv, [
-    "EASYSUBWAY_PRIVACY_POLICY_URL=https://github.com/AquilaXk/easysubway#privacy-policy",
+    "EASYSUBWAY_PRIVACY_POLICY_URL=https://easysubway-api.aquilaxk.site/easysubway/privacy",
     "EASYSUBWAY_SUPPORT_EMAIL=support@aquilaxk.site",
     "EASYSUBWAY_SECURITY_EMAIL=security@aquilaxk.site",
     "EASYSUBWAY_DATA_DELETION_EMAIL=privacy@aquilaxk.site",


### PR DESCRIPTION
## 관련 이슈

#1018 부분 해결. 이 PR만으로 #1018을 닫지 않는다.

## 작업 배경

- QA 요청에 따라 GitHub README anchor가 아니라 쉬운 지하철 운영 도메인에서 인증 없이 열리는 개인정보처리방침 URL이 필요하다.
- Play Console 개인정보처리방침 URL과 앱 도움말 `EASYSUBWAY_PRIVACY_POLICY_URL` 값이 같은 public HTTPS URL을 사용해야 한다.
- `datapack.aquilaxk.site`는 데이터팩 artifact 배포용이므로 정책 페이지는 backend/API 도메인인 `easysubway-api.aquilaxk.site`에 둔다.
- 업로드 전 검토에서 Google Play User Data 정책과 개인정보보호법 제30조 취지에 맞춰 처리 항목, 목적, 보관, 파기, 위탁, 권리 행사, 보호책임자, 아동, 안전성 확보 항목을 본문에 명시했다.

## 작업 내용

- `/easysubway/privacy`와 `/privacy`에서 같은 개인정보처리방침 페이지를 렌더링하는 backend controller와 Thymeleaf template를 추가했다.
- Spring Security default-deny 정책은 유지하고, privacy policy route만 명시적으로 `permitAll`에 추가했다.
- README와 store privacy env contract의 개인정보처리방침 URL을 `https://easysubway-api.aquilaxk.site/easysubway/privacy`로 전환했다.
- 정책 본문에 위치, 검색/즐겨찾기, 이동 조건, 신고 내용/사진, 진단 정보별 목적과 보관 기준을 표로 분리했다.
- 장애·임신·질병 증빙이나 진단정보를 요구하지 않고 이동 조건 선택값만 경로 안내에 사용한다는 문구를 추가했다.
- Cloudflare, Oracle Cloud Infrastructure, Google Play Console은 인프라/스토어 운영 목적 처리로만 쓰며 판매·광고 추적이 없다는 기준을 명시했다.

## 검증

- 실행한 명령과 결과:
- `./backend/gradlew -p backend test --tests '*HealthCheckControllerTest' --tests '*SecurityConfigTest'`: exit 0
- `node --test --test-name-pattern "스토어 개인정보 제출 기준선" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
- `./backend/gradlew -p backend test`: exit 0
- `node --test tools/ci/*.test.mjs`: exit 0, 129 tests passed
- `git diff --check`: exit 0
- `curl -I --max-time 10 https://easysubway-api.aquilaxk.site/actuator/health/readiness`: HTTP 200, 운영 backend 도메인 확인
- `curl -I --max-time 10 https://easysubway-api.aquilaxk.site/easysubway/privacy`: HTTP 403, 배포 전 현재 운영본은 아직 route 미공개 상태임을 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 개인정보처리방침 route | backend local test | MockMvc GET `/easysubway/privacy` | `HealthCheckControllerTest.privacyPolicyPageIsPublic`, exit 0 | 인증 없이 200과 본문 핵심 문구 확인 |
| 개인정보처리방침 본문 | backend local test | 필수 항목 문구 assertion | 처리 항목/목적, 위탁/추적, 권리 행사, 보호책임자 문구 확인 | Google Play 제출 전 보강 항목 반영 |
| 보안 allowlist | backend local test | SecurityConfig 포함 테스트 | `./backend/gradlew -p backend test --tests '*HealthCheckControllerTest' --tests '*SecurityConfigTest'`, exit 0 | default-deny 유지, privacy route만 공개 |
| store privacy URL 계약 | local CI | repository contract targeted/full | targeted 1 passed, full 129 passed | README/env 검증 URL이 운영 도메인과 일치 |
| 운영 도메인 | production DNS/HTTP | readiness HEAD 요청 | `https://easysubway-api.aquilaxk.site/actuator/health/readiness` HTTP 200 | backend 운영 도메인 확인 |
| 배포 전 공개 상태 | production HTTP | privacy route HEAD 요청 | `https://easysubway-api.aquilaxk.site/easysubway/privacy` HTTP 403 | PR merge/CD 전에는 아직 미공개, merge 후 CD에서 200 재확인 필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `SecurityConfig`에서 새 공개 route가 `/privacy`, `/easysubway/privacy` 두 개로 제한되어 있는지 확인하면 된다.
- `datapack.aquilaxk.site`는 데이터팩 artifact용이라 개인정보처리방침 URL로 쓰지 않았다.
- 법률 검토는 제출 전 실무 리스크 축소 목적이며, 최종 법률 자문은 별도 확인이 필요하다.

## 리스크

- 운영 CD가 merge된 backend image를 배포하기 전까지 실제 Play Console URL은 403이다.
- release artifact build에 쓰는 `EASYSUBWAY_ENV` secret은 이 PR merge 후 같은 URL로 갱신해야 앱 도움말과 Play Console 값이 일치한다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
