### PR TITLE
[Fix] realtime service pattern 후보 매칭 고정

### DIFF
--- a/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
@@ -334,7 +334,8 @@ public class RealtimeGatewayService {
 			adjustedEtaSeconds,
 			arrivalMessage(adjustedEtaSeconds),
 			arrival.positionMessage(),
-			arrival.providerReceivedAt()
+			arrival.providerReceivedAt(),
+			arrival.servicePattern()
 		);
 	}
 

--- a/backend/src/main/java/com/easysubway/realtime/application/TopisRealtimeProvider.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/TopisRealtimeProvider.java
@@ -117,7 +117,8 @@ final class TopisRealtimeProvider implements RealtimeProvider {
 				optionalInt(item, "barvlDt"),
 				stringOrEmpty(item, "arvlMsg2"),
 				stringOrEmpty(item, "arvlMsg3"),
-				stringOrEmpty(item, "recptnDt")
+				stringOrEmpty(item, "recptnDt"),
+				stringOrEmpty(item, "btrainSttus")
 			));
 		}
 		return List.copyOf(arrivals);

--- a/backend/src/main/java/com/easysubway/realtime/domain/RealtimeArrival.java
+++ b/backend/src/main/java/com/easysubway/realtime/domain/RealtimeArrival.java
@@ -9,6 +9,31 @@ public record RealtimeArrival(
 	Integer etaSeconds,
 	String message,
 	String positionMessage,
-	String providerReceivedAt
+	String providerReceivedAt,
+	String servicePattern
 ) {
+	public RealtimeArrival(
+		String lineId,
+		String stationName,
+		String destination,
+		String direction,
+		String trainNo,
+		Integer etaSeconds,
+		String message,
+		String positionMessage,
+		String providerReceivedAt
+	) {
+		this(
+			lineId,
+			stationName,
+			destination,
+			direction,
+			trainNo,
+			etaSeconds,
+			message,
+			positionMessage,
+			providerReceivedAt,
+			null
+		);
+	}
 }

--- a/backend/src/main/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolver.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolver.java
@@ -74,6 +74,7 @@ class RealtimeGatewayArrivalResolver implements RealtimeArrivalResolver {
 			arrival.etaSeconds(),
 			expectedArrivalAt,
 			providerReceivedAt,
+			arrival.servicePattern(),
 			status,
 			confidenceOf(status)
 		);

