### PR TITLE
[Feat] 관리자 데이터팩 release blocker 요약 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
@@ -1,5 +1,7 @@
 package com.easysubway.admin.adapter.in.web;
 
+import com.easysubway.admin.authorization.AdminAuthorization;
+import com.easysubway.admin.authorization.AdminPermission;
 import com.easysubway.collection.application.port.in.DataCollectionUseCase;
 import com.easysubway.collection.domain.DataCollectionRun;
 import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository;
@@ -19,6 +21,7 @@ import com.easysubway.usage.domain.UserActivityDashboardSummary;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -56,7 +59,7 @@ class AdminOverviewPageController {
 	}
 
 	@GetMapping("/admin/dashboard/page")
-	String dashboardPage(Model model) {
+	String dashboardPage(Model model, Authentication authentication) {
 		DataQualitySummary quality = dataQualityUseCase.summarizeDataQuality();
 		Map<FacilityReportStatus, Long> reportCounts = facilityReportUseCase.countReportsByStatus();
 		RouteSearchDashboardSummary routes = routeSearchDashboardUseCase.summarizeRouteSearches();
@@ -77,7 +80,9 @@ class AdminOverviewPageController {
 			health.status(),
 			health.service()
 		));
-		model.addAttribute("datapackReleaseSummary", datapackReleaseBlockerSummaryRepository.summarize());
+		if (AdminAuthorization.hasPermission(authentication, AdminPermission.DATAPACK_READ)) {
+			model.addAttribute("datapackReleaseSummary", datapackReleaseBlockerSummaryRepository.summarize());
+		}
 		return "admin/dashboard";
 	}
 

--- a/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
@@ -2,6 +2,7 @@ package com.easysubway.admin.adapter.in.web;
 
 import com.easysubway.collection.application.port.in.DataCollectionUseCase;
 import com.easysubway.collection.domain.DataCollectionRun;
+import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository;
 import com.easysubway.health.application.port.in.CheckHealthUseCase;
 import com.easysubway.health.domain.HealthComponent;
 import com.easysubway.health.domain.HealthStatus;
@@ -32,6 +33,7 @@ class AdminOverviewPageController {
 	private final UserActivityDashboardUseCase userActivityDashboardUseCase;
 	private final DataCollectionUseCase dataCollectionUseCase;
 	private final CheckHealthUseCase checkHealthUseCase;
+	private final JdbcDatapackReleaseBlockerSummaryRepository datapackReleaseBlockerSummaryRepository;
 
 	AdminOverviewPageController(
 		DataQualityUseCase dataQualityUseCase,
@@ -40,7 +42,8 @@ class AdminOverviewPageController {
 		PushNotificationDashboardUseCase pushNotificationDashboardUseCase,
 		UserActivityDashboardUseCase userActivityDashboardUseCase,
 		DataCollectionUseCase dataCollectionUseCase,
-		CheckHealthUseCase checkHealthUseCase
+		CheckHealthUseCase checkHealthUseCase,
+		JdbcDatapackReleaseBlockerSummaryRepository datapackReleaseBlockerSummaryRepository
 	) {
 		this.dataQualityUseCase = dataQualityUseCase;
 		this.facilityReportUseCase = facilityReportUseCase;
@@ -49,6 +52,7 @@ class AdminOverviewPageController {
 		this.userActivityDashboardUseCase = userActivityDashboardUseCase;
 		this.dataCollectionUseCase = dataCollectionUseCase;
 		this.checkHealthUseCase = checkHealthUseCase;
+		this.datapackReleaseBlockerSummaryRepository = datapackReleaseBlockerSummaryRepository;
 	}
 
 	@GetMapping("/admin/dashboard/page")
@@ -73,6 +77,7 @@ class AdminOverviewPageController {
 			health.status(),
 			health.service()
 		));
+		model.addAttribute("datapackReleaseSummary", datapackReleaseBlockerSummaryRepository.summarize());
 		return "admin/dashboard";
 	}
 

--- a/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
+++ b/backend/src/main/java/com/easysubway/admin/adapter/in/web/AdminOverviewPageController.java
@@ -4,7 +4,7 @@ import com.easysubway.admin.authorization.AdminAuthorization;
 import com.easysubway.admin.authorization.AdminPermission;
 import com.easysubway.collection.application.port.in.DataCollectionUseCase;
 import com.easysubway.collection.domain.DataCollectionRun;
-import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository;
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase;
 import com.easysubway.health.application.port.in.CheckHealthUseCase;
 import com.easysubway.health.domain.HealthComponent;
 import com.easysubway.health.domain.HealthStatus;
@@ -36,7 +36,7 @@ class AdminOverviewPageController {
 	private final UserActivityDashboardUseCase userActivityDashboardUseCase;
 	private final DataCollectionUseCase dataCollectionUseCase;
 	private final CheckHealthUseCase checkHealthUseCase;
-	private final JdbcDatapackReleaseBlockerSummaryRepository datapackReleaseBlockerSummaryRepository;
+	private final DatapackReleaseBlockerSummaryUseCase datapackReleaseBlockerSummaryUseCase;
 
 	AdminOverviewPageController(
 		DataQualityUseCase dataQualityUseCase,
@@ -46,7 +46,7 @@ class AdminOverviewPageController {
 		UserActivityDashboardUseCase userActivityDashboardUseCase,
 		DataCollectionUseCase dataCollectionUseCase,
 		CheckHealthUseCase checkHealthUseCase,
-		JdbcDatapackReleaseBlockerSummaryRepository datapackReleaseBlockerSummaryRepository
+		DatapackReleaseBlockerSummaryUseCase datapackReleaseBlockerSummaryUseCase
 	) {
 		this.dataQualityUseCase = dataQualityUseCase;
 		this.facilityReportUseCase = facilityReportUseCase;
@@ -55,7 +55,7 @@ class AdminOverviewPageController {
 		this.userActivityDashboardUseCase = userActivityDashboardUseCase;
 		this.dataCollectionUseCase = dataCollectionUseCase;
 		this.checkHealthUseCase = checkHealthUseCase;
-		this.datapackReleaseBlockerSummaryRepository = datapackReleaseBlockerSummaryRepository;
+		this.datapackReleaseBlockerSummaryUseCase = datapackReleaseBlockerSummaryUseCase;
 	}
 
 	@GetMapping("/admin/dashboard/page")
@@ -81,7 +81,7 @@ class AdminOverviewPageController {
 			health.service()
 		));
 		if (AdminAuthorization.hasPermission(authentication, AdminPermission.DATAPACK_READ)) {
-			model.addAttribute("datapackReleaseSummary", datapackReleaseBlockerSummaryRepository.summarize());
+			model.addAttribute("datapackReleaseSummary", datapackReleaseBlockerSummaryUseCase.summarize());
 		}
 		return "admin/dashboard";
 	}

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
@@ -73,14 +73,17 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 	public StationReleaseBlockerSummary summarizeStation(String stationId) {
 		long facilityBlockers = countFacilityBlockers(stationId);
 		long routeGateBlockers = countRouteGateBlockers(stationId);
+		long facilityEvidenceRows = countFacilityEvidenceRows(stationId);
+		long routeEvidenceRows = countRouteEvidenceRows(stationId);
 		long totalBlockers = facilityBlockers + routeGateBlockers;
+		boolean hasAnyEvidence = facilityEvidenceRows > 0 || routeEvidenceRows > 0;
 		return new StationReleaseBlockerSummary(
 			stationId,
-			totalBlockers == 0 ? "PASS" : "확인 필요",
+			hasAnyEvidence && totalBlockers == 0 ? "PASS" : "확인 필요",
 			totalBlockers,
 			List.of(
-				new StationReleaseBlockerRow("Facility evidence", facilityBlockers, rowStatus(facilityBlockers)),
-				new StationReleaseBlockerRow("Route gate", routeGateBlockers, rowStatus(routeGateBlockers))
+				new StationReleaseBlockerRow("Facility evidence", facilityBlockers, stationRowStatus(facilityBlockers, facilityEvidenceRows)),
+				new StationReleaseBlockerRow("Route gate", routeGateBlockers, stationRowStatus(routeGateBlockers, routeEvidenceRows))
 			)
 		);
 	}
@@ -190,6 +193,24 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 			""", stationId);
 	}
 
+	private long countFacilityEvidenceRows(String stationId) {
+		Long result = jdbcTemplate.queryForObject("""
+			SELECT COUNT(*)
+			FROM facility_evidence
+			WHERE station_id = ?
+			""", Long.class, stationId);
+		return result == null ? 0L : result;
+	}
+
+	private long countRouteEvidenceRows(String stationId) {
+		Long result = jdbcTemplate.queryForObject("""
+			SELECT COUNT(*)
+			FROM route_edge_evidence
+			WHERE station_id = ?
+			""", Long.class, stationId);
+		return result == null ? 0L : result;
+	}
+
 	private long countWithOptionalStation(String baseSql, String stationId) {
 		if (stationId == null) {
 			return count(baseSql);
@@ -216,6 +237,13 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 
 	private static String rowStatus(long blockerCount) {
 		return blockerCount == 0 ? "PASS" : "확인 필요";
+	}
+
+	private static String stationRowStatus(long blockerCount, long evidenceRows) {
+		if (evidenceRows == 0) {
+			return "집계 전";
+		}
+		return rowStatus(blockerCount);
 	}
 
 	private static String sourceNote(long aliasBlockers, long quarantineBlockers) {

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
@@ -56,6 +56,7 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 			manualOverrideBlockers,
 			facilityBlockers,
 			routeGateBlockers,
+			manifestSignature.blockerCount(),
 			readinessRows(candidate, aliasBlockers, quarantineBlockers, facilityBlockers, routeGateBlockers, manifestSignature),
 			candidate.map(CandidateGateSummary::createdAt).orElse(null)
 		);
@@ -218,6 +219,7 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 		long manualOverrideBlockers,
 		long facilityBlockers,
 		long routeGateBlockers,
+		long manifestBlockers,
 		List<ReleaseReadinessRow> readinessRows,
 		LocalDateTime candidateCreatedAt
 	) {
@@ -227,6 +229,7 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 				"-",
 				"-",
 				"확인 필요",
+				0,
 				0,
 				0,
 				0,

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
@@ -1,5 +1,10 @@
 package com.easysubway.datapack.adapter.out.persistence;
 
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase;
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase.DatapackReleaseBlockerSummary;
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase.ReleaseReadinessRow;
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase.StationReleaseBlockerRow;
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase.StationReleaseBlockerSummary;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
@@ -11,7 +16,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public class JdbcDatapackReleaseBlockerSummaryRepository {
+public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackReleaseBlockerSummaryUseCase {
 
 	private final JdbcTemplate jdbcTemplate;
 
@@ -250,75 +255,6 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 
 	private static String sourceNote(long aliasBlockers, long quarantineBlockers) {
 		return "alias " + aliasBlockers + " / quarantine " + quarantineBlockers;
-	}
-
-	public record DatapackReleaseBlockerSummary(
-		String candidateId,
-		String scopeId,
-		String status,
-		long totalBlockers,
-		long candidateGateBlockers,
-		long aliasBlockers,
-		long quarantineBlockers,
-		long manualOverrideBlockers,
-		long facilityBlockers,
-		long routeGateBlockers,
-		long manifestBlockers,
-		List<ReleaseReadinessRow> readinessRows,
-		LocalDateTime candidateCreatedAt
-	) {
-
-		public static DatapackReleaseBlockerSummary empty() {
-			return new DatapackReleaseBlockerSummary(
-				"-",
-				"-",
-				"확인 필요",
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				0,
-				List.of(
-					new ReleaseReadinessRow("Source coverage", "확인 필요", 0, "candidate 없음"),
-					new ReleaseReadinessRow("Validator", "확인 필요", 0, "candidate 없음"),
-					new ReleaseReadinessRow("Facility evidence", "확인 필요", 0, "candidate 없음"),
-					new ReleaseReadinessRow("Route gate", "확인 필요", 0, "candidate 없음"),
-					new ReleaseReadinessRow("Android evidence", "확인 필요", 0, "candidate 없음"),
-					new ReleaseReadinessRow("Manifest signature", "확인 필요", 0, "candidate 없음"),
-					new ReleaseReadinessRow("Manual override", "확인 필요", 0, "candidate 없음")
-				),
-				null
-			);
-		}
-	}
-
-	public record ReleaseReadinessRow(String label, String status, long blockerCount, String note) {
-	}
-
-	public record StationReleaseBlockerSummary(
-		String stationId,
-		String status,
-		long totalBlockers,
-		List<StationReleaseBlockerRow> rows
-	) {
-
-		public static StationReleaseBlockerSummary empty(String stationId) {
-			return new StationReleaseBlockerSummary(
-				stationId,
-				"확인 필요",
-				0,
-				List.of(
-					new StationReleaseBlockerRow("Facility evidence", 0, "확인 필요"),
-					new StationReleaseBlockerRow("Route gate", 0, "확인 필요")
-				)
-			);
-		}
-	}
-
-	public record StationReleaseBlockerRow(String label, long blockerCount, String status) {
 	}
 
 	private record CandidateGateSummary(

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
@@ -37,12 +37,14 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 		long manualOverrideBlockers = countManualOverrideBlockers();
 		long facilityBlockers = countFacilityBlockers(null);
 		long routeGateBlockers = countRouteGateBlockers(null);
+		ManifestSignatureSummary manifestSignature = manifestSignature(candidate);
 		long totalBlockers = candidateGateBlockers
 			+ aliasBlockers
 			+ quarantineBlockers
 			+ manualOverrideBlockers
 			+ facilityBlockers
-			+ routeGateBlockers;
+			+ routeGateBlockers
+			+ manifestSignature.blockerCount();
 		return new DatapackReleaseBlockerSummary(
 			candidate.map(CandidateGateSummary::candidateId).orElse("-"),
 			candidate.map(CandidateGateSummary::scopeId).orElse("-"),
@@ -54,7 +56,7 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 			manualOverrideBlockers,
 			facilityBlockers,
 			routeGateBlockers,
-			readinessRows(candidate, aliasBlockers, quarantineBlockers, facilityBlockers, routeGateBlockers),
+			readinessRows(candidate, aliasBlockers, quarantineBlockers, facilityBlockers, routeGateBlockers, manifestSignature),
 			candidate.map(CandidateGateSummary::createdAt).orElse(null)
 		);
 	}
@@ -101,7 +103,8 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 		long aliasBlockers,
 		long quarantineBlockers,
 		long facilityBlockers,
-		long routeGateBlockers
+		long routeGateBlockers,
+		ManifestSignatureSummary manifestSignature
 	) {
 		long sourceBlockers = candidate.map(row -> "PASS".equals(row.coverageStatus()) ? 0L : 1L).orElse(1L)
 			+ aliasBlockers
@@ -112,30 +115,24 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 			new ReleaseReadinessRow("Source coverage", statusFor(sourceBlockers), sourceBlockers, sourceNote(aliasBlockers, quarantineBlockers)),
 			new ReleaseReadinessRow("Facility evidence", statusFor(facilityBlockers), facilityBlockers, "strict route eligible facility evidence"),
 			new ReleaseReadinessRow("Route gate", statusFor(routeBlockers), routeBlockers, "ENTRY/EXIT/TRANSFER and generated connector gates"),
-			new ReleaseReadinessRow("Manifest signature", manifestSignatureStatus(candidate), manifestBlockerCount(candidate), "release evidence bundle / signature")
+			new ReleaseReadinessRow("Manifest signature", manifestSignature.status(), manifestSignature.blockerCount(), "release evidence bundle / signature")
 		);
 	}
 
-	private String manifestSignatureStatus(Optional<CandidateGateSummary> candidate) {
+	private ManifestSignatureSummary manifestSignature(Optional<CandidateGateSummary> candidate) {
 		if (candidate.isEmpty()) {
-			return "확인 필요";
+			return new ManifestSignatureSummary("확인 필요", 1);
 		}
-		return jdbcTemplate.query("""
+		String status = jdbcTemplate.query("""
 			SELECT manifest_signature_status
 			FROM datapack_release_evidence_bundles
 			WHERE candidate_id = ?
 			""", (resultSet, rowNumber) -> resultSet.getString("manifest_signature_status"), candidate.get().candidateId())
 			.stream()
 			.findFirst()
-			.map(status -> "PASS".equals(status) ? "PASS" : status)
+			.map(manifestStatus -> "PASS".equals(manifestStatus) ? "PASS" : manifestStatus)
 			.orElse("확인 필요");
-	}
-
-	private long manifestBlockerCount(Optional<CandidateGateSummary> candidate) {
-		if (candidate.isEmpty()) {
-			return 1L;
-		}
-		return "PASS".equals(manifestSignatureStatus(candidate)) ? 0L : 1L;
+		return new ManifestSignatureSummary(status, "PASS".equals(status) ? 0 : 1);
 	}
 
 	private long countManualOverrideBlockers() {
@@ -290,5 +287,8 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 				.filter(status -> !"PASS".equals(status))
 				.count();
 		}
+	}
+
+	private record ManifestSignatureSummary(String status, long blockerCount) {
 	}
 }

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
@@ -57,7 +57,15 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 			facilityBlockers,
 			routeGateBlockers,
 			manifestSignature.blockerCount(),
