### PR TITLE
[Fix] 홈 보조 색상 토큰 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -45,7 +45,7 @@ const _mainThemeControlRadius = BorderRadius.all(Radius.circular(8));
 const _highContrastTextColor = Color(0xFF000000);
 const _highContrastPrimaryColor = Color(0xFF003D40);
 const _highContrastSecondaryColor = Color(0xFF005E68);
-const _homeRouteDraftBorderColor = Color(0xFFB7DDF4);
+const _homeInfoBorderColor = Color(0xFFB7DDF4);
 const _homeFacilityCautionBorderColor = Color(0xFFF1D49A);
 const _homeFacilityInfoBorderColor = Color(0xFFC8E6F8);
 const _settingsSwitchActiveTrackColor = Color(0xFF0D8A6D);
@@ -2505,7 +2505,7 @@ class _HomeRouteDraftCard extends StatelessWidget {
             borderRadius: BorderRadius.circular(18),
             child: _AppCard(
               backgroundColor: EasySubwayAccessibleColors.skySoft,
-              borderColor: _homeRouteDraftBorderColor,
+              borderColor: _homeInfoBorderColor,
               borderRadius: 18,
               padding: const EdgeInsets.all(14),
               child: Row(
@@ -4988,7 +4988,7 @@ class UserDataDeletionResultScreen extends StatelessWidget {
             const SizedBox(height: 12),
             const _AppCard(
               backgroundColor: EasySubwayAccessibleColors.skySoft,
-              borderColor: _homeRouteDraftBorderColor,
+              borderColor: _homeInfoBorderColor,
               child: _AppInfoRow(
                 icon: Icons.map_outlined,
                 iconBackground: Colors.white,

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -48,6 +48,8 @@ const _highContrastSecondaryColor = Color(0xFF005E68);
 const _homeRouteDraftBorderColor = Color(0xFFB7DDF4);
 const _homeFacilityCautionBorderColor = Color(0xFFF1D49A);
 const _homeFacilityInfoBorderColor = Color(0xFFC8E6F8);
+const _settingsSwitchActiveTrackColor = Color(0xFF0D8A6D);
+const _settingsSwitchInactiveTrackColor = Color(0xFFC8D3DC);
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -3785,9 +3787,9 @@ class _AppSettingsPreferenceTile extends StatelessWidget {
                 value: enabled,
                 onChanged: onChanged,
                 activeThumbColor: Colors.white,
-                activeTrackColor: const Color(0xFF0D8A6D),
+                activeTrackColor: _settingsSwitchActiveTrackColor,
                 inactiveThumbColor: Colors.white,
-                inactiveTrackColor: const Color(0xFFC8D3DC),
+                inactiveTrackColor: _settingsSwitchInactiveTrackColor,
                 materialTapTargetSize: MaterialTapTargetSize.padded,
               ),
             ],
@@ -4986,7 +4988,7 @@ class UserDataDeletionResultScreen extends StatelessWidget {
             const SizedBox(height: 12),
             const _AppCard(
               backgroundColor: EasySubwayAccessibleColors.skySoft,
-              borderColor: Color(0xFFB7DDF4),
+              borderColor: _homeRouteDraftBorderColor,
               child: _AppInfoRow(
                 icon: Icons.map_outlined,
                 iconBackground: Colors.white,


### PR DESCRIPTION
## Summary
- move settings switch track colors into local main.dart tokens
- reuse the home route draft border token for the data deletion result info card

## Verification
- dart format lib/main.dart
- git diff --check
- flutter analyze lib/main.dart
- flutter test test/widget_test.dart --name "(설정 화면 보기 옵션은 큰 글자에서도 스위치를 조작할 수 있다|데이터 삭제 결과는 보낸 정보 정리를 쉬운 문구로 보여준다)" --reporter expanded

Issue: #1075

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 설정 화면의 스위치 색상과 일부 카드 테두리 색상을 공통 상수로 정리해 일관성을 높였습니다.
  * 화면 전반의 색상 표현은 그대로 유지하면서, 중복된 색상 값을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->