### PR TITLE
[Feat] Accessibility risk vector 도입

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -786,12 +786,40 @@ class RouteSearchV2Leg {
 
 class RouteSearchV2AccessibilityRisk {
   const RouteSearchV2AccessibilityRisk({
+    required this.stairCount,
+    required this.unknownAccessibilityCount,
+    required this.generatedConnectorCount,
+    required this.staleDataCount,
+    required this.lowConfidenceCount,
+    required this.unavailableFacilityCount,
+    required this.riskLevel,
+    required this.reasonCodes,
     required this.level,
     required this.reasons,
   });
 
   factory RouteSearchV2AccessibilityRisk.fromJson(Map<String, Object?> json) {
+    final reasonCodes = _routeStringList(
+      json['reasonCodes'] ?? json['reasons'],
+      'route v2 accessibility risk reason',
+    );
+    final riskLevel = _optionalRouteString(
+      json,
+      'riskLevel',
+      fallback: _optionalRouteString(json, 'level', fallback: 'UNKNOWN'),
+    );
     return RouteSearchV2AccessibilityRisk(
+      stairCount: _optionalRouteInt(json, 'stairCount') ?? 0,
+      unknownAccessibilityCount:
+          _optionalRouteInt(json, 'unknownAccessibilityCount') ?? 0,
+      generatedConnectorCount:
+          _optionalRouteInt(json, 'generatedConnectorCount') ?? 0,
+      staleDataCount: _optionalRouteInt(json, 'staleDataCount') ?? 0,
+      lowConfidenceCount: _optionalRouteInt(json, 'lowConfidenceCount') ?? 0,
+      unavailableFacilityCount:
+          _optionalRouteInt(json, 'unavailableFacilityCount') ?? 0,
+      riskLevel: riskLevel,
+      reasonCodes: reasonCodes,
       level: _requiredRouteString(json, 'level'),
       reasons: _routeStringList(
         json['reasons'],
@@ -800,6 +828,14 @@ class RouteSearchV2AccessibilityRisk {
     );
   }
 
+  final int stairCount;
+  final int unknownAccessibilityCount;
+  final int generatedConnectorCount;
+  final int staleDataCount;
+  final int lowConfidenceCount;
+  final int unavailableFacilityCount;
+  final String riskLevel;
+  final List<String> reasonCodes;
   final String level;
   final List<String> reasons;
 }

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -575,6 +575,18 @@ void main() {
           'transferCount': 0,
           'walkingDistanceMeters': 180,
           'accessibilityRisk': {
+            'stairCount': 1,
+            'unknownAccessibilityCount': 1,
+            'generatedConnectorCount': 0,
+            'staleDataCount': 1,
+            'lowConfidenceCount': 1,
+            'unavailableFacilityCount': 0,
+            'riskLevel': 'HIGH',
+            'reasonCodes': [
+              'LOW_DATA_CONFIDENCE',
+              'STALE_ACCESSIBILITY_DATA',
+              'ACCESSIBILITY_CHECK_REQUIRED',
+            ],
             'level': 'REVIEW_REQUIRED',
             'reasons': ['ACCESSIBILITY_CHECK_REQUIRED'],
           },
@@ -599,6 +611,17 @@ void main() {
               'etaSource': 'STATIC_BACKEND_V1',
               'confidence': 'LOW',
               'accessibilityRisk': {
+                'stairCount': 1,
+                'unknownAccessibilityCount': 1,
+                'generatedConnectorCount': 0,
+                'staleDataCount': 0,
+                'lowConfidenceCount': 0,
+                'unavailableFacilityCount': 0,
+                'riskLevel': 'HIGH',
+                'reasonCodes': [
+                  'STAIR_ONLY_ACCESS',
+                  'ACCESSIBILITY_CHECK_REQUIRED',
+                ],
                 'level': 'REVIEW_REQUIRED',
                 'reasons': ['ACCESSIBILITY_CHECK_REQUIRED'],
               },
@@ -616,7 +639,18 @@ void main() {
           'durationSeconds': 420,
           'transferCount': 0,
           'walkingDistanceMeters': 180,
-          'accessibilityRisk': {'level': 'UNKNOWN', 'reasons': <Object?>[]},
+          'accessibilityRisk': {
+            'stairCount': 0,
+            'unknownAccessibilityCount': 0,
+            'generatedConnectorCount': 0,
+            'staleDataCount': 0,
+            'lowConfidenceCount': 0,
+            'unavailableFacilityCount': 0,
+            'riskLevel': 'UNKNOWN',
+            'reasonCodes': <Object?>[],
+            'level': 'UNKNOWN',
+            'reasons': <Object?>[],
+          },
           'legs': <Object?>[],
           'commercialEtaEligible': false,
         },
@@ -634,7 +668,23 @@ void main() {
     expect(result.itineraries.first.realtimeArrivalTime, isNull);
     expect(result.itineraries.first.commercialEtaEligible, isFalse);
     expect(result.itineraries.first.accessibilityRisk.level, 'REVIEW_REQUIRED');
+    expect(result.itineraries.first.accessibilityRisk.riskLevel, 'HIGH');
+    expect(result.itineraries.first.accessibilityRisk.stairCount, 1);
+    expect(
+      result.itineraries.first.accessibilityRisk.unknownAccessibilityCount,
+      1,
+    );
+    expect(result.itineraries.first.accessibilityRisk.staleDataCount, 1);
+    expect(result.itineraries.first.accessibilityRisk.lowConfidenceCount, 1);
+    expect(
+      result.itineraries.first.accessibilityRisk.reasonCodes,
+      contains('STALE_ACCESSIBILITY_DATA'),
+    );
     expect(result.itineraries.first.legs.single.legType, 'ACCESS');
+    expect(
+      result.itineraries.first.legs.single.accessibilityRisk.riskLevel,
+      'HIGH',
+    );
     expect(result.itineraries.first.legs.single.waitTimeSeconds, 0);
     expect(result.itineraries.first.legs.single.slackSeconds, 0);
     expect(result.itineraries.first.legs.single.etaSource, 'STATIC_BACKEND_V1');

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -10,6 +10,7 @@ import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
 import com.easysubway.route.domain.RouteWarning;
+import com.easysubway.route.domain.RouteWarningCode;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Min;
@@ -267,10 +268,11 @@ class RouteSearchController {
 			int unknownAccessibilityCount = Math.toIntExact(result.steps().stream()
 				.filter(step -> "UNKNOWN".equals(step.stairAccessState()))
 				.count());
-			int generatedConnectorCount = countReason(reasonCodes, "GENERATED_CONNECTOR_UNVERIFIED");
-			int staleDataCount = countReason(reasonCodes, "STALE_ACCESSIBILITY_DATA");
-			int lowConfidenceCount = countReason(reasonCodes, "LOW_DATA_CONFIDENCE");
-			int unavailableFacilityCount = countReason(reasonCodes, "FACILITY_UNAVAILABLE");
+			// Keep the V2 response shape stable until route warnings expose these signals.
+			int generatedConnectorCount = 0;
+			int staleDataCount = countWarning(result.warnings(), RouteWarningCode.STALE_ACCESSIBILITY_DATA);
+			int lowConfidenceCount = countWarning(result.warnings(), RouteWarningCode.LOW_DATA_CONFIDENCE);
+			int unavailableFacilityCount = 0;
 			String riskLevel = riskLevel(
 				result.status(),
 				stairCount,
@@ -353,6 +355,12 @@ class RouteSearchController {
 		private static int countReason(List<String> reasonCodes, String reasonCode) {
 			return Math.toIntExact(reasonCodes.stream()
 				.filter(reasonCode::equals)
+				.count());
+		}
+
+		private static int countWarning(List<RouteWarning> warnings, RouteWarningCode warningCode) {
+			return Math.toIntExact(warnings.stream()
+				.filter(warning -> warning.code() == warningCode)
 				.count());
 		}
 

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -246,14 +246,150 @@ class RouteSearchController {
 		}
 	}
 
-	private record AccessibilityRiskDto(String level, List<String> reasons) {
+	private record AccessibilityRiskDto(
+		int stairCount,
+		int unknownAccessibilityCount,
+		int generatedConnectorCount,
+		int staleDataCount,
+		int lowConfidenceCount,
+		int unavailableFacilityCount,
+		String riskLevel,
+		List<String> reasonCodes,
+		String level,
+		List<String> reasons
+	) {
 
 		private static AccessibilityRiskDto from(RouteSearchResult result) {
-			List<String> reasons = result.evidenceSummary().stream()
-				.filter("ACCESSIBILITY_CHECK_REQUIRED"::equals)
-				.toList();
-			String level = reasons.isEmpty() ? "LOW" : "REVIEW_REQUIRED";
-			return new AccessibilityRiskDto(level, reasons);
+			List<String> reasonCodes = reasonCodesFrom(result);
+			int stairCount = Math.toIntExact(result.steps().stream()
+				.filter(RouteStep::includesStairs)
+				.count());
+			int unknownAccessibilityCount = Math.toIntExact(result.steps().stream()
+				.filter(step -> step.requiresAccessibilityCheck() || "UNKNOWN".equals(step.stairAccessState()))
+				.count());
+			int generatedConnectorCount = countReason(reasonCodes, "GENERATED_CONNECTOR_UNVERIFIED");
+			int staleDataCount = countReason(reasonCodes, "STALE_ACCESSIBILITY_DATA");
+			int lowConfidenceCount = countReason(reasonCodes, "LOW_DATA_CONFIDENCE");
+			int unavailableFacilityCount = countReason(reasonCodes, "FACILITY_UNAVAILABLE");
+			String riskLevel = riskLevel(
+				result.status(),
+				stairCount,
+				unknownAccessibilityCount,
+				generatedConnectorCount,
+				staleDataCount,
+				lowConfidenceCount,
+				unavailableFacilityCount
+			);
+			return new AccessibilityRiskDto(
+				stairCount,
+				unknownAccessibilityCount,
+				generatedConnectorCount,
+				staleDataCount,
+				lowConfidenceCount,
+				unavailableFacilityCount,
+				riskLevel,
+				reasonCodes,
+				legacyLevel(riskLevel),
+				reasonCodes
+			);
+		}
+
+		private static AccessibilityRiskDto from(RouteStep step) {
+			List<String> reasonCodes = reasonCodesFrom(step);
+			int stairCount = step.includesStairs() ? 1 : 0;
+			int unknownAccessibilityCount = step.requiresAccessibilityCheck() || "UNKNOWN".equals(step.stairAccessState()) ? 1 : 0;
+			int generatedConnectorCount = countReason(reasonCodes, "GENERATED_CONNECTOR_UNVERIFIED");
+			int staleDataCount = countReason(reasonCodes, "STALE_ACCESSIBILITY_DATA");
+			int lowConfidenceCount = countReason(reasonCodes, "LOW_DATA_CONFIDENCE");
+			int unavailableFacilityCount = countReason(reasonCodes, "FACILITY_UNAVAILABLE");
+			String riskLevel = riskLevel(
+				RouteSearchStatus.FOUND,
+				stairCount,
+				unknownAccessibilityCount,
+				generatedConnectorCount,
+				staleDataCount,
+				lowConfidenceCount,
+				unavailableFacilityCount
+			);
+			return new AccessibilityRiskDto(
+				stairCount,
+				unknownAccessibilityCount,
+				generatedConnectorCount,
+				staleDataCount,
+				lowConfidenceCount,
+				unavailableFacilityCount,
+				riskLevel,
+				reasonCodes,
+				legacyLevel(riskLevel),
+				reasonCodes
+			);
+		}
+
+		private static List<String> reasonCodesFrom(RouteSearchResult result) {
+			List<String> reasonCodes = new ArrayList<>();
+			result.blockedReasons().stream()
+				.filter(reason -> reason != null && !reason.isBlank())
+				.forEach(reasonCodes::add);
+			result.warnings().stream()
+				.map(warning -> warning.code().name())
+				.forEach(reasonCodes::add);
+			if (result.evidenceSummary().contains("ACCESSIBILITY_CHECK_REQUIRED")) {
+				reasonCodes.add("ACCESSIBILITY_CHECK_REQUIRED");
+			}
+			if (result.status() == RouteSearchStatus.BLOCKED && reasonCodes.isEmpty()) {
+				reasonCodes.add("BLOCKED_ACCESSIBILITY");
+			}
+			return List.copyOf(reasonCodes.stream().distinct().toList());
+		}
+
+		private static List<String> reasonCodesFrom(RouteStep step) {
+			List<String> reasonCodes = new ArrayList<>();
+			if (step.includesStairs()) {
+				reasonCodes.add("STAIR_ONLY_ACCESS");
+			}
+			if (step.requiresAccessibilityCheck() || "UNKNOWN".equals(step.stairAccessState())) {
+				reasonCodes.add("ACCESSIBILITY_CHECK_REQUIRED");
+			}
+			return List.copyOf(reasonCodes);
+		}
+
+		private static int countReason(List<String> reasonCodes, String reasonCode) {
+			return Math.toIntExact(reasonCodes.stream()
+				.filter(reasonCode::equals)
+				.count());
+		}
+
+		private static String riskLevel(
+			RouteSearchStatus status,
+			int stairCount,
+			int unknownAccessibilityCount,
+			int generatedConnectorCount,
+			int staleDataCount,
+			int lowConfidenceCount,
+			int unavailableFacilityCount
+		) {
+			if (status == RouteSearchStatus.BLOCKED) {
+				return "BLOCKED";
+			}
+			if (unavailableFacilityCount > 0 || stairCount > 0) {
+				return "HIGH";
+			}
+			if (unknownAccessibilityCount > 0 || generatedConnectorCount > 0) {
+				return "MEDIUM";
+			}
+			if (staleDataCount > 0 || lowConfidenceCount > 0) {
+				return "LOW";
+			}
+			return "NONE";
+		}
+
+		private static String legacyLevel(String riskLevel) {
+			return switch (riskLevel) {
+				case "BLOCKED" -> "BLOCKED";
+				case "HIGH", "MEDIUM" -> "REVIEW_REQUIRED";
+				case "LOW" -> "LOW";
+				default -> "LOW";
+			};
 		}
 	}
 
@@ -316,10 +452,7 @@ class RouteSearchController {
 				Math.max(0, step.distanceMeters()),
 				"STATIC_BACKEND_V1",
 				"LOW",
-				new AccessibilityRiskDto(
-					step.requiresAccessibilityCheck() ? "REVIEW_REQUIRED" : "LOW",
-					step.requiresAccessibilityCheck() ? List.of("ACCESSIBILITY_CHECK_REQUIRED") : List.of()
-				)
+				AccessibilityRiskDto.from(step)
 			);
 		}
 

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -265,7 +265,7 @@ class RouteSearchController {
 				.filter(RouteStep::includesStairs)
 				.count());
 			int unknownAccessibilityCount = Math.toIntExact(result.steps().stream()
-				.filter(step -> step.requiresAccessibilityCheck() || "UNKNOWN".equals(step.stairAccessState()))
+				.filter(step -> "UNKNOWN".equals(step.stairAccessState()))
 				.count());
 			int generatedConnectorCount = countReason(reasonCodes, "GENERATED_CONNECTOR_UNVERIFIED");
 			int staleDataCount = countReason(reasonCodes, "STALE_ACCESSIBILITY_DATA");
@@ -297,7 +297,7 @@ class RouteSearchController {
 		private static AccessibilityRiskDto from(RouteStep step) {
 			List<String> reasonCodes = reasonCodesFrom(step);
 			int stairCount = step.includesStairs() ? 1 : 0;
-			int unknownAccessibilityCount = step.requiresAccessibilityCheck() || "UNKNOWN".equals(step.stairAccessState()) ? 1 : 0;
+			int unknownAccessibilityCount = "UNKNOWN".equals(step.stairAccessState()) ? 1 : 0;
 			int generatedConnectorCount = countReason(reasonCodes, "GENERATED_CONNECTOR_UNVERIFIED");
 			int staleDataCount = countReason(reasonCodes, "STALE_ACCESSIBILITY_DATA");
 			int lowConfidenceCount = countReason(reasonCodes, "LOW_DATA_CONFIDENCE");
@@ -327,17 +327,14 @@ class RouteSearchController {
 
 		private static List<String> reasonCodesFrom(RouteSearchResult result) {
 			List<String> reasonCodes = new ArrayList<>();
-			result.blockedReasons().stream()
-				.filter(reason -> reason != null && !reason.isBlank())
-				.forEach(reasonCodes::add);
+			if (result.status() == RouteSearchStatus.BLOCKED) {
+				reasonCodes.add("BLOCKED_ACCESSIBILITY");
+			}
 			result.warnings().stream()
 				.map(warning -> warning.code().name())
 				.forEach(reasonCodes::add);
 			if (result.evidenceSummary().contains("ACCESSIBILITY_CHECK_REQUIRED")) {
 				reasonCodes.add("ACCESSIBILITY_CHECK_REQUIRED");
-			}
-			if (result.status() == RouteSearchStatus.BLOCKED && reasonCodes.isEmpty()) {
-				reasonCodes.add("BLOCKED_ACCESSIBILITY");
 			}
 			return List.copyOf(reasonCodes.stream().distinct().toList());
 		}

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -14,6 +14,8 @@ import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
+import com.easysubway.route.domain.RouteWarning;
+import com.easysubway.route.domain.RouteWarningCode;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -90,6 +92,13 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.data.itineraries[0].transferCount").value(0))
 			.andExpect(jsonPath("$.data.itineraries[0].walkingDistanceMeters").value(300))
 			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.level").value("LOW"))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.riskLevel").value("NONE"))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.stairCount").value(0))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.unknownAccessibilityCount").value(0))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.generatedConnectorCount").value(0))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.staleDataCount").value(0))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.lowConfidenceCount").value(0))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.unavailableFacilityCount").value(0))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].legType").value("ACCESS"))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].plannedDepartureTime").value("2026-06-30T09:15:00+09:00"))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].plannedArrivalTime").value("2026-06-30T09:19:00+09:00"))
