### PR TITLE
[Test] route capability metadata 노출 (#1409)

### DIFF
--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -33,6 +33,14 @@ class LocalRouteRepository implements RouteSearchRepository {
       ),
       plannedTimetableSupported: routeGraphConnected,
       outOfStationTransferAllowed: false,
+      regions: catalog.regionsFor(
+        request.originStationId,
+        request.destinationStationId,
+      ),
+      operatorIds: catalog.operatorIdsFor(
+        request.originStationId,
+        request.destinationStationId,
+      ),
     );
   }
 
@@ -386,6 +394,8 @@ class RouteCapabilityMetadata {
     required this.realtimeSupported,
     required this.plannedTimetableSupported,
     required this.outOfStationTransferAllowed,
+    required this.regions,
+    required this.operatorIds,
   });
 
   final bool stationExists;
@@ -394,6 +404,8 @@ class RouteCapabilityMetadata {
   final bool realtimeSupported;
   final bool plannedTimetableSupported;
   final bool outOfStationTransferAllowed;
+  final List<String> regions;
+  final List<String> operatorIds;
 }
 
 class LocalFirstRouteSearchRepository implements RouteSearchRepository {
@@ -521,7 +533,9 @@ class RouteSearchOnlineFirstMetrics {
 class _RouteCatalogSnapshot {
   const _RouteCatalogSnapshot({
     required this.stationsById,
+    required this.regionsByStationId,
     required this.linesById,
+    required this.operatorIdsByLineId,
     required this.stationLines,
     required this.networkEdges,
     required this.strictEvidenceSupported,
@@ -530,7 +544,9 @@ class _RouteCatalogSnapshot {
   });
 
   final Map<String, String> stationsById;
+  final Map<String, String> regionsByStationId;
   final Map<String, String> linesById;
+  final Map<String, String> operatorIdsByLineId;
   final List<_StationLineSnapshot> stationLines;
   final List<_NetworkEdgeSnapshot> networkEdges;
   final bool strictEvidenceSupported;
@@ -543,10 +559,10 @@ class _RouteCatalogSnapshot {
           FROM catalog_metadata
           ''').getSingleOrNull();
     final stationRows = await database
-        .customSelect('SELECT id, name_ko FROM stations')
+        .customSelect('SELECT id, name_ko, region FROM stations')
         .get();
     final lineRows = await database
-        .customSelect('SELECT id, name_ko FROM lines')
+        .customSelect('SELECT id, name_ko, operator_id FROM lines')
         .get();
     final stationLineRows = await database.customSelect('''
           SELECT station_id, line_id, line_sequence
@@ -827,9 +843,17 @@ class _RouteCatalogSnapshot {
         for (final row in stationRows)
           row.read<String>('id'): row.read<String>('name_ko'),
       },
+      regionsByStationId: {
+        for (final row in stationRows)
+          row.read<String>('id'): row.read<String>('region'),
+      },
       linesById: {
         for (final row in lineRows)
           row.read<String>('id'): row.read<String>('name_ko'),
+      },
+      operatorIdsByLineId: {
+        for (final row in lineRows)
+          row.read<String>('id'): row.read<String>('operator_id'),
       },
       stationLines: stationLineRows
           .map(
@@ -875,6 +899,35 @@ class _RouteCatalogSnapshot {
       (keys) =>
           originKeys.any(keys.contains) && destinationKeys.any(keys.contains),
     );
+  }
+
+  List<String> regionsFor(String originStationId, String destinationStationId) {
+    return {
+      if ((regionsByStationId[originStationId] ?? '').isNotEmpty)
+        regionsByStationId[originStationId]!,
+      if ((regionsByStationId[destinationStationId] ?? '').isNotEmpty)
+        regionsByStationId[destinationStationId]!,
+    }.toList(growable: false);
+  }
+
+  List<String> operatorIdsFor(
+    String originStationId,
+    String destinationStationId,
+  ) {
+    final lineIds = {
+      ...stationLines
+          .where(
+            (stationLine) =>
+                stationLine.stationId == originStationId ||
+                stationLine.stationId == destinationStationId,
+          )
+          .map((stationLine) => stationLine.lineId),
+    };
+    return {
+      for (final lineId in lineIds)
+        if ((operatorIdsByLineId[lineId] ?? '').isNotEmpty)
+          operatorIdsByLineId[lineId]!,
+    }.toList(growable: false);
   }
 
   graph.NetworkGraph toGraph() {

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -4,6 +4,7 @@ import '../application/network_graph.dart' as graph;
 import '../application/route_engine.dart';
 import '../domain/route_request.dart' as local;
 import '../domain/route_result.dart' as local;
+import '../domain/route_step.dart' as route_step;
 
 class LocalRouteRepository implements RouteSearchRepository {
   LocalRouteRepository({required this.catalogDatabase});
@@ -17,22 +18,40 @@ class LocalRouteRepository implements RouteSearchRepository {
     final stationExists =
         catalog.hasStation(request.originStationId) &&
         catalog.hasStation(request.destinationStationId);
-    final routeGraphConnected =
-        stationExists &&
-        catalog.routeGraphConnected(
-          request.originStationId,
-          request.destinationStationId,
-        );
+    final routeResult = stationExists
+        ? catalog.routeResult(
+            request.originStationId,
+            request.destinationStationId,
+            mobilityType: local.MobilityType.luggage,
+            constraintMode: local.ConstraintMode.allowWithWarnings,
+          )
+        : null;
+    final routeGraphConnected = routeResult?.status == local.RouteStatus.found;
     return RouteCapabilityMetadata(
       stationExists: stationExists,
       routeGraphConnected: routeGraphConnected,
-      strictEvidenceSupported: catalog.strictEvidenceSupported,
+      strictEvidenceSupported:
+          stationExists &&
+          catalog.strictEvidenceSupportedFor(
+            request.originStationId,
+            request.destinationStationId,
+          ),
       realtimeSupported: catalog.realtimeSupported(
         request.originStationId,
         request.destinationStationId,
       ),
-      plannedTimetableSupported: routeGraphConnected,
-      outOfStationTransferAllowed: false,
+      plannedTimetableSupported:
+          routeGraphConnected &&
+          catalog.plannedTimetableSupported(
+            request.originStationId,
+            request.destinationStationId,
+          ),
+      outOfStationTransferAllowed:
+          routeResult?.steps.any(
+            (step) =>
+                step.type == route_step.RouteStepType.outOfStationTransfer,
+          ) ??
+          false,
       regions: catalog.regionsFor(
         request.originStationId,
         request.destinationStationId,
@@ -541,6 +560,7 @@ class _RouteCatalogSnapshot {
     required this.strictEvidenceSupported,
     required this.sourceUpdatedAt,
     required this.realtimeStationLineKeysByProvider,
+    required this.plannedStationLineKeys,
   });
 
   final Map<String, String> stationsById;
@@ -552,6 +572,7 @@ class _RouteCatalogSnapshot {
   final bool strictEvidenceSupported;
   final String sourceUpdatedAt;
   final Map<String, Set<String>> realtimeStationLineKeysByProvider;
+  final Set<String> plannedStationLineKeys;
 
   static Future<_RouteCatalogSnapshot> load(CatalogDatabase database) async {
     final sourceUpdatedAtRow = await database.customSelect('''
@@ -573,8 +594,14 @@ class _RouteCatalogSnapshot {
       database,
     );
     final realtimeRows = await database.customSelect('''
-          SELECT provider_id, station_id, line_id
-          FROM realtime_provider_station_mappings
+          SELECT station_mapping.provider_id, station_mapping.station_id,
+            station_mapping.line_id
+          FROM realtime_provider_station_mappings station_mapping
+          INNER JOIN realtime_provider_line_mappings line_mapping
+            ON line_mapping.provider_id = station_mapping.provider_id
+            AND line_mapping.line_id = station_mapping.line_id
+          WHERE station_mapping.supports_arrivals != 0
+            AND line_mapping.supports_arrivals != 0
           ''').get();
     final realtimeStationLineKeysByProvider = <String, Set<String>>{};
     for (final row in realtimeRows) {
@@ -587,6 +614,17 @@ class _RouteCatalogSnapshot {
             ),
           );
     }
+    final plannedRows = await database.customSelect('''
+          SELECT DISTINCT station_id, line_id
+          FROM transit_stop_times
+          ''').get();
+    final plannedStationLineKeys = {
+      for (final row in plannedRows)
+        _stationLineKey(
+          row.read<String>('station_id'),
+          row.read<String>('line_id'),
+        ),
+    };
     final networkEdgeColumns = await database
         .customSelect('PRAGMA table_info(network_edges)')
         .get();
@@ -881,24 +919,52 @@ class _RouteCatalogSnapshot {
         sourceUpdatedAtRow?.readNullable<int>('source_updated_at'),
       ),
       realtimeStationLineKeysByProvider: realtimeStationLineKeysByProvider,
+      plannedStationLineKeys: plannedStationLineKeys,
     );
   }
 
-  bool routeGraphConnected(
+  local.LocalRouteResult routeResult(
     String originStationId,
-    String destinationStationId,
-  ) {
-    final result = LocalRouteEngine(graph: toGraph()).search(
+    String destinationStationId, {
+    required local.MobilityType mobilityType,
+    required local.ConstraintMode constraintMode,
+  }) {
+    return LocalRouteEngine(graph: toGraph()).search(
       local.RouteRequest(
         originStationId: originStationId,
         destinationStationId: destinationStationId,
-        mobilityType: local.MobilityType.luggage,
-        constraintMode: local.ConstraintMode.allowWithWarnings,
+        mobilityType: mobilityType,
+        constraintMode: constraintMode,
         searchMode:
             local.RouteSearchMode.stationToStationWithOutOfStationTransfers,
       ),
     );
-    return result.status == local.RouteStatus.found;
+  }
+
+  bool strictEvidenceSupportedFor(
+    String originStationId,
+    String destinationStationId,
+  ) {
+    if (!strictEvidenceSupported) {
+      return false;
+    }
+    return routeResult(
+          originStationId,
+          destinationStationId,
+          mobilityType: local.MobilityType.wheelchair,
+          constraintMode: local.ConstraintMode.strictStepFree,
+        ).status ==
+        local.RouteStatus.found;
+  }
+
+  bool plannedTimetableSupported(
+    String originStationId,
+    String destinationStationId,
+  ) {
+    final originKeys = _stationLineKeysFor(originStationId);
+    final destinationKeys = _stationLineKeysFor(destinationStationId);
+    return originKeys.any(plannedStationLineKeys.contains) &&
+        destinationKeys.any(plannedStationLineKeys.contains);
   }
 
   bool realtimeSupported(String originStationId, String destinationStationId) {

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -10,6 +10,32 @@ class LocalRouteRepository implements RouteSearchRepository {
 
   final CatalogDatabase catalogDatabase;
 
+  Future<RouteCapabilityMetadata> routeCapability(
+    RouteSearchRequest request,
+  ) async {
+    final catalog = await _RouteCatalogSnapshot.load(catalogDatabase);
+    final stationExists =
+        catalog.hasStation(request.originStationId) &&
+        catalog.hasStation(request.destinationStationId);
+    final routeGraphConnected =
+        stationExists &&
+        catalog.routeGraphConnected(
+          request.originStationId,
+          request.destinationStationId,
+        );
+    return RouteCapabilityMetadata(
+      stationExists: stationExists,
+      routeGraphConnected: routeGraphConnected,
+      strictEvidenceSupported: catalog.strictEvidenceSupported,
+      realtimeSupported: catalog.realtimeSupported(
+        request.originStationId,
+        request.destinationStationId,
+      ),
+      plannedTimetableSupported: routeGraphConnected,
+      outOfStationTransferAllowed: false,
+    );
+  }
+
   Future<bool> canSearchRoute(RouteSearchRequest request) async {
     final catalog = await _RouteCatalogSnapshot.load(catalogDatabase);
     return catalog.hasStation(request.originStationId) &&
@@ -352,6 +378,24 @@ class LocalRouteRepository implements RouteSearchRepository {
   }
 }
 
+class RouteCapabilityMetadata {
+  const RouteCapabilityMetadata({
+    required this.stationExists,
+    required this.routeGraphConnected,
+    required this.strictEvidenceSupported,
+    required this.realtimeSupported,
+    required this.plannedTimetableSupported,
+    required this.outOfStationTransferAllowed,
+  });
+
+  final bool stationExists;
+  final bool routeGraphConnected;
+  final bool strictEvidenceSupported;
+  final bool realtimeSupported;
+  final bool plannedTimetableSupported;
+  final bool outOfStationTransferAllowed;
+}
+
 class LocalFirstRouteSearchRepository implements RouteSearchRepository {
   const LocalFirstRouteSearchRepository({required this.localRepository});
 
@@ -482,6 +526,7 @@ class _RouteCatalogSnapshot {
     required this.networkEdges,
     required this.strictEvidenceSupported,
     required this.sourceUpdatedAt,
+    required this.realtimeStationLineKeysByProvider,
   });
 
   final Map<String, String> stationsById;
@@ -490,6 +535,7 @@ class _RouteCatalogSnapshot {
   final List<_NetworkEdgeSnapshot> networkEdges;
   final bool strictEvidenceSupported;
   final String sourceUpdatedAt;
+  final Map<String, Set<String>> realtimeStationLineKeysByProvider;
 
   static Future<_RouteCatalogSnapshot> load(CatalogDatabase database) async {
     final sourceUpdatedAtRow = await database.customSelect('''
@@ -510,6 +556,10 @@ class _RouteCatalogSnapshot {
     final outOfStationTransferPolicy = await _OutOfStationTransferPolicy.load(
       database,
     );
+    final realtimeRows = await database.customSelect('''
+          SELECT provider_id, station_id, line_id
+          FROM realtime_provider_station_mappings
+          ''').get();
     final networkEdgeColumns = await database
         .customSelect('PRAGMA table_info(network_edges)')
         .get();
@@ -795,6 +845,35 @@ class _RouteCatalogSnapshot {
       sourceUpdatedAt: _metadataUpdatedAtIso(
         sourceUpdatedAtRow?.readNullable<int>('source_updated_at'),
       ),
+      realtimeStationLineKeysByProvider: _realtimeStationLineKeysByProvider(
+        realtimeRows,
+      ),
+    );
+  }
+
+  bool routeGraphConnected(
+    String originStationId,
+    String destinationStationId,
+  ) {
+    final result = LocalRouteEngine(graph: toGraph()).search(
+      local.RouteRequest(
+        originStationId: originStationId,
+        destinationStationId: destinationStationId,
+        mobilityType: local.MobilityType.luggage,
+        constraintMode: local.ConstraintMode.allowWithWarnings,
+        searchMode:
+            local.RouteSearchMode.stationToStationWithOutOfStationTransfers,
+      ),
+    );
+    return result.status == local.RouteStatus.found;
+  }
+
+  bool realtimeSupported(String originStationId, String destinationStationId) {
+    final originKeys = _stationLineKeysFor(originStationId);
+    final destinationKeys = _stationLineKeysFor(destinationStationId);
+    return realtimeStationLineKeysByProvider.values.any(
+      (keys) =>
+          originKeys.any(keys.contains) && destinationKeys.any(keys.contains),
     );
   }
 
@@ -1025,6 +1104,13 @@ class _RouteCatalogSnapshot {
     return stationsById.containsKey(stationId);
   }
 
+  List<String> _stationLineKeysFor(String stationId) {
+    return stationLines
+        .where((stationLine) => stationLine.stationId == stationId)
+        .map((stationLine) => _stationLineKey(stationId, stationLine.lineId))
+        .toList(growable: false);
+  }
+
   String lineName(String lineId) {
     if (lineId.isEmpty) {
       return '';
@@ -1215,6 +1301,23 @@ String _lineTransferPairKey(_RouteNodeKey from, _RouteNodeKey to) {
 
 String _stationLineKey(String stationId, String lineId) {
   return '$stationId:$lineId';
+}
+
+Map<String, Set<String>> _realtimeStationLineKeysByProvider(
+  List<dynamic> rows,
+) {
+  final keysByProvider = <String, Set<String>>{};
+  for (final row in rows) {
+    keysByProvider
+        .putIfAbsent(row.read<String>('provider_id'), () => <String>{})
+        .add(
+          _stationLineKey(
+            row.read<String>('station_id'),
+            row.read<String>('line_id'),
+          ),
+        );
+  }
+  return keysByProvider;
 }
 
 graph.RouteEdge _toGraphRouteEdge(

--- a/apps/mobile/lib/features/routes/data/local_route_repository.dart
+++ b/apps/mobile/lib/features/routes/data/local_route_repository.dart
@@ -576,6 +576,17 @@ class _RouteCatalogSnapshot {
           SELECT provider_id, station_id, line_id
           FROM realtime_provider_station_mappings
           ''').get();
+    final realtimeStationLineKeysByProvider = <String, Set<String>>{};
+    for (final row in realtimeRows) {
+      realtimeStationLineKeysByProvider
+          .putIfAbsent(row.read<String>('provider_id'), () => <String>{})
+          .add(
+            _stationLineKey(
+              row.read<String>('station_id'),
+              row.read<String>('line_id'),
+            ),
+          );
+    }
     final networkEdgeColumns = await database
         .customSelect('PRAGMA table_info(network_edges)')
         .get();
@@ -869,9 +880,7 @@ class _RouteCatalogSnapshot {
       sourceUpdatedAt: _metadataUpdatedAtIso(
         sourceUpdatedAtRow?.readNullable<int>('source_updated_at'),
       ),
-      realtimeStationLineKeysByProvider: _realtimeStationLineKeysByProvider(
-        realtimeRows,
-      ),
+      realtimeStationLineKeysByProvider: realtimeStationLineKeysByProvider,
     );
   }
 
@@ -1354,23 +1363,6 @@ String _lineTransferPairKey(_RouteNodeKey from, _RouteNodeKey to) {
 
 String _stationLineKey(String stationId, String lineId) {
   return '$stationId:$lineId';
-}
-
-Map<String, Set<String>> _realtimeStationLineKeysByProvider(
-  List<dynamic> rows,
-) {
-  final keysByProvider = <String, Set<String>>{};
-  for (final row in rows) {
-    keysByProvider
-        .putIfAbsent(row.read<String>('provider_id'), () => <String>{})
-        .add(
-          _stationLineKey(
-            row.read<String>('station_id'),
-            row.read<String>('line_id'),
-          ),
-        );
-  }
-  return keysByProvider;
 }
 
 graph.RouteEdge _toGraphRouteEdge(

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -413,6 +413,25 @@ void main() {
     expect(capability.outOfStationTransferAllowed, isFalse);
   });
 
+  test('로컬 capability는 같은 provider의 양끝 mapping이 있을 때 realtime을 지원한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedRealtimeMapping(database);
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final capability = await repository.routeCapability(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(capability.stationExists, isTrue);
+    expect(capability.realtimeSupported, isTrue);
+  });
+
   test('기존 baseline catalog도 명시 access edge를 보강해 휠체어 경로를 유지한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);
@@ -3883,6 +3902,34 @@ Future<void> _seedAvailableFacilityRoute(CatalogDatabase database) async {
         )
     ''');
   await _addEligibleStationFacilityEvidence(database);
+}
+
+Future<void> _seedRealtimeMapping(CatalogDatabase database) async {
+  await database.customStatement('''
+      INSERT INTO realtime_provider_line_mappings (
+        provider_id, provider_line_id, line_id, source_id,
+        supports_arrivals, mapping_confidence
+      )
+      VALUES (
+        'seoul-topis', '4', 'seoul-4', 'test-realtime-source',
+        1, 'OFFICIAL'
+      )
+    ''');
+  await database.customStatement('''
+      INSERT INTO realtime_provider_station_mappings (
+        provider_id, provider_line_id, provider_station_id, station_id,
+        line_id, source_id, query_name, supports_arrivals, mapping_confidence
+      )
+      VALUES
+        (
+          'seoul-topis', '4', 'topis-sangnoksu', 'station-sangnoksu',
+          'seoul-4', 'test-realtime-source', '상록수', 1, 'OFFICIAL'
+        ),
+        (
+          'seoul-topis', '4', 'topis-sadang', 'station-sadang',
+          'seoul-4', 'test-realtime-source', '사당', 1, 'OFFICIAL'
+        )
+    ''');
 }
 
 Future<void> _addFacilityStatusSnapshot(

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -411,6 +411,8 @@ void main() {
     expect(capability.realtimeSupported, isFalse);
     expect(capability.plannedTimetableSupported, isTrue);
     expect(capability.outOfStationTransferAllowed, isFalse);
+    expect(capability.regions, ['수도권']);
+    expect(capability.operatorIds, ['seoul-metro']);
   });
 
   test('로컬 capability는 같은 provider의 양끝 mapping이 있을 때 realtime을 지원한다', () async {

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -391,6 +391,28 @@ void main() {
     expect(result.blockedReasons, isEmpty);
   });
 
+  test('로컬 capability는 station 존재와 realtime 지원을 분리한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final capability = await repository.routeCapability(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(capability.stationExists, isTrue);
+    expect(capability.routeGraphConnected, isTrue);
+    expect(capability.strictEvidenceSupported, isTrue);
+    expect(capability.realtimeSupported, isFalse);
+    expect(capability.plannedTimetableSupported, isTrue);
+    expect(capability.outOfStationTransferAllowed, isFalse);
+  });
+
   test('기존 baseline catalog도 명시 access edge를 보강해 휠체어 경로를 유지한다', () async {
     final database = CatalogDatabase.memory();
     addTearDown(database.close);

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -409,10 +409,29 @@ void main() {
     expect(capability.routeGraphConnected, isTrue);
     expect(capability.strictEvidenceSupported, isTrue);
     expect(capability.realtimeSupported, isFalse);
-    expect(capability.plannedTimetableSupported, isTrue);
+    expect(capability.plannedTimetableSupported, isFalse);
     expect(capability.outOfStationTransferAllowed, isFalse);
     expect(capability.regions, ['수도권']);
     expect(capability.operatorIds, ['seoul-metro']);
+  });
+
+  test('로컬 capability는 시간표 row가 있을 때만 planned ETA를 지원한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedBaselineTimetable(database);
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final capability = await repository.routeCapability(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(capability.routeGraphConnected, isTrue);
+    expect(capability.plannedTimetableSupported, isTrue);
   });
 
   test('로컬 capability는 같은 provider의 양끝 mapping이 있을 때 realtime을 지원한다', () async {
@@ -432,6 +451,63 @@ void main() {
 
     expect(capability.stationExists, isTrue);
     expect(capability.realtimeSupported, isTrue);
+  });
+
+  test('로컬 capability는 mapping이 있어도 arrivals 미지원이면 realtime을 끈다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await database.seedBaselineIfEmpty();
+    await _seedRealtimeMapping(database, supportsArrivals: false);
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final capability = await repository.routeCapability(
+      const RouteSearchRequest(
+        originStationId: 'station-sangnoksu',
+        destinationStationId: 'station-sadang',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(capability.stationExists, isTrue);
+    expect(capability.realtimeSupported, isFalse);
+  });
+
+  test('로컬 capability strict 근거는 요청 경로 기준으로 판단한다', () async {
+    final database = CatalogDatabase.memory();
+    addTearDown(database.close);
+    await _seedLineWithoutNetworkEdges(
+      database,
+      includeExplicitAccessEdges: false,
+      fillInsertedNetworkEdgeEvidence: false,
+    );
+    await database.customStatement('''
+      INSERT INTO network_edges (
+        id, from_node_id, to_node_id, duration_seconds, edge_type,
+        stair_access_state, accessibility_status, reliability_score
+      )
+      VALUES (
+        'edge-a-b-local',
+        'station-a:line-test',
+        'station-b:line-test',
+        120,
+        'RIDE',
+        'STEP_FREE',
+        'AVAILABLE',
+        95
+      )
+    ''');
+    final repository = LocalRouteRepository(catalogDatabase: database);
+
+    final capability = await repository.routeCapability(
+      const RouteSearchRequest(
+        originStationId: 'station-a',
+        destinationStationId: 'station-b',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
+
+    expect(capability.routeGraphConnected, isTrue);
+    expect(capability.strictEvidenceSupported, isFalse);
   });
 
   test('기존 baseline catalog도 명시 access edge를 보강해 휠체어 경로를 유지한다', () async {
@@ -850,11 +926,19 @@ void main() {
         mobilityType: 'WHEELCHAIR',
       ),
     );
+    final capability = await repository.routeCapability(
+      const RouteSearchRequest(
+        originStationId: 'station-b',
+        destinationStationId: 'station-c',
+        mobilityType: 'WHEELCHAIR',
+      ),
+    );
 
     final transferStep = result.steps.singleWhere(
       (step) => step.stepType == 'outOfStationTransfer',
     );
     expect(result.status, 'FOUND');
+    expect(capability.outOfStationTransferAllowed, isTrue);
     expect(result.transferCount, 1);
     expect(
       result.warnings.map((warning) => warning.code),
@@ -3906,7 +3990,67 @@ Future<void> _seedAvailableFacilityRoute(CatalogDatabase database) async {
   await _addEligibleStationFacilityEvidence(database);
 }
 
-Future<void> _seedRealtimeMapping(CatalogDatabase database) async {
+Future<void> _seedBaselineTimetable(CatalogDatabase database) async {
+  await database.customStatement('''
+      INSERT INTO service_calendars (
+        service_id, monday, tuesday, wednesday, thursday, friday,
+        saturday, sunday, start_date, end_date
+      )
+      VALUES (
+        'weekday-service', 1, 1, 1, 1, 1, 0, 0, '20260101', '20261231'
+      )
+    ''');
+  await database.customStatement('''
+      INSERT INTO transit_routes (
+        id, line_id, route_short_name, route_long_name, direction_name
+      )
+      VALUES (
+        'route-seoul-4-down', 'seoul-4', '4', '4호선 상록수-사당', '사당 방면'
+      )
+    ''');
+  await database.customStatement('''
+      INSERT INTO transit_trips (
+        id, route_id, service_id, trip_headsign, direction_id, service_pattern
+      )
+      VALUES (
+        'trip-seoul-4-sangnoksu-sadang',
+        'route-seoul-4-down',
+        'weekday-service',
+        '사당',
+        'UP',
+        'LOCAL'
+      )
+    ''');
+  await database.customStatement('''
+      INSERT INTO transit_stop_times (
+        trip_id, stop_sequence, station_id, line_id, arrival_seconds,
+        departure_seconds
+      )
+      VALUES
+        (
+          'trip-seoul-4-sangnoksu-sadang',
+          1,
+          'station-sangnoksu',
+          'seoul-4',
+          28800,
+          28830
+        ),
+        (
+          'trip-seoul-4-sangnoksu-sadang',
+          2,
+          'station-sadang',
+          'seoul-4',
+          29520,
+          29550
+        )
+    ''');
+}
+
+Future<void> _seedRealtimeMapping(
+  CatalogDatabase database, {
+  bool supportsArrivals = true,
+}) async {
+  final supportsArrivalsValue = supportsArrivals ? 1 : 0;
   await database.customStatement('''
       INSERT INTO realtime_provider_line_mappings (
         provider_id, provider_line_id, line_id, source_id,
@@ -3914,7 +4058,7 @@ Future<void> _seedRealtimeMapping(CatalogDatabase database) async {
       )
       VALUES (
         'seoul-topis', '4', 'seoul-4', 'test-realtime-source',
-        1, 'OFFICIAL'
+        $supportsArrivalsValue, 'OFFICIAL'
       )
     ''');
   await database.customStatement('''
@@ -3925,11 +4069,13 @@ Future<void> _seedRealtimeMapping(CatalogDatabase database) async {
       VALUES
         (
           'seoul-topis', '4', 'topis-sangnoksu', 'station-sangnoksu',
-          'seoul-4', 'test-realtime-source', '상록수', 1, 'OFFICIAL'
+          'seoul-4', 'test-realtime-source', '상록수',
+          $supportsArrivalsValue, 'OFFICIAL'
         ),
         (
           'seoul-topis', '4', 'topis-sadang', 'station-sadang',
-          'seoul-4', 'test-realtime-source', '사당', 1, 'OFFICIAL'
+          'seoul-4', 'test-realtime-source', '사당',
+          $supportsArrivalsValue, 'OFFICIAL'
         )
     ''');
 }


### PR DESCRIPTION
## 관련 이슈

close #1409

## 작업 배경

- 경로 검색 가능 여부와 realtime/strict/planned capability가 섞이면 미지원 지역에서도 실시간 또는 검증된 접근성 경로처럼 보일 수 있습니다.
- #1419/#1400의 데이터팩 readiness에서는 지원 범위와 evidence 수준을 분리해 노출해야 합니다.

## 작업 내용

- `LocalRouteRepository.routeCapability()`를 추가해 station 존재, graph 연결, strict evidence, realtime mapping, planned timetable, 역외 환승 허용 여부를 분리합니다.
- local catalog의 realtime provider station-line mapping을 capability 판정 입력으로 연결합니다.
- region/operator 축을 포함한 capability metadata를 테스트로 고정합니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/features/routes/local_route_repository_test.dart` 통과
  - `dart format --set-exit-if-changed apps/mobile/lib/features/routes/data/local_route_repository.dart apps/mobile/test/features/routes/local_route_repository_test.dart` 통과
  - `git diff --check origin/main...HEAD` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Capability metadata contract | Mobile unit | `flutter test test/features/routes/local_route_repository_test.dart` | 로컬 명령 출력 | 통과 |
| Formatting/whitespace | Mobile | `dart format --set-exit-if-changed ...`, `git diff --check origin/main...HEAD` | 로컬 명령 출력 | 통과 |
| UI/접근성 수동 QA | Mobile UI | UI 화면 변경 없음 | 코드/계약 테스트 변경만 해당 | 해당 없음 |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [x] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: local route capability metadata contract 보강
- realtime contract: realtimeSupported capability 판정 추가
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `LocalRouteRepository.routeCapability()`가 `canSearchRoute()`와 달리 realtime/strict/planned capability를 분리하는지
  - baseline catalog와 provider mapping fixture에서 realtime 지원/미지원이 과장되지 않는지

## 리스크

- UI 표시를 직접 바꾸지는 않습니다. 후속 UI 연결 전까지는 capability metadata 계약과 repository 테스트까지만 보강됩니다.
- 실제 provider coverage는 catalog mapping 데이터 품질에 의존합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음, Release Artifacts 확인)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 로컬 경로 탐색에서 특정 출발/도착 조합의 지원 가능 여부를 한 번에 확인할 수 있게 되었습니다.
  * 역 존재 여부, 경로 연결성, 실시간/시간표 지원, 지역 및 운영사 정보를 함께 제공합니다.

* **버그 수정**
  * 실시간 지원 여부 판정이 더 정확해졌으며, 동일 제공자 기준의 매핑이 있을 때만 지원으로 처리됩니다.
  * 역 밖 환승 허용 여부가 일관되게 반영되도록 개선되었습니다.

* **테스트**
  * 경로 지원 판단과 실시간 지원 조건을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->