### PR TITLE
[Test] 홈 shell 상태 회귀 계약 추가

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -879,6 +879,25 @@ test("노선도 탭 화면은 자체 하단 NavigationBar를 만들지 않는다
   );
 });
 
+test("모바일 홈 shell과 주요 상태 UI 회귀 테스트는 유지된다", () => {
+  const main = read("apps/mobile/lib/main.dart");
+  const widgetTest = read("apps/mobile/test/widget_test.dart");
+
+  assert.match(main, /selectedIndex:\s*_selectedTabIndex/);
+  assert.doesNotMatch(main, /selectedIndex:\s*[0-9]/);
+  assert.match(widgetTest, /홈 노선도 탭은 같은 shell 안에서 선택 상태를 바꾼다/);
+  assert.match(widgetTest, /홈 하단 탭은 길찾기 즐겨찾기 더보기를 같은 shell에서 전환한다/);
+  assert.match(widgetTest, /홈 하단 루트 탭에서 시스템 뒤로가기는 홈으로 돌아온다/);
+  assert.match(widgetTest, /홈은 시설 알림과 최근 경로 로드 실패를 화면에 보여준다/);
+  assert.match(widgetTest, /노선도 로드 실패는 재시도와 역 검색 대안을 보여준다/);
+  assert.match(main, /homeFacilityAlertLoadingState/);
+  assert.match(main, /homeFacilityAlertErrorState/);
+  assert.match(main, /homeFacilityAlertEmptyState/);
+  assert.match(main, /homeRecentRouteLoadingState/);
+  assert.match(main, /homeRecentRouteErrorState/);
+  assert.match(main, /homeRecentRouteEmptyState/);
+});
+
 test("Android 권한 파서는 속성 순서와 추가 속성이 달라도 권한명을 추출한다", () => {
   const permissions = androidManifestPermissions(`
     <manifest xmlns:android="http://schemas.android.com/apk/res/android">


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- #1075의 P0 항목 중 홈 shell navigation, 하단 탭 선택 상태, 홈 시설 알림/최근 경로 상태 UI, 노선도 실패 복구 UI는 이미 구현과 widget test가 들어와 있다.
- 이번 PR은 해당 회귀 테스트가 빠지거나 하단 탭 선택 상태가 다시 하드코딩되는 일을 CI에서 막는다.

## 작업 내용

- repository contract에 홈 shell/상태 UI 회귀 계약을 추가했다.
- `selectedIndex`가 숫자 하드코딩이 아니라 `_selectedTabIndex`로 관리되는지 검사한다.
- 홈 shell 탭 전환, 루트 탭 시스템 뒤로가기, 홈 시설 알림/최근 경로 실패 상태, 노선도 실패 재시도 테스트가 유지되는지 검사한다.
- 홈 시설 알림과 최근 경로의 loading/error/empty 상태 key가 production 코드에 남아 있는지 검사한다.

## 검증

- 실행한 명령과 결과:
- `node --test --test-name-pattern "모바일 홈 shell과 주요 상태 UI|노선도 탭 화면" tools/ci/repository-contract.test.mjs`: exit 0, 대상 2개 테스트 통과
- `flutter test test/widget_test.dart --name "홈 노선도 탭은 같은 shell|홈 하단 탭은 길찾기|홈 하단 루트 탭|홈은 시설 알림과 최근 경로 로드 실패|노선도 로드 실패는 재시도" --reporter expanded`: exit 0, 5개 테스트 통과
- `git diff --check`: exit 0
- GitHub Actions PR checks: all required checks pass
- Codex CLI fallback review: actionable comments 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| shell/상태 UI 계약 | local CI | `node --test --test-name-pattern "모바일 홈 shell과 주요 상태 UI|노선도 탭 화면" tools/ci/repository-contract.test.mjs` | 명령 출력 | 통과 |
| 실제 widget 회귀 테스트 | Flutter test | `flutter test test/widget_test.dart --name "홈 노선도 탭은 같은 shell|홈 하단 탭은 길찾기|홈 하단 루트 탭|홈은 시설 알림과 최근 경로 로드 실패|노선도 로드 실패는 재시도" --reporter expanded` | 명령 출력 | 통과 |
| 패치 형식 | local | `git diff --check` | 명령 출력 | 통과 |
| PR CI | GitHub Actions | `gh pr checks 1149 --watch=false` | PR #1149 check list | 통과 |
| 코드 리뷰 | GitHub PR review | CodeRabbit 상태 확인 후 Codex CLI fallback review 게시 | PR #1149 review 기록 | actionable 0 |
| 화면 증거 | mobile | 증거 불필요 사유: 화면 UI 동작을 바꾸지 않고 기존 widget test와 CI 계약만 고정함 | 해당 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 새 contract가 구현 세부 전체를 고정하지 않고 #1075 P0 회귀 신호만 좁게 잡는지 확인해 주세요.

## 리스크

- 테스트 이름을 바꾸는 리팩터링도 contract 실패를 만들 수 있다. 의도적인 이름 변경이면 contract도 함께 갱신해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
