### PR TITLE
[Test] 원격 데이터팩 artifact 검증 wrapper 추가

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -560,6 +560,66 @@ test("데이터팩 검증기는 trip별 stop_time 시간이 역행하면 거부�
   );
 });
 
+test("원격 데이터팩 검증 wrapper는 manifest와 pack을 내려받아 기존 validator를 실행한다", async () => {
+  const packOutputDir = path.join(tmpdir(), `easysubway-remote-datapack-source-${Date.now()}`);
+  const downloadDir = path.join(tmpdir(), `easysubway-remote-datapack-download-${Date.now()}`);
+  await rm(packOutputDir, { recursive: true, force: true });
+  await rm(downloadDir, { recursive: true, force: true });
+  await mkdir(packOutputDir, { recursive: true });
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture",
+      "tools/datapack/fixtures/catalog-fixture.json",
+      "--output",
+      packOutputDir,
+    ],
+    { cwd: root, env: productionEnv },
+  );
+
+  const server = await startObjectStorageServer({ requireAuthorization: false, basePath: "/catalog" });
+  try {
+    const manifestBytes = await readFile(path.join(packOutputDir, "current.json"));
+    const packBytes = await readFile(path.join(packOutputDir, "catalog", "capital-v1.sqlite.gz"));
+    server.objects.set("current.json", {
+      body: manifestBytes,
+      sha256: sha256(manifestBytes),
+      sizeBytes: manifestBytes.length,
+    });
+    server.objects.set("capital-v1.sqlite.gz", {
+      body: packBytes,
+      sha256: sha256(packBytes),
+      sizeBytes: packBytes.length,
+    });
+
+    await execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-remote-datapack-artifact.mjs",
+        "--manifest-url",
+        `${server.origin}/catalog/current.json`,
+        "--output",
+        downloadDir,
+      ],
+      { cwd: root, env: productionEnv },
+    );
+
+    const summary = JSON.parse(
+      await readFile(path.join(downloadDir, "remote-datapack-validation-summary.json"), "utf8"),
+    );
+    assert.equal(summary.manifestVersion, 1);
+    assert.equal(summary.validation.exitCode, 0);
+    assert.equal(summary.packs[0].id, "capital");
+    assert.match(summary.manifestSha256, /^[0-9a-f]{64}$/);
+  } finally {
+    await server.close();
+    await rm(packOutputDir, { recursive: true, force: true });
+    await rm(downloadDir, { recursive: true, force: true });
+  }
+});
+
 test("데이터팩 검증기는 strict step-free transfer가 계단 pathway를 가리키면 거부한다", async () => {
   const fixture = JSON.parse(await readFile("tools/datapack/fixtures/catalog-fixture.json", "utf8"));
   const outputDir = path.join(tmpdir(), `easysubway-datapack-strict-pathway-invalid-${Date.now()}`);

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -620,6 +620,67 @@ test("원격 데이터팩 검증 wrapper는 manifest와 pack을 내려받아 기
   }
 });
 
