### PR TITLE
[Test] route V2 contract gate 대안 itinerary 기준 상향

### DIFF
--- a/apps/mobile/release/route-commercialization-gate.json
+++ b/apps/mobile/release/route-commercialization-gate.json
@@ -33,7 +33,7 @@
   "routing": {
     "multiTransferSupported": false,
     "outOfStationTransferSupported": false,
-    "alternativeItinerariesMin": 1
+    "alternativeItinerariesMin": 2
   },
   "etaSourceIntegrity": {
     "realtimeEtaWithoutFreshProviderAllowed": false,

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -103,7 +103,7 @@ test("route commercialization release gate blocks unsupported commercial route c
   assert.equal(gate.accessibility.unknownAccessibilityMustBeLabeled, true);
   assert.equal(gate.routing.multiTransferSupported, false);
   assert.equal(gate.routing.outOfStationTransferSupported, false);
-  assert.equal(gate.routing.alternativeItinerariesMin, 1);
+  assert.equal(gate.routing.alternativeItinerariesMin, 2);
   assert.equal(gate.etaSourceIntegrity.realtimeEtaWithoutFreshProviderAllowed, false);
   assert.equal(gate.etaSourceIntegrity.staleRealtimeUsedAsFreshAllowed, false);
   assert.equal(gate.etaSourceIntegrity.staticLocalMustBeLabeled, true);

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -51,7 +51,7 @@ test("route commercialization gate passes with production-ready reports", async 
       schemaVersion: 1,
       multiTransferSupported: false,
       outOfStationTransferSupported: false,
-      alternativeItinerariesMinObserved: 1,
+      alternativeItinerariesMinObserved: 2,
       wrongTransferCount: 0,
       wrongLineSequence: 0,
       routeNotFoundRate: 0.01,
@@ -133,6 +133,7 @@ test("route commercialization gate fails closed for fixture-only or unsafe route
       assert.ok(report.failures.includes("realtimeCoverage stale-as-fresh count exceeds 0"));
       assert.ok(report.failures.includes("route graph generated connector verified count exceeds 0"));
       assert.ok(report.failures.includes("route graph strict route not found rate exceeds 0.02"));
+      assert.ok(report.failures.includes("routing alternative itineraries below 2"));
       assert.ok(!report.failures.includes("routing D-3 blocker must be satisfied before out-of-station transfer release claim"));
       return true;
     },
@@ -246,7 +247,7 @@ test("route commercialization gate derives realtime pair minimum from coverage s
       schemaVersion: 1,
       multiTransferSupported: false,
       outOfStationTransferSupported: false,
-      alternativeItinerariesMinObserved: 1,
+      alternativeItinerariesMinObserved: 2,
       wrongTransferCount: 0,
       wrongLineSequence: 0,
       routeNotFoundRate: 0.01,
@@ -304,7 +305,7 @@ test("route commercialization gate fails on unclassified ETA deviations", async 
       schemaVersion: 1,
       multiTransferSupported: false,
       outOfStationTransferSupported: false,
-      alternativeItinerariesMinObserved: 1,
+      alternativeItinerariesMinObserved: 2,
       wrongTransferCount: 0,
       wrongLineSequence: 0,
       routeNotFoundRate: 0.01,


### PR DESCRIPTION
## 관련 이슈

Refs #1402
Refs #1414

## 작업 배경

- #1402는 route V2 contract report에서 `alternativeItinerariesMinObserved >= 2` 증거를 요구합니다.
- V2 planner와 report builder는 복수 itinerary를 산출·집계할 수 있지만, release gate 기준은 아직 `alternativeItinerariesMin: 1`이라 #1402 완료 조건을 차단하지 못했습니다.

## 작업 내용

- `route-commercialization-gate.json`의 V2 alternative itinerary 최소 기준을 2로 상향했습니다.
- repository contract test가 gate 기준 2를 고정하도록 갱신했습니다.
- route commercialization checker test가 1개 itinerary report를 실패로 보고, 2개 itinerary report만 통과하도록 fixture를 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/routes/check-route-commercialization-gate.test.mjs`: 통과
  - `node --test tools/ci/repository-contract.test.mjs`: 통과
  - `node --test tools/routes/*.test.mjs`: 통과
  - `git diff --check`: 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| route V2 contract gate 기준 | release tooling | route checker + repository contract test | 로컬 명령 출력 | 통과 |
| route tooling regression | route tooling | `node --test tools/routes/*.test.mjs` | 로컬 명령 출력 | 통과 |
| UI/접근성 수동 QA | Android | release gate/test-only 변경 | 불필요 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [x] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: route V2 alternative itinerary gate 최소 기준 2로 상향
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `route-commercialization-gate.json`의 `routing.alternativeItinerariesMin`
  - 1개 itinerary report를 실패로 고정한 checker regression

## 리스크

- 낮음. release gate/test-only 기준 상향입니다.
- 실제 production evidence report가 2개 미만 itinerary를 기록하면 gate가 의도대로 실패합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
