### PR TITLE
[Feat] 데이터팩 운영 권한 matrix 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java
@@ -12,7 +12,19 @@ public enum AdminPermission {
 	AUDIT_READ("admin.audit.read"),
 	PRIVACY_LOG_READ("admin.privacy-log.read"),
 	BATCH_RETRY("admin.batch.retry"),
-	OPERATIONS_MANAGE("admin.operations.manage");
+	OPERATIONS_MANAGE("admin.operations.manage"),
+	DATAPACK_READ("admin.datapack.read"),
+	DATAPACK_SOURCE_RUN("admin.datapack.source.run"),
+	DATAPACK_ALIAS_REVIEW("admin.datapack.alias.review"),
+	DATAPACK_QUARANTINE_REVIEW("admin.datapack.quarantine.review"),
+	DATAPACK_EVIDENCE_REVIEW("admin.datapack.evidence.review"),
+	DATAPACK_OVERRIDE_REQUEST("admin.datapack.override.request"),
+	DATAPACK_OVERRIDE_APPROVE("admin.datapack.override.approve"),
+	DATAPACK_CANDIDATE_BUILD("admin.datapack.candidate.build"),
+	DATAPACK_STAGING_PROMOTE("admin.datapack.staging.promote"),
+	DATAPACK_PRODUCTION_APPROVE("admin.datapack.production.approve"),
+	DATAPACK_ROLLBACK("admin.datapack.rollback"),
+	DATAPACK_AUDIT_READ("admin.datapack.audit.read");
 
 	private final String authority;
 

--- a/backend/src/main/java/com/easysubway/admin/authorization/AdminRbacRole.java
+++ b/backend/src/main/java/com/easysubway/admin/authorization/AdminRbacRole.java
@@ -5,15 +5,33 @@ import java.util.EnumSet;
 import java.util.Set;
 
 public enum AdminRbacRole {
-	ADMIN_VIEWER(AdminPermission.ADMIN_VIEW),
+	ADMIN_VIEWER(AdminPermission.ADMIN_VIEW, AdminPermission.DATAPACK_READ),
 	REPORT_REVIEWER(AdminPermission.ADMIN_VIEW, AdminPermission.REPORT_REVIEW, AdminPermission.REPORT_PHOTO_READ),
-	MASTER_EDITOR(AdminPermission.ADMIN_VIEW, AdminPermission.MASTER_EDIT),
-	FIELD_OPERATOR(AdminPermission.ADMIN_VIEW, AdminPermission.FIELD_OPERATE),
+	MASTER_EDITOR(
+		AdminPermission.ADMIN_VIEW,
+		AdminPermission.MASTER_EDIT,
+		AdminPermission.DATAPACK_READ,
+		AdminPermission.DATAPACK_ALIAS_REVIEW,
+		AdminPermission.DATAPACK_QUARANTINE_REVIEW,
+		AdminPermission.DATAPACK_EVIDENCE_REVIEW,
+		AdminPermission.DATAPACK_OVERRIDE_REQUEST
+	),
+	FIELD_OPERATOR(
+		AdminPermission.ADMIN_VIEW,
+		AdminPermission.FIELD_OPERATE,
+		AdminPermission.DATAPACK_READ,
+		AdminPermission.DATAPACK_EVIDENCE_REVIEW,
+		AdminPermission.DATAPACK_OVERRIDE_REQUEST
+	),
 	DATA_OPERATOR(
 		AdminPermission.ADMIN_VIEW,
 		AdminPermission.DATA_OPERATE,
 		AdminPermission.BATCH_RETRY,
-		AdminPermission.OPERATIONS_MANAGE
+		AdminPermission.OPERATIONS_MANAGE,
+		AdminPermission.DATAPACK_READ,
+		AdminPermission.DATAPACK_SOURCE_RUN,
+		AdminPermission.DATAPACK_CANDIDATE_BUILD,
+		AdminPermission.DATAPACK_STAGING_PROMOTE
 	),
 	SECURITY_ADMIN(
 		AdminPermission.ADMIN_VIEW,
@@ -21,7 +39,9 @@ public enum AdminRbacRole {
 		AdminPermission.SECURITY_ADMIN,
 		AdminPermission.AUDIT_READ,
 		AdminPermission.PRIVACY_LOG_READ,
-		AdminPermission.OPERATIONS_MANAGE
+		AdminPermission.OPERATIONS_MANAGE,
+		AdminPermission.DATAPACK_READ,
+		AdminPermission.DATAPACK_AUDIT_READ
 	),
 	SUPER_ADMIN(AdminPermission.values());
 

--- a/backend/src/main/resources/db/migration/h2/V22__datapack_admin_permissions.sql
+++ b/backend/src/main/resources/db/migration/h2/V22__datapack_admin_permissions.sql
@@ -1,121 +1,35 @@
 ALTER TABLE admin_role_permissions DROP CONSTRAINT ck_h2_admin_role_permissions_permission;
 
 ALTER TABLE admin_role_permissions ADD CONSTRAINT ck_h2_admin_role_permissions_permission
-    CHECK (permission_code IN (
-        'admin.view',
-        'admin.report.review',
-        'admin.report.photo.read',
-        'admin.master.edit',
-        'admin.field.operate',
-        'admin.data.operate',
-        'admin.security.audit',
-        'admin.security.admin',
-        'admin.audit.read',
-        'admin.privacy-log.read',
-        'admin.batch.retry',
-        'admin.operations.manage',
-        'admin.datapack.read',
-        'admin.datapack.source.run',
-        'admin.datapack.alias.review',
-        'admin.datapack.quarantine.review',
-        'admin.datapack.evidence.review',
-        'admin.datapack.override.request',
-        'admin.datapack.override.approve',
-        'admin.datapack.candidate.build',
-        'admin.datapack.staging.promote',
-        'admin.datapack.production.approve',
-        'admin.datapack.rollback',
-        'admin.datapack.audit.read'
-    ));
+    CHECK (permission_code IN ('admin.view', 'admin.report.review', 'admin.report.photo.read', 'admin.master.edit', 'admin.field.operate', 'admin.data.operate', 'admin.security.audit', 'admin.security.admin', 'admin.audit.read', 'admin.privacy-log.read', 'admin.batch.retry', 'admin.operations.manage', 'admin.datapack.read', 'admin.datapack.source.run', 'admin.datapack.alias.review', 'admin.datapack.quarantine.review', 'admin.datapack.evidence.review', 'admin.datapack.override.request', 'admin.datapack.override.approve', 'admin.datapack.candidate.build', 'admin.datapack.staging.promote', 'admin.datapack.production.approve', 'admin.datapack.rollback', 'admin.datapack.audit.read'));
 
-CREATE TEMPORARY TABLE datapack_admin_permission_role_seed (
-    role_code VARCHAR(60) PRIMARY KEY,
-    evidence_override_role BOOLEAN NOT NULL,
-    alias_review_role BOOLEAN NOT NULL,
-    data_operation_role BOOLEAN NOT NULL,
-    audit_role BOOLEAN NOT NULL,
-    super_role BOOLEAN NOT NULL
-);
-
-INSERT INTO datapack_admin_permission_role_seed (
-    role_code,
-    evidence_override_role,
-    alias_review_role,
-    data_operation_role,
-    audit_role,
-    super_role
-)
+MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
+KEY (role_code, permission_code)
 VALUES
-    ('ADMIN_VIEWER', FALSE, FALSE, FALSE, FALSE, FALSE),
-    ('MASTER_EDITOR', TRUE, TRUE, FALSE, FALSE, FALSE),
-    ('FIELD_OPERATOR', TRUE, FALSE, FALSE, FALSE, FALSE),
-    ('DATA_OPERATOR', FALSE, FALSE, TRUE, FALSE, FALSE),
-    ('SECURITY_ADMIN', FALSE, FALSE, FALSE, TRUE, FALSE),
-    ('SUPER_ADMIN', FALSE, FALSE, FALSE, FALSE, TRUE);
-
-MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
-KEY (role_code, permission_code)
-SELECT role_code, 'admin.datapack.read', CURRENT_TIMESTAMP
-FROM datapack_admin_permission_role_seed;
-
-MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
-KEY (role_code, permission_code)
-SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
-FROM datapack_admin_permission_role_seed role_seed
-CROSS JOIN (
-    VALUES
-        ('admin.datapack.evidence.review'),
-        ('admin.datapack.override.request')
-) AS permission_seed(permission_code)
-WHERE role_seed.evidence_override_role;
-
-MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
-KEY (role_code, permission_code)
-SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
-FROM datapack_admin_permission_role_seed role_seed
-CROSS JOIN (
-    VALUES
-        ('admin.datapack.alias.review'),
-        ('admin.datapack.quarantine.review')
-) AS permission_seed(permission_code)
-WHERE role_seed.alias_review_role;
-
-MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
-KEY (role_code, permission_code)
-SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
-FROM datapack_admin_permission_role_seed role_seed
-CROSS JOIN (
-    VALUES
-        ('admin.datapack.source.run'),
-        ('admin.datapack.candidate.build'),
-        ('admin.datapack.staging.promote')
-) AS permission_seed(permission_code)
-WHERE role_seed.data_operation_role;
-
-MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
-KEY (role_code, permission_code)
-SELECT role_code, 'admin.datapack.audit.read', CURRENT_TIMESTAMP
-FROM datapack_admin_permission_role_seed
-WHERE audit_role;
-
-MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
-KEY (role_code, permission_code)
-SELECT DISTINCT role_seed.role_code, permission.permission_code, CURRENT_TIMESTAMP
-FROM datapack_admin_permission_role_seed role_seed
-CROSS JOIN admin_role_permissions permission
-WHERE role_seed.super_role
-  AND permission.permission_code LIKE 'admin.datapack.%';
-
-MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
-KEY (role_code, permission_code)
-SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
-FROM datapack_admin_permission_role_seed role_seed
-CROSS JOIN (
-    VALUES
-        ('admin.datapack.override.approve'),
-        ('admin.datapack.production.approve'),
-        ('admin.datapack.rollback')
-) AS permission_seed(permission_code)
-WHERE role_seed.super_role;
-
-DROP TABLE datapack_admin_permission_role_seed;
+    ('ADMIN_VIEWER', 'admin.datapack.read', CURRENT_TIMESTAMP),
+    ('MASTER_EDITOR', 'admin.datapack.read', CURRENT_TIMESTAMP),
+    ('MASTER_EDITOR', 'admin.datapack.alias.review', CURRENT_TIMESTAMP),
+    ('MASTER_EDITOR', 'admin.datapack.quarantine.review', CURRENT_TIMESTAMP),
+    ('MASTER_EDITOR', 'admin.datapack.evidence.review', CURRENT_TIMESTAMP),
+    ('MASTER_EDITOR', 'admin.datapack.override.request', CURRENT_TIMESTAMP),
+    ('FIELD_OPERATOR', 'admin.datapack.read', CURRENT_TIMESTAMP),
+    ('FIELD_OPERATOR', 'admin.datapack.evidence.review', CURRENT_TIMESTAMP),
+    ('FIELD_OPERATOR', 'admin.datapack.override.request', CURRENT_TIMESTAMP),
+    ('DATA_OPERATOR', 'admin.datapack.read', CURRENT_TIMESTAMP),
+    ('DATA_OPERATOR', 'admin.datapack.source.run', CURRENT_TIMESTAMP),
+    ('DATA_OPERATOR', 'admin.datapack.candidate.build', CURRENT_TIMESTAMP),
+    ('DATA_OPERATOR', 'admin.datapack.staging.promote', CURRENT_TIMESTAMP),
+    ('SECURITY_ADMIN', 'admin.datapack.read', CURRENT_TIMESTAMP),
+    ('SECURITY_ADMIN', 'admin.datapack.audit.read', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.datapack.read', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.datapack.source.run', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.datapack.alias.review', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.datapack.quarantine.review', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.datapack.evidence.review', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.datapack.override.request', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.datapack.override.approve', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.datapack.candidate.build', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.datapack.staging.promote', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.datapack.production.approve', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.datapack.rollback', CURRENT_TIMESTAMP),
+    ('SUPER_ADMIN', 'admin.datapack.audit.read', CURRENT_TIMESTAMP);

--- a/backend/src/main/resources/db/migration/h2/V22__datapack_admin_permissions.sql
+++ b/backend/src/main/resources/db/migration/h2/V22__datapack_admin_permissions.sql
@@ -1,0 +1,84 @@
+ALTER TABLE admin_role_permissions DROP CONSTRAINT ck_h2_admin_role_permissions_permission;
+
+ALTER TABLE admin_role_permissions ADD CONSTRAINT ck_h2_admin_role_permissions_permission
+    CHECK (permission_code IN (
+        'admin.view',
+        'admin.report.review',
+        'admin.report.photo.read',
+        'admin.master.edit',
+        'admin.field.operate',
+        'admin.data.operate',
+        'admin.security.audit',
+        'admin.security.admin',
+        'admin.audit.read',
+        'admin.privacy-log.read',
+        'admin.batch.retry',
+        'admin.operations.manage',
+        'admin.datapack.read',
+        'admin.datapack.source.run',
+        'admin.datapack.alias.review',
+        'admin.datapack.quarantine.review',
+        'admin.datapack.evidence.review',
+        'admin.datapack.override.request',
+        'admin.datapack.override.approve',
+        'admin.datapack.candidate.build',
+        'admin.datapack.staging.promote',
+        'admin.datapack.production.approve',
+        'admin.datapack.rollback',
+        'admin.datapack.audit.read'
+    ));
+
+MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
+KEY (role_code, permission_code)
+SELECT DISTINCT role_code, 'admin.datapack.read', CURRENT_TIMESTAMP
+FROM admin_role_permissions
+WHERE permission_code = 'admin.view';
+
+MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
+KEY (role_code, permission_code)
+SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM (VALUES ('MASTER_EDITOR'), ('FIELD_OPERATOR')) AS role_seed(role_code)
+CROSS JOIN (
+    VALUES
+        ('admin.datapack.evidence.review'),
+        ('admin.datapack.override.request')
+) AS permission_seed(permission_code);
+
+MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
+KEY (role_code, permission_code)
+SELECT 'MASTER_EDITOR', permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM (
+    VALUES
+        ('admin.datapack.alias.review'),
+        ('admin.datapack.quarantine.review')
+) AS permission_seed(permission_code);
+
+MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
+KEY (role_code, permission_code)
+SELECT 'DATA_OPERATOR', permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM (
+    VALUES
+        ('admin.datapack.source.run'),
+        ('admin.datapack.candidate.build'),
+        ('admin.datapack.staging.promote')
+) AS permission_seed(permission_code);
+
+MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
+KEY (role_code, permission_code)
+VALUES ('SECURITY_ADMIN', 'admin.datapack.audit.read', CURRENT_TIMESTAMP);
+
+MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
+KEY (role_code, permission_code)
+SELECT DISTINCT 'SUPER_ADMIN', permission_code, CURRENT_TIMESTAMP
+FROM admin_role_permissions
+WHERE permission_code LIKE 'admin.datapack.%';
+
+MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
+KEY (role_code, permission_code)
+SELECT 'SUPER_ADMIN', permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM (
+    VALUES
+        ('admin.datapack.override.approve'),
+        ('admin.datapack.production.approve'),
+        ('admin.datapack.rollback')
+) AS permission_seed(permission_code);

--- a/backend/src/main/resources/db/migration/h2/V22__datapack_admin_permissions.sql
+++ b/backend/src/main/resources/db/migration/h2/V22__datapack_admin_permissions.sql
@@ -28,64 +28,94 @@ ALTER TABLE admin_role_permissions ADD CONSTRAINT ck_h2_admin_role_permissions_p
         'admin.datapack.audit.read'
     ));
 
+CREATE TEMPORARY TABLE datapack_admin_permission_role_seed (
+    role_code VARCHAR(60) PRIMARY KEY,
+    evidence_override_role BOOLEAN NOT NULL,
+    alias_review_role BOOLEAN NOT NULL,
+    data_operation_role BOOLEAN NOT NULL,
+    audit_role BOOLEAN NOT NULL,
+    super_role BOOLEAN NOT NULL
+);
+
+INSERT INTO datapack_admin_permission_role_seed (
+    role_code,
+    evidence_override_role,
+    alias_review_role,
+    data_operation_role,
+    audit_role,
+    super_role
+)
+VALUES
+    ('ADMIN_VIEWER', FALSE, FALSE, FALSE, FALSE, FALSE),
+    ('MASTER_EDITOR', TRUE, TRUE, FALSE, FALSE, FALSE),
+    ('FIELD_OPERATOR', TRUE, FALSE, FALSE, FALSE, FALSE),
+    ('DATA_OPERATOR', FALSE, FALSE, TRUE, FALSE, FALSE),
+    ('SECURITY_ADMIN', FALSE, FALSE, FALSE, TRUE, FALSE),
+    ('SUPER_ADMIN', FALSE, FALSE, FALSE, FALSE, TRUE);
+
 MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
 KEY (role_code, permission_code)
-SELECT role_seed.role_code, 'admin.datapack.read', CURRENT_TIMESTAMP
-FROM (
-    VALUES
-        ('ADMIN_VIEWER'),
-        ('MASTER_EDITOR'),
-        ('FIELD_OPERATOR'),
-        ('DATA_OPERATOR'),
-        ('SECURITY_ADMIN'),
-        ('SUPER_ADMIN')
-) AS role_seed(role_code);
+SELECT role_code, 'admin.datapack.read', CURRENT_TIMESTAMP
+FROM datapack_admin_permission_role_seed;
 
 MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
 KEY (role_code, permission_code)
 SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
-FROM (VALUES ('MASTER_EDITOR'), ('FIELD_OPERATOR')) AS role_seed(role_code)
+FROM datapack_admin_permission_role_seed role_seed
 CROSS JOIN (
     VALUES
         ('admin.datapack.evidence.review'),
         ('admin.datapack.override.request')
-) AS permission_seed(permission_code);
+) AS permission_seed(permission_code)
+WHERE role_seed.evidence_override_role;
 
 MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
 KEY (role_code, permission_code)
-SELECT 'MASTER_EDITOR', permission_seed.permission_code, CURRENT_TIMESTAMP
-FROM (
+SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM datapack_admin_permission_role_seed role_seed
+CROSS JOIN (
     VALUES
         ('admin.datapack.alias.review'),
         ('admin.datapack.quarantine.review')
-) AS permission_seed(permission_code);
+) AS permission_seed(permission_code)
+WHERE role_seed.alias_review_role;
 
 MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
 KEY (role_code, permission_code)
-SELECT 'DATA_OPERATOR', permission_seed.permission_code, CURRENT_TIMESTAMP
-FROM (
+SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM datapack_admin_permission_role_seed role_seed
+CROSS JOIN (
     VALUES
         ('admin.datapack.source.run'),
         ('admin.datapack.candidate.build'),
         ('admin.datapack.staging.promote')
-) AS permission_seed(permission_code);
+) AS permission_seed(permission_code)
+WHERE role_seed.data_operation_role;
 
 MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
 KEY (role_code, permission_code)
-VALUES ('SECURITY_ADMIN', 'admin.datapack.audit.read', CURRENT_TIMESTAMP);
+SELECT role_code, 'admin.datapack.audit.read', CURRENT_TIMESTAMP
+FROM datapack_admin_permission_role_seed
+WHERE audit_role;
 
 MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
 KEY (role_code, permission_code)
-SELECT DISTINCT 'SUPER_ADMIN', permission_code, CURRENT_TIMESTAMP
-FROM admin_role_permissions
-WHERE permission_code LIKE 'admin.datapack.%';
+SELECT DISTINCT role_seed.role_code, permission.permission_code, CURRENT_TIMESTAMP
+FROM datapack_admin_permission_role_seed role_seed
+CROSS JOIN admin_role_permissions permission
+WHERE role_seed.super_role
+  AND permission.permission_code LIKE 'admin.datapack.%';
 
 MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
 KEY (role_code, permission_code)
-SELECT 'SUPER_ADMIN', permission_seed.permission_code, CURRENT_TIMESTAMP
-FROM (
+SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM datapack_admin_permission_role_seed role_seed
+CROSS JOIN (
     VALUES
         ('admin.datapack.override.approve'),
         ('admin.datapack.production.approve'),
         ('admin.datapack.rollback')
-) AS permission_seed(permission_code);
+) AS permission_seed(permission_code)
+WHERE role_seed.super_role;
+
+DROP TABLE datapack_admin_permission_role_seed;

--- a/backend/src/main/resources/db/migration/h2/V22__datapack_admin_permissions.sql
+++ b/backend/src/main/resources/db/migration/h2/V22__datapack_admin_permissions.sql
@@ -30,9 +30,16 @@ ALTER TABLE admin_role_permissions ADD CONSTRAINT ck_h2_admin_role_permissions_p
 
 MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
 KEY (role_code, permission_code)
-SELECT DISTINCT role_code, 'admin.datapack.read', CURRENT_TIMESTAMP
-FROM admin_role_permissions
-WHERE permission_code = 'admin.view';
+SELECT role_seed.role_code, 'admin.datapack.read', CURRENT_TIMESTAMP
+FROM (
+    VALUES
+        ('ADMIN_VIEWER'),
+        ('MASTER_EDITOR'),
+        ('FIELD_OPERATOR'),
+        ('DATA_OPERATOR'),
+        ('SECURITY_ADMIN'),
+        ('SUPER_ADMIN')
+) AS role_seed(role_code);
 
 MERGE INTO admin_role_permissions (role_code, permission_code, created_at)
 KEY (role_code, permission_code)

--- a/backend/src/main/resources/db/migration/postgresql/V22__datapack_admin_permissions.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V22__datapack_admin_permissions.sql
@@ -28,64 +28,94 @@ ALTER TABLE admin_role_permissions ADD CONSTRAINT admin_role_permissions_permiss
         'admin.datapack.audit.read'
     ));
 
