### PR TITLE
[Feat] Route Commercialization C-3 realtime provider mapping 전환

### DIFF
--- a/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/InMemoryRealtimeMappingPort.java
+++ b/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/InMemoryRealtimeMappingPort.java
@@ -1,0 +1,61 @@
+package com.easysubway.realtime.adapter.out.persistence;
+
+import com.easysubway.realtime.application.RealtimeQuery;
+import com.easysubway.realtime.application.port.out.RealtimeMappingPort;
+import com.easysubway.realtime.domain.RealtimeMapping;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("!prod & !staging & !release & !prod-like")
+public class InMemoryRealtimeMappingPort implements RealtimeMappingPort {
+
+	private final List<RealtimeMapping> mappings;
+
+	public InMemoryRealtimeMappingPort() {
+		this(seededMappings());
+	}
+
+	InMemoryRealtimeMappingPort(List<RealtimeMapping> mappings) {
+		this.mappings = List.copyOf(mappings);
+	}
+
+	public static InMemoryRealtimeMappingPort seededFixture() {
+		return new InMemoryRealtimeMappingPort(seededMappings());
+	}
+
+	private static List<RealtimeMapping> seededMappings() {
+		return List.of(new RealtimeMapping(
+			"seoul-topis",
+			"station-sangnoksu",
+			"seoul-4",
+			"1004",
+			"1004000448",
+			"상록수",
+			"4호선",
+			true,
+			true,
+			"OFFICIAL",
+			1L
+		));
+	}
+
+	@Override
+	public Optional<RealtimeMapping> findArrivalMapping(String providerId, RealtimeQuery query) {
+		return mappings.stream()
+			.filter((mapping) -> mapping.providerId().equals(providerId))
+			.filter((mapping) -> mapping.stationId().equals(query.stationId()))
+			.filter((mapping) -> query.lineId() == null || query.lineId().isBlank() || mapping.lineId().equals(query.lineId()))
+			.findFirst();
+	}
+
+	@Override
+	public Optional<RealtimeMapping> findTrainPositionMapping(String providerId, RealtimeQuery query) {
+		return mappings.stream()
+			.filter((mapping) -> mapping.providerId().equals(providerId))
+			.filter((mapping) -> query.lineId() == null || query.lineId().isBlank() || mapping.lineId().equals(query.lineId()))
+			.findFirst();
+	}
+}

--- a/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/InMemoryRealtimeMappingPort.java
+++ b/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/InMemoryRealtimeMappingPort.java
@@ -47,7 +47,7 @@ public class InMemoryRealtimeMappingPort implements RealtimeMappingPort {
 		return mappings.stream()
 			.filter((mapping) -> mapping.providerId().equals(providerId))
 			.filter((mapping) -> mapping.stationId().equals(query.stationId()))
-			.filter((mapping) -> query.lineId() == null || query.lineId().isBlank() || mapping.lineId().equals(query.lineId()))
+			.filter((mapping) -> mapping.matchesLine(query.lineId()))
 			.findFirst();
 	}
 
@@ -55,7 +55,7 @@ public class InMemoryRealtimeMappingPort implements RealtimeMappingPort {
 	public Optional<RealtimeMapping> findTrainPositionMapping(String providerId, RealtimeQuery query) {
 		return mappings.stream()
 			.filter((mapping) -> mapping.providerId().equals(providerId))
-			.filter((mapping) -> query.lineId() == null || query.lineId().isBlank() || mapping.lineId().equals(query.lineId()))
+			.filter((mapping) -> mapping.matchesLine(query.lineId()))
 			.findFirst();
 	}
 }

