### PR TITLE
[Fix] 홈 컨트롤 radius 토큰 재사용

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4186,7 +4186,7 @@ class _FavoriteHomeQuickCard extends StatelessWidget {
       child: ExcludeSemantics(
         child: InkWell(
           onTap: onTap,
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: _mainThemeControlRadius,
           child: _AppCard(
             backgroundColor: Colors.white,
             borderRadius: 8,
@@ -4198,7 +4198,7 @@ class _FavoriteHomeQuickCard extends StatelessWidget {
                 DecoratedBox(
                   decoration: BoxDecoration(
                     color: EasySubwayAccessibleColors.mintSoft,
-                    borderRadius: BorderRadius.circular(8),
+                    borderRadius: _mainThemeControlRadius,
                   ),
                   child: SizedBox(
                     width: 44,
@@ -4537,13 +4537,13 @@ class _UserDataDeletionAccessItem extends StatelessWidget {
         child: Material(
           color: EasySubwayAccessibleColors.surface,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: _mainThemeControlRadius,
             side: BorderSide(
               color: Theme.of(context).colorScheme.outlineVariant,
             ),
           ),
           child: InkWell(
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: _mainThemeControlRadius,
             onTap: openDeletionScreen,
             child: Padding(
               padding: const EdgeInsets.all(16),
@@ -5047,7 +5047,7 @@ class _DataDeletionResultRow extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       decoration: BoxDecoration(
         color: EasySubwayAccessibleColors.mintSoft,
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: _mainThemeControlRadius,
         border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
       ),
       child: const Text(
@@ -5130,7 +5130,7 @@ class _SecurityContactNotice extends StatelessWidget {
           decoration: BoxDecoration(
             color: EasySubwayAccessibleColors.skySoft,
             border: Border.all(color: EasySubwayAccessibleColors.line),
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: _mainThemeControlRadius,
           ),
           child: Padding(
             padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## 요약
- #1075 후속으로 홈 즐겨찾기 카드, 개인정보 삭제 안내, 삭제 결과, 보안 문의 notice의 8px radius 직접값을 기존 local token으로 정리했습니다.
- 동작 변경 없이 반복 스타일 값을 줄였습니다.

## 검증
- cd apps/mobile && dart format lib/main.dart
- cd apps/mobile && flutter analyze lib/main.dart
- cd apps/mobile && flutter test test/widget_test.dart --name "도움말은 개인정보 사용 목적과 삭제 요청 대상을 쉬운 문구로 안내한다" --reporter expanded
- git diff --check

Fixes part of #1075