### PR TITLE
[Mobile] route ETA source label contract 보강

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -97,6 +97,7 @@ const routeEtaSourceLabels = <String, String>{
   'REALTIME': '실시간 도착정보 준비 중',
   'MIXED': '일부 도착정보를 확인하고 있어요',
   'PLANNED': '시간표 기준',
+  'STATIC_BACKEND_ESTIMATE': '시간표 기준',
   'STATIC_BACKEND_V1': '시간표 기준',
   'STATIC_LOCAL': '저장된 데이터 기준',
   'STATIC_ESTIMATE': '정적 추정',

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -639,6 +639,7 @@ void main() {
       'REALTIME',
       'MIXED',
       'PLANNED',
+      'STATIC_BACKEND_ESTIMATE',
       'STATIC_BACKEND_V1',
       'STATIC_LOCAL',
       'STATIC_ESTIMATE',
@@ -648,6 +649,7 @@ void main() {
     });
     expect(routeEtaSourceLabel('REALTIME'), '실시간 도착정보 준비 중');
     expect(routeEtaSourceLabel('MIXED'), '일부 도착정보를 확인하고 있어요');
+    expect(routeEtaSourceLabel('STATIC_BACKEND_ESTIMATE'), '시간표 기준');
     expect(routeEtaSourceLabel('STATIC_ESTIMATE'), '정적 추정');
     expect(routeEtaSourceLabel('UNSUPPORTED'), '실시간 미지원');
     expect(routeEtaSourceLabel('STALE'), '저장된 데이터 기준 · 갱신 필요');


### PR DESCRIPTION
## 관련 이슈

Refs #1414
Refs #1544

## 작업 배경

- #1544 사후 Codex fallback review에서 backend 신규 ETA source enum이 mobile label 계약에 반영되지 않은 점이 확인됐습니다.
- `STATIC_BACKEND_ESTIMATE`가 mobile에서 미인식 값으로 떨어지면 교통약자 경로 안내 화면이 일반 fallback 문구를 표시할 수 있습니다.

## 작업 내용

- mobile ETA source label map에 `STATIC_BACKEND_ESTIMATE`를 추가했습니다.
- ETA source label 테스트가 backend 신규 enum을 allowlist에서 검증하도록 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/route_search.dart apps/mobile/test/route_search_test.dart`: 통과
  - `git diff --check`: 통과
  - `flutter test test/route_search_test.dart --plain-name "ETA source 라벨은 상용 claim 전에 무음 또는 실시간 claim으로 떨어지지 않는다"`: 통과
  - PR CI: 통과
  - Codex CLI fallback review: actionable 0건

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| ETA source label contract | mobile | targeted Flutter test | 로컬 명령 출력 | 통과 |
| PR CI | GitHub Actions | `gh pr checks 1548 --watch --interval 20` | https://github.com/AquilaXk/easysubway/pull/1548/checks | 통과 |
| Codex fallback review | GitHub PR review | CodeRabbit rate limit 후 단일 PR review 게시 | https://github.com/AquilaXk/easysubway/pull/1548#pullrequestreview-4617736449 | actionable 0건 |
| UI/접근성 수동 QA | mobile | label map 단위 변경으로 화면 구조/터치/권한 변경 없음 | 불필요: 표시 문자열 매핑만 추가 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: backend enum 표시 계약 보강, API schema 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/route_search.dart`의 `STATIC_BACKEND_ESTIMATE` label 추가
  - `apps/mobile/test/route_search_test.dart`의 allowlist 검증

## 리스크

- 낮음. backend가 이미 반환하는 enum의 mobile 표시 매핑만 추가합니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
