### PR TITLE
[Chore] 대화면 스토어 스크린샷 증거 계약 추가

### DIFF
--- a/apps/mobile/release/android-rc-store-evidence.json
+++ b/apps/mobile/release/android-rc-store-evidence.json
@@ -98,6 +98,7 @@
       "privacy-policy-url-help-screen-match",
       "korean-store-listing-contract",
       "store-graphic-screenshot-asset-record",
+      "large-screen-store-screenshot-asset-record",
       "store-listing-scope-copy-review",
       "support-channel-release-notes-review"
     ],

--- a/apps/mobile/release/play-store-submission-content.json
+++ b/apps/mobile/release/play-store-submission-content.json
@@ -63,7 +63,7 @@
       "requiredScreenshotIds": ["home_support_scope", "station_search", "station_detail_facility_status"],
       "requiredEvidenceFields": [
         "sourceGitSha",
-        "buildVariant",
+        "sourceBuildType",
         "viewport",
         "seedData",
         "captureTarget",
@@ -81,7 +81,7 @@
       "requiredScreenshotIds": ["home_support_scope", "station_search", "station_detail_facility_status"],
       "requiredEvidenceFields": [
         "sourceGitSha",
-        "buildVariant",
+        "sourceBuildType",
         "viewport",
         "seedData",
         "captureTarget",
@@ -104,7 +104,7 @@
       ],
       "requiredEvidenceFields": [
         "sourceGitSha",
-        "buildVariant",
+        "sourceBuildType",
         "viewport",
         "seedData",
         "captureTarget",
@@ -128,7 +128,7 @@
       ],
       "requiredEvidenceFields": [
         "sourceGitSha",
-        "buildVariant",
+        "sourceBuildType",
         "viewport",
         "seedData",
         "captureTarget",

--- a/apps/mobile/release/play-store-submission-content.json
+++ b/apps/mobile/release/play-store-submission-content.json
@@ -337,6 +337,7 @@
         "targetDeviceClass",
         "viewport",
         "seedData",
+        "uiTreePath",
         "screenTitleKo",
         "forbiddenClaimsAbsent",
         "matchesFeatureScope",

--- a/apps/mobile/release/play-store-submission-content.json
+++ b/apps/mobile/release/play-store-submission-content.json
@@ -54,6 +54,91 @@
       "titleKo": "데이터 기준일과 실시간 제공 범위"
     }
   ],
