### PR TITLE
[Test] route strict step-free evidence gate 보강

### DIFF
--- a/tools/routes/check-route-commercialization-gate.mjs
+++ b/tools/routes/check-route-commercialization-gate.mjs
@@ -133,7 +133,10 @@ function validateEtaSourceCounts(gate, report, failures) {
 
 function validateAccessibility(gate, report, failures) {
   if (report.schemaVersion !== 1) failures.push("accessibility report schemaVersion must be 1");
-  if (number(report.strictStepFreeKnownStairFalsePositiveCount) > gate.accessibility.strictStepFreeKnownStairFalsePositiveAllowed) {
+  const strictStepFreeFalsePositiveCount = report.strictStepFreeKnownStairFalsePositiveCount;
+  if (strictStepFreeFalsePositiveCount === null || !Number.isFinite(Number(strictStepFreeFalsePositiveCount))) {
+    failures.push("accessibility strict step-free false positive count must be reported");
+  } else if (number(strictStepFreeFalsePositiveCount) > gate.accessibility.strictStepFreeKnownStairFalsePositiveAllowed) {
     failures.push("accessibility strict step-free false positive count exceeds 0");
   }
   if (!gate.accessibility.generatedConnectorAsVerifiedAllowed && number(report.generatedConnectorVerifiedAccessibilityCount) > 0) {

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -66,6 +66,66 @@ test("route commercialization gate passes with production-ready reports", async 
   assert.deepEqual(report.failures, []);
 });
 
+test("route commercialization gate fails closed when strict step-free false positive count is missing", async () => {
+  const fixture = await writeFixtureSet({
+    accuracy: {
+      schemaVersion: 1,
+      sampleSize: 120,
+      sampleSourceCounts: {
+        fixture: 0,
+        staticTimetable: 0,
+        realtimeProvider: 120,
+        manualObservation: 120,
+        staleRealtime: 0,
+      },
+      productionSampleSize: 120,
+      metrics: {
+        singleRide: { sampleSize: 60, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
+        transfer: { sampleSize: 60, p50ErrorSeconds: 90, p90ErrorSeconds: 240 },
+      },
+      failures: [],
+    },
+    accessibility: {
+      schemaVersion: 1,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      unknownAccessibilityLabeled: true,
+    },
+    coverage: {
+      schemaVersion: 1,
+      supportedStationLinePairs: 150,
+      providerFreshnessSecondsMaxObserved: 80,
+      staleFallbackRequired: true,
+      freshness: { staleAsFreshCount: 0 },
+      mapping: { failureRate: 0 },
+    },
+    routeGraphCoverage: {
+      schemaVersion: 1,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      strictRouteNotFound: { total: 100, notFoundCount: 1, rate: 0.01, byReasonCode: {} },
+    },
+    contract: {
+      schemaVersion: 1,
+      multiTransferSupported: false,
+      outOfStationTransferSupported: false,
+      alternativeItinerariesMinObserved: 2,
+      wrongTransferCount: 0,
+      wrongLineSequence: 0,
+      routeNotFoundRate: 0.01,
+      releaseBlockersSatisfied: ["D-2", "D-3", "H-1"],
+    },
+  });
+
+  await assert.rejects(
+    execChecker(fixture),
+    (error) => {
+      const report = JSON.parse(error.stdout);
+      assert.equal(report.status, "FAIL");
+      assert.ok(report.failures.includes("accessibility strict step-free false positive count must be reported"));
+      return true;
+    },
+  );
+});
+
 test("route commercialization gate fails closed for fixture-only or unsafe route reports", async () => {
   const fixture = await writeFixtureSet({
     accuracy: {


### PR DESCRIPTION
## 관련 이슈

close #1413

## 작업 배경

- #1413은 strict step-free unknown/누락 증거가 safe로 승격되지 않도록 false positive 0 기준을 강제해야 합니다.
- 서비스 판정은 이미 양성 시설 증거 기반으로 정리되어 있었지만, route commercialization gate는 `strictStepFreeKnownStairFalsePositiveCount`가 누락돼도 0처럼 통과할 수 있었습니다.

## 작업 내용

- accessibility regression report에서 `strictStepFreeKnownStairFalsePositiveCount`가 누락되면 gate가 FAIL 하도록 변경했습니다.
- 누락 report가 fail-closed 되는 회귀 테스트를 추가했습니다.
- 기존 strict step-free 서비스 회귀 테스트도 함께 재검증했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/routes/check-route-commercialization-gate.test.mjs` 성공
  - `node --test tools/routes/*.test.mjs` 성공
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` 성공
  - `git -C /private/tmp/easysubway-1402 diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| strict step-free false positive metric | route gate | Node route gate tests | local command output | 성공 |
| strict step-free service regression | backend | Gradle RouteSearchServiceTest | local command output | 성공 |
| whitespace check | repo | `git diff --check` | local command output | 성공 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [x] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: accessibility regression report metric required
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `validateAccessibility()`의 missing metric fail-closed 처리와 누락 fixture 테스트

## 리스크

- 기존 report 생성 파이프라인이 `strictStepFreeKnownStairFalsePositiveCount`를 누락하면 gate가 실패합니다. 이는 #1413의 false positive 0 증거를 강제하기 위한 의도된 차단입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
