### PR TITLE
[Fix] 길찾기 14px radius 표현 정리

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -32,6 +32,7 @@ const _routeSearchPagePadding = EdgeInsets.only(
   bottom: 32,
 );
 const _routeSearchSmallRadius = BorderRadius.all(Radius.circular(8));
+const _routeSearchMediumRadius = BorderRadius.all(Radius.circular(14));
 
 String _mobilityLabelFor(String mobilityType) {
   for (final option in mobilityProfileOptions) {
@@ -1796,7 +1797,7 @@ class _RoutePointRow extends StatelessWidget {
       child: ExcludeSemantics(
         child: InkWell(
           onTap: onTap,
-          borderRadius: BorderRadius.circular(14),
+          borderRadius: _routeSearchMediumRadius,
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 10),
             child: Row(
@@ -1923,7 +1924,7 @@ class _RouteRecentDestinationListState
               decoration: BoxDecoration(
                 color: Colors.white,
                 border: Border.all(color: const Color(0xFFD5E2E4)),
-                borderRadius: BorderRadius.circular(14),
+                borderRadius: _routeSearchMediumRadius,
               ),
               child: Column(
                 children: [
@@ -2034,7 +2035,7 @@ class _RouteRecentDestinationRow extends StatelessWidget {
       child: ExcludeSemantics(
         child: InkWell(
           onTap: onSelected,
-          borderRadius: BorderRadius.circular(14),
+          borderRadius: _routeSearchMediumRadius,
           child: ListTile(
             leading: const Icon(Icons.train_outlined, color: Color(0xFF006D77)),
             title: Text(


### PR DESCRIPTION
## 관련 이슈

- 관련: #1075
- #1075는 parent blocker라 이 PR만으로 닫지 않습니다.

## 작업 배경

- #1075에서 모바일 반복 UI의 raw style 표현을 줄이는 작업을 이어갑니다.
- 길찾기 화면의 14px radius 직접 표현을 같은 파일 상수로 정리합니다.

## 작업 내용

- `_routeSearchMediumRadius`를 추가했습니다.
- `route_search.dart`에 남아 있던 `BorderRadius.circular(14)` 3곳을 `_routeSearchMediumRadius`로 바꿨습니다.

## 검증

- 실행한 명령과 결과:
  - `rg -n "BorderRadius\\.circular\\(14\\)" apps/mobile/lib/route_search.dart`: exit 1, 잔여 없음
  - `flutter test test/widget_test.dart --name "경로 검색 최근 도착지 실패는 빈 화면으로 숨기지 않는다" --reporter expanded`: exit 0, 1 test passed
  - `flutter analyze lib/route_search.dart`: exit 0, No issues found
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 길찾기 14px radius 표현 | Flutter | raw radius 검색 | `rg -n "BorderRadius\\.circular\\(14\\)" apps/mobile/lib/route_search.dart` | exit 1, 잔여 없음 |
| 최근 도착지 상태 회귀 | Flutter | widget test | `flutter test test/widget_test.dart --name "경로 검색 최근 도착지 실패는 빈 화면으로 숨기지 않는다" --reporter expanded` | 통과 |
| 정적 분석 | Flutter | 단일 파일 analyze | `flutter analyze lib/route_search.dart` | No issues found |
| 화면 증거 | Android/iOS | 시각 변화 없는 radius 상수 재사용 | 증거 불필요 사유: 렌더링 값 변경 없이 같은 14px radius 표현만 치환 | 추가 캡처 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/route_search.dart`의 `_routeSearchMediumRadius`와 3개 치환입니다.

## 리스크

- 낮음. 동일 radius 값을 같은 파일 상수로 재사용하는 변경입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
