### PR TITLE
[Feat] 역 검색 대화면 레이아웃 추가

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'accessible_design.dart';
+import 'adaptive_layout.dart';
 import 'facility_status.dart';
 import 'facility_report.dart';
 import 'features/route_draft/application/route_draft_controller.dart';
@@ -1893,6 +1894,176 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
         _hasSearchQuery ||
         _shouldShowNearbyFallbackSearch;
     final showNearbyRetryButton = isNearbyEntry && !_hasSearchQuery;
+    final searchInputSection = Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (showSearchInput) ...[
+          TextField(
+            key: const Key('stationSearchInput'),
+            controller: _queryController,
+            minLines: 1,
+            textInputAction: TextInputAction.search,
+            style: const TextStyle(fontSize: 20, height: 1.35),
+            decoration: InputDecoration(
+              hintText: '역 이름을 입력해 주세요',
+              floatingLabelBehavior: FloatingLabelBehavior.always,
+              prefixIcon: const Icon(Icons.search),
+              suffixIcon: _hasSearchQuery
+                  ? IconButton(
+                      tooltip: '검색어 지우기',
+                      onPressed: _queryController.clear,
+                      icon: const Icon(Icons.close),
+                    )
+                  : null,
+              filled: true,
+              fillColor: Colors.white,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(18),
+                borderSide: const BorderSide(
+                  color: EasySubwayAccessibleColors.line,
+                ),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(18),
+                borderSide: const BorderSide(
+                  color: EasySubwayAccessibleColors.line,
+                ),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(18),
+                borderSide: const BorderSide(
+                  color: EasySubwayAccessibleColors.primary,
+                  width: 2,
+                ),
+              ),
+            ),
+            onSubmitted: _submit,
+          ),
+          const SizedBox(height: 12),
+        ],
+      ],
+    );
+    final recentSearchSection = AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        final isSearching =
+            _controller.state.status == StationSearchStatus.loading;
+        if (isNearbyEntry || _hasSearchQuery) {
+          return const SizedBox.shrink();
+        }
+        if (_recentQueries.isEmpty) {
+          return isRecentEntry
+              ? Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: _StationRecentSearchEmptyState(
+                    onSearchTap: _openStationSearch,
+                  ),
+                )
+              : const SizedBox.shrink();
+        }
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: _StationRecentSearchSection(
+            queries: _recentQueries,
+            showTitle: !isRecentEntry,
+            enabled: !isSearching && !_isNearbySearchRunning,
+            onQuerySelected: _searchRecentQuery,
+            onQueryRemoved: _removeRecentQuery,
+            onClearAll: _clearRecentQueries,
+          ),
+        );
+      },
+    );
+    final actionButtonSection = Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (showSearchInput || showNearbyRetryButton) ...[
+          AnimatedBuilder(
+            animation: _controller,
+            builder: (context, _) {
+              final isSearching =
+                  _controller.state.status == StationSearchStatus.loading;
+              final isNearbyDisabled = isSearching || _isNearbySearchRunning;
+              if (showNearbyRetryButton) {
+                return OutlinedButton.icon(
+                  key: const Key('nearbyStationSearchButton'),
+                  onPressed: isNearbyDisabled ? null : _searchNearby,
+                  icon: const Icon(Icons.my_location),
+                  label: const Text('내 주변 역 다시 찾기'),
+                );
+              }
+              if (_hasSearchQuery) {
+                return FilledButton.icon(
+                  key: const Key('stationSearchSubmitButton'),
+                  onPressed: isSearching
+                      ? null
+                      : () => _submit(_queryController.text),
+                  icon: const Icon(Icons.search),
+                  label: const Text('검색'),
+                );
+              }
+              return OutlinedButton.icon(
+                key: const Key('nearbyStationSearchButton'),
+                onPressed: isNearbyDisabled ? null : _searchNearby,
+                icon: const Icon(Icons.my_location),
+                label: const Text('내 주변 역 찾기'),
+              );
+            },
+          ),
+          const SizedBox(height: 20),
+        ],
+      ],
+    );
+    final resultSection = AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        return _StationSearchBody(
+          state: _controller.state,
+          onResultTap: _openStationDetail,
+          onSetOrigin: widget.routeDraftController == null
+              ? null
+              : _setRouteOrigin,
+          onSetDestination: widget.routeDraftController == null
+              ? null
+              : _setRouteDestination,
+          isOpeningLocationSettings: _isOpeningLocationSettings,
+          onOpenLocationSettings: _openLocationSettings,
+        );
+      },
+    );
+    final lineFilterSection = Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (showSearchInput && _lineOptionsFuture != null)
+          AnimatedBuilder(
+            animation: _controller,
+            builder: (context, _) {
+              final isSearching =
+                  _controller.state.status == StationSearchStatus.loading;
+              final hasSearchResults =
+                  _controller.state.status == StationSearchStatus.success &&
+                  _controller.state.source == StationSearchResultSource.search;
+              return _StationLineFilterPanel(
+                expanded: !hasSearchResults || _isLineFilterExpanded,
+                collapsible: hasSearchResults,
+                onToggleExpanded: () {
+                  setState(() {
+                    _isLineFilterExpanded = !_isLineFilterExpanded;
+                  });
+                },
+                child: _StationLineFilterSection(
+                  linesFuture: _lineOptionsFuture!,
+                  selectedLine: _selectedLine,
+                  selectedRegion: _selectedLineRegion,
+                  enabled: !isSearching && !_isNearbySearchRunning,
+                  onRegionSelected: _selectLineRegion,
+                  onLineSelected: _selectLine,
+                ),
+              );
+            },
+          ),
+      ],
+    );
     return Scaffold(
       appBar: AppBar(
         title: Text(switch (widget.entryMode) {
@@ -1911,169 +2082,27 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
         ],
       ),
       body: SafeArea(
-        child: ListView(
-          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
-          children: [
-            if (showSearchInput) ...[
-              TextField(
-                key: const Key('stationSearchInput'),
-                controller: _queryController,
-                minLines: 1,
-                textInputAction: TextInputAction.search,
-                style: const TextStyle(fontSize: 20, height: 1.35),
-                decoration: InputDecoration(
-                  hintText: '역 이름을 입력해 주세요',
-                  floatingLabelBehavior: FloatingLabelBehavior.always,
-                  prefixIcon: const Icon(Icons.search),
-                  suffixIcon: _hasSearchQuery
-                      ? IconButton(
-                          tooltip: '검색어 지우기',
-                          onPressed: _queryController.clear,
-                          icon: const Icon(Icons.close),
-                        )
-                      : null,
-                  filled: true,
-                  fillColor: Colors.white,
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(18),
-                    borderSide: const BorderSide(
-                      color: EasySubwayAccessibleColors.line,
-                    ),
-                  ),
-                  enabledBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(18),
-                    borderSide: const BorderSide(
-                      color: EasySubwayAccessibleColors.line,
-                    ),
-                  ),
-                  focusedBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(18),
-                    borderSide: const BorderSide(
-                      color: EasySubwayAccessibleColors.primary,
-                      width: 2,
-                    ),
-                  ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final isLargeScreen = EasySubwayAdaptiveLayout.isLargeScreen(
+              constraints,
+            );
+            return ListView(
+              padding: isLargeScreen
+                  ? const EdgeInsets.fromLTRB(24, 24, 24, 40)
+                  : const EdgeInsets.fromLTRB(20, 20, 20, 32),
+              children: [
+                _StationSearchAdaptiveContent(
+                  isLargeScreen: isLargeScreen,
+                  searchInputSection: searchInputSection,
+                  recentSearchSection: recentSearchSection,
+                  actionButtonSection: actionButtonSection,
+                  resultSection: resultSection,
+                  lineFilterSection: lineFilterSection,
                 ),
-                onSubmitted: _submit,
-              ),
-              const SizedBox(height: 12),
-            ],
-            AnimatedBuilder(
-              animation: _controller,
-              builder: (context, _) {
-                final isSearching =
-                    _controller.state.status == StationSearchStatus.loading;
-                if (isNearbyEntry || _hasSearchQuery) {
-                  return const SizedBox.shrink();
-                }
-                if (_recentQueries.isEmpty) {
-                  return isRecentEntry
-                      ? Padding(
-                          padding: const EdgeInsets.only(bottom: 12),
-                          child: _StationRecentSearchEmptyState(
-                            onSearchTap: _openStationSearch,
-                          ),
-                        )
-                      : const SizedBox.shrink();
-                }
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: 12),
-                  child: _StationRecentSearchSection(
-                    queries: _recentQueries,
-                    showTitle: !isRecentEntry,
-                    enabled: !isSearching && !_isNearbySearchRunning,
-                    onQuerySelected: _searchRecentQuery,
-                    onQueryRemoved: _removeRecentQuery,
-                    onClearAll: _clearRecentQueries,
-                  ),
-                );
-              },
-            ),
-            if (showSearchInput || showNearbyRetryButton) ...[
-              AnimatedBuilder(
-                animation: _controller,
-                builder: (context, _) {
-                  final isSearching =
-                      _controller.state.status == StationSearchStatus.loading;
-                  final isNearbyDisabled =
-                      isSearching || _isNearbySearchRunning;
-                  if (showNearbyRetryButton) {
-                    return OutlinedButton.icon(
-                      key: const Key('nearbyStationSearchButton'),
-                      onPressed: isNearbyDisabled ? null : _searchNearby,
-                      icon: const Icon(Icons.my_location),
-                      label: const Text('내 주변 역 다시 찾기'),
-                    );
-                  }
-                  if (_hasSearchQuery) {
-                    return FilledButton.icon(
-                      key: const Key('stationSearchSubmitButton'),
-                      onPressed: isSearching
-                          ? null
-                          : () => _submit(_queryController.text),
-                      icon: const Icon(Icons.search),
-                      label: const Text('검색'),
-                    );
-                  }
-                  return OutlinedButton.icon(
-                    key: const Key('nearbyStationSearchButton'),
-                    onPressed: isNearbyDisabled ? null : _searchNearby,
-                    icon: const Icon(Icons.my_location),
-                    label: const Text('내 주변 역 찾기'),
-                  );
-                },
-              ),
-              const SizedBox(height: 20),
-            ],
-            AnimatedBuilder(
-              animation: _controller,
-              builder: (context, _) {
-                return _StationSearchBody(
-                  state: _controller.state,
-                  onResultTap: _openStationDetail,
-                  onSetOrigin: widget.routeDraftController == null
-                      ? null
-                      : _setRouteOrigin,
-                  onSetDestination: widget.routeDraftController == null
-                      ? null
-                      : _setRouteDestination,
-                  isOpeningLocationSettings: _isOpeningLocationSettings,
-                  onOpenLocationSettings: _openLocationSettings,
-                );
-              },
-            ),
-            if (showSearchInput && _lineOptionsFuture != null) ...[
-              const SizedBox(height: 16),
-              AnimatedBuilder(
-                animation: _controller,
-                builder: (context, _) {
-                  final isSearching =
-                      _controller.state.status == StationSearchStatus.loading;
-                  final hasSearchResults =
-                      _controller.state.status == StationSearchStatus.success &&
-                      _controller.state.source ==
-                          StationSearchResultSource.search;
-                  return _StationLineFilterPanel(
-                    expanded: !hasSearchResults || _isLineFilterExpanded,
-                    collapsible: hasSearchResults,
-                    onToggleExpanded: () {
-                      setState(() {
-                        _isLineFilterExpanded = !_isLineFilterExpanded;
-                      });
-                    },
-                    child: _StationLineFilterSection(
-                      linesFuture: _lineOptionsFuture!,
-                      selectedLine: _selectedLine,
-                      selectedRegion: _selectedLineRegion,
-                      enabled: !isSearching && !_isNearbySearchRunning,
-                      onRegionSelected: _selectLineRegion,
-                      onLineSelected: _selectLine,
-                    ),
-                  );
-                },
-              ),
-            ],
-          ],
+              ],
+            );
+          },
         ),
       ),
     );
