### PR TITLE
[Test] Play 제출 개인정보 증거 판정 고정

### DIFF
--- a/apps/mobile/release/play-store-submission-content.json
+++ b/apps/mobile/release/play-store-submission-content.json
@@ -8,6 +8,33 @@
   "storePrivacyInventory": "apps/mobile/release/store-privacy-inventory.json",
   "storeSubmissionReadiness": "apps/mobile/release/store-submission-readiness.json",
   "status": "BLOCKED_EXTERNAL",
+  "latestQaEvidenceSummary": {
+    "qaEvidenceDateKst": "2026-06-28",
+    "privacyPolicyUrl": {
+      "result": "PASS_PUBLIC_HTTPS",
+      "url": "https://easysubway-api.aquilaxk.site/easysubway/privacy",
+      "requiredIn": ["Play Console", "app help", "README.md or public policy page"],
+      "remainingActionKo": "Play Console URL 입력 화면과 앱 도움말 화면의 같은 URL 캡처를 최종 제출 전에 다시 확인한다."
+    },
+    "publicContactMailboxes": {
+      "result": "RESOLVED_BY_QA_MANUAL_EVIDENCE",
+      "domain": "aquilaxk.site",
+      "addresses": ["support@aquilaxk.site", "security@aquilaxk.site", "privacy@aquilaxk.site"],
+      "redactionPolicy": "GitHub에는 mailbox 개인 정보, raw report receipt token, message body, operator private contact, provider credential or quota token, photo metadata를 올리지 않는다."
+    },
+    "remainingExternalBlockers": [
+      "play-console-data-safety-preview",
+      "play-console-main-listing-preview",
+      "play-pre-launch-report-or-android-vitals-export",
+      "play-upload-or-play-installed-required-screenshot-set"
+    ],
+    "remainingEvidenceBeforeFinalGo": [
+      "network-trace-match-summary",
+      "crash-anr-privacy-summary",
+      "store-screenshot-summary",
+      "privacy-url-same-url-summary"
+    ]
+  },
   "appContentDeclarations": {
     "ads": false,
     "appAccessRequiresSignIn": false,

--- a/apps/mobile/release/store-submission-readiness.json
+++ b/apps/mobile/release/store-submission-readiness.json
@@ -17,6 +17,18 @@
     "App Store Connect App Privacy",
     "App Store Connect Review Information"
   ],
