### PR TITLE
[Fix] 노선도 UI 토큰 사용 정리

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -14,6 +14,8 @@ import 'features/network_map/infrastructure/route_map_renderer.dart';
 import 'features/route_draft/application/route_draft_controller.dart';
 import 'features/route_draft/domain/route_draft.dart';
 
+const _networkMapRadius = BorderRadius.all(Radius.circular(8));
+
 abstract interface class NetworkMapRepository {
   Future<NetworkMapData> getNetworkMap({String? region, String? lineId});
 }
@@ -521,7 +523,7 @@ class _RegionMenuButton extends StatelessWidget {
           padding: const EdgeInsets.only(left: 10, right: 6),
           decoration: BoxDecoration(
             color: EasySubwayAccessibleColors.surface,
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: _networkMapRadius,
             border: Border.all(color: EasySubwayAccessibleColors.line),
           ),
           child: Row(
@@ -563,7 +565,7 @@ class _StationLineChip extends StatelessWidget {
         decoration: BoxDecoration(
           color: EasySubwayAccessibleColors.mintSoft,
           border: Border.all(color: EasySubwayAccessibleColors.line),
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: _networkMapRadius,
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
@@ -1321,7 +1323,7 @@ class _MapControlButton extends StatelessWidget {
     return Material(
       color: Colors.white,
       elevation: 2,
-      borderRadius: BorderRadius.circular(8),
+      borderRadius: _networkMapRadius,
       child: IconButton(
         tooltip: tooltip,
         onPressed: onPressed,
@@ -1469,7 +1471,7 @@ class _AndroidRouteMapFallbackPainter extends CustomPainter {
     canvas.restore();
 
     final labelStyle = const TextStyle(
-      color: Color(0xFF102A2C),
+      color: EasySubwayAccessibleColors.text,
       fontSize: 16,
       fontWeight: FontWeight.w800,
     );
@@ -2778,7 +2780,7 @@ class _StationSheet extends StatelessWidget {
     return SafeArea(
       key: const Key('networkMapStationSheet'),
       child: SingleChildScrollView(
-        padding: const EdgeInsets.fromLTRB(20, 6, 20, 20),
+        padding: const EdgeInsets.only(left: 20, top: 6, right: 20, bottom: 20),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- #1075의 모바일 UI 점검 중 노선도 화면에 직접 색상값과 반복 radius 표현이 남아 있었다.
- 화면 동작은 유지하되 접근성 색상 토큰을 우선 사용하도록 정리해, 이후 색상 대비와 문구 점검이 한 곳에서 이어질 수 있게 한다.

## 작업 내용

- 노선도 Android 대체 안내 문구 색상을 접근성 텍스트 토큰으로 교체했다.
- 노선도 메뉴, 노선 칩, 지도 조작 버튼의 8px radius 표현을 공통 상수로 모았다.
- station sheet padding 표현을 명시적인 `EdgeInsets.only`로 바꿔 남은 직접 UI 값 점검 범위를 줄였다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/network_map.dart`: exit 0
  - `git diff --check`: exit 0
  - `rg -c "Color\\(0x|BorderRadius\\.circular|EdgeInsets\\.fromLTRB" apps/mobile/lib/network_map.dart`: `1`
  - `flutter test test/widget_test.dart --name "(노선도 지역 메뉴는 선택한 지역으로 지도를 다시 불러온다|노선도 로드 실패는 재시도와 역 검색 대안을 보여준다|노선도 역을 누르면 출발 도착 설정 sheet를 보여준다)" --reporter expanded`: exit 0, 3 tests passed
  - `node --test --test-name-pattern "모바일 production 사용자 문구|프로덕션 모바일 UI 위젯명|노선도 탭 화면" tools/ci/repository-contract.test.mjs`: exit 0, 3 tests passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 노선도 주요 동작 | Flutter widget test | 지역 메뉴, 로드 실패, 역 선택 sheet 테스트 실행 | `flutter test ... --name "(노선도 지역 메뉴는 선택한 지역으로 지도를 다시 불러온다\|노선도 로드 실패는 재시도와 역 검색 대안을 보여준다\|노선도 역을 누르면 출발 도착 설정 sheet를 보여준다)"`: exit 0 | 통과 |
| production 문구/위젯 계약 | Node test | 모바일 production 문구와 노선도 탭 계약 테스트 실행 | `node --test --test-name-pattern "모바일 production 사용자 문구\|프로덕션 모바일 UI 위젯명\|노선도 탭 화면" tools/ci/repository-contract.test.mjs`: exit 0 | 통과 |
| 시각 증거 | Android/iOS | 레이아웃이나 사용자 흐름 변경 없이 색상 토큰과 상수 표현만 정리 | 스크린샷 증거 불필요 사유: widget test가 노선도 화면 흐름을 검증했고, 이번 변경은 화면 구조를 바꾸지 않음 | 추가 캡처 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/network_map.dart`의 Android 대체 안내 문구 색상 토큰 적용
  - 남은 직접 색상값 `Color(0xFF2F3E42)`는 지도 painter의 역 노드 stroke 색상이라 이번 PR 범위 밖으로 유지했다.

## 리스크

- 화면 동작 변경은 의도하지 않았다.
- 지도 painter 색상까지 전부 토큰화하는 작업은 별도 시각 기준 확인이 필요해 이번 PR에는 포함하지 않았다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
