### PR TITLE
[Test] route V2 planner 복수 itinerary 계약 보강

### DIFF
--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -693,6 +693,21 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 alternativeCount 범위 안에서 복수 itinerary와 실제 상태를 반환한다")
+	void routeV2PlannerReturnsAlternativeItinerariesWithActualStatuses() {
+		var planner = routeV2Planner(new MixedTransferAccessibilityTransitMasterPort());
+
+		var plan = planner.search(routeV2Command(ConstraintMode.STRICT_STEP_FREE, MobilityType.WHEELCHAIR, 1, 2));
+
+		assertThat(plan.plannerAdr()).isEqualTo("tools/routes/route-algorithm-v2-adr.json");
+		assertThat(plan.itineraries()).hasSize(2);
+		assertThat(plan.statuses()).containsExactly("FOUND", "BLOCKED_ACCESSIBILITY");
+		assertThat(plan.itineraries())
+			.extracting(RouteSearchResult::status)
+			.containsExactly(RouteSearchStatus.FOUND, RouteSearchStatus.BLOCKED);
+	}
+
+	@Test
 	@DisplayName("V2 planner는 1회 환승 경로를 FOUND itinerary로 반환한다")
 	void routeV2PlannerReturnsOneTransferItinerary() {
 		var planner = routeV2Planner(new OneTransferTransitMasterPort());


### PR DESCRIPTION
## 관련 이슈

Refs #1402
Refs #1414

## 작업 배경

- #1402는 V2 planner가 `alternativeCount` 범위 안에서 복수 itinerary와 실제 판정 상태를 반환하는 증거를 요구합니다.
- #1545에서 단건 wrapper 제거는 끝났지만, planner 단위 테스트에 복수 itinerary 계약을 직접 잠그는 검증이 부족했습니다.

## 작업 내용

- `RouteV2Planner` 단위 성격의 기존 service test에 `alternativeCount=2` 복수 itinerary 계약 테스트를 추가했습니다.
- 같은 테스트에서 ADR 연결 경로와 `FOUND`/`BLOCKED_ACCESSIBILITY` 상태 노출을 함께 확인합니다.

## 검증

- 실행한 명령과 결과:
  - `git diff --check`: 통과
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest`: 통과
  - `./gradlew check --no-daemon`: 통과
- PR CI:
  - CI run `28596379634`: 통과
  - Release Artifacts run `28596088751`: 통과
  - SonarCloud run `28596088645`: 통과
- Code review:
  - CodeRabbit: actionable 0, GitHub PR Review 객체 없음
  - Codex fallback review: `pullrequestreview-4618270792`, actionable 0

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| V2 planner 복수 itinerary contract | backend | Gradle targeted test | 로컬 명령 출력 | 통과 |
| backend 전체 check | backend | Gradle check + PR Backend CI | run `28596379634` | 통과 |
| release artifact 영향 | backend | PR Release Artifacts | run `28596088751` | 통과 |
| UI/접근성 수동 QA | Android | backend test-only 변경 | 불필요 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: V2 planner 복수 itinerary test evidence 보강
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteV2Planner` 테스트가 `alternativeCount=2`에서 복수 itinerary와 실제 상태를 검증하는지

## 리스크

- 낮음. test-only 변경입니다.
- #1402 전체 완료 조건 중 production contract report 연결은 후속으로 남습니다.

## 체크리스트

- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] CodeRabbit 실행이 불가능한 경우 Codex CLI code review 결과를 확인했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
