### PR TITLE
[Feat] 경로 탐색 정책 분리와 역외 환승 모드 추가

### DIFF
--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -26,6 +26,7 @@ class LocalRouteEngine {
       destinationNodeId: request.destinationStationId,
       mobilityType: request.mobilityType,
       constraintMode: request.effectiveConstraintMode,
+      searchMode: request.searchMode,
     );
     final path = pathResult.path;
     if (path == null) {
@@ -126,6 +127,7 @@ class AccessGraphRouter {
     required String destinationNodeId,
     required MobilityType mobilityType,
     required ConstraintMode constraintMode,
+    RouteSearchMode searchMode = RouteSearchMode.stationToStation,
   }) {
     if (graph.nodes.isEmpty || graph.edges.isEmpty) {
       return AccessPathResult.noPath(
@@ -140,6 +142,7 @@ class AccessGraphRouter {
       destinationNodeId,
       mobilityType,
       constraintMode,
+      RouteTraversalPolicy(searchMode),
       blockedReasonCodes,
     );
     if (edges != null) {
@@ -196,6 +199,7 @@ class AccessGraphRouter {
     String destinationNodeId,
     MobilityType mobilityType,
     ConstraintMode constraintMode,
+    RouteTraversalPolicy traversalPolicy,
     Set<String> blockedReasonCodes,
   ) {
     final costs = <String, int>{originNodeId: 0};
@@ -214,11 +218,12 @@ class AccessGraphRouter {
       visited.add(current);
 
       for (final edge in graph.edgesFrom(current)) {
-        if (edge.type == RouteEdgeType.entry && current != originNodeId) {
-          continue;
-        }
-        if (edge.type == RouteEdgeType.exit &&
-            edge.toNodeId != destinationNodeId) {
+        if (!traversalPolicy.canTraverse(
+          edge,
+          currentNodeId: current,
+          originNodeId: originNodeId,
+          destinationNodeId: destinationNodeId,
+        )) {
           continue;
         }
         final edgeCost = costCalculator.costFor(
@@ -270,6 +275,31 @@ class AccessGraphRouter {
   }
 }
 
+class RouteTraversalPolicy {
+  const RouteTraversalPolicy(this.searchMode);
+
+  final RouteSearchMode searchMode;
+
+  bool canTraverse(
+    RouteEdge edge, {
+    required String currentNodeId,
+    required String originNodeId,
+    required String destinationNodeId,
+  }) {
+    if (searchMode == RouteSearchMode.debugAllEdges ||
+        searchMode == RouteSearchMode.stationInternal) {
+      return true;
+    }
+    if (edge.type == RouteEdgeType.entry) {
+      return currentNodeId == originNodeId;
+    }
+    if (edge.type == RouteEdgeType.exit) {
+      return edge.toNodeId == destinationNodeId;
+    }
+    return true;
+  }
+}
+
 class StationPathwayRouter {
   const StationPathwayRouter({required this.accessGraphRouter});
 
@@ -287,6 +317,7 @@ class StationPathwayRouter {
       destinationNodeId: toNodeId,
       mobilityType: mobilityType,
       constraintMode: constraintMode,
+      searchMode: RouteSearchMode.stationInternal,
     );
   }
 }

--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -296,6 +296,10 @@ class RouteTraversalPolicy {
     if (edge.type == RouteEdgeType.exit) {
       return edge.toNodeId == destinationNodeId;
     }
+    if (edge.type == RouteEdgeType.outOfStationTransfer) {
+      return searchMode ==
+          RouteSearchMode.stationToStationWithOutOfStationTransfers;
+    }
     return true;
   }
 }

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -31,6 +31,9 @@ class LocalRouteRepository implements RouteSearchRepository {
               destinationStationId: request.destinationStationId,
               mobilityType: mobilityType,
               constraintMode: constraintMode,
+              searchMode: local
+                  .RouteSearchMode
+                  .stationToStationWithOutOfStationTransfers,
             ),
           );
 

--- a/apps/mobile/lib/features/routes/domain/route_request.dart
+++ b/apps/mobile/lib/features/routes/domain/route_request.dart
@@ -16,18 +16,27 @@ enum MobilityType {
 
 enum ConstraintMode { strictStepFree, preferStepFree, allowWithWarnings }
 
+enum RouteSearchMode {
+  stationToStation,
+  stationToStationWithOutOfStationTransfers,
+  stationInternal,
+  debugAllEdges,
+}
+
 class RouteRequest {
   const RouteRequest({
     required this.originStationId,
     required this.destinationStationId,
     required this.mobilityType,
     this.constraintMode,
+    this.searchMode = RouteSearchMode.stationToStation,
   });
 
   final String originStationId;
   final String destinationStationId;
   final MobilityType mobilityType;
   final ConstraintMode? constraintMode;
+  final RouteSearchMode searchMode;
 
   ConstraintMode get effectiveConstraintMode =>
       constraintMode ?? mobilityType.defaultConstraintMode;

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -199,6 +199,20 @@ void main() {
       ]);
     });
 
+    test('기본 역간 탐색은 역외 환승 edge를 쓰지 않는다', () {
+      final result =
+          LocalRouteEngine(graph: _outOfStationTransferFixtureGraph()).search(
+            const RouteRequest(
+              originStationId: 'station-a',
+              destinationStationId: 'station-d',
+              mobilityType: MobilityType.senior,
+            ),
+          );
+
+      expect(result.status, RouteStatus.unknown);
+      expect(result.edgeIds, isEmpty);
+    });
+
     test('역외 환승 모드도 임의 중간 exit와 entry 우회는 거부한다', () {
       final result = LocalRouteEngine(graph: _midRouteExitEntryFixtureGraph())
           .search(

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -177,6 +177,63 @@ void main() {
       expect(crossStationResult.transferStationIds, isEmpty);
     });
 
+    test('역외 환승 모드는 검증된 역외 환승 edge를 허용한다', () {
+      final result =
+          LocalRouteEngine(graph: _outOfStationTransferFixtureGraph()).search(
+            const RouteRequest(
+              originStationId: 'station-a',
+              destinationStationId: 'station-d',
+              mobilityType: MobilityType.senior,
+              searchMode:
+                  RouteSearchMode.stationToStationWithOutOfStationTransfers,
+            ),
+          );
+
+      expect(result.status, RouteStatus.found);
+      expect(result.edgeIds, [
+        'entry-a-line-1',
+        'ride-a-b-line-1',
+        'out-transfer-b-c',
+        'ride-c-d-line-2',
+        'exit-d-line-2',
+      ]);
+    });
+
+    test('역외 환승 모드도 임의 중간 exit와 entry 우회는 거부한다', () {
+      final result = LocalRouteEngine(graph: _midRouteExitEntryFixtureGraph())
+          .search(
+            const RouteRequest(
+              originStationId: 'station-a',
+              destinationStationId: 'station-d',
+              mobilityType: MobilityType.senior,
+              searchMode:
+                  RouteSearchMode.stationToStationWithOutOfStationTransfers,
+            ),
+          );
+
+      expect(result.status, RouteStatus.unknown);
+      expect(result.edgeIds, isEmpty);
+    });
+
+    test('strict 역외 환승 모드는 generated 역외 환승 connector를 검증된 edge로 쓰지 않는다', () {
+      final result =
+          LocalRouteEngine(
+            graph: _generatedOutOfStationTransferFixtureGraph(),
+          ).search(
+            const RouteRequest(
+              originStationId: 'station-a',
+              destinationStationId: 'station-d',
+              mobilityType: MobilityType.wheelchair,
+              searchMode:
+                  RouteSearchMode.stationToStationWithOutOfStationTransfers,
+            ),
+          );
+
+      expect(result.status, RouteStatus.unknown);
+      expect(result.edgeIds, isEmpty);
+      expect(result.blockedReasonCodes, ['GENERATED_CONNECTOR_UNVERIFIED']);
+    });
+
     test('휠체어 조건은 계단만 있는 경로를 비용 증가가 아니라 차단으로 처리한다', () {
       final engine = LocalRouteEngine(graph: _stairOnlyFixtureGraph());
 
@@ -730,6 +787,159 @@ NetworkGraph _crossStationTransferCatalogFixtureGraph() {
         id: 'exit-c-line-2',
         fromNodeId: 'station-c:line-2',
         toNodeId: 'station-c',
+        type: RouteEdgeType.exit,
+        baseCost: 90,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+    ],
+  );
+}
+
+NetworkGraph _outOfStationTransferFixtureGraph({
+  bool generatedOutOfStationTransfer = false,
+}) {
+  return NetworkGraph(
+    nodes: const [
+      RouteNode(
+        id: 'station-a:line-1',
+        stationId: 'station-a',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-b:line-1',
+        stationId: 'station-b',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-c:line-2',
+        stationId: 'station-c',
+        lineId: 'line-2',
+      ),
+      RouteNode(
+        id: 'station-d:line-2',
+        stationId: 'station-d',
+        lineId: 'line-2',
+      ),
+    ],
+    edges: [
+      const RouteEdge(
+        id: 'entry-a-line-1',
+        fromNodeId: 'station-a',
+        toNodeId: 'station-a:line-1',
+        type: RouteEdgeType.entry,
+        baseCost: 90,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+      const RouteEdge(
+        id: 'ride-a-b-line-1',
+        fromNodeId: 'station-a:line-1',
+        toNodeId: 'station-b:line-1',
+        type: RouteEdgeType.ride,
+        baseCost: 180,
+        lineId: 'line-1',
+      ),
+      RouteEdge(
+        id: 'out-transfer-b-c',
+        fromNodeId: 'station-b:line-1',
+        toNodeId: 'station-c:line-2',
+        type: RouteEdgeType.outOfStationTransfer,
+        baseCost: 240,
+        stairAccessState: RouteStairAccessState.stepFree,
+        isGeneratedConnector: generatedOutOfStationTransfer,
+      ),
+      const RouteEdge(
+        id: 'ride-c-d-line-2',
+        fromNodeId: 'station-c:line-2',
+        toNodeId: 'station-d:line-2',
+        type: RouteEdgeType.ride,
+        baseCost: 180,
+        lineId: 'line-2',
+      ),
+      const RouteEdge(
+        id: 'exit-d-line-2',
+        fromNodeId: 'station-d:line-2',
+        toNodeId: 'station-d',
+        type: RouteEdgeType.exit,
+        baseCost: 90,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+    ],
+  );
+}
+
+NetworkGraph _generatedOutOfStationTransferFixtureGraph() {
+  return _outOfStationTransferFixtureGraph(generatedOutOfStationTransfer: true);
+}
+
+NetworkGraph _midRouteExitEntryFixtureGraph() {
+  return NetworkGraph(
+    nodes: const [
+      RouteNode(
+        id: 'station-a:line-1',
+        stationId: 'station-a',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-b:line-1',
+        stationId: 'station-b',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-b:line-2',
+        stationId: 'station-b',
+        lineId: 'line-2',
+      ),
+      RouteNode(
+        id: 'station-d:line-2',
+        stationId: 'station-d',
+        lineId: 'line-2',
+      ),
+    ],
+    edges: const [
+      RouteEdge(
+        id: 'entry-a-line-1',
+        fromNodeId: 'station-a',
+        toNodeId: 'station-a:line-1',
+        type: RouteEdgeType.entry,
+        baseCost: 90,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+      RouteEdge(
+        id: 'ride-a-b-line-1',
+        fromNodeId: 'station-a:line-1',
+        toNodeId: 'station-b:line-1',
+        type: RouteEdgeType.ride,
+        baseCost: 180,
+        lineId: 'line-1',
+      ),
+      RouteEdge(
+        id: 'exit-b-line-1',
+        fromNodeId: 'station-b:line-1',
+        toNodeId: 'station-b',
+        type: RouteEdgeType.exit,
+        baseCost: 60,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+      RouteEdge(
+        id: 'entry-b-line-2',
+        fromNodeId: 'station-b',
+        toNodeId: 'station-b:line-2',
+        type: RouteEdgeType.entry,
+        baseCost: 90,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+      RouteEdge(
+        id: 'ride-b-d-line-2',
+        fromNodeId: 'station-b:line-2',
+        toNodeId: 'station-d:line-2',
+        type: RouteEdgeType.ride,
+        baseCost: 180,
+        lineId: 'line-2',
+      ),
+      RouteEdge(
+        id: 'exit-d-line-2',
+        fromNodeId: 'station-d:line-2',
+        toNodeId: 'station-d',
         type: RouteEdgeType.exit,
         baseCost: 90,
         stairAccessState: RouteStairAccessState.stepFree,


### PR DESCRIPTION
## 관련 이슈

close #1218

## 작업 배경

- route engine의 entry/exit traversal 제한이 `_findLowestCostPath` 내부 if문에 박혀 있었습니다.
- H-1 이후 역외 환승 edge를 다루려면 traversal 정책을 명시 모드로 분리해야 합니다.
- exit + walk + entry bundle router와 상용 ETA claim은 이번 범위가 아닙니다.

## 작업 내용

- `RouteSearchMode`를 추가했습니다.
- `RouteTraversalPolicy.canTraverse(...)`로 entry/exit guard를 분리했습니다.
- 기본 `stationToStation`은 `outOfStationTransfer`를 쓰지 않고, `stationToStationWithOutOfStationTransfers`에서만 검증된 역외 환승 edge를 허용합니다.
- `LocalRouteRepository`의 사용자 경로 검색은 catalog의 검증된 역외 환승 edge를 사용할 수 있도록 명시 mode로 호출합니다.
- `stationInternal` 경로는 pathway router가 내부 edge를 탐색할 수 있게 분리했습니다.
- 역외 환승 mode에서 검증된 `outOfStationTransfer` edge, 기본 mode 차단, 임의 중간 exit/entry 거부, generated connector strict 차단을 테스트했습니다.

## 검증

- 실행한 명령과 결과:
  - `cd apps/mobile && flutter test test/features/routes/route_engine_test.dart --plain-name "역외 환승 모드"`: failed (RED, `RouteSearchMode`/`searchMode` 없음)
  - `cd apps/mobile && flutter test test/features/routes/route_engine_test.dart --plain-name "역외 환승 모드"`: passed
  - `cd apps/mobile && flutter test test/features/routes/route_engine_test.dart --plain-name "역외 환승"`: passed
  - `cd apps/mobile && flutter test test/features/routes/local_route_repository_test.dart --plain-name "역외 환승 edge는 역 밖 환승 문구로 표시한다"`: passed
  - `cd apps/mobile && flutter test test/features/routes/route_engine_test.dart`: passed
  - `cd apps/mobile && flutter test test/features/routes`: passed
  - `cd apps/mobile && flutter analyze`: passed
  - `git diff --check`: passed

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| traversal policy | Android / iOS 공통 | `cd apps/mobile && flutter test test/features/routes/route_engine_test.dart` | 명령 결과 | passed |
| route regression | Android / iOS 공통 | `cd apps/mobile && flutter test test/features/routes` | 명령 결과 | passed |
| 정적 분석 | Android / iOS 공통 | `cd apps/mobile && flutter analyze` | 명령 결과 | passed |
| PR CI | GitHub Actions | `gh pr checks 1336 --watch --fail-fast` | CI run `28492965560`, Release Artifacts run `28492965395` | passed |
| CodeRabbit review | GitHub PR review | CodeRabbit initial review + inline thread reply | finding fixed in `0425c5cbfe5a1c48708ea65a4effc6321524dae5` | passed |
| Codex fallback review | GitHub PR review | CodeRabbit incremental review rate-limited, Codex CLI fallback posted | actionable correctness issues 0 | passed |
| post-merge CI | GitHub Actions main | merge commit `ba0d390332241cb93f13de08c84b8fb8f419bfa9` | CI run `28493242775`, Release Artifacts run `28493242562`, SonarCloud run `28493242556` | passed |
| post-merge CD | GitHub Actions main | merge commit `ba0d390332241cb93f13de08c84b8fb8f419bfa9` | CD run `28493389193` | passed |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: route traversal mode/policy 추가
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `route_engine.dart`의 `RouteTraversalPolicy`, `local_route_repository.dart`의 mode 호출부, `route_engine_test.dart`의 역외 환승 mode 테스트
- CodeRabbit finding은 fix commit 전 inline review로 게시됐고, `0425c5cbfe5a1c48708ea65a4effc6321524dae5`에서 수정 후 원 thread에 검증을 답했습니다.

## 리스크

- `stationToStationWithOutOfStationTransfers`는 이번 PR에서 exit + walk + entry bundle을 열지 않습니다.
- generated connector 차단은 기존 accessibility cost policy를 그대로 사용합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