@@ -2908,6 +2937,76 @@ class _LineFilterBadge extends StatelessWidget {
           fontSize: fontSize * 0.8,
           fontWeight: FontWeight.w700,
           height: 1.0,
+        ),
+      ),
+    );
+  }
+}
+
+class _StationSearchAdaptiveContent extends StatelessWidget {
+  const _StationSearchAdaptiveContent({
+    required this.isLargeScreen,
+    required this.searchInputSection,
+    required this.recentSearchSection,
+    required this.actionButtonSection,
+    required this.resultSection,
+    required this.lineFilterSection,
+  });
+
+  final bool isLargeScreen;
+  final Widget searchInputSection;
+  final Widget recentSearchSection;
+  final Widget actionButtonSection;
+  final Widget resultSection;
+  final Widget lineFilterSection;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isLargeScreen) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          searchInputSection,
+          recentSearchSection,
+          actionButtonSection,
+          resultSection,
+          const SizedBox(height: 16),
+          lineFilterSection,
+        ],
+      );
+    }
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(
+          maxWidth: EasySubwayAdaptiveLayout.largeScreenMaxContentWidth,
+        ),
+        child: Row(
+          key: const Key('stationSearchLargeScreenLayout'),
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              flex: 5,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  searchInputSection,
+                  actionButtonSection,
+                  resultSection,
+                ],
+              ),
+            ),
+            const SizedBox(
+              width: EasySubwayAdaptiveLayout.largeScreenColumnGap,
+            ),
+            Expanded(
+              flex: 4,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [recentSearchSection, lineFilterSection],
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5478,6 +5478,86 @@ void main() {
     expect(find.byKey(const Key('stationLineFilter-seoul-4')), findsOneWidget);
   });
 
