### PR TITLE
[Feat] 데이터팩 facility evidence matrix 화면 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
@@ -22,6 +22,7 @@ public enum AdminProgram {
 	ROUTE_FEEDBACK("a-route-feedback", "운영·분석", "경로 피드백 분석", "/admin/routes/feedback/page", AdminPermission.ADMIN_VIEW),
 	DATAPACK_SOURCE_SNAPSHOTS("a-datapack-source-snapshots", "데이터팩", "Source Snapshots", "/admin/datapack/source-snapshots/page", AdminPermission.DATAPACK_READ),
 	DATAPACK_ALIAS_QUARANTINE("a-datapack-alias-quarantine", "데이터팩", "Alias / Quarantine", "/admin/datapack/alias-quarantine/page", AdminPermission.DATAPACK_READ),
+	DATAPACK_FACILITY_EVIDENCE("a-datapack-facility-evidence", "데이터팩", "Facility Evidence", "/admin/datapack/facility-evidence/page", AdminPermission.DATAPACK_READ),
 	PUSH("a-push", "운영·분석", "푸시 알림", "/admin/notifications/push/page", AdminPermission.DATA_OPERATE),
 	USAGE("a-usage", "운영·분석", "사용 현황", "/admin/usage/activity/page", AdminPermission.SECURITY_AUDIT),
 	SYSTEM("a-system", "운영·분석", "시스템 상태", "/admin/system/page", AdminPermission.SECURITY_AUDIT),

--- a/backend/src/main/java/com/easysubway/datapack/adapter/in/web/FacilityEvidenceAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/in/web/FacilityEvidenceAdminPageController.java
@@ -1,0 +1,86 @@
+package com.easysubway.datapack.adapter.in.web;
+
+import com.easysubway.datapack.adapter.out.persistence.JdbcFacilityEvidenceMatrixRepository;
+import com.easysubway.datapack.adapter.out.persistence.JdbcFacilityEvidenceMatrixRepository.FacilityEvidenceRow;
+import java.time.LocalDateTime;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class FacilityEvidenceAdminPageController {
+
+	private static final int MATRIX_LIMIT = 200;
+
+	private final JdbcFacilityEvidenceMatrixRepository matrixRepository;
+
+	FacilityEvidenceAdminPageController(JdbcFacilityEvidenceMatrixRepository matrixRepository) {
+		this.matrixRepository = matrixRepository;
+	}
+
+	@GetMapping("/admin/datapack/facility-evidence/page")
+	@PreAuthorize("hasAuthority('admin.datapack.read')")
+	String facilityEvidenceMatrix(Model model) {
+		model.addAttribute("evidenceRows", matrixRepository.listRecentEvidence(MATRIX_LIMIT).stream()
+			.map(FacilityEvidenceView::from)
+			.toList());
+		return "admin/datapack/facility-evidence/list";
+	}
+
+	record FacilityEvidenceView(
+		String id,
+		String stationId,
+		String lineId,
+		String facilityType,
+		String evidenceKind,
+		String sourceId,
+		String sourceSnapshotId,
+		String providerRecordHash,
+		String statusMeaning,
+		String installationStatus,
+		String operationalStatus,
+		LocalDateTime verifiedAt,
+		LocalDateTime retrievedAt,
+		LocalDateTime freshnessExpiresAt,
+		int confidence,
+		boolean strictRouteEligible,
+		String strictRouteLabel,
+		String strictRouteReason,
+		String conflictStatus,
+		String manualOverrideId
+	) {
+
+		static FacilityEvidenceView from(FacilityEvidenceRow row) {
+			return new FacilityEvidenceView(
+				row.id(),
+				row.stationId(),
+				valueOrDash(row.lineId()),
+				row.facilityType(),
+				row.evidenceKind(),
+				row.sourceId(),
+				row.sourceSnapshotId(),
+				row.providerRecordHash(),
+				row.statusMeaning(),
+				row.installationStatus(),
+				row.operationalStatus(),
+				row.verifiedAt(),
+				row.retrievedAt(),
+				row.freshnessExpiresAt(),
+				row.confidence(),
+				row.strictRouteEligible(),
+				row.strictRouteEligible() ? "strict 가능" : "strict 불가",
+				valueOrDash(row.strictRouteEligibleReason()),
+				row.conflictStatus(),
+				valueOrDash(row.manualOverrideId())
+			);
+		}
+	}
+
+	private static String valueOrDash(String value) {
+		if (value == null || value.isBlank()) {
+			return "-";
+		}
+		return value;
+	}
+}

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcFacilityEvidenceMatrixRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcFacilityEvidenceMatrixRepository.java
@@ -1,0 +1,89 @@
+package com.easysubway.datapack.adapter.out.persistence;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcFacilityEvidenceMatrixRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	public JdbcFacilityEvidenceMatrixRepository(DataSource dataSource) {
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+
+	public List<FacilityEvidenceRow> listRecentEvidence(int limit) {
+		return jdbcTemplate.query("""
+			SELECT id, station_id, line_id, facility_type, evidence_kind, source_id,
+				source_snapshot_id, provider_record_hash, status_meaning,
+				installation_status, operational_status, verified_at, retrieved_at,
+				freshness_expires_at, confidence, strict_route_eligible,
+				strict_route_eligible_reason, conflict_status, manual_override_id,
+				created_at
+			FROM facility_evidence
+			ORDER BY station_id ASC, line_id ASC, facility_type ASC, created_at DESC, id ASC
+			LIMIT ?
+			""", this::mapRow, limit);
+	}
+
+	private FacilityEvidenceRow mapRow(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new FacilityEvidenceRow(
+			resultSet.getString("id"),
+			resultSet.getString("station_id"),
+			resultSet.getString("line_id"),
+			resultSet.getString("facility_type"),
+			resultSet.getString("evidence_kind"),
+			resultSet.getString("source_id"),
+			resultSet.getString("source_snapshot_id"),
+			resultSet.getString("provider_record_hash"),
+			resultSet.getString("status_meaning"),
+			resultSet.getString("installation_status"),
+			resultSet.getString("operational_status"),
+			toLocalDateTime(resultSet, "verified_at"),
+			toLocalDateTime(resultSet, "retrieved_at"),
+			toLocalDateTime(resultSet, "freshness_expires_at"),
+			resultSet.getInt("confidence"),
+			resultSet.getBoolean("strict_route_eligible"),
+			resultSet.getString("strict_route_eligible_reason"),
+			resultSet.getString("conflict_status"),
+			resultSet.getString("manual_override_id"),
+			toLocalDateTime(resultSet, "created_at")
+		);
+	}
+
+	private LocalDateTime toLocalDateTime(ResultSet resultSet, String column) throws SQLException {
+		var timestamp = resultSet.getTimestamp(column);
+		return timestamp == null ? null : timestamp.toLocalDateTime();
+	}
+
+	public record FacilityEvidenceRow(
+		String id,
+		String stationId,
+		String lineId,
+		String facilityType,
+		String evidenceKind,
+		String sourceId,
+		String sourceSnapshotId,
+		String providerRecordHash,
+		String statusMeaning,
+		String installationStatus,
+		String operationalStatus,
+		LocalDateTime verifiedAt,
+		LocalDateTime retrievedAt,
+		LocalDateTime freshnessExpiresAt,
+		int confidence,
+		boolean strictRouteEligible,
+		String strictRouteEligibleReason,
+		String conflictStatus,
+		String manualOverrideId,
+		LocalDateTime createdAt
+	) {
+	}
+}

--- a/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/facility-evidence/list.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Facility Evidence Matrix</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<a th:replace="~{admin/fragments/shell :: skipLink}"></a>
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-datapack-facility-evidence')}"></div>
+<main class="admin-main">
+	<div th:replace="~{admin/fragments/shell :: topbar}"></div>
+	<div th:replace="~{admin/fragments/shell :: contentStart}"></div>
+	<header class="admin-page-head">
+		<div>
+			<h1>Facility Evidence Matrix</h1>
+			<p>station x facility type별 source evidence, 상태 의미, strict route 사용 가능 여부를 읽기 전용으로 확인합니다.</p>
+		</div>
+	</header>
+
+	<section class="admin-panel">
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">station</th>
+				<th scope="col">line</th>
+				<th scope="col">facility</th>
+				<th scope="col">evidence</th>
+				<th scope="col">installation</th>
+				<th scope="col">operation</th>
+				<th scope="col">meaning</th>
+				<th scope="col">source</th>
+				<th scope="col">verified</th>
+				<th scope="col">freshness</th>
+				<th scope="col">confidence</th>
+				<th scope="col">strict</th>
+				<th scope="col">conflict</th>
+				<th scope="col">override</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:if="${evidenceRows.isEmpty()}">
+				<td colspan="14">facility evidence row가 없습니다.</td>
+			</tr>
+			<tr th:each="row : ${evidenceRows}">
+				<td th:text="${row.stationId}">station-id</td>
+				<td th:text="${row.lineId}">line-id</td>
+				<td th:text="${row.facilityType}">ELEVATOR</td>
+				<td th:text="${row.evidenceKind}">EXISTS</td>
+				<td th:text="${row.installationStatus}">INSTALLED</td>
+				<td th:text="${row.operationalStatus}">AVAILABLE</td>
+				<td th:text="${row.statusMeaning}">OPERATOR_CONFIRMED</td>
+				<td>
+					<span th:text="${row.sourceId}">source-id</span>
+					<span th:text="${row.sourceSnapshotId}">snapshot-id</span>
+					<span th:text="${row.providerRecordHash}">sha256</span>
+				</td>
+				<td>
+					<span th:text="${row.verifiedAt}">2026-06-29T03:00</span>
+					<span th:text="${row.retrievedAt}">2026-06-29T03:00</span>
+				</td>
+				<td th:text="${row.freshnessExpiresAt}">2026-07-06T03:00</td>
+				<td th:text="${row.confidence}">95</td>
+				<td>
+					<strong th:text="${row.strictRouteLabel}">strict 가능</strong>
+					<span th:text="${row.strictRouteReason}">-</span>
+				</td>
+				<td th:text="${row.conflictStatus}">NONE</td>
+				<td th:text="${row.manualOverrideId}">-</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/AliasQuarantineAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/AliasQuarantineAdminPageControllerTest.java
@@ -31,6 +31,8 @@ class AliasQuarantineAdminPageControllerTest {
 
 	@BeforeEach
 	void setUp() {
+		jdbcTemplate.update("DELETE FROM facility_evidence");
+		jdbcTemplate.update("DELETE FROM manual_overrides");
 		jdbcTemplate.update("DELETE FROM source_quarantine_resolutions");
 		jdbcTemplate.update("DELETE FROM source_quarantine_records");
 		jdbcTemplate.update("DELETE FROM external_alias_approvals");

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageControllerTest.java
@@ -31,6 +31,8 @@ class DataSourceSnapshotAdminPageControllerTest {
 
 	@BeforeEach
 	void setUp() {
+		jdbcTemplate.update("DELETE FROM facility_evidence");
+		jdbcTemplate.update("DELETE FROM manual_overrides");
 		jdbcTemplate.update("DELETE FROM source_quarantine_resolutions");
 		jdbcTemplate.update("DELETE FROM source_quarantine_records");
 		jdbcTemplate.update("DELETE FROM external_alias_approvals");

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/FacilityEvidenceAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/FacilityEvidenceAdminPageControllerTest.java
@@ -1,0 +1,164 @@
+package com.easysubway.datapack.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("관리자 데이터팩 facility evidence matrix 화면")
+class FacilityEvidenceAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.update("DELETE FROM facility_evidence");
+		jdbcTemplate.update("DELETE FROM manual_overrides");
+		jdbcTemplate.update("DELETE FROM data_source_snapshots");
+		insertSnapshot();
+		insertManualOverride();
+		insertStrictEligibleEvidence();
+		insertUnknownEvidence();
+	}
+
+	@Test
+	@DisplayName("datapack read 권한 관리자는 facility evidence matrix를 확인한다")
+	void datapackReadAdminViewsFacilityEvidenceMatrix() throws Exception {
+		String html = mockMvc.perform(get("/admin/datapack/facility-evidence/page")
+				.with(user("datapack-viewer").authorities(new SimpleGrantedAuthority("admin.datapack.read"))))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("Facility Evidence Matrix")
+			.contains("station-sangnoksu")
+			.contains("line-4")
+			.contains("ELEVATOR")
+			.contains("EXISTS")
+			.contains("INSTALLED")
+			.contains("AVAILABLE")
+			.contains("OPERATOR_CONFIRMED")
+			.contains("strict 가능")
+			.contains("station-sadang")
+			.contains("WHEELCHAIR_LIFT")
+			.contains("UNKNOWN_PENDING_REVIEW")
+			.contains("UNKNOWN")
+			.contains("strict 불가")
+			.contains("운행 상태 확인 필요")
+			.contains("override-facility-1")
+			.doesNotContain("name=\"commandToken\"")
+			.doesNotContain("수정 저장")
+			.doesNotContain("serviceKey");
+	}
+
+	@Test
+	@DisplayName("datapack read 권한이 없으면 facility evidence matrix에 접근할 수 없다")
+	void facilityEvidencePageRequiresDatapackReadPermission() throws Exception {
+		mockMvc.perform(get("/admin/datapack/facility-evidence/page")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view"))))
+			.andExpect(status().isForbidden());
+	}
+
+	private void insertSnapshot() {
+		jdbcTemplate.update("""
+			INSERT INTO data_source_snapshots (
+				snapshot_id, source_id, provider, retrieved_at, source_updated_at, row_count,
+				raw_sha256, raw_object_uri, redacted_request_fingerprint, schema_fingerprint,
+				snapshot_status, schema_status, license_status, fetch_status, redistribution_allowed,
+				credential_redacted, previous_snapshot_id, diff_summary, freshness_expires_at,
+				raw_retention_expires_at
+			)
+			VALUES ('snapshot-kric-20260629', 'kric-station-elevator', '국가철도공단',
+				'2026-06-29 03:00:00', '2026-06-28 00:00:00', 12345,
+				?, 's3://easysubway-datapack-sources/kric-station-elevator/snapshot-kric-20260629.json',
+				?, ?, 'LOCKED', 'PASS', 'PASS', 'SUCCESS', TRUE, TRUE, NULL,
+				'이전 snapshot 대비 +12 rows', '2026-07-06 03:00:00', '2026-09-29 03:00:00')
+			""",
+			"a".repeat(64),
+			"b".repeat(64),
+			"c".repeat(64)
+		);
+	}
+
+	private void insertManualOverride() {
+		jdbcTemplate.update("""
+			INSERT INTO manual_overrides (
+				id, entity_type, entity_id, field_name, before_value, after_value,
+				reason_code, reason, evidence_uri, evidence_hash, requested_by, approved_by,
+				approved_at, route_safety_approved_by, approval_status, conflict_status,
+				strict_route_eligible, effective_from, expires_at, superseded_by, created_at
+			)
+			VALUES ('override-facility-1', 'FACILITY', 'station-sadang:WHEELCHAIR_LIFT',
+				'operational_status', 'UNKNOWN', 'CHECK_REQUIRED', 'FIELD_CHECK',
+				'현장 확인 필요', 's3://easysubway-evidence/facility/override-facility-1.json',
+				?, 'qa-operator', 'qa-reviewer', '2026-06-29 03:30:00', NULL,
+				'APPROVED', 'NONE', FALSE, '2026-06-29 03:30:00',
+				'2026-07-29 03:30:00', NULL, '2026-06-29 03:20:00')
+			""",
+			"d".repeat(64)
+		);
+	}
+
+	private void insertStrictEligibleEvidence() {
+		jdbcTemplate.update("""
+			INSERT INTO facility_evidence (
+				id, station_id, line_id, facility_type, evidence_kind, source_id,
+				source_snapshot_id, provider_record_hash, status_meaning,
+				installation_status, operational_status, verified_at, retrieved_at,
+				freshness_expires_at, confidence, strict_route_eligible,
+				strict_route_eligible_reason, conflict_status, manual_override_id,
+				created_at
+			)
+			VALUES ('facility-evidence-elevator-1', 'station-sangnoksu', 'line-4',
+				'ELEVATOR', 'EXISTS', 'kric-station-elevator', 'snapshot-kric-20260629',
+				?, 'OPERATOR_CONFIRMED', 'INSTALLED', 'AVAILABLE',
+				'2026-06-29 03:00:00', '2026-06-29 03:00:00',
+				'2026-07-06 03:00:00', 95, TRUE, NULL, 'NONE', NULL,
+				'2026-06-29 03:10:00')
+			""",
+			"e".repeat(64)
+		);
+	}
+
+	private void insertUnknownEvidence() {
+		jdbcTemplate.update("""
+			INSERT INTO facility_evidence (
+				id, station_id, line_id, facility_type, evidence_kind, source_id,
+				source_snapshot_id, provider_record_hash, status_meaning,
+				installation_status, operational_status, verified_at, retrieved_at,
+				freshness_expires_at, confidence, strict_route_eligible,
+				strict_route_eligible_reason, conflict_status, manual_override_id,
+				created_at
+			)
+			VALUES ('facility-evidence-lift-unknown', 'station-sadang', 'line-2',
+				'WHEELCHAIR_LIFT', 'UNKNOWN_PENDING_REVIEW', 'kric-station-elevator',
+				'snapshot-kric-20260629', ?, 'STATIC_LOCATION', 'UNKNOWN',
+				'UNKNOWN', '2026-06-29 03:00:00', '2026-06-29 03:00:00',
+				'2026-07-06 03:00:00', 40, FALSE, '운행 상태 확인 필요',
+				'UNRESOLVED', 'override-facility-1', '2026-06-29 03:11:00')
+			""",
+			"f".repeat(64)
+		);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #1117

## 작업 배경

#1081 데이터팩 운영 콘솔은 station x facility type별 evidence 상태를 운영자가 확인할 수 있어야 한다. 이번 변경은 기존 `facility_evidence` ledger를 직접 수정하지 않고, 설치 근거와 운행 상태, strict route 사용 가능 여부를 읽기 전용 matrix로 보여준다.

## 작업 내용

- `/admin/datapack/facility-evidence/page` 화면과 admin sidebar 메뉴를 추가했다.
- `facility_evidence` 최신 row를 조회해 station, line, facility type, evidence kind, installation/operational status, status meaning, source/snapshot, freshness, confidence, strict eligibility, conflict/manual override 상태를 표시한다.
- 화면에는 수정 form을 두지 않고, `admin.datapack.read` 권한으로 GET 접근을 제한한다.
- datapack admin controller 테스트들이 facility evidence/manual override FK row와 격리되도록 cleanup 순서를 보강했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests '*FacilityEvidenceAdminPageControllerTest'`: 2 tests passed, exit 0
  - `./gradlew test --tests '*AdminV3PageSmokeTest' --tests '*FacilityEvidenceAdminPageControllerTest' --tests '*AliasQuarantineAdminPageControllerTest' --tests '*DataSourceSnapshotAdminPageControllerTest'`: exit 0
  - `/usr/local/bin/node --test tools/ci/repository-contract.test.mjs`: 123 tests passed, exit 0
  - `./gradlew test`: exit 0
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Facility Evidence Matrix | Backend admin | MockMvc 렌더링 테스트 | `./gradlew test --tests '*FacilityEvidenceAdminPageControllerTest'` | 2 tests passed |
| 권한 차단 | Backend admin | MockMvc 403 테스트 | `./gradlew test --tests '*FacilityEvidenceAdminPageControllerTest'` | pass |
| read-only 보장 | Backend admin | `commandToken`, 수정 저장 문구, credential 미노출 assertion | `./gradlew test --tests '*FacilityEvidenceAdminPageControllerTest'` | pass |
| admin navigation 영향 | Backend admin | admin smoke/controller 조합 테스트 | `./gradlew test --tests '*AdminV3PageSmokeTest' --tests '*FacilityEvidenceAdminPageControllerTest' --tests '*AliasQuarantineAdminPageControllerTest' --tests '*DataSourceSnapshotAdminPageControllerTest'` | pass |
| repository contract | Local Node 24 | repository contract test | `/usr/local/bin/node --test tools/ci/repository-contract.test.mjs` | 123 tests passed |
| backend regression | Backend | 전체 backend test | `./gradlew test` | pass |
| whitespace | local git | diff whitespace check | `git diff --check` | pass |

## 리뷰어 메모

- 새 화면은 read-only다. facility evidence 생성/승인, manual override 생성/승인은 이번 PR 범위가 아니다.
- 한 화면에 최근 200건만 표시한다. 실제 운영에서 필터/paging이 필요해지면 같은 화면에 붙이면 된다.

## 리스크

- 대량 ledger 환경에서는 최근 row 위주로 보이므로 station/facility type 필터는 후속 화면 고도화가 필요하다.
- 이 화면은 ledger 조회만 제공하며 candidate build 반영 여부는 후속 Candidate Pack 화면에서 다룬다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI fallback은 필요하지 않았다.
- [x] 배포 영향 없음. merge 후 post-merge workflow 실패 여부만 확인한다.
