### PR TITLE
[Style] 즐겨찾기 경로 카드 플레이스홀더 문구 정리

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -734,18 +734,20 @@ class FavoriteRoute {
 
   String get summaryTitle => '$originStationName에서 $destinationStationName까지';
 
-  String get lineLabel => lineName.isEmpty ? '노선을 아직 알 수 없어요' : lineName;
+  /// 노선명(모르면 빈 문자열 — 호출부에서 줄 자체를 숨긴다).
+  String get lineLabel => lineName;
 
-  String get scoreLabel => '다시 찾으면 자세히 볼 수 있어요';
+  bool get hasLine => lineName.isNotEmpty;
 
   String get mobilityLabel => _mobilityLabelFor(mobilityType);
 
   String get etaSourceLabel => routeEtaSourceLabel(etaSource);
 
+  /// 확정 정보만: 이동 조건 · 노선(있을 때) · 최근 확인일 · 출처.
   String get scoreBasisText {
     return [
       '$mobilityLabel 조건',
-      lineLabel,
+      if (hasLine) lineLabel,
       _routeDateLabel(routeCreatedAt),
       if (etaSourceLabel.isNotEmpty) etaSourceLabel,
     ].join(' · ');
@@ -754,31 +756,19 @@ class FavoriteRoute {
   String get scoreBasisSemanticLabel {
     return [
       '$mobilityLabel 조건',
-      lineLabel,
+      if (hasLine) lineLabel,
       _routeDateLabel(routeCreatedAt),
       if (etaSourceLabel.isNotEmpty) etaSourceLabel,
     ].join(', ');
   }
 
-  String get movementMetricLabel =>
-      '예상 시간을 확인하고 있어요 · 환승 안내를 확인하고 있어요 · 걷는 거리를 확인하고 있어요';
-
-  String get accessibilityMetricLabel =>
-      '계단 여부를 아직 알 수 없어요 · 엘리베이터 연결을 아직 알 수 없어요';
-
   String get semanticLabel {
     return [
       '즐겨찾기 경로',
       summaryTitle,
-      lineLabel,
+      if (hasLine) lineLabel,
       mobilityLabel,
-      scoreLabel,
       scoreBasisSemanticLabel,
-      '예상 시간을 확인하고 있어요',
-      '환승 안내를 확인하고 있어요',
-      '걷는 거리를 확인하고 있어요',
-      '계단 여부를 아직 알 수 없어요',
-      '엘리베이터 연결을 아직 알 수 없어요',
     ].join(', ');
   }
 }
@@ -3144,6 +3134,13 @@ StationSearchLine _routeRecentLine(String name) {
 
 String _routeLineColor(String name) => fallbackLineColorHex(lineName: name);
 
+/// 기본 레벨(LEVEL_1)·미확정 품질 필러는 목록에서 감춘다(#1477과 동일 규칙).
+bool _showsRouteDataQualityLabel(String dataQualityLevel) {
+  return dataQualityLevel == 'LEVEL_2' ||
+      dataQualityLevel == 'LEVEL_3' ||
+      dataQualityLevel == 'LEVEL_4';
+}
+
 class _RouteRecentDestinationRow extends StatelessWidget {
   const _RouteRecentDestinationRow({
     required this.route,
@@ -3667,14 +3664,18 @@ class _RouteStationOptionTile extends StatelessWidget {
                               height: 1.3,
                             ),
                           ),
-                          const SizedBox(height: 4),
-                          Text(
-                            result.dataQualityLabel,
-                            style: textTheme.bodyMedium?.copyWith(
-                              color: _routeTextMutedColor,
-                              height: 1.3,
+                          if (_showsRouteDataQualityLabel(
+                            result.dataQualityLevel,
+                          )) ...[
+                            const SizedBox(height: 4),
+                            Text(
+                              result.dataQualityLabel,
+                              style: textTheme.bodyMedium?.copyWith(
+                                color: _routeTextMutedColor,
+                                height: 1.3,
+                              ),
                             ),
-                          ),
+                          ],
                         ],
                       ),
                     ),
@@ -5801,11 +5802,6 @@ class _FavoriteRouteTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final menuButtonKey =
-        GlobalKey<PopupMenuButtonState<_FavoriteRouteMenuAction>>();
-    final moreSemanticLabel =
-        '${favorite.summaryTitle} 더 보기${isRemoving ? ', 삭제 중' : ''}';
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -5842,35 +5838,20 @@ class _FavoriteRouteTile extends StatelessWidget {
               const SizedBox(width: 8),
             ],
             Semantics(
-              key: Key('favoriteRouteMore-${favorite.favoriteRouteId}'),
-              container: true,
-              label: moreSemanticLabel,
+              label: '${favorite.summaryTitle} 삭제',
               button: true,
               enabled: !isRemoving,
               onTap: isRemoving
                   ? null
-                  : () => menuButtonKey.currentState?.showButtonMenu(),
+                  : () => unawaited(_confirmRemove(context)),
               child: ExcludeSemantics(
-                child: PopupMenuButton<_FavoriteRouteMenuAction>(
-                  key: menuButtonKey,
-                  enabled: !isRemoving,
-                  tooltip: '경로 더 보기',
-                  onSelected: (action) {
-                    switch (action) {
-                      case _FavoriteRouteMenuAction.remove:
-                        unawaited(_confirmRemove(context));
-                    }
-                  },
-                  itemBuilder: (context) => [
-                    PopupMenuItem<_FavoriteRouteMenuAction>(
-                      key: Key(
-                        'favoriteRouteRemove-${favorite.favoriteRouteId}',
-                      ),
-                      value: _FavoriteRouteMenuAction.remove,
-                      child: const Text('삭제'),
-                    ),
-                  ],
-                  icon: const Icon(Icons.more_vert),
+                child: IconButton(
+                  key: Key('favoriteRouteRemove-${favorite.favoriteRouteId}'),
+                  tooltip: '삭제',
+                  onPressed: isRemoving
+                      ? null
+                      : () => unawaited(_confirmRemove(context)),
+                  icon: const Icon(Icons.delete_outline),
                 ),
               ),
             ),
@@ -5910,8 +5891,6 @@ class _FavoriteRouteTile extends StatelessWidget {
   }
 }
 
-enum _FavoriteRouteMenuAction { remove }
-
 class _FavoriteRouteSummaryCard extends StatelessWidget {
   const _FavoriteRouteSummaryCard({required this.favorite});
 
@@ -5942,59 +5921,27 @@ class _FavoriteRouteSummaryCard extends StatelessWidget {
                     favorite.summaryTitle,
                     style: textTheme.titleLarge?.copyWith(
                       color: _routeTextPrimaryColor,
-                      fontWeight: FontWeight.w900,
+                      fontWeight: FontWeight.w800,
                       height: 1.25,
                     ),
                   ),
-                  const SizedBox(height: 8),
-                  Text(
-                    favorite.lineLabel,
-                    style: textTheme.bodyLarge?.copyWith(
-                      color: _routeTextSecondaryColor,
-                      fontWeight: FontWeight.w800,
-                      height: 1.3,
+                  if (favorite.hasLine) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      favorite.lineLabel,
+                      style: textTheme.bodyLarge?.copyWith(
+                        color: _routeTextSecondaryColor,
+                        fontWeight: FontWeight.w700,
+                        height: 1.3,
+                      ),
                     ),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    favorite.mobilityLabel,
-                    style: textTheme.bodyLarge?.copyWith(
-                      color: _routeTextSecondaryColor,
-                      fontWeight: FontWeight.w800,
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    favorite.scoreLabel,
-                    style: textTheme.bodyLarge?.copyWith(
-                      color: _routeTextSecondaryColor,
-                      fontWeight: FontWeight.w800,
-                      height: 1.3,
-                    ),
-                  ),
+                  ],
                   const SizedBox(height: 6),
                   Text(
                     favorite.scoreBasisText,
                     style: textTheme.bodyMedium?.copyWith(
                       color: _routeTextMutedColor,
                       fontWeight: FontWeight.w700,
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    favorite.movementMetricLabel,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: _routeTextMutedColor,
-                      height: 1.3,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    favorite.accessibilityMetricLabel,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: _routeTextMutedColor,
                       height: 1.3,
                     ),
                   ),

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -1402,8 +1402,10 @@ void main() {
     expect(favorites.single.summaryTitle, '상록수에서 사당까지');
     expect(saved.favoriteRouteId, 'route-1');
     expect(saved.mobilityLabel, '천천히 이동');
-    expect(saved.scoreLabel, '다시 찾으면 자세히 볼 수 있어요');
-    expect(saved.scoreLabel, isNot(contains('92점')));
+    // 플레이스홀더(score/이동·접근성 메트릭) 문구는 카드·시맨틱에서 제거됐다(#1488).
+    expect(saved.semanticLabel, contains('상록수에서 사당까지'));
+    expect(saved.semanticLabel, isNot(contains('92점')));
+    expect(saved.semanticLabel, isNot(contains('아직 알 수 없어요')));
   });
 
   test('경로 피드백 API 저장소는 익명 사용자 식별자와 평가를 전송한다', () async {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -5607,30 +5607,25 @@ void main() {
       expect(find.text('즐겨찾기한 경로'), findsOneWidget);
       expect(find.text('상록수에서 사당까지'), findsOneWidget);
       expect(find.text('수도권 4호선'), findsOneWidget);
-      expect(find.text('천천히 이동'), findsOneWidget);
       expect(find.text('이동 편의도 92점'), findsNothing);
-      expect(find.text('다시 찾으면 자세히 볼 수 있어요'), findsOneWidget);
+      // 고정 플레이스홀더 문구는 카드에서 제거됐다(#1488).
+      expect(find.text('다시 찾으면 자세히 볼 수 있어요'), findsNothing);
       expect(
         find.text('천천히 이동 조건 · 수도권 4호선 · 최근 확인 2026-06-13 · 도착 정보를 확인하고 있어요'),
         findsOneWidget,
       );
       expect(
         find.text('예상 시간을 확인하고 있어요 · 환승 안내를 확인하고 있어요 · 걷는 거리를 확인하고 있어요'),
-        findsOneWidget,
+        findsNothing,
       );
       expect(
         find.text('계단 여부를 아직 알 수 없어요 · 엘리베이터 연결을 아직 알 수 없어요'),
-        findsOneWidget,
+        findsNothing,
       );
-      expect(find.text('상록수에서 사당까지'), findsOneWidget);
-      expect(find.bySemanticsLabel('상록수에서 사당까지 더 보기'), findsOneWidget);
+      // 항목 1개짜리 더 보기 메뉴 → 삭제 아이콘 버튼으로 단순화(#1488).
       expect(
-        tester.getSemantics(find.bySemanticsLabel('상록수에서 사당까지 더 보기')),
-        isSemantics(
-          label: '상록수에서 사당까지 더 보기',
-          isButton: true,
-          hasTapAction: true,
-        ),
+        find.byKey(const Key('favoriteRouteRemove-route-1')),
+        findsOneWidget,
       );
       expect(
         find.byKey(const Key('favoriteRouteSearchAgain-route-1')),
@@ -5657,8 +5652,6 @@ void main() {
         },
       );
 
-      await tester.tap(find.byKey(const Key('favoriteRouteMore-route-1')));
-      await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('favoriteRouteRemove-route-1')));
       await tester.pumpAndSettle();
       expect(find.text('즐겨찾기 경로 삭제'), findsOneWidget);
@@ -5705,8 +5698,6 @@ void main() {
 
     await _openFavoriteList(tester);
 
-    await tester.tap(find.byKey(const Key('favoriteRouteMore-route-1')));
-    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key('favoriteRouteRemove-route-1')));
     await tester.pumpAndSettle();
     await tester.tap(
@@ -5716,9 +5707,12 @@ void main() {
 
     expect(favoriteRouteRepository.removedFavoriteRouteIds, ['route-1']);
     expect(find.text('삭제 중'), findsOneWidget);
-    expect(find.bySemanticsLabel('상록수에서 사당까지 더 보기, 삭제 중'), findsOneWidget);
 
-    await tester.tap(find.byKey(const Key('favoriteRouteMore-route-1')));
+    // 삭제 중에는 삭제 버튼이 비활성화되어 다시 눌러도 재요청되지 않는다.
+    await tester.tap(
+      find.byKey(const Key('favoriteRouteRemove-route-1')),
+      warnIfMissed: false,
+    );
     await tester.pump();
 
     expect(favoriteRouteRepository.removedFavoriteRouteIds, ['route-1']);


### PR DESCRIPTION
## Summary

즐겨찾기 경로 카드가 "정보가 없다"는 플레이스홀더 문구를 여러 줄 나열하던 문제를 정리했습니다. 카드에는 확정 정보만 남깁니다. (#1488)

- **플레이스홀더 3종 제거**: `scoreLabel`("다시 찾으면…")·`movementMetricLabel`("예상 시간을 확인하고 있어요 · …")·`accessibilityMetricLabel`("계단 여부를 아직 알 수 없어요 · …")을 카드와 시맨틱 라벨에서 제거. 카드는 출발→도착 제목 + 노선(있을 때) + 이동 조건·최근 확인일(`scoreBasisText`)만.
- **`lineLabel` 폴백 제거**: 노선을 모르면 "노선을 아직 알 수 없어요" 대신 줄 자체를 숨김(`hasLine`).
- **길찾기 역 피커 결과 타일**: `dataQualityLabel` 필러도 #1477과 동일하게 의미 있을 때(LEVEL_2+)만 노출.
- **더 보기 메뉴 단순화**: 항목이 "삭제" 하나뿐인 `PopupMenuButton` → 삭제 아이콘 버튼 + 확인 다이얼로그(과설계 제거). test Key(`favoriteRouteRemove-*`)·확인 흐름 유지.
- 카드 제목 w900 → w800.

## Verification

- `dart format` · `flutter analyze lib` → **No issues found**
- `flutter test` → **617 passed, 0 failed** (삭제 흐름·시맨틱·필러 문구 관련 테스트 갱신)

## Notes

- 토대 PR(#1500) 위에 스택합니다. base 병합 후 `main`으로 재지정 예정.
- FavoriteRoute API 스키마 변경 없음(표시 계층만 정리).