### PR TITLE
[Fix] realtime provider ETA anchor와 direction fail-closed

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolver.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolver.java
@@ -12,6 +12,7 @@ import com.easysubway.route.domain.EtaConfidence;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -39,36 +40,32 @@ class RealtimeGatewayArrivalResolver implements RealtimeArrivalResolver {
 			result.fallbackCode(),
 			providerSnapshotId(result),
 			receivedAt,
-			candidates(query, result, status, receivedAt)
+			candidates(result, status)
 		);
 	}
 
 	private List<ArrivalCandidate> candidates(
-		Query query,
 		RealtimeArrivalResult result,
-		ArrivalFreshness status,
-		Instant receivedAt
+		ArrivalFreshness status
 	) {
 		return result.arrivals()
 			.stream()
 			.filter(arrival -> arrival.etaSeconds() != null)
 			.filter(arrival -> arrival.etaSeconds() >= 0)
-			.map(arrival -> candidate(query, arrival, status, receivedAt))
+			.map(arrival -> candidate(arrival, status))
+			.filter(Objects::nonNull)
 			.toList();
 	}
 
 	private ArrivalCandidate candidate(
-		Query query,
 		RealtimeArrival arrival,
-		ArrivalFreshness status,
-		Instant receivedAt
+		ArrivalFreshness status
 	) {
 		Instant providerReceivedAt = parseInstant(arrival.providerReceivedAt());
 		if (providerReceivedAt == null) {
-			providerReceivedAt = receivedAt;
+			return null;
 		}
-		Instant etaBase = receivedAt == null ? query.readyAt() : receivedAt;
-		Instant expectedArrivalAt = etaBase.plusSeconds(arrival.etaSeconds());
+		Instant expectedArrivalAt = providerReceivedAt.plusSeconds(arrival.etaSeconds());
 		return new ArrivalCandidate(
 			arrival.trainNo(),
 			arrival.lineId(),

--- a/backend/src/main/java/com/easysubway/route/domain/RealtimeEtaOverlay.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RealtimeEtaOverlay.java
@@ -103,7 +103,7 @@ public final class RealtimeEtaOverlay {
 		return candidates.stream()
 			.filter(candidate -> candidate.freshness() == ArrivalFreshness.FRESH_REALTIME)
 			.filter(candidate -> !candidate.expectedArrivalAt().isBefore(readyAt))
-			.filter(candidate -> matchesDirection(direction, candidate.direction()))
+			.filter(candidate -> matchesDirection(direction, candidate))
 			.min(Comparator.comparing(ArrivalCandidate::expectedArrivalAt))
 			.map(candidate -> realtime(readyAt, plannedWaitSeconds, providerSnapshotId, providerReceivedAt, providerHealthCount, candidate))
 			.orElseGet(() -> planned(
@@ -171,8 +171,17 @@ public final class RealtimeEtaOverlay {
 		);
 	}
 
-	private boolean matchesDirection(String expected, String actual) {
-		return expected == null || expected.isBlank() || expected.equals(actual);
+	private boolean matchesDirection(String expected, ArrivalCandidate candidate) {
+		if (expected == null || expected.isBlank()) {
+			return false;
+		}
+		if (expected.equals(candidate.direction())) {
+			return true;
+		}
+		String destinationDirection = candidate.destination() == null || candidate.destination().isBlank()
+			? ""
+			: candidate.destination() + " 방면";
+		return expected.equals(destinationDirection);
 	}
 
 	private List<String> warnings(String defaultCode, String fallbackCode) {

--- a/backend/src/test/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolverTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolverTest.java
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.Test;
 class RealtimeGatewayArrivalResolverTest {
 
 	@Test
-	@DisplayName("gateway가 조정한 ETA는 gateway receivedAt 기준 expectedArrivalAt으로 변환한다")
-	void adjustedEtaUsesGatewayReceivedAtAsBase() {
+	@DisplayName("gateway가 조정한 ETA는 provider timestamp 기준 expectedArrivalAt으로 변환한다")
+	void adjustedEtaUsesProviderTimestampAsBase() {
 		RealtimeGatewayService gatewayService = org.mockito.Mockito.mock(RealtimeGatewayService.class);
 		when(gatewayService.arrivals(any(RealtimeQuery.class))).thenReturn(RealtimeArrivalResult.fresh(
 			"2026-06-26T08:00:00Z",
@@ -49,6 +49,39 @@ class RealtimeGatewayArrivalResolverTest {
 
 		ArrivalCandidate candidate = resolution.candidates().getFirst();
 		assertThat(candidate.providerReceivedAt()).isEqualTo(Instant.parse("2026-06-26T07:59:30Z"));
-		assertThat(candidate.expectedArrivalAt()).isEqualTo(Instant.parse("2026-06-26T08:02:30Z"));
+		assertThat(candidate.expectedArrivalAt()).isEqualTo(Instant.parse("2026-06-26T08:02:00Z"));
+	}
+
+	@Test
+	@DisplayName("provider timestamp가 없는 realtime 도착 후보는 anchor 없는 ETA로 쓰지 않는다")
+	void realtimeCandidateRequiresProviderTimestampAnchor() {
+		RealtimeGatewayService gatewayService = org.mockito.Mockito.mock(RealtimeGatewayService.class);
+		when(gatewayService.arrivals(any(RealtimeQuery.class))).thenReturn(RealtimeArrivalResult.fresh(
+			"2026-06-26T08:00:00Z",
+			List.of(new RealtimeArrival(
+				"line-4",
+				"상록수",
+				"사당",
+				"상행",
+				"T1001",
+				150,
+				"3분 후",
+				"전역 출발",
+				null
+			))
+		));
+		RealtimeGatewayArrivalResolver resolver = new RealtimeGatewayArrivalResolver(gatewayService);
+
+		RealtimeArrivalResolver.Resolution resolution = resolver.resolve(new RealtimeArrivalResolver.Query(
+			"station-sangnoksu",
+			"line-4",
+			"1004",
+			"상록수",
+			"4호선",
+			"상행",
+			Instant.parse("2026-06-26T08:00:00Z")
+		));
+
+		assertThat(resolution.candidates()).isEmpty();
 	}
 }

--- a/backend/src/test/java/com/easysubway/route/domain/RealtimeEtaOverlayTest.java
+++ b/backend/src/test/java/com/easysubway/route/domain/RealtimeEtaOverlayTest.java
@@ -153,4 +153,61 @@ class RealtimeEtaOverlayTest {
 		assertThat(result.waitSeconds()).isEqualTo(PLANNED_WAIT_SECONDS);
 		assertThat(result.warningCodes()).containsExactly("NO_USABLE_REALTIME_CANDIDATE");
 	}
+
+	@Test
+	@DisplayName("기대 방향이 비어 있으면 fresh 후보를 realtime ETA로 쓰지 않는다")
+	void freshRealtimeCandidateRequiresResolvedDirection() {
+		ArrivalCandidate candidate = new ArrivalCandidate(
+			"train-403",
+			"seoul-4",
+			"당고개 방면",
+			"당고개",
+			90,
+			READY_AT.plusSeconds(90),
+			READY_AT.minusSeconds(20),
+			ArrivalFreshness.FRESH_REALTIME,
+			EtaConfidence.HIGH
+		);
+
+		RealtimeEtaOverlay.Result result = overlay.overlay(
+			READY_AT,
+			PLANNED_WAIT_SECONDS,
+			"",
+			ArrivalFreshness.FRESH_REALTIME,
+			null,
+			List.of(candidate)
+		);
+
+		assertThat(result.etaSource()).isEqualTo(EtaSource.FALLBACK);
+		assertThat(result.warningCodes()).containsExactly("NO_USABLE_REALTIME_CANDIDATE");
+	}
+
+	@Test
+	@DisplayName("provider raw direction 표기가 달라도 destination canonical 방향이 같으면 fresh 후보를 사용한다")
+	void freshRealtimeCandidateCanMatchCanonicalDestinationDirection() {
+		ArrivalCandidate candidate = new ArrivalCandidate(
+			"train-404",
+			"seoul-4",
+			"상행",
+			"당고개",
+			90,
+			READY_AT.plusSeconds(90),
+			READY_AT.minusSeconds(20),
+			ArrivalFreshness.FRESH_REALTIME,
+			EtaConfidence.HIGH
+		);
+
+		RealtimeEtaOverlay.Result result = overlay.overlay(
+			READY_AT,
+			PLANNED_WAIT_SECONDS,
+			"당고개 방면",
+			ArrivalFreshness.FRESH_REALTIME,
+			null,
+			List.of(candidate)
+		);
+
+		assertThat(result.etaSource()).isEqualTo(EtaSource.REALTIME);
+		assertThat(result.waitSeconds()).isEqualTo(90);
+		assertThat(result.trainNo()).isEqualTo("train-404");
+	}
 }


### PR DESCRIPTION
## 관련 이슈

refs #1412

상위 tracker: #1414

## 작업 배경

- Realtime ETA가 gateway 수신 시각을 provider 관측 시각처럼 사용할 수 있어 provider 지연만큼 도착 예측이 밀릴 수 있었습니다.
- 방향 매칭이 raw string에만 묶여 blank 방향을 통과시키거나 provider 표기 차이로 정상 후보를 탈락시키는 리스크가 있었습니다.
- 이 PR은 #1412 전체 조건 중 provider timestamp anchor와 direction fail-closed/canonical positive test를 먼저 고정합니다.

## 작업 내용

- `RealtimeGatewayArrivalResolver`에서 provider timestamp가 있는 후보만 ETA 후보로 만들고, `expectedArrivalAt = providerObservedAt + etaSeconds` 기준으로 계산하도록 고정했습니다.
- provider timestamp가 없는 후보는 gateway 수신 시각 fallback 없이 제외합니다.
- `RealtimeEtaOverlay`에서 blank expected direction 통과를 제거했습니다.
- provider raw direction이 다르더라도 destination canonical 방향(`<destination> 방면`)이 expected direction과 같으면 fresh realtime 후보로 사용할 수 있게 했습니다.
- provider timestamp anchor, timestamp 누락 후보 제외, direction blank-pass 제거, destination canonical positive test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.domain.RealtimeEtaOverlayTest --tests com.easysubway.route.adapter.out.realtime.RealtimeGatewayArrivalResolverTest` (`/private/tmp/easysubway-1412/backend`) - 성공
  - `git -C /private/tmp/easysubway-1412 diff --check` - 성공
  - PR CI #1584: CI run `28605990278` - 성공
  - PR release artifacts run `28605990515` - 성공
  - CodeRabbit: rate limit comment만 게시되어 GitHub PR Review 객체 없음
  - Codex fallback review: `4619464090` - 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| provider timestamp anchor | backend | `RealtimeGatewayArrivalResolverTest` | Gradle test output | 성공 |
| direction fail-closed/canonical positive | backend | `RealtimeEtaOverlayTest` | Gradle test output | 성공 |
| formatting | repo | `git diff --check` | CLI output | 성공 |
| UI/접근성/수동 QA | N/A | backend domain/resolver test only | UI 변경 없음 | 불필요 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: provider timestamp anchor와 direction matching 동작 강화
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RealtimeGatewayArrivalResolver.candidate()`의 provider timestamp 필수화
  - `RealtimeEtaOverlay.matchesDirection()`의 blank-pass 제거와 destination canonical 방향 matching
  - #1412 전체 완료 조건 중 registry/coverage report/leg evidence는 별도 후속이 남아 있습니다.

## 리스크

- provider timestamp가 없는 realtime candidate는 더 이상 gateway timestamp로 보정하지 않고 제외됩니다.
- provider가 destination을 제공하지 않고 raw direction도 canonical direction과 다르면 realtime 후보에서 제외됩니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