@@ -99,6 +108,44 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].slackSeconds").value(0))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].etaSource").value("STATIC_BACKEND_V1"))
 			.andExpect(jsonPath("$.data.itineraries[0].commercialEtaEligible").value(false));
+	}
+
+	@Test
+	@DisplayName("모바일 V2 계약으로 accessibility risk vector count를 반환한다")
+	void routeSearchV2ReturnsAccessibilityRiskVectorCounts() throws Exception {
+		when(routeSearchUseCase.searchRoute(argThat(command ->
+			"station-risk-origin".equals(command.originStationId())
+				&& "station-risk-destination".equals(command.destinationStationId())
+		))).thenReturn(riskyRouteSearch());
+
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-risk-origin",
+					  "destinationStationId": "station-risk-destination",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "constraintMode": "ALLOW_WITH_WARNINGS",
+					  "useRealtime": true,
+					  "maxTransfers": 1,
+					  "alternativeCount": 1
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.riskLevel").value("HIGH"))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.stairCount").value(1))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.unknownAccessibilityCount").value(1))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.generatedConnectorCount").value(0))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.staleDataCount").value(1))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.lowConfidenceCount").value(1))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.unavailableFacilityCount").value(0))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.reasonCodes[0]").value("LOW_DATA_CONFIDENCE"))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.reasonCodes[1]").value("STALE_ACCESSIBILITY_DATA"))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.reasonCodes[2]").value("ACCESSIBILITY_CHECK_REQUIRED"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].accessibilityRisk.riskLevel").value("HIGH"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].accessibilityRisk.stairCount").value(1))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].accessibilityRisk.unknownAccessibilityCount").value(1));
 	}
 
 	@Test
