### PR TITLE
[Test] datapack expiry alert evidence gate

### DIFF
--- a/tools/datapack/check-datapack-expiry-alert.mjs
+++ b/tools/datapack/check-datapack-expiry-alert.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+
+function argValue(args, name) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function parseIsoDurationSeconds(value) {
+  const match = /^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/.exec(value ?? "");
+  if (!match) throw new Error("alertBeforePackExpiry must be PT duration");
+  return Number(match[1] ?? 0) * 3600 + Number(match[2] ?? 0) * 60 + Number(match[3] ?? 0);
+}
+
+function parseTime(value, name) {
+  const millis = Date.parse(value ?? "");
+  if (!Number.isFinite(millis)) throw new Error(`${name} must be ISO date-time`);
+  return millis;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const manifestPath = argValue(args, "--manifest");
+  const outputPath = argValue(args, "--output");
+  const policyPath = argValue(args, "--policy") ?? "apps/mobile/release/datapack-freshness-sla.json";
+  const now = parseTime(argValue(args, "--now") ?? new Date().toISOString(), "now");
+  if (!manifestPath || !outputPath) throw new Error("--manifest and --output are required");
+
+  const [manifestRaw, policy] = await Promise.all([readFile(manifestPath, "utf8"), readJson(policyPath)]);
+  const manifest = JSON.parse(manifestRaw);
+  const thresholdSeconds = parseIsoDurationSeconds(policy.monitoring?.alertBeforePackExpiry);
+  const expiresAtMillis = parseTime(manifest.expiresAt, "manifest.expiresAt");
+  const secondsUntilExpiry = Math.floor((expiresAtMillis - now) / 1000);
+  const shouldAlert = secondsUntilExpiry <= thresholdSeconds;
+  const severity = secondsUntilExpiry <= 0 ? "critical" : shouldAlert ? "warning" : "none";
+
+  const evidence = {
+    schemaVersion: 1,
+    artifactKind: "datapack-expiry-alert-evidence",
+    policy: {
+      path: policyPath,
+      alertBeforePackExpiry: policy.monitoring.alertBeforePackExpiry,
+      thresholdSeconds,
+    },
+    manifest: {
+      path: manifestPath,
+      sha256: createHash("sha256").update(manifestRaw).digest("hex"),
+      channel: manifest.channel,
+      releaseSequence: manifest.releaseSequence,
+      publishedAt: manifest.publishedAt,
+      expiresAt: manifest.expiresAt,
+    },
+    alert: {
+      status: shouldAlert ? "FIRING" : "OK",
+      severity,
+      secondsUntilExpiry,
+      summary: shouldAlert ? "Data pack manifest is near expiry" : "Data pack manifest freshness is within SLA",
+    },
+    checkedAt: new Date(now).toISOString(),
+  };
+  await writeFile(outputPath, `${JSON.stringify(evidence, null, 2)}\n`);
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error.message);
+  process.exitCode = 1;
+}

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -8930,6 +8930,54 @@ test("emergency datapack drill은 rollback, patch, route regression 증거를 �
   assert.equal(evidence.verification.commandOutputSha256, sha256('{"failures":[],"sampleSize":100}'));
 });
 
+test("데이터팩 만료 알림 evidence는 SLA 임박 manifest를 FIRING으로 기록한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-datapack-expiry-alert-${Date.now()}`);
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  const manifestPath = path.join(outputDir, "current.json");
+  const outputPath = path.join(outputDir, "expiry-alert-evidence.json");
+
+  await writeFile(
+    manifestPath,
+    `${JSON.stringify(
+      {
+        manifestVersion: 2,
+        channel: "production",
+        releaseSequence: 42,
+        publishedAt: "2026-07-01T18:00:00.000Z",
+        expiresAt: "2026-07-02T05:30:00.000Z",
+        activePack: { id: "capital", version: "1" },
+        packs: [],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/check-datapack-expiry-alert.mjs",
+      "--manifest",
+      manifestPath,
+      "--output",
+      outputPath,
+      "--now",
+      "2026-07-02T00:00:00.000Z",
+    ],
+    { cwd: root },
+  );
+
+  const evidence = JSON.parse(await readFile(outputPath, "utf8"));
+  assert.equal(evidence.artifactKind, "datapack-expiry-alert-evidence");
+  assert.equal(evidence.policy.alertBeforePackExpiry, "PT6H");
+  assert.equal(evidence.manifest.channel, "production");
+  assert.equal(evidence.manifest.releaseSequence, 42);
+  assert.equal(evidence.alert.status, "FIRING");
+  assert.equal(evidence.alert.severity, "warning");
+  assert.equal(evidence.alert.secondsUntilExpiry, 19800);
+});
+
 function sha256(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
 }


### PR DESCRIPTION
## 관련 이슈

refs #1418

## 작업 배경

- #1418은 데이터팩 만료 임박 알림 evidence를 요구합니다.
- 현재 freshness SLA JSON에는 `alertBeforePackExpiry: PT6H` 정책이 있지만, manifest 만료 임박 상태를 재현 가능한 evidence JSON으로 남기는 도구가 없습니다.

## 작업 내용

- `tools/datapack/check-datapack-expiry-alert.mjs`를 추가해 manifest `expiresAt`이 SLA threshold 안에 들어오면 `datapack-expiry-alert-evidence`를 생성합니다.
- 만료 임박 production manifest가 `FIRING`/`warning`으로 기록되는 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "데이터팩 만료 알림 evidence" tools/datapack/datapack-tools.test.mjs` 성공
  - `node --test --test-name-pattern "(데이터팩 만료 알림 evidence|emergency datapack drill)" tools/datapack/datapack-tools.test.mjs` 성공
  - `node --test tools/datapack/datapack-tools.test.mjs` 성공, 159 pass
  - `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 데이터팩 만료 임박 알림 evidence | local Node.js | `check-datapack-expiry-alert.mjs` dry-run | `.codex/evidence/1418/datapack-expiry-alert-evidence.json` (`12e16f031771910c527f1679afe1c5a88bf3ee532f7b510b56a7cb1d923641e6`) | `FIRING`, `warning`, `secondsUntilExpiry: 19800` 확인 |
| 만료 임박 manifest fixture | local file | SHA256 | `.codex/evidence/1418/near-expiry-current.json` (`4f18dc63cf12ce638c994959ee6ed008fde2797dc421a5dfb3056c17dfb23224`) | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `check-datapack-expiry-alert.mjs`의 threshold 판정과 evidence schema
- 이 PR은 #1418의 만료 임박 알림 evidence gap만 줄입니다. 실제 `schedule` event 1-cycle evidence는 아직 별도 확인이 필요합니다.

## 리스크

- 실제 Slack/Alertmanager 전송은 구현하지 않습니다. 이 PR은 SLA threshold 판정과 evidence 생성까지만 다룹니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
