### PR TITLE
[Test] 관리자 신고 사진 권한 경계 고정

### DIFF
--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.easysubway.admin.authorization.AdminPermission;
 import com.easysubway.admin.audit.adapter.out.persistence.InMemoryAdminAuditEventRepository;
 import com.easysubway.admin.audit.domain.AdminAuditOutcome;
 import com.easysubway.admin.audit.domain.AdminAuditEventType;
@@ -228,7 +229,7 @@ class FacilityReportAdminPageControllerTest {
 	void adminReportPhotoEndpointsRequirePhotoReadPermission() throws Exception {
 		String reportId = createReportWithPhotoAndLocation("사진 권한 경계를 확인할 신고");
 		RequestPostProcessor reportReviewer = user("report-reviewer")
-			.authorities(new SimpleGrantedAuthority("admin.report.review"));
+			.authorities(new SimpleGrantedAuthority(AdminPermission.REPORT_REVIEW.authority()));
 
 		mockMvc.perform(get("/admin/reports/{reportId}/photo/thumbnail", reportId)
 				.with(reportReviewer))

--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAdminPageControllerTest.java
@@ -3,6 +3,7 @@ package com.easysubway.report.adapter.in.web;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -23,6 +24,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
@@ -219,6 +221,22 @@ class FacilityReportAdminPageControllerTest {
 				"VIEW_REPORT_PHOTO_ORIGINAL:FACILITY_REPORT_PHOTO:" + reportId + ":업무 맥락: 신고 원본 사진 조회",
 				"VIEW_REPORT_PHOTO_THUMBNAIL:FACILITY_REPORT_PHOTO:" + reportId + ":업무 맥락: 신고 사진 미리보기 조회"
 			);
+	}
+
+	@Test
+	@DisplayName("신고 검수 권한만 있는 관리자는 신고 사진 endpoint에 접근할 수 없다")
+	void adminReportPhotoEndpointsRequirePhotoReadPermission() throws Exception {
+		String reportId = createReportWithPhotoAndLocation("사진 권한 경계를 확인할 신고");
+		RequestPostProcessor reportReviewer = user("report-reviewer")
+			.authorities(new SimpleGrantedAuthority("admin.report.review"));
+
+		mockMvc.perform(get("/admin/reports/{reportId}/photo/thumbnail", reportId)
+				.with(reportReviewer))
+			.andExpect(status().isForbidden());
+
+		mockMvc.perform(get("/admin/reports/{reportId}/photo/original", reportId)
+				.with(reportReviewer))
+			.andExpect(status().isForbidden());
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

#1022

## 작업 배경

#1022의 admin/operator security 범위에는 권한 없는 role이 개인정보와 사진에 접근하지 못한다는 negative rehearsal이 포함된다. 신고 검수 권한(`admin.report.review`)은 신고 상세와 검수 업무에 필요하지만, 신고 사진 thumbnail/original 조회는 별도 개인정보 권한(`admin.report.photo.read`)으로 분리되어야 한다.

이 PR은 #1022 전체를 닫지 않는다. Play-installed build smoke, pre-launch report, deployed signed URL/object storage lifecycle, 운영 HTTPS 환경 rehearsal evidence는 후속 검증으로 남고, 이번 변경은 admin report photo read permission negative case만 회귀 테스트로 고정한다.

## 작업 내용

- `FacilityReportAdminPageControllerTest`에 신고 사진 endpoint 권한 negative test를 추가했다.
- `admin.report.review`만 가진 관리자 principal이 thumbnail/original 사진 endpoint에 접근하면 모두 403으로 거부되는지 검증했다.
- 기존 사진 endpoint 성공 테스트는 유지해 `admin.report.photo.read` 권한이 있는 정상 관리자 흐름과 분리했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.report.adapter.in.web.FacilityReportAdminPageControllerTest --no-daemon`: BUILD SUCCESSFUL
  - `node --test --test-name-pattern "릴리즈 보안 기준선" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `git diff --check`: exit 0
  - `./gradlew check --no-daemon`: BUILD SUCCESSFUL
  - GitHub PR checks: required checks passed
  - CodeRabbit: actionable 1건 확인, `57e1bc35`에서 수정 후 원래 inline thread에 답글 및 resolve 완료
  - CodeRabbit follow-up re-review: rate limit으로 실제 리뷰 시작 불가
  - Codex CLI fallback review: PR review #4587997414, actionable 0 / nitpick 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| admin report photo permission negative | backend | `FacilityReportAdminPageControllerTest` | `./gradlew test --tests com.easysubway.report.adapter.in.web.FacilityReportAdminPageControllerTest --no-daemon` | `admin.report.review`만 가진 principal은 thumbnail/original 사진 endpoint에서 403 |
| 릴리즈 보안 계약 | repository | release security contract | `node --test --test-name-pattern "릴리즈 보안 기준선" tools/ci/repository-contract.test.mjs` | exit 0, 1 test passed |
| backend 회귀 | backend | Gradle check | `./gradlew check --no-daemon` | BUILD SUCCESSFUL |
| PR CI | GitHub Actions | PR #1059 checks | `gh pr checks 1059 --watch --interval 10` | required checks passed |
| 코드 리뷰 | GitHub PR review | CodeRabbit review, inline thread reply/resolve, Codex fallback re-review | CodeRabbit inline thread, PR review #4587997414 | CodeRabbit finding 수정 완료, Codex fallback actionable 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `adminReportPhotoEndpointsRequirePhotoReadPermission` 테스트가 신고 검수 권한과 사진 조회 권한을 분리해 검증하는지.
- runtime 코드 변경 없이 #1022의 admin photo read permission negative evidence를 회귀 테스트로 고정한다.

## 리스크

- 테스트 보강만 포함하므로 runtime 동작 변경은 없다.
- deployed admin/operator rehearsal, Play-installed artifact, object storage lifecycle, signed URL TTL/method/content-type 검증은 이 PR 범위가 아니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
