### PR TITLE
[CI] 서버 변경 기준 CD 자동 배포 정리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,13 +32,83 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  plan:
+    name: CD Plan
+    runs-on: ubuntu-latest
+    outputs:
+      deploy_target_relevant: ${{ steps.changes.outputs.deploy }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.head_repository.full_name == github.repository) }}
+
+    steps:
+      - name: CD Plan / Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: CD Plan / Resolve deployment target
+        id: target
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          DISPATCH_SHA: ${{ inputs.deploy_sha }}
+          DISPATCH_MODE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            deploy_sha="${WORKFLOW_RUN_SHA}"
+            mode="deploy"
+          else
+            deploy_sha="${DISPATCH_SHA:-${GITHUB_SHA}}"
+            mode="${DISPATCH_MODE:-deploy}"
+          fi
+
+          if [[ ! "${deploy_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "invalid deploy sha: ${deploy_sha}" >&2
+            exit 1
+          fi
+
+          git fetch origin main
+          if ! git merge-base --is-ancestor "${deploy_sha}" origin/main; then
+            echo "deploy target is not on origin/main: ${deploy_sha}" >&2
+            exit 1
+          fi
+
+          echo "sha=${deploy_sha}" >> "${GITHUB_OUTPUT}"
+          echo "mode=${mode}" >> "${GITHUB_OUTPUT}"
+
+      - name: CD Plan / Detect deployment changes
+        id: changes
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DEPLOY_SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "deploy=true" >> "${GITHUB_OUTPUT}"
+            echo "manual dispatch deploys the requested main SHA" >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          if git rev-parse "${DEPLOY_SHA}^" >/dev/null 2>&1; then
+            git diff --name-only "${DEPLOY_SHA}^" "${DEPLOY_SHA}" > changed-files.txt
+          else
+            git diff-tree --root --name-only "${DEPLOY_SHA}" > changed-files.txt
+          fi
+          bash tools/ci/detect-changed-paths.sh changed-files.txt
+
   deploy:
     name: CD Deploy
+    needs: plan
     runs-on:
       - self-hosted
       - easysubway-production
     environment: production
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.head_repository.full_name == github.repository) }}
+    if: ${{ needs.plan.outputs.deploy_target_relevant == 'true' }}
 
     steps:
       - name: CD Deploy / Checkout repository

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -436,6 +436,10 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
   assert.match(workflow, /printf '%s' "\$\{EASYSUBWAY_ENV_SECRET\}" > "\$\{env_file\}"/);
   assert.doesNotMatch(workflow, /printf '%s\\n' "\$\{EASYSUBWAY_ENV_SECRET\}"/);
   assert.match(workflow, /CD Deploy \/ Validate deployment dotenv contract/);
+  assert.match(workflow, /CD Plan \/ Detect deployment changes/);
+  assert.match(workflow, /bash tools\/ci\/detect-changed-paths\.sh changed-files\.txt/);
+  assert.match(workflow, /deploy_target_relevant: \$\{\{ steps\.changes\.outputs\.deploy \}\}/);
+  assert.match(workflow, /if: \$\{\{ needs\.plan\.outputs\.deploy_target_relevant == 'true' \}\}/);
   assert.match(workflow, /CD Deploy \/ Prepare split deployment env files/);
   assert.match(workflow, /tools\/deploy\/prepare-deployment-env\.sh/);
   assert.match(workflow, /tools\/deploy\/compose-server-env\.allowlist/);


### PR DESCRIPTION
## 관련 이슈

close #1269

## 작업 배경

`main` CI 성공 후 CD가 실행될 때 모바일 전용 변경에서도 서버 배포 job이 열릴 수 있었다. 서버 배포는 OCI runtime 상태를 바꾸므로 backend/deploy 영향이 있는 변경에서만 실제 deploy job을 실행하도록 제한한다.

## 작업 내용

- CD workflow 앞단에 `CD Plan` job을 추가해 배포 대상 SHA의 변경 파일을 분류했다.
- `tools/ci/detect-changed-paths.sh`의 `deploy` 출력이 `true`일 때만 self-hosted OCI deploy job이 실행되도록 했다.
- 수동 dispatch는 기존처럼 요청 SHA의 deploy/preflight를 실행할 수 있게 유지했다.
- 기존 backend 배포 스크립트의 lock, backup, readiness, rollback 계약은 변경하지 않았다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "지속적 배포 준비 상태" tools/ci/repository-contract.test.mjs`: exit 0, 1 pass
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cd.yml"); puts "cd.yml ok"'`: exit 0
  - `node --test tools/ci/backend-deploy.test.mjs`: exit 0, 4 pass
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 147 pass
  - `git diff --check -- .github/workflows/cd.yml tools/ci/repository-contract.test.mjs`: exit 0
  - `node --test tools/ci/*.test.mjs`: exit 0, 157 pass

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| CD 변경 감지 계약 | GitHub Actions workflow | repository contract targeted test | `node --test --test-name-pattern "지속적 배포 준비 상태" tools/ci/repository-contract.test.mjs` | 1 pass |
| CD YAML 문법 | GitHub Actions workflow | YAML parse | `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cd.yml"); puts "cd.yml ok"'` | exit 0 |
| 기존 backend 배포 안전장치 | Local CI | backend deploy contract test | `node --test tools/ci/backend-deploy.test.mjs` | 4 pass |
| repository contract | Local CI | repository contract 전체 실행 | `node --test tools/ci/repository-contract.test.mjs` | 147 pass |
| CI contract 전체 | Local CI | `tools/ci` 전체 node test | `node --test tools/ci/*.test.mjs` | 157 pass |
| 화면 증거 | 해당 없음 | 증거 불필요 사유 | GitHub Actions 조건 변경이며 UI/접근성 변경이 아님 | 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `CD Plan` job이 모바일-only 변경에서 `deploy=false`를 출력하면 `CD Deploy` job이 시작되지 않는지 확인하면 된다.
- CodeRabbit은 rate limit으로 실제 리뷰가 시작되지 않아 최신 head에 Codex fallback summary review를 남겼다.

## 리스크

- `workflow_run`에는 `paths` 필터가 없어서 대상 SHA의 직전 커밋과 diff를 계산한다. 일반 PR merge/squash merge 흐름에서는 변경 범위가 정확히 잡힌다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰 상태를 확인했다. rate limit으로 실제 리뷰가 시작되지 않았다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
