### PR TITLE
[Fix] 홈 길찾기 탭 전환 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1502,7 +1502,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
     final heroSection = _HomeHero(
       profile: currentProfile,
-      onRouteSearch: openRouteSearch,
+      onRouteSearch: openRouteTab,
       onStationSearch: () => unawaited(openStationSearch()),
       onProfileTap: openSettings,
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -988,6 +988,38 @@ void main() {
     );
   });
 
+  testWidgets('홈 길찾기 버튼은 새 화면이 아니라 shell 길찾기 탭으로 전환한다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('routeSearchButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('homeBottomNavigationBar')), findsOneWidget);
+    expect(
+      tester
+          .widget<NavigationBar>(
+            find.byKey(const Key('homeBottomNavigationBar')),
+          )
+          .selectedIndex,
+      2,
+    );
+    expect(
+      find.descendant(of: find.byType(AppBar), matching: find.text('길찾기')),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('노선도 지역 메뉴는 선택한 지역으로 지도를 다시 불러온다', (tester) async {
     final repository = FakeStationSearchRepository(
       networkMapRegionNames: const ['테스트권', '부산'],


### PR DESCRIPTION
## 관련 이슈

refs #1075

#1075의 하단 탭 navigation 완료 조건 중 홈 `길찾기` CTA가 shell 탭 전환을 따르도록 좁게 처리합니다. #1075 전체는 이 PR로 닫지 않습니다.

## 작업 배경

홈 하단 탭은 shell 구조로 전환됐지만, 홈의 주요 `길찾기` 버튼은 아직 별도 화면 push로 길찾기 화면을 열었습니다. 이 경우 하단 탭 선택 상태가 사라져 QA가 요구한 persistent navigation 기준과 어긋날 수 있습니다.

## 작업 내용

- 홈 `길찾기` 버튼을 별도 화면 push 대신 shell의 길찾기 탭 전환으로 연결했습니다.
- 홈 `길찾기` 버튼을 눌렀을 때 하단 탭이 유지되고 `selectedIndex=2`가 되는 widget test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/widget_test.dart --no-pub --reporter expanded --plain-name "홈 길찾기 버튼은 새 화면이 아니라 shell 길찾기 탭으로 전환한다"`: 최초 red 확인 후 수정 뒤 exit 0, All tests passed
  - `cd apps/mobile && flutter test test/widget_test.dart --no-pub --reporter expanded --plain-name "홈 하단 탭은 길찾기 즐겨찾기 더보기를 같은 shell에서 전환한다"`: exit 0, All tests passed
  - `cd apps/mobile && flutter test test/widget_test.dart --no-pub --reporter expanded --plain-name "홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다"`: exit 0, All tests passed
  - `cd apps/mobile && flutter analyze`: exit 0, No issues found
  - `git diff --check`: exit 0
  - GitHub Actions: Android CI, Android Release Artifact, Mobile App CI, Backend CI, Repository CI, Release Gate Consistency, RC Evidence Manifest, Dependency Vulnerability Scan, SonarCloud Code Analysis pass
  - 병합 후 main push run 확인: SonarCloud success, CI/Release Artifacts in progress, 즉시 실패 신호 없음

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 홈 길찾기 CTA shell 전환 | Flutter 공통 | widget test | `flutter test ... --plain-name "홈 길찾기 버튼은 새 화면이 아니라 shell 길찾기 탭으로 전환한다"` | 하단 탭 유지, 길찾기 탭 선택 확인 |
| 기존 하단 탭 shell | Flutter 공통 | widget test | `flutter test ... --plain-name "홈 하단 탭은 길찾기 즐겨찾기 더보기를 같은 shell에서 전환한다"` | route/saved/more shell 전환 유지 |
| 홈 핵심 CTA 회귀 | Flutter 공통 | widget test | `flutter test ... --plain-name "홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다"` | 기존 홈 CTA 구조 유지 |
| 정적 분석 | Flutter 공통 | analyzer | `flutter analyze` | No issues found |
| PR CI | GitHub Actions | PR #1116 checks | Android CI, Android Release Artifact, Mobile App CI, Backend CI, Repository CI, Release Gate Consistency, RC Evidence Manifest, Dependency Vulnerability Scan, SonarCloud Code Analysis pass | 병합 전 게이트 통과 |
| 병합 후 CD 상태 | GitHub Actions main | merge commit `e80db596` run 조회 | SonarCloud success, CI/Release Artifacts in progress | 즉시 실패 신호 없음 |
| 화면 캡처 | Android/iOS | 증거 불필요 사유 | shell selectedIndex와 화면 존재를 widget test가 직접 검증하며 레이아웃/플랫폼별 UI를 바꾸지 않음 | 테스트 로그로 대체 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/main.dart`의 `_HomeHero.onRouteSearch` 연결 변경과 새 widget test입니다.
- Flutter 테스트를 병렬 실행하면 native asset 산출물 경합이 생겨 직렬로 재실행했습니다.
- CodeRabbit은 rate limit으로 실제 리뷰를 시작하지 못했습니다. 대신 Codex CLI fallback review를 PR review로 남겼고 actionable comment는 0건입니다.

## 리스크

- 홈의 길찾기 CTA만 변경한 1줄 동작 수정이라 기능 리스크는 낮습니다.
- 역 검색 CTA는 하단 탭 대상이 아니므로 기존처럼 별도 검색 화면 push를 유지했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
