### PR TITLE
[Test] Provider credential과 security boundary regression 검증

### DIFF
--- a/backend/src/main/java/com/easysubway/realtime/adapter/in/web/RealtimeController.java
+++ b/backend/src/main/java/com/easysubway/realtime/adapter/in/web/RealtimeController.java
@@ -1,16 +1,33 @@
 package com.easysubway.realtime.adapter.in.web;
 
+import com.easysubway.common.error.InvalidRequestException;
 import com.easysubway.common.web.ApiResponse;
 import com.easysubway.realtime.application.RealtimeArrivalResult;
 import com.easysubway.realtime.application.RealtimeGatewayService;
 import com.easysubway.realtime.application.RealtimeQuery;
 import com.easysubway.realtime.application.RealtimeTrainPositionResult;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Locale;
+import java.util.Set;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 class RealtimeController {
+
+	private static final Set<String> SECRET_BEARING_PARAMETER_NAMES = Set.of(
+		"apikey",
+		"api_key",
+		"key",
+		"providerurl",
+		"provider_url",
+		"secret",
+		"servicekey",
+		"service_key",
+		"token",
+		"url"
+	);
 
 	private final RealtimeGatewayService realtimeGatewayService;
 
@@ -23,8 +40,10 @@ class RealtimeController {
 		@RequestParam String stationId,
 		@RequestParam(required = false) String lineId,
 		@RequestParam(required = false) String providerLineId,
-		@RequestParam String stationQueryName
+		@RequestParam String stationQueryName,
+		HttpServletRequest request
 	) {
+		rejectSecretBearingProviderParameters(request);
 		return ApiResponse.ok(realtimeGatewayService.arrivals(new RealtimeQuery(
 			stationId,
 			lineId,
@@ -38,8 +57,10 @@ class RealtimeController {
 	ApiResponse<RealtimeTrainPositionResult> trainPositions(
 		@RequestParam(required = false) String lineId,
 		@RequestParam(required = false) String providerLineId,
-		@RequestParam String lineName
+		@RequestParam String lineName,
+		HttpServletRequest request
 	) {
+		rejectSecretBearingProviderParameters(request);
 		return ApiResponse.ok(realtimeGatewayService.trainPositions(new RealtimeQuery(
 			null,
 			lineId,
@@ -47,5 +68,14 @@ class RealtimeController {
 			null,
 			lineName
 		)));
+	}
+
+	private void rejectSecretBearingProviderParameters(HttpServletRequest request) {
+		for (String parameterName : request.getParameterMap().keySet()) {
+			String normalized = parameterName.toLowerCase(Locale.ROOT).replace("-", "_");
+			if (SECRET_BEARING_PARAMETER_NAMES.contains(normalized)) {
+				throw new InvalidRequestException("실시간 provider credential은 앱/API 요청에 포함할 수 없습니다.");
+			}
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
@@ -467,7 +467,7 @@ public class RealtimeGatewayService {
 	}
 
 	private String safeFallbackCode(String fallbackCode) {
-		return SAFE_FALLBACK_CODES.contains(fallbackCode) ? fallbackCode : "PROVIDER_ERROR";
+		return fallbackCode != null && SAFE_FALLBACK_CODES.contains(fallbackCode) ? fallbackCode : "PROVIDER_ERROR";
 	}
 
 	private static final class ProviderCallRateLimiter {

--- a/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
@@ -15,6 +15,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,15 +30,25 @@ public class RealtimeGatewayService {
 	private static final Duration STALE_TTL = Duration.ofSeconds(120);
 	private static final Duration PROVIDER_FRESHNESS_TTL = Duration.ofSeconds(90);
 	private static final Duration QUOTA_CIRCUIT_OPEN = Duration.ofSeconds(60);
+	private static final int DEFAULT_PROVIDER_CALL_LIMIT_PER_MINUTE = 120;
 	private static final ZoneId PROVIDER_ZONE = ZoneId.of("Asia/Seoul");
 	private static final DateTimeFormatter PROVIDER_TIMESTAMP_FORMATTER =
 		DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 	private static final String PROVIDER_ID = "seoul-topis";
+	private static final Set<String> SAFE_FALLBACK_CODES = Set.of(
+		"EMPTY_PROVIDER_RESULT",
+		"PROVIDER_ERROR",
+		"PROVIDER_QUOTA_EXCEEDED",
+		"PROVIDER_RATE_LIMITED",
+		"PROVIDER_TIMEOUT",
+		"PROVIDER_UNAVAILABLE"
+	);
 
 	private final RealtimeProvider provider;
 	private final RealtimeMappingPort mappingPort;
 	private final Clock clock;
 	private final RealtimeProviderControl providerControl;
+	private final ProviderCallRateLimiter providerCallRateLimiter;
 	private final ProviderMetrics providerMetrics = new ProviderMetrics();
 	private final Map<String, CachedArrival> arrivalCache = new ConcurrentHashMap<>();
 	private final Map<String, CachedTrainPosition> trainPositionCache = new ConcurrentHashMap<>();
@@ -64,10 +75,21 @@ public class RealtimeGatewayService {
 		RealtimeMappingPort mappingPort,
 		RealtimeProviderControl providerControl
 	) {
+		this(provider, clock, mappingPort, providerControl, DEFAULT_PROVIDER_CALL_LIMIT_PER_MINUTE);
+	}
+
+	RealtimeGatewayService(
+		RealtimeProvider provider,
+		Clock clock,
+		RealtimeMappingPort mappingPort,
+		RealtimeProviderControl providerControl,
+		int providerCallLimitPerMinute
+	) {
 		this.provider = provider;
 		this.clock = clock;
 		this.mappingPort = mappingPort;
 		this.providerControl = providerControl;
+		this.providerCallRateLimiter = new ProviderCallRateLimiter(providerCallLimitPerMinute);
 	}
 
 	public RealtimeArrivalResult arrivals(RealtimeQuery query) {
@@ -105,6 +127,11 @@ public class RealtimeGatewayService {
 			return recordArrivalResult(joinArrival(existing));
 		}
 		try {
+			if (!providerCallRateLimiter.tryAcquire(clock.instant())) {
+				RealtimeArrivalResult result = RealtimeArrivalResult.unavailable("PROVIDER_RATE_LIMITED");
+				request.complete(result);
+				return recordArrivalResult(result);
+			}
 			RealtimeArrivalResult result = fetchArrivals(normalizedQuery.query(), cacheKey, cached);
 			request.complete(result);
 			return recordArrivalResult(result);
@@ -136,9 +163,10 @@ public class RealtimeGatewayService {
 			arrivalCache.put(cacheKey, new CachedArrival(result, receivedAt));
 			return result;
 		} catch (RealtimeProviderException exception) {
-			providerMetrics.recordProviderException(exception.fallbackCode());
+			String fallbackCode = safeFallbackCode(exception.fallbackCode());
+			providerMetrics.recordProviderException(fallbackCode);
 			openQuotaCircuitIfNeeded(exception);
-			return staleArrivalOrUnavailable(cached, exception.fallbackCode());
+			return staleArrivalOrUnavailable(cached, fallbackCode);
 		} finally {
 			providerMetrics.recordProviderCall(Duration.between(providerCallStartedAt, clock.instant()));
 		}
@@ -178,6 +206,11 @@ public class RealtimeGatewayService {
 			return recordTrainPositionResult(joinTrainPosition(existing));
 		}
 		try {
+			if (!providerCallRateLimiter.tryAcquire(clock.instant())) {
+				RealtimeTrainPositionResult result = RealtimeTrainPositionResult.unavailable("PROVIDER_RATE_LIMITED");
+				request.complete(result);
+				return recordTrainPositionResult(result);
+			}
 			RealtimeTrainPositionResult result = fetchTrainPositions(normalizedQuery.query(), cacheKey, cached);
 			request.complete(result);
 			return recordTrainPositionResult(result);
@@ -213,9 +246,10 @@ public class RealtimeGatewayService {
 			trainPositionCache.put(cacheKey, new CachedTrainPosition(result, receivedAt));
 			return result;
 		} catch (RealtimeProviderException exception) {
-			providerMetrics.recordProviderException(exception.fallbackCode());
+			String fallbackCode = safeFallbackCode(exception.fallbackCode());
+			providerMetrics.recordProviderException(fallbackCode);
 			openQuotaCircuitIfNeeded(exception);
-			return staleTrainPositionOrUnavailable(cached, exception.fallbackCode());
+			return staleTrainPositionOrUnavailable(cached, fallbackCode);
 		} finally {
 			providerMetrics.recordProviderCall(Duration.between(providerCallStartedAt, clock.instant()));
 		}
@@ -429,6 +463,33 @@ public class RealtimeGatewayService {
 	private void openQuotaCircuitIfNeeded(RealtimeProviderException exception) {
 		if ("PROVIDER_QUOTA_EXCEEDED".equals(exception.fallbackCode())) {
 			quotaCircuitOpenUntil = clock.instant().plus(QUOTA_CIRCUIT_OPEN);
+		}
+	}
+
+	private String safeFallbackCode(String fallbackCode) {
+		return SAFE_FALLBACK_CODES.contains(fallbackCode) ? fallbackCode : "PROVIDER_ERROR";
+	}
+
+	private static final class ProviderCallRateLimiter {
+		private final int limitPerMinute;
+		private long windowMinute = Long.MIN_VALUE;
+		private int calls;
+
+		private ProviderCallRateLimiter(int limitPerMinute) {
+			this.limitPerMinute = Math.max(1, limitPerMinute);
+		}
+
+		private synchronized boolean tryAcquire(Instant now) {
+			long minute = now.getEpochSecond() / 60;
+			if (minute != windowMinute) {
+				windowMinute = minute;
+				calls = 0;
+			}
+			if (calls >= limitPerMinute) {
+				return false;
+			}
+			calls += 1;
+			return true;
 		}
 	}
 

--- a/backend/src/test/java/com/easysubway/realtime/adapter/in/web/RealtimeControllerTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/adapter/in/web/RealtimeControllerTest.java
@@ -1,6 +1,9 @@
 package com.easysubway.realtime.adapter.in.web;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -52,6 +55,35 @@ class RealtimeControllerTest {
 			.andExpect(jsonPath("$.data.status").value("UNSUPPORTED"))
 			.andExpect(jsonPath("$.data.fallbackCode").value("MAPPING_MISSING"))
 			.andExpect(jsonPath("$.data.message").value("서울 TOPIS 실시간 지원 범위 밖입니다."));
+	}
+
+	@Test
+	@DisplayName("공개 실시간 API는 provider credential query parameter를 받지 않는다")
+	void realtimePublicApiRejectsProviderCredentialParameters() throws Exception {
+		mockMvc.perform(get("/api/v1/realtime/arrivals")
+				.param("stationId", "station-sangnoksu")
+				.param("lineId", "seoul-4")
+				.param("stationQueryName", "상록수")
+				.param("serviceKey", "raw-provider-secret"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").value("실시간 provider credential은 앱/API 요청에 포함할 수 없습니다."))
+			.andExpect(content().string(not(containsString("raw-provider-secret"))))
+			.andExpect(content().string(not(containsString("상록수"))));
+	}
+
+	@Test
+	@DisplayName("열차 위치 API도 provider URL proxy parameter를 거부한다")
+	void trainPositionsRejectProviderUrlProxyParameter() throws Exception {
+		mockMvc.perform(get("/api/v1/realtime/train-positions")
+				.param("lineId", "seoul-4")
+				.param("lineName", "4호선")
+				.param("providerUrl", "http://swopenapi.seoul.go.kr/api/subway/raw-key/json/realtimePosition/0/10/4호선"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(content().string(not(containsString("raw-key"))))
+			.andExpect(content().string(not(containsString("swopenapi.seoul.go.kr"))))
+			.andExpect(content().string(not(containsString("4호선"))));
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
@@ -183,6 +183,56 @@ class RealtimeGatewayServiceTest {
 	}
 
 	@Test
+	@DisplayName("provider call rate limit은 cache miss 남용을 외부 provider 호출 전에 차단한다")
+	void providerRateLimitBlocksRepeatedCacheMissesBeforeProviderCall() {
+		MutableClock clock = new MutableClock(Instant.parse("2026-06-26T08:00:00Z"));
+		CountingProvider provider = new CountingProvider();
+		RealtimeGatewayService service = service(
+			provider,
+			clock,
+			InMemoryRealtimeMappingPort.seededFixture(),
+			new RealtimeProviderControl(),
+			1
+		);
+		RealtimeQuery query = sangnoksuQuery();
+
+		RealtimeArrivalResult first = service.arrivals(query);
+		clock.instant = Instant.parse("2026-06-26T08:00:30Z");
+		provider.providerReceivedAt = "2026-06-26T08:00:30Z";
+		RealtimeArrivalResult limited = service.arrivals(query);
+
+		assertThat(first.status()).hasToString("FRESH");
+		assertThat(limited.status()).hasToString("UNAVAILABLE");
+		assertThat(limited.fallbackCode()).isEqualTo("PROVIDER_RATE_LIMITED");
+		assertThat(provider.arrivalCalls).hasValue(1);
+	}
+
+	@Test
+	@DisplayName("provider fallback code는 allowlist 밖 값을 API/metric으로 노출하지 않는다")
+	void providerFallbackCodeIsAllowlistedBeforeExposure() {
+		CountingProvider provider = new CountingProvider();
+		provider.failureCode = "PROVIDER_TIMEOUT serviceKey=raw-secret stationQueryName=상록수 trainNo=4123";
+		RealtimeGatewayService service = service(
+			provider,
+			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
+		);
+
+		RealtimeArrivalResult result = service.arrivals(sangnoksuQuery());
+		RealtimeProviderHealthSnapshot snapshot = service.providerHealthSnapshot();
+
+		assertThat(result.status()).hasToString("UNAVAILABLE");
+		assertThat(result.fallbackCode()).isEqualTo("PROVIDER_ERROR");
+		assertThat(result.toString())
+			.doesNotContain("raw-secret")
+			.doesNotContain("상록수")
+			.doesNotContain("4123");
+		assertThat(snapshot.toString())
+			.doesNotContain("raw-secret")
+			.doesNotContain("상록수")
+			.doesNotContain("4123");
+	}
+
+	@Test
 	@DisplayName("열차 위치 quota 초과도 circuit을 열고 다음 요청에서 provider를 호출하지 않는다")
 	void trainPositionQuotaExhaustionOpensCircuit() {
 		MutableClock clock = new MutableClock(Instant.parse("2026-06-26T08:00:00Z"));
@@ -723,6 +773,16 @@ class RealtimeGatewayServiceTest {
 		RealtimeProviderControl control
 	) {
 		return new RealtimeGatewayService(provider, clock, mappingPort, control);
+	}
+
+	private RealtimeGatewayService service(
+		RealtimeProvider provider,
+		Clock clock,
+		RealtimeMappingPort mappingPort,
+		RealtimeProviderControl control,
+		int providerCallLimitPerMinute
+	) {
+		return new RealtimeGatewayService(provider, clock, mappingPort, control, providerCallLimitPerMinute);
 	}
 
 	private RealtimeMapping mapping(

--- a/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
@@ -233,6 +233,57 @@ class RealtimeGatewayServiceTest {
 	}
 
 	@Test
+	@DisplayName("열차 위치 provider call rate limit도 cache miss 남용을 외부 provider 호출 전에 차단한다")
+	void trainPositionProviderRateLimitBlocksRepeatedCacheMissesBeforeProviderCall() {
+		MutableClock clock = new MutableClock(Instant.parse("2026-06-26T08:00:00Z"));
+		CountingProvider provider = new CountingProvider();
+		RealtimeGatewayService service = service(
+			provider,
+			clock,
+			InMemoryRealtimeMappingPort.seededFixture(),
+			new RealtimeProviderControl(),
+			1
+		);
+		RealtimeQuery query = line4Query();
+
+		RealtimeTrainPositionResult first = service.trainPositions(query);
+		clock.instant = Instant.parse("2026-06-26T08:00:30Z");
+		provider.providerReceivedAt = "2026-06-26T08:00:30Z";
+		RealtimeTrainPositionResult limited = service.trainPositions(query);
+
+		assertThat(first.status()).hasToString("FRESH");
+		assertThat(limited.status()).hasToString("UNAVAILABLE");
+		assertThat(limited.fallbackCode()).isEqualTo("PROVIDER_RATE_LIMITED");
+		assertThat(provider.trainPositionCalls).hasValue(1);
+	}
+
+	@Test
+	@DisplayName("열차 위치 provider fallback code도 allowlist 밖 값을 API/metric으로 노출하지 않는다")
+	void trainPositionProviderFallbackCodeIsAllowlistedBeforeExposure() {
+		CountingProvider provider = new CountingProvider();
+		provider.failureCode = "PROVIDER_TIMEOUT serviceKey=raw-secret lineName=4호선 trainNo=4123";
+		RealtimeGatewayService service = service(
+			provider,
+			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
+		);
+
+		RealtimeTrainPositionResult result = service.trainPositions(line4Query());
+		RealtimeProviderHealthSnapshot snapshot = service.providerHealthSnapshot();
+
+		assertThat(result.status()).hasToString("UNAVAILABLE");
+		assertThat(result.fallbackCode()).isEqualTo("PROVIDER_ERROR");
+		assertThat(result.toString())
+			.doesNotContain("raw-secret")
+			.doesNotContain("4호선")
+			.doesNotContain("4123");
+		assertThat(snapshot.toString())
+			.doesNotContain("raw-secret")
+			.doesNotContain("4호선")
+			.doesNotContain("4123");
+		assertThat(provider.trainPositionCalls).hasValue(1);
+	}
+
+	@Test
 	@DisplayName("열차 위치 quota 초과도 circuit을 열고 다음 요청에서 provider를 호출하지 않는다")
 	void trainPositionQuotaExhaustionOpensCircuit() {
 		MutableClock clock = new MutableClock(Instant.parse("2026-06-26T08:00:00Z"));

--- a/tools/ci/provider-security-boundary.test.mjs
+++ b/tools/ci/provider-security-boundary.test.mjs
@@ -49,7 +49,7 @@ test("provider credential과 release artifact security boundary regression을 �
   for (const [file, content] of mobileTrackedSource) {
     assert.doesNotMatch(content, /swopenapi\.seoul\.go\.kr/i, `${file} must not call TOPIS directly`);
     assert.doesNotMatch(content, /EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY/i, `${file} must not reference backend TOPIS key`);
-    assert.doesNotMatch(content, /(?:serviceKey|apiKey|providerUrl|provider_url)=/i, `${file} must not carry provider credential query`);
+    assert.doesNotMatch(content, /["']?(?:serviceKey|apiKey|providerUrl|provider_url)["']?\s*(?:=|:)/i, `${file} must not carry provider credential fields`);
   }
 });
 

--- a/tools/ci/provider-security-boundary.test.mjs
+++ b/tools/ci/provider-security-boundary.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
@@ -19,6 +20,7 @@ test("provider credential과 release artifact security boundary regression을 �
   const abuseGate = readJson("apps/mobile/release/abuse-penetration-rehearsal-gate.json");
   const releaseArtifactsWorkflow = read(".github/workflows/release-artifacts.yml");
   const androidBuildGradle = read("apps/mobile/android/app/build.gradle.kts");
+  const mobileTrackedSource = trackedFiles("apps/mobile").map((file) => [file, read(file)]);
 
   const providerStorageExposureGuard = releaseSecurityGate.items.find(
     (item) => item.id === "repository_provider_storage_exposure_guard",
@@ -43,4 +45,17 @@ test("provider credential과 release artifact security boundary regression을 �
   assert.doesNotMatch(releaseArtifactsWorkflow, /EASYSUBWAY_OBJECT_STORAGE_(?:ACCESS_KEY|SECRET_KEY|ENDPOINT|REGION)/);
   assert.doesNotMatch(releaseArtifactsWorkflow, /EASYSUBWAY_[A-Z0-9_]*(?:PROVIDER|REALTIME)[A-Z0-9_]*KEY/);
   assert.doesNotMatch(androidBuildGradle, /EASYSUBWAY_OBJECT_STORAGE|PROVIDER_API_KEY|REALTIME_PROVIDER_KEY/);
+
+  for (const [file, content] of mobileTrackedSource) {
+    assert.doesNotMatch(content, /swopenapi\.seoul\.go\.kr/i, `${file} must not call TOPIS directly`);
+    assert.doesNotMatch(content, /EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY/i, `${file} must not reference backend TOPIS key`);
+    assert.doesNotMatch(content, /(?:serviceKey|apiKey|providerUrl|provider_url)=/i, `${file} must not carry provider credential query`);
+  }
 });
+
+function trackedFiles(prefix) {
+  return execFileSync("git", ["ls-files", prefix], { cwd: root, encoding: "utf8" })
+    .split("\n")
+    .filter(Boolean)
+    .filter((file) => /\.(dart|gradle|kts|xml|json|ya?ml|properties|plist|swift|kt)$/.test(file));
+}


### PR DESCRIPTION
## Summary
- Reject secret-bearing realtime provider query parameters at the public backend API boundary.
- Add provider-call rate limiting and fallback-code allowlisting before provider errors reach API responses or health metrics.
- Extend provider security contract scanning so tracked mobile source cannot reference TOPIS direct endpoints or backend TOPIS keys.

## Issue
Closes #1239

## Evidence
| Type | Result |
| --- | --- |
| Backend regression | `cd backend && ./gradlew test --tests '*Realtime*' --tests '*Security*'` pass |
| Repository contract | `node --test tools/ci/repository-contract.test.mjs` pass |
| Provider boundary contract | `node --test tools/ci/provider-security-boundary.test.mjs` pass |
| Whitespace | `git diff --check` pass |

## QA note
- UI/screenshot evidence is not required: this change is backend/API and CI regression coverage only.
- No mobile UI files were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 실시간 도착/열차 위치 API에서 민감한 요청 파라미터가 포함되면 즉시 거부하도록 강화되었습니다.
  * 외부 호출 빈도 제한이 추가되어 과도한 요청 시 자동으로 차단됩니다.

* **Bug Fixes**
  * 외부 오류 코드 처리 시 민감한 값이 응답이나 상태 정보에 노출되지 않도록 개선되었습니다.
  * 관련 보안 검증 테스트가 확대되어 민감 정보 유출 가능성을 더 엄격하게 점검합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->