### PR TITLE
[Test] ETA deviation reason gate 고정

### DIFF
--- a/tools/routes/check-route-commercialization-gate.mjs
+++ b/tools/routes/check-route-commercialization-gate.mjs
@@ -109,6 +109,9 @@ function validateAccuracy(gate, report, failures) {
   max(singleRide.p90ErrorSeconds, gate.routeEtaAccuracy.singleRideP90ErrorSecondsMax, "singleRide P90 ETA error", failures);
   max(transfer.p50ErrorSeconds, gate.routeEtaAccuracy.transferP50ErrorSecondsMax, "transfer P50 ETA error", failures);
   max(transfer.p90ErrorSeconds, gate.routeEtaAccuracy.transferP90ErrorSecondsMax, "transfer P90 ETA error", failures);
+  if (number(report.metrics?.unclassifiedEtaDeviationCount) > 0) {
+    failures.push("routeEtaAccuracy unclassified ETA deviation count exceeds 0");
+  }
 }
 
 function validateAccessibility(gate, report, failures) {

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -193,6 +193,66 @@ test("route commercialization gate keeps legacy production sample fallback", asy
   );
 });
 
+test("route commercialization gate fails on unclassified ETA deviations", async () => {
+  const fixture = await writeFixtureSet({
+    accuracy: {
+      schemaVersion: 1,
+      sampleSize: 120,
+      sampleSourceCounts: {
+        fixture: 0,
+        staticTimetable: 0,
+        realtimeProvider: 120,
+        manualObservation: 120,
+        staleRealtime: 0,
+      },
+      productionSampleSize: 120,
+      metrics: {
+        singleRide: { sampleSize: 60, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
+        transfer: { sampleSize: 60, p50ErrorSeconds: 90, p90ErrorSeconds: 240 },
+        unclassifiedEtaDeviationCount: 1,
+      },
+      failures: [],
+    },
+    accessibility: {
+      schemaVersion: 1,
+      strictStepFreeKnownStairFalsePositiveCount: 0,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      unknownAccessibilityLabeled: true,
+    },
+    coverage: {
+      schemaVersion: 1,
+      supportedStationLinePairs: 150,
+      providerFreshnessSecondsMaxObserved: 80,
+      staleFallbackRequired: true,
+    },
+    routeGraphCoverage: {
+      schemaVersion: 1,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      strictRouteNotFound: { total: 100, notFoundCount: 1, rate: 0.01, byReasonCode: {} },
+    },
+    contract: {
+      schemaVersion: 1,
+      multiTransferSupported: false,
+      outOfStationTransferSupported: false,
+      alternativeItinerariesMinObserved: 1,
+      wrongTransferCount: 0,
+      wrongLineSequence: 0,
+      routeNotFoundRate: 0.01,
+      releaseBlockersSatisfied: ["D-2", "D-3", "H-1"],
+    },
+  });
+
+  await assert.rejects(
+    execChecker(fixture),
+    (error) => {
+      const report = JSON.parse(error.stdout);
+      assert.equal(report.status, "FAIL");
+      assert.ok(report.failures.includes("routeEtaAccuracy unclassified ETA deviation count exceeds 0"));
+      return true;
+    },
+  );
+});
+
 test("route commercialization gate sorts checked reports with an explicit comparator", async () => {
   const source = await readFile("tools/routes/check-route-commercialization-gate.mjs", "utf8");
 

--- a/tools/routes/evaluate-eta-accuracy.mjs
+++ b/tools/routes/evaluate-eta-accuracy.mjs
@@ -132,6 +132,7 @@ function buildReport(rows) {
     etaSourceMismatch: 0,
     realtimeFallbackMismatch: 0,
     providerStaleMisuse: 0,
+    unclassifiedEtaDeviation: 0,
   };
   for (const row of rows) {
     collectQualityFailures(row, failures, quality);
@@ -140,6 +141,10 @@ function buildReport(rows) {
     if (observed === null || max === null) continue;
     if (observed > max) {
       addFailure(failures, row, "ETA_ERROR", "observed ETA error exceeds max", { maxEtaErrorSeconds: max }, { observedEtaErrorSeconds: observed });
+      if (!hasValue(row.deviation_reason_code)) {
+        quality.unclassifiedEtaDeviation += 1;
+        addFailure(failures, row, "UNCLASSIFIED_ETA_DEVIATION", "over-budget ETA deviation must include deviation reason code", { deviationReasonCode: "classified" }, { deviationReasonCode: "" });
+      }
     }
     errors.push(observed);
     if (Number(row.expected_transfer_count) === 0) {
@@ -189,6 +194,7 @@ function buildReport(rows) {
       etaSourceMismatchCount: quality.etaSourceMismatch,
       realtimeFallbackMismatchCount: quality.realtimeFallbackMismatch,
       providerStaleMisuseCount: quality.providerStaleMisuse,
+      unclassifiedEtaDeviationCount: quality.unclassifiedEtaDeviation,
     },
     failures,
   };

--- a/tools/routes/evaluate-eta-accuracy.test.mjs
+++ b/tools/routes/evaluate-eta-accuracy.test.mjs
@@ -52,6 +52,7 @@ test("ETA evaluator emits the route accuracy report contract", async (t) => {
   assert.equal(report.metrics.etaSourceMismatchCount, 0);
   assert.equal(report.metrics.realtimeFallbackMismatchCount, 0);
   assert.equal(report.metrics.providerStaleMisuseCount, 0);
+  assert.equal(report.metrics.unclassifiedEtaDeviationCount, 0);
   assert.deepEqual(report.metrics.singleRide, {
     sampleSize: 35,
     p50ErrorSeconds: 45,
@@ -242,5 +243,61 @@ test("ETA evaluator emits structured production-safe failures", async (t) => {
   )));
   assert.ok(report.failures.some((failure) => (
     failure.caseId === "case-unverified-edge" && failure.type === "ACCESSIBILITY_FALSE_POSITIVE"
+  )));
+});
+
+test("ETA evaluator fails over-budget rows without deviation reason code", async (t) => {
+  const dataset = path.join(tmpdir(), `route-accuracy-deviation-${Date.now()}`);
+  const output = path.join(tmpdir(), `route-accuracy-deviation-${Date.now()}.json`);
+  t.after(() => rm(dataset, { recursive: true, force: true }));
+  t.after(() => rm(output, { force: true }));
+  await mkdir(dataset, { recursive: true });
+
+  const header = [
+    "case_id",
+    "origin_station_id",
+    "destination_station_id",
+    "departure_time",
+    "mobility_type",
+    "constraint_mode",
+    "reference_source",
+    "provider_freshness_status",
+    "expected_transfer_count",
+    "max_eta_error_seconds",
+    "observed_eta_error_seconds",
+    "use_realtime",
+    "actual_route_found",
+    "deviation_reason_code",
+    "notes",
+  ].join(",");
+  const rowsByFile = {
+    "single_ride_cases.csv": "case-unclassified,station-a,station-b,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,PROVIDER_LIVE_ARRIVAL,FRESH,0,30,90,true,true,,manual live",
+    "one_transfer_cases.csv": "case-classified,station-a,station-c,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,PROVIDER_LIVE_ARRIVAL,FRESH,1,30,90,true,true,WAIT_ESTIMATE,manual live classified",
+    "two_transfer_cases.csv": "case-ok-2,station-a,station-d,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,MANUAL_OBSERVATION,FRESH,2,100,20,false,true,,manual",
+    "express_cases.csv": "case-ok-express,station-a,station-e,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,MANUAL_OBSERVATION,FRESH,0,100,20,false,true,,manual",
+    "out_of_station_transfer_cases.csv": "case-ok-out,station-a,station-f,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,MANUAL_OBSERVATION,FRESH,1,100,20,false,true,,manual",
+    "strict_step_free_cases.csv": "case-ok-strict,station-a,station-g,2026-06-30T09:00:00+09:00,WHEELCHAIR,STRICT_STEP_FREE,MANUAL_OBSERVATION,FRESH,0,100,20,false,true,,manual",
+  };
+  await Promise.all(Object.entries(rowsByFile).map(([file, row]) => (
+    writeFile(path.join(dataset, file), `${header}\n${row}\n`)
+  )));
+
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      "tools/routes/evaluate-eta-accuracy.mjs",
+      "--dataset",
+      dataset,
+      "--output",
+      output,
+    ], { cwd: root }),
+  );
+
+  const report = JSON.parse(await readFile(output, "utf8"));
+  assert.equal(report.metrics.unclassifiedEtaDeviationCount, 1);
+  assert.ok(report.failures.some((failure) => (
+    failure.caseId === "case-unclassified" && failure.type === "UNCLASSIFIED_ETA_DEVIATION"
+  )));
+  assert.ok(!report.failures.some((failure) => (
+    failure.caseId === "case-classified" && failure.type === "UNCLASSIFIED_ETA_DEVIATION"
   )));
 });


### PR DESCRIPTION
## Summary
- ETA accuracy evaluator가 허용 오차를 넘긴 case에 `deviation_reason_code`가 없으면 `UNCLASSIFIED_ETA_DEVIATION` failure와 metric을 남기도록 했습니다.
- route commercialization gate가 `metrics.unclassifiedEtaDeviationCount > 0`을 release blocker로 처리하도록 했습니다.

## 이슈 범위
- #1417의 “오차 상위 케이스 원인 분류” 조건 일부를 gate로 고정합니다.
- #1417 전체 완료가 아닙니다. sampleSize >= 100 실측 캠페인, offline/online 별도 집계, ground truth evidence는 아직 남아 있습니다.

## Verification
- `node --test tools/routes/evaluate-eta-accuracy.test.mjs tools/routes/check-route-commercialization-gate.test.mjs`
- `node --test tools/routes/*.test.mjs`
- `node --test tools/ci/repository-contract.test.mjs`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * ETA 정확도 리포트에 “분류되지 않은 편차” 집계가 추가되었습니다.
  * 상한을 초과한 ETA 오차 중 사유 코드가 없는 항목을 별도 실패로 표시합니다.

* **버그 수정**
  * 분류되지 않은 ETA 편차가 있으면 상용화 게이트가 실패하도록 강화되었습니다.
  * 관련 리포트 상태와 실패 사유가 더 정확하게 표시됩니다.

* **테스트**
  * 분류되지 않은 편차와 기존 분류된 편차에 대한 검증 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
