### PR TITLE
[Feat] 데이터팩 alias/quarantine 검수 큐 화면 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
@@ -21,6 +21,7 @@ public enum AdminProgram {
 	ROUTE_SEARCHES("a-route-searches", "운영·분석", "경로 검색 분석", "/admin/routes/searches/page", AdminPermission.ADMIN_VIEW),
 	ROUTE_FEEDBACK("a-route-feedback", "운영·분석", "경로 피드백 분석", "/admin/routes/feedback/page", AdminPermission.ADMIN_VIEW),
 	DATAPACK_SOURCE_SNAPSHOTS("a-datapack-source-snapshots", "데이터팩", "Source Snapshots", "/admin/datapack/source-snapshots/page", AdminPermission.DATAPACK_READ),
+	DATAPACK_ALIAS_QUARANTINE("a-datapack-alias-quarantine", "데이터팩", "Alias / Quarantine", "/admin/datapack/alias-quarantine/page", AdminPermission.DATAPACK_READ),
 	PUSH("a-push", "운영·분석", "푸시 알림", "/admin/notifications/push/page", AdminPermission.DATA_OPERATE),
 	USAGE("a-usage", "운영·분석", "사용 현황", "/admin/usage/activity/page", AdminPermission.SECURITY_AUDIT),
 	SYSTEM("a-system", "운영·분석", "시스템 상태", "/admin/system/page", AdminPermission.SECURITY_AUDIT),

--- a/backend/src/main/java/com/easysubway/datapack/adapter/in/web/AliasQuarantineAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/in/web/AliasQuarantineAdminPageController.java
@@ -1,0 +1,124 @@
+package com.easysubway.datapack.adapter.in.web;
+
+import com.easysubway.datapack.adapter.out.persistence.JdbcAliasQuarantineQueueRepository;
+import com.easysubway.datapack.adapter.out.persistence.JdbcAliasQuarantineQueueRepository.AliasApprovalRow;
+import com.easysubway.datapack.adapter.out.persistence.JdbcAliasQuarantineQueueRepository.QuarantineRow;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class AliasQuarantineAdminPageController {
+
+	private static final int QUEUE_LIMIT = 100;
+
+	private final JdbcAliasQuarantineQueueRepository queueRepository;
+
+	AliasQuarantineAdminPageController(JdbcAliasQuarantineQueueRepository queueRepository) {
+		this.queueRepository = queueRepository;
+	}
+
+	@GetMapping("/admin/datapack/alias-quarantine/page")
+	@PreAuthorize("hasAuthority('admin.datapack.read')")
+	String aliasQuarantineQueue(Model model) {
+		model.addAttribute("aliasApprovals", queueRepository.listRecentAliasApprovals(QUEUE_LIMIT).stream()
+			.map(AliasApprovalView::from)
+			.toList());
+		model.addAttribute("quarantineRecords", queueRepository.listRecentQuarantineRecords(QUEUE_LIMIT).stream()
+			.map(QuarantineView::from)
+			.toList());
+		return "admin/datapack/alias-quarantine/list";
+	}
+
+	record AliasApprovalView(
+		String id,
+		String sourceId,
+		String sourceSnapshotId,
+		String providerEntity,
+		String canonicalEntity,
+		int confidence,
+		String matchMethod,
+		String approvalStatus,
+		String requestedBy,
+		String approvedBy,
+		String approvedAt,
+		String evidenceHash,
+		String supersededBy,
+		LocalDateTime createdAt
+	) {
+
+		static AliasApprovalView from(AliasApprovalRow row) {
+			return new AliasApprovalView(
+				row.id(),
+				row.sourceId(),
+				row.sourceSnapshotId(),
+				row.providerEntityType() + ":" + row.providerEntityId(),
+				row.canonicalEntityType() + ":" + row.canonicalEntityId(),
+				row.confidence(),
+				row.matchMethod(),
+				row.approvalStatus(),
+				row.requestedBy(),
+				valueOrDash(row.approvedBy()),
+				valueOrDash(row.approvedAt()),
+				row.evidenceHash(),
+				valueOrDash(row.supersededBy()),
+				row.createdAt()
+			);
+		}
+	}
+
+	record QuarantineView(
+		String id,
+		String sourceId,
+		String sourceSnapshotId,
+		String providerRecordHash,
+		String reasonCode,
+		String severity,
+		String redactedExcerpt,
+		String resolutionStatus,
+		String resolvedBy,
+		String resolvedAt,
+		LocalDateTime createdAt,
+		String latestResolution,
+		String latestCanonicalEntity
+	) {
+
+		static QuarantineView from(QuarantineRow row) {
+			return new QuarantineView(
+				row.id(),
+				row.sourceId(),
+				row.sourceSnapshotId(),
+				row.providerRecordHash(),
+				row.reasonCode(),
+				row.severity(),
+				valueOrDash(row.redactedExcerpt()),
+				row.resolutionStatus(),
+				valueOrDash(row.resolvedBy()),
+				valueOrDash(row.resolvedAt()),
+				row.createdAt(),
+				valueOrDash(row.latestResolutionStatus()),
+				entityOrDash(row.latestCanonicalEntityType(), row.latestCanonicalEntityId())
+			);
+		}
+	}
+
+	private static String entityOrDash(String type, String id) {
+		if (type == null || type.isBlank() || id == null || id.isBlank()) {
+			return "-";
+		}
+		return type + ":" + id;
+	}
+
+	private static String valueOrDash(Object value) {
+		if (value == null) {
+			return "-";
+		}
+		if (value instanceof String text && text.isBlank()) {
+			return "-";
+		}
+		return value.toString();
+	}
+}

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcAliasQuarantineQueueRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcAliasQuarantineQueueRepository.java
@@ -5,6 +5,7 @@ import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.List;
 import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -13,6 +14,7 @@ public class JdbcAliasQuarantineQueueRepository {
 
 	private final JdbcTemplate jdbcTemplate;
 
+	@Autowired
 	public JdbcAliasQuarantineQueueRepository(DataSource dataSource) {
 		this.jdbcTemplate = new JdbcTemplate(dataSource);
 	}

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcAliasQuarantineQueueRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcAliasQuarantineQueueRepository.java
@@ -1,0 +1,142 @@
+package com.easysubway.datapack.adapter.out.persistence;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcAliasQuarantineQueueRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	public JdbcAliasQuarantineQueueRepository(DataSource dataSource) {
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+
+	public List<AliasApprovalRow> listRecentAliasApprovals(int limit) {
+		return jdbcTemplate.query("""
+			SELECT id, source_id, source_snapshot_id, provider_entity_type, provider_entity_id,
+				canonical_entity_type, canonical_entity_id, confidence, match_method,
+				approval_status, requested_by, approved_by, approved_at, evidence_hash,
+				superseded_by, created_at
+			FROM external_alias_approvals
+			ORDER BY
+				CASE approval_status WHEN 'PENDING' THEN 0 ELSE 1 END,
+				created_at DESC,
+				id ASC
+			LIMIT ?
+			""", this::mapAliasApproval, limit);
+	}
+
+	public List<QuarantineRow> listRecentQuarantineRecords(int limit) {
+		return jdbcTemplate.query("""
+			SELECT q.id, q.source_id, q.source_snapshot_id, q.provider_record_hash,
+				q.reason_code, q.severity, q.redacted_excerpt, q.resolution_status,
+				q.resolved_by, q.resolved_at, q.created_at,
+				r.resolution_status AS latest_resolution_status,
+				r.canonical_entity_type AS latest_canonical_entity_type,
+				r.canonical_entity_id AS latest_canonical_entity_id
+			FROM source_quarantine_records q
+			LEFT JOIN source_quarantine_resolutions r
+				ON r.id = (
+					SELECT r2.id
+					FROM source_quarantine_resolutions r2
+					WHERE r2.quarantine_record_id = q.id
+					ORDER BY r2.resolved_at DESC, r2.id DESC
+					LIMIT 1
+				)
+			ORDER BY
+				CASE q.resolution_status WHEN 'OPEN' THEN 0 ELSE 1 END,
+				q.created_at DESC,
+				q.id ASC
+			LIMIT ?
+			""", this::mapQuarantine, limit);
+	}
+
+	private AliasApprovalRow mapAliasApproval(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new AliasApprovalRow(
+			resultSet.getString("id"),
+			resultSet.getString("source_id"),
+			resultSet.getString("source_snapshot_id"),
+			resultSet.getString("provider_entity_type"),
+			resultSet.getString("provider_entity_id"),
+			resultSet.getString("canonical_entity_type"),
+			resultSet.getString("canonical_entity_id"),
+			resultSet.getInt("confidence"),
+			resultSet.getString("match_method"),
+			resultSet.getString("approval_status"),
+			resultSet.getString("requested_by"),
+			resultSet.getString("approved_by"),
+			toLocalDateTime(resultSet, "approved_at"),
+			resultSet.getString("evidence_hash"),
+			resultSet.getString("superseded_by"),
+			toLocalDateTime(resultSet, "created_at")
+		);
+	}
+
+	private QuarantineRow mapQuarantine(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new QuarantineRow(
+			resultSet.getString("id"),
+			resultSet.getString("source_id"),
+			resultSet.getString("source_snapshot_id"),
+			resultSet.getString("provider_record_hash"),
+			resultSet.getString("reason_code"),
+			resultSet.getString("severity"),
+			resultSet.getString("redacted_excerpt"),
+			resultSet.getString("resolution_status"),
+			resultSet.getString("resolved_by"),
+			toLocalDateTime(resultSet, "resolved_at"),
+			toLocalDateTime(resultSet, "created_at"),
+			resultSet.getString("latest_resolution_status"),
+			resultSet.getString("latest_canonical_entity_type"),
+			resultSet.getString("latest_canonical_entity_id")
+		);
+	}
+
+	private LocalDateTime toLocalDateTime(ResultSet resultSet, String column) throws SQLException {
+		var timestamp = resultSet.getTimestamp(column);
+		return timestamp == null ? null : timestamp.toLocalDateTime();
+	}
+
+	public record AliasApprovalRow(
+		String id,
+		String sourceId,
+		String sourceSnapshotId,
+		String providerEntityType,
+		String providerEntityId,
+		String canonicalEntityType,
+		String canonicalEntityId,
+		int confidence,
+		String matchMethod,
+		String approvalStatus,
+		String requestedBy,
+		String approvedBy,
+		LocalDateTime approvedAt,
+		String evidenceHash,
+		String supersededBy,
+		LocalDateTime createdAt
+	) {
+	}
+
+	public record QuarantineRow(
+		String id,
+		String sourceId,
+		String sourceSnapshotId,
+		String providerRecordHash,
+		String reasonCode,
+		String severity,
+		String redactedExcerpt,
+		String resolutionStatus,
+		String resolvedBy,
+		LocalDateTime resolvedAt,
+		LocalDateTime createdAt,
+		String latestResolutionStatus,
+		String latestCanonicalEntityType,
+		String latestCanonicalEntityId
+	) {
+	}
+}

--- a/backend/src/main/resources/templates/admin/datapack/alias-quarantine/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/alias-quarantine/list.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Alias / Quarantine</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<a th:replace="~{admin/fragments/shell :: skipLink}"></a>
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-datapack-alias-quarantine')}"></div>
+<main class="admin-main">
+	<div th:replace="~{admin/fragments/shell :: topbar}"></div>
+	<div th:replace="~{admin/fragments/shell :: contentStart}"></div>
+	<header class="admin-page-head">
+		<div>
+			<h1>Alias / Quarantine</h1>
+			<p>candidate 입력 전에 source row 매핑 충돌과 quarantine blocker를 읽기 전용으로 확인합니다.</p>
+		</div>
+	</header>
+
+	<section class="admin-panel">
+		<h2>Alias 검수 큐</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">id</th>
+				<th scope="col">source</th>
+				<th scope="col">snapshot</th>
+				<th scope="col">provider entity</th>
+				<th scope="col">canonical entity</th>
+				<th scope="col">confidence</th>
+				<th scope="col">method</th>
+				<th scope="col">status</th>
+				<th scope="col">requested</th>
+				<th scope="col">approved</th>
+				<th scope="col">evidence</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:if="${aliasApprovals.isEmpty()}">
+				<td colspan="11">alias 검수 row가 없습니다.</td>
+			</tr>
+			<tr th:each="alias : ${aliasApprovals}">
+				<td th:text="${alias.id}">alias-id</td>
+				<td th:text="${alias.sourceId}">source-id</td>
+				<td th:text="${alias.sourceSnapshotId}">snapshot-id</td>
+				<td th:text="${alias.providerEntity}">STATION:provider-id</td>
+				<td th:text="${alias.canonicalEntity}">STATION:station-id</td>
+				<td th:text="${alias.confidence}">90</td>
+				<td th:text="${alias.matchMethod}">AUTO</td>
+				<td th:text="${alias.approvalStatus}">PENDING</td>
+				<td th:text="${alias.requestedBy}">qa</td>
+				<td>
+					<span th:text="${alias.approvedBy}">-</span>
+					<span th:text="${alias.approvedAt}">-</span>
+				</td>
+				<td th:text="${alias.evidenceHash}">sha256</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section class="admin-panel">
+		<h2>Quarantine 큐</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">id</th>
+				<th scope="col">source</th>
+				<th scope="col">snapshot</th>
+				<th scope="col">provider hash</th>
+				<th scope="col">reason</th>
+				<th scope="col">severity</th>
+				<th scope="col">status</th>
+				<th scope="col">latest resolution</th>
+				<th scope="col">canonical</th>
+				<th scope="col">resolved</th>
+				<th scope="col">excerpt</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:if="${quarantineRecords.isEmpty()}">
+				<td colspan="11">quarantine row가 없습니다.</td>
+			</tr>
+			<tr th:each="record : ${quarantineRecords}">
+				<td th:text="${record.id}">quarantine-id</td>
+				<td th:text="${record.sourceId}">source-id</td>
+				<td th:text="${record.sourceSnapshotId}">snapshot-id</td>
+				<td th:text="${record.providerRecordHash}">sha256</td>
+				<td th:text="${record.reasonCode}">ALIAS_CONFLICT</td>
+				<td th:text="${record.severity}">P1</td>
+				<td th:text="${record.resolutionStatus}">OPEN</td>
+				<td th:text="${record.latestResolution}">-</td>
+				<td th:text="${record.latestCanonicalEntity}">-</td>
+				<td>
+					<span th:text="${record.resolvedBy}">-</span>
+					<span th:text="${record.resolvedAt}">-</span>
+				</td>
+				<td th:text="${record.redactedExcerpt}">redacted excerpt</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/AliasQuarantineAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/AliasQuarantineAdminPageControllerTest.java
@@ -1,0 +1,160 @@
+package com.easysubway.datapack.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("관리자 데이터팩 alias/quarantine 검수 큐 화면")
+class AliasQuarantineAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.update("DELETE FROM source_quarantine_resolutions");
+		jdbcTemplate.update("DELETE FROM source_quarantine_records");
+		jdbcTemplate.update("DELETE FROM external_alias_approvals");
+		jdbcTemplate.update("DELETE FROM data_source_snapshots");
+		insertSnapshot();
+		insertAliasApproval();
+		insertQuarantineRecord();
+		insertResolvedQuarantineRecord();
+	}
+
+	@Test
+	@DisplayName("datapack read 권한 관리자는 alias/quarantine 검수 큐를 확인한다")
+	void datapackReadAdminViewsAliasQuarantineQueue() throws Exception {
+		String html = mockMvc.perform(get("/admin/datapack/alias-quarantine/page")
+				.with(user("datapack-viewer").authorities(new SimpleGrantedAuthority("admin.datapack.read"))))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("Alias / Quarantine")
+			.contains("alias-station-1")
+			.contains("provider-station-code-243")
+			.contains("station-sangnoksu")
+			.contains("92")
+			.contains("PENDING")
+			.contains("quarantine-open-1")
+			.contains("ALIAS_CONFLICT")
+			.contains("provider line=4, station=상록수")
+			.contains("quarantine-resolved-1")
+			.contains("ALIAS_APPROVED")
+			.contains("station-sadang")
+			.doesNotContain("name=\"commandToken\"")
+			.doesNotContain("승인 저장")
+			.doesNotContain("해결 저장")
+			.doesNotContain("serviceKey");
+	}
+
+	@Test
+	@DisplayName("datapack read 권한이 없으면 alias/quarantine 화면에 접근할 수 없다")
+	void aliasQuarantinePageRequiresDatapackReadPermission() throws Exception {
+		mockMvc.perform(get("/admin/datapack/alias-quarantine/page")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view"))))
+			.andExpect(status().isForbidden());
+	}
+
+	private void insertSnapshot() {
+		jdbcTemplate.update("""
+			INSERT INTO data_source_snapshots (
+				snapshot_id, source_id, provider, retrieved_at, source_updated_at, row_count,
+				raw_sha256, raw_object_uri, redacted_request_fingerprint, schema_fingerprint,
+				snapshot_status, schema_status, license_status, fetch_status, redistribution_allowed,
+				credential_redacted, previous_snapshot_id, diff_summary, freshness_expires_at,
+				raw_retention_expires_at
+			)
+			VALUES ('snapshot-kric-20260629', 'kric-station-elevator', '국가철도공단',
+				'2026-06-29 03:00:00', '2026-06-28 00:00:00', 12345,
+				?, 's3://easysubway-datapack-sources/kric-station-elevator/snapshot-kric-20260629.json',
+				?, ?, 'LOCKED', 'PASS', 'PASS', 'SUCCESS', TRUE, TRUE, NULL,
+				'이전 snapshot 대비 +12 rows', '2026-07-06 03:00:00', '2026-09-29 03:00:00')
+			""",
+			"a".repeat(64),
+			"b".repeat(64),
+			"c".repeat(64)
+		);
+	}
+
+	private void insertAliasApproval() {
+		jdbcTemplate.update("""
+			INSERT INTO external_alias_approvals (
+				id, source_id, source_snapshot_id, provider_entity_type, provider_entity_id,
+				canonical_entity_type, canonical_entity_id, confidence, match_method,
+				approval_status, requested_by, approved_by, approved_at, evidence_hash,
+				superseded_by, created_at
+			)
+			VALUES ('alias-station-1', 'kric-station-elevator', 'snapshot-kric-20260629',
+				'STATION', 'provider-station-code-243', 'STATION', 'station-sangnoksu',
+				92, 'AUTO_NAME_LINE', 'PENDING', 'qa-operator', NULL, NULL, ?,
+				NULL, '2026-06-29 03:10:00')
+			""",
+			"d".repeat(64)
+		);
+	}
+
+	private void insertQuarantineRecord() {
+		jdbcTemplate.update("""
+			INSERT INTO source_quarantine_records (
+				id, source_id, source_snapshot_id, provider_record_hash, reason_code,
+				severity, redacted_excerpt, resolution_status, resolved_by, resolved_at,
+				created_at
+			)
+			VALUES ('quarantine-open-1', 'kric-station-elevator', 'snapshot-kric-20260629',
+				?, 'ALIAS_CONFLICT', 'P1', 'provider line=4, station=상록수',
+				'OPEN', NULL, NULL, '2026-06-29 03:20:00')
+			""",
+			"e".repeat(64)
+		);
+	}
+
+	private void insertResolvedQuarantineRecord() {
+		jdbcTemplate.update("""
+			INSERT INTO source_quarantine_records (
+				id, source_id, source_snapshot_id, provider_record_hash, reason_code,
+				severity, redacted_excerpt, resolution_status, resolved_by, resolved_at,
+				created_at
+			)
+			VALUES ('quarantine-resolved-1', 'kric-station-elevator', 'snapshot-kric-20260629',
+				?, 'MISSING_CANONICAL_STATION', 'P2', 'provider station=사당',
+				'RESOLVED', 'qa-reviewer', '2026-06-29 03:35:00', '2026-06-29 03:30:00')
+			""",
+			"f".repeat(64)
+		);
+		jdbcTemplate.update("""
+			INSERT INTO source_quarantine_resolutions (
+				id, quarantine_record_id, resolution_status, resolution_reason,
+				resolved_by, resolved_at, canonical_entity_type, canonical_entity_id,
+				evidence_hash
+			)
+			VALUES ('resolution-1', 'quarantine-resolved-1', 'ALIAS_APPROVED',
+				'station alias approved', 'qa-reviewer', '2026-06-29 03:35:00',
+				'STATION', 'station-sadang', ?)
+			""",
+			"0".repeat(64)
+		);
+	}
+}

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageControllerTest.java
@@ -31,6 +31,9 @@ class DataSourceSnapshotAdminPageControllerTest {
 
 	@BeforeEach
 	void setUp() {
+		jdbcTemplate.update("DELETE FROM source_quarantine_resolutions");
+		jdbcTemplate.update("DELETE FROM source_quarantine_records");
+		jdbcTemplate.update("DELETE FROM external_alias_approvals");
 		jdbcTemplate.update("DELETE FROM data_source_snapshots");
 		jdbcTemplate.update("""
 			INSERT INTO data_source_snapshots (


### PR DESCRIPTION
## 관련 이슈

close #1114

## 작업 배경

#1081 데이터팩 운영 콘솔은 candidate 입력 전 alias 매핑 충돌과 quarantine blocker를 운영자가 확인할 수 있어야 한다. 이번 변경은 기존 ledger를 직접 수정하지 않고, 검수 대기 상태를 읽기 전용으로 확인하는 admin 화면을 추가한다.

## 작업 내용

- `/admin/datapack/alias-quarantine/page` 화면과 admin sidebar 메뉴를 추가했다.
- `external_alias_approvals`와 `source_quarantine_records`/`source_quarantine_resolutions` 최신 row를 조회해 alias 검수 큐와 quarantine 큐로 표시한다.
- 화면에는 승인/해결 form을 두지 않고, `admin.datapack.read` 권한으로 GET 접근을 제한한다.
- source snapshot controller 테스트가 alias/quarantine FK row와 격리되도록 cleanup 순서를 보강했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests '*AliasQuarantineAdminPageControllerTest'`: 2 tests passed, exit 0
  - `./gradlew test --tests '*AdminV3PageSmokeTest' --tests '*AliasQuarantineAdminPageControllerTest' --tests '*DataSourceSnapshotAdminPageControllerTest'`: exit 0
  - `/usr/local/bin/node --test tools/ci/repository-contract.test.mjs`: 123 tests passed, exit 0
  - `./gradlew test`: exit 0
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Alias / Quarantine 큐 | Backend admin | MockMvc 렌더링 테스트 | `./gradlew test --tests '*AliasQuarantineAdminPageControllerTest'` | 2 tests passed |
| 권한 차단 | Backend admin | MockMvc 403 테스트 | `./gradlew test --tests '*AliasQuarantineAdminPageControllerTest'` | pass |
| read-only 보장 | Backend admin | `commandToken`, 승인/해결 저장 문구, credential 미노출 assertion | `./gradlew test --tests '*AliasQuarantineAdminPageControllerTest'` | pass |
| admin navigation 영향 | Backend admin | admin smoke/controller 조합 테스트 | `./gradlew test --tests '*AdminV3PageSmokeTest' --tests '*AliasQuarantineAdminPageControllerTest' --tests '*DataSourceSnapshotAdminPageControllerTest'` | pass |
| repository contract | Local Node 24 | repository contract test | `/usr/local/bin/node --test tools/ci/repository-contract.test.mjs` | 123 tests passed |
| backend regression | Backend | 전체 backend test | `./gradlew test` | pass |
| whitespace | local git | diff whitespace check | `git diff --check` | pass |

## 리뷰어 메모

- 새 화면은 read-only다. alias 승인/반려, quarantine 해결 command는 이번 PR 범위가 아니다.
- 한 화면에 최근 100건만 표시한다. 운영상 paging/filter가 필요해지면 이 화면에 붙이면 된다.

## 리스크

- 대량 ledger 환경에서는 최근 row 위주로 보이므로 세부 검색은 후속 화면이 필요하다.
- latest quarantine resolution은 가장 최근 `resolved_at` row만 표시한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI fallback은 필요하지 않았다.
- [x] 배포 영향 없음. merge 후 post-merge workflow 실패 여부만 확인한다.
