### PR TITLE
[Fix] 모바일 사용자 노출 문구를 쉽게 정리

### DIFF
--- a/apps/mobile/lib/app/app_bootstrap.dart
+++ b/apps/mobile/lib/app/app_bootstrap.dart
@@ -136,7 +136,11 @@ Future<void> _runDataPackUpdateSafely({
       userDatabase: userDatabase,
     );
   } catch (error, stackTrace) {
-    reportMobileError(error, stackTrace, context: '데이터팩 업데이트 확인 중 예외가 발생했습니다.');
+    reportMobileError(
+      error,
+      stackTrace,
+      context: '이동 정보 업데이트 확인 중 예외가 발생했습니다.',
+    );
   }
 }
 

--- a/apps/mobile/lib/core/database/catalog/catalog_database.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_database.dart
@@ -260,7 +260,7 @@ class CatalogDatabase extends _$CatalogDatabase {
             installationStatus: const Value('INSTALLED'),
             floorFrom: const Value('B1'),
             floorTo: const Value('1F'),
-            description: const Value('현장 검증 전 이동 보조 시설'),
+            description: const Value('확인이 더 필요한 이동 보조 시설'),
           ),
           FacilitiesCompanion.insert(
             id: 'facility-sangnoksu-accessible-toilet-1',

--- a/apps/mobile/lib/core/datapack/data_pack_client.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_client.dart
@@ -55,7 +55,7 @@ class DataPackClient {
       );
     }
     if (response.statusCode != HttpStatus.ok) {
-      throw const DataPackClientException('데이터팩 정보를 확인하지 못했습니다.');
+      throw const DataPackClientException('이동 정보를 확인하지 못했습니다.');
     }
 
     final body = await utf8
@@ -65,10 +65,10 @@ class DataPackClient {
     try {
       decoded = jsonDecode(body);
     } on FormatException {
-      throw const DataPackClientException('데이터팩 정보 형식이 올바르지 않습니다.');
+      throw const DataPackClientException('이동 정보 형식이 올바르지 않습니다.');
     }
     if (decoded is! Map<String, Object?>) {
-      throw const DataPackClientException('데이터팩 정보 형식이 올바르지 않습니다.');
+      throw const DataPackClientException('이동 정보 형식이 올바르지 않습니다.');
     }
     final DataPackManifest manifest;
     try {
@@ -77,11 +77,11 @@ class DataPackClient {
         productionSigningPublicKey: productionSigningPublicKey,
       );
     } on FormatException {
-      throw const DataPackClientException('데이터팩 정보 형식이 올바르지 않습니다.');
+      throw const DataPackClientException('이동 정보 형식이 올바르지 않습니다.');
     }
     _ensureExpectedManifestChannel(manifest);
     if (manifest.isExpiredAt(_now())) {
-      throw const DataPackClientException('데이터팩 정보가 만료되었습니다.');
+      throw const DataPackClientException('이동 정보가 만료되었습니다.');
     }
     try {
       await stateRepository.ensureManifestCanBeAccepted(manifest);
@@ -123,7 +123,7 @@ class DataPackClient {
     }
     final expiryTtl = expiresAt.difference(checkedAt.toUtc());
     if (expiryTtl <= Duration.zero) {
-      throw const DataPackClientException('데이터팩 정보가 만료되었습니다.');
+      throw const DataPackClientException('이동 정보가 만료되었습니다.');
     }
     return expiryTtl < ttl ? expiryTtl : ttl;
   }
@@ -136,7 +136,7 @@ class DataPackClient {
         ? 'production'
         : expectedManifestChannel.trim();
     if (manifest.channel != expected) {
-      throw const DataPackClientException('데이터팩 manifest 채널이 올바르지 않습니다.');
+      throw const DataPackClientException('이동 정보가 앱과 맞지 않습니다.');
     }
   }
 }

--- a/apps/mobile/lib/core/datapack/data_pack_update_state.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_update_state.dart
@@ -93,7 +93,7 @@ class DataPackUpdateStateRepository {
     if (!manifest.hasReplayProtection) {
       if (await hasAcceptedManifestState()) {
         throw const DataPackManifestReplayException(
-          '데이터팩 manifest 보호 정보가 없습니다.',
+          '앱 이동 정보를 안전하게 확인하지 못했습니다.',
         );
       }
       return;
@@ -106,14 +106,10 @@ class DataPackUpdateStateRepository {
       return;
     }
     if (sequence < accepted.releaseSequence) {
-      throw const DataPackManifestReplayException(
-        '데이터팩 manifest가 이전 release입니다.',
-      );
+      throw const DataPackManifestReplayException('앱 이동 정보가 오래된 버전입니다.');
     }
     if (sequence == accepted.releaseSequence && hash != accepted.manifestHash) {
-      throw const DataPackManifestReplayException(
-        '데이터팩 manifest release가 일치하지 않습니다.',
-      );
+      throw const DataPackManifestReplayException('앱 이동 정보가 서로 맞지 않습니다.');
     }
   }
 

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -180,7 +180,7 @@ class DataPackUpdater {
       if (installedPointer != null) {
         return installedPointer;
       }
-      throw const DataPackClientException('활성 데이터팩을 선택하지 못했습니다.');
+      throw const DataPackClientException('사용할 이동 정보를 선택하지 못했습니다.');
     }
 
     if (results.isEmpty) {
@@ -199,7 +199,7 @@ class DataPackUpdater {
       }
     }
     if (selected == null) {
-      throw const DataPackClientException('활성 데이터팩을 선택하지 못했습니다.');
+      throw const DataPackClientException('사용할 이동 정보를 선택하지 못했습니다.');
     }
     return selected;
   }
