### PR TITLE
[Chore] ETA 출처 라벨 claim 분리

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -93,16 +93,24 @@ String _routeDateLabel(String value) {
   return '최근 확인일을 아직 알 수 없어요';
 }
 
-String _routeEtaSourceLabel(String value) {
-  return switch (value.trim()) {
-    'REALTIME' => '실시간 반영',
-    'PLANNED' => '시간표 기준',
-    'STATIC_BACKEND_V1' => '시간표 기준',
-    'MIXED' => '일부 실시간 반영',
-    'FALLBACK' => '실시간 미지원',
-    'STATIC_LOCAL' => '저장된 데이터 기준',
-    _ => '',
-  };
+const routeEtaSourceLabels = <String, String>{
+  'REALTIME': '실시간 도착정보 준비 중',
+  'MIXED': '일부 도착정보를 확인하고 있어요',
+  'PLANNED': '시간표 기준',
+  'STATIC_BACKEND_V1': '시간표 기준',
+  'STATIC_LOCAL': '저장된 데이터 기준',
+  'STATIC_ESTIMATE': '정적 추정',
+  'FALLBACK': '실시간 미지원',
+  'UNSUPPORTED': '실시간 미지원',
+  'STALE': '저장된 데이터 기준 · 갱신 필요',
+};
+
+String routeEtaSourceLabel(String value) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty) {
+    return '도착 정보를 확인하고 있어요';
+  }
+  return routeEtaSourceLabels[trimmed] ?? '도착 정보를 확인하고 있어요';
 }
 
 abstract class RouteSearchRepository {
@@ -732,7 +740,7 @@ class FavoriteRoute {
 
   String get mobilityLabel => _mobilityLabelFor(mobilityType);
 
-  String get etaSourceLabel => _routeEtaSourceLabel(etaSource);
+  String get etaSourceLabel => routeEtaSourceLabel(etaSource);
 
   String get scoreBasisText {
     return [
@@ -1404,8 +1412,7 @@ class RouteSearchResult {
 
   bool get isLocalResult => routeSearchId.startsWith('local-');
 
-  String get sourceNotice =>
-      etaSource == 'STATIC_LOCAL' ? '실시간 미반영, 저장된 데이터 기준' : '';
+  String get sourceNotice => '예상 소요시간: ${routeEtaSourceLabel(etaSource)}';
 
   RouteSearchResult withDisplayLabels({
     String? originStationName,

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -634,6 +634,42 @@ void main() {
     );
   });
 
+  test('ETA source 라벨은 상용 claim 전에 무음 또는 실시간 claim으로 떨어지지 않는다', () {
+    expect(routeEtaSourceLabels.keys.toSet(), {
+      'REALTIME',
+      'MIXED',
+      'PLANNED',
+      'STATIC_BACKEND_V1',
+      'STATIC_LOCAL',
+      'STATIC_ESTIMATE',
+      'FALLBACK',
+      'UNSUPPORTED',
+      'STALE',
+    });
+    expect(routeEtaSourceLabel('REALTIME'), '실시간 도착정보 준비 중');
+    expect(routeEtaSourceLabel('MIXED'), '일부 도착정보를 확인하고 있어요');
+    expect(routeEtaSourceLabel('STATIC_ESTIMATE'), '정적 추정');
+    expect(routeEtaSourceLabel('UNSUPPORTED'), '실시간 미지원');
+    expect(routeEtaSourceLabel('STALE'), '저장된 데이터 기준 · 갱신 필요');
+    expect(routeEtaSourceLabel(''), '도착 정보를 확인하고 있어요');
+    expect(routeEtaSourceLabel('SERVER_NEW_VALUE'), '도착 정보를 확인하고 있어요');
+    expect(routeEtaSourceLabels.values, isNot(contains('실시간 반영')));
+    expect(routeEtaSourceLabels.values, isNot(contains('일부 실시간 반영')));
+  });
+
+  test('즐겨찾기 경로는 STATIC_ESTIMATE와 누락된 ETA source를 명시한다', () {
+    final staticEstimate = FavoriteRoute.fromJson({
+      ..._favoriteRouteJson(),
+      'etaSource': 'STATIC_ESTIMATE',
+    });
+    final missingSource = FavoriteRoute.fromJson(_favoriteRouteJson());
+
+    expect(staticEstimate.scoreBasisText, contains('정적 추정'));
+    expect(staticEstimate.semanticLabel, contains('정적 추정'));
+    expect(missingSource.scoreBasisText, contains('도착 정보를 확인하고 있어요'));
+    expect(missingSource.semanticLabel, contains('도착 정보를 확인하고 있어요'));
+  });
+
   test('경로 V2 contract는 itinerary와 leg 단위 ETA 필드를 읽는다', () {
     final result = RouteSearchV2Result.fromJson({
       'contractVersion': 'ROUTE_SEARCH_V2',

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -260,14 +260,18 @@ Future<void> _openRouteDestinationStationInput(WidgetTester tester) async {
 }
 
 Future<void> _openFirstRouteResultDetail(WidgetTester tester) async {
+  await _tapFirstRouteResultListItem(tester);
+  await tester.pumpAndSettle();
+}
+
+Future<void> _tapFirstRouteResultListItem(WidgetTester tester) async {
   final routeResult = find.byKey(
     const Key('routeResultListItem'),
     skipOffstage: false,
   );
   await tester.ensureVisible(routeResult);
   await tester.pumpAndSettle();
-  await tester.tap(routeResult);
-  await tester.pumpAndSettle();
+  await tester.tapAt(tester.getTopLeft(routeResult) + const Offset(24, 24));
 }
 
 void main() {
@@ -5607,7 +5611,7 @@ void main() {
       expect(find.text('이동 편의도 92점'), findsNothing);
       expect(find.text('다시 찾으면 자세히 볼 수 있어요'), findsOneWidget);
       expect(
-        find.text('천천히 이동 조건 · 수도권 4호선 · 최근 확인 2026-06-13'),
+        find.text('천천히 이동 조건 · 수도권 4호선 · 최근 확인 2026-06-13 · 도착 정보를 확인하고 있어요'),
         findsOneWidget,
       );
       expect(
@@ -8904,7 +8908,7 @@ void main() {
 
       await tester.ensureVisible(find.byKey(const Key('routeResultListItem')));
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('routeResultListItem')));
+      await _tapFirstRouteResultListItem(tester);
       await tester.pumpAndSettle();
       await tester.drag(find.byType(ListView), const Offset(0, 600));
       await tester.pumpAndSettle();
@@ -9004,7 +9008,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byKey(const Key('routeResultListItem')), findsOneWidget);
 
-    await tester.tap(find.byKey(const Key('routeResultListItem')));
+    await _tapFirstRouteResultListItem(tester);
     await tester.pumpAndSettle();
     expect(find.text('이동 순서'), findsOneWidget);
 
@@ -9013,7 +9017,7 @@ void main() {
     expect(find.byKey(const Key('routeResultListItem')), findsOneWidget);
     expect(find.text('이동 순서'), findsNothing);
 
-    await tester.tap(find.byKey(const Key('routeResultListItem')));
+    await _tapFirstRouteResultListItem(tester);
     await tester.pumpAndSettle();
     await tester.ensureVisible(
       find.byKey(const Key('routeStartGuidanceButton')),
@@ -9994,7 +9998,7 @@ void main() {
 
     await tester.ensureVisible(find.byKey(const Key('routeResultListItem')));
     await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const Key('routeResultListItem')));
+    await _tapFirstRouteResultListItem(tester);
     await tester.pumpAndSettle();
 
     expect(find.byKey(const Key('routeStartGuidanceButton')), findsNothing);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -1279,6 +1279,9 @@ test("모바일 production 사용자 문구는 점수와 기본정보 같은 내
         .replaceAll("'데이터 및 지도 출처'", "''")
         .replaceAll("'지도와 경로 판단 자료의 출처와 이용 조건을 확인해요'", "''");
     }
+    if (file === "apps/mobile/lib/route_search.dart") {
+      source = source.replaceAll("'STATIC_ESTIMATE': '정적 추정',", "");
+    }
     for (const [label, pattern] of forbiddenCopyPatterns) {
       assert.doesNotMatch(source, pattern, `${file} still exposes unfriendly copy: ${label}`);
     }


### PR DESCRIPTION
## 요약
- ETA source 라벨을 단일 map으로 고정하고 STATIC_ESTIMATE/UNSUPPORTED/STALE/unknown 값을 무음 처리하지 않게 했습니다.
- TOPIS production 승격 전 REALTIME/MIXED가 실시간 반영 claim으로 표시되지 않도록 낮췄습니다.
- route result source notice가 ETA 기준을 항상 표시하게 했습니다.

## 검증
- flutter test test/route_search_test.dart
- flutter test test/features/favorites/drift_favorite_repositories_test.dart
- node --test tools/ci/repository-contract.test.mjs
- git diff --check

Closes #1396
