### PR TITLE
[Feat] 역 상세 대화면 레이아웃 추가

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -4126,80 +4126,104 @@ class _StationDetailContent extends StatelessWidget {
       facilities: facilities,
     );
 
-    return ListView(
-      padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
-      children: [
-        _StationDetailHeader(detail: detail),
-        const SizedBox(height: 12),
-        _InfoBasisDisclosure(
-          labels: [detail.dataSourceLabel, '마지막 확인 ${detail.lastVerifiedAt}'],
+    final primaryChildren = <Widget>[
+      _StationDetailHeader(detail: detail),
+      const SizedBox(height: 12),
+      _InfoBasisDisclosure(
+        labels: [detail.dataSourceLabel, '마지막 확인 ${detail.lastVerifiedAt}'],
+      ),
+      const SizedBox(height: 12),
+      if (facilityAttentionSummary.isNotEmpty) ...[
+        _StationFacilityStatusSummary(
+          text: facilityAttentionSummary,
+          semanticLabel: facilityAttentionSemanticLabel,
         ),
         const SizedBox(height: 12),
-        if (facilityAttentionSummary.isNotEmpty) ...[
-          _StationFacilityStatusSummary(
-            text: facilityAttentionSummary,
-            semanticLabel: facilityAttentionSemanticLabel,
-          ),
-          const SizedBox(height: 12),
-        ],
-        _StationDetailRouteActions(
-          detail: detail,
-          routeDraftController: routeDraftController,
-        ),
-        const SizedBox(height: 12),
-        const _StationSafetyGuidanceNotice(),
-        if (favoriteController != null) ...[
-          const SizedBox(height: 16),
-          _StationFavoriteControl(
-            detail: detail,
-            controller: favoriteController!,
-          ),
-        ],
-        const SizedBox(height: 24),
-        if (layoutSummaryItems.isNotEmpty) ...[
-          const _StationDetailSectionTitle(title: '이동 구조'),
-          const SizedBox(height: 12),
-          _StationLayoutSummary(
-            items: layoutSummaryItems,
-            semanticLabel: layoutSummarySemanticLabel,
-          ),
-          const SizedBox(height: 24),
-        ],
-        if (internalRouteState != null) ...[
-          const _StationDetailSectionTitle(title: '역 안 이동 순서'),
-          const SizedBox(height: 12),
-          _StationInternalRouteGuidance(state: internalRouteState!),
-          const SizedBox(height: 24),
-        ],
-        if (mapMarkers.isNotEmpty) ...[
-          const _StationDetailSectionTitle(title: '지도 위치 목록'),
-          const SizedBox(height: 12),
-          _StationMapTextFallback(markers: mapMarkers),
-          const SizedBox(height: 24),
-        ],
-        const _StationDetailSectionTitle(title: '출구'),
-        const SizedBox(height: 12),
-        if (exits.isEmpty)
-          const _StationDetailEmptyMessage(message: '출구 정보가 아직 없습니다.')
-        else
-          for (final exit in exits) _StationExitCard(exit: exit),
-        const SizedBox(height: 24),
-        const _StationDetailSectionTitle(title: '시설'),
-        const SizedBox(height: 12),
-        if (facilities.isEmpty)
-          const _StationDetailEmptyMessage(message: '시설 정보가 아직 없습니다.')
-        else
-          for (final facility in facilities)
-            _StationFacilityCard(
-              facility: facility,
-              station: detail,
-              onReportTap: () => _openFacilityReport(context, facility),
-            ),
-        const SizedBox(height: 24),
-        const _StationDetailSectionTitle(title: '실시간 열차'),
-        const SizedBox(height: 12),
-        _StationRealtimeSummary(snapshot: realtimeSnapshot),
       ],
+      _StationDetailRouteActions(
+        detail: detail,
+        routeDraftController: routeDraftController,
+      ),
+      const SizedBox(height: 12),
+      const _StationSafetyGuidanceNotice(),
+      if (favoriteController != null) ...[
+        const SizedBox(height: 16),
+        _StationFavoriteControl(
+          detail: detail,
+          controller: favoriteController!,
+        ),
+      ],
+    ];
+    final detailChildren = <Widget>[
+      if (layoutSummaryItems.isNotEmpty) ...[
+        const _StationDetailSectionTitle(title: '이동 구조'),
+        const SizedBox(height: 12),
+        _StationLayoutSummary(
+          items: layoutSummaryItems,
+          semanticLabel: layoutSummarySemanticLabel,
+        ),
+        const SizedBox(height: 24),
+      ],
+      if (internalRouteState != null) ...[
+        const _StationDetailSectionTitle(title: '역 안 이동 순서'),
+        const SizedBox(height: 12),
+        _StationInternalRouteGuidance(state: internalRouteState!),
+        const SizedBox(height: 24),
+      ],
+      if (mapMarkers.isNotEmpty) ...[
+        const _StationDetailSectionTitle(title: '지도 위치 목록'),
+        const SizedBox(height: 12),
+        _StationMapTextFallback(markers: mapMarkers),
+        const SizedBox(height: 24),
+      ],
+      const _StationDetailSectionTitle(title: '출구'),
+      const SizedBox(height: 12),
+      if (exits.isEmpty)
+        const _StationDetailEmptyMessage(message: '출구 정보가 아직 없습니다.')
+      else
+        for (final exit in exits) _StationExitCard(exit: exit),
+      const SizedBox(height: 24),
+      const _StationDetailSectionTitle(title: '시설'),
+      const SizedBox(height: 12),
+      if (facilities.isEmpty)
+        const _StationDetailEmptyMessage(message: '시설 정보가 아직 없습니다.')
+      else
+        for (final facility in facilities)
+          _StationFacilityCard(
+            facility: facility,
+            station: detail,
+            onReportTap: () => _openFacilityReport(context, facility),
+          ),
+      const SizedBox(height: 24),
+      const _StationDetailSectionTitle(title: '실시간 열차'),
+      const SizedBox(height: 12),
+      _StationRealtimeSummary(snapshot: realtimeSnapshot),
+    ];
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isLargeScreen = EasySubwayAdaptiveLayout.isLargeScreen(
+          constraints,
+        );
+        return ListView(
+          key: const Key('stationDetailList'),
+          padding: isLargeScreen
+              ? const EdgeInsets.fromLTRB(24, 24, 24, 40)
+              : const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          children: isLargeScreen
+              ? [
+                  _StationDetailAdaptiveContent(
+                    primaryChildren: primaryChildren,
+                    detailChildren: detailChildren,
+                  ),
+                ]
+              : [
+                  ...primaryChildren,
+                  const SizedBox(height: 24),
+                  ...detailChildren,
+                ],
+        );
+      },
     );
   }
 
