### PR TITLE
[Feat] 데이터팩 manual override ledger 화면 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
+++ b/backend/src/main/java/com/easysubway/admin/navigation/AdminProgram.java
@@ -24,6 +24,7 @@ public enum AdminProgram {
 	DATAPACK_ALIAS_QUARANTINE("a-datapack-alias-quarantine", "데이터팩", "Alias / Quarantine", "/admin/datapack/alias-quarantine/page", AdminPermission.DATAPACK_READ),
 	DATAPACK_FACILITY_EVIDENCE("a-datapack-facility-evidence", "데이터팩", "Facility Evidence", "/admin/datapack/facility-evidence/page", AdminPermission.DATAPACK_READ),
 	DATAPACK_ROUTE_GATES("a-datapack-route-gates", "데이터팩", "Route Gates", "/admin/datapack/route-gates/page", AdminPermission.DATAPACK_READ),
+	DATAPACK_MANUAL_OVERRIDES("a-datapack-manual-overrides", "데이터팩", "Manual Overrides", "/admin/datapack/manual-overrides/page", AdminPermission.DATAPACK_READ),
 	PUSH("a-push", "운영·분석", "푸시 알림", "/admin/notifications/push/page", AdminPermission.DATA_OPERATE),
 	USAGE("a-usage", "운영·분석", "사용 현황", "/admin/usage/activity/page", AdminPermission.SECURITY_AUDIT),
 	SYSTEM("a-system", "운영·분석", "시스템 상태", "/admin/system/page", AdminPermission.SECURITY_AUDIT),

--- a/backend/src/main/java/com/easysubway/datapack/adapter/in/web/ManualOverrideLedgerAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/in/web/ManualOverrideLedgerAdminPageController.java
@@ -1,0 +1,117 @@
+package com.easysubway.datapack.adapter.in.web;
+
+import com.easysubway.datapack.adapter.out.persistence.JdbcManualOverrideLedgerRepository;
+import com.easysubway.datapack.adapter.out.persistence.JdbcManualOverrideLedgerRepository.ManualOverrideRow;
+import java.time.LocalDateTime;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+class ManualOverrideLedgerAdminPageController {
+
+	private static final int LEDGER_LIMIT = 200;
+
+	private final JdbcManualOverrideLedgerRepository ledgerRepository;
+
+	ManualOverrideLedgerAdminPageController(JdbcManualOverrideLedgerRepository ledgerRepository) {
+		this.ledgerRepository = ledgerRepository;
+	}
+
+	@GetMapping("/admin/datapack/manual-overrides/page")
+	@PreAuthorize("hasAuthority('admin.datapack.read')")
+	String manualOverrides(Model model) {
+		model.addAttribute("overrideRows", ledgerRepository.listRecentOverrides(LEDGER_LIMIT).stream()
+			.map(ManualOverrideView::from)
+			.toList());
+		return "admin/datapack/manual-overrides/list";
+	}
+
+	record ManualOverrideView(
+		String id,
+		String entityType,
+		String entityId,
+		String fieldName,
+		String beforeValue,
+		String afterValue,
+		String reasonCode,
+		String reason,
+		String evidenceUri,
+		String evidenceHash,
+		String requestedBy,
+		String approvedBy,
+		LocalDateTime approvedAt,
+		String routeSafetyApprovedBy,
+		String approvalStatus,
+		String conflictStatus,
+		boolean strictRouteEligible,
+		LocalDateTime effectiveFrom,
+		LocalDateTime expiresAt,
+		String supersededBy,
+		String productionStatus
+	) {
+
+		static ManualOverrideView from(ManualOverrideRow row) {
+			return new ManualOverrideView(
+				row.id(),
+				row.entityType(),
+				row.entityId(),
+				row.fieldName(),
+				valueOrDash(row.beforeValue()),
+				row.afterValue(),
+				row.reasonCode(),
+				row.reason(),
+				row.evidenceUri(),
+				row.evidenceHash(),
+				row.requestedBy(),
+				valueOrDash(row.approvedBy()),
+				row.approvedAt(),
+				valueOrDash(row.routeSafetyApprovedBy()),
+				row.approvalStatus(),
+				row.conflictStatus(),
+				row.strictRouteEligible(),
+				row.effectiveFrom(),
+				row.expiresAt(),
+				valueOrDash(row.supersededBy()),
+				ManualOverrideLedgerAdminPageController.productionStatus(row)
+			);
+		}
+	}
+
+	private static String productionStatus(ManualOverrideRow row) {
+		if ("EXPIRED".equals(row.approvalStatus())) {
+			return "expired";
+		}
+		if ("SUPERSEDED".equals(row.approvalStatus()) || hasText(row.supersededBy())) {
+			return "superseded";
+		}
+		if ("REJECTED".equals(row.approvalStatus())) {
+			return "rejected";
+		}
+		if ("UNRESOLVED".equals(row.conflictStatus())) {
+			return "unresolved conflict";
+		}
+		if (row.strictRouteEligible() && !hasText(row.routeSafetyApprovedBy())) {
+			return "route safety approval missing";
+		}
+		if (!"APPROVED".equals(row.approvalStatus())) {
+			return "approval pending";
+		}
+		if (!hasText(row.approvedBy()) || row.approvedAt() == null) {
+			return "approval missing";
+		}
+		if (row.requestedBy().equals(row.approvedBy())) {
+			return "requester approver same";
+		}
+		return "candidate 가능";
+	}
+
+	private static boolean hasText(String value) {
+		return value != null && !value.isBlank();
+	}
+
+	private static String valueOrDash(String value) {
+		return hasText(value) ? value : "-";
+	}
+}

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcManualOverrideLedgerRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcManualOverrideLedgerRepository.java
@@ -1,0 +1,90 @@
+package com.easysubway.datapack.adapter.out.persistence;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcManualOverrideLedgerRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	public JdbcManualOverrideLedgerRepository(DataSource dataSource) {
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+
+	public List<ManualOverrideRow> listRecentOverrides(int limit) {
+		return jdbcTemplate.query("""
+			SELECT id, entity_type, entity_id, field_name, before_value, after_value,
+				reason_code, reason, evidence_uri, evidence_hash, requested_by,
+				approved_by, approved_at, route_safety_approved_by, approval_status,
+				conflict_status, strict_route_eligible, effective_from, expires_at,
+				superseded_by, created_at
+			FROM manual_overrides
+			ORDER BY entity_type ASC, entity_id ASC, approval_status ASC, created_at DESC, id ASC
+			LIMIT ?
+			""", this::mapRow, limit);
+	}
+
+	private ManualOverrideRow mapRow(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new ManualOverrideRow(
+			resultSet.getString("id"),
+			resultSet.getString("entity_type"),
+			resultSet.getString("entity_id"),
+			resultSet.getString("field_name"),
+			resultSet.getString("before_value"),
+			resultSet.getString("after_value"),
+			resultSet.getString("reason_code"),
+			resultSet.getString("reason"),
+			resultSet.getString("evidence_uri"),
+			resultSet.getString("evidence_hash"),
+			resultSet.getString("requested_by"),
+			resultSet.getString("approved_by"),
+			toLocalDateTime(resultSet, "approved_at"),
+			resultSet.getString("route_safety_approved_by"),
+			resultSet.getString("approval_status"),
+			resultSet.getString("conflict_status"),
+			resultSet.getBoolean("strict_route_eligible"),
+			toLocalDateTime(resultSet, "effective_from"),
+			toLocalDateTime(resultSet, "expires_at"),
+			resultSet.getString("superseded_by"),
+			toLocalDateTime(resultSet, "created_at")
+		);
+	}
+
+	private LocalDateTime toLocalDateTime(ResultSet resultSet, String column) throws SQLException {
+		var timestamp = resultSet.getTimestamp(column);
+		return timestamp == null ? null : timestamp.toLocalDateTime();
+	}
+
+	public record ManualOverrideRow(
+		String id,
+		String entityType,
+		String entityId,
+		String fieldName,
+		String beforeValue,
+		String afterValue,
+		String reasonCode,
+		String reason,
+		String evidenceUri,
+		String evidenceHash,
+		String requestedBy,
+		String approvedBy,
+		LocalDateTime approvedAt,
+		String routeSafetyApprovedBy,
+		String approvalStatus,
+		String conflictStatus,
+		boolean strictRouteEligible,
+		LocalDateTime effectiveFrom,
+		LocalDateTime expiresAt,
+		String supersededBy,
+		LocalDateTime createdAt
+	) {
+	}
+}

--- a/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
+++ b/backend/src/main/resources/templates/admin/datapack/manual-overrides/list.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Manual Overrides</title>
+	<link rel="stylesheet" th:href="@{/css/admin-v3.css}">
+</head>
+<body class="admin-v3">
+<a th:replace="~{admin/fragments/shell :: skipLink}"></a>
+<div class="admin-shell">
+<div th:replace="~{admin/fragments/shell :: sidebar('a-datapack-manual-overrides')}"></div>
+<main class="admin-main">
+	<div th:replace="~{admin/fragments/shell :: topbar}"></div>
+	<div th:replace="~{admin/fragments/shell :: contentStart}"></div>
+	<header class="admin-page-head">
+		<div>
+			<h1>Manual Overrides</h1>
+			<p>production candidate 입력 전에 override 승인, 충돌, 만료, strict route 안전 승인 상태를 읽기 전용으로 확인합니다.</p>
+		</div>
+	</header>
+
+	<section class="admin-panel">
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">id</th>
+				<th scope="col">entity</th>
+				<th scope="col">field</th>
+				<th scope="col">before</th>
+				<th scope="col">after</th>
+				<th scope="col">reason</th>
+				<th scope="col">evidence</th>
+				<th scope="col">requested</th>
+				<th scope="col">approved</th>
+				<th scope="col">status</th>
+				<th scope="col">conflict</th>
+				<th scope="col">strict</th>
+				<th scope="col">window</th>
+				<th scope="col">superseded</th>
+				<th scope="col">production</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:if="${overrideRows.isEmpty()}">
+				<td colspan="15">manual override row가 없습니다.</td>
+			</tr>
+			<tr th:each="row : ${overrideRows}">
+				<td th:text="${row.id}">override-id</td>
+				<td>
+					<span th:text="${row.entityType}">FACILITY</span>
+					<span th:text="${row.entityId}">entity-id</span>
+				</td>
+				<td th:text="${row.fieldName}">field</td>
+				<td th:text="${row.beforeValue}">before</td>
+				<td th:text="${row.afterValue}">after</td>
+				<td>
+					<span th:text="${row.reasonCode}">FIELD_CHECK</span>
+					<span th:text="${row.reason}">reason</span>
+				</td>
+				<td>
+					<span th:text="${row.evidenceUri}">evidence-uri</span>
+					<span th:text="${row.evidenceHash}">sha256</span>
+				</td>
+				<td th:text="${row.requestedBy}">requester</td>
+				<td>
+					<span th:text="${row.approvedBy}">approver</span>
+					<span th:text="${row.approvedAt}">approved-at</span>
+				</td>
+				<td th:text="${row.approvalStatus}">APPROVED</td>
+				<td th:text="${row.conflictStatus}">NONE</td>
+				<td>
+					<span th:text="${row.strictRouteEligible ? 'strict 요청' : 'strict 아님'}">strict 아님</span>
+					<span th:text="${row.routeSafetyApprovedBy}">-</span>
+				</td>
+				<td>
+					<span th:text="${row.effectiveFrom}">2026-06-29T03:00</span>
+					<span th:text="${row.expiresAt}">2026-07-29T03:00</span>
+				</td>
+				<td th:text="${row.supersededBy}">-</td>
+				<td th:text="${row.productionStatus}">candidate 가능</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+</main>
+</div>
+</body>
+</html>

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/ManualOverrideLedgerAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/ManualOverrideLedgerAdminPageControllerTest.java
@@ -1,0 +1,226 @@
+package com.easysubway.datapack.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("관리자 데이터팩 manual override ledger 화면")
+class ManualOverrideLedgerAdminPageControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.update("DELETE FROM route_edge_evidence");
+		jdbcTemplate.update("DELETE FROM facility_evidence");
+		jdbcTemplate.update("DELETE FROM source_quarantine_resolutions");
+		jdbcTemplate.update("DELETE FROM source_quarantine_records");
+		jdbcTemplate.update("DELETE FROM external_alias_approvals");
+		jdbcTemplate.update("DELETE FROM datapack_normalization_runs");
+		jdbcTemplate.update("DELETE FROM data_source_snapshots");
+		jdbcTemplate.update("DELETE FROM manual_overrides");
+		insertApprovedOverride();
+		insertPendingConflictOverride();
+		insertStrictPendingOverride();
+		insertExpiredOverride();
+	}
+
+	@Test
+	@DisplayName("datapack read 권한 관리자는 manual override ledger를 확인한다")
+	void datapackReadAdminViewsManualOverrideLedger() throws Exception {
+		String html = mockMvc.perform(get("/admin/datapack/manual-overrides/page")
+				.with(user("datapack-viewer").authorities(new SimpleGrantedAuthority("admin.datapack.read"))))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+
+		assertThat(html)
+			.contains("Manual Overrides")
+			.contains("override-approved-1")
+			.contains("FACILITY")
+			.contains("operational_status")
+			.contains("APPROVED")
+			.contains("candidate 가능")
+			.contains("override-conflict-1")
+			.contains("UNRESOLVED")
+			.contains("unresolved conflict")
+			.contains("override-strict-pending")
+			.contains("route safety approval missing")
+			.contains("override-expired-1")
+			.contains("EXPIRED")
+			.contains("expired")
+			.doesNotContain("name=\"commandToken\"")
+			.doesNotContain("승인 저장")
+			.doesNotContain("serviceKey");
+	}
+
+	@Test
+	@DisplayName("datapack read 권한이 없으면 manual override ledger에 접근할 수 없다")
+	void manualOverrideLedgerPageRequiresDatapackReadPermission() throws Exception {
+		mockMvc.perform(get("/admin/datapack/manual-overrides/page")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view"))))
+			.andExpect(status().isForbidden());
+	}
+
+	private void insertApprovedOverride() {
+		insertOverride(
+			"override-approved-1",
+			"FACILITY",
+			"station-sangnoksu:ELEVATOR",
+			"operational_status",
+			"UNKNOWN",
+			"AVAILABLE",
+			"FIELD_CHECK",
+			"현장 확인으로 운행 가능 확인",
+			"qa-operator",
+			"qa-reviewer",
+			"2026-06-29 03:30:00",
+			null,
+			"APPROVED",
+			"NONE",
+			false,
+			null,
+			"a".repeat(64)
+		);
+	}
+
+	private void insertPendingConflictOverride() {
+		insertOverride(
+			"override-conflict-1",
+			"FACILITY",
+			"station-sadang:WHEELCHAIR_LIFT",
+			"operational_status",
+			"UNKNOWN",
+			"CHECK_REQUIRED",
+			"SOURCE_CONFLICT",
+			"공식 source와 현장 확인 결과가 충돌",
+			"qa-operator",
+			null,
+			null,
+			null,
+			"PENDING",
+			"UNRESOLVED",
+			false,
+			null,
+			"b".repeat(64)
+		);
+	}
+
+	private void insertStrictPendingOverride() {
+		insertOverride(
+			"override-strict-pending",
+			"ROUTE_EDGE",
+			"edge-transfer-1",
+			"strict_route_eligible",
+			"FALSE",
+			"TRUE",
+			"ROUTE_SAFETY",
+			"strict 경로 사용 가능 여부 검수 대기",
+			"qa-operator",
+			null,
+			null,
+			null,
+			"PENDING",
+			"NONE",
+			true,
+			null,
+			"c".repeat(64)
+		);
+	}
+
+	private void insertExpiredOverride() {
+		insertOverride(
+			"override-expired-1",
+			"FACILITY",
+			"station-old:ELEVATOR",
+			"operational_status",
+			"AVAILABLE",
+			"UNAVAILABLE",
+			"TEMP_CLOSURE",
+			"임시 운휴 기간 종료",
+			"qa-operator",
+			null,
+			null,
+			null,
+			"EXPIRED",
+			"NONE",
+			false,
+			null,
+			"d".repeat(64)
+		);
+	}
+
+	private void insertOverride(
+		String id,
+		String entityType,
+		String entityId,
+		String fieldName,
+		String beforeValue,
+		String afterValue,
+		String reasonCode,
+		String reason,
+		String requestedBy,
+		String approvedBy,
+		String approvedAt,
+		String routeSafetyApprovedBy,
+		String approvalStatus,
+		String conflictStatus,
+		boolean strictRouteEligible,
+		String supersededBy,
+		String evidenceHash
+	) {
+		jdbcTemplate.update("""
+			INSERT INTO manual_overrides (
+				id, entity_type, entity_id, field_name, before_value, after_value,
+				reason_code, reason, evidence_uri, evidence_hash, requested_by,
+				approved_by, approved_at, route_safety_approved_by, approval_status,
+				conflict_status, strict_route_eligible, effective_from, expires_at,
+				superseded_by, created_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?,
+				's3://easysubway-evidence/manual-overrides/' || ? || '.json',
+				?, ?, ?, ?, ?, ?, ?, ?, '2026-06-29 03:00:00',
+				'2026-07-29 03:00:00', ?, '2026-06-29 03:10:00')
+			""",
+			id,
+			entityType,
+			entityId,
+			fieldName,
+			beforeValue,
+			afterValue,
+			reasonCode,
+			reason,
+			id,
+			evidenceHash,
+			requestedBy,
+			approvedBy,
+			approvedAt,
+			routeSafetyApprovedBy,
+			approvalStatus,
+			conflictStatus,
+			strictRouteEligible,
+			supersededBy
+		);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #1122

## 작업 배경

#1081 데이터팩 운영 콘솔 기준은 production candidate가 기존 즉시 override가 아니라 `manual_overrides` ledger의 reason/evidence/expiry/approval/conflict/strict eligibility 상태를 확인한 뒤 반영하도록 요구한다. Ledger schema는 있지만 관리자가 승인 상태와 blocker를 한 화면에서 확인하는 read-only 화면이 없었다.

## 작업 내용

- 데이터팩 관리자 메뉴에 Manual Overrides 화면을 추가했다.
- `manual_overrides` ledger를 entity/field/status 기준으로 조회하는 read-only repository와 controller를 추가했다.
- 화면에서 before/after, reason, evidence URI/hash, 요청자/승인자, conflict, strict route safety 승인, effective/expiry window, superseded 상태와 production blocker label을 표시한다.
- 승인/반려/수정 form은 추가하지 않아 최종 데이터 직접 편집 경로를 만들지 않았다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests '*ManualOverrideLedgerAdminPageControllerTest'`: BUILD SUCCESSFUL
  - `./gradlew test --tests '*AdminV3PageSmokeTest' --tests '*ManualOverrideLedgerAdminPageControllerTest' --tests '*RouteGateMatrixAdminPageControllerTest' --tests '*FacilityEvidenceAdminPageControllerTest' --tests '*AliasQuarantineAdminPageControllerTest' --tests '*DataSourceSnapshotAdminPageControllerTest'`: BUILD SUCCESSFUL
  - `node --test tools/ci/repository-contract.test.mjs`: 123 tests passed
  - `./gradlew test`: BUILD SUCCESSFUL
  - `git diff --check`: exit 0
  - rebase 후 `./gradlew test --tests '*ManualOverrideLedgerAdminPageControllerTest' --tests '*AdminV3PageSmokeTest'`: BUILD SUCCESSFUL
  - rebase 후 `node --test tools/ci/repository-contract.test.mjs`: 123 tests passed
  - rebase 후 `git diff --check origin/main...HEAD`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Manual Overrides 렌더링 | backend/H2 test | `./gradlew test --tests '*ManualOverrideLedgerAdminPageControllerTest'` | MockMvc 응답 HTML에 APPROVED/PENDING/EXPIRED와 blocker label 표시 확인 | 통과 |
| 관리자 권한 차단 | backend/H2 test | `./gradlew test --tests '*ManualOverrideLedgerAdminPageControllerTest'` | `admin.datapack.read` 없는 요청 403 확인 | 통과 |
| 인접 admin 화면 회귀 | backend/H2 test | `./gradlew test --tests '*AdminV3PageSmokeTest' --tests '*ManualOverrideLedgerAdminPageControllerTest' --tests '*RouteGateMatrixAdminPageControllerTest' --tests '*FacilityEvidenceAdminPageControllerTest' --tests '*AliasQuarantineAdminPageControllerTest' --tests '*DataSourceSnapshotAdminPageControllerTest'` | admin/datapack 화면 렌더링 테스트 | 통과 |
| Repository contract | local Node | `node --test tools/ci/repository-contract.test.mjs` | 123 tests passed | 통과 |
| Backend 전체 회귀 | local Gradle | `./gradlew test` | BUILD SUCCESSFUL | 통과 |
| 화면 증거 | admin read-only table | 증거 불필요 사유: 신규 동작은 MockMvc HTML 렌더링과 권한 차단으로 검증되는 관리자 read-only table이며, PR에는 CI와 테스트 출력으로 충분하다. | 스크린샷 없음 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `ManualOverrideLedgerAdminPageController`의 production blocker label 파생 순서와 `manual_overrides` 조회 컬럼.

## 리스크

- 현재 화면은 ledger 최신 200건의 read-only 목록이다. 승인/반려 workflow와 `transit_master_overrides` 승격 flow는 별도 작업으로 남긴다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 가능해 Codex CLI fallback은 필요하지 않았다.
- [x] 배포 영향 없음. merge 후 post-merge workflow 실패 여부만 확인한다.
