### PR TITLE
[Fix] 수도권 pilot coverage closure target 추가

### DIFF
--- a/tools/datapack/capital-pilot-coverage-targets.json
+++ b/tools/datapack/capital-pilot-coverage-targets.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "nationwide-datapack-coverage-targets",
+  "targetVersion": "2026-06-29",
+  "coverageGoal": "Android v1 capital pilot production closure coverage",
+  "knownRegionIds": [
+    "busan",
+    "daegu",
+    "gwangju",
+    "daejeon"
+  ],
+  "knownOperatorIds": [
+    "korail",
+    "incheon-transit",
+    "busan-transportation",
+    "daegu-transportation",
+    "gwangju-metropolitan-rapid-transit",
+    "daejeon-transportation"
+  ],
+  "knownSourceDomains": [
+    "route_graph_topology",
+    "realtime_arrivals",
+    "route_map_positions",
+    "demand_reference"
+  ],
+  "requiredSourceDomains": [
+    {
+      "id": "station_line_membership",
+      "displayName": "수도권 pilot 역/노선 소속",
+      "requiredFields": [
+        "line",
+        "station_name",
+        "station_code"
+      ],
+      "blockingThreshold": {
+        "minimumOfficialFieldCoverageRatio": 1
+      }
+    },
+    {
+      "id": "accessibility_facilities",
+      "displayName": "수도권 pilot 접근성 시설 근거",
+      "requiredFields": [
+        "elevator",
+        "escalator",
+        "wheelchair_lift",
+        "verified_at"
+      ],
+      "blockingThreshold": {
+        "minimumOfficialFieldCoverageRatio": 1
+      }
+    }
+  ],
+  "regions": [
+    {
+      "id": "capital",
+      "displayName": "수도권 pilot",
+      "operatorIds": [
+        "seoul-metro"
+      ]
+    }
+  ]
+}

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -5422,6 +5422,27 @@ test("수도권 pilot production source input은 production manifest v2 pack으�
     { cwd: root, env: productionEnv },
   );
 
+  const coverageReportPath = path.join(outputDir, "capital-pilot-coverage-summary.json");
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/report-coverage-gaps.mjs",
+      "--targets",
+      "tools/datapack/capital-pilot-coverage-targets.json",
+      "--inventory",
+      "tools/datapack/source-inventory.json",
+      "--provenance",
+      path.join(packOutputDir, "current.provenance.json"),
+      "--output",
+      coverageReportPath,
+    ],
+    { cwd: root },
+  );
+  const coverageReport = JSON.parse(await readFile(coverageReportPath, "utf8"));
+  assert.equal(coverageReport.summary.coverageComplete, true);
+  assert.equal(coverageReport.summary.missingRequirements, 0);
+  assert.equal(coverageReport.summary.coverageRatio, 1);
+
   const manifest = JSON.parse(await readFile(path.join(packOutputDir, "current.json"), "utf8"));
   assert.equal(manifest.manifestVersion, 2);
   assert.equal(manifest.channel, "production");

