### PR TITLE
[Style] 지원 범위 안내 카피 사용자 언어로 정비

### DIFF
--- a/apps/mobile/lib/production_scope.dart
+++ b/apps/mobile/lib/production_scope.dart
@@ -1,13 +1,20 @@
 class ProductionScopeCopy {
   const ProductionScopeCopy._();
 
-  static const supportedClaimKo = '상록수·사당 검증 pilot';
+  /// 안내 가능한 구간(명사구). 문장에 끼워 넣어 쓴다.
+  static const supportedRegionKo = '상록수역·사당역 구간';
+
+  /// 지원 범위 안내(문장). 앱바 부제·설정·도움말 등 단독 노출용.
+  /// 개발/운영 용어(pilot 등) 없이 사용자 언어로 쓴다.
+  static const supportedClaimKo = '지금은 $supportedRegionKo을 안내해요';
+
   static const unsupportedRegionStatus = 'UNSUPPORTED_REGION';
   static const unsupportedRegionActionKo = '다시 확인';
+
   static const routeSearchNotice =
-      '$supportedClaimKo 범위의 경로만 안내하고, 범위 밖 경로는 현장 안내를 $unsupportedRegionActionKo해 주세요.';
+      '$supportedRegionKo 길을 안내해요. 이 구간을 벗어난 경로는 아직 준비 중이에요.';
   static const stationSearchNotice =
-      '$supportedClaimKo 범위의 역 정보를 먼저 보여주고, 벗어난 지역은 $unsupportedRegionActionKo해 주세요.';
+      '$supportedRegionKo 역 정보를 먼저 보여드려요. 다른 지역은 준비되는 대로 추가할게요.';
   static const helpNotice =
-      '현재 지원 범위는 $supportedClaimKo입니다. 범위 밖 정보는 준비 중이거나 $unsupportedRegionActionKo해 주세요.';
+      '지금은 $supportedRegionKo을 안내하고 있어요. 다른 구간은 준비되는 대로 추가할게요.';
 }

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1157,7 +1157,7 @@ void main() {
     await tester.pump();
     await tester.scrollUntilVisible(find.text('지도 표시용 asset'), 240);
     expect(find.text('지도 표시용 asset'), findsOneWidget);
-    expect(find.text('상록수·사당 검증 pilot'), findsOneWidget);
+    expect(find.text('지금은 상록수역·사당역 구간을 안내해요'), findsOneWidget);
   });
 
   testWidgets('노선도 지역 메뉴는 선택한 지역으로 지도를 다시 불러온다', (tester) async {
@@ -3715,7 +3715,7 @@ void main() {
 
     expect(find.text('저장된 안내 상태'), findsOneWidget);
     expect(find.text('검증 구간'), findsOneWidget);
-    expect(find.text('상록수·사당 검증 pilot'), findsNWidgets(2));
+    expect(find.text('지금은 상록수역·사당역 구간을 안내해요'), findsNWidgets(2));
     expect(find.text('마지막 갱신'), findsOneWidget);
     expect(find.text('앱 설치 때 함께 받은 안내'), findsOneWidget);
     expect(find.text('저장 정보 다시 확인'), findsOneWidget);
@@ -5852,7 +5852,7 @@ void main() {
       expect(
         find.descendant(
           of: find.byType(AppBar),
-          matching: find.text('상록수·사당 검증 pilot'),
+          matching: find.text('지금은 상록수역·사당역 구간을 안내해요'),
         ),
         findsOneWidget,
       );
@@ -6140,7 +6140,7 @@ void main() {
       expect(
         find.descendant(
           of: find.byType(AppBar),
-          matching: find.text('상록수·사당 검증 pilot'),
+          matching: find.text('지금은 상록수역·사당역 구간을 안내해요'),
         ),
         findsOneWidget,
       );
@@ -7887,7 +7887,7 @@ void main() {
     expect(
       find.descendant(
         of: find.byType(AppBar),
-        matching: find.text('상록수·사당 검증 pilot'),
+        matching: find.text('지금은 상록수역·사당역 구간을 안내해요'),
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
## Summary

서비스 범위 안내 카피에서 개발·운영 용어를 걷어내고 쉬운 한국어로 바꿨습니다. (#1484)

- **`supportedClaimKo`**: `'상록수·사당 검증 pilot'`(영문 혼용·개발 용어) → `'지금은 상록수역·사당역 구간을 안내해요'`.
- **명사구 분리**: 문장에 끼워 쓰는 `supportedRegionKo`('상록수역·사당역 구간')를 분리해 안내문이 문법적으로 자연스럽게.
- **안내문 재작성**: `routeSearchNotice`/`stationSearchNotice`/`helpNotice`의 기계적 문형("범위 밖 경로는 현장 안내를 다시 확인해 주세요") → 자연스러운 문장("이 구간을 벗어난 경로는 아직 준비 중이에요").

## Verification

- `dart format` · `flutter analyze lib` → **No issues found**
- `flutter test` → **617 passed, 0 failed** (지원 범위 문구 기대값 5곳 동기화)

## Notes

- 토대 PR(#1500) 위에 스택합니다. base 병합 후 `main`으로 재지정 예정.
- 앱바 부제는 문구만 사용자 언어로 교체하고 노출 위치는 유지했습니다(반복 노출 축소는 화면 레이아웃·시맨틱 영향이 커 별도 검토 대상으로 남김).
- 사용자 노출 문구에서 "pilot" 등 영문 개발 용어가 사라졌습니다.