-			readinessRows(candidate, aliasBlockers, quarantineBlockers, facilityBlockers, routeGateBlockers, manifestSignature),
+			readinessRows(
+				candidate,
+				aliasBlockers,
+				quarantineBlockers,
+				manualOverrideBlockers,
+				facilityBlockers,
+				routeGateBlockers,
+				manifestSignature
+			),
 			candidate.map(CandidateGateSummary::createdAt).orElse(null)
 		);
 	}
@@ -103,6 +111,7 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 		Optional<CandidateGateSummary> candidate,
 		long aliasBlockers,
 		long quarantineBlockers,
+		long manualOverrideBlockers,
 		long facilityBlockers,
 		long routeGateBlockers,
 		ManifestSignatureSummary manifestSignature
@@ -110,13 +119,18 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 		long sourceBlockers = candidate.map(row -> "PASS".equals(row.coverageStatus()) ? 0L : 1L).orElse(1L)
 			+ aliasBlockers
 			+ quarantineBlockers;
+		long validatorBlockers = candidate.map(row -> "PASS".equals(row.validatorStatus()) ? 0L : 1L).orElse(1L);
 		long routeBlockers = candidate.map(row -> "PASS".equals(row.routeRegressionStatus()) ? 0L : 1L).orElse(1L)
 			+ routeGateBlockers;
+		long androidBlockers = candidate.map(row -> "PASS".equals(row.androidEvidenceStatus()) ? 0L : 1L).orElse(1L);
 		return List.of(
 			new ReleaseReadinessRow("Source coverage", statusFor(sourceBlockers), sourceBlockers, sourceNote(aliasBlockers, quarantineBlockers)),
+			new ReleaseReadinessRow("Validator", statusFor(validatorBlockers), validatorBlockers, "SQLite integrity / validator gates"),
 			new ReleaseReadinessRow("Facility evidence", statusFor(facilityBlockers), facilityBlockers, "strict route eligible facility evidence"),
 			new ReleaseReadinessRow("Route gate", statusFor(routeBlockers), routeBlockers, "ENTRY/EXIT/TRANSFER and generated connector gates"),
-			new ReleaseReadinessRow("Manifest signature", manifestSignature.status(), manifestSignature.blockerCount(), "release evidence bundle / signature")
+			new ReleaseReadinessRow("Android evidence", statusFor(androidBlockers), androidBlockers, "Android datapack adoption evidence"),
+			new ReleaseReadinessRow("Manifest signature", manifestSignature.status(), manifestSignature.blockerCount(), "release evidence bundle / signature"),
+			new ReleaseReadinessRow("Manual override", statusFor(manualOverrideBlockers), manualOverrideBlockers, "approval / expiry / conflict gates")
 		);
 	}
 
