### PR TITLE
[Fix] 역 검색 결과 카드 radius 표현 정리

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -50,6 +50,8 @@ const _stationSearchLargePagePadding = EdgeInsets.fromLTRB(24, 24, 24, 40);
 const _stationLineSheetPadding = EdgeInsets.fromLTRB(20, 8, 20, 24);
 const _stationRoleActionPadding = EdgeInsets.fromLTRB(12, 0, 12, 12);
 const _stationSearchInputRadius = BorderRadius.all(Radius.circular(18));
+const _stationResultCardRadius = BorderRadius.all(Radius.circular(18));
+const _stationCompactCardRadius = BorderRadius.all(Radius.circular(8));
 
 abstract class StationSearchRepository {
   Future<List<StationSearchResult>> searchStations(String query);
@@ -2450,7 +2452,7 @@ class _StationRecentSearchItem extends StatelessWidget {
       child: Material(
         color: Colors.white,
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: _stationCompactCardRadius,
           side: const BorderSide(color: EasySubwayAccessibleColors.line),
         ),
         child: Padding(
@@ -2466,7 +2468,7 @@ class _StationRecentSearchItem extends StatelessWidget {
                   child: ExcludeSemantics(
                     child: InkWell(
                       key: Key('stationRecentSearchQuery-$query'),
-                      borderRadius: BorderRadius.circular(8),
+                      borderRadius: _stationCompactCardRadius,
                       onTap: enabled ? () => onQuerySelected(query) : null,
                       child: Padding(
                         padding: const EdgeInsets.symmetric(vertical: 6),
@@ -3131,7 +3133,7 @@ class _NearbyStationOverview extends StatelessWidget {
       color: EasySubwayAccessibleColors.skySoft,
       elevation: 0,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(18),
+        borderRadius: _stationResultCardRadius,
         side: const BorderSide(color: EasySubwayAccessibleColors.line),
       ),
       child: Column(
@@ -3144,7 +3146,7 @@ class _NearbyStationOverview extends StatelessWidget {
             child: ExcludeSemantics(
               child: InkWell(
                 key: const Key('nearbyStationPrimaryCard'),
-                borderRadius: BorderRadius.circular(18),
+                borderRadius: _stationResultCardRadius,
                 onTap: onTap,
                 child: Padding(
                   padding: const EdgeInsets.all(16),
@@ -3340,7 +3342,7 @@ class _StationSearchResultTile extends StatelessWidget {
       color: Colors.white,
       elevation: 0,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(18),
+        borderRadius: _stationResultCardRadius,
         side: const BorderSide(color: Color(0xFFD5E2E4)),
       ),
       child: Column(
@@ -3353,7 +3355,7 @@ class _StationSearchResultTile extends StatelessWidget {
               child: ExcludeSemantics(
                 child: InkWell(
                   key: Key('stationSearchResult-${result.id}'),
-                  borderRadius: BorderRadius.circular(8),
+                  borderRadius: _stationCompactCardRadius,
                   onTap: onTap,
                   child: ConstrainedBox(
                     constraints: const BoxConstraints(minHeight: 78),
@@ -3816,7 +3818,7 @@ class _FavoriteStationTile extends StatelessWidget {
       color: Colors.white,
       elevation: 0,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: _stationCompactCardRadius,
         side: const BorderSide(color: Color(0xFFD5E2E4)),
       ),
       child: Padding(
@@ -3832,7 +3834,7 @@ class _FavoriteStationTile extends StatelessWidget {
                 child: ExcludeSemantics(
                   child: InkWell(
                     key: Key('favoriteStationTile-${favorite.stationId}'),
-                    borderRadius: BorderRadius.circular(8),
+                    borderRadius: _stationCompactCardRadius,
                     onTap: onOpenDetail,
                     child: Padding(
                       padding: const EdgeInsets.only(bottom: 12),


### PR DESCRIPTION
## 관련 이슈

part of #1075

## 작업 내용

- 역 검색 최근 검색어, 주변 역 대표 카드, 검색 결과 카드, 즐겨찾기 역 카드의 반복 radius 직접 표현을 파일 상수로 정리했습니다.
- UI 동작과 문구는 바꾸지 않았습니다.

## 검증

- `flutter test test/widget_test.dart --name "역 검색 대화면은 경계 폭 큰 글씨와 긴 노선명에서 렌더링된다" --reporter expanded`: exit 0, All tests passed
- `flutter analyze lib/station_search.dart`: exit 0, No issues found
- `git diff --check`: exit 0

## 증거

| 항목 | 방법 | 결과 |
| --- | --- | --- |
| 역 검색 대화면 큰 글씨 회귀 | Flutter widget test | 통과 |
| station_search 정적 분석 | flutter analyze | 통과 |
| diff whitespace | git diff --check | 통과 |

## 리뷰어 메모

- 동작 변경 없이 `apps/mobile/lib/station_search.dart` radius 직접 표현 일부만 상수로 치환했습니다.
