### PR TITLE
[Fix] UNKNOWN 시설 strict eligibility 차단

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -3050,6 +3050,45 @@ test("데이터팩 검증기는 현장·운영기관 확인 시설 AVAILABLE 근
   );
 });
 
+test("데이터팩 검증기는 UNKNOWN 운행상태 시설의 strict route eligibility를 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-production-facility-strict-unknown-${Date.now()}`);
+  const fixturePath = path.join(outputDir, "catalog-fixture.json");
+  const packOutputDir = path.join(outputDir, "pack");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  const fixture = await importOfficialSourceInput(outputDir, productionSourceIngestInput());
+  fixture.packs[0].stationFacilityEvidence[0].strictRouteEligible = true;
+  fixture.packs[0].stationFacilityEvidence[0].strictRouteEligibleReason = "FACILITY_EXISTS_AND_PROVENANCE_VERIFIED";
+  await writeFile(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`);
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture",
+      fixturePath,
+      "--output",
+      packOutputDir,
+    ],
+    { cwd: root, env: productionEnv },
+  );
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-datapack.mjs",
+        "--manifest",
+        path.join(packOutputDir, "current.json"),
+        "--root",
+        packOutputDir,
+      ],
+      { cwd: root, env: productionEnv },
+    ),
+    /station_facility_evidence strict route eligibility requires available operation status/,
+  );
+});
+
 test("데이터팩 검증기는 production verified edge coverage report를 출력한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-datapack-production-edge-report-${Date.now()}`);
   const fixturePath = path.join(outputDir, "fixture.json");
@@ -7269,12 +7308,13 @@ test("공식 source ingest adapter는 동일 station-line-type 시설을 evidenc
           row.lineId === "seoul-4" &&
           row.facilityType === "ELEVATOR",
       )
-      .map(({ stationId, lineId, facilityType, sourceId, strictRouteEligible }) => ({
+      .map(({ stationId, lineId, facilityType, sourceId, strictRouteEligible, strictRouteEligibleReason }) => ({
         stationId,
         lineId,
         facilityType,
         sourceId,
         strictRouteEligible,
+        strictRouteEligibleReason,
       })),
     [
       {
@@ -7282,7 +7322,8 @@ test("공식 source ingest adapter는 동일 station-line-type 시설을 evidenc
         lineId: "seoul-4",
         facilityType: "ELEVATOR",
         sourceId: "kric-station-elevator",
-        strictRouteEligible: true,
+        strictRouteEligible: false,
+        strictRouteEligibleReason: "OPERATION_STATUS_UNKNOWN",
       },
     ],
   );

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -811,6 +811,7 @@ function stationFacilityEvidenceRows(input, stationRows, facilities, isProductio
       for (const facility of [...facilitiesByCoverageKey.values()]
         .filter((entry) => entry.stationId === stationId && entry.type === facilityType)
         .sort((left, right) => left.lineId.localeCompare(right.lineId))) {
+        const strictEligibility = facilityStrictRouteEligibility(facility);
         rows.push({
           stationId,
           lineId: facility.lineId,
@@ -827,13 +828,28 @@ function stationFacilityEvidenceRows(input, stationRows, facilities, isProductio
           confidence: facility.confidence,
           verifiedAt: facility.verifiedAt,
           retrievedAt: facility.retrievedAt,
-          strictRouteEligible: true,
-          strictRouteEligibleReason: "FACILITY_EXISTS_AND_PROVENANCE_VERIFIED",
+          strictRouteEligible: strictEligibility.eligible,
+          strictRouteEligibleReason: strictEligibility.reason,
         });
       }
     }
   }
   return rows;
+}
+
+function facilityStrictRouteEligibility(facility) {
+  const operationalStatus = String(facility.operationalStatus ?? "").toUpperCase();
+  const statusMeaning = String(facility.statusMeaning ?? "").toUpperCase();
+  if (["UNKNOWN", "CHECK_REQUIRED", ""].includes(operationalStatus)) {
+    return { eligible: false, reason: "OPERATION_STATUS_UNKNOWN" };
+  }
+  if (!["NORMAL", "AVAILABLE", "IN_SERVICE", "OPERATING", "OPEN", "ADMIN_VERIFIED"].includes(operationalStatus)) {
+    return { eligible: false, reason: "OPERATION_STATUS_NOT_AVAILABLE" };
+  }
+  if (!["REALTIME_OPERATION", "OPERATOR_CONFIRMED", "FIELD_SURVEY"].includes(statusMeaning)) {
+    return { eligible: false, reason: "OPERATION_EVIDENCE_MISSING" };
+  }
+  return { eligible: true, reason: "FACILITY_OPERATION_VERIFIED" };
 }
 
 function productionString(value, isProductionPack, label) {

--- a/tools/datapack/validate-datapack.mjs
+++ b/tools/datapack/validate-datapack.mjs
@@ -1361,6 +1361,18 @@ function validateProductionStationFacilityEvidenceRow(row, sourceIds, pack) {
   }
   if (row.strict_route_eligible === 1) {
     requiredString(row.strict_route_eligible_reason, `station_facility_evidence.${id}.strict_route_eligible_reason`);
+    validateStrictRouteEligibleFacilityEvidence(row, pack, id);
+  }
+}
+
+function validateStrictRouteEligibleFacilityEvidence(row, pack, id) {
+  const operationalStatus = String(row.operational_status ?? "").toUpperCase();
+  const statusMeaning = String(row.status_meaning ?? "").toUpperCase();
+  if (!["NORMAL", "AVAILABLE", "IN_SERVICE", "OPERATING", "OPEN", "ADMIN_VERIFIED"].includes(operationalStatus)) {
+    throw new Error(`${pack.id}@${pack.version} station_facility_evidence strict route eligibility requires available operation status: ${id}`);
+  }
+  if (!["REALTIME_OPERATION", "OPERATOR_CONFIRMED", "FIELD_SURVEY"].includes(statusMeaning)) {
+    throw new Error(`${pack.id}@${pack.version} station_facility_evidence strict route eligibility requires verified operation evidence: ${id}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- production source ingest가 UNKNOWN/CHECK_REQUIRED 운행상태 시설을 strict route eligible로 만들지 않도록 수정했습니다.
- strict route eligible station_facility_evidence는 AVAILABLE 계열 operational status와 REALTIME_OPERATION/OPERATOR_CONFIRMED/FIELD_SURVEY 근거가 없으면 validator가 거부합니다.
- 기존 중복 facility evidence 테스트 기대값과 UNKNOWN negative validator 테스트를 갱신했습니다.

## Verification
- node --test --test-name-pattern "UNKNOWN 운행상태 시설|station-line 단위 facility evidence" tools/datapack/datapack-tools.test.mjs
- node --test --test-name-pattern "동일 station-line-type" tools/datapack/datapack-tools.test.mjs
- node --test tools/datapack/datapack-tools.test.mjs
- git diff --check

Refs #1394
