### PR TITLE
[Style] 더보기 하위 화면 정보 카드 톤·영문 라벨 정비

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4360,11 +4360,10 @@ class OfflineDataScreen extends StatelessWidget {
           padding: _mainPagePadding,
           children: const [
             _AppCard(
-              backgroundColor: EasySubwayAccessibleColors.mintSoft,
-              borderColor: EasySubwayAccessibleColors.mintBorder,
+              showBorder: true,
               child: _AppInfoRow(
                 icon: Icons.check_circle_outline,
-                iconColor: EasySubwayAccessibleColors.mintDark,
+                iconColor: EasySubwayAccessibleColors.primary,
                 title: '인터넷 없이도 이용할 수 있어요',
                 subtitle: '마지막으로 받은 노선도와 역 정보를 보여줍니다.',
               ),
@@ -5235,11 +5234,10 @@ class UserDataDeletionResultScreen extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             const _AppCard(
-              backgroundColor: EasySubwayAccessibleColors.skySoft,
-              borderColor: _homeInfoBorderColor,
+              showBorder: true,
               child: _AppInfoRow(
                 icon: Icons.map_outlined,
-                iconColor: EasySubwayAccessibleColors.brand,
+                iconColor: EasySubwayAccessibleColors.primary,
                 title: '노선도와 역 정보는 계속 이용할 수 있어요',
               ),
             ),
@@ -5274,7 +5272,7 @@ class _DataDeletionResultRow extends StatelessWidget {
           title,
           style: textTheme.titleMedium?.copyWith(
             color: EasySubwayAccessibleColors.text,
-            fontWeight: FontWeight.w900,
+            fontWeight: FontWeight.w800,
           ),
         ),
         const SizedBox(height: 4),
@@ -5287,6 +5285,7 @@ class _DataDeletionResultRow extends StatelessWidget {
         ),
       ],
     );
+    // 삭제 완료는 복구/완료 상태 의미가 있어 민트 뱃지를 유지한다.
     final statusBadge = Container(
       key: Key('dataDeletionResultStatus-$id'),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
@@ -5298,8 +5297,8 @@ class _DataDeletionResultRow extends StatelessWidget {
       child: const Text(
         '완료',
         style: TextStyle(
-          color: EasySubwayAccessibleColors.text,
-          fontWeight: FontWeight.w900,
+          color: EasySubwayAccessibleColors.mintDark,
+          fontWeight: FontWeight.w800,
         ),
       ),
     );
@@ -5753,9 +5752,9 @@ class _DataSourceAttributionScreenState
                         subtitle: ProductionScopeCopy.supportedClaimKo,
                       ),
                     ),
-                    const _AppSectionTitle(title: '지도 표시용 asset'),
+                    const _AppSectionTitle(title: '지도 표시용 파일'),
                     for (final map in maps) _AttributionCard.map(map, manifest),
-                    const _AppSectionTitle(title: '경로·시설 판단용 data pack'),
+                    const _AppSectionTitle(title: '경로·시설 판단용 데이터'),
                     for (final source in sources)
                       _AttributionCard.source(source),
                   ],
@@ -5782,24 +5781,21 @@ class _AttributionCard extends StatelessWidget {
     final offline = (map['offline'] as Map<String, Object?>?) ?? const {};
     return _AttributionCard._(
       title: _text(map['name_ko']),
-      subtitle: 'provider/owner: ${_text(map['operator'])}',
+      subtitle: '제공·소유: ${_text(map['operator'])}',
       rows: [
-        ('source name', _text(license['source'], _text(map['name_ko']))),
+        ('출처명', _text(license['source'], _text(map['name_ko']))),
+        ('라이선스', '${_text(license['name'])} (${_text(license['spdx'])})'),
+        ('라이선스 링크', _text(license['url'])),
+        ('출처 표기 필요', _yesNo(license['attributionRequired'])),
+        ('가져온 날짜', _text(license['date'])),
+        ('확인한 날짜', _text(manifest['generated_at_utc'])),
         (
-          'license type',
-          '${_text(license['name'])} (${_text(license['spdx'])})',
-        ),
-        ('license URL', _text(license['url'])),
-        ('attribution required', _yesNo(license['attributionRequired'])),
-        ('last retrieved', _text(license['date'])),
-        ('last verified', _text(manifest['generated_at_utc'])),
-        (
-          'commercial use / redistribution',
+          '상업적 이용 / 재배포',
           '${_allowed(license['commercialUseAllowed'])} / ${_allowed(license['redistributionAllowed'])}',
         ),
-        ('review status', _text(license['reviewStatus'])),
-        ('changes', _text(license['changes'])),
-        ('asset path', _text(offline['path'])),
+        ('검토 상태', _text(license['reviewStatus'])),
+        ('변경 사항', _text(license['changes'])),
+        ('파일 경로', _text(offline['path'])),
       ],
     );
   }
