### PR TITLE
[Fix] UNKNOWN 시설 운행상태 문구 분리 (#1394)

### DIFF
--- a/apps/mobile/lib/favorite_facility.dart
+++ b/apps/mobile/lib/favorite_facility.dart
@@ -276,7 +276,7 @@ class FavoriteFacility {
       'UNDER_CONSTRUCTION' => '공사 중',
       'CONSTRUCTION' => '공사 중',
       'CLOSED' => '폐쇄',
-      'UNKNOWN' => '상태를 확인하고 있어요',
+      'UNKNOWN' => '설치 확인 · 운행상태 미확인',
       'USER_REPORTED' => '제보됨',
       'ADMIN_VERIFIED' => '확인 완료',
       'NEEDS_REPORT' => '알려 주세요',

--- a/apps/mobile/lib/station_search.dart
+++ b/apps/mobile/lib/station_search.dart
@@ -766,7 +766,7 @@ class StationFacilityInfo {
       'UNDER_CONSTRUCTION' => '공사 중',
       'CONSTRUCTION' => '공사 중',
       'CLOSED' => '폐쇄',
-      'UNKNOWN' => '상태를 확인하고 있어요',
+      'UNKNOWN' => '설치 확인 · 운행상태 미확인',
       'USER_REPORTED' => '제보됨',
       'ADMIN_VERIFIED' => '확인 완료',
       'NEEDS_REPORT' => '알려 주세요',

--- a/apps/mobile/test/favorite_facility_test.dart
+++ b/apps/mobile/test/favorite_facility_test.dart
@@ -101,6 +101,7 @@ void main() {
     expect(reported.nextActionLabel, '역무원 도움 요청');
     expect(unknown.severityLabel, '확인 중');
     expect(unknown.nextActionLabel, '자세히 보기');
+    expect(operationalUnknown.statusLabel, '설치 확인 · 운행상태 미확인');
     expect(operationalUnknown.statusTitle, '설치 확인 · 운행상태 미확인');
     expect(operationalUnknown.needsAttention, isTrue);
     expect(available.severityLabel, '정상');

--- a/apps/mobile/test/station_search_test.dart
+++ b/apps/mobile/test/station_search_test.dart
@@ -1488,6 +1488,7 @@ void main() {
     expect(customerCenter.semanticLabel, isNot(contains('정보 신뢰도')));
     expect(customerCenter.semanticLabel, isNot(contains('현장 검증')));
     expect(customerCenter.semanticLabel, isNot(contains('출처')));
+    expect(_stationFacility(status: 'UNKNOWN').statusLabel, '설치 확인 · 운행상태 미확인');
     expect(uncheckedDescription.locationLabel, '이동 보조 시설');
     expect(uncheckedDescription.semanticLabel, isNot(contains('현장 검증')));
     expect(metadataOnlyDescription.locationLabel, 'B1-1F');


### PR DESCRIPTION
## 관련 이슈

Refs #1394

#1394 하위 조건 중 Android 역 상세/즐겨찾기 시설 UNKNOWN copy만 보강합니다. #1394/#1414는 닫지 않습니다.

## 작업 배경

- UNKNOWN 운행상태 시설은 설치 여부와 운행 가능 여부가 다르므로 `상태를 확인하고 있어요`만으로는 `사용 가능`과의 차이가 약합니다.
- 기존 `facility_status.dart`에는 UNKNOWN 전용 `설치 확인 · 운행상태 미확인` presentation이 이미 있어 모델 label만 맞추면 됩니다.

## 작업 내용

- 역 상세 시설 `StationFacilityInfo.statusLabel`의 `UNKNOWN` 문구를 `설치 확인 · 운행상태 미확인`으로 변경했습니다.
- 즐겨찾기 시설 `FavoriteFacility.statusLabel`의 `UNKNOWN` 문구도 같은 문구로 맞췄습니다.
- 두 모델 테스트에 UNKNOWN statusLabel 회귀 검증을 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `dart format apps/mobile/lib/station_search.dart apps/mobile/lib/favorite_facility.dart apps/mobile/test/station_search_test.dart apps/mobile/test/favorite_facility_test.dart` PASS
- `flutter test test/station_search_test.dart test/favorite_facility_test.dart` PASS
- `node --test tools/ci/repository-contract.test.mjs` PASS, 156 tests
- `git diff --check` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| UNKNOWN facility copy | mobile model | Flutter unit tests | `station_search_test.dart`, `favorite_facility_test.dart` | PASS |
| copy policy | repository | repository contract | `node --test tools/ci/repository-contract.test.mjs` | PASS |
| UI screenshot | mobile | 화면 구조 변경 없음 | 모델 label copy만 변경 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `StationFacilityInfo.statusLabel`, `FavoriteFacility.statusLabel`의 `UNKNOWN` 문구.
- 기존 `facilityStatusPresentation('UNKNOWN')`의 statusTitle과 모델 statusLabel을 맞춘 변경입니다.

## 리스크

- 화면에 노출되는 UNKNOWN 시설 문구가 길어집니다. 이미 statusTitle에서 쓰던 문구라 의미 변경은 없습니다.
- pathway graph, field evidence, strict route regression은 이 PR에서 해결하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (배포 영향 없음, Release Artifacts 성공 확인)
