### PR TITLE
[Chore] 시간표 headway 근거 artifact 추가 (#1415)

### DIFF
--- a/tools/datapack/build-headway-report.mjs
+++ b/tools/datapack/build-headway-report.mjs
@@ -42,6 +42,9 @@ function headwaysForPack(pack) {
   const departuresByGroup = new Map();
 
   for (const stopTime of pack.transitStopTimes ?? []) {
+    if (stopTime.pickupType === 1) {
+      continue;
+    }
     const trip = tripsById.get(stopTime.tripId);
     const route = trip ? routesById.get(trip.routeId) : undefined;
     if (!trip || !route) {

--- a/tools/datapack/build-headway-report.mjs
+++ b/tools/datapack/build-headway-report.mjs
@@ -51,11 +51,12 @@ function headwaysForPack(pack) {
     if (!trip || !route) {
       continue;
     }
+    const servicePattern = trip.servicePattern ?? "LOCAL";
     const key = [
       route.lineId,
       trip.serviceId,
       trip.directionId,
-      trip.servicePattern,
+      servicePattern,
       stopTime.stationId,
       stopTime.lineId,
     ].join("|");
@@ -64,7 +65,7 @@ function headwaysForPack(pack) {
         lineId: route.lineId,
         serviceId: trip.serviceId,
         directionId: trip.directionId,
-        servicePattern: trip.servicePattern,
+        servicePattern,
         stationId: stopTime.stationId,
         stationLineId: stopTime.lineId,
         departures: [],

--- a/tools/datapack/build-headway-report.mjs
+++ b/tools/datapack/build-headway-report.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const args = Object.fromEntries(process.argv.slice(2).flatMap((value, index, values) =>
+  value.startsWith("--") ? [[value.slice(2), values[index + 1]]] : [],
+));
+
+if (!args.fixture) {
+  console.error("usage: build-headway-report.mjs --fixture <catalog-fixture.json> [--output <report.json>]");
+  process.exit(1);
+}
+
+try {
+  const fixture = JSON.parse(await readFile(args.fixture, "utf8"));
+  const packs = (fixture.packs ?? []).map(headwaysForPack);
+  const report = {
+    schemaVersion: 1,
+    artifactKind: "datapack-headway-report",
+    summary: {
+      packCount: packs.length,
+      observedHeadwayGroupCount: packs.reduce((count, pack) => count + pack.observedHeadways.length, 0),
+      declaredFrequencyCount: packs.reduce((count, pack) => count + pack.declaredFrequencies.length, 0),
+    },
+    packs,
+  };
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+  if (args.output) {
+    await mkdir(path.dirname(args.output), { recursive: true });
+    await writeFile(args.output, json);
+  } else {
+    process.stdout.write(json);
+  }
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
+
+function headwaysForPack(pack) {
+  const routesById = new Map((pack.transitRoutes ?? []).map((route) => [route.id, route]));
+  const tripsById = new Map((pack.transitTrips ?? []).map((trip) => [trip.id, trip]));
+  const departuresByGroup = new Map();
+
+  for (const stopTime of pack.transitStopTimes ?? []) {
+    const trip = tripsById.get(stopTime.tripId);
+    const route = trip ? routesById.get(trip.routeId) : undefined;
+    if (!trip || !route) {
+      continue;
+    }
+    const key = [
+      route.lineId,
+      trip.serviceId,
+      trip.directionId,
+      trip.servicePattern,
+      stopTime.stationId,
+      stopTime.lineId,
+    ].join("|");
+    if (!departuresByGroup.has(key)) {
+      departuresByGroup.set(key, {
+        lineId: route.lineId,
+        serviceId: trip.serviceId,
+        directionId: trip.directionId,
+        servicePattern: trip.servicePattern,
+        stationId: stopTime.stationId,
+        stationLineId: stopTime.lineId,
+        departures: [],
+      });
+    }
+    departuresByGroup.get(key).departures.push(stopTime.departureSeconds);
+  }
+
+  const observedHeadways = [...departuresByGroup.values()]
+    .map((group) => {
+      const departures = [...new Set(group.departures)].sort((left, right) => left - right);
+      const gaps = departures.slice(1).map((departure, index) => departure - departures[index]);
+      return {
+        ...group,
+        departures,
+        minHeadwaySeconds: gaps.length ? Math.min(...gaps) : null,
+        maxHeadwaySeconds: gaps.length ? Math.max(...gaps) : null,
+      };
+    })
+    .filter((group) => group.departures.length >= 2);
+
+  return {
+    id: pack.id,
+    version: pack.version,
+    observedHeadways,
+    declaredFrequencies: (pack.transitFrequencies ?? []).map((frequency) => ({
+      tripId: frequency.tripId,
+      startTimeSeconds: frequency.startTimeSeconds,
+      endTimeSeconds: frequency.endTimeSeconds,
+      headwaySeconds: frequency.headwaySeconds,
+      exactTimes: frequency.exactTimes === true,
+    })),
+  };
+}

--- a/tools/datapack/build-headway-report.mjs
+++ b/tools/datapack/build-headway-report.mjs
@@ -39,10 +39,11 @@ try {
 function headwaysForPack(pack) {
   const routesById = new Map((pack.transitRoutes ?? []).map((route) => [route.id, route]));
   const tripsById = new Map((pack.transitTrips ?? []).map((trip) => [trip.id, trip]));
+  const frequencyTripIds = new Set((pack.transitFrequencies ?? []).map((frequency) => frequency.tripId));
   const departuresByGroup = new Map();
 
   for (const stopTime of pack.transitStopTimes ?? []) {
-    if (stopTime.pickupType === 1) {
+    if (stopTime.pickupType === 1 || frequencyTripIds.has(stopTime.tripId)) {
       continue;
     }
     const trip = tripsById.get(stopTime.tripId);

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -4437,6 +4437,51 @@ test("데이터팩 headway report는 stop_times와 frequencies에서 대기시�
   assert.deepEqual(sangnoksu.departures, [29100, 90300]);
   assert.equal(sangnoksu.minHeadwaySeconds, 61200);
 
+  const frequencyTemplateFixture = JSON.parse(await readFile("tools/datapack/fixtures/catalog-fixture.json", "utf8"));
+  frequencyTemplateFixture.packs[0].transitTrips.push({
+    id: "trip-seoul-2-local-0830",
+    routeId: "route-seoul-2-inner",
+    serviceId: "weekday-2026",
+    tripHeadsign: "내선순환",
+    directionId: "inner",
+    servicePattern: "LOCAL",
+    serviceDayStartSeconds: 0,
+  });
+  frequencyTemplateFixture.packs[0].transitStopTimes.push({
+    tripId: "trip-seoul-2-local-0830",
+    stopSequence: 1,
+    stationId: "station-sadang",
+    lineId: "seoul-2",
+    arrivalSeconds: 30600,
+    departureSeconds: 30600,
+  });
+  frequencyTemplateFixture.packs[0].transitFrequencies.push({
+    tripId: "trip-seoul-2-local-0830",
+    startTimeSeconds: 30600,
+    endTimeSeconds: 33600,
+    headwaySeconds: 600,
+    exactTimes: false,
+  });
+  const frequencyTemplateFixturePath = path.join(outputDir, "frequency-template-fixture.json");
+  const frequencyTemplateReportPath = path.join(outputDir, "artifacts/datapack-headways-frequency-template.json");
+  await writeFile(frequencyTemplateFixturePath, `${JSON.stringify(frequencyTemplateFixture, null, 2)}\n`);
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-headway-report.mjs",
+      "--fixture",
+      frequencyTemplateFixturePath,
+      "--output",
+      frequencyTemplateReportPath,
+    ],
+    { cwd: root },
+  );
+  const frequencyTemplateReport = JSON.parse(await readFile(frequencyTemplateReportPath, "utf8"));
+  assert.equal(
+    frequencyTemplateReport.packs[0].observedHeadways.some((row) => row.lineId === "seoul-2"),
+    false,
+  );
+
   const noPickupFixture = JSON.parse(await readFile("tools/datapack/fixtures/catalog-fixture.json", "utf8"));
   noPickupFixture.packs[0].transitStopTimes.find(
     (row) => row.tripId === "trip-seoul-4-local-2505" && row.stationId === "station-sangnoksu",

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -4405,6 +4405,39 @@ test("데이터팩 quality metric report는 denominator 기반 metric과 freshne
   assert.equal(report.packs[0].metrics.freshnessValidRatio, 0);
 });
 
+test("데이터팩 headway report는 stop_times와 frequencies에서 대기시간 근거를 산출한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-datapack-headway-report-${Date.now()}`);
+  const reportPath = path.join(outputDir, "artifacts/datapack-headways.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-headway-report.mjs",
+      "--fixture",
+      "tools/datapack/fixtures/catalog-fixture.json",
+      "--output",
+      reportPath,
+    ],
+    { cwd: root },
+  );
+
+  const report = JSON.parse(await readFile(reportPath, "utf8"));
+  assert.equal(report.artifactKind, "datapack-headway-report");
+  assert.equal(report.summary.packCount, 1);
+  assert.equal(report.summary.declaredFrequencyCount, 1);
+  assert.equal(report.packs[0].declaredFrequencies[0].headwaySeconds, 600);
+  const sangnoksu = report.packs[0].observedHeadways.find(
+    (row) =>
+      row.stationId === "station-sangnoksu" &&
+      row.stationLineId === "seoul-4" &&
+      row.servicePattern === "LOCAL",
+  );
+  assert.deepEqual(sangnoksu.departures, [29100, 90300]);
+  assert.equal(sangnoksu.minHeadwaySeconds, 61200);
+});
+
 test("데이터팩 quality metric report는 freshness metric 누락 manifest를 거부한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-datapack-quality-report-invalid-${Date.now()}`);
   await rm(outputDir, { recursive: true, force: true });

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -4436,6 +4436,35 @@ test("데이터팩 headway report는 stop_times와 frequencies에서 대기시�
   );
   assert.deepEqual(sangnoksu.departures, [29100, 90300]);
   assert.equal(sangnoksu.minHeadwaySeconds, 61200);
+
+  const noPickupFixture = JSON.parse(await readFile("tools/datapack/fixtures/catalog-fixture.json", "utf8"));
+  noPickupFixture.packs[0].transitStopTimes.find(
+    (row) => row.tripId === "trip-seoul-4-local-2505" && row.stationId === "station-sangnoksu",
+  ).pickupType = 1;
+  const noPickupFixturePath = path.join(outputDir, "no-pickup-fixture.json");
+  const noPickupReportPath = path.join(outputDir, "artifacts/datapack-headways-no-pickup.json");
+  await writeFile(noPickupFixturePath, `${JSON.stringify(noPickupFixture, null, 2)}\n`);
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-headway-report.mjs",
+      "--fixture",
+      noPickupFixturePath,
+      "--output",
+      noPickupReportPath,
+    ],
+    { cwd: root },
+  );
+  const noPickupReport = JSON.parse(await readFile(noPickupReportPath, "utf8"));
+  assert.equal(
+    noPickupReport.packs[0].observedHeadways.some(
+      (row) =>
+        row.stationId === "station-sangnoksu" &&
+        row.stationLineId === "seoul-4" &&
+        row.servicePattern === "LOCAL",
+    ),
+    false,
+  );
 });
 
 test("데이터팩 quality metric report는 freshness metric 누락 manifest를 거부한다", async () => {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -4437,6 +4437,33 @@ test("데이터팩 headway report는 stop_times와 frequencies에서 대기시�
   assert.deepEqual(sangnoksu.departures, [29100, 90300]);
   assert.equal(sangnoksu.minHeadwaySeconds, 61200);
 
+  const defaultLocalFixture = JSON.parse(await readFile("tools/datapack/fixtures/catalog-fixture.json", "utf8"));
+  delete defaultLocalFixture.packs[0].transitTrips.find(
+    (row) => row.id === "trip-seoul-4-local-2505",
+  ).servicePattern;
+  const defaultLocalFixturePath = path.join(outputDir, "default-local-fixture.json");
+  const defaultLocalReportPath = path.join(outputDir, "artifacts/datapack-headways-default-local.json");
+  await writeFile(defaultLocalFixturePath, `${JSON.stringify(defaultLocalFixture, null, 2)}\n`);
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-headway-report.mjs",
+      "--fixture",
+      defaultLocalFixturePath,
+      "--output",
+      defaultLocalReportPath,
+    ],
+    { cwd: root },
+  );
+  const defaultLocalReport = JSON.parse(await readFile(defaultLocalReportPath, "utf8"));
+  const defaultLocalSangnoksu = defaultLocalReport.packs[0].observedHeadways.find(
+    (row) =>
+      row.stationId === "station-sangnoksu" &&
+      row.stationLineId === "seoul-4" &&
+      row.servicePattern === "LOCAL",
+  );
+  assert.deepEqual(defaultLocalSangnoksu.departures, [29100, 90300]);
+
   const frequencyTemplateFixture = JSON.parse(await readFile("tools/datapack/fixtures/catalog-fixture.json", "utf8"));
   frequencyTemplateFixture.packs[0].transitTrips.push({
     id: "trip-seoul-2-local-0830",


### PR DESCRIPTION
## 관련 이슈

Refs #1415

#1419 하위 작업 일부입니다. #1415/#1419는 닫지 않습니다.

## 작업 배경

- #1415는 오프라인 PLANNED ETA의 대기시간 근거로 시간표 headway artifact를 요구합니다.
- 현재 schema와 fixture에는 `transit_stop_times`와 `transit_frequencies`가 있으나, 이를 검토 가능한 JSON artifact로 뽑는 도구가 없습니다.

## 작업 내용

- `tools/datapack/build-headway-report.mjs`를 추가해 fixture의 `transitStopTimes`와 `transitFrequencies`에서 headway report를 산출합니다.
- stop_times 기반 관측 출발 간격과 frequencies 기반 선언 배차간격을 같은 report에 보존합니다.
- datapack 도구 테스트에 headway artifact 생성 회귀 테스트를 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `node --test --test-name-pattern "headway report" tools/datapack/datapack-tools.test.mjs` PASS, 1 test
- `node --test tools/datapack/datapack-tools.test.mjs` PASS, 164 tests
- `git diff --check` PASS

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| headway artifact | datapack | build-headway-report fixture output | `tools/datapack/datapack-tools.test.mjs` headway report test | PASS |
| datapack regression | datapack | node --test datapack-tools | 164 tests pass | PASS |
| UI evidence | mobile | UI 변경 없음 | datapack tool/test만 변경 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1419 하위 production evidence 완료 조건을 일부 보강했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/build-headway-report.mjs`의 grouping key와 `tools/datapack/datapack-tools.test.mjs`의 fixture 기반 검증.
- 이 PR은 #1415의 headway artifact만 처리합니다. 실제 시간표 source admission, production timetable import, Android PLANNED UI evidence는 남아 있습니다.

## 리스크

- fixture 기반 artifact 도구입니다. production 배포 pack에서 직접 읽는 단계는 #1415의 timetable admission 이후 별도 확장 대상입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다. (Review limit reached 확인, Codex CLI fallback 적용)
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.

