### PR TITLE
[Fix] 즐겨찾기 시설 카드 색상 토큰 정리

### DIFF
--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 import 'auth_headers.dart';
+import 'accessible_design.dart';
 import 'facility_report.dart';
 import 'facility_status.dart';
 import 'mobile_error_reporter.dart';
@@ -12,6 +13,7 @@ import 'mobile_error_reporter.dart';
 const _favoriteFacilityTimeout = Duration(seconds: 8);
 const _favoriteFacilityLoadErrorMessage = '즐겨찾기 시설을 불러오지 못했어요.';
 const _favoriteFacilityChangeErrorMessage = '즐겨찾기 시설을 처리하지 못했어요.';
+const _favoriteFacilityCardRadius = BorderRadius.all(Radius.circular(8));
 
 abstract class FavoriteFacilityRepository {
   Future<List<FavoriteFacility>> listFavoriteFacilities();
@@ -608,11 +610,11 @@ class _FavoriteFacilityTile extends StatelessWidget {
     return Card(
       key: Key('favoriteFacilityTile-${favorite.facilityId}'),
       margin: const EdgeInsets.only(bottom: 12),
-      color: Colors.white,
+      color: EasySubwayAccessibleColors.surface,
       elevation: 0,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8),
-        side: const BorderSide(color: Color(0xFFD5E2E4)),
+        borderRadius: _favoriteFacilityCardRadius,
+        side: const BorderSide(color: EasySubwayAccessibleColors.line),
       ),
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -629,7 +631,7 @@ class _FavoriteFacilityTile extends StatelessWidget {
                       Text(
                         favorite.name,
                         style: textTheme.titleLarge?.copyWith(
-                          color: const Color(0xFF102A2C),
+                          color: EasySubwayAccessibleColors.text,
                           fontWeight: FontWeight.w900,
                           height: 1.25,
                         ),
@@ -638,7 +640,7 @@ class _FavoriteFacilityTile extends StatelessWidget {
                       Text(
                         favorite.stationLabel,
                         style: textTheme.bodyLarge?.copyWith(
-                          color: const Color(0xFF29484B),
+                          color: EasySubwayAccessibleColors.mutedText,
                           fontWeight: FontWeight.w800,
                           height: 1.3,
                         ),
@@ -647,7 +649,7 @@ class _FavoriteFacilityTile extends StatelessWidget {
                       Text(
                         favorite.statusTitle,
                         style: textTheme.bodyMedium?.copyWith(
-                          color: const Color(0xFF405A5D),
+                          color: EasySubwayAccessibleColors.mutedText,
                           height: 1.3,
                         ),
                       ),
@@ -655,7 +657,7 @@ class _FavoriteFacilityTile extends StatelessWidget {
                       Text(
                         '${favorite.severityLabel} · ${favorite.nextActionLabel}',
                         style: textTheme.bodyMedium?.copyWith(
-                          color: const Color(0xFF405A5D),
+                          color: EasySubwayAccessibleColors.mutedText,
                           fontWeight: FontWeight.w700,
                           height: 1.3,
                         ),
@@ -664,7 +666,7 @@ class _FavoriteFacilityTile extends StatelessWidget {
                       Text(
                         favorite.locationLabel,
                         style: textTheme.bodyMedium?.copyWith(
-                          color: const Color(0xFF405A5D),
+                          color: EasySubwayAccessibleColors.mutedText,
                           height: 1.3,
                         ),
                       ),
@@ -672,7 +674,7 @@ class _FavoriteFacilityTile extends StatelessWidget {
                       Text(
                         favorite.updatedLabel,
                         style: textTheme.bodyMedium?.copyWith(
-                          color: const Color(0xFF405A5D),
+                          color: EasySubwayAccessibleColors.mutedText,
                           height: 1.3,
                         ),
                       ),
@@ -680,7 +682,7 @@ class _FavoriteFacilityTile extends StatelessWidget {
                       Text(
                         favorite.verificationStatusLabel,
                         style: textTheme.bodyMedium?.copyWith(
-                          color: const Color(0xFF405A5D),
+                          color: EasySubwayAccessibleColors.mutedText,
                           height: 1.3,
                         ),
                       ),
@@ -721,7 +723,7 @@ class _FavoriteFacilityMessage extends StatelessWidget {
       child: Text(
         message,
         style: Theme.of(context).textTheme.titleMedium?.copyWith(
-          color: const Color(0xFF102A2C),
+          color: EasySubwayAccessibleColors.text,
           fontWeight: FontWeight.w800,
           height: 1.35,
         ),


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- #1075의 남은 항목 중 모바일 화면의 raw 디자인 값을 줄이는 작업입니다.
- 즐겨찾기 시설 카드에 직접 색상값과 직접 radius 표현이 남아 있어 접근성 색상 토큰과 로컬 radius 상수로 정리합니다.

## 작업 내용

- 즐겨찾기 시설 카드의 배경, 테두리, 제목/상세/상태 메시지 색상을 `EasySubwayAccessibleColors`로 바꿨습니다.
- 카드 radius를 `_favoriteFacilityCardRadius` 상수로 맞췄습니다.
- 이번 PR은 `favorite_facility.dart` 파일 하나만 건드렸고, 목록 page padding은 화면 여백 기준이라 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/favorite_facility.dart`: exit 0
  - `git diff --check`: exit 0
  - `rg -n "Color\\(0x|BorderRadius\\.circular|EdgeInsets\\.fromLTRB" apps/mobile/lib/favorite_facility.dart`: 남은 항목 1건은 page padding
  - `flutter test test/favorite_facility_test.dart --reporter expanded`: exit 0, 5 tests passed
  - `flutter test test/widget_test.dart --name "(홈 즐겨찾기 시설은 저장한 시설을 큰 목록으로 보여준다|홈 즐겨찾기 시설 제보는 위치 권한 확인 흐름을 유지한다)" --reporter expanded`: 첫 병렬 실행은 Flutter startup lock 충돌로 실패, 단독 재실행 exit 0, 2 tests passed
  - PR CI: Android CI, Backend CI, Mobile App CI, Repository CI, Dependency Vulnerability Scan, Release Gate Consistency, Release Artifacts, SonarCloud Code Analysis pass
  - CodeRabbit: rate limit으로 실제 리뷰 미시작 확인
  - Codex CLI fallback review: actionable 0건
  - Post-merge run check: merge SHA `c4ffed1e`에서 SonarCloud pass, CI/Release Artifacts in progress, 즉시 실패 신호 없음

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 즐겨찾기 시설 카드 | Flutter widget test | 저장한 시설 목록 표시와 상태 제보 진입 흐름 테스트 2건 | `flutter test test/widget_test.dart --name "(홈 즐겨찾기 시설은 저장한 시설을 큰 목록으로 보여준다|홈 즐겨찾기 시설 제보는 위치 권한 확인 흐름을 유지한다)" --reporter expanded` | pass |
| 즐겨찾기 시설 모델/API | Flutter test | 파싱, 상태 라벨, 인증 재시도, 저장/해제, 목록 상태 테스트 | `flutter test test/favorite_facility_test.dart --reporter expanded` | pass |
| raw 디자인 값 감소 | 정적 스캔 | 즐겨찾기 시설 파일의 직접 색상/radius 제거 확인 | `rg -n "Color\\(0x|BorderRadius\\.circular|EdgeInsets\\.fromLTRB" apps/mobile/lib/favorite_facility.dart` | 색상/radius 제거, page padding 1건 유지 |
| PR CI | GitHub Actions | #1187 checks | `https://github.com/AquilaXk/easysubway/pull/1187/checks` | pass |
| 코드 리뷰 | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review 게시 | `https://github.com/AquilaXk/easysubway/pull/1187#pullrequestreview-4597383488` | actionable 0건 |
| Merge/CD quick check | GitHub Actions main | merge 후 run list 확인 | `https://github.com/AquilaXk/easysubway/actions/runs/28421550140`, `https://github.com/AquilaXk/easysubway/actions/runs/28421549888` | 진행 중, 실패 신호 없음 |
| 화면 캡처 | Android/iOS | 증거 불필요 사유 | 시각 구조와 문구 변경 없이 색상 토큰과 radius 표현만 치환했고, 관련 widget 테스트로 카드 표시와 제보 흐름을 검증했습니다. | pass |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/favorite_facility.dart`

## 리스크

- 즐겨찾기 시설 카드의 토큰 참조만 바꾸며 시설 목록, 상태 라벨, 제보 진입 동작은 바꾸지 않았습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
