### PR TITLE
[Feat] Route quality observability dashboard 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchDashboardView.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchDashboardView.java
@@ -1,6 +1,7 @@
 package com.easysubway.route.adapter.in.web;
 
 import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteSearchDashboardSummary;
 import java.util.List;
 import java.util.Locale;
@@ -10,12 +11,17 @@ public record RouteSearchDashboardView(
 	long foundCount,
 	long blockedCount,
 	String blockedRateLabel,
+	String routeNotFoundRateLabel,
 	String blockedAlertLabel,
 	String blockedAlertDescription,
 	String blockedAlertClass,
 	List<MobilityTypeCountRow> mobilityTypeRows,
 	List<RegionUsageCountRow> regionUsageRows,
-	List<BlockedReasonCountRow> blockedReasonRows
+	List<BlockedReasonCountRow> blockedReasonRows,
+	List<EtaSourceCountRow> etaSourceRows,
+	List<FallbackReasonCountRow> fallbackReasonRows,
+	List<RouteQualitySignalRow> routeQualitySignalRows,
+	List<AlertThresholdRow> alertThresholdRows
 ) {
 
 	static RouteSearchDashboardView from(RouteSearchDashboardSummary summary) {
@@ -23,6 +29,7 @@ public record RouteSearchDashboardView(
 			summary.totalCount(),
 			summary.foundCount(),
 			summary.blockedCount(),
+			percentageLabel(summary.blockedCount(), summary.totalCount()),
 			percentageLabel(summary.blockedCount(), summary.totalCount()),
 			blockedAlertLabel(summary.blockedCount(), summary.totalCount()),
 			blockedAlertDescription(summary.blockedCount(), summary.totalCount()),
@@ -38,7 +45,20 @@ public record RouteSearchDashboardView(
 			summary.blockedReasonCounts()
 				.stream()
 				.map(row -> new BlockedReasonCountRow(row.reason(), row.count()))
-				.toList()
+				.toList(),
+			summary.etaSourceCounts()
+				.stream()
+				.map(row -> new EtaSourceCountRow(row.etaSource().name(), etaSourceLabel(row.etaSource()), row.count()))
+				.toList(),
+			summary.fallbackReasonCounts()
+				.stream()
+				.map(row -> new FallbackReasonCountRow(row.reason(), fallbackReasonLabel(row.reason()), row.count()))
+				.toList(),
+			summary.routeQualitySignalCounts()
+				.stream()
+				.map(row -> new RouteQualitySignalRow(row.signal(), routeQualitySignalLabel(row.signal()), row.count()))
+				.toList(),
+			defaultAlertThresholdRows()
 		);
 	}
 
@@ -49,6 +69,18 @@ public record RouteSearchDashboardView(
 	}
 
 	public record BlockedReasonCountRow(String reason, long count) {
+	}
+
+	public record EtaSourceCountRow(String code, String label, long count) {
+	}
+
+	public record FallbackReasonCountRow(String reason, String label, long count) {
+	}
+
+	public record RouteQualitySignalRow(String signal, String label, long count) {
+	}
+
+	public record AlertThresholdRow(String metric, String threshold, String action) {
 	}
 
 	private static String percentageLabel(long numerator, long denominator) {
@@ -100,5 +132,54 @@ public record RouteSearchDashboardView(
 			case TEMPORARY_INJURY -> "일시 부상";
 			case LUGGAGE -> "큰 짐 동반";
 		};
+	}
+
+	private static String etaSourceLabel(EtaSource etaSource) {
+		return switch (etaSource) {
+			case REALTIME -> "실시간 반영";
+			case MIXED -> "일부 실시간 반영";
+			case PLANNED -> "시간표 기준";
+			case FALLBACK -> "provider 지연/장애 fallback";
+		};
+	}
+
+	private static String fallbackReasonLabel(String reason) {
+		return switch (reason) {
+			case "PROVIDER_OUTAGE_OR_STALE_REALTIME" -> "provider 장애 또는 stale realtime";
+			case "ROUTE_GRAPH_OR_STRICT_ACCESSIBILITY_BLOCK" -> "route graph/accessibility data quality failure";
+			case "LOW_DATA_CONFIDENCE" -> "낮은 데이터 신뢰도";
+			case "STALE_ACCESSIBILITY_DATA" -> "오래된 접근성 데이터";
+			case "STRICT_STAIR_ONLY_ACCESS" -> "strict 조건 계단 전용 경로";
+			default -> reason;
+		};
+	}
+
+	private static String routeQualitySignalLabel(String signal) {
+		return switch (signal) {
+			case "PROVIDER_OUTAGE" -> "provider outage/stale";
+			case "ROUTE_GRAPH_DATA_QUALITY" -> "route graph/data quality";
+			case "STRICT_ACCESSIBILITY_BLOCK" -> "strict accessibility block";
+			default -> signal;
+		};
+	}
+
+	private static List<AlertThresholdRow> defaultAlertThresholdRows() {
+		return List.of(
+			new AlertThresholdRow(
+				"route_not_found_rate",
+				">= 2.0%",
+				"route graph/strict accessibility source review"
+			),
+			new AlertThresholdRow(
+				"PROVIDER_OUTAGE_OR_STALE_REALTIME",
+				"> 0",
+				"realtime provider health 확인"
+			),
+			new AlertThresholdRow(
+				"LOW_DATA_CONFIDENCE",
+				"> 0",
+				"data quality source 검수"
+			)
+		);
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/InMemoryRouteSearchRepository.java
@@ -7,6 +7,7 @@ import com.easysubway.route.application.port.out.SaveRouteSearchPort;
 import com.easysubway.route.application.port.out.SummarizeRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchBlockedReasons;
+import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchQualitySignals;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchStationPair;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteFeedbackDashboardSummary;
@@ -17,6 +18,7 @@ import com.easysubway.route.domain.RouteSearchDashboardSummary;
 import com.easysubway.route.domain.RouteSearchDashboardSummary.MobilityTypeCount;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.route.domain.RouteWarning;
 import com.easysubway.user.application.port.out.AnonymizeUserRouteFeedbackPort;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -118,6 +120,23 @@ public class InMemoryRouteSearchRepository
 				.stream()
 				.filter(routeSearch -> routeSearch.status() == RouteSearchStatus.BLOCKED)
 				.map(routeSearch -> new RouteSearchBlockedReasons(routeSearch.blockedReasons()))
+				.toList();
+		}
+	}
+
+	@Override
+	public List<RouteSearchQualitySignals> loadRouteSearchQualitySignalsForDashboard() {
+		synchronized (routeSearches) {
+			return routeSearches.values()
+				.stream()
+				.map(routeSearch -> new RouteSearchQualitySignals(
+					routeSearch.status(),
+					routeSearch.etaSource(),
+					routeSearch.warnings()
+						.stream()
+						.map(RouteWarning::code)
+						.toList()
+				))
 				.toList();
 		}
 	}

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
@@ -7,6 +7,7 @@ import com.easysubway.route.application.port.out.SaveRouteSearchPort;
 import com.easysubway.route.application.port.out.SummarizeRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchBlockedReasons;
+import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchQualitySignals;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchStationPair;
 import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.EtaSource;
@@ -245,6 +246,30 @@ public class JdbcRouteSearchRepository
 			(resultSet, rowNumber) -> new RouteSearchBlockedReasons(
 				readJson(resultSet.getString("blocked_reasons_json"), STRING_LIST_TYPE)
 			)
+		);
+	}
+
+	@Override
+	public List<RouteSearchQualitySignals> loadRouteSearchQualitySignalsForDashboard() {
+		return jdbcTemplate.query(
+			"""
+				SELECT status,
+					steps_json,
+					warnings_json
+				FROM route_search_results
+				ORDER BY created_at DESC, route_search_id
+				""",
+			(resultSet, rowNumber) -> {
+				List<RouteStep> steps = readJson(resultSet.getString("steps_json"), ROUTE_STEPS_TYPE);
+				List<RouteWarning> warnings = readJson(resultSet.getString("warnings_json"), ROUTE_WARNINGS_TYPE);
+				return new RouteSearchQualitySignals(
+					RouteSearchStatus.valueOf(resultSet.getString("status")),
+					etaSourceFromSteps(steps),
+					warnings.stream()
+						.map(RouteWarning::code)
+						.toList()
+				);
+			}
 		);
 	}
 
