### PR TITLE
[Fix] route v2 production planner port 분리

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -238,7 +238,9 @@ class RouteSearchController {
 				Boolean.TRUE.equals(request.useRealtime()),
 				request.maxTransfers(),
 				request.alternativeCount(),
-				plan.statuses(),
+				plan.statuses().stream()
+					.map(Enum::name)
+					.toList(),
 				plan.itineraries().stream()
 					.map(result -> ItineraryDto.from(result, departureTime))
 					.toList()

--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -5,8 +5,8 @@ import com.easysubway.common.web.ApiResponse;
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
-import com.easysubway.route.application.service.RouteV2Planner;
-import com.easysubway.route.application.service.RouteV2Planner.RouteV2Plan;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Plan;
 import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.EtaConfidence;
 import com.easysubway.route.domain.EtaSource;
@@ -39,11 +39,11 @@ import org.springframework.web.bind.annotation.RestController;
 class RouteSearchController {
 
 	private final RouteSearchUseCase routeSearchUseCase;
-	private final RouteV2Planner routeV2Planner;
+	private final RouteV2SearchUseCase routeV2SearchUseCase;
 
-	RouteSearchController(RouteSearchUseCase routeSearchUseCase, RouteV2Planner routeV2Planner) {
+	RouteSearchController(RouteSearchUseCase routeSearchUseCase, RouteV2SearchUseCase routeV2SearchUseCase) {
 		this.routeSearchUseCase = routeSearchUseCase;
-		this.routeV2Planner = routeV2Planner;
+		this.routeV2SearchUseCase = routeV2SearchUseCase;
 	}
 
 	@PostMapping("/api/v1/routes/search")
@@ -54,7 +54,7 @@ class RouteSearchController {
 	@PostMapping("/api/v2/routes/search")
 	ApiResponse<RouteSearchV2Response> searchRouteV2(@Valid @RequestBody RouteSearchV2Request request) {
 		OffsetDateTime departureTime = request.parsedDepartureTime();
-		RouteV2Plan plan = routeV2Planner.search(request.toV2Command(departureTime));
+		RouteV2Plan plan = routeV2SearchUseCase.search(request.toV2Command(departureTime));
 		return ApiResponse.ok(RouteSearchV2Response.from(plan, request, departureTime));
 	}
 
@@ -161,8 +161,8 @@ class RouteSearchController {
 		int alternativeCount
 	) {
 
-		RouteV2Planner.SearchRouteV2Command toV2Command(OffsetDateTime departureTime) {
-			return new RouteV2Planner.SearchRouteV2Command(
+		RouteV2SearchUseCase.SearchRouteV2Command toV2Command(OffsetDateTime departureTime) {
+			return new RouteV2SearchUseCase.SearchRouteV2Command(
 				originStationId,
 				destinationStationId,
 				departureTime,

--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteV2SearchUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteV2SearchUseCase.java
@@ -5,6 +5,7 @@ import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.RouteSearchResult;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 
 public interface RouteV2SearchUseCase {
 
@@ -20,12 +21,46 @@ public interface RouteV2SearchUseCase {
 		int maxTransfers,
 		int alternativeCount
 	) {
+		public SearchRouteV2Command {
+			requireText(originStationId, "originStationId");
+			requireText(destinationStationId, "destinationStationId");
+			Objects.requireNonNull(departureTime, "departureTime must not be null");
+			Objects.requireNonNull(mobilityType, "mobilityType must not be null");
+			Objects.requireNonNull(constraintMode, "constraintMode must not be null");
+			if (maxTransfers < 0) {
+				throw new IllegalArgumentException("maxTransfers must not be negative");
+			}
+			if (maxTransfers > 3) {
+				throw new IllegalArgumentException("maxTransfers must be 3 or less");
+			}
+			if (alternativeCount < 1) {
+				throw new IllegalArgumentException("alternativeCount must be at least 1");
+			}
+		}
 	}
 
 	record RouteV2Plan(
 		List<RouteSearchResult> itineraries,
-		List<String> statuses,
+		List<RouteV2Status> statuses,
 		String plannerAdr
 	) {
+		public RouteV2Plan {
+			itineraries = List.copyOf(Objects.requireNonNull(itineraries, "itineraries must not be null"));
+			statuses = List.copyOf(Objects.requireNonNull(statuses, "statuses must not be null"));
+			Objects.requireNonNull(plannerAdr, "plannerAdr must not be null");
+		}
+	}
+
+	enum RouteV2Status {
+		FOUND,
+		BLOCKED_ACCESSIBILITY,
+		NO_TIMETABLE_SERVICE,
+		REALTIME_UNAVAILABLE_PLANNED_USED
+	}
+
+	private static void requireText(String value, String fieldName) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(fieldName + " must not be blank");
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/port/in/RouteV2SearchUseCase.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/in/RouteV2SearchUseCase.java
@@ -1,0 +1,31 @@
+package com.easysubway.route.application.port.in;
+
+import com.easysubway.profile.domain.MobilityType;
+import com.easysubway.route.domain.ConstraintMode;
+import com.easysubway.route.domain.RouteSearchResult;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public interface RouteV2SearchUseCase {
+
+	RouteV2Plan search(SearchRouteV2Command command);
+
+	record SearchRouteV2Command(
+		String originStationId,
+		String destinationStationId,
+		OffsetDateTime departureTime,
+		MobilityType mobilityType,
+		ConstraintMode constraintMode,
+		boolean useRealtime,
+		int maxTransfers,
+		int alternativeCount
+	) {
+	}
+
+	record RouteV2Plan(
+		List<RouteSearchResult> itineraries,
+		List<String> statuses,
+		String plannerAdr
+	) {
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -1,20 +1,20 @@
 package com.easysubway.route.application.service;
 
-import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
-import com.easysubway.route.domain.ConstraintMode;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase.SearchRouteV2Command;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Plan;
 import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
 @Service
-public class RouteV2Planner {
+public class RouteV2Planner implements RouteV2SearchUseCase {
 
 	private static final String PLANNER_ADR = "tools/routes/route-algorithm-v2-adr.json";
 
@@ -24,9 +24,10 @@ public class RouteV2Planner {
 		this.routeSearchUseCase = routeSearchUseCase;
 	}
 
+	@Override
 	public RouteV2Plan search(SearchRouteV2Command command) {
 		try {
-			SearchRouteCommand searchRouteCommand = command.toSearchRouteCommand();
+			SearchRouteCommand searchRouteCommand = toSearchRouteCommand(command);
 			List<RouteSearchResult> itineraries = routeSearchUseCase.searchRouteAlternatives(
 				searchRouteCommand,
 				command.alternativeCount()
@@ -65,34 +66,15 @@ public class RouteV2Planner {
 		return itinerary.status() == RouteSearchStatus.BLOCKED ? "BLOCKED_ACCESSIBILITY" : itinerary.status().name();
 	}
 
-	public record SearchRouteV2Command(
-		String originStationId,
-		String destinationStationId,
-		OffsetDateTime departureTime,
-		MobilityType mobilityType,
-		ConstraintMode constraintMode,
-		boolean useRealtime,
-		int maxTransfers,
-		int alternativeCount
-	) {
-
-		private SearchRouteCommand toSearchRouteCommand() {
-			return new SearchRouteCommand(
-				originStationId,
-				destinationStationId,
-				mobilityType,
-				constraintMode,
-				maxTransfers,
-				departureTime,
-				useRealtime
-			);
-		}
-	}
-
-	public record RouteV2Plan(
-		List<RouteSearchResult> itineraries,
-		List<String> statuses,
-		String plannerAdr
-	) {
+	private SearchRouteCommand toSearchRouteCommand(SearchRouteV2Command command) {
+		return new SearchRouteCommand(
+			command.originStationId(),
+			command.destinationStationId(),
+			command.mobilityType(),
+			command.constraintMode(),
+			command.maxTransfers(),
+			command.departureTime(),
+			command.useRealtime()
+		);
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -5,6 +5,7 @@ import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase.SearchRouteV2Command;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Plan;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Status;
 import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteSearchResult;
@@ -38,16 +39,16 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 				PLANNER_ADR
 			);
 		} catch (RouteNotFoundException exception) {
-			return new RouteV2Plan(List.of(), List.of("NO_TIMETABLE_SERVICE"), PLANNER_ADR);
+			return new RouteV2Plan(List.of(), List.of(RouteV2Status.NO_TIMETABLE_SERVICE), PLANNER_ADR);
 		}
 	}
 
-	private List<String> statusesOf(List<RouteSearchResult> itineraries, boolean useRealtime) {
-		List<String> statuses = new ArrayList<>();
+	private List<RouteV2Status> statusesOf(List<RouteSearchResult> itineraries, boolean useRealtime) {
+		List<RouteV2Status> statuses = new ArrayList<>();
 		for (RouteSearchResult itinerary : itineraries) {
 			statuses.add(statusOf(itinerary));
 			if (usesPlannedEtaAfterRealtimeRequest(itinerary, useRealtime)) {
-				statuses.add("REALTIME_UNAVAILABLE_PLANNED_USED");
+				statuses.add(RouteV2Status.REALTIME_UNAVAILABLE_PLANNED_USED);
 			}
 		}
 		return List.copyOf(statuses.stream().distinct().toList());
@@ -62,8 +63,10 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 			|| itinerary.etaSource() == EtaSource.FALLBACK;
 	}
 
-	private String statusOf(RouteSearchResult itinerary) {
-		return itinerary.status() == RouteSearchStatus.BLOCKED ? "BLOCKED_ACCESSIBILITY" : itinerary.status().name();
+	private RouteV2Status statusOf(RouteSearchResult itinerary) {
+		return itinerary.status() == RouteSearchStatus.BLOCKED
+			? RouteV2Status.BLOCKED_ACCESSIBILITY
+			: RouteV2Status.valueOf(itinerary.status().name());
 	}
 
 	private SearchRouteCommand toSearchRouteCommand(SearchRouteV2Command command) {

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -9,6 +9,7 @@ import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepositor
 import com.easysubway.route.application.port.in.SearchInternalRouteCommand;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Status;
 import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
 import com.easysubway.route.application.port.out.RealtimeArrivalResolver;
 import com.easysubway.route.domain.ArrivalCandidate;
@@ -721,7 +722,7 @@ class RouteSearchServiceTest {
 
 		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 0, 3));
 
-		assertThat(plan.statuses()).containsExactly("FOUND");
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
 		assertThat(plan.itineraries()).hasSize(1);
 		assertThat(plan.itineraries().getFirst().transferCount()).isZero();
 	}
@@ -735,7 +736,7 @@ class RouteSearchServiceTest {
 
 		assertThat(plan.plannerAdr()).isEqualTo("tools/routes/route-algorithm-v2-adr.json");
 		assertThat(plan.itineraries()).hasSize(2);
-		assertThat(plan.statuses()).containsExactly("FOUND", "BLOCKED_ACCESSIBILITY");
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND, RouteV2Status.BLOCKED_ACCESSIBILITY);
 		assertThat(plan.itineraries())
 			.extracting(RouteSearchResult::status)
 			.containsExactly(RouteSearchStatus.FOUND, RouteSearchStatus.BLOCKED);
@@ -748,7 +749,7 @@ class RouteSearchServiceTest {
 
 		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
 
-		assertThat(plan.statuses()).containsExactly("FOUND");
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
 		assertThat(plan.itineraries()).hasSize(1);
 		assertThat(plan.itineraries().getFirst().transferCount()).isEqualTo(1);
 	}
@@ -760,7 +761,7 @@ class RouteSearchServiceTest {
 
 		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 2, 3));
 
-		assertThat(plan.statuses()).containsExactly("FOUND");
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
 		assertThat(plan.itineraries()).hasSize(1);
 		assertThat(plan.itineraries().getFirst().transferCount()).isEqualTo(2);
 	}
@@ -772,7 +773,7 @@ class RouteSearchServiceTest {
 
 		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
 
-		assertThat(plan.statuses()).containsExactly("NO_TIMETABLE_SERVICE");
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.NO_TIMETABLE_SERVICE);
 		assertThat(plan.itineraries()).isEmpty();
 	}
 
@@ -783,7 +784,7 @@ class RouteSearchServiceTest {
 
 		var plan = planner.search(routeV2Command(ConstraintMode.STRICT_STEP_FREE, MobilityType.WHEELCHAIR, 0, 3));
 
-		assertThat(plan.statuses()).containsExactly("BLOCKED_ACCESSIBILITY");
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.BLOCKED_ACCESSIBILITY);
 		assertThat(plan.itineraries()).hasSize(1);
 		assertThat(plan.itineraries().getFirst().status()).isEqualTo(RouteSearchStatus.BLOCKED);
 	}
@@ -821,7 +822,7 @@ class RouteSearchServiceTest {
 			.filteredOn(step -> "ride".equals(step.stepType()))
 			.extracting("timeSource")
 			.containsExactly(EtaSource.REALTIME.name());
-		assertThat(plan.statuses()).containsExactly("FOUND");
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
 	}
 
 	@Test
@@ -851,7 +852,7 @@ class RouteSearchServiceTest {
 
 		assertThat(resolver.callCount()).isZero();
 		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.STATIC_BACKEND_ESTIMATE);
-		assertThat(plan.statuses()).containsExactly("FOUND");
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
 	}
 
 	@Test
@@ -885,7 +886,22 @@ class RouteSearchServiceTest {
 		));
 
 		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.FALLBACK);
-		assertThat(plan.statuses()).containsExactly("FOUND", "REALTIME_UNAVAILABLE_PLANNED_USED");
+		assertThat(plan.statuses())
+			.containsExactly(RouteV2Status.FOUND, RouteV2Status.REALTIME_UNAVAILABLE_PLANNED_USED);
+	}
+
+	@Test
+	@DisplayName("V2 search port command는 adapter를 우회한 잘못된 planner 조건을 거부한다")
+	void routeV2SearchCommandRejectsInvalidPlannerBounds() {
+		assertThatThrownBy(() -> routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, -1, 1))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("maxTransfers must not be negative");
+		assertThatThrownBy(() -> routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 4, 1))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("maxTransfers must be 3 or less");
+		assertThatThrownBy(() -> routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 0))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("alternativeCount must be at least 1");
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -8,6 +8,7 @@ import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.adapter.out.persistence.InMemoryRouteSearchRepository;
 import com.easysubway.route.application.port.in.SearchInternalRouteCommand;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
+import com.easysubway.route.application.port.in.RouteV2SearchUseCase;
 import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
 import com.easysubway.route.application.port.out.RealtimeArrivalResolver;
 import com.easysubway.route.domain.ArrivalCandidate;
@@ -801,7 +802,7 @@ class RouteSearchServiceTest {
 		);
 		var planner = new RouteV2Planner(routeSearchService);
 
-		var plan = planner.search(new RouteV2Planner.SearchRouteV2Command(
+		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
 			"station-a",
 			"station-b",
 			OffsetDateTime.parse("2026-07-01T09:00:00+09:00"),
@@ -837,7 +838,7 @@ class RouteSearchServiceTest {
 		);
 		var planner = new RouteV2Planner(routeSearchService);
 
-		var plan = planner.search(new RouteV2Planner.SearchRouteV2Command(
+		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
 			"station-a",
 			"station-b",
 			OffsetDateTime.parse("2026-07-01T09:00:00+09:00"),
@@ -872,7 +873,7 @@ class RouteSearchServiceTest {
 		);
 		var planner = new RouteV2Planner(routeSearchService);
 
-		var plan = planner.search(new RouteV2Planner.SearchRouteV2Command(
+		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
 			"station-a",
 			"station-b",
 			OffsetDateTime.parse("2026-07-01T09:00:00+09:00"),
@@ -1557,13 +1558,13 @@ class RouteSearchServiceTest {
 		return new RouteV2Planner(new RouteSearchService(repository, repository, transitMasterPort, CLOCK));
 	}
 
-	private static RouteV2Planner.SearchRouteV2Command routeV2Command(
+	private static RouteV2SearchUseCase.SearchRouteV2Command routeV2Command(
 		ConstraintMode constraintMode,
 		MobilityType mobilityType,
 		int maxTransfers,
 		int alternativeCount
 	) {
-		return new RouteV2Planner.SearchRouteV2Command(
+		return new RouteV2SearchUseCase.SearchRouteV2Command(
 			"station-a",
 			"station-b",
 			OffsetDateTime.parse("2026-07-01T09:00:00+09:00"),

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -9225,29 +9225,32 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
 
 test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 전달한다", () => {
   const controller = read("backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java");
+  const useCasePath = "backend/src/main/java/com/easysubway/route/application/port/in/RouteV2SearchUseCase.java";
   const plannerPath = "backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java";
 
+  assert.equal(existsSync(path.join(root, useCasePath)), true, "RouteV2SearchUseCase must expose the V2 planning port");
   assert.equal(existsSync(path.join(root, plannerPath)), true, "RouteV2Planner must own V2 production search planning");
 
+  const useCase = read(useCasePath);
   const planner = read(plannerPath);
   const v2Endpoint = controller.match(
     /@PostMapping\("\/api\/v2\/routes\/search"\)[\s\S]*?ApiResponse<RouteSearchV2Response> searchRouteV2[\s\S]*?\n\t}/,
   )?.[0] ?? "";
 
-  assert.match(v2Endpoint, /routeV2Planner\.search/);
+  assert.match(v2Endpoint, /routeV2SearchUseCase\.search/);
   assert.doesNotMatch(v2Endpoint, /routeSearchUseCase\.searchRoute/);
   assert.match(controller, /toV2Command\(departureTime\)/);
   assert.match(controller, /RouteSearchV2Response\.from\(plan, request, departureTime\)/);
   assert.match(controller, /plan\.statuses\(\)/);
   assert.doesNotMatch(controller, /List\.of\(\s*"FOUND"[\s\S]*"ROUTE_GRAPH_UNKNOWN"/);
-  assert.match(planner, /class RouteV2Planner/);
+  assert.match(planner, /class RouteV2Planner implements RouteV2SearchUseCase/);
   assert.match(planner, /searchRouteAlternatives/);
   assert.match(planner, /statusesOf/);
-  assert.match(planner, /record SearchRouteV2Command/);
-  assert.match(planner, /OffsetDateTime departureTime/);
-  assert.match(planner, /boolean useRealtime/);
-  assert.match(planner, /int maxTransfers/);
-  assert.match(planner, /int alternativeCount/);
+  assert.match(useCase, /record SearchRouteV2Command/);
+  assert.match(useCase, /OffsetDateTime departureTime/);
+  assert.match(useCase, /boolean useRealtime/);
+  assert.match(useCase, /int maxTransfers/);
+  assert.match(useCase, /int alternativeCount/);
   assert.match(planner, /route-algorithm-v2-adr\.json|Range RAPTOR/);
 });
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -9251,6 +9251,11 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(useCase, /boolean useRealtime/);
   assert.match(useCase, /int maxTransfers/);
   assert.match(useCase, /int alternativeCount/);
+  assert.match(useCase, /SearchRouteV2Command \{/);
+  assert.match(useCase, /maxTransfers < 0/);
+  assert.match(useCase, /alternativeCount < 1/);
+  assert.match(useCase, /enum RouteV2Status/);
+  assert.match(useCase, /List<RouteV2Status> statuses/);
   assert.match(planner, /route-algorithm-v2-adr\.json|Range RAPTOR/);
 });
 


### PR DESCRIPTION
## 관련 이슈

close #1402

## 작업 배경

- `/api/v2/routes/search`가 V2 planner 경계를 명확히 호출하도록 web adapter와 production planner 사이의 전용 input port를 고정합니다.
- #1402의 V1 단일 wrapper 회귀를 막기 위해 controller가 concrete `RouteV2Planner` 구현이 아니라 V2 search use case 계약에만 의존하게 합니다.

## 작업 내용

- `RouteV2SearchUseCase` port를 추가하고 V2 command/plan 계약을 application port 계층으로 이동했습니다.
- `RouteV2Planner`가 `RouteV2SearchUseCase`를 구현하도록 바꾸고, V1 `SearchRouteCommand` 변환은 planner 내부로 제한했습니다.
- `RouteV2Status` enum과 `SearchRouteV2Command` compact constructor 검증을 추가해 V2 port 계약을 컴파일/런타임 경계에서 고정했습니다.
- `RouteSearchController`의 V2 endpoint가 `RouteV2SearchUseCase`만 호출하도록 분리하고, 응답 JSON status 문자열 shape는 유지했습니다.
- planner 단위 테스트와 repository contract 테스트를 새 V2 port 계약 기준으로 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest --tests com.easysubway.route.adapter.in.web.RouteSearchControllerTest --tests com.easysubway.route.application.service.RouteSearchServiceTest` PASS
  - `./gradlew test --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest --tests com.easysubway.route.application.service.RouteSearchServiceTest` PASS
  - `node --test tools/ci/repository-contract.test.mjs` PASS
  - `node --test tools/routes/build-route-v2-contract-report.test.mjs tools/routes/check-route-commercialization-gate.test.mjs tools/routes/prototype-route-v2.test.mjs` PASS
  - `./gradlew test` PASS
  - `git diff --check` PASS
  - PR CI run `28613232287` PASS
  - PR Release Artifacts run `28612790083` PASS
  - PR SonarCloud run `28612790093` PASS
  - post-merge CI run `28613570193` PASS
  - post-merge Release Artifacts run `28613569895` PASS
  - post-merge SonarCloud run `28613569875` PASS
  - post-merge CD run `28613876905` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| V2 planner port 분리 | backend | controller/planner targeted test | local gradle output | PASS |
| V2 port contract | repository tooling | `node --test tools/ci/repository-contract.test.mjs` | local node output, PR CI `28613232287` | PASS |
| route commercialization contract/gate script | backend tooling | node --test route scripts | local node output | PASS |
| backend regression | backend | `./gradlew test` | local gradle output, PR CI `28613232287` | PASS |
| PR review | GitHub PR review | CodeRabbit review + Codex fallback review | CodeRabbit finding replies, fallback review `4620255580` | PASS |
| PR CI/Artifacts/Sonar | GitHub Actions | PR checks | CI `28613232287`, Release Artifacts `28612790083`, SonarCloud `28612790093` | PASS |
| post-merge CI/Artifacts/Sonar | GitHub Actions | main checks on merge commit `d85d10d821d50a9323079cce0b29b315145f1085` | CI `28613570193`, Release Artifacts `28613569895`, SonarCloud `28613569875` | PASS |
| post-merge CD | GitHub Actions | main CD workflow on merge commit `d85d10d821d50a9323079cce0b29b315145f1085` | CD `28613876905`; `DEPLOY_PUBLIC_API_BASE_URL` 미설정 annotation, local readiness checked | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 응답 JSON shape 변경 없음, V2 planner application port 분리 및 port 내부 status enum화
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteSearchController`가 V2 endpoint에서 `RouteV2SearchUseCase`만 호출하는지
  - `RouteV2Planner`의 V1 command 변환이 planner 내부에만 남았는지
  - `RouteV2SearchUseCase`가 command invariant와 enum status 계약을 고정하는지

## 리스크

- runtime 응답 shape 변경은 없습니다. Spring bean wiring 경계와 V2 port invariant는 controller/planner/repository contract 테스트로 확인했습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
