### PR TITLE
[Fix] 경로 검색 스타일 토큰 잔여 정리

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -42,6 +42,14 @@ const _routeTextSubtleColor = Color(0xFF50656F);
 const _routeNextActionTextColor = Color(0xFF506B6F);
 const _routeAccentColor = Color(0xFF006D77);
 const _routeCardBorderColor = Color(0xFFD5E2E4);
+const _routeDividerColor = Color(0xFFE0E7EC);
+const _routeControlBorderColor = Color(0xFF9DB6BA);
+const _routeSoftPanelColor = Color(0xFFE9F5F6);
+const _routeSoftPanelBorderColor = Color(0xFFB9D4D8);
+const _routeGuidanceDarkColor = Color(0xFF073245);
+const _routeBlockedBorderColor = Color(0xFFEFCCCC);
+const _routeCardShadowColor = Color(0x0F071B2F);
+const _routeAccentShadowColor = Color(0x1A0D8A6D);
 const _routeMobilitySheetHeaderPadding = EdgeInsets.fromLTRB(20, 8, 20, 0);
 const _routeMobilitySheetListPadding = EdgeInsets.fromLTRB(20, 0, 20, 8);
 const _routeMobilitySheetActionPadding = EdgeInsets.fromLTRB(20, 8, 20, 20);
@@ -1723,7 +1731,7 @@ class _RoutePointPickerCard extends StatelessWidget {
         borderRadius: _routeSearchLargeRadius,
         boxShadow: const [
           BoxShadow(
-            color: Color(0x0F071B2F),
+            color: _routeCardShadowColor,
             blurRadius: 16,
             offset: Offset(0, 5),
           ),
@@ -1744,7 +1752,7 @@ class _RoutePointPickerCard extends StatelessWidget {
                       fallback: '출발역 선택',
                       onTap: onOriginTap,
                     ),
-                const Divider(height: 1, color: Color(0xFFE0E7EC)),
+                const Divider(height: 1, color: _routeDividerColor),
                 destinationPicker ??
                     _RoutePointRow(
                       key: const Key('routeDestinationPointButton'),
@@ -1770,7 +1778,7 @@ class _RoutePointPickerCard extends StatelessWidget {
                   color: _routeTextPrimaryColor,
                   style: IconButton.styleFrom(
                     fixedSize: const Size(48, 48),
-                    side: const BorderSide(color: Color(0xFF9DB6BA)),
+                    side: const BorderSide(color: _routeControlBorderColor),
                   ),
                 ),
               ),
@@ -1826,7 +1834,7 @@ class _RoutePointRow extends StatelessWidget {
                     ),
                   ),
                 ),
-                const Icon(Icons.map_outlined, color: Color(0xFF50656F)),
+                const Icon(Icons.map_outlined, color: _routeTextSubtleColor),
               ],
             ),
           ),
@@ -1944,7 +1952,7 @@ class _RouteRecentDestinationListState
                 children: [
                   for (final entry in destinations.indexed) ...[
                     if (entry.$1 > 0)
-                      const Divider(height: 1, color: Color(0xFFE0E7EC)),
+                      const Divider(height: 1, color: _routeDividerColor),
                     _RouteRecentDestinationRow(
                       route: entry.$2,
                       onSelected: () => widget.onSelected(
@@ -2149,8 +2157,8 @@ class _RouteMobilityTypeSummary extends StatelessWidget {
       liveRegion: true,
       child: DecoratedBox(
         decoration: BoxDecoration(
-          color: const Color(0xFFE9F5F6),
-          border: Border.all(color: const Color(0xFFB9D4D8)),
+          color: _routeSoftPanelColor,
+          border: Border.all(color: _routeSoftPanelBorderColor),
           borderRadius: _routeSearchSmallRadius,
         ),
         child: Padding(
@@ -2954,7 +2962,7 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
         const SizedBox(height: 8),
         DecoratedBox(
           decoration: BoxDecoration(
-            color: const Color(0xFF073245),
+            color: _routeGuidanceDarkColor,
             borderRadius: _routeSearchLargeRadius,
           ),
           child: Padding(
@@ -3046,14 +3054,14 @@ class _RouteGuidanceWorkflowView extends StatelessWidget {
                     color: Colors.white,
                     border: Border.all(
                       color: result.isBlocked
-                          ? const Color(0xFFEFCCCC)
+                          ? _routeBlockedBorderColor
                           : EasySubwayAccessibleColors.mint,
                       width: 2,
                     ),
                     borderRadius: _routeSearchLargeRadius,
                     boxShadow: const [
                       BoxShadow(
-                        color: Color(0x1A0D8A6D),
+                        color: _routeAccentShadowColor,
                         blurRadius: 18,
                         offset: Offset(0, 6),
                       ),
@@ -3445,7 +3453,7 @@ class _RouteDarkSummaryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: const Color(0xFF073245),
+        color: _routeGuidanceDarkColor,
         borderRadius: _routeSearchSmallRadius,
       ),
       child: Padding(


### PR DESCRIPTION
## 요약
- #1075 남은 route search UI 직접 색상 표현 일부를 파일 local style token으로 정리했습니다.
- 경로 선택 카드, 최근 도착지 divider, 이동 조건 요약, 단계별 안내 카드의 반복 색상값을 이름 있는 상수로 치환했습니다.

## 검증
- `dart format lib/route_search.dart`: exit 0
- `flutter analyze lib/route_search.dart`: exit 0
- `flutter test test/widget_test.dart --name "경로 검색 실패는 도움말을 쉬운 문구로 안내한다" --reporter expanded`: exit 0
- `git diff --check`: exit 0

## 참고
- 첫 test 시도는 analyzer와 병렬 실행 중 Flutter iOS ephemeral symlink 충돌로 tool crash가 났고, 같은 명령을 단독 재실행해 통과했습니다.

Closes none. Parent: #1075