### PR TITLE
[Test] route ETA source gate 분리 검증

### DIFF
--- a/tools/routes/check-route-commercialization-gate.mjs
+++ b/tools/routes/check-route-commercialization-gate.mjs
@@ -90,6 +90,7 @@ function validateGate(gate) {
 function validateAccuracy(gate, report, failures) {
   if (report.schemaVersion !== 1) failures.push("route accuracy report schemaVersion must be 1");
   if (Array.isArray(report.failures) && report.failures.length > 0) failures.push("route accuracy report contains failures");
+  validateEtaSourceCounts(gate, report, failures);
 
   const sampleSizeMin = gate.routeEtaAccuracy.sampleSizeMin;
   const sources = report.sampleSourceCounts ?? {};
@@ -111,6 +112,20 @@ function validateAccuracy(gate, report, failures) {
   max(transfer.p90ErrorSeconds, gate.routeEtaAccuracy.transferP90ErrorSecondsMax, "transfer P90 ETA error", failures);
   if (number(report.metrics?.unclassifiedEtaDeviationCount) > 0) {
     failures.push("routeEtaAccuracy unclassified ETA deviation count exceeds 0");
+  }
+}
+
+function validateEtaSourceCounts(gate, report, failures) {
+  if (!gate.etaSourceIntegrity) return;
+  const counts = report.actualEtaSourceCounts;
+  if (!counts || typeof counts !== "object") {
+    failures.push("routeEtaAccuracy actual ETA source counts must be reported");
+    return;
+  }
+  for (const source of ["REALTIME", "PLANNED", "STATIC_BACKEND_ESTIMATE", "STATIC_LOCAL", "FALLBACK"]) {
+    if (!Number.isFinite(Number(counts[source]))) {
+      failures.push(`routeEtaAccuracy actual ETA source count missing: ${source}`);
+    }
   }
 }
 

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -324,6 +324,135 @@ test("route commercialization gate fails on unclassified ETA deviations", async 
   );
 });
 
