### PR TITLE
[Style] 내 제보 상태 배지 색상 체계와 빈 상태 정비

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -90,6 +90,12 @@ _ReportStatusPresentation _reportStatusPresentation(String status) {
       foreground: EasySubwayAccessibleColors.red,
       icon: Icons.cancel_outlined,
     ),
+    'DUPLICATE' => const _ReportStatusPresentation(
+      background: _reportStatusNeutralColor,
+      border: EasySubwayAccessibleColors.line,
+      foreground: EasySubwayAccessibleColors.mutedText,
+      icon: Icons.content_copy_outlined,
+    ),
     _ => const _ReportStatusPresentation(
       background: _reportStatusNeutralColor,
       border: EasySubwayAccessibleColors.line,

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -43,6 +43,61 @@ const _facilityReportPagePadding = EdgeInsets.only(
   bottom: 32,
 );
 const _facilityReportCardRadius = BorderRadius.all(Radius.circular(8));
+const _reportStatusSkyBorderColor = Color(0xFFC0E0F5);
+const _reportStatusSkyTextColor = Color(0xFF17527C);
+const _reportStatusAmberBorderColor = Color(0xFFF1D49A);
+const _reportStatusRedBorderColor = Color(0xFFF3C7C2);
+const _reportStatusNeutralColor = Color(0xFFEEF2F4);
+
+/// 제보 상태(FacilityReportStatus)를 상태별 배지 색상·아이콘으로 매핑한다.
+class _ReportStatusPresentation {
+  const _ReportStatusPresentation({
+    required this.background,
+    required this.border,
+    required this.foreground,
+    required this.icon,
+  });
+
+  final Color background;
+  final Color border;
+  final Color foreground;
+  final IconData icon;
+}
+
+_ReportStatusPresentation _reportStatusPresentation(String status) {
+  return switch (status) {
+    'SUBMITTED' => const _ReportStatusPresentation(
+      background: EasySubwayAccessibleColors.skySoft,
+      border: _reportStatusSkyBorderColor,
+      foreground: _reportStatusSkyTextColor,
+      icon: Icons.inbox_outlined,
+    ),
+    'UNDER_REVIEW' => const _ReportStatusPresentation(
+      background: EasySubwayAccessibleColors.amberSoft,
+      border: _reportStatusAmberBorderColor,
+      foreground: EasySubwayAccessibleColors.amber,
+      icon: Icons.hourglass_bottom_outlined,
+    ),
+    'ACCEPTED' || 'RESOLVED' => const _ReportStatusPresentation(
+      background: EasySubwayAccessibleColors.mintSoft,
+      border: EasySubwayAccessibleColors.mintBorder,
+      foreground: EasySubwayAccessibleColors.mintDark,
+      icon: Icons.check_circle_outline,
+    ),
+    'REJECTED' => const _ReportStatusPresentation(
+      background: EasySubwayAccessibleColors.redSoft,
+      border: _reportStatusRedBorderColor,
+      foreground: EasySubwayAccessibleColors.red,
+      icon: Icons.cancel_outlined,
+    ),
+    _ => const _ReportStatusPresentation(
+      background: _reportStatusNeutralColor,
+      border: EasySubwayAccessibleColors.line,
+      foreground: EasySubwayAccessibleColors.mutedText,
+      icon: Icons.info_outline,
+    ),
+  };
+}
 
 abstract class FacilityReportRepository {
   Future<FacilityReportResult> createReport(FacilityReportRequest request);
@@ -1390,14 +1445,42 @@ class _MyReportEmpty extends StatelessWidget {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(24),
-        child: Text(
-          '접수한 제보가 없습니다.',
-          textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: EasySubwayAccessibleColors.text,
-            fontWeight: FontWeight.w900,
-            height: 1.3,
-          ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 64,
+              height: 64,
+              decoration: const BoxDecoration(
+                color: EasySubwayAccessibleColors.mintSoft,
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(
+                Icons.receipt_long_outlined,
+                size: 32,
+                color: EasySubwayAccessibleColors.mintDark,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '접수한 제보가 없습니다.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                color: EasySubwayAccessibleColors.text,
+                fontWeight: FontWeight.w900,
+                height: 1.3,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '시설 제보를 남기면 여기에서 진행 상황을 확인할 수 있어요.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: EasySubwayAccessibleColors.mutedText,
+                height: 1.4,
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -1495,7 +1578,10 @@ class _MyReportListItem extends StatelessWidget {
                         ),
                       ),
                       const SizedBox(width: 12),
-                      _MyReportStatusPill(label: report.statusLabel),
+                      _MyReportStatusPill(
+                        status: report.status,
+                        label: report.statusLabel,
+                      ),
                     ],
                   ),
                   const SizedBox(height: 10),
@@ -1559,7 +1645,10 @@ class MyFacilityReportDetailScreen extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: 12),
-              _MyReportDetailStatus(label: report.statusLabel),
+              _MyReportDetailStatus(
+                status: report.status,
+                label: report.statusLabel,
+              ),
               const SizedBox(height: 24),
               _MyReportDetailRow(
                 label: '제보 번호',
@@ -1578,29 +1667,38 @@ class MyFacilityReportDetailScreen extends StatelessWidget {
 }
 
 class _MyReportDetailStatus extends StatelessWidget {
-  const _MyReportDetailStatus({required this.label});
+  const _MyReportDetailStatus({required this.status, required this.label});
 
+  final String status;
   final String label;
 
   @override
   Widget build(BuildContext context) {
+    final presentation = _reportStatusPresentation(status);
     return Align(
       alignment: Alignment.centerLeft,
       child: Container(
         decoration: BoxDecoration(
-          color: EasySubwayAccessibleColors.mintSoft,
+          color: presentation.background,
           borderRadius: _facilityReportCardRadius,
-          border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
+          border: Border.all(color: presentation.border),
         ),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-          child: Text(
-            label,
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: EasySubwayAccessibleColors.text,
-              fontWeight: FontWeight.w900,
-              height: 1.2,
-            ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(presentation.icon, size: 20, color: presentation.foreground),
+              const SizedBox(width: 8),
+              Text(
+                label,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: presentation.foreground,
+                  fontWeight: FontWeight.w900,
+                  height: 1.2,
+                ),
+              ),
+            ],
           ),
         ),
       ),
@@ -1642,27 +1740,36 @@ class _MyReportDetailRow extends StatelessWidget {
 }
 
 class _MyReportStatusPill extends StatelessWidget {
-  const _MyReportStatusPill({required this.label});
+  const _MyReportStatusPill({required this.status, required this.label});
 
+  final String status;
   final String label;
 
   @override
   Widget build(BuildContext context) {
+    final presentation = _reportStatusPresentation(status);
     return Container(
       decoration: BoxDecoration(
-        color: EasySubwayAccessibleColors.mintSoft,
+        color: presentation.background,
         borderRadius: _facilityReportCardRadius,
-        border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
+        border: Border.all(color: presentation.border),
       ),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        child: Text(
-          label,
-          style: Theme.of(context).textTheme.labelLarge?.copyWith(
-            color: EasySubwayAccessibleColors.text,
-            fontWeight: FontWeight.w900,
-            height: 1.2,
-          ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(presentation.icon, size: 15, color: presentation.foreground),
+            const SizedBox(width: 5),
+            Text(
+              label,
+              style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                color: presentation.foreground,
+                fontWeight: FontWeight.w900,
+                height: 1.2,
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -284,6 +284,16 @@ void main() {
           status: 'ACCEPTED',
           createdAt: '2026-06-15T09:00:00',
         ),
+        const FacilityReportResult(
+          id: 'report-3',
+          publicReceiptCode: 'ES-1003',
+          stationId: 'station-sangnoksu',
+          facilityId: 'facility-sangnoksu-elevator-2',
+          reportType: 'BROKEN',
+          description: '이미 접수된 제보입니다.',
+          status: 'DUPLICATE',
+          createdAt: '2026-06-15T10:00:00',
+        ),
       ],
     );
 
@@ -303,6 +313,9 @@ void main() {
 
     expect(find.text('내 제보'), findsOneWidget);
     expect(find.text('반영됨'), findsOneWidget);
+    expect(find.text('중복 제보'), findsOneWidget);
+    expect(find.byIcon(Icons.content_copy_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.info_outline), findsNothing);
     expect(find.text('출입문이 막혀 있습니다.'), findsOneWidget);
     expect(
       find.bySemanticsLabel(


### PR DESCRIPTION
## Summary

- Closes #1362
- 내 제보 목록·상세의 상태 배지가 상태와 무관하게 항상 같은 민트색이던 것을 백엔드 `FacilityReportStatus` 상태별 색상 체계로 바꿨습니다. 접수(sky)·확인 중(amber)·반영·확인 완료(mint)·반려(red)·중복(neutral)을 색과 outline 아이콘으로 한눈에 구분합니다.
- 목록(`_MyReportStatusPill`)과 상세(`_MyReportDetailStatus`)가 동일한 상태 표현 헬퍼(`_reportStatusPresentation`)를 공유합니다.
- 빈 상태(`_MyReportEmpty`)에 아이콘과 짧은 보조 문구를 더해 앱의 다른 빈 상태와 톤을 맞췄습니다. 기존 "접수한 제보가 없습니다." 문구와 짧은 형태, retry 버튼 없음은 유지했습니다.
- 상태 라벨 텍스트, test key, 시맨틱은 그대로 유지했습니다. 이모지는 사용하지 않았습니다.

## Verification

- `dart format lib/facility_report.dart` (0 changed)
- `flutter analyze lib/facility_report.dart` (No issues found)
- `flutter test test/widget_test.dart --plain-name "내 신고"` → 2 passed (목록 ACCEPTED=반영됨 배지 렌더 + 상세 상태 화면 이동)
- `flutter test test/widget_test.dart --plain-name "내 제보"` → 1 passed (빈 상태: 문구 유지, retry 버튼 없음)

## Notes

- 상태별 배지 색상은 populated 리스트/상세 위젯 테스트로 검증했습니다. 실기기 세션에는 이 익명 사용자의 제보 데이터가 없어 라이브 스크린샷으로는 populated 상태를 재현할 수 없어, 회귀는 위젯 테스트로 확인했습니다.
- 상태 색상은 기존 `EasySubwayAccessibleColors`(skySoft/amberSoft/mintSoft/redSoft) 토큰을 재사용해 앱 전역 상태 색 체계와 일치시켰습니다.
- 시각 변경 위주로 제보 접수/조회 로직과 백엔드 API에는 영향이 없습니다.
