### PR TITLE
[Fix] 노선도 탭을 홈 shell 안에서 전환

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1211,6 +1211,7 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
+  int _selectedTabIndex = 0;
   late String _mobilityType;
   late final RouteDraftController _routeDraftController;
   Future<List<FavoriteRoute>>? _recentRoutesFuture;
@@ -1342,6 +1343,15 @@ class _HomeScreenState extends State<HomeScreen> {
       );
     }
 
+    void openHomeTab() {
+      if (_selectedTabIndex == 0) {
+        return;
+      }
+      setState(() {
+        _selectedTabIndex = 0;
+      });
+    }
+
     Future<void> refreshHomeState() async {
       final facilitiesFuture = widget.favoriteFacilityRepository
           ?.listFavoriteFacilities();
@@ -1449,18 +1459,12 @@ class _HomeScreenState extends State<HomeScreen> {
     }
 
     void openNetworkMap() {
-      Navigator.of(context).push(
-        MaterialPageRoute<void>(
-          builder: (_) => NetworkMapScreen(
-            repository: networkMapRepository,
-            routeDraftController: _routeDraftController,
-            onOpenRouteSearch: openRouteSearch,
-            onOpenStationSearch: () => unawaited(openStationSearch()),
-            onOpenSaved: openSavedItems,
-            onOpenSettings: openSettings,
-          ),
-        ),
-      );
+      if (_selectedTabIndex == 1) {
+        return;
+      }
+      setState(() {
+        _selectedTabIndex = 1;
+      });
     }
 
     final heroSection = _HomePrototypeHero(
@@ -1496,6 +1500,75 @@ class _HomeScreenState extends State<HomeScreen> {
       onTap: openRouteSearch,
       onRetry: () => unawaited(refreshHomeState()),
     );
+    final bottomNavigationBar = NavigationBar(
+      key: const Key('homeBottomNavigationBar'),
+      selectedIndex: _selectedTabIndex,
+      height: 72,
+      onDestinationSelected: (index) {
+        switch (index) {
+          case 0:
+            openHomeTab();
+            break;
+          case 1:
+            openNetworkMap();
+            break;
+          case 2:
+            unawaited(openRouteSearch());
+            break;
+          case 3:
+            openSavedItems();
+            break;
+          case 4:
+            openSettings();
+            break;
+        }
+      },
+      destinations: const [
+        NavigationDestination(
+          key: Key('bottomNavHome'),
+          icon: Icon(Icons.home_outlined),
+          selectedIcon: Icon(Icons.home),
+          label: '홈',
+        ),
+        NavigationDestination(
+          key: Key('bottomNavMap'),
+          icon: Icon(Icons.map_outlined),
+          selectedIcon: Icon(Icons.map),
+          label: '노선도',
+        ),
+        NavigationDestination(
+          key: Key('bottomNavRoute'),
+          icon: Icon(Icons.route_outlined),
+          selectedIcon: Icon(Icons.route),
+          label: '길찾기',
+        ),
+        NavigationDestination(
+          key: Key('bottomNavSaved'),
+          icon: Icon(Icons.star_border),
+          selectedIcon: Icon(Icons.star),
+          label: '즐겨찾기',
+        ),
+        NavigationDestination(
+          key: Key('bottomNavMore'),
+          icon: Icon(Icons.more_horiz),
+          selectedIcon: Icon(Icons.more),
+          label: '더보기',
+        ),
+      ],
+    );
+
+    if (_selectedTabIndex == 1) {
+      return NetworkMapScreen(
+        repository: networkMapRepository,
+        routeDraftController: _routeDraftController,
+        onOpenRouteSearch: openRouteSearch,
+        onOpenStationSearch: () => unawaited(openStationSearch()),
+        onOpenSaved: openSavedItems,
+        onOpenSettings: openSettings,
+        onOpenHome: openHomeTab,
+        bottomNavigationBar: bottomNavigationBar,
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(
@@ -1546,61 +1619,7 @@ class _HomeScreenState extends State<HomeScreen> {
           },
         ),
       ),
-      bottomNavigationBar: NavigationBar(
-        key: const Key('homeBottomNavigationBar'),
-        selectedIndex: 0,
-        height: 72,
-        onDestinationSelected: (index) {
-          switch (index) {
-            case 0:
-              break;
-            case 1:
-              openNetworkMap();
-              break;
-            case 2:
-              unawaited(openRouteSearch());
-              break;
-            case 3:
-              openSavedItems();
-              break;
-            case 4:
-              openSettings();
-              break;
-          }
-        },
-        destinations: const [
-          NavigationDestination(
-            key: Key('bottomNavHome'),
-            icon: Icon(Icons.home_outlined),
-            selectedIcon: Icon(Icons.home),
-            label: '홈',
-          ),
-          NavigationDestination(
-            key: Key('bottomNavMap'),
-            icon: Icon(Icons.map_outlined),
-            selectedIcon: Icon(Icons.map),
-            label: '노선도',
-          ),
-          NavigationDestination(
-            key: Key('bottomNavRoute'),
-            icon: Icon(Icons.route_outlined),
-            selectedIcon: Icon(Icons.route),
-            label: '길찾기',
-          ),
-          NavigationDestination(
-            key: Key('bottomNavSaved'),
-            icon: Icon(Icons.star_border),
-            selectedIcon: Icon(Icons.star),
-            label: '즐겨찾기',
-          ),
-          NavigationDestination(
-            key: Key('bottomNavMore'),
-            icon: Icon(Icons.more_horiz),
-            selectedIcon: Icon(Icons.more),
-            label: '더보기',
-          ),
-        ],
-      ),
+      bottomNavigationBar: bottomNavigationBar,
     );
   }
 

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -272,6 +272,8 @@ class NetworkMapScreen extends StatefulWidget {
     required this.onOpenStationSearch,
     required this.onOpenSaved,
     required this.onOpenSettings,
+    this.onOpenHome,
+    this.bottomNavigationBar,
     super.key,
   });
 
