### PR TITLE
[Route Commercialization] V2 contract report legType 판정 보강

### DIFF
--- a/tools/routes/build-route-v2-contract-report.mjs
+++ b/tools/routes/build-route-v2-contract-report.mjs
@@ -84,7 +84,7 @@ function hasMultiTransfer(samples) {
 function hasOutOfStationTransfer(samples) {
   return samples.some((sample) => itinerariesOf(sample).some((itinerary) => {
     const steps = itinerary.legs ?? itinerary.steps ?? [];
-    return steps.some((step) => step.type === "OUT_OF_STATION_TRANSFER" || step.stepType === "out_of_station_transfer");
+    return steps.some((step) => isOutOfStationTransferStep(step));
   }));
 }
 
@@ -119,6 +119,10 @@ function lineSequenceOf(itinerary) {
 
 function isRideStep(step) {
   return ["RIDE", "ride"].includes(step.legType ?? step.type ?? step.stepType);
+}
+
+function isOutOfStationTransferStep(step) {
+  return ["OUT_OF_STATION_TRANSFER", "out_of_station_transfer"].includes(step.legType ?? step.type ?? step.stepType);
 }
 
 function number(value) {

--- a/tools/routes/build-route-v2-contract-report.test.mjs
+++ b/tools/routes/build-route-v2-contract-report.test.mjs
@@ -73,6 +73,34 @@ test("reads line sequence from route v2 legType runtime response", () => {
   assert.equal(report.wrongLineSequence, 0);
 });
 
+test("detects out-of-station transfer from route v2 legType runtime response", () => {
+  const report = buildContractReport({
+    schemaVersion: 1,
+    samples: [
+      {
+        id: "out-of-station-runtime",
+        response: {
+          data: {
+            itineraries: [
+              {
+                status: "FOUND",
+                transferCount: 1,
+                legs: [
+                  { legType: "RIDE", lineId: "line-a" },
+                  { legType: "OUT_OF_STATION_TRANSFER" },
+                  { legType: "RIDE", lineId: "line-b" },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    ],
+  });
+
+  assert.equal(report.outOfStationTransferSupported, true);
+});
+
 test("writes route v2 contract report json", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "route-v2-contract-"));
   const inputPath = path.join(dir, "responses.json");


### PR DESCRIPTION
## 요약
- V2 runtime response의 legType=OUT_OF_STATION_TRANSFER를 contract report out-of-station capability로 판정
- legType 기반 회귀 테스트 추가

## 검증
- node --test tools/routes/build-route-v2-contract-report.test.mjs
- node --test tools/routes/*.test.mjs
- git diff --check

Refs #1402
Refs #1414