### PR TITLE
[Fix] cAdvisor 이미지 태그 CD 실패 수정

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       - observability
 
   docker-runtime-probe:
-    image: ghcr.io/google/cadvisor:v0.55.1
+    image: ghcr.io/google/cadvisor:v0.60.3
     container_name: easysubway-docker-runtime-probe
     profiles:
       - observability

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5397,6 +5397,7 @@ test("Docker Compose는 backend 필수 서비스를 기본값으로 노출하고
   assert.match(compose, /prometheus:[\s\S]*profiles:\s*\n\s*-\s*observability/);
   assert.match(compose, /"\$\{EASYSUBWAY_PROMETHEUS_BIND:-127\.0\.0\.1\}:\$\{EASYSUBWAY_PROMETHEUS_PORT:-9090\}:9090"/);
   assert.match(compose, /public-edge-probe:[\s\S]*profiles:\s*\n\s*-\s*observability/);
+  assert.match(compose, /docker-runtime-probe:[\s\S]*image: ghcr\.io\/google\/cadvisor:v0\.60\.3/);
   assert.match(compose, /docker-runtime-probe:[\s\S]*profiles:\s*\n\s*-\s*observability/);
   assert.match(compose, /loki:[\s\S]*profiles:\s*\n\s*-\s*observability/);
   assert.match(compose, /grafana:[\s\S]*profiles:\s*\n\s*-\s*observability/);


### PR DESCRIPTION
## 관련 이슈

close #1297

## 작업 배경

PR #1294 merge 후 CD run `28463948883`이 observability stack 기동 중 실패했다. 원인은 `docker-runtime-probe` 이미지 `ghcr.io/google/cadvisor:v0.55.1`가 registry에 없어 pull이 실패한 것이다. GitHub cAdvisor latest release와 manifest 확인 기준으로 존재하는 official tag `v0.60.3`을 사용하도록 고친다.

## 작업 내용

- `docker-runtime-probe` image를 `ghcr.io/google/cadvisor:v0.60.3`으로 교체했다.
- repository contract test가 cAdvisor image tag를 명시적으로 검증하도록 추가했다.

## 검증

- 실행한 명령과 결과:
  - `gh api repos/google/cadvisor/releases/latest --jq '{tag_name,html_url,name}'`: `v0.60.3`, `https://github.com/google/cadvisor/releases/tag/v0.60.3`
  - `docker manifest inspect ghcr.io/google/cadvisor:v0.60.3`: exit 0, amd64/arm64 manifest 확인
  - `node --test --test-name-pattern "Docker Compose|관측성" tools/ci/repository-contract.test.mjs`: exit 0, 5 tests passed
  - `docker compose --env-file .env.example -f infra/docker-compose.yml --profile observability config --quiet`: exit 0
  - `git diff --check`: exit 0
  - `node --test tools/ci/repository-contract.test.mjs`: exit 0, 149 tests passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| CD 실패 원인 | GitHub Actions | CD run `28463948883` 로그 확인 | `docker-runtime-probe Error failed to resolve reference "ghcr.io/google/cadvisor:v0.55.1": not found` | 원인 확인 |
| cAdvisor official release | GitHub API | `gh api repos/google/cadvisor/releases/latest --jq '{tag_name,html_url,name}'` | `v0.60.3`, release URL | 확인 |
| cAdvisor manifest | Docker registry | `docker manifest inspect ghcr.io/google/cadvisor:v0.60.3` | amd64/arm64 manifest 출력 | 통과 |
| 관측성/Compose 계약 | local Node.js | `node --test --test-name-pattern "Docker Compose|관측성" tools/ci/repository-contract.test.mjs` | command output, 5 tests passed | 통과 |
| repository contract | local Node.js | `node --test tools/ci/repository-contract.test.mjs` | command output, 149 tests passed | 통과 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `infra/docker-compose.yml`의 cAdvisor tag와 `tools/ci/repository-contract.test.mjs`의 tag 고정 assertion이다.

## 리스크

- cAdvisor minor version이 올라간다. official release manifest가 amd64/arm64를 제공하는 것을 확인했고, 기존 Compose 실행 방식은 유지했다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