@@ -281,6 +283,8 @@ class NetworkMapScreen extends StatefulWidget {
   final VoidCallback onOpenStationSearch;
   final VoidCallback onOpenSaved;
   final VoidCallback onOpenSettings;
+  final VoidCallback? onOpenHome;
+  final Widget? bottomNavigationBar;
 
   @override
   State<NetworkMapScreen> createState() => _NetworkMapScreenState();
@@ -358,38 +362,54 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
           },
         ),
       ),
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: 1,
-        height: 72,
-        onDestinationSelected: (index) {
-          switch (index) {
-            case 0:
-              Navigator.of(context).maybePop();
-              break;
-            case 1:
-              break;
-            case 2:
-              Navigator.of(context).maybePop();
-              widget.onOpenRouteSearch();
-              break;
-            case 3:
-              Navigator.of(context).maybePop();
-              widget.onOpenSaved();
-              break;
-            case 4:
-              Navigator.of(context).maybePop();
-              widget.onOpenSettings();
-              break;
-          }
-        },
-        destinations: const [
-          NavigationDestination(icon: Icon(Icons.home_outlined), label: '홈'),
-          NavigationDestination(icon: Icon(Icons.map), label: '노선도'),
-          NavigationDestination(icon: Icon(Icons.route_outlined), label: '길찾기'),
-          NavigationDestination(icon: Icon(Icons.star_border), label: '즐겨찾기'),
-          NavigationDestination(icon: Icon(Icons.more_horiz), label: '더보기'),
-        ],
-      ),
+      bottomNavigationBar:
+          widget.bottomNavigationBar ??
+          NavigationBar(
+            selectedIndex: 1,
+            height: 72,
+            onDestinationSelected: (index) {
+              switch (index) {
+                case 0:
+                  final onOpenHome = widget.onOpenHome;
+                  if (onOpenHome == null) {
+                    Navigator.of(context).maybePop();
+                  } else {
+                    onOpenHome();
+                  }
+                  break;
+                case 1:
+                  break;
+                case 2:
+                  Navigator.of(context).maybePop();
+                  widget.onOpenRouteSearch();
+                  break;
+                case 3:
+                  Navigator.of(context).maybePop();
+                  widget.onOpenSaved();
+                  break;
+                case 4:
+                  Navigator.of(context).maybePop();
+                  widget.onOpenSettings();
+                  break;
+              }
+            },
+            destinations: const [
+              NavigationDestination(
+                icon: Icon(Icons.home_outlined),
+                label: '홈',
+              ),
+              NavigationDestination(icon: Icon(Icons.map), label: '노선도'),
+              NavigationDestination(
+                icon: Icon(Icons.route_outlined),
+                label: '길찾기',
+              ),
+              NavigationDestination(
+                icon: Icon(Icons.star_border),
+                label: '즐겨찾기',
+              ),
+              NavigationDestination(icon: Icon(Icons.more_horiz), label: '더보기'),
+            ],
+          ),
     );
   }
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -889,6 +889,40 @@ void main() {
     expect(find.byKey(const Key('routeMapViewportRenderer')), findsOneWidget);
   });
 
