### PR TITLE
[Feat] source snapshot raw evidence guard 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepository.java
@@ -48,7 +48,8 @@ public class JdbcDataSourceSnapshotRepository {
 				SELECT snapshot_id, source_id, provider, retrieved_at, source_updated_at, row_count,
 					raw_sha256, raw_object_uri, redacted_request_fingerprint, schema_fingerprint,
 					snapshot_status, schema_status, license_status, fetch_status, redistribution_allowed,
-					credential_redacted, previous_snapshot_id, diff_summary, freshness_expires_at
+					credential_redacted, previous_snapshot_id, diff_summary, freshness_expires_at,
+					raw_retention_expires_at
 				FROM data_source_snapshots
 				WHERE snapshot_id = ?
 				""", this::mapSnapshot, snapshotId));
@@ -63,9 +64,10 @@ public class JdbcDataSourceSnapshotRepository {
 				snapshot_id, source_id, provider, retrieved_at, source_updated_at, row_count,
 				raw_sha256, raw_object_uri, redacted_request_fingerprint, schema_fingerprint,
 				snapshot_status, schema_status, license_status, fetch_status, redistribution_allowed,
-				credential_redacted, previous_snapshot_id, diff_summary, freshness_expires_at
+				credential_redacted, previous_snapshot_id, diff_summary, freshness_expires_at,
+				raw_retention_expires_at
 			)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			""",
 			snapshot.snapshotId(),
 			snapshot.sourceId(),
@@ -85,7 +87,8 @@ public class JdbcDataSourceSnapshotRepository {
 			snapshot.credentialRedacted(),
 			snapshot.previousSnapshotId(),
 			snapshot.diffSummary(),
-			snapshot.freshnessExpiresAt()
+			snapshot.freshnessExpiresAt(),
+			snapshot.rawRetentionExpiresAt()
 		);
 	}
 
