### PR TITLE
[Backend] route V2 planner 단건 wrapper 제거

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteSearchUseCase.java
@@ -4,10 +4,13 @@ import com.easysubway.route.domain.InternalRouteResult;
 import com.easysubway.route.domain.RouteFeedback;
 import com.easysubway.route.domain.RouteRefreshResult;
 import com.easysubway.route.domain.RouteSearchResult;
+import java.util.List;
 
 public interface RouteSearchUseCase {
 
 	RouteSearchResult searchRoute(SearchRouteCommand command);
+
+	List<RouteSearchResult> searchRouteAlternatives(SearchRouteCommand command, int alternativeCount);
 
 	InternalRouteResult searchInternalRoute(SearchInternalRouteCommand command);
 

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -173,7 +173,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 		return searchRouteAlternatives(command, 1).getFirst();
 	}
 
-	List<RouteSearchResult> searchRouteAlternatives(SearchRouteCommand command, int alternativeCount) {
+	public List<RouteSearchResult> searchRouteAlternatives(SearchRouteCommand command, int alternativeCount) {
 		requireCommand(command);
 		Station origin = loadActiveStation(command.originStationId());
 		Station destination = loadActiveStation(command.destinationStationId());

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -1,7 +1,6 @@
 package com.easysubway.route.application.service;
 
 import com.easysubway.profile.domain.MobilityType;
-import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.EtaSource;
@@ -18,29 +17,24 @@ public class RouteV2Planner {
 
 	private static final String PLANNER_ADR = "tools/routes/route-algorithm-v2-adr.json";
 
-	private final RouteSearchUseCase routeSearchUseCase;
+	private final RouteSearchService routeSearchService;
 
-	public RouteV2Planner(RouteSearchUseCase routeSearchUseCase) {
-		this.routeSearchUseCase = routeSearchUseCase;
+	public RouteV2Planner(RouteSearchService routeSearchService) {
+		this.routeSearchService = routeSearchService;
 	}
 
 	public RouteV2Plan search(SearchRouteV2Command command) {
 		try {
 			SearchRouteCommand searchRouteCommand = command.toSearchRouteCommand();
-			if (routeSearchUseCase instanceof RouteSearchService routeSearchService) {
-				List<RouteSearchResult> itineraries = routeSearchService.searchRouteAlternatives(
-					searchRouteCommand,
-					command.alternativeCount()
-				);
-				return new RouteV2Plan(
-					itineraries,
-					statusesOf(itineraries, command.useRealtime()),
-					PLANNER_ADR
-				);
-			}
-			RouteSearchResult primary = routeSearchUseCase.searchRoute(searchRouteCommand);
-			List<RouteSearchResult> itineraries = List.of(primary);
-			return new RouteV2Plan(itineraries, statusesOf(itineraries, command.useRealtime()), PLANNER_ADR);
+			List<RouteSearchResult> itineraries = routeSearchService.searchRouteAlternatives(
+				searchRouteCommand,
+				command.alternativeCount()
+			);
+			return new RouteV2Plan(
+				itineraries,
+				statusesOf(itineraries, command.useRealtime()),
+				PLANNER_ADR
+			);
 		} catch (RouteNotFoundException exception) {
 			return new RouteV2Plan(List.of(), List.of("NO_TIMETABLE_SERVICE"), PLANNER_ADR);
 		}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -1,6 +1,7 @@
 package com.easysubway.route.application.service;
 
 import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.EtaSource;
@@ -17,16 +18,16 @@ public class RouteV2Planner {
 
 	private static final String PLANNER_ADR = "tools/routes/route-algorithm-v2-adr.json";
 
-	private final RouteSearchService routeSearchService;
+	private final RouteSearchUseCase routeSearchUseCase;
 
-	public RouteV2Planner(RouteSearchService routeSearchService) {
-		this.routeSearchService = routeSearchService;
+	public RouteV2Planner(RouteSearchUseCase routeSearchUseCase) {
+		this.routeSearchUseCase = routeSearchUseCase;
 	}
 
 	public RouteV2Plan search(SearchRouteV2Command command) {
 		try {
 			SearchRouteCommand searchRouteCommand = command.toSearchRouteCommand();
-			List<RouteSearchResult> itineraries = routeSearchService.searchRouteAlternatives(
+			List<RouteSearchResult> itineraries = routeSearchUseCase.searchRouteAlternatives(
 				searchRouteCommand,
 				command.alternativeCount()
 			);

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -10,7 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.easysubway.profile.domain.MobilityType;
-import com.easysubway.route.application.service.RouteSearchService;
+import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.domain.EtaConfidence;
 import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteRefreshResult;
@@ -45,12 +45,12 @@ class RouteSearchV2ControllerTest {
 	private MockMvc mockMvc;
 
 	@MockitoBean
-	private RouteSearchService routeSearchService;
+	private RouteSearchUseCase routeSearchUseCase;
 
 	@Test
 	@DisplayName("모바일 V2 계약으로 itinerary와 leg 단위 ETA 필드를 반환한다")
 	void routeSearchV2ReturnsItineraryContract() throws Exception {
-		when(routeSearchService.searchRouteAlternatives(argThat(command ->
+		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->
 			"station-sangnoksu".equals(command.originStationId())
 				&& "station-sadang".equals(command.destinationStationId())
 				&& command.mobilityType() == MobilityType.STROLLER
@@ -119,7 +119,7 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 경로 검색은 시간표 서비스가 없으면 NO_TIMETABLE_SERVICE status와 빈 itinerary를 반환한다")
 	void routeSearchV2ReturnsNoTimetableServiceStatus() throws Exception {
-		when(routeSearchService.searchRouteAlternatives(argThat(command ->
+		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->
 			"station-no-service-origin".equals(command.originStationId())
 				&& "station-no-service-destination".equals(command.destinationStationId())
 		), eq(3))).thenThrow(new RouteNotFoundException());
@@ -148,7 +148,7 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 route refresh는 저장된 itinerary와 refresh 상태를 반환한다")
 	void routeRefreshV2ReturnsRefreshStatusAndStoredRoute() throws Exception {
-		when(routeSearchService.refreshRoute("route-search-1"))
+		when(routeSearchUseCase.refreshRoute("route-search-1"))
 			.thenReturn(new RouteRefreshResult(
 				"route-search-1",
 				RouteRefreshStatus.STALE_FALLBACK,
@@ -177,7 +177,7 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 route refresh는 없는 routeSearchId를 안정 JSON 404로 반환한다")
 	void routeRefreshV2UnknownRouteSearchIdReturnsJsonNotFound() throws Exception {
-		when(routeSearchService.refreshRoute("route-missing"))
+		when(routeSearchUseCase.refreshRoute("route-missing"))
 			.thenThrow(new com.easysubway.route.domain.RouteSearchNotFoundException());
 
 		mockMvc.perform(post("/api/v2/routes/route-missing/refresh"))
@@ -190,7 +190,7 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("모바일 V2 계약으로 accessibility risk vector count를 반환한다")
 	void routeSearchV2ReturnsAccessibilityRiskVectorCounts() throws Exception {
-		when(routeSearchService.searchRouteAlternatives(argThat(command ->
+		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->
 			"station-risk-origin".equals(command.originStationId())
 				&& "station-risk-destination".equals(command.destinationStationId())
 		), eq(1))).thenReturn(List.of(riskyRouteSearch()));
@@ -231,7 +231,7 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 leg ETA source와 confidence는 step data에서 파생한다")
 	void routeSearchV2MapsLegEtaSourceAndConfidence() throws Exception {
-		when(routeSearchService.searchRouteAlternatives(argThat(command ->
+		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->
 			command != null && "station-realtime-origin".equals(command.originStationId())
 		), eq(1))).thenReturn(List.of(realtimeRouteSearch()));
 
@@ -259,7 +259,7 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 첫 탑승과 환승 후 탑승은 이동약자 준비시간 이후로 계산한다")
 	void routeSearchV2AppliesBoardingAndTransferSlackBeforeRideLegs() throws Exception {
-		when(routeSearchService.searchRouteAlternatives(argThat(command ->
+		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->
 			command != null && "station-boarding-origin".equals(command.originStationId())
 		), eq(1))).thenReturn(List.of(boardingTransferRouteSearch()));
 
@@ -291,7 +291,7 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 큰 짐 이동은 탑승 준비시간 60초를 적용한다")
 	void routeSearchV2AppliesLuggageBoardingSlack() throws Exception {
-		when(routeSearchService.searchRouteAlternatives(argThat(command ->
+		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->
 			command != null && command.mobilityType() == MobilityType.LUGGAGE
 		), eq(1))).thenReturn(List.of(boardingTransferRouteSearch(MobilityType.LUGGAGE)));
 
@@ -321,7 +321,7 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("모바일 V2 계약의 blocked reasonCodes는 사용자 문장 대신 안정적인 코드만 반환한다")
 	void routeSearchV2BlockedRiskReasonCodesAreStableCodes() throws Exception {
-		when(routeSearchService.searchRouteAlternatives(argThat(command ->
+		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->
 			"station-blocked-origin".equals(command.originStationId())
 				&& "station-blocked-destination".equals(command.destinationStationId())
 		), eq(1))).thenReturn(List.of(blockedRouteSearch()));
@@ -369,7 +369,7 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.message").value("출발 시간은 ISO offset 형식이어야 합니다."));
 
-		verifyNoInteractions(routeSearchService);
+		verifyNoInteractions(routeSearchUseCase);
 	}
 
 	@Test
@@ -394,7 +394,7 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.message").exists());
 
-		verifyNoInteractions(routeSearchService);
+		verifyNoInteractions(routeSearchUseCase);
 	}
 
 	@Test
@@ -418,13 +418,13 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.message").exists());
 
-		verifyNoInteractions(routeSearchService);
+		verifyNoInteractions(routeSearchUseCase);
 	}
 
 	@Test
 	@DisplayName("V2 prefer step-free는 mobility type을 유지한 채 command에 전달한다")
 	void routeSearchV2PreferStepFreeKeepsMobilityType() throws Exception {
-		when(routeSearchService.searchRouteAlternatives(argThat(command ->
+		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->
 			command.mobilityType() == MobilityType.STROLLER
 				&& command.constraintMode() == ConstraintMode.PREFER_STEP_FREE
 		), eq(3))).thenReturn(List.of(foundRouteSearch()));
@@ -450,7 +450,7 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 PROFILE_DEFAULT는 기존 client 호환을 위해 mobility type 기본 constraint로 처리한다")
 	void routeSearchV2ProfileDefaultUsesMobilityTypeDefaultConstraintMode() throws Exception {
-		when(routeSearchService.searchRouteAlternatives(argThat(command ->
+		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->
 			command.mobilityType() == MobilityType.STROLLER
 				&& command.constraintMode() == ConstraintMode.PREFER_STEP_FREE
 		), eq(3))).thenReturn(List.of(foundRouteSearch()));
@@ -476,7 +476,7 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 allow-with-warnings는 constraintMode를 command와 응답에 반영한다")
 	void routeSearchV2AllowWithWarningsKeepsConstraintMode() throws Exception {
-		when(routeSearchService.searchRouteAlternatives(argThat(command ->
+		when(routeSearchUseCase.searchRouteAlternatives(argThat(command ->
 			command.mobilityType() == MobilityType.STROLLER
 				&& command.constraintMode() == ConstraintMode.ALLOW_WITH_WARNINGS
 		), eq(3))).thenReturn(List.of(foundRouteSearch()));
@@ -521,7 +521,7 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.message").value("지원하지 않는 이동 제약 조건입니다."));
 
-		verifyNoInteractions(routeSearchService);
+		verifyNoInteractions(routeSearchUseCase);
 	}
 
 	private RouteSearchResult foundRouteSearch() {

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -1,6 +1,7 @@
 package com.easysubway.route.adapter.in.web;
 
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -9,7 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.easysubway.profile.domain.MobilityType;
-import com.easysubway.route.application.port.in.RouteSearchUseCase;
+import com.easysubway.route.application.service.RouteSearchService;
 import com.easysubway.route.domain.EtaConfidence;
 import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteRefreshResult;
@@ -44,18 +45,18 @@ class RouteSearchV2ControllerTest {
 	private MockMvc mockMvc;
 
 	@MockitoBean
-	private RouteSearchUseCase routeSearchUseCase;
+	private RouteSearchService routeSearchService;
 
 	@Test
 	@DisplayName("모바일 V2 계약으로 itinerary와 leg 단위 ETA 필드를 반환한다")
 	void routeSearchV2ReturnsItineraryContract() throws Exception {
-		when(routeSearchUseCase.searchRoute(argThat(command ->
+		when(routeSearchService.searchRouteAlternatives(argThat(command ->
 			"station-sangnoksu".equals(command.originStationId())
 				&& "station-sadang".equals(command.destinationStationId())
 				&& command.mobilityType() == MobilityType.STROLLER
 				&& command.constraintMode() == ConstraintMode.STRICT_STEP_FREE
 				&& command.maxTransfers() == 3
-		))).thenReturn(foundRouteSearch());
+		), eq(3))).thenReturn(List.of(foundRouteSearch(), blockedRouteSearch()));
 
 		mockMvc.perform(post("/api/v2/routes/search")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -84,7 +85,7 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.data.alternativeCount").value(3))
 			.andExpect(jsonPath("$.data.statuses[0]").value("FOUND"))
 			.andExpect(jsonPath("$.data.statuses[1]").value("REALTIME_UNAVAILABLE_PLANNED_USED"))
-			.andExpect(jsonPath("$.data.statuses[2]").doesNotExist())
+			.andExpect(jsonPath("$.data.statuses[2]").value("BLOCKED_ACCESSIBILITY"))
 			.andExpect(jsonPath("$.data.itineraries[0].itineraryId").value("route-search-1-primary"))
 			.andExpect(jsonPath("$.data.itineraries[0].status").value("FOUND"))
 			.andExpect(jsonPath("$.data.itineraries[0].plannedArrivalTime").value("2026-06-30T09:22:00+09:00"))
@@ -110,16 +111,18 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].waitTimeSeconds").value(0))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].slackSeconds").value(0))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].etaSource").value("STATIC_BACKEND_ESTIMATE"))
-			.andExpect(jsonPath("$.data.itineraries[0].commercialEtaEligible").value(false));
+			.andExpect(jsonPath("$.data.itineraries[0].commercialEtaEligible").value(false))
+			.andExpect(jsonPath("$.data.itineraries[1].status").value("BLOCKED_ACCESSIBILITY"))
+			.andExpect(jsonPath("$.data.itineraries[2]").doesNotExist());
 	}
 
 	@Test
 	@DisplayName("V2 경로 검색은 시간표 서비스가 없으면 NO_TIMETABLE_SERVICE status와 빈 itinerary를 반환한다")
 	void routeSearchV2ReturnsNoTimetableServiceStatus() throws Exception {
-		when(routeSearchUseCase.searchRoute(argThat(command ->
+		when(routeSearchService.searchRouteAlternatives(argThat(command ->
 			"station-no-service-origin".equals(command.originStationId())
 				&& "station-no-service-destination".equals(command.destinationStationId())
-		))).thenThrow(new RouteNotFoundException());
+		), eq(3))).thenThrow(new RouteNotFoundException());
 
 		mockMvc.perform(post("/api/v2/routes/search")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -145,7 +148,7 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 route refresh는 저장된 itinerary와 refresh 상태를 반환한다")
 	void routeRefreshV2ReturnsRefreshStatusAndStoredRoute() throws Exception {
-		when(routeSearchUseCase.refreshRoute("route-search-1"))
+		when(routeSearchService.refreshRoute("route-search-1"))
 			.thenReturn(new RouteRefreshResult(
 				"route-search-1",
 				RouteRefreshStatus.STALE_FALLBACK,
@@ -174,7 +177,7 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 route refresh는 없는 routeSearchId를 안정 JSON 404로 반환한다")
 	void routeRefreshV2UnknownRouteSearchIdReturnsJsonNotFound() throws Exception {
-		when(routeSearchUseCase.refreshRoute("route-missing"))
+		when(routeSearchService.refreshRoute("route-missing"))
 			.thenThrow(new com.easysubway.route.domain.RouteSearchNotFoundException());
 
 		mockMvc.perform(post("/api/v2/routes/route-missing/refresh"))
@@ -187,10 +190,10 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("모바일 V2 계약으로 accessibility risk vector count를 반환한다")
 	void routeSearchV2ReturnsAccessibilityRiskVectorCounts() throws Exception {
-		when(routeSearchUseCase.searchRoute(argThat(command ->
+		when(routeSearchService.searchRouteAlternatives(argThat(command ->
 			"station-risk-origin".equals(command.originStationId())
 				&& "station-risk-destination".equals(command.destinationStationId())
-		))).thenReturn(riskyRouteSearch());
+		), eq(1))).thenReturn(List.of(riskyRouteSearch()));
 
 		mockMvc.perform(post("/api/v2/routes/search")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -228,9 +231,9 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 leg ETA source와 confidence는 step data에서 파생한다")
 	void routeSearchV2MapsLegEtaSourceAndConfidence() throws Exception {
-		when(routeSearchUseCase.searchRoute(argThat(command ->
+		when(routeSearchService.searchRouteAlternatives(argThat(command ->
 			command != null && "station-realtime-origin".equals(command.originStationId())
-		))).thenReturn(realtimeRouteSearch());
+		), eq(1))).thenReturn(List.of(realtimeRouteSearch()));
 
 		mockMvc.perform(post("/api/v2/routes/search")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -256,9 +259,9 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 첫 탑승과 환승 후 탑승은 이동약자 준비시간 이후로 계산한다")
 	void routeSearchV2AppliesBoardingAndTransferSlackBeforeRideLegs() throws Exception {
-		when(routeSearchUseCase.searchRoute(argThat(command ->
+		when(routeSearchService.searchRouteAlternatives(argThat(command ->
 			command != null && "station-boarding-origin".equals(command.originStationId())
-		))).thenReturn(boardingTransferRouteSearch());
+		), eq(1))).thenReturn(List.of(boardingTransferRouteSearch()));
 
 		mockMvc.perform(post("/api/v2/routes/search")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -288,9 +291,9 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 큰 짐 이동은 탑승 준비시간 60초를 적용한다")
 	void routeSearchV2AppliesLuggageBoardingSlack() throws Exception {
-		when(routeSearchUseCase.searchRoute(argThat(command ->
+		when(routeSearchService.searchRouteAlternatives(argThat(command ->
 			command != null && command.mobilityType() == MobilityType.LUGGAGE
-		))).thenReturn(boardingTransferRouteSearch(MobilityType.LUGGAGE));
+		), eq(1))).thenReturn(List.of(boardingTransferRouteSearch(MobilityType.LUGGAGE)));
 
 		mockMvc.perform(post("/api/v2/routes/search")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -318,10 +321,10 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("모바일 V2 계약의 blocked reasonCodes는 사용자 문장 대신 안정적인 코드만 반환한다")
 	void routeSearchV2BlockedRiskReasonCodesAreStableCodes() throws Exception {
-		when(routeSearchUseCase.searchRoute(argThat(command ->
+		when(routeSearchService.searchRouteAlternatives(argThat(command ->
 			"station-blocked-origin".equals(command.originStationId())
 				&& "station-blocked-destination".equals(command.destinationStationId())
-		))).thenReturn(blockedRouteSearch());
+		), eq(1))).thenReturn(List.of(blockedRouteSearch()));
 
 		mockMvc.perform(post("/api/v2/routes/search")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -366,7 +369,7 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.message").value("출발 시간은 ISO offset 형식이어야 합니다."));
 
-		verifyNoInteractions(routeSearchUseCase);
+		verifyNoInteractions(routeSearchService);
 	}
 
 	@Test
@@ -391,7 +394,7 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.message").exists());
 
-		verifyNoInteractions(routeSearchUseCase);
+		verifyNoInteractions(routeSearchService);
 	}
 
 	@Test
@@ -415,16 +418,16 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.message").exists());
 
-		verifyNoInteractions(routeSearchUseCase);
+		verifyNoInteractions(routeSearchService);
 	}
 
 	@Test
 	@DisplayName("V2 prefer step-free는 mobility type을 유지한 채 command에 전달한다")
 	void routeSearchV2PreferStepFreeKeepsMobilityType() throws Exception {
-		when(routeSearchUseCase.searchRoute(argThat(command ->
+		when(routeSearchService.searchRouteAlternatives(argThat(command ->
 			command.mobilityType() == MobilityType.STROLLER
 				&& command.constraintMode() == ConstraintMode.PREFER_STEP_FREE
-		))).thenReturn(foundRouteSearch());
+		), eq(3))).thenReturn(List.of(foundRouteSearch()));
 
 		mockMvc.perform(post("/api/v2/routes/search")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -447,10 +450,10 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 PROFILE_DEFAULT는 기존 client 호환을 위해 mobility type 기본 constraint로 처리한다")
 	void routeSearchV2ProfileDefaultUsesMobilityTypeDefaultConstraintMode() throws Exception {
-		when(routeSearchUseCase.searchRoute(argThat(command ->
+		when(routeSearchService.searchRouteAlternatives(argThat(command ->
 			command.mobilityType() == MobilityType.STROLLER
 				&& command.constraintMode() == ConstraintMode.PREFER_STEP_FREE
-		))).thenReturn(foundRouteSearch());
+		), eq(3))).thenReturn(List.of(foundRouteSearch()));
 
 		mockMvc.perform(post("/api/v2/routes/search")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -473,10 +476,10 @@ class RouteSearchV2ControllerTest {
 	@Test
 	@DisplayName("V2 allow-with-warnings는 constraintMode를 command와 응답에 반영한다")
 	void routeSearchV2AllowWithWarningsKeepsConstraintMode() throws Exception {
-		when(routeSearchUseCase.searchRoute(argThat(command ->
+		when(routeSearchService.searchRouteAlternatives(argThat(command ->
 			command.mobilityType() == MobilityType.STROLLER
 				&& command.constraintMode() == ConstraintMode.ALLOW_WITH_WARNINGS
-		))).thenReturn(foundRouteSearch());
+		), eq(3))).thenReturn(List.of(foundRouteSearch()));
 
 		mockMvc.perform(post("/api/v2/routes/search")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -518,7 +521,7 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.message").value("지원하지 않는 이동 제약 조건입니다."));
 
-		verifyNoInteractions(routeSearchUseCase);
+		verifyNoInteractions(routeSearchService);
 	}
 
 	private RouteSearchResult foundRouteSearch() {


### PR DESCRIPTION
## 관련 이슈

Refs #1402
Refs #1414

## 작업 배경

- `/api/v2/routes/search`가 V2 request를 받으면서도 기존 V1 단건 search 결과를 감싸는 경로에 머물러 있었습니다.
- #1402 완료 조건 중 `alternativeCount`를 planner input으로 전달하고 가능한 경우 복수 itinerary를 반환하는 경로가 필요합니다.
- 기존 PR CI에서 `RouteV2Planner`가 concrete `RouteSearchService`를 요구해 V1 controller test의 `RouteSearchUseCase` mock과 충돌했습니다.

## 작업 내용

- `RouteSearchService.searchRouteAlternatives` 경로를 `RouteSearchUseCase` 계약으로 승격했습니다.
- `RouteV2Planner`가 concrete service가 아니라 `RouteSearchUseCase`를 의존하도록 조정했습니다.
- V2 controller 테스트 mock도 같은 usecase 경계로 맞췄습니다.
- branch를 최신 `main` 위로 rebase했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.adapter.in.web.RouteSearchControllerTest --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest --tests com.easysubway.route.application.service.RouteSearchServiceTest`: 통과
  - `./gradlew check --no-daemon`: 통과
  - `git diff --check`: 통과
- PR CI:
  - CI run `28594709957`: 통과
  - Release Artifacts run `28594709391`: 통과
  - SonarCloud run `28594707242`: 통과
- Code review:
  - CodeRabbit: rate limit으로 실제 PR Review 객체 없음
  - Codex fallback review: `pullrequestreview-4618032107`, actionable 0

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| V1/V2 controller Spring context | backend | Gradle targeted test | 로컬 명령 출력 | 통과 |
| backend 전체 check | backend | Gradle check + PR Backend CI | run `28594709957` | 통과 |
| Release artifact 영향 | backend | PR Release Artifacts | run `28594709391` | 통과 |
| UI/접근성 수동 QA | Android | backend planner wiring 변경으로 UI 변경 없음 | 불필요 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: V2 planner가 alternative search usecase를 호출하도록 backend 내부 계약 보강
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteV2Planner`가 `RouteSearchUseCase.searchRouteAlternatives`를 호출하는지
  - V1/V2 controller tests가 같은 Spring mock 경계에서 충돌하지 않는지

## 리스크

- 중간. V2 planner wiring 변경이지만 기존 `RouteSearchService` 구현을 interface로 노출하는 범위라 blast radius는 작습니다.
- #1402 전체 완료 조건 중 production-grade Range RAPTOR와 route commercialization report 연결은 후속으로 남습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
