### PR TITLE
[Fix] 운영 알림 메일 한글 UX 개선

### DIFF
--- a/infra/alertmanager/templates/email.tmpl
+++ b/infra/alertmanager/templates/email.tmpl
@@ -1,29 +1,65 @@
-{{ define "easysubway.email.subject" }}[EasySubway 운영][{{ .Status | toUpper }}:{{ len .Alerts.Firing }}] {{ .CommonLabels.alertname }}{{ end }}
+{{ define "easysubway.status_ko" -}}
+{{- if eq . "firing" -}}장애 발생{{- else if eq . "resolved" -}}복구{{- else -}}{{ . }}{{- end -}}
+{{- end }}
+
+{{ define "easysubway.severity_ko" -}}
+{{- if eq . "critical" -}}긴급{{- else if eq . "warning" -}}주의{{- else if . -}}{{ . }}{{- else -}}미분류{{- end -}}
+{{- end }}
+
+{{ define "easysubway.email.subject" -}}
+{{- $title := or (index .CommonAnnotations "title_ko") (index .CommonAnnotations "summary") .CommonLabels.alertname -}}
+{{- $severity := or .CommonLabels.severity "unknown" -}}
+[쉬운지하철 운영][{{ template "easysubway.status_ko" .Status }}][{{ template "easysubway.severity_ko" $severity }}] {{ $title }}
+{{- end }}
 
 {{ define "easysubway.email.text" -}}
-상태: {{ .Status }}
-{{ if .ExternalURL }}Alertmanager: {{ .ExternalURL }}
-{{ end }}
+{{- $root := . -}}
 {{ range .Alerts }}
-- 알림: {{ .Labels.alertname }}
-  심각도: {{ .Labels.severity }}
-  서비스: {{ or .Labels.service .Labels.job }}
-  요약: {{ .Annotations.summary }}
-  설명: {{ .Annotations.description }}
-  시작: {{ .StartsAt }}
+쉬운지하철 운영 알림
+
+상태: {{ template "easysubway.status_ko" .Status }}
+심각도: {{ template "easysubway.severity_ko" .Labels.severity }}
+대상: {{ or .Labels.service .Labels.job }}
+알림: {{ or (index .Annotations "title_ko") (index .Annotations "summary") .Labels.alertname }}
+
+영향
+{{ or (index .Annotations "impact_ko") (index .Annotations "description") }}
+
+확인할 것
+{{ or (index .Annotations "action_ko") "Alertmanager와 관련 서비스 상태를 확인하세요." }}
+
+시작 시각
+{{ .StartsAt | tz "Asia/Seoul" | date "2006-01-02 15:04:05 -0700" }}
+
+{{ if $root.ExternalURL }}Alertmanager에서 보기
+{{ $root.ExternalURL }}
+{{ end }}
+
+내부 알림명: {{ .Labels.alertname }}
+job: {{ .Labels.job }}
+service: {{ .Labels.service }}
+
 {{ end }}
 {{- end }}
 
 {{ define "easysubway.email.html" -}}
-<h2>EasySubway 운영 알림: {{ .Status }}</h2>
-{{ if .ExternalURL }}<p><a href="{{ .ExternalURL }}">Alertmanager에서 보기</a></p>{{ end }}
+{{- $root := . -}}
+<h2>쉬운지하철 운영 알림</h2>
 {{ range .Alerts }}
+<table role="presentation" cellpadding="6" cellspacing="0" style="border-collapse:collapse;border:1px solid #d0d7de;width:100%;max-width:720px">
+  <tr><th align="left">상태</th><td>{{ template "easysubway.status_ko" .Status }}</td></tr>
+  <tr><th align="left">심각도</th><td>{{ template "easysubway.severity_ko" .Labels.severity }}</td></tr>
+  <tr><th align="left">대상</th><td>{{ or .Labels.service .Labels.job }}</td></tr>
+  <tr><th align="left">알림</th><td>{{ or (index .Annotations "title_ko") (index .Annotations "summary") .Labels.alertname }}</td></tr>
+</table>
+<h3>영향</h3>
+<p>{{ or (index .Annotations "impact_ko") (index .Annotations "description") }}</p>
+<h3>확인할 것</h3>
+<p>{{ or (index .Annotations "action_ko") "Alertmanager와 관련 서비스 상태를 확인하세요." }}</p>
+<h3>시작 시각</h3>
+<p>{{ .StartsAt | tz "Asia/Seoul" | date "2006-01-02 15:04:05 -0700" }}</p>
+{{ if $root.ExternalURL }}<p><a href="{{ $root.ExternalURL }}">Alertmanager에서 보기</a></p>{{ end }}
 <hr>
