### PR TITLE
[Test] Abuse rehearsal summary case 결과 검증 보강

### DIFF
--- a/apps/mobile/release/abuse-penetration-rehearsal-gate.json
+++ b/apps/mobile/release/abuse-penetration-rehearsal-gate.json
@@ -149,6 +149,13 @@
         "url_header_log_redaction"
       ],
       "summaryFields": ["caseId", "endpoint", "attemptCount", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"],
+      "expectedStatusByCase": {
+        "brute_force_guessing": [401, 403, 429],
+        "replay_after_status_lookup": [401, 403, 409, 410],
+        "cross_report_enumeration": [403, 404],
+        "confirm_endpoint_abuse": [401, 403, 409, 410],
+        "url_header_log_redaction": [200, 204]
+      },
       "forbiddenSummaryValues": ["raw receipt token", "receipt token hash", "authorization header", "session cookie"]
     },
     "signedUploadUrlBoundary": {
@@ -163,6 +170,14 @@
         "signed_url_reuse"
       ],
       "summaryFields": ["caseId", "method", "contentType", "sizeBytes", "ttlSeconds", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"],
+      "expectedStatusByCase": {
+        "method_mismatch": [403, 405],
+        "content_type_mismatch": [400, 403, 415],
+        "size_limit_exceeded": [400, 413],
+        "ttl_expired": [401, 403, 410],
+        "object_key_prefix_traversal": [400, 403],
+        "signed_url_reuse": [403, 409, 410]
+      },
       "forbiddenSummaryValues": ["raw signed URL", "object storage credential", "object key with user identifier", "photo binary"]
     },
     "reportUploadLifecycle": {
@@ -178,6 +193,15 @@
         "malicious_photo_upload"
       ],
       "summaryFields": ["caseId", "apiStep", "expectedStatus", "observedStatus", "cleanupResult", "redactionResult", "localEvidencePath"],
+      "expectedStatusByCase": {
+        "upload_intent_abuse": [400, 403, 429],
+        "duplicate_claim": [409],
+        "submit_without_valid_claim": [400, 403, 409],
+        "status_lookup_without_valid_receipt": [401, 403, 404],
+        "confirm_without_valid_receipt": [401, 403, 404, 409],
+        "orphan_cleanup_after_failed_claim": [200, 204],
+        "malicious_photo_upload": [400, 403, 413, 415]
+      },
       "forbiddenSummaryValues": ["raw receipt token", "raw signed URL", "photo binary", "precise coordinates"]
     },
     "adminOperatorSecurity": {
@@ -194,6 +218,16 @@
         "break_glass_audit_redaction"
       ],
       "summaryFields": ["caseId", "role", "tenantScope", "endpoint", "expectedStatus", "observedStatus", "redactionResult", "auditRedactionResult", "localEvidencePath"],
+      "expectedStatusByCase": {
+        "login_failure_lockout": [401, 403, 423, 429],
+        "logout_session_invalidation": [401, 403],
+        "session_expiry": [401, 403],
+        "csrf_missing_mutation": [403],
+        "role_denied_personal_data": [403, 404],
+        "role_denied_photo_read": [403, 404],
+        "tenant_authorization_bypass": [403, 404],
+        "break_glass_audit_redaction": [200, 204]
+      },
       "forbiddenSummaryValues": ["operator password", "session cookie", "csrf token", "raw personal data", "raw photo metadata"]
     },
     "objectStorageLifecycle": {
@@ -207,6 +241,13 @@
         "storage_audit_redaction"
       ],
       "summaryFields": ["caseId", "bucketOrPolicyAlias", "retentionRule", "deleteOrCleanupResult", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"],
+      "expectedStatusByCase": {
+        "orphan_object_cleanup": [200, 204],
+        "retention_policy_record": [200, 204],
+        "delete_after_report_deletion": [200, 204, 404, 410],
+        "signed_url_expiry_enforced": [403, 410],
+        "storage_audit_redaction": [200, 204]
+      },
       "forbiddenSummaryValues": ["raw signed URL", "object storage credential", "photo binary", "full object key"]
     },
     "distributedRateLimitAbuse": {
@@ -220,6 +261,13 @@
         "single_instance_exception_link"
       ],
       "summaryFields": ["caseId", "nodeOrStoreMode", "endpoint", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"],
+      "expectedStatusByCase": {
+        "multi_node_upload_intent_flooding": [429],
+        "claim_submit_status_confirm_flooding": [429],
+        "trusted_proxy_spoofing": [400, 403],
+        "abuse_store_mode_record": [200, 204],
+        "single_instance_exception_link": [200, 204]
+      },
       "forbiddenSummaryValues": ["raw receipt token", "raw signed URL", "client IP full address", "trusted proxy credential"]
     },
     "providerReleaseSecretExposure": {
@@ -233,6 +281,13 @@
         "pr_evidence_redaction"
       ],
       "summaryFields": ["caseId", "artifactType", "scanTarget", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"],
+      "expectedStatusByCase": {
+        "tracked_secret_search": [0],
+        "android_artifact_secret_scan": [0],
+        "backend_image_env_redaction": [0],
+        "release_endpoint_allowlist_diff": [0],
+        "pr_evidence_redaction": [0]
+      },
       "forbiddenSummaryValues": ["provider secret", "object storage credential", "production password", "signing private key", "local or internal endpoint"]
     }
   },

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2027,6 +2027,15 @@ test("모바일 signed release artifact gate는 CI 산출물과 스토어 제출
     for (const field of ["caseId", "expectedStatus", "observedStatus", "redactionResult", "localEvidencePath"]) {
       assert.ok(matrix.summaryFields.includes(field), `${matrixId} must include PR summary field ${field}`);
     }
+    assert.equal(typeof matrix.expectedStatusByCase, "object", `${matrixId} must define expected statuses by case`);
+    for (const caseId of requiredCases) {
+      assert.ok(Array.isArray(matrix.expectedStatusByCase[caseId]), `${matrixId}.${caseId} must define expected statuses`);
+      assert.ok(matrix.expectedStatusByCase[caseId].length > 0, `${matrixId}.${caseId} expected statuses must not be empty`);
+      assert.ok(
+        matrix.expectedStatusByCase[caseId].every(Number.isInteger),
+        `${matrixId}.${caseId} expected statuses must be integer status codes`,
+      );
+    }
     assert.ok(Array.isArray(matrix.requiredEvidence), `${matrixId} must define evidence`);
     assert.ok(matrix.requiredEvidence.length > 0, `${matrixId} must require evidence`);
     assert.ok(Array.isArray(matrix.forbiddenSummaryValues), `${matrixId} must forbid sensitive summary values`);

--- a/tools/security/validate-abuse-penetration-summary.mjs
+++ b/tools/security/validate-abuse-penetration-summary.mjs
@@ -72,9 +72,24 @@ function assertFindingCounts(matrixSummary, requirePass, gate) {
   }
 }
 
