### PR TITLE
[Feat] Route V2 favorite snapshot metadata 보존

### DIFF
--- a/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
+++ b/apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart
@@ -441,6 +441,8 @@ class DriftFavoriteRouteRepository implements FavoriteRouteRepository {
       score: snapshot['score'] is int ? snapshot['score'] as int : 0,
       routeCreatedAt: _string(snapshot['createdAt']),
       addedAt: addedAt,
+      etaSource: _string(snapshot['etaSource']),
+      fallbackReason: _string(snapshot['fallbackReason']),
     );
   }
 
@@ -551,6 +553,8 @@ FavoriteRoute _favoriteRouteFromResult({
     score: result.score,
     routeCreatedAt: result.createdAt,
     addedAt: addedAt,
+    etaSource: result.etaSource,
+    fallbackReason: result.fallbackReason,
   );
 }
 
@@ -593,6 +597,8 @@ Map<String, Object?> _routeResultToJson(RouteSearchResult result) {
     'recommendationReasons': result.recommendationReasons,
     'blockedReasons': result.blockedReasons,
     'createdAt': result.createdAt,
+    'etaSource': result.etaSource,
+    'fallbackReason': result.fallbackReason,
   };
 }
 
@@ -609,7 +615,15 @@ Map<String, Object?> _routeStepToJson(RouteSearchStep step) {
     'estimatedMinutes': step.estimatedMinutes,
     'distanceMeters': step.distanceMeters,
     'includesStairs': step.includesStairs,
+    'stairAccessState': step.stairAccessState,
     'requiresAccessibilityCheck': step.requiresAccessibilityCheck,
+    'actionTitle': step.actionTitle,
+    'actionDetail': step.actionDetail,
+    'reason': step.reason,
+    'evidenceSources': step.evidenceSources,
+    'timeSource': step.timeSource,
+    'distanceSource': step.distanceSource,
+    'confidenceLabel': step.confidenceLabel,
   };
 }
 

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -91,6 +91,7 @@ String _routeEtaSourceLabel(String value) {
   return switch (value.trim()) {
     'REALTIME' => '실시간 반영',
     'PLANNED' => '시간표 기준',
+    'STATIC_BACKEND_V1' => '시간표 기준',
     'MIXED' => '일부 실시간 반영',
     'FALLBACK' => '실시간 미지원',
     'STATIC_LOCAL' => '저장된 데이터 기준',

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -87,6 +87,17 @@ String _routeDateLabel(String value) {
   return '최근 확인일을 아직 알 수 없어요';
 }
 
+String _routeEtaSourceLabel(String value) {
+  return switch (value.trim()) {
+    'REALTIME' => '실시간 반영',
+    'PLANNED' => '시간표 기준',
+    'MIXED' => '일부 실시간 반영',
+    'FALLBACK' => '실시간 미지원',
+    'STATIC_LOCAL' => '저장된 데이터 기준',
+    _ => '',
+  };
+}
+
 abstract class RouteSearchRepository {
   Future<RouteSearchResult> searchRoute(RouteSearchRequest request);
 
@@ -627,6 +638,8 @@ class FavoriteRoute {
     required this.score,
     required this.routeCreatedAt,
     required this.addedAt,
+    this.etaSource = '',
+    this.fallbackReason = '',
   });
 
   factory FavoriteRoute.fromJson(Map<String, Object?> json) {
@@ -648,6 +661,8 @@ class FavoriteRoute {
       score: _requiredRouteInt(json, 'score'),
       routeCreatedAt: _requiredRouteString(json, 'routeCreatedAt'),
       addedAt: _requiredRouteString(json, 'addedAt'),
+      etaSource: _optionalRouteString(json, 'etaSource'),
+      fallbackReason: _optionalRouteString(json, 'fallbackReason'),
     );
   }
 
@@ -665,6 +680,8 @@ class FavoriteRoute {
   final int score;
   final String routeCreatedAt;
   final String addedAt;
+  final String etaSource;
+  final String fallbackReason;
 
   String get summaryTitle => '$originStationName에서 $destinationStationName까지';
 
@@ -674,11 +691,25 @@ class FavoriteRoute {
 
   String get mobilityLabel => _mobilityLabelFor(mobilityType);
 
-  String get scoreBasisText =>
-      '$mobilityLabel 조건 · $lineLabel · ${_routeDateLabel(routeCreatedAt)}';
+  String get etaSourceLabel => _routeEtaSourceLabel(etaSource);
 
-  String get scoreBasisSemanticLabel =>
-      '$mobilityLabel 조건, $lineLabel, ${_routeDateLabel(routeCreatedAt)}';
+  String get scoreBasisText {
+    return [
+      '$mobilityLabel 조건',
+      lineLabel,
+      _routeDateLabel(routeCreatedAt),
+      if (etaSourceLabel.isNotEmpty) etaSourceLabel,
+    ].join(' · ');
+  }
+
+  String get scoreBasisSemanticLabel {
+    return [
+      '$mobilityLabel 조건',
+      lineLabel,
+      _routeDateLabel(routeCreatedAt),
+      if (etaSourceLabel.isNotEmpty) etaSourceLabel,
+    ].join(', ');
+  }
 
   String get movementMetricLabel =>
       '예상 시간을 확인하고 있어요 · 환승 안내를 확인하고 있어요 · 걷는 거리를 확인하고 있어요';

--- a/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
+++ b/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
@@ -255,6 +255,83 @@ void main() {
     );
   });
 
+  test('V2 경로 즐겨찾기는 ETA 출처와 step metadata를 snapshot에 보존한다', () async {
+    final catalogDatabase = CatalogDatabase.memory();
+    final userDatabase = user_db.UserDatabase.memory();
+    addTearDown(catalogDatabase.close);
+    addTearDown(userDatabase.close);
+    await catalogDatabase.seedBaselineIfEmpty();
+    final repository = DriftFavoriteRouteRepository(
+      catalogDatabase: catalogDatabase,
+      userDatabase: userDatabase,
+    );
+    final result = RouteSearchResult(
+      routeSearchId: 'route-v2',
+      originStationId: 'station-sangnoksu',
+      originStationName: '상록수',
+      destinationStationId: 'station-sadang',
+      destinationStationName: '사당',
+      mobilityType: 'WHEELCHAIR',
+      status: 'FOUND',
+      lineId: 'seoul-4',
+      lineName: '수도권 4호선',
+      score: 88,
+      steps: const [
+        RouteSearchStep(
+          sequence: 1,
+          stepType: 'ride',
+          title: '상록수에서 사당까지 이동',
+          description: '4호선 이동',
+          lineId: 'seoul-4',
+          lineName: '수도권 4호선',
+          fromStationId: 'station-sangnoksu',
+          toStationId: 'station-sadang',
+          estimatedMinutes: 26,
+          distanceMeters: 0,
+          includesStairs: false,
+          requiresAccessibilityCheck: false,
+          timeSource: 'PLANNED',
+          distanceSource: 'BACKEND_V2',
+          confidenceLabel: 'LOW',
+        ),
+      ],
+      warnings: const [],
+      blockedReasons: const [],
+      createdAt: '2026-07-01T09:00:00+09:00',
+      etaSource: 'PLANNED',
+    );
+
+    final saved = await repository.saveFavoriteRoute(
+      result.routeSearchId,
+      result: result,
+    );
+    final favorites = await repository.listFavoriteRoutes();
+    final snapshotRows = await userDatabase
+        .customSelect(
+          'SELECT value FROM app_preferences WHERE key = ?',
+          variables: [
+            Variable.withString(
+              'favorite_route_snapshot:${saved.favoriteRouteId}',
+            ),
+          ],
+          readsFrom: {userDatabase.appPreferences},
+        )
+        .get();
+    final snapshot =
+        jsonDecode(snapshotRows.single.read<String>('value'))
+            as Map<String, Object?>;
+    final steps = snapshot['steps'] as List<Object?>;
+    final firstStep = steps.single as Map<String, Object?>;
+
+    expect(favorites.single.routeSearchId, 'route-v2');
+    expect(favorites.single.scoreBasisText, contains('시간표 기준'));
+    expect(favorites.single.semanticLabel, contains('시간표 기준'));
+    expect(snapshot['etaSource'], 'PLANNED');
+    expect(firstStep['timeSource'], 'PLANNED');
+    expect(firstStep['distanceSource'], 'BACKEND_V2');
+    expect(firstStep['confidenceLabel'], 'LOW');
+  });
+
   test('로컬 알림 설정과 최근 검색은 app_preferences와 search_history에 보관한다', () async {
     final userDatabase = user_db.UserDatabase.memory();
     addTearDown(userDatabase.close);

--- a/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
+++ b/apps/mobile/test/features/favorites/drift_favorite_repositories_test.dart
@@ -290,7 +290,7 @@ void main() {
           distanceMeters: 0,
           includesStairs: false,
           requiresAccessibilityCheck: false,
-          timeSource: 'PLANNED',
+          timeSource: 'STATIC_BACKEND_V1',
           distanceSource: 'BACKEND_V2',
           confidenceLabel: 'LOW',
         ),
@@ -298,7 +298,7 @@ void main() {
       warnings: const [],
       blockedReasons: const [],
       createdAt: '2026-07-01T09:00:00+09:00',
-      etaSource: 'PLANNED',
+      etaSource: 'STATIC_BACKEND_V1',
     );
 
     final saved = await repository.saveFavoriteRoute(
@@ -326,8 +326,8 @@ void main() {
     expect(favorites.single.routeSearchId, 'route-v2');
     expect(favorites.single.scoreBasisText, contains('시간표 기준'));
     expect(favorites.single.semanticLabel, contains('시간표 기준'));
-    expect(snapshot['etaSource'], 'PLANNED');
-    expect(firstStep['timeSource'], 'PLANNED');
+    expect(snapshot['etaSource'], 'STATIC_BACKEND_V1');
+    expect(firstStep['timeSource'], 'STATIC_BACKEND_V1');
     expect(firstStep['distanceSource'], 'BACKEND_V2');
     expect(firstStep['confidenceLabel'], 'LOW');
   });


### PR DESCRIPTION
## 관련 이슈

close #1238

## 작업 배경

- V2 route result를 favorite snapshot에 저장할 때 ETA 출처와 step metadata가 사라지면 저장된 경로가 stale realtime ETA를 현재 ETA처럼 보이게 할 수 있습니다.

## 작업 내용

- FavoriteRoute에 optional etaSource/fallbackReason을 추가하고 저장된 경로 basis/semantics에 ETA 출처가 있을 때만 표시합니다.
- Drift favorite route snapshot JSON에 V2 route etaSource/fallbackReason과 step metadata를 보존합니다.
- V2 favorite snapshot round-trip 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - cd apps/mobile && flutter test test/features/favorites test/route_search_test.dart 성공
  - cd apps/mobile && flutter analyze 성공
  - git diff --check 성공

## 검증 증거

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| V2 favorite snapshot metadata | mobile local test | flutter test test/features/favorites test/route_search_test.dart | 증거 불필요: 저장소/모델 단위 테스트 | 성공 |
| Static analysis | mobile | flutter analyze | 증거 불필요: 정적 분석 | 성공 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: apps/mobile/lib/features/favorites/data/drift_favorite_repositories.dart snapshot serializer

## 리스크

- 기존 snapshot에는 etaSource가 없으므로 기존 V1/legacy favorite 표시는 그대로 유지됩니다.

## 체크리스트

- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.