### PR TITLE
[Style] 역 검색·즐겨찾기 역 목록 틴트 카드와 품질 라벨 정비

### DIFF
--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -58,8 +58,8 @@ const _stationDetailInfoCardRadius = BorderRadius.all(Radius.circular(16));
 const _stationDetailHelpCardRadius = BorderRadius.all(Radius.circular(16));
 const _stationDetailActionButtonRadius = BorderRadius.all(Radius.circular(12));
 const _stationDetailFacilityCardRadius = BorderRadius.all(Radius.circular(16));
-const _stationTextMutedColor = Color(0xFF405A5D);
-const _stationTextSubtleColor = Color(0xFF506B6F);
+const _stationTextMutedColor = EasySubwayAccessibleColors.secondaryText;
+const _stationTextSubtleColor = EasySubwayAccessibleColors.mutedText;
 const _stationDetailTextColor = Color(0xFF2C5558);
 const _stationDetailSoftPanelColor = Color(0xFFEAF6F4);
 const _stationDetailSoftPanelBorderColor = Color(0xFFB9D7D2);
@@ -963,6 +963,15 @@ String _dataQualityLabel(String dataQualityLevel) {
     'LEVEL_4' => '고장·공사 소식이 반영됐어요',
     _ => '정보를 준비 중이에요',
   };
+}
+
+/// 데이터 품질 라벨을 목록에 노출할지 여부.
+/// 기본 레벨(LEVEL_1)·미확정 값은 "확인 중" 같은 필러라 목록에서는 감춘다
+/// (실제 안내 역량을 뜻하는 LEVEL_2 이상만 노출). simple is best.
+bool _showsDataQualityLabel(String dataQualityLevel) {
+  return dataQualityLevel == 'LEVEL_2' ||
+      dataQualityLevel == 'LEVEL_3' ||
+      dataQualityLevel == 'LEVEL_4';
 }
 
 String _dataConfidenceLabel(String dataConfidence) {
@@ -2418,7 +2427,7 @@ class _StationRecentSearchSection extends StatelessWidget {
             '최근 검색',
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
               color: EasySubwayAccessibleColors.text,
-              fontWeight: FontWeight.w900,
+              fontWeight: FontWeight.w800,
               height: 1.25,
             ),
           ),
@@ -3203,7 +3212,7 @@ class _NearbyStationOverview extends StatelessWidget {
     final stationName = _stationResultDisplayName(result.nameKo);
     return Card(
       margin: EdgeInsets.zero,
-      color: EasySubwayAccessibleColors.skySoft,
+      color: EasySubwayAccessibleColors.surface,
       elevation: 0,
       shape: RoundedRectangleBorder(
         borderRadius: _stationDetailFacilityCardRadius,
@@ -3260,10 +3269,14 @@ class _NearbyStationOverview extends StatelessWidget {
                                     height: 1.3,
                                   ),
                             ),
-                            const SizedBox(height: 8),
-                            _StationDetailTextPill(
-                              text: result.dataQualityLabel,
-                            ),
+                            if (_showsDataQualityLabel(
+                              result.dataQualityLevel,
+                            )) ...[
+                              const SizedBox(height: 8),
+                              _StationDetailTextPill(
+                                text: result.dataQualityLabel,
+                              ),
+                            ],
                           ],
                         ),
                       ),
@@ -3473,15 +3486,19 @@ class _StationSearchResultTile extends StatelessWidget {
                                     height: 1.25,
                                   ),
                                 ),
-                                const SizedBox(height: 4),
-                                Text(
-                                  result.dataQualityLabel,
-                                  style: textTheme.bodyMedium?.copyWith(
-                                    color: _stationTextMutedColor,
-                                    fontWeight: FontWeight.w600,
-                                    height: 1.25,
+                                if (_showsDataQualityLabel(
+                                  result.dataQualityLevel,
+                                )) ...[
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    result.dataQualityLabel,
+                                    style: textTheme.bodyMedium?.copyWith(
+                                      color: _stationTextMutedColor,
+                                      fontWeight: FontWeight.w600,
+                                      height: 1.25,
+                                    ),
                                   ),
-                                ),
+                                ],
                               ],
                             ),
                           ),
@@ -3918,7 +3935,7 @@ class _FavoriteStationTile extends StatelessWidget {
                             favorite.nameKo,
                             style: textTheme.titleLarge?.copyWith(
                               color: EasySubwayAccessibleColors.text,
-                              fontWeight: FontWeight.w900,
+                              fontWeight: FontWeight.w800,
                               height: 1.25,
                             ),
                           ),
@@ -3941,14 +3958,18 @@ class _FavoriteStationTile extends StatelessWidget {
                               height: 1.3,
                             ),
                           ),