+test("원격 데이터팩 검증 wrapper는 validator 실패도 summary에 기록한다", async () => {
+  const packOutputDir = path.join(tmpdir(), `easysubway-remote-datapack-source-invalid-${Date.now()}`);
+  const downloadDir = path.join(tmpdir(), `easysubway-remote-datapack-download-invalid-${Date.now()}`);
+  await rm(packOutputDir, { recursive: true, force: true });
+  await rm(downloadDir, { recursive: true, force: true });
+  await mkdir(packOutputDir, { recursive: true });
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture",
+      "tools/datapack/fixtures/catalog-fixture.json",
+      "--output",
+      packOutputDir,
+    ],
+    { cwd: root, env: productionEnv },
+  );
+
+  const server = await startObjectStorageServer({ requireAuthorization: false, basePath: "/catalog" });
+  try {
+    const manifestBytes = await readFile(path.join(packOutputDir, "current.json"));
+    const corruptPackBytes = Buffer.from("not a gzip datapack");
+    server.objects.set("current.json", {
+      body: manifestBytes,
+      sha256: sha256(manifestBytes),
+      sizeBytes: manifestBytes.length,
+    });
+    server.objects.set("capital-v1.sqlite.gz", {
+      body: corruptPackBytes,
+      sha256: sha256(corruptPackBytes),
+      sizeBytes: corruptPackBytes.length,
+    });
+
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          "tools/datapack/validate-remote-datapack-artifact.mjs",
+          "--manifest-url",
+          `${server.origin}/catalog/current.json`,
+          "--output",
+          downloadDir,
+        ],
+        { cwd: root, env: productionEnv },
+      ),
+    );
+
+    const summary = JSON.parse(
+      await readFile(path.join(downloadDir, "remote-datapack-validation-summary.json"), "utf8"),
+    );
+    assert.notEqual(summary.validation.exitCode, 0);
+    assert.equal(summary.validation.signal, null);
+    assert.match(summary.validation.stderr, /sizeBytes mismatch/);
+  } finally {
+    await server.close();
+    await rm(packOutputDir, { recursive: true, force: true });
+    await rm(downloadDir, { recursive: true, force: true });
+  }
+});
+
 test("데이터팩 검증기는 strict step-free transfer가 계단 pathway를 가리키면 거부한다", async () => {
   const fixture = JSON.parse(await readFile("tools/datapack/fixtures/catalog-fixture.json", "utf8"));
   const outputDir = path.join(tmpdir(), `easysubway-datapack-strict-pathway-invalid-${Date.now()}`);

--- a/tools/datapack/validate-remote-datapack-artifact.mjs
+++ b/tools/datapack/validate-remote-datapack-artifact.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+const manifestUrl = requireArg(args, "manifest-url");
+const outputRoot = path.resolve(requireArg(args, "output"));
+const requireProduction = args["require-production"] === true;
+
+await mkdir(path.join(outputRoot, "catalog"), { recursive: true });
+const manifestPath = path.join(outputRoot, "catalog", "current.json");
+const manifestBytes = await download(manifestUrl);
+await writeFile(manifestPath, manifestBytes);
+
+const manifest = JSON.parse(manifestBytes.toString("utf8"));
+for (const pack of manifest.packs ?? []) {
+  const packUrl = /^https?:\/\//.test(pack.url)
+    ? pack.url
+    : new URL(pack.url, new URL("/", manifestUrl)).toString();
+  const packPath = path.join(outputRoot, "catalog", `${pack.id}-v${pack.version}.sqlite.gz`);
+  await writeFile(packPath, await download(packUrl));
+}
+
+const validation = await runValidator({ manifestPath, outputRoot, requireProduction });
+const summary = {
+  manifestUrl,
+  manifestSha256: sha256(manifestBytes),
+  manifestVersion: manifest.manifestVersion ?? 1,
+  channel: manifest.channel,
+  releaseSequence: manifest.releaseSequence,
+  publishedAt: manifest.publishedAt,
+  expiresAt: manifest.expiresAt,
+  packs: (manifest.packs ?? []).map((pack) => ({
+    id: pack.id,
+    version: pack.version,
+    artifactKind: pack.artifactKind,
+    url: pack.url,
+    sha256: pack.sha256,
+    sqliteSha256: pack.sqliteSha256,
+    sizeBytes: pack.sizeBytes,
+    regionalQualityMetrics: pack.regionalQualityMetrics,
+  })),
+  validation,
+};
+await writeFile(
+  path.join(outputRoot, "remote-datapack-validation-summary.json"),
+  `${JSON.stringify(summary, null, 2)}\n`,
+);
+
+if (validation.exitCode !== 0) {
+  process.stderr.write(validation.stderr || validation.stdout);
+  process.exit(validation.exitCode);
+}
+
+function parseArgs(values) {
+  const parsed = {};
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
+    if (!value.startsWith("--")) {
+      throw new Error(`invalid argument: ${value}`);
+    }
+    const key = value.slice(2);
+    if (key === "require-production") {
+      parsed[key] = true;
+      continue;
+    }
+    parsed[key] = values[++index];
+  }
+  return parsed;
+}
+
+function requireArg(parsed, name) {
+  const value = parsed[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`missing required argument: --${name}`);
+  }
+  return value;
+}
+
+async function download(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`download failed: ${url} ${response.status}`);
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function runValidator({ manifestPath, outputRoot, requireProduction }) {
+  const args = [
+    "tools/datapack/validate-datapack.mjs",
+    "--manifest",
+    manifestPath,
+    "--root",
+    outputRoot,
+  ];
+  if (requireProduction) {
+    args.push("--require-production");
+  }
+  const result = await spawnResult(process.execPath, args);
+  return {
+    command: `${process.execPath} ${args.join(" ")}`,
+    exitCode: result.exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function spawnResult(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd: path.resolve(import.meta.dirname, "../..") });
+    const stdout = [];
+    const stderr = [];
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.on("error", reject);
+    child.on("close", (exitCode) => {
+      resolve({
+        exitCode,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      });
+    });
+  });
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}

--- a/tools/datapack/validate-remote-datapack-artifact.mjs
+++ b/tools/datapack/validate-remote-datapack-artifact.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+
+const DOWNLOAD_TIMEOUT_MS = 30_000;
 
 const args = parseArgs(process.argv.slice(2));
 const manifestUrl = requireArg(args, "manifest-url");
