### PR TITLE
[Style] 좌측 메뉴에 설정 진입점 추가(설정 도달 불가 해소)

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1622,6 +1622,7 @@ class _HomeScreenState extends State<HomeScreen> {
               unawaited(openStationSearch(StationSearchEntryMode.recent)),
           onOpenNearbyStations: () =>
               unawaited(openStationSearch(StationSearchEntryMode.nearby)),
+          onOpenSettings: openMoreTab,
           onOpenDataSources: openDataSources,
           notificationAction: notificationRepository == null
               ? null

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -314,6 +314,7 @@ class NetworkMapScreen extends StatefulWidget {
     this.onOpenSavedItems,
     this.onOpenRecentSearch,
     this.onOpenNearbyStations,
+    this.onOpenSettings,
     this.onOpenDataSources,
     this.notificationAction,
     this.bottomNavigationBar,
@@ -330,6 +331,7 @@ class NetworkMapScreen extends StatefulWidget {
   final VoidCallback? onOpenSavedItems;
   final VoidCallback? onOpenRecentSearch;
   final VoidCallback? onOpenNearbyStations;
+  final VoidCallback? onOpenSettings;
   final VoidCallback? onOpenDataSources;
   final Widget? notificationAction;
   final Widget? bottomNavigationBar;
@@ -651,6 +653,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
           onOpenSavedItems: widget.onOpenSavedItems,
           onOpenNearbyStations: widget.onOpenNearbyStations,
           onOpenRecentSearch: widget.onOpenRecentSearch,
+          onOpenSettings: widget.onOpenSettings,
           onOpenDataSources: widget.onOpenDataSources,
         );
       },
@@ -1679,6 +1682,7 @@ class _NetworkMapMenuPanel extends StatelessWidget {
     required this.onOpenSavedItems,
     required this.onOpenNearbyStations,
     required this.onOpenRecentSearch,
+    required this.onOpenSettings,
     required this.onOpenDataSources,
   });
 
@@ -1687,6 +1691,7 @@ class _NetworkMapMenuPanel extends StatelessWidget {
   final VoidCallback? onOpenSavedItems;
   final VoidCallback? onOpenNearbyStations;
   final VoidCallback? onOpenRecentSearch;
+  final VoidCallback? onOpenSettings;
   final VoidCallback? onOpenDataSources;
 
   void _runAction(BuildContext context, VoidCallback action) {
@@ -1749,14 +1754,22 @@ class _NetworkMapMenuPanel extends StatelessWidget {
                     label: '최근 검색',
                     onTap: () => _runAction(context, onOpenRecentSearch!),
                   ),
-                if (onOpenSavedItems != null) ...[
+                if (onOpenSavedItems != null || onOpenSettings != null) ...[
                   const _NetworkMapMenuSectionLabel('내 정보'),
-                  _NetworkMapMenuTile(
-                    key: const Key('networkMapMenuSavedButton'),
-                    icon: Icons.star_border_rounded,
-                    label: '즐겨찾기',
-                    onTap: () => _runAction(context, onOpenSavedItems!),
-                  ),
+                  if (onOpenSavedItems != null)
+                    _NetworkMapMenuTile(
+                      key: const Key('networkMapMenuSavedButton'),
+                      icon: Icons.star_border_rounded,
+                      label: '즐겨찾기',
+                      onTap: () => _runAction(context, onOpenSavedItems!),
+                    ),
+                  if (onOpenSettings != null)
+                    _NetworkMapMenuTile(
+                      key: const Key('networkMapMenuSettingsButton'),
+                      icon: Icons.settings_outlined,
+                      label: '설정',
+                      onTap: () => _runAction(context, onOpenSettings!),
+                    ),
                 ],
                 if (onOpenDataSources != null) ...[
                   const _NetworkMapMenuSectionLabel('안내'),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3269,6 +3269,34 @@ void main() {
     expect(locationProvider.requestCount, 0);
   });
 
+  testWidgets('노선도 좌측 메뉴에서 설정 화면으로 들어갈 수 있다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('networkMapMenuButton')));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const Key('networkMapMenuSettingsButton')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const Key('networkMapMenuSettingsButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppSettingsScreen), findsOneWidget);
+  });
+
   testWidgets('가까운 역 화면은 위치 실패 후 역명 검색 입력을 보여준다', (tester) async {
     final locationProvider = FakeCurrentLocationProvider(
       error: const CurrentLocationException('현재 위치를 확인하지 못했어요.'),


### PR DESCRIPTION
## Summary

정상 구성에서 설정(더보기) 화면에 도달할 경로가 없던 P0 문제를 해소했습니다. 좌측 메뉴(공식 내비게이션)에 설정 진입점을 추가합니다. (#1494)

- **`NetworkMapScreen`에 `onOpenSettings` 콜백 추가** → HomeScreen에서 `openMoreTab`(설정 탭)으로 연결.
- **좌측 메뉴 "내 정보" 섹션에 "설정" 타일 추가**: 기존 `_NetworkMapMenuTile` 패턴 + 아웃라인 아이콘(`Icons.settings_outlined`). 즐겨찾기 아래, 사용 빈도 순(탐색 → 내 정보 → 안내)에 맞게 배치.
- **항상 도달 가능**: 즐겨찾기 저장소가 모두 없는 구성에서도 "내 정보" 섹션이 설정만으로 렌더링되도록 조건을 조정.

## Verification

- `dart format` · `flutter analyze lib test` → **No issues found**
- `flutter test` → **618 passed, 0 failed** (메뉴 → 설정 → `AppSettingsScreen` 도달 테스트 1건 추가)

## Notes

- 토대 PR(#1500) 위에 스택합니다. base 병합 후 `main`으로 재지정 예정.
- "자료 제공 정보" 메뉴 항목은 #1462에서 의도적으로 연결한 빠른 진입점이라 이번엔 유지했습니다(설정 안 "데이터 및 지도 출처"와 중복이나 저마찰 shortcut). 폴백 경로(`openSavedTab`/알림 버튼) 단순화는 레거시 히어로 제거(#1483)와 함께 정리합니다.