### PR TITLE
[Style] 패밀리룩 디박싱: 상태 표현을 색 점·색 텍스트로 통일

### DIFF
--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -44,6 +44,18 @@ const _facilityReportPagePadding = EdgeInsets.only(
 );
 const _facilityReportCardRadius = BorderRadius.all(Radius.circular(8));
 
+/// 제보 상태(FacilityReportStatus)를 상태색으로 매핑한다. 박스 대신 색 점·색
+/// 텍스트로 상태를 구분하기 위한 전경색만 돌려준다.
+Color _reportStatusColor(String status) {
+  return switch (status) {
+    'SUBMITTED' => const Color(0xFF17527C),
+    'UNDER_REVIEW' => EasySubwayAccessibleColors.amber,
+    'ACCEPTED' || 'RESOLVED' => EasySubwayAccessibleColors.mintDark,
+    'REJECTED' => EasySubwayAccessibleColors.red,
+    _ => EasySubwayAccessibleColors.mutedText,
+  };
+}
+
 abstract class FacilityReportRepository {
   Future<FacilityReportResult> createReport(FacilityReportRequest request);
 
@@ -1390,14 +1402,34 @@ class _MyReportEmpty extends StatelessWidget {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(24),
-        child: Text(
-          '접수한 제보가 없습니다.',
-          textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: EasySubwayAccessibleColors.text,
-            fontWeight: FontWeight.w900,
-            height: 1.3,
-          ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.receipt_long_outlined,
+              size: 40,
+              color: EasySubwayAccessibleColors.mutedText,
+            ),
+            const SizedBox(height: 14),
+            Text(
+              '접수한 제보가 없습니다.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                color: EasySubwayAccessibleColors.text,
+                fontWeight: FontWeight.w900,
+                height: 1.3,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '시설 제보를 남기면 여기에서 진행 상황을 확인할 수 있어요.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: EasySubwayAccessibleColors.mutedText,
+                height: 1.4,
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -1495,7 +1527,10 @@ class _MyReportListItem extends StatelessWidget {
                         ),
                       ),
                       const SizedBox(width: 12),
-                      _MyReportStatusPill(label: report.statusLabel),
+                      _MyReportStatusLabel(
+                        status: report.status,
+                        label: report.statusLabel,
+                      ),
                     ],
                   ),
                   const SizedBox(height: 10),
@@ -1559,7 +1594,10 @@ class MyFacilityReportDetailScreen extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: 12),
-              _MyReportDetailStatus(label: report.statusLabel),
+              _MyReportDetailStatus(
+                status: report.status,
+                label: report.statusLabel,
+              ),
               const SizedBox(height: 24),
               _MyReportDetailRow(
                 label: '제보 번호',
@@ -1578,31 +1616,34 @@ class MyFacilityReportDetailScreen extends StatelessWidget {
 }
 
 class _MyReportDetailStatus extends StatelessWidget {
-  const _MyReportDetailStatus({required this.label});
+  const _MyReportDetailStatus({required this.status, required this.label});
 
+  final String status;
   final String label;
 
   @override
   Widget build(BuildContext context) {
+    final color = _reportStatusColor(status);
     return Align(
       alignment: Alignment.centerLeft,
-      child: Container(
-        decoration: BoxDecoration(
-          color: EasySubwayAccessibleColors.mintSoft,
-          borderRadius: _facilityReportCardRadius,
-          border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-          child: Text(
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 10,
+            height: 10,
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+          ),
+          const SizedBox(width: 8),
+          Text(
             label,
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: EasySubwayAccessibleColors.text,
+              color: color,
               fontWeight: FontWeight.w900,
               height: 1.2,
             ),
           ),
-        ),
+        ],
       ),
     );
   }
@@ -1641,30 +1682,33 @@ class _MyReportDetailRow extends StatelessWidget {
   }
 }
 
-class _MyReportStatusPill extends StatelessWidget {
-  const _MyReportStatusPill({required this.label});
+class _MyReportStatusLabel extends StatelessWidget {
+  const _MyReportStatusLabel({required this.status, required this.label});
 
+  final String status;
   final String label;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: EasySubwayAccessibleColors.mintSoft,
-        borderRadius: _facilityReportCardRadius,
-        border: Border.all(color: EasySubwayAccessibleColors.mintBorder),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        child: Text(
+    final color = _reportStatusColor(status);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 6),
+        Text(
           label,
           style: Theme.of(context).textTheme.labelLarge?.copyWith(
-            color: EasySubwayAccessibleColors.text,
+            color: color,
             fontWeight: FontWeight.w900,
             height: 1.2,
           ),
         ),
-      ),
+      ],
     );
   }
 }

--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -16,6 +16,17 @@ const _favoriteFacilityChangeErrorMessage = '즐겨찾기 시설을 바꾸지 �
 const _favoriteFacilityCardRadius = BorderRadius.all(Radius.circular(8));
 const _favoriteFacilityListPadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
 
