### PR TITLE
[Test] 역 검색 큰 글자 회귀 계약 추가

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -898,6 +898,36 @@ test("모바일 홈 shell과 주요 상태 UI 회귀 테스트는 유지된다",
   assert.match(main, /homeRecentRouteEmptyState/);
 });
 
+test("모바일 역 검색 결과 큰 글자 문구 회귀 테스트는 유지된다", () => {
+  const stationSearch = read("apps/mobile/lib/station_search.dart");
+  const widgetTest = read("apps/mobile/test/widget_test.dart");
+  const resultTileMatch = stationSearch.match(
+    /class _StationSearchResultTile[\s\S]*?class _StationRoleActionBar/,
+  );
+  const largeTextTestMatch = widgetTest.match(
+    /testWidgets\('역 검색 결과 핵심 문구는 큰 글자에서 한 줄 말줄임으로 고정하지 않는다'[\s\S]*?\n  testWidgets\('/,
+  );
+
+  assert.ok(resultTileMatch, "_StationSearchResultTile block not found");
+  const resultTile = resultTileMatch[0];
+  assert.match(resultTile, /StationLineBadges\([\s\S]*maxBadgeCount:\s*2/);
+  assert.match(
+    resultTile,
+    /Text\(\s*stationName[\s\S]*Text\(\s*result\.distanceLabel\.isEmpty[\s\S]*Text\(\s*result\.dataQualityLabel/,
+  );
+  assert.doesNotMatch(resultTile, /maxLines:\s*1/);
+  assert.doesNotMatch(resultTile, /overflow:\s*TextOverflow\.ellipsis/);
+  assert.ok(largeTextTestMatch, "station search large text widget test block not found");
+  const largeTextTest = largeTextTestMatch[0];
+  assert.match(largeTextTest, /TextScaler\.linear\(2\.0\)/);
+  assert.match(largeTextTest, /김포공항국제선환승센터/);
+  assert.match(largeTextTest, /수도권 9호선 급행/);
+  assert.match(largeTextTest, /공항철도 직통 일반 공용/);
+  assert.match(largeTextTest, /일부 정보는 확인 중이에요/);
+  assert.match(largeTextTest, /expect\(widget\.maxLines, isNot\(1\)\)/);
+  assert.match(largeTextTest, /expect\(widget\.overflow, isNot\(TextOverflow\.ellipsis\)\)/);
+});
+
 test("모바일 경로 결과 단계별 뒤로가기 회귀 테스트는 유지된다", () => {
   const routeSearch = read("apps/mobile/lib/route_search.dart");
   const widgetTest = read("apps/mobile/test/widget_test.dart");


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- #1075에는 역 검색 결과의 역명, 노선/거리, 데이터 상태 문구가 큰 글자와 작은 화면에서도 의미가 잘리지 않아야 한다는 완료 기준이 있다.
- 현재 main에는 역 검색 결과 큰 글자 widget test와 production 타일 구조가 이미 들어와 있으므로, 이번 PR은 해당 흐름이 다시 `maxLines: 1` 또는 `TextOverflow.ellipsis`로 되돌아가지 않도록 repository contract로 고정한다.

## 작업 내용

- repository contract에 역 검색 결과 큰 글자 회귀 테스트 유지 조건을 추가했다.
- production `_StationSearchResultTile`이 역명, 거리/노선, 데이터 상태 문구를 모두 노출하고 한 줄 말줄임으로 고정하지 않는지 검사한다.
- widget test가 긴 역명, 긴 노선명, 쉬운 데이터 상태 문구를 200% 글자 크기에서 검증하는지 확인한다.

## 검증

- 실행한 명령과 결과:
- `node --test --test-name-pattern "모바일 역 검색 결과 큰 글자" tools/ci/repository-contract.test.mjs`: exit 0, 대상 1개 테스트 통과
- `flutter test test/widget_test.dart --name "역 검색 결과 핵심 문구는 큰 글자에서 한 줄 말줄임" --reporter expanded`: exit 0, 대상 1개 widget test 통과
- `git diff --check`: exit 0
- GitHub Actions PR checks: 전체 통과
- CodeRabbit: rate limit으로 실제 리뷰가 시작되지 않아 Codex CLI fallback review 실행, actionable 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 검색 큰 글자 계약 | local CI | `node --test --test-name-pattern "모바일 역 검색 결과 큰 글자" tools/ci/repository-contract.test.mjs` | 명령 출력 | 통과 |
| 실제 widget 흐름 | Flutter test | `flutter test test/widget_test.dart --name "역 검색 결과 핵심 문구는 큰 글자에서 한 줄 말줄임" --reporter expanded` | 명령 출력 | 통과 |
| 패치 형식 | local | `git diff --check` | 명령 출력 | 통과 |
| PR CI | GitHub Actions | `gh pr checks 1152 --watch=false` | Android CI, Android Release Artifact, Backend CI, Backend Release Image, Mobile App CI, Repository CI, Release Gate Consistency, SonarCloud, RC Evidence Manifest 모두 통과 | 통과 |
| 코드 리뷰 | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review | PR review에 actionable 0 기록 | 통과 |
| 화면 증거 | mobile | 증거 불필요 사유: 화면 UI를 바꾸지 않고 기존 widget test와 CI 계약만 고정함 | 해당 없음 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: contract가 production 타일 구조와 실제 큰 글자 widget test를 함께 고정하는지 확인해 주세요.

## 리스크

- 역 검색 결과 타일 클래스명이나 테스트명을 바꾸는 리팩터링도 contract 실패를 만들 수 있다. 의도적인 변경이면 contract를 함께 갱신해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
