### PR TITLE
[Backend] route ETA burden 단위 분리

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -978,23 +978,23 @@ public class RouteSearchService implements RouteSearchUseCase {
 			.filter(edgeFilter)
 			.collect(Collectors.groupingBy(RouteEdge::fromNodeId));
 		PriorityQueue<InternalRouteCandidate> queue = new PriorityQueue<>(
-			Comparator.comparingInt(InternalRouteCandidate::cost)
+			Comparator.comparing(InternalRouteCandidate::cost)
 		);
-		Map<String, Integer> bestCostByNodeId = new HashMap<>();
-		queue.add(new InternalRouteCandidate(fromNodeId, 0, List.of()));
-		bestCostByNodeId.put(fromNodeId, 0);
+		Map<String, InternalRouteCost> bestCostByNodeId = new HashMap<>();
+		queue.add(new InternalRouteCandidate(fromNodeId, InternalRouteCost.ZERO, List.of()));
+		bestCostByNodeId.put(fromNodeId, InternalRouteCost.ZERO);
 
 		while (!queue.isEmpty()) {
 			InternalRouteCandidate current = queue.poll();
-			if (current.cost() > bestCostByNodeId.getOrDefault(current.nodeId(), Integer.MAX_VALUE)) {
+			if (current.cost().compareTo(bestCostByNodeId.getOrDefault(current.nodeId(), InternalRouteCost.MAX)) > 0) {
 				continue;
 			}
 			if (current.nodeId().equals(toNodeId)) {
 				return Optional.of(current.path());
 			}
 			for (RouteEdge edge : edgesByFromNode.getOrDefault(current.nodeId(), List.of())) {
-				int nextCost = current.cost() + internalEdgeCost(edge);
-				if (nextCost >= bestCostByNodeId.getOrDefault(edge.toNodeId(), Integer.MAX_VALUE)) {
+				InternalRouteCost nextCost = current.cost().plus(internalEdgeCost(edge));
+				if (nextCost.compareTo(bestCostByNodeId.getOrDefault(edge.toNodeId(), InternalRouteCost.MAX)) >= 0) {
 					continue;
 				}
 				List<RouteEdge> nextPath = new ArrayList<>(current.path());
@@ -1010,14 +1010,16 @@ public class RouteSearchService implements RouteSearchUseCase {
 		return findInternalRoutePath(edges, fromNodeId, toNodeId, edge -> true).isPresent();
 	}
 
-	private int internalEdgeCost(RouteEdge edge) {
+	private InternalRouteCost internalEdgeCost(RouteEdge edge) {
 		int stairPenalty = edge.hasStairs() ? 120 : 0;
 		int elevatorPenalty = edge.requiresElevator() ? 20 : 0;
 		int escalatorPenalty = edge.requiresEscalator() ? 35 : 0;
 		int slopePenalty = edge.slopeLevel() * 8;
 		int widthPenalty = (6 - edge.widthLevel()) * 4;
-		return edge.distanceMeters() + edge.estimatedSeconds() + stairPenalty + elevatorPenalty + escalatorPenalty
-			+ slopePenalty + widthPenalty;
+		return new InternalRouteCost(
+			edge.estimatedSeconds(),
+			edge.distanceMeters() + stairPenalty + elevatorPenalty + escalatorPenalty + slopePenalty + widthPenalty
+		);
 	}
 
 	private List<InternalRouteStep> internalRouteSteps(List<RouteEdge> path, Map<String, RouteNode> nodesById) {
@@ -1486,9 +1488,34 @@ public class RouteSearchService implements RouteSearchUseCase {
 
 	private record InternalRouteCandidate(
 		String nodeId,
-		int cost,
+		InternalRouteCost cost,
 		List<RouteEdge> path
 	) {
+	}
+
+	private record InternalRouteCost(
+		int timeSeconds,
+		int burdenScore
+	) implements Comparable<InternalRouteCost> {
+
+		private static final InternalRouteCost ZERO = new InternalRouteCost(0, 0);
+		private static final InternalRouteCost MAX = new InternalRouteCost(Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+		InternalRouteCost plus(InternalRouteCost other) {
+			return new InternalRouteCost(
+				Math.addExact(timeSeconds, other.timeSeconds),
+				Math.addExact(burdenScore, other.burdenScore)
+			);
+		}
+
+		@Override
+		public int compareTo(InternalRouteCost other) {
+			int timeComparison = Integer.compare(timeSeconds, other.timeSeconds);
+			if (timeComparison != 0) {
+				return timeComparison;
+			}
+			return Integer.compare(burdenScore, other.burdenScore);
+		}
 	}
 
 	private record DirectLine(

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -1413,6 +1413,35 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("역 내부 ETA는 burden 점수보다 먼저 비교하고 표시 초는 시간 항만 합산한다")
+	void internalRouteRanksEtaBeforeBurdenScore() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeEdgeService = new RouteSearchService(
+			repository,
+			repository,
+			new EtaBurdenSplitInternalTransitMasterPort(),
+			CLOCK
+		);
+
+		var result = routeEdgeService.searchInternalRoute(new SearchInternalRouteCommand(
+			"station-a",
+			"node-station-a-entrance",
+			"node-station-a-platform",
+			MobilityType.STROLLER
+		));
+
+		assertThat(result.status()).isEqualTo(RouteSearchStatus.FOUND);
+		assertThat(result.totalEstimatedSeconds()).isEqualTo(90);
+		assertThat(result.totalDistanceMeters()).isEqualTo(400);
+		assertThat(result.steps())
+			.extracting("edgeId")
+			.containsExactly("edge-fast-stair");
+		assertThat(result.warnings())
+			.extracting("code")
+			.containsExactly(RouteWarningCode.STAIR_ONLY_ACCESS);
+	}
+
+	@Test
 	@DisplayName("역 내부 이동 경로는 같은 역에 속한 노드를 요구한다")
 	void searchInternalRouteRequiresNodesInStation() {
 		assertThatThrownBy(() -> service.searchInternalRoute(new SearchInternalRouteCommand(
@@ -2315,6 +2344,51 @@ class RouteSearchServiceTest {
 		}
 	}
 
+	private static class EtaBurdenSplitInternalTransitMasterPort extends ExitSummaryAccessibleTransitMasterPort {
+
+		@Override
+		public List<RouteEdge> loadRouteEdges() {
+			return List.of(
+				internalEdge(
+					"edge-fast-stair",
+					"node-station-a-entrance",
+					"node-station-a-platform",
+					RouteEdgeType.STAIR,
+					400,
+					90,
+					true
+				),
+				internalEdge(
+					"edge-slower-step-free-a",
+					"node-station-a-entrance",
+					"node-station-a-landing",
+					RouteEdgeType.WALKWAY,
+					5,
+					60,
+					false
+				),
+				internalEdge(
+					"edge-slower-step-free-b",
+					"node-station-a-landing",
+					"node-station-a-platform",
+					RouteEdgeType.WALKWAY,
+					5,
+					60,
+					false
+				)
+			);
+		}
+
+		@Override
+		public List<RouteNode> loadRouteNodes() {
+			return List.of(
+				routeNode("node-station-a-entrance", "station-a", RouteNodeType.ENTRANCE, "출입구"),
+				routeNode("node-station-a-landing", "station-a", RouteNodeType.CONCOURSE, "중간 지점"),
+				routeNode("node-station-a-platform", "station-a", RouteNodeType.PLATFORM, "승강장")
+			);
+		}
+	}
+
 	private static class BrokenElevatorInternalEdgeTransitMasterPort extends ExitSummaryAccessibleTransitMasterPort {
 
 		@Override
@@ -2589,6 +2663,33 @@ class RouteSearchServiceTest {
 			false,
 			1,
 			3,
+			95,
+			true
+		);
+	}
+
+	private static RouteEdge internalEdge(
+		String id,
+		String fromNodeId,
+		String toNodeId,
+		RouteEdgeType type,
+		int distanceMeters,
+		int estimatedSeconds,
+		boolean hasStairs
+	) {
+		return new RouteEdge(
+			id,
+			"station-a",
+			fromNodeId,
+			toNodeId,
+			type,
+			distanceMeters,
+			estimatedSeconds,
+			hasStairs,
+			false,
+			false,
+			1,
+			5,
 			95,
 			true
 		);


### PR DESCRIPTION
## 관련 이슈

close #1408

## 작업 배경

- #1414 route release readiness의 ETA 정확도 기준은 사용자 표시 ETA(초)와 접근성 burden/risk score가 분리되어야 검증 가능합니다.
- 기존 역 내부 경로 탐색 비용은 `distanceMeters + estimatedSeconds + accessibility penalty`를 한 정수로 합산해, ETA 시간 항과 ranking burden 항이 섞일 수 있었습니다.

## 작업 내용

- 역 내부 경로 탐색 후보 비용을 `timeSeconds`와 `burdenScore`로 분리했습니다.
- 내부 후보 비교는 `timeSeconds`를 먼저 비교하고, 같은 ETA일 때만 `burdenScore`를 비교하도록 고정했습니다.
- 더 느리지만 burden 점수가 낮은 경로가 빠른 ETA 경로를 덮어쓰지 않는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` 성공
  - `./gradlew test --tests 'com.easysubway.route.*'` 성공
  - `git -C /private/tmp/easysubway-1402 diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| route ETA/burden unit regression | backend | Gradle route service/package tests | local command output | 성공 |
| whitespace check | repo | `git diff --check` | local command output | 성공 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 내부 ranking cost 단위 분리
- realtime contract: 변경 없음
- backend identity: `RouteSearchService` internal route planner

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchService.InternalRouteCost` 비교 순서와 `internalRouteRanksEtaBeforeBurdenScore` 회귀 테스트

## 리스크

- 역 내부 경로 후보 선택에서 ETA 시간이 burden보다 우선되므로, 같은 시간대 접근성 부담 tie-break는 유지되지만 더 빠른 경로가 우선됩니다. 엄격 계단 회피는 기존 `STRICT_STEP_FREE`/휠체어 필터가 계속 담당합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
