### PR TITLE
[Route Commercialization] V2 realtime ETA 정책 연결

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/port/in/SearchRouteCommand.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/SearchRouteCommand.java
@@ -2,13 +2,16 @@ package com.easysubway.route.application.port.in;
 
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.domain.ConstraintMode;
+import java.time.OffsetDateTime;
 
 public record SearchRouteCommand(
 	String originStationId,
 	String destinationStationId,
 	MobilityType mobilityType,
 	ConstraintMode constraintMode,
-	int maxTransfers
+	int maxTransfers,
+	OffsetDateTime departureTime,
+	boolean useRealtime
 ) {
 	public SearchRouteCommand(String originStationId, String destinationStationId, MobilityType mobilityType) {
 		this(originStationId, destinationStationId, mobilityType, ConstraintMode.defaultFor(mobilityType), 1);
@@ -21,6 +24,16 @@ public record SearchRouteCommand(
 		ConstraintMode constraintMode
 	) {
 		this(originStationId, destinationStationId, mobilityType, constraintMode, 1);
+	}
+
+	public SearchRouteCommand(
+		String originStationId,
+		String destinationStationId,
+		MobilityType mobilityType,
+		ConstraintMode constraintMode,
+		int maxTransfers
+	) {
+		this(originStationId, destinationStationId, mobilityType, constraintMode, maxTransfers, null, false);
 	}
 
 	public SearchRouteCommand {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -6,6 +6,7 @@ import com.easysubway.route.application.port.in.SearchInternalRouteCommand;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
 import com.easysubway.route.application.port.out.LoadRouteSearchPort;
+import com.easysubway.route.application.port.out.RealtimeArrivalResolver;
 import com.easysubway.route.application.port.out.SaveRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
 import com.easysubway.route.domain.EtaConfidence;
@@ -25,6 +26,7 @@ import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
 import com.easysubway.route.domain.RouteWarning;
 import com.easysubway.route.domain.RouteWarningCode;
+import com.easysubway.route.domain.RealtimeEtaOverlay;
 import com.easysubway.transit.application.port.out.LoadTransitMasterPort;
 import com.easysubway.transit.domain.AccessibilityFacility;
 import com.easysubway.transit.domain.AccessibilityFacilityStatus;
@@ -39,8 +41,10 @@ import com.easysubway.transit.domain.StationLine;
 import com.easysubway.transit.domain.StationNotFoundException;
 import com.easysubway.transit.domain.SubwayLine;
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -55,6 +59,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -75,15 +80,25 @@ public class RouteSearchService implements RouteSearchUseCase {
 	private final SaveRouteFeedbackPort saveRouteFeedbackPort;
 	private final LoadTransitMasterPort loadTransitMasterPort;
 	private final Clock clock;
+	private final RealtimeArrivalResolver realtimeArrivalResolver;
+	private final RealtimeEtaOverlay realtimeEtaOverlay;
 
 	@Autowired
 	public RouteSearchService(
 		LoadRouteSearchPort loadRouteSearchPort,
 		SaveRouteSearchPort saveRouteSearchPort,
 		SaveRouteFeedbackPort saveRouteFeedbackPort,
-		LoadTransitMasterPort loadTransitMasterPort
+		LoadTransitMasterPort loadTransitMasterPort,
+		ObjectProvider<RealtimeArrivalResolver> realtimeArrivalResolver
 	) {
-		this(loadRouteSearchPort, saveRouteSearchPort, saveRouteFeedbackPort, loadTransitMasterPort, Clock.systemDefaultZone());
+		this(
+			loadRouteSearchPort,
+			saveRouteSearchPort,
+			saveRouteFeedbackPort,
+			loadTransitMasterPort,
+			Clock.systemDefaultZone(),
+			realtimeArrivalResolver.getIfAvailable()
+		);
 	}
 
 	public RouteSearchService(
@@ -107,11 +122,24 @@ public class RouteSearchService implements RouteSearchUseCase {
 		LoadTransitMasterPort loadTransitMasterPort,
 		Clock clock
 	) {
+		this(loadRouteSearchPort, saveRouteSearchPort, saveRouteFeedbackPort, loadTransitMasterPort, clock, null);
+	}
+
+	public RouteSearchService(
+		LoadRouteSearchPort loadRouteSearchPort,
+		SaveRouteSearchPort saveRouteSearchPort,
+		SaveRouteFeedbackPort saveRouteFeedbackPort,
+		LoadTransitMasterPort loadTransitMasterPort,
+		Clock clock,
+		RealtimeArrivalResolver realtimeArrivalResolver
+	) {
 		this.loadRouteSearchPort = loadRouteSearchPort;
 		this.saveRouteSearchPort = saveRouteSearchPort;
 		this.saveRouteFeedbackPort = saveRouteFeedbackPort;
 		this.loadTransitMasterPort = loadTransitMasterPort;
 		this.clock = clock;
+		this.realtimeArrivalResolver = realtimeArrivalResolver;
+		this.realtimeEtaOverlay = new RealtimeEtaOverlay();
 	}
 
 	public RouteSearchService(
@@ -121,6 +149,23 @@ public class RouteSearchService implements RouteSearchUseCase {
 		Clock clock
 	) {
 		this(loadRouteSearchPort, saveRouteSearchPort, requireFeedbackPort(saveRouteSearchPort), loadTransitMasterPort, clock);
+	}
+
+	public RouteSearchService(
+		LoadRouteSearchPort loadRouteSearchPort,
+		SaveRouteSearchPort saveRouteSearchPort,
+		LoadTransitMasterPort loadTransitMasterPort,
+		Clock clock,
+		RealtimeArrivalResolver realtimeArrivalResolver
+	) {
+		this(
+			loadRouteSearchPort,
+			saveRouteSearchPort,
+			requireFeedbackPort(saveRouteSearchPort),
+			loadTransitMasterPort,
+			clock,
+			realtimeArrivalResolver
+		);
 	}
 
 	@Override
@@ -182,6 +227,10 @@ public class RouteSearchService implements RouteSearchUseCase {
 			));
 		}
 
+		List<RouteStep> routeSteps = realtimeAwareRouteSteps(
+			command,
+			routeSteps(origin, destination, routePlan, profileWeight)
+		);
 		return saveRouteSearchPort.saveRouteSearch(new RouteSearchResult(
 			newRouteSearchId(),
 			origin.id(),
@@ -193,7 +242,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			routePlan.lineId(),
 			routePlan.lineName(),
 			routeScore(profileWeight, routePlan, warnings),
-			routeSteps(origin, destination, routePlan, profileWeight),
+			routeSteps,
 			warnings,
 			List.of(),
 			LocalDateTime.now(clock)
@@ -426,6 +475,15 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.filter(station -> station.id().equals(stationId))
 			.findFirst()
 			.orElseThrow(StationNotFoundException::new);
+	}
+
+	private SubwayLine loadActiveLine(String lineId) {
+		return loadTransitMasterPort.loadLines()
+			.stream()
+			.filter(SubwayLine::active)
+			.filter(line -> line.id().equals(lineId))
+			.findFirst()
+			.orElseThrow(RouteNotFoundException::new);
 	}
 
 	private List<RoutePlan> findRoutePlans(
@@ -1073,6 +1131,84 @@ public class RouteSearchService implements RouteSearchUseCase {
 			return routeAssembler.assemble(transferSteps(origin, destination, routePlan.transferRoute().get(), profileWeight));
 		}
 		return routeAssembler.assemble(directLineSteps(origin, destination, routePlan.directLine().orElseThrow(), profileWeight));
+	}
+
+	private List<RouteStep> realtimeAwareRouteSteps(SearchRouteCommand command, List<RouteStep> plannedSteps) {
+		if (!command.useRealtime() || realtimeArrivalResolver == null || command.departureTime() == null) {
+			return plannedSteps;
+		}
+		List<RouteStep> realtimeSteps = new ArrayList<>(plannedSteps);
+		int elapsedMinutes = 0;
+		for (int index = 0; index < realtimeSteps.size(); index++) {
+			RouteStep step = realtimeSteps.get(index);
+			if (!"ride".equals(step.stepType())) {
+				elapsedMinutes += Math.max(0, step.estimatedMinutes());
+				continue;
+			}
+			Instant readyAt = command.departureTime().toInstant().plusSeconds(elapsedMinutes * 60L);
+			RealtimeArrivalResolver.Resolution resolution = realtimeArrivalResolver.resolve(realtimeQuery(step, readyAt));
+			RealtimeEtaOverlay.Result overlay = realtimeEtaOverlay.overlay(
+				readyAt,
+				Math.max(0, step.estimatedMinutes()) * 60,
+				directionFor(step),
+				resolution.status(),
+				resolution.fallbackCode(),
+				resolution.providerSnapshotId(),
+				resolution.providerReceivedAt(),
+				resolution.candidates().size(),
+				resolution.candidates()
+			);
+			realtimeSteps.set(index, withEtaOverlay(step, overlay));
+			break;
+		}
+		return List.copyOf(realtimeSteps);
+	}
+
+	private RealtimeArrivalResolver.Query realtimeQuery(RouteStep step, Instant readyAt) {
+		Station station = loadActiveStation(step.fromStationId());
+		SubwayLine line = loadActiveLine(step.lineId());
+		return new RealtimeArrivalResolver.Query(
+			station.id(),
+			line.id(),
+			providerLineId(line),
+			station.nameKo(),
+			line.name(),
+			directionFor(step),
+			readyAt
+		);
+	}
+
+	private RouteStep withEtaOverlay(RouteStep step, RealtimeEtaOverlay.Result overlay) {
+		return new RouteStep(
+			step.sequence(),
+			step.stepType(),
+			step.title(),
+			step.description(),
+			step.lineId(),
+			step.lineName(),
+			step.fromStationId(),
+			step.toStationId(),
+			Math.max(1, (overlay.waitSeconds() + 59) / 60),
+			step.distanceMeters(),
+			step.includesStairs(),
+			step.stairAccessState(),
+			step.requiresAccessibilityCheck(),
+			overlay.etaSource().name(),
+			step.distanceSource(),
+			overlay.confidence().name()
+		);
+	}
+
+	private String directionFor(RouteStep step) {
+		try {
+			return loadActiveStation(step.toStationId()).nameKo() + " 방면";
+		} catch (StationNotFoundException ignored) {
+			return "";
+		}
+	}
+
+	private String providerLineId(SubwayLine line) {
+		return line.lineCode() == null || line.lineCode().isBlank() ? line.id() : line.lineCode();
 	}
 
 	private List<RouteStep> directLineSteps(

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -73,7 +73,9 @@ public class RouteV2Planner {
 				destinationStationId,
 				mobilityType,
 				constraintMode,
-				maxTransfers
+				maxTransfers,
+				departureTime,
+				useRealtime
 			);
 		}
 	}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -45,11 +45,18 @@ public class RouteV2Planner {
 		List<String> statuses = new ArrayList<>();
 		for (RouteSearchResult itinerary : itineraries) {
 			statuses.add(statusOf(itinerary));
-			if (useRealtime && itinerary.status() == RouteSearchStatus.FOUND && itinerary.etaSource() == EtaSource.PLANNED) {
+			if (usesPlannedEtaAfterRealtimeRequest(itinerary, useRealtime)) {
 				statuses.add("REALTIME_UNAVAILABLE_PLANNED_USED");
 			}
 		}
 		return List.copyOf(statuses.stream().distinct().toList());
+	}
+
+	private boolean usesPlannedEtaAfterRealtimeRequest(RouteSearchResult itinerary, boolean useRealtime) {
+		if (!useRealtime || itinerary.status() != RouteSearchStatus.FOUND) {
+			return false;
+		}
+		return itinerary.etaSource() == EtaSource.PLANNED || itinerary.etaSource() == EtaSource.FALLBACK;
 	}
 
 	private String statusOf(RouteSearchResult itinerary) {

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -746,6 +746,40 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 realtime provider를 사용할 수 없으면 fallback ETA source와 planned 사용 상태를 노출한다")
+	void routeV2PlannerReportsRealtimeUnavailableFallbackStatus() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeSearchService = new RouteSearchService(
+			repository,
+			repository,
+			new RampAccessibleTransitMasterPort(),
+			CLOCK,
+			query -> new RealtimeArrivalResolver.Resolution(
+				ArrivalFreshness.UNAVAILABLE,
+				"PROVIDER_QUOTA_EXCEEDED",
+				null,
+				null,
+				List.of()
+			)
+		);
+		var planner = new RouteV2Planner(routeSearchService);
+
+		var plan = planner.search(new RouteV2Planner.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-01T09:00:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			true,
+			1,
+			1
+		));
+
+		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.FALLBACK);
+		assertThat(plan.statuses()).containsExactly("FOUND", "REALTIME_UNAVAILABLE_PLANNED_USED");
+	}
+
+	@Test
 	@DisplayName("휠체어 이동 유형은 우회 거리가 길어도 무단차 환승역을 우선한다")
 	void wheelchairRoutePrefersStepFreeTransferStationEvenWhenDetourIsLong() {
 		var repository = new InMemoryRouteSearchRepository();

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -9,7 +9,11 @@ import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepositor
 import com.easysubway.route.application.port.in.SearchInternalRouteCommand;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
+import com.easysubway.route.application.port.out.RealtimeArrivalResolver;
+import com.easysubway.route.domain.ArrivalCandidate;
+import com.easysubway.route.domain.ArrivalFreshness;
 import com.easysubway.route.domain.ConstraintMode;
+import com.easysubway.route.domain.EtaConfidence;
 import com.easysubway.route.domain.InvalidRouteFeedbackException;
 import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteNotFoundException;
@@ -43,9 +47,11 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -675,6 +681,71 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 useRealtime=true는 provider ETA를 첫 승차 단계에 반영한다")
+	void routeV2PlannerAppliesRealtimeEtaWhenRequested() {
+		var repository = new InMemoryRouteSearchRepository();
+		var resolver = new CountingRealtimeArrivalResolver();
+		var routeSearchService = new RouteSearchService(
+			repository,
+			repository,
+			new RampAccessibleTransitMasterPort(),
+			CLOCK,
+			resolver
+		);
+		var planner = new RouteV2Planner(routeSearchService);
+
+		var plan = planner.search(new RouteV2Planner.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-01T09:00:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			true,
+			1,
+			1
+		));
+
+		assertThat(resolver.callCount()).isEqualTo(1);
+		assertThat(resolver.lastQuery().stationId()).isEqualTo("station-a");
+		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.MIXED);
+		assertThat(plan.itineraries().getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("timeSource")
+			.containsExactly(EtaSource.REALTIME.name());
+		assertThat(plan.statuses()).containsExactly("FOUND");
+	}
+
+	@Test
+	@DisplayName("V2 useRealtime=false는 provider를 호출하지 않고 계획 ETA를 유지한다")
+	void routeV2PlannerSkipsRealtimeProviderWhenDisabled() {
+		var repository = new InMemoryRouteSearchRepository();
+		var resolver = new CountingRealtimeArrivalResolver();
+		var routeSearchService = new RouteSearchService(
+			repository,
+			repository,
+			new RampAccessibleTransitMasterPort(),
+			CLOCK,
+			resolver
+		);
+		var planner = new RouteV2Planner(routeSearchService);
+
+		var plan = planner.search(new RouteV2Planner.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-01T09:00:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			false,
+			1,
+			1
+		));
+
+		assertThat(resolver.callCount()).isZero();
+		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.PLANNED);
+		assertThat(plan.statuses()).containsExactly("FOUND");
+	}
+
+	@Test
 	@DisplayName("휠체어 이동 유형은 우회 거리가 길어도 무단차 환승역을 우선한다")
 	void wheelchairRoutePrefersStepFreeTransferStationEvenWhenDetourIsLong() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -1297,6 +1368,44 @@ class RouteSearchServiceTest {
 			.steps()
 			.getFirst()
 			.description();
+	}
+
+	private static class CountingRealtimeArrivalResolver implements RealtimeArrivalResolver {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+		private Query lastQuery;
+
+		@Override
+		public Resolution resolve(Query query) {
+			callCount.incrementAndGet();
+			lastQuery = query;
+			Instant expectedArrivalAt = query.readyAt().plusSeconds(120);
+			return new Resolution(
+				ArrivalFreshness.FRESH_REALTIME,
+				null,
+				"test-realtime-snapshot",
+				query.readyAt().minusSeconds(30),
+				List.of(new ArrivalCandidate(
+					"train-test",
+					query.lineId(),
+					query.direction(),
+					"도착역",
+					120,
+					expectedArrivalAt,
+					query.readyAt().minusSeconds(30),
+					ArrivalFreshness.FRESH_REALTIME,
+					EtaConfidence.HIGH
+				))
+			);
+		}
+
+		int callCount() {
+			return callCount.get();
+		}
+
+		Query lastQuery() {
+			return lastQuery;
+		}
 	}
 
 	private static class StairOnlyTransitMasterPort implements LoadTransitMasterPort {


### PR DESCRIPTION
## 변경
- V2 planner가 departureTime/useRealtime을 SearchRouteCommand까지 전달하도록 연결했습니다.
- RouteSearchService에 optional RealtimeArrivalResolver를 주입하고, useRealtime=true일 때 첫 ride step에 realtime ETA overlay를 적용합니다.
- useRealtime=false는 provider를 호출하지 않고 PLANNED ETA source를 유지하는 테스트를 추가했습니다.

## 검증
- ./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest
- ./gradlew test --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest
- ./gradlew test
- node --test --test-name-pattern "V2 경로 검색은 production planner" tools/ci/repository-contract.test.mjs
- node --test tools/ci/repository-contract.test.mjs
- git diff --check

Refs #1402