### PR TITLE
[Test] route graph coverage gate 연결

### DIFF
--- a/apps/mobile/release/route-commercialization-gate.json
+++ b/apps/mobile/release/route-commercialization-gate.json
@@ -10,6 +10,7 @@
     "accuracy": "artifacts/route-accuracy-report.json",
     "accessibility": "artifacts/route-accessibility-regression-report.json",
     "coverage": "artifacts/realtime-provider-coverage-report.json",
+    "routeGraphCoverage": "artifacts/route-graph-coverage-report.json",
     "contract": "artifacts/route-v2-contract-report.json"
   },
   "routeEtaAccuracy": {

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -81,6 +81,7 @@ test("route commercialization release gate blocks unsupported commercial route c
   const readme = read("README.md");
   const prTemplate = read(".github/pull_request_template.md");
   const contractReportBuilder = "tools/routes/build-route-v2-contract-report.mjs";
+  const routeGraphCoverageBuilder = "tools/routes/build-route-graph-coverage-report.mjs";
 
   assert.equal(gate.schemaVersion, 1);
   assert.equal(gate.applicationId, "easysubway");
@@ -117,11 +118,13 @@ test("route commercialization release gate blocks unsupported commercial route c
     accuracy: "artifacts/route-accuracy-report.json",
     accessibility: "artifacts/route-accessibility-regression-report.json",
     coverage: "artifacts/realtime-provider-coverage-report.json",
+    routeGraphCoverage: "artifacts/route-graph-coverage-report.json",
     contract: "artifacts/route-v2-contract-report.json",
   });
   assert.deepEqual(gate.outOfStationTransferReleaseBlockers, ["D-2", "D-3", "H-1"]);
 
   assert.equal(existsSync(path.join(root, contractReportBuilder)), true, "route v2 contract report builder must exist");
+  assert.equal(existsSync(path.join(root, routeGraphCoverageBuilder)), true, "route graph coverage report builder must exist");
   assert.match(readme, /Route commercialization gate/);
   assert.match(readme, /apps\/mobile\/release\/route-commercialization-gate\.json/);
   assert.match(readme, /tools\/routes\/build-route-v2-contract-report\.mjs/);

--- a/tools/routes/build-route-graph-coverage-report.mjs
+++ b/tools/routes/build-route-graph-coverage-report.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+export async function main(argv) {
+  const args = parseArgs(argv);
+  if (!args.input) throw new Error("usage: build-route-graph-coverage-report.mjs --input <coverage-input.json> [--output <report.json>]");
+  const input = JSON.parse(await readFile(args.input, "utf8"));
+  const report = buildRouteGraphCoverageReport(input);
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+  if (args.output) {
+    await writeFile(args.output, json);
+  } else {
+    process.stdout.write(json);
+  }
+  return report;
+}
+
+export function buildRouteGraphCoverageReport(input) {
+  const generatedConnectors = Array.isArray(input.generatedConnectors) ? input.generatedConnectors : [];
+  const strictOdResults = Array.isArray(input.strictOdResults) ? input.strictOdResults : [];
+  return {
+    schemaVersion: 1,
+    generatedConnector: {
+      byStation: aggregate(generatedConnectors, ["stationId", "lineId", "edgeType", "region", "operatorId"]),
+      byRegion: aggregate(generatedConnectors, ["region", "operatorId"]),
+    },
+    generatedConnectorVerifiedAccessibilityCount: generatedConnectors
+      .filter((row) => row.generated === true && row.verifiedAccessibility === true).length,
+    strictRouteNotFound: strictRouteNotFound(strictOdResults),
+    priorityBacklog: strictOdResults
+      .filter((row) => row.found === false && row.priority === "HIGH")
+      .map((row) => ({
+        odId: row.odId,
+        originStationId: row.originStationId,
+        destinationStationId: row.destinationStationId,
+        reasonCode: row.reasonCode ?? "ROUTE_GRAPH_UNKNOWN",
+      })),
+  };
+}
+
+function aggregate(rows, keys) {
+  const byKey = new Map();
+  for (const row of rows) {
+    const key = keys.map((field) => row[field] ?? "").join("\0");
+    const current = byKey.get(key) ?? Object.fromEntries(keys.map((field) => [field, row[field] ?? ""]));
+    current.generatedCount = (current.generatedCount ?? 0) + (row.generated === true ? 1 : 0);
+    current.explicitCount = (current.explicitCount ?? 0) + (row.generated === true ? 0 : 1);
+    byKey.set(key, current);
+  }
+  return [...byKey.values()]
+    .map((row) => ({ ...row, ratio: ratio(row.generatedCount, row.generatedCount + row.explicitCount) }))
+    .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+}
+
+function strictRouteNotFound(rows) {
+  const notFound = rows.filter((row) => row.found === false);
+  const byReasonCode = {};
+  for (const row of notFound) {
+    const reasonCode = row.reasonCode ?? "ROUTE_GRAPH_UNKNOWN";
+    byReasonCode[reasonCode] = (byReasonCode[reasonCode] ?? 0) + 1;
+  }
+  return {
+    total: rows.length,
+    notFoundCount: notFound.length,
+    rate: ratio(notFound.length, rows.length),
+    byReasonCode,
+  };
+}
+
+function ratio(count, total) {
+  return total === 0 ? 0 : count / total;
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    if (!key.startsWith("--")) throw new Error(`unexpected argument: ${key}`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`missing value for ${key}`);
+    parsed[key.slice(2)] = value;
+    index += 1;
+  }
+  return parsed;
+}

