### PR TITLE
[Fix] 노선도 디자인 토큰 적용

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -520,9 +520,9 @@ class _RegionMenuButton extends StatelessWidget {
           height: EasySubwayTouchTarget.general,
           padding: const EdgeInsets.only(left: 10, right: 6),
           decoration: BoxDecoration(
-            color: Colors.white,
+            color: EasySubwayAccessibleColors.surface,
             borderRadius: BorderRadius.circular(8),
-            border: Border.all(color: const Color(0xFFD7E1E3)),
+            border: Border.all(color: EasySubwayAccessibleColors.line),
           ),
           child: Row(
             children: [
@@ -532,14 +532,14 @@ class _RegionMenuButton extends StatelessWidget {
                   style: const TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w800,
-                    color: Color(0xFF102A2C),
+                    color: EasySubwayAccessibleColors.text,
                   ),
                 ),
               ),
               const Icon(
                 Icons.arrow_drop_down,
                 size: 22,
-                color: Color(0xFF4C5759),
+                color: EasySubwayAccessibleColors.mutedText,
               ),
             ],
           ),
@@ -561,8 +561,8 @@ class _StationLineChip extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
         decoration: BoxDecoration(
-          color: const Color(0xFFF8FBFB),
-          border: Border.all(color: const Color(0xFFD7E2E4)),
+          color: EasySubwayAccessibleColors.mintSoft,
+          border: Border.all(color: EasySubwayAccessibleColors.line),
           borderRadius: BorderRadius.circular(8),
         ),
         child: Row(
@@ -593,7 +593,7 @@ class _LineCircleBadge extends StatelessWidget {
     final foreground =
         ThemeData.estimateBrightnessForColor(color) == Brightness.dark
         ? Colors.white
-        : const Color(0xFF102A2D);
+        : EasySubwayAccessibleColors.text;
     return ExcludeSemantics(
       child: Container(
         width: size,
@@ -2798,7 +2798,10 @@ class _StationSheet extends StatelessWidget {
             const SizedBox(height: 6),
             const Text(
               '노선 순서에 맞춰 표시됩니다.',
-              style: TextStyle(fontSize: 15, color: Color(0xFF4D6367)),
+              style: TextStyle(
+                fontSize: 15,
+                color: EasySubwayAccessibleColors.mutedText,
+              ),
             ),
             const SizedBox(height: 18),
             Row(


### PR DESCRIPTION
## 관련 이슈

#1075

## 작업 배경

#1075 최종 점검에서 노선도 화면의 사용자 노출 버튼과 sheet 일부가 공통 색상 토큰 대신 raw color를 계속 쓰는 것이 확인됐습니다. 큰 구조 변경 없이 반복 UI의 raw 값을 먼저 줄입니다.

## 작업 내용

- 노선도 지역 선택 버튼의 surface, border, text, icon 색상을 `EasySubwayAccessibleColors`로 변경
- 노선도 역 sheet의 노선 chip surface/border와 보조 문구 색상을 공통 토큰으로 변경
- 노선 badge foreground fallback을 공통 text 토큰으로 변경

## 검증

- 실행한 명령과 결과:
- `dart format apps/mobile/lib/network_map.dart`: exit 0, 0 changed
- `git diff --check`: exit 0
- `flutter test test/widget_test.dart --name "(노선도 지역 메뉴는 선택한 지역으로 지도를 다시 불러온다|노선도 로드 실패는 재시도와 역 검색 대안을 보여준다|노선도 역을 누르면 출발 도착 설정 sheet를 보여준다)" --reporter expanded`: exit 0, 3 tests passed
- `node --test --test-name-pattern "모바일 production 사용자 문구|프로덕션 모바일 UI 위젯명|노선도 탭 화면" tools/ci/repository-contract.test.mjs`: exit 0, matching 3 tests passed
- `rg -c "Color\\(0x|BorderRadius\\.circular|EdgeInsets\\.fromLTRB" apps/mobile/lib/network_map.dart`: `6`, 기존 점검 count `13`에서 감소

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 노선도 지역/오류/sheet 회귀 | Flutter widget | targeted widget test | command output | 통과 |
| production 문구/Prototype/노선도 shell 계약 | Repository | Node contract test | command output | 통과 |
| 디자인 토큰 적용 범위 | Repository | raw value count | command output | `network_map.dart` 13 -> 6 |
| 시각 증거 | Android emulator | #1075 최신 점검 local-only screenshot/UI tree | `.codex/evidence/1075/android-home-completed-bf2db36c/` | 색상 토큰 치환 PR이라 새 screenshot 첨부 대신 기존 local-only 홈 증거와 widget test로 확인 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/network_map.dart`의 사용자 노출 region button, station line chip, station sheet 색상 치환만 확인하면 됩니다.

## 리스크

- 낮음. layout, copy, route flow는 변경하지 않고 기존 색상 상수를 공통 토큰으로 바꿨습니다.
- #1075 전체 close 조건은 아직 남아 있으므로 이 PR은 #1075를 닫지 않습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.