### PR TITLE
[Route Commercialization] strict step-free 출구 판정 보수화

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -778,11 +778,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.filter(facility -> facility.dataConfidence() == DataConfidenceLevel.HIGH)
 			.filter(this::isStepFreeFacility)
 			.toList();
-		boolean hasUsableStepFreeFacility = highConfidenceStepFreeFacilities.stream()
-			.anyMatch(this::hasUsableStatus);
 		boolean hasUsableStepFreeExit = highConfidenceExits.stream()
 			.anyMatch(exit -> isUsableStepFreeExit(exit, highConfidenceStepFreeFacilities));
-		return !hasUsableStepFreeFacility && !hasUsableStepFreeExit;
+		return !hasUsableStepFreeExit;
 	}
 
 	private Optional<Boolean> hasStairOnlyInternalEdges(String stationId) {
@@ -852,14 +850,14 @@ public class RouteSearchService implements RouteSearchUseCase {
 	}
 
 	private Optional<StationExit> recommendedStepFreeExit(String stationId) {
-		List<AccessibilityFacility> highConfidenceStepFreeFacilities = stationFacilities(stationId).stream()
-			.filter(facility -> facility.dataConfidence() == DataConfidenceLevel.HIGH)
-			.filter(this::isStepFreeFacility)
-			.toList();
 		return stationExits(stationId).stream()
 			.filter(exit -> exit.dataConfidence() == DataConfidenceLevel.HIGH)
-			.filter(exit -> isUsableStepFreeExit(exit, highConfidenceStepFreeFacilities))
+			.filter(this::hasStepFreeExitSummary)
 			.findFirst();
+	}
+
+	private boolean hasStepFreeExitSummary(StationExit exit) {
+		return exit.hasElevatorConnection() && !exit.hasStairOnlyPath();
 	}
 
 	private boolean isStepFreeFacility(AccessibilityFacility facility) {
@@ -867,13 +865,6 @@ public class RouteSearchService implements RouteSearchUseCase {
 			case ELEVATOR, WHEELCHAIR_LIFT, RAMP -> true;
 			default -> false;
 		};
-	}
-
-	private boolean hasUsableStepFreeFacility(String stationId) {
-		return stationFacilities(stationId).stream()
-			.filter(facility -> facility.dataConfidence() == DataConfidenceLevel.HIGH)
-			.filter(this::isStepFreeFacility)
-			.anyMatch(this::hasUsableStatus);
 	}
 
 	private boolean hasUsableStatus(AccessibilityFacility facility) {
@@ -889,7 +880,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			return false;
 		}
 		return highConfidenceStepFreeFacilities.stream()
-			.noneMatch(facility -> exit.id().equals(facility.exitId()) && !hasUsableStatus(facility));
+			.anyMatch(facility -> exit.id().equals(facility.exitId()) && hasUsableStatus(facility));
 	}
 
 	private List<StationExit> stationExits(String stationId) {

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -88,7 +88,7 @@ class RouteSearchServiceTest {
 			.containsExactly(
 				"선택된 경로에서 접근성 확인이 필요한 구간을 표시합니다.",
 				"출구와 시설 상태는 현장 안내를 함께 확인해 주세요.",
-				"유모차 이동 조건을 반영해 이동 부담이 낮은 경로를 우선했습니다."
+				"계단 포함 구간을 미리 표시했어요"
 			);
 		assertThat(String.join("\n", result.recommendationReasons())).doesNotContain("확인했어요");
 		assertThat(result.steps())
@@ -1002,8 +1002,8 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
-	@DisplayName("휠체어 이동 유형은 출구 요약에 엘리베이터 연결이 있으면 별도 시설 행이 없어도 경로를 제공한다")
-	void wheelchairRouteAllowsElevatorConnectedExitWithoutFacilityRow() {
+	@DisplayName("휠체어 이동 유형은 출구 요약만 있고 검증된 시설 행이 없으면 strict 경로를 차단한다")
+	void wheelchairRouteBlocksElevatorConnectedExitWithoutFacilityRow() {
 		var repository = new InMemoryRouteSearchRepository();
 		var exitSummaryService = new RouteSearchService(
 			repository,
@@ -1018,8 +1018,33 @@ class RouteSearchServiceTest {
 			MobilityType.WHEELCHAIR
 		));
 
-		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
-		assertThat(result.blockedReasons()).isEmpty();
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
+		assertThat(result.steps()).isEmpty();
+		assertThat(result.blockedReasons())
+			.containsExactly("계단 없는 역 접근 경로를 확인할 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("휠체어 이동 유형은 출구와 연결되지 않은 시설 행만 있으면 strict 경로를 차단한다")
+	void wheelchairRouteBlocksUnlinkedStepFreeFacilityRow() {
+		var repository = new InMemoryRouteSearchRepository();
+		var unlinkedFacilityService = new RouteSearchService(
+			repository,
+			repository,
+			new UnlinkedStepFreeFacilityTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = unlinkedFacilityService.searchRoute(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.WHEELCHAIR
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.BLOCKED);
+		assertThat(result.steps()).isEmpty();
+		assertThat(result.blockedReasons())
+			.containsExactly("계단 없는 역 접근 경로를 확인할 수 없습니다.");
 	}
 
 	@Test
@@ -2020,6 +2045,7 @@ class RouteSearchServiceTest {
 		public List<StationExit> loadStationExits() {
 			return List.of(
 				stairOnlyExit("exit-a-1", "station-a"),
+				stepFreeExit("exit-a-2", "station-a"),
 				stepFreeExit("exit-b-1", "station-b")
 			);
 		}
@@ -2030,12 +2056,14 @@ class RouteSearchServiceTest {
 				facility(
 					"facility-a-ramp",
 					"station-a",
+					"exit-a-2",
 					AccessibilityFacilityType.RAMP,
 					AccessibilityFacilityStatus.NORMAL
 				),
 				facility(
 					"facility-b-elevator",
 					"station-b",
+					"exit-b-1",
 					AccessibilityFacilityType.ELEVATOR,
 					AccessibilityFacilityStatus.NORMAL
 				)
@@ -2051,6 +2079,29 @@ class RouteSearchServiceTest {
 				stairOnlyExit("exit-a-1", "station-a"),
 				stepFreeExit("exit-a-2", "station-a"),
 				stepFreeExit("exit-b-1", "station-b")
+			);
+		}
+	}
+
+	private static class UnlinkedStepFreeFacilityTransitMasterPort extends ExitSummaryAccessibleTransitMasterPort {
+
+		@Override
+		public List<AccessibilityFacility> loadAccessibilityFacilities() {
+			return List.of(
+				facility(
+					"facility-a-elevator",
+					"station-a",
+					"exit-a-missing",
+					AccessibilityFacilityType.ELEVATOR,
+					AccessibilityFacilityStatus.NORMAL
+				),
+				facility(
+					"facility-b-elevator",
+					"station-b",
+					"exit-b-missing",
+					AccessibilityFacilityType.ELEVATOR,
+					AccessibilityFacilityStatus.NORMAL
+				)
 			);
 		}
 	}


### PR DESCRIPTION
## 요약
- strict step-free 경로 판정에서 출구 요약만으로 safe 승격하지 않도록 변경
- 출구와 연결된 high-confidence usable 시설 행이 있을 때만 strict safe로 판정
- 안내 문구용 출구 요약 fallback은 별도 함수로 유지

## 검증
- RED: ./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest (신규 2개 테스트 실패 확인)
- ./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest
- ./gradlew test
- git diff --check

Refs #1413
Refs #1414