### PR TITLE
[Fix] 노선도 노드 색상 토큰 정리

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -15,6 +15,7 @@ import 'features/route_draft/application/route_draft_controller.dart';
 import 'features/route_draft/domain/route_draft.dart';
 
 const _networkMapRadius = BorderRadius.all(Radius.circular(8));
+const _networkMapStationNodeStrokeColor = Color(0xFF2F3E42);
 
 abstract interface class NetworkMapRepository {
   Future<NetworkMapData> getNetworkMap({String? region, String? lineId});
@@ -1456,7 +1457,7 @@ class _AndroidRouteMapFallbackPainter extends CustomPainter {
     }
 
     final nodeStroke = Paint()
-      ..color = const Color(0xFF2F3E42)
+      ..color = _networkMapStationNodeStrokeColor
       ..style = PaintingStyle.stroke
       ..strokeWidth = 2 / camera.scale;
     final nodeFill = Paint()


### PR DESCRIPTION
## Summary
- apps/mobile/lib/network_map.dart의 fallback 노선도 역 노드 stroke 색상 직접값을 local token으로 분리
- 지도 렌더링 동작 변경 없이 #1075 디자인 토큰 drift를 줄임

## Verification
- rg direct paint Color check: no matches
- flutter analyze lib/network_map.dart
- flutter analyze
- flutter test test/widget_test.dart --name "(홈 노선도 버튼은 v3 노선도 화면을 연다|노선도는 카드가 아니라 공식 지도처럼 전면 캔버스로 보인다|수도권 노선도는 Android에서도 viewport renderer를 사용한다)" --reporter expanded
- git diff --check

Refs #1075