### PR TITLE
[Fix] realtime 환승 이후 ETA overlay 적용

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -7,6 +7,7 @@ import com.easysubway.route.application.port.in.RouteSearchUseCase;
 import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Plan;
+import com.easysubway.route.domain.BoardingSlackPolicy;
 import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.EtaConfidence;
 import com.easysubway.route.domain.EtaSource;
@@ -529,12 +530,7 @@ class RouteSearchController {
 				return 0;
 			}
 			// ponytail: schedule candidate selection belongs with timetable schema; expose only mobility buffer for now.
-			return switch (mobilityType) {
-				case LUGGAGE -> 60;
-				case SENIOR, PREGNANT -> 90;
-				case STROLLER, TEMPORARY_INJURY -> 120;
-				case WHEELCHAIR -> 180;
-			};
+			return BoardingSlackPolicy.secondsFor(mobilityType);
 		}
 
 			private static EtaSource etaSourceOf(RouteStep step) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -1153,8 +1153,9 @@ public class RouteSearchService implements RouteSearchUseCase {
 				resolution.candidates().size(),
 				resolution.candidates()
 			);
-			realtimeSteps.set(index, withEtaOverlay(step, overlay));
-			break;
+			RouteStep realtimeStep = withEtaOverlay(step, overlay);
+			realtimeSteps.set(index, realtimeStep);
+			elapsedMinutes += Math.max(0, realtimeStep.estimatedMinutes());
 		}
 		return List.copyOf(realtimeSteps);
 	}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -1155,7 +1155,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			);
 			RouteStep realtimeStep = withEtaOverlay(step, overlay);
 			realtimeSteps.set(index, realtimeStep);
-			elapsedMinutes += Math.max(0, realtimeStep.estimatedMinutes()) + Math.max(0, step.estimatedMinutes());
+			elapsedMinutes += roundedWaitMinutes(overlay) + Math.max(0, step.estimatedMinutes());
 		}
 		return List.copyOf(realtimeSteps);
 	}
@@ -1184,7 +1184,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			step.lineName(),
 			step.fromStationId(),
 			step.toStationId(),
-			Math.max(1, (overlay.waitSeconds() + 59) / 60),
+			step.estimatedMinutes(),
 			step.distanceMeters(),
 			step.includesStairs(),
 			step.stairAccessState(),
@@ -1193,6 +1193,10 @@ public class RouteSearchService implements RouteSearchUseCase {
 			step.distanceSource(),
 			overlay.confidence().name()
 		);
+	}
+
+	private int roundedWaitMinutes(RealtimeEtaOverlay.Result overlay) {
+		return Math.max(0, (overlay.waitSeconds() + 59) / 60);
 	}
 
 	private String directionFor(RouteStep step) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -1155,7 +1155,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			);
 			RouteStep realtimeStep = withEtaOverlay(step, overlay);
 			realtimeSteps.set(index, realtimeStep);
-			elapsedMinutes += roundedWaitMinutes(overlay) + Math.max(0, step.estimatedMinutes());
+			elapsedMinutes += realtimeWaitMinutes(overlay) + Math.max(0, step.estimatedMinutes());
 		}
 		return List.copyOf(realtimeSteps);
 	}
@@ -1195,7 +1195,10 @@ public class RouteSearchService implements RouteSearchUseCase {
 		);
 	}
 
-	private int roundedWaitMinutes(RealtimeEtaOverlay.Result overlay) {
+	private int realtimeWaitMinutes(RealtimeEtaOverlay.Result overlay) {
+		if (overlay.etaSource() != EtaSource.REALTIME) {
+			return 0;
+		}
 		return Math.max(0, (overlay.waitSeconds() + 59) / 60);
 	}
 

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -1133,18 +1133,19 @@ public class RouteSearchService implements RouteSearchUseCase {
 			return plannedSteps;
 		}
 		List<RouteStep> realtimeSteps = new ArrayList<>(plannedSteps);
-		int elapsedMinutes = 0;
+		int elapsedSeconds = 0;
 		for (int index = 0; index < realtimeSteps.size(); index++) {
 			RouteStep step = realtimeSteps.get(index);
 			if (!"ride".equals(step.stepType())) {
-				elapsedMinutes += Math.max(0, step.estimatedMinutes());
+				elapsedSeconds += durationSeconds(step);
 				continue;
 			}
-			Instant readyAt = command.departureTime().toInstant().plusSeconds(elapsedMinutes * 60L);
+			int boardingSlackSeconds = boardingSlackSeconds(command.mobilityType());
+			Instant readyAt = command.departureTime().toInstant().plusSeconds(elapsedSeconds + boardingSlackSeconds);
 			RealtimeArrivalResolver.Resolution resolution = realtimeArrivalResolver.resolve(realtimeQuery(step, readyAt));
 			RealtimeEtaOverlay.Result overlay = realtimeEtaOverlay.overlay(
 				readyAt,
-				Math.max(0, step.estimatedMinutes()) * 60,
+				durationSeconds(step),
 				directionFor(step),
 				resolution.status(),
 				resolution.fallbackCode(),
@@ -1155,7 +1156,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			);
 			RouteStep realtimeStep = withEtaOverlay(step, overlay);
 			realtimeSteps.set(index, realtimeStep);
-			elapsedMinutes += realtimeWaitMinutes(overlay) + Math.max(0, step.estimatedMinutes());
+			elapsedSeconds += boardingSlackSeconds + realtimeWaitSeconds(overlay) + durationSeconds(step);
 		}
 		return List.copyOf(realtimeSteps);
 	}
