### PR TITLE
[Fix] 길찾기 pill radius 표현 정리

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -34,6 +34,7 @@ const _routeSearchPagePadding = EdgeInsets.only(
 const _routeSearchSmallRadius = BorderRadius.all(Radius.circular(8));
 const _routeSearchMediumRadius = BorderRadius.all(Radius.circular(14));
 const _routeSearchLargeRadius = BorderRadius.all(Radius.circular(20));
+const _routeSearchPillRadius = BorderRadius.all(Radius.circular(999));
 
 String _mobilityLabelFor(String mobilityType) {
   for (final option in mobilityProfileOptions) {
@@ -3622,7 +3623,7 @@ class _RouteStatusChip extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: const Color(0xFFDEF5E7),
-        borderRadius: BorderRadius.circular(999),
+        borderRadius: _routeSearchPillRadius,
       ),
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
       child: Wrap(


### PR DESCRIPTION
## 관련 이슈

- 관련: #1075
- #1075는 parent blocker라 이 PR만으로 닫지 않습니다.

## 작업 배경

- #1075에서 모바일 반복 UI의 raw style 표현을 줄이는 작업을 이어갑니다.
- 길찾기 화면에 마지막으로 남은 `BorderRadius.circular(...)` 직접 표현을 같은 파일 상수로 정리합니다.

## 작업 내용

- `_routeSearchPillRadius`를 추가했습니다.
- `_RouteStatusChip`의 pill radius를 `_routeSearchPillRadius`로 바꿨습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/route_search.dart`: exit 0, 0 changed
  - `rg -n "BorderRadius\\.circular\\([^)]+\\)" apps/mobile/lib/route_search.dart`: exit 1, 잔여 없음
  - `flutter test test/widget_test.dart --name "경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다" --reporter expanded`: exit 0, 1 test passed
  - `flutter analyze lib/route_search.dart`: exit 0, No issues found
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 길찾기 radius 직접 표현 | Flutter | raw radius 검색 | `rg -n "BorderRadius\\.circular\\([^)]+\\)" apps/mobile/lib/route_search.dart` | exit 1, 잔여 없음 |
| 경로 결과/안내 회귀 | Flutter | widget test | `flutter test test/widget_test.dart --name "경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다" --reporter expanded` | 통과 |
| 정적 분석 | Flutter | 단일 파일 analyze | `flutter analyze lib/route_search.dart` | No issues found |
| 화면 증거 | Android/iOS | 시각 변화 없는 radius 상수 재사용 | 증거 불필요 사유: 렌더링 값 변경 없이 같은 999 radius 표현만 치환 | 추가 캡처 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/route_search.dart`의 `_routeSearchPillRadius`와 `_RouteStatusChip` 치환입니다.

## 리스크

- 낮음. 동일 radius 값을 같은 파일 상수로 재사용하는 변경입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit이 정상 완료되어 Codex CLI fallback은 사용하지 않았다.
- [x] merge 후 CD 상태를 확인했다.
