### PR TITLE
[Test] pilot 시간표 coverage gap 고정

### DIFF
--- a/tools/datapack/capital-pilot-coverage-targets.json
+++ b/tools/datapack/capital-pilot-coverage-targets.json
@@ -20,6 +20,7 @@
   "knownSourceDomains": [
     "route_graph_topology",
     "realtime_arrivals",
+    "schedule_timetable",
     "route_map_positions",
     "demand_reference"
   ],
@@ -44,6 +45,18 @@
         "escalator",
         "wheelchair_lift",
         "verified_at"
+      ],
+      "blockingThreshold": {
+        "minimumOfficialFieldCoverageRatio": 1
+      }
+    },
+    {
+      "id": "schedule_timetable",
+      "displayName": "수도권 pilot 시간표와 운행 calendar",
+      "requiredFields": [
+        "service_calendar",
+        "trip",
+        "stop_time"
       ],
       "blockingThreshold": {
         "minimumOfficialFieldCoverageRatio": 1

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -7736,13 +7736,18 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
       path.join(packOutputDir, "current.provenance.json"),
       "--output",
       coverageReportPath,
+      "--allow-gaps",
     ],
     { cwd: root },
   );
   const coverageReport = JSON.parse(await readFile(coverageReportPath, "utf8"));
-  assert.equal(coverageReport.summary.coverageComplete, true);
-  assert.equal(coverageReport.summary.missingRequirements, 0);
-  assert.equal(coverageReport.summary.coverageRatio, 1);
+  assert.equal(coverageReport.summary.coverageComplete, false);
+  assert.equal(coverageReport.summary.missingRequirements, 1);
+  assert.equal(coverageReport.summary.coverageRatio, 0.6667);
+  assert.deepEqual(
+    coverageReport.requirements.find((requirement) => requirement.sourceDomain === "schedule_timetable").missingFields,
+    ["service_calendar", "trip", "stop_time"],
+  );
 
   const manifest = JSON.parse(await readFile(path.join(packOutputDir, "current.json"), "utf8"));
   assert.equal(manifest.manifestVersion, 2);


### PR DESCRIPTION
## Summary
- capital pilot coverage target에 `schedule_timetable`을 required domain으로 추가했습니다.
- pilot pack에 시간표가 없으면 coverage report가 complete로 보이지 않고, `service_calendar/trip/stop_time` gap을 노출하도록 테스트를 고정했습니다.

## Verification
- `node --test --test-name-pattern "수도권 pilot production source input" tools/datapack/datapack-tools.test.mjs`
- `node --test --test-name-pattern "운영 데이터팩 공식 출처 inventory|TAGO 시간표" tools/ci/repository-contract.test.mjs`
- `node --test tools/datapack/datapack-tools.test.mjs`
- `node --test --test-name-pattern "운영 데이터팩 공식 출처 inventory|TAGO 시간표|데이터팩 freshness SLA" tools/ci/repository-contract.test.mjs`
- `git diff --check`

Refs #1415