@@ -1195,11 +1196,24 @@ public class RouteSearchService implements RouteSearchUseCase {
 		);
 	}
 
-	private int realtimeWaitMinutes(RealtimeEtaOverlay.Result overlay) {
+	private int durationSeconds(RouteStep step) {
+		return Math.max(0, step.estimatedMinutes()) * 60;
+	}
+
+	private int realtimeWaitSeconds(RealtimeEtaOverlay.Result overlay) {
 		if (overlay.etaSource() != EtaSource.REALTIME) {
 			return 0;
 		}
-		return Math.max(0, (overlay.waitSeconds() + 59) / 60);
+		return Math.max(0, overlay.waitSeconds());
+	}
+
+	private int boardingSlackSeconds(MobilityType mobilityType) {
+		return switch (mobilityType) {
+			case LUGGAGE -> 60;
+			case SENIOR, PREGNANT -> 90;
+			case STROLLER, TEMPORARY_INJURY -> 120;
+			case WHEELCHAIR -> 180;
+		};
 	}
 
 	private String directionFor(RouteStep step) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -9,6 +9,7 @@ import com.easysubway.route.application.port.out.LoadRouteSearchPort;
 import com.easysubway.route.application.port.out.RealtimeArrivalResolver;
 import com.easysubway.route.application.port.out.SaveRouteFeedbackPort;
 import com.easysubway.route.application.port.out.SaveRouteSearchPort;
+import com.easysubway.route.domain.BoardingSlackPolicy;
 import com.easysubway.route.domain.EtaConfidence;
 import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.InternalRouteResult;
@@ -1208,12 +1209,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 	}
 
 	private int boardingSlackSeconds(MobilityType mobilityType) {
-		return switch (mobilityType) {
-			case LUGGAGE -> 60;
-			case SENIOR, PREGNANT -> 90;
-			case STROLLER, TEMPORARY_INJURY -> 120;
-			case WHEELCHAIR -> 180;
-		};
+		return BoardingSlackPolicy.secondsFor(mobilityType);
 	}
 
 	private String directionFor(RouteStep step) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -1155,7 +1155,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			);
 			RouteStep realtimeStep = withEtaOverlay(step, overlay);
 			realtimeSteps.set(index, realtimeStep);
-			elapsedMinutes += Math.max(0, realtimeStep.estimatedMinutes());
+			elapsedMinutes += Math.max(0, realtimeStep.estimatedMinutes()) + Math.max(0, step.estimatedMinutes());
 		}
 		return List.copyOf(realtimeSteps);
 	}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -1185,7 +1185,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			step.lineName(),
 			step.fromStationId(),
 			step.toStationId(),
-			step.estimatedMinutes(),
+			step.estimatedMinutes() + ((realtimeWaitSeconds(overlay) + 59) / 60),
 			step.distanceMeters(),
 			step.includesStairs(),
 			step.stairAccessState(),

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -1185,7 +1185,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 			step.lineName(),
 			step.fromStationId(),
 			step.toStationId(),
-			step.estimatedMinutes() + ((realtimeWaitSeconds(overlay) + 59) / 60),
+			step.estimatedMinutes(),
 			step.distanceMeters(),
 			step.includesStairs(),
 			step.stairAccessState(),

