### PR TITLE
[Fix] 하단 탭을 홈 shell에서 전환

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1352,6 +1352,39 @@ class _HomeScreenState extends State<HomeScreen> {
       });
     }
 
+    void openRouteTab() {
+      if (_selectedTabIndex == 2) {
+        return;
+      }
+      setState(() {
+        _selectedTabIndex = 2;
+      });
+    }
+
+    void openMoreTab() {
+      if (_selectedTabIndex == 4) {
+        return;
+      }
+      setState(() {
+        _selectedTabIndex = 4;
+      });
+    }
+
+    void openSavedTab() {
+      if (favoriteRepository == null &&
+          favoriteFacilityRepository == null &&
+          favoriteRouteRepository == null) {
+        openMoreTab();
+        return;
+      }
+      if (_selectedTabIndex == 3) {
+        return;
+      }
+      setState(() {
+        _selectedTabIndex = 3;
+      });
+    }
+
     Future<void> refreshHomeState() async {
       final facilitiesFuture = widget.favoriteFacilityRepository
           ?.listFavoriteFacilities();
@@ -1513,13 +1546,13 @@ class _HomeScreenState extends State<HomeScreen> {
             openNetworkMap();
             break;
           case 2:
-            unawaited(openRouteSearch());
+            openRouteTab();
             break;
           case 3:
-            openSavedItems();
+            openSavedTab();
             break;
           case 4:
-            openSettings();
+            openMoreTab();
             break;
         }
       },
@@ -1566,6 +1599,51 @@ class _HomeScreenState extends State<HomeScreen> {
         onOpenSaved: openSavedItems,
         onOpenSettings: openSettings,
         onOpenHome: openHomeTab,
+        bottomNavigationBar: bottomNavigationBar,
+      );
+    }
+
+    if (_selectedTabIndex == 2) {
+      return RouteSearchScreen(
+        repository: routeRepository,
+        stationRepository: repository,
+        routeFeedbackRepository: routeFeedbackRepository,
+        favoriteRouteRepository: favoriteRouteRepository,
+        initialMobilityType: initialMobilityType,
+        initialDraft: _routeDraftController.draft,
+        simpleViewEnabled: simpleViewEnabled,
+        shellNavigationBar: bottomNavigationBar,
+      );
+    }
+
+    if (_selectedTabIndex == 3) {
+      return FavoriteHomeScreen(
+        favoriteRepository: favoriteRepository,
+        favoriteFacilityRepository: favoriteFacilityRepository,
+        favoriteRouteRepository: favoriteRouteRepository,
+        stationRepository: repository,
+        reportRepository: reportRepository,
+        locationProvider: locationProvider,
+        facilityReportDraftTargetStore: facilityReportDraftTargetStore,
+        internalRouteRepository: internalRouteRepository,
+        realtimeRepository: realtimeRepository,
+        routeDraftController: _routeDraftController,
+        initialMobilityType: initialMobilityType,
+        onOpenRouteSearch: ([mobilityType]) async => openRouteTab(),
+        bottomNavigationBar: bottomNavigationBar,
+      );
+    }
+
+    if (_selectedTabIndex == 4) {
+      return AppSettingsScreen(
+        currentProfile: currentProfile,
+        viewPreferences: widget.viewPreferences,
+        notificationRepository: notificationRepository,
+        notificationPermissionProvider: notificationPermissionProvider,
+        onViewPreferencesChanged: widget.onViewPreferencesChanged,
+        onOpenMobilityProfile: _openMobilityProfile,
+        onOpenSupportAccess: openSupportAccess,
+        onOpenMyReports: openMyReports,
         bottomNavigationBar: bottomNavigationBar,
       );
     }
@@ -3205,6 +3283,7 @@ class AppSettingsScreen extends StatefulWidget {
     required this.onOpenMobilityProfile,
     required this.onOpenSupportAccess,
     required this.onOpenMyReports,
+    this.bottomNavigationBar,
     super.key,
   });
 
