### PR TITLE
[Feat] 데이터팩 release readiness dashboard와 evidence viewer 보강

### DIFF
--- a/backend/src/main/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageController.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageController.java
@@ -10,6 +10,7 @@ import com.easysubway.datapack.application.service.DatapackCandidateCommandServi
 import com.easysubway.datapack.application.service.DatapackCandidateCommandService.CandidateGateRerunCommand;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -174,7 +175,7 @@ class DatapackCandidateAdminPageController {
 				row.id(),
 				row.candidateId(),
 				row.evidenceBundleSha256(),
-				row.workflowRunUrl(),
+				redactedUrl(row.workflowRunUrl()),
 				row.validatorStatus(),
 				row.routeRegressionStatus(),
 				row.manifestSignatureStatus(),
@@ -186,6 +187,19 @@ class DatapackCandidateAdminPageController {
 		static EvidenceBundleView empty(String candidateId) {
 			return new EvidenceBundleView("-", candidateId, "-", "-", "-", "-", "-", "-", null);
 		}
+
+		public boolean productionPromoteAllowed() {
+			return List.of(validatorStatus, routeRegressionStatus, manifestSignatureStatus, androidEvidenceStatus)
+				.stream()
+				.allMatch("PASS"::equals);
+		}
+
+		public String productionPromoteReason() {
+			if (productionPromoteAllowed()) {
+				return "production promote 가능";
+			}
+			return "production promote 차단: evidence bundle PASS 필요";
+		}
 	}
 
 	private static String valueOrDash(String value) {
@@ -193,6 +207,14 @@ class DatapackCandidateAdminPageController {
 			return "-";
 		}
 		return value;
+	}
+
+	private static String redactedUrl(String value) {
+		String text = valueOrDash(value);
+		int query = text.indexOf('?');
+		int fragment = text.indexOf('#');
+		int cut = query < 0 ? fragment : (fragment < 0 ? query : Math.min(query, fragment));
+		return cut < 0 ? text : text.substring(0, cut) + "?redacted";
 	}
 
 	record CandidateGateRerunForm(String reason, String idempotencyKey) {

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
@@ -42,8 +42,8 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 		long manualOverrideBlockers = countManualOverrideBlockers();
 		long facilityBlockers = countFacilityBlockers(null);
 		long routeGateBlockers = countRouteGateBlockers(null);
-		ManifestSignatureSummary manifestSignature = manifestSignature(candidate);
 		EvidenceBundleSummary evidenceBundle = evidenceBundle(candidate);
+		ManifestSignatureSummary manifestSignature = evidenceBundle.manifestSignature();
 		ReleaseChannelSummary productionChannel = productionChannel();
 		long totalBlockers = candidateGateBlockers
 			+ aliasBlockers
@@ -51,7 +51,7 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 			+ manualOverrideBlockers
 			+ facilityBlockers
 			+ routeGateBlockers
-			+ manifestSignature.blockerCount();
+			+ evidenceBundle.blockerCount();
 		return new DatapackReleaseBlockerSummary(
 			candidate.map(CandidateGateSummary::candidateId).orElse("-"),
 			candidate.map(CandidateGateSummary::scopeId).orElse("-"),
@@ -77,6 +77,7 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 				manualOverrideBlockers,
 				facilityBlockers,
 				routeGateBlockers,
+				evidenceBundle,
 				manifestSignature
 			),
 			candidate.map(CandidateGateSummary::createdAt).orElse(null)
@@ -133,15 +134,19 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 		long manualOverrideBlockers,
 		long facilityBlockers,
 		long routeGateBlockers,
+		EvidenceBundleSummary evidenceBundle,
 		ManifestSignatureSummary manifestSignature
 	) {
 		long sourceBlockers = candidate.map(row -> "PASS".equals(row.coverageStatus()) ? 0L : 1L).orElse(1L)
 			+ aliasBlockers
 			+ quarantineBlockers;
-		long validatorBlockers = candidate.map(row -> "PASS".equals(row.validatorStatus()) ? 0L : 1L).orElse(1L);
+		long validatorBlockers = candidate.map(row -> "PASS".equals(row.validatorStatus()) ? 0L : 1L).orElse(1L)
+			+ evidenceBundle.validatorBlocker();
 		long routeBlockers = candidate.map(row -> "PASS".equals(row.routeRegressionStatus()) ? 0L : 1L).orElse(1L)
-			+ routeGateBlockers;
-		long androidBlockers = candidate.map(row -> "PASS".equals(row.androidEvidenceStatus()) ? 0L : 1L).orElse(1L);
+			+ routeGateBlockers
+			+ evidenceBundle.routeRegressionBlocker();
+		long androidBlockers = candidate.map(row -> "PASS".equals(row.androidEvidenceStatus()) ? 0L : 1L).orElse(1L)
+			+ evidenceBundle.androidBlocker();
 		return List.of(
 			new ReleaseReadinessRow("Source coverage", statusFor(sourceBlockers), sourceBlockers, sourceNote(aliasBlockers, quarantineBlockers)),
 			new ReleaseReadinessRow("Validator", statusFor(validatorBlockers), validatorBlockers, "SQLite integrity / validator gates"),
@@ -153,33 +158,23 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 		);
 	}
 
-	private ManifestSignatureSummary manifestSignature(Optional<CandidateGateSummary> candidate) {
-		if (candidate.isEmpty()) {
-			return new ManifestSignatureSummary("확인 필요", 1);
-		}
-		String status = jdbcTemplate.query("""
-			SELECT manifest_signature_status
-			FROM datapack_release_evidence_bundles
-			WHERE candidate_id = ?
-			""", (resultSet, rowNumber) -> resultSet.getString("manifest_signature_status"), candidate.get().candidateId())
-			.stream()
-			.findFirst()
-			.map(manifestStatus -> "PASS".equals(manifestStatus) ? "PASS" : manifestStatus)
-			.orElse("확인 필요");
-		return new ManifestSignatureSummary(status, "PASS".equals(status) ? 0 : 1);
-	}
-
 	private EvidenceBundleSummary evidenceBundle(Optional<CandidateGateSummary> candidate) {
 		if (candidate.isEmpty()) {
 			return EvidenceBundleSummary.empty();
 		}
 		return jdbcTemplate.query("""
-			SELECT evidence_bundle_sha256, workflow_run_url
+			SELECT evidence_bundle_sha256, workflow_run_url, validator_status,
+				route_regression_status, manifest_signature_status, android_evidence_status
 			FROM datapack_release_evidence_bundles
 			WHERE candidate_id = ?
 			""", (resultSet, rowNumber) -> new EvidenceBundleSummary(
+				true,
 				resultSet.getString("evidence_bundle_sha256"),
-				redactedUrl(resultSet.getString("workflow_run_url"))
+				redactedUrl(resultSet.getString("workflow_run_url")),
+				resultSet.getString("validator_status"),
+				resultSet.getString("route_regression_status"),
+				resultSet.getString("manifest_signature_status"),
+				resultSet.getString("android_evidence_status")
 			), candidate.get().candidateId()).stream().findFirst().orElse(EvidenceBundleSummary.empty());
 	}
 
@@ -331,10 +326,49 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 	private record ManifestSignatureSummary(String status, long blockerCount) {
 	}
 
-	private record EvidenceBundleSummary(String evidenceBundleSha256, String workflowRunUrl) {
+	private record EvidenceBundleSummary(
+		boolean exists,
+		String evidenceBundleSha256,
+		String workflowRunUrl,
+		String validatorStatus,
+		String routeRegressionStatus,
+		String manifestSignatureStatus,
+		String androidEvidenceStatus
+	) {
+
+		long blockerCount() {
+			if (!exists) {
+				return 1;
+			}
+			return validatorBlocker() + routeRegressionBlocker() + manifestSignature().blockerCount() + androidBlocker();
+		}
+
+		long validatorBlocker() {
+			return statusBlocker(validatorStatus);
+		}
+
+		long routeRegressionBlocker() {
+			return statusBlocker(routeRegressionStatus);
+		}
+
+		long androidBlocker() {
+			return statusBlocker(androidEvidenceStatus);
+		}
+
+		ManifestSignatureSummary manifestSignature() {
+			return new ManifestSignatureSummary(statusOrNeed(manifestSignatureStatus), statusBlocker(manifestSignatureStatus));
+		}
 
 		static EvidenceBundleSummary empty() {
-			return new EvidenceBundleSummary("-", "-");
+			return new EvidenceBundleSummary(false, "-", "-", "PASS", "PASS", "확인 필요", "PASS");
+		}
+
+		private static long statusBlocker(String status) {
+			return "PASS".equals(status) ? 0 : 1;
+		}
+
+		private static String statusOrNeed(String status) {
+			return status == null || status.isBlank() ? "확인 필요" : status;
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
+++ b/backend/src/main/java/com/easysubway/datapack/adapter/out/persistence/JdbcDatapackReleaseBlockerSummaryRepository.java
@@ -43,6 +43,8 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 		long facilityBlockers = countFacilityBlockers(null);
 		long routeGateBlockers = countRouteGateBlockers(null);
 		ManifestSignatureSummary manifestSignature = manifestSignature(candidate);
+		EvidenceBundleSummary evidenceBundle = evidenceBundle(candidate);
+		ReleaseChannelSummary productionChannel = productionChannel();
 		long totalBlockers = candidateGateBlockers
 			+ aliasBlockers
 			+ quarantineBlockers
@@ -53,6 +55,12 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 		return new DatapackReleaseBlockerSummary(
 			candidate.map(CandidateGateSummary::candidateId).orElse("-"),
 			candidate.map(CandidateGateSummary::scopeId).orElse("-"),
+			candidate.map(CandidateGateSummary::sourceSnapshotSetHash).orElse("-"),
+			candidate.map(CandidateGateSummary::manifestSha256).orElse("-"),
+			evidenceBundle.evidenceBundleSha256(),
+			evidenceBundle.workflowRunUrl(),
+			productionChannel.candidateId(),
+			productionChannel.rollbackCandidateId(),
 			releaseStatus(candidate, totalBlockers),
 			totalBlockers,
 			candidateGateBlockers,
@@ -95,7 +103,8 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 
 	private Optional<CandidateGateSummary> latestCandidate() {
 		return jdbcTemplate.query("""
-			SELECT id, scope_id, coverage_status, validator_status,
+			SELECT id, scope_id, source_snapshot_set_hash, manifest_sha256,
+				coverage_status, validator_status,
 				route_regression_status, android_evidence_status, created_at
 			FROM datapack_candidates
 			ORDER BY created_at DESC, id ASC
@@ -107,6 +116,8 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 		return new CandidateGateSummary(
 			resultSet.getString("id"),
 			resultSet.getString("scope_id"),
+			resultSet.getString("source_snapshot_set_hash"),
+			valueOrDash(resultSet.getString("manifest_sha256")),
 			resultSet.getString("coverage_status"),
 			resultSet.getString("validator_status"),
 			resultSet.getString("route_regression_status"),
@@ -156,6 +167,31 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 			.map(manifestStatus -> "PASS".equals(manifestStatus) ? "PASS" : manifestStatus)
 			.orElse("확인 필요");
 		return new ManifestSignatureSummary(status, "PASS".equals(status) ? 0 : 1);
+	}
+
+	private EvidenceBundleSummary evidenceBundle(Optional<CandidateGateSummary> candidate) {
+		if (candidate.isEmpty()) {
+			return EvidenceBundleSummary.empty();
+		}
+		return jdbcTemplate.query("""
+			SELECT evidence_bundle_sha256, workflow_run_url
+			FROM datapack_release_evidence_bundles
+			WHERE candidate_id = ?
+			""", (resultSet, rowNumber) -> new EvidenceBundleSummary(
+				resultSet.getString("evidence_bundle_sha256"),
+				redactedUrl(resultSet.getString("workflow_run_url"))
+			), candidate.get().candidateId()).stream().findFirst().orElse(EvidenceBundleSummary.empty());
+	}
+
+	private ReleaseChannelSummary productionChannel() {
+		return jdbcTemplate.query("""
+			SELECT candidate_id, previous_stable_candidate_id
+			FROM datapack_release_channels
+			WHERE channel = 'production'
+			""", (resultSet, rowNumber) -> new ReleaseChannelSummary(
+			resultSet.getString("candidate_id"),
+			valueOrDash(resultSet.getString("previous_stable_candidate_id"))
+		)).stream().findFirst().orElse(ReleaseChannelSummary.empty());
 	}
 
 	private long countManualOverrideBlockers() {
@@ -257,9 +293,26 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 		return "alias " + aliasBlockers + " / quarantine " + quarantineBlockers;
 	}
 
+	private static String valueOrDash(String value) {
+		if (value == null || value.isBlank()) {
+			return "-";
+		}
+		return value;
+	}
+
+	private static String redactedUrl(String value) {
+		String text = valueOrDash(value);
+		int query = text.indexOf('?');
+		int fragment = text.indexOf('#');
+		int cut = query < 0 ? fragment : (fragment < 0 ? query : Math.min(query, fragment));
+		return cut < 0 ? text : text.substring(0, cut) + "?redacted";
+	}
+
 	private record CandidateGateSummary(
 		String candidateId,
 		String scopeId,
+		String sourceSnapshotSetHash,
+		String manifestSha256,
 		String coverageStatus,
 		String validatorStatus,
 		String routeRegressionStatus,
@@ -276,5 +329,19 @@ public class JdbcDatapackReleaseBlockerSummaryRepository implements DatapackRele
 	}
 
 	private record ManifestSignatureSummary(String status, long blockerCount) {
+	}
+
+	private record EvidenceBundleSummary(String evidenceBundleSha256, String workflowRunUrl) {
+
+		static EvidenceBundleSummary empty() {
+			return new EvidenceBundleSummary("-", "-");
+		}
+	}
+
+	private record ReleaseChannelSummary(String candidateId, String rollbackCandidateId) {
+
+		static ReleaseChannelSummary empty() {
+			return new ReleaseChannelSummary("-", "-");
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/datapack/application/port/in/DatapackReleaseBlockerSummaryUseCase.java
+++ b/backend/src/main/java/com/easysubway/datapack/application/port/in/DatapackReleaseBlockerSummaryUseCase.java
@@ -12,6 +12,12 @@ public interface DatapackReleaseBlockerSummaryUseCase {
 	record DatapackReleaseBlockerSummary(
 		String candidateId,
 		String scopeId,
+		String sourceSnapshotSetHash,
+		String manifestSha256,
+		String evidenceBundleSha256,
+		String evidenceWorkflowRunUrl,
+		String productionCandidateId,
+		String rollbackCandidateId,
 		String status,
 		long totalBlockers,
 		long candidateGateBlockers,
@@ -27,6 +33,12 @@ public interface DatapackReleaseBlockerSummaryUseCase {
 
 		public static DatapackReleaseBlockerSummary empty() {
 			return new DatapackReleaseBlockerSummary(
+				"-",
+				"-",
+				"-",
+				"-",
+				"-",
+				"-",
 				"-",
 				"-",
 				"확인 필요",
@@ -49,6 +61,17 @@ public interface DatapackReleaseBlockerSummaryUseCase {
 				),
 				null
 			);
+		}
+
+		public boolean productionPromoteAllowed() {
+			return "READY".equals(status);
+		}
+
+		public String productionPromoteReason() {
+			if (productionPromoteAllowed()) {
+				return "production promote 가능";
+			}
+			return "production promote 차단: blocker " + totalBlockers + "건";
 		}
 	}
 

--- a/backend/src/main/resources/templates/admin/dashboard.html
+++ b/backend/src/main/resources/templates/admin/dashboard.html
@@ -47,8 +47,16 @@
 			<span> · </span>
 			<span th:text="|route gate ${datapackReleaseSummary.routeGateBlockers}|">route gate 0</span>
 		</p>
+		<p class="summary" th:text="${datapackReleaseSummary.productionPromoteReason()}">production promote 차단: blocker 0건</p>
 		<table>
 			<tbody>
+			<tr><th scope="row">scope</th><td th:text="${datapackReleaseSummary.scopeId}">scope</td></tr>
+			<tr><th scope="row">source snapshot set</th><td th:text="${datapackReleaseSummary.sourceSnapshotSetHash}">sha</td></tr>
+			<tr><th scope="row">manifest</th><td th:text="${datapackReleaseSummary.manifestSha256}">sha</td></tr>
+			<tr><th scope="row">evidence bundle</th><td th:text="${datapackReleaseSummary.evidenceBundleSha256}">sha</td></tr>
+			<tr><th scope="row">evidence workflow</th><td th:text="${datapackReleaseSummary.evidenceWorkflowRunUrl}">workflow</td></tr>
+			<tr><th scope="row">production current</th><td th:text="${datapackReleaseSummary.productionCandidateId}">candidate</td></tr>
+			<tr><th scope="row">rollback target</th><td th:text="${datapackReleaseSummary.rollbackCandidateId}">candidate</td></tr>
 			<tr><th scope="row">candidate gate</th><td th:text="${datapackReleaseSummary.candidateGateBlockers}">0</td></tr>
 			<tr><th scope="row">alias</th><td th:text="${datapackReleaseSummary.aliasBlockers}">0</td></tr>
 			<tr><th scope="row">quarantine</th><td th:text="${datapackReleaseSummary.quarantineBlockers}">0</td></tr>

--- a/backend/src/main/resources/templates/admin/datapack/candidates/detail.html
+++ b/backend/src/main/resources/templates/admin/datapack/candidates/detail.html
@@ -52,6 +52,8 @@
 
 	<section class="admin-panel">
 		<h2>Evidence Bundle</h2>
+		<p class="summary">raw evidence 원문은 표시하지 않고 검증된 hash/status만 표시합니다.</p>
+		<p class="summary" th:text="${evidenceBundle.productionPromoteReason()}">production promote 차단</p>
 		<table>
 			<tbody>
 			<tr><th scope="row">evidenceBundleSha256</th><td th:text="${evidenceBundle.evidenceBundleSha256}">sha</td></tr>

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageControllerTest.java
@@ -81,11 +81,14 @@ class DatapackCandidateAdminPageControllerTest {
 			.contains("snapshot-kric-20260629")
 			.contains("buildSpec")
 			.contains("workflowRunUrl")
-			.contains("https://github.com/AquilaXk/easysubway/actions/runs/123")
+			.contains("https://github.com/AquilaXk/easysubway/actions/runs/123?redacted")
 			.contains("evidenceBundleSha256")
+			.contains("raw evidence 원문은 표시하지 않고 검증된 hash/status만 표시합니다.")
+			.contains("production promote 가능")
 			.contains("name=\"commandToken\"")
 			.contains("gate 재실행")
-			.doesNotContain("production 승인");
+			.doesNotContain("production 승인")
+			.doesNotContain("serviceKey");
 	}
 
 	@Test
@@ -168,7 +171,7 @@ class DatapackCandidateAdminPageControllerTest {
 				android_evidence_status, created_at
 			)
 			VALUES ('evidence-bundle-1', 'candidate-capital-1', ?,
-				'https://github.com/AquilaXk/easysubway/actions/runs/123',
+				'https://github.com/AquilaXk/easysubway/actions/runs/123?serviceKey=secret',
 				'PASS', 'PASS', 'PASS', 'PASS', '2026-06-29 03:02:00')
 			""",
 			"5".repeat(64)

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackCandidateAdminPageControllerTest.java
@@ -38,6 +38,8 @@ class DatapackCandidateAdminPageControllerTest {
 
 	@BeforeEach
 	void setUp() {
+		jdbcTemplate.update("DELETE FROM datapack_release_channel_events");
+		jdbcTemplate.update("DELETE FROM datapack_release_channels");
 		jdbcTemplate.update("DELETE FROM datapack_release_evidence_bundles");
 		jdbcTemplate.update("DELETE FROM datapack_candidate_inputs");
 		jdbcTemplate.update("DELETE FROM datapack_candidates");

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
@@ -40,7 +40,10 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 	void setUp() {
 		clearDatapackTables();
 		insertSourceSnapshot();
+		insertPreviousCandidate();
 		insertCandidate();
+		insertEvidenceBundle();
+		insertProductionChannel();
 		insertAliasQuarantineOverride();
 		insertEvidenceBlockers();
 	}
@@ -54,13 +57,18 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 			.contains("데이터팩 출시 준비")
 			.contains("FAIL")
 			.contains("candidate-release-blocked")
+			.contains(SHA_A)
+			.contains("https://github.com/AquilaXk/easysubway/actions/runs/1164?redacted")
+			.contains("candidate-previous-stable")
+			.contains("production promote 차단: blocker 9건")
 			.contains("전체 blocker 9건")
 			.contains("alias 1")
 			.contains("quarantine 1")
 			.contains("manual override 1")
 			.contains("route gate 1")
 			.contains("manifest signature")
-			.doesNotContain("name=\"commandToken\"");
+			.doesNotContain("name=\"commandToken\"")
+			.doesNotContain("serviceKey");
 	}
 
 	@Test
@@ -236,6 +244,51 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 				'FAIL', 'PASS', 'FAIL', 'PENDING', 'READY_FOR_APPROVAL',
 				'2026-06-29 03:30:00')
 			""", SHA_A, SHA_B, SHA_C, SHA_D, SHA_E, SHA_F, "1".repeat(64));
+	}
+
+	private void insertPreviousCandidate() {
+		jdbcTemplate.update("""
+			INSERT INTO datapack_candidates (
+				id, scope_id, artifact_kind, version, source_snapshot_set_hash,
+				override_set_hash, build_spec_sha256, source_inventory_sha256,
+				sqlite_sha256, gzip_sha256, manifest_sha256, coverage_status,
+				validator_status, route_regression_status, android_evidence_status,
+				approval_status, created_at
+			)
+			VALUES ('candidate-previous-stable', 'capital_pilot_android_v1', 'DATAPACK',
+				'2026.06.29-cand.previous', ?, ?, ?, ?, ?, ?, ?,
+				'PASS', 'PASS', 'PASS', 'PASS', 'PROMOTED',
+				'2026-06-29 02:30:00')
+			""", SHA_A, SHA_B, SHA_C, SHA_D, SHA_E, SHA_F, "2".repeat(64));
+	}
+
+	private void insertEvidenceBundle() {
+		jdbcTemplate.update("""
+			INSERT INTO datapack_release_evidence_bundles (
+				id, candidate_id, evidence_bundle_sha256, workflow_run_url,
+				validator_status, route_regression_status, manifest_signature_status,
+				android_evidence_status, created_at
+			)
+			VALUES ('evidence-bundle-blocked', 'candidate-release-blocked', ?,
+				'https://github.com/AquilaXk/easysubway/actions/runs/1164?serviceKey=secret',
+				'PASS', 'PASS', 'FAIL', 'PASS', '2026-06-29 03:36:00')
+			""", "3".repeat(64));
+	}
+
+	private void insertProductionChannel() {
+		jdbcTemplate.update("""
+			INSERT INTO datapack_release_channels (
+				channel, candidate_id, manifest_url, manifest_sha256,
+				previous_stable_candidate_id, previous_manifest_sha256,
+				rollback_available, last_operation_type, last_operation_status,
+				requested_by, approved_by, reason, idempotency_key, updated_at
+			)
+			VALUES ('production', 'candidate-release-blocked',
+				'https://datapack.example.com/production/current.json', ?,
+				'candidate-previous-stable', ?, TRUE, 'PROMOTE', 'PENDING',
+				'data-operator', 'release-approver', 'release readiness blocked',
+				'idempotency-readiness-1164', '2026-06-29 03:37:00')
+			""", "1".repeat(64), "2".repeat(64));
 	}
 
 	private void insertAliasQuarantineOverride() {

--- a/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
+++ b/backend/src/test/java/com/easysubway/datapack/adapter/in/web/DatapackReleaseBlockerSummaryAdminPageTest.java
@@ -72,6 +72,41 @@ class DatapackReleaseBlockerSummaryAdminPageTest {
 	}
 
 	@Test
+	@DisplayName("evidence bundle 상태가 실패하면 candidate gate가 PASS여도 production promote를 차단한다")
+	void dashboardBlocksProductionPromoteWhenEvidenceBundleStatusFails() throws Exception {
+		jdbcTemplate.update("""
+			UPDATE datapack_candidates
+			SET coverage_status = 'PASS',
+				route_regression_status = 'PASS',
+				android_evidence_status = 'PASS'
+			WHERE id = 'candidate-release-blocked'
+			""");
+		jdbcTemplate.update("""
+			UPDATE datapack_release_evidence_bundles
+			SET route_regression_status = 'FAIL',
+				manifest_signature_status = 'PASS'
+			WHERE candidate_id = 'candidate-release-blocked'
+			""");
+		jdbcTemplate.update("DELETE FROM external_alias_approvals");
+		jdbcTemplate.update("DELETE FROM source_quarantine_records");
+		jdbcTemplate.update("DELETE FROM manual_overrides");
+		jdbcTemplate.update("DELETE FROM facility_evidence");
+		jdbcTemplate.update("DELETE FROM route_edge_evidence");
+
+		String dashboardHtml = getAdminHtml("/admin/dashboard/page");
+		String qualityHtml = getAdminHtml("/admin/data-quality/page");
+
+		assertThat(dashboardHtml)
+			.contains("production promote 차단: blocker 1건")
+			.contains("전체 blocker 1건")
+			.doesNotContain("production promote 가능")
+			.doesNotContain("READY");
+		assertThat(qualityHtml)
+			.contains("Route gate")
+			.contains("ENTRY/EXIT/TRANSFER and generated connector gates");
+	}
+
+	@Test
 	@DisplayName("datapack read 권한이 없으면 통합 대시보드 release blocker 요약을 숨긴다")
 	void dashboardHidesDatapackReleaseBlockerSummaryWithoutDatapackRead() throws Exception {
 		String html = getAdminHtmlWithoutDatapackRead("/admin/dashboard/page");


### PR DESCRIPTION
## 관련 이슈

close #1164

## 작업 배경

데이터팩 production 전환 전에 admin/QA가 candidate hash, release evidence bundle 상태, production channel pointer, blocker reason을 한 화면에서 확인할 수 있어야 합니다. 기존 dashboard와 candidate detail은 readiness 일부를 보여줬지만, evidence bundle 메타데이터와 production promote 차단 사유가 분리되어 있어 Go-No-Go 판단 근거가 약했습니다.

## 작업 내용

- 통합 대시보드의 데이터팩 출시 준비 요약에 source snapshot set hash, manifest hash, evidence bundle hash, redacted workflow URL, production current/rollback target을 표시했습니다.
- blocker가 남아 있으면 `production promote 차단: blocker N건` reason을 직접 표시합니다.
- candidate detail의 evidence bundle viewer는 raw evidence 원문 대신 검증된 hash/status만 보여주고, workflow URL query/fragment는 redaction 처리합니다.
- readiness dashboard와 candidate detail render 테스트에 hash/status, redaction, production promote reason 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check origin/main...HEAD`: exit 0
  - `cd backend && ./gradlew test --tests '*DatapackCandidateAdminPageControllerTest' --tests '*DatapackReleaseBlockerSummaryAdminPageTest'`: BUILD SUCCESSFUL
  - `cd backend && ./gradlew test`: BUILD SUCCESSFUL

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| readiness aggregate | Backend | MockMvc dashboard render test | `DatapackReleaseBlockerSummaryAdminPageTest` | candidate/source/evidence/channel hash와 production 차단 reason 표시 확인 |
| evidence viewer | Backend | MockMvc candidate detail render test | `DatapackCandidateAdminPageControllerTest` | evidence bundle hash/status와 production 가능 reason 표시 확인 |
| raw evidence redaction | Backend | MockMvc HTML assertion | `DatapackCandidateAdminPageControllerTest`, `DatapackReleaseBlockerSummaryAdminPageTest` | workflow URL query의 `serviceKey` 미노출 확인 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `JdbcDatapackReleaseBlockerSummaryRepository`가 기존 candidate/evidence/channel 테이블만 읽어 dashboard view model을 보강하는 부분입니다.

## 리스크

- release evidence bundle 원문 JSON은 현재 DB에 저장하지 않으므로 새 raw parser는 추가하지 않았습니다. viewer는 저장된 hash/status/workflow metadata만 표시합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