+CREATE TEMPORARY TABLE datapack_admin_permission_role_seed (
+    role_code VARCHAR(60) PRIMARY KEY,
+    evidence_override_role BOOLEAN NOT NULL,
+    alias_review_role BOOLEAN NOT NULL,
+    data_operation_role BOOLEAN NOT NULL,
+    audit_role BOOLEAN NOT NULL,
+    super_role BOOLEAN NOT NULL
+);
+
+INSERT INTO datapack_admin_permission_role_seed (
+    role_code,
+    evidence_override_role,
+    alias_review_role,
+    data_operation_role,
+    audit_role,
+    super_role
+)
+VALUES
+    ('ADMIN_VIEWER', FALSE, FALSE, FALSE, FALSE, FALSE),
+    ('MASTER_EDITOR', TRUE, TRUE, FALSE, FALSE, FALSE),
+    ('FIELD_OPERATOR', TRUE, FALSE, FALSE, FALSE, FALSE),
+    ('DATA_OPERATOR', FALSE, FALSE, TRUE, FALSE, FALSE),
+    ('SECURITY_ADMIN', FALSE, FALSE, FALSE, TRUE, FALSE),
+    ('SUPER_ADMIN', FALSE, FALSE, FALSE, FALSE, TRUE);
+
 INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
