### PR TITLE
[Fix] 이동 조건 카드 색상 토큰 정리

### DIFF
--- a/apps/mobile/lib/mobility_profile.dart
+++ b/apps/mobile/lib/mobility_profile.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'accessible_design.dart';
 
+const _mobilityProfileCardRadius = BorderRadius.all(Radius.circular(8));
+
 class MobilityProfileOption {
   const MobilityProfileOption({
     required this.id,
@@ -203,8 +205,10 @@ class _MobilityProfileCard extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final borderColor = selected
         ? colorScheme.primary
-        : const Color(0xFFD5E2E4);
-    final backgroundColor = selected ? const Color(0xFFE6F2F0) : Colors.white;
+        : EasySubwayAccessibleColors.line;
+    final backgroundColor = selected
+        ? EasySubwayAccessibleColors.mintSoft
+        : EasySubwayAccessibleColors.surface;
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
@@ -217,12 +221,12 @@ class _MobilityProfileCard extends StatelessWidget {
           child: Material(
             color: backgroundColor,
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: _mobilityProfileCardRadius,
               side: BorderSide(color: borderColor, width: selected ? 2 : 1),
             ),
             child: InkWell(
               key: Key('mobilityProfileCard-${option.id}'),
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: _mobilityProfileCardRadius,
               onTap: onTap,
               child: ConstrainedBox(
                 constraints: const BoxConstraints(minHeight: 76),
@@ -241,7 +245,7 @@ class _MobilityProfileCard extends StatelessWidget {
                               option.title,
                               style: Theme.of(context).textTheme.titleMedium
                                   ?.copyWith(
-                                    color: const Color(0xFF102A2C),
+                                    color: EasySubwayAccessibleColors.text,
                                     fontWeight: FontWeight.w900,
                                     height: 1.25,
                                   ),
@@ -251,7 +255,7 @@ class _MobilityProfileCard extends StatelessWidget {
                               option.summary,
                               style: Theme.of(context).textTheme.bodyLarge
                                   ?.copyWith(
-                                    color: const Color(0xFF29484B),
+                                    color: EasySubwayAccessibleColors.mutedText,
                                     fontWeight: FontWeight.w700,
                                     height: 1.3,
                                   ),
@@ -290,7 +294,7 @@ class _SelectionStatus extends StatelessWidget {
       child: Text(
         '${selectedOption.title} 조건을 선택했습니다',
         style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-          color: const Color(0xFF102A2C),
+          color: EasySubwayAccessibleColors.text,
           fontWeight: FontWeight.w800,
           height: 1.35,
         ),


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- #1075의 남은 항목 중 모바일 화면의 raw 디자인 값을 줄이는 작업입니다.
- 이동 조건 선택 카드에 직접 색상값과 직접 radius 표현이 남아 있어 접근성 색상 토큰과 로컬 radius 상수로 정리합니다.

## 작업 내용

- 이동 조건 선택 카드의 기본 테두리, 선택 배경, 제목/설명/선택 상태 문구 색상을 `EasySubwayAccessibleColors`로 바꿨습니다.
- 카드와 터치 영역 radius를 `_mobilityProfileCardRadius` 상수로 맞췄습니다.
- 이번 PR은 `mobility_profile.dart` 파일 하나만 건드렸고, page padding은 화면 여백 기준이라 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/mobility_profile.dart`: exit 0
  - `git diff --check`: exit 0
  - `rg -n "Color\\(0x|BorderRadius\\.circular|EdgeInsets\\.fromLTRB" apps/mobile/lib/mobility_profile.dart`: 남은 항목 1건은 page padding
  - `flutter test test/widget_test.dart --name "(이동 조건 화면은 큰 선택 카드로 사용자 상황을 고를 수 있다|홈 이동 조건 화면은 저장된 profile을 선택 상태로 연다|홈에서 바꾼 이동 조건은 재시작 뒤 다음 경로 요청에 반영된다)" --reporter expanded`: exit 0, 3 tests passed
  - PR CI: Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan, Release Gate Consistency, Release Artifacts, SonarCloud Code Analysis pass
  - CodeRabbit: rate limit으로 실제 리뷰 미시작 확인
  - Codex CLI fallback review: actionable 0건
  - Post-merge run check: merge SHA `f31c0b5a`에서 SonarCloud pass, CI/Release Artifacts in progress, 즉시 실패 신호 없음

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 이동 조건 선택 화면 | Flutter widget test | 이동 조건 선택, 저장된 선택 상태, 재시작 후 경로 요청 반영 테스트 3건 | `flutter test test/widget_test.dart --name "(이동 조건 화면은 큰 선택 카드로 사용자 상황을 고를 수 있다|홈 이동 조건 화면은 저장된 profile을 선택 상태로 연다|홈에서 바꾼 이동 조건은 재시작 뒤 다음 경로 요청에 반영된다)" --reporter expanded` | pass |
| raw 디자인 값 감소 | 정적 스캔 | 이동 조건 파일의 직접 색상/radius 제거 확인 | `rg -n "Color\\(0x|BorderRadius\\.circular|EdgeInsets\\.fromLTRB" apps/mobile/lib/mobility_profile.dart` | 색상/radius 제거, page padding 1건 유지 |
| PR CI | GitHub Actions | #1186 checks | `https://github.com/AquilaXk/easysubway/pull/1186/checks` | pass |
| 코드 리뷰 | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review 게시 | `https://github.com/AquilaXk/easysubway/pull/1186#pullrequestreview-4597343061` | actionable 0건 |
| Merge/CD quick check | GitHub Actions main | merge 후 run list 확인 | `https://github.com/AquilaXk/easysubway/actions/runs/28421138494`, `https://github.com/AquilaXk/easysubway/actions/runs/28421138294` | 진행 중, 실패 신호 없음 |
| 화면 캡처 | Android/iOS | 증거 불필요 사유 | 시각 구조와 문구 변경 없이 색상 토큰과 radius 표현만 치환했고, 관련 widget 테스트로 선택 흐름을 검증했습니다. | pass |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/mobility_profile.dart`

## 리스크

- 선택 카드의 토큰 참조만 바꾸며 이동 조건 선택, 저장, 경로 요청 동작은 바꾸지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
