### PR TITLE
[Style] 노선도 주변역 패널 정리(인접역 폴백·지역 드롭다운 폭)

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1008,7 +1008,7 @@ class _NetworkMapTopBar extends StatelessWidget {
                   button: true,
                   label: '지역: $currentRegion',
                   child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 84),
+                    constraints: const BoxConstraints(maxWidth: 148),
                     child: SizedBox(
                       height: EasySubwayTouchTarget.general,
                       child: ExcludeSemantics(
@@ -1016,27 +1016,28 @@ class _NetworkMapTopBar extends StatelessWidget {
                           key: const Key('networkMapRegionDropdown'),
                           onTap: () =>
                               _showRegionSheet(context, availableRegions),
-                          child: FittedBox(
-                            fit: BoxFit.scaleDown,
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Text(
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Flexible(
+                                child: Text(
                                   currentRegion,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
                                   style: const TextStyle(
                                     color: Color(0xFF606060),
                                     fontSize: 15,
                                     fontWeight: FontWeight.w600,
                                   ),
                                 ),
-                                const SizedBox(width: 2),
-                                const Icon(
-                                  Icons.keyboard_arrow_down,
-                                  color: Color(0xFF606060),
-                                  size: 18,
-                                ),
-                              ],
-                            ),
+                              ),
+                              const SizedBox(width: 2),
+                              const Icon(
+                                Icons.keyboard_arrow_down,
+                                color: Color(0xFF606060),
+                                size: 18,
+                              ),
+                            ],
                           ),
                         ),
                       ),
@@ -1496,8 +1497,8 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final primary = results.first;
-    final leftName = adjacentStations.leftName ?? '-';
-    final rightName = adjacentStations.rightName ?? '-';
+    final leftName = adjacentStations.leftName;
+    final rightName = adjacentStations.rightName;
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -1513,7 +1514,7 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
               children: [
                 Expanded(
                   child: Text(
-                    '< $leftName',
+                    leftName == null ? '' : '< $leftName',
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     textAlign: TextAlign.center,
@@ -1550,7 +1551,7 @@ class _NetworkMapNearbySuccessList extends StatelessWidget {
                 ),
                 Expanded(
                   child: Text(
-                    '$rightName >',
+                    rightName == null ? '' : '$rightName >',
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     textAlign: TextAlign.center,

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -990,7 +990,8 @@ void main() {
         matching: find.text('수도권'),
       ),
     );
-    expect(regionText.overflow, isNot(TextOverflow.ellipsis));
+    // 지역명은 FittedBox 축소 대신 말줄임으로 가독성을 유지한다(#1487).
+    expect(regionText.overflow, TextOverflow.ellipsis);
     expect(find.text('전국'), findsNothing);
     expect(
       tester.getSize(find.byKey(const Key('mapRegionTabs'))).height,


### PR DESCRIPTION
## Summary

주변역 패널의 남은 스타일 항목을 정리했습니다. 실시간 도착 실연동과 "실시간" 뱃지 팔레트 토큰화는 #1493에서 확정되어, 여기서는 폴백·드롭다운만 다듬습니다. (#1487)

- **인접역 "-" 폴백 제거**: 좌/우 인접역 이름이 없으면 "-" 대신 해당 방향을 표시하지 않음(모르는 정보는 표기하지 않는 원칙).
- **(P2) 상단 지역 선택 드롭다운**: `maxWidth: 84` + `FittedBox(scaleDown)`으로 긴 지역명이 축소되어 가독성이 떨어지던 것을 → 폭 확대(148) + `TextOverflow.ellipsis`로 변경(축소 대신 말줄임).

## Verification

- `dart format` · `flutter analyze lib` → **No issues found**
- `flutter test` → **618 passed, 0 failed** (지역명 overflow 기대값을 말줄임으로 갱신)

## Notes

- 실연동 PR(#1503) 위에 스택합니다. #1503 → #1500 → #1498 → main 순으로 base를 재지정합니다.