### PR TITLE
[Test] Android quality Console 증거 gate 고정

### DIFF
--- a/apps/mobile/release/android-release-quality-gate.json
+++ b/apps/mobile/release/android-release-quality-gate.json
@@ -35,6 +35,25 @@
     ],
     "mismatchDisposition": "NO_GO"
   },
+  "playConsoleEvidencePolicy": {
+    "requiredBeforeGo": true,
+    "requiredSummaryFields": [
+      "playPreLaunchReportResult",
+      "playPreLaunchCrashCount",
+      "playPreLaunchAnrCount",
+      "playPolicyWarningStatus",
+      "androidVitalsCrashAnrSummary",
+      "triageDisposition",
+      "capturedAtUtc"
+    ],
+    "goNoGoRules": {
+      "missingConsoleSummary": "BLOCKED_EXTERNAL",
+      "preLaunchCrashOrAnr": "BLOCKED_TECHNICAL",
+      "untriagedPolicyWarning": "BLOCKED_TECHNICAL",
+      "privacyUnsafeCrashLog": "BLOCKED_TECHNICAL"
+    },
+    "summaryRequiredKo": "Play Console pre-launch report와 Android vitals의 crash, ANR, policy warning 상태를 민감정보 없이 요약한다."
+  },
   "deviceEvidencePolicy": {
     "codexQaDevice": "local_android_emulator_only",
     "physicalDeviceEvidence": "not_used_for_codex_pr_evidence",
@@ -71,6 +90,8 @@
       "uiTreePath",
       "screenshotOrRecordingPath",
       "logcatSummaryPath",
+      "talkbackNotesPath",
+      "playConsoleSummaryPath",
       "result",
       "blockerDisposition"
     ],
@@ -90,7 +111,7 @@
       "id": "talkback_primary_journey",
       "releaseBlocker": true,
       "journeys": ["home", "station-search", "route-result", "facility-report", "support-info"],
-      "evidence": ["ui-tree", "talkback-notes", "screen-recording-or-screenshot-sequence"],
+      "evidence": ["ui-tree", "talkback-reading-order-notes", "screen-recording-or-screenshot-sequence"],
       "passCriteriaKo": "focus order, role, state, action, dynamic update가 이동 흐름을 이해할 수 있게 읽힌다."
     },
     {
@@ -156,7 +177,7 @@
     {
       "id": "crash_anr_privacy_safe_reporting",
       "releaseBlocker": true,
-      "evidence": ["logcat-summary", "privacy-review-notes"],
+      "evidence": ["logcat-summary", "play-console-pre-launch-report-summary", "android-vitals-summary", "privacy-review-notes"],
       "passCriteriaKo": "crash/ANR reporting은 민감 위치, 신고 사진, receipt token, signing/credential 값을 노출하지 않는다."
     }
   ],
@@ -211,7 +232,7 @@
     {
       "checkId": "talkback_primary_journey",
       "requiredEvidenceIds": ["home_support_scope", "station_search", "route_result_found_unknown_unavailable", "facility_report_recovery", "help_privacy_data_deletion"],
-      "requiredSummaryFields": ["checkId", "buildIdentity", "deviceId", "androidApi", "evidencePaths", "uiTreePath", "screenshotOrRecordingPath", "result", "blockerDisposition"]
+      "requiredSummaryFields": ["checkId", "buildIdentity", "deviceId", "androidApi", "evidencePaths", "uiTreePath", "screenshotOrRecordingPath", "talkbackNotesPath", "result", "blockerDisposition"]
     },
     {
       "checkId": "font_scale_150_200_small_screen",
@@ -251,7 +272,7 @@
     {
       "checkId": "crash_anr_privacy_safe_reporting",
       "requiredEvidenceIds": ["facility_report_recovery", "help_privacy_data_deletion"],
-      "requiredSummaryFields": ["checkId", "buildIdentity", "buildSource", "deviceId", "evidencePaths", "logcatSummaryPath", "result", "blockerDisposition"]
+      "requiredSummaryFields": ["checkId", "buildIdentity", "buildSource", "deviceId", "evidencePaths", "logcatSummaryPath", "playConsoleSummaryPath", "result", "blockerDisposition"]
     }
   ],
   "evidencePolicy": {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7417,6 +7417,21 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
     "androidApplicationId",
   ]);
   assert.equal(gate.buildIdentityPolicy.mismatchDisposition, "NO_GO");
+  assert.equal(gate.playConsoleEvidencePolicy.requiredBeforeGo, true);
+  assert.deepEqual(gate.playConsoleEvidencePolicy.requiredSummaryFields, [
+    "playPreLaunchReportResult",
+    "playPreLaunchCrashCount",
+    "playPreLaunchAnrCount",
+    "playPolicyWarningStatus",
+    "androidVitalsCrashAnrSummary",
+    "triageDisposition",
+    "capturedAtUtc",
+  ]);
+  assert.equal(gate.playConsoleEvidencePolicy.goNoGoRules.missingConsoleSummary, "BLOCKED_EXTERNAL");
+  assert.equal(gate.playConsoleEvidencePolicy.goNoGoRules.preLaunchCrashOrAnr, "BLOCKED_TECHNICAL");
+  assert.equal(gate.playConsoleEvidencePolicy.goNoGoRules.untriagedPolicyWarning, "BLOCKED_TECHNICAL");
+  assert.match(gate.playConsoleEvidencePolicy.summaryRequiredKo, /Play Console pre-launch report/);
+  assert.match(gate.playConsoleEvidencePolicy.summaryRequiredKo, /Android vitals/);
   assert.equal(gate.deviceEvidencePolicy.codexQaDevice, "local_android_emulator_only");
   assert.equal(gate.deviceEvidencePolicy.physicalDeviceEvidence, "not_used_for_codex_pr_evidence");
   assert.equal(gate.deviceEvidencePolicy.releaseRcEvidence, "play_installed_or_exact_rc_required_before_go");
