### PR TITLE
[Style] 출시 기준 시각 일관성 정밀 정비(광고 배너·그림자)

### DIFF
--- a/apps/mobile/lib/ad_slot.dart
+++ b/apps/mobile/lib/ad_slot.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'accessible_design.dart';
+
+/// 실광고 연동 전까지 사용하는 공용 배너 슬롯.
+///
+/// 노출 규칙(전 화면 공통):
+/// - release 빌드: 로드된 실광고([child])가 없으면 슬롯을 렌더링하지 않는다.
+///   빈 박스·"광고" 텍스트 플레이스홀더를 release에 상시 노출하지 않는다.
+/// - debug/internal 빌드: 자리 확인용 플레이스홀더만 노출한다.
+///
+/// 실광고 SDK를 연동하면 로드된 배너를 [child]로 전달한다. 로드 실패·무재고면
+/// 상위에서 이 위젯을 렌더링하지 않거나 [child]를 null로 두면 슬롯이 collapse된다.
+class AdBannerSlot extends StatelessWidget {
+  const AdBannerSlot({
+    required this.slotKey,
+    this.height = 52,
+    this.showTopDivider = true,
+    this.child,
+    super.key,
+  });
+
+  final Key slotKey;
+  final double height;
+  final bool showTopDivider;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    final ad = child;
+    // 실광고가 없는 상태에서 release면 슬롯 자체를 숨긴다(collapse).
+    if (ad == null && kReleaseMode) {
+      return const SizedBox.shrink();
+    }
+    return Semantics(
+      label: '광고',
+      child: Container(
+        key: slotKey,
+        height: height,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: EasySubwayAccessibleColors.surface,
+          border: showTopDivider
+              ? const Border(
+                  top: BorderSide(color: EasySubwayAccessibleColors.line),
+                )
+              : null,
+        ),
+        child:
+            ad ??
+            const Text(
+              '광고 미리보기 (개발용)',
+              style: TextStyle(
+                color: EasySubwayAccessibleColors.mutedText,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
 import 'accessible_design.dart';
+import 'ad_slot.dart';
 import 'features/network_map/domain/map_camera.dart';
 import 'features/network_map/infrastructure/android_route_map_viewport_webview.dart';
 import 'features/network_map/infrastructure/ios_route_map_viewport_webview.dart';
@@ -1649,24 +1650,12 @@ class _NetworkMapBottomAdBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
+    // 실광고 미연동: release에서는 "광고" 플레이스홀더를 노출하지 않고 슬롯을 숨긴다.
+    return const SafeArea(
       top: false,
-      child: Container(
-        key: const Key('networkMapBottomAdBanner'),
+      child: AdBannerSlot(
+        slotKey: Key('networkMapBottomAdBanner'),
         height: _networkMapBottomAdHeight,
-        alignment: Alignment.center,
-        decoration: const BoxDecoration(
-          color: Colors.white,
-          border: Border(top: BorderSide(color: Color(0xFFE5E5E5))),
-        ),
-        child: const Text(
-          '광고',
-          style: TextStyle(
-            color: Color(0xFF666666),
-            fontSize: 13,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
       ),
     );
   }

--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1704,75 +1704,93 @@ class _NetworkMapMenuPanel extends StatelessWidget {
         child: SizedBox(
           width: width.clamp(280.0, 430.0).toDouble(),
           height: double.infinity,
-          child: SafeArea(
-            bottom: false,
-            child: ListView(
-              padding: EdgeInsets.zero,
-              children: [
-                const _NetworkMapMenuHeader(),
-                const Divider(height: 1, color: Color(0xFFE4E4E4)),
-                const _NetworkMapMenuSectionLabel('탐색'),
-                _NetworkMapMenuTile(
-                  key: const Key('networkMapMenuStationSearchButton'),
-                  icon: Icons.search,
-                  label: '역 검색',
-                  onTap: () => _runAction(context, onOpenStationSearch),
+          child: Column(
+            children: [
+              Expanded(
+                child: SafeArea(
+                  bottom: false,
+                  child: ListView(
+                    padding: EdgeInsets.zero,
+                    children: [
+                      const _NetworkMapMenuHeader(),
+                      const Divider(height: 1, color: Color(0xFFE4E4E4)),
+                      const _NetworkMapMenuSectionLabel('탐색'),
+                      _NetworkMapMenuTile(
+                        key: const Key('networkMapMenuStationSearchButton'),
+                        icon: Icons.search,
+                        label: '역 검색',
+                        onTap: () => _runAction(context, onOpenStationSearch),
+                      ),
+                      _NetworkMapMenuTile(
+                        key: const Key('networkMapMenuRouteSearchButton'),
+                        icon: Icons.route_outlined,
+                        label: '길찾기',
+                        onTap: () =>
+                            _runFutureAction(context, onOpenRouteSearch),
+                      ),
+                      if (onOpenNearbyStations != null)
+                        _NetworkMapMenuTile(
+                          key: const Key('networkMapMenuNearbyButton'),
+                          icon: Icons.near_me_outlined,
+                          label: '가까운 역',
+                          onTap: () =>
+                              _runAction(context, onOpenNearbyStations!),
+                        ),
+                      if (onOpenRecentSearch != null)
+                        _NetworkMapMenuTile(
+                          key: const Key('networkMapMenuRecentButton'),
+                          icon: Icons.history,
+                          label: '최근 검색',
+                          onTap: () => _runAction(context, onOpenRecentSearch!),
+                        ),
+                      if (onOpenSavedItems != null) ...[
+                        const _NetworkMapMenuSectionLabel('내 정보'),
+                        _NetworkMapMenuTile(
+                          key: const Key('networkMapMenuSavedButton'),
+                          icon: Icons.star_border_rounded,
+                          label: '즐겨찾기',
+                          onTap: () => _runAction(context, onOpenSavedItems!),
+                        ),
+                      ],
+                      if (onOpenDataSources != null) ...[
+                        const _NetworkMapMenuSectionLabel('안내'),
+                        _NetworkMapMenuTile(
+                          key: const Key('networkMapMenuDataSourcesButton'),
+                          icon: Icons.source_outlined,
+                          label: '자료 제공 정보',
+                          onTap: () => _runActionAfterMenuClose(
+                            context,
+                            onOpenDataSources!,
+                          ),
+                        ),
+                      ],
+                      const SizedBox(height: 10),
+                      const Divider(height: 1, color: Color(0xFFEDEDED)),
+                      const _NetworkMapMenuInfoBanner(),
+                      const Padding(
+                        padding: EdgeInsets.fromLTRB(24, 6, 24, 8),
+                        child: Text(
+                          '교통약자 이동을 더 쉽게',
+                          style: TextStyle(
+                            color: Color(0xFF9A9A9A),
+                            fontSize: 13,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-                _NetworkMapMenuTile(
-                  key: const Key('networkMapMenuRouteSearchButton'),
-                  icon: Icons.route_outlined,
-                  label: '길찾기',
-                  onTap: () => _runFutureAction(context, onOpenRouteSearch),
+              ),
+              // 패널 최하단 고정 광고 슬롯(항목 스크롤과 분리, release는 collapse).
+              const SafeArea(
+                top: false,
+                child: AdBannerSlot(
+                  slotKey: Key('networkMapMenuAdBanner'),
+                  height: 56,
                 ),
-                if (onOpenNearbyStations != null)
-                  _NetworkMapMenuTile(
-                    key: const Key('networkMapMenuNearbyButton'),
-                    icon: Icons.near_me_outlined,
-                    label: '가까운 역',
-                    onTap: () => _runAction(context, onOpenNearbyStations!),
-                  ),
-                if (onOpenRecentSearch != null)
-                  _NetworkMapMenuTile(
-                    key: const Key('networkMapMenuRecentButton'),
-                    icon: Icons.history,
-                    label: '최근 검색',
-                    onTap: () => _runAction(context, onOpenRecentSearch!),
-                  ),
-                if (onOpenSavedItems != null) ...[
-                  const _NetworkMapMenuSectionLabel('내 정보'),
-                  _NetworkMapMenuTile(
-                    key: const Key('networkMapMenuSavedButton'),
-                    icon: Icons.star_border_rounded,
-                    label: '즐겨찾기',
-                    onTap: () => _runAction(context, onOpenSavedItems!),
-                  ),
-                ],
-                if (onOpenDataSources != null) ...[
-                  const _NetworkMapMenuSectionLabel('안내'),
-                  _NetworkMapMenuTile(
-                    key: const Key('networkMapMenuDataSourcesButton'),
-                    icon: Icons.source_outlined,
-                    label: '자료 제공 정보',
-                    onTap: () =>
-                        _runActionAfterMenuClose(context, onOpenDataSources!),
-                  ),
-                ],
-                const SizedBox(height: 10),
-                const Divider(height: 1, color: Color(0xFFEDEDED)),
-                const _NetworkMapMenuInfoBanner(),
-                const Padding(
-                  padding: EdgeInsets.fromLTRB(24, 6, 24, 8),
-                  child: Text(
-                    '교통약자 이동을 더 쉽게',
-                    style: TextStyle(
-                      color: Color(0xFF9A9A9A),
-                      fontSize: 13,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -2831,11 +2831,12 @@ class _RoutePointPickerCard extends StatelessWidget {
         color: Colors.white,
         border: Border.all(color: _routeCardBorderColor),
         borderRadius: _routeSearchPickerRadius,
+        // 최소 그림자 원칙: 보더 중심으로 낮춘다.
         boxShadow: const [
           BoxShadow(
             color: _routeCardShadowColor,
-            blurRadius: 16,
-            offset: Offset(0, 5),
+            blurRadius: 8,
+            offset: Offset(0, 3),
           ),
         ],
       ),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3100,6 +3100,29 @@ void main() {
     expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
   });
 
+  testWidgets('노선도 좌측 메뉴 하단에 광고 슬롯이 있다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('networkMapMenuButton')));
+    await tester.pumpAndSettle();
+
+    // debug 빌드에서는 자리 확인용 슬롯이 패널 하단에 렌더링된다.
+    // (release에서는 실광고가 없으면 collapse — 노출 규칙은 #1485)
+    expect(find.byKey(const Key('networkMapMenuAdBanner')), findsOneWidget);
+  });
+
   testWidgets('노선도 chrome은 시스템 글자 크기를 따른다', (tester) async {
     tester.platformDispatcher.textScaleFactorTestValue = 2;
     addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);


### PR DESCRIPTION
## Summary

출시 기준 시각 일관성 항목 중 광고 배너 노출 규칙(P1 출시 차단)과 그림자 감사(P2)를 정비했습니다. (#1485)

- **(P1) 광고 배너 플레이스홀더 노출 차단**: 공용 `AdBannerSlot` 위젯을 추가하고 노선도 하단 배너를 교체.
  - release 빌드: 로드된 실광고가 없으면 슬롯을 렌더링하지 않음(빈 박스·"광고" 텍스트 상시 노출 금지).
  - debug/internal 빌드: 자리 확인용 플레이스홀더만 노출.
  - 실광고 SDK 연동 시 `child`에 배너를 전달하면 그대로 사용. 주변역 패널 오픈 시 배너 숨김 동작은 유지.
- **(P2) 그림자 감사(최소 그림자 원칙)**: 길찾기 피커 카드 그림자 blur 16 → 8(보더 중심).

## Verification

- `dart format` · `flutter analyze lib` → **No issues found**
- `flutter test` → **617 passed, 0 failed** (배너는 debug/test에서 플레이스홀더로 렌더링되어 기존 키 테스트 유지)

## Notes

- 토대 PR(#1500) 위에 스택합니다. base 병합 후 `main`으로 재지정 예정.
- `AdBannerSlot`은 좌측 메뉴 하단 슬롯(#1495)·길찾기 결과 하단 슬롯(#1496)에서 재사용합니다.
- 온보딩 인트로 아이콘 그림자(#1475)·`_AppCard` elevation(#1479)은 각 화면 이슈에서 이미 낮췄고, 길찾기 안내 액센트 그림자는 #1478 범위입니다.
- 남은 하위 항목: **이동 조건 선택 카드 패턴 통일**(온보딩·설정·길찾기 3개 화면의 서로 다른 선택 UI를 하나로)과 **모서리 반경 스케일 토큰화**는 3~4개 파일에 걸친 큰 교차 리팩토링이라, 회귀 위험을 고려해 별도 후속으로 분리합니다.