@@ -4259,6 +4283,52 @@ class _StationDetailContent extends StatelessWidget {
       return null;
     }
     return provider.openLocationSettings;
+  }
+}
+
+class _StationDetailAdaptiveContent extends StatelessWidget {
+  const _StationDetailAdaptiveContent({
+    required this.primaryChildren,
+    required this.detailChildren,
+  });
+
+  final List<Widget> primaryChildren;
+  final List<Widget> detailChildren;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(
+          maxWidth: EasySubwayAdaptiveLayout.largeScreenMaxContentWidth,
+        ),
+        child: Row(
+          key: const Key('stationDetailLargeScreenLayout'),
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              flex: 4,
+              child: Column(
+                key: const Key('stationDetailPrimaryColumn'),
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: primaryChildren,
+              ),
+            ),
+            const SizedBox(
+              width: EasySubwayAdaptiveLayout.largeScreenColumnGap,
+            ),
+            Expanded(
+              flex: 5,
+              child: Column(
+                key: const Key('stationDetailDetailColumn'),
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: detailChildren,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -6412,6 +6412,99 @@ void main() {
     }
   });
 
+  testWidgets('역 상세는 태블릿 landscape에서 요약과 시설 정보를 나란히 보여준다', (tester) async {
+    tester.view.physicalSize = const Size(1280, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final repository = FakeStationSearchRepository(
+      nextResults: [_stationResult(id: 'station-sangnoksu', name: '상록수')],
+      stationDetail: _stationDetail(id: 'station-sangnoksu', name: '상록수'),
+      stationExits: const [
+        StationExitInfo(
+          id: 'exit-sangnoksu-1',
+          stationId: 'station-sangnoksu',
+          exitNumber: '1',
+          name: '1번 출구',
+          hasElevatorConnection: true,
+          hasStairOnlyPath: false,
+          dataConfidence: 'HIGH',
+          dataSourceType: 'OFFICIAL_FILE',
+          fieldValidationStatus: 'VERIFIED',
+        ),
+      ],
+      stationFacilities: const [
+        StationFacilityInfo(
+          id: 'facility-sangnoksu-elevator-1',
+          stationId: 'station-sangnoksu',
+          exitId: 'exit-sangnoksu-1',
+          type: 'ELEVATOR',
+          name: '1번 출구 엘리베이터',
+          floorFrom: 'B1',
+          floorTo: '1F',
+          description: '1번 출구 앞',
+          status: 'NORMAL',
+          dataConfidence: 'HIGH',
+          dataSourceType: 'OFFICIAL_FILE',
+          lastUpdatedAt: '2026-06-12',
+          fieldValidationStatus: 'VERIFIED',
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('stationSearchButton')));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byKey(const Key('stationSearchInput')), '상록수');
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('stationDetailLargeScreenLayout')),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('stationDetailPrimaryColumn')), findsOneWidget);
+    expect(find.byKey(const Key('stationDetailDetailColumn')), findsOneWidget);
+    expect(find.text('상록수역'), findsOneWidget);
+    expect(
+      find.byKey(
+        const Key('stationFacilityCard-facility-sangnoksu-elevator-1'),
+      ),
+      findsOneWidget,
+    );
+
+    final primaryRect = tester.getRect(
+      find.byKey(const Key('stationDetailPrimaryColumn')),
+    );
+    final detailRect = tester.getRect(
+      find.byKey(const Key('stationDetailDetailColumn')),
+    );
+    final facilityRect = tester.getRect(
+      find.byKey(
+        const Key('stationFacilityCard-facility-sangnoksu-elevator-1'),
+      ),
+    );
+
+    expect(primaryRect.right, lessThan(detailRect.left));
+    expect(facilityRect.left, greaterThan(primaryRect.right));
+    expect(detailRect.top, lessThan(primaryRect.bottom));
+  });
+
   testWidgets('시설 상세는 실제 시설 데이터로 위치 상태 제보 진입을 보여준다', (tester) async {
     final reportRepository = FakeFacilityReportRepository();
     final repository = FakeStationSearchRepository(


### PR DESCRIPTION
## 관련 이슈

#1051 부분 해결

## 작업 배경

태블릿 landscape와 Chromebook 16:9 화면에서 역 상세가 휴대전화 단일 컬럼으로만 이어지면 역 요약, 출구, 시설 상태를 한 화면에서 비교하기 어렵습니다. Play 등록정보용 실제 앱 화면 증거를 만들 수 있도록 역 상세 화면도 홈/역 검색과 같은 대화면 기준을 적용합니다.

## 작업 내용

- 역 상세 화면에 `EasySubwayAdaptiveLayout` 기준의 대화면 분기를 추가했습니다.
- 대화면에서는 역 요약, 정보 기준, 출발/도착 설정, 안전 안내, 즐겨찾기 버튼을 왼쪽 컬럼에 배치했습니다.
- 이동 구조, 역 안 이동 순서, 지도 위치 목록, 출구, 시설, 실시간 열차 영역은 오른쪽 컬럼에 배치했습니다.
- 휴대전화 화면에서는 기존 `ListView` children 순서를 유지해 스크롤 기반 표시와 기존 테스트 계약을 보존했습니다.
- 태블릿 landscape에서 역 상세 요약 컬럼과 시설 컬럼이 좌우로 분리되는 위젯 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/widget_test.dart --plain-name "역 상세는 태블릿 landscape에서 요약과 시설 정보를 나란히 보여준다"`: exit 0
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/widget_test.dart --plain-name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다"`: exit 0
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter analyze`: exit 0, No issues found
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test test/widget_test.dart`: exit 0, 162 tests passed
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter test`: exit 0, 530 tests passed
  - `node --test tools/ci/*.test.mjs`: exit 0, 129 tests passed
  - `/Volumes/MACSSD/Android/flutter/flutter/bin/flutter build apk --debug`: exit 0, `build/app/outputs/flutter-apk/app-debug.apk` 생성
  - `adb -s emulator-5554 install -r apps/mobile/build/app/outputs/flutter-apk/app-debug.apk`: exit 0, Success

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 상세 대화면 요약·시설 분리 | Flutter widget test | 1280x800 viewport에서 요약 컬럼, 상세 컬럼, 시설 카드 bounds 비교 | `flutter test test/widget_test.dart --plain-name "역 상세는 태블릿 landscape에서 요약과 시설 정보를 나란히 보여준다"` | 요약 컬럼과 시설 컬럼이 좌우로 분리됨 |
| 휴대전화 역 상세 스크롤 흐름 유지 | Flutter widget test | 기존 역 상세 출구/시설/지도 위치 스크롤 테스트 재실행 | `flutter test test/widget_test.dart --plain-name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다"` | 기존 단일 컬럼·스크롤 계약 유지 |
| Android 대화면 실제 렌더링 | Android emulator | debug APK 설치 후 1920x1080 landscape 화면에서 역 상세 캡처 | local-only: `.codex/evidence/1051/station-detail-large.png`, `.codex/evidence/1051/station-detail-large-ui.xml` | 역 요약은 `[82,112][507,287]`, 우측 상세/시설 영역은 `[525,112][1056,...]`에 표시되어 겹치지 않음 |
| 전체 모바일 회귀 | Flutter test | 전체 위젯·단위 테스트 실행 | `flutter test` | 530 tests passed |
| 저장소 문서/정책 회귀 | Node test | CI 정책 테스트 실행 | `node --test tools/ci/*.test.mjs` | 129 tests passed |

Android 스크린샷과 UI tree는 repo 정책상 git에 커밋하지 않았고, 외부 이미지 업로드 승인이 없어 local-only 증거로 보관했습니다. PR에서는 자동 테스트의 좌표 assertion과 UI tree bounds를 대체 검증 증거로 기록합니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/station_search.dart`의 `_StationDetailAdaptiveContent`
  - `apps/mobile/test/widget_test.dart`의 태블릿 landscape 역 상세 테스트

## 리스크

- 이번 PR은 역 상세 화면 자체의 좌우 컬럼 배치만 다룹니다. Play 등록정보용 최종 스크린샷 생성은 UI 안정화 후 별도 PR에서 진행합니다.
- 시설 카드는 별도 grid로 바꾸지 않고 기존 카드 폭과 제보/상세 진입 동작을 유지했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
