### PR TITLE
[Fix] realtime provider trip mapping registry 추가

### DIFF
--- a/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/InMemoryRealtimeMappingPort.java
+++ b/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/InMemoryRealtimeMappingPort.java
@@ -3,6 +3,8 @@ package com.easysubway.realtime.adapter.out.persistence;
 import com.easysubway.realtime.application.RealtimeQuery;
 import com.easysubway.realtime.application.port.out.RealtimeMappingPort;
 import com.easysubway.realtime.domain.RealtimeMapping;
+import com.easysubway.realtime.domain.RealtimeTripMapping;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.context.annotation.Profile;
@@ -13,17 +15,23 @@ import org.springframework.stereotype.Repository;
 public class InMemoryRealtimeMappingPort implements RealtimeMappingPort {
 
 	private final List<RealtimeMapping> mappings;
+	private final List<RealtimeTripMapping> tripMappings;
 
 	public InMemoryRealtimeMappingPort() {
-		this(seededMappings());
+		this(seededMappings(), seededTripMappings());
 	}
 
 	InMemoryRealtimeMappingPort(List<RealtimeMapping> mappings) {
+		this(mappings, List.of());
+	}
+
+	InMemoryRealtimeMappingPort(List<RealtimeMapping> mappings, List<RealtimeTripMapping> tripMappings) {
 		this.mappings = List.copyOf(mappings);
+		this.tripMappings = List.copyOf(tripMappings);
 	}
 
 	public static InMemoryRealtimeMappingPort seededFixture() {
-		return new InMemoryRealtimeMappingPort(seededMappings());
+		return new InMemoryRealtimeMappingPort(seededMappings(), seededTripMappings());
 	}
 
 	private static List<RealtimeMapping> seededMappings() {
@@ -42,6 +50,37 @@ public class InMemoryRealtimeMappingPort implements RealtimeMappingPort {
 		));
 	}
 
+	private static List<RealtimeTripMapping> seededTripMappings() {
+		return List.of(
+			new RealtimeTripMapping(
+				"seoul-topis",
+				"seoul-4",
+				"1004",
+				"상행",
+				"당고개 방면",
+				"당고개",
+				"당고개",
+				"",
+				"",
+				"OFFICIAL",
+				1L
+			),
+			new RealtimeTripMapping(
+				"seoul-topis",
+				"seoul-4",
+				"1004",
+				"하행",
+				"오이도 방면",
+				"오이도",
+				"오이도",
+				"",
+				"",
+				"OFFICIAL",
+				1L
+			)
+		);
+	}
+
 	@Override
 	public Optional<RealtimeMapping> findArrivalMapping(String providerId, RealtimeQuery query) {
 		return mappings.stream()
@@ -57,5 +96,22 @@ public class InMemoryRealtimeMappingPort implements RealtimeMappingPort {
 			.filter((mapping) -> mapping.providerId().equals(providerId))
 			.filter((mapping) -> mapping.matchesLine(query.lineId()))
 			.findFirst();
+	}
+
+	@Override
+	public Optional<RealtimeTripMapping> findTripMapping(
+		String providerId,
+		String lineId,
+		String providerLineId,
+		String rawDirection,
+		String rawDestination,
+		String rawServicePattern
+	) {
+		return tripMappings.stream()
+			.filter((mapping) -> mapping.providerId().equals(providerId))
+			.filter((mapping) -> mapping.matchesLine(lineId, providerLineId))
+			.filter((mapping) -> mapping.matchesRaw(rawDirection, rawDestination, rawServicePattern))
+			.filter(RealtimeTripMapping::liveEligible)
+			.max(Comparator.comparingInt(RealtimeTripMapping::specificity));
 	}
 }

--- a/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepository.java
+++ b/backend/src/main/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepository.java
@@ -3,6 +3,7 @@ package com.easysubway.realtime.adapter.out.persistence;
 import com.easysubway.realtime.application.RealtimeQuery;
 import com.easysubway.realtime.application.port.out.RealtimeMappingPort;
 import com.easysubway.realtime.domain.RealtimeMapping;
+import com.easysubway.realtime.domain.RealtimeTripMapping;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Optional;
@@ -125,6 +126,60 @@ public class JdbcRealtimeMappingRepository implements RealtimeMappingPort {
 		}
 	}
 