@@ -7458,6 +7473,8 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
     "uiTreePath",
     "screenshotOrRecordingPath",
     "logcatSummaryPath",
+    "talkbackNotesPath",
+    "playConsoleSummaryPath",
     "result",
     "blockerDisposition",
   ]) {
@@ -7516,6 +7533,18 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
     requiredChecks
       .get("route_map_performance_budget")
       .evidence.includes("matched-profile-route-map-camera-latency-summary"),
+  );
+  assert.ok(
+    requiredChecks.get("talkback_primary_journey").evidence.includes("talkback-reading-order-notes"),
+    "TalkBack check must require actual reading-order notes instead of only UI tree evidence",
+  );
+  assert.ok(
+    requiredChecks.get("crash_anr_privacy_safe_reporting").evidence.includes("play-console-pre-launch-report-summary"),
+    "crash/ANR check must require Play Console pre-launch summary evidence",
+  );
+  assert.ok(
+    requiredChecks.get("crash_anr_privacy_safe_reporting").evidence.includes("android-vitals-summary"),
+    "crash/ANR check must require Android vitals summary evidence",
   );
 
   const evidenceSet = new Map(gate.requiredEvidenceSet.map((item) => [item.id, item]));
@@ -7578,12 +7607,20 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
     "font scale check must record the viewport",
   );
   assert.ok(
+    checkEvidenceMatrix.get("talkback_primary_journey").requiredSummaryFields.includes("talkbackNotesPath"),
+    "TalkBack check must record the actual reading-order notes path",
+  );
+  assert.ok(
     checkEvidenceMatrix.get("route_map_performance_budget").requiredSummaryFields.includes("buildSource"),
     "performance check must record RC or Play-installed build source",
   );
   assert.ok(
     checkEvidenceMatrix.get("crash_anr_privacy_safe_reporting").requiredSummaryFields.includes("logcatSummaryPath"),
     "crash/ANR privacy check must record logcat or crash summary path",
+  );
+  assert.ok(
+    checkEvidenceMatrix.get("crash_anr_privacy_safe_reporting").requiredSummaryFields.includes("playConsoleSummaryPath"),
+    "crash/ANR privacy check must record Play Console or Android vitals summary path",
   );
 
   assert.ok(androidRcEvidence.requiredEvidence.androidAccessibilityQa.includes("android-release-quality-gate-manifest"));


### PR DESCRIPTION
## 관련 이슈

AquilaXk/easysubway-mobile#9

이 PR은 #1021의 Android 출시 UX·접근성·성능 gate 중 Play Console crash/ANR/policy warning 요약과 TalkBack 실제 읽기 기록 요구사항을 고정하는 부분 보강입니다. Play-installed build와 Play Console 실증 수집이 남아 있어 이 PR만으로 #1021을 닫지 않습니다.

## 작업 배경

Android release quality gate는 이미 local emulator evidence, font scale, small screen, route map performance 기준을 포함하고 있습니다. 다만 QA 증거를 정리할 때 TalkBack UI tree와 실제 읽기 순서 기록이 섞일 수 있고, crash/ANR privacy-safe reporting이 local logcat만으로 충분한 것처럼 해석될 수 있어 Go 판단 전에 필요한 Play Console/Android vitals 요약을 별도 필드로 고정했습니다.

## 작업 내용

- `android-release-quality-gate.json`에 Play Console pre-launch report와 Android vitals 요약 정책을 추가했습니다.
- TalkBack 주요 여정 evidence를 `talkback-reading-order-notes`로 명확히 하고 summary 필드에 `talkbackNotesPath`를 추가했습니다.
- crash/ANR privacy check에 `play-console-pre-launch-report-summary`, `android-vitals-summary`, `playConsoleSummaryPath`를 추가했습니다.
- repository contract test가 위 필드와 No-Go 판단을 검증하도록 확장했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --check tools/ci/repository-contract.test.mjs`: exit 0
  - `node -e "JSON.parse(require('fs').readFileSync('apps/mobile/release/android-release-quality-gate.json','utf8')); console.log('json ok')"`: exit 0, `json ok`
  - `node --test --test-name-pattern "Android 출시 UX 접근성 성능 gate" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `git diff --check`: exit 0
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 119 tests passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Android release quality gate contract | Local repository | repository contract focused test | `node --test --test-name-pattern "Android 출시 UX 접근성 성능 gate" tools/ci/repository-contract.test.mjs` output | PASS, 1 test passed |
| Repository contract regression | Local repository | full repository contract test | `node --test tools/ci/repository-contract.test.mjs` output | PASS, 119 tests passed |
| Artifact syntax | Local repository | JSON parse and JS syntax check | `json ok`, `node --check tools/ci/repository-contract.test.mjs` exit 0 | PASS |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `playConsoleEvidencePolicy`, `talkbackNotesPath`, `playConsoleSummaryPath`가 #1021의 남은 증거 분류를 충분히 분리하는지 확인해 주세요.
- 이 PR은 실제 Play-installed build smoke, Play Console pre-launch report, Android vitals 캡처를 생성하지 않습니다. 해당 증거는 AquilaXk/easysubway-mobile#8/#1021의 외부 blocker가 해소된 뒤 수집해야 합니다.

## 리스크

- 런타임 동작 변경은 없습니다.
- release gate vocabulary가 늘어나므로 이후 증거 요약 작성 시 새 필드를 채워야 합니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
