### PR TITLE
[Test] 비신뢰 forwarded rate limit 경계 고정

### DIFF
--- a/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControlTest.java
+++ b/backend/src/test/java/com/easysubway/report/adapter/in/web/FacilityReportAbuseControlTest.java
@@ -123,6 +123,18 @@ class FacilityReportAbuseControlTest {
 	}
 
 	@Test
+	@DisplayName("trusted proxy가 아닌 요청은 X-Forwarded-For로 client identity를 바꾸지 못한다")
+	void untrustedRemoteCannotSpoofForwardedForIdentity() throws Exception {
+		getUnknownStatusFromUntrustedForwardedClient("198.51.100.210", "203.0.113.30")
+			.andExpect(status().isNotFound());
+		getUnknownStatusFromUntrustedForwardedClient("198.51.100.210", "203.0.113.31")
+			.andExpect(status().isNotFound());
+
+		getUnknownStatusFromUntrustedForwardedClient("198.51.100.210", "203.0.113.32")
+			.andExpect(status().isTooManyRequests());
+	}
+
+	@Test
 	@DisplayName("trusted proxy 요청은 invalid X-Forwarded-For 값을 unknown client identity로 묶는다")
 	void trustedProxyInvalidForwardedForUsesUnknownIdentity() throws Exception {
 		getUnknownStatusFromForwardedChain("not-an-ip-1").andExpect(status().isNotFound());
@@ -265,6 +277,17 @@ class FacilityReportAbuseControlTest {
 		throws Exception {
 		return mockMvc.perform(get("/api/v1/reports/unknown-forwarded-report")
 			.with(remoteAddr("10.0.0.10"))
+			.header("X-Forwarded-For", forwardedFor)
+			.header("X-Easysubway-Report-Receipt-Token", "receipt-token-for-rate-limit"));
+	}
+
+	private org.springframework.test.web.servlet.ResultActions getUnknownStatusFromUntrustedForwardedClient(
+		String remoteAddr,
+		String forwardedFor
+	)
+		throws Exception {
+		return mockMvc.perform(get("/api/v1/reports/unknown-untrusted-forwarded-report")
+			.with(remoteAddr(remoteAddr))
 			.header("X-Forwarded-For", forwardedFor)
 			.header("X-Easysubway-Report-Receipt-Token", "receipt-token-for-rate-limit"));
 	}


### PR DESCRIPTION
## 관련 이슈

#1022 부분 보강입니다. production-like rehearsal 증거가 남아 있으므로 issue를 닫지 않습니다.

## 작업 배경

#1022의 distributed rate-limit abuse matrix는 trusted proxy negative test를 요구합니다. 기존 테스트는 trusted proxy가 전달한 `X-Forwarded-For` chain에서 spoofed leftmost 값을 쓰지 않는 경계를 확인했지만, trusted proxy가 아닌 remote client가 `X-Forwarded-For`를 직접 넣어 rate-limit identity를 바꾸는 시도는 별도 회귀 테스트로 고정되어 있지 않았습니다.

## 작업 내용

- 비신뢰 remote address의 요청이 서로 다른 `X-Forwarded-For` 값을 보내도 remote address 기준 같은 rate-limit bucket에 묶이는 테스트를 추가했습니다.
- 동일 remote에서 3번째 status lookup 요청이 429로 차단되는지 확인해 untrusted forwarded spoofing 우회를 막았습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.report.adapter.in.web.FacilityReportAbuseControlTest --no-daemon`: exit 0, BUILD SUCCESSFUL
  - `node --test --test-name-pattern "abuse|penetration|rehearsal|security privacy" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `git diff --check`: exit 0
  - `./gradlew check --no-daemon`: exit 0, BUILD SUCCESSFUL

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| untrusted forwarded rate-limit boundary | backend local test | targeted JUnit class | `./gradlew test --tests com.easysubway.report.adapter.in.web.FacilityReportAbuseControlTest --no-daemon` output | pass |
| #1022 release contract | local Node.js | repository contract filtered test | `node --test --test-name-pattern "abuse|penetration|rehearsal|security privacy" tools/ci/repository-contract.test.mjs` output | pass |
| backend regression | backend local test | full backend check | `./gradlew check --no-daemon` output | pass |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `untrustedRemoteCannotSpoofForwardedForIdentity`가 trusted proxy CIDR 밖 remote의 `X-Forwarded-For` header를 client identity로 쓰지 않는 경계를 충분히 보여주는지 확인해 주세요.

## 리스크

- 이 PR은 로컬 abuse-control 회귀 테스트 보강입니다. Play-installed artifact, deployed HTTPS 환경, multi-node/distributed store rehearsal, object storage lifecycle 증거는 여전히 #1022 잔여 blocker입니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
