### PR TITLE
[Fix] 4호선 pilot lineSequence 보정 (#1400)

### DIFF
--- a/apps/mobile/lib/core/database/catalog/catalog_database.dart
+++ b/apps/mobile/lib/core/database/catalog/catalog_database.dart
@@ -220,7 +220,7 @@ class CatalogDatabase extends _$CatalogDatabase {
             stationId: 'station-sangnoksu',
             lineId: 'seoul-4',
             stationCode: const Value('448'),
-            lineSequence: 48,
+            lineSequence: 43,
             platformInfo: const Value('당고개 방면 / 오이도 방면'),
           ),
           StationLinesCompanion.insert(
@@ -234,7 +234,7 @@ class CatalogDatabase extends _$CatalogDatabase {
             stationId: 'station-sadang',
             lineId: 'seoul-4',
             stationCode: const Value('433'),
-            lineSequence: 33,
+            lineSequence: 28,
             platformInfo: const Value('당고개 방면 / 오이도 방면'),
           ),
         ]);

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -7466,7 +7466,7 @@ test("공식 source ingest adapter는 전국 마스터 source를 canonical 역·
         stationId: "station-sangnoksu",
         lineId: "seoul-4",
         stationCode: "448",
-        lineSequence: 48,
+        lineSequence: 43,
       },
       {
         stationId: "station-busan-station",
@@ -9692,7 +9692,7 @@ function sourceIngestInput() {
         latitude: 37.3028,
         longitude: 126.8666,
         stationCode: "448",
-        lineSequence: 48,
+        lineSequence: 43,
         platformInfo: "당고개 방면 / 오이도 방면",
         lastVerifiedAt: "2026-06-21T00:00:00.000Z",
       },
@@ -9707,7 +9707,7 @@ function sourceIngestInput() {
         latitude: 37.3028,
         longitude: 126.8666,
         stationCode: "448",
-        lineSequence: 48,
+        lineSequence: 43,
         platformInfo: "당고개 방면 / 오이도 방면",
         lastVerifiedAt: "2026-06-21T00:00:00.000Z",
       },
@@ -9722,7 +9722,7 @@ function sourceIngestInput() {
         latitude: 37.4766,
         longitude: 126.9816,
         stationCode: "433",
-        lineSequence: 33,
+        lineSequence: 28,
         platformInfo: "당고개 방면 / 오이도 방면",
         lastVerifiedAt: "2026-06-21T00:00:00.000Z",
       },
@@ -9810,9 +9810,9 @@ function sourceIngestInput() {
 
 function nationwideMasterSourceIngestInput() {
   const stationSources = [
-    ["molit-urban-rail-full-route", "MOLIT-SEOUL-4-448", "seoul-4", "station-sangnoksu", "448", 48, "상록수", "Sangnoksu", "수도권", 37.3028, 126.8666],
-    ["molit-tago-subway-info", "448", "seoul-4", "station-sangnoksu", "448", 48, "상록수", "Sangnoksu", "수도권", 37.3028, 126.8666],
-    ["kric-metropolitan-rail-station-info", "KRIC-SEOUL-4-448", "seoul-4", "station-sangnoksu", "448", 48, "상록수", "Sangnoksu", "수도권", 37.3028, 126.8666],
+    ["molit-urban-rail-full-route", "MOLIT-SEOUL-4-448", "seoul-4", "station-sangnoksu", "448", 43, "상록수", "Sangnoksu", "수도권", 37.3028, 126.8666],
+    ["molit-tago-subway-info", "448", "seoul-4", "station-sangnoksu", "448", 43, "상록수", "Sangnoksu", "수도권", 37.3028, 126.8666],
+    ["kric-metropolitan-rail-station-info", "KRIC-SEOUL-4-448", "seoul-4", "station-sangnoksu", "448", 43, "상록수", "Sangnoksu", "수도권", 37.3028, 126.8666],
     ["molit-urban-rail-full-route", "MOLIT-BUSAN-1-113", "busan-1", "station-busan-station", "113", 13, "부산역", "Busan Station", "부산권", 35.1152, 129.0422],
     ["kric-metropolitan-rail-station-info", "KRIC-BUSAN-1-113", "busan-1", "station-busan-station", "113", 13, "부산역", "Busan Station", "부산권", 35.1152, 129.0422],
   ];

--- a/tools/datapack/fixtures/catalog-fixture.json
+++ b/tools/datapack/fixtures/catalog-fixture.json
@@ -236,7 +236,7 @@
           "stationId": "station-sangnoksu",
           "lineId": "seoul-4",
           "stationCode": "448",
-          "lineSequence": 48,
+          "lineSequence": 43,
           "platformInfo": "당고개 방면 / 오이도 방면"
         },
         {
@@ -250,7 +250,7 @@
           "stationId": "station-sadang",
           "lineId": "seoul-4",
           "stationCode": "433",
-          "lineSequence": 33,
+          "lineSequence": 28,
           "platformInfo": "당고개 방면 / 오이도 방면"
         },
         {

--- a/tools/datapack/inputs/capital-pilot-production-source-input.json
+++ b/tools/datapack/inputs/capital-pilot-production-source-input.json
@@ -145,7 +145,7 @@
       "latitude": 37.3028,
       "longitude": 126.8666,
       "stationCode": "448",
-      "lineSequence": 48,
+      "lineSequence": 43,
       "platformInfo": "당고개 방면 / 오이도 방면",
       "lastVerifiedAt": "2026-06-21T00:00:00.000Z"
     },
@@ -160,7 +160,7 @@
       "latitude": 37.4766,
       "longitude": 126.9816,
       "stationCode": "433",
-      "lineSequence": 33,
+      "lineSequence": 28,
       "platformInfo": "당고개 방면 / 오이도 방면",
       "lastVerifiedAt": "2026-06-21T00:00:00.000Z"
     },
@@ -175,7 +175,7 @@
       "latitude": 37.3028,
       "longitude": 126.8666,
       "stationCode": "448",
-      "lineSequence": 48,
+      "lineSequence": 43,
       "platformInfo": "당고개 방면 / 오이도 방면",
       "lastVerifiedAt": "2026-06-21T00:00:00.000Z"
     },
