### PR TITLE
[Test] ETA accuracy mode별 집계 gate 고정

### DIFF
--- a/tools/routes/check-route-commercialization-gate.mjs
+++ b/tools/routes/check-route-commercialization-gate.mjs
@@ -106,6 +106,8 @@ function validateAccuracy(gate, report, failures) {
 
   const singleRide = report.metrics?.singleRide ?? {};
   const transfer = report.metrics?.transfer ?? {};
+  if (number(report.metrics?.offlinePlanned?.sampleSize) <= 0) failures.push("routeEtaAccuracy offline PLANNED metrics must be reported");
+  if (number(report.metrics?.onlineRealtime?.sampleSize) <= 0) failures.push("routeEtaAccuracy online REALTIME metrics must be reported");
   max(singleRide.p50ErrorSeconds, gate.routeEtaAccuracy.singleRideP50ErrorSecondsMax, "singleRide P50 ETA error", failures);
   max(singleRide.p90ErrorSeconds, gate.routeEtaAccuracy.singleRideP90ErrorSecondsMax, "singleRide P90 ETA error", failures);
   max(transfer.p50ErrorSeconds, gate.routeEtaAccuracy.transferP50ErrorSecondsMax, "transfer P50 ETA error", failures);

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -453,6 +453,70 @@ test("route commercialization gate requires static, planned, realtime, and fallb
   );
 });
 
