### PR TITLE
[Test] realtime provider coverage reason breakdown gate

### DIFF
--- a/tools/routes/build-realtime-provider-coverage-report.mjs
+++ b/tools/routes/build-realtime-provider-coverage-report.mjs
@@ -30,6 +30,8 @@ export function buildRealtimeProviderCoverageReport(input) {
   const mappingFailures = pairs.filter((row) => row.mappingStatus !== "MAPPED");
   const realtimeSamples = samples.filter((row) => row.labeledAsRealtime === true);
   const staleAsFresh = realtimeSamples.filter((row) => row.freshnessStatus !== "FRESH");
+  const providerIds = uniqueKeys([...pairs, ...samples], "providerId");
+  const regions = uniqueKeys([...pairs, ...samples], "region");
 
   return {
     schemaVersion: 1,
@@ -48,7 +50,29 @@ export function buildRealtimeProviderCoverageReport(input) {
       failureRate: ratio(mappingFailures.length, pairs.length),
       failuresByReason: countBy(mappingFailures, "failureReason"),
     },
+    byProvider: providerIds.map((providerId) => aggregateScope(providerId, "providerId", pairs, samples)),
+    byRegion: regions.map((region) => aggregateScope(region, "region", pairs, samples)),
     unsupportedRegions: Array.isArray(input.unsupportedRegions) ? input.unsupportedRegions : [],
+  };
+}
+
+function uniqueKeys(rows, field) {
+  return [...new Set(rows.map((row) => row[field]).filter((value) => value != null && value !== ""))]
+    .sort((left, right) => `${left}`.localeCompare(`${right}`));
+}
+
+function aggregateScope(key, field, pairs, samples) {
+  const scopedPairs = pairs.filter((row) => row[field] === key);
+  const scopedSamples = samples.filter((row) => row[field] === key);
+  const mappedPairs = scopedPairs.filter((row) => row.supportsArrivals === true && row.mappingStatus === "MAPPED");
+  const mappingFailures = scopedPairs.filter((row) => row.mappingStatus !== "MAPPED");
+  return {
+    [field]: key,
+    supportedStationLinePairs: uniquePairCount(mappedPairs),
+    mappingFailedRows: mappingFailures.length,
+    mappingFailuresByReason: countBy(mappingFailures, "failureReason"),
+    freshCount: scopedSamples.filter((row) => row.freshnessStatus === "FRESH").length,
+    staleCount: scopedSamples.filter((row) => row.freshnessStatus === "STALE").length,
   };
 }
 

--- a/tools/routes/build-realtime-provider-coverage-report.test.mjs
+++ b/tools/routes/build-realtime-provider-coverage-report.test.mjs
@@ -11,13 +11,13 @@ test("builds realtime provider coverage report with freshness and mapping metric
     scope: { id: "capital_pilot_android_v1", supportedStationLinePairsMin: 2 },
     staleFallbackRequired: true,
     stationLinePairs: [
-      { stationId: "station-sangnoksu", lineId: "seoul-4", supportsArrivals: true, mappingStatus: "MAPPED" },
-      { stationId: "station-sadang", lineId: "seoul-4", supportsArrivals: true, mappingStatus: "MAPPED" },
-      { stationId: "station-busan", lineId: "busan-1", supportsArrivals: false, mappingStatus: "UNSUPPORTED_REGION", failureReason: "UNSUPPORTED_REGION" },
+      { providerId: "seoul-topis", region: "capital", stationId: "station-sangnoksu", lineId: "seoul-4", supportsArrivals: true, mappingStatus: "MAPPED" },
+      { providerId: "seoul-topis", region: "capital", stationId: "station-sadang", lineId: "seoul-4", supportsArrivals: true, mappingStatus: "MAPPED" },
+      { providerId: "busan-openapi", region: "busan", stationId: "station-busan", lineId: "busan-1", supportsArrivals: false, mappingStatus: "UNSUPPORTED_REGION", failureReason: "UNSUPPORTED_REGION" },
     ],
     samples: [
-      { providerFreshnessSeconds: 12, freshnessStatus: "FRESH", labeledAsRealtime: true },
-      { providerFreshnessSeconds: 120, freshnessStatus: "STALE", labeledAsRealtime: false },
+      { providerId: "seoul-topis", region: "capital", providerFreshnessSeconds: 12, freshnessStatus: "FRESH", labeledAsRealtime: true },
+      { providerId: "busan-openapi", region: "busan", providerFreshnessSeconds: 120, freshnessStatus: "STALE", labeledAsRealtime: false },
     ],
     unsupportedRegions: [{ region: "busan", reason: "실시간 미지원" }],
   });
