### PR TITLE
[CI] PR 제목 양식 검증 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,24 @@ jobs:
         --lockfile=apps/mobile/android/app/gradle.lockfile
         --lockfile=backend/gradle.lockfile
 
+  pr-title:
+    name: PR Title
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      contents: read
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - name: PR Title / Validate bracket prefix
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${PR_TITLE}" =~ ^\[(Feat|Fix|Test|Chore|Docs|Build|CI|Style|Refactor|Backend|Mobile)\]\ .+ ]]; then
+            echo "::error title=PR title::Use '[Type] 한국어 작업 요약' format."
+            exit 1
+          fi
+
   release-gate-consistency:
     name: Release Gate Consistency
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - edited
   push:
     branches:
       - main

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -623,6 +623,7 @@ test("지속적 통합 작업과 스텝 이름은 실패 영역을 구분할 수
   const releaseGateJob = jobBlock(workflow, "release-gate-consistency", "repository-contracts");
 
   assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /pull_request:[\s\S]*types:[\s\S]*- edited/);
   assert.match(workflow, /name: Changes/);
   assert.match(workflow, /name: PR Title/);
   assert.match(workflow, /PR Title \/ Validate bracket prefix/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -624,6 +624,10 @@ test("지속적 통합 작업과 스텝 이름은 실패 영역을 구분할 수
 
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /name: Changes/);
+  assert.match(workflow, /name: PR Title/);
+  assert.match(workflow, /PR Title \/ Validate bracket prefix/);
+  assert.ok(workflow.includes("^\\[(Feat|Fix|Test|Chore|Docs|Build|CI|Style|Refactor|Backend|Mobile)\\]\\ .+"));
+  assert.match(workflow, /Use '\[Type\] 한국어 작업 요약' format\./);
   assert.match(workflow, /name: Repository CI/);
   assert.match(workflow, /name: Backend CI/);
   assert.match(workflow, /name: Mobile App CI/);


### PR DESCRIPTION
## Summary
- pull_request CI에 PR 제목 bracket prefix 검증 job을 추가했습니다.
- 허용 prefix는 기존 issue/PR 관례의 Feat/Fix/Test/Chore/Docs/Build/CI/Style/Refactor/Backend/Mobile입니다.
- repository contract test가 gate와 안내 문구를 고정합니다.

## Verification
- node --test --test-name-pattern "지속적 통합 작업" tools/ci/repository-contract.test.mjs
- node --test --test-name-pattern "필수 지속적 통합" tools/ci/repository-contract.test.mjs
- node --test tools/ci/repository-contract.test.mjs
- git diff --check

Closes #1526