@@ -277,6 +324,45 @@ class RouteSearchV2ControllerTest {
 				"LEGACY_STATIC"
 			)),
 			List.of(),
+			List.of(),
+			LocalDateTime.of(2026, 6, 30, 9, 0)
+		);
+	}
+
+	private RouteSearchResult riskyRouteSearch() {
+		return new RouteSearchResult(
+			"route-search-risk",
+			"station-risk-origin",
+			"위험 출발역",
+			"station-risk-destination",
+			"위험 도착역",
+			MobilityType.STROLLER,
+			RouteSearchStatus.FOUND,
+			"line-risk",
+			"위험 노선",
+			42,
+			List.of(new RouteStep(
+				1,
+				"entry",
+				"계단 포함 진입",
+				"계단과 확인 필요 구간을 포함합니다.",
+				"line-risk",
+				"위험 노선",
+				"station-risk-origin",
+				"station-risk-origin",
+				5,
+				90,
+				true,
+				"UNKNOWN",
+				true,
+				"STATIC_BACKEND_V1",
+				"STATIC_BACKEND_V1",
+				"LOW_CONFIDENCE"
+			)),
+			List.of(
+				new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE),
+				new RouteWarning(RouteWarningCode.STALE_ACCESSIBILITY_DATA)
+			),
 			List.of(),
 			LocalDateTime.of(2026, 6, 30, 9, 0)
 		);

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -145,7 +145,39 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.reasonCodes[2]").value("ACCESSIBILITY_CHECK_REQUIRED"))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].accessibilityRisk.riskLevel").value("HIGH"))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].accessibilityRisk.stairCount").value(1))
-			.andExpect(jsonPath("$.data.itineraries[0].legs[0].accessibilityRisk.unknownAccessibilityCount").value(1));
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].accessibilityRisk.unknownAccessibilityCount").value(0))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[1].accessibilityRisk.riskLevel").value("MEDIUM"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[1].accessibilityRisk.stairCount").value(0))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[1].accessibilityRisk.unknownAccessibilityCount").value(1));
+	}
+
+	@Test
+	@DisplayName("모바일 V2 계약의 blocked reasonCodes는 사용자 문장 대신 안정적인 코드만 반환한다")
+	void routeSearchV2BlockedRiskReasonCodesAreStableCodes() throws Exception {
+		when(routeSearchUseCase.searchRoute(argThat(command ->
+			"station-blocked-origin".equals(command.originStationId())
+				&& "station-blocked-destination".equals(command.destinationStationId())
+		))).thenReturn(blockedRouteSearch());
+
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-blocked-origin",
+					  "destinationStationId": "station-blocked-destination",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "WHEELCHAIR",
+					  "constraintMode": "STRICT_STEP_FREE",
+					  "useRealtime": true,
+					  "maxTransfers": 1,
+					  "alternativeCount": 1
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.itineraries[0].status").value("BLOCKED_ACCESSIBILITY"))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.riskLevel").value("BLOCKED"))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.reasonCodes[0]").value("BLOCKED_ACCESSIBILITY"))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.reasonCodes[1]").doesNotExist());
 	}
 
 	@Test
