### PR TITLE
[Fix] V2 realtime leg evidence 노출

### DIFF
--- a/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
+++ b/backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java
@@ -472,6 +472,11 @@ class RouteSearchController {
 		int distanceMeters,
 		String etaSource,
 		String confidence,
+		List<String> reasonCodes,
+		String providerSnapshotId,
+		String providerObservedAt,
+		String gatewayReceivedAt,
+		String servedAt,
 		AccessibilityRiskDto accessibilityRisk
 	) {
 
@@ -521,6 +526,11 @@ class RouteSearchController {
 				Math.max(0, step.distanceMeters()),
 				etaSourceOf(step).name(),
 				etaConfidenceOf(step),
+				step.reasonCodes(),
+				step.providerSnapshotId(),
+				step.providerObservedAt(),
+				step.gatewayReceivedAt(),
+				step.servedAt(),
 				AccessibilityRiskDto.from(step)
 			);
 		}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -75,6 +75,7 @@ public class RouteSearchService implements RouteSearchUseCase {
 	private static final int MINUTES_PER_STATION = 2;
 	private static final int METERS_PER_STATION = 900;
 	private static final int ACCESSIBILITY_DATA_FRESH_DAYS = 30;
+	private static final String MATCHED_REALTIME_REASON = "MATCHED_REALTIME";
 
 	private final LoadRouteSearchPort loadRouteSearchPort;
 	private final SaveRouteSearchPort saveRouteSearchPort;
@@ -1194,12 +1195,22 @@ public class RouteSearchService implements RouteSearchUseCase {
 			overlay.etaSource().name(),
 			step.distanceSource(),
 			overlay.confidence().name(),
-			overlay.warningCodes(),
+			reasonCodesFor(overlay),
 			overlay.providerSnapshotId(),
 			formatInstant(overlay.providerObservedAt()),
 			formatInstant(overlay.gatewayReceivedAt()),
 			formatInstant(Instant.now(clock))
 		);
+	}
+
+	private List<String> reasonCodesFor(RealtimeEtaOverlay.Result overlay) {
+		if (overlay.etaSource() != EtaSource.REALTIME) {
+			return overlay.warningCodes();
+		}
+		List<String> reasonCodes = new ArrayList<>();
+		reasonCodes.add(MATCHED_REALTIME_REASON);
+		reasonCodes.addAll(overlay.warningCodes());
+		return List.copyOf(reasonCodes);
 	}
 
 	private String formatInstant(Instant instant) {

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteSearchService.java
@@ -1193,8 +1193,17 @@ public class RouteSearchService implements RouteSearchUseCase {
 			step.requiresAccessibilityCheck(),
 			overlay.etaSource().name(),
 			step.distanceSource(),
-			overlay.confidence().name()
+			overlay.confidence().name(),
+			overlay.warningCodes(),
+			overlay.providerSnapshotId(),
+			formatInstant(overlay.providerObservedAt()),
+			formatInstant(overlay.gatewayReceivedAt()),
+			formatInstant(Instant.now(clock))
 		);
+	}
+
+	private String formatInstant(Instant instant) {
+		return instant == null ? null : instant.toString();
 	}
 
 	private int durationSeconds(RouteStep step) {

--- a/backend/src/main/java/com/easysubway/route/domain/RealtimeEtaOverlay.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RealtimeEtaOverlay.java
@@ -182,6 +182,8 @@ public final class RealtimeEtaOverlay {
 			evidence,
 			providerSnapshotId,
 			evidenceReceivedAt,
+			candidate.providerReceivedAt(),
+			providerReceivedAt,
 			providerHealthCount,
 			List.of()
 		);
@@ -206,6 +208,8 @@ public final class RealtimeEtaOverlay {
 			null,
 			null,
 			providerSnapshotId,
+			providerReceivedAt,
+			null,
 			providerReceivedAt,
 			providerHealthCount,
 			warningCodes
@@ -267,6 +271,8 @@ public final class RealtimeEtaOverlay {
 		String providerEvidence,
 		String providerSnapshotId,
 		Instant providerReceivedAt,
+		Instant providerObservedAt,
+		Instant gatewayReceivedAt,
 		int providerHealthCount,
 		List<String> warningCodes
 	) {

--- a/backend/src/main/java/com/easysubway/route/domain/RouteStep.java
+++ b/backend/src/main/java/com/easysubway/route/domain/RouteStep.java
@@ -1,5 +1,7 @@
 package com.easysubway.route.domain;
 
+import java.util.List;
+
 public record RouteStep(
 	int sequence,
 	String stepType,
@@ -16,7 +18,12 @@ public record RouteStep(
 	boolean requiresAccessibilityCheck,
 	String timeSource,
 	String distanceSource,
-	String confidenceLabel
+	String confidenceLabel,
+	List<String> reasonCodes,
+	String providerSnapshotId,
+	String providerObservedAt,
+	String gatewayReceivedAt,
+	String servedAt
 ) {
 	public RouteStep {
 		stairAccessState = stairAccessState == null || stairAccessState.isBlank()
@@ -25,6 +32,50 @@ public record RouteStep(
 		timeSource = timeSource == null || timeSource.isBlank() ? "UNKNOWN" : timeSource;
 		distanceSource = distanceSource == null || distanceSource.isBlank() ? "UNKNOWN" : distanceSource;
 		confidenceLabel = confidenceLabel == null || confidenceLabel.isBlank() ? "확인 필요" : confidenceLabel;
+		reasonCodes = reasonCodes == null ? List.of() : List.copyOf(reasonCodes);
+	}
+
+	public RouteStep(
+		int sequence,
+		String stepType,
+		String title,
+		String description,
+		String lineId,
+		String lineName,
+		String fromStationId,
+		String toStationId,
+		int estimatedMinutes,
+		int distanceMeters,
+		boolean includesStairs,
+		String stairAccessState,
+		boolean requiresAccessibilityCheck,
+		String timeSource,
+		String distanceSource,
+		String confidenceLabel
+	) {
+		this(
+			sequence,
+			stepType,
+			title,
+			description,
+			lineId,
+			lineName,
+			fromStationId,
+			toStationId,
+			estimatedMinutes,
+			distanceMeters,
+			includesStairs,
+			stairAccessState,
+			requiresAccessibilityCheck,
+			timeSource,
+			distanceSource,
+			confidenceLabel,
+			List.of(),
+			null,
+			null,
+			null,
+			null
+		);
 	}
 
 	public RouteStep(

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -253,7 +253,12 @@ class RouteSearchV2ControllerTest {
 			.andExpect(jsonPath("$.data.itineraries[0].etaSource").value("REALTIME"))
 			.andExpect(jsonPath("$.data.itineraries[0].etaConfidence").value("HIGH"))
 			.andExpect(jsonPath("$.data.itineraries[0].legs[0].etaSource").value("REALTIME"))
-			.andExpect(jsonPath("$.data.itineraries[0].legs[0].confidence").value("HIGH"));
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].confidence").value("HIGH"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].reasonCodes[0]").value("MATCHED_REALTIME"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].providerSnapshotId").value("seoul-topis:2026-06-30T00:14:30Z"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].providerObservedAt").value("2026-06-30T00:14:20Z"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].gatewayReceivedAt").value("2026-06-30T00:14:30Z"))
+			.andExpect(jsonPath("$.data.itineraries[0].legs[0].servedAt").value("2026-06-30T00:15:00Z"));
 	}
 
 	@Test
@@ -701,7 +706,12 @@ class RouteSearchV2ControllerTest {
 				false,
 				"REALTIME",
 				"ESTIMATED_CONSTANT",
-				"HIGH"
+				"HIGH",
+				List.of("MATCHED_REALTIME"),
+				"seoul-topis:2026-06-30T00:14:30Z",
+				"2026-06-30T00:14:20Z",
+				"2026-06-30T00:14:30Z",
+				"2026-06-30T00:15:00Z"
 			)),
 			List.of(),
 			List.of(),

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -827,7 +827,7 @@ class RouteSearchServiceTest {
 			.filteredOn(step -> "ride".equals(step.stepType()))
 			.first()
 			.satisfies(step -> {
-				assertThat(step.reasonCodes()).isEmpty();
+				assertThat(step.reasonCodes()).containsExactly("MATCHED_REALTIME");
 				assertThat(step.providerSnapshotId()).isEqualTo("test-realtime-snapshot");
 				assertThat(step.providerObservedAt()).isEqualTo("2026-07-01T00:05:00Z");
 				assertThat(step.gatewayReceivedAt()).isEqualTo("2026-07-01T00:05:00Z");

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -823,6 +823,16 @@ class RouteSearchServiceTest {
 			.filteredOn(step -> "ride".equals(step.stepType()))
 			.extracting("timeSource")
 			.containsExactly(EtaSource.REALTIME.name());
+		assertThat(plan.itineraries().getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.first()
+			.satisfies(step -> {
+				assertThat(step.reasonCodes()).isEmpty();
+				assertThat(step.providerSnapshotId()).isEqualTo("test-realtime-snapshot");
+				assertThat(step.providerObservedAt()).isEqualTo("2026-07-01T00:05:00Z");
+				assertThat(step.gatewayReceivedAt()).isEqualTo("2026-07-01T00:05:00Z");
+				assertThat(step.servedAt()).isEqualTo("2026-06-13T09:00:00Z");
+			});
 		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
 	}
 
@@ -971,6 +981,11 @@ class RouteSearchServiceTest {
 		));
 
 		assertThat(plan.itineraries().getFirst().etaSource()).isEqualTo(EtaSource.FALLBACK);
+		assertThat(plan.itineraries().getFirst().steps())
+			.filteredOn(step -> "ride".equals(step.stepType()))
+			.first()
+			.satisfies(step -> assertThat(step.reasonCodes())
+				.containsExactly("REALTIME_UNAVAILABLE_PLANNED_USED", "PROVIDER_QUOTA_EXCEEDED"));
 		assertThat(plan.statuses())
 			.containsExactly(RouteV2Status.FOUND, RouteV2Status.REALTIME_UNAVAILABLE_PLANNED_USED);
 	}

--- a/backend/src/test/java/com/easysubway/route/domain/RealtimeEtaOverlayTest.java
+++ b/backend/src/test/java/com/easysubway/route/domain/RealtimeEtaOverlayTest.java
@@ -50,6 +50,8 @@ class RealtimeEtaOverlayTest {
 		assertThat(result.providerEvidence()).isEqualTo("providerReceivedAt=2026-07-01T00:00:00Z");
 		assertThat(result.providerSnapshotId()).isEqualTo("seoul-topis:2026-07-01T00:00:00Z");
 		assertThat(result.providerReceivedAt()).isEqualTo(READY_AT);
+		assertThat(result.providerObservedAt()).isEqualTo(Instant.parse("2026-06-30T23:59:30Z"));
+		assertThat(result.gatewayReceivedAt()).isEqualTo(READY_AT);
 		assertThat(result.providerHealthCount()).isEqualTo(1);
 		assertThat(result.warningCodes()).isEmpty();
 	}


### PR DESCRIPTION
## 관련 이슈

close #1404

## 작업 배경

- realtime arrival이 V2 탐색에 반영되더라도 leg 단위 fallback reason과 provider timestamp evidence가 응답에 없으면 UI가 `REALTIME`/`PLANNED`/fallback copy를 안정적으로 분기할 수 없습니다.

## 작업 내용

- `RouteStep`에 leg 단위 realtime reason code와 provider evidence metadata를 추가했습니다.
- `RealtimeEtaOverlay`가 provider 관측 시각과 gateway 수신 시각을 분리해 반환하도록 했습니다.
- `RouteSearchService`가 overlay 결과를 ride step에 복사하고, V2 API `LegDto`가 `reasonCodes`, `providerSnapshotId`, `providerObservedAt`, `gatewayReceivedAt`, `servedAt`을 노출하도록 연결했습니다.
- V2 planner/service/controller 테스트에 realtime evidence와 fallback reason code 계약을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests com.easysubway.route.domain.RealtimeEtaOverlayTest --tests com.easysubway.route.application.service.RouteSearchServiceTest --tests com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest` PASS
  - `./gradlew test` PASS
  - `git diff --check` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| realtime overlay evidence | backend domain | `RealtimeEtaOverlayTest` | local test output | PASS |
| V2 planner/service realtime reason | backend service | `RouteSearchServiceTest` | local test output | PASS |
| V2 route API leg contract | backend API | `RouteSearchV2ControllerTest` | local test output | PASS |
| backend regression | backend | `./gradlew test` | local test output | PASS |
| whitespace | repo | `git diff --check` | local command output | PASS |
| PR CI | GitHub Actions | CI workflow | https://github.com/AquilaXk/easysubway/actions/runs/28620518755 | PASS |
| Release artifacts | GitHub Actions | Release Artifacts workflow | https://github.com/AquilaXk/easysubway/actions/runs/28620518350 | PASS |
| SonarCloud | GitHub Actions / SonarCloud | SonarCloud workflow | https://github.com/AquilaXk/easysubway/actions/runs/28620518283 | PASS |
| Code review | GitHub PR Review | Codex fallback review, actionable 0 | https://github.com/AquilaXk/easysubway/pull/1595#pullrequestreview-4621062767 | PASS |
| CodeRabbit status | GitHub status context | CodeRabbit status check, PR Review 객체 없음 확인 후 fallback review 게시 | PR status context `CodeRabbit` | PASS |
| PR 단계 CD | GitHub Actions | 배포 workflow는 PR 단계에서 실행 대상 없음, Release Artifacts로 backend image 검증 | Release Artifacts run 28620518350 | PASS |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [x] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: V2 leg realtime evidence/reason metadata 추가
- realtime contract: provider observed/gateway received/served timestamp 노출
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `backend/src/main/java/com/easysubway/route/domain/RouteStep.java` metadata 필드 추가
  - `backend/src/main/java/com/easysubway/route/domain/RealtimeEtaOverlay.java` timestamp 분리
  - `backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java` V2 `LegDto` 응답 필드

## 리스크

- V2 route leg 응답에 nullable metadata 필드가 추가됩니다. 기존 필드는 제거하지 않았고, 기존 생성자는 빈 reason/null evidence로 유지됩니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