--- a/backend/src/main/java/com/easysubway/route/domain/ArrivalCandidate.java
+++ b/backend/src/main/java/com/easysubway/route/domain/ArrivalCandidate.java
@@ -10,9 +10,35 @@ public record ArrivalCandidate(
 	int etaSeconds,
 	Instant expectedArrivalAt,
 	Instant providerReceivedAt,
+	String servicePattern,
 	ArrivalFreshness freshness,
 	EtaConfidence confidence
 ) {
+	public ArrivalCandidate(
+		String trainNo,
+		String lineId,
+		String direction,
+		String destination,
+		int etaSeconds,
+		Instant expectedArrivalAt,
+		Instant providerReceivedAt,
+		ArrivalFreshness freshness,
+		EtaConfidence confidence
+	) {
+		this(
+			trainNo,
+			lineId,
+			direction,
+			destination,
+			etaSeconds,
+			expectedArrivalAt,
+			providerReceivedAt,
+			null,
+			freshness,
+			confidence
+		);
+	}
+
 	public ArrivalCandidate {
 		if (etaSeconds < 0) {
 			throw new IllegalArgumentException("etaSeconds must be greater than or equal to zero.");

--- a/backend/src/main/java/com/easysubway/route/domain/RealtimeEtaOverlay.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RealtimeEtaOverlay.java
@@ -16,13 +16,51 @@ public final class RealtimeEtaOverlay {
 		String fallbackCode,
 		List<ArrivalCandidate> candidates
 	) {
-		return overlay(readyAt, plannedWaitSeconds, direction, providerStatus, fallbackCode, null, null, 0, candidates);
+		return overlay(readyAt, plannedWaitSeconds, direction, null, providerStatus, fallbackCode, null, null, 0, candidates);
 	}
 
 	public Result overlay(
 		Instant readyAt,
 		int plannedWaitSeconds,
 		String direction,
+		String servicePattern,
+		ArrivalFreshness providerStatus,
+		String fallbackCode,
+		List<ArrivalCandidate> candidates
+	) {
+		return overlay(readyAt, plannedWaitSeconds, direction, servicePattern, providerStatus, fallbackCode, null, null, 0, candidates);
+	}
+
+	public Result overlay(
+		Instant readyAt,
+		int plannedWaitSeconds,
+		String direction,
+		ArrivalFreshness providerStatus,
+		String fallbackCode,
+		String providerSnapshotId,
+		Instant providerReceivedAt,
+		int providerHealthCount,
+		List<ArrivalCandidate> candidates
+	) {
+		return overlay(
+			readyAt,
+			plannedWaitSeconds,
+			direction,
+			null,
+			providerStatus,
+			fallbackCode,
+			providerSnapshotId,
+			providerReceivedAt,
+			providerHealthCount,
+			candidates
+		);
+	}
+
+	public Result overlay(
+		Instant readyAt,
+		int plannedWaitSeconds,
+		String direction,
+		String servicePattern,
 		ArrivalFreshness providerStatus,
 		String fallbackCode,
 		String providerSnapshotId,
@@ -43,6 +81,7 @@ public final class RealtimeEtaOverlay {
 				readyAt,
 				plannedWaitSeconds,
 				direction,
+				servicePattern,
 				providerSnapshotId,
 				providerReceivedAt,
 				providerHealthCount,
@@ -95,6 +134,7 @@ public final class RealtimeEtaOverlay {
 		Instant readyAt,
 		int plannedWaitSeconds,
 		String direction,
+		String servicePattern,
 		String providerSnapshotId,
 		Instant providerReceivedAt,
 		int providerHealthCount,
@@ -104,6 +144,7 @@ public final class RealtimeEtaOverlay {
 			.filter(candidate -> candidate.freshness() == ArrivalFreshness.FRESH_REALTIME)
 			.filter(candidate -> !candidate.expectedArrivalAt().isBefore(readyAt))
 			.filter(candidate -> matchesDirection(direction, candidate))
+			.filter(candidate -> matchesServicePattern(servicePattern, candidate))
 			.min(Comparator.comparing(ArrivalCandidate::expectedArrivalAt))
 			.map(candidate -> realtime(readyAt, plannedWaitSeconds, providerSnapshotId, providerReceivedAt, providerHealthCount, candidate))
 			.orElseGet(() -> planned(
@@ -182,6 +223,29 @@ public final class RealtimeEtaOverlay {
 			? ""
 			: candidate.destination() + " 방면";
 		return expected.equals(destinationDirection);
+	}
+
+	private boolean matchesServicePattern(String expected, ArrivalCandidate candidate) {
+		String expectedPattern = normalizedServicePattern(expected);
+		if (expectedPattern.isBlank()) {
+			return true;
+		}
+		String actualPattern = normalizedServicePattern(candidate.servicePattern());
+		return !actualPattern.isBlank() && expectedPattern.equals(actualPattern);
+	}
+
+	private String normalizedServicePattern(String value) {
+		if (value == null || value.isBlank()) {
+			return "";
+		}
+		String normalized = value.trim().toUpperCase();
+		if (normalized.contains("EXPRESS") || normalized.contains("RAPID") || normalized.contains("급행")) {
+			return "EXPRESS";
+		}
+		if (normalized.contains("LOCAL") || normalized.contains("완행") || normalized.contains("일반")) {
+			return "LOCAL";
+		}
+		return normalized;
 	}
 
 	private List<String> warnings(String defaultCode, String fallbackCode) {

--- a/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
@@ -788,6 +788,7 @@ class RealtimeGatewayServiceTest {
 				      "trainLineNm": "오이도행 - 중앙방면",
 				      "updnLine": "하행",
 				      "btrainNo": "4001",
+				      "btrainSttus": "급행",
 				      "barvlDt": "180",
 				      "arvlMsg2": "3분 후"
 				    }
@@ -799,6 +800,7 @@ class RealtimeGatewayServiceTest {
 
 		assertThat(arrivals).hasSize(1);
 		assertThat(arrivals.get(0).destination()).isEqualTo("오이도행 - 중앙방면");
+		assertThat(arrivals.get(0).servicePattern()).isEqualTo("급행");
 	}
 
 	private RealtimeQuery sangnoksuQuery() {

--- a/backend/src/test/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolverTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/out/realtime/RealtimeGatewayArrivalResolverTest.java
@@ -32,7 +32,8 @@ class RealtimeGatewayArrivalResolverTest {
 				150,
 				"3분 후",
 				"전역 출발",
-				"2026-06-26T07:59:30Z"
+				"2026-06-26T07:59:30Z",
+				"급행"
 			))
 		));
 		RealtimeGatewayArrivalResolver resolver = new RealtimeGatewayArrivalResolver(gatewayService);
@@ -50,6 +51,7 @@ class RealtimeGatewayArrivalResolverTest {
 		ArrivalCandidate candidate = resolution.candidates().getFirst();
 		assertThat(candidate.providerReceivedAt()).isEqualTo(Instant.parse("2026-06-26T07:59:30Z"));
 		assertThat(candidate.expectedArrivalAt()).isEqualTo(Instant.parse("2026-06-26T08:02:00Z"));
+		assertThat(candidate.servicePattern()).isEqualTo("급행");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/route/domain/RealtimeEtaOverlayTest.java
+++ b/backend/src/test/java/com/easysubway/route/domain/RealtimeEtaOverlayTest.java
@@ -210,4 +210,66 @@ class RealtimeEtaOverlayTest {
 		assertThat(result.waitSeconds()).isEqualTo(90);
 		assertThat(result.trainNo()).isEqualTo("train-404");
 	}
+
+	@Test
+	@DisplayName("service pattern이 다르면 같은 방향 fresh 후보도 realtime ETA로 쓰지 않는다")
+	void freshRealtimeCandidateRequiresMatchingServicePattern() {
+		ArrivalCandidate expressCandidate = new ArrivalCandidate(
+			"train-405",
+			"seoul-4",
+			"상행",
+			"당고개",
+			90,
+			READY_AT.plusSeconds(90),
+			READY_AT.minusSeconds(20),
+			"급행",
+			ArrivalFreshness.FRESH_REALTIME,
+			EtaConfidence.HIGH
+		);
+
+		RealtimeEtaOverlay.Result result = overlay.overlay(
+			READY_AT,
+			PLANNED_WAIT_SECONDS,
+			"당고개 방면",
+			"LOCAL",
+			ArrivalFreshness.FRESH_REALTIME,
+			null,
+			List.of(expressCandidate)
+		);
+
+		assertThat(result.etaSource()).isEqualTo(EtaSource.FALLBACK);
+		assertThat(result.waitSeconds()).isEqualTo(PLANNED_WAIT_SECONDS);
+		assertThat(result.warningCodes()).containsExactly("NO_USABLE_REALTIME_CANDIDATE");
+	}
+
+	@Test
+	@DisplayName("provider raw service pattern 표기가 달라도 canonical pattern이 같으면 fresh 후보를 사용한다")
+	void freshRealtimeCandidateCanMatchCanonicalServicePattern() {
+		ArrivalCandidate expressCandidate = new ArrivalCandidate(
+			"train-406",
+			"seoul-4",
+			"상행",
+			"당고개",
+			90,
+			READY_AT.plusSeconds(90),
+			READY_AT.minusSeconds(20),
+			"급행",
+			ArrivalFreshness.FRESH_REALTIME,
+			EtaConfidence.HIGH
+		);
+
+		RealtimeEtaOverlay.Result result = overlay.overlay(
+			READY_AT,
+			PLANNED_WAIT_SECONDS,
+			"당고개 방면",
+			"EXPRESS",
+			ArrivalFreshness.FRESH_REALTIME,
+			null,
+			List.of(expressCandidate)
+		);
+
+		assertThat(result.etaSource()).isEqualTo(EtaSource.REALTIME);
+		assertThat(result.waitSeconds()).isEqualTo(90);
+		assertThat(result.trainNo()).isEqualTo("train-406");
+	}
 }


### PR DESCRIPTION
## 관련 이슈

refs #1412
refs #1414

## 작업 배경

- #1412의 남은 완료 조건 중 express/local mismatch가 같은 방향 realtime 후보를 잘못 ETA에 반영할 수 있는 위험을 닫습니다.
- TOPIS 도착 payload의 급행/완행 raw 값을 backend realtime arrival 후보까지 보존하고, overlay가 기대 service pattern을 받으면 canonical 비교로 fail-closed하도록 고정합니다.

## 작업 내용

- `RealtimeArrival`과 `ArrivalCandidate`에 `servicePattern`을 추가하고 기존 생성자 호환성을 유지했습니다.
- TOPIS `btrainSttus` 값을 arrival raw service pattern으로 보존하고, gateway ETA 보정 후에도 유지합니다.
- `RealtimeGatewayArrivalResolver`가 provider service pattern을 `ArrivalCandidate`로 전달합니다.
- `RealtimeEtaOverlay`가 expected service pattern을 받으면 `EXPRESS`/`LOCAL` canonical 비교로 mismatch 후보를 제외합니다.
- 같은 방향의 급행 후보가 planned local ETA를 덮어쓰지 않는 negative test와 raw `급행` 표기가 canonical `EXPRESS`와 매칭되는 positive test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.domain.RealtimeEtaOverlayTest --tests com.easysubway.route.adapter.out.realtime.RealtimeGatewayArrivalResolverTest --tests com.easysubway.realtime.application.RealtimeGatewayServiceTest` → pass
  - `./gradlew test` → pass
  - `git diff --check` → pass

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| realtime service pattern 후보 매칭 | backend | JUnit unit/integration tests | `./gradlew test` | pass |
| whitespace | repo | `git diff --check` | local command output | pass |
| UI/접근성 수동 QA | 해당 없음 | backend 후보 매칭 계약 변경이며 화면 변경 없음 | 필요 없음 | N/A |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: realtime 후보 overlay가 expected service pattern을 받을 때 express/local mismatch를 제외
- realtime contract: arrival/candidate servicePattern 보존
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RealtimeEtaOverlay.matchesServicePattern()`
  - `TopisRealtimeProvider.arrivalsFromPayload()`
  - `RealtimeGatewayArrivalResolver.candidate()`

## 리스크

- 기존 route search path는 아직 expected service pattern을 전달하지 않으므로 기존 사용자 동작 변화는 없습니다.
- provider raw pattern 값이 비어 있으면 expected pattern이 있는 overlay 호출에서는 realtime 후보를 사용하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