@@ -5809,26 +5805,23 @@ class _AttributionCard extends StatelessWidget {
     return _AttributionCard._(
       title: _text(source['displayName']),
       subtitle:
-          'provider/owner: ${_text(source['provider'])} / ${_text(source['owner'])}',
+          '제공·소유: ${_text(source['provider'])} / ${_text(source['owner'])}',
       rows: [
-        ('source name', _text(source['displayName'])),
+        ('출처명', _text(source['displayName'])),
+        ('라이선스', '${_text(license['name'])} (${_text(license['type'])})'),
+        ('라이선스 링크', _text(license['evidenceUrl'])),
+        ('출처 표기 필요', _text(license['attribution'])),
+        ('가져온 날짜', _text(source['retrievedAt'])),
+        ('확인한 날짜', _text(source['observedDataUpdatedAt'])),
         (
-          'license type',
-          '${_text(license['name'])} (${_text(license['type'])})',
-        ),
-        ('license URL', _text(license['evidenceUrl'])),
-        ('attribution required', _text(license['attribution'])),
-        ('last retrieved', _text(source['retrievedAt'])),
-        ('last verified', _text(source['observedDataUpdatedAt'])),
-        (
-          'commercial use / redistribution',
+          '상업적 이용 / 재배포',
           '${_allowed(license['commercialUseAllowed'])} / ${_allowed(license['redistributionAllowed'])}',
         ),
         (
-          'changes',
+          '변경 사항',
           source.containsKey('changes')
               ? _text(source['changes'])
-              : 'inventory에 별도 변경 고지 없음',
+              : '자료 목록에 별도 변경 고지 없음',
         ),
       ],
     );
@@ -5857,7 +5850,7 @@ class _AttributionCard extends StatelessWidget {
                 title,
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
                   color: EasySubwayAccessibleColors.text,
-                  fontWeight: FontWeight.w900,
+                  fontWeight: FontWeight.w800,
                   height: 1.25,
                 ),
               ),
@@ -5930,7 +5923,7 @@ class _AttributionRow extends StatelessWidget {
             label,
             style: Theme.of(context).textTheme.labelLarge?.copyWith(
               color: EasySubwayAccessibleColors.secondaryText,
-              fontWeight: FontWeight.w900,
+              fontWeight: FontWeight.w800,
               height: 1.25,
             ),
           ),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1155,8 +1155,8 @@ void main() {
     expect(find.text('데이터 및 지도 출처'), findsOneWidget);
     await tester.pump();
     await tester.pump();
-    await tester.scrollUntilVisible(find.text('지도 표시용 asset'), 240);
-    expect(find.text('지도 표시용 asset'), findsOneWidget);
+    await tester.scrollUntilVisible(find.text('지도 표시용 파일'), 240);
+    expect(find.text('지도 표시용 파일'), findsOneWidget);
     expect(find.text('상록수·사당 검증 pilot'), findsOneWidget);
   });
 


### PR DESCRIPTION
## Summary

더보기 하위 화면(인터넷 없이 이용·내 정보 삭제 결과·데이터 및 지도 출처)의 장식 틴트와 영문 라벨을 정리했습니다. (#1480)

- **영문 라벨 → 한국어**: 데이터 출처 화면의 `source name`·`license type`·`license URL`·`attribution required`·`last retrieved`·`commercial use / redistribution`·`asset path`·`provider/owner` 등을 한국어로. 섹션 제목 "지도 표시용 asset"/"경로·시설 판단용 data pack" → "…파일"/"…데이터".
- **틴트 카드 디박싱**: `OfflineDataScreen` 헤더 mintSoft 카드·`UserDataDeletionResultScreen` skySoft 안내 카드 → 화이트 + 얇은 보더, 아이콘 primary.
- **`_DataDeletionResultRow`**: 제목 w900 → w800. "완료" 민트 뱃지는 완료 상태 의미가 있어 유지(텍스트 w800·mint).
- **데이터 출처 카드 라벨** w900 → w800.

## Verification

- `dart format` · `flutter analyze lib test` → **No issues found**
- `flutter test` → **617 passed, 0 failed** ("지도 표시용 파일" 등 라벨 기대값 동기화)

## Notes

- 토대 PR(#1500) 위에 스택합니다. base 병합 후 `main`으로 재지정 예정.
- 데이터 lookup 키('changes' 등)는 그대로 두고 표시 라벨만 한국어로 바꿨습니다.
- 안전 안내(`_SafetyDataNotice`)의 amber는 주의 성격으로 판단해 유지했습니다.