### PR TITLE
[Fix] CD workflow pending 해소

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,10 +27,6 @@ permissions:
   actions: read
   contents: read
 
-concurrency:
-  group: cd-production-deploy
-  cancel-in-progress: false
-
 jobs:
   plan:
     name: CD Plan
@@ -108,6 +104,9 @@ jobs:
       - self-hosted
       - easysubway-production
     environment: production
+    concurrency:
+      group: cd-production-deploy
+      cancel-in-progress: false
     if: ${{ needs.plan.outputs.deploy_target_relevant == 'true' }}
 
     steps:

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -423,11 +423,12 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
   assert.match(workflow, /workflow_run:[\s\S]*branches:\s*\n\s*-\s*main/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /permissions:[\s\S]*actions:\s*read[\s\S]*contents:\s*read/);
-  assert.match(workflow, /group: cd-production-deploy/);
-  assert.match(workflow, /cancel-in-progress: false/);
+  assert.doesNotMatch(workflow, /\nconcurrency:\s*\n\s*group: cd-production-deploy/);
   assert.match(workflow, /environment: production/);
   assert.match(workflow, /runs-on:[\s\S]*-\s*self-hosted[\s\S]*-\s*easysubway-production/);
   assert.match(workflow, /name: CD Deploy/);
+  const deployJob = workflow.match(/\n  deploy:[\s\S]*$/)?.[0] ?? "";
+  assert.match(deployJob, /\n    concurrency:\s*\n\s*group: cd-production-deploy\s*\n\s*cancel-in-progress: false/);
   assert.match(workflow, /secrets\.EASYSUBWAY_ENV/);
   assert.match(workflow, /CD Deploy \/ Validate manual dispatch CI/);
   assert.match(workflow, /manual deployment requires a successful CI workflow/);


### PR DESCRIPTION
## 관련 이슈

close #1274

## 작업 배경

- CD run이 `pending` 상태에서 jobs 0건으로 멈춰 post-merge 배포 검증을 진행할 수 없었다.
- pending deployment와 queued job이 없는 상태라 workflow 최상단 concurrency가 run 전체를 job 생성 전 단계에서 묶는 구조를 줄였다.

## 작업 내용

- CD workflow 최상단 `concurrency`를 제거했다.
- `CD Deploy` job에만 `cd-production-deploy` concurrency를 적용해 실제 배포 lock은 유지했다.
- repository contract test가 workflow-level lock 금지와 deploy job-level lock 필수를 검증하도록 보강했다.

## 검증

- 실행한 명령과 결과:
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cd.yml"); puts "cd.yml ok"'`: exit 0, `cd.yml ok`
  - `node --test --test-name-pattern "지속적 배포 준비 상태" tools/ci/repository-contract.test.mjs`: exit 0, 1 test passed
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 147 tests passed
  - `git diff --check -- .github/workflows/cd.yml tools/ci/repository-contract.test.mjs`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| CD workflow YAML | GitHub Actions | Ruby YAML parse | 로컬 명령 출력 | 통과 |
| CD lock 계약 | 로컬 Node test | repository contract test | 로컬 명령 출력 | 147 tests passed |
| CD pending 해소 | GitHub Actions | PR CI 후 post-merge CD run 확인 | merge 후 workflow link 기록 예정 | 대기 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `concurrency`가 workflow 최상단에서 `deploy` job으로 이동한 점.

## 리스크

- 동시에 여러 CD run이 생성되면 `plan` job은 각각 실행되지만, 실제 `CD Deploy` job은 기존과 동일한 group으로 한 번에 하나만 실행된다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
