### PR TITLE
[Fix] main page padding 표현 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -35,6 +35,7 @@ const defaultDemoHomeDataEnabled = bool.fromEnvironment(
   'EASYSUBWAY_DEMO_HOME_DATA',
   defaultValue: false,
 );
+const _mainPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -4255,7 +4256,7 @@ class OfflineDataScreen extends StatelessWidget {
       appBar: AppBar(title: const Text('인터넷 없이 이용')),
       body: SafeArea(
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          padding: _mainPagePadding,
           children: const [
             _AppCard(
               backgroundColor: EasySubwayAccessibleColors.mintSoft,
@@ -4389,7 +4390,7 @@ class SupportAccessScreen extends StatelessWidget {
       appBar: AppBar(title: const Text('도움말·문의')),
       body: SafeArea(
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          padding: _mainPagePadding,
           children: [
             const _SupportSectionTitle(title: '내 정보와 개인정보'),
             _PrivacyDataUseSummary(deletionScope: deletionScope),
@@ -4716,7 +4717,7 @@ class _UserDataDeletionScreenState extends State<UserDataDeletionScreen> {
       ),
       body: SafeArea(
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          padding: _mainPagePadding,
           children: [
             Semantics(
               header: true,
@@ -4880,7 +4881,7 @@ class UserDataDeletionResultScreen extends StatelessWidget {
       ),
       body: SafeArea(
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+          padding: _mainPagePadding,
           children: [
             _AppCard(
               backgroundColor: EasySubwayAccessibleColors.mintSoft,


### PR DESCRIPTION
## 관련 이슈

- 관련: #1075
- #1075는 parent blocker라 이 PR만으로 닫지 않습니다.

## 작업 배경

- #1075에서 모바일 반복 UI의 raw style 표현을 줄이는 작업을 이어갑니다.
- `main.dart`의 여러 보조 화면에서 반복되는 page padding 값을 같은 파일 상수로 정리합니다.

## 작업 내용

- `_mainPagePadding`을 추가했습니다.
- 오프라인 안내, 도움말, 내 정보 삭제, 삭제 결과 화면의 page padding 직접 사용 4곳을 상수로 바꿨습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/main.dart`: exit 0, 0 changed
  - `rg -n "EdgeInsets\\.fromLTRB\\(20, 20, 20, 32\\)" apps/mobile/lib/main.dart`: 상수 정의 1곳만 출력
  - `flutter test test/widget_test.dart --name "도움말은 이동 전 살펴보기 안내를 함께 보여준다" --reporter expanded`: exit 0, 1 test passed
  - `flutter analyze lib/main.dart`: exit 0, No issues found
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| main page padding 직접 표현 | Flutter | raw padding 검색 | `rg -n "EdgeInsets\\.fromLTRB\\(20, 20, 20, 32\\)" apps/mobile/lib/main.dart` | 상수 정의 1곳만 남음 |
| 도움말 화면 회귀 | Flutter | widget test | `flutter test test/widget_test.dart --name "도움말은 이동 전 살펴보기 안내를 함께 보여준다" --reporter expanded` | 통과 |
| 정적 분석 | Flutter | 단일 파일 analyze | `flutter analyze lib/main.dart` | No issues found |
| 화면 증거 | Android/iOS | 시각 변화 없는 padding 상수 재사용 | 증거 불필요 사유: 렌더링 값 변경 없이 같은 padding 값을 상수로 치환 | 추가 캡처 없음 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/main.dart`의 `_mainPagePadding`과 치환 4곳입니다.

## 리스크

- 낮음. 동일 padding 값을 같은 파일 상수로 재사용하는 변경입니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit이 정상 완료되어 Codex CLI fallback은 사용하지 않았다.
- [x] merge 후 CD 상태를 확인했다.
