### PR TITLE
[Test] production artifact 검증 summary 해시 증거 보강

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -612,6 +612,9 @@ test("원격 데이터팩 검증 wrapper는 manifest와 pack을 내려받아 기
     assert.equal(summary.manifestVersion, 1);
     assert.equal(summary.validation.exitCode, 0);
     assert.equal(summary.packs[0].id, "capital");
+    assert.equal(summary.packs[0].download.sizeBytesMatchesManifest, true);
+    assert.equal(summary.packs[0].download.sha256MatchesManifest, true);
+    assert.equal(summary.packs[0].download.sqliteSha256MatchesManifest, true);
     assert.match(summary.manifestSha256, /^[0-9a-f]{64}$/);
   } finally {
     await server.close();
@@ -673,6 +676,10 @@ test("원격 데이터팩 검증 wrapper는 validator 실패도 summary에 기�
     );
     assert.notEqual(summary.validation.exitCode, 0);
     assert.equal(summary.validation.signal, null);
+    assert.equal(summary.packs[0].download.sizeBytesMatchesManifest, false);
+    assert.equal(summary.packs[0].download.sha256MatchesManifest, false);
+    assert.equal(summary.packs[0].download.sqliteSha256MatchesManifest, false);
+    assert.match(summary.packs[0].download.sqliteDecompressionError, /incorrect header check|not in gzip format/);
     assert.match(summary.validation.stderr, /sizeBytes mismatch/);
   } finally {
     await server.close();

--- a/tools/datapack/validate-remote-datapack-artifact.mjs
+++ b/tools/datapack/validate-remote-datapack-artifact.mjs
@@ -2,6 +2,7 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
+import { gunzipSync } from "node:zlib";
 import path from "node:path";
 
 const DOWNLOAD_TIMEOUT_MS = 30_000;
@@ -17,12 +18,15 @@ const manifestBytes = await download(manifestUrl);
 await writeFile(manifestPath, manifestBytes);
 
 const manifest = JSON.parse(manifestBytes.toString("utf8"));
+const downloadedPacks = [];
 for (const pack of manifest.packs ?? []) {
   const packUrl = /^https?:\/\//.test(pack.url)
     ? pack.url
     : new URL(pack.url, new URL("/", manifestUrl)).toString();
   const packPath = path.join(outputRoot, "catalog", `${pack.id}-v${pack.version}.sqlite.gz`);
-  await writeFile(packPath, await download(packUrl));
+  const packBytes = await download(packUrl);
+  await writeFile(packPath, packBytes);
+  downloadedPacks.push(summarizeDownloadedPack({ pack, packUrl, packBytes }));
 }
 
 const validation = await runValidator({ manifestPath, outputRoot, requireProduction });
@@ -42,6 +46,9 @@ const summary = {
     sha256: pack.sha256,
     sqliteSha256: pack.sqliteSha256,
     sizeBytes: pack.sizeBytes,
+    download: downloadedPacks.find(
+      (downloadedPack) => downloadedPack.id === pack.id && downloadedPack.version === pack.version,
+    ),
     regionalQualityMetrics: pack.regionalQualityMetrics,
   })),
   validation,
@@ -85,6 +92,29 @@ function requireArg(parsed, name) {
     throw new Error(`missing required argument: --${name}`);
   }
   return value;
+}
+
+function summarizeDownloadedPack({ pack, packUrl, packBytes }) {
+  const compressedSha256 = sha256(packBytes);
+  const summary = {
+    id: pack.id,
+    version: pack.version,
+    resolvedUrl: packUrl,
+    sizeBytes: packBytes.length,
+    sha256: compressedSha256,
+    sizeBytesMatchesManifest: packBytes.length === pack.sizeBytes,
+    sha256MatchesManifest: compressedSha256 === pack.sha256,
+  };
+  try {
+    const sqliteBytes = gunzipSync(packBytes);
+    const sqliteSha256 = sha256(sqliteBytes);
+    summary.sqliteSha256 = sqliteSha256;
+    summary.sqliteSha256MatchesManifest = sqliteSha256 === pack.sqliteSha256;
+  } catch (error) {
+    summary.sqliteSha256MatchesManifest = false;
+    summary.sqliteDecompressionError = error.message;
+  }
+  return summary;
 }
 
 async function download(url) {


### PR DESCRIPTION
## 관련 이슈

Refs #1393

## 작업 배경

- #1393 원격 production artifact 검증은 validator 실패 시에도 다운로드한 manifest/pack의 해시 증거가 남아야 한다.
- 기존 `validate-remote-datapack-artifact.mjs`는 validator 결과는 남겼지만, 실패 전에 내려받은 pack의 gzip SHA256/SQLite SHA256/크기 대조 결과를 summary에 남기지 않았다.

## 작업 내용

- 원격 데이터팩 검증 wrapper가 pack 다운로드 직후 gzip SHA256, gzip 크기, gunzip 후 SQLite SHA256을 계산해 manifest 값과의 일치 여부를 summary에 기록하게 했다.
- corrupt pack 실패 테스트에도 다운로드 mismatch와 gunzip 오류가 summary에 남는지 검증을 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/datapack-tools.test.mjs` PASS (158 tests)
  - `node --test tools/ci/repository-contract.test.mjs` PASS (156 tests)
  - `git diff --check` PASS
  - `node tools/datapack/validate-remote-datapack-artifact.mjs --manifest-url https://objectstorage.ap-seoul-1.oraclecloud.com/n/axvym6vk8g7i/b/easysubway-datapacks/o/catalog/current.json --output /private/tmp/easysubway-1393-artifact-evidence --require-production` FAIL expected: deployed artifact validator failure recorded

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 원격 manifest/pack 다운로드 무결성 | datapack | wrapper summary | `/private/tmp/easysubway-1393-artifact-evidence/remote-datapack-validation-summary.json` | gzip size/SHA256/SQLite SHA256 match |
| 원격 production validator | datapack | `--require-production` | 같은 summary의 `validation.stderr` | FAIL: `regionalQualityMetrics.requiredFacilityEvidenceCoverageRatio must be a ratio` |
| wrapper 회귀 테스트 | local | `node --test tools/datapack/datapack-tools.test.mjs` | command output | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: N/A
- mobile versionCode: N/A
- datapack version: N/A
- route contract: N/A
- realtime contract: N/A
- backend identity: N/A

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/validate-remote-datapack-artifact.mjs`의 `download` summary 필드가 credential 없이 해시/크기 검증 결과만 남기는지 확인해 주세요.
- 현재 배포 artifact 자체는 아직 #1393 완료 조건을 통과하지 못합니다. 이 PR은 실패 증거를 더 정확히 남기는 도구 보강입니다.
- CodeRabbit은 review limit으로 실제 PR Review 객체를 남기지 못해 Codex fallback PR review `4619666142`를 게시했습니다.

## 리스크

- summary JSON 필드가 늘어나지만 기존 필드는 유지된다.
- 원격 validator 실패는 이번 변경으로 새로 생긴 실패가 아니라, 현재 배포 manifest의 production metric 누락이 드러난 상태다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 원격 데이터팩 검증 결과에 각 pack의 다운로드 무결성 정보가 더 자세히 포함됩니다.
  * 검증 요약에서 압축 파일과 압축 해제된 SQLite 파일의 해시 일치 여부를 확인할 수 있습니다.

* **Bug Fixes**
  * 손상된 gzip 파일의 오류가 더 명확하게 기록되어, 실패 원인 파악이 쉬워졌습니다.
  * 검증 결과에서 성공/실패 상태와 관련된 표시가 더 정확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->