### PR TITLE
[Feat] MobilityType과 ConstraintMode 분리

### DIFF
--- a/apps/mobile/lib/features/internal_route/application/internal_route_engine.dart
+++ b/apps/mobile/lib/features/internal_route/application/internal_route_engine.dart
@@ -167,7 +167,7 @@ class LocalInternalRouteEngine {
     Set<String> blockedReasonCodes,
   ) {
     final accessibilityStatus = edge.accessibilityStatus.toUpperCase();
-    if (edge.includesStairs && mobilityType.blocksStairOnlyAccess) {
+    if (edge.includesStairs && mobilityType.blocksStairOnlyAccess(null)) {
       blockedReasonCodes.add('STAIR_ONLY_ACCESS');
       return true;
     }
@@ -176,7 +176,7 @@ class LocalInternalRouteEngine {
       return true;
     }
     if (accessibilityStatus == 'UNKNOWN' &&
-        mobilityType.blocksStairOnlyAccess) {
+        mobilityType.blocksStairOnlyAccess(null)) {
       blockedReasonCodes.add('ACCESSIBILITY_STATE_UNKNOWN');
       return true;
     }

--- a/apps/mobile/lib/features/routes/application/accessibility_cost_calculator.dart
+++ b/apps/mobile/lib/features/routes/application/accessibility_cost_calculator.dart
@@ -17,12 +17,16 @@ class AccessibilityCost {
 class AccessibilityCostCalculator {
   const AccessibilityCostCalculator();
 
-  AccessibilityCost costFor(RouteEdge edge, MobilityType mobilityType) {
+  AccessibilityCost costFor(
+    RouteEdge edge,
+    MobilityType mobilityType, {
+    ConstraintMode? constraintMode,
+  }) {
     final weight = RouteWeight.from(mobilityType);
     final warningCodes = <String>[];
+    final blocksStairs = mobilityType.blocksStairOnlyAccess(constraintMode);
 
-    if (mobilityType.blocksStairOnlyAccess &&
-        !edge.safetyEvidence.strictRouteEligible) {
+    if (blocksStairs && !edge.safetyEvidence.strictRouteEligible) {
       return AccessibilityCost(
         cost: 0,
         isBlocked: true,
@@ -33,7 +37,7 @@ class AccessibilityCostCalculator {
     // route contract: generated connector strict block
     // Generated connectors are topology scaffolding, not verified step-free
     // accessibility evidence for profiles that cannot safely use stairs.
-    if (edge.isGeneratedConnector && mobilityType.blocksStairOnlyAccess) {
+    if (edge.isGeneratedConnector && blocksStairs) {
       return const AccessibilityCost(
         cost: 0,
         isBlocked: true,
@@ -53,7 +57,7 @@ class AccessibilityCostCalculator {
     // Missing source data must not be treated as accessible for profiles that
     // cannot safely use stairs; other profiles keep the route with a warning.
     if (edge.accessibilityState == RouteAccessibilityState.unknown) {
-      if (mobilityType.blocksStairOnlyAccess) {
+      if (blocksStairs) {
         return const AccessibilityCost(
           cost: 0,
           isBlocked: true,
@@ -67,7 +71,7 @@ class AccessibilityCostCalculator {
     // Stair-only or unknown stair state blocks wheelchair-style profiles and
     // only becomes a penalty/warning for profiles that can still choose it.
     if (edge.stairAccessState == RouteStairAccessState.unknown) {
-      if (mobilityType.blocksStairOnlyAccess) {
+      if (blocksStairs) {
         return const AccessibilityCost(
           cost: 0,
           isBlocked: true,
@@ -78,7 +82,7 @@ class AccessibilityCostCalculator {
     }
 
     if (edge.stairAccessState == RouteStairAccessState.stairOnly &&
-        mobilityType.blocksStairOnlyAccess) {
+        blocksStairs) {
       return const AccessibilityCost(
         cost: 0,
         isBlocked: true,
@@ -86,7 +90,7 @@ class AccessibilityCostCalculator {
       );
     }
 
-    if (edge.isDataStale && mobilityType.blocksStairOnlyAccess) {
+    if (edge.isDataStale && blocksStairs) {
       return const AccessibilityCost(
         cost: 0,
         isBlocked: true,

--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -20,6 +20,7 @@ class LocalRouteEngine {
       request.originStationId,
       request.destinationStationId,
       request.mobilityType,
+      request.effectiveConstraintMode,
       blockedReasonCodes,
     );
     if (path == null) {
@@ -101,6 +102,7 @@ class LocalRouteEngine {
     String originNodeId,
     String destinationNodeId,
     MobilityType mobilityType,
+    ConstraintMode constraintMode,
     Set<String> blockedReasonCodes,
   ) {
     final costs = <String, int>{originNodeId: 0};
@@ -126,7 +128,11 @@ class LocalRouteEngine {
             edge.toNodeId != destinationNodeId) {
           continue;
         }
-        final edgeCost = costCalculator.costFor(edge, mobilityType);
+        final edgeCost = costCalculator.costFor(
+          edge,
+          mobilityType,
+          constraintMode: constraintMode,
+        );
         if (edgeCost.isBlocked) {
           blockedReasonCodes.addAll(edgeCost.warningCodes);
           continue;

--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -39,7 +39,11 @@ class LocalRouteEngine {
     final steps = <RouteStep>[];
 
     for (final edge in path) {
-      final accessCost = costCalculator.costFor(edge, request.mobilityType);
+      final accessCost = costCalculator.costFor(
+        edge,
+        request.mobilityType,
+        constraintMode: request.effectiveConstraintMode,
+      );
       totalCost += accessCost.cost;
       for (final code in accessCost.warningCodes) {
         warnings[code] = RouteWarning(

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -20,14 +20,17 @@ class LocalRouteRepository implements RouteSearchRepository {
   Future<RouteSearchResult> searchRoute(RouteSearchRequest request) async {
     final catalog = await _RouteCatalogSnapshot.load(catalogDatabase);
     final mobilityType = _mobilityType(request.mobilityType);
+    final constraintMode = _constraintMode(request.effectiveConstraintMode);
     final result =
-        mobilityType.blocksStairOnlyAccess && !catalog.strictEvidenceSupported
+        mobilityType.blocksStairOnlyAccess(constraintMode) &&
+            !catalog.strictEvidenceSupported
         ? local.LocalRouteResult.unknown(const ['STRICT_EVIDENCE_UNSUPPORTED'])
         : LocalRouteEngine(graph: catalog.toGraph()).search(
             local.RouteRequest(
               originStationId: request.originStationId,
               destinationStationId: request.destinationStationId,
               mobilityType: mobilityType,
+              constraintMode: constraintMode,
             ),
           );
 
@@ -288,6 +291,15 @@ class LocalRouteRepository implements RouteSearchRepository {
       'TEMPORARY_INJURY' => local.MobilityType.temporaryInjury,
       'LUGGAGE' => local.MobilityType.luggage,
       _ => throw const RouteSearchException('지원하지 않는 이동 조건입니다.'),
+    };
+  }
+
+  local.ConstraintMode _constraintMode(String constraintMode) {
+    return switch (constraintMode) {
+      'STRICT_STEP_FREE' => local.ConstraintMode.strictStepFree,
+      'PREFER_STEP_FREE' => local.ConstraintMode.preferStepFree,
+      'ALLOW_WITH_WARNINGS' => local.ConstraintMode.allowWithWarnings,
+      _ => throw const RouteSearchException('지원하지 않는 이동 제약 조건입니다.'),
     };
   }
 }

--- a/apps/mobile/lib/features/routes/domain/route_request.dart
+++ b/apps/mobile/lib/features/routes/domain/route_request.dart
@@ -6,20 +6,34 @@ enum MobilityType {
   temporaryInjury,
   luggage;
 
-  bool get blocksStairOnlyAccess =>
-      this == MobilityType.wheelchair || this == MobilityType.stroller;
+  ConstraintMode get defaultConstraintMode => this == MobilityType.wheelchair
+      ? ConstraintMode.strictStepFree
+      : ConstraintMode.preferStepFree;
+
+  bool blocksStairOnlyAccess(ConstraintMode? mode) =>
+      (mode ?? defaultConstraintMode) == ConstraintMode.strictStepFree;
 }
+
+enum ConstraintMode { strictStepFree, preferStepFree, allowWithWarnings }
 
 class RouteRequest {
   const RouteRequest({
     required this.originStationId,
     required this.destinationStationId,
     required this.mobilityType,
+    this.constraintMode,
   });
 
   final String originStationId;
   final String destinationStationId;
   final MobilityType mobilityType;
+  final ConstraintMode? constraintMode;
+
+  ConstraintMode get effectiveConstraintMode =>
+      constraintMode ?? mobilityType.defaultConstraintMode;
+
+  bool get blocksStairOnlyAccess =>
+      mobilityType.blocksStairOnlyAccess(effectiveConstraintMode);
 }
 
 class InternalRouteSearchRequest {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -550,17 +550,23 @@ class RouteSearchRequest {
     required this.originStationId,
     required this.destinationStationId,
     required this.mobilityType,
+    this.constraintMode,
   });
 
   final String originStationId;
   final String destinationStationId;
   final String mobilityType;
+  final String? constraintMode;
+
+  String get effectiveConstraintMode =>
+      constraintMode ?? _defaultConstraintMode(mobilityType);
 
   RouteSearchRequest trimmed() {
     return RouteSearchRequest(
       originStationId: originStationId.trim(),
       destinationStationId: destinationStationId.trim(),
       mobilityType: mobilityType,
+      constraintMode: constraintMode?.trim(),
     );
   }
 
@@ -570,8 +576,12 @@ class RouteSearchRequest {
       'originStationId': trimmedRequest.originStationId,
       'destinationStationId': trimmedRequest.destinationStationId,
       'mobilityType': trimmedRequest.mobilityType,
+      'constraintMode': trimmedRequest.effectiveConstraintMode,
     };
   }
+
+  static String _defaultConstraintMode(String mobilityType) =>
+      mobilityType == 'WHEELCHAIR' ? 'STRICT_STEP_FREE' : 'PREFER_STEP_FREE';
 }
 
 class RouteSearchV2Result {
@@ -1568,6 +1578,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
   StationSearchResult? _destinationStation;
   _RouteStationRole? _activeStationPicker;
   late String _selectedMobilityType;
+  late String _selectedConstraintMode;
   String _validationMessage = '';
 
   @override
@@ -1577,6 +1588,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
     _originStation = _stationFromDraft(widget.initialDraft?.origin);
     _destinationStation = _stationFromDraft(widget.initialDraft?.destination);
     _selectedMobilityType = widget.initialMobilityType;
+    _selectedConstraintMode = RouteSearchRequest._defaultConstraintMode(
+      _selectedMobilityType,
+    );
   }
 
   @override
@@ -1699,11 +1713,27 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
                       }
                       setState(() {
                         _selectedMobilityType = value;
+                        _selectedConstraintMode =
+                            RouteSearchRequest._defaultConstraintMode(value);
                       });
                     },
                   ),
                 ),
               ),
+            SwitchListTile(
+              key: const Key('routeStrictStepFreeSwitch'),
+              contentPadding: EdgeInsets.zero,
+              title: const Text('계단 없는 길만'),
+              subtitle: const Text('켜면 경로가 줄거나 없을 수 있어요.'),
+              value: _selectedConstraintMode == 'STRICT_STEP_FREE',
+              onChanged: (value) {
+                setState(() {
+                  _selectedConstraintMode = value
+                      ? 'STRICT_STEP_FREE'
+                      : 'PREFER_STEP_FREE';
+                });
+              },
+            ),
             AnimatedBuilder(
               animation: _controller,
               builder: (context, _) => _RouteSearchBody(
@@ -1762,6 +1792,7 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
         originStationId: _originStation!.id,
         destinationStationId: _destinationStation!.id,
         mobilityType: _selectedMobilityType,
+        constraintMode: _selectedConstraintMode,
       ),
     );
   }
@@ -1913,6 +1944,9 @@ class _RouteSearchScreenState extends State<RouteSearchScreen> {
     }
     setState(() {
       _selectedMobilityType = selectedMobilityType;
+      _selectedConstraintMode = RouteSearchRequest._defaultConstraintMode(
+        selectedMobilityType,
+      );
     });
     _controller.reset();
   }

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -547,6 +547,7 @@ void main() {
         originStationId: 'station-a',
         destinationStationId: 'station-c',
         mobilityType: 'STROLLER',
+        constraintMode: 'STRICT_STEP_FREE',
       ),
     );
 

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -144,6 +144,24 @@ void main() {
       expect(result.blockedReasonCodes, ['STAIR_ONLY_ACCESS']);
     });
 
+    test('휠체어 prefer 조건은 계단 포함 경로 비용을 경고와 함께 유지한다', () {
+      final engine = LocalRouteEngine(graph: _stairOnlyFixtureGraph());
+
+      final result = engine.search(
+        const RouteRequest(
+          originStationId: 'station-sangnoksu',
+          destinationStationId: 'station-sadang',
+          mobilityType: MobilityType.wheelchair,
+          constraintMode: ConstraintMode.preferStepFree,
+        ),
+      );
+
+      expect(result.status, RouteStatus.found);
+      expect(result.totalCost, 749);
+      expect(result.steps.map((step) => step.cost), [160, 420, 145]);
+      expect(result.warningCodes, ['STAIR_ONLY_ACCESS']);
+    });
+
     test('휠체어 조건은 미확인 접근성 edge를 안전한 경로로 사용하지 않는다', () {
       final engine = LocalRouteEngine(
         graph: _unknownAccessibilityFixtureGraph(),

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -128,6 +128,22 @@ void main() {
       expect(result.warningCodes, isEmpty);
     });
 
+    test('일시적 부상 strict 조건은 계단만 있는 경로를 차단한다', () {
+      final engine = LocalRouteEngine(graph: _stairOnlyFixtureGraph());
+
+      final result = engine.search(
+        const RouteRequest(
+          originStationId: 'station-sangnoksu',
+          destinationStationId: 'station-sadang',
+          mobilityType: MobilityType.temporaryInjury,
+          constraintMode: ConstraintMode.strictStepFree,
+        ),
+      );
+
+      expect(result.status, RouteStatus.blocked);
+      expect(result.blockedReasonCodes, ['STAIR_ONLY_ACCESS']);
+    });
+
     test('휠체어 조건은 미확인 접근성 edge를 안전한 경로로 사용하지 않는다', () {
       final engine = LocalRouteEngine(
         graph: _unknownAccessibilityFixtureGraph(),
@@ -367,6 +383,7 @@ void main() {
               originStationId: 'station-sangnoksu',
               destinationStationId: 'station-sadang',
               mobilityType: MobilityType.stroller,
+              constraintMode: ConstraintMode.strictStepFree,
             ),
           );
       final staleResult = LocalRouteEngine(graph: _lowQualityFixtureGraph())
@@ -375,6 +392,7 @@ void main() {
               originStationId: 'station-sangnoksu',
               destinationStationId: 'station-sadang',
               mobilityType: MobilityType.stroller,
+              constraintMode: ConstraintMode.strictStepFree,
             ),
           );
       final generatedResult =
@@ -383,6 +401,7 @@ void main() {
               originStationId: 'station-a',
               destinationStationId: 'station-b',
               mobilityType: MobilityType.stroller,
+              constraintMode: ConstraintMode.strictStepFree,
             ),
           );
 

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -264,6 +264,7 @@ void main() {
       'originStationId': 'station-sangnoksu',
       'destinationStationId': 'station-sadang',
       'mobilityType': 'WHEELCHAIR',
+      'constraintMode': 'STRICT_STEP_FREE',
     });
     expect(result.routeSearchId, 'route-1');
     expect(result.summaryTitle, '상록수에서 사당까지');
@@ -513,6 +514,34 @@ void main() {
     expect(legacyResult.score, 92);
     expect(legacyResult.accessibilityScore, 92);
     expect(legacyResult.burdenCost, 92);
+  });
+
+  test('경로 검색 요청은 이동 유형별 기본 constraintMode를 직렬화한다', () {
+    expect(
+      const RouteSearchRequest(
+        originStationId: 'a',
+        destinationStationId: 'b',
+        mobilityType: 'WHEELCHAIR',
+      ).toJson()['constraintMode'],
+      'STRICT_STEP_FREE',
+    );
+    expect(
+      const RouteSearchRequest(
+        originStationId: 'a',
+        destinationStationId: 'b',
+        mobilityType: 'STROLLER',
+      ).toJson()['constraintMode'],
+      'PREFER_STEP_FREE',
+    );
+    expect(
+      const RouteSearchRequest(
+        originStationId: 'a',
+        destinationStationId: 'b',
+        mobilityType: 'TEMPORARY_INJURY',
+        constraintMode: 'STRICT_STEP_FREE',
+      ).toJson()['constraintMode'],
+      'STRICT_STEP_FREE',
+    );
   });
 
   test('경로 V2 contract는 itinerary와 leg 단위 ETA 필드를 읽는다', () {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -6102,6 +6102,8 @@ void main() {
       expect(find.bySemanticsLabel('출발 도착 바꾸기'), findsOneWidget);
       expect(find.text('이동 조건'), findsOneWidget);
       expect(find.text('계단 피하기 · 환승 줄이기'), findsWidgets);
+      expect(find.text('계단 없는 길만'), findsOneWidget);
+      expect(find.text('켜면 경로가 줄거나 없을 수 있어요.'), findsOneWidget);
       expect(find.widgetWithText(FilledButton, '길찾기'), findsOneWidget);
 
       await tester.drag(find.byType(ListView), const Offset(0, -260));
@@ -6115,6 +6117,43 @@ void main() {
     } finally {
       semanticsHandle.dispose();
     }
+  });
+
+  testWidgets('경로 검색 strict switch는 STRICT_STEP_FREE 요청을 보낸다', (tester) async {
+    final routeRepository = FakeRouteSearchRepository();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: routeRepository,
+          stationRepository: FakeStationSearchRepository(),
+          favoriteRouteRepository: FakeFavoriteRouteRepository(),
+          initialMobilityType: 'SENIOR',
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 6, 30),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeStrictStepFreeSwitch')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(routeRepository.requests.single.mobilityType, 'SENIOR');
+    expect(
+      routeRepository.requests.single.effectiveConstraintMode,
+      'STRICT_STEP_FREE',
+    );
   });
 
   testWidgets('경로 검색 최근 도착지 실패는 빈 화면으로 숨기지 않는다', (tester) async {

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -5,6 +5,7 @@ import com.easysubway.common.web.ApiResponse;
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
+import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
@@ -51,11 +52,15 @@ class RouteSearchController {
 		@NotBlank(message = "도착역을 선택해야 합니다.")
 		String destinationStationId,
 		@NotNull(message = "이동 유형을 선택해야 합니다.")
-		MobilityType mobilityType
+		MobilityType mobilityType,
+		String constraintMode
 	) {
 
 		SearchRouteCommand toCommand() {
-			return new SearchRouteCommand(originStationId, destinationStationId, mobilityType);
+			ConstraintMode mode = constraintMode == null || constraintMode.isBlank()
+				? ConstraintMode.defaultFor(mobilityType)
+				: parseConstraintMode(constraintMode);
+			return new SearchRouteCommand(originStationId, destinationStationId, mobilityType, mode);
 		}
 	}
 
@@ -138,7 +143,7 @@ class RouteSearchController {
 	) {
 
 		SearchRouteCommand toCommand() {
-			return new SearchRouteCommand(originStationId, destinationStationId, effectiveMobilityType());
+			return new SearchRouteCommand(originStationId, destinationStationId, mobilityType, parseConstraintMode(constraintMode));
 		}
 
 		OffsetDateTime parsedDepartureTime() {
@@ -149,15 +154,6 @@ class RouteSearchController {
 			}
 		}
 
-		private MobilityType effectiveMobilityType() {
-			if ("PROFILE_DEFAULT".equals(constraintMode)) {
-				return mobilityType;
-			}
-			if ("STRICT_STEP_FREE".equals(constraintMode)) {
-				return MobilityType.WHEELCHAIR;
-			}
-			throw new InvalidRequestException("지원하지 않는 이동 제약 조건입니다.");
-		}
 	}
 
 	private record RouteSearchV2Response(
@@ -334,5 +330,13 @@ class RouteSearchController {
 
 	private static String formatOffset(OffsetDateTime dateTime) {
 		return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX"));
+	}
+
+	private static ConstraintMode parseConstraintMode(String value) {
+		try {
+			return ConstraintMode.valueOf(value);
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidRequestException("지원하지 않는 이동 제약 조건입니다.", exception);
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -59,7 +59,7 @@ class RouteSearchController {
 		SearchRouteCommand toCommand() {
 			ConstraintMode mode = constraintMode == null || constraintMode.isBlank()
 				? ConstraintMode.defaultFor(mobilityType)
-				: parseConstraintMode(constraintMode);
+				: parseConstraintMode(mobilityType, constraintMode);
 			return new SearchRouteCommand(originStationId, destinationStationId, mobilityType, mode);
 		}
 	}
@@ -143,7 +143,12 @@ class RouteSearchController {
 	) {
 
 		SearchRouteCommand toCommand() {
-			return new SearchRouteCommand(originStationId, destinationStationId, mobilityType, parseConstraintMode(constraintMode));
+			return new SearchRouteCommand(
+				originStationId,
+				destinationStationId,
+				mobilityType,
+				parseConstraintMode(mobilityType, constraintMode)
+			);
 		}
 
 		OffsetDateTime parsedDepartureTime() {
@@ -338,5 +343,12 @@ class RouteSearchController {
 		} catch (IllegalArgumentException exception) {
 			throw new InvalidRequestException("지원하지 않는 이동 제약 조건입니다.", exception);
 		}
+	}
+
+	private static ConstraintMode parseConstraintMode(MobilityType mobilityType, String value) {
+		if ("PROFILE_DEFAULT".equals(value)) {
+			return ConstraintMode.defaultFor(mobilityType);
+		}
+		return parseConstraintMode(value);
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/port/in/SearchRouteCommand.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/SearchRouteCommand.java
@@ -1,10 +1,21 @@
 package com.easysubway.route.application.port.in;
 
 import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.domain.ConstraintMode;
 
 public record SearchRouteCommand(
 	String originStationId,
 	String destinationStationId,
-	MobilityType mobilityType
+	MobilityType mobilityType,
+	ConstraintMode constraintMode
 ) {
+	public SearchRouteCommand(String originStationId, String destinationStationId, MobilityType mobilityType) {
+		this(originStationId, destinationStationId, mobilityType, ConstraintMode.defaultFor(mobilityType));
+	}
+
+	public SearchRouteCommand {
+		if (constraintMode == null) {
+			constraintMode = ConstraintMode.defaultFor(mobilityType);
+		}
+	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -126,7 +126,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			throw new InvalidRouteSearchException("출발역과 도착역이 달라야 합니다.");
 		}
 
-		RouteProfileWeight profileWeight = RouteProfileWeight.from(command.mobilityType());
+		RouteProfileWeight profileWeight = RouteProfileWeight.from(command.mobilityType(), command.constraintMode());
 		RoutePlan routePlan = findRoutePlan(origin.id(), destination.id(), profileWeight);
 		List<String> accessibilityStationIds = routePlan.accessibilityStationIds(origin.id(), destination.id());
 		boolean stairOnlyAccess = hasStairOnlyAccess(accessibilityStationIds);

--- a/backend/src/main/java/com/easysubway/route/domain/ConstraintMode.java
+++ b/backend/src/main/java/com/easysubway/route/domain/ConstraintMode.java
@@ -1,0 +1,13 @@
+package com.easysubway.route.domain;
+
+import com.easysubway.profile.domain.MobilityType;
+
+public enum ConstraintMode {
+	STRICT_STEP_FREE,
+	PREFER_STEP_FREE,
+	ALLOW_WITH_WARNINGS;
+
+	public static ConstraintMode defaultFor(MobilityType mobilityType) {
+		return mobilityType == MobilityType.WHEELCHAIR ? STRICT_STEP_FREE : PREFER_STEP_FREE;
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteProfileWeight.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteProfileWeight.java
@@ -71,4 +71,17 @@ public record RouteProfileWeight(
 			);
 		};
 	}
+
+	public static RouteProfileWeight from(MobilityType mobilityType, ConstraintMode constraintMode) {
+		RouteProfileWeight base = from(mobilityType);
+		return new RouteProfileWeight(
+			base.baseAccessCost(),
+			base.lowDataConfidencePenalty(),
+			base.stairOnlyAccessPenalty(),
+			base.transferPenalty(),
+			constraintMode == ConstraintMode.STRICT_STEP_FREE,
+			base.entryGuidance(),
+			base.exitGuidance()
+		);
+	}
 }

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -153,6 +153,32 @@ class RouteSearchV2ControllerTest {
 	}
 
 	@Test
+	@DisplayName("V2 PROFILE_DEFAULT는 기존 client 호환을 위해 mobility type 기본 constraint로 처리한다")
+	void routeSearchV2ProfileDefaultUsesMobilityTypeDefaultConstraintMode() throws Exception {
+		when(routeSearchUseCase.searchRoute(argThat(command ->
+			command.mobilityType() == MobilityType.STROLLER
+				&& command.constraintMode() == ConstraintMode.PREFER_STEP_FREE
+		))).thenReturn(foundRouteSearch());
+
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "constraintMode": "PROFILE_DEFAULT",
+					  "useRealtime": true,
+					  "maxTransfers": 3,
+					  "alternativeCount": 3
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.constraintMode").value("PROFILE_DEFAULT"));
+	}
+
+	@Test
 	@DisplayName("알 수 없는 V2 constraintMode는 search 저장 전에 JSON 400으로 거부한다")
 	void unknownRouteSearchV2ConstraintModeReturnsBadRequestBeforeSearch() throws Exception {
 		mockMvc.perform(post("/api/v2/routes/search")

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -179,6 +179,32 @@ class RouteSearchV2ControllerTest {
 	}
 
 	@Test
+	@DisplayName("V2 allow-with-warnings는 constraintMode를 command와 응답에 반영한다")
+	void routeSearchV2AllowWithWarningsKeepsConstraintMode() throws Exception {
+		when(routeSearchUseCase.searchRoute(argThat(command ->
+			command.mobilityType() == MobilityType.STROLLER
+				&& command.constraintMode() == ConstraintMode.ALLOW_WITH_WARNINGS
+		))).thenReturn(foundRouteSearch());
+
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "constraintMode": "ALLOW_WITH_WARNINGS",
+					  "useRealtime": true,
+					  "maxTransfers": 3,
+					  "alternativeCount": 3
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.constraintMode").value("ALLOW_WITH_WARNINGS"));
+	}
+
+	@Test
 	@DisplayName("알 수 없는 V2 constraintMode는 search 저장 전에 JSON 400으로 거부한다")
 	void unknownRouteSearchV2ConstraintModeReturnsBadRequestBeforeSearch() throws Exception {
 		mockMvc.perform(post("/api/v2/routes/search")

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
+import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
@@ -44,7 +45,8 @@ class RouteSearchV2ControllerTest {
 		when(routeSearchUseCase.searchRoute(argThat(command ->
 			"station-sangnoksu".equals(command.originStationId())
 				&& "station-sadang".equals(command.destinationStationId())
-				&& command.mobilityType() == MobilityType.WHEELCHAIR
+				&& command.mobilityType() == MobilityType.STROLLER
+				&& command.constraintMode() == ConstraintMode.STRICT_STEP_FREE
 		))).thenReturn(foundRouteSearch());
 
 		mockMvc.perform(post("/api/v2/routes/search")
@@ -120,6 +122,57 @@ class RouteSearchV2ControllerTest {
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.message").value("출발 시간은 ISO offset 형식이어야 합니다."));
+
+		verifyNoInteractions(routeSearchUseCase);
+	}
+
+	@Test
+	@DisplayName("V2 prefer step-free는 mobility type을 유지한 채 command에 전달한다")
+	void routeSearchV2PreferStepFreeKeepsMobilityType() throws Exception {
+		when(routeSearchUseCase.searchRoute(argThat(command ->
+			command.mobilityType() == MobilityType.STROLLER
+				&& command.constraintMode() == ConstraintMode.PREFER_STEP_FREE
+		))).thenReturn(foundRouteSearch());
+
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "constraintMode": "PREFER_STEP_FREE",
+					  "useRealtime": true,
+					  "maxTransfers": 3,
+					  "alternativeCount": 3
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.constraintMode").value("PREFER_STEP_FREE"));
+	}
+
+	@Test
+	@DisplayName("알 수 없는 V2 constraintMode는 search 저장 전에 JSON 400으로 거부한다")
+	void unknownRouteSearchV2ConstraintModeReturnsBadRequestBeforeSearch() throws Exception {
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "constraintMode": "STAIRS_ARE_FINE",
+					  "useRealtime": true,
+					  "maxTransfers": 3,
+					  "alternativeCount": 3
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").value("지원하지 않는 이동 제약 조건입니다."));
 
 		verifyNoInteractions(routeSearchUseCase);
 	}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -272,6 +272,30 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("유모차 strict step-free 조건은 계단만 있는 역 접근 경로를 차단한다")
+	void strollerStrictStepFreeBlocksStairOnlyStationAccess() {
+		var repository = new InMemoryRouteSearchRepository();
+		var stairOnlyService = new RouteSearchService(
+			repository,
+			repository,
+			new StairOnlyTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = stairOnlyService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.STROLLER,
+			ConstraintMode.STRICT_STEP_FREE
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
+		assertThat(result.steps()).isEmpty();
+		assertThat(result.blockedReasons())
+			.containsExactly("계단 없는 역 접근 경로를 확인할 수 없습니다.");
+	}
+
+	@Test
 	@DisplayName("공통 노선이 없으면 한 번 환승 가능한 역을 경로로 반환한다")
 	void searchRouteReturnsOneTransferRecommendation() {
 		var repository = new InMemoryRouteSearchRepository();

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -9,6 +9,7 @@ import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepositor
 import com.easysubway.route.application.port.in.SearchInternalRouteCommand;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
+import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.InvalidRouteFeedbackException;
 import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteFeedbackRating;
@@ -242,6 +243,30 @@ class RouteSearchServiceTest {
 		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
 		assertThat(result.steps()).isEmpty();
 		assertThat(result.recommendationReasons()).isEmpty();
+		assertThat(result.blockedReasons())
+			.containsExactly("계단 없는 역 접근 경로를 확인할 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("일시적 부상 strict step-free 조건은 계단만 있는 역 접근 경로를 차단한다")
+	void temporaryInjuryStrictStepFreeBlocksStairOnlyStationAccess() {
+		var repository = new InMemoryRouteSearchRepository();
+		var stairOnlyService = new RouteSearchService(
+			repository,
+			repository,
+			new StairOnlyTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = stairOnlyService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.TEMPORARY_INJURY,
+			ConstraintMode.STRICT_STEP_FREE
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
+		assertThat(result.steps()).isEmpty();
 		assertThat(result.blockedReasons())
 			.containsExactly("계단 없는 역 접근 경로를 확인할 수 없습니다.");
 	}


### PR DESCRIPTION
## 관련 이슈

close #1224

## 작업 배경

- MobilityType은 사용자 상황으로 유지하고, 계단 없는 경로 강제 여부는 ConstraintMode로 별도 전달해야 한다.
- 휠체어 기본 strict 동작은 유지하면서 stroller, pregnant, temporary injury, luggage, senior는 기본 prefer로 둔다.

## 작업 내용

- mobile/backend에 `STRICT_STEP_FREE`, `PREFER_STEP_FREE`, `ALLOW_WITH_WARNINGS` ConstraintMode mapping과 기본값을 추가했다.
- strict mode일 때 휠체어 외 이동 유형도 stair-only/unknown accessibility edge를 차단하도록 route weight/cost 계산에 연결했다.
- route search 화면에 `계단 없는 길만` switch와 안내 문구를 추가하고 요청 payload에 `constraintMode`를 직렬화한다.
- V1은 `constraintMode` 누락 시 기존 기본 동작을 유지하고, V2는 unknown `constraintMode`를 search 저장 전에 400으로 거부한다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests '*RouteSearchV2ControllerTest' --tests '*RouteSearchServiceTest'` -> PASS
  - `cd apps/mobile && flutter test test/features/routes test/route_search_test.dart test/widget_test.dart` -> PASS, `All tests passed!`
  - `node --test tools/ci/*.test.mjs` -> PASS, 159 tests
  - `git diff --check origin/main...HEAD` -> PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| constraintMode API contract | backend | controller/service targeted test | `./gradlew test --tests '*RouteSearchV2ControllerTest' --tests '*RouteSearchServiceTest'` | PASS |
| strict route blocking | Android / iOS 공통 domain | route engine/local repository test | `flutter test test/features/routes` | PASS |
| strict switch UI copy/request | Android / iOS 공통 widget | widget test로 문구와 request payload 확인 | `flutter test test/widget_test.dart` | PASS |
| repository contract gates | repository | Node CI contract tests | `node --test tools/ci/*.test.mjs` | PASS |

## Version impact

- [ ] no version change
- [x] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: route search request `constraintMode` enum 분리
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java`
  - `apps/mobile/lib/route_search.dart`
  - `apps/mobile/lib/features/routes/domain/route_request.dart`

## 리스크

- saved favorite/history migration은 #1224 제외 범위라 추가하지 않았다. 현재 선택한 strict mode는 경로 검색 요청 단위로만 전달된다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 경로 검색에 이동 제약 모드를 추가해, “계단 없는 길만” 옵션을 선택할 수 있게 됐습니다.
  * 이동 유형에 따라 기본 제약 모드가 자동 적용되어 경로 검색이 더 일관되게 동작합니다.

* **Bug Fixes**
  * 엄격한 계단 없는 길 조건에서 미확인·생성·오래된 경로가 잘못 사용되던 문제를 개선했습니다.
  * 계단만 있는 경로는 더 정확하게 차단되며, 관련 안내 문구가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->