### PR TITLE
[Feat] 공식 source snapshot build gate 고정

### DIFF
--- a/tools/datapack/build-datapack.mjs
+++ b/tools/datapack/build-datapack.mjs
@@ -254,8 +254,11 @@ function requiredSourceSnapshots(value, label) {
 }
 
 function assertSourceSnapshotSet(sourceSnapshotIds, sourceSnapshots) {
-  const ids = requiredStringArray(sourceSnapshotIds, "buildSpec.sourceSnapshotIds").sort();
-  const snapshotIds = sourceSnapshots.map((snapshot) => snapshot.snapshotId).sort();
+  const ids = requiredStringArray(sourceSnapshotIds, "buildSpec.sourceSnapshotIds")
+    .sort((left, right) => left.localeCompare(right));
+  const snapshotIds = sourceSnapshots
+    .map((snapshot) => snapshot.snapshotId)
+    .sort((left, right) => left.localeCompare(right));
   if (JSON.stringify(ids) !== JSON.stringify(snapshotIds)) {
     throw new Error("buildSpec.sourceSnapshotIds must match buildSpec.sourceSnapshots[].snapshotId");
   }

--- a/tools/datapack/build-datapack.mjs
+++ b/tools/datapack/build-datapack.mjs
@@ -6,6 +6,7 @@ import { DatabaseSync } from "node:sqlite";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import { usesLocalPlaceholderHost } from "./production-url-policy.mjs";
+import { requiredCredentialFreeObjectUri } from "./source-snapshot-policy.mjs";
 
 const root = path.resolve(import.meta.dirname, "../..");
 const productionMinimumTableRowNames = [
@@ -508,28 +509,6 @@ function validatePackUrlMatchesStagedPath(packUrl, pack, label) {
   if (!url.pathname.endsWith(expectedPathSuffix) || url.search !== "" || url.hash !== "") {
     throw new Error(`${label} absolute HTTPS URL path must end with ${stagedPackPath(pack)}`);
   }
-}
-
-function requiredCredentialFreeObjectUri(value, label) {
-  const uri = requiredString(value, label);
-  let parsed;
-  try {
-    parsed = new URL(uri);
-  } catch {
-    throw new Error(`${label} must be a credential-free object storage URI`);
-  }
-  if (!["s3:", "oci:"].includes(parsed.protocol)
-    || parsed.username !== ""
-    || parsed.password !== ""
-    || parsed.search !== ""
-    || parsed.hash !== ""
-    || parsed.hostname === ""
-    || parsed.pathname === ""
-    || parsed.pathname === "/"
-    || uri.includes("@")) {
-    throw new Error(`${label} must be a credential-free object storage URI`);
-  }
-  return uri;
 }
 
 function stagedPackPath(pack) {

--- a/tools/datapack/build-datapack.mjs
+++ b/tools/datapack/build-datapack.mjs
@@ -24,6 +24,7 @@ const candidateBuildSpecHashFields = [
   "approvedOverrideSetHash",
   "sourceInventorySha256",
 ];
+const sourceSnapshotStatuses = new Set(["LOCKED"]);
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -180,6 +181,8 @@ async function validateCandidateBuildSpec(buildSpec) {
   requiredString(buildSpec.productionScopeId, "buildSpec.productionScopeId");
   await resolveBuildInputPath(buildSpec.fixturePath, "buildSpec.fixturePath");
   requiredStringArray(buildSpec.sourceSnapshotIds, "buildSpec.sourceSnapshotIds");
+  const sourceSnapshots = requiredSourceSnapshots(buildSpec.sourceSnapshots, "buildSpec.sourceSnapshots");
+  assertSourceSnapshotSet(buildSpec.sourceSnapshotIds, sourceSnapshots);
   for (const field of candidateBuildSpecHashFields) {
     sha256HexString(buildSpec[field], `buildSpec.${field}`);
   }
@@ -202,6 +205,7 @@ function candidateBuildProvenance(buildSpec, buildSpecSha256) {
     productionScopeId: requiredString(buildSpec.productionScopeId, "buildSpec.productionScopeId"),
     buildSpecSha256,
     sourceSnapshotIds: requiredStringArray(buildSpec.sourceSnapshotIds, "buildSpec.sourceSnapshotIds"),
+    sourceSnapshots: requiredSourceSnapshots(buildSpec.sourceSnapshots, "buildSpec.sourceSnapshots"),
     sourceSnapshotSetHash: normalizedHashes.sourceSnapshotSetHash,
     approvedAliasLedgerHash: normalizedHashes.approvedAliasLedgerHash,
     facilityEvidenceLedgerHash: normalizedHashes.facilityEvidenceLedgerHash,
@@ -211,6 +215,55 @@ function candidateBuildProvenance(buildSpec, buildSpecSha256) {
     builderGitSha: requiredString(buildSpec.builderGitSha, "buildSpec.builderGitSha"),
     builderVersion: requiredString(buildSpec.builderVersion, "buildSpec.builderVersion"),
   };
+}
+
+function requiredSourceSnapshots(value, label) {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${label} must be a non-empty array`);
+  }
+  return value.map((snapshot, index) => {
+    const prefix = `${label}[${index}]`;
+    if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) {
+      throw new Error(`${prefix} must be an object`);
+    }
+    const normalized = {
+      snapshotId: requiredString(snapshot.snapshotId, `${prefix}.snapshotId`),
+      sourceId: requiredString(snapshot.sourceId, `${prefix}.sourceId`),
+      rawObjectUri: requiredCredentialFreeObjectUri(snapshot.rawObjectUri, `${prefix}.rawObjectUri`),
+      rawSha256: sha256HexString(snapshot.rawSha256, `${prefix}.rawSha256`),
+      redactedRequestFingerprint: sha256HexString(
+        snapshot.redactedRequestFingerprint,
+        `${prefix}.redactedRequestFingerprint`,
+      ),
+      schemaFingerprint: sha256HexString(snapshot.schemaFingerprint, `${prefix}.schemaFingerprint`),
+      snapshotStatus: requiredString(snapshot.snapshotStatus, `${prefix}.snapshotStatus`),
+      credentialRedacted: snapshot.credentialRedacted,
+      freshnessExpiresAt: requiredUtcDateString(snapshot.freshnessExpiresAt, `${prefix}.freshnessExpiresAt`),
+    };
+    if (!sourceSnapshotStatuses.has(normalized.snapshotStatus)) {
+      throw new Error(`${prefix}.snapshotStatus must be LOCKED`);
+    }
+    if (snapshot.credentialRedacted !== true) {
+      throw new Error(`${prefix}.credentialRedacted must be true`);
+    }
+    if (Date.parse(normalized.freshnessExpiresAt) <= candidateBuildNow().getTime()) {
+      throw new Error(`${prefix}.freshnessExpiresAt must be in the future`);
+    }
+    return normalized;
+  });
+}
+
+function assertSourceSnapshotSet(sourceSnapshotIds, sourceSnapshots) {
+  const ids = requiredStringArray(sourceSnapshotIds, "buildSpec.sourceSnapshotIds").sort();
+  const snapshotIds = sourceSnapshots.map((snapshot) => snapshot.snapshotId).sort();
+  if (JSON.stringify(ids) !== JSON.stringify(snapshotIds)) {
+    throw new Error("buildSpec.sourceSnapshotIds must match buildSpec.sourceSnapshots[].snapshotId");
+  }
+}
+
+function candidateBuildNow() {
+  const value = process.env.EASYSUBWAY_DATAPACK_BUILD_NOW;
+  return value ? new Date(requiredUtcDateString(value, "EASYSUBWAY_DATAPACK_BUILD_NOW")) : new Date();
 }
 
 async function resolveBuildInputPath(value, label) {
@@ -452,6 +505,28 @@ function validatePackUrlMatchesStagedPath(packUrl, pack, label) {
   if (!url.pathname.endsWith(expectedPathSuffix) || url.search !== "" || url.hash !== "") {
     throw new Error(`${label} absolute HTTPS URL path must end with ${stagedPackPath(pack)}`);
   }
+}
+
+function requiredCredentialFreeObjectUri(value, label) {
+  const uri = requiredString(value, label);
+  let parsed;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    throw new Error(`${label} must be a credential-free object storage URI`);
+  }
+  if (!["s3:", "oci:"].includes(parsed.protocol)
+    || parsed.username !== ""
+    || parsed.password !== ""
+    || parsed.search !== ""
+    || parsed.hash !== ""
+    || parsed.hostname === ""
+    || parsed.pathname === ""
+    || parsed.pathname === "/"
+    || uri.includes("@")) {
+    throw new Error(`${label} must be a credential-free object storage URI`);
+  }
+  return uri;
 }
 
 function stagedPackPath(pack) {

--- a/tools/datapack/build-source-snapshot.mjs
+++ b/tools/datapack/build-source-snapshot.mjs
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { requiredCredentialFreeObjectUri } from "./source-snapshot-policy.mjs";
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -139,28 +140,6 @@ function validateSnapshot(snapshot) {
 async function writeFileWithParents(filePath, body) {
   await mkdir(path.dirname(path.resolve(filePath)), { recursive: true });
   await writeFile(filePath, body);
-}
-
-function requiredCredentialFreeObjectUri(value, label) {
-  const uri = requiredText(value, label);
-  let parsed;
-  try {
-    parsed = new URL(uri);
-  } catch {
-    throw new Error(`${label} must be a credential-free object storage URI`);
-  }
-  if (!["s3:", "oci:"].includes(parsed.protocol)
-    || parsed.username !== ""
-    || parsed.password !== ""
-    || parsed.search !== ""
-    || parsed.hash !== ""
-    || parsed.hostname === ""
-    || parsed.pathname === ""
-    || parsed.pathname === "/"
-    || uri.includes("@")) {
-    throw new Error(`${label} must be a credential-free object storage URI`);
-  }
-  return uri;
 }
 
 function requiredDate(value, label) {

--- a/tools/datapack/build-source-snapshot.mjs
+++ b/tools/datapack/build-source-snapshot.mjs
@@ -96,7 +96,8 @@ function rowsFromRaw(raw) {
 }
 
 function schemaFields(records) {
-  return [...new Set(records.flatMap((record) => Object.keys(record)))].sort();
+  return [...new Set(records.flatMap((record) => Object.keys(record)))]
+    .sort((left, right) => left.localeCompare(right));
 }
 
 function sortJson(value) {

--- a/tools/datapack/build-source-snapshot.mjs
+++ b/tools/datapack/build-source-snapshot.mjs
@@ -19,7 +19,7 @@ async function main() {
     sourceUpdatedAt: args["source-updated-at"] ?? null,
     rowCount: records.length,
     rawSha256: sha256(canonicalRaw),
-    rawObjectUri: requireArg(args, "raw-object-uri"),
+    rawObjectUri: requiredCredentialFreeObjectUri(args["raw-object-uri"], "--raw-object-uri"),
     redactedRequestFingerprint: sha256(redactedRequest(args)),
     schemaFingerprint: sha256(JSON.stringify(schemaFields(records))),
     snapshotStatus: "LOCKED",
@@ -127,8 +127,12 @@ function validateSnapshot(snapshot) {
   if (!/^[0-9a-f]{64}$/.test(snapshot.rawSha256) || !/^[0-9a-f]{64}$/.test(snapshot.schemaFingerprint)) {
     throw new Error("snapshot hash fields must be sha256");
   }
-  if (Date.parse(snapshot.freshnessExpiresAt) <= Date.parse(snapshot.retrievedAt)) {
+  const retrievedAt = requiredDate(snapshot.retrievedAt, "retrievedAt");
+  if (requiredDate(snapshot.freshnessExpiresAt, "freshnessExpiresAt") <= retrievedAt) {
     throw new Error("freshnessExpiresAt must be after retrievedAt");
+  }
+  if (requiredDate(snapshot.rawRetentionExpiresAt, "rawRetentionExpiresAt") <= retrievedAt) {
+    throw new Error("rawRetentionExpiresAt must be after retrievedAt");
   }
 }
 
@@ -137,10 +141,43 @@ async function writeFileWithParents(filePath, body) {
   await writeFile(filePath, body);
 }
 
+function requiredCredentialFreeObjectUri(value, label) {
+  const uri = requiredText(value, label);
+  let parsed;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    throw new Error(`${label} must be a credential-free object storage URI`);
+  }
+  if (!["s3:", "oci:"].includes(parsed.protocol)
+    || parsed.username !== ""
+    || parsed.password !== ""
+    || parsed.search !== ""
+    || parsed.hash !== ""
+    || parsed.hostname === ""
+    || parsed.pathname === ""
+    || parsed.pathname === "/"
+    || uri.includes("@")) {
+    throw new Error(`${label} must be a credential-free object storage URI`);
+  }
+  return uri;
+}
+
+function requiredDate(value, label) {
+  const millis = Date.parse(requiredText(value, label));
+  if (Number.isNaN(millis)) {
+    throw new Error(`${label} must be an ISO date-time`);
+  }
+  return millis;
+}
+
 function requireArg(args, name) {
-  const value = args[name];
+  return requiredText(args[name], `--${name}`);
+}
+
+function requiredText(value, label) {
   if (typeof value !== "string" || value.trim() === "") {
-    throw new Error(`--${name} is required`);
+    throw new Error(`${label} is required`);
   }
   return value.trim();
 }

--- a/tools/datapack/build-source-snapshot.mjs
+++ b/tools/datapack/build-source-snapshot.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const raw = await readRaw(args);
+  assertNoCredential(raw);
+  const canonicalRaw = canonicalizeRaw(raw);
+  const records = rowsFromRaw(canonicalRaw);
+  const snapshot = {
+    schemaVersion: 1,
+    artifactKind: "official-source-snapshot",
+    snapshotId: requireArg(args, "snapshot-id"),
+    sourceId: requireArg(args, "source-id"),
+    provider: requireArg(args, "provider"),
+    retrievedAt: requireArg(args, "retrieved-at"),
+    sourceUpdatedAt: args["source-updated-at"] ?? null,
+    rowCount: records.length,
+    rawSha256: sha256(canonicalRaw),
+    rawObjectUri: requireArg(args, "raw-object-uri"),
+    redactedRequestFingerprint: sha256(redactedRequest(args)),
+    schemaFingerprint: sha256(JSON.stringify(schemaFields(records))),
+    snapshotStatus: "LOCKED",
+    schemaStatus: "PASS",
+    licenseStatus: "PASS",
+    fetchStatus: "SUCCESS",
+    redistributionAllowed: true,
+    credentialRedacted: true,
+    previousSnapshotId: args["previous-snapshot-id"] ?? null,
+    diffSummary: args["diff-summary"] ?? null,
+    freshnessExpiresAt: requireArg(args, "freshness-expires-at"),
+    rawRetentionExpiresAt: requireArg(args, "raw-retention-expires-at"),
+    providerRecordHashes: records.map((record) => sha256(JSON.stringify(record))),
+  };
+  validateSnapshot(snapshot);
+
+  if (args["raw-output"]) {
+    await writeFileWithParents(args["raw-output"], canonicalRaw);
+  }
+  await writeFileWithParents(requireArg(args, "output"), `${JSON.stringify(snapshot, null, 2)}\n`);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    if (!key?.startsWith("--")) throw new Error(`unknown argument: ${key}`);
+    args[key.slice(2)] = argv[index + 1];
+  }
+  return args;
+}
+
+async function readRaw(args) {
+  if ((args.input == null) === (args.url == null)) {
+    throw new Error("exactly one of --input or --url is required");
+  }
+  if (args.input != null) {
+    return readFile(path.resolve(args.input), "utf8");
+  }
+  const response = await fetch(args.url);
+  if (!response.ok) {
+    throw new Error(`source fetch failed: ${response.status}`);
+  }
+  return response.text();
+}
+
+function canonicalizeRaw(raw) {
+  const trimmed = raw.trim();
+  if (!trimmed) throw new Error("raw snapshot must not be empty");
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    return `${JSON.stringify(sortJson(JSON.parse(trimmed)))}\n`;
+  }
+  return `${trimmed.replace(/\r\n/g, "\n")}\n`;
+}
+
+function rowsFromRaw(raw) {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("[")) return JSON.parse(trimmed).map(sortJson);
+  if (trimmed.startsWith("{")) {
+    const json = JSON.parse(trimmed);
+    const array = Object.values(json).find(Array.isArray);
+    return (array ?? [json]).map(sortJson);
+  }
+  const lines = trimmed.split("\n").filter(Boolean);
+  if (lines.length === 0) return [];
+  if (lines[0].includes(",")) {
+    const headers = lines[0].split(",").map((value) => value.trim());
+    return lines.slice(1).map((line) => Object.fromEntries(line.split(",").map((value, index) => [
+      headers[index] ?? `column${index + 1}`,
+      value.trim(),
+    ])));
+  }
+  return lines.map((line) => ({ value: line }));
+}
+
+function schemaFields(records) {
+  return [...new Set(records.flatMap((record) => Object.keys(record)))].sort();
+}
+
+function sortJson(value) {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.entries(value).sort(([left], [right]) => left.localeCompare(right)).map(([key, entry]) => [
+    key,
+    sortJson(entry),
+  ]));
+}
+
+function redactedRequest(args) {
+  return JSON.stringify(sortJson({
+    input: args.input ? path.basename(args.input) : undefined,
+    url: args.url ? args.url.replace(/([?&](?:serviceKey|apiKey|key|token)=)[^&#]*/gi, "$1[REDACTED]") : undefined,
+    sourceId: args["source-id"],
+  }));
+}
+
+function assertNoCredential(raw) {
+  if (/(serviceKey|apiKey|access[_-]?token|secret)[=:][^\s&"']+/i.test(raw)) {
+    throw new Error("raw snapshot contains credential-like token");
+  }
+}
+
+function validateSnapshot(snapshot) {
+  if (!/^[0-9a-f]{64}$/.test(snapshot.rawSha256) || !/^[0-9a-f]{64}$/.test(snapshot.schemaFingerprint)) {
+    throw new Error("snapshot hash fields must be sha256");
+  }
+  if (Date.parse(snapshot.freshnessExpiresAt) <= Date.parse(snapshot.retrievedAt)) {
+    throw new Error("freshnessExpiresAt must be after retrievedAt");
+  }
+}
+
+async function writeFileWithParents(filePath, body) {
+  await mkdir(path.dirname(path.resolve(filePath)), { recursive: true });
+  await writeFile(filePath, body);
+}
+
+function requireArg(args, name) {
+  const value = args[name];
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`--${name} is required`);
+  }
+  return value.trim();
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -327,10 +327,163 @@ test("데이터팩 생성기는 buildSpec 요청으로 candidate provenance를 �
     "snapshot-molit-urban-rail-full-route-fixture",
     "snapshot-seoulmetro-station-line-info-fixture",
   ]);
+  assert.deepEqual(
+    provenance.candidateBuild.sourceSnapshots.map((snapshot) => ({
+      snapshotId: snapshot.snapshotId,
+      sourceId: snapshot.sourceId,
+      snapshotStatus: snapshot.snapshotStatus,
+      credentialRedacted: snapshot.credentialRedacted,
+    })),
+    [
+      {
+        snapshotId: "snapshot-molit-urban-rail-full-route-fixture",
+        sourceId: "molit-urban-rail-full-route",
+        snapshotStatus: "LOCKED",
+        credentialRedacted: true,
+      },
+      {
+        snapshotId: "snapshot-seoulmetro-station-line-info-fixture",
+        sourceId: "seoulmetro-station-line-info",
+        snapshotStatus: "LOCKED",
+        credentialRedacted: true,
+      },
+    ],
+  );
   assert.equal(
     provenance.candidateBuild.approvedAliasLedgerHash,
     "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   );
+});
+
+test("데이터팩 생성기는 만료된 source snapshot buildSpec을 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-datapack-build-spec-expired-output-${Date.now()}`);
+  const buildSpecDir = path.join(root, "tmp", `easysubway-datapack-build-spec-expired-${process.pid}-${Date.now()}`);
+  const buildSpecPath = path.join(buildSpecDir, "candidate-build-spec.expired.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await rm(buildSpecDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await mkdir(buildSpecDir, { recursive: true });
+  const buildSpec = JSON.parse(await readFile("tools/datapack/fixtures/candidate-build-spec.json", "utf8"));
+  buildSpec.sourceSnapshots[0].freshnessExpiresAt = "2026-06-30T00:00:00Z";
+  await writeFile(buildSpecPath, `${JSON.stringify(buildSpec, null, 2)}\n`);
+
+  try {
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          "tools/datapack/build-datapack.mjs",
+          "--build-spec",
+          buildSpecPath,
+          "--output",
+          outputDir,
+        ],
+        {
+          cwd: root,
+          env: {
+            ...productionEnv,
+            EASYSUBWAY_DATAPACK_BUILD_NOW: "2026-06-30T01:00:00Z",
+          },
+        },
+      ),
+      /buildSpec\.sourceSnapshots\[0\]\.freshnessExpiresAt must be in the future/,
+    );
+  } finally {
+    await rm(buildSpecDir, { recursive: true, force: true });
+  }
+});
+
+test("source snapshot command는 raw token을 저장 전에 거부한다", async () => {
+  const workDir = path.join(tmpdir(), `easysubway-source-snapshot-token-${process.pid}-${Date.now()}`);
+  const rawPath = path.join(workDir, "raw.csv");
+  const outputPath = path.join(workDir, "snapshot.json");
+  await rm(workDir, { recursive: true, force: true });
+  await mkdir(workDir, { recursive: true });
+  await writeFile(rawPath, "station\nSadang\nserviceKey=secret-token\n");
+
+  try {
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          "tools/datapack/build-source-snapshot.mjs",
+          "--input",
+          rawPath,
+          "--output",
+          outputPath,
+          "--snapshot-id",
+          "snapshot-kric-token",
+          "--source-id",
+          "kric-station-elevator",
+          "--provider",
+          "국가철도공단",
+          "--retrieved-at",
+          "2026-06-30T03:00:00Z",
+          "--raw-object-uri",
+          "s3://easysubway-datapack-sources/kric-station-elevator/snapshot-kric-token.json",
+          "--freshness-expires-at",
+          "2026-07-07T03:00:00Z",
+          "--raw-retention-expires-at",
+          "2026-09-30T03:00:00Z",
+        ],
+        { cwd: root },
+      ),
+      /raw snapshot contains credential-like token/,
+    );
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+});
+
+test("source snapshot command는 raw CSV를 LOCKED snapshot metadata로 canonicalize한다", async () => {
+  const workDir = path.join(tmpdir(), `easysubway-source-snapshot-ok-${process.pid}-${Date.now()}`);
+  const rawPath = path.join(workDir, "raw.csv");
+  const canonicalRawPath = path.join(workDir, "canonical.csv");
+  const outputPath = path.join(workDir, "snapshot.json");
+  await rm(workDir, { recursive: true, force: true });
+  await mkdir(workDir, { recursive: true });
+  await writeFile(rawPath, "station,line\nSadang,2\nSangnoksu,4\n");
+
+  try {
+    await execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/build-source-snapshot.mjs",
+        "--input",
+        rawPath,
+        "--raw-output",
+        canonicalRawPath,
+        "--output",
+        outputPath,
+        "--snapshot-id",
+        "snapshot-kric-station-elevator-20260630",
+        "--source-id",
+        "kric-station-elevator",
+        "--provider",
+        "국가철도공단",
+        "--retrieved-at",
+        "2026-06-30T03:00:00Z",
+        "--raw-object-uri",
+        "s3://easysubway-datapack-sources/kric-station-elevator/snapshot-kric-station-elevator-20260630.csv",
+        "--freshness-expires-at",
+        "2026-07-07T03:00:00Z",
+        "--raw-retention-expires-at",
+        "2026-09-30T03:00:00Z",
+      ],
+      { cwd: root },
+    );
+
+    const snapshot = JSON.parse(await readFile(outputPath, "utf8"));
+    assert.equal(snapshot.snapshotStatus, "LOCKED");
+    assert.equal(snapshot.credentialRedacted, true);
+    assert.equal(snapshot.rowCount, 2);
+    assert.match(snapshot.rawSha256, /^[0-9a-f]{64}$/);
+    assert.match(snapshot.schemaFingerprint, /^[0-9a-f]{64}$/);
+    assert.equal(snapshot.providerRecordHashes.length, 2);
+    assert.equal(await readFile(canonicalRawPath, "utf8"), "station,line\nSadang,2\nSangnoksu,4\n");
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
 });
 
 test("데이터팩 생성기는 같은 buildSpec에서 candidate artifact hash를 재현한다", async () => {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -435,6 +435,64 @@ test("source snapshot command는 raw token을 저장 전에 거부한다", async
   }
 });
 
