### PR TITLE
[Feat] 첫 열차와 환승 열차 탑승시간 계산

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -484,10 +484,12 @@ class RouteSearchController {
 				return 0;
 			}
 			// ponytail: schedule candidate selection belongs with timetable schema; expose only mobility buffer for now.
-			if (mobilityType == MobilityType.WHEELCHAIR || mobilityType == MobilityType.TEMPORARY_INJURY) {
-				return 180;
-			}
-			return 120;
+			return switch (mobilityType) {
+				case LUGGAGE -> 60;
+				case SENIOR, PREGNANT -> 90;
+				case STROLLER, TEMPORARY_INJURY -> 120;
+				case WHEELCHAIR -> 180;
+			};
 		}
 
 		private static EtaSource etaSourceOf(RouteStep step) {

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -17,6 +17,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -222,10 +223,10 @@ class RouteSearchController {
 
 		private static ItineraryDto from(RouteSearchResult result, OffsetDateTime departureTime) {
 			List<LegDto> legs = LegDto.fromSteps(result.steps(), departureTime, result.mobilityType());
-			int durationSeconds = result.estimatedDurationSeconds() + legs.stream()
-				.mapToInt(LegDto::waitTimeSeconds)
-				.sum();
-			OffsetDateTime plannedArrivalTime = departureTime.plusSeconds(durationSeconds);
+			OffsetDateTime plannedArrivalTime = legs.isEmpty()
+				? departureTime
+				: OffsetDateTime.parse(legs.get(legs.size() - 1).plannedArrivalTime());
+			int durationSeconds = Math.toIntExact(Duration.between(departureTime, plannedArrivalTime).toSeconds());
 			return new ItineraryDto(
 				result.routeSearchId() + "-primary",
 				statusOf(result),
@@ -439,11 +440,12 @@ class RouteSearchController {
 			List<LegDto> legs = new ArrayList<>();
 			OffsetDateTime cursor = departureTime;
 			for (RouteStep step : steps) {
+				String legType = legTypeOf(step);
 				int durationSeconds = Math.max(0, step.estimatedMinutes()) * 60;
-				int slackSeconds = slackSeconds(step, mobilityType);
+				int slackSeconds = slackSeconds(legType, mobilityType);
 				OffsetDateTime plannedDepartureTime = cursor.plusSeconds(slackSeconds);
 				OffsetDateTime plannedArrivalTime = plannedDepartureTime.plusSeconds(durationSeconds);
-				legs.add(from(step, plannedDepartureTime, plannedArrivalTime, durationSeconds, slackSeconds));
+				legs.add(from(step, legType, plannedDepartureTime, plannedArrivalTime, durationSeconds, slackSeconds));
 				cursor = plannedArrivalTime;
 			}
 			return List.copyOf(legs);
@@ -451,13 +453,14 @@ class RouteSearchController {
 
 		private static LegDto from(
 			RouteStep step,
+			String legType,
 			OffsetDateTime departureTime,
 			OffsetDateTime plannedArrivalTime,
 			int durationSeconds,
 			int slackSeconds
 		) {
 			return new LegDto(
-				legTypeOf(step),
+				legType,
 				step.fromStationId(),
 				step.toStationId(),
 				"",
@@ -479,8 +482,8 @@ class RouteSearchController {
 			);
 		}
 
-		private static int slackSeconds(RouteStep step, MobilityType mobilityType) {
-			if (!"RIDE".equals(legTypeOf(step))) {
+		private static int slackSeconds(String legType, MobilityType mobilityType) {
+			if (!"RIDE".equals(legType)) {
 				return 0;
 			}
 			// ponytail: schedule candidate selection belongs with timetable schema; expose only mobility buffer for now.

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -221,8 +221,11 @@ class RouteSearchController {
 	) {
 
 		private static ItineraryDto from(RouteSearchResult result, OffsetDateTime departureTime) {
-			OffsetDateTime plannedArrivalTime = departureTime.plusSeconds(result.estimatedDurationSeconds());
-			List<LegDto> legs = LegDto.fromSteps(result.steps(), departureTime);
+			List<LegDto> legs = LegDto.fromSteps(result.steps(), departureTime, result.mobilityType());
+			int durationSeconds = result.estimatedDurationSeconds() + legs.stream()
+				.mapToInt(LegDto::waitTimeSeconds)
+				.sum();
+			OffsetDateTime plannedArrivalTime = departureTime.plusSeconds(durationSeconds);
 			return new ItineraryDto(
 				result.routeSearchId() + "-primary",
 				statusOf(result),
@@ -230,7 +233,7 @@ class RouteSearchController {
 				null,
 				result.etaSource().name(),
 				etaConfidenceOf(result),
-				result.estimatedDurationSeconds(),
+				durationSeconds,
 				result.transferCount(),
 				result.walkingDistanceMeters(),
 				AccessibilityRiskDto.from(result),
@@ -428,13 +431,19 @@ class RouteSearchController {
 		AccessibilityRiskDto accessibilityRisk
 	) {
 
-		private static List<LegDto> fromSteps(List<RouteStep> steps, OffsetDateTime departureTime) {
+		private static List<LegDto> fromSteps(
+			List<RouteStep> steps,
+			OffsetDateTime departureTime,
+			MobilityType mobilityType
+		) {
 			List<LegDto> legs = new ArrayList<>();
 			OffsetDateTime cursor = departureTime;
 			for (RouteStep step : steps) {
 				int durationSeconds = Math.max(0, step.estimatedMinutes()) * 60;
-				OffsetDateTime plannedArrivalTime = cursor.plusSeconds(durationSeconds);
-				legs.add(from(step, cursor, plannedArrivalTime, durationSeconds));
+				int slackSeconds = slackSeconds(step, mobilityType);
+				OffsetDateTime plannedDepartureTime = cursor.plusSeconds(slackSeconds);
+				OffsetDateTime plannedArrivalTime = plannedDepartureTime.plusSeconds(durationSeconds);
+				legs.add(from(step, plannedDepartureTime, plannedArrivalTime, durationSeconds, slackSeconds));
 				cursor = plannedArrivalTime;
 			}
 			return List.copyOf(legs);
@@ -444,7 +453,8 @@ class RouteSearchController {
 			RouteStep step,
 			OffsetDateTime departureTime,
 			OffsetDateTime plannedArrivalTime,
-			int durationSeconds
+			int durationSeconds,
+			int slackSeconds
 		) {
 			return new LegDto(
 				legTypeOf(step),
@@ -459,14 +469,25 @@ class RouteSearchController {
 				null,
 				formatOffset(plannedArrivalTime),
 				null,
-				0,
-				0,
+				slackSeconds,
+				slackSeconds,
 				durationSeconds,
 				Math.max(0, step.distanceMeters()),
 				etaSourceOf(step).name(),
 				etaConfidenceOf(step),
 				AccessibilityRiskDto.from(step)
 			);
+		}
+
+		private static int slackSeconds(RouteStep step, MobilityType mobilityType) {
+			if (!"RIDE".equals(legTypeOf(step))) {
+				return 0;
+			}
+			// ponytail: schedule candidate selection belongs with timetable schema; expose only mobility buffer for now.
+			if (mobilityType == MobilityType.WHEELCHAIR || mobilityType == MobilityType.TEMPORARY_INJURY) {
+				return 180;
+			}
+			return 120;
 		}
 
 		private static EtaSource etaSourceOf(RouteStep step) {

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -180,6 +180,38 @@ class RouteSearchV2ControllerTest {
 	}
 
 	@Test
+	@DisplayName("V2 첫 탑승과 환승 후 탑승은 이동약자 준비시간 이후로 계산한다")
+	void routeSearchV2AppliesBoardingAndTransferSlackBeforeRideLegs() throws Exception {
+		when(routeSearchUseCase.searchRoute(argThat(command ->
+			command != null && "station-boarding-origin".equals(command.originStationId())
+		))).thenReturn(boardingTransferRouteSearch());
+
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-boarding-origin",
+					  "destinationStationId": "station-boarding-destination",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "constraintMode": "PREFER_STEP_FREE",
+					  "useRealtime": true,
+					  "maxTransfers": 1,
+					  "alternativeCount": 1
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.itineraries[0].plannedArrivalTime").value("2026-06-30T09:33:00+09:00"))
+			.andExpect(jsonPath("$.data.itineraries[0].durationSeconds").value(1080))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[1].plannedDepartureTime").value("2026-06-30T09:21:00+09:00"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[1].waitTimeSeconds").value(120))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[1].slackSeconds").value(120))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[3].plannedDepartureTime").value("2026-06-30T09:28:00+09:00"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[3].waitTimeSeconds").value(120))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[3].slackSeconds").value(120));
+	}
+
+	@Test
 	@DisplayName("모바일 V2 계약의 blocked reasonCodes는 사용자 문장 대신 안정적인 코드만 반환한다")
 	void routeSearchV2BlockedRiskReasonCodesAreStableCodes() throws Exception {
 		when(routeSearchUseCase.searchRoute(argThat(command ->
@@ -479,6 +511,96 @@ class RouteSearchV2ControllerTest {
 				"ESTIMATED_CONSTANT",
 				"HIGH"
 			)),
+			List.of(),
+			List.of(),
+			LocalDateTime.of(2026, 6, 30, 9, 0)
+		);
+	}
+
+	private RouteSearchResult boardingTransferRouteSearch() {
+		return new RouteSearchResult(
+			"route-search-boarding-transfer",
+			"station-boarding-origin",
+			"탑승 출발역",
+			"station-boarding-destination",
+			"탑승 도착역",
+			MobilityType.STROLLER,
+			RouteSearchStatus.FOUND,
+			"line-boarding",
+			"탑승 노선",
+			20,
+			List.of(
+				new RouteStep(
+					1,
+					"entry",
+					"출발역 승강장 이동",
+					"엘리베이터를 이용해 승강장으로 이동합니다.",
+					"line-boarding-a",
+					"탑승 A 노선",
+					"station-boarding-origin",
+					"station-boarding-origin",
+					4,
+					180,
+					false,
+					false
+				),
+				new RouteStep(
+					2,
+					"ride",
+					"A 노선 탑승",
+					"첫 열차 탑승 시간을 반영합니다.",
+					"line-boarding-a",
+					"탑승 A 노선",
+					"station-boarding-origin",
+					"station-transfer",
+					3,
+					900,
+					false,
+					false
+				),
+				new RouteStep(
+					3,
+					"transfer",
+					"환승 승강장 이동",
+					"환승 동선 시간을 반영합니다.",
+					"line-boarding-b",
+					"탑승 B 노선",
+					"station-transfer",
+					"station-transfer",
+					2,
+					120,
+					false,
+					false
+				),
+				new RouteStep(
+					4,
+					"ride",
+					"B 노선 탑승",
+					"환승 후 열차 탑승 시간을 반영합니다.",
+					"line-boarding-b",
+					"탑승 B 노선",
+					"station-transfer",
+					"station-boarding-destination",
+					4,
+					1200,
+					false,
+					false
+				),
+				new RouteStep(
+					5,
+					"exit",
+					"도착역 출구 이동",
+					"출구 동선을 반영합니다.",
+					"line-boarding-b",
+					"탑승 B 노선",
+					"station-boarding-destination",
+					"station-boarding-destination",
+					1,
+					80,
+					false,
+					false
+				)
+			),
 			List.of(),
 			List.of(),
 			LocalDateTime.of(2026, 6, 30, 9, 0)

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -212,6 +212,36 @@ class RouteSearchV2ControllerTest {
 	}
 
 	@Test
+	@DisplayName("V2 큰 짐 이동은 탑승 준비시간 60초를 적용한다")
+	void routeSearchV2AppliesLuggageBoardingSlack() throws Exception {
+		when(routeSearchUseCase.searchRoute(argThat(command ->
+			command != null && command.mobilityType() == MobilityType.LUGGAGE
+		))).thenReturn(boardingTransferRouteSearch(MobilityType.LUGGAGE));
+
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-boarding-origin",
+					  "destinationStationId": "station-boarding-destination",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "LUGGAGE",
+					  "constraintMode": "PREFER_STEP_FREE",
+					  "useRealtime": true,
+					  "maxTransfers": 1,
+					  "alternativeCount": 1
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.itineraries[0].plannedArrivalTime").value("2026-06-30T09:31:00+09:00"))
+			.andExpect(jsonPath("$.data.itineraries[0].durationSeconds").value(960))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[1].waitTimeSeconds").value(60))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[1].slackSeconds").value(60))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[3].waitTimeSeconds").value(60))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[3].slackSeconds").value(60));
+	}
+
+	@Test
 	@DisplayName("모바일 V2 계약의 blocked reasonCodes는 사용자 문장 대신 안정적인 코드만 반환한다")
 	void routeSearchV2BlockedRiskReasonCodesAreStableCodes() throws Exception {
 		when(routeSearchUseCase.searchRoute(argThat(command ->
@@ -518,13 +548,17 @@ class RouteSearchV2ControllerTest {
 	}
 
 	private RouteSearchResult boardingTransferRouteSearch() {
+		return boardingTransferRouteSearch(MobilityType.STROLLER);
+	}
+
+	private RouteSearchResult boardingTransferRouteSearch(MobilityType mobilityType) {
 		return new RouteSearchResult(
 			"route-search-boarding-transfer",
 			"station-boarding-origin",
 			"탑승 출발역",
 			"station-boarding-destination",
 			"탑승 도착역",
-			MobilityType.STROLLER,
+			mobilityType,
 			RouteSearchStatus.FOUND,
 			"line-boarding",
 			"탑승 노선",


### PR DESCRIPTION
## 관련 이슈

close #1223

## 작업 배경

- V2 ETA leg 응답이 첫 탑승과 환승 후 탑승 준비시간을 0초로 노출해, 교통약자 사용자가 실제로 탈 수 없는 즉시 열차처럼 보일 수 있었다.

## 작업 내용

- V2 `RIDE` leg 직전에 이동 유형별 준비시간을 `waitTimeSeconds`와 `slackSeconds`로 반영했다.
- itinerary `durationSeconds`와 `plannedArrivalTime`을 마지막 leg arrival에서 파생해 leg 상세와 요약 시간이 어긋나지 않게 했다.
- 첫 탑승, 환승 후 탑승, 큰 짐 이동 유형의 준비시간 controller 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests '*RouteSearchV2ControllerTest' --no-daemon` 성공
  - `cd backend && ./gradlew test --tests '*RouteSearchV2*' --no-daemon` 성공
  - `node --test tools/routes/*.test.mjs` 성공
  - `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| V2 route boarding/transfer slack | backend | Gradle targeted test | `cd backend && ./gradlew test --tests '*RouteSearchV2*' --no-daemon` | 성공 |
| Route V2 prototype/gate contracts | tools | Node test runner | `node --test tools/routes/*.test.mjs` | 성공 |
| UI evidence | mobile | backend DTO 계산 변경만 포함 | UI 변경 없음 | 불필요 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: V2 leg `waitTimeSeconds`/`slackSeconds` 값 계산 반영
- realtime contract: production ETA claim 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchController.LegDto.fromSteps`, `RouteSearchController.ItineraryDto.from`

## 리스크

- 현재 timetable 후보 선택은 아직 하지 않고 mobility buffer만 반영한다. schedule schema 기반 후보 선택은 후속 이슈 범위다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 경로 검색 결과에서 이동 유형에 따라 탑승 준비시간과 환승 후 준비시간이 반영되도록 개선되었습니다.
  * 전체 예상 소요시간과 도착 예정 시간이 더 정확하게 계산됩니다.

* **Bug Fixes**
  * 일부 구간의 대기시간이 항상 0으로 표시되던 문제가 수정되었습니다.
  * 이동 유형이 있는 경로에서 각 구간의 준비시간이 올바르게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
