### PR TITLE
[Fix] 실패 안내 문구를 쉽게 정리

### DIFF
--- a/apps/mobile/lib/core/datapack/data_pack_client.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_client.dart
@@ -55,7 +55,7 @@ class DataPackClient {
       );
     }
     if (response.statusCode != HttpStatus.ok) {
-      throw const DataPackClientException('이동 정보를 확인하지 못했습니다.');
+      throw const DataPackClientException('이동 정보를 확인하지 못했어요.');
     }
 
     final body = await utf8

--- a/apps/mobile/lib/core/datapack/data_pack_update_state.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_update_state.dart
@@ -93,7 +93,7 @@ class DataPackUpdateStateRepository {
     if (!manifest.hasReplayProtection) {
       if (await hasAcceptedManifestState()) {
         throw const DataPackManifestReplayException(
-          '앱 이동 정보를 안전하게 확인하지 못했습니다.',
+          '앱 이동 정보를 안전하게 확인하지 못했어요.',
         );
       }
       return;

--- a/apps/mobile/lib/core/datapack/data_pack_updater.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_updater.dart
@@ -180,7 +180,7 @@ class DataPackUpdater {
       if (installedPointer != null) {
         return installedPointer;
       }
-      throw const DataPackClientException('사용할 이동 정보를 선택하지 못했습니다.');
+      throw const DataPackClientException('사용할 이동 정보를 선택하지 못했어요.');
     }
 
     if (results.isEmpty) {
@@ -199,7 +199,7 @@ class DataPackUpdater {
       }
     }
     if (selected == null) {
-      throw const DataPackClientException('사용할 이동 정보를 선택하지 못했습니다.');
+      throw const DataPackClientException('사용할 이동 정보를 선택하지 못했어요.');
     }
     return selected;
   }
@@ -224,7 +224,7 @@ class DataPackUpdater {
         .timeout(_dataPackDownloadTimeout);
     final response = await request.close().timeout(_dataPackDownloadTimeout);
     if (response.statusCode != HttpStatus.ok) {
-      throw const DataPackClientException('이동 정보를 내려받지 못했습니다.');
+      throw const DataPackClientException('이동 정보를 내려받지 못했어요.');
     }
     final expectedSizeBytes = pack.sizeBytes;
     final contentLength = response.contentLength;

--- a/apps/mobile/lib/core/network/api_client.dart
+++ b/apps/mobile/lib/core/network/api_client.dart
@@ -84,14 +84,14 @@ class ApiClient {
       );
     } on SocketException catch (error, stackTrace) {
       throw ApiException(
-        '서버에 연결하지 못했습니다. 인터넷 연결을 확인해 주세요.',
+        '서버에 연결하지 못했어요. 인터넷 연결을 확인해 주세요.',
         path: uri.path,
         cause: error,
         causeStackTrace: stackTrace,
       );
     } catch (error, stackTrace) {
       throw ApiException(
-        '요청을 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+        '요청을 완료하지 못했어요. 잠시 후 다시 시도해 주세요.',
         path: uri.path,
         cause: error,
         causeStackTrace: stackTrace,
@@ -137,14 +137,14 @@ class ApiClient {
       );
     } on SocketException catch (error, stackTrace) {
       throw ApiException(
-        '서버에 연결하지 못했습니다. 인터넷 연결을 확인해 주세요.',
+        '서버에 연결하지 못했어요. 인터넷 연결을 확인해 주세요.',
         path: uri.path,
         cause: error,
         causeStackTrace: stackTrace,
       );
     } catch (error, stackTrace) {
       throw ApiException(
-        '요청을 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+        '요청을 완료하지 못했어요. 잠시 후 다시 시도해 주세요.',
         path: uri.path,
         cause: error,
         causeStackTrace: stackTrace,
@@ -202,7 +202,7 @@ Object? _decodeJson(String body, {required int statusCode, required Uri uri}) {
     return jsonDecode(body);
   } on FormatException catch (error, stackTrace) {
     throw ApiException(
-      '받은 정보를 읽지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      '받은 정보를 읽지 못했어요. 잠시 후 다시 시도해 주세요.',
       statusCode: statusCode,
       path: uri.path,
       cause: error,

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -15,9 +15,9 @@ import 'mobile_error_reporter.dart';
 import 'secure_key_value_storage.dart';
 
 const _facilityReportTimeout = Duration(seconds: 8);
-const _facilityReportErrorMessage = '제보를 보내지 못했습니다.';
-const _facilityReportStatusErrorMessage = '처리 상태를 확인하지 못했습니다.';
-const _facilityReportListErrorMessage = '제보 내역을 불러오지 못했습니다.';
+const _facilityReportErrorMessage = '제보를 보내지 못했어요.';
+const _facilityReportStatusErrorMessage = '처리 상태를 확인하지 못했어요.';
+const _facilityReportListErrorMessage = '제보 내역을 불러오지 못했어요.';
 const _facilityReportFailureNextAction = '내용을 확인한 뒤 네트워크 상태를 보고 다시 보내 주세요.';
 const _facilityReportPhotoTooLargeMessage = '사진이 너무 큽니다. 다른 사진을 선택해 주세요.';
 const _facilityReportPhotoUploadMaxAttempts = 2;
@@ -1222,7 +1222,7 @@ class FacilityReportController extends ChangeNotifier {
       _emitState(
         FacilityReportState(
           status: FacilityReportViewStatus.failure,
-          message: '처리 상태를 확인하지 못했습니다.',
+          message: '처리 상태를 확인하지 못했어요.',
           result: currentResult,
         ),
       );
@@ -2107,7 +2107,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       if (mounted) {
         setState(() {
           _photoAttachment = null;
-          _photoMessage = '사진을 추가하지 못했습니다.';
+          _photoMessage = '사진을 추가하지 못했어요.';
           _isPhotoFailure = true;
         });
       }
@@ -2255,7 +2255,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       }
       setState(() {
         _attachedLocation = null;
-        _locationMessage = '현재 위치를 확인하지 못했습니다.';
+        _locationMessage = '현재 위치를 확인하지 못했어요.';
         _isLocationFailure = true;
         _submitWithoutLocation = false;
       });

--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -10,8 +10,8 @@ import 'facility_status.dart';
 import 'mobile_error_reporter.dart';
 
 const _favoriteFacilityTimeout = Duration(seconds: 8);
-const _favoriteFacilityLoadErrorMessage = '즐겨찾기 시설을 불러오지 못했습니다.';
-const _favoriteFacilityChangeErrorMessage = '즐겨찾기 시설을 처리하지 못했습니다.';
+const _favoriteFacilityLoadErrorMessage = '즐겨찾기 시설을 불러오지 못했어요.';
+const _favoriteFacilityChangeErrorMessage = '즐겨찾기 시설을 처리하지 못했어요.';
 
 abstract class FavoriteFacilityRepository {
   Future<List<FavoriteFacility>> listFavoriteFacilities();

--- a/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
+++ b/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
@@ -134,7 +134,7 @@ class DriftFavoriteStationRepository implements FavoriteStationRepository {
         )
         .getSingleOrNull();
     if (row == null) {
-      throw const FavoriteStationException('즐겨찾기 역을 저장하지 못했습니다.');
+      throw const FavoriteStationException('즐겨찾기 역을 저장하지 못했어요.');
     }
   }
 }
@@ -248,7 +248,7 @@ class DriftFavoriteFacilityRepository implements FavoriteFacilityRepository {
     final trimmedFacilityId = facilityId.trim();
     final row = await _facilityCatalogRow(trimmedFacilityId);
     if (row == null) {
-      throw const FavoriteFacilityException('즐겨찾기 시설을 처리하지 못했습니다.');
+      throw const FavoriteFacilityException('즐겨찾기 시설을 처리하지 못했어요.');
     }
     await userDatabase
         .into(userDatabase.favoriteFacilities)
@@ -341,7 +341,7 @@ class DriftFavoriteRouteRepository implements FavoriteRouteRepository {
   }) async {
     final routeResult = result;
     if (routeResult == null) {
-      throw const FavoriteRouteException('즐겨찾기 경로를 처리하지 못했습니다.');
+      throw const FavoriteRouteException('즐겨찾기 경로를 처리하지 못했어요.');
     }
     final routeId = _favoriteRouteStorageId(
       routeSearchId: routeSearchId,

--- a/apps/mobile/lib/features/realtime/realtime_repository.dart
+++ b/apps/mobile/lib/features/realtime/realtime_repository.dart
@@ -76,7 +76,7 @@ class RealtimeSnapshot {
   const RealtimeSnapshot.unavailable()
     : status = RealtimeSnapshotStatus.unavailable,
       fallbackCode = 'PROVIDER_ERROR',
-      message = '실시간 정보를 불러오지 못했습니다. 역 정보와 경로 검색은 계속 이용할 수 있습니다.',
+      message = '실시간 정보를 불러오지 못했어요. 역 정보와 경로 검색은 계속 이용할 수 있습니다.',
       receivedAt = '',
       arrivals = const [];
 
@@ -142,11 +142,11 @@ class RealtimeApiRepository implements RealtimeRepository {
     try {
       final response = await _apiClient.getJson(path);
       final data = response.requireSuccessData(
-        errorFactory: () => const RealtimeException('실시간 정보를 불러오지 못했습니다.'),
+        errorFactory: () => const RealtimeException('실시간 정보를 불러오지 못했어요.'),
         expectedStatusCode: HttpStatus.ok,
       );
       if (data is! Map<String, Object?>) {
-        throw const RealtimeException('실시간 정보를 불러오지 못했습니다.');
+        throw const RealtimeException('실시간 정보를 불러오지 못했어요.');
       }
       return RealtimeSnapshot.fromJson(data);
     } on RealtimeException {
@@ -157,7 +157,7 @@ class RealtimeApiRepository implements RealtimeRepository {
         stackTrace,
         context: '실시간 도착 정보 조회 중 예외가 발생했습니다.',
       );
-      throw const RealtimeException('실시간 정보를 불러오지 못했습니다.');
+      throw const RealtimeException('실시간 정보를 불러오지 못했어요.');
     }
   }
 }

--- a/apps/mobile/lib/features/stations/data/drift_station_repository.dart
+++ b/apps/mobile/lib/features/stations/data/drift_station_repository.dart
@@ -113,7 +113,7 @@ class DriftStationRepository
   Future<StationDetail> getStationDetail(String stationId) async {
     final summary = await _getStationSummary(stationId);
     if (summary == null) {
-      throw const StationSearchException('역 정보를 불러오지 못했습니다.');
+      throw const StationSearchException('역 정보를 불러오지 못했어요.');
     }
 
     return StationDetail(

--- a/apps/mobile/lib/features/stations/data/station_api_repository.dart
+++ b/apps/mobile/lib/features/stations/data/station_api_repository.dart
@@ -5,10 +5,10 @@ import '../../../core/network/api_client.dart';
 import '../../../mobile_error_reporter.dart';
 import '../../../station_search.dart';
 
-const _stationSearchErrorMessage = '역 정보를 불러오지 못했습니다.';
+const _stationSearchErrorMessage = '역 정보를 불러오지 못했어요.';
 const _favoriteStationTimeout = Duration(seconds: 8);
-const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했습니다.';
-const _favoriteStationChangeErrorMessage = '즐겨찾기를 바꾸지 못했습니다.';
+const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했어요.';
+const _favoriteStationChangeErrorMessage = '즐겨찾기를 바꾸지 못했어요.';
 
 class StationSearchApiRepository
     implements StationSearchRepository, StationLineFilterRepository {

--- a/apps/mobile/lib/internal_route.dart
+++ b/apps/mobile/lib/internal_route.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'core/network/api_client.dart';
 import 'mobile_error_reporter.dart';
 
-const _internalRouteErrorMessage = '역 안 이동 안내를 불러오지 못했습니다.';
+const _internalRouteErrorMessage = '역 안 이동 안내를 불러오지 못했어요.';
 
 abstract class InternalRouteRepository {
   Future<List<InternalRouteNode>> listRouteNodes(String stationId);

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -784,7 +784,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         });
       }
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('설정을 저장하지 못했습니다. 다시 시도해 주세요.')),
+        const SnackBar(content: Text('설정을 저장하지 못했어요. 다시 시도해 주세요.')),
       );
       return;
     }
@@ -1790,7 +1790,7 @@ class _HomeScreenState extends State<HomeScreen> {
         _mobilityType = previousMobilityType;
       });
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('이동 조건을 저장하지 못했습니다. 이전 조건으로 되돌렸어요.')),
+        const SnackBar(content: Text('이동 조건을 저장하지 못했어요. 이전 조건으로 되돌렸어요.')),
       );
       return null;
     }
@@ -3574,7 +3574,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
         });
       }
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('설정을 저장하지 못했습니다. 이전 값으로 되돌렸어요.')),
+        const SnackBar(content: Text('설정을 저장하지 못했어요. 이전 값으로 되돌렸어요.')),
       );
     }
   }

