### PR TITLE
[Fix] 시설 제보 화면 색상 토큰 적용

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -8,6 +8,7 @@ import 'package:drift/drift.dart' show OrderingTerm, Value;
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 
+import 'accessible_design.dart';
 import 'auth_headers.dart';
 import 'core/database/user/user_database.dart' as user_db;
 import 'core/network/api_client.dart';
@@ -1359,7 +1360,7 @@ class _MyReportEmpty extends StatelessWidget {
           '접수한 제보가 없습니다.',
           textAlign: TextAlign.center,
           style: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: const Color(0xFF102A2C),
+            color: EasySubwayAccessibleColors.text,
             fontWeight: FontWeight.w900,
             height: 1.3,
           ),
@@ -1386,7 +1387,7 @@ class _MyReportError extends StatelessWidget {
               _facilityReportListErrorMessage,
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                color: const Color(0xFF102A2C),
+                color: EasySubwayAccessibleColors.text,
                 fontWeight: FontWeight.w900,
                 height: 1.3,
               ),
@@ -1432,10 +1433,10 @@ class _MyReportListItem extends StatelessWidget {
       onTap: openReportDetail,
       child: ExcludeSemantics(
         child: Material(
-          color: Colors.white,
+          color: EasySubwayAccessibleColors.surface,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(8),
-            side: const BorderSide(color: Color(0xFFD5E2E4)),
+            side: const BorderSide(color: EasySubwayAccessibleColors.line),
           ),
           child: InkWell(
             key: Key('myReport-${report.id}'),
@@ -1453,7 +1454,7 @@ class _MyReportListItem extends StatelessWidget {
                         child: Text(
                           report.reportTypeLabel,
                           style: textTheme.titleMedium?.copyWith(
-                            color: const Color(0xFF102A2C),
+                            color: EasySubwayAccessibleColors.text,
                             fontWeight: FontWeight.w900,
                             height: 1.25,
                           ),
@@ -1467,7 +1468,7 @@ class _MyReportListItem extends StatelessWidget {
                   Text(
                     description,
                     style: textTheme.bodyLarge?.copyWith(
-                      color: const Color(0xFF102A2C),
+                      color: EasySubwayAccessibleColors.text,
                       fontWeight: FontWeight.w700,
                       height: 1.35,
                     ),
@@ -1518,7 +1519,7 @@ class MyFacilityReportDetailScreen extends StatelessWidget {
               Text(
                 report.reportTypeLabel,
                 style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  color: const Color(0xFF102A2C),
+                  color: EasySubwayAccessibleColors.text,
                   fontWeight: FontWeight.w900,
                   height: 1.25,
                 ),
@@ -1553,16 +1554,16 @@ class _MyReportDetailStatus extends StatelessWidget {
       alignment: Alignment.centerLeft,
       child: Container(
         decoration: BoxDecoration(
-          color: const Color(0xFFE6F2F0),
+          color: EasySubwayAccessibleColors.mintSoft,
           borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: const Color(0xFF93C7C2)),
+          border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
         ),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
           child: Text(
             label,
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: const Color(0xFF102A2C),
+              color: EasySubwayAccessibleColors.text,
               fontWeight: FontWeight.w900,
               height: 1.2,
             ),
@@ -1587,7 +1588,7 @@ class _MyReportDetailRow extends StatelessWidget {
         Text(
           label,
           style: Theme.of(context).textTheme.labelLarge?.copyWith(
-            color: const Color(0xFF29484B),
+            color: EasySubwayAccessibleColors.mutedText,
             fontWeight: FontWeight.w900,
             height: 1.2,
           ),
@@ -1596,7 +1597,7 @@ class _MyReportDetailRow extends StatelessWidget {
         Text(
           value,
           style: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: const Color(0xFF102A2C),
+            color: EasySubwayAccessibleColors.text,
             fontWeight: FontWeight.w800,
             height: 1.3,
           ),
@@ -1615,16 +1616,16 @@ class _MyReportStatusPill extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: const Color(0xFFE6F2F0),
+        color: EasySubwayAccessibleColors.mintSoft,
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: const Color(0xFF93C7C2)),
+        border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
       ),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
         child: Text(
           label,
           style: Theme.of(context).textTheme.labelLarge?.copyWith(
-            color: const Color(0xFF102A2C),
+            color: EasySubwayAccessibleColors.text,
             fontWeight: FontWeight.w900,
             height: 1.2,
           ),
@@ -1645,7 +1646,7 @@ class _MyReportMetaText extends StatelessWidget {
     return Text(
       '$label $value',
       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-        color: const Color(0xFF29484B),
+        color: EasySubwayAccessibleColors.mutedText,
         fontWeight: FontWeight.w700,
         height: 1.3,
       ),
@@ -2282,9 +2283,9 @@ class _FacilityReportStatusPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: const Color(0xFFE6F2F0),
+        color: EasySubwayAccessibleColors.mintSoft,
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: const Color(0xFF93C7C2)),
+        border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
       ),
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -2342,7 +2343,7 @@ class _FacilityReportStatusRow extends StatelessWidget {
         Text(
           label,
           style: textTheme.labelLarge?.copyWith(
-            color: const Color(0xFF29484B),
+            color: EasySubwayAccessibleColors.mutedText,
             fontWeight: FontWeight.w800,
           ),
         ),
@@ -2350,7 +2351,7 @@ class _FacilityReportStatusRow extends StatelessWidget {
         Text(
           value,
           style: textTheme.titleMedium?.copyWith(
-            color: const Color(0xFF102A2C),
+            color: EasySubwayAccessibleColors.text,
             fontWeight: FontWeight.w900,
             height: 1.25,
           ),
@@ -2380,7 +2381,7 @@ class _FacilityReportHeader extends StatelessWidget {
             Text(
               '${target.stationName}역',
               style: textTheme.headlineSmall?.copyWith(
-                color: const Color(0xFF102A2C),
+                color: EasySubwayAccessibleColors.text,
                 fontWeight: FontWeight.w900,
                 height: 1.2,
               ),
@@ -2389,7 +2390,7 @@ class _FacilityReportHeader extends StatelessWidget {
             Text(
               target.facilityName,
               style: textTheme.titleLarge?.copyWith(
-                color: const Color(0xFF102A2C),
+                color: EasySubwayAccessibleColors.text,
                 fontWeight: FontWeight.w800,
                 height: 1.25,
               ),
@@ -2398,7 +2399,7 @@ class _FacilityReportHeader extends StatelessWidget {
             Text(
               '${target.facilityTypeLabel} · ${target.facilityStatusLabel}',
               style: textTheme.bodyLarge?.copyWith(
-                color: const Color(0xFF29484B),
+                color: EasySubwayAccessibleColors.mutedText,
                 fontWeight: FontWeight.w700,
                 height: 1.3,
               ),
@@ -2422,7 +2423,7 @@ class _FacilityReportSectionTitle extends StatelessWidget {
       child: Text(
         title,
         style: Theme.of(context).textTheme.titleLarge?.copyWith(
-          color: const Color(0xFF102A2C),
+          color: EasySubwayAccessibleColors.text,
           fontWeight: FontWeight.w900,
           height: 1.25,
         ),
@@ -2444,8 +2445,12 @@ class _FacilityReportTypeCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = selected ? const Color(0xFF006D77) : const Color(0xFFD5E2E4);
-    final textColor = selected ? Colors.white : const Color(0xFF102A2C);
+    final color = selected
+        ? EasySubwayAccessibleColors.primary
+        : EasySubwayAccessibleColors.line;
+    final textColor = selected
+        ? EasySubwayAccessibleColors.surface
+        : EasySubwayAccessibleColors.text;
     final semanticsLabel = '${option.label} ${selected ? '선택됨' : '선택 가능'}';
 
     return Semantics(
@@ -2455,7 +2460,7 @@ class _FacilityReportTypeCard extends StatelessWidget {
       onTap: onTap,
       child: ExcludeSemantics(
         child: Material(
-          color: selected ? color : Colors.white,
+          color: selected ? color : EasySubwayAccessibleColors.surface,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(8),
             side: BorderSide(color: color, width: 1.5),
@@ -2505,7 +2510,9 @@ class _FacilityReportMessage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isFailure = state.status == FacilityReportViewStatus.failure;
-    final color = isFailure ? const Color(0xFF8A4B00) : const Color(0xFF006D77);
+    final color = isFailure
+        ? EasySubwayAccessibleColors.amber
+        : EasySubwayAccessibleColors.primary;
     final icon = isFailure ? Icons.error_outline : Icons.check_circle_outline;
     final shouldShowNextAction = _shouldShowFacilityReportFailureNextAction(
       state,
@@ -2527,7 +2534,7 @@ class _FacilityReportMessage extends StatelessWidget {
                   child: Text(
                     state.message,
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: const Color(0xFF102A2C),
+                      color: EasySubwayAccessibleColors.text,
                       fontWeight: FontWeight.w800,
                       height: 1.3,
                     ),
@@ -2548,7 +2555,7 @@ class _FacilityReportMessage extends StatelessWidget {
             child: Text(
               _facilityReportFailureNextAction,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: const Color(0xFF506B6F),
+                color: EasySubwayAccessibleColors.mutedText,
                 fontWeight: FontWeight.w700,
                 height: 1.35,
               ),
@@ -2576,7 +2583,9 @@ class _FacilityReportLocationMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = isFailure ? const Color(0xFF8A4B00) : const Color(0xFF006D77);
+    final color = isFailure
+        ? EasySubwayAccessibleColors.amber
+        : EasySubwayAccessibleColors.primary;
     final icon = isFailure ? Icons.error_outline : Icons.check_circle_outline;
 
     return Semantics(
@@ -2591,7 +2600,7 @@ class _FacilityReportLocationMessage extends StatelessWidget {
               child: Text(
                 message,
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: const Color(0xFF102A2C),
+                  color: EasySubwayAccessibleColors.text,
                   fontWeight: FontWeight.w800,
                   height: 1.3,
                 ),


### PR DESCRIPTION
## 관련 이슈

refs #1075

이 PR은 #1075의 디자인 시스템 정리 항목 중 시설 제보 화면의 색상 토큰 적용 범위를 줄이는 후속 작업입니다. #1075는 iOS 수동 증거와 남은 화면 점검이 있어 이 PR만으로 닫지 않습니다.

## 작업 배경

시설 제보, 내 제보 목록, 제보 상세 화면에 raw color 값이 반복되어 #1075의 디자인 시스템 정리 기준에 남아 있었습니다. 사용자에게 보이는 문구와 상태 흐름은 유지하고, 색상만 기존 접근성 색상 토큰으로 맞춥니다.

## 작업 내용

- 시설 제보 화면의 본문, 보조 문구, 카드 표면, 테두리, 상태 안내 색상을 `EasySubwayAccessibleColors`로 치환했습니다.
- 선택 카드와 성공/실패 안내 icon 색상을 공용 primary/amber 토큰으로 맞췄습니다.
- `facility_report.dart`의 raw 디자인 패턴 count를 `40`에서 `10`으로 줄였습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/facility_report.dart`: exit 0, 0 changed
  - `git diff --check`: exit 0
  - `rg -c "Color\\(0x|BorderRadius\\.circular|EdgeInsets\\.fromLTRB" apps/mobile/lib/facility_report.dart`: `10`
  - `rg -n "기본 정보|기본정보|정보만|점수|[0-9]+\\s*점|없음|확인 필요|상세 정보|추정|측정값|기준점|이동 구조|데이터팩|공공 API|관리자 검수|현장 검증|새 알림 없음|현재 이용할 수 없음|계단 없음 확인|prototype|Prototype" apps/mobile/lib`: exit 1, matching production 후보 없음
  - `flutter test test/widget_test.dart --name "(홈에서 내 신고 화면으로 이동한다|내 신고 항목을 누르면 상세 상태 화면으로 이동한다|내 제보 화면은 접수한 제보가 없으면 짧은 빈 상태를 보여준다|시설 신고 실패는 도움말을 쉬운 문구로 안내한다)" --reporter expanded`: exit 0, 4 tests passed
  - `node --test --test-name-pattern "모바일 production 사용자 문구|모바일 설정 저장 실패와 시설 제보 위치 실패" tools/ci/repository-contract.test.mjs`: exit 0, matching 2 tests passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 시설 제보 색상 토큰 적용 | Flutter widget | 제보 목록, 상세, 빈 상태, 실패 안내 widget/accessibility test | 위 `flutter test` 출력 | 통과 |
| 사용자 친화 문구 회귀 | Repository contract | production 모바일 문구 guard | 위 `node --test` 출력 | 통과 |
| raw 디자인 값 축소 | Local source audit | `facility_report.dart` raw pattern count | `rg -c ...`: `10` | 기존 점검 count `40`에서 감소 |
| 화면 스크린샷 | Android/iOS | 증거 불필요 사유 | 문구·레이아웃 변경 없이 기존 색상 값을 공용 접근성 토큰으로 치환한 범위이며, #1075의 별도 Android 화면 증거는 이미 local-only로 보관됨 | 추가 스크린샷 미첨부 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/facility_report.dart`에서 raw color가 공용 접근성 토큰으로만 치환됐는지 확인해 주세요.

## 리스크

- 색상 토큰 값이 기존 raw 값과 1:1 완전히 같지는 않아 일부 상태 pill과 보조 문구의 색감이 조금 달라질 수 있습니다. 텍스트, semantics, 상태 흐름은 변경하지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
