### PR TITLE
[Fix] 개인정보 도움말 색상 토큰 정리

### DIFF
--- a/apps/mobile/lib/accessible_design.dart
+++ b/apps/mobile/lib/accessible_design.dart
@@ -17,6 +17,7 @@ class EasySubwayAccessibleColors {
   static const skySoft = Color(0xFFE6F5FF);
   static const line = Color(0xFFDBE3E9);
   static const text = Color(0xFF102A2C);
+  static const secondaryText = Color(0xFF29484B);
   static const mutedText = Color(0xFF466467);
   static const surface = Colors.white;
 }

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -5341,8 +5341,8 @@ class _PrivacyDataUseSummary extends StatelessWidget {
       child: ExcludeSemantics(
         child: Container(
           decoration: BoxDecoration(
-            color: const Color(0xFFEAF5F4),
-            border: Border.all(color: const Color(0xFFB7D7D3)),
+            color: EasySubwayAccessibleColors.mintSoft,
+            border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
             borderRadius: BorderRadius.circular(8),
           ),
           child: Padding(
@@ -5353,7 +5353,7 @@ class _PrivacyDataUseSummary extends StatelessWidget {
                 Text(
                   _title,
                   style: textTheme.titleMedium?.copyWith(
-                    color: const Color(0xFF102A2C),
+                    color: EasySubwayAccessibleColors.text,
                     fontWeight: FontWeight.w800,
                     height: 1.25,
                   ),
@@ -5387,14 +5387,18 @@ class _PrivacyDataUseLine extends StatelessWidget {
         children: [
           const Padding(
             padding: EdgeInsets.only(top: 7),
-            child: Icon(Icons.circle, size: 7, color: Color(0xFF006D77)),
+            child: Icon(
+              Icons.circle,
+              size: 7,
+              color: EasySubwayAccessibleColors.primary,
+            ),
           ),
           const SizedBox(width: 10),
           Expanded(
             child: Text(
               text,
               style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: const Color(0xFF29484B),
+                color: EasySubwayAccessibleColors.secondaryText,
                 height: 1.35,
               ),
             ),
@@ -5467,7 +5471,7 @@ class _SupportAccessItem extends StatelessWidget {
                   Text(
                     displayValue,
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: const Color(0xFF29484B),
+                      color: EasySubwayAccessibleColors.secondaryText,
                       height: 1.25,
                     ),
                   ),
@@ -5476,7 +5480,7 @@ class _SupportAccessItem extends StatelessWidget {
                     Text(
                       secondaryText,
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: const Color(0xFF466467),
+                        color: EasySubwayAccessibleColors.mutedText,
                         fontWeight: FontWeight.w700,
                         height: 1.25,
                       ),
@@ -5563,7 +5567,7 @@ class FeatureTile extends StatelessWidget {
             elevation: 0,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(8),
-              side: const BorderSide(color: Color(0xFFD5E2E4)),
+              side: const BorderSide(color: EasySubwayAccessibleColors.line),
             ),
             child: Padding(
               padding: const EdgeInsets.all(16),
@@ -5576,7 +5580,7 @@ class FeatureTile extends StatelessWidget {
                     child: Text(
                       title,
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: const Color(0xFF102A2C),
+                        color: EasySubwayAccessibleColors.text,
                         fontWeight: FontWeight.w800,
                         height: 1.35,
                       ),


### PR DESCRIPTION
Closes/Refs: #1075

## Summary
- 개인정보 사용 안내/지원 접근/기능 타일 색상을 `EasySubwayAccessibleColors` 토큰으로 정리했습니다.
- 본문용 보조 텍스트 색상 토큰을 추가해 반복되는 직접 색상값을 줄였습니다.

## Verification
- `flutter analyze lib/accessible_design.dart lib/main.dart`
- `flutter test test/widget_test.dart --name "도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다" --reporter expanded`
- `git diff --check`

## Evidence
- 증거 불필요 사유: 문구, 레이아웃, semantics 동작 변경 없이 색상 토큰 참조만 정리했습니다.
