### PR TITLE
[Fix] 데이터팩 좌표 audit claim 범위 보정

### DIFF
--- a/tools/route-map/audit-route-map.mjs
+++ b/tools/route-map/audit-route-map.mjs
@@ -574,6 +574,7 @@ function auditPack(pack, reviewedAmbiguities, options = {}) {
   const positions = Array.isArray(pack.routeMapPositions)
     ? pack.routeMapPositions
     : [];
+  const requiresRouteMapPositions = packRequiresRouteMapPositions(pack, positions);
   const stationLineKeys = new Set(stationLines.map(stationLineKeyFor));
   const stationLineCoverageKeys = new Set(
     stationLines.map((stationLine) =>
@@ -777,24 +778,26 @@ function auditPack(pack, reviewedAmbiguities, options = {}) {
     });
   }
 
-  for (const membership of stationLines) {
-    if (
-      positionedStationLineCoverageKeys.has(
-        coverageKeyForStationLine(membership, stationsById),
-      )
-    ) {
-      continue;
+  if (requiresRouteMapPositions) {
+    for (const membership of stationLines) {
+      if (
+        positionedStationLineCoverageKeys.has(
+          coverageKeyForStationLine(membership, stationsById),
+        )
+      ) {
+        continue;
+      }
+      addFinding(findings, {
+        severity: "BLOCKER",
+        code: "MISSING_ROUTE_MAP_POSITION",
+        packId: pack.id,
+        region: "",
+        lineId: membership.lineId,
+        stationId: membership.stationId,
+        message:
+          "stationLines membership has no matching routeMapPositions coordinate.",
+      });
     }
-    addFinding(findings, {
-      severity: "BLOCKER",
-      code: "MISSING_ROUTE_MAP_POSITION",
-      packId: pack.id,
-      region: "",
-      lineId: membership.lineId,
-      stationId: membership.stationId,
-      message:
-        "stationLines membership has no matching routeMapPositions coordinate.",
-    });
   }
 
   const missingLabelPolygonByRegion = new Map();
@@ -918,6 +921,18 @@ function auditPack(pack, reviewedAmbiguities, options = {}) {
       );
     }),
   };
+}
+
+function packRequiresRouteMapPositions(pack, positions) {
+  if (positions.length > 0) {
+    return true;
+  }
+  return (pack.sourceInventory ?? []).some((source) => {
+    if ((source.fields ?? []).includes("route_map_positions")) {
+      return true;
+    }
+    return (source.coverageScope?.sourceDomains ?? []).includes("route_map_positions");
+  });
 }
 
 function auditFixture(fixturePath, fixture, reviewedAmbiguities, options = {}) {

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -734,6 +734,42 @@ test("route map position audit passes clean catalog fixture", async () => {
   ]);
 });
 
+test("route map position audit does not require coordinates for packs without route map claim", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "easysubway-route-map-no-claim-"));
+  try {
+    const fixture = JSON.parse(
+      await readFile("tools/datapack/fixtures/catalog-fixture.json", "utf8"),
+    );
+    const pack = fixture.packs[0];
+    pack.routeMapPositions = [];
+    pack.sourceInventory = pack.sourceInventory.map((source) => ({
+      ...source,
+      fields: (source.fields ?? []).filter((field) => field !== "route_map_positions"),
+    }));
+    const fixturePath = path.join(tmp, "fixture.json");
+    await writeFile(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`, "utf8");
+
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "tools/route-map/audit-route-map.mjs",
+        "--fixture",
+        fixturePath,
+        "--fail-on",
+        "BLOCKER,HIGH",
+      ],
+      { cwd: root, maxBuffer: 1024 * 1024 },
+    );
+    const output = JSON.parse(stdout);
+
+    assert.equal(output.summary.findingsBySeverity.BLOCKER, 0);
+    assert.equal(output.packs[0].summary.routeMapPositionCount, 0);
+    assert.equal(output.packs[0].summary.coverageRatio, 0);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("route map position audit can require label polygons", async () => {
   await assert.rejects(
     () =>


### PR DESCRIPTION
## 관련 이슈

refs #1074

## 작업 배경

- #1076 merge 후 main의 `Data Pack Release`가 `Audit route map coordinate coverage` 단계에서 실패했습니다.
- production source fixture는 v1 claim에서 route-map 좌표 source를 선택하지 않는데, route-map audit가 모든 `stationLines`에 좌표를 요구해 `MISSING_ROUTE_MAP_POSITION` blocker를 만들었습니다.
- route map 좌표를 claim하지 않는 pack은 좌표 coverage가 0이어도 release blocker로 보지 않아야 합니다.

## 작업 내용

- `audit-route-map`이 pack의 `sourceInventory.fields` 또는 `coverageScope.sourceDomains`에서 `route_map_positions` claim을 확인하도록 했습니다.
- route-map claim이 없고 `routeMapPositions` row도 없는 pack은 missing coordinate blocker를 만들지 않도록 했습니다.
- 좌표 row가 있거나 route-map source를 claim한 pack은 기존 좌표 검증을 그대로 유지합니다.
- post-merge 실패 fixture와 같은 형태를 회귀 테스트로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/route-map/route-map-tools.test.mjs`: 24 tests passed
  - `node tools/route-map/audit-route-map.mjs --fixture /tmp/easysubway-datapack-debug-1076/reviewed-production-source-fixture.json --reviewed-ambiguities tools/route-map/fixtures/reviewed-ambiguities.json --fail-on BLOCKER,HIGH --pretty`: exit 0, BLOCKER 0 / HIGH 0
  - `node --test tools/ci/repository-contract.test.mjs`: 119 tests passed
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| route-map audit 회귀 | local Node | `node --test tools/route-map/route-map-tools.test.mjs` | 24 tests passed | PASS |
| post-merge 실패 재현 fixture | local Node | production reviewed fixture에 `audit-route-map --fail-on BLOCKER,HIGH` 실행 | BLOCKER 0 / HIGH 0 | PASS |
| repository contract | local Node | `node --test tools/ci/repository-contract.test.mjs` | 119 tests passed | PASS |
| whitespace | git | `git diff --check` | exit 0 | PASS |

## 리뷰어 메모

- route-map 좌표 지원을 claim하지 않는 v1 production source pack만 missing coordinate blocker에서 제외합니다.
- 좌표 row 자체의 유효성, source metadata, duplicate coordinate, label polygon 검증은 유지됩니다.

## 리스크

- 이 PR은 route-map 좌표 지원을 추가하지 않습니다. v1에서 route-map 좌표를 claim하려면 source selection과 `routeMapPositions` row를 별도 PR로 닫아야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
