### PR TITLE
[Style] 전역 버튼 위계 재정의(아웃라인 보조 버튼 톤 다운)

### DIFF
--- a/apps/mobile/lib/accessible_design.dart
+++ b/apps/mobile/lib/accessible_design.dart
@@ -68,6 +68,9 @@ class EasySubwayAccessibleColors {
   /// 고장·오류 상태 배경 틴트.
   static const redSoft = Color(0xFFFFE8E6);
 
+  /// 확인 중·제보됨(needsInfo) 상태색. 브랜드 액센트 1계열로 통일한다.
+  static const needsInfo = primary;
+
   /// 정보 틴트(레거시). 장식용이므로 화면 정비 시 여백·구분선으로 대체한다.
   static const skySoft = Color(0xFFE6F5FF);
 

--- a/apps/mobile/lib/ad_slot.dart
+++ b/apps/mobile/lib/ad_slot.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'accessible_design.dart';
+
+/// 실광고 연동 전까지 사용하는 공용 배너 슬롯.
+///
+/// 노출 규칙(전 화면 공통):
+/// - release 빌드: 로드된 실광고([child])가 없으면 슬롯을 렌더링하지 않는다.
+///   빈 박스·"광고" 텍스트 플레이스홀더를 release에 상시 노출하지 않는다.
+/// - debug/internal 빌드: 자리 확인용 플레이스홀더만 노출한다.
+///
+/// 실광고 SDK를 연동하면 로드된 배너를 [child]로 전달한다. 로드 실패·무재고면
+/// 상위에서 이 위젯을 렌더링하지 않거나 [child]를 null로 두면 슬롯이 collapse된다.
+class AdBannerSlot extends StatelessWidget {
+  const AdBannerSlot({
+    required this.slotKey,
+    this.height = 52,
+    this.showTopDivider = true,
+    this.child,
+    super.key,
+  });
+
+  final Key slotKey;
+  final double height;
+  final bool showTopDivider;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    final ad = child;
+    // 실광고가 없는 상태에서 release면 슬롯 자체를 숨긴다(collapse).
+    if (ad == null && kReleaseMode) {
+      return const SizedBox.shrink();
+    }
+    return Semantics(
+      label: '광고',
+      child: Container(
+        key: slotKey,
+        height: height,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: EasySubwayAccessibleColors.surface,
+          border: showTopDivider
+              ? const Border(
+                  top: BorderSide(color: EasySubwayAccessibleColors.line),
+                )
+              : null,
+        ),
+        child:
+            ad ??
+            const Text(
+              '광고 미리보기 (개발용)',
+              style: TextStyle(
+                color: EasySubwayAccessibleColors.mutedText,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -48,7 +48,7 @@ const _facilityReportCardRadius = BorderRadius.all(Radius.circular(16));
 /// 텍스트로 상태를 구분하기 위한 전경색만 돌려준다.
 Color _reportStatusColor(String status) {
   return switch (status) {
-    'SUBMITTED' => const Color(0xFF17527C),
+    'SUBMITTED' => EasySubwayAccessibleColors.needsInfo,
     'UNDER_REVIEW' => EasySubwayAccessibleColors.amber,
     'ACCEPTED' || 'RESOLVED' => EasySubwayAccessibleColors.mintDark,
     'REJECTED' => EasySubwayAccessibleColors.red,
@@ -1417,7 +1417,7 @@ class _MyReportEmpty extends StatelessWidget {
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.titleLarge?.copyWith(
                 color: EasySubwayAccessibleColors.text,
-                fontWeight: FontWeight.w900,
+                fontWeight: FontWeight.w800,
                 height: 1.3,
               ),
             ),
@@ -1455,7 +1455,7 @@ class _MyReportError extends StatelessWidget {
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.titleLarge?.copyWith(
                 color: EasySubwayAccessibleColors.text,
-                fontWeight: FontWeight.w900,
+                fontWeight: FontWeight.w800,
                 height: 1.3,
               ),
             ),
@@ -1522,7 +1522,7 @@ class _MyReportListItem extends StatelessWidget {
                           report.reportTypeLabel,
                           style: textTheme.titleMedium?.copyWith(
                             color: EasySubwayAccessibleColors.text,
-                            fontWeight: FontWeight.w900,
+                            fontWeight: FontWeight.w800,
                             height: 1.25,
                           ),
                         ),
@@ -1590,7 +1590,7 @@ class MyFacilityReportDetailScreen extends StatelessWidget {
                 report.reportTypeLabel,
                 style: Theme.of(context).textTheme.headlineSmall?.copyWith(
                   color: EasySubwayAccessibleColors.text,
-                  fontWeight: FontWeight.w900,
+                  fontWeight: FontWeight.w800,
                   height: 1.25,
                 ),
               ),
@@ -1640,7 +1640,7 @@ class _MyReportDetailStatus extends StatelessWidget {
             label,
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
               color: color,
-              fontWeight: FontWeight.w900,
+              fontWeight: FontWeight.w800,
               height: 1.2,
             ),
           ),
@@ -1665,7 +1665,7 @@ class _MyReportDetailRow extends StatelessWidget {
           label,
           style: Theme.of(context).textTheme.labelLarge?.copyWith(
             color: EasySubwayAccessibleColors.mutedText,
-            fontWeight: FontWeight.w900,
+            fontWeight: FontWeight.w800,
             height: 1.2,
           ),
         ),
@@ -1705,7 +1705,7 @@ class _MyReportStatusLabel extends StatelessWidget {
           label,
           style: Theme.of(context).textTheme.labelLarge?.copyWith(
             color: color,
-            fontWeight: FontWeight.w900,
+            fontWeight: FontWeight.w800,
             height: 1.2,
           ),
         ),
@@ -2440,7 +2440,7 @@ class _FacilityReportStatusRow extends StatelessWidget {
           value,
           style: textTheme.titleMedium?.copyWith(
             color: EasySubwayAccessibleColors.text,
-            fontWeight: FontWeight.w900,
+            fontWeight: FontWeight.w800,
             height: 1.25,
           ),
         ),
@@ -2470,7 +2470,7 @@ class _FacilityReportHeader extends StatelessWidget {
               '${target.stationName}역',
               style: textTheme.headlineSmall?.copyWith(
                 color: EasySubwayAccessibleColors.text,
-                fontWeight: FontWeight.w900,
+                fontWeight: FontWeight.w800,
                 height: 1.2,
               ),
             ),
@@ -2512,7 +2512,7 @@ class _FacilityReportSectionTitle extends StatelessWidget {
         title,
         style: Theme.of(context).textTheme.titleLarge?.copyWith(
           color: EasySubwayAccessibleColors.text,
-          fontWeight: FontWeight.w900,
+          fontWeight: FontWeight.w800,
           height: 1.25,
         ),
       ),
@@ -2574,7 +2574,7 @@ class _FacilityReportTypeCard extends StatelessWidget {
                         style: Theme.of(context).textTheme.titleMedium
                             ?.copyWith(
                               color: textColor,
-                              fontWeight: FontWeight.w900,
+                              fontWeight: FontWeight.w800,
                               height: 1.25,
                             ),
                       ),
@@ -2599,7 +2599,7 @@ class _FacilityReportMessage extends StatelessWidget {
   Widget build(BuildContext context) {
     final isFailure = state.status == FacilityReportViewStatus.failure;
     final color = isFailure
-        ? EasySubwayAccessibleColors.amber
+        ? EasySubwayAccessibleColors.red
         : EasySubwayAccessibleColors.primary;
     final icon = isFailure ? Icons.error_outline : Icons.check_circle_outline;
     final shouldShowNextAction = _shouldShowFacilityReportFailureNextAction(
@@ -2672,7 +2672,7 @@ class _FacilityReportLocationMessage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final color = isFailure
-        ? EasySubwayAccessibleColors.amber
+        ? EasySubwayAccessibleColors.red
         : EasySubwayAccessibleColors.primary;
     final icon = isFailure ? Icons.error_outline : Icons.check_circle_outline;
 

--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -22,7 +22,7 @@ Color _favoriteFacilitySeverityColor(FacilityStatusSeverity severity) {
   return switch (severity) {
     FacilityStatusSeverity.blocked => EasySubwayAccessibleColors.red,
     FacilityStatusSeverity.caution => EasySubwayAccessibleColors.amber,
-    FacilityStatusSeverity.needsInfo => const Color(0xFF17527C),
+    FacilityStatusSeverity.needsInfo => EasySubwayAccessibleColors.needsInfo,
     FacilityStatusSeverity.normal => EasySubwayAccessibleColors.mintDark,
   };
 }
@@ -658,7 +658,7 @@ class _FavoriteFacilityTile extends StatelessWidget {
                             favorite.severityLabel,
                             style: textTheme.bodyMedium?.copyWith(
                               color: severityColor,
-                              fontWeight: FontWeight.w900,
+                              fontWeight: FontWeight.w800,
                               height: 1.2,
                             ),
                           ),
@@ -669,7 +669,7 @@ class _FavoriteFacilityTile extends StatelessWidget {
                         favorite.name,
                         style: textTheme.titleLarge?.copyWith(
                           color: EasySubwayAccessibleColors.text,
-                          fontWeight: FontWeight.w900,
+                          fontWeight: FontWeight.w800,
                           height: 1.25,
                         ),
                       ),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4359,11 +4359,10 @@ class OfflineDataScreen extends StatelessWidget {
           padding: _mainPagePadding,
           children: const [
             _AppCard(
-              backgroundColor: EasySubwayAccessibleColors.mintSoft,
-              borderColor: EasySubwayAccessibleColors.mintBorder,
+              showBorder: true,
               child: _AppInfoRow(
                 icon: Icons.check_circle_outline,
-                iconColor: EasySubwayAccessibleColors.mintDark,
+                iconColor: EasySubwayAccessibleColors.primary,
                 title: '인터넷 없이도 이용할 수 있어요',
                 subtitle: '마지막으로 받은 노선도와 역 정보를 보여줍니다.',
               ),
@@ -5234,11 +5233,10 @@ class UserDataDeletionResultScreen extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             const _AppCard(
-              backgroundColor: EasySubwayAccessibleColors.skySoft,
-              borderColor: _homeInfoBorderColor,
+              showBorder: true,
               child: _AppInfoRow(
                 icon: Icons.map_outlined,
-                iconColor: EasySubwayAccessibleColors.brand,
+                iconColor: EasySubwayAccessibleColors.primary,
                 title: '노선도와 역 정보는 계속 이용할 수 있어요',
               ),
             ),
@@ -5273,7 +5271,7 @@ class _DataDeletionResultRow extends StatelessWidget {
           title,
           style: textTheme.titleMedium?.copyWith(
             color: EasySubwayAccessibleColors.text,
-            fontWeight: FontWeight.w900,
+            fontWeight: FontWeight.w800,
           ),
         ),
         const SizedBox(height: 4),
@@ -5286,6 +5284,7 @@ class _DataDeletionResultRow extends StatelessWidget {
         ),
       ],
     );
+    // 삭제 완료는 복구/완료 상태 의미가 있어 민트 뱃지를 유지한다.
     final statusBadge = Container(
       key: Key('dataDeletionResultStatus-$id'),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
@@ -5297,8 +5296,8 @@ class _DataDeletionResultRow extends StatelessWidget {
       child: const Text(
         '완료',
         style: TextStyle(
-          color: EasySubwayAccessibleColors.text,
-          fontWeight: FontWeight.w900,
+          color: EasySubwayAccessibleColors.mintDark,
+          fontWeight: FontWeight.w800,
         ),
       ),
     );
@@ -5752,9 +5751,9 @@ class _DataSourceAttributionScreenState
                         subtitle: ProductionScopeCopy.supportedClaimKo,
                       ),
                     ),
-                    const _AppSectionTitle(title: '지도 표시용 asset'),
+                    const _AppSectionTitle(title: '지도 표시용 파일'),
                     for (final map in maps) _AttributionCard.map(map, manifest),
-                    const _AppSectionTitle(title: '경로·시설 판단용 data pack'),
+                    const _AppSectionTitle(title: '경로·시설 판단용 데이터'),
                     for (final source in sources)
                       _AttributionCard.source(source),
                   ],
@@ -5781,24 +5780,21 @@ class _AttributionCard extends StatelessWidget {
     final offline = (map['offline'] as Map<String, Object?>?) ?? const {};
     return _AttributionCard._(
       title: _text(map['name_ko']),
-      subtitle: 'provider/owner: ${_text(map['operator'])}',
+      subtitle: '제공·소유: ${_text(map['operator'])}',
       rows: [
-        ('source name', _text(license['source'], _text(map['name_ko']))),
+        ('출처명', _text(license['source'], _text(map['name_ko']))),
+        ('라이선스', '${_text(license['name'])} (${_text(license['spdx'])})'),
+        ('라이선스 링크', _text(license['url'])),
+        ('출처 표기 필요', _yesNo(license['attributionRequired'])),
+        ('가져온 날짜', _text(license['date'])),
+        ('확인한 날짜', _text(manifest['generated_at_utc'])),
         (
-          'license type',
-          '${_text(license['name'])} (${_text(license['spdx'])})',
-        ),
-        ('license URL', _text(license['url'])),
-        ('attribution required', _yesNo(license['attributionRequired'])),
-        ('last retrieved', _text(license['date'])),
-        ('last verified', _text(manifest['generated_at_utc'])),
-        (
-          'commercial use / redistribution',
+          '상업적 이용 / 재배포',
           '${_allowed(license['commercialUseAllowed'])} / ${_allowed(license['redistributionAllowed'])}',
         ),
-        ('review status', _text(license['reviewStatus'])),
-        ('changes', _text(license['changes'])),
-        ('asset path', _text(offline['path'])),
+        ('검토 상태', _text(license['reviewStatus'])),
+        ('변경 사항', _text(license['changes'])),
+        ('파일 경로', _text(offline['path'])),
       ],
     );
   }
@@ -5808,26 +5804,23 @@ class _AttributionCard extends StatelessWidget {
     return _AttributionCard._(
       title: _text(source['displayName']),
       subtitle:
-          'provider/owner: ${_text(source['provider'])} / ${_text(source['owner'])}',
+          '제공·소유: ${_text(source['provider'])} / ${_text(source['owner'])}',
       rows: [
-        ('source name', _text(source['displayName'])),
+        ('출처명', _text(source['displayName'])),
+        ('라이선스', '${_text(license['name'])} (${_text(license['type'])})'),
+        ('라이선스 링크', _text(license['evidenceUrl'])),
+        ('출처 표기 필요', _text(license['attribution'])),
+        ('가져온 날짜', _text(source['retrievedAt'])),
+        ('확인한 날짜', _text(source['observedDataUpdatedAt'])),
         (
-          'license type',
-          '${_text(license['name'])} (${_text(license['type'])})',
-        ),
-        ('license URL', _text(license['evidenceUrl'])),
-        ('attribution required', _text(license['attribution'])),
-        ('last retrieved', _text(source['retrievedAt'])),
-        ('last verified', _text(source['observedDataUpdatedAt'])),
-        (
-          'commercial use / redistribution',
+          '상업적 이용 / 재배포',
           '${_allowed(license['commercialUseAllowed'])} / ${_allowed(license['redistributionAllowed'])}',
         ),
         (
-          'changes',
+          '변경 사항',
           source.containsKey('changes')
               ? _text(source['changes'])
-              : 'inventory에 별도 변경 고지 없음',
+              : '자료 목록에 별도 변경 고지 없음',
         ),
       ],
     );
@@ -5856,7 +5849,7 @@ class _AttributionCard extends StatelessWidget {
                 title,
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
                   color: EasySubwayAccessibleColors.text,
-                  fontWeight: FontWeight.w900,
+                  fontWeight: FontWeight.w800,
                   height: 1.25,
                 ),
               ),
@@ -5929,7 +5922,7 @@ class _AttributionRow extends StatelessWidget {
             label,
             style: Theme.of(context).textTheme.labelLarge?.copyWith(
               color: EasySubwayAccessibleColors.secondaryText,
-              fontWeight: FontWeight.w900,
+              fontWeight: FontWeight.w800,
               height: 1.25,
             ),
           ),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1875,7 +1875,7 @@ class _HomeNotificationButton extends StatelessWidget {
               style: IconButton.styleFrom(
                 minimumSize: const Size.square(48),
                 backgroundColor: Colors.white,
-                foregroundColor: EasySubwayAccessibleColors.mintDark,
+                foregroundColor: EasySubwayAccessibleColors.secondaryText,
                 side: const BorderSide(
                   color: EasySubwayAccessibleColors.line,
                   width: 1.5,
@@ -2669,7 +2669,7 @@ class _AppSectionTitle extends StatelessWidget {
         title,
         style: Theme.of(context).textTheme.titleMedium?.copyWith(
           color: EasySubwayAccessibleColors.text,
-          fontWeight: FontWeight.w900,
+          fontWeight: FontWeight.w800,
           height: 1.2,
         ),
       ),
@@ -3185,13 +3185,10 @@ class _HomeSavedRouteCard extends StatelessWidget {
             showBorder: true,
             child: Row(
               children: [
-                CircleAvatar(
-                  radius: 21,
-                  backgroundColor: EasySubwayAccessibleColors.mintSoft,
-                  child: const Icon(
-                    Icons.route_outlined,
-                    color: EasySubwayAccessibleColors.mintDark,
-                  ),
+                const Icon(
+                  Icons.route_outlined,
+                  color: EasySubwayAccessibleColors.primary,
+                  size: 30,
                 ),
                 const SizedBox(width: 12),
                 Expanded(
@@ -3203,7 +3200,7 @@ class _HomeSavedRouteCard extends StatelessWidget {
                         style: const TextStyle(
                           color: EasySubwayAccessibleColors.text,
                           fontSize: 16,
-                          fontWeight: FontWeight.w900,
+                          fontWeight: FontWeight.w800,
                           height: 1.25,
                         ),
                       ),
@@ -3271,13 +3268,13 @@ class _HomeMiniBadge extends StatelessWidget {
     return Chip(
       label: Text(label),
       visualDensity: VisualDensity.compact,
-      backgroundColor: EasySubwayAccessibleColors.mintSoft,
-      side: BorderSide.none,
+      backgroundColor: EasySubwayAccessibleColors.surface,
+      side: const BorderSide(color: EasySubwayAccessibleColors.line),
       shape: const StadiumBorder(),
       labelStyle: const TextStyle(
-        color: EasySubwayAccessibleColors.mintDark,
+        color: EasySubwayAccessibleColors.secondaryText,
         fontSize: 11,
-        fontWeight: FontWeight.w900,
+        fontWeight: FontWeight.w700,
         height: 1.2,
       ),
       padding: const EdgeInsets.symmetric(horizontal: 2),
@@ -3292,7 +3289,7 @@ class _AppCard extends StatelessWidget {
     this.borderColor = EasySubwayAccessibleColors.line,
     this.borderRadius = 20,
     this.padding = const EdgeInsets.all(16),
-    this.showBorder = false,
+    this.showBorder = true,
   });
 
   final Widget child;
@@ -3304,10 +3301,11 @@ class _AppCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // 최소 그림자 원칙: 그림자 대신 얇은 보더로 카드를 구분한다.
     return Card(
       margin: EdgeInsets.zero,
       color: backgroundColor,
-      elevation: 2,
+      elevation: 0,
       shadowColor: _appCardShadowColor,
       shape: RoundedRectangleBorder(
         side: showBorder ? BorderSide(color: borderColor) : BorderSide.none,
@@ -3682,7 +3680,7 @@ class _AppSettingsSection extends StatelessWidget {
               title,
               style: textTheme.titleMedium?.copyWith(
                 color: EasySubwayAccessibleColors.text,
-                fontWeight: FontWeight.w900,
+                fontWeight: FontWeight.w800,
                 height: 1.25,
               ),
             ),
@@ -3998,7 +3996,7 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
                         child: _AppCard(
                           child: _AppInfoRow(
                             icon: Icons.bookmark_border,
-                            iconColor: EasySubwayAccessibleColors.mintDark,
+                            iconColor: EasySubwayAccessibleColors.mutedText,
                             title: '즐겨찾기한 항목이 없습니다',
                             subtitle: '역, 시설, 경로에서 즐겨찾기를 추가해 주세요.',
                           ),
@@ -4271,18 +4269,13 @@ class _FavoriteHomeQuickCard extends StatelessWidget {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: EasySubwayAccessibleColors.mintSoft,
-                    borderRadius: _mainThemeControlRadius,
-                  ),
-                  child: SizedBox(
-                    width: 44,
-                    height: 44,
-                    child: Icon(
-                      icon,
-                      color: EasySubwayAccessibleColors.mintDark,
-                    ),
+                SizedBox(
+                  width: 44,
+                  height: 44,
+                  child: Icon(
+                    icon,
+                    color: EasySubwayAccessibleColors.primary,
+                    size: 28,
                   ),
                 ),
                 const SizedBox(width: 12),
@@ -4295,7 +4288,7 @@ class _FavoriteHomeQuickCard extends StatelessWidget {
                         style: const TextStyle(
                           color: EasySubwayAccessibleColors.text,
                           fontSize: 18,
-                          fontWeight: FontWeight.w900,
+                          fontWeight: FontWeight.w800,
                           height: 1.25,
                         ),
                       ),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1616,6 +1616,7 @@ class _HomeScreenState extends State<HomeScreen> {
           stationSearchRepository: repository,
           locationProvider: locationProvider,
           viewportRepository: widget.networkMapViewportRepository,
+          realtimeRepository: widget.realtimeRepository,
           onOpenSavedItems: openSavedTab,
           onOpenRecentSearch: () =>
               unawaited(openStationSearch(StationSearchEntryMode.recent)),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -397,9 +397,10 @@ class EasySubwayApp extends StatelessWidget {
             fontWeight: FontWeight.w700,
           ),
         ),
+        // 주 행동(채움)만 강하게: 높이 60, 진한 채움.
         filledButtonTheme: FilledButtonThemeData(
           style: FilledButton.styleFrom(
-            minimumSize: const Size.fromHeight(60),
+            minimumSize: const Size.fromHeight(EasySubwayTouchTarget.primary),
             shape: const RoundedRectangleBorder(
               borderRadius: _mainThemeControlRadius,
             ),
@@ -409,18 +410,21 @@ class EasySubwayApp extends StatelessWidget {
             ),
           ),
         ),
+        // 보조 행동은 조용하게: 중립 얇은 보더(line 토큰) + primary 텍스트,
+        // 높이는 접근성 최소(56). 고대비 대비는 _themeForPreferences에서 보정.
         outlinedButtonTheme: OutlinedButtonThemeData(
           style: OutlinedButton.styleFrom(
-            minimumSize: const Size.fromHeight(60),
+            minimumSize: const Size.fromHeight(EasySubwayTouchTarget.general),
+            foregroundColor: EasySubwayAccessibleColors.primary,
             side: const BorderSide(
-              color: EasySubwayAccessibleColors.primary,
-              width: 2,
+              color: EasySubwayAccessibleColors.line,
+              width: 1.5,
             ),
             shape: const RoundedRectangleBorder(
               borderRadius: _mainThemeControlRadius,
             ),
             textStyle: const TextStyle(
-              fontSize: 18,
+              fontSize: 16,
               fontWeight: FontWeight.w700,
             ),
           ),
@@ -1112,6 +1116,17 @@ ThemeData _themeForPreferences(
       foregroundColor: _highContrastTextColor,
       titleTextStyle: baseTheme.appBarTheme.titleTextStyle?.copyWith(
         color: _highContrastTextColor,
+      ),
+    ),
+    // 보조 버튼이 중립 보더로 바뀌었으므로 고대비에서 보더·텍스트 대비를 보정.
+    outlinedButtonTheme: OutlinedButtonThemeData(
+      style: baseTheme.outlinedButtonTheme.style?.copyWith(
+        foregroundColor: const WidgetStatePropertyAll(
+          _highContrastPrimaryColor,
+        ),
+        side: const WidgetStatePropertyAll(
+          BorderSide(color: _highContrastTextColor, width: 1.5),
+        ),
       ),
     ),
   );

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1622,6 +1622,7 @@ class _HomeScreenState extends State<HomeScreen> {
               unawaited(openStationSearch(StationSearchEntryMode.recent)),
           onOpenNearbyStations: () =>
               unawaited(openStationSearch(StationSearchEntryMode.nearby)),
+          onOpenSettings: openMoreTab,
           onOpenDataSources: openDataSources,
           notificationAction: notificationRepository == null
               ? null

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -60,7 +60,6 @@ const _highContrastSecondaryColor =
     EasySubwayAccessibleColors.highContrastSecondary;
 const _homeInfoBorderColor = Color(0xFFB7DDF4);
 const _homeFacilityCautionBorderColor = Color(0xFFF1D49A);
-const _homeFacilityInfoBorderColor = Color(0xFFC8E6F8);
 const _settingsSwitchActiveTrackColor =
     EasySubwayAccessibleColors.switchActiveTrack;
 const _settingsSwitchInactiveTrackColor =
@@ -2834,9 +2833,9 @@ _FacilitySeverityAccent _facilitySeverityAccent(
       iconColor: EasySubwayAccessibleColors.amber,
     ),
     FacilityStatusSeverity.needsInfo => const _FacilitySeverityAccent(
-      backgroundColor: EasySubwayAccessibleColors.skySoft,
-      borderColor: _homeFacilityInfoBorderColor,
-      iconColor: EasySubwayAccessibleColors.brand,
+      backgroundColor: Colors.white,
+      borderColor: EasySubwayAccessibleColors.needsInfo,
+      iconColor: EasySubwayAccessibleColors.needsInfo,
     ),
     FacilityStatusSeverity.normal => const _FacilitySeverityAccent(
       backgroundColor: Colors.white,

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
 import 'accessible_design.dart';
+import 'ad_slot.dart';
 import 'features/network_map/domain/map_camera.dart';
 import 'features/network_map/infrastructure/android_route_map_viewport_webview.dart';
 import 'features/network_map/infrastructure/ios_route_map_viewport_webview.dart';
@@ -1649,24 +1650,12 @@ class _NetworkMapBottomAdBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
+    // 실광고 미연동: release에서는 "광고" 플레이스홀더를 노출하지 않고 슬롯을 숨긴다.
+    return const SafeArea(
       top: false,
-      child: Container(
-        key: const Key('networkMapBottomAdBanner'),
+      child: AdBannerSlot(
+        slotKey: Key('networkMapBottomAdBanner'),
         height: _networkMapBottomAdHeight,
-        alignment: Alignment.center,
-        decoration: const BoxDecoration(
-          color: Colors.white,
-          border: Border(top: BorderSide(color: Color(0xFFE5E5E5))),
-        ),
-        child: const Text(
-          '광고',
-          style: TextStyle(
-            color: Color(0xFF666666),
-            fontSize: 13,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
       ),
     );
   }
@@ -1715,75 +1704,93 @@ class _NetworkMapMenuPanel extends StatelessWidget {
         child: SizedBox(
           width: width.clamp(280.0, 430.0).toDouble(),
           height: double.infinity,
-          child: SafeArea(
-            bottom: false,
-            child: ListView(
-              padding: EdgeInsets.zero,
-              children: [
-                const _NetworkMapMenuHeader(),
-                const Divider(height: 1, color: Color(0xFFE4E4E4)),
-                const _NetworkMapMenuSectionLabel('탐색'),
-                _NetworkMapMenuTile(
-                  key: const Key('networkMapMenuStationSearchButton'),
-                  icon: Icons.search,
-                  label: '역 검색',
-                  onTap: () => _runAction(context, onOpenStationSearch),
+          child: Column(
+            children: [
+              Expanded(
+                child: SafeArea(
+                  bottom: false,
+                  child: ListView(
+                    padding: EdgeInsets.zero,
+                    children: [
+                      const _NetworkMapMenuHeader(),
+                      const Divider(height: 1, color: Color(0xFFE4E4E4)),
+                      const _NetworkMapMenuSectionLabel('탐색'),
+                      _NetworkMapMenuTile(
+                        key: const Key('networkMapMenuStationSearchButton'),
+                        icon: Icons.search,
+                        label: '역 검색',
+                        onTap: () => _runAction(context, onOpenStationSearch),
+                      ),
+                      _NetworkMapMenuTile(
+                        key: const Key('networkMapMenuRouteSearchButton'),
+                        icon: Icons.route_outlined,
+                        label: '길찾기',
+                        onTap: () =>
+                            _runFutureAction(context, onOpenRouteSearch),
+                      ),
+                      if (onOpenNearbyStations != null)
+                        _NetworkMapMenuTile(
+                          key: const Key('networkMapMenuNearbyButton'),
+                          icon: Icons.near_me_outlined,
+                          label: '가까운 역',
+                          onTap: () =>
+                              _runAction(context, onOpenNearbyStations!),
+                        ),
+                      if (onOpenRecentSearch != null)
+                        _NetworkMapMenuTile(
+                          key: const Key('networkMapMenuRecentButton'),
+                          icon: Icons.history,
+                          label: '최근 검색',
+                          onTap: () => _runAction(context, onOpenRecentSearch!),
+                        ),
+                      if (onOpenSavedItems != null) ...[
+                        const _NetworkMapMenuSectionLabel('내 정보'),
+                        _NetworkMapMenuTile(
+                          key: const Key('networkMapMenuSavedButton'),
+                          icon: Icons.star_border_rounded,
+                          label: '즐겨찾기',
+                          onTap: () => _runAction(context, onOpenSavedItems!),
+                        ),
+                      ],
+                      if (onOpenDataSources != null) ...[
+                        const _NetworkMapMenuSectionLabel('안내'),
+                        _NetworkMapMenuTile(
+                          key: const Key('networkMapMenuDataSourcesButton'),
+                          icon: Icons.source_outlined,
+                          label: '자료 제공 정보',
+                          onTap: () => _runActionAfterMenuClose(
+                            context,
+                            onOpenDataSources!,
+                          ),
+                        ),
+                      ],
+                      const SizedBox(height: 10),
+                      const Divider(height: 1, color: Color(0xFFEDEDED)),
+                      const _NetworkMapMenuInfoBanner(),
+                      const Padding(
+                        padding: EdgeInsets.fromLTRB(24, 6, 24, 8),
+                        child: Text(
+                          '교통약자 이동을 더 쉽게',
+                          style: TextStyle(
+                            color: Color(0xFF9A9A9A),
+                            fontSize: 13,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-                _NetworkMapMenuTile(
-                  key: const Key('networkMapMenuRouteSearchButton'),
-                  icon: Icons.route_outlined,
-                  label: '길찾기',
-                  onTap: () => _runFutureAction(context, onOpenRouteSearch),
+              ),
+              // 패널 최하단 고정 광고 슬롯(항목 스크롤과 분리, release는 collapse).
+              const SafeArea(
+                top: false,
+                child: AdBannerSlot(
+                  slotKey: Key('networkMapMenuAdBanner'),
+                  height: 56,
                 ),
-                if (onOpenNearbyStations != null)
-                  _NetworkMapMenuTile(
-                    key: const Key('networkMapMenuNearbyButton'),
-                    icon: Icons.near_me_outlined,
-                    label: '가까운 역',
-                    onTap: () => _runAction(context, onOpenNearbyStations!),
-                  ),
-                if (onOpenRecentSearch != null)
-                  _NetworkMapMenuTile(
-                    key: const Key('networkMapMenuRecentButton'),
-                    icon: Icons.history,
-                    label: '최근 검색',
-                    onTap: () => _runAction(context, onOpenRecentSearch!),
-                  ),
-                if (onOpenSavedItems != null) ...[
-                  const _NetworkMapMenuSectionLabel('내 정보'),
-                  _NetworkMapMenuTile(
-                    key: const Key('networkMapMenuSavedButton'),
-                    icon: Icons.star_border_rounded,
-                    label: '즐겨찾기',
-                    onTap: () => _runAction(context, onOpenSavedItems!),
-                  ),
-                ],
-                if (onOpenDataSources != null) ...[
-                  const _NetworkMapMenuSectionLabel('안내'),
-                  _NetworkMapMenuTile(
-                    key: const Key('networkMapMenuDataSourcesButton'),
-                    icon: Icons.source_outlined,
-                    label: '자료 제공 정보',
-                    onTap: () =>
-                        _runActionAfterMenuClose(context, onOpenDataSources!),
-                  ),
-                ],
-                const SizedBox(height: 10),
-                const Divider(height: 1, color: Color(0xFFEDEDED)),
-                const _NetworkMapMenuInfoBanner(),
-                const Padding(
-                  padding: EdgeInsets.fromLTRB(24, 6, 24, 8),
-                  child: Text(
-                    '교통약자 이동을 더 쉽게',
-                    style: TextStyle(
-                      color: Color(0xFF9A9A9A),
-                      fontSize: 13,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -12,6 +12,7 @@ import 'features/network_map/domain/map_camera.dart';
 import 'features/network_map/infrastructure/android_route_map_viewport_webview.dart';
 import 'features/network_map/infrastructure/ios_route_map_viewport_webview.dart';
 import 'features/network_map/infrastructure/route_map_renderer.dart';
+import 'features/realtime/realtime_repository.dart';
 import 'features/route_draft/application/route_draft_controller.dart';
 import 'features/route_draft/domain/route_draft.dart';
 import 'mobile_error_reporter.dart';
@@ -312,6 +313,7 @@ class NetworkMapScreen extends StatefulWidget {
     this.stationSearchRepository,
     this.locationProvider,
     this.viewportRepository,
+    this.realtimeRepository,
     this.onOpenSavedItems,
     this.onOpenRecentSearch,
     this.onOpenNearbyStations,
@@ -328,6 +330,7 @@ class NetworkMapScreen extends StatefulWidget {
   final StationSearchRepository? stationSearchRepository;
   final CurrentLocationProvider? locationProvider;
   final NetworkMapViewportRepository? viewportRepository;
+  final RealtimeRepository? realtimeRepository;
   final VoidCallback? onOpenSavedItems;
   final VoidCallback? onOpenRecentSearch;
   final VoidCallback? onOpenNearbyStations;
@@ -349,7 +352,52 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
   String? _nearbyLookupMessage;
   Timer? _nearbyLookupMessageTimer;
   bool _initialNearbyFocusStarted = false;
+  RealtimeSnapshot _nearbyRealtime = const RealtimeSnapshot.loading();
+  int _nearbyRealtimeToken = 0;
   late Future<_NetworkMapLoadResult> _future = _loadMap();
+
+  Future<void> _loadNearbyRealtime(StationSearchResult station) async {
+    final repository = widget.realtimeRepository;
+    final firstLine = station.lines.isEmpty ? null : station.lines.first;
+    final token = ++_nearbyRealtimeToken;
+    if (repository == null || firstLine == null) {
+      setState(() {
+        _nearbyRealtime = const RealtimeSnapshot(
+          status: RealtimeSnapshotStatus.unsupported,
+          fallbackCode: 'LINE_MAPPING_MISSING',
+          message: '이 노선은 아직 실시간 열차 안내가 어려워요.',
+        );
+      });
+      return;
+    }
+    setState(() => _nearbyRealtime = const RealtimeSnapshot.loading());
+    RealtimeSnapshot snapshot;
+    try {
+      snapshot = await repository.arrivals(
+        RealtimeStationQuery(
+          stationId: station.id,
+          lineId: firstLine.id,
+          providerLineId: firstLine.stationCode.isEmpty
+              ? firstLine.id
+              : firstLine.stationCode,
+          stationQueryName: station.nameKo,
+        ),
+      );
+    } on RealtimeException {
+      snapshot = const RealtimeSnapshot.unavailable();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '노선도 주변역 실시간 조회 중 예외가 발생했습니다.',
+      );
+      snapshot = const RealtimeSnapshot.unavailable();
+    }
+    if (!mounted || token != _nearbyRealtimeToken) {
+      return;
+    }
+    setState(() => _nearbyRealtime = snapshot);
+  }
 
   @override
   void dispose() {
@@ -371,6 +419,8 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       _nearbySelectedStationId = null;
       _nearbyPanelVisible = false;
       _nearbyPanelData = const _NetworkMapNearbyPanelData.idle();
+      _nearbyRealtime = const RealtimeSnapshot.loading();
+      _nearbyRealtimeToken++;
       _initialNearbyFocusStarted = false;
       _future = _loadMap();
     });
@@ -399,6 +449,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               },
               nearbyPanelVisible: _nearbyPanelVisible,
               nearbyPanelData: _nearbyPanelData,
+              realtime: _nearbyRealtime,
               nearbyLookupMessage: _nearbyLookupMessage,
               adjacentStations: const _NetworkMapAdjacentStations(),
               onCurrentLocationTap: _showNearbyPanel,
@@ -422,6 +473,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               },
               nearbyPanelVisible: _nearbyPanelVisible,
               nearbyPanelData: _nearbyPanelData,
+              realtime: _nearbyRealtime,
               nearbyLookupMessage: _nearbyLookupMessage,
               adjacentStations: const _NetworkMapAdjacentStations(),
               onCurrentLocationTap: _showNearbyPanel,
@@ -454,6 +506,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
             },
             nearbyPanelVisible: _nearbyPanelVisible,
             nearbyPanelData: _nearbyPanelData,
+            realtime: _nearbyRealtime,
             nearbyLookupMessage: _nearbyLookupMessage,
             adjacentStations: _adjacentStationsFor(data),
             onCurrentLocationTap: _showNearbyPanel,
@@ -526,6 +579,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
         _nearbySelectedStationId = results.first.id;
         _nearbyPanelData = _NetworkMapNearbyPanelData.success(results);
       });
+      unawaited(_loadNearbyRealtime(results.first));
     } on CurrentLocationException catch (error) {
       if (!mounted) {
         return;
@@ -557,7 +611,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       _nearbyPanelData = const _NetworkMapNearbyPanelData.idle();
       _nearbyLookupMessage = message;
     });
-    _nearbyLookupMessageTimer = Timer(const Duration(milliseconds: 1800), () {
+    _nearbyLookupMessageTimer = Timer(const Duration(seconds: 4), () {
       if (!mounted) {
         return;
       }
@@ -635,6 +689,8 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       _nearbyPanelVisible = false;
       _nearbySelectedStationId = null;
       _nearbyPanelData = const _NetworkMapNearbyPanelData.idle();
+      _nearbyRealtime = const RealtimeSnapshot.loading();
+      _nearbyRealtimeToken++;
     });
   }
 
@@ -763,6 +819,7 @@ class _NetworkMapChrome extends StatelessWidget {
     required this.onExpressViewChanged,
     required this.nearbyPanelVisible,
     required this.nearbyPanelData,
+    required this.realtime,
     required this.nearbyLookupMessage,
     required this.adjacentStations,
     required this.onCurrentLocationTap,
@@ -782,6 +839,7 @@ class _NetworkMapChrome extends StatelessWidget {
   final ValueChanged<bool> onExpressViewChanged;
   final bool nearbyPanelVisible;
   final _NetworkMapNearbyPanelData nearbyPanelData;
+  final RealtimeSnapshot realtime;
   final String? nearbyLookupMessage;
   final _NetworkMapAdjacentStations adjacentStations;
   final VoidCallback onCurrentLocationTap;
@@ -827,6 +885,7 @@ class _NetworkMapChrome extends StatelessWidget {
             bottom: 0,
             child: _NetworkMapNearbyStationPanel(
               data: nearbyPanelData,
+              realtime: realtime,
               adjacentStations: adjacentStations,
               onClose: onCloseNearbyPanel,
               onRetry: onCurrentLocationTap,
@@ -950,7 +1009,7 @@ class _NetworkMapTopBar extends StatelessWidget {
                   button: true,
                   label: '지역: $currentRegion',
                   child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 84),
+                    constraints: const BoxConstraints(maxWidth: 148),
                     child: SizedBox(
                       height: EasySubwayTouchTarget.general,
                       child: ExcludeSemantics(
@@ -958,27 +1017,28 @@ class _NetworkMapTopBar extends StatelessWidget {
                           key: const Key('networkMapRegionDropdown'),
                           onTap: () =>
                               _showRegionSheet(context, availableRegions),
-                          child: FittedBox(
-                            fit: BoxFit.scaleDown,
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Text(
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Flexible(
+                                child: Text(
                                   currentRegion,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
                                   style: const TextStyle(
                                     color: Color(0xFF606060),
                                     fontSize: 15,
                                     fontWeight: FontWeight.w600,
                                   ),
                                 ),
-                                const SizedBox(width: 2),
-                                const Icon(
-                                  Icons.keyboard_arrow_down,
-                                  color: Color(0xFF606060),
-                                  size: 18,
-                                ),
-                              ],
-                            ),
+                              ),
+                              const SizedBox(width: 2),
+                              const Icon(
+                                Icons.keyboard_arrow_down,
+                                color: Color(0xFF606060),
+                                size: 18,
+                              ),
+                            ],
                           ),
                         ),
                       ),
@@ -1278,12 +1338,14 @@ class _NetworkMapAdjacentStations {
 class _NetworkMapNearbyStationPanel extends StatelessWidget {
   const _NetworkMapNearbyStationPanel({
     required this.data,
+    required this.realtime,
     required this.adjacentStations,
     required this.onClose,
     required this.onRetry,
   });
 
   final _NetworkMapNearbyPanelData data;
+  final RealtimeSnapshot realtime;
   final _NetworkMapAdjacentStations adjacentStations;
   final VoidCallback onClose;
   final VoidCallback onRetry;
@@ -1318,26 +1380,29 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
                       child: _SubwayLinePanelTab(line: primaryLine),
                     ),
                     const Spacer(),
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 10),
-                      child: Container(
-                        height: 24,
-                        alignment: Alignment.center,
-                        padding: const EdgeInsets.symmetric(horizontal: 8),
-                        decoration: BoxDecoration(
-                          border: Border.all(color: const Color(0xFFFFCACA)),
-                          borderRadius: BorderRadius.circular(3),
-                        ),
-                        child: const Text(
-                          '실시간',
-                          style: TextStyle(
-                            color: Color(0xFFFF7777),
-                            fontSize: 12,
-                            fontWeight: FontWeight.w800,
+                    if (realtime.status == RealtimeSnapshotStatus.fresh)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 10),
+                        child: Container(
+                          height: 24,
+                          alignment: Alignment.center,
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
+                          decoration: BoxDecoration(
+                            border: Border.all(
+                              color: EasySubwayAccessibleColors.mintBorder,
+                            ),
+                            borderRadius: BorderRadius.circular(3),
+                          ),
+                          child: const Text(
+                            '실시간',
+                            style: TextStyle(
+                              color: EasySubwayAccessibleColors.mint,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w800,
+                            ),
                           ),
                         ),
                       ),
-                    ),
                     Padding(
                       padding: const EdgeInsets.only(bottom: 3),
                       child: IconButton(
@@ -1380,6 +1445,7 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
               const Divider(height: 1, color: Color(0xFFD8D8D8)),
               _NetworkMapNearbyPanelBody(
                 data: data,
+                realtime: realtime,
                 adjacentStations: adjacentStations,
               ),
             ],
@@ -1393,10 +1459,12 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
 class _NetworkMapNearbyPanelBody extends StatelessWidget {
   const _NetworkMapNearbyPanelBody({
     required this.data,
+    required this.realtime,
     required this.adjacentStations,
   });
 
   final _NetworkMapNearbyPanelData data;
+  final RealtimeSnapshot realtime;
   final _NetworkMapAdjacentStations adjacentStations;
 
   @override
@@ -1409,6 +1477,7 @@ class _NetworkMapNearbyPanelBody extends StatelessWidget {
       ),
       _NetworkMapNearbyPanelStatus.success => _NetworkMapNearbySuccessList(
         results: data.results,
+        realtime: realtime,
         adjacentStations: adjacentStations,
       ),
     };
@@ -1418,17 +1487,19 @@ class _NetworkMapNearbyPanelBody extends StatelessWidget {
 class _NetworkMapNearbySuccessList extends StatelessWidget {
   const _NetworkMapNearbySuccessList({
     required this.results,
+    required this.realtime,
     required this.adjacentStations,
   });
 
   final List<StationSearchResult> results;
+  final RealtimeSnapshot realtime;
   final _NetworkMapAdjacentStations adjacentStations;
 
   @override
   Widget build(BuildContext context) {
     final primary = results.first;
-    final leftName = adjacentStations.leftName ?? '-';
-    final rightName = adjacentStations.rightName ?? '-';
+    final leftName = adjacentStations.leftName;
+    final rightName = adjacentStations.rightName;
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -1444,7 +1515,7 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
               children: [
                 Expanded(
                   child: Text(
-                    '< $leftName',
+                    leftName == null ? '' : '< $leftName',
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     textAlign: TextAlign.center,
@@ -1481,7 +1552,7 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
                 ),
                 Expanded(
                   child: Text(
-                    '$rightName >',
+                    rightName == null ? '' : '$rightName >',
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     textAlign: TextAlign.center,
@@ -1498,26 +1569,8 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
         ),
         const SizedBox(height: 17),
         Padding(
-          padding: const EdgeInsets.fromLTRB(42, 0, 42, 12),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: _SubwayArrivalColumn(
-                  arrivals: const [_SubwayArrivalPlaceholder()],
-                ),
-              ),
-              const SizedBox(
-                height: 46,
-                child: VerticalDivider(color: Color(0xFFE0E0E0), width: 30),
-              ),
-              Expanded(
-                child: _SubwayArrivalColumn(
-                  arrivals: const [_SubwayArrivalPlaceholder()],
-                ),
-              ),
-            ],
-          ),
+          padding: const EdgeInsets.fromLTRB(24, 0, 24, 12),
+          child: _SubwayArrivalPanel(snapshot: realtime),
         ),
       ],
     );
@@ -1564,44 +1617,219 @@ class _SubwayLinePanelTab extends StatelessWidget {
   }
 }
 
-class _SubwayArrivalPlaceholder {
-  const _SubwayArrivalPlaceholder();
+String _formatArrivalEta(RealtimeArrival arrival) {
+  final eta = arrival.etaSeconds;
+  if (eta != null && eta > 0) {
+    final minutes = (eta / 60).round();
+    return minutes <= 0 ? '곧 도착' : '약 $minutes분';
+  }
+  return arrival.message.trim();
+}
+
+String _arrivalDirectionLabel(RealtimeArrival arrival) {
+  final direction = arrival.direction.trim();
+  if (direction.isNotEmpty) {
+    return direction;
+  }
+  final destination = arrival.destination.trim();
+  return destination.isEmpty ? '' : '$destination 방면';
+}
+
+/// 주변역 패널의 도착 정보 영역. 실시간 스냅샷 상태에 따라 방향별 도착을
+/// 표시하거나, 미지원·실패 시 "-" 대신 한 줄 안내를 보여준다.
+class _SubwayArrivalPanel extends StatelessWidget {
+  const _SubwayArrivalPanel({required this.snapshot});
+
+  final RealtimeSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context) {
+    switch (snapshot.status) {
+      case RealtimeSnapshotStatus.loading:
+        return const SizedBox(
+          key: Key('networkMapNearbyArrivalLoading'),
+          height: 46,
+          child: Center(
+            child: SizedBox(
+              width: 22,
+              height: 22,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          ),
+        );
+      case RealtimeSnapshotStatus.unsupported:
+      case RealtimeSnapshotStatus.unavailable:
+        final message = snapshot.message.trim().isEmpty
+            ? '실시간 도착 정보를 준비하고 있어요.'
+            : snapshot.message.trim();
+        return _SubwayArrivalNotice(message: message);
+      case RealtimeSnapshotStatus.fresh:
+      case RealtimeSnapshotStatus.stale:
+        if (snapshot.arrivals.isEmpty) {
+          return const _SubwayArrivalNotice(message: '표시할 도착 정보가 없어요.');
+        }
+        final groups = <String, List<RealtimeArrival>>{};
+        for (final arrival in snapshot.arrivals) {
+          groups.putIfAbsent(arrival.direction, () => []).add(arrival);
+        }
+        final directions = groups.keys.toList(growable: false);
+        final left = groups[directions.first]!;
+        final right = directions.length > 1
+            ? groups[directions[1]]!
+            : const <RealtimeArrival>[];
+        final isStale = snapshot.status == RealtimeSnapshotStatus.stale;
+        final semanticParts = <String>[
+          for (final arrival in [...left, ...right])
+            [
+              _arrivalDirectionLabel(arrival),
+              arrival.destination.trim().isEmpty
+                  ? ''
+                  : '${arrival.destination.trim()}행',
+              _formatArrivalEta(arrival),
+            ].where((part) => part.isNotEmpty).join(' '),
+        ].where((part) => part.isNotEmpty).toList(growable: false);
+        return Semantics(
+          liveRegion: true,
+          label: semanticParts.isEmpty ? '도착 정보 없음' : semanticParts.join(', '),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (isStale) ...[
+                Text(
+                  snapshot.receivedAt.trim().isEmpty
+                      ? '최근 도착 정보'
+                      : '최근 도착 정보 · ${snapshot.receivedAt.trim()}',
+                  style: const TextStyle(
+                    color: EasySubwayAccessibleColors.mutedText,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 6),
+              ],
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(child: _SubwayArrivalColumn(arrivals: left)),
+                  if (right.isNotEmpty) ...[
+                    const SizedBox(
+                      height: 46,
+                      child: VerticalDivider(
+                        color: Color(0xFFE0E0E0),
+                        width: 30,
+                      ),
+                    ),
+                    Expanded(child: _SubwayArrivalColumn(arrivals: right)),
+                  ],
+                ],
+              ),
+            ],
+          ),
+        );
+    }
+  }
+}
+
+class _SubwayArrivalNotice extends StatelessWidget {
+  const _SubwayArrivalNotice({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 46,
+      child: Center(
+        child: Text(
+          message,
+          textAlign: TextAlign.center,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(
+            color: EasySubwayAccessibleColors.mutedText,
+            fontSize: 13,
+            height: 1.3,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class _SubwayArrivalColumn extends StatelessWidget {
   const _SubwayArrivalColumn({required this.arrivals});
 
-  final List<_SubwayArrivalPlaceholder> arrivals;
+  final List<RealtimeArrival> arrivals;
 
   @override
   Widget build(BuildContext context) {
+    final visible = arrivals.take(2).toList(growable: false);
+    final directionLabel = visible.isEmpty
+        ? ''
+        : _arrivalDirectionLabel(visible.first);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       mainAxisSize: MainAxisSize.min,
-      children: arrivals
-          .map((arrival) => const _SubwayArrivalRow())
-          .toList(growable: false),
+      children: [
+        if (directionLabel.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 4),
+            child: Text(
+              directionLabel,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: EasySubwayAccessibleColors.primary,
+                fontSize: 12,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ),
+        for (final arrival in visible) _SubwayArrivalRow(arrival: arrival),
+      ],
     );
   }
 }
 
 class _SubwayArrivalRow extends StatelessWidget {
-  const _SubwayArrivalRow();
+  const _SubwayArrivalRow({required this.arrival});
+
+  final RealtimeArrival arrival;
 
   @override
   Widget build(BuildContext context) {
-    return const Padding(
-      padding: EdgeInsets.only(bottom: 2),
-      child: Center(
-        child: Text(
-          '-',
-          style: TextStyle(
-            color: Color(0xFF2F2F2F),
-            fontSize: 12,
-            height: 1.45,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
+    final destination = arrival.destination.trim();
+    final eta = _formatArrivalEta(arrival);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Column(
+        children: [
+          if (destination.isNotEmpty)
+            Text(
+              '$destination행',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: Color(0xFF2F2F2F),
+                fontSize: 13,
+                height: 1.3,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          if (eta.isNotEmpty)
+            Text(
+              eta,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: EasySubwayAccessibleColors.secondaryText,
+                fontSize: 12,
+                height: 1.3,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -317,6 +317,7 @@ class NetworkMapScreen extends StatefulWidget {
     this.onOpenSavedItems,
     this.onOpenRecentSearch,
     this.onOpenNearbyStations,
+    this.onOpenSettings,
     this.onOpenDataSources,
     this.notificationAction,
     this.bottomNavigationBar,
@@ -334,6 +335,7 @@ class NetworkMapScreen extends StatefulWidget {
   final VoidCallback? onOpenSavedItems;
   final VoidCallback? onOpenRecentSearch;
   final VoidCallback? onOpenNearbyStations;
+  final VoidCallback? onOpenSettings;
   final VoidCallback? onOpenDataSources;
   final Widget? notificationAction;
   final Widget? bottomNavigationBar;
@@ -708,6 +710,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
           onOpenSavedItems: widget.onOpenSavedItems,
           onOpenNearbyStations: widget.onOpenNearbyStations,
           onOpenRecentSearch: widget.onOpenRecentSearch,
+          onOpenSettings: widget.onOpenSettings,
           onOpenDataSources: widget.onOpenDataSources,
         );
       },
@@ -1896,6 +1899,7 @@ class _NetworkMapMenuPanel extends StatelessWidget {
     required this.onOpenSavedItems,
     required this.onOpenNearbyStations,
     required this.onOpenRecentSearch,
+    required this.onOpenSettings,
     required this.onOpenDataSources,
   });
 
@@ -1904,6 +1908,7 @@ class _NetworkMapMenuPanel extends StatelessWidget {
   final VoidCallback? onOpenSavedItems;
   final VoidCallback? onOpenNearbyStations;
   final VoidCallback? onOpenRecentSearch;
+  final VoidCallback? onOpenSettings;
   final VoidCallback? onOpenDataSources;
 
   void _runAction(BuildContext context, VoidCallback action) {
@@ -1971,14 +1976,23 @@ class _NetworkMapMenuPanel extends StatelessWidget {
                           label: '최근 검색',
                           onTap: () => _runAction(context, onOpenRecentSearch!),
                         ),
-                      if (onOpenSavedItems != null) ...[
+                      if (onOpenSavedItems != null ||
+                          onOpenSettings != null) ...[
                         const _NetworkMapMenuSectionLabel('내 정보'),
-                        _NetworkMapMenuTile(
-                          key: const Key('networkMapMenuSavedButton'),
-                          icon: Icons.star_border_rounded,
-                          label: '즐겨찾기',
-                          onTap: () => _runAction(context, onOpenSavedItems!),
-                        ),
+                        if (onOpenSavedItems != null)
+                          _NetworkMapMenuTile(
+                            key: const Key('networkMapMenuSavedButton'),
+                            icon: Icons.star_border_rounded,
+                            label: '즐겨찾기',
+                            onTap: () => _runAction(context, onOpenSavedItems!),
+                          ),
+                        if (onOpenSettings != null)
+                          _NetworkMapMenuTile(
+                            key: const Key('networkMapMenuSettingsButton'),
+                            icon: Icons.settings_outlined,
+                            label: '설정',
+                            onTap: () => _runAction(context, onOpenSettings!),
+                          ),
                       ],
                       if (onOpenDataSources != null) ...[
                         const _NetworkMapMenuSectionLabel('안내'),

--- a/apps/mobile/lib/onboarding.dart
+++ b/apps/mobile/lib/onboarding.dart
@@ -212,6 +212,8 @@ class StartScreen extends StatelessWidget {
                                 children: [
                                   TextSpan(text: '빠른 길보다,\n'),
                                   TextSpan(
+                                    // 스타트 화면(브랜드 스플래시) 한정 강조색.
+                                    // 팔레트 액센트(primary) 배경 위 대비를 위한 예외.
                                     text: '갈 수 있는 길',
                                     style: TextStyle(color: Color(0xFFB8F4DF)),
                                   ),
@@ -350,7 +352,7 @@ class _IntroVisual extends StatelessWidget {
               top: 38,
               child: _IntroIcon(
                 icon: Icons.accessible_forward,
-                color: EasySubwayAccessibleColors.mint,
+                color: EasySubwayAccessibleColors.primary,
               ),
             ),
             Positioned(
@@ -405,9 +407,9 @@ class _IntroIcon extends StatelessWidget {
         borderRadius: BorderRadius.circular(radius),
         boxShadow: const [
           BoxShadow(
-            color: Color(0x16071B2F),
-            blurRadius: 20,
-            offset: Offset(0, 8),
+            color: EasySubwayAccessibleColors.cardShadow,
+            blurRadius: 8,
+            offset: Offset(0, 4),
           ),
         ],
       ),
@@ -484,15 +486,13 @@ class _IntroInfoRow extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        DecoratedBox(
-          decoration: BoxDecoration(
-            color: const Color(0xFFDFF7EF),
-            borderRadius: BorderRadius.circular(14),
-          ),
-          child: SizedBox(
-            width: 43,
-            height: 43,
-            child: Icon(icon, color: const Color(0xFF0A705A), size: 22),
+        SizedBox(
+          width: 43,
+          height: 43,
+          child: Icon(
+            icon,
+            color: EasySubwayAccessibleColors.primary,
+            size: 26,
           ),
         ),
         const SizedBox(width: 12),
@@ -504,14 +504,14 @@ class _IntroInfoRow extends StatelessWidget {
                 title,
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
                   color: EasySubwayAccessibleColors.text,
-                  fontWeight: FontWeight.w900,
+                  fontWeight: FontWeight.w800,
                 ),
               ),
               const SizedBox(height: 3),
               Text(
                 subtitle,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: const Color(0xFF647686),
+                  color: EasySubwayAccessibleColors.mutedText,
                   fontWeight: FontWeight.w700,
                   height: 1.35,
                 ),
@@ -531,7 +531,7 @@ class _IntroDivider extends StatelessWidget {
   Widget build(BuildContext context) {
     return const Padding(
       padding: EdgeInsets.symmetric(vertical: 13),
-      child: Divider(height: 1, color: Color(0xFFE0E7EC)),
+      child: Divider(height: 1, color: EasySubwayAccessibleColors.line),
     );
   }
 }
@@ -557,8 +557,8 @@ class _OnboardingStepIndicator extends StatelessWidget {
                 child: DecoratedBox(
                   decoration: BoxDecoration(
                     color: step <= currentStep
-                        ? const Color(0xFF0D8A6D)
-                        : const Color(0xFFDBE3E9),
+                        ? EasySubwayAccessibleColors.primary
+                        : EasySubwayAccessibleColors.line,
                     borderRadius: BorderRadius.circular(10),
                   ),
                   child: const SizedBox(height: 5),
@@ -573,7 +573,7 @@ class _OnboardingStepIndicator extends StatelessWidget {
           '$currentStep / $totalSteps',
           textAlign: TextAlign.right,
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
-            color: const Color(0xFF647686),
+            color: EasySubwayAccessibleColors.mutedText,
             fontWeight: FontWeight.w700,
           ),
         ),
@@ -604,7 +604,6 @@ class _PermissionInfoCard extends StatelessWidget {
             icon: Icons.location_on_outlined,
             title: '현재 위치',
             subtitle: '가까운 역 찾기',
-            mint: true,
             value: locationSelected,
             onChanged: onLocationChanged,
           ),
@@ -629,7 +628,6 @@ class _PermissionInfoRow extends StatelessWidget {
     required this.subtitle,
     required this.value,
     required this.onChanged,
-    this.mint = false,
   });
 
   final IconData icon;
@@ -637,26 +635,18 @@ class _PermissionInfoRow extends StatelessWidget {
   final String subtitle;
   final bool value;
   final ValueChanged<bool> onChanged;
-  final bool mint;
 
   @override
   Widget build(BuildContext context) {
-    final iconColor = mint ? const Color(0xFF0A705A) : const Color(0xFF17527C);
-    final iconBackground = mint
-        ? const Color(0xFFDFF7EF)
-        : const Color(0xFFEEF3F6);
-
     return Row(
       children: [
-        DecoratedBox(
-          decoration: BoxDecoration(
-            color: iconBackground,
-            borderRadius: BorderRadius.circular(14),
-          ),
-          child: SizedBox(
-            width: 43,
-            height: 43,
-            child: Icon(icon, color: iconColor, size: 22),
+        SizedBox(
+          width: 43,
+          height: 43,
+          child: Icon(
+            icon,
+            color: EasySubwayAccessibleColors.primary,
+            size: 26,
           ),
         ),
         const SizedBox(width: 12),
@@ -668,14 +658,14 @@ class _PermissionInfoRow extends StatelessWidget {
                 title,
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
                   color: EasySubwayAccessibleColors.text,
-                  fontWeight: FontWeight.w900,
+                  fontWeight: FontWeight.w800,
                 ),
               ),
               const SizedBox(height: 3),
               Text(
                 subtitle,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: const Color(0xFF647686),
+                  color: EasySubwayAccessibleColors.mutedText,
                   fontWeight: FontWeight.w700,
                   height: 1.35,
                 ),
@@ -936,7 +926,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                       child: Text(
                         _onboardingNotificationFailureNextAction,
                         style: textTheme.bodyMedium?.copyWith(
-                          color: const Color(0xFF506B6F),
+                          color: EasySubwayAccessibleColors.mutedText,
                           fontWeight: FontWeight.w700,
                           height: 1.35,
                         ),
@@ -1085,9 +1075,11 @@ class _OnboardingProfileCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const primaryColor = Color(0xFF0D8A6D);
-    final borderColor = selected ? primaryColor : const Color(0xFFDBE3E9);
-    final backgroundColor = selected ? const Color(0xFFEAF8F3) : Colors.white;
+    const primaryColor = EasySubwayAccessibleColors.primary;
+    final borderColor = selected
+        ? primaryColor
+        : EasySubwayAccessibleColors.line;
+    const backgroundColor = Colors.white;
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 9),
@@ -1116,23 +1108,13 @@ class _OnboardingProfileCard extends StatelessWidget {
                   ),
                   child: Row(
                     children: [
-                      DecoratedBox(
-                        decoration: BoxDecoration(
-                          color: selected
-                              ? const Color(0xFFDFF7EF)
-                              : const Color(0xFFEEF3F6),
-                          borderRadius: BorderRadius.circular(15),
-                        ),
-                        child: SizedBox(
-                          width: 46,
-                          height: 46,
-                          child: Icon(
-                            profile.icon,
-                            color: selected
-                                ? primaryColor
-                                : const Color(0xFF17527C),
-                            size: 23,
-                          ),
+                      SizedBox(
+                        width: 46,
+                        height: 46,
+                        child: Icon(
+                          profile.icon,
+                          color: EasySubwayAccessibleColors.primary,
+                          size: 27,
                         ),
                       ),
                       const SizedBox(width: 12),
@@ -1146,7 +1128,7 @@ class _OnboardingProfileCard extends StatelessWidget {
                               style: Theme.of(context).textTheme.titleMedium
                                   ?.copyWith(
                                     color: EasySubwayAccessibleColors.text,
-                                    fontWeight: FontWeight.w900,
+                                    fontWeight: FontWeight.w800,
                                     height: 1.25,
                                   ),
                             ),
@@ -1155,7 +1137,7 @@ class _OnboardingProfileCard extends StatelessWidget {
                               _profileDisplaySummary(profile),
                               style: Theme.of(context).textTheme.bodyLarge
                                   ?.copyWith(
-                                    color: const Color(0xFF647686),
+                                    color: EasySubwayAccessibleColors.mutedText,
                                     fontWeight: FontWeight.w700,
                                     height: 1.3,
                                   ),
@@ -1203,7 +1185,9 @@ class _ProfileRadio extends StatelessWidget {
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         border: Border.all(
-          color: selected ? const Color(0xFF0D8A6D) : const Color(0xFFC8D3DC),
+          color: selected
+              ? EasySubwayAccessibleColors.primary
+              : EasySubwayAccessibleColors.line,
           width: 2,
         ),
       ),
@@ -1214,7 +1198,7 @@ class _ProfileRadio extends StatelessWidget {
             ? const Center(
                 child: DecoratedBox(
                   decoration: BoxDecoration(
-                    color: Color(0xFF0D8A6D),
+                    color: EasySubwayAccessibleColors.primary,
                     shape: BoxShape.circle,
                   ),
                   child: SizedBox(width: 10, height: 10),
@@ -1236,7 +1220,7 @@ class _OnboardingPreferenceCard extends StatelessWidget {
     return DecoratedBox(
       decoration: BoxDecoration(
         color: Colors.white,
-        border: Border.all(color: const Color(0xFFDBE3E9)),
+        border: Border.all(color: EasySubwayAccessibleColors.line),
         borderRadius: BorderRadius.circular(18),
       ),
       child: Padding(
@@ -1280,14 +1264,14 @@ class _OnboardingConditionRow extends StatelessWidget {
                       title,
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
                         color: EasySubwayAccessibleColors.text,
-                        fontWeight: FontWeight.w900,
+                        fontWeight: FontWeight.w800,
                       ),
                     ),
                     const SizedBox(height: 3),
                     Text(
                       subtitle,
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: const Color(0xFF647686),
+                        color: EasySubwayAccessibleColors.mutedText,
                         fontWeight: FontWeight.w700,
                         height: 1.35,
                       ),
@@ -1295,37 +1279,34 @@ class _OnboardingConditionRow extends StatelessWidget {
                   ],
                 ),
               ),
-              DecoratedBox(
-                decoration: BoxDecoration(
-                  color: enabled
-                      ? const Color(0xFFDFF7EF)
-                      : const Color(0xFFEEF3F6),
-                  borderRadius: BorderRadius.circular(18),
-                ),
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(
-                    minWidth: 72,
-                    minHeight: 36,
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 10,
-                      vertical: 7,
-                    ),
-                    child: Center(
-                      child: Text(
-                        state,
-                        style: TextStyle(
-                          color: enabled
-                              ? const Color(0xFF0D8A6D)
-                              : const Color(0xFF647686),
-                          fontSize: 13,
-                          fontWeight: FontWeight.w800,
-                          height: 1.1,
-                        ),
+              Padding(
+                padding: const EdgeInsets.only(left: 12),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 8,
+                      height: 8,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: enabled
+                            ? EasySubwayAccessibleColors.primary
+                            : EasySubwayAccessibleColors.line,
                       ),
                     ),
-                  ),
+                    const SizedBox(width: 6),
+                    Text(
+                      state,
+                      style: TextStyle(
+                        color: enabled
+                            ? EasySubwayAccessibleColors.primary
+                            : EasySubwayAccessibleColors.mutedText,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w800,
+                        height: 1.1,
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],
@@ -1371,14 +1352,14 @@ class _OnboardingViewPreferenceSwitch extends StatelessWidget {
                       title,
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
                         color: EasySubwayAccessibleColors.text,
-                        fontWeight: FontWeight.w900,
+                        fontWeight: FontWeight.w800,
                       ),
                     ),
                     const SizedBox(height: 3),
                     Text(
                       subtitle,
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: const Color(0xFF647686),
+                        color: EasySubwayAccessibleColors.mutedText,
                         fontWeight: FontWeight.w700,
                         height: 1.35,
                       ),
@@ -1409,6 +1390,6 @@ class _OnboardingPreferenceDivider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Divider(height: 1, color: Color(0xFFDBE3E9));
+    return const Divider(height: 1, color: EasySubwayAccessibleColors.line);
   }
 }

--- a/apps/mobile/lib/production_scope.dart
+++ b/apps/mobile/lib/production_scope.dart
@@ -1,13 +1,20 @@
 class ProductionScopeCopy {
   const ProductionScopeCopy._();
 
-  static const supportedClaimKo = '상록수·사당 검증 pilot';
+  /// 안내 가능한 구간(명사구). 문장에 끼워 넣어 쓴다.
+  static const supportedRegionKo = '상록수역·사당역 구간';
+
+  /// 지원 범위 안내(문장). 앱바 부제·설정·도움말 등 단독 노출용.
+  /// 개발/운영 용어(pilot 등) 없이 사용자 언어로 쓴다.
+  static const supportedClaimKo = '지금은 $supportedRegionKo을 안내해요';
+
   static const unsupportedRegionStatus = 'UNSUPPORTED_REGION';
   static const unsupportedRegionActionKo = '다시 확인';
+
   static const routeSearchNotice =
-      '$supportedClaimKo 범위의 경로만 안내하고, 범위 밖 경로는 현장 안내를 $unsupportedRegionActionKo해 주세요.';
+      '$supportedRegionKo 길을 안내해요. 이 구간을 벗어난 경로는 아직 준비 중이에요.';
   static const stationSearchNotice =
-      '$supportedClaimKo 범위의 역 정보를 먼저 보여주고, 벗어난 지역은 $unsupportedRegionActionKo해 주세요.';
+      '$supportedRegionKo 역 정보를 먼저 보여드려요. 다른 지역은 준비되는 대로 추가할게요.';
   static const helpNotice =
-      '현재 지원 범위는 $supportedClaimKo입니다. 범위 밖 정보는 준비 중이거나 $unsupportedRegionActionKo해 주세요.';
+      '지금은 $supportedRegionKo을 안내하고 있어요. 다른 구간은 준비되는 대로 추가할게요.';
 }

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2831,11 +2831,12 @@ class _RoutePointPickerCard extends StatelessWidget {
         color: Colors.white,
         border: Border.all(color: _routeCardBorderColor),
         borderRadius: _routeSearchPickerRadius,
+        // 최소 그림자 원칙: 보더 중심으로 낮춘다.
         boxShadow: const [
           BoxShadow(
             color: _routeCardShadowColor,
-            blurRadius: 16,
-            offset: Offset(0, 5),
+            blurRadius: 8,
+            offset: Offset(0, 3),
           ),
         ],
       ),

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -734,18 +734,20 @@ class FavoriteRoute {
 
   String get summaryTitle => '$originStationName에서 $destinationStationName까지';
 
-  String get lineLabel => lineName.isEmpty ? '노선을 아직 알 수 없어요' : lineName;
+  /// 노선명(모르면 빈 문자열 — 호출부에서 줄 자체를 숨긴다).
+  String get lineLabel => lineName;
 
-  String get scoreLabel => '다시 찾으면 자세히 볼 수 있어요';
+  bool get hasLine => lineName.isNotEmpty;
 
   String get mobilityLabel => _mobilityLabelFor(mobilityType);
 
   String get etaSourceLabel => routeEtaSourceLabel(etaSource);
 
+  /// 확정 정보만: 이동 조건 · 노선(있을 때) · 최근 확인일 · 출처.
   String get scoreBasisText {
     return [
       '$mobilityLabel 조건',
-      lineLabel,
+      if (hasLine) lineLabel,
       _routeDateLabel(routeCreatedAt),
       if (etaSourceLabel.isNotEmpty) etaSourceLabel,
     ].join(' · ');
@@ -754,31 +756,19 @@ class FavoriteRoute {
   String get scoreBasisSemanticLabel {
     return [
       '$mobilityLabel 조건',
-      lineLabel,
+      if (hasLine) lineLabel,
       _routeDateLabel(routeCreatedAt),
       if (etaSourceLabel.isNotEmpty) etaSourceLabel,
     ].join(', ');
   }
 
-  String get movementMetricLabel =>
-      '예상 시간을 확인하고 있어요 · 환승 안내를 확인하고 있어요 · 걷는 거리를 확인하고 있어요';
-
-  String get accessibilityMetricLabel =>
-      '계단 여부를 아직 알 수 없어요 · 엘리베이터 연결을 아직 알 수 없어요';
-
   String get semanticLabel {
     return [
       '즐겨찾기 경로',
       summaryTitle,
-      lineLabel,
+      if (hasLine) lineLabel,
       mobilityLabel,
-      scoreLabel,
       scoreBasisSemanticLabel,
-      '예상 시간을 확인하고 있어요',
-      '환승 안내를 확인하고 있어요',
-      '걷는 거리를 확인하고 있어요',
-      '계단 여부를 아직 알 수 없어요',
-      '엘리베이터 연결을 아직 알 수 없어요',
     ].join(', ');
   }
 }
@@ -3145,6 +3135,13 @@ StationSearchLine _routeRecentLine(String name) {
 
 String _routeLineColor(String name) => fallbackLineColorHex(lineName: name);
 
+/// 기본 레벨(LEVEL_1)·미확정 품질 필러는 목록에서 감춘다(#1477과 동일 규칙).
+bool _showsRouteDataQualityLabel(String dataQualityLevel) {
+  return dataQualityLevel == 'LEVEL_2' ||
+      dataQualityLevel == 'LEVEL_3' ||
+      dataQualityLevel == 'LEVEL_4';
+}
+
 class _RouteRecentDestinationRow extends StatelessWidget {
   const _RouteRecentDestinationRow({
     required this.route,
@@ -3668,14 +3665,18 @@ class _RouteStationOptionTile extends StatelessWidget {
                               height: 1.3,
                             ),
                           ),
-                          const SizedBox(height: 4),
-                          Text(
-                            result.dataQualityLabel,
-                            style: textTheme.bodyMedium?.copyWith(
-                              color: _routeTextMutedColor,
-                              height: 1.3,
+                          if (_showsRouteDataQualityLabel(
+                            result.dataQualityLevel,
+                          )) ...[
+                            const SizedBox(height: 4),
+                            Text(
+                              result.dataQualityLabel,
+                              style: textTheme.bodyMedium?.copyWith(
+                                color: _routeTextMutedColor,
+                                height: 1.3,
+                              ),
                             ),
-                          ),
+                          ],
                         ],
                       ),
                     ),
@@ -5802,11 +5803,6 @@ class _FavoriteRouteTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final menuButtonKey =
-        GlobalKey<PopupMenuButtonState<_FavoriteRouteMenuAction>>();
-    final moreSemanticLabel =
-        '${favorite.summaryTitle} 더 보기${isRemoving ? ', 삭제 중' : ''}';
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -5843,35 +5839,20 @@ class _FavoriteRouteTile extends StatelessWidget {
               const SizedBox(width: 8),
             ],
             Semantics(
-              key: Key('favoriteRouteMore-${favorite.favoriteRouteId}'),
-              container: true,
-              label: moreSemanticLabel,
+              label: '${favorite.summaryTitle} 삭제',
               button: true,
               enabled: !isRemoving,
               onTap: isRemoving
                   ? null
-                  : () => menuButtonKey.currentState?.showButtonMenu(),
+                  : () => unawaited(_confirmRemove(context)),
               child: ExcludeSemantics(
-                child: PopupMenuButton<_FavoriteRouteMenuAction>(
-                  key: menuButtonKey,
-                  enabled: !isRemoving,
-                  tooltip: '경로 더 보기',
-                  onSelected: (action) {
-                    switch (action) {
-                      case _FavoriteRouteMenuAction.remove:
-                        unawaited(_confirmRemove(context));
-                    }
-                  },
-                  itemBuilder: (context) => [
-                    PopupMenuItem<_FavoriteRouteMenuAction>(
-                      key: Key(
-                        'favoriteRouteRemove-${favorite.favoriteRouteId}',
-                      ),
-                      value: _FavoriteRouteMenuAction.remove,
-                      child: const Text('삭제'),
-                    ),
-                  ],
-                  icon: const Icon(Icons.more_vert),
+                child: IconButton(
+                  key: Key('favoriteRouteRemove-${favorite.favoriteRouteId}'),
+                  tooltip: '삭제',
+                  onPressed: isRemoving
+                      ? null
+                      : () => unawaited(_confirmRemove(context)),
+                  icon: const Icon(Icons.delete_outline),
                 ),
               ),
             ),
@@ -5911,8 +5892,6 @@ class _FavoriteRouteTile extends StatelessWidget {
   }
 }
 
-enum _FavoriteRouteMenuAction { remove }
-
 class _FavoriteRouteSummaryCard extends StatelessWidget {
   const _FavoriteRouteSummaryCard({required this.favorite});
 
@@ -5943,59 +5922,27 @@ class _FavoriteRouteSummaryCard extends StatelessWidget {
                     favorite.summaryTitle,
                     style: textTheme.titleLarge?.copyWith(
                       color: _routeTextPrimaryColor,
-                      fontWeight: FontWeight.w900,
+                      fontWeight: FontWeight.w800,
                       height: 1.25,
                     ),
                   ),
-                  const SizedBox(height: 8),
-                  Text(
-                    favorite.lineLabel,
-                    style: textTheme.bodyLarge?.copyWith(
-                      color: _routeTextSecondaryColor,
-                      fontWeight: FontWeight.w800,
-                      height: 1.3,
+                  if (favorite.hasLine) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      favorite.lineLabel,
+                      style: textTheme.bodyLarge?.copyWith(
+                        color: _routeTextSecondaryColor,
+                        fontWeight: FontWeight.w700,
+                        height: 1.3,
+                      ),
                     ),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    favorite.mobilityLabel,
-                    style: textTheme.bodyLarge?.copyWith(
-                      color: _routeTextSecondaryColor,
-                      fontWeight: FontWeight.w800,
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    favorite.scoreLabel,
-                    style: textTheme.bodyLarge?.copyWith(
-                      color: _routeTextSecondaryColor,
-                      fontWeight: FontWeight.w800,
-                      height: 1.3,
-                    ),
-                  ),
+                  ],
                   const SizedBox(height: 6),
                   Text(
                     favorite.scoreBasisText,
                     style: textTheme.bodyMedium?.copyWith(
                       color: _routeTextMutedColor,
                       fontWeight: FontWeight.w700,
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    favorite.movementMetricLabel,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: _routeTextMutedColor,
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    favorite.accessibilityMetricLabel,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: _routeTextMutedColor,
                       height: 1.3,
                     ),
                   ),

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -58,8 +58,8 @@ const _stationDetailInfoCardRadius = BorderRadius.all(Radius.circular(16));
 const _stationDetailHelpCardRadius = BorderRadius.all(Radius.circular(16));
 const _stationDetailActionButtonRadius = BorderRadius.all(Radius.circular(12));
 const _stationDetailFacilityCardRadius = BorderRadius.all(Radius.circular(16));
-const _stationTextMutedColor = Color(0xFF405A5D);
-const _stationTextSubtleColor = Color(0xFF506B6F);
+const _stationTextMutedColor = EasySubwayAccessibleColors.secondaryText;
+const _stationTextSubtleColor = EasySubwayAccessibleColors.mutedText;
 const _stationDetailTextColor = Color(0xFF2C5558);
 const _stationDetailSoftPanelColor = Color(0xFFEAF6F4);
 const _stationDetailSoftPanelBorderColor = Color(0xFFB9D7D2);
@@ -963,6 +963,15 @@ String _dataQualityLabel(String dataQualityLevel) {
     'LEVEL_4' => '고장·공사 소식이 반영됐어요',
     _ => '정보를 준비 중이에요',
   };
+}
+
+/// 데이터 품질 라벨을 목록에 노출할지 여부.
+/// 기본 레벨(LEVEL_1)·미확정 값은 "확인 중" 같은 필러라 목록에서는 감춘다
+/// (실제 안내 역량을 뜻하는 LEVEL_2 이상만 노출). simple is best.
+bool _showsDataQualityLabel(String dataQualityLevel) {
+  return dataQualityLevel == 'LEVEL_2' ||
+      dataQualityLevel == 'LEVEL_3' ||
+      dataQualityLevel == 'LEVEL_4';
 }
 
 String _dataConfidenceLabel(String dataConfidence) {
@@ -2418,7 +2427,7 @@ class _StationRecentSearchSection extends StatelessWidget {
             '최근 검색',
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
               color: EasySubwayAccessibleColors.text,
-              fontWeight: FontWeight.w900,
+              fontWeight: FontWeight.w800,
               height: 1.25,
             ),
           ),
@@ -3203,7 +3212,7 @@ class _NearbyStationOverview extends StatelessWidget {
     final stationName = _stationResultDisplayName(result.nameKo);
     return Card(
       margin: EdgeInsets.zero,
-      color: EasySubwayAccessibleColors.skySoft,
+      color: EasySubwayAccessibleColors.surface,
       elevation: 0,
       shape: RoundedRectangleBorder(
         borderRadius: _stationDetailFacilityCardRadius,
@@ -3260,10 +3269,14 @@ class _NearbyStationOverview extends StatelessWidget {
                                     height: 1.3,
                                   ),
                             ),
-                            const SizedBox(height: 8),
-                            _StationDetailTextPill(
-                              text: result.dataQualityLabel,
-                            ),
+                            if (_showsDataQualityLabel(
+                              result.dataQualityLevel,
+                            )) ...[
+                              const SizedBox(height: 8),
+                              _StationDetailTextPill(
+                                text: result.dataQualityLabel,
+                              ),
+                            ],
                           ],
                         ),
                       ),
@@ -3473,15 +3486,19 @@ class _StationSearchResultTile extends StatelessWidget {
                                     height: 1.25,
                                   ),
                                 ),
-                                const SizedBox(height: 4),
-                                Text(
-                                  result.dataQualityLabel,
-                                  style: textTheme.bodyMedium?.copyWith(
-                                    color: _stationTextMutedColor,
-                                    fontWeight: FontWeight.w600,
-                                    height: 1.25,
+                                if (_showsDataQualityLabel(
+                                  result.dataQualityLevel,
+                                )) ...[
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    result.dataQualityLabel,
+                                    style: textTheme.bodyMedium?.copyWith(
+                                      color: _stationTextMutedColor,
+                                      fontWeight: FontWeight.w600,
+                                      height: 1.25,
+                                    ),
                                   ),
-                                ),
+                                ],
                               ],
                             ),
                           ),
@@ -3918,7 +3935,7 @@ class _FavoriteStationTile extends StatelessWidget {
                             favorite.nameKo,
                             style: textTheme.titleLarge?.copyWith(
                               color: EasySubwayAccessibleColors.text,
-                              fontWeight: FontWeight.w900,
+                              fontWeight: FontWeight.w800,
                               height: 1.25,
                             ),
                           ),
@@ -3941,14 +3958,18 @@ class _FavoriteStationTile extends StatelessWidget {
                               height: 1.3,
                             ),
                           ),
-                          const SizedBox(height: 4),
-                          Text(
-                            favorite.dataQualityLabel,
-                            style: textTheme.bodyMedium?.copyWith(
-                              color: _stationTextMutedColor,
-                              height: 1.3,
+                          if (_showsDataQualityLabel(
+                            favorite.dataQualityLevel,
+                          )) ...[
+                            const SizedBox(height: 4),
+                            Text(
+                              favorite.dataQualityLabel,
+                              style: textTheme.bodyMedium?.copyWith(
+                                color: _stationTextMutedColor,
+                                height: 1.3,
+                              ),
                             ),
-                          ),
+                          ],
                         ],
                       ),
                     ),

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -1402,8 +1402,10 @@ void main() {
     expect(favorites.single.summaryTitle, '상록수에서 사당까지');
     expect(saved.favoriteRouteId, 'route-1');
     expect(saved.mobilityLabel, '천천히 이동');
-    expect(saved.scoreLabel, '다시 찾으면 자세히 볼 수 있어요');
-    expect(saved.scoreLabel, isNot(contains('92점')));
+    // 플레이스홀더(score/이동·접근성 메트릭) 문구는 카드·시맨틱에서 제거됐다(#1488).
+    expect(saved.semanticLabel, contains('상록수에서 사당까지'));
+    expect(saved.semanticLabel, isNot(contains('92점')));
+    expect(saved.semanticLabel, isNot(contains('아직 알 수 없어요')));
   });
 
   test('경로 피드백 API 저장소는 익명 사용자 식별자와 평가를 전송한다', () async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5630,30 +5630,25 @@ void main() {
       expect(find.text('즐겨찾기한 경로'), findsOneWidget);
       expect(find.text('상록수에서 사당까지'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
-      expect(find.text('천천히 이동'), findsOneWidget);
       expect(find.text('이동 편의도 92점'), findsNothing);
-      expect(find.text('다시 찾으면 자세히 볼 수 있어요'), findsOneWidget);
+      // 고정 플레이스홀더 문구는 카드에서 제거됐다(#1488).
+      expect(find.text('다시 찾으면 자세히 볼 수 있어요'), findsNothing);
       expect(
         find.text('천천히 이동 조건 · 수도권 4호선 · 최근 확인 2026-06-13 · 도착 정보를 확인하고 있어요'),
         findsOneWidget,
       );
       expect(
         find.text('예상 시간을 확인하고 있어요 · 환승 안내를 확인하고 있어요 · 걷는 거리를 확인하고 있어요'),
-        findsOneWidget,
+        findsNothing,
       );
       expect(
         find.text('계단 여부를 아직 알 수 없어요 · 엘리베이터 연결을 아직 알 수 없어요'),
-        findsOneWidget,
+        findsNothing,
       );
-      expect(find.text('상록수에서 사당까지'), findsOneWidget);
-      expect(find.bySemanticsLabel('상록수에서 사당까지 더 보기'), findsOneWidget);
+      // 항목 1개짜리 더 보기 메뉴 → 삭제 아이콘 버튼으로 단순화(#1488).
       expect(
-        tester.getSemantics(find.bySemanticsLabel('상록수에서 사당까지 더 보기')),
-        isSemantics(
-          label: '상록수에서 사당까지 더 보기',
-          isButton: true,
-          hasTapAction: true,
-        ),
+        find.byKey(const Key('favoriteRouteRemove-route-1')),
+        findsOneWidget,
       );
       expect(
         find.byKey(const Key('favoriteRouteSearchAgain-route-1')),
@@ -5680,8 +5675,6 @@ void main() {
         },
       );
 
-      await tester.tap(find.byKey(const Key('favoriteRouteMore-route-1')));
-      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('favoriteRouteRemove-route-1')));
       await tester.pumpAndSettle();
       expect(find.text('즐겨찾기 경로 삭제'), findsOneWidget);
@@ -5728,8 +5721,6 @@ void main() {
 
     await _openFavoriteList(tester);
 
-    await tester.tap(find.byKey(const Key('favoriteRouteMore-route-1')));
-    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('favoriteRouteRemove-route-1')));
     await tester.pumpAndSettle();
     await tester.tap(
@@ -5739,9 +5730,12 @@ void main() {
 
     expect(favoriteRouteRepository.removedFavoriteRouteIds, ['route-1']);
     expect(find.text('삭제 중'), findsOneWidget);
-    expect(find.bySemanticsLabel('상록수에서 사당까지 더 보기, 삭제 중'), findsOneWidget);
 
-    await tester.tap(find.byKey(const Key('favoriteRouteMore-route-1')));
+    // 삭제 중에는 삭제 버튼이 비활성화되어 다시 눌러도 재요청되지 않는다.
+    await tester.tap(
+      find.byKey(const Key('favoriteRouteRemove-route-1')),
+      warnIfMissed: false,
+    );
     await tester.pump();
 
     expect(favoriteRouteRepository.removedFavoriteRouteIds, ['route-1']);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -7209,7 +7209,10 @@ void main() {
       final nearbyButtonSize = tester.getSize(
         find.byKey(const Key('nearbyStationSearchButton')),
       );
-      expect(nearbyButtonSize.height, greaterThanOrEqualTo(60));
+      expect(
+        nearbyButtonSize.height,
+        greaterThanOrEqualTo(EasySubwayTouchTarget.general),
+      );
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3343,6 +3343,34 @@ void main() {
     expect(locationProvider.requestCount, 0);
   });
 
+  testWidgets('노선도 좌측 메뉴에서 설정 화면으로 들어갈 수 있다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('networkMapMenuButton')));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('networkMapMenuSettingsButton')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('networkMapMenuSettingsButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppSettingsScreen), findsOneWidget);
+  });
+
   testWidgets('가까운 역 화면은 위치 실패 후 역명 검색 입력을 보여준다', (tester) async {
     final locationProvider = FakeCurrentLocationProvider(
       error: const CurrentLocationException('현재 위치를 확인하지 못했어요.'),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -990,7 +990,8 @@ void main() {
         matching: find.text('수도권'),
       ),
     );
-    expect(regionText.overflow, isNot(TextOverflow.ellipsis));
+    // 지역명은 FittedBox 축소 대신 말줄임으로 가독성을 유지한다(#1487).
+    expect(regionText.overflow, TextOverflow.ellipsis);
     expect(find.text('전국'), findsNothing);
     expect(
       tester.getSize(find.byKey(const Key('mapRegionTabs'))).height,
@@ -3092,11 +3093,13 @@ void main() {
     final requested = repository.requestedNearbyLocations.single;
     expect(requested.latitude, closeTo(37.3028, 0.0001));
     expect(requested.longitude, closeTo(126.8665, 0.0001));
-    expect(find.text('실시간'), findsOneWidget);
+    // 실시간 미연동(UnavailableRealtimeRepository) 상태에서는 "실시간" 뱃지와
+    // "-" 자리표시 대신 한 줄 안내만 보여준다.
+    expect(find.text('실시간'), findsNothing);
     expect(find.text('상록수'), findsOneWidget);
     expect(find.textContaining('반월'), findsOneWidget);
     expect(find.textContaining('한대앞'), findsOneWidget);
-    expect(find.text('-'), findsWidgets);
+    expect(find.textContaining('이용할 수 있습니다'), findsOneWidget);
     expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
   });
 
@@ -3206,11 +3209,59 @@ void main() {
     );
     expect(find.text('현재 위치를 확인하지 못했어요.'), findsOneWidget);
 
-    await tester.pump(const Duration(milliseconds: 1900));
+    await tester.pump(const Duration(seconds: 5));
     await tester.pumpAndSettle();
 
     expect(find.text('현재 위치를 확인하지 못했어요.'), findsNothing);
     expect(find.byKey(const Key('networkMapNearbyStationPanel')), findsNothing);
+  });
+
+  testWidgets('노선도 주변역 패널은 실시간 도착 정보를 방향별로 보여준다', (tester) async {
+    final locationProvider = FakeCurrentLocationProvider(
+      location: _freshCurrentLocation(),
+      needsPermissionRequest: false,
+    );
+    final repository = FakeStationSearchRepository(
+      nearbyResults: [
+        _stationResult(
+          id: 'station-sangnoksu',
+          name: '상록수',
+          distanceMeters: 230,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        locationProvider: locationProvider,
+        realtimeRepository: const _FreshNearbyRealtimeRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('networkMapNearbyStationPanel')),
+      findsOneWidget,
+    );
+    // FRESH 상태에서만 "실시간" 뱃지가 노출되고, 도착 정보가 방향별로 표시된다.
+    expect(find.text('실시간'), findsOneWidget);
+    expect(find.text('상행'), findsOneWidget);
+    expect(find.text('하행'), findsOneWidget);
+    expect(find.text('한대앞행'), findsOneWidget);
+    expect(find.text('사당행'), findsOneWidget);
+    expect(find.text('약 3분'), findsOneWidget);
+    expect(find.text('약 5분'), findsOneWidget);
   });
 
   testWidgets('노선도는 위치 권한이 이미 있으면 가까운 역 중심 viewport를 저장한다', (tester) async {
@@ -12973,6 +13024,38 @@ CurrentLocation _freshCurrentLocation({
     provider: 'test',
     permissionPrecision: LocationPermissionPrecision.precise,
   );
+}
+
+class _FreshNearbyRealtimeRepository implements RealtimeRepository {
+  const _FreshNearbyRealtimeRepository();
+
+  @override
+  Future<RealtimeSnapshot> arrivals(RealtimeStationQuery query) async {
+    return const RealtimeSnapshot(
+      status: RealtimeSnapshotStatus.fresh,
+      receivedAt: '방금',
+      arrivals: [
+        RealtimeArrival(
+          lineId: 'seoul-2',
+          stationName: '상록수',
+          destination: '한대앞',
+          direction: '상행',
+          trainNo: '2001',
+          message: '',
+          etaSeconds: 180,
+        ),
+        RealtimeArrival(
+          lineId: 'seoul-2',
+          stationName: '상록수',
+          destination: '사당',
+          direction: '하행',
+          trainNo: '2002',
+          message: '',
+          etaSeconds: 300,
+        ),
+      ],
+    );
+  }
 }
 
 class FakeCurrentLocationProvider implements CurrentLocationProvider {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3100,6 +3100,29 @@ void main() {
     expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
   });
 
+  testWidgets('노선도 좌측 메뉴 하단에 광고 슬롯이 있다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('networkMapMenuButton')));
+    await tester.pumpAndSettle();
+
+    // debug 빌드에서는 자리 확인용 슬롯이 패널 하단에 렌더링된다.
+    // (release에서는 실광고가 없으면 collapse — 노출 규칙은 #1485)
+    expect(find.byKey(const Key('networkMapMenuAdBanner')), findsOneWidget);
+  });
+
   testWidgets('노선도 chrome은 시스템 글자 크기를 따른다', (tester) async {
     tester.platformDispatcher.textScaleFactorTestValue = 2;
     addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5444,7 +5444,8 @@ void main() {
       expect(find.text('즐겨찾기한 역'), findsOneWidget);
       expect(find.text('상록수'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
-      expect(find.text('일부 정보는 확인 중이에요'), findsOneWidget);
+      // 기본 레벨(LEVEL_1) 품질 필러는 목록에서 감춘다(#1477). 시맨틱에는 유지.
+      expect(find.text('일부 정보는 확인 중이에요'), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '출발지로 설정'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '도착지로 설정'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '역 상세 보기'), findsOneWidget);
@@ -5912,7 +5913,8 @@ void main() {
       );
       expect(find.text('수도권 4호선, 경의중앙선'), findsOneWidget);
       expect(find.text('수도권'), findsNothing);
-      expect(find.text('일부 정보는 확인 중이에요'), findsOneWidget);
+      // 기본 레벨(LEVEL_1) 품질 필러는 목록에서 감춘다(#1477). 시맨틱에는 유지.
+      expect(find.text('일부 정보는 확인 중이에요'), findsNothing);
       expect(find.text('출처 확인 필요'), findsNothing);
       expect(find.bySemanticsLabel('검색 결과 1개'), findsOneWidget);
       expect(
@@ -6025,7 +6027,6 @@ void main() {
     for (final text in [
       '$longStationName역',
       '현재 위치에서 1.3km · 수도권 9호선 급행, 공항철도 직통 일반 공용',
-      '일부 정보는 확인 중이에요',
     ]) {
       final widget = tester.widget<Text>(find.text(text));
       expect(widget.maxLines, isNot(1));
@@ -7645,7 +7646,8 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
       await tester.pumpAndSettle();
-      expect(find.text('일부 정보는 확인 중이에요'), findsOneWidget);
+      // 기본 레벨(LEVEL_1) 품질 필러는 목록에서 감춘다(#1477). 시맨틱에는 유지.
+      expect(find.text('일부 정보는 확인 중이에요'), findsNothing);
       expect(find.text('출처 공식 파일'), findsNothing);
       expect(
         find.bySemanticsLabel('상록수역, 수도권 2호선, 수도권, 일부 정보는 확인 중이에요'),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1158,7 +1158,7 @@ void main() {
     await tester.pump();
     await tester.scrollUntilVisible(find.text('지도 표시용 파일'), 240);
     expect(find.text('지도 표시용 파일'), findsOneWidget);
-    expect(find.text('상록수·사당 검증 pilot'), findsOneWidget);
+    expect(find.text('지금은 상록수역·사당역 구간을 안내해요'), findsOneWidget);
   });
 
   testWidgets('노선도 지역 메뉴는 선택한 지역으로 지도를 다시 불러온다', (tester) async {
@@ -3789,7 +3789,7 @@ void main() {
 
     expect(find.text('저장된 안내 상태'), findsOneWidget);
     expect(find.text('검증 구간'), findsOneWidget);
-    expect(find.text('상록수·사당 검증 pilot'), findsNWidgets(2));
+    expect(find.text('지금은 상록수역·사당역 구간을 안내해요'), findsNWidgets(2));
     expect(find.text('마지막 갱신'), findsOneWidget);
     expect(find.text('앱 설치 때 함께 받은 안내'), findsOneWidget);
     expect(find.text('저장 정보 다시 확인'), findsOneWidget);
@@ -5921,7 +5921,7 @@ void main() {
       expect(
         find.descendant(
           of: find.byType(AppBar),
-          matching: find.text('상록수·사당 검증 pilot'),
+          matching: find.text('지금은 상록수역·사당역 구간을 안내해요'),
         ),
         findsOneWidget,
       );
@@ -6209,7 +6209,7 @@ void main() {
       expect(
         find.descendant(
           of: find.byType(AppBar),
-          matching: find.text('상록수·사당 검증 pilot'),
+          matching: find.text('지금은 상록수역·사당역 구간을 안내해요'),
         ),
         findsOneWidget,
       );
@@ -7957,7 +7957,7 @@ void main() {
     expect(
       find.descendant(
         of: find.byType(AppBar),
-        matching: find.text('상록수·사당 검증 pilot'),
+        matching: find.text('지금은 상록수역·사당역 구간을 안내해요'),
       ),
       findsOneWidget,
     );

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1155,8 +1155,8 @@ void main() {
     expect(find.text('데이터 및 지도 출처'), findsOneWidget);
     await tester.pump();
     await tester.pump();
-    await tester.scrollUntilVisible(find.text('지도 표시용 asset'), 240);
-    expect(find.text('지도 표시용 asset'), findsOneWidget);
+    await tester.scrollUntilVisible(find.text('지도 표시용 파일'), 240);
+    expect(find.text('지도 표시용 파일'), findsOneWidget);
     expect(find.text('상록수·사당 검증 pilot'), findsOneWidget);
   });
 


### PR DESCRIPTION
## Summary

모든 OutlinedButton이 primary 2px 보더 + 높이 60으로 주 행동만큼 강조되던 문제를 정리했습니다. 주 행동 1개만 강하게(채움), 보조는 조용하게. (#1491)

- **OutlinedButton 전역 테마 재정의**: primary 2px 보더 → 중립 얇은 보더(`line` 토큰, 1.5px) + `primary` 텍스트, 높이 `EasySubwayTouchTarget.general`(56). FilledButton(주 행동)과 시각 강도를 분리.
- **버튼 높이 토큰화**: 테마의 매직넘버 60을 `EasySubwayTouchTarget.primary`(FilledButton) / `.general`(OutlinedButton) 토큰으로.
- **고대비 대비 보정**: 보조 버튼이 중립 보더로 바뀌었으므로 `_themeForPreferences`에서 고대비 모드일 때 보더·텍스트를 고대비 색으로 override(텍스트 대비 유지).

## Verification

- `dart format` · `flutter analyze lib` → **No issues found**
- `flutter test` → **617 passed, 0 failed**
- 주변역 찾기 버튼 높이 회귀 테스트를 새 보조 버튼 기준(56, `EasySubwayTouchTarget.general`)으로 갱신.

## Notes

- 토대 PR(#1498, 팔레트 토큰) 위에 스택합니다. base 병합 후 `main`으로 재지정 예정.
- 개별 화면의 버튼 개수 축소(예: 즐겨찾기 역 카드 5버튼)와 레거시 히어로 홈의 버튼 오버라이드는 트래커 방침대로 각 화면 이슈(#1477, #1483 등)에서 정리합니다. 노선 필터 칩·'변경' 같은 컴팩트/상태 토글 버튼은 의도된 예외로 유지했습니다.
- 순수 테마 변경으로 로직·API 영향은 없습니다.