### PR TITLE
[Feat] 데이터팩 release channel 요청 안전장치 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseChannelRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseChannelRepository.java
@@ -1,5 +1,6 @@
 package com.easysubway.datapack.adapter.out.persistence;
 
+import com.easysubway.datapack.application.port.out.DatapackReleaseChannelCommandPort;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
@@ -11,7 +12,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class JdbcDatapackReleaseChannelRepository {
+public class JdbcDatapackReleaseChannelRepository implements DatapackReleaseChannelCommandPort {
 
 	private final JdbcTemplate jdbcTemplate;
 
@@ -55,18 +56,20 @@ public class JdbcDatapackReleaseChannelRepository {
 			""", this::mapEvent, limit);
 	}
 
-	public Optional<ReleaseChannelEventRow> findEventByIdempotencyKey(String channel, String idempotencyKey) {
+	@Override
+	public Optional<ReleaseChannelEvent> findEventByIdempotencyKey(String channel, String idempotencyKey) {
 		return jdbcTemplate.query("""
 			SELECT id, channel, previous_candidate_id, next_candidate_id,
 				previous_manifest_sha256, next_manifest_sha256, operation_type,
-				operation_status, requested_by, approved_by, reason,
+				requested_by, approved_by, reason,
 				idempotency_key, workflow_run_url, created_at
 			FROM datapack_release_channel_events
 			WHERE channel = ? AND idempotency_key = ?
-			""", this::mapEvent, channel, idempotencyKey).stream().findFirst();
+			""", this::mapCommandEvent, channel, idempotencyKey).stream().findFirst();
 	}
 
-	public Optional<ReleaseChannelStateRow> lockChannel(String channel) {
+	@Override
+	public Optional<ReleaseChannelState> lockChannel(String channel) {
 		return jdbcTemplate.query("""
 			SELECT channel, candidate_id, manifest_sha256,
 				previous_stable_candidate_id, previous_manifest_sha256,
@@ -77,6 +80,7 @@ public class JdbcDatapackReleaseChannelRepository {
 			""", this::mapChannelState, channel).stream().findFirst();
 	}
 
+	@Override
 	public boolean candidateHasManifest(String candidateId, String manifestSha256) {
 		Integer count = jdbcTemplate.queryForObject("""
 			SELECT COUNT(*)
@@ -86,6 +90,7 @@ public class JdbcDatapackReleaseChannelRepository {
 		return count != null && count > 0;
 	}
 
+	@Override
 	public void updateChannel(
 		String channel,
 		String nextCandidateId,
@@ -129,6 +134,7 @@ public class JdbcDatapackReleaseChannelRepository {
 		);
 	}
 
+	@Override
 	public void insertEvent(
 		String id,
 		String channel,
@@ -210,8 +216,25 @@ public class JdbcDatapackReleaseChannelRepository {
 		);
 	}
 
-	private ReleaseChannelStateRow mapChannelState(ResultSet resultSet, int rowNumber) throws SQLException {
-		return new ReleaseChannelStateRow(
+	private ReleaseChannelEvent mapCommandEvent(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new ReleaseChannelEvent(
+			resultSet.getString("id"),
+			resultSet.getString("channel"),
+			resultSet.getString("previous_candidate_id"),
+			resultSet.getString("next_candidate_id"),
+			resultSet.getString("previous_manifest_sha256"),
+			resultSet.getString("next_manifest_sha256"),
+			resultSet.getString("operation_type"),
+			resultSet.getString("requested_by"),
+			resultSet.getString("approved_by"),
+			resultSet.getString("reason"),
+			resultSet.getString("idempotency_key"),
+			resultSet.getString("workflow_run_url")
+		);
+	}
+
+	private ReleaseChannelState mapChannelState(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new ReleaseChannelState(
 			resultSet.getString("channel"),
 			resultSet.getString("candidate_id"),
 			resultSet.getString("manifest_sha256"),
@@ -257,17 +280,6 @@ public class JdbcDatapackReleaseChannelRepository {
 		String idempotencyKey,
 		String workflowRunUrl,
 		LocalDateTime createdAt
-	) {
-	}
-
-	public record ReleaseChannelStateRow(
-		String channel,
-		String candidateId,
-		String manifestSha256,
-		String previousStableCandidateId,
-		String previousManifestSha256,
-		boolean rollbackAvailable,
-		String lastOperationStatus
 	) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseChannelRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseChannelRepository.java
@@ -4,6 +4,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -54,6 +55,120 @@ public class JdbcDatapackReleaseChannelRepository {
 			""", this::mapEvent, limit);
 	}
 
+	public Optional<ReleaseChannelEventRow> findEventByIdempotencyKey(String channel, String idempotencyKey) {
+		return jdbcTemplate.query("""
+			SELECT id, channel, previous_candidate_id, next_candidate_id,
+				previous_manifest_sha256, next_manifest_sha256, operation_type,
+				operation_status, requested_by, approved_by, reason,
+				idempotency_key, workflow_run_url, created_at
+			FROM datapack_release_channel_events
+			WHERE channel = ? AND idempotency_key = ?
+			""", this::mapEvent, channel, idempotencyKey).stream().findFirst();
+	}
+
+	public Optional<ReleaseChannelStateRow> lockChannel(String channel) {
+		return jdbcTemplate.query("""
+			SELECT channel, candidate_id, manifest_sha256,
+				previous_stable_candidate_id, previous_manifest_sha256,
+				rollback_available, last_operation_status
+			FROM datapack_release_channels
+			WHERE channel = ?
+			FOR UPDATE
+			""", this::mapChannelState, channel).stream().findFirst();
+	}
+
+	public boolean candidateHasManifest(String candidateId, String manifestSha256) {
+		Integer count = jdbcTemplate.queryForObject("""
+			SELECT COUNT(*)
+			FROM datapack_candidates
+			WHERE id = ? AND manifest_sha256 = ?
+			""", Integer.class, candidateId, manifestSha256);
+		return count != null && count > 0;
+	}
+
+	public void updateChannel(
+		String channel,
+		String nextCandidateId,
+		String nextManifestSha256,
+		String previousStableCandidateId,
+		String previousManifestSha256,
+		String operationType,
+		String requestedBy,
+		String approvedBy,
+		String reason,
+		String idempotencyKey,
+		LocalDateTime updatedAt
+	) {
+		jdbcTemplate.update("""
+			UPDATE datapack_release_channels
+			SET candidate_id = ?,
+				manifest_sha256 = ?,
+				previous_stable_candidate_id = ?,
+				previous_manifest_sha256 = ?,
+				rollback_available = TRUE,
+				last_operation_type = ?,
+				last_operation_status = 'PASS',
+				requested_by = ?,
+				approved_by = ?,
+				reason = ?,
+				idempotency_key = ?,
+				updated_at = ?
+			WHERE channel = ?
+			""",
+			nextCandidateId,
+			nextManifestSha256,
+			previousStableCandidateId,
+			previousManifestSha256,
+			operationType,
+			requestedBy,
+			approvedBy,
+			reason,
+			idempotencyKey,
+			updatedAt,
+			channel
+		);
+	}
+
+	public void insertEvent(
+		String id,
+		String channel,
+		String previousCandidateId,
+		String nextCandidateId,
+		String previousManifestSha256,
+		String nextManifestSha256,
+		String operationType,
+		String requestedBy,
+		String approvedBy,
+		String reason,
+		String idempotencyKey,
+		String workflowRunUrl,
+		LocalDateTime createdAt
+	) {
+		jdbcTemplate.update("""
+			INSERT INTO datapack_release_channel_events (
+				id, channel, previous_candidate_id, next_candidate_id,
+				previous_manifest_sha256, next_manifest_sha256, operation_type,
+				operation_status, requested_by, approved_by, reason,
+				idempotency_key, workflow_run_url, created_at
+			)
+			VALUES (?, ?, ?, ?, ?, ?, ?, 'PASS', ?, ?, ?, ?, ?, ?)
+			""",
+			id,
+			channel,
+			previousCandidateId,
+			nextCandidateId,
+			previousManifestSha256,
+			nextManifestSha256,
+			operationType,
+			requestedBy,
+			approvedBy,
+			reason,
+			idempotencyKey,
+			workflowRunUrl,
+			createdAt
+		);
+	}
+
 	private ReleaseChannelRow mapChannel(ResultSet resultSet, int rowNumber) throws SQLException {
 		return new ReleaseChannelRow(
 			resultSet.getString("channel"),
@@ -95,6 +210,18 @@ public class JdbcDatapackReleaseChannelRepository {
 		);
 	}
 
+	private ReleaseChannelStateRow mapChannelState(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new ReleaseChannelStateRow(
+			resultSet.getString("channel"),
+			resultSet.getString("candidate_id"),
+			resultSet.getString("manifest_sha256"),
+			resultSet.getString("previous_stable_candidate_id"),
+			resultSet.getString("previous_manifest_sha256"),
+			resultSet.getBoolean("rollback_available"),
+			resultSet.getString("last_operation_status")
+		);
+	}
+
 	public record ReleaseChannelRow(
 		String channel,
 		String candidateId,
@@ -130,6 +257,17 @@ public class JdbcDatapackReleaseChannelRepository {
 		String idempotencyKey,
 		String workflowRunUrl,
 		LocalDateTime createdAt
+	) {
+	}
+
+	public record ReleaseChannelStateRow(
+		String channel,
+		String candidateId,
+		String manifestSha256,
+		String previousStableCandidateId,
+		String previousManifestSha256,
+		boolean rollbackAvailable,
+		String lastOperationStatus
 	) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/datapack/application/port/out/DatapackReleaseChannelCommandPort.java
+++ b/backend/src/main/java/com/easysubway/datapack/application/port/out/DatapackReleaseChannelCommandPort.java
@@ -1,0 +1,70 @@
+package com.easysubway.datapack.application.port.out;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface DatapackReleaseChannelCommandPort {
+
+	Optional<ReleaseChannelEvent> findEventByIdempotencyKey(String channel, String idempotencyKey);
+
+	Optional<ReleaseChannelState> lockChannel(String channel);
+
+	boolean candidateHasManifest(String candidateId, String manifestSha256);
+
+	void updateChannel(
+		String channel,
+		String nextCandidateId,
+		String nextManifestSha256,
+		String previousStableCandidateId,
+		String previousManifestSha256,
+		String operationType,
+		String requestedBy,
+		String approvedBy,
+		String reason,
+		String idempotencyKey,
+		LocalDateTime updatedAt
+	);
+
+	void insertEvent(
+		String id,
+		String channel,
+		String previousCandidateId,
+		String nextCandidateId,
+		String previousManifestSha256,
+		String nextManifestSha256,
+		String operationType,
+		String requestedBy,
+		String approvedBy,
+		String reason,
+		String idempotencyKey,
+		String workflowRunUrl,
+		LocalDateTime createdAt
+	);
+
+	record ReleaseChannelEvent(
+		String id,
+		String channel,
+		String previousCandidateId,
+		String nextCandidateId,
+		String previousManifestSha256,
+		String nextManifestSha256,
+		String operationType,
+		String requestedBy,
+		String approvedBy,
+		String reason,
+		String idempotencyKey,
+		String workflowRunUrl
+	) {
+	}
+
+	record ReleaseChannelState(
+		String channel,
+		String candidateId,
+		String manifestSha256,
+		String previousStableCandidateId,
+		String previousManifestSha256,
+		boolean rollbackAvailable,
+		String lastOperationStatus
+	) {
+	}
+}

--- a/backend/src/main/java/com/easysubway/datapack/application/service/DatapackReleaseChannelCommandService.java
+++ b/backend/src/main/java/com/easysubway/datapack/application/service/DatapackReleaseChannelCommandService.java
@@ -1,0 +1,206 @@
+package com.easysubway.datapack.application.service;
+
+import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseChannelRepository;
+import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseChannelRepository.ReleaseChannelEventRow;
+import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseChannelRepository.ReleaseChannelStateRow;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DatapackReleaseChannelCommandService {
+
+	private final JdbcDatapackReleaseChannelRepository repository;
+	private final Clock clock;
+
+	public DatapackReleaseChannelCommandService(
+		JdbcDatapackReleaseChannelRepository repository,
+		ObjectProvider<Clock> clockProvider
+	) {
+		this.repository = repository;
+		this.clock = clockProvider.getIfAvailable(Clock::systemDefaultZone);
+	}
+
+	@Transactional
+	public ReleaseChannelOperationResult promote(ReleaseChannelCommand command) {
+		return apply("PROMOTE", command);
+	}
+
+	@Transactional
+	public ReleaseChannelOperationResult rollback(ReleaseChannelCommand command) {
+		return apply("ROLLBACK", command);
+	}
+
+	private ReleaseChannelOperationResult apply(String operationType, ReleaseChannelCommand command) {
+		command.validate();
+		var existingEvent = repository.findEventByIdempotencyKey(command.channel(), command.idempotencyKey());
+		if (existingEvent.isPresent()) {
+			ensureSameIdempotentRequest(operationType, command, existingEvent.get());
+			return ReleaseChannelOperationResult.from(existingEvent.get(), true);
+		}
+
+		var channel = repository.lockChannel(command.channel())
+			.orElseThrow(() -> new IllegalArgumentException("release channel not found: " + command.channel()));
+		existingEvent = repository.findEventByIdempotencyKey(command.channel(), command.idempotencyKey());
+		if (existingEvent.isPresent()) {
+			ensureSameIdempotentRequest(operationType, command, existingEvent.get());
+			return ReleaseChannelOperationResult.from(existingEvent.get(), true);
+		}
+		ensureNoPendingOperation(channel);
+		ensureCurrentPointerMatches(channel, command);
+		ensureNextCandidateExists(command);
+		if ("ROLLBACK".equals(operationType)) {
+			ensureRollbackTarget(channel, command);
+		}
+
+		var now = LocalDateTime.now(clock);
+		var eventId = "release-channel-event-" + UUID.randomUUID();
+		repository.updateChannel(
+			command.channel(),
+			command.nextCandidateId(),
+			command.nextManifestSha256(),
+			channel.candidateId(),
+			channel.manifestSha256(),
+			operationType,
+			command.requestedBy(),
+			command.approvedBy(),
+			command.reason(),
+			command.idempotencyKey(),
+			now
+		);
+		repository.insertEvent(
+			eventId,
+			command.channel(),
+			channel.candidateId(),
+			command.nextCandidateId(),
+			channel.manifestSha256(),
+			command.nextManifestSha256(),
+			operationType,
+			command.requestedBy(),
+			command.approvedBy(),
+			command.reason(),
+			command.idempotencyKey(),
+			command.workflowRunUrl(),
+			now
+		);
+		return new ReleaseChannelOperationResult(
+			eventId,
+			command.channel(),
+			channel.candidateId(),
+			command.nextCandidateId(),
+			operationType,
+			false
+		);
+	}
+
+	private void ensureNoPendingOperation(ReleaseChannelStateRow channel) {
+		if ("PENDING".equals(channel.lastOperationStatus())) {
+			throw new IllegalStateException("release channel " + channel.channel()
+				+ " already has a pending release operation");
+		}
+	}
+
+	private void ensureSameIdempotentRequest(
+		String operationType,
+		ReleaseChannelCommand command,
+		ReleaseChannelEventRow event
+	) {
+		if (!operationType.equals(event.operationType())
+			|| !command.previousCandidateId().equals(event.previousCandidateId())
+			|| !command.nextCandidateId().equals(event.nextCandidateId())
+			|| !command.previousManifestSha256().equals(event.previousManifestSha256())
+			|| !command.nextManifestSha256().equals(event.nextManifestSha256())
+			|| !command.requestedBy().equals(event.requestedBy())
+			|| !command.approvedBy().equals(event.approvedBy())
+			|| !command.reason().equals(event.reason())) {
+			throw new IllegalArgumentException(
+				"idempotency key already belongs to a different release operation");
+		}
+	}
+
+	private void ensureCurrentPointerMatches(ReleaseChannelStateRow channel, ReleaseChannelCommand command) {
+		if (!channel.candidateId().equals(command.previousCandidateId())
+			|| !channel.manifestSha256().equals(command.previousManifestSha256())) {
+			throw new IllegalArgumentException("previous candidate or manifest hash does not match current channel");
+		}
+	}
+
+	private void ensureNextCandidateExists(ReleaseChannelCommand command) {
+		if (!repository.candidateHasManifest(command.nextCandidateId(), command.nextManifestSha256())) {
+			throw new IllegalArgumentException("next candidate manifest hash does not match a known candidate");
+		}
+	}
+
+	private void ensureRollbackTarget(ReleaseChannelStateRow channel, ReleaseChannelCommand command) {
+		if (!channel.rollbackAvailable()
+			|| channel.previousStableCandidateId() == null
+			|| channel.previousManifestSha256() == null
+			|| !channel.previousStableCandidateId().equals(command.nextCandidateId())
+			|| !channel.previousManifestSha256().equals(command.nextManifestSha256())) {
+			throw new IllegalArgumentException("rollback target must be the previous stable candidate");
+		}
+	}
+
+	public record ReleaseChannelCommand(
+		String channel,
+		String previousCandidateId,
+		String nextCandidateId,
+		String previousManifestSha256,
+		String nextManifestSha256,
+		String requestedBy,
+		String approvedBy,
+		String reason,
+		String idempotencyKey,
+		String workflowRunUrl
+	) {
+
+		private void validate() {
+			requireText(channel, "channel");
+			requireText(previousCandidateId, "previousCandidateId");
+			requireText(nextCandidateId, "nextCandidateId");
+			requireSha(previousManifestSha256, "previousManifestSha256");
+			requireSha(nextManifestSha256, "nextManifestSha256");
+			requireText(requestedBy, "requestedBy");
+			requireText(approvedBy, "approvedBy");
+			requireText(reason, "reason");
+			requireText(idempotencyKey, "idempotencyKey");
+		}
+
+		private static void requireText(String value, String name) {
+			if (value == null || value.isBlank()) {
+				throw new IllegalArgumentException(name + " is required");
+			}
+		}
+
+		private static void requireSha(String value, String name) {
+			requireText(value, name);
+			if (value.length() != 64) {
+				throw new IllegalArgumentException(name + " must be a sha256 hex string");
+			}
+		}
+	}
+
+	public record ReleaseChannelOperationResult(
+		String eventId,
+		String channel,
+		String previousCandidateId,
+		String nextCandidateId,
+		String operationType,
+		boolean idempotentReplay
+	) {
+
+		private static ReleaseChannelOperationResult from(ReleaseChannelEventRow event, boolean idempotentReplay) {
+			return new ReleaseChannelOperationResult(
+				event.id(),
+				event.channel(),
+				event.previousCandidateId(),
+				event.nextCandidateId(),
+				event.operationType(),
+				idempotentReplay
+			);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/datapack/application/service/DatapackReleaseChannelCommandService.java
+++ b/backend/src/main/java/com/easysubway/datapack/application/service/DatapackReleaseChannelCommandService.java
@@ -1,11 +1,12 @@
 package com.easysubway.datapack.application.service;
 
-import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseChannelRepository;
-import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseChannelRepository.ReleaseChannelEventRow;
-import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseChannelRepository.ReleaseChannelStateRow;
+import com.easysubway.datapack.application.port.out.DatapackReleaseChannelCommandPort;
+import com.easysubway.datapack.application.port.out.DatapackReleaseChannelCommandPort.ReleaseChannelEvent;
+import com.easysubway.datapack.application.port.out.DatapackReleaseChannelCommandPort.ReleaseChannelState;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,11 +14,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class DatapackReleaseChannelCommandService {
 
-	private final JdbcDatapackReleaseChannelRepository repository;
+	private static final Pattern SHA256_HEX = Pattern.compile("[0-9a-fA-F]{64}");
+
+	private final DatapackReleaseChannelCommandPort repository;
 	private final Clock clock;
 
 	public DatapackReleaseChannelCommandService(
-		JdbcDatapackReleaseChannelRepository repository,
+		DatapackReleaseChannelCommandPort repository,
 		ObjectProvider<Clock> clockProvider
 	) {
 		this.repository = repository;
@@ -96,7 +99,7 @@ public class DatapackReleaseChannelCommandService {
 		);
 	}
 
-	private void ensureNoPendingOperation(ReleaseChannelStateRow channel) {
+	private void ensureNoPendingOperation(ReleaseChannelState channel) {
 		if ("PENDING".equals(channel.lastOperationStatus())) {
 			throw new IllegalStateException("release channel " + channel.channel()
 				+ " already has a pending release operation");
@@ -106,7 +109,7 @@ public class DatapackReleaseChannelCommandService {
 	private void ensureSameIdempotentRequest(
 		String operationType,
 		ReleaseChannelCommand command,
-		ReleaseChannelEventRow event
+		ReleaseChannelEvent event
 	) {
 		if (!operationType.equals(event.operationType())
 			|| !command.previousCandidateId().equals(event.previousCandidateId())
@@ -115,13 +118,14 @@ public class DatapackReleaseChannelCommandService {
 			|| !command.nextManifestSha256().equals(event.nextManifestSha256())
 			|| !command.requestedBy().equals(event.requestedBy())
 			|| !command.approvedBy().equals(event.approvedBy())
-			|| !command.reason().equals(event.reason())) {
+			|| !command.reason().equals(event.reason())
+			|| !command.workflowRunUrl().equals(event.workflowRunUrl())) {
 			throw new IllegalArgumentException(
 				"idempotency key already belongs to a different release operation");
 		}
 	}
 
-	private void ensureCurrentPointerMatches(ReleaseChannelStateRow channel, ReleaseChannelCommand command) {
+	private void ensureCurrentPointerMatches(ReleaseChannelState channel, ReleaseChannelCommand command) {
 		if (!channel.candidateId().equals(command.previousCandidateId())
 			|| !channel.manifestSha256().equals(command.previousManifestSha256())) {
 			throw new IllegalArgumentException("previous candidate or manifest hash does not match current channel");
@@ -134,7 +138,7 @@ public class DatapackReleaseChannelCommandService {
 		}
 	}
 
-	private void ensureRollbackTarget(ReleaseChannelStateRow channel, ReleaseChannelCommand command) {
+	private void ensureRollbackTarget(ReleaseChannelState channel, ReleaseChannelCommand command) {
 		if (!channel.rollbackAvailable()
 			|| channel.previousStableCandidateId() == null
 			|| channel.previousManifestSha256() == null
@@ -167,6 +171,7 @@ public class DatapackReleaseChannelCommandService {
 			requireText(approvedBy, "approvedBy");
 			requireText(reason, "reason");
 			requireText(idempotencyKey, "idempotencyKey");
+			requireText(workflowRunUrl, "workflowRunUrl");
 		}
 
 		private static void requireText(String value, String name) {
@@ -177,7 +182,7 @@ public class DatapackReleaseChannelCommandService {
 
 		private static void requireSha(String value, String name) {
 			requireText(value, name);
-			if (value.length() != 64) {
+			if (!SHA256_HEX.matcher(value).matches()) {
 				throw new IllegalArgumentException(name + " must be a sha256 hex string");
 			}
 		}
@@ -192,7 +197,7 @@ public class DatapackReleaseChannelCommandService {
 		boolean idempotentReplay
 	) {
 
-		private static ReleaseChannelOperationResult from(ReleaseChannelEventRow event, boolean idempotentReplay) {
+		private static ReleaseChannelOperationResult from(ReleaseChannelEvent event, boolean idempotentReplay) {
 			return new ReleaseChannelOperationResult(
 				event.id(),
 				event.channel(),

--- a/backend/src/test/java/com/easysubway/datapack/application/service/DatapackReleaseChannelCommandServiceTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/application/service/DatapackReleaseChannelCommandServiceTest.java
@@ -7,9 +7,13 @@ import com.easysubway.datapack.application.service.DatapackReleaseChannelCommand
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -86,6 +90,30 @@ class DatapackReleaseChannelCommandServiceTest {
 	}
 
 	@Test
+	@DisplayName("같은 idempotency key라도 workflow run URL이 다르면 거절한다")
+	void idempotencyKeyIncludesWorkflowRunUrl() {
+		service.promote(command("candidate-stable-3", "candidate-stable-4", SHA_3, SHA_4, "idem-workflow"));
+
+		var changedWorkflowCommand = new ReleaseChannelCommand(
+			"production",
+			"candidate-stable-3",
+			"candidate-stable-4",
+			SHA_3,
+			SHA_4,
+			"data-operator",
+			"release-approver",
+			"release request",
+			"idem-workflow",
+			"https://github.com/AquilaXk/easysubway/actions/runs/changed"
+		);
+
+		assertThatThrownBy(() -> service.promote(changedWorkflowCommand))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("idempotency key already belongs to a different release operation");
+		assertThat(eventCount("idem-workflow")).isEqualTo(1);
+	}
+
+	@Test
 	@DisplayName("진행 중인 channel operation이 있으면 새 요청을 거절한다")
 	void pendingOperationBlocksNewCommand() {
 		jdbcTemplate.update("""
@@ -124,25 +152,34 @@ class DatapackReleaseChannelCommandServiceTest {
 		assertThat(eventCount("idem-rollback")).isEqualTo(1);
 	}
 
-	@Test
+	@ParameterizedTest(name = "{0} 누락은 요청을 거절한다")
+	@MethodSource("missingAuditAndHashFields")
 	@DisplayName("reason, actor, manifest hash 같은 필수 값이 없으면 요청을 거절한다")
-	void commandRequiresAuditAndHashFields() {
+	void commandRequiresAuditAndHashFields(String expectedFieldName, ReleaseChannelCommand command) {
+		assertThatThrownBy(() -> service.promote(command))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining(expectedFieldName);
+	}
+
+	@Test
+	@DisplayName("manifest hash가 64자 hex가 아니면 요청을 거절한다")
+	void commandRejectsNonHexManifestHash() {
 		var command = new ReleaseChannelCommand(
 			"production",
 			"candidate-stable-3",
 			"candidate-stable-4",
 			SHA_3,
-			"",
+			"z".repeat(64),
 			"data-operator",
 			"release-approver",
 			"ship stable 4",
-			"idem-missing-hash",
+			"idem-non-hex-hash",
 			"https://github.com/AquilaXk/easysubway/actions/runs/1131"
 		);
 
 		assertThatThrownBy(() -> service.promote(command))
 			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("nextManifestSha256");
+			.hasMessageContaining("nextManifestSha256 must be a sha256 hex string");
 	}
 
 	private ReleaseChannelCommand command(
@@ -224,6 +261,31 @@ class DatapackReleaseChannelCommandServiceTest {
 			SELECT COUNT(*) FROM datapack_release_channel_events
 			WHERE channel = 'production' AND idempotency_key = ?
 			""", Integer.class, idempotencyKey);
+	}
+
+	private static Stream<Arguments> missingAuditAndHashFields() {
+		return Stream.of(
+			Arguments.of("requestedBy", commandWithMissing("requestedBy")),
+			Arguments.of("approvedBy", commandWithMissing("approvedBy")),
+			Arguments.of("reason", commandWithMissing("reason")),
+			Arguments.of("previousManifestSha256", commandWithMissing("previousManifestSha256")),
+			Arguments.of("nextManifestSha256", commandWithMissing("nextManifestSha256"))
+		);
+	}
+
+	private static ReleaseChannelCommand commandWithMissing(String fieldName) {
+		return new ReleaseChannelCommand(
+			"production",
+			"candidate-stable-3",
+			"candidate-stable-4",
+			"previousManifestSha256".equals(fieldName) ? "" : SHA_3,
+			"nextManifestSha256".equals(fieldName) ? "" : SHA_4,
+			"requestedBy".equals(fieldName) ? "" : "data-operator",
+			"approvedBy".equals(fieldName) ? "" : "release-approver",
+			"reason".equals(fieldName) ? "" : "ship stable 4",
+			"idem-missing-" + fieldName,
+			"https://github.com/AquilaXk/easysubway/actions/runs/1131"
+		);
 	}
 
 	@TestConfiguration

--- a/backend/src/test/java/com/easysubway/datapack/application/service/DatapackReleaseChannelCommandServiceTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/application/service/DatapackReleaseChannelCommandServiceTest.java
@@ -1,0 +1,237 @@
+package com.easysubway.datapack.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.easysubway.datapack.application.service.DatapackReleaseChannelCommandService.ReleaseChannelCommand;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootTest
+@DisplayName("데이터팩 release channel command service")
+class DatapackReleaseChannelCommandServiceTest {
+
+	private static final String SHA_1 = "1".repeat(64);
+	private static final String SHA_2 = "2".repeat(64);
+	private static final String SHA_3 = "3".repeat(64);
+	private static final String SHA_4 = "4".repeat(64);
+
+	@Autowired
+	private DatapackReleaseChannelCommandService service;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.update("DELETE FROM datapack_release_channel_events");
+		jdbcTemplate.update("DELETE FROM datapack_release_channels");
+		jdbcTemplate.update("DELETE FROM datapack_release_evidence_bundles");
+		jdbcTemplate.update("DELETE FROM datapack_candidate_inputs");
+		jdbcTemplate.update("DELETE FROM datapack_candidates");
+		insertCandidate("candidate-stable-1", "2026.06.27-stable.1", SHA_1, "PROMOTED");
+		insertCandidate("candidate-stable-2", "2026.06.28-stable.2", SHA_2, "PROMOTED");
+		insertCandidate("candidate-stable-3", "2026.06.29-stable.3", SHA_3, "PROMOTED");
+		insertCandidate("candidate-stable-4", "2026.06.30-stable.4", SHA_4, "APPROVED");
+		insertProductionChannel("PASS");
+	}
+
+	@Test
+	@DisplayName("promotion은 channel pointer와 event를 한 transaction으로 기록한다")
+	void promoteUpdatesChannelAndWritesEvent() {
+		var result = service.promote(command("candidate-stable-3", "candidate-stable-4", SHA_3, SHA_4, "idem-promote-1"));
+
+		assertThat(result.idempotentReplay()).isFalse();
+		assertThat(result.operationType()).isEqualTo("PROMOTE");
+		assertThat(result.nextCandidateId()).isEqualTo("candidate-stable-4");
+		assertThat(channelValue("candidate_id")).isEqualTo("candidate-stable-4");
+		assertThat(channelValue("manifest_sha256")).isEqualTo(SHA_4);
+		assertThat(channelValue("previous_stable_candidate_id")).isEqualTo("candidate-stable-3");
+		assertThat(channelValue("previous_manifest_sha256")).isEqualTo(SHA_3);
+		assertThat(channelValue("last_operation_type")).isEqualTo("PROMOTE");
+		assertThat(channelValue("last_operation_status")).isEqualTo("PASS");
+		assertThat(eventCount("idem-promote-1")).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("같은 idempotency key 재요청은 기존 event를 재사용한다")
+	void repeatedIdempotencyKeyDoesNotCreateEventAgain() {
+		var first = service.promote(command("candidate-stable-3", "candidate-stable-4", SHA_3, SHA_4, "idem-replay"));
+		var second = service.promote(command("candidate-stable-3", "candidate-stable-4", SHA_3, SHA_4, "idem-replay"));
+
+		assertThat(first.eventId()).isEqualTo(second.eventId());
+		assertThat(second.idempotentReplay()).isTrue();
+		assertThat(eventCount("idem-replay")).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("같은 idempotency key라도 요청 본문이 다르면 거절한다")
+	void idempotencyKeyRequiresSameRequestPayload() {
+		service.promote(command("candidate-stable-3", "candidate-stable-4", SHA_3, SHA_4, "idem-conflict"));
+
+		assertThatThrownBy(() -> service.rollback(
+			command("candidate-stable-4", "candidate-stable-3", SHA_4, SHA_3, "idem-conflict")))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("idempotency key already belongs to a different release operation");
+		assertThat(eventCount("idem-conflict")).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("진행 중인 channel operation이 있으면 새 요청을 거절한다")
+	void pendingOperationBlocksNewCommand() {
+		jdbcTemplate.update("""
+			UPDATE datapack_release_channels
+			SET last_operation_status = 'PENDING', idempotency_key = 'idem-pending'
+			WHERE channel = 'production'
+			""");
+
+		assertThatThrownBy(() -> service.promote(
+			command("candidate-stable-3", "candidate-stable-4", SHA_3, SHA_4, "idem-new")))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("already has a pending release operation");
+	}
+
+	@Test
+	@DisplayName("rollback은 이전 stable candidate로만 허용된다")
+	void rollbackRejectsCandidateThatIsNotPreviousStable() {
+		assertThatThrownBy(() -> service.rollback(
+			command("candidate-stable-3", "candidate-stable-1", SHA_3, SHA_1, "idem-bad-rollback")))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("previous stable candidate");
+	}
+
+	@Test
+	@DisplayName("rollback은 이전 stable pointer로 되돌리고 현재 stable을 rollback 대상으로 보관한다")
+	void rollbackSwapsCurrentAndPreviousStable() {
+		var result = service.rollback(command("candidate-stable-3", "candidate-stable-2", SHA_3, SHA_2, "idem-rollback"));
+
+		assertThat(result.operationType()).isEqualTo("ROLLBACK");
+		assertThat(result.nextCandidateId()).isEqualTo("candidate-stable-2");
+		assertThat(channelValue("candidate_id")).isEqualTo("candidate-stable-2");
+		assertThat(channelValue("manifest_sha256")).isEqualTo(SHA_2);
+		assertThat(channelValue("previous_stable_candidate_id")).isEqualTo("candidate-stable-3");
+		assertThat(channelValue("previous_manifest_sha256")).isEqualTo(SHA_3);
+		assertThat(channelValue("last_operation_type")).isEqualTo("ROLLBACK");
+		assertThat(eventCount("idem-rollback")).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("reason, actor, manifest hash 같은 필수 값이 없으면 요청을 거절한다")
+	void commandRequiresAuditAndHashFields() {
+		var command = new ReleaseChannelCommand(
+			"production",
+			"candidate-stable-3",
+			"candidate-stable-4",
+			SHA_3,
+			"",
+			"data-operator",
+			"release-approver",
+			"ship stable 4",
+			"idem-missing-hash",
+			"https://github.com/AquilaXk/easysubway/actions/runs/1131"
+		);
+
+		assertThatThrownBy(() -> service.promote(command))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("nextManifestSha256");
+	}
+
+	private ReleaseChannelCommand command(
+		String previousCandidateId,
+		String nextCandidateId,
+		String previousManifestSha256,
+		String nextManifestSha256,
+		String idempotencyKey
+	) {
+		return new ReleaseChannelCommand(
+			"production",
+			previousCandidateId,
+			nextCandidateId,
+			previousManifestSha256,
+			nextManifestSha256,
+			"data-operator",
+			"release-approver",
+			"release request",
+			idempotencyKey,
+			"https://github.com/AquilaXk/easysubway/actions/runs/1131"
+		);
+	}
+
+	private void insertCandidate(String id, String version, String manifestSha256, String approvalStatus) {
+		jdbcTemplate.update("""
+			INSERT INTO datapack_candidates (
+				id, scope_id, artifact_kind, version, source_snapshot_set_hash,
+				override_set_hash, build_spec_sha256, source_inventory_sha256,
+				sqlite_sha256, gzip_sha256, manifest_sha256, coverage_status,
+				validator_status, route_regression_status, android_evidence_status,
+				approval_status, created_at
+			)
+			VALUES (?, 'capital_pilot_android_v1', 'DATAPACK',
+				?, ?, ?, ?, ?, ?, ?, ?, 'PASS', 'PASS', 'PASS',
+				'PASS', ?, '2026-06-29 03:00:00')
+			""",
+			id,
+			version,
+			"a".repeat(64),
+			"b".repeat(64),
+			"c".repeat(64),
+			"d".repeat(64),
+			"e".repeat(64),
+			"f".repeat(64),
+			manifestSha256,
+			approvalStatus
+		);
+	}
+
+	private void insertProductionChannel(String status) {
+		jdbcTemplate.update("""
+			INSERT INTO datapack_release_channels (
+				channel, candidate_id, manifest_url, manifest_sha256,
+				previous_stable_candidate_id, previous_manifest_sha256,
+				rollback_available, last_operation_type, last_operation_status,
+				requested_by, approved_by, reason, idempotency_key, updated_at
+			)
+			VALUES ('production', 'candidate-stable-3',
+				'https://datapack.example.com/production/current.json', ?,
+				'candidate-stable-2', ?, TRUE, 'PROMOTE', ?,
+				'data-operator', 'release-approver', 'approval-1128',
+				'idempotency-production-1128', '2026-06-29 03:10:00')
+			""",
+			SHA_3,
+			SHA_2,
+			status
+		);
+	}
+
+	private String channelValue(String column) {
+		return jdbcTemplate.queryForObject(
+			"SELECT " + column + " FROM datapack_release_channels WHERE channel = 'production'",
+			String.class
+		);
+	}
+
+	private Integer eventCount(String idempotencyKey) {
+		return jdbcTemplate.queryForObject("""
+			SELECT COUNT(*) FROM datapack_release_channel_events
+			WHERE channel = 'production' AND idempotency_key = ?
+			""", Integer.class, idempotencyKey);
+	}
+
+	@TestConfiguration
+	static class ClockConfiguration {
+
+		@Bean
+		Clock datapackReleaseChannelCommandClock() {
+			return Clock.fixed(Instant.parse("2026-06-29T03:30:00Z"), ZoneId.of("Asia/Seoul"));
+		}
+	}
+}


### PR DESCRIPTION
## 관련 이슈

close #1131

## 작업 배경

#1081 데이터팩 운영 콘솔에서 release channel pointer 변경은 앱이 채택할 production/staging 데이터팩을 바꾸는 고위험 작업이다. #1128에서 channel/event ledger와 read-only 화면을 추가했지만, 실제 promotion/rollback 요청의 동시 실행 차단과 idempotency 재요청 처리는 별도 안전장치가 필요했다.

## 작업 내용

- `DatapackReleaseChannelCommandService`를 추가해 promotion/rollback 요청을 transaction으로 처리한다.
- channel row를 `FOR UPDATE`로 잠그고 `PENDING` operation이 있으면 새 요청을 거절한다.
- 같은 idempotency key의 같은 요청은 기존 event를 replay하고, 같은 key의 다른 요청은 거절한다.
- rollback target은 channel에 기록된 previous stable candidate/hash와 일치할 때만 허용한다.
- channel pointer update와 release event insert를 하나의 transaction 안에서 수행한다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests '*DatapackReleaseChannelCommandServiceTest'`: BUILD SUCCESSFUL
  - `./gradlew test --tests '*DatapackReleaseChannel*' --tests '*DatabaseMigrationContainerTest'`: BUILD SUCCESSFUL
  - `/usr/local/bin/node --test tools/ci/repository-contract.test.mjs`: 123 tests passed
  - `./gradlew test`: BUILD SUCCESSFUL
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| release channel command | Backend H2 test | `./gradlew test --tests '*DatapackReleaseChannelCommandServiceTest'` | promotion/rollback, PENDING 차단, idempotency replay/mismatch, rollback target 검증 테스트 통과 | 통과 |
| release channel regression | Backend H2 + migration test | `./gradlew test --tests '*DatapackReleaseChannel*' --tests '*DatabaseMigrationContainerTest'` | 기존 read-only 화면 테스트와 migration container 테스트 통과 | 통과 |
| repository contract | Node test runner | `/usr/local/bin/node --test tools/ci/repository-contract.test.mjs` | 123 tests passed | 통과 |
| backend regression | Backend Gradle | `./gradlew test` | BUILD SUCCESSFUL | 통과 |
| UI evidence | Backend service only | 증거 불필요 사유: 관리자 화면 변경이 아닌 release channel command service 안전장치이며, 동작은 service/integration test로 검증했다. | screenshot 없음 | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `DatapackReleaseChannelCommandService`의 idempotency replay 조건과 rollback target 검증

## 리스크

- 아직 admin command endpoint나 CI/release worker callback API는 연결하지 않았다. 이번 PR은 future caller가 사용할 service 안전장치와 repository transaction 경계까지만 추가한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행 가능 상태라 Codex CLI fallback은 사용하지 않았다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
