### PR TITLE
[Chore] 시간표 coverage denominator 고정

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5553,6 +5553,10 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
   assert.equal(candidate.serviceKeyHandling, "offline_import_secret_only");
   assert.equal(candidate.mobileEmbeddingAllowed, false);
   assert.equal(candidate.productionInventoryReferenceId, "molit-tago-subway-info");
+  assert.equal(candidate.requestUrl, "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList");
+  assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
+  assert.match(candidate.evidence.sampleUrl, /serviceKey=\[서비스키값\]/);
+  assert.match(candidate.evidence.sampleUrl, /subwayStationId=448/);
   assert.equal(productionSourceIds.has(candidate.id), true, "TAGO inventory entry exists but must remain non-production");
 
   const inventorySource = inventory.sources.find(({ id }) => id === "molit-tago-subway-info");
@@ -5567,6 +5571,8 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
   assert.deepEqual(candidate.evidence.missingEvidence, ["sampleResponse", "scheduleImporterValidation"]);
   assert.ok(candidate.evidence.outputFields.includes("depTime"));
   assert.ok(candidate.evidence.outputFields.includes("arrTime"));
+  assert.ok(candidate.evidence.outputFields.includes("dailyTypeCode"));
+  assert.ok(candidate.evidence.outputFields.includes("upDownTypeCode"));
 });
 
 test("KRIC 환승 이동경로 후보는 상세 근거가 있어도 route graph edge로 자동 승격하지 않는다", () => {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4393,6 +4393,7 @@ test("운영 데이터팩 공식 출처 inventory는 라이선스와 갱신 기�
       "route_graph_topology",
       "accessibility_facilities",
       "realtime_arrivals",
+      "schedule_timetable",
       "route_map_positions",
       "demand_reference",
     ],
@@ -4460,11 +4461,12 @@ test("운영 데이터팩 공식 출처 inventory는 라이선스와 갱신 기�
   assert.equal(targets.roadmapEvidenceLedger.issue, 1399);
   assert.equal(targets.roadmapEvidenceLedger.goNoGoSummaryIssue, 1020);
   assert.match(targets.roadmapEvidenceLedger.goNoGoSummaryReferencePolicyKo, /#1020/);
-  assert.equal(targets.roadmapEvidenceLedger.targetComparison.nationwideTargets.requiredSourceDomainCount, 6);
+  assert.equal(targets.roadmapEvidenceLedger.targetComparison.nationwideTargets.requiredSourceDomainCount, 7);
   assert.equal(targets.roadmapEvidenceLedger.targetComparison.capitalPilotTargets.requiredSourceDomainCount, 2);
   assert.deepEqual(targets.roadmapEvidenceLedger.targetComparison.capitalPilotTargets.deferredSourceDomains, [
     "route_graph_topology",
     "realtime_arrivals",
+    "schedule_timetable",
     "route_map_positions",
     "demand_reference",
   ]);
@@ -5534,6 +5536,37 @@ test("서울 TOPIS 실시간 후보는 backend-only key 경계와 production 분
       assert.match(candidate.productionInventoryRelationship, /live_provider_contract_remains_candidate/);
     }
   }
+});
+
+test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되지 않는다", () => {
+  const inventory = readJson("tools/datapack/source-inventory.json");
+  const candidates = readJson("tools/datapack/source-candidates.json");
+  const productionSourceIds = new Set(inventory.sources.map((source) => source.id));
+  const candidate = candidates.candidates.find(({ id }) => id === "molit-tago-subway-info");
+
+  assert.ok(candidate);
+  assert.equal(candidate.priority, "P0");
+  assert.equal(candidate.domain, "schedule_timetable");
+  assert.equal(candidate.licenseEvidenceStatus, "confirmed_attribution");
+  assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
+  assert.equal(candidate.admissionStatus, "evidence_recorded_admin_review_required");
+  assert.equal(candidate.serviceKeyHandling, "offline_import_secret_only");
+  assert.equal(candidate.mobileEmbeddingAllowed, false);
+  assert.equal(candidate.productionInventoryReferenceId, "molit-tago-subway-info");
+  assert.equal(productionSourceIds.has(candidate.id), true, "TAGO inventory entry exists but must remain non-production");
+
+  const inventorySource = inventory.sources.find(({ id }) => id === "molit-tago-subway-info");
+  assert.equal(inventorySource.requiredForProductionPack, false);
+  assert.equal(inventorySource.capabilities.schedule.status, "CANDIDATE");
+  assert.equal(inventorySource.capabilities.schedule.productionUseAllowed, false);
+  assert.equal(inventorySource.coverageScope.sourceDomains.includes("schedule_timetable"), false);
+
+  assert.equal(candidate.capabilities.schedule.status, "CANDIDATE");
+  assert.equal(candidate.capabilities.schedule.productionUseAllowed, false);
+  assert.equal(candidate.capabilities.schedule.coverageStatus, "SAMPLE_EVIDENCE_REQUIRED");
+  assert.deepEqual(candidate.evidence.missingEvidence, ["sampleResponse", "scheduleImporterValidation"]);
+  assert.ok(candidate.evidence.outputFields.includes("depTime"));
+  assert.ok(candidate.evidence.outputFields.includes("arrTime"));
 });
 
 test("KRIC 환승 이동경로 후보는 상세 근거가 있어도 route graph edge로 자동 승격하지 않는다", () => {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -5970,9 +5970,9 @@ test("전국 coverage gap report는 TAGO, 국가철도공단, 부산 source inve
   );
 
   const report = JSON.parse(await readFile(reportPath, "utf8"));
-  assert.equal(report.summary.totalRequirements, 102);
+  assert.equal(report.summary.totalRequirements, 119);
   assert.equal(report.summary.coveredRequirements, 4);
-  assert.equal(report.summary.missingRequirements, 98);
+  assert.equal(report.summary.missingRequirements, 115);
 
   const busanStationMembership = report.requirements.find(
     (entry) =>

--- a/tools/datapack/nationwide-coverage-targets.json
+++ b/tools/datapack/nationwide-coverage-targets.json
@@ -16,7 +16,7 @@
       "claimKo": "전국 도시철도·광역철도·공항철도·GTX·경전철 지원",
       "status": "NO_GO",
       "releaseScopeArtifact": "tools/datapack/nationwide-coverage-targets.json",
-      "unblockConditionKo": "모든 roadmap stage의 source admission과 6개 requiredSourceDomains coverage ratio 1을 통과해야 한다."
+      "unblockConditionKo": "모든 roadmap stage의 source admission과 7개 requiredSourceDomains coverage ratio 1을 통과해야 한다."
     },
     {
       "claimId": "realtime_eta_accuracy",
@@ -77,6 +77,18 @@
       "displayName": "실시간 도착/열차 참조",
       "requiredFields": [
         "realtime_arrival_reference"
+      ],
+      "blockingThreshold": {
+        "minimumOfficialFieldCoverageRatio": 1
+      }
+    },
+    {
+      "id": "schedule_timetable",
+      "displayName": "시간표와 운행 calendar",
+      "requiredFields": [
+        "service_calendar",
+        "trip",
+        "stop_time"
       ],
       "blockingThreshold": {
         "minimumOfficialFieldCoverageRatio": 1
@@ -261,12 +273,13 @@
     "readmeScopeEvidence": "README.md Scope section separates long-term denominator from Android v1 상록수·사당 검증 pilot claim.",
     "targetComparison": {
       "nationwideTargets": {
-        "requiredSourceDomainCount": 6,
+        "requiredSourceDomainCount": 7,
         "requiredSourceDomains": [
           "station_line_membership",
           "route_graph_topology",
           "accessibility_facilities",
           "realtime_arrivals",
+          "schedule_timetable",
           "route_map_positions",
           "demand_reference"
         ]
@@ -277,6 +290,7 @@
         "deferredSourceDomains": [
           "route_graph_topology",
           "realtime_arrivals",
+          "schedule_timetable",
           "route_map_positions",
           "demand_reference"
         ]
@@ -284,10 +298,10 @@
     },
     "sourceCandidateAdmission": {
       "sourceCandidatesPath": "tools/datapack/source-candidates.json",
-      "p0CandidateCount": 12,
+      "p0CandidateCount": 13,
       "requiredAdmissionStatusBeforeProductionClaim": "admitted_to_production_inventory",
       "currentSharedAdmissionStatus": "evidence_recorded_admin_review_required",
-      "productionClaimImpactKo": "P0 source candidate 12건이 production inventory로 승격되기 전까지 모든 expansionRoadmap stage는 NO-GO다."
+      "productionClaimImpactKo": "P0 source candidate 13건이 production inventory로 승격되기 전까지 모든 expansionRoadmap stage는 NO-GO다."
     },
     "gapEscalationRuleKo": "지원 claim을 깨는 P1/P2 gap은 P0 release blocker로 승격하고 release gate에서 실패시킨다."
   }

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -654,7 +654,7 @@
       "domain": "schedule_timetable",
       "displayName": "국토교통부_(TAGO)_지하철정보",
       "detailUrl": "https://www.data.go.kr/data/15098554/openapi.do",
-      "requestUrl": "https://www.data.go.kr/data/15098554/openapi.do",
+      "requestUrl": "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList",
       "licenseEvidenceStatus": "confirmed_attribution",
       "sampleEvidenceStatus": "sample_url_documented_key_required",
       "admissionStatus": "evidence_recorded_admin_review_required",
@@ -665,8 +665,8 @@
       "evidence": {
         "detailPageUrl": "https://www.data.go.kr/data/15098554/openapi.do",
         "retrievedAt": "2026-06-22",
-        "endpoint": "https://www.data.go.kr/data/15098554/openapi.do",
-        "sampleUrl": "https://www.data.go.kr/data/15098554/openapi.do",
+        "endpoint": "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList",
+        "sampleUrl": "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList?serviceKey=[서비스키값]&pageNo=1&numOfRows=10&_type=json&subwayStationId=448&dailyTypeCode=01&upDownTypeCode=U",
         "usePermissionRange": "공공데이터포털 이용허락범위 제한 없음",
         "formats": [
           "XML",
@@ -677,11 +677,15 @@
           "route graph RIDE edge duration과 stop_times 정합 검증 필요"
         ],
         "outputFields": [
-          "subwayRouteName",
+          "endSubwayStationNm",
+          "subwayRouteId",
           "subwayStationId",
-          "subwayStationName",
+          "subwayStationNm",
+          "dailyTypeCode",
+          "upDownTypeCode",
           "depTime",
-          "arrTime"
+          "arrTime",
+          "endSubwayStationId"
         ],
         "missingEvidence": [
           "sampleResponse",

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -649,6 +649,73 @@
       }
     },
     {
+      "id": "molit-tago-subway-info",
+      "priority": "P0",
+      "domain": "schedule_timetable",
+      "displayName": "국토교통부_(TAGO)_지하철정보",
+      "detailUrl": "https://www.data.go.kr/data/15098554/openapi.do",
+      "requestUrl": "https://www.data.go.kr/data/15098554/openapi.do",
+      "licenseEvidenceStatus": "confirmed_attribution",
+      "sampleEvidenceStatus": "sample_url_documented_key_required",
+      "admissionStatus": "evidence_recorded_admin_review_required",
+      "productionInventoryReferenceId": "molit-tago-subway-info",
+      "productionInventoryRelationship": "same_dataset_inventory_entry_remains_schedule_candidate_until_sample_and_importer_validation",
+      "serviceKeyHandling": "offline_import_secret_only",
+      "mobileEmbeddingAllowed": false,
+      "evidence": {
+        "detailPageUrl": "https://www.data.go.kr/data/15098554/openapi.do",
+        "retrievedAt": "2026-06-22",
+        "endpoint": "https://www.data.go.kr/data/15098554/openapi.do",
+        "sampleUrl": "https://www.data.go.kr/data/15098554/openapi.do",
+        "usePermissionRange": "공공데이터포털 이용허락범위 제한 없음",
+        "formats": [
+          "XML",
+          "JSON"
+        ],
+        "coverageLimitations": [
+          "시간표 import adapter와 provider sample validation 전까지 production PLANNED ETA 근거로 쓰지 않음",
+          "route graph RIDE edge duration과 stop_times 정합 검증 필요"
+        ],
+        "outputFields": [
+          "subwayRouteName",
+          "subwayStationId",
+          "subwayStationName",
+          "depTime",
+          "arrTime"
+        ],
+        "missingEvidence": [
+          "sampleResponse",
+          "scheduleImporterValidation"
+        ]
+      },
+      "nextAction": "capture sanitized TAGO live sample and validate schedule importer before production timetable admission",
+      "capabilities": {
+        "schedule": {
+          "status": "CANDIDATE",
+          "productionUseAllowed": false,
+          "coverageStatus": "SAMPLE_EVIDENCE_REQUIRED",
+          "updateFrequency": "provider documented; production cadence not admitted",
+          "unsupportedNotes": "commercial schedule import remains blocked until production schedule importer and provider sample validation are complete"
+        },
+        "realtime": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "liveEtaEligible": false,
+          "rateLimitStatus": "NOT_APPLICABLE",
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "provider documented; production cadence not admitted",
+          "unsupportedNotes": "candidate does not provide realtime arrival data for production live ETA"
+        },
+        "facility": {
+          "status": "UNSUPPORTED",
+          "productionUseAllowed": false,
+          "coverageStatus": "NOT_PROVIDED_BY_SOURCE",
+          "updateFrequency": "provider documented; production cadence not admitted",
+          "unsupportedNotes": "candidate does not provide accessibility facility records"
+        }
+      }
+    },
+    {
       "id": "seoul-topis-realtime-station-arrival",
       "priority": "P0",
       "domain": "realtime_arrivals",


### PR DESCRIPTION
## Summary
- 전국 coverage target에 schedule_timetable required domain을 추가했습니다.
- TAGO 지하철정보를 P0 schedule candidate로 등록하되 production PLANNED ETA 근거로 자동 승격되지 않도록 계약을 고정했습니다.
- coverage gap/report 계약과 repository contract 기대값을 갱신했습니다.

## Verification
- node --test tools/ci/repository-contract.test.mjs
- node --test tools/datapack/datapack-tools.test.mjs
- git diff --check

## 이슈
- Part of #1415
- Parent tracker #1419 remains open

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 일정 시간표 관련 데이터가 자동으로 공개/승격되지 않도록 검증이 강화되어, 잘못된 생산 반영을 줄였습니다.
  * 전국 커버리지 기준이 최신 소스 범위를 반영하도록 업데이트되어 감사 결과와 안내 문구가 더 정확해졌습니다.
  * 커버리지 갭 리포트의 집계 수치가 현재 기준에 맞게 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
