### PR TITLE
[Test] 데이터팩 stale 라벨 증거 고정

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -3491,21 +3491,25 @@ class _FavoriteListScreen extends StatelessWidget {
 }
 
 class OfflineDataScreen extends StatelessWidget {
-  const OfflineDataScreen({super.key});
+  const OfflineDataScreen({super.key, this.expiresAt, this.now});
 
   // ponytail: static v1 QA source; wire live catalog metadata when offline status is dynamic.
   static const _offlineDataSourceOfTruth = 'installed catalog metadata';
 
+  final DateTime? expiresAt;
+  final DateTime Function()? now;
+
   @override
   Widget build(BuildContext context) {
     assert(_offlineDataSourceOfTruth == 'installed catalog metadata');
+    final storedDataStatus = _storedDataStatus(expiresAt: expiresAt, now: now);
     return Scaffold(
       appBar: AppBar(title: const Text('인터넷 없이 이용')),
       body: SafeArea(
         child: ListView(
           padding: _mainPagePadding,
-          children: const [
-            _AppCard(
+          children: [
+            const _AppCard(
               showBorder: true,
               child: _AppInfoRow(
                 icon: Icons.check_circle_outline,
@@ -3514,11 +3518,11 @@ class OfflineDataScreen extends StatelessWidget {
                 subtitle: '마지막으로 받은 노선도와 역 정보를 보여줍니다.',
               ),
             ),
-            _AppSectionTitle(title: '저장된 안내 상태'),
+            const _AppSectionTitle(title: '저장된 안내 상태'),
             _AppCard(
               child: Column(
                 children: [
-                  _AppInfoRow(
+                  const _AppInfoRow(
                     icon: Icons.public,
                     iconColor: EasySubwayAccessibleColors.mintDark,
                     title: '검증 구간',
@@ -3529,24 +3533,24 @@ class OfflineDataScreen extends StatelessWidget {
                     icon: Icons.update,
                     iconColor: EasySubwayAccessibleColors.brand,
                     title: '마지막 갱신',
-                    subtitle: '앱 설치 때 함께 받은 안내',
-                    trailing: '저장됨',
+                    subtitle: storedDataStatus.subtitle,
+                    trailing: storedDataStatus.trailing,
                   ),
-                  _AppInfoRow(
+                  const _AppInfoRow(
                     icon: Icons.manage_search_outlined,
                     iconColor: EasySubwayAccessibleColors.amber,
                     title: '저장 정보 다시 확인',
                     subtitle: '저장 정보 기록을 확인할 수 없으면 현장 안내를 우선 확인해 주세요',
                     trailing: '확인',
                   ),
-                  _AppInfoRow(
+                  const _AppInfoRow(
                     icon: Icons.verified_outlined,
                     iconColor: EasySubwayAccessibleColors.brand,
                     title: '안내 범위',
                     subtitle: ProductionScopeCopy.supportedClaimKo,
                     trailing: '일부',
                   ),
-                  _AppInfoRow(
+                  const _AppInfoRow(
                     icon: Icons.info_outline,
                     iconColor: EasySubwayAccessibleColors.amber,
                     title: '제한 사항',
@@ -3556,8 +3560,8 @@ class OfflineDataScreen extends StatelessWidget {
                 ],
               ),
             ),
-            _AppSectionTitle(title: '이용 가능'),
-            _AppCard(
+            const _AppSectionTitle(title: '이용 가능'),
+            const _AppCard(
               child: Column(
                 children: [
                   _AppInfoRow(
@@ -3584,8 +3588,8 @@ class OfflineDataScreen extends StatelessWidget {
                 ],
               ),
             ),
-            _AppSectionTitle(title: '인터넷 연결 필요'),
-            _AppCard(
+            const _AppSectionTitle(title: '인터넷 연결 필요'),
+            const _AppCard(
               child: Column(
                 children: [
                   _AppInfoRow(
@@ -3610,6 +3614,18 @@ class OfflineDataScreen extends StatelessWidget {
       ),
     );
   }
+}
+
+({String subtitle, String trailing}) _storedDataStatus({
+  DateTime? expiresAt,
+  DateTime Function()? now,
+}) {
+  final expiry = expiresAt;
+  final current = (now ?? DateTime.now)().toUtc();
+  if (expiry != null && !current.isBefore(expiry.toUtc())) {
+    return (subtitle: '저장된 데이터 기준 · 갱신 필요', trailing: '갱신 필요');
+  }
+  return (subtitle: '앱 설치 때 함께 받은 안내', trailing: '저장됨');
 }
 
 class SupportAccessScreen extends StatelessWidget {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3829,6 +3829,21 @@ void main() {
     expect(find.text('실시간 시설 상태와 제보 전송은 인터넷 연결이 필요해요'), findsOneWidget);
   });
 
+  testWidgets('오프라인 데이터 안내는 만료된 저장 정보를 갱신 필요로 보여준다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OfflineDataScreen(
+          expiresAt: DateTime.utc(2026, 6, 25, 12),
+          now: () => DateTime.utc(2026, 6, 25, 12, 1),
+        ),
+      ),
+    );
+
+    expect(find.text('마지막 갱신'), findsOneWidget);
+    expect(find.text('저장된 데이터 기준 · 갱신 필요'), findsOneWidget);
+    expect(find.text('갱신 필요'), findsOneWidget);
+  });
+
   testWidgets('데이터 및 지도 출처 화면은 manifest와 source inventory를 보여준다', (
     tester,
   ) async {


### PR DESCRIPTION
## 관련 이슈

Refs #1418

## 작업 배경

- #1418의 남은 Android stale label evidence 중, 만료된 저장 데이터가 화면에서 `갱신 필요`로 보이는 최소 UI 계약을 고정합니다.
- 실제 schedule event 실행, 알림 evidence, production freshness cycle은 이 PR 범위가 아니므로 #1418은 닫지 않습니다.

## 작업 내용

- `OfflineDataScreen`에 만료 시각 기준 저장 데이터 상태 표시를 추가했습니다.
- 만료된 pack 상태에서 `저장된 데이터 기준 · 갱신 필요`와 `갱신 필요`가 렌더링되는 widget test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `dart format --set-exit-if-changed apps/mobile/lib/main.dart apps/mobile/test/widget_test.dart` 통과
  - `flutter test test/widget_test.dart --name "오프라인 데이터 안내는 만료된 저장 정보를 갱신 필요로 보여준다"` 통과
  - `flutter test test/widget_test.dart --name "오프라인 데이터 안내는 저장 범위와 품질 제한을 보여준다"` 통과
  - `git diff --check` 통과
  - 최신 main rebase 후 위 format/widget test 2건/`git diff --check` 재통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 만료된 저장 데이터 stale 라벨 | Android/Flutter widget | `flutter test test/widget_test.dart --name "오프라인 데이터 안내는 만료된 저장 정보를 갱신 필요로 보여준다"` | widget tree에서 `저장된 데이터 기준 · 갱신 필요`, `갱신 필요` 확인 | 통과 |
| 기존 오프라인 데이터 안내 회귀 | Android/Flutter widget | `flutter test test/widget_test.dart --name "오프라인 데이터 안내는 저장 범위와 품질 제한을 보여준다"` | 기존 저장 범위/제한 문구 유지 확인 | 통과 |
| PR CI | GitHub Actions | PR #1556 checks, head `9b3eefd56e7039d989b94397f9f34d172c78df65` | CI run `28609159760`, Release Artifacts run `28609159402`, SonarCloud Code Analysis | 통과 |
| PR review | GitHub PR Review | CodeRabbit status 확인 후 current-head fallback review 게시 | Review `4619886294`, actionable 0 | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `OfflineDataScreen`의 만료 상태 문구와 `widget_test.dart` 신규 케이스.

## 리스크

- 실제 설치된 data pack cache를 화면에 연결한 작업은 아닙니다. #1418의 Android stale label evidence를 위한 UI 계약 고정만 반영했습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
