### PR TITLE
[Chore] Android Go-No-Go blocker snapshot 갱신

### DIFF
--- a/apps/mobile/release/release-governance-gate.json
+++ b/apps/mobile/release/release-governance-gate.json
@@ -102,7 +102,6 @@
       "server-minimized-android-release-scope-fixed",
       "android-quality-local-emulator-real-device-smoke-summary",
       "abuse-rehearsal-local-and-store-preflight-summary",
-      "abuse-rehearsal-case-level-summary-gate-hardening",
       "operations-alert-and-mailbox-routing-summary"
     ],
     "remainingP0Blockers": [
@@ -291,7 +290,7 @@
       "status": "IN_PROGRESS",
       "owner": "mobile-ux",
       "nextAction": "Route result V2 badge와 accessibility copy evidence 수집",
-      "evidenceReference": "apps/mobile/release/route-commercialization-gate.json"
+      "evidenceReference": "apps/mobile/release/route-result-v2-ui-copy-gate.json"
     }
   ],
   "childIssueLinks": [547, 571, 1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1230],

--- a/apps/mobile/release/release-governance-gate.json
+++ b/apps/mobile/release/release-governance-gate.json
@@ -89,11 +89,11 @@
     ]
   },
   "latestGoNoGoStatus": {
-    "qaEvidenceDateKst": "2026-06-29",
-    "reviewedMainMergeSha": "a1a6da80b3433c26ae2f5a45b02de86c8f37ce82",
+    "qaEvidenceDateKst": "2026-07-02",
+    "reviewedMainMergeSha": "8df06ae4be931f78ee1b908e286beec1e6bb4954",
     "currentDecision": "NO_GO",
     "decisionOwner": "release-owner",
-    "blockingOpenIssues": [571, 1016, 1018, 1019, 1021, 1022],
+    "blockingOpenIssues": [571, 1016, 1018, 1019, 1021, 1022, 1230],
     "recentlyResolvedEvidence": [
       "production-datapack-release-publish-success",
       "store-distribution-evidence-success",
@@ -102,6 +102,7 @@
       "server-minimized-android-release-scope-fixed",
       "android-quality-local-emulator-real-device-smoke-summary",
       "abuse-rehearsal-local-and-store-preflight-summary",
+      "abuse-rehearsal-case-level-summary-gate-hardening",
       "operations-alert-and-mailbox-routing-summary"
     ],
     "remainingP0Blockers": [
@@ -113,7 +114,8 @@
       "post-launch-review-window-evidence-after-public-release",
       "play-installed-android-quality-performance-recovery-evidence",
       "production-like-abuse-rehearsal-evidence",
-      "play-installed-server-minimized-final-acceptance-evidence"
+      "play-installed-server-minimized-final-acceptance-evidence",
+      "route-result-v2-ui-badge-accessibility-copy-evidence"
     ],
     "remainingApprovalPrerequisites": [
       "release-owner-final-go-approval"
@@ -281,9 +283,18 @@
       "owner": "release-owner",
       "nextAction": "final RC evidence manifest identity와 waiver 판정 동결",
       "evidenceReference": "apps/mobile/release/rc-evidence-manifest-contract.json"
+    },
+    {
+      "id": "G12_ROUTE_RESULT_V2_UI_COPY",
+      "issue": 1230,
+      "priority": "P0",
+      "status": "IN_PROGRESS",
+      "owner": "mobile-ux",
+      "nextAction": "Route result V2 badge와 accessibility copy evidence 수집",
+      "evidenceReference": "apps/mobile/release/route-commercialization-gate.json"
     }
   ],
-  "childIssueLinks": [547, 571, 1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022],
+  "childIssueLinks": [547, 571, 1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1230],
   "evidencePolicy": {
     "localOnlyEvidenceRoot": ".codex/evidence/release/android-release-100/",
     "githubEvidencePolicy": "summary_or_public_link",

--- a/apps/mobile/release/route-result-v2-ui-copy-gate.json
+++ b/apps/mobile/release/route-result-v2-ui-copy-gate.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": 1,
+  "applicationId": "easysubway",
+  "androidApplicationId": "com.easysubway.app",
+  "releaseGate": "route-result-v2-ui-copy",
+  "issue": 1230,
+  "releaseBlockerPolicy": true,
+  "status": "IN_PROGRESS",
+  "currentDecision": "NO_GO",
+  "evidenceRoot": ".codex/evidence/release/android-route-result-v2-ui-copy/<run>/",
+  "latestQaEvidenceStatus": {
+    "qaEvidenceDateKst": "2026-07-02",
+    "resolvedEvidence": [],
+    "remainingEvidence": [
+      "route-result-v2-badge-visible-screenshot",
+      "route-result-v2-accessibility-copy-ui-tree",
+      "route-result-v2-screenreader-label-audit",
+      "route-result-v2-large-touch-target-and-contrast-regression"
+    ],
+    "notClosingReasonKo": "#1230은 Route result V2 badge와 accessibility copy 구현/검증 증거가 아직 동결되지 않아 Android v1 GO 판정 전에 open 유지한다."
+  },
+  "requiredEvidence": {
+    "badgeScreenshotRequired": true,
+    "accessibilityUiTreeRequired": true,
+    "screenReaderCopyAuditRequired": true,
+    "touchTargetAndContrastRegressionRequired": true
+  },
+  "forbiddenEvidence": [
+    "old-route-result-v1-screenshot",
+    "generated-placeholder-copy",
+    "static-json-only-route-result",
+    "unverified-screenreader-summary"
+  ]
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2674,8 +2674,18 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "route-result-v2-screenreader-label-audit",
     "route-result-v2-large-touch-target-and-contrast-regression",
   ]);
