### PR TITLE
[Feat] Route V2 badge signals 보존

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1113,6 +1113,11 @@ class RouteSearchResult {
     required this.blockedReasons,
     required this.createdAt,
     this.etaSource = '',
+    this.etaConfidence = '',
+    this.accessibilityRiskLevel = '',
+    this.transferSlackSeconds,
+    this.hasOutOfStationTransfer = false,
+    this.commercialEtaEligible = false,
   }) : // `burdenCost`는 API contract 이름이고 저장 필드는 private 값이다.
        // ignore: prefer_initializing_formals
        _accessibilityScore = accessibilityScore,
@@ -1208,6 +1213,16 @@ class RouteSearchResult {
           .toList(growable: false),
       createdAt: _requiredRouteString(json, 'createdAt'),
       etaSource: _optionalRouteString(json, 'etaSource'),
+      etaConfidence: _optionalRouteString(json, 'etaConfidence'),
+      accessibilityRiskLevel: _optionalRouteString(
+        json,
+        'accessibilityRiskLevel',
+      ),
+      transferSlackSeconds: _optionalRouteInt(json, 'transferSlackSeconds'),
+      hasOutOfStationTransfer:
+          _optionalRouteBool(json, 'hasOutOfStationTransfer') ?? false,
+      commercialEtaEligible:
+          _optionalRouteBool(json, 'commercialEtaEligible') ?? false,
     );
   }
 
@@ -1260,6 +1275,13 @@ class RouteSearchResult {
           : itinerary.accessibilityRisk.reasonCodes,
       createdAt: result.departureTime,
       etaSource: itinerary.etaSource,
+      etaConfidence: itinerary.etaConfidence,
+      accessibilityRiskLevel: itinerary.accessibilityRisk.riskLevel,
+      transferSlackSeconds: _routeV2TransferSlackSeconds(itinerary.legs),
+      hasOutOfStationTransfer: itinerary.legs.any(
+        (leg) => leg.legType == 'OUT_OF_STATION_TRANSFER',
+      ),
+      commercialEtaEligible: itinerary.commercialEtaEligible,
     );
   }
 
@@ -1286,6 +1308,11 @@ class RouteSearchResult {
   final List<String> blockedReasons;
   final String createdAt;
   final String etaSource;
+  final String etaConfidence;
+  final String accessibilityRiskLevel;
+  final int? transferSlackSeconds;
+  final bool hasOutOfStationTransfer;
+  final bool commercialEtaEligible;
 
   int get accessibilityScore => _accessibilityScore ?? score;
 
@@ -1411,6 +1438,11 @@ class RouteSearchResult {
       blockedReasons: blockedReasons,
       createdAt: createdAt,
       etaSource: etaSource ?? this.etaSource,
+      etaConfidence: etaConfidence,
+      accessibilityRiskLevel: accessibilityRiskLevel,
+      transferSlackSeconds: transferSlackSeconds,
+      hasOutOfStationTransfer: hasOutOfStationTransfer,
+      commercialEtaEligible: commercialEtaEligible,
     );
   }
 
@@ -2034,6 +2066,22 @@ bool _isRouteTransferStepType(String stepType) {
   return stepType == 'transfer' ||
       stepType == 'inStationTransfer' ||
       stepType == 'outOfStationTransfer';
+}
+
+int? _routeV2TransferSlackSeconds(List<RouteSearchV2Leg> legs) {
+  final transferSlacks = legs
+      .where(
+        (leg) =>
+            leg.legType == 'TRANSFER' ||
+            leg.legType == 'OUT_OF_STATION_TRANSFER',
+      )
+      .map((leg) => leg.slackSeconds)
+      .toList(growable: false);
+  if (transferSlacks.isEmpty) {
+    return null;
+  }
+  transferSlacks.sort();
+  return transferSlacks.first;
 }
 
 class RouteSearchWarning {
@@ -6025,4 +6073,12 @@ bool _requiredRouteBool(Map<String, Object?> json, String key) {
     return value;
   }
   throw FormatException('Missing required route field: $key');
+}
+
+bool? _optionalRouteBool(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is bool) {
+    return value;
+  }
+  return null;
 }

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2073,6 +2073,8 @@ int? _routeV2TransferSlackSeconds(List<RouteSearchV2Leg> legs) {
       .where(
         (leg) =>
             leg.legType == 'TRANSFER' ||
+            leg.legType == 'IN_STATION_TRANSFER' ||
+            leg.legType == 'LEGACY_TRANSFER' ||
             leg.legType == 'OUT_OF_STATION_TRANSFER',
       )
       .map((leg) => leg.slackSeconds)

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -748,6 +748,38 @@ void main() {
                 'reasons': <Object?>[],
               },
             },
