### PR TITLE
[Feat] Route result V2 badge copy 추가 (#1230)

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1423,18 +1423,18 @@ class RouteSearchResult {
 
   String get accessibilityBadgeLabel {
     if (isBlocked) {
-      return '엘리베이터 상태 확인 필요';
+      return '엘리베이터 상태를 살펴봐 주세요';
     }
     final risk = accessibilityRiskLevel.trim().toUpperCase();
     if (risk == 'HIGH' ||
         risk == 'UNKNOWN' ||
         steps.any((step) => step.requiresAccessibilityCheck)) {
-      return '엘리베이터 상태 확인 필요';
+      return '엘리베이터 상태를 살펴봐 주세요';
     }
     if (stairAccessLabel == '계단 없는 길이에요') {
       return '계단 없는 경로 확인';
     }
-    return '일부 확인 필요';
+    return '일부 이동 정보를 살펴봐 주세요';
   }
 
   String get transferBadgeLabel {
@@ -4710,17 +4710,13 @@ class _RouteResultListButton extends StatelessWidget {
 }
 
 IconData _routeBadgeIcon(String label) {
+  if (routeEtaSourceLabels.containsValue(label) ||
+      label == routeEtaSourceLabel('')) {
+    return Icons.schedule;
+  }
   return switch (label) {
-    '실시간 도착정보 준비 중' ||
-    '일부 도착정보를 확인하고 있어요' ||
-    '시간표 기준' ||
-    '저장된 데이터 기준' ||
-    '정적 추정' ||
-    '실시간 미지원' ||
-    '저장된 데이터 기준 · 갱신 필요' ||
-    '도착 정보를 확인하고 있어요' => Icons.schedule,
     '계단 없는 경로 확인' => Icons.check_circle_outline,
-    '엘리베이터 상태 확인 필요' || '일부 확인 필요' => Icons.accessible_forward,
+    '엘리베이터 상태를 살펴봐 주세요' || '일부 이동 정보를 살펴봐 주세요' => Icons.accessible_forward,
     '환승 여유 충분' || '환승 빠듯함' || '역 밖 환승' => Icons.compare_arrows,
     _ => Icons.info_outline,
   };

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -1419,6 +1419,43 @@ class RouteSearchResult {
     return '예상 소요시간: ${routeEtaSourceLabel(etaSource)}';
   }
 
+  String get etaBadgeLabel => routeEtaSourceLabel(etaSource);
+
+  String get accessibilityBadgeLabel {
+    if (isBlocked) {
+      return '엘리베이터 상태 확인 필요';
+    }
+    final risk = accessibilityRiskLevel.trim().toUpperCase();
+    if (risk == 'HIGH' ||
+        risk == 'UNKNOWN' ||
+        steps.any((step) => step.requiresAccessibilityCheck)) {
+      return '엘리베이터 상태 확인 필요';
+    }
+    if (stairAccessLabel == '계단 없는 길이에요') {
+      return '계단 없는 경로 확인';
+    }
+    return '일부 확인 필요';
+  }
+
+  String get transferBadgeLabel {
+    if (hasOutOfStationTransfer) {
+      return '역 밖 환승';
+    }
+    final slackSeconds = transferSlackSeconds;
+    if (slackSeconds == null) {
+      return '';
+    }
+    return slackSeconds <= 90 ? '환승 빠듯함' : '환승 여유 충분';
+  }
+
+  List<String> get badgeLabels {
+    return [
+      etaBadgeLabel,
+      accessibilityBadgeLabel,
+      transferBadgeLabel,
+    ].where((label) => label.trim().isNotEmpty).toList(growable: false);
+  }
+
   RouteSearchResult withDisplayLabels({
     String? originStationName,
     String? destinationStationName,
@@ -1527,6 +1564,7 @@ class RouteSearchResult {
       lineLabel,
       comfortLabel,
       stairAccessLabel,
+      ...badgeLabels,
     ];
     if (!isBlocked && warnings.isNotEmpty) {
       parts.add(attentionLabel);
@@ -4584,8 +4622,13 @@ class _RouteResultListButton extends StatelessWidget {
     final totalMinutes = _routeTotalMinutes(result);
     return Semantics(
       button: true,
-      label:
-          '${result.summaryTitle}, ${_routeMetaLabel(result)}, ${result.comfortLabel}, ${result.stairAccessLabel}',
+      label: [
+        result.summaryTitle,
+        _routeMetaLabel(result),
+        result.comfortLabel,
+        result.stairAccessLabel,
+        ...result.badgeLabels,
+      ].join(', '),
       onTap: onPressed,
       child: ExcludeSemantics(
         child: Material(
@@ -4647,6 +4690,12 @@ class _RouteResultListButton extends StatelessWidget {
                           label: result.stairAccessLabel,
                           icon: _routeStairAccessIcon(result),
                         ),
+                        for (final label in result.badgeLabels)
+                          _RouteStatusChip(
+                            key: Key('routeResultBadge-$label'),
+                            label: label,
+                            icon: _routeBadgeIcon(label),
+                          ),
                       ],
                     ),
                   ],
@@ -4658,6 +4707,23 @@ class _RouteResultListButton extends StatelessWidget {
       ),
     );
   }
+}
+
+IconData _routeBadgeIcon(String label) {
+  return switch (label) {
+    '실시간 도착정보 준비 중' ||
+    '일부 도착정보를 확인하고 있어요' ||
+    '시간표 기준' ||
+    '저장된 데이터 기준' ||
+    '정적 추정' ||
+    '실시간 미지원' ||
+    '저장된 데이터 기준 · 갱신 필요' ||
+    '도착 정보를 확인하고 있어요' => Icons.schedule,
+    '계단 없는 경로 확인' => Icons.check_circle_outline,
+    '엘리베이터 상태 확인 필요' || '일부 확인 필요' => Icons.accessible_forward,
+    '환승 여유 충분' || '환승 빠듯함' || '역 밖 환승' => Icons.compare_arrows,
+    _ => Icons.info_outline,
+  };
 }
 
 class _RouteDarkSummaryCard extends StatelessWidget {

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -1002,6 +1002,63 @@ void main() {
     expect(result.hasOutOfStationTransfer, isFalse);
   });
 
+  test('경로 결과 badge는 ETA, 접근성, 환승 explicit 필드에서 파생된다', () {
+    final tightTransfer = _sampleRouteSearchResult(
+      etaSource: 'STATIC_ESTIMATE',
+      accessibilityRiskLevel: 'HIGH',
+      transferSlackSeconds: 45,
+      hasOutOfStationTransfer: true,
+      steps: const [
+        RouteSearchStep(
+          sequence: 1,
+          stepType: 'transfer',
+          title: '역 밖 환승',
+          description: '밖으로 나가 다음 노선으로 갈아탑니다.',
+          lineId: 'seoul-4',
+          lineName: '수도권 4호선',
+          fromStationId: 'station-sadang',
+          toStationId: 'station-sadang',
+          estimatedMinutes: 5,
+          distanceMeters: 180,
+          includesStairs: false,
+          stairAccessState: 'unknown',
+          requiresAccessibilityCheck: true,
+        ),
+      ],
+    );
+
+    expect(tightTransfer.badgeLabels, ['정적 추정', '엘리베이터 상태 확인 필요', '역 밖 환승']);
+    expect(tightTransfer.semanticLabel, contains('정적 추정'));
+    expect(tightTransfer.semanticLabel, contains('엘리베이터 상태 확인 필요'));
+    expect(tightTransfer.semanticLabel, contains('역 밖 환승'));
+
+    final clearTransfer = _sampleRouteSearchResult(
+      etaSource: 'PLANNED',
+      accessibilityRiskLevel: 'LOW',
+      transferSlackSeconds: 180,
+      warnings: const [],
+      steps: const [
+        RouteSearchStep(
+          sequence: 1,
+          stepType: 'transfer',
+          title: '노선 변경 준비',
+          description: '다음 노선으로 갈아탑니다.',
+          lineId: 'seoul-4',
+          lineName: '수도권 4호선',
+          fromStationId: 'station-sadang',
+          toStationId: 'station-sadang',
+          estimatedMinutes: 4,
+          distanceMeters: 120,
+          includesStairs: false,
+          stairAccessState: 'stepFree',
+          requiresAccessibilityCheck: false,
+        ),
+      ],
+    );
+
+    expect(clearTransfer.badgeLabels, ['시간표 기준', '계단 없는 경로 확인', '환승 여유 충분']);
+  });
+
   test('경로 V2 blocked reasonCodes가 비어 있으면 status를 보존한다', () {
     const clearRisk = RouteSearchV2AccessibilityRisk(
       stairCount: 0,
@@ -1567,6 +1624,11 @@ RouteSearchResult _sampleRouteSearchResult({
     ),
   ],
   List<String> blockedReasons = const [],
+  String etaSource = '',
+  String etaConfidence = '',
+  String accessibilityRiskLevel = '',
+  int? transferSlackSeconds,
+  bool hasOutOfStationTransfer = false,
 }) {
   return RouteSearchResult(
     routeSearchId: routeSearchId,
@@ -1585,6 +1647,11 @@ RouteSearchResult _sampleRouteSearchResult({
     recommendationReasons: recommendationReasons,
     blockedReasons: blockedReasons,
     createdAt: '2026-06-13T04:20:00',
+    etaSource: etaSource,
+    etaConfidence: etaConfidence,
+    accessibilityRiskLevel: accessibilityRiskLevel,
+    transferSlackSeconds: transferSlackSeconds,
+    hasOutOfStationTransfer: hasOutOfStationTransfer,
   );
 }
 

--- a/apps/mobile/test/route_search_test.dart
+++ b/apps/mobile/test/route_search_test.dart
@@ -1027,9 +1027,9 @@ void main() {
       ],
     );
 
-    expect(tightTransfer.badgeLabels, ['정적 추정', '엘리베이터 상태 확인 필요', '역 밖 환승']);
+    expect(tightTransfer.badgeLabels, ['정적 추정', '엘리베이터 상태를 살펴봐 주세요', '역 밖 환승']);
     expect(tightTransfer.semanticLabel, contains('정적 추정'));
-    expect(tightTransfer.semanticLabel, contains('엘리베이터 상태 확인 필요'));
+    expect(tightTransfer.semanticLabel, contains('엘리베이터 상태를 살펴봐 주세요'));
     expect(tightTransfer.semanticLabel, contains('역 밖 환승'));
 
     final clearTransfer = _sampleRouteSearchResult(


### PR DESCRIPTION
## 관련 이슈

close #1230

## 작업 배경

- 경로 결과 모델에는 ETA source, 접근성 risk, 환승 여유, 역 밖 환승 필드가 있었지만 결과 카드 badge와 semantics가 이 값을 모두 노출하지 않았다.
- TalkBack 사용자가 예상 소요시간 출처, 접근성 확인 필요 여부, 환승 빠듯함을 카드에서 바로 들을 수 있어야 한다.

## 작업 내용

- `RouteSearchResult`에 ETA/accessibility/transfer badge label getter를 추가했다.
- 결과 리스트 카드 chip과 semantics label이 동일한 badge label 목록을 사용하도록 연결했다.
- `STATIC_ESTIMATE`, 접근성 HIGH/UNKNOWN, 환승 slack, 역 밖 환승이 explicit 필드에서만 badge로 파생되는 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `dart format apps/mobile/lib/route_search.dart apps/mobile/test/route_search_test.dart` 통과
  - `cd apps/mobile && flutter test test/route_search_test.dart test/accessibility_baseline_test.dart` 통과
  - `node --test tools/ci/repository-contract.test.mjs` 통과
  - `git diff --check origin/main...HEAD` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Route result badge labels | Mobile unit | `flutter test test/route_search_test.dart` | 로컬 명령 출력 | 통과 |
| Accessibility baseline | Mobile test | `flutter test test/accessibility_baseline_test.dart` | 로컬 명령 출력 | 통과 |
| Repository copy contract | Repository CI | `node --test tools/ci/repository-contract.test.mjs` | 로컬 명령 출력 | 통과 |
| Formatting/whitespace | Mobile | `dart format ...`, `git diff --check origin/main...HEAD` | 로컬 명령 출력 | 통과 |
| Manual Android TalkBack/UI tree | Mobile UI | 코드/모델 label 연결 및 unit test 변경 | 이번 PR에서 수동 RC build 화면 증거는 생성하지 않음 | 후속 RC evidence 대상 |

## Version impact

- [ ] no version change
- [x] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `RouteSearchResult.badgeLabels`가 explicit ETA/accessibility/transfer fields에서만 라벨을 만드는지
  - 결과 리스트 카드와 semantics label이 같은 badge label 목록을 쓰는지

## 리스크

- 기존 결과 카드에 ETA/accessibility badge chip이 추가로 보이므로 작은 화면에서 chip 줄바꿈이 늘어날 수 있다. 기존 `Wrap`을 유지해 겹침 대신 줄바꿈되도록 했다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (status check 성공, PR Review 객체 없음)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음, Release Artifacts 확인)
