### PR TITLE
[Feature] 노선도 주변역 패널 실시간 도착정보 실연동

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1617,6 +1617,7 @@ class _HomeScreenState extends State<HomeScreen> {
           stationSearchRepository: repository,
           locationProvider: locationProvider,
           viewportRepository: widget.networkMapViewportRepository,
+          realtimeRepository: widget.realtimeRepository,
           onOpenSavedItems: openSavedTab,
           onOpenRecentSearch: () =>
               unawaited(openStationSearch(StationSearchEntryMode.recent)),

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -11,6 +11,7 @@ import 'features/network_map/domain/map_camera.dart';
 import 'features/network_map/infrastructure/android_route_map_viewport_webview.dart';
 import 'features/network_map/infrastructure/ios_route_map_viewport_webview.dart';
 import 'features/network_map/infrastructure/route_map_renderer.dart';
+import 'features/realtime/realtime_repository.dart';
 import 'features/route_draft/application/route_draft_controller.dart';
 import 'features/route_draft/domain/route_draft.dart';
 import 'mobile_error_reporter.dart';
@@ -311,6 +312,7 @@ class NetworkMapScreen extends StatefulWidget {
     this.stationSearchRepository,
     this.locationProvider,
     this.viewportRepository,
+    this.realtimeRepository,
     this.onOpenSavedItems,
     this.onOpenRecentSearch,
     this.onOpenNearbyStations,
@@ -327,6 +329,7 @@ class NetworkMapScreen extends StatefulWidget {
   final StationSearchRepository? stationSearchRepository;
   final CurrentLocationProvider? locationProvider;
   final NetworkMapViewportRepository? viewportRepository;
+  final RealtimeRepository? realtimeRepository;
   final VoidCallback? onOpenSavedItems;
   final VoidCallback? onOpenRecentSearch;
   final VoidCallback? onOpenNearbyStations;
@@ -348,7 +351,52 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
   String? _nearbyLookupMessage;
   Timer? _nearbyLookupMessageTimer;
   bool _initialNearbyFocusStarted = false;
+  RealtimeSnapshot _nearbyRealtime = const RealtimeSnapshot.loading();
+  int _nearbyRealtimeToken = 0;
   late Future<_NetworkMapLoadResult> _future = _loadMap();
+
+  Future<void> _loadNearbyRealtime(StationSearchResult station) async {
+    final repository = widget.realtimeRepository;
+    final firstLine = station.lines.isEmpty ? null : station.lines.first;
+    final token = ++_nearbyRealtimeToken;
+    if (repository == null || firstLine == null) {
+      setState(() {
+        _nearbyRealtime = const RealtimeSnapshot(
+          status: RealtimeSnapshotStatus.unsupported,
+          fallbackCode: 'LINE_MAPPING_MISSING',
+          message: '이 노선은 아직 실시간 열차 안내가 어려워요.',
+        );
+      });
+      return;
+    }
+    setState(() => _nearbyRealtime = const RealtimeSnapshot.loading());
+    RealtimeSnapshot snapshot;
+    try {
+      snapshot = await repository.arrivals(
+        RealtimeStationQuery(
+          stationId: station.id,
+          lineId: firstLine.id,
+          providerLineId: firstLine.stationCode.isEmpty
+              ? firstLine.id
+              : firstLine.stationCode,
+          stationQueryName: station.nameKo,
+        ),
+      );
+    } on RealtimeException {
+      snapshot = const RealtimeSnapshot.unavailable();
+    } catch (error, stackTrace) {
+      reportMobileError(
+        error,
+        stackTrace,
+        context: '노선도 주변역 실시간 조회 중 예외가 발생했습니다.',
+      );
+      snapshot = const RealtimeSnapshot.unavailable();
+    }
+    if (!mounted || token != _nearbyRealtimeToken) {
+      return;
+    }
+    setState(() => _nearbyRealtime = snapshot);
+  }
 
   @override
   void dispose() {
@@ -370,6 +418,8 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       _nearbySelectedStationId = null;
       _nearbyPanelVisible = false;
       _nearbyPanelData = const _NetworkMapNearbyPanelData.idle();
+      _nearbyRealtime = const RealtimeSnapshot.loading();
+      _nearbyRealtimeToken++;
       _initialNearbyFocusStarted = false;
       _future = _loadMap();
     });
@@ -398,6 +448,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               },
               nearbyPanelVisible: _nearbyPanelVisible,
               nearbyPanelData: _nearbyPanelData,
+              realtime: _nearbyRealtime,
               nearbyLookupMessage: _nearbyLookupMessage,
               adjacentStations: const _NetworkMapAdjacentStations(),
               onCurrentLocationTap: _showNearbyPanel,
@@ -421,6 +472,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
               },
               nearbyPanelVisible: _nearbyPanelVisible,
               nearbyPanelData: _nearbyPanelData,