-function assertCasePass(matrixId, caseId, item) {
+function expectedStatuses(matrixId, caseId, matrix) {
+  const statuses = required(matrix.expectedStatusByCase?.[caseId], `${matrixId}.expectedStatusByCase.${caseId}`);
+  if (!Array.isArray(statuses) || statuses.length === 0 || !statuses.every(Number.isInteger)) {
+    throw new Error(`${matrixId}.expectedStatusByCase.${caseId} must be non-empty integer status list`);
+  }
+  return statuses;
+}
+
+function assertCasePass(matrixId, caseId, item, matrix) {
   if (item.observedStatus !== item.expectedStatus) {
     throw new Error(`${matrixId}.cases.${caseId}.observedStatus must match expectedStatus`);
+  }
+  const statuses = expectedStatuses(matrixId, caseId, matrix);
+  if (!statuses.includes(item.expectedStatus)) {
+    throw new Error(`${matrixId}.cases.${caseId}.expectedStatus must match release gate`);
+  }
+  if (!statuses.includes(item.observedStatus)) {
+    throw new Error(`${matrixId}.cases.${caseId}.observedStatus must match release gate`);
   }
   for (const field of ["redactionResult", "auditRedactionResult", "cleanupResult", "deleteOrCleanupResult"]) {
     if (item[field] !== undefined && item[field] !== "PASS") {
@@ -101,7 +116,7 @@ function assertMatrix(matrixId, matrix, matrixSummary, gate, requirePass) {
     for (const field of matrix.summaryFields) {
       required(item[field], `${matrixId}.cases.${caseId}.${field}`);
     }
-    if (requirePass) assertCasePass(matrixId, caseId, item);
+    if (requirePass) assertCasePass(matrixId, caseId, item, matrix);
   }
 }
 

--- a/tools/security/validate-abuse-penetration-summary.mjs
+++ b/tools/security/validate-abuse-penetration-summary.mjs
@@ -72,7 +72,18 @@ function assertFindingCounts(matrixSummary, requirePass, gate) {
   }
 }
 
-function assertMatrix(matrixId, matrix, matrixSummary, gate) {
+function assertCasePass(matrixId, caseId, item) {
+  if (item.observedStatus !== item.expectedStatus) {
+    throw new Error(`${matrixId}.cases.${caseId}.observedStatus must match expectedStatus`);
+  }
+  for (const field of ["redactionResult", "auditRedactionResult", "cleanupResult", "deleteOrCleanupResult"]) {
+    if (item[field] !== undefined && item[field] !== "PASS") {
+      throw new Error(`${matrixId}.cases.${caseId}.${field} must be PASS`);
+    }
+  }
+}
+
+function assertMatrix(matrixId, matrix, matrixSummary, gate, requirePass) {
   required(matrixSummary, `matrices.${matrixId}`);
   if (matrixSummary.scenarioId !== matrix.scenarioId) {
     throw new Error(`${matrixId}.scenarioId must be ${matrix.scenarioId}`);
@@ -90,6 +101,7 @@ function assertMatrix(matrixId, matrix, matrixSummary, gate) {
     for (const field of matrix.summaryFields) {
       required(item[field], `${matrixId}.cases.${caseId}.${field}`);
     }
+    if (requirePass) assertCasePass(matrixId, caseId, item);
   }
 }
 
@@ -113,7 +125,7 @@ async function main() {
   const matrixSummaries = new Map(required(summary.matrices, "matrices").map((matrix) => [matrix.matrixId, matrix]));
   for (const [matrixId, matrix] of Object.entries(gate.rehearsalMatrices)) {
     const matrixSummary = matrixSummaries.get(matrixId);
-    assertMatrix(matrixId, matrix, matrixSummary, gate);
+    assertMatrix(matrixId, matrix, matrixSummary, gate, requirePass);
     assertIdentity(matrixSummary, gate, `${matrixId}.artifactIdentity`, artifactIdentity);
     assertFindingCounts(matrixSummary, requirePass, gate);
   }

--- a/tools/security/validate-abuse-penetration-summary.test.mjs
+++ b/tools/security/validate-abuse-penetration-summary.test.mjs
@@ -19,7 +19,8 @@ const artifactIdentity = {
   backendArtifactSha256: "c".repeat(64),
 };
 
-function caseValue(field) {
+function caseValue(field, matrix, caseId) {
+  if (field === "expectedStatus" || field === "observedStatus") return matrix.expectedStatusByCase[caseId][0];
   return {
     apiStep: "submit",
     artifactType: "android-aab",
@@ -30,11 +31,9 @@ function caseValue(field) {
     contentType: "image/jpeg",
     deleteOrCleanupResult: "PASS",
     endpoint: "/api/v1/reports",
-    expectedStatus: 403,
     localEvidencePath: ".codex/evidence/security/abuse-penetration-rehearsal/rc/redacted-summary.json",
     method: "PUT",
     nodeOrStoreMode: "multi-node",
-    observedStatus: 403,
     redactionResult: "PASS",
     retentionRule: "30d",
     role: "REPORT_REVIEWER",
@@ -64,7 +63,7 @@ function validSummary() {
       requiredEvidence: matrix.requiredEvidence,
       cases: matrix.requiredCases.map((caseId) => {
         const item = { caseId };
-        for (const field of matrix.summaryFields) item[field] = field === "caseId" ? caseId : caseValue(field);
+        for (const field of matrix.summaryFields) item[field] = field === "caseId" ? caseId : caseValue(field, matrix, caseId);
         return item;
       }),
     })),
@@ -178,5 +177,20 @@ test("abuse penetration summary validator rejects case-level failed rehearsal ev
       ], { cwd: root }),
     ),
     /redactionResult must be PASS/,
+  );
+
+  const untrustedStatusPair = validSummary();
+  untrustedStatusPair.matrices[0].cases[0].expectedStatus = 500;
+  untrustedStatusPair.matrices[0].cases[0].observedStatus = 500;
+  await assert.rejects(
+    withSummary(untrustedStatusPair, (summaryPath) =>
+      execFileAsync(process.execPath, [
+        "tools/security/validate-abuse-penetration-summary.mjs",
+        "--summary",
+        summaryPath,
+        "--require-pass",
+      ], { cwd: root }),
+    ),
+    /expectedStatus must match release gate/,
   );
 });

--- a/tools/security/validate-abuse-penetration-summary.test.mjs
+++ b/tools/security/validate-abuse-penetration-summary.test.mjs
@@ -150,3 +150,33 @@ test("abuse penetration summary validator rejects missing cases, raw sensitive m
     /artifactIdentity must match/,
   );
 });
