### PR TITLE
[Test] schedule provenance gate 고정

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -7076,6 +7076,38 @@ test("공식 source ingest adapter는 production schedule pass-through를 거부
   );
 });
 
+test("공식 source ingest adapter는 admission 전 schedule provenance도 production 적재하지 않는다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-ingest-production-schedule-candidate-${Date.now()}`);
+  const input = productionSourceIngestInput();
+  input.sourceIds.push("molit-tago-subway-info");
+  input.scheduleProvenance = {
+    sourceId: "molit-tago-subway-info",
+    sourceSnapshotId: "molit-tago-subway-info-snapshot-20260702",
+    providerRecordHash: sha256("provider:molit-tago-subway-info:schedule:20260702"),
+    evidenceHash: sha256("evidence:molit-tago-subway-info:schedule:20260702"),
+    retrievedAt: "2026-07-02T00:00:00.000Z",
+  };
+  input.serviceCalendars = [
+    {
+      serviceId: "weekday-2026",
+      monday: true,
+      tuesday: true,
+      wednesday: true,
+      thursday: true,
+      friday: true,
+      saturday: false,
+      sunday: false,
+      startDate: "20260701",
+      endDate: "20261231",
+    },
+  ];
+
+  await assert.rejects(
+    importOfficialSourceInput(outputDir, input),
+    /scheduleProvenance source is not a schedule_timetable source: molit-tago-subway-info/,
+  );
+});
+
 test("공식 source ingest adapter는 station-line 단위 facility evidence coverage를 요구한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-ingest-facility-line-coverage-${Date.now()}`);
   const input = productionSourceIngestInput();

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -45,7 +45,7 @@ function buildFixture(inventory, input) {
   const transitSchedule = transitScheduleRows(input);
   const transitScheduleTableRows = transitScheduleMinimumTableRows(transitSchedule);
   if (isProductionPack && Object.keys(transitScheduleTableRows).length > 0) {
-    throw new Error("production transit schedule import requires sourced schedule provenance");
+    validateProductionScheduleProvenance(input.scheduleProvenance, selectedSources, allowedSourceIds);
   }
   validateSelectedSourceRows(input, sourceIds);
   validateSupportedScopeDenominator(input, stationRows, networkEdges, facilities, movementCandidates, routeMapPositions);
@@ -950,6 +950,24 @@ function transitScheduleMinimumTableRows(rows) {
       ["transit_frequencies", rows.transitFrequencies.length],
     ].filter(([, count]) => count > 0),
   );
+}
+
+function validateProductionScheduleProvenance(provenance, selectedSources, allowedSourceIds) {
+  if (!provenance || typeof provenance !== "object" || Array.isArray(provenance)) {
+    throw new Error("production transit schedule import requires sourced schedule provenance");
+  }
+  const sourceId = requiredKnownSource(provenance.sourceId, allowedSourceIds, "scheduleProvenance.sourceId");
+  const source = selectedSources.find((entry) => entry.id === sourceId);
+  if (!sourceDomainEnabled([source], "schedule_timetable")) {
+    throw new Error(`scheduleProvenance source is not a schedule_timetable source: ${sourceId}`);
+  }
+  if (source.capabilities?.schedule?.productionUseAllowed !== true) {
+    throw new Error(`scheduleProvenance source is not admitted for production schedule use: ${sourceId}`);
+  }
+  requiredString(provenance.sourceSnapshotId, "scheduleProvenance.sourceSnapshotId");
+  productionEvidenceHash(provenance.providerRecordHash, true, sourceId, "scheduleProvenance.providerRecordHash");
+  productionEvidenceHash(provenance.evidenceHash, true, sourceId, "scheduleProvenance.evidenceHash");
+  requiredString(provenance.retrievedAt, "scheduleProvenance.retrievedAt");
 }
 
 function optionalRows(value, label) {


### PR DESCRIPTION
## Summary
- production schedule rows가 들어올 때 `scheduleProvenance`를 요구하도록 importer gate를 좁혔습니다.
- provenance가 있어도 source가 `schedule_timetable` coverage로 admission되지 않았거나 `productionUseAllowed=true`가 아니면 production pack 적재를 거부합니다.
- TAGO 후보가 admission 전 PLANNED ETA 근거로 자동 승격되지 않는 회귀 테스트를 추가했습니다.

## Verification
- `node --test --test-name-pattern "production schedule" tools/datapack/datapack-tools.test.mjs`
- `node --test --test-name-pattern "schedule provenance" tools/datapack/datapack-tools.test.mjs`
- `node --test tools/datapack/datapack-tools.test.mjs`
- `node --test tools/ci/repository-contract.test.mjs`
- `git diff --check`

## 이슈
- Part of #1415

## 남은 일
- TAGO live sample capture/sanitize
- schedule importer validation
- service calendar/trip/stop_times 실제 production 적재
- PLANNED ETA Android evidence


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 생산 스케줄 적재 시 스케줄 provenance 검증이 강화되어, 허용된 소스와 조건을 충족할 때만 계속 진행됩니다.
  * 잘못된 provenance, 누락된 필드, 지원되지 않는 소스 정보는 명확한 오류로 거부됩니다.

* **Tests**
  * 공식 source ingest 경로에서 production schedule 적재 시 provenance 거부 동작을 확인하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
