### PR TITLE
[Feat] 홈 대화면 레이아웃 기준 추가

### DIFF
--- a/apps/mobile/lib/adaptive_layout.dart
+++ b/apps/mobile/lib/adaptive_layout.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/widgets.dart';
+
+class EasySubwayAdaptiveLayout {
+  const EasySubwayAdaptiveLayout._();
+
+  static const double largeScreenMinWidth = 840;
+  static const double largeScreenMaxContentWidth = 1180;
+  static const double largeScreenGutter = 24;
+  static const double largeScreenColumnGap = 18;
+
+  static bool isLargeScreen(BoxConstraints constraints) {
+    return constraints.maxWidth >= largeScreenMinWidth;
+  }
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'accessible_design.dart';
+import 'adaptive_layout.dart';
 import 'app/app_bootstrap.dart';
 import 'app/app_dependencies.dart';
 import 'facility_report.dart';
@@ -1359,6 +1360,38 @@ class _HomeScreenState extends State<HomeScreen> {
       );
     }
 
+    final heroSection = _HomePrototypeHero(
+      profile: currentProfile,
+      onRouteSearch: openRouteSearch,
+      onStationSearch: () => unawaited(openStationSearch()),
+      onProfileTap: openSettings,
+    );
+    final routeDraftSection = AnimatedBuilder(
+      animation: _routeDraftController,
+      builder: (context, _) {
+        final draft = _routeDraftController.draft;
+        if (draft.origin == null && draft.destination == null) {
+          return const SizedBox.shrink();
+        }
+        return _HomeRouteDraftCard(draft: draft, onTap: openRouteSearch);
+      },
+    );
+    final stationActions = _HomeStationActionRow(
+      onRecentSearch: () =>
+          unawaited(openStationSearch(StationSearchEntryMode.recent)),
+      onNearbyStations: () =>
+          unawaited(openStationSearch(StationSearchEntryMode.nearby)),
+    );
+    final facilitySection = _HomeFacilityAlertSection(
+      facilitiesFuture: _favoriteFacilitiesFuture,
+      onOpenFacilities: openSavedItems,
+    );
+    final recentRouteSection = _HomeRecentRouteSection(
+      key: const Key('homeRecentRouteSection'),
+      routesFuture: _recentRoutesFuture,
+      onTap: openRouteSearch,
+    );
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('쉬운 지하철'),
@@ -1379,50 +1412,33 @@ class _HomeScreenState extends State<HomeScreen> {
         ],
       ),
       body: SafeArea(
-        child: RefreshIndicator(
-          key: const Key('homeRefreshIndicator'),
-          onRefresh: refreshHomeState,
-          child: ListView(
-            key: const Key('homePrototypeList'),
-            physics: const AlwaysScrollableScrollPhysics(),
-            padding: const EdgeInsets.fromLTRB(17, 18, 17, 96),
-            children: [
-              _HomePrototypeHero(
-                profile: currentProfile,
-                onRouteSearch: openRouteSearch,
-                onStationSearch: () => unawaited(openStationSearch()),
-                onProfileTap: openSettings,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final isLargeScreen = EasySubwayAdaptiveLayout.isLargeScreen(
+              constraints,
+            );
+            return RefreshIndicator(
+              key: const Key('homeRefreshIndicator'),
+              onRefresh: refreshHomeState,
+              child: ListView(
+                key: const Key('homePrototypeList'),
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: isLargeScreen
+                    ? const EdgeInsets.fromLTRB(24, 24, 24, 112)
+                    : const EdgeInsets.fromLTRB(17, 18, 17, 96),
+                children: [
+                  _HomeAdaptiveContent(
+                    isLargeScreen: isLargeScreen,
+                    heroSection: heroSection,
+                    routeDraftSection: routeDraftSection,
+                    stationActions: stationActions,
+                    facilitySection: facilitySection,
+                    recentRouteSection: recentRouteSection,
+                  ),
+                ],
               ),
-              AnimatedBuilder(
-                animation: _routeDraftController,
-                builder: (context, _) {
-                  final draft = _routeDraftController.draft;
-                  if (draft.origin == null && draft.destination == null) {
-                    return const SizedBox.shrink();
-                  }
-                  return _HomeRouteDraftCard(
-                    draft: draft,
-                    onTap: openRouteSearch,
-                  );
-                },
-              ),
-              _HomeStationActionRow(
-                onRecentSearch: () =>
-                    unawaited(openStationSearch(StationSearchEntryMode.recent)),
-                onNearbyStations: () =>
-                    unawaited(openStationSearch(StationSearchEntryMode.nearby)),
-              ),
-              _HomeFacilityAlertSection(
-                facilitiesFuture: _favoriteFacilitiesFuture,
-                onOpenFacilities: openSavedItems,
-              ),
-              _HomeRecentRouteSection(
-                key: const Key('homeRecentRouteSection'),
-                routesFuture: _recentRoutesFuture,
-                onTap: openRouteSearch,
-              ),
-            ],
-          ),
+            );
+          },
         ),
       ),
       bottomNavigationBar: NavigationBar(
@@ -1592,6 +1608,70 @@ class _HomeNotificationButton extends StatelessWidget {
               icon: const Icon(Icons.notifications_none),
             ),
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeAdaptiveContent extends StatelessWidget {
+  const _HomeAdaptiveContent({
+    required this.isLargeScreen,
+    required this.heroSection,
+    required this.routeDraftSection,
+    required this.stationActions,
+    required this.facilitySection,
+    required this.recentRouteSection,
+  });
+
+  final bool isLargeScreen;
+  final Widget heroSection;
+  final Widget routeDraftSection;
+  final Widget stationActions;
+  final Widget facilitySection;
+  final Widget recentRouteSection;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isLargeScreen) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          heroSection,
+          routeDraftSection,
+          stationActions,
+          facilitySection,
+          recentRouteSection,
+        ],
+      );
+    }
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(
+          maxWidth: EasySubwayAdaptiveLayout.largeScreenMaxContentWidth,
+        ),
+        child: Row(
+          key: const Key('homeLargeScreenLayout'),
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(flex: 5, child: heroSection),
+            const SizedBox(
+              width: EasySubwayAdaptiveLayout.largeScreenColumnGap,
+            ),
+            Expanded(
+              flex: 4,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  routeDraftSection,
+                  stationActions,
+                  facilitySection,
+                  recentRouteSection,
+                ],
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5,6 +5,7 @@ import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:easysubway_mobile/accessible_design.dart';
+import 'package:easysubway_mobile/adaptive_layout.dart';
 import 'package:easysubway_mobile/auth_headers.dart';
 import 'package:easysubway_mobile/main.dart';
 import 'package:easysubway_mobile/facility_report.dart';
@@ -609,6 +610,54 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('홈 화면은 태블릿 landscape에서 핵심 CTA와 보조 영역을 나란히 보여준다', (tester) async {
+    tester.view.physicalSize = const Size(1280, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(
+          favorites: [_favoriteRoute()],
+        ),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('homeLargeScreenLayout')), findsOneWidget);
+    expect(find.byKey(const Key('homeBottomNavigationBar')), findsOneWidget);
+    expect(find.byKey(const Key('routeSearchButton')), findsOneWidget);
+    expect(find.byKey(const Key('heroStationSearchButton')), findsOneWidget);
+    expect(find.byKey(const Key('recentSearchButton')), findsOneWidget);
+    expect(find.byKey(const Key('homeRecentRouteSection')), findsOneWidget);
+
+    final homeList = tester.widget<ListView>(
+      find.byKey(const Key('homePrototypeList')),
+    );
+    final padding = homeList.padding!.resolve(TextDirection.ltr);
+    expect(padding.left, EasySubwayAdaptiveLayout.largeScreenGutter);
+    expect(padding.right, EasySubwayAdaptiveLayout.largeScreenGutter);
+    expect(padding.bottom, 112);
+
+    final heroRect = tester.getRect(find.byKey(const Key('homeHeroCard')));
+    final recentSearchRect = tester.getRect(
+      find.byKey(const Key('recentSearchButton')),
+    );
+
+    expect(heroRect.left, lessThan(recentSearchRect.left));
+    expect(heroRect.right, lessThan(recentSearchRect.left));
+    expect(heroRect.width, lessThan(800));
+    expect(recentSearchRect.top, lessThan(heroRect.bottom));
   });
 
   testWidgets('홈 우측 상단 알림 버튼은 알림함으로 이동한다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

- #1051 부분 해결
- 이 PR만으로 #1051을 닫지 않는다.

## 작업 배경

태블릿 landscape 환경에서 홈 화면이 phone 기준 단일 column으로만 보여 핵심 길찾기 CTA와 보조 진입점이 같은 세로 흐름에 쌓였다. 대화면 첫 화면에서 주요 행동과 보조 행동을 나란히 볼 수 있도록 홈 화면의 최소 adaptive 기준을 추가한다.

## 작업 내용

- 홈 화면에 840dp 이상 대화면 분기 기준을 추가했다.
- 대화면에서는 길찾기/역 검색 hero 영역을 왼쪽에 두고 최근 검색/가까운 역/저장 정보 영역을 오른쪽 column에 배치했다.
- phone 폭에서는 기존 단일 column 순서와 여백을 유지한다.
- 1280x800 widget viewport에서 대화면 row layout, CTA 유지, 좌우 배치, padding을 검증하는 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter analyze`: exit 0, No issues found.
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test`: exit 0, 528 tests passed.
  - `node --test tools/ci/*.test.mjs`: exit 0, 129 tests passed.
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성.
  - `adb -s emulator-5554 install apps/mobile/build/app/outputs/flutter-apk/app-debug.apk`: 기존 로컬 에뮬레이터 패키지 서명 불일치로 1회 실패 후 `adb -s emulator-5554 uninstall com.easysubway.app`로 로컬 QA 앱만 제거하고 재설치 성공.
  - `adb -s emulator-5554 shell am start -n com.easysubway.app/com.easysubway.easysubway_mobile.MainActivity`: exit 0, Android API 36 emulator에서 홈 화면 실행.
  - post-merge `gh run list --branch main --limit 10`: merge commit `e50d18b0`의 CI/Release Artifacts/SonarCloud push run 생성 확인. 같은 commit의 CD run은 아직 없고, 이 merge로 이미 실패한 CD 신호는 없음.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 정적 분석 | local macOS / Flutter | `flutter analyze` | command output | No issues found |
| 모바일 테스트 | local macOS / Flutter test | `flutter test` | command output | 528 tests passed |
| 저장소 계약 | local macOS / Node test | `node --test tools/ci/*.test.mjs` | command output | 129 tests passed |
| Android 대화면 홈 | Android API 36 emulator | 1920x1080, 160dpi 조건에서 debug APK 실행 후 screenshot/UI tree 확인 | local-only: `.codex/evidence/1051/android-home-large.png`, `.codex/evidence/1051/android-home-large-ui.xml` | hero CTA는 왼쪽, 최근 검색/가까운 역 버튼은 오른쪽에 표시됨 |

화면 증거는 이 저장소 정책상 git에 커밋하지 않았다. 이 세션에서 별도 외부 이미지 업로드 승인은 받지 않았으므로 local-only evidence로 보관하고, PR에는 command 결과와 UI tree bounds 확인을 함께 남긴다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/adaptive_layout.dart`: 대화면 breakpoint와 content width 상수.
  - `apps/mobile/lib/main.dart`: phone 단일 column 유지와 large screen row 전환.
  - `apps/mobile/test/widget_test.dart`: tablet landscape layout 회귀 테스트.

## 리스크

- 이번 PR은 홈 화면 첫 작업 단위만 다룬다. #1051의 다른 화면 tablet 대응은 후속 PR에서 계속 진행해야 한다.
- Android screenshot은 local-only evidence라 PR에서 직접 렌더링되지 않는다. 대신 widget test와 UI tree bounds로 배치 조건을 재검증했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
