### PR TITLE
[Fix] 역외 환승 allowlist kill switch 적용

### DIFF
--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -507,6 +507,9 @@ class _RouteCatalogSnapshot {
           FROM station_lines
           ORDER BY line_id, line_sequence
           ''').get();
+    final outOfStationTransferPolicy = await _OutOfStationTransferPolicy.load(
+      database,
+    );
     final networkEdgeColumns = await database
         .customSelect('PRAGMA table_info(network_edges)')
         .get();
@@ -754,6 +757,11 @@ class _RouteCatalogSnapshot {
                 row.read<String>('evidence_hash'),
           );
         })
+        .where(
+          (edge) =>
+              edge.routeEdgeType != graph.RouteEdgeType.outOfStationTransfer ||
+              outOfStationTransferPolicy.allows(edge),
+        )
         .toList(growable: false);
     final strictEvidenceSupported =
         networkEdgeColumnNames.containsAll({
@@ -1043,6 +1051,60 @@ String _metadataUpdatedAtIso(int? updatedAtMillis) {
     normalizedMillis,
     isUtc: true,
   ).toIso8601String();
+}
+
+class _OutOfStationTransferPolicy {
+  const _OutOfStationTransferPolicy({
+    required this.enabled,
+    required this.runtimeEnabled,
+    required this.allowlist,
+  });
+
+  final bool enabled;
+  final bool runtimeEnabled;
+  final Set<String> allowlist;
+
+  static Future<_OutOfStationTransferPolicy> load(
+    CatalogDatabase database,
+  ) async {
+    final rows = await database.customSelect('''
+      SELECT key, value
+      FROM catalog_metadata
+      WHERE key IN (
+        'route.outOfStationTransfer.enabled',
+        'route.outOfStationTransfer.runtimeEnabled',
+        'route.outOfStationTransfer.allowlist'
+      )
+    ''').get();
+    final values = {
+      for (final row in rows)
+        row.read<String>('key'): row.read<String>('value'),
+    };
+    return _OutOfStationTransferPolicy(
+      enabled:
+          values['route.outOfStationTransfer.enabled']?.toLowerCase() == 'true',
+      runtimeEnabled:
+          values['route.outOfStationTransfer.runtimeEnabled']?.toLowerCase() !=
+          'false',
+      allowlist: _parseOutOfStationTransferAllowlist(
+        values['route.outOfStationTransfer.allowlist'] ?? '',
+      ),
+    );
+  }
+
+  bool allows(_NetworkEdgeSnapshot edge) {
+    return enabled &&
+        runtimeEnabled &&
+        allowlist.contains(_edgePairKey(edge.fromNodeId, edge.toNodeId));
+  }
+}
+
+Set<String> _parseOutOfStationTransferAllowlist(String value) {
+  return value
+      .split(RegExp(r'[\s,]+'))
+      .map((pair) => pair.trim())
+      .where((pair) => pair.isNotEmpty)
+      .toSet();
 }
 
 String _edgePairKey(String fromNodeId, String toNodeId) {

--- a/apps/mobile/release/route-commercialization-gate.json
+++ b/apps/mobile/release/route-commercialization-gate.json
@@ -33,6 +33,7 @@
   "routing": {
     "multiTransferSupported": false,
     "outOfStationTransferSupported": false,
+    "outOfStationTransferAllowlistSource": "catalog_metadata:route.outOfStationTransfer.allowlist",
     "alternativeItinerariesMin": 2
   },
   "etaSourceIntegrity": {

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -742,6 +742,10 @@ void main() {
     addTearDown(database.close);
     await _seedLineWithoutNetworkEdges(database);
     await _addSecondLineForTransferFixture(database);
+    await _allowOutOfStationTransfer(
+      database,
+      'station-a:line-test->station-c:line-alt',
+    );
     await _insertVerifiedNetworkEdge(
       database,
       id: 'edge-b-a-line-test',
@@ -781,11 +785,100 @@ void main() {
     expect(transferStep.actionTitle, '역외 환승');
   });
 
+  test('역외 환승 edge는 allowlist 없으면 후보에서 제외한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await _addSecondLineForTransferFixture(database);
+    await _insertVerifiedNetworkEdge(
+      database,
+      id: 'edge-b-a-line-test',
+      fromNodeId: 'station-b:line-test',
+      toNodeId: 'station-a:line-test',
+      edgeType: 'RIDE',
+      durationSeconds: 90,
+    );
+    await _insertVerifiedNetworkEdge(
+      database,
+      id: 'out-transfer-a-c',
+      fromNodeId: 'station-a:line-test',
+      toNodeId: 'station-c:line-alt',
+      edgeType: 'OUT_OF_STATION_TRANSFER',
+      durationSeconds: 300,
+    );
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final result = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-b',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(result.status, isNot('FOUND'));
+    expect(
+      result.steps.where((step) => step.stepType == 'outOfStationTransfer'),
+      isEmpty,
+    );
+  });
+
+  test('역외 환승 runtime kill switch off는 다음 검색부터 후보에서 제외한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(database);
+    await _addSecondLineForTransferFixture(database);
+    await _allowOutOfStationTransfer(
+      database,
+      'station-a:line-test->station-c:line-alt',
+    );
+    await _insertVerifiedNetworkEdge(
+      database,
+      id: 'edge-b-a-line-test',
+      fromNodeId: 'station-b:line-test',
+      toNodeId: 'station-a:line-test',
+      edgeType: 'RIDE',
+      durationSeconds: 90,
+    );
+    await _insertVerifiedNetworkEdge(
+      database,
+      id: 'out-transfer-a-c',
+      fromNodeId: 'station-a:line-test',
+      toNodeId: 'station-c:line-alt',
+      edgeType: 'OUT_OF_STATION_TRANSFER',
+      durationSeconds: 300,
+    );
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final enabledResult = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-b',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+    await _setOutOfStationTransferRuntimeEnabled(database, false);
+    final disabledResult = await repository.searchRoute(
+      const RouteSearchRequest(
+        originStationId: 'station-b',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(enabledResult.status, 'FOUND');
+    expect(disabledResult.status, isNot('FOUND'));
+  });
+
   test('역외 환승 edge는 역방향을 자동으로 열지 않는다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
     await _seedLineWithoutNetworkEdges(database);
     await _addSecondLineForTransferFixture(database);
+    await _allowOutOfStationTransfer(
+      database,
+      'station-a:line-test->station-c:line-alt',
+    );
     await _insertVerifiedNetworkEdge(
       database,
       id: 'edge-a-b-line-test',
@@ -3352,6 +3445,36 @@ Future<void> _seedLineWithoutNetworkEdges(
   if (fillInsertedNetworkEdgeEvidence) {
     await _fillInsertedNetworkEdgeEvidence(database);
   }
+}
+
+Future<void> _allowOutOfStationTransfer(
+  CatalogDatabase database,
+  String pairId,
+) async {
+  await database.customStatement(
+    '''
+      INSERT INTO catalog_metadata (key, value, updated_at)
+      VALUES
+        ('route.outOfStationTransfer.enabled', 'true', 1781827200),
+        ('route.outOfStationTransfer.allowlist', ?, 1781827200)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    ''',
+    [pairId],
+  );
+}
+
+Future<void> _setOutOfStationTransferRuntimeEnabled(
+  CatalogDatabase database,
+  bool enabled,
+) async {
+  await database.customStatement(
+    '''
+      INSERT INTO catalog_metadata (key, value, updated_at)
+      VALUES ('route.outOfStationTransfer.runtimeEnabled', ?, 1781827200)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    ''',
+    [enabled ? 'true' : 'false'],
+  );
 }
 
 Future<void> _fillInsertedNetworkEdgeEvidence(CatalogDatabase database) async {

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -1438,6 +1438,27 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("backend planner는 allowlist 없는 역외 환승 간선을 내부 경로 후보로 승격하지 않는다")
+	void searchInternalRouteIgnoresOutOfStationTransferEdges() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeEdgeService = new RouteSearchService(
+			repository,
+			repository,
+			new OutOfStationTransferOnlyTransitMasterPort(),
+			CLOCK
+		);
+
+		assertThatThrownBy(() -> routeEdgeService.searchInternalRoute(new SearchInternalRouteCommand(
+			"station-a",
+			"node-station-a-entrance",
+			"node-station-a-platform",
+			MobilityType.STROLLER
+		)))
+			.isInstanceOf(RouteNotFoundException.class)
+			.hasMessage("연결 가능한 경로를 찾을 수 없습니다.");
+	}
+
+	@Test
 	@DisplayName("휠체어 역 내부 이동 경로는 계단만 있으면 차단한다")
 	void wheelchairInternalRouteBlocksStairOnlyInternalPath() {
 		var repository = new InMemoryRouteSearchRepository();
@@ -2503,6 +2524,30 @@ class RouteSearchServiceTest {
 			return List.of(
 				routeNode("node-station-a-entrance", "station-a", RouteNodeType.ENTRANCE, "출입구"),
 				routeNode("node-station-a-landing", "station-a", RouteNodeType.CONCOURSE, "중간 지점"),
+				routeNode("node-station-a-platform", "station-a", RouteNodeType.PLATFORM, "승강장")
+			);
+		}
+	}
+
+	private static class OutOfStationTransferOnlyTransitMasterPort extends ExitSummaryAccessibleTransitMasterPort {
+
+		@Override
+		public List<RouteEdge> loadRouteEdges() {
+			return List.of(internalEdge(
+				"edge-a-out-of-station-transfer",
+				"node-station-a-entrance",
+				"node-station-a-platform",
+				RouteEdgeType.OUT_OF_STATION_TRANSFER,
+				120,
+				180,
+				false
+			));
+		}
+
+		@Override
+		public List<RouteNode> loadRouteNodes() {
+			return List.of(
+				routeNode("node-station-a-entrance", "station-a", RouteNodeType.ENTRANCE, "외부 출입구"),
 				routeNode("node-station-a-platform", "station-a", RouteNodeType.PLATFORM, "승강장")
 			);
 		}

--- a/tools/routes/build-route-v2-contract-report.mjs
+++ b/tools/routes/build-route-v2-contract-report.mjs
@@ -46,8 +46,19 @@ export function buildContractReport(input) {
     routeNotFoundRate: input.samples.length === 0
       ? 0
       : (input.samples.length - foundSamples.length) / input.samples.length,
+    outOfStationTransferAllowlistSource: input.capabilities?.outOfStationTransferAllowlistSource ?? "",
+    outOfStationTransferAllowlistPairCount: outOfStationTransferAllowlistPairCount(input.capabilities ?? {}),
     releaseBlockersSatisfied: input.capabilities?.releaseBlockersSatisfied ?? [],
   };
+}
+
+function outOfStationTransferAllowlistPairCount(capabilities) {
+  if (Number.isFinite(Number(capabilities.outOfStationTransferAllowlistPairCount))) {
+    return Number(capabilities.outOfStationTransferAllowlistPairCount);
+  }
+  return Array.isArray(capabilities.outOfStationTransferAllowlist)
+    ? capabilities.outOfStationTransferAllowlist.length
+    : 0;
 }
 
 function parseArgs(argv) {

--- a/tools/routes/build-route-v2-contract-report.test.mjs
+++ b/tools/routes/build-route-v2-contract-report.test.mjs
@@ -42,6 +42,41 @@ test("builds route v2 contract report from runtime responses", () => {
   assert.deepEqual(report.releaseBlockersSatisfied, ["D-2", "D-3", "H-1"]);
 });
 
+test("records out-of-station transfer allowlist source in contract report", () => {
+  const report = buildContractReport({
+    schemaVersion: 1,
+    capabilities: {
+      outOfStationTransferSupported: true,
+      outOfStationTransferAllowlistSource: "catalog_metadata:route.outOfStationTransfer.allowlist",
+      outOfStationTransferAllowlist: [
+        "station-a:line-a->station-b:line-b",
+      ],
+    },
+    samples: [
+      {
+        id: "allowlisted-out-of-station-runtime",
+        response: routeResponse([
+          {
+            status: "FOUND",
+            transferCount: 1,
+            legs: [
+              { type: "RIDE", lineId: "line-a" },
+              { type: "OUT_OF_STATION_TRANSFER" },
+              { type: "RIDE", lineId: "line-b" },
+            ],
+          },
+        ]),
+      },
+    ],
+  });
+
+  assert.equal(
+    report.outOfStationTransferAllowlistSource,
+    "catalog_metadata:route.outOfStationTransfer.allowlist",
+  );
+  assert.equal(report.outOfStationTransferAllowlistPairCount, 1);
+});
+
 test("reads line sequence from route v2 legType runtime response", () => {
   const report = buildContractReport({
     schemaVersion: 1,

--- a/tools/routes/check-route-commercialization-gate.mjs
+++ b/tools/routes/check-route-commercialization-gate.mjs
@@ -249,6 +249,12 @@ function validateContract(gate, report, failures) {
   if (number(report.wrongLineSequence) > gate.routeQuality.wrongLineSequenceAllowed) failures.push("routeQuality wrong line sequence exceeds 0");
   max(report.routeNotFoundRate, gate.routeQuality.routeNotFoundRateMax, "routeQuality route not found rate", failures);
   if (gate.routing.outOfStationTransferSupported) {
+    if (report.outOfStationTransferAllowlistSource !== gate.routing.outOfStationTransferAllowlistSource) {
+      failures.push("routing out-of-station transfer allowlist source mismatch");
+    }
+    if (number(report.outOfStationTransferAllowlistPairCount) < 1) {
+      failures.push("routing out-of-station transfer allowlist must contain at least one pair");
+    }
     const satisfied = new Set(report.releaseBlockersSatisfied ?? []);
     for (const blocker of gate.outOfStationTransferReleaseBlockers) {
       if (!satisfied.has(blocker)) failures.push(`routing ${blocker} blocker must be satisfied before out-of-station transfer release claim`);

--- a/tools/routes/check-route-commercialization-gate.test.mjs
+++ b/tools/routes/check-route-commercialization-gate.test.mjs
@@ -722,6 +722,72 @@ test("route commercialization gate requires realtime coverage provider and regio
   );
 });
 
+test("route commercialization gate requires out-of-station allowlist evidence", async () => {
+  const fixture = await writeFixtureSet({
+    gateOverride: {
+      routing: {
+        outOfStationTransferSupported: true,
+        outOfStationTransferAllowlistSource: "catalog_metadata:route.outOfStationTransfer.allowlist",
+      },
+    },
+    accuracy: {
+      schemaVersion: 1,
+      sampleSize: 120,
+      sampleSourceCounts: {
+        fixture: 0,
+        staticTimetable: 0,
+        realtimeProvider: 120,
+        manualObservation: 120,
+        staleRealtime: 0,
+      },
+      productionSampleSize: 120,
+      metrics: {
+        singleRide: { sampleSize: 60, p50ErrorSeconds: 45, p90ErrorSeconds: 100 },
+        transfer: { sampleSize: 60, p50ErrorSeconds: 90, p90ErrorSeconds: 240 },
+      },
+      failures: [],
+    },
+    accessibility: {
+      schemaVersion: 1,
+      strictStepFreeKnownStairFalsePositiveCount: 0,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      unknownAccessibilityLabeled: true,
+    },
+    coverage: {
+      schemaVersion: 1,
+      supportedStationLinePairs: 150,
+      providerFreshnessSecondsMaxObserved: 80,
+      staleFallbackRequired: true,
+    },
+    routeGraphCoverage: {
+      schemaVersion: 1,
+      generatedConnectorVerifiedAccessibilityCount: 0,
+      strictRouteNotFound: { total: 100, notFoundCount: 1, rate: 0.01, byReasonCode: {} },
+    },
+    contract: {
+      schemaVersion: 1,
+      multiTransferSupported: false,
+      outOfStationTransferSupported: true,
+      alternativeItinerariesMinObserved: 2,
+      wrongTransferCount: 0,
+      wrongLineSequence: 0,
+      routeNotFoundRate: 0.01,
+      releaseBlockersSatisfied: ["D-2", "D-3", "H-1"],
+    },
+  });
+
+  await assert.rejects(
+    execChecker(fixture),
+    (error) => {
+      const report = JSON.parse(error.stdout);
+      assert.equal(report.status, "FAIL");
+      assert.ok(report.failures.includes("routing out-of-station transfer allowlist source mismatch"));
+      assert.ok(report.failures.includes("routing out-of-station transfer allowlist must contain at least one pair"));
+      return true;
+    },
+  );
+});
+
 test("route commercialization gate sorts checked reports with an explicit comparator", async () => {
   const source = await readFile("tools/routes/check-route-commercialization-gate.mjs", "utf8");
 
@@ -730,8 +796,19 @@ test("route commercialization gate sorts checked reports with an explicit compar
 
 async function writeFixtureSet(reports) {
   const dir = await mkdtemp(path.join(tmpdir(), "route-commercialization-gate-"));
+  const gatePath = path.join(dir, "route-commercialization-gate.json");
+  const gate = JSON.parse(await readFile("apps/mobile/release/route-commercialization-gate.json", "utf8"));
+  const gateOverride = reports.gateOverride ?? {};
+  await writeFile(gatePath, `${JSON.stringify({
+    ...gate,
+    ...gateOverride,
+    routing: {
+      ...gate.routing,
+      ...(gateOverride.routing ?? {}),
+    },
+  }, null, 2)}\n`);
   const files = {
-    gate: path.join(root, "apps/mobile/release/route-commercialization-gate.json"),
+    gate: gatePath,
     accuracy: path.join(dir, "route-accuracy-report.json"),
     accessibility: path.join(dir, "route-accessibility-regression-report.json"),
     coverage: path.join(dir, "realtime-provider-coverage-report.json"),
@@ -743,7 +820,9 @@ async function writeFixtureSet(reports) {
     accuracy: normalizeAccuracyReport(reports.accuracy),
     coverage: normalizeCoverageReport(reports.coverage),
   };
-  await Promise.all(Object.entries(normalizedReports).map(([key, report]) => writeFile(files[key], `${JSON.stringify(report, null, 2)}\n`)));
+  await Promise.all(Object.entries(normalizedReports)
+    .filter(([key]) => key !== "gateOverride")
+    .map(([key, report]) => writeFile(files[key], `${JSON.stringify(report, null, 2)}\n`)));
   return files;
 }
 


### PR DESCRIPTION
## 관련 이슈

close #1411

## 작업 배경

- 역외 환승은 D-2/D-3/H-1 blocker와 allowlist 없이는 ETA 예산과 보행 안전 caveat를 통제하기 어려워 production 기본 후보로 열면 안 됩니다.

## 작업 내용

- 모바일 local route repository가 `route.outOfStationTransfer.enabled`, `route.outOfStationTransfer.runtimeEnabled`, `route.outOfStationTransfer.allowlist` catalog metadata를 읽어 역외 환승 edge를 기본 차단하고 allowlist pair만 후보로 남기도록 했습니다.
- 역외 환승 step의 문구와 warning/caveat 노출을 테스트로 고정했습니다.
- route v2 contract report와 commercialization gate가 동일 allowlist source와 pair count를 검증하도록 연결했습니다.
- backend route service는 allowlist 없는 `OUT_OF_STATION_TRANSFER` edge를 내부 경로 후보로 승격하지 않는 fail-closed 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` PASS
  - `./gradlew test` PASS
  - `flutter test test/features/routes/local_route_repository_test.dart` PASS
  - `node --test tools/routes/check-route-commercialization-gate.test.mjs tools/routes/build-route-v2-contract-report.test.mjs` PASS
  - `node --test tools/routes/*.test.mjs` PASS
  - `dart format --set-exit-if-changed apps/mobile/lib/features/routes/data/local_route_repository.dart apps/mobile/test/features/routes/local_route_repository_test.dart` PASS
  - `git diff --check origin/main...HEAD` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 역외 환승 allowlist/kill switch | mobile local route | `flutter test test/features/routes/local_route_repository_test.dart` | local test output | PASS |
| backend fail-closed guard | backend | `./gradlew test --tests com.easysubway.route.application.service.RouteSearchServiceTest` | local test output | PASS |
| route gate/contract | tools | `node --test tools/routes/*.test.mjs` | local test output | PASS |
| PR template / whitespace | repo | `git diff --check origin/main...HEAD` | local command output | PASS |
| PR CI | GitHub Actions | CI workflow | https://github.com/AquilaXk/easysubway/actions/runs/28618968217 | PASS |
| Release artifacts | GitHub Actions | Release Artifacts workflow | https://github.com/AquilaXk/easysubway/actions/runs/28618967894 | PASS |
| SonarCloud | GitHub Actions / SonarCloud | SonarCloud workflow | https://github.com/AquilaXk/easysubway/actions/runs/28618967880 | PASS |
| Code review | GitHub PR Review | Codex fallback review, actionable 0 | https://github.com/AquilaXk/easysubway/pull/1593#pullrequestreview-4620923200 | PASS |
| CodeRabbit status | GitHub status context | CodeRabbit status check, PR Review 객체 없음 확인 후 fallback review 게시 | PR status context `CodeRabbit` | PASS |
| PR 단계 CD | GitHub Actions | 배포 workflow는 PR 단계에서 실행 대상 없음, Release Artifacts로 산출물 검증 | Release Artifacts run 28618967894 | PASS |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [x] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 역외 환승 allowlist source/pair count report field 추가
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `apps/mobile/lib/features/routes/data/local_route_repository.dart`의 `_OutOfStationTransferPolicy`
  - `tools/routes/check-route-commercialization-gate.mjs`의 allowlist source/pair count 검증
  - `backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java`의 backend fail-closed 회귀 테스트

## 리스크

- 기존 catalog에 allowlist metadata가 없으면 역외 환승 edge는 기본 차단됩니다. 이는 release blocker 정책상 의도한 fail-closed 동작입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