-  assert.equal(routeResultV2UiCopyGate.requiredEvidence.badgeScreenshotRequired, true);
-  assert.ok(routeResultV2UiCopyGate.forbiddenEvidence.includes("generated-placeholder-copy"));
+  assert.deepEqual(routeResultV2UiCopyGate.requiredEvidence, {
+    badgeScreenshotRequired: true,
+    accessibilityUiTreeRequired: true,
+    screenReaderCopyAuditRequired: true,
+    touchTargetAndContrastRegressionRequired: true,
+  });
+  assert.deepEqual(routeResultV2UiCopyGate.forbiddenEvidence, [
+    "old-route-result-v1-screenshot",
+    "generated-placeholder-copy",
+    "static-json-only-route-result",
+    "unverified-screenreader-summary",
+  ]);
   assert.deepEqual(
     gate.gates.find((item) => item.issue === 1230),
     {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2632,7 +2632,6 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "server-minimized-android-release-scope-fixed",
     "android-quality-local-emulator-real-device-smoke-summary",
     "abuse-rehearsal-local-and-store-preflight-summary",
-    "abuse-rehearsal-case-level-summary-gate-hardening",
     "operations-alert-and-mailbox-routing-summary",
   ]);
   assert.deepEqual(gate.latestGoNoGoStatus.remainingP0Blockers, [
@@ -2662,7 +2661,33 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
   );
   assert.ok(gate.gates.some((item) => item.issue === 1021 && item.id === "G7_ANDROID_QUALITY"));
   assert.ok(gate.gates.some((item) => item.issue === 1018 && item.id === "G9_GOOGLE_PLAY"));
-  assert.ok(gate.gates.some((item) => item.issue === 1230 && item.id === "G12_ROUTE_RESULT_V2_UI_COPY"));
+  const routeResultV2UiCopyGatePath = "apps/mobile/release/route-result-v2-ui-copy-gate.json";
+  const routeResultV2UiCopyGate = readJson(routeResultV2UiCopyGatePath);
+  assert.equal(routeResultV2UiCopyGate.releaseGate, "route-result-v2-ui-copy");
+  assert.equal(routeResultV2UiCopyGate.issue, 1230);
+  assert.equal(routeResultV2UiCopyGate.status, "IN_PROGRESS");
+  assert.equal(routeResultV2UiCopyGate.currentDecision, "NO_GO");
+  assert.deepEqual(routeResultV2UiCopyGate.latestQaEvidenceStatus.resolvedEvidence, []);
+  assert.deepEqual(routeResultV2UiCopyGate.latestQaEvidenceStatus.remainingEvidence, [
+    "route-result-v2-badge-visible-screenshot",
+    "route-result-v2-accessibility-copy-ui-tree",
+    "route-result-v2-screenreader-label-audit",
+    "route-result-v2-large-touch-target-and-contrast-regression",
+  ]);
+  assert.equal(routeResultV2UiCopyGate.requiredEvidence.badgeScreenshotRequired, true);
+  assert.ok(routeResultV2UiCopyGate.forbiddenEvidence.includes("generated-placeholder-copy"));
+  assert.deepEqual(
+    gate.gates.find((item) => item.issue === 1230),
+    {
+      id: "G12_ROUTE_RESULT_V2_UI_COPY",
+      issue: 1230,
+      priority: "P0",
+      status: "IN_PROGRESS",
+      owner: "mobile-ux",
+      nextAction: "Route result V2 badge와 accessibility copy evidence 수집",
+      evidenceReference: routeResultV2UiCopyGatePath,
+    },
+  );
   assert.deepEqual(
     gate.gates.find((item) => item.issue === 1015),
     {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2619,11 +2619,11 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "post-launch-review-window-evidence-after-public-release",
     "support-incident-response-dry-run-evidence",
   ]);
-  assert.equal(gate.latestGoNoGoStatus.qaEvidenceDateKst, "2026-06-29");
-  assert.equal(gate.latestGoNoGoStatus.reviewedMainMergeSha, "a1a6da80b3433c26ae2f5a45b02de86c8f37ce82");
+  assert.equal(gate.latestGoNoGoStatus.qaEvidenceDateKst, "2026-07-02");
+  assert.equal(gate.latestGoNoGoStatus.reviewedMainMergeSha, "8df06ae4be931f78ee1b908e286beec1e6bb4954");
   assert.equal(gate.latestGoNoGoStatus.currentDecision, "NO_GO");
   assert.equal(gate.latestGoNoGoStatus.decisionOwner, "release-owner");
-  assert.deepEqual(gate.latestGoNoGoStatus.blockingOpenIssues, [571, 1016, 1018, 1019, 1021, 1022]);
+  assert.deepEqual(gate.latestGoNoGoStatus.blockingOpenIssues, [571, 1016, 1018, 1019, 1021, 1022, 1230]);
   assert.deepEqual(gate.latestGoNoGoStatus.recentlyResolvedEvidence, [
     "production-datapack-release-publish-success",
     "store-distribution-evidence-success",
@@ -2632,6 +2632,7 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "server-minimized-android-release-scope-fixed",
     "android-quality-local-emulator-real-device-smoke-summary",
     "abuse-rehearsal-local-and-store-preflight-summary",
+    "abuse-rehearsal-case-level-summary-gate-hardening",
     "operations-alert-and-mailbox-routing-summary",
   ]);
   assert.deepEqual(gate.latestGoNoGoStatus.remainingP0Blockers, [
@@ -2644,6 +2645,7 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "play-installed-android-quality-performance-recovery-evidence",
     "production-like-abuse-rehearsal-evidence",
     "play-installed-server-minimized-final-acceptance-evidence",
+    "route-result-v2-ui-badge-accessibility-copy-evidence",
   ]);
   assert.deepEqual(gate.latestGoNoGoStatus.remainingApprovalPrerequisites, [
     "release-owner-final-go-approval",
@@ -2660,6 +2662,7 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
   );
   assert.ok(gate.gates.some((item) => item.issue === 1021 && item.id === "G7_ANDROID_QUALITY"));
   assert.ok(gate.gates.some((item) => item.issue === 1018 && item.id === "G9_GOOGLE_PLAY"));
+  assert.ok(gate.gates.some((item) => item.issue === 1230 && item.id === "G12_ROUTE_RESULT_V2_UI_COPY"));
   assert.deepEqual(
     gate.gates.find((item) => item.issue === 1015),
     {
@@ -2678,7 +2681,7 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
   );
   assert.deepEqual(
     gate.childIssueLinks,
-    [547, 571, 1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022],
+    [547, 571, 1014, 1015, 1016, 1017, 1018, 1019, 1020, 1021, 1022, 1230],
   );
   for (const item of gate.gates.filter((gateItem) => gateItem.priority.startsWith("P0"))) {
     assert.ok(item.owner, `${item.id} must define owner`);


### PR DESCRIPTION
## 관련 이슈

Refs #1020

## 작업 배경

Android v1 Go/No-Go 판정은 아직 `NO_GO`이며, open P0 blocker와 evidence freeze 상태를 release governance manifest에 최신 main 기준으로 맞춰야 합니다. #1230은 UI 구현을 직접 건드리지 않고 release blocker/evidence gate로만 연결합니다.

## 작업 내용

- `release-governance-gate.json`의 `qaEvidenceDateKst`, `reviewedMainMergeSha`, open blocker 목록을 최신 상태로 갱신했습니다.
- #1230 전용 `route-result-v2-ui-copy-gate.json`을 추가해 badge/accessibility copy 증거가 아직 `IN_PROGRESS`이고 `NO_GO`임을 명시했습니다.
- #1022 관련 resolved evidence는 하위 manifest에 없는 claim을 제거해 과장된 resolved 상태가 통과하지 않도록 했습니다.
- `repository-contract.test.mjs`에서 #1230 gate 전체 객체, required evidence 전체, forbidden evidence 전체를 검증하도록 보강했습니다.

## 범위

- 변경 범위: `apps/mobile/release/*.json`, `tools/ci/repository-contract.test.mjs`
- UI/Flutter 화면 구현 변경 없음
- production/public release 허용 없음: 계속 `NO_GO`

## 증거 및 검증

| 구분 | 결과 |
| --- | --- |
| Local contract | `node --test tools/ci/repository-contract.test.mjs` pass |
| Local whitespace | `git diff --check` pass |
| PR CI | 확인 중 |
| Review | CodeRabbit + Codex CLI fallback review |

## Version Impact

- 앱 runtime/UI 변경 없음
- Android release governance/evidence contract만 변경

## 리스크

- #1230은 실제 UI 구현/스크린샷/UI tree/screen reader evidence가 아직 없으므로 Android v1 GO 조건을 만족하지 않습니다.
- 이 PR은 blocker 상태를 더 명확히 하는 변경이며, release blocker를 해소하지 않습니다.
