### PR TITLE
[Chore] Operations release summary validator 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,12 @@ jobs:
           NODE_OPTIONS: --disable-warning=ExperimentalWarning
         run: node --test tools/security/*.test.mjs
 
+      - name: Repository CI / Run ops tool tests
+        if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.ci == 'true' }}
+        env:
+          NODE_OPTIONS: --disable-warning=ExperimentalWarning
+        run: node --test tools/ops/*.test.mjs
+
       - name: Repository CI / Validate Docker Compose config
         if: ${{ needs.changes.outputs.repository == 'true' || needs.changes.outputs.docs_only == 'true' || needs.changes.outputs.ci == 'true' }}
         run: docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet

--- a/apps/mobile/release/operations-release-evidence.json
+++ b/apps/mobile/release/operations-release-evidence.json
@@ -257,6 +257,10 @@
     ],
     "blockedWhenKo": "각 operations signal에 dashboard, alert route, runbook 또는 외부 blocker 기록이 없으면 운영 관측성 gate를 닫지 않는다."
   },
+  "releaseEvidenceSummaryValidator": {
+    "command": "node tools/ops/validate-operations-release-summary.mjs --summary <summary.json> --require-pass",
+    "passPolicyKo": "external-blocker-record는 남은 외부 blocker를 기록하는 용도이며 최종 PASS를 대체할 수 없다."
+  },
   "sensitiveEvidencePolicy": {
     "localOnly": true,
     "forbiddenInPullRequest": [

--- a/tools/ci/detect-changed-paths.sh
+++ b/tools/ci/detect-changed-paths.sh
@@ -64,6 +64,12 @@ while IFS= read -r file; do
     tools/security/**)
       repository=true
       ;;
+    tools/ops/**)
+      repository=true
+      ;;
+    tools/release/**)
+      repository=true
+      ;;
     apps/mobile/release/**)
       mobile=true
       android=true

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -486,6 +486,8 @@ test("지속적 통합 작업과 스텝 이름은 실패 영역을 구분할 수
   assert.match(workflow, /Repository CI \/ Run route map tool tests/);
   assert.match(workflow, /Repository CI \/ Run security tool tests/);
   assert.match(workflow, /node --test tools\/security\/\*\.test\.mjs/);
+  assert.match(workflow, /Repository CI \/ Run ops tool tests/);
+  assert.match(workflow, /node --test tools\/ops\/\*\.test\.mjs/);
   assert.match(releaseGateJob, /Release Gate Consistency \/ Run release gate contract tests/);
   assert.match(releaseGateJob, /node --test tools\/ci\/repository-contract\.test\.mjs/);
   assert.doesNotMatch(releaseGateJob, /--test-name-pattern/);
@@ -3377,6 +3379,12 @@ test("운영 관측성과 알림 기준선은 필수 release 신호와 심볼 �
   assert.ok(operationsEvidence.observability.requiredResolutionKinds.includes("alert-route"));
   assert.ok(operationsEvidence.observability.requiredResolutionKinds.includes("runbook"));
   assert.ok(operationsEvidence.observability.allowedFallbackKinds.includes("external-blocker-record"));
+  assert.equal(
+    operationsEvidence.releaseEvidenceSummaryValidator.command,
+    "node tools/ops/validate-operations-release-summary.mjs --summary <summary.json> --require-pass",
+  );
+  assert.match(operationsEvidence.releaseEvidenceSummaryValidator.passPolicyKo, /external-blocker-record/);
+  assert.equal(existsSync(path.join(root, "tools/ops/validate-operations-release-summary.mjs")), true);
   assert.equal(backupRestoreGate.rcEvidenceManifest, operationsEvidencePath);
 
   assert.match(applicationProd, /management:[\s\S]*health:[\s\S]*readiness:[\s\S]*productionReadiness/);
@@ -10625,6 +10633,20 @@ test("경로 분류기는 저장소, 백엔드, 모바일, Android, iOS 변경�
   assert.equal(securityTool.android, "false");
   assert.equal(securityTool.ios, "false");
   assert.equal(securityTool.deploy, "false");
+
+  const opsTool = await classifyChangedFiles(["tools/ops/validate-operations-release-summary.mjs"]);
+  assert.equal(opsTool.repository, "true");
+  assert.equal(opsTool.mobile, "false");
+  assert.equal(opsTool.android, "false");
+  assert.equal(opsTool.ios, "false");
+  assert.equal(opsTool.deploy, "false");
+
+  const releaseTool = await classifyChangedFiles(["tools/release/summary-validation-utils.mjs"]);
+  assert.equal(releaseTool.repository, "true");
+  assert.equal(releaseTool.mobile, "false");
+  assert.equal(releaseTool.android, "false");
+  assert.equal(releaseTool.ios, "false");
+  assert.equal(releaseTool.deploy, "false");
 });
 
 test("경로 분류기는 백엔드 품질 gate 변경을 repository contract 대상으로 처리한다", async () => {

--- a/tools/ops/validate-operations-release-summary.mjs
+++ b/tools/ops/validate-operations-release-summary.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+import {
+  argValue,
+  collectStrings,
+  readJson,
+  required,
+  stableFlatJson,
+} from "../release/summary-validation-utils.mjs";
+
+const STATUS = new Set(["PASS", "FAIL", "BLOCKED_EXTERNAL"]);
+const RAW_SECRET_PATTERNS = [
+  /https?:\/\/\S*(x-amz-signature|x-goog-signature|signature=|sig=|token=|receipt)/i,
+  /\bAuthorization:\s*(Bearer|Basic)\s+\S+/i,
+  /\bCookie:\s*\S+/i,
+  /\b(JSESSIONID|sessionid)=\S+/i,
+  /\b[a-f0-9]{64}\b.*\b(device|mailbox|personal)\b/i,
+];
+
+function assertNoSensitiveSummary(summary, gates) {
+  const observabilityMarkers = [
+    gates.observability.sensitiveLogPolicy.forbidReceiptTokens ? "receipt token" : "",
+    gates.observability.sensitiveLogPolicy.forbidUploadUrls ? "upload URL" : "",
+    gates.observability.sensitiveLogPolicy.forbidPhotoMetadata ? "photo metadata" : "",
+  ];
+  const forbiddenValues = new Set([
+    ...observabilityMarkers,
+    ...gates.postLaunch.releaseEvidenceSummaryPolicy.forbiddenInGithubSummary,
+    ...gates.postLaunch.sensitiveEvidencePolicy.forbiddenInPullRequest,
+    ...gates.support.supportEvidenceSummaryPolicy.forbiddenInGithubSummary,
+    ...gates.support.sensitiveEvidencePolicy.forbiddenInPullRequest,
+  ].filter(Boolean).map((value) => value.toLowerCase()));
+  for (const [path, value] of collectStrings(summary)) {
+    const normalized = value.toLowerCase();
+    const descriptivePolicyField = /\.(firstResponse|threshold|decision|redactionNotes)$/.test(path);
+    if (!descriptivePolicyField) {
+      for (const forbidden of forbiddenValues) {
+        if (normalized.includes(forbidden)) {
+          throw new Error(`${path} contains forbidden sensitive evidence marker: ${forbidden}`);
+        }
+      }
+    }
+    for (const pattern of RAW_SECRET_PATTERNS) {
+      if (pattern.test(value)) {
+        throw new Error(`${path} appears to contain raw secret, token, cookie, signed URL, or personal data`);
+      }
+    }
+  }
+}
+
+function assertIdentity(summary, path = "artifactIdentity") {
+  const identity = required(summary.artifactIdentity, path);
+  for (const field of [
+    "gitSha",
+    "versionName",
+    "versionCode",
+    "androidApplicationId",
+    "aabSha256",
+    "backendArtifactSha256",
+    "dataPackManifestSha256",
+  ]) {
+    required(identity[field], `${path}.${field}`);
+  }
+  return identity;
+}
+
+function assertObservability(summary, gate, requirePass) {
+  const allowedKinds = new Set(gate.signalEvidencePolicy.allowedResolutionKinds);
+  const byId = new Map(required(summary.observabilitySignals, "observabilitySignals").map((item) => [item.signalId, item]));
+  for (const signal of gate.signals) {
+    const item = required(byId.get(signal.id), `observabilitySignals.${signal.id}`);
+    required(item.owner, `observabilitySignals.${signal.id}.owner`);
+    required(item.threshold, `observabilitySignals.${signal.id}.threshold`);
+    required(item.firstResponse, `observabilitySignals.${signal.id}.firstResponse`);
+    required(item.result, `observabilitySignals.${signal.id}.result`);
+    required(item.redactionNotes, `observabilitySignals.${signal.id}.redactionNotes`);
+    required(item.localEvidencePath, `observabilitySignals.${signal.id}.localEvidencePath`);
+    if (!allowedKinds.has(item.resolutionKind)) {
+      throw new Error(`observabilitySignals.${signal.id}.resolutionKind must be allowed`);
+    }
+    if (requirePass && item.resolutionKind === "external-blocker-record") {
+      throw new Error("external-blocker-record cannot satisfy --require-pass");
+    }
+    const evidence = new Set(required(item.evidenceIds, `observabilitySignals.${signal.id}.evidenceIds`));
+    if (!signal.evidence.some((evidenceId) => evidence.has(evidenceId))) {
+      throw new Error(`observabilitySignals.${signal.id}.evidenceIds must include signal evidence`);
+    }
+    if (requirePass && item.result !== "PASS") {
+      throw new Error(`observabilitySignals.${signal.id}.result must be PASS`);
+    }
+  }
+}
+
+function assertPostLaunch(summary, gate, artifactIdentity, requirePass) {
+  const byId = new Map(required(summary.postLaunchReviews, "postLaunchReviews").map((item) => [item.reviewWindowId, item]));
+  for (const window of gate.reviewWindows) {
+    const item = required(byId.get(window.id), `postLaunchReviews.${window.id}`);
+    assertIdentity(item, `postLaunchReviews.${window.id}.artifactIdentity`);
+    if (stableFlatJson(item.artifactIdentity) !== stableFlatJson(artifactIdentity)) {
+      throw new Error(`postLaunchReviews.${window.id}.artifactIdentity must match artifactIdentity`);
+    }
+    for (const field of gate.releaseEvidenceSummaryPolicy.githubSummaryFields) {
+      required(item[field], `postLaunchReviews.${window.id}.${field}`);
+    }
+    const snapshot = new Set(required(item.signalSnapshot, `postLaunchReviews.${window.id}.signalSnapshot`));
+    for (const signalId of window.requiredSignals) {
+      if (!snapshot.has(signalId)) throw new Error(`postLaunchReviews.${window.id}.signalSnapshot missing ${signalId}`);
+    }
+    if (requirePass && item.goNoGoResult !== "PASS") {
+      throw new Error(`postLaunchReviews.${window.id}.goNoGoResult must be PASS`);
+    }
+  }
+  const fixedSteps = new Set(required(summary.fixedReleaseSteps, "fixedReleaseSteps"));
+  for (const step of gate.fixedReleaseProcedure.requiredSteps) {
+    if (!fixedSteps.has(step)) throw new Error(`fixedReleaseSteps missing ${step}`);
+  }
+}
+
+function assertSupport(summary, gate, requirePass) {
+  const byId = new Map(required(summary.supportChannels, "supportChannels").map((item) => [item.channelId, item]));
+  for (const channel of gate.supportChannels) {
+    const item = required(byId.get(channel.id), `supportChannels.${channel.id}`);
+    for (const field of gate.supportEvidenceSummaryPolicy.githubSummaryFields) {
+      required(item[field], `supportChannels.${channel.id}.${field}`);
+    }
+    const evidence = new Set(required(item.evidenceIds, `supportChannels.${channel.id}.evidenceIds`));
+    for (const evidenceId of channel.requiredEvidence) {
+      if (!evidence.has(evidenceId)) throw new Error(`supportChannels.${channel.id}.evidenceIds missing ${evidenceId}`);
+    }
+    if (requirePass && item.result !== "PASS") throw new Error(`supportChannels.${channel.id}.result must be PASS`);
+  }
+  for (const [field, requiredValues] of [
+    ["supportDryRunEvidence", gate.dryRunRequiredEvidence],
+    ["dataCorrectionSteps", gate.dataCorrectionFlow.requiredSteps],
+  ]) {
+    const values = new Set(required(summary[field], field));
+    for (const value of requiredValues) {
+      if (!values.has(value)) throw new Error(`${field} missing ${value}`);
+    }
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const summaryPath = argValue(args, "--summary");
+  const requirePass = args.includes("--require-pass");
+  if (!summaryPath) throw new Error("--summary is required");
+
+  const [summary, observability, postLaunch, support] = await Promise.all([
+    readJson(summaryPath),
+    readJson(argValue(args, "--observability-gate", "apps/mobile/release/operations-observability-gate.json")),
+    readJson(argValue(args, "--post-launch-gate", "apps/mobile/release/post-launch-operations-review-gate.json")),
+    readJson(argValue(args, "--support-gate", "apps/mobile/release/support-incident-response-gate.json")),
+  ]);
+  if (summary.schemaVersion !== 1) throw new Error("schemaVersion must be 1");
+  if (summary.releaseGate !== "operations-release-summary") throw new Error("releaseGate must be operations-release-summary");
+  if (summary.issue !== 1019) throw new Error("issue must be 1019");
+  if (!STATUS.has(summary.status)) throw new Error("status must be a release gate status");
+  if (requirePass && summary.status !== "PASS") throw new Error("status must be PASS");
+  if (requirePass && required(summary.externalBlockers, "externalBlockers").length > 0) {
+    throw new Error("externalBlockers must be empty for --require-pass");
+  }
+
+  const artifactIdentity = assertIdentity(summary);
+  const gates = { observability, postLaunch, support };
+  assertNoSensitiveSummary(summary, gates);
+  assertObservability(summary, observability, requirePass);
+  assertPostLaunch(summary, postLaunch, artifactIdentity, requirePass);
+  assertSupport(summary, support, requirePass);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/tools/ops/validate-operations-release-summary.mjs
+++ b/tools/ops/validate-operations-release-summary.mjs
@@ -38,6 +38,13 @@ function assertNoSensitiveSummary(summary, gates) {
           throw new Error(`${path} contains forbidden sensitive evidence marker: ${forbidden}`);
         }
       }
+    } else {
+      for (const forbidden of forbiddenValues) {
+        const rawMarker = forbidden.startsWith("raw ") ? forbidden : `raw ${forbidden}`;
+        if (normalized.includes(rawMarker)) {
+          throw new Error(`${path} contains forbidden sensitive evidence marker: ${rawMarker}`);
+        }
+      }
     }
     for (const pattern of RAW_SECRET_PATTERNS) {
       if (pattern.test(value)) {

--- a/tools/ops/validate-operations-release-summary.test.mjs
+++ b/tools/ops/validate-operations-release-summary.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(import.meta.dirname, "../..");
+const observabilityGate = JSON.parse(
+  readFileSync(path.join(root, "apps/mobile/release/operations-observability-gate.json"), "utf8"),
+);
+const postLaunchGate = JSON.parse(
+  readFileSync(path.join(root, "apps/mobile/release/post-launch-operations-review-gate.json"), "utf8"),
+);
+const supportGate = JSON.parse(
+  readFileSync(path.join(root, "apps/mobile/release/support-incident-response-gate.json"), "utf8"),
+);
+
+const artifactIdentity = {
+  gitSha: "abcdef1234567890",
+  versionName: "1.0.2",
+  versionCode: 10002,
+  androidApplicationId: "com.easysubway.app",
+  aabSha256: "a".repeat(64),
+  backendArtifactSha256: "b".repeat(64),
+  dataPackManifestSha256: "c".repeat(64),
+};
+
+function validSummary() {
+  return {
+    schemaVersion: 1,
+    releaseGate: "operations-release-summary",
+    issue: 1019,
+    status: "PASS",
+    artifactIdentity: { ...artifactIdentity },
+    observabilitySignals: observabilityGate.signals.map((signal) => ({
+      signalId: signal.id,
+      owner: signal.ownerKo,
+      threshold: signal.thresholdKo,
+      firstResponse: signal.firstResponseKo,
+      resolutionKind: "dashboard-url",
+      evidenceIds: signal.evidence,
+      result: "PASS",
+      redactionNotes: "summary only; sensitive values removed",
+      localEvidencePath: ".codex/evidence/operations-release/rc/redacted-summary.json",
+    })),
+    postLaunchReviews: postLaunchGate.reviewWindows.map((window) => ({
+      reviewWindowId: window.id,
+      artifactIdentity: { ...artifactIdentity },
+      signalSnapshot: window.requiredSignals,
+      owner: window.ownerKo,
+      decision: window.decisionKo,
+      goNoGoResult: "PASS",
+      redactionNotes: "summary only; no personal data",
+      localEvidencePath: ".codex/evidence/release/post-launch-operations-review/rc/redacted-summary.json",
+    })),
+    supportChannels: supportGate.supportChannels.map((channel) => ({
+      channelId: channel.id,
+      redactedReceiptReference: "redacted-routing-check",
+      receivedAt: "2026-07-02T00:00:00+09:00",
+      owner: channel.ownerKo,
+      result: "PASS",
+      redactionNotes: "message body and mailbox personal data omitted",
+      localEvidencePath: ".codex/evidence/release/support-incident-response/rc/redacted-summary.json",
+      evidenceIds: channel.requiredEvidence,
+    })),
+    supportDryRunEvidence: supportGate.dryRunRequiredEvidence,
+    dataCorrectionSteps: supportGate.dataCorrectionFlow.requiredSteps,
+    fixedReleaseSteps: postLaunchGate.fixedReleaseProcedure.requiredSteps,
+    externalBlockers: [],
+  };
+}
+
+async function withSummary(summary, fn) {
+  const dir = path.join(tmpdir(), `operations-summary-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  await rm(dir, { recursive: true, force: true });
+  await mkdir(dir, { recursive: true });
+  const summaryPath = path.join(dir, "summary.json");
+  await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+  return fn(summaryPath);
+}
+
+test("operations release summary validator accepts complete redacted release evidence", async () => {
+  await withSummary(validSummary(), (summaryPath) =>
+    execFileAsync(process.execPath, [
+      "tools/ops/validate-operations-release-summary.mjs",
+      "--summary",
+      summaryPath,
+      "--require-pass",
+    ], { cwd: root }),
+  );
+});
+
+test("operations release summary validator compares artifact identity independent of JSON key order", async () => {
+  const summary = validSummary();
+  summary.postLaunchReviews[0].artifactIdentity = {
+    versionCode: artifactIdentity.versionCode,
+    gitSha: artifactIdentity.gitSha,
+    dataPackManifestSha256: artifactIdentity.dataPackManifestSha256,
+    backendArtifactSha256: artifactIdentity.backendArtifactSha256,
+    aabSha256: artifactIdentity.aabSha256,
+    androidApplicationId: artifactIdentity.androidApplicationId,
+    versionName: artifactIdentity.versionName,
+  };
+  await withSummary(summary, (summaryPath) =>
+    execFileAsync(process.execPath, [
+      "tools/ops/validate-operations-release-summary.mjs",
+      "--summary",
+      summaryPath,
+      "--require-pass",
+    ], { cwd: root }),
+  );
+});
+
+test("operations release summary validator rejects missing signals, fallback pass-through, and raw sensitive data", async () => {
+  const missingSignal = validSummary();
+  missingSignal.observabilitySignals.pop();
+  await assert.rejects(
+    withSummary(missingSignal, (summaryPath) =>
+      execFileAsync(process.execPath, ["tools/ops/validate-operations-release-summary.mjs", "--summary", summaryPath], {
+        cwd: root,
+      }),
+    ),
+    /observabilitySignals\./,
+  );
+
+  const fallbackPass = validSummary();
+  fallbackPass.observabilitySignals[0].resolutionKind = "external-blocker-record";
+  await assert.rejects(
+    withSummary(fallbackPass, (summaryPath) =>
+      execFileAsync(process.execPath, [
+        "tools/ops/validate-operations-release-summary.mjs",
+        "--summary",
+        summaryPath,
+        "--require-pass",
+      ], { cwd: root }),
+    ),
+    /external-blocker-record cannot satisfy --require-pass/,
+  );
+
+  const leaked = validSummary();
+  leaked.supportChannels[0].redactionNotes = "Authorization: Bearer raw-token";
+  await assert.rejects(
+    withSummary(leaked, (summaryPath) =>
+      execFileAsync(process.execPath, ["tools/ops/validate-operations-release-summary.mjs", "--summary", summaryPath], {
+        cwd: root,
+      }),
+    ),
+    /raw secret, token, cookie, signed URL, or personal data/,
+  );
+});

--- a/tools/ops/validate-operations-release-summary.test.mjs
+++ b/tools/ops/validate-operations-release-summary.test.mjs
@@ -151,4 +151,15 @@ test("operations release summary validator rejects missing signals, fallback pas
     ),
     /raw secret, token, cookie, signed URL, or personal data/,
   );
+
+  const rawReceiptMarker = validSummary();
+  rawReceiptMarker.supportChannels[0].redactionNotes = "raw report receipt token: abc123";
+  await assert.rejects(
+    withSummary(rawReceiptMarker, (summaryPath) =>
+      execFileAsync(process.execPath, ["tools/ops/validate-operations-release-summary.mjs", "--summary", summaryPath], {
+        cwd: root,
+      }),
+    ),
+    /forbidden sensitive evidence marker/,
+  );
 });

--- a/tools/release/summary-validation-utils.mjs
+++ b/tools/release/summary-validation-utils.mjs
@@ -1,0 +1,31 @@
+import { readFile } from "node:fs/promises";
+
+export function argValue(args, name, fallback) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : fallback;
+}
+
+export function required(value, name) {
+  if (value === undefined || value === null || value === "") {
+    throw new Error(`summary missing ${name}`);
+  }
+  return value;
+}
+
+export function collectStrings(value, path = "$", out = []) {
+  if (typeof value === "string") out.push([path, value]);
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectStrings(item, `${path}[${index}]`, out));
+  } else if (value && typeof value === "object") {
+    Object.entries(value).forEach(([key, item]) => collectStrings(item, `${path}.${key}`, out));
+  }
+  return out;
+}
+
+export function stableFlatJson(value) {
+  return JSON.stringify(Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b))));
+}
+
+export async function readJson(path) {
+  return readFile(path, "utf8").then(JSON.parse);
+}

--- a/tools/security/validate-abuse-penetration-summary.mjs
+++ b/tools/security/validate-abuse-penetration-summary.mjs
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
-import { readFile } from "node:fs/promises";
+import {
+  argValue,
+  collectStrings,
+  readJson,
+  required,
+  stableFlatJson,
+} from "../release/summary-validation-utils.mjs";
 
 const STATUS = new Set(["PASS", "FAIL", "BLOCKED_EXTERNAL"]);
 const RAW_SECRET_PATTERNS = [
@@ -9,28 +15,6 @@ const RAW_SECRET_PATTERNS = [
   /\b(JSESSIONID|sessionid)=\S+/i,
   /-----BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY-----/i,
 ];
-
-function argValue(args, name, fallback) {
-  const index = args.indexOf(name);
-  return index >= 0 ? args[index + 1] : fallback;
-}
-
-function required(value, name) {
-  if (value === undefined || value === null || value === "") {
-    throw new Error(`abuse rehearsal summary missing ${name}`);
-  }
-  return value;
-}
-
-function collectStrings(value, path = "$", out = []) {
-  if (typeof value === "string") out.push([path, value]);
-  if (Array.isArray(value)) {
-    value.forEach((item, index) => collectStrings(item, `${path}[${index}]`, out));
-  } else if (value && typeof value === "object") {
-    Object.entries(value).forEach(([key, item]) => collectStrings(item, `${path}.${key}`, out));
-  }
-  return out;
-}
 
 function assertNoSensitiveSummary(summary, gate) {
   const forbiddenValues = new Set([
@@ -51,10 +35,6 @@ function assertNoSensitiveSummary(summary, gate) {
       }
     }
   }
-}
-
-function stableFlatJson(value) {
-  return JSON.stringify(Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b))));
 }
 
 function assertIdentity(summary, gate, path = "artifactIdentity", expectedIdentity) {
@@ -120,10 +100,7 @@ async function main() {
   const requirePass = args.includes("--require-pass");
   if (!summaryPath) throw new Error("--summary is required");
 
-  const [summary, gate] = await Promise.all([
-    readFile(summaryPath, "utf8").then(JSON.parse),
-    readFile(gatePath, "utf8").then(JSON.parse),
-  ]);
+  const [summary, gate] = await Promise.all([readJson(summaryPath), readJson(gatePath)]);
   if (summary.schemaVersion !== 1) throw new Error("schemaVersion must be 1");
   if (summary.releaseGate !== gate.releaseGate) throw new Error(`releaseGate must be ${gate.releaseGate}`);
   if (summary.issue !== gate.issue) throw new Error(`issue must be ${gate.issue}`);


### PR DESCRIPTION
## Summary
- add a #1019 operations release summary validator for redacted evidence packages
- wire ops tool tests into Repository CI and changed-path classification
- record that external-blocker-record cannot satisfy final --require-pass validation

Refs #1019

## Verification
- node --test tools/ops/*.test.mjs
- node --test tools/ci/*.test.mjs
- git diff --check

## Notes
- No mobile UI files changed.
- This does not mark #1019 complete; real dashboard, alert, support, post-launch, and release evidence are still external/manual gates.