### PR TITLE
[Fix] 경로 요약 색상 토큰 정리

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -47,6 +47,7 @@ const _routeControlBorderColor = Color(0xFF9DB6BA);
 const _routeSoftPanelColor = Color(0xFFE9F5F6);
 const _routeSoftPanelBorderColor = Color(0xFFB9D4D8);
 const _routeGuidanceDarkColor = Color(0xFF073245);
+const _routeGuidanceSecondaryColor = Color(0xFFC7D8E3);
 const _routeBlockedBorderColor = Color(0xFFEFCCCC);
 const _routeCardShadowColor = Color(0x0F071B2F);
 const _routeAccentShadowColor = Color(0x1A0D8A6D);
@@ -3481,7 +3482,10 @@ class _RouteDarkSummaryCard extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 4),
-            Text(subtitle, style: const TextStyle(color: Color(0xFFC7D8E3))),
+            Text(
+              subtitle,
+              style: const TextStyle(color: _routeGuidanceSecondaryColor),
+            ),
             const SizedBox(height: 12),
             Wrap(
               spacing: 6,


### PR DESCRIPTION
## Summary
- move the route dark summary subtitle color into a local route_search.dart token
- keep route result UI behavior unchanged while removing the last inline Color(0x...) use outside route_search.dart constants

## Verification
- dart format lib/route_search.dart
- git diff --check
- flutter analyze lib/route_search.dart
- flutter test test/widget_test.dart --name "경로 검색 화면은 쉬운 경로 결과와 경고를 보여준다" --reporter expanded

Issue: #1075