### PR TITLE
[CI] CD workflow_run 트리거를 main CI로 제한

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,8 @@ on:
       - CI
     types:
       - completed
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       mode:

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -420,6 +420,7 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
 
   assert.match(workflow, /name: CD/);
   assert.match(workflow, /workflow_run:[\s\S]*workflows:\s*\n\s*-\s*CI[\s\S]*types:\s*\n\s*-\s*completed/);
+  assert.match(workflow, /workflow_run:[\s\S]*branches:\s*\n\s*-\s*main/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /permissions:[\s\S]*actions:\s*read[\s\S]*contents:\s*read/);
   assert.match(workflow, /group: cd-production-deploy/);


### PR DESCRIPTION
## 관련 이슈

close #1194

## 작업 배경

production environment required reviewer는 유지한 상태에서 CD를 진행해야 한다. 기존 CD workflow_run은 CI 완료 이벤트의 branch 제한이 없어 PR 또는 비-main CI 완료에도 production CD run을 새로 만들 수 있고, 그 결과 승인 대기 중인 run이 concurrency로 취소될 수 있다.

## 작업 내용

- CD workflow_run trigger를 main branch CI 완료로 제한했다.
- repository contract test가 CD workflow_run의 main branch 제한을 검증하도록 추가했다.
- workflow_dispatch 수동 실행과 production environment 보호 설정은 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - Ruby YAML parser로 `.github/workflows/cd.yml` 로드: `cd yaml ok`, exit 0
  - `node --test --test-name-pattern "지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을 검증한다" tools/ci/repository-contract.test.mjs`: 1 pass, 145 skipped, exit 0
  - `git diff --check -- .github/workflows/cd.yml tools/ci/repository-contract.test.mjs`: exit 0
  - PR CI: pass
  - Codex CLI fallback review: actionable comments 0
  - 현재 CD run #28423825086: failure, `Upload and run SSH deployment`에서 port 22 connection timeout

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| CD workflow YAML parse | local | Ruby YAML parser | command output | 통과 |
| CD repository contract | local | targeted node:test | command output | 통과 |
| whitespace check | local | git diff --check | command output | 통과 |
| PR CI | GitHub Actions | PR checks | https://github.com/AquilaXk/easysubway/pull/1195/checks | 통과 |
| fallback review | GitHub PR review | Codex CLI review summary | https://github.com/AquilaXk/easysubway/pull/1195#pullrequestreview-4597693355 | 지적 없음 |
| 현재 CD 실패 | GitHub Actions production | failed job log | https://github.com/AquilaXk/easysubway/actions/runs/28423825086/job/84222305707 | SSH port 22 timeout |
| 화면 증거 | 해당 없음 | CI/CD 설정 변경 | 증거 불필요 사유: UI 변경이 아님 | 해당 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `.github/workflows/cd.yml`의 workflow_run branch filter가 main으로 제한되어 있고 manual dispatch는 유지된다.
- 이 PR은 CD 중복 생성 문제를 막는 변경이다. 현재 production CD 실패 원인은 OCI SSH port 22 timeout으로 별도 네트워크 조치가 필요하다.

## 리스크

- main CI 완료 후 자동 CD는 유지되지만, PR CI 완료로 production CD가 생성되던 기존 동작은 사라진다.
- merge 전 default branch의 기존 CD workflow는 PR CI 완료 이벤트에 반응할 수 있다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.