-<p><strong>알림</strong>: {{ .Labels.alertname }}</p>
-<p><strong>심각도</strong>: {{ .Labels.severity }}</p>
-<p><strong>서비스</strong>: {{ or .Labels.service .Labels.job }}</p>
-<p><strong>요약</strong>: {{ .Annotations.summary }}</p>
-<p><strong>설명</strong>: {{ .Annotations.description }}</p>
-<p><strong>시작</strong>: {{ .StartsAt }}</p>
+<p><small>내부 알림명: {{ .Labels.alertname }}<br>job: {{ .Labels.job }}<br>service: {{ .Labels.service }}</small></p>
 {{ end }}
 {{- end }}

--- a/infra/prometheus/alerts.yml
+++ b/infra/prometheus/alerts.yml
@@ -10,6 +10,9 @@ groups:
         annotations:
           summary: Public edge probe scrape is down
           description: Prometheus cannot scrape public_edge_probe for 5m. Check the exporter container, live probe refresh loop, and network path.
+          title_ko: "공개 접속 점검 실패"
+          impact_ko: "외부에서 API readiness를 확인하는 관측 신호가 멈췄습니다."
+          action_ko: "public-edge-probe 컨테이너 상태와 외부 HTTPS readiness 응답을 확인하세요."
 
       - alert: AquilaDockerRuntimeProbeScrapeDown
         expr: min(up{job="docker_runtime_probe"}) < 1
@@ -20,6 +23,9 @@ groups:
         annotations:
           summary: docker runtime probe scrape is down
           description: Prometheus cannot scrape docker_runtime_probe for 3m. Check probe container health and docker socket access.
+          title_ko: "Docker 런타임 점검 실패"
+          impact_ko: "컨테이너 상태 관측 신호가 멈춰 Docker 기반 장애 탐지가 늦어질 수 있습니다."
+          action_ko: "docker-runtime-probe 컨테이너 상태와 Docker socket 접근 권한을 확인하세요."
 
       - alert: AquilaBackWorkerScrapeDown
         expr: min(up{job="back_worker"}) < 1
@@ -30,3 +36,6 @@ groups:
         annotations:
           summary: Back worker metrics scrape is down
           description: Prometheus cannot scrape the backend worker target for 3m. Task queue and DLQ alerts may stop evaluating.