@@ -32,6 +32,42 @@ test("builds realtime provider coverage report with freshness and mapping metric
     failureRate: 1 / 3,
     failuresByReason: { UNSUPPORTED_REGION: 1 },
   });
+  assert.deepEqual(report.byProvider, [
+    {
+      providerId: "busan-openapi",
+      supportedStationLinePairs: 0,
+      mappingFailedRows: 1,
+      mappingFailuresByReason: { UNSUPPORTED_REGION: 1 },
+      freshCount: 0,
+      staleCount: 1,
+    },
+    {
+      providerId: "seoul-topis",
+      supportedStationLinePairs: 2,
+      mappingFailedRows: 0,
+      mappingFailuresByReason: {},
+      freshCount: 1,
+      staleCount: 0,
+    },
+  ]);
+  assert.deepEqual(report.byRegion, [
+    {
+      region: "busan",
+      supportedStationLinePairs: 0,
+      mappingFailedRows: 1,
+      mappingFailuresByReason: { UNSUPPORTED_REGION: 1 },
+      freshCount: 0,
+      staleCount: 1,
+    },
+    {
+      region: "capital",
+      supportedStationLinePairs: 2,
+      mappingFailedRows: 0,
+      mappingFailuresByReason: {},
+      freshCount: 1,
+      staleCount: 0,
+    },
+  ]);
   assert.deepEqual(report.unsupportedRegions, [{ region: "busan", reason: "실시간 미지원" }]);
 });
 

--- a/tools/routes/check-route-commercialization-gate.mjs
+++ b/tools/routes/check-route-commercialization-gate.mjs
@@ -186,8 +186,42 @@ function validateCoverage(gate, report, failures) {
   if (number(report.freshness?.staleAsFreshCount) > 0) {
     failures.push("realtimeCoverage stale-as-fresh count exceeds 0");
   }
+  if (!Number.isFinite(Number(report.freshness?.staleCount))) {
+    failures.push("realtimeCoverage stale count must be reported");
+  }
   if (!Number.isFinite(Number(report.mapping?.failureRate))) {
     failures.push("realtimeCoverage mapping failure rate must be reported");
+  }
+  if (number(report.mapping?.failedRows) > 0 && objectCount(report.mapping?.failuresByReason) <= 0) {
+    failures.push("realtimeCoverage mapping failures must include reason codes");
+  }
+  if (number(report.mapping?.failuresByReason?.UNKNOWN) > 0) {
+    failures.push("realtimeCoverage mapping failures must not use UNKNOWN reason code");
+  }
+  validateCoverageBreakdown(report.byProvider, "providerId", "provider", failures);
+  validateCoverageBreakdown(report.byRegion, "region", "region", failures);
+}
+
+function validateCoverageBreakdown(rows, key, label, failures) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    failures.push(`realtimeCoverage ${label} breakdown must be reported`);
+    return;
+  }
+  for (const row of rows) {
+    if (typeof row?.[key] !== "string" || row[key].trim() === "") {
+      failures.push(`realtimeCoverage ${label} breakdown key must be reported`);
+    }
+    for (const metric of ["supportedStationLinePairs", "mappingFailedRows", "staleCount"]) {
+      if (!Number.isFinite(Number(row?.[metric]))) {
+        failures.push(`realtimeCoverage ${label} breakdown ${metric} must be reported`);
+      }
+    }
+    if (number(row?.mappingFailedRows) > 0 && objectCount(row?.mappingFailuresByReason) <= 0) {
+      failures.push(`realtimeCoverage ${label} mapping failures must include reason codes`);
+    }
+    if (number(row?.mappingFailuresByReason?.UNKNOWN) > 0) {
+      failures.push(`realtimeCoverage ${label} mapping failures must not use UNKNOWN reason code`);
+    }
   }
 }
 
