### PR TITLE
[Fix] 경로 주의 안내 문구 개선

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -808,7 +808,7 @@ class RouteSearchResult {
     if (needsConfirmation) {
       return '살펴볼 내용';
     }
-    return warnings.isEmpty ? '주의 없음' : '주의 확인';
+    return warnings.isEmpty ? '주의 안내가 없어요' : '주의 안내 보기';
   }
 
   String get semanticLabel {

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -415,6 +415,18 @@ void main() {
     expect(result.semanticLabel, isNot(contains('안내할 수 있는 경로를 아직 찾지 못했어요.')));
   });
 
+  test('경로 검색 결과는 주의 안내를 쉬운 문구로 보여준다', () {
+    final safeResult = _sampleRouteSearchResult(warnings: const []);
+    final warningResult = _sampleRouteSearchResult(
+      warnings: const [
+        RouteSearchWarning(code: 'ROUTE_GRAPH_UNKNOWN', message: ''),
+      ],
+    );
+
+    expect(safeResult.attentionLabel, '주의 안내가 없어요');
+    expect(warningResult.attentionLabel, '주의 안내 보기');
+  });
+
   test('경로 warning은 code만으로 사용자 문구를 만들고 서버 원문을 읽지 않는다', () {
     final result = RouteSearchResult.fromJson({
       'routeSearchId': 'route-unknown-warning',


### PR DESCRIPTION
## 관련 이슈

#1075 일부

## 작업 배경

- QA 요청에 따라 모바일 화면의 딱딱한 상태 문구를 쉬운 말로 정리하고 있습니다.
- 경로 결과의 `주의 없음`, `주의 확인`은 짧지만 사용자가 다음에 무엇을 보면 되는지 덜 분명했습니다.

## 작업 내용

- 경로 결과의 주의 안내 label을 `주의 안내가 없어요`, `주의 안내 보기`로 변경했습니다.
- 해당 문구가 다시 짧은 상태 코드처럼 돌아가지 않도록 route model test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/route_search.dart apps/mobile/test/route_search_test.dart`: exit 0, 0 changed
  - `git diff --check`: exit 0
  - `flutter test test/route_search_test.dart --name "경로 검색 결과는 주의 안내를 쉬운 문구로 보여준다" --reporter expanded`: exit 0, 1 test passed
  - `node --test --test-name-pattern "모바일 production 사용자 문구" tools/ci/repository-contract.test.mjs`: exit 0, matching contract passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 경로 주의 안내 문구 | Flutter unit test | warning 유무별 `attentionLabel` 문구 확인 | `flutter test test/route_search_test.dart --name "경로 검색 결과는 주의 안내를 쉬운 문구로 보여준다" --reporter expanded` | 통과 |
| production 사용자 문구 | Repository contract | 사용자에게 친화적이지 않은 문구 guard 확인 | `node --test --test-name-pattern "모바일 production 사용자 문구" tools/ci/repository-contract.test.mjs` | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchResult.attentionLabel`의 문구 변경입니다.
- 경로 계산, warning 판정, 화면 구조는 변경하지 않았습니다.

## 리스크

- 낮음. 사용자 문구와 회귀 테스트만 바꿨습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. CodeRabbit은 review limit으로 실제 리뷰를 시작하지 못했습니다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. Actionable comments 0건입니다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. merge commit `867cfd25`의 CD run은 생성됐고 pending 상태이며 즉시 실패 신호는 없습니다: https://github.com/AquilaXk/easysubway/actions/runs/28412668756