+  testWidgets('홈 노선도 탭은 같은 shell 안에서 선택 상태를 바꾼다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(
+          networkMapRegionNames: const ['수도권'],
+        ),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('bottomNavMap')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(HomeScreen), findsOneWidget);
+    expect(find.byKey(const Key('networkMapScreen')), findsOneWidget);
+    final navigationBar = tester.widget<NavigationBar>(
+      find.byKey(const Key('homeBottomNavigationBar')),
+    );
+    expect(navigationBar.selectedIndex, 1);
+
+    await tester.tap(find.byKey(const Key('bottomNavHome')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('networkMapScreen')), findsNothing);
+    final homeNavigationBar = tester.widget<NavigationBar>(
+      find.byKey(const Key('homeBottomNavigationBar')),
+    );
+    expect(homeNavigationBar.selectedIndex, 0);
+  });
+
   testWidgets('노선도 지역 메뉴는 선택한 지역으로 지도를 다시 불러온다', (tester) async {
     final repository = FakeStationSearchRepository(
       networkMapRegionNames: const ['테스트권', '부산'],


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- #1075의 하단 탭 상태 보존 문제 중 노선도 탭부터 route push/pop 대신 HomeScreen shell 내부 전환으로 줄인다.
- 전체 탭 구조 재작성이나 go_router 도입은 이번 PR 범위가 아니다.

## 작업 내용

- 홈 하단 노선도 탭을 `Navigator.push` 대신 `_selectedTabIndex` 상태 전환으로 처리했다.
- `NetworkMapScreen`이 Home shell의 `NavigationBar`를 받을 수 있게 해 노선도 화면에서도 선택 상태가 1로 유지되도록 했다.
- 홈↔노선도 탭 전환이 같은 shell 안에서 일어나는지 확인하는 widget regression test를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter analyze`: exit 0, No issues found
  - `flutter test --reporter compact test/widget_test.dart`: exit 0, 177 tests passed
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 121 tests passed
  - `git diff --check`: exit 0
  - GitHub PR checks: CI, Release Artifacts, SonarCloud, CodeRabbit 모두 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 홈→노선도 탭 shell 전환 | Flutter widget test | `flutter test --reporter compact test/widget_test.dart` | `홈 노선도 탭은 같은 shell 안에서 선택 상태를 바꾼다`가 `HomeScreen`, `networkMapScreen`, `homeBottomNavigationBar.selectedIndex` 1→0을 검증 | 통과 |
| 정적 분석 | Flutter analyzer | `flutter analyze` | 로컬 명령 출력 `No issues found` | 통과 |
| 저장소 계약 | Node test | `node --test tools/ci/repository-contract.test.mjs` | 로컬 명령 출력 `121 pass, 0 fail` | 통과 |
| PR 게이트 | GitHub Actions / CodeRabbit | PR #1090 checks와 review thread 확인 | CI, Release Artifacts, SonarCloud, CodeRabbit success / unresolved review thread 0개 | 통과 |
| 화면 증거 | 해당 없음 | 이 PR은 색상/배치 변경 없이 route stack 동작을 shell state로 바꾸는 회귀 수정이며, 선택 상태와 화면 presence를 widget test로 고정했다. #1075 전체 close 전 Android/iOS 접근성 증거는 별도 PR에서 유지한다. | 증거 불필요 사유 기록 | 확인 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `HomeScreen`의 `_selectedTabIndex`, `NetworkMapScreen.bottomNavigationBar` fallback 경로.
- #1075의 전체 하단 탭/접근성 scope를 닫는 PR이 아니라, 노선도 탭 push/pop 문제를 줄이는 좁은 PR이다.

## 리스크

- 길찾기, 즐겨찾기, 더보기 탭은 기존 동작을 유지한다. 해당 탭의 persistent shell 전환은 후속 작업으로 남는다.
- `NetworkMapScreen` 단독 push 진입 경로를 위해 기존 fallback `NavigationBar`와 `maybePop()` 경로는 유지했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. 해당 없음: CodeRabbit이 정상 완료됐다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.