--- a/backend/src/main/java/com/easysubway/route/domain/BoardingSlackPolicy.java
+++ b/backend/src/main/java/com/easysubway/route/domain/BoardingSlackPolicy.java
@@ -1,0 +1,18 @@
+package com.easysubway.route.domain;
+
+import com.easysubway.profile.domain.MobilityType;
+
+public final class BoardingSlackPolicy {
+
+	private BoardingSlackPolicy() {
+	}
+
+	public static int secondsFor(MobilityType mobilityType) {
+		return switch (mobilityType) {
+			case LUGGAGE -> 60;
+			case SENIOR, PREGNANT -> 90;
+			case STROLLER, TEMPORARY_INJURY -> 120;
+			case WHEELCHAIR -> 180;
+		};
+	}
+}

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -826,6 +826,38 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 useRealtime=true는 환승 이후 승차 단계에도 provider ETA를 반영한다")
+	void routeV2PlannerAppliesRealtimeEtaAfterTransfer() {
+		var repository = new InMemoryRouteSearchRepository();
+		var resolver = new CountingRealtimeArrivalResolver();
+		var routeSearchService = new RouteSearchService(
+			repository,
+			repository,
+			new OneTransferTransitMasterPort(),
+			CLOCK,
+			resolver
+		);
+		var planner = new RouteV2Planner(routeSearchService);
+
+		var plan = planner.search(new RouteV2Planner.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-01T09:00:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			true,
+			1,
+			1
+		));
+
+		assertThat(resolver.callCount()).isEqualTo(2);
+		assertThat(plan.itineraries().getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("timeSource")
+			.containsExactly(EtaSource.REALTIME.name(), EtaSource.REALTIME.name());
+	}
+
+	@Test
 	@DisplayName("V2 useRealtime=false는 provider를 호출하지 않고 계획 ETA를 유지한다")
 	void routeV2PlannerSkipsRealtimeProviderWhenDisabled() {
 		var repository = new InMemoryRouteSearchRepository();

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -51,6 +51,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -851,6 +852,12 @@ class RouteSearchServiceTest {
 		));
 
 		assertThat(resolver.callCount()).isEqualTo(2);
+		assertThat(resolver.queries())
+			.extracting(RealtimeArrivalResolver.Query::readyAt)
+			.containsExactly(
+				Instant.parse("2026-07-01T00:04:00Z"),
+				Instant.parse("2026-07-01T00:16:00Z")
+			);
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))
 			.extracting("timeSource")
@@ -1641,11 +1648,13 @@ class RouteSearchServiceTest {
 	private static class CountingRealtimeArrivalResolver implements RealtimeArrivalResolver {
 
 		private final AtomicInteger callCount = new AtomicInteger();
+		private final List<Query> queries = new ArrayList<>();
 		private Query lastQuery;
 
 		@Override
 		public Resolution resolve(Query query) {
 			callCount.incrementAndGet();
+			queries.add(query);
 			lastQuery = query;
 			Instant expectedArrivalAt = query.readyAt().plusSeconds(120);
 			return new Resolution(
@@ -1673,6 +1682,10 @@ class RouteSearchServiceTest {
 
 		Query lastQuery() {
 			return lastQuery;
+		}
+
+		List<Query> queries() {
+			return List.copyOf(queries);
 		}
 	}
 

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -862,6 +862,10 @@ class RouteSearchServiceTest {
 			.filteredOn(step -> "ride".equals(step.stepType()))
 			.extracting("timeSource")
 			.containsExactly(EtaSource.REALTIME.name(), EtaSource.REALTIME.name());
+		assertThat(plan.itineraries().getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("estimatedMinutes")
+			.containsExactly(4, 4);
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -865,7 +865,7 @@ class RouteSearchServiceTest {
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))
 			.extracting("estimatedMinutes")
-			.containsExactly(4, 4);
+			.containsExactly(6, 6);
 	}
 
 	@Test
@@ -907,7 +907,7 @@ class RouteSearchServiceTest {
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))
 			.extracting("estimatedMinutes")
-			.containsExactly(4, 4);
+			.containsExactly(4, 6);
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -865,7 +865,7 @@ class RouteSearchServiceTest {
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))
 			.extracting("estimatedMinutes")
-			.containsExactly(6, 6);
+			.containsExactly(4, 4);
 	}
 
 	@Test
@@ -907,7 +907,7 @@ class RouteSearchServiceTest {
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))
 			.extracting("estimatedMinutes")
