### PR TITLE
[Test] source candidate sample evidence hash 고정

### DIFF
--- a/tools/datapack/build-source-candidate-sample-evidence.mjs
+++ b/tools/datapack/build-source-candidate-sample-evidence.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -83,54 +84,65 @@ function itemRows(value) {
   return Object.values(value).flatMap(itemRows);
 }
 
-function fieldsFromJson(raw) {
+function fieldsFromRows(rows, format) {
+  const fields = new Set();
+  for (const row of rows) {
+    for (const [key, value] of Object.entries(row)) {
+      if (value == null || typeof value !== "object") {
+        fields.add(key);
+      }
+    }
+  }
+  if (fields.size === 0) {
+    throw new Error(`${format} response has no object fields`);
+  }
+  return [...fields].sort();
+}
+
+function jsonRows(raw) {
   const parsed = JSON.parse(raw);
   const rows = itemRows(parsed);
   if (rows.length > 0) {
-    const fields = new Set();
-    for (const row of rows) {
-      for (const [key, value] of Object.entries(row)) {
-        if (value == null || typeof value !== "object") {
-          fields.add(key);
-        }
-      }
-    }
-    if (fields.size === 0) {
-      throw new Error("JSON response has no object fields");
-    }
-    return [...fields].sort();
+    return rows.map(sortJson);
   }
 
   const row = bestJsonRow(parsed).row;
   if (!row) {
     throw new Error("JSON response has no object fields");
   }
-  return Object.keys(row)
-    .filter((key) => row[key] == null || typeof row[key] !== "object")
-    .sort();
+  return [sortJson(row)];
 }
 
-function fieldsFromXml(raw) {
+function fieldsFromJson(raw) {
+  return fieldsFromRows(jsonRows(raw), "JSON");
+}
+
+function xmlRows(raw) {
   const items = [...raw.matchAll(/<item\b[^>]*>([\s\S]*?)<\/item>/gi)].map((match) => match[1]);
   const fragments = items.length > 0 ? items : [raw];
-  const fields = new Set();
-  for (const fragment of fragments) {
+  return fragments.map((fragment) => {
+    const row = {};
     const selfClosingTagPattern = /<([A-Za-z_][\w.-]*)\b[^>]*\/>/g;
     for (const match of fragment.matchAll(selfClosingTagPattern)) {
-      fields.add(match[1]);
+      row[match[1]] = null;
     }
     const tagPattern = /<([A-Za-z_][\w.-]*)\b[^>]*>([\s\S]*?)<\/\1>/g;
     for (const match of fragment.matchAll(tagPattern)) {
       const [, tagName, body] = match;
       if (!/<[A-Za-z_][\w.-]*\b/.test(body)) {
-        fields.add(tagName);
+        row[tagName] = body.trim();
       }
     }
-  }
-  if (fields.size === 0) {
+    return sortJson(row);
+  }).filter((row) => Object.keys(row).length > 0);
+}
+
+function fieldsFromXml(raw) {
+  const fields = fieldsFromRows(xmlRows(raw), "XML");
+  if (fields.length === 0) {
     throw new Error("XML response has no leaf fields");
   }
-  return [...fields].sort();
+  return fields;
 }
 
 function detectFormat(raw, explicitFormat) {
@@ -147,6 +159,28 @@ function detectFormat(raw, explicitFormat) {
   throw new Error("response format must be json or xml");
 }
 
+function rowsFromRaw(raw, format) {
+  return format === "json" ? jsonRows(raw) : xmlRows(raw);
+}
+
+function sortJson(value) {
+  if (Array.isArray(value)) {
+    return value.map(sortJson);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, sortJson(entry)]),
+  );
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const candidates = await readJson(path.resolve(args.candidates));
@@ -159,19 +193,25 @@ async function main() {
   assertNoServiceKey(raw);
   const format = detectFormat(raw, args.format);
   const fields = format === "json" ? fieldsFromJson(raw) : fieldsFromXml(raw);
+  const rows = rowsFromRaw(raw, format);
+  const providerRecordHashes = rows.map((row) => sha256(JSON.stringify(row)));
+  const rawSha256 = sha256(raw);
+  const schemaFingerprint = sha256(JSON.stringify(fields));
 
-  console.log(
-    JSON.stringify(
-      {
-        candidateId: args.candidate,
-        endpoint: candidate.evidence.endpoint,
-        format,
-        fields,
-      },
-      null,
-      2,
-    ),
-  );
+  const evidence = {
+    candidateId: args.candidate,
+    endpoint: candidate.evidence.endpoint,
+    format,
+    fields,
+    rowCount: rows.length,
+    rawSha256,
+    schemaFingerprint,
+    credentialRedacted: true,
+    providerRecordHashes,
+  };
+  evidence.evidenceHash = sha256(JSON.stringify(evidence));
+
+  console.log(JSON.stringify(evidence, null, 2));
 }
 
 main().catch((error) => {

--- a/tools/datapack/build-source-candidate-sample-evidence.mjs
+++ b/tools/datapack/build-source-candidate-sample-evidence.mjs
@@ -71,6 +71,10 @@ function bestJsonRow(value, best = { row: null, count: 0 }) {
 
 function itemRows(value) {
   if (Array.isArray(value)) {
+    const objectRows = value.filter((item) => item && typeof item === "object" && !Array.isArray(item));
+    if (objectRows.some((item) => scalarFieldCount(item) > 0)) {
+      return objectRows;
+    }
     return value.flatMap(itemRows);
   }
   if (!value || typeof value !== "object") {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -5487,33 +5487,39 @@ test("source candidate sample 검증기는 KRIC live evidence metadata를 허용
   const samplePath = path.join(outputDir, "sample.json");
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
+  const sample = {
+    candidateId: "kric-subway-route-info",
+    endpoint: "https://openapi.kric.go.kr/openapi/trainUseInfo/subwayRouteInfo",
+    format: "json",
+    fields: [
+      "lnCd",
+      "mreaWideCd",
+      "railOprIsttCd",
+      "routCd",
+      "routNm",
+      "stinCd",
+      "stinConsOrdr",
+      "stinNm",
+    ],
+    rowCount: 1,
+    rawSha256: sha256("kric-subway-route-info raw sample"),
+    schemaFingerprint: sha256(JSON.stringify([
+      "lnCd",
+      "mreaWideCd",
+      "railOprIsttCd",
+      "routCd",
+      "routNm",
+      "stinCd",
+      "stinConsOrdr",
+      "stinNm",
+    ])),
+    credentialRedacted: true,
+    providerRecordHashes: [sha256("kric-subway-route-info row")],
+  };
+  sample.evidenceHash = sha256(JSON.stringify(sample));
   await writeFile(
     samplePath,
-    `${JSON.stringify(
-      {
-        candidateId: "kric-subway-route-info",
-        endpoint: "https://openapi.kric.go.kr/openapi/trainUseInfo/subwayRouteInfo",
-        format: "json",
-        fields: [
-          "lnCd",
-          "mreaWideCd",
-          "railOprIsttCd",
-          "routCd",
-          "routNm",
-          "stinCd",
-          "stinConsOrdr",
-          "stinNm",
-        ],
-        rowCount: 1,
-        rawSha256: sha256("kric-subway-route-info raw sample"),
-        schemaFingerprint: sha256("kric-subway-route-info schema"),
-        credentialRedacted: true,
-        providerRecordHashes: [sha256("kric-subway-route-info row")],
-        evidenceHash: sha256("kric-subway-route-info evidence"),
-      },
-      null,
-      2,
-    )}\n`,
+    `${JSON.stringify(sample, null, 2)}\n`,
   );
 
   const { stdout } = await execFileAsync(
@@ -5572,6 +5578,42 @@ test("source candidate sample 검증기는 evidence hash metadata 누락을 거�
       { cwd: root },
     ),
     /rawSha256 must be a sha256 hex string/,
+  );
+});
+
+test("source candidate sample 검증기는 hand-edited evidence hash를 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-stale-hash-${Date.now()}`);
+  const samplePath = path.join(outputDir, "sample.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  const sample = {
+    candidateId: "kric-train-operation-organ",
+    endpoint: "https://openapi.kric.go.kr/openapi/convenientInfo/trainOperationOrgan",
+    format: "json",
+    fields: ["railOprIsttCd", "railOprIsttNm"],
+    rowCount: 1,
+    rawSha256: sha256("raw"),
+    schemaFingerprint: sha256(JSON.stringify(["railOprIsttCd", "railOprIsttNm"])),
+    credentialRedacted: true,
+    providerRecordHashes: [sha256("row")],
+  };
+  sample.evidenceHash = sha256(JSON.stringify(sample));
+  sample.fields.push("unexpectedField");
+  await writeFile(samplePath, `${JSON.stringify(sample, null, 2)}\n`);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-candidate-sample.mjs",
+        "--candidate",
+        "kric-train-operation-organ",
+        "--sample",
+        samplePath,
+      ],
+      { cwd: root },
+    ),
+    /output field missing|schemaFingerprint does not match fields/,
   );
 });
 
@@ -5792,25 +5834,14 @@ test("source candidate sample evidence builder는 raw JSON response를 validator
   await mkdir(outputDir, { recursive: true });
   await writeFile(
     responsePath,
-    `${JSON.stringify({
-      response: {
-        body: {
-          pageNo: 1,
-          numOfRows: 10,
-          totalCount: 1,
-          items: {
-            item: [
-              {
-                railOprIsttCd: "S1",
-              },
-              {
-                railOprIsttNm: "서울교통공사",
-              },
-            ],
-          },
-        },
+    `${JSON.stringify([
+      {
+        railOprIsttCd: "S1",
       },
-    })}\n`,
+      {
+        railOprIsttNm: "서울교통공사",
+      },
+    ])}\n`,
   );
 
   const { stdout } = await execFileAsync(

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -5504,6 +5504,12 @@ test("source candidate sample 검증기는 KRIC live evidence metadata를 허용
           "stinConsOrdr",
           "stinNm",
         ],
+        rowCount: 1,
+        rawSha256: sha256("kric-subway-route-info raw sample"),
+        schemaFingerprint: sha256("kric-subway-route-info schema"),
+        credentialRedacted: true,
+        providerRecordHashes: [sha256("kric-subway-route-info row")],
+        evidenceHash: sha256("kric-subway-route-info evidence"),
       },
       null,
       2,
@@ -5523,6 +5529,50 @@ test("source candidate sample 검증기는 KRIC live evidence metadata를 허용
   );
 
   assert.match(stdout, /source candidate sample evidence valid: kric-subway-route-info/);
+});
+
+test("source candidate sample 검증기는 evidence hash metadata 누락을 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-candidate-sample-hash-${Date.now()}`);
+  const samplePath = path.join(outputDir, "sample.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    samplePath,
+    `${JSON.stringify(
+      {
+        candidateId: "kric-subway-route-info",
+        endpoint: "https://openapi.kric.go.kr/openapi/trainUseInfo/subwayRouteInfo",
+        format: "json",
+        fields: [
+          "lnCd",
+          "mreaWideCd",
+          "railOprIsttCd",
+          "routCd",
+          "routNm",
+          "stinCd",
+          "stinConsOrdr",
+          "stinNm",
+        ],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-candidate-sample.mjs",
+        "--candidate",
+        "kric-subway-route-info",
+        "--sample",
+        samplePath,
+      ],
+      { cwd: root },
+    ),
+    /rawSha256 must be a sha256 hex string/,
+  );
 });
 
 test("source candidate sample 검증기는 endpoint mismatch를 거부한다", async () => {
@@ -5775,6 +5825,13 @@ test("source candidate sample evidence builder는 raw JSON response를 validator
     { cwd: root },
   );
   await writeFile(evidencePath, stdout);
+  const evidence = JSON.parse(stdout);
+  assert.match(evidence.rawSha256, /^[0-9a-f]{64}$/);
+  assert.match(evidence.schemaFingerprint, /^[0-9a-f]{64}$/);
+  assert.equal(evidence.credentialRedacted, true);
+  assert.equal(evidence.rowCount, 2);
+  assert.equal(evidence.providerRecordHashes.length, 2);
+  assert.match(evidence.evidenceHash, /^[0-9a-f]{64}$/);
 
   await execFileAsync(
     process.execPath,
@@ -5817,6 +5874,13 @@ test("source candidate sample evidence builder는 raw XML response를 validator 
     { cwd: root },
   );
   await writeFile(evidencePath, stdout);
+  const evidence = JSON.parse(stdout);
+  assert.match(evidence.rawSha256, /^[0-9a-f]{64}$/);
+  assert.match(evidence.schemaFingerprint, /^[0-9a-f]{64}$/);
+  assert.equal(evidence.credentialRedacted, true);
+  assert.equal(evidence.rowCount, 2);
+  assert.equal(evidence.providerRecordHashes.length, 2);
+  assert.match(evidence.evidenceHash, /^[0-9a-f]{64}$/);
 
   await execFileAsync(
     process.execPath,

--- a/tools/datapack/validate-source-candidate-sample.mjs
+++ b/tools/datapack/validate-source-candidate-sample.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -117,12 +118,39 @@ function validateSample({ candidate, candidateId, sample }) {
   for (const [index, hash] of sample.providerRecordHashes.entries()) {
     assertSha256(hash, `providerRecordHashes.${index}`);
   }
+  if (!Number.isInteger(sample.rowCount) || sample.rowCount !== sample.providerRecordHashes.length) {
+    throw new Error("rowCount must match providerRecordHashes length");
+  }
+
+  const expectedSchemaFingerprint = sha256(JSON.stringify([...sample.fields].sort()));
+  if (sample.schemaFingerprint !== expectedSchemaFingerprint) {
+    throw new Error("schemaFingerprint does not match fields");
+  }
+
+  const expectedEvidenceHash = sha256(JSON.stringify({
+    candidateId: sample.candidateId,
+    endpoint: sample.endpoint,
+    format: sample.format,
+    fields: sample.fields,
+    rowCount: sample.rowCount,
+    rawSha256: sample.rawSha256,
+    schemaFingerprint: sample.schemaFingerprint,
+    credentialRedacted: sample.credentialRedacted,
+    providerRecordHashes: sample.providerRecordHashes,
+  }));
+  if (sample.evidenceHash !== expectedEvidenceHash) {
+    throw new Error("evidenceHash does not match sample evidence");
+  }
 }
 
 function assertSha256(value, label) {
   if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
     throw new Error(`${label} must be a sha256 hex string`);
   }
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
 }
 
 async function main() {

--- a/tools/datapack/validate-source-candidate-sample.mjs
+++ b/tools/datapack/validate-source-candidate-sample.mjs
@@ -106,6 +106,10 @@ function validateSample({ candidate, candidateId, sample }) {
     throw new Error(`sample evidence must not contain serviceKey credentials: ${leakPath}`);
   }
 
+  validateEvidenceMetadata(sample);
+}
+
+function validateEvidenceMetadata(sample) {
   assertSha256(sample.rawSha256, "rawSha256");
   assertSha256(sample.schemaFingerprint, "schemaFingerprint");
   assertSha256(sample.evidenceHash, "evidenceHash");
@@ -122,7 +126,9 @@ function validateSample({ candidate, candidateId, sample }) {
     throw new Error("rowCount must match providerRecordHashes length");
   }
 
-  const expectedSchemaFingerprint = sha256(JSON.stringify([...sample.fields].sort()));
+  const expectedSchemaFingerprint = sha256(JSON.stringify(
+    [...sample.fields].sort((left, right) => left.localeCompare(right)),
+  ));
   if (sample.schemaFingerprint !== expectedSchemaFingerprint) {
     throw new Error("schemaFingerprint does not match fields");
   }

--- a/tools/datapack/validate-source-candidate-sample.mjs
+++ b/tools/datapack/validate-source-candidate-sample.mjs
@@ -104,6 +104,25 @@ function validateSample({ candidate, candidateId, sample }) {
   if (leakPath) {
     throw new Error(`sample evidence must not contain serviceKey credentials: ${leakPath}`);
   }
+
+  assertSha256(sample.rawSha256, "rawSha256");
+  assertSha256(sample.schemaFingerprint, "schemaFingerprint");
+  assertSha256(sample.evidenceHash, "evidenceHash");
+  if (sample.credentialRedacted !== true) {
+    throw new Error("credentialRedacted must be true");
+  }
+  if (!Array.isArray(sample.providerRecordHashes) || sample.providerRecordHashes.length === 0) {
+    throw new Error("providerRecordHashes must be a non-empty array");
+  }
+  for (const [index, hash] of sample.providerRecordHashes.entries()) {
+    assertSha256(hash, `providerRecordHashes.${index}`);
+  }
+}
+
+function assertSha256(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
+    throw new Error(`${label} must be a sha256 hex string`);
+  }
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- source candidate sample evidence builder가 rawSha256, schemaFingerprint, rowCount, providerRecordHashes, evidenceHash, credentialRedacted를 출력하도록 고정했습니다.
- validator가 hash metadata 없는 sample evidence를 거부하도록 했습니다.
- JSON/XML builder 출력과 metadata 누락 negative test를 추가했습니다.

## Verification
- node --test --test-name-pattern "source candidate sample" tools/datapack/datapack-tools.test.mjs
- node --test tools/datapack/datapack-tools.test.mjs
- node --test tools/ci/repository-contract.test.mjs
- git diff --check

## 이슈
- #1397 부분 보강입니다. 실제 provider key live sample, object storage/local-only raw archive, admin review, production inventory admission 증거는 아직 남아 있으므로 이 PR은 #1397을 닫지 않습니다.
