### PR TITLE
[Feat] 2회 이상 환승 backend 지원

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -13,6 +13,7 @@ import com.easysubway.route.domain.RouteStep;
 import com.easysubway.route.domain.RouteWarning;
 import com.easysubway.route.domain.RouteWarningCode;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -139,7 +140,8 @@ class RouteSearchController {
 		String constraintMode,
 		@NotNull(message = "실시간 반영 여부를 선택해야 합니다.")
 		Boolean useRealtime,
-		@Min(value = 1, message = "V2 skeleton은 최대 환승 수 1 이상만 지원합니다.")
+		@Min(value = 0, message = "최대 환승 수는 0 이상이어야 합니다.")
+		@Max(value = 3, message = "최대 환승 수는 3 이하여야 합니다.")
 		int maxTransfers,
 		@Min(value = 1, message = "대안 경로 수는 1 이상이어야 합니다.")
 		int alternativeCount
@@ -150,7 +152,8 @@ class RouteSearchController {
 				originStationId,
 				destinationStationId,
 				mobilityType,
-				parseConstraintMode(mobilityType, constraintMode)
+				parseConstraintMode(mobilityType, constraintMode),
+				maxTransfers
 			);
 		}
 

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -140,9 +140,10 @@ class RouteSearchController {
 		String constraintMode,
 		@NotNull(message = "실시간 반영 여부를 선택해야 합니다.")
 		Boolean useRealtime,
+		@NotNull(message = "최대 환승 수를 선택해야 합니다.")
 		@Min(value = 0, message = "최대 환승 수는 0 이상이어야 합니다.")
 		@Max(value = 3, message = "최대 환승 수는 3 이하여야 합니다.")
-		int maxTransfers,
+		Integer maxTransfers,
 		@Min(value = 1, message = "대안 경로 수는 1 이상이어야 합니다.")
 		int alternativeCount
 	) {

--- a/backend/src/main/java/com/easysubway/route/application/port/in/SearchRouteCommand.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/SearchRouteCommand.java
@@ -7,15 +7,26 @@ public record SearchRouteCommand(
 	String originStationId,
 	String destinationStationId,
 	MobilityType mobilityType,
-	ConstraintMode constraintMode
+	ConstraintMode constraintMode,
+	int maxTransfers
 ) {
 	public SearchRouteCommand(String originStationId, String destinationStationId, MobilityType mobilityType) {
-		this(originStationId, destinationStationId, mobilityType, ConstraintMode.defaultFor(mobilityType));
+		this(originStationId, destinationStationId, mobilityType, ConstraintMode.defaultFor(mobilityType), 1);
+	}
+
+	public SearchRouteCommand(
+		String originStationId,
+		String destinationStationId,
+		MobilityType mobilityType,
+		ConstraintMode constraintMode
+	) {
+		this(originStationId, destinationStationId, mobilityType, constraintMode, 1);
 	}
 
 	public SearchRouteCommand {
 		if (constraintMode == null) {
 			constraintMode = ConstraintMode.defaultFor(mobilityType);
 		}
+		maxTransfers = Math.max(0, maxTransfers);
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -314,13 +314,34 @@ public class RouteSearchService implements RouteSearchUseCase {
 	) {
 		return findDirectLine(originStationId, destinationStationId)
 			.map(RoutePlan::direct)
-			.or(() -> maxTransfers >= 1
-				? findOneTransferRoute(originStationId, destinationStationId, profileWeight).map(RoutePlan::transfer)
-				: Optional.empty())
-			.or(() -> maxTransfers >= 2
-				? findMultiTransferRoute(originStationId, destinationStationId, maxTransfers).map(RoutePlan::multiTransfer)
-				: Optional.empty())
+			.or(() -> findTransferRoutePlan(originStationId, destinationStationId, profileWeight, maxTransfers))
 			.orElseThrow(RouteNotFoundException::new);
+	}
+
+	private Optional<RoutePlan> findTransferRoutePlan(
+		String originStationId,
+		String destinationStationId,
+		RouteProfileWeight profileWeight,
+		int maxTransfers
+	) {
+		List<RoutePlan> candidates = new ArrayList<>();
+		if (maxTransfers >= 1) {
+			findOneTransferRoute(originStationId, destinationStationId, profileWeight)
+				.map(RoutePlan::transfer)
+				.ifPresent(candidates::add);
+		}
+		if (maxTransfers >= 2) {
+			findMultiTransferRoute(originStationId, destinationStationId, profileWeight, maxTransfers)
+				.map(RoutePlan::multiTransfer)
+				.ifPresent(candidates::add);
+		}
+		return candidates.stream()
+			.min(Comparator.comparingInt((RoutePlan routePlan) ->
+					routeAccessibilityRank(routePlan, originStationId, destinationStationId, profileWeight))
+				.thenComparingInt(routePlan ->
+					routeCandidateCost(routePlan, originStationId, destinationStationId, profileWeight))
+				.thenComparingInt(RoutePlan::transferCount)
+				.thenComparing(RoutePlan::lineName));
 	}
 
 	private Optional<DirectLine> findDirectLine(String originStationId, String destinationStationId) {
@@ -376,6 +397,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 	private Optional<MultiTransferRoute> findMultiTransferRoute(
 		String originStationId,
 		String destinationStationId,
+		RouteProfileWeight profileWeight,
 		int maxTransfers
 	) {
 		Map<String, SubwayLine> activeLinesById = loadTransitMasterPort.loadLines()
@@ -439,7 +461,14 @@ public class RouteSearchService implements RouteSearchUseCase {
 		}
 		return routes.stream()
 			.filter(route -> route.transferCount() <= maxTransfers)
-			.min(Comparator.comparingInt(MultiTransferRoute::stopCount)
+			.min(Comparator.comparingInt((MultiTransferRoute route) ->
+					accessibilityRank(route.accessibilityStationIds(originStationId, destinationStationId), profileWeight))
+				.thenComparingInt(route -> accessibilityAwareCost(
+					route.stopCount(),
+					route.transferCount(),
+					route.accessibilityStationIds(originStationId, destinationStationId),
+					profileWeight
+				))
 				.thenComparingInt(MultiTransferRoute::transferCount)
 				.thenComparing(MultiTransferRoute::lineName));
 	}
@@ -465,6 +494,51 @@ public class RouteSearchService implements RouteSearchUseCase {
 		return List.copyOf(warnings);
 	}
 
+	private int routeAccessibilityRank(
+		RoutePlan routePlan,
+		String originStationId,
+		String destinationStationId,
+		RouteProfileWeight profileWeight
+	) {
+		return accessibilityRank(routePlan.accessibilityStationIds(originStationId, destinationStationId), profileWeight);
+	}
+
+	private int accessibilityRank(List<String> stationIds, RouteProfileWeight profileWeight) {
+		if (profileWeight.blocksStairOnlyAccess() && hasStairOnlyAccess(stationIds)) {
+			return 1;
+		}
+		return 0;
+	}
+
+	private int routeCandidateCost(
+		RoutePlan routePlan,
+		String originStationId,
+		String destinationStationId,
+		RouteProfileWeight profileWeight
+	) {
+		return accessibilityAwareCost(
+			routePlan.stopCount(),
+			routePlan.transferCount(),
+			routePlan.accessibilityStationIds(originStationId, destinationStationId),
+			profileWeight
+		);
+	}
+
+	private int accessibilityAwareCost(
+		int stopCount,
+		int transferCount,
+		List<String> accessibilityStationIds,
+		RouteProfileWeight profileWeight
+	) {
+		int stairOnlyPenalty = hasStairOnlyAccess(accessibilityStationIds)
+			? profileWeight.stairOnlyAccessPenalty()
+			: 0;
+		int lowDataPenalty = hasLowAccessibilityData(accessibilityStationIds)
+			? profileWeight.lowDataConfidencePenalty()
+			: 0;
+		return stopCount * 3 + transferCount * profileWeight.transferPenalty() + stairOnlyPenalty + lowDataPenalty;
+	}
+
 	private boolean hasLowAccessibilityData(String stationId) {
 		List<StationExit> exits = stationExits(stationId);
 		if (exits.isEmpty()) {
@@ -476,6 +550,10 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.filter(this::isStepFreeFacility)
 			.anyMatch(facility -> facility.dataConfidence() != DataConfidenceLevel.HIGH);
 		return hasLowConfidenceExit || hasLowConfidenceStepFreeFacility;
+	}
+
+	private boolean hasLowAccessibilityData(List<String> stationIds) {
+		return stationIds.stream().anyMatch(this::hasLowAccessibilityData);
 	}
 
 	private boolean hasStaleAccessibilityData(String stationId) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -40,10 +40,12 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.PriorityQueue;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -127,7 +129,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 		}
 
 		RouteProfileWeight profileWeight = RouteProfileWeight.from(command.mobilityType(), command.constraintMode());
-		RoutePlan routePlan = findRoutePlan(origin.id(), destination.id(), profileWeight);
+		RoutePlan routePlan = findRoutePlan(origin.id(), destination.id(), profileWeight, command.maxTransfers());
 		List<String> accessibilityStationIds = routePlan.accessibilityStationIds(origin.id(), destination.id());
 		boolean stairOnlyAccess = hasStairOnlyAccess(accessibilityStationIds);
 		List<RouteWarning> warnings = routeWarnings(accessibilityStationIds, stairOnlyAccess);
@@ -307,11 +309,17 @@ public class RouteSearchService implements RouteSearchUseCase {
 	private RoutePlan findRoutePlan(
 		String originStationId,
 		String destinationStationId,
-		RouteProfileWeight profileWeight
+		RouteProfileWeight profileWeight,
+		int maxTransfers
 	) {
 		return findDirectLine(originStationId, destinationStationId)
 			.map(RoutePlan::direct)
-			.or(() -> findOneTransferRoute(originStationId, destinationStationId, profileWeight).map(RoutePlan::transfer))
+			.or(() -> maxTransfers >= 1
+				? findOneTransferRoute(originStationId, destinationStationId, profileWeight).map(RoutePlan::transfer)
+				: Optional.empty())
+			.or(() -> maxTransfers >= 2
+				? findMultiTransferRoute(originStationId, destinationStationId, maxTransfers).map(RoutePlan::multiTransfer)
+				: Optional.empty())
 			.orElseThrow(RouteNotFoundException::new);
 	}
 
@@ -363,6 +371,83 @@ public class RouteSearchService implements RouteSearchUseCase {
 			stairOnlyAccess,
 			lowAccessibilityData
 		);
+	}
+
+	private Optional<MultiTransferRoute> findMultiTransferRoute(
+		String originStationId,
+		String destinationStationId,
+		int maxTransfers
+	) {
+		Map<String, SubwayLine> activeLinesById = loadTransitMasterPort.loadLines()
+			.stream()
+			.filter(SubwayLine::active)
+			.collect(Collectors.toMap(SubwayLine::id, Function.identity()));
+		Map<String, Station> activeStationsById = loadTransitMasterPort.loadStations()
+			.stream()
+			.filter(Station::active)
+			.collect(Collectors.toMap(Station::id, Function.identity()));
+		List<StationLine> activeStationLines = loadTransitMasterPort.loadStationLines()
+			.stream()
+			.filter(stationLine -> activeLinesById.containsKey(stationLine.lineId()))
+			.filter(stationLine -> activeStationsById.containsKey(stationLine.stationId()))
+			.toList();
+		Map<String, List<StationLine>> stationLinesByStationId = activeStationLines.stream()
+			.collect(Collectors.groupingBy(StationLine::stationId));
+		Map<String, List<StationLine>> stationLinesByLineId = activeStationLines.stream()
+			.collect(Collectors.groupingBy(StationLine::lineId));
+		PriorityQueue<MultiTransferCandidate> queue = new PriorityQueue<>(
+			Comparator.comparingInt(MultiTransferCandidate::cost)
+				.thenComparingInt(candidate -> candidate.segments().size())
+		);
+		for (StationLine originLine : stationLinesByStationId.getOrDefault(originStationId, List.of())) {
+			queue.add(new MultiTransferCandidate(originLine, List.of(), Set.of(originStationId + ":" + originLine.lineId())));
+		}
+
+		List<MultiTransferRoute> routes = new ArrayList<>();
+		while (!queue.isEmpty()) {
+			MultiTransferCandidate current = queue.poll();
+			for (StationLine lineStop : stationLinesByLineId.getOrDefault(current.currentLine().lineId(), List.of())) {
+				if (lineStop.stationId().equals(current.currentLine().stationId())) {
+					continue;
+				}
+				List<RouteSegment> nextSegments = appendSegment(current.segments(), current.currentLine(), lineStop);
+				if (lineStop.stationId().equals(destinationStationId)) {
+					routes.add(new MultiTransferRoute(nextSegments, activeLinesById, activeStationsById));
+					continue;
+				}
+				int nextTransferCount = nextSegments.size();
+				if (nextTransferCount > maxTransfers) {
+					continue;
+				}
+				for (StationLine transferLine : stationLinesByStationId.getOrDefault(lineStop.stationId(), List.of())) {
+					if (transferLine.lineId().equals(lineStop.lineId())) {
+						continue;
+					}
+					String visitKey = transferLine.stationId() + ":" + transferLine.lineId();
+					if (current.visited().contains(visitKey)) {
+						continue;
+					}
+					Set<String> visited = new HashSet<>(current.visited());
+					visited.add(visitKey);
+					queue.add(new MultiTransferCandidate(
+						transferLine,
+						nextSegments,
+						Set.copyOf(visited)
+					));
+				}
+			}
+		}
+		return routes.stream()
+			.filter(route -> route.transferCount() <= maxTransfers)
+			.min(Comparator.comparingInt(MultiTransferRoute::stopCount)
+				.thenComparingInt(MultiTransferRoute::transferCount)
+				.thenComparing(MultiTransferRoute::lineName));
+	}
+
+	private List<RouteSegment> appendSegment(List<RouteSegment> segments, StationLine from, StationLine to) {
+		List<RouteSegment> next = new ArrayList<>(segments);
+		next.add(new RouteSegment(from, to));
+		return List.copyOf(next);
 	}
 
 	private List<RouteWarning> routeWarnings(List<String> stationIds, boolean stairOnlyAccess) {
@@ -770,6 +855,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 		RouteProfileWeight profileWeight
 	) {
 		RouteAssembler routeAssembler = new RouteAssembler();
+		if (routePlan.multiTransferRoute().isPresent()) {
+			return routeAssembler.assemble(multiTransferSteps(origin, destination, routePlan.multiTransferRoute().get(), profileWeight));
+		}
 		if (routePlan.transferRoute().isPresent()) {
 			return routeAssembler.assemble(transferSteps(origin, destination, routePlan.transferRoute().get(), profileWeight));
 		}
@@ -930,6 +1018,108 @@ public class RouteSearchService implements RouteSearchUseCase {
 		);
 	}
 
+	private List<RouteStep> multiTransferSteps(
+		Station origin,
+		Station destination,
+		MultiTransferRoute route,
+		RouteProfileWeight profileWeight
+	) {
+		List<RouteStep> steps = new ArrayList<>();
+		AccessGraphRouter accessGraphRouter = new AccessGraphRouter();
+		StationPathwayRouter stationPathwayRouter = new StationPathwayRouter();
+		RouteSegment firstSegment = route.segments().getFirst();
+		RouteSegment lastSegment = route.segments().getLast();
+		SubwayLine firstLine = route.line(firstSegment.lineId());
+		SubwayLine lastLine = route.line(lastSegment.lineId());
+		AccessPath entryAccess = accessGraphRouter.entryAccess(
+			origin.id(),
+			firstSegment.lineId(),
+			hasStairOnlyAccess(origin.id()),
+			profileWeight
+		);
+		steps.add(new RouteStep(
+			1,
+			"entry",
+			origin.nameKo() + "역에서 " + displayLineName(firstLine) + " 승강장으로 이동",
+			profileWeight.entryGuidance(),
+			firstLine.id(),
+			firstLine.name(),
+			origin.id(),
+			origin.id(),
+			entryAccess.estimatedMinutes(),
+			entryAccess.distanceMeters(),
+			entryAccess.includesStairs(),
+			true
+		));
+		for (int index = 0; index < route.segments().size(); index++) {
+			RouteSegment segment = route.segments().get(index);
+			SubwayLine line = route.line(segment.lineId());
+			Station fromStation = route.station(segment.fromStationId());
+			Station toStation = route.station(segment.toStationId());
+			steps.add(new RouteStep(
+				steps.size() + 1,
+				"ride",
+				line.name() + "으로 " + toStation.nameKo() + "역까지 이동",
+				segment.stopCount() + "개 역을 이동합니다.",
+				line.id(),
+				line.name(),
+				fromStation.id(),
+				toStation.id(),
+				trainEstimatedMinutes(segment.stopCount()),
+				trainDistanceMeters(segment.stopCount()),
+				false,
+				false
+			));
+			if (index == route.segments().size() - 1) {
+				continue;
+			}
+			RouteSegment nextSegment = route.segments().get(index + 1);
+			SubwayLine nextLine = route.line(nextSegment.lineId());
+			AccessPath transferAccess = stationPathwayRouter.transferPath(
+				toStation.id(),
+				line.id(),
+				nextLine.id(),
+				hasStairOnlyAccess(toStation.id()),
+				profileWeight
+			);
+			steps.add(new RouteStep(
+				steps.size() + 1,
+				"transfer",
+				toStation.nameKo() + "역에서 " + displayLineName(nextLine) + " 승강장으로 환승",
+				toStation.nameKo() + "의 엘리베이터와 계단 없는 연결 동선을 먼저 확인합니다.",
+				nextLine.id(),
+				nextLine.name(),
+				toStation.id(),
+				toStation.id(),
+				transferAccess.estimatedMinutes(),
+				transferAccess.distanceMeters(),
+				transferAccess.includesStairs(),
+				true
+			));
+		}
+		AccessPath egressAccess = accessGraphRouter.egressAccess(
+			destination.id(),
+			lastSegment.lineId(),
+			hasStairOnlyAccess(destination.id()),
+			profileWeight
+		);
+		steps.add(new RouteStep(
+			steps.size() + 1,
+			"exit",
+			destination.nameKo() + "역에서 출구 접근성 정보를 확인",
+			exitGuidance(destination.id(), profileWeight.exitGuidance()),
+			lastLine.id(),
+			lastLine.name(),
+			destination.id(),
+			destination.id(),
+			egressAccess.estimatedMinutes(),
+			egressAccess.distanceMeters(),
+			egressAccess.includesStairs(),
+			true
+		));
+		return List.copyOf(steps);
+	}
+
 	private int trainEstimatedMinutes(int stopCount) {
 		return Math.max(1, stopCount) * MINUTES_PER_STATION;
 	}
@@ -974,15 +1164,20 @@ public class RouteSearchService implements RouteSearchUseCase {
 
 	private record RoutePlan(
 		Optional<DirectLine> directLine,
-		Optional<TransferRoute> transferRoute
+		Optional<TransferRoute> transferRoute,
+		Optional<MultiTransferRoute> multiTransferRoute
 	) {
 
 		static RoutePlan direct(DirectLine directLine) {
-			return new RoutePlan(Optional.of(directLine), Optional.empty());
+			return new RoutePlan(Optional.of(directLine), Optional.empty(), Optional.empty());
 		}
 
 		static RoutePlan transfer(TransferRoute transferRoute) {
-			return new RoutePlan(Optional.empty(), Optional.of(transferRoute));
+			return new RoutePlan(Optional.empty(), Optional.of(transferRoute), Optional.empty());
+		}
+
+		static RoutePlan multiTransfer(MultiTransferRoute multiTransferRoute) {
+			return new RoutePlan(Optional.empty(), Optional.empty(), Optional.of(multiTransferRoute));
 		}
 
 		String lineId() {
@@ -990,7 +1185,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 				.map(direct -> direct.line().id())
 				.orElseGet(() -> transferRoute
 					.map(route -> route.firstLine().id() + "/" + route.secondLine().id())
-					.orElseThrow());
+					.orElseGet(() -> multiTransferRoute.map(MultiTransferRoute::lineId).orElseThrow()));
 		}
 
 		String lineName() {
@@ -998,23 +1193,110 @@ public class RouteSearchService implements RouteSearchUseCase {
 				.map(direct -> direct.line().name())
 				.orElseGet(() -> transferRoute
 					.map(route -> route.firstLine().name() + " / " + route.secondLine().name())
-					.orElseThrow());
+					.orElseGet(() -> multiTransferRoute.map(MultiTransferRoute::lineName).orElseThrow()));
 		}
 
 		int stopCount() {
 			return directLine
 				.map(DirectLine::stopCount)
-				.orElseGet(() -> transferRoute.map(TransferRoute::stopCount).orElseThrow());
+				.orElseGet(() -> transferRoute
+					.map(TransferRoute::stopCount)
+					.orElseGet(() -> multiTransferRoute.map(MultiTransferRoute::stopCount).orElseThrow()));
 		}
 
 		int transferCount() {
-			return transferRoute.isPresent() ? 1 : 0;
+			return multiTransferRoute.map(MultiTransferRoute::transferCount)
+				.orElseGet(() -> transferRoute.isPresent() ? 1 : 0);
 		}
 
 		List<String> accessibilityStationIds(String originStationId, String destinationStationId) {
 			return transferRoute
 				.map(route -> List.of(originStationId, route.transferStation().id(), destinationStationId))
-				.orElseGet(() -> List.of(originStationId, destinationStationId));
+				.orElseGet(() -> multiTransferRoute
+					.map(route -> route.accessibilityStationIds(originStationId, destinationStationId))
+					.orElseGet(() -> List.of(originStationId, destinationStationId)));
+		}
+	}
+
+	private record RouteSegment(
+		StationLine from,
+		StationLine to
+	) {
+
+		String lineId() {
+			return from.lineId();
+		}
+
+		String fromStationId() {
+			return from.stationId();
+		}
+
+		String toStationId() {
+			return to.stationId();
+		}
+
+		int stopCount() {
+			return Math.abs(from.sequence() - to.sequence());
+		}
+	}
+
+	private record MultiTransferRoute(
+		List<RouteSegment> segments,
+		Map<String, SubwayLine> linesById,
+		Map<String, Station> stationsById
+	) {
+
+		String lineId() {
+			return segments.stream()
+				.map(RouteSegment::lineId)
+				.collect(Collectors.joining("/"));
+		}
+
+		String lineName() {
+			return segments.stream()
+				.map(segment -> line(segment.lineId()).name())
+				.collect(Collectors.joining(" / "));
+		}
+
+		int stopCount() {
+			return segments.stream()
+				.mapToInt(RouteSegment::stopCount)
+				.sum();
+		}
+
+		int transferCount() {
+			return Math.max(0, segments.size() - 1);
+		}
+
+		SubwayLine line(String lineId) {
+			return linesById.get(lineId);
+		}
+
+		Station station(String stationId) {
+			return stationsById.get(stationId);
+		}
+
+		List<String> accessibilityStationIds(String originStationId, String destinationStationId) {
+			List<String> stationIds = new ArrayList<>();
+			stationIds.add(originStationId);
+			for (int index = 0; index < segments.size() - 1; index++) {
+				stationIds.add(segments.get(index).toStationId());
+			}
+			stationIds.add(destinationStationId);
+			return List.copyOf(stationIds);
+		}
+	}
+
+	private record MultiTransferCandidate(
+		StationLine currentLine,
+		List<RouteSegment> segments,
+		Set<String> visited
+	) {
+
+		int cost() {
+			return segments.stream()
+				.mapToInt(RouteSegment::stopCount)
+				.sum() + segments.size() * 100;
 		}
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -49,6 +49,7 @@ class RouteSearchV2ControllerTest {
 				&& "station-sadang".equals(command.destinationStationId())
 				&& command.mobilityType() == MobilityType.STROLLER
 				&& command.constraintMode() == ConstraintMode.STRICT_STEP_FREE
+				&& command.maxTransfers() == 3
 		))).thenReturn(foundRouteSearch());
 
 		mockMvc.perform(post("/api/v2/routes/search")
@@ -291,6 +292,31 @@ class RouteSearchV2ControllerTest {
 			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.message").value("출발 시간은 ISO offset 형식이어야 합니다."));
+
+		verifyNoInteractions(routeSearchUseCase);
+	}
+
+	@Test
+	@DisplayName("V2 최대 환승 수는 3회를 초과하면 search 저장 전에 JSON 400으로 거부한다")
+	void routeSearchV2MaxTransfersAboveThreeReturnsBadRequestBeforeSearch() throws Exception {
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "constraintMode": "STRICT_STEP_FREE",
+					  "useRealtime": true,
+					  "maxTransfers": 4,
+					  "alternativeCount": 3
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").exists());
 
 		verifyNoInteractions(routeSearchUseCase);
 	}

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -322,6 +322,30 @@ class RouteSearchV2ControllerTest {
 	}
 
 	@Test
+	@DisplayName("V2 최대 환승 수 누락은 search 저장 전에 JSON 400으로 거부한다")
+	void routeSearchV2MissingMaxTransfersReturnsBadRequestBeforeSearch() throws Exception {
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-sangnoksu",
+					  "destinationStationId": "station-sadang",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "STROLLER",
+					  "constraintMode": "STRICT_STEP_FREE",
+					  "useRealtime": true,
+					  "alternativeCount": 3
+					}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").exists());
+
+		verifyNoInteractions(routeSearchUseCase);
+	}
+
+	@Test
 	@DisplayName("V2 prefer step-free는 mobility type을 유지한 채 command에 전달한다")
 	void routeSearchV2PreferStepFreeKeepsMobilityType() throws Exception {
 		when(routeSearchUseCase.searchRoute(argThat(command ->

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -332,6 +332,101 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("maxTransfers 2는 2회 환승 경로를 찾고 환승역 순서를 보존한다")
+	void searchRouteFindsTwoTransferRouteWhenAllowed() {
+		var repository = new InMemoryRouteSearchRepository();
+		var transferService = new RouteSearchService(
+			repository,
+			repository,
+			new TwoTransferTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = transferService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			2
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.transferCount()).isEqualTo(2);
+		assertThat(result.lineName()).isEqualTo("A 노선 / B 노선 / C 노선");
+		assertThat(result.steps())
+			.filteredOn(step -> "transfer".equals(step.stepType()))
+			.extracting("fromStationId")
+			.containsExactly("station-transfer-1", "station-transfer-2");
+	}
+
+	@Test
+	@DisplayName("maxTransfers 1은 2회 환승 전용 경로를 찾지 않는다")
+	void searchRouteDoesNotFindTwoTransferRouteWhenLimitIsOne() {
+		var repository = new InMemoryRouteSearchRepository();
+		var transferService = new RouteSearchService(
+			repository,
+			repository,
+			new TwoTransferTransitMasterPort(),
+			CLOCK
+		);
+
+		assertThatThrownBy(() -> transferService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			1
+		))).isInstanceOf(RouteNotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("maxTransfers 0은 직접 경로만 허용한다")
+	void searchRouteWithZeroMaxTransfersIsDirectOnly() {
+		var repository = new InMemoryRouteSearchRepository();
+		var transferService = new RouteSearchService(
+			repository,
+			repository,
+			new OneTransferTransitMasterPort(),
+			CLOCK
+		);
+
+		assertThatThrownBy(() -> transferService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			0
+		))).isInstanceOf(RouteNotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("maxTransfers 3은 3회 환승 경로를 찾는다")
+	void searchRouteFindsThreeTransferRouteWhenAllowed() {
+		var repository = new InMemoryRouteSearchRepository();
+		var transferService = new RouteSearchService(
+			repository,
+			repository,
+			new ThreeTransferTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = transferService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			3
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.transferCount()).isEqualTo(3);
+		assertThat(result.steps())
+			.filteredOn(step -> "transfer".equals(step.stepType()))
+			.extracting("fromStationId")
+			.containsExactly("station-transfer-1", "station-transfer-2", "station-transfer-3");
+	}
+
+	@Test
 	@DisplayName("access graph 계약은 진입, 환승, 진출 시간과 no-path reason을 분리한다")
 	void accessGraphContractSeparatesAccessTimesAndNoPathReasons() {
 		var profileWeight = RouteProfileWeight.from(MobilityType.WHEELCHAIR, ConstraintMode.STRICT_STEP_FREE);
@@ -1152,6 +1247,120 @@ class RouteSearchServiceTest {
 			return List.of(
 				facility("facility-a-elevator", "station-a", "exit-a-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
 				facility("facility-transfer-elevator", "station-transfer", "exit-transfer-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-b-elevator", "station-b", "exit-b-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL)
+			);
+		}
+	}
+
+	private static class TwoTransferTransitMasterPort extends StairOnlyTransitMasterPort {
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of(
+				new SubwayLine("line-a", "operator-a", "A 노선", "#0052A4", "수도권", null, true),
+				new SubwayLine("line-b", "operator-a", "B 노선", "#00A84D", "수도권", null, true),
+				new SubwayLine("line-c", "operator-a", "C 노선", "#F5A200", "수도권", null, true)
+			);
+		}
+
+		@Override
+		public List<Station> loadStations() {
+			return List.of(
+				station("station-a", "출발역"),
+				station("station-transfer-1", "첫환승역"),
+				station("station-transfer-2", "둘째환승역"),
+				station("station-b", "도착역")
+			);
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of(
+				new StationLine("station-a", "line-a", "101", 1, "상행 / 하행"),
+				new StationLine("station-transfer-1", "line-a", "102", 2, "상행 / 하행"),
+				new StationLine("station-transfer-1", "line-b", "201", 1, "상행 / 하행"),
+				new StationLine("station-transfer-2", "line-b", "202", 2, "상행 / 하행"),
+				new StationLine("station-transfer-2", "line-c", "301", 1, "상행 / 하행"),
+				new StationLine("station-b", "line-c", "302", 2, "상행 / 하행")
+			);
+		}
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				stepFreeExit("exit-a-1", "station-a"),
+				stepFreeExit("exit-transfer-1", "station-transfer-1"),
+				stepFreeExit("exit-transfer-2", "station-transfer-2"),
+				stepFreeExit("exit-b-1", "station-b")
+			);
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility("facility-a-elevator", "station-a", "exit-a-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-transfer-1-elevator", "station-transfer-1", "exit-transfer-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-transfer-2-elevator", "station-transfer-2", "exit-transfer-2", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-b-elevator", "station-b", "exit-b-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL)
+			);
+		}
+	}
+
+	private static class ThreeTransferTransitMasterPort extends TwoTransferTransitMasterPort {
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of(
+				new SubwayLine("line-a", "operator-a", "A 노선", "#0052A4", "수도권", null, true),
+				new SubwayLine("line-b", "operator-a", "B 노선", "#00A84D", "수도권", null, true),
+				new SubwayLine("line-c", "operator-a", "C 노선", "#F5A200", "수도권", null, true),
+				new SubwayLine("line-d", "operator-a", "D 노선", "#8A2BE2", "수도권", null, true)
+			);
+		}
+
+		@Override
+		public List<Station> loadStations() {
+			return List.of(
+				station("station-a", "출발역"),
+				station("station-transfer-1", "첫환승역"),
+				station("station-transfer-2", "둘째환승역"),
+				station("station-transfer-3", "셋째환승역"),
+				station("station-b", "도착역")
+			);
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of(
+				new StationLine("station-a", "line-a", "101", 1, "상행 / 하행"),
+				new StationLine("station-transfer-1", "line-a", "102", 2, "상행 / 하행"),
+				new StationLine("station-transfer-1", "line-b", "201", 1, "상행 / 하행"),
+				new StationLine("station-transfer-2", "line-b", "202", 2, "상행 / 하행"),
+				new StationLine("station-transfer-2", "line-c", "301", 1, "상행 / 하행"),
+				new StationLine("station-transfer-3", "line-c", "302", 2, "상행 / 하행"),
+				new StationLine("station-transfer-3", "line-d", "401", 1, "상행 / 하행"),
+				new StationLine("station-b", "line-d", "402", 2, "상행 / 하행")
+			);
+		}
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				stepFreeExit("exit-a-1", "station-a"),
+				stepFreeExit("exit-transfer-1", "station-transfer-1"),
+				stepFreeExit("exit-transfer-2", "station-transfer-2"),
+				stepFreeExit("exit-transfer-3", "station-transfer-3"),
+				stepFreeExit("exit-b-1", "station-b")
+			);
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility("facility-a-elevator", "station-a", "exit-a-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-transfer-1-elevator", "station-transfer-1", "exit-transfer-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-transfer-2-elevator", "station-transfer-2", "exit-transfer-2", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-transfer-3-elevator", "station-transfer-3", "exit-transfer-3", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
 				facility("facility-b-elevator", "station-b", "exit-b-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL)
 			);
 		}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -427,6 +427,66 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("휠체어 이동 유형은 계단 전용 1회 환승보다 무단차 2회 환승을 우선한다")
+	void wheelchairRoutePrefersStepFreeTwoTransferRouteOverStairOnlyOneTransferRoute() {
+		var repository = new InMemoryRouteSearchRepository();
+		var transferService = new RouteSearchService(
+			repository,
+			repository,
+			new StairOnlyOneTransferWithStepFreeTwoTransferTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = transferService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR,
+			ConstraintMode.STRICT_STEP_FREE,
+			2
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.transferCount()).isEqualTo(2);
+		assertThat(result.steps())
+			.filteredOn(step -> "transfer".equals(step.stepType()))
+			.extracting("fromStationId")
+			.containsExactly("station-transfer-1", "station-transfer-2");
+		assertThat(result.warnings())
+			.extracting("code")
+			.doesNotContain(RouteWarningCode.STAIR_ONLY_ACCESS);
+	}
+
+	@Test
+	@DisplayName("휠체어 이동 유형은 짧은 계단 전용 다중 환승보다 긴 무단차 다중 환승을 우선한다")
+	void wheelchairRoutePrefersStepFreeMultiTransferRouteEvenWhenDetourIsLong() {
+		var repository = new InMemoryRouteSearchRepository();
+		var transferService = new RouteSearchService(
+			repository,
+			repository,
+			new MixedMultiTransferAccessibilityTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = transferService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR,
+			ConstraintMode.STRICT_STEP_FREE,
+			2
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.transferCount()).isEqualTo(2);
+		assertThat(result.steps())
+			.filteredOn(step -> "transfer".equals(step.stepType()))
+			.extracting("fromStationId")
+			.containsExactly("station-step-free-transfer-1", "station-step-free-transfer-2");
+		assertThat(result.warnings())
+			.extracting("code")
+			.doesNotContain(RouteWarningCode.STAIR_ONLY_ACCESS);
+	}
+
+	@Test
 	@DisplayName("access graph 계약은 진입, 환승, 진출 시간과 no-path reason을 분리한다")
 	void accessGraphContractSeparatesAccessTimesAndNoPathReasons() {
 		var profileWeight = RouteProfileWeight.from(MobilityType.WHEELCHAIR, ConstraintMode.STRICT_STEP_FREE);
@@ -1361,6 +1421,131 @@ class RouteSearchServiceTest {
 				facility("facility-transfer-1-elevator", "station-transfer-1", "exit-transfer-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
 				facility("facility-transfer-2-elevator", "station-transfer-2", "exit-transfer-2", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
 				facility("facility-transfer-3-elevator", "station-transfer-3", "exit-transfer-3", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-b-elevator", "station-b", "exit-b-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL)
+			);
+		}
+	}
+
+	private static class StairOnlyOneTransferWithStepFreeTwoTransferTransitMasterPort extends TwoTransferTransitMasterPort {
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of(
+				new SubwayLine("line-a", "operator-a", "A 노선", "#0052A4", "수도권", null, true),
+				new SubwayLine("line-b", "operator-a", "B 노선", "#00A84D", "수도권", null, true),
+				new SubwayLine("line-c", "operator-a", "C 노선", "#F5A200", "수도권", null, true),
+				new SubwayLine("line-d", "operator-a", "D 노선", "#8A2BE2", "수도권", null, true)
+			);
+		}
+
+		@Override
+		public List<Station> loadStations() {
+			return List.of(
+				station("station-a", "출발역"),
+				station("station-stair-transfer", "계단환승역"),
+				station("station-transfer-1", "첫환승역"),
+				station("station-transfer-2", "둘째환승역"),
+				station("station-b", "도착역")
+			);
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of(
+				new StationLine("station-a", "line-a", "101", 1, "상행 / 하행"),
+				new StationLine("station-stair-transfer", "line-a", "102", 2, "상행 / 하행"),
+				new StationLine("station-stair-transfer", "line-d", "401", 1, "상행 / 하행"),
+				new StationLine("station-transfer-1", "line-a", "103", 3, "상행 / 하행"),
+				new StationLine("station-transfer-1", "line-b", "201", 1, "상행 / 하행"),
+				new StationLine("station-transfer-2", "line-b", "202", 2, "상행 / 하행"),
+				new StationLine("station-transfer-2", "line-c", "301", 1, "상행 / 하행"),
+				new StationLine("station-b", "line-c", "302", 2, "상행 / 하행"),
+				new StationLine("station-b", "line-d", "402", 2, "상행 / 하행")
+			);
+		}
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				stepFreeExit("exit-a-1", "station-a"),
+				stairOnlyExit("exit-stair-transfer-1", "station-stair-transfer"),
+				stepFreeExit("exit-transfer-1", "station-transfer-1"),
+				stepFreeExit("exit-transfer-2", "station-transfer-2"),
+				stepFreeExit("exit-b-1", "station-b")
+			);
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility("facility-a-elevator", "station-a", "exit-a-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-transfer-1-elevator", "station-transfer-1", "exit-transfer-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-transfer-2-elevator", "station-transfer-2", "exit-transfer-2", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-b-elevator", "station-b", "exit-b-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL)
+			);
+		}
+	}
+
+	private static class MixedMultiTransferAccessibilityTransitMasterPort extends TwoTransferTransitMasterPort {
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of(
+				new SubwayLine("line-a", "operator-a", "A 노선", "#0052A4", "수도권", null, true),
+				new SubwayLine("line-stair-mid", "operator-a", "계단 중간 노선", "#00A84D", "수도권", null, true),
+				new SubwayLine("line-stair-end", "operator-a", "계단 도착 노선", "#F5A200", "수도권", null, true),
+				new SubwayLine("line-step-free-mid", "operator-a", "무단차 중간 노선", "#8A2BE2", "수도권", null, true),
+				new SubwayLine("line-step-free-end", "operator-a", "무단차 도착 노선", "#00FFFF", "수도권", null, true)
+			);
+		}
+
+		@Override
+		public List<Station> loadStations() {
+			return List.of(
+				station("station-a", "출발역"),
+				station("station-stair-transfer-1", "첫계단환승역"),
+				station("station-stair-transfer-2", "둘째계단환승역"),
+				station("station-step-free-transfer-1", "첫무단차환승역"),
+				station("station-step-free-transfer-2", "둘째무단차환승역"),
+				station("station-b", "도착역")
+			);
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of(
+				new StationLine("station-a", "line-a", "101", 1, "상행 / 하행"),
+				new StationLine("station-stair-transfer-1", "line-a", "102", 2, "상행 / 하행"),
+				new StationLine("station-stair-transfer-1", "line-stair-mid", "201", 1, "상행 / 하행"),
+				new StationLine("station-stair-transfer-2", "line-stair-mid", "202", 2, "상행 / 하행"),
+				new StationLine("station-stair-transfer-2", "line-stair-end", "301", 1, "상행 / 하행"),
+				new StationLine("station-b", "line-stair-end", "302", 2, "상행 / 하행"),
+				new StationLine("station-step-free-transfer-1", "line-a", "110", 10, "상행 / 하행"),
+				new StationLine("station-step-free-transfer-1", "line-step-free-mid", "401", 1, "상행 / 하행"),
+				new StationLine("station-step-free-transfer-2", "line-step-free-mid", "402", 2, "상행 / 하행"),
+				new StationLine("station-step-free-transfer-2", "line-step-free-end", "501", 1, "상행 / 하행"),
+				new StationLine("station-b", "line-step-free-end", "502", 2, "상행 / 하행")
+			);
+		}
+
+		@Override
+		public List<StationExit> loadStationExits() {
+			return List.of(
+				stepFreeExit("exit-a-1", "station-a"),
+				stairOnlyExit("exit-stair-transfer-1", "station-stair-transfer-1"),
+				stairOnlyExit("exit-stair-transfer-2", "station-stair-transfer-2"),
+				stepFreeExit("exit-step-free-transfer-1", "station-step-free-transfer-1"),
+				stepFreeExit("exit-step-free-transfer-2", "station-step-free-transfer-2"),
+				stepFreeExit("exit-b-1", "station-b")
+			);
+		}
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility("facility-a-elevator", "station-a", "exit-a-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-step-free-transfer-1-elevator", "station-step-free-transfer-1", "exit-step-free-transfer-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
+				facility("facility-step-free-transfer-2-elevator", "station-step-free-transfer-2", "exit-step-free-transfer-2", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
 				facility("facility-b-elevator", "station-b", "exit-b-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL)
 			);
 		}


### PR DESCRIPTION
## 관련 이슈

close #1227

## 작업 배경

- Route Search V2 backend가 요청의 `maxTransfers`를 실제 탐색 정책에 반영하지 못해 2회 이상 환승 경로 fixture를 backend 결과로 검증할 수 없었다.
- H-2 범위는 backend route V2가 `maxTransfers`에 따라 직접, 1회, 2회 이상 환승 경로를 제한하고, 환승역 순서를 보존한 step sequence를 반환하는 것이다.

## 작업 내용

- `SearchRouteCommand`에 `maxTransfers`를 추가하고 기존 호출자는 기본 1회 환승 제한을 유지하게 했다.
- V2 route search request가 `maxTransfers`를 command로 전달하게 하고, API 입력 범위를 0~3으로 검증한다.
- backend route search service에 2회 이상 환승 경로 탐색과 multi-transfer step 조립을 추가했다.
- 1회 환승과 다중 환승 후보를 접근성 rank/cost로 함께 비교해 stair-only 후보보다 무단차 후보를 우선한다.
- 0회, 1회 제한, 2회 환승, 3회 환승, 접근성 우회, V2 controller 전달/검증 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `cd backend && ./gradlew test --tests '*RouteSearchV2*' --tests '*RouteSearchServiceTest*'` 성공
  - `node --test tools/routes/*.test.mjs` 성공
  - `cd backend && ./gradlew test` 성공
  - `git diff --check` 성공
  - `codex review --base origin/main` 재실행: actionable issue 0개
  - PR CI run `28494477042` 성공
  - PR Release Artifacts run `28494476850` 성공
  - post-merge SonarCloud run `28494712130` 성공
  - post-merge CI run `28494712357` 성공
  - post-merge Release Artifacts run `28494712152` 성공
  - post-merge CD run `28494874205` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 2회 이상 환승 backend 탐색 | backend | `./gradlew test --tests '*RouteSearchServiceTest*'` | 로컬 테스트 로그, PR CI `28494477042` | 성공 |
| V2 request `maxTransfers` 전달/검증 | backend API | `./gradlew test --tests '*RouteSearchV2*'` | 로컬 테스트 로그, PR CI `28494477042` | 성공 |
| route V2 prototype fixture 회귀 | tools/routes | `node --test tools/routes/*.test.mjs` | 로컬 테스트 로그 | 성공 |
| CodeRabbit/Codex review | PR review | CodeRabbit status, Codex fallback review | CodeRabbit success, Codex actionable issue 0개 | 성공 |
| post-merge CI/CD | GitHub Actions | main push/workflow_run 확인 | SonarCloud `28494712130`, CI `28494712357`, Release Artifacts `28494712152`, CD `28494874205` | 성공 |
| UI/접근성 수동 증거 | 해당 없음 | backend 탐색 정책 변경이며 화면 변경 없음 | 증거 불필요 | 해당 없음 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: V2 `maxTransfers` backend 적용 및 0~3 입력 검증
- realtime contract: 변경 없음
- backend identity: deploy only

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteSearchService.findTransferRoutePlan`의 1회/다중 환승 후보 비교
  - `RouteSearchService.findMultiTransferRoute`의 `maxTransfers` 제한과 접근성 비용 정렬
  - `RouteSearchController.RouteSearchV2Request`의 `maxTransfers` command 전달 및 입력 범위

## 리스크

- 실제 상용 ETA claim은 변경하지 않는다.
- multi-transfer 탐색은 backend fixture 기반 기본 탐색이며, timetable/realtime 최적화는 prototype/tools와 후속 backend 통합 범위에 남는다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
