### PR TITLE
[Fix] 도움말과 제보 문구 쉽게 정리

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -1809,7 +1809,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
                             _submitWithoutLocation = true;
                             _isLocationFailure = false;
                             _locationMessage =
-                                '위치 없이 제보합니다. 현장 위치 확인이 늦어질 수 있어요.';
+                                '위치 없이 제보합니다. 정확한 위치를 찾는 데 시간이 걸릴 수 있어요.';
                           });
                         },
                   icon: const Icon(Icons.location_off_outlined),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4391,7 +4391,7 @@ class SupportAccessScreen extends StatelessWidget {
         child: ListView(
           padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
           children: [
-            const _SupportSectionTitle(title: '개인정보 및 데이터'),
+            const _SupportSectionTitle(title: '내 정보와 개인정보'),
             _PrivacyDataUseSummary(deletionScope: deletionScope),
             const SizedBox(height: 12),
             _SupportAccessItem(

--- a/apps/mobile/test/user_copy_guard.dart
+++ b/apps/mobile/test/user_copy_guard.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 const _forbiddenUserCopy = <String>[
   '실기기 QA',
   '데이터팩',
+  '개인정보 및 데이터',
   '공공 API',
   '공식 파일',
   '관리자 검수',
@@ -34,6 +35,7 @@ const _forbiddenUserCopy = <String>[
   '정보 확인 필요',
   '상태 확인 필요',
   '현장 확인 필요',
+  '현장 위치 확인',
   '노선 정보 없음',
   '살펴볼 시설 없음',
   '다시 볼 시설 없음',

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -11269,7 +11269,10 @@ void main() {
       find.byKey(const Key('facilityReportSubmitWithoutLocationButton')),
     );
     await tester.pumpAndSettle();
-    expect(find.text('위치 없이 제보합니다. 현장 위치 확인이 늦어질 수 있어요.'), findsOneWidget);
+    expect(
+      find.text('위치 없이 제보합니다. 정확한 위치를 찾는 데 시간이 걸릴 수 있어요.'),
+      findsOneWidget,
+    );
 
     final noLocationSubmitButton = tester.widget<FilledButton>(
       find.byKey(const Key('facilityReportSubmitButton')),


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- QA 요청에 따라 모바일 화면에서 사용자에게 딱딱하게 보이는 문구를 계속 줄이고 있습니다.
- 도움말 섹션 제목과 위치 없이 제보하는 안내에 개발/운영식 표현이 남아 있어 쉬운 문장으로 정리합니다.

## 작업 내용

- 도움말의 `개인정보 및 데이터` 섹션 제목을 `내 정보와 개인정보`로 변경했습니다.
- 시설 제보에서 위치 없이 제보할 때 `현장 위치 확인` 대신 `정확한 위치를 찾는 데 시간이 걸릴 수 있어요`로 안내합니다.
- `개인정보 및 데이터`, `현장 위치 확인` 문구가 production 사용자 문구로 돌아오면 widget copy guard에서 차단하도록 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/main.dart apps/mobile/lib/facility_report.dart apps/mobile/test/widget_test.dart apps/mobile/test/user_copy_guard.dart`: exit 0, 0 changed
  - `git diff --check`: exit 0
  - `rg -n "개인정보 및 데이터|현장 위치 확인|기본정보|기본 정보만 있음|정보 부족|부족해요|점수|[0-9]+\\s*점|확인 필요|현장 확인 필요|추정|정적 추정|측정값" apps/mobile/lib --glob '!**/*.g.dart'`: exit 1
  - `node --test --test-name-pattern "모바일 production 사용자 문구" tools/ci/repository-contract.test.mjs`: exit 0, 1 matching test passed
  - `flutter test test/widget_test.dart --name "도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다" --reporter expanded`: exit 0, 1 test passed
  - `flutter test test/widget_test.dart --name "시설 신고 화면은 GPS가 꺼져 있으면 위치 없이 제보를 선택할 수 있다" --reporter expanded`: exit 0, 1 test passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 도움말 문구 | Flutter widget test | 도움말 개인정보/삭제 요청 테스트 | `flutter test test/widget_test.dart --name "도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다" --reporter expanded` | pass |
| 시설 제보 문구 | Flutter widget test | GPS 꺼짐 상태에서 위치 없이 제보 흐름 확인 | `flutter test test/widget_test.dart --name "시설 신고 화면은 GPS가 꺼져 있으면 위치 없이 제보를 선택할 수 있다" --reporter expanded` | pass |
| 사용자 문구 회귀 방지 | Repository contract | production 사용자 문구 금지어 검사 | `node --test --test-name-pattern "모바일 production 사용자 문구" tools/ci/repository-contract.test.mjs` | pass |
| 화면 캡처 | Android/iOS | 증거 불필요 사유 | 문구-only 변경이며 동일 흐름을 widget test와 semantics copy guard로 검증했습니다. | pass |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: [apps/mobile/lib/main.dart](https://github.com/AquilaXk/easysubway/blob/fix/1075-friendly-support-report-copy/apps/mobile/lib/main.dart), [apps/mobile/lib/facility_report.dart](https://github.com/AquilaXk/easysubway/blob/fix/1075-friendly-support-report-copy/apps/mobile/lib/facility_report.dart)

## 리스크

- 기능 동작은 바꾸지 않고 화면 문구와 테스트 기대값만 변경했습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
