### PR TITLE
[Route Commercialization] V2 planner no-service status 고정

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -5,6 +5,7 @@ import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.EtaSource;
+import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import java.time.OffsetDateTime;
@@ -24,21 +25,25 @@ public class RouteV2Planner {
 	}
 
 	public RouteV2Plan search(SearchRouteV2Command command) {
-		SearchRouteCommand searchRouteCommand = command.toSearchRouteCommand();
-		if (routeSearchUseCase instanceof RouteSearchService routeSearchService) {
-			List<RouteSearchResult> itineraries = routeSearchService.searchRouteAlternatives(
-				searchRouteCommand,
-				command.alternativeCount()
-			);
-			return new RouteV2Plan(
-				itineraries,
-				statusesOf(itineraries, command.useRealtime()),
-				PLANNER_ADR
-			);
+		try {
+			SearchRouteCommand searchRouteCommand = command.toSearchRouteCommand();
+			if (routeSearchUseCase instanceof RouteSearchService routeSearchService) {
+				List<RouteSearchResult> itineraries = routeSearchService.searchRouteAlternatives(
+					searchRouteCommand,
+					command.alternativeCount()
+				);
+				return new RouteV2Plan(
+					itineraries,
+					statusesOf(itineraries, command.useRealtime()),
+					PLANNER_ADR
+				);
+			}
+			RouteSearchResult primary = routeSearchUseCase.searchRoute(searchRouteCommand);
+			List<RouteSearchResult> itineraries = List.of(primary);
+			return new RouteV2Plan(itineraries, statusesOf(itineraries, command.useRealtime()), PLANNER_ADR);
+		} catch (RouteNotFoundException exception) {
+			return new RouteV2Plan(List.of(), List.of("NO_TIMETABLE_SERVICE"), PLANNER_ADR);
 		}
-		RouteSearchResult primary = routeSearchUseCase.searchRoute(searchRouteCommand);
-		List<RouteSearchResult> itineraries = List.of(primary);
-		return new RouteV2Plan(itineraries, statusesOf(itineraries, command.useRealtime()), PLANNER_ADR);
 	}
 
 	private List<String> statusesOf(List<RouteSearchResult> itineraries, boolean useRealtime) {

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -15,6 +15,7 @@ import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteRefreshResult;
 import com.easysubway.route.domain.RouteRefreshStatus;
 import com.easysubway.route.domain.ConstraintMode;
+import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
@@ -110,6 +111,35 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].slackSeconds").value(0))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].etaSource").value("PLANNED"))
 			.andExpect(jsonPath("$.data.itineraries[0].commercialEtaEligible").value(false));
