### PR TITLE
[Fix] 최근 도착지 실패 상태를 표시

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1821,15 +1821,19 @@ class _RouteRecentDestinationListState
   @override
   void initState() {
     super.initState();
-    _future = widget.repository?.listFavoriteRoutes();
+    _loadFavorites();
   }
 
   @override
   void didUpdateWidget(_RouteRecentDestinationList oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.repository != widget.repository) {
-      _future = widget.repository?.listFavoriteRoutes();
+      _loadFavorites();
     }
+  }
+
+  void _loadFavorites() {
+    _future = widget.repository?.listFavoriteRoutes();
   }
 
   @override
@@ -1841,6 +1845,25 @@ class _RouteRecentDestinationListState
     return FutureBuilder<List<FavoriteRoute>>(
       future: future,
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const _RouteSearchMessage(
+                message: '최근 도착지를 불러오지 못했어요.',
+                liveRegion: true,
+              ),
+              const SizedBox(height: 8),
+              OutlinedButton.icon(
+                key: const Key('routeRecentDestinationRetryButton'),
+                onPressed: () => setState(_loadFavorites),
+                icon: const Icon(Icons.refresh),
+                label: const Text('다시 불러오기'),
+              ),
+              const SizedBox(height: 18),
+            ],
+          );
+        }
         final routes = snapshot.data ?? const <FavoriteRoute>[];
         final destinations = _routeRecentDestinations(routes);
         if (destinations.isEmpty) {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5794,6 +5794,39 @@ void main() {
     }
   });
 
+  testWidgets('경로 검색 최근 도착지 실패는 빈 화면으로 숨기지 않는다', (tester) async {
+    final favoriteRouteRepository = FakeFavoriteRouteRepository(
+      favorites: [_favoriteRoute()],
+    )..error = Exception('network');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(),
+          stationRepository: FakeStationSearchRepository(),
+          favoriteRouteRepository: favoriteRouteRepository,
+          initialMobilityType: 'SENIOR',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('최근 도착지를 불러오지 못했어요.'), findsOneWidget);
+    expect(
+      find.byKey(const Key('routeRecentDestinationRetryButton')),
+      findsOneWidget,
+    );
+
+    favoriteRouteRepository.error = null;
+    await tester.tap(
+      find.byKey(const Key('routeRecentDestinationRetryButton')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('최근 도착지를 불러오지 못했어요.'), findsNothing);
+    expect(find.text('최근 도착지'), findsOneWidget);
+  });
+
   testWidgets('경로 검색은 출발 도착 선택 전 CTA 사유와 입력창 검색 아이콘을 보여준다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     try {


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- 길찾기 화면의 최근 도착지 목록이 저장소 오류를 빈 목록처럼 숨기면 사용자는 최근 경로가 없는 것인지, 앱이 불러오지 못한 것인지 구분하기 어렵습니다.
- #1075의 “네트워크/저장소 실패를 빈 목록으로 위장하지 않는다” 기준에 맞춰 이 작은 실패 상태를 먼저 정리합니다.

## 작업 내용

- 최근 도착지 목록 조회가 실패하면 `최근 도착지를 불러오지 못했어요.` 문구와 `다시 불러오기` 버튼을 표시합니다.
- 다시 불러오기 버튼을 누르면 같은 저장소를 재조회합니다.
- 실패 상태가 빈 화면으로 숨겨지지 않고, 재시도 후 최근 도착지가 돌아오는 widget test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --plain-name "경로 검색 최근 도착지 실패"`: 1 test passed
  - `flutter test test/widget_test.dart --plain-name "경로 검색 첫 화면"`: 1 test passed
  - `flutter analyze`: No issues found
  - `git diff --check`: exit 0
  - `rg -n "확인 필요|확인이 필요|확인 요청|점수|기준점|기본정보|기본 정보만 있음|정보만|이동 편의도|이동 점수|[0-9]+\s*점|출처 확인 필요|노선 정보 없음|위치 확인 필요|이용 불가 확인" apps/mobile/lib apps/mobile/assets apps/mobile/release --glob '!**/*.g.dart'`: no matches
  - GitHub Actions CI: pass, https://github.com/AquilaXk/easysubway/actions/runs/28393225711
  - GitHub Actions Release Artifacts: pass, https://github.com/AquilaXk/easysubway/actions/runs/28393225320
  - Codex CLI fallback review: CodeRabbit rate limit으로 대체 확인, actionable 0건

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 최근 도착지 실패 상태 | Flutter widget | 저장소 failure double | `flutter test test/widget_test.dart --plain-name "경로 검색 최근 도착지 실패"` | 1 test passed |
| 길찾기 첫 화면 회귀 | Flutter widget | 기존 첫 화면 구조 test | `flutter test test/widget_test.dart --plain-name "경로 검색 첫 화면"` | 1 test passed |
| 정적 분석 | Flutter analyzer | `flutter analyze` | 로컬 명령 출력 | No issues found |
| 금지 문구 | Local grep | 사용자에게 어려운 문구 검색 | `rg -n ... apps/mobile/lib apps/mobile/assets apps/mobile/release` | no matches |
| Android emulator | Android emulator | `adb devices`, `adb shell getprop sys.boot_completed`, `adb exec-out uiautomator dump /dev/tty` | `emulator-5554`, boot_completed `1`, UI tree dump success | Android evidence path available |
| iOS Simulator | iOS Simulator | XcodeBuildMCP `list_sims`, `session_show_defaults` | `Maum iPhone 17` exists but shutdown, session defaults empty | 이번 fake repository 상태는 widget test로 검증 |
| CI | GitHub Actions | PR check suite | https://github.com/AquilaXk/easysubway/actions/runs/28393225711 | pass |
| Release Artifacts | GitHub Actions | PR release artifact gate | https://github.com/AquilaXk/easysubway/actions/runs/28393225320 | pass |
| 코드 리뷰 | GitHub PR review | CodeRabbit rate limit 후 Codex CLI fallback review | PR review `4594310474` | actionable 0건 |

## 리뷰어 메모

- #1075 전체 close PR이 아닙니다. 저장소 실패를 빈 화면으로 숨기는 잔여 지점을 하나 줄이는 PR입니다.
- 실제 앱 데이터만으로는 이 실패 상태를 안정적으로 재현하기 어려워, widget test에서 repository failure double로 검증했습니다.

## 리스크

- 최근 도착지 목록에만 표시되는 오류/재시도 UI라 동작 범위가 좁습니다.
- 저장소가 없는 환경은 기존처럼 최근 도착지 섹션을 숨깁니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