@@ -110,7 +113,8 @@ public class JdbcDataSourceSnapshotRepository {
 			resultSet.getBoolean("credential_redacted"),
 			resultSet.getString("previous_snapshot_id"),
 			resultSet.getString("diff_summary"),
-			resultSet.getTimestamp("freshness_expires_at").toLocalDateTime()
+			resultSet.getTimestamp("freshness_expires_at").toLocalDateTime(),
+			resultSet.getTimestamp("raw_retention_expires_at").toLocalDateTime()
 		);
 	}
 }

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepository.java
@@ -29,6 +29,7 @@ public class JdbcDataSourceSnapshotRepository {
 	}
 
 	public DataSourceSnapshot saveSnapshot(DataSourceSnapshot snapshot) {
+		snapshot.requireRawEvidenceWritePolicy();
 		try {
 			insert(snapshot);
 			return snapshot;

--- a/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
+++ b/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
@@ -100,6 +100,9 @@ public record DataSourceSnapshot(
 		if (!objectStorageScheme
 			|| uri.getRawAuthority() == null
 			|| uri.getRawAuthority().isBlank()
+			|| uri.getRawPath() == null
+			|| uri.getRawPath().isBlank()
+			|| "/".equals(uri.getRawPath())
 			|| uri.getRawQuery() != null
 			|| uri.getRawUserInfo() != null
 			|| uri.getRawFragment() != null) {

--- a/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
+++ b/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
@@ -1,5 +1,7 @@
 package com.easysubway.datapack.domain;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.regex.Pattern;
@@ -84,7 +86,14 @@ public record DataSourceSnapshot(
 
 	private static String requireRawObjectUri(String value) {
 		String trimmed = requireText(value, "rawObjectUri");
-		if ((!trimmed.startsWith("s3://") && !trimmed.startsWith("oci://")) || trimmed.contains("?")) {
+		URI uri;
+		try {
+			uri = new URI(trimmed);
+		} catch (URISyntaxException exception) {
+			throw new InvalidDataSourceSnapshotException("rawObjectUri must be a credential-free object storage URI.");
+		}
+		var objectStorageScheme = "s3".equals(uri.getScheme()) || "oci".equals(uri.getScheme());
+		if (!objectStorageScheme || uri.getRawQuery() != null || uri.getRawUserInfo() != null || uri.getRawFragment() != null) {
 			throw new InvalidDataSourceSnapshotException("rawObjectUri must be a credential-free object storage URI.");
 		}
 		return trimmed;

--- a/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
+++ b/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
@@ -103,6 +103,7 @@ public record DataSourceSnapshot(
 			|| uri.getRawPath() == null
 			|| uri.getRawPath().isBlank()
 			|| "/".equals(uri.getRawPath())
+			|| trimmed.contains("@")
 			|| uri.getRawQuery() != null
 			|| uri.getRawUserInfo() != null
 			|| uri.getRawFragment() != null) {

--- a/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
+++ b/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
@@ -93,7 +93,7 @@ public record DataSourceSnapshot(
 			throw new InvalidDataSourceSnapshotException("rawObjectUri must be a credential-free object storage URI.");
 		}
 		var objectStorageScheme = "s3".equals(uri.getScheme()) || "oci".equals(uri.getScheme());
-		if (!objectStorageScheme || uri.getRawQuery() != null || uri.getRawUserInfo() != null || uri.getRawFragment() != null) {
+		if (!objectStorageScheme || uri.getRawAuthority() == null || uri.getRawAuthority().isBlank() || uri.getRawQuery() != null || uri.getRawUserInfo() != null || uri.getRawFragment() != null) {
 			throw new InvalidDataSourceSnapshotException("rawObjectUri must be a credential-free object storage URI.");
 		}
 		return trimmed;

--- a/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
+++ b/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
@@ -44,7 +44,7 @@ public record DataSourceSnapshot(
 			throw new InvalidDataSourceSnapshotException("rowCount must be zero or positive.");
 		}
 		rawSha256 = requireSha256(rawSha256, "rawSha256");
-		rawObjectUri = requireRawObjectUri(rawObjectUri);
+		rawObjectUri = requireText(rawObjectUri, "rawObjectUri");
 		redactedRequestFingerprint = requireSha256(redactedRequestFingerprint, "redactedRequestFingerprint");
 		schemaFingerprint = requireSha256(schemaFingerprint, "schemaFingerprint");
 		snapshotStatus = requireText(snapshotStatus, "snapshotStatus");
@@ -57,13 +57,17 @@ public record DataSourceSnapshot(
 			throw new InvalidDataSourceSnapshotException("freshnessExpiresAt is required.");
 		}
 		freshnessExpiresAt = normalizeTimestamp(freshnessExpiresAt);
-		if (!credentialRedacted) {
-			throw new InvalidDataSourceSnapshotException("credentialRedacted must be true before storing raw evidence.");
-		}
 		if (rawRetentionExpiresAt == null) {
 			throw new InvalidDataSourceSnapshotException("rawRetentionExpiresAt is required.");
 		}
 		rawRetentionExpiresAt = normalizeTimestamp(rawRetentionExpiresAt);
+	}
+
+	public void requireRawEvidenceWritePolicy() {
+		if (!credentialRedacted) {
+			throw new InvalidDataSourceSnapshotException("credentialRedacted must be true before storing raw evidence.");
+		}
+		requireCredentialFreeRawObjectUri(rawObjectUri);
 		if (!rawRetentionExpiresAt.isAfter(retrievedAt)) {
 			throw new InvalidDataSourceSnapshotException("rawRetentionExpiresAt must be after retrievedAt.");
 		}
@@ -84,7 +88,7 @@ public record DataSourceSnapshot(
 		return trimmed;
 	}
 
-	private static String requireRawObjectUri(String value) {
+	private static void requireCredentialFreeRawObjectUri(String value) {
 		String trimmed = requireText(value, "rawObjectUri");
 		URI uri;
 		try {
@@ -93,10 +97,14 @@ public record DataSourceSnapshot(
 			throw new InvalidDataSourceSnapshotException("rawObjectUri must be a credential-free object storage URI.");
 		}
 		var objectStorageScheme = "s3".equals(uri.getScheme()) || "oci".equals(uri.getScheme());
-		if (!objectStorageScheme || uri.getRawAuthority() == null || uri.getRawAuthority().isBlank() || uri.getRawQuery() != null || uri.getRawUserInfo() != null || uri.getRawFragment() != null) {
+		if (!objectStorageScheme
+			|| uri.getRawAuthority() == null
+			|| uri.getRawAuthority().isBlank()
+			|| uri.getRawQuery() != null
+			|| uri.getRawUserInfo() != null
+			|| uri.getRawFragment() != null) {
 			throw new InvalidDataSourceSnapshotException("rawObjectUri must be a credential-free object storage URI.");
 		}
-		return trimmed;
 	}
 
 	private static String trimToNull(String value) {

--- a/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
+++ b/backend/src/main/java/com/easysubway/datapack/domain/DataSourceSnapshot.java
@@ -23,7 +23,8 @@ public record DataSourceSnapshot(
 	boolean credentialRedacted,
 	String previousSnapshotId,
 	String diffSummary,
-	LocalDateTime freshnessExpiresAt
+	LocalDateTime freshnessExpiresAt,
+	LocalDateTime rawRetentionExpiresAt
 ) {
 
 	private static final Pattern SHA256 = Pattern.compile("[0-9a-f]{64}");
@@ -41,7 +42,7 @@ public record DataSourceSnapshot(
 			throw new InvalidDataSourceSnapshotException("rowCount must be zero or positive.");
 		}
 		rawSha256 = requireSha256(rawSha256, "rawSha256");
-		rawObjectUri = requireText(rawObjectUri, "rawObjectUri");
+		rawObjectUri = requireRawObjectUri(rawObjectUri);
 		redactedRequestFingerprint = requireSha256(redactedRequestFingerprint, "redactedRequestFingerprint");
 		schemaFingerprint = requireSha256(schemaFingerprint, "schemaFingerprint");
 		snapshotStatus = requireText(snapshotStatus, "snapshotStatus");
@@ -54,6 +55,16 @@ public record DataSourceSnapshot(
 			throw new InvalidDataSourceSnapshotException("freshnessExpiresAt is required.");
 		}
 		freshnessExpiresAt = normalizeTimestamp(freshnessExpiresAt);
+		if (!credentialRedacted) {
+			throw new InvalidDataSourceSnapshotException("credentialRedacted must be true before storing raw evidence.");
+		}
+		if (rawRetentionExpiresAt == null) {
+			throw new InvalidDataSourceSnapshotException("rawRetentionExpiresAt is required.");
+		}
+		rawRetentionExpiresAt = normalizeTimestamp(rawRetentionExpiresAt);
+		if (!rawRetentionExpiresAt.isAfter(retrievedAt)) {
+			throw new InvalidDataSourceSnapshotException("rawRetentionExpiresAt must be after retrievedAt.");
+		}
 	}
 
 	private static String requireText(String value, String field) {
@@ -67,6 +78,14 @@ public record DataSourceSnapshot(
 		String trimmed = requireText(value, field);
 		if (!SHA256.matcher(trimmed).matches()) {
 			throw new InvalidDataSourceSnapshotException(field + " must be a lowercase SHA-256 hex value.");
+		}
+		return trimmed;
+	}
+
+	private static String requireRawObjectUri(String value) {
+		String trimmed = requireText(value, "rawObjectUri");
+		if ((!trimmed.startsWith("s3://") && !trimmed.startsWith("oci://")) || trimmed.contains("?")) {
+			throw new InvalidDataSourceSnapshotException("rawObjectUri must be a credential-free object storage URI.");
 		}
 		return trimmed;
 	}

--- a/backend/src/main/resources/db/migration/h2/V23__datapack_source_snapshot_raw_evidence_policy.sql
+++ b/backend/src/main/resources/db/migration/h2/V23__datapack_source_snapshot_raw_evidence_policy.sql
@@ -14,7 +14,7 @@ ALTER TABLE data_source_snapshots
 
 ALTER TABLE data_source_snapshots
 	ADD CONSTRAINT chk_data_source_snapshots_raw_object_uri
-		CHECK ((raw_object_uri LIKE 's3://%' OR raw_object_uri LIKE 'oci://%') AND raw_object_uri NOT LIKE '%?%');
+		CHECK ((raw_object_uri LIKE 's3://%' OR raw_object_uri LIKE 'oci://%') AND raw_object_uri NOT LIKE '%?%' AND raw_object_uri NOT LIKE '%@%' AND raw_object_uri NOT LIKE '%#%');
 
 ALTER TABLE data_source_snapshots
 	ADD CONSTRAINT chk_data_source_snapshots_raw_retention

--- a/backend/src/main/resources/db/migration/h2/V23__datapack_source_snapshot_raw_evidence_policy.sql
+++ b/backend/src/main/resources/db/migration/h2/V23__datapack_source_snapshot_raw_evidence_policy.sql
@@ -14,7 +14,7 @@ ALTER TABLE data_source_snapshots
 
 ALTER TABLE data_source_snapshots
 	ADD CONSTRAINT chk_data_source_snapshots_raw_object_uri
-		CHECK (((raw_object_uri LIKE 's3://_%' AND raw_object_uri NOT LIKE 's3:///%') OR (raw_object_uri LIKE 'oci://_%' AND raw_object_uri NOT LIKE 'oci:///%')) AND raw_object_uri NOT LIKE '%?%' AND raw_object_uri NOT LIKE '%@%' AND raw_object_uri NOT LIKE '%#%');
+		CHECK (((raw_object_uri LIKE 's3://_%/_%' AND raw_object_uri NOT LIKE 's3:///%') OR (raw_object_uri LIKE 'oci://_%/_%' AND raw_object_uri NOT LIKE 'oci:///%')) AND raw_object_uri NOT LIKE '%?%' AND raw_object_uri NOT LIKE '%@%' AND raw_object_uri NOT LIKE '%#%');
 
 ALTER TABLE data_source_snapshots
 	ADD CONSTRAINT chk_data_source_snapshots_raw_retention

--- a/backend/src/main/resources/db/migration/h2/V23__datapack_source_snapshot_raw_evidence_policy.sql
+++ b/backend/src/main/resources/db/migration/h2/V23__datapack_source_snapshot_raw_evidence_policy.sql
@@ -14,7 +14,7 @@ ALTER TABLE data_source_snapshots
 
 ALTER TABLE data_source_snapshots
 	ADD CONSTRAINT chk_data_source_snapshots_raw_object_uri
-		CHECK ((raw_object_uri LIKE 's3://%' OR raw_object_uri LIKE 'oci://%') AND raw_object_uri NOT LIKE '%?%' AND raw_object_uri NOT LIKE '%@%' AND raw_object_uri NOT LIKE '%#%');
+		CHECK (((raw_object_uri LIKE 's3://_%' AND raw_object_uri NOT LIKE 's3:///%') OR (raw_object_uri LIKE 'oci://_%' AND raw_object_uri NOT LIKE 'oci:///%')) AND raw_object_uri NOT LIKE '%?%' AND raw_object_uri NOT LIKE '%@%' AND raw_object_uri NOT LIKE '%#%');
 
 ALTER TABLE data_source_snapshots
 	ADD CONSTRAINT chk_data_source_snapshots_raw_retention

--- a/backend/src/main/resources/db/migration/h2/V23__datapack_source_snapshot_raw_evidence_policy.sql
+++ b/backend/src/main/resources/db/migration/h2/V23__datapack_source_snapshot_raw_evidence_policy.sql
@@ -1,0 +1,21 @@
+ALTER TABLE data_source_snapshots
+	ADD COLUMN raw_retention_expires_at TIMESTAMP;
+
+UPDATE data_source_snapshots
+SET raw_retention_expires_at = freshness_expires_at
+WHERE raw_retention_expires_at IS NULL;
+
+ALTER TABLE data_source_snapshots
+	ALTER COLUMN raw_retention_expires_at SET NOT NULL;
+
+ALTER TABLE data_source_snapshots
+	ADD CONSTRAINT chk_data_source_snapshots_credential_redacted
+		CHECK (credential_redacted = TRUE);
+
+ALTER TABLE data_source_snapshots
+	ADD CONSTRAINT chk_data_source_snapshots_raw_object_uri
+		CHECK ((raw_object_uri LIKE 's3://%' OR raw_object_uri LIKE 'oci://%') AND raw_object_uri NOT LIKE '%?%');
+
+ALTER TABLE data_source_snapshots
+	ADD CONSTRAINT chk_data_source_snapshots_raw_retention
+		CHECK (raw_retention_expires_at > retrieved_at);

--- a/backend/src/main/resources/db/migration/postgresql/V23__datapack_source_snapshot_raw_evidence_policy.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V23__datapack_source_snapshot_raw_evidence_policy.sql
@@ -10,8 +10,8 @@ ALTER TABLE data_source_snapshots
 
 ALTER TABLE data_source_snapshots
 	ADD CONSTRAINT chk_data_source_snapshots_credential_redacted
-		CHECK (credential_redacted = TRUE),
+		CHECK (credential_redacted = TRUE) NOT VALID,
 	ADD CONSTRAINT chk_data_source_snapshots_raw_object_uri
-		CHECK ((raw_object_uri LIKE 's3://%' OR raw_object_uri LIKE 'oci://%') AND POSITION('?' IN raw_object_uri) = 0 AND POSITION('@' IN raw_object_uri) = 0 AND POSITION('#' IN raw_object_uri) = 0),
+		CHECK ((raw_object_uri LIKE 's3://%' OR raw_object_uri LIKE 'oci://%') AND POSITION('?' IN raw_object_uri) = 0 AND POSITION('@' IN raw_object_uri) = 0 AND POSITION('#' IN raw_object_uri) = 0) NOT VALID,
 	ADD CONSTRAINT chk_data_source_snapshots_raw_retention
-		CHECK (raw_retention_expires_at > retrieved_at);
+		CHECK (raw_retention_expires_at > retrieved_at) NOT VALID;

--- a/backend/src/main/resources/db/migration/postgresql/V23__datapack_source_snapshot_raw_evidence_policy.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V23__datapack_source_snapshot_raw_evidence_policy.sql
@@ -12,6 +12,6 @@ ALTER TABLE data_source_snapshots
 	ADD CONSTRAINT chk_data_source_snapshots_credential_redacted
 		CHECK (credential_redacted = TRUE) NOT VALID,
 	ADD CONSTRAINT chk_data_source_snapshots_raw_object_uri
-		CHECK (((raw_object_uri LIKE 's3://_%' AND raw_object_uri NOT LIKE 's3:///%') OR (raw_object_uri LIKE 'oci://_%' AND raw_object_uri NOT LIKE 'oci:///%')) AND POSITION('?' IN raw_object_uri) = 0 AND POSITION('@' IN raw_object_uri) = 0 AND POSITION('#' IN raw_object_uri) = 0) NOT VALID,
+		CHECK (((raw_object_uri LIKE 's3://_%/_%' AND raw_object_uri NOT LIKE 's3:///%') OR (raw_object_uri LIKE 'oci://_%/_%' AND raw_object_uri NOT LIKE 'oci:///%')) AND POSITION('?' IN raw_object_uri) = 0 AND POSITION('@' IN raw_object_uri) = 0 AND POSITION('#' IN raw_object_uri) = 0) NOT VALID,
 	ADD CONSTRAINT chk_data_source_snapshots_raw_retention
 		CHECK (raw_retention_expires_at > retrieved_at) NOT VALID;

--- a/backend/src/main/resources/db/migration/postgresql/V23__datapack_source_snapshot_raw_evidence_policy.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V23__datapack_source_snapshot_raw_evidence_policy.sql
@@ -1,0 +1,17 @@
+ALTER TABLE data_source_snapshots
+	ADD COLUMN raw_retention_expires_at TIMESTAMP;
+
+UPDATE data_source_snapshots
+SET raw_retention_expires_at = freshness_expires_at
+WHERE raw_retention_expires_at IS NULL;
+
+ALTER TABLE data_source_snapshots
+	ALTER COLUMN raw_retention_expires_at SET NOT NULL;
+
+ALTER TABLE data_source_snapshots
+	ADD CONSTRAINT chk_data_source_snapshots_credential_redacted
+		CHECK (credential_redacted = TRUE),
+	ADD CONSTRAINT chk_data_source_snapshots_raw_object_uri
+		CHECK ((raw_object_uri LIKE 's3://%' OR raw_object_uri LIKE 'oci://%') AND POSITION('?' IN raw_object_uri) = 0),
+	ADD CONSTRAINT chk_data_source_snapshots_raw_retention
+		CHECK (raw_retention_expires_at > retrieved_at);

--- a/backend/src/main/resources/db/migration/postgresql/V23__datapack_source_snapshot_raw_evidence_policy.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V23__datapack_source_snapshot_raw_evidence_policy.sql
@@ -12,6 +12,6 @@ ALTER TABLE data_source_snapshots
 	ADD CONSTRAINT chk_data_source_snapshots_credential_redacted
 		CHECK (credential_redacted = TRUE),
 	ADD CONSTRAINT chk_data_source_snapshots_raw_object_uri
-		CHECK ((raw_object_uri LIKE 's3://%' OR raw_object_uri LIKE 'oci://%') AND POSITION('?' IN raw_object_uri) = 0),
+		CHECK ((raw_object_uri LIKE 's3://%' OR raw_object_uri LIKE 'oci://%') AND POSITION('?' IN raw_object_uri) = 0 AND POSITION('@' IN raw_object_uri) = 0 AND POSITION('#' IN raw_object_uri) = 0),
 	ADD CONSTRAINT chk_data_source_snapshots_raw_retention
 		CHECK (raw_retention_expires_at > retrieved_at);

--- a/backend/src/main/resources/db/migration/postgresql/V23__datapack_source_snapshot_raw_evidence_policy.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V23__datapack_source_snapshot_raw_evidence_policy.sql
@@ -12,6 +12,6 @@ ALTER TABLE data_source_snapshots
 	ADD CONSTRAINT chk_data_source_snapshots_credential_redacted
 		CHECK (credential_redacted = TRUE) NOT VALID,
 	ADD CONSTRAINT chk_data_source_snapshots_raw_object_uri
-		CHECK ((raw_object_uri LIKE 's3://%' OR raw_object_uri LIKE 'oci://%') AND POSITION('?' IN raw_object_uri) = 0 AND POSITION('@' IN raw_object_uri) = 0 AND POSITION('#' IN raw_object_uri) = 0) NOT VALID,
+		CHECK (((raw_object_uri LIKE 's3://_%' AND raw_object_uri NOT LIKE 's3:///%') OR (raw_object_uri LIKE 'oci://_%' AND raw_object_uri NOT LIKE 'oci:///%')) AND POSITION('?' IN raw_object_uri) = 0 AND POSITION('@' IN raw_object_uri) = 0 AND POSITION('#' IN raw_object_uri) = 0) NOT VALID,
 	ADD CONSTRAINT chk_data_source_snapshots_raw_retention
 		CHECK (raw_retention_expires_at > retrieved_at) NOT VALID;

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -59,7 +59,7 @@ class DatabaseMigrationContainerTest {
 				"transit_master_overrides",
 				"transit_master_override_audits"
 			);
-		assertThat(successfulMigrationVersions(jdbcTemplate)).contains("1", "14", "16", "17", "18", "19", "20", "21", "22");
+		assertThat(successfulMigrationVersions(jdbcTemplate)).contains("1", "14", "16", "17", "18", "19", "20", "21", "22", "23");
 		assertThat(foreignKeyNames(jdbcTemplate))
 			.contains(
 				"fk_facility_report_review_audits_report",
@@ -84,14 +84,18 @@ class DatabaseMigrationContainerTest {
 				"chk_external_alias_approvals_approved_state",
 				"chk_source_quarantine_records_resolution_state",
 				"chk_source_quarantine_resolutions_status",
+				"chk_data_source_snapshots_credential_redacted",
+				"chk_data_source_snapshots_raw_object_uri",
+				"chk_data_source_snapshots_raw_retention",
 				"chk_facility_evidence_strict_route",
 				"chk_manual_overrides_approval_state",
 				"chk_manual_overrides_effective_window",
 				"chk_manual_overrides_route_safety",
 				"chk_route_edge_evidence_strict_route"
-			);
+		);
 		assertNormalizationRunGuards(jdbcTemplate);
 		assertSnapshotSourceForeignKeysRejectMismatch(jdbcTemplate);
+		assertSnapshotRawEvidencePolicyGuards(jdbcTemplate);
 		assertFacilityEvidenceStrictRouteGuards(jdbcTemplate);
 		assertManualOverrideProductionGuards(jdbcTemplate);
 		assertRouteEdgeEvidenceStrictRouteGuards(jdbcTemplate);
@@ -113,6 +117,23 @@ class DatabaseMigrationContainerTest {
 			.migrate();
 
 		assertSnapshotSourceForeignKeysRejectMismatch(new JdbcTemplate(dataSource));
+	}
+
+	@Test
+	@DisplayName("H2 migration도 source snapshot raw evidence policy를 차단한다")
+	void h2MigrationRejectsUnsafeSourceSnapshotEvidence() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:datapack-source-snapshot-evidence;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		Flyway.configure()
+			.dataSource(dataSource)
+			.locations("classpath:db/migration/h2")
+			.load()
+			.migrate();
+
+		assertSnapshotRawEvidencePolicyGuards(new JdbcTemplate(dataSource));
 	}
 
 	@Test
@@ -305,10 +326,11 @@ class DatabaseMigrationContainerTest {
 				raw_sha256, raw_object_uri, redacted_request_fingerprint, schema_fingerprint,
 				snapshot_status, schema_status, license_status, fetch_status,
 				redistribution_allowed, credential_redacted, previous_snapshot_id,
-				diff_summary, freshness_expires_at
+				diff_summary, freshness_expires_at, raw_retention_expires_at
 			)
 			VALUES (?, ?, 'KRIC', '2026-06-29 00:00:00', NULL, 1, ?, ?, ?, ?,
-				'LOCKED', 'PASS', 'PASS', 'SUCCESS', TRUE, TRUE, NULL, NULL, '2026-07-06 00:00:00')
+				'LOCKED', 'PASS', 'PASS', 'SUCCESS', TRUE, TRUE, NULL, NULL,
+				'2026-07-06 00:00:00', '2026-09-29 00:00:00')
 			""",
 			snapshotId,
 			sourceId,
@@ -316,6 +338,64 @@ class DatabaseMigrationContainerTest {
 			"s3://evidence/" + snapshotId,
 			"b".repeat(64),
 			"c".repeat(64)
+		);
+	}
+
+	private void assertSnapshotRawEvidencePolicyGuards(JdbcTemplate jdbcTemplate) {
+		insertSnapshot(jdbcTemplate, "snapshot-raw-policy-ok", "source-raw-policy");
+
+		assertThatThrownBy(() -> insertSnapshotEvidencePolicyCase(
+			jdbcTemplate,
+			"snapshot-raw-policy-unredacted",
+			"s3://evidence/snapshot-raw-policy-unredacted.json",
+			false,
+			"2026-07-06 00:00:00"
+		))
+			.isInstanceOf(DataAccessException.class);
+		assertThatThrownBy(() -> insertSnapshotEvidencePolicyCase(
+			jdbcTemplate,
+			"snapshot-raw-policy-secret-uri",
+			"s3://evidence/snapshot-raw-policy-secret-uri.json?serviceKey=secret",
+			true,
+			"2026-07-06 00:00:00"
+		))
+			.isInstanceOf(DataAccessException.class);
+		assertThatThrownBy(() -> insertSnapshotEvidencePolicyCase(
+			jdbcTemplate,
+			"snapshot-raw-policy-expired-retention",
+			"s3://evidence/snapshot-raw-policy-expired-retention.json",
+			true,
+			"2026-06-28 00:00:00"
+		))
+			.isInstanceOf(DataAccessException.class);
+	}
+
+	private void insertSnapshotEvidencePolicyCase(
+		JdbcTemplate jdbcTemplate,
+		String snapshotId,
+		String rawObjectUri,
+		boolean credentialRedacted,
+		String rawRetentionExpiresAt
+	) {
+		jdbcTemplate.update("""
+			INSERT INTO data_source_snapshots (
+				snapshot_id, source_id, provider, retrieved_at, source_updated_at, row_count,
+				raw_sha256, raw_object_uri, redacted_request_fingerprint, schema_fingerprint,
+				snapshot_status, schema_status, license_status, fetch_status,
+				redistribution_allowed, credential_redacted, previous_snapshot_id,
+				diff_summary, freshness_expires_at, raw_retention_expires_at
+			)
+			VALUES (?, 'source-raw-policy', 'KRIC', '2026-06-29 00:00:00', NULL, 1,
+				?, ?, ?, ?, 'LOCKED', 'PASS', 'PASS', 'SUCCESS',
+				TRUE, ?, NULL, NULL, '2026-07-06 00:00:00', ?)
+			""",
+			snapshotId,
+			"a".repeat(64),
+			rawObjectUri,
+			"b".repeat(64),
+			"c".repeat(64),
+			credentialRedacted,
+			Timestamp.valueOf(rawRetentionExpiresAt)
 		);
 	}
 

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -406,6 +406,14 @@ class DatabaseMigrationContainerTest {
 			.isInstanceOf(DataAccessException.class);
 		assertThatThrownBy(() -> insertSnapshotEvidencePolicyCase(
 			jdbcTemplate,
+			"snapshot-raw-policy-bucket-only-uri",
+			"s3://evidence",
+			true,
+			"2026-07-06 00:00:00"
+		))
+			.isInstanceOf(DataAccessException.class);
+		assertThatThrownBy(() -> insertSnapshotEvidencePolicyCase(
+			jdbcTemplate,
 			"snapshot-raw-policy-expired-retention",
 			"s3://evidence/snapshot-raw-policy-expired-retention.json",
 			true,

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -390,6 +390,14 @@ class DatabaseMigrationContainerTest {
 			.isInstanceOf(DataAccessException.class);
 		assertThatThrownBy(() -> insertSnapshotEvidencePolicyCase(
 			jdbcTemplate,
+			"snapshot-raw-policy-object-key-at-uri",
+			"s3://evidence/raw/provider@example.json",
+			true,
+			"2026-07-06 00:00:00"
+		))
+			.isInstanceOf(DataAccessException.class);
+		assertThatThrownBy(() -> insertSnapshotEvidencePolicyCase(
+			jdbcTemplate,
 			"snapshot-raw-policy-fragment-uri",
 			"oci://evidence/snapshot-raw-policy-fragment-uri.json#token=secret",
 			true,

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -96,6 +96,7 @@ class DatabaseMigrationContainerTest {
 		assertNormalizationRunGuards(jdbcTemplate);
 		assertSnapshotSourceForeignKeysRejectMismatch(jdbcTemplate);
 		assertSnapshotRawEvidencePolicyGuards(jdbcTemplate);
+		assertPostgresqlSnapshotRawEvidenceConstraintsAreStaged(jdbcTemplate);
 		assertFacilityEvidenceStrictRouteGuards(jdbcTemplate);
 		assertManualOverrideProductionGuards(jdbcTemplate);
 		assertRouteEdgeEvidenceStrictRouteGuards(jdbcTemplate);
@@ -240,6 +241,25 @@ class DatabaseMigrationContainerTest {
 				AND constraint_type = 'CHECK'
 			ORDER BY constraint_name
 			""", String.class);
+	}
+
+	private void assertPostgresqlSnapshotRawEvidenceConstraintsAreStaged(JdbcTemplate jdbcTemplate) {
+		assertThat(jdbcTemplate.queryForList("""
+			SELECT conname
+			FROM pg_constraint
+			WHERE conname IN (
+				'chk_data_source_snapshots_credential_redacted',
+				'chk_data_source_snapshots_raw_object_uri',
+				'chk_data_source_snapshots_raw_retention'
+			)
+				AND convalidated = false
+			ORDER BY conname
+			""", String.class))
+			.containsExactly(
+				"chk_data_source_snapshots_credential_redacted",
+				"chk_data_source_snapshots_raw_object_uri",
+				"chk_data_source_snapshots_raw_retention"
+			);
 	}
 
 	private void assertDatapackPermissionMatrix(JdbcTemplate jdbcTemplate) {

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -398,6 +398,14 @@ class DatabaseMigrationContainerTest {
 			.isInstanceOf(DataAccessException.class);
 		assertThatThrownBy(() -> insertSnapshotEvidencePolicyCase(
 			jdbcTemplate,
+			"snapshot-raw-policy-empty-bucket-uri",
+			"s3:///snapshot-raw-policy-empty-bucket-uri.json",
+			true,
+			"2026-07-06 00:00:00"
+		))
+			.isInstanceOf(DataAccessException.class);
+		assertThatThrownBy(() -> insertSnapshotEvidencePolicyCase(
+			jdbcTemplate,
 			"snapshot-raw-policy-expired-retention",
 			"s3://evidence/snapshot-raw-policy-expired-retention.json",
 			true,

--- a/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
+++ b/backend/src/test/java/com/easysubway/common/persistence/DatabaseMigrationContainerTest.java
@@ -92,7 +92,7 @@ class DatabaseMigrationContainerTest {
 				"chk_manual_overrides_effective_window",
 				"chk_manual_overrides_route_safety",
 				"chk_route_edge_evidence_strict_route"
-		);
+			);
 		assertNormalizationRunGuards(jdbcTemplate);
 		assertSnapshotSourceForeignKeysRejectMismatch(jdbcTemplate);
 		assertSnapshotRawEvidencePolicyGuards(jdbcTemplate);
@@ -356,6 +356,22 @@ class DatabaseMigrationContainerTest {
 			jdbcTemplate,
 			"snapshot-raw-policy-secret-uri",
 			"s3://evidence/snapshot-raw-policy-secret-uri.json?serviceKey=secret",
+			true,
+			"2026-07-06 00:00:00"
+		))
+			.isInstanceOf(DataAccessException.class);
+		assertThatThrownBy(() -> insertSnapshotEvidencePolicyCase(
+			jdbcTemplate,
+			"snapshot-raw-policy-userinfo-uri",
+			"s3://access:secret@evidence/snapshot-raw-policy-userinfo-uri.json",
+			true,
+			"2026-07-06 00:00:00"
+		))
+			.isInstanceOf(DataAccessException.class);
+		assertThatThrownBy(() -> insertSnapshotEvidencePolicyCase(
+			jdbcTemplate,
+			"snapshot-raw-policy-fragment-uri",
+			"oci://evidence/snapshot-raw-policy-fragment-uri.json#token=secret",
 			true,
 			"2026-07-06 00:00:00"
 		))

--- a/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
@@ -116,6 +116,15 @@ class JdbcDataSourceSnapshotRepositoryTest {
 			.isInstanceOf(InvalidDataSourceSnapshotException.class)
 			.hasMessageContaining("rawObjectUri");
 		assertThatThrownBy(() -> repository.saveSnapshot(lockedSnapshot(
+			"snapshot-uri-object-key-at",
+			"a".repeat(64),
+			13,
+			"s3://easysubway-datapack-sources/kric-station-elevator/provider@example.json",
+			true
+		)))
+			.isInstanceOf(InvalidDataSourceSnapshotException.class)
+			.hasMessageContaining("rawObjectUri");
+		assertThatThrownBy(() -> repository.saveSnapshot(lockedSnapshot(
 			"snapshot-uri-fragment",
 			"a".repeat(64),
 			13,

--- a/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
@@ -123,6 +123,15 @@ class JdbcDataSourceSnapshotRepositoryTest {
 		))
 			.isInstanceOf(InvalidDataSourceSnapshotException.class)
 			.hasMessageContaining("rawObjectUri");
+		assertThatThrownBy(() -> lockedSnapshot(
+			"snapshot-uri-empty-bucket",
+			"a".repeat(64),
+			13,
+			"s3:///kric-station-elevator/snapshot-uri-empty-bucket.json",
+			true
+		))
+			.isInstanceOf(InvalidDataSourceSnapshotException.class)
+			.hasMessageContaining("rawObjectUri");
 	}
 
 	private DataSourceSnapshot lockedSnapshot(String snapshotId, String rawSha256, int rowCount) {

--- a/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
@@ -133,6 +133,15 @@ class JdbcDataSourceSnapshotRepositoryTest {
 		)))
 			.isInstanceOf(InvalidDataSourceSnapshotException.class)
 			.hasMessageContaining("rawObjectUri");
+		assertThatThrownBy(() -> repository.saveSnapshot(lockedSnapshot(
+			"snapshot-uri-bucket-only",
+			"a".repeat(64),
+			13,
+			"s3://easysubway-datapack-sources",
+			true
+		)))
+			.isInstanceOf(InvalidDataSourceSnapshotException.class)
+			.hasMessageContaining("rawObjectUri");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
@@ -46,7 +46,8 @@ class JdbcDataSourceSnapshotRepositoryTest {
 				credential_redacted BOOLEAN NOT NULL,
 				previous_snapshot_id VARCHAR(120),
 				diff_summary VARCHAR(1000),
-				freshness_expires_at TIMESTAMP NOT NULL
+				freshness_expires_at TIMESTAMP NOT NULL,
+				raw_retention_expires_at TIMESTAMP NOT NULL
 			)
 			""");
 		repository = new JdbcDataSourceSnapshotRepository(jdbcTemplate);
@@ -83,7 +84,46 @@ class JdbcDataSourceSnapshotRepositoryTest {
 		assertThat(repository.saveSnapshot(snapshot)).isEqualTo(snapshot);
 	}
 
+	@Test
+	@DisplayName("raw evidence는 credential redaction과 credential 없는 object URI가 필요하다")
+	void rawEvidenceRequiresRedactedCredentialAndObjectUri() {
+		assertThatThrownBy(() -> lockedSnapshot(
+			"snapshot-unredacted",
+			"a".repeat(64),
+			13,
+			"s3://easysubway-datapack-sources/kric-station-elevator/snapshot-unredacted.json",
+			false
+		))
+			.isInstanceOf(InvalidDataSourceSnapshotException.class)
+			.hasMessageContaining("credentialRedacted");
+		assertThatThrownBy(() -> lockedSnapshot(
+			"snapshot-uri-secret",
+			"a".repeat(64),
+			13,
+			"s3://easysubway-datapack-sources/kric-station-elevator/snapshot-uri-secret.json?serviceKey=secret",
+			true
+		))
+			.isInstanceOf(InvalidDataSourceSnapshotException.class)
+			.hasMessageContaining("rawObjectUri");
+	}
+
 	private DataSourceSnapshot lockedSnapshot(String snapshotId, String rawSha256, int rowCount) {
+		return lockedSnapshot(
+			snapshotId,
+			rawSha256,
+			rowCount,
+			"s3://easysubway-datapack-sources/kric-station-elevator/%s.json".formatted(snapshotId),
+			true
+		);
+	}
+
+	private DataSourceSnapshot lockedSnapshot(
+		String snapshotId,
+		String rawSha256,
+		int rowCount,
+		String rawObjectUri,
+		boolean credentialRedacted
+	) {
 		return new DataSourceSnapshot(
 			snapshotId,
 			"kric-station-elevator",
@@ -92,7 +132,7 @@ class JdbcDataSourceSnapshotRepositoryTest {
 			LocalDateTime.of(2026, 6, 28, 0, 0, 0, 987654321),
 			rowCount,
 			rawSha256,
-			"s3://easysubway-datapack-sources/kric-station-elevator/%s.json".formatted(snapshotId),
+			rawObjectUri,
 			"c".repeat(64),
 			"d".repeat(64),
 			"LOCKED",
@@ -100,10 +140,11 @@ class JdbcDataSourceSnapshotRepositoryTest {
 			"PASS",
 			"SUCCESS",
 			true,
-			true,
+			credentialRedacted,
 			null,
 			"initial snapshot",
-			LocalDateTime.of(2026, 7, 6, 3, 0, 0, 555555555)
+			LocalDateTime.of(2026, 7, 6, 3, 0, 0, 555555555),
+			LocalDateTime.of(2026, 9, 29, 3, 0, 0, 555555555)
 		);
 	}
 }

--- a/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
 class JdbcDataSourceSnapshotRepositoryTest {
 
 	private JdbcDataSourceSnapshotRepository repository;
+	private JdbcTemplate jdbcTemplate;
 
 	@BeforeEach
 	void setUp() {
@@ -24,7 +25,7 @@ class JdbcDataSourceSnapshotRepositoryTest {
 			"sa",
 			""
 		);
-		var jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate = new JdbcTemplate(dataSource);
 		jdbcTemplate.execute("DROP TABLE IF EXISTS data_source_snapshots");
 		jdbcTemplate.execute("""
 			CREATE TABLE data_source_snapshots (
@@ -87,51 +88,84 @@ class JdbcDataSourceSnapshotRepositoryTest {
 	@Test
 	@DisplayName("raw evidence는 credential redaction과 credential 없는 object URI가 필요하다")
 	void rawEvidenceRequiresRedactedCredentialAndObjectUri() {
-		assertThatThrownBy(() -> lockedSnapshot(
+		assertThatThrownBy(() -> repository.saveSnapshot(lockedSnapshot(
 			"snapshot-unredacted",
 			"a".repeat(64),
 			13,
 			"s3://easysubway-datapack-sources/kric-station-elevator/snapshot-unredacted.json",
 			false
-		))
+		)))
 			.isInstanceOf(InvalidDataSourceSnapshotException.class)
 			.hasMessageContaining("credentialRedacted");
-		assertThatThrownBy(() -> lockedSnapshot(
+		assertThatThrownBy(() -> repository.saveSnapshot(lockedSnapshot(
 			"snapshot-uri-secret",
 			"a".repeat(64),
 			13,
 			"s3://easysubway-datapack-sources/kric-station-elevator/snapshot-uri-secret.json?serviceKey=secret",
 			true
-		))
+		)))
 			.isInstanceOf(InvalidDataSourceSnapshotException.class)
 			.hasMessageContaining("rawObjectUri");
-		assertThatThrownBy(() -> lockedSnapshot(
+		assertThatThrownBy(() -> repository.saveSnapshot(lockedSnapshot(
 			"snapshot-uri-userinfo",
 			"a".repeat(64),
 			13,
 			"s3://access:secret@easysubway-datapack-sources/kric-station-elevator/snapshot-uri-userinfo.json",
 			true
-		))
+		)))
 			.isInstanceOf(InvalidDataSourceSnapshotException.class)
 			.hasMessageContaining("rawObjectUri");
-		assertThatThrownBy(() -> lockedSnapshot(
+		assertThatThrownBy(() -> repository.saveSnapshot(lockedSnapshot(
 			"snapshot-uri-fragment",
 			"a".repeat(64),
 			13,
 			"oci://easysubway-datapack-sources/kric-station-elevator/snapshot-uri-fragment.json#token=secret",
 			true
-		))
+		)))
 			.isInstanceOf(InvalidDataSourceSnapshotException.class)
 			.hasMessageContaining("rawObjectUri");
-		assertThatThrownBy(() -> lockedSnapshot(
+		assertThatThrownBy(() -> repository.saveSnapshot(lockedSnapshot(
 			"snapshot-uri-empty-bucket",
 			"a".repeat(64),
 			13,
 			"s3:///kric-station-elevator/snapshot-uri-empty-bucket.json",
 			true
-		))
+		)))
 			.isInstanceOf(InvalidDataSourceSnapshotException.class)
 			.hasMessageContaining("rawObjectUri");
+	}
+
+	@Test
+	@DisplayName("staged constraint cleanup 전 legacy snapshot row도 조회할 수 있다")
+	void loadSnapshotAllowsLegacyRowsBeforeConstraintValidation() {
+		insertLegacyUnsafeSnapshot();
+
+		var snapshot = repository.loadSnapshot("snapshot-legacy-unsafe");
+
+		assertThat(snapshot).isPresent();
+		assertThat(snapshot.get().credentialRedacted()).isFalse();
+		assertThat(snapshot.get().rawObjectUri()).isEqualTo("s3:///legacy-unsafe.json");
+		assertThat(snapshot.get().rawRetentionExpiresAt()).isEqualTo(snapshot.get().retrievedAt());
+	}
+
+	private void insertLegacyUnsafeSnapshot() {
+		jdbcTemplate.update("""
+			INSERT INTO data_source_snapshots (
+				snapshot_id, source_id, provider, retrieved_at, source_updated_at, row_count,
+				raw_sha256, raw_object_uri, redacted_request_fingerprint, schema_fingerprint,
+				snapshot_status, schema_status, license_status, fetch_status, redistribution_allowed,
+				credential_redacted, previous_snapshot_id, diff_summary, freshness_expires_at,
+				raw_retention_expires_at
+			)
+			VALUES ('snapshot-legacy-unsafe', 'kric-station-elevator', '국가철도공단',
+				'2026-06-29 03:00:00', NULL, 13, ?, 's3:///legacy-unsafe.json', ?, ?,
+				'LOCKED', 'PASS', 'PASS', 'SUCCESS', TRUE, FALSE, NULL, 'legacy unsafe row',
+				'2026-07-06 03:00:00', '2026-06-29 03:00:00')
+			""",
+			"a".repeat(64),
+			"c".repeat(64),
+			"d".repeat(64)
+		);
 	}
 
 	private DataSourceSnapshot lockedSnapshot(String snapshotId, String rawSha256, int rowCount) {

--- a/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepositoryTest.java
@@ -105,6 +105,24 @@ class JdbcDataSourceSnapshotRepositoryTest {
 		))
 			.isInstanceOf(InvalidDataSourceSnapshotException.class)
 			.hasMessageContaining("rawObjectUri");
+		assertThatThrownBy(() -> lockedSnapshot(
+			"snapshot-uri-userinfo",
+			"a".repeat(64),
+			13,
+			"s3://access:secret@easysubway-datapack-sources/kric-station-elevator/snapshot-uri-userinfo.json",
+			true
+		))
+			.isInstanceOf(InvalidDataSourceSnapshotException.class)
+			.hasMessageContaining("rawObjectUri");
+		assertThatThrownBy(() -> lockedSnapshot(
+			"snapshot-uri-fragment",
+			"a".repeat(64),
+			13,
+			"oci://easysubway-datapack-sources/kric-station-elevator/snapshot-uri-fragment.json#token=secret",
+			true
+		))
+			.isInstanceOf(InvalidDataSourceSnapshotException.class)
+			.hasMessageContaining("rawObjectUri");
 	}
 
 	private DataSourceSnapshot lockedSnapshot(String snapshotId, String rawSha256, int rowCount) {


### PR DESCRIPTION
## 관련 이슈

#1081 일부 작업입니다. #1081은 umbrella 이슈라 이 PR로 닫지 않습니다.

## 작업 배경

source snapshot은 데이터팩 candidate의 입력 근거입니다. raw evidence에 credential이 남거나 보관 만료 기준이 없으면 이후 alias/evidence/candidate ledger가 재현 가능하더라도 운영 증거 자체를 안전하게 다룰 수 없습니다.

## 작업 내용

- `data_source_snapshots`에 `raw_retention_expires_at`을 추가했습니다.
- source snapshot 저장 시 `credential_redacted=true`, credential query가 없는 object storage URI, retrieved 이후 raw retention 만료 시각을 강제했습니다.
- H2/PostgreSQL migration에 같은 check constraint를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.datapack.adapter.out.persistence.JdbcDataSourceSnapshotRepositoryTest --rerun-tasks`: RED 단계에서 신규 테스트 실패 확인 후 구현 뒤 exit 0
  - `./gradlew test --tests com.easysubway.common.persistence.DatabaseMigrationContainerTest.h2MigrationRejectsUnsafeSourceSnapshotEvidence --rerun-tasks`: exit 0
  - `./gradlew test --tests com.easysubway.common.persistence.DatabaseMigrationContainerTest.flywayMigratesCleanPostgresqlSchema --rerun-tasks`: exit 0
  - `./gradlew test --tests com.easysubway.common.persistence.DatabaseMigrationContainerTest --rerun-tasks`: exit 0
  - `node --test tools/ci/repository-contract.test.mjs`: 121 tests passed, exit 0
  - `git diff --cached --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Source Snapshot raw evidence guard | Backend JVM | repository 단위 테스트 | `JdbcDataSourceSnapshotRepositoryTest`, RED 실패 후 구현 뒤 exit 0 | 통과 |
| H2 migration guard | Backend H2 | unsafe snapshot evidence insert 차단 | `DatabaseMigrationContainerTest.h2MigrationRejectsUnsafeSourceSnapshotEvidence`, exit 0 | 통과 |
| PostgreSQL migration guard | Backend PostgreSQL | clean schema migration + constraint 확인 | `DatabaseMigrationContainerTest.flywayMigratesCleanPostgresqlSchema`, exit 0 | 통과 |
| Repository contract | CI local | 저장소 계약 테스트 | `node --test tools/ci/repository-contract.test.mjs`, 121 tests passed | 통과 |
| UI evidence | Backend admin | 화면 변경 없음 | 증거 불필요 사유: DB/domain guard만 변경했고 admin 화면 렌더링 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `DataSourceSnapshot` 값 객체와 V23 migration의 raw evidence policy guard가 같은 조건을 강제하는지 확인해 주세요.

## 리스크

- raw source URI는 `s3://` 또는 `oci://` object storage URI만 허용합니다. 다른 내부 evidence store scheme이 필요하면 별도 PR에서 허용값을 늘리면 됩니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 스냅샷 저장 시 원본 증거 보관 만료 시각을 함께 관리하도록 지원이 추가되었습니다.
  * 스냅샷의 원본 URI 형식과 자격 증명 마스킹 조건에 대한 검증이 강화되었습니다.

* **Bug Fixes**
  * 기존 스냅샷 데이터 조회/저장에 새 보관 만료 정보가 반영되도록 수정되었습니다.
  * 데이터베이스 마이그레이션에 새 제약 조건과 초기값 보정이 추가되어 더 안전하게 적용됩니다.

* **Tests**
  * 새 정책 위반 사례와 기존 데이터 호환성에 대한 테스트가 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->