### PR TITLE
[Test] abuse rehearsal 증거 판정 고정

### DIFF
--- a/apps/mobile/release/abuse-penetration-rehearsal-gate.json
+++ b/apps/mobile/release/abuse-penetration-rehearsal-gate.json
@@ -9,6 +9,53 @@
   "securityPrivacyEvidenceManifest": "apps/mobile/release/security-privacy-release-evidence.json",
   "releaseSecurityGate": "apps/mobile/release/release-security-gate.json",
   "evidenceRoot": ".codex/evidence/security/abuse-penetration-rehearsal/<rc-or-run>/",
+  "latestQaEvidenceStatus": {
+    "qaEvidenceDateKst": "2026-06-28",
+    "playAndStorePreflight": {
+      "androidPlayInternalTrack": "READY",
+      "datapackObjectStoragePublish": "READY",
+      "googlePlayApi": "READY_EDIT_TRACK_VALIDATE",
+      "uploadedInternalVersionCode": 10001,
+      "latestVersionCodeEnv": 10001
+    },
+    "resolvedEvidence": [
+      "android-play-internal-track-env-preflight",
+      "datapack-object-storage-publish-env-preflight",
+      "google-play-api-edit-track-validate",
+      "play-internal-upload-version-code-10001",
+      "store-distribution-evidence-success",
+      "production-datapack-release-publish-success",
+      "android-aab-release-artifact-secret-scan-output",
+      "release-aab-internal-endpoint-scan-output",
+      "backend-image-env-redaction-summary",
+      "backend-abuse-security-selected-tests",
+      "trusted-proxy-negative-test-output"
+    ],
+    "remainingExternalBlockers": [
+      "play-generated-apk-download-id-summary",
+      "play-installed-build-smoke",
+      "play-pre-launch-report-crash-anr-policy-summary",
+      "network-trace-redaction-summary-from-play-installed-build",
+      "deployed-public-https-backend-report-admin-base-url-evidence",
+      "deployed-admin-operator-auth-session-csrf-summary",
+      "deployed-signed-url-boundary-summary",
+      "object-storage-lifecycle-retention-delete-summary",
+      "deployed-distributed-or-multi-node-rate-limit-rehearsal"
+    ],
+    "notClosingReasonKo": "#1022는 Play credential/store preflight와 local/backend 자동 검증은 확보됐지만, Play-generated/Play-installed artifact 및 deployed production-like rehearsal evidence가 아직 없어 open 유지한다.",
+    "redactionPolicy": {
+      "secretValuesPrinted": false,
+      "forbiddenInGitHubEvidence": [
+        "raw receipt token",
+        "raw signed URL",
+        "photo binary",
+        "provider credential",
+        "operator password",
+        "session cookie",
+        "full object key"
+      ]
+    }
+  },
   "buildIdentityPolicy": {
     "requiredIssueLinks": ["#1015", "#1016", "#1020"],
     "acceptedArtifactSources": ["rc-aab", "play-generated-apk", "play-installed-build", "backend-release-image"],

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1299,6 +1299,45 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
   assert.equal(abusePenetrationRehearsalGate.androidRcEvidenceManifest, androidRcEvidencePath);
   assert.equal(abusePenetrationRehearsalGate.securityPrivacyEvidenceManifest, "apps/mobile/release/security-privacy-release-evidence.json");
   assert.match(abusePenetrationRehearsalGate.evidenceRoot, /\.codex\/evidence\/security\/abuse-penetration-rehearsal\/<rc-or-run>/);
+  assert.equal(abusePenetrationRehearsalGate.latestQaEvidenceStatus.qaEvidenceDateKst, "2026-06-28");
+  assert.equal(abusePenetrationRehearsalGate.latestQaEvidenceStatus.playAndStorePreflight.androidPlayInternalTrack, "READY");
+  assert.equal(
+    abusePenetrationRehearsalGate.latestQaEvidenceStatus.playAndStorePreflight.googlePlayApi,
+    "READY_EDIT_TRACK_VALIDATE",
+  );
+  assert.equal(abusePenetrationRehearsalGate.latestQaEvidenceStatus.playAndStorePreflight.uploadedInternalVersionCode, 10001);
+  assert.equal(abusePenetrationRehearsalGate.latestQaEvidenceStatus.playAndStorePreflight.latestVersionCodeEnv, 10001);
+  assert.deepEqual(abusePenetrationRehearsalGate.latestQaEvidenceStatus.resolvedEvidence, [
+    "android-play-internal-track-env-preflight",
+    "datapack-object-storage-publish-env-preflight",
+    "google-play-api-edit-track-validate",
+    "play-internal-upload-version-code-10001",
+    "store-distribution-evidence-success",
+    "production-datapack-release-publish-success",
+    "android-aab-release-artifact-secret-scan-output",
+    "release-aab-internal-endpoint-scan-output",
+    "backend-image-env-redaction-summary",
+    "backend-abuse-security-selected-tests",
+    "trusted-proxy-negative-test-output",
+  ]);
+  assert.deepEqual(abusePenetrationRehearsalGate.latestQaEvidenceStatus.remainingExternalBlockers, [
+    "play-generated-apk-download-id-summary",
+    "play-installed-build-smoke",
+    "play-pre-launch-report-crash-anr-policy-summary",
+    "network-trace-redaction-summary-from-play-installed-build",
+    "deployed-public-https-backend-report-admin-base-url-evidence",
+    "deployed-admin-operator-auth-session-csrf-summary",
+    "deployed-signed-url-boundary-summary",
+    "object-storage-lifecycle-retention-delete-summary",
+    "deployed-distributed-or-multi-node-rate-limit-rehearsal",
+  ]);
+  assert.match(abusePenetrationRehearsalGate.latestQaEvidenceStatus.notClosingReasonKo, /#1022/);
+  assert.equal(abusePenetrationRehearsalGate.latestQaEvidenceStatus.redactionPolicy.secretValuesPrinted, false);
+  assert.ok(
+    abusePenetrationRehearsalGate.latestQaEvidenceStatus.redactionPolicy.forbiddenInGitHubEvidence.includes(
+      "raw signed URL",
+    ),
+  );
   assert.deepEqual(abusePenetrationRehearsalGate.buildIdentityPolicy.requiredIssueLinks, ["#1015", "#1016", "#1020"]);
   assert.deepEqual(abusePenetrationRehearsalGate.buildIdentityPolicy.acceptedArtifactSources, [
     "rc-aab",


### PR DESCRIPTION
## 관련 이슈

#1022 참고. 이 PR은 abuse-case / penetration rehearsal 증거 상태를 보강하지만, Play-installed 및 deployed production-like rehearsal 증거가 남아 있어 이슈는 open 유지합니다.

## 작업 배경

#1022에는 Play credential/store preflight, production datapack publish, release artifact secret scan, backend abuse/security 자동 검증, trusted proxy negative test가 순차적으로 쌓였습니다. 하지만 gate JSON에는 무엇이 resolved이고 무엇이 아직 외부 blocker인지 한 곳에 정리되어 있지 않아 Go/No-Go 판단에서 누락될 수 있습니다.

## 작업 내용

- `abuse-penetration-rehearsal-gate.json`에 최신 QA evidence 상태를 추가했습니다.
- Play internal track, datapack object storage publish, Google Play API, uploaded internal versionCode, latest versionCode env 상태를 기록했습니다.
- 해결된 evidence와 남은 external blocker를 분리했습니다.
- raw receipt token, signed URL, photo binary, provider credential, operator password, session cookie, full object key를 GitHub evidence에 올리지 않는 redaction policy를 명시했습니다.
- repository contract test가 #1022 최신 상태와 남은 blocker 목록을 검증하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --check tools/ci/repository-contract.test.mjs`: exit 0
  - JSON parse `apps/mobile/release/abuse-penetration-rehearsal-gate.json`: exit 0
  - `git diff --check`: exit 0
  - `node --test --test-name-pattern "abuse|penetration|rehearsal|security privacy" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 119 tests passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| #1022 abuse rehearsal status | repository | JSON parse와 repository contract test | local command output | PASS |
| resolved evidence와 남은 blocker 분리 | repository | targeted contract test | local command output | PASS |
| 민감 증거 redaction policy | repository | repository contract assertion | local command output | PASS |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/release/abuse-penetration-rehearsal-gate.json`의 `latestQaEvidenceStatus`
- 이 PR은 #1022를 닫지 않습니다. Play-generated/Play-installed artifact와 deployed production-like rehearsal 증거가 아직 필요합니다.

## 리스크

- 앱/백엔드 실행 경로는 변경하지 않고 release evidence JSON과 contract test만 변경합니다.
- 남은 blocker가 release gate에서 누락되지 않도록 `remainingExternalBlockers`에 계속 유지했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