+  "largeScreenScreenshotTargets": [
+    {
+      "id": "seven_inch_tablet_landscape",
+      "playConsoleSlot": "7-inch tablet",
+      "viewportClass": "compact-tablet-landscape",
+      "aspectRatio": "16:9-or-play-accepted",
+      "requiredScreenshotIds": ["home_support_scope", "station_search", "station_detail_facility_status"],
+      "requiredEvidenceFields": [
+        "sourceGitSha",
+        "buildVariant",
+        "viewport",
+        "seedData",
+        "captureTarget",
+        "localEvidencePath",
+        "uiTreePath",
+        "result"
+      ],
+      "scopeNoteKo": "휴대전화 중앙 고립 UI가 아니라 핵심 CTA, 검색, 역 상세 요약이 대화면 기준으로 표시되는지 확인한다."
+    },
+    {
+      "id": "ten_inch_tablet_landscape",
+      "playConsoleSlot": "10-inch tablet",
+      "viewportClass": "expanded-tablet-landscape",
+      "aspectRatio": "16:9",
+      "requiredScreenshotIds": ["home_support_scope", "station_search", "station_detail_facility_status"],
+      "requiredEvidenceFields": [
+        "sourceGitSha",
+        "buildVariant",
+        "viewport",
+        "seedData",
+        "captureTarget",
+        "localEvidencePath",
+        "uiTreePath",
+        "result"
+      ],
+      "scopeNoteKo": "홈, 역 검색, 역 상세가 넓은 화면에서 좌우 정보 구조를 유지하고 큰 글씨 기준의 overflow가 없는지 확인한다."
+    },
+    {
+      "id": "chromebook_16_9",
+      "playConsoleSlot": "Chromebook",
+      "viewportClass": "desktop-window-16-9",
+      "aspectRatio": "16:9",
+      "requiredScreenshotIds": [
+        "home_support_scope",
+        "station_search",
+        "station_detail_facility_status",
+        "help_privacy_data_deletion"
+      ],
+      "requiredEvidenceFields": [
+        "sourceGitSha",
+        "buildVariant",
+        "viewport",
+        "seedData",
+        "captureTarget",
+        "localEvidencePath",
+        "uiTreePath",
+        "keyboardMouseSmokeResult",
+        "result"
+      ],
+      "scopeNoteKo": "Chromebook 전용 UX 완성이 아니라 등록정보용 16:9 실제 앱 화면과 기본 focus, 입력, 클릭, 스크롤 smoke 결과를 기록한다."
+    },
+    {
+      "id": "android_xr_16_9",
+      "playConsoleSlot": "Android XR",
+      "viewportClass": "xr-listing-16-9",
+      "aspectRatio": "16:9",
+      "requiredScreenshotIds": [
+        "home_support_scope",
+        "station_search",
+        "station_detail_facility_status",
+        "help_privacy_data_deletion"
+      ],
+      "requiredEvidenceFields": [
+        "sourceGitSha",
+        "buildVariant",
+        "viewport",
+        "seedData",
+        "captureTarget",
+        "localEvidencePath",
+        "uiTreePath",
+        "result"
+      ],
+      "scopeNoteKo": "Android XR 등록정보 칸을 위한 16:9 실제 앱 화면 후보이며 XR 전용 spatial UI 지원으로 표현하지 않는다."
+    }
+  ],
   "dataSafetyDeclarations": {
     "tracking": false,
     "sharesDataWithThirdParties": false,
@@ -247,7 +332,11 @@
       "requiredFields": [
         "screenshotId",
         "buildIdentity",
+        "sourceGitSha",
         "sourceBuildType",
+        "targetDeviceClass",
+        "viewport",
+        "seedData",
         "screenTitleKo",
         "forbiddenClaimsAbsent",
         "matchesFeatureScope",
@@ -327,7 +416,10 @@
     "appIcon": "required_play_console_preview_or_asset_record",
     "featureGraphic": "required_play_console_preview_or_asset_record",
     "phoneScreenshots": "required_release_build_screenshots_matching_requiredScreenshotSet",
-    "tabletPolicy": "tablet_compatible_until_tablet_specific_ui_gate",
+    "tabletScreenshots": "required_large_screen_screenshots_matching_largeScreenScreenshotTargets",
+    "chromebookScreenshots": "required_16_9_app_screenshots_matching_largeScreenScreenshotTargets",
+    "androidXrScreenshots": "required_16_9_app_screenshots_without_xr_specific_ui_claim",
+    "tabletPolicy": "large_screen_layout_gate_required_before_final_tablet_listing_assets",
     "listingPreview": "required_play_console_preview_summary"
   },
   "evidencePolicy": {

--- a/apps/mobile/release/store-submission-readiness.json
+++ b/apps/mobile/release/store-submission-readiness.json
@@ -145,8 +145,8 @@
       "category": "store-listing",
       "titleKo": "Play 스토어 등록 정보와 스크린샷",
       "decisionOwnerKo": "제품/마케팅 담당",
-      "readyWhenKo": "설명, 고정 스크린샷 세트, 기능 문구가 실제 앱 화면과 일치하고 실시간 안전 경로 보장처럼 과장된 표현을 사용하지 않는다.",
-      "evidence": ["screenshot-review", "copy-review"],
+      "readyWhenKo": "설명, 고정 스크린샷 세트, 7인치/10인치 태블릿, Chromebook, Android XR 16:9 후보 이미지, 기능 문구가 실제 앱 화면과 일치하고 실시간 안전 경로 보장처럼 과장된 표현을 사용하지 않는다.",
+      "evidence": ["screenshot-review", "large-screen-screenshot-review", "copy-review"],
       "linkedArtifacts": ["README.md", "apps/mobile/lib/main.dart", "apps/mobile/release/accessibility-release-qa.json", "apps/mobile/release/play-store-submission-content.json"],
       "configurationSources": ["release build screenshots"]
     },

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7728,6 +7728,7 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
       `${target.id} must include station detail evidence`,
     );
     assert.ok(target.requiredEvidenceFields.includes("sourceGitSha"), `${target.id} must record source git SHA`);
