### PR TITLE
[Fix] 홈 핵심 문구 말줄임 제거

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -2453,11 +2453,7 @@ class _HomeProfilePill extends StatelessWidget {
             ),
           ),
           icon: Icon(profile.icon, size: 16),
-          label: Text(
-            '이동 조건: ${profile.title} 〉',
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
+          label: Text('이동 조건: ${profile.title} 〉'),
         ),
       ),
     );
@@ -3051,8 +3047,6 @@ class _HomeRouteStationLabel extends StatelessWidget {
         Flexible(
           child: Text(
             stationName,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
             style: const TextStyle(
               color: EasySubwayAccessibleColors.text,
               fontSize: _stationFontSize,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3340,6 +3340,44 @@ void main() {
       tester.getSize(find.byKey(const Key('homeProfilePill'))).height,
       greaterThanOrEqualTo(36),
     );
+    final profileText = tester.widget<Text>(
+      find.descendant(
+        of: find.byKey(const Key('homeProfilePill')),
+        matching: find.text('이동 조건: 천천히 이동 〉'),
+      ),
+    );
+    expect(profileText.maxLines, isNull);
+    expect(profileText.overflow, isNot(TextOverflow.ellipsis));
+  });
+
+  testWidgets('홈 최근 경로 역명은 말줄임으로 자르지 않는다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        recentRoutesFuture: Future.value([_favoriteRoute()]),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.dragUntilVisible(
+      find.byKey(const Key('homeRecentRouteCard')),
+      find.byKey(const Key('homeContentList')),
+      const Offset(0, -120),
+    );
+    await tester.pumpAndSettle();
+
+    for (final stationName in ['상록수역', '사당역']) {
+      final stationText = tester.widget<Text>(find.text(stationName));
+      expect(stationText.maxLines, isNull);
+      expect(stationText.overflow, isNot(TextOverflow.ellipsis));
+    }
   });
 
   testWidgets('홈 대화면은 시스템 고대비와 200% 글자에서 핵심 CTA를 유지한다', (tester) async {


### PR DESCRIPTION
## 관련 이슈

#1075 일부 항목

## 작업 배경

- QA 요청에 따라 사용자에게 중요한 홈 문구가 큰 글자에서 잘리지 않도록 #1075의 문구/큰 글자 회귀 항목을 계속 좁게 처리한다.
- 최신 main 기준 production 사용자 문구 guard는 통과하지만, 홈 이동 조건 pill과 최근 경로 역명에는 `TextOverflow.ellipsis`가 남아 있어 큰 글자 사용자가 핵심 정보를 끝까지 읽지 못할 수 있었다.
- 이 PR은 #1075 전체를 닫지 않고, 홈 핵심 문구 말줄임 제거 항목만 처리한다.

## 작업 내용

- 홈 이동 조건 pill의 `maxLines: 1` / `TextOverflow.ellipsis` 제한을 제거했다.
- 홈 최근 경로 카드의 출발역/도착역 역명에서 1줄 말줄임 제한을 제거했다.
- widget test에서 이동 조건 pill과 최근 경로 역명이 말줄임 설정을 쓰지 않는지 검증한다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "홈 핵심 행동은 좁은 화면과 큰 글자에서도 터치 기준을 지킨다|홈 최근 경로 역명은 말줄임으로 자르지 않는다" --reporter expanded`: exit 0, 2 tests passed
  - `node --test --test-name-pattern "모바일 production 사용자 문구" tools/ci/repository-contract.test.mjs`: exit 0, matching test passed
  - `dart format apps/mobile/lib/main.dart apps/mobile/test/widget_test.dart`: exit 0
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 홈 이동 조건 큰 글자 문구 | Flutter widget | `homeProfilePill` 안 Text가 `maxLines`와 ellipsis를 쓰지 않는지 검사 | 로컬 test output: `홈 핵심 행동은 좁은 화면과 큰 글자에서도 터치 기준을 지킨다` pass | 통과 |
| 홈 최근 경로 역명 | Flutter widget | 최근 경로 카드의 출발역/도착역 Text가 `maxLines`와 ellipsis를 쓰지 않는지 검사 | 로컬 test output: `홈 최근 경로 역명은 말줄임으로 자르지 않는다` pass | 통과 |
| production 사용자 문구 | Repository contract | 금지된 내부/개발/어려운 표현 재유입 검사 | 로컬 Node test output: matching test pass | 통과 |
| PR CI | GitHub Actions | PR #1161 checks 확인 | CI, Release Artifacts, SonarCloud, OSV checks pass | 통과 |
| post-merge CD | GitHub Actions | main/CD run 목록 확인 | #1161 merge commit의 CI/Release Artifacts 생성, 진행 중. 최신 visible CD는 직전 merge commit 기준 pending | 현재 실패 신호 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/main.dart`의 `_HomeProfilePill`, `_HomeRouteStationLabel`
- 스크린샷 대신 widget test로 Text 속성을 직접 검증했다. 이번 변경은 픽셀 스타일 추가가 아니라 말줄임 제한 제거라서 속성 검증이 회귀 방지에 더 직접적이다.

## 리스크

- 아주 좁은 화면에서 이동 조건 pill과 최근 경로 역명이 여러 줄로 늘어날 수 있다. 이미 홈 큰 글자 widget test에서 터치 기준과 화면 순서를 확인한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