+	}
+
+	@Test
+	@DisplayName("V2 경로 검색은 시간표 서비스가 없으면 NO_TIMETABLE_SERVICE status와 빈 itinerary를 반환한다")
+	void routeSearchV2ReturnsNoTimetableServiceStatus() throws Exception {
+		when(routeSearchUseCase.searchRoute(argThat(command ->
+			"station-no-service-origin".equals(command.originStationId())
+				&& "station-no-service-destination".equals(command.destinationStationId())
+		))).thenThrow(new RouteNotFoundException());
+
+		mockMvc.perform(post("/api/v2/routes/search")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{
+					  "originStationId": "station-no-service-origin",
+					  "destinationStationId": "station-no-service-destination",
+					  "departureTime": "2026-06-30T09:15:00+09:00",
+					  "mobilityType": "SENIOR",
+					  "constraintMode": "PREFER_STEP_FREE",
+					  "useRealtime": false,
+					  "maxTransfers": 1,
+					  "alternativeCount": 3
+					}
+					"""))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.statuses[0]").value("NO_TIMETABLE_SERVICE"))
+			.andExpect(jsonPath("$.data.statuses[1]").doesNotExist())
+			.andExpect(jsonPath("$.data.itineraries").isEmpty());
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -681,6 +681,65 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 직접 경로를 FOUND 단일 itinerary로 반환한다")
+	void routeV2PlannerReturnsDirectItinerary() {
+		var planner = routeV2Planner(new StairOnlyTransitMasterPort());
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 0, 3));
+
+		assertThat(plan.statuses()).containsExactly("FOUND");
+		assertThat(plan.itineraries()).hasSize(1);
+		assertThat(plan.itineraries().getFirst().transferCount()).isZero();
+	}
+
+	@Test
+	@DisplayName("V2 planner는 1회 환승 경로를 FOUND itinerary로 반환한다")
+	void routeV2PlannerReturnsOneTransferItinerary() {
+		var planner = routeV2Planner(new OneTransferTransitMasterPort());
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
+
+		assertThat(plan.statuses()).containsExactly("FOUND");
+		assertThat(plan.itineraries()).hasSize(1);
+		assertThat(plan.itineraries().getFirst().transferCount()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("V2 planner는 2회 환승 경로를 FOUND itinerary로 반환한다")
+	void routeV2PlannerReturnsTwoTransferItinerary() {
+		var planner = routeV2Planner(new TwoTransferTransitMasterPort());
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 2, 3));
+
+		assertThat(plan.statuses()).containsExactly("FOUND");
+		assertThat(plan.itineraries()).hasSize(1);
+		assertThat(plan.itineraries().getFirst().transferCount()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("V2 planner는 시간표 서비스가 없으면 NO_TIMETABLE_SERVICE status를 반환한다")
+	void routeV2PlannerReturnsNoTimetableServiceStatus() {
+		var planner = routeV2Planner(new TwoTransferTransitMasterPort());
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
+
+		assertThat(plan.statuses()).containsExactly("NO_TIMETABLE_SERVICE");
+		assertThat(plan.itineraries()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("V2 planner는 접근성 차단 경로를 BLOCKED_ACCESSIBILITY status로 반환한다")
+	void routeV2PlannerReturnsBlockedAccessibilityStatus() {
+		var planner = routeV2Planner(new StairOnlyTransitMasterPort());
+
+		var plan = planner.search(routeV2Command(ConstraintMode.STRICT_STEP_FREE, MobilityType.WHEELCHAIR, 0, 3));
+
+		assertThat(plan.statuses()).containsExactly("BLOCKED_ACCESSIBILITY");
+		assertThat(plan.itineraries()).hasSize(1);
+		assertThat(plan.itineraries().getFirst().status()).isEqualTo(RouteSearchStatus.BLOCKED);
+	}
+
+	@Test
 	@DisplayName("V2 useRealtime=true는 provider ETA를 첫 승차 단계에 반영한다")
 	void routeV2PlannerAppliesRealtimeEtaWhenRequested() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -1388,6 +1447,29 @@ class RouteSearchServiceTest {
 		var repository = new InMemoryRouteSearchRepository();
 		var routeSearchService = new RouteSearchService(repository, repository, transitMasterPort, CLOCK);
 		return routeSearchService.searchRoute(new SearchRouteCommand("station-a", "station-b", mobilityType)).score();
+	}
+
+	private static RouteV2Planner routeV2Planner(LoadTransitMasterPort transitMasterPort) {
+		var repository = new InMemoryRouteSearchRepository();
+		return new RouteV2Planner(new RouteSearchService(repository, repository, transitMasterPort, CLOCK));
+	}
+
+	private static RouteV2Planner.SearchRouteV2Command routeV2Command(
+		ConstraintMode constraintMode,
+		MobilityType mobilityType,
+		int maxTransfers,
+		int alternativeCount
+	) {
+		return new RouteV2Planner.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-01T09:00:00+09:00"),
+			mobilityType,
+			constraintMode,
+			false,
+			maxTransfers,
+			alternativeCount
+		);
 	}
 
 	private static String firstStepDescription(MobilityType mobilityType) {


### PR DESCRIPTION
## Summary
- V2 planner가 경로 없음/시간표 서비스 없음 상황을 404 예외 대신 NO_TIMETABLE_SERVICE status와 빈 itinerary로 반환하게 했습니다.
- #1402 완료 조건의 V2 planner 단위 테스트 범위 direct, one-transfer, two-transfer, no service, blocked accessibility를 고정했습니다.

## Verification
- ./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest
- ./gradlew test
- node --test --test-name-pattern "V2 경로 검색은 production planner" tools/ci/repository-contract.test.mjs
- git diff --check

## Route commercialization gate impact
- V2 runtime status coverage를 보강했습니다.
- production/manual contract report evidence 수집은 아직 후속 작업으로 남습니다.

Refs #1402
Refs #1414