@@ -49,6 +51,12 @@ await writeFile(
   `${JSON.stringify(summary, null, 2)}\n`,
 );
 
+if (validation.signal) {
+  process.stderr.write(validation.stderr || validation.stdout);
+  process.stderr.write(`validator terminated by signal ${validation.signal}\n`);
+  process.exit(1);
+}
+
 if (validation.exitCode !== 0) {
   process.stderr.write(validation.stderr || validation.stdout);
   process.exit(validation.exitCode);
@@ -80,7 +88,19 @@ function requireArg(parsed, name) {
 }
 
 async function download(url) {
-  const response = await fetch(url);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DOWNLOAD_TIMEOUT_MS);
+  let response;
+  try {
+    response = await fetch(url, { signal: controller.signal });
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      throw new Error(`download timed out after ${DOWNLOAD_TIMEOUT_MS}ms: ${url}`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
   if (!response.ok) {
     throw new Error(`download failed: ${url} ${response.status}`);
   }
@@ -102,6 +122,7 @@ async function runValidator({ manifestPath, outputRoot, requireProduction }) {
   return {
     command: `${process.execPath} ${args.join(" ")}`,
     exitCode: result.exitCode,
+    signal: result.signal,
     stdout: result.stdout,
     stderr: result.stderr,
   };
@@ -115,9 +136,10 @@ function spawnResult(command, args) {
     child.stdout.on("data", (chunk) => stdout.push(chunk));
     child.stderr.on("data", (chunk) => stderr.push(chunk));
     child.on("error", reject);
-    child.on("close", (exitCode) => {
+    child.on("close", (exitCode, signal) => {
       resolve({
         exitCode,
+        signal,
         stdout: Buffer.concat(stdout).toString("utf8"),
         stderr: Buffer.concat(stderr).toString("utf8"),
       });


### PR DESCRIPTION
## 관련 이슈

Refs #1393

## 작업 배경

- #1393의 실제 배포 artifact 검증은 레포 source input만으로는 완료할 수 없습니다.
- production manifest URL에서 `current.json`과 pack을 내려받고 기존 validator로 재검증하는 재현 가능한 wrapper가 필요합니다.
- 현재 원격 object storage artifact는 최신 validator 기준 실패하므로 #1393과 parent #1419는 닫지 않습니다.

## 작업 내용

- 원격 production manifest URL을 받아 `current.json`과 pack을 내려받는 datapack 검증 wrapper를 추가했습니다.
- 다운로드한 artifact를 기존 `tools/datapack/validate-datapack.mjs`로 검증하고 summary JSON을 남기도록 했습니다.
- #1393 실제 배포 artifact 검증을 재실행 가능한 명령으로 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/datapack-tools.test.mjs` 통과
  - `node --test --test-name-pattern "운영 데이터팩 공식 출처 inventory|데이터팩 freshness SLA|production 데이터팩" tools/ci/repository-contract.test.mjs` 통과
  - `git diff --check origin/main...HEAD` 통과
  - 원격 object storage `current.json` 다운로드 성공
  - wrapper 원격 검증은 현재 production artifact의 최신 validator 실패를 재현함
  - GitHub Actions #1546 checks 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| datapack tools | repo | Node test | `node --test tools/datapack/datapack-tools.test.mjs` | 통과 |
| repository contract | repo | Node test | `node --test --test-name-pattern "운영 데이터팩 공식 출처 inventory|데이터팩 freshness SLA|production 데이터팩" tools/ci/repository-contract.test.mjs` | 통과 |
| whitespace | repo | diff check | `git diff --check origin/main...HEAD` | 통과 |
| remote artifact | object storage | wrapper download + validator | manifestVersion=2, channel=production, releaseSequence=114 | 최신 validator 실패 재현 |
| GitHub Actions | PR | `gh pr checks 1546 --repo AquilaXk/easysubway` | Android CI, Mobile App CI, Repository CI, Release Artifacts, SonarCloud, CodeRabbit | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/validate-remote-datapack-artifact.mjs`
- 현재 원격 artifact 실패: `capital@1 regionalQualityMetrics.requiredFacilityEvidenceCoverageRatio must be a ratio`
- 이 PR은 #1393 완료 PR이 아니라, #1393 검증을 재현 가능하게 만드는 부분 진행 PR입니다.

## 리스크

- 검증 wrapper/test 추가라 런타임 앱/서버 영향은 없습니다.
- 원격 production artifact 재게시와 Android installer 증거는 별도 후속 범위로 남습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 가능했고 PR Review 객체가 있어 Codex CLI fallback은 게시하지 않았다.
- [x] 배포 영향 없음. Release Artifacts PR checks 통과를 확인했다.
