### PR TITLE
[Chore] Go-No-Go blocker 상태 고정

### DIFF
--- a/apps/mobile/release/release-governance-gate.json
+++ b/apps/mobile/release/release-governance-gate.json
@@ -87,6 +87,39 @@
       "support-incident-response-dry-run-evidence"
     ]
   },
+  "latestGoNoGoStatus": {
+    "qaEvidenceDateKst": "2026-06-29",
+    "reviewedMainMergeSha": "1fbf3314e2867d41676f749baa75ea31679d35af",
+    "currentDecision": "NO_GO",
+    "decisionOwner": "release-owner",
+    "blockingOpenIssues": [571, 1016, 1018, 1019, 1021, 1022],
+    "recentlyResolvedEvidence": [
+      "production-datapack-release-publish-success",
+      "store-distribution-evidence-success",
+      "play-internal-upload-version-code-10001",
+      "android-quality-local-emulator-real-device-smoke-summary",
+      "abuse-rehearsal-local-and-store-preflight-summary",
+      "operations-alert-and-mailbox-routing-summary"
+    ],
+    "remainingP0Blockers": [
+      "play-installed-build-provenance",
+      "play-pre-launch-crash-anr-policy-summary",
+      "play-console-data-safety-listing-screenshot-final-preview",
+      "android-vitals-crash-anr-summary",
+      "support-incident-response-dry-run-evidence",
+      "post-launch-review-window-evidence-after-public-release",
+      "play-installed-android-quality-performance-recovery-evidence",
+      "production-like-abuse-rehearsal-evidence",
+      "server-minimized-final-acceptance-evidence",
+      "release-owner-final-go-approval"
+    ],
+    "externalEffectGate": {
+      "googlePlayProductionSubmitAllowed": false,
+      "publicReleaseAllowed": false,
+      "reasonKo": "open Android P0 blocker가 남아 있고 Play-installed, Play Console, Android vitals, production-like rehearsal 증거가 아직 동결되지 않았다."
+    },
+    "notClosingReasonKo": "#1020은 latest evidence status를 동결했지만, open release blocker와 final GO approval이 남아 있어 NO-GO 상태로 open 유지한다."
+  },
   "releaseControl": {
     "raciRequired": true,
     "freezeRequired": true,

--- a/apps/mobile/release/release-governance-gate.json
+++ b/apps/mobile/release/release-governance-gate.json
@@ -110,7 +110,9 @@
       "post-launch-review-window-evidence-after-public-release",
       "play-installed-android-quality-performance-recovery-evidence",
       "production-like-abuse-rehearsal-evidence",
-      "server-minimized-final-acceptance-evidence",
+      "server-minimized-final-acceptance-evidence"
+    ],
+    "remainingApprovalPrerequisites": [
       "release-owner-final-go-approval"
     ],
     "externalEffectGate": {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2031,11 +2031,14 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
   assert.equal(gate.latestGoNoGoStatus.currentDecision, "NO_GO");
   assert.equal(gate.latestGoNoGoStatus.decisionOwner, "release-owner");
   assert.deepEqual(gate.latestGoNoGoStatus.blockingOpenIssues, [571, 1016, 1018, 1019, 1021, 1022]);
-  assert.ok(
-    gate.latestGoNoGoStatus.recentlyResolvedEvidence.includes(
-      "android-quality-local-emulator-real-device-smoke-summary",
-    ),
-  );
+  assert.deepEqual(gate.latestGoNoGoStatus.recentlyResolvedEvidence, [
+    "production-datapack-release-publish-success",
+    "store-distribution-evidence-success",
+    "play-internal-upload-version-code-10001",
+    "android-quality-local-emulator-real-device-smoke-summary",
+    "abuse-rehearsal-local-and-store-preflight-summary",
+    "operations-alert-and-mailbox-routing-summary",
+  ]);
   assert.deepEqual(gate.latestGoNoGoStatus.remainingP0Blockers, [
     "play-installed-build-provenance",
     "play-pre-launch-crash-anr-policy-summary",
@@ -2046,12 +2049,20 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "play-installed-android-quality-performance-recovery-evidence",
     "production-like-abuse-rehearsal-evidence",
     "server-minimized-final-acceptance-evidence",
+  ]);
+  assert.deepEqual(gate.latestGoNoGoStatus.remainingApprovalPrerequisites, [
     "release-owner-final-go-approval",
   ]);
   assert.equal(gate.latestGoNoGoStatus.externalEffectGate.googlePlayProductionSubmitAllowed, false);
   assert.equal(gate.latestGoNoGoStatus.externalEffectGate.publicReleaseAllowed, false);
-  assert.match(gate.latestGoNoGoStatus.externalEffectGate.reasonKo, /open Android P0 blocker/);
-  assert.match(gate.latestGoNoGoStatus.notClosingReasonKo, /#1020/);
+  assert.equal(
+    gate.latestGoNoGoStatus.externalEffectGate.reasonKo,
+    "open Android P0 blocker가 남아 있고 Play-installed, Play Console, Android vitals, production-like rehearsal 증거가 아직 동결되지 않았다.",
+  );
+  assert.equal(
+    gate.latestGoNoGoStatus.notClosingReasonKo,
+    "#1020은 latest evidence status를 동결했지만, open release blocker와 final GO approval이 남아 있어 NO-GO 상태로 open 유지한다.",
+  );
   assert.ok(gate.gates.some((item) => item.issue === 1021 && item.id === "G7_ANDROID_QUALITY"));
   assert.ok(gate.gates.some((item) => item.issue === 1018 && item.id === "G9_GOOGLE_PLAY"));
   assert.deepEqual(

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2026,6 +2026,32 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "post-launch-review-window-evidence-after-public-release",
     "support-incident-response-dry-run-evidence",
   ]);
+  assert.equal(gate.latestGoNoGoStatus.qaEvidenceDateKst, "2026-06-29");
+  assert.equal(gate.latestGoNoGoStatus.reviewedMainMergeSha, "1fbf3314e2867d41676f749baa75ea31679d35af");
+  assert.equal(gate.latestGoNoGoStatus.currentDecision, "NO_GO");
+  assert.equal(gate.latestGoNoGoStatus.decisionOwner, "release-owner");
+  assert.deepEqual(gate.latestGoNoGoStatus.blockingOpenIssues, [571, 1016, 1018, 1019, 1021, 1022]);
+  assert.ok(
+    gate.latestGoNoGoStatus.recentlyResolvedEvidence.includes(
+      "android-quality-local-emulator-real-device-smoke-summary",
+    ),
+  );
+  assert.deepEqual(gate.latestGoNoGoStatus.remainingP0Blockers, [
+    "play-installed-build-provenance",
+    "play-pre-launch-crash-anr-policy-summary",
+    "play-console-data-safety-listing-screenshot-final-preview",
+    "android-vitals-crash-anr-summary",
+    "support-incident-response-dry-run-evidence",
+    "post-launch-review-window-evidence-after-public-release",
+    "play-installed-android-quality-performance-recovery-evidence",
+    "production-like-abuse-rehearsal-evidence",
+    "server-minimized-final-acceptance-evidence",
+    "release-owner-final-go-approval",
+  ]);
+  assert.equal(gate.latestGoNoGoStatus.externalEffectGate.googlePlayProductionSubmitAllowed, false);
+  assert.equal(gate.latestGoNoGoStatus.externalEffectGate.publicReleaseAllowed, false);
+  assert.match(gate.latestGoNoGoStatus.externalEffectGate.reasonKo, /open Android P0 blocker/);
+  assert.match(gate.latestGoNoGoStatus.notClosingReasonKo, /#1020/);
   assert.ok(gate.gates.some((item) => item.issue === 1021 && item.id === "G7_ANDROID_QUALITY"));
   assert.ok(gate.gates.some((item) => item.issue === 1018 && item.id === "G9_GOOGLE_PLAY"));
   assert.deepEqual(


### PR DESCRIPTION
## 관련 이슈

AquilaXk/easysubway#1020 참고. 이 PR은 Android 출시 Go/No-Go 최신 판정을 보강하지만, open release blocker와 final GO approval이 남아 있어 이슈는 open 유지합니다.

## 작업 배경

#1020에는 여러 차례 NO-GO 재판정과 RC evidence manifest 보강이 쌓였습니다. 최근 AquilaXk/easysubway-mobile#9 Android quality 상태와 AquilaXk/easysubway#1022 abuse rehearsal 상태가 추가로 정리됐지만, release-governance gate에는 현재 main merge SHA 기준 최종 판단과 남은 P0 blocker가 한 곳에 고정되어 있지 않았습니다.

## 작업 내용

- `release-governance-gate.json`에 최신 Go/No-Go 상태를 추가했습니다.
- 현재 main merge SHA, 판정일, release owner, `NO_GO` 결론을 기록했습니다.
- 현재 open release blocker issue와 남은 P0 blocker를 분리했습니다.
- Play production submit과 public release는 아직 허용하지 않는 external-effect gate를 명시했습니다.
- repository contract test가 AquilaXk/easysubway#1020 최신 NO-GO 상태와 남은 blocker 목록을 검증하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --check tools/ci/repository-contract.test.mjs`: exit 0
  - JSON parse `apps/mobile/release/release-governance-gate.json`: exit 0
  - `git diff --check`: exit 0
  - `node --test --test-name-pattern "Android release 100 governance gate" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 119 tests passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| AquilaXk/easysubway#1020 Go/No-Go status | repository | JSON parse와 repository contract test | local command output | PASS |
| 남은 P0 blocker 목록 | repository | targeted contract test | local command output | PASS |
| external-effect submit gate | repository | repository contract assertion | local command output | PASS |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/release/release-governance-gate.json`의 `latestGoNoGoStatus`
- 이 PR은 #1020을 닫지 않습니다. Play-installed, Play Console, Android vitals, production-like rehearsal, support dry-run, final release owner approval이 아직 필요합니다.

## 리스크

- 앱/백엔드 실행 경로는 변경하지 않고 release governance JSON과 contract test만 변경합니다.
- 현재 판정은 `NO_GO`로 고정해 public release와 Play production submit을 허용하지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI code review fallback은 사용하지 않았다.
- [x] Release Artifacts와 RC Evidence Manifest 상태를 확인했다.