+test("source snapshot command는 credential URI와 만료 retention metadata를 거부한다", async () => {
+  const workDir = path.join(tmpdir(), `easysubway-source-snapshot-policy-${process.pid}-${Date.now()}`);
+  const rawPath = path.join(workDir, "raw.csv");
+  await rm(workDir, { recursive: true, force: true });
+  await mkdir(workDir, { recursive: true });
+  await writeFile(rawPath, "station\nSadang\n");
+  const baseArgs = [
+    "tools/datapack/build-source-snapshot.mjs",
+    "--input",
+    rawPath,
+    "--output",
+    path.join(workDir, "snapshot.json"),
+    "--snapshot-id",
+    "snapshot-kric-policy",
+    "--source-id",
+    "kric-station-elevator",
+    "--provider",
+    "국가철도공단",
+    "--retrieved-at",
+    "2026-06-30T03:00:00Z",
+    "--freshness-expires-at",
+    "2026-07-07T03:00:00Z",
+  ];
+
+  try {
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          ...baseArgs,
+          "--raw-object-uri",
+          "s3://bucket/snapshot.json?serviceKey=secret",
+          "--raw-retention-expires-at",
+          "2026-09-30T03:00:00Z",
+        ],
+        { cwd: root },
+      ),
+      /--raw-object-uri must be a credential-free object storage URI/,
+    );
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          ...baseArgs,
+          "--raw-object-uri",
+          "s3://bucket/snapshot.json",
+          "--raw-retention-expires-at",
+          "2026-01-01T00:00:00Z",
+        ],
+        { cwd: root },
+      ),
+      /rawRetentionExpiresAt must be after retrievedAt/,
+    );
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+});
+
 test("source snapshot command는 raw CSV를 LOCKED snapshot metadata로 canonicalize한다", async () => {
   const workDir = path.join(tmpdir(), `easysubway-source-snapshot-ok-${process.pid}-${Date.now()}`);
   const rawPath = path.join(workDir, "raw.csv");

--- a/tools/datapack/fixtures/candidate-build-spec.json
+++ b/tools/datapack/fixtures/candidate-build-spec.json
@@ -8,6 +8,30 @@
     "snapshot-molit-urban-rail-full-route-fixture",
     "snapshot-seoulmetro-station-line-info-fixture"
   ],
+  "sourceSnapshots": [
+    {
+      "snapshotId": "snapshot-molit-urban-rail-full-route-fixture",
+      "sourceId": "molit-urban-rail-full-route",
+      "rawObjectUri": "s3://easysubway-datapack-sources/molit-urban-rail-full-route/snapshot-fixture.json",
+      "rawSha256": "1111111111111111111111111111111111111111111111111111111111111111",
+      "redactedRequestFingerprint": "2222222222222222222222222222222222222222222222222222222222222222",
+      "schemaFingerprint": "3333333333333333333333333333333333333333333333333333333333333333",
+      "snapshotStatus": "LOCKED",
+      "credentialRedacted": true,
+      "freshnessExpiresAt": "2099-07-07T03:00:00Z"
+    },
+    {
+      "snapshotId": "snapshot-seoulmetro-station-line-info-fixture",
+      "sourceId": "seoulmetro-station-line-info",
+      "rawObjectUri": "s3://easysubway-datapack-sources/seoulmetro-station-line-info/snapshot-fixture.json",
+      "rawSha256": "4444444444444444444444444444444444444444444444444444444444444444",
+      "redactedRequestFingerprint": "5555555555555555555555555555555555555555555555555555555555555555",
+      "schemaFingerprint": "6666666666666666666666666666666666666666666666666666666666666666",
+      "snapshotStatus": "LOCKED",
+      "credentialRedacted": true,
+      "freshnessExpiresAt": "2099-07-07T03:00:00Z"
+    }
+  ],
   "sourceSnapshotSetHash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "approvedAliasLedgerHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "facilityEvidenceLedgerHash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",

--- a/tools/datapack/source-snapshot-policy.mjs
+++ b/tools/datapack/source-snapshot-policy.mjs
@@ -1,0 +1,28 @@
+export function requiredCredentialFreeObjectUri(value, label) {
+  const uri = requiredText(value, label);
+  let parsed;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    throw new Error(`${label} must be a credential-free object storage URI`);
+  }
+  if (!["s3:", "oci:"].includes(parsed.protocol)
+    || parsed.username !== ""
+    || parsed.password !== ""
+    || parsed.search !== ""
+    || parsed.hash !== ""
+    || parsed.hostname === ""
+    || parsed.pathname === ""
+    || parsed.pathname === "/"
+    || uri.includes("@")) {
+    throw new Error(`${label} must be a credential-free object storage URI`);
+  }
+  return uri;
+}
+
+function requiredText(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} is required`);
+  }
+  return value.trim();
+}


### PR DESCRIPTION
## Summary
- add a stdlib source snapshot command that canonicalizes raw official-source CSV/JSON/XML into LOCKED snapshot metadata
- require production buildSpec sourceSnapshots metadata to match sourceSnapshotIds, stay LOCKED, be credential-redacted, use credential-free raw object URIs, and remain fresh
- keep candidate provenance carrying source snapshot evidence for release review

Closes #1165

## Verification
- node --test tools/datapack/*.test.mjs
- node --test tools/ci/repository-contract.test.mjs