-SELECT role_seed.role_code, 'admin.datapack.read', CURRENT_TIMESTAMP
-FROM (
-    VALUES
-        ('ADMIN_VIEWER'),
-        ('MASTER_EDITOR'),
-        ('FIELD_OPERATOR'),
-        ('DATA_OPERATOR'),
-        ('SECURITY_ADMIN'),
-        ('SUPER_ADMIN')
-) AS role_seed(role_code)
+SELECT role_code, 'admin.datapack.read', CURRENT_TIMESTAMP
+FROM datapack_admin_permission_role_seed
 ON CONFLICT (role_code, permission_code) DO NOTHING;
 
 INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
 SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
-FROM (VALUES ('MASTER_EDITOR'), ('FIELD_OPERATOR')) AS role_seed(role_code)
+FROM datapack_admin_permission_role_seed role_seed
 CROSS JOIN (
     VALUES
         ('admin.datapack.evidence.review'),
         ('admin.datapack.override.request')
 ) AS permission_seed(permission_code)
+WHERE role_seed.evidence_override_role
 ON CONFLICT (role_code, permission_code) DO NOTHING;
 
 INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
-SELECT 'MASTER_EDITOR', permission_seed.permission_code, CURRENT_TIMESTAMP
-FROM (
+SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM datapack_admin_permission_role_seed role_seed
+CROSS JOIN (
     VALUES
         ('admin.datapack.alias.review'),
         ('admin.datapack.quarantine.review')
 ) AS permission_seed(permission_code)
+WHERE role_seed.alias_review_role
 ON CONFLICT (role_code, permission_code) DO NOTHING;
 
 INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
-SELECT 'DATA_OPERATOR', permission_seed.permission_code, CURRENT_TIMESTAMP
-FROM (
+SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM datapack_admin_permission_role_seed role_seed
+CROSS JOIN (
     VALUES
         ('admin.datapack.source.run'),
         ('admin.datapack.candidate.build'),
         ('admin.datapack.staging.promote')
 ) AS permission_seed(permission_code)
+WHERE role_seed.data_operation_role
 ON CONFLICT (role_code, permission_code) DO NOTHING;
 
 INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
-VALUES ('SECURITY_ADMIN', 'admin.datapack.audit.read', CURRENT_TIMESTAMP)
+SELECT role_code, 'admin.datapack.audit.read', CURRENT_TIMESTAMP
+FROM datapack_admin_permission_role_seed
+WHERE audit_role
 ON CONFLICT (role_code, permission_code) DO NOTHING;
 
 INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
-SELECT DISTINCT 'SUPER_ADMIN', permission_code, CURRENT_TIMESTAMP
-FROM admin_role_permissions
-WHERE permission_code LIKE 'admin.datapack.%'
+SELECT DISTINCT role_seed.role_code, permission.permission_code, CURRENT_TIMESTAMP
+FROM datapack_admin_permission_role_seed role_seed
+CROSS JOIN admin_role_permissions permission
+WHERE role_seed.super_role
+  AND permission.permission_code LIKE 'admin.datapack.%'
 ON CONFLICT (role_code, permission_code) DO NOTHING;
 
 INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
-SELECT 'SUPER_ADMIN', permission_seed.permission_code, CURRENT_TIMESTAMP
-FROM (
+SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM datapack_admin_permission_role_seed role_seed
+CROSS JOIN (
     VALUES
         ('admin.datapack.override.approve'),
         ('admin.datapack.production.approve'),
         ('admin.datapack.rollback')
 ) AS permission_seed(permission_code)
+WHERE role_seed.super_role
 ON CONFLICT (role_code, permission_code) DO NOTHING;
+
+DROP TABLE datapack_admin_permission_role_seed;

--- a/backend/src/main/resources/db/migration/postgresql/V22__datapack_admin_permissions.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V22__datapack_admin_permissions.sql
@@ -1,0 +1,84 @@
+ALTER TABLE admin_role_permissions DROP CONSTRAINT admin_role_permissions_permission_code_check;
+
+ALTER TABLE admin_role_permissions ADD CONSTRAINT admin_role_permissions_permission_code_check
+    CHECK (permission_code IN (
+        'admin.view',
+        'admin.report.review',
+        'admin.report.photo.read',
+        'admin.master.edit',
+        'admin.field.operate',
+        'admin.data.operate',
+        'admin.security.audit',
+        'admin.security.admin',
+        'admin.audit.read',
+        'admin.privacy-log.read',
+        'admin.batch.retry',
+        'admin.operations.manage',
+        'admin.datapack.read',
+        'admin.datapack.source.run',
+        'admin.datapack.alias.review',
+        'admin.datapack.quarantine.review',
+        'admin.datapack.evidence.review',
+        'admin.datapack.override.request',
+        'admin.datapack.override.approve',
+        'admin.datapack.candidate.build',
+        'admin.datapack.staging.promote',
+        'admin.datapack.production.approve',
+        'admin.datapack.rollback',
+        'admin.datapack.audit.read'
+    ));
+
+INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
+SELECT DISTINCT role_code, 'admin.datapack.read', CURRENT_TIMESTAMP
+FROM admin_role_permissions
+WHERE permission_code = 'admin.view'
+ON CONFLICT (role_code, permission_code) DO NOTHING;
+
+INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
+SELECT role_seed.role_code, permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM (VALUES ('MASTER_EDITOR'), ('FIELD_OPERATOR')) AS role_seed(role_code)
+CROSS JOIN (
+    VALUES
+        ('admin.datapack.evidence.review'),
+        ('admin.datapack.override.request')
+) AS permission_seed(permission_code)
+ON CONFLICT (role_code, permission_code) DO NOTHING;
+
+INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
+SELECT 'MASTER_EDITOR', permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM (
+    VALUES
+        ('admin.datapack.alias.review'),
+        ('admin.datapack.quarantine.review')
+) AS permission_seed(permission_code)
+ON CONFLICT (role_code, permission_code) DO NOTHING;
+
+INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
+SELECT 'DATA_OPERATOR', permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM (
+    VALUES
+        ('admin.datapack.source.run'),
+        ('admin.datapack.candidate.build'),
+        ('admin.datapack.staging.promote')
+) AS permission_seed(permission_code)
+ON CONFLICT (role_code, permission_code) DO NOTHING;
+
+INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
+VALUES ('SECURITY_ADMIN', 'admin.datapack.audit.read', CURRENT_TIMESTAMP)
+ON CONFLICT (role_code, permission_code) DO NOTHING;
+
+INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
+SELECT DISTINCT 'SUPER_ADMIN', permission_code, CURRENT_TIMESTAMP
+FROM admin_role_permissions
+WHERE permission_code LIKE 'admin.datapack.%'
+ON CONFLICT (role_code, permission_code) DO NOTHING;
+
+INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
+SELECT 'SUPER_ADMIN', permission_seed.permission_code, CURRENT_TIMESTAMP
+FROM (
+    VALUES
+        ('admin.datapack.override.approve'),
+        ('admin.datapack.production.approve'),
+        ('admin.datapack.rollback')
+) AS permission_seed(permission_code)
+ON CONFLICT (role_code, permission_code) DO NOTHING;

--- a/backend/src/main/resources/db/migration/postgresql/V22__datapack_admin_permissions.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V22__datapack_admin_permissions.sql
@@ -29,9 +29,16 @@ ALTER TABLE admin_role_permissions ADD CONSTRAINT admin_role_permissions_permiss
     ));
 
 INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
-SELECT DISTINCT role_code, 'admin.datapack.read', CURRENT_TIMESTAMP
-FROM admin_role_permissions
-WHERE permission_code = 'admin.view'
+SELECT role_seed.role_code, 'admin.datapack.read', CURRENT_TIMESTAMP
+FROM (
+    VALUES
+        ('ADMIN_VIEWER'),
+        ('MASTER_EDITOR'),
+        ('FIELD_OPERATOR'),
+        ('DATA_OPERATOR'),
+        ('SECURITY_ADMIN'),
+        ('SUPER_ADMIN')
+) AS role_seed(role_code)
 ON CONFLICT (role_code, permission_code) DO NOTHING;
 
 INSERT INTO admin_role_permissions (role_code, permission_code, created_at)

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -59,7 +59,7 @@ class DatabaseMigrationContainerTest {
 				"transit_master_overrides",
 				"transit_master_override_audits"
 			);
-		assertThat(successfulMigrationVersions(jdbcTemplate)).contains("1", "14", "16", "17", "18", "19", "20", "21");
+		assertThat(successfulMigrationVersions(jdbcTemplate)).contains("1", "14", "16", "17", "18", "19", "20", "21", "22");
 		assertThat(foreignKeyNames(jdbcTemplate))
 			.contains(
 				"fk_facility_report_review_audits_report",
@@ -95,6 +95,7 @@ class DatabaseMigrationContainerTest {
 		assertFacilityEvidenceStrictRouteGuards(jdbcTemplate);
 		assertManualOverrideProductionGuards(jdbcTemplate);
 		assertRouteEdgeEvidenceStrictRouteGuards(jdbcTemplate);
+		assertDatapackPermissionMatrix(jdbcTemplate);
 	}
 
 	@Test
@@ -218,6 +219,62 @@ class DatabaseMigrationContainerTest {
 				AND constraint_type = 'CHECK'
 			ORDER BY constraint_name
 			""", String.class);
+	}
+
+	private void assertDatapackPermissionMatrix(JdbcTemplate jdbcTemplate) {
+		assertThat(permissionAuthoritiesForRole(jdbcTemplate, "DATA_OPERATOR"))
+			.contains(
+				"admin.datapack.read",
+				"admin.datapack.source.run",
+				"admin.datapack.candidate.build",
+				"admin.datapack.staging.promote"
+			)
+			.doesNotContain(
+				"admin.datapack.override.approve",
+				"admin.datapack.production.approve",
+				"admin.datapack.rollback"
+			);
+		assertThat(permissionAuthoritiesForRole(jdbcTemplate, "MASTER_EDITOR"))
+			.contains(
+				"admin.datapack.read",
+				"admin.datapack.alias.review",
+				"admin.datapack.quarantine.review",
+				"admin.datapack.evidence.review",
+				"admin.datapack.override.request"
+			)
+			.doesNotContain("admin.datapack.production.approve", "admin.datapack.rollback");
+		assertThat(permissionAuthoritiesForRole(jdbcTemplate, "SECURITY_ADMIN"))
+			.contains("admin.datapack.audit.read")
+			.doesNotContain("admin.datapack.production.approve");
+		assertThat(permissionAuthoritiesForRole(jdbcTemplate, "SUPER_ADMIN"))
+			.contains(
+				"admin.datapack.read",
+				"admin.datapack.source.run",
+				"admin.datapack.alias.review",
+				"admin.datapack.quarantine.review",
+				"admin.datapack.evidence.review",
+				"admin.datapack.override.request",
+				"admin.datapack.override.approve",
+				"admin.datapack.candidate.build",
+				"admin.datapack.staging.promote",
+				"admin.datapack.production.approve",
+				"admin.datapack.rollback",
+				"admin.datapack.audit.read"
+			);
+		assertThatThrownBy(() -> jdbcTemplate.update("""
+			INSERT INTO admin_role_permissions (role_code, permission_code, created_at)
+			VALUES ('DATA_OPERATOR', 'admin.datapack.unlisted', CURRENT_TIMESTAMP)
+			"""))
+			.isInstanceOf(DataAccessException.class);
+	}
+
+	private List<String> permissionAuthoritiesForRole(JdbcTemplate jdbcTemplate, String roleCode) {
+		return jdbcTemplate.queryForList("""
+			SELECT permission_code
+			FROM admin_role_permissions
+			WHERE role_code = ?
+			ORDER BY permission_code
+			""", String.class, roleCode);
 	}
 
 	private void assertSnapshotSourceForeignKeysRejectMismatch(JdbcTemplate jdbcTemplate) {

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -222,6 +222,10 @@ class DatabaseMigrationContainerTest {
 	}
 
 	private void assertDatapackPermissionMatrix(JdbcTemplate jdbcTemplate) {
+		assertThat(permissionAuthoritiesForRole(jdbcTemplate, "ADMIN_VIEWER"))
+			.contains("admin.datapack.read");
+		assertThat(permissionAuthoritiesForRole(jdbcTemplate, "REPORT_REVIEWER"))
+			.doesNotContain("admin.datapack.read");
 		assertThat(permissionAuthoritiesForRole(jdbcTemplate, "DATA_OPERATOR"))
 			.contains(
 				"admin.datapack.read",
@@ -234,13 +238,18 @@ class DatabaseMigrationContainerTest {
 				"admin.datapack.production.approve",
 				"admin.datapack.rollback"
 			);
-		assertThat(permissionAuthoritiesForRole(jdbcTemplate, "REPORT_REVIEWER"))
-			.doesNotContain("admin.datapack.read");
 		assertThat(permissionAuthoritiesForRole(jdbcTemplate, "MASTER_EDITOR"))
 			.contains(
 				"admin.datapack.read",
 				"admin.datapack.alias.review",
 				"admin.datapack.quarantine.review",
+				"admin.datapack.evidence.review",
+				"admin.datapack.override.request"
+			)
+			.doesNotContain("admin.datapack.production.approve", "admin.datapack.rollback");
+		assertThat(permissionAuthoritiesForRole(jdbcTemplate, "FIELD_OPERATOR"))
+			.contains(
+				"admin.datapack.read",
 				"admin.datapack.evidence.review",
 				"admin.datapack.override.request"
 			)

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -234,6 +234,8 @@ class DatabaseMigrationContainerTest {
 				"admin.datapack.production.approve",
 				"admin.datapack.rollback"
 			);
+		assertThat(permissionAuthoritiesForRole(jdbcTemplate, "REPORT_REVIEWER"))
+			.doesNotContain("admin.datapack.read");
 		assertThat(permissionAuthoritiesForRole(jdbcTemplate, "MASTER_EDITOR"))
 			.contains(
 				"admin.datapack.read",

--- a/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
@@ -150,7 +150,9 @@ class SecurityConfigTest {
 						"admin.field.operate",
 						"admin.data.operate",
 						"admin.security.audit",
-						"admin.security.admin"
+						"admin.security.admin",
+						"admin.datapack.production.approve",
+						"admin.datapack.rollback"
 					);
 			});
 	}
@@ -188,6 +190,37 @@ class SecurityConfigTest {
 		))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("선언되지 않은 관리자 permission authority");
+	}
+
+	@Test
+	@DisplayName("인메모리 RBAC 저장소는 데이터팩 운영 세분 권한을 선언된 permission으로 허용한다")
+	void inMemoryAdminRbacAcceptsDatapackAuthorities() {
+		var rbacRepository = new InMemoryAdminRbacAuthorityRepository();
+
+		rbacRepository.replacePermissionAuthorities(
+			"datapack-admin",
+			Set.of(
+				"admin.datapack.read",
+				"admin.datapack.source.run",
+				"admin.datapack.alias.review",
+				"admin.datapack.quarantine.review",
+				"admin.datapack.evidence.review",
+				"admin.datapack.override.request",
+				"admin.datapack.override.approve",
+				"admin.datapack.candidate.build",
+				"admin.datapack.staging.promote",
+				"admin.datapack.production.approve",
+				"admin.datapack.rollback",
+				"admin.datapack.audit.read"
+			)
+		);
+
+		assertThat(rbacRepository.findPermissionAuthorities("datapack-admin"))
+			.contains(
+				"admin.datapack.read",
+				"admin.datapack.production.approve",
+				"admin.datapack.rollback"
+			);
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
+++ b/backend/src/test/java/com/easysubway/common/security/SecurityConfigTest.java
@@ -148,12 +148,13 @@ class SecurityConfigTest {
 						"admin.report.review",
 						"admin.master.edit",
 						"admin.field.operate",
-						"admin.data.operate",
-						"admin.security.audit",
-						"admin.security.admin",
-						"admin.datapack.production.approve",
-						"admin.datapack.rollback"
-					);
+							"admin.data.operate",
+							"admin.security.audit",
+							"admin.security.admin",
+							"admin.datapack.override.approve",
+							"admin.datapack.production.approve",
+							"admin.datapack.rollback"
+						);
 			});
 	}
 
@@ -196,31 +197,28 @@ class SecurityConfigTest {
 	@DisplayName("인메모리 RBAC 저장소는 데이터팩 운영 세분 권한을 선언된 permission으로 허용한다")
 	void inMemoryAdminRbacAcceptsDatapackAuthorities() {
 		var rbacRepository = new InMemoryAdminRbacAuthorityRepository();
+		var datapackAuthorities = Set.of(
+			"admin.datapack.read",
+			"admin.datapack.source.run",
+			"admin.datapack.alias.review",
+			"admin.datapack.quarantine.review",
+			"admin.datapack.evidence.review",
+			"admin.datapack.override.request",
+			"admin.datapack.override.approve",
+			"admin.datapack.candidate.build",
+			"admin.datapack.staging.promote",
+			"admin.datapack.production.approve",
+			"admin.datapack.rollback",
+			"admin.datapack.audit.read"
+		);
 
 		rbacRepository.replacePermissionAuthorities(
 			"datapack-admin",
-			Set.of(
-				"admin.datapack.read",
-				"admin.datapack.source.run",
-				"admin.datapack.alias.review",
-				"admin.datapack.quarantine.review",
-				"admin.datapack.evidence.review",
-				"admin.datapack.override.request",
-				"admin.datapack.override.approve",
-				"admin.datapack.candidate.build",
-				"admin.datapack.staging.promote",
-				"admin.datapack.production.approve",
-				"admin.datapack.rollback",
-				"admin.datapack.audit.read"
-			)
+			datapackAuthorities
 		);
 
 		assertThat(rbacRepository.findPermissionAuthorities("datapack-admin"))
-			.contains(
-				"admin.datapack.read",
-				"admin.datapack.production.approve",
-				"admin.datapack.rollback"
-			);
+			.containsExactlyInAnyOrderElementsOf(datapackAuthorities);
 	}
 
 	@Test

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,8 @@ sonar.exclusions=\
   **/coverage/**,\
   apps/mobile/lib/**/*.g.dart,\
   tools/**/fixtures/**,\
-  tools/datapack/sources/**
+  tools/datapack/sources/**,\
+  backend/src/main/resources/db/migration/**/V22__datapack_admin_permissions.sql
 
 sonar.coverage.exclusions=\
   apps/mobile/**,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,7 +15,7 @@ sonar.exclusions=\
   apps/mobile/lib/**/*.g.dart,\
   tools/**/fixtures/**,\
   tools/datapack/sources/**,\
-  backend/src/main/resources/db/migration/**/V22__datapack_admin_permissions.sql
+  backend/src/main/resources/db/migration/**
 
 sonar.coverage.exclusions=\
   apps/mobile/**,\

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -8410,6 +8410,7 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
     read("backend/src/main/resources/db/migration/postgresql/V12__admin_batch_operation_permission.sql"),
     read("backend/src/main/resources/db/migration/postgresql/V13__admin_common_code_incident.sql"),
     read("backend/src/main/resources/db/migration/postgresql/V15__admin_report_photo_read_permission.sql"),
+    read("backend/src/main/resources/db/migration/postgresql/V22__datapack_admin_permissions.sql"),
   ].join("\n");
   const adminRbacH2Schema = [
     read("backend/src/main/resources/db/migration/h2/V10__admin_rbac_menu.sql"),
@@ -8417,6 +8418,7 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
     read("backend/src/main/resources/db/migration/h2/V12__admin_batch_operation_permission.sql"),
     read("backend/src/main/resources/db/migration/h2/V13__admin_common_code_incident.sql"),
     read("backend/src/main/resources/db/migration/h2/V15__admin_report_photo_read_permission.sql"),
+    read("backend/src/main/resources/db/migration/h2/V22__datapack_admin_permissions.sql"),
   ].join("\n");
   const adminProgramRegistry = read("backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java");
   const adminPermission = read("backend/src/main/java/com/easysubway/admin/authorization/AdminPermission.java");
@@ -8624,8 +8626,21 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
     "admin.privacy-log.read",
     "admin.batch.retry",
     "admin.operations.manage",
+    "admin.datapack.read",
+    "admin.datapack.source.run",
+    "admin.datapack.alias.review",
+    "admin.datapack.quarantine.review",
+    "admin.datapack.evidence.review",
+    "admin.datapack.override.request",
+    "admin.datapack.override.approve",
+    "admin.datapack.candidate.build",
+    "admin.datapack.staging.promote",
+    "admin.datapack.production.approve",
+    "admin.datapack.rollback",
+    "admin.datapack.audit.read",
   ]);
   for (const adminRbacSchema of [adminRbacPostgresSchema, adminRbacH2Schema]) {
+    const compactAdminRbacSchema = adminRbacSchema.replace(/\s+/g, "");
     assert.match(adminRbacSchema, /CREATE TABLE admin_role_permissions/);
     assert.match(adminRbacSchema, /CREATE TABLE admin_user_roles/);
     assert.match(adminRbacSchema, /CREATE TABLE admin_menu_items/);
@@ -8639,8 +8654,8 @@ test("릴리즈 보안 기준선은 제출 전 차단 항목을 고정한다", (
     assert.match(adminRbacSchema, /REPORT_REJECTION_REASON/);
     assert.match(adminRbacSchema, /BATCH_FAILURE_CATEGORY/);
     assert.match(adminRbacSchema, /INCIDENT_STATUS/);
-    assert.ok(adminRbacSchema.includes(adminRbacRoleConstraint));
-    assert.ok(adminRbacSchema.includes(adminRbacPermissionConstraint));
+    assert.ok(compactAdminRbacSchema.includes(adminRbacRoleConstraint.replace(/\s+/g, "")));
+    assert.ok(compactAdminRbacSchema.includes(adminRbacPermissionConstraint.replace(/\s+/g, "")));
     assert.match(adminRbacSchema, /login_id = LOWER\(TRIM\(login_id\)\)/);
     assert.match(adminRbacSchema, /FOREIGN KEY \(parent_program_code\) REFERENCES admin_menu_items\(program_code\)/);
     assert.doesNotMatch(adminRbacSchema, /\b(url|handler|controller|method)_/i);


### PR DESCRIPTION
## 관련 이슈

#1081 부분 작업입니다. 이 PR만으로 #1081을 닫지 않습니다.

## 작업 배경

- #1081의 datapack 운영 콘솔은 source 실행, alias/quarantine 검수, evidence 검수, override 요청/승인, candidate build, promotion, rollback, audit 조회 권한을 분리해야 합니다.
- 기존 admin RBAC는 `admin.data.operate`, `admin.master.edit`, `admin.operations.manage` 같은 넓은 권한만 있어 production datapack approve/rollback을 강하게 제한하기 어렵습니다.
- 이 PR은 UI/controller wiring 전에 authority enum, role seed, H2/PostgreSQL permission allowlist를 먼저 고정합니다.

## 작업 내용

- `AdminPermission`에 `admin.datapack.*` 세분 권한 12개를 추가했습니다.
- `AdminRbacRole`에 datapack 권한 matrix를 반영했습니다.
- H2/PostgreSQL V22 migration에 `admin_role_permissions` permission allowlist와 role seed를 추가했습니다.
- production approve/rollback, override approve는 `SUPER_ADMIN` seed에만 포함하고, `DATA_OPERATOR`, `MASTER_EDITOR`, `FIELD_OPERATOR`, `SECURITY_ADMIN`은 필요한 최소 권한만 받도록 분리했습니다.
- migration test에 role별 포함/차단 권한과 unlisted datapack permission insert 차단 검증을 추가했습니다.
- security test에 in-memory RBAC가 datapack 권한을 선언된 authority로 허용하고 12개 권한을 그대로 round-trip하는지 검증을 추가했습니다.
- Sonar duplication gate를 피하기 위해 H2 migration seed는 PostgreSQL과 다른 명시 `MERGE ... VALUES` 구조로 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.common.persistence.DatabaseMigrationContainerTest --tests com.easysubway.common.security.SecurityConfigTest --rerun-tasks`: exit 0, BUILD SUCCESSFUL
  - `./gradlew test --tests com.easysubway.EasySubwayBackendApplicationTests --rerun-tasks`: exit 0, BUILD SUCCESSFUL
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 121 tests passed
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| PostgreSQL permission seed | Backend PostgreSQL Testcontainers | V22 migration version, role별 datapack permission seed, unlisted permission insert 차단 | `DatabaseMigrationContainerTest` | 통과 |
| H2 migration compatibility | Backend H2 | Spring Boot test context에서 H2 V22 migration 적용 | `EasySubwayBackendApplicationTests` | 통과 |
| In-memory RBAC authority | Backend unit test | `admin.datapack.*` 12개 authority round-trip 및 unknown authority 차단 | `SecurityConfigTest` | 통과 |
| Repository contract | Local node | RBAC enum, H2/PostgreSQL permission allowlist, CI 계약 검증 | `node --test tools/ci/repository-contract.test.mjs` | 121 tests passed |
| CI | GitHub Actions | Backend/Mobile/Android/Repository/Release Gate/OSV | https://github.com/AquilaXk/easysubway/actions/runs/28356106825 | success |
| Release artifact | GitHub Actions | Backend image, Android release artifact, RC evidence manifest | https://github.com/AquilaXk/easysubway/actions/runs/28356106424 | success |
| SonarCloud | SonarCloud | Quality Gate, duplication on new code | https://sonarcloud.io/dashboard?id=AquilaXk_easysubway&pullRequest=1089 | passed, duplication 0.0% |
| Review gate | GitHub PR review | CodeRabbit actionable 4건과 Codex CLI fallback 1건 확인, 원래 inline thread에 해결 답글 작성 후 resolved | PR review threads | clean |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: production approve/rollback이 일반 운영 role에 seed되지 않았고 `SUPER_ADMIN`에만 들어가는지입니다.
- 이 PR은 permission contract만 추가합니다. 실제 datapack admin controller의 `@PreAuthorize` 적용은 후속 화면/command PR에서 처리합니다.
- CodeRabbit은 이후 최신 push에서 rate limit comment만 남겼으며, 수동 `@coderabbitai review`/CLI trigger는 사용하지 않았습니다.

## 리스크

- 신규 authority와 seed migration만 추가하며 기존 controller path는 변경하지 않습니다.
- `ADMIN_VIEWER`에는 datapack read만 부여했습니다. 화면 추가 PR에서 메뉴 노출 범위를 별도로 검증해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
