### PR TITLE
[Fix] 역 상세 상태 제보 문구 정리

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -5325,7 +5325,7 @@ class _StationFacilityCard extends StatelessWidget {
                     Expanded(
                       child: Semantics(
                         container: true,
-                        label: '${facility.name} 상태 신고',
+                        label: '${facility.name} 상태 제보',
                         button: true,
                         onTap: onReportTap,
                         child: ExcludeSemantics(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -7646,7 +7646,7 @@ void main() {
         ),
         findsOneWidget,
       );
-      expect(find.bySemanticsLabel('1번 출구 엘리베이터 상태 신고'), findsOneWidget);
+      expect(find.bySemanticsLabel('1번 출구 엘리베이터 상태 제보'), findsOneWidget);
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -8241,6 +8241,7 @@ test("모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다",
   assert.doesNotMatch(widgetTest, /첫 실행 앱은 온보딩 알림 권한 실패 도움말을 안내한다/);
   assert.match(stationSearch, /가까운 역 찾기와 시설 제보 위치 확인에만 현재 위치를 사용합니다/);
   assert.match(stationSearch, /위치 권한을 거부해도 역명 검색, 즐겨찾기, 접근성 정보 조회는 계속 사용할 수 있습니다/);
+  assert.doesNotMatch(stationSearch, /상태 신고/);
   assert.match(facilityReport, /사진과 제보 위치는 시설 제보 확인에만 사용됩니다/);
   assert.match(facilityReport, /제보 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다/);
   assert.match(widgetTest, /역 검색은 첫 위치 권한 요청 전에 사용 목적을 안내한다/);


### PR DESCRIPTION
## 관련 이슈

refs #1075

이 PR은 #1075의 모바일 사용자 문구 정리 항목 중 역 상세 시설 상태 CTA의 스크린리더 문구를 정리하는 후속 작업입니다. #1075는 iOS 수동 증거와 남은 디자인 토큰 정리 항목이 있어 이 PR만으로 닫지 않습니다.

## 작업 배경

역 상세 시설 카드의 버튼 텍스트는 이미 `상태 제보`로 표시되지만, 같은 버튼의 Semantics label은 `상태 신고`로 읽혔습니다. 화면 문구와 스크린리더 문구가 서로 다르면 보조기술 사용자가 같은 기능을 다른 의미로 이해할 수 있어, 화면 표현에 맞춰 `제보`로 통일합니다.

## 작업 내용

- 역 상세 시설 상태 버튼의 Semantics label을 `상태 신고`에서 `상태 제보`로 변경했습니다.
- 해당 widget test 기대값을 새 문구로 갱신했습니다.
- production 모바일 문자열에 `상태 신고`가 다시 들어오지 않도록 repository contract guard를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/station_search.dart test/widget_test.dart`: exit 0, 0 changed
  - `git diff --check`: exit 0
  - `rg -n "상태 신고|기본 정보|기본정보|정보만|점수|[0-9]+\\s*점|없음|확인 필요|상세 정보|추정|측정값|기준점|이동 구조|데이터팩|공공 API|관리자 검수|현장 검증|새 알림 없음|현재 이용할 수 없음|계단 없음 확인" apps/mobile/lib`: exit 1, matching production 후보 없음
  - `flutter test test/widget_test.dart --name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다" --reporter expanded`: exit 0, 1 test passed
  - `node --test --test-name-pattern "모바일 스캐폴드는 Flutter Android와 iOS 앱 구조를 가진다" tools/ci/repository-contract.test.mjs`: exit 0, matching 1 test passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 상세 스크린리더 문구 | Flutter widget | Semantics label widget test | 위 `flutter test` 출력 | 통과 |
| production 문구 회귀 | Repository contract | `상태 신고` 재유입 차단 guard | 위 `node --test` 출력 | 통과 |
| 어려운 문구 후보 제거 | Local source audit | production lib grep | 위 `rg -n ... apps/mobile/lib`: exit 1 | 후보 없음 |
| 코드 리뷰 | GitHub PR | CodeRabbit 상태 확인 및 Codex CLI fallback review | CodeRabbit rate limit, Codex review #4596850295 | actionable 0 |
| 화면 스크린샷 | Android/iOS | 증거 불필요 사유 | 화면 레이아웃 변경 없이 Semantics label만 버튼 텍스트와 맞춘 범위이며, widget accessibility test로 확인함 | 추가 스크린샷 미첨부 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: 버튼 시각 텍스트 `상태 제보`와 Semantics label `상태 제보`가 같은 의미로 유지되는지 확인해 주세요.

## 리스크

- 기능 동작 변경은 없습니다. 스크린리더 label과 회귀 guard만 바뀝니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
