### PR TITLE
[Fix] route local source policy 표시 고정

### DIFF
--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -89,6 +89,9 @@ class LocalRouteRepository implements RouteSearchRepository {
           .map(_blockedReasonMessage)
           .toList(growable: false),
       createdAt: DateTime.now().toIso8601String(),
+      etaSource: 'STATIC_LOCAL',
+      etaConfidence: 'STATIC',
+      sourceUpdatedAt: catalog.sourceUpdatedAt,
     );
   }
 
@@ -478,6 +481,7 @@ class _RouteCatalogSnapshot {
     required this.stationLines,
     required this.networkEdges,
     required this.strictEvidenceSupported,
+    required this.sourceUpdatedAt,
   });
 
   final Map<String, String> stationsById;
@@ -485,8 +489,13 @@ class _RouteCatalogSnapshot {
   final List<_StationLineSnapshot> stationLines;
   final List<_NetworkEdgeSnapshot> networkEdges;
   final bool strictEvidenceSupported;
+  final String sourceUpdatedAt;
 
   static Future<_RouteCatalogSnapshot> load(CatalogDatabase database) async {
+    final sourceUpdatedAtRow = await database.customSelect('''
+          SELECT MAX(CAST(updated_at AS INTEGER)) AS source_updated_at
+          FROM catalog_metadata
+          ''').getSingleOrNull();
     final stationRows = await database
         .customSelect('SELECT id, name_ko FROM stations')
         .get();
@@ -775,6 +784,9 @@ class _RouteCatalogSnapshot {
           .toList(growable: false),
       networkEdges: networkEdges,
       strictEvidenceSupported: strictEvidenceSupported,
+      sourceUpdatedAt: _metadataUpdatedAtIso(
+        sourceUpdatedAtRow?.readNullable<int>('source_updated_at'),
+      ),
     );
   }
 
@@ -1018,6 +1030,19 @@ class _RouteCatalogSnapshot {
     }
     return nodeId.split(':').first;
   }
+}
+
+String _metadataUpdatedAtIso(int? updatedAtMillis) {
+  if (updatedAtMillis == null || updatedAtMillis <= 0) {
+    return '';
+  }
+  final normalizedMillis = updatedAtMillis < 100000000000
+      ? updatedAtMillis * 1000
+      : updatedAtMillis;
+  return DateTime.fromMillisecondsSinceEpoch(
+    normalizedMillis,
+    isUtc: true,
+  ).toIso8601String();
 }
 
 String _edgePairKey(String fromNodeId, String toNodeId) {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1127,6 +1127,7 @@ class RouteSearchResult {
     this.transferSlackSeconds,
     this.hasOutOfStationTransfer = false,
     this.commercialEtaEligible = false,
+    this.sourceUpdatedAt = '',
   }) : // `burdenCost`는 API contract 이름이고 저장 필드는 private 값이다.
        // ignore: prefer_initializing_formals
        _accessibilityScore = accessibilityScore,
@@ -1232,6 +1233,7 @@ class RouteSearchResult {
           _optionalRouteBool(json, 'hasOutOfStationTransfer') ?? false,
       commercialEtaEligible:
           _optionalRouteBool(json, 'commercialEtaEligible') ?? false,
+      sourceUpdatedAt: _optionalRouteString(json, 'sourceUpdatedAt'),
     );
   }
 
@@ -1291,6 +1293,7 @@ class RouteSearchResult {
         (leg) => leg.legType == 'OUT_OF_STATION_TRANSFER',
       ),
       commercialEtaEligible: itinerary.commercialEtaEligible,
+      sourceUpdatedAt: result.departureTime,
     );
   }
 
@@ -1322,6 +1325,7 @@ class RouteSearchResult {
   final int? transferSlackSeconds;
   final bool hasOutOfStationTransfer;
   final bool commercialEtaEligible;
+  final String sourceUpdatedAt;
 
   int get accessibilityScore => _accessibilityScore ?? score;
 
@@ -1412,7 +1416,16 @@ class RouteSearchResult {
 
   bool get isLocalResult => routeSearchId.startsWith('local-');
 
-  String get sourceNotice => '예상 소요시간: ${routeEtaSourceLabel(etaSource)}';
+  String get sourceNotice {
+    if (isLocalResult && etaSource == 'STATIC_LOCAL') {
+      final updatedAt = sourceUpdatedAt.trim();
+      final freshness = updatedAt.isEmpty
+          ? ''
+          : ' · ${_routeDateLabel(updatedAt)}';
+      return '예상 소요시간: 저장된 데이터 기준$freshness';
+    }
+    return '예상 소요시간: ${routeEtaSourceLabel(etaSource)}';
+  }
 
   RouteSearchResult withDisplayLabels({
     String? originStationName,
@@ -1451,6 +1464,7 @@ class RouteSearchResult {
       transferSlackSeconds: transferSlackSeconds,
       hasOutOfStationTransfer: hasOutOfStationTransfer,
       commercialEtaEligible: commercialEtaEligible,
+      sourceUpdatedAt: sourceUpdatedAt,
     );
   }
 

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -340,6 +340,11 @@ void main() {
     expect(result.transferCount, 0);
     expect(result.evidenceSummary, contains('DURATION_ESTIMATED'));
     expect(result.evidenceSummary, contains('DISTANCE_UNKNOWN'));
+    expect(result.etaSource, 'STATIC_LOCAL');
+    expect(result.sourceNotice, contains('저장된 데이터 기준'));
+    expect(result.sourceNotice, contains('최근 확인 2026-06-19'));
+    expect(result.sourceNotice, isNot(contains('실시간')));
+    expect(result.sourceNotice, isNot(contains('시간표')));
     expect(
       result.steps
           .map((step) => step.lineId)


### PR DESCRIPTION
## Summary
- 로컬 catalog 기반 경로 결과의 ETA source를 `STATIC_LOCAL`로 고정했습니다.
- 로컬 경로 안내 문구가 실시간/시간표 claim으로 보이지 않도록 `저장된 데이터 기준`과 catalog metadata 최신 확인일을 표시합니다.

## 이슈 범위
- #1416의 offline/local source 분리 라벨 조건 일부를 반영합니다.
- #1416 전체 완료가 아닙니다. realtime overlay provider 승격, live sample, 수신지연 보정, coverage report는 아직 남아 있습니다.

## Verification
- `flutter test test/features/routes/local_route_repository_test.dart test/route_search_test.dart`
- `flutter test test/route_search_test.dart`
- `dart format --set-exit-if-changed apps/mobile/lib/features/routes/data/local_route_repository.dart apps/mobile/lib/route_search.dart apps/mobile/test/features/routes/local_route_repository_test.dart`
- `node --test tools/ci/repository-contract.test.mjs`
- `git diff --check`