@@ -341,29 +373,68 @@ class RouteSearchV2ControllerTest {
 			"line-risk",
 			"위험 노선",
 			42,
-			List.of(new RouteStep(
-				1,
-				"entry",
-				"계단 포함 진입",
-				"계단과 확인 필요 구간을 포함합니다.",
-				"line-risk",
-				"위험 노선",
-				"station-risk-origin",
-				"station-risk-origin",
-				5,
-				90,
-				true,
-				"UNKNOWN",
-				true,
-				"STATIC_BACKEND_V1",
-				"STATIC_BACKEND_V1",
-				"LOW_CONFIDENCE"
-			)),
+			List.of(
+				new RouteStep(
+					1,
+					"entry",
+					"계단 포함 진입",
+					"계단과 확인 필요 구간을 포함합니다.",
+					"line-risk",
+					"위험 노선",
+					"station-risk-origin",
+					"station-risk-origin",
+					5,
+					90,
+					true,
+					"STAIR_ONLY",
+					true,
+					"STATIC_BACKEND_V1",
+					"STATIC_BACKEND_V1",
+					"LOW_CONFIDENCE"
+				),
+				new RouteStep(
+					2,
+					"exit",
+					"확인 필요 출구",
+					"계단 없는 길인지 추가 확인이 필요합니다.",
+					"line-risk",
+					"위험 노선",
+					"station-risk-destination",
+					"station-risk-destination",
+					3,
+					60,
+					false,
+					"UNKNOWN",
+					true,
+					"STATIC_BACKEND_V1",
+					"STATIC_BACKEND_V1",
+					"LOW_CONFIDENCE"
+				)
+			),
 			List.of(
 				new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE),
 				new RouteWarning(RouteWarningCode.STALE_ACCESSIBILITY_DATA)
 			),
 			List.of(),