+	@Override
+	public Optional<RealtimeTripMapping> findTripMapping(
+		String providerId,
+		String lineId,
+		String providerLineId,
+		String rawDirection,
+		String rawDestination,
+		String rawServicePattern
+	) {
+		return jdbcTemplate.query(
+			"""
+				SELECT provider_id,
+					line_id,
+					provider_line_id,
+					raw_direction,
+					canonical_direction,
+					raw_destination,
+					canonical_destination,
+					raw_service_pattern,
+					canonical_service_pattern,
+					mapping_confidence,
+					cache_version
+				FROM realtime_provider_trip_mappings
+				WHERE provider_id = ?
+					AND (? IS NULL OR ? = '' OR line_id = ? OR line_id LIKE CONCAT('%-', ?))
+					AND (? IS NULL OR ? = '' OR provider_line_id = ?)
+					AND (raw_direction = ? OR raw_direction = '')
+					AND (raw_destination = ? OR raw_destination = '')
+					AND (raw_service_pattern = ? OR raw_service_pattern = '')
+					AND mapping_confidence IN ('OFFICIAL', 'MANUAL')
+					AND (valid_from IS NULL OR valid_from <= CURRENT_TIMESTAMP)
+					AND (valid_until IS NULL OR valid_until > CURRENT_TIMESTAMP)
+				ORDER BY
+					(CASE WHEN raw_direction = '' THEN 0 ELSE 1 END
+					 + CASE WHEN raw_destination = '' THEN 0 ELSE 1 END
+					 + CASE WHEN raw_service_pattern = '' THEN 0 ELSE 1 END) DESC,
+					cache_version DESC
+				LIMIT 1
+				""",
+			this::mapTripMapping,
+			providerId,
+			lineId,
+			lineId,
+			lineId,
+			lineId,
+			providerLineId,
+			providerLineId,
+			providerLineId,
+			rawDirection,
+			rawDestination,
+			rawServicePattern
+		).stream().findFirst();
+	}
+
 	private RealtimeMapping mapMapping(ResultSet resultSet, int rowNumber) throws SQLException {
 		return new RealtimeMapping(
 			resultSet.getString("provider_id"),
@@ -136,6 +191,22 @@ public class JdbcRealtimeMappingRepository implements RealtimeMappingPort {
 			resultSet.getString("provider_line_name"),
 			resultSet.getBoolean("supports_arrivals"),
 			resultSet.getBoolean("supports_train_positions"),
+			resultSet.getString("mapping_confidence"),
+			resultSet.getLong("cache_version")
+		);
+	}
+
+	private RealtimeTripMapping mapTripMapping(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new RealtimeTripMapping(
+			resultSet.getString("provider_id"),
+			resultSet.getString("line_id"),
+			resultSet.getString("provider_line_id"),
+			resultSet.getString("raw_direction"),
+			resultSet.getString("canonical_direction"),
+			resultSet.getString("raw_destination"),
+			resultSet.getString("canonical_destination"),
+			resultSet.getString("raw_service_pattern"),
+			resultSet.getString("canonical_service_pattern"),
 			resultSet.getString("mapping_confidence"),
 			resultSet.getLong("cache_version")
 		);

--- a/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/RealtimeGatewayService.java
@@ -5,6 +5,7 @@ import com.easysubway.realtime.domain.RealtimeMapping;
 import com.easysubway.realtime.domain.RealtimeArrival;
 import com.easysubway.realtime.domain.RealtimeStatus;
 import com.easysubway.realtime.domain.RealtimeTrainPosition;
+import com.easysubway.realtime.domain.RealtimeTripMapping;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -152,7 +153,7 @@ public class RealtimeGatewayService {
 				return RealtimeArrivalResult.unavailable("EMPTY_PROVIDER_RESULT");
 			}
 			Instant receivedAt = clock.instant();
-			List<RealtimeArrival> freshArrivals = freshArrivals(arrivals, receivedAt);
+			List<RealtimeArrival> freshArrivals = freshArrivals(arrivals, receivedAt, normalizedQuery);
 			if (freshArrivals.isEmpty()) {
 				return staleArrivalOrUnavailable(cached, "PROVIDER_ERROR");
 			}
@@ -291,14 +292,19 @@ public class RealtimeGatewayService {
 		return RealtimeTrainPositionResult.unavailable(fallbackCode);
 	}
 
-	private List<RealtimeArrival> freshArrivals(List<RealtimeArrival> arrivals, Instant receivedAt) {
+	private List<RealtimeArrival> freshArrivals(
+		List<RealtimeArrival> arrivals,
+		Instant receivedAt,
+		RealtimeQuery normalizedQuery
+	) {
 		List<RealtimeArrival> freshArrivals = new ArrayList<>();
 		for (RealtimeArrival arrival : arrivals) {
 			Instant providerReceivedAt = parseProviderReceivedAt(arrival.providerReceivedAt());
 			if (providerReceivedAt == null || !isProviderFresh(providerReceivedAt, receivedAt)) {
 				continue;
 			}
-			freshArrivals.add(adjustArrivalEta(arrival, providerReceivedAt, receivedAt));
+			RealtimeArrival adjusted = adjustArrivalEta(arrival, providerReceivedAt, receivedAt);
+			freshArrivals.add(canonicalizeArrival(adjusted, normalizedQuery));
 		}
 		return List.copyOf(freshArrivals);
 	}
@@ -335,7 +341,40 @@ public class RealtimeGatewayService {
 			arrivalMessage(adjustedEtaSeconds),
 			arrival.positionMessage(),
 			arrival.providerReceivedAt(),
-			arrival.servicePattern()
+			arrival.servicePattern(),
+			arrival.rawDestination(),
+			arrival.rawDirection(),
+			arrival.rawServicePattern()
+		);
+	}
+
+	private RealtimeArrival canonicalizeArrival(RealtimeArrival arrival, RealtimeQuery normalizedQuery) {
+		return mappingPort.findTripMapping(
+			PROVIDER_ID,
+			normalizedQuery.lineId(),
+			normalizedQuery.providerLineId(),
+			arrival.rawDirection(),
+			arrival.rawDestination(),
+			arrival.rawServicePattern()
+		).map((mapping) -> mappedArrival(arrival, mapping))
+			.orElse(arrival);
+	}
+
+	private RealtimeArrival mappedArrival(RealtimeArrival arrival, RealtimeTripMapping mapping) {
+		return new RealtimeArrival(
+			arrival.lineId(),
+			arrival.stationName(),
+			mapping.canonicalDestination(arrival.destination()),
+			mapping.canonicalDirection(arrival.direction()),
+			arrival.trainNo(),
+			arrival.etaSeconds(),
+			arrival.message(),
+			arrival.positionMessage(),
+			arrival.providerReceivedAt(),
+			mapping.canonicalServicePattern(arrival.servicePattern()),
+			arrival.rawDestination(),
+			arrival.rawDirection(),
+			arrival.rawServicePattern()
 		);
 	}
 

--- a/backend/src/main/java/com/easysubway/realtime/application/port/out/RealtimeMappingPort.java
+++ b/backend/src/main/java/com/easysubway/realtime/application/port/out/RealtimeMappingPort.java
@@ -2,10 +2,20 @@ package com.easysubway.realtime.application.port.out;
 
 import com.easysubway.realtime.application.RealtimeQuery;
 import com.easysubway.realtime.domain.RealtimeMapping;
+import com.easysubway.realtime.domain.RealtimeTripMapping;
 import java.util.Optional;
 
 public interface RealtimeMappingPort {
 	Optional<RealtimeMapping> findArrivalMapping(String providerId, RealtimeQuery query);
 
 	Optional<RealtimeMapping> findTrainPositionMapping(String providerId, RealtimeQuery query);
+
+	Optional<RealtimeTripMapping> findTripMapping(
+		String providerId,
+		String lineId,
+		String providerLineId,
+		String rawDirection,
+		String rawDestination,
+		String rawServicePattern
+	);
 }

--- a/backend/src/main/java/com/easysubway/realtime/domain/RealtimeArrival.java
+++ b/backend/src/main/java/com/easysubway/realtime/domain/RealtimeArrival.java
@@ -10,8 +10,46 @@ public record RealtimeArrival(
 	String message,
 	String positionMessage,
 	String providerReceivedAt,
-	String servicePattern
+	String servicePattern,
+	String rawDestination,
+	String rawDirection,
+	String rawServicePattern
 ) {
+	public RealtimeArrival {
+		rawDestination = rawDestination == null ? destination : rawDestination;
+		rawDirection = rawDirection == null ? direction : rawDirection;
+		rawServicePattern = rawServicePattern == null ? servicePattern : rawServicePattern;
+	}
+
+	public RealtimeArrival(
+		String lineId,
+		String stationName,
+		String destination,
+		String direction,
+		String trainNo,
+		Integer etaSeconds,
+		String message,
+		String positionMessage,
+		String providerReceivedAt,
+		String servicePattern
+	) {
+		this(
+			lineId,
+			stationName,
+			destination,
+			direction,
+			trainNo,
+			etaSeconds,
+			message,
+			positionMessage,
+			providerReceivedAt,
+			servicePattern,
+			destination,
+			direction,
+			servicePattern
+		);
+	}
+
 	public RealtimeArrival(
 		String lineId,
 		String stationName,
@@ -33,6 +71,9 @@ public record RealtimeArrival(
 			message,
 			positionMessage,
 			providerReceivedAt,
+			null,
+			destination,
+			direction,
 			null
 		);
 	}

--- a/backend/src/main/java/com/easysubway/realtime/domain/RealtimeTripMapping.java
+++ b/backend/src/main/java/com/easysubway/realtime/domain/RealtimeTripMapping.java
@@ -1,0 +1,70 @@
+package com.easysubway.realtime.domain;
+
+public record RealtimeTripMapping(
+	String providerId,
+	String lineId,
+	String providerLineId,
+	String rawDirection,
+	String canonicalDirection,
+	String rawDestination,
+	String canonicalDestination,
+	String rawServicePattern,
+	String canonicalServicePattern,
+	String mappingConfidence,
+	long cacheVersion
+) {
+	public boolean liveEligible() {
+		return "OFFICIAL".equals(mappingConfidence) || "MANUAL".equals(mappingConfidence);
+	}
+
+	public String canonicalDirection(String fallback) {
+		return canonicalOrFallback(canonicalDirection, fallback);
+	}
+
+	public String canonicalDestination(String fallback) {
+		return canonicalOrFallback(canonicalDestination, fallback);
+	}
+
+	public String canonicalServicePattern(String fallback) {
+		return canonicalOrFallback(canonicalServicePattern, fallback);
+	}
+
+	public boolean matchesLine(String requestedLineId, String requestedProviderLineId) {
+		if (requestedProviderLineId != null && !requestedProviderLineId.isBlank()
+			&& !providerLineId.equals(requestedProviderLineId)) {
+			return false;
+		}
+		if (requestedLineId == null || requestedLineId.isBlank()) {
+			return true;
+		}
+		return lineId.equals(requestedLineId) || lineId.endsWith("-" + requestedLineId);
+	}
+
+	public boolean matchesRaw(String direction, String destination, String servicePattern) {
+		return rawMatches(rawDirection, direction)
+			&& rawMatches(rawDestination, destination)
+			&& rawMatches(rawServicePattern, servicePattern);
+	}
+
+	public int specificity() {
+		int specificity = 0;
+		if (rawDirection != null && !rawDirection.isBlank()) {
+			specificity += 1;
+		}
+		if (rawDestination != null && !rawDestination.isBlank()) {
+			specificity += 1;
+		}
+		if (rawServicePattern != null && !rawServicePattern.isBlank()) {
+			specificity += 1;
+		}
+		return specificity;
+	}
+
+	private boolean rawMatches(String expected, String actual) {
+		return expected == null || expected.isBlank() || expected.equals(actual);
+	}
+
+	private String canonicalOrFallback(String canonical, String fallback) {
+		return canonical == null || canonical.isBlank() ? fallback : canonical;
+	}
+}

--- a/backend/src/main/resources/db/migration/h2/V34__realtime_provider_trip_mappings.sql
+++ b/backend/src/main/resources/db/migration/h2/V34__realtime_provider_trip_mappings.sql
@@ -1,0 +1,50 @@
+CREATE TABLE IF NOT EXISTS realtime_provider_trip_mappings (
+  provider_id CHARACTER VARYING(80) NOT NULL,
+  provider_line_id CHARACTER VARYING(80) NOT NULL,
+  line_id CHARACTER VARYING(80) NOT NULL,
+  raw_direction CHARACTER VARYING(120) DEFAULT '' NOT NULL,
+  canonical_direction CHARACTER VARYING(120) DEFAULT '' NOT NULL,
+  raw_destination CHARACTER VARYING(120) DEFAULT '' NOT NULL,
+  canonical_destination CHARACTER VARYING(120) DEFAULT '' NOT NULL,
+  raw_service_pattern CHARACTER VARYING(80) DEFAULT '' NOT NULL,
+  canonical_service_pattern CHARACTER VARYING(80) DEFAULT '' NOT NULL,
+  mapping_confidence CHARACTER VARYING(40) DEFAULT 'UNKNOWN' NOT NULL,
+  valid_from TIMESTAMP WITH TIME ZONE,
+  valid_until TIMESTAMP WITH TIME ZONE,
+  cache_version BIGINT DEFAULT 1 NOT NULL,
+  PRIMARY KEY (
+    provider_id,
+    provider_line_id,
+    raw_direction,
+    raw_destination,
+    raw_service_pattern
+  ),
+  FOREIGN KEY (provider_id, provider_line_id) REFERENCES realtime_provider_line_mappings(provider_id, provider_line_id),
+  CONSTRAINT h2_realtime_trip_mapping_confidence CHECK (mapping_confidence IN ('OFFICIAL', 'MANUAL', 'HEURISTIC', 'UNKNOWN')),
+  CONSTRAINT h2_realtime_trip_cache_version CHECK (cache_version > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_realtime_provider_trip_canonical
+  ON realtime_provider_trip_mappings(provider_id, line_id, provider_line_id);
+
+MERGE INTO realtime_provider_trip_mappings (
+  provider_id,
+  provider_line_id,
+  line_id,
+  raw_direction,
+  canonical_direction,
+  raw_destination,
+  canonical_destination,
+  raw_service_pattern,
+  canonical_service_pattern,
+  mapping_confidence,
+  cache_version
+) KEY (
+  provider_id,
+  provider_line_id,
+  raw_direction,
+  raw_destination,
+  raw_service_pattern
+) VALUES
+  ('seoul-topis', '1004', 'seoul-4', '상행', '당고개 방면', '당고개', '당고개', '', '', 'OFFICIAL', 1),
+  ('seoul-topis', '1004', 'seoul-4', '하행', '오이도 방면', '오이도', '오이도', '', '', 'OFFICIAL', 1);

--- a/backend/src/main/resources/db/migration/postgresql/V34__realtime_provider_trip_mappings.sql
+++ b/backend/src/main/resources/db/migration/postgresql/V34__realtime_provider_trip_mappings.sql
@@ -1,0 +1,51 @@
+CREATE TABLE IF NOT EXISTS realtime_provider_trip_mappings (
+  provider_id VARCHAR(80) NOT NULL,
+  provider_line_id VARCHAR(80) NOT NULL,
+  line_id VARCHAR(80) NOT NULL,
+  raw_direction VARCHAR(120) NOT NULL DEFAULT '',
+  canonical_direction VARCHAR(120) NOT NULL DEFAULT '',
+  raw_destination VARCHAR(120) NOT NULL DEFAULT '',
+  canonical_destination VARCHAR(120) NOT NULL DEFAULT '',
+  raw_service_pattern VARCHAR(80) NOT NULL DEFAULT '',
+  canonical_service_pattern VARCHAR(80) NOT NULL DEFAULT '',
+  mapping_confidence VARCHAR(40) NOT NULL DEFAULT 'UNKNOWN',
+  valid_from TIMESTAMPTZ,
+  valid_until TIMESTAMPTZ,
+  cache_version BIGINT NOT NULL DEFAULT 1,
+  PRIMARY KEY (
+    provider_id,
+    provider_line_id,
+    raw_direction,
+    raw_destination,
+    raw_service_pattern
+  ),
+  FOREIGN KEY (provider_id, provider_line_id) REFERENCES realtime_provider_line_mappings(provider_id, provider_line_id),
+  CONSTRAINT chk_realtime_trip_mapping_confidence CHECK (mapping_confidence IN ('OFFICIAL', 'MANUAL', 'HEURISTIC', 'UNKNOWN')),
+  CONSTRAINT chk_realtime_trip_cache_version CHECK (cache_version > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_realtime_provider_trip_canonical
+  ON realtime_provider_trip_mappings(provider_id, line_id, provider_line_id);
+
+INSERT INTO realtime_provider_trip_mappings (
+  provider_id,
+  provider_line_id,
+  line_id,
+  raw_direction,
+  canonical_direction,
+  raw_destination,
+  canonical_destination,
+  raw_service_pattern,
+  canonical_service_pattern,
+  mapping_confidence,
+  cache_version
+) VALUES
+  ('seoul-topis', '1004', 'seoul-4', '상행', '당고개 방면', '당고개', '당고개', '', '', 'OFFICIAL', 1),
+  ('seoul-topis', '1004', 'seoul-4', '하행', '오이도 방면', '오이도', '오이도', '', '', 'OFFICIAL', 1)
+ON CONFLICT (
+  provider_id,
+  provider_line_id,
+  raw_direction,
+  raw_destination,
+  raw_service_pattern
+) DO NOTHING;

--- a/backend/src/test/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepositoryTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/adapter/out/persistence/JdbcRealtimeMappingRepositoryTest.java
@@ -23,6 +23,7 @@ class JdbcRealtimeMappingRepositoryTest {
 			""
 		);
 		jdbcTemplate = new JdbcTemplate(dataSource);
+		jdbcTemplate.execute("DROP TABLE IF EXISTS realtime_provider_trip_mappings");
 		jdbcTemplate.execute("DROP TABLE IF EXISTS realtime_provider_station_mappings");
 		jdbcTemplate.execute("DROP TABLE IF EXISTS realtime_provider_line_mappings");
 		jdbcTemplate.execute("""
@@ -59,6 +60,30 @@ class JdbcRealtimeMappingRepositoryTest {
 				UNIQUE (provider_id, line_id, station_id)
 			)
 			""");
+		jdbcTemplate.execute("""
+			CREATE TABLE realtime_provider_trip_mappings (
+				provider_id VARCHAR(80) NOT NULL,
+				provider_line_id VARCHAR(80) NOT NULL,
+				line_id VARCHAR(80) NOT NULL,
+				raw_direction VARCHAR(120) NOT NULL DEFAULT '',
+				canonical_direction VARCHAR(120) NOT NULL DEFAULT '',
+				raw_destination VARCHAR(120) NOT NULL DEFAULT '',
+				canonical_destination VARCHAR(120) NOT NULL DEFAULT '',
+				raw_service_pattern VARCHAR(80) NOT NULL DEFAULT '',
+				canonical_service_pattern VARCHAR(80) NOT NULL DEFAULT '',
+				mapping_confidence VARCHAR(40) NOT NULL,
+				valid_from TIMESTAMP,
+				valid_until TIMESTAMP,
+				cache_version BIGINT NOT NULL,
+				PRIMARY KEY (
+					provider_id,
+					provider_line_id,
+					raw_direction,
+					raw_destination,
+					raw_service_pattern
+				)
+			)
+			""");
 		jdbcTemplate.update("""
 			INSERT INTO realtime_provider_line_mappings (
 				provider_id, provider_line_id, line_id, provider_line_name,
@@ -72,6 +97,13 @@ class JdbcRealtimeMappingRepositoryTest {
 				supports_arrivals, supports_train_positions, mapping_confidence, cache_version
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			""", "seoul-topis", "1004", "1004000448", "station-sangnoksu", "seoul-4", "상록수", true, true, "OFFICIAL", 8L);
+		jdbcTemplate.update("""
+			INSERT INTO realtime_provider_trip_mappings (
+				provider_id, provider_line_id, line_id, raw_direction, canonical_direction,
+				raw_destination, canonical_destination, raw_service_pattern, canonical_service_pattern,
+				mapping_confidence, valid_from, valid_until, cache_version
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?)
+			""", "seoul-topis", "1004", "seoul-4", "상행", "당고개 방면", "당고개", "당고개", "", "", "OFFICIAL", 9L);
 		repository = new JdbcRealtimeMappingRepository(jdbcTemplate);
 	}
 
@@ -208,5 +240,46 @@ class JdbcRealtimeMappingRepositoryTest {
 			assertThat(value.liveEligible()).isFalse();
 			assertThat(value.ineligibleReason()).isEqualTo("MAPPING_LOW_CONFIDENCE");
 		});
+	}
+
+	@Test
+	@DisplayName("trip mapping은 provider raw direction/destination을 canonical 값으로 조회한다")
+	void findTripMappingByProviderRawDirectionDestination() {
+		var mapping = repository.findTripMapping(
+			"seoul-topis",
+			"seoul-4",
+			"1004",
+			"상행",
+			"당고개",
+			null
+		);
+
+		assertThat(mapping).hasValueSatisfying((value) -> {
+			assertThat(value.canonicalDirection()).isEqualTo("당고개 방면");
+			assertThat(value.canonicalDestination()).isEqualTo("당고개");
+			assertThat(value.rawDirection()).isEqualTo("상행");
+			assertThat(value.cacheVersion()).isEqualTo(9L);
+		});
+	}
+
+	@Test
+	@DisplayName("trip mapping은 HEURISTIC raw mapping을 production canonical 후보로 쓰지 않는다")
+	void findTripMappingIgnoresLowConfidenceRows() {
+		jdbcTemplate.update("""
+			UPDATE realtime_provider_trip_mappings
+			SET mapping_confidence = 'HEURISTIC'
+			WHERE provider_id = 'seoul-topis'
+			""");
+
+		var mapping = repository.findTripMapping(
+			"seoul-topis",
+			"seoul-4",
+			"1004",
+			"상행",
+			"당고개",
+			null
+		);
+
+		assertThat(mapping).isEmpty();
 	}
 }

--- a/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
+++ b/backend/src/test/java/com/easysubway/realtime/application/RealtimeGatewayServiceTest.java
@@ -8,6 +8,7 @@ import com.easysubway.realtime.application.port.out.RealtimeMappingPort;
 import com.easysubway.realtime.domain.RealtimeMapping;
 import com.easysubway.realtime.domain.RealtimeArrival;
 import com.easysubway.realtime.domain.RealtimeTrainPosition;
+import com.easysubway.realtime.domain.RealtimeTripMapping;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.time.Clock;
@@ -162,6 +163,25 @@ class RealtimeGatewayServiceTest {
 		assertThat(result.status()).hasToString("FRESH");
 		assertThat(result.arrivals().get(0).etaSeconds()).isEqualTo(150);
 		assertThat(result.arrivals().get(0).message()).isEqualTo("3분 후");
+	}
+
+	@Test
+	@DisplayName("provider raw trip 표기는 canonical 값으로 변환하되 raw evidence도 보존한다")
+	void arrivalTripMappingCanonicalizesDirectionAndPreservesRawEvidence() {
+		CountingProvider provider = new CountingProvider();
+		RealtimeGatewayService service = service(
+			provider,
+			Clock.fixed(Instant.parse("2026-06-26T08:00:00Z"), ZoneOffset.UTC)
+		);
+
+		RealtimeArrivalResult result = service.arrivals(sangnoksuQuery());
+
+		assertThat(result.status()).hasToString("FRESH");
+		RealtimeArrival arrival = result.arrivals().getFirst();
+		assertThat(arrival.direction()).isEqualTo("당고개 방면");
+		assertThat(arrival.destination()).isEqualTo("당고개");
+		assertThat(arrival.rawDirection()).isEqualTo("상행");
+		assertThat(arrival.rawDestination()).isEqualTo("당고개");
 	}
 
 	@Test
@@ -865,6 +885,7 @@ class RealtimeGatewayServiceTest {
 
 	private static final class StubMappingPort implements RealtimeMappingPort {
 		private final Map<String, RealtimeMapping> mappings = new HashMap<>();
+		private final Map<String, RealtimeTripMapping> tripMappings = new HashMap<>();
 
 		private void add(RealtimeMapping mapping) {
 			mappings.put(arrivalKey(mapping.stationId(), mapping.lineId()), mapping);
@@ -880,6 +901,19 @@ class RealtimeGatewayServiceTest {
 		@Override
 		public Optional<RealtimeMapping> findTrainPositionMapping(String providerId, RealtimeQuery query) {
 			return Optional.ofNullable(mappings.get(lineKey(query.lineId())))
+				.filter((mapping) -> providerId.equals(mapping.providerId()));
+		}
+
+		@Override
+		public Optional<RealtimeTripMapping> findTripMapping(
+			String providerId,
+			String lineId,
+			String providerLineId,
+			String rawDirection,
+			String rawDestination,
+			String rawServicePattern
+		) {
+			return Optional.ofNullable(tripMappings.get("%s:%s:%s".formatted(lineId, rawDirection, rawDestination)))
 				.filter((mapping) -> providerId.equals(mapping.providerId()));
 		}
 


### PR DESCRIPTION
## 관련 이슈

close #1412

## 작업 배경

- #1412의 남은 범위 중 provider별 direction/headsign/service pattern canonical mapping을 코드 수정 없이 확장할 수 있는 registry가 필요했습니다.
- 기존 gateway는 provider raw direction/destination/servicePattern을 그대로 후보에 싣기 때문에 운영기관별 표기 차이가 route ETA 후보 매칭 품질에 직접 영향을 줄 수 있었습니다.

## 작업 내용

- `RealtimeTripMapping`과 `RealtimeMappingPort.findTripMapping(...)`을 추가해 provider raw trip 표기를 canonical direction/destination/servicePattern으로 변환합니다.
- `realtime_provider_trip_mappings` Flyway migration을 H2/PostgreSQL 양쪽에 추가하고 서울 TOPIS 4호선 기본 방향 seed를 넣었습니다.
- `RealtimeArrival`에 canonical 필드와 raw evidence 필드를 함께 보존하도록 확장했습니다.
- gateway fresh arrival 처리에서 provider timestamp ETA 조정 후 trip mapping을 적용합니다.
- JDBC/in-memory mapping repository와 서비스 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.realtime.adapter.out.persistence.JdbcRealtimeMappingRepositoryTest --tests com.easysubway.realtime.application.RealtimeGatewayServiceTest --tests com.easysubway.route.adapter.out.realtime.RealtimeGatewayArrivalResolverTest --tests com.easysubway.route.domain.RealtimeEtaOverlayTest` 성공
  - `./gradlew test --tests com.easysubway.common.persistence.DatabaseMigrationContainerTest` 성공
  - `./gradlew test` 성공
  - `git diff --check` 성공
- PR CI: CI run `28610982303` 성공, Release Artifacts run `28610589438` 성공, SonarCloud run `28610589954` 성공
- Code review: CodeRabbit은 rate limit으로 PR Review 객체 없음, Codex fallback review `4620011159` 게시
- Post-merge: main CI run `28611280252` 성공, Release Artifacts run `28611279756` 성공, SonarCloud run `28611279683` 성공, CD run `28611565559` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| trip mapping canonicalization | Backend | `RealtimeGatewayServiceTest` | local Gradle test output | 통과 |
| JDBC/Flyway schema | Backend | `JdbcRealtimeMappingRepositoryTest`, `DatabaseMigrationContainerTest` | local Gradle test output | 통과 |
| 전체 회귀 | Backend | `./gradlew test` | local Gradle test output | 통과 |
| UI/접근성 증거 | Mobile | backend realtime mapping registry 변경이라 화면 변경 없음 | 해당 없음 | 해당 없음 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [x] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: provider trip canonical/raw evidence 보존
- realtime contract: provider trip mapping registry와 raw/canonical arrival evidence 보존
- backend identity: DB migration V34 추가

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RealtimeGatewayService.canonicalizeArrival(...)`
  - `JdbcRealtimeMappingRepository.findTripMapping(...)`
  - `V34__realtime_provider_trip_mappings.sql`

## 리스크

- DB migration이 추가됩니다. 기존 line mapping에 FK로 붙는 registry라, seed는 기존 `seoul-topis`/`1004` line mapping 이후 실행되어야 합니다.
- mapping이 없거나 confidence가 낮으면 기존 raw 값을 그대로 유지하므로 실시간 후보를 잘못 canonical으로 승격하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
