### PR TITLE
[Docs] Route Commercialization E-1 Routing Core V2 ADR 추가

### DIFF
--- a/tools/routes/algorithm-fixtures/route-v2-fixtures.json
+++ b/tools/routes/algorithm-fixtures/route-v2-fixtures.json
@@ -1,0 +1,428 @@
+{
+  "schemaVersion": 1,
+  "timezone": "Asia/Seoul",
+  "transferSlackSeconds": 180,
+  "paretoLimit": 3,
+  "calendarDates": {
+    "2026-07-02": ["holiday_removed"]
+  },
+  "transfers": [
+    {
+      "from": "sadang_l4",
+      "to": "sadang_l2",
+      "durationSeconds": 600,
+      "stepFree": true,
+      "verified": true
+    },
+    {
+      "from": "gangnam_l2",
+      "to": "gangnam_shin",
+      "durationSeconds": 240,
+      "stepFree": true,
+      "verified": true
+    },
+    {
+      "from": "pareto_mid_l1",
+      "to": "pareto_mid_l2",
+      "durationSeconds": 60,
+      "stepFree": true,
+      "verified": true
+    },
+    {
+      "from": "stairs_l4",
+      "to": "stairs_l2",
+      "durationSeconds": 180,
+      "stepFree": false,
+      "verified": true
+    },
+    {
+      "from": "stepfree_l4",
+      "to": "stepfree_l2",
+      "durationSeconds": 420,
+      "stepFree": true,
+      "verified": true
+    }
+  ],
+  "trips": [
+    {
+      "id": "l4-local-0900",
+      "lineId": "line-4",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["sangnoksu_l4", "09:00", "09:00"],
+        ["banwol_l4", "09:08", "09:08"],
+        ["sadang_l4", "09:35", "09:35"]
+      ]
+    },
+    {
+      "id": "l4-local-0905",
+      "lineId": "line-4",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["sangnoksu_l4", "09:05", "09:05"],
+        ["banwol_l4", "09:13", "09:13"],
+        ["sadang_l4", "09:40", "09:40"]
+      ]
+    },
+    {
+      "id": "l4-express-0903",
+      "lineId": "line-4",
+      "service": "daily",
+      "pattern": "express",
+      "stops": [
+        ["sangnoksu_l4", "09:03", "09:03"],
+        ["sadang_l4", "09:24", "09:24"]
+      ]
+    },
+    {
+      "id": "l4-express-0925",
+      "lineId": "line-4",
+      "service": "daily",
+      "pattern": "express",
+      "stops": [
+        ["sangnoksu_l4", "09:25", "09:25"],
+        ["sadang_l4", "09:50", "09:50"]
+      ]
+    },
+    {
+      "id": "l2-missed-0936",
+      "lineId": "line-2",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["sadang_l2", "09:36", "09:36"],
+        ["gangnam_l2", "09:48", "09:48"],
+        ["jamsil_l2", "10:08", "10:08"]
+      ]
+    },
+    {
+      "id": "l2-local-0945",
+      "lineId": "line-2",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["sadang_l2", "09:45", "09:45"],
+        ["gangnam_l2", "09:57", "09:57"],
+        ["jamsil_l2", "10:17", "10:17"]
+      ]
+    },
+    {
+      "id": "shin-local-1005",
+      "lineId": "shinbundang",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["gangnam_shin", "10:05", "10:05"],
+        ["pangyo_shin", "10:22", "10:22"]
+      ]
+    },
+    {
+      "id": "l4-stairs-0910",
+      "lineId": "line-4",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["origin_l4", "09:10", "09:10"],
+        ["stairs_l4", "09:20", "09:20"],
+        ["stepfree_l4", "09:35", "09:35"]
+      ]
+    },
+    {
+      "id": "l2-stairs-0924",
+      "lineId": "line-2",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["stairs_l2", "09:24", "09:24"],
+        ["destination_l2", "09:34", "09:34"]
+      ]
+    },
+    {
+      "id": "l2-stepfree-0945",
+      "lineId": "line-2",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["stepfree_l2", "09:45", "09:45"],
+        ["destination_l2", "09:55", "09:55"]
+      ]
+    },
+    {
+      "id": "l4-last-2350",
+      "lineId": "line-4",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["late_a_l4", "23:50", "23:50"],
+        ["late_b_l4", "24:05", "24:05"]
+      ]
+    },
+    {
+      "id": "l4-first-2410",
+      "lineId": "line-4",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["late_a_l4", "24:10", "24:10"],
+        ["late_b_l4", "24:25", "24:25"]
+      ]
+    },
+    {
+      "id": "holiday-removed-0900",
+      "lineId": "line-h",
+      "service": "holiday_removed",
+      "pattern": "local",
+      "stops": [
+        ["holiday_a", "09:00", "09:00"],
+        ["holiday_b", "09:10", "09:10"]
+      ]
+    },
+    {
+      "id": "holiday-daily-0915",
+      "lineId": "line-h",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["holiday_a", "09:15", "09:15"],
+        ["holiday_b", "09:25", "09:25"]
+      ]
+    },
+    {
+      "id": "freq-0900",
+      "lineId": "line-f",
+      "service": "daily",
+      "pattern": "frequency",
+      "stops": [
+        ["freq_a", "09:00", "09:00"],
+        ["freq_b", "09:12", "09:12"]
+      ]
+    },
+    {
+      "id": "freq-0910",
+      "lineId": "line-f",
+      "service": "daily",
+      "pattern": "frequency",
+      "stops": [
+        ["freq_a", "09:10", "09:10"],
+        ["freq_b", "09:22", "09:22"]
+      ]
+    },
+    {
+      "id": "fresh-0902",
+      "lineId": "line-r",
+      "service": "daily",
+      "pattern": "local",
+      "realtime": "fresh",
+      "stops": [
+        ["rt_a", "09:02", "09:02"],
+        ["rt_b", "09:17", "09:17"]
+      ]
+    },
+    {
+      "id": "stale-0900",
+      "lineId": "line-r",
+      "service": "daily",
+      "pattern": "local",
+      "realtime": "stale",
+      "stops": [
+        ["rt_a", "09:00", "09:00"],
+        ["rt_b", "09:15", "09:15"]
+      ]
+    },
+    {
+      "id": "pareto-direct-0900",
+      "lineId": "line-p",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["pareto_a", "09:00", "09:00"],
+        ["pareto_b", "09:30", "09:30"]
+      ]
+    },
+    {
+      "id": "pareto-leg1-0900",
+      "lineId": "line-p1",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["pareto_a", "09:00", "09:00"],
+        ["pareto_mid_l1", "09:10", "09:10"]
+      ]
+    },
+    {
+      "id": "pareto-leg2-0915",
+      "lineId": "line-p2",
+      "service": "daily",
+      "pattern": "local",
+      "stops": [
+        ["pareto_mid_l2", "09:15", "09:15"],
+        ["pareto_b", "09:25", "09:25"]
+      ]
+    }
+  ],
+  "queries": [
+    {
+      "id": "direct_timetable_route",
+      "origin": "sangnoksu_l4",
+      "destination": "sadang_l4",
+      "departure": "2026-07-01T08:58:00+09:00",
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": "09:24",
+      "expectedTransfers": 0,
+      "expectedTripIds": ["l4-express-0903"]
+    },
+    {
+      "id": "one_transfer",
+      "origin": "sangnoksu_l4",
+      "destination": "jamsil_l2",
+      "departure": "2026-07-01T08:58:00+09:00",
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": "10:17",
+      "expectedTransfers": 1,
+      "expectedTripIds": ["l4-express-0903", "l2-local-0945"]
+    },
+    {
+      "id": "two_transfer",
+      "origin": "sangnoksu_l4",
+      "destination": "pangyo_shin",
+      "departure": "2026-07-01T08:58:00+09:00",
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": "10:22",
+      "expectedTransfers": 2,
+      "expectedTripIds": ["l4-express-0903", "l2-local-0945", "shin-local-1005"]
+    },
+    {
+      "id": "express_beats_local",
+      "origin": "sangnoksu_l4",
+      "destination": "sadang_l4",
+      "departure": "2026-07-01T09:00:00+09:00",
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": "09:24",
+      "expectedTransfers": 0,
+      "expectedTripIds": ["l4-express-0903"]
+    },
+    {
+      "id": "missed_express_makes_local_faster",
+      "origin": "sangnoksu_l4",
+      "destination": "sadang_l4",
+      "departure": "2026-07-01T09:04:00+09:00",
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": "09:40",
+      "expectedTransfers": 0,
+      "expectedTripIds": ["l4-local-0905"]
+    },
+    {
+      "id": "transfer_buffer_too_short_selects_next_train",
+      "origin": "sangnoksu_l4",
+      "destination": "gangnam_l2",
+      "departure": "2026-07-01T08:58:00+09:00",
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": "09:57",
+      "expectedTransfers": 1,
+      "expectedTripIds": ["l4-express-0903", "l2-local-0945"]
+    },
+    {
+      "id": "strict_step_free_excludes_transfer",
+      "origin": "origin_l4",
+      "destination": "destination_l2",
+      "departure": "2026-07-01T09:00:00+09:00",
+      "constraintMode": "STRICT_STEP_FREE",
+      "expectedArrival": "09:55",
+      "expectedTransfers": 1,
+      "expectedTripIds": ["l4-stairs-0910", "l2-stepfree-0945"]
+    },
+    {
+      "id": "last_train_missed",
+      "origin": "late_a_l4",
+      "destination": "late_b_l4",
+      "departure": "2026-07-01T23:55:00+09:00",
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": "24:25",
+      "expectedTransfers": 0,
+      "expectedTripIds": ["l4-first-2410"]
+    },
+    {
+      "id": "first_train_next_day",
+      "origin": "late_a_l4",
+      "destination": "late_b_l4",
+      "departure": "2026-07-01T24:00:00+09:00",
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": "24:25",
+      "expectedTransfers": 0,
+      "expectedTripIds": ["l4-first-2410"]
+    },
+    {
+      "id": "service_calendar_holiday_removed",
+      "origin": "holiday_a",
+      "destination": "holiday_b",
+      "departure": "2026-07-02T08:50:00+09:00",
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": "09:25",
+      "expectedTransfers": 0,
+      "expectedTripIds": ["holiday-daily-0915"]
+    },
+    {
+      "id": "frequency_based_service",
+      "origin": "freq_a",
+      "destination": "freq_b",
+      "departure": "2026-07-01T09:03:00+09:00",
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": "09:22",
+      "expectedTransfers": 0,
+      "expectedTripIds": ["freq-0910"]
+    },
+    {
+      "id": "same_eta_fewer_transfers",
+      "origin": "sangnoksu_l4",
+      "destination": "sadang_l4",
+      "departure": "2026-07-01T09:00:00+09:00",
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": "09:24",
+      "expectedTransfers": 0,
+      "expectedTripIds": ["l4-express-0903"]
+    },
+    {
+      "id": "slower_but_strict_step_free_verified",
+      "origin": "origin_l4",
+      "destination": "destination_l2",
+      "departure": "2026-07-01T09:00:00+09:00",
+      "constraintMode": "STRICT_STEP_FREE",
+      "expectedArrival": "09:55",
+      "expectedTransfers": 1,
+      "expectedTripIds": ["l4-stairs-0910", "l2-stepfree-0945"]
+    },
+    {
+      "id": "pareto_arrival_vs_transfer",
+      "origin": "pareto_a",
+      "destination": "pareto_b",
+      "departure": "2026-07-01T08:58:00+09:00",
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": "09:25",
+      "expectedTransfers": 1,
+      "expectedTripIds": ["pareto-leg1-0900", "pareto-leg2-0915"]
+    },
+    {
+      "id": "provider_realtime_stale",
+      "origin": "rt_a",
+      "destination": "rt_b",
+      "departure": "2026-07-01T08:59:00+09:00",
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": "09:17",
+      "expectedTransfers": 0,
+      "expectedTripIds": ["fresh-0902"]
+    },
+    {
+      "id": "provider_realtime_fresh_but_not_boardable_due_to_entry_slack",
+      "origin": "rt_a",
+      "destination": "rt_b",
+      "departure": "2026-07-01T09:01:00+09:00",
+      "entrySlackSeconds": 120,
+      "constraintMode": "ALLOW_UNKNOWN",
+      "expectedArrival": null,
+      "expectedTransfers": null,
+      "expectedTripIds": []
+    }
+  ]
+}

