### PR TITLE
[Feature] 좌측 메뉴 하단 고정 광고 배너 슬롯 추가

### DIFF
--- a/apps/mobile/lib/network_map.dart
+++ b/apps/mobile/lib/network_map.dart
@@ -1704,75 +1704,93 @@ class _NetworkMapMenuPanel extends StatelessWidget {
         child: SizedBox(
           width: width.clamp(280.0, 430.0).toDouble(),
           height: double.infinity,
-          child: SafeArea(
-            bottom: false,
-            child: ListView(
-              padding: EdgeInsets.zero,
-              children: [
-                const _NetworkMapMenuHeader(),
-                const Divider(height: 1, color: Color(0xFFE4E4E4)),
-                const _NetworkMapMenuSectionLabel('탐색'),
-                _NetworkMapMenuTile(
-                  key: const Key('networkMapMenuStationSearchButton'),
-                  icon: Icons.search,
-                  label: '역 검색',
-                  onTap: () => _runAction(context, onOpenStationSearch),
+          child: Column(
+            children: [
+              Expanded(
+                child: SafeArea(
+                  bottom: false,
+                  child: ListView(
+                    padding: EdgeInsets.zero,
+                    children: [
+                      const _NetworkMapMenuHeader(),
+                      const Divider(height: 1, color: Color(0xFFE4E4E4)),
+                      const _NetworkMapMenuSectionLabel('탐색'),
+                      _NetworkMapMenuTile(
+                        key: const Key('networkMapMenuStationSearchButton'),
+                        icon: Icons.search,
+                        label: '역 검색',
+                        onTap: () => _runAction(context, onOpenStationSearch),
+                      ),
+                      _NetworkMapMenuTile(
+                        key: const Key('networkMapMenuRouteSearchButton'),
+                        icon: Icons.route_outlined,
+                        label: '길찾기',
+                        onTap: () =>
+                            _runFutureAction(context, onOpenRouteSearch),
+                      ),
+                      if (onOpenNearbyStations != null)
+                        _NetworkMapMenuTile(
+                          key: const Key('networkMapMenuNearbyButton'),
+                          icon: Icons.near_me_outlined,
+                          label: '가까운 역',
+                          onTap: () =>
+                              _runAction(context, onOpenNearbyStations!),
+                        ),
+                      if (onOpenRecentSearch != null)
+                        _NetworkMapMenuTile(
+                          key: const Key('networkMapMenuRecentButton'),
+                          icon: Icons.history,
+                          label: '최근 검색',
+                          onTap: () => _runAction(context, onOpenRecentSearch!),
+                        ),
+                      if (onOpenSavedItems != null) ...[
+                        const _NetworkMapMenuSectionLabel('내 정보'),
+                        _NetworkMapMenuTile(
+                          key: const Key('networkMapMenuSavedButton'),
+                          icon: Icons.star_border_rounded,
+                          label: '즐겨찾기',
+                          onTap: () => _runAction(context, onOpenSavedItems!),
+                        ),
+                      ],
+                      if (onOpenDataSources != null) ...[
+                        const _NetworkMapMenuSectionLabel('안내'),
+                        _NetworkMapMenuTile(
+                          key: const Key('networkMapMenuDataSourcesButton'),
+                          icon: Icons.source_outlined,
+                          label: '자료 제공 정보',
+                          onTap: () => _runActionAfterMenuClose(
+                            context,
+                            onOpenDataSources!,
+                          ),
+                        ),
+                      ],
+                      const SizedBox(height: 10),
+                      const Divider(height: 1, color: Color(0xFFEDEDED)),
+                      const _NetworkMapMenuInfoBanner(),
+                      const Padding(
+                        padding: EdgeInsets.fromLTRB(24, 6, 24, 8),
+                        child: Text(
+                          '교통약자 이동을 더 쉽게',
+                          style: TextStyle(
+                            color: Color(0xFF9A9A9A),
+                            fontSize: 13,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-                _NetworkMapMenuTile(
-                  key: const Key('networkMapMenuRouteSearchButton'),
-                  icon: Icons.route_outlined,
-                  label: '길찾기',
-                  onTap: () => _runFutureAction(context, onOpenRouteSearch),
+              ),
+              // 패널 최하단 고정 광고 슬롯(항목 스크롤과 분리, release는 collapse).
+              const SafeArea(
+                top: false,
+                child: AdBannerSlot(
+                  slotKey: Key('networkMapMenuAdBanner'),
+                  height: 56,
                 ),
-                if (onOpenNearbyStations != null)
-                  _NetworkMapMenuTile(
-                    key: const Key('networkMapMenuNearbyButton'),
-                    icon: Icons.near_me_outlined,
-                    label: '가까운 역',
-                    onTap: () => _runAction(context, onOpenNearbyStations!),
-                  ),
-                if (onOpenRecentSearch != null)
-                  _NetworkMapMenuTile(
-                    key: const Key('networkMapMenuRecentButton'),
-                    icon: Icons.history,
-                    label: '최근 검색',
-                    onTap: () => _runAction(context, onOpenRecentSearch!),
-                  ),
-                if (onOpenSavedItems != null) ...[
-                  const _NetworkMapMenuSectionLabel('내 정보'),
-                  _NetworkMapMenuTile(
-                    key: const Key('networkMapMenuSavedButton'),
-                    icon: Icons.star_border_rounded,
-                    label: '즐겨찾기',
-                    onTap: () => _runAction(context, onOpenSavedItems!),
-                  ),
-                ],
-                if (onOpenDataSources != null) ...[
-                  const _NetworkMapMenuSectionLabel('안내'),
-                  _NetworkMapMenuTile(
-                    key: const Key('networkMapMenuDataSourcesButton'),
-                    icon: Icons.source_outlined,
-                    label: '자료 제공 정보',
-                    onTap: () =>
-                        _runActionAfterMenuClose(context, onOpenDataSources!),
-                  ),
-                ],
-                const SizedBox(height: 10),
-                const Divider(height: 1, color: Color(0xFFEDEDED)),
-                const _NetworkMapMenuInfoBanner(),
-                const Padding(
-                  padding: EdgeInsets.fromLTRB(24, 6, 24, 8),
-                  child: Text(
-                    '교통약자 이동을 더 쉽게',
-                    style: TextStyle(
-                      color: Color(0xFF9A9A9A),
-                      fontSize: 13,
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3100,6 +3100,29 @@ void main() {
     expect(find.byKey(const Key('networkMapStationSheet')), findsOneWidget);
   });
 
+  testWidgets('노선도 좌측 메뉴 하단에 광고 슬롯이 있다', (tester) async {
+    await tester.pumpWidget(
+      EasySubwayApp(
+        repository: FakeStationSearchRepository(),
+        reportRepository: FakeFacilityReportRepository(),
+        routeRepository: FakeRouteSearchRepository(),
+        favoriteRepository: FakeFavoriteStationRepository(),
+        favoriteFacilityRepository: FakeFavoriteFacilityRepository(),
+        favoriteRouteRepository: FakeFavoriteRouteRepository(),
+        notificationRepository: FakeNotificationSettingsRepository(),
+        initialOnboardingState: _completedOnboardingState(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('networkMapMenuButton')));
+    await tester.pumpAndSettle();
+
+    // debug 빌드에서는 자리 확인용 슬롯이 패널 하단에 렌더링된다.
+    // (release에서는 실광고가 없으면 collapse — 노출 규칙은 #1485)
+    expect(find.byKey(const Key('networkMapMenuAdBanner')), findsOneWidget);
+  });
+
   testWidgets('노선도 chrome은 시스템 글자 크기를 따른다', (tester) async {
     tester.platformDispatcher.textScaleFactorTestValue = 2;
     addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);


### PR DESCRIPTION
## Summary

좌측 메뉴(햄버거) 패널 최하단에 고정 광고 배너 슬롯을 추가했습니다. 내비게이션을 방해하지 않는 자리입니다. (#1495)

- **구조 변경**: `_NetworkMapMenuPanel`을 `Column(Expanded(ListView 항목들), 광고 슬롯)`으로 바꿔 항목은 스크롤하고 광고는 패널 바닥에 핀. 메뉴가 짧아도 광고가 항목 바로 아래 붙지 않아 오탭이 없습니다.
- **공용 슬롯 재사용**: `AdBannerSlot`(#1485) 사용 — 위에 얇은 `line` 구분선 + `SafeArea(bottom)`.
- **노출 규칙(#1485 공통)**: 실광고 없으면 release collapse, "광고" 플레이스홀더는 debug 빌드에서만, 시맨틱 라벨 "광고".
- 기존 인포 배너·태그라인("교통약자 이동을 더 쉽게")은 리스트 끝에 유지.

## Verification

- `dart format` · `flutter analyze lib` → **No issues found**
- `flutter test` → **618 passed, 0 failed** (메뉴 하단 광고 슬롯 렌더링 테스트 추가)

## Notes

- #1485(공용 AdBannerSlot) 위에 스택합니다. #1485 → #1500 → #1498 → main 순으로 base 재지정.
- #1494(설정 진입점)와는 다른 위치(항목 리스트 vs 바닥 슬롯)라 병합 시 함께 반영됩니다.