@@ -493,6 +518,24 @@ public class JdbcRouteSearchRepository
 			.filter(row -> row.mobilityType() == mobilityType)
 			.mapToLong(RouteSearchDashboardCountRow::count)
 			.sum();
+	}
+
+	private EtaSource etaSourceFromSteps(List<RouteStep> steps) {
+		if (steps.isEmpty()) {
+			return EtaSource.PLANNED;
+		}
+		boolean fallback = steps.stream()
+			.anyMatch(step -> EtaSource.FALLBACK.name().equals(step.timeSource()));
+		if (fallback) {
+			return EtaSource.FALLBACK;
+		}
+		long realtimeSteps = steps.stream()
+			.filter(step -> EtaSource.REALTIME.name().equals(step.timeSource()))
+			.count();
+		if (realtimeSteps == 0) {
+			return EtaSource.PLANNED;
+		}
+		return realtimeSteps == steps.size() ? EtaSource.REALTIME : EtaSource.MIXED;
 	}
 
 	private String writeJson(Object value) {

--- a/backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteSearchPort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/SummarizeRouteSearchPort.java
@@ -1,6 +1,9 @@
 package com.easysubway.route.application.port.out;
 
+import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteSearchDashboardSummary;
+import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.route.domain.RouteWarningCode;
 import java.util.List;
 
 public interface SummarizeRouteSearchPort {
@@ -11,6 +14,8 @@ public interface SummarizeRouteSearchPort {
 
 	List<RouteSearchBlockedReasons> loadRouteSearchBlockedReasonsForDashboard();
 
+	List<RouteSearchQualitySignals> loadRouteSearchQualitySignalsForDashboard();
+
 	record RouteSearchStationPair(String originStationId, String destinationStationId) {
 	}
 
@@ -18,6 +23,17 @@ public interface SummarizeRouteSearchPort {
 
 		public RouteSearchBlockedReasons {
 			blockedReasons = List.copyOf(blockedReasons);
+		}
+	}
+
+	record RouteSearchQualitySignals(
+		RouteSearchStatus status,
+		EtaSource etaSource,
+		List<RouteWarningCode> warningCodes
+	) {
+
+		public RouteSearchQualitySignals {
+			warningCodes = List.copyOf(warningCodes);
 		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchDashboardService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchDashboardService.java
@@ -3,10 +3,17 @@ package com.easysubway.route.application.service;
 import com.easysubway.route.application.port.in.RouteSearchDashboardUseCase;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchBlockedReasons;
+import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchQualitySignals;
 import com.easysubway.route.application.port.out.SummarizeRouteSearchPort.RouteSearchStationPair;
+import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteSearchDashboardSummary;
 import com.easysubway.route.domain.RouteSearchDashboardSummary.BlockedReasonCount;
+import com.easysubway.route.domain.RouteSearchDashboardSummary.EtaSourceCount;
+import com.easysubway.route.domain.RouteSearchDashboardSummary.FallbackReasonCount;
 import com.easysubway.route.domain.RouteSearchDashboardSummary.RegionUsageCount;
+import com.easysubway.route.domain.RouteSearchDashboardSummary.RouteQualitySignalCount;
+import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.route.domain.RouteWarningCode;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.transit.domain.Station;
 import java.util.Comparator;
@@ -35,14 +42,89 @@ public class RouteSearchDashboardService implements RouteSearchDashboardUseCase 
 	@Override
 	public RouteSearchDashboardSummary summarizeRouteSearches() {
 		RouteSearchDashboardSummary summary = summarizeRouteSearchPort.summarizeRouteSearches();
+		List<RouteSearchQualitySignals> qualitySignals = summarizeRouteSearchPort.loadRouteSearchQualitySignalsForDashboard();
 		return new RouteSearchDashboardSummary(
 			summary.totalCount(),
 			summary.foundCount(),
 			summary.blockedCount(),
 			summary.mobilityTypeCounts(),
 			regionUsageCounts(summarizeRouteSearchPort.loadRouteSearchStationPairsForDashboard()),
-			blockedReasonCounts(summarizeRouteSearchPort.loadRouteSearchBlockedReasonsForDashboard())
+			blockedReasonCounts(summarizeRouteSearchPort.loadRouteSearchBlockedReasonsForDashboard()),
+			etaSourceCounts(qualitySignals),
+			fallbackReasonCounts(qualitySignals),
+			routeQualitySignalCounts(qualitySignals)
 		);
+	}
+
+	private List<EtaSourceCount> etaSourceCounts(List<RouteSearchQualitySignals> qualitySignals) {
+		Map<EtaSource, Long> countsByEtaSource = new HashMap<>();
+		for (RouteSearchQualitySignals row : qualitySignals) {
+			if (row.status() != RouteSearchStatus.FOUND) {
+				continue;
+			}
+			countsByEtaSource.merge(row.etaSource(), 1L, Long::sum);
+		}
+		return countsByEtaSource.entrySet()
+			.stream()
+			.map(entry -> new EtaSourceCount(entry.getKey(), entry.getValue()))
+			.sorted(Comparator
+				.comparingLong(EtaSourceCount::count)
+				.reversed()
+				.thenComparing(row -> row.etaSource().name()))
+			.toList();
+	}
+
+	private List<FallbackReasonCount> fallbackReasonCounts(List<RouteSearchQualitySignals> qualitySignals) {
+		Map<String, Long> countsByReason = new HashMap<>();
+		for (RouteSearchQualitySignals row : qualitySignals) {
+			if (row.status() == RouteSearchStatus.BLOCKED) {
+				countsByReason.merge("ROUTE_GRAPH_OR_STRICT_ACCESSIBILITY_BLOCK", 1L, Long::sum);
+			}
+			if (row.etaSource() == EtaSource.FALLBACK) {
+				countsByReason.merge("PROVIDER_OUTAGE_OR_STALE_REALTIME", 1L, Long::sum);
+			}
+			for (RouteWarningCode warningCode : row.warningCodes()) {
+				switch (warningCode) {
+					case LOW_DATA_CONFIDENCE -> countsByReason.merge("LOW_DATA_CONFIDENCE", 1L, Long::sum);
+					case STALE_ACCESSIBILITY_DATA -> countsByReason.merge("STALE_ACCESSIBILITY_DATA", 1L, Long::sum);
+					case STAIR_ONLY_ACCESS -> countsByReason.merge("STRICT_STAIR_ONLY_ACCESS", 1L, Long::sum);
+				}
+			}
+		}
+		return countsByReason.entrySet()
+			.stream()
+			.map(entry -> new FallbackReasonCount(entry.getKey(), entry.getValue()))
+			.sorted(Comparator
+				.comparingLong(FallbackReasonCount::count)
+				.reversed()
+				.thenComparing(FallbackReasonCount::reason))
+			.toList();
+	}
+
+	private List<RouteQualitySignalCount> routeQualitySignalCounts(List<RouteSearchQualitySignals> qualitySignals) {
+		Map<String, Long> countsBySignal = new HashMap<>();
+		for (RouteSearchQualitySignals row : qualitySignals) {
+			if (row.etaSource() == EtaSource.FALLBACK) {
+				countsBySignal.merge("PROVIDER_OUTAGE", 1L, Long::sum);
+			}
+			if (row.status() == RouteSearchStatus.BLOCKED
+				|| row.warningCodes().contains(RouteWarningCode.LOW_DATA_CONFIDENCE)
+				|| row.warningCodes().contains(RouteWarningCode.STALE_ACCESSIBILITY_DATA)) {
+				countsBySignal.merge("ROUTE_GRAPH_DATA_QUALITY", 1L, Long::sum);
+			}
+			if (row.status() == RouteSearchStatus.BLOCKED
+				|| row.warningCodes().contains(RouteWarningCode.STAIR_ONLY_ACCESS)) {
+				countsBySignal.merge("STRICT_ACCESSIBILITY_BLOCK", 1L, Long::sum);
+			}
+		}
+		return countsBySignal.entrySet()
+			.stream()
+			.map(entry -> new RouteQualitySignalCount(entry.getKey(), entry.getValue()))
+			.sorted(Comparator
+				.comparingLong(RouteQualitySignalCount::count)
+				.reversed()
+				.thenComparing(RouteQualitySignalCount::signal))
+			.toList();
 	}
 
 	private List<BlockedReasonCount> blockedReasonCounts(List<RouteSearchBlockedReasons> blockedReasonsRows) {

--- a/backend/src/main/java/com/easysubway/route/domain/RouteSearchDashboardSummary.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteSearchDashboardSummary.java
@@ -9,7 +9,10 @@ public record RouteSearchDashboardSummary(
 	long blockedCount,
 	List<MobilityTypeCount> mobilityTypeCounts,
 	List<RegionUsageCount> regionUsageCounts,
-	List<BlockedReasonCount> blockedReasonCounts
+	List<BlockedReasonCount> blockedReasonCounts,
+	List<EtaSourceCount> etaSourceCounts,
+	List<FallbackReasonCount> fallbackReasonCounts,
+	List<RouteQualitySignalCount> routeQualitySignalCounts
 ) {
 
 	public RouteSearchDashboardSummary(
@@ -18,7 +21,17 @@ public record RouteSearchDashboardSummary(
 		long blockedCount,
 		List<MobilityTypeCount> mobilityTypeCounts
 	) {
-		this(totalCount, foundCount, blockedCount, mobilityTypeCounts, List.of(), List.of());
+		this(
+			totalCount,
+			foundCount,
+			blockedCount,
+			mobilityTypeCounts,
+			List.of(),
+			List.of(),
+			List.of(),
+			List.of(),
+			List.of()
+		);
 	}
 
 	public RouteSearchDashboardSummary(
@@ -28,7 +41,38 @@ public record RouteSearchDashboardSummary(
 		List<MobilityTypeCount> mobilityTypeCounts,
 		List<RegionUsageCount> regionUsageCounts
 	) {
-		this(totalCount, foundCount, blockedCount, mobilityTypeCounts, regionUsageCounts, List.of());
+		this(
+			totalCount,
+			foundCount,
+			blockedCount,
+			mobilityTypeCounts,
+			regionUsageCounts,
+			List.of(),
+			List.of(),
+			List.of(),
+			List.of()
+		);
+	}
+
+	public RouteSearchDashboardSummary(
+		long totalCount,
+		long foundCount,
+		long blockedCount,
+		List<MobilityTypeCount> mobilityTypeCounts,
+		List<RegionUsageCount> regionUsageCounts,
+		List<BlockedReasonCount> blockedReasonCounts
+	) {
+		this(
+			totalCount,
+			foundCount,
+			blockedCount,
+			mobilityTypeCounts,
+			regionUsageCounts,
+			blockedReasonCounts,
+			List.of(),
+			List.of(),
+			List.of()
+		);
 	}
 
 	public RouteSearchDashboardSummary {
@@ -47,6 +91,9 @@ public record RouteSearchDashboardSummary(
 		}
 		regionUsageCounts = List.copyOf(regionUsageCounts);
 		blockedReasonCounts = List.copyOf(blockedReasonCounts);
+		etaSourceCounts = List.copyOf(etaSourceCounts);
+		fallbackReasonCounts = List.copyOf(fallbackReasonCounts);
+		routeQualitySignalCounts = List.copyOf(routeQualitySignalCounts);
 	}
 
 	public record MobilityTypeCount(MobilityType mobilityType, long count) {
@@ -81,6 +128,42 @@ public record RouteSearchDashboardSummary(
 			}
 			if (count < 0) {
 				throw new InvalidRouteSearchException("경로 검색 차단 사유 수는 0 이상이어야 합니다.");
+			}
+		}
+	}
+
+	public record EtaSourceCount(EtaSource etaSource, long count) {
+
+		public EtaSourceCount {
+			if (etaSource == null) {
+				throw new InvalidRouteSearchException("ETA source 집계에는 ETA source가 필요합니다.");
+			}
+			if (count < 0) {
+				throw new InvalidRouteSearchException("ETA source 집계 수는 0 이상이어야 합니다.");
+			}
+		}
+	}
+
+	public record FallbackReasonCount(String reason, long count) {
+
+		public FallbackReasonCount {
+			if (reason == null || reason.isBlank()) {
+				throw new InvalidRouteSearchException("fallback 사유 집계에는 사유가 필요합니다.");
+			}
+			if (count < 0) {
+				throw new InvalidRouteSearchException("fallback 사유 집계 수는 0 이상이어야 합니다.");
+			}
+		}
+	}
+
+	public record RouteQualitySignalCount(String signal, long count) {
+
+		public RouteQualitySignalCount {
+			if (signal == null || signal.isBlank()) {
+				throw new InvalidRouteSearchException("경로 품질 신호 집계에는 신호명이 필요합니다.");
+			}
+			if (count < 0) {
+				throw new InvalidRouteSearchException("경로 품질 신호 집계 수는 0 이상이어야 합니다.");
 			}
 		}
 	}

--- a/backend/src/main/resources/templates/admin/routes/searches.html
+++ b/backend/src/main/resources/templates/admin/routes/searches.html
@@ -143,7 +143,7 @@
 	<header class="admin-page-head">
 		<div>
 			<h1>경로 검색 분석</h1>
-			<p>경로 탐색 성공·차단률과 이동 유형·지역·차단 사유를 분석합니다.</p>
+			<p>경로 탐색 성공·차단률과 route quality 운영 신호를 분석합니다.</p>
 		</div>
 	</header>
 
@@ -164,6 +164,11 @@
 			<span>경로 차단율</span>
 			<strong th:text="${summary.blockedRateLabel}">0.0%</strong>
 			<em>전체 검색 중 차단 비율</em>
+		</div>
+		<div class="metric">
+			<span>route_not_found_rate</span>
+			<strong th:text="${summary.routeNotFoundRateLabel}">0.0%</strong>
+			<em>route graph·strict 접근성 차단 비율</em>
 		</div>
 	</div>
 
@@ -223,6 +228,86 @@
 			<tr th:each="row : ${summary.blockedReasonRows}">
 				<td th:text="${row.reason}">계단 없는 역 접근 경로를 확인할 수 없습니다.</td>
 				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>ETA source 현황</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">ETA source</th>
+				<th scope="col">설명</th>
+				<th scope="col">건수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.etaSourceRows}">
+				<td th:text="${row.code}">PLANNED</td>
+				<td th:text="${row.label}">시간표 기준</td>
+				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>fallback 사유별 현황</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">fallback 사유</th>
+				<th scope="col">설명</th>
+				<th scope="col">건수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.fallbackReasonRows}">
+				<td th:text="${row.reason}">PROVIDER_OUTAGE_OR_STALE_REALTIME</td>
+				<td th:text="${row.label}">provider 장애 또는 stale realtime</td>
+				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>품질 신호 구분</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">신호</th>
+				<th scope="col">구분</th>
+				<th scope="col">건수</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.routeQualitySignalRows}">
+				<td th:text="${row.signal}">ROUTE_GRAPH_DATA_QUALITY</td>
+				<td th:text="${row.label}">route graph/data quality</td>
+				<td th:text="${row.count}">0</td>
+			</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>알림 기준</h2>
+		<table>
+			<thead>
+			<tr>
+				<th scope="col">metric</th>
+				<th scope="col">threshold</th>
+				<th scope="col">대응</th>
+			</tr>
+			</thead>
+			<tbody>
+			<tr th:each="row : ${summary.alertThresholdRows}">
+				<td th:text="${row.metric}">route_not_found_rate</td>
+				<td th:text="${row.threshold}">&gt;= 2.0%</td>
+				<td th:text="${row.action}">route graph/strict accessibility source review</td>
 			</tr>
 			</tbody>
 		</table>

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchAdminApiControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchAdminApiControllerTest.java
@@ -8,8 +8,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
+import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.route.domain.RouteStep;
+import com.easysubway.route.domain.RouteWarning;
+import com.easysubway.route.domain.RouteWarningCode;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -40,7 +44,12 @@ class RouteSearchAdminApiControllerTest {
 	@Test
 	@DisplayName("관리자는 경로 검색 요약을 JSON으로 조회한다")
 	void adminGetsRouteSearchSummary() throws Exception {
-		saveRouteSearchPort.saveRouteSearch(foundRouteSearch("route-search-found-1", MobilityType.SENIOR));
+		saveRouteSearchPort.saveRouteSearch(foundRouteSearch(
+			"route-search-found-1",
+			MobilityType.SENIOR,
+			List.of(routeStep(EtaSource.FALLBACK)),
+			List.of(new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE))
+		));
 		saveRouteSearchPort.saveRouteSearch(foundRouteSearch("route-search-found-2", MobilityType.WHEELCHAIR));
 		saveRouteSearchPort.saveRouteSearch(blockedRouteSearch(
 			"route-search-blocked-1",
@@ -54,6 +63,7 @@ class RouteSearchAdminApiControllerTest {
 			.andExpect(jsonPath("$.data.totalCount").value(3))
 			.andExpect(jsonPath("$.data.foundCount").value(2))
 			.andExpect(jsonPath("$.data.blockedCount").value(1))
+			.andExpect(jsonPath("$.data.routeNotFoundRateLabel").value("33.3%"))
 			.andExpect(jsonPath("$.data.mobilityTypeRows[0].label").value("고령자"))
 			.andExpect(jsonPath("$.data.mobilityTypeRows[0].count").value(1))
 			.andExpect(jsonPath("$.data.mobilityTypeRows[1].label").value("휠체어 사용자"))
@@ -62,10 +72,18 @@ class RouteSearchAdminApiControllerTest {
 			.andExpect(jsonPath("$.data.regionUsageRows[0].destinationCount").value(3))
 			.andExpect(jsonPath("$.data.blockedReasonRows[0].reason").value("계단 없는 역 접근 경로를 확인할 수 없습니다."))
 			.andExpect(jsonPath("$.data.blockedReasonRows[0].count").value(1))
+			.andExpect(jsonPath("$.data.etaSourceRows[0].code").value("FALLBACK"))
+			.andExpect(jsonPath("$.data.etaSourceRows[0].label").value("provider 지연/장애 fallback"))
+			.andExpect(jsonPath("$.data.fallbackReasonRows[0].reason").value("LOW_DATA_CONFIDENCE"))
+			.andExpect(jsonPath("$.data.routeQualitySignalRows[0].signal").value("ROUTE_GRAPH_DATA_QUALITY"))
+			.andExpect(jsonPath("$.data.alertThresholdRows[0].metric").value("route_not_found_rate"))
 			.andReturn();
 
 		String json = result.getResponse().getContentAsString();
 		assertThat(json)
+			.contains("PROVIDER_OUTAGE_OR_STALE_REALTIME")
+			.contains("ROUTE_GRAPH_OR_STRICT_ACCESSIBILITY_BLOCK")
+			.contains("provider outage/stale")
 			.doesNotContain("route-search-blocked-1")
 			.doesNotContain("station-sangnoksu")
 			.doesNotContain("station-sadang");
@@ -83,6 +101,15 @@ class RouteSearchAdminApiControllerTest {
 	}
 
 	private RouteSearchResult foundRouteSearch(String routeSearchId, MobilityType mobilityType) {
+		return foundRouteSearch(routeSearchId, mobilityType, List.of(), List.of());
+	}
+
+	private RouteSearchResult foundRouteSearch(
+		String routeSearchId,
+		MobilityType mobilityType,
+		List<RouteStep> steps,
+		List<RouteWarning> warnings
+	) {
 		return new RouteSearchResult(
 			routeSearchId,
 			"station-sangnoksu",
@@ -94,10 +121,31 @@ class RouteSearchAdminApiControllerTest {
 			"line-4",
 			"수도권 4호선",
 			18,
-			List.of(),
-			List.of(),
+			steps,
+			warnings,
 			List.of(),
 			LocalDateTime.of(2026, 6, 17, 9, 0)
+		);
+	}
+
+	private RouteStep routeStep(EtaSource etaSource) {
+		return new RouteStep(
+			1,
+			"ride",
+			"상록수에서 사당까지 이동",
+			"수도권 4호선을 이용합니다.",
+			"line-4",
+			"수도권 4호선",
+			"station-sangnoksu",
+			"station-sadang",
+			24,
+			15000,
+			false,
+			"VERIFIED_STEP_FREE",
+			false,
+			etaSource.name(),
+			"ESTIMATED_CONSTANT",
+			"낮음"
 		);
 	}
 

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchAdminPageControllerTest.java
@@ -7,8 +7,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
+import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.route.domain.RouteStep;
+import com.easysubway.route.domain.RouteWarning;
+import com.easysubway.route.domain.RouteWarningCode;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -39,7 +43,12 @@ class RouteSearchAdminPageControllerTest {
 	@Test
 	@DisplayName("관리자는 경로 검색의 전체, 상태별, 이동 프로필별 건수를 확인한다")
 	void adminGetsRouteSearchDashboardPage() throws Exception {
-		saveRouteSearchPort.saveRouteSearch(foundRouteSearch("route-search-found-1", MobilityType.SENIOR));
+		saveRouteSearchPort.saveRouteSearch(foundRouteSearch(
+			"route-search-found-1",
+			MobilityType.SENIOR,
+			List.of(routeStep(EtaSource.FALLBACK)),
+			List.of(new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE))
+		));
 		saveRouteSearchPort.saveRouteSearch(foundRouteSearch("route-search-found-2", MobilityType.WHEELCHAIR));
 
 		String html = mockMvc.perform(get("/admin/routes/searches/page")
@@ -56,6 +65,7 @@ class RouteSearchAdminPageControllerTest {
 			.contains("경로 찾음")
 			.contains("경로 차단")
 			.contains(">0<")
+			.contains("route_not_found_rate")
 			.contains("이동 프로필별 검색")
 			.contains("고령자")
 			.contains("휠체어 사용자")
@@ -64,6 +74,15 @@ class RouteSearchAdminPageControllerTest {
 			.contains("출발 검색")
 			.contains("도착 검색")
 			.contains("수도권")
+			.contains("ETA source 현황")
+			.contains("FALLBACK")
+			.contains("provider 지연/장애 fallback")
+			.contains("fallback 사유별 현황")
+			.contains("LOW_DATA_CONFIDENCE")
+			.contains("품질 신호 구분")
+			.contains("PROVIDER_OUTAGE")
+			.contains("알림 기준")
+			.contains("route graph/strict accessibility source review")
 			.doesNotContain("routeSearchId")
 			.doesNotContain("station-sangnoksu");
 	}
@@ -107,6 +126,15 @@ class RouteSearchAdminPageControllerTest {
 	}
 
 	private RouteSearchResult foundRouteSearch(String routeSearchId, MobilityType mobilityType) {
+		return foundRouteSearch(routeSearchId, mobilityType, List.of(), List.of());
+	}
+
+	private RouteSearchResult foundRouteSearch(
+		String routeSearchId,
+		MobilityType mobilityType,
+		List<RouteStep> steps,
+		List<RouteWarning> warnings
+	) {
 		return new RouteSearchResult(
 			routeSearchId,
 			"station-sangnoksu",
@@ -118,10 +146,31 @@ class RouteSearchAdminPageControllerTest {
 			"line-4",
 			"수도권 4호선",
 			18,
-			List.of(),
-			List.of(),
+			steps,
+			warnings,
 			List.of(),
 			LocalDateTime.of(2026, 6, 17, 9, 0)
+		);
+	}
+
+	private RouteStep routeStep(EtaSource etaSource) {
+		return new RouteStep(
+			1,
+			"ride",
+			"상록수에서 사당까지 이동",
+			"수도권 4호선을 이용합니다.",
+			"line-4",
+			"수도권 4호선",
+			"station-sangnoksu",
+			"station-sadang",
+			24,
+			15000,
+			false,
+			"VERIFIED_STEP_FREE",
+			false,
+			etaSource.name(),
+			"ESTIMATED_CONSTANT",
+			"낮음"
 		);
 	}
 

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
@@ -302,6 +302,36 @@ class JdbcRouteSearchRepositoryTest {
 			.containsExactly("계단 없는 역 접근 경로를 확인할 수 없습니다.");
 	}
 
+	@Test
+	@DisplayName("경로 품질 dashboard 신호는 저장된 status, ETA source, warning code만 집계한다")
+	void loadRouteSearchQualitySignalsForDashboard() {
+		repository.saveRouteSearch(directRouteSearch("route-search-1", "상록수", "사당"));
+		repository.saveRouteSearch(blockedRouteSearch("route-search-2"));
+		repository.saveRouteSearch(fallbackRouteSearch("route-search-3"));
+
+		var rows = repository.loadRouteSearchQualitySignalsForDashboard();
+
+		assertThat(rows)
+			.extracting("status", "etaSource", "warningCodes")
+			.containsExactly(
+				tuple(
+					RouteSearchStatus.FOUND,
+					EtaSource.FALLBACK,
+					List.of(RouteWarningCode.STALE_ACCESSIBILITY_DATA)
+				),
+				tuple(
+					RouteSearchStatus.BLOCKED,
+					EtaSource.PLANNED,
+					List.of(RouteWarningCode.STAIR_ONLY_ACCESS)
+				),
+				tuple(
+					RouteSearchStatus.FOUND,
+					EtaSource.PLANNED,
+					List.of(RouteWarningCode.LOW_DATA_CONFIDENCE)
+				)
+			);
+	}
+
 	private RouteSearchResult directRouteSearch(
 		String routeSearchId,
 		String originStationName,
@@ -364,6 +394,42 @@ class JdbcRouteSearchRepositoryTest {
 			List.of(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS)),
 			List.of("계단 없는 역 접근 경로를 확인할 수 없습니다."),
 			LocalDateTime.of(2026, 6, 17, 10, 0)
+		);
+	}
+
+	private RouteSearchResult fallbackRouteSearch(String routeSearchId) {
+		return new RouteSearchResult(
+			routeSearchId,
+			"station-origin",
+			"출발역",
+			"station-destination",
+			"도착역",
+			MobilityType.SENIOR,
+			RouteSearchStatus.FOUND,
+			"line-4",
+			"수도권 4호선",
+			50,
+			List.of(new RouteStep(
+				1,
+				"ride",
+				"출발역에서 도착역까지 이동",
+				"provider ETA가 없어 보수 추정값을 사용합니다.",
+				"line-4",
+				"수도권 4호선",
+				"station-origin",
+				"station-destination",
+				20,
+				8000,
+				false,
+				"VERIFIED_STEP_FREE",
+				false,
+				EtaSource.FALLBACK.name(),
+				"ESTIMATED_CONSTANT",
+				"낮음"
+			)),
+			List.of(new RouteWarning(RouteWarningCode.STALE_ACCESSIBILITY_DATA)),
+			List.of(),
+			LocalDateTime.of(2026, 6, 17, 11, 0)
 		);
 	}
 

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchDashboardServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchDashboardServiceTest.java
@@ -5,8 +5,12 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
+import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
+import com.easysubway.route.domain.RouteStep;
+import com.easysubway.route.domain.RouteWarning;
+import com.easysubway.route.domain.RouteWarningCode;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.DataQualityLevel;
@@ -118,10 +122,62 @@ class RouteSearchDashboardServiceTest {
 			);
 	}
 
+	@Test
+	@DisplayName("route quality 운영 신호를 낮은 cardinality 값으로 집계한다")
+	void summarizeRouteQualitySignalsForOperations() {
+		var repository = new InMemoryRouteSearchRepository();
+		repository.saveRouteSearch(routeSearch(
+			"route-search-1",
+			MobilityType.SENIOR,
+			RouteSearchStatus.FOUND,
+			List.of(routeStep(EtaSource.FALLBACK)),
+			List.of(new RouteWarning(RouteWarningCode.LOW_DATA_CONFIDENCE))
+		));
+		repository.saveRouteSearch(routeSearch(
+			"route-search-2",
+			MobilityType.WHEELCHAIR,
+			RouteSearchStatus.BLOCKED,
+			List.of(),
+			List.of(new RouteWarning(RouteWarningCode.STAIR_ONLY_ACCESS))
+		));
+		var service = new RouteSearchDashboardService(repository, new FakeTransitMasterPort());
+
+		var summary = service.summarizeRouteSearches();
+
+		assertThat(summary.etaSourceCounts())
+			.extracting("etaSource", "count")
+			.containsExactly(tuple(EtaSource.FALLBACK, 1L));
+		assertThat(summary.fallbackReasonCounts())
+			.extracting("reason", "count")
+			.contains(
+				tuple("PROVIDER_OUTAGE_OR_STALE_REALTIME", 1L),
+				tuple("ROUTE_GRAPH_OR_STRICT_ACCESSIBILITY_BLOCK", 1L),
+				tuple("LOW_DATA_CONFIDENCE", 1L),
+				tuple("STRICT_STAIR_ONLY_ACCESS", 1L)
+			);
+		assertThat(summary.routeQualitySignalCounts())
+			.extracting("signal", "count")
+			.contains(
+				tuple("PROVIDER_OUTAGE", 1L),
+				tuple("ROUTE_GRAPH_DATA_QUALITY", 2L),
+				tuple("STRICT_ACCESSIBILITY_BLOCK", 1L)
+			);
+	}
+
 	private RouteSearchResult routeSearch(
 		String routeSearchId,
 		MobilityType mobilityType,
 		RouteSearchStatus status
+	) {
+		return routeSearch(routeSearchId, mobilityType, status, List.of(), List.of());
+	}
+
+	private RouteSearchResult routeSearch(
+		String routeSearchId,
+		MobilityType mobilityType,
+		RouteSearchStatus status,
+		List<RouteStep> steps,
+		List<RouteWarning> warnings
 	) {
 		return routeSearch(
 			routeSearchId,
@@ -130,7 +186,9 @@ class RouteSearchDashboardServiceTest {
 			"station-sangnoksu",
 			"상록수",
 			"station-sadang",
-			"사당"
+			"사당",
+			steps,
+			warnings
 		);
 	}
 
@@ -143,6 +201,30 @@ class RouteSearchDashboardServiceTest {
 		String destinationStationId,
 		String destinationStationName
 	) {
+		return routeSearch(
+			routeSearchId,
+			mobilityType,
+			status,
+			originStationId,
+			originStationName,
+			destinationStationId,
+			destinationStationName,
+			List.of(),
+			List.of()
+		);
+	}
+
+	private RouteSearchResult routeSearch(
+		String routeSearchId,
+		MobilityType mobilityType,
+		RouteSearchStatus status,
+		String originStationId,
+		String originStationName,
+		String destinationStationId,
+		String destinationStationName,
+		List<RouteStep> steps,
+		List<RouteWarning> warnings
+	) {
 		return new RouteSearchResult(
 			routeSearchId,
 			originStationId,
@@ -154,10 +236,31 @@ class RouteSearchDashboardServiceTest {
 			"line-4",
 			"수도권 4호선",
 			status == RouteSearchStatus.FOUND ? 90 : 0,
-			List.of(),
-			List.of(),
+			steps,
+			warnings,
 			status == RouteSearchStatus.FOUND ? List.of() : List.of("계단 없는 역 접근 경로를 확인할 수 없습니다."),
 			LocalDateTime.of(2026, 6, 17, 10, 0)
+		);
+	}
+
+	private RouteStep routeStep(EtaSource etaSource) {
+		return new RouteStep(
+			1,
+			"ride",
+			"상록수에서 사당까지 이동",
+			"수도권 4호선을 이용합니다.",
+			"line-4",
+			"수도권 4호선",
+			"station-sangnoksu",
+			"station-sadang",
+			24,
+			15000,
+			false,
+			"VERIFIED_STEP_FREE",
+			false,
+			etaSource.name(),
+			"ESTIMATED_CONSTANT",
+			"낮음"
 		);
 	}
 


### PR DESCRIPTION
## Summary
- Adds route quality observability fields to the existing admin route search dashboard.
- Reports `route_not_found_rate`, ETA source counts, fallback reason counts, route quality signal counts, and alert thresholds.
- Keeps metrics low-cardinality by aggregating only status, ETA source, and warning code signals; no station/train labels are added to the new dashboard metrics.

## Scope
- Backend/admin dashboard only.
- No route search behavior, provider fallback behavior, or mobile UI changes.

## Verification
- `cd backend && ./gradlew test --rerun-tasks --tests '*Route*Dashboard*' --tests 'com.easysubway.route.adapter.in.web.RouteSearchAdminApiControllerTest' --tests 'com.easysubway.route.adapter.in.web.RouteSearchAdminPageControllerTest' --tests 'com.easysubway.route.adapter.out.persistence.JdbcRouteSearchRepositoryTest'`
- `git diff --check HEAD~1 HEAD`

Closes #1240
