### PR TITLE
[Test] 운영 지원 증거 판정 고정

### DIFF
--- a/apps/mobile/release/post-launch-operations-review-gate.json
+++ b/apps/mobile/release/post-launch-operations-review-gate.json
@@ -9,6 +9,27 @@
   "operationsEvidenceManifest": "apps/mobile/release/operations-release-evidence.json",
   "supportIncidentResponseGate": "apps/mobile/release/support-incident-response-gate.json",
   "evidenceRoot": ".codex/evidence/release/post-launch-operations-review/<rc-or-run>/",
+  "latestQaEvidenceSummary": {
+    "qaEvidenceDateKst": "2026-06-28",
+    "alertRouteDryRun": {
+      "result": "PASS",
+      "channel": "Slack Incoming Webhook",
+      "publicEvidenceSummary": "HTTP 200 / ok dry-run passed; webhook URL is not stored in tracked files or GitHub comments.",
+      "localOnlyEvidenceRoot": ".codex/evidence/release/post-launch-operations-review/slack-alert-route-20260628/"
+    },
+    "supportMailboxRouting": {
+      "result": "RESOLVED_BY_QA_MANUAL_EVIDENCE",
+      "publicContactDomain": "aquilaxk.site",
+      "addresses": ["support@aquilaxk.site", "security@aquilaxk.site", "privacy@aquilaxk.site"],
+      "summaryKo": "QA 수동 메일 테스트로 support/security/privacy 주소 routing을 정상 확인했다."
+    },
+    "remainingExternalBlockers": [
+      "play-review-status-summary",
+      "crash-anr-vitals-summary",
+      "support-ticket-summary-after-public-release",
+      "post-launch-review-window-evidence-after-public-release"
+    ]
+  },
   "reviewWindows": [
     {
       "id": "first_2h",

--- a/apps/mobile/release/release-governance-gate.json
+++ b/apps/mobile/release/release-governance-gate.json
@@ -76,6 +76,17 @@
       "install_update_rollback_failure"
     ]
   },
