### PR TITLE
[Route Commercialization] Route V2 planner boundary 분리

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -5,6 +5,8 @@ import com.easysubway.common.web.ApiResponse;
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
+import com.easysubway.route.application.service.RouteV2Planner;
+import com.easysubway.route.application.service.RouteV2Planner.RouteV2Plan;
 import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.EtaConfidence;
 import com.easysubway.route.domain.EtaSource;
@@ -37,9 +39,11 @@ import org.springframework.web.bind.annotation.RestController;
 class RouteSearchController {
 
 	private final RouteSearchUseCase routeSearchUseCase;
+	private final RouteV2Planner routeV2Planner;
 
-	RouteSearchController(RouteSearchUseCase routeSearchUseCase) {
+	RouteSearchController(RouteSearchUseCase routeSearchUseCase, RouteV2Planner routeV2Planner) {
 		this.routeSearchUseCase = routeSearchUseCase;
+		this.routeV2Planner = routeV2Planner;
 	}
 
 	@PostMapping("/api/v1/routes/search")
@@ -50,8 +54,8 @@ class RouteSearchController {
 	@PostMapping("/api/v2/routes/search")
 	ApiResponse<RouteSearchV2Response> searchRouteV2(@Valid @RequestBody RouteSearchV2Request request) {
 		OffsetDateTime departureTime = request.parsedDepartureTime();
-		SearchRouteCommand command = request.toCommand();
-		return ApiResponse.ok(RouteSearchV2Response.from(routeSearchUseCase.searchRoute(command), request, departureTime));
+		RouteV2Plan plan = routeV2Planner.search(request.toV2Command(departureTime));
+		return ApiResponse.ok(RouteSearchV2Response.from(plan, request, departureTime));
 	}
 
 	@PostMapping("/api/v2/routes/{routeSearchId}/refresh")
@@ -157,13 +161,16 @@ class RouteSearchController {
 		int alternativeCount
 	) {
 
-		SearchRouteCommand toCommand() {
-			return new SearchRouteCommand(
+		RouteV2Planner.SearchRouteV2Command toV2Command(OffsetDateTime departureTime) {
+			return new RouteV2Planner.SearchRouteV2Command(
 				originStationId,
 				destinationStationId,
+				departureTime,
 				mobilityType,
 				parseConstraintMode(mobilityType, constraintMode),
-				maxTransfers
+				Boolean.TRUE.equals(useRealtime),
+				maxTransfers,
+				alternativeCount
 			);
 		}
 
@@ -217,7 +224,7 @@ class RouteSearchController {
 	) {
 
 		private static RouteSearchV2Response from(
-			RouteSearchResult result,
+			RouteV2Plan plan,
 			RouteSearchV2Request request,
 			OffsetDateTime departureTime
 		) {
@@ -239,7 +246,9 @@ class RouteSearchController {
 					"UNSUPPORTED_REGION",
 					"ROUTE_GRAPH_UNKNOWN"
 				),
-				List.of(ItineraryDto.from(result, departureTime))
+				plan.itineraries().stream()
+					.map(result -> ItineraryDto.from(result, departureTime))
+					.toList()
 			);
 		}
 	}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -1,0 +1,55 @@
+package com.easysubway.route.application.service;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.application.port.in.RouteSearchUseCase;
+import com.easysubway.route.application.port.in.SearchRouteCommand;
+import com.easysubway.route.domain.ConstraintMode;
+import com.easysubway.route.domain.RouteSearchResult;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RouteV2Planner {
+
+	private static final String PLANNER_ADR = "tools/routes/route-algorithm-v2-adr.json";
+
+	private final RouteSearchUseCase routeSearchUseCase;
+
+	public RouteV2Planner(RouteSearchUseCase routeSearchUseCase) {
+		this.routeSearchUseCase = routeSearchUseCase;
+	}
+
+	public RouteV2Plan search(SearchRouteV2Command command) {
+		RouteSearchResult primary = routeSearchUseCase.searchRoute(command.toSearchRouteCommand());
+		return new RouteV2Plan(List.of(primary), PLANNER_ADR);
+	}
+
+	public record SearchRouteV2Command(
+		String originStationId,
+		String destinationStationId,
+		OffsetDateTime departureTime,
+		MobilityType mobilityType,
+		ConstraintMode constraintMode,
+		boolean useRealtime,
+		int maxTransfers,
+		int alternativeCount
+	) {
+
+		private SearchRouteCommand toSearchRouteCommand() {
+			return new SearchRouteCommand(
+				originStationId,
+				destinationStationId,
+				mobilityType,
+				constraintMode,
+				maxTransfers
+			);
+		}
+	}
+
+	public record RouteV2Plan(
+		List<RouteSearchResult> itineraries,
+		String plannerAdr
+	) {
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -8989,6 +8989,30 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
   assert.doesNotMatch(operatorRouteFeedbackReportTemplate, /<form|_csrf|routeSearchId|userId|comment|\/admin\/reports/);
 });
 
+test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 전달한다", () => {
+  const controller = read("backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java");
+  const plannerPath = "backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java";
+
+  assert.equal(existsSync(path.join(root, plannerPath)), true, "RouteV2Planner must own V2 production search planning");
+
+  const planner = read(plannerPath);
+  const v2Endpoint = controller.match(
+    /@PostMapping\("\/api\/v2\/routes\/search"\)[\s\S]*?ApiResponse<RouteSearchV2Response> searchRouteV2[\s\S]*?\n\t}/,
+  )?.[0] ?? "";
+
+  assert.match(v2Endpoint, /routeV2Planner\.search/);
+  assert.doesNotMatch(v2Endpoint, /routeSearchUseCase\.searchRoute/);
+  assert.match(controller, /toV2Command\(departureTime\)/);
+  assert.match(controller, /RouteSearchV2Response\.from\(plan, request, departureTime\)/);
+  assert.match(planner, /class RouteV2Planner/);
+  assert.match(planner, /record SearchRouteV2Command/);
+  assert.match(planner, /OffsetDateTime departureTime/);
+  assert.match(planner, /boolean useRealtime/);
+  assert.match(planner, /int maxTransfers/);
+  assert.match(planner, /int alternativeCount/);
+  assert.match(planner, /route-algorithm-v2-adr\.json|Range RAPTOR/);
+});
+
 test("모바일 async lint 기준선은 Future 처리 누락을 analyzer에서 잡는다", () => {
   const analysisOptions = read("apps/mobile/analysis_options.yaml");
   const asyncLintBaseline = readJson("apps/mobile/analysis/async-lint-baseline.json");


### PR DESCRIPTION
## 변경
- `/api/v2/routes/search`가 V1 `RouteSearchUseCase.searchRoute`를 직접 호출하지 않고 `RouteV2Planner.search` 경계를 통과하게 변경했습니다.
- V2 요청의 `departureTime`, `useRealtime`, `maxTransfers`, `alternativeCount`를 `SearchRouteV2Command`에 보존했습니다.
- ADR 연결 경계와 controller wiring을 repository contract로 고정했습니다.

## 검증
- `node --test --test-name-pattern "V2 경로 검색은 production planner" tools/ci/repository-contract.test.mjs`
- `node --test tools/ci/repository-contract.test.mjs`
- `./gradlew test --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest` (backend)
- `./gradlew test` (backend)

## 범위
Refs #1402

이 PR은 production planner 경계 분리와 V2 입력 전달까지 처리합니다. #1402의 남은 완료 조건인 2~3개 Pareto itinerary 반환, `useRealtime` provider 정책 반영, route commercialization contract report의 `alternativeItinerariesMinObserved >= 2` 증거는 아직 이슈에 남깁니다.