@@ -239,9 +253,12 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 				0,
 				List.of(
 					new ReleaseReadinessRow("Source coverage", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("Validator", "확인 필요", 0, "candidate 없음"),
 					new ReleaseReadinessRow("Facility evidence", "확인 필요", 0, "candidate 없음"),
 					new ReleaseReadinessRow("Route gate", "확인 필요", 0, "candidate 없음"),
-					new ReleaseReadinessRow("Manifest signature", "확인 필요", 0, "candidate 없음")
+					new ReleaseReadinessRow("Android evidence", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("Manifest signature", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("Manual override", "확인 필요", 0, "candidate 없음")
 				),
 				null
 			);

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
@@ -1,0 +1,294 @@
+package com.easysubway.datapack.adapter.out.persistence;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcDatapackReleaseBlockerSummaryRepository {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	public JdbcDatapackReleaseBlockerSummaryRepository(DataSource dataSource) {
+		this.jdbcTemplate = new JdbcTemplate(dataSource);
+	}
+
+	public DatapackReleaseBlockerSummary summarize() {
+		Optional<CandidateGateSummary> candidate = latestCandidate();
+		long candidateGateBlockers = candidate.map(CandidateGateSummary::blockerCount).orElse(0L);
+		long aliasBlockers = count("""
+			SELECT COUNT(*)
+			FROM external_alias_approvals
+			WHERE approval_status <> 'APPROVED'
+				AND superseded_by IS NULL
+			""");
+		long quarantineBlockers = count("""
+			SELECT COUNT(*)
+			FROM source_quarantine_records
+			WHERE resolution_status = 'OPEN'
+			""");
+		long manualOverrideBlockers = countManualOverrideBlockers();
+		long facilityBlockers = countFacilityBlockers(null);
+		long routeGateBlockers = countRouteGateBlockers(null);
+		long totalBlockers = candidateGateBlockers
+			+ aliasBlockers
+			+ quarantineBlockers
+			+ manualOverrideBlockers
+			+ facilityBlockers
+			+ routeGateBlockers;
+		return new DatapackReleaseBlockerSummary(
+			candidate.map(CandidateGateSummary::candidateId).orElse("-"),
+			candidate.map(CandidateGateSummary::scopeId).orElse("-"),
+			releaseStatus(candidate, totalBlockers),
+			totalBlockers,
+			candidateGateBlockers,
+			aliasBlockers,
+			quarantineBlockers,
+			manualOverrideBlockers,
+			facilityBlockers,
+			routeGateBlockers,
+			readinessRows(candidate, aliasBlockers, quarantineBlockers, facilityBlockers, routeGateBlockers),
+			candidate.map(CandidateGateSummary::createdAt).orElse(null)
+		);
+	}
+
+	public StationReleaseBlockerSummary summarizeStation(String stationId) {
+		long facilityBlockers = countFacilityBlockers(stationId);
+		long routeGateBlockers = countRouteGateBlockers(stationId);
+		long totalBlockers = facilityBlockers + routeGateBlockers;
+		return new StationReleaseBlockerSummary(
+			stationId,
+			totalBlockers == 0 ? "PASS" : "확인 필요",
+			totalBlockers,
+			List.of(
+				new StationReleaseBlockerRow("Facility evidence", facilityBlockers, rowStatus(facilityBlockers)),
+				new StationReleaseBlockerRow("Route gate", routeGateBlockers, rowStatus(routeGateBlockers))
+			)
+		);
+	}
+
+	private Optional<CandidateGateSummary> latestCandidate() {
+		return jdbcTemplate.query("""
+			SELECT id, scope_id, coverage_status, validator_status,
+				route_regression_status, android_evidence_status, created_at
+			FROM datapack_candidates
+			ORDER BY created_at DESC, id ASC
+			LIMIT 1
+			""", this::mapCandidate).stream().findFirst();
+	}
+
+	private CandidateGateSummary mapCandidate(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new CandidateGateSummary(
+			resultSet.getString("id"),
+			resultSet.getString("scope_id"),
+			resultSet.getString("coverage_status"),
+			resultSet.getString("validator_status"),
+			resultSet.getString("route_regression_status"),
+			resultSet.getString("android_evidence_status"),
+			resultSet.getTimestamp("created_at").toLocalDateTime()
+		);
+	}
+
+	private List<ReleaseReadinessRow> readinessRows(
+		Optional<CandidateGateSummary> candidate,
+		long aliasBlockers,
+		long quarantineBlockers,
+		long facilityBlockers,
+		long routeGateBlockers
+	) {
+		long sourceBlockers = candidate.map(row -> "PASS".equals(row.coverageStatus()) ? 0L : 1L).orElse(1L)
+			+ aliasBlockers
+			+ quarantineBlockers;
+		long routeBlockers = candidate.map(row -> "PASS".equals(row.routeRegressionStatus()) ? 0L : 1L).orElse(1L)
+			+ routeGateBlockers;
+		return List.of(
+			new ReleaseReadinessRow("Source coverage", statusFor(sourceBlockers), sourceBlockers, sourceNote(aliasBlockers, quarantineBlockers)),
+			new ReleaseReadinessRow("Facility evidence", statusFor(facilityBlockers), facilityBlockers, "strict route eligible facility evidence"),
+			new ReleaseReadinessRow("Route gate", statusFor(routeBlockers), routeBlockers, "ENTRY/EXIT/TRANSFER and generated connector gates"),
+			new ReleaseReadinessRow("Manifest signature", manifestSignatureStatus(candidate), manifestBlockerCount(candidate), "release evidence bundle / signature")
+		);
+	}
+
+	private String manifestSignatureStatus(Optional<CandidateGateSummary> candidate) {
+		if (candidate.isEmpty()) {
+			return "확인 필요";
+		}
+		return jdbcTemplate.query("""
+			SELECT manifest_signature_status
+			FROM datapack_release_evidence_bundles
+			WHERE candidate_id = ?
+			""", (resultSet, rowNumber) -> resultSet.getString("manifest_signature_status"), candidate.get().candidateId())
+			.stream()
+			.findFirst()
+			.map(status -> "PASS".equals(status) ? "PASS" : status)
+			.orElse("확인 필요");
+	}
+
+	private long manifestBlockerCount(Optional<CandidateGateSummary> candidate) {
+		if (candidate.isEmpty()) {
+			return 1L;
+		}
+		return "PASS".equals(manifestSignatureStatus(candidate)) ? 0L : 1L;
+	}
+
+	private long countManualOverrideBlockers() {
+		return count("""
+			SELECT COUNT(*)
+			FROM manual_overrides
+			WHERE approval_status <> 'APPROVED'
+				OR conflict_status = 'UNRESOLVED'
+				OR superseded_by IS NOT NULL
+				OR approved_by IS NULL
+				OR approved_at IS NULL
+				OR approved_by = requested_by
+				OR (strict_route_eligible = TRUE AND route_safety_approved_by IS NULL)
+			""");
+	}
+
+	private long countFacilityBlockers(String stationId) {
+		return countWithOptionalStation("""
+			SELECT COUNT(*)
+			FROM facility_evidence
+			WHERE (
+				strict_route_eligible = FALSE
+				OR evidence_kind = 'UNKNOWN_PENDING_REVIEW'
+				OR operational_status IN ('UNKNOWN', 'CHECK_REQUIRED')
+				OR conflict_status = 'UNRESOLVED'
+			)
+			""", stationId);
+	}
+
+	private long countRouteGateBlockers(String stationId) {
+		return countWithOptionalStation("""
+			SELECT COUNT(*)
+			FROM route_edge_evidence
+			WHERE (
+				strict_route_eligible = FALSE
+				OR edge_type = 'GENERATED_CONNECTOR'
+				OR provenance_kind IN ('GENERATED', 'UNKNOWN')
+				OR verification_status IN ('UNKNOWN', 'GENERATED', 'STALE', 'MISSING')
+			)
+			""", stationId);
+	}
+
+	private long countWithOptionalStation(String baseSql, String stationId) {
+		if (stationId == null) {
+			return count(baseSql);
+		}
+		Long result = jdbcTemplate.queryForObject(baseSql + " AND station_id = ?", Long.class, stationId);
+		return result == null ? 0L : result;
+	}
+
+	private long count(String sql) {
+		Long result = jdbcTemplate.queryForObject(sql, Long.class);
+		return result == null ? 0L : result;
+	}
+
+	private static String releaseStatus(Optional<CandidateGateSummary> candidate, long totalBlockers) {
+		if (candidate.isEmpty()) {
+			return "확인 필요";
+		}
+		return totalBlockers == 0 ? "READY" : "FAIL";
+	}
+
+	private static String statusFor(long blockerCount) {
+		return blockerCount == 0 ? "PASS" : "FAIL";
+	}
+
+	private static String rowStatus(long blockerCount) {
+		return blockerCount == 0 ? "PASS" : "확인 필요";
+	}
+
+	private static String sourceNote(long aliasBlockers, long quarantineBlockers) {
+		return "alias " + aliasBlockers + " / quarantine " + quarantineBlockers;
+	}
+
+	public record DatapackReleaseBlockerSummary(
+		String candidateId,
+		String scopeId,
+		String status,
+		long totalBlockers,
+		long candidateGateBlockers,
+		long aliasBlockers,
+		long quarantineBlockers,
+		long manualOverrideBlockers,
+		long facilityBlockers,
+		long routeGateBlockers,
+		List<ReleaseReadinessRow> readinessRows,
+		LocalDateTime candidateCreatedAt
+	) {
+
+		public static DatapackReleaseBlockerSummary empty() {
+			return new DatapackReleaseBlockerSummary(
+				"-",
+				"-",
+				"확인 필요",
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				List.of(
+					new ReleaseReadinessRow("Source coverage", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("Facility evidence", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("Route gate", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("Manifest signature", "확인 필요", 0, "candidate 없음")
+				),
+				null
+			);
+		}
+	}
+
+	public record ReleaseReadinessRow(String label, String status, long blockerCount, String note) {
+	}
+
+	public record StationReleaseBlockerSummary(
+		String stationId,
+		String status,
+		long totalBlockers,
+		List<StationReleaseBlockerRow> rows
+	) {
+
+		public static StationReleaseBlockerSummary empty(String stationId) {
+			return new StationReleaseBlockerSummary(
+				stationId,
+				"확인 필요",
+				0,
+				List.of(
+					new StationReleaseBlockerRow("Facility evidence", 0, "확인 필요"),
+					new StationReleaseBlockerRow("Route gate", 0, "확인 필요")
+				)
+			);
+		}
+	}
+
+	public record StationReleaseBlockerRow(String label, long blockerCount, String status) {
+	}
+
+	private record CandidateGateSummary(
+		String candidateId,
+		String scopeId,
+		String coverageStatus,
+		String validatorStatus,
+		String routeRegressionStatus,
+		String androidEvidenceStatus,
+		LocalDateTime createdAt
+	) {
+
+		long blockerCount() {
+			return List.of(coverageStatus, validatorStatus, routeRegressionStatus, androidEvidenceStatus)
+				.stream()
+				.filter(status -> !"PASS".equals(status))
+				.count();
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
@@ -157,13 +157,15 @@ public class JdbcDatapackReleaseBlockerSummaryRepository {
 		return count("""
 			SELECT COUNT(*)
 			FROM manual_overrides
-			WHERE approval_status <> 'APPROVED'
-				OR conflict_status = 'UNRESOLVED'
-				OR superseded_by IS NOT NULL
-				OR approved_by IS NULL
-				OR approved_at IS NULL
-				OR approved_by = requested_by
-				OR (strict_route_eligible = TRUE AND route_safety_approved_by IS NULL)
+			WHERE superseded_by IS NULL
+				AND (
+					approval_status <> 'APPROVED'
+					OR conflict_status = 'UNRESOLVED'
+					OR approved_by IS NULL
+					OR approved_at IS NULL
+					OR approved_by = requested_by
+					OR (strict_route_eligible = TRUE AND route_safety_approved_by IS NULL)
+				)
 			""");
 	}
 

--- a/backend/src/main/java/com/easysubway/datapack/application/port/in/DatapackReleaseBlockerSummaryUseCase.java
+++ b/backend/src/main/java/com/easysubway/datapack/application/port/in/DatapackReleaseBlockerSummaryUseCase.java
@@ -1,0 +1,80 @@
+package com.easysubway.datapack.application.port.in;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface DatapackReleaseBlockerSummaryUseCase {
+
+	DatapackReleaseBlockerSummary summarize();
+
+	StationReleaseBlockerSummary summarizeStation(String stationId);
+
+	record DatapackReleaseBlockerSummary(
+		String candidateId,
+		String scopeId,
+		String status,
+		long totalBlockers,
+		long candidateGateBlockers,
+		long aliasBlockers,
+		long quarantineBlockers,
+		long manualOverrideBlockers,
+		long facilityBlockers,
+		long routeGateBlockers,
+		long manifestBlockers,
+		List<ReleaseReadinessRow> readinessRows,
+		LocalDateTime candidateCreatedAt
+	) {
+
+		public static DatapackReleaseBlockerSummary empty() {
+			return new DatapackReleaseBlockerSummary(
+				"-",
+				"-",
+				"확인 필요",
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				List.of(
+					new ReleaseReadinessRow("Source coverage", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("Validator", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("Facility evidence", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("Route gate", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("Android evidence", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("Manifest signature", "확인 필요", 0, "candidate 없음"),
+					new ReleaseReadinessRow("Manual override", "확인 필요", 0, "candidate 없음")
+				),
+				null
+			);
+		}
+	}
+
+	record ReleaseReadinessRow(String label, String status, long blockerCount, String note) {
+	}
+
+	record StationReleaseBlockerSummary(
+		String stationId,
+		String status,
+		long totalBlockers,
+		List<StationReleaseBlockerRow> rows
+	) {
+
+		public static StationReleaseBlockerSummary empty(String stationId) {
+			return new StationReleaseBlockerSummary(
+				stationId,
+				"확인 필요",
+				0,
+				List.of(
+					new StationReleaseBlockerRow("Facility evidence", 0, "집계 전"),
+					new StationReleaseBlockerRow("Route gate", 0, "집계 전")
+				)
+			);
+		}
+	}
+
+	record StationReleaseBlockerRow(String label, long blockerCount, String status) {
+	}
+}

--- a/backend/src/main/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageController.java
@@ -1,5 +1,7 @@
 package com.easysubway.quality.adapter.in.web;
 
+import com.easysubway.admin.authorization.AdminAuthorization;
+import com.easysubway.admin.authorization.AdminPermission;
 import com.easysubway.common.web.WebMessageResolver;
 import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository;
 import com.easysubway.quality.application.port.in.DataQualityUseCase;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -51,7 +54,7 @@ class DataQualityAdminPageController {
 	}
 
 	@GetMapping("/admin/data-quality/page")
-	String dataQualityDashboardPage(Model model) {
+	String dataQualityDashboardPage(Model model, Authentication authentication) {
 		DataQualitySummary summary = dataQualityUseCase.summarizeDataQuality();
 		List<TransitRegionSummary> regions = transitMasterQueryUseCase.listRegions();
 		Map<FacilityReportStatus, Long> reportStatusCounts = facilityReportUseCase.countReportsByStatus();
@@ -84,7 +87,9 @@ class DataQualityAdminPageController {
 				messages
 			)
 		);
-		model.addAttribute("datapackReleaseSummary", datapackReleaseBlockerSummaryRepository.summarize());
+		if (AdminAuthorization.hasPermission(authentication, AdminPermission.DATAPACK_READ)) {
+			model.addAttribute("datapackReleaseSummary", datapackReleaseBlockerSummaryRepository.summarize());
+		}
 		return "admin/quality/dashboard";
 	}
 

--- a/backend/src/main/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageController.java
@@ -3,7 +3,7 @@ package com.easysubway.quality.adapter.in.web;
 import com.easysubway.admin.authorization.AdminAuthorization;
 import com.easysubway.admin.authorization.AdminPermission;
 import com.easysubway.common.web.WebMessageResolver;
-import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository;
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase;
 import com.easysubway.quality.application.port.in.DataQualityUseCase;
 import com.easysubway.quality.domain.AccessibilityImprovementPriority;
 import com.easysubway.quality.domain.DataQualitySummary;
@@ -37,20 +37,20 @@ class DataQualityAdminPageController {
 	private final TransitMasterQueryUseCase transitMasterQueryUseCase;
 	private final FacilityReportUseCase facilityReportUseCase;
 	private final WebMessageResolver messages;
-	private final JdbcDatapackReleaseBlockerSummaryRepository datapackReleaseBlockerSummaryRepository;
+	private final DatapackReleaseBlockerSummaryUseCase datapackReleaseBlockerSummaryUseCase;
 
 	DataQualityAdminPageController(
 		DataQualityUseCase dataQualityUseCase,
 		TransitMasterQueryUseCase transitMasterQueryUseCase,
 		FacilityReportUseCase facilityReportUseCase,
 		WebMessageResolver messages,
-		JdbcDatapackReleaseBlockerSummaryRepository datapackReleaseBlockerSummaryRepository
+		DatapackReleaseBlockerSummaryUseCase datapackReleaseBlockerSummaryUseCase
 	) {
 		this.dataQualityUseCase = dataQualityUseCase;
 		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
 		this.facilityReportUseCase = facilityReportUseCase;
 		this.messages = messages;
-		this.datapackReleaseBlockerSummaryRepository = datapackReleaseBlockerSummaryRepository;
+		this.datapackReleaseBlockerSummaryUseCase = datapackReleaseBlockerSummaryUseCase;
 	}
 
 	@GetMapping("/admin/data-quality/page")
@@ -88,7 +88,7 @@ class DataQualityAdminPageController {
 			)
 		);
 		if (AdminAuthorization.hasPermission(authentication, AdminPermission.DATAPACK_READ)) {
-			model.addAttribute("datapackReleaseSummary", datapackReleaseBlockerSummaryRepository.summarize());
+			model.addAttribute("datapackReleaseSummary", datapackReleaseBlockerSummaryUseCase.summarize());
 		}
 		return "admin/quality/dashboard";
 	}

--- a/backend/src/main/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageController.java
@@ -1,6 +1,7 @@
 package com.easysubway.quality.adapter.in.web;
 
 import com.easysubway.common.web.WebMessageResolver;
+import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository;
 import com.easysubway.quality.application.port.in.DataQualityUseCase;
 import com.easysubway.quality.domain.AccessibilityImprovementPriority;
 import com.easysubway.quality.domain.DataQualitySummary;
@@ -33,17 +34,20 @@ class DataQualityAdminPageController {
 	private final TransitMasterQueryUseCase transitMasterQueryUseCase;
 	private final FacilityReportUseCase facilityReportUseCase;
 	private final WebMessageResolver messages;
+	private final JdbcDatapackReleaseBlockerSummaryRepository datapackReleaseBlockerSummaryRepository;
 
 	DataQualityAdminPageController(
 		DataQualityUseCase dataQualityUseCase,
 		TransitMasterQueryUseCase transitMasterQueryUseCase,
 		FacilityReportUseCase facilityReportUseCase,
-		WebMessageResolver messages
+		WebMessageResolver messages,
+		JdbcDatapackReleaseBlockerSummaryRepository datapackReleaseBlockerSummaryRepository
 	) {
 		this.dataQualityUseCase = dataQualityUseCase;
 		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
 		this.facilityReportUseCase = facilityReportUseCase;
 		this.messages = messages;
+		this.datapackReleaseBlockerSummaryRepository = datapackReleaseBlockerSummaryRepository;
 	}
 
 	@GetMapping("/admin/data-quality/page")
@@ -80,6 +84,7 @@ class DataQualityAdminPageController {
 				messages
 			)
 		);
+		model.addAttribute("datapackReleaseSummary", datapackReleaseBlockerSummaryRepository.summarize());
 		return "admin/quality/dashboard";
 	}
 

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
@@ -1,5 +1,7 @@
 package com.easysubway.transit.adapter.in.web;
 
+import com.easysubway.admin.authorization.AdminAuthorization;
+import com.easysubway.admin.authorization.AdminPermission;
 import com.easysubway.admin.web.AdminFormErrorView;
 import com.easysubway.common.web.pagination.AdminPageRequest;
 import com.easysubway.common.web.pagination.EgovPaginationView;
@@ -32,9 +34,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -88,7 +91,7 @@ class TransitStationAdminPageController {
 	}
 
 	@GetMapping("/admin/stations/{stationId}/page")
-	String stationDetailPage(@PathVariable String stationId, Model model) {
+	String stationDetailPage(@PathVariable String stationId, Model model, Authentication authentication) {
 		StationWithLines station = transitMasterQueryUseCase.getStation(stationId);
 		model.addAttribute("station", StationDetail.from(station));
 		model.addAttribute("exits", transitMasterQueryUseCase.listStationExits(stationId).stream()
@@ -101,7 +104,9 @@ class TransitStationAdminPageController {
 		model.addAttribute("layoutCount", transitMasterQueryUseCase.listSimplifiedStationLayouts(stationId).size());
 		model.addAttribute("routeNodeCount", transitMasterQueryUseCase.listRouteNodes(stationId).size());
 		model.addAttribute("routeEdgeCount", transitMasterQueryUseCase.listRouteEdges(stationId).size());
-		model.addAttribute("stationReleaseSummary", datapackReleaseBlockerSummaryRepository.summarizeStation(stationId));
+		if (AdminAuthorization.hasPermission(authentication, AdminPermission.DATAPACK_READ)) {
+			model.addAttribute("stationReleaseSummary", datapackReleaseBlockerSummaryRepository.summarizeStation(stationId));
+		}
 		return "admin/stations/detail";
 	}
 

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
@@ -3,6 +3,7 @@ package com.easysubway.transit.adapter.in.web;
 import com.easysubway.admin.web.AdminFormErrorView;
 import com.easysubway.common.web.pagination.AdminPageRequest;
 import com.easysubway.common.web.pagination.EgovPaginationView;
+import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository;
 import com.easysubway.transit.application.port.in.CreateAccessibilityFacilityCommand;
 import com.easysubway.transit.application.port.in.StationMasterDataCounts;
 import com.easysubway.transit.application.port.in.StationSearchCommand;
@@ -47,13 +48,16 @@ class TransitStationAdminPageController {
 
 	private final TransitMasterQueryUseCase transitMasterQueryUseCase;
 	private final TransitMasterAdminUseCase transitMasterAdminUseCase;
+	private final JdbcDatapackReleaseBlockerSummaryRepository datapackReleaseBlockerSummaryRepository;
 
 	TransitStationAdminPageController(
 		TransitMasterQueryUseCase transitMasterQueryUseCase,
-		TransitMasterAdminUseCase transitMasterAdminUseCase
+		TransitMasterAdminUseCase transitMasterAdminUseCase,
+		JdbcDatapackReleaseBlockerSummaryRepository datapackReleaseBlockerSummaryRepository
 	) {
 		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
 		this.transitMasterAdminUseCase = transitMasterAdminUseCase;
+		this.datapackReleaseBlockerSummaryRepository = datapackReleaseBlockerSummaryRepository;
 	}
 
 	@GetMapping("/admin/stations/page")
@@ -97,6 +101,7 @@ class TransitStationAdminPageController {
 		model.addAttribute("layoutCount", transitMasterQueryUseCase.listSimplifiedStationLayouts(stationId).size());
 		model.addAttribute("routeNodeCount", transitMasterQueryUseCase.listRouteNodes(stationId).size());
 		model.addAttribute("routeEdgeCount", transitMasterQueryUseCase.listRouteEdges(stationId).size());
+		model.addAttribute("stationReleaseSummary", datapackReleaseBlockerSummaryRepository.summarizeStation(stationId));
 		return "admin/stations/detail";
 	}
 

--- a/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/transit/adapter/in/web/TransitStationAdminPageController.java
@@ -5,7 +5,7 @@ import com.easysubway.admin.authorization.AdminPermission;
 import com.easysubway.admin.web.AdminFormErrorView;
 import com.easysubway.common.web.pagination.AdminPageRequest;
 import com.easysubway.common.web.pagination.EgovPaginationView;
-import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository;
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase;
 import com.easysubway.transit.application.port.in.CreateAccessibilityFacilityCommand;
 import com.easysubway.transit.application.port.in.StationMasterDataCounts;
 import com.easysubway.transit.application.port.in.StationSearchCommand;
@@ -51,16 +51,16 @@ class TransitStationAdminPageController {
 
 	private final TransitMasterQueryUseCase transitMasterQueryUseCase;
 	private final TransitMasterAdminUseCase transitMasterAdminUseCase;
-	private final JdbcDatapackReleaseBlockerSummaryRepository datapackReleaseBlockerSummaryRepository;
+	private final DatapackReleaseBlockerSummaryUseCase datapackReleaseBlockerSummaryUseCase;
 
 	TransitStationAdminPageController(
 		TransitMasterQueryUseCase transitMasterQueryUseCase,
 		TransitMasterAdminUseCase transitMasterAdminUseCase,
-		JdbcDatapackReleaseBlockerSummaryRepository datapackReleaseBlockerSummaryRepository
+		DatapackReleaseBlockerSummaryUseCase datapackReleaseBlockerSummaryUseCase
 	) {
 		this.transitMasterQueryUseCase = transitMasterQueryUseCase;
 		this.transitMasterAdminUseCase = transitMasterAdminUseCase;
-		this.datapackReleaseBlockerSummaryRepository = datapackReleaseBlockerSummaryRepository;
+		this.datapackReleaseBlockerSummaryUseCase = datapackReleaseBlockerSummaryUseCase;
 	}
 
 	@GetMapping("/admin/stations/page")
@@ -105,7 +105,7 @@ class TransitStationAdminPageController {
 		model.addAttribute("routeNodeCount", transitMasterQueryUseCase.listRouteNodes(stationId).size());
 		model.addAttribute("routeEdgeCount", transitMasterQueryUseCase.listRouteEdges(stationId).size());
 		if (AdminAuthorization.hasPermission(authentication, AdminPermission.DATAPACK_READ)) {
-			model.addAttribute("stationReleaseSummary", datapackReleaseBlockerSummaryRepository.summarizeStation(stationId));
+			model.addAttribute("stationReleaseSummary", datapackReleaseBlockerSummaryUseCase.summarizeStation(stationId));
 		}
 		return "admin/stations/detail";
 	}

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -30,6 +30,35 @@
 		<div class="metric"><span>서비스 상태</span><strong th:text="${dashboard.healthStatus}">UP</strong><em th:text="${dashboard.serviceName}">easysubway</em></div>
 	</div>
 
+	<section class="admin-panel">
+		<h2>데이터팩 출시 준비</h2>
+		<p class="summary">
+			<span th:text="${datapackReleaseSummary.candidateId}">candidate-id</span>
+			<span> · </span>
+			<strong th:text="${datapackReleaseSummary.status}">FAIL</strong>
+			<span> · </span>
+			<span th:text="|전체 blocker ${datapackReleaseSummary.totalBlockers}건|">전체 blocker 0건</span>
+			<span> · </span>
+			<span th:text="|alias ${datapackReleaseSummary.aliasBlockers}|">alias 0</span>
+			<span> · </span>
+			<span th:text="|quarantine ${datapackReleaseSummary.quarantineBlockers}|">quarantine 0</span>
+			<span> · </span>
+			<span th:text="|manual override ${datapackReleaseSummary.manualOverrideBlockers}|">manual override 0</span>
+			<span> · </span>
+			<span th:text="|route gate ${datapackReleaseSummary.routeGateBlockers}|">route gate 0</span>
+		</p>
+		<table>
+			<tbody>
+			<tr><th scope="row">candidate gate</th><td th:text="${datapackReleaseSummary.candidateGateBlockers}">0</td></tr>
+			<tr><th scope="row">alias</th><td th:text="${datapackReleaseSummary.aliasBlockers}">0</td></tr>
+			<tr><th scope="row">quarantine</th><td th:text="${datapackReleaseSummary.quarantineBlockers}">0</td></tr>
+			<tr><th scope="row">manual override</th><td th:text="${datapackReleaseSummary.manualOverrideBlockers}">0</td></tr>
+			<tr><th scope="row">facility evidence</th><td th:text="${datapackReleaseSummary.facilityBlockers}">0</td></tr>
+			<tr><th scope="row">route gate</th><td th:text="${datapackReleaseSummary.routeGateBlockers}">0</td></tr>
+			</tbody>
+		</table>
+	</section>
+
 	<div class="admin-grid-2">
 		<section class="admin-panel" th:if="${adminProgramIds.contains('a-reports')}">
 			<h2>먼저 확인할 제보</h2>

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -30,7 +30,7 @@
 		<div class="metric"><span>서비스 상태</span><strong th:text="${dashboard.healthStatus}">UP</strong><em th:text="${dashboard.serviceName}">easysubway</em></div>
 	</div>
 
-	<section class="admin-panel">
+	<section class="admin-panel" th:if="${datapackReleaseSummary != null}">
 		<h2>데이터팩 출시 준비</h2>
 		<p class="summary">
 			<span th:text="${datapackReleaseSummary.candidateId}">candidate-id</span>
@@ -55,6 +55,7 @@
 			<tr><th scope="row">manual override</th><td th:text="${datapackReleaseSummary.manualOverrideBlockers}">0</td></tr>
 			<tr><th scope="row">facility evidence</th><td th:text="${datapackReleaseSummary.facilityBlockers}">0</td></tr>
 			<tr><th scope="row">route gate</th><td th:text="${datapackReleaseSummary.routeGateBlockers}">0</td></tr>
+			<tr><th scope="row">manifest signature</th><td th:text="${datapackReleaseSummary.manifestBlockers}">0</td></tr>
 			</tbody>
 		</table>
 	</section>

--- a/backend/src/main/resources/templates/admin/quality/dashboard.html
+++ b/backend/src/main/resources/templates/admin/quality/dashboard.html
@@ -149,7 +149,7 @@
 		</div>
 	</div>
 
-	<section>
+	<section th:if="${datapackReleaseSummary != null}">
 		<h2>데이터팩 Release readiness</h2>
 		<table>
 			<thead>

--- a/backend/src/main/resources/templates/admin/quality/dashboard.html
+++ b/backend/src/main/resources/templates/admin/quality/dashboard.html
@@ -150,6 +150,28 @@
 	</div>
 
 	<section>
+		<h2>데이터팩 Release readiness</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">항목</th>
+				<th scope="col">상태</th>
+				<th scope="col">blocker</th>
+				<th scope="col">근거</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${datapackReleaseSummary.readinessRows}">
+				<td th:text="${row.label}">Source coverage</td>
+				<td th:text="${row.status}">FAIL</td>
+				<td th:text="${row.blockerCount}">0</td>
+				<td th:text="${row.note}">확인 필요</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
 		<h2>역 품질 등급</h2>
 		<table>
 			<thead>

--- a/backend/src/main/resources/templates/admin/stations/detail.html
+++ b/backend/src/main/resources/templates/admin/stations/detail.html
@@ -60,6 +60,31 @@
 	</div>
 
 	<section>
+		<h2>Release readiness</h2>
+		<p class="summary">
+			<span th:text="|${station.stationName}역 release blocker|">상록수역 release blocker</span>
+			<span> · </span>
+			<strong th:text="|${stationReleaseSummary.status} ${stationReleaseSummary.totalBlockers}건|">확인 필요 0건</strong>
+		</p>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">항목</th>
+				<th scope="col">상태</th>
+				<th scope="col">blocker</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${stationReleaseSummary.rows}">
+				<td th:text="${row.label}">Facility evidence</td>
+				<td th:text="${row.status}">확인 필요</td>
+				<td th:text="${row.blockerCount}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
 		<h2>출구</h2>
 		<table>
 			<thead>

--- a/backend/src/main/resources/templates/admin/stations/detail.html
+++ b/backend/src/main/resources/templates/admin/stations/detail.html
@@ -59,7 +59,7 @@
 		</section>
 	</div>
 
-	<section>
+	<section th:if="${stationReleaseSummary != null}">
 		<h2>Release readiness</h2>
 		<p class="summary">
 			<span th:text="|${station.stationName}역 release blocker|">상록수역 release blocker</span>

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
@@ -102,6 +102,20 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 	}
 
 	@Test
+	@DisplayName("대체된 manual override 이력은 release blocker로 집계하지 않는다")
+	void supersededManualOverrideHistoryIsNotReleaseBlocker() throws Exception {
+		insertSupersededManualOverrideHistory();
+
+		String html = getAdminHtml("/admin/dashboard/page");
+
+		assertThat(html)
+			.contains("전체 blocker 9건")
+			.contains("manual override 1")
+			.doesNotContain("전체 blocker 10건")
+			.doesNotContain("manual override 2");
+	}
+
+	@Test
 	@DisplayName("데이터 품질 화면은 release readiness matrix를 보여준다")
 	void qualityDashboardShowsReleaseReadinessMatrix() throws Exception {
 		String html = getAdminHtml("/admin/data-quality/page");
@@ -236,6 +250,37 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 				'PENDING', 'NONE', FALSE, '2026-06-29 03:33:00',
 				'2026-07-06 03:33:00', '2026-06-29 03:33:00')
 			""", SHA_F);
+	}
+
+	private void insertSupersededManualOverrideHistory() {
+		jdbcTemplate.update("""
+			INSERT INTO manual_overrides (
+				id, entity_type, entity_id, field_name, before_value, after_value,
+				reason_code, reason, evidence_uri, evidence_hash, requested_by,
+				approved_by, approved_at, approval_status, conflict_status,
+				strict_route_eligible, effective_from, expires_at, created_at
+			)
+			VALUES ('override-replacement', 'FACILITY', 'facility-superseded',
+				'operational_status', 'UNKNOWN', 'AVAILABLE', 'FIELD_CHECK',
+				'대체 override 승인', 's3://evidence/replacement', ?, 'data-operator',
+				'release-approver', '2026-06-29 03:40:00', 'APPROVED', 'NONE',
+				FALSE, '2026-06-29 03:40:00', '2026-07-06 03:40:00',
+				'2026-06-29 03:40:00')
+			""", SHA_A);
+		jdbcTemplate.update("""
+			INSERT INTO manual_overrides (
+				id, entity_type, entity_id, field_name, before_value, after_value,
+				reason_code, reason, evidence_uri, evidence_hash, requested_by,
+				approval_status, conflict_status, strict_route_eligible,
+				effective_from, expires_at, superseded_by, created_at
+			)
+			VALUES ('override-superseded-history', 'FACILITY', 'facility-superseded',
+				'operational_status', 'UNKNOWN', 'AVAILABLE', 'FIELD_CHECK',
+				'대체된 override 이력', 's3://evidence/superseded', ?, 'data-operator',
+				'SUPERSEDED', 'UNRESOLVED', TRUE, '2026-06-29 03:39:00',
+				'2026-07-06 03:39:00', 'override-replacement',
+				'2026-06-29 03:39:00')
+			""", SHA_B);
 	}
 
 	private void insertEvidenceBlockers() {

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
@@ -38,18 +38,7 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 
 	@BeforeEach
 	void setUp() {
-		jdbcTemplate.update("DELETE FROM datapack_release_channel_events");
-		jdbcTemplate.update("DELETE FROM datapack_release_channels");
-		jdbcTemplate.update("DELETE FROM datapack_release_evidence_bundles");
-		jdbcTemplate.update("DELETE FROM datapack_candidate_inputs");
-		jdbcTemplate.update("DELETE FROM datapack_candidates");
-		jdbcTemplate.update("DELETE FROM route_edge_evidence");
-		jdbcTemplate.update("DELETE FROM facility_evidence");
-		jdbcTemplate.update("DELETE FROM manual_overrides");
-		jdbcTemplate.update("DELETE FROM source_quarantine_resolutions");
-		jdbcTemplate.update("DELETE FROM source_quarantine_records");
-		jdbcTemplate.update("DELETE FROM external_alias_approvals");
-		jdbcTemplate.update("DELETE FROM data_source_snapshots");
+		clearDatapackTables();
 		insertSourceSnapshot();
 		insertCandidate();
 		insertAliasQuarantineOverride();
@@ -83,6 +72,33 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 			.doesNotContain("데이터팩 출시 준비")
 			.doesNotContain("candidate-release-blocked")
 			.doesNotContain("전체 blocker 9건");
+	}
+
+	@Test
+	@DisplayName("데이터팩 근거가 없으면 release readiness는 집계 전 상태를 보여준다")
+	void releaseReadinessFallsBackWhenDatapackEvidenceIsEmpty() throws Exception {
+		clearDatapackTables();
+
+		String dashboardHtml = getAdminHtml("/admin/dashboard/page");
+		String qualityHtml = getAdminHtml("/admin/data-quality/page");
+		String stationHtml = getAdminHtml("/admin/stations/station-sangnoksu/page");
+
+		assertThat(dashboardHtml)
+			.contains("데이터팩 출시 준비")
+			.contains("확인 필요")
+			.contains("전체 blocker 1건")
+			.doesNotContain("FAIL")
+			.doesNotContain("PASS");
+		assertThat(qualityHtml)
+			.contains("데이터팩 Release readiness")
+			.contains("Source coverage")
+			.contains("확인 필요");
+		assertThat(stationHtml)
+			.contains("Release readiness")
+			.contains("상록수역 release blocker")
+			.contains("확인 필요 0건")
+			.contains("집계 전")
+			.doesNotContain("PASS 0건");
 	}
 
 	@Test
@@ -135,6 +151,21 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 			.andReturn()
 			.getResponse()
 			.getContentAsString();
+	}
+
+	private void clearDatapackTables() {
+		jdbcTemplate.update("DELETE FROM datapack_release_channel_events");
+		jdbcTemplate.update("DELETE FROM datapack_release_channels");
+		jdbcTemplate.update("DELETE FROM datapack_release_evidence_bundles");
+		jdbcTemplate.update("DELETE FROM datapack_candidate_inputs");
+		jdbcTemplate.update("DELETE FROM datapack_candidates");
+		jdbcTemplate.update("DELETE FROM route_edge_evidence");
+		jdbcTemplate.update("DELETE FROM facility_evidence");
+		jdbcTemplate.update("DELETE FROM manual_overrides");
+		jdbcTemplate.update("DELETE FROM source_quarantine_resolutions");
+		jdbcTemplate.update("DELETE FROM source_quarantine_records");
+		jdbcTemplate.update("DELETE FROM external_alias_approvals");
+		jdbcTemplate.update("DELETE FROM data_source_snapshots");
 	}
 
 	private void insertSourceSnapshot() {

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
@@ -1,0 +1,212 @@
+package com.easysubway.datapack.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("관리자 데이터팩 release blocker 요약")
+class DatapackReleaseBlockerSummaryAdminPageTest {
+
+	private static final String SHA_A = "a".repeat(64);
+	private static final String SHA_B = "b".repeat(64);
+	private static final String SHA_C = "c".repeat(64);
+	private static final String SHA_D = "d".repeat(64);
+	private static final String SHA_E = "e".repeat(64);
+	private static final String SHA_F = "f".repeat(64);
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.update("DELETE FROM datapack_release_channel_events");
+		jdbcTemplate.update("DELETE FROM datapack_release_channels");
+		jdbcTemplate.update("DELETE FROM datapack_release_evidence_bundles");
+		jdbcTemplate.update("DELETE FROM datapack_candidate_inputs");
+		jdbcTemplate.update("DELETE FROM datapack_candidates");
+		jdbcTemplate.update("DELETE FROM route_edge_evidence");
+		jdbcTemplate.update("DELETE FROM facility_evidence");
+		jdbcTemplate.update("DELETE FROM manual_overrides");
+		jdbcTemplate.update("DELETE FROM source_quarantine_resolutions");
+		jdbcTemplate.update("DELETE FROM source_quarantine_records");
+		jdbcTemplate.update("DELETE FROM external_alias_approvals");
+		jdbcTemplate.update("DELETE FROM data_source_snapshots");
+		insertSourceSnapshot();
+		insertCandidate();
+		insertAliasQuarantineOverride();
+		insertEvidenceBlockers();
+	}
+
+	@Test
+	@DisplayName("통합 대시보드는 데이터팩 release blocker 요약을 보여준다")
+	void dashboardShowsDatapackReleaseBlockerSummary() throws Exception {
+		String html = getAdminHtml("/admin/dashboard/page");
+
+		assertThat(html)
+			.contains("데이터팩 출시 준비")
+			.contains("FAIL")
+			.contains("candidate-release-blocked")
+			.contains("전체 blocker 8건")
+			.contains("alias 1")
+			.contains("quarantine 1")
+			.contains("manual override 1")
+			.contains("route gate 1")
+			.doesNotContain("name=\"commandToken\"");
+	}
+
+	@Test
+	@DisplayName("데이터 품질 화면은 release readiness matrix를 보여준다")
+	void qualityDashboardShowsReleaseReadinessMatrix() throws Exception {
+		String html = getAdminHtml("/admin/data-quality/page");
+
+		assertThat(html)
+			.contains("데이터팩 Release readiness")
+			.contains("Source coverage")
+			.contains("Facility evidence")
+			.contains("Route gate")
+			.contains("Manifest signature")
+			.contains("FAIL")
+			.contains("확인 필요");
+	}
+
+	@Test
+	@DisplayName("역 상세 화면은 역 단위 release readiness를 보여준다")
+	void stationDetailShowsStationReleaseReadiness() throws Exception {
+		String html = getAdminHtml("/admin/stations/station-sangnoksu/page");
+
+		assertThat(html)
+			.contains("Release readiness")
+			.contains("상록수역 release blocker")
+			.contains("Facility evidence")
+			.contains("Route gate")
+			.contains("확인 필요 2건");
+	}
+
+	private String getAdminHtml(String path) throws Exception {
+		return mockMvc.perform(get(path)
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view"))))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+	}
+
+	private void insertSourceSnapshot() {
+		jdbcTemplate.update("""
+			INSERT INTO data_source_snapshots (
+				snapshot_id, source_id, provider, retrieved_at, source_updated_at,
+				row_count, raw_sha256, raw_object_uri, redacted_request_fingerprint,
+				schema_fingerprint, snapshot_status, schema_status, license_status,
+				fetch_status, redistribution_allowed, credential_redacted,
+				freshness_expires_at, raw_retention_expires_at
+			)
+			VALUES (
+				'snapshot-release-blocked', 'kric-station-elevator', 'KRIC',
+				'2026-06-29 03:00:00', '2026-06-28 03:00:00', 10, ?, 's3://raw/snapshot',
+				?, ?, 'LOCKED', 'PASS', 'PASS', 'SUCCESS', TRUE, TRUE,
+				'2026-07-06 03:00:00', '2026-09-29 03:00:00'
+			)
+			""", SHA_A, SHA_B, SHA_C);
+	}
+
+	private void insertCandidate() {
+		jdbcTemplate.update("""
+			INSERT INTO datapack_candidates (
+				id, scope_id, artifact_kind, version, source_snapshot_set_hash,
+				override_set_hash, build_spec_sha256, source_inventory_sha256,
+				sqlite_sha256, gzip_sha256, manifest_sha256, coverage_status,
+				validator_status, route_regression_status, android_evidence_status,
+				approval_status, created_at
+			)
+			VALUES ('candidate-release-blocked', 'capital_pilot_android_v1', 'DATAPACK',
+				'2026.06.30-cand.blocked', ?, ?, ?, ?, ?, ?, ?,
+				'FAIL', 'PASS', 'FAIL', 'PENDING', 'READY_FOR_APPROVAL',
+				'2026-06-29 03:30:00')
+			""", SHA_A, SHA_B, SHA_C, SHA_D, SHA_E, SHA_F, "1".repeat(64));
+	}
+
+	private void insertAliasQuarantineOverride() {
+		jdbcTemplate.update("""
+			INSERT INTO external_alias_approvals (
+				id, source_id, source_snapshot_id, provider_entity_type,
+				provider_entity_id, canonical_entity_type, canonical_entity_id,
+				confidence, match_method, approval_status, requested_by,
+				evidence_hash, created_at
+			)
+			VALUES ('alias-pending', 'kric-station-elevator', 'snapshot-release-blocked',
+				'STATION', 'provider-station', 'STATION', 'station-sangnoksu',
+				73, 'AUTO', 'PENDING', 'data-operator', ?, '2026-06-29 03:31:00')
+			""", SHA_D);
+		jdbcTemplate.update("""
+			INSERT INTO source_quarantine_records (
+				id, source_id, source_snapshot_id, provider_record_hash, reason_code,
+				severity, redacted_excerpt, resolution_status, created_at
+			)
+			VALUES ('quarantine-open', 'kric-station-elevator', 'snapshot-release-blocked',
+				?, 'MISSING_FIELD', 'HIGH', 'station redacted', 'OPEN',
+				'2026-06-29 03:32:00')
+			""", SHA_E);
+		jdbcTemplate.update("""
+			INSERT INTO manual_overrides (
+				id, entity_type, entity_id, field_name, before_value, after_value,
+				reason_code, reason, evidence_uri, evidence_hash, requested_by,
+				approval_status, conflict_status, strict_route_eligible,
+				effective_from, expires_at, created_at
+			)
+			VALUES ('override-pending', 'FACILITY', 'facility-sangnoksu-elevator-1',
+				'operational_status', 'UNKNOWN', 'AVAILABLE', 'FIELD_CHECK',
+				'현장 확인 필요', 's3://evidence/override', ?, 'data-operator',
+				'PENDING', 'NONE', FALSE, '2026-06-29 03:33:00',
+				'2026-07-06 03:33:00', '2026-06-29 03:33:00')
+			""", SHA_F);
+	}
+
+	private void insertEvidenceBlockers() {
+		jdbcTemplate.update("""
+			INSERT INTO facility_evidence (
+				id, station_id, line_id, facility_type, evidence_kind, source_id,
+				source_snapshot_id, provider_record_hash, status_meaning,
+				installation_status, operational_status, verified_at, retrieved_at,
+				freshness_expires_at, confidence, strict_route_eligible,
+				strict_route_eligible_reason, conflict_status, created_at
+			)
+			VALUES ('facility-blocker', 'station-sangnoksu', 'line-4',
+				'WHEELCHAIR_LIFT', 'UNKNOWN_PENDING_REVIEW', 'kric-station-elevator',
+				'snapshot-release-blocked', ?, 'STATIC_LOCATION', 'UNKNOWN',
+				'UNKNOWN', '2026-06-29 03:34:00', '2026-06-29 03:34:00',
+				'2026-07-06 03:34:00', 40, FALSE, 'UNKNOWN_PENDING_REVIEW',
+				'NONE', '2026-06-29 03:34:00')
+			""", SHA_A);
+		jdbcTemplate.update("""
+			INSERT INTO route_edge_evidence (
+				id, station_id, line_id, edge_id, edge_type, source_id,
+				source_snapshot_id, provenance_kind, verification_status,
+				last_verified_at, evidence_hash, strict_route_eligible,
+				blocker_reason, created_at
+			)
+			VALUES ('route-blocker', 'station-sangnoksu', 'line-4', 'edge-generated',
+				'GENERATED_CONNECTOR', 'kric-station-elevator', 'snapshot-release-blocked',
+				'GENERATED', 'GENERATED', '2026-06-29 03:35:00', ?, FALSE,
+				'GENERATED_CONNECTOR', '2026-06-29 03:35:00')
+			""", SHA_B);
+	}
+}

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
@@ -70,7 +70,19 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 			.contains("quarantine 1")
 			.contains("manual override 1")
 			.contains("route gate 1")
+			.contains("manifest signature")
 			.doesNotContain("name=\"commandToken\"");
+	}
+
+	@Test
+	@DisplayName("datapack read 권한이 없으면 통합 대시보드 release blocker 요약을 숨긴다")
+	void dashboardHidesDatapackReleaseBlockerSummaryWithoutDatapackRead() throws Exception {
+		String html = getAdminHtmlWithoutDatapackRead("/admin/dashboard/page");
+
+		assertThat(html)
+			.doesNotContain("데이터팩 출시 준비")
+			.doesNotContain("candidate-release-blocked")
+			.doesNotContain("전체 blocker 9건");
 	}
 
 	@Test
@@ -102,6 +114,18 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 	}
 
 	private String getAdminHtml(String path) throws Exception {
+		return mockMvc.perform(get(path)
+				.with(user("viewer").authorities(
+					new SimpleGrantedAuthority("admin.view"),
+					new SimpleGrantedAuthority("admin.datapack.read")
+				)))
+			.andExpect(status().isOk())
+			.andReturn()
+			.getResponse()
+			.getContentAsString();
+	}
+
+	private String getAdminHtmlWithoutDatapackRead(String path) throws Exception {
 		return mockMvc.perform(get(path)
 				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view"))))
 			.andExpect(status().isOk())

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
@@ -93,9 +93,12 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 		assertThat(html)
 			.contains("데이터팩 Release readiness")
 			.contains("Source coverage")
+			.contains("Validator")
 			.contains("Facility evidence")
 			.contains("Route gate")
+			.contains("Android evidence")
 			.contains("Manifest signature")
+			.contains("Manual override")
 			.contains("FAIL")
 			.contains("확인 필요");
 	}

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
@@ -65,7 +65,7 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 			.contains("데이터팩 출시 준비")
 			.contains("FAIL")
 			.contains("candidate-release-blocked")
-			.contains("전체 blocker 8건")
+			.contains("전체 blocker 9건")
 			.contains("alias 1")
 			.contains("quarantine 1")
 			.contains("manual override 1")

--- a/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageControllerTest.java
@@ -42,6 +42,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
@@ -163,7 +164,10 @@ class DataQualityAdminPageControllerTest {
 			.thenReturn(List.of(facility("facility-sangnoksu-elevator-1", "1번 출구 엘리베이터")));
 
 		ExtendedModelMap model = new ExtendedModelMap();
-		String viewName = controller.dataQualityDashboardPage(model);
+		String viewName = controller.dataQualityDashboardPage(
+			model,
+			new TestingAuthenticationToken("viewer", "n/a", "admin.datapack.read")
+		);
 
 		assertThat(viewName).isEqualTo("admin/quality/dashboard");
 		DataQualityAdminPageController.DataQualityDashboardView view =

--- a/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageControllerTest.java
@@ -10,8 +10,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.easysubway.common.web.WebMessageResolver;
-import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository;
-import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository.DatapackReleaseBlockerSummary;
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase;
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase.DatapackReleaseBlockerSummary;
 import com.easysubway.quality.application.port.in.DataQualityUseCase;
 import com.easysubway.quality.domain.DataQualitySummary;
 import com.easysubway.report.application.port.in.FacilityReportUseCase;
@@ -140,19 +140,19 @@ class DataQualityAdminPageControllerTest {
 		DataQualityUseCase dataQualityUseCase = mock(DataQualityUseCase.class);
 		TransitMasterQueryUseCase transitMasterQueryUseCase = mock(TransitMasterQueryUseCase.class);
 		FacilityReportUseCase facilityReportUseCase = mock(FacilityReportUseCase.class);
-		JdbcDatapackReleaseBlockerSummaryRepository releaseSummaryRepository =
-			mock(JdbcDatapackReleaseBlockerSummaryRepository.class);
+		DatapackReleaseBlockerSummaryUseCase releaseSummaryUseCase =
+			mock(DatapackReleaseBlockerSummaryUseCase.class);
 		DataQualityAdminPageController controller = new DataQualityAdminPageController(
 			dataQualityUseCase,
 			transitMasterQueryUseCase,
 			facilityReportUseCase,
 			WebMessageResolver.defaultMessages(),
-			releaseSummaryRepository
+			releaseSummaryUseCase
 		);
 		when(dataQualityUseCase.summarizeDataQuality()).thenReturn(emptySummary());
 		when(transitMasterQueryUseCase.listRegions()).thenReturn(List.of());
 		when(facilityReportUseCase.countReportsByStatus()).thenReturn(Map.of());
-		when(releaseSummaryRepository.summarize()).thenReturn(DatapackReleaseBlockerSummary.empty());
+		when(releaseSummaryUseCase.summarize()).thenReturn(DatapackReleaseBlockerSummary.empty());
 		when(facilityReportUseCase.listRepeatedBrokenReportFacilities()).thenReturn(List.of(
 			new RepeatedBrokenFacilityReportSummary("station-sangnoksu", "facility-removed", 2),
 			new RepeatedBrokenFacilityReportSummary("station-removed", "facility-old", 3),

--- a/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/quality/adapter/in/web/DataQualityAdminPageControllerTest.java
@@ -10,6 +10,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.easysubway.common.web.WebMessageResolver;
+import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository;
+import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository.DatapackReleaseBlockerSummary;
 import com.easysubway.quality.application.port.in.DataQualityUseCase;
 import com.easysubway.quality.domain.DataQualitySummary;
 import com.easysubway.report.application.port.in.FacilityReportUseCase;
@@ -137,15 +139,19 @@ class DataQualityAdminPageControllerTest {
 		DataQualityUseCase dataQualityUseCase = mock(DataQualityUseCase.class);
 		TransitMasterQueryUseCase transitMasterQueryUseCase = mock(TransitMasterQueryUseCase.class);
 		FacilityReportUseCase facilityReportUseCase = mock(FacilityReportUseCase.class);
+		JdbcDatapackReleaseBlockerSummaryRepository releaseSummaryRepository =
+			mock(JdbcDatapackReleaseBlockerSummaryRepository.class);
 		DataQualityAdminPageController controller = new DataQualityAdminPageController(
 			dataQualityUseCase,
 			transitMasterQueryUseCase,
 			facilityReportUseCase,
-			WebMessageResolver.defaultMessages()
+			WebMessageResolver.defaultMessages(),
+			releaseSummaryRepository
 		);
 		when(dataQualityUseCase.summarizeDataQuality()).thenReturn(emptySummary());
 		when(transitMasterQueryUseCase.listRegions()).thenReturn(List.of());
 		when(facilityReportUseCase.countReportsByStatus()).thenReturn(Map.of());
+		when(releaseSummaryRepository.summarize()).thenReturn(DatapackReleaseBlockerSummary.empty());
 		when(facilityReportUseCase.listRepeatedBrokenReportFacilities()).thenReturn(List.of(
 			new RepeatedBrokenFacilityReportSummary("station-sangnoksu", "facility-removed", 2),
 			new RepeatedBrokenFacilityReportSummary("station-removed", "facility-old", 3),

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
@@ -3,7 +3,7 @@ package com.easysubway.transit.adapter.in.web;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository;
+import com.easysubway.datapack.application.port.in.DatapackReleaseBlockerSummaryUseCase;
 import com.easysubway.transit.adapter.out.persistence.UnavailableTransitMasterRepository;
 import com.easysubway.transit.application.service.TransitMasterService;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
@@ -80,7 +80,7 @@ class TransitReadOnlyAdminPageModelTest {
 		var controller = new TransitStationAdminPageController(
 			transitMasterService,
 			transitMasterService,
-			mock(JdbcDatapackReleaseBlockerSummaryRepository.class)
+			mock(DatapackReleaseBlockerSummaryUseCase.class)
 		);
 		var model = new ExtendedModelMap();
 
@@ -96,7 +96,7 @@ class TransitReadOnlyAdminPageModelTest {
 		var controller = new TransitStationAdminPageController(
 			transitMasterService,
 			transitMasterService,
-			mock(JdbcDatapackReleaseBlockerSummaryRepository.class)
+			mock(DatapackReleaseBlockerSummaryUseCase.class)
 		);
 		var redirectAttributes = new RedirectAttributesModelMap();
 

--- a/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
+++ b/backend/src/test/java/com/easysubway/transit/adapter/in/web/TransitReadOnlyAdminPageModelTest.java
@@ -1,7 +1,9 @@
 package com.easysubway.transit.adapter.in.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
+import com.easysubway.datapack.adapter.out.persistence.JdbcDatapackReleaseBlockerSummaryRepository;
 import com.easysubway.transit.adapter.out.persistence.UnavailableTransitMasterRepository;
 import com.easysubway.transit.application.service.TransitMasterService;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
@@ -75,7 +77,11 @@ class TransitReadOnlyAdminPageModelTest {
 	@Test
 	@DisplayName("시설 등록·수정 화면은 저장 버튼 비활성화 기준을 전달한다")
 	void facilityEditorPageExposesReadOnlyMasterDataFlag() {
-		var controller = new TransitStationAdminPageController(transitMasterService, transitMasterService);
+		var controller = new TransitStationAdminPageController(
+			transitMasterService,
+			transitMasterService,
+			mock(JdbcDatapackReleaseBlockerSummaryRepository.class)
+		);
 		var model = new ExtendedModelMap();
 
 		String viewName = controller.facilityEditorPage("station-sangnoksu", "facility-sangnoksu-elevator-1", model);
@@ -87,7 +93,11 @@ class TransitReadOnlyAdminPageModelTest {
 	@Test
 	@DisplayName("시설 등록·수정 직접 저장 요청은 읽기 전용 오류를 flash로 돌려보낸다")
 	void facilityEditorPostRedirectsWithReadOnlyFlash() {
-		var controller = new TransitStationAdminPageController(transitMasterService, transitMasterService);
+		var controller = new TransitStationAdminPageController(
+			transitMasterService,
+			transitMasterService,
+			mock(JdbcDatapackReleaseBlockerSummaryRepository.class)
+		);
 		var redirectAttributes = new RedirectAttributesModelMap();
 
 		String viewName = controller.saveFacilityFromPage(


### PR DESCRIPTION
## 관련 이슈

close #1134

## 작업 배경

- #1081 운영 콘솔 보완 기준에서 dashboard, data quality, station detail에 release blocker 요약이 빠져 있었다.
- 운영자가 candidate, alias/quarantine, manual override, facility evidence, route gate blocker를 별도 화면으로 이동하기 전에 한눈에 볼 수 있는 읽기 전용 요약이 필요하다.

## 작업 내용

- 최신 datapack candidate와 검수 ledger의 blocker 수를 집계하는 `JdbcDatapackReleaseBlockerSummaryRepository`를 추가했다.
- 통합 대시보드에 candidate id, 출시 준비 상태, 전체 blocker, alias/quarantine/manual override/facility/route gate blocker 요약을 표시했다.
- 데이터 품질 화면에 Source coverage, Facility evidence, Route gate, Manifest signature release readiness matrix를 추가했다.
- 역 상세 화면에 station 단위 Facility evidence / Route gate blocker 요약을 추가했다.
- 새 summary는 읽기 전용이며 신규 commandToken, form, write action을 만들지 않는다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests '*DatapackReleaseBlockerSummaryAdminPageTest'`: exit 0
  - `./gradlew test --tests '*DatapackReleaseBlockerSummaryAdminPageTest' --tests '*DataQualityAdminPageControllerTest' --tests '*TransitReadOnlyAdminPageModelTest' --tests '*AdminV3PageSmokeTest'`: exit 0
  - `./gradlew test`: exit 0
  - `git diff --check`: exit 0
  - `node --test tools/ci/*.test.mjs`: 로컬 Node v20.20.2에는 `node:sqlite` 내장 모듈이 없어 기존 `mobile datapack asset audit`에서 중단됨. CI는 Node 24를 사용하므로 PR CI에서 확인한다.

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Dashboard release blocker summary | Backend admin / MockMvc | `DatapackReleaseBlockerSummaryAdminPageTest.dashboardShowsDatapackReleaseBlockerSummary` | `./gradlew test --tests '*DatapackReleaseBlockerSummaryAdminPageTest'` | `데이터팩 출시 준비`, `전체 blocker 8건`, `alias 1`, `route gate 1` 렌더링 확인 |
| Data quality release readiness matrix | Backend admin / MockMvc | `DatapackReleaseBlockerSummaryAdminPageTest.qualityDashboardShowsReleaseReadinessMatrix` | `./gradlew test --tests '*DatapackReleaseBlockerSummaryAdminPageTest'` | Source coverage, Facility evidence, Route gate, Manifest signature 렌더링 확인 |
| Station release readiness | Backend admin / MockMvc | `DatapackReleaseBlockerSummaryAdminPageTest.stationDetailShowsStationReleaseReadiness` | `./gradlew test --tests '*DatapackReleaseBlockerSummaryAdminPageTest'` | 상록수역 station blocker 2건 렌더링 확인 |
| Read-only UI boundary | Backend admin / MockMvc | dashboard rendered HTML assertion | `./gradlew test --tests '*DatapackReleaseBlockerSummaryAdminPageTest'` | 신규 summary 영역에 `name="commandToken"` 미노출 확인 |
| Backend regression | Local JVM | 전체 backend test | `./gradlew test` | exit 0 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `JdbcDatapackReleaseBlockerSummaryRepository`의 blocker 집계 조건
  - 세 admin template이 write action 없이 summary만 표시하는지
  - station detail은 station_id 기준 facility/route blocker만 집계하는지

## 리스크

- Release blocker summary는 현재 운영 ledger table의 상태값을 직접 집계한다. 향후 ledger 상태 머신이 확장되면 blocker 조건도 함께 갱신해야 한다.
- 로컬 repository contract는 Node 20 환경 한계로 완주하지 못했다. GitHub Actions의 Node 24 CI 결과를 merge gate로 확인한다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 관리자 대시보드, 데이터 품질 화면, 역 상세 화면에 데이터팩 출시 준비/준비 상태 요약이 추가되었습니다.
  * 각 화면에서 전체 상태와 세부 항목별 점검 결과를 표로 확인할 수 있습니다.

* **버그 수정**
  * 데이터팩 출시 관련 차단 사유가 더 정확히 반영되도록 상태 표시가 보강되었습니다.
  * 대상이 없거나 정보가 부족한 경우에도 확인 필요 상태로 일관되게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->