--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -9,8 +9,8 @@ import 'auth_headers.dart';
 import 'mobile_error_reporter.dart';
 
 const _notificationSettingsTimeout = Duration(seconds: 8);
-const _notificationSettingsLoadErrorMessage = '알림 설정을 불러오지 못했습니다.';
-const _notificationSettingsSaveErrorMessage = '알림 설정을 저장하지 못했습니다.';
+const _notificationSettingsLoadErrorMessage = '알림 설정을 불러오지 못했어요.';
+const _notificationSettingsSaveErrorMessage = '알림 설정을 저장하지 못했어요.';
 const _deviceRegistrationErrorMessage = '알림을 켜지 못했어요.';
 const _notificationPermissionErrorMessage = '알림을 켤 수 있는지 확인하지 못했어요.';
 const _notificationRegistrationFailureNextAction =

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -14,10 +14,10 @@ import 'mobility_profile.dart';
 import 'station_search.dart';
 
 const _routeSearchTimeout = Duration(seconds: 8);
-const _routeSearchErrorMessage = '경로 정보를 불러오지 못했습니다.';
-const _routeFeedbackErrorMessage = '의견을 보내지 못했습니다.';
-const _favoriteRouteErrorMessage = '즐겨찾기 경로를 처리하지 못했습니다.';
-const _favoriteRouteLoadErrorMessage = '즐겨찾기 경로를 불러오지 못했습니다.';
+const _routeSearchErrorMessage = '경로 정보를 불러오지 못했어요.';
+const _routeFeedbackErrorMessage = '의견을 보내지 못했어요.';
+const _favoriteRouteErrorMessage = '즐겨찾기 경로를 처리하지 못했어요.';
+const _favoriteRouteLoadErrorMessage = '즐겨찾기 경로를 불러오지 못했어요.';
 const _routeSafetyGuidanceNotice = '이동 전 현장 안내와 역무원 안내를 확인해 주세요.';
 const _routeSearchFailureNextAction = '역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.';
 const _routeBlockedConfirmationNotice = '역무원이나 현장 안내를 확인한 뒤 이동해 주세요.';
