### PR TITLE
[Refactor] 모바일 prototype UI 명칭 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1500,7 +1500,7 @@ class _HomeScreenState extends State<HomeScreen> {
       });
     }
 
-    final heroSection = _HomePrototypeHero(
+    final heroSection = _HomeHero(
       profile: currentProfile,
       onRouteSearch: openRouteSearch,
       onStationSearch: () => unawaited(openStationSearch()),
@@ -1677,7 +1677,7 @@ class _HomeScreenState extends State<HomeScreen> {
               key: const Key('homeRefreshIndicator'),
               onRefresh: refreshHomeState,
               child: ListView(
-                key: const Key('homePrototypeList'),
+                key: const Key('homeContentList'),
                 physics: const AlwaysScrollableScrollPhysics(),
                 padding: isLargeScreen
                     ? const EdgeInsets.fromLTRB(24, 24, 24, 112)
@@ -1957,8 +1957,8 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
                   if (snapshot.connectionState != ConnectionState.done)
                     const LinearProgressIndicator(minHeight: 3),
                   if (items.isEmpty)
-                    const _PrototypeCard(
-                      child: _PrototypeInfoRow(
+                    const _AppCard(
+                      child: _AppInfoRow(
                         icon: Icons.notifications_none,
                         iconBackground: EasySubwayAccessibleColors.mintSoft,
                         iconColor: EasySubwayAccessibleColors.mintDark,
@@ -2126,14 +2126,14 @@ class _NotificationInboxCard extends StatelessWidget {
     }
 
     final accent = _facilitySeverityAccent(item.severity);
-    final card = _PrototypeCard(
+    final card = _AppCard(
       backgroundColor: accent.backgroundColor,
       borderColor: accent.borderColor,
       showBorder: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          _PrototypeInfoRow(
+          _AppInfoRow(
             icon: item.icon,
             iconBackground: Colors.white,
             iconColor: accent.iconColor,
@@ -2175,8 +2175,8 @@ class _NotificationInboxCard extends StatelessWidget {
   }
 }
 
-class _HomePrototypeHero extends StatelessWidget {
-  const _HomePrototypeHero({
+class _HomeHero extends StatelessWidget {
+  const _HomeHero({
     required this.profile,
     required this.onRouteSearch,
     required this.onStationSearch,
@@ -2429,7 +2429,7 @@ class _HomeRouteDraftCard extends StatelessWidget {
             key: const Key('homeRouteDraftPanel'),
             onTap: onTap,
             borderRadius: BorderRadius.circular(18),
-            child: _PrototypeCard(
+            child: _AppCard(
               backgroundColor: EasySubwayAccessibleColors.skySoft,
               borderColor: const Color(0xFFB7DDF4),
               borderRadius: 18,
@@ -2490,8 +2490,8 @@ class _HomeRouteDraftCard extends StatelessWidget {
   }
 }
 
-class _HomePrototypeSection extends StatelessWidget {
-  const _HomePrototypeSection({required this.title});
+class _AppSectionTitle extends StatelessWidget {
+  const _AppSectionTitle({required this.title});
 
   final String title;
 
@@ -2604,13 +2604,13 @@ class _HomeFacilityAlertCard extends StatelessWidget {
       container: true,
       explicitChildNodes: true,
       label: semanticLabel,
-      child: _PrototypeCard(
+      child: _AppCard(
         backgroundColor: accent.backgroundColor,
         borderColor: accent.borderColor,
         showBorder: true,
         child: Column(
           children: [
-            _PrototypeInfoRow(
+            _AppInfoRow(
               icon: _facilityIcon(facility.type),
               iconBackground: Colors.white,
               iconColor: accent.iconColor,
@@ -2835,7 +2835,7 @@ class _HomeStateSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _HomePrototypeSection(title: title),
+        _AppSectionTitle(title: title),
         child,
       ],
     );
@@ -2865,12 +2865,12 @@ class _HomeStateCard extends StatelessWidget {
       container: true,
       liveRegion: true,
       label: '$title, $subtitle',
-      child: _PrototypeCard(
+      child: _AppCard(
         showBorder: true,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _PrototypeInfoRow(
+            _AppInfoRow(
               icon: icon,
               iconBackground: EasySubwayAccessibleColors.mintSoft,
               iconColor: EasySubwayAccessibleColors.mintDark,
@@ -2913,7 +2913,7 @@ class _HomeRecentRouteCard extends StatelessWidget {
           key: const Key('homeRecentRouteCard'),
           onTap: () => unawaited(onTap()),
           borderRadius: BorderRadius.circular(26),
-          child: _PrototypeCard(
+          child: _AppCard(
             borderRadius: 26,
             showBorder: true,
             padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 18),
@@ -3012,7 +3012,7 @@ class _HomeSavedRouteCard extends StatelessWidget {
         child: InkWell(
           onTap: onTap,
           borderRadius: BorderRadius.circular(20),
-          child: _PrototypeCard(
+          child: _AppCard(
             showBorder: true,
             child: Row(
               children: [
@@ -3130,8 +3130,8 @@ class _HomeMiniBadge extends StatelessWidget {
   }
 }
 
-class _PrototypeCard extends StatelessWidget {
-  const _PrototypeCard({
+class _AppCard extends StatelessWidget {
+  const _AppCard({
     required this.child,
     this.backgroundColor = Colors.white,
     this.borderColor = EasySubwayAccessibleColors.line,
@@ -3164,8 +3164,8 @@ class _PrototypeCard extends StatelessWidget {
   }
 }
 
-class _PrototypeInfoRow extends StatelessWidget {
-  const _PrototypeInfoRow({
+class _AppInfoRow extends StatelessWidget {
+  const _AppInfoRow({
     required this.icon,
     required this.iconBackground,
     required this.iconColor,
@@ -3796,7 +3796,7 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
                 children: [
                   if (snapshot.connectionState != ConnectionState.done)
                     const LinearProgressIndicator(minHeight: 3),
-                  const _HomePrototypeSection(title: '즐겨찾기한 항목'),
+                  const _AppSectionTitle(title: '즐겨찾기한 항목'),
                   if (hasError)
                     _HomeStateCard(
                       key: const Key('favoriteHomeErrorState'),
@@ -3827,14 +3827,14 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
                     ),
                     if (_firstFacilityAlert(data.facilities)
                         case final alert?) ...[
-                      const _HomePrototypeSection(title: '확인 필요'),
+                      const _AppSectionTitle(title: '확인 필요'),
                       _HomeFacilityAlertCard(
                         facility: alert,
                         onOpenFacilities: _openFavoriteFacilities,
                       ),
                     ],
                     if (data.routes.isNotEmpty) ...[
-                      const _HomePrototypeSection(title: '최근 경로'),
+                      const _AppSectionTitle(title: '최근 경로'),
                       _HomeSavedRouteCard(
                         route: data.routes.first,
                         onTap: _openFavoriteRoutes,
@@ -3843,8 +3843,8 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
                     if (data.isEmpty)
                       const Padding(
                         padding: EdgeInsets.only(top: 16),
-                        child: _PrototypeCard(
-                          child: _PrototypeInfoRow(
+                        child: _AppCard(
+                          child: _AppInfoRow(
                             icon: Icons.bookmark_border,
                             iconBackground: EasySubwayAccessibleColors.mintSoft,
                             iconColor: EasySubwayAccessibleColors.mintDark,
@@ -4097,7 +4097,7 @@ class _FavoriteHomeQuickCard extends StatelessWidget {
         child: InkWell(
           onTap: onTap,
           borderRadius: BorderRadius.circular(8),
-          child: _PrototypeCard(
+          child: _AppCard(
             backgroundColor: Colors.white,
             borderRadius: 8,
             showBorder: true,
@@ -4188,10 +4188,10 @@ class OfflineDataScreen extends StatelessWidget {
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
           children: const [
-            _PrototypeCard(
+            _AppCard(
               backgroundColor: EasySubwayAccessibleColors.mintSoft,
               borderColor: EasySubwayAccessibleColors.mintBorder,
-              child: _PrototypeInfoRow(
+              child: _AppInfoRow(
                 icon: Icons.check_circle_outline,
                 iconBackground: Colors.white,
                 iconColor: EasySubwayAccessibleColors.mintDark,
@@ -4199,11 +4199,11 @@ class OfflineDataScreen extends StatelessWidget {
                 subtitle: '마지막으로 받은 노선도와 역 정보를 보여줍니다.',
               ),
             ),
-            _HomePrototypeSection(title: '저장된 데이터 상태'),
-            _PrototypeCard(
+            _AppSectionTitle(title: '저장된 데이터 상태'),
+            _AppCard(
               child: Column(
                 children: [
-                  _PrototypeInfoRow(
+                  _AppInfoRow(
                     icon: Icons.public,
                     iconBackground: EasySubwayAccessibleColors.mintSoft,
                     iconColor: EasySubwayAccessibleColors.mintDark,
@@ -4211,7 +4211,7 @@ class OfflineDataScreen extends StatelessWidget {
                     subtitle: '수도권 기본 데이터',
                     trailing: '저장됨',
                   ),
-                  _PrototypeInfoRow(
+                  _AppInfoRow(
                     icon: Icons.update,
                     iconBackground: EasySubwayAccessibleColors.skySoft,
                     iconColor: EasySubwayAccessibleColors.brand,
@@ -4219,7 +4219,7 @@ class OfflineDataScreen extends StatelessWidget {
                     subtitle: '앱에 포함된 기본 데이터',
                     trailing: '확인 필요',
                   ),
-                  _PrototypeInfoRow(
+                  _AppInfoRow(
                     icon: Icons.verified_outlined,
                     iconBackground: EasySubwayAccessibleColors.skySoft,
                     iconColor: EasySubwayAccessibleColors.brand,
@@ -4227,7 +4227,7 @@ class OfflineDataScreen extends StatelessWidget {
                     subtitle: '기본 역·노선 정보 우선',
                     trailing: '보통',
                   ),
-                  _PrototypeInfoRow(
+                  _AppInfoRow(
                     icon: Icons.info_outline,
                     iconBackground: EasySubwayAccessibleColors.amberSoft,
                     iconColor: EasySubwayAccessibleColors.amber,
@@ -4238,11 +4238,11 @@ class OfflineDataScreen extends StatelessWidget {
                 ],
               ),
             ),
-            _HomePrototypeSection(title: '이용 가능'),
-            _PrototypeCard(
+            _AppSectionTitle(title: '이용 가능'),
+            _AppCard(
               child: Column(
                 children: [
-                  _PrototypeInfoRow(
+                  _AppInfoRow(
                     icon: Icons.map_outlined,
                     iconBackground: EasySubwayAccessibleColors.mintSoft,
                     iconColor: EasySubwayAccessibleColors.mintDark,
@@ -4250,7 +4250,7 @@ class OfflineDataScreen extends StatelessWidget {
                     subtitle: '지역·노선·역 보기',
                     trailing: '가능',
                   ),
-                  _PrototypeInfoRow(
+                  _AppInfoRow(
                     icon: Icons.train_outlined,
                     iconBackground: EasySubwayAccessibleColors.mintSoft,
                     iconColor: EasySubwayAccessibleColors.mintDark,
@@ -4258,7 +4258,7 @@ class OfflineDataScreen extends StatelessWidget {
                     subtitle: '출구와 엘리베이터 보기',
                     trailing: '가능',
                   ),
-                  _PrototypeInfoRow(
+                  _AppInfoRow(
                     icon: Icons.bookmark_border,
                     iconBackground: EasySubwayAccessibleColors.mintSoft,
                     iconColor: EasySubwayAccessibleColors.mintDark,
@@ -4269,11 +4269,11 @@ class OfflineDataScreen extends StatelessWidget {
                 ],
               ),
             ),
-            _HomePrototypeSection(title: '인터넷 연결 필요'),
-            _PrototypeCard(
+            _AppSectionTitle(title: '인터넷 연결 필요'),
+            _AppCard(
               child: Column(
                 children: [
-                  _PrototypeInfoRow(
+                  _AppInfoRow(
                     icon: Icons.report_outlined,
                     iconBackground: EasySubwayAccessibleColors.amberSoft,
                     iconColor: EasySubwayAccessibleColors.amber,
@@ -4281,7 +4281,7 @@ class OfflineDataScreen extends StatelessWidget {
                     subtitle: '사진과 제보 보내기',
                     trailing: '연결 필요',
                   ),
-                  _PrototypeInfoRow(
+                  _AppInfoRow(
                     icon: Icons.refresh,
                     iconBackground: EasySubwayAccessibleColors.amberSoft,
                     iconColor: EasySubwayAccessibleColors.amber,
@@ -4805,7 +4805,7 @@ class UserDataDeletionResultScreen extends StatelessWidget {
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
           children: [
-            _PrototypeCard(
+            _AppCard(
               backgroundColor: EasySubwayAccessibleColors.mintSoft,
               borderColor: EasySubwayAccessibleColors.mintBorder,
               child: Column(
@@ -4832,8 +4832,8 @@ class UserDataDeletionResultScreen extends StatelessWidget {
                 ],
               ),
             ),
-            const _HomePrototypeSection(title: '처리 결과'),
-            _PrototypeCard(
+            const _AppSectionTitle(title: '처리 결과'),
+            _AppCard(
               child: Column(
                 children: [
                   _DataDeletionResultRow(
@@ -4889,10 +4889,10 @@ class UserDataDeletionResultScreen extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 12),
-            const _PrototypeCard(
+            const _AppCard(
               backgroundColor: EasySubwayAccessibleColors.skySoft,
               borderColor: Color(0xFFB7DDF4),
-              child: _PrototypeInfoRow(
+              child: _AppInfoRow(
                 icon: Icons.map_outlined,
                 iconBackground: Colors.white,
                 iconColor: EasySubwayAccessibleColors.brand,

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2919,7 +2919,7 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 22),
-                _RoutePrototypeSection(
+                _RouteResultSection(
                   title: result.isBlocked
                       ? '안내 불가 이유'
                       : _isRecommendedRoute(result)
@@ -3029,12 +3029,12 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
                         if (_isRecommendedRoute(result) &&
                             result.movementSteps.isNotEmpty) ...[
                           const SizedBox(height: 15),
-                          const _RoutePrototypeLinePath(),
+                          const _RouteLinePath(),
                         ],
                         if (blockedReasonLabels.isNotEmpty) ...[
                           const SizedBox(height: 13),
                           for (final reason in blockedReasonLabels)
-                            _RoutePrototypeReason(text: reason, blocked: true),
+                            _RouteReasonBadge(text: reason, blocked: true),
                         ],
                         if (result.arrivalGuidanceStep != null) ...[
                           const SizedBox(height: 16),
@@ -3173,7 +3173,7 @@ class _RouteBlockedWorkflow extends StatelessWidget {
         ),
         const SizedBox(height: 12),
         for (final reason in reasons)
-          _RoutePrototypeReason(text: reason, blocked: true),
+          _RouteReasonBadge(text: reason, blocked: true),
         const SizedBox(height: 12),
         const _RouteNotice(
           key: Key('routeBlockedNextActionNotice'),
@@ -3282,28 +3282,28 @@ class _RouteResultListButton extends StatelessWidget {
                     const SizedBox(height: 4),
                     Text(_routeMetaLabel(result)),
                     const SizedBox(height: 12),
-                    const _RoutePrototypeLinePath(),
+                    const _RouteLinePath(),
                     const SizedBox(height: 12),
                     Wrap(
                       spacing: 6,
                       runSpacing: 6,
                       children: [
-                        _RoutePrototypeChip(
+                        _RouteStatusChip(
                           label: _routeTransferLabel(result),
                           icon: Icons.route_outlined,
                         ),
-                        _RoutePrototypeChip(
+                        _RouteStatusChip(
                           label: '걷기 ${_routeWalkingDistanceLabel(result)}',
                           icon: Icons.directions_walk,
                         ),
-                        _RoutePrototypeChip(
+                        _RouteStatusChip(
                           key: const Key('routeGuidanceMobilityChip'),
                           label: result.mobilityLabel == '이동 조건 확인 필요'
                               ? result.mobilityLabel
                               : result.comfortLabel,
                           icon: Icons.accessible_forward,
                         ),
-                        _RoutePrototypeChip(
+                        _RouteStatusChip(
                           label: result.stairAccessLabel,
                           icon: _routeStairAccessIcon(result),
                         ),
@@ -3358,7 +3358,7 @@ class _RouteDarkSummaryCard extends StatelessWidget {
               runSpacing: 6,
               children: [
                 for (final chip in chips)
-                  _RoutePrototypeChip(
+                  _RouteStatusChip(
                     key: Key('routeDarkSummaryChip-${chip.label}'),
                     label: chip.label,
                     icon: chip.icon,
@@ -3475,8 +3475,8 @@ String _normalizeRouteStairState(String value) {
   };
 }
 
-class _RoutePrototypeSection extends StatelessWidget {
-  const _RoutePrototypeSection({required this.title, required this.subtitle});
+class _RouteResultSection extends StatelessWidget {
+  const _RouteResultSection({required this.title, required this.subtitle});
 
   final String title;
   final String subtitle;
@@ -3510,12 +3510,8 @@ class _RoutePrototypeSection extends StatelessWidget {
   }
 }
 
-class _RoutePrototypeChip extends StatelessWidget {
-  const _RoutePrototypeChip({
-    super.key,
-    required this.label,
-    required this.icon,
-  });
+class _RouteStatusChip extends StatelessWidget {
+  const _RouteStatusChip({super.key, required this.label, required this.icon});
 
   final String label;
   final IconData icon;
@@ -3555,22 +3551,22 @@ class _RouteSummaryChip {
   final IconData icon;
 }
 
-class _RoutePrototypeLinePath extends StatelessWidget {
-  const _RoutePrototypeLinePath();
+class _RouteLinePath extends StatelessWidget {
+  const _RouteLinePath();
 
   @override
   Widget build(BuildContext context) {
     return Row(
       children: [
-        _RoutePrototypeNode(),
+        _RouteLineNode(),
         Expanded(child: Container(height: 6, color: const Color(0xFF27A6D9))),
-        _RoutePrototypeNode(),
+        _RouteLineNode(),
       ],
     );
   }
 }
 
-class _RoutePrototypeNode extends StatelessWidget {
+class _RouteLineNode extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -3586,8 +3582,8 @@ class _RoutePrototypeNode extends StatelessWidget {
   }
 }
 
-class _RoutePrototypeReason extends StatelessWidget {
-  const _RoutePrototypeReason({required this.text, this.blocked = false});
+class _RouteReasonBadge extends StatelessWidget {
+  const _RouteReasonBadge({required this.text, this.blocked = false});
 
   final String text;
   final bool blocked;

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -363,7 +363,7 @@ void main() {
 
     await tester.dragUntilVisible(
       find.text('최근 경로'),
-      find.byKey(const Key('homePrototypeList')),
+      find.byKey(const Key('homeContentList')),
       const Offset(0, -160),
     );
     await tester.pumpAndSettle();
@@ -405,7 +405,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final homeList = tester.widget<ListView>(
-      find.byKey(const Key('homePrototypeList')),
+      find.byKey(const Key('homeContentList')),
     );
     expect(homeList.padding?.resolve(TextDirection.ltr).bottom, 96);
   });
@@ -639,7 +639,7 @@ void main() {
       expect(find.text('경로를 저장하면 현재 시설 상태와 함께 다시 볼 수 있어요.'), findsNothing);
 
       await tester.drag(
-        find.byKey(const Key('homePrototypeList')),
+        find.byKey(const Key('homeContentList')),
         const Offset(0, -620),
       );
       await tester.pumpAndSettle();
@@ -682,7 +682,7 @@ void main() {
     expect(find.byKey(const Key('homeRecentRouteSection')), findsOneWidget);
 
     final homeList = tester.widget<ListView>(
-      find.byKey(const Key('homePrototypeList')),
+      find.byKey(const Key('homeContentList')),
     );
     final padding = homeList.padding!.resolve(TextDirection.ltr);
     expect(padding.left, EasySubwayAdaptiveLayout.largeScreenGutter);
@@ -2760,14 +2760,14 @@ void main() {
 
     await tester.dragUntilVisible(
       find.text('최근 경로'),
-      find.byKey(const Key('homePrototypeList')),
+      find.byKey(const Key('homeContentList')),
       const Offset(0, -160),
     );
     await tester.pumpAndSettle();
     expect(find.text('최근 경로'), findsOneWidget);
     await tester.dragUntilVisible(
       find.byKey(const Key('homeRecentRouteCard')),
-      find.byKey(const Key('homePrototypeList')),
+      find.byKey(const Key('homeContentList')),
       const Offset(0, -120),
     );
     await tester.pumpAndSettle();
@@ -2870,7 +2870,7 @@ void main() {
     expect(find.text('시설 알림을 불러오지 못했어요'), findsOneWidget);
     await tester.dragUntilVisible(
       find.byKey(const Key('homeRecentRouteErrorState')),
-      find.byKey(const Key('homePrototypeList')),
+      find.byKey(const Key('homeContentList')),
       const Offset(0, -120),
     );
     await tester.pumpAndSettle();
@@ -3075,7 +3075,7 @@ void main() {
     );
     await tester.dragUntilVisible(
       find.byKey(const Key('recentSearchButton')),
-      find.byKey(const Key('homePrototypeList')),
+      find.byKey(const Key('homeContentList')),
       const Offset(0, -120),
     );
     await tester.pumpAndSettle();
@@ -3930,7 +3930,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.dragUntilVisible(
       find.byKey(const Key('routeSearchButton')),
-      find.byKey(const Key('homePrototypeList')),
+      find.byKey(const Key('homeContentList')),
       const Offset(0, 180),
     );
     await tester.pumpAndSettle();

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -819,6 +819,17 @@ test("모바일 generic catch는 원본 예외와 스택을 버리지 않는다"
   }
 });
 
+test("프로덕션 모바일 UI 위젯명은 prototype 명칭을 쓰지 않는다", () => {
+  const mobileFiles = execFileSync("git", ["ls-files", "apps/mobile/lib/*.dart"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim().split("\n").filter(Boolean);
+
+  for (const file of mobileFiles) {
+    assert.doesNotMatch(read(file), /Prototype/, `${file} still has prototype UI naming`);
+  }
+});
+
 test("Android 권한 파서는 속성 순서와 추가 속성이 달라도 권한명을 추출한다", () => {
   const permissions = androidManifestPermissions(`
     <manifest xmlns:android="http://schemas.android.com/apk/res/android">


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

#1075의 디자인 시스템 정리 항목 중 프로덕션 UI에 `_Prototype*` 이름이 남아 있어, 실제 제품 컴포넌트와 임시 시안 컴포넌트의 경계가 흐렸습니다. 동작은 바꾸지 않고 이름만 제품 UI 기준으로 정리하고, 같은 명칭이 다시 들어오지 않도록 저장소 계약 테스트를 추가합니다.

## 작업 내용

- `main.dart`의 `_HomePrototypeHero`, `_HomePrototypeSection`, `_PrototypeCard`, `_PrototypeInfoRow`를 제품 UI 이름으로 변경했습니다.
- `route_search.dart`의 `_RoutePrototype*` 위젯명을 경로 결과 UI 이름으로 변경했습니다.
- `homePrototypeList` test key를 `homeContentList`로 변경하고 widget test 참조를 맞췄습니다.
- `apps/mobile/lib`에 `Prototype` 명칭이 남으면 실패하는 repository contract test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
- RED: `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "프로덕션 모바일 UI 위젯명은 prototype 명칭을 쓰지 않는다"`: `apps/mobile/lib/main.dart still has prototype UI naming`로 실패 확인
- GREEN: `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "프로덕션 모바일 UI 위젯명은 prototype 명칭을 쓰지 않는다"`: exit 0, 122 tests passed
- `node --test tools/ci/repository-contract.test.mjs`: exit 0, 122 tests passed
- `flutter analyze` in `apps/mobile`: exit 0, No issues found
- `flutter test --reporter expanded --fail-fast test/widget_test.dart` in `apps/mobile`: exit 0, 179 tests passed
- `git diff --check`: exit 0
- PR checks: CI, Release Artifacts, SonarCloud, OSV, CodeRabbit status 모두 pass. CodeRabbit 실제 리뷰는 rate limit으로 시작되지 않아 Codex CLI fallback review를 PR review로 기록했습니다.
- Post-merge main checks: CI `28364841407` success, Release Artifacts `28364841082` success.
- Post-merge CD: CD `28365226683`가 merge commit `e40cb6c` 기준으로 생성되어 pending 상태이며, 현재 실패 신호는 없습니다.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| prototype 명칭 차단 | Node test | repository contract test를 RED/GREEN으로 확인 | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern "프로덕션 모바일 UI 위젯명은 prototype 명칭을 쓰지 않는다"` | RED 후 GREEN, 122 tests passed |
| 저장소 계약 | Node test | 전체 repository contract 테스트 실행 | `node --test tools/ci/repository-contract.test.mjs` | 122 tests passed |
| 모바일 정적 분석 | Flutter analyzer | 모바일 앱 analyzer 실행 | `flutter analyze` | No issues found |
| 모바일 widget 회귀 | Flutter widget test | 전체 widget test 실행 | `flutter test --reporter expanded --fail-fast test/widget_test.dart` | 179 tests passed |
| PR CI | GitHub Actions | PR #1094 checks 확인 | CI, Release Artifacts, SonarCloud, OSV, CodeRabbit status | pass |
| 코드 리뷰 fallback | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review 게시 | PR review `Actionable comments posted: 0` | actionable 0, nitpick 0 |
| post-merge main checks | GitHub Actions | merge commit `e40cb6c`의 main push workflow 확인 | CI `28364841407`, Release Artifacts `28364841082` | success |
| post-merge CD | GitHub Actions | merge commit `e40cb6c`의 CD workflow_run 생성 및 현재 상태 확인 | CD `28365226683` | pending, 실패 신호 없음 |
| 화면 캡처 | 해당 없음 | 위젯명과 test key rename만 포함한 비시각 refactor | 증거 불필요 사유: 렌더링 동작과 문구를 바꾸지 않는 명칭 정리이며, widget/analyzer/contract로 회귀를 확인했습니다. | 대체 검증 완료 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 새 컴포넌트 구조를 만들지 않고 기존 private widget 이름만 바꿨습니다.
- 이 PR은 #1075 전체를 닫지 않습니다. 디자인 시스템 정리 중 prototype 명칭 제거 slice만 반영합니다.

## 리스크

- 동작 변경은 의도하지 않았습니다.
- `_App*` 위젯은 아직 `main.dart` 내부 private 위젯입니다. 별도 공통 패키지화는 더 넓은 변경이라 이번 PR에서는 하지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
