### PR TITLE
[Style] 이동 조건 화면 안내 카드와 카드 모서리 정비

### DIFF
--- a/apps/mobile/lib/mobility_profile.dart
+++ b/apps/mobile/lib/mobility_profile.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'accessible_design.dart';
 
 const _mobilityProfilePagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
-const _mobilityProfileCardRadius = BorderRadius.all(Radius.circular(8));
+const _mobilityProfileCardRadius = BorderRadius.all(Radius.circular(16));
 
 class MobilityProfileOption {
   const MobilityProfileOption({
@@ -170,8 +170,8 @@ class _MobilityProfileScreenState extends State<MobilityProfileScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              _SelectionStatus(option: _selectedOption),
-              if (_selectedOption != null) const SizedBox(height: 12),
+              _MobilityGuidanceCard(option: _selectedOption),
+              const SizedBox(height: 16),
               for (final option in mobilityProfileOptions)
                 _MobilityProfileCard(
                   option: option,
@@ -278,26 +278,63 @@ class _MobilityProfileCard extends StatelessWidget {
   }
 }
 
-class _SelectionStatus extends StatelessWidget {
-  const _SelectionStatus({required this.option});
+class _MobilityGuidanceCard extends StatelessWidget {
+  const _MobilityGuidanceCard({required this.option});
 
   final MobilityProfileOption? option;
 
   @override
   Widget build(BuildContext context) {
     final selectedOption = option;
-    if (selectedOption == null) {
-      return const SizedBox.shrink();
-    }
-
+    final isSelected = selectedOption != null;
+    final message = isSelected
+        ? '\'${selectedOption.title}\' 조건을 선택했어요. 아래에서 바꿀 수 있어요.'
+        : '경로를 찾을 때 적용할 이동 조건을 선택하세요.';
     return Semantics(
       liveRegion: true,
-      child: Text(
-        '${selectedOption.title} 조건을 선택했습니다',
-        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-          color: EasySubwayAccessibleColors.text,
-          fontWeight: FontWeight.w800,
-          height: 1.35,
+      label: message,
+      child: ExcludeSemantics(
+        child: Container(
+          decoration: BoxDecoration(
+            color: EasySubwayAccessibleColors.mintSoft,
+            borderRadius: _mobilityProfileCardRadius,
+            border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 40,
+                  height: 40,
+                  alignment: Alignment.center,
+                  decoration: const BoxDecoration(
+                    color: EasySubwayAccessibleColors.surface,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    isSelected
+                        ? Icons.check_circle_outline
+                        : Icons.directions_walk,
+                    color: EasySubwayAccessibleColors.mintDark,
+                    size: 24,
+                  ),
+                ),
+                const SizedBox(width: 14),
+                Expanded(
+                  child: Text(
+                    message,
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: EasySubwayAccessibleColors.text,
+                      fontWeight: FontWeight.w800,
+                      height: 1.35,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -8532,7 +8532,7 @@ void main() {
         find.bySemanticsLabel('휠체어 이용 선택됨, 계단 없는 길만 안내해요'),
         findsOneWidget,
       );
-      expect(find.text('휠체어 이용 조건을 선택했습니다'), findsOneWidget);
+      expect(find.text("'휠체어 이용' 조건을 선택했어요. 아래에서 바꿀 수 있어요."), findsOneWidget);
       expect(find.bySemanticsLabel('선택 완료'), findsOneWidget);
     } finally {
       semanticsHandle.dispose();
@@ -8561,7 +8561,7 @@ void main() {
         find.bySemanticsLabel('휠체어 이용 선택됨, 계단 없는 길만 안내해요'),
         findsOneWidget,
       );
-      expect(find.text('휠체어 이용 조건을 선택했습니다'), findsOneWidget);
+      expect(find.text("'휠체어 이용' 조건을 선택했어요. 아래에서 바꿀 수 있어요."), findsOneWidget);
     } finally {
       semanticsHandle.dispose();
     }


### PR DESCRIPTION
## Summary

- Closes #1364
- 이동 조건 화면 상단에 항상 보이는 안내 카드를 추가했습니다. 선택 전에는 "경로를 찾을 때 적용할 이동 조건을 선택하세요.", 선택 후에는 선택한 조건을 확인하는 문구를 보여줘 맥락을 줍니다.
- 안내 카드는 앱 상태 색 토큰(mintSoft/mintBorder/mintDark)과 outline 아이콘(directions_walk/check_circle_outline)을 사용해 노선도·길찾기 패밀리룩과 맞췄습니다.
- 선택 카드 모서리를 radius 8 -> 16으로 정리해 길찾기 입력 카드 언어와 통일했습니다.
- 선택 카드의 선택 표시(primary border 2px, mintSoft 배경, check_circle)와 test key(`mobilityProfileCard-*`, `mobilityProfileDoneButton`), 카드 시맨틱은 그대로 유지했습니다.
- 이모지는 사용하지 않았습니다.

## Verification

- `dart format lib/mobility_profile.dart` (0 changed)
- `flutter analyze lib/mobility_profile.dart` (No issues found)
- `flutter test test/widget_test.dart --plain-name "이동 조건"` → 13 passed
- 안내 카드 확인 문구 변경에 맞춰 관련 widget test 기대값 2곳을 갱신했습니다.

## Notes

- 안내 카드는 기존 `_SelectionStatus`(선택 후에만 한 줄 텍스트)를 대체합니다. liveRegion 시맨틱을 유지해 선택 변경이 스크린리더로 안내됩니다.
- 이 화면은 앱 셸에서 설정 경유로만 도달하는데, 브랜치 격리 빌드에서는 설정 진입점이 없어 라이브 스크린샷을 재현할 수 없어 회귀는 위젯 테스트(선택/확인 카드 렌더 포함 13개)로 확인했습니다.
- 시각 변경 위주로 이동 조건 저장 로직과 백엔드 API에는 영향이 없습니다.
