### PR TITLE
[Test] 관리자 CSRF abuse 경계 고정

### DIFF
--- a/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminE2EFlowTest.java
+++ b/backend/src/test/java/com/easysubway/admin/adapter/in/web/AdminE2EFlowTest.java
@@ -192,6 +192,26 @@ class AdminE2EFlowTest {
 	}
 
 	@Test
+	@DisplayName("관리자 mutation은 유효한 세션과 command token이 있어도 CSRF 없이는 거부된다")
+	void adminMutationRequiresCsrfToken() throws Exception {
+		RequestPostProcessor admin = fullAdmin();
+		String reportId = createReport("CSRF 없이 검수하면 안 되는 신고");
+		MockHttpSession session = new MockHttpSession();
+		String commandToken = commandTokenFrom(getAdminHtml("/admin/reports/%s/page".formatted(reportId), session, admin));
+
+		mockMvc.perform(post("/admin/reports/{reportId}/page/review", reportId)
+				.session(session)
+				.with(admin)
+				.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+				.param("commandToken", commandToken)
+				.param("decision", "ACCEPT"))
+			.andExpect(status().isForbidden());
+
+		assertThat(getAdminHtml("/admin/reports/%s/page".formatted(reportId), session, admin))
+			.doesNotContain("반영됨");
+	}
+
+	@Test
 	@DisplayName("관리자 오류 shell은 403, 409, validation 실패를 같은 화면 기준으로 표시한다")
 	void adminErrorShellCoversForbiddenConflictAndValidation() throws Exception {
 		RequestPostProcessor admin = fullAdmin();


### PR DESCRIPTION
## 관련 이슈

#1022

## 작업 배경

Android RC abuse-case와 penetration rehearsal의 admin/operator security 범위에는 `csrf_missing_mutation` negative test가 포함된다. 관리자 검수 화면은 command token을 별도로 쓰지만, command token만으로 CSRF를 대체하면 안 된다. 기존 테스트는 정상 mutation에 CSRF를 붙이고 권한/lockout 흐름을 확인했지만, 유효한 관리자 세션과 command token이 있어도 Spring CSRF token이 없으면 mutation이 거부되는 경계를 명시적으로 고정하지 않았다.

이 PR은 #1022 전체를 닫지 않는다. Android RC artifact scan, network trace, 실환경 object storage lifecycle, operator tenant rehearsal evidence는 후속 검증으로 남고, 이번 변경은 admin CSRF negative case 증거만 보강한다.

## 작업 내용

- `AdminE2EFlowTest`에 관리자 신고 검수 mutation의 CSRF negative test를 추가했다.
- 유효한 관리자 권한, session, 화면 command token을 모두 갖춘 요청도 Spring CSRF token이 없으면 403으로 거부되는지 검증했다.
- 거부 이후 신고 상세 화면에 승인 반영 문구가 나타나지 않아 mutation side effect가 없음을 확인했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.admin.adapter.in.web.AdminE2EFlowTest --no-daemon`: BUILD SUCCESSFUL
  - `node --test --test-name-pattern "릴리즈 보안 기준선" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `git diff --check`: exit 0
  - `./gradlew check --no-daemon`: BUILD SUCCESSFUL
  - GitHub PR checks: required checks passed
  - CodeRabbit: rate limit으로 실제 리뷰 시작 불가
  - Codex CLI fallback review: PR review #4587978264, actionable 0 / nitpick 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| admin CSRF missing mutation | backend | `AdminE2EFlowTest` | `./gradlew test --tests com.easysubway.admin.adapter.in.web.AdminE2EFlowTest --no-daemon` | 유효 session/command token이 있어도 CSRF 없으면 403, 검수 side effect 없음 |
| 릴리즈 보안 계약 | repository | release security contract | `node --test --test-name-pattern "릴리즈 보안 기준선" tools/ci/repository-contract.test.mjs` | exit 0, 1 test passed |
| backend 회귀 | backend | Gradle check | `./gradlew check --no-daemon` | BUILD SUCCESSFUL |
| PR CI | GitHub Actions | PR #1058 checks | `gh pr checks 1058 --watch --interval 10` | required checks passed |
| 코드 리뷰 fallback | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI review | PR review #4587978264 | actionable 0, nitpick 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `adminMutationRequiresCsrfToken` 테스트가 command token 검증이 아니라 CSRF token 누락 자체를 검증하는지.
- runtime 코드 변경 없이 #1022의 `csrf_missing_mutation` abuse rehearsal 증거를 회귀 테스트로 고정한다.

## 리스크

- 테스트 보강만 포함하므로 runtime 동작 변경은 없다.
- operator tenant authorization, 실환경 admin/operator rehearsal, Android RC evidence는 이 PR 범위가 아니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
