### PR TITLE
[Fix] online-first source 정책 문구 분리

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -17,6 +17,7 @@ import 'station_search.dart';
 
 const _routeSearchTimeout = Duration(seconds: 8);
 const _routeSearchErrorMessage = '경로 정보를 불러오지 못했어요.';
+const _routeOnlineSearchErrorMessage = '실시간/서버 경로를 확인하지 못했어요.';
 const _routeRefreshErrorMessage = '도착 시간을 새로 확인하지 못했어요.';
 const _routeFeedbackErrorMessage = '의견을 보내지 못했어요.';
 const _favoriteRouteErrorMessage = '즐겨찾기 경로를 바꾸지 못했어요.';
@@ -387,7 +388,7 @@ class RouteSearchOnlineException extends RouteSearchException {
   const RouteSearchOnlineException.unavailable({
     this.statusCode,
     this.failureReason = 'online-unavailable',
-  }) : super(_routeSearchErrorMessage);
+  }) : super(_routeOnlineSearchErrorMessage);
 
   factory RouteSearchOnlineException.http(int statusCode) {
     final backend4xxFailure = statusCode >= 400 && statusCode < 500;
@@ -405,7 +406,7 @@ class RouteSearchOnlineException extends RouteSearchException {
   const RouteSearchOnlineException._({
     required this.statusCode,
     required this.failureReason,
-  }) : super(_routeSearchErrorMessage);
+  }) : super(_routeOnlineSearchErrorMessage);
 
   final int? statusCode;
   final String failureReason;

--- a/apps/mobile/test/features/routes/local_route_repository_test.dart
+++ b/apps/mobile/test/features/routes/local_route_repository_test.dart
@@ -168,7 +168,19 @@ void main() {
             mobilityType: 'WHEELCHAIR',
           ),
         ),
-        throwsA(isA<RouteSearchException>()),
+        throwsA(
+          isA<RouteSearchOnlineException>()
+              .having(
+                (error) => error.message,
+                'message',
+                '실시간/서버 경로를 확인하지 못했어요.',
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                isNot(contains('저장된 데이터')),
+              ),
+        ),
       );
 
       expect(metrics.onlineSuccessCount, 0);
@@ -212,7 +224,19 @@ void main() {
             mobilityType: 'WHEELCHAIR',
           ),
         ),
-        throwsA(isA<RouteSearchException>()),
+        throwsA(
+          isA<RouteSearchOnlineException>()
+              .having(
+                (error) => error.message,
+                'message',
+                '실시간/서버 경로를 확인하지 못했어요.',
+              )
+              .having(
+                (error) => error.message,
+                'message',
+                isNot(contains('저장된 데이터')),
+              ),
+        ),
       );
 
       expect(metrics.onlineSuccessCount, 0);
@@ -254,7 +278,19 @@ void main() {
           mobilityType: 'WHEELCHAIR',
         ),
       ),
-      throwsA(isA<RouteSearchException>()),
+      throwsA(
+        isA<RouteSearchOnlineException>()
+            .having(
+              (error) => error.message,
+              'message',
+              '실시간/서버 경로를 확인하지 못했어요.',
+            )
+            .having(
+              (error) => error.message,
+              'message',
+              isNot(contains('저장된 데이터')),
+            ),
+      ),
     );
     expect(metrics.onlineSuccessCount, 0);
     expect(metrics.onlineFailureCount, 1);

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9768,6 +9768,42 @@ void main() {
     );
   });
 
+  testWidgets('로컬 경로 결과는 저장된 데이터 source를 실시간이나 시간표로 표시하지 않는다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(
+            result: _sampleRouteSearchResult(
+              routeSearchId: 'local-station-sangnoksu-station-sadang',
+              etaSource: 'STATIC_LOCAL',
+              sourceUpdatedAt: '2026-06-19T00:00:00Z',
+            ),
+          ),
+          stationRepository: FakeStationSearchRepository(),
+          initialMobilityType: 'SENIOR',
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 6, 23),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('예상 소요시간: 저장된 데이터 기준 · 최근 확인 2026-06-19'), findsOneWidget);
+    expect(find.textContaining('실시간'), findsNothing);
+    expect(find.textContaining('시간표'), findsNothing);
+  });
+
   testWidgets('추천 경로 항목은 스크린리더에서 상세 진입 버튼으로 남는다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     try {
@@ -13333,6 +13369,8 @@ RouteSearchResult _sampleRouteSearchResult({
   String routeSearchId = 'route-1',
   String status = 'FOUND',
   String mobilityType = 'SENIOR',
+  String etaSource = '',
+  String sourceUpdatedAt = '',
   List<RouteSearchStep>? steps,
   List<String> recommendationReasons = const [
     '엘리베이터 동선을 우선했어요',
@@ -13403,6 +13441,8 @@ RouteSearchResult _sampleRouteSearchResult({
     recommendationReasons: recommendationReasons,
     blockedReasons: [],
     createdAt: '2026-06-13T04:20:00',
+    etaSource: etaSource,
+    sourceUpdatedAt: sourceUpdatedAt,
   );
 }
 


### PR DESCRIPTION
## 관련 이슈

close #1410

## 작업 배경

- online-first 경로 검색 실패가 local static 결과로 자동 대체되지 않는 정책은 유지하되, 실패 문구가 generic해서 서버/실시간 경로 확인 실패와 저장된 데이터 안내가 분리되어 보이지 않았다.
- local static 결과가 UI에서 `REALTIME`/`PLANNED`로 오인되지 않는 negative test가 필요했다.

## 작업 내용

- `RouteSearchOnlineException` 전용 문구를 `실시간/서버 경로를 확인하지 못했어요.`로 분리했다.
- backend 5xx/404/4xx validation 실패가 local route로 숨겨지지 않고 online 실패 문구와 metrics reason을 유지하는 test를 보강했다.
- local static route result가 UI에서 `저장된 데이터 기준`과 freshness만 표시하고 `실시간`/`시간표` 문구를 표시하지 않는 widget test를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/route_search.dart apps/mobile/test/features/routes/local_route_repository_test.dart apps/mobile/test/widget_test.dart` 통과
  - `flutter test test/features/routes/local_route_repository_test.dart` 통과
  - `flutter test test/widget_test.dart --plain-name '로컬 경로 결과는 저장된 데이터 source를 실시간이나 시간표로 표시하지 않는다'` 통과
  - `git diff --check` 통과
  - GitHub PR CI `28622361195` 통과
  - GitHub Release Artifacts `28622360861` 통과
  - GitHub SonarCloud `28622360920` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| online-first 실패 copy/source policy | mobile test | `flutter test test/features/routes/local_route_repository_test.dart` | 로컬 명령 출력 | 통과 |
| local static source badge negative UI | Flutter widget test | `flutter test test/widget_test.dart --plain-name '로컬 경로 결과는 저장된 데이터 source를 실시간이나 시간표로 표시하지 않는다'` | 로컬 명령 출력 | 통과 |

## Version impact

- [ ] no version change
- [x] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteSearchOnlineException` 문구 분리
  - local static source UI negative widget test

## 리스크

- online-first 실패 문구가 바뀌므로 기존 copy snapshot 기대값이 있으면 함께 확인이 필요하다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
