### PR TITLE
[Fix] 역 검색 노선 필터 색상 토큰 정리

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -69,6 +69,10 @@ const _stationDetailMintPanelColor = Color(0xFFEFF8F6);
 const _stationDetailMintPanelBorderColor = Color(0xFFB7D8D2);
 const _stationDetailNoticeColor = Color(0xFFE6F2F0);
 const _stationDetailNoticeBorderColor = Color(0xFFB8D8D3);
+const _stationLineFilterSelectedColor = Color(0xFF007A80);
+const _stationLineFilterBorderColor = Color(0xFF93C7C2);
+const _stationDetailHeroSecondaryColor = Color(0xFFAFC6D4);
+const _stationDetailCautionColor = Color(0xFF8A4B00);
 
 abstract class StationSearchRepository {
   Future<List<StationSearchResult>> searchStations(String query);
@@ -2818,9 +2822,9 @@ class _StationLineRegionButton extends StatelessWidget {
             color: selected ? Colors.white : EasySubwayAccessibleColors.text,
             fontWeight: FontWeight.w800,
           ),
-          selectedColor: const Color(0xFF007A80),
+          selectedColor: _stationLineFilterSelectedColor,
           backgroundColor: Colors.white,
-          side: const BorderSide(color: Color(0xFF93C7C2)),
+          side: const BorderSide(color: _stationLineFilterBorderColor),
           shape: const RoundedRectangleBorder(
             borderRadius: _stationLineRegionChipRadius,
           ),
@@ -2867,13 +2871,15 @@ class _StationLineFilterButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final backgroundColor = selected ? const Color(0xFF007A80) : Colors.white;
+    final backgroundColor = selected
+        ? _stationLineFilterSelectedColor
+        : Colors.white;
     final foregroundColor = selected
         ? Colors.white
         : EasySubwayAccessibleColors.text;
     final borderColor = selected
-        ? const Color(0xFF007A80)
-        : const Color(0xFF93C7C2);
+        ? _stationLineFilterSelectedColor
+        : _stationLineFilterBorderColor;
 
     return Semantics(
       label: '$semanticLabel ${selected ? '선택됨' : '선택 안 됨'}',
@@ -5467,7 +5473,7 @@ class FacilityDetailScreen extends StatelessWidget {
                             '${station.nameKo}역',
                             style: Theme.of(context).textTheme.bodyMedium
                                 ?.copyWith(
-                                  color: const Color(0xFFAFC6D4),
+                                  color: _stationDetailHeroSecondaryColor,
                                   fontWeight: FontWeight.w600,
                                 ),
                           ),
@@ -5669,7 +5675,7 @@ class _StationDetailStatusPill extends StatelessWidget {
   Widget build(BuildContext context) {
     final color = positive
         ? EasySubwayAccessibleColors.primary
-        : const Color(0xFF8A4B00);
+        : _stationDetailCautionColor;
 
     return Row(
       children: [


### PR DESCRIPTION
## 요약
- #1075 후속으로 역 검색 노선 필터 선택/경계 색상을 파일 style token으로 정리했습니다.
- 시설 상세 hero 보조 텍스트와 주의 상태 색상 직접값도 같은 파일 상수로 치환했습니다.

## 검증
- `dart format lib/station_search.dart`
- `flutter analyze lib/station_search.dart`
- `flutter test test/widget_test.dart --name "역 검색은 노선을 선택해 결과를 좁힌다" --reporter expanded`
- `git diff --check`

Refs #1075