### PR TITLE
[Fix] 역 검색 입력 radius 표현 정리

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -49,6 +49,7 @@ const _stationSearchPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
 const _stationSearchLargePagePadding = EdgeInsets.fromLTRB(24, 24, 24, 40);
 const _stationLineSheetPadding = EdgeInsets.fromLTRB(20, 8, 20, 24);
 const _stationRoleActionPadding = EdgeInsets.fromLTRB(12, 0, 12, 12);
+const _stationSearchInputRadius = BorderRadius.all(Radius.circular(18));
 
 abstract class StationSearchRepository {
   Future<List<StationSearchResult>> searchStations(String query);
@@ -1917,19 +1918,19 @@ class _StationSearchScreenState extends State<StationSearchScreen> {
               filled: true,
               fillColor: Colors.white,
               border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(18),
+                borderRadius: _stationSearchInputRadius,
                 borderSide: const BorderSide(
                   color: EasySubwayAccessibleColors.line,
                 ),
               ),
               enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(18),
+                borderRadius: _stationSearchInputRadius,
                 borderSide: const BorderSide(
                   color: EasySubwayAccessibleColors.line,
                 ),
               ),
               focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(18),
+                borderRadius: _stationSearchInputRadius,
                 borderSide: const BorderSide(
                   color: EasySubwayAccessibleColors.primary,
                   width: 2,


### PR DESCRIPTION
## 관련 이슈

관련: #1075

## 작업 배경

- #1075의 디자인 시스템 정리 항목 중 `station_search.dart` 역 검색 입력창에 남은 직접 radius 표현을 줄입니다.
- QA 요청 범위에 맞춰 사용자에게 보이는 문구와 화면 값은 바꾸지 않습니다.

## 작업 내용

- 역 검색 입력창의 `OutlineInputBorder` radius를 `_stationSearchInputRadius` 상수로 분리했습니다.
- 기존 `BorderRadius.circular(18)` 값은 `BorderRadius.all(Radius.circular(18))`로 동일하게 유지했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format lib/station_search.dart`: exit 0, 0 changed
  - `flutter test test/widget_test.dart --name "역 검색 결과 핵심 문구는 큰 글자에서 한 줄 말줄임으로 고정하지 않는다" --reporter expanded`: exit 0, 1 test passed
  - `flutter analyze lib/station_search.dart`: exit 0, No issues found
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역 검색 입력 radius 정리 | Flutter 공통 | diff 확인 | `BorderRadius.circular(18)` 직접 사용 3곳을 `_stationSearchInputRadius`로 대체 | 값 변경 없음 |
| 역 검색 큰 글자 흐름 | Flutter widget test | 관련 위젯 테스트 실행 | `flutter test test/widget_test.dart --name "역 검색 결과 핵심 문구는 큰 글자에서 한 줄 말줄임으로 고정하지 않는다" --reporter expanded` exit 0 | 1 test passed |
| 정적 분석 | Flutter analyzer | 대상 파일 분석 | `flutter analyze lib/station_search.dart` exit 0 | No issues found |
| 화면 증거 | Android/iOS | 렌더링 값과 사용자 문구 변경 없음 | 증거 불필요 사유: 기존 radius 수치만 상수로 이동했고 화면 출력은 동일함 | 추가 스크린샷 불필요 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/station_search.dart` 상단 radius 상수와 역 검색 입력창 `OutlineInputBorder` 세 사용처입니다.

## 리스크

- 렌더링 값 변경 없이 참조만 바꾼 1파일 변경이라 UI 회귀 위험은 낮습니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 대체 review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.