-                          const SizedBox(height: 4),
-                          Text(
-                            favorite.dataQualityLabel,
-                            style: textTheme.bodyMedium?.copyWith(
-                              color: _stationTextMutedColor,
-                              height: 1.3,
+                          if (_showsDataQualityLabel(
+                            favorite.dataQualityLevel,
+                          )) ...[
+                            const SizedBox(height: 4),
+                            Text(
+                              favorite.dataQualityLabel,
+                              style: textTheme.bodyMedium?.copyWith(
+                                color: _stationTextMutedColor,
+                                height: 1.3,
+                              ),
                             ),
-                          ),
+                          ],
                         ],
                       ),
                     ),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5421,7 +5421,8 @@ void main() {
       expect(find.text('즐겨찾기한 역'), findsOneWidget);
       expect(find.text('상록수'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
-      expect(find.text('일부 정보는 확인 중이에요'), findsOneWidget);
+      // 기본 레벨(LEVEL_1) 품질 필러는 목록에서 감춘다(#1477). 시맨틱에는 유지.
+      expect(find.text('일부 정보는 확인 중이에요'), findsNothing);
       expect(find.widgetWithText(OutlinedButton, '출발지로 설정'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '도착지로 설정'), findsOneWidget);
       expect(find.widgetWithText(OutlinedButton, '역 상세 보기'), findsOneWidget);
@@ -5895,7 +5896,8 @@ void main() {
       );
       expect(find.text('수도권 4호선, 경의중앙선'), findsOneWidget);
       expect(find.text('수도권'), findsNothing);
-      expect(find.text('일부 정보는 확인 중이에요'), findsOneWidget);
+      // 기본 레벨(LEVEL_1) 품질 필러는 목록에서 감춘다(#1477). 시맨틱에는 유지.
+      expect(find.text('일부 정보는 확인 중이에요'), findsNothing);
       expect(find.text('출처 확인 필요'), findsNothing);
       expect(find.bySemanticsLabel('검색 결과 1개'), findsOneWidget);
       expect(
@@ -6008,7 +6010,6 @@ void main() {
     for (final text in [
       '$longStationName역',
       '현재 위치에서 1.3km · 수도권 9호선 급행, 공항철도 직통 일반 공용',
-      '일부 정보는 확인 중이에요',
     ]) {
       final widget = tester.widget<Text>(find.text(text));
       expect(widget.maxLines, isNot(1));
@@ -7628,7 +7629,8 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('stationSearchSubmitButton')));
       await tester.pumpAndSettle();
-      expect(find.text('일부 정보는 확인 중이에요'), findsOneWidget);
+      // 기본 레벨(LEVEL_1) 품질 필러는 목록에서 감춘다(#1477). 시맨틱에는 유지.
+      expect(find.text('일부 정보는 확인 중이에요'), findsNothing);
       expect(find.text('출처 공식 파일'), findsNothing);
       expect(
         find.bySemanticsLabel('상록수역, 수도권 2호선, 수도권, 일부 정보는 확인 중이에요'),


### PR DESCRIPTION
## Summary

역 검색·즐겨찾기 역 목록의 남은 장식 틴트 카드와 데이터 품질 필러 문구를 정리했습니다. (#1477)

- **틴트 카드 제거**: `_NearbyStationOverview`("가장 가까운 역") 레거시 `skySoft` 배경 → 화이트 + `line` 보더.
- **품질 라벨 필러 정리**: 기본 레벨(`LEVEL_1`)·미확정 값의 "확인 중" 필러는 목록에서 감추고, 실제 안내 역량을 뜻하는 `LEVEL_2` 이상만 노출(검색 결과 행·주변 역 카드·즐겨찾기 역 카드). `_showsDataQualityLabel` 헬퍼로 규칙 통일.
- **하드코딩 색 수렴**: `_stationTextMutedColor`/`_stationTextSubtleColor` → 팔레트 토큰(`secondaryText`/`mutedText`).
- **w900 완화**: "최근 검색" 타이틀·즐겨찾기 역 이름 → w800.

## Verification

- `dart format` · `flutter analyze lib` → **No issues found**
- `flutter test` → **617 passed, 0 failed** (기본 레벨 필러 미노출로 바뀐 목록 테스트 갱신)

## Notes

- 토대 PR(#1500) 위에 스택합니다. base 병합 후 `main`으로 재지정 예정.
- 시맨틱 라벨에는 품질 신호를 유지했습니다(스크린리더 맥락 보존, #1472와 동일 방침). 시각적 TMI만 제거.
- 즐겨찾기 역 카드 하단 버튼 개수 축소(P2)는 별도 후속으로 둡니다(터치 타깃·기존 동선 영향 큼).
- 역 상세부 색 상수(`_stationDetail*`) 수렴은 #1476 범위로 둡니다.