--- a/tools/routes/build-route-graph-coverage-report.test.mjs
+++ b/tools/routes/build-route-graph-coverage-report.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { buildRouteGraphCoverageReport } from "./build-route-graph-coverage-report.mjs";
+
+const execFileAsync = promisify(execFile);
+
+test("builds generated connector and strict route-not-found coverage report", () => {
+  const report = buildRouteGraphCoverageReport({
+    generatedConnectors: [
+      { stationId: "station-a", lineId: "line-4", edgeType: "entry", region: "수도권", operatorId: "seoul-metro", generated: true, verifiedAccessibility: false },
+      { stationId: "station-a", lineId: "line-4", edgeType: "entry", region: "수도권", operatorId: "seoul-metro", generated: false, verifiedAccessibility: true },
+      { stationId: "station-b", lineId: "line-2", edgeType: "inStationTransfer", region: "수도권", operatorId: "seoul-metro", generated: true, verifiedAccessibility: false },
+    ],
+    strictOdResults: [
+      { odId: "od-1", originStationId: "station-a", destinationStationId: "station-b", found: true },
+      { odId: "od-2", originStationId: "station-a", destinationStationId: "station-c", found: false, reasonCode: "GENERATED_CONNECTOR_UNVERIFIED", priority: "HIGH" },
+    ],
+  });
+
+  assert.equal(report.schemaVersion, 1);
+  assert.deepEqual(report.generatedConnector.byStation[0], {
+    stationId: "station-a",
+    lineId: "line-4",
+    edgeType: "entry",
+    region: "수도권",
+    operatorId: "seoul-metro",
+    generatedCount: 1,
+    explicitCount: 1,
+    ratio: 0.5,
+  });
+  assert.deepEqual(report.generatedConnector.byRegion, [
+    { region: "수도권", operatorId: "seoul-metro", generatedCount: 2, explicitCount: 1, ratio: 2 / 3 },
+  ]);
+  assert.equal(report.generatedConnectorVerifiedAccessibilityCount, 0);
+  assert.deepEqual(report.strictRouteNotFound, {
+    total: 2,
+    notFoundCount: 1,
+    rate: 0.5,
+    byReasonCode: { GENERATED_CONNECTOR_UNVERIFIED: 1 },
+  });
+  assert.deepEqual(report.priorityBacklog, [
+    {
+      odId: "od-2",
+      originStationId: "station-a",
+      destinationStationId: "station-c",
+      reasonCode: "GENERATED_CONNECTOR_UNVERIFIED",
+    },
+  ]);
+});
+
+test("writes route graph coverage report json", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "route-graph-coverage-"));
+  const input = path.join(dir, "coverage-input.json");
+  const output = path.join(dir, "route-graph-coverage-report.json");
+  await writeFile(input, JSON.stringify({ generatedConnectors: [], strictOdResults: [] }));
+
+  await execFileAsync(process.execPath, ["tools/routes/build-route-graph-coverage-report.mjs", "--input", input, "--output", output]);
+
+  const report = JSON.parse(await readFile(output, "utf8"));
+  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.strictRouteNotFound.rate, 0);
+});