+			LocalDateTime.of(2026, 6, 30, 9, 0)
+		);
+	}
+
+	private RouteSearchResult blockedRouteSearch() {
+		return new RouteSearchResult(
+			"route-search-blocked",
+			"station-blocked-origin",
+			"차단 출발역",
+			"station-blocked-destination",
+			"차단 도착역",
+			MobilityType.WHEELCHAIR,
+			RouteSearchStatus.BLOCKED,
+			"line-blocked",
+			"차단 노선",
+			0,
+			List.of(),
+			List.of(),
+			List.of("계단 없는 역 접근 경로를 확인할 수 없습니다."),
 			LocalDateTime.of(2026, 6, 30, 9, 0)
 		);
 	}

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -138,7 +138,7 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.unknownAccessibilityCount").value(1))
 			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.generatedConnectorCount").value(0))
 			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.staleDataCount").value(1))
-			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.lowConfidenceCount").value(1))
+			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.lowConfidenceCount").value(2))
 			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.unavailableFacilityCount").value(0))
 			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.reasonCodes[0]").value("LOW_DATA_CONFIDENCE"))
 			.andExpect(jsonPath("$.data.itineraries[0].accessibilityRisk.reasonCodes[1]").value("STALE_ACCESSIBILITY_DATA"))
@@ -412,6 +412,7 @@ class RouteSearchV2ControllerTest {
 				)
 			),
 			List.of(
+				new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE),
 				new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE),
 				new RouteWarning(RouteWarningCode.STALE_ACCESSIBILITY_DATA)
 			),


