### PR TITLE
[Feat] Access/Egress/Station graph router 분리

### DIFF
--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -9,76 +9,151 @@ class LocalRouteEngine {
   LocalRouteEngine({
     required this.graph,
     this.costCalculator = const AccessibilityCostCalculator(),
+  }) : accessGraphRouter = AccessGraphRouter(
+         graph: graph,
+         costCalculator: costCalculator,
+       ),
+       routeAssembler = RouteAssembler(costCalculator: costCalculator);
+
+  final NetworkGraph graph;
+  final AccessibilityCostCalculator costCalculator;
+  final AccessGraphRouter accessGraphRouter;
+  final RouteAssembler routeAssembler;
+
+  LocalRouteResult search(RouteRequest request) {
+    final pathResult = accessGraphRouter.findPath(
+      originNodeId: request.originStationId,
+      destinationNodeId: request.destinationStationId,
+      mobilityType: request.mobilityType,
+      constraintMode: request.effectiveConstraintMode,
+    );
+    final path = pathResult.path;
+    if (path == null) {
+      if (pathResult.noPathReason != AccessNoPathReason.blocked) {
+        return LocalRouteResult.unknown(pathResult.reasonCodes);
+      }
+      return LocalRouteResult.blocked(pathResult.reasonCodes);
+    }
+
+    final weight = RouteWeight.from(request.mobilityType);
+    final assembled = routeAssembler.assemble(
+      path,
+      request.mobilityType,
+      constraintMode: request.effectiveConstraintMode,
+    );
+
+    return LocalRouteResult(
+      status: RouteStatus.found,
+      totalCost: weight.baseAccessCost + assembled.totalCost,
+      steps: assembled.steps,
+      warnings: assembled.warnings,
+      blockedReasonCodes: const [],
+    );
+  }
+}
+
+enum AccessNoPathReason { blocked, unknown, unsupported, noData }
+
+class AccessPathResult {
+  const AccessPathResult._({
+    required this.path,
+    required this.noPathReason,
+    required this.reasonCodes,
+  });
+
+  factory AccessPathResult.found(AccessPath path) {
+    return AccessPathResult._(
+      path: path,
+      noPathReason: null,
+      reasonCodes: const [],
+    );
+  }
+
+  factory AccessPathResult.noPath({
+    required AccessNoPathReason reason,
+    required List<String> reasonCodes,
+  }) {
+    return AccessPathResult._(
+      path: null,
+      noPathReason: reason,
+      reasonCodes: List.unmodifiable(reasonCodes),
+    );
+  }
+
+  final AccessPath? path;
+  final AccessNoPathReason? noPathReason;
+  final List<String> reasonCodes;
+}
+
+class AccessPath {
+  const AccessPath({required this.edges});
+
+  final List<RouteEdge> edges;
+
+  int get entrySeconds => _secondsForTypes({RouteEdgeType.entry});
+
+  int get transferSeconds => _secondsForTypes({
+    RouteEdgeType.inStationTransfer,
+    RouteEdgeType.outOfStationTransfer,
+  });
+
+  int get egressSeconds => _secondsForTypes({RouteEdgeType.exit});
+
+  List<String> get edgeIds =>
+      edges.map((edge) => edge.id).toList(growable: false);
+
+  List<String> get evidenceSources =>
+      edges.expand(_routeEvidenceSources).toSet().toList(growable: false);
+
+  int _secondsForTypes(Set<RouteEdgeType> types) {
+    return edges
+        .where((edge) => types.contains(edge.type))
+        .fold(0, (total, edge) => total + edge.durationSeconds);
+  }
+}
+
+class AccessGraphRouter {
+  const AccessGraphRouter({
+    required this.graph,
+    this.costCalculator = const AccessibilityCostCalculator(),
   });
 
   final NetworkGraph graph;
   final AccessibilityCostCalculator costCalculator;
 
-  LocalRouteResult search(RouteRequest request) {
+  AccessPathResult findPath({
+    required String originNodeId,
+    required String destinationNodeId,
+    required MobilityType mobilityType,
+    required ConstraintMode constraintMode,
+  }) {
+    if (graph.nodes.isEmpty || graph.edges.isEmpty) {
+      return AccessPathResult.noPath(
+        reason: AccessNoPathReason.noData,
+        reasonCodes: const ['NO_DATA'],
+      );
+    }
+
     final blockedReasonCodes = <String>{};
-    final path = _findLowestCostPath(
-      request.originStationId,
-      request.destinationStationId,
-      request.mobilityType,
-      request.effectiveConstraintMode,
+    final edges = _findLowestCostPath(
+      originNodeId,
+      destinationNodeId,
+      mobilityType,
+      constraintMode,
       blockedReasonCodes,
     );
-    if (path == null) {
-      final reasonCodes = blockedReasonCodes.isEmpty
-          ? const ['ROUTE_GRAPH_UNKNOWN']
-          : blockedReasonCodes.toList(growable: false);
-      if (_hasUnknownRouteReason(reasonCodes)) {
-        return LocalRouteResult.unknown(reasonCodes);
-      }
-      return LocalRouteResult.blocked(reasonCodes);
-    }
-
-    final weight = RouteWeight.from(request.mobilityType);
-    final warnings = <String, RouteWarning>{};
-    var totalCost = weight.baseAccessCost;
-    final steps = <RouteStep>[];
-
-    for (final edge in path) {
-      final accessCost = costCalculator.costFor(
-        edge,
-        request.mobilityType,
-        constraintMode: request.effectiveConstraintMode,
-      );
-      totalCost += accessCost.cost;
-      for (final code in accessCost.warningCodes) {
-        warnings[code] = RouteWarning(
-          code: code,
-          message: _warningMessage(code),
-        );
-      }
-      steps.add(
-        RouteStep(
-          sequence: steps.length + 1,
-          edgeId: edge.id,
-          fromNodeId: edge.fromNodeId,
-          toNodeId: edge.toNodeId,
-          type: _stepType(edge.type),
-          cost: accessCost.cost,
-          durationSeconds: edge.durationSeconds,
-          distanceMeters: edge.distanceMeters,
-          lineId: edge.lineId,
-          transferStationId: _transferStationId(edge),
-          includesStairs: edge.includesStairs,
-          stairAccessState: edge.stairAccessState.name,
-          evidenceSources: _evidenceSources(edge),
-          timeSource: edge.durationSeconds > 0 ? 'STATIC_ESTIMATE' : 'UNKNOWN',
-          distanceSource: edge.distanceMeters > 0 ? 'MEASURED' : 'UNKNOWN',
-          confidenceLabel: _confidenceLabel(edge),
-        ),
+    if (edges != null) {
+      return AccessPathResult.found(
+        AccessPath(edges: List.unmodifiable(edges)),
       );
     }
 
-    return LocalRouteResult(
-      status: RouteStatus.found,
-      totalCost: totalCost,
-      steps: List.unmodifiable(steps),
-      warnings: List.unmodifiable(warnings.values),
-      blockedReasonCodes: const [],
+    final reasonCodes = blockedReasonCodes.isEmpty
+        ? const ['ROUTE_GRAPH_UNKNOWN']
+        : blockedReasonCodes.toList(growable: false);
+    return AccessPathResult.noPath(
+      reason: _noPathReason(reasonCodes),
+      reasonCodes: reasonCodes,
     );
   }
 
@@ -100,6 +175,20 @@ class LocalRouteEngine {
     };
     return reasonCodes.isNotEmpty &&
         reasonCodes.any((code) => unknownCodes.contains(code));
+  }
+
+  AccessNoPathReason _noPathReason(List<String> reasonCodes) {
+    if (reasonCodes.contains('NO_DATA')) {
+      return AccessNoPathReason.noData;
+    }
+    if (reasonCodes.contains('BLOCKED_UNSUPPORTED_SCOPE') ||
+        reasonCodes.contains('STRICT_EVIDENCE_UNSUPPORTED')) {
+      return AccessNoPathReason.unsupported;
+    }
+    if (_hasUnknownRouteReason(reasonCodes)) {
+      return AccessNoPathReason.unknown;
+    }
+    return AccessNoPathReason.blocked;
   }
 
   List<RouteEdge>? _findLowestCostPath(
@@ -179,6 +268,129 @@ class LocalRouteEngine {
     }
     return selected;
   }
+}
+
+class StationPathwayRouter {
+  const StationPathwayRouter({required this.accessGraphRouter});
+
+  final AccessGraphRouter accessGraphRouter;
+
+  AccessPathResult findPathway({
+    required String stationId,
+    required String fromNodeId,
+    required String toNodeId,
+    required MobilityType mobilityType,
+    required ConstraintMode constraintMode,
+  }) {
+    return accessGraphRouter.findPath(
+      originNodeId: fromNodeId,
+      destinationNodeId: toNodeId,
+      mobilityType: mobilityType,
+      constraintMode: constraintMode,
+    );
+  }
+}
+
+class TransferAccess {
+  const TransferAccess({
+    required this.path,
+    required this.transferReadyAtSeconds,
+    required this.slackSeconds,
+    required this.isFeasible,
+  });
+
+  final AccessPath path;
+  final int transferReadyAtSeconds;
+  final int slackSeconds;
+  final bool isFeasible;
+}
+
+class TransferAccessResolver {
+  const TransferAccessResolver();
+
+  TransferAccess resolve({
+    required AccessPath path,
+    required int alightAtSeconds,
+    required int nextDepartureSeconds,
+  }) {
+    final transferReadyAtSeconds = alightAtSeconds + path.transferSeconds;
+    return TransferAccess(
+      path: path,
+      transferReadyAtSeconds: transferReadyAtSeconds,
+      slackSeconds: nextDepartureSeconds - transferReadyAtSeconds,
+      isFeasible: nextDepartureSeconds >= transferReadyAtSeconds,
+    );
+  }
+}
+
+class AssembledRoute {
+  const AssembledRoute({
+    required this.totalCost,
+    required this.steps,
+    required this.warnings,
+  });
+
+  final int totalCost;
+  final List<RouteStep> steps;
+  final List<RouteWarning> warnings;
+}
+
+class RouteAssembler {
+  const RouteAssembler({
+    this.costCalculator = const AccessibilityCostCalculator(),
+  });
+
+  final AccessibilityCostCalculator costCalculator;
+
+  AssembledRoute assemble(
+    AccessPath path,
+    MobilityType mobilityType, {
+    required ConstraintMode constraintMode,
+  }) {
+    final warnings = <String, RouteWarning>{};
+    var totalCost = 0;
+    final steps = <RouteStep>[];
+    for (final edge in path.edges) {
+      final accessCost = costCalculator.costFor(
+        edge,
+        mobilityType,
+        constraintMode: constraintMode,
+      );
+      totalCost += accessCost.cost;
+      for (final code in accessCost.warningCodes) {
+        warnings[code] = RouteWarning(
+          code: code,
+          message: _warningMessage(code),
+        );
+      }
+      steps.add(
+        RouteStep(
+          sequence: steps.length + 1,
+          edgeId: edge.id,
+          fromNodeId: edge.fromNodeId,
+          toNodeId: edge.toNodeId,
+          type: _stepType(edge.type),
+          cost: accessCost.cost,
+          durationSeconds: edge.durationSeconds,
+          distanceMeters: edge.distanceMeters,
+          lineId: edge.lineId,
+          transferStationId: _transferStationId(edge),
+          includesStairs: edge.includesStairs,
+          stairAccessState: edge.stairAccessState.name,
+          evidenceSources: _routeEvidenceSources(edge),
+          timeSource: edge.durationSeconds > 0 ? 'STATIC_ESTIMATE' : 'UNKNOWN',
+          distanceSource: edge.distanceMeters > 0 ? 'MEASURED' : 'UNKNOWN',
+          confidenceLabel: _confidenceLabel(edge),
+        ),
+      );
+    }
+
+    return AssembledRoute(
+      totalCost: totalCost,
+      steps: List.unmodifiable(steps),
+      warnings: List.unmodifiable(warnings.values),
+    );
+  }
 
   RouteStepType _stepType(RouteEdgeType edgeType) {
     return switch (edgeType) {
@@ -228,14 +440,6 @@ class LocalRouteEngine {
     return parts.length >= 2 ? parts[1] : '';
   }
 
-  List<String> _evidenceSources(RouteEdge edge) {
-    return [
-      'edge:${edge.id}',
-      if (edge.isGeneratedConnector) 'GENERATED_CONNECTOR',
-      if (edge.lineId.isNotEmpty) 'line:${edge.lineId}',
-    ];
-  }
-
   String _confidenceLabel(RouteEdge edge) {
     if (edge.isGeneratedConnector ||
         edge.durationSeconds <= 0 ||
@@ -272,4 +476,12 @@ class LocalRouteEngine {
       _ => '이동 전 현장 안내를 확인해 주세요.',
     };
   }
+}
+
+List<String> _routeEvidenceSources(RouteEdge edge) {
+  return [
+    'edge:${edge.id}',
+    if (edge.isGeneratedConnector) 'GENERATED_CONNECTOR',
+    if (edge.lineId.isNotEmpty) 'line:${edge.lineId}',
+  ];
 }

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -56,6 +56,74 @@ void main() {
       expect(result.includesStairs, isFalse);
     });
 
+    test('access graph contract는 진입, 환승, 진출 시간을 분리한다', () {
+      final router = AccessGraphRouter(graph: _capitalFixtureGraph());
+
+      final result = router.findPath(
+        originNodeId: 'station-sangnoksu',
+        destinationNodeId: 'station-cityhall',
+        mobilityType: MobilityType.senior,
+        constraintMode: ConstraintMode.preferStepFree,
+      );
+      final path = result.path!;
+      final transfer = const TransferAccessResolver().resolve(
+        path: path,
+        alightAtSeconds: 600,
+        nextDepartureSeconds: 780,
+      );
+
+      expect(path.edgeIds, [
+        'entry-sangnoksu-step-free',
+        'ride-sangnoksu-sadang-line4',
+        'transfer-sadang-line4-line2',
+        'ride-sadang-cityhall-line2',
+        'exit-cityhall-step-free',
+      ]);
+      expect(path.entrySeconds, 90);
+      expect(path.transferSeconds, 140);
+      expect(path.egressSeconds, 90);
+      expect(
+        path.evidenceSources,
+        contains('edge:transfer-sadang-line4-line2'),
+      );
+      expect(transfer.transferReadyAtSeconds, 740);
+      expect(transfer.slackSeconds, 40);
+      expect(transfer.isFeasible, isTrue);
+    });
+
+    test('access graph no-path reason은 차단, 미확인, 데이터 없음으로 분리된다', () {
+      final blocked = AccessGraphRouter(graph: _stairOnlyFixtureGraph())
+          .findPath(
+            originNodeId: 'station-sangnoksu',
+            destinationNodeId: 'station-sadang',
+            mobilityType: MobilityType.wheelchair,
+            constraintMode: ConstraintMode.strictStepFree,
+          );
+      final unknown =
+          AccessGraphRouter(graph: _generatedConnectorFixtureGraph()).findPath(
+            originNodeId: 'station-a',
+            destinationNodeId: 'station-b',
+            mobilityType: MobilityType.stroller,
+            constraintMode: ConstraintMode.strictStepFree,
+          );
+      final noData =
+          AccessGraphRouter(
+            graph: NetworkGraph(nodes: const [], edges: const []),
+          ).findPath(
+            originNodeId: 'station-a',
+            destinationNodeId: 'station-b',
+            mobilityType: MobilityType.stroller,
+            constraintMode: ConstraintMode.strictStepFree,
+          );
+
+      expect(blocked.noPathReason, AccessNoPathReason.blocked);
+      expect(blocked.reasonCodes, ['STAIR_ONLY_ACCESS']);
+      expect(unknown.noPathReason, AccessNoPathReason.unknown);
+      expect(unknown.reasonCodes, ['GENERATED_CONNECTOR_UNVERIFIED']);
+      expect(noData.noPathReason, AccessNoPathReason.noData);
+      expect(noData.reasonCodes, ['NO_DATA']);
+    });
+
     test('2회 환승 경로는 catalog transfer edge에서 환승역 순서를 보존한다', () {
       final engine = LocalRouteEngine(graph: _twoTransferCatalogFixtureGraph());
 

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -769,10 +769,11 @@ public class RouteSearchService implements RouteSearchUseCase {
 		RoutePlan routePlan,
 		RouteProfileWeight profileWeight
 	) {
+		RouteAssembler routeAssembler = new RouteAssembler();
 		if (routePlan.transferRoute().isPresent()) {
-			return transferSteps(origin, destination, routePlan.transferRoute().get(), profileWeight);
+			return routeAssembler.assemble(transferSteps(origin, destination, routePlan.transferRoute().get(), profileWeight));
 		}
-		return directLineSteps(origin, destination, routePlan.directLine().orElseThrow(), profileWeight);
+		return routeAssembler.assemble(directLineSteps(origin, destination, routePlan.directLine().orElseThrow(), profileWeight));
 	}
 
 	private List<RouteStep> directLineSteps(
@@ -784,6 +785,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 		String displayLine = displayLineName(directLine.line());
 		boolean originIncludesStairs = hasStairOnlyAccess(origin.id());
 		boolean destinationIncludesStairs = hasStairOnlyAccess(destination.id());
+		AccessGraphRouter accessGraphRouter = new AccessGraphRouter();
+		AccessPath entryAccess = accessGraphRouter.entryAccess(origin.id(), directLine.line().id(), originIncludesStairs, profileWeight);
+		AccessPath egressAccess = accessGraphRouter.egressAccess(destination.id(), directLine.line().id(), destinationIncludesStairs, profileWeight);
 		return List.of(
 			new RouteStep(
 				1,
@@ -794,9 +798,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 				directLine.line().name(),
 				origin.id(),
 				origin.id(),
-				ENTRY_ESTIMATED_MINUTES,
-				ENTRY_DISTANCE_METERS,
-				originIncludesStairs,
+				entryAccess.estimatedMinutes(),
+				entryAccess.distanceMeters(),
+				entryAccess.includesStairs(),
 				true
 			),
 			new RouteStep(
@@ -822,9 +826,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 				directLine.line().name(),
 				destination.id(),
 				destination.id(),
-				EXIT_ESTIMATED_MINUTES,
-				EXIT_DISTANCE_METERS,
-				destinationIncludesStairs,
+				egressAccess.estimatedMinutes(),
+				egressAccess.distanceMeters(),
+				egressAccess.includesStairs(),
 				true
 			)
 		);
@@ -841,6 +845,17 @@ public class RouteSearchService implements RouteSearchUseCase {
 		boolean originIncludesStairs = hasStairOnlyAccess(origin.id());
 		boolean transferIncludesStairs = hasStairOnlyAccess(route.transferStation().id());
 		boolean destinationIncludesStairs = hasStairOnlyAccess(destination.id());
+		AccessGraphRouter accessGraphRouter = new AccessGraphRouter();
+		StationPathwayRouter stationPathwayRouter = new StationPathwayRouter();
+		AccessPath entryAccess = accessGraphRouter.entryAccess(origin.id(), route.firstLine().id(), originIncludesStairs, profileWeight);
+		AccessPath transferAccess = stationPathwayRouter.transferPath(
+			route.transferStation().id(),
+			route.firstLine().id(),
+			route.secondLine().id(),
+			transferIncludesStairs,
+			profileWeight
+		);
+		AccessPath egressAccess = accessGraphRouter.egressAccess(destination.id(), route.secondLine().id(), destinationIncludesStairs, profileWeight);
 		return List.of(
 			new RouteStep(
 				1,
@@ -851,9 +866,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 				route.firstLine().name(),
 				origin.id(),
 				origin.id(),
-				ENTRY_ESTIMATED_MINUTES,
-				ENTRY_DISTANCE_METERS,
-				originIncludesStairs,
+				entryAccess.estimatedMinutes(),
+				entryAccess.distanceMeters(),
+				entryAccess.includesStairs(),
 				true
 			),
 			new RouteStep(
@@ -879,9 +894,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 				route.secondLine().name(),
 				route.transferStation().id(),
 				route.transferStation().id(),
-				TRANSFER_ESTIMATED_MINUTES,
-				TRANSFER_DISTANCE_METERS,
-				transferIncludesStairs,
+				transferAccess.estimatedMinutes(),
+				transferAccess.distanceMeters(),
+				transferAccess.includesStairs(),
 				true
 			),
 			new RouteStep(
@@ -907,9 +922,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 				route.secondLine().name(),
 				destination.id(),
 				destination.id(),
-				EXIT_ESTIMATED_MINUTES,
-				EXIT_DISTANCE_METERS,
-				destinationIncludesStairs,
+				egressAccess.estimatedMinutes(),
+				egressAccess.distanceMeters(),
+				egressAccess.includesStairs(),
 				true
 			)
 		);
@@ -1001,5 +1016,164 @@ public class RouteSearchService implements RouteSearchUseCase {
 				.map(route -> List.of(originStationId, route.transferStation().id(), destinationStationId))
 				.orElseGet(() -> List.of(originStationId, destinationStationId));
 		}
+	}
+}
+
+enum AccessNoPathReason {
+	BLOCKED,
+	UNKNOWN,
+	UNSUPPORTED,
+	NO_DATA
+}
+
+record AccessPath(
+	int estimatedMinutes,
+	int distanceMeters,
+	boolean includesStairs,
+	String stairAccessState,
+	List<String> evidenceSources,
+	AccessNoPathReason noPathReason,
+	List<String> reasonCodes
+) {
+
+	static AccessPath found(
+		int estimatedMinutes,
+		int distanceMeters,
+		boolean includesStairs,
+		String stationId,
+		String lineId,
+		String evidenceKind
+	) {
+		List<String> evidenceSources = new ArrayList<>();
+		evidenceSources.add("station:" + stationId);
+		if (lineId != null && !lineId.isBlank()) {
+			evidenceSources.add("line:" + lineId);
+		}
+		evidenceSources.add("access:" + evidenceKind);
+		return new AccessPath(
+			estimatedMinutes,
+			distanceMeters,
+			includesStairs,
+			includesStairs ? "STAIR_ONLY" : "UNKNOWN",
+			List.copyOf(evidenceSources),
+			null,
+			List.of()
+		);
+	}
+
+	static AccessPath transfer(
+		String stationId,
+		String fromLineId,
+		String toLineId,
+		boolean includesStairs
+	) {
+		return new AccessPath(
+			6,
+			260,
+			includesStairs,
+			includesStairs ? "STAIR_ONLY" : "UNKNOWN",
+			List.of("station:" + stationId, "transfer:" + fromLineId + ":" + toLineId, "access:transfer"),
+			null,
+			List.of()
+		);
+	}
+
+	static AccessPath blocked(List<String> reasonCodes) {
+		return noPath(AccessNoPathReason.BLOCKED, reasonCodes);
+	}
+
+	static AccessPath unknown(List<String> reasonCodes) {
+		return noPath(AccessNoPathReason.UNKNOWN, reasonCodes);
+	}
+
+	static AccessPath unsupported(List<String> reasonCodes) {
+		return noPath(AccessNoPathReason.UNSUPPORTED, reasonCodes);
+	}
+
+	static AccessPath noData() {
+		return noPath(AccessNoPathReason.NO_DATA, List.of("NO_DATA"));
+	}
+
+	private static AccessPath noPath(AccessNoPathReason reason, List<String> reasonCodes) {
+		return new AccessPath(0, 0, false, "UNKNOWN", List.of(), reason, List.copyOf(reasonCodes));
+	}
+}
+
+final class AccessGraphRouter {
+
+	AccessPath entryAccess(
+		String stationId,
+		String lineId,
+		boolean includesStairs,
+		RouteProfileWeight profileWeight
+	) {
+		if (profileWeight.blocksStairOnlyAccess() && includesStairs) {
+			return AccessPath.blocked(List.of("STAIR_ONLY_ACCESS"));
+		}
+		return AccessPath.found(4, 180, includesStairs, stationId, lineId, "entry");
+	}
+
+	AccessPath egressAccess(
+		String stationId,
+		String lineId,
+		boolean includesStairs,
+		RouteProfileWeight profileWeight
+	) {
+		if (profileWeight.blocksStairOnlyAccess() && includesStairs) {
+			return AccessPath.blocked(List.of("STAIR_ONLY_ACCESS"));
+		}
+		return AccessPath.found(3, 120, includesStairs, stationId, lineId, "egress");
+	}
+
+	AccessPath generatedConnector(String edgeId, RouteProfileWeight profileWeight) {
+		if (profileWeight.blocksStairOnlyAccess()) {
+			return AccessPath.unknown(List.of("GENERATED_CONNECTOR_UNVERIFIED"));
+		}
+		return AccessPath.found(0, 0, false, edgeId, "", "generated");
+	}
+}
+
+final class StationPathwayRouter {
+
+	AccessPath transferPath(
+		String stationId,
+		String fromLineId,
+		String toLineId,
+		boolean includesStairs,
+		RouteProfileWeight profileWeight
+	) {
+		if (profileWeight.blocksStairOnlyAccess() && includesStairs) {
+			return AccessPath.blocked(List.of("STAIR_ONLY_ACCESS"));
+		}
+		return AccessPath.transfer(stationId, fromLineId, toLineId, includesStairs);
+	}
+}
+
+record TransferAccess(
+	AccessPath path,
+	int transferReadyAtMinutes,
+	int slackMinutes,
+	boolean feasible
+) {
+}
+
+final class TransferAccessResolver {
+
+	TransferAccess resolve(AccessPath path, int alightAtMinutes, int nextDepartureMinutes) {
+		int transferReadyAtMinutes = alightAtMinutes + path.estimatedMinutes();
+		return new TransferAccess(
+			path,
+			transferReadyAtMinutes,
+			nextDepartureMinutes - transferReadyAtMinutes,
+			nextDepartureMinutes >= transferReadyAtMinutes
+		);
+	}
+}
+
+final class RouteAssembler {
+
+	List<RouteStep> assemble(List<RouteStep> steps) {
+		// ponytail: keep this boundary thin until E/F add schedule and realtime inputs.
+		return List.copyOf(steps);
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -13,6 +13,7 @@ import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.InvalidRouteFeedbackException;
 import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteFeedbackRating;
+import com.easysubway.route.domain.RouteProfileWeight;
 import com.easysubway.route.domain.RouteSearchNotFoundException;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteWarningCode;
@@ -328,6 +329,38 @@ class RouteSearchServiceTest {
 		assertThat(result.steps().get(2).estimatedMinutes()).isEqualTo(6);
 		assertThat(result.steps().get(2).distanceMeters()).isEqualTo(260);
 		assertThat(result.steps().get(2).requiresAccessibilityCheck()).isTrue();
+	}
+
+	@Test
+	@DisplayName("access graph 계약은 진입, 환승, 진출 시간과 no-path reason을 분리한다")
+	void accessGraphContractSeparatesAccessTimesAndNoPathReasons() {
+		var profileWeight = RouteProfileWeight.from(MobilityType.WHEELCHAIR, ConstraintMode.STRICT_STEP_FREE);
+		var accessRouter = new AccessGraphRouter();
+		var stationRouter = new StationPathwayRouter();
+
+		var entry = accessRouter.entryAccess("station-a", "line-a", false, profileWeight);
+		var transfer = stationRouter.transferPath("station-x", "line-a", "line-b", false, profileWeight);
+		var egress = accessRouter.egressAccess("station-b", "line-b", false, profileWeight);
+		var ready = new TransferAccessResolver().resolve(transfer, 600, 1000);
+
+		assertThat(entry.estimatedMinutes()).isEqualTo(4);
+		assertThat(transfer.estimatedMinutes()).isEqualTo(6);
+		assertThat(egress.estimatedMinutes()).isEqualTo(3);
+		assertThat(transfer.evidenceSources()).containsExactly(
+			"station:station-x",
+			"transfer:line-a:line-b",
+			"access:transfer"
+		);
+		assertThat(ready.transferReadyAtMinutes()).isEqualTo(606);
+		assertThat(ready.slackMinutes()).isEqualTo(394);
+		assertThat(ready.feasible()).isTrue();
+		assertThat(accessRouter.entryAccess("station-a", "line-a", true, profileWeight).noPathReason())
+			.isEqualTo(AccessNoPathReason.BLOCKED);
+		assertThat(accessRouter.generatedConnector("edge-generated", profileWeight).noPathReason())
+			.isEqualTo(AccessNoPathReason.UNKNOWN);
+		assertThat(AccessPath.unsupported(List.of("STRICT_EVIDENCE_UNSUPPORTED")).noPathReason())
+			.isEqualTo(AccessNoPathReason.UNSUPPORTED);
+		assertThat(AccessPath.noData().noPathReason()).isEqualTo(AccessNoPathReason.NO_DATA);
 	}
 
 	@Test


### PR DESCRIPTION
## 관련 이슈

close #1221

## 작업 배경

- Access/Egress/Station graph router를 분리해 entry access time, transfer pathway time, egress time을 독립적으로 계산할 수 있게 합니다.
- F-2 readyAt 계산 전 단계로, production ETA 알고리즘은 추가하지 않습니다.

## 작업 내용

- Mobile `LocalRouteEngine`의 Dijkstra 결과를 `AccessGraphRouter`, `StationPathwayRouter`, `TransferAccessResolver`, `RouteAssembler` 계약으로 분리했습니다.
- Backend route service의 entry/transfer/egress 상수 조립을 동일한 conceptual contract로 감쌌습니다.
- strict step-free 차단, no-path reason 분리, evidenceSources, transfer readyAt 계산 테스트를 추가했습니다.
- V1 adapter/result/accessibility risk 출력은 기존 테스트로 유지 확인했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/features/routes test/features/internal_route` 성공
  - `cd backend && ./gradlew test --tests '*RouteSearchServiceTest' --no-daemon` 성공

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| route/access graph contract | Mobile | Flutter test | local command output | 성공 |
| route/access graph contract | Backend | Gradle targeted test | local command output | 성공 |
| UI/수동 QA | 공통 | UI 변경 없음 | 증거 불필요 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: access/egress/station graph router 내부 계약 추가
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/features/routes/application/route_engine.dart`
  - `backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java`

## 리스크

- Mobile route engine의 no-path reason은 내부적으로 분리하지만, V1 결과 상태는 기존 UNKNOWN/BLOCKED 호환을 유지합니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
