### PR TITLE
[Chore] Go-No-Go 검토 기준 SHA 갱신

### DIFF
--- a/apps/mobile/release/release-governance-gate.json
+++ b/apps/mobile/release/release-governance-gate.json
@@ -89,7 +89,7 @@
   },
   "latestGoNoGoStatus": {
     "qaEvidenceDateKst": "2026-06-29",
-    "reviewedMainMergeSha": "1fbf3314e2867d41676f749baa75ea31679d35af",
+    "reviewedMainMergeSha": "a1a6da80b3433c26ae2f5a45b02de86c8f37ce82",
     "currentDecision": "NO_GO",
     "decisionOwner": "release-owner",
     "blockingOpenIssues": [571, 1016, 1018, 1019, 1021, 1022],
@@ -112,7 +112,7 @@
       "post-launch-review-window-evidence-after-public-release",
       "play-installed-android-quality-performance-recovery-evidence",
       "production-like-abuse-rehearsal-evidence",
-      "server-minimized-final-acceptance-evidence"
+      "play-installed-server-minimized-final-acceptance-evidence"
     ],
     "remainingApprovalPrerequisites": [
       "release-owner-final-go-approval"

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2051,7 +2051,7 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "support-incident-response-dry-run-evidence",
   ]);
   assert.equal(gate.latestGoNoGoStatus.qaEvidenceDateKst, "2026-06-29");
-  assert.equal(gate.latestGoNoGoStatus.reviewedMainMergeSha, "1fbf3314e2867d41676f749baa75ea31679d35af");
+  assert.equal(gate.latestGoNoGoStatus.reviewedMainMergeSha, "a1a6da80b3433c26ae2f5a45b02de86c8f37ce82");
   assert.equal(gate.latestGoNoGoStatus.currentDecision, "NO_GO");
   assert.equal(gate.latestGoNoGoStatus.decisionOwner, "release-owner");
   assert.deepEqual(gate.latestGoNoGoStatus.blockingOpenIssues, [571, 1016, 1018, 1019, 1021, 1022]);
@@ -2074,7 +2074,7 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "post-launch-review-window-evidence-after-public-release",
     "play-installed-android-quality-performance-recovery-evidence",
     "production-like-abuse-rehearsal-evidence",
-    "server-minimized-final-acceptance-evidence",
+    "play-installed-server-minimized-final-acceptance-evidence",
   ]);
   assert.deepEqual(gate.latestGoNoGoStatus.remainingApprovalPrerequisites, [
     "release-owner-final-go-approval",


### PR DESCRIPTION
## 관련 이슈

AquilaXk/easysubway#1020 참고. 이 PR은 Go/No-Go gate의 검토 기준 SHA를 AquilaXk/easysubway-mobile#7 범위 정리 merge 이후로 갱신하지만, 남은 Play-installed/Console/운영 rehearsal 증거가 있어 이슈는 open 유지합니다.

## 작업 배경

PR #1071에서 #571의 서버 최소화 release blocker 범위를 Android Google Play v1로 정렬했습니다. 하지만 `release-governance-gate.json`의 `latestGoNoGoStatus.reviewedMainMergeSha`는 이전 Android quality 증거 merge SHA를 계속 가리켜, 최신 NO-GO 판정이 어떤 main 상태를 기준으로 한 것인지 추적성이 약했습니다.

## 작업 내용

- Go/No-Go latest status의 `reviewedMainMergeSha`를 PR AquilaXk/easysubway#1071 merge commit으로 갱신했습니다.
- #571의 남은 blocker 표현을 Play-installed final acceptance evidence로 좁혀, iOS deferred 범위와 충돌하지 않게 했습니다.
- repository contract test가 같은 SHA와 blocker 명칭을 검증하도록 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --check tools/ci/repository-contract.test.mjs`: exit 0
  - JSON parse `apps/mobile/release/release-governance-gate.json`: exit 0
  - `git diff --check`: exit 0
  - `node --test --test-name-pattern "Android release 100 governance gate" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 119 tests passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Go/No-Go latest status | repository | repository contract test | local command output | PASS |
| JSON syntax | repository | JSON parse | local command output | PASS |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/release/release-governance-gate.json`의 `latestGoNoGoStatus`
- 이번 PR은 release 판정을 `GO`로 바꾸지 않습니다.

## 리스크

- 앱/백엔드 실행 경로는 변경하지 않고 release gate JSON과 contract test만 변경합니다.
- 남은 Play-installed, Play Console, Android vitals, production-like rehearsal 증거는 계속 release blocker입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit은 rate limit으로 실제 review가 시작되지 않았음을 확인했다.
- [x] Codex CLI fallback review 결과를 확인했다.
- [x] Release Artifacts 상태를 확인했다.
