### PR TITLE
[Backend] route static ETA source 분리

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -294,7 +294,7 @@ class RouteSearchController {
 			return switch (result.etaSource()) {
 				case REALTIME -> "HIGH";
 				case MIXED -> "MEDIUM";
-				case PLANNED, FALLBACK -> "LOW";
+				case STATIC_BACKEND_ESTIMATE, PLANNED, FALLBACK -> "LOW";
 			};
 		}
 	}
@@ -535,16 +535,19 @@ class RouteSearchController {
 			};
 		}
 
-		private static EtaSource etaSourceOf(RouteStep step) {
-			if (step.timeSource() == null || step.timeSource().isBlank()) {
-				return EtaSource.PLANNED;
+			private static EtaSource etaSourceOf(RouteStep step) {
+				if (step.timeSource() == null || step.timeSource().isBlank()) {
+					return EtaSource.STATIC_BACKEND_ESTIMATE;
+				}
+				if ("ESTIMATED_CONSTANT".equals(step.timeSource()) || "STATIC_BACKEND_V1".equals(step.timeSource())) {
+					return EtaSource.STATIC_BACKEND_ESTIMATE;
+				}
+				try {
+					return EtaSource.valueOf(step.timeSource());
+				} catch (IllegalArgumentException exception) {
+					return EtaSource.STATIC_BACKEND_ESTIMATE;
+				}
 			}
-			try {
-				return EtaSource.valueOf(step.timeSource());
-			} catch (IllegalArgumentException exception) {
-				return EtaSource.PLANNED;
-			}
-		}
 
 		private static String etaConfidenceOf(RouteStep step) {
 			if ("HIGH".equals(step.confidenceLabel())
@@ -552,12 +555,12 @@ class RouteSearchController {
 				|| "LOW".equals(step.confidenceLabel())) {
 				return step.confidenceLabel();
 			}
-			return switch (etaSourceOf(step)) {
-				case REALTIME -> "HIGH";
-				case MIXED -> "MEDIUM";
-				case PLANNED, FALLBACK -> "LOW";
-			};
-		}
+				return switch (etaSourceOf(step)) {
+					case REALTIME -> "HIGH";
+					case MIXED -> "MEDIUM";
+					case STATIC_BACKEND_ESTIMATE, PLANNED, FALLBACK -> "LOW";
+				};
+			}
 
 		private static String legTypeOf(RouteStep step) {
 			return switch (step.stepType()) {

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchDashboardView.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchDashboardView.java
@@ -138,6 +138,7 @@ public record RouteSearchDashboardView(
 		return switch (etaSource) {
 			case REALTIME -> "실시간 반영";
 			case MIXED -> "일부 실시간 반영";
+			case STATIC_BACKEND_ESTIMATE -> "상수 추정";
 			case PLANNED -> "시간표 기준";
 			case FALLBACK -> "provider 지연/장애 fallback";
 		};

--- a/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepository.java
@@ -533,7 +533,9 @@ public class JdbcRouteSearchRepository
 			.filter(step -> EtaSource.REALTIME.name().equals(step.timeSource()))
 			.count();
 		if (realtimeSteps == 0) {
-			return EtaSource.PLANNED;
+			return steps.stream().allMatch(step -> EtaSource.PLANNED.name().equals(step.timeSource()))
+				? EtaSource.PLANNED
+				: EtaSource.STATIC_BACKEND_ESTIMATE;
 		}
 		return realtimeSteps == steps.size() ? EtaSource.REALTIME : EtaSource.MIXED;
 	}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -364,7 +364,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			case REALTIME -> EtaConfidence.HIGH;
 			case MIXED -> EtaConfidence.MEDIUM;
 			case PLANNED -> EtaConfidence.MEDIUM;
-			case FALLBACK -> EtaConfidence.LOW;
+			case STATIC_BACKEND_ESTIMATE, FALLBACK -> EtaConfidence.LOW;
 		};
 	}
 
@@ -375,7 +375,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 			case REROUTE_REQUIRED -> "경로를 다시 찾아야 합니다";
 			case UNCHANGED -> routeSearch.etaSource() == EtaSource.PLANNED
 				? "계획 시간 기준"
-				: "기존 안내 유지";
+				: routeSearch.etaSource() == EtaSource.STATIC_BACKEND_ESTIMATE
+					? "상수 추정 기준"
+					: "기존 안내 유지";
 		};
 	}
 

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -61,7 +61,9 @@ public class RouteV2Planner {
 		if (!useRealtime || itinerary.status() != RouteSearchStatus.FOUND) {
 			return false;
 		}
-		return itinerary.etaSource() == EtaSource.PLANNED || itinerary.etaSource() == EtaSource.FALLBACK;
+		return itinerary.etaSource() == EtaSource.STATIC_BACKEND_ESTIMATE
+			|| itinerary.etaSource() == EtaSource.PLANNED
+			|| itinerary.etaSource() == EtaSource.FALLBACK;
 	}
 
 	private String statusOf(RouteSearchResult itinerary) {

--- a/backend/src/main/java/com/easysubway/route/domain/EtaSource.java
+++ b/backend/src/main/java/com/easysubway/route/domain/EtaSource.java
@@ -1,6 +1,7 @@
 package com.easysubway.route.domain;
 
 public enum EtaSource {
+	STATIC_BACKEND_ESTIMATE,
 	PLANNED,
 	REALTIME,
 	MIXED,

--- a/backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteSearchResult.java
@@ -66,7 +66,9 @@ public record RouteSearchResult(
 			return EtaSource.FALLBACK;
 		}
 		if (realtimeSteps == 0) {
-			return EtaSource.PLANNED;
+			return steps.stream().allMatch(step -> EtaSource.PLANNED.name().equals(step.timeSource()))
+				? EtaSource.PLANNED
+				: EtaSource.STATIC_BACKEND_ESTIMATE;
 		}
 		return realtimeSteps == steps.size() ? EtaSource.REALTIME : EtaSource.MIXED;
 	}

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchControllerTest.java
@@ -74,7 +74,7 @@ class RouteSearchControllerTest {
 			.andExpect(jsonPath("$.data.warnings").isArray())
 			.andExpect(jsonPath("$.data.blockedReasons").isArray())
 			.andExpect(jsonPath("$.data.createdAt").value("2026-06-30T09:00:00"))
-			.andExpect(jsonPath("$.data.etaSource").value("PLANNED"))
+			.andExpect(jsonPath("$.data.etaSource").value("STATIC_BACKEND_ESTIMATE"))
 			.andExpect(jsonPath("$.data.routeQuality").value("LEGACY_STATIC"))
 			.andExpect(jsonPath("$.data.commercialEtaEligible").value(false));
 	}

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -89,7 +89,7 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.data.itineraries[0].status").value("FOUND"))
 			.andExpect(jsonPath("$.data.itineraries[0].plannedArrivalTime").value("2026-06-30T09:22:00+09:00"))
 			.andExpect(jsonPath("$.data.itineraries[0].realtimeArrivalTime").doesNotExist())
-			.andExpect(jsonPath("$.data.itineraries[0].etaSource").value("PLANNED"))
+			.andExpect(jsonPath("$.data.itineraries[0].etaSource").value("STATIC_BACKEND_ESTIMATE"))
 			.andExpect(jsonPath("$.data.itineraries[0].etaConfidence").value("LOW"))
 			.andExpect(jsonPath("$.data.itineraries[0].durationSeconds").value(420))
 			.andExpect(jsonPath("$.data.itineraries[0].transferCount").value(0))
@@ -109,7 +109,7 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.data.itineraries[0].legs[1].plannedArrivalTime").value("2026-06-30T09:22:00+09:00"))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].waitTimeSeconds").value(0))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].slackSeconds").value(0))
-			.andExpect(jsonPath("$.data.itineraries[0].legs[0].etaSource").value("PLANNED"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].etaSource").value("STATIC_BACKEND_ESTIMATE"))
 			.andExpect(jsonPath("$.data.itineraries[0].commercialEtaEligible").value(false));
 	}
 

