### PR TITLE
[Test] 서버 최소화 Android 범위 고정

### DIFF
--- a/apps/mobile/release/release-governance-gate.json
+++ b/apps/mobile/release/release-governance-gate.json
@@ -98,6 +98,7 @@
       "store-distribution-evidence-success",
       "play-internal-upload-version-code-10001",
       "android-publisher-api-access-ready",
+      "server-minimized-android-release-scope-fixed",
       "android-quality-local-emulator-real-device-smoke-summary",
       "abuse-rehearsal-local-and-store-preflight-summary",
       "operations-alert-and-mailbox-routing-summary"

--- a/apps/mobile/release/server-minimized-qa-gate.json
+++ b/apps/mobile/release/server-minimized-qa-gate.json
@@ -4,10 +4,16 @@
   "releaseGate": "server-minimized-device-qa",
   "localOnlyEvidence": true,
   "evidenceRoot": ".codex/evidence/server-minimization/pr10",
+  "releaseBlockerScope": {
+    "androidGooglePlayV1Required": true,
+    "iosDeferredOutOfScope": true,
+    "iosEvidenceRetainedForHistory": true,
+    "completionRuleKo": "Android Google Play v1 release evidence만 #571 release blocker로 본다. 기존 iOS 증거는 참고로 유지하지만 Android 완료를 차단하지 않는다."
+  },
   "platformCompletionRule": {
     "androidRequired": true,
-    "iosRequired": true,
-    "singlePlatformEvidenceIsInsufficient": true
+    "iosRequired": false,
+    "singlePlatformEvidenceIsInsufficient": false
   },
   "checks": [
     {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2060,6 +2060,7 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "store-distribution-evidence-success",
     "play-internal-upload-version-code-10001",
     "android-publisher-api-access-ready",
+    "server-minimized-android-release-scope-fixed",
     "android-quality-local-emulator-real-device-smoke-summary",
     "abuse-rehearsal-local-and-store-preflight-summary",
     "operations-alert-and-mailbox-routing-summary",
@@ -2847,14 +2848,18 @@ test("서버 최소화 PR10 QA gate는 최종 인수 증거를 로컬 전용 정
   assert.equal(gate.releaseGate, "server-minimized-device-qa");
   assert.equal(gate.localOnlyEvidence, true);
   assert.match(gate.evidenceRoot, /^\.codex\/evidence\/server-minimization\/pr10$/);
+  assert.equal(gate.releaseBlockerScope.androidGooglePlayV1Required, true);
+  assert.equal(gate.releaseBlockerScope.iosDeferredOutOfScope, true);
+  assert.equal(gate.releaseBlockerScope.iosEvidenceRetainedForHistory, true);
+  assert.match(gate.releaseBlockerScope.completionRuleKo, /Android Google Play v1 release evidence만/);
   assert.doesNotMatch(
     JSON.stringify(gate),
     /com\.easysubway\.mobile/,
     "server minimized QA gate must not reference the retired Android package",
   );
   assert.equal(gate.platformCompletionRule.androidRequired, true);
-  assert.equal(gate.platformCompletionRule.iosRequired, true);
-  assert.equal(gate.platformCompletionRule.singlePlatformEvidenceIsInsufficient, true);
+  assert.equal(gate.platformCompletionRule.iosRequired, false);
+  assert.equal(gate.platformCompletionRule.singlePlatformEvidenceIsInsufficient, false);
   assert.doesNotMatch(JSON.stringify(gate), /\b(TBD|TODO)\b|\.{3}/i);
 
   const requiredFinalAcceptanceIds = [


### PR DESCRIPTION
## 관련 이슈

AquilaXk/easysubway-mobile#7 참고. 이 PR은 서버 최소화 최종 인수 QA gate의 release blocker 범위를 Android Google Play v1로 정렬하지만, Play-installed 증거가 남아 있어 이슈는 open 유지합니다.

## 작업 배경

AquilaXk/easysubway-mobile#7 본문은 Android Google Play v1만 release blocker이고 iOS는 `DEFERRED_OUT_OF_SCOPE`라고 정리되어 있습니다. 하지만 `server-minimized-qa-gate.json`은 아직 iOS를 필수 완료 조건으로 두고 있어, Android release blocker 판정과 gate 계약이 충돌했습니다.

## 작업 내용

- `server-minimized-qa-gate.json`에 `releaseBlockerScope`를 추가했습니다.
- Android Google Play v1 evidence만 AquilaXk/easysubway-mobile#7 release blocker로 보도록 `iosRequired=false`로 정리했습니다.
- 기존 iOS evidence 항목은 역사적 참고로 유지하되 Android 완료를 차단하지 않도록 했습니다.
- release governance의 resolved evidence에 `server-minimized-android-release-scope-fixed`를 추가했습니다.
- repository contract가 Android-only scope와 Go/No-Go resolved evidence를 검증하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --check tools/ci/repository-contract.test.mjs`: exit 0
  - JSON parse `apps/mobile/release/server-minimized-qa-gate.json`, `apps/mobile/release/release-governance-gate.json`: exit 0
  - `git diff --check`: exit 0
  - `node --test --test-name-pattern "서버 최소화 PR10 QA gate" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `node --test --test-name-pattern "Android release 100 governance gate" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 119 tests passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| AquilaXk/easysubway-mobile#7 release blocker scope | repository | server-minimized QA gate contract test | local command output | PASS |
| Go/No-Go resolved evidence | repository | release governance contract test | local command output | PASS |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/release/server-minimized-qa-gate.json`의 `releaseBlockerScope`
- iOS check 목록은 삭제하지 않았습니다. 기존 증거와 future iOS release 참고용으로 유지합니다.
- #571은 Play-installed build provenance와 Android final acceptance evidence가 아직 남아 open 유지합니다.

## 리스크

- 앱/백엔드 실행 경로는 변경하지 않고 release gate JSON과 contract test만 변경합니다.
- iOS를 Android release blocker에서 제외하는 계약 정리이므로, iOS 출시 시에는 별도 gate에서 다시 요구사항을 활성화해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit은 rate limit으로 실제 review가 시작되지 않았음을 확인했다.
- [x] Codex CLI fallback review 결과를 확인했다.
- [x] Release Artifacts와 RC Evidence Manifest 상태를 확인했다.
