### PR TITLE
[Test] 데이터팩 품질 metric artifact 고정

### DIFF
--- a/tools/datapack/build-quality-metric-report.mjs
+++ b/tools/datapack/build-quality-metric-report.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const args = Object.fromEntries(process.argv.slice(2).flatMap((value, index, values) =>
+  value.startsWith("--") ? [[value.slice(2), values[index + 1]]] : [],
+));
+
+if (!args.manifest) {
+  console.error("usage: build-quality-metric-report.mjs --manifest <current.json> [--output <report.json>]");
+  process.exit(1);
+}
+
+const ratioKeys = [
+  "facilityCoverageRatio",
+  "requiredFacilityEvidenceCoverageRatio",
+  "strictRouteEligibleFacilityRatio",
+  "operationalKnownRatio",
+  "freshnessValidRatio",
+  "fieldVerifiedPathwayRatio",
+  "unknownAccessibilityRatio",
+];
+
+try {
+  const manifest = JSON.parse(await readFile(args.manifest, "utf8"));
+  if (!Array.isArray(manifest.packs) || manifest.packs.length === 0) {
+    throw new Error("manifest packs must be a non-empty array");
+  }
+  const packs = manifest.packs.map((pack) => {
+    const metrics = pack.regionalQualityMetrics;
+    if (!metrics || typeof metrics !== "object" || Array.isArray(metrics)) {
+      throw new Error(`${pack.id}@${pack.version} regionalQualityMetrics must be an object`);
+    }
+    if (!Number.isInteger(metrics.stationCount) || !Number.isInteger(metrics.edgeCount)) {
+      throw new Error(`${pack.id}@${pack.version} stationCount and edgeCount must be integers`);
+    }
+    for (const key of ratioKeys) {
+      if (typeof metrics[key] !== "number" || metrics[key] < 0 || metrics[key] > 1) {
+        throw new Error(`${pack.id}@${pack.version} ${key} must be a ratio`);
+      }
+    }
+    for (const key of ["wheelchair", "stroller", "lowMobility"]) {
+      const value = metrics.unknownEdgeRatioByProfile?.[key];
+      if (typeof value !== "number" || value < 0 || value > 1) {
+        throw new Error(`${pack.id}@${pack.version} unknownEdgeRatioByProfile.${key} must be a ratio`);
+      }
+    }
+    return {
+      id: pack.id,
+      version: pack.version,
+      artifactKind: pack.artifactKind ?? null,
+      url: pack.url ?? null,
+      denominatorPolicy: "station_line_x_required_facility_type",
+      freshnessPolicy: "verified_or_retrieved_timestamp_present",
+      metrics: {
+        stationCount: metrics.stationCount,
+        edgeCount: metrics.edgeCount,
+        ...Object.fromEntries(ratioKeys.map((key) => [key, metrics[key]])),
+        unknownEdgeRatioByProfile: {
+          wheelchair: metrics.unknownEdgeRatioByProfile.wheelchair,
+          stroller: metrics.unknownEdgeRatioByProfile.stroller,
+          lowMobility: metrics.unknownEdgeRatioByProfile.lowMobility,
+        },
+      },
+    };
+  });
+  const metric = (key) => Math.min(...packs.map((pack) => pack.metrics[key]));
+  const report = {
+    schemaVersion: 1,
+    artifactKind: "datapack-quality-metric-report",
+    manifestVersion: manifest.manifestVersion ?? 1,
+    channel: manifest.channel ?? null,
+    releaseSequence: manifest.releaseSequence ?? null,
+    summary: {
+      packCount: packs.length,
+      worstRequiredFacilityEvidenceCoverageRatio: metric("requiredFacilityEvidenceCoverageRatio"),
+      worstFreshnessValidRatio: metric("freshnessValidRatio"),
+    },
+    packs,
+  };
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+  if (args.output) {
+    await mkdir(path.dirname(args.output), { recursive: true });
+    await writeFile(args.output, json);
+  } else {
+    process.stdout.write(json);
+  }
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -4060,6 +4060,82 @@ test("데이터팩 생성기는 시설 coverage를 시설이 있는 역 비율�
   );
 });
 
+test("데이터팩 quality metric report는 denominator 기반 metric과 freshness를 산출한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-datapack-quality-report-${Date.now()}`);
+  const reportPath = path.join(outputDir, "artifacts/datapack-quality-metrics.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture",
+      "tools/datapack/fixtures/catalog-fixture.json",
+      "--output",
+      outputDir,
+    ],
+    { cwd: root },
+  );
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-quality-metric-report.mjs",
+      "--manifest",
+      path.join(outputDir, "current.json"),
+      "--output",
+      reportPath,
+    ],
+    { cwd: root },
+  );
+
+  const report = JSON.parse(await readFile(reportPath, "utf8"));
+  assert.equal(report.artifactKind, "datapack-quality-metric-report");
+  assert.equal(report.summary.packCount, 1);
+  assert.equal(report.summary.worstRequiredFacilityEvidenceCoverageRatio, 0.1852);
+  assert.equal(report.summary.worstFreshnessValidRatio, 0);
+  assert.equal(report.packs[0].denominatorPolicy, "station_line_x_required_facility_type");
+  assert.equal(report.packs[0].metrics.requiredFacilityEvidenceCoverageRatio, 0.1852);
+  assert.equal(report.packs[0].metrics.freshnessValidRatio, 0);
+});
+
+test("데이터팩 quality metric report는 freshness metric 누락 manifest를 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-datapack-quality-report-invalid-${Date.now()}`);
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture",
+      "tools/datapack/fixtures/catalog-fixture.json",
+      "--output",
+      outputDir,
+    ],
+    { cwd: root },
+  );
+
+  const manifestPath = path.join(outputDir, "current.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  delete manifest.packs[0].regionalQualityMetrics.freshnessValidRatio;
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/build-quality-metric-report.mjs",
+        "--manifest",
+        manifestPath,
+      ],
+      { cwd: root },
+    ),
+    /freshnessValidRatio must be a ratio/,
+  );
+});
+
 test("데이터팩 생성기는 accessibilityStatus 대소문자를 정규화해 산출물을 검증 가능하게 만든다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-datapack-accessibility-status-${Date.now()}`);
   const fixturePath = path.join(outputDir, "fixture.json");


### PR DESCRIPTION
## Summary
- `current.json` manifest의 `regionalQualityMetrics`를 `artifacts/datapack-quality-metrics.json` 형태로 산출하는 CLI 추가
- denominator 기반 coverage metric(`requiredFacilityEvidenceCoverageRatio`)과 `freshnessValidRatio` 누락 시 report 생성을 실패시키는 회귀 테스트 추가

## Verification
- `node --test --test-name-pattern "quality metric report" tools/datapack/datapack-tools.test.mjs`
- `node --test tools/datapack/datapack-tools.test.mjs`
- `node --test tools/ci/repository-contract.test.mjs`
- `git diff --check`

## 이슈
- Part of #1400
- Part of #1419

## 주의
- #1400 전체 완료가 아닙니다. 인접역 graph 실제 승격, route map position 실제 적재, 앱 데이터 품질 표시 evidence는 남아 있습니다.
