### PR TITLE
[Fix] 큰 글씨 경계 폭에서 1열 유지

### DIFF
--- a/apps/mobile/lib/adaptive_layout.dart
+++ b/apps/mobile/lib/adaptive_layout.dart
@@ -8,7 +8,11 @@ class EasySubwayAdaptiveLayout {
   static const double largeScreenGutter = 24;
   static const double largeScreenColumnGap = 18;
 
-  static bool isLargeScreen(BoxConstraints constraints) {
-    return constraints.maxWidth >= largeScreenMinWidth;
+  static bool isLargeScreen(
+    BoxConstraints constraints, {
+    double textScaleFactor = 1,
+  }) {
+    final minWidth = textScaleFactor >= 1.6 ? 1024 : largeScreenMinWidth;
+    return constraints.maxWidth >= minWidth;
   }
 }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1693,6 +1693,7 @@ class _HomeScreenState extends State<HomeScreen> {
           builder: (context, constraints) {
             final isLargeScreen = EasySubwayAdaptiveLayout.isLargeScreen(
               constraints,
+              textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
             );
             return RefreshIndicator(
               key: const Key('homeRefreshIndicator'),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -2079,6 +2079,7 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
           builder: (context, constraints) {
             final isLargeScreen = EasySubwayAdaptiveLayout.isLargeScreen(
               constraints,
+              textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
             );
             return ListView(
               padding: isLargeScreen
@@ -4191,6 +4192,7 @@ class _StationDetailContent extends StatelessWidget {
       builder: (context, constraints) {
         final isLargeScreen = EasySubwayAdaptiveLayout.isLargeScreen(
           constraints,
+          textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
         );
         return ListView(
           key: const Key('stationDetailList'),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3378,6 +3378,7 @@ void main() {
       final homeContext = tester.element(find.byType(HomeScreen));
       expect(MediaQuery.of(homeContext).highContrast, isTrue);
       expect(tester.takeException(), isNull);
+      expect(find.byKey(const Key('homeLargeScreenLayout')), findsNothing);
       expect(find.byKey(const Key('routeSearchButton')), findsOneWidget);
       expect(find.byKey(const Key('heroStationSearchButton')), findsOneWidget);
       expect(find.byKey(const Key('homeBottomNavigationBar')), findsOneWidget);
@@ -6704,7 +6705,7 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(
       find.byKey(const Key('stationSearchLargeScreenLayout')),
-      findsOneWidget,
+      findsNothing,
     );
     expect(
       find.byKey(const Key('stationSearchResult-station-transfer')),
@@ -7748,36 +7749,40 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
       await tester.pumpAndSettle();
+      await tester.ensureVisible(
+        find.byKey(const Key('stationSearchResult-station-sangnoksu')),
+      );
+      await tester.pumpAndSettle();
       await tester.tap(
         find.byKey(const Key('stationSearchResult-station-sangnoksu')),
       );
       await tester.pumpAndSettle();
 
       expect(tester.takeException(), isNull);
+      expect(find.byKey(const Key('stationDetailList')), findsOneWidget);
       expect(
         find.byKey(const Key('stationDetailLargeScreenLayout')),
-        findsOneWidget,
+        findsNothing,
       );
-      expect(
-        find.byKey(const Key('stationFacilityCard-facility-normal')),
-        findsOneWidget,
-      );
-      await tester.scrollUntilVisible(
-        find.byKey(const Key('stationFacilityCard-facility-broken')),
-        120,
-        scrollable: find.byType(Scrollable).last,
-      );
-      await tester.pumpAndSettle();
-      await tester.scrollUntilVisible(
-        find.byKey(const Key('stationFacilityCard-facility-needs-check')),
-        120,
-        scrollable: find.byType(Scrollable).last,
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.text('이용 가능'), findsOneWidget);
-      expect(find.text('이용할 수 없어요'), findsOneWidget);
-      expect(find.text('상태 정보가 부족해요'), findsOneWidget);
+      var sawNormal = false;
+      var sawBroken = false;
+      var sawNeedsCheck = false;
+      for (var index = 0; index < 8; index += 1) {
+        sawNormal |= find.text('이용 가능').evaluate().isNotEmpty;
+        sawBroken |= find.text('이용할 수 없어요').evaluate().isNotEmpty;
+        sawNeedsCheck |= find.text('상태 정보가 부족해요').evaluate().isNotEmpty;
+        if (sawNormal && sawBroken && sawNeedsCheck) {
+          break;
+        }
+        await tester.drag(
+          find.byKey(const Key('stationDetailList')),
+          const Offset(0, -260),
+        );
+        await tester.pumpAndSettle();
+      }
+      expect(sawNormal, isTrue);
+      expect(sawBroken, isTrue);
+      expect(sawNeedsCheck, isTrue);
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
     } finally {


### PR DESCRIPTION
## 관련 이슈

refs #1075
refs #1073

이 PR은 #1075 전체를 닫지 않고, 큰 글씨 경계 폭에서 2열 레이아웃이 과밀해질 수 있는 항목만 보강합니다.

## 작업 배경

- #1073은 840~900px 경계 폭과 OS 큰 글씨 조건에서 홈, 역 검색, 역 상세가 렌더링 예외 없이 표시되어야 한다고 정의했습니다.
- 기존 helper는 글자 크기를 보지 않고 840px부터 대화면 2열을 켜서, 900px + 200% 글자 조건에서도 좁은 2열이 유지될 수 있었습니다.
- QA 요청에 따라 어려운 내부 용어를 추가하지 않고, 화면 구조만 안전한 1열로 낮춥니다.

## 작업 내용

- `EasySubwayAdaptiveLayout.isLargeScreen`이 `textScaleFactor >= 1.6`일 때 1024px 이상에서만 대화면 2열을 켜도록 조정했습니다.
- 홈, 역 검색, 역 상세가 현재 `MediaQuery.textScaler` 값을 layout helper에 넘기도록 연결했습니다.
- 900x800 + 200% 글자 + 고대비 조건 테스트는 대화면 2열 대신 1열 fallback을 기대하도록 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/adaptive_layout.dart apps/mobile/lib/main.dart apps/mobile/lib/station_search.dart apps/mobile/test/widget_test.dart`: exit 0
  - `flutter test test/widget_test.dart --name "홈 대화면은 시스템 고대비|역 검색 대화면은 경계 폭|역 상세 대화면은 큰 글씨" --reporter expanded`: exit 0, 3 tests passed
  - `flutter analyze`: exit 0, No issues found
  - `flutter test test/widget_test.dart --reporter expanded`: exit 0, 186 tests passed
  - `node --test --test-name-pattern "모바일 스토어 심사 정보 기준선" tools/ci/repository-contract.test.mjs`: exit 0, target contract passed
  - `git diff --check`: exit 0
  - GitHub Actions CI: success, https://github.com/AquilaXk/easysubway/actions/runs/28406289118
  - GitHub Actions SonarCloud: success, https://github.com/AquilaXk/easysubway/actions/runs/28406288819
  - GitHub Actions Release Artifacts: success, https://github.com/AquilaXk/easysubway/actions/runs/28406288815
  - CodeRabbit: review limit으로 실제 리뷰 미시작
  - Codex CLI fallback review: actionable 0건, https://github.com/AquilaXk/easysubway/pull/1147#pullrequestreview-4595768970

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 홈 큰 글씨 경계 폭 | Flutter widget | 900x800, text scale 2.0, 시스템 고대비에서 핵심 CTA와 하단 탭 확인 | `flutter test test/widget_test.dart --name "홈 대화면은 시스템 고대비|역 검색 대화면은 경계 폭|역 상세 대화면은 큰 글씨"` 로컬 로그 | 1열 fallback 상태에서 핵심 CTA 유지 |
| 역 검색 큰 글씨 경계 폭 | Flutter widget | 900x800, text scale 2.0, 긴 노선명 fixture 확인 | 같은 로컬 테스트 로그 | 1열 fallback 상태에서 검색 결과와 필터 렌더링 |
| 역 상세 큰 글씨 경계 폭 | Flutter widget | 900x800, text scale 2.0, 시설 상태 3종 스크롤 확인 | 같은 로컬 테스트 로그 | 1열 fallback 상태에서 시설 상태 3종 노출 |
| 접근성 guideline | Flutter widget | Android tap target, labeled tap target guideline 실행 | 같은 로컬 테스트 로그 | guideline 통과 |
| 스토어 대화면 evidence contract | repository | large screen required evidence fields 기준선 확인 | `node --test --test-name-pattern "모바일 스토어 심사 정보 기준선" tools/ci/repository-contract.test.mjs` 로컬 로그 | contract 통과 |
| 스크린샷 | Android/iOS | 증거 불필요 사유 | 이번 변경은 렌더링 분기와 widget/accessibility guideline 회귀 테스트 보강이며, 새 화면 copy나 시각 자산을 추가하지 않음 | 테스트 로그로 대체 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/adaptive_layout.dart`
- 1024px 기준은 큰 글씨 경계 폭인 840~900px에서 2열을 끄고, 기존 1280px 태블릿 landscape 2열은 유지하기 위한 최소 기준입니다.

## 리스크

- 900px 폭에서 큰 글씨를 쓰는 사용자는 2열 대신 1열 스크롤을 보게 됩니다.
- 의도한 trade-off는 정보 과밀보다 읽기 안전을 우선하는 것입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
