### PR TITLE
[Fix] 앱 테마 접근성 토큰 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -40,6 +40,8 @@ const _mainListPagePadding = EdgeInsets.fromLTRB(17, 18, 17, 32);
 const _homeHeroCardPadding = EdgeInsets.fromLTRB(20, 24, 20, 24);
 const _appSectionTitlePadding = EdgeInsets.fromLTRB(1, 22, 1, 11);
 const _settingsPagePadding = EdgeInsets.fromLTRB(20, 16, 20, 32);
+const _mainScaffoldBackgroundColor = Color(0xFFF6F8F9);
+const _mainThemeControlRadius = BorderRadius.all(Radius.circular(8));
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -355,13 +357,15 @@ class EasySubwayApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       scrollBehavior: const EasySubwayScrollBehavior(),
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF006D77)),
-        scaffoldBackgroundColor: const Color(0xFFF6F8F9),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: EasySubwayAccessibleColors.primary,
+        ),
+        scaffoldBackgroundColor: _mainScaffoldBackgroundColor,
         appBarTheme: const AppBarTheme(
           centerTitle: false,
           toolbarHeight: 64,
           titleTextStyle: TextStyle(
-            color: Color(0xFF102A2C),
+            color: EasySubwayAccessibleColors.text,
             fontSize: 22,
             fontWeight: FontWeight.w700,
           ),
@@ -369,8 +373,8 @@ class EasySubwayApp extends StatelessWidget {
         filledButtonTheme: FilledButtonThemeData(
           style: FilledButton.styleFrom(
             minimumSize: const Size.fromHeight(60),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
+            shape: const RoundedRectangleBorder(
+              borderRadius: _mainThemeControlRadius,
             ),
             textStyle: const TextStyle(
               fontSize: 18,
@@ -381,9 +385,12 @@ class EasySubwayApp extends StatelessWidget {
         outlinedButtonTheme: OutlinedButtonThemeData(
           style: OutlinedButton.styleFrom(
             minimumSize: const Size.fromHeight(60),
-            side: const BorderSide(color: Color(0xFF006D77), width: 2),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
+            side: const BorderSide(
+              color: EasySubwayAccessibleColors.primary,
+              width: 2,
+            ),
+            shape: const RoundedRectangleBorder(
+              borderRadius: _mainThemeControlRadius,
             ),
             textStyle: const TextStyle(
               fontSize: 18,


### PR DESCRIPTION
## 요약
- #1075 후속으로 앱 테마의 seed/text 색상을 접근성 색상 토큰으로 정리했습니다.
- scaffold background와 공통 버튼 radius 직접값을 파일 상수로 분리했습니다.

## 검증
- `dart format lib/main.dart`
- `flutter analyze lib/main.dart`
- `flutter test test/widget_test.dart --name "도움말은 이동 전 살펴보기 안내를 함께 보여준다" --reporter expanded`
- `git diff --check`

Refs #1075