### PR TITLE
[Fix] 모바일 공통 상태 카드 적용

### DIFF
--- a/apps/mobile/lib/accessible_design.dart
+++ b/apps/mobile/lib/accessible_design.dart
@@ -77,3 +77,70 @@ class AccessibleShortcutButton extends StatelessWidget {
     );
   }
 }
+
+class AccessibleStateCard extends StatelessWidget {
+  const AccessibleStateCard({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    this.actions = const [],
+    super.key,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final List<Widget> actions;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      label: '$title, $subtitle',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 48,
+                height: 48,
+                decoration: BoxDecoration(
+                  color: EasySubwayAccessibleColors.mintSoft,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(icon, color: colorScheme.primary, size: 28),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w900,
+                        height: 1.25,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      subtitle,
+                      style: Theme.of(
+                        context,
+                      ).textTheme.bodyMedium?.copyWith(height: 1.35),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (actions.isNotEmpty) ...[const SizedBox(height: 12), ...actions],
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -2965,32 +2965,20 @@ class _HomeStateCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final actionLabel = this.actionLabel;
-    return Semantics(
-      container: true,
-      liveRegion: true,
-      label: '$title, $subtitle',
-      child: _AppCard(
-        showBorder: true,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            _AppInfoRow(
-              icon: icon,
-              iconBackground: EasySubwayAccessibleColors.mintSoft,
-              iconColor: EasySubwayAccessibleColors.mintDark,
-              title: title,
-              subtitle: subtitle,
+    return _AppCard(
+      showBorder: true,
+      child: AccessibleStateCard(
+        icon: icon,
+        title: title,
+        subtitle: subtitle,
+        actions: [
+          if (actionLabel != null && onAction != null)
+            OutlinedButton.icon(
+              onPressed: onAction,
+              icon: const Icon(Icons.refresh),
+              label: Text(actionLabel),
             ),
-            if (actionLabel != null && onAction != null) ...[
-              const SizedBox(height: 12),
-              OutlinedButton.icon(
-                onPressed: onAction,
-                icon: const Icon(Icons.refresh),
-                label: Text(actionLabel),
-              ),
-            ],
-          ],
-        ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -408,55 +408,28 @@ class _NetworkMapLoadFailure extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Semantics(
-      container: true,
-      liveRegion: true,
-      label: '노선도를 불러오지 못했어요. 다시 시도하거나 역명으로 검색할 수 있어요.',
-      child: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Icon(
-                Icons.map_outlined,
-                size: 48,
-                color: Theme.of(context).colorScheme.primary,
-              ),
-              const SizedBox(height: 16),
-              Text(
-                '노선도를 불러오지 못했어요',
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                  fontWeight: FontWeight.w900,
-                  height: 1.25,
-                ),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                '네트워크 상태를 확인한 뒤 다시 시도하거나 역명으로 검색해 주세요.',
-                textAlign: TextAlign.center,
-                style: Theme.of(
-                  context,
-                ).textTheme.bodyMedium?.copyWith(height: 1.35),
-              ),
-              const SizedBox(height: 16),
-              FilledButton.icon(
-                key: const Key('networkMapRetryButton'),
-                onPressed: onRetry,
-                icon: const Icon(Icons.refresh),
-                label: const Text('다시 시도'),
-              ),
-              const SizedBox(height: 8),
-              OutlinedButton.icon(
-                key: const Key('networkMapStationSearchFallbackButton'),
-                onPressed: onOpenStationSearch,
-                icon: const Icon(Icons.search),
-                label: const Text('역명으로 검색'),
-              ),
-            ],
-          ),
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: AccessibleStateCard(
+          icon: Icons.map_outlined,
+          title: '노선도를 불러오지 못했어요',
+          subtitle: '네트워크 상태를 확인한 뒤 다시 시도하거나 역명으로 검색해 주세요.',
+          actions: [
+            FilledButton.icon(
+              key: const Key('networkMapRetryButton'),
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('다시 시도'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton.icon(
+              key: const Key('networkMapStationSearchFallbackButton'),
+              onPressed: onOpenStationSearch,
+              icon: const Icon(Icons.search),
+              label: const Text('역명으로 검색'),
+            ),
+          ],
         ),
       ),
     );

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1045,6 +1045,16 @@ test("모바일 async 실패는 빈 목록으로 조용히 숨기지 않는다",
   }
 });
 
+test("모바일 공통 상태 카드는 홈 즐겨찾기 노선도에서 사용된다", () => {
+  const accessibleDesign = read("apps/mobile/lib/accessible_design.dart");
+  const main = read("apps/mobile/lib/main.dart");
+  const networkMap = read("apps/mobile/lib/network_map.dart");
+
+  assert.match(accessibleDesign, /class AccessibleStateCard extends StatelessWidget/);
+  assert.match(main, /class _HomeStateCard extends StatelessWidget[\s\S]*AccessibleStateCard\(/);
+  assert.match(networkMap, /AccessibleStateCard\([\s\S]*networkMapRetryButton/);
+});
+
 test("프로덕션 모바일 UI 위젯명은 prototype 명칭을 쓰지 않는다", () => {
   const mobileFiles = execFileSync("git", ["ls-files", "apps/mobile/lib/*.dart"], {
     cwd: root,


### PR DESCRIPTION
## 요약
- 홈/즐겨찾기 상태 카드가 공통 AccessibleStateCard를 사용하도록 정리했습니다.
- 노선도 로드 실패 상태도 같은 공통 상태 카드와 재시도/역 검색 대안을 사용하도록 맞췄습니다.
- repository contract에 홈/즐겨찾기/노선도 공통 상태 카드 사용 계약을 추가했습니다.

## 검증
- node --test --test-name-pattern "모바일 공통 상태 카드" tools/ci/repository-contract.test.mjs
- cd apps/mobile && flutter test test/widget_test.dart --name "홈은 시설 알림과 최근 경로 로드 실패를 화면에 보여준다" --reporter expanded
- cd apps/mobile && flutter test test/widget_test.dart --name "즐겨찾기 홈 새로고침 실패는 오류 상태로 끝나고 예외를 흘리지 않는다" --reporter expanded
- cd apps/mobile && flutter test test/widget_test.dart --name "노선도 로드 실패는 재시도와 역 검색 대안을 보여준다" --reporter expanded
- cd apps/mobile && flutter analyze lib/accessible_design.dart lib/main.dart lib/network_map.dart
- node --test tools/ci/repository-contract.test.mjs
- git diff --check

증거 불필요 사유: 공통 컴포넌트 적용과 기존 실패/빈 상태 UI 구조 재사용이며, 신규 시각 QA 항목은 #1075의 별도 남은 체크박스에서 screenshot/golden 증거로 처리합니다.

Refs #1075