### PR TITLE
[Test] realtime provider coverage report 고정

### DIFF
--- a/tools/routes/build-realtime-provider-coverage-report.mjs
+++ b/tools/routes/build-realtime-provider-coverage-report.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}
+
+export async function main(argv) {
+  const args = parseArgs(argv);
+  if (!args.input) throw new Error("usage: build-realtime-provider-coverage-report.mjs --input <coverage-input.json> [--output <report.json>]");
+  const input = JSON.parse(await readFile(args.input, "utf8"));
+  const report = buildRealtimeProviderCoverageReport(input);
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+  if (args.output) {
+    await writeFile(args.output, json);
+  } else {
+    process.stdout.write(json);
+  }
+  return report;
+}
+
+export function buildRealtimeProviderCoverageReport(input) {
+  const pairs = Array.isArray(input.stationLinePairs) ? input.stationLinePairs : [];
+  const samples = Array.isArray(input.samples) ? input.samples : [];
+  const mappedPairs = pairs.filter((row) => row.supportsArrivals === true && row.mappingStatus === "MAPPED");
+  const mappingFailures = pairs.filter((row) => row.mappingStatus !== "MAPPED");
+  const realtimeSamples = samples.filter((row) => row.labeledAsRealtime === true);
+  const staleAsFresh = realtimeSamples.filter((row) => row.freshnessStatus !== "FRESH");
+
+  return {
+    schemaVersion: 1,
+    scope: input.scope ?? {},
+    supportedStationLinePairs: uniquePairCount(mappedPairs),
+    providerFreshnessSecondsMaxObserved: max(realtimeSamples.map((row) => row.providerFreshnessSeconds)),
+    staleFallbackRequired: input.staleFallbackRequired === true,
+    freshness: {
+      freshCount: samples.filter((row) => row.freshnessStatus === "FRESH").length,
+      staleCount: samples.filter((row) => row.freshnessStatus === "STALE").length,
+      staleAsFreshCount: staleAsFresh.length,
+    },
+    mapping: {
+      attemptedRows: pairs.length,
+      failedRows: mappingFailures.length,
+      failureRate: ratio(mappingFailures.length, pairs.length),
+      failuresByReason: countBy(mappingFailures, "failureReason"),
+    },
+    unsupportedRegions: Array.isArray(input.unsupportedRegions) ? input.unsupportedRegions : [],
+  };
+}
+
+function uniquePairCount(rows) {
+  return new Set(rows.map((row) => `${row.stationId}\0${row.lineId}`)).size;
+}
+
+function countBy(rows, field) {
+  const counts = {};
+  for (const row of rows) {
+    const key = row[field] ?? "UNKNOWN";
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function max(values) {
+  const finite = values.map(Number).filter(Number.isFinite);
+  return finite.length === 0 ? 0 : Math.max(...finite);
+}
+
+function ratio(count, total) {
+  return total === 0 ? 0 : count / total;
+}
+
+function parseArgs(argv) {
+  const pairs = [];
+  while (argv.length > 0) {
+    const [key, value] = argv.splice(0, 2);
+    if (!key?.startsWith("--")) throw new Error(`unexpected argument: ${key}`);
+    if (!value || value.startsWith("--")) throw new Error(`missing value for ${key}`);
+    pairs.push([key.slice(2), value]);
+  }
+  return Object.fromEntries(pairs);
+}

--- a/tools/routes/build-realtime-provider-coverage-report.test.mjs
+++ b/tools/routes/build-realtime-provider-coverage-report.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { buildRealtimeProviderCoverageReport, main } from "./build-realtime-provider-coverage-report.mjs";
+
+test("builds realtime provider coverage report with freshness and mapping metrics", () => {
+  const report = buildRealtimeProviderCoverageReport({
+    scope: { id: "capital_pilot_android_v1", supportedStationLinePairsMin: 2 },
+    staleFallbackRequired: true,
+    stationLinePairs: [
+      { stationId: "station-sangnoksu", lineId: "seoul-4", supportsArrivals: true, mappingStatus: "MAPPED" },
+      { stationId: "station-sadang", lineId: "seoul-4", supportsArrivals: true, mappingStatus: "MAPPED" },
+      { stationId: "station-busan", lineId: "busan-1", supportsArrivals: false, mappingStatus: "UNSUPPORTED_REGION", failureReason: "UNSUPPORTED_REGION" },
+    ],
+    samples: [
+      { providerFreshnessSeconds: 12, freshnessStatus: "FRESH", labeledAsRealtime: true },
+      { providerFreshnessSeconds: 120, freshnessStatus: "STALE", labeledAsRealtime: false },
+    ],
+    unsupportedRegions: [{ region: "busan", reason: "실시간 미지원" }],
+  });
+
+  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.supportedStationLinePairs, 2);
+  assert.equal(report.providerFreshnessSecondsMaxObserved, 12);
+  assert.deepEqual(report.freshness, { freshCount: 1, staleCount: 1, staleAsFreshCount: 0 });
+  assert.deepEqual(report.mapping, {
+    attemptedRows: 3,
+    failedRows: 1,
+    failureRate: 1 / 3,
+    failuresByReason: { UNSUPPORTED_REGION: 1 },
+  });
+  assert.deepEqual(report.unsupportedRegions, [{ region: "busan", reason: "실시간 미지원" }]);
+});
+
+test("writes realtime provider coverage report json", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "realtime-provider-coverage-"));
+  const input = path.join(dir, "coverage-input.json");
+  const output = path.join(dir, "realtime-provider-coverage-report.json");
+  await writeFile(input, JSON.stringify({ staleFallbackRequired: true, stationLinePairs: [], samples: [] }));
+
+  await main(["--input", input, "--output", output]);
+
+  const report = JSON.parse(await readFile(output, "utf8"));
+  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.mapping.failureRate, 0);
+});