--- a/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/persistence/JdbcRouteSearchRepositoryTest.java
@@ -324,11 +324,11 @@ class JdbcRouteSearchRepositoryTest {
 					EtaSource.PLANNED,
 					List.of(RouteWarningCode.STAIR_ONLY_ACCESS)
 				),
-				tuple(
-					RouteSearchStatus.FOUND,
-					EtaSource.PLANNED,
-					List.of(RouteWarningCode.LOW_DATA_CONFIDENCE)
-				)
+					tuple(
+						RouteSearchStatus.FOUND,
+						EtaSource.STATIC_BACKEND_ESTIMATE,
+						List.of(RouteWarningCode.LOW_DATA_CONFIDENCE)
+					)
 			);
 	}
 

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -183,7 +183,7 @@ class RouteSearchServiceTest {
 		assertThat(refreshed.routeSearch()).isEqualTo(created);
 		assertThat(refreshed.status()).isEqualTo(RouteRefreshStatus.UNCHANGED);
 		assertThat(refreshed.etaSource()).isEqualTo(created.etaSource());
-		assertThat(refreshed.sourceLabel()).isEqualTo("계획 시간 기준");
+		assertThat(refreshed.sourceLabel()).isEqualTo("상수 추정 기준");
 		assertThat(refreshed.refreshedAt()).isEqualTo(LocalDate.of(2026, 6, 13).atTime(18, 0));
 	}
 
@@ -800,7 +800,7 @@ class RouteSearchServiceTest {
 		));
 
 		assertThat(resolver.callCount()).isZero();
-		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.PLANNED);
+		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.STATIC_BACKEND_ESTIMATE);
 		assertThat(plan.statuses()).containsExactly("FOUND");
 	}
 


### PR DESCRIPTION
## Summary
- separate backend static ETA route results from planned/realtime ETA source semantics
- expose static ETA source through route search controller/dashboard result surfaces
- update route search persistence/service/controller tests for the source contract

## Verification
- ./gradlew test --tests com.easysubway.route.adapter.in.web.RouteSearchControllerTest --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest --tests com.easysubway.route.adapter.out.persistence.JdbcRouteSearchRepositoryTest --tests com.easysubway.route.application.service.RouteSearchServiceTest (in backend/)
- git diff --check

Refs #1401