### PR TITLE
[Feat] RealtimeArrivalResolver와 ETA overlay 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -6,6 +6,7 @@ import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.domain.ConstraintMode;
+import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
@@ -113,7 +114,7 @@ class RouteSearchController {
 				result.recommendationReasons(),
 				result.evidenceSummary(),
 				result.createdAt(),
-				"STATIC_BACKEND_V1",
+				result.etaSource().name(),
 				"LEGACY_STATIC",
 				false
 			);
@@ -227,7 +228,7 @@ class RouteSearchController {
 				statusOf(result),
 				formatOffset(plannedArrivalTime),
 				null,
-				"STATIC_BACKEND_V1",
+				result.etaSource().name(),
 				confidenceOf(result),
 				result.estimatedDurationSeconds(),
 				result.transferCount(),
@@ -455,10 +456,18 @@ class RouteSearchController {
 				0,
 				durationSeconds,
 				Math.max(0, step.distanceMeters()),
-				"STATIC_BACKEND_V1",
+				etaSourceOf(step).name(),
 				"LOW",
 				AccessibilityRiskDto.from(step)
 			);
+		}
+
+		private static EtaSource etaSourceOf(RouteStep step) {
+			try {
+				return EtaSource.valueOf(step.timeSource());
+			} catch (IllegalArgumentException exception) {
+				return EtaSource.PLANNED;
+			}
 		}
 
 		private static String legTypeOf(RouteStep step) {

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -229,7 +229,7 @@ class RouteSearchController {
 				formatOffset(plannedArrivalTime),
 				null,
 				result.etaSource().name(),
-				confidenceOf(result),
+				etaConfidenceOf(result),
 				result.estimatedDurationSeconds(),
 				result.transferCount(),
 				result.walkingDistanceMeters(),
@@ -243,8 +243,15 @@ class RouteSearchController {
 			return result.status() == RouteSearchStatus.BLOCKED ? "BLOCKED_ACCESSIBILITY" : result.status().name();
 		}
 
-		private static String confidenceOf(RouteSearchResult result) {
-			return result.status() == RouteSearchStatus.FOUND ? "LOW" : "UNKNOWN";
+		private static String etaConfidenceOf(RouteSearchResult result) {
+			if (result.status() != RouteSearchStatus.FOUND) {
+				return "UNKNOWN";
+			}
+			return switch (result.etaSource()) {
+				case REALTIME -> "HIGH";
+				case MIXED -> "MEDIUM";
+				case PLANNED, FALLBACK -> "LOW";
+			};
 		}
 	}
 

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -457,17 +457,33 @@ class RouteSearchController {
 				durationSeconds,
 				Math.max(0, step.distanceMeters()),
 				etaSourceOf(step).name(),
-				"LOW",
+				etaConfidenceOf(step),
 				AccessibilityRiskDto.from(step)
 			);
 		}
 
 		private static EtaSource etaSourceOf(RouteStep step) {
+			if (step.timeSource() == null || step.timeSource().isBlank()) {
+				return EtaSource.PLANNED;
+			}
 			try {
 				return EtaSource.valueOf(step.timeSource());
 			} catch (IllegalArgumentException exception) {
 				return EtaSource.PLANNED;
 			}
+		}
+
+		private static String etaConfidenceOf(RouteStep step) {
+			if ("HIGH".equals(step.confidenceLabel())
+				|| "MEDIUM".equals(step.confidenceLabel())
+				|| "LOW".equals(step.confidenceLabel())) {
+				return step.confidenceLabel();
+			}
+			return switch (etaSourceOf(step)) {
+				case REALTIME -> "HIGH";
+				case MIXED -> "MEDIUM";
+				case PLANNED, FALLBACK -> "LOW";
+			};
 		}
 
 		private static String legTypeOf(RouteStep step) {

--- a/backend/src/main/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolver.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolver.java
@@ -1,0 +1,120 @@
+package com.easysubway.route.adapter.out.realtime;
+
+import com.easysubway.realtime.application.RealtimeArrivalResult;
+import com.easysubway.realtime.application.RealtimeGatewayService;
+import com.easysubway.realtime.application.RealtimeQuery;
+import com.easysubway.realtime.domain.RealtimeArrival;
+import com.easysubway.realtime.domain.RealtimeStatus;
+import com.easysubway.route.application.port.out.RealtimeArrivalResolver;
+import com.easysubway.route.domain.ArrivalCandidate;
+import com.easysubway.route.domain.ArrivalFreshness;
+import com.easysubway.route.domain.EtaConfidence;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+class RealtimeGatewayArrivalResolver implements RealtimeArrivalResolver {
+
+	private final RealtimeGatewayService realtimeGatewayService;
+
+	RealtimeGatewayArrivalResolver(RealtimeGatewayService realtimeGatewayService) {
+		this.realtimeGatewayService = realtimeGatewayService;
+	}
+
+	@Override
+	public Resolution resolve(Query query) {
+		RealtimeArrivalResult result = realtimeGatewayService.arrivals(new RealtimeQuery(
+			query.stationId(),
+			query.lineId(),
+			query.providerLineId(),
+			query.stationQueryName(),
+			query.lineName()
+		));
+		ArrivalFreshness status = statusOf(result);
+		Instant receivedAt = parseInstant(result.receivedAt());
+		return new Resolution(
+			status,
+			result.fallbackCode(),
+			providerSnapshotId(result),
+			receivedAt,
+			candidates(query, result, status, receivedAt)
+		);
+	}
+
+	private List<ArrivalCandidate> candidates(
+		Query query,
+		RealtimeArrivalResult result,
+		ArrivalFreshness status,
+		Instant receivedAt
+	) {
+		return result.arrivals()
+			.stream()
+			.filter(arrival -> arrival.etaSeconds() != null)
+			.filter(arrival -> arrival.etaSeconds() >= 0)
+			.map(arrival -> candidate(query, arrival, status, receivedAt))
+			.toList();
+	}
+
+	private ArrivalCandidate candidate(
+		Query query,
+		RealtimeArrival arrival,
+		ArrivalFreshness status,
+		Instant receivedAt
+	) {
+		Instant providerReceivedAt = parseInstant(arrival.providerReceivedAt());
+		if (providerReceivedAt == null) {
+			providerReceivedAt = receivedAt;
+		}
+		Instant expectedArrivalAt = providerReceivedAt == null
+			? query.readyAt().plusSeconds(arrival.etaSeconds())
+			: providerReceivedAt.plusSeconds(arrival.etaSeconds());
+		return new ArrivalCandidate(
+			arrival.trainNo(),
+			arrival.lineId(),
+			arrival.direction(),
+			arrival.destination(),
+			arrival.etaSeconds(),
+			expectedArrivalAt,
+			providerReceivedAt,
+			status,
+			confidenceOf(status)
+		);
+	}
+
+	private ArrivalFreshness statusOf(RealtimeArrivalResult result) {
+		if (result.status() == RealtimeStatus.FRESH) {
+			return ArrivalFreshness.FRESH_REALTIME;
+		}
+		if (result.status() == RealtimeStatus.STALE) {
+			return ArrivalFreshness.STALE_REALTIME;
+		}
+		if (result.status() == RealtimeStatus.UNSUPPORTED) {
+			return ArrivalFreshness.UNSUPPORTED;
+		}
+		if ("EMPTY_PROVIDER_RESULT".equals(result.fallbackCode())) {
+			return ArrivalFreshness.EMPTY_PROVIDER_RESULT;
+		}
+		return ArrivalFreshness.UNAVAILABLE;
+	}
+
+	private EtaConfidence confidenceOf(ArrivalFreshness status) {
+		return status == ArrivalFreshness.FRESH_REALTIME ? EtaConfidence.HIGH : EtaConfidence.LOW;
+	}
+
+	private String providerSnapshotId(RealtimeArrivalResult result) {
+		return result.receivedAt() == null ? null : result.providerId() + ":" + result.receivedAt();
+	}
+
+	private Instant parseInstant(String value) {
+		if (value == null || value.isBlank()) {
+			return null;
+		}
+		try {
+			return Instant.parse(value);
+		} catch (DateTimeParseException ignored) {
+			return null;
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolver.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolver.java
@@ -67,9 +67,8 @@ class RealtimeGatewayArrivalResolver implements RealtimeArrivalResolver {
 		if (providerReceivedAt == null) {
 			providerReceivedAt = receivedAt;
 		}
-		Instant expectedArrivalAt = providerReceivedAt == null
-			? query.readyAt().plusSeconds(arrival.etaSeconds())
-			: providerReceivedAt.plusSeconds(arrival.etaSeconds());
+		Instant etaBase = receivedAt == null ? query.readyAt() : receivedAt;
+		Instant expectedArrivalAt = etaBase.plusSeconds(arrival.etaSeconds());
 		return new ArrivalCandidate(
 			arrival.trainNo(),
 			arrival.lineId(),

--- a/backend/src/main/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolver.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolver.java
@@ -93,7 +93,7 @@ class RealtimeGatewayArrivalResolver implements RealtimeArrivalResolver {
 		if (result.status() == RealtimeStatus.UNSUPPORTED) {
 			return ArrivalFreshness.UNSUPPORTED;
 		}
-		if ("EMPTY_PROVIDER_RESULT".equals(result.fallbackCode())) {
+		if (ArrivalFreshness.EMPTY_PROVIDER_RESULT.name().equals(result.fallbackCode())) {
 			return ArrivalFreshness.EMPTY_PROVIDER_RESULT;
 		}
 		return ArrivalFreshness.UNAVAILABLE;

--- a/backend/src/main/java/com/easysubway/route/application/port/out/RealtimeArrivalResolver.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/RealtimeArrivalResolver.java
@@ -1,0 +1,39 @@
+package com.easysubway.route.application.port.out;
+
+import com.easysubway.route.domain.ArrivalCandidate;
+import com.easysubway.route.domain.ArrivalFreshness;
+import java.time.Instant;
+import java.util.List;
+
+public interface RealtimeArrivalResolver {
+
+	Resolution resolve(Query query);
+
+	record Query(
+		String stationId,
+		String lineId,
+		String providerLineId,
+		String stationQueryName,
+		String lineName,
+		String direction,
+		Instant readyAt
+	) {
+		public Query {
+			if (readyAt == null) {
+				throw new IllegalArgumentException("readyAt is required.");
+			}
+		}
+	}
+
+	record Resolution(
+		ArrivalFreshness status,
+		String fallbackCode,
+		String providerSnapshotId,
+		Instant providerReceivedAt,
+		List<ArrivalCandidate> candidates
+	) {
+		public Resolution {
+			candidates = candidates == null ? List.of() : List.copyOf(candidates);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/domain/ArrivalCandidate.java
+++ b/backend/src/main/java/com/easysubway/route/domain/ArrivalCandidate.java
@@ -1,0 +1,30 @@
+package com.easysubway.route.domain;
+
+import java.time.Instant;
+
+public record ArrivalCandidate(
+	String trainNo,
+	String lineId,
+	String direction,
+	String destination,
+	int etaSeconds,
+	Instant expectedArrivalAt,
+	Instant providerReceivedAt,
+	ArrivalFreshness freshness,
+	EtaConfidence confidence
+) {
+	public ArrivalCandidate {
+		if (etaSeconds < 0) {
+			throw new IllegalArgumentException("etaSeconds must be greater than or equal to zero.");
+		}
+		if (expectedArrivalAt == null) {
+			throw new IllegalArgumentException("expectedArrivalAt is required.");
+		}
+		if (freshness == null) {
+			throw new IllegalArgumentException("freshness is required.");
+		}
+		if (confidence == null) {
+			throw new IllegalArgumentException("confidence is required.");
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/domain/ArrivalFreshness.java
+++ b/backend/src/main/java/com/easysubway/route/domain/ArrivalFreshness.java
@@ -1,0 +1,9 @@
+package com.easysubway.route.domain;
+
+public enum ArrivalFreshness {
+	FRESH_REALTIME,
+	STALE_REALTIME,
+	UNSUPPORTED,
+	UNAVAILABLE,
+	EMPTY_PROVIDER_RESULT
+}

--- a/backend/src/main/java/com/easysubway/route/domain/EtaConfidence.java
+++ b/backend/src/main/java/com/easysubway/route/domain/EtaConfidence.java
@@ -1,0 +1,7 @@
+package com.easysubway.route.domain;
+
+public enum EtaConfidence {
+	HIGH,
+	MEDIUM,
+	LOW
+}

--- a/backend/src/main/java/com/easysubway/route/domain/EtaSource.java
+++ b/backend/src/main/java/com/easysubway/route/domain/EtaSource.java
@@ -1,0 +1,8 @@
+package com.easysubway.route.domain;
+
+public enum EtaSource {
+	PLANNED,
+	REALTIME,
+	MIXED,
+	FALLBACK
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RealtimeEtaOverlay.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RealtimeEtaOverlay.java
@@ -16,6 +16,20 @@ public final class RealtimeEtaOverlay {
 		String fallbackCode,
 		List<ArrivalCandidate> candidates
 	) {
+		return overlay(readyAt, plannedWaitSeconds, direction, providerStatus, fallbackCode, null, null, 0, candidates);
+	}
+
+	public Result overlay(
+		Instant readyAt,
+		int plannedWaitSeconds,
+		String direction,
+		ArrivalFreshness providerStatus,
+		String fallbackCode,
+		String providerSnapshotId,
+		Instant providerReceivedAt,
+		int providerHealthCount,
+		List<ArrivalCandidate> candidates
+	) {
 		if (readyAt == null) {
 			throw new IllegalArgumentException("readyAt is required.");
 		}
@@ -25,12 +39,23 @@ public final class RealtimeEtaOverlay {
 		ArrivalFreshness status = providerStatus == null ? ArrivalFreshness.UNAVAILABLE : providerStatus;
 		List<ArrivalCandidate> safeCandidates = candidates == null ? List.of() : candidates;
 		return switch (status) {
-			case FRESH_REALTIME -> freshOverlay(readyAt, plannedWaitSeconds, direction, safeCandidates);
+			case FRESH_REALTIME -> freshOverlay(
+				readyAt,
+				plannedWaitSeconds,
+				direction,
+				providerSnapshotId,
+				providerReceivedAt,
+				providerHealthCount,
+				safeCandidates
+			);
 			case STALE_REALTIME -> planned(
 				readyAt,
 				plannedWaitSeconds,
 				EtaSource.PLANNED,
 				EtaConfidence.MEDIUM,
+				providerSnapshotId,
+				providerReceivedAt,
+				providerHealthCount,
 				List.of("STALE_REALTIME")
 			);
 			case UNSUPPORTED -> planned(
@@ -38,6 +63,9 @@ public final class RealtimeEtaOverlay {
 				plannedWaitSeconds,
 				EtaSource.PLANNED,
 				EtaConfidence.MEDIUM,
+				providerSnapshotId,
+				providerReceivedAt,
+				providerHealthCount,
 				List.of("UNSUPPORTED_REALTIME")
 			);
 			case UNAVAILABLE -> planned(
@@ -45,6 +73,9 @@ public final class RealtimeEtaOverlay {
 				plannedWaitSeconds,
 				EtaSource.FALLBACK,
 				EtaConfidence.LOW,
+				providerSnapshotId,
+				providerReceivedAt,
+				providerHealthCount,
 				warnings("REALTIME_UNAVAILABLE_PLANNED_USED", fallbackCode)
 			);
 			case EMPTY_PROVIDER_RESULT -> planned(
@@ -52,7 +83,10 @@ public final class RealtimeEtaOverlay {
 				plannedWaitSeconds,
 				EtaSource.FALLBACK,
 				EtaConfidence.LOW,
-				warnings("EMPTY_PROVIDER_RESULT", fallbackCode)
+				providerSnapshotId,
+				providerReceivedAt,
+				providerHealthCount,
+				warnings(ArrivalFreshness.EMPTY_PROVIDER_RESULT.name(), fallbackCode)
 			);
 		};
 	}
@@ -61,6 +95,9 @@ public final class RealtimeEtaOverlay {
 		Instant readyAt,
 		int plannedWaitSeconds,
 		String direction,
+		String providerSnapshotId,
+		Instant providerReceivedAt,
+		int providerHealthCount,
 		List<ArrivalCandidate> candidates
 	) {
 		return candidates.stream()
@@ -68,21 +105,32 @@ public final class RealtimeEtaOverlay {
 			.filter(candidate -> !candidate.expectedArrivalAt().isBefore(readyAt))
 			.filter(candidate -> matchesDirection(direction, candidate.direction()))
 			.min(Comparator.comparing(ArrivalCandidate::expectedArrivalAt))
-			.map(candidate -> realtime(readyAt, plannedWaitSeconds, candidate))
+			.map(candidate -> realtime(readyAt, plannedWaitSeconds, providerSnapshotId, providerReceivedAt, providerHealthCount, candidate))
 			.orElseGet(() -> planned(
 				readyAt,
 				plannedWaitSeconds,
 				EtaSource.FALLBACK,
 				EtaConfidence.LOW,
+				providerSnapshotId,
+				providerReceivedAt,
+				providerHealthCount,
 				List.of("NO_USABLE_REALTIME_CANDIDATE")
 			));
 	}
 
-	private Result realtime(Instant readyAt, int plannedWaitSeconds, ArrivalCandidate candidate) {
+	private Result realtime(
+		Instant readyAt,
+		int plannedWaitSeconds,
+		String providerSnapshotId,
+		Instant providerReceivedAt,
+		int providerHealthCount,
+		ArrivalCandidate candidate
+	) {
 		int waitSeconds = Math.toIntExact(Duration.between(readyAt, candidate.expectedArrivalAt()).toSeconds());
-		String evidence = candidate.providerReceivedAt() == null
+		Instant evidenceReceivedAt = providerReceivedAt == null ? candidate.providerReceivedAt() : providerReceivedAt;
+		String evidence = evidenceReceivedAt == null
 			? null
-			: "providerReceivedAt=" + candidate.providerReceivedAt();
+			: "providerReceivedAt=" + evidenceReceivedAt;
 		return new Result(
 			EtaSource.REALTIME,
 			candidate.confidence(),
@@ -91,6 +139,9 @@ public final class RealtimeEtaOverlay {
 			candidate.expectedArrivalAt(),
 			candidate.trainNo(),
 			evidence,
+			providerSnapshotId,
+			evidenceReceivedAt,
+			providerHealthCount,
 			List.of()
 		);
 	}
@@ -100,6 +151,9 @@ public final class RealtimeEtaOverlay {
 		int plannedWaitSeconds,
 		EtaSource etaSource,
 		EtaConfidence confidence,
+		String providerSnapshotId,
+		Instant providerReceivedAt,
+		int providerHealthCount,
 		List<String> warningCodes
 	) {
 		return new Result(
@@ -110,6 +164,9 @@ public final class RealtimeEtaOverlay {
 			readyAt.plusSeconds(plannedWaitSeconds),
 			null,
 			null,
+			providerSnapshotId,
+			providerReceivedAt,
+			providerHealthCount,
 			warningCodes
 		);
 	}
@@ -135,6 +192,9 @@ public final class RealtimeEtaOverlay {
 		Instant expectedDepartureAt,
 		String trainNo,
 		String providerEvidence,
+		String providerSnapshotId,
+		Instant providerReceivedAt,
+		int providerHealthCount,
 		List<String> warningCodes
 	) {
 		public Result {

--- a/backend/src/main/java/com/easysubway/route/domain/RealtimeEtaOverlay.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RealtimeEtaOverlay.java
@@ -1,0 +1,144 @@
+package com.easysubway.route.domain;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public final class RealtimeEtaOverlay {
+
+	public Result overlay(
+		Instant readyAt,
+		int plannedWaitSeconds,
+		String direction,
+		ArrivalFreshness providerStatus,
+		String fallbackCode,
+		List<ArrivalCandidate> candidates
+	) {
+		if (readyAt == null) {
+			throw new IllegalArgumentException("readyAt is required.");
+		}
+		if (plannedWaitSeconds < 0) {
+			throw new IllegalArgumentException("plannedWaitSeconds must be greater than or equal to zero.");
+		}
+		ArrivalFreshness status = providerStatus == null ? ArrivalFreshness.UNAVAILABLE : providerStatus;
+		List<ArrivalCandidate> safeCandidates = candidates == null ? List.of() : candidates;
+		return switch (status) {
+			case FRESH_REALTIME -> freshOverlay(readyAt, plannedWaitSeconds, direction, safeCandidates);
+			case STALE_REALTIME -> planned(
+				readyAt,
+				plannedWaitSeconds,
+				EtaSource.PLANNED,
+				EtaConfidence.MEDIUM,
+				List.of("STALE_REALTIME")
+			);
+			case UNSUPPORTED -> planned(
+				readyAt,
+				plannedWaitSeconds,
+				EtaSource.PLANNED,
+				EtaConfidence.MEDIUM,
+				List.of("UNSUPPORTED_REALTIME")
+			);
+			case UNAVAILABLE -> planned(
+				readyAt,
+				plannedWaitSeconds,
+				EtaSource.FALLBACK,
+				EtaConfidence.LOW,
+				warnings("REALTIME_UNAVAILABLE_PLANNED_USED", fallbackCode)
+			);
+			case EMPTY_PROVIDER_RESULT -> planned(
+				readyAt,
+				plannedWaitSeconds,
+				EtaSource.FALLBACK,
+				EtaConfidence.LOW,
+				warnings("EMPTY_PROVIDER_RESULT", fallbackCode)
+			);
+		};
+	}
+
+	private Result freshOverlay(
+		Instant readyAt,
+		int plannedWaitSeconds,
+		String direction,
+		List<ArrivalCandidate> candidates
+	) {
+		return candidates.stream()
+			.filter(candidate -> candidate.freshness() == ArrivalFreshness.FRESH_REALTIME)
+			.filter(candidate -> !candidate.expectedArrivalAt().isBefore(readyAt))
+			.filter(candidate -> matchesDirection(direction, candidate.direction()))
+			.min(Comparator.comparing(ArrivalCandidate::expectedArrivalAt))
+			.map(candidate -> realtime(readyAt, plannedWaitSeconds, candidate))
+			.orElseGet(() -> planned(
+				readyAt,
+				plannedWaitSeconds,
+				EtaSource.FALLBACK,
+				EtaConfidence.LOW,
+				List.of("NO_USABLE_REALTIME_CANDIDATE")
+			));
+	}
+
+	private Result realtime(Instant readyAt, int plannedWaitSeconds, ArrivalCandidate candidate) {
+		int waitSeconds = Math.toIntExact(Duration.between(readyAt, candidate.expectedArrivalAt()).toSeconds());
+		String evidence = candidate.providerReceivedAt() == null
+			? null
+			: "providerReceivedAt=" + candidate.providerReceivedAt();
+		return new Result(
+			EtaSource.REALTIME,
+			candidate.confidence(),
+			plannedWaitSeconds,
+			waitSeconds,
+			candidate.expectedArrivalAt(),
+			candidate.trainNo(),
+			evidence,
+			List.of()
+		);
+	}
+
+	private Result planned(
+		Instant readyAt,
+		int plannedWaitSeconds,
+		EtaSource etaSource,
+		EtaConfidence confidence,
+		List<String> warningCodes
+	) {
+		return new Result(
+			etaSource,
+			confidence,
+			plannedWaitSeconds,
+			plannedWaitSeconds,
+			readyAt.plusSeconds(plannedWaitSeconds),
+			null,
+			null,
+			warningCodes
+		);
+	}
+
+	private boolean matchesDirection(String expected, String actual) {
+		return expected == null || expected.isBlank() || expected.equals(actual);
+	}
+
+	private List<String> warnings(String defaultCode, String fallbackCode) {
+		List<String> warnings = new ArrayList<>();
+		warnings.add(defaultCode);
+		if (fallbackCode != null && !fallbackCode.isBlank() && !defaultCode.equals(fallbackCode)) {
+			warnings.add(fallbackCode);
+		}
+		return List.copyOf(warnings);
+	}
+
+	public record Result(
+		EtaSource etaSource,
+		EtaConfidence confidence,
+		int plannedWaitSeconds,
+		int waitSeconds,
+		Instant expectedDepartureAt,
+		String trainNo,
+		String providerEvidence,
+		List<String> warningCodes
+	) {
+		public Result {
+			warningCodes = warningCodes == null ? List.of() : List.copyOf(warningCodes);
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java
@@ -52,6 +52,25 @@ public record RouteSearchResult(
 			.sum();
 	}
 
+	@JsonProperty("etaSource")
+	public EtaSource etaSource() {
+		if (steps.isEmpty()) {
+			return EtaSource.PLANNED;
+		}
+		long realtimeSteps = steps.stream()
+			.filter(step -> EtaSource.REALTIME.name().equals(step.timeSource()))
+			.count();
+		boolean fallback = steps.stream()
+			.anyMatch(step -> EtaSource.FALLBACK.name().equals(step.timeSource()));
+		if (fallback) {
+			return EtaSource.FALLBACK;
+		}
+		if (realtimeSteps == 0) {
+			return EtaSource.PLANNED;
+		}
+		return realtimeSteps == steps.size() ? EtaSource.REALTIME : EtaSource.MIXED;
+	}
+
 	@JsonProperty("walkingDistanceMeters")
 	public int walkingDistanceMeters() {
 		return steps.stream()

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
@@ -74,7 +74,7 @@ class RouteSearchControllerTest {
 			.andExpect(jsonPath("$.data.warnings").isArray())
 			.andExpect(jsonPath("$.data.blockedReasons").isArray())
 			.andExpect(jsonPath("$.data.createdAt").value("2026-06-30T09:00:00"))
-			.andExpect(jsonPath("$.data.etaSource").value("STATIC_BACKEND_V1"))
+			.andExpect(jsonPath("$.data.etaSource").value("PLANNED"))
 			.andExpect(jsonPath("$.data.routeQuality").value("LEGACY_STATIC"))
 			.andExpect(jsonPath("$.data.commercialEtaEligible").value(false));
 	}
@@ -138,7 +138,7 @@ class RouteSearchControllerTest {
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.status").value("BLOCKED"))
 			.andExpect(jsonPath("$.data.blockedReasons[0]").value("계단 없는 역 접근 경로를 확인할 수 없습니다."))
-			.andExpect(jsonPath("$.data.etaSource").value("STATIC_BACKEND_V1"))
+			.andExpect(jsonPath("$.data.etaSource").value("PLANNED"))
 			.andExpect(jsonPath("$.data.routeQuality").value("LEGACY_STATIC"))
 			.andExpect(jsonPath("$.data.commercialEtaEligible").value(false));
 	}

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
@@ -143,6 +143,41 @@ class RouteSearchControllerTest {
 			.andExpect(jsonPath("$.data.commercialEtaEligible").value(false));
 	}
 
+	@Test
+	@DisplayName("V1 ETA source는 step timeSource의 REALTIME, MIXED, FALLBACK을 노출한다")
+	void searchRouteMapsCommercialEtaSources() throws Exception {
+		when(routeSearchUseCase.searchRoute(argThat(command -> command != null
+			&& "station-realtime".equals(command.originStationId()))))
+			.thenReturn(routeSearchWithSteps(List.of(routeStep("REALTIME", "HIGH"))));
+		when(routeSearchUseCase.searchRoute(argThat(command -> command != null
+			&& "station-mixed".equals(command.originStationId()))))
+			.thenReturn(routeSearchWithSteps(List.of(
+				routeStep("REALTIME", "HIGH"),
+				routeStep("ESTIMATED_CONSTANT", "LOW")
+			)));
+		when(routeSearchUseCase.searchRoute(argThat(command -> command != null
+			&& "station-fallback".equals(command.originStationId()))))
+			.thenReturn(routeSearchWithSteps(List.of(routeStep("FALLBACK", "LOW"))));
+
+		assertEtaSource("station-realtime", "REALTIME");
+		assertEtaSource("station-mixed", "MIXED");
+		assertEtaSource("station-fallback", "FALLBACK");
+	}
+
+	private void assertEtaSource(String originStationId, String etaSource) throws Exception {
+		mockMvc.perform(post("/api/v1/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "%s",
+					  "destinationStationId": "station-sadang",
+					  "mobilityType": "WHEELCHAIR"
+					}
+					""".formatted(originStationId)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.etaSource").value(etaSource));
+	}
+
 	private RouteSearchResult foundRouteSearch() {
 		return new RouteSearchResult(
 			"route-search-1",
@@ -176,6 +211,46 @@ class RouteSearchControllerTest {
 			List.of(),
 			List.of(),
 			LocalDateTime.of(2026, 6, 30, 9, 0)
+		);
+	}
+
+	private RouteSearchResult routeSearchWithSteps(List<RouteStep> steps) {
+		return new RouteSearchResult(
+			"route-search-eta",
+			"station-origin",
+			"출발역",
+			"station-sadang",
+			"사당",
+			MobilityType.WHEELCHAIR,
+			RouteSearchStatus.FOUND,
+			"line-4",
+			"수도권 4호선",
+			18,
+			steps,
+			List.of(),
+			List.of(),
+			LocalDateTime.of(2026, 6, 30, 9, 0)
+		);
+	}
+
+	private RouteStep routeStep(String timeSource, String confidenceLabel) {
+		return new RouteStep(
+			1,
+			"ride",
+			"4호선 이동",
+			"열차로 이동합니다.",
+			"line-4",
+			"수도권 4호선",
+			"station-origin",
+			"station-sadang",
+			7,
+			1800,
+			false,
+			"VERIFIED",
+			false,
+			timeSource,
+			"ESTIMATED_CONSTANT",
+			confidenceLabel
 		);
 	}
 

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -152,6 +152,33 @@ class RouteSearchV2ControllerTest {
 	}
 
 	@Test
+	@DisplayName("V2 leg ETA source와 confidence는 step data에서 파생한다")
+	void routeSearchV2MapsLegEtaSourceAndConfidence() throws Exception {
+		when(routeSearchUseCase.searchRoute(argThat(command ->
+			command != null && "station-realtime-origin".equals(command.originStationId())
+		))).thenReturn(realtimeRouteSearch());
+
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-realtime-origin",
+					  "destinationStationId": "station-sadang",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "constraintMode": "ALLOW_WITH_WARNINGS",
+					  "useRealtime": true,
+					  "maxTransfers": 1,
+					  "alternativeCount": 1
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.itineraries[0].etaSource").value("REALTIME"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].etaSource").value("REALTIME"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].confidence").value("HIGH"));
+	}
+
+	@Test
 	@DisplayName("모바일 V2 계약의 blocked reasonCodes는 사용자 문장 대신 안정적인 코드만 반환한다")
 	void routeSearchV2BlockedRiskReasonCodesAreStableCodes() throws Exception {
 		when(routeSearchUseCase.searchRoute(argThat(command ->
@@ -416,6 +443,42 @@ class RouteSearchV2ControllerTest {
 				new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE),
 				new RouteWarning(RouteWarningCode.STALE_ACCESSIBILITY_DATA)
 			),
+			List.of(),
+			LocalDateTime.of(2026, 6, 30, 9, 0)
+		);
+	}
+
+	private RouteSearchResult realtimeRouteSearch() {
+		return new RouteSearchResult(
+			"route-search-realtime",
+			"station-realtime-origin",
+			"실시간 출발역",
+			"station-sadang",
+			"사당",
+			MobilityType.STROLLER,
+			RouteSearchStatus.FOUND,
+			"line-4",
+			"수도권 4호선",
+			18,
+			List.of(new RouteStep(
+				1,
+				"ride",
+				"실시간 열차",
+				"실시간 도착 후보를 반영합니다.",
+				"line-4",
+				"수도권 4호선",
+				"station-realtime-origin",
+				"station-sadang",
+				3,
+				1800,
+				false,
+				"VERIFIED",
+				false,
+				"REALTIME",
+				"ESTIMATED_CONSTANT",
+				"HIGH"
+			)),
+			List.of(),
 			List.of(),
 			LocalDateTime.of(2026, 6, 30, 9, 0)
 		);

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -86,7 +86,7 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.data.itineraries[0].status").value("FOUND"))
 			.andExpect(jsonPath("$.data.itineraries[0].plannedArrivalTime").value("2026-06-30T09:22:00+09:00"))
 			.andExpect(jsonPath("$.data.itineraries[0].realtimeArrivalTime").doesNotExist())
-			.andExpect(jsonPath("$.data.itineraries[0].etaSource").value("STATIC_BACKEND_V1"))
+			.andExpect(jsonPath("$.data.itineraries[0].etaSource").value("PLANNED"))
 			.andExpect(jsonPath("$.data.itineraries[0].etaConfidence").value("LOW"))
 			.andExpect(jsonPath("$.data.itineraries[0].durationSeconds").value(420))
 			.andExpect(jsonPath("$.data.itineraries[0].transferCount").value(0))
@@ -106,7 +106,7 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.data.itineraries[0].legs[1].plannedArrivalTime").value("2026-06-30T09:22:00+09:00"))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].waitTimeSeconds").value(0))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].slackSeconds").value(0))
-			.andExpect(jsonPath("$.data.itineraries[0].legs[0].etaSource").value("STATIC_BACKEND_V1"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].etaSource").value("PLANNED"))
 			.andExpect(jsonPath("$.data.itineraries[0].commercialEtaEligible").value(false));
 	}
 

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -174,6 +174,7 @@ class RouteSearchV2ControllerTest {
 					"""))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.itineraries[0].etaSource").value("REALTIME"))
+			.andExpect(jsonPath("$.data.itineraries[0].etaConfidence").value("HIGH"))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].etaSource").value("REALTIME"))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].confidence").value("HIGH"));
 	}

--- a/backend/src/test/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolverTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolverTest.java
@@ -1,0 +1,54 @@
+package com.easysubway.route.adapter.out.realtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.easysubway.realtime.application.RealtimeArrivalResult;
+import com.easysubway.realtime.application.RealtimeGatewayService;
+import com.easysubway.realtime.application.RealtimeQuery;
+import com.easysubway.realtime.domain.RealtimeArrival;
+import com.easysubway.route.application.port.out.RealtimeArrivalResolver;
+import com.easysubway.route.domain.ArrivalCandidate;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RealtimeGatewayArrivalResolverTest {
+
+	@Test
+	@DisplayName("gateway가 조정한 ETA는 gateway receivedAt 기준 expectedArrivalAt으로 변환한다")
+	void adjustedEtaUsesGatewayReceivedAtAsBase() {
+		RealtimeGatewayService gatewayService = org.mockito.Mockito.mock(RealtimeGatewayService.class);
+		when(gatewayService.arrivals(any(RealtimeQuery.class))).thenReturn(RealtimeArrivalResult.fresh(
+			"2026-06-26T08:00:00Z",
+			List.of(new RealtimeArrival(
+				"line-4",
+				"상록수",
+				"사당",
+				"상행",
+				"T1001",
+				150,
+				"3분 후",
+				"전역 출발",
+				"2026-06-26T07:59:30Z"
+			))
+		));
+		RealtimeGatewayArrivalResolver resolver = new RealtimeGatewayArrivalResolver(gatewayService);
+
+		RealtimeArrivalResolver.Resolution resolution = resolver.resolve(new RealtimeArrivalResolver.Query(
+			"station-sangnoksu",
+			"line-4",
+			"1004",
+			"상록수",
+			"4호선",
+			"상행",
+			Instant.parse("2026-06-26T08:00:00Z")
+		));
+
+		ArrivalCandidate candidate = resolution.candidates().getFirst();
+		assertThat(candidate.providerReceivedAt()).isEqualTo(Instant.parse("2026-06-26T07:59:30Z"));
+		assertThat(candidate.expectedArrivalAt()).isEqualTo(Instant.parse("2026-06-26T08:02:30Z"));
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/domain/RealtimeEtaOverlayTest.java
+++ b/backend/src/test/java/com/easysubway/route/domain/RealtimeEtaOverlayTest.java
@@ -36,6 +36,9 @@ class RealtimeEtaOverlayTest {
 			"당고개 방면",
 			ArrivalFreshness.FRESH_REALTIME,
 			null,
+			"seoul-topis:2026-07-01T00:00:00Z",
+			READY_AT,
+			1,
 			List.of(candidate)
 		);
 
@@ -44,7 +47,10 @@ class RealtimeEtaOverlayTest {
 		assertThat(result.plannedWaitSeconds()).isEqualTo(PLANNED_WAIT_SECONDS);
 		assertThat(result.waitSeconds()).isEqualTo(120);
 		assertThat(result.trainNo()).isEqualTo("train-401");
-		assertThat(result.providerEvidence()).isEqualTo("providerReceivedAt=2026-06-30T23:59:30Z");
+		assertThat(result.providerEvidence()).isEqualTo("providerReceivedAt=2026-07-01T00:00:00Z");
+		assertThat(result.providerSnapshotId()).isEqualTo("seoul-topis:2026-07-01T00:00:00Z");
+		assertThat(result.providerReceivedAt()).isEqualTo(READY_AT);
+		assertThat(result.providerHealthCount()).isEqualTo(1);
 		assertThat(result.warningCodes()).isEmpty();
 	}
 

--- a/backend/src/test/java/com/easysubway/route/domain/RealtimeEtaOverlayTest.java
+++ b/backend/src/test/java/com/easysubway/route/domain/RealtimeEtaOverlayTest.java
@@ -1,0 +1,150 @@
+package com.easysubway.route.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("실시간 ETA overlay")
+class RealtimeEtaOverlayTest {
+
+	private static final Instant READY_AT = Instant.parse("2026-07-01T00:00:00Z");
+	private static final int PLANNED_WAIT_SECONDS = 300;
+
+	private final RealtimeEtaOverlay overlay = new RealtimeEtaOverlay();
+
+	@Test
+	@DisplayName("fresh realtime 후보는 첫 승차 대기시간과 provider 증거를 반영한다")
+	void freshRealtimeCandidateUpdatesWaitTime() {
+		ArrivalCandidate candidate = new ArrivalCandidate(
+			"train-401",
+			"seoul-4",
+			"당고개 방면",
+			"당고개",
+			120,
+			READY_AT.plusSeconds(120),
+			Instant.parse("2026-06-30T23:59:30Z"),
+			ArrivalFreshness.FRESH_REALTIME,
+			EtaConfidence.HIGH
+		);
+
+		RealtimeEtaOverlay.Result result = overlay.overlay(
+			READY_AT,
+			PLANNED_WAIT_SECONDS,
+			"당고개 방면",
+			ArrivalFreshness.FRESH_REALTIME,
+			null,
+			List.of(candidate)
+		);
+
+		assertThat(result.etaSource()).isEqualTo(EtaSource.REALTIME);
+		assertThat(result.confidence()).isEqualTo(EtaConfidence.HIGH);
+		assertThat(result.plannedWaitSeconds()).isEqualTo(PLANNED_WAIT_SECONDS);
+		assertThat(result.waitSeconds()).isEqualTo(120);
+		assertThat(result.trainNo()).isEqualTo("train-401");
+		assertThat(result.providerEvidence()).isEqualTo("providerReceivedAt=2026-06-30T23:59:30Z");
+		assertThat(result.warningCodes()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("stale realtime은 경고만 남기고 planned timetable을 사용한다")
+	void staleRealtimeUsesPlannedWait() {
+		RealtimeEtaOverlay.Result result = overlay.overlay(
+			READY_AT,
+			PLANNED_WAIT_SECONDS,
+			"당고개 방면",
+			ArrivalFreshness.STALE_REALTIME,
+			"STALE_CACHE",
+			List.of()
+		);
+
+		assertThat(result.etaSource()).isEqualTo(EtaSource.PLANNED);
+		assertThat(result.confidence()).isEqualTo(EtaConfidence.MEDIUM);
+		assertThat(result.waitSeconds()).isEqualTo(PLANNED_WAIT_SECONDS);
+		assertThat(result.warningCodes()).containsExactly("STALE_REALTIME");
+	}
+
+	@Test
+	@DisplayName("unavailable provider는 route search를 실패시키지 않고 fallback source와 오류 코드를 남긴다")
+	void unavailableProviderUsesFallbackWait() {
+		RealtimeEtaOverlay.Result result = overlay.overlay(
+			READY_AT,
+			PLANNED_WAIT_SECONDS,
+			"당고개 방면",
+			ArrivalFreshness.UNAVAILABLE,
+			"PROVIDER_QUOTA_EXCEEDED",
+			List.of()
+		);
+
+		assertThat(result.etaSource()).isEqualTo(EtaSource.FALLBACK);
+		assertThat(result.confidence()).isEqualTo(EtaConfidence.LOW);
+		assertThat(result.waitSeconds()).isEqualTo(PLANNED_WAIT_SECONDS);
+		assertThat(result.warningCodes())
+			.containsExactly("REALTIME_UNAVAILABLE_PLANNED_USED", "PROVIDER_QUOTA_EXCEEDED");
+	}
+
+	@Test
+	@DisplayName("empty provider result는 planned fallback과 provider health 코드를 남긴다")
+	void emptyProviderResultUsesFallbackWait() {
+		RealtimeEtaOverlay.Result result = overlay.overlay(
+			READY_AT,
+			PLANNED_WAIT_SECONDS,
+			"당고개 방면",
+			ArrivalFreshness.EMPTY_PROVIDER_RESULT,
+			"EMPTY_PROVIDER_RESULT",
+			List.of()
+		);
+
+		assertThat(result.etaSource()).isEqualTo(EtaSource.FALLBACK);
+		assertThat(result.waitSeconds()).isEqualTo(PLANNED_WAIT_SECONDS);
+		assertThat(result.warningCodes()).containsExactly("EMPTY_PROVIDER_RESULT");
+	}
+
+	@Test
+	@DisplayName("unsupported realtime은 planned timetable만 사용한다")
+	void unsupportedRealtimeUsesPlannedWait() {
+		RealtimeEtaOverlay.Result result = overlay.overlay(
+			READY_AT,
+			PLANNED_WAIT_SECONDS,
+			"당고개 방면",
+			ArrivalFreshness.UNSUPPORTED,
+			"UNSUPPORTED_REGION",
+			List.of()
+		);
+
+		assertThat(result.etaSource()).isEqualTo(EtaSource.PLANNED);
+		assertThat(result.waitSeconds()).isEqualTo(PLANNED_WAIT_SECONDS);
+		assertThat(result.warningCodes()).containsExactly("UNSUPPORTED_REALTIME");
+	}
+
+	@Test
+	@DisplayName("방향이 맞지 않는 fresh 후보는 ETA 개선에 사용하지 않는다")
+	void freshRealtimeCandidateRequiresMatchingDirection() {
+		ArrivalCandidate wrongDirection = new ArrivalCandidate(
+			"train-402",
+			"seoul-4",
+			"오이도 방면",
+			"오이도",
+			90,
+			READY_AT.plusSeconds(90),
+			READY_AT.minusSeconds(20),
+			ArrivalFreshness.FRESH_REALTIME,
+			EtaConfidence.HIGH
+		);
+
+		RealtimeEtaOverlay.Result result = overlay.overlay(
+			READY_AT,
+			PLANNED_WAIT_SECONDS,
+			"당고개 방면",
+			ArrivalFreshness.FRESH_REALTIME,
+			null,
+			List.of(wrongDirection)
+		);
+
+		assertThat(result.etaSource()).isEqualTo(EtaSource.FALLBACK);
+		assertThat(result.waitSeconds()).isEqualTo(PLANNED_WAIT_SECONDS);
+		assertThat(result.warningCodes()).containsExactly("NO_USABLE_REALTIME_CANDIDATE");
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -8617,7 +8617,8 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.match(controller, /@PostMapping\("\/api\/v1\/routes\/search"\)/);
   assert.match(controller, /RouteSearchUseCase/);
   assert.match(controller, /ApiResponse<RouteSearchV1Response>/);
-  assert.match(controller, /"STATIC_BACKEND_V1"/);
+  assert.match(controller, /EtaSource/);
+  assert.match(controller, /result\.etaSource\(\)\.name\(\)/);
   assert.match(controller, /"LEGACY_STATIC"/);
   assert.match(controller, /false/);
   assert.doesNotMatch(controller, /@GetMapping|feedback|SubmitRouteFeedbackCommand/);


### PR DESCRIPTION
## 관련 이슈

close #1222

## 작업 배경

- backend realtime gateway는 fresh/stale/unavailable arrival 결과를 만들지만 route search 응답 계약에는 아직 실시간 ETA 출처와 evidence가 반영되지 않습니다.
- F-1 범위에서는 production ETA claim을 추가하지 않고, route/realtime boundary와 overlay 정책을 먼저 고정합니다.

## 작업 내용

- `RealtimeArrivalResolver` port와 `RealtimeGatewayArrivalResolver` adapter를 추가했습니다.
- `ArrivalCandidate`, `ArrivalFreshness`, `EtaConfidence`, `EtaSource`, `RealtimeEtaOverlay` 도메인 계약을 추가했습니다.
- V1/V2 route response의 `etaSource`를 `PLANNED | REALTIME | MIXED | FALLBACK`로 정규화했습니다.
- fresh realtime candidate만 ETA에 반영하고, stale/unsupported/unavailable/empty provider result는 planned/fallback 정책과 warning으로 분리했습니다.
- CodeRabbit 및 Codex CLI fallback review 지적사항을 반영해 provider evidence 보존, null-safe etaSource, confidence mapping, adjusted ETA 기준시각을 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests "*RealtimeGatewayArrivalResolverTest" --tests "*RealtimeEtaOverlayTest" --tests "*RouteSearchControllerTest" --tests "*RouteSearchV2ControllerTest" --no-daemon` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공, 151 tests pass
  - `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Realtime/Route backend regression | Backend | Gradle targeted tests | 로컬 명령 로그 | 성공 |
| Repository contract | Repo | `node --test tools/ci/repository-contract.test.mjs` | 로컬 명령 로그 | 성공 |
| Whitespace check | Repo | `git diff --check` | 로컬 명령 로그 | 성공 |
| UI/접근성 수동 증거 | Android / iOS | Backend contract-only 변경 | 화면 변경 없음, 증거 불필요 | 해당 없음 |
| PR CI | GitHub Actions | PR checks | CI run 28488945606, Release Artifacts run 28488945454, SonarCloud PR analysis | 성공 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: `etaSource = PLANNED | REALTIME | MIXED | FALLBACK` 응답 계약 추가
- realtime contract: `RealtimeArrivalResolver`, `ArrivalCandidate`, `RealtimeEtaOverlay` backend contract 추가
- backend identity: backend deploy only

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RealtimeGatewayArrivalResolver`의 adjusted ETA 기준시각 처리
  - `RealtimeEtaOverlay`의 fresh/stale/unavailable/empty provider 정책
  - V1/V2 `etaSource` 및 `etaConfidence` 응답 mapping
  - CodeRabbit 최신 incremental review가 rate-limited되어 Codex CLI fallback review를 단일 PR review로 게시했고, P2 2건은 `b67b1869`에서 처리했습니다.

## 리스크

- Production ETA claim은 이번 범위에서 추가하지 않았습니다.
- 실제 route engine에 resolver injection을 넓히는 작업은 F-2 이후 범위로 남습니다.
- provider 장애는 route search 실패로 전파하지 않고 planned/fallback 응답으로 낮춥니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
