### PR TITLE
[Fix] 시설 제보 화면 스타일 토큰 정리

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -36,6 +36,13 @@ const _facilityReportUploadDisclosureScope =
     '제보 내용은 접수 담당자에게 전달되며 앱 사용자에게 공개되지 않습니다.';
 const _facilityReportDraftTargetStorageKey =
     'easysubway.facilityReport.draftTarget';
+const _facilityReportPagePadding = EdgeInsets.only(
+  left: 20,
+  top: 20,
+  right: 20,
+  bottom: 32,
+);
+const _facilityReportCardRadius = BorderRadius.all(Radius.circular(8));
 
 abstract class FacilityReportRepository {
   Future<FacilityReportResult> createReport(FacilityReportRequest request);
@@ -1316,7 +1323,7 @@ class _MyFacilityReportListScreenState
             }
 
             return ListView.separated(
-              padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+              padding: _facilityReportPagePadding,
               itemCount: reports.length,
               separatorBuilder: (_, _) => const SizedBox(height: 12),
               itemBuilder: (context, index) {
@@ -1436,12 +1443,12 @@ class _MyReportListItem extends StatelessWidget {
         child: Material(
           color: EasySubwayAccessibleColors.surface,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: _facilityReportCardRadius,
             side: const BorderSide(color: EasySubwayAccessibleColors.line),
           ),
           child: InkWell(
             key: Key('myReport-${report.id}'),
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: _facilityReportCardRadius,
             onTap: openReportDetail,
             child: Padding(
               padding: const EdgeInsets.all(16),
@@ -1515,7 +1522,7 @@ class MyFacilityReportDetailScreen extends StatelessWidget {
           label:
               '내 제보 상세, ${report.reportTypeLabel}, 현재 상태 ${report.statusLabel}, 제보 번호 ${report.displayReceiptCode}',
           child: ListView(
-            padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+            padding: _facilityReportPagePadding,
             children: [
               Text(
                 report.reportTypeLabel,
@@ -1556,7 +1563,7 @@ class _MyReportDetailStatus extends StatelessWidget {
       child: Container(
         decoration: BoxDecoration(
           color: EasySubwayAccessibleColors.mintSoft,
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: _facilityReportCardRadius,
           border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
         ),
         child: Padding(
@@ -1618,7 +1625,7 @@ class _MyReportStatusPill extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: EasySubwayAccessibleColors.mintSoft,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: _facilityReportCardRadius,
         border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
       ),
       child: Padding(
@@ -1718,7 +1725,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
       appBar: AppBar(title: const Text('시설 알려주기')),
       body: SafeArea(
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          padding: _facilityReportPagePadding,
           children: [
             _FacilityReportHeader(target: widget.target),
             const SizedBox(height: 24),
@@ -1760,7 +1767,7 @@ class _FacilityReportScreenState extends State<FacilityReportScreen> {
                 hintText: '상황을 짧게 적어 주세요',
                 floatingLabelBehavior: FloatingLabelBehavior.always,
                 border: OutlineInputBorder(
-                  borderRadius: BorderRadius.all(Radius.circular(8)),
+                  borderRadius: _facilityReportCardRadius,
                 ),
               ),
             ),
@@ -2294,7 +2301,7 @@ class _FacilityReportStatusPanel extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: EasySubwayAccessibleColors.mintSoft,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: _facilityReportCardRadius,
         border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
       ),
       child: Padding(
@@ -2472,12 +2479,12 @@ class _FacilityReportTypeCard extends StatelessWidget {
         child: Material(
           color: selected ? color : EasySubwayAccessibleColors.surface,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: _facilityReportCardRadius,
             side: BorderSide(color: color, width: 1.5),
           ),
           child: InkWell(
             key: Key('facilityReportType-${option.reportType}'),
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: _facilityReportCardRadius,
             onTap: onTap,
             child: ConstrainedBox(
               constraints: const BoxConstraints(minHeight: 72),


### PR DESCRIPTION
## 관련 이슈

#1075 하위 작업입니다. #1075는 Android/iOS 증거와 남은 디자인 토큰 정리 확인 전까지 닫지 않습니다.

## 작업 배경

#1075의 디자인 시스템 정리 항목 중 시설 제보 화면에는 직접 radius와 page padding 표현이 일부 남아 있었습니다. 화면 동작은 유지하고 반복 스타일만 기존 파일 상수로 모았습니다.

## 작업 내용

- 시설 제보 목록, 상세, 작성 화면의 반복 page padding을 `_facilityReportPagePadding`으로 통일했습니다.
- 시설 제보 카드, 상태 pill, 입력 필드, 선택 카드의 반복 8px radius를 `_facilityReportCardRadius`로 통일했습니다.
- `facility_report.dart`에서 `Color(0x...)`, `BorderRadius.circular(...)`, `EdgeInsets.fromLTRB(...)` 검색 잔여를 제거했습니다.

## 검증

- 실행한 명령과 결과:
- `dart format apps/mobile/lib/facility_report.dart`: exit 0
- `rg -n "Color\\(0x|BorderRadius\\.circular|EdgeInsets\\.fromLTRB" apps/mobile/lib/facility_report.dart`: exit 1, 잔여 없음
- `flutter analyze lib/facility_report.dart`: exit 0, No issues found
- `flutter test test/widget_test.dart --name "시설 신고 화면은 사진과 위치를 보내기 전에 공개 범위를 안내한다" --reporter expanded`: exit 0, 1 test passed
- `flutter test test/facility_report_test.dart --reporter expanded`: exit 0, 26 tests passed
- `flutter test test/widget_test.dart --name "시설 신고 화면은 GPS가 꺼져 있으면 위치 없이 제보를 선택할 수 있다" --reporter expanded`: exit 0, 1 test passed
- `node --test --test-name-pattern "모바일 production 사용자 문구|모바일 설정 저장 실패와 시설 제보 위치 실패 회귀 테스트는 유지된다" tools/ci/repository-contract.test.mjs`: exit 0, 2 tests passed
- `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 시설 제보 스타일 토큰 | Flutter test/analyze | targeted analyze/test와 raw style 검색 | 위 검증 명령 출력 | 동작 변경 없이 시설 제보 파일 raw style 검색 잔여 없음 |
| Android 200% 글자/탭 shell | Android emulator `easysubway_ps16k_api36` | 최신 main `47b9ffcf` debug 실행, font scale 2.0, UI tree/screenshot/logcat 수집 | local-only `.codex/evidence/1075/android-main-47b9ffcf/` | 홈/노선도/길찾기/즐겨찾기/더보기 탭과 시스템 back 홈 복귀 확인 |
| iOS 수동 증거 | iOS Simulator | XcodeBuildMCP `list_sims` 확인 | `Maum iPhone 17` simulator가 Shutdown 상태 | iOS skill 지침상 임의 부팅하지 않았고 #1075 close 전 별도 수집 필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/facility_report.dart` 상단 상수와 기존 위젯 대체만 확인하면 됩니다.
- 이 PR은 #1075 전체 close PR이 아닙니다.

## 리스크

- 레이아웃 값은 기존과 같아 사용자 화면 변화는 없어야 합니다.
- #1075 전체 기준으로는 `main.dart`, `route_search.dart`, `station_search.dart`에 raw style 정리가 아직 남아 있습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다. rate limit으로 실제 review가 시작되지 않았다.
- [x] Codex CLI fallback review 결과를 PR review `4599085178`로 남겼다.
- [x] merge 후 CI/Release Artifacts run 생성과 현재 실패 신호 없음 상태를 확인했다.
