### PR TITLE
[Fix] Observability probes 재시작 처리

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -101,12 +101,14 @@ services:
   public-edge-probe:
     image: prom/blackbox-exporter:v0.27.0
     container_name: easysubway-public-edge-probe
+    restart: unless-stopped
     profiles:
       - observability
 
   docker-runtime-probe:
     image: ghcr.io/google/cadvisor:v0.60.3
     container_name: easysubway-docker-runtime-probe
+    restart: unless-stopped
     profiles:
       - observability
     privileged: true

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5867,6 +5867,8 @@ test("로컬 관측성 스택은 Prometheus와 Grafana 기준선을 제공한다
   assert.match(prometheusConfig, /job_name: "docker_runtime_probe"/);
   assert.match(prometheusConfig, /targets: \["docker-runtime-probe:8080"\]/);
   assert.match(prometheusConfig, /job_name: "public_edge_probe"/);
+  assert.match(compose, /public-edge-probe:[\s\S]*restart: unless-stopped/);
+  assert.match(compose, /docker-runtime-probe:[\s\S]*restart: unless-stopped/);
   assert.match(prometheusConfig, /metrics_path: "\/probe"/);
   assert.match(prometheusConfig, /module: \[http_2xx\]/);
   assert.match(prometheusConfig, /https:\/\/easysubway-api\.aquilaxk\.site\/actuator\/health\/readiness/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5867,8 +5867,8 @@ test("로컬 관측성 스택은 Prometheus와 Grafana 기준선을 제공한다
   assert.match(prometheusConfig, /job_name: "docker_runtime_probe"/);
   assert.match(prometheusConfig, /targets: \["docker-runtime-probe:8080"\]/);
   assert.match(prometheusConfig, /job_name: "public_edge_probe"/);
-  assert.match(compose, /public-edge-probe:[\s\S]*restart: unless-stopped/);
-  assert.match(compose, /docker-runtime-probe:[\s\S]*restart: unless-stopped/);
+  assert.match(compose, /public-edge-probe:\n(?: {4}[^\n]*\n)* {4}restart: unless-stopped/);
+  assert.match(compose, /docker-runtime-probe:\n(?: {4}[^\n]*\n)* {4}restart: unless-stopped/);
   assert.match(prometheusConfig, /metrics_path: "\/probe"/);
   assert.match(prometheusConfig, /module: \[http_2xx\]/);
   assert.match(prometheusConfig, /https:\/\/easysubway-api\.aquilaxk\.site\/actuator\/health\/readiness/);


### PR DESCRIPTION
## Summary
- Fixes #1389
- public-edge-probe와 docker-runtime-probe에 restart 정책을 추가해 종료 후 scrape down 알림이 계속 남는 상황을 줄입니다.
- repository contract에 probe restart 정책을 고정합니다.

## Root cause
- 운영 CD는 probe 컨테이너를 시작했지만, exporter가 이후 종료될 경우 자동 재시작 정책이 없어 Prometheus scrape down 알림이 지속될 수 있었습니다.

## Verification
- docker compose --env-file .env.example -f infra/docker-compose.yml config --quiet
- node --test tools/ci/repository-contract.test.mjs
- node --test tools/ci/backend-deploy.test.mjs