+    assert.ok(target.requiredEvidenceFields.includes("sourceBuildType"), `${target.id} must record source build type`);
     assert.ok(target.requiredEvidenceFields.includes("viewport"), `${target.id} must record viewport`);
     assert.ok(target.requiredEvidenceFields.includes("seedData"), `${target.id} must record seed data`);
     assert.ok(target.requiredEvidenceFields.includes("uiTreePath"), `${target.id} must record UI tree evidence`);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7694,7 +7694,10 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
   assert.match(items.get("play_permissions_declaration").readyWhenKo, /위치|권한/);
   assert.ok(items.get("play_listing_assets_truthfulness").linkedArtifacts.includes("apps/mobile/release/play-store-submission-content.json"));
   assert.match(items.get("play_listing_assets_truthfulness").readyWhenKo, /고정 스크린샷 세트/);
-  assert.match(items.get("play_listing_assets_truthfulness").readyWhenKo, /7인치\/10인치 태블릿|Chromebook|Android XR/);
+  const playListingAssetsTruthfulnessReadyWhenKo = items.get("play_listing_assets_truthfulness").readyWhenKo;
+  assert.match(playListingAssetsTruthfulnessReadyWhenKo, /7인치\/10인치 태블릿/);
+  assert.match(playListingAssetsTruthfulnessReadyWhenKo, /Chromebook/);
+  assert.match(playListingAssetsTruthfulnessReadyWhenKo, /Android XR/);
   assert.ok(items.get("play_listing_assets_truthfulness").evidence.includes("large-screen-screenshot-review"));
   assert.match(items.get("play_account_data_deletion").configurationSources.join("\n"), /EASYSUBWAY_DATA_DELETION_EMAIL/);
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("app-content-declarations"));
@@ -7867,6 +7870,7 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
   assert.ok(playStoreContent.evidenceSummarySchemas.storeScreenshotSummary.requiredFields.includes("targetDeviceClass"));
   assert.ok(playStoreContent.evidenceSummarySchemas.storeScreenshotSummary.requiredFields.includes("viewport"));
   assert.ok(playStoreContent.evidenceSummarySchemas.storeScreenshotSummary.requiredFields.includes("seedData"));
+  assert.ok(playStoreContent.evidenceSummarySchemas.storeScreenshotSummary.requiredFields.includes("uiTreePath"));
   assert.equal(
     playStoreContent.assetEvidence.tabletScreenshots,
     "required_large_screen_screenshots_matching_largeScreenScreenshotTargets",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7694,9 +7694,12 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
   assert.match(items.get("play_permissions_declaration").readyWhenKo, /위치|권한/);
   assert.ok(items.get("play_listing_assets_truthfulness").linkedArtifacts.includes("apps/mobile/release/play-store-submission-content.json"));
   assert.match(items.get("play_listing_assets_truthfulness").readyWhenKo, /고정 스크린샷 세트/);
+  assert.match(items.get("play_listing_assets_truthfulness").readyWhenKo, /7인치\/10인치 태블릿|Chromebook|Android XR/);
+  assert.ok(items.get("play_listing_assets_truthfulness").evidence.includes("large-screen-screenshot-review"));
   assert.match(items.get("play_account_data_deletion").configurationSources.join("\n"), /EASYSUBWAY_DATA_DELETION_EMAIL/);
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("app-content-declarations"));
   assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("store-listing-scope-copy-review"));
+  assert.ok(androidRcEvidence.requiredEvidence.playConsoleSubmission.includes("large-screen-store-screenshot-asset-record"));
   assert.deepEqual(playStoreContent.requiredScreenshotSet.map((item) => item.id), [
     "home_support_scope",
     "station_search",
@@ -7707,6 +7710,30 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
     "help_privacy_data_deletion",
     "data_baseline_source_realtime_scope",
   ]);
