### PR TITLE
[Fix] 홈 상태 숨김 방지

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -2584,7 +2584,15 @@ class _HomeFacilityAlertSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final facilitiesFuture = this.facilitiesFuture;
     if (facilitiesFuture == null) {
-      return const SizedBox.shrink();
+      return const _HomeStateSection(
+        title: '시설 알림',
+        child: _HomeStateCard(
+          key: Key('homeFacilityAlertUnavailableState'),
+          icon: Icons.notifications_off_outlined,
+          title: '시설 알림을 준비하지 못했어요',
+          subtitle: '앱을 다시 열어도 계속 보이면 도움말에서 알려 주세요.',
+        ),
+      );
     }
     return FutureBuilder<List<FavoriteFacility>>(
       future: facilitiesFuture,
@@ -2830,7 +2838,15 @@ class _HomeRecentRouteSection extends StatelessWidget {
   Widget build(BuildContext context) {
     final routesFuture = this.routesFuture;
     if (routesFuture == null) {
-      return const SizedBox.shrink();
+      return const _HomeStateSection(
+        title: '최근 경로',
+        child: _HomeStateCard(
+          key: Key('homeRecentRouteUnavailableState'),
+          icon: Icons.route_outlined,
+          title: '최근 경로를 준비하지 못했어요',
+          subtitle: '앱을 다시 열어도 계속 보이면 도움말에서 알려 주세요.',
+        ),
+      );
     }
     return FutureBuilder<List<FavoriteRoute>>(
       future: routesFuture,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -319,7 +319,7 @@ void main() {
     expect(find.text('어떤 도움이 필요한가요?'), findsNothing);
   });
 
-  testWidgets('기본 앱은 사진 복구 저장소가 없어도 플랫폼 오류 없이 홈을 보여준다', (tester) async {
+  testWidgets('기본 앱은 저장소가 없어도 상태를 숨기지 않고 홈을 보여준다', (tester) async {
     final reportedErrors = <FlutterErrorDetails>[];
 
     await runWithMobileErrorReporter(reportedErrors.add, () async {
@@ -343,8 +343,18 @@ void main() {
       findsOneWidget,
     );
 
-    expect(find.text('자주 가는 곳'), findsNothing);
-    expect(find.text('최근 경로'), findsNothing);
+    expect(find.text('시설 알림'), findsOneWidget);
+    expect(
+      find.byKey(const Key('homeFacilityAlertUnavailableState')),
+      findsOneWidget,
+    );
+    expect(find.text('시설 알림을 준비하지 못했어요'), findsOneWidget);
+    expect(find.text('최근 경로'), findsOneWidget);
+    expect(
+      find.byKey(const Key('homeRecentRouteUnavailableState')),
+      findsOneWidget,
+    );
+    expect(find.text('최근 경로를 준비하지 못했어요'), findsOneWidget);
     expect(find.text('저장한 경로가 없습니다'), findsNothing);
   });
 


### PR DESCRIPTION
## 관련 이슈

related #1075

## 작업 배경

- 홈의 시설 알림/최근 경로 영역은 로딩, 오류, 빈 상태를 표시하지만 저장소 주입이 빠진 경우에는 영역 자체가 사라졌습니다.
- Android v1 출시 QA 기준에서는 실패나 준비 불가 상태가 빈 화면처럼 보이면 안 되므로, 저장소가 없는 경우도 사용자가 이해할 수 있는 안내로 고정합니다.

## 작업 내용

- 홈 시설 알림 저장소가 없을 때 `homeFacilityAlertUnavailableState` 안내 카드를 표시합니다.
- 홈 최근 경로 저장소가 없을 때 `homeRecentRouteUnavailableState` 안내 카드를 표시합니다.
- 기존 widget test를 “상태를 숨기지 않는다” 기준으로 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter analyze`: No issues found
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "기본 앱은 저장소가 없어도 상태를 숨기지 않고 홈을 보여준다" --reporter expanded`: pass
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "홈은 시설 알림과 최근 경로 로드 실패를 화면에 보여준다" --reporter expanded`: pass
  - `cd apps/mobile && flutter test test/widget_test.dart --plain-name "홈 화면은 핵심 행동과 보조 행동을 나누어 보여준다" --reporter expanded`: pass
  - `cd apps/mobile && flutter test test/widget_test.dart --reporter expanded`: pass, 186 tests
  - `git diff --check`: pass
  - `rg -n "상세 정보|상세정보|기본정보|기본 정보|기본 정보만 있음|[0-9]+점|점수|이동 점수" apps/mobile/lib apps/mobile/test --glob '!**/*.g.dart'`: production `apps/mobile/lib` match 없음, 테스트의 금지어 검증만 match

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 저장소 누락 상태 노출 | Flutter widget | 저장소 없이 `EasySubwayApp` 렌더링 | `flutter test test/widget_test.dart --plain-name "기본 앱은 저장소가 없어도 상태를 숨기지 않고 홈을 보여준다"` | 시설 알림/최근 경로 준비 불가 상태가 화면에 표시됨 |
| 기존 홈 상태 처리 | Flutter widget | 시설 알림/최근 경로 로드 실패 테스트 | `flutter test test/widget_test.dart --plain-name "홈은 시설 알림과 최근 경로 로드 실패를 화면에 보여준다"` | 실패 상태가 빈 화면으로 숨겨지지 않음 |
| 홈 화면 기본 흐름 | Android emulator | `easysubway_ps16k_api36`에 debug APK 설치 후 온보딩 완료 | local-only `.codex/evidence/pr-1075-accessible-state-copy/android-home-after-onboarding.png`, `android-home-after-onboarding-summary.txt` | 홈이 정상 렌더링되고 시설 알림/최근 경로 상태가 UI tree에 노출됨 |
| iOS 확인 | iOS Simulator | XcodeBuildMCP/Flutter 장치 상태 확인 | `mcp__xcodebuildmcp.session_show_defaults`: project/scheme/simulator default 없음, `list_sims`: shutdown simulator만 있음, `flutter devices`: iOS device 없음 | 이번 패치는 widget 상태 분기라 iOS는 자동 테스트로 대체, 남은 리스크는 낮음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: [apps/mobile/lib/main.dart](apps/mobile/lib/main.dart)의 `facilitiesFuture == null`, `routesFuture == null` 분기입니다.
- 이 PR은 #1075 전체 완료가 아니라 홈 상태 숨김 구멍을 막는 후속 패치입니다.
- Android screenshot/UI tree는 로컬 에뮬레이터 증거라 git에 커밋하지 않았습니다.

## 리스크

- 정상 앱 의존성에서는 저장소가 주입되므로 새 안내 카드는 비정상 의존성 경로에서만 보입니다.
- iOS simulator는 현재 booted device와 MCP project/scheme default가 없어 수동 화면 증거를 남기지 못했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
