### PR TITLE
[Fix] 길찾기 20px radius 표현 정리

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -33,6 +33,7 @@ const _routeSearchPagePadding = EdgeInsets.only(
 );
 const _routeSearchSmallRadius = BorderRadius.all(Radius.circular(8));
 const _routeSearchMediumRadius = BorderRadius.all(Radius.circular(14));
+const _routeSearchLargeRadius = BorderRadius.all(Radius.circular(20));
 
 String _mobilityLabelFor(String mobilityType) {
   for (final option in mobilityProfileOptions) {
@@ -1706,7 +1707,7 @@ class _RoutePointPickerCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: Colors.white,
         border: Border.all(color: const Color(0xFFD5E2E4)),
-        borderRadius: BorderRadius.circular(20),
+        borderRadius: _routeSearchLargeRadius,
         boxShadow: const [
           BoxShadow(
             color: Color(0x0F071B2F),
@@ -2945,7 +2946,7 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
         DecoratedBox(
           decoration: BoxDecoration(
             color: const Color(0xFF073245),
-            borderRadius: BorderRadius.circular(20),
+            borderRadius: _routeSearchLargeRadius,
           ),
           child: Padding(
             padding: const EdgeInsets.all(18),
@@ -2958,7 +2959,7 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
                     border: Border.all(
                       color: EasySubwayAccessibleColors.mintBorder,
                     ),
-                    borderRadius: BorderRadius.circular(20),
+                    borderRadius: _routeSearchLargeRadius,
                   ),
                   child: Padding(
                     padding: const EdgeInsets.all(16),
@@ -3040,7 +3041,7 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
                           : EasySubwayAccessibleColors.mint,
                       width: 2,
                     ),
-                    borderRadius: BorderRadius.circular(20),
+                    borderRadius: _routeSearchLargeRadius,
                     boxShadow: const [
                       BoxShadow(
                         color: Color(0x1A0D8A6D),


### PR DESCRIPTION
## 관련 이슈

- 관련: #1075
- #1075는 parent blocker라 이 PR만으로 닫지 않습니다.

## 작업 배경

- #1075에서 모바일 반복 UI의 raw style 표현을 줄이는 작업을 이어갑니다.
- 길찾기 화면의 20px radius 직접 표현을 같은 파일 상수로 정리합니다.

## 작업 내용

- `_routeSearchLargeRadius`를 추가했습니다.
- `route_search.dart`에 남아 있던 `BorderRadius.circular(20)` 4곳을 `_routeSearchLargeRadius`로 바꿨습니다.

## 검증

- 실행한 명령과 결과:
  - `rg -n "BorderRadius\\.circular\\(20\\)" apps/mobile/lib/route_search.dart`: exit 1, 잔여 없음
  - `flutter test test/widget_test.dart --name "경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다" --reporter expanded`: exit 0, 1 test passed
  - `flutter analyze lib/route_search.dart`: exit 0, No issues found
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 길찾기 20px radius 표현 | Flutter | raw radius 검색 | `rg -n "BorderRadius\\.circular\\(20\\)" apps/mobile/lib/route_search.dart` | exit 1, 잔여 없음 |
| 경로 결과/안내 회귀 | Flutter | widget test | `flutter test test/widget_test.dart --name "경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다" --reporter expanded` | 통과 |
| 정적 분석 | Flutter | 단일 파일 analyze | `flutter analyze lib/route_search.dart` | No issues found |
| 화면 증거 | Android/iOS | 시각 변화 없는 radius 상수 재사용 | 증거 불필요 사유: 렌더링 값 변경 없이 같은 20px radius 표현만 치환 | 추가 캡처 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/route_search.dart`의 `_routeSearchLargeRadius`와 4개 치환입니다.
- Flutter test와 analyze를 처음에 병렬 실행해 Flutter iOS ephemeral link 경합이 한 번 발생했지만, test를 순차 재실행해 통과를 확인했습니다.

## 리스크

- 낮음. 동일 radius 값을 같은 파일 상수로 재사용하는 변경입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit이 정상 완료되어 Codex CLI fallback은 사용하지 않았다.
- [x] merge 후 CD 상태를 확인했다.
