### PR TITLE
[Feat] Route Commercialization A-2 Golden OD dataset과 ETA accuracy evaluator 추가

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -31,6 +31,32 @@ function readJson(relativePath) {
   return JSON.parse(read(relativePath));
 }
 
+test("route ETA accuracy evaluator report contract is machine-readable", async () => {
+  const outputDir = await mkdtemp(path.join(tmpdir(), "route-accuracy-"));
+  const output = path.join(outputDir, "route-accuracy-report.json");
+  await execFileAsync(process.execPath, [
+    "tools/routes/evaluate-eta-accuracy.mjs",
+    "--dataset",
+    "tools/routes/golden-od",
+    "--output",
+    output,
+  ], { cwd: root });
+
+  const report = JSON.parse(readFileSync(output, "utf8"));
+  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.sampleSize, 100);
+  assert.equal(report.metrics.sampleSize, 100);
+  assert.equal(report.coverage.singleRide, true);
+  assert.equal(report.coverage.oneTransfer, true);
+  assert.equal(report.coverage.twoTransfer, true);
+  assert.equal(report.coverage.express, true);
+  assert.equal(report.coverage.outOfStationTransfer, true);
+  assert.equal(report.coverage.strictStepFree, true);
+  assert.equal(report.coverage.realtimeSupported, true);
+  assert.equal(report.coverage.realtimeUnsupported, true);
+  assert.deepEqual(report.failures, []);
+});
+
 function currentMobileVersionCode() {
   const match = read("apps/mobile/pubspec.yaml").match(/^version:\s*[^+\s]+[+](\d+)\s*$/m);
   assert.ok(match, "mobile pubspec must contain versionName+versionCode");

--- a/tools/routes/evaluate-eta-accuracy.mjs
+++ b/tools/routes/evaluate-eta-accuracy.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const requiredFiles = new Map([
+  ["single_ride_cases.csv", "singleRide"],
+  ["one_transfer_cases.csv", "oneTransfer"],
+  ["two_transfer_cases.csv", "twoTransfer"],
+  ["express_cases.csv", "express"],
+  ["out_of_station_transfer_cases.csv", "outOfStationTransfer"],
+  ["strict_step_free_cases.csv", "strictStepFree"],
+]);
+const requiredColumns = [
+  "origin_station_id",
+  "destination_station_id",
+  "departure_time",
+  "mobility_type",
+  "constraint_mode",
+  "expected_transfer_count",
+  "max_eta_error_seconds",
+  "observed_eta_error_seconds",
+  "use_realtime",
+  "notes",
+];
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const dataset = args.dataset ?? "tools/routes/golden-od";
+  const output = args.output ?? "artifacts/route-accuracy-report.json";
+  const rows = await readDataset(dataset);
+  const report = buildReport(rows);
+
+  await mkdir(path.dirname(output), { recursive: true });
+  await writeFile(output, `${JSON.stringify(report, null, 2)}\n`);
+  if (report.failures.length > 0) {
+    process.exit(1);
+  }
+}
+
+function parseArgs(args) {
+  const parsed = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const key = args[index]?.replace(/^--/, "");
+    const value = args[index + 1];
+    if (!key || !value) throw new Error("usage: evaluate-eta-accuracy.mjs --dataset <dir> --output <file>");
+    parsed[key] = value;
+  }
+  return parsed;
+}
+
+async function readDataset(datasetDir) {
+  const files = new Set(await readdir(datasetDir));
+  const rows = [];
+  for (const [file, category] of requiredFiles) {
+    if (!files.has(file)) throw new Error(`missing golden OD file: ${file}`);
+    const csvRows = parseCsv(await readFile(path.join(datasetDir, file), "utf8"));
+    for (const row of csvRows) {
+      rows.push({ ...row, category, sourceFile: file });
+    }
+  }
+  return rows;
+}
+
+function parseCsv(source) {
+  const lines = source.trim().split(/\r?\n/);
+  const header = splitCsvLine(lines.shift() ?? "");
+  for (const column of requiredColumns) {
+    if (!header.includes(column)) throw new Error(`golden OD CSV missing column: ${column}`);
+  }
+  return lines.filter(Boolean).map((line) => {
+    const values = splitCsvLine(line);
+    return Object.fromEntries(header.map((column, index) => [column, values[index] ?? ""]));
+  });
+}
+
+function splitCsvLine(line) {
+  const values = [];
+  let value = "";
+  let quoted = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === "\"") {
+      quoted = !quoted;
+    } else if (char === "," && !quoted) {
+      values.push(value);
+      value = "";
+    } else {
+      value += char;
+    }
+  }
+  values.push(value);
+  return values;
+}
+
+function buildReport(rows) {
+  const failures = [];
+  const errors = rows.map((row, index) => {
+    const observed = requiredNumber(row.observed_eta_error_seconds, row, "observed_eta_error_seconds", failures);
+    const max = requiredNumber(row.max_eta_error_seconds, row, "max_eta_error_seconds", failures);
+    if (observed > max) failures.push(`${row.sourceFile}:${index + 2} observed ETA error exceeds max`);
+    return observed;
+  }).sort((left, right) => left - right);
+  const coverage = {
+    singleRide: rows.some((row) => row.category === "singleRide"),
+    oneTransfer: rows.some((row) => row.category === "oneTransfer"),
+    twoTransfer: rows.some((row) => row.category === "twoTransfer"),
+    express: rows.some((row) => row.category === "express"),
+    outOfStationTransfer: rows.some((row) => row.category === "outOfStationTransfer"),
+    strictStepFree: rows.some((row) => row.category === "strictStepFree"),
+    realtimeSupported: rows.some((row) => row.use_realtime === "true"),
+    realtimeUnsupported: rows.some((row) => row.use_realtime === "false"),
+  };
+  for (const [key, covered] of Object.entries(coverage)) {
+    if (!covered) failures.push(`missing required coverage: ${key}`);
+  }
+  if (rows.length < 100) failures.push("golden OD sampleSize must be at least 100");
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    sampleSize: rows.length,
+    coverage,
+    metrics: {
+      sampleSize: rows.length,
+      p50ErrorSeconds: percentile(errors, 0.5),
+      p90ErrorSeconds: percentile(errors, 0.9),
+      maxErrorSeconds: errors.at(-1) ?? 0,
+    },
+    failures,
+  };
+}
+
+function requiredNumber(value, row, column, failures) {
+  const number = Number.parseInt(value, 10);
+  if (!Number.isFinite(number)) failures.push(`${row.sourceFile} invalid number: ${column}`);
+  return number;
+}
+
+function percentile(sortedValues, percentileValue) {
+  if (sortedValues.length === 0) return 0;
+  const index = Math.max(0, Math.ceil(sortedValues.length * percentileValue) - 1);
+  return sortedValues[index];
+}