@@ -3217,6 +3296,7 @@ class AppSettingsScreen extends StatefulWidget {
   final Future<MobilityProfileOption?> Function() onOpenMobilityProfile;
   final VoidCallback onOpenSupportAccess;
   final VoidCallback onOpenMyReports;
+  final Widget? bottomNavigationBar;
 
   @override
   State<AppSettingsScreen> createState() => _AppSettingsScreenState();
@@ -3239,7 +3319,9 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
     return _OnboardingPreferenceScope(
       preferences: _viewPreferences,
       child: Scaffold(
+        key: const Key('settingsScreen'),
         appBar: AppBar(title: const Text('설정')),
+        bottomNavigationBar: widget.bottomNavigationBar,
         body: SafeArea(
           child: ListView(
             padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
@@ -3649,6 +3731,7 @@ class FavoriteHomeScreen extends StatefulWidget {
     required this.routeDraftController,
     required this.initialMobilityType,
     this.onOpenRouteSearch,
+    this.bottomNavigationBar,
     super.key,
   });
 
@@ -3664,6 +3747,7 @@ class FavoriteHomeScreen extends StatefulWidget {
   final RouteDraftController routeDraftController;
   final String initialMobilityType;
   final Future<void> Function([String? mobilityType])? onOpenRouteSearch;
+  final Widget? bottomNavigationBar;
 
   @override
   State<FavoriteHomeScreen> createState() => _FavoriteHomeScreenState();
@@ -3681,7 +3765,9 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      key: const Key('favoriteHomeScreen'),
       appBar: AppBar(title: const Text('즐겨찾기')),
+      bottomNavigationBar: widget.bottomNavigationBar,
       body: SafeArea(
         child: FutureBuilder<_FavoriteHomeData>(
           future: _dataFuture,

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1243,6 +1243,7 @@ class RouteSearchScreen extends StatefulWidget {
     this.favoriteRouteRepository,
     this.simpleViewEnabled = true,
     this.initialDraft,
+    this.shellNavigationBar,
     String? initialMobilityType,
     super.key,
   }) : initialMobilityType = _resolveInitialMobilityType(initialMobilityType);
@@ -1252,6 +1253,7 @@ class RouteSearchScreen extends StatefulWidget {
   final RouteFeedbackRepository? routeFeedbackRepository;
   final FavoriteRouteRepository? favoriteRouteRepository;
   final RouteDraft? initialDraft;
+  final Widget? shellNavigationBar;
   final String initialMobilityType;
   final bool simpleViewEnabled;
 
@@ -1299,43 +1301,50 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('길찾기')),
-      bottomNavigationBar: Padding(
-        padding: easySubwayBottomActionInsets(context),
-        child: AnimatedBuilder(
-          animation: _controller,
-          builder: (context, _) {
-            final isLoading =
-                _controller.state.status == RouteSearchViewStatus.loading;
-            final canSubmit =
-                _originStation != null && _destinationStation != null;
-            final submitLabel = isLoading
-                ? '경로 검색 중'
-                : canSubmit
-                ? '길찾기'
-                : '길찾기, 출발역과 도착역을 먼저 선택해 주세요';
-            return Semantics(
-              button: true,
-              enabled: canSubmit && !isLoading,
-              label: submitLabel,
-              child: ExcludeSemantics(
-                child: FilledButton(
-                  key: const Key('routeSearchSubmitButton'),
-                  onPressed: canSubmit && !isLoading ? _submit : null,
-                  style: FilledButton.styleFrom(
-                    minimumSize: const Size.fromHeight(60),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(8),
-                    ),
+    final submitButton = Padding(
+      padding: easySubwayBottomActionInsets(context),
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, _) {
+          final isLoading =
+              _controller.state.status == RouteSearchViewStatus.loading;
+          final canSubmit =
+              _originStation != null && _destinationStation != null;
+          final submitLabel = isLoading
+              ? '경로 검색 중'
+              : canSubmit
+              ? '길찾기'
+              : '길찾기, 출발역과 도착역을 먼저 선택해 주세요';
+          return Semantics(
+            button: true,
+            enabled: canSubmit && !isLoading,
+            label: submitLabel,
+            child: ExcludeSemantics(
+              child: FilledButton(
+                key: const Key('routeSearchSubmitButton'),
+                onPressed: canSubmit && !isLoading ? _submit : null,
+                style: FilledButton.styleFrom(
+                  minimumSize: const Size.fromHeight(60),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
                   ),
-                  child: Text(isLoading ? '경로 검색 중' : '길찾기'),
                 ),
+                child: Text(isLoading ? '경로 검색 중' : '길찾기'),
               ),
-            );
-          },
-        ),
+            ),
+          );
+        },
       ),
+    );
+    return Scaffold(
+      key: const Key('routeSearchScreen'),
+      appBar: AppBar(title: const Text('길찾기')),
+      bottomNavigationBar: widget.shellNavigationBar == null
+          ? submitButton
+          : Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [submitButton, widget.shellNavigationBar!],
+            ),
       body: SafeArea(
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -859,7 +859,7 @@ void main() {
     expect(find.byTooltip('중심 보기'), findsNothing);
     expect(find.text('노선 목록으로 보기'), findsNothing);
     expect(find.byKey(const Key('networkMapSurface')), findsOneWidget);
-    expect(find.text('즐겨찾기'), findsOneWidget);
+    expect(find.byKey(const Key('networkMapScreen')), findsOneWidget);
     expect(find.text('저장'), findsNothing);
     expect(find.text('수도권'), findsOneWidget);
     expect(find.text('전국'), findsNothing);
@@ -921,6 +921,71 @@ void main() {
       find.byKey(const Key('homeBottomNavigationBar')),
     );
     expect(homeNavigationBar.selectedIndex, 0);
+  });
+
+  testWidgets('홈 하단 탭은 길찾기 즐겨찾기 더보기를 같은 shell에서 전환한다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    Future<void> expectShellTab({
+      required Key tabKey,
+      required Key screenKey,
+      required int selectedIndex,
+    }) async {
+      await tester.tap(find.byKey(tabKey));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomeScreen), findsOneWidget);
+      expect(find.byKey(screenKey), findsOneWidget);
+      expect(
+        tester
+            .widget<NavigationBar>(
+              find.byKey(const Key('homeBottomNavigationBar')),
+            )
+            .selectedIndex,
+        selectedIndex,
+      );
+    }
+
+    await expectShellTab(
+      tabKey: const Key('bottomNavRoute'),
+      screenKey: const Key('routeSearchScreen'),
+      selectedIndex: 2,
+    );
+    await expectShellTab(
+      tabKey: const Key('bottomNavSaved'),
+      screenKey: const Key('favoriteHomeScreen'),
+      selectedIndex: 3,
+    );
+    await expectShellTab(
+      tabKey: const Key('bottomNavMore'),
+      screenKey: const Key('settingsScreen'),
+      selectedIndex: 4,
+    );
+
+    await tester.tap(find.byKey(const Key('bottomNavHome')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('settingsScreen')), findsNothing);
+    expect(
+      tester
+          .widget<NavigationBar>(
+            find.byKey(const Key('homeBottomNavigationBar')),
+          )
+          .selectedIndex,
+      0,
+    );
   });
 
   testWidgets('노선도 지역 메뉴는 선택한 지역으로 지도를 다시 불러온다', (tester) async {
@@ -3867,7 +3932,7 @@ void main() {
     await tester.tap(find.byKey(const Key('bottomNavSaved')));
     await tester.pumpAndSettle();
 
-    expect(find.text('즐겨찾기'), findsOneWidget);
+    expect(find.byKey(const Key('favoriteHomeScreen')), findsOneWidget);
     expect(find.byKey(const Key('favoriteHomeStationsButton')), findsOneWidget);
     expect(
       find.byKey(const Key('favoriteHomeFacilitiesButton')),


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- #1090에서 노선도 탭은 HomeScreen shell 안에서 전환되도록 바뀌었지만, 길찾기·즐겨찾기·더보기 탭은 여전히 push 흐름으로 남아 있었다.
- #1075의 P0인 persistent 하단 탭 동작을 더 닫기 위해 남은 하단 탭 루트 화면을 같은 shell state로 전환한다.

## 작업 내용

- 홈 하단 `NavigationBar`의 길찾기, 즐겨찾기, 더보기 탭을 route push 대신 `_selectedTabIndex` 전환으로 처리했다.
- `RouteSearchScreen`은 shell 진입 시 기존 길찾기 submit 버튼 아래에 공통 하단 nav를 붙일 수 있게 했다.
- `FavoriteHomeScreen`, `AppSettingsScreen`은 shell 진입 시 공통 하단 nav를 받을 수 있게 했다.
- 길찾기·즐겨찾기·더보기 탭이 `HomeScreen` shell 안에서 선택 상태 2/3/4를 유지하는 widget test를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test --reporter compact test/widget_test.dart --name "홈 하단 탭은 길찾기 즐겨찾기 더보기를 같은 shell에서 전환한다"`: RED에서 `HomeScreen`이 사라져 실패 확인 후 GREEN 통과
  - `flutter test --reporter compact test/widget_test.dart --name "홈 노선도 탭은 같은 shell 안에서 선택 상태를 바꾼다|홈 하단 탭은 길찾기 즐겨찾기 더보기를 같은 shell에서 전환한다"`: exit 0, 2 tests passed
  - `flutter test --reporter expanded --fail-fast test/widget_test.dart`: exit 0, 178 tests passed
  - `flutter analyze`: exit 0, No issues found
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 121 tests passed
  - `git diff --check`: exit 0
  - GitHub PR checks: CI, Release Artifacts, SonarCloud, CodeRabbit 모두 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 하단 탭 shell 전환 | Flutter widget test | 길찾기·즐겨찾기·더보기 탭 탭 후 `HomeScreen`, 화면 key, `homeBottomNavigationBar.selectedIndex` 확인 | `홈 하단 탭은 길찾기 즐겨찾기 더보기를 같은 shell에서 전환한다` | 통과 |
| 기존 노선도 shell 회귀 | Flutter widget test | 노선도 탭 선택 상태와 홈 복귀 확인 | `홈 노선도 탭은 같은 shell 안에서 선택 상태를 바꾼다` | 통과 |
| 전체 모바일 widget 회귀 | Flutter widget test | `flutter test --reporter expanded --fail-fast test/widget_test.dart` | 178 tests passed | 통과 |
| 정적 분석 | Flutter analyzer | `flutter analyze` | `No issues found` | 통과 |
| 저장소 계약 | Node test | `node --test tools/ci/repository-contract.test.mjs` | 121 pass, 0 fail | 통과 |
| PR 게이트 | GitHub Actions / CodeRabbit | PR #1092 checks와 review thread 확인 | CI, Release Artifacts, SonarCloud, CodeRabbit success / unresolved review thread 0개 | 통과 |
| 화면 증거 | 해당 없음 | 색상·배치 개편이 아니라 route stack 동작을 shell state로 바꾸는 회귀 수정이며, selectedIndex와 화면 presence를 widget test로 고정했다. #1075 전체 close 전 Android/iOS 접근성 수동 증거는 별도 PR에서 유지한다. | 증거 불필요 사유 기록 | 확인 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `HomeScreen`의 `_selectedTabIndex` 분기와 `RouteSearchScreen.shellNavigationBar`.
- 길찾기 화면은 기존 submit 버튼을 유지해야 해서 shell nav를 submit 버튼 아래에만 붙였다.
- #1075 전체 close PR이 아니라 하단 탭 P0 범위를 줄이는 PR이다.

## 리스크

- 길찾기 탭 내부 상세 단계의 back model 정리는 별도 P0 항목으로 남아 있다.
- 탭별 nested stack을 새 라우터로 만들지는 않았다. 현재 의존성/구조에서 가장 작은 shell state 전환만 적용했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. 해당 없음: CodeRabbit이 정상 완료됐다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.