### PR TITLE
[Fix] 오프라인 데이터 상태를 안내

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4199,6 +4199,45 @@ class OfflineDataScreen extends StatelessWidget {
                 subtitle: '마지막으로 받은 노선도와 역 정보를 보여줍니다.',
               ),
             ),
+            _HomePrototypeSection(title: '저장된 데이터 상태'),
+            _PrototypeCard(
+              child: Column(
+                children: [
+                  _PrototypeInfoRow(
+                    icon: Icons.public,
+                    iconBackground: EasySubwayAccessibleColors.mintSoft,
+                    iconColor: EasySubwayAccessibleColors.mintDark,
+                    title: '지역',
+                    subtitle: '수도권 기본 데이터',
+                    trailing: '저장됨',
+                  ),
+                  _PrototypeInfoRow(
+                    icon: Icons.update,
+                    iconBackground: EasySubwayAccessibleColors.skySoft,
+                    iconColor: EasySubwayAccessibleColors.brand,
+                    title: '마지막 갱신',
+                    subtitle: '앱에 포함된 기본 데이터',
+                    trailing: '확인 필요',
+                  ),
+                  _PrototypeInfoRow(
+                    icon: Icons.verified_outlined,
+                    iconBackground: EasySubwayAccessibleColors.skySoft,
+                    iconColor: EasySubwayAccessibleColors.brand,
+                    title: '데이터 품질',
+                    subtitle: '기본 역·노선 정보 우선',
+                    trailing: '보통',
+                  ),
+                  _PrototypeInfoRow(
+                    icon: Icons.info_outline,
+                    iconBackground: EasySubwayAccessibleColors.amberSoft,
+                    iconColor: EasySubwayAccessibleColors.amber,
+                    title: '제한 사항',
+                    subtitle: '실시간 시설 상태와 제보 전송은 인터넷 연결이 필요해요',
+                    trailing: '주의',
+                  ),
+                ],
+              ),
+            ),
             _HomePrototypeSection(title: '이용 가능'),
             _PrototypeCard(
               child: Column(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3326,6 +3326,45 @@ void main() {
     }
   });
 
+  testWidgets('오프라인 데이터 안내는 저장 범위와 품질 제한을 보여준다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('bottomNavMore')));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('offlineDataSettingsButton')),
+      160,
+    );
+    await tester.ensureVisible(
+      find.byKey(const Key('offlineDataSettingsButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('offlineDataSettingsButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('저장된 데이터 상태'), findsOneWidget);
+    expect(find.text('지역'), findsOneWidget);
+    expect(find.text('수도권 기본 데이터'), findsOneWidget);
+    expect(find.text('마지막 갱신'), findsOneWidget);
+    expect(find.text('앱에 포함된 기본 데이터'), findsOneWidget);
+    expect(find.text('데이터 품질'), findsOneWidget);
+    expect(find.text('기본 역·노선 정보 우선'), findsOneWidget);
+    expect(find.text('제한 사항'), findsOneWidget);
+    expect(find.text('실시간 시설 상태와 제보 전송은 인터넷 연결이 필요해요'), findsOneWidget);
+  });
+
   testWidgets('설정 화면 보기 옵션은 변경값을 저장하고 다시 실행해도 유지한다', (tester) async {
     final onboardingStore = MemoryOnboardingResultStore(
       initialResult: OnboardingResult(


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

#1075의 모바일 오프라인 안내 보강 중, 현재 오프라인 데이터 화면이 단순 이용 가능 여부와 인터넷 필요 안내만 보여 저장된 데이터의 범위와 신뢰 수준을 판단하기 어려웠습니다. 운영 사용자에게 기본 데이터와 실시간/제보 기능의 한계를 분리해 보여주도록 작은 단위로 반영합니다.

## 작업 내용

- 오프라인 데이터 화면에 `저장된 데이터 상태` 섹션을 추가했습니다.
- 저장 지역, 마지막 갱신 기준, 데이터 품질, 제한 사항을 각각 별도 행으로 표시했습니다.
- 하단 더보기 탭에서 오프라인 데이터 화면으로 진입해 새 상태 문구가 보이는 widget test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `flutter analyze` in `apps/mobile`: exit 0, No issues found
- `flutter test --reporter expanded --fail-fast test/widget_test.dart` in `apps/mobile`: exit 0, 179 tests passed
- `node --test tools/ci/repository-contract.test.mjs`: exit 0, 121 tests passed
- `git diff --check`: exit 0
- PR checks: CI, Release Artifacts, SonarCloud, OSV, CodeRabbit status 모두 pass. CodeRabbit 실제 리뷰는 rate limit으로 시작되지 않아 Codex CLI fallback review를 PR review로 기록했습니다.
- Post-merge main checks: CI `28359431876` success, Release Artifacts `28359431459` success, CD `28359705837` pending 생성 및 실패 신호 없음.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 오프라인 데이터 상태 문구 | Flutter widget test | 더보기 탭에서 오프라인 데이터 화면으로 진입한 뒤 저장 지역/갱신/품질/제한 사항 문구 assert | `flutter test --reporter expanded --fail-fast test/widget_test.dart` | 179 tests passed |
| 정적 분석 | Flutter analyzer | 모바일 앱 analyzer 실행 | `flutter analyze` | No issues found |
| 저장소 계약 | Node test | repository contract 테스트 실행 | `node --test tools/ci/repository-contract.test.mjs` | 121 tests passed |
| PR CI | GitHub Actions | PR #1093 checks 확인 | CI, Release Artifacts, SonarCloud, OSV, CodeRabbit status | pass |
| 코드 리뷰 fallback | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review 게시 | PR review `Actionable comments posted: 0` | actionable 0, nitpick 0 |
| post-merge main checks | GitHub Actions | merge commit `6668ca03`의 main workflow 확인 | CI `28359431876`, Release Artifacts `28359431459` | success |
| post-merge CD | GitHub Actions | CD workflow_run 생성 및 현재 상태 확인 | CD `28359705837` | pending, 실패 신호 없음 |
| 화면 캡처 | 해당 없음 | 상태 문구 추가와 widget assertion만 포함한 비시각 동작 변경 | 증거 불필요 사유: UI 레이아웃/접근성 흐름 변경 없이 기존 화면에 텍스트 상태 행을 추가한 변경이며, #1075 전체 닫힘 전 Android/iOS 수동 증거를 별도 확보합니다. | 대체 검증 완료 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `OfflineDataScreen`의 `저장된 데이터 상태` 섹션 문구가 운영 사용자에게 과도한 확정 표현으로 읽히지 않는지 확인해 주세요.
- 이 PR은 #1075 전체를 닫지 않습니다. 오프라인 데이터 안내 slice만 반영합니다.

## 리스크

- 실제 데이터팩 메타데이터를 동적으로 읽지는 않고, 현재 앱에 포함된 기본 데이터 상태를 보수적으로 설명합니다.
- #1075의 fixture/fallback 차단 전체 범위는 별도 PR들이 이어져야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.