@@ -190,7 +190,7 @@
       "latitude": 37.4766,
       "longitude": 126.9816,
       "stationCode": "433",
-      "lineSequence": 33,
+      "lineSequence": 28,
       "platformInfo": "당고개 방면 / 오이도 방면",
       "lastVerifiedAt": "2026-06-21T00:00:00.000Z"
     }


### PR DESCRIPTION
## 관련 이슈

Refs #1400

## 작업 배경

- 4호선 pilot production input과 모바일 내장 catalog가 역번호를 노선 순번처럼 사용하고 있었습니다.
- repo에 보관된 MOLIT 도시철도 전체노선정보 source 기준 4호선 순번은 상록수 43, 사당 28입니다.

## 작업 내용

- `capital-pilot-production-source-input.json`의 상록수/사당 4호선 `lineSequence`를 원천 순번으로 보정했습니다.
- datapack fixture와 source ingest 테스트 기대값을 같은 순번으로 맞췄습니다.
- 모바일 내장 baseline catalog의 `station_lines.line_sequence`도 동일하게 맞췄습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "공식 source ingest adapter|route graph|LOCAL RIDE|인접" tools/datapack/datapack-tools.test.mjs` 통과
  - `node --test tools/datapack/datapack-tools.test.mjs` 통과
  - `flutter test test/core/database/mobile_local_database_test.dart` 통과
  - `node --test tools/ci/repository-contract.test.mjs` 통과
  - `git diff --check` 통과
  - `node tools/datapack/import-official-sources.mjs --input tools/datapack/inputs/capital-pilot-production-source-input.json --inventory tools/datapack/source-inventory.json --output /private/tmp/easysubway-1400-production-fixture.json` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Datapack source ingest | local | node test/import | 터미널 출력 | PASS |
| Mobile baseline catalog | Android/Flutter local | `flutter test test/core/database/mobile_local_database_test.dart` | 터미널 출력 | PASS |
| UI/접근성 수동 QA | N/A | 데이터 순번 보정만 포함 | UI 변경 없음 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `stationCode`는 448/433 그대로 두고 `lineSequence`만 43/28로 분리한 점.

## 리스크

- 낮음. 잘못된 순번 값 보정이며, 실제 4호선 중간역 graph 승격은 별도 작업으로 남깁니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