+          title_ko: "백그라운드 작업자 상태 점검 실패"
+          impact_ko: "작업 큐와 DLQ 관련 알림 평가가 늦거나 멈출 수 있습니다."
+          action_ko: "back-worker 컨테이너 상태와 /actuator/health/readiness 응답을 확인하세요."

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5754,10 +5754,24 @@ test("로컬 관측성 스택은 Prometheus와 Grafana 기준선을 제공한다
   assert.match(prometheusAlerts, /alert: AquilaPublicEdgeProbeScrapeDown/);
   assert.match(prometheusAlerts, /alert: AquilaDockerRuntimeProbeScrapeDown/);
   assert.match(prometheusAlerts, /alert: AquilaBackWorkerScrapeDown/);
+  assert.match(prometheusAlerts, /alert: AquilaPublicEdgeProbeScrapeDown[\s\S]*severity: warning[\s\S]*title_ko: "공개 접속 점검 실패"[\s\S]*impact_ko: "외부에서 API readiness를 확인하는 관측 신호가 멈췄습니다\."[\s\S]*action_ko: "public-edge-probe 컨테이너 상태와 외부 HTTPS readiness 응답을 확인하세요\."/);
+  assert.match(prometheusAlerts, /alert: AquilaDockerRuntimeProbeScrapeDown[\s\S]*severity: warning[\s\S]*title_ko: "Docker 런타임 점검 실패"[\s\S]*impact_ko: "컨테이너 상태 관측 신호가 멈춰 Docker 기반 장애 탐지가 늦어질 수 있습니다\."[\s\S]*action_ko: "docker-runtime-probe 컨테이너 상태와 Docker socket 접근 권한을 확인하세요\."/);
+  assert.match(prometheusAlerts, /alert: AquilaBackWorkerScrapeDown[\s\S]*severity: critical[\s\S]*title_ko: "백그라운드 작업자 상태 점검 실패"[\s\S]*impact_ko: "작업 큐와 DLQ 관련 알림 평가가 늦거나 멈출 수 있습니다\."[\s\S]*action_ko: "back-worker 컨테이너 상태와 \/actuator\/health\/readiness 응답을 확인하세요\."/);
   assert.match(alertmanagerConfig, /receiver: operations-null/);
   assert.match(alertmanagerConfig, /templates:\s*\n\s*-\s*\/etc\/alertmanager\/templates\/\*\.tmpl/);
   assert.match(alertmanagerTemplate, /define "easysubway\.email\.subject"/);
+  assert.match(alertmanagerTemplate, /define "easysubway\.status_ko"/);
+  assert.match(alertmanagerTemplate, /define "easysubway\.severity_ko"/);
+  assert.match(alertmanagerTemplate, /장애 발생/);
+  assert.match(alertmanagerTemplate, /복구/);
+  assert.match(alertmanagerTemplate, /주의/);
+  assert.match(alertmanagerTemplate, /긴급/);
+  assert.match(alertmanagerTemplate, /title_ko/);
+  assert.match(alertmanagerTemplate, /impact_ko/);
+  assert.match(alertmanagerTemplate, /action_ko/);
+  assert.match(alertmanagerTemplate, /Asia\/Seoul/);
   assert.doesNotMatch(alertmanagerTemplate, /\.GeneratorURL/);
+  assert.doesNotMatch(alertmanagerTemplate, /alertmanager:9093|prometheus:9090|backend:8080|back-worker:8080/);
 
   assert.match(grafanaDatasource, /name: easysubway-prometheus/);
   assert.match(grafanaDatasource, /type: prometheus/);


### PR DESCRIPTION
## 관련 이슈

close #1329

## 작업 배경

- 운영 알림 메일 제목과 본문 상단에 `FIRING`, `warning`, `AquilaPublicEdgeProbeScrapeDown` 같은 내부 값이 그대로 노출되어 장애 범위를 빠르게 판단하기 어렵다.
- 라우팅 계약인 `severity` label 값은 유지하고, 메일 표시만 한글 운영 문구로 바꾼다.

## 작업 내용

- scrape-down alert 3개에 `title_ko`, `impact_ko`, `action_ko` annotation을 추가했다.
- Alertmanager 이메일 제목을 `[쉬운지하철 운영][장애 발생/복구][주의/긴급] 한글 알림명` 형식으로 바꿨다.
- text/html 본문에 상태, 심각도, 대상, 알림, 영향, 확인할 것, KST 시작 시각을 표시하고 내부 alertname/job/service는 하단 보조 정보로 내렸다.
- 관측성 계약 테스트가 한글 annotation, 상태/심각도 한글 변환, 내부 Docker URL 미노출을 고정하도록 보강했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs --test-name-pattern='로컬 관측성'`: 151 tests passed
  - `node --test tools/ci/backend-deploy.test.mjs`: 4 tests passed
  - `promtool check rules infra/prometheus/alerts.yml`: SUCCESS, 3 rules found
  - `docker run --rm --entrypoint amtool -v "$PWD/infra/alertmanager:/etc/alertmanager:ro" prom/alertmanager:v0.33.0 check-config /etc/alertmanager/alertmanager.local.yml`: SUCCESS
  - `docker run --rm --entrypoint amtool -v "$PWD/infra/alertmanager/templates:/etc/alertmanager/templates:ro" -v "$PWD/.codex/evidence/1329-alertmanager-email.yml:/etc/alertmanager/alertmanager.yml:ro" prom/alertmanager:v0.33.0 check-config /etc/alertmanager/alertmanager.yml`: SUCCESS
  - `docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet`: exit 0
  - `node --test tools/ci/*.test.mjs`: 161 tests passed
  - `git diff --check`: exit 0

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 한글 알림 계약 | local | `node --test tools/ci/repository-contract.test.mjs --test-name-pattern='로컬 관측성'` | command output | 151 tests passed |
| 배포 계약 | local | `node --test tools/ci/backend-deploy.test.mjs` | command output | 4 tests passed |
| Prometheus rule 문법 | local | `promtool check rules infra/prometheus/alerts.yml` | command output | SUCCESS, 3 rules found |
| Alertmanager local config | local Docker | `prom/alertmanager:v0.33.0 amtool check-config` | command output | SUCCESS |
| Alertmanager email config | local Docker | email receiver sample config check | `.codex/evidence/1329-alertmanager-email.yml` local-only | SUCCESS |
| Compose config | local | `docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet` | command output | exit 0 |
| 전체 CI 계약 | local | `node --test tools/ci/*.test.mjs` | command output | 161 tests passed |

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `labels.severity` 값은 `warning/critical` 그대로 유지하고 템플릿 표시만 `주의/긴급`으로 바꿨다.
  - `BackWorker` 조치 문구는 현재 probe 경로인 `/actuator/health/readiness` 기준으로 맞췄다.

## 리스크

- HTML 메일은 메일 클라이언트 호환성을 위해 table 1개와 기본 태그만 사용했다.
- 실제 운영 외부 Alertmanager URL 접근성은 merge/CD 후 서버에서 확인해야 한다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
