### PR TITLE
[Style] 즐겨찾기 홈·설정 아이콘 타일과 스위치 액센트 정비

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1876,7 +1876,7 @@ class _HomeNotificationButton extends StatelessWidget {
               style: IconButton.styleFrom(
                 minimumSize: const Size.square(48),
                 backgroundColor: Colors.white,
-                foregroundColor: EasySubwayAccessibleColors.mintDark,
+                foregroundColor: EasySubwayAccessibleColors.secondaryText,
                 side: const BorderSide(
                   color: EasySubwayAccessibleColors.line,
                   width: 1.5,
@@ -2670,7 +2670,7 @@ class _AppSectionTitle extends StatelessWidget {
         title,
         style: Theme.of(context).textTheme.titleMedium?.copyWith(
           color: EasySubwayAccessibleColors.text,
-          fontWeight: FontWeight.w900,
+          fontWeight: FontWeight.w800,
           height: 1.2,
         ),
       ),
@@ -3186,13 +3186,10 @@ class _HomeSavedRouteCard extends StatelessWidget {
             showBorder: true,
             child: Row(
               children: [
-                CircleAvatar(
-                  radius: 21,
-                  backgroundColor: EasySubwayAccessibleColors.mintSoft,
-                  child: const Icon(
-                    Icons.route_outlined,
-                    color: EasySubwayAccessibleColors.mintDark,
-                  ),
+                const Icon(
+                  Icons.route_outlined,
+                  color: EasySubwayAccessibleColors.primary,
+                  size: 30,
                 ),
                 const SizedBox(width: 12),
                 Expanded(
@@ -3204,7 +3201,7 @@ class _HomeSavedRouteCard extends StatelessWidget {
                         style: const TextStyle(
                           color: EasySubwayAccessibleColors.text,
                           fontSize: 16,
-                          fontWeight: FontWeight.w900,
+                          fontWeight: FontWeight.w800,
                           height: 1.25,
                         ),
                       ),
@@ -3272,13 +3269,13 @@ class _HomeMiniBadge extends StatelessWidget {
     return Chip(
       label: Text(label),
       visualDensity: VisualDensity.compact,
-      backgroundColor: EasySubwayAccessibleColors.mintSoft,
-      side: BorderSide.none,
+      backgroundColor: EasySubwayAccessibleColors.surface,
+      side: const BorderSide(color: EasySubwayAccessibleColors.line),
       shape: const StadiumBorder(),
       labelStyle: const TextStyle(
-        color: EasySubwayAccessibleColors.mintDark,
+        color: EasySubwayAccessibleColors.secondaryText,
         fontSize: 11,
-        fontWeight: FontWeight.w900,
+        fontWeight: FontWeight.w700,
         height: 1.2,
       ),
       padding: const EdgeInsets.symmetric(horizontal: 2),
@@ -3293,7 +3290,7 @@ class _AppCard extends StatelessWidget {
     this.borderColor = EasySubwayAccessibleColors.line,
     this.borderRadius = 20,
     this.padding = const EdgeInsets.all(16),
-    this.showBorder = false,
+    this.showBorder = true,
   });
 
   final Widget child;
@@ -3305,10 +3302,11 @@ class _AppCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // 최소 그림자 원칙: 그림자 대신 얇은 보더로 카드를 구분한다.
     return Card(
       margin: EdgeInsets.zero,
       color: backgroundColor,
-      elevation: 2,
+      elevation: 0,
       shadowColor: _appCardShadowColor,
       shape: RoundedRectangleBorder(
         side: showBorder ? BorderSide(color: borderColor) : BorderSide.none,
@@ -3683,7 +3681,7 @@ class _AppSettingsSection extends StatelessWidget {
               title,
               style: textTheme.titleMedium?.copyWith(
                 color: EasySubwayAccessibleColors.text,
-                fontWeight: FontWeight.w900,
+                fontWeight: FontWeight.w800,
                 height: 1.25,
               ),
             ),
@@ -3999,7 +3997,7 @@ class _FavoriteHomeScreenState extends State<FavoriteHomeScreen> {
                         child: _AppCard(
                           child: _AppInfoRow(
                             icon: Icons.bookmark_border,
-                            iconColor: EasySubwayAccessibleColors.mintDark,
+                            iconColor: EasySubwayAccessibleColors.mutedText,
                             title: '즐겨찾기한 항목이 없습니다',
                             subtitle: '역, 시설, 경로에서 즐겨찾기를 추가해 주세요.',
                           ),
@@ -4272,18 +4270,13 @@ class _FavoriteHomeQuickCard extends StatelessWidget {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: EasySubwayAccessibleColors.mintSoft,
-                    borderRadius: _mainThemeControlRadius,
-                  ),
-                  child: SizedBox(
-                    width: 44,
-                    height: 44,
-                    child: Icon(
-                      icon,
-                      color: EasySubwayAccessibleColors.mintDark,
-                    ),
+                SizedBox(
+                  width: 44,
+                  height: 44,
+                  child: Icon(
+                    icon,
+                    color: EasySubwayAccessibleColors.primary,
+                    size: 28,
                   ),
                 ),
                 const SizedBox(width: 12),
@@ -4296,7 +4289,7 @@ class _FavoriteHomeQuickCard extends StatelessWidget {
                         style: const TextStyle(
                           color: EasySubwayAccessibleColors.text,
                           fontSize: 18,
-                          fontWeight: FontWeight.w900,
+                          fontWeight: FontWeight.w800,
                           height: 1.25,
                         ),
                       ),


### PR DESCRIPTION
## Summary

즐겨찾기 홈과 더보기(설정) 화면의 컬러 아이콘 타일·민트 칩을 정리해 단일 primary 액센트와 아웃라인 아이콘 체계로 통일했습니다. (#1479)

- **아이콘 타일 디박싱**: `_FavoriteHomeQuickCard`(mintSoft 타일 + mintDark)·`_HomeSavedRouteCard`(mintSoft CircleAvatar) → 아웃라인 아이콘(타일 제거). 제목 w900 → w800.
- **`_HomeMiniBadge`**: 비상태 정보(노선·이동조건)에 쓰던 mintSoft 칩 + w900 → 화이트 + `line` 보더 + 중립 텍스트.
- **`_HomeNotificationButton`**: 알림 아이콘 전경 mintDark(상태색) → 중립 그레이.
- **즐겨찾기 홈 빈 상태** `_AppInfoRow` 아이콘 mintDark → 중립.
- **`_AppCard`**: elevation 2 + 커스텀 그림자 → elevation 0 + 얇은 보더 기본(최소 그림자 원칙).
- **섹션 타이틀 w900 완화**: `_AppSectionTitle`·`_AppSettingsSection` → w800.

## Verification

- `dart format` · `flutter analyze lib` → **No issues found**
- `flutter test` → **617 passed, 0 failed**

## Notes

- 토대 PR(#1500) 위에 스택합니다. base 병합 후 `main`으로 재지정 예정.
- 설정·온보딩 스위치 트랙의 primary 통일은 토대(#1482, #1475)에서 이미 처리되어 여기서는 제외했습니다.
- "가기 전 살펴보기" 등 의미 있는 상태 틴트는 유지했습니다.