### PR TITLE
[Feat] 데이터팩 source snapshot 불변 저장 기반 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepository.java
@@ -1,0 +1,116 @@
+package com.easysubway.datapack.adapter.out.persistence;
+
+import com.easysubway.datapack.domain.DataSourceSnapshot;
+import com.easysubway.datapack.domain.InvalidDataSourceSnapshotException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("prod")
+public class JdbcDataSourceSnapshotRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	public JdbcDataSourceSnapshotRepository(DataSource dataSource) {
+		this(new JdbcTemplate(dataSource));
+	}
+
+	JdbcDataSourceSnapshotRepository(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	public DataSourceSnapshot saveSnapshot(DataSourceSnapshot snapshot) {
+		try {
+			insert(snapshot);
+			return snapshot;
+		} catch (DuplicateKeyException exception) {
+			DataSourceSnapshot existing = loadSnapshot(snapshot.snapshotId())
+				.orElseThrow(() -> exception);
+			if (existing.equals(snapshot)) {
+				return snapshot;
+			}
+			throw new InvalidDataSourceSnapshotException("LOCKED source snapshot is append-only; create a new snapshot instead.");
+		}
+	}
+
+	public Optional<DataSourceSnapshot> loadSnapshot(String snapshotId) {
+		try {
+			return Optional.ofNullable(jdbcTemplate.queryForObject("""
+				SELECT snapshot_id, source_id, provider, retrieved_at, source_updated_at, row_count,
+					raw_sha256, raw_object_uri, redacted_request_fingerprint, schema_fingerprint,
+					snapshot_status, schema_status, license_status, fetch_status, redistribution_allowed,
+					credential_redacted, previous_snapshot_id, diff_summary, freshness_expires_at
+				FROM data_source_snapshots
+				WHERE snapshot_id = ?
+				""", this::mapSnapshot, snapshotId));
+		} catch (EmptyResultDataAccessException exception) {
+			return Optional.empty();
+		}
+	}
+
+	private void insert(DataSourceSnapshot snapshot) {
+		jdbcTemplate.update("""
+			INSERT INTO data_source_snapshots (
+				snapshot_id, source_id, provider, retrieved_at, source_updated_at, row_count,
+				raw_sha256, raw_object_uri, redacted_request_fingerprint, schema_fingerprint,
+				snapshot_status, schema_status, license_status, fetch_status, redistribution_allowed,
+				credential_redacted, previous_snapshot_id, diff_summary, freshness_expires_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			""",
+			snapshot.snapshotId(),
+			snapshot.sourceId(),
+			snapshot.provider(),
+			snapshot.retrievedAt(),
+			snapshot.sourceUpdatedAt(),
+			snapshot.rowCount(),
+			snapshot.rawSha256(),
+			snapshot.rawObjectUri(),
+			snapshot.redactedRequestFingerprint(),
+			snapshot.schemaFingerprint(),
+			snapshot.snapshotStatus(),
+			snapshot.schemaStatus(),
+			snapshot.licenseStatus(),
+			snapshot.fetchStatus(),
+			snapshot.redistributionAllowed(),
+			snapshot.credentialRedacted(),
+			snapshot.previousSnapshotId(),
+			snapshot.diffSummary(),
+			snapshot.freshnessExpiresAt()
+		);
+	}
+
+	private DataSourceSnapshot mapSnapshot(ResultSet resultSet, int rowNumber) throws SQLException {
+		var sourceUpdatedAt = resultSet.getTimestamp("source_updated_at");
+		return new DataSourceSnapshot(
+			resultSet.getString("snapshot_id"),
+			resultSet.getString("source_id"),
+			resultSet.getString("provider"),
+			resultSet.getTimestamp("retrieved_at").toLocalDateTime(),
+			sourceUpdatedAt == null ? null : sourceUpdatedAt.toLocalDateTime(),
+			resultSet.getInt("row_count"),
+			resultSet.getString("raw_sha256"),
+			resultSet.getString("raw_object_uri"),
+			resultSet.getString("redacted_request_fingerprint"),
+			resultSet.getString("schema_fingerprint"),
+			resultSet.getString("snapshot_status"),
+			resultSet.getString("schema_status"),
+			resultSet.getString("license_status"),
+			resultSet.getString("fetch_status"),
+			resultSet.getBoolean("redistribution_allowed"),
+			resultSet.getBoolean("credential_redacted"),
+			resultSet.getString("previous_snapshot_id"),
+			resultSet.getString("diff_summary"),
+			resultSet.getTimestamp("freshness_expires_at").toLocalDateTime()
+		);
+	}
+}