@@ -228,4 +262,9 @@ function max(actual, limit, label, failures) {
 
 function number(value) {
   return Number.isFinite(Number(value)) ? Number(value) : 0;
+}
+
+function objectCount(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return 0;
+  return Object.values(value).reduce((sum, count) => sum + number(count), 0);
 }

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -657,6 +657,71 @@ test("route commercialization gate requires runtime traceability summary", async
   );
 });
 
+test("route commercialization gate requires realtime coverage provider and region reason breakdowns", async () => {
+  const fixture = await writeFixtureSet({
+    accuracy: {
+      schemaVersion: 1,
+      sampleSize: 120,
+      sampleSourceCounts: {
+        fixture: 0,
+        staticTimetable: 0,
+        realtimeProvider: 120,
+        manualObservation: 120,
+        staleRealtime: 0,
+      },
+      productionSampleSize: 120,
+      metrics: {
+        singleRide: { sampleSize: 60, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
+        transfer: { sampleSize: 60, p50ErrorSeconds: 90, p90ErrorSeconds: 240 },
+      },
+      failures: [],
+    },
+    accessibility: {
+      schemaVersion: 1,
+      strictStepFreeKnownStairFalsePositiveCount: 0,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      unknownAccessibilityLabeled: true,
+    },
+    coverage: {
+      schemaVersion: 1,
+      supportedStationLinePairs: 150,
+      providerFreshnessSecondsMaxObserved: 80,
+      staleFallbackRequired: true,
+      freshness: { staleAsFreshCount: 0 },
+      mapping: { failedRows: 1, failureRate: 0.1, failuresByReason: { UNKNOWN: 1 } },
+      byProvider: [],
+      byRegion: [{ region: "capital", supportedStationLinePairs: 150, mappingFailedRows: 1, staleCount: 0, mappingFailuresByReason: { UNKNOWN: 1 } }],
+    },
+    routeGraphCoverage: {
+      schemaVersion: 1,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      strictRouteNotFound: { total: 100, notFoundCount: 1, rate: 0.01, byReasonCode: {} },
+    },
+    contract: {
+      schemaVersion: 1,
+      multiTransferSupported: false,
+      outOfStationTransferSupported: false,
+      alternativeItinerariesMinObserved: 2,
+      wrongTransferCount: 0,
+      wrongLineSequence: 0,
+      routeNotFoundRate: 0.01,
+      releaseBlockersSatisfied: ["D-2", "D-3", "H-1"],
+    },
+  });
+
+  await assert.rejects(
+    execChecker(fixture),
+    (error) => {
+      const report = JSON.parse(error.stdout);
+      assert.equal(report.status, "FAIL");
+      assert.ok(report.failures.includes("realtimeCoverage mapping failures must not use UNKNOWN reason code"));
+      assert.ok(report.failures.includes("realtimeCoverage provider breakdown must be reported"));
+      assert.ok(report.failures.includes("realtimeCoverage region mapping failures must not use UNKNOWN reason code"));
+      return true;
+    },
+  );
+});
+
 test("route commercialization gate sorts checked reports with an explicit comparator", async () => {
   const source = await readFile("tools/routes/check-route-commercialization-gate.mjs", "utf8");
 
@@ -676,6 +741,7 @@ async function writeFixtureSet(reports) {
   const normalizedReports = {
     ...reports,
     accuracy: normalizeAccuracyReport(reports.accuracy),
+    coverage: normalizeCoverageReport(reports.coverage),
   };
   await Promise.all(Object.entries(normalizedReports).map(([key, report]) => writeFile(files[key], `${JSON.stringify(report, null, 2)}\n`)));
   return files;
@@ -711,6 +777,39 @@ function normalizeAccuracyReport(report) {
       STATIC_LOCAL: 0,
       FALLBACK: 0,
     },
+  };
+}
+
+function normalizeCoverageReport(report) {
+  return {
+    ...report,
+    freshness: {
+      staleCount: 0,
+      ...report.freshness,
+    },
+    mapping: {
+      failedRows: 0,
+      failuresByReason: {},
+      ...report.mapping,
+    },
+    byProvider: report.byProvider ?? [
+      {
+        providerId: "seoul-topis",
+        supportedStationLinePairs: report.supportedStationLinePairs ?? 0,
+        mappingFailedRows: report.mapping?.failedRows ?? 0,
+        mappingFailuresByReason: report.mapping?.failuresByReason ?? {},
+        staleCount: report.freshness?.staleCount ?? 0,
+      },
+    ],
+    byRegion: report.byRegion ?? [
+      {
+        region: "capital",
+        supportedStationLinePairs: report.supportedStationLinePairs ?? 0,
+        mappingFailedRows: report.mapping?.failedRows ?? 0,
+        mappingFailuresByReason: report.mapping?.failuresByReason ?? {},
+        staleCount: report.freshness?.staleCount ?? 0,
+      },
+    ],
   };
 }
 


### PR DESCRIPTION
## 관련 이슈

refs #1412

상위 tracker: #1414

## 작업 배경

- #1412 완료 조건에는 realtime provider coverage report가 mapping miss와 stale count를 provider/region별로 집계해야 한다는 조건이 있습니다.
- 기존 coverage report는 전체 mapping failure rate와 stale-as-fresh count만 확인해 provider/region 단위 원인 분류가 빠져도 gate를 통과할 수 있었습니다.

## 작업 내용

- `build-realtime-provider-coverage-report.mjs`가 `byProvider`, `byRegion` breakdown을 생성하도록 확장했습니다.
- breakdown에는 supported station-line pair 수, mapping failure row 수, mapping failure reason code, stale count를 포함했습니다.
- `check-route-commercialization-gate.mjs`가 stale count, mapping failure reason code, provider/region breakdown 누락을 fail-closed로 검증하도록 강화했습니다.
- route gate 테스트에 provider/region reason breakdown negative case를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/routes/build-realtime-provider-coverage-report.test.mjs tools/routes/check-route-commercialization-gate.test.mjs` - 성공
  - `node --test tools/routes/*.test.mjs` - 성공
  - `git -C /private/tmp/easysubway-1412 diff --check` - 성공
  - PR CI #1586: CI run `28607735321` - 성공
  - PR release artifacts run `28607734553` - 성공
  - CodeRabbit: rate limit comment만 게시되어 GitHub PR Review 객체 없음
  - Codex fallback review: `4619675839` - 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| realtime coverage report breakdown | route tools | `build-realtime-provider-coverage-report.test.mjs` | CLI output | 성공 |
| route commercialization gate validation | route tools | `check-route-commercialization-gate.test.mjs` | CLI output | 성공 |
| full route tools regression | route tools | `node --test tools/routes/*.test.mjs` | CLI output | 성공 |
| formatting | repo | `git diff --check` | CLI output | 성공 |
| UI/접근성/수동 QA | N/A | route gate tool only | UI 변경 없음 | 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [x] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: coverage report가 provider/region별 reason breakdown을 요구
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `validateCoverage()`의 fail-closed 조건
  - `buildRealtimeProviderCoverageReport()`의 provider/region aggregate shape
  - #1412 전체 완료 조건 중 backend leg evidence와 full canonical registry 검증은 별도 후속이 남아 있습니다.

## 리스크

- 기존 realtime provider coverage report fixture가 `byProvider`/`byRegion`을 제공하지 않으면 gate가 실패합니다.
- mapping failure가 있는데 reason code가 비어 있으면 gate가 실패합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
