### PR TITLE
[Test] 경로 단계 뒤로가기 회귀 계약 추가

### DIFF
--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -8789,6 +8789,42 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('이동 순서'), findsOneWidget);
     expect(find.byKey(const Key('routeStartGuidanceButton')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('routeStartGuidanceButton')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+      find.byKey(const Key('routeOpenInternalRouteButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeOpenInternalRouteButton')));
+    await tester.pumpAndSettle();
+    expect(find.text('역 안 이동 순서'), findsOneWidget);
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+    expect(find.text('전체 순서'), findsWidgets);
+    expect(
+      find.byKey(const Key('routeOpenInternalRouteButton')),
+      findsOneWidget,
+    );
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+    expect(find.text('이동 순서'), findsOneWidget);
+    expect(find.byKey(const Key('routeOpenFeedbackButton')), findsOneWidget);
+
+    await tester.ensureVisible(
+      find.byKey(const Key('routeOpenFeedbackButton')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeOpenFeedbackButton')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('routeFeedbackHelpfulButton')), findsOneWidget);
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+    expect(find.text('이동 순서'), findsOneWidget);
+    expect(find.byKey(const Key('routeOpenFeedbackButton')), findsOneWidget);
   });
 
   testWidgets('경로 검색 단순 보기를 끄면 화면에서 이동 조건을 바꿀 수 있다', (tester) async {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -898,6 +898,21 @@ test("모바일 홈 shell과 주요 상태 UI 회귀 테스트는 유지된다",
   assert.match(main, /homeRecentRouteEmptyState/);
 });
 
+test("모바일 경로 결과 단계별 뒤로가기 회귀 테스트는 유지된다", () => {
+  const routeSearch = read("apps/mobile/lib/route_search.dart");
+  const widgetTest = read("apps/mobile/test/widget_test.dart");
+
+  assert.match(widgetTest, /경로 결과 단계는 시스템 뒤로가기를 화면 내 뒤로가기와 맞춘다/);
+  assert.match(widgetTest, /routeStartGuidanceButton/);
+  assert.match(widgetTest, /routeOpenInternalRouteButton/);
+  assert.match(widgetTest, /routeOpenFeedbackButton/);
+  assert.match(routeSearch, /return PopScope\(/);
+  assert.match(routeSearch, /_RouteWorkflowView\.detail\s*=>\s*_RouteWorkflowView\.list/);
+  assert.match(routeSearch, /_RouteWorkflowView\.guidance\s*=>\s*_RouteWorkflowView\.detail/);
+  assert.match(routeSearch, /_RouteWorkflowView\.internalRoute\s*=>\s*_RouteWorkflowView\.guidance/);
+  assert.match(routeSearch, /_RouteWorkflowView\.feedback\s*=>\s*_RouteWorkflowView\.detail/);
+});
+
 test("Android 권한 파서는 속성 순서와 추가 속성이 달라도 권한명을 추출한다", () => {
   const permissions = androidManifestPermissions(`
     <manifest xmlns:android="http://schemas.android.com/apk/res/android">

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -901,11 +901,15 @@ test("모바일 홈 shell과 주요 상태 UI 회귀 테스트는 유지된다",
 test("모바일 경로 결과 단계별 뒤로가기 회귀 테스트는 유지된다", () => {
   const routeSearch = read("apps/mobile/lib/route_search.dart");
   const widgetTest = read("apps/mobile/test/widget_test.dart");
+  const routeBackTestPattern = new RegExp([
+    "testWidgets\\('경로 결과 단계는 시스템 뒤로가기를 화면 내 뒤로가기와 맞춘다'",
+    "routeStartGuidanceButton",
+    "routeOpenInternalRouteButton",
+    "routeOpenFeedbackButton",
+    "routeFeedbackHelpfulButton",
+  ].join("[\\s\\S]*"));
 
-  assert.match(widgetTest, /경로 결과 단계는 시스템 뒤로가기를 화면 내 뒤로가기와 맞춘다/);
-  assert.match(widgetTest, /routeStartGuidanceButton/);
-  assert.match(widgetTest, /routeOpenInternalRouteButton/);
-  assert.match(widgetTest, /routeOpenFeedbackButton/);
+  assert.match(widgetTest, routeBackTestPattern);
   assert.match(routeSearch, /return PopScope\(/);
   assert.match(routeSearch, /_RouteWorkflowView\.detail\s*=>\s*_RouteWorkflowView\.list/);
   assert.match(routeSearch, /_RouteWorkflowView\.guidance\s*=>\s*_RouteWorkflowView\.detail/);


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- #1075 완료 기준에는 경로 결과 상세, 단계별 안내, 역 안 이동 안내, 피드백 화면의 시스템 뒤로가기 동작이 화면 내 뒤로가기와 같은 규칙을 따라야 한다.
- 기존 widget test는 상세에서 목록으로, 단계별 안내에서 상세로 돌아오는 흐름만 확인했다.
- 이번 PR은 내부 이동 안내와 피드백 화면까지 같은 테스트에서 확인하고, 해당 회귀 테스트가 빠지지 않도록 repository contract에 고정한다.

## 작업 내용

- 경로 결과 단계별 widget test를 확장해 내부 이동 안내에서 시스템 뒤로가기를 누르면 단계별 안내로 돌아오는지 확인한다.
- 피드백 화면에서 시스템 뒤로가기를 누르면 경로 상세로 돌아오는지 확인한다.
- repository contract에 경로 결과 단계별 뒤로가기 테스트명, 주요 진입 버튼 key, `PopScope` 단계 전환 매핑을 추가했다.
- CodeRabbit 지적에 따라 contract가 `widget_test.dart` 전체가 아니라 대상 test block 안에서 버튼 흐름을 확인하도록 범위를 좁혔다.

## 검증

- 실행한 명령과 결과:
- `node --test --test-name-pattern "모바일 경로 결과 단계별 뒤로가기" tools/ci/repository-contract.test.mjs`: exit 0, 대상 1개 테스트 통과
- `flutter test test/widget_test.dart --name "경로 결과 단계는 시스템 뒤로가기를 화면 내 뒤로가기와 맞춘다" --reporter expanded`: exit 0, 대상 widget test 통과
- `git diff --check`: exit 0
- GitHub Actions PR checks: all required checks pass
- CodeRabbit review: actionable 1건 확인 후 수정, 원래 inline thread에 해결 답글 작성 및 resolved 처리
- Codex CLI fallback review: follow-up commit 기준 actionable comments 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 경로 단계 back 계약 | local CI | `node --test --test-name-pattern "모바일 경로 결과 단계별 뒤로가기" tools/ci/repository-contract.test.mjs` | 명령 출력 | 통과 |
| 실제 widget back 흐름 | Flutter test | `flutter test test/widget_test.dart --name "경로 결과 단계는 시스템 뒤로가기를 화면 내 뒤로가기와 맞춘다" --reporter expanded` | 명령 출력 | 통과 |
| 패치 형식 | local | `git diff --check` | 명령 출력 | 통과 |
| PR CI | GitHub Actions | `gh pr checks 1150 --watch=false` | PR #1150 check list | 통과 |
| CodeRabbit 지적 수정 | GitHub review thread | inline review 확인, fix commit push, 원 thread 답글 및 resolved 처리 | PR #1150 review thread | 해결 |
| Codex fallback review | GitHub PR review | `codex review --base origin/main --title "[Test] 경로 단계 뒤로가기 회귀 계약 추가"` | PR #1150 review 기록 | actionable 0 |
| 화면 증거 | mobile | 증거 불필요 사유: 화면 UI를 바꾸지 않고 기존 경로 workflow의 widget test 범위를 확장함 | 해당 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: widget test가 경로 상세, 단계별 안내, 역 안 이동 안내, 피드백 화면의 시스템 back 기대 흐름을 모두 확인하는지 봐 주세요.

## 리스크

- 경로 workflow 버튼 key나 화면 제목을 리팩터링하면 contract와 widget test를 함께 갱신해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
