### PR TITLE
[Fix] 알림 설정 padding 토큰 정리

### DIFF
--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -17,6 +17,8 @@ const _notificationPermissionErrorMessage = '알림을 켤 수 있는지 확인�
 const _notificationRegistrationFailureNextAction =
     '휴대전화 알림 설정과 인터넷 연결을 확인한 뒤 다시 시도해 주세요.';
 const _notificationSwitchTileRadius = BorderRadius.all(Radius.circular(8));
+const _notificationSettingsContentPadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
+const _notificationSettingsFailurePadding = EdgeInsets.fromLTRB(20, 32, 20, 32);
 
 abstract class NotificationSettingsRepository {
   Future<NotificationSettings> getNotificationSettings();
@@ -780,7 +782,7 @@ class _NotificationSettingsContent extends StatelessWidget {
     final isSaving = state.isSaving;
 
     return ListView(
-      padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+      padding: _notificationSettingsContentPadding,
       children: [
         if (notificationPermissionProvider != null) ...[
           Semantics(
@@ -1001,7 +1003,7 @@ class _NotificationSettingsFailure extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView(
-      padding: const EdgeInsets.fromLTRB(20, 32, 20, 32),
+      padding: _notificationSettingsFailurePadding,
       children: [
         Semantics(
           liveRegion: true,


### PR DESCRIPTION
## 요약

- #1075 디자인 시스템 정리 후속입니다.
- 알림 설정 화면의 content/failure 목록 padding 직접값을 파일 local token으로 분리했습니다.

## 검증

- `dart format lib/notification_settings.dart`
- `rg -n "padding: const EdgeInsets\\.fromLTRB\\(" lib/notification_settings.dart` (no matches)
- `flutter analyze lib/notification_settings.dart`
- `flutter test test/notification_settings_test.dart --reporter expanded`
- `flutter test test/widget_test.dart --name "알림 설정 화면" --reporter expanded`
- `flutter analyze`
- `git diff --check`

## 증거

- UI 동작 변경 없는 style token 추출이라 별도 스크린샷 증거는 불필요합니다.