@@ -224,13 +224,13 @@ class DataPackUpdater {
         .timeout(_dataPackDownloadTimeout);
     final response = await request.close().timeout(_dataPackDownloadTimeout);
     if (response.statusCode != HttpStatus.ok) {
-      throw const DataPackClientException('데이터팩을 내려받지 못했습니다.');
+      throw const DataPackClientException('이동 정보를 내려받지 못했습니다.');
     }
     final expectedSizeBytes = pack.sizeBytes;
     final contentLength = response.contentLength;
     final maxBytes = expectedSizeBytes ?? _maxDataPackDownloadBytes;
     if (contentLength > maxBytes || contentLength > _maxDataPackDownloadBytes) {
-      throw const DataPackClientException('데이터팩 크기가 허용 범위를 넘었습니다.');
+      throw const DataPackClientException('이동 정보 파일이 너무 큽니다.');
     }
     final directory = await installer.catalogDirectory.create(recursive: true);
     final temporary = File(
@@ -242,7 +242,7 @@ class DataPackUpdater {
       await for (final chunk in response.timeout(_dataPackDownloadTimeout)) {
         received += chunk.length;
         if (received > maxBytes || received > _maxDataPackDownloadBytes) {
-          throw const DataPackClientException('데이터팩 크기가 허용 범위를 넘었습니다.');
+          throw const DataPackClientException('이동 정보 파일이 너무 큽니다.');
         }
         sink.add(chunk);
       }

--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -774,15 +774,8 @@ String _facilityVerificationStatusLabel(String fieldValidationStatus) {
 
 String _facilityUserLocationLabel(String description) {
   var label = description.trim();
-  const internalValidationPhrases = [
-    '현장 검증됨',
-    '현장 검증 전',
-    '현장 재확인 필요',
-    '관리자 검수',
-  ];
-  for (final phrase in internalValidationPhrases) {
-    label = label.replaceAll(phrase, '');
-  }
+  label = label.replaceAll(RegExp(r'현장\s*(검증됨|검증 전|재확인 필요)'), '');
+  label = label.replaceAll(RegExp(r'관리자\s*검수'), '');
   label = label.replaceAll(RegExp(r'\s+'), ' ').trim();
   return label;
 }

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -965,15 +965,8 @@ String _fieldVerificationStatusLabel(String fieldValidationStatus) {
 
 String _facilityUserLocationLabel(String description) {
   var label = description.trim();
-  const internalValidationPhrases = [
-    '현장 검증됨',
-    '현장 검증 전',
-    '현장 재확인 필요',
-    '관리자 검수',
-  ];
-  for (final phrase in internalValidationPhrases) {
-    label = label.replaceAll(phrase, '');
-  }
+  label = label.replaceAll(RegExp(r'현장\s*(검증됨|검증 전|재확인 필요)'), '');
+  label = label.replaceAll(RegExp(r'관리자\s*검수'), '');
   label = label.replaceAll(RegExp(r'\s+'), ' ').trim();
   return label;
 }
@@ -1353,7 +1346,7 @@ class StationDetailController extends ChangeNotifier {
     notifyListeners();
 
     try {
-      // 상세 화면은 기본 정보, 출구, 시설을 함께 읽되 느린 네트워크에서 대기 시간이 합산되지 않게 병렬로 요청한다.
+      // 상세 화면은 요약, 출구, 시설을 함께 읽되 느린 네트워크에서 대기 시간이 합산되지 않게 병렬로 요청한다.
       final responses = await Future.wait<Object>([
         repository.getStationDetail(stationId),
         repository.listStationExits(stationId),

--- a/apps/mobile/test/core/database/mobile_local_database_test.dart
+++ b/apps/mobile/test/core/database/mobile_local_database_test.dart
@@ -1089,7 +1089,7 @@ void main() {
     expect(reports, hasLength(1));
     expect(
       reports.single.context.toString(),
-      contains('데이터팩 업데이트 확인 중 예외가 발생했습니다.'),
+      contains('이동 정보 업데이트 확인 중 예외가 발생했습니다.'),
     );
   });
 

--- a/apps/mobile/test/core/datapack/data_pack_update_state_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_update_state_test.dart
@@ -284,7 +284,7 @@ void main() {
           isA<DataPackClientException>().having(
             (error) => error.message,
             'message',
-            '데이터팩 정보 형식이 올바르지 않습니다.',
+            '이동 정보 형식이 올바르지 않습니다.',
           ),
         ),
       );


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- QA 요청에 따라 최종 사용자가 보는 모바일 앱 문구에서 `데이터팩`, `현장 검증`, `관리자 검수`, `신뢰도`, `측정값`, `점`처럼 어렵거나 개발·운영 내부에 가까운 표현을 계속 제거합니다.
- 이 PR은 #1075 전체 중 모바일 앱 코드에 남은 사용자 노출 가능 문구를 정리하는 후속 작업입니다.

## 작업 내용

- 앱 이동 정보 업데이트 실패 메시지에서 `데이터팩`, `manifest`, `release`, `channel` 표현을 제거하고 `이동 정보`, `앱 이동 정보` 중심의 쉬운 안내로 바꿨습니다.
- 기본 catalog fixture의 시설 설명에서 `현장 검증 전` 표현을 제거했습니다.
- 역 상세와 즐겨찾기 시설의 위치 설명 정리 로직에서 내부 검수 표현을 출력하지 않도록 유지하면서, 코드에 남는 직접 문구 목록을 정규식으로 줄였습니다.
- 관련 데이터 업데이트 예외 메시지 테스트 기대값을 새 문구로 맞췄습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/core/datapack/data_pack_update_state.dart apps/mobile/lib/core/datapack/data_pack_updater.dart apps/mobile/lib/core/datapack/data_pack_client.dart apps/mobile/lib/app/app_bootstrap.dart apps/mobile/lib/core/database/catalog/catalog_database.dart apps/mobile/lib/station_search.dart apps/mobile/lib/favorite_facility.dart`: exit 0.
  - `dart format apps/mobile/test/core/datapack/data_pack_update_state_test.dart apps/mobile/test/core/database/mobile_local_database_test.dart`: exit 0.
  - `flutter test --reporter expanded --fail-fast test/core/database/mobile_local_database_test.dart test/core/datapack/data_pack_update_state_test.dart test/favorite_facility_test.dart test/station_search_test.dart test/widget_test.dart`: exit 0, `All tests passed!`.
  - `flutter analyze`: exit 0, `No issues found!`.
  - `rg "신뢰도|측정값|기본 정보|기본정보|[0-9]+\\s*점|데이터팩|공공 API|정적 추정|관리자 검수|현장 검증|확인 수준|검수 완료|제보 필요|실기기 QA" apps/mobile/lib -n`: exit 1, 모바일 앱 코드 매칭 0건.
  - `git diff --check`: exit 0.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 사용자 노출 문구 검색 | Mobile source | 어려운 표현을 앱 코드에서 검색 | `rg "신뢰도|측정값|기본 정보|기본정보|[0-9]+\\s*점|데이터팩|공공 API|정적 추정|관리자 검수|현장 검증|확인 수준|검수 완료|제보 필요|실기기 QA" apps/mobile/lib -n` | 매칭 0건 |
| 관련 모바일 회귀 | Flutter test | 데이터 업데이트, 로컬 DB 예외 문구, 즐겨찾기 시설, 역 검색, 위젯 테스트 실행 | `flutter test --reporter expanded --fail-fast test/core/database/mobile_local_database_test.dart test/core/datapack/data_pack_update_state_test.dart test/favorite_facility_test.dart test/station_search_test.dart test/widget_test.dart` | `All tests passed!` |
| 정적 분석 | Flutter analyzer | 모바일 분석 실행 | `flutter analyze` | `No issues found!` |
| 화면 증거 | Android/iOS | 스크린샷 미첨부 | 증거 불필요 사유: 화면 배치 변경 없이 사용자 노출 텍스트와 예외 문구만 바꾼 작업입니다. 관련 위젯/semantic 테스트와 앱 코드 검색으로 검증했습니다. | 대체 검증 완료 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/core/datapack/*`의 사용자 안내 문구
  - `apps/mobile/lib/station_search.dart`, `apps/mobile/lib/favorite_facility.dart`의 시설 위치 설명 정리

## 리스크

- 문구 변경 중심이라 기능 동작 리스크는 낮습니다.
- 테스트 fixture에는 내부 표현 제거를 검증하기 위한 입력 문자열이 남아 있습니다. 실제 앱 코드 검색 결과에는 남지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
