### PR TITLE
[Chore] pilot route map positions 적재 (#1400)

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -7958,8 +7958,37 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
     { cwd: root },
   );
   const importedFixture = JSON.parse(await readFile(importedFixturePath, "utf8"));
-  assert.equal(importedFixture.packs[0].requiredTables.includes("route_map_positions"), false);
-  assert.equal(importedFixture.packs[0].minimumTableRows.route_map_positions, undefined);
+  assert.equal(importedFixture.packs[0].requiredTables.includes("route_map_positions"), true);
+  assert.equal(importedFixture.packs[0].minimumTableRows.route_map_positions, 2);
+  assert.equal(importedFixture.packs[0].routeMapPositions.length, 2);
+  assert.deepEqual(
+    importedFixture.packs[0].routeMapPositions.map((position) => ({
+      stationId: position.stationId,
+      lineId: position.lineId,
+      sourceId: position.sourceId,
+      sourceSha256: position.sourceSha256,
+      labelPolygonCount: position.labelPolygon.length,
+      updatedAt: position.updatedAt,
+    })),
+    [
+      {
+        stationId: "station-sangnoksu",
+        lineId: "seoul-4",
+        sourceId: "seoulmetro-cyberstation-route-map",
+        sourceSha256: "7370b4db2d2f398f46c55314b71d7335c77ec6745fd388793804874447cd25e0",
+        labelPolygonCount: 4,
+        updatedAt: "2026-06-28T00:00:00.000Z",
+      },
+      {
+        stationId: "station-sadang",
+        lineId: "seoul-4",
+        sourceId: "seoulmetro-cyberstation-route-map",
+        sourceSha256: "7370b4db2d2f398f46c55314b71d7335c77ec6745fd388793804874447cd25e0",
+        labelPolygonCount: 4,
+        updatedAt: "2026-06-28T00:00:00.000Z",
+      },
+    ],
+  );
 
   const validatorBypassFixture = JSON.parse(JSON.stringify(importedFixture));
   validatorBypassFixture.packs[0].networkEdges = validatorBypassFixture.packs[0].networkEdges.map((edge) =>
@@ -8260,7 +8289,7 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
   const routeMapRecords = provenance.packs[0].records.filter(
     (record) => record.sourceId === "seoulmetro-cyberstation-route-map",
   );
-  assert.equal(routeMapRecords.length, 0);
+  assert.equal(routeMapRecords.length, 4);
   assert.equal(
     provenance.packs[0].records.filter(
       (record) => record.entityType === "facility" && record.field === "status",
@@ -8292,7 +8321,8 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
       entry.operatorId === "seoul-metro" &&
       entry.sourceDomain === "route_map_positions",
   );
-  assert.notEqual(capitalRouteMapCoverage.status, "covered");
+  assert.equal(capitalRouteMapCoverage.status, "covered");
+  assert.deepEqual(capitalRouteMapCoverage.missingFields, []);
 });
 
 test("관리자 검수 NORMAL override는 production 시설 provenance와 validator를 통과한다", async () => {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -7989,6 +7989,44 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
       },
     ],
   );
