### PR TITLE
[Fix] datapack stale offline status surface

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'accessible_design.dart';
 import 'app/app_bootstrap.dart';
 import 'app/app_dependencies.dart';
+import 'core/datapack/data_pack_update_state.dart';
 import 'facility_report.dart';
 import 'facility_status.dart';
 import 'favorite_facility.dart';
@@ -80,6 +81,9 @@ Future<void> main() async {
         : null,
   );
   final photoPicker = ImagePickerFacilityReportPhotoPicker();
+  final dataPackUpdateStateRepository = DataPackUpdateStateRepository(
+    userDatabase: bootstrap.userDatabase,
+  );
   runApp(
     AppBootstrapLifecycle(
       close: bootstrap.close,
@@ -90,6 +94,9 @@ Future<void> main() async {
             const SecureFacilityReportDraftTargetStore(),
         facilityReportLostPhotoRestorer: photoPicker.retrieveLostPhoto,
         legacyCredentialCleaner: const SecureLegacyCredentialCleaner(),
+        offlineDataExpiresAtLoader: () async =>
+            (await dataPackUpdateStateRepository.readManifestCache())
+                ?.expiresAt,
       ),
     ),
   );
@@ -273,6 +280,7 @@ class EasySubwayApp extends StatelessWidget {
         const SupportAccessInfo.fromEnvironment(),
     SupportAccessLauncher supportAccessLauncher =
         const UrlLauncherSupportAccessLauncher(),
+    OfflineDataExpiresAtLoader? offlineDataExpiresAtLoader,
     OnboardingState initialOnboardingState = const OnboardingState.initial(),
     bool enablePushNotifications = defaultPushNotificationsEnabled,
     Key? key,
@@ -307,6 +315,7 @@ class EasySubwayApp extends StatelessWidget {
            isReleaseMode: kReleaseMode,
          ),
          supportAccessLauncher: supportAccessLauncher,
+         offlineDataExpiresAtLoader: offlineDataExpiresAtLoader,
          recentRoutesFuture:
              recentRoutesFuture ??
              (defaultDemoHomeDataEnabled
@@ -324,6 +333,7 @@ class EasySubwayApp extends StatelessWidget {
     required this.legacyCredentialCleaner,
     required this.supportAccessInfo,
     required this.supportAccessLauncher,
+    required this.offlineDataExpiresAtLoader,
     required this.recentRoutesFuture,
     super.key,
   }) : repository = dependencies.repository,
@@ -367,6 +377,7 @@ class EasySubwayApp extends StatelessWidget {
   final LegacyCredentialCleaner legacyCredentialCleaner;
   final SupportAccessInfo supportAccessInfo;
   final SupportAccessLauncher supportAccessLauncher;
+  final OfflineDataExpiresAtLoader? offlineDataExpiresAtLoader;
   final Future<List<FavoriteRoute>>? recentRoutesFuture;
 
   @override
@@ -447,11 +458,14 @@ class EasySubwayApp extends StatelessWidget {
         supportAccessInfo: supportAccessInfo,
         supportAccessLauncher: supportAccessLauncher,
         userDataDeletionRepository: userDataDeletionRepository,
+        offlineDataExpiresAtLoader: offlineDataExpiresAtLoader,
         recentRoutesFuture: recentRoutesFuture,
       ),
     );
   }
 }
+
+typedef OfflineDataExpiresAtLoader = Future<DateTime?> Function();
 
 class EasySubwayScrollBehavior extends MaterialScrollBehavior {
   const EasySubwayScrollBehavior();
@@ -567,6 +581,7 @@ class _EasySubwayHome extends StatefulWidget {
     required this.supportAccessInfo,
     required this.supportAccessLauncher,
     required this.userDataDeletionRepository,
+    required this.offlineDataExpiresAtLoader,
     required this.recentRoutesFuture,
   });
 