+  testWidgets('역 검색은 태블릿 landscape에서 결과와 필터를 나란히 보여준다', (tester) async {
+    tester.view.physicalSize = const Size(1280, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final repository = FakeStationSearchRepository(
+      lineOptions: const [
+        SubwayLineOption(
+          id: 'seoul-4',
+          name: '수도권 4호선',
+          color: '#00A5DE',
+          region: '수도권',
+          lineCode: '4',
+          active: true,
+        ),
+      ],
+      nextResults: [
+        const StationSearchResult(
+          id: 'station-sangnoksu',
+          nameKo: '상록수',
+          nameEn: 'Sangnoksu',
+          region: '수도권',
+          dataQualityLevel: 'LEVEL_1',
+          lastVerifiedAt: '2026-06-12',
+          lines: [
+            StationSearchLine(
+              id: 'seoul-4',
+              name: '수도권 4호선',
+              color: '#00A5DE',
+              stationCode: '448',
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('stationSearchLargeScreenLayout')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('stationLineFilterPanel')), findsOneWidget);
+    expect(find.text('노선 필터 펼치기'), findsOneWidget);
+
+    final resultRect = tester.getRect(
+      find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+    );
+    final filterRect = tester.getRect(
+      find.byKey(const Key('stationLineFilterPanel')),
+    );
+    final inputRect = tester.getRect(
+      find.byKey(const Key('stationSearchInput')),
+    );
+
+    expect(inputRect.right, lessThan(filterRect.left));
+    expect(resultRect.right, lessThan(filterRect.left));
+    expect(filterRect.top, lessThan(resultRect.bottom));
+  });
+
   testWidgets('역 검색은 노선을 선택해 결과를 좁힌다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final repository = FakeStationSearchRepository(


### PR DESCRIPTION
## 관련 이슈

#1051 부분 해결

## 작업 배경

태블릿 landscape 같은 넓은 화면에서 역 검색 화면이 휴대폰과 같은 단일 컬럼으로만 표시되어, 입력·결과 영역과 노선 필터를 동시에 비교하기 어렵습니다. 홈 화면 대화면 기준과 같은 breakpoint를 역 검색에도 적용해 넓은 화면에서 정보 탐색 흐름을 분리합니다.

## 작업 내용

- 역 검색 화면에 `EasySubwayAdaptiveLayout` 기준의 대화면 분기를 추가했습니다.
- 대화면에서는 검색 입력·검색 버튼·결과 영역을 왼쪽 컬럼에 두고, 최근 검색·노선 필터를 오른쪽 컬럼에 배치했습니다.
- 휴대폰 화면에서는 기존 단일 컬럼 흐름과 역 상세 전체 화면 이동 방식을 유지했습니다.
- 태블릿 landscape에서 검색 결과와 노선 필터가 좌우로 분리되는 위젯 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/widget_test.dart --plain-name "역 검색은 태블릿 landscape에서 결과와 필터를 나란히 보여준다"`: exit 0
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/widget_test.dart --plain-name "역 검색 결과는 입력창 바로 아래에 먼저 보이고 필터는 접을 수 있다"`: exit 0
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter analyze`: exit 0, No issues found
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/widget_test.dart`: exit 0, 161 tests passed
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test`: exit 0, 529 tests passed
  - `node --test tools/ci/*.test.mjs`: exit 0, 129 tests passed
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `adb -s emulator-5554 install -r apps/mobile/build/app/outputs/flutter-apk/app-debug.apk`: exit 0, Success

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 검색 대화면 결과·필터 분리 | Flutter widget test | 1280x800 viewport에서 검색 결과 카드와 필터 패널 bounds 비교 | `flutter test test/widget_test.dart --plain-name "역 검색은 태블릿 landscape에서 결과와 필터를 나란히 보여준다"` | 결과 카드와 필터 패널이 좌우로 분리됨 |
| 휴대폰 역 검색 흐름 유지 | Flutter widget test | 기존 휴대폰 검색 결과·필터 접힘 테스트 재실행 | `flutter test test/widget_test.dart --plain-name "역 검색 결과는 입력창 바로 아래에 먼저 보이고 필터는 접을 수 있다"` | 기존 단일 컬럼 계약 유지 |
| Android 대화면 실제 렌더링 | Android emulator | debug APK 설치 후 1920x1080 landscape 화면에서 역 검색 캡처 | local-only: `.codex/evidence/1051/station-search-large.png`, `.codex/evidence/1051/station-search-large-ui.xml` | 입력·검색 버튼은 `[82,112][613,254]`, 노선 필터는 `[631,112][1056,1127]`에 표시되어 겹치지 않음 |
| 전체 모바일 회귀 | Flutter test | 전체 위젯·단위 테스트 실행 | `flutter test` | 529 tests passed |
| 저장소 문서/정책 회귀 | Node test | CI 정책 테스트 실행 | `node --test tools/ci/*.test.mjs` | 129 tests passed |

Android 스크린샷과 UI tree는 repo 정책상 git에 커밋하지 않았고, 외부 이미지 업로드 승인이 없어 local-only 증거로 보관했습니다. PR에서는 자동 테스트의 좌표 assertion과 UI tree bounds를 대체 검증 증거로 기록합니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/station_search.dart`의 `_StationSearchAdaptiveContent`
  - `apps/mobile/test/widget_test.dart`의 태블릿 landscape 역 검색 테스트

## 리스크

- 이번 PR은 역 상세 split-view를 포함하지 않습니다. 역 상세는 기존처럼 별도 화면으로 이동합니다.
- #1051 전체 범위 중 경로 검색, 즐겨찾기 등 다른 화면 대화면 대응은 후속 PR에서 이어집니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
