### PR TITLE
[Test] Android quality blocker 상태 고정

### DIFF
--- a/apps/mobile/release/android-release-quality-gate.json
+++ b/apps/mobile/release/android-release-quality-gate.json
@@ -275,6 +275,58 @@
       "requiredSummaryFields": ["checkId", "buildIdentity", "buildSource", "deviceId", "evidencePaths", "logcatSummaryPath", "playConsoleSummaryPath", "result", "blockerDisposition"]
     }
   ],
+  "latestQaEvidenceStatus": {
+    "qaEvidenceDateKst": "2026-06-29",
+    "localEvidenceStatus": {
+      "local16KbEmulatorSmoke": "PASS",
+      "fontScale150HomeSmoke": "PASS",
+      "fontScale200HomeSmoke": "PASS",
+      "routeMapInitialViewportSmoke": "PASS",
+      "talkBackRouteMapUiTree": "PASS_UI_TREE_ONLY",
+      "locationPermissionDeniedRecovery": "PASS",
+      "myReportsBackendFailureRecovery": "PASS",
+      "realDeviceHomeSmoke": "PASS",
+      "playInstalledBuildProvenance": "BLOCKED_EXTERNAL",
+      "playConsolePreLaunchAndVitals": "BLOCKED_EXTERNAL"
+    },
+    "resolvedEvidence": [
+      "android-quality-gate-contract",
+      "emulator-discovery-command-policy",
+      "local-16kb-runtime-home-station-search-smoke",
+      "font-scale-150-home-smoke",
+      "font-scale-200-home-smoke",
+      "route-map-initial-bounds-visual-smoke",
+      "talkback-route-map-ui-tree-accessibility-service",
+      "location-permission-denied-recovery",
+      "my-reports-backend-failure-recovery",
+      "real-device-home-smoke",
+      "release-logcat-privacy-marker-scan"
+    ],
+    "remainingExternalBlockers": [
+      "play-installed-build-provenance",
+      "play-generated-apk-download-id-summary",
+      "talkback-manual-reading-order-notes",
+      "play-pre-launch-crash-anr-policy-summary",
+      "android-vitals-crash-anr-summary",
+      "play-installed-network-logcat-privacy-summary",
+      "play-installed-route-map-performance-budget",
+      "play-installed-font-scale-150-200-compact-screen-screenshots",
+      "upload-failure-recovery-on-rc-or-play-installed-build"
+    ],
+    "notClosingReasonKo": "#1021은 local emulator/real-device smoke 일부가 PASS여도 Play-installed provenance, 실제 TalkBack reading order, Play Console pre-launch/vitals, Play-installed 성능/복구 증거가 남아 open 유지한다.",
+    "redactionPolicy": {
+      "secretValuesPrinted": false,
+      "forbiddenInGitHubEvidence": [
+        "raw location coordinates",
+        "facility report photo",
+        "receipt token",
+        "network trace with device identifiers",
+        "Play-installed APK or AAB binary",
+        "signing credential",
+        "session cookie"
+      ]
+    }
+  },
   "evidencePolicy": {
     "localOnlyEvidenceRoot": ".codex/evidence/release/android-quality/<rc-or-run>/",
     "githubEvidencePolicy": "summary-or-public-link",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7637,6 +7637,42 @@ test("Android 출시 UX 접근성 성능 gate는 local emulator evidence와 P0 b
   ]);
   assert.equal(gate.deviceEvidencePolicy.emptyAdbDevicesDisposition, "INSUFFICIENT_EVIDENCE");
   assert.equal(gate.evidencePolicy.localOnlyEvidenceRoot, ".codex/evidence/release/android-quality/<rc-or-run>/");