--- a/tools/datapack/report-coverage-gaps.mjs
+++ b/tools/datapack/report-coverage-gaps.mjs
@@ -77,9 +77,18 @@ function buildCoverageGapReport(targets, inventory, provenance = null) {
 
 function coverageTargetIndex(targets) {
   return {
-    regionIds: new Set(targets.regions.map((region) => region.id)),
-    operatorIds: new Set(targets.regions.flatMap((region) => region.operatorIds)),
-    sourceDomains: new Set(targets.requiredSourceDomains.map((domain) => domain.id)),
+    regionIds: new Set([
+      ...targets.regions.map((region) => region.id),
+      ...optionalStringArray(targets.knownRegionIds, "knownRegionIds"),
+    ]),
+    operatorIds: new Set([
+      ...targets.regions.flatMap((region) => region.operatorIds),
+      ...optionalStringArray(targets.knownOperatorIds, "knownOperatorIds"),
+    ]),
+    sourceDomains: new Set([
+      ...targets.requiredSourceDomains.map((domain) => domain.id),
+      ...optionalStringArray(targets.knownSourceDomains, "knownSourceDomains"),
+    ]),
   };
 }
 
@@ -117,6 +126,9 @@ function validateTargets(targets) {
   if (!Array.isArray(targets.requiredSourceDomains) || targets.requiredSourceDomains.length === 0) {
     throw new Error("requiredSourceDomains must be a non-empty array");
   }
+  optionalStringArray(targets.knownRegionIds, "knownRegionIds");
+  optionalStringArray(targets.knownOperatorIds, "knownOperatorIds");
+  optionalStringArray(targets.knownSourceDomains, "knownSourceDomains");
   const domainIds = new Set();
   for (const domain of targets.requiredSourceDomains) {
     const id = requiredString(domain.id, "requiredSourceDomains.id");
@@ -282,6 +294,16 @@ function requiredString(value, label) {
 function requiredStringArray(value, label) {
   if (!Array.isArray(value) || value.length === 0 || value.some((entry) => typeof entry !== "string" || entry.trim() === "")) {
     throw new Error(`${label} must be a non-empty string array`);
+  }
+  return value;
+}
+
+function optionalStringArray(value, label) {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string" || entry.trim() === "")) {
+    throw new Error(`${label} must be a string array`);
   }
   return value;
 }


### PR DESCRIPTION
## 관련 이슈

close #1074

## 작업 배경

- #1074의 release closure 검증은 전국 전체 coverage가 아니라 승인된 `capital_pilot_android_v1` 범위에서 P0 데이터팩 근거가 닫히는지 재현할 수 있어야 한다.
- 기존 coverage target은 전국 observation 전용이라 수도권 pilot production candidate의 `capital/seoul-metro` 근거만 missing 0으로 판정하는 artifact가 없었다.

## 작업 내용

- `tools/datapack/capital-pilot-coverage-targets.json`을 추가해 수도권 pilot의 역/노선 소속과 접근성 시설 근거를 closure target으로 분리했다.
- coverage reporter가 target의 required 범위와 inventory 검증용 known 범위를 구분하도록 `knownRegionIds`, `knownOperatorIds`, `knownSourceDomains`를 지원한다.
- production source input 통합 테스트에서 provenance 기반 capital pilot coverage report가 `coverageComplete=true`로 생성되는지 검증한다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/*.test.mjs`: 107 tests passed
  - `node --test tools/ci/*.test.mjs`: 129 tests passed
  - `cd apps/mobile && flutter test test/features/routes/route_engine_test.dart test/features/routes/local_route_repository_test.dart`: 57 tests passed
  - `node tools/datapack/report-coverage-gaps.mjs --targets tools/datapack/capital-pilot-coverage-targets.json --inventory tools/datapack/source-inventory.json --provenance build/datapack/production-candidate/current.provenance.json --output build/datapack/reports/capital-pilot-coverage-summary.json`: exit 0, summary total 2 / covered 2 / missing 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 수도권 pilot coverage closure | local Node | production candidate provenance로 coverage report 생성 | command output summary | totalRequirements 2, coveredRequirements 2, missingRequirements 0 |
| 데이터팩 도구 회귀 | local Node | `node --test tools/datapack/*.test.mjs` | command output | 107 tests passed |
| 저장소 계약 회귀 | local Node | `node --test tools/ci/*.test.mjs` | command output | 129 tests passed |
| strict route 회귀 | local Flutter | `flutter test test/features/routes/route_engine_test.dart test/features/routes/local_route_repository_test.dart` | command output | 57 tests passed |
| 화면 증거 | 해당 없음 | 데이터팩 검증 target과 Node reporter 변경이라 UI 표시가 바뀌지 않음 | 증거 불필요 사유 | 스크린샷/녹화 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `capital-pilot-coverage-targets.json`의 required 범위가 `capital/seoul-metro`와 station/accessibility domain만 닫는지 확인하면 된다.

## 리스크

- reporter가 known 범위를 허용하면서 target 파일이 기존보다 더 명시적이어야 한다. 기존 nationwide target은 known 필드를 쓰지 않아 기존 동작이 유지된다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
