### PR TITLE
[Fix] PostGIS 배포 이미지를 ARM64 지원 태그로 전환

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: imresamu/postgis:16-3.5
+    image: imresamu/postgis:16-3.5@sha256:92031b614897082103c00729ea26e62f118ecb59b71e27b5c3ac3a8dc13bff23
     container_name: easysubway-postgres
     environment:
       POSTGRES_DB: ${EASYSUBWAY_POSTGRES_DB:-easysubway}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgis/postgis:16-3.5
+    image: imresamu/postgis:16-3.5
     container_name: easysubway-postgres
     environment:
       POSTGRES_DB: ${EASYSUBWAY_POSTGRES_DB:-easysubway}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5129,7 +5129,10 @@ test("Docker Compose는 backend 필수 서비스를 기본값으로 노출하고
   const objectStorageBlock = compose.match(/  object-storage:\n[\s\S]*?\n\n  prometheus:/)?.[0] ?? "";
 
   assert.match(compose, /postgres:\n/);
-  assert.match(compose, /image: imresamu\/postgis:16-3\.5/);
+  assert.match(
+    compose,
+    /image: imresamu\/postgis:16-3\.5@sha256:92031b614897082103c00729ea26e62f118ecb59b71e27b5c3ac3a8dc13bff23/,
+  );
   assert.doesNotMatch(postgresBlock, /profiles:/);
   assert.match(compose, /POSTGRES_DB: \$\{EASYSUBWAY_POSTGRES_DB:-easysubway\}/);
   assert.match(compose, /POSTGRES_USER: \$\{EASYSUBWAY_POSTGRES_USER:-easysubway\}/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5129,7 +5129,7 @@ test("Docker Compose는 backend 필수 서비스를 기본값으로 노출하고
   const objectStorageBlock = compose.match(/  object-storage:\n[\s\S]*?\n\n  prometheus:/)?.[0] ?? "";
 
   assert.match(compose, /postgres:\n/);
-  assert.match(compose, /image: postgis\/postgis:16-3\.5/);
+  assert.match(compose, /image: imresamu\/postgis:16-3\.5/);
   assert.doesNotMatch(postgresBlock, /profiles:/);
   assert.match(compose, /POSTGRES_DB: \$\{EASYSUBWAY_POSTGRES_DB:-easysubway\}/);
   assert.match(compose, /POSTGRES_USER: \$\{EASYSUBWAY_POSTGRES_USER:-easysubway\}/);


### PR DESCRIPTION
## 관련 이슈

close #1204

## 작업 배경

- CD run `28426784825`에서 `postgis/postgis:16-3.5` 이미지가 `linux/arm64/v8` manifest를 제공하지 않아 OCI A1 self-hosted runner 배포가 중단됐다.
- MinIO 태그 문제는 이전 수정 후 통과했으며, 이번 실패 지점은 `postgres` 서비스 이미지 pull 단계다.

## 작업 내용

- Docker Compose `postgres` 서비스를 ARM64 manifest가 있는 `imresamu/postgis:16-3.5` 이미지로 전환하고 manifest-list digest까지 고정했다.
- Repository contract test가 새 PostGIS 이미지 태그와 digest를 고정하도록 갱신했다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "Docker Compose" tools/ci/repository-contract.test.mjs`: pass 2, fail 0, skipped 144
  - `git diff --check -- infra/docker-compose.yml tools/ci/repository-contract.test.mjs`: exit 0
  - `curl -fsSL https://hub.docker.com/v2/repositories/imresamu/postgis/tags/16-3.5`: `linux/arm64/v8` image entry 확인
  - PR checks: CI `28427400754`, Release Artifacts `28427400382`, SonarCloud `28427400391` pass
  - Codex CLI fallback review: actionable 1건 발견, `61f7576a`에서 digest pin으로 수정 후 원래 inline thread에 해결 답글 작성 및 resolved 처리

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 기존 CD 실패 | GitHub Actions / OCI A1 | CD run 실패 로그 확인 | `28426784825` `Run local deployment` 로그 | `postgis/postgis:16-3.5`가 `linux/arm64/v8` manifest를 제공하지 않아 실패 |
| PostGIS ARM64 manifest | Docker Hub | tag API 응답 확인 | `imresamu/postgis:16-3.5` images 배열 | `linux/arm64/v8` active image와 manifest-list digest 확인 |
| Docker Compose 계약 | macOS local | `node --test --test-name-pattern "Docker Compose" tools/ci/repository-contract.test.mjs` | 로컬 명령 출력 | pass 2, fail 0 |
| diff whitespace | macOS local | `git diff --check -- infra/docker-compose.yml tools/ci/repository-contract.test.mjs` | 로컬 명령 출력 | exit 0 |
| PR CI | GitHub Actions | PR checks 확인 | CI `28427400754`, Release Artifacts `28427400382`, SonarCloud `28427400391` | pass |
| fallback review | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI review 수행 | PR review `4598154454`, inline discussion `3496878834` | digest pin 수정 답글 후 resolved |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `infra/docker-compose.yml`의 PostGIS 이미지 출처 변경과 `tools/ci/repository-contract.test.mjs`의 태그 고정 assertion.

## 리스크

- 공식 `postgis/postgis:16-3.5` 태그가 ARM64를 제공하지 않아 ARM64 지원 mirror 태그를 사용한다.
- Postgres 16 / PostGIS 3.5 조합은 유지했고 digest pin을 적용했지만 이미지 repository가 바뀌므로 merge 후 CD에서 실제 pull과 컨테이너 기동을 확인한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 로컬 Docker 스택의 PostgreSQL/PostGIS 이미지가 특정 버전 다이제스트로 고정되어, 환경별 차이로 인한 실행 편차를 줄였습니다.
  * 로컬 스택 검증 기준도 새 이미지 고정 방식에 맞게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->