### PR TITLE
[Test] 대표 경로 regression direct-only scope 고정

### DIFF
--- a/apps/mobile/release/route-commercialization-gate.json
+++ b/apps/mobile/release/route-commercialization-gate.json
@@ -30,9 +30,9 @@
     "unknownAccessibilityMustBeLabeled": true
   },
   "routing": {
-    "multiTransferSupported": true,
-    "outOfStationTransferSupported": true,
-    "alternativeItinerariesMin": 2
+    "multiTransferSupported": false,
+    "outOfStationTransferSupported": false,
+    "alternativeItinerariesMin": 1
   },
   "etaSourceIntegrity": {
     "realtimeEtaWithoutFreshProviderAllowed": false,

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -100,9 +100,9 @@ test("route commercialization release gate blocks unsupported commercial route c
   assert.equal(gate.accessibility.strictStepFreeKnownStairFalsePositiveAllowed, 0);
   assert.equal(gate.accessibility.generatedConnectorAsVerifiedAllowed, false);
   assert.equal(gate.accessibility.unknownAccessibilityMustBeLabeled, true);
-  assert.equal(gate.routing.multiTransferSupported, true);
-  assert.equal(gate.routing.outOfStationTransferSupported, true);
-  assert.equal(gate.routing.alternativeItinerariesMin, 2);
+  assert.equal(gate.routing.multiTransferSupported, false);
+  assert.equal(gate.routing.outOfStationTransferSupported, false);
+  assert.equal(gate.routing.alternativeItinerariesMin, 1);
   assert.equal(gate.etaSourceIntegrity.realtimeEtaWithoutFreshProviderAllowed, false);
   assert.equal(gate.etaSourceIntegrity.staleRealtimeUsedAsFreshAllowed, false);
   assert.equal(gate.etaSourceIntegrity.staticLocalMustBeLabeled, true);
@@ -4620,6 +4620,17 @@ test("Android v1 production 데이터팩 scope는 수도권 pilot 승인 기준�
     productionInput.supportedV1Scope.facilityCoverageDenominator,
     scope.supportScope.facilityCoverageDenominator,
   );
+  assert.deepEqual(productionInput.routeRegressionScope, {
+    mode: "DIRECT_ONLY",
+    excludedPatterns: ["TRANSFER", "MULTI_TRANSFER", "LOOP_BRANCH", "EXPRESS_LOCAL"],
+    claim: productionInput.routeRegressionScope.claim,
+  });
+  assert.match(productionInput.routeRegressionScope.claim, /direct ride only/);
+  assert.deepEqual(productionInput.representativeRouteRegressions.map((route) => route.pattern), ["DIRECT"]);
+  for (const edge of productionInput.routeEdges.filter((routeEdge) => routeEdge.edgeType === "RIDE")) {
+    const speedKmh = (edge.distanceMeters / edge.durationSeconds) * 3.6;
+    assert.ok(speedKmh >= 15 && speedKmh <= 110, `${edge.id} must stay within production ride speed bounds`);
+  }
   assert.deepEqual(scope.supportScope.unsupportedRegionPolicy.requiredAppStatus, [
     "UNSUPPORTED_REGION",
     "다시 확인",

--- a/tools/datapack/build-datapack.mjs
+++ b/tools/datapack/build-datapack.mjs
@@ -84,6 +84,7 @@ async function main() {
       schemaVersion: pack.schemaVersion,
       sourceInventory: pack.sourceInventory,
       regionalQualityMetrics: regionalQualityMetrics(pack),
+      ...(pack.routeRegressionScope ? { routeRegressionScope: canonicalRouteRegressionScope(pack.routeRegressionScope) } : {}),
       representativeRouteRegressions,
       representativeRouteRegressionSignature: representativeRouteRegressionSignature({
         id: pack.id,
@@ -610,6 +611,16 @@ function canonicalRepresentativeRouteRegressions(routes) {
       requiredString(edgeId, "representativeRouteRegressions.requiredEdgeIds"),
     ),
   }));
+}
+
+function canonicalRouteRegressionScope(scope) {
+  return {
+    mode: requiredString(scope.mode, "routeRegressionScope.mode"),
+    excludedPatterns: Array.isArray(scope.excludedPatterns)
+      ? scope.excludedPatterns.map((pattern) => requiredString(pattern, "routeRegressionScope.excludedPatterns"))
+      : [],
+    claim: requiredString(scope.claim, "routeRegressionScope.claim"),
+  };
 }
 
 function canonicalProductionPackUrl(packUrl) {
@@ -1531,7 +1542,10 @@ function validateFixture(fixture) {
       throw new Error("production pack url must not use a local placeholder host");
     }
     validateSourceInventory(pack.sourceInventory, artifactKind);
-    validateRepresentativeRouteRegressions(pack.representativeRouteRegressions);
+    if (pack.routeRegressionScope !== undefined) {
+      validateRouteRegressionScope(pack.routeRegressionScope);
+    }
+    validateRepresentativeRouteRegressions(pack.representativeRouteRegressions, pack.routeRegressionScope);
     if (!Array.isArray(pack.requiredTables) || pack.requiredTables.length === 0) {
       throw new Error(`${pack.id} requiredTables must be a non-empty array`);
     }
@@ -1591,17 +1605,11 @@ function validateTableName(value) {
   }
 }
 
-function validateRepresentativeRouteRegressions(routes) {
+function validateRepresentativeRouteRegressions(routes, scope = null) {
   if (!Array.isArray(routes) || routes.length === 0) {
     throw new Error("pack.representativeRouteRegressions must be a non-empty array");
   }
-  const requiredPatterns = new Set([
-    "DIRECT",
-    "TRANSFER",
-    "MULTI_TRANSFER",
-    "LOOP_BRANCH",
-    "EXPRESS_LOCAL",
-  ]);
+  const requiredPatterns = requiredRepresentativeRoutePatterns(scope);
   const seenPatterns = new Set();
   for (const route of routes) {
     requiredString(route.id, "representativeRouteRegressions.id");
@@ -1624,6 +1632,30 @@ function validateRepresentativeRouteRegressions(routes) {
       throw new Error(`representativeRouteRegressions missing required pattern: ${pattern}`);
     }
   }
+}
+
+function validateRouteRegressionScope(scope) {
+  if (!scope || typeof scope !== "object" || Array.isArray(scope)) {
+    throw new Error("routeRegressionScope must be an object");
+  }
+  const mode = requiredString(scope.mode, "routeRegressionScope.mode");
+  if (mode !== "DIRECT_ONLY") {
+    throw new Error("routeRegressionScope.mode is invalid");
+  }
+  if (!Array.isArray(scope.excludedPatterns)) {
+    throw new Error("routeRegressionScope.excludedPatterns must be an array");
+  }
+  for (const pattern of scope.excludedPatterns) {
+    requiredString(pattern, "routeRegressionScope.excludedPatterns");
+  }
+  requiredString(scope.claim, "routeRegressionScope.claim");
+}
+
+function requiredRepresentativeRoutePatterns(scope = null) {
+  if (scope?.mode === "DIRECT_ONLY") {
+    return new Set(["DIRECT"]);
+  }
+  return new Set(["DIRECT", "TRANSFER", "MULTI_TRANSFER", "LOOP_BRANCH", "EXPRESS_LOCAL"]);
 }
 
 function validateSourceInventory(sourceInventory, artifactKind) {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -4678,6 +4678,48 @@ test("데이터팩 검증기는 대표 route regression 필수 pattern 누락을
   );
 });
 
+test("데이터팩 검증기는 대표 route regression route shape 재사용을 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-datapack-duplicate-route-shape-${Date.now()}`);
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture",
+      "tools/datapack/fixtures/catalog-fixture.json",
+      "--output",
+      outputDir,
+    ],
+    { cwd: root, env: productionEnv },
+  );
+
+  const manifestPath = path.join(outputDir, "current.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  const direct = manifest.packs[0].representativeRouteRegressions.find((route) => route.pattern === "DIRECT");
+  const transfer = manifest.packs[0].representativeRouteRegressions.find((route) => route.pattern === "TRANSFER");
+  transfer.fromNodeId = direct.fromNodeId;
+  transfer.toNodeId = direct.toNodeId;
+  transfer.requiredEdgeIds = direct.requiredEdgeIds;
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-datapack.mjs",
+        "--manifest",
+        manifestPath,
+        "--root",
+        outputDir,
+      ],
+      { cwd: root, env: productionEnv },
+    ),
+    /representativeRouteRegressions duplicate route shape across patterns/,
+  );
+});
+
 test("데이터팩 검증기는 대표 route regression required edge 누락을 거부한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-datapack-missing-route-edge-${Date.now()}`);
   const fixturePath = path.join(outputDir, "fixture.json");
@@ -6338,7 +6380,7 @@ test("공식 source ingest adapter는 stable id mapping으로 catalog fixture pa
     id: "edge-sangnoksu-sadang-seoul-4",
     fromNodeId: "station-sangnoksu:seoul-4",
     toNodeId: "station-sadang:seoul-4",
-    durationSeconds: 420,
+    durationSeconds: 1860,
     distanceMeters: 18600,
     edgeType: "RIDE",
     servicePattern: "LOCAL",
@@ -7124,6 +7166,64 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
     /production facility evidence missing: station-sadang:seoul-4:WHEELCHAIR_LIFT/,
   );
 
+  const unrealisticRideSpeedInputPath = path.join(outputDir, "capital-pilot-production-unrealistic-ride-speed.json");
+  await writeFile(
+    unrealisticRideSpeedInputPath,
+    `${JSON.stringify(
+      {
+        ...input,
+        routeEdges: input.routeEdges.map((edge) =>
+          edge.edgeType === "RIDE"
+            ? { ...edge, durationSeconds: 420 }
+            : edge,
+        ),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  const unrealisticRideSpeedFixturePath = path.join(outputDir, "unrealistic-ride-speed.json");
+  const unrealisticRideSpeedPackDir = path.join(outputDir, "unrealistic-ride-speed-pack");
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/import-official-sources.mjs",
+      "--inventory",
+      "tools/datapack/source-inventory.json",
+      "--input",
+      unrealisticRideSpeedInputPath,
+      "--output",
+      unrealisticRideSpeedFixturePath,
+    ],
+    { cwd: root },
+  );
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture",
+      unrealisticRideSpeedFixturePath,
+      "--output",
+      unrealisticRideSpeedPackDir,
+    ],
+    { cwd: root, env: productionEnv },
+  );
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-datapack.mjs",
+        "--manifest",
+        path.join(unrealisticRideSpeedPackDir, "current.json"),
+        "--root",
+        unrealisticRideSpeedPackDir,
+        "--require-production",
+      ],
+      { cwd: root, env: productionEnv },
+    ),
+    /network_edges ride speed is outside production bounds/,
+  );
+
   await execFileAsync(
     process.execPath,
     [
@@ -7194,6 +7294,12 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
   assert.equal(manifest.signature.algorithm, "rsa-sha256-manifest-v2");
   assert.equal(manifest.packs[0].artifactKind, "production");
   assert.equal(manifest.packs[0].signature.algorithm, "rsa-sha256-pack-manifest-v2");
+  assert.deepEqual(manifest.packs[0].routeRegressionScope, {
+    mode: "DIRECT_ONLY",
+    excludedPatterns: ["TRANSFER", "MULTI_TRANSFER", "LOOP_BRANCH", "EXPRESS_LOCAL"],
+    claim: manifest.packs[0].routeRegressionScope.claim,
+  });
+  assert.deepEqual(manifest.packs[0].representativeRouteRegressions.map((route) => route.pattern), ["DIRECT"]);
   const database = new DatabaseSync(path.join(packOutputDir, "catalog", "capital-v1.sqlite"), { readOnly: true });
   try {
     assert.deepEqual(
@@ -8464,7 +8570,7 @@ function sourceIngestInput() {
           sourceStationCode: "433",
           lineId: "seoul-4",
         },
-        durationSeconds: 420,
+        durationSeconds: 1860,
         distanceMeters: 18600,
         edgeType: "RIDE",
         servicePattern: "LOCAL",
@@ -8487,7 +8593,7 @@ function sourceIngestInput() {
           sourceStationCode: "448",
           lineId: "seoul-4",
         },
-        durationSeconds: 420,
+        durationSeconds: 1860,
         distanceMeters: 18600,
         edgeType: "RIDE",
         servicePattern: "LOCAL",
@@ -8514,38 +8620,15 @@ function sourceIngestInput() {
         description: "상록수역 승강장과 지상을 연결합니다.",
       },
     ],
+    routeRegressionScope: {
+      mode: "DIRECT_ONLY",
+      excludedPatterns: ["TRANSFER", "MULTI_TRANSFER", "LOOP_BRANCH", "EXPRESS_LOCAL"],
+      claim: "capital pilot Android v1 direct ride only; transfer, multi-transfer, branch/loop, and express/local claims are excluded until route graph evidence exists",
+    },
     representativeRouteRegressions: [
       {
         id: "direct-local-capital",
         pattern: "DIRECT",
-        fromNodeId: "station-sangnoksu:seoul-4",
-        toNodeId: "station-sadang:seoul-4",
-        requiredEdgeIds: ["edge-sangnoksu-sadang-seoul-4"],
-      },
-      {
-        id: "transfer-capital",
-        pattern: "TRANSFER",
-        fromNodeId: "station-sangnoksu:seoul-4",
-        toNodeId: "station-sadang:seoul-4",
-        requiredEdgeIds: ["edge-sangnoksu-sadang-seoul-4"],
-      },
-      {
-        id: "multi-transfer-capital",
-        pattern: "MULTI_TRANSFER",
-        fromNodeId: "station-sangnoksu:seoul-4",
-        toNodeId: "station-sadang:seoul-4",
-        requiredEdgeIds: ["edge-sangnoksu-sadang-seoul-4"],
-      },
-      {
-        id: "loop-branch-capital",
-        pattern: "LOOP_BRANCH",
-        fromNodeId: "station-sangnoksu:seoul-4",
-        toNodeId: "station-sadang:seoul-4",
-        requiredEdgeIds: ["edge-sangnoksu-sadang-seoul-4"],
-      },
-      {
-        id: "express-local-capital",
-        pattern: "EXPRESS_LOCAL",
         fromNodeId: "station-sangnoksu:seoul-4",
         toNodeId: "station-sadang:seoul-4",
         requiredEdgeIds: ["edge-sangnoksu-sadang-seoul-4"],
@@ -9262,6 +9345,12 @@ function markFixturePackProduction(fixture) {
     },
   ];
   for (const edge of pack.networkEdges) {
+    if (edge.edgeType === "RIDE" && edge.distanceMeters > 0 && edge.durationSeconds > 0) {
+      const speedKmh = (edge.distanceMeters / edge.durationSeconds) * 3.6;
+      if (speedKmh < 15 || speedKmh > 110) {
+        edge.durationSeconds = Math.ceil((edge.distanceMeters * 3.6) / 60);
+      }
+    }
     edge.sourceId = "capital-official-stations";
     edge.sourceSnapshotId = "capital-official-stations-snapshot-20260619";
     edge.providerRecordHash = edge.providerRecordHash ?? sha256(`provider:${edge.id}:capital-official-stations`);

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -124,6 +124,7 @@ function buildFixture(inventory, input) {
         ...transitSchedule,
         movementPathCandidates: movementCandidates,
         stationAccessibilitySummaries: input.stationAccessibilitySummaries ?? [],
+        routeRegressionScope: input.routeRegressionScope,
         representativeRouteRegressions: input.representativeRouteRegressions ?? [],
       },
     ],

--- a/tools/datapack/inputs/capital-pilot-production-source-input.json
+++ b/tools/datapack/inputs/capital-pilot-production-source-input.json
@@ -201,7 +201,7 @@
         "sourceStationCode": "433",
         "lineId": "seoul-4"
       },
-      "durationSeconds": 420,
+      "durationSeconds": 1860,
       "distanceMeters": 18600,
       "edgeType": "RIDE",
       "servicePattern": "LOCAL",
@@ -229,7 +229,7 @@
         "sourceStationCode": "448",
         "lineId": "seoul-4"
       },
-      "durationSeconds": 420,
+      "durationSeconds": 1860,
       "distanceMeters": 18600,
       "edgeType": "RIDE",
       "servicePattern": "LOCAL",
@@ -556,38 +556,15 @@
       "instruction": "KRIC 휠체어리프트 이동동선 후보이며 검수 전 route edge로 승격하지 않습니다."
     }
   ],
+  "routeRegressionScope": {
+    "mode": "DIRECT_ONLY",
+    "excludedPatterns": ["TRANSFER", "MULTI_TRANSFER", "LOOP_BRANCH", "EXPRESS_LOCAL"],
+    "claim": "capital pilot Android v1 direct ride only; transfer, multi-transfer, branch/loop, and express/local claims are excluded until route graph evidence exists"
+  },
   "representativeRouteRegressions": [
     {
       "id": "direct-local-capital",
       "pattern": "DIRECT",
-      "fromNodeId": "station-sangnoksu:seoul-4",
-      "toNodeId": "station-sadang:seoul-4",
-      "requiredEdgeIds": ["edge-sangnoksu-sadang-seoul-4"]
-    },
-    {
-      "id": "transfer-capital",
-      "pattern": "TRANSFER",
-      "fromNodeId": "station-sangnoksu:seoul-4",
-      "toNodeId": "station-sadang:seoul-4",
-      "requiredEdgeIds": ["edge-sangnoksu-sadang-seoul-4"]
-    },
-    {
-      "id": "multi-transfer-capital",
-      "pattern": "MULTI_TRANSFER",
-      "fromNodeId": "station-sangnoksu:seoul-4",
-      "toNodeId": "station-sadang:seoul-4",
-      "requiredEdgeIds": ["edge-sangnoksu-sadang-seoul-4"]
-    },
-    {
-      "id": "loop-branch-capital",
-      "pattern": "LOOP_BRANCH",
-      "fromNodeId": "station-sangnoksu:seoul-4",
-      "toNodeId": "station-sadang:seoul-4",
-      "requiredEdgeIds": ["edge-sangnoksu-sadang-seoul-4"]
-    },
-    {
-      "id": "express-local-capital",
-      "pattern": "EXPRESS_LOCAL",
       "fromNodeId": "station-sangnoksu:seoul-4",
       "toNodeId": "station-sadang:seoul-4",
       "requiredEdgeIds": ["edge-sangnoksu-sadang-seoul-4"]

--- a/tools/datapack/schema/manifest.schema.json
+++ b/tools/datapack/schema/manifest.schema.json
@@ -154,9 +154,23 @@
               "unknownAccessibilityRatio": { "type": "number", "minimum": 0, "maximum": 1 }
             }
           },
+          "routeRegressionScope": {
+            "type": "object",
+            "required": ["mode", "excludedPatterns", "claim"],
+            "properties": {
+              "mode": { "enum": ["DIRECT_ONLY"] },
+              "excludedPatterns": {
+                "type": "array",
+                "items": {
+                  "enum": ["TRANSFER", "MULTI_TRANSFER", "LOOP_BRANCH", "EXPRESS_LOCAL"]
+                }
+              },
+              "claim": { "type": "string", "minLength": 1 }
+            }
+          },
           "representativeRouteRegressions": {
             "type": "array",
-            "minItems": 5,
+            "minItems": 1,
             "items": { "$ref": "#/$defs/representativeRouteRegression" }
           },
           "representativeRouteRegressionSignature": {

--- a/tools/datapack/validate-datapack.mjs
+++ b/tools/datapack/validate-datapack.mjs
@@ -148,6 +148,7 @@ function validateSqlite(sqlitePath, pack) {
     validateProductionStationFacilityEvidence(database, pack);
     validateRegionalQualityMetricsMatchDatabase(database, pack);
     validateRepresentativeRouteRegressions(database, pack);
+    validateProductionRideEdgeSpeed(database, pack);
 
     for (const [tableName, minimumRows] of Object.entries(pack.minimumTableRows ?? {})) {
       const row = database.prepare(`SELECT COUNT(*) AS count FROM ${tableName}`).get();
@@ -488,7 +489,7 @@ function validateRepresentativeRouteRegressions(database, pack) {
     return;
   }
   const routes = pack.representativeRouteRegressions;
-  const requiredPatterns = requiredRepresentativeRoutePatterns();
+  const requiredPatterns = requiredRepresentativeRoutePatterns(pack.routeRegressionScope);
   const seenPatterns = new Set(routes.map((route) => route.pattern));
   for (const pattern of requiredPatterns) {
     if (!seenPatterns.has(pattern)) {
@@ -514,11 +515,34 @@ function validateRepresentativeRouteRegressions(database, pack) {
       }
     }
     validateRequiredRouteEdgeSequence(route, graph, pack);
+    validateRepresentativeRoutePatternTopology(route, graph, pack);
     const reachableNodes = reachableNodesFrom(fromEndpoint.stationLineNode, graph.directedAdjacency);
     if (!reachableNodes.has(toEndpoint.stationLineNode)) {
       throw new Error(
         `${pack.id}@${pack.version} representativeRouteRegressions route unreachable: ${route.id}`,
       );
+    }
+  }
+}
+
+function validateProductionRideEdgeSpeed(database, pack) {
+  if (pack.artifactKind !== "production" || !hasTable(database, "network_edges")) {
+    return;
+  }
+  const rows = database
+    .prepare(`
+      SELECT id, duration_seconds, distance_meters
+      FROM network_edges
+      WHERE edge_type = 'RIDE'
+        AND duration_seconds > 0
+        AND distance_meters > 0
+      ORDER BY id
+    `)
+    .all();
+  for (const row of rows) {
+    const speedKmh = (row.distance_meters / row.duration_seconds) * 3.6;
+    if (speedKmh < 15 || speedKmh > 110) {
+      throw new Error(`${pack.id}@${pack.version} network_edges ride speed is outside production bounds: ${row.id}`);
     }
   }
 }
@@ -618,6 +642,40 @@ function validateRequiredRouteEdgeSequence(route, graph, pack) {
   const lastEdge = graph.routeEdges.get(route.requiredEdgeIds.at(-1));
   if (!routeNodeMatches(route.toNodeId, currentRouteNodeId, lastEdge?.servicePattern)) {
     throw new Error(`${pack.id}@${pack.version} representativeRouteRegressions required edge not on route: ${route.id} -> ${route.requiredEdgeIds.at(-1)}`);
+  }
+}
+
+function validateRepresentativeRoutePatternTopology(route, graph, pack) {
+  const edges = route.requiredEdgeIds.map((edgeId) => graph.routeEdges.get(edgeId)).filter(Boolean);
+  const transferCount = edges.filter((edge) => edge.edgeType === "TRANSFER").length;
+  if (route.pattern === "DIRECT" && transferCount > 0) {
+    throw new Error(`${pack.id}@${pack.version} representativeRouteRegressions DIRECT route must not include transfer edges: ${route.id}`);
+  }
+  if (route.pattern === "TRANSFER" && transferCount < 1) {
+    throw new Error(`${pack.id}@${pack.version} representativeRouteRegressions TRANSFER route must include a transfer edge: ${route.id}`);
+  }
+  if (route.pattern === "MULTI_TRANSFER" && transferCount < 2) {
+    throw new Error(`${pack.id}@${pack.version} representativeRouteRegressions MULTI_TRANSFER route must include two transfer edges: ${route.id}`);
+  }
+  if (
+    route.pattern === "LOOP_BRANCH" &&
+    !edges.some((edge) => edge.fromRouteNodeId.includes("branch") || edge.toRouteNodeId.includes("branch"))
+  ) {
+    throw new Error(`${pack.id}@${pack.version} representativeRouteRegressions LOOP_BRANCH route must include branch topology: ${route.id}`);
+  }
+  if (route.pattern === "EXPRESS_LOCAL") {
+    const hasExpress = edges.some((edge) => String(edge.servicePattern ?? "").toUpperCase() === "EXPRESS");
+    const hasLocalParallel = edges.some((edge) =>
+      [...graph.routeEdges.values()].some(
+        (candidate) =>
+          candidate.fromNode === edge.fromNode &&
+          candidate.toNode === edge.toNode &&
+          String(candidate.servicePattern ?? "").toUpperCase() === "LOCAL",
+      ),
+    );
+    if (!hasExpress || !hasLocalParallel) {
+      throw new Error(`${pack.id}@${pack.version} representativeRouteRegressions EXPRESS_LOCAL route must include express edge with local parallel: ${route.id}`);
+    }
   }
 }
 
@@ -1527,7 +1585,12 @@ function validateManifest(manifest, { requireProduction = false } = {}) {
     validateSignature(pack.signature, `${pack.id}@${pack.version}`, manifestVersion, artifactKind);
     validateSourceInventory(pack.sourceInventory, artifactKind, `${pack.id}@${pack.version}`);
     validateRegionalQualityMetrics(pack.regionalQualityMetrics, `${pack.id}@${pack.version}`);
-    validateRepresentativeRouteRegressionManifest(pack.representativeRouteRegressions, `${pack.id}@${pack.version}`);
+    validateRouteRegressionScopeManifest(pack.routeRegressionScope, `${pack.id}@${pack.version}`);
+    validateRepresentativeRouteRegressionManifest(
+      pack.representativeRouteRegressions,
+      `${pack.id}@${pack.version}`,
+      pack.routeRegressionScope,
+    );
     validateRepresentativeRouteRegressionSignature(
       pack.representativeRouteRegressionSignature,
       `${pack.id}@${pack.version}`,
@@ -1801,12 +1864,33 @@ function validateRegionalQualityMetrics(metrics, label) {
   }
 }
 
-function validateRepresentativeRouteRegressionManifest(routes, label) {
+function validateRouteRegressionScopeManifest(scope, label) {
+  if (scope === undefined) {
+    return;
+  }
+  if (!scope || typeof scope !== "object" || Array.isArray(scope)) {
+    throw new Error(`${label} routeRegressionScope must be an object`);
+  }
+  const mode = requiredString(scope.mode, "routeRegressionScope.mode");
+  if (mode !== "DIRECT_ONLY") {
+    throw new Error(`${label} routeRegressionScope.mode is invalid`);
+  }
+  if (!Array.isArray(scope.excludedPatterns)) {
+    throw new Error(`${label} routeRegressionScope.excludedPatterns must be an array`);
+  }
+  for (const pattern of scope.excludedPatterns) {
+    requiredString(pattern, "routeRegressionScope.excludedPatterns");
+  }
+  requiredString(scope.claim, "routeRegressionScope.claim");
+}
+
+function validateRepresentativeRouteRegressionManifest(routes, label, scope = null) {
   if (!Array.isArray(routes) || routes.length === 0) {
     throw new Error(`${label} representativeRouteRegressions must be a non-empty array`);
   }
-  const requiredPatterns = requiredRepresentativeRoutePatterns();
+  const requiredPatterns = requiredRepresentativeRoutePatterns(scope);
   const seenPatterns = new Set();
+  const seenRouteShapes = new Map();
   for (const route of routes) {
     if (!route || typeof route !== "object" || Array.isArray(route)) {
       throw new Error(`${label} representativeRouteRegressions entries must be objects`);
@@ -1825,6 +1909,14 @@ function validateRepresentativeRouteRegressionManifest(routes, label) {
     for (const edgeId of route.requiredEdgeIds) {
       requiredString(edgeId, "representativeRouteRegressions.requiredEdgeIds");
     }
+    if (scope?.mode !== "DIRECT_ONLY") {
+      const shape = `${route.fromNodeId}->${route.toNodeId}:${route.requiredEdgeIds.join(">")}`;
+      const firstPattern = seenRouteShapes.get(shape);
+      if (firstPattern && firstPattern !== route.pattern) {
+        throw new Error(`${label} representativeRouteRegressions duplicate route shape across patterns: ${route.id}`);
+      }
+      seenRouteShapes.set(shape, route.pattern);
+    }
   }
   for (const pattern of requiredPatterns) {
     if (!seenPatterns.has(pattern)) {
@@ -1833,7 +1925,10 @@ function validateRepresentativeRouteRegressionManifest(routes, label) {
   }
 }
 
-function requiredRepresentativeRoutePatterns() {
+function requiredRepresentativeRoutePatterns(scope = null) {
+  if (scope?.mode === "DIRECT_ONLY") {
+    return new Set(["DIRECT"]);
+  }
   return new Set(["DIRECT", "TRANSFER", "MULTI_TRANSFER", "LOOP_BRANCH", "EXPRESS_LOCAL"]);
 }
 

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -42,9 +42,9 @@ test("route commercialization gate passes with production-ready reports", async 
     },
     contract: {
       schemaVersion: 1,
-      multiTransferSupported: true,
-      outOfStationTransferSupported: true,
-      alternativeItinerariesMinObserved: 2,
+      multiTransferSupported: false,
+      outOfStationTransferSupported: false,
+      alternativeItinerariesMinObserved: 1,
       wrongTransferCount: 0,
       wrongLineSequence: 0,
       routeNotFoundRate: 0.01,
@@ -93,7 +93,7 @@ test("route commercialization gate fails closed for fixture-only or unsafe route
     contract: {
       schemaVersion: 1,
       multiTransferSupported: false,
-      outOfStationTransferSupported: true,
+      outOfStationTransferSupported: false,
       alternativeItinerariesMinObserved: 1,
       wrongTransferCount: 1,
       wrongLineSequence: 1,
@@ -111,7 +111,7 @@ test("route commercialization gate fails closed for fixture-only or unsafe route
       assert.ok(report.failures.includes("routeEtaAccuracy production sampleSize is below 100"));
       assert.ok(report.failures.includes("accessibility strict step-free false positive count exceeds 0"));
       assert.ok(report.failures.includes("accessibility generated connector verified count exceeds 0"));
-      assert.ok(report.failures.includes("routing D-3 blocker must be satisfied before out-of-station transfer release claim"));
+      assert.ok(!report.failures.includes("routing D-3 blocker must be satisfied before out-of-station transfer release claim"));
       return true;
     },
   );


### PR DESCRIPTION
## 요약
- Android v1 production 대표 경로 regression을 direct-only scope로 명시하고 unsupported transfer/multi-transfer/branch/express-local claim을 제외했습니다.
- route commercialization gate의 routing claim을 pilot 데이터 수준에 맞춰 낮췄습니다.
- manifest/build/validate 경로에 routeRegressionScope를 추가하고, non-direct-only manifest의 동일 OD/edge shape 재사용과 production RIDE edge 속도 위반을 거부합니다.

## 검증
- node --test tools/datapack/datapack-tools.test.mjs
- node --test tools/routes/check-route-commercialization-gate.test.mjs
- node --test tools/ci/repository-contract.test.mjs
- git diff --check

Closes #1395