### PR TITLE
[Fix] 역 화면 page padding 표현 정리

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -45,6 +45,8 @@ const _favoriteStationLoadErrorMessage = '즐겨찾기를 불러오지 못했어
 const _favoriteStationStatusErrorMessage = '즐겨찾기를 확인하지 못했어요.';
 const _favoriteStationChangeErrorMessage = '즐겨찾기를 바꾸지 못했어요.';
 const _searchHistoryChangeErrorMessage = '최근 검색을 지우지 못했어요.';
+const _stationSearchPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
+const _stationSearchLargePagePadding = EdgeInsets.fromLTRB(24, 24, 24, 40);
 
 abstract class StationSearchRepository {
   Future<List<StationSearchResult>> searchStations(String query);
@@ -2085,8 +2087,8 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
             );
             return ListView(
               padding: isLargeScreen
-                  ? const EdgeInsets.fromLTRB(24, 24, 24, 40)
-                  : const EdgeInsets.fromLTRB(20, 20, 20, 32),
+                  ? _stationSearchLargePagePadding
+                  : _stationSearchPagePadding,
               children: [
                 _StationSearchAdaptiveContent(
                   isLargeScreen: isLargeScreen,
@@ -3756,7 +3758,7 @@ class _FavoriteStationListBody extends StatelessWidget {
         ),
       ),
       FavoriteStationListStatus.success => ListView(
-        padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+        padding: _stationSearchPagePadding,
         children: [
           Semantics(
             label: '즐겨찾기 역 ${state.favorites.length}개',
@@ -4206,8 +4208,8 @@ class _StationDetailContent extends StatelessWidget {
         return ListView(
           key: const Key('stationDetailList'),
           padding: isLargeScreen
-              ? const EdgeInsets.fromLTRB(24, 24, 24, 40)
-              : const EdgeInsets.fromLTRB(20, 20, 20, 32),
+              ? _stationSearchLargePagePadding
+              : _stationSearchPagePadding,
           children: isLargeScreen
               ? [
                   _StationDetailAdaptiveContent(
@@ -5405,7 +5407,7 @@ class FacilityDetailScreen extends StatelessWidget {
       appBar: AppBar(title: const Text('시설 상세')),
       body: SafeArea(
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          padding: _stationSearchPagePadding,
           children: [
             Card(
               margin: EdgeInsets.zero,


### PR DESCRIPTION
## 관련 이슈

- 관련: #1075
- #1075는 parent blocker라 이 PR만으로 닫지 않습니다.

## 작업 배경

- #1075에서 모바일 반복 UI의 raw style 표현을 줄이는 작업을 이어갑니다.
- 역 검색/상세/즐겨찾기/시설 상세 화면에서 반복되는 page padding 값을 같은 파일 상수로 정리합니다.

## 작업 내용

- `_stationSearchPagePadding`, `_stationSearchLargePagePadding`을 추가했습니다.
- `station_search.dart`의 반복 page padding 직접 사용 6곳을 상수로 바꿨습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/station_search.dart`: exit 0, 1 file formatted
  - `rg -n "EdgeInsets\\.fromLTRB\\((20, 20, 20, 32|24, 24, 24, 40)\\)" apps/mobile/lib/station_search.dart`: 상수 정의 2곳만 출력
  - `flutter test test/widget_test.dart --name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다" --reporter expanded`: exit 0, 1 test passed
  - `flutter analyze lib/station_search.dart`: exit 0, No issues found
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 화면 page padding 직접 표현 | Flutter | raw padding 검색 | `rg -n "EdgeInsets\\.fromLTRB\\((20, 20, 20, 32|24, 24, 24, 40)\\)" apps/mobile/lib/station_search.dart` | 상수 정의 2곳만 남음 |
| 역 검색/상세 회귀 | Flutter | widget test | `flutter test test/widget_test.dart --name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다" --reporter expanded` | 통과 |
| 정적 분석 | Flutter | 단일 파일 analyze | `flutter analyze lib/station_search.dart` | No issues found |
| 화면 증거 | Android/iOS | 시각 변화 없는 padding 상수 재사용 | 증거 불필요 사유: 렌더링 값 변경 없이 같은 padding 값을 상수로 치환 | 추가 캡처 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/station_search.dart`의 page padding 상수 2개와 치환 6곳입니다.

## 리스크

- 낮음. 동일 padding 값을 같은 파일 상수로 재사용하는 변경입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit이 정상 완료되어 Codex CLI fallback은 사용하지 않았다.
- [x] merge 후 CD 상태를 확인했다.
