### PR TITLE
[Test] route V2 시간축 fixture coverage 고정

### DIFF
--- a/tools/routes/prototype-route-v2.test.mjs
+++ b/tools/routes/prototype-route-v2.test.mjs
@@ -36,6 +36,21 @@ test("route v2 prototypes honor requested alternative count", () => {
   assert.equal(alternatives[0].arrival, "09:25");
 });
 
+test("route v2 fixture suite covers commercialization time-axis blockers", () => {
+  const queryIds = new Set(fixtures.queries.map((query) => query.id));
+
+  for (const id of [
+    "provider_realtime_fresh_but_not_boardable_due_to_entry_slack",
+    "transfer_buffer_too_short_selects_next_train",
+    "pareto_arrival_vs_transfer",
+    "provider_realtime_stale",
+    "unmatched_realtime_express_does_not_override_planned_local",
+    "strict_step_free_excludes_transfer",
+  ]) {
+    assert.ok(queryIds.has(id), `missing route commercialization fixture: ${id}`);
+  }
+});
+
 test("route v2 time-axis fixtures reject unboardable realtime arrivals", () => {
   const query = fixtureQuery("provider_realtime_fresh_but_not_boardable_due_to_entry_slack");
 


### PR DESCRIPTION
## 관련 이슈

close #1403

## 작업 배경

- #1403은 route V2 시간축 regression fixture가 상용화 gate 기준에서 빠지지 않도록 고정해야 합니다.
- 개별 fixture 동작 테스트는 이미 존재하므로, 이번 변경은 #1403 핵심 blocker fixture 목록이 suite에서 누락되지 않게 잠급니다.

## 작업 내용

- route V2 prototype test에 commercialization time-axis blocker fixture 존재 여부를 검증하는 테스트를 추가했습니다.
- unboardable realtime, transfer feasibility, 대안 itinerary, stale realtime, realtime mismatch, strict step-free fixture가 suite에 남아있도록 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/routes/*.test.mjs` 성공
  - `git -C /private/tmp/easysubway-1402 diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| route V2 time-axis fixture coverage | route tools | `node --test tools/routes/*.test.mjs` | local command output | 성공 |
| whitespace check | repo | `git diff --check` | local command output | 성공 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: route V2 time-axis fixture coverage fixed
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `route v2 fixture suite covers commercialization time-axis blockers` 테스트

## 리스크

- 새 로직은 없고 fixture 누락 방지 테스트만 추가했습니다. 향후 fixture ID를 바꿀 때는 #1403 blocker coverage를 유지하도록 테스트도 같이 갱신해야 합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

