### PR TITLE
[Fix] 홈 공통 스타일 토큰 정리

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -42,6 +42,8 @@ const _appSectionTitlePadding = EdgeInsets.fromLTRB(1, 22, 1, 11);
 const _settingsPagePadding = EdgeInsets.fromLTRB(20, 16, 20, 32);
 const _mainScaffoldBackgroundColor = Color(0xFFF6F8F9);
 const _mainThemeControlRadius = BorderRadius.all(Radius.circular(8));
+const _mainIconControlRadius = BorderRadius.all(Radius.circular(14));
+const _appCardShadowColor = Color(0x0A071B2F);
 const _highContrastTextColor = Color(0xFF000000);
 const _highContrastPrimaryColor = Color(0xFF003D40);
 const _highContrastSecondaryColor = Color(0xFF005E68);
@@ -1860,7 +1862,7 @@ class _HomeNotificationButton extends StatelessWidget {
                   width: 1.5,
                 ),
                 shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(14),
+                  borderRadius: _mainIconControlRadius,
                 ),
               ),
               icon: const Icon(Icons.notifications_none),
@@ -3241,7 +3243,7 @@ class _AppCard extends StatelessWidget {
       margin: EdgeInsets.zero,
       color: backgroundColor,
       elevation: 2,
-      shadowColor: const Color(0x0A071B2F),
+      shadowColor: _appCardShadowColor,
       shape: RoundedRectangleBorder(
         side: showBorder ? BorderSide(color: borderColor) : BorderSide.none,
         borderRadius: BorderRadius.circular(borderRadius),
@@ -3283,7 +3285,7 @@ class _AppInfoRow extends StatelessWidget {
       height: iconBoxSize,
       decoration: BoxDecoration(
         color: iconBackground,
-        borderRadius: BorderRadius.circular(14),
+        borderRadius: _mainIconControlRadius,
       ),
       child: Icon(icon, color: iconColor, size: iconSize),
     );


### PR DESCRIPTION
## 요약
- #1075 후속으로 홈 공통 카드 shadow 색상과 아이콘 컨트롤 radius 직접값을 local token으로 정리했습니다.
- 동작 변경 없이 반복 스타일 값을 한 곳에서 읽히게 했습니다.

## 검증
- cd apps/mobile && dart format lib/main.dart
- cd apps/mobile && flutter analyze lib/main.dart
- cd apps/mobile && flutter test test/widget_test.dart --name "도움말은 이동 전 살펴보기 안내를 함께 보여준다" --reporter expanded
- git diff --check

## 참고
- Flutter 명령을 병렬 실행한 첫 test는 iOS ephemeral symlink PathExistsException으로 tool crash가 났고, 같은 test를 단독 재실행해 통과했습니다.

Fixes part of #1075