### PR TITLE
[Docs] 데이터 품질 Level metric 대응 고정 (#1400)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@
 - 지역별 데이터 품질은 Level 1-4로 구분하고, 신뢰도와 마지막 갱신일을 숨기지 않습니다.
 - 초기 현장 검증 지역은 상록수역입니다.
 
+## Data Quality Levels
+
+- Level 1: 역·노선 기본 식별 정보와 출처가 있고, `stationCount`/`edgeCount`로 분모를 공개합니다.
+- Level 2: 역-노선 × 필수 시설 유형 근거가 채워지며, `requiredFacilityEvidenceCoverageRatio`로 측정합니다.
+- Level 3: 운행상태와 freshness가 확인된 시설만 경로 근거로 쓰며, `operationalKnownRatio`와 `freshnessValidRatio`로 측정합니다.
+- Level 4: 현장 또는 운영기관 검증 pathway만 교통약자 경로 claim에 쓰며, `strictRouteEligibleFacilityRatio`와 `fieldVerifiedPathwayRatio`로 측정합니다.
+- `unknownEdgeRatioByProfile`은 휠체어·유모차·저이동성 profile에서 UNKNOWN edge가 strict 경로를 만들지 않는지 확인하는 보조 차단 지표입니다.
+
 ## Stack
 
 - Mobile: Flutter, Dart, Riverpod, go_router, Dio, Drift

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -213,6 +213,28 @@ test("datapack release readiness gate blocks commercial datapack and realtime ET
   assert.match(readme, /오프라인 데이터팩과 온라인 실시간 overlay를 분리/);
 });
 
+test("README maps data quality levels to production datapack metrics", () => {
+  const readme = read("README.md");
+
+  for (const text of [
+    "## Data Quality Levels",
+    "Level 1",
+    "Level 2",
+    "Level 3",
+    "Level 4",
+    "stationCount",
+    "edgeCount",
+    "requiredFacilityEvidenceCoverageRatio",
+    "operationalKnownRatio",
+    "freshnessValidRatio",
+    "strictRouteEligibleFacilityRatio",
+    "fieldVerifiedPathwayRatio",
+    "unknownEdgeRatioByProfile",
+  ]) {
+    assert.match(readme, new RegExp(text));
+  }
+});
+
 test("route release readiness tracker keeps issue 1414 as a release blocker", () => {
   const trackerPath = "apps/mobile/release/route-release-readiness-tracker.json";
   assert.equal(existsSync(path.join(root, trackerPath)), true, "route release readiness tracker must exist");


### PR DESCRIPTION
## 관련 이슈

Refs #1400

## 작업 배경

- #1400의 README Level 1-4 데이터 품질 약속과 production metric 대응이 문서/계약으로 고정되지 않았습니다.

## 작업 내용

- README에 Data Quality Levels 섹션을 추가해 Level 1-4와 `regionalQualityMetrics` 지표 대응을 명시했습니다.
- repository contract test로 README의 metric 대응 문구를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "README maps data quality levels" tools/ci/repository-contract.test.mjs` 통과
  - `node --test tools/ci/repository-contract.test.mjs` 통과, 157 pass
  - `git diff --check` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 데이터 품질 Level metric 문서 계약 | repo | repository contract test | 증거 불필요 사유: README/계약 테스트 변경 | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: README의 Data Quality Levels 섹션과 `tools/ci/repository-contract.test.mjs`의 고정 test.

## 리스크

- 문서/계약 테스트 변경이라 runtime 영향은 없습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
