### PR TITLE
[Fix] Sonar route report sorting 정리

### DIFF
--- a/tools/routes/check-route-commercialization-gate.mjs
+++ b/tools/routes/check-route-commercialization-gate.mjs
@@ -48,7 +48,7 @@ async function main(argv) {
     schemaVersion: 1,
     gate: "route-commercialization",
     status: failures.length > 0 ? "FAIL" : "PASS",
-    checkedReports: Object.keys(reports).sort(),
+    checkedReports: Object.keys(reports).sort((left, right) => left.localeCompare(right)),
     failures,
   };
 }

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -169,6 +169,12 @@ test("route commercialization gate keeps legacy production sample fallback", asy
       return true;
     },
   );
+});
+
+test("route commercialization gate sorts checked reports with an explicit comparator", async () => {
+  const source = await readFile("tools/routes/check-route-commercialization-gate.mjs", "utf8");
+
+  assert.match(source, /Object\.keys\(reports\)\.sort\(\([^)]*\) => [^)]*localeCompare/);
 });
 
 async function writeFixtureSet(reports) {


### PR DESCRIPTION
## Summary
- Add an explicit localeCompare comparator for route commercialization checked report sorting.
- Add a small regression test for the Sonar S2871 issue.

## Root Cause
- SonarCloud main Quality Gate failed because tools/routes/check-route-commercialization-gate.mjs used Array.sort() without a comparator on new code.

## Verification
- node --test tools/routes/check-route-commercialization-gate.test.mjs
- node --test tools/ci/*.test.mjs