@@ -593,6 +608,7 @@ class _EasySubwayHome extends StatefulWidget {
   final SupportAccessInfo supportAccessInfo;
   final SupportAccessLauncher supportAccessLauncher;
   final UserDataDeletionRepository? userDataDeletionRepository;
+  final OfflineDataExpiresAtLoader? offlineDataExpiresAtLoader;
   final Future<List<FavoriteRoute>>? recentRoutesFuture;
 
   @override
@@ -714,6 +730,7 @@ class _EasySubwayHomeState extends State<_EasySubwayHome> {
         supportAccessLauncher: widget.supportAccessLauncher,
         userDataDeletionRepository: widget.userDataDeletionRepository,
         recentRoutesFuture: widget.recentRoutesFuture,
+        offlineDataExpiresAtLoader: widget.offlineDataExpiresAtLoader,
         onUserDataDeleted: _handleUserDataDeleted,
         onMobilityProfileChanged: _saveMobilityProfile,
         onViewPreferencesChanged: _saveViewPreferences,
@@ -1219,6 +1236,7 @@ class HomeScreen extends StatefulWidget {
     this.viewPreferences = const OnboardingViewPreferences.defaults(),
     this.simpleViewEnabled = true,
     this.facilityReportDraftTargetStore,
+    this.offlineDataExpiresAtLoader,
     String? initialMobilityType,
     super.key,
   }) : initialMobilityType =
@@ -1248,6 +1266,7 @@ class HomeScreen extends StatefulWidget {
   final Future<void> Function(OnboardingViewPreferences preferences)
   onViewPreferencesChanged;
   final Future<List<FavoriteRoute>>? recentRoutesFuture;
+  final OfflineDataExpiresAtLoader? offlineDataExpiresAtLoader;
   final String initialMobilityType;
   final OnboardingViewPreferences viewPreferences;
   final bool simpleViewEnabled;
@@ -1580,6 +1599,7 @@ class _HomeScreenState extends State<HomeScreen> {
           onOpenMobilityProfile: _openMobilityProfile,
           onOpenSupportAccess: openSupportAccess,
           onOpenMyReports: openMyReports,
+          offlineDataExpiresAtLoader: widget.offlineDataExpiresAtLoader,
         ),
       );
     }
@@ -2586,6 +2606,7 @@ class AppSettingsScreen extends StatefulWidget {
     required this.onOpenMobilityProfile,
     required this.onOpenSupportAccess,
     required this.onOpenMyReports,
+    this.offlineDataExpiresAtLoader,
     this.bottomNavigationBar,
     super.key,
   });
