### PR TITLE
[Fix] 길찾기 radius 표현 정리

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -31,7 +31,7 @@ const _routeSearchPagePadding = EdgeInsets.only(
   right: 20,
   bottom: 32,
 );
-const _routeSearchButtonRadius = BorderRadius.all(Radius.circular(8));
+const _routeSearchSmallRadius = BorderRadius.all(Radius.circular(8));
 
 String _mobilityLabelFor(String mobilityType) {
   for (final option in mobilityProfileOptions) {
@@ -1356,7 +1356,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
                 style: FilledButton.styleFrom(
                   minimumSize: const Size.fromHeight(60),
                   shape: RoundedRectangleBorder(
-                    borderRadius: _routeSearchButtonRadius,
+                    borderRadius: _routeSearchSmallRadius,
                   ),
                 ),
                 child: Text(isLoading ? '경로 검색 중' : '길찾기'),
@@ -2136,7 +2136,7 @@ class _RouteMobilityTypeSummary extends StatelessWidget {
         decoration: BoxDecoration(
           color: const Color(0xFFE9F5F6),
           border: Border.all(color: const Color(0xFFB9D4D8)),
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: _routeSearchSmallRadius,
         ),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
@@ -2502,12 +2502,12 @@ class _RouteStationOptionTile extends StatelessWidget {
             color: Colors.white,
             elevation: 0,
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: _routeSearchSmallRadius,
               side: const BorderSide(color: Color(0xFFD5E2E4)),
             ),
             child: InkWell(
               onTap: () => onSelected(result),
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: _routeSearchSmallRadius,
               child: Padding(
                 padding: const EdgeInsets.all(16),
                 child: Row(
@@ -3352,12 +3352,12 @@ class _RouteResultListButton extends StatelessWidget {
           child: InkWell(
             key: const Key('routeResultListItem'),
             onTap: onPressed,
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: _routeSearchSmallRadius,
             child: Ink(
               decoration: BoxDecoration(
                 color: Colors.white,
                 border: Border.all(color: const Color(0xFF0D8A6D), width: 2),
-                borderRadius: BorderRadius.circular(8),
+                borderRadius: _routeSearchSmallRadius,
               ),
               child: Padding(
                 padding: const EdgeInsets.all(16),
@@ -3435,7 +3435,7 @@ class _RouteDarkSummaryCard extends StatelessWidget {
     return DecoratedBox(
       decoration: BoxDecoration(
         color: const Color(0xFF073245),
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: _routeSearchSmallRadius,
       ),
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -3737,7 +3737,7 @@ class _RouteArrivalGuidance extends StatelessWidget {
       decoration: BoxDecoration(
         color: const Color(0xFFE6F2F0),
         border: Border.all(color: const Color(0xFF9FCACE)),
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: _routeSearchSmallRadius,
       ),
       child: Padding(
         padding: const EdgeInsets.all(14),
@@ -3799,7 +3799,7 @@ class _RouteNotice extends StatelessWidget {
         decoration: BoxDecoration(
           color: const Color(0xFFFFF7E0),
           border: Border.all(color: const Color(0xFFE6C875)),
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: _routeSearchSmallRadius,
         ),
         child: Padding(
           padding: const EdgeInsets.all(12),
@@ -4697,7 +4697,7 @@ class _FavoriteRouteSummaryCard extends StatelessWidget {
             color: Colors.white,
             elevation: 0,
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: _routeSearchSmallRadius,
               side: const BorderSide(color: Color(0xFFD5E2E4)),
             ),
             child: Padding(


### PR DESCRIPTION
## 관련 이슈

- 관련: #1075
- #1075는 parent blocker라 이 PR만으로 닫지 않습니다.

## 작업 배경

- #1075에서 모바일 반복 UI의 raw style 표현을 줄이는 작업을 이어갑니다.
- 직전 PR에서 추가한 길찾기 8px radius 상수를 같은 파일의 동일 radius 표현에 재사용합니다.

## 작업 내용

- `_routeSearchButtonRadius`를 `_routeSearchSmallRadius`로 바꿔 버튼 외 카드/칩/안내 박스에서도 재사용할 수 있게 했습니다.
- `route_search.dart`에 남아 있던 `BorderRadius.circular(8)` 9곳을 `_routeSearchSmallRadius`로 바꿨습니다.

## 검증

- 실행한 명령과 결과:
  - `rg -n "BorderRadius\\.circular\\(8\\)" apps/mobile/lib/route_search.dart`: exit 1, 잔여 없음
  - `flutter test test/widget_test.dart --name "경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다" --reporter expanded`: exit 0, 1 test passed
  - `flutter analyze lib/route_search.dart`: exit 0, No issues found
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 길찾기 8px radius 표현 | Flutter | raw radius 검색 | `rg -n "BorderRadius\\.circular\\(8\\)" apps/mobile/lib/route_search.dart` | exit 1, 잔여 없음 |
| 길찾기 화면 회귀 | Flutter | route_search 포함 widget test | `flutter test test/widget_test.dart --name "경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다" --reporter expanded` | 통과 |
| 정적 분석 | Flutter | 단일 파일 analyze | `flutter analyze lib/route_search.dart` | No issues found |
| 화면 증거 | Android/iOS | 시각 변화 없는 radius 상수 재사용 | 증거 불필요 사유: 렌더링 값 변경 없이 같은 8px radius 표현만 치환 | 추가 캡처 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/route_search.dart`의 `_routeSearchSmallRadius` 치환입니다.
- 전체 raw style 제거가 아니라 `BorderRadius.circular(8)`만 닫는 작은 후속 PR입니다.

## 리스크

- 낮음. 동일 radius 값을 같은 파일 상수로 재사용하는 변경입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
