### PR TITLE
[Fix] 알림함 실패 상태를 표시

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1945,7 +1945,15 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
                 setState(() {
                   _itemsFuture = next;
                 });
-                await next;
+                try {
+                  await next;
+                } catch (error, stackTrace) {
+                  reportMobileError(
+                    error,
+                    stackTrace,
+                    context: '알림함 새로고침 중 예외가 발생했습니다.',
+                  );
+                }
               },
               child: ListView(
                 physics: const AlwaysScrollableScrollPhysics(),
@@ -1953,7 +1961,20 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
                 children: [
                   if (snapshot.connectionState != ConnectionState.done)
                     const LinearProgressIndicator(minHeight: 3),
-                  if (items.isEmpty)
+                  if (snapshot.hasError)
+                    _HomeStateCard(
+                      key: const Key('notificationInboxErrorState'),
+                      icon: Icons.error_outline,
+                      title: '알림을 불러오지 못했어요',
+                      subtitle: '잠시 후 다시 시도해 주세요.',
+                      actionLabel: '다시 시도',
+                      onAction: () {
+                        setState(() {
+                          _itemsFuture = _loadItems();
+                        });
+                      },
+                    )
+                  else if (items.isEmpty)
                     const _AppCard(
                       child: _AppInfoRow(
                         icon: Icons.notifications_none,
@@ -1983,6 +2004,7 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
 
   Future<List<_NotificationInboxItem>> _loadItems() async {
     final items = <_NotificationInboxItem>[];
+    var loadFailed = false;
     final favoriteFacilityRepository = widget.favoriteFacilityRepository;
     if (favoriteFacilityRepository != null) {
       try {
@@ -1992,6 +2014,7 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
           items.add(_NotificationInboxItem.facility(facility));
         }
       } catch (error, stackTrace) {
+        loadFailed = true;
         reportMobileError(
           error,
           stackTrace,
@@ -2006,11 +2029,15 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
         items.add(_NotificationInboxItem.report(report));
       }
     } catch (error, stackTrace) {
+      loadFailed = true;
       reportMobileError(
         error,
         stackTrace,
         context: '알림함 제보 상태를 불러오는 중 예외가 발생했습니다.',
       );
+    }
+    if (items.isEmpty && loadFailed) {
+      throw StateError('notification inbox load failed');
     }
     return items;
   }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1917,7 +1917,7 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
   @override
   void initState() {
     super.initState();
-    _itemsFuture = _loadItems();
+    _itemsFuture = _loadItemsForDisplay();
   }
 
   @override
@@ -1941,7 +1941,7 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
             final items = snapshot.data ?? const <_NotificationInboxItem>[];
             return RefreshIndicator(
               onRefresh: () async {
-                final next = _loadItems();
+                final next = _loadItemsForDisplay();
                 setState(() {
                   _itemsFuture = next;
                 });
@@ -1970,7 +1970,7 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
                       actionLabel: '다시 시도',
                       onAction: () {
                         setState(() {
-                          _itemsFuture = _loadItems();
+                          _itemsFuture = _loadItemsForDisplay();
                         });
                       },
                     )
@@ -2000,6 +2000,16 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
         ),
       ),
     );
+  }
+
+  Future<List<_NotificationInboxItem>> _loadItemsForDisplay() {
+    final next = _loadItems();
+    unawaited(
+      next.catchError((Object error, StackTrace stackTrace) {
+        return const <_NotificationInboxItem>[];
+      }),
+    );
+    return next;
   }
 
   Future<List<_NotificationInboxItem>> _loadItems() async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -769,6 +769,12 @@ void main() {
       expect(find.text('알림을 불러오지 못했어요'), findsOneWidget);
       expect(find.text('새 알림이 없습니다'), findsNothing);
 
+      await tester.tap(find.widgetWithText(OutlinedButton, '다시 시도'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('알림을 불러오지 못했어요'), findsOneWidget);
+      expect(find.text('새 알림이 없습니다'), findsNothing);
+
       reportRepository.error = null;
       await tester.tap(find.widgetWithText(OutlinedButton, '다시 시도'));
       await tester.pumpAndSettle();

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -741,6 +741,44 @@ void main() {
     expect(find.text('새 알림이 없습니다'), findsOneWidget);
   });
 
+  testWidgets('알림함은 로드 실패를 빈 알림으로 숨기지 않는다', (tester) async {
+    final reportedErrors = <FlutterErrorDetails>[];
+    final reportRepository = FakeFacilityReportRepository()
+      ..error = Exception('network');
+
+    await runWithMobileErrorReporter(reportedErrors.add, () async {
+      await tester.pumpWidget(
+        EasySubwayApp(
+          repository: FakeStationSearchRepository(),
+          reportRepository: reportRepository,
+          routeRepository: FakeRouteSearchRepository(),
+          favoriteRepository: FakeFavoriteStationRepository(),
+          notificationRepository: FakeNotificationSettingsRepository(),
+          initialOnboardingState: _completedOnboardingState(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('homeNotificationActionButton')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('notificationInboxErrorState')),
+        findsOneWidget,
+      );
+      expect(find.text('알림을 불러오지 못했어요'), findsOneWidget);
+      expect(find.text('새 알림이 없습니다'), findsNothing);
+
+      reportRepository.error = null;
+      await tester.tap(find.widgetWithText(OutlinedButton, '다시 시도'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('알림을 불러오지 못했어요'), findsNothing);
+      expect(find.text('새 알림이 없습니다'), findsOneWidget);
+    });
+    expect(reportedErrors, isNotEmpty);
+  });
+
   testWidgets('홈 알림 버튼은 확인할 알림이 있으면 배지와 상태를 알려준다', (tester) async {
     final favoriteFacilityRepository = FakeFavoriteFacilityRepository(
       favorites: [_favoriteFacility(status: 'USER_REPORTED')],


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- 알림함에서 시설 알림 또는 제보 상태를 불러오지 못해도 빈 목록으로 처리되어 `새 알림이 없습니다`가 표시될 수 있었다.
- 실패를 빈 상태로 보이면 사용자가 실제로 알림이 없는 상황과 일시적인 로드 실패를 구분할 수 없다.
- QA 요청에 따라 앱 사용자에게 `~점`, `기본정보만 있음`, 개발용 상태 표현처럼 이해하기 어려운 문구가 노출되지 않도록 이번 변경 문구도 쉬운 표현으로 정리했다.

## 작업 내용

- 알림함 로드 중 시설/제보 저장소가 모두 실패하고 표시할 항목이 없으면 빈 알림 대신 실패 상태를 표시한다.
- 실패 상태 문구는 `알림을 불러오지 못했어요`, `잠시 후 다시 시도해 주세요.`, `다시 시도`로 구성했다.
- 새로고침 중 발생한 오류도 mobile error reporter에 남기고 화면에서 재시도할 수 있게 했다.
- 한쪽 저장소가 실패해도 다른 저장소에서 가져온 알림이 있으면 기존처럼 목록을 표시한다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/main.dart test/widget_test.dart`: exit 0, 변경 없음
  - `flutter test test/widget_test.dart --plain-name "알림함은 로드 실패"`: exit 0, 1 test passed
  - `flutter test test/widget_test.dart --plain-name "홈 우측 상단 알림 버튼"`: exit 0, 1 test passed
  - `flutter test test/widget_test.dart`: exit 0, 183 tests passed
  - `flutter analyze`: exit 0, No issues found
  - `git diff --check`: exit 0
  - `rg -n "확인 필요|확인이 필요|확인 요청|점수|기준점|기본정보|기본 정보만 있음|정보만|이동 편의도|이동 점수|[0-9]+\\s*점|출처 확인 필요|노선 정보 없음|위치 확인 필요|이용 불가 확인" apps/mobile/lib apps/mobile/assets apps/mobile/release --glob '!**/*.g.dart'`: exit 1, 앱 코드/에셋/릴리즈 문구에서 금지 표현 미검출
  - GitHub Actions CI: 성공, https://github.com/AquilaXk/easysubway/actions/runs/28394829358
  - GitHub Actions Release Artifacts: 성공, https://github.com/AquilaXk/easysubway/actions/runs/28394828939
  - SonarCloud: 성공, https://github.com/AquilaXk/easysubway/actions/runs/28394828949
  - CodeRabbit: rate limit으로 실제 리뷰 미시작
  - Codex CLI fallback review: actionable 1건 발견, inline thread에 답글 및 resolve 완료
  - Post-merge main 확인: merge commit `baae5b04e741991dadcace557a46726ad0ccf0dc`
  - Post-merge CD: 생성됨, pending, https://github.com/AquilaXk/easysubway/actions/runs/28395352749
  - Post-merge CI/Release: 생성됨, 진행 중, 실패 신호 없음

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 알림함 로드 실패 표시 | Flutter widget | `flutter test test/widget_test.dart --plain-name "알림함은 로드 실패"` | 명령 출력: `All tests passed!` | 실패를 `새 알림이 없습니다`로 숨기지 않고 `알림을 불러오지 못했어요`와 `다시 시도`를 표시 |
| 기존 알림 버튼 이동 | Flutter widget | `flutter test test/widget_test.dart --plain-name "홈 우측 상단 알림 버튼"` | 명령 출력: `All tests passed!` | 홈 알림 버튼에서 알림함으로 이동하는 기존 흐름 유지 |
| 전체 홈/알림 widget 회귀 | Flutter widget | `flutter test test/widget_test.dart` | 명령 출력: `183 tests passed` | 기존 홈, 알림, 경로, 역 검색 widget 흐름 유지 |
| 정적 분석 | Flutter shared | `flutter analyze` | 명령 출력: `No issues found!` | 분석 통과 |
| 사용자 문구 금지 표현 | Flutter shared | `rg` 금지 표현 검색 | 명령 출력 없음, exit 1 | `~점`, `기본정보`, `정보만` 등 지정 표현 미검출 |
| PR CI | GitHub Actions | CI / Release Artifacts / SonarCloud 확인 | CI: https://github.com/AquilaXk/easysubway/actions/runs/28394829358, Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/28394828939, SonarCloud: https://github.com/AquilaXk/easysubway/actions/runs/28394828949 | 모두 성공 |
| 코드 리뷰 | GitHub PR | CodeRabbit rate limit 확인 후 Codex CLI fallback review 실행 | PR review: `Actionable comments posted: 1`, discussion `#discussion_r3493942163` 답글 및 resolve | review 지적 수정 완료 |
| Post-merge CD | GitHub Actions main | merge commit 기준 run 조회 | CD: https://github.com/AquilaXk/easysubway/actions/runs/28395352749 | run 생성됨, pending 상태이며 실패 신호 없음 |
| 화면 증거 | Android/iOS 공통 Flutter UI | Widget test가 공유 UI 문구와 상태 전환을 직접 검증 | 스크린샷 불필요 사유: 플랫폼별 네이티브 UI가 아니라 공통 Flutter widget의 상태/문구 변경이며, 테스트가 실제 표시 문구와 재시도 동작을 검증함 | 플랫폼별 분기 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `NotificationInboxScreen._loadItems()`가 부분 성공은 목록으로 유지하고, 전부 실패해 표시할 항목이 없을 때만 실패 상태로 넘기는지 확인해 주세요.
  - 화면 문구가 앱 사용자에게 쉬운 표현인지 확인해 주세요.

## 리스크

- 실패 상태가 새로 노출되므로 기존에 조용히 빈 알림으로 보이던 오류가 사용자에게 보인다.
- 한쪽 저장소 실패와 다른 한쪽 성공이 섞인 경우에는 기존처럼 표시 가능한 알림을 보여주므로, 일부 실패 안내는 별도로 노출하지 않는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
