### PR TITLE
[Fix] Loki 볼륨 권한 초기화 CD 실패 수정

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -142,11 +142,21 @@ services:
       retries: 5
       start_period: 20s
 
+  loki-volume-init:
+    image: busybox:1.37.0
+    container_name: easysubway-loki-volume-init
+    profiles:
+      - observability
+    command: ["sh", "-c", "mkdir -p /loki/chunks /loki/rules /loki/rules-temp /loki/retention && chown -R 10001:10001 /loki"]
+    volumes:
+      - loki-data:/loki
+
   loki:
     image: grafana/loki:3.6.0
     container_name: easysubway-loki
     profiles:
       - observability
+    user: "10001:10001"
     command:
       - "--config.file=/etc/loki/loki.yml"
     ports:
@@ -154,6 +164,9 @@ services:
     volumes:
       - ./loki/loki.yml:/etc/loki/loki.yml:ro
       - loki-data:/loki
+    depends_on:
+      loki-volume-init:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "loki", "-config.file=/etc/loki/loki.yml", "-verify-config"]
       interval: 10s

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5635,12 +5635,18 @@ test("로컬 로그 관측성 스택은 Loki 기준선을 제공한다", () => {
   const prometheusDatasource = read("infra/grafana/provisioning/datasources/prometheus.yml");
 
   assert.match(compose, /loki:\n/);
+  assert.match(compose, /loki-volume-init:\n/);
+  assert.match(compose, /loki-volume-init:[\s\S]*image: busybox:1\.37\.0/);
+  assert.match(compose, /loki-volume-init:[\s\S]*command: \["sh", "-c", "mkdir -p \/loki\/chunks \/loki\/rules \/loki\/rules-temp \/loki\/retention && chown -R 10001:10001 \/loki"\]/);
+  assert.match(compose, /loki-volume-init:[\s\S]*loki-data:\/loki/);
   assert.match(compose, /loki:[\s\S]*profiles:\s*\n\s*-\s*observability/);
   assert.match(compose, /image: grafana\/loki:3\.6\.0/);
+  assert.match(compose, /loki:[\s\S]*user: "10001:10001"/);
   assert.match(compose, /--config\.file=\/etc\/loki\/loki\.yml/);
   assert.match(compose, /\.\/loki\/loki\.yml:\/etc\/loki\/loki\.yml:ro/);
   assert.match(compose, /"127\.0\.0\.1:\$\{EASYSUBWAY_LOKI_PORT:-3100\}:3100"/);
   assert.match(compose, /loki-data:\/loki/);
+  assert.match(compose, /loki:[\s\S]*depends_on:\s*\n\s*loki-volume-init:\s*\n\s*condition: service_completed_successfully/);
   assert.match(compose, /test: \["CMD", "loki", "-config\.file=\/etc\/loki\/loki\.yml", "-verify-config"\]/);
 
   assert.match(lokiConfig, /auth_enabled: false/);


### PR DESCRIPTION
## 관련 이슈

close #1301

## 작업 배경

OCI CD에서 observability profile 시작 중 Loki 3.6.0이 `mkdir /loki/chunks: permission denied`로 종료했다. Grafana가 Loki health에 의존하면서 observability 시작이 실패했고, 배포 run도 실패 처리됐다.

## 작업 내용

- `loki-volume-init` service를 추가해 `loki-data` named volume의 필수 디렉터리를 만들고 UID 10001 소유권으로 보정한다.
- Loki 본 컨테이너는 `10001:10001`로 실행하고, init service 완료 후 시작되도록 `service_completed_successfully` 의존성을 둔다.
- repository contract test가 Loki 볼륨 초기화와 비-root 실행 조건을 고정한다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "로컬 로그 관측성 스택은 Loki 기준선을 제공한다" tools/ci/repository-contract.test.mjs`: pass 1, fail 0
  - `docker compose --env-file .env.example -f infra/docker-compose.yml --profile observability config --quiet`: exit 0
  - `node --test tools/ci/repository-contract.test.mjs`: pass 149, fail 0
  - `node --test tools/ci/backend-deploy.test.mjs`: pass 4, fail 0
  - `git diff --check`: exit 0
  - `docker manifest inspect busybox:1.37.0`: exit 0, linux/amd64와 linux/arm64 manifest 확인

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Loki 권한 회귀 테스트 | local | repository contract 단일 테스트 | 로컬 명령 출력: pass 1, fail 0 | 통과 |
| Compose observability 설정 | local | docker compose config | 로컬 명령 출력: exit 0 | 통과 |
| 저장소 계약 테스트 | local | node test runner | 로컬 명령 출력: pass 149, fail 0 | 통과 |
| CD 배포 계약 테스트 | local | node test runner | 로컬 명령 출력: pass 4, fail 0 | 통과 |
| init 이미지 pull 가능성 | Docker Hub | docker manifest inspect | busybox:1.37.0 linux/amd64, linux/arm64 manifest | 통과 |
| CD/OCI 확인 | GitHub Actions, OCI | merge 후 CD run과 서버 컨테이너 상태 확인 | merge 후 업데이트 예정 | 대기 |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: Loki를 root로 실행하지 않고, init service만 root 기본 권한으로 볼륨 소유권을 보정하는 구조다.

## 리스크

- Docker Compose의 `service_completed_successfully` 조건을 사용하므로 self-hosted runner의 compose plugin이 해당 조건을 지원해야 한다. 현재 `docker compose config --quiet`로 문법 검증은 통과했다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.