### PR TITLE
[Perf] Mobile LocalRouteEngine priority queue 전환

### DIFF
--- a/apps/mobile/lib/features/routes/application/route_engine.dart
+++ b/apps/mobile/lib/features/routes/application/route_engine.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import '../domain/route_request.dart';
 import '../domain/route_result.dart';
 import '../domain/route_step.dart';
@@ -202,25 +204,34 @@ class AccessGraphRouter {
     RouteTraversalPolicy traversalPolicy,
     Set<String> blockedReasonCodes,
   ) {
-    final costs = <String, int>{originNodeId: 0};
+    final bestCostByNode = <String, int>{originNodeId: 0};
     final previousNode = <String, String>{};
     final previousEdge = <String, RouteEdge>{};
-    final visited = <String>{};
+    var sequence = 0;
+    final candidates =
+        PriorityQueue<_RouteCandidate>((a, b) {
+          final costComparison = a.cost.compareTo(b.cost);
+          if (costComparison != 0) {
+            return costComparison;
+          }
+          return a.sequence.compareTo(b.sequence);
+        })..add(
+          _RouteCandidate(nodeId: originNodeId, cost: 0, sequence: sequence++),
+        );
 
-    while (true) {
-      final current = _lowestUnvisitedNode(costs, visited);
-      if (current == null) {
-        return null;
+    while (candidates.isNotEmpty) {
+      final candidate = candidates.removeFirst();
+      if (candidate.cost != bestCostByNode[candidate.nodeId]) {
+        continue;
       }
-      if (current == destinationNodeId) {
+      if (candidate.nodeId == destinationNodeId) {
         break;
       }
-      visited.add(current);
 
-      for (final edge in graph.edgesFrom(current)) {
+      for (final edge in graph.edgesFrom(candidate.nodeId)) {
         if (!traversalPolicy.canTraverse(
           edge,
-          currentNodeId: current,
+          currentNodeId: candidate.nodeId,
           originNodeId: originNodeId,
           destinationNodeId: destinationNodeId,
         )) {
@@ -235,13 +246,24 @@ class AccessGraphRouter {
           blockedReasonCodes.addAll(edgeCost.warningCodes);
           continue;
         }
-        final nextCost = costs[current]! + edgeCost.cost;
-        if (nextCost < (costs[edge.toNodeId] ?? 1 << 62)) {
-          costs[edge.toNodeId] = nextCost;
-          previousNode[edge.toNodeId] = current;
+        final nextCost = candidate.cost + edgeCost.cost;
+        if (nextCost < (bestCostByNode[edge.toNodeId] ?? 1 << 62)) {
+          bestCostByNode[edge.toNodeId] = nextCost;
+          previousNode[edge.toNodeId] = candidate.nodeId;
           previousEdge[edge.toNodeId] = edge;
+          candidates.add(
+            _RouteCandidate(
+              nodeId: edge.toNodeId,
+              cost: nextCost,
+              sequence: sequence++,
+            ),
+          );
         }
       }
+    }
+
+    if (!bestCostByNode.containsKey(destinationNodeId)) {
+      return null;
     }
 
     final reversed = <RouteEdge>[];
@@ -258,21 +280,18 @@ class AccessGraphRouter {
 
     return reversed.reversed.toList(growable: false);
   }
+}
 
-  String? _lowestUnvisitedNode(Map<String, int> costs, Set<String> visited) {
-    String? selected;
-    var selectedCost = 1 << 62;
-    for (final entry in costs.entries) {
-      if (visited.contains(entry.key)) {
-        continue;
-      }
-      if (entry.value < selectedCost) {
-        selected = entry.key;
-        selectedCost = entry.value;
-      }
-    }
-    return selected;
-  }
+class _RouteCandidate {
+  const _RouteCandidate({
+    required this.nodeId,
+    required this.cost,
+    required this.sequence,
+  });
+
+  final String nodeId;
+  final int cost;
+  final int sequence;
 }
 
 class RouteTraversalPolicy {

--- a/apps/mobile/pubspec.lock
+++ b/apps/mobile/pubspec.lock
@@ -154,7 +154,7 @@ packages:
     source: hosted
     version: "1.2.1"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   crypto: ^3.0.7
   archive: ^4.0.9
   path: ^1.9.1
+  collection: ^1.19.1
   sqlite3: ^3.3.3
 dev_dependencies:
   flutter_test:

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -438,6 +438,33 @@ void main() {
       expect(result.edgeIds.length, 9999);
     });
 
+    test('개선된 후보가 있는 경로는 반복 실행해도 같은 최저 비용 경로를 반환한다', () {
+      final engine = LocalRouteEngine(graph: _improvedCandidateFixtureGraph());
+
+      final results = List.generate(
+        5,
+        (_) => engine.search(
+          const RouteRequest(
+            originStationId: 'station-a',
+            destinationStationId: 'station-d',
+            mobilityType: MobilityType.senior,
+          ),
+        ),
+      );
+
+      for (final result in results) {
+        expect(result.status, RouteStatus.found);
+        expect(result.edgeIds, [
+          'entry-a-line-1',
+          'ride-a-b-line-1',
+          'ride-b-d-line-1',
+          'exit-d-line-1',
+        ]);
+        expect(result.totalCost, 398);
+        expect(result.blockedReasonCodes, isEmpty);
+      }
+    });
+
     test('generated connector edge 비율을 일반 접근성 edge와 별도로 계산한다', () {
       final graph = NetworkGraph(
         nodes: const [
@@ -572,6 +599,70 @@ void main() {
       ]);
     });
   });
+}
+
+NetworkGraph _improvedCandidateFixtureGraph() {
+  return NetworkGraph(
+    nodes: const [
+      RouteNode(
+        id: 'station-a:line-1',
+        stationId: 'station-a',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-b:line-1',
+        stationId: 'station-b',
+        lineId: 'line-1',
+      ),
+      RouteNode(
+        id: 'station-d:line-1',
+        stationId: 'station-d',
+        lineId: 'line-1',
+      ),
+    ],
+    edges: const [
+      RouteEdge(
+        id: 'entry-a-line-1',
+        fromNodeId: 'station-a',
+        toNodeId: 'station-a:line-1',
+        type: RouteEdgeType.entry,
+        baseCost: 90,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+      RouteEdge(
+        id: 'ride-a-d-expensive-line-1',
+        fromNodeId: 'station-a:line-1',
+        toNodeId: 'station-d:line-1',
+        type: RouteEdgeType.ride,
+        baseCost: 500,
+        lineId: 'line-1',
+      ),
+      RouteEdge(
+        id: 'ride-a-b-line-1',
+        fromNodeId: 'station-a:line-1',
+        toNodeId: 'station-b:line-1',
+        type: RouteEdgeType.ride,
+        baseCost: 100,
+        lineId: 'line-1',
+      ),
+      RouteEdge(
+        id: 'ride-b-d-line-1',
+        fromNodeId: 'station-b:line-1',
+        toNodeId: 'station-d:line-1',
+        type: RouteEdgeType.ride,
+        baseCost: 100,
+        lineId: 'line-1',
+      ),
+      RouteEdge(
+        id: 'exit-d-line-1',
+        fromNodeId: 'station-d:line-1',
+        toNodeId: 'station-d',
+        type: RouteEdgeType.exit,
+        baseCost: 90,
+        stairAccessState: RouteStairAccessState.stepFree,
+      ),
+    ],
+  );
 }
 
 NetworkGraph _generatedConnectorFixtureGraph() {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2983,6 +2983,8 @@ test("경로 source contract 불변식은 접근성 안전과 metric fallback �
   const accessibilityCostCalculator = read(
     "apps/mobile/lib/features/routes/application/accessibility_cost_calculator.dart",
   );
+  const routeEngine = read("apps/mobile/lib/features/routes/application/route_engine.dart");
+  const mobilePubspec = read("apps/mobile/pubspec.yaml");
   const localRouteRepository = read("apps/mobile/lib/features/routes/data/local_route_repository.dart");
   const routeSearch = read("apps/mobile/lib/route_search.dart");
 
@@ -2992,6 +2994,12 @@ test("경로 source contract 불변식은 접근성 안전과 metric fallback �
   assert.match(accessibilityCostCalculator, /route contract: unknown accessibility data/);
   assert.match(accessibilityCostCalculator, /route contract: stair-only block/);
   assert.match(accessibilityCostCalculator, /route contract: generated connector strict block/);
+  assert.match(mobilePubspec, /^\s{2}collection:\s*\^/m);
+  assert.match(routeEngine, /PriorityQueue<_RouteCandidate>/);
+  assert.match(routeEngine, /class _RouteCandidate/);
+  assert.match(routeEngine, /sequence/);
+  assert.match(routeEngine, /candidate\.cost != bestCostByNode\[candidate\.nodeId\]/);
+  assert.doesNotMatch(routeEngine, /_lowestUnvisitedNode/);
   assert.match(localRouteRepository, /route contract: synthetic connector edge/);
   assert.match(localRouteRepository, /isGeneratedConnector: true/);
   assert.match(localRouteRepository, /route contract: local metric fallback/);


### PR DESCRIPTION
## Summary

- Replaced `AccessGraphRouter` lowest-cost scan with a `PriorityQueue<_RouteCandidate>`.
- Added deterministic cost/sequence tie-breaking and stale candidate skip.
- Promoted `collection` to a direct mobile dependency.
- Added route stability regression coverage and repository contract checks for the priority queue implementation.

Closes #1217.

## Verification

- Red: `node --test --test-name-pattern "경로 source contract" tools/ci/repository-contract.test.mjs` failed before implementation because `collection` was not direct and `PriorityQueue` was absent.
- `flutter test test/features/routes/route_engine_test.dart`
- `flutter analyze`
- `node --test tools/ci/repository-contract.test.mjs`
- `git diff --check`

## Evidence

- UI evidence is not required: this PR only changes the mobile route engine algorithm, dependency metadata, and tests. No presentation/UI files were modified.
