### PR TITLE
[Style] 노선도 검색창·좌측 메뉴 패밀리룩 정비

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -19,6 +19,14 @@ import 'station_search.dart';
 const _supermoveHeaderHeight = 60.0;
 const _networkMapBottomAdHeight = 52.0;
 const _supermovePillRadius = BorderRadius.all(Radius.circular(28));
+const _supermoveSearchFieldRadius = BorderRadius.all(Radius.circular(12));
+const _supermoveSearchFieldBorderColor = Color(0xFFDBE3E9);
+const _supermoveSearchFieldHintColor = Color(0xFF466467);
+const _supermoveSearchFieldIconColor = Color(0xFF8A9AA0);
+const _supermoveMenuIconColor = Color(0xFF466467);
+const _supermoveMenuLabelColor = Color(0xFF1E3234);
+const _supermoveMenuSectionColor = Color(0xFF7C949A);
+const _supermoveMenuChevronColor = Color(0xFFB0BEC5);
 
 abstract interface class NetworkMapRepository {
   Future<NetworkMapData> getNetworkMap({String? region, String? lineId});
@@ -999,7 +1007,7 @@ class _SupermoveSearchField extends StatelessWidget {
         child: InkWell(
           key: const Key('stationSearchButton'),
           onTap: onSearchTap,
-          borderRadius: _supermovePillRadius,
+          borderRadius: _supermoveSearchFieldRadius,
           child: LayoutBuilder(
             builder: (context, constraints) {
               final compact = constraints.maxWidth < 72;
@@ -1012,24 +1020,29 @@ class _SupermoveSearchField extends StatelessWidget {
                     decoration: BoxDecoration(
                       color: EasySubwayAccessibleColors.surface,
                       border: Border.all(
-                        color: const Color(0xFFE8E8E8),
-                        width: 2,
+                        color: _supermoveSearchFieldBorderColor,
+                        width: 1.5,
                       ),
-                      borderRadius: _supermovePillRadius,
+                      borderRadius: _supermoveSearchFieldRadius,
                     ),
-                    padding: EdgeInsets.symmetric(horizontal: compact ? 0 : 14),
+                    padding: EdgeInsets.symmetric(horizontal: compact ? 0 : 12),
                     child: compact
                         ? const SizedBox.shrink()
                         : const Row(
                             children: [
-                              SizedBox(width: 17),
+                              Icon(
+                                Icons.search,
+                                size: 18,
+                                color: _supermoveSearchFieldIconColor,
+                              ),
+                              SizedBox(width: 8),
                               Expanded(
                                 child: Text(
                                   '지하철역 검색',
                                   maxLines: 1,
                                   overflow: TextOverflow.ellipsis,
                                   style: TextStyle(
-                                    color: Color(0xFF666666),
+                                    color: _supermoveSearchFieldHintColor,
                                     fontSize: 15,
                                     fontWeight: FontWeight.w600,
                                   ),
@@ -1600,33 +1613,23 @@ class _SupermoveMapMenu extends StatelessWidget {
               children: [
                 const _SupermoveMenuHeader(),
                 const Divider(height: 1, color: Color(0xFFE4E4E4)),
+                const _SupermoveMenuSectionLabel('탐색'),
                 _SupermoveMenuTile(
                   key: const Key('networkMapMenuStationSearchButton'),
                   icon: Icons.search,
-                  iconColor: Color(0xFF00BFA5),
                   label: '역 검색',
                   onTap: () => _runAction(context, onOpenStationSearch),
                 ),
                 _SupermoveMenuTile(
                   key: const Key('networkMapMenuRouteSearchButton'),
                   icon: Icons.route_outlined,
-                  iconColor: Color(0xFF00BFA5),
                   label: '길찾기',
                   onTap: () => _runFutureAction(context, onOpenRouteSearch),
                 ),
-                if (onOpenSavedItems != null)
-                  _SupermoveMenuTile(
-                    key: const Key('networkMapMenuSavedButton'),
-                    icon: Icons.star_border_rounded,
-                    iconColor: Color(0xFF00BFA5),
-                    label: '즐겨찾기',
-                    onTap: () => _runAction(context, onOpenSavedItems!),
-                  ),
                 if (onOpenNearbyStations != null)
                   _SupermoveMenuTile(
                     key: const Key('networkMapMenuNearbyButton'),
                     icon: Icons.near_me_outlined,
-                    iconColor: Color(0xFFB7B7B7),
                     label: '가까운 역',
                     onTap: () => _runAction(context, onOpenNearbyStations!),
                   ),
@@ -1634,10 +1637,18 @@ class _SupermoveMapMenu extends StatelessWidget {
                   _SupermoveMenuTile(
                     key: const Key('networkMapMenuRecentButton'),
                     icon: Icons.history,
-                    iconColor: Color(0xFFB7B7B7),
                     label: '최근 검색',
                     onTap: () => _runAction(context, onOpenRecentSearch!),
                   ),
+                if (onOpenSavedItems != null) ...[
+                  const _SupermoveMenuSectionLabel('내 정보'),
+                  _SupermoveMenuTile(
+                    key: const Key('networkMapMenuSavedButton'),
+                    icon: Icons.star_border_rounded,
+                    label: '즐겨찾기',
+                    onTap: () => _runAction(context, onOpenSavedItems!),
+                  ),
+                ],
                 const SizedBox(height: 10),
                 const Divider(height: 1, color: Color(0xFFEDEDED)),
                 const _SupermoveMenuInfoBanner(),
@@ -1667,29 +1678,30 @@ class _SupermoveMenuHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Padding(
-      padding: EdgeInsets.fromLTRB(24, 8, 20, 8),
-      child: Row(
+      padding: EdgeInsets.fromLTRB(24, 14, 20, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          CircleAvatar(
-            radius: 24,
-            backgroundColor: Color(0xFFE9E9E9),
-            child: Icon(
-              Icons.accessible_forward,
-              size: 26,
-              color: Color(0xFFB9B9B9),
+          Text(
+            '쉬운 지하철',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: _supermoveMenuLabelColor,
+              fontSize: 21,
+              fontWeight: FontWeight.w800,
+              letterSpacing: -0.2,
             ),
           ),
-          SizedBox(width: 20),
-          Expanded(
-            child: Text(
-              '쉬운 지하철',
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                color: Color(0xFF7D7D7D),
-                fontSize: 22,
-                fontWeight: FontWeight.w900,
-              ),
+          SizedBox(height: 3),
+          Text(
+            '교통약자 지하철 길찾기',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: _supermoveMenuSectionColor,
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
             ),
           ),
         ],
@@ -1698,17 +1710,39 @@ class _SupermoveMenuHeader extends StatelessWidget {
   }
 }
 
+class _SupermoveMenuSectionLabel extends StatelessWidget {
+  const _SupermoveMenuSectionLabel(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 18, 24, 6),
+      child: Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: const TextStyle(
+          color: _supermoveMenuSectionColor,
+          fontSize: 13,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.2,
+        ),
+      ),
+    );
+  }
+}
+
 class _SupermoveMenuTile extends StatelessWidget {
   const _SupermoveMenuTile({
     required this.icon,
-    required this.iconColor,
     required this.label,
     required this.onTap,
     super.key,
   });
 
   final IconData icon;
-  final Color iconColor;
   final String label;
   final VoidCallback onTap;
 
@@ -1721,25 +1755,32 @@ class _SupermoveMenuTile extends StatelessWidget {
       child: ExcludeSemantics(
         child: InkWell(
           onTap: onTap,
+          highlightColor: const Color(0x14006D77),
+          splashColor: const Color(0x14006D77),
           child: SizedBox(
-            height: 58,
+            height: 52,
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 30),
+              padding: const EdgeInsets.symmetric(horizontal: 24),
               child: Row(
                 children: [
-                  Icon(icon, size: 28, color: iconColor),
-                  const SizedBox(width: 24),
+                  Icon(icon, size: 22, color: _supermoveMenuIconColor),
+                  const SizedBox(width: 18),
                   Expanded(
                     child: Text(
                       label,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: const TextStyle(
-                        color: Color(0xFF333333),
-                        fontSize: 23,
-                        fontWeight: FontWeight.w500,
+                        color: _supermoveMenuLabelColor,
+                        fontSize: 17,
+                        fontWeight: FontWeight.w600,
                       ),
                     ),
+                  ),
+                  const Icon(
+                    Icons.chevron_right,
+                    size: 20,
+                    color: _supermoveMenuChevronColor,
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary

- Closes #1357
- 노선도 첫 화면 상단 검색창을 pill(radius 28)에서 부드러운 사각 필드(radius 12)로 바꾸고, 좌측 검색 아이콘과 노선도 line 토큰(`#DBE3E9`) border를 적용해 카카오 지하철·슈퍼무브 감성의 검색바로 정리했습니다.
- 좌측 슬라이드 메뉴를 `탐색`(역 검색·길찾기·가까운 역·최근 검색)과 `내 정보`(즐겨찾기) 섹션으로 나누고 섹션 레이블을 추가했습니다.
- 메뉴 항목 아이콘 색을 제각각(`#00BFA5`/`#B7B7B7`)이던 것에서 단일 톤(mutedText)으로 통일하고, 폰트를 다운스케일(23sp -> 17sp)하며 각 항목 우측에 이동 표시 chevron을 붙였습니다.
- 메뉴 헤더의 장식용 원형 아바타를 제거하고 워드마크(제목 + 서브카피) 중심으로 단순화했습니다.
- 기존 메뉴 이동 동작과 test key(역 검색·길찾기·즐겨찾기·가까운 역·최근 검색)는 그대로 유지했습니다. 이모지는 사용하지 않았습니다.

## Verification

- `dart format lib/network_map.dart` (0 changed)
- `flutter analyze lib/network_map.dart` (No issues found)
- `flutter test test/widget_test.dart --plain-name "노선도 메뉴 길찾기는 길찾기 화면으로 전환한다" --reporter expanded`
- `flutter test test/widget_test.dart --plain-name "가까운 역 화면" --reporter expanded`
- `flutter test test/widget_test.dart --plain-name "노선도 첫 화면" --reporter compact`
- `flutter test test/widget_test.dart --plain-name "기본 앱은 저장소가 없어도 노선도 중심 첫 화면을 보여준다" --reporter compact`
- Android debug run on `RFKYA01VMQY` (SM A175N, 1080x2340)
- Android screenshot evidence (local `.codex`):
  - `.codex/tasks/family-look-drawer-search/easysubway-search-field.png`
  - `.codex/tasks/family-look-drawer-search/easysubway-drawer-menu.png`

## Notes

- 이번 PR은 노선도 화면 기준 패밀리룩의 기준점(검색창·좌측 메뉴)만 다룹니다. 역 검색/길찾기/즐겨찾기/내 제보/설정 등 개별 화면 내부 리디자인과, 메뉴에 알림·내 제보·이동 조건·설정 항목을 신규로 추가(콜백 배선 필요)하는 작업은 후속 이슈로 분리합니다.
- 시각 변경만 있어 백엔드 API와 기존 동작/test key에는 영향이 없습니다.
