### PR TITLE
[Fix] UNKNOWN 시설 운행상태 미확인 문구 분리

### DIFF
--- a/apps/mobile/lib/facility_status.dart
+++ b/apps/mobile/lib/facility_status.dart
@@ -47,6 +47,15 @@ const _needsInfoPresentation = FacilityStatusPresentation(
   priority: 30,
 );
 
+const _unknownPresentation = FacilityStatusPresentation(
+  severity: FacilityStatusSeverity.needsInfo,
+  severityLabel: '확인 중',
+  statusTitle: '설치 확인 · 운행상태 미확인',
+  nextActionLabel: '자세히 보기',
+  nextActionDescription: '설치 여부는 확인됐어요. 운행 상태는 현장 안내도 함께 봐 주세요.',
+  priority: 30,
+);
+
 const _normalPresentation = FacilityStatusPresentation(
   severity: FacilityStatusSeverity.normal,
   severityLabel: '정상',
@@ -65,7 +74,7 @@ FacilityStatusPresentation facilityStatusPresentation(String status) {
     'UNDER_CONSTRUCTION' ||
     'CONSTRUCTION' ||
     'USER_REPORTED' => _cautionPresentation,
-    'UNKNOWN' ||
+    'UNKNOWN' => _unknownPresentation,
     'NEEDS_REPORT' ||
     'NEEDS_CHECK' ||
     'CHECK_REQUIRED' => _needsInfoPresentation,
@@ -136,6 +145,7 @@ Map<FacilityStatusPresentation, int> _attentionCounts(
       _blockedPresentation,
       _cautionPresentation,
       _needsInfoPresentation,
+      _unknownPresentation,
     ])
       if (counts[presentation] != null) presentation: counts[presentation]!,
   };

--- a/apps/mobile/test/favorite_facility_test.dart
+++ b/apps/mobile/test/favorite_facility_test.dart
@@ -87,6 +87,7 @@ void main() {
     final unavailable = _favoriteFacility(status: 'OUT_OF_SERVICE');
     final reported = _favoriteFacility(status: 'USER_REPORTED');
     final unknown = _favoriteFacility(status: 'NEEDS_CHECK');
+    final operationalUnknown = _favoriteFacility(status: 'UNKNOWN');
     final available = _favoriteFacility(status: 'AVAILABLE');
     final verified = _favoriteFacility(fieldValidationStatus: 'VERIFIED');
     final metadataOnlyDescription = _favoriteFacility(description: '현장 검증 전');
@@ -100,6 +101,8 @@ void main() {
     expect(reported.nextActionLabel, '역무원 도움 요청');
     expect(unknown.severityLabel, '확인 중');
     expect(unknown.nextActionLabel, '자세히 보기');
+    expect(operationalUnknown.statusTitle, '설치 확인 · 운행상태 미확인');
+    expect(operationalUnknown.needsAttention, isTrue);
     expect(available.severityLabel, '정상');
     expect(available.needsAttention, isFalse);
     expect(available.verificationStatusLabel, '최신 상태를 준비 중이에요');


### PR DESCRIPTION
## 관련 이슈

Refs #1394

## 작업 배경

- UNKNOWN 운행상태 시설이 `상태를 확인하고 있어요`로만 보여 설치 정보와 운행 가능 여부가 분리되지 않았다.
- #1394 전체 완료는 아니다. 실제 pathway graph와 field/operator evidence는 별도 작업으로 남아 있다.

## 작업 내용

- `UNKNOWN` 시설 상태만 `설치 확인 · 운행상태 미확인`으로 분리했다.
- `NEEDS_CHECK` 등 일반 확인 필요 상태는 기존 문구를 유지했다.
- `UNKNOWN` 시설도 살펴볼 시설 집계에 포함되도록 유지했다.
- 즐겨찾기 시설 상태 테스트에 UNKNOWN 문구 회귀를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/favorite_facility_test.dart` PASS
  - `flutter test test/station_search_test.dart --name "시설"` PASS
  - `node --test tools/ci/repository-contract.test.mjs` PASS
  - `dart format --set-exit-if-changed apps/mobile/lib/facility_status.dart apps/mobile/test/favorite_facility_test.dart` PASS
  - `git diff --check` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| UNKNOWN 시설 문구 | Flutter model/widget input | `flutter test test/favorite_facility_test.dart` | 증거 불필요 사유: 공용 presentation 단위 계약 | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/facility_status.dart`
- Codex CLI fallback review: #4619466463

## 리스크

- UNKNOWN 상태 문구만 바꾸며 실제 시설 운행 가능 여부를 승격하지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
