### PR TITLE
[Test] 모바일 async 실패 상태 감사 계약 추가

### DIFF
--- a/apps/mobile/release/issue-1075-async-state-audit.json
+++ b/apps/mobile/release/issue-1075-async-state-audit.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "issue": 1075,
+  "titleKo": "모바일 async 실패 상태 감사",
+  "scope": "apps/mobile/lib/**/*.dart",
+  "command": "node --test --test-name-pattern \"모바일 async 실패\" tools/ci/repository-contract.test.mjs",
+  "silentEmptyListCatchReturns": [],
+  "checkedStates": [
+    "homeFacilityAlert",
+    "homeRecentRoute",
+    "favoriteHome",
+    "favoriteStationList",
+    "favoriteFacilityList",
+    "favoriteRouteList",
+    "networkMap",
+    "routeSearch",
+    "stationSearch",
+    "facilityReport"
+  ]
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -221,6 +221,22 @@ function assertMobileCatchPolicy(file, source) {
   }
 }
 
+function catchBlocks(source) {
+  const blocks = [];
+  const catchPattern = /catch\s*\([^)]*\)\s*\{/g;
+  for (const match of source.matchAll(catchPattern)) {
+    let depth = 1;
+    let cursor = match.index + match[0].length;
+    while (cursor < source.length && depth > 0) {
+      const char = source[cursor++];
+      if (char === "{") depth++;
+      if (char === "}") depth--;
+    }
+    blocks.push(source.slice(match.index, cursor));
+  }
+  return blocks;
+}
+
 function collectStatusValues(value, values = []) {
   if (Array.isArray(value)) {
     for (const item of value) {
@@ -1008,6 +1024,24 @@ test("모바일 generic catch는 원본 예외와 스택을 버리지 않는다"
   assert.ok(mobileFiles.length > 0, "mobile Dart files not found");
   for (const file of mobileFiles) {
     assertMobileCatchPolicy(file, read(file));
+  }
+});
+
+test("모바일 async 실패는 빈 목록으로 조용히 숨기지 않는다", () => {
+  const audit = readJson("apps/mobile/release/issue-1075-async-state-audit.json");
+
+  assert.equal(audit.issue, 1075);
+  assert.deepEqual(audit.silentEmptyListCatchReturns, []);
+  assert.match(audit.command, /node --test/);
+
+  for (const file of mobileProductionDartFiles()) {
+    for (const block of catchBlocks(read(file))) {
+      assert.doesNotMatch(
+        block,
+        /return const (?:<[^>]+>)?\[\];/,
+        `${file} hides an async catch failure as an empty list`,
+      );
+    }
   }
 });
 


### PR DESCRIPTION
## 요약
- #1075 모바일 async 실패 상태 감사 manifest 추가
- repository contract에서 generic catch 블록이 `return const []`로 실패를 숨기지 않는지 스캔
- 남은 체크리스트 중 `async 실패를 빈 목록으로 변환하는 catch 처리` 감사 항목 증거 보강

## 검증
- `node --test --test-name-pattern "모바일 async 실패" tools/ci/repository-contract.test.mjs`
- `node --test tools/ci/repository-contract.test.mjs`
- `git diff --check HEAD~1..HEAD`

## 증거
- audit manifest: `apps/mobile/release/issue-1075-async-state-audit.json`
- UI 변경 없음, screenshot 증거 불필요

Closes part of #1075.
