### PR TITLE
[Chore] source admission pipeline gate 추가

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6365,6 +6365,212 @@ test("source candidate sample evidence builder는 raw response의 TOPIS path ser
   );
 });
 
+test("source admission pipeline은 admin 승인 record로 inventory admission evidence를 만든다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-admission-${Date.now()}`);
+  const rawPath = path.join(outputDir, "kric-train-operation-organ.raw.json");
+  const seedSamplePath = path.join(outputDir, "seed-sample.json");
+  const adminReviewPath = path.join(outputDir, "admin-review.json");
+  const outputInventoryPath = path.join(outputDir, "source-inventory.admitted.json");
+  const summaryPath = path.join(outputDir, "admission-summary.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(rawPath, `${JSON.stringify([{ railOprIsttCd: "S1", railOprIsttNm: "서울교통공사" }])}\n`);
+
+  const { stdout: sampleStdout } = await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-source-candidate-sample-evidence.mjs",
+      "--candidate",
+      "kric-train-operation-organ",
+      "--response",
+      rawPath,
+    ],
+    { cwd: root },
+  );
+  await writeFile(seedSamplePath, sampleStdout);
+  const sample = JSON.parse(sampleStdout);
+  const productionSource = {
+    id: "kric-train-operation-organ",
+    displayName: "열차운영기관정보",
+    owner: "국가철도공단",
+    provider: "국가철도공단",
+    sourceSystem: "KRIC OpenAPI",
+    datasetUrl: "https://data.kric.go.kr/rips/M_01_02/detail.do?id=266&service=convenientInfo&operation=trainOperationOrgan&page=3",
+    requiredForProductionPack: false,
+    updateFrequency: "provider-documented",
+    observedDataUpdatedAt: "2026-07-02",
+    retrievedAt: "2026-07-02",
+    license: {
+      type: "KOGL-1",
+      name: "공공누리 1유형",
+      attribution: "공공누리 제1유형: 출처표시",
+      commercialUseAllowed: true,
+      derivativeWorkAllowed: true,
+      redistributionAllowed: true,
+      evidenceUrl: "https://data.kric.go.kr/rips/M_01_02/detail.do?id=266&service=convenientInfo&operation=trainOperationOrgan&page=3",
+    },
+    coverageScope: {
+      regionIds: ["capital"],
+      operatorIds: ["seoul-metro"],
+      sourceDomains: ["station_line_membership"],
+    },
+    fieldsProvided: ["railOprIsttCd", "railOprIsttNm"],
+    capabilities: {
+      schedule: {
+        status: "UNSUPPORTED",
+        productionUseAllowed: false,
+        coverageStatus: "NOT_PROVIDED_BY_SOURCE",
+        updateFrequency: "provider-documented",
+        unsupportedNotes: "candidate does not provide scheduled timetable data",
+      },
+      realtime: {
+        status: "UNSUPPORTED",
+        productionUseAllowed: false,
+        liveEtaEligible: false,
+        rateLimitStatus: "NOT_APPLICABLE",
+        coverageStatus: "NOT_PROVIDED_BY_SOURCE",
+        updateFrequency: "provider-documented",
+        unsupportedNotes: "candidate does not provide realtime arrival data",
+      },
+      facility: {
+        status: "UNSUPPORTED",
+        productionUseAllowed: false,
+        coverageStatus: "NOT_PROVIDED_BY_SOURCE",
+        updateFrequency: "provider-documented",
+        unsupportedNotes: "candidate does not provide accessibility facility records",
+      },
+    },
+  };
+  const adminReview = {
+    schemaVersion: 1,
+    artifactKind: "source-admission-admin-review",
+    candidateId: "kric-train-operation-organ",
+    sourceId: "kric-train-operation-organ",
+    snapshotId: "kric-train-operation-organ-snapshot-20260702",
+    sampleEvidenceHash: sample.evidenceHash,
+    decision: "APPROVED",
+    approvedBy: "qa-admin",
+    approvedAt: "2026-07-02T00:10:00Z",
+    licenseEvidenceHash: sha256("license-evidence"),
+    aliasLedgerHash: sha256("alias-ledger"),
+    operatorMappingLedgerHash: sha256("operator-mapping-ledger"),
+    facilityEvidenceLedgerHash: sha256("facility-evidence-ledger"),
+    routeEvidenceLedgerHash: sha256("route-evidence-ledger"),
+    overrideHash: sha256("override-ledger"),
+    productionSource,
+  };
+  await writeFile(adminReviewPath, `${JSON.stringify(adminReview, null, 2)}\n`);
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/run-source-admission-pipeline.mjs",
+      "--candidate",
+      "kric-train-operation-organ",
+      "--raw-input",
+      rawPath,
+      "--evidence-dir",
+      outputDir,
+      "--snapshot-id",
+      "kric-train-operation-organ-snapshot-20260702",
+      "--source-id",
+      "kric-train-operation-organ",
+      "--provider",
+      "국가철도공단",
+      "--retrieved-at",
+      "2026-07-02T00:00:00Z",
+      "--source-updated-at",
+      "2026-07-02T00:00:00Z",
+      "--raw-object-uri",
+      "s3://easysubway-datapack-sources/kric-train-operation-organ/20260702.json",
+      "--freshness-expires-at",
+      "2026-08-01T00:00:00Z",
+      "--raw-retention-expires-at",
+      "2026-10-01T00:00:00Z",
+      "--admin-review",
+      adminReviewPath,
+      "--output-inventory",
+      outputInventoryPath,
+      "--output",
+      summaryPath,
+    ],
+    { cwd: root },
+  );
+
+  assert.match(stdout, /source admission pipeline evidence written/);
+  const summary = JSON.parse(await readFile(summaryPath, "utf8"));
+  assert.equal(summary.artifactKind, "source-admission-pipeline-evidence");
+  assert.equal(summary.candidateId, "kric-train-operation-organ");
+  assert.match(summary.sourceSnapshotSetHash, /^[0-9a-f]{64}$/);
+  assert.equal(summary.adminReviewRecordHash, sha256(JSON.stringify(sortJsonForHash(adminReview))));
+  const outputInventory = JSON.parse(await readFile(outputInventoryPath, "utf8"));
+  assert.ok(outputInventory.sources.some((source) => source.id === "kric-train-operation-organ"));
+});
+
+test("source admission pipeline은 admin 승인 없는 inventory admission을 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-admission-negative-${Date.now()}`);
+  const rawPath = path.join(outputDir, "kric-train-operation-organ.raw.json");
+  const adminReviewPath = path.join(outputDir, "admin-review.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(rawPath, `${JSON.stringify([{ railOprIsttCd: "S1", railOprIsttNm: "서울교통공사" }])}\n`);
+  await writeFile(
+    adminReviewPath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        artifactKind: "source-admission-admin-review",
+        candidateId: "kric-train-operation-organ",
+        sourceId: "kric-train-operation-organ",
+        snapshotId: "kric-train-operation-organ-snapshot-20260702",
+        sampleEvidenceHash: sha256("not-used"),
+        decision: "PENDING",
+        approvedBy: "qa-admin",
+        approvedAt: "2026-07-02T00:10:00Z",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/run-source-admission-pipeline.mjs",
+        "--candidate",
+        "kric-train-operation-organ",
+        "--raw-input",
+        rawPath,
+        "--evidence-dir",
+        outputDir,
+        "--snapshot-id",
+        "kric-train-operation-organ-snapshot-20260702",
+        "--source-id",
+        "kric-train-operation-organ",
+        "--provider",
+        "국가철도공단",
+        "--retrieved-at",
+        "2026-07-02T00:00:00Z",
+        "--raw-object-uri",
+        "s3://easysubway-datapack-sources/kric-train-operation-organ/20260702.json",
+        "--freshness-expires-at",
+        "2026-08-01T00:00:00Z",
+        "--raw-retention-expires-at",
+        "2026-10-01T00:00:00Z",
+        "--admin-review",
+        adminReviewPath,
+        "--output-inventory",
+        path.join(outputDir, "source-inventory.admitted.json"),
+        "--output",
+        path.join(outputDir, "admission-summary.json"),
+      ],
+      { cwd: root },
+    ),
+    /adminReview\.decision must be APPROVED/,
+  );
+});
+
 test("전국 coverage gap report는 현재 source inventory의 누락 coverage를 실패로 노출한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-coverage-gap-fail-${Date.now()}`);
   const reportPath = path.join(outputDir, "coverage-gap-report.json");
@@ -8980,6 +9186,15 @@ test("데이터팩 만료 알림 evidence는 SLA 임박 manifest를 FIRING으로
 
 function sha256(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+function sortJsonForHash(value) {
+  if (Array.isArray(value)) return value.map(sortJsonForHash);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.entries(value).sort(([left], [right]) => left.localeCompare(right)).map(([key, entry]) => [
+    key,
+    sortJsonForHash(entry),
+  ]));
 }
 
 function objectStorageEnv(origin) {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import test from "node:test";
+import { sortJson } from "./run-source-admission-pipeline.mjs";
 
 const execFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
@@ -6502,9 +6503,130 @@ test("source admission pipeline은 admin 승인 record로 inventory admission ev
   assert.equal(summary.artifactKind, "source-admission-pipeline-evidence");
   assert.equal(summary.candidateId, "kric-train-operation-organ");
   assert.match(summary.sourceSnapshotSetHash, /^[0-9a-f]{64}$/);
-  assert.equal(summary.adminReviewRecordHash, sha256(JSON.stringify(sortJsonForHash(adminReview))));
+  assert.equal(summary.adminReviewRecordHash, sha256(JSON.stringify(sortJson(adminReview))));
+  assert.equal(summary.licenseEvidenceHash, adminReview.licenseEvidenceHash);
   const outputInventory = JSON.parse(await readFile(outputInventoryPath, "utf8"));
   assert.ok(outputInventory.sources.some((source) => source.id === "kric-train-operation-organ"));
+});
+
+test("source admission pipeline은 JSON credential raw response를 저장 전에 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-admission-secret-${Date.now()}`);
+  const rawPath = path.join(outputDir, "kric-train-operation-organ.raw.json");
+  const adminReviewPath = path.join(outputDir, "admin-review.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(rawPath, JSON.stringify({ response: { body: { serviceKey: "actual-secret" } } }));
+  await writeFile(
+    adminReviewPath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        artifactKind: "source-admission-admin-review",
+        decision: "APPROVED",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/run-source-admission-pipeline.mjs",
+        "--candidate",
+        "kric-train-operation-organ",
+        "--raw-input",
+        rawPath,
+        "--evidence-dir",
+        outputDir,
+        "--snapshot-id",
+        "kric-train-operation-organ-snapshot-20260702",
+        "--source-id",
+        "kric-train-operation-organ",
+        "--provider",
+        "국가철도공단",
+        "--retrieved-at",
+        "2026-07-02T00:00:00Z",
+        "--raw-object-uri",
+        "s3://easysubway-datapack-sources/kric-train-operation-organ/20260702.json",
+        "--freshness-expires-at",
+        "2026-08-01T00:00:00Z",
+        "--raw-retention-expires-at",
+        "2026-10-01T00:00:00Z",
+        "--admin-review",
+        adminReviewPath,
+        "--output-inventory",
+        path.join(outputDir, "source-inventory.admitted.json"),
+        "--output",
+        path.join(outputDir, "admission-summary.json"),
+      ],
+      { cwd: root },
+    ),
+    /source admission raw response contains credential-like token/,
+  );
+});
+
+test("source admission pipeline은 live fetch 실패 메시지에서 service key를 숨긴다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-admission-fetch-secret-${Date.now()}`);
+  const adminReviewPath = path.join(outputDir, "admin-review.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    adminReviewPath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        artifactKind: "source-admission-admin-review",
+        decision: "APPROVED",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/run-source-admission-pipeline.mjs",
+        "--candidate",
+        "kric-train-operation-organ",
+        "--url-template",
+        "http://127.0.0.1:1/source?serviceKey={serviceKey}",
+        "--service-key-env",
+        "EASYSUBWAY_TEST_SERVICE_KEY",
+        "--evidence-dir",
+        outputDir,
+        "--snapshot-id",
+        "kric-train-operation-organ-snapshot-20260702",
+        "--source-id",
+        "kric-train-operation-organ",
+        "--provider",
+        "국가철도공단",
+        "--retrieved-at",
+        "2026-07-02T00:00:00Z",
+        "--raw-object-uri",
+        "s3://easysubway-datapack-sources/kric-train-operation-organ/20260702.json",
+        "--freshness-expires-at",
+        "2026-08-01T00:00:00Z",
+        "--raw-retention-expires-at",
+        "2026-10-01T00:00:00Z",
+        "--admin-review",
+        adminReviewPath,
+        "--output-inventory",
+        path.join(outputDir, "source-inventory.admitted.json"),
+        "--output",
+        path.join(outputDir, "admission-summary.json"),
+      ],
+      { cwd: root, env: { ...process.env, EASYSUBWAY_TEST_SERVICE_KEY: "actual-secret-value" } },
+    ),
+    (error) => {
+      assert.match(error.stderr, /source live fetch failed before response/);
+      assert.doesNotMatch(error.stderr, /actual-secret-value/);
+      return true;
+    },
+  );
 });
 
 test("source admission pipeline은 admin 승인 없는 inventory admission을 거부한다", async () => {
@@ -9186,15 +9308,6 @@ test("데이터팩 만료 알림 evidence는 SLA 임박 manifest를 FIRING으로
 
 function sha256(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
-}
-
-function sortJsonForHash(value) {
-  if (Array.isArray(value)) return value.map(sortJsonForHash);
-  if (!value || typeof value !== "object") return value;
-  return Object.fromEntries(Object.entries(value).sort(([left], [right]) => left.localeCompare(right)).map(([key, entry]) => [
-    key,
-    sortJsonForHash(entry),
-  ]));
 }
 
 function objectStorageEnv(origin) {

--- a/tools/datapack/run-source-admission-pipeline.mjs
+++ b/tools/datapack/run-source-admission-pipeline.mjs
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -23,7 +24,7 @@ async function main() {
 
   const raw = await readRaw(args);
   assertNoCredential(raw);
-  await writeFile(rawPath, raw.endsWith("\n") ? raw : `${raw}\n`);
+  await writeFile(rawPath, raw);
 
   const sample = await buildSampleEvidence({ candidateId, rawPath, samplePath, args });
   const snapshot = await buildSnapshot({ rawPath, canonicalRawPath, snapshotPath, args });
@@ -51,6 +52,7 @@ async function main() {
     sourceSnapshotSetHash: sha256(JSON.stringify([snapshot])),
     sourceInventorySha256: sha256(JSON.stringify(outputInventory)),
     adminReviewRecordHash,
+    licenseEvidenceHash: adminReview.licenseEvidenceHash,
     aliasLedgerHash: adminReview.aliasLedgerHash,
     operatorMappingLedgerHash: adminReview.operatorMappingLedgerHash,
     facilityEvidenceLedgerHash: adminReview.facilityEvidenceLedgerHash,
@@ -91,11 +93,20 @@ async function readRaw(args) {
     throw new Error(`${args["service-key-env"]} is required for live source fetch`);
   }
   const url = args["url-template"].replace("{serviceKey}", encodeURIComponent(key));
-  const response = await fetch(url);
+  let response;
+  try {
+    response = await fetch(url);
+  } catch {
+    throw new Error("source live fetch failed before response");
+  }
   if (!response.ok) {
     throw new Error(`source live fetch failed: ${response.status}`);
   }
-  return response.text();
+  try {
+    return await response.text();
+  } catch {
+    throw new Error("source live fetch response read failed");
+  }
 }
 
 async function buildSampleEvidence({ candidateId, rawPath, samplePath, args }) {
@@ -199,7 +210,7 @@ async function readJson(filePath) {
 }
 
 function assertNoCredential(raw) {
-  if (/(serviceKey|apiKey|access[_-]?token|secret)[=:][^\s&"']+/i.test(raw)) {
+  if (/"?(serviceKey|apiKey|access[_-]?token|secret)"?\s*[:=]\s*"?[^\s&"'}]+/i.test(raw)) {
     throw new Error("source admission raw response contains credential-like token");
   }
 }
@@ -238,7 +249,13 @@ function sha256(value) {
   return createHash("sha256").update(value).digest("hex");
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+export { sortJson };

--- a/tools/datapack/run-source-admission-pipeline.mjs
+++ b/tools/datapack/run-source-admission-pipeline.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(import.meta.dirname, "../..");
+
+async function main() {
+  const startedAt = Date.now();
+  const args = parseArgs(process.argv.slice(2));
+  const candidateId = requireArg(args, "candidate");
+  const evidenceDir = path.resolve(root, requireArg(args, "evidence-dir"));
+  await mkdir(evidenceDir, { recursive: true });
+
+  const rawPath = path.join(evidenceDir, `${candidateId}.raw`);
+  const samplePath = path.join(evidenceDir, `${candidateId}.sample-evidence.json`);
+  const snapshotPath = path.join(evidenceDir, `${requireArg(args, "snapshot-id")}.snapshot.json`);
+  const canonicalRawPath = path.join(evidenceDir, `${requireArg(args, "snapshot-id")}.canonical.raw`);
+  const outputInventoryPath = path.resolve(root, requireArg(args, "output-inventory"));
+
+  const raw = await readRaw(args);
+  assertNoCredential(raw);
+  await writeFile(rawPath, raw.endsWith("\n") ? raw : `${raw}\n`);
+
+  const sample = await buildSampleEvidence({ candidateId, rawPath, samplePath, args });
+  const snapshot = await buildSnapshot({ rawPath, canonicalRawPath, snapshotPath, args });
+  const adminReview = await readJson(path.resolve(root, requireArg(args, "admin-review")));
+  const adminReviewRecordHash = validateAdminReview({ adminReview, candidateId, sample, snapshot, args });
+  const inventory = await readJson(path.resolve(root, requireArg(args, "inventory")));
+  const outputInventory = admitSource({ inventory, productionSource: adminReview.productionSource });
+  await writeFile(outputInventoryPath, `${JSON.stringify(outputInventory, null, 2)}\n`);
+  await execNode(["tools/datapack/validate-source-inventory.mjs", "--inventory", outputInventoryPath]);
+
+  const summary = {
+    schemaVersion: 1,
+    artifactKind: "source-admission-pipeline-evidence",
+    candidateId,
+    sourceId: requireArg(args, "source-id"),
+    snapshotId: snapshot.snapshotId,
+    decision: adminReview.decision,
+    sampleEvidencePath: path.relative(root, samplePath),
+    sourceSnapshotPath: path.relative(root, snapshotPath),
+    outputInventoryPath: path.relative(root, outputInventoryPath),
+    rawObjectUri: snapshot.rawObjectUri,
+    rawSha256: sample.rawSha256,
+    schemaFingerprint: sample.schemaFingerprint,
+    providerRecordHashes: sample.providerRecordHashes,
+    sourceSnapshotSetHash: sha256(JSON.stringify([snapshot])),
+    sourceInventorySha256: sha256(JSON.stringify(outputInventory)),
+    adminReviewRecordHash,
+    aliasLedgerHash: adminReview.aliasLedgerHash,
+    operatorMappingLedgerHash: adminReview.operatorMappingLedgerHash,
+    facilityEvidenceLedgerHash: adminReview.facilityEvidenceLedgerHash,
+    routeEvidenceLedgerHash: adminReview.routeEvidenceLedgerHash,
+    overrideHash: adminReview.overrideHash,
+    admissionDurationSeconds: Math.max(0, Math.round((Date.now() - startedAt) / 1000)),
+  };
+
+  await writeFile(path.resolve(root, requireArg(args, "output")), `${JSON.stringify(summary, null, 2)}\n`);
+  console.log(`source admission pipeline evidence written: ${path.relative(root, requireArg(args, "output"))}`);
+}
+
+function parseArgs(argv) {
+  const args = {
+    candidates: "tools/datapack/source-candidates.json",
+    inventory: "tools/datapack/source-inventory.json",
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag?.startsWith("--")) throw new Error(`unexpected argument: ${flag}`);
+    if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+    args[flag.slice(2)] = value;
+    index += 1;
+  }
+  return args;
+}
+
+async function readRaw(args) {
+  if ((args["raw-input"] == null) === (args["url-template"] == null)) {
+    throw new Error("exactly one of --raw-input or --url-template is required");
+  }
+  if (args["raw-input"]) {
+    return readFile(path.resolve(root, args["raw-input"]), "utf8");
+  }
+  const key = process.env[requireArg(args, "service-key-env")];
+  if (!key) {
+    throw new Error(`${args["service-key-env"]} is required for live source fetch`);
+  }
+  const url = args["url-template"].replace("{serviceKey}", encodeURIComponent(key));
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`source live fetch failed: ${response.status}`);
+  }
+  return response.text();
+}
+
+async function buildSampleEvidence({ candidateId, rawPath, samplePath, args }) {
+  const { stdout } = await execNode([
+    "tools/datapack/build-source-candidate-sample-evidence.mjs",
+    "--candidates",
+    args.candidates,
+    "--candidate",
+    candidateId,
+    "--response",
+    rawPath,
+  ]);
+  await writeFile(samplePath, stdout);
+  await execNode([
+    "tools/datapack/validate-source-candidate-sample.mjs",
+    "--candidates",
+    args.candidates,
+    "--candidate",
+    candidateId,
+    "--sample",
+    samplePath,
+  ]);
+  return JSON.parse(stdout);
+}
+
+async function buildSnapshot({ rawPath, canonicalRawPath, snapshotPath, args }) {
+  await execNode([
+    "tools/datapack/build-source-snapshot.mjs",
+    "--input",
+    rawPath,
+    "--raw-output",
+    canonicalRawPath,
+    "--output",
+    snapshotPath,
+    "--snapshot-id",
+    requireArg(args, "snapshot-id"),
+    "--source-id",
+    requireArg(args, "source-id"),
+    "--provider",
+    requireArg(args, "provider"),
+    "--retrieved-at",
+    requireArg(args, "retrieved-at"),
+    "--raw-object-uri",
+    requireArg(args, "raw-object-uri"),
+    "--freshness-expires-at",
+    requireArg(args, "freshness-expires-at"),
+    "--raw-retention-expires-at",
+    requireArg(args, "raw-retention-expires-at"),
+    ...(args["source-updated-at"] ? ["--source-updated-at", args["source-updated-at"]] : []),
+  ]);
+  return readJson(snapshotPath);
+}
+
+function validateAdminReview({ adminReview, candidateId, sample, snapshot, args }) {
+  if (adminReview.schemaVersion !== 1) throw new Error("adminReview.schemaVersion must be 1");
+  if (adminReview.artifactKind !== "source-admission-admin-review") {
+    throw new Error("adminReview.artifactKind must be source-admission-admin-review");
+  }
+  if (adminReview.decision !== "APPROVED") throw new Error("adminReview.decision must be APPROVED");
+  assertEqual(adminReview.candidateId, candidateId, "adminReview.candidateId");
+  assertEqual(adminReview.sourceId, requireArg(args, "source-id"), "adminReview.sourceId");
+  assertEqual(adminReview.snapshotId, snapshot.snapshotId, "adminReview.snapshotId");
+  assertEqual(adminReview.sampleEvidenceHash, sample.evidenceHash, "adminReview.sampleEvidenceHash");
+  requiredText(adminReview.approvedBy, "adminReview.approvedBy");
+  requiredText(adminReview.approvedAt, "adminReview.approvedAt");
+  for (const field of [
+    "licenseEvidenceHash",
+    "aliasLedgerHash",
+    "operatorMappingLedgerHash",
+    "facilityEvidenceLedgerHash",
+    "routeEvidenceLedgerHash",
+    "overrideHash",
+  ]) {
+    assertSha256(adminReview[field], `adminReview.${field}`);
+  }
+  if (!adminReview.productionSource || adminReview.productionSource.id !== adminReview.sourceId) {
+    throw new Error("adminReview.productionSource.id must match adminReview.sourceId");
+  }
+  const fieldsProvided = new Set(adminReview.productionSource.fieldsProvided ?? []);
+  for (const field of sample.fields) {
+    if (!fieldsProvided.has(field)) {
+      throw new Error(`adminReview.productionSource.fieldsProvided missing sample field: ${field}`);
+    }
+  }
+  return sha256(JSON.stringify(sortJson(adminReview)));
+}
+
+function admitSource({ inventory, productionSource }) {
+  const sources = inventory.sources.filter((source) => source.id !== productionSource.id);
+  sources.push(productionSource);
+  sources.sort((left, right) => left.id.localeCompare(right.id));
+  return { ...inventory, sources };
+}
+
+async function execNode(args) {
+  return execFileAsync(process.execPath, args, { cwd: root });
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+function assertNoCredential(raw) {
+  if (/(serviceKey|apiKey|access[_-]?token|secret)[=:][^\s&"']+/i.test(raw)) {
+    throw new Error("source admission raw response contains credential-like token");
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) throw new Error(`${label} must be ${expected}`);
+}
+
+function assertSha256(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
+    throw new Error(`${label} must be a sha256 hex string`);
+  }
+}
+
+function requiredText(value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`${label} is required`);
+  }
+  return value;
+}
+
+function requireArg(args, name) {
+  return requiredText(args[name], `--${name}`);
+}
+
+function sortJson(value) {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.entries(value).sort(([left], [right]) => left.localeCompare(right)).map(([key, entry]) => [
+    key,
+    sortJson(entry),
+  ]));
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/tools/datapack/source-admission-runbook.json
+++ b/tools/datapack/source-admission-runbook.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "source-admission-runbook",
+  "issue": 1397,
+  "command": "node tools/datapack/run-source-admission-pipeline.mjs --candidate <candidateId> --url-template '<providerUrlWith{serviceKey}>' --service-key-env <ENV_NAME> --evidence-dir .codex/evidence/1397/<candidateId> --snapshot-id <snapshotId> --source-id <sourceId> --provider <providerName> --retrieved-at <ISO> --source-updated-at <ISO> --raw-object-uri s3://<bucket>/<key> --freshness-expires-at <ISO> --raw-retention-expires-at <ISO> --admin-review <local-admin-review.json> --output-inventory <candidate-source-inventory.json> --output <admission-summary.json>",
+  "steps": [
+    "fetch provider live sample using a backend/local secret env var",
+    "write raw response only under local evidence storage",
+    "build sanitized sample evidence with rawSha256, schemaFingerprint, providerRecordHashes, and evidenceHash",
+    "validate sample evidence against source-candidates.json",
+    "build a LOCKED source snapshot with credential-free rawObjectUri and freshness expiry",
+    "require admin review APPROVED record before production inventory admission",
+    "write candidate source inventory and validate it",
+    "write admission summary with sourceSnapshotSetHash, sourceInventorySha256, ledger hashes, and adminReviewRecordHash"
+  ],
+  "secretHandling": {
+    "serviceKeyInput": "environment variable only",
+    "trackedOutput": "sanitized summary only",
+    "rawOutput": ".codex/evidence or object storage only",
+    "mobileEmbeddingAllowed": false
+  },
+  "requiredAdminReviewFields": [
+    "schemaVersion",
+    "artifactKind",
+    "candidateId",
+    "sourceId",
+    "snapshotId",
+    "sampleEvidenceHash",
+    "decision",
+    "approvedBy",
+    "approvedAt",
+    "licenseEvidenceHash",
+    "aliasLedgerHash",
+    "operatorMappingLedgerHash",
+    "facilityEvidenceLedgerHash",
+    "routeEvidenceLedgerHash",
+    "overrideHash",
+    "productionSource"
+  ]
+}


### PR DESCRIPTION
## 관련 이슈

Refs #1397

## 작업 배경

- #1397의 실제 provider live sample 승격 전에, candidate sample evidence → source snapshot → admin approval → source inventory admission을 한 명령 체인으로 재현할 gate가 필요했습니다.
- 현재 로컬 환경에는 KRIC/TOPIS service key가 없어 실제 provider 호출 증거는 남기지 않습니다. 이 PR은 key 주입 후 실행 가능한 admission pipeline과 승인 없는 admission 차단을 고정합니다.

## 작업 내용

- `run-source-admission-pipeline.mjs` 추가: raw/local input 또는 `{serviceKey}` URL template + env key로 sample을 받아 기존 evidence builder, sample validator, source snapshot builder, source inventory validator를 순서대로 실행합니다.
- `source-admission-runbook.json` 추가: live sample 실행 명령, secret handling, required admin review fields를 고정했습니다.
- datapack tool test에 admin 승인 성공/미승인 실패 admission pipeline 테스트를 추가했습니다.
- CodeRabbit review 후속으로 raw evidence hash 보존, JSON credential 감지, sanitized live fetch failure, `licenseEvidenceHash` summary, import-safe `sortJson` export/top-level await guard를 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "source admission pipeline" tools/datapack/datapack-tools.test.mjs` 통과, 4 pass
  - `node --test tools/datapack/datapack-tools.test.mjs` 통과, 163 pass
  - `node tools/datapack/validate-source-inventory.mjs` 통과
  - `git diff --check` 통과
  - GitHub CI 통과: https://github.com/AquilaXk/easysubway/actions/runs/28620067557
  - Release Artifacts 통과: https://github.com/AquilaXk/easysubway/actions/runs/28620067060
  - SonarCloud 통과, 0 new issues

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| source admission pipeline | local Node.js | datapack tool test | `node --test tools/datapack/datapack-tools.test.mjs` | 163 pass |
| source inventory validator | local Node.js | validator 직접 실행 | `node tools/datapack/validate-source-inventory.mjs` | pass |
| CI | GitHub Actions | PR checks | https://github.com/AquilaXk/easysubway/actions/runs/28620067557 | pass |
| Release Artifacts | GitHub Actions | PR checks | https://github.com/AquilaXk/easysubway/actions/runs/28620067060 | pass |
| Code review | GitHub PR Review | CodeRabbit initial review + Codex fallback latest-head review | https://github.com/AquilaXk/easysubway/pull/1594#pullrequestreview-4621029207 | pass |
| live provider sample | external provider | service key 필요 | 로컬 환경에 provider key 없음. 이 PR에서는 실행하지 않음 | pending |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/run-source-admission-pipeline.mjs`의 admin review gate와 credential handling
- CodeRabbit initial review actionable 6개는 `40b6e6e4b0b3e48198bbc5097976c0fafb5eff7a`에서 수정했고 각 inline thread에 답변했습니다.
- 최신 fix commit 재검토는 CodeRabbit rate limit으로 skipped/rate-limited되어 Codex CLI fallback review를 단일 PR review로 게시했습니다: https://github.com/AquilaXk/easysubway/pull/1594#pullrequestreview-4621029207

## 리스크

- 실제 provider key가 없는 상태에서는 #1397의 “1차 승격 실행” 완료 조건을 닫을 수 없습니다. 이 PR은 실행 가능한 pipeline과 negative gate까지만 닫습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