--- a/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepository.java
+++ b/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepository.java
@@ -59,7 +59,7 @@ public class JdbcRealtimeMappingRepository implements RealtimeMappingPort {
 						AND lm.line_id = sm.line_id
 					WHERE sm.provider_id = ?
 						AND sm.station_id = ?
-						AND (? IS NULL OR ? = '' OR sm.line_id = ?)
+						AND (? IS NULL OR ? = '' OR sm.line_id = ? OR sm.line_id LIKE CONCAT('%-', ?))
 						AND (? IS NULL OR ? = '' OR sm.provider_line_id = ? OR sm.provider_station_id LIKE CONCAT('%', ?))
 						AND (lm.valid_from IS NULL OR lm.valid_from <= CURRENT_TIMESTAMP)
 						AND (lm.valid_until IS NULL OR lm.valid_until > CURRENT_TIMESTAMP)
@@ -67,6 +67,7 @@ public class JdbcRealtimeMappingRepository implements RealtimeMappingPort {
 				this::mapMapping,
 				providerId,
 				query.stationId(),
+				query.lineId(),
 				query.lineId(),
 				query.lineId(),
 				query.lineId(),
@@ -99,7 +100,7 @@ public class JdbcRealtimeMappingRepository implements RealtimeMappingPort {
 					FROM realtime_provider_line_mappings lm
 					WHERE lm.provider_id = ?
 						AND (
-							(? IS NOT NULL AND ? <> '' AND lm.line_id = ?)
+							(? IS NOT NULL AND ? <> '' AND (lm.line_id = ? OR lm.line_id LIKE CONCAT('%-', ?)))
 							OR ((? IS NULL OR ? = '') AND lm.provider_line_name = ?)
 						)
 						AND (? IS NULL OR ? = '' OR lm.provider_line_id = ?)
@@ -108,6 +109,7 @@ public class JdbcRealtimeMappingRepository implements RealtimeMappingPort {
 					""",
 				this::mapMapping,
 				providerId,
+				query.lineId(),
 				query.lineId(),
 				query.lineId(),
 				query.lineId(),

--- a/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepository.java
+++ b/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepository.java
@@ -59,8 +59,8 @@ public class JdbcRealtimeMappingRepository implements RealtimeMappingPort {
 						AND lm.line_id = sm.line_id
 					WHERE sm.provider_id = ?
 						AND sm.station_id = ?
-						AND sm.line_id = ?
-						AND (? IS NULL OR ? = '' OR sm.provider_line_id = ?)
+						AND (? IS NULL OR ? = '' OR sm.line_id = ?)
+						AND (? IS NULL OR ? = '' OR sm.provider_line_id = ? OR sm.provider_station_id LIKE CONCAT('%', ?))
 						AND (lm.valid_from IS NULL OR lm.valid_from <= CURRENT_TIMESTAMP)
 						AND (lm.valid_until IS NULL OR lm.valid_until > CURRENT_TIMESTAMP)
 					""",
@@ -68,6 +68,9 @@ public class JdbcRealtimeMappingRepository implements RealtimeMappingPort {
 				providerId,
 				query.stationId(),
 				query.lineId(),
+				query.lineId(),
+				query.lineId(),
+				query.providerLineId(),
 				query.providerLineId(),
 				query.providerLineId(),
 				query.providerLineId()
@@ -95,7 +98,10 @@ public class JdbcRealtimeMappingRepository implements RealtimeMappingPort {
 						lm.cache_version
 					FROM realtime_provider_line_mappings lm
 					WHERE lm.provider_id = ?
-						AND lm.line_id = ?
+						AND (
+							(? IS NOT NULL AND ? <> '' AND lm.line_id = ?)
+							OR ((? IS NULL OR ? = '') AND lm.provider_line_name = ?)
+						)
 						AND (? IS NULL OR ? = '' OR lm.provider_line_id = ?)
 						AND (lm.valid_from IS NULL OR lm.valid_from <= CURRENT_TIMESTAMP)
 						AND (lm.valid_until IS NULL OR lm.valid_until > CURRENT_TIMESTAMP)
@@ -103,6 +109,11 @@ public class JdbcRealtimeMappingRepository implements RealtimeMappingPort {
 				this::mapMapping,
 				providerId,
 				query.lineId(),
+				query.lineId(),
+				query.lineId(),
+				query.lineId(),
+				query.lineId(),
+				query.lineName(),
 				query.providerLineId(),
 				query.providerLineId(),
 				query.providerLineId()

--- a/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepository.java
+++ b/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepository.java
@@ -1,0 +1,130 @@
+package com.easysubway.realtime.adapter.out.persistence;
+
+import com.easysubway.realtime.application.RealtimeQuery;
+import com.easysubway.realtime.application.port.out.RealtimeMappingPort;
+import com.easysubway.realtime.domain.RealtimeMapping;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Profile("prod | staging | release | prod-like")
+public class JdbcRealtimeMappingRepository implements RealtimeMappingPort {
+
+	private final JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	public JdbcRealtimeMappingRepository(DataSource dataSource) {
+		this(new JdbcTemplate(dataSource));
+	}
+
+	JdbcRealtimeMappingRepository(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public Optional<RealtimeMapping> findArrivalMapping(String providerId, RealtimeQuery query) {
+		try {
+			return Optional.ofNullable(jdbcTemplate.queryForObject(
+				"""
+					SELECT sm.provider_id,
+						sm.station_id,
+						sm.line_id,
+						sm.provider_line_id,
+						sm.provider_station_id,
+						sm.query_name,
+						lm.provider_line_name,
+						(sm.supports_arrivals AND lm.supports_arrivals) AS supports_arrivals,
+						(sm.supports_train_positions AND lm.supports_train_positions) AS supports_train_positions,
+						CASE
+							WHEN sm.mapping_confidence IN ('OFFICIAL', 'MANUAL')
+								AND lm.mapping_confidence IN ('OFFICIAL', 'MANUAL')
+								THEN sm.mapping_confidence
+							ELSE 'UNKNOWN'
+						END AS mapping_confidence,
+						CASE
+							WHEN sm.cache_version > lm.cache_version THEN sm.cache_version
+							ELSE lm.cache_version
+						END AS cache_version
+					FROM realtime_provider_station_mappings sm
+					JOIN realtime_provider_line_mappings lm
+						ON lm.provider_id = sm.provider_id
+						AND lm.provider_line_id = sm.provider_line_id
+						AND lm.line_id = sm.line_id
+					WHERE sm.provider_id = ?
+						AND sm.station_id = ?
+						AND sm.line_id = ?
+						AND (? IS NULL OR ? = '' OR sm.provider_line_id = ?)
+						AND (lm.valid_from IS NULL OR lm.valid_from <= CURRENT_TIMESTAMP)
+						AND (lm.valid_until IS NULL OR lm.valid_until > CURRENT_TIMESTAMP)
+					""",
+				this::mapMapping,
+				providerId,
+				query.stationId(),
+				query.lineId(),
+				query.providerLineId(),
+				query.providerLineId(),
+				query.providerLineId()
+			));
+		} catch (EmptyResultDataAccessException exception) {
+			return Optional.empty();
+		}
+	}
+
+	@Override
+	public Optional<RealtimeMapping> findTrainPositionMapping(String providerId, RealtimeQuery query) {
+		try {
+			return Optional.ofNullable(jdbcTemplate.queryForObject(
+				"""
+					SELECT lm.provider_id,
+						'' AS station_id,
+						lm.line_id,
+						lm.provider_line_id,
+						'' AS provider_station_id,
+						'' AS query_name,
+						lm.provider_line_name,
+						lm.supports_arrivals,
+						lm.supports_train_positions,
+						lm.mapping_confidence,
+						lm.cache_version
+					FROM realtime_provider_line_mappings lm
+					WHERE lm.provider_id = ?
+						AND lm.line_id = ?
+						AND (? IS NULL OR ? = '' OR lm.provider_line_id = ?)
+						AND (lm.valid_from IS NULL OR lm.valid_from <= CURRENT_TIMESTAMP)
+						AND (lm.valid_until IS NULL OR lm.valid_until > CURRENT_TIMESTAMP)
+					""",
+				this::mapMapping,
+				providerId,
+				query.lineId(),
+				query.providerLineId(),
+				query.providerLineId(),
+				query.providerLineId()
+			));
+		} catch (EmptyResultDataAccessException exception) {
+			return Optional.empty();
+		}
+	}
+
+	private RealtimeMapping mapMapping(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new RealtimeMapping(
+			resultSet.getString("provider_id"),
+			resultSet.getString("station_id"),
+			resultSet.getString("line_id"),
+			resultSet.getString("provider_line_id"),
+			resultSet.getString("provider_station_id"),
+			resultSet.getString("query_name"),
+			resultSet.getString("provider_line_name"),
+			resultSet.getBoolean("supports_arrivals"),
+			resultSet.getBoolean("supports_train_positions"),
+			resultSet.getString("mapping_confidence"),
+			resultSet.getLong("cache_version")
+		);
+	}
+}

--- a/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
@@ -1,5 +1,7 @@
 package com.easysubway.realtime.application;
 
+import com.easysubway.realtime.application.port.out.RealtimeMappingPort;
+import com.easysubway.realtime.domain.RealtimeMapping;
 import com.easysubway.realtime.domain.RealtimeArrival;
 import com.easysubway.realtime.domain.RealtimeTrainPosition;
 import java.time.Clock;
@@ -28,13 +30,10 @@ public class RealtimeGatewayService {
 	private static final ZoneId PROVIDER_ZONE = ZoneId.of("Asia/Seoul");
 	private static final DateTimeFormatter PROVIDER_TIMESTAMP_FORMATTER =
 		DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-	private static final String SANGNOKSU_STATION_ID = "station-sangnoksu";
-	private static final String SANGNOKSU_STATION_NAME = "상록수";
-	private static final String LINE_ID = "4";
-	private static final String LINE_NAME = "4호선";
-	private static final String PROVIDER_LINE_ID = "1004";
+	private static final String PROVIDER_ID = "seoul-topis";
 
 	private final RealtimeProvider provider;
+	private final RealtimeMappingPort mappingPort;
 	private final Clock clock;
 	private final Map<String, CachedArrival> arrivalCache = new ConcurrentHashMap<>();
 	private final Map<String, CachedTrainPosition> trainPositionCache = new ConcurrentHashMap<>();
@@ -43,28 +42,30 @@ public class RealtimeGatewayService {
 	private volatile java.time.Instant quotaCircuitOpenUntil;
 
 	@Autowired
-	public RealtimeGatewayService(RealtimeProvider provider) {
-		this(provider, Clock.systemUTC());
+	public RealtimeGatewayService(RealtimeProvider provider, RealtimeMappingPort mappingPort) {
+		this(provider, Clock.systemUTC(), mappingPort);
 	}
 
-	RealtimeGatewayService(RealtimeProvider provider, Clock clock) {
+	RealtimeGatewayService(RealtimeProvider provider, Clock clock, RealtimeMappingPort mappingPort) {
 		this.provider = provider;
 		this.clock = clock;
+		this.mappingPort = mappingPort;
 	}
 
 	public RealtimeArrivalResult arrivals(RealtimeQuery query) {
-		RealtimeQuery normalizedQuery = normalizeArrivalQuery(query);
-		if (normalizedQuery == null) {
+		NormalizedRealtimeQuery normalizedQuery = normalizeArrivalQuery(query);
+		if (normalizedQuery.rejected()) {
 			return RealtimeArrivalResult.unsupported(
-				"UNSUPPORTED_REGION",
+				normalizedQuery.fallbackCode(),
 				"서울 TOPIS 실시간 지원 범위 밖입니다."
 			);
 		}
 		String cacheKey = "ARRIVALS:%s:%s:%s".formatted(
-			normalizedQuery.providerLineId(),
-			normalizedQuery.stationId(),
-			normalizedQuery.stationQueryName()
+			normalizedQuery.query().providerLineId(),
+			normalizedQuery.query().stationId(),
+			normalizedQuery.query().stationQueryName()
 		);
+		cacheKey = "%s:%d".formatted(cacheKey, normalizedQuery.cacheVersion());
 		CachedArrival cached = arrivalCache.get(cacheKey);
 		if (cached != null && isFresh(cached.cachedAt())) {
 			return cached.result();
@@ -80,7 +81,7 @@ public class RealtimeGatewayService {
 			return joinArrival(existing);
 		}
 		try {
-			RealtimeArrivalResult result = fetchArrivals(normalizedQuery, cacheKey, cached);
+			RealtimeArrivalResult result = fetchArrivals(normalizedQuery.query(), cacheKey, cached);
 			request.complete(result);
 			return result;
 		} catch (RuntimeException exception) {
@@ -115,14 +116,18 @@ public class RealtimeGatewayService {
 	}
 
 	public RealtimeTrainPositionResult trainPositions(RealtimeQuery query) {
-		RealtimeQuery normalizedQuery = normalizeTrainPositionQuery(query);
-		if (normalizedQuery == null) {
+		NormalizedRealtimeQuery normalizedQuery = normalizeTrainPositionQuery(query);
+		if (normalizedQuery.rejected()) {
 			return RealtimeTrainPositionResult.unsupported(
-				"UNSUPPORTED_REGION",
+				normalizedQuery.fallbackCode(),
 				"서울 TOPIS 실시간 지원 범위 밖입니다."
 			);
 		}
-		String cacheKey = "POSITIONS:%s:%s".formatted(normalizedQuery.providerLineId(), normalizedQuery.lineName());
+		String cacheKey = "POSITIONS:%s:%s:%d".formatted(
+			normalizedQuery.query().providerLineId(),
+			normalizedQuery.query().lineName(),
+			normalizedQuery.cacheVersion()
+		);
 		CachedTrainPosition cached = trainPositionCache.get(cacheKey);
 		if (cached != null && isFresh(cached.cachedAt())) {
 			return cached.result();
@@ -138,7 +143,7 @@ public class RealtimeGatewayService {
 			return joinTrainPosition(existing);
 		}
 		try {
-			RealtimeTrainPositionResult result = fetchTrainPositions(normalizedQuery, cacheKey, cached);
+			RealtimeTrainPositionResult result = fetchTrainPositions(normalizedQuery.query(), cacheKey, cached);
 			request.complete(result);
 			return result;
 		} catch (RuntimeException exception) {
@@ -295,54 +300,60 @@ public class RealtimeGatewayService {
 		return exception;
 	}
 
-	private RealtimeQuery normalizeArrivalQuery(RealtimeQuery query) {
-		if (!SANGNOKSU_STATION_ID.equals(query.stationId()) || !SANGNOKSU_STATION_NAME.equals(query.stationQueryName())) {
-			return null;
-		}
-		if (!isBlankOrOneOf(query.lineId(), LINE_ID, "seoul-4")) {
-			return null;
-		}
-		if (!isBlankOrOneOf(query.providerLineId(), PROVIDER_LINE_ID, "448")) {
-			return null;
-		}
-		return new RealtimeQuery(
-			SANGNOKSU_STATION_ID,
-			LINE_ID,
-			PROVIDER_LINE_ID,
-			SANGNOKSU_STATION_NAME,
-			LINE_NAME
-		);
+	private NormalizedRealtimeQuery normalizeArrivalQuery(RealtimeQuery query) {
+		return mappingPort.findArrivalMapping(PROVIDER_ID, query)
+			.map((mapping) -> normalizeArrivalMapping(query, mapping))
+			.orElseGet(() -> NormalizedRealtimeQuery.rejected("MAPPING_MISSING"));
 	}
 
-	private RealtimeQuery normalizeTrainPositionQuery(RealtimeQuery query) {
-		if (!LINE_NAME.equals(query.lineName())) {
-			return null;
+	private NormalizedRealtimeQuery normalizeArrivalMapping(RealtimeQuery query, RealtimeMapping mapping) {
+		if (!providerLineMatches(query, mapping)) {
+			return NormalizedRealtimeQuery.rejected("MAPPING_MISSING");
 		}
-		if (!isBlankOrOneOf(query.lineId(), LINE_ID, "seoul-4")) {
-			return null;
+		if (!mapping.supportsArrivals()) {
+			return NormalizedRealtimeQuery.rejected("UNSUPPORTED_CAPABILITY");
 		}
-		if (!isBlankOrOneOf(query.providerLineId(), PROVIDER_LINE_ID)) {
-			return null;
+		if (!mapping.liveEligible()) {
+			return NormalizedRealtimeQuery.rejected(mapping.ineligibleReason());
 		}
-		return new RealtimeQuery(
-			SANGNOKSU_STATION_ID,
-			LINE_ID,
-			PROVIDER_LINE_ID,
-			SANGNOKSU_STATION_NAME,
-			LINE_NAME
-		);
+		return NormalizedRealtimeQuery.mapped(new RealtimeQuery(
+			mapping.stationId(),
+			mapping.lineId(),
+			mapping.providerLineId(),
+			mapping.effectiveQueryName(query.stationQueryName()),
+			mapping.effectiveProviderLineName(query.lineName())
+		), mapping.cacheVersion());
 	}
 
-	private boolean isBlankOrOneOf(String value, String... allowedValues) {
-		if (value == null || value.isBlank()) {
-			return true;
+	private NormalizedRealtimeQuery normalizeTrainPositionQuery(RealtimeQuery query) {
+		return mappingPort.findTrainPositionMapping(PROVIDER_ID, query)
+			.map((mapping) -> normalizeTrainPositionMapping(query, mapping))
+			.orElseGet(() -> NormalizedRealtimeQuery.rejected("MAPPING_MISSING"));
+	}
+
+	private NormalizedRealtimeQuery normalizeTrainPositionMapping(RealtimeQuery query, RealtimeMapping mapping) {
+		if (!providerLineMatches(query, mapping)) {
+			return NormalizedRealtimeQuery.rejected("MAPPING_MISSING");
 		}
-		for (String allowedValue : allowedValues) {
-			if (allowedValue.equals(value)) {
-				return true;
-			}
+		if (!mapping.supportsTrainPositions()) {
+			return NormalizedRealtimeQuery.rejected("UNSUPPORTED_CAPABILITY");
 		}
-		return false;
+		if (!mapping.liveEligible()) {
+			return NormalizedRealtimeQuery.rejected(mapping.ineligibleReason());
+		}
+		return NormalizedRealtimeQuery.mapped(new RealtimeQuery(
+			mapping.stationId(),
+			mapping.lineId(),
+			mapping.providerLineId(),
+			mapping.effectiveQueryName(query.stationQueryName()),
+			mapping.effectiveProviderLineName(query.lineName())
+		), mapping.cacheVersion());
+	}
+
+	private boolean providerLineMatches(RealtimeQuery query, RealtimeMapping mapping) {
+		return query.providerLineId() == null
+			|| query.providerLineId().isBlank()
+			|| mapping.providerLineId().equals(query.providerLineId());
 	}
 
 	private boolean isFresh(java.time.Instant cachedAt) {
@@ -368,5 +379,19 @@ public class RealtimeGatewayService {
 	}
 
 	private record CachedTrainPosition(RealtimeTrainPositionResult result, java.time.Instant cachedAt) {
+	}
+
+	private record NormalizedRealtimeQuery(RealtimeQuery query, long cacheVersion, String fallbackCode) {
+		static NormalizedRealtimeQuery mapped(RealtimeQuery query, long cacheVersion) {
+			return new NormalizedRealtimeQuery(query, cacheVersion, null);
+		}
+
+		static NormalizedRealtimeQuery rejected(String fallbackCode) {
+			return new NormalizedRealtimeQuery(null, 0, fallbackCode);
+		}
+
+		boolean rejected() {
+			return fallbackCode != null;
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
@@ -351,9 +351,7 @@ public class RealtimeGatewayService {
 	}
 
 	private boolean providerLineMatches(RealtimeQuery query, RealtimeMapping mapping) {
-		return query.providerLineId() == null
-			|| query.providerLineId().isBlank()
-			|| mapping.providerLineId().equals(query.providerLineId());
+		return mapping.matchesProviderLine(query.providerLineId());
 	}
 
 	private boolean isFresh(java.time.Instant cachedAt) {

--- a/backend/src/main/java/com/easysubway/realtime/application/port/out/RealtimeMappingPort.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/port/out/RealtimeMappingPort.java
@@ -1,0 +1,11 @@
+package com.easysubway.realtime.application.port.out;
+
+import com.easysubway.realtime.application.RealtimeQuery;
+import com.easysubway.realtime.domain.RealtimeMapping;
+import java.util.Optional;
+
+public interface RealtimeMappingPort {
+	Optional<RealtimeMapping> findArrivalMapping(String providerId, RealtimeQuery query);
+
+	Optional<RealtimeMapping> findTrainPositionMapping(String providerId, RealtimeQuery query);
+}

--- a/backend/src/main/java/com/easysubway/realtime/domain/RealtimeMapping.java
+++ b/backend/src/main/java/com/easysubway/realtime/domain/RealtimeMapping.java
@@ -1,0 +1,34 @@
+package com.easysubway.realtime.domain;
+
+public record RealtimeMapping(
+	String providerId,
+	String stationId,
+	String lineId,
+	String providerLineId,
+	String providerStationId,
+	String queryName,
+	String providerLineName,
+	boolean supportsArrivals,
+	boolean supportsTrainPositions,
+	String mappingConfidence,
+	long cacheVersion
+) {
+	public boolean liveEligible() {
+		return "OFFICIAL".equals(mappingConfidence) || "MANUAL".equals(mappingConfidence);
+	}
+
+	public String ineligibleReason() {
+		if (!liveEligible()) {
+			return "MAPPING_LOW_CONFIDENCE";
+		}
+		return null;
+	}
+
+	public String effectiveQueryName(String fallback) {
+		return queryName == null || queryName.isBlank() ? fallback : queryName;
+	}
+
+	public String effectiveProviderLineName(String fallback) {
+		return providerLineName == null || providerLineName.isBlank() ? fallback : providerLineName;
+	}
+}

--- a/backend/src/main/java/com/easysubway/realtime/domain/RealtimeMapping.java
+++ b/backend/src/main/java/com/easysubway/realtime/domain/RealtimeMapping.java
@@ -42,4 +42,11 @@ public record RealtimeMapping(
 		// ponytail: TOPIS station-code alias is the provider station id suffix; add explicit alias data if another provider needs it.
 		return providerStationId != null && providerStationId.endsWith(requestedProviderLineId);
 	}
+
+	public boolean matchesLine(String requestedLineId) {
+		if (requestedLineId == null || requestedLineId.isBlank()) {
+			return true;
+		}
+		return lineId.equals(requestedLineId) || lineId.endsWith("-" + requestedLineId);
+	}
 }

--- a/backend/src/main/java/com/easysubway/realtime/domain/RealtimeMapping.java
+++ b/backend/src/main/java/com/easysubway/realtime/domain/RealtimeMapping.java
@@ -31,4 +31,15 @@ public record RealtimeMapping(
 	public String effectiveProviderLineName(String fallback) {
 		return providerLineName == null || providerLineName.isBlank() ? fallback : providerLineName;
 	}
+
+	public boolean matchesProviderLine(String requestedProviderLineId) {
+		if (requestedProviderLineId == null || requestedProviderLineId.isBlank()) {
+			return true;
+		}
+		if (providerLineId.equals(requestedProviderLineId)) {
+			return true;
+		}
+		// ponytail: TOPIS station-code alias is the provider station id suffix; add explicit alias data if another provider needs it.
+		return providerStationId != null && providerStationId.endsWith(requestedProviderLineId);
+	}
 }

--- a/backend/src/main/resources/db/migration/h2/V31__realtime_provider_mappings.sql
+++ b/backend/src/main/resources/db/migration/h2/V31__realtime_provider_mappings.sql
@@ -1,0 +1,87 @@
+CREATE TABLE IF NOT EXISTS realtime_provider_line_mappings (
+  provider_id CHARACTER VARYING(80) NOT NULL,
+  provider_line_id CHARACTER VARYING(80) NOT NULL,
+  line_id CHARACTER VARYING(80) NOT NULL,
+  provider_line_name CHARACTER VARYING(120) DEFAULT '' NOT NULL,
+  supports_arrivals BOOL DEFAULT FALSE NOT NULL,
+  supports_train_positions BOOL DEFAULT FALSE NOT NULL,
+  mapping_confidence CHARACTER VARYING(40) DEFAULT 'UNKNOWN' NOT NULL,
+  provider_priority INT DEFAULT 100 NOT NULL,
+  coverage_region CHARACTER VARYING(80) DEFAULT '' NOT NULL,
+  valid_from TIMESTAMP WITH TIME ZONE,
+  valid_until TIMESTAMP WITH TIME ZONE,
+  cache_version BIGINT DEFAULT 1 NOT NULL,
+  PRIMARY KEY (provider_id, provider_line_id),
+  UNIQUE (provider_id, line_id),
+  CONSTRAINT h2_realtime_line_mapping_confidence CHECK (mapping_confidence IN ('OFFICIAL', 'MANUAL', 'HEURISTIC', 'UNKNOWN')),
+  CONSTRAINT h2_realtime_line_cache_version CHECK (cache_version > 0)
+);
+
+CREATE TABLE IF NOT EXISTS realtime_provider_station_mappings (
+  provider_id CHARACTER VARYING(80) NOT NULL,
+  provider_line_id CHARACTER VARYING(80) NOT NULL,
+  provider_station_id CHARACTER VARYING(80) NOT NULL,
+  station_id CHARACTER VARYING(120) NOT NULL,
+  line_id CHARACTER VARYING(80) NOT NULL,
+  query_name CHARACTER VARYING(120) DEFAULT '' NOT NULL,
+  supports_arrivals BOOL DEFAULT FALSE NOT NULL,
+  supports_train_positions BOOL DEFAULT FALSE NOT NULL,
+  mapping_confidence CHARACTER VARYING(40) DEFAULT 'UNKNOWN' NOT NULL,
+  cache_version BIGINT DEFAULT 1 NOT NULL,
+  PRIMARY KEY (provider_id, provider_line_id, provider_station_id),
+  UNIQUE (provider_id, line_id, station_id),
+  FOREIGN KEY (provider_id, provider_line_id) REFERENCES realtime_provider_line_mappings(provider_id, provider_line_id),
+  CONSTRAINT h2_realtime_station_mapping_confidence CHECK (mapping_confidence IN ('OFFICIAL', 'MANUAL', 'HEURISTIC', 'UNKNOWN')),
+  CONSTRAINT h2_realtime_station_cache_version CHECK (cache_version > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_realtime_provider_station_internal
+  ON realtime_provider_station_mappings(provider_id, station_id, line_id);
+
+MERGE INTO realtime_provider_line_mappings (
+  provider_id,
+  provider_line_id,
+  line_id,
+  provider_line_name,
+  supports_arrivals,
+  supports_train_positions,
+  mapping_confidence,
+  provider_priority,
+  coverage_region,
+  cache_version
+) KEY (provider_id, provider_line_id) VALUES (
+  'seoul-topis',
+  '1004',
+  'seoul-4',
+  '4호선',
+  TRUE,
+  TRUE,
+  'OFFICIAL',
+  10,
+  'capital',
+  1
+);
+
+MERGE INTO realtime_provider_station_mappings (
+  provider_id,
+  provider_line_id,
+  provider_station_id,
+  station_id,
+  line_id,
+  query_name,
+  supports_arrivals,
+  supports_train_positions,
+  mapping_confidence,
+  cache_version
+) KEY (provider_id, provider_line_id, provider_station_id) VALUES (
+  'seoul-topis',
+  '1004',
+  '1004000448',
+  'station-sangnoksu',
+  'seoul-4',
+  '상록수',
+  TRUE,
+  TRUE,
+  'OFFICIAL',
+  1
+);

--- a/backend/src/main/resources/db/migration/postgresql/V31__realtime_provider_mappings.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V31__realtime_provider_mappings.sql
@@ -1,0 +1,87 @@
+CREATE TABLE IF NOT EXISTS realtime_provider_line_mappings (
+  provider_id VARCHAR(80) NOT NULL,
+  provider_line_id VARCHAR(80) NOT NULL,
+  line_id VARCHAR(80) NOT NULL,
+  provider_line_name VARCHAR(120) NOT NULL DEFAULT '',
+  supports_arrivals BOOLEAN NOT NULL DEFAULT FALSE,
+  supports_train_positions BOOLEAN NOT NULL DEFAULT FALSE,
+  mapping_confidence VARCHAR(40) NOT NULL DEFAULT 'UNKNOWN',
+  provider_priority INTEGER NOT NULL DEFAULT 100,
+  coverage_region VARCHAR(80) NOT NULL DEFAULT '',
+  valid_from TIMESTAMPTZ,
+  valid_until TIMESTAMPTZ,
+  cache_version BIGINT NOT NULL DEFAULT 1,
+  PRIMARY KEY (provider_id, provider_line_id),
+  UNIQUE (provider_id, line_id),
+  CONSTRAINT chk_realtime_line_mapping_confidence CHECK (mapping_confidence IN ('OFFICIAL', 'MANUAL', 'HEURISTIC', 'UNKNOWN')),
+  CONSTRAINT chk_realtime_line_cache_version CHECK (cache_version > 0)
+);
+
+CREATE TABLE IF NOT EXISTS realtime_provider_station_mappings (
+  provider_id VARCHAR(80) NOT NULL,
+  provider_line_id VARCHAR(80) NOT NULL,
+  provider_station_id VARCHAR(80) NOT NULL,
+  station_id VARCHAR(120) NOT NULL,
+  line_id VARCHAR(80) NOT NULL,
+  query_name VARCHAR(120) NOT NULL DEFAULT '',
+  supports_arrivals BOOLEAN NOT NULL DEFAULT FALSE,
+  supports_train_positions BOOLEAN NOT NULL DEFAULT FALSE,
+  mapping_confidence VARCHAR(40) NOT NULL DEFAULT 'UNKNOWN',
+  cache_version BIGINT NOT NULL DEFAULT 1,
+  PRIMARY KEY (provider_id, provider_line_id, provider_station_id),
+  UNIQUE (provider_id, line_id, station_id),
+  FOREIGN KEY (provider_id, provider_line_id) REFERENCES realtime_provider_line_mappings(provider_id, provider_line_id),
+  CONSTRAINT chk_realtime_station_mapping_confidence CHECK (mapping_confidence IN ('OFFICIAL', 'MANUAL', 'HEURISTIC', 'UNKNOWN')),
+  CONSTRAINT chk_realtime_station_cache_version CHECK (cache_version > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_realtime_provider_station_internal
+  ON realtime_provider_station_mappings(provider_id, station_id, line_id);
+
+INSERT INTO realtime_provider_line_mappings (
+  provider_id,
+  provider_line_id,
+  line_id,
+  provider_line_name,
+  supports_arrivals,
+  supports_train_positions,
+  mapping_confidence,
+  provider_priority,
+  coverage_region,
+  cache_version
+) VALUES (
+  'seoul-topis',
+  '1004',
+  'seoul-4',
+  '4호선',
+  TRUE,
+  TRUE,
+  'OFFICIAL',
+  10,
+  'capital',
+  1
+) ON CONFLICT (provider_id, provider_line_id) DO NOTHING;
+
+INSERT INTO realtime_provider_station_mappings (
+  provider_id,
+  provider_line_id,
+  provider_station_id,
+  station_id,
+  line_id,
+  query_name,
+  supports_arrivals,
+  supports_train_positions,
+  mapping_confidence,
+  cache_version
+) VALUES (
+  'seoul-topis',
+  '1004',
+  '1004000448',
+  'station-sangnoksu',
+  'seoul-4',
+  '상록수',
+  TRUE,
+  TRUE,
+  'OFFICIAL',
+  1
+) ON CONFLICT (provider_id, provider_line_id, provider_station_id) DO NOTHING;

--- a/backend/src/test/java/com/easysubway/realtime/adapter/in/web/RealtimeControllerTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/adapter/in/web/RealtimeControllerTest.java
@@ -30,7 +30,7 @@ class RealtimeControllerTest {
 	void arrivalsReturnNormalizedFreshItems() throws Exception {
 		mockMvc.perform(get("/api/v1/realtime/arrivals")
 				.param("stationId", "station-sangnoksu")
-				.param("lineId", "4")
+				.param("lineId", "seoul-4")
 				.param("providerLineId", "1004")
 				.param("stationQueryName", "상록수"))
 			.andExpect(status().isOk())
@@ -50,7 +50,7 @@ class RealtimeControllerTest {
 				.param("stationQueryName", "외부역"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.status").value("UNSUPPORTED"))
-			.andExpect(jsonPath("$.data.fallbackCode").value("UNSUPPORTED_REGION"))
+			.andExpect(jsonPath("$.data.fallbackCode").value("MAPPING_MISSING"))
 			.andExpect(jsonPath("$.data.message").value("서울 TOPIS 실시간 지원 범위 밖입니다."));
 	}
 
@@ -58,7 +58,7 @@ class RealtimeControllerTest {
 	@DisplayName("열차 위치는 GPS가 아닌 운행 정보 snapshot 안내를 포함한다")
 	void trainPositionsIncludeOperationSnapshotNotice() throws Exception {
 		mockMvc.perform(get("/api/v1/realtime/train-positions")
-				.param("lineId", "4")
+				.param("lineId", "seoul-4")
 				.param("providerLineId", "1004")
 				.param("lineName", "4호선"))
 			.andExpect(status().isOk())

--- a/backend/src/test/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepositoryTest.java
@@ -104,6 +104,28 @@ class JdbcRealtimeMappingRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("도착 mapping은 TOPIS station code providerLineId alias를 조회한다")
+	void findArrivalMappingByStationCodeProviderLineAlias() {
+		var mapping = repository.findArrivalMapping(
+			"seoul-topis",
+			new RealtimeQuery("station-sangnoksu", "seoul-4", "448", "상록수", null)
+		);
+
+		assertThat(mapping).hasValueSatisfying((value) -> assertThat(value.providerLineId()).isEqualTo("1004"));
+	}
+
+	@Test
+	@DisplayName("도착 mapping은 lineId가 없어도 station-provider alias로 조회한다")
+	void findArrivalMappingWithoutLineId() {
+		var mapping = repository.findArrivalMapping(
+			"seoul-topis",
+			new RealtimeQuery("station-sangnoksu", null, "448", "상록수", null)
+		);
+
+		assertThat(mapping).isPresent();
+	}
+
+	@Test
 	@DisplayName("열차 위치 mapping은 line query로 provider line alias와 cache version을 조회한다")
 	void findTrainPositionMappingByLine() {
 		var mapping = repository.findTrainPositionMapping(
@@ -116,6 +138,17 @@ class JdbcRealtimeMappingRepositoryTest {
 			assertThat(value.providerLineName()).isEqualTo("4호선");
 			assertThat(value.cacheVersion()).isEqualTo(7L);
 		});
+	}
+
+	@Test
+	@DisplayName("열차 위치 mapping은 lineId가 없으면 provider line name으로 조회한다")
+	void findTrainPositionMappingByLineNameWhenLineIdIsBlank() {
+		var mapping = repository.findTrainPositionMapping(
+			"seoul-topis",
+			new RealtimeQuery(null, null, null, null, "4호선")
+		);
+
+		assertThat(mapping).hasValueSatisfying((value) -> assertThat(value.lineId()).isEqualTo("seoul-4"));
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepositoryTest.java
@@ -126,6 +126,17 @@ class JdbcRealtimeMappingRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("도착 mapping은 legacy shorthand lineId로 조회한다")
+	void findArrivalMappingByLegacyShorthandLineId() {
+		var mapping = repository.findArrivalMapping(
+			"seoul-topis",
+			new RealtimeQuery("station-sangnoksu", "4", "448", "상록수", null)
+		);
+
+		assertThat(mapping).isPresent();
+	}
+
+	@Test
 	@DisplayName("열차 위치 mapping은 line query로 provider line alias와 cache version을 조회한다")
 	void findTrainPositionMappingByLine() {
 		var mapping = repository.findTrainPositionMapping(
@@ -149,6 +160,17 @@ class JdbcRealtimeMappingRepositoryTest {
 		);
 
 		assertThat(mapping).hasValueSatisfying((value) -> assertThat(value.lineId()).isEqualTo("seoul-4"));
+	}
+
+	@Test
+	@DisplayName("열차 위치 mapping은 legacy shorthand lineId로 조회한다")
+	void findTrainPositionMappingByLegacyShorthandLineId() {
+		var mapping = repository.findTrainPositionMapping(
+			"seoul-topis",
+			new RealtimeQuery(null, "4", null, null, "4호선")
+		);
+
+		assertThat(mapping).isPresent();
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepositoryTest.java
@@ -1,0 +1,157 @@
+package com.easysubway.realtime.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.easysubway.realtime.application.RealtimeQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+@DisplayName("JDBC 실시간 provider mapping 저장소")
+class JdbcRealtimeMappingRepositoryTest {
+
+	private JdbcRealtimeMappingRepository repository;
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		var dataSource = new DriverManagerDataSource(
+			"jdbc:h2:mem:realtime-mapping;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+			"sa",
+			""
+		);
+		jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS realtime_provider_station_mappings");
+		jdbcTemplate.execute("DROP TABLE IF EXISTS realtime_provider_line_mappings");
+		jdbcTemplate.execute("""
+			CREATE TABLE realtime_provider_line_mappings (
+				provider_id VARCHAR(80) NOT NULL,
+				provider_line_id VARCHAR(80) NOT NULL,
+				line_id VARCHAR(80) NOT NULL,
+				provider_line_name VARCHAR(120) NOT NULL,
+				supports_arrivals BOOLEAN NOT NULL,
+				supports_train_positions BOOLEAN NOT NULL,
+				mapping_confidence VARCHAR(40) NOT NULL,
+				provider_priority INTEGER NOT NULL,
+				coverage_region VARCHAR(80) NOT NULL,
+				valid_from TIMESTAMP,
+				valid_until TIMESTAMP,
+				cache_version BIGINT NOT NULL,
+				PRIMARY KEY (provider_id, provider_line_id),
+				UNIQUE (provider_id, line_id)
+			)
+			""");
+		jdbcTemplate.execute("""
+			CREATE TABLE realtime_provider_station_mappings (
+				provider_id VARCHAR(80) NOT NULL,
+				provider_line_id VARCHAR(80) NOT NULL,
+				provider_station_id VARCHAR(80) NOT NULL,
+				station_id VARCHAR(120) NOT NULL,
+				line_id VARCHAR(80) NOT NULL,
+				query_name VARCHAR(120) NOT NULL,
+				supports_arrivals BOOLEAN NOT NULL,
+				supports_train_positions BOOLEAN NOT NULL,
+				mapping_confidence VARCHAR(40) NOT NULL,
+				cache_version BIGINT NOT NULL,
+				PRIMARY KEY (provider_id, provider_line_id, provider_station_id),
+				UNIQUE (provider_id, line_id, station_id)
+			)
+			""");
+		jdbcTemplate.update("""
+			INSERT INTO realtime_provider_line_mappings (
+				provider_id, provider_line_id, line_id, provider_line_name,
+				supports_arrivals, supports_train_positions, mapping_confidence,
+				provider_priority, coverage_region, valid_from, valid_until, cache_version
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?)
+			""", "seoul-topis", "1004", "seoul-4", "4호선", true, true, "OFFICIAL", 10, "capital", 7L);
+		jdbcTemplate.update("""
+			INSERT INTO realtime_provider_station_mappings (
+				provider_id, provider_line_id, provider_station_id, station_id, line_id, query_name,
+				supports_arrivals, supports_train_positions, mapping_confidence, cache_version
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			""", "seoul-topis", "1004", "1004000448", "station-sangnoksu", "seoul-4", "상록수", true, true, "OFFICIAL", 8L);
+		repository = new JdbcRealtimeMappingRepository(jdbcTemplate);
+	}
+
+	@Test
+	@DisplayName("도착 mapping은 station-line query로 provider alias와 cache version을 조회한다")
+	void findArrivalMappingByStationLine() {
+		var mapping = repository.findArrivalMapping(
+			"seoul-topis",
+			new RealtimeQuery("station-sangnoksu", "seoul-4", null, "상록수역", null)
+		);
+
+		assertThat(mapping).hasValueSatisfying((value) -> {
+			assertThat(value.providerLineId()).isEqualTo("1004");
+			assertThat(value.providerStationId()).isEqualTo("1004000448");
+			assertThat(value.queryName()).isEqualTo("상록수");
+			assertThat(value.providerLineName()).isEqualTo("4호선");
+			assertThat(value.cacheVersion()).isEqualTo(8L);
+		});
+	}
+
+	@Test
+	@DisplayName("도착 mapping은 providerLineId가 불일치하면 조회하지 않는다")
+	void findArrivalMappingRejectsProviderLineMismatch() {
+		var mapping = repository.findArrivalMapping(
+			"seoul-topis",
+			new RealtimeQuery("station-sangnoksu", "seoul-4", "9999", "상록수", null)
+		);
+
+		assertThat(mapping).isEmpty();
+	}
+
+	@Test
+	@DisplayName("열차 위치 mapping은 line query로 provider line alias와 cache version을 조회한다")
+	void findTrainPositionMappingByLine() {
+		var mapping = repository.findTrainPositionMapping(
+			"seoul-topis",
+			new RealtimeQuery(null, "seoul-4", null, null, "4호선")
+		);
+
+		assertThat(mapping).hasValueSatisfying((value) -> {
+			assertThat(value.providerLineId()).isEqualTo("1004");
+			assertThat(value.providerLineName()).isEqualTo("4호선");
+			assertThat(value.cacheVersion()).isEqualTo(7L);
+		});
+	}
+
+	@Test
+	@DisplayName("valid_until이 지난 mapping은 조회하지 않는다")
+	void expiredMappingIsIgnored() {
+		jdbcTemplate.update("""
+			UPDATE realtime_provider_line_mappings
+			SET valid_until = TIMESTAMP '2026-06-25 00:00:00'
+			WHERE provider_id = 'seoul-topis'
+			""");
+
+		var mapping = repository.findArrivalMapping(
+			"seoul-topis",
+			new RealtimeQuery("station-sangnoksu", "seoul-4", null, "상록수", null)
+		);
+
+		assertThat(mapping).isEmpty();
+	}
+
+	@Test
+	@DisplayName("도착 mapping은 line mapping confidence가 낮으면 live eligible이 아니다")
+	void lowConfidenceLineMarksArrivalMappingIneligible() {
+		jdbcTemplate.update("""
+			UPDATE realtime_provider_line_mappings
+			SET mapping_confidence = 'HEURISTIC'
+			WHERE provider_id = 'seoul-topis'
+			""");
+
+		var mapping = repository.findArrivalMapping(
+			"seoul-topis",
+			new RealtimeQuery("station-sangnoksu", "seoul-4", null, "상록수", null)
+		);
+
+		assertThat(mapping).hasValueSatisfying((value) -> {
+			assertThat(value.liveEligible()).isFalse();
+			assertThat(value.ineligibleReason()).isEqualTo("MAPPING_LOW_CONFIDENCE");
+		});
+	}
+}

--- a/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
@@ -3,6 +3,9 @@ package com.easysubway.realtime.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.easysubway.realtime.adapter.out.persistence.InMemoryRealtimeMappingPort;
+import com.easysubway.realtime.application.port.out.RealtimeMappingPort;
+import com.easysubway.realtime.domain.RealtimeMapping;
 import com.easysubway.realtime.domain.RealtimeArrival;
 import com.easysubway.realtime.domain.RealtimeTrainPosition;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,7 +14,9 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -29,7 +34,7 @@ class RealtimeGatewayServiceTest {
 	@DisplayName("같은 도착 요청은 cache TTL 안에서 provider 호출을 반복하지 않는다")
 	void arrivalsUseCacheWithinTtl() {
 		CountingProvider provider = new CountingProvider();
-		RealtimeGatewayService service = new RealtimeGatewayService(
+		RealtimeGatewayService service = service(
 			provider,
 			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
 		);
@@ -47,7 +52,7 @@ class RealtimeGatewayServiceTest {
 	@DisplayName("같은 도착 요청의 동시 cache miss는 provider 호출을 공유한다")
 	void concurrentArrivalMissesShareProviderCall() throws Exception {
 		BlockingProvider provider = new BlockingProvider();
-		RealtimeGatewayService service = new RealtimeGatewayService(
+		RealtimeGatewayService service = service(
 			provider,
 			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
 		);
@@ -79,7 +84,7 @@ class RealtimeGatewayServiceTest {
 	@DisplayName("같은 열차 위치 요청의 동시 cache miss는 provider 호출을 공유한다")
 	void concurrentTrainPositionMissesShareProviderCall() throws Exception {
 		BlockingProvider provider = new BlockingProvider();
-		RealtimeGatewayService service = new RealtimeGatewayService(
+		RealtimeGatewayService service = service(
 			provider,
 			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
 		);
@@ -112,7 +117,7 @@ class RealtimeGatewayServiceTest {
 	void timeoutServesStaleCache() {
 		MutableClock clock = new MutableClock(Instant.parse("2026-06-26T08:00:00Z"));
 		CountingProvider provider = new CountingProvider();
-		RealtimeGatewayService service = new RealtimeGatewayService(provider, clock);
+		RealtimeGatewayService service = service(provider, clock);
 		RealtimeQuery query = sangnoksuQuery();
 
 		service.arrivals(query);
@@ -130,7 +135,7 @@ class RealtimeGatewayServiceTest {
 	void staleProviderTimestampDoesNotReturnFreshArrivals() {
 		CountingProvider provider = new CountingProvider();
 		provider.providerReceivedAt = "2026-06-26T07:58:00Z";
-		RealtimeGatewayService service = new RealtimeGatewayService(
+		RealtimeGatewayService service = service(
 			provider,
 			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
 		);
@@ -147,7 +152,7 @@ class RealtimeGatewayServiceTest {
 	void providerTimestampDelayAdjustsArrivalEta() {
 		CountingProvider provider = new CountingProvider();
 		provider.providerReceivedAt = "2026-06-26T07:59:30Z";
-		RealtimeGatewayService service = new RealtimeGatewayService(
+		RealtimeGatewayService service = service(
 			provider,
 			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
 		);
@@ -164,7 +169,7 @@ class RealtimeGatewayServiceTest {
 	void quotaExhaustionOpensCircuit() {
 		MutableClock clock = new MutableClock(Instant.parse("2026-06-26T08:00:00Z"));
 		CountingProvider provider = new CountingProvider();
-		RealtimeGatewayService service = new RealtimeGatewayService(provider, clock);
+		RealtimeGatewayService service = service(provider, clock);
 		RealtimeQuery query = sangnoksuQuery();
 		provider.failureCode = "PROVIDER_QUOTA_EXCEEDED";
 
@@ -182,7 +187,7 @@ class RealtimeGatewayServiceTest {
 	void trainPositionQuotaExhaustionOpensCircuit() {
 		MutableClock clock = new MutableClock(Instant.parse("2026-06-26T08:00:00Z"));
 		CountingProvider provider = new CountingProvider();
-		RealtimeGatewayService service = new RealtimeGatewayService(provider, clock);
+		RealtimeGatewayService service = service(provider, clock);
 		RealtimeQuery query = line4Query();
 		provider.failureCode = "PROVIDER_QUOTA_EXCEEDED";
 
@@ -199,7 +204,7 @@ class RealtimeGatewayServiceTest {
 	@DisplayName("지원 범위 밖 역은 provider를 호출하지 않고 unsupported로 끝난다")
 	void unsupportedSkipsProviderCall() {
 		CountingProvider provider = new CountingProvider();
-		RealtimeGatewayService service = new RealtimeGatewayService(
+		RealtimeGatewayService service = service(
 			provider,
 			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
 		);
@@ -213,51 +218,150 @@ class RealtimeGatewayServiceTest {
 		));
 
 		assertThat(result.status()).hasToString("UNSUPPORTED");
-		assertThat(result.fallbackCode()).isEqualTo("UNSUPPORTED_REGION");
+		assertThat(result.fallbackCode()).isEqualTo("MAPPING_MISSING");
 		assertThat(provider.arrivalCalls).hasValue(0);
 	}
 
 	@Test
-	@DisplayName("불일치한 역 query 조합은 provider를 호출하지 않고 unsupported로 끝난다")
+	@DisplayName("실시간 mapping이 없는 도착 요청은 provider를 호출하지 않고 MAPPING_MISSING으로 끝난다")
+	void missingArrivalMappingSkipsProviderCall() {
+		CountingProvider provider = new CountingProvider();
+		StubMappingPort mappingPort = new StubMappingPort();
+		RealtimeGatewayService service = service(
+			provider,
+			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC),
+			mappingPort
+		);
+
+		RealtimeArrivalResult result = service.arrivals(new RealtimeQuery(
+			"station-sadang",
+			"seoul-4",
+			null,
+			"사당",
+			null
+		));
+
+		assertThat(result.status()).hasToString("UNSUPPORTED");
+		assertThat(result.fallbackCode()).isEqualTo("MAPPING_MISSING");
+		assertThat(provider.arrivalCalls).hasValue(0);
+	}
+
+	@Test
+	@DisplayName("도착 mapping이 arrivals를 지원하지 않으면 provider를 호출하지 않는다")
+	void unsupportedArrivalCapabilitySkipsProviderCall() {
+		CountingProvider provider = new CountingProvider();
+		StubMappingPort mappingPort = new StubMappingPort();
+		mappingPort.add(mapping("station-sadang", "seoul-4", "2004", "1004000433", "사당", false, true, "OFFICIAL"));
+		RealtimeGatewayService service = service(
+			provider,
+			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC),
+			mappingPort
+		);
+
+		RealtimeArrivalResult result = service.arrivals(new RealtimeQuery(
+			"station-sadang",
+			"seoul-4",
+			null,
+			"사당",
+			null
+		));
+
+		assertThat(result.status()).hasToString("UNSUPPORTED");
+		assertThat(result.fallbackCode()).isEqualTo("UNSUPPORTED_CAPABILITY");
+		assertThat(provider.arrivalCalls).hasValue(0);
+	}
+
+	@Test
+	@DisplayName("HEURISTIC/UNKNOWN 도착 mapping은 production live query에서 provider를 호출하지 않는다")
+	void lowConfidenceArrivalMappingSkipsProviderCall() {
+		CountingProvider provider = new CountingProvider();
+		StubMappingPort mappingPort = new StubMappingPort();
+		mappingPort.add(mapping("station-sadang", "seoul-4", "1004", "1004000433", "사당", true, true, "HEURISTIC"));
+		RealtimeGatewayService service = service(
+			provider,
+			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC),
+			mappingPort
+		);
+
+		RealtimeArrivalResult result = service.arrivals(new RealtimeQuery(
+			"station-sadang",
+			"seoul-4",
+			null,
+			"사당",
+			null
+		));
+
+		assertThat(result.status()).hasToString("UNSUPPORTED");
+		assertThat(result.fallbackCode()).isEqualTo("MAPPING_LOW_CONFIDENCE");
+		assertThat(provider.arrivalCalls).hasValue(0);
+	}
+
+	@Test
+	@DisplayName("도착 요청은 provider station query alias를 사용한다")
+	void arrivalUsesProviderStationQueryAlias() {
+		CapturingProvider provider = new CapturingProvider();
+		StubMappingPort mappingPort = new StubMappingPort();
+		mappingPort.add(mapping("station-sadang", "seoul-4", "1004", "1004000433", "사당역", true, true, "OFFICIAL"));
+		RealtimeGatewayService service = service(
+			provider,
+			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC),
+			mappingPort
+		);
+
+		RealtimeArrivalResult result = service.arrivals(new RealtimeQuery(
+			"station-sadang",
+			"seoul-4",
+			null,
+			"사당",
+			null
+		));
+
+		assertThat(result.status()).hasToString("FRESH");
+		assertThat(provider.lastArrivalQuery.stationQueryName()).isEqualTo("사당역");
+		assertThat(provider.lastArrivalQuery.providerLineId()).isEqualTo("1004");
+	}
+
+	@Test
+	@DisplayName("불일치한 provider line 도착 query는 provider를 호출하지 않고 mapping missing으로 끝난다")
 	void mismatchedArrivalQuerySkipsProviderCall() {
 		CountingProvider provider = new CountingProvider();
-		RealtimeGatewayService service = new RealtimeGatewayService(
+		RealtimeGatewayService service = service(
 			provider,
 			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
 		);
 
 		RealtimeArrivalResult result = service.arrivals(new RealtimeQuery(
 			"station-sangnoksu",
-			"4",
-			"1004",
-			"서울",
+			"seoul-4",
+			"9999",
+			"상록수",
 			null
 		));
 
 		assertThat(result.status()).hasToString("UNSUPPORTED");
-		assertThat(result.fallbackCode()).isEqualTo("UNSUPPORTED_REGION");
+		assertThat(result.fallbackCode()).isEqualTo("MAPPING_MISSING");
 		assertThat(provider.arrivalCalls).hasValue(0);
 	}
 
 	@Test
-	@DisplayName("불일치한 열차 위치 query 조합은 provider를 호출하지 않고 unsupported로 끝난다")
+	@DisplayName("불일치한 provider line 열차 위치 query는 provider를 호출하지 않고 mapping missing으로 끝난다")
 	void mismatchedTrainPositionQuerySkipsProviderCall() {
 		CountingProvider provider = new CountingProvider();
-		RealtimeGatewayService service = new RealtimeGatewayService(
+		RealtimeGatewayService service = service(
 			provider,
 			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
 		);
 
 		RealtimeTrainPositionResult result = service.trainPositions(new RealtimeQuery(
 			null,
-			"4",
-			"1004",
+			"seoul-4",
+			"9999",
 			null,
-			"1호선"
+			"4호선"
 		));
 
 		assertThat(result.status()).hasToString("UNSUPPORTED");
-		assertThat(result.fallbackCode()).isEqualTo("UNSUPPORTED_REGION");
+		assertThat(result.fallbackCode()).isEqualTo("MAPPING_MISSING");
 		assertThat(provider.trainPositionCalls).hasValue(0);
 	}
 
@@ -265,7 +369,7 @@ class RealtimeGatewayServiceTest {
 	@DisplayName("provider empty 결과는 quota circuit을 열지 않는다")
 	void emptyProviderResultDoesNotOpenQuotaCircuit() {
 		CountingProvider provider = new CountingProvider();
-		RealtimeGatewayService service = new RealtimeGatewayService(
+		RealtimeGatewayService service = service(
 			provider,
 			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
 		);
@@ -459,14 +563,86 @@ class RealtimeGatewayServiceTest {
 	}
 
 	private RealtimeQuery sangnoksuQuery() {
-		return new RealtimeQuery("station-sangnoksu", "4", "1004", "상록수", null);
+		return new RealtimeQuery("station-sangnoksu", "seoul-4", "1004", "상록수", null);
 	}
 
 	private RealtimeQuery line4Query() {
-		return new RealtimeQuery(null, "4", "1004", null, "4호선");
+		return new RealtimeQuery(null, "seoul-4", "1004", null, "4호선");
 	}
 
-	private static final class CountingProvider implements RealtimeProvider {
+	private RealtimeGatewayService service(RealtimeProvider provider, Clock clock) {
+		return service(provider, clock, InMemoryRealtimeMappingPort.seededFixture());
+	}
+
+	private RealtimeGatewayService service(RealtimeProvider provider, Clock clock, RealtimeMappingPort mappingPort) {
+		return new RealtimeGatewayService(provider, clock, mappingPort);
+	}
+
+	private RealtimeMapping mapping(
+		String stationId,
+		String lineId,
+		String providerLineId,
+		String providerStationId,
+		String queryName,
+		boolean supportsArrivals,
+		boolean supportsTrainPositions,
+		String mappingConfidence
+	) {
+		return new RealtimeMapping(
+			"seoul-topis",
+			stationId,
+			lineId,
+			providerLineId,
+			providerStationId,
+			queryName,
+			"4호선",
+			supportsArrivals,
+			supportsTrainPositions,
+			mappingConfidence,
+			1L
+		);
+	}
+
+	private static final class StubMappingPort implements RealtimeMappingPort {
+		private final Map<String, RealtimeMapping> mappings = new HashMap<>();
+
+		private void add(RealtimeMapping mapping) {
+			mappings.put(arrivalKey(mapping.stationId(), mapping.lineId()), mapping);
+			mappings.put(lineKey(mapping.lineId()), mapping);
+		}
+
+		@Override
+		public Optional<RealtimeMapping> findArrivalMapping(String providerId, RealtimeQuery query) {
+			return Optional.ofNullable(mappings.get(arrivalKey(query.stationId(), query.lineId())))
+				.filter((mapping) -> providerId.equals(mapping.providerId()));
+		}
+
+		@Override
+		public Optional<RealtimeMapping> findTrainPositionMapping(String providerId, RealtimeQuery query) {
+			return Optional.ofNullable(mappings.get(lineKey(query.lineId())))
+				.filter((mapping) -> providerId.equals(mapping.providerId()));
+		}
+
+		private static String arrivalKey(String stationId, String lineId) {
+			return "%s:%s".formatted(stationId, lineId);
+		}
+
+		private static String lineKey(String lineId) {
+			return lineId;
+		}
+	}
+
+	private static final class CapturingProvider extends CountingProvider {
+		private RealtimeQuery lastArrivalQuery;
+
+		@Override
+		public List<RealtimeArrival> arrivals(RealtimeQuery query) {
+			lastArrivalQuery = query;
+			return super.arrivals(query);
+		}
+	}
+
+	private static class CountingProvider implements RealtimeProvider {
 		private final AtomicInteger arrivalCalls = new AtomicInteger();
 		private final AtomicInteger trainPositionCalls = new AtomicInteger();
 		private String failureCode;

--- a/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
@@ -322,6 +322,27 @@ class RealtimeGatewayServiceTest {
 	}
 
 	@Test
+	@DisplayName("도착 요청은 TOPIS station code providerLineId alias를 유지한다")
+	void arrivalAcceptsStationCodeProviderLineAlias() {
+		CountingProvider provider = new CountingProvider();
+		RealtimeGatewayService service = service(
+			provider,
+			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
+		);
+
+		RealtimeArrivalResult result = service.arrivals(new RealtimeQuery(
+			"station-sangnoksu",
+			"seoul-4",
+			"448",
+			"상록수",
+			null
+		));
+
+		assertThat(result.status()).hasToString("FRESH");
+		assertThat(provider.arrivalCalls).hasValue(1);
+	}
+
+	@Test
 	@DisplayName("불일치한 provider line 도착 query는 provider를 호출하지 않고 mapping missing으로 끝난다")
 	void mismatchedArrivalQuerySkipsProviderCall() {
 		CountingProvider provider = new CountingProvider();
@@ -363,6 +384,27 @@ class RealtimeGatewayServiceTest {
 		assertThat(result.status()).hasToString("UNSUPPORTED");
 		assertThat(result.fallbackCode()).isEqualTo("MAPPING_MISSING");
 		assertThat(provider.trainPositionCalls).hasValue(0);
+	}
+
+	@Test
+	@DisplayName("lineId 없는 열차 위치 요청은 provider line name으로 mapping을 찾는다")
+	void trainPositionWithoutLineIdUsesProviderLineNameMapping() {
+		CountingProvider provider = new CountingProvider();
+		RealtimeGatewayService service = service(
+			provider,
+			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
+		);
+
+		RealtimeTrainPositionResult result = service.trainPositions(new RealtimeQuery(
+			null,
+			null,
+			"1004",
+			null,
+			"4호선"
+		));
+
+		assertThat(result.status()).hasToString("FRESH");
+		assertThat(provider.trainPositionCalls).hasValue(1);
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
@@ -343,6 +343,27 @@ class RealtimeGatewayServiceTest {
 	}
 
 	@Test
+	@DisplayName("도착 요청은 legacy shorthand lineId를 유지한다")
+	void arrivalAcceptsLegacyShorthandLineId() {
+		CountingProvider provider = new CountingProvider();
+		RealtimeGatewayService service = service(
+			provider,
+			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
+		);
+
+		RealtimeArrivalResult result = service.arrivals(new RealtimeQuery(
+			"station-sangnoksu",
+			"4",
+			"448",
+			"상록수",
+			null
+		));
+
+		assertThat(result.status()).hasToString("FRESH");
+		assertThat(provider.arrivalCalls).hasValue(1);
+	}
+
+	@Test
 	@DisplayName("불일치한 provider line 도착 query는 provider를 호출하지 않고 mapping missing으로 끝난다")
 	void mismatchedArrivalQuerySkipsProviderCall() {
 		CountingProvider provider = new CountingProvider();
@@ -398,6 +419,27 @@ class RealtimeGatewayServiceTest {
 		RealtimeTrainPositionResult result = service.trainPositions(new RealtimeQuery(
 			null,
 			null,
+			"1004",
+			null,
+			"4호선"
+		));
+
+		assertThat(result.status()).hasToString("FRESH");
+		assertThat(provider.trainPositionCalls).hasValue(1);
+	}
+
+	@Test
+	@DisplayName("열차 위치 요청은 legacy shorthand lineId를 유지한다")
+	void trainPositionAcceptsLegacyShorthandLineId() {
+		CountingProvider provider = new CountingProvider();
+		RealtimeGatewayService service = service(
+			provider,
+			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
+		);
+
+		RealtimeTrainPositionResult result = service.trainPositions(new RealtimeQuery(
+			null,
+			"4",
 			"1004",
 			null,
 			"4호선"


### PR DESCRIPTION
## 관련 이슈

close #1216

## 작업 배경

- TOPIS 실시간 gateway가 상록수/4호선 조합을 코드 상수로만 normalize해서 provider별 역/노선 mapping, capability, confidence, cache version을 운영 데이터로 제어할 수 없었습니다.

## 작업 내용

- `RealtimeMappingPort`와 `RealtimeMapping`을 추가해 실시간 provider mapping 조회 경계를 만들었습니다.
- 운영 profile용 JDBC mapping repository와 비운영 profile용 seed fixture adapter를 추가했습니다.
- `V31__realtime_provider_mappings.sql`에서 provider line/station mapping 테이블과 상록수 `seoul-4` seed를 추가했습니다.
- gateway normalize 로직을 mapping lookup 기반으로 바꾸고 `MAPPING_MISSING`, `UNSUPPORTED_CAPABILITY`, `MAPPING_LOW_CONFIDENCE`를 분리했습니다.
- mapping cache version을 arrival/train-position cache key에 포함했습니다.
- 기존 입력 호환성인 `providerLineId=448`, `lineId=4`, lineId 없는 `lineName=4호선` 요청을 mapping lookup에서 보존했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests '*RealtimeGatewayServiceTest' --tests '*RealtimeMapping*' --tests '*RealtimeControllerTest' --tests '*Migration*'` → BUILD SUCCESSFUL
  - `node --test tools/datapack/datapack-tools.test.mjs` → 143 pass, 0 fail
  - `node --test tools/ci/*.test.mjs` → 159 pass, 0 fail
  - `git diff --check` → 통과
  - PR CI #1307 → Backend CI, Repository CI, Release Gate Consistency, Backend Release Image, SonarCloud, OSV 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Realtime mapping gateway | Backend | Gradle targeted tests | 로컬 명령 출력 | 통과 |
| Datapack realtime schema contract | Node | datapack tools tests | 로컬 명령 출력 | 통과 |
| Repository CI contract | Node | tools/ci tests | 로컬 명령 출력 | 통과 |
| PR CI | GitHub Actions | `gh pr checks 1307` | https://github.com/AquilaXk/easysubway/actions/runs/28471845122 | 통과 |
| UI/접근성 증거 | 해당 없음 | backend mapping/DB 변경이며 화면 변경 없음 | 증거 불필요 | 해당 없음 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [x] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: provider mapping DB/port, fallback code, cache key, legacy alias compatibility contract 변경
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RealtimeGatewayService`의 mapping 기반 normalize/fallback 분기
  - `JdbcRealtimeMappingRepository`의 confidence/capability/valid window/alias 조회
  - `V31__realtime_provider_mappings.sql`의 seed와 constraint
- CodeRabbit은 review limit reached 상태라 Codex CLI fallback review를 게시했습니다.
- Codex fallback actionables:
  - `119e26f2`: TOPIS station-code alias와 lineId 없는 train-position lookup 보존
  - `a1cca289`: legacy shorthand `lineId=4` alias 보존

## 리스크

- 운영 profile에서는 V31 migration seed가 없거나 confidence가 `HEURISTIC`/`UNKNOWN`이면 live provider 호출이 닫힙니다.
- TOPIS station-code alias는 provider station id suffix로 보존했습니다. 다른 provider에서 alias 규칙이 달라지면 explicit alias column으로 승격해야 합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