--- a/tools/routes/check-route-commercialization-gate.mjs
+++ b/tools/routes/check-route-commercialization-gate.mjs
@@ -16,13 +16,14 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
 async function main(argv) {
   const args = parseArgs(argv);
   const gatePath = args.gate ?? args._[0];
-  if (!gatePath) throw new Error("usage: check-route-commercialization-gate.mjs --gate <gate.json> --accuracy <report.json> --accessibility <report.json> --coverage <report.json> --contract <report.json>");
+  if (!gatePath) throw new Error("usage: check-route-commercialization-gate.mjs --gate <gate.json> --accuracy <report.json> --accessibility <report.json> --coverage <report.json> --routeGraphCoverage <report.json> --contract <report.json>");
 
   const gate = await readJson(gatePath);
   const reportPaths = {
     accuracy: args.accuracy ?? gate.requiredReports?.accuracy,
     accessibility: args.accessibility ?? gate.requiredReports?.accessibility,
     coverage: args.coverage ?? gate.requiredReports?.coverage,
+    routeGraphCoverage: args.routeGraphCoverage ?? gate.requiredReports?.routeGraphCoverage,
     contract: args.contract ?? gate.requiredReports?.contract,
   };
   const failures = validateGate(gate);
@@ -42,6 +43,7 @@ async function main(argv) {
   if (reports.accuracy) validateAccuracy(gate, reports.accuracy, failures);
   if (reports.accessibility) validateAccessibility(gate, reports.accessibility, failures);
   if (reports.coverage) validateCoverage(gate, reports.coverage, failures);
+  if (reports.routeGraphCoverage) validateRouteGraphCoverage(gate, reports.routeGraphCoverage, failures);
   if (reports.contract) validateContract(gate, reports.contract, failures);
 
   return {
@@ -79,7 +81,7 @@ function validateGate(gate) {
   if (gate.schemaVersion !== 1) failures.push("gate schemaVersion must be 1");
   if (gate.releaseGate !== "route-commercialization") failures.push("gate releaseGate must be route-commercialization");
   if (gate.releaseBlockerPolicy !== true) failures.push("gate releaseBlockerPolicy must be true");
-  for (const key of ["accuracy", "accessibility", "coverage", "contract"]) {
+  for (const key of ["accuracy", "accessibility", "coverage", "routeGraphCoverage", "contract"]) {
     if (typeof gate.requiredReports?.[key] !== "string") failures.push(`gate requiredReports.${key} must be set`);
   }
   return failures;
@@ -131,6 +133,14 @@ function validateCoverage(gate, report, failures) {
   if (gate.realtimeCoverage.staleFallbackRequired && report.staleFallbackRequired !== true) {
     failures.push("realtimeCoverage stale fallback must be required");
   }
+}
+
+function validateRouteGraphCoverage(gate, report, failures) {
+  if (report.schemaVersion !== 1) failures.push("route graph coverage report schemaVersion must be 1");
+  if (!gate.accessibility.generatedConnectorAsVerifiedAllowed && number(report.generatedConnectorVerifiedAccessibilityCount) > 0) {
+    failures.push("route graph generated connector verified count exceeds 0");
+  }
+  max(report.strictRouteNotFound?.rate, gate.routeQuality.routeNotFoundRateMax, "route graph strict route not found rate", failures);
 }
 
 function validateContract(gate, report, failures) {

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -40,6 +40,11 @@ test("route commercialization gate passes with production-ready reports", async 
       providerFreshnessSecondsMaxObserved: 80,
       staleFallbackRequired: true,
     },
+    routeGraphCoverage: {
+      schemaVersion: 1,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      strictRouteNotFound: { total: 100, notFoundCount: 1, rate: 0.01, byReasonCode: {} },
+    },
     contract: {
       schemaVersion: 1,
       multiTransferSupported: false,
@@ -90,6 +95,16 @@ test("route commercialization gate fails closed for fixture-only or unsafe route
       providerFreshnessSecondsMaxObserved: 120,
       staleFallbackRequired: false,
     },
+    routeGraphCoverage: {
+      schemaVersion: 1,
+      generatedConnectorVerifiedAccessibilityCount: 1,
+      strictRouteNotFound: {
+        total: 100,
+        notFoundCount: 5,
+        rate: 0.05,
+        byReasonCode: { GENERATED_CONNECTOR_UNVERIFIED: 5 },
+      },
+    },
     contract: {
       schemaVersion: 1,
       multiTransferSupported: false,
@@ -111,6 +126,8 @@ test("route commercialization gate fails closed for fixture-only or unsafe route
       assert.ok(report.failures.includes("routeEtaAccuracy production sampleSize is below 100"));
       assert.ok(report.failures.includes("accessibility strict step-free false positive count exceeds 0"));
       assert.ok(report.failures.includes("accessibility generated connector verified count exceeds 0"));
+      assert.ok(report.failures.includes("route graph generated connector verified count exceeds 0"));
+      assert.ok(report.failures.includes("route graph strict route not found rate exceeds 0.02"));
       assert.ok(!report.failures.includes("routing D-3 blocker must be satisfied before out-of-station transfer release claim"));
       return true;
     },
@@ -146,6 +163,11 @@ test("route commercialization gate keeps legacy production sample fallback", asy
       supportedStationLinePairs: 150,
       providerFreshnessSecondsMaxObserved: 80,
       staleFallbackRequired: true,
+    },
+    routeGraphCoverage: {
+      schemaVersion: 1,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      strictRouteNotFound: { total: 100, notFoundCount: 1, rate: 0.01, byReasonCode: {} },
     },
     contract: {
       schemaVersion: 1,
@@ -184,6 +206,7 @@ async function writeFixtureSet(reports) {
     accuracy: path.join(dir, "route-accuracy-report.json"),
     accessibility: path.join(dir, "route-accessibility-regression-report.json"),
     coverage: path.join(dir, "realtime-provider-coverage-report.json"),
+    routeGraphCoverage: path.join(dir, "route-graph-coverage-report.json"),
     contract: path.join(dir, "route-v2-contract-report.json"),
   };
   await Promise.all(Object.entries(reports).map(([key, report]) => writeFile(files[key], `${JSON.stringify(report, null, 2)}\n`)));
@@ -201,6 +224,8 @@ function execChecker(files) {
     files.accessibility,
     "--coverage",
     files.coverage,
+    "--routeGraphCoverage",
+    files.routeGraphCoverage,
     "--contract",
     files.contract,
   ], { cwd: root });


### PR DESCRIPTION
## Summary
- generated connector와 strict route-not-found를 집계하는 `route-graph-coverage-report.json` builder 추가.
- route commercialization gate에 `routeGraphCoverage` 필수 report를 연결.
- generated connector가 verified accessibility로 계산되거나 strict route-not-found rate가 기준을 넘으면 gate가 실패하도록 고정.

## Verification
- `node --test tools/routes/build-route-graph-coverage-report.test.mjs tools/routes/check-route-commercialization-gate.test.mjs`
- `node --test tools/routes/*.test.mjs`
- `node --test tools/ci/repository-contract.test.mjs`
- `git diff --check origin/main..HEAD`

## 범위
- #1406 완료 대상입니다.
- #1400에는 route graph topology/coverage evidence 일부만 보강합니다. 실제 4호선 인접역 graph 승격, route map position 확장 적재, 앱 품질 표시 evidence는 남아 있어 #1400은 닫지 않습니다.

Closes #1406
Refs #1400
Refs #1419