--- a/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
+++ b/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
@@ -1,6 +1,7 @@
 package com.easysubway.datapack.domain;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.regex.Pattern;
 
 public record DataSourceSnapshot(
@@ -34,6 +35,8 @@ public record DataSourceSnapshot(
 		if (retrievedAt == null) {
 			throw new InvalidDataSourceSnapshotException("retrievedAt is required.");
 		}
+		retrievedAt = normalizeTimestamp(retrievedAt);
+		sourceUpdatedAt = normalizeTimestamp(sourceUpdatedAt);
 		if (rowCount < 0) {
 			throw new InvalidDataSourceSnapshotException("rowCount must be zero or positive.");
 		}
@@ -50,6 +53,7 @@ public record DataSourceSnapshot(
 		if (freshnessExpiresAt == null) {
 			throw new InvalidDataSourceSnapshotException("freshnessExpiresAt is required.");
 		}
+		freshnessExpiresAt = normalizeTimestamp(freshnessExpiresAt);
 	}
 
 	private static String requireText(String value, String field) {
@@ -72,5 +76,12 @@ public record DataSourceSnapshot(
 			return null;
 		}
 		return value.trim();
+	}
+
+	private static LocalDateTime normalizeTimestamp(LocalDateTime value) {
+		if (value == null) {
+			return null;
+		}
+		return value.truncatedTo(ChronoUnit.MICROS);
 	}
 }

--- a/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
+++ b/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
@@ -1,0 +1,76 @@
+package com.easysubway.datapack.domain;
+
+import java.time.LocalDateTime;
+import java.util.regex.Pattern;
+
+public record DataSourceSnapshot(
+	String snapshotId,
+	String sourceId,
+	String provider,
+	LocalDateTime retrievedAt,
+	LocalDateTime sourceUpdatedAt,
+	int rowCount,
+	String rawSha256,
+	String rawObjectUri,
+	String redactedRequestFingerprint,
+	String schemaFingerprint,
+	String snapshotStatus,
+	String schemaStatus,
+	String licenseStatus,
+	String fetchStatus,
+	boolean redistributionAllowed,
+	boolean credentialRedacted,
+	String previousSnapshotId,
+	String diffSummary,
+	LocalDateTime freshnessExpiresAt
+) {
+
+	private static final Pattern SHA256 = Pattern.compile("[0-9a-f]{64}");
+
+	public DataSourceSnapshot {
+		snapshotId = requireText(snapshotId, "snapshotId");
+		sourceId = requireText(sourceId, "sourceId");
+		provider = requireText(provider, "provider");
+		if (retrievedAt == null) {
+			throw new InvalidDataSourceSnapshotException("retrievedAt is required.");
+		}
+		if (rowCount < 0) {
+			throw new InvalidDataSourceSnapshotException("rowCount must be zero or positive.");
+		}
+		rawSha256 = requireSha256(rawSha256, "rawSha256");
+		rawObjectUri = requireText(rawObjectUri, "rawObjectUri");
+		redactedRequestFingerprint = requireSha256(redactedRequestFingerprint, "redactedRequestFingerprint");
+		schemaFingerprint = requireSha256(schemaFingerprint, "schemaFingerprint");
+		snapshotStatus = requireText(snapshotStatus, "snapshotStatus");
+		schemaStatus = requireText(schemaStatus, "schemaStatus");
+		licenseStatus = requireText(licenseStatus, "licenseStatus");
+		fetchStatus = requireText(fetchStatus, "fetchStatus");
+		previousSnapshotId = trimToNull(previousSnapshotId);
+		diffSummary = trimToNull(diffSummary);
+		if (freshnessExpiresAt == null) {
+			throw new InvalidDataSourceSnapshotException("freshnessExpiresAt is required.");
+		}
+	}
+
+	private static String requireText(String value, String field) {
+		if (value == null || value.isBlank()) {
+			throw new InvalidDataSourceSnapshotException(field + " is required.");
+		}
+		return value.trim();
+	}
+
+	private static String requireSha256(String value, String field) {
+		String trimmed = requireText(value, field);
+		if (!SHA256.matcher(trimmed).matches()) {
+			throw new InvalidDataSourceSnapshotException(field + " must be a lowercase SHA-256 hex value.");
+		}
+		return trimmed;
+	}
+
+	private static String trimToNull(String value) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		return value.trim();
+	}
+}

