### PR TITLE
[Test] receipt token abuse 경계 고정

### DIFF
--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportControllerTest.java
@@ -580,6 +580,56 @@ class FacilityReportControllerTest {
 	}
 
 	@Test
+	@DisplayName("receipt token은 다른 신고의 상태 조회와 확인 요청에 재사용할 수 없다")
+	void receiptTokenCannotBeReusedAcrossReportsForStatusOrConfirm() throws Exception {
+		ReceiptReport firstReport = createAnonymousReceiptReport(
+			"client-submission-token-abuse-1",
+			"첫 번째 receipt token abuse 검증 신고"
+		);
+		ReceiptReport secondReport = createAnonymousReceiptReport(
+			"client-submission-token-abuse-2",
+			"두 번째 receipt token abuse 검증 신고"
+		);
+
+		mockMvc.perform(post("/admin/reports/{reportId}/review", firstReport.reportId())
+				.with(httpBasic("admin-test", "admin-test-password"))
+				.with(csrf())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "decision": "REJECT"
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.status").value("REJECTED"));
+
+		String statusResponse = mockMvc.perform(get("/api/v1/reports/{reportId}", firstReport.reportId())
+				.header("X-Easysubway-Report-Receipt-Token", secondReport.receiptToken()))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").value("신고 정보를 찾을 수 없습니다."))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		Assertions.assertThat(statusResponse)
+			.doesNotContain(firstReport.receiptToken())
+			.doesNotContain(secondReport.receiptToken());
+
+		String confirmResponse = mockMvc.perform(post("/api/v1/reports/{reportId}/confirm", firstReport.reportId())
+				.with(csrf())
+				.header("X-Easysubway-Report-Receipt-Token", secondReport.receiptToken()))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").value("신고 정보를 찾을 수 없습니다."))
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+		Assertions.assertThat(confirmResponse)
+			.doesNotContain(firstReport.receiptToken())
+			.doesNotContain(secondReport.receiptToken());
+	}
+
+	@Test
 	@DisplayName("다른 사용자의 신고 처리 결과 확인은 공통 404 응답을 반환한다")
 	void confirmReportResultRequiresOwner() throws Exception {
 		String reportId = createReport("basic-user", "user-test-password", "spoofed-user", "다른 사용자가 확인하면 안 되는 신고");
@@ -1103,6 +1153,30 @@ class FacilityReportControllerTest {
 		return JsonPath.read(response, "$.data.id");
 	}
 
+	private ReceiptReport createAnonymousReceiptReport(String clientSubmissionId, String description) throws Exception {
+		String response = mockMvc.perform(post("/api/v1/reports")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "clientSubmissionId": "%s",
+					  "stationId": "station-sangnoksu",
+					  "facilityId": "facility-sangnoksu-elevator-1",
+					  "reportType": "BROKEN",
+					  "description": "%s"
+					}
+					""".formatted(clientSubmissionId, description)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.data.receiptToken").isNotEmpty())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		return new ReceiptReport(
+			JsonPath.read(response, "$.data.id"),
+			JsonPath.read(response, "$.data.receiptToken")
+		);
+	}
+
 	private UploadedObject uploadReportPhotoObject(
 		String clientSubmissionId,
 		String contentType,
@@ -1168,5 +1242,8 @@ class FacilityReportControllerTest {
 	}
 
 	private record UploadedObject(String objectKey, String sha256) {
+	}
+
+	private record ReceiptReport(String reportId, String receiptToken) {
 	}
 }


### PR DESCRIPTION
## 관련 이슈

#1022

## 작업 배경

Android RC abuse-case와 penetration rehearsal에서 receipt token은 계정 없는 신고 상태 조회와 확인 흐름을 보호하는 핵심 경계다. 기존 테스트는 정상 token 조회와 정상 확인 흐름을 검증했지만, 다른 신고에서 발급된 token을 재사용해 status/confirm endpoint를 호출하는 cross-report abuse case가 명시적인 회귀 테스트로 고정되어 있지 않았다.

이 PR은 #1022 전체를 닫지 않는다. Android RC artifact scan, network trace, 실환경 object storage lifecycle, admin/operator 전체 rehearsal evidence는 후속 검증으로 남고, 이번 변경은 receipt token cross-report abuse boundary 증거만 보강한다.

## 작업 내용

- 익명 receipt 신고 2건을 생성한 뒤 두 번째 신고의 receipt token으로 첫 번째 신고 상태 조회를 시도하면 404가 반환되는 테스트를 추가했다.
- 같은 cross-report token으로 첫 번째 신고 confirm endpoint를 호출해도 404가 반환되는 테스트를 추가했다.
- 두 오류 응답이 첫 번째/두 번째 receipt token 원문을 포함하지 않는 redaction 계약을 함께 검증했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.report.adapter.in.web.FacilityReportControllerTest --no-daemon`: BUILD SUCCESSFUL
  - `node --test --test-name-pattern "릴리즈 보안 기준선" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `git diff --check`: exit 0
  - `./gradlew check --no-daemon`: BUILD SUCCESSFUL
  - GitHub PR checks: Android CI, Backend CI, Mobile App CI, Repository CI, Release Gate Consistency, Dependency Vulnerability Scan, Backend Release Image, RC Evidence Manifest, SonarCloud Code Analysis 모두 통과
  - CodeRabbit: rate limit으로 실제 review 미시작 확인
  - Codex CLI fallback review: `codex review --base origin/main --title "[Test] receipt token abuse 경계 고정"` 실행, actionable/nitpick 0건, PR review #4587970057 게시

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| receipt token cross-report status abuse | backend | `FacilityReportControllerTest` | `./gradlew test --tests com.easysubway.report.adapter.in.web.FacilityReportControllerTest --no-daemon` | 다른 신고 token으로 상태 조회 시 404, token 원문 미노출 |
| receipt token cross-report confirm abuse | backend | `FacilityReportControllerTest` | `./gradlew test --tests com.easysubway.report.adapter.in.web.FacilityReportControllerTest --no-daemon` | 다른 신고 token으로 confirm 요청 시 404, token 원문 미노출 |
| 릴리즈 보안 계약 | repository | release security contract | `node --test --test-name-pattern "릴리즈 보안 기준선" tools/ci/repository-contract.test.mjs` | exit 0, 1 test passed |
| backend 회귀 | backend | Gradle check | `./gradlew check --no-daemon` | BUILD SUCCESSFUL |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `receiptTokenCannotBeReusedAcrossReportsForStatusOrConfirm` 테스트의 status/confirm negative case.
- 실제 production 코드 변경 없이 현재 controller/service 경계가 #1022의 `cross_report_enumeration`, `confirm_endpoint_abuse`, `url_header_log_redaction` 일부를 만족하는지 회귀 테스트로 고정한다.

## 리스크

- 테스트 보강만 포함하므로 runtime 동작 변경은 없다.
- Android RC artifact scan, network trace, 실환경 object storage lifecycle, admin/operator 전체 rehearsal evidence는 이 PR 범위가 아니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
