### PR TITLE
[Route Commercialization] route V2 alternativeCount 계약 보강

### DIFF
--- a/tools/routes/algorithm-fixtures/route-v2-fixtures.json
+++ b/tools/routes/algorithm-fixtures/route-v2-fixtures.json
@@ -491,6 +491,7 @@
       "destination": "pareto_b",
       "departure": "2026-07-01T08:58:00+09:00",
       "constraintMode": "ALLOW_UNKNOWN",
+      "alternativeCount": 3,
       "expectedArrival": "09:25",
       "expectedTransfers": 1,
       "expectedTripIds": ["pareto-leg1-0900", "pareto-leg2-0915"]

--- a/tools/routes/prototype-route-v2.mjs
+++ b/tools/routes/prototype-route-v2.mjs
@@ -42,7 +42,7 @@ export function runRangeRaptor(fixtures, query) {
     labelsByRound[round + 1] = mergeMaps(labelsByRound[round + 1], current, fixtures.paretoLimit);
   }
 
-  return alternatives(labelsByRound.at(-1)?.get(query.destination) ?? [], fixtures.paretoLimit);
+  return alternatives(labelsByRound.at(-1)?.get(query.destination) ?? [], resultLimit(fixtures, query));
 }
 
 export function runTimeDependentDijkstra(fixtures, query) {
@@ -62,7 +62,7 @@ export function runTimeDependentDijkstra(fixtures, query) {
     }
   }
 
-  return alternatives(best.get(query.destination) ?? [], fixtures.paretoLimit);
+  return alternatives(best.get(query.destination) ?? [], resultLimit(fixtures, query));
 }
 
 function normalize(fixtures) {
@@ -249,6 +249,10 @@ function betterBoarding(current, label, stop) {
 
 function maxTransfers(query) {
   return query.maxTransfers ?? 3;
+}
+
+function resultLimit(fixtures, query) {
+  return query.alternativeCount ?? fixtures.paretoLimit;
 }
 
 function departureMinute(fixtures, query) {

--- a/tools/routes/prototype-route-v2.test.mjs
+++ b/tools/routes/prototype-route-v2.test.mjs
@@ -17,6 +17,7 @@ test("route v2 prototypes return Pareto alternatives with reconstructed paths", 
   assert.ok(query, "missing fixture query: pareto_arrival_vs_transfer");
   const alternatives = runTimeDependentDijkstra(fixtures, query);
 
+  assert.equal(query.alternativeCount, 3);
   assert.equal(alternatives.length, 2);
   assert.equal(alternatives[0].arrival, "09:25");
   assert.equal(alternatives[0].transferCount, 1);
@@ -24,6 +25,15 @@ test("route v2 prototypes return Pareto alternatives with reconstructed paths", 
   assert.equal(alternatives[1].transferCount, 0);
   assert.equal(alternatives[0].path[0].from, "pareto_a");
   assert.equal(alternatives[0].path.at(-1).to, "pareto_b");
+});
+
+test("route v2 prototypes honor requested alternative count", () => {
+  const query = fixtures.queries.find((candidate) => candidate.id === "pareto_arrival_vs_transfer");
+  assert.ok(query, "missing fixture query: pareto_arrival_vs_transfer");
+  const alternatives = runTimeDependentDijkstra(fixtures, { ...query, alternativeCount: 1 });
+
+  assert.equal(alternatives.length, 1);
+  assert.equal(alternatives[0].arrival, "09:25");
 });
 
 test("route v2 CLI report keeps full Pareto alternatives", () => {


### PR DESCRIPTION
## Summary
- route V2 fixture에 `alternativeCount` 요청 계약을 명시
- prototype runner가 query별 `alternativeCount`로 반환 대안 수를 제한하도록 보강
- alternativeCount=1 회귀 테스트 추가

## Verification
- RED: `node --test tools/routes/prototype-route-v2.test.mjs` (alternativeCount 미반영으로 2 !== 1)
- GREEN: `node --test tools/routes/prototype-route-v2.test.mjs`
- GREEN: `node --test tools/routes/*.test.mjs`
- GREEN: `git diff --check`

Refs #1403
Refs #1414