--- a/backend/src/main/java/com/easysubway/datapack/domain/InvalidDataSourceSnapshotException.java
+++ b/backend/src/main/java/com/easysubway/datapack/domain/InvalidDataSourceSnapshotException.java
@@ -1,0 +1,8 @@
+package com.easysubway.datapack.domain;
+
+public class InvalidDataSourceSnapshotException extends RuntimeException {
+
+	public InvalidDataSourceSnapshotException(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/resources/db/migration/h2/V16__datapack_source_snapshots.sql
+++ b/backend/src/main/resources/db/migration/h2/V16__datapack_source_snapshots.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS data_source_snapshots (
+	snapshot_id VARCHAR(120) NOT NULL PRIMARY KEY,
+	source_id VARCHAR(120) NOT NULL,
+	provider VARCHAR(120) NOT NULL,
+	retrieved_at TIMESTAMP NOT NULL,
+	source_updated_at TIMESTAMP,
+	row_count INTEGER NOT NULL,
+	raw_sha256 VARCHAR(64) NOT NULL,
+	raw_object_uri VARCHAR(1000) NOT NULL,
+	redacted_request_fingerprint VARCHAR(64) NOT NULL,
+	schema_fingerprint VARCHAR(64) NOT NULL,
+	snapshot_status VARCHAR(30) NOT NULL,
+	schema_status VARCHAR(30) NOT NULL,
+	license_status VARCHAR(30) NOT NULL,
+	fetch_status VARCHAR(30) NOT NULL,
+	redistribution_allowed BOOLEAN NOT NULL,
+	credential_redacted BOOLEAN NOT NULL,
+	previous_snapshot_id VARCHAR(120),
+	diff_summary VARCHAR(1000),
+	freshness_expires_at TIMESTAMP NOT NULL,
+	CONSTRAINT fk_data_source_snapshots_previous
+		FOREIGN KEY (previous_snapshot_id) REFERENCES data_source_snapshots(snapshot_id)
+		ON DELETE RESTRICT ON UPDATE RESTRICT,
+	CONSTRAINT chk_data_source_snapshots_row_count
+		CHECK (row_count >= 0),
+	CONSTRAINT chk_data_source_snapshots_raw_sha256
+		CHECK (char_length(raw_sha256) = 64),
+	CONSTRAINT chk_data_source_snapshots_request_fingerprint
+		CHECK (char_length(redacted_request_fingerprint) = 64),
+	CONSTRAINT chk_data_source_snapshots_schema_fingerprint
+		CHECK (char_length(schema_fingerprint) = 64)
+);
+
+CREATE INDEX IF NOT EXISTS idx_data_source_snapshots_source_retrieved
+	ON data_source_snapshots (source_id ASC, retrieved_at DESC, snapshot_id ASC);

--- a/backend/src/main/resources/db/migration/postgresql/V16__datapack_source_snapshots.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V16__datapack_source_snapshots.sql
@@ -1,3 +1,6 @@
+CREATE DOMAIN datapack_sha256 AS VARCHAR(64)
+	CHECK (VALUE ~ '^[0-9a-f]{64}$');
+
 CREATE TABLE IF NOT EXISTS data_source_snapshots (
 	snapshot_id VARCHAR(120) NOT NULL PRIMARY KEY,
 	source_id VARCHAR(120) NOT NULL,
@@ -5,10 +8,10 @@ CREATE TABLE IF NOT EXISTS data_source_snapshots (
 	retrieved_at TIMESTAMP NOT NULL,
 	source_updated_at TIMESTAMP,
 	row_count INTEGER NOT NULL,
-	raw_sha256 VARCHAR(64) NOT NULL,
+	raw_sha256 datapack_sha256 NOT NULL,
 	raw_object_uri VARCHAR(1000) NOT NULL,
-	redacted_request_fingerprint VARCHAR(64) NOT NULL,
-	schema_fingerprint VARCHAR(64) NOT NULL,
+	redacted_request_fingerprint datapack_sha256 NOT NULL,
+	schema_fingerprint datapack_sha256 NOT NULL,
 	snapshot_status VARCHAR(30) NOT NULL,
 	schema_status VARCHAR(30) NOT NULL,
 	license_status VARCHAR(30) NOT NULL,
@@ -22,13 +25,7 @@ CREATE TABLE IF NOT EXISTS data_source_snapshots (
 		FOREIGN KEY (previous_snapshot_id) REFERENCES data_source_snapshots(snapshot_id)
 		ON DELETE RESTRICT ON UPDATE RESTRICT,
 	CONSTRAINT chk_data_source_snapshots_row_count
-		CHECK (row_count >= 0),
-	CONSTRAINT chk_data_source_snapshots_sha256_fields
-		CHECK (
-			raw_sha256 ~ '^[0-9a-f]{64}$'
-			AND redacted_request_fingerprint ~ '^[0-9a-f]{64}$'
-			AND schema_fingerprint ~ '^[0-9a-f]{64}$'
-		)
+		CHECK (row_count >= 0)
 );
 
 CREATE INDEX IF NOT EXISTS idx_data_source_snapshots_source_retrieved

--- a/backend/src/main/resources/db/migration/postgresql/V16__datapack_source_snapshots.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V16__datapack_source_snapshots.sql
@@ -23,12 +23,12 @@ CREATE TABLE IF NOT EXISTS data_source_snapshots (
 		ON DELETE RESTRICT ON UPDATE RESTRICT,
 	CONSTRAINT chk_data_source_snapshots_row_count
 		CHECK (row_count >= 0),
-	CONSTRAINT chk_data_source_snapshots_raw_sha256
-		CHECK (raw_sha256 ~ '^[0-9a-f]{64}$'),
-	CONSTRAINT chk_data_source_snapshots_request_fingerprint
-		CHECK (redacted_request_fingerprint ~ '^[0-9a-f]{64}$'),
-	CONSTRAINT chk_data_source_snapshots_schema_fingerprint
-		CHECK (schema_fingerprint ~ '^[0-9a-f]{64}$')
+	CONSTRAINT chk_data_source_snapshots_sha256_fields
+		CHECK (
+			raw_sha256 ~ '^[0-9a-f]{64}$'
+			AND redacted_request_fingerprint ~ '^[0-9a-f]{64}$'
+			AND schema_fingerprint ~ '^[0-9a-f]{64}$'
+		)
 );
 
 CREATE INDEX IF NOT EXISTS idx_data_source_snapshots_source_retrieved

--- a/backend/src/main/resources/db/migration/postgresql/V16__datapack_source_snapshots.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V16__datapack_source_snapshots.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS data_source_snapshots (
+	snapshot_id VARCHAR(120) NOT NULL PRIMARY KEY,
+	source_id VARCHAR(120) NOT NULL,
+	provider VARCHAR(120) NOT NULL,
+	retrieved_at TIMESTAMP NOT NULL,
+	source_updated_at TIMESTAMP,
+	row_count INTEGER NOT NULL,
+	raw_sha256 VARCHAR(64) NOT NULL,
+	raw_object_uri VARCHAR(1000) NOT NULL,
+	redacted_request_fingerprint VARCHAR(64) NOT NULL,
+	schema_fingerprint VARCHAR(64) NOT NULL,
+	snapshot_status VARCHAR(30) NOT NULL,
+	schema_status VARCHAR(30) NOT NULL,
+	license_status VARCHAR(30) NOT NULL,
+	fetch_status VARCHAR(30) NOT NULL,
+	redistribution_allowed BOOLEAN NOT NULL,
+	credential_redacted BOOLEAN NOT NULL,
+	previous_snapshot_id VARCHAR(120),
+	diff_summary VARCHAR(1000),
+	freshness_expires_at TIMESTAMP NOT NULL,
+	CONSTRAINT fk_data_source_snapshots_previous
+		FOREIGN KEY (previous_snapshot_id) REFERENCES data_source_snapshots(snapshot_id)
+		ON DELETE RESTRICT ON UPDATE RESTRICT,
+	CONSTRAINT chk_data_source_snapshots_row_count
+		CHECK (row_count >= 0),
+	CONSTRAINT chk_data_source_snapshots_raw_sha256
+		CHECK (raw_sha256 ~ '^[0-9a-f]{64}$'),
+	CONSTRAINT chk_data_source_snapshots_request_fingerprint
+		CHECK (redacted_request_fingerprint ~ '^[0-9a-f]{64}$'),
+	CONSTRAINT chk_data_source_snapshots_schema_fingerprint
+		CHECK (schema_fingerprint ~ '^[0-9a-f]{64}$')
+);
+
+CREATE INDEX IF NOT EXISTS idx_data_source_snapshots_source_retrieved
+	ON data_source_snapshots (source_id ASC, retrieved_at DESC, snapshot_id ASC);

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -44,12 +44,13 @@ class DatabaseMigrationContainerTest {
 				"batch_job_instance",
 				"facility_reports",
 				"push_notification_outbox",
+				"data_source_snapshots",
 				"transit_master_overrides",
 				"transit_master_override_audits"
 			);
-		assertThat(successfulMigrationVersions(jdbcTemplate)).contains("1", "14");
+		assertThat(successfulMigrationVersions(jdbcTemplate)).contains("1", "14", "16");
 		assertThat(foreignKeyNames(jdbcTemplate))
-			.contains("fk_facility_report_review_audits_report");
+			.contains("fk_facility_report_review_audits_report", "fk_data_source_snapshots_previous");
 	}
 
 	private List<String> tableNames(JdbcTemplate jdbcTemplate) {

--- a/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
@@ -73,13 +73,23 @@ class JdbcDataSourceSnapshotRepositoryTest {
 			.hasMessageContaining("LOCKED source snapshot");
 	}
 
+	@Test
+	@DisplayName("DB timestamp 정밀도보다 작은 nano 값이 있어도 같은 snapshot 재저장은 허용한다")
+	void sameSnapshotWithNanosecondTimestampIsIdempotent() {
+		var snapshot = lockedSnapshot("snapshot-1", "a".repeat(64), 13);
+
+		repository.saveSnapshot(snapshot);
+
+		assertThat(repository.saveSnapshot(snapshot)).isEqualTo(snapshot);
+	}
+
 	private DataSourceSnapshot lockedSnapshot(String snapshotId, String rawSha256, int rowCount) {
 		return new DataSourceSnapshot(
 			snapshotId,
 			"kric-station-elevator",
 			"국가철도공단",
-			LocalDateTime.of(2026, 6, 29, 3, 0),
-			LocalDateTime.of(2026, 6, 28, 0, 0),
+			LocalDateTime.of(2026, 6, 29, 3, 0, 0, 123456789),
+			LocalDateTime.of(2026, 6, 28, 0, 0, 0, 987654321),
 			rowCount,
 			rawSha256,
 			"s3://easysubway-datapack-sources/kric-station-elevator/%s.json".formatted(snapshotId),
@@ -93,7 +103,7 @@ class JdbcDataSourceSnapshotRepositoryTest {
 			true,
 			null,
 			"initial snapshot",
-			LocalDateTime.of(2026, 7, 6, 3, 0)
+			LocalDateTime.of(2026, 7, 6, 3, 0, 0, 555555555)
 		);
 	}
 }

--- a/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
@@ -1,0 +1,99 @@
+package com.easysubway.datapack.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.datapack.domain.DataSourceSnapshot;
+import com.easysubway.datapack.domain.InvalidDataSourceSnapshotException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("JDBC 데이터팩 source snapshot 저장소")
+class JdbcDataSourceSnapshotRepositoryTest {
+
+	private JdbcDataSourceSnapshotRepository repository;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:datapack-source-snapshots;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS data_source_snapshots");
+		jdbcTemplate.execute("""
+			CREATE TABLE data_source_snapshots (
+				snapshot_id VARCHAR(120) PRIMARY KEY,
+				source_id VARCHAR(120) NOT NULL,
+				provider VARCHAR(120) NOT NULL,
+				retrieved_at TIMESTAMP NOT NULL,
+				source_updated_at TIMESTAMP,
+				row_count INTEGER NOT NULL,
+				raw_sha256 VARCHAR(64) NOT NULL,
+				raw_object_uri VARCHAR(1000) NOT NULL,
+				redacted_request_fingerprint VARCHAR(64) NOT NULL,
+				schema_fingerprint VARCHAR(64) NOT NULL,
+				snapshot_status VARCHAR(30) NOT NULL,
+				schema_status VARCHAR(30) NOT NULL,
+				license_status VARCHAR(30) NOT NULL,
+				fetch_status VARCHAR(30) NOT NULL,
+				redistribution_allowed BOOLEAN NOT NULL,
+				credential_redacted BOOLEAN NOT NULL,
+				previous_snapshot_id VARCHAR(120),
+				diff_summary VARCHAR(1000),
+				freshness_expires_at TIMESTAMP NOT NULL
+			)
+			""");
+		repository = new JdbcDataSourceSnapshotRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("source snapshot을 저장하고 식별자로 조회한다")
+	void saveAndLoadSnapshot() {
+		var snapshot = lockedSnapshot("snapshot-1", "a".repeat(64), 13);
+
+		repository.saveSnapshot(snapshot);
+
+		assertThat(repository.loadSnapshot("snapshot-1")).contains(snapshot);
+	}
+
+	@Test
+	@DisplayName("LOCKED source snapshot의 raw hash, object URI, row count, schema fingerprint는 바꿀 수 없다")
+	void lockedSnapshotImmutableFieldsCannotChange() {
+		repository.saveSnapshot(lockedSnapshot("snapshot-1", "a".repeat(64), 13));
+		var changedRawHash = lockedSnapshot("snapshot-1", "b".repeat(64), 13);
+
+		assertThatThrownBy(() -> repository.saveSnapshot(changedRawHash))
+			.isInstanceOf(InvalidDataSourceSnapshotException.class)
+			.hasMessageContaining("LOCKED source snapshot");
+	}
+
+	private DataSourceSnapshot lockedSnapshot(String snapshotId, String rawSha256, int rowCount) {
+		return new DataSourceSnapshot(
+			snapshotId,
+			"kric-station-elevator",
+			"국가철도공단",
+			LocalDateTime.of(2026, 6, 29, 3, 0),
+			LocalDateTime.of(2026, 6, 28, 0, 0),
+			rowCount,
+			rawSha256,
+			"s3://easysubway-datapack-sources/kric-station-elevator/%s.json".formatted(snapshotId),
+			"c".repeat(64),
+			"d".repeat(64),
+			"LOCKED",
+			"PASS",
+			"PASS",
+			"SUCCESS",
+			true,
+			true,
+			null,
+			"initial snapshot",
+			LocalDateTime.of(2026, 7, 6, 3, 0)
+		);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

#1081 부분 작업입니다. 이 PR만으로 #1081을 닫지 않습니다.

## 작업 배경

- #1081의 OPS-001 범위인 source snapshot immutable model의 첫 저장 기반을 마련합니다.
- 데이터팩 운영 콘솔이 source 수집 결과를 candidate 입력으로 쓰려면 raw hash, object URI, schema fingerprint, freshness 만료 시각을 가진 snapshot record가 먼저 고정되어야 합니다.

## 작업 내용

- `DataSourceSnapshot` domain record와 JDBC 저장소를 추가했습니다.
- 같은 `snapshot_id`로 동일 payload를 다시 저장하는 것은 idempotent하게 허용하고, 다른 payload는 append-only 위반으로 차단합니다.
- Java `LocalDateTime`과 DB `TIMESTAMP` 정밀도 차이로 동일 snapshot 재시도가 실패하지 않도록 timestamp를 microsecond로 정규화했습니다.
- H2/PostgreSQL V16 migration에 `data_source_snapshots` table, previous snapshot FK, hash length/check constraint, source/retrieved index를 추가했습니다.
- PostgreSQL migration container test가 V16과 `data_source_snapshots` 생성 여부를 확인하도록 확장했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.datapack.adapter.out.persistence.JdbcDataSourceSnapshotRepositoryTest`: BUILD SUCCESSFUL
  - `./gradlew test --tests com.easysubway.EasySubwayBackendApplicationTests`: BUILD SUCCESSFUL
  - `./gradlew test --tests com.easysubway.common.persistence.DatabaseMigrationContainerTest`: BUILD SUCCESSFUL
  - `./gradlew test --tests com.easysubway.datapack.adapter.out.persistence.JdbcDataSourceSnapshotRepositoryTest --tests com.easysubway.common.persistence.DatabaseMigrationContainerTest --tests com.easysubway.EasySubwayBackendApplicationTests`: BUILD SUCCESSFUL
  - `./gradlew test --tests com.easysubway.datapack.adapter.out.persistence.JdbcDataSourceSnapshotRepositoryTest --rerun-tasks`: timestamp 정밀도 regression test 추가 직후 2 failures로 문제 재현, 수정 후 BUILD SUCCESSFUL
  - `./gradlew test --tests com.easysubway.common.persistence.DatabaseMigrationContainerTest --tests com.easysubway.EasySubwayBackendApplicationTests --tests com.easysubway.datapack.adapter.out.persistence.JdbcDataSourceSnapshotRepositoryTest`: BUILD SUCCESSFUL
  - `./gradlew test`: BUILD SUCCESSFUL
  - `git diff --check`: 통과
  - PR CI: `CI`, `Release Artifacts`, `SonarCloud Code Analysis`, `osv-scanner` 모두 success
  - CodeRabbit: rate limit/credit exhausted로 실제 리뷰 시작 실패 확인
  - Codex CLI fallback review: 1건 지적 게시 후 수정, re-review actionable 0건

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Source Snapshot 저장소 | Backend H2 | save/load와 duplicate payload 차단 test | `JdbcDataSourceSnapshotRepositoryTest` | 통과 |
| Timestamp 정밀도 재시도 | Backend H2 | nano timestamp snapshot 재저장 regression test | `sameSnapshotWithNanosecondTimestampIsIdempotent` | 통과 |
| H2 Flyway migration | Backend H2 | Spring Boot context migration | `EasySubwayBackendApplicationTests` | 통과 |
| PostgreSQL migration | Backend PostgreSQL Testcontainers | Flyway migration table/version/FK assertion | `DatabaseMigrationContainerTest` | 통과 |
| PR CI | GitHub Actions | required checks와 release artifact checks 확인 | PR #1082 check rollup | 통과 |
| SonarCloud | SonarCloud | Quality Gate와 open issue 확인 | SonarCloud PR analysis | 통과, 0 new issues |
| Review fallback | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review 게시 | PR review `4588938541`, re-review `4588954772` | actionable 0건 |
| Diff hygiene | Local git | whitespace/error check | `git diff --check` | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `JdbcDataSourceSnapshotRepository#saveSnapshot`의 append-only duplicate 처리와 `DataSourceSnapshot` timestamp 정규화입니다.
- 아직 Source Snapshot admin 화면, raw evidence redaction store, batch registry 연결은 없습니다. #1081 후속 OPS 작업으로 남깁니다.

## 리스크

- 이 PR은 저장 기반만 추가합니다. 실제 source 수집 job이 이 table을 쓰기 전까지 운영 동작 변화는 없습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
