### PR TITLE
[Fix] Route ETA evaluator production report format 보강

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -45,7 +45,23 @@ test("route ETA accuracy evaluator report contract is machine-readable", async (
   const report = JSON.parse(readFileSync(output, "utf8"));
   assert.equal(report.schemaVersion, 1);
   assert.equal(report.sampleSize, 100);
+  assert.deepEqual(report.referenceSourceCounts, {
+    PROVIDER_LIVE_ARRIVAL: 0,
+    STATIC_TIMETABLE_REFERENCE: 0,
+    MANUAL_OBSERVATION: 0,
+    COMPETING_APP_COMPARISON: 0,
+    FIXTURE_EXPECTED: 100,
+  });
+  assert.equal(report.productionSampleSize, 0);
+  assert.equal(report.nonProductionSampleSize, 100);
   assert.equal(report.metrics.sampleSize, 100);
+  assert.equal(report.metrics.routeNotFoundRate, 0);
+  assert.equal(report.metrics.wrongTransferCountRate, 0);
+  assert.equal(report.metrics.wrongLineSequenceRate, 0);
+  assert.equal(report.metrics.strictStepFreeFalsePositiveCount, 0);
+  assert.equal(report.metrics.etaSourceMismatchCount, 0);
+  assert.equal(report.metrics.realtimeFallbackMismatchCount, 0);
+  assert.equal(report.metrics.providerStaleMisuseCount, 0);
   assert.equal(report.coverage.singleRide, true);
   assert.equal(report.coverage.oneTransfer, true);
   assert.equal(report.coverage.twoTransfer, true);

--- a/tools/routes/check-route-commercialization-gate.mjs
+++ b/tools/routes/check-route-commercialization-gate.mjs
@@ -92,15 +92,13 @@ function validateAccuracy(gate, report, failures) {
   const sampleSizeMin = gate.routeEtaAccuracy.sampleSizeMin;
   const sources = report.sampleSourceCounts ?? {};
   if (number(report.sampleSize) < sampleSizeMin) failures.push(`routeEtaAccuracy sampleSize is below ${sampleSizeMin}`);
-  const commercialSampleSize = Math.max(
-    0,
-    Math.min(number(sources.realtimeProvider), number(sources.manualObservation)) - number(sources.staleRealtime),
-  );
+  const commercialSampleSize = Number.isFinite(Number(report.productionSampleSize))
+    ? number(report.productionSampleSize)
+    : Math.max(0, Math.min(number(sources.realtimeProvider), number(sources.manualObservation)) - number(sources.staleRealtime));
   if (commercialSampleSize < sampleSizeMin) failures.push(`routeEtaAccuracy production sampleSize is below ${sampleSizeMin}`);
   if (number(sources.fixture) >= sampleSizeMin && commercialSampleSize < sampleSizeMin) {
     failures.push("routeEtaAccuracy fixture-only samples cannot satisfy production gate");
   }
-  if (number(sources.staticTimetable) > 0) failures.push("routeEtaAccuracy static local samples must be labeled outside commercial ETA samples");
   if (number(sources.staleRealtime) > 0) failures.push("routeEtaAccuracy stale realtime samples cannot count as fresh provider samples");
 
   const singleRide = report.metrics?.singleRide ?? {};

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -117,6 +117,60 @@ test("route commercialization gate fails closed for fixture-only or unsafe route
   );
 });
 
+test("route commercialization gate keeps legacy production sample fallback", async () => {
+  const fixture = await writeFixtureSet({
+    accuracy: {
+      schemaVersion: 1,
+      sampleSize: 120,
+      sampleSourceCounts: {
+        fixture: 0,
+        staticTimetable: 0,
+        realtimeProvider: 120,
+        manualObservation: 100,
+        staleRealtime: 20,
+      },
+      metrics: {
+        singleRide: { sampleSize: 60, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
+        transfer: { sampleSize: 60, p50ErrorSeconds: 90, p90ErrorSeconds: 240 },
+      },
+      failures: [],
+    },
+    accessibility: {
+      schemaVersion: 1,
+      strictStepFreeKnownStairFalsePositiveCount: 0,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      unknownAccessibilityLabeled: true,
+    },
+    coverage: {
+      schemaVersion: 1,
+      supportedStationLinePairs: 150,
+      providerFreshnessSecondsMaxObserved: 80,
+      staleFallbackRequired: true,
+    },
+    contract: {
+      schemaVersion: 1,
+      multiTransferSupported: true,
+      outOfStationTransferSupported: true,
+      alternativeItinerariesMinObserved: 2,
+      wrongTransferCount: 0,
+      wrongLineSequence: 0,
+      routeNotFoundRate: 0.01,
+      releaseBlockersSatisfied: ["D-2", "D-3", "H-1"],
+    },
+  });
+
+  await assert.rejects(
+    execChecker(fixture),
+    (error) => {
+      const report = JSON.parse(error.stdout);
+      assert.equal(report.status, "FAIL");
+      assert.ok(report.failures.includes("routeEtaAccuracy production sampleSize is below 100"));
+      assert.ok(report.failures.includes("routeEtaAccuracy stale realtime samples cannot count as fresh provider samples"));
+      return true;
+    },
+  );
+});
+
 async function writeFixtureSet(reports) {
   const dir = await mkdtemp(path.join(tmpdir(), "route-commercialization-gate-"));
   const files = {

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -21,6 +21,7 @@ test("route commercialization gate passes with production-ready reports", async 
         manualObservation: 120,
         staleRealtime: 0,
       },
+      productionSampleSize: 120,
       metrics: {
         singleRide: { sampleSize: 60, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
         transfer: { sampleSize: 60, p50ErrorSeconds: 90, p90ErrorSeconds: 240 },
@@ -70,6 +71,7 @@ test("route commercialization gate fails closed for fixture-only or unsafe route
         manualObservation: 0,
         staleRealtime: 0,
       },
+      productionSampleSize: 0,
       metrics: {
         singleRide: { sampleSize: 50, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
         transfer: { sampleSize: 50, p50ErrorSeconds: 90, p90ErrorSeconds: 240 },

--- a/tools/routes/evaluate-eta-accuracy.mjs
+++ b/tools/routes/evaluate-eta-accuracy.mjs
@@ -134,13 +134,13 @@ function buildReport(rows) {
     providerStaleMisuse: 0,
   };
   for (const row of rows) {
+    collectQualityFailures(row, failures, quality);
     const observed = requiredNumber(row.observed_eta_error_seconds, row, "observed_eta_error_seconds", failures);
     const max = requiredNumber(row.max_eta_error_seconds, row, "max_eta_error_seconds", failures);
     if (observed === null || max === null) continue;
     if (observed > max) {
       addFailure(failures, row, "ETA_ERROR", "observed ETA error exceeds max", { maxEtaErrorSeconds: max }, { observedEtaErrorSeconds: observed });
     }
-    collectQualityFailures(row, failures, quality);
     errors.push(observed);
     if (Number(row.expected_transfer_count) === 0) {
       singleRideErrors.push(observed);

--- a/tools/routes/evaluate-eta-accuracy.mjs
+++ b/tools/routes/evaluate-eta-accuracy.mjs
@@ -23,6 +23,13 @@ const requiredColumns = [
   "use_realtime",
   "notes",
 ];
+const referenceSources = [
+  "PROVIDER_LIVE_ARRIVAL",
+  "STATIC_TIMETABLE_REFERENCE",
+  "MANUAL_OBSERVATION",
+  "COMPETING_APP_COMPARISON",
+  "FIXTURE_EXPECTED",
+];
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   try {
@@ -117,11 +124,23 @@ function buildReport(rows) {
   const errors = [];
   const singleRideErrors = [];
   const transferErrors = [];
+  const quality = {
+    routeNotFound: 0,
+    wrongTransferCount: 0,
+    wrongLineSequence: 0,
+    strictStepFreeFalsePositive: 0,
+    etaSourceMismatch: 0,
+    realtimeFallbackMismatch: 0,
+    providerStaleMisuse: 0,
+  };
   for (const row of rows) {
     const observed = requiredNumber(row.observed_eta_error_seconds, row, "observed_eta_error_seconds", failures);
     const max = requiredNumber(row.max_eta_error_seconds, row, "max_eta_error_seconds", failures);
     if (observed === null || max === null) continue;
-    if (observed > max) failures.push(`${row.sourceFile}:${row.lineNumber} observed ETA error exceeds max`);
+    if (observed > max) {
+      addFailure(failures, row, "ETA_ERROR", "observed ETA error exceeds max", { maxEtaErrorSeconds: max }, { observedEtaErrorSeconds: observed });
+    }
+    collectQualityFailures(row, failures, quality);
     errors.push(observed);
     if (Number(row.expected_transfer_count) === 0) {
       singleRideErrors.push(observed);
@@ -152,6 +171,9 @@ function buildReport(rows) {
     generatedAt: new Date().toISOString(),
     sampleSize: rows.length,
     sampleSourceCounts: countSampleSources(rows),
+    referenceSourceCounts: countReferenceSources(rows),
+    productionSampleSize: rows.filter(isProductionSample).length,
+    nonProductionSampleSize: rows.filter((row) => !isProductionSample(row)).length,
     coverage,
     metrics: {
       sampleSize: errors.length,
@@ -160,6 +182,13 @@ function buildReport(rows) {
       maxErrorSeconds: errors.at(-1) ?? 0,
       singleRide: metricBlock(singleRideErrors),
       transfer: metricBlock(transferErrors),
+      routeNotFoundRate: rate(quality.routeNotFound, rows.length),
+      wrongTransferCountRate: rate(quality.wrongTransferCount, rows.length),
+      wrongLineSequenceRate: rate(quality.wrongLineSequence, rows.length),
+      strictStepFreeFalsePositiveCount: quality.strictStepFreeFalsePositive,
+      etaSourceMismatchCount: quality.etaSourceMismatch,
+      realtimeFallbackMismatchCount: quality.realtimeFallbackMismatch,
+      providerStaleMisuseCount: quality.providerStaleMisuse,
     },
     failures,
   };
@@ -190,6 +219,76 @@ function countSampleSources(rows) {
   return counts;
 }
 
+function countReferenceSources(rows) {
+  const counts = Object.fromEntries(referenceSources.map((source) => [source, 0]));
+  for (const row of rows) {
+    counts[referenceSource(row)] += 1;
+  }
+  return counts;
+}
+
+function referenceSource(row) {
+  if (referenceSources.includes(row.reference_source)) return row.reference_source;
+  const note = row.notes.toLowerCase();
+  if (note.includes("fixture")) return "FIXTURE_EXPECTED";
+  if (note.includes("manual")) return "MANUAL_OBSERVATION";
+  if (row.use_realtime === "true") return "PROVIDER_LIVE_ARRIVAL";
+  return "STATIC_TIMETABLE_REFERENCE";
+}
+
+function isProductionSample(row) {
+  const source = referenceSource(row);
+  if (source === "MANUAL_OBSERVATION" || source === "COMPETING_APP_COMPARISON") return true;
+  return source === "PROVIDER_LIVE_ARRIVAL" && !isStale(row);
+}
+
+function collectQualityFailures(row, failures, quality) {
+  if (row.actual_route_found === "false") {
+    quality.routeNotFound += 1;
+    addFailure(failures, row, "ROUTE_NOT_FOUND", "route was not found", { found: true }, { found: false });
+  }
+  if (hasValue(row.actual_transfer_count) && Number(row.actual_transfer_count) !== Number(row.expected_transfer_count)) {
+    quality.wrongTransferCount += 1;
+    addFailure(failures, row, "WRONG_TRANSFER_COUNT", "wrong transfer count", { transferCount: Number(row.expected_transfer_count) }, { transferCount: Number(row.actual_transfer_count) });
+  }
+  if (hasValue(row.expected_line_sequence) && hasValue(row.actual_line_sequence) && row.expected_line_sequence !== row.actual_line_sequence) {
+    quality.wrongLineSequence += 1;
+    addFailure(failures, row, "WRONG_LINE_SEQUENCE", "wrong line sequence", { lineSequence: row.expected_line_sequence }, { lineSequence: row.actual_line_sequence });
+  }
+  if (isStrictStepFree(row) && containsBlockedStepFreeEdge(row.actual_edge_types)) {
+    quality.strictStepFreeFalsePositive += 1;
+    addFailure(failures, row, "ACCESSIBILITY_FALSE_POSITIVE", "strict step-free route contains blocked edge", { stepFree: true }, { edgeTypes: row.actual_edge_types });
+  }
+  if (hasValue(row.expected_eta_source) && hasValue(row.actual_eta_source) && row.expected_eta_source !== row.actual_eta_source) {
+    quality.etaSourceMismatch += 1;
+    addFailure(failures, row, "ETA_SOURCE_MISMATCH", "ETA source mismatch", { etaSource: row.expected_eta_source }, { etaSource: row.actual_eta_source });
+  }
+  if (row.realtime_expected === "true" && hasValue(row.actual_eta_source) && row.actual_eta_source !== "REALTIME") {
+    quality.realtimeFallbackMismatch += 1;
+    addFailure(failures, row, "REALTIME_FALLBACK_MISMATCH", "realtime expected but actual ETA is not realtime", { etaSource: "REALTIME" }, { etaSource: row.actual_eta_source });
+  }
+  if (row.actual_eta_source === "REALTIME" && isStale(row)) {
+    quality.providerStaleMisuse += 1;
+    addFailure(failures, row, "PROVIDER_STALE_MISUSE", "stale provider sample used as realtime ETA", { providerFreshnessStatus: "FRESH" }, { providerFreshnessStatus: row.provider_freshness_status || "STALE" });
+  }
+}
+
+function isStrictStepFree(row) {
+  return row.constraint_mode === "STRICT_STEP_FREE" || row.strict_step_free_expected_status === "STEP_FREE";
+}
+
+function containsBlockedStepFreeEdge(edgeTypes = "") {
+  return edgeTypes.split("|").some((type) => type === "STAIR" || type === "ESCALATOR" || type === "ESCALATOR_ONLY");
+}
+
+function isStale(row) {
+  return row.provider_freshness_status === "STALE" || row.notes.toLowerCase().includes("stale");
+}
+
+function hasValue(value) {
+  return value !== undefined && value !== "";
+}
+
 function metricBlock(sortedErrors) {
   return {
     sampleSize: sortedErrors.length,
@@ -202,10 +301,26 @@ function metricBlock(sortedErrors) {
 function requiredNumber(value, row, column, failures) {
   const number = Number(value);
   if (!Number.isFinite(number)) {
-    failures.push(`${row.sourceFile}:${row.lineNumber} invalid number: ${column}`);
+    addFailure(failures, row, "INVALID_NUMBER", `invalid number: ${column}`, { numeric: true }, { value });
     return null;
   }
   return number;
+}
+
+function addFailure(failures, row, type, message, expected, actual) {
+  failures.push({
+    caseId: row.case_id || `${row.sourceFile}:${row.lineNumber}`,
+    type,
+    message,
+    sourceFile: row.sourceFile,
+    lineNumber: row.lineNumber,
+    expected,
+    actual,
+  });
+}
+
+function rate(count, total) {
+  return total === 0 ? 0 : count / total;
 }
 
 function percentile(sortedValues, percentileValue) {

--- a/tools/routes/evaluate-eta-accuracy.test.mjs
+++ b/tools/routes/evaluate-eta-accuracy.test.mjs
@@ -33,9 +33,25 @@ test("ETA evaluator emits the route accuracy report contract", async (t) => {
     manualObservation: 0,
     staleRealtime: 0,
   });
+  assert.deepEqual(report.referenceSourceCounts, {
+    PROVIDER_LIVE_ARRIVAL: 0,
+    STATIC_TIMETABLE_REFERENCE: 0,
+    MANUAL_OBSERVATION: 0,
+    COMPETING_APP_COMPARISON: 0,
+    FIXTURE_EXPECTED: 100,
+  });
+  assert.equal(report.productionSampleSize, 0);
+  assert.equal(report.nonProductionSampleSize, 100);
   assert.equal(report.metrics.sampleSize, 100);
   assert.equal(report.metrics.p50ErrorSeconds, 45);
   assert.equal(report.metrics.p90ErrorSeconds, 90);
+  assert.equal(report.metrics.routeNotFoundRate, 0);
+  assert.equal(report.metrics.wrongTransferCountRate, 0);
+  assert.equal(report.metrics.wrongLineSequenceRate, 0);
+  assert.equal(report.metrics.strictStepFreeFalsePositiveCount, 0);
+  assert.equal(report.metrics.etaSourceMismatchCount, 0);
+  assert.equal(report.metrics.realtimeFallbackMismatchCount, 0);
+  assert.equal(report.metrics.providerStaleMisuseCount, 0);
   assert.deepEqual(report.metrics.singleRide, {
     sampleSize: 35,
     p50ErrorSeconds: 45,
@@ -117,6 +133,91 @@ test("ETA evaluator reports file-local lines and excludes invalid numbers from m
     staleRealtime: 0,
   });
   assert.equal(report.metrics.maxErrorSeconds, 50);
-  assert.ok(report.failures.includes("one_transfer_cases.csv:2 observed ETA error exceeds max"));
-  assert.ok(report.failures.includes("two_transfer_cases.csv:2 invalid number: observed_eta_error_seconds"));
+  assert.ok(report.failures.some((failure) => failure.message === "observed ETA error exceeds max"));
+  assert.ok(report.failures.some((failure) => failure.message === "invalid number: observed_eta_error_seconds"));
+});
+
+test("ETA evaluator emits structured production-safe failures", async (t) => {
+  const dataset = path.join(tmpdir(), `route-accuracy-production-${Date.now()}`);
+  const output = path.join(tmpdir(), `route-accuracy-production-${Date.now()}.json`);
+  t.after(() => rm(dataset, { recursive: true, force: true }));
+  t.after(() => rm(output, { force: true }));
+  await mkdir(dataset, { recursive: true });
+
+  const header = [
+    "case_id",
+    "origin_station_id",
+    "destination_station_id",
+    "departure_time",
+    "mobility_type",
+    "constraint_mode",
+    "realtime_expected",
+    "reference_source",
+    "reference_collected_at",
+    "reference_confidence",
+    "realtime_provider_id",
+    "realtime_supported",
+    "planned_only_allowed",
+    "provider_freshness_status",
+    "expected_eta_source",
+    "actual_eta_source",
+    "expected_line_sequence",
+    "actual_line_sequence",
+    "expected_transfer_count",
+    "actual_transfer_count",
+    "max_eta_error_seconds",
+    "observed_eta_error_seconds",
+    "use_realtime",
+    "actual_route_found",
+    "strict_step_free_expected_status",
+    "actual_edge_types",
+    "notes",
+  ].join(",");
+  const rowsByFile = {
+    "single_ride_cases.csv": "case-live,station-a,station-b,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,true,PROVIDER_LIVE_ARRIVAL,2026-06-30T08:59:30+09:00,HIGH,seoul-topis,true,false,FRESH,REALTIME,REALTIME,line-4,line-4,0,0,100,20,true,true,STEP_FREE,RIDE,live ok",
+    "one_transfer_cases.csv": "case-stale,station-a,station-c,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,true,PROVIDER_LIVE_ARRIVAL,2026-06-30T08:50:00+09:00,LOW,seoul-topis,true,false,STALE,REALTIME,REALTIME,line-4|line-2,line-4|line-2,1,1,100,30,true,true,STEP_FREE,RIDE|TRANSFER,stale live",
+    "two_transfer_cases.csv": "case-transfer,station-a,station-d,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,false,STATIC_TIMETABLE_REFERENCE,2026-06-30T08:55:00+09:00,MEDIUM,,false,true,FRESH,PLANNED,STATIC_LOCAL,line-1|line-2,line-1|line-3,2,1,100,40,false,true,STEP_FREE,RIDE|TRANSFER,wrong transfer",
+    "express_cases.csv": "case-manual,station-a,station-e,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,false,MANUAL_OBSERVATION,2026-06-30T09:30:00+09:00,HIGH,,false,true,FRESH,PLANNED,PLANNED,line-9,line-9,0,0,100,50,false,true,STEP_FREE,RIDE,manual",
+    "out_of_station_transfer_cases.csv": "case-competing,station-a,station-f,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,false,COMPETING_APP_COMPARISON,2026-06-30T09:30:00+09:00,MEDIUM,,false,true,FRESH,PLANNED,PLANNED,line-1|line-8,line-1|line-8,1,1,100,60,false,true,STEP_FREE,RIDE|WALK,competing",
+    "strict_step_free_cases.csv": "case-stair,station-a,station-g,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,false,FIXTURE_EXPECTED,2026-06-30T09:30:00+09:00,LOW,,false,true,FRESH,PLANNED,PLANNED,line-1,line-1,0,0,100,70,false,true,STEP_FREE,RIDE|STAIR,fixture stair",
+  };
+  await Promise.all(Object.entries(rowsByFile).map(([file, row]) => (
+    writeFile(path.join(dataset, file), `${header}\n${row}\n`)
+  )));
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "tools/routes/evaluate-eta-accuracy.mjs",
+      "--dataset",
+      dataset,
+      "--output",
+      output,
+    ], { cwd: root }),
+  );
+
+  const report = JSON.parse(await readFile(output, "utf8"));
+  assert.deepEqual(report.referenceSourceCounts, {
+    PROVIDER_LIVE_ARRIVAL: 2,
+    STATIC_TIMETABLE_REFERENCE: 1,
+    MANUAL_OBSERVATION: 1,
+    COMPETING_APP_COMPARISON: 1,
+    FIXTURE_EXPECTED: 1,
+  });
+  assert.equal(report.productionSampleSize, 3);
+  assert.equal(report.nonProductionSampleSize, 3);
+  assert.equal(report.metrics.wrongTransferCountRate, 1 / 6);
+  assert.equal(report.metrics.wrongLineSequenceRate, 1 / 6);
+  assert.equal(report.metrics.strictStepFreeFalsePositiveCount, 1);
+  assert.equal(report.metrics.etaSourceMismatchCount, 1);
+  assert.equal(report.metrics.realtimeFallbackMismatchCount, 0);
+  assert.equal(report.metrics.providerStaleMisuseCount, 1);
+  assert.ok(report.failures.some((failure) => (
+    failure.caseId === "case-stale" && failure.type === "PROVIDER_STALE_MISUSE"
+  )));
+  assert.ok(report.failures.some((failure) => (
+    failure.caseId === "case-transfer" && failure.type === "WRONG_TRANSFER_COUNT"
+  )));
+  assert.ok(report.failures.some((failure) => (
+    failure.caseId === "case-stair" && failure.type === "ACCESSIBILITY_FALSE_POSITIVE"
+  )));
 });

--- a/tools/routes/evaluate-eta-accuracy.test.mjs
+++ b/tools/routes/evaluate-eta-accuracy.test.mjs
@@ -174,10 +174,16 @@ test("ETA evaluator emits structured production-safe failures", async (t) => {
     "notes",
   ].join(",");
   const rowsByFile = {
-    "single_ride_cases.csv": "case-live,station-a,station-b,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,true,PROVIDER_LIVE_ARRIVAL,2026-06-30T08:59:30+09:00,HIGH,seoul-topis,true,false,FRESH,REALTIME,REALTIME,line-4,line-4,0,0,100,20,true,true,STEP_FREE,RIDE,live ok",
+    "single_ride_cases.csv": [
+      "case-live,station-a,station-b,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,true,PROVIDER_LIVE_ARRIVAL,2026-06-30T08:59:30+09:00,HIGH,seoul-topis,true,false,FRESH,REALTIME,REALTIME,line-4,line-4,0,0,100,20,true,true,STEP_FREE,RIDE,live ok",
+      "case-fallback,station-a,station-h,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,true,PROVIDER_LIVE_ARRIVAL,2026-06-30T08:59:40+09:00,HIGH,seoul-topis,true,false,FRESH,REALTIME,STATIC_LOCAL,line-4,line-4,0,0,100,25,true,true,STEP_FREE,RIDE,provider fallback",
+    ].join("\n"),
     "one_transfer_cases.csv": "case-stale,station-a,station-c,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,true,PROVIDER_LIVE_ARRIVAL,2026-06-30T08:50:00+09:00,LOW,seoul-topis,true,false,STALE,REALTIME,REALTIME,line-4|line-2,line-4|line-2,1,1,100,30,true,true,STEP_FREE,RIDE|TRANSFER,stale live",
     "two_transfer_cases.csv": "case-transfer,station-a,station-d,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,false,STATIC_TIMETABLE_REFERENCE,2026-06-30T08:55:00+09:00,MEDIUM,,false,true,FRESH,PLANNED,STATIC_LOCAL,line-1|line-2,line-1|line-3,2,1,100,40,false,true,STEP_FREE,RIDE|TRANSFER,wrong transfer",
-    "express_cases.csv": "case-manual,station-a,station-e,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,false,MANUAL_OBSERVATION,2026-06-30T09:30:00+09:00,HIGH,,false,true,FRESH,PLANNED,PLANNED,line-9,line-9,0,0,100,50,false,true,STEP_FREE,RIDE,manual",
+    "express_cases.csv": [
+      "case-manual,station-a,station-e,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,false,MANUAL_OBSERVATION,2026-06-30T09:30:00+09:00,HIGH,,false,true,FRESH,PLANNED,PLANNED,line-9,line-9,0,0,100,50,false,true,STEP_FREE,RIDE,manual",
+      "case-not-found,station-a,station-i,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,false,MANUAL_OBSERVATION,2026-06-30T09:30:00+09:00,HIGH,,false,true,FRESH,PLANNED,PLANNED,line-9,line-9,0,0,100,55,false,false,STEP_FREE,RIDE,route missing",
+    ].join("\n"),
     "out_of_station_transfer_cases.csv": "case-competing,station-a,station-f,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,false,COMPETING_APP_COMPARISON,2026-06-30T09:30:00+09:00,MEDIUM,,false,true,FRESH,PLANNED,PLANNED,line-1|line-8,line-1|line-8,1,1,100,60,false,true,STEP_FREE,RIDE|WALK,competing",
     "strict_step_free_cases.csv": "case-stair,station-a,station-g,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,false,FIXTURE_EXPECTED,2026-06-30T09:30:00+09:00,LOW,,false,true,FRESH,PLANNED,PLANNED,line-1,line-1,0,0,100,70,false,true,STEP_FREE,RIDE|STAIR,fixture stair",
   };
@@ -197,20 +203,27 @@ test("ETA evaluator emits structured production-safe failures", async (t) => {
 
   const report = JSON.parse(await readFile(output, "utf8"));
   assert.deepEqual(report.referenceSourceCounts, {
-    PROVIDER_LIVE_ARRIVAL: 2,
+    PROVIDER_LIVE_ARRIVAL: 3,
     STATIC_TIMETABLE_REFERENCE: 1,
-    MANUAL_OBSERVATION: 1,
+    MANUAL_OBSERVATION: 2,
     COMPETING_APP_COMPARISON: 1,
     FIXTURE_EXPECTED: 1,
   });
-  assert.equal(report.productionSampleSize, 3);
+  assert.equal(report.productionSampleSize, 5);
   assert.equal(report.nonProductionSampleSize, 3);
-  assert.equal(report.metrics.wrongTransferCountRate, 1 / 6);
-  assert.equal(report.metrics.wrongLineSequenceRate, 1 / 6);
+  assert.equal(report.metrics.routeNotFoundRate, 1 / 8);
+  assert.equal(report.metrics.wrongTransferCountRate, 1 / 8);
+  assert.equal(report.metrics.wrongLineSequenceRate, 1 / 8);
   assert.equal(report.metrics.strictStepFreeFalsePositiveCount, 1);
-  assert.equal(report.metrics.etaSourceMismatchCount, 1);
-  assert.equal(report.metrics.realtimeFallbackMismatchCount, 0);
+  assert.equal(report.metrics.etaSourceMismatchCount, 2);
+  assert.equal(report.metrics.realtimeFallbackMismatchCount, 1);
   assert.equal(report.metrics.providerStaleMisuseCount, 1);
+  assert.ok(report.failures.some((failure) => (
+    failure.caseId === "case-fallback" && failure.type === "REALTIME_FALLBACK_MISMATCH"
+  )));
+  assert.ok(report.failures.some((failure) => (
+    failure.caseId === "case-not-found" && failure.type === "ROUTE_NOT_FOUND"
+  )));
   assert.ok(report.failures.some((failure) => (
     failure.caseId === "case-stale" && failure.type === "PROVIDER_STALE_MISUSE"
   )));


### PR DESCRIPTION
## Summary
- add production-safe reference source counts and production/non-production sample counts to the route ETA evaluator report
- emit structured failure rows for transfer, line sequence, ETA source, stale realtime, route-not-found, and strict step-free regressions
- make the route commercialization gate prefer evaluator productionSampleSize instead of inferring production evidence from aggregate source counts

## Scope
- UI untouched
- no fallback PASS path added; fixture/static/stale samples remain non-production evidence

## Verification
- node --test tools/routes/*.test.mjs
- node tools/routes/evaluate-eta-accuracy.mjs --dataset tools/routes/golden-od --output /tmp/route-accuracy-report.json
- node --test tools/ci/repository-contract.test.mjs

Refs #1375


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ETA 정확도 보고서에 샘플 분류와 품질 지표가 더 세분화되어 표시됩니다.
  * 상용 샘플 크기 계산이 실제 생산 샘플 정보를 우선 반영하도록 개선되었습니다.
  * 오류가 더 구조화된 형태로 기록되어, 실패 원인을 더 일관되게 확인할 수 있습니다.

* **Tests**
  * 보고서의 카운트/비율 검증 범위가 확장되었습니다.
  * 생산/비생산 샘플 관련 검증과 다양한 품질 오류 케이스 확인이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->