### PR TITLE
[Fix] manual deploy validation gh 의존 제거

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -156,21 +156,23 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          ci_url="$(
-            gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${DEPLOY_SHA}&branch=main&event=push&status=success&per_page=20" \
-              --jq '.workflow_runs[] | select(.name == "CI" and .conclusion == "success") | .html_url' \
-              | head -n 1
+          ci_runs="$(
+            curl -fsS \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${DEPLOY_SHA}&branch=main&event=push&status=success&per_page=20"
           )"
-          if [[ -z "${ci_url}" ]]; then
+          if ! grep -q '"name": "CI"' <<< "${ci_runs}"; then
             echo "manual deployment requires a successful CI workflow for ${DEPLOY_SHA}" >&2
             exit 1
           fi
 
-          echo "validated_ci_url=${ci_url}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "validated_ci_sha=${DEPLOY_SHA}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: CD Deploy / Restore GitHub Actions dotenv secret
         id: dotenv

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -527,6 +527,8 @@ test("지속적 배포 준비 상태는 단일 dotenv secret과 배포 설정을
   assert.match(workflow, /secrets\.EASYSUBWAY_ENV/);
   assert.match(workflow, /CD Deploy \/ Validate manual dispatch CI/);
   assert.match(workflow, /manual deployment requires a successful CI workflow/);
+  assert.match(workflow, /https:\/\/api\.github\.com\/repos\/\$\{GITHUB_REPOSITORY\}\/actions\/runs/);
+  assert.doesNotMatch(workflow, /\bgh api\b/);
   assert.match(workflow, /CD Deploy \/ Restore GitHub Actions dotenv secret/);
   assert.match(workflow, /CD Deploy \/ Restore GitHub Actions dotenv secret[\s\S]*?env:\s*\n\s*EASYSUBWAY_ENV_SECRET: \$\{\{ secrets\.EASYSUBWAY_ENV \}\}/);
   assert.match(workflow, /printf '%s' "\$\{EASYSUBWAY_ENV_SECRET\}" > "\$\{env_file\}"/);


### PR DESCRIPTION
## 관련 이슈
- 운영 public edge probe 알림 조사 중 manual CD가 self-hosted runner의 missing gh CLI 때문에 배포 전 검증에서 실패한 문제 수정

## Summary
- CD manual dispatch CI 검증을 runner-local gh CLI 대신 GitHub REST API curl 호출로 변경
- repository contract에 gh api 의존 금지와 REST API 사용을 고정

## Verification
- node --test tools/ci/repository-contract.test.mjs
