### PR TITLE
[Chore] Operations post-launch dry-run evidence 검증

### DIFF
--- a/tools/ops/validate-operations-release-summary.mjs
+++ b/tools/ops/validate-operations-release-summary.mjs
@@ -120,6 +120,10 @@ function assertPostLaunch(summary, gate, artifactIdentity, requirePass) {
   for (const step of gate.fixedReleaseProcedure.requiredSteps) {
     if (!fixedSteps.has(step)) throw new Error(`fixedReleaseSteps missing ${step}`);
   }
+  const dryRunEvidence = new Set(required(summary.postLaunchDryRunEvidence, "postLaunchDryRunEvidence"));
+  for (const evidenceId of gate.dryRunRequiredEvidence) {
+    if (!dryRunEvidence.has(evidenceId)) throw new Error(`postLaunchDryRunEvidence missing ${evidenceId}`);
+  }
 }
 
 function assertSupport(summary, gate, requirePass) {

--- a/tools/ops/validate-operations-release-summary.test.mjs
+++ b/tools/ops/validate-operations-release-summary.test.mjs
@@ -57,6 +57,7 @@ function validSummary() {
       redactionNotes: "summary only; no personal data",
       localEvidencePath: ".codex/evidence/release/post-launch-operations-review/rc/redacted-summary.json",
     })),
+    postLaunchDryRunEvidence: postLaunchGate.dryRunRequiredEvidence,
     supportChannels: supportGate.supportChannels.map((channel) => ({
       channelId: channel.id,
       redactedReceiptReference: "redacted-routing-check",
@@ -112,6 +113,22 @@ test("operations release summary validator compares artifact identity independen
       summaryPath,
       "--require-pass",
     ], { cwd: root }),
+  );
+});
+
+test("operations release summary validator rejects missing post-launch dry-run evidence", async () => {
+  const summary = validSummary();
+  delete summary.postLaunchDryRunEvidence;
+  await assert.rejects(
+    withSummary(summary, (summaryPath) =>
+      execFileAsync(process.execPath, [
+        "tools/ops/validate-operations-release-summary.mjs",
+        "--summary",
+        summaryPath,
+        "--require-pass",
+      ], { cwd: root }),
+    ),
+    /postLaunchDryRunEvidence/,
   );
 });
 


### PR DESCRIPTION
## 관련 이슈

Refs #1019

## 작업 배경

#1019 operations release summary validator가 post-launch review gate의 `dryRunRequiredEvidence`를 실제 summary에서 확인하지 않아, post-launch dry-run evidence가 빠져도 `--require-pass`가 통과할 수 있었습니다.

## 작업 내용

- `postLaunchDryRunEvidence` top-level summary field를 요구하도록 validator를 보강했습니다.
- gate의 `dryRunRequiredEvidence` 전체가 summary에 포함되는지 검증합니다.
- 누락 시 실패하는 regression test를 추가했습니다.

## 범위

- `tools/ops/validate-operations-release-summary.mjs`
- `tools/ops/validate-operations-release-summary.test.mjs`
- UI/Flutter 화면 변경 없음
- #1019 외부 운영 증거 자체를 대체하지 않음

## 검증

- `node --test tools/ops/validate-operations-release-summary.test.mjs`
- `node --test tools/ci/repository-contract.test.mjs`
- `git diff --check`

## 리스크

- 기존 summary producer가 있다면 `postLaunchDryRunEvidence` 배열을 추가해야 합니다.
- 외부 dashboard/inbox/Play evidence가 아직 필요하므로 #1019는 open 유지합니다.