+  assert.equal(gate.latestQaEvidenceStatus.qaEvidenceDateKst, "2026-06-29");
+  assert.equal(gate.latestQaEvidenceStatus.localEvidenceStatus.local16KbEmulatorSmoke, "PASS");
+  assert.equal(gate.latestQaEvidenceStatus.localEvidenceStatus.talkBackRouteMapUiTree, "PASS_UI_TREE_ONLY");
+  assert.equal(gate.latestQaEvidenceStatus.localEvidenceStatus.playInstalledBuildProvenance, "BLOCKED_EXTERNAL");
+  assert.equal(gate.latestQaEvidenceStatus.localEvidenceStatus.playConsolePreLaunchAndVitals, "BLOCKED_EXTERNAL");
+  assert.deepEqual(gate.latestQaEvidenceStatus.resolvedEvidence, [
+    "android-quality-gate-contract",
+    "emulator-discovery-command-policy",
+    "local-16kb-runtime-home-station-search-smoke",
+    "font-scale-150-home-smoke",
+    "font-scale-200-home-smoke",
+    "route-map-initial-bounds-visual-smoke",
+    "talkback-route-map-ui-tree-accessibility-service",
+    "location-permission-denied-recovery",
+    "my-reports-backend-failure-recovery",
+    "real-device-home-smoke",
+    "release-logcat-privacy-marker-scan",
+  ]);
+  assert.deepEqual(gate.latestQaEvidenceStatus.remainingExternalBlockers, [
+    "play-installed-build-provenance",
+    "play-generated-apk-download-id-summary",
+    "talkback-manual-reading-order-notes",
+    "play-pre-launch-crash-anr-policy-summary",
+    "android-vitals-crash-anr-summary",
+    "play-installed-network-logcat-privacy-summary",
+    "play-installed-route-map-performance-budget",
+    "play-installed-font-scale-150-200-compact-screen-screenshots",
+    "upload-failure-recovery-on-rc-or-play-installed-build",
+  ]);
+  assert.match(gate.latestQaEvidenceStatus.notClosingReasonKo, /#1021/);
+  assert.equal(gate.latestQaEvidenceStatus.redactionPolicy.secretValuesPrinted, false);
+  assert.ok(
+    gate.latestQaEvidenceStatus.redactionPolicy.forbiddenInGitHubEvidence.includes(
+      "network trace with device identifiers",
+    ),
+  );
   assert.match(
     gate.deviceEvidencePolicy.requiredDeviceDiscoveryCommands.join("\n"),
     /ANDROID_HOME|ANDROID_SDK_ROOT/,


### PR DESCRIPTION
## 관련 이슈

AquilaXk/easysubway-mobile#9 참고. 이 PR은 Android 출시 UX·접근성·성능 gate의 최신 증거 상태를 보강하지만, Play-installed 및 Play Console 증거가 남아 있어 이슈는 open 유지합니다.

## 작업 배경

#1021에는 16KB emulator, 큰 글자, route map, TalkBack UI tree, 위치 권한 거부, backend failure recovery, 실기기 홈 smoke 증거가 순차적으로 쌓였습니다. 하지만 gate JSON에는 어떤 항목이 local evidence로 해소됐고 어떤 항목이 외부 증거 blocker인지 한 곳에 정리되어 있지 않아 Go/No-Go 판단에서 누락될 수 있습니다.

## 작업 내용

- `android-release-quality-gate.json`에 최신 QA evidence 상태를 추가했습니다.
- local 16KB emulator, font scale, route map, TalkBack UI tree, 위치 권한 거부, backend failure recovery, 실기기 홈 smoke 결과를 resolved evidence로 분리했습니다.
- Play-installed provenance, Play-generated APK id, 실제 TalkBack reading order, Play Console pre-launch/vitals, Play-installed performance/recovery 증거를 remaining external blocker로 유지했습니다.
- 위치 좌표, 신고 사진, receipt token, device identifier 포함 network trace, Play-installed binary, signing credential, session cookie를 GitHub evidence에 올리지 않는 redaction policy를 명시했습니다.
- repository contract test가 AquilaXk/easysubway-mobile#9 최신 상태와 남은 blocker 목록을 검증하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --check tools/ci/repository-contract.test.mjs`: exit 0
  - JSON parse `apps/mobile/release/android-release-quality-gate.json`: exit 0
  - `git diff --check`: exit 0
  - `node --test --test-name-pattern "Android 출시 UX 접근성 성능 gate" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 119 tests passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| AquilaXk/easysubway-mobile#9 Android quality status | repository | JSON parse와 repository contract test | local command output | PASS |
| resolved evidence와 남은 blocker 분리 | repository | targeted contract test | local command output | PASS |
| 민감 증거 redaction policy | repository | repository contract assertion | local command output | PASS |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/release/android-release-quality-gate.json`의 `latestQaEvidenceStatus`
- 이 PR은 #1021을 닫지 않습니다. Play-installed provenance, 실제 TalkBack reading order, Play Console pre-launch/vitals, Play-installed 성능/복구 증거가 아직 필요합니다.

## 리스크

- 앱 실행 경로는 변경하지 않고 release evidence JSON과 contract test만 변경합니다.
- 남은 blocker가 release gate에서 누락되지 않도록 `remainingExternalBlockers`에 계속 유지했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
