### PR TITLE
[Fix] 역 상세 이동 구조 말줄임 제거

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -4660,8 +4660,6 @@ class _StationLayoutStep extends StatelessWidget {
           Text(
             item.text,
             textAlign: TextAlign.center,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
             style: textTheme.bodyLarge?.copyWith(
               color: const Color(0xFF102A2C),
               fontWeight: FontWeight.w900,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -7492,6 +7492,9 @@ void main() {
       );
       await tester.pumpAndSettle();
       expect(find.text('승강장'), findsOneWidget);
+      final platformText = tester.widget<Text>(find.text('승강장'));
+      expect(platformText.maxLines, isNot(2));
+      expect(platformText.overflow, isNot(TextOverflow.ellipsis));
       expect(find.bySemanticsLabel('이동 구조, 1번 출구, 엘리베이터, 승강장'), findsOneWidget);
       await tester.scrollUntilVisible(
         find.text('지도 위치 목록'),


### PR DESCRIPTION
## 관련 이슈

#1075 일부

## 작업 배경

- QA 요청에 따라 모바일 화면에서 어려운 표현과 큰 글씨 말줄임을 계속 줄이고 있습니다.
- 역 상세의 이동 구조 타일은 `승강장` 같은 짧은 안내도 2줄 제한과 말줄임 설정을 갖고 있어, 글자 크기나 번역 길이가 늘면 안내가 잘릴 수 있었습니다.

## 작업 내용

- 역 상세 이동 구조 타일의 문구에서 2줄 제한과 말줄임 표시를 제거했습니다.
- 같은 화면의 widget test에 이동 구조 문구가 다시 2줄 말줄임으로 고정되지 않도록 회귀 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/station_search.dart apps/mobile/test/widget_test.dart`: exit 0, 2 files checked, 0 changed
  - `git diff --check`: exit 0
  - `flutter test test/widget_test.dart --name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다" --reporter expanded`: exit 0, 1 test passed
  - `node --test --test-name-pattern "모바일 production 사용자 문구" tools/ci/repository-contract.test.mjs`: exit 0, matching contract passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 상세 이동 구조 문구 | Flutter widget test | 큰 글씨 역 상세 흐름에서 `승강장` Text가 2줄 말줄임으로 고정되지 않는지 확인 | `flutter test test/widget_test.dart --name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다" --reporter expanded` | 통과 |
| production 사용자 문구 | Repository contract | `점수`, `기본정보` 등 사용자에게 친화적이지 않은 문구 guard 확인 | `node --test --test-name-pattern "모바일 production 사용자 문구" tools/ci/repository-contract.test.mjs` | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/station_search.dart`의 `_StationLayoutStep` Text 제한 제거와 `apps/mobile/test/widget_test.dart`의 회귀 assertion입니다.
- 노선도 canvas, 역 검색 데이터, 경로 계산 로직은 변경하지 않았습니다.

## 리스크

- 글자 크기가 매우 큰 환경에서는 이동 구조 타일 높이가 늘어날 수 있습니다. 기존보다 문구를 숨기지 않는 쪽을 선택했습니다.

## 체크리스트

- [x] CI 결과를 확인했다. PR checks 전체 통과.
- [x] CodeRabbit 리뷰를 확인했다. rate limit으로 실제 리뷰가 시작되지 않음.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. Actionable comments posted: 0.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. merge 후 main CI/Release Artifacts는 진행 중, SonarCloud는 통과, CD는 직전 run pending 상태이며 실패 신호 없음.
