### PR TITLE
[Fix] 역 상세 카드 radius 상수 정리

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -55,8 +55,10 @@ const _stationCompactCardRadius = BorderRadius.all(Radius.circular(8));
 const _stationLineRegionChipRadius = BorderRadius.all(Radius.circular(8));
 const _stationLineFilterButtonRadius = BorderRadius.all(Radius.circular(14));
 const _stationDetailInfoCardRadius = BorderRadius.all(Radius.circular(8));
+const _stationDetailHelpCardRadius = BorderRadius.all(Radius.circular(12));
 const _stationDetailActionButtonRadius = BorderRadius.all(Radius.circular(14));
 const _stationDetailFacilityCardRadius = BorderRadius.all(Radius.circular(16));
+const _stationDetailHeroCardRadius = BorderRadius.all(Radius.circular(18));
 
 abstract class StationSearchRepository {
   Future<List<StationSearchResult>> searchStations(String query);
@@ -4715,8 +4717,8 @@ class _StationFacilityStatusSummary extends StatelessWidget {
           margin: EdgeInsets.zero,
           color: EasySubwayAccessibleColors.redSoft,
           elevation: 0,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
+          shape: const RoundedRectangleBorder(
+            borderRadius: _stationDetailFacilityCardRadius,
           ),
           child: Padding(
             padding: const EdgeInsets.all(14),
@@ -4764,8 +4766,8 @@ class _StationDetailHeader extends StatelessWidget {
           margin: EdgeInsets.zero,
           color: EasySubwayAccessibleColors.brandDark,
           elevation: 0,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(18),
+          shape: const RoundedRectangleBorder(
+            borderRadius: _stationDetailHeroCardRadius,
           ),
           child: Padding(
             padding: const EdgeInsets.all(16),
@@ -5126,9 +5128,9 @@ class _InfoBasisDisclosureState extends State<_InfoBasisDisclosure> {
             margin: EdgeInsets.zero,
             elevation: 0,
             color: Colors.white,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(12),
-              side: const BorderSide(color: EasySubwayAccessibleColors.line),
+            shape: const RoundedRectangleBorder(
+              borderRadius: _stationDetailHelpCardRadius,
+              side: BorderSide(color: EasySubwayAccessibleColors.line),
             ),
             child: Padding(
               padding: const EdgeInsets.all(14),
@@ -5427,8 +5429,8 @@ class FacilityDetailScreen extends StatelessWidget {
               margin: EdgeInsets.zero,
               color: EasySubwayAccessibleColors.brandDark,
               elevation: 0,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(18),
+              shape: const RoundedRectangleBorder(
+                borderRadius: _stationDetailHeroCardRadius,
               ),
               child: Padding(
                 padding: const EdgeInsets.all(16),
@@ -5479,8 +5481,8 @@ class FacilityDetailScreen extends StatelessWidget {
               margin: EdgeInsets.zero,
               color: statusBackgroundColor,
               elevation: 0,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(16),
+              shape: const RoundedRectangleBorder(
+                borderRadius: _stationDetailFacilityCardRadius,
               ),
               child: Padding(
                 padding: const EdgeInsets.all(16),
@@ -5538,9 +5540,9 @@ class FacilityDetailScreen extends StatelessWidget {
               margin: EdgeInsets.zero,
               color: Colors.white,
               elevation: 0,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(16),
-                side: const BorderSide(color: EasySubwayAccessibleColors.line),
+              shape: const RoundedRectangleBorder(
+                borderRadius: _stationDetailFacilityCardRadius,
+                side: BorderSide(color: EasySubwayAccessibleColors.line),
               ),
               child: Padding(
                 padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## 요약
- 역/시설 상세 화면 카드 radius 직접 표현을 이름 있는 상수로 정리했습니다.
- 안내 확인 카드, 시설 상태 요약, 상세 header/status/location 카드의 반복 radius 값을 줄였습니다.

## 검증
- cd apps/mobile && flutter test test/widget_test.dart --name "시설 상세는 실제 시설 데이터로 시설 알려주기 진입을 보여준다" --reporter expanded
- cd apps/mobile && flutter test test/widget_test.dart --name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다" --reporter expanded
- cd apps/mobile && flutter analyze lib/station_search.dart
- git diff --check

Refs #1075