### PR TITLE
[Fix] main remaining padding 표현 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -37,6 +37,9 @@ const defaultDemoHomeDataEnabled = bool.fromEnvironment(
 );
 const _mainPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
 const _mainListPagePadding = EdgeInsets.fromLTRB(17, 18, 17, 32);
+const _homeHeroCardPadding = EdgeInsets.fromLTRB(20, 24, 20, 24);
+const _appSectionTitlePadding = EdgeInsets.fromLTRB(1, 22, 1, 11);
+const _settingsPagePadding = EdgeInsets.fromLTRB(20, 16, 20, 32);
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -2270,7 +2273,7 @@ class _HomeHero extends StatelessWidget {
         ),
         clipBehavior: Clip.antiAlias,
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(20, 24, 20, 24),
+          padding: _homeHeroCardPadding,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -2555,7 +2558,7 @@ class _AppSectionTitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(1, 22, 1, 11),
+      padding: _appSectionTitlePadding,
       child: Text(
         title,
         style: Theme.of(context).textTheme.titleMedium?.copyWith(
@@ -3395,7 +3398,7 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
         bottomNavigationBar: widget.bottomNavigationBar,
         body: SafeArea(
           child: ListView(
-            padding: const EdgeInsets.fromLTRB(20, 16, 20, 32),
+            padding: _settingsPagePadding,
             children: [
               _AppSettingsSection(
                 key: const Key('settingsSection-mobility'),


### PR DESCRIPTION
## 관련 이슈

관련: #1075

## 작업 배경

- #1075의 디자인 시스템 정리 항목 중 `main.dart`에 남은 직접 padding 표현을 줄입니다.
- QA 요청 범위에 맞춰 사용자에게 보이는 문구와 화면 값은 바꾸지 않습니다.

## 작업 내용

- 홈 hero card padding을 `_homeHeroCardPadding` 상수로 분리했습니다.
- 공통 section title padding을 `_appSectionTitlePadding` 상수로 분리했습니다.
- 설정 화면 list padding을 `_settingsPagePadding` 상수로 분리했습니다.
- 기존 `EdgeInsets.fromLTRB` 값은 그대로 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/main.dart`: exit 0, 0 changed
  - `rg -n "padding: const EdgeInsets\.fromLTRB" lib/main.dart`: exit 1, 직접 padding 매칭 없음
  - `flutter test test/widget_test.dart --name "홈 핵심 행동은 좁은 화면과 큰 글자에서도 터치 기준을 지킨다" --reporter expanded`: exit 0, 1 test passed
  - `flutter test test/widget_test.dart --name "설정 화면은 교통약자 사용 맥락별 섹션과 기존 설정 진입점을 제공한다" --reporter expanded`: exit 0, 1 test passed
  - `flutter analyze lib/main.dart`: exit 0, No issues found
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| main 직접 padding 정리 | Flutter 공통 | 직접 padding 검색 | `rg -n "padding: const EdgeInsets\.fromLTRB" lib/main.dart` exit 1 | 직접 padding 표현 없음 |
| 홈 hero CTA | Flutter widget test | 큰 글자/좁은 화면 회귀 테스트 | `flutter test test/widget_test.dart --name "홈 핵심 행동은 좁은 화면과 큰 글자에서도 터치 기준을 지킨다" --reporter expanded` exit 0 | 1 test passed |
| 설정 화면 | Flutter widget test | 설정 섹션 회귀 테스트 | `flutter test test/widget_test.dart --name "설정 화면은 교통약자 사용 맥락별 섹션과 기존 설정 진입점을 제공한다" --reporter expanded` exit 0 | 1 test passed |
| 정적 분석 | Flutter analyzer | 대상 파일 분석 | `flutter analyze lib/main.dart` exit 0 | No issues found |
| PR CI | GitHub Actions | PR #1272 check rollup 확인 | Repository CI, Backend CI, Mobile App CI, Android CI, Release Gate Consistency, Android Release Artifact, RC Evidence Manifest, Dependency Vulnerability Scan, SonarCloud Code Analysis success | required checks 통과 |
| 코드 리뷰 | GitHub PR review | CodeRabbit rate limit 확인 후 Codex manual fallback review 게시 | `Actionable comments posted: 0` review: https://github.com/AquilaXk/easysubway/pull/1272#pullrequestreview-4600479977 | actionable/nitpick 없음 |
| Post-merge CD | GitHub Actions main | merge commit `cf5c701` workflow 확인 | CI in_progress, Release Artifacts in_progress, CD 실패 신호 없음 | run 생성 확인, 실패 없음 |
| 화면 증거 | Android/iOS | 렌더링 값과 사용자 문구 변경 없음 | 증거 불필요 사유: 기존 padding 수치만 상수로 이동했고 화면 출력은 동일함 | 추가 스크린샷 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/main.dart` 상단 padding 상수와 세 사용처입니다.

## 리스크

- 렌더링 값 변경 없이 참조만 바꾼 1파일 변경이라 UI 회귀 위험은 낮습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 대체 review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.