### PR TITLE
[Fix] 데이터팩 공개 base URL 정정

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3046,7 +3046,7 @@ test("스토어 개인정보 제출 기준선은 release artifact placeholder �
     "EASYSUBWAY_SUPPORT_EMAIL=support@aquilaxk.site",
     "EASYSUBWAY_SECURITY_EMAIL=security@aquilaxk.site",
     "EASYSUBWAY_DATA_DELETION_EMAIL=privacy@aquilaxk.site",
-    "EASYSUBWAY_DATA_PACK_BASE_URL=https://datapack.aquilaxk.site/datapacks/",
+    "EASYSUBWAY_DATA_PACK_BASE_URL=https://objectstorage.ap-seoul-1.oraclecloud.com/n/axvym6vk8g7i/b/easysubway-datapacks/o",
     `EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_N=${validDataPackPublicKeyModulus}`,
     "EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_E=AQAB",
     "EASYSUBWAY_DATAPACK_SIGNING_KEY_ID=production-v1",
@@ -3070,7 +3070,7 @@ test("스토어 개인정보 제출 기준선은 release artifact placeholder �
     },
   );
   const rcGithubEnvOutput = readFileSync(rcGithubEnv, "utf8");
-  assert.match(rcGithubEnvOutput, /^EASYSUBWAY_DATA_PACK_BASE_URL=https:\/\/datapack\.aquilaxk\.site\/datapacks\/$/m);
+  assert.match(rcGithubEnvOutput, /^EASYSUBWAY_DATA_PACK_BASE_URL=https:\/\/objectstorage\.ap-seoul-1\.oraclecloud\.com\/n\/axvym6vk8g7i\/b\/easysubway-datapacks\/o$/m);
   assert.match(rcGithubEnvOutput, /^EASYSUBWAY_DATAPACK_SIGNING_KEY_ID=production-v1$/m);
   assert.match(rcGithubEnvOutput, /^EASYSUBWAY_DATAPACK_CHANNEL=production$/m);
   assert.match(
@@ -3125,7 +3125,7 @@ test("스토어 개인정보 제출 기준선은 release artifact placeholder �
     "EASYSUBWAY_SUPPORT_EMAIL=support@aquilaxk.site",
     "EASYSUBWAY_SECURITY_EMAIL=security@aquilaxk.site",
     "EASYSUBWAY_DATA_DELETION_EMAIL=privacy@aquilaxk.site",
-    "EASYSUBWAY_DATA_PACK_BASE_URL=https://datapack.aquilaxk.site/datapacks/",
+    "EASYSUBWAY_DATA_PACK_BASE_URL=https://objectstorage.ap-seoul-1.oraclecloud.com/n/axvym6vk8g7i/b/easysubway-datapacks/o",
     "EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_N=public-key-modulus",
     "EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_E=AQAB",
     "EASYSUBWAY_DATAPACK_SIGNING_KEY_ID=production-v1",
@@ -3151,7 +3151,7 @@ test("스토어 개인정보 제출 기준선은 release artifact placeholder �
     "EASYSUBWAY_SUPPORT_EMAIL=support@aquilaxk.site",
     "EASYSUBWAY_SECURITY_EMAIL=security@aquilaxk.site",
     "EASYSUBWAY_DATA_DELETION_EMAIL=privacy@aquilaxk.site",
-    "EASYSUBWAY_DATA_PACK_BASE_URL=https://datapack.aquilaxk.site/datapacks/",
+    "EASYSUBWAY_DATA_PACK_BASE_URL=https://objectstorage.ap-seoul-1.oraclecloud.com/n/axvym6vk8g7i/b/easysubway-datapacks/o",
     `EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_N=${validDataPackPublicKeyModulus}`,
     "EASYSUBWAY_DATAPACK_SIGNING_PUBLIC_KEY_E=AQAB",
     "EASYSUBWAY_DATAPACK_SIGNING_KEY_ID=production-v1",

--- a/tools/datapack/inputs/capital-pilot-production-source-input.json
+++ b/tools/datapack/inputs/capital-pilot-production-source-input.json
@@ -6,7 +6,7 @@
     "version": "1",
     "schemaVersion": "1",
     "artifactKind": "production",
-    "url": "https://datapack.aquilaxk.site/catalog/capital-v1.sqlite.gz"
+    "url": "https://objectstorage.ap-seoul-1.oraclecloud.com/n/axvym6vk8g7i/b/easysubway-datapacks/o/catalog/capital-v1.sqlite.gz"
   },
   "manifest": {
     "manifestVersion": 2,


### PR DESCRIPTION
## Summary
- production source input의 data pack URL을 실제 200인 OCI Object Storage 공개 URL로 교체했습니다.
- Android RC env 계약 테스트의 data pack base URL 기대값도 같은 OCI base로 정렬했습니다.

## 서버 조치
- 운영 Nginx에서 `https://datapack.aquilaxk.site/catalog/*`와 `https://datapack.aquilaxk.site/datapacks/catalog/*`를 OCI Object Storage `/catalog/*`로 proxy하도록 live 수정했습니다.
- `nginx -t` 통과 후 reload 완료했습니다.
- 확인: `/catalog/current.json`, `/catalog/capital-v1.sqlite.gz`, `/datapacks/catalog/current.json` 모두 HTTP 200.

## Verification
- `node --test tools/ci/repository-contract.test.mjs` 통과
- `node --test tools/datapack/datapack-tools.test.mjs` 통과
- `node tools/ci/validate-store-privacy-env.mjs --env-file .env --require-android-rc-production` 통과
- `git diff --check` 통과
- OCI 원본 artifact 다운로드 및 SHA 확인:
  - `current.json`: `fa67db645ee57fe2ca422a5641f2fb5ccbfa76fc4466c657ab90234481d22682`
  - `capital-v1.sqlite.gz`: `0ea5d96b1ec1bf555796d641a6e50cef4bd8b6aa6930d75a891b259798744b94`
  - decompressed SQLite SHA: `209d0b8bff5c2f729202d696047f6b04a1efe3ee8dd2aeb77aad431bcae260a0`

## 남은 blocker
- 현재 배포된 `current.json` 내부 pack URL은 아직 `https://datapack.aquilaxk.site/catalog/capital-v1.sqlite.gz`입니다. 서버 proxy로 다운로드는 복구했지만, 새 manifest publish 전까지 manifest 내용 자체는 바뀌지 않습니다.
- 현재 배포 manifest는 최신 `--require-production` validator에서 `capital@1 regionalQualityMetrics.requiredFacilityEvidenceCoverageRatio must be a ratio`로 실패합니다. 따라서 #1393은 이 PR만으로 닫지 않습니다.
- `scripts/github/sync-actions-env-secret.sh .env`는 로컬 `.env`에 alert 관련 필수 env 이름이 없어 secret overwrite를 차단했습니다. 값을 추측하지 않았습니다.

Refs #1393
Refs #1419