--- a/tools/routes/algorithm-fixtures/route-v2-fixtures.json
+++ b/tools/routes/algorithm-fixtures/route-v2-fixtures.json
@@ -1,6 +1,7 @@
 {
   "schemaVersion": 1,
   "timezone": "Asia/Seoul",
+  "serviceDayCutoffHour": 3,
   "transferSlackSeconds": 180,
   "paretoLimit": 3,
   "calendarDates": {
@@ -270,6 +271,7 @@
       "departure": "2026-07-01T08:58:00+09:00",
       "constraintMode": "ALLOW_UNKNOWN",
       "expectedArrival": "09:24",
+      "expectedDurationSeconds": 1560,
       "expectedTransfers": 0,
       "expectedTripIds": ["l4-express-0903"]
     },
@@ -347,7 +349,7 @@
       "id": "first_train_next_day",
       "origin": "late_a_l4",
       "destination": "late_b_l4",
-      "departure": "2026-07-01T24:00:00+09:00",
+      "departure": "2026-07-02T00:00:00+09:00",
       "constraintMode": "ALLOW_UNKNOWN",
       "expectedArrival": "24:25",
       "expectedTransfers": 0,

--- a/tools/routes/prototype-route-v2.mjs
+++ b/tools/routes/prototype-route-v2.mjs
@@ -25,15 +25,15 @@ export function runAll(fixtures) {
     fixtureCount: fixtures.queries.length,
     results: fixtures.queries.map((query) => ({
       queryId: query.id,
-      raptor: runRangeRaptor(fixtures, query)[0] ?? null,
-      timeDependentDijkstra: runTimeDependentDijkstra(fixtures, query)[0] ?? null,
+      raptor: runRangeRaptor(fixtures, query),
+      timeDependentDijkstra: runTimeDependentDijkstra(fixtures, query),
     })),
   };
 }
 
 export function runRangeRaptor(fixtures, query) {
   const start = departureMinute(fixtures, query);
-  const labelsByRound = [new Map([[query.origin, [label(query.origin, start)]]])];
+  const labelsByRound = [new Map([[query.origin, [label(query.origin, start, start)]]])];
 
   for (let round = 0; round <= maxTransfers(query); round += 1) {
     const current = cloneLabels(labelsByRound[round] ?? new Map());
@@ -42,12 +42,12 @@ export function runRangeRaptor(fixtures, query) {
     labelsByRound[round + 1] = mergeMaps(labelsByRound[round + 1], current, fixtures.paretoLimit);
   }
 
-  return alternatives(labelsByRound.at(-1)?.get(query.destination) ?? [], fixtures.paretoLimit, start);
+  return alternatives(labelsByRound.at(-1)?.get(query.destination) ?? [], fixtures.paretoLimit);
 }
 
 export function runTimeDependentDijkstra(fixtures, query) {
   const start = departureMinute(fixtures, query);
-  let queue = [label(query.origin, start)];
+  let queue = [label(query.origin, start, start)];
   const best = new Map([[query.origin, queue]]);
 
   while (queue.length > 0) {
@@ -62,7 +62,7 @@ export function runTimeDependentDijkstra(fixtures, query) {
     }
   }
 
-  return alternatives(best.get(query.destination) ?? [], fixtures.paretoLimit, start);
+  return alternatives(best.get(query.destination) ?? [], fixtures.paretoLimit);
 }
 
 function normalize(fixtures) {
@@ -91,7 +91,7 @@ function scanTrips(fixtures, query, labels, round) {
     let boarded = null;
     for (const stop of trip.stops) {
       for (const previous of labels.get(stop.station) ?? []) {
-        if (previous.boardings === round && canBoard(fixtures, query, previous, stop)) {
+        if (canBoardAtRound(fixtures, query, previous, stop, round)) {
           boarded = betterBoarding(boarded, previous, stop);
         }
       }
@@ -99,6 +99,7 @@ function scanTrips(fixtures, query, labels, round) {
       addLabel(labels, {
         station: stop.station,
         time: stop.arrival,
+        startTime: boarded.label.startTime,
         boardings: boarded.label.boardings + 1,
         path: [...boarded.label.path, leg(trip, boarded.stop, stop)],
       }, fixtures.paretoLimit);
@@ -116,6 +117,7 @@ function scanTransfers(fixtures, query, labels) {
         changed = addLabel(labels, {
           station: transfer.to,
           time: previous.time + Math.ceil(transfer.durationSeconds / 60),
+          startTime: previous.startTime,
           boardings: previous.boardings,
           path: [...previous.path, { type: "transfer", from: transfer.from, to: transfer.to, durationSeconds: transfer.durationSeconds }],
         }, fixtures.paretoLimit) || changed;
@@ -132,6 +134,7 @@ function nextLabels(fixtures, query, current) {
     next.push({
       station: transfer.to,
       time: current.time + Math.ceil(transfer.durationSeconds / 60),
+      startTime: current.startTime,
       boardings: current.boardings,
       path: [...current.path, { type: "transfer", from: transfer.from, to: transfer.to, durationSeconds: transfer.durationSeconds }],
     });
@@ -146,6 +149,7 @@ function nextLabels(fixtures, query, current) {
       next.push({
         station: to.station,
         time: to.arrival,
+        startTime: current.startTime,
         boardings: current.boardings + 1,
         path: [...current.path, leg(trip, from, to)],
       });
@@ -154,8 +158,8 @@ function nextLabels(fixtures, query, current) {
   return next;
 }
 
-function label(station, time) {
-  return { station, time, boardings: 0, path: [] };
+function label(station, time, startTime) {
+  return { station, time, startTime, boardings: 0, path: [] };
 }
 
 function leg(trip, from, to) {
@@ -181,10 +185,10 @@ function addLabel(labels, candidate, limit) {
   return true;
 }
 
-function alternatives(labels, limit, start) {
+function alternatives(labels, limit) {
   return keepPareto(labels, limit).map((result) => ({
     arrival: formatClock(result.time),
-    durationSeconds: (result.time - start) * 60,
+    durationSeconds: (result.time - result.startTime) * 60,
     transferCount: Math.max(0, result.boardings - 1),
     tripIds: result.path.filter((step) => step.type === "ride").map((step) => step.tripId),
     path: result.path,
@@ -217,6 +221,10 @@ function canBoard(fixtures, query, previous, stop) {
   const entrySlack = Math.ceil((query.entrySlackSeconds ?? 0) / 60);
   const slack = previous.path.length === 0 ? entrySlack : fixtures.transferSlackMinutes;
   return stop.departure >= previous.time + slack;
+}
+
+function canBoardAtRound(fixtures, query, previous, stop, round) {
+  return previous.boardings === round && canBoard(fixtures, query, previous, stop);
 }
 
 function betterBoarding(current, label, stop) {

--- a/tools/routes/prototype-route-v2.mjs
+++ b/tools/routes/prototype-route-v2.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const defaultFixture = "tools/routes/algorithm-fixtures/route-v2-fixtures.json";
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const fixtures = await loadFixtures(process.argv[2] ?? defaultFixture);
+    console.log(JSON.stringify(runAll(fixtures), null, 2));
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+export async function loadFixtures(filePath = defaultFixture) {
+  return normalize(JSON.parse(await readFile(path.resolve(filePath), "utf8")));
+}
+
+export function runAll(fixtures) {
+  return {
+    schemaVersion: 1,
+    fixtureCount: fixtures.queries.length,
+    results: fixtures.queries.map((query) => ({
+      queryId: query.id,
+      raptor: runRangeRaptor(fixtures, query)[0] ?? null,
+      timeDependentDijkstra: runTimeDependentDijkstra(fixtures, query)[0] ?? null,
+    })),
+  };
+}
+
+export function runRangeRaptor(fixtures, query) {
+  const start = departureMinute(query);
+  const labelsByRound = [new Map([[query.origin, [label(query.origin, start)]]])];
+
+  for (let round = 0; round <= maxTransfers(query); round += 1) {
+    const current = cloneLabels(labelsByRound[round] ?? new Map());
+    scanTrips(fixtures, query, current, round);
+    scanTransfers(fixtures, query, current);
+    labelsByRound[round + 1] = mergeMaps(labelsByRound[round + 1], current, fixtures.paretoLimit);
+  }
+
+  return alternatives(labelsByRound.at(-1)?.get(query.destination) ?? [], fixtures.paretoLimit);
+}
+
+export function runTimeDependentDijkstra(fixtures, query) {
+  const start = departureMinute(query);
+  let queue = [label(query.origin, start)];
+  const best = new Map([[query.origin, queue]]);
+
+  while (queue.length > 0) {
+    queue.sort(compareLabels);
+    const current = queue.shift();
+    for (const next of nextLabels(fixtures, query, current)) {
+      const stationLabels = best.get(next.station) ?? [];
+      if (stationLabels.some((candidate) => sameLabel(candidate, next) || dominates(candidate, next))) continue;
+      const kept = keepPareto([...stationLabels.filter((candidate) => !dominates(next, candidate)), next], fixtures.paretoLimit);
+      best.set(next.station, kept);
+      queue.push(next);
+    }
+  }
+
+  return alternatives(best.get(query.destination) ?? [], fixtures.paretoLimit);
+}
+
+function normalize(fixtures) {
+  return {
+    ...fixtures,
+    paretoLimit: fixtures.paretoLimit ?? 3,
+    transferSlackMinutes: Math.ceil((fixtures.transferSlackSeconds ?? 0) / 60),
+    transfers: fixtures.transfers ?? [],
+    trips: fixtures.trips.map((trip) => ({
+      ...trip,
+      stops: trip.stops.map(([station, arrival, departure], index) => ({
+        station,
+        arrival: parseClock(arrival),
+        departure: parseClock(departure),
+        index,
+      })),
+    })),
+  };
+}
+
+function scanTrips(fixtures, query, labels, round) {
+  // ponytail: fixture scan only; production RAPTOR should index trips by route and marked stops.
+  for (const trip of fixtures.trips) {
+    if (!isServiceActive(fixtures, query, trip) || trip.realtime === "stale") continue;
+    let boarded = null;
+    for (const stop of trip.stops) {
+      for (const previous of labels.get(stop.station) ?? []) {
+        if (previous.boardings === round && canBoard(fixtures, query, previous, stop)) {
+          boarded = betterBoarding(boarded, previous, stop);
+        }
+      }
+      if (!boarded || stop.index <= boarded.stop.index) continue;
+      addLabel(labels, {
+        station: stop.station,
+        time: stop.arrival,
+        boardings: boarded.label.boardings + 1,
+        path: [...boarded.label.path, leg(trip, boarded.stop, stop)],
+      }, fixtures.paretoLimit);
+    }
+  }
+}
+
+function scanTransfers(fixtures, query, labels) {
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const transfer of fixtures.transfers) {
+      if (query.constraintMode === "STRICT_STEP_FREE" && (!transfer.stepFree || !transfer.verified)) continue;
+      for (const previous of labels.get(transfer.from) ?? []) {
+        changed = addLabel(labels, {
+          station: transfer.to,
+          time: previous.time + Math.ceil(transfer.durationSeconds / 60),
+          boardings: previous.boardings,
+          path: [...previous.path, { type: "transfer", from: transfer.from, to: transfer.to, durationSeconds: transfer.durationSeconds }],
+        }, fixtures.paretoLimit) || changed;
+      }
+    }
+  }
+}
+
+function nextLabels(fixtures, query, current) {
+  const next = [];
+  for (const transfer of fixtures.transfers) {
+    if (transfer.from !== current.station) continue;
+    if (query.constraintMode === "STRICT_STEP_FREE" && (!transfer.stepFree || !transfer.verified)) continue;
+    next.push({
+      station: transfer.to,
+      time: current.time + Math.ceil(transfer.durationSeconds / 60),
+      boardings: current.boardings,
+      path: [...current.path, { type: "transfer", from: transfer.from, to: transfer.to, durationSeconds: transfer.durationSeconds }],
+    });
+  }
+
+  if (current.boardings >= maxTransfers(query) + 1) return next;
+  for (const trip of fixtures.trips) {
+    if (!isServiceActive(fixtures, query, trip) || trip.realtime === "stale") continue;
+    const from = trip.stops.find((stop) => stop.station === current.station && canBoard(fixtures, query, current, stop));
+    if (!from) continue;
+    for (const to of trip.stops.slice(from.index + 1)) {
+      next.push({
+        station: to.station,
+        time: to.arrival,
+        boardings: current.boardings + 1,
+        path: [...current.path, leg(trip, from, to)],
+      });
+    }
+  }
+  return next;
+}
+
+function label(station, time) {
+  return { station, time, boardings: 0, path: [] };
+}
+
+function leg(trip, from, to) {
+  return {
+    type: "ride",
+    tripId: trip.id,
+    lineId: trip.lineId,
+    pattern: trip.pattern,
+    from: from.station,
+    to: to.station,
+    departure: formatClock(from.departure),
+    arrival: formatClock(to.arrival),
+  };
+}
+
+function addLabel(labels, candidate, limit) {
+  const stationLabels = labels.get(candidate.station) ?? [];
+  if (stationLabels.some((existing) => sameLabel(existing, candidate) || dominates(existing, candidate))) return false;
+  labels.set(candidate.station, keepPareto([
+    ...stationLabels.filter((existing) => !dominates(candidate, existing)),
+    candidate,
+  ], limit));
+  return true;
+}
+
+function alternatives(labels, limit) {
+  return keepPareto(labels, limit).map((result) => ({
+    arrival: formatClock(result.time),
+    durationSeconds: (result.time - (result.path[0]?.departure ? parseClock(result.path[0].departure) : result.time)) * 60,
+    transferCount: Math.max(0, result.boardings - 1),
+    tripIds: result.path.filter((step) => step.type === "ride").map((step) => step.tripId),
+    path: result.path,
+  }));
+}
+
+function keepPareto(labels, limit) {
+  return labels
+    .filter((candidate, index, all) => !all.some((other, otherIndex) => otherIndex !== index && dominates(other, candidate)))
+    .sort(compareLabels)
+    .slice(0, limit);
+}
+
+function dominates(left, right) {
+  return left.time <= right.time && left.boardings <= right.boardings && (left.time < right.time || left.boardings < right.boardings);
+}
+
+function sameLabel(left, right) {
+  return left.time === right.time
+    && left.boardings === right.boardings
+    && left.path.map((step) => step.tripId ?? `${step.from}->${step.to}`).join("|")
+      === right.path.map((step) => step.tripId ?? `${step.from}->${step.to}`).join("|");
+}
+
+function compareLabels(left, right) {
+  return left.time - right.time || left.boardings - right.boardings || left.path.length - right.path.length;
+}
+
+function canBoard(fixtures, query, previous, stop) {
+  const entrySlack = Math.ceil((query.entrySlackSeconds ?? 0) / 60);
+  const slack = previous.path.length === 0 ? entrySlack : fixtures.transferSlackMinutes;
+  return stop.departure >= previous.time + slack;
+}
+
+function betterBoarding(current, label, stop) {
+  if (!current) return { label, stop };
+  return label.time < current.label.time ? { label, stop } : current;
+}
+
+function maxTransfers(query) {
+  return query.maxTransfers ?? 3;
+}
+
+function departureMinute(query) {
+  return parseClock(query.departure.slice(11, 16));
+}
+
+function parseClock(clock) {
+  const [hours, minutes] = clock.split(":").map(Number);
+  return hours * 60 + minutes;
+}
+
+function formatClock(minutes) {
+  return `${String(Math.floor(minutes / 60)).padStart(2, "0")}:${String(minutes % 60).padStart(2, "0")}`;
+}
+
+function isServiceActive(fixtures, query, trip) {
+  const serviceDate = query.departure.slice(0, 10);
+  return !(fixtures.calendarDates?.[serviceDate] ?? []).includes(trip.service);
+}
+
+function cloneLabels(labels) {
+  return new Map([...labels].map(([station, values]) => [station, [...values]]));
+}
+
+function mergeMaps(left = new Map(), right = new Map(), limit = 3) {
+  const merged = cloneLabels(left);
+  for (const [station, labels] of right) {
+    merged.set(station, keepPareto([...(merged.get(station) ?? []), ...labels], limit));
+  }
+  return merged;
+}

--- a/tools/routes/prototype-route-v2.mjs
+++ b/tools/routes/prototype-route-v2.mjs
@@ -32,7 +32,7 @@ export function runAll(fixtures) {
 }
 
 export function runRangeRaptor(fixtures, query) {
-  const start = departureMinute(query);
+  const start = departureMinute(fixtures, query);
   const labelsByRound = [new Map([[query.origin, [label(query.origin, start)]]])];
 
   for (let round = 0; round <= maxTransfers(query); round += 1) {
@@ -42,11 +42,11 @@ export function runRangeRaptor(fixtures, query) {
     labelsByRound[round + 1] = mergeMaps(labelsByRound[round + 1], current, fixtures.paretoLimit);
   }
 
-  return alternatives(labelsByRound.at(-1)?.get(query.destination) ?? [], fixtures.paretoLimit);
+  return alternatives(labelsByRound.at(-1)?.get(query.destination) ?? [], fixtures.paretoLimit, start);
 }
 
 export function runTimeDependentDijkstra(fixtures, query) {
-  const start = departureMinute(query);
+  const start = departureMinute(fixtures, query);
   let queue = [label(query.origin, start)];
   const best = new Map([[query.origin, queue]]);
 
@@ -62,13 +62,14 @@ export function runTimeDependentDijkstra(fixtures, query) {
     }
   }
 
-  return alternatives(best.get(query.destination) ?? [], fixtures.paretoLimit);
+  return alternatives(best.get(query.destination) ?? [], fixtures.paretoLimit, start);
 }
 
 function normalize(fixtures) {
   return {
     ...fixtures,
     paretoLimit: fixtures.paretoLimit ?? 3,
+    serviceDayCutoffHour: fixtures.serviceDayCutoffHour ?? 3,
     transferSlackMinutes: Math.ceil((fixtures.transferSlackSeconds ?? 0) / 60),
     transfers: fixtures.transfers ?? [],
     trips: fixtures.trips.map((trip) => ({
@@ -180,10 +181,10 @@ function addLabel(labels, candidate, limit) {
   return true;
 }
 
-function alternatives(labels, limit) {
+function alternatives(labels, limit, start) {
   return keepPareto(labels, limit).map((result) => ({
     arrival: formatClock(result.time),
-    durationSeconds: (result.time - (result.path[0]?.departure ? parseClock(result.path[0].departure) : result.time)) * 60,
+    durationSeconds: (result.time - start) * 60,
     transferCount: Math.max(0, result.boardings - 1),
     tripIds: result.path.filter((step) => step.type === "ride").map((step) => step.tripId),
     path: result.path,
@@ -227,8 +228,9 @@ function maxTransfers(query) {
   return query.maxTransfers ?? 3;
 }
 
-function departureMinute(query) {
-  return parseClock(query.departure.slice(11, 16));
+function departureMinute(fixtures, query) {
+  const minute = parseClock(query.departure.slice(11, 16));
+  return minute < fixtures.serviceDayCutoffHour * 60 ? minute + 24 * 60 : minute;
 }
 
 function parseClock(clock) {
@@ -241,8 +243,18 @@ function formatClock(minutes) {
 }
 
 function isServiceActive(fixtures, query, trip) {
-  const serviceDate = query.departure.slice(0, 10);
+  const serviceDate = serviceDay(fixtures, query);
   return !(fixtures.calendarDates?.[serviceDate] ?? []).includes(trip.service);
+}
+
+function serviceDay(fixtures, query) {
+  const date = query.departure.slice(0, 10);
+  const hour = Number(query.departure.slice(11, 13));
+  if (hour >= fixtures.serviceDayCutoffHour) return date;
+
+  const serviceDate = new Date(`${date}T00:00:00Z`);
+  serviceDate.setUTCDate(serviceDate.getUTCDate() - 1);
+  return serviceDate.toISOString().slice(0, 10);
 }
 
 function cloneLabels(labels) {

--- a/tools/routes/prototype-route-v2.test.mjs
+++ b/tools/routes/prototype-route-v2.test.mjs
@@ -42,6 +42,9 @@ function assertPrototype(query, result, name) {
   }
 
   assert.equal(result.arrival, query.expectedArrival, `${name} arrival`);
+  if (query.expectedDurationSeconds !== undefined) {
+    assert.equal(result.durationSeconds, query.expectedDurationSeconds, `${name} duration`);
+  }
   assert.equal(result.transferCount, query.expectedTransfers, `${name} transfer count`);
   assert.deepEqual(result.tripIds, query.expectedTripIds, `${name} trip ids`);
   assert.ok(result.path.length > 0, `${name} reconstructs path`);

--- a/tools/routes/prototype-route-v2.test.mjs
+++ b/tools/routes/prototype-route-v2.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { loadFixtures, runRangeRaptor, runTimeDependentDijkstra } from "./prototype-route-v2.mjs";
+import { loadFixtures, runAll, runRangeRaptor, runTimeDependentDijkstra } from "./prototype-route-v2.mjs";
 
 const fixtures = await loadFixtures();
 
@@ -14,6 +14,7 @@ for (const query of fixtures.queries) {
 
 test("route v2 prototypes return Pareto alternatives with reconstructed paths", () => {
   const query = fixtures.queries.find((candidate) => candidate.id === "pareto_arrival_vs_transfer");
+  assert.ok(query, "missing fixture query: pareto_arrival_vs_transfer");
   const alternatives = runTimeDependentDijkstra(fixtures, query);
 
   assert.equal(alternatives.length, 2);
@@ -23,6 +24,14 @@ test("route v2 prototypes return Pareto alternatives with reconstructed paths", 
   assert.equal(alternatives[1].transferCount, 0);
   assert.equal(alternatives[0].path[0].from, "pareto_a");
   assert.equal(alternatives[0].path.at(-1).to, "pareto_b");
+});
+
+test("route v2 CLI report keeps full Pareto alternatives", () => {
+  const result = runAll(fixtures).results.find((candidate) => candidate.queryId === "pareto_arrival_vs_transfer");
+
+  assert.ok(result, "missing runAll result: pareto_arrival_vs_transfer");
+  assert.equal(result.raptor.length, 2);
+  assert.equal(result.timeDependentDijkstra.length, 2);
 });
 
 test("route algorithm ADR fixes backend and mobile responsibilities", async () => {

--- a/tools/routes/prototype-route-v2.test.mjs
+++ b/tools/routes/prototype-route-v2.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { loadFixtures, runRangeRaptor, runTimeDependentDijkstra } from "./prototype-route-v2.mjs";
+
+const fixtures = await loadFixtures();
+
+for (const query of fixtures.queries) {
+  test(`route v2 prototypes match fixture: ${query.id}`, () => {
+    assertPrototype(query, runRangeRaptor(fixtures, query)[0] ?? null, "raptor");
+    assertPrototype(query, runTimeDependentDijkstra(fixtures, query)[0] ?? null, "time-dependent Dijkstra");
+  });
+}
+
+test("route v2 prototypes return Pareto alternatives with reconstructed paths", () => {
+  const query = fixtures.queries.find((candidate) => candidate.id === "pareto_arrival_vs_transfer");
+  const alternatives = runTimeDependentDijkstra(fixtures, query);
+
+  assert.equal(alternatives.length, 2);
+  assert.equal(alternatives[0].arrival, "09:25");
+  assert.equal(alternatives[0].transferCount, 1);
+  assert.equal(alternatives[1].arrival, "09:30");
+  assert.equal(alternatives[1].transferCount, 0);
+  assert.equal(alternatives[0].path[0].from, "pareto_a");
+  assert.equal(alternatives[0].path.at(-1).to, "pareto_b");
+});
+
+test("route algorithm ADR fixes backend and mobile responsibilities", async () => {
+  const adr = JSON.parse(await readFile(new URL("./route-algorithm-v2-adr.json", import.meta.url), "utf8"));
+
+  assert.equal(adr.decision.includes("Range RAPTOR"), true);
+  assert.equal(adr.mobileRole.includes("not live high-quality routing"), true);
+  assert.ok(adr.accessGraphDijkstraRole.includes("offline static fallback"));
+  assert.equal(adr.v2Rules.paretoCandidateLimit, 3);
+  assert.equal(adr.verification, "node --test tools/routes/*.test.mjs");
+});
+
+function assertPrototype(query, result, name) {
+  if (query.expectedArrival === null) {
+    assert.equal(result, null, `${name} should not find a boardable itinerary`);
+    return;
+  }
+
+  assert.equal(result.arrival, query.expectedArrival, `${name} arrival`);
+  assert.equal(result.transferCount, query.expectedTransfers, `${name} transfer count`);
+  assert.deepEqual(result.tripIds, query.expectedTripIds, `${name} trip ids`);
+  assert.ok(result.path.length > 0, `${name} reconstructs path`);
+}

--- a/tools/routes/route-algorithm-v2-adr.json
+++ b/tools/routes/route-algorithm-v2-adr.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": 1,
+  "status": "accepted-for-prototype",
+  "issue": 1220,
+  "decision": "Use Range RAPTOR for backend high-quality route search. Keep time-dependent Dijkstra for access graph legs and mobile static fallback only.",
+  "mobileRole": "static/local fallback with visible freshness and quality labels; not live high-quality routing",
+  "accessGraphDijkstraRole": [
+    "station entrance and exit legs",
+    "station pathway and platform transfer legs",
+    "elevator, escalator, stair and generated connector filtering",
+    "offline static fallback"
+  ],
+  "decisionMatrix": [
+    {
+      "criterion": "correctness",
+      "rangeRaptor": "round model matches trips, transfer count and service calendar scans",
+      "timeDependentDijkstra": "correct on fixtures but expands boardable trip edges as graph states",
+      "choice": "Range RAPTOR"
+    },
+    {
+      "criterion": "mobile feasibility",
+      "rangeRaptor": "keeps high-quality live ETA backend-only",
+      "timeDependentDijkstra": "too easy to overclaim mobile graph routing as live ETA",
+      "choice": "Range RAPTOR"
+    },
+    {
+      "criterion": "performance",
+      "rangeRaptor": "bounded by rounds and trip scans",
+      "timeDependentDijkstra": "priority queue over many time-dependent edges",
+      "choice": "Range RAPTOR"
+    },
+    {
+      "criterion": "accessibility constraints",
+      "rangeRaptor": "uses access graph filters around transfer and entry legs",
+      "timeDependentDijkstra": "best fit inside the access graph itself",
+      "choice": "Split responsibilities"
+    },
+    {
+      "criterion": "realtime handling",
+      "rangeRaptor": "overlay fresh provider stop times before scan",
+      "timeDependentDijkstra": "edge update model is noisier",
+      "choice": "Range RAPTOR"
+    }
+  ],
+  "v2Rules": {
+    "timezone": "Asia/Seoul",
+    "realtimeOverlay": "Fresh realtime updates boardable trip stop times before RAPTOR scan. Stale or unsupported realtime must not silently become live ETA.",
+    "transferSlack": "Apply transfer slack before each next boarding and entry slack before first boarding.",
+    "paretoCandidateLimit": 3,
+    "ranking": ["earliest arrival", "fewer transfers", "verified step-free", "lower unknown accessibility risk"],
+    "strictStepFree": "Exclude known stair transfers and unverified generated connectors."
+  },
+  "nonGoalsForV1CommercialRelease": [
+    "crowd density prediction",
+    "weather-aware routing",
+    "ML ETA correction",
+    "cross-provider fare optimization",
+    "mobile-only live high-quality routing",
+    "unlimited Pareto frontier exposure"
+  ],
+  "verification": "node --test tools/routes/*.test.mjs"
+}

--- a/tools/routes/route-algorithm-v2-adr.json
+++ b/tools/routes/route-algorithm-v2-adr.json
@@ -40,6 +40,12 @@
       "rangeRaptor": "overlay fresh provider stop times before scan",
       "timeDependentDijkstra": "edge update model is noisier",
       "choice": "Range RAPTOR"
+    },
+    {
+      "criterion": "calendar and timezone handling",
+      "rangeRaptor": "evaluate Asia/Seoul service day, 24:xx overnight trips and calendar exceptions before trip scans",
+      "timeDependentDijkstra": "can support the same rules but would duplicate them across time-dependent edges",
+      "choice": "Range RAPTOR"
     }
   ],
   "v2Rules": {


### PR DESCRIPTION
## 관련 이슈

close #1220

## 작업 배경

- Routing Core V2 production 구현 전에 같은 fixture로 Range RAPTOR와 time-dependent Dijkstra prototype을 비교하고, backend high-quality router 알고리즘 결정을 고정합니다.
- 프로젝트 Markdown 추적 정책 때문에 ADR은 추적 가능한 JSON artifact로 남깁니다.

## 작업 내용

- `tools/routes/algorithm-fixtures/route-v2-fixtures.json`에 direct, 1회/2회 환승, 급행/완행, 막차/첫차, calendar, frequency, step-free, realtime stale/entry slack fixture를 추가했습니다.
- `tools/routes/prototype-route-v2.mjs`에 Range RAPTOR prototype과 time-dependent Dijkstra prototype runner를 추가했습니다.
- `tools/routes/route-algorithm-v2-adr.json`에 backend는 Range RAPTOR, access graph/mobile fallback은 Dijkstra로 분리하는 ADR 결정을 고정했습니다.
- `tools/routes/prototype-route-v2.test.mjs`에서 fixture 결과, path reconstruction, Pareto alternatives, ADR 핵심 계약을 검증합니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/routes/*.test.mjs` PASS, 23 tests
  - `node --test tools/ci/*.test.mjs` PASS, 159 tests
  - `git diff --check` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Route V2 prototype/ADR | Node.js | `node --test tools/routes/*.test.mjs` | 로컬 명령 결과 | PASS, 24 tests |
| Repository contract | Node.js | `node --test tools/ci/*.test.mjs` | 로컬 명령 결과 | PASS, 159 tests |
| PR CI | GitHub Actions | CI workflow | https://github.com/AquilaXk/easysubway/actions/runs/28474193626 | PASS |
| Release artifacts | GitHub Actions | Release Artifacts workflow | https://github.com/AquilaXk/easysubway/actions/runs/28474193203 | PASS/SKIP as classified |
| Code review | GitHub PR review | CodeRabbit + Codex fallback review threads | PR #1310 review/comments | PASS, actionables fixed |
| UI/접근성 수동 증거 | N/A | 도구/ADR 변경만 포함 | 증거 불필요 사유: 런타임 UI 변경 없음 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: production API contract 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 먼저 볼 지점: `tools/routes/route-algorithm-v2-adr.json`
- ADR 결정: backend high-quality route search는 Range RAPTOR, access graph와 mobile static/local fallback은 time-dependent Dijkstra 역할로 분리합니다.
- production Java route class는 의도적으로 추가하지 않았습니다.

## 리스크

- Prototype fixture는 production datapack coverage가 아닙니다. C-1/C-2 schema와 실제 source coverage가 붙기 전까지 production ETA claim으로 쓰면 안 됩니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
