### PR TITLE
[Feat] Provider health metrics와 kill switch 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/realtime/adapter/in/web/RealtimeProviderAdminController.java
+++ b/backend/src/main/java/com/easysubway/realtime/adapter/in/web/RealtimeProviderAdminController.java
@@ -1,0 +1,58 @@
+package com.easysubway.realtime.adapter.in.web;
+
+import com.easysubway.common.web.ApiResponse;
+import com.easysubway.realtime.application.RealtimeGatewayService;
+import com.easysubway.realtime.application.RealtimeProviderControl;
+import com.easysubway.realtime.application.RealtimeProviderHealthSnapshot;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+class RealtimeProviderAdminController {
+
+	private static final String PROVIDER_ID = "seoul-topis";
+
+	private final RealtimeGatewayService realtimeGatewayService;
+	private final RealtimeProviderControl providerControl;
+
+	RealtimeProviderAdminController(
+		RealtimeGatewayService realtimeGatewayService,
+		RealtimeProviderControl providerControl
+	) {
+		this.realtimeGatewayService = realtimeGatewayService;
+		this.providerControl = providerControl;
+	}
+
+	@GetMapping("/admin/realtime/providers/health")
+	ApiResponse<RealtimeProviderHealthSnapshot> health() {
+		return ApiResponse.ok(realtimeGatewayService.providerHealthSnapshot());
+	}
+
+	@PostMapping("/admin/realtime/providers/{providerId}/disable")
+	ApiResponse<RealtimeProviderHealthSnapshot> disableProvider(
+		@PathVariable String providerId,
+		@RequestParam(required = false) String reason
+	) {
+		validateProvider(providerId);
+		providerControl.disableProvider(providerId, reason);
+		return ApiResponse.ok(realtimeGatewayService.providerHealthSnapshot());
+	}
+
+	@PostMapping("/admin/realtime/providers/{providerId}/enable")
+	ApiResponse<RealtimeProviderHealthSnapshot> enableProvider(@PathVariable String providerId) {
+		validateProvider(providerId);
+		providerControl.enableProvider(providerId);
+		return ApiResponse.ok(realtimeGatewayService.providerHealthSnapshot());
+	}
+
+	private void validateProvider(String providerId) {
+		if (!PROVIDER_ID.equals(providerId)) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "지원하지 않는 실시간 provider입니다.");
+		}
+	}
+}

--- a/backend/src/main/java/com/easysubway/realtime/adapter/in/web/RealtimeProviderAdminController.java
+++ b/backend/src/main/java/com/easysubway/realtime/adapter/in/web/RealtimeProviderAdminController.java
@@ -5,6 +5,7 @@ import com.easysubway.realtime.application.RealtimeGatewayService;
 import com.easysubway.realtime.application.RealtimeProviderControl;
 import com.easysubway.realtime.application.RealtimeProviderHealthSnapshot;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,6 +35,7 @@ class RealtimeProviderAdminController {
 	}
 
 	@PostMapping("/admin/realtime/providers/{providerId}/disable")
