### PR TITLE
[Chore] 데이터팩 품질 metric denominator 보강

### DIFF
--- a/tools/datapack/build-datapack.mjs
+++ b/tools/datapack/build-datapack.mjs
@@ -642,22 +642,83 @@ function rsaSha256Signature(privateKey, value) {
 function regionalQualityMetrics(pack) {
   const stationIds = new Set((pack.stations ?? []).map((station) => station.id));
   const stationCount = stationIds.size;
+  const stationLineKeys = new Set((pack.stationLines ?? []).map((row) => `${row.stationId}:${row.lineId}`));
   const coveredStationIds = new Set(
     (pack.facilities ?? [])
       .map((facility) => facility.stationId)
       .filter((stationId) => stationIds.has(stationId)),
   );
+  const facilityEvidence = pack.stationFacilityEvidence ?? [];
+  const facilityRows = pack.facilities ?? [];
+  const facilityTypes = new Set([
+    ...facilityEvidence.map((row) => row.facilityType),
+    ...facilityRows.map((row) => row.type),
+  ].filter(Boolean));
+  const facilityDenominator = stationLineKeys.size * facilityTypes.size;
+  const facilityEvidenceKeys = facilityEvidence.length > 0
+    ? new Set(facilityEvidence.map((row) => `${row.stationId}:${row.lineId}:${row.facilityType}`))
+    : facilityKeysFromRows(facilityRows, pack.stationLines ?? []);
+  const facilityFreshnessRows = facilityEvidence.length > 0 ? facilityEvidence : facilityRows;
+  const strictEligibleCount = facilityEvidence.filter((row) => row.strictRouteEligible === true).length;
+  const operationalKnownCount = facilityFreshnessRows.filter((row) =>
+    knownOperationalStatus(row.operationalStatus ?? row.status)
+  ).length;
+  const freshnessValidCount = facilityFreshnessRows.filter((row) => hasVerificationTimestamp(row)).length;
+  const pathwayEdges = pack.stationPathwayEdges ?? [];
+  const fieldVerifiedPathwayCount = pathwayEdges.filter((row) =>
+    ["FIELD_SURVEY", "OPERATOR_CONFIRMED"].includes(String(row.provenanceKind ?? "").toUpperCase())
+  ).length;
   const networkEdges = routeGraphNetworkEdges(pack);
   const edgeCount = networkEdges.length;
   const unknownAccessibilityCount = networkEdges.filter(
     (edge) => normalizedAccessibilityStatus(edge.accessibilityStatus, "networkEdges.accessibilityStatus") === "UNKNOWN",
   ).length;
+  const unknownAccessibilityRatio = ratio(unknownAccessibilityCount, edgeCount);
   return {
     stationCount,
-    facilityCoverageRatio: stationCount === 0 ? 0 : Number((coveredStationIds.size / stationCount).toFixed(4)),
+    facilityCoverageRatio: ratio(coveredStationIds.size, stationCount),
+    requiredFacilityEvidenceCoverageRatio: ratio(facilityEvidenceKeys.size, facilityDenominator),
+    strictRouteEligibleFacilityRatio: ratio(strictEligibleCount, facilityEvidence.length),
+    operationalKnownRatio: ratio(operationalKnownCount, facilityFreshnessRows.length),
+    freshnessValidRatio: ratio(freshnessValidCount, facilityFreshnessRows.length),
+    fieldVerifiedPathwayRatio: ratio(fieldVerifiedPathwayCount, pathwayEdges.length),
     edgeCount,
-    unknownAccessibilityRatio: edgeCount === 0 ? 0 : Number((unknownAccessibilityCount / edgeCount).toFixed(4)),
+    unknownAccessibilityRatio,
+    unknownEdgeRatioByProfile: {
+      wheelchair: unknownAccessibilityRatio,
+      stroller: unknownAccessibilityRatio,
+      lowMobility: unknownAccessibilityRatio,
+    },
   };
+}
+
+function ratio(numerator, denominator) {
+  return denominator === 0 ? 0 : Number((numerator / denominator).toFixed(4));
+}
+
+function facilityKeysFromRows(facilities, stationLines) {
+  const lineIdsByStationId = new Map();
+  for (const row of stationLines) {
+    const lineIds = lineIdsByStationId.get(row.stationId) ?? [];
+    lineIds.push(row.lineId);
+    lineIdsByStationId.set(row.stationId, lineIds);
+  }
+  const keys = new Set();
+  for (const facility of facilities) {
+    for (const lineId of lineIdsByStationId.get(facility.stationId) ?? []) {
+      keys.add(`${facility.stationId}:${lineId}:${facility.type}`);
+    }
+  }
+  return keys;
+}
+
+function knownOperationalStatus(value) {
+  const status = String(value ?? "").toUpperCase();
+  return status !== "" && status !== "UNKNOWN";
+}
+
+function hasVerificationTimestamp(row) {
+  return Boolean(row.verifiedAt ?? row.lastVerifiedAt ?? row.reviewedAt ?? row.updatedAt);
 }
 
 function routeGraphNetworkEdges(pack) {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -88,6 +88,11 @@ test("데이터팩 생성기는 fixture로 원격 manifest와 gzip SQLite pack�
   assert.equal(pack.sourceInventory[0].updatedAt, "2026-06-19T00:00:00.000Z");
   assert.equal(pack.regionalQualityMetrics.stationCount, 6);
   assert.equal(pack.regionalQualityMetrics.facilityCoverageRatio, 0.3333);
+  assert.equal(pack.regionalQualityMetrics.requiredFacilityEvidenceCoverageRatio, 0.1852);
+  assert.equal(pack.regionalQualityMetrics.strictRouteEligibleFacilityRatio, 0);
+  assert.equal(pack.regionalQualityMetrics.operationalKnownRatio, 1);
+  assert.equal(pack.regionalQualityMetrics.freshnessValidRatio, 0);
+  assert.equal(pack.regionalQualityMetrics.fieldVerifiedPathwayRatio, 0);
 
   const provenance = JSON.parse(await readFile(path.join(outputDir, "current.provenance.json"), "utf8"));
   assert.equal(provenance.artifactKind, "datapack-field-provenance");
@@ -106,6 +111,11 @@ test("데이터팩 생성기는 fixture로 원격 manifest와 gzip SQLite pack�
   );
   assert.equal(pack.regionalQualityMetrics.edgeCount, 20);
   assert.equal(pack.regionalQualityMetrics.unknownAccessibilityRatio, 0);
+  assert.deepEqual(pack.regionalQualityMetrics.unknownEdgeRatioByProfile, {
+    wheelchair: 0,
+    stroller: 0,
+    lowMobility: 0,
+  });
   assert.deepEqual(
     pack.representativeRouteRegressions.map((route) => route.pattern).sort(),
     ["DIRECT", "EXPRESS_LOCAL", "LOOP_BRANCH", "MULTI_TRANSFER", "TRANSFER"],
@@ -4036,6 +4046,7 @@ test("데이터팩 생성기는 시설 coverage를 시설이 있는 역 비율�
   const manifest = JSON.parse(await readFile(path.join(outputDir, "current.json"), "utf8"));
   assert.equal(manifest.packs[0].regionalQualityMetrics.stationCount, 6);
   assert.equal(manifest.packs[0].regionalQualityMetrics.facilityCoverageRatio, 0.3333);
+  assert.equal(manifest.packs[0].regionalQualityMetrics.freshnessValidRatio, 0);
   await execFileAsync(
     process.execPath,
     [

--- a/tools/datapack/schema/manifest.schema.json
+++ b/tools/datapack/schema/manifest.schema.json
@@ -144,14 +144,34 @@
             "required": [
               "stationCount",
               "facilityCoverageRatio",
+              "requiredFacilityEvidenceCoverageRatio",
+              "strictRouteEligibleFacilityRatio",
+              "operationalKnownRatio",
+              "freshnessValidRatio",
+              "fieldVerifiedPathwayRatio",
               "edgeCount",
-              "unknownAccessibilityRatio"
+              "unknownAccessibilityRatio",
+              "unknownEdgeRatioByProfile"
             ],
             "properties": {
               "stationCount": { "type": "integer", "minimum": 0 },
               "facilityCoverageRatio": { "type": "number", "minimum": 0, "maximum": 1 },
+              "requiredFacilityEvidenceCoverageRatio": { "type": "number", "minimum": 0, "maximum": 1 },
+              "strictRouteEligibleFacilityRatio": { "type": "number", "minimum": 0, "maximum": 1 },
+              "operationalKnownRatio": { "type": "number", "minimum": 0, "maximum": 1 },
+              "freshnessValidRatio": { "type": "number", "minimum": 0, "maximum": 1 },
+              "fieldVerifiedPathwayRatio": { "type": "number", "minimum": 0, "maximum": 1 },
               "edgeCount": { "type": "integer", "minimum": 0 },
-              "unknownAccessibilityRatio": { "type": "number", "minimum": 0, "maximum": 1 }
+              "unknownAccessibilityRatio": { "type": "number", "minimum": 0, "maximum": 1 },
+              "unknownEdgeRatioByProfile": {
+                "type": "object",
+                "required": ["wheelchair", "stroller", "lowMobility"],
+                "properties": {
+                  "wheelchair": { "type": "number", "minimum": 0, "maximum": 1 },
+                  "stroller": { "type": "number", "minimum": 0, "maximum": 1 },
+                  "lowMobility": { "type": "number", "minimum": 0, "maximum": 1 }
+                }
+              }
             }
           },
           "routeRegressionScope": {

--- a/tools/datapack/validate-datapack.mjs
+++ b/tools/datapack/validate-datapack.mjs
@@ -1857,9 +1857,26 @@ function validateRegionalQualityMetrics(metrics, label) {
   if (!Number.isInteger(metrics.edgeCount) || metrics.edgeCount < 0) {
     throw new Error(`${label} regionalQualityMetrics.edgeCount must be a non-negative integer`);
   }
-  for (const key of ["facilityCoverageRatio", "unknownAccessibilityRatio"]) {
+  for (const key of [
+    "facilityCoverageRatio",
+    "requiredFacilityEvidenceCoverageRatio",
+    "strictRouteEligibleFacilityRatio",
+    "operationalKnownRatio",
+    "freshnessValidRatio",
+    "fieldVerifiedPathwayRatio",
+    "unknownAccessibilityRatio",
+  ]) {
     if (typeof metrics[key] !== "number" || metrics[key] < 0 || metrics[key] > 1) {
       throw new Error(`${label} regionalQualityMetrics.${key} must be a ratio`);
+    }
+  }
+  if (!metrics.unknownEdgeRatioByProfile || typeof metrics.unknownEdgeRatioByProfile !== "object") {
+    throw new Error(`${label} regionalQualityMetrics.unknownEdgeRatioByProfile must be an object`);
+  }
+  for (const key of ["wheelchair", "stroller", "lowMobility"]) {
+    const value = metrics.unknownEdgeRatioByProfile[key];
+    if (typeof value !== "number" || value < 0 || value > 1) {
+      throw new Error(`${label} regionalQualityMetrics.unknownEdgeRatioByProfile.${key} must be a ratio`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- regionalQualityMetrics에 station-line x facility type denominator 기반 시설 evidence coverage를 추가했습니다.
- strict route eligible 시설 비율, 운영상태 확인 비율, freshness signal 비율, field-verified pathway 비율, profile별 unknown edge 비율을 manifest/schema/validator 계약에 추가했습니다.
- #1400의 quality metric artifact 요구 중 denominator/freshness/profile 지표 산출 기반만 보강합니다. 인접역 graph 실제 확장과 route map position 적재는 이 PR에서 닫지 않습니다.

## Verification
- node --test tools/datapack/datapack-tools.test.mjs
- node --test tools/ci/repository-contract.test.mjs
- git diff --check

Refs #1400
Refs #1419