+  "latestEvidenceStatus": {
+    "issue": 1018,
+    "privacyPolicyUrl": "PASS_PUBLIC_HTTPS",
+    "publicContactMailboxes": "RESOLVED_BY_QA_MANUAL_EVIDENCE",
+    "remainingGooglePlayBlockers": [
+      "play-console-data-safety-preview",
+      "play-console-main-listing-preview",
+      "play-pre-launch-report-or-android-vitals-export",
+      "play-upload-or-play-installed-required-screenshot-set"
+    ],
+    "notClosingReasonKo": "Play Console preview, pre-launch/Android vitals, Play-uploaded screenshot set 증거가 남아 있어 #1018은 open 유지한다."
+  },
   "items": [
     {
       "id": "play_data_safety",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7749,6 +7749,16 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
   assert.match(readiness.policyRefreshKo, /제출 직전|최신/);
   assert.doesNotMatch(JSON.stringify(readiness), /\b(TBD|TODO)\b|\.{3}/i);
   assert.ok(Array.isArray(readiness.items));
+  assert.equal(readiness.latestEvidenceStatus.issue, 1018);
+  assert.equal(readiness.latestEvidenceStatus.privacyPolicyUrl, "PASS_PUBLIC_HTTPS");
+  assert.equal(readiness.latestEvidenceStatus.publicContactMailboxes, "RESOLVED_BY_QA_MANUAL_EVIDENCE");
+  assert.deepEqual(readiness.latestEvidenceStatus.remainingGooglePlayBlockers, [
+    "play-console-data-safety-preview",
+    "play-console-main-listing-preview",
+    "play-pre-launch-report-or-android-vitals-export",
+    "play-upload-or-play-installed-required-screenshot-set",
+  ]);
+  assert.match(readiness.latestEvidenceStatus.notClosingReasonKo, /#1018은 open 유지/);
 
   const items = new Map(readiness.items.map((item) => [item.id, item]));
   const requiredIds = [
@@ -7782,6 +7792,44 @@ test("모바일 스토어 심사 정보 기준선은 제출 전 필수 항목을
 
   const stores = new Set(readiness.items.map((item) => item.store));
   assert.deepEqual([...stores].sort(), ["app-store", "cross-store", "google-play"]);
+
+  assert.equal(playStoreContent.latestQaEvidenceSummary.qaEvidenceDateKst, "2026-06-28");
+  assert.equal(playStoreContent.latestQaEvidenceSummary.privacyPolicyUrl.result, "PASS_PUBLIC_HTTPS");
+  assert.equal(
+    playStoreContent.latestQaEvidenceSummary.privacyPolicyUrl.url,
+    "https://easysubway-api.aquilaxk.site/easysubway/privacy",
+  );
+  assert.deepEqual(playStoreContent.latestQaEvidenceSummary.privacyPolicyUrl.requiredIn, [
+    "Play Console",
+    "app help",
+    "README.md or public policy page",
+  ]);
+  assert.equal(
+    playStoreContent.latestQaEvidenceSummary.publicContactMailboxes.result,
+    "RESOLVED_BY_QA_MANUAL_EVIDENCE",
+  );
+  assert.equal(playStoreContent.latestQaEvidenceSummary.publicContactMailboxes.domain, "aquilaxk.site");
+  assert.deepEqual(playStoreContent.latestQaEvidenceSummary.publicContactMailboxes.addresses, [
+    "support@aquilaxk.site",
+    "security@aquilaxk.site",
+    "privacy@aquilaxk.site",
+  ]);
+  assert.match(playStoreContent.latestQaEvidenceSummary.publicContactMailboxes.redactionPolicy, /raw report receipt token/);
+  assert.match(playStoreContent.latestQaEvidenceSummary.publicContactMailboxes.redactionPolicy, /operator private contact/);
+  assert.match(playStoreContent.latestQaEvidenceSummary.publicContactMailboxes.redactionPolicy, /provider credential or quota token/);
+  assert.match(playStoreContent.latestQaEvidenceSummary.publicContactMailboxes.redactionPolicy, /photo metadata/);
+  assert.deepEqual(playStoreContent.latestQaEvidenceSummary.remainingExternalBlockers, [
+    "play-console-data-safety-preview",
+    "play-console-main-listing-preview",
+    "play-pre-launch-report-or-android-vitals-export",
+    "play-upload-or-play-installed-required-screenshot-set",
+  ]);
+  assert.deepEqual(playStoreContent.latestQaEvidenceSummary.remainingEvidenceBeforeFinalGo, [
+    "network-trace-match-summary",
+    "crash-anr-privacy-summary",
+    "store-screenshot-summary",
+    "privacy-url-same-url-summary",
+  ]);
 
   for (const id of requiredIds) {
     const item = items.get(id);


### PR DESCRIPTION
## 관련 이슈

#1018 follow-up

이 PR은 #1018의 공개 privacy URL/contact mailbox 판정과 남은 Play Console blocker 분리를 고정하지만, Play Console preview/pre-launch/Android vitals/Play-uploaded screenshot 증거가 남아 있어 #1018을 닫지 않습니다.

## 작업 배경

#1018에는 Play Console Data Safety, listing preview, pre-launch/Android vitals, screenshot evidence가 아직 남아 있습니다. 반면 공개 privacy URL과 `aquilaxk.site` contact mailbox routing은 최신 QA evidence 흐름에서 별도 판정이 가능하므로, store submission gate에서 해소된 항목과 남은 blocker를 분리해야 합니다.

## 작업 내용

- `play-store-submission-content.json`에 최신 QA evidence summary를 추가해 privacy URL, public contact mailboxes, 남은 Play Console blocker를 분리했습니다.
- `store-submission-readiness.json`에 #1018을 open 유지해야 하는 이유와 남은 Google Play blocker 배열을 기록했습니다.
- repository contract test가 privacy URL, contact mailbox, redaction policy, remaining blocker 배열을 정확히 검증하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --check tools/ci/repository-contract.test.mjs`: exit 0
  - JSON parse for `play-store-submission-content.json`, `store-submission-readiness.json`: exit 0
  - `node --test --test-name-pattern "모바일 스토어 심사 정보 기준선" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `git diff --check`: exit 0
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 119 tests passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Play 제출/privacy gate 계약 | local Node.js | repository contract test | `node --test tools/ci/repository-contract.test.mjs` output | 119 tests passed |
| JSON 계약 문법 | local Node.js | 두 release gate JSON parse | command output | exit 0 |
| privacy URL 판정 | release contract | 공개 HTTPS URL을 gate summary에 고정 | `apps/mobile/release/play-store-submission-content.json` | PASS_PUBLIC_HTTPS |
| contact mailbox 판정 | release contract | QA 수동 evidence resolved 상태를 gate summary에 고정 | `apps/mobile/release/store-submission-readiness.json` | resolved로 고정 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: Play Console 자체 증거를 대체하지 않습니다. 해소된 공개 URL/contact 판정과 남은 Console/pre-launch/screenshot blocker를 분리하는 변경입니다.

## 리스크

- Play Console Data Safety/listing preview, pre-launch report 또는 Android vitals, Play-uploaded screenshot set은 외부 증거가 필요해 여전히 #1018 blocker입니다.
- mailbox receipt, Console screenshot, network trace 원문은 민감할 수 있어 tracked 파일이나 PR 본문에 올리지 않습니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
