### PR TITLE
[Test] realtime coverage gate scope 기준 고정

### DIFF
--- a/tools/routes/check-route-commercialization-gate.mjs
+++ b/tools/routes/check-route-commercialization-gate.mjs
@@ -129,13 +129,19 @@ function validateAccessibility(gate, report, failures) {
 
 function validateCoverage(gate, report, failures) {
   if (report.schemaVersion !== 1) failures.push("coverage report schemaVersion must be 1");
-  if (number(report.supportedStationLinePairs) < gate.realtimeCoverage.supportedStationLinePairsMin) {
-    failures.push(`realtimeCoverage supported station-line pairs below ${gate.realtimeCoverage.supportedStationLinePairsMin}`);
+  const supportedStationLinePairsMin = realtimeSupportedStationLinePairsMin(gate, report);
+  if (number(report.supportedStationLinePairs) < supportedStationLinePairsMin) {
+    failures.push(`realtimeCoverage supported station-line pairs below ${supportedStationLinePairsMin}`);
   }
   max(report.providerFreshnessSecondsMaxObserved, gate.realtimeCoverage.providerFreshnessSecondsMax, "realtimeCoverage provider freshness seconds", failures);
   if (gate.realtimeCoverage.staleFallbackRequired && report.staleFallbackRequired !== true) {
     failures.push("realtimeCoverage stale fallback must be required");
   }
+}
+
+function realtimeSupportedStationLinePairsMin(gate, report) {
+  const scopedMin = number(report.scope?.supportedStationLinePairsMin);
+  return scopedMin > 0 ? scopedMin : gate.realtimeCoverage.supportedStationLinePairsMin;
 }
 
 function validateRouteGraphCoverage(gate, report, failures) {

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -193,6 +193,65 @@ test("route commercialization gate keeps legacy production sample fallback", asy
   );
 });
 
+test("route commercialization gate derives realtime pair minimum from coverage scope", async () => {
+  const fixture = await writeFixtureSet({
+    accuracy: {
+      schemaVersion: 1,
+      sampleSize: 120,
+      sampleSourceCounts: {
+        fixture: 0,
+        staticTimetable: 0,
+        realtimeProvider: 120,
+        manualObservation: 120,
+        staleRealtime: 0,
+      },
+      productionSampleSize: 120,
+      metrics: {
+        singleRide: { sampleSize: 60, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
+        transfer: { sampleSize: 60, p50ErrorSeconds: 90, p90ErrorSeconds: 240 },
+      },
+      failures: [],
+    },
+    accessibility: {
+      schemaVersion: 1,
+      strictStepFreeKnownStairFalsePositiveCount: 0,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      unknownAccessibilityLabeled: true,
+    },
+    coverage: {
+      schemaVersion: 1,
+      scope: {
+        id: "capital_pilot_android_v1",
+        supportedStationLinePairsMin: 2,
+      },
+      supportedStationLinePairs: 2,
+      providerFreshnessSecondsMaxObserved: 80,
+      staleFallbackRequired: true,
+    },
+    routeGraphCoverage: {
+      schemaVersion: 1,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      strictRouteNotFound: { total: 100, notFoundCount: 1, rate: 0.01, byReasonCode: {} },
+    },
+    contract: {
+      schemaVersion: 1,
+      multiTransferSupported: false,
+      outOfStationTransferSupported: false,
+      alternativeItinerariesMinObserved: 1,
+      wrongTransferCount: 0,
+      wrongLineSequence: 0,
+      routeNotFoundRate: 0.01,
+      releaseBlockersSatisfied: ["D-2", "D-3", "H-1"],
+    },
+  });
+
+  const { stdout } = await execChecker(fixture);
+  const report = JSON.parse(stdout);
+
+  assert.equal(report.status, "PASS");
+  assert.deepEqual(report.failures, []);
+});
+
 test("route commercialization gate fails on unclassified ETA deviations", async () => {
   const fixture = await writeFixtureSet({
     accuracy: {


### PR DESCRIPTION
## Summary
- realtime provider coverage gate가 coverage report의 scope별 `supportedStationLinePairsMin`을 우선 사용하게 했습니다.
- 전국 기본 gate 값 `100`은 유지하고, pilot report가 `2` pair 기준을 명시하면 그 기준으로 평가합니다.

## Verification
- `node --test tools/routes/check-route-commercialization-gate.test.mjs`
- `node --test --test-name-pattern "route commercialization release gate" tools/ci/repository-contract.test.mjs`
- `git diff --check`

Refs #1416