### PR DESCRIPTION
## 관련 이슈

close #1225

## 작업 배경

- Route V2 응답의 접근성 상태가 `level/reasons` 중심이라 계단, unknown, stale, low confidence 같은 risk를 수치로 구분하기 어렵다.
- G-2는 itinerary와 leg 단위에서 접근성 risk vector를 명시해 후속 UI badge, release gate, ranking 정책이 API 필드에 의존할 수 있게 하는 작업이다.

## 작업 내용

- backend Route V2 `accessibilityRisk`에 count 기반 risk vector를 추가했다.
- itinerary와 leg 모두 `stairCount`, `unknownAccessibilityCount`, `generatedConnectorCount`, `staleDataCount`, `lowConfidenceCount`, `unavailableFacilityCount`, `riskLevel`, `reasonCodes`를 반환한다.
- 기존 client 호환을 위해 `level/reasons` 필드는 유지했다.
- mobile Route V2 parser가 새 risk vector 필드를 읽도록 확장했다.
- backend/mobile contract test fixture에 risk count와 reasonCodes를 고정했다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests '*RouteSearchV2*'`: `BUILD SUCCESSFUL`
  - `cd apps/mobile && flutter test test/features/routes test/route_search_test.dart`: `All tests passed!` (`97` tests)

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Route V2 risk contract | Backend | `cd backend && ./gradlew test --tests '*RouteSearchV2*'` | terminal output | 통과 |
| Mobile route parser/route engine | Android / iOS 공통 | `cd apps/mobile && flutter test test/features/routes test/route_search_test.dart` | terminal output | 통과 |
| UI evidence | Android / iOS 공통 | 이번 PR은 DTO/parser contract 변경이며 화면 렌더링 변경 없음 | 증거 불필요 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: Route V2 `accessibilityRisk` additive fields 추가, legacy `level/reasons` 유지
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java`의 `AccessibilityRiskDto`
  - `apps/mobile/lib/route_search.dart`의 `RouteSearchV2AccessibilityRisk`

## 리스크

- 새 필드는 additive라 기존 `level/reasons` client는 유지된다.
- 실제 production ranking 변경은 이번 범위가 아니며 후속 route algorithm/ranking 작업에서 처리한다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 경로의 접근성 위험 정보가 더 세분화되어 표시됩니다. 계단 수, 미확인/생성 연결, 오래된 데이터, 낮은 신뢰도, 이용 불가 시설 관련 정보와 위험 수준, 사유 코드가 함께 제공됩니다.
  * 구간(leg)별로도 접근성 위험이 계산되어 더 정확한 경로 안내가 가능합니다.

* **버그 수정**
  * 위험 수준이 없을 때도 안정적으로 기본값을 사용하도록 개선했습니다.
  * 기존 요약 형태의 응답도 새 형식과 호환되도록 처리해 파싱 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->