### PR TITLE
[Feat] 데이터팩 source snapshot 관리 화면 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
@@ -20,6 +20,7 @@ public enum AdminProgram {
 	INCIDENTS("a-incidents", "운영·분석", "장애관리", "/admin/incidents/page", AdminPermission.OPERATIONS_MANAGE),
 	ROUTE_SEARCHES("a-route-searches", "운영·분석", "경로 검색 분석", "/admin/routes/searches/page", AdminPermission.ADMIN_VIEW),
 	ROUTE_FEEDBACK("a-route-feedback", "운영·분석", "경로 피드백 분석", "/admin/routes/feedback/page", AdminPermission.ADMIN_VIEW),
+	DATAPACK_SOURCE_SNAPSHOTS("a-datapack-source-snapshots", "데이터팩", "Source Snapshots", "/admin/datapack/source-snapshots/page", AdminPermission.DATAPACK_READ),
 	PUSH("a-push", "운영·분석", "푸시 알림", "/admin/notifications/push/page", AdminPermission.DATA_OPERATE),
 	USAGE("a-usage", "운영·분석", "사용 현황", "/admin/usage/activity/page", AdminPermission.SECURITY_AUDIT),
 	SYSTEM("a-system", "운영·분석", "시스템 상태", "/admin/system/page", AdminPermission.SECURITY_AUDIT),

--- a/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/easysubway/common/security/SecurityConfig.java
@@ -117,6 +117,8 @@ public class SecurityConfig {
 				.hasAuthority(AdminPermission.BATCH_RETRY.authority())
 				.requestMatchers(HttpMethod.GET, "/admin/batches/**")
 				.hasAuthority(AdminPermission.DATA_OPERATE.authority())
+				.requestMatchers(HttpMethod.GET, "/admin/datapack/**")
+				.hasAuthority(AdminPermission.DATAPACK_READ.authority())
 				.requestMatchers("/admin/codes/**", "/admin/incidents/**")
 				.hasAuthority(AdminPermission.OPERATIONS_MANAGE.authority())
 				.requestMatchers("/admin/audits/privacy/**")

--- a/backend/src/main/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageController.java
@@ -1,0 +1,124 @@
+package com.easysubway.datapack.adapter.in.web;
+
+import com.easysubway.common.web.pagination.AdminPageRequest;
+import com.easysubway.common.web.pagination.EgovPaginationView;
+import com.easysubway.datapack.adapter.out.persistence.JdbcDataSourceSnapshotRepository;
+import com.easysubway.datapack.domain.DataSourceSnapshot;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.server.ResponseStatusException;
+
+@Controller
+class DataSourceSnapshotAdminPageController {
+
+	private final JdbcDataSourceSnapshotRepository snapshotRepository;
+
+	DataSourceSnapshotAdminPageController(JdbcDataSourceSnapshotRepository snapshotRepository) {
+		this.snapshotRepository = snapshotRepository;
+	}
+
+	@GetMapping("/admin/datapack/source-snapshots/page")
+	@PreAuthorize("hasAuthority('admin.datapack.read')")
+	String listSourceSnapshots(
+		@RequestParam(required = false) Integer page,
+		@RequestParam(required = false) Integer size,
+		Model model
+	) {
+		AdminPageRequest pageRequest = AdminPageRequest.of(page, size);
+		List<SourceSnapshotRow> rows = snapshotRepository
+			.listRecentSnapshots(pageRequest.limitForHasNext(), pageRequest.offset())
+			.stream()
+			.map(SourceSnapshotRow::from)
+			.toList();
+		EgovPaginationView pageView = EgovPaginationView.fromSlice(pageRequest.page(), pageRequest.size(), rows.size());
+		model.addAttribute("snapshots", pageView.visibleItems(rows));
+		model.addAttribute("page", pageView);
+		model.addAttribute(
+			"paginationLinks",
+			pageView.links("/admin/datapack/source-snapshots/page", Collections.emptyMap())
+		);
+		return "admin/datapack/source-snapshots/list";
+	}
+
+	@GetMapping("/admin/datapack/source-snapshots/{snapshotId}/page")
+	@PreAuthorize("hasAuthority('admin.datapack.read')")
+	String sourceSnapshotDetail(@PathVariable String snapshotId, Model model) {
+		SourceSnapshotRow snapshot = snapshotRepository.loadSnapshot(snapshotId)
+			.map(SourceSnapshotRow::from)
+			.orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Source snapshot not found."));
+		model.addAttribute("snapshot", snapshot);
+		return "admin/datapack/source-snapshots/detail";
+	}
+
+	record SourceSnapshotRow(
+		String snapshotId,
+		String sourceId,
+		String provider,
+		LocalDateTime retrievedAt,
+		LocalDateTime sourceUpdatedAt,
+		int rowCount,
+		String rawSha256,
+		String rawObjectUri,
+		String redactedRequestFingerprint,
+		String schemaFingerprint,
+		String snapshotStatus,
+		String schemaStatus,
+		String licenseStatus,
+		String fetchStatus,
+		boolean redistributionAllowed,
+		boolean credentialRedacted,
+		String previousSnapshotId,
+		String diffSummary,
+		LocalDateTime freshnessExpiresAt,
+		LocalDateTime rawRetentionExpiresAt
+	) {
+
+		static SourceSnapshotRow from(DataSourceSnapshot snapshot) {
+			return new SourceSnapshotRow(
+				snapshot.snapshotId(),
+				snapshot.sourceId(),
+				snapshot.provider(),
+				snapshot.retrievedAt(),
+				snapshot.sourceUpdatedAt(),
+				snapshot.rowCount(),
+				snapshot.rawSha256(),
+				snapshot.rawObjectUri(),
+				snapshot.redactedRequestFingerprint(),
+				snapshot.schemaFingerprint(),
+				snapshot.snapshotStatus(),
+				snapshot.schemaStatus(),
+				snapshot.licenseStatus(),
+				snapshot.fetchStatus(),
+				snapshot.redistributionAllowed(),
+				snapshot.credentialRedacted(),
+				valueOrDash(snapshot.previousSnapshotId()),
+				valueOrDash(snapshot.diffSummary()),
+				snapshot.freshnessExpiresAt(),
+				snapshot.rawRetentionExpiresAt()
+			);
+		}
+
+		public String credentialRedactedLabel() {
+			return credentialRedacted ? "credential redacted" : "credential redaction 필요";
+		}
+
+		public String redistributionLabel() {
+			return redistributionAllowed ? "허용" : "불가";
+		}
+
+		private static String valueOrDash(String value) {
+			if (value == null || value.isBlank()) {
+				return "-";
+			}
+			return value;
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDataSourceSnapshotRepository.java
@@ -4,17 +4,16 @@ import com.easysubway.datapack.domain.DataSourceSnapshot;
 import com.easysubway.datapack.domain.InvalidDataSourceSnapshotException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Optional;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Profile;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@Profile("prod")
 public class JdbcDataSourceSnapshotRepository {
 
 	private final JdbcTemplate jdbcTemplate;
@@ -57,6 +56,19 @@ public class JdbcDataSourceSnapshotRepository {
 		} catch (EmptyResultDataAccessException exception) {
 			return Optional.empty();
 		}
+	}
+
+	public List<DataSourceSnapshot> listRecentSnapshots(int limit, int offset) {
+		return jdbcTemplate.query("""
+			SELECT snapshot_id, source_id, provider, retrieved_at, source_updated_at, row_count,
+				raw_sha256, raw_object_uri, redacted_request_fingerprint, schema_fingerprint,
+				snapshot_status, schema_status, license_status, fetch_status, redistribution_allowed,
+				credential_redacted, previous_snapshot_id, diff_summary, freshness_expires_at,
+				raw_retention_expires_at
+			FROM data_source_snapshots
+			ORDER BY retrieved_at DESC, snapshot_id ASC
+			LIMIT ? OFFSET ?
+			""", this::mapSnapshot, limit, offset);
 	}
 
 	private void insert(DataSourceSnapshot snapshot) {

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/detail.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title th:text="${snapshot.snapshotId + ' Source Snapshot'}">Source Snapshot</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<a th:replace="~{admin/fragments/shell :: skipLink}"></a>
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-datapack-source-snapshots')}"></div>
+<main class="admin-main">
+	<div th:replace="~{admin/fragments/shell :: topbar}"></div>
+	<div th:replace="~{admin/fragments/shell :: contentStart}"></div>
+	<header class="admin-page-head">
+		<div>
+			<h1 th:text="${snapshot.snapshotId}">snapshot-id</h1>
+			<p>raw 전문은 노출하지 않고 source snapshot metadata와 evidence 위치만 표시합니다.</p>
+		</div>
+		<div class="admin-actions">
+			<a class="admin-btn" th:href="@{/admin/datapack/source-snapshots/page}">목록</a>
+		</div>
+	</header>
+
+	<section class="admin-panel">
+		<h2>기본 정보</h2>
+		<table>
+			<tbody>
+			<tr><th scope="row">source id</th><td th:text="${snapshot.sourceId}">source-id</td></tr>
+			<tr><th scope="row">provider</th><td th:text="${snapshot.provider}">provider</td></tr>
+			<tr><th scope="row">retrieved at</th><td th:text="${snapshot.retrievedAt}">2026-06-29T03:00</td></tr>
+			<tr><th scope="row">source updated at</th><td th:text="${snapshot.sourceUpdatedAt}">2026-06-28T00:00</td></tr>
+			<tr><th scope="row">row count</th><td th:text="${snapshot.rowCount}">0</td></tr>
+			<tr><th scope="row">previous snapshot</th><td th:text="${snapshot.previousSnapshotId}">-</td></tr>
+			<tr><th scope="row">diff summary</th><td th:text="${snapshot.diffSummary}">-</td></tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section class="admin-panel">
+		<h2>상태</h2>
+		<table>
+			<tbody>
+			<tr><th scope="row">snapshot status</th><td th:text="${snapshot.snapshotStatus}">LOCKED</td></tr>
+			<tr><th scope="row">schema status</th><td th:text="${snapshot.schemaStatus}">PASS</td></tr>
+			<tr><th scope="row">license status</th><td th:text="${snapshot.licenseStatus}">PASS</td></tr>
+			<tr><th scope="row">fetch status</th><td th:text="${snapshot.fetchStatus}">SUCCESS</td></tr>
+			<tr><th scope="row">redistribution</th><td th:text="${snapshot.redistributionLabel()}">허용</td></tr>
+			<tr><th scope="row">credential redacted</th><td th:text="${snapshot.credentialRedactedLabel()}">credential redacted</td></tr>
+			<tr><th scope="row">freshness expires</th><td th:text="${snapshot.freshnessExpiresAt}">2026-07-06T03:00</td></tr>
+			<tr><th scope="row">raw retention</th><td th:text="${snapshot.rawRetentionExpiresAt}">2026-09-29T03:00</td></tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section class="admin-panel">
+		<h2>Evidence</h2>
+		<table>
+			<tbody>
+			<tr><th scope="row">raw sha256</th><td th:text="${snapshot.rawSha256}">sha256</td></tr>
+			<tr><th scope="row">raw object uri</th><td th:text="${snapshot.rawObjectUri}">s3://bucket/object.json</td></tr>
+			<tr><th scope="row">request fingerprint</th><td th:text="${snapshot.redactedRequestFingerprint}">sha256</td></tr>
+			<tr><th scope="row">schema fingerprint</th><td th:text="${snapshot.schemaFingerprint}">sha256</td></tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/source-snapshots/list.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Source Snapshots</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<a th:replace="~{admin/fragments/shell :: skipLink}"></a>
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-datapack-source-snapshots')}"></div>
+<main class="admin-main">
+	<div th:replace="~{admin/fragments/shell :: topbar}"></div>
+	<div th:replace="~{admin/fragments/shell :: contentStart}"></div>
+	<header class="admin-page-head">
+		<div>
+			<h1>Source Snapshots</h1>
+			<p>데이터팩 candidate 입력으로 쓰는 공식 source snapshot의 고정 상태와 evidence hash를 확인합니다.</p>
+		</div>
+	</header>
+
+	<section>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">snapshot</th>
+				<th scope="col">source</th>
+				<th scope="col">provider</th>
+				<th scope="col">retrieved</th>
+				<th scope="col">rows</th>
+				<th scope="col">status</th>
+				<th scope="col">raw sha256</th>
+				<th scope="col">diff</th>
+				<th scope="col">상세</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:if="${snapshots.isEmpty()}">
+				<td colspan="9">source snapshot이 없습니다.</td>
+			</tr>
+			<tr th:each="snapshot : ${snapshots}">
+				<td th:text="${snapshot.snapshotId}">snapshot-id</td>
+				<td th:text="${snapshot.sourceId}">source-id</td>
+				<td th:text="${snapshot.provider}">provider</td>
+				<td th:text="${snapshot.retrievedAt}">2026-06-29T03:00</td>
+				<td th:text="${snapshot.rowCount}">0</td>
+				<td>
+					<span th:text="${snapshot.snapshotStatus}">LOCKED</span>
+					<span th:text="${snapshot.schemaStatus}">PASS</span>
+					<span th:text="${snapshot.licenseStatus}">PASS</span>
+					<span th:text="${snapshot.fetchStatus}">SUCCESS</span>
+				</td>
+				<td th:text="${snapshot.rawSha256}">sha256</td>
+				<td th:text="${snapshot.diffSummary}">-</td>
+				<td>
+					<a class="detail-link"
+					   th:href="@{/admin/datapack/source-snapshots/{snapshotId}/page(snapshotId=${snapshot.snapshotId})}">보기</a>
+				</td>
+			</tr>
+			</tbody>
+		</table>
+		<div th:replace="~{admin/fragments/pagination :: pager('Source snapshot 목록 페이지', ${page}, ${paginationLinks})}"></div>
+	</section>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageControllerTest.java
@@ -1,0 +1,106 @@
+package com.easysubway.datapack.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("관리자 데이터팩 source snapshot 화면")
+class DataSourceSnapshotAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.update("DELETE FROM data_source_snapshots");
+		jdbcTemplate.update("""
+			INSERT INTO data_source_snapshots (
+				snapshot_id, source_id, provider, retrieved_at, source_updated_at, row_count,
+				raw_sha256, raw_object_uri, redacted_request_fingerprint, schema_fingerprint,
+				snapshot_status, schema_status, license_status, fetch_status, redistribution_allowed,
+				credential_redacted, previous_snapshot_id, diff_summary, freshness_expires_at,
+				raw_retention_expires_at
+			)
+			VALUES ('snapshot-kric-20260629', 'kric-station-elevator', '국가철도공단',
+				'2026-06-29 03:00:00', '2026-06-28 00:00:00', 12345,
+				?, 's3://easysubway-datapack-sources/kric-station-elevator/snapshot-kric-20260629.json',
+				?, ?, 'LOCKED', 'PASS', 'PASS', 'SUCCESS', TRUE, TRUE, NULL,
+				'이전 snapshot 대비 +12 rows', '2026-07-06 03:00:00', '2026-09-29 03:00:00')
+			""",
+			"a".repeat(64),
+			"b".repeat(64),
+			"c".repeat(64)
+		);
+	}
+
+	@Test
+	@DisplayName("datapack read 권한 관리자는 source snapshot 목록을 확인한다")
+	void datapackReadAdminViewsSourceSnapshotList() throws Exception {
+		String html = mockMvc.perform(get("/admin/datapack/source-snapshots/page")
+				.with(user("datapack-viewer").authorities(new SimpleGrantedAuthority("admin.datapack.read"))))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("Source Snapshots")
+			.contains("kric-station-elevator")
+			.contains("국가철도공단")
+			.contains("12345")
+			.contains("LOCKED")
+			.contains("PASS")
+			.contains("SUCCESS")
+			.contains("이전 snapshot 대비 +12 rows")
+			.contains("/admin/datapack/source-snapshots/snapshot-kric-20260629/page")
+			.doesNotContain("serviceKey");
+	}
+
+	@Test
+	@DisplayName("source snapshot 상세는 raw 전문 없이 metadata와 evidence 위치만 보여준다")
+	void datapackReadAdminViewsSourceSnapshotDetail() throws Exception {
+		String html = mockMvc.perform(get("/admin/datapack/source-snapshots/snapshot-kric-20260629/page")
+				.with(user("datapack-viewer").authorities(new SimpleGrantedAuthority("admin.datapack.read"))))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("snapshot-kric-20260629")
+			.contains("raw sha256")
+			.contains("s3://easysubway-datapack-sources/kric-station-elevator/snapshot-kric-20260629.json")
+			.contains("credential redacted")
+			.contains("raw retention")
+			.doesNotContain("name=\"commandToken\"")
+			.doesNotContain("수집 실행")
+			.doesNotContain("serviceKey");
+	}
+
+	@Test
+	@DisplayName("datapack read 권한이 없으면 source snapshot 화면에 접근할 수 없다")
+	void sourceSnapshotPageRequiresDatapackReadPermission() throws Exception {
+		mockMvc.perform(get("/admin/datapack/source-snapshots/page")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view"))))
+			.andExpect(status().isForbidden());
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #1111

## 작업 배경

#1081 데이터팩 운영 콘솔은 candidate 입력이 되는 source snapshot을 사람이 검수할 수 있어야 한다. 이번 변경은 최종 데이터팩 파일 편집 기능 없이, 고정된 source snapshot metadata와 evidence 위치를 읽기 전용으로 확인하는 admin 화면을 추가한다.

## 작업 내용

- `/admin/datapack/source-snapshots/page` 목록 화면과 `/admin/datapack/source-snapshots/{snapshotId}/page` 상세 화면을 추가했다.
- `admin.datapack.read` 권한으로 `/admin/datapack/**` GET 접근을 제한하고, admin sidebar에 Source Snapshots 메뉴를 추가했다.
- source snapshot repository에 최신 snapshot 목록 조회를 추가했다.
- 목록/상세 화면이 raw 전문이나 credential을 노출하지 않고, 상세 화면에 source snapshot 조작 form을 두지 않는 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests '*DataSourceSnapshotAdminPageControllerTest'`: 3 tests passed, exit 0
  - `./gradlew test --tests '*AdminV3PageSmokeTest' --tests '*DataSourceSnapshotAdminPageControllerTest' --tests '*JdbcDataSourceSnapshotRepositoryTest'`: exit 0
  - `/usr/local/bin/node --test tools/ci/repository-contract.test.mjs --test-name-pattern "관리자|데이터팩"`: 123 tests passed, exit 0
  - `./gradlew test`: exit 0
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Source Snapshot 목록/상세 | Backend admin | MockMvc 렌더링 테스트 | `./gradlew test --tests '*DataSourceSnapshotAdminPageControllerTest'` | 3 tests passed |
| admin navigation/security | Backend admin | Smoke/repository 테스트 | `./gradlew test --tests '*AdminV3PageSmokeTest' --tests '*DataSourceSnapshotAdminPageControllerTest' --tests '*JdbcDataSourceSnapshotRepositoryTest'` | pass |
| repository contract | Local Node 24 | repository contract test | `/usr/local/bin/node --test tools/ci/repository-contract.test.mjs --test-name-pattern "관리자|데이터팩"` | 123 tests passed |
| backend regression | Backend | 전체 backend test | `./gradlew test` | pass |
| whitespace | local git | diff whitespace check | `git diff --check` | pass |

## 리뷰어 메모

- 새 화면은 read-only다. source fetch 실행, raw body 다운로드, snapshot 생성/수정은 포함하지 않았다.
- `JdbcDataSourceSnapshotRepository`는 admin 조회가 필요해 기본 profile에서도 bean으로 등록되도록 했다.

## 리스크

- 실제 source snapshot 데이터가 없는 환경에서는 빈 목록만 표시된다.
- 목록/상세 화면은 현재 DB ledger 조회만 제공하고, source diff 상세 drill-down은 후속 Alias/Quarantine UI에서 다룬다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI fallback은 필요하지 않았다.
- [x] 배포 영향 없음. merge 후 post-merge workflow 실패 여부만 확인한다.