+            {
+              'legType': 'IN_STATION_TRANSFER',
+              'fromStationId': 'station-transfer',
+              'toStationId': 'station-transfer',
+              'fromNodeId': '',
+              'toNodeId': '',
+              'lineId': '',
+              'tripId': '',
+              'trainNo': '',
+              'plannedDepartureTime': '2026-06-30T09:24:00+09:00',
+              'realtimeDepartureTime': null,
+              'plannedArrivalTime': '2026-06-30T09:25:00+09:00',
+              'realtimeArrivalTime': null,
+              'waitTimeSeconds': 0,
+              'slackSeconds': 45,
+              'durationSeconds': 60,
+              'distanceMeters': 40,
+              'etaSource': 'PLANNED',
+              'confidence': 'MEDIUM',
+              'accessibilityRisk': {
+                'stairCount': 0,
+                'unknownAccessibilityCount': 0,
+                'generatedConnectorCount': 0,
+                'staleDataCount': 0,
+                'lowConfidenceCount': 0,
+                'unavailableFacilityCount': 0,
+                'riskLevel': 'LOW',
+                'reasonCodes': <Object?>[],
+                'level': 'LOW',
+                'reasons': <Object?>[],
+              },
+            },
           ],
           'commercialEtaEligible': false,
         },
@@ -814,7 +846,7 @@ void main() {
     expect(displayResult.steps.first.metricSourceLabel, '서버 경로 안내 기준이에요');
     expect(displayResult.etaConfidence, 'LOW');
     expect(displayResult.accessibilityRiskLevel, 'HIGH');
-    expect(displayResult.transferSlackSeconds, 90);
+    expect(displayResult.transferSlackSeconds, 45);
     expect(displayResult.hasOutOfStationTransfer, isTrue);
     expect(displayResult.commercialEtaEligible, isFalse);
   });