-			.containsExactly(4, 6);
+			.containsExactly(4, 4);
 	}
 
 	@Test

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -869,6 +869,48 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 useRealtime=true는 환승 전 fallback ride의 planned duration을 wait으로 중복 계산하지 않는다")
+	void routeV2PlannerDoesNotDoubleCountFallbackWaitBeforeTransfer() {
+		var repository = new InMemoryRouteSearchRepository();
+		var resolver = new CountingRealtimeArrivalResolver(ArrivalFreshness.UNAVAILABLE, ArrivalFreshness.FRESH_REALTIME);
+		var routeSearchService = new RouteSearchService(
+			repository,
+			repository,
+			new OneTransferTransitMasterPort(),
+			CLOCK,
+			resolver
+		);
+		var planner = new RouteV2Planner(routeSearchService);
+
+		var plan = planner.search(new RouteV2Planner.SearchRouteV2Command(
+			"station-a",
+			"station-b",
+			OffsetDateTime.parse("2026-07-01T09:00:00+09:00"),
+			MobilityType.SENIOR,
+			ConstraintMode.PREFER_STEP_FREE,
+			true,
+			1,
+			1
+		));
+
+		assertThat(resolver.callCount()).isEqualTo(2);
+		assertThat(resolver.queries())
+			.extracting(RealtimeArrivalResolver.Query::readyAt)
+			.containsExactly(
+				Instant.parse("2026-07-01T00:04:00Z"),
+				Instant.parse("2026-07-01T00:14:00Z")
+			);
+		assertThat(plan.itineraries().getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("timeSource")
+			.containsExactly(EtaSource.FALLBACK.name(), EtaSource.REALTIME.name());
+		assertThat(plan.itineraries().getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.extracting("estimatedMinutes")
+			.containsExactly(4, 4);
+	}
+
+	@Test
 	@DisplayName("V2 useRealtime=false는 provider를 호출하지 않고 계획 ETA를 유지한다")
 	void routeV2PlannerSkipsRealtimeProviderWhenDisabled() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -1653,20 +1695,24 @@ class RouteSearchServiceTest {
 
 		private final AtomicInteger callCount = new AtomicInteger();
 		private final List<Query> queries = new ArrayList<>();
+		private final List<ArrivalFreshness> statuses;
 		private Query lastQuery;
+
+		CountingRealtimeArrivalResolver(ArrivalFreshness... statuses) {
+			this.statuses = statuses.length == 0
+				? List.of(ArrivalFreshness.FRESH_REALTIME)
+				: List.of(statuses);
+		}
 
 		@Override
 		public Resolution resolve(Query query) {
-			callCount.incrementAndGet();
+			int callIndex = callCount.getAndIncrement();
 			queries.add(query);
 			lastQuery = query;
+			ArrivalFreshness status = statuses.get(Math.min(callIndex, statuses.size() - 1));
 			Instant expectedArrivalAt = query.readyAt().plusSeconds(120);
-			return new Resolution(
-				ArrivalFreshness.FRESH_REALTIME,
-				null,
-				"test-realtime-snapshot",
-				query.readyAt().minusSeconds(30),
-				List.of(new ArrivalCandidate(
+			List<ArrivalCandidate> candidates = status == ArrivalFreshness.FRESH_REALTIME
+				? List.of(new ArrivalCandidate(
 					"train-test",
 					query.lineId(),
 					query.direction(),
@@ -1677,6 +1723,13 @@ class RouteSearchServiceTest {
 					ArrivalFreshness.FRESH_REALTIME,
 					EtaConfidence.HIGH
 				))
+				: List.of();
+			return new Resolution(
+				status,
+				status == ArrivalFreshness.FRESH_REALTIME ? null : "PROVIDER_UNAVAILABLE",
+				status == ArrivalFreshness.FRESH_REALTIME ? "test-realtime-snapshot" : null,
+				query.readyAt().minusSeconds(30),
+				candidates
 			);
 		}
 

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -817,7 +817,7 @@ class RouteSearchServiceTest {
 
 		assertThat(resolver.callCount()).isEqualTo(1);
 		assertThat(resolver.lastQuery().stationId()).isEqualTo("station-a");
-		assertThat(resolver.lastQuery().readyAt()).isEqualTo(Instant.parse("2026-07-01T00:04:00Z"));
+		assertThat(resolver.lastQuery().readyAt()).isEqualTo(Instant.parse("2026-07-01T00:05:30Z"));
 		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.MIXED);
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))
@@ -855,8 +855,8 @@ class RouteSearchServiceTest {
 		assertThat(resolver.queries())
 			.extracting(RealtimeArrivalResolver.Query::readyAt)
 			.containsExactly(
-				Instant.parse("2026-07-01T00:04:00Z"),
-				Instant.parse("2026-07-01T00:16:00Z")
+				Instant.parse("2026-07-01T00:05:30Z"),
+				Instant.parse("2026-07-01T00:19:00Z")
 			);
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))
@@ -897,8 +897,8 @@ class RouteSearchServiceTest {
 		assertThat(resolver.queries())
 			.extracting(RealtimeArrivalResolver.Query::readyAt)
 			.containsExactly(
-				Instant.parse("2026-07-01T00:04:00Z"),
-				Instant.parse("2026-07-01T00:14:00Z")
+				Instant.parse("2026-07-01T00:05:30Z"),
+				Instant.parse("2026-07-01T00:17:00Z")
 			);
 		assertThat(plan.itineraries().getFirst().steps())
 			.filteredOn(step -> "ride".equals(step.stepType()))


### PR DESCRIPTION
## 관련 이슈

refs #1404

## 작업 배경

- V2 `useRealtime=true` 경로에서 첫 승차 ride에만 provider ETA overlay가 적용되고, 환승 이후 ride는 계획 ETA로 남을 수 있었다.
- #1404의 완료 조건 중 "환승 이후 다음 승차 후보에도 realtime/planned boardable filtering과 source 표기가 이어져야 한다"는 항목의 부분 증거를 보강한다.

## 작업 내용

- realtime overlay 적용 루프가 첫 ride에서 중단되지 않도록 수정했다.
- overlay가 적용된 ride의 예상 시간을 누적해 환승 이후 ride의 resolver 기준 시각이 이전 leg 결과를 반영하도록 했다.
- realtime ride duration은 기존 ride duration에 provider wait을 분 단위로 포함해 반환 ETA/duration에 반영하고, fallback ride는 planned duration을 유지하도록 분리했다.
- fallback overlay의 `waitSeconds`를 실제 realtime wait으로 취급하지 않도록 막았다.
- V2 boarding slack을 provider 조회 `readyAt` 계산에 포함해, slack window 안에 도착하는 열차를 boardable realtime으로 잘못 고르지 않게 했다.
- boarding slack 정책을 `BoardingSlackPolicy`로 단일화해 provider 조회와 V2 응답 mapping이 같은 값을 쓰도록 했다.
- 환승 포함 fixture에서 provider resolver가 두 번 호출되고 두 ride 모두 `REALTIME` source로 표시되는 회귀 테스트를 추가했다.
- 첫 ride fallback, 두 번째 ride realtime 조합에서 fallback planned duration이 wait으로 중복 계산되지 않는 회귀 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` 성공
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest` 성공
  - `./gradlew test` 성공
  - `git diff --check origin/main...HEAD` 성공
  - `gh run watch 28616323189 --interval 10` 성공
  - `gh run watch 28616322881 --interval 10` 성공
  - `gh run watch 28617223881 --interval 10` 성공
  - `gh pr checks 1590` 최종 pass/skip 정상

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 환승 이후 realtime ETA overlay | Backend | RouteSearchServiceTest 회귀 테스트 | `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` | 통과 |
| V2 boarding slack 응답 계약 | Backend | RouteSearchV2ControllerTest 회귀 테스트 | `./gradlew test --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest` | 통과 |
| Backend 전체 회귀 | Backend | Gradle 전체 테스트 | `./gradlew test` | 통과 |
| 정적 diff hygiene | Repo | whitespace/error marker 검사 | `git diff --check origin/main...HEAD` | 통과 |
| CI | GitHub Actions | CI workflow | https://github.com/AquilaXk/easysubway/actions/runs/28616323189 | 통과 |
| Release artifact | GitHub Actions | Release Artifacts workflow | https://github.com/AquilaXk/easysubway/actions/runs/28616322881 | 통과 |
| CD | GitHub Actions | CD workflow | https://github.com/AquilaXk/easysubway/actions/runs/28617223881 | 통과 |
| Code review | GitHub PR Review | CodeRabbit review + Codex CLI fallback review + fix threads | reviews 4620541051, 4620574286, 4620575065 | actionable 게시 후 수정 답글 완료, 최종 actionable 0 |
| CodeRabbit status | GitHub Checks | PR check | CodeRabbit `pass` | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteSearchService.realtimeAwareRouteSteps`의 ride별 overlay 적용, `readyAt` 누적, boarding slack 반영 부분과 `routeV2PlannerAppliesRealtimeEtaAfterTransfer`, `routeV2PlannerDoesNotDoubleCountFallbackWaitBeforeTransfer` 테스트
- 이 PR은 #1404를 닫지 않는 부분 진행 PR이다.

## 리스크

- realtime resolver 호출이 환승 포함 경로에서 ride 수만큼 늘어난다. 기존 `useRealtime=false` 경로는 provider를 호출하지 않는 테스트가 유지된다.
- V2 `readyAt` 계산이 boarding slack을 포함하도록 바뀌어, 이전보다 보수적으로 realtime train candidate를 고른다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