+/// 시설 상태 심각도를 상태색으로 매핑한다. 박스 대신 색 점·색 텍스트로 상태를
+/// 구분하기 위한 전경색만 돌려준다.
+Color _favoriteFacilitySeverityColor(FacilityStatusSeverity severity) {
+  return switch (severity) {
+    FacilityStatusSeverity.blocked => EasySubwayAccessibleColors.red,
+    FacilityStatusSeverity.caution => EasySubwayAccessibleColors.amber,
+    FacilityStatusSeverity.needsInfo => const Color(0xFF17527C),
+    FacilityStatusSeverity.normal => EasySubwayAccessibleColors.mintDark,
+  };
+}
+
 abstract class FavoriteFacilityRepository {
   Future<List<FavoriteFacility>> listFavoriteFacilities();
 
@@ -629,6 +640,32 @@ class _FavoriteFacilityTile extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      Row(
+                        children: [
+                          Container(
+                            width: 9,
+                            height: 9,
+                            decoration: BoxDecoration(
+                              color: _favoriteFacilitySeverityColor(
+                                favorite.statusPresentation.severity,
+                              ),
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                          const SizedBox(width: 7),
+                          Text(
+                            favorite.severityLabel,
+                            style: textTheme.bodyMedium?.copyWith(
+                              color: _favoriteFacilitySeverityColor(
+                                favorite.statusPresentation.severity,
+                              ),
+                              fontWeight: FontWeight.w900,
+                              height: 1.2,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
                       Text(
                         favorite.name,
                         style: textTheme.titleLarge?.copyWith(
@@ -651,15 +688,6 @@ class _FavoriteFacilityTile extends StatelessWidget {
                         favorite.statusTitle,
                         style: textTheme.bodyMedium?.copyWith(
                           color: EasySubwayAccessibleColors.mutedText,
-                          height: 1.3,
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        '${favorite.severityLabel} · ${favorite.nextActionLabel}',
-                        style: textTheme.bodyMedium?.copyWith(
-                          color: EasySubwayAccessibleColors.mutedText,
-                          fontWeight: FontWeight.w700,
                           height: 1.3,
                         ),
                       ),

--- a/apps/mobile/lib/mobility_profile.dart
+++ b/apps/mobile/lib/mobility_profile.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'accessible_design.dart';
 
 const _mobilityProfilePagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
-const _mobilityProfileCardRadius = BorderRadius.all(Radius.circular(8));
+const _mobilityProfileCardRadius = BorderRadius.all(Radius.circular(16));
 
 class MobilityProfileOption {
   const MobilityProfileOption({

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2718,8 +2718,8 @@ class _RoutePointPickerCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 카카오/슈퍼무브식 출발(○)-도착(●) 노드는 각 역 행 안쪽에 두어 역명이
-    // 노드 뒤로 들여써지도록 한다. 입력 피커가 열리면 해당 행의 노드는 접힌다.
+    // 출발(○)-도착(●) 노드는 각 역 행 안쪽에 두어 역명이 노드 뒤로
+    // 들여써지도록 한다. 입력 피커가 열리면 해당 행의 노드는 접힌다.
     final originChild =
         originPicker ??
         _RoutePointRow(


### PR DESCRIPTION
## Summary

- Closes #1366
- Supersedes #1363, #1365
- 상태를 tinted 박스/칩으로 감싸던 표현을 걷어내고 **색 점 + 색 텍스트**로 통일했습니다. 이미 손댄 화면(내 제보·이동 조건)의 박스도 이 PR에서 함께 정리했습니다.
- **내 제보**: 목록/상세 상태 배지(mintSoft 박스)를 상태색 점 + 상태색 텍스트로 교체. 접수(sky)·확인 중(amber)·반영/완료(mint)·반려(red)·중복(neutral)으로 구분합니다. 빈 상태의 tinted 원 박스는 단순 outline 아이콘 + 문구로 정리했습니다.
- **즐겨찾기 시설**: 회색 텍스트로 뭉쳐 있던 상태를 상단 상태색 점 + severityLabel(색 텍스트)로 표현하고 중복 문구 한 줄을 정리했습니다.
- **이동 조건**: 상단 안내 박스 카드를 넣지 않고(원본 선택 안내 텍스트 유지), 선택 카드 모서리만 radius 16으로 정리했습니다.
- 상태 라벨 텍스트, test key, 시맨틱은 유지했습니다. 이모지는 사용하지 않았습니다.

## Verification

- `dart format` (0 changed) · `flutter analyze` (No issues found) — 3개 파일
- `flutter test --plain-name "내 신고"` → 2 passed
- `flutter test --plain-name "내 제보"` → 1 passed
- `flutter test --plain-name "즐겨찾기 시설"` → 2 passed
- `flutter test --plain-name "이동 조건"` → 13 passed

## Notes

- 이 PR은 #1363(내 제보 상태 색)과 #1365(이동 조건)를 대체합니다. 두 PR의 상태-색 표현 의도는 유지하되, 박스 대신 색 점·색 텍스트로 다시 구현했습니다.
- populated 상태(색 점·색 텍스트)는 위젯 테스트로 검증했습니다. 실기기 익명 세션에는 제보·즐겨찾기 시설 데이터가 없어 populated 상태를 라이브 스크린샷으로 재현할 수 없습니다.
- 시각 변경 위주로 저장 로직과 백엔드 API에는 영향이 없습니다.
