### PR TITLE
[Feat] 데이터팩 route gate matrix 화면 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
@@ -23,6 +23,7 @@ public enum AdminProgram {
 	DATAPACK_SOURCE_SNAPSHOTS("a-datapack-source-snapshots", "데이터팩", "Source Snapshots", "/admin/datapack/source-snapshots/page", AdminPermission.DATAPACK_READ),
 	DATAPACK_ALIAS_QUARANTINE("a-datapack-alias-quarantine", "데이터팩", "Alias / Quarantine", "/admin/datapack/alias-quarantine/page", AdminPermission.DATAPACK_READ),
 	DATAPACK_FACILITY_EVIDENCE("a-datapack-facility-evidence", "데이터팩", "Facility Evidence", "/admin/datapack/facility-evidence/page", AdminPermission.DATAPACK_READ),
+	DATAPACK_ROUTE_GATES("a-datapack-route-gates", "데이터팩", "Route Gates", "/admin/datapack/route-gates/page", AdminPermission.DATAPACK_READ),
 	PUSH("a-push", "운영·분석", "푸시 알림", "/admin/notifications/push/page", AdminPermission.DATA_OPERATE),
 	USAGE("a-usage", "운영·분석", "사용 현황", "/admin/usage/activity/page", AdminPermission.SECURITY_AUDIT),
 	SYSTEM("a-system", "운영·분석", "시스템 상태", "/admin/system/page", AdminPermission.SECURITY_AUDIT),

--- a/backend/src/main/java/com/easysubway/datapack/adapter/in/web/RouteGateMatrixAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/in/web/RouteGateMatrixAdminPageController.java
@@ -1,0 +1,101 @@
+package com.easysubway.datapack.adapter.in.web;
+
+import com.easysubway.datapack.adapter.out.persistence.JdbcRouteGateMatrixRepository;
+import com.easysubway.datapack.adapter.out.persistence.JdbcRouteGateMatrixRepository.RouteGateRow;
+import java.time.LocalDateTime;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class RouteGateMatrixAdminPageController {
+
+	private static final int MATRIX_LIMIT = 200;
+
+	private final JdbcRouteGateMatrixRepository matrixRepository;
+
+	RouteGateMatrixAdminPageController(JdbcRouteGateMatrixRepository matrixRepository) {
+		this.matrixRepository = matrixRepository;
+	}
+
+	@GetMapping("/admin/datapack/route-gates/page")
+	@PreAuthorize("hasAuthority('admin.datapack.read')")
+	String routeGateMatrix(Model model) {
+		model.addAttribute("routeGateRows", matrixRepository.listRecentEdges(MATRIX_LIMIT).stream()
+			.map(RouteGateView::from)
+			.toList());
+		return "admin/datapack/route-gates/list";
+	}
+
+	record RouteGateView(
+		String id,
+		String stationId,
+		String lineId,
+		String edgeId,
+		String edgeType,
+		String sourceId,
+		String sourceSnapshotId,
+		String provenanceKind,
+		String verificationStatus,
+		LocalDateTime lastVerifiedAt,
+		String evidenceHash,
+		boolean generatedConnector,
+		boolean strictRouteEligible,
+		String strictRouteLabel,
+		String blockerReason
+	) {
+
+		static RouteGateView from(RouteGateRow row) {
+			boolean generated = isGenerated(row);
+			return new RouteGateView(
+				row.id(),
+				row.stationId(),
+				valueOrDash(row.lineId()),
+				row.edgeId(),
+				row.edgeType(),
+				row.sourceId(),
+				row.sourceSnapshotId(),
+				row.provenanceKind(),
+				row.verificationStatus(),
+				row.lastVerifiedAt(),
+				row.evidenceHash(),
+				generated,
+				row.strictRouteEligible(),
+				row.strictRouteEligible() ? "strict 가능" : "strict 불가",
+				RouteGateMatrixAdminPageController.blockerReason(row, generated)
+			);
+		}
+	}
+
+	private static boolean isGenerated(RouteGateRow row) {
+		return "GENERATED_CONNECTOR".equals(row.edgeType())
+			|| "GENERATED".equals(row.provenanceKind())
+			|| "GENERATED".equals(row.verificationStatus());
+	}
+
+	private static String blockerReason(RouteGateRow row, boolean generated) {
+		if (row.strictRouteEligible()) {
+			return "-";
+		}
+		if (row.blockerReason() != null && !row.blockerReason().isBlank()) {
+			return row.blockerReason();
+		}
+		if (generated) {
+			return "generated connector";
+		}
+		return switch (row.verificationStatus()) {
+			case "UNKNOWN" -> "unknown edge";
+			case "STALE" -> "stale source";
+			case "MISSING" -> "missing edge";
+			default -> "strict route blocker";
+		};
+	}
+
+	private static String valueOrDash(String value) {
+		if (value == null || value.isBlank()) {
+			return "-";
+		}
+		return value;
+	}
+}

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcRouteGateMatrixRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcRouteGateMatrixRepository.java
@@ -1,0 +1,75 @@
+package com.easysubway.datapack.adapter.out.persistence;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcRouteGateMatrixRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	public JdbcRouteGateMatrixRepository(DataSource dataSource) {
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+
+	public List<RouteGateRow> listRecentEdges(int limit) {
+		return jdbcTemplate.query("""
+			SELECT id, station_id, line_id, edge_id, edge_type, source_id,
+				source_snapshot_id, provenance_kind, verification_status, last_verified_at,
+				evidence_hash, strict_route_eligible, blocker_reason, created_at
+			FROM route_edge_evidence
+			ORDER BY station_id ASC, line_id ASC, edge_type ASC, verification_status ASC,
+				created_at DESC, id ASC
+			LIMIT ?
+			""", this::mapRow, limit);
+	}
+
+	private RouteGateRow mapRow(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new RouteGateRow(
+			resultSet.getString("id"),
+			resultSet.getString("station_id"),
+			resultSet.getString("line_id"),
+			resultSet.getString("edge_id"),
+			resultSet.getString("edge_type"),
+			resultSet.getString("source_id"),
+			resultSet.getString("source_snapshot_id"),
+			resultSet.getString("provenance_kind"),
+			resultSet.getString("verification_status"),
+			toLocalDateTime(resultSet, "last_verified_at"),
+			resultSet.getString("evidence_hash"),
+			resultSet.getBoolean("strict_route_eligible"),
+			resultSet.getString("blocker_reason"),
+			toLocalDateTime(resultSet, "created_at")
+		);
+	}
+
+	private LocalDateTime toLocalDateTime(ResultSet resultSet, String column) throws SQLException {
+		var timestamp = resultSet.getTimestamp(column);
+		return timestamp == null ? null : timestamp.toLocalDateTime();
+	}
+
+	public record RouteGateRow(
+		String id,
+		String stationId,
+		String lineId,
+		String edgeId,
+		String edgeType,
+		String sourceId,
+		String sourceSnapshotId,
+		String provenanceKind,
+		String verificationStatus,
+		LocalDateTime lastVerifiedAt,
+		String evidenceHash,
+		boolean strictRouteEligible,
+		String blockerReason,
+		LocalDateTime createdAt
+	) {
+	}
+}

--- a/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/route-gates/list.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Route Gate Matrix</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<a th:replace="~{admin/fragments/shell :: skipLink}"></a>
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-datapack-route-gates')}"></div>
+<main class="admin-main">
+	<div th:replace="~{admin/fragments/shell :: topbar}"></div>
+	<div th:replace="~{admin/fragments/shell :: contentStart}"></div>
+	<header class="admin-page-head">
+		<div>
+			<h1>Route Gate Matrix</h1>
+			<p>ENTRY, EXIT, TRANSFER edge evidence와 strict route blocker를 읽기 전용으로 확인합니다.</p>
+		</div>
+	</header>
+
+	<section class="admin-panel">
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">station</th>
+				<th scope="col">line</th>
+				<th scope="col">edge</th>
+				<th scope="col">type</th>
+				<th scope="col">verification</th>
+				<th scope="col">provenance</th>
+				<th scope="col">generated</th>
+				<th scope="col">source</th>
+				<th scope="col">verified</th>
+				<th scope="col">evidence</th>
+				<th scope="col">strict</th>
+				<th scope="col">blocker</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:if="${routeGateRows.isEmpty()}">
+				<td colspan="12">route gate row가 없습니다.</td>
+			</tr>
+			<tr th:each="row : ${routeGateRows}">
+				<td th:text="${row.stationId}">station-id</td>
+				<td th:text="${row.lineId}">line-id</td>
+				<td th:text="${row.edgeId}">edge-id</td>
+				<td th:text="${row.edgeType}">ENTRY</td>
+				<td th:text="${row.verificationStatus}">VERIFIED</td>
+				<td th:text="${row.provenanceKind}">OFFICIAL_SOURCE</td>
+				<td th:text="${row.generatedConnector ? 'generated connector' : '-'}">-</td>
+				<td>
+					<span th:text="${row.sourceId}">source-id</span>
+					<span th:text="${row.sourceSnapshotId}">snapshot-id</span>
+				</td>
+				<td th:text="${row.lastVerifiedAt}">2026-06-29T03:00</td>
+				<td th:text="${row.evidenceHash}">sha256</td>
+				<td th:text="${row.strictRouteLabel}">strict 가능</td>
+				<td th:text="${row.blockerReason}">-</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/AliasQuarantineAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/AliasQuarantineAdminPageControllerTest.java
@@ -31,11 +31,13 @@ class AliasQuarantineAdminPageControllerTest {
 
 	@BeforeEach
 	void setUp() {
+		jdbcTemplate.update("DELETE FROM route_edge_evidence");
 		jdbcTemplate.update("DELETE FROM facility_evidence");
 		jdbcTemplate.update("DELETE FROM manual_overrides");
 		jdbcTemplate.update("DELETE FROM source_quarantine_resolutions");
 		jdbcTemplate.update("DELETE FROM source_quarantine_records");
 		jdbcTemplate.update("DELETE FROM external_alias_approvals");
+		jdbcTemplate.update("DELETE FROM datapack_normalization_runs");
 		jdbcTemplate.update("DELETE FROM data_source_snapshots");
 		insertSnapshot();
 		insertAliasApproval();

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DataSourceSnapshotAdminPageControllerTest.java
@@ -31,11 +31,13 @@ class DataSourceSnapshotAdminPageControllerTest {
 
 	@BeforeEach
 	void setUp() {
+		jdbcTemplate.update("DELETE FROM route_edge_evidence");
 		jdbcTemplate.update("DELETE FROM facility_evidence");
 		jdbcTemplate.update("DELETE FROM manual_overrides");
 		jdbcTemplate.update("DELETE FROM source_quarantine_resolutions");
 		jdbcTemplate.update("DELETE FROM source_quarantine_records");
 		jdbcTemplate.update("DELETE FROM external_alias_approvals");
+		jdbcTemplate.update("DELETE FROM datapack_normalization_runs");
 		jdbcTemplate.update("DELETE FROM data_source_snapshots");
 		jdbcTemplate.update("""
 			INSERT INTO data_source_snapshots (

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/FacilityEvidenceAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/FacilityEvidenceAdminPageControllerTest.java
@@ -31,8 +31,13 @@ class FacilityEvidenceAdminPageControllerTest {
 
 	@BeforeEach
 	void setUp() {
+		jdbcTemplate.update("DELETE FROM route_edge_evidence");
 		jdbcTemplate.update("DELETE FROM facility_evidence");
 		jdbcTemplate.update("DELETE FROM manual_overrides");
+		jdbcTemplate.update("DELETE FROM source_quarantine_resolutions");
+		jdbcTemplate.update("DELETE FROM source_quarantine_records");
+		jdbcTemplate.update("DELETE FROM external_alias_approvals");
+		jdbcTemplate.update("DELETE FROM datapack_normalization_runs");
 		jdbcTemplate.update("DELETE FROM data_source_snapshots");
 		insertSnapshot();
 		insertManualOverride();

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/RouteGateMatrixAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/RouteGateMatrixAdminPageControllerTest.java
@@ -1,0 +1,192 @@
+package com.easysubway.datapack.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("관리자 데이터팩 route gate matrix 화면")
+class RouteGateMatrixAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.update("DELETE FROM route_edge_evidence");
+		jdbcTemplate.update("DELETE FROM facility_evidence");
+		jdbcTemplate.update("DELETE FROM manual_overrides");
+		jdbcTemplate.update("DELETE FROM source_quarantine_resolutions");
+		jdbcTemplate.update("DELETE FROM source_quarantine_records");
+		jdbcTemplate.update("DELETE FROM external_alias_approvals");
+		jdbcTemplate.update("DELETE FROM datapack_normalization_runs");
+		jdbcTemplate.update("DELETE FROM data_source_snapshots");
+		insertSnapshot();
+		insertVerifiedEntryEdge();
+		insertGeneratedConnectorBlocker();
+		insertStaleTransferBlocker();
+	}
+
+	@Test
+	@DisplayName("datapack read 권한 관리자는 route gate matrix를 확인한다")
+	void datapackReadAdminViewsRouteGateMatrix() throws Exception {
+		String html = mockMvc.perform(get("/admin/datapack/route-gates/page")
+				.with(user("datapack-viewer").authorities(new SimpleGrantedAuthority("admin.datapack.read"))))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("Route Gate Matrix")
+			.contains("station-sangnoksu")
+			.contains("line-4")
+			.contains("ENTRY")
+			.contains("VERIFIED")
+			.contains("OFFICIAL_SOURCE")
+			.contains("strict 가능")
+			.contains("station-sadang")
+			.contains("GENERATED_CONNECTOR")
+			.contains("GENERATED")
+			.contains("generated connector")
+			.contains("strict 불가")
+			.contains("station-transfer")
+			.contains("TRANSFER")
+			.contains("STALE")
+			.contains("stale source")
+			.doesNotContain("name=\"commandToken\"")
+			.doesNotContain("수정 저장")
+			.doesNotContain("serviceKey");
+	}
+
+	@Test
+	@DisplayName("datapack read 권한이 없으면 route gate matrix에 접근할 수 없다")
+	void routeGateMatrixPageRequiresDatapackReadPermission() throws Exception {
+		mockMvc.perform(get("/admin/datapack/route-gates/page")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view"))))
+			.andExpect(status().isForbidden());
+	}
+
+	private void insertSnapshot() {
+		jdbcTemplate.update("""
+			INSERT INTO data_source_snapshots (
+				snapshot_id, source_id, provider, retrieved_at, source_updated_at, row_count,
+				raw_sha256, raw_object_uri, redacted_request_fingerprint, schema_fingerprint,
+				snapshot_status, schema_status, license_status, fetch_status, redistribution_allowed,
+				credential_redacted, previous_snapshot_id, diff_summary, freshness_expires_at,
+				raw_retention_expires_at
+			)
+			VALUES ('snapshot-route-20260629', 'route-source-a', '수도권 운영기관',
+				'2026-06-29 03:00:00', '2026-06-28 00:00:00', 400,
+				?, 's3://easysubway-datapack-sources/route-source-a/snapshot-route-20260629.json',
+				?, ?, 'LOCKED', 'PASS', 'PASS', 'SUCCESS', TRUE, TRUE, NULL,
+				'route edge evidence +3 rows', '2026-07-06 03:00:00', '2026-09-29 03:00:00')
+			""",
+			"a".repeat(64),
+			"b".repeat(64),
+			"c".repeat(64)
+		);
+	}
+
+	private void insertVerifiedEntryEdge() {
+		insertRouteEdge(
+			"route-edge-entry-1",
+			"station-sangnoksu",
+			"line-4",
+			"edge-entry-1",
+			"ENTRY",
+			"OFFICIAL_SOURCE",
+			"VERIFIED",
+			true,
+			null,
+			"d".repeat(64),
+			"2026-06-29 03:10:00"
+		);
+	}
+
+	private void insertGeneratedConnectorBlocker() {
+		insertRouteEdge(
+			"route-edge-generated-1",
+			"station-sadang",
+			"line-2",
+			"edge-generated-1",
+			"GENERATED_CONNECTOR",
+			"GENERATED",
+			"GENERATED",
+			false,
+			"generated connector",
+			"e".repeat(64),
+			"2026-06-29 03:11:00"
+		);
+	}
+
+	private void insertStaleTransferBlocker() {
+		insertRouteEdge(
+			"route-edge-stale-transfer",
+			"station-transfer",
+			"line-2",
+			"edge-transfer-stale",
+			"TRANSFER",
+			"OPERATOR_CONFIRMED",
+			"STALE",
+			false,
+			"stale source",
+			"f".repeat(64),
+			"2026-06-29 03:12:00"
+		);
+	}
+
+	private void insertRouteEdge(
+		String id,
+		String stationId,
+		String lineId,
+		String edgeId,
+		String edgeType,
+		String provenanceKind,
+		String verificationStatus,
+		boolean strictRouteEligible,
+		String blockerReason,
+		String evidenceHash,
+		String createdAt
+	) {
+		jdbcTemplate.update("""
+			INSERT INTO route_edge_evidence (
+				id, station_id, line_id, edge_id, edge_type, source_id,
+				source_snapshot_id, provenance_kind, verification_status, last_verified_at,
+				evidence_hash, strict_route_eligible, blocker_reason, created_at
+			)
+			VALUES (?, ?, ?, ?, ?, 'route-source-a', 'snapshot-route-20260629',
+				?, ?, '2026-06-29 03:00:00', ?, ?, ?, ?)
+			""",
+			id,
+			stationId,
+			lineId,
+			edgeId,
+			edgeType,
+			provenanceKind,
+			verificationStatus,
+			evidenceHash,
+			strictRouteEligible,
+			blockerReason,
+			createdAt
+		);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #1119

## 작업 배경

#1081 데이터팩 운영 콘솔 보완 기준에서 strict route gate를 운영자가 station/line 단위로 확인할 수 있어야 한다. Route edge evidence ledger는 이미 존재하지만, 관리자 화면에서 ENTRY/EXIT/TRANSFER, generated connector, UNKNOWN/STALE/MISSING blocker를 읽기 전용으로 확인하는 화면이 없었다.

## 작업 내용

- 데이터팩 관리자 메뉴에 Route Gates 화면을 추가했다.
- `route_edge_evidence` ledger를 station/line/edge 기준으로 조회하는 read-only repository와 controller를 추가했다.
- Route Gate Matrix 화면에서 verification, provenance, generated connector 여부, strict 가능 여부, blocker reason, source/snapshot/evidence hash를 표시한다.
- 데이터팩 화면 테스트 cleanup에 route edge evidence와 normalization run 삭제를 보강해 snapshot FK 간섭을 줄였다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests '*RouteGateMatrixAdminPageControllerTest'`: BUILD SUCCESSFUL
  - `./gradlew test --tests '*AdminV3PageSmokeTest' --tests '*RouteGateMatrixAdminPageControllerTest' --tests '*FacilityEvidenceAdminPageControllerTest' --tests '*AliasQuarantineAdminPageControllerTest' --tests '*DataSourceSnapshotAdminPageControllerTest'`: BUILD SUCCESSFUL
  - `node --test tools/ci/repository-contract.test.mjs`: 123 tests passed
  - `./gradlew test`: BUILD SUCCESSFUL
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Route Gate Matrix 렌더링 | backend/H2 test | `./gradlew test --tests '*RouteGateMatrixAdminPageControllerTest'` | MockMvc 응답 HTML에 VERIFIED/generated/stale blocker 표시 확인 | 통과 |
| 관리자 권한 차단 | backend/H2 test | `./gradlew test --tests '*RouteGateMatrixAdminPageControllerTest'` | `admin.datapack.read` 없는 요청 403 확인 | 통과 |
| 인접 admin 화면 회귀 | backend/H2 test | `./gradlew test --tests '*AdminV3PageSmokeTest' --tests '*RouteGateMatrixAdminPageControllerTest' --tests '*FacilityEvidenceAdminPageControllerTest' --tests '*AliasQuarantineAdminPageControllerTest' --tests '*DataSourceSnapshotAdminPageControllerTest'` | admin/datapack 화면 렌더링 테스트 | 통과 |
| Repository contract | local Node | `node --test tools/ci/repository-contract.test.mjs` | 123 tests passed | 통과 |
| Backend 전체 회귀 | local Gradle | `./gradlew test` | BUILD SUCCESSFUL | 통과 |
| 화면 증거 | admin read-only table | 증거 불필요 사유: 신규 동작은 MockMvc HTML 렌더링과 권한 차단으로 검증되는 관리자 read-only table이며, PR에는 CI와 테스트 출력으로 충분하다. | 스크린샷 없음 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteGateMatrixAdminPageController`의 blocker label 파생 로직과 `route_edge_evidence` 조회 컬럼.

## 리스크

- 현재 화면은 ledger 최신 200건의 read-only 목록이다. 집계형 station x line matrix나 candidate diff 강조는 후속 화면 고도화에서 다룬다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI fallback은 필요하지 않았다.
- [x] 배포 영향 없음. merge 후 post-merge workflow 실패 여부만 확인한다.
