### PR TITLE
[Fix] 알림 설정 색상 토큰 정리

### DIFF
--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import 'accessible_design.dart';
 import 'auth_headers.dart';
 import 'mobile_error_reporter.dart';
 
@@ -15,6 +16,7 @@ const _deviceRegistrationErrorMessage = '알림을 켜지 못했어요.';
 const _notificationPermissionErrorMessage = '알림을 켤 수 있는지 확인하지 못했어요.';
 const _notificationRegistrationFailureNextAction =
     '휴대전화 알림 설정과 인터넷 연결을 확인한 뒤 다시 시도해 주세요.';
+const _notificationSwitchTileRadius = BorderRadius.all(Radius.circular(8));
 
 abstract class NotificationSettingsRepository {
   Future<NotificationSettings> getNotificationSettings();
@@ -883,7 +885,7 @@ class _NotificationSettingsMessage extends StatelessWidget {
             message,
             key: const Key('notificationSettingsMessage'),
             style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              color: const Color(0xFF102A2C),
+              color: EasySubwayAccessibleColors.text,
               fontWeight: FontWeight.w700,
               height: 1.35,
             ),
@@ -900,7 +902,7 @@ class _NotificationSettingsMessage extends StatelessWidget {
             child: Text(
               _notificationRegistrationFailureNextAction,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: const Color(0xFF506B6F),
+                color: EasySubwayAccessibleColors.mutedText,
                 fontWeight: FontWeight.w700,
                 height: 1.35,
               ),
@@ -939,9 +941,9 @@ class _NotificationSwitchTile extends StatelessWidget {
       margin: const EdgeInsets.only(bottom: 12),
       color: Colors.white,
       elevation: 0,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8),
-        side: const BorderSide(color: Color(0xFFD5E2E4)),
+      shape: const RoundedRectangleBorder(
+        borderRadius: _notificationSwitchTileRadius,
+        side: BorderSide(color: EasySubwayAccessibleColors.line),
       ),
       child: Semantics(
         container: true,
@@ -959,7 +961,7 @@ class _NotificationSwitchTile extends StatelessWidget {
           title: Text(
             title,
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: const Color(0xFF102A2C),
+              color: EasySubwayAccessibleColors.text,
               fontWeight: FontWeight.w800,
               height: 1.35,
             ),
@@ -1007,7 +1009,7 @@ class _NotificationSettingsFailure extends StatelessWidget {
           child: Text(
             message,
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: const Color(0xFF102A2C),
+              color: EasySubwayAccessibleColors.text,
               fontWeight: FontWeight.w800,
               height: 1.35,
             ),


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- #1075의 남은 항목 중 모바일 화면의 raw 디자인 값을 줄이는 작업입니다.
- 알림 설정 화면에 직접 색상값과 직접 radius 표현이 남아 있어 기존 접근성 색상 토큰으로 정리합니다.

## 작업 내용

- 알림 설정 메시지, 도움말, 실패 문구 색상을 `EasySubwayAccessibleColors`로 바꿨습니다.
- 알림 설정 switch card의 border color와 radius를 토큰/상수로 바꿨습니다.
- 이번 PR은 알림 설정 화면 파일 하나만 건드렸고, page padding은 레이아웃 영향이 있어 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/notification_settings.dart`: exit 0
  - `git diff --check`: exit 0
  - `rg -n "Color\\(0x|BorderRadius\\.circular|EdgeInsets\\.fromLTRB" apps/mobile/lib/notification_settings.dart`: 남은 항목 2건은 page padding
  - `flutter test test/widget_test.dart --name "(알림 설정 화면은 현재 설정을 불러오고 바꾼 값을 저장한다|알림 설정 화면은 기기 알림 권한을 사용자 확인 뒤 요청한다|알림 설정 화면은 기기 알림 권한 거부를 짧게 안내한다|알림 설정 화면은 기기 알림 실패 도움말을 안내한다)" --reporter expanded`: exit 0, 4 tests passed
  - PR CI: Android CI, Backend CI, Mobile App CI, Repository CI, Release Gate Consistency, Release Artifacts, SonarCloud Code Analysis pass
  - CodeRabbit: rate limit으로 실제 리뷰 미시작 확인
  - Codex CLI fallback review: actionable 0건
  - Post-merge run check: merge SHA `7d1afe4f`에서 SonarCloud pass, CI/Release Artifacts in progress, 즉시 실패 신호 없음

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 알림 설정 화면 | Flutter widget test | 알림 설정/권한/실패 도움말 테스트 4건 | `flutter test test/widget_test.dart --name "(알림 설정 화면은 현재 설정을 불러오고 바꾼 값을 저장한다|알림 설정 화면은 기기 알림 권한을 사용자 확인 뒤 요청한다|알림 설정 화면은 기기 알림 권한 거부를 짧게 안내한다|알림 설정 화면은 기기 알림 실패 도움말을 안내한다)" --reporter expanded` | pass |
| raw 디자인 값 감소 | 정적 스캔 | 알림 설정 파일의 직접 색상/radius 제거 확인 | `rg -n "Color\\(0x|BorderRadius\\.circular|EdgeInsets\\.fromLTRB" apps/mobile/lib/notification_settings.dart` | 색상/radius 제거, page padding 2건 유지 |
| PR CI | GitHub Actions | #1185 checks | `https://github.com/AquilaXk/easysubway/pull/1185/checks` | pass |
| 코드 리뷰 | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review 게시 | `https://github.com/AquilaXk/easysubway/pull/1185#pullrequestreview-4597283525` | actionable 0건 |
| Merge/CD quick check | GitHub Actions main | merge 후 run list 확인 | `https://github.com/AquilaXk/easysubway/actions/runs/28420680586`, `https://github.com/AquilaXk/easysubway/actions/runs/28420680376` | 진행 중, 실패 신호 없음 |
| 화면 캡처 | Android/iOS | 증거 불필요 사유 | 시각 구조 변경 없이 색상 토큰과 radius 표현만 치환했고, 관련 widget 테스트로 화면 상태를 검증했습니다. | pass |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/notification_settings.dart`

## 리스크

- 알림 설정 화면의 색상 참조만 바꾸며 기능 동작과 문구는 바꾸지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
