### PR TITLE
[Test] Abuse rehearsal evidence summary validator 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,12 @@ jobs:
           NODE_OPTIONS: --disable-warning=ExperimentalWarning
         run: node --test tools/realtime/*.test.mjs
 
+      - name: Repository CI / Run security tool tests
+        if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.ci == 'true' }}
+        env:
+          NODE_OPTIONS: --disable-warning=ExperimentalWarning
+        run: node --test tools/security/*.test.mjs
+
       - name: Repository CI / Validate Docker Compose config
         if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         run: docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet

--- a/apps/mobile/release/abuse-penetration-rehearsal-gate.json
+++ b/apps/mobile/release/abuse-penetration-rehearsal-gate.json
@@ -239,6 +239,7 @@
   "manualRehearsalPolicy": {
     "redactionRequired": true,
     "requestResponseSummaryOnly": true,
+    "validatorCommand": "node tools/security/validate-abuse-penetration-summary.mjs --summary <summary.json> --require-pass",
     "githubSummaryFields": [
       "scenarioId",
       "artifactIdentity",

--- a/tools/ci/detect-changed-paths.sh
+++ b/tools/ci/detect-changed-paths.sh
@@ -61,6 +61,9 @@ while IFS= read -r file; do
     tools/realtime/**)
       repository=true
       ;;
+    tools/security/**)
+      repository=true
+      ;;
     apps/mobile/release/**)
       mobile=true
       android=true

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -484,6 +484,8 @@ test("지속적 통합 작업과 스텝 이름은 실패 영역을 구분할 수
   assert.match(workflow, /CHROME_PATH: \$\{\{ steps\.setup-chrome\.outputs\.chrome-path \}\}/);
   assert.match(workflow, /ROUTE_MAP_CHROME_NO_SANDBOX: "1"/);
   assert.match(workflow, /Repository CI \/ Run route map tool tests/);
+  assert.match(workflow, /Repository CI \/ Run security tool tests/);
+  assert.match(workflow, /node --test tools\/security\/\*\.test\.mjs/);
   assert.match(releaseGateJob, /Release Gate Consistency \/ Run release gate contract tests/);
   assert.match(releaseGateJob, /node --test tools\/ci\/repository-contract\.test\.mjs/);
   assert.doesNotMatch(releaseGateJob, /--test-name-pattern/);
@@ -2042,6 +2044,11 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
     "storage lifecycle rehearsal must require retention/delete evidence",
   );
   assert.equal(abusePenetrationRehearsalGate.manualRehearsalPolicy.localAndroidEmulatorRequiredForMobileEvidence, true);
+  assert.equal(
+    abusePenetrationRehearsalGate.manualRehearsalPolicy.validatorCommand,
+    "node tools/security/validate-abuse-penetration-summary.mjs --summary <summary.json> --require-pass",
+  );
+  assert.equal(existsSync(path.join(root, "tools/security/validate-abuse-penetration-summary.mjs")), true);
   assert.deepEqual(abusePenetrationRehearsalGate.manualRehearsalPolicy.githubSummaryFields, [
     "scenarioId",
     "artifactIdentity",
@@ -10611,6 +10618,13 @@ test("경로 분류기는 저장소, 백엔드, 모바일, Android, iOS 변경�
   assert.equal(realtimeTool.android, "false");
   assert.equal(realtimeTool.ios, "false");
   assert.equal(realtimeTool.deploy, "false");
+
+  const securityTool = await classifyChangedFiles(["tools/security/validate-abuse-penetration-summary.mjs"]);
+  assert.equal(securityTool.repository, "true");
+  assert.equal(securityTool.mobile, "false");
+  assert.equal(securityTool.android, "false");
+  assert.equal(securityTool.ios, "false");
+  assert.equal(securityTool.deploy, "false");
 });
 
 test("경로 분류기는 백엔드 품질 gate 변경을 repository contract 대상으로 처리한다", async () => {

--- a/tools/security/validate-abuse-penetration-summary.mjs
+++ b/tools/security/validate-abuse-penetration-summary.mjs
@@ -53,25 +53,33 @@ function assertNoSensitiveSummary(summary, gate) {
   }
 }
 
-function assertIdentity(summary, gate) {
-  const identity = required(summary.artifactIdentity, "artifactIdentity");
+function stableFlatJson(value) {
+  return JSON.stringify(Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b))));
+}
+
+function assertIdentity(summary, gate, path = "artifactIdentity", expectedIdentity) {
+  const identity = required(summary.artifactIdentity, path);
   for (const field of gate.buildIdentityPolicy.requiredIdentityFields) {
-    required(identity[field], `artifactIdentity.${field}`);
+    required(identity[field], `${path}.${field}`);
   }
   for (const fields of gate.buildIdentityPolicy.requiredIdentityAnyOf) {
     if (!fields.some((field) => identity[field])) {
-      throw new Error(`artifactIdentity must include one of: ${fields.join(", ")}`);
+      throw new Error(`${path} must include one of: ${fields.join(", ")}`);
     }
   }
+  if (expectedIdentity && stableFlatJson(identity) !== stableFlatJson(expectedIdentity)) {
+    throw new Error(`${path} must match artifactIdentity`);
+  }
+  return identity;
 }
 
 function assertFindingCounts(matrixSummary, requirePass, gate) {
   const counts = required(matrixSummary.findingCounts, `${matrixSummary.matrixId}.findingCounts`);
-  const critical = Number(counts.critical ?? 0);
-  const high = Number(counts.high ?? 0);
-  const medium = Number(counts.medium ?? 0);
-  if (!Number.isFinite(critical) || !Number.isFinite(high) || !Number.isFinite(medium)) {
-    throw new Error(`${matrixSummary.matrixId}.findingCounts must be numeric`);
+  const critical = counts.critical ?? 0;
+  const high = counts.high ?? 0;
+  const medium = counts.medium ?? 0;
+  if (![critical, high, medium].every((value) => Number.isInteger(value) && value >= 0)) {
+    throw new Error(`${matrixSummary.matrixId}.findingCounts must be non-negative integers`);
   }
   if (critical > gate.findingPolicy.criticalHighAllowed || high > gate.findingPolicy.criticalHighAllowed) {
     throw new Error(`${matrixSummary.matrixId} has critical/high findings`);
@@ -122,13 +130,14 @@ async function main() {
   if (!STATUS.has(summary.status)) throw new Error("status must be a release gate status");
   if (requirePass && summary.status !== "PASS") throw new Error("status must be PASS");
 
-  assertIdentity(summary, gate);
+  const artifactIdentity = assertIdentity(summary, gate);
   assertNoSensitiveSummary(summary, gate);
 
   const matrixSummaries = new Map(required(summary.matrices, "matrices").map((matrix) => [matrix.matrixId, matrix]));
   for (const [matrixId, matrix] of Object.entries(gate.rehearsalMatrices)) {
     const matrixSummary = matrixSummaries.get(matrixId);
     assertMatrix(matrixId, matrix, matrixSummary, gate);
+    assertIdentity(matrixSummary, gate, `${matrixId}.artifactIdentity`, artifactIdentity);
     assertFindingCounts(matrixSummary, requirePass, gate);
   }
 }

--- a/tools/security/validate-abuse-penetration-summary.mjs
+++ b/tools/security/validate-abuse-penetration-summary.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+
+const STATUS = new Set(["PASS", "FAIL", "BLOCKED_EXTERNAL"]);
+const RAW_SECRET_PATTERNS = [
+  /https?:\/\/\S*(x-amz-signature|x-goog-signature|signature=|sig=|token=|receipt)/i,
+  /\bAuthorization:\s*(Bearer|Basic)\s+\S+/i,
+  /\bCookie:\s*\S+/i,
+  /\b(JSESSIONID|sessionid)=\S+/i,
+  /-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----/i,
+];
+
+function argValue(args, name, fallback) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : fallback;
+}
+
+function required(value, name) {
+  if (value === undefined || value === null || value === "") {
+    throw new Error(`abuse rehearsal summary missing ${name}`);
+  }
+  return value;
+}
+
+function collectStrings(value, path = "$", out = []) {
+  if (typeof value === "string") out.push([path, value]);
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectStrings(item, `${path}[${index}]`, out));
+  } else if (value && typeof value === "object") {
+    Object.entries(value).forEach(([key, item]) => collectStrings(item, `${path}.${key}`, out));
+  }
+  return out;
+}
+
+function assertNoSensitiveSummary(summary, gate) {
+  const forbiddenValues = new Set([
+    ...gate.manualRehearsalPolicy.forbiddenInEvidence,
+    ...Object.values(gate.rehearsalMatrices).flatMap((matrix) => matrix.forbiddenSummaryValues),
+    ...gate.latestQaEvidenceStatus.redactionPolicy.forbiddenInGitHubEvidence,
+  ].map((value) => value.toLowerCase()));
+  for (const [path, value] of collectStrings(summary)) {
+    const normalized = value.toLowerCase();
+    for (const forbidden of forbiddenValues) {
+      if (normalized.includes(forbidden)) {
+        throw new Error(`${path} contains forbidden sensitive evidence marker: ${forbidden}`);
+      }
+    }
+    for (const pattern of RAW_SECRET_PATTERNS) {
+      if (pattern.test(value)) {
+        throw new Error(`${path} appears to contain raw secret, token, cookie, or signed URL material`);
+      }
+    }
+  }
+}
+
+function assertIdentity(summary, gate) {
+  const identity = required(summary.artifactIdentity, "artifactIdentity");
+  for (const field of gate.buildIdentityPolicy.requiredIdentityFields) {
+    required(identity[field], `artifactIdentity.${field}`);
+  }
+  for (const fields of gate.buildIdentityPolicy.requiredIdentityAnyOf) {
+    if (!fields.some((field) => identity[field])) {
+      throw new Error(`artifactIdentity must include one of: ${fields.join(", ")}`);
+    }
+  }
+}
+
+function assertFindingCounts(matrixSummary, requirePass, gate) {
+  const counts = required(matrixSummary.findingCounts, `${matrixSummary.matrixId}.findingCounts`);
+  const critical = Number(counts.critical ?? 0);
+  const high = Number(counts.high ?? 0);
+  const medium = Number(counts.medium ?? 0);
+  if (!Number.isFinite(critical) || !Number.isFinite(high) || !Number.isFinite(medium)) {
+    throw new Error(`${matrixSummary.matrixId}.findingCounts must be numeric`);
+  }
+  if (critical > gate.findingPolicy.criticalHighAllowed || high > gate.findingPolicy.criticalHighAllowed) {
+    throw new Error(`${matrixSummary.matrixId} has critical/high findings`);
+  }
+  if (medium > 0 && (!matrixSummary.mediumFindingDisposition?.owner || !matrixSummary.mediumFindingDisposition?.fixPlan)) {
+    throw new Error(`${matrixSummary.matrixId} medium findings require owner and fixPlan`);
+  }
+  if (requirePass && matrixSummary.result !== "PASS") {
+    throw new Error(`${matrixSummary.matrixId}.result must be PASS`);
+  }
+}
+
+function assertMatrix(matrixId, matrix, matrixSummary, gate) {
+  required(matrixSummary, `matrices.${matrixId}`);
+  if (matrixSummary.scenarioId !== matrix.scenarioId) {
+    throw new Error(`${matrixId}.scenarioId must be ${matrix.scenarioId}`);
+  }
+  for (const field of ["matrixId", ...gate.manualRehearsalPolicy.githubSummaryFields]) {
+    required(matrixSummary[field], `${matrixId}.${field}`);
+  }
+  const evidence = new Set(required(matrixSummary.requiredEvidence, `${matrixId}.requiredEvidence`));
+  for (const evidenceId of matrix.requiredEvidence) {
+    if (!evidence.has(evidenceId)) throw new Error(`${matrixId}.requiredEvidence missing ${evidenceId}`);
+  }
+  const caseById = new Map(required(matrixSummary.cases, `${matrixId}.cases`).map((item) => [item.caseId, item]));
+  for (const caseId of matrix.requiredCases) {
+    const item = required(caseById.get(caseId), `${matrixId}.cases.${caseId}`);
+    for (const field of matrix.summaryFields) {
+      required(item[field], `${matrixId}.cases.${caseId}.${field}`);
+    }
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const summaryPath = argValue(args, "--summary");
+  const gatePath = argValue(args, "--gate", "apps/mobile/release/abuse-penetration-rehearsal-gate.json");
+  const requirePass = args.includes("--require-pass");
+  if (!summaryPath) throw new Error("--summary is required");
+
+  const [summary, gate] = await Promise.all([
+    readFile(summaryPath, "utf8").then(JSON.parse),
+    readFile(gatePath, "utf8").then(JSON.parse),
+  ]);
+  if (summary.schemaVersion !== 1) throw new Error("schemaVersion must be 1");
+  if (summary.releaseGate !== gate.releaseGate) throw new Error(`releaseGate must be ${gate.releaseGate}`);
+  if (summary.issue !== gate.issue) throw new Error(`issue must be ${gate.issue}`);
+  if (!STATUS.has(summary.status)) throw new Error("status must be a release gate status");
+  if (requirePass && summary.status !== "PASS") throw new Error("status must be PASS");
+
+  assertIdentity(summary, gate);
+  assertNoSensitiveSummary(summary, gate);
+
+  const matrixSummaries = new Map(required(summary.matrices, "matrices").map((matrix) => [matrix.matrixId, matrix]));
+  for (const [matrixId, matrix] of Object.entries(gate.rehearsalMatrices)) {
+    const matrixSummary = matrixSummaries.get(matrixId);
+    assertMatrix(matrixId, matrix, matrixSummary, gate);
+    assertFindingCounts(matrixSummary, requirePass, gate);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/tools/security/validate-abuse-penetration-summary.test.mjs
+++ b/tools/security/validate-abuse-penetration-summary.test.mjs
@@ -51,11 +51,11 @@ function validSummary() {
     releaseGate: gate.releaseGate,
     issue: gate.issue,
     status: "PASS",
-    artifactIdentity,
+    artifactIdentity: { ...artifactIdentity },
     matrices: Object.entries(gate.rehearsalMatrices).map(([matrixId, matrix]) => ({
       matrixId,
       scenarioId: matrix.scenarioId,
-      artifactIdentity,
+      artifactIdentity: { ...artifactIdentity },
       commandOrManualCheck: "redacted local rehearsal",
       findingCounts: { critical: 0, high: 0, medium: 0, low: 0 },
       result: "PASS",
@@ -126,5 +126,27 @@ test("abuse penetration summary validator rejects missing cases, raw sensitive m
       ], { cwd: root }),
     ),
     /critical\/high findings/,
+  );
+
+  const stringCount = validSummary();
+  stringCount.matrices[0].findingCounts.critical = "0";
+  await assert.rejects(
+    withSummary(stringCount, (summaryPath) =>
+      execFileAsync(process.execPath, ["tools/security/validate-abuse-penetration-summary.mjs", "--summary", summaryPath], {
+        cwd: root,
+      }),
+    ),
+    /non-negative integers/,
+  );
+
+  const mixedIdentity = validSummary();
+  mixedIdentity.matrices[0].artifactIdentity.versionCode = 10002;
+  await assert.rejects(
+    withSummary(mixedIdentity, (summaryPath) =>
+      execFileAsync(process.execPath, ["tools/security/validate-abuse-penetration-summary.mjs", "--summary", summaryPath], {
+        cwd: root,
+      }),
+    ),
+    /artifactIdentity must match/,
   );
 });

--- a/tools/security/validate-abuse-penetration-summary.test.mjs
+++ b/tools/security/validate-abuse-penetration-summary.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(import.meta.dirname, "../..");
+const gate = JSON.parse(readFileSync(path.join(root, "apps/mobile/release/abuse-penetration-rehearsal-gate.json"), "utf8"));
+const artifactIdentity = {
+  gitSha: "abcdef1234567890",
+  versionCode: 10001,
+  androidApplicationId: "com.easysubway.app",
+  dataPackManifestSha256: "a".repeat(64),
+  aabSha256: "b".repeat(64),
+  backendArtifactSha256: "c".repeat(64),
+};
+
+function caseValue(field) {
+  return {
+    apiStep: "submit",
+    artifactType: "android-aab",
+    auditRedactionResult: "PASS",
+    bucketOrPolicyAlias: "report-photo-release",
+    cleanupResult: "PASS",
+    commandOrManualCheck: "redacted local rehearsal",
+    contentType: "image/jpeg",
+    deleteOrCleanupResult: "PASS",
+    endpoint: "/api/v1/reports",
+    expectedStatus: 403,
+    localEvidencePath: ".codex/evidence/security/abuse-penetration-rehearsal/rc/redacted-summary.json",
+    method: "PUT",
+    nodeOrStoreMode: "multi-node",
+    observedStatus: 403,
+    redactionResult: "PASS",
+    retentionRule: "30d",
+    role: "REPORT_REVIEWER",
+    scanTarget: "release artifact",
+    sizeBytes: 1024,
+    tenantScope: "operator-global",
+    ttlSeconds: 60,
+  }[field] ?? "PASS";
+}
+
+function validSummary() {
+  return {
+    schemaVersion: 1,
+    releaseGate: gate.releaseGate,
+    issue: gate.issue,
+    status: "PASS",
+    artifactIdentity,
+    matrices: Object.entries(gate.rehearsalMatrices).map(([matrixId, matrix]) => ({
+      matrixId,
+      scenarioId: matrix.scenarioId,
+      artifactIdentity,
+      commandOrManualCheck: "redacted local rehearsal",
+      findingCounts: { critical: 0, high: 0, medium: 0, low: 0 },
+      result: "PASS",
+      redactionNotes: "sensitive values removed",
+      localEvidencePath: ".codex/evidence/security/abuse-penetration-rehearsal/rc/redacted-summary.json",
+      requiredEvidence: matrix.requiredEvidence,
+      cases: matrix.requiredCases.map((caseId) => {
+        const item = { caseId };
+        for (const field of matrix.summaryFields) item[field] = field === "caseId" ? caseId : caseValue(field);
+        return item;
+      }),
+    })),
+  };
+}
+
+async function withSummary(summary, fn) {
+  const dir = path.join(tmpdir(), `abuse-summary-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  await rm(dir, { recursive: true, force: true });
+  await mkdir(dir, { recursive: true });
+  const summaryPath = path.join(dir, "summary.json");
+  await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+  return fn(summaryPath);
+}
+
+test("abuse penetration summary validator accepts a complete redacted matrix summary", async () => {
+  await withSummary(validSummary(), (summaryPath) =>
+    execFileAsync(process.execPath, [
+      "tools/security/validate-abuse-penetration-summary.mjs",
+      "--summary",
+      summaryPath,
+      "--require-pass",
+    ], { cwd: root }),
+  );
+});
+
+test("abuse penetration summary validator rejects missing cases, raw sensitive markers, and high findings", async () => {
+  const missingCase = validSummary();
+  missingCase.matrices[0].cases.pop();
+  await assert.rejects(
+    withSummary(missingCase, (summaryPath) =>
+      execFileAsync(process.execPath, ["tools/security/validate-abuse-penetration-summary.mjs", "--summary", summaryPath], {
+        cwd: root,
+      }),
+    ),
+    /cases\./,
+  );
+
+  const leaked = validSummary();
+  leaked.matrices[0].redactionNotes = "raw signed URL leaked";
+  await assert.rejects(
+    withSummary(leaked, (summaryPath) =>
+      execFileAsync(process.execPath, ["tools/security/validate-abuse-penetration-summary.mjs", "--summary", summaryPath], {
+        cwd: root,
+      }),
+    ),
+    /forbidden sensitive evidence marker/,
+  );
+
+  const highFinding = validSummary();
+  highFinding.matrices[0].findingCounts.high = 1;
+  await assert.rejects(
+    withSummary(highFinding, (summaryPath) =>
+      execFileAsync(process.execPath, [
+        "tools/security/validate-abuse-penetration-summary.mjs",
+        "--summary",
+        summaryPath,
+        "--require-pass",
+      ], { cwd: root }),
+    ),
+    /critical\/high findings/,
+  );
+});


### PR DESCRIPTION
## 요약
- #1022 abuse/penetration rehearsal redacted summary validator를 추가합니다.
- gate matrix/case 정의를 직접 읽어 누락 case, critical/high finding, 민감값 marker를 차단합니다.
- tools/security 변경이 repository CI와 security tool tests를 타도록 경로 분류와 workflow를 연결합니다.

## 범위
- 모바일 UI 변경 없음.
- production fallback 추가 없음.
- #1022는 여전히 Play-generated/Play-installed 및 deployed rehearsal evidence가 필요하므로 닫지 않습니다.

Refs #1022

## 검증
- node --test tools/security/*.test.mjs
- node --test tools/ci/*.test.mjs
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 보안 관련 검증이 릴리스/CI 흐름에 추가되어, 변경 시 자동 점검 범위가 넓어졌습니다.
  * 모바일 릴리스용 수동 검증 기준이 더 엄격하게 적용되도록 업데이트되었습니다.

* **버그 수정**
  * 보안 요약 검증에서 누락된 항목, 민감 정보 포함, 높은 위험도 항목을 더 정확히 감지하도록 개선되었습니다.

* **테스트**
  * 새로운 보안 검증 스크립트와 관련 CI 동작에 대한 자동 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->