+
+test("abuse penetration summary validator rejects case-level failed rehearsal evidence", async () => {
+  const statusMismatch = validSummary();
+  statusMismatch.matrices[0].cases[0].observedStatus = 200;
+  await assert.rejects(
+    withSummary(statusMismatch, (summaryPath) =>
+      execFileAsync(process.execPath, [
+        "tools/security/validate-abuse-penetration-summary.mjs",
+        "--summary",
+        summaryPath,
+        "--require-pass",
+      ], { cwd: root }),
+    ),
+    /observedStatus must match expectedStatus/,
+  );
+
+  const redactionFailure = validSummary();
+  redactionFailure.matrices[0].cases[0].redactionResult = "FAIL";
+  await assert.rejects(
+    withSummary(redactionFailure, (summaryPath) =>
+      execFileAsync(process.execPath, [
+        "tools/security/validate-abuse-penetration-summary.mjs",
+        "--summary",
+        summaryPath,
+        "--require-pass",
+      ], { cwd: root }),
+    ),
+    /redactionResult must be PASS/,
+  );
+});


### PR DESCRIPTION
## Summary
- require-pass mode에서 abuse rehearsal summary의 case-level observedStatus가 expectedStatus와 일치하는지 검증합니다.
- case-level redaction/cleanup/audit 결과가 FAIL이어도 matrix PASS로 통과하던 경로를 차단합니다.

## Scope
- UI untouched
- no fallback PASS path added
- #1022 전체 수동/외부 evidence는 계속 open 상태로 남깁니다.

## Verification
- node --test tools/security/*.test.mjs
- node --test tools/ci/repository-contract.test.mjs
- git diff --check

Refs #1022