### PR TITLE
[Docs] route graph admission 정책 고정 (#1400)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@
 - Level 4: 현장 또는 운영기관 검증 pathway만 교통약자 경로 claim에 쓰며, `strictRouteEligibleFacilityRatio`와 `fieldVerifiedPathwayRatio`로 측정합니다.
 - `unknownEdgeRatioByProfile`은 휠체어·유모차·저이동성 profile에서 UNKNOWN edge가 strict 경로를 만들지 않는지 확인하는 보조 차단 지표입니다.
 
+## Production Routing Graph
+
+- Production LOCAL `RIDE` edge는 같은 노선의 인접 `lineSequence`만 연결합니다. 비인접 요약 edge는 regression fixture 또는 공식 정차 패턴이 있는 `EXPRESS` 근거로만 둡니다.
+- 기본 route node는 station-line(`stationId:lineId`)입니다. platform node는 공식 platform/source가 admission되기 전까지 만들지 않고, 방향 문구는 `platformInfo`에만 둡니다.
+- 표시용 SVG asset은 앱 지도 표시용입니다. canonical route map position은 `routeMapPositions`의 source, license, `sourceSha256`, `reviewedAt`, `updatedAt`, label polygon으로만 판정합니다.
+- 앱의 `데이터 및 지도 출처` 화면은 source inventory와 manifest를 보여주는 사용자 연결점입니다. Level 4 또는 전국 claim은 #1397 source admission과 #1400 인접역 graph/position 확장 증거가 닫힐 때까지 NO-GO입니다.
+
 ## Stack
 
 - Mobile: Flutter, Dart, Riverpod, go_router, Dio, Drift

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -231,7 +231,29 @@ test("README maps data quality levels to production datapack metrics", () => {
     "fieldVerifiedPathwayRatio",
     "unknownEdgeRatioByProfile",
   ]) {
-    assert.match(readme, new RegExp(text));
+    assert.ok(readme.includes(text), `README must include ${text}`);
+  }
+});
+
+test("README fixes production routing graph admission policy", () => {
+  const readme = read("README.md");
+
+  for (const text of [
+    "## Production Routing Graph",
+    "Production LOCAL `RIDE` edge",
+    "인접 `lineSequence`",
+    "regression fixture",
+    "`EXPRESS`",
+    "station-line(`stationId:lineId`)",
+    "`platformInfo`",
+    "canonical route map position",
+    "`routeMapPositions`",
+    "sourceSha256",
+    "데이터 및 지도 출처",
+    "#1397 source admission",
+    "#1400 인접역 graph/position 확장 증거",
+  ]) {
+    assert.ok(readme.includes(text), `README must include ${text}`);
   }
 });
 


### PR DESCRIPTION
## 관련 이슈

Refs #1400

## 작업 배경

- #1400의 routing graph 정책 중 README에 남아 있지 않은 admission/노드/position 연결 기준을 고정합니다.

## 작업 내용

- README에 Production Routing Graph 섹션을 추가했습니다.
- LOCAL RIDE 인접 `lineSequence`, non-adjacent summary edge, station-line route node, `platformInfo`, canonical route map position, 앱 `데이터 및 지도 출처` 연결을 문서화했습니다.
- repository contract test로 README 정책 문구가 빠지지 않게 했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "README .*production routing graph|README maps data quality levels" tools/ci/repository-contract.test.mjs` 통과
  - `node --test tools/ci/repository-contract.test.mjs` 통과
  - `git diff --check` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| README/contract | repo | repository contract + diff check | 위 검증 명령 | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: README 정책 문서/contract test만 갱신
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: README Production Routing Graph 섹션과 `repository-contract.test.mjs`의 README 문구 계약입니다.

## 리스크

- 문서/계약 테스트 변경이라 runtime 영향은 없습니다.
- #1400 전체 완료는 아닙니다. 4호선 전체 graph/position 승격과 production artifact evidence는 계속 남습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
