### PR TITLE
[Test] route V2 시간축 fixture 회귀 명시화

### DIFF
--- a/tools/routes/prototype-route-v2.test.mjs
+++ b/tools/routes/prototype-route-v2.test.mjs
@@ -36,6 +36,23 @@ test("route v2 prototypes honor requested alternative count", () => {
   assert.equal(alternatives[0].arrival, "09:25");
 });
 
+test("route v2 time-axis fixtures reject unboardable realtime arrivals", () => {
+  const query = fixtureQuery("provider_realtime_fresh_but_not_boardable_due_to_entry_slack");
+
+  assert.equal(runRangeRaptor(fixtures, query)[0] ?? null, null);
+  assert.equal(runTimeDependentDijkstra(fixtures, query)[0] ?? null, null);
+});
+
+test("route v2 time-axis fixtures keep transfer feasibility and stale realtime fallback explicit", () => {
+  const transfer = fixtureQuery("transfer_buffer_too_short_selects_next_train");
+  const staleRealtime = fixtureQuery("provider_realtime_stale");
+  const unmatchedRealtime = fixtureQuery("unmatched_realtime_express_does_not_override_planned_local");
+
+  assert.deepEqual(runTimeDependentDijkstra(fixtures, transfer)[0].tripIds, ["l4-express-0903", "l2-local-0945"]);
+  assert.deepEqual(runTimeDependentDijkstra(fixtures, staleRealtime)[0].path.map((step) => step.realtimeMatchLevel), ["MATCHED_REALTIME"]);
+  assert.deepEqual(runTimeDependentDijkstra(fixtures, unmatchedRealtime)[0].path.map((step) => step.realtimeMatchLevel), ["PLANNED"]);
+});
+
 test("route v2 CLI report keeps full Pareto alternatives", () => {
   const result = runAll(fixtures).results.find((candidate) => candidate.queryId === "pareto_arrival_vs_transfer");
 
@@ -74,6 +91,12 @@ function assertPrototype(query, result, name) {
   assertExpected(query, "expectedDestinationStationIds", rideSteps.map((step) => step.destinationStationId), name);
   assertExpected(query, "expectedStopPatterns", rideSteps.map((step) => step.stopPattern), name);
   assertExpected(query, "expectedRealtimeMatchLevels", rideSteps.map((step) => step.realtimeMatchLevel), name);
+}
+
+function fixtureQuery(id) {
+  const query = fixtures.queries.find((candidate) => candidate.id === id);
+  assert.ok(query, `missing fixture query: ${id}`);
+  return query;
 }
 
 function assertExpected(query, field, actual, name) {


### PR DESCRIPTION
## 관련 이슈

Refs #1403
Refs #1414

## 작업 배경

- #1403은 route V2 시간축 regression fixture가 CI 계약으로 명확히 드러나야 한다고 요구합니다.
- 기존 fixture loop가 시간축 케이스를 검증하고 있었지만, entry slack, transfer feasibility, stale/unmatched realtime fallback을 이름 있는 테스트로 직접 고정하지는 않았습니다.

## 작업 내용

- `provider_realtime_fresh_but_not_boardable_due_to_entry_slack` fixture가 두 prototype 알고리즘에서 모두 boardable itinerary를 만들지 않는지 명시 테스트를 추가했습니다.
- `transfer_buffer_too_short_selects_next_train`, `provider_realtime_stale`, `unmatched_realtime_express_does_not_override_planned_local` fixture가 시간축·realtime source 회귀를 드러내도록 named assertion을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/routes/*.test.mjs`: 통과
  - `git diff --check`: 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| route V2 시간축 fixture regression | route tooling | `node --test tools/routes/*.test.mjs` | 로컬 명령 출력 | 통과 |
| UI/접근성 수동 QA | Android | test-only tooling 변경 | 불필요 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: route V2 시간축 fixture regression 명시화
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - named tests가 기존 fixture를 중복 생성하지 않고 #1403 핵심 시간축 케이스를 직접 가리키는지

## 리스크

- 낮음. route prototype test-only 변경입니다.
- backend V2 planner unit 연결은 #1403 후속 PR로 남습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
