### PR TITLE
[Fix] 즐겨찾기 시설 padding 토큰 정리

### DIFF
--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -14,6 +14,7 @@ const _favoriteFacilityTimeout = Duration(seconds: 8);
 const _favoriteFacilityLoadErrorMessage = '즐겨찾기 시설을 불러오지 못했어요.';
 const _favoriteFacilityChangeErrorMessage = '즐겨찾기 시설을 바꾸지 못했어요.';
 const _favoriteFacilityCardRadius = BorderRadius.all(Radius.circular(8));
+const _favoriteFacilityListPadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
 
 abstract class FavoriteFacilityRepository {
   Future<List<FavoriteFacility>> listFavoriteFacilities();
@@ -574,7 +575,7 @@ class _FavoriteFacilityListBody extends StatelessWidget {
         ),
       ),
       FavoriteFacilityListStatus.success => ListView(
-        padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+        padding: _favoriteFacilityListPadding,
         children: [
           Semantics(
             label: '즐겨찾기 시설 ${state.favorites.length}개',


### PR DESCRIPTION
## 요약

- #1075 디자인 시스템 정리 후속입니다.
- 즐겨찾기 시설 성공 목록의 직접 `EdgeInsets.fromLTRB(20, 20, 20, 32)` 사용을 파일 local padding token으로 분리했습니다.

## 검증

- `dart format lib/favorite_facility.dart`
- `rg -n "padding: const EdgeInsets\\.fromLTRB\\(" lib/favorite_facility.dart` (no matches)
- `flutter analyze lib/favorite_facility.dart`
- `flutter test test/favorite_facility_test.dart --reporter expanded`
- `flutter test test/widget_test.dart --name "홈 즐겨찾기 시설" --reporter expanded`
- `flutter analyze`
- `git diff --check`

## 증거

- UI 동작 변경 없는 style token 추출이라 별도 스크린샷 증거는 불필요합니다.
