### PR TITLE
[Chore] Abuse rehearsal evidence closure guard 추가

### DIFF
--- a/apps/mobile/release/abuse-penetration-rehearsal-gate.json
+++ b/apps/mobile/release/abuse-penetration-rehearsal-gate.json
@@ -56,6 +56,26 @@
       ]
     }
   },
+  "productionLikeEvidencePolicy": {
+    "requiredForClosing": [
+      "play-installed-or-play-generated-artifact-identity",
+      "network-trace-from-play-installed-or-generated-build",
+      "deployed-public-https-backend-base-url",
+      "deployed-admin-security-negative-test",
+      "deployed-signed-url-boundary-run",
+      "deployed-object-storage-lifecycle-run",
+      "distributed-or-waived-rate-limit-rehearsal"
+    ],
+    "forbiddenClosureEvidence": [
+      "static gate JSON",
+      "fixture output only",
+      "preflight env check only",
+      "local selected tests only",
+      "stale evidence from previous RC"
+    ],
+    "missingEvidenceDisposition": "KEEP_OPEN_NO_GO",
+    "policyKo": "#1022는 Play-generated/Play-installed artifact와 deployed production-like backend/object-storage rehearsal 증거가 없으면 preflight, local selected test, static contract만으로 완료 처리하지 않는다."
+  },
   "buildIdentityPolicy": {
     "requiredIssueLinks": ["#1015", "#1016", "#1020"],
     "acceptedArtifactSources": ["rc-aab", "play-generated-apk", "play-installed-build", "backend-release-image"],

--- a/tools/ci/provider-security-boundary.test.mjs
+++ b/tools/ci/provider-security-boundary.test.mjs
@@ -42,6 +42,17 @@ test("provider credential과 release artifact security boundary regression을 �
   assert.ok(providerExposureMatrix.forbiddenSummaryValues.includes("object storage credential"));
   assert.ok(providerExposureMatrix.forbiddenSummaryValues.includes("local or internal endpoint"));
 
+  assert.equal(abuseGate.productionLikeEvidencePolicy.missingEvidenceDisposition, "KEEP_OPEN_NO_GO");
+  assert.ok(
+    abuseGate.productionLikeEvidencePolicy.requiredForClosing.includes("play-installed-or-play-generated-artifact-identity"),
+  );
+  assert.ok(
+    abuseGate.productionLikeEvidencePolicy.requiredForClosing.includes("deployed-public-https-backend-base-url"),
+  );
+  assert.ok(abuseGate.productionLikeEvidencePolicy.forbiddenClosureEvidence.includes("preflight env check only"));
+  assert.ok(abuseGate.productionLikeEvidencePolicy.forbiddenClosureEvidence.includes("local selected tests only"));
+  assert.ok(abuseGate.productionLikeEvidencePolicy.forbiddenClosureEvidence.includes("stale evidence from previous RC"));
+
   assert.doesNotMatch(releaseArtifactsWorkflow, /EASYSUBWAY_OBJECT_STORAGE_(?:ACCESS_KEY|SECRET_KEY|ENDPOINT|REGION)/);
   assert.doesNotMatch(releaseArtifactsWorkflow, /EASYSUBWAY_[A-Z0-9_]*(?:PROVIDER|REALTIME)[A-Z0-9_]*KEY/);
   assert.doesNotMatch(androidBuildGradle, /EASYSUBWAY_OBJECT_STORAGE|PROVIDER_API_KEY|REALTIME_PROVIDER_KEY/);

--- a/tools/security/validate-abuse-penetration-summary.mjs
+++ b/tools/security/validate-abuse-penetration-summary.mjs
@@ -21,6 +21,7 @@ function assertNoSensitiveSummary(summary, gate) {
     ...gate.manualRehearsalPolicy.forbiddenInEvidence,
     ...Object.values(gate.rehearsalMatrices).flatMap((matrix) => matrix.forbiddenSummaryValues),
     ...gate.latestQaEvidenceStatus.redactionPolicy.forbiddenInGitHubEvidence,
+    ...gate.productionLikeEvidencePolicy.forbiddenClosureEvidence,
   ].map((value) => value.toLowerCase()));
   for (const [path, value] of collectStrings(summary)) {
     const normalized = value.toLowerCase();

--- a/tools/security/validate-abuse-penetration-summary.mjs
+++ b/tools/security/validate-abuse-penetration-summary.mjs
@@ -72,6 +72,19 @@ function assertFindingCounts(matrixSummary, requirePass, gate) {
   }
 }
 
+function assertProductionLikeEvidence(summary, gate, requirePass) {
+  if (!requirePass) return;
+
+  const evidenceById = new Map(
+    required(summary.productionLikeEvidence, "productionLikeEvidence").map((item) => [item.evidenceId, item]),
+  );
+  for (const evidenceId of gate.productionLikeEvidencePolicy.requiredForClosing) {
+    const evidence = required(evidenceById.get(evidenceId), `productionLikeEvidence missing ${evidenceId}`);
+    if (evidence.result !== "PASS") throw new Error(`productionLikeEvidence.${evidenceId}.result must be PASS`);
+    required(evidence.localEvidencePath, `productionLikeEvidence.${evidenceId}.localEvidencePath`);
+  }
+}
+
 function expectedStatuses(matrixId, caseId, matrix) {
   const statuses = required(matrix.expectedStatusByCase?.[caseId], `${matrixId}.expectedStatusByCase.${caseId}`);
   if (!Array.isArray(statuses) || statuses.length === 0 || !statuses.every(Number.isInteger)) {
@@ -136,6 +149,7 @@ async function main() {
 
   const artifactIdentity = assertIdentity(summary, gate);
   assertNoSensitiveSummary(summary, gate);
+  assertProductionLikeEvidence(summary, gate, requirePass);
 
   const matrixSummaries = new Map(required(summary.matrices, "matrices").map((matrix) => [matrix.matrixId, matrix]));
   for (const [matrixId, matrix] of Object.entries(gate.rehearsalMatrices)) {

--- a/tools/security/validate-abuse-penetration-summary.test.mjs
+++ b/tools/security/validate-abuse-penetration-summary.test.mjs
@@ -111,6 +111,22 @@ test("abuse penetration summary validator rejects pass without production-like c
   );
 });
 
+test("abuse penetration summary validator rejects forbidden closure evidence markers", async () => {
+  const forbiddenClosureEvidence = validSummary();
+  forbiddenClosureEvidence.productionLikeEvidence[0].source = "preflight env check only";
+  await assert.rejects(
+    withSummary(forbiddenClosureEvidence, (summaryPath) =>
+      execFileAsync(process.execPath, [
+        "tools/security/validate-abuse-penetration-summary.mjs",
+        "--summary",
+        summaryPath,
+        "--require-pass",
+      ], { cwd: root }),
+    ),
+    /forbidden sensitive evidence marker/,
+  );
+});
+
 test("abuse penetration summary validator rejects missing cases, raw sensitive markers, and high findings", async () => {
   const missingCase = validSummary();
   missingCase.matrices[0].cases.pop();

--- a/tools/security/validate-abuse-penetration-summary.test.mjs
+++ b/tools/security/validate-abuse-penetration-summary.test.mjs
@@ -51,6 +51,11 @@ function validSummary() {
     issue: gate.issue,
     status: "PASS",
     artifactIdentity: { ...artifactIdentity },
+    productionLikeEvidence: gate.productionLikeEvidencePolicy.requiredForClosing.map((evidenceId) => ({
+      evidenceId,
+      result: "PASS",
+      localEvidencePath: ".codex/evidence/security/abuse-penetration-rehearsal/rc/redacted-summary.json",
+    })),
     matrices: Object.entries(gate.rehearsalMatrices).map(([matrixId, matrix]) => ({
       matrixId,
       scenarioId: matrix.scenarioId,
@@ -87,6 +92,22 @@ test("abuse penetration summary validator accepts a complete redacted matrix sum
       summaryPath,
       "--require-pass",
     ], { cwd: root }),
+  );
+});
+
+test("abuse penetration summary validator rejects pass without production-like closure evidence", async () => {
+  const missingProductionEvidence = validSummary();
+  missingProductionEvidence.productionLikeEvidence.pop();
+  await assert.rejects(
+    withSummary(missingProductionEvidence, (summaryPath) =>
+      execFileAsync(process.execPath, [
+        "tools/security/validate-abuse-penetration-summary.mjs",
+        "--summary",
+        summaryPath,
+        "--require-pass",
+      ], { cwd: root }),
+    ),
+    /productionLikeEvidence missing/,
   );
 });
 


### PR DESCRIPTION
## Summary
- Add a #1022 production-like evidence policy to the abuse penetration rehearsal gate.
- Forbid closing #1022 with static gate JSON, fixture-only output, preflight env checks, local selected tests, or stale evidence from a previous RC.
- Cover the policy in provider/security boundary regression tests.

## Scope
- No UI or Flutter screen changes.
- Does not fabricate or replace external Play/deployed evidence; #1022 remains open until required evidence exists.

## Verification
- RED: `node --test tools/ci/provider-security-boundary.test.mjs` failed before the JSON policy existed.
- GREEN: `node --test tools/ci/provider-security-boundary.test.mjs`
- `node --test tools/ci/repository-contract.test.mjs`
- `node -e "JSON.parse(require('fs').readFileSync('apps/mobile/release/abuse-penetration-rehearsal-gate.json','utf8')); console.log('json ok')"`
- `git diff --check`

Refs #1022