### PR TITLE
[Fix] 길찾기 이동 조건 padding 표현 정리

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -35,6 +35,9 @@ const _routeSearchSmallRadius = BorderRadius.all(Radius.circular(8));
 const _routeSearchMediumRadius = BorderRadius.all(Radius.circular(14));
 const _routeSearchLargeRadius = BorderRadius.all(Radius.circular(20));
 const _routeSearchPillRadius = BorderRadius.all(Radius.circular(999));
+const _routeMobilitySheetHeaderPadding = EdgeInsets.fromLTRB(20, 8, 20, 0);
+const _routeMobilitySheetListPadding = EdgeInsets.fromLTRB(20, 0, 20, 8);
+const _routeMobilitySheetActionPadding = EdgeInsets.fromLTRB(20, 8, 20, 20);
 
 String _mobilityLabelFor(String mobilityType) {
   for (final option in mobilityProfileOptions) {
@@ -1587,7 +1590,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     Padding(
-                      padding: const EdgeInsets.fromLTRB(20, 8, 20, 0),
+                      padding: _routeMobilitySheetHeaderPadding,
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         children: [
@@ -1617,7 +1620,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
                     Expanded(
                       child: ListView(
                         key: const Key('routeMobilityOptionsList'),
-                        padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+                        padding: _routeMobilitySheetListPadding,
                         children: [
                           for (final option in mobilityProfileOptions)
                             _RouteMobilityTypeOptionButton(
@@ -1637,7 +1640,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
                       ),
                     ),
                     Padding(
-                      padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+                      padding: _routeMobilitySheetActionPadding,
                       child: FilledButton.icon(
                         key: const Key('routeMobilityApplyButton'),
                         onPressed: () =>


### PR DESCRIPTION
## 관련 이슈

- 관련: #1075
- #1075는 parent blocker라 이 PR만으로 닫지 않습니다.

## 작업 배경

- #1075에서 모바일 반복 UI의 raw style 표현을 줄이는 작업을 이어갑니다.
- 길찾기 이동 조건 bottom sheet에 직접 들어간 padding 값을 같은 파일 상수로 정리합니다.

## 작업 내용

- 이동 조건 bottom sheet의 header/list/action padding 상수를 추가했습니다.
- `padding: const EdgeInsets.fromLTRB(...)` 직접 사용 3곳을 상수로 바꿨습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/route_search.dart`: exit 0, 0 changed
  - `rg -n "padding: const EdgeInsets\\.fromLTRB\\(20, (8, 20, 0|0, 20, 8|8, 20, 20)\\)" apps/mobile/lib/route_search.dart`: exit 1, 직접 사용 잔여 없음
  - `flutter test test/widget_test.dart --name "경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다" --reporter expanded`: exit 0, 1 test passed
  - `flutter analyze lib/route_search.dart`: exit 0, No issues found
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 이동 조건 sheet padding 직접 표현 | Flutter | raw padding 검색 | `rg -n "padding: const EdgeInsets\\.fromLTRB\\(20, (8, 20, 0|0, 20, 8|8, 20, 20)\\)" apps/mobile/lib/route_search.dart` | exit 1, 직접 사용 잔여 없음 |
| 경로 결과/안내 회귀 | Flutter | widget test | `flutter test test/widget_test.dart --name "경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다" --reporter expanded` | 통과 |
| 정적 분석 | Flutter | 단일 파일 analyze | `flutter analyze lib/route_search.dart` | No issues found |
| 화면 증거 | Android/iOS | 시각 변화 없는 padding 상수 재사용 | 증거 불필요 사유: 렌더링 값 변경 없이 같은 padding 값을 상수로 치환 | 추가 캡처 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/route_search.dart`의 이동 조건 sheet padding 상수 3개와 치환 3곳입니다.

## 리스크

- 낮음. 동일 padding 값을 같은 파일 상수로 재사용하는 변경입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit이 정상 완료되어 Codex CLI fallback은 사용하지 않았다.
- [x] merge 후 CD 상태를 확인했다.
