### PR TITLE
[Test] UNKNOWN 시설 역 상세 표시 증거 추가 (#1394)

### DIFF
--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -7742,7 +7742,7 @@ void main() {
           fieldValidationStatus: 'VERIFIED',
         ),
         StationFacilityInfo(
-          id: 'facility-sangnoksu-info-needed',
+          id: 'facility-sangnoksu-operation-unknown',
           stationId: 'station-sangnoksu',
           exitId: 'exit-sangnoksu-3',
           type: 'ESCALATOR',
@@ -7750,7 +7750,7 @@ void main() {
           floorFrom: 'B1',
           floorTo: '1F',
           description: '3번 출구 앞',
-          status: 'NEEDS_CHECK',
+          status: 'UNKNOWN',
           dataConfidence: 'LOW',
           dataSourceType: 'OFFICIAL_FILE',
           lastUpdatedAt: '2026-06-10',
@@ -7863,7 +7863,7 @@ void main() {
       expect(find.text('이용할 수 없어요'), findsOneWidget);
       await tester.scrollUntilVisible(
         find.byKey(
-          const Key('stationFacilityCard-facility-sangnoksu-info-needed'),
+          const Key('stationFacilityCard-facility-sangnoksu-operation-unknown'),
         ),
         120,
         scrollable: find.byType(Scrollable).last,
@@ -7873,9 +7873,28 @@ void main() {
       expect(
         find.descendant(
           of: find.byKey(
-            const Key('stationFacilityCard-facility-sangnoksu-info-needed'),
+            const Key(
+              'stationFacilityCard-facility-sangnoksu-operation-unknown',
+            ),
           ),
-          matching: find.text('상태를 확인하고 있어요'),
+          matching: find.text('설치 확인 · 운행상태 미확인'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: find.byKey(
+            const Key(
+              'stationFacilityCard-facility-sangnoksu-operation-unknown',
+            ),
+          ),
+          matching: find.text('이용 가능'),
+        ),
+        findsNothing,
+      );
+      expect(
+        find.bySemanticsLabel(
+          '3번 출구 에스컬레이터, 에스컬레이터, 설치 확인 · 운행상태 미확인, 3번 출구 앞, 최근 확인 2026-06-10, 최신 상태를 준비 중이에요, 자세히 보기',
         ),
         findsOneWidget,
       );


### PR DESCRIPTION
## 관련 이슈

Refs #1394
Refs #1414

## 작업 배경

- #1394는 UNKNOWN 시설이 앱에서 `사용 가능`처럼 보이지 않는다는 Android UI evidence를 요구한다.
- 실제 field/operator evidence가 없는 pathway graph는 만들지 않고, 현재 데이터 상태를 정직하게 표시하는 회귀 증거만 추가한다.

## 작업 내용

- 역 상세 widget test의 시설 상태 케이스를 pilot 조건인 `UNKNOWN` 시설로 바꿨다.
- UNKNOWN 시설 카드가 `설치 확인 · 운행상태 미확인`을 표시하고 `이용 가능`을 표시하지 않음을 검증했다.
- 스크린리더 semantics label도 UNKNOWN 문구와 `최신 상태를 준비 중이에요` 안내를 포함하도록 검증했다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다"`: pass
  - `flutter test test/widget_test.dart`: pass, 204 tests
  - `git diff --check`: pass

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| UNKNOWN 시설 역 상세 표시 | Flutter widget | `find.text`, descendant finder | `flutter test test/widget_test.dart --name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다"` | `설치 확인 · 운행상태 미확인` 표시, `이용 가능` 미표시 |
| UNKNOWN 시설 스크린리더 문구 | Flutter semantics tree | `find.bySemanticsLabel` | `flutter test test/widget_test.dart --name "역 검색 결과를 누르면 출구와 시설 상태를 쉬운 문구로 보여준다"` | `최신 상태를 준비 중이에요` 포함 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/test/widget_test.dart`의 역 상세 시설 상태 assertion

## 리스크

- 테스트 변경만 있으며 런타임 코드 경로는 바꾸지 않는다.
- #1394의 field/operator evidence와 pathway graph 완료 조건은 아직 남아 있다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
