### PR TITLE
[Fix] 즐겨찾기 경로 padding 표현 정리

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -4482,7 +4482,7 @@ class _FavoriteRouteListBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView(
-      padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+      padding: _routeSearchPagePadding,
       children: [
         switch (state.status) {
           FavoriteRouteListStatus.loading => Semantics(


### PR DESCRIPTION
## 관련 이슈

- 관련: #1075
- #1075는 parent blocker라 이 PR만으로 닫지 않습니다.

## 작업 배경

- #1075에서 모바일 반복 UI의 raw style 표현을 줄이는 작업을 이어갑니다.
- 길찾기 화면에 남은 동일 page padding 직접 표현을 기존 상수로 정리합니다.

## 작업 내용

- 즐겨찾기 경로 목록 `ListView`의 `EdgeInsets.fromLTRB(20, 20, 20, 32)` 직접 사용을 `_routeSearchPagePadding`으로 바꿨습니다.

## 검증

- 실행한 명령과 결과:
  - `rg -n "EdgeInsets\\.fromLTRB\\(20, 20, 20, 32\\)|BorderRadius\\.circular\\(8\\)" apps/mobile/lib/route_search.dart`: exit 1, 잔여 없음
  - `flutter test test/widget_test.dart --name "즐겨찾기 경로 목록 실패는 도움말을 쉬운 문구로 안내한다" --reporter expanded`: exit 0, 1 test passed
  - `flutter analyze lib/route_search.dart`: exit 0, No issues found
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 길찾기 padding/radius 표현 | Flutter | raw style 검색 | `rg -n "EdgeInsets\\.fromLTRB\\(20, 20, 20, 32\\)|BorderRadius\\.circular\\(8\\)" apps/mobile/lib/route_search.dart` | exit 1, 잔여 없음 |
| 즐겨찾기 경로 목록 회귀 | Flutter | widget test | `flutter test test/widget_test.dart --name "즐겨찾기 경로 목록 실패는 도움말을 쉬운 문구로 안내한다" --reporter expanded` | 통과 |
| 정적 분석 | Flutter | 단일 파일 analyze | `flutter analyze lib/route_search.dart` | No issues found |
| 화면 증거 | Android/iOS | 시각 변화 없는 padding 상수 재사용 | 증거 불필요 사유: 렌더링 값 변경 없이 같은 padding 표현만 치환 | 추가 캡처 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/route_search.dart`의 1줄 치환입니다.
- 처음에 잘못된 테스트 이름으로 `No tests ran`이 한 번 발생했고, 현재 파일의 실제 테스트 이름으로 다시 실행해 통과를 확인했습니다.

## 리스크

- 낮음. 동일 padding 값을 기존 파일 상수로 재사용하는 변경입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
