### PR TITLE
[Chore] 데이터팩 freshness SLA 정책 고정

### DIFF
--- a/.github/workflows/datapack-release.yml
+++ b/.github/workflows/datapack-release.yml
@@ -7,9 +7,12 @@ on:
     paths:
       - tools/datapack/**
       - tools/route-map/**
+      - apps/mobile/release/datapack-freshness-sla.json
       - apps/mobile/lib/core/datapack/**
       - apps/mobile/lib/core/database/catalog/**
       - .github/workflows/datapack-release.yml
+  schedule:
+    - cron: "17 18 * * *"
   workflow_dispatch:
     inputs:
       mode:

--- a/apps/mobile/release/datapack-freshness-sla.json
+++ b/apps/mobile/release/datapack-freshness-sla.json
@@ -1,0 +1,84 @@
+{
+  "schemaVersion": 1,
+  "applicationId": "easysubway",
+  "androidApplicationId": "com.easysubway.app",
+  "releaseGate": "datapack-freshness-sla",
+  "issue": 1418,
+  "status": "IN_PROGRESS",
+  "currentDecision": "NO_GO",
+  "policyOwner": "QA",
+  "sourceClasses": [
+    {
+      "id": "static_accessibility_facility",
+      "examples": ["KRIC elevator", "KRIC escalator", "KRIC wheelchair lift"],
+      "reverificationCadence": "P90D",
+      "eventTriggers": ["operator construction notice", "facility outage notice", "field verification override"],
+      "changePublishSla": "P3D",
+      "freshnessMetric": "freshnessValidRatio"
+    },
+    {
+      "id": "planned_timetable",
+      "examples": ["service calendar", "trips", "stop_times", "headway"],
+      "reverificationCadence": "event-based",
+      "eventTriggers": ["operator timetable revision", "service calendar expiry", "line extension opening"],
+      "changePublishSla": "before-effective-date",
+      "freshnessMetric": "plannedEtaCoverageRatio"
+    },
+    {
+      "id": "route_map_asset",
+      "examples": ["official cyber-station SVG", "route map label polygons"],
+      "reverificationCadence": "P1Y",
+      "eventTriggers": ["new station opening", "line extension opening", "official map revision"],
+      "changePublishSla": "P14D",
+      "freshnessMetric": "routeMapPositionFreshnessRatio"
+    },
+    {
+      "id": "realtime_overlay",
+      "examples": ["Seoul TOPIS arrival", "provider train position"],
+      "reverificationCadence": "PT90S",
+      "eventTriggers": ["provider stale", "mapping failure spike", "quota or terms change"],
+      "changePublishSla": "online-overlay-only",
+      "freshnessMetric": "providerFreshnessSecondsMax"
+    }
+  ],
+  "monitoring": {
+    "manualCheckCadence": "P1D",
+    "channels": ["operator notices", "public data portal update metadata", "GitHub Actions schedule"],
+    "alertBeforePackExpiry": "PT6H",
+    "alertWhenFreshnessInvalid": true,
+    "productionChannelAllowsExpiredPack": false
+  },
+  "scheduledPipeline": {
+    "cadence": "P1D",
+    "requiredStages": [
+      "source-snapshot",
+      "build",
+      "validate",
+      "publish",
+      "post-publish-artifact-validation"
+    ],
+    "releaseSequenceManagedByPipeline": true,
+    "expiresAtManagedByPipeline": true,
+    "reusesProductionValidationIssue": 1393
+  },
+  "staleExposurePolicy": {
+    "expiredManifestAppBehavior": "continue-with-visible-stale-label",
+    "expiredManifestEtaSource": "STALE",
+    "visibleLabelKo": "저장된 데이터 기준 · 갱신 필요",
+    "strictProfileCanUseStaleAsFound": false,
+    "supportClaimDowngradeRequired": true,
+    "linkedUiIssues": [1396, 1398]
+  },
+  "rollback": {
+    "runbookCommand": "node tools/datapack/run-emergency-datapack-drill.mjs --input <drill-input.json> --output <drill-evidence.json>",
+    "rehearsalEvidenceRequired": true,
+    "requiredEvidence": ["manifest-hashes", "rollback-time-seconds", "route-regression-replay"]
+  },
+  "requiredEvidence": [
+    "freshness-policy-json",
+    "scheduled-pipeline-log-one-cycle",
+    "expiry-alert-evidence",
+    "rollback-rehearsal-evidence",
+    "stale-label-android-ui-tree-or-screenshot"
+  ]
+}

--- a/apps/mobile/release/datapack-release-readiness-gate.json
+++ b/apps/mobile/release/datapack-release-readiness-gate.json
@@ -74,6 +74,7 @@
     "routeV2ContractReport": "artifacts/route-v2-contract-report.json",
     "coverageGapReport": "artifacts/datapack-coverage-gaps.json",
     "qualityMetricReport": "artifacts/datapack-quality-metrics.json",
+    "freshnessSlaPolicy": "apps/mobile/release/datapack-freshness-sla.json",
     "androidOfflineRouteEvidence": ".codex/evidence/datapack-release-readiness/<rc-or-run>/android-offline-route-summary.md"
   },
   "requiredVerificationCommands": [

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -175,6 +175,7 @@ test("datapack release readiness gate blocks commercial datapack and realtime ET
     routeV2ContractReport: "artifacts/route-v2-contract-report.json",
     coverageGapReport: "artifacts/datapack-coverage-gaps.json",
     qualityMetricReport: "artifacts/datapack-quality-metrics.json",
+    freshnessSlaPolicy: "apps/mobile/release/datapack-freshness-sla.json",
     androidOfflineRouteEvidence: ".codex/evidence/datapack-release-readiness/<rc-or-run>/android-offline-route-summary.md",
   });
   assert.ok(
@@ -3852,6 +3853,8 @@ test("데이터팩 release workflow는 production publish hard gate를 강제한
   const releaseEvidenceBundleSchema = readJson("tools/datapack/schema/release-evidence-bundle.schema.json");
 
   assert.match(workflow, /mode:[\s\S]*options:[\s\S]*- exploratory[\s\S]*- release-candidate[\s\S]*- production-publish/);
+  assert.match(workflow, /schedule:[\s\S]*cron: "17 18 \* \* \*"/);
+  assert.match(workflow, /apps\/mobile\/release\/datapack-freshness-sla\.json/);
   assert.match(workflow, /buildSpecPath:[\s\S]*required: true/);
   assert.match(workflow, /allowGaps:[\s\S]*default: false/);
   assert.match(workflow, /targetChannel:[\s\S]*options:[\s\S]*- dev[\s\S]*- staging[\s\S]*- production/);
@@ -4755,6 +4758,44 @@ test("Android v1 production 데이터팩 scope는 수도권 pilot 승인 기준�
   assert.equal(scope.evidencePolicy.githubSummaryOnly, true);
   assert.ok(scope.linkedReleaseBlockers.includes(571));
   assert.ok(scope.linkedReleaseBlockers.includes(1020));
+});
+
+test("데이터팩 freshness SLA는 source별 갱신 주기와 stale 노출 정책을 고정한다", () => {
+  const policy = readJson("apps/mobile/release/datapack-freshness-sla.json");
+  const classes = new Map(policy.sourceClasses.map((sourceClass) => [sourceClass.id, sourceClass]));
+
+  assert.equal(policy.schemaVersion, 1);
+  assert.equal(policy.issue, 1418);
+  assert.equal(policy.currentDecision, "NO_GO");
+  assert.equal(classes.get("static_accessibility_facility").reverificationCadence, "P90D");
+  assert.equal(classes.get("static_accessibility_facility").changePublishSla, "P3D");
+  assert.equal(classes.get("planned_timetable").changePublishSla, "before-effective-date");
+  assert.equal(classes.get("route_map_asset").reverificationCadence, "P1Y");
+  assert.equal(classes.get("realtime_overlay").reverificationCadence, "PT90S");
+  assert.equal(policy.monitoring.manualCheckCadence, "P1D");
+  assert.equal(policy.monitoring.alertBeforePackExpiry, "PT6H");
+  assert.equal(policy.monitoring.productionChannelAllowsExpiredPack, false);
+  assert.deepEqual(policy.scheduledPipeline.requiredStages, [
+    "source-snapshot",
+    "build",
+    "validate",
+    "publish",
+    "post-publish-artifact-validation",
+  ]);
+  assert.equal(policy.scheduledPipeline.releaseSequenceManagedByPipeline, true);
+  assert.equal(policy.scheduledPipeline.expiresAtManagedByPipeline, true);
+  assert.equal(policy.scheduledPipeline.reusesProductionValidationIssue, 1393);
+  assert.equal(policy.staleExposurePolicy.expiredManifestEtaSource, "STALE");
+  assert.equal(policy.staleExposurePolicy.visibleLabelKo, "저장된 데이터 기준 · 갱신 필요");
+  assert.equal(policy.staleExposurePolicy.strictProfileCanUseStaleAsFound, false);
+  assert.deepEqual(policy.staleExposurePolicy.linkedUiIssues, [1396, 1398]);
+  assert.equal(
+    policy.rollback.runbookCommand,
+    "node tools/datapack/run-emergency-datapack-drill.mjs --input <drill-input.json> --output <drill-evidence.json>",
+  );
+  assert.ok(policy.requiredEvidence.includes("scheduled-pipeline-log-one-cycle"));
+  assert.ok(policy.requiredEvidence.includes("rollback-rehearsal-evidence"));
+  assert.ok(policy.requiredEvidence.includes("stale-label-android-ui-tree-or-screenshot"));
 });
 
 test("official source importer는 production placeholder evidence hash를 거부한다", async () => {


### PR DESCRIPTION
## 요약
- 데이터팩 source class별 재검증 주기, 변경 반영 SLA, stale 노출 정책을 `datapack-freshness-sla.json`으로 고정
- datapack release workflow를 daily schedule로 실행하고 freshness SLA artifact 변경도 workflow trigger에 포함
- readiness gate와 repository contract test가 freshness SLA artifact를 요구하도록 연결

## 검증
- `node --test tools/ci/repository-contract.test.mjs`
- `git diff --check`

Refs #1418

## 남은 #1418 evidence
- 실제 scheduled pipeline 1회 실행 로그
- 만료 임박 알림 evidence
- rollback rehearsal evidence
- Android stale label screenshot 또는 UI tree