--- a/tools/routes/evaluate-eta-accuracy.mjs
+++ b/tools/routes/evaluate-eta-accuracy.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 const requiredFiles = new Map([
   ["single_ride_cases.csv", "singleRide"],
@@ -23,10 +24,14 @@ const requiredColumns = [
   "notes",
 ];
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
@@ -72,26 +77,36 @@ function parseCsv(source) {
   for (const column of requiredColumns) {
     if (!header.includes(column)) throw new Error(`golden OD CSV missing column: ${column}`);
   }
-  return lines.filter(Boolean).map((line) => {
+  return lines.map((line, index) => ({ line, lineNumber: index + 2 })).filter(({ line }) => line).map(({ line, lineNumber }) => {
     const values = splitCsvLine(line);
-    return Object.fromEntries(header.map((column, index) => [column, values[index] ?? ""]));
+    return {
+      ...Object.fromEntries(header.map((column, index) => [column, values[index] ?? ""])),
+      lineNumber,
+    };
   });
 }
 
-function splitCsvLine(line) {
+export function splitCsvLine(line) {
   const values = [];
   let value = "";
   let quoted = false;
-  for (let index = 0; index < line.length; index += 1) {
+  let index = 0;
+  while (index < line.length) {
     const char = line[index];
     if (char === "\"") {
-      quoted = !quoted;
+      if (quoted && line[index + 1] === "\"") {
+        value += "\"";
+        index += 1;
+      } else {
+        quoted = !quoted;
+      }
     } else if (char === "," && !quoted) {
       values.push(value);
       value = "";
     } else {
       value += char;
     }
+    index += 1;
   }
   values.push(value);
   return values;
@@ -99,12 +114,15 @@ function splitCsvLine(line) {
 
 function buildReport(rows) {
   const failures = [];
-  const errors = rows.map((row, index) => {
+  const errors = [];
+  for (const row of rows) {
     const observed = requiredNumber(row.observed_eta_error_seconds, row, "observed_eta_error_seconds", failures);
     const max = requiredNumber(row.max_eta_error_seconds, row, "max_eta_error_seconds", failures);
-    if (observed > max) failures.push(`${row.sourceFile}:${index + 2} observed ETA error exceeds max`);
-    return observed;
-  }).sort((left, right) => left - right);
+    if (observed === null || max === null) continue;
+    if (observed > max) failures.push(`${row.sourceFile}:${row.lineNumber} observed ETA error exceeds max`);
+    errors.push(observed);
+  }
+  errors.sort((left, right) => left - right);
   const coverage = {
     singleRide: rows.some((row) => row.category === "singleRide"),
     oneTransfer: rows.some((row) => row.category === "oneTransfer"),
@@ -126,7 +144,7 @@ function buildReport(rows) {
     sampleSize: rows.length,
     coverage,
     metrics: {
-      sampleSize: rows.length,
+      sampleSize: errors.length,
       p50ErrorSeconds: percentile(errors, 0.5),
       p90ErrorSeconds: percentile(errors, 0.9),
       maxErrorSeconds: errors.at(-1) ?? 0,
@@ -136,8 +154,11 @@ function buildReport(rows) {
 }
 
 function requiredNumber(value, row, column, failures) {
-  const number = Number.parseInt(value, 10);
-  if (!Number.isFinite(number)) failures.push(`${row.sourceFile} invalid number: ${column}`);
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    failures.push(`${row.sourceFile}:${row.lineNumber} invalid number: ${column}`);
+    return null;
+  }
   return number;
 }
 

--- a/tools/routes/evaluate-eta-accuracy.test.mjs
+++ b/tools/routes/evaluate-eta-accuracy.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(import.meta.dirname, "../..");
+
+test("ETA evaluator emits the route accuracy report contract", async () => {
+  const output = path.join(tmpdir(), `route-accuracy-report-${Date.now()}.json`);
+  await rm(output, { force: true });
+
+  await execFileAsync(process.execPath, [
+    "tools/routes/evaluate-eta-accuracy.mjs",
+    "--dataset",
+    "tools/routes/golden-od",
+    "--output",
+    output,
+  ], { cwd: root });
+
+  const report = JSON.parse(await readFile(output, "utf8"));
+  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.sampleSize, 100);
+  assert.equal(report.metrics.sampleSize, 100);
+  assert.equal(report.metrics.p50ErrorSeconds, 45);
+  assert.equal(report.metrics.p90ErrorSeconds, 90);
+  assert.deepEqual(report.failures, []);
+  assert.equal(report.coverage.singleRide, true);
+  assert.equal(report.coverage.oneTransfer, true);
+  assert.equal(report.coverage.twoTransfer, true);
+  assert.equal(report.coverage.express, true);
+  assert.equal(report.coverage.outOfStationTransfer, true);
+  assert.equal(report.coverage.strictStepFree, true);
+  assert.equal(report.coverage.realtimeSupported, true);
+  assert.equal(report.coverage.realtimeUnsupported, true);
+});

--- a/tools/routes/evaluate-eta-accuracy.test.mjs
+++ b/tools/routes/evaluate-eta-accuracy.test.mjs
@@ -1,17 +1,19 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { readFile, rm } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
+import { splitCsvLine } from "./evaluate-eta-accuracy.mjs";
 
 const execFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
 
-test("ETA evaluator emits the route accuracy report contract", async () => {
+test("ETA evaluator emits the route accuracy report contract", async (t) => {
   const output = path.join(tmpdir(), `route-accuracy-report-${Date.now()}.json`);
   await rm(output, { force: true });
+  t.after(() => rm(output, { force: true }));
 
   await execFileAsync(process.execPath, [
     "tools/routes/evaluate-eta-accuracy.mjs",
@@ -36,4 +38,59 @@ test("ETA evaluator emits the route accuracy report contract", async () => {
   assert.equal(report.coverage.strictStepFree, true);
   assert.equal(report.coverage.realtimeSupported, true);
   assert.equal(report.coverage.realtimeUnsupported, true);
+});
+
+test("CSV parser preserves escaped quotes inside quoted fields", () => {
+  assert.deepEqual(
+    splitCsvLine('station-a,station-b,"note ""with quote"", and comma"'),
+    ["station-a", "station-b", 'note "with quote", and comma'],
+  );
+});
+
+test("ETA evaluator reports file-local lines and excludes invalid numbers from metrics", async (t) => {
+  const dataset = path.join(tmpdir(), `route-accuracy-dataset-${Date.now()}`);
+  const output = path.join(tmpdir(), `route-accuracy-invalid-${Date.now()}.json`);
+  t.after(() => rm(dataset, { recursive: true, force: true }));
+  t.after(() => rm(output, { force: true }));
+  await mkdir(dataset, { recursive: true });
+
+  const header = [
+    "origin_station_id",
+    "destination_station_id",
+    "departure_time",
+    "mobility_type",
+    "constraint_mode",
+    "expected_transfer_count",
+    "max_eta_error_seconds",
+    "observed_eta_error_seconds",
+    "use_realtime",
+    "notes",
+  ].join(",");
+  const rowsByFile = {
+    "single_ride_cases.csv": "station-a,station-b,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,100,10,true,ok",
+    "one_transfer_cases.csv": "station-a,station-c,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,10,20,false,too slow",
+    "two_transfer_cases.csv": "station-a,station-d,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,100,bad,false,invalid",
+    "express_cases.csv": "station-a,station-b,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,100,30,false,express",
+    "out_of_station_transfer_cases.csv": "station-a,station-e,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,100,40,false,out",
+    "strict_step_free_cases.csv": "station-a,station-f,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,100,50,false,strict",
+  };
+  await Promise.all(Object.entries(rowsByFile).map(([file, row]) => (
+    writeFile(path.join(dataset, file), `${header}\n${row}\n`)
+  )));
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "tools/routes/evaluate-eta-accuracy.mjs",
+      "--dataset",
+      dataset,
+      "--output",
+      output,
+    ], { cwd: root }),
+  );
+
+  const report = JSON.parse(await readFile(output, "utf8"));
+  assert.equal(report.metrics.sampleSize, 5);
+  assert.equal(report.metrics.maxErrorSeconds, 50);
+  assert.ok(report.failures.includes("one_transfer_cases.csv:2 observed ETA error exceeds max"));
+  assert.ok(report.failures.includes("two_transfer_cases.csv:2 invalid number: observed_eta_error_seconds"));
 });

--- a/tools/routes/golden-od/express_cases.csv
+++ b/tools/routes/golden-od/express_cases.csv
@@ -1,0 +1,16 @@
+origin_station_id,destination_station_id,departure_time,mobility_type,constraint_mode,expected_transfer_count,max_eta_error_seconds,observed_eta_error_seconds,use_realtime,notes
+station-sangnoksu,station-sadang,2026-06-30T12:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,true,express fixture
+station-sadang,station-sangnoksu,2026-06-30T12:04:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,true,express fixture
+station-sangnoksu,station-sadang,2026-06-30T12:08:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,true,express fixture
+station-sadang,station-sangnoksu,2026-06-30T12:12:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,true,express fixture
+station-sangnoksu,station-sadang,2026-06-30T12:16:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,true,express fixture
+station-sadang,station-sangnoksu,2026-06-30T12:20:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,false,express fixture
+station-sangnoksu,station-sadang,2026-06-30T12:24:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,false,express fixture
+station-sadang,station-sangnoksu,2026-06-30T12:28:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,false,express fixture
+station-sangnoksu,station-sadang,2026-06-30T12:32:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,false,express fixture
+station-sadang,station-sangnoksu,2026-06-30T12:36:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,false,express fixture
+station-sangnoksu,station-sadang,2026-06-30T12:40:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,90,false,express fixture
+station-sadang,station-sangnoksu,2026-06-30T12:44:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,90,false,express fixture
+station-sangnoksu,station-sadang,2026-06-30T12:48:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,90,false,express fixture
+station-sadang,station-sangnoksu,2026-06-30T12:52:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,90,false,express fixture
+station-sangnoksu,station-sadang,2026-06-30T12:56:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,90,false,express fixture

--- a/tools/routes/golden-od/one_transfer_cases.csv
+++ b/tools/routes/golden-od/one_transfer_cases.csv
@@ -1,0 +1,21 @@
+origin_station_id,destination_station_id,departure_time,mobility_type,constraint_mode,expected_transfer_count,max_eta_error_seconds,observed_eta_error_seconds,use_realtime,notes
+station-sangnoksu,station-gangnam,2026-06-30T10:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,240,45,true,one transfer fixture
+station-gangnam,station-sangnoksu,2026-06-30T10:03:00+09:00,STROLLER,STRICT_STEP_FREE,1,240,45,true,one transfer fixture
+station-sangnoksu,station-gangnam,2026-06-30T10:06:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,240,45,true,one transfer fixture
+station-gangnam,station-sangnoksu,2026-06-30T10:09:00+09:00,STROLLER,STRICT_STEP_FREE,1,240,45,true,one transfer fixture
+station-sangnoksu,station-gangnam,2026-06-30T10:12:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,240,45,true,one transfer fixture
+station-gangnam,station-sangnoksu,2026-06-30T10:15:00+09:00,STROLLER,STRICT_STEP_FREE,1,240,45,true,one transfer fixture
+station-sangnoksu,station-gangnam,2026-06-30T10:18:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,240,45,true,one transfer fixture
+station-gangnam,station-sangnoksu,2026-06-30T10:21:00+09:00,STROLLER,STRICT_STEP_FREE,1,240,45,true,one transfer fixture
+station-sangnoksu,station-gangnam,2026-06-30T10:24:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,240,45,true,one transfer fixture
+station-gangnam,station-sangnoksu,2026-06-30T10:27:00+09:00,STROLLER,STRICT_STEP_FREE,1,240,45,true,one transfer fixture
+station-sangnoksu,station-gangnam,2026-06-30T10:30:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,240,45,false,one transfer fixture
+station-gangnam,station-sangnoksu,2026-06-30T10:33:00+09:00,STROLLER,STRICT_STEP_FREE,1,240,45,false,one transfer fixture
+station-sangnoksu,station-gangnam,2026-06-30T10:36:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,240,45,false,one transfer fixture
+station-gangnam,station-sangnoksu,2026-06-30T10:39:00+09:00,STROLLER,STRICT_STEP_FREE,1,240,45,false,one transfer fixture
+station-sangnoksu,station-gangnam,2026-06-30T10:42:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,240,45,false,one transfer fixture
+station-gangnam,station-sangnoksu,2026-06-30T10:45:00+09:00,STROLLER,STRICT_STEP_FREE,1,240,45,false,one transfer fixture
+station-sangnoksu,station-gangnam,2026-06-30T10:48:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,240,45,false,one transfer fixture
+station-gangnam,station-sangnoksu,2026-06-30T10:51:00+09:00,STROLLER,STRICT_STEP_FREE,1,240,45,false,one transfer fixture
+station-sangnoksu,station-gangnam,2026-06-30T10:54:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,240,45,false,one transfer fixture
+station-gangnam,station-sangnoksu,2026-06-30T10:57:00+09:00,STROLLER,STRICT_STEP_FREE,1,240,45,false,one transfer fixture

--- a/tools/routes/golden-od/out_of_station_transfer_cases.csv
+++ b/tools/routes/golden-od/out_of_station_transfer_cases.csv
@@ -1,0 +1,16 @@
+origin_station_id,destination_station_id,departure_time,mobility_type,constraint_mode,expected_transfer_count,max_eta_error_seconds,observed_eta_error_seconds,use_realtime,notes
+station-sangnoksu,station-seongsu,2026-06-30T13:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,300,90,true,out of station transfer fixture
+station-seongsu,station-sangnoksu,2026-06-30T13:04:00+09:00,STROLLER,STRICT_STEP_FREE,1,300,90,true,out of station transfer fixture
+station-sangnoksu,station-seongsu,2026-06-30T13:08:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,300,90,true,out of station transfer fixture
+station-seongsu,station-sangnoksu,2026-06-30T13:12:00+09:00,STROLLER,STRICT_STEP_FREE,1,300,90,true,out of station transfer fixture
+station-sangnoksu,station-seongsu,2026-06-30T13:16:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,300,90,true,out of station transfer fixture
+station-seongsu,station-sangnoksu,2026-06-30T13:20:00+09:00,STROLLER,STRICT_STEP_FREE,1,300,90,false,out of station transfer fixture
+station-sangnoksu,station-seongsu,2026-06-30T13:24:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,300,90,false,out of station transfer fixture
+station-seongsu,station-sangnoksu,2026-06-30T13:28:00+09:00,STROLLER,STRICT_STEP_FREE,1,300,90,false,out of station transfer fixture
+station-sangnoksu,station-seongsu,2026-06-30T13:32:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,300,90,false,out of station transfer fixture
+station-seongsu,station-sangnoksu,2026-06-30T13:36:00+09:00,STROLLER,STRICT_STEP_FREE,1,300,90,false,out of station transfer fixture
+station-sangnoksu,station-seongsu,2026-06-30T13:40:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,300,90,false,out of station transfer fixture
+station-seongsu,station-sangnoksu,2026-06-30T13:44:00+09:00,STROLLER,STRICT_STEP_FREE,1,300,90,false,out of station transfer fixture
+station-sangnoksu,station-seongsu,2026-06-30T13:48:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,300,90,false,out of station transfer fixture
+station-seongsu,station-sangnoksu,2026-06-30T13:52:00+09:00,STROLLER,STRICT_STEP_FREE,1,300,90,false,out of station transfer fixture
+station-sangnoksu,station-seongsu,2026-06-30T13:56:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,1,300,90,false,out of station transfer fixture

--- a/tools/routes/golden-od/single_ride_cases.csv
+++ b/tools/routes/golden-od/single_ride_cases.csv
@@ -1,0 +1,21 @@
+origin_station_id,destination_station_id,departure_time,mobility_type,constraint_mode,expected_transfer_count,max_eta_error_seconds,observed_eta_error_seconds,use_realtime,notes
+station-sangnoksu,station-sadang,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,true,single ride fixture
+station-sadang,station-sangnoksu,2026-06-30T09:03:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,true,single ride fixture
+station-sangnoksu,station-sadang,2026-06-30T09:06:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,true,single ride fixture
+station-sadang,station-sangnoksu,2026-06-30T09:09:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,true,single ride fixture
+station-sangnoksu,station-sadang,2026-06-30T09:12:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,true,single ride fixture
+station-sadang,station-sangnoksu,2026-06-30T09:15:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,true,single ride fixture
+station-sangnoksu,station-sadang,2026-06-30T09:18:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,true,single ride fixture
+station-sadang,station-sangnoksu,2026-06-30T09:21:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,true,single ride fixture
+station-sangnoksu,station-sadang,2026-06-30T09:24:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,true,single ride fixture
+station-sadang,station-sangnoksu,2026-06-30T09:27:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,true,single ride fixture
+station-sangnoksu,station-sadang,2026-06-30T09:30:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,false,single ride fixture
+station-sadang,station-sangnoksu,2026-06-30T09:33:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,false,single ride fixture
+station-sangnoksu,station-sadang,2026-06-30T09:36:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,false,single ride fixture
+station-sadang,station-sangnoksu,2026-06-30T09:39:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,false,single ride fixture
+station-sangnoksu,station-sadang,2026-06-30T09:42:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,false,single ride fixture
+station-sadang,station-sangnoksu,2026-06-30T09:45:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,false,single ride fixture
+station-sangnoksu,station-sadang,2026-06-30T09:48:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,false,single ride fixture
+station-sadang,station-sangnoksu,2026-06-30T09:51:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,false,single ride fixture
+station-sangnoksu,station-sadang,2026-06-30T09:54:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,0,180,45,false,single ride fixture
+station-sadang,station-sangnoksu,2026-06-30T09:57:00+09:00,STROLLER,STRICT_STEP_FREE,0,180,45,false,single ride fixture

--- a/tools/routes/golden-od/strict_step_free_cases.csv
+++ b/tools/routes/golden-od/strict_step_free_cases.csv
@@ -1,0 +1,16 @@
+origin_station_id,destination_station_id,departure_time,mobility_type,constraint_mode,expected_transfer_count,max_eta_error_seconds,observed_eta_error_seconds,use_realtime,notes
+station-sangnoksu,station-sinseoldong,2026-06-30T14:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,90,true,strict step free fixture
+station-sinseoldong,station-sangnoksu,2026-06-30T14:04:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,90,true,strict step free fixture
+station-sangnoksu,station-sinseoldong,2026-06-30T14:08:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,90,true,strict step free fixture
+station-sinseoldong,station-sangnoksu,2026-06-30T14:12:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,90,true,strict step free fixture
+station-sangnoksu,station-sinseoldong,2026-06-30T14:16:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,90,true,strict step free fixture
+station-sinseoldong,station-sangnoksu,2026-06-30T14:20:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,120,false,strict step free fixture
+station-sangnoksu,station-sinseoldong,2026-06-30T14:24:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,120,false,strict step free fixture
+station-sinseoldong,station-sangnoksu,2026-06-30T14:28:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,120,false,strict step free fixture
+station-sangnoksu,station-sinseoldong,2026-06-30T14:32:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,120,false,strict step free fixture
+station-sinseoldong,station-sangnoksu,2026-06-30T14:36:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,120,false,strict step free fixture
+station-sangnoksu,station-sinseoldong,2026-06-30T14:40:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,120,false,strict step free fixture
+station-sinseoldong,station-sangnoksu,2026-06-30T14:44:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,120,false,strict step free fixture
+station-sangnoksu,station-sinseoldong,2026-06-30T14:48:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,120,false,strict step free fixture
+station-sinseoldong,station-sangnoksu,2026-06-30T14:52:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,120,false,strict step free fixture
+station-sangnoksu,station-sinseoldong,2026-06-30T14:56:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,120,false,strict step free fixture

--- a/tools/routes/golden-od/two_transfer_cases.csv
+++ b/tools/routes/golden-od/two_transfer_cases.csv
@@ -1,0 +1,16 @@
+origin_station_id,destination_station_id,departure_time,mobility_type,constraint_mode,expected_transfer_count,max_eta_error_seconds,observed_eta_error_seconds,use_realtime,notes
+station-sangnoksu,station-jeongja,2026-06-30T11:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,90,true,two transfer fixture
+station-jeongja,station-sangnoksu,2026-06-30T11:04:00+09:00,STROLLER,STRICT_STEP_FREE,2,300,90,true,two transfer fixture
+station-sangnoksu,station-jeongja,2026-06-30T11:08:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,90,true,two transfer fixture
+station-jeongja,station-sangnoksu,2026-06-30T11:12:00+09:00,STROLLER,STRICT_STEP_FREE,2,300,90,true,two transfer fixture
+station-sangnoksu,station-jeongja,2026-06-30T11:16:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,90,true,two transfer fixture
+station-jeongja,station-sangnoksu,2026-06-30T11:20:00+09:00,STROLLER,STRICT_STEP_FREE,2,300,90,false,two transfer fixture
+station-sangnoksu,station-jeongja,2026-06-30T11:24:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,90,false,two transfer fixture
+station-jeongja,station-sangnoksu,2026-06-30T11:28:00+09:00,STROLLER,STRICT_STEP_FREE,2,300,90,false,two transfer fixture
+station-sangnoksu,station-jeongja,2026-06-30T11:32:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,90,false,two transfer fixture
+station-jeongja,station-sangnoksu,2026-06-30T11:36:00+09:00,STROLLER,STRICT_STEP_FREE,2,300,90,false,two transfer fixture
+station-sangnoksu,station-jeongja,2026-06-30T11:40:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,90,false,two transfer fixture
+station-jeongja,station-sangnoksu,2026-06-30T11:44:00+09:00,STROLLER,STRICT_STEP_FREE,2,300,90,false,two transfer fixture
+station-sangnoksu,station-jeongja,2026-06-30T11:48:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,90,false,two transfer fixture
+station-jeongja,station-sangnoksu,2026-06-30T11:52:00+09:00,STROLLER,STRICT_STEP_FREE,2,300,90,false,two transfer fixture
+station-sangnoksu,station-jeongja,2026-06-30T11:56:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,2,300,90,false,two transfer fixture


### PR DESCRIPTION
## 관련 이슈

close #1211

## 작업 배경

- route 상용화 품질을 주장하기 전에 Golden OD dataset과 ETA accuracy evaluator의 report format을 먼저 고정합니다.
- A-1 release gate가 다음 순서에서 이 report artifact를 읽어 threshold를 적용할 수 있게 합니다.

## 작업 내용

- `tools/routes/golden-od/*.csv`에 100개 Golden OD fixture를 추가했습니다.
- `tools/routes/evaluate-eta-accuracy.mjs`를 추가해 `sampleSize`, `P50`, `P90`, `failures`, coverage를 JSON report로 출력합니다.
- `tools/routes/evaluate-eta-accuracy.test.mjs`와 `tools/ci/repository-contract.test.mjs`에 report contract 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/routes/evaluate-eta-accuracy.test.mjs` 통과
  - `node tools/routes/evaluate-eta-accuracy.mjs --dataset tools/routes/golden-od --output /tmp/route-accuracy-report.json` 통과
  - `node --test tools/ci/repository-contract.test.mjs` 통과
  - `node --test tools/ci/*.test.mjs` 통과, 158 tests pass
- GitHub Actions:
  - CI #2461 success
  - SonarCloud #824 success
  - Release Artifacts #1735 success

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| ETA evaluator report | local Node.js | evaluator CLI와 node:test | `/tmp/route-accuracy-report.json` 요약: sampleSize 100, P50 45, P90 90, failures [] | 통과 |
| Repository contract | local Node.js | `node --test tools/ci/*.test.mjs` | command output | 통과 |
| GitHub Actions | GitHub | CI, SonarCloud, Release Artifacts | CI #2461, SonarCloud #824, Release Artifacts #1735 | 통과 |
| UI/접근성 수동 증거 | 해당 없음 | CLI/report format 변경만 포함 | 증거 불필요 사유: 화면/수동 QA 변경 없음 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: ETA accuracy report artifact schema v1 추가
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/routes/evaluate-eta-accuracy.mjs`, `tools/routes/evaluate-eta-accuracy.test.mjs`
- 의도적으로 production ETA runner 연결은 하지 않았습니다. A-1에서 gate가 이 report를 읽고, E/F 이후 실제 planned/realtime ETA 산출과 연결해야 합니다.

## 리스크

- Golden OD는 fixture 품질 계약이며 production ETA 품질 증거가 아닙니다.
- CSV는 CodeRabbit path filter에서 제외되므로 local contract test가 dataset coverage를 대신 검증합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다. (해당 없음: CodeRabbit 정상 완료)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (해당 없음: deploy/store submit 없음; Release Artifacts #1735 success)