+  "latestOperationsEvidenceStatus": {
+    "issue": 1019,
+    "supportMailboxRouting": "RESOLVED_BY_QA_MANUAL_EVIDENCE",
+    "alertRouteDryRun": "PASS",
+    "remainingBlockers": [
+      "play-review-status-summary",
+      "crash-anr-vitals-summary",
+      "post-launch-review-window-evidence-after-public-release",
+      "support-incident-response-dry-run-evidence"
+    ]
+  },
   "releaseControl": {
     "raciRequired": true,
     "freezeRequired": true,

--- a/apps/mobile/release/support-incident-response-gate.json
+++ b/apps/mobile/release/support-incident-response-gate.json
@@ -15,7 +15,7 @@
       "result": "RESOLVED_BY_QA_MANUAL_EVIDENCE",
       "addresses": ["support@aquilaxk.site", "security@aquilaxk.site", "privacy@aquilaxk.site"],
       "dnsEvidence": ["MX records present", "SPF TXT present", "DKIM TXT present"],
-      "redactionPolicy": "GitHub에는 mailbox 개인 정보, raw receipt token, message body를 올리지 않는다."
+      "redactionPolicy": "GitHub에는 support mailbox 개인 정보, raw report receipt token, message body, operator private contact, provider credential or quota token, photo metadata를 올리지 않는다."
     },
     "remainingSupportReadiness": [
       "data-error-triage-dry-run",

--- a/apps/mobile/release/support-incident-response-gate.json
+++ b/apps/mobile/release/support-incident-response-gate.json
@@ -8,6 +8,23 @@
   "androidRcEvidenceManifest": "apps/mobile/release/android-rc-store-evidence.json",
   "postLaunchOperationsReviewGate": "apps/mobile/release/post-launch-operations-review-gate.json",
   "evidenceRoot": ".codex/evidence/release/support-incident-response/<rc-or-run>/",
+  "latestQaEvidenceSummary": {
+    "qaEvidenceDateKst": "2026-06-28",
+    "publicContactDomain": "aquilaxk.site",
+    "mailboxRouting": {
+      "result": "RESOLVED_BY_QA_MANUAL_EVIDENCE",
+      "addresses": ["support@aquilaxk.site", "security@aquilaxk.site", "privacy@aquilaxk.site"],
+      "dnsEvidence": ["MX records present", "SPF TXT present", "DKIM TXT present"],
+      "redactionPolicy": "GitHub에는 mailbox 개인 정보, raw receipt token, message body를 올리지 않는다."
+    },
+    "remainingSupportReadiness": [
+      "data-error-triage-dry-run",
+      "emergency-datapack-release-rollback-runbook-match",
+      "incident-notice-copy-review",
+      "local-emulator-help-screen-screenshot-or-ui-tree",
+      "operator-contact-route-evidence"
+    ]
+  },
   "supportChannels": [
     {
       "id": "support_email",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1097,11 +1097,12 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
     "security@aquilaxk.site",
     "privacy@aquilaxk.site",
   ]);
-  assert.ok(
-    postLaunchOperationsReviewGate.latestQaEvidenceSummary.remainingExternalBlockers.includes(
-      "post-launch-review-window-evidence-after-public-release",
-    ),
-  );
+  assert.deepEqual(postLaunchOperationsReviewGate.latestQaEvidenceSummary.remainingExternalBlockers, [
+    "play-review-status-summary",
+    "crash-anr-vitals-summary",
+    "support-ticket-summary-after-public-release",
+    "post-launch-review-window-evidence-after-public-release",
+  ]);
   assert.deepEqual(
     postLaunchOperationsReviewGate.reviewWindows.map((window) => window.id),
     ["first_2h", "first_24h", "day_7", "day_30"],
@@ -1193,13 +1194,27 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.ok(supportIncidentResponseGate.latestQaEvidenceSummary.mailboxRouting.dnsEvidence.includes("MX records present"));
   assert.match(
     supportIncidentResponseGate.latestQaEvidenceSummary.mailboxRouting.redactionPolicy,
-    /raw receipt token/,
+    /raw report receipt token/,
   );
-  assert.ok(
-    supportIncidentResponseGate.latestQaEvidenceSummary.remainingSupportReadiness.includes(
-      "data-error-triage-dry-run",
-    ),
+  assert.match(
+    supportIncidentResponseGate.latestQaEvidenceSummary.mailboxRouting.redactionPolicy,
+    /operator private contact/,
   );
+  assert.match(
+    supportIncidentResponseGate.latestQaEvidenceSummary.mailboxRouting.redactionPolicy,
+    /provider credential or quota token/,
+  );
+  assert.match(
+    supportIncidentResponseGate.latestQaEvidenceSummary.mailboxRouting.redactionPolicy,
+    /photo metadata/,
+  );
+  assert.deepEqual(supportIncidentResponseGate.latestQaEvidenceSummary.remainingSupportReadiness, [
+    "data-error-triage-dry-run",
+    "emergency-datapack-release-rollback-runbook-match",
+    "incident-notice-copy-review",
+    "local-emulator-help-screen-screenshot-or-ui-tree",
+    "operator-contact-route-evidence",
+  ]);
   assert.deepEqual(
     supportIncidentResponseGate.supportChannels.map((channel) => channel.id).sort(),
     ["faq_and_status_notice", "security_privacy_deletion", "support_email"],
@@ -1966,11 +1981,12 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
   assert.equal(gate.latestOperationsEvidenceStatus.issue, 1019);
   assert.equal(gate.latestOperationsEvidenceStatus.supportMailboxRouting, "RESOLVED_BY_QA_MANUAL_EVIDENCE");
   assert.equal(gate.latestOperationsEvidenceStatus.alertRouteDryRun, "PASS");
-  assert.ok(
-    gate.latestOperationsEvidenceStatus.remainingBlockers.includes(
-      "post-launch-review-window-evidence-after-public-release",
-    ),
-  );
+  assert.deepEqual(gate.latestOperationsEvidenceStatus.remainingBlockers, [
+    "play-review-status-summary",
+    "crash-anr-vitals-summary",
+    "post-launch-review-window-evidence-after-public-release",
+    "support-incident-response-dry-run-evidence",
+  ]);
   assert.ok(gate.gates.some((item) => item.issue === 1021 && item.id === "G7_ANDROID_QUALITY"));
   assert.ok(gate.gates.some((item) => item.issue === 1018 && item.id === "G9_GOOGLE_PLAY"));
   assert.deepEqual(

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1081,6 +1081,27 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.equal(postLaunchOperationsReviewGate.operationsEvidenceManifest, "apps/mobile/release/operations-release-evidence.json");
   assert.equal(postLaunchOperationsReviewGate.supportIncidentResponseGate, supportIncidentResponsePath);
   assert.match(postLaunchOperationsReviewGate.evidenceRoot, /\.codex\/evidence\/release\/post-launch-operations-review\/<rc-or-run>/);
+  assert.equal(postLaunchOperationsReviewGate.latestQaEvidenceSummary.qaEvidenceDateKst, "2026-06-28");
+  assert.equal(postLaunchOperationsReviewGate.latestQaEvidenceSummary.alertRouteDryRun.result, "PASS");
+  assert.equal(postLaunchOperationsReviewGate.latestQaEvidenceSummary.alertRouteDryRun.channel, "Slack Incoming Webhook");
+  assert.match(
+    postLaunchOperationsReviewGate.latestQaEvidenceSummary.alertRouteDryRun.publicEvidenceSummary,
+    /HTTP 200 \/ ok/,
+  );
+  assert.equal(
+    postLaunchOperationsReviewGate.latestQaEvidenceSummary.supportMailboxRouting.result,
+    "RESOLVED_BY_QA_MANUAL_EVIDENCE",
+  );
+  assert.deepEqual(postLaunchOperationsReviewGate.latestQaEvidenceSummary.supportMailboxRouting.addresses, [
+    "support@aquilaxk.site",
+    "security@aquilaxk.site",
+    "privacy@aquilaxk.site",
+  ]);
+  assert.ok(
+    postLaunchOperationsReviewGate.latestQaEvidenceSummary.remainingExternalBlockers.includes(
+      "post-launch-review-window-evidence-after-public-release",
+    ),
+  );
   assert.deepEqual(
     postLaunchOperationsReviewGate.reviewWindows.map((window) => window.id),
     ["first_2h", "first_24h", "day_7", "day_30"],
@@ -1159,6 +1180,26 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.equal(supportIncidentResponseGate.androidRcEvidenceManifest, androidRcEvidencePath);
   assert.equal(supportIncidentResponseGate.postLaunchOperationsReviewGate, postLaunchOperationsReviewPath);
   assert.match(supportIncidentResponseGate.evidenceRoot, /\.codex\/evidence\/release\/support-incident-response\/<rc-or-run>/);
+  assert.equal(supportIncidentResponseGate.latestQaEvidenceSummary.publicContactDomain, "aquilaxk.site");
+  assert.equal(
+    supportIncidentResponseGate.latestQaEvidenceSummary.mailboxRouting.result,
+    "RESOLVED_BY_QA_MANUAL_EVIDENCE",
+  );
+  assert.deepEqual(supportIncidentResponseGate.latestQaEvidenceSummary.mailboxRouting.addresses, [
+    "support@aquilaxk.site",
+    "security@aquilaxk.site",
+    "privacy@aquilaxk.site",
+  ]);
+  assert.ok(supportIncidentResponseGate.latestQaEvidenceSummary.mailboxRouting.dnsEvidence.includes("MX records present"));
+  assert.match(
+    supportIncidentResponseGate.latestQaEvidenceSummary.mailboxRouting.redactionPolicy,
+    /raw receipt token/,
+  );
+  assert.ok(
+    supportIncidentResponseGate.latestQaEvidenceSummary.remainingSupportReadiness.includes(
+      "data-error-triage-dry-run",
+    ),
+  );
   assert.deepEqual(
     supportIncidentResponseGate.supportChannels.map((channel) => channel.id).sort(),
     ["faq_and_status_notice", "security_privacy_deletion", "support_email"],
@@ -1922,6 +1963,14 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
   assert.equal(gate.releaseReadiness.iosBlocksAndroidRelease, false);
   assert.ok(gate.releaseReadiness.p0EscalationRules.includes("measured_performance_budget_failure"));
   assert.ok(gate.releaseReadiness.p0EscalationRules.includes("play_prelaunch_crash"));
+  assert.equal(gate.latestOperationsEvidenceStatus.issue, 1019);
+  assert.equal(gate.latestOperationsEvidenceStatus.supportMailboxRouting, "RESOLVED_BY_QA_MANUAL_EVIDENCE");
+  assert.equal(gate.latestOperationsEvidenceStatus.alertRouteDryRun, "PASS");
+  assert.ok(
+    gate.latestOperationsEvidenceStatus.remainingBlockers.includes(
+      "post-launch-review-window-evidence-after-public-release",
+    ),
+  );
   assert.ok(gate.gates.some((item) => item.issue === 1021 && item.id === "G7_ANDROID_QUALITY"));
   assert.ok(gate.gates.some((item) => item.issue === 1018 && item.id === "G9_GOOGLE_PLAY"));
   assert.deepEqual(


### PR DESCRIPTION
## 관련 이슈

#1019 follow-up

이 PR은 #1019의 mailbox/alert 판정과 남은 blocker 분리를 고정하지만, public release 이후 Play/post-launch 증거가 남아 있어 #1019를 닫지 않습니다.

## 작업 배경

#1019 운영 증거 중 support/security/privacy mailbox routing은 QA 수동 확인으로 해소됐고, Slack alert route dry-run도 HTTP 200 / ok로 통과했습니다. 반면 Play review, crash/ANR vitals, public release 이후 review window evidence, support incident dry-run은 아직 별도 증거가 필요합니다.

## 작업 내용

- post-launch operations gate에 최신 QA evidence summary를 추가해 Slack alert route와 mailbox routing 해소 상태를 고정했습니다.
- support incident response gate에 `aquilaxk.site` 공개 연락처 domain, 세 contact address, DNS evidence, GitHub redaction policy를 기록했습니다.
- release governance gate에 #1019의 현재 판정을 mailbox/alert resolved와 남은 blocker로 분리했습니다.
- repository contract test가 위 판정을 검증하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --check tools/ci/repository-contract.test.mjs`: exit 0
  - JSON parse for `post-launch-operations-review-gate.json`, `support-incident-response-gate.json`, `release-governance-gate.json`: exit 0
  - `node --test --test-name-pattern "모바일 signed release artifact gate" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `node --test --test-name-pattern "Android release 100 governance gate" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `git diff --check`: exit 0
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 119 tests passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 운영/지원 gate 계약 | local Node.js | repository contract test | `node --test tools/ci/repository-contract.test.mjs` output | 119 tests passed |
| JSON 계약 문법 | local Node.js | 세 release gate JSON parse | command output | exit 0 |
| Slack alert route dry-run 판정 | release contract | 기존 #1019 QA evidence summary를 tracked gate에 반영 | `apps/mobile/release/post-launch-operations-review-gate.json` | PASS로 고정 |
| mailbox routing 판정 | release contract | 기존 #1019 QA 수동 evidence summary를 tracked gate에 반영 | `apps/mobile/release/support-incident-response-gate.json` | resolved로 고정 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: #1019 전체를 완료 처리하려는 변경이 아니라, 이미 해소된 mailbox/alert 증거와 아직 남은 post-launch/Play evidence blocker를 gate에서 분리하는 변경입니다.

## 리스크

- public release 이후에만 얻을 수 있는 Play review, crash/ANR vitals, support ticket summary는 여전히 외부 증거가 필요합니다.
- mailbox와 alert의 raw evidence는 webhook URL, mailbox receipt, 개인 정보가 포함될 수 있어 tracked 파일이나 PR 본문에 원문을 올리지 않습니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