+              realtime: _nearbyRealtime,
               nearbyLookupMessage: _nearbyLookupMessage,
               adjacentStations: const _NetworkMapAdjacentStations(),
               onCurrentLocationTap: _showNearbyPanel,
@@ -453,6 +505,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
             },
             nearbyPanelVisible: _nearbyPanelVisible,
             nearbyPanelData: _nearbyPanelData,
+            realtime: _nearbyRealtime,
             nearbyLookupMessage: _nearbyLookupMessage,
             adjacentStations: _adjacentStationsFor(data),
             onCurrentLocationTap: _showNearbyPanel,
@@ -525,6 +578,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
         _nearbySelectedStationId = results.first.id;
         _nearbyPanelData = _NetworkMapNearbyPanelData.success(results);
       });
+      unawaited(_loadNearbyRealtime(results.first));
     } on CurrentLocationException catch (error) {
       if (!mounted) {
         return;
@@ -556,7 +610,7 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       _nearbyPanelData = const _NetworkMapNearbyPanelData.idle();
       _nearbyLookupMessage = message;
     });
-    _nearbyLookupMessageTimer = Timer(const Duration(milliseconds: 1800), () {
+    _nearbyLookupMessageTimer = Timer(const Duration(seconds: 4), () {
       if (!mounted) {
         return;
       }
@@ -634,6 +688,8 @@ class _NetworkMapScreenState extends State<NetworkMapScreen> {
       _nearbyPanelVisible = false;
       _nearbySelectedStationId = null;
       _nearbyPanelData = const _NetworkMapNearbyPanelData.idle();
+      _nearbyRealtime = const RealtimeSnapshot.loading();
+      _nearbyRealtimeToken++;
     });
   }
 
@@ -762,6 +818,7 @@ class _NetworkMapChrome extends StatelessWidget {
     required this.onExpressViewChanged,
     required this.nearbyPanelVisible,
     required this.nearbyPanelData,
+    required this.realtime,
     required this.nearbyLookupMessage,
     required this.adjacentStations,
     required this.onCurrentLocationTap,
@@ -781,6 +838,7 @@ class _NetworkMapChrome extends StatelessWidget {
   final ValueChanged<bool> onExpressViewChanged;
   final bool nearbyPanelVisible;
   final _NetworkMapNearbyPanelData nearbyPanelData;
+  final RealtimeSnapshot realtime;
   final String? nearbyLookupMessage;
   final _NetworkMapAdjacentStations adjacentStations;
   final VoidCallback onCurrentLocationTap;
@@ -826,6 +884,7 @@ class _NetworkMapChrome extends StatelessWidget {
             bottom: 0,
             child: _NetworkMapNearbyStationPanel(
               data: nearbyPanelData,
+              realtime: realtime,
               adjacentStations: adjacentStations,
               onClose: onCloseNearbyPanel,
               onRetry: onCurrentLocationTap,
@@ -1277,12 +1336,14 @@ class _NetworkMapAdjacentStations {
 class _NetworkMapNearbyStationPanel extends StatelessWidget {
   const _NetworkMapNearbyStationPanel({
     required this.data,
+    required this.realtime,
     required this.adjacentStations,
     required this.onClose,
     required this.onRetry,
   });
 
   final _NetworkMapNearbyPanelData data;
+  final RealtimeSnapshot realtime;
   final _NetworkMapAdjacentStations adjacentStations;
   final VoidCallback onClose;
   final VoidCallback onRetry;
@@ -1317,26 +1378,29 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
                       child: _SubwayLinePanelTab(line: primaryLine),
                     ),
                     const Spacer(),
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 10),
-                      child: Container(
-                        height: 24,
-                        alignment: Alignment.center,
-                        padding: const EdgeInsets.symmetric(horizontal: 8),
-                        decoration: BoxDecoration(
-                          border: Border.all(color: const Color(0xFFFFCACA)),
-                          borderRadius: BorderRadius.circular(3),
-                        ),
-                        child: const Text(
-                          '실시간',
-                          style: TextStyle(
-                            color: Color(0xFFFF7777),
-                            fontSize: 12,
-                            fontWeight: FontWeight.w800,
+                    if (realtime.status == RealtimeSnapshotStatus.fresh)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 10),
+                        child: Container(
+                          height: 24,
+                          alignment: Alignment.center,
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
+                          decoration: BoxDecoration(
+                            border: Border.all(
+                              color: EasySubwayAccessibleColors.mintBorder,
+                            ),
+                            borderRadius: BorderRadius.circular(3),
+                          ),
+                          child: const Text(
+                            '실시간',
+                            style: TextStyle(
+                              color: EasySubwayAccessibleColors.mint,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w800,
+                            ),
                           ),
                         ),
                       ),
-                    ),
                     Padding(
                       padding: const EdgeInsets.only(bottom: 3),
                       child: IconButton(
@@ -1379,6 +1443,7 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
               const Divider(height: 1, color: Color(0xFFD8D8D8)),
               _NetworkMapNearbyPanelBody(
                 data: data,
+                realtime: realtime,
                 adjacentStations: adjacentStations,
               ),
             ],
@@ -1392,10 +1457,12 @@ class _NetworkMapNearbyStationPanel extends StatelessWidget {
 class _NetworkMapNearbyPanelBody extends StatelessWidget {
   const _NetworkMapNearbyPanelBody({
     required this.data,
+    required this.realtime,
     required this.adjacentStations,
   });
 
   final _NetworkMapNearbyPanelData data;
+  final RealtimeSnapshot realtime;
   final _NetworkMapAdjacentStations adjacentStations;
 
   @override
@@ -1408,6 +1475,7 @@ class _NetworkMapNearbyPanelBody extends StatelessWidget {
       ),
       _NetworkMapNearbyPanelStatus.success => _NetworkMapNearbySuccessList(
         results: data.results,
+        realtime: realtime,
         adjacentStations: adjacentStations,
       ),
     };
@@ -1417,10 +1485,12 @@ class _NetworkMapNearbyPanelBody extends StatelessWidget {
 class _NetworkMapNearbySuccessList extends StatelessWidget {
   const _NetworkMapNearbySuccessList({
     required this.results,
+    required this.realtime,
     required this.adjacentStations,
   });
 
   final List<StationSearchResult> results;
+  final RealtimeSnapshot realtime;
   final _NetworkMapAdjacentStations adjacentStations;
 
   @override
@@ -1497,26 +1567,8 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
         ),
         const SizedBox(height: 17),
         Padding(
-          padding: const EdgeInsets.fromLTRB(42, 0, 42, 12),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: _SubwayArrivalColumn(
-                  arrivals: const [_SubwayArrivalPlaceholder()],
-                ),
-              ),
-              const SizedBox(
-                height: 46,
-                child: VerticalDivider(color: Color(0xFFE0E0E0), width: 30),
-              ),
-              Expanded(
-                child: _SubwayArrivalColumn(
-                  arrivals: const [_SubwayArrivalPlaceholder()],
-                ),
-              ),
-            ],
-          ),
+          padding: const EdgeInsets.fromLTRB(24, 0, 24, 12),
+          child: _SubwayArrivalPanel(snapshot: realtime),
         ),
       ],
     );
@@ -1563,44 +1615,219 @@ class _SubwayLinePanelTab extends StatelessWidget {
   }
 }
 
-class _SubwayArrivalPlaceholder {
-  const _SubwayArrivalPlaceholder();
+String _formatArrivalEta(RealtimeArrival arrival) {
+  final eta = arrival.etaSeconds;
+  if (eta != null && eta > 0) {
+    final minutes = (eta / 60).round();
+    return minutes <= 0 ? '곧 도착' : '약 $minutes분';
+  }
+  return arrival.message.trim();
+}
+
+String _arrivalDirectionLabel(RealtimeArrival arrival) {
+  final direction = arrival.direction.trim();
+  if (direction.isNotEmpty) {
+    return direction;
+  }
+  final destination = arrival.destination.trim();
+  return destination.isEmpty ? '' : '$destination 방면';
+}
+
+/// 주변역 패널의 도착 정보 영역. 실시간 스냅샷 상태에 따라 방향별 도착을
+/// 표시하거나, 미지원·실패 시 "-" 대신 한 줄 안내를 보여준다.
+class _SubwayArrivalPanel extends StatelessWidget {
+  const _SubwayArrivalPanel({required this.snapshot});
+
+  final RealtimeSnapshot snapshot;
+
+  @override
+  Widget build(BuildContext context) {
+    switch (snapshot.status) {
+      case RealtimeSnapshotStatus.loading:
+        return const SizedBox(
+          key: Key('networkMapNearbyArrivalLoading'),
+          height: 46,
+          child: Center(
+            child: SizedBox(
+              width: 22,
+              height: 22,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          ),
+        );
+      case RealtimeSnapshotStatus.unsupported:
+      case RealtimeSnapshotStatus.unavailable:
+        final message = snapshot.message.trim().isEmpty
+            ? '실시간 도착 정보를 준비하고 있어요.'
+            : snapshot.message.trim();
+        return _SubwayArrivalNotice(message: message);
+      case RealtimeSnapshotStatus.fresh:
+      case RealtimeSnapshotStatus.stale:
+        if (snapshot.arrivals.isEmpty) {
+          return const _SubwayArrivalNotice(message: '표시할 도착 정보가 없어요.');
+        }
+        final groups = <String, List<RealtimeArrival>>{};
+        for (final arrival in snapshot.arrivals) {
+          groups.putIfAbsent(arrival.direction, () => []).add(arrival);
+        }
+        final directions = groups.keys.toList(growable: false);
+        final left = groups[directions.first]!;
+        final right = directions.length > 1
+            ? groups[directions[1]]!
+            : const <RealtimeArrival>[];
+        final isStale = snapshot.status == RealtimeSnapshotStatus.stale;
+        final semanticParts = <String>[
+          for (final arrival in [...left, ...right])
+            [
+              _arrivalDirectionLabel(arrival),
+              arrival.destination.trim().isEmpty
+                  ? ''
+                  : '${arrival.destination.trim()}행',
+              _formatArrivalEta(arrival),
+            ].where((part) => part.isNotEmpty).join(' '),
+        ].where((part) => part.isNotEmpty).toList(growable: false);
+        return Semantics(
+          liveRegion: true,
+          label: semanticParts.isEmpty ? '도착 정보 없음' : semanticParts.join(', '),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (isStale) ...[
+                Text(
+                  snapshot.receivedAt.trim().isEmpty
+                      ? '최근 도착 정보'
+                      : '최근 도착 정보 · ${snapshot.receivedAt.trim()}',
+                  style: const TextStyle(
+                    color: EasySubwayAccessibleColors.mutedText,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 6),
+              ],
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(child: _SubwayArrivalColumn(arrivals: left)),
+                  if (right.isNotEmpty) ...[
+                    const SizedBox(
+                      height: 46,
+                      child: VerticalDivider(
+                        color: Color(0xFFE0E0E0),
+                        width: 30,
+                      ),
+                    ),
+                    Expanded(child: _SubwayArrivalColumn(arrivals: right)),
+                  ],
+                ],
+              ),
+            ],
+          ),
+        );
+    }
+  }
+}
+
+class _SubwayArrivalNotice extends StatelessWidget {
+  const _SubwayArrivalNotice({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 46,
+      child: Center(
+        child: Text(
+          message,
+          textAlign: TextAlign.center,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(
+            color: EasySubwayAccessibleColors.mutedText,
+            fontSize: 13,
+            height: 1.3,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class _SubwayArrivalColumn extends StatelessWidget {
   const _SubwayArrivalColumn({required this.arrivals});
 
-  final List<_SubwayArrivalPlaceholder> arrivals;
+  final List<RealtimeArrival> arrivals;
 
   @override
   Widget build(BuildContext context) {
+    final visible = arrivals.take(2).toList(growable: false);
+    final directionLabel = visible.isEmpty
+        ? ''
+        : _arrivalDirectionLabel(visible.first);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       mainAxisSize: MainAxisSize.min,
-      children: arrivals
-          .map((arrival) => const _SubwayArrivalRow())
-          .toList(growable: false),
+      children: [
+        if (directionLabel.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 4),
+            child: Text(
+              directionLabel,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: EasySubwayAccessibleColors.primary,
+                fontSize: 12,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ),
+        for (final arrival in visible) _SubwayArrivalRow(arrival: arrival),
+      ],
     );
   }
 }
 
 class _SubwayArrivalRow extends StatelessWidget {
-  const _SubwayArrivalRow();
+  const _SubwayArrivalRow({required this.arrival});
+
+  final RealtimeArrival arrival;
 
   @override
   Widget build(BuildContext context) {
-    return const Padding(
-      padding: EdgeInsets.only(bottom: 2),
-      child: Center(
-        child: Text(
-          '-',
-          style: TextStyle(
-            color: Color(0xFF2F2F2F),
-            fontSize: 12,
-            height: 1.45,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
+    final destination = arrival.destination.trim();
+    final eta = _formatArrivalEta(arrival);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Column(
+        children: [
+          if (destination.isNotEmpty)
+            Text(
+              '$destination행',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: Color(0xFF2F2F2F),
+                fontSize: 13,
+                height: 1.3,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          if (eta.isNotEmpty)
+            Text(
+              eta,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: EasySubwayAccessibleColors.secondaryText,
+                fontSize: 12,
+                height: 1.3,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1008,7 +1008,7 @@ class _NetworkMapTopBar extends StatelessWidget {
                   button: true,
                   label: '지역: $currentRegion',
                   child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 84),
+                    constraints: const BoxConstraints(maxWidth: 148),
                     child: SizedBox(
                       height: EasySubwayTouchTarget.general,
                       child: ExcludeSemantics(
@@ -1016,27 +1016,28 @@ class _NetworkMapTopBar extends StatelessWidget {
                           key: const Key('networkMapRegionDropdown'),
                           onTap: () =>
                               _showRegionSheet(context, availableRegions),
-                          child: FittedBox(
-                            fit: BoxFit.scaleDown,
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Text(
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Flexible(
+                                child: Text(
                                   currentRegion,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
                                   style: const TextStyle(
                                     color: Color(0xFF606060),
                                     fontSize: 15,
                                     fontWeight: FontWeight.w600,
                                   ),
                                 ),
-                                const SizedBox(width: 2),
-                                const Icon(
-                                  Icons.keyboard_arrow_down,
-                                  color: Color(0xFF606060),
-                                  size: 18,
-                                ),
-                              ],
-                            ),
+                              ),
+                              const SizedBox(width: 2),
+                              const Icon(
+                                Icons.keyboard_arrow_down,
+                                color: Color(0xFF606060),
+                                size: 18,
+                              ),
+                            ],
                           ),
                         ),
                       ),
@@ -1496,8 +1497,8 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final primary = results.first;
-    final leftName = adjacentStations.leftName ?? '-';
-    final rightName = adjacentStations.rightName ?? '-';
+    final leftName = adjacentStations.leftName;
+    final rightName = adjacentStations.rightName;
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -1513,7 +1514,7 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
               children: [
                 Expanded(
                   child: Text(
-                    '< $leftName',
+                    leftName == null ? '' : '< $leftName',
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     textAlign: TextAlign.center,
@@ -1550,7 +1551,7 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
                 ),
                 Expanded(
                   child: Text(
-                    '$rightName >',
+                    rightName == null ? '' : '$rightName >',
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     textAlign: TextAlign.center,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3092,11 +3092,13 @@ void main() {
     final requested = repository.requestedNearbyLocations.single;
     expect(requested.latitude, closeTo(37.3028, 0.0001));
     expect(requested.longitude, closeTo(126.8665, 0.0001));
-    expect(find.text('실시간'), findsOneWidget);
+    // 실시간 미연동(UnavailableRealtimeRepository) 상태에서는 "실시간" 뱃지와
+    // "-" 자리표시 대신 한 줄 안내만 보여준다.
+    expect(find.text('실시간'), findsNothing);
     expect(find.text('상록수'), findsOneWidget);
     expect(find.textContaining('반월'), findsOneWidget);
     expect(find.textContaining('한대앞'), findsOneWidget);
-    expect(find.text('-'), findsWidgets);
+    expect(find.textContaining('이용할 수 있습니다'), findsOneWidget);
     expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
   });
 
@@ -3183,11 +3185,59 @@ void main() {
     );
     expect(find.text('현재 위치를 확인하지 못했어요.'), findsOneWidget);
 
-    await tester.pump(const Duration(milliseconds: 1900));
+    await tester.pump(const Duration(seconds: 5));
     await tester.pumpAndSettle();
 
     expect(find.text('현재 위치를 확인하지 못했어요.'), findsNothing);
     expect(find.byKey(const Key('networkMapNearbyStationPanel')), findsNothing);
+  });
+
+  testWidgets('노선도 주변역 패널은 실시간 도착 정보를 방향별로 보여준다', (tester) async {
+    final locationProvider = FakeCurrentLocationProvider(
+      location: _freshCurrentLocation(),
+      needsPermissionRequest: false,
+    );
+    final repository = FakeStationSearchRepository(
+      nearbyResults: [
+        _stationResult(
+          id: 'station-sangnoksu',
+          name: '상록수',
+          distanceMeters: 230,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: repository,
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        locationProvider: locationProvider,
+        realtimeRepository: const _FreshNearbyRealtimeRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('nearbyStationButton')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const Key('networkMapNearbyStationPanel')),
+      findsOneWidget,
+    );
+    // FRESH 상태에서만 "실시간" 뱃지가 노출되고, 도착 정보가 방향별로 표시된다.
+    expect(find.text('실시간'), findsOneWidget);
+    expect(find.text('상행'), findsOneWidget);
+    expect(find.text('하행'), findsOneWidget);
+    expect(find.text('한대앞행'), findsOneWidget);
+    expect(find.text('사당행'), findsOneWidget);
+    expect(find.text('약 3분'), findsOneWidget);
+    expect(find.text('약 5분'), findsOneWidget);
   });
 
   testWidgets('노선도는 위치 권한이 이미 있으면 가까운 역 중심 viewport를 저장한다', (tester) async {
@@ -12954,6 +13004,38 @@ CurrentLocation _freshCurrentLocation({
     provider: 'test',
     permissionPrecision: LocationPermissionPrecision.precise,
   );
+}
+
+class _FreshNearbyRealtimeRepository implements RealtimeRepository {
+  const _FreshNearbyRealtimeRepository();
+
+  @override
+  Future<RealtimeSnapshot> arrivals(RealtimeStationQuery query) async {
+    return const RealtimeSnapshot(
+      status: RealtimeSnapshotStatus.fresh,
+      receivedAt: '방금',
+      arrivals: [
+        RealtimeArrival(
+          lineId: 'seoul-2',
+          stationName: '상록수',
+          destination: '한대앞',
+          direction: '상행',
+          trainNo: '2001',
+          message: '',
+          etaSeconds: 180,
+        ),
+        RealtimeArrival(
+          lineId: 'seoul-2',
+          stationName: '상록수',
+          destination: '사당',
+          direction: '하행',
+          trainNo: '2002',
+          message: '',
+          etaSeconds: 300,
+        ),
+      ],
+    );
+  }
 }
 
 class FakeCurrentLocationProvider implements CurrentLocationProvider {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -990,7 +990,8 @@ void main() {
         matching: find.text('수도권'),
       ),
     );
-    expect(regionText.overflow, isNot(TextOverflow.ellipsis));
+    // 지역명은 FittedBox 축소 대신 말줄임으로 가독성을 유지한다(#1487).
+    expect(regionText.overflow, TextOverflow.ellipsis);
     expect(find.text('전국'), findsNothing);
     expect(
       tester.getSize(find.byKey(const Key('mapRegionTabs'))).height,


### PR DESCRIPTION
## Summary

노선도(홈) 주변역 패널이 "실시간" 뱃지를 달고 도착정보 자리에 항상 "-"만 그리던 미완성 UI를 실데이터 연동으로 해소했습니다(#1487 검토 중 1안 확정). (#1493)

- **`RealtimeRepository` 주입**: `NetworkMapScreen`에 저장소를 추가하고 HomeScreen에서 전달. 주변역 조회 성공 시 선택 역 기준으로 실시간 도착을 불러옵니다(stale 요청은 토큰으로 무시).
- **쿼리 규칙 재사용**: 역 상세와 동일하게 `stationId`/`lineId`/`providerLineId(stationCode 우선)`/`stationQueryName`으로 `RealtimeStationQuery` 구성.
- **방향별 표시**: 도착을 `direction`으로 나눠 2컬럼으로, `etaSeconds` → "약 n분"(없으면 `message`).
- **상태별 표현**(역 상세 문구 체계와 정렬):
  - FRESH → 도착 시간 + "실시간" 뱃지(팔레트 mint 계열)
  - STALE → "최근 도착 정보 · {receivedAt}"
  - UNSUPPORTED/UNAVAILABLE → 무의미한 "-" 대신 한 줄 안내
  - loading → 스피너
- **뱃지 노출 조건**: "실시간"은 FRESH일 때만. 색 `0xFFFF7777`/`0xFFFFCACA` → mint 토큰.
- **접근성**: 도착 영역에 `liveRegion` + "방향 목적지행 약 n분" 시맨틱.
- **(연계)** 주변역 조회 실패 토스트 자동 소멸 1.8초 → 4초(읽을 시간 확보).

## Verification

- `dart format` · `flutter analyze lib test` → **No issues found**
- `flutter test` → **618 passed, 0 failed**
- 추가 테스트: FRESH 방향별 도착 렌더링(fake repository), 미연동(Unavailable) 시 뱃지 미노출 + 한 줄 안내.

## Notes

- 토대 PR(#1500) 위에 스택합니다. base 병합 후 `main`으로 재지정 예정.
- 인접역 "-" 폴백 정리와 지역 드롭다운 폭 등 순수 스타일 항목은 #1487에서 이어서 정리합니다(#1493은 실연동 담당).
- 갱신은 수동(패널 새로고침·재오픈) 기준이며 과도한 자동 폴링은 두지 않았습니다.