### PR TITLE
[Fix] 노선 추가 배지 색상 토큰 정리

### DIFF
--- a/apps/mobile/lib/features/stations/presentation/station_line_badges.dart
+++ b/apps/mobile/lib/features/stations/presentation/station_line_badges.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../accessible_design.dart';
 import '../domain/station_line.dart';
 
 class StationLineBadges extends StatelessWidget {
@@ -113,15 +114,15 @@ class _StationLineOverflowBadge extends StatelessWidget {
       height: size,
       alignment: Alignment.center,
       decoration: BoxDecoration(
-        color: const Color(0xFFE8F0F1),
+        color: EasySubwayAccessibleColors.skySoft,
         shape: BoxShape.circle,
-        border: Border.all(color: const Color(0xFFB8CACC)),
+        border: Border.all(color: EasySubwayAccessibleColors.line),
       ),
       child: Text(
         '+$count',
         textAlign: TextAlign.center,
         style: Theme.of(context).textTheme.labelLarge?.copyWith(
-          color: const Color(0xFF29484B),
+          color: EasySubwayAccessibleColors.mutedText,
           fontSize: 13 * (size / 32),
           fontWeight: FontWeight.w900,
           height: 1.0,


### PR DESCRIPTION
## 관련 이슈

refs #1075

## 작업 배경

- 역 검색 결과의 환승 노선 추가 개수 배지가 직접 색상값을 사용하고 있어 큰 글씨·고대비 정리 작업의 남은 UI 흔들림으로 남아 있었다.
- 실제 노선 아이콘 이미지는 그대로 두고, 추가 개수 배지만 공통 접근성 색상 토큰을 쓰도록 좁게 정리했다.

## 작업 내용

- `StationLineBadges`의 `+N` 추가 노선 배지 배경, 테두리, 글자색을 `EasySubwayAccessibleColors` 토큰으로 교체했다.
- 공식 노선 PNG 배지의 크기와 모서리 처리는 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/features/stations/presentation/station_line_badges.dart`: exit 0
  - `git diff --check`: exit 0
  - `rg -n "Color\\(0x|BorderRadius\\.circular|EdgeInsets\\.fromLTRB" apps/mobile/lib/features/stations/presentation/station_line_badges.dart`: 공식 노선 PNG 배지 모서리 처리 1건만 남음
  - `flutter test test/station_line_badge_test.dart --reporter expanded`: exit 0, 3 tests passed
  - `flutter test test/widget_test.dart --name "역 검색 결과는 환승 노선 배지를 대표 노선과 추가 개수로 줄인다" --reporter expanded`: exit 0, 1 test passed
  - `flutter analyze lib/features/stations/presentation/station_line_badges.dart`: exit 0, No issues found
  - GitHub Actions PR checks: Android CI, Mobile App CI, Backend CI, Repository CI, Release Gate Consistency, Dependency Vulnerability Scan, Android Release Artifact, RC Evidence Manifest, SonarCloud Code Analysis 모두 pass
  - CodeRabbit: rate limit으로 실제 review 미시작, Codex CLI fallback review `Actionable comments posted: 0`
  - post-merge main run 확인: merge commit `6168e061` 기준 CD pending, CI/Release Artifacts in progress, SonarCloud success, 실패 신호 없음

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 추가 노선 배지 색상 토큰 | Flutter | focused widget/unit test와 analyzer | `flutter test test/station_line_badge_test.dart --reporter expanded`, `flutter analyze lib/features/stations/presentation/station_line_badges.dart` | 통과 |
| 대표 노선 + 추가 개수 표시 회귀 | Flutter | 기존 검색 결과 widget test | `flutter test test/widget_test.dart --name "역 검색 결과는 환승 노선 배지를 대표 노선과 추가 개수로 줄인다" --reporter expanded` | 통과 |
| PR 원격 검증 | GitHub Actions | PR #1190 checks | https://github.com/AquilaXk/easysubway/pull/1190/checks | 통과 |
| CodeRabbit 대체 리뷰 | GitHub PR review | Codex CLI fallback review | https://github.com/AquilaXk/easysubway/pull/1190#pullrequestreview-4597495940 | actionable 0 |
| post-merge CD 확인 | GitHub Actions main | merge commit `6168e061` run 생성과 실패 신호 확인 | https://github.com/AquilaXk/easysubway/actions/runs/28422290559 | pending, 실패 신호 없음 |
| 화면 증거 | 공통 | 색상 토큰 단일 파일 교체로 화면 구조·문구·상호작용 변경 없음 | 증거 불필요 사유: 새 화면 상태나 사용자 흐름을 만들지 않고 기존 배지의 색상 source만 바꿈 | 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/features/stations/presentation/station_line_badges.dart`의 `_StationLineOverflowBadge`

## 리스크

- 변경 범위는 추가 개수 배지 색상에 한정된다. 공식 노선 이미지 자체의 색상·모서리 처리는 이번 PR에서 바꾸지 않았다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