+  for (const testCase of [
+    {
+      name: "string-label-dx",
+      mutate(position) {
+        position.labelDx = "0";
+      },
+      expected: /routeMapPositions\.labelDx must be an integer/,
+    },
+    {
+      name: "number-up-path",
+      mutate(position) {
+        position.upPath = 1;
+      },
+      expected: /routeMapPositions\.upPath must be a string/,
+    },
+  ]) {
+    const invalidRouteMapPositionInput = JSON.parse(JSON.stringify(adjacencySafeInput));
+    testCase.mutate(invalidRouteMapPositionInput.routeMapPositions[0]);
+    const invalidRouteMapPositionInputPath = path.join(outputDir, `${testCase.name}-input.json`);
+    const invalidRouteMapPositionOutputPath = path.join(outputDir, `${testCase.name}-fixture.json`);
+    await writeFile(invalidRouteMapPositionInputPath, `${JSON.stringify(invalidRouteMapPositionInput, null, 2)}\n`);
+    await assert.rejects(
+      execFileAsync(
+        process.execPath,
+        [
+          "tools/datapack/import-official-sources.mjs",
+          "--inventory",
+          "tools/datapack/source-inventory.json",
+          "--input",
+          invalidRouteMapPositionInputPath,
+          "--output",
+          invalidRouteMapPositionOutputPath,
+        ],
+        { cwd: root },
+      ),
+      testCase.expected,
+    );
+  }
 
   const validatorBypassFixture = JSON.parse(JSON.stringify(importedFixture));
   validatorBypassFixture.packs[0].networkEdges = validatorBypassFixture.packs[0].networkEdges.map((edge) =>

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -962,7 +962,11 @@ function routeMapPositionRows(rows, allowedSourceIds, mappingBySourceKey) {
       region: requiredString(row.region, "routeMapPositions.region"),
       x: requiredNonNegativeInteger(row.x, "routeMapPositions.x"),
       y: requiredNonNegativeInteger(row.y, "routeMapPositions.y"),
+      labelDx: row.labelDx ?? 0,
+      labelDy: row.labelDy ?? 0,
       labelPolygon: row.labelPolygon ?? undefined,
+      upPath: row.upPath ?? "",
+      downPath: row.downPath ?? "",
       sourceId,
       sourceName: requiredString(row.sourceName, "routeMapPositions.sourceName"),
       sourceUrl: requiredString(row.sourceUrl, "routeMapPositions.sourceUrl"),
@@ -974,6 +978,7 @@ function routeMapPositionRows(rows, allowedSourceIds, mappingBySourceKey) {
       derivationKind: "OFFICIAL",
       sourceLabel: row.sourceLabel ?? "",
       reviewedAt: requiredString(row.reviewedAt, "routeMapPositions.reviewedAt"),
+      updatedAt: requiredString(row.updatedAt, "routeMapPositions.updatedAt"),
     };
   });
 }

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -962,11 +962,11 @@ function routeMapPositionRows(rows, allowedSourceIds, mappingBySourceKey) {
       region: requiredString(row.region, "routeMapPositions.region"),
       x: requiredNonNegativeInteger(row.x, "routeMapPositions.x"),
       y: requiredNonNegativeInteger(row.y, "routeMapPositions.y"),
-      labelDx: row.labelDx ?? 0,
-      labelDy: row.labelDy ?? 0,
+      labelDx: optionalInteger(row.labelDx, "routeMapPositions.labelDx"),
+      labelDy: optionalInteger(row.labelDy, "routeMapPositions.labelDy"),
       labelPolygon: row.labelPolygon ?? undefined,
-      upPath: row.upPath ?? "",
-      downPath: row.downPath ?? "",
+      upPath: optionalString(row.upPath, "routeMapPositions.upPath"),
+      downPath: optionalString(row.downPath, "routeMapPositions.downPath"),
       sourceId,
       sourceName: requiredString(row.sourceName, "routeMapPositions.sourceName"),
       sourceUrl: requiredString(row.sourceUrl, "routeMapPositions.sourceUrl"),
@@ -1093,6 +1093,23 @@ function requiredString(value, label) {
 function requiredInteger(value, label) {
   if (!Number.isInteger(value)) {
     throw new Error(`${label} must be an integer`);
+  }
+  return value;
+}
+
+function optionalInteger(value, label) {
+  if (value === undefined || value === null) {
+    return 0;
+  }
+  return requiredInteger(value, label);
+}
+
+function optionalString(value, label) {
+  if (value === undefined || value === null) {
+    return "";
+  }
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string`);
   }
   return value;
 }

--- a/tools/datapack/inputs/capital-pilot-production-source-input.json
+++ b/tools/datapack/inputs/capital-pilot-production-source-input.json
@@ -21,6 +21,7 @@
   "sourceIds": [
     "molit-urban-rail-full-route",
     "seoulmetro-station-line-info",
+    "seoulmetro-cyberstation-route-map",
     "kric-station-elevator",
     "kric-station-elevator-movement",
     "kric-station-escalator",
@@ -52,6 +53,13 @@
       "sourceDomain": "station_line_membership",
       "sourceIds": ["molit-urban-rail-full-route", "seoulmetro-station-line-info"],
       "evidence": "국토교통부 도시철도 전체노선정보와 서울교통공사 노선별 지하철역 정보 source inventory coverageScope"
+    },
+    {
+      "regionId": "capital",
+      "operatorId": "seoul-metro",
+      "sourceDomain": "route_map_positions",
+      "sourceIds": ["seoulmetro-cyberstation-route-map"],
+      "evidence": "서울교통공사 사이버스테이션 route map snapshot sourceSha256와 label polygon 관리자 검수 기준"
     },
     {
       "regionId": "capital",
@@ -361,7 +369,66 @@
       "evidenceHash": "a3b03c2cd0fc3fb8445cb2e4946329380db7a50d8b153ba7701674d991a72343"
     }
   ],
-  "routeMapPositions": [],
+  "routeMapPositions": [
+    {
+      "sourceId": "seoulmetro-cyberstation-route-map",
+      "station": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "448",
+        "lineId": "seoul-4"
+      },
+      "region": "수도권",
+      "x": 380,
+      "y": 945,
+      "labelDx": 0,
+      "labelDy": -14,
+      "labelPolygon": [
+        { "x": 352, "y": 915 },
+        { "x": 408, "y": 915 },
+        { "x": 408, "y": 937 },
+        { "x": 352, "y": 937 }
+      ],
+      "sourceName": "서울교통공사 사이버스테이션 노선도",
+      "sourceUrl": "https://www.seoulmetro.co.kr/kr/cyberStation.do",
+      "sourceSha256": "7370b4db2d2f398f46c55314b71d7335c77ec6745fd388793804874447cd25e0",
+      "license": "공공누리 제1유형",
+      "licenseStatus": "redistributable-commercial-derivative-attribution-required",
+      "commercialUseAllowed": true,
+      "attributionRequired": true,
+      "sourceLabel": "상록수",
+      "reviewedAt": "2026-06-28T00:00:00.000Z",
+      "updatedAt": "2026-06-28T00:00:00.000Z"
+    },
+    {
+      "sourceId": "seoulmetro-cyberstation-route-map",
+      "station": {
+        "sourceId": "seoulmetro-station-line-info",
+        "sourceStationCode": "433",
+        "lineId": "seoul-4"
+      },
+      "region": "수도권",
+      "x": 705,
+      "y": 680,
+      "labelDx": 20,
+      "labelDy": -20,
+      "labelPolygon": [
+        { "x": 721, "y": 650 },
+        { "x": 769, "y": 650 },
+        { "x": 769, "y": 672 },
+        { "x": 721, "y": 672 }
+      ],
+      "sourceName": "서울교통공사 사이버스테이션 노선도",
+      "sourceUrl": "https://www.seoulmetro.co.kr/kr/cyberStation.do",
+      "sourceSha256": "7370b4db2d2f398f46c55314b71d7335c77ec6745fd388793804874447cd25e0",
+      "license": "공공누리 제1유형",
+      "licenseStatus": "redistributable-commercial-derivative-attribution-required",
+      "commercialUseAllowed": true,
+      "attributionRequired": true,
+      "sourceLabel": "사당",
+      "reviewedAt": "2026-06-28T00:00:00.000Z",
+      "updatedAt": "2026-06-28T00:00:00.000Z"
+    }
+  ],
   "facilityRows": [
     {
       "sourceId": "kric-station-elevator",


### PR DESCRIPTION
## 관련 이슈

Refs #1400

#1419 하위 작업 일부입니다. #1400/#1419는 닫지 않습니다.

## 작업 배경

- production pilot input의 routeMapPositions가 0건이라 route map position coverage가 실제 artifact로 잡히지 않았습니다.
- 상록수/사당 pilot 범위 안에서 먼저 검수 가능한 2개 station-line 좌표와 label polygon 근거를 적재합니다.

## 작업 내용

- `capital-pilot-production-source-input.json`에 `seoulmetro-cyberstation-route-map` source와 coverage evidence를 추가했습니다.
- 상록수/사당 4호선 routeMapPositions 2건을 서울교통공사 사이버스테이션 snapshot sha256, KOGL-1 라이선스, reviewedAt/updatedAt, label polygon과 함께 적재했습니다.
- importer가 route map label metadata와 `updatedAt`을 fixture/build 단계까지 보존하도록 했습니다.
- importer가 `labelDx`/`labelDy` integer와 `upPath`/`downPath` string 타입을 import 단계에서 검증하도록 보강했습니다.
- production source input 회귀 테스트를 2건 좌표, 4건 provenance field, nationwide route_map_positions coverage covered 기준으로 갱신했습니다.

## 검증

- 실행한 명령과 결과:
- `node -e "JSON.parse(require('fs').readFileSync('tools/datapack/inputs/capital-pilot-production-source-input.json','utf8')); console.log('json ok')"` PASS
- `node --test --test-name-pattern "수도권 pilot production source input" tools/datapack/datapack-tools.test.mjs` PASS, 1 test
- `node --test tools/datapack/datapack-tools.test.mjs` PASS, 163 tests
- `node tools/datapack/import-official-sources.mjs --inventory tools/datapack/source-inventory.json --input tools/datapack/inputs/capital-pilot-production-source-input.json --output /private/tmp/easysubway-1400-route-map.CpY2M6/capital-pilot-production.json` PASS
- `node tools/route-map/audit-route-map.mjs --fixture /private/tmp/easysubway-1400-route-map.CpY2M6/capital-pilot-production.json --require-label-polygons --fail-on BLOCKER,HIGH --pretty` PASS, BLOCKER 0 / HIGH 0 / coverageRatio 1 / labelPolygonCoverageRatio 1
- `git diff --check` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| route map position input | datapack | JSON parse + import-official-sources | `/private/tmp/easysubway-1400-route-map.CpY2M6/capital-pilot-production.json` | PASS |
| route map audit | datapack | audit-route-map require label polygons | stdout: BLOCKER 0, HIGH 0, coverageRatio 1, labelPolygonCoverageRatio 1 | PASS |
| datapack regression | datapack | node --test datapack-tools | 163 tests pass | PASS |
| UI evidence | mobile | UI 변경 없음 | 데이터팩 input/importer만 변경 | N/A |

## Version impact

- [ ] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [x] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [ ] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: capital v1 input 변경, release는 별도
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/inputs/capital-pilot-production-source-input.json`의 routeMapPositions region/sourceSha256/labelPolygon, `import-official-sources.mjs`의 updatedAt 보존.
- 이 PR은 #1400의 route map positions pilot 2건 적재까지만 처리합니다. 4호선 전체 인접역 graph 승격, 앱 품질 표시 evidence, production artifact 묶음 검증은 남아 있습니다.

## 리스크

- label polygon은 서울교통공사 snapshot 좌표를 기준으로 한 관리자 검수 polygon입니다. 4호선 전체 확장 시 자동 추출/검수 pipeline으로 확대해야 합니다.
- production pack strict ENTRY/EXIT coverage gap은 기존대로 남아 있으며, 이 PR에서 해결하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. CodeRabbit status check는 pass였으나 GitHub PR Review 객체가 없어 rate-limit 상태로 판단했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. Android/Backend release artifact checks와 RC Evidence Manifest를 확인했다.
