### PR TITLE
[Fix] 신고 사진 object storage key 경계 강화

### DIFF
--- a/backend/src/main/java/com/easysubway/report/adapter/out/storage/ObjectStorageFacilityReportPhotoStorage.java
+++ b/backend/src/main/java/com/easysubway/report/adapter/out/storage/ObjectStorageFacilityReportPhotoStorage.java
@@ -44,6 +44,7 @@ public class ObjectStorageFacilityReportPhotoStorage implements
 
 	private static final String HMAC_ALGORITHM = "HmacSHA256";
 	private static final String SIGNING_ALGORITHM = "AWS4-HMAC-SHA256";
+	private static final String OBJECT_KEY_PREFIX = "facility-reports/";
 	private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd")
 		.withZone(ZoneOffset.UTC);
 	private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'")
@@ -106,15 +107,17 @@ public class ObjectStorageFacilityReportPhotoStorage implements
 
 	@Override
 	public void storeUploadedReportPhoto(StoreUploadedReportPhotoCommand command) {
-		putObject(command.objectKey(), contentTypeFor(command.objectKey()), command.bytes());
+		String objectKey = requireFacilityReportObjectKey(command.objectKey());
+		putObject(objectKey, contentTypeFor(objectKey), command.bytes());
 	}
 
 	@Override
 	public Optional<LoadedFacilityReportPhoto> loadFacilityReportPhoto(String objectKey) {
-		if (objectKey == null || objectKey.isBlank()) {
+		String normalizedObjectKey = normalizeFacilityReportObjectKey(objectKey);
+		if (normalizedObjectKey == null) {
 			return Optional.empty();
 		}
-		HttpResponse<InputStream> response = sendStream(signedRequest("GET", objectKey.trim(), null, null));
+		HttpResponse<InputStream> response = sendStream(signedRequest("GET", normalizedObjectKey, null, null));
 		try (InputStream responseBody = response.body()) {
 			if (response.statusCode() == 404) {
 				return Optional.empty();
@@ -129,7 +132,7 @@ public class ObjectStorageFacilityReportPhotoStorage implements
 				.firstValue("content-type")
 				.map(value -> value.split(";", 2)[0].trim().toLowerCase(Locale.ROOT))
 				.filter(value -> !value.isBlank())
-				.orElseGet(() -> contentTypeFor(objectKey));
+				.orElseGet(() -> contentTypeFor(normalizedObjectKey));
 			return Optional.of(new LoadedFacilityReportPhoto(contentType, bytes));
 		} catch (IOException exception) {
 			throw new UncheckedIOException("Failed to read facility report photo object", exception);
@@ -138,10 +141,11 @@ public class ObjectStorageFacilityReportPhotoStorage implements
 
 	@Override
 	public void deleteFacilityReportPhoto(String objectKey) {
-		if (objectKey == null || objectKey.isBlank()) {
+		String normalizedObjectKey = normalizeFacilityReportObjectKey(objectKey);
+		if (normalizedObjectKey == null) {
 			return;
 		}
-		HttpResponse<byte[]> response = sendBytes(signedRequest("DELETE", objectKey.trim(), null, null));
+		HttpResponse<byte[]> response = sendBytes(signedRequest("DELETE", normalizedObjectKey, null, null));
 		if (response.statusCode() == 404) {
 			return;
 		}
@@ -149,7 +153,12 @@ public class ObjectStorageFacilityReportPhotoStorage implements
 	}
 
 	private void putObject(String objectKey, String contentType, byte[] bytes) {
-		HttpResponse<byte[]> response = sendBytes(signedRequest("PUT", objectKey, contentType, bytes));
+		HttpResponse<byte[]> response = sendBytes(signedRequest(
+			"PUT",
+			requireFacilityReportObjectKey(objectKey),
+			contentType,
+			bytes
+		));
 		requireSuccess(response.statusCode(), "Failed to store facility report photo object");
 	}
 
@@ -301,6 +310,33 @@ public class ObjectStorageFacilityReportPhotoStorage implements
 
 	private static String canonicalUri(String bucket, String objectKey) {
 		return "/" + ObjectStorageUrlEncoding.encodePathSegment(bucket) + "/" + ObjectStorageUrlEncoding.encodePath(objectKey);
+	}
+
+	private static String requireFacilityReportObjectKey(String objectKey) {
+		String normalizedObjectKey = normalizeFacilityReportObjectKey(objectKey);
+		if (normalizedObjectKey == null) {
+			throw new InvalidFacilityReportException("사진 첨부 정보를 확인해야 합니다.");
+		}
+		return normalizedObjectKey;
+	}
+
+	private static String normalizeFacilityReportObjectKey(String objectKey) {
+		if (objectKey == null || objectKey.isBlank()) {
+			return null;
+		}
+		String normalizedObjectKey = objectKey.trim();
+		if (!normalizedObjectKey.startsWith(OBJECT_KEY_PREFIX)
+			|| normalizedObjectKey.startsWith("/")
+			|| normalizedObjectKey.contains("\\")
+			|| normalizedObjectKey.contains("//")) {
+			return null;
+		}
+		for (String segment : normalizedObjectKey.split("/", -1)) {
+			if (segment.isBlank() || ".".equals(segment) || "..".equals(segment)) {
+				return null;
+			}
+		}
+		return normalizedObjectKey;
 	}
 
 	private static String requireText(String value, String message) {

--- a/backend/src/test/java/com/easysubway/report/adapter/out/storage/ObjectStorageFacilityReportPhotoStorageTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/out/storage/ObjectStorageFacilityReportPhotoStorageTest.java
@@ -100,6 +100,37 @@ class ObjectStorageFacilityReportPhotoStorageTest {
 			.hasMessage("사진 파일 크기를 줄여야 합니다.");
 	}
 
+	@Test
+	void rejectsObjectKeysOutsideFacilityReportPrefixBeforeSigningRequests() {
+		ObjectStorageFacilityReportPhotoStorage storage = new ObjectStorageFacilityReportPhotoStorage(
+			"http://127.0.0.1:1",
+			"easysubway-report-uploads",
+			900L * 1024L,
+			"prod-object-storage-access-key",
+			"prod-object-storage-secret-key-with-enough-entropy",
+			"ap-northeast-2",
+			HttpClient.newHttpClient(),
+			Clock.fixed(Instant.parse("2026-06-20T00:00:00Z"), ZoneOffset.UTC)
+		);
+
+		for (String objectKey : new String[] {
+			"other-prefix/object.jpg",
+			"/facility-reports/unclaimed/object.jpg",
+			"facility-reports/../object.jpg",
+			"facility-reports//object.jpg",
+			"facility-reports\\unclaimed\\object.jpg"
+		}) {
+			assertThat(storage.loadFacilityReportPhoto(objectKey)).isEmpty();
+			storage.deleteFacilityReportPhoto(objectKey);
+			assertThatThrownBy(() -> storage.storeUploadedReportPhoto(new StoreUploadedReportPhotoCommand(
+				objectKey,
+				new byte[] {1, 2, 3}
+			)))
+				.isInstanceOf(InvalidFacilityReportException.class)
+				.hasMessage("사진 첨부 정보를 확인해야 합니다.");
+		}
+	}
+
 	private void startObjectStorageServer() throws IOException {
 		server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
 		server.createContext("/", this::handleObjectRequest);


### PR DESCRIPTION
## 관련 이슈

#1022

## 작업 배경

Android RC abuse-case와 penetration rehearsal에서 신고 사진 object storage 경계는 prefix 이탈, 절대 경로, traversal, 잘못된 segment를 원격 저장소 요청 전에 차단해야 한다. 기존 운영 object storage adapter는 blank key만 막고 전달받은 object key를 그대로 서명 요청에 사용해, `facility-reports/` 밖의 key도 signed GET/DELETE/PUT 대상으로 만들 수 있었다.

이 PR은 #1022 전체를 닫지 않는다. RC/Play/실환경 object storage rehearsal evidence는 별도 후속 검증으로 남고, 이번 변경은 backend object storage key 경계의 코드/테스트 보강만 다룬다.

## 작업 내용

- 신고 사진 object key를 `facility-reports/` prefix 내부 key로 정규화한 뒤 signed request에 사용하도록 제한했다.
- prefix 이탈, 절대 경로, `..`, 빈 segment, backslash가 포함된 key는 원격 요청 전에 차단한다.
- 조회/삭제는 잘못된 key를 외부 요청 없이 empty/no-op으로 처리하고, 업로드는 `InvalidFacilityReportException`으로 거부한다.
- 운영 object storage adapter 단위 테스트에 잘못된 key들이 signing request 전에 차단되는 케이스를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.report.adapter.out.storage.ObjectStorageFacilityReportPhotoStorageTest --no-daemon`: BUILD SUCCESSFUL
  - `node --test --test-name-pattern "릴리즈 보안 기준선" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `git diff --check`: exit 0
  - `node --test tools/ci/*.test.mjs`: exit 0, 129 tests passed
  - `./gradlew check --no-daemon`: BUILD SUCCESSFUL
  - GitHub PR checks: Android CI, Backend CI, Mobile App CI, Repository CI, Release Gate Consistency, Dependency Vulnerability Scan, Backend Release Image, RC Evidence Manifest, SonarCloud Code Analysis 모두 통과
  - CodeRabbit: rate limit으로 실제 review 미시작 확인
  - Codex CLI fallback review: `codex review --base origin/main --title "[Fix] 신고 사진 object storage key 경계 강화"` 실행, actionable/nitpick 0건, PR review #4587959652 게시

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Object storage key 경계 | backend | `ObjectStorageFacilityReportPhotoStorageTest` | `./gradlew test --tests com.easysubway.report.adapter.out.storage.ObjectStorageFacilityReportPhotoStorageTest --no-daemon` | prefix 이탈, 절대 경로, traversal, 빈 segment, backslash key가 원격 요청 전 차단됨 |
| 릴리즈 보안 계약 | repository | release security contract | `node --test --test-name-pattern "릴리즈 보안 기준선" tools/ci/repository-contract.test.mjs` | exit 0, 1 test passed |
| 전체 repository contract | repository | CI contract test | `node --test tools/ci/*.test.mjs` | exit 0, 129 tests passed |
| backend 회귀 | backend | Gradle check | `./gradlew check --no-daemon` | BUILD SUCCESSFUL |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `ObjectStorageFacilityReportPhotoStorage`가 object key를 정규화한 뒤에만 signed request를 만들도록 바뀐 부분.
- `loadFacilityReportPhoto`와 `deleteFacilityReportPhoto`는 invalid key를 원격 요청 없이 무시하고, `storeUploadedReportPhoto`는 잘못된 key를 입력 오류로 거부한다.
- #1022의 RC abuse-case 전체 evidence는 아직 남아 있으며, 이번 PR은 object storage key 경계 hardening 범위만 검증한다.

## 리스크

- 기존에 `facility-reports/` 밖에 저장된 신고 사진 key가 있다면 더 이상 운영 adapter에서 접근하지 않는다. 현재 신고 사진 생성 경로는 `facility-reports/<reportId>/...` 형식을 사용하므로 정상 업로드 경로 영향은 없다.
- 외부 object storage 실환경, Play 생성 설치 빌드, penetration rehearsal 결과는 이 PR의 로컬 검증에 포함되지 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