+	@PreAuthorize("hasAuthority('admin.data.operate')")
 	ApiResponse<RealtimeProviderHealthSnapshot> disableProvider(
 		@PathVariable String providerId,
 		@RequestParam(required = false) String reason
@@ -44,6 +46,7 @@ class RealtimeProviderAdminController {
 	}
 
 	@PostMapping("/admin/realtime/providers/{providerId}/enable")
+	@PreAuthorize("hasAuthority('admin.data.operate')")
 	ApiResponse<RealtimeProviderHealthSnapshot> enableProvider(@PathVariable String providerId) {
 		validateProvider(providerId);
 		providerControl.enableProvider(providerId);

--- a/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
@@ -3,6 +3,7 @@ package com.easysubway.realtime.application;
 import com.easysubway.realtime.application.port.out.RealtimeMappingPort;
 import com.easysubway.realtime.domain.RealtimeMapping;
 import com.easysubway.realtime.domain.RealtimeArrival;
+import com.easysubway.realtime.domain.RealtimeStatus;
 import com.easysubway.realtime.domain.RealtimeTrainPosition;
 import java.time.Clock;
 import java.time.Duration;
@@ -17,6 +18,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -35,6 +37,8 @@ public class RealtimeGatewayService {
 	private final RealtimeProvider provider;
 	private final RealtimeMappingPort mappingPort;
 	private final Clock clock;
+	private final RealtimeProviderControl providerControl;
+	private final ProviderMetrics providerMetrics = new ProviderMetrics();
 	private final Map<String, CachedArrival> arrivalCache = new ConcurrentHashMap<>();
 	private final Map<String, CachedTrainPosition> trainPositionCache = new ConcurrentHashMap<>();
 	private final Map<String, CompletableFuture<RealtimeArrivalResult>> arrivalRequests = new ConcurrentHashMap<>();
@@ -42,23 +46,43 @@ public class RealtimeGatewayService {
 	private volatile java.time.Instant quotaCircuitOpenUntil;
 
 	@Autowired
-	public RealtimeGatewayService(RealtimeProvider provider, RealtimeMappingPort mappingPort) {
-		this(provider, Clock.systemUTC(), mappingPort);
+	public RealtimeGatewayService(
+		RealtimeProvider provider,
+		RealtimeMappingPort mappingPort,
+		RealtimeProviderControl providerControl
+	) {
+		this(provider, Clock.systemUTC(), mappingPort, providerControl);
 	}
 
 	RealtimeGatewayService(RealtimeProvider provider, Clock clock, RealtimeMappingPort mappingPort) {
+		this(provider, clock, mappingPort, new RealtimeProviderControl());
+	}
+
+	RealtimeGatewayService(
+		RealtimeProvider provider,
+		Clock clock,
+		RealtimeMappingPort mappingPort,
+		RealtimeProviderControl providerControl
+	) {
 		this.provider = provider;
 		this.clock = clock;
 		this.mappingPort = mappingPort;
+		this.providerControl = providerControl;
 	}
 
 	public RealtimeArrivalResult arrivals(RealtimeQuery query) {
 		NormalizedRealtimeQuery normalizedQuery = normalizeArrivalQuery(query);
 		if (normalizedQuery.rejected()) {
-			return RealtimeArrivalResult.unsupported(
+			return recordArrivalResult(RealtimeArrivalResult.unsupported(
 				normalizedQuery.fallbackCode(),
 				"서울 TOPIS 실시간 지원 범위 밖입니다."
-			);
+			));
+		}
+		if (!providerControl.providerEnabled(PROVIDER_ID)) {
+			return recordArrivalResult(RealtimeArrivalResult.unsupported(
+				"PROVIDER_DISABLED",
+				"실시간 provider가 운영자 설정으로 일시 중지되었습니다."
+			));
 		}
 		String cacheKey = "ARRIVALS:%s:%s:%s".formatted(
 			normalizedQuery.query().providerLineId(),
@@ -68,22 +92,22 @@ public class RealtimeGatewayService {
 		cacheKey = "%s:%d".formatted(cacheKey, normalizedQuery.cacheVersion());
 		CachedArrival cached = arrivalCache.get(cacheKey);
 		if (cached != null && isFresh(cached.cachedAt())) {
-			return cached.result();
+			return recordArrivalResult(cached.result());
 		}
 		if (isQuotaCircuitOpen()) {
-			return cached != null && isStaleUsable(cached.cachedAt())
+			return recordArrivalResult(cached != null && isStaleUsable(cached.cachedAt())
 				? cached.result().stale()
-				: RealtimeArrivalResult.unavailable("PROVIDER_QUOTA_EXCEEDED");
+				: RealtimeArrivalResult.unavailable("PROVIDER_QUOTA_EXCEEDED"));
 		}
 		CompletableFuture<RealtimeArrivalResult> request = new CompletableFuture<>();
 		CompletableFuture<RealtimeArrivalResult> existing = arrivalRequests.putIfAbsent(cacheKey, request);
 		if (existing != null) {
-			return joinArrival(existing);
+			return recordArrivalResult(joinArrival(existing));
 		}
 		try {
 			RealtimeArrivalResult result = fetchArrivals(normalizedQuery.query(), cacheKey, cached);
 			request.complete(result);
-			return result;
+			return recordArrivalResult(result);
 		} catch (RuntimeException exception) {
 			request.completeExceptionally(exception);
 			throw exception;
@@ -93,9 +117,11 @@ public class RealtimeGatewayService {
 	}
 
 	private RealtimeArrivalResult fetchArrivals(RealtimeQuery normalizedQuery, String cacheKey, CachedArrival cached) {
+		Instant providerCallStartedAt = clock.instant();
 		try {
 			List<RealtimeArrival> arrivals = provider.arrivals(normalizedQuery);
 			if (arrivals.isEmpty()) {
+				providerMetrics.recordEmptyResult();
 				return RealtimeArrivalResult.unavailable("EMPTY_PROVIDER_RESULT");
 			}
 			Instant receivedAt = clock.instant();
@@ -110,18 +136,27 @@ public class RealtimeGatewayService {
 			arrivalCache.put(cacheKey, new CachedArrival(result, receivedAt));
 			return result;
 		} catch (RealtimeProviderException exception) {
+			providerMetrics.recordProviderException(exception.fallbackCode());
 			openQuotaCircuitIfNeeded(exception);
 			return staleArrivalOrUnavailable(cached, exception.fallbackCode());
+		} finally {
+			providerMetrics.recordProviderCall(Duration.between(providerCallStartedAt, clock.instant()));
 		}
 	}
 
 	public RealtimeTrainPositionResult trainPositions(RealtimeQuery query) {
 		NormalizedRealtimeQuery normalizedQuery = normalizeTrainPositionQuery(query);
 		if (normalizedQuery.rejected()) {
-			return RealtimeTrainPositionResult.unsupported(
+			return recordTrainPositionResult(RealtimeTrainPositionResult.unsupported(
 				normalizedQuery.fallbackCode(),
 				"서울 TOPIS 실시간 지원 범위 밖입니다."
-			);
+			));
+		}
+		if (!providerControl.providerEnabled(PROVIDER_ID)) {
+			return recordTrainPositionResult(RealtimeTrainPositionResult.unsupported(
+				"PROVIDER_DISABLED",
+				"실시간 provider가 운영자 설정으로 일시 중지되었습니다."
+			));
 		}
 		String cacheKey = "POSITIONS:%s:%s:%d".formatted(
 			normalizedQuery.query().providerLineId(),
@@ -130,22 +165,22 @@ public class RealtimeGatewayService {
 		);
 		CachedTrainPosition cached = trainPositionCache.get(cacheKey);
 		if (cached != null && isFresh(cached.cachedAt())) {
-			return cached.result();
+			return recordTrainPositionResult(cached.result());
 		}
 		if (isQuotaCircuitOpen()) {
-			return cached != null && isStaleUsable(cached.cachedAt())
+			return recordTrainPositionResult(cached != null && isStaleUsable(cached.cachedAt())
 				? cached.result().stale()
-				: RealtimeTrainPositionResult.unavailable("PROVIDER_QUOTA_EXCEEDED");
+				: RealtimeTrainPositionResult.unavailable("PROVIDER_QUOTA_EXCEEDED"));
 		}
 		CompletableFuture<RealtimeTrainPositionResult> request = new CompletableFuture<>();
 		CompletableFuture<RealtimeTrainPositionResult> existing = trainPositionRequests.putIfAbsent(cacheKey, request);
 		if (existing != null) {
-			return joinTrainPosition(existing);
+			return recordTrainPositionResult(joinTrainPosition(existing));
 		}
 		try {
 			RealtimeTrainPositionResult result = fetchTrainPositions(normalizedQuery.query(), cacheKey, cached);
 			request.complete(result);
-			return result;
+			return recordTrainPositionResult(result);
 		} catch (RuntimeException exception) {
 			request.completeExceptionally(exception);
 			throw exception;
@@ -159,9 +194,11 @@ public class RealtimeGatewayService {
 		String cacheKey,
 		CachedTrainPosition cached
 	) {
+		Instant providerCallStartedAt = clock.instant();
 		try {
 			List<RealtimeTrainPosition> trainPositions = provider.trainPositions(normalizedQuery);
 			if (trainPositions.isEmpty()) {
+				providerMetrics.recordEmptyResult();
 				return RealtimeTrainPositionResult.unavailable("EMPTY_PROVIDER_RESULT");
 			}
 			Instant receivedAt = clock.instant();
@@ -176,9 +213,31 @@ public class RealtimeGatewayService {
 			trainPositionCache.put(cacheKey, new CachedTrainPosition(result, receivedAt));
 			return result;
 		} catch (RealtimeProviderException exception) {
+			providerMetrics.recordProviderException(exception.fallbackCode());
 			openQuotaCircuitIfNeeded(exception);
 			return staleTrainPositionOrUnavailable(cached, exception.fallbackCode());
+		} finally {
+			providerMetrics.recordProviderCall(Duration.between(providerCallStartedAt, clock.instant()));
 		}
+	}
+
+	public RealtimeProviderHealthSnapshot providerHealthSnapshot() {
+		RealtimeProviderControl.RealtimeProviderSwitchState switchState = providerControl.switchState(PROVIDER_ID);
+		return providerMetrics.snapshot(
+			PROVIDER_ID,
+			switchState.enabled(),
+			switchState.disabledReason()
+		);
+	}
+
+	private RealtimeArrivalResult recordArrivalResult(RealtimeArrivalResult result) {
+		providerMetrics.recordResult(result.status());
+		return result;
+	}
+
+	private RealtimeTrainPositionResult recordTrainPositionResult(RealtimeTrainPositionResult result) {
+		providerMetrics.recordResult(result.status());
+		return result;
 	}
 
 	private RealtimeArrivalResult staleArrivalOrUnavailable(CachedArrival cached, String fallbackCode) {
@@ -377,6 +436,75 @@ public class RealtimeGatewayService {
 	}
 
 	private record CachedTrainPosition(RealtimeTrainPositionResult result, java.time.Instant cachedAt) {
+	}
+
+	private static final class ProviderMetrics {
+		private final AtomicLong providerCallCount = new AtomicLong();
+		private final AtomicLong providerTimeoutCount = new AtomicLong();
+		private final AtomicLong providerQuotaExceededCount = new AtomicLong();
+		private final AtomicLong providerEmptyResultCount = new AtomicLong();
+		private final AtomicLong providerLatencyMsTotal = new AtomicLong();
+		private final AtomicLong resultCount = new AtomicLong();
+		private final AtomicLong freshResultCount = new AtomicLong();
+		private final AtomicLong staleResultCount = new AtomicLong();
+		private final AtomicLong unsupportedResultCount = new AtomicLong();
+
+		private void recordProviderCall(Duration latency) {
+			providerCallCount.incrementAndGet();
+			providerLatencyMsTotal.addAndGet(Math.max(0, latency.toMillis()));
+		}
+
+		private void recordProviderException(String fallbackCode) {
+			if ("PROVIDER_TIMEOUT".equals(fallbackCode)) {
+				providerTimeoutCount.incrementAndGet();
+			}
+			if ("PROVIDER_QUOTA_EXCEEDED".equals(fallbackCode)) {
+				providerQuotaExceededCount.incrementAndGet();
+			}
+		}
+
+		private void recordEmptyResult() {
+			providerEmptyResultCount.incrementAndGet();
+		}
+
+		private void recordResult(RealtimeStatus status) {
+			resultCount.incrementAndGet();
+			if (status == RealtimeStatus.FRESH) {
+				freshResultCount.incrementAndGet();
+			}
+			if (status == RealtimeStatus.STALE) {
+				staleResultCount.incrementAndGet();
+			}
+			if (status == RealtimeStatus.UNSUPPORTED) {
+				unsupportedResultCount.incrementAndGet();
+			}
+		}
+
+		private RealtimeProviderHealthSnapshot snapshot(
+			String providerId,
+			boolean providerEnabled,
+			String disabledReason
+		) {
+			long calls = providerCallCount.get();
+			long results = resultCount.get();
+			return new RealtimeProviderHealthSnapshot(
+				providerId,
+				providerEnabled,
+				disabledReason,
+				calls,
+				providerTimeoutCount.get(),
+				providerQuotaExceededCount.get(),
+				providerEmptyResultCount.get(),
+				ratio(freshResultCount.get(), results),
+				ratio(staleResultCount.get(), results),
+				ratio(unsupportedResultCount.get(), results),
+				calls == 0 ? 0 : providerLatencyMsTotal.get() / calls
+			);
+		}
+
+		private double ratio(long count, long total) {
+			return total == 0 ? 0.0 : (double) count / total;
+		}
 	}
 
 	private record NormalizedRealtimeQuery(RealtimeQuery query, long cacheVersion, String fallbackCode) {

--- a/backend/src/main/java/com/easysubway/realtime/application/RealtimeProviderControl.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/RealtimeProviderControl.java
@@ -1,0 +1,38 @@
+package com.easysubway.realtime.application;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RealtimeProviderControl {
+
+	private final ConcurrentMap<String, ProviderSwitch> switches = new ConcurrentHashMap<>();
+
+	public boolean providerEnabled(String providerId) {
+		return switchState(providerId).enabled();
+	}
+
+	public void disableProvider(String providerId, String reason) {
+		switches.put(providerId, new ProviderSwitch(false, cleanReason(reason)));
+	}
+
+	public void enableProvider(String providerId) {
+		switches.put(providerId, new ProviderSwitch(true, null));
+	}
+
+	public RealtimeProviderSwitchState switchState(String providerId) {
+		ProviderSwitch state = switches.getOrDefault(providerId, new ProviderSwitch(true, null));
+		return new RealtimeProviderSwitchState(providerId, state.enabled(), state.disabledReason());
+	}
+
+	private String cleanReason(String reason) {
+		return reason == null || reason.isBlank() ? "DISABLED_BY_OPERATOR" : reason.strip();
+	}
+
+	private record ProviderSwitch(boolean enabled, String disabledReason) {
+	}
+
+	public record RealtimeProviderSwitchState(String providerId, boolean enabled, String disabledReason) {
+	}
+}

--- a/backend/src/main/java/com/easysubway/realtime/application/RealtimeProviderHealthSnapshot.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/RealtimeProviderHealthSnapshot.java
@@ -1,0 +1,16 @@
+package com.easysubway.realtime.application;
+
+public record RealtimeProviderHealthSnapshot(
+	String providerId,
+	boolean providerEnabled,
+	String disabledReason,
+	long providerCallCount,
+	long providerTimeoutCount,
+	long providerQuotaExceededCount,
+	long providerEmptyResultCount,
+	double freshResultRatio,
+	double staleResultRatio,
+	double unsupportedRatio,
+	long averageProviderLatencyMs
+) {
+}

--- a/backend/src/test/java/com/easysubway/realtime/adapter/in/web/RealtimeProviderAdminControllerTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/adapter/in/web/RealtimeProviderAdminControllerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(properties = {
@@ -96,5 +98,15 @@ class RealtimeProviderAdminControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.providerEnabled").value(true))
 			.andExpect(jsonPath("$.data.disabledReason").doesNotExist());
+	}
+
+	@Test
+	@DisplayName("view 권한만 있는 관리자는 실시간 provider kill switch를 토글할 수 없다")
+	void realtimeProviderKillSwitchRequiresDataOperateAuthority() throws Exception {
+		mockMvc.perform(post("/admin/realtime/providers/seoul-topis/disable")
+				.with(user("viewer").authorities(new SimpleGrantedAuthority("admin.view")))
+				.with(csrf())
+				.param("reason", "MAINTENANCE"))
+			.andExpect(status().isForbidden());
 	}
 }

--- a/backend/src/test/java/com/easysubway/realtime/adapter/in/web/RealtimeProviderAdminControllerTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/adapter/in/web/RealtimeProviderAdminControllerTest.java
@@ -1,0 +1,100 @@
+package com.easysubway.realtime.adapter.in.web;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.easysubway.realtime.application.RealtimeProviderControl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+	"easysubway.admin.username=admin-user",
+	"easysubway.admin.password=admin-test-password",
+	"easysubway.user.username=basic-user",
+	"easysubway.user.password=user-test-password"
+})
+@AutoConfigureMockMvc
+@DisplayName("관리자 실시간 provider health summary API")
+class RealtimeProviderAdminControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private RealtimeProviderControl providerControl;
+
+	@AfterEach
+	void resetProviderControl() {
+		providerControl.enableProvider("seoul-topis");
+	}
+
+	@Test
+	@DisplayName("관리자는 실시간 provider health summary를 조회한다")
+	void adminGetsRealtimeProviderHealthSummary() throws Exception {
+		mockMvc.perform(get("/admin/realtime/providers/health")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.providerId").value("seoul-topis"))
+			.andExpect(jsonPath("$.data.providerEnabled").value(true))
+			.andExpect(jsonPath("$.data.providerCallCount").isNumber())
+			.andExpect(jsonPath("$.data.providerTimeoutCount").isNumber())
+			.andExpect(jsonPath("$.data.providerQuotaExceededCount").isNumber())
+			.andExpect(jsonPath("$.data.providerEmptyResultCount").isNumber())
+			.andExpect(jsonPath("$.data.freshResultRatio").isNumber())
+			.andExpect(jsonPath("$.data.staleResultRatio").isNumber())
+			.andExpect(jsonPath("$.data.unsupportedRatio").isNumber())
+			.andExpect(jsonPath("$.data.averageProviderLatencyMs").isNumber())
+			.andExpect(content().string(not(containsString("상록수"))))
+			.andExpect(content().string(not(containsString("4123"))))
+			.andExpect(content().string(not(containsString("1004"))));
+	}
+
+	@Test
+	@DisplayName("실시간 provider health summary는 관리자만 사용할 수 있다")
+	void realtimeProviderHealthSummaryRequiresAdminAuthentication() throws Exception {
+		mockMvc.perform(get("/admin/realtime/providers/health"))
+			.andExpect(status().isUnauthorized());
+
+		mockMvc.perform(get("/admin/realtime/providers/health")
+				.with(httpBasic("basic-user", "user-test-password")))
+			.andExpect(status().isForbidden());
+	}
+
+	@Test
+	@DisplayName("관리자는 실시간 provider kill switch를 토글한다")
+	void adminTogglesRealtimeProviderKillSwitch() throws Exception {
+		mockMvc.perform(post("/admin/realtime/providers/seoul-topis/disable")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf())
+				.param("reason", "MAINTENANCE"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.providerEnabled").value(false))
+			.andExpect(jsonPath("$.data.disabledReason").value("MAINTENANCE"));
+
+		mockMvc.perform(get("/admin/realtime/providers/health")
+				.with(httpBasic("admin-user", "admin-test-password")))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.providerEnabled").value(false))
+			.andExpect(jsonPath("$.data.disabledReason").value("MAINTENANCE"));
+
+		mockMvc.perform(post("/admin/realtime/providers/seoul-topis/enable")
+				.with(httpBasic("admin-user", "admin-test-password"))
+				.with(csrf()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.providerEnabled").value(true))
+			.andExpect(jsonPath("$.data.disabledReason").doesNotExist());
+	}
+}

--- a/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
@@ -470,6 +470,60 @@ class RealtimeGatewayServiceTest {
 	}
 
 	@Test
+	@DisplayName("provider kill switch는 외부 호출을 막고 cache를 오염시키지 않는다")
+	void providerKillSwitchSkipsProviderCallWithoutPoisoningCache() {
+		CountingProvider provider = new CountingProvider();
+		RealtimeProviderControl control = new RealtimeProviderControl();
+		RealtimeGatewayService service = service(
+			provider,
+			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC),
+			InMemoryRealtimeMappingPort.seededFixture(),
+			control
+		);
+
+		control.disableProvider("seoul-topis", "MAINTENANCE");
+		RealtimeArrivalResult disabled = service.arrivals(sangnoksuQuery());
+		control.enableProvider("seoul-topis");
+		RealtimeArrivalResult fresh = service.arrivals(sangnoksuQuery());
+
+		assertThat(disabled.status()).hasToString("UNSUPPORTED");
+		assertThat(disabled.fallbackCode()).isEqualTo("PROVIDER_DISABLED");
+		assertThat(fresh.status()).hasToString("FRESH");
+		assertThat(provider.arrivalCalls).hasValue(1);
+	}
+
+	@Test
+	@DisplayName("provider health snapshot은 low-cardinality 집계만 노출한다")
+	void providerHealthSnapshotExposesOnlySafeCounters() {
+		MutableClock clock = new MutableClock(Instant.parse("2026-06-26T08:00:00Z"));
+		CountingProvider provider = new CountingProvider();
+		RealtimeGatewayService service = service(provider, clock);
+
+		service.arrivals(sangnoksuQuery());
+		clock.instant = Instant.parse("2026-06-26T08:00:30Z");
+		provider.failureCode = "PROVIDER_TIMEOUT";
+		service.arrivals(sangnoksuQuery());
+		service.arrivals(new RealtimeQuery("station-outside", "other", null, "외부역", null));
+		provider.failureCode = "PROVIDER_QUOTA_EXCEEDED";
+		service.trainPositions(line4Query());
+
+		RealtimeProviderHealthSnapshot snapshot = service.providerHealthSnapshot();
+
+		assertThat(snapshot.providerId()).isEqualTo("seoul-topis");
+		assertThat(snapshot.providerCallCount()).isEqualTo(3);
+		assertThat(snapshot.providerTimeoutCount()).isEqualTo(1);
+		assertThat(snapshot.providerQuotaExceededCount()).isEqualTo(1);
+		assertThat(snapshot.freshResultRatio()).isPositive();
+		assertThat(snapshot.staleResultRatio()).isPositive();
+		assertThat(snapshot.unsupportedRatio()).isPositive();
+		assertThat(snapshot.toString())
+			.doesNotContain("상록수")
+			.doesNotContain("외부역")
+			.doesNotContain("4123")
+			.doesNotContain("1004");
+	}
+
+	@Test
 	@DisplayName("TOPIS provider는 backend service key가 없으면 unavailable로 낮춘다")
 	void topisProviderWithoutBackendServiceKeyIsUnavailableByDefault() {
 		TopisRealtimeProvider provider = new TopisRealtimeProvider(
@@ -660,6 +714,15 @@ class RealtimeGatewayServiceTest {
 
 	private RealtimeGatewayService service(RealtimeProvider provider, Clock clock, RealtimeMappingPort mappingPort) {
 		return new RealtimeGatewayService(provider, clock, mappingPort);
+	}
+
+	private RealtimeGatewayService service(
+		RealtimeProvider provider,
+		Clock clock,
+		RealtimeMappingPort mappingPort,
+		RealtimeProviderControl control
+	) {
+		return new RealtimeGatewayService(provider, clock, mappingPort, control);
 	}
 
 	private RealtimeMapping mapping(


### PR DESCRIPTION
## Summary
- RealtimeGatewayService에 provider call/result health counter와 안전한 snapshot을 추가했습니다.
- admin JSON summary API와 provider disable/enable kill switch API를 추가했습니다.
- kill switch 상태에서는 provider 호출과 cache 오염 없이 PROVIDER_DISABLED로 종료하도록 했습니다.

## Issue
- Closes #1231

## Verification
- ./gradlew test --tests '*RealtimeGatewayServiceTest' --tests '*RealtimeProviderAdminControllerTest'
- ./gradlew test
- git diff --check

## Evidence
- admin summary는 providerId, enabled 상태, timeout/quota/empty/provider call count, fresh/stale/unsupported ratio, average latency만 노출합니다.
- 테스트에서 station name, train number, provider line id가 summary response에 포함되지 않음을 확인했습니다.