+test("route commercialization gate requires explicit ETA source buckets", async () => {
+  const fixture = await writeFixtureSet({
+    accuracy: {
+      schemaVersion: 1,
+      sampleSize: 120,
+      sampleSourceCounts: {
+        fixture: 0,
+        staticTimetable: 0,
+        realtimeProvider: 120,
+        manualObservation: 120,
+        staleRealtime: 0,
+      },
+      actualEtaSourceCounts: null,
+      productionSampleSize: 120,
+      metrics: {
+        singleRide: { sampleSize: 60, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
+        transfer: { sampleSize: 60, p50ErrorSeconds: 90, p90ErrorSeconds: 240 },
+      },
+      failures: [],
+    },
+    accessibility: {
+      schemaVersion: 1,
+      strictStepFreeKnownStairFalsePositiveCount: 0,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      unknownAccessibilityLabeled: true,
+    },
+    coverage: {
+      schemaVersion: 1,
+      supportedStationLinePairs: 150,
+      providerFreshnessSecondsMaxObserved: 80,
+      staleFallbackRequired: true,
+      freshness: { staleAsFreshCount: 0 },
+      mapping: { failureRate: 0 },
+    },
+    routeGraphCoverage: {
+      schemaVersion: 1,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      strictRouteNotFound: { total: 100, notFoundCount: 1, rate: 0.01, byReasonCode: {} },
+    },
+    contract: {
+      schemaVersion: 1,
+      multiTransferSupported: false,
+      outOfStationTransferSupported: false,
+      alternativeItinerariesMinObserved: 2,
+      wrongTransferCount: 0,
+      wrongLineSequence: 0,
+      routeNotFoundRate: 0.01,
+      releaseBlockersSatisfied: ["D-2", "D-3", "H-1"],
+    },
+  });
+
+  await assert.rejects(
+    execChecker(fixture),
+    (error) => {
+      const report = JSON.parse(error.stdout);
+      assert.equal(report.status, "FAIL");
+      assert.ok(report.failures.includes("routeEtaAccuracy actual ETA source counts must be reported"));
+      return true;
+    },
+  );
+});
+
+test("route commercialization gate requires static, planned, realtime, and fallback source labels", async () => {
+  const fixture = await writeFixtureSet({
+    accuracy: {
+      schemaVersion: 1,
+      sampleSize: 120,
+      sampleSourceCounts: {
+        fixture: 0,
+        staticTimetable: 0,
+        realtimeProvider: 120,
+        manualObservation: 120,
+        staleRealtime: 0,
+      },
+      actualEtaSourceCounts: {
+        REALTIME: 120,
+        PLANNED: 0,
+        STATIC_LOCAL: 0,
+        FALLBACK: 0,
+      },
+      productionSampleSize: 120,
+      metrics: {
+        singleRide: { sampleSize: 60, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
+        transfer: { sampleSize: 60, p50ErrorSeconds: 90, p90ErrorSeconds: 240 },
+      },
+      failures: [],
+    },
+    accessibility: {
+      schemaVersion: 1,
+      strictStepFreeKnownStairFalsePositiveCount: 0,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      unknownAccessibilityLabeled: true,
+    },
+    coverage: {
+      schemaVersion: 1,
+      supportedStationLinePairs: 150,
+      providerFreshnessSecondsMaxObserved: 80,
+      staleFallbackRequired: true,
+      freshness: { staleAsFreshCount: 0 },
+      mapping: { failureRate: 0 },
+    },
+    routeGraphCoverage: {
+      schemaVersion: 1,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      strictRouteNotFound: { total: 100, notFoundCount: 1, rate: 0.01, byReasonCode: {} },
+    },
+    contract: {
+      schemaVersion: 1,
+      multiTransferSupported: false,
+      outOfStationTransferSupported: false,
+      alternativeItinerariesMinObserved: 2,
+      wrongTransferCount: 0,
+      wrongLineSequence: 0,
+      routeNotFoundRate: 0.01,
+      releaseBlockersSatisfied: ["D-2", "D-3", "H-1"],
+    },
+  });
+
+  await assert.rejects(
+    execChecker(fixture),
+    (error) => {
+      const report = JSON.parse(error.stdout);
+      assert.equal(report.status, "FAIL");
+      assert.ok(report.failures.includes("routeEtaAccuracy actual ETA source count missing: STATIC_BACKEND_ESTIMATE"));
+      return true;
+    },
+  );
+});
+
 test("route commercialization gate sorts checked reports with an explicit comparator", async () => {
   const source = await readFile("tools/routes/check-route-commercialization-gate.mjs", "utf8");
 
@@ -340,8 +469,26 @@ async function writeFixtureSet(reports) {
     routeGraphCoverage: path.join(dir, "route-graph-coverage-report.json"),
     contract: path.join(dir, "route-v2-contract-report.json"),
   };
-  await Promise.all(Object.entries(reports).map(([key, report]) => writeFile(files[key], `${JSON.stringify(report, null, 2)}\n`)));
+  const normalizedReports = {
+    ...reports,
+    accuracy: normalizeAccuracyReport(reports.accuracy),
+  };
+  await Promise.all(Object.entries(normalizedReports).map(([key, report]) => writeFile(files[key], `${JSON.stringify(report, null, 2)}\n`)));
   return files;
+}
+
+function normalizeAccuracyReport(report) {
+  if (Object.hasOwn(report, "actualEtaSourceCounts")) return report;
+  return {
+    ...report,
+    actualEtaSourceCounts: {
+      REALTIME: 0,
+      PLANNED: 0,
+      STATIC_BACKEND_ESTIMATE: 0,
+      STATIC_LOCAL: 0,
+      FALLBACK: 0,
+    },
+  };
 }
 
 function execChecker(files) {

--- a/tools/routes/evaluate-eta-accuracy.mjs
+++ b/tools/routes/evaluate-eta-accuracy.mjs
@@ -177,6 +177,8 @@ function buildReport(rows) {
     sampleSize: rows.length,
     sampleSourceCounts: countSampleSources(rows),
     referenceSourceCounts: countReferenceSources(rows),
+    actualEtaSourceCounts: countEtaSources(rows, "actual_eta_source"),
+    expectedEtaSourceCounts: countEtaSources(rows, "expected_eta_source"),
     productionSampleSize: rows.filter(isProductionSample).length,
     nonProductionSampleSize: rows.filter((row) => !isProductionSample(row)).length,
     coverage,
@@ -229,6 +231,20 @@ function countReferenceSources(rows) {
   const counts = Object.fromEntries(referenceSources.map((source) => [source, 0]));
   for (const row of rows) {
     counts[referenceSource(row)] += 1;
+  }
+  return counts;
+}
+
+function countEtaSources(rows, key) {
+  const counts = {
+    REALTIME: 0,
+    PLANNED: 0,
+    STATIC_BACKEND_ESTIMATE: 0,
+    STATIC_LOCAL: 0,
+    FALLBACK: 0,
+  };
+  for (const row of rows) {
+    if (Object.hasOwn(counts, row[key])) counts[row[key]] += 1;
   }
   return counts;
 }

--- a/tools/routes/evaluate-eta-accuracy.test.mjs
+++ b/tools/routes/evaluate-eta-accuracy.test.mjs
@@ -40,6 +40,10 @@ test("ETA evaluator emits the route accuracy report contract", async (t) => {
     COMPETING_APP_COMPARISON: 0,
     FIXTURE_EXPECTED: 100,
   });
+  for (const source of ["REALTIME", "PLANNED", "STATIC_BACKEND_ESTIMATE", "STATIC_LOCAL", "FALLBACK"]) {
+    assert.equal(typeof report.actualEtaSourceCounts[source], "number");
+    assert.equal(typeof report.expectedEtaSourceCounts[source], "number");
+  }
   assert.equal(report.productionSampleSize, 0);
   assert.equal(report.nonProductionSampleSize, 100);
   assert.equal(report.metrics.sampleSize, 100);
@@ -213,6 +217,20 @@ test("ETA evaluator emits structured production-safe failures", async (t) => {
     MANUAL_OBSERVATION: 2,
     COMPETING_APP_COMPARISON: 1,
     FIXTURE_EXPECTED: 3,
+  });
+  assert.deepEqual(report.actualEtaSourceCounts, {
+    REALTIME: 2,
+    PLANNED: 6,
+    STATIC_BACKEND_ESTIMATE: 0,
+    STATIC_LOCAL: 2,
+    FALLBACK: 0,
+  });
+  assert.deepEqual(report.expectedEtaSourceCounts, {
+    REALTIME: 3,
+    PLANNED: 7,
+    STATIC_BACKEND_ESTIMATE: 0,
+    STATIC_LOCAL: 0,
+    FALLBACK: 0,
   });
   assert.equal(report.productionSampleSize, 5);
   assert.equal(report.nonProductionSampleSize, 5);


### PR DESCRIPTION
## 관련 이슈

close #1401

## 작업 배경

- #1414 release readiness 하위 이슈인 #1401의 ETA source 분리 계약을 gate/report 레벨에서 고정합니다.
- backend/controller는 이미 `ESTIMATED_CONSTANT`를 `STATIC_BACKEND_ESTIMATE`로 내리지만, route commercialization gate 입력 report가 static/planned/realtime/fallback source bucket을 명시적으로 구분하는지는 강제하지 않았습니다.

## 작업 내용

- `evaluate-eta-accuracy.mjs`가 `actualEtaSourceCounts`, `expectedEtaSourceCounts`를 산출하도록 추가했습니다.
- `check-route-commercialization-gate.mjs`가 route accuracy report의 실제 ETA source bucket(`REALTIME`, `PLANNED`, `STATIC_BACKEND_ESTIMATE`, `STATIC_LOCAL`, `FALLBACK`)을 요구하도록 보강했습니다.
- evaluator/gate 테스트에 ETA source bucket 산출과 누락 실패 케이스를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/routes/evaluate-eta-accuracy.test.mjs tools/routes/check-route-commercialization-gate.test.mjs` PASS
  - `node --test tools/routes/*.test.mjs` PASS
  - `git -C /private/tmp/easysubway-1402 diff --check` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| ETA source report/gate 계약 | route tools | Node 테스트 | `node --test tools/routes/evaluate-eta-accuracy.test.mjs tools/routes/check-route-commercialization-gate.test.mjs` | PASS |
| route tools 전체 회귀 | route tools | Node 테스트 | `node --test tools/routes/*.test.mjs` | PASS |
| whitespace/check | repo | diff check | `git -C /private/tmp/easysubway-1402 diff --check` | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [x] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: route accuracy report ETA source bucket 계약 보강
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `tools/routes/evaluate-eta-accuracy.mjs`의 ETA source count 산출
  - `tools/routes/check-route-commercialization-gate.mjs`의 ETA source bucket 검증

## 리스크

- gate 입력 report가 `actualEtaSourceCounts`를 제공하지 않으면 fail-closed 됩니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