--- a/tools/routes/check-route-commercialization-gate.mjs
+++ b/tools/routes/check-route-commercialization-gate.mjs
@@ -137,6 +137,12 @@ function validateCoverage(gate, report, failures) {
   if (gate.realtimeCoverage.staleFallbackRequired && report.staleFallbackRequired !== true) {
     failures.push("realtimeCoverage stale fallback must be required");
   }
+  if (number(report.freshness?.staleAsFreshCount) > 0) {
+    failures.push("realtimeCoverage stale-as-fresh count exceeds 0");
+  }
+  if (!Number.isFinite(Number(report.mapping?.failureRate))) {
+    failures.push("realtimeCoverage mapping failure rate must be reported");
+  }
 }
 
 function realtimeSupportedStationLinePairsMin(gate, report) {

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -39,6 +39,8 @@ test("route commercialization gate passes with production-ready reports", async 
       supportedStationLinePairs: 150,
       providerFreshnessSecondsMaxObserved: 80,
       staleFallbackRequired: true,
+      freshness: { staleAsFreshCount: 0 },
+      mapping: { failureRate: 0 },
     },
     routeGraphCoverage: {
       schemaVersion: 1,
@@ -94,6 +96,8 @@ test("route commercialization gate fails closed for fixture-only or unsafe route
       supportedStationLinePairs: 50,
       providerFreshnessSecondsMaxObserved: 120,
       staleFallbackRequired: false,
+      freshness: { staleAsFreshCount: 1 },
+      mapping: { failureRate: 0.1 },
     },
     routeGraphCoverage: {
       schemaVersion: 1,
@@ -126,6 +130,7 @@ test("route commercialization gate fails closed for fixture-only or unsafe route
       assert.ok(report.failures.includes("routeEtaAccuracy production sampleSize is below 100"));
       assert.ok(report.failures.includes("accessibility strict step-free false positive count exceeds 0"));
       assert.ok(report.failures.includes("accessibility generated connector verified count exceeds 0"));
+      assert.ok(report.failures.includes("realtimeCoverage stale-as-fresh count exceeds 0"));
       assert.ok(report.failures.includes("route graph generated connector verified count exceeds 0"));
       assert.ok(report.failures.includes("route graph strict route not found rate exceeds 0.02"));
       assert.ok(!report.failures.includes("routing D-3 blocker must be satisfied before out-of-station transfer release claim"));
@@ -163,6 +168,8 @@ test("route commercialization gate keeps legacy production sample fallback", asy
       supportedStationLinePairs: 150,
       providerFreshnessSecondsMaxObserved: 80,
       staleFallbackRequired: true,
+      freshness: { staleAsFreshCount: 0 },
+      mapping: { failureRate: 0 },
     },
     routeGraphCoverage: {
       schemaVersion: 1,
@@ -227,6 +234,8 @@ test("route commercialization gate derives realtime pair minimum from coverage s
       supportedStationLinePairs: 2,
       providerFreshnessSecondsMaxObserved: 80,
       staleFallbackRequired: true,
+      freshness: { staleAsFreshCount: 0 },
+      mapping: { failureRate: 0 },
     },
     routeGraphCoverage: {
       schemaVersion: 1,
@@ -283,6 +292,8 @@ test("route commercialization gate fails on unclassified ETA deviations", async 
       supportedStationLinePairs: 150,
       providerFreshnessSecondsMaxObserved: 80,
       staleFallbackRequired: true,
+      freshness: { staleAsFreshCount: 0 },
+      mapping: { failureRate: 0 },
     },
     routeGraphCoverage: {
       schemaVersion: 1,


### PR DESCRIPTION
## Summary
- realtime provider coverage report builder를 추가해 지원 station-line pair, freshness 분포, stale-as-fresh count, mapping 실패율을 산출합니다.
- route commercialization gate가 stale-as-fresh와 mapping failure rate 누락을 실패로 잡도록 보강했습니다.

## Verification
- `node --test tools/routes/build-realtime-provider-coverage-report.test.mjs`
- `node --test tools/routes/check-route-commercialization-gate.test.mjs`
- `node --test tools/routes/*.test.mjs`
- `node --test --test-name-pattern "route commercialization release gate" tools/ci/repository-contract.test.mjs`
- `git diff --check`

Refs #1416
