### PR TITLE
[Test] route V2 realtime readyAt 계약 보강

### DIFF
--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -781,6 +781,7 @@ class RouteSearchServiceTest {
 
 		assertThat(resolver.callCount()).isEqualTo(1);
 		assertThat(resolver.lastQuery().stationId()).isEqualTo("station-a");
+		assertThat(resolver.lastQuery().readyAt()).isEqualTo(Instant.parse("2026-07-01T00:04:00Z"));
 		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.MIXED);
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))


### PR DESCRIPTION
## 관련 이슈

Refs #1403
Refs #1414

## 작업 배경

- #1403은 route V2 시간축 regression을 backend V2 planner 테스트에도 연결해야 합니다.
- 기존 test는 realtime provider 호출 여부만 확인했고, `departureTime`에 entry access 시간이 반영된 provider 조회 시각은 직접 고정하지 않았습니다.

## 작업 내용

- V2 planner realtime test에서 provider `readyAt`이 `departureTime + entry access 4분`인지 검증했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest`: 통과
  - `git diff --check`: 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| backend V2 planner readyAt contract | backend | targeted Gradle test | 로컬 명령 출력 | 통과 |
| UI/접근성 수동 QA | Android | backend test-only 변경 | 불필요 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: backend V2 planner readyAt 시간축 test 보강
- realtime contract: provider 조회 시각 산정 test 보강
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteSearchServiceTest`의 `readyAt` assertion이 departure time과 entry access time을 함께 고정하는지

## 리스크

- 낮음. backend test-only 변경입니다.
- 더 큰 boardable trip fixture는 #1403 후속으로 남습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