+  assert.deepEqual(playStoreContent.largeScreenScreenshotTargets.map((item) => item.id), [
+    "seven_inch_tablet_landscape",
+    "ten_inch_tablet_landscape",
+    "chromebook_16_9",
+    "android_xr_16_9",
+  ]);
+  const largeScreenTargets = new Map(playStoreContent.largeScreenScreenshotTargets.map((item) => [item.id, item]));
+  for (const target of largeScreenTargets.values()) {
+    assert.ok(target.requiredScreenshotIds.includes("home_support_scope"), `${target.id} must include home evidence`);
+    assert.ok(target.requiredScreenshotIds.includes("station_search"), `${target.id} must include station search evidence`);
+    assert.ok(
+      target.requiredScreenshotIds.includes("station_detail_facility_status"),
+      `${target.id} must include station detail evidence`,
+    );
+    assert.ok(target.requiredEvidenceFields.includes("sourceGitSha"), `${target.id} must record source git SHA`);
+    assert.ok(target.requiredEvidenceFields.includes("viewport"), `${target.id} must record viewport`);
+    assert.ok(target.requiredEvidenceFields.includes("seedData"), `${target.id} must record seed data`);
+    assert.ok(target.requiredEvidenceFields.includes("uiTreePath"), `${target.id} must record UI tree evidence`);
+    assert.ok(target.requiredEvidenceFields.includes("result"), `${target.id} must record result`);
+  }
+  assert.ok(largeScreenTargets.get("chromebook_16_9").requiredScreenshotIds.includes("help_privacy_data_deletion"));
+  assert.ok(largeScreenTargets.get("chromebook_16_9").requiredEvidenceFields.includes("keyboardMouseSmokeResult"));
+  assert.ok(largeScreenTargets.get("android_xr_16_9").requiredScreenshotIds.includes("help_privacy_data_deletion"));
+  assert.match(largeScreenTargets.get("android_xr_16_9").scopeNoteKo, /XR 전용 spatial UI 지원으로 표현하지 않는다/);
   assert.deepEqual(playStoreContent.dataSafetyDeclarations.requiredFieldsPerDataType, [
     "collected",
     "collectionType",
@@ -7835,6 +7862,22 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
   );
   assert.ok(
     playStoreContent.evidenceSummarySchemas.storeScreenshotSummary.requiredFields.includes("forbiddenClaimsAbsent"),
+  );
+  assert.ok(playStoreContent.evidenceSummarySchemas.storeScreenshotSummary.requiredFields.includes("sourceGitSha"));
+  assert.ok(playStoreContent.evidenceSummarySchemas.storeScreenshotSummary.requiredFields.includes("targetDeviceClass"));
+  assert.ok(playStoreContent.evidenceSummarySchemas.storeScreenshotSummary.requiredFields.includes("viewport"));
+  assert.ok(playStoreContent.evidenceSummarySchemas.storeScreenshotSummary.requiredFields.includes("seedData"));
+  assert.equal(
+    playStoreContent.assetEvidence.tabletScreenshots,
+    "required_large_screen_screenshots_matching_largeScreenScreenshotTargets",
+  );
+  assert.equal(
+    playStoreContent.assetEvidence.chromebookScreenshots,
+    "required_16_9_app_screenshots_matching_largeScreenScreenshotTargets",
+  );
+  assert.equal(
+    playStoreContent.assetEvidence.androidXrScreenshots,
+    "required_16_9_app_screenshots_without_xr_specific_ui_claim",
   );
   assert.ok(
     playStoreContent.evidenceSummarySchemas.crashAnrPrivacySummary.requiredFields.includes("forbiddenPayloadAbsent"),


### PR DESCRIPTION
## 관련 이슈

close #1051

## 작업 배경

태블릿, Chromebook, Android XR 등록정보에 쓸 대화면 스크린샷 후보는 phone screenshot 계약과 분리해서 추적해야 합니다. 홈, 역 검색, 역 상세 대화면 레이아웃은 앞선 PR에서 적용됐으므로 이번 PR에서는 Play 제출 계약에 대화면 target matrix와 증거 필드를 고정하고, 실제 Android emulator 후보 화면 증거를 수집했습니다.

## 작업 내용

- `play-store-submission-content`에 7인치 태블릿, 10인치 태블릿, Chromebook, Android XR 16:9 스크린샷 target matrix를 추가했습니다.
- store screenshot summary에 git SHA, viewport, seed data, target device class 필드를 추가했습니다.
- `store-submission-readiness`와 `android-rc-store-evidence`가 대화면 스크린샷 검토를 release blocker 증거로 요구하도록 연결했습니다.
- repository contract test에서 대화면 target id, 필수 screenshot id, evidence field, XR 표현 제한을 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "모바일 스토어 심사 정보 기준선" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `node --test tools/ci/*.test.mjs`: exit 0, 129 tests passed
  - `file .codex/evidence/release/large-screen-layout/2026-06-29-1051/home-1920x1080.png .codex/evidence/release/large-screen-layout/2026-06-29-1051/station-search-entry-1920x1080.png .codex/evidence/release/large-screen-layout/2026-06-29-1051/station-search-results-1920x1080.png .codex/evidence/release/large-screen-layout/2026-06-29-1051/station-detail-1920x1080.png .codex/evidence/release/large-screen-layout/2026-06-29-1051/help-privacy-1920x1080.png .codex/evidence/release/large-screen-layout/2026-06-29-1051/home-1280x720.png .codex/evidence/release/large-screen-layout/2026-06-29-1051/station-search-results-1280x720.png .codex/evidence/release/large-screen-layout/2026-06-29-1051/station-detail-1280x720.png`: 모두 16:9 PNG 크기 확인
  - `adb -s emulator-5554 shell wm size`: `Physical size: 1080x2400`, display override reset 확인
  - `adb -s emulator-5554 shell wm density`: `Physical density: 420`, density override reset 확인
  - `codex review --base origin/main --title "[Chore] 대화면 스토어 스크린샷 증거 계약 추가"`: actionable 1건 확인, `b712a8ec`에서 수정 후 원래 inline thread 답글 및 resolve 완료

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 7인치 태블릿 후보 | Android emulator | 1280x720 raw screenshot과 UI tree 캡처 | local-only: `.codex/evidence/release/large-screen-layout/2026-06-29-1051/home-1280x720.png`, `station-search-results-1280x720.png`, `station-detail-1280x720.png` | home/search/detail이 16:9로 저장되고 상세는 좌우 컬럼 표시 |
| 10인치 태블릿 후보 | Android emulator | 1920x1080 raw screenshot과 UI tree 캡처 | local-only: `.codex/evidence/release/large-screen-layout/2026-06-29-1051/home-1920x1080.png`, `station-search-results-1920x1080.png`, `station-detail-1920x1080.png` | home/search/detail이 16:9로 저장되고 검색/상세가 대화면 구조 표시 |
| Chromebook 후보 | Android emulator | 1920x1080 home/search/detail/help 화면 캡처와 기본 tap/scroll/input smoke | local-only: `.codex/evidence/release/large-screen-layout/2026-06-29-1051/station-search-entry-1920x1080.png`, `station-detail-1920x1080.png`, `help-privacy-1920x1080.png` | 검색 최근 항목 tap, 상세 진입, 설정 스크롤, 도움말 진입 가능 |
| Android XR 등록정보 후보 | Android emulator | 1920x1080 실제 앱 화면 후보 캡처, XR 전용 UI 지원 표현 제외 | local-only: `.codex/evidence/release/large-screen-layout/2026-06-29-1051/home-1920x1080.png`, `help-privacy-1920x1080.png` | 16:9 후보 이미지만 확보했고 XR spatial UI 지원으로 표현하지 않음 |
| release 계약 회귀 | Node test | store submission contract test와 전체 CI contract test 실행 | `node --test --test-name-pattern "모바일 스토어 심사 정보 기준선" tools/ci/repository-contract.test.mjs`, `node --test tools/ci/*.test.mjs` | 각각 exit 0 |

스크린샷과 UI tree는 repo 정책상 git에 커밋하지 않았고, 외부 이미지 업로드 승인이 없어 local-only 증거로 보관했습니다. PR에서는 파일 크기, UI tree bounds, 수동 시각 확인 결과를 대체 검증 증거로 기록합니다.

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/release/play-store-submission-content.json`의 `largeScreenScreenshotTargets`
  - `tools/ci/repository-contract.test.mjs`의 store submission contract assertion

## 리스크

- 이 PR은 Play Console에 이미지를 업로드하지 않습니다. 실제 업로드 전에는 같은 git SHA 또는 최종 RC SHA 기준으로 민감정보 없는 공개 가능 이미지 세트를 다시 확정해야 합니다.
- Android XR 항목은 등록정보용 16:9 이미지 후보만 의미하며, XR 전용 spatial UI 지원으로 해석하면 안 됩니다.

## 체크리스트

- [x] CI 결과를 확인했다: PR #1055 required checks pass
- [x] CodeRabbit 리뷰를 확인했다: initial review actionable 2건 수정 및 원래 thread 답글 완료, 후속 range rate limit 확인
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다: fallback actionable 1건 수정 및 원래 thread 답글 완료
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다: 배포 설정 변경 없음, merge 후 main run 생성/실패 여부만 확인
