### PR TITLE
[Style] 시설 제보·즐겨찾기 시설 상태색 매핑 통일

### DIFF
--- a/apps/mobile/lib/accessible_design.dart
+++ b/apps/mobile/lib/accessible_design.dart
@@ -68,6 +68,9 @@ class EasySubwayAccessibleColors {
   /// 고장·오류 상태 배경 틴트.
   static const redSoft = Color(0xFFFFE8E6);
 
+  /// 확인 중·제보됨(needsInfo) 상태색. 브랜드 액센트 1계열로 통일한다.
+  static const needsInfo = primary;
+
   /// 정보 틴트(레거시). 장식용이므로 화면 정비 시 여백·구분선으로 대체한다.
   static const skySoft = Color(0xFFE6F5FF);
 

--- a/apps/mobile/lib/facility_report.dart
+++ b/apps/mobile/lib/facility_report.dart
@@ -48,7 +48,7 @@ const _facilityReportCardRadius = BorderRadius.all(Radius.circular(16));
 /// 텍스트로 상태를 구분하기 위한 전경색만 돌려준다.
 Color _reportStatusColor(String status) {
   return switch (status) {
-    'SUBMITTED' => const Color(0xFF17527C),
+    'SUBMITTED' => EasySubwayAccessibleColors.needsInfo,
     'UNDER_REVIEW' => EasySubwayAccessibleColors.amber,
     'ACCEPTED' || 'RESOLVED' => EasySubwayAccessibleColors.mintDark,
     'REJECTED' => EasySubwayAccessibleColors.red,
@@ -1417,7 +1417,7 @@ class _MyReportEmpty extends StatelessWidget {
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.titleLarge?.copyWith(
                 color: EasySubwayAccessibleColors.text,
-                fontWeight: FontWeight.w900,
+                fontWeight: FontWeight.w800,
                 height: 1.3,
               ),
             ),
@@ -1455,7 +1455,7 @@ class _MyReportError extends StatelessWidget {
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.titleLarge?.copyWith(
                 color: EasySubwayAccessibleColors.text,
-                fontWeight: FontWeight.w900,
+                fontWeight: FontWeight.w800,
                 height: 1.3,
               ),
             ),
@@ -1522,7 +1522,7 @@ class _MyReportListItem extends StatelessWidget {
                           report.reportTypeLabel,
                           style: textTheme.titleMedium?.copyWith(
                             color: EasySubwayAccessibleColors.text,
-                            fontWeight: FontWeight.w900,
+                            fontWeight: FontWeight.w800,
                             height: 1.25,
                           ),
                         ),
@@ -1590,7 +1590,7 @@ class MyFacilityReportDetailScreen extends StatelessWidget {
                 report.reportTypeLabel,
                 style: Theme.of(context).textTheme.headlineSmall?.copyWith(
                   color: EasySubwayAccessibleColors.text,
-                  fontWeight: FontWeight.w900,
+                  fontWeight: FontWeight.w800,
                   height: 1.25,
                 ),
               ),
@@ -1640,7 +1640,7 @@ class _MyReportDetailStatus extends StatelessWidget {
             label,
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
               color: color,
-              fontWeight: FontWeight.w900,
+              fontWeight: FontWeight.w800,
               height: 1.2,
             ),
           ),
@@ -1665,7 +1665,7 @@ class _MyReportDetailRow extends StatelessWidget {
           label,
           style: Theme.of(context).textTheme.labelLarge?.copyWith(
             color: EasySubwayAccessibleColors.mutedText,
-            fontWeight: FontWeight.w900,
+            fontWeight: FontWeight.w800,
             height: 1.2,
           ),
         ),
@@ -1705,7 +1705,7 @@ class _MyReportStatusLabel extends StatelessWidget {
           label,
           style: Theme.of(context).textTheme.labelLarge?.copyWith(
             color: color,
-            fontWeight: FontWeight.w900,
+            fontWeight: FontWeight.w800,
             height: 1.2,
           ),
         ),
@@ -2440,7 +2440,7 @@ class _FacilityReportStatusRow extends StatelessWidget {
           value,
           style: textTheme.titleMedium?.copyWith(
             color: EasySubwayAccessibleColors.text,
-            fontWeight: FontWeight.w900,
+            fontWeight: FontWeight.w800,
             height: 1.25,
           ),
         ),
@@ -2470,7 +2470,7 @@ class _FacilityReportHeader extends StatelessWidget {
               '${target.stationName}역',
               style: textTheme.headlineSmall?.copyWith(
                 color: EasySubwayAccessibleColors.text,
-                fontWeight: FontWeight.w900,
+                fontWeight: FontWeight.w800,
                 height: 1.2,
               ),
             ),
@@ -2512,7 +2512,7 @@ class _FacilityReportSectionTitle extends StatelessWidget {
         title,
         style: Theme.of(context).textTheme.titleLarge?.copyWith(
           color: EasySubwayAccessibleColors.text,
-          fontWeight: FontWeight.w900,
+          fontWeight: FontWeight.w800,
           height: 1.25,
         ),
       ),
@@ -2574,7 +2574,7 @@ class _FacilityReportTypeCard extends StatelessWidget {
                         style: Theme.of(context).textTheme.titleMedium
                             ?.copyWith(
                               color: textColor,
-                              fontWeight: FontWeight.w900,
+                              fontWeight: FontWeight.w800,
                               height: 1.25,
                             ),
                       ),
@@ -2599,7 +2599,7 @@ class _FacilityReportMessage extends StatelessWidget {
   Widget build(BuildContext context) {
     final isFailure = state.status == FacilityReportViewStatus.failure;
     final color = isFailure
-        ? EasySubwayAccessibleColors.amber
+        ? EasySubwayAccessibleColors.red
         : EasySubwayAccessibleColors.primary;
     final icon = isFailure ? Icons.error_outline : Icons.check_circle_outline;
     final shouldShowNextAction = _shouldShowFacilityReportFailureNextAction(
@@ -2672,7 +2672,7 @@ class _FacilityReportLocationMessage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final color = isFailure
-        ? EasySubwayAccessibleColors.amber
+        ? EasySubwayAccessibleColors.red
         : EasySubwayAccessibleColors.primary;
     final icon = isFailure ? Icons.error_outline : Icons.check_circle_outline;
 

--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -22,7 +22,7 @@ Color _favoriteFacilitySeverityColor(FacilityStatusSeverity severity) {
   return switch (severity) {
     FacilityStatusSeverity.blocked => EasySubwayAccessibleColors.red,
     FacilityStatusSeverity.caution => EasySubwayAccessibleColors.amber,
-    FacilityStatusSeverity.needsInfo => const Color(0xFF17527C),
+    FacilityStatusSeverity.needsInfo => EasySubwayAccessibleColors.needsInfo,
     FacilityStatusSeverity.normal => EasySubwayAccessibleColors.mintDark,
   };
 }
@@ -658,7 +658,7 @@ class _FavoriteFacilityTile extends StatelessWidget {
                             favorite.severityLabel,
                             style: textTheme.bodyMedium?.copyWith(
                               color: severityColor,
-                              fontWeight: FontWeight.w900,
+                              fontWeight: FontWeight.w800,
                               height: 1.2,
                             ),
                           ),
@@ -669,7 +669,7 @@ class _FavoriteFacilityTile extends StatelessWidget {
                         favorite.name,
                         style: textTheme.titleLarge?.copyWith(
                           color: EasySubwayAccessibleColors.text,
-                          fontWeight: FontWeight.w900,
+                          fontWeight: FontWeight.w800,
                           height: 1.25,
                         ),
                       ),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -60,7 +60,6 @@ const _highContrastSecondaryColor =
     EasySubwayAccessibleColors.highContrastSecondary;
 const _homeInfoBorderColor = Color(0xFFB7DDF4);
 const _homeFacilityCautionBorderColor = Color(0xFFF1D49A);
-const _homeFacilityInfoBorderColor = Color(0xFFC8E6F8);
 const _settingsSwitchActiveTrackColor =
     EasySubwayAccessibleColors.switchActiveTrack;
 const _settingsSwitchInactiveTrackColor =
@@ -2834,9 +2833,9 @@ _FacilitySeverityAccent _facilitySeverityAccent(
       iconColor: EasySubwayAccessibleColors.amber,
     ),
     FacilityStatusSeverity.needsInfo => const _FacilitySeverityAccent(
-      backgroundColor: EasySubwayAccessibleColors.skySoft,
-      borderColor: _homeFacilityInfoBorderColor,
-      iconColor: EasySubwayAccessibleColors.brand,
+      backgroundColor: Colors.white,
+      borderColor: EasySubwayAccessibleColors.needsInfo,
+      iconColor: EasySubwayAccessibleColors.needsInfo,
     ),
     FacilityStatusSeverity.normal => const _FacilitySeverityAccent(
       backgroundColor: Colors.white,


### PR DESCRIPTION
## Summary

시설 제보·즐겨찾기 시설 화면의 상태색을 팔레트 토큰으로 수렴해, 같은 상태가 화면이 달라도 같은 색으로 보이게 통일했습니다. (#1481)

- **needsInfo(확인 중·제보됨) 통일**: 팔레트에 `needsInfo` 토큰(primary 계열) 추가 후, 서로 달랐던 하드코딩 네이비(`0xFF17527C`) 3곳 수렴 — `favorite_facility`(needsInfo), `facility_report`(SUBMITTED), `main._facilitySeverityAccent`.
- **홈 시설 알림 needsInfo 카드**: 레거시 skySoft 틴트 → 화이트 + primary 보더/아이콘.
- **제보 실패 색 의미 정리**: 실패(오류) 메시지 amber → red(팔레트 의미 체계: 고장·오류=red, 주의=amber).
- **w900 완화**: `facility_report` 11곳·`favorite_facility` 2곳 → w800.
- 사용처가 사라진 `_homeFacilityInfoBorderColor` 상수 제거.

## Verification

- `dart format` · `flutter analyze lib` → **No issues found**
- `flutter test` → **617 passed, 0 failed**

## Notes

- 토대 PR(#1500) 위에 스택합니다. base 병합 후 `main`으로 재지정 예정.
- `_FacilityReportStatusPanel`의 mintSoft는 "접수 완료" 상태 의미가 있어 유지했습니다. dot+컬러 텍스트 패턴은 기준에 부합하여 유지.
- 시설 유형 아이콘 매핑 공용화는 로직 영향 범위가 커 별도 검토 대상으로 남깁니다.