### PR TITLE
[Feat] 데이터 출처 화면 메뉴 진입점 연결

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1534,6 +1534,14 @@ class _HomeScreenState extends State<HomeScreen> {
       unawaited(openFavorites());
     }
 
+    void openDataSources() {
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => const DataSourceAttributionScreen(),
+        ),
+      );
+    }
+
     final heroSection = _HomeHero(
       profile: currentProfile,
       onRouteSearch: openRouteTab,
@@ -1595,6 +1603,7 @@ class _HomeScreenState extends State<HomeScreen> {
               unawaited(openStationSearch(StationSearchEntryMode.recent)),
           onOpenNearbyStations: () =>
               unawaited(openStationSearch(StationSearchEntryMode.nearby)),
+          onOpenDataSources: openDataSources,
           notificationAction: notificationRepository == null
               ? null
               : FutureBuilder<bool>(
@@ -5459,12 +5468,24 @@ class _PrivacyDataUseLine extends StatelessWidget {
   }
 }
 
-class DataSourceAttributionScreen extends StatelessWidget {
+class DataSourceAttributionScreen extends StatefulWidget {
   const DataSourceAttributionScreen({super.key});
 
+  @override
+  State<DataSourceAttributionScreen> createState() =>
+      _DataSourceAttributionScreenState();
+}
+
+class _DataSourceAttributionScreenState
+    extends State<DataSourceAttributionScreen> {
   static const _mapManifestAsset =
       'assets/datapacks/metro_map_pack/manifest.json';
   static const _sourceInventoryAsset = 'assets/datapacks/source-inventory.json';
+
+  late final Future<
+    ({Map<String, Object?> manifest, Map<String, Object?> inventory})
+  >
+  _future = _load();
 
   Future<({Map<String, Object?> manifest, Map<String, Object?> inventory})>
   _load() async {
@@ -5488,7 +5509,7 @@ class DataSourceAttributionScreen extends StatelessWidget {
             FutureBuilder<
               ({Map<String, Object?> manifest, Map<String, Object?> inventory})
             >(
-              future: _load(),
+              future: _future,
               builder: (context, snapshot) {
                 if (snapshot.hasError) {
                   return ListView(

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -306,6 +306,7 @@ class NetworkMapScreen extends StatefulWidget {
     this.onOpenSavedItems,
     this.onOpenRecentSearch,
     this.onOpenNearbyStations,
+    this.onOpenDataSources,
     this.notificationAction,
     this.bottomNavigationBar,
     super.key,
@@ -321,6 +322,7 @@ class NetworkMapScreen extends StatefulWidget {
   final VoidCallback? onOpenSavedItems;
   final VoidCallback? onOpenRecentSearch;
   final VoidCallback? onOpenNearbyStations;
+  final VoidCallback? onOpenDataSources;
   final Widget? notificationAction;
   final Widget? bottomNavigationBar;
 
@@ -641,6 +643,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
           onOpenSavedItems: widget.onOpenSavedItems,
           onOpenNearbyStations: widget.onOpenNearbyStations,
           onOpenRecentSearch: widget.onOpenRecentSearch,
+          onOpenDataSources: widget.onOpenDataSources,
         );
       },
       transitionBuilder: (context, animation, secondaryAnimation, child) {
@@ -1668,6 +1671,7 @@ class _NetworkMapMenuPanel extends StatelessWidget {
     required this.onOpenSavedItems,
     required this.onOpenNearbyStations,
     required this.onOpenRecentSearch,
+    required this.onOpenDataSources,
   });
 
   final VoidCallback onOpenStationSearch;
@@ -1675,10 +1679,16 @@ class _NetworkMapMenuPanel extends StatelessWidget {
   final VoidCallback? onOpenSavedItems;
   final VoidCallback? onOpenNearbyStations;
   final VoidCallback? onOpenRecentSearch;
+  final VoidCallback? onOpenDataSources;
 
   void _runAction(BuildContext context, VoidCallback action) {
     Navigator.of(context).pop();
     action();
+  }
+
+  void _runActionAfterMenuClose(BuildContext context, VoidCallback action) {
+    Navigator.of(context).pop();
+    Future<void>.delayed(const Duration(milliseconds: 180), action);
   }
 
   void _runFutureAction(BuildContext context, Future<void> Function() action) {
@@ -1699,8 +1709,8 @@ class _NetworkMapMenuPanel extends StatelessWidget {
           height: double.infinity,
           child: SafeArea(
             bottom: false,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
+            child: ListView(
+              padding: EdgeInsets.zero,
               children: [
                 const _NetworkMapMenuHeader(),
                 const Divider(height: 1, color: Color(0xFFE4E4E4)),
@@ -1738,6 +1748,16 @@ class _NetworkMapMenuPanel extends StatelessWidget {
                     icon: Icons.star_border_rounded,
                     label: '즐겨찾기',
                     onTap: () => _runAction(context, onOpenSavedItems!),
+                  ),
+                ],
+                if (onOpenDataSources != null) ...[
+                  const _NetworkMapMenuSectionLabel('안내'),
+                  _NetworkMapMenuTile(
+                    key: const Key('networkMapMenuDataSourcesButton'),
+                    icon: Icons.source_outlined,
+                    label: '자료 제공 정보',
+                    onTap: () =>
+                        _runActionAfterMenuClose(context, onOpenDataSources!),
                   ),
                 ],
                 const SizedBox(height: 10),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1116,6 +1116,46 @@ void main() {
     );
   });
 
+  testWidgets('노선도 메뉴에서 데이터 및 지도 출처 화면으로 이동한다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('networkMapMenuButton')));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(const Key('networkMapMenuDataSourcesButton')),
+      120,
+    );
+    await tester.tap(
+      find.descendant(
+        of: find.byKey(const Key('networkMapMenuDataSourcesButton')),
+        matching: find.byType(InkWell),
+      ),
+    );
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      find.byKey(const Key('dataSourceAttributionScreen')),
+      findsOneWidget,
+    );
+    expect(find.text('데이터 및 지도 출처'), findsOneWidget);
+    await tester.pump();
+    await tester.pump();
+    await tester.scrollUntilVisible(find.text('지도 표시용 asset'), 240);
+    expect(find.text('지도 표시용 asset'), findsOneWidget);
+    expect(find.text('상록수·사당 검증 pilot'), findsOneWidget);
+  });
+
   testWidgets('노선도 지역 메뉴는 선택한 지역으로 지도를 다시 불러온다', (tester) async {
     final repository = FakeStationSearchRepository(
       networkMapRegionNames: const ['테스트권', '부산'],
@@ -3685,39 +3725,35 @@ void main() {
     tester,
   ) async {
     await tester.pumpWidget(
-      EasySubwayApp(
-        repository: FakeStationSearchRepository(),
-        reportRepository: FakeFacilityReportRepository(),
-        routeRepository: FakeRouteSearchRepository(),
-        favoriteRepository: FakeFavoriteStationRepository(),
-        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
-        favoriteRouteRepository: FakeFavoriteRouteRepository(),
-        notificationRepository: FakeNotificationSettingsRepository(),
-        initialOnboardingState: _completedOnboardingState(),
-      ),
+      const MaterialApp(home: DataSourceAttributionScreen()),
     );
-    await tester.pumpAndSettle();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump();
 
-    await _openSettingsScreen(tester);
-    await tester.scrollUntilVisible(
-      find.byKey(const Key('dataSourceAttributionSettingsButton')),
-      160,
+    expect(
+      find.byKey(const Key('dataSourceAttributionScreen')),
+      findsOneWidget,
     );
-    await tester.ensureVisible(
-      find.byKey(const Key('dataSourceAttributionSettingsButton')),
-    );
-    await tester.pumpAndSettle();
-    await tester.tap(
-      find.byKey(const Key('dataSourceAttributionSettingsButton')),
-    );
-    await tester.pumpAndSettle();
-
     expect(find.text('데이터 및 지도 출처'), findsOneWidget);
-    expect(find.text('지도 표시용 asset'), findsOneWidget);
-    expect(find.text('상록수·사당 검증 pilot'), findsOneWidget);
-    expect(find.text('수도권'), findsOneWidget);
-    await tester.scrollUntilVisible(find.text('경로·시설 판단용 data pack'), 420);
-    expect(find.text('경로·시설 판단용 data pack'), findsOneWidget);
+
+    final manifest =
+        jsonDecode(
+              File(
+                'assets/datapacks/metro_map_pack/manifest.json',
+              ).readAsStringSync(),
+            )
+            as Map<String, Object?>;
+    final inventory =
+        jsonDecode(
+              File('assets/datapacks/source-inventory.json').readAsStringSync(),
+            )
+            as Map<String, Object?>;
+    final maps = (manifest['maps'] as List).cast<Map<String, Object?>>();
+    final sources = (inventory['sources'] as List).cast<Map<String, Object?>>();
+
+    expect(maps.map((map) => map['app_region']), contains('수도권'));
+    expect(sources, isNotEmpty);
   });
 
   testWidgets('설정 화면 보기 옵션은 변경값을 저장하고 다시 실행해도 유지한다', (tester) async {


### PR DESCRIPTION
## 요약
- 노선도 drawer에 자료 제공 정보 진입점을 추가해 기존 데이터 및 지도 출처 화면으로 이동할 수 있게 했습니다.
- drawer 메뉴를 스크롤 가능하게 바꿔 150%/200% 글자 크기에서 항목 추가로 overflow가 나지 않게 했습니다.
- 출처 화면의 asset load Future를 1회 생성으로 고정해 반복 rebuild/loading을 막았습니다.

## 검증
- flutter test test/widget_test.dart --name '노선도 메뉴에서 데이터 및 지도 출처 화면으로 이동한다|데이터 및 지도 출처 화면은 manifest와 source inventory를 보여준다|공식 노선도 데이터팩 manifest는 앱 번들 asset을 가리킨다'
- node --test tools/ci/repository-contract.test.mjs
- git diff --check
- flutter build apk --debug
- Android emulator evidence: .codex/evidence/datapack-source-attribution/1398-android-ui-20260702/ source-screen-font100/150/200, menu-with-source-font100/150/200

Refs #1398
Refs #1419