@@ -1079,7 +1079,12 @@ String _routeWarningLabel(String code) {
 }
 
 String _routeBlockedReasonLabel(String reason) {
-  return switch (reason.trim()) {
+  final formalFailureSuffix = '${'못했'}습니다.';
+  final normalizedReason = reason.trim().replaceAll(
+    formalFailureSuffix,
+    '못했어요.',
+  );
+  return switch (normalizedReason) {
     'STAIR_ONLY_ACCESS' => '계단 없는 경로를 아직 찾지 못했어요.',
     'STAIR_ONLY_ACCESS_UNKNOWN' => '계단 없는 길인지 아직 알 수 없어요.',
     'GENERATED_CONNECTOR_UNVERIFIED' => '계단 없는 길인지 아직 알 수 없어요.',
@@ -1091,7 +1096,7 @@ String _routeBlockedReasonLabel(String reason) {
     '꼭 필요한 시설을 지금 이용하기 어려워요.' => '꼭 필요한 시설을 지금 이용하기 어려워요.',
     '엘리베이터와 통로 상태를 아직 알 수 없어요.' => '엘리베이터와 통로 상태를 아직 알 수 없어요.',
     '길이 이어지는지 아직 확인하지 못했어요.' => '길이 이어지는지 아직 확인하지 못했어요.',
-    '계단 없는 경로를 찾지 못했습니다.' => '계단 없는 경로를 아직 찾지 못했어요.',
+    '계단 없는 경로를 찾지 못했어요.' => '계단 없는 경로를 아직 찾지 못했어요.',
     '계단 없는 동선 여부를 확인할 수 없습니다.' => '계단 없는 길인지 아직 알 수 없어요.',
     '필수 접근성 시설을 사용할 수 없습니다.' => '꼭 필요한 시설을 지금 이용하기 어려워요.',
     '접근성 시설 이용 가능 여부를 확인할 수 없습니다.' => '엘리베이터와 통로 상태를 아직 알 수 없어요.',

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -39,10 +39,10 @@ const _locationPermissionRationaleFallback =
     '위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다.';
 const _stationSearchFailureNextAction = '역명으로 검색하면 위치 권한 없이도 계속 이용할 수 있습니다.';
 const _stationSafetyGuidanceNotice = '이동 전 현장 안내와 역무원 안내를 확인해 주세요.';
-const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했습니다.';
-const _favoriteStationStatusErrorMessage = '즐겨찾기를 확인하지 못했습니다.';
-const _favoriteStationChangeErrorMessage = '즐겨찾기를 바꾸지 못했습니다.';
-const _searchHistoryChangeErrorMessage = '최근 검색을 지우지 못했습니다.';
+const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했어요.';
+const _favoriteStationStatusErrorMessage = '즐겨찾기를 확인하지 못했어요.';
+const _favoriteStationChangeErrorMessage = '즐겨찾기를 바꾸지 못했어요.';
+const _searchHistoryChangeErrorMessage = '최근 검색을 지우지 못했어요.';
 
 abstract class StationSearchRepository {
   Future<List<StationSearchResult>> searchStations(String query);
@@ -200,7 +200,7 @@ class MethodChannelCurrentLocationProvider implements CurrentLocationProvider {
       final latitude = _coordinateFrom(response, 'latitude');
       final longitude = _coordinateFrom(response, 'longitude');
       if (latitude == null || longitude == null) {
-        throw const CurrentLocationException('현재 위치를 확인하지 못했습니다.');
+        throw const CurrentLocationException('현재 위치를 확인하지 못했어요.');
       }
       return CurrentLocation(
         latitude: latitude,
@@ -219,7 +219,7 @@ class MethodChannelCurrentLocationProvider implements CurrentLocationProvider {
       throw CurrentLocationException(_locationErrorMessage(error.code));
     } catch (error, stackTrace) {
       reportMobileError(error, stackTrace, context: '현재 위치 조회 중 예외가 발생했습니다.');
-      throw const CurrentLocationException('현재 위치를 확인하지 못했습니다.');
+      throw const CurrentLocationException('현재 위치를 확인하지 못했어요.');
     }
   }
 
@@ -301,8 +301,8 @@ class MethodChannelCurrentLocationProvider implements CurrentLocationProvider {
     return switch (code) {
       'permissionDenied' => '위치 권한을 확인해 주세요.',
       'locationDisabled' => _currentLocationDisabledMessage,
-      'locationUnavailable' => '현재 위치를 확인하지 못했습니다.',
-      _ => '현재 위치를 확인하지 못했습니다.',
+      'locationUnavailable' => '현재 위치를 확인하지 못했어요.',
+      _ => '현재 위치를 확인하지 못했어요.',
     };
   }
 }
@@ -1080,7 +1080,7 @@ class StationSearchController extends ChangeNotifier {
       _state = const StationSearchState(
         status: StationSearchStatus.failure,
         results: [],
-        message: '역 정보를 불러오지 못했습니다.',
+        message: '역 정보를 불러오지 못했어요.',
       );
     }
     _notifyIfActive(requestId);
@@ -1129,7 +1129,7 @@ class StationSearchController extends ChangeNotifier {
         _state = const StationSearchState(
           status: StationSearchStatus.empty,
           results: [],
-          message: '주변 역을 찾지 못했습니다.',
+          message: '주변 역을 찾지 못했어요.',
         );
       } else {
         _state = StationSearchState(
@@ -1168,7 +1168,7 @@ class StationSearchController extends ChangeNotifier {
       _state = const StationSearchState(
         status: StationSearchStatus.failure,
         results: [],
-        message: '역 정보를 불러오지 못했습니다.',
+        message: '역 정보를 불러오지 못했어요.',
       );
     }
     _notifyIfActive(requestId);
@@ -1372,7 +1372,7 @@ class StationDetailController extends ChangeNotifier {
       }
       _state = const StationDetailState(
         status: StationDetailStatus.failure,
-        message: '역 안내를 불러오지 못했습니다.',
+        message: '역 안내를 불러오지 못했어요.',
       );
     } catch (error, stackTrace) {
       reportMobileError(error, stackTrace, context: '역 상세 화면 로드 중 예외가 발생했습니다.');
@@ -1381,7 +1381,7 @@ class StationDetailController extends ChangeNotifier {
       }
       _state = const StationDetailState(
         status: StationDetailStatus.failure,
-        message: '역 안내를 불러오지 못했습니다.',
+        message: '역 안내를 불러오지 못했어요.',
       );
     }
 
@@ -2617,7 +2617,7 @@ class _StationLineFilterSection extends StatelessWidget {
 
         if (snapshot.hasError) {
           return Text(
-            '노선을 불러오지 못했습니다.',
+            '노선을 불러오지 못했어요.',
             style: Theme.of(context).textTheme.bodyLarge?.copyWith(
               color: const Color(0xFF29484B),
               fontWeight: FontWeight.w700,
@@ -3057,7 +3057,7 @@ class _StationSearchBody extends StatelessWidget {
           if (state.source == StationSearchResultSource.nearby) ...[
             if (state.results.isEmpty)
               _StationSearchFailureMessage(
-                message: '주변 역을 찾지 못했습니다.',
+                message: '주변 역을 찾지 못했어요.',
                 isOpeningLocationSettings: isOpeningLocationSettings,
                 onOpenLocationSettings: onOpenLocationSettings,
               )
@@ -3273,8 +3273,8 @@ class _StationSearchFailureMessage extends StatelessWidget {
 bool _shouldShowStationSearchFailureNextAction(String message) {
   return message == '위치 권한을 확인해 주세요.' ||
       message == _currentLocationDisabledMessage ||
-      message == '현재 위치를 확인하지 못했습니다.' ||
-      message == '주변 역을 찾지 못했습니다.';
+      message == '현재 위치를 확인하지 못했어요.' ||
+      message == '주변 역을 찾지 못했어요.';
 }
 
 class _StationSearchMessage extends StatelessWidget {

--- a/apps/mobile/lib/user_data_deletion.dart
+++ b/apps/mobile/lib/user_data_deletion.dart
@@ -7,7 +7,7 @@ import 'core/database/user/user_database.dart';
 import 'core/network/api_client.dart';
 import 'mobile_error_reporter.dart';
 
-const userDataDeletionErrorMessage = '데이터 삭제를 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.';
+const userDataDeletionErrorMessage = '데이터 삭제를 완료하지 못했어요. 잠시 후 다시 시도해 주세요.';
 const _userDataDeletionTimeout = defaultApiTimeout;
 
 abstract class UserDataDeletionRepository {

--- a/apps/mobile/test/facility_report_test.dart
+++ b/apps/mobile/test/facility_report_test.dart
@@ -745,7 +745,7 @@ void main() {
           isA<FacilityReportException>().having(
             (error) => error.message,
             'message',
-            '제보를 보내지 못했습니다.',
+            '제보를 보내지 못했어요.',
           ),
         ),
       );
@@ -785,7 +785,7 @@ void main() {
           isA<FacilityReportException>().having(
             (error) => error.message,
             'message',
-            '제보를 보내지 못했습니다.',
+            '제보를 보내지 못했어요.',
           ),
         ),
       );
@@ -1011,7 +1011,7 @@ void main() {
         isA<FacilityReportException>().having(
           (error) => error.message,
           'message',
-          '처리 상태를 확인하지 못했습니다.',
+          '처리 상태를 확인하지 못했어요.',
         ),
       ),
     );
@@ -1089,7 +1089,7 @@ void main() {
 
     expect(repository.loadedReportIds, ['report-1']);
     expect(controller.state.status, FacilityReportViewStatus.failure);
-    expect(controller.state.message, '처리 상태를 확인하지 못했습니다.');
+    expect(controller.state.message, '처리 상태를 확인하지 못했어요.');
     expect(controller.state.result?.id, 'report-1');
     expect(controller.state.result?.statusLabel, '접수됨');
   });
@@ -1227,7 +1227,7 @@ class FailingRefreshFacilityReportRepository
   @override
   Future<FacilityReportResult> getReport(String reportId) {
     loadedReportIds.add(reportId);
-    return Future.error(const FacilityReportException('처리 상태를 확인하지 못했습니다.'));
+    return Future.error(const FacilityReportException('처리 상태를 확인하지 못했어요.'));
   }
 
   @override

--- a/apps/mobile/test/favorite_facility_test.dart
+++ b/apps/mobile/test/favorite_facility_test.dart
@@ -229,11 +229,11 @@ void main() {
     expect(controller.state.status, FavoriteFacilityListStatus.empty);
     expect(controller.state.message, '즐겨찾기한 시설이 없습니다.');
 
-    repository.error = const FavoriteFacilityException('즐겨찾기 시설을 불러오지 못했습니다.');
+    repository.error = const FavoriteFacilityException('즐겨찾기 시설을 불러오지 못했어요.');
     await controller.load();
 
     expect(controller.state.status, FavoriteFacilityListStatus.failure);
-    expect(controller.state.message, '즐겨찾기 시설을 불러오지 못했습니다.');
+    expect(controller.state.message, '즐겨찾기 시설을 불러오지 못했어요.');
   });
 }
 

--- a/apps/mobile/test/onboarding_test.dart
+++ b/apps/mobile/test/onboarding_test.dart
@@ -296,7 +296,7 @@ void main() {
 
   testWidgets('온보딩은 알림 권한 요청 실패 도움말을 안내한다', (tester) async {
     final notificationPermissionProvider = _FakeNotificationPermissionProvider(
-      error: const NotificationSettingsException('알림 권한을 확인하지 못했습니다.'),
+      error: const NotificationSettingsException('알림 권한을 확인하지 못했어요.'),
     );
     OnboardingResult? completedResult;
 

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -148,7 +148,7 @@ void main() {
         isA<InternalRouteException>().having(
           (error) => error.message,
           'message',
-          '역 안 이동 안내를 불러오지 못했습니다.',
+          '역 안 이동 안내를 불러오지 못했어요.',
         ),
       ),
     );
@@ -322,7 +322,7 @@ void main() {
     expect(controller.state.status, RouteSearchViewStatus.failure);
     expect(controller.state.message, '출발역과 도착역을 입력해 주세요.');
 
-    repository.error = const RouteSearchException('경로 정보를 불러오지 못했습니다.');
+    repository.error = const RouteSearchException('경로 정보를 불러오지 못했어요.');
 
     await controller.search(
       const RouteSearchRequest(
@@ -337,7 +337,7 @@ void main() {
     expect(repository.requests.single.destinationStationId, 'station-sadang');
     expect(repository.requests.single.mobilityType, 'SENIOR');
     expect(controller.state.status, RouteSearchViewStatus.failure);
-    expect(controller.state.message, '경로 정보를 불러오지 못했습니다.');
+    expect(controller.state.message, '경로 정보를 불러오지 못했어요.');
   });
 
   test('경로 검색 컨트롤러는 화면 종료 후 비동기 결과를 알리지 않는다', () async {

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -454,7 +454,7 @@ void main() {
           isA<StationSearchException>().having(
             (error) => error.message,
             'message',
-            '역 정보를 불러오지 못했습니다.',
+            '역 정보를 불러오지 못했어요.',
           ),
         ),
       );
@@ -857,7 +857,7 @@ void main() {
           isA<StationSearchException>().having(
             (error) => error.message,
             'message',
-            '역 정보를 불러오지 못했습니다.',
+            '역 정보를 불러오지 못했어요.',
           ),
         ),
       );
@@ -963,12 +963,12 @@ void main() {
     expect(controller.state.status, StationSearchStatus.empty);
     expect(controller.state.message, '검색 결과가 없습니다.');
 
-    repository.error = const StationSearchException('역 정보를 불러오지 못했습니다.');
+    repository.error = const StationSearchException('역 정보를 불러오지 못했어요.');
 
     await controller.search('상록수');
 
     expect(controller.state.status, StationSearchStatus.failure);
-    expect(controller.state.message, '역 정보를 불러오지 못했습니다.');
+    expect(controller.state.message, '역 정보를 불러오지 못했어요.');
   });
 
   test('역 검색 컨트롤러는 현재 위치 주변 역을 거리와 함께 표시한다', () async {
@@ -1267,7 +1267,7 @@ void main() {
 
     expect(reportedErrors, isEmpty);
     expect(controller.state.status, StationDetailStatus.failure);
-    expect(controller.state.message, '역 안내를 불러오지 못했습니다.');
+    expect(controller.state.message, '역 안내를 불러오지 못했어요.');
   });
 
   test('역 상세 상태는 확인이 필요한 시설을 먼저 보여 주고 짧은 요약을 만든다', () {
@@ -1371,11 +1371,11 @@ void main() {
     expect(controller.state.status, FavoriteStationListStatus.empty);
     expect(controller.state.message, '즐겨찾기한 역이 없습니다.');
 
-    repository.error = const FavoriteStationException('즐겨찾기를 불러오지 못했습니다.');
+    repository.error = const FavoriteStationException('즐겨찾기를 불러오지 못했어요.');
     await controller.load();
 
     expect(controller.state.status, FavoriteStationListStatus.failure);
-    expect(controller.state.message, '즐겨찾기를 불러오지 못했습니다.');
+    expect(controller.state.message, '즐겨찾기를 불러오지 못했어요.');
   });
 
   test('역 상세 즐겨찾기 컨트롤러는 저장과 해제를 순서대로 처리한다', () async {
@@ -1860,7 +1860,7 @@ class FailingStationDetailRepository implements StationSearchRepository {
 
   @override
   Future<StationDetail> getStationDetail(String stationId) async {
-    throw const StationSearchException('역 정보를 불러오지 못했습니다.');
+    throw const StationSearchException('역 정보를 불러오지 못했어요.');
   }
 
   @override
@@ -1921,7 +1921,7 @@ class FailingRealtimeRepository implements RealtimeRepository {
 
   @override
   Future<RealtimeSnapshot> arrivals(RealtimeStationQuery query) async {
-    throw const RealtimeException('실시간 정보를 불러오지 못했습니다.');
+    throw const RealtimeException('실시간 정보를 불러오지 못했어요.');
   }
 }
 

--- a/apps/mobile/test/user_data_deletion_test.dart
+++ b/apps/mobile/test/user_data_deletion_test.dart
@@ -179,7 +179,7 @@ void main() {
         isA<UserDataDeletionException>().having(
           (error) => error.message,
           'message',
-          '데이터 삭제를 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+          '데이터 삭제를 완료하지 못했어요. 잠시 후 다시 시도해 주세요.',
         ),
       ),
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -523,7 +523,7 @@ void main() {
     expect(onboardingStore.savedResult, isNull);
     expect(find.byKey(const Key('onboardingIntroSkipButton')), findsOneWidget);
     expect(find.byType(HomeScreen), findsNothing);
-    expect(find.text('설정을 저장하지 못했습니다. 다시 시도해 주세요.'), findsOneWidget);
+    expect(find.text('설정을 저장하지 못했어요. 다시 시도해 주세요.'), findsOneWidget);
   });
 
   testWidgets('온보딩 보기 설정은 완료 뒤 홈 UI에 적용된다', (tester) async {
@@ -3215,7 +3215,7 @@ void main() {
 
   testWidgets('가까운 역 화면은 위치 실패 후 역명 검색 입력을 보여준다', (tester) async {
     final locationProvider = FakeCurrentLocationProvider(
-      error: const CurrentLocationException('현재 위치를 확인하지 못했습니다.'),
+      error: const CurrentLocationException('현재 위치를 확인하지 못했어요.'),
       needsPermissionRequest: false,
     );
     final repository = FakeStationSearchRepository(
@@ -3242,7 +3242,7 @@ void main() {
     await tester.tap(find.byKey(const Key('nearbyStationButton')));
     await tester.pumpAndSettle();
 
-    expect(find.text('현재 위치를 확인하지 못했습니다.'), findsOneWidget);
+    expect(find.text('현재 위치를 확인하지 못했어요.'), findsOneWidget);
     expect(find.byKey(const Key('stationSearchInput')), findsOneWidget);
     expect(find.byKey(const Key('nearbyStationSearchButton')), findsOneWidget);
     expect(find.byKey(const Key('stationRecentSearchSection')), findsNothing);
@@ -3418,7 +3418,7 @@ void main() {
 
   testWidgets('홈은 저장 경로 재조회 실패를 즐겨찾기 카드로 표시하지 않는다', (tester) async {
     final favoriteRouteRepository = FakeFavoriteRouteRepository()
-      ..error = const FavoriteRouteException('즐겨찾기 경로를 불러오지 못했습니다.');
+      ..error = const FavoriteRouteException('즐겨찾기 경로를 불러오지 못했어요.');
 
     await tester.pumpWidget(
       EasySubwayApp(
@@ -3442,7 +3442,7 @@ void main() {
     await tester.binding.handlePopRoute();
     await tester.pumpAndSettle();
 
-    expect(find.text('즐겨찾기한 경로를 불러오지 못했습니다'), findsNothing);
+    expect(find.text('즐겨찾기한 경로를 불러오지 못했어요'), findsNothing);
     expect(find.widgetWithText(OutlinedButton, '즐겨찾기 경로 보기'), findsNothing);
   });
 
@@ -3746,7 +3746,7 @@ void main() {
       find.bySemanticsLabel(RegExp('큰 글자, 켜짐, .*두 번 탭해 끄기')),
       findsOneWidget,
     );
-    expect(find.text('설정을 저장하지 못했습니다. 이전 값으로 되돌렸어요.'), findsOneWidget);
+    expect(find.text('설정을 저장하지 못했어요. 이전 값으로 되돌렸어요.'), findsOneWidget);
   });
 
   testWidgets('설정 화면 이동 조건 저장 실패는 이전 조건으로 되돌린다', (tester) async {
@@ -3788,7 +3788,7 @@ void main() {
     expect(onboardingStore.savedResult?.profile.id, 'elderly');
     expect(find.text('계단 피하기 · 환승 줄이기 적용 중'), findsOneWidget);
     expect(find.text('계단 없는 길만 안내해요'), findsNothing);
-    expect(find.text('이동 조건을 저장하지 못했습니다. 이전 조건으로 되돌렸어요.'), findsOneWidget);
+    expect(find.text('이동 조건을 저장하지 못했어요. 이전 조건으로 되돌렸어요.'), findsOneWidget);
   });
 
   testWidgets('설정 화면 보기 옵션은 빠른 연속 변경에서도 마지막 값을 저장한다', (tester) async {
@@ -3919,7 +3919,7 @@ void main() {
       find.bySemanticsLabel(RegExp('간편 보기, 꺼짐, .*두 번 탭해 켜기')),
       findsOneWidget,
     );
-    expect(find.text('설정을 저장하지 못했습니다. 이전 값으로 되돌렸어요.'), findsNothing);
+    expect(find.text('설정을 저장하지 못했어요. 이전 값으로 되돌렸어요.'), findsNothing);
   });
 
   testWidgets('설정 화면 보기 옵션 마지막 queued 저장 실패는 마지막 변경만 되돌린다', (tester) async {
@@ -3982,7 +3982,7 @@ void main() {
       find.bySemanticsLabel(RegExp('고대비, 꺼짐, .*두 번 탭해 켜기')),
       findsOneWidget,
     );
-    expect(find.text('설정을 저장하지 못했습니다. 이전 값으로 되돌렸어요.'), findsOneWidget);
+    expect(find.text('설정을 저장하지 못했어요. 이전 값으로 되돌렸어요.'), findsOneWidget);
   });
 
   testWidgets('설정 화면 보기 옵션 연속 저장 실패는 마지막 저장값으로 되돌린다', (tester) async {
@@ -4047,7 +4047,7 @@ void main() {
       find.bySemanticsLabel(RegExp('고대비, 꺼짐, .*두 번 탭해 켜기')),
       findsOneWidget,
     );
-    expect(find.text('설정을 저장하지 못했습니다. 이전 값으로 되돌렸어요.'), findsOneWidget);
+    expect(find.text('설정을 저장하지 못했어요. 이전 값으로 되돌렸어요.'), findsOneWidget);
   });
 
   testWidgets('설정 화면 보기 옵션 저장 중 이동 조건을 바꿔도 마지막 결과를 유지한다', (tester) async {
@@ -4885,7 +4885,7 @@ void main() {
   testWidgets('데이터 삭제 실패 시 로컬 상태를 유지하고 오류를 안내한다', (tester) async {
     final deletionRepository = FakeUserDataDeletionRepository(
       error: const UserDataDeletionException(
-        '데이터 삭제를 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+        '데이터 삭제를 완료하지 못했어요. 잠시 후 다시 시도해 주세요.',
       ),
     );
     final onboardingStore = MemoryOnboardingResultStore(
@@ -4932,7 +4932,7 @@ void main() {
     expect(deletionRepository.deleteCount, 1);
     expect(onboardingStore.savedResult, isNotNull);
     expect(draftTargetStore.target, isNotNull);
-    expect(find.text('데이터 삭제를 완료하지 못했습니다. 잠시 후 다시 시도해 주세요.'), findsOneWidget);
+    expect(find.text('데이터 삭제를 완료하지 못했어요. 잠시 후 다시 시도해 주세요.'), findsOneWidget);
   });
 
   testWidgets('도움말은 연결값이 비어 있으면 준비 중으로 보여주고 실행하지 않는다', (tester) async {
@@ -5202,7 +5202,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(notificationPermissionProvider.requestCount, 1);
-      expect(find.text('기기 알림 등록을 마치지 못했습니다.'), findsNothing);
+      expect(find.text('기기 알림 등록을 마치지 못했어요.'), findsNothing);
       expect(find.text('알림을 켜지 못했어요.'), findsOneWidget);
       expect(
         find.text('휴대전화 알림 설정과 인터넷 연결을 확인한 뒤 다시 시도해 주세요.'),
@@ -5607,7 +5607,7 @@ void main() {
   testWidgets('즐겨찾기 경로 목록 실패는 도움말을 쉬운 문구로 안내한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final favoriteRouteRepository = FakeFavoriteRouteRepository()
-      ..error = const FavoriteRouteException('즐겨찾기 경로를 불러오지 못했습니다.');
+      ..error = const FavoriteRouteException('즐겨찾기 경로를 불러오지 못했어요.');
 
     try {
       await tester.pumpWidget(
@@ -5619,7 +5619,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('즐겨찾기 경로를 불러오지 못했습니다.'), findsOneWidget);
+      expect(find.text('즐겨찾기 경로를 불러오지 못했어요.'), findsOneWidget);
       expect(find.text('네트워크 상태를 확인한 뒤 다시 불러와 주세요.'), findsOneWidget);
       expect(
         find.bySemanticsLabel('도움말, 네트워크 상태를 확인한 뒤 다시 불러와 주세요.'),
@@ -9094,7 +9094,7 @@ void main() {
       },
     );
     final favoriteRouteRepository = FakeFavoriteRouteRepository()
-      ..error = const FavoriteRouteException('즐겨찾기 경로를 처리하지 못했습니다.');
+      ..error = const FavoriteRouteException('즐겨찾기 경로를 처리하지 못했어요.');
 
     try {
       await tester.pumpWidget(
@@ -9149,7 +9149,7 @@ void main() {
       await tester.tap(find.byKey(const Key('routeFavoriteSaveButton')));
       await tester.pumpAndSettle();
 
-      expect(find.text('즐겨찾기 경로를 처리하지 못했습니다.'), findsOneWidget);
+      expect(find.text('즐겨찾기 경로를 처리하지 못했어요.'), findsOneWidget);
       expect(
         find.text('네트워크 상태를 확인한 뒤 자주 쓰는 경로 저장을 다시 눌러 주세요.'),
         findsOneWidget,
@@ -9569,7 +9569,7 @@ void main() {
       },
     );
     final routeFeedbackRepository = FakeRouteFeedbackRepository()
-      ..error = const RouteFeedbackException('의견을 보내지 못했습니다.');
+      ..error = const RouteFeedbackException('의견을 보내지 못했어요.');
 
     try {
       await tester.pumpWidget(
@@ -9630,7 +9630,7 @@ void main() {
       await tester.tap(find.byKey(const Key('routeFeedbackNotHelpfulButton')));
       await tester.pumpAndSettle();
 
-      expect(find.text('의견을 보내지 못했습니다.'), findsOneWidget);
+      expect(find.text('의견을 보내지 못했어요.'), findsOneWidget);
       expect(find.text('잠시 후 다시 보내거나 경로 조건을 바꿔 다시 찾아보세요.'), findsOneWidget);
       expect(
         find.bySemanticsLabel('도움말, 잠시 후 다시 보내거나 경로 조건을 바꿔 다시 찾아보세요.'),
@@ -9653,7 +9653,7 @@ void main() {
       routeFeedbackRepository.requests.single.rating,
       RouteFeedbackRating.notHelpful,
     );
-    expect(find.text('의견을 보내지 못했습니다.'), findsOneWidget);
+    expect(find.text('의견을 보내지 못했어요.'), findsOneWidget);
   });
 
   testWidgets('경로 안내 칩은 좁은 화면과 큰 글자에서도 넘치지 않는다', (tester) async {
@@ -9777,7 +9777,7 @@ void main() {
       },
     );
     final routeRepository = FakeRouteSearchRepository(
-      error: const RouteSearchException('경로 정보를 불러오지 못했습니다.'),
+      error: const RouteSearchException('경로 정보를 불러오지 못했어요.'),
     );
 
     try {
@@ -9824,7 +9824,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(routeRepository.requests, hasLength(1));
-      expect(find.text('경로 정보를 불러오지 못했습니다.'), findsOneWidget);
+      expect(find.text('경로 정보를 불러오지 못했어요.'), findsOneWidget);
       expect(
         find.text('역을 다시 선택하거나 이동 조건을 바꾼 뒤 경로를 다시 찾아보세요.'),
         findsOneWidget,
@@ -10159,7 +10159,7 @@ void main() {
   testWidgets('시설 신고 실패는 도움말을 쉬운 문구로 안내한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final reportRepository = FakeFacilityReportRepository()
-      ..error = const FacilityReportException('신고를 보내지 못했습니다.');
+      ..error = const FacilityReportException('신고를 보내지 못했어요.');
 
     try {
       await tester.pumpWidget(
@@ -10192,7 +10192,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(reportRepository.requests, hasLength(1));
-      expect(find.text('신고를 보내지 못했습니다.'), findsOneWidget);
+      expect(find.text('신고를 보내지 못했어요.'), findsOneWidget);
       expect(find.text('내용을 확인한 뒤 네트워크 상태를 보고 다시 보내 주세요.'), findsOneWidget);
       expect(
         find.bySemanticsLabel('도움말, 내용을 확인한 뒤 네트워크 상태를 보고 다시 보내 주세요.'),
@@ -11520,7 +11520,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('위치 권한을 허용해 주세요.'), findsOneWidget);
-    expect(find.text('현재 위치를 확인하지 못했습니다.'), findsNothing);
+    expect(find.text('현재 위치를 확인하지 못했어요.'), findsNothing);
     final failedLocationSubmitButton = tester.widget<FilledButton>(
       find.byKey(const Key('facilityReportSubmitButton')),
     );

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -7772,7 +7772,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.match(userDataDeletion, /refreshExistingAuthorization/);
   assert.match(
     userDataDeletion,
-    /userDataDeletionErrorMessage = '데이터 삭제를 완료하지 못했습니다\. 잠시 후 다시 시도해 주세요\.'/,
+    /userDataDeletionErrorMessage = '데이터 삭제를 완료하지 못했어요\. 잠시 후 다시 시도해 주세요\.'/,
   );
   assert.match(userDataDeletionTest, /인증 헤더로 DELETE \/api\/v1\/me를 호출한다/);
   assert.match(userDataDeletionTest, /기존 인증 갱신 실패 시 새 사용자 삭제로 처리하지 않는다/);


### PR DESCRIPTION
## 관련 이슈

#1075 후속 반영

이번 PR은 #1075의 사용자 문구 정리 중 실패 안내 톤을 좁게 다룹니다. #1075 전체 조건을 닫지는 않습니다.

## 작업 배경

QA 요청에 따라 앱 화면에 개발용어처럼 보이거나 사용자에게 딱딱하게 느껴지는 표현을 줄입니다. 이번 변경은 오류와 실패 안내에서 `...못했습니다` 톤을 `...못했어요`로 맞춰, 역 검색·경로 검색·제보·알림·데이터 삭제 흐름의 안내를 더 쉽게 읽히게 합니다.

## 작업 내용

- 모바일 오류 안내 문구의 `...못했습니다` 표현을 `...못했어요` 톤으로 정리했습니다.
- 서버가 예전 차단 사유 문구를 내려줘도 기존 쉬운 안내로 바뀌도록 경로 사유 정규화를 유지했습니다.
- 문구 변경에 맞춰 컨트롤러와 위젯 테스트 기대값을 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter analyze`: exit 0, No issues found
  - `flutter test test/route_search_test.dart test/station_search_test.dart test/favorite_facility_test.dart test/facility_report_test.dart test/user_data_deletion_test.dart test/onboarding_test.dart --reporter expanded`: exit 0, 118 tests passed
  - `flutter test test/widget_test.dart --reporter expanded`: exit 0, 186 tests passed
  - `node --test --test-name-pattern "모바일 generic catch" tools/ci/repository-contract.test.mjs`: exit 0, 대상 contract 통과
  - `git diff --check`: exit 0
  - `rg -n "못했습니다|기본정보|기본 정보만 있음|상세정보|상세 정보|이동 점수|정보 신뢰도|[0-9]+점" apps/mobile/lib apps/mobile/test --glob '!**/*.g.dart'`: 앱 코드에는 사용자 노출 문구 없음, 테스트의 금지 문구 가드와 `findsNothing` 기대값만 검색됨
  - CI / Release Gate Consistency: 통과
  - CI / Mobile App CI: 통과
  - CI / Android CI: 통과
  - Release Artifacts / Android Release Artifact: 통과

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 실패 안내 문구 분석 | Flutter | `flutter analyze` | 로컬 명령 출력 | 통과 |
| 실패 안내 단위 테스트 | Flutter | 관련 단위 테스트 6개 파일 실행 | 로컬 명령 출력, 118 tests passed | 통과 |
| 사용자 문구 가드 포함 위젯 테스트 | Flutter | `test/widget_test.dart` 전체 실행 | 로컬 명령 출력, 186 tests passed | 통과 |
| release 문구 contract | Node 24 CI | Release Gate Consistency | https://github.com/AquilaXk/easysubway/actions/runs/28405208109 | 통과 |
| 모바일 CI | GitHub Actions | Mobile App CI, Android CI | https://github.com/AquilaXk/easysubway/actions/runs/28405208109 | 통과 |
| release artifact | GitHub Actions | Android Release Artifact, RC Evidence Manifest | https://github.com/AquilaXk/easysubway/actions/runs/28405207783 | 통과 |
| 어려운 문구 검색 | Flutter | 금지 문구 `rg` 검색 | 앱 코드에는 노출 문구 없음, 테스트 가드만 검색 | 통과 |
| 화면 증거 | Android/iOS | 문구만 바꾸는 변경이라 레이아웃·동선 변화 없음 | 증거 불필요 사유: UI 구조와 화면 배치 변경 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/route_search.dart`의 차단 사유 정규화가 예전 서버 문구를 쉬운 문구로 유지하는지
  - `apps/mobile/test/user_copy_guard.dart`의 금지 문구 가드와 이번 검색 결과가 맞는지
  - CodeRabbit 리뷰가 rate limit으로 실제 시작되지 않아 Codex CLI fallback review를 PR review로 남겼습니다.
  - 로컬 전체 `node --test tools/ci/repository-contract.test.mjs`는 로컬 Node 20의 `node:sqlite` 미지원으로 datapack audit에서 실패했습니다. CI는 Node 24에서 같은 release gate 전체가 통과했습니다.

## 리스크

- 오류 문구 톤 변경이라 기능 리스크는 낮습니다.
- 서버가 보내는 예전 한국어 사유 문구는 정규화로 계속 지원합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