+test("route commercialization gate requires offline planned and online realtime metrics", async () => {
+  const fixture = await writeFixtureSet({
+    accuracy: {
+      schemaVersion: 1,
+      sampleSize: 120,
+      sampleSourceCounts: {
+        fixture: 0,
+        staticTimetable: 0,
+        realtimeProvider: 120,
+        manualObservation: 120,
+        staleRealtime: 0,
+      },
+      productionSampleSize: 120,
+      metrics: {
+        singleRide: { sampleSize: 60, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
+        transfer: { sampleSize: 60, p50ErrorSeconds: 90, p90ErrorSeconds: 240 },
+        offlinePlanned: { sampleSize: 0, p50ErrorSeconds: 0, p90ErrorSeconds: 0 },
+        onlineRealtime: { sampleSize: 0, p50ErrorSeconds: 0, p90ErrorSeconds: 0 },
+      },
+      failures: [],
+    },
+    accessibility: {
+      schemaVersion: 1,
+      strictStepFreeKnownStairFalsePositiveCount: 0,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      unknownAccessibilityLabeled: true,
+    },
+    coverage: {
+      schemaVersion: 1,
+      supportedStationLinePairs: 150,
+      providerFreshnessSecondsMaxObserved: 80,
+      staleFallbackRequired: true,
+      freshness: { staleAsFreshCount: 0 },
+      mapping: { failureRate: 0 },
+    },
+    routeGraphCoverage: {
+      schemaVersion: 1,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      strictRouteNotFound: { total: 100, notFoundCount: 1, rate: 0.01, byReasonCode: {} },
+    },
+    contract: {
+      schemaVersion: 1,
+      multiTransferSupported: false,
+      outOfStationTransferSupported: false,
+      alternativeItinerariesMinObserved: 2,
+      wrongTransferCount: 0,
+      wrongLineSequence: 0,
+      routeNotFoundRate: 0.01,
+      releaseBlockersSatisfied: ["D-2", "D-3", "H-1"],
+    },
+  });
+
+  await assert.rejects(
+    execChecker(fixture),
+    (error) => {
+      const report = JSON.parse(error.stdout);
+      assert.equal(report.status, "FAIL");
+      assert.ok(report.failures.includes("routeEtaAccuracy offline PLANNED metrics must be reported"));
+      assert.ok(report.failures.includes("routeEtaAccuracy online REALTIME metrics must be reported"));
+      return true;
+    },
+  );
+});
+
 test("route commercialization gate sorts checked reports with an explicit comparator", async () => {
   const source = await readFile("tools/routes/check-route-commercialization-gate.mjs", "utf8");
 
@@ -478,9 +542,17 @@ async function writeFixtureSet(reports) {
 }
 
 function normalizeAccuracyReport(report) {
-  if (Object.hasOwn(report, "actualEtaSourceCounts")) return report;
-  return {
+  const normalized = {
     ...report,
+    metrics: {
+      offlinePlanned: { sampleSize: 60, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
+      onlineRealtime: { sampleSize: 60, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
+      ...report.metrics,
+    },
+  };
+  if (Object.hasOwn(report, "actualEtaSourceCounts")) return normalized;
+  return {
+    ...normalized,
     actualEtaSourceCounts: {
       REALTIME: 0,
       PLANNED: 0,

--- a/tools/routes/evaluate-eta-accuracy.mjs
+++ b/tools/routes/evaluate-eta-accuracy.mjs
@@ -124,6 +124,8 @@ function buildReport(rows) {
   const errors = [];
   const singleRideErrors = [];
   const transferErrors = [];
+  const offlinePlannedErrors = [];
+  const onlineRealtimeErrors = [];
   const quality = {
     routeNotFound: 0,
     wrongTransferCount: 0,
@@ -147,6 +149,11 @@ function buildReport(rows) {
       }
     }
     errors.push(observed);
+    if (row.use_realtime === "true") {
+      onlineRealtimeErrors.push(observed);
+    } else {
+      offlinePlannedErrors.push(observed);
+    }
     if (Number(row.expected_transfer_count) === 0) {
       singleRideErrors.push(observed);
     } else {
@@ -156,6 +163,8 @@ function buildReport(rows) {
   errors.sort((left, right) => left - right);
   singleRideErrors.sort((left, right) => left - right);
   transferErrors.sort((left, right) => left - right);
+  offlinePlannedErrors.sort((left, right) => left - right);
+  onlineRealtimeErrors.sort((left, right) => left - right);
   const coverage = {
     singleRide: rows.some((row) => row.category === "singleRide"),
     oneTransfer: rows.some((row) => row.category === "oneTransfer"),
@@ -189,6 +198,8 @@ function buildReport(rows) {
       maxErrorSeconds: errors.at(-1) ?? 0,
       singleRide: metricBlock(singleRideErrors),
       transfer: metricBlock(transferErrors),
+      offlinePlanned: metricBlock(offlinePlannedErrors),
+      onlineRealtime: metricBlock(onlineRealtimeErrors),
       routeNotFoundRate: rate(quality.routeNotFound, rows.length),
       wrongTransferCountRate: rate(quality.wrongTransferCount, rows.length),
       wrongLineSequenceRate: rate(quality.wrongLineSequence, rows.length),

--- a/tools/routes/evaluate-eta-accuracy.test.mjs
+++ b/tools/routes/evaluate-eta-accuracy.test.mjs
@@ -69,6 +69,18 @@ test("ETA evaluator emits the route accuracy report contract", async (t) => {
     p90ErrorSeconds: 120,
     maxErrorSeconds: 120,
   });
+  assert.deepEqual(report.metrics.offlinePlanned, {
+    sampleSize: 60,
+    p50ErrorSeconds: 90,
+    p90ErrorSeconds: 120,
+    maxErrorSeconds: 120,
+  });
+  assert.deepEqual(report.metrics.onlineRealtime, {
+    sampleSize: 40,
+    p50ErrorSeconds: 45,
+    p90ErrorSeconds: 90,
+    maxErrorSeconds: 90,
+  });
   assert.deepEqual(report.failures, []);
   assert.equal(report.coverage.singleRide, true);
   assert.equal(report.coverage.oneTransfer, true);


### PR DESCRIPTION
## 관련 이슈

part of #1417

## 작업 배경

- ETA accuracy report가 전체/single/transfer 오차만 제공해서 offline PLANNED와 online REALTIME 품질을 따로 gate할 수 없었다.

## 작업 내용

- `evaluate-eta-accuracy.mjs`가 `use_realtime` 기준으로 `metrics.offlinePlanned`, `metrics.onlineRealtime`을 산출하도록 했다.
- route commercialization gate가 두 mode metric의 sampleSize 누락/0건을 실패로 막도록 했다.
- evaluator/gate 테스트에 mode별 report contract와 실패 케이스를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/routes/evaluate-eta-accuracy.test.mjs tools/routes/check-route-commercialization-gate.test.mjs` PASS
  - `node --test tools/routes/*.test.mjs` PASS
  - `node --test --test-name-pattern "route ETA accuracy evaluator report contract|route commercialization release gate" tools/ci/repository-contract.test.mjs` PASS
  - `git diff --check` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| ETA mode metric contract | local | Node test | 증거 불필요 사유: CLI report/gate 계약 테스트 변경 | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [x] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: ETA accuracy report now requires offline PLANNED and online REALTIME metric blocks
- realtime contract: no runtime API change
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/routes/evaluate-eta-accuracy.mjs`, `tools/routes/check-route-commercialization-gate.mjs`
- #1417 전체 완료는 아니다. real campaign sampleSize, ground truth collection, stratified breakdown은 별도 작업으로 남아 있다.

## 리스크

- 기존 report producer가 mode별 metric을 내지 않으면 gate가 실패한다. 이번 PR의 evaluator는 해당 metric을 생성한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
