### PR TITLE
[Style] 역 검색 결과를 구분선 리스트 행으로 정리

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -49,8 +49,7 @@ const _stationSearchPagePadding = EdgeInsets.fromLTRB(20, 20, 20, 32);
 const _stationSearchLargePagePadding = EdgeInsets.fromLTRB(24, 24, 24, 40);
 const _stationLineSheetPadding = EdgeInsets.fromLTRB(20, 8, 20, 24);
 const _stationRoleActionPadding = EdgeInsets.fromLTRB(12, 0, 12, 12);
-const _stationSearchInputRadius = BorderRadius.all(Radius.circular(18));
-const _stationResultCardRadius = BorderRadius.all(Radius.circular(18));
+const _stationSearchInputRadius = BorderRadius.all(Radius.circular(12));
 const _stationCompactCardRadius = BorderRadius.all(Radius.circular(8));
 const _stationLineRegionChipRadius = BorderRadius.all(Radius.circular(8));
 const _stationLineFilterButtonRadius = BorderRadius.all(Radius.circular(14));
@@ -3092,7 +3091,7 @@ class _NearbyStationOverview extends StatelessWidget {
       color: EasySubwayAccessibleColors.skySoft,
       elevation: 0,
       shape: RoundedRectangleBorder(
-        borderRadius: _stationResultCardRadius,
+        borderRadius: _stationDetailFacilityCardRadius,
         side: const BorderSide(color: EasySubwayAccessibleColors.line),
       ),
       child: Column(
@@ -3105,7 +3104,7 @@ class _NearbyStationOverview extends StatelessWidget {
             child: ExcludeSemantics(
               child: InkWell(
                 key: const Key('nearbyStationPrimaryCard'),
-                borderRadius: _stationResultCardRadius,
+                borderRadius: _stationDetailFacilityCardRadius,
                 onTap: onTap,
                 child: Padding(
                   padding: const EdgeInsets.all(16),
@@ -3296,13 +3295,13 @@ class _StationSearchResultTile extends StatelessWidget {
     final semanticLabel = _stationResultSemanticLabel(result);
     final hasRoleActions = onSetOrigin != null || onSetDestination != null;
 
-    return Card(
-      margin: const EdgeInsets.only(bottom: 10),
-      color: Colors.white,
-      elevation: 0,
-      shape: RoundedRectangleBorder(
-        borderRadius: _stationResultCardRadius,
-        side: const BorderSide(color: EasySubwayAccessibleColors.line),
+    // 항목마다 테두리 박스를 두지 않고 하단 구분선만 둔 깔끔한 리스트 행으로 표시한다.
+    return DecoratedBox(
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        border: Border(
+          bottom: BorderSide(color: EasySubwayAccessibleColors.line),
+        ),
       ),
       child: Column(
         children: [
@@ -3314,7 +3313,6 @@ class _StationSearchResultTile extends StatelessWidget {
               child: ExcludeSemantics(
                 child: InkWell(
                   key: Key('stationSearchResult-${result.id}'),
-                  borderRadius: _stationCompactCardRadius,
                   onTap: onTap,
                   child: ConstrainedBox(
                     constraints: const BoxConstraints(minHeight: 78),


### PR DESCRIPTION
## Summary

- Closes #1383
- 역 검색 결과를 항목마다 테두리 박스로 감싸던 것을 하단 구분선만 둔 깔끔한 리스트 행으로 바꿔 불필요한 블록을 걷어냈습니다.
- 검색 입력창 모서리를 radius 18에서 12로 낮춰 노선도 검색 필드와 통일했습니다.
- 가까운 역 강조 카드 모서리를 카드 스케일(16)로 통일했습니다.
- 결과 항목 test key와 시맨틱, 탭 타깃은 그대로 유지했습니다. 이모지는 사용하지 않았습니다.

## Verification

- `dart format lib/station_search.dart` · `flutter analyze` (No issues found)
- `flutter test test/widget_test.dart --plain-name "역 검색"` → 22 passed
- Android debug run on `RFKYA01VMQY` (검색 입력창 radius 12 확인)
- Android screenshot: `.codex/tasks/station-search-deblock/search-input-radius12.png`

## Notes

- 결과 리스트 행(구분선 스타일)은 위젯 테스트로 검증했습니다. 실기기 익명 세션은 한글 입력·GPS 결과 재현이 어려워 라이브로 결과 목록을 채우지 못해, 회귀는 22개 위젯 테스트로 확인했습니다.
- 시각 변경 위주로 로직과 백엔드 API에는 영향이 없습니다.