@@ -928,6 +960,8 @@ void main() {
     expect(result.steps.last.estimatedMinutes, 26);
     expect(result.steps.first.stairAccessState, 'unknown');
     expect(result.stairAccessLabel, '계단 여부를 아직 알 수 없어요');
+    expect(result.transferSlackSeconds, isNull);
+    expect(result.hasOutOfStationTransfer, isFalse);
   });
 
   test('경로 V2 blocked reasonCodes가 비어 있으면 status를 보존한다', () {

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -662,7 +662,7 @@ void main() {
           'etaSource': 'STATIC_BACKEND_V1',
           'etaConfidence': 'LOW',
           'durationSeconds': 420,
-          'transferCount': 0,
+          'transferCount': 1,
           'walkingDistanceMeters': 180,
           'accessibilityRisk': {
             'stairCount': 1,
@@ -714,6 +714,38 @@ void main() {
                 ],
                 'level': 'REVIEW_REQUIRED',
                 'reasons': ['ACCESSIBILITY_CHECK_REQUIRED'],
+              },
+            },
+            {
+              'legType': 'OUT_OF_STATION_TRANSFER',
+              'fromStationId': 'station-sangnoksu',
+              'toStationId': 'station-transfer',
+              'fromNodeId': '',
+              'toNodeId': '',
+              'lineId': '',
+              'tripId': '',
+              'trainNo': '',
+              'plannedDepartureTime': '2026-06-30T09:22:00+09:00',
+              'realtimeDepartureTime': null,
+              'plannedArrivalTime': '2026-06-30T09:24:00+09:00',
+              'realtimeArrivalTime': null,
+              'waitTimeSeconds': 0,
+              'slackSeconds': 90,
+              'durationSeconds': 120,
+              'distanceMeters': 80,
+              'etaSource': 'PLANNED',
+              'confidence': 'MEDIUM',
+              'accessibilityRisk': {
+                'stairCount': 0,
+                'unknownAccessibilityCount': 0,
+                'generatedConnectorCount': 0,
+                'staleDataCount': 0,
+                'lowConfidenceCount': 0,
+                'unavailableFacilityCount': 0,
+                'riskLevel': 'LOW',
+                'reasonCodes': <Object?>[],
+                'level': 'LOW',
+                'reasons': <Object?>[],
               },
             },
           ],
@@ -770,18 +802,21 @@ void main() {
       result.itineraries.first.accessibilityRisk.reasonCodes,
       contains('STALE_ACCESSIBILITY_DATA'),
     );
-    expect(result.itineraries.first.legs.single.legType, 'ACCESS');
+    expect(result.itineraries.first.legs.first.legType, 'ACCESS');
     expect(
-      result.itineraries.first.legs.single.accessibilityRisk.riskLevel,
+      result.itineraries.first.legs.first.accessibilityRisk.riskLevel,
       'HIGH',
     );
-    expect(result.itineraries.first.legs.single.waitTimeSeconds, 0);
-    expect(result.itineraries.first.legs.single.slackSeconds, 0);
-    expect(result.itineraries.first.legs.single.etaSource, 'STATIC_BACKEND_V1');
-    expect(
-      RouteSearchResult.fromV2(result).steps.single.metricSourceLabel,
-      '서버 경로 안내 기준이에요',
-    );
+    expect(result.itineraries.first.legs.first.waitTimeSeconds, 0);
+    expect(result.itineraries.first.legs.first.slackSeconds, 0);
+    expect(result.itineraries.first.legs.first.etaSource, 'STATIC_BACKEND_V1');
+    final displayResult = RouteSearchResult.fromV2(result);
+    expect(displayResult.steps.first.metricSourceLabel, '서버 경로 안내 기준이에요');
+    expect(displayResult.etaConfidence, 'LOW');
+    expect(displayResult.accessibilityRiskLevel, 'HIGH');
+    expect(displayResult.transferSlackSeconds, 90);
+    expect(displayResult.hasOutOfStationTransfer, isTrue);
+    expect(displayResult.commercialEtaEligible, isFalse);
   });
 
   test('경로 V2 변환은 ride 노선과 불확실 접근성을 보수적으로 표시한다', () {


### PR DESCRIPTION
## Summary
- Preserve Route V2 ETA confidence, accessibility risk level, transfer slack, out-of-station transfer, and commercial ETA eligibility on the mobile route display model.
- Add route search contract coverage so future badges can read explicit API fields instead of inferring from prose.

## Scope
- Refs #1230.
- This intentionally does not close #1230 because visible badge UI, TalkBack traversal, large text evidence, and manual Android evidence remain separate UI work.
- No route result widget/layout/style changes in this PR.

## Verification
- RED: `flutter test test/route_search_test.dart` failed before implementation because `RouteSearchResult` did not expose the V2 badge signals.
- `flutter test test/route_search_test.dart`
- `flutter analyze lib/route_search.dart test/route_search_test.dart`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 경로 검색 결과에 ETA 신뢰도, 접근성 위험도, 환승 여유 시간, 역외 환승 여부, 상업용 ETA 적용 가능 여부가 함께 표시되도록 확장되었습니다.
  * V2 응답과 기존 응답 간 변환 시 관련 정보가 더 정확하게 유지됩니다.

* **Bug Fixes**
  * 일부 경로에서 환승 관련 값이 누락되던 문제를 개선해, 결과 복사 및 표시 시 일관되게 반영되도록 수정했습니다.
  * Boolean 값이 없을 때도 안정적으로 처리되도록 파싱이 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->