### PR TITLE
[Chore] Go-No-Go operations evidence snapshot 갱신

### DIFF
--- a/apps/mobile/release/release-governance-gate.json
+++ b/apps/mobile/release/release-governance-gate.json
@@ -90,7 +90,7 @@
   },
   "latestGoNoGoStatus": {
     "qaEvidenceDateKst": "2026-07-02",
-    "reviewedMainMergeSha": "8df06ae4be931f78ee1b908e286beec1e6bb4954",
+    "reviewedMainMergeSha": "da34e5215daf64ae4c1c31a7682d4fa774588074",
     "currentDecision": "NO_GO",
     "decisionOwner": "release-owner",
     "blockingOpenIssues": [571, 1016, 1018, 1019, 1021, 1022, 1230],
@@ -102,7 +102,8 @@
       "server-minimized-android-release-scope-fixed",
       "android-quality-local-emulator-real-device-smoke-summary",
       "abuse-rehearsal-local-and-store-preflight-summary",
-      "operations-alert-and-mailbox-routing-summary"
+      "operations-alert-and-mailbox-routing-summary",
+      "operations-post-launch-dry-run-required-evidence-contract"
     ],
     "remainingP0Blockers": [
       "play-installed-build-provenance",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -2620,7 +2620,7 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "support-incident-response-dry-run-evidence",
   ]);
   assert.equal(gate.latestGoNoGoStatus.qaEvidenceDateKst, "2026-07-02");
-  assert.equal(gate.latestGoNoGoStatus.reviewedMainMergeSha, "8df06ae4be931f78ee1b908e286beec1e6bb4954");
+  assert.equal(gate.latestGoNoGoStatus.reviewedMainMergeSha, "da34e5215daf64ae4c1c31a7682d4fa774588074");
   assert.equal(gate.latestGoNoGoStatus.currentDecision, "NO_GO");
   assert.equal(gate.latestGoNoGoStatus.decisionOwner, "release-owner");
   assert.deepEqual(gate.latestGoNoGoStatus.blockingOpenIssues, [571, 1016, 1018, 1019, 1021, 1022, 1230]);
@@ -2633,6 +2633,7 @@ test("Android release 100 governance gate는 Android-only 범위와 evidence sch
     "android-quality-local-emulator-real-device-smoke-summary",
     "abuse-rehearsal-local-and-store-preflight-summary",
     "operations-alert-and-mailbox-routing-summary",
+    "operations-post-launch-dry-run-required-evidence-contract",
   ]);
   assert.deepEqual(gate.latestGoNoGoStatus.remainingP0Blockers, [
     "play-installed-build-provenance",


### PR DESCRIPTION
Refs #1020

## 변경
- 최신 main merge commit `da34e5215daf64ae4c1c31a7682d4fa774588074` 기준으로 Go/No-Go snapshot을 갱신했습니다.
- #1379의 operations post-launch dry-run required evidence contract 보강을 `recentlyResolvedEvidence`에 연결했습니다.
- `currentDecision=NO_GO`, open blocker 목록, production submit/public release 차단 상태는 유지했습니다.

## fallback 주의
- 실제 Play-installed, Play Console, Android vitals, production-like rehearsal, support dry-run 증거는 대체하지 않았습니다.
- 이번 PR은 누락 증거를 PASS로 처리하지 않고, 최신 contract 보강분만 release governance snapshot에 연결합니다.

## 검증
- RED: `node --test --test-name-pattern "Android release 100 governance gate" tools/ci/repository-contract.test.mjs`가 기존 SHA 불일치로 실패하는 것을 확인
- GREEN: `node --test --test-name-pattern "Android release 100 governance gate" tools/ci/repository-contract.test.mjs`
- `node -e 'JSON.parse(require("fs").readFileSync("apps/mobile/release/release-governance-gate.json", "utf8")); console.log("release governance json ok")'`\n- `node --test tools/ci/repository-contract.test.mjs`\n- `git diff --check`