@@ -2599,6 +2620,7 @@ class AppSettingsScreen extends StatefulWidget {
   final Future<MobilityProfileOption?> Function() onOpenMobilityProfile;
   final VoidCallback onOpenSupportAccess;
   final VoidCallback onOpenMyReports;
+  final OfflineDataExpiresAtLoader? offlineDataExpiresAtLoader;
   final Widget? bottomNavigationBar;
 
   @override
@@ -2697,7 +2719,9 @@ class _AppSettingsScreenState extends State<AppSettingsScreen> {
                     onTap: () {
                       Navigator.of(context).push(
                         MaterialPageRoute<void>(
-                          builder: (_) => const OfflineDataScreen(),
+                          builder: (_) => OfflineDataScreen(
+                            expiresAtLoader: widget.offlineDataExpiresAtLoader,
+                          ),
                         ),
                       );
                     },
@@ -3491,18 +3515,38 @@ class _FavoriteListScreen extends StatelessWidget {
 }
 
 class OfflineDataScreen extends StatelessWidget {
-  const OfflineDataScreen({super.key, this.expiresAt, this.now});
+  const OfflineDataScreen({
+    super.key,
+    this.expiresAt,
+    this.expiresAtLoader,
+    this.now,
+  });
 
-  // ponytail: static v1 QA source; wire live catalog metadata when offline status is dynamic.
+  // ponytail: v1 stale badge only needs manifest expiry; add source freshness when surfaced here.
   static const _offlineDataSourceOfTruth = 'installed catalog metadata';
 
   final DateTime? expiresAt;
+  final OfflineDataExpiresAtLoader? expiresAtLoader;
   final DateTime Function()? now;
 
   @override
   Widget build(BuildContext context) {
     assert(_offlineDataSourceOfTruth == 'installed catalog metadata');
-    final storedDataStatus = _storedDataStatus(expiresAt: expiresAt, now: now);
+    final loader = expiresAtLoader;
+    if (loader != null && expiresAt == null) {
+      return FutureBuilder<DateTime?>(
+        future: loader(),
+        builder: (context, snapshot) => _buildScaffold(context, snapshot.data),
+      );
+    }
+    return _buildScaffold(context, expiresAt);
+  }
+
+  Widget _buildScaffold(BuildContext context, DateTime? effectiveExpiresAt) {
+    final storedDataStatus = _storedDataStatus(
+      expiresAt: effectiveExpiresAt,
+      now: now,
+    );
     return Scaffold(
       appBar: AppBar(title: const Text('인터넷 없이 이용')),
       body: SafeArea(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3844,6 +3844,30 @@ void main() {
     expect(find.text('갱신 필요'), findsOneWidget);
   });
 
+  testWidgets('설정의 오프라인 데이터 안내는 저장 manifest 만료를 갱신 필요로 보여준다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppSettingsScreen(
+          currentProfile: mobilityProfileOptions.first,
+          viewPreferences: const OnboardingViewPreferences.defaults(),
+          notificationRepository: null,
+          notificationPermissionProvider: null,
+          onViewPreferencesChanged: (_) async {},
+          onOpenMobilityProfile: () async => null,
+          onOpenSupportAccess: () {},
+          onOpenMyReports: () {},
+          offlineDataExpiresAtLoader: () async => DateTime.utc(2026, 6, 25, 12),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('offlineDataSettingsButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('저장된 데이터 기준 · 갱신 필요'), findsOneWidget);
+    expect(find.text('갱신 필요'), findsOneWidget);
+  });
+
   testWidgets('데이터 및 지도 출처 화면은 manifest와 source inventory를 보여준다', (
     tester,
   ) async {


### PR DESCRIPTION
## 관련 이슈

refs #1418

## 작업 배경

- #1418은 만료된 데이터팩을 앱에서 `저장된 데이터 기준 · 갱신 필요`로 강등해 보여주는 Android evidence를 요구합니다.
- 기존 `OfflineDataScreen`은 테스트 주입값으로는 stale 라벨을 보여줬지만, 실제 앱 설정 경로에서는 설치된 manifest cache의 `expiresAt`을 읽지 않아 기본 안내만 표시했습니다.

## 작업 내용

- 앱 bootstrap의 `DataPackUpdateStateRepository.readManifestCache()`를 설정의 오프라인 데이터 안내 화면에 연결했습니다.
- `OfflineDataScreen`이 저장 manifest `expiresAt`을 비동기로 읽어 만료 시 기존 stale 라벨을 그대로 표시하게 했습니다.
- 설정 화면 경로에서 만료 manifest가 `저장된 데이터 기준 · 갱신 필요`로 보이는 widget test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --plain-name '설정의 오프라인 데이터 안내는 저장 manifest 만료를 갱신 필요로 보여준다'` 성공
  - `flutter analyze` 성공
  - `git diff --check` 성공
  - Android emulator(`emulator-5554`, API 36)에서 `user.db` manifest cache 만료값 seed 후 설정 > 인터넷 없이 이용 UI tree 확인 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| stale 오프라인 데이터 라벨 | Android API 36 emulator | `adb shell uiautomator dump` | `.codex/evidence/1418/easysubway-1418-stale-offline-data.xml` (`a5dec6d959d94bb1e6d8133fc59c743b662030b49782467531363b9808ba29dd`) | `저장된 데이터 기준 · 갱신 필요`, `갱신 필요` 확인 |
| stale 오프라인 데이터 화면 | Android API 36 emulator | `adb exec-out screencap -p` | `.codex/evidence/1418/easysubway-1418-stale-offline-data.png` (`545843f0a149a4afed13b7143c98e05de2cf434bbb8f0396f0ef6a07979ddaf5`) | 통과 |
| manifest cache seed | Android API 36 emulator | sqlite seed | `.codex/evidence/1418/seed-expired-manifest-cache.sql` (`e82ad91a541a5a47451b23d72fafa69369c0307a3ee2005d4b2238a9ef49d5a4`) | 통과 |

## Version impact

- [ ] no version change
- [x] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `OfflineDataScreen`의 `expiresAtLoader` 연결과 설정 경로 widget test
- 이 PR은 #1418의 Android stale label evidence 갭을 줄이는 부분 진행입니다. schedule event 1-cycle과 만료 임박 알림 evidence는 아직 별도 남음.

## 리스크

- manifest cache 읽기 실패/미존재 시 기존 기본 안내 상태로 남습니다.
- 화면 진입 시 FutureBuilder가 한 번 갱신되므로 stale 라벨은 manifest cache read 완료 후 표시됩니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
