### PR TITLE
[Fix] MinIO 배포 이미지 태그 수정

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       start_period: 20s
 
   object-storage:
-    image: minio/minio:RELEASE.2026-06-13T11-33-47Z
+    image: minio/minio:RELEASE.2025-06-13T11-33-47Z
     container_name: easysubway-object-storage
     command: ["server", "/data", "--console-address", ":9001"]
     environment:

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5140,6 +5140,7 @@ test("Docker Compose는 backend 필수 서비스를 기본값으로 노출하고
 
   assert.match(compose, /object-storage:\n/);
   assert.match(compose, /image: minio\/minio:/);
+  assert.match(compose, /image: minio\/minio:RELEASE\.2025-06-13T11-33-47Z/);
   assert.doesNotMatch(objectStorageBlock, /profiles:/);
   assert.match(compose, /MINIO_ROOT_USER: \$\{EASYSUBWAY_OBJECT_STORAGE_ACCESS_KEY:-easysubway_local\}/);
   assert.match(compose, /MINIO_ROOT_PASSWORD: \$\{EASYSUBWAY_OBJECT_STORAGE_SECRET_KEY:-easysubway_local_secret\}/);


### PR DESCRIPTION
## 관련 이슈

close #1202

## 작업 배경

- production CD run `28425529989`가 `Run local deployment` 단계에서 object-storage 이미지를 pull하지 못해 실패했다.
- 실패 로그는 `minio/minio:RELEASE.2026-06-13T11-33-47Z` 태그가 Docker Hub에 없다고 보고했다.

## 작업 내용

- Docker Compose의 MinIO 이미지를 존재하는 `RELEASE.2025-06-13T11-33-47Z` 태그로 수정했다.
- repository contract가 해당 MinIO 태그를 직접 검증하도록 보강했다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "Docker Compose" tools/ci/repository-contract.test.mjs`: pass 2, skipped 144, fail 0
  - `git diff --check -- infra/docker-compose.yml tools/ci/repository-contract.test.mjs`: exit 0
  - Docker Hub tag API: `RELEASE.2025-06-13T11-33-47Z` 태그와 linux/arm64 이미지 존재 확인
  - `docker manifest inspect minio/minio:RELEASE.2025-06-13T11-33-47Z`: 로컬 DNS 제한으로 Docker registry 조회 실패

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Docker Compose contract | local | Node test | `node --test --test-name-pattern "Docker Compose" tools/ci/repository-contract.test.mjs` | pass 2, skipped 144, fail 0 |
| MinIO image tag | Docker Hub | tag API 조회 | `RELEASE.2025-06-13T11-33-47Z` linux/arm64 이미지 확인 | 존재함 |
| CD 실패 원인 | GitHub Actions | run log | CD run `28425529989`, `Run local deployment` | 기존 태그 not found |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `infra/docker-compose.yml`의 object-storage 이미지 태그가 존재하는 날짜 태그로 바뀐 점.

## 리스크

- MinIO patch level 변경으로 object-storage 컨테이너가 새 이미지 digest를 받는다.
- backend API 코드는 변경하지 않았다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.