### PR TITLE
[Style] 알림 설정 스위치를 하나의 카드로 묶기

### DIFF
--- a/apps/mobile/lib/notification_settings.dart
+++ b/apps/mobile/lib/notification_settings.dart
@@ -816,33 +816,39 @@ class _NotificationSettingsContent extends StatelessWidget {
           _NotificationSettingsMessage(message: state.message),
           const SizedBox(height: 12),
         ],
-        _NotificationSwitchTile(
-          key: const Key('notificationSwitch-favoriteStationFacilityAlerts'),
-          title: '역 시설 알림',
-          value: settings.favoriteStationFacilityAlerts,
-          enabled: !isSaving,
-          onChanged: onFavoriteStationFacilityAlertsChanged,
-        ),
-        _NotificationSwitchTile(
-          key: const Key('notificationSwitch-favoriteRouteFacilityAlerts'),
-          title: '경로 시설 알림',
-          value: settings.favoriteRouteFacilityAlerts,
-          enabled: !isSaving,
-          onChanged: onFavoriteRouteFacilityAlertsChanged,
-        ),
-        _NotificationSwitchTile(
-          key: const Key('notificationSwitch-reportStatusAlerts'),
-          title: '제보 진행 알림',
-          value: settings.reportStatusAlerts,
-          enabled: !isSaving,
-          onChanged: onReportStatusAlertsChanged,
-        ),
-        _NotificationSwitchTile(
-          key: const Key('notificationSwitch-dataQualityAlerts'),
-          title: '최신 안내 알림',
-          value: settings.dataQualityAlerts,
-          enabled: !isSaving,
-          onChanged: onDataQualityAlertsChanged,
+        _NotificationSwitchGroup(
+          tiles: [
+            _NotificationSwitchTile(
+              key: const Key(
+                'notificationSwitch-favoriteStationFacilityAlerts',
+              ),
+              title: '역 시설 알림',
+              value: settings.favoriteStationFacilityAlerts,
+              enabled: !isSaving,
+              onChanged: onFavoriteStationFacilityAlertsChanged,
+            ),
+            _NotificationSwitchTile(
+              key: const Key('notificationSwitch-favoriteRouteFacilityAlerts'),
+              title: '경로 시설 알림',
+              value: settings.favoriteRouteFacilityAlerts,
+              enabled: !isSaving,
+              onChanged: onFavoriteRouteFacilityAlertsChanged,
+            ),
+            _NotificationSwitchTile(
+              key: const Key('notificationSwitch-reportStatusAlerts'),
+              title: '제보 진행 알림',
+              value: settings.reportStatusAlerts,
+              enabled: !isSaving,
+              onChanged: onReportStatusAlertsChanged,
+            ),
+            _NotificationSwitchTile(
+              key: const Key('notificationSwitch-dataQualityAlerts'),
+              title: '최신 안내 알림',
+              value: settings.dataQualityAlerts,
+              enabled: !isSaving,
+              onChanged: onDataQualityAlertsChanged,
+            ),
+          ],
         ),
         const SizedBox(height: 12),
         Semantics(
@@ -939,38 +945,62 @@ class _NotificationSwitchTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
-    return Card(
-      margin: const EdgeInsets.only(bottom: 12),
+    return Semantics(
+      container: true,
+      excludeSemantics: true,
+      label: '$title ${value ? '켜짐' : '꺼짐'}',
+      toggled: value,
+      enabled: enabled,
+      onTap: enabled ? () => onChanged(!value) : null,
+      child: SwitchListTile.adaptive(
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 12,
+        ),
+        activeThumbColor: colorScheme.primary,
+        title: Text(
+          title,
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+            color: EasySubwayAccessibleColors.text,
+            fontWeight: FontWeight.w800,
+            height: 1.35,
+          ),
+        ),
+        value: value,
+        onChanged: enabled ? onChanged : null,
+      ),
+    );
+  }
+}
+
+/// 알림 스위치들을 개별 박스 대신 하나의 카드에 묶고 구분선으로 나눈다.
+class _NotificationSwitchGroup extends StatelessWidget {
+  const _NotificationSwitchGroup({required this.tiles});
+
+  final List<Widget> tiles;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
       color: Colors.white,
-      elevation: 0,
+      clipBehavior: Clip.antiAlias,
       shape: const RoundedRectangleBorder(
         borderRadius: _notificationSwitchTileRadius,
         side: BorderSide(color: EasySubwayAccessibleColors.line),
       ),
-      child: Semantics(
-        container: true,
-        excludeSemantics: true,
-        label: '$title ${value ? '켜짐' : '꺼짐'}',
-        toggled: value,
-        enabled: enabled,
-        onTap: enabled ? () => onChanged(!value) : null,
-        child: SwitchListTile.adaptive(
-          contentPadding: const EdgeInsets.symmetric(
-            horizontal: 16,
-            vertical: 12,
-          ),
-          activeThumbColor: colorScheme.primary,
-          title: Text(
-            title,
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: EasySubwayAccessibleColors.text,
-              fontWeight: FontWeight.w800,
-              height: 1.35,
-            ),
-          ),
-          value: value,
-          onChanged: enabled ? onChanged : null,
-        ),
+      child: Column(
+        children: [
+          for (var i = 0; i < tiles.length; i++) ...[
+            if (i > 0)
+              const Divider(
+                height: 1,
+                indent: 16,
+                endIndent: 16,
+                color: EasySubwayAccessibleColors.line,
+              ),
+            tiles[i],
+          ],
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary

- Closes #1371
- 알림 설정 스위치 4개가 각각 별도 카드(박스)이던 것을 하나의 카드에 구분선으로 묶어 불필요한 박스를 걷어냈습니다. 온보딩·설정 화면이 이미 쓰는 그룹 카드 패턴과 일치시켰습니다.
- 스위치 타일에서 개별 Card를 제거하고 그룹 컨테이너를 Material로 두어 ink/탭 효과와 둥근 모서리를 유지했습니다.
- 제목·시맨틱·test key·탭 타깃은 그대로 유지했습니다. 이모지는 사용하지 않았습니다.

## Verification

- `dart format lib/notification_settings.dart` · `flutter analyze` (No issues found)
- `flutter test test/widget_test.dart --plain-name "알림 설정"` → 5 passed

## Notes

- 온보딩 화면은 함께 검토했으나 인트로·권한·환경설정 카드가 이미 "하나의 카드 + 구분선" 그룹 패턴을 따르고 있어 별도 변경이 필요하지 않았습니다. 이번 정비로 알림 설정이 그 패턴에 합류합니다.
- populated 상태는 위젯 테스트로 검증했습니다. 시각 변경 위주로 저장/권한 로직과 백엔드 API에는 영향이 없습니다.
