### PR TITLE
[Fix] 역 검색 노선 필터 radius 표현 정리

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -52,6 +52,8 @@ const _stationRoleActionPadding = EdgeInsets.fromLTRB(12, 0, 12, 12);
 const _stationSearchInputRadius = BorderRadius.all(Radius.circular(18));
 const _stationResultCardRadius = BorderRadius.all(Radius.circular(18));
 const _stationCompactCardRadius = BorderRadius.all(Radius.circular(8));
+const _stationLineRegionChipRadius = BorderRadius.all(Radius.circular(8));
+const _stationLineFilterButtonRadius = BorderRadius.all(Radius.circular(14));
 
 abstract class StationSearchRepository {
   Future<List<StationSearchResult>> searchStations(String query);
@@ -2804,7 +2806,9 @@ class _StationLineRegionButton extends StatelessWidget {
           selectedColor: const Color(0xFF007A80),
           backgroundColor: Colors.white,
           side: const BorderSide(color: Color(0xFF93C7C2)),
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          shape: const RoundedRectangleBorder(
+            borderRadius: _stationLineRegionChipRadius,
+          ),
         ),
       ),
     );
@@ -2869,8 +2873,8 @@ class _StationLineFilterButton extends StatelessWidget {
             backgroundColor: backgroundColor,
             foregroundColor: foregroundColor,
             side: BorderSide(color: borderColor, width: selected ? 2 : 1.5),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(14),
+            shape: const RoundedRectangleBorder(
+              borderRadius: _stationLineFilterButtonRadius,
             ),
             textStyle: const TextStyle(
               fontSize: 15,


### PR DESCRIPTION
## 관련 이슈

part of #1075

## 작업 내용

- 역 검색 노선 지역 chip과 노선 필터 버튼의 반복 radius 직접 표현을 파일 상수로 정리했습니다.
- 필터 동작, 문구, Semantics label은 바꾸지 않았습니다.

## 검증

- `flutter test test/widget_test.dart --name "역 검색은 노선을 선택해 결과를 좁힌다" --reporter expanded`: exit 0, All tests passed
- `flutter analyze lib/station_search.dart`: exit 0, No issues found
- `git diff --check`: exit 0

## 증거

| 항목 | 방법 | 결과 |
| --- | --- | --- |
| 노선 필터 선택 회귀 | Flutter widget test | 통과 |
| station_search 정적 분석 | flutter analyze | 통과 |
| diff whitespace | git diff --check | 통과 |

## 리뷰어 메모

- 동작 변경 없이 `apps/mobile/lib/station_search.dart` 노선 필터 radius 직접 표현만 상수로 치환했습니다.
