### PR TITLE
[Fix] 노선도 지역 문구 말줄임 제거

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -529,7 +529,6 @@ class _RegionMenuButton extends StatelessWidget {
               Expanded(
                 child: Text(
                   label,
-                  overflow: TextOverflow.ellipsis,
                   style: const TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w800,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -920,6 +920,13 @@ void main() {
     expect(find.byKey(const Key('networkMapScreen')), findsOneWidget);
     expect(find.text('저장'), findsNothing);
     expect(find.text('수도권'), findsOneWidget);
+    final regionText = tester.widget<Text>(
+      find.descendant(
+        of: find.byKey(const Key('mapRegionTabs')),
+        matching: find.text('수도권'),
+      ),
+    );
+    expect(regionText.overflow, isNot(TextOverflow.ellipsis));
     expect(find.text('전국'), findsNothing);
     expect(
       tester.getSize(find.byKey(const Key('mapRegionTabs'))).height,


### PR DESCRIPTION
## 관련 이슈

#1075 일부 항목

## 작업 배경

- QA 요청에 따라 큰 글자 사용자에게 핵심 문구가 잘리지 않도록 #1075의 노선도 문구 회귀 항목을 좁게 처리한다.
- 홈/최근 경로 말줄임 제거에 이어, 노선도 지역 선택 버튼에도 `TextOverflow.ellipsis`가 남아 있어 지역명이 길어지거나 글자가 커질 때 의미가 잘릴 수 있었다.
- 이 PR은 #1075 전체를 닫지 않고, 노선도 지역 선택 문구 말줄임 제거 항목만 처리한다.

## 작업 내용

- 노선도 지역 선택 버튼의 `TextOverflow.ellipsis` 제한을 제거했다.
- 기존 노선도 화면 widget test에서 지역 선택 버튼 Text가 ellipsis를 쓰지 않는지 검증한다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "홈 노선도 버튼은 v3 노선도 화면을 연다" --reporter expanded`: exit 0, 1 test passed
  - `node --test --test-name-pattern "모바일 production 사용자 문구" tools/ci/repository-contract.test.mjs`: exit 0, matching test passed
  - `dart format apps/mobile/lib/network_map.dart apps/mobile/test/widget_test.dart`: exit 0
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 노선도 지역 선택 문구 | Flutter widget | `mapRegionTabs` 안 Text가 ellipsis를 쓰지 않는지 검사 | 로컬 test output: `홈 노선도 버튼은 v3 노선도 화면을 연다` pass | 통과 |
| production 사용자 문구 | Repository contract | 금지된 내부/개발/어려운 표현 재유입 검사 | 로컬 Node test output: matching test pass | 통과 |
| PR CI | GitHub Actions | PR #1163 checks 확인 | CI, Release Artifacts, SonarCloud, OSV checks pass | 통과 |
| CodeRabbit | GitHub PR review | CodeRabbit review 상태 확인 | No actionable comments | 통과 |
| post-merge CD | GitHub Actions | main/CD run 목록 확인 | #1163 merge commit의 CI/Release Artifacts 생성, 진행 중. 최신 visible CD는 직전 merge commit 기준 pending | 현재 실패 신호 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/network_map.dart`의 `_RegionMenuButton`
- 지도 캔버스 역명 라벨의 `maxLines: 1`은 겹침 회피용 렌더링 경계라 이번 PR에서 건드리지 않았다.

## 리스크

- 긴 지역명은 버튼 안에서 여러 줄로 표시될 수 있다. 현재 버튼 높이는 기존 터치 기준을 유지하며, 지역명 자체는 Semantics label로도 제공된다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
