### PR TITLE
[Test] route direct 후보 ranking 회귀 보강

### DIFF
--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -595,6 +595,39 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("직접 경로가 있어도 더 낮은 비용의 환승 후보를 우선한다")
+	void directRouteDoesNotShortCircuitLowerCostTransferCandidate() {
+		var repository = new InMemoryRouteSearchRepository();
+		var transferService = new RouteSearchService(
+			repository,
+			repository,
+			new DirectAndShorterTransferTransitMasterPort(),
+			CLOCK
+		);
+
+		var results = transferService.searchRouteAlternatives(new SearchRouteCommand(
+			"station-a",
+			"station-b",
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			1
+		), 2);
+
+		assertThat(results).hasSize(2);
+		assertThat(results)
+			.extracting(RouteSearchResult::status)
+			.containsExactly(RouteSearchStatus.FOUND, RouteSearchStatus.FOUND);
+		assertThat(results)
+			.extracting(RouteSearchResult::transferCount)
+			.containsExactly(1, 0);
+		assertThat(results.get(0).steps())
+			.filteredOn(step -> "transfer".equals(step.stepType()))
+			.extracting("fromStationId")
+			.containsExactly("station-transfer");
+		assertThat(results.get(1).lineName()).isEqualTo("테스트 직통");
+	}
+
+	@Test
 	@DisplayName("휠체어 이동 유형은 환승역이 계단 전용이면 경로를 차단한다")
 	void wheelchairRouteBlocksStairOnlyTransferStation() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -1945,6 +1978,30 @@ class RouteSearchServiceTest {
 			return List.of(
 				facility("facility-a-elevator", "station-a", "exit-a-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL),
 				facility("facility-b-elevator", "station-b", "exit-b-1", AccessibilityFacilityType.ELEVATOR, AccessibilityFacilityStatus.NORMAL)
+			);
+		}
+	}
+
+	private static class DirectAndShorterTransferTransitMasterPort extends OneTransferTransitMasterPort {
+
+		@Override
+		public List<SubwayLine> loadLines() {
+			return List.of(
+				new SubwayLine("line-a", "operator-a", "A 노선", "#0052A4", "수도권", null, true),
+				new SubwayLine("line-b", "operator-a", "B 노선", "#00A84D", "수도권", null, true),
+				new SubwayLine("line-direct", "operator-a", "테스트 직통", "#F5A200", "수도권", null, true)
+			);
+		}
+
+		@Override
+		public List<StationLine> loadStationLines() {
+			return List.of(
+				new StationLine("station-a", "line-a", "101", 1, "상행 / 하행"),
+				new StationLine("station-transfer", "line-a", "103", 3, "상행 / 하행"),
+				new StationLine("station-transfer", "line-b", "201", 1, "상행 / 하행"),
+				new StationLine("station-b", "line-b", "203", 3, "상행 / 하행"),
+				new StationLine("station-a", "line-direct", "101", 1, "상행 / 하행"),
+				new StationLine("station-b", "line-direct", "150", 50, "상행 / 하행")
 			);
 		}
 	}


### PR DESCRIPTION
## 관련 이슈

close #1405

## 작업 배경

- #1414 release readiness 하위 이슈인 #1405의 direct route short-circuit 재발을 막기 위한 테스트 보강입니다.
- 현재 구현은 direct, one-transfer, multi-transfer 후보를 함께 ranking하지만, 직통 후보가 존재할 때 더 낮은 비용의 환승 후보가 우선되는지를 직접 검증하는 회귀 테스트가 부족했습니다.

## 작업 내용

- `RouteSearchServiceTest`에 직통 후보와 더 짧은 1회 환승 후보가 동시에 존재하는 fixture를 추가했습니다.
- `searchRouteAlternatives(..., 2)` 결과가 환승 후보를 먼저 반환하고 직통 후보를 두 번째로 유지하는지 검증했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` PASS
  - `git -C /private/tmp/easysubway-1402 diff --check` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| RouteSearchService direct/transfer ranking 회귀 | backend | Gradle 단위 테스트 | `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` | PASS |
| whitespace/check | repo | diff check | `git -C /private/tmp/easysubway-1402 diff --check` | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: direct/transfer 후보 ranking 회귀 테스트 보강
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteSearchServiceTest.directRouteDoesNotShortCircuitLowerCostTransferCandidate`
  - `DirectAndShorterTransferTransitMasterPort`

## 리스크

- 테스트 전용 변경이라 runtime 동작 변경은 없습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 대안 경로 검색 동작을 검증하는 테스트가 추가되었습니다.
  * 직통 경로가 있어도 더 낮은 비용의 환승 경로가 먼저 선택되는지 확인합니다.
  * 검색 결과가 올바른 상태로 반환되고, 환승 구간의 출발 역이 정확히 선택되는지 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->