### PR TITLE
[Fix] main list padding 표현 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -36,6 +36,7 @@ const defaultDemoHomeDataEnabled = bool.fromEnvironment(
   defaultValue: false,
 );
 const _mainPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
+const _mainListPagePadding = EdgeInsets.fromLTRB(17, 18, 17, 32);
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -1983,7 +1984,7 @@ class _NotificationInboxScreenState extends State<NotificationInboxScreen> {
               },
               child: ListView(
                 physics: const AlwaysScrollableScrollPhysics(),
-                padding: const EdgeInsets.fromLTRB(17, 18, 17, 32),
+                padding: _mainListPagePadding,
                 children: [
                   if (snapshot.connectionState != ConnectionState.done)
                     const LinearProgressIndicator(minHeight: 3),
@@ -3862,7 +3863,7 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
               },
               child: ListView(
                 physics: const AlwaysScrollableScrollPhysics(),
-                padding: const EdgeInsets.fromLTRB(17, 18, 17, 32),
+                padding: _mainListPagePadding,
                 children: [
                   if (snapshot.connectionState != ConnectionState.done)
                     const LinearProgressIndicator(minHeight: 3),


### PR DESCRIPTION
## 관련 이슈

관련: #1075

## 작업 배경

- #1075의 디자인 시스템 정리 항목 중 `main.dart`에 반복으로 남은 직접 padding 표현을 줄입니다.
- QA 요청 범위에 맞춰 사용자에게 보이는 문구와 화면 값은 바꾸지 않습니다.

## 작업 내용

- 알림함과 즐겨찾기 홈의 동일한 ListView padding을 `_mainListPagePadding` 상수로 분리했습니다.
- 기존 `EdgeInsets.fromLTRB(17, 18, 17, 32)` 값은 그대로 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/main.dart`: exit 0, 0 changed
  - `rg -n "EdgeInsets\.fromLTRB\(17, 18, 17, 32\)" lib/main.dart`: 상수 선언 1곳만 매칭
  - `flutter test test/widget_test.dart --name "홈 우측 상단 알림 버튼은 알림함으로 이동한다" --reporter expanded`: exit 0, 1 test passed
  - `flutter test test/widget_test.dart --name "홈 즐겨찾기는 하나의 진입점에서 탭 목록을 바로 보여준다" --reporter expanded`: exit 0, 1 test passed
  - `flutter analyze lib/main.dart`: exit 0, No issues found
  - `git diff --check`: exit 0
  - rebase 후 같은 두 widget test와 `flutter analyze lib/main.dart`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| main list padding 정리 | Flutter 공통 | 반복 padding 검색 | `rg -n "EdgeInsets\.fromLTRB\(17, 18, 17, 32\)" lib/main.dart` | 상수 선언 1곳만 남음 |
| 알림함 흐름 | Flutter widget test | 관련 위젯 테스트 실행 | `flutter test test/widget_test.dart --name "홈 우측 상단 알림 버튼은 알림함으로 이동한다" --reporter expanded` exit 0 | 1 test passed |
| 즐겨찾기 홈 흐름 | Flutter widget test | 관련 위젯 테스트 실행 | `flutter test test/widget_test.dart --name "홈 즐겨찾기는 하나의 진입점에서 탭 목록을 바로 보여준다" --reporter expanded` exit 0 | 1 test passed |
| 정적 분석 | Flutter analyzer | 대상 파일 분석 | `flutter analyze lib/main.dart` exit 0 | No issues found |
| PR CI | GitHub Actions | PR #1268 최신 head check rollup 확인 | Repository CI, Backend CI, Mobile App CI, Android CI, Release Gate Consistency, Android Release Artifact, RC Evidence Manifest, Dependency Vulnerability Scan, SonarCloud Code Analysis success | required checks 통과 |
| 코드 리뷰 | GitHub PR review | CodeRabbit rate limit 확인 후 Codex CLI fallback review 게시 | `Actionable comments posted: 0` review: https://github.com/AquilaXk/easysubway/pull/1268#pullrequestreview-4600369698 | actionable/nitpick 없음 |
| Post-merge CD | GitHub Actions main | merge commit `7872469` workflow 확인 | CI in_progress, Release Artifacts in_progress, CD 실패 신호 없음 | run 생성 확인, 실패 없음 |
| 화면 증거 | Android/iOS | 렌더링 값과 사용자 문구 변경 없음 | 증거 불필요 사유: 기존 padding 수치만 상수로 이동했고 화면 출력은 동일함 | 추가 스크린샷 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/main.dart` 상단 padding 상수와 두 사용처입니다.

## 리스크

- 렌더링 값 변경 없이 참조만 바꾼 1파일 변경이라 UI 회귀 위험은 낮습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.