### PR TITLE
[Fix] UNKNOWN 경로 결과 상세 문구 보정 (#1394)

### DIFF
--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -4132,19 +4132,14 @@ class _RouteDetailWorkflowView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final totalMinutes = _routeTotalMinutes(result);
-    final meta = _routeMetaLabel(result);
-    final recommended = _isRecommendedRoute(result);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _RouteWorkflowBackButton(label: '경로 목록', onPressed: onBack),
         const SizedBox(height: 8),
         _RouteDarkSummaryCard(
-          title: recommended && totalMinutes > 0
-              ? '$totalMinutes분'
-              : result.statusLabel,
-          subtitle: recommended ? meta : result.guidanceLabel,
+          title: _routeWorkflowSummaryTitle(result),
+          subtitle: _routeWorkflowSummarySubtitle(result),
           chips: [
             _RouteSummaryChip(label: result.comfortLabel),
             _RouteSummaryChip(
@@ -4846,7 +4841,7 @@ String _routeWorkflowSummaryTitle(RouteSearchResult result) {
 String _routeWorkflowSummarySubtitle(RouteSearchResult result) {
   return _isRecommendedRoute(result)
       ? _routeMetaLabel(result)
-      : result.statusLabel;
+      : result.guidanceLabel;
 }
 
 IconData _routeStairAccessIcon(RouteSearchResult result) {

--- a/apps/mobile/lib/route_search.dart
+++ b/apps/mobile/lib/route_search.dart
@@ -4134,14 +4134,17 @@ class _RouteDetailWorkflowView extends StatelessWidget {
   Widget build(BuildContext context) {
     final totalMinutes = _routeTotalMinutes(result);
     final meta = _routeMetaLabel(result);
+    final recommended = _isRecommendedRoute(result);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _RouteWorkflowBackButton(label: '경로 목록', onPressed: onBack),
         const SizedBox(height: 8),
         _RouteDarkSummaryCard(
-          title: totalMinutes > 0 ? '$totalMinutes분' : result.statusLabel,
-          subtitle: meta,
+          title: recommended && totalMinutes > 0
+              ? '$totalMinutes분'
+              : result.statusLabel,
+          subtitle: recommended ? meta : result.guidanceLabel,
           chips: [
             _RouteSummaryChip(label: result.comfortLabel),
             _RouteSummaryChip(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -9496,6 +9496,42 @@ void main() {
     expect(favoriteRouteRepository.savedRouteSearchIds, isEmpty);
   });
 
+  testWidgets('경로 검색 UNKNOWN 결과는 이동 가능 화면 문구로 보이지 않는다', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RouteSearchScreen(
+          repository: FakeRouteSearchRepository(
+            result: _sampleRouteSearchResult(status: 'UNKNOWN'),
+          ),
+          stationRepository: FakeStationSearchRepository(),
+          favoriteRouteRepository: FakeFavoriteRouteRepository(),
+          initialDraft: RouteDraft(
+            origin: const RouteDraftStation(
+              id: 'station-sangnoksu',
+              nameKo: '상록수',
+            ),
+            destination: const RouteDraftStation(
+              id: 'station-sadang',
+              nameKo: '사당',
+            ),
+            lastModifiedAt: DateTime(2026, 6, 26),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('routeSearchSubmitButton')));
+    await tester.pumpAndSettle();
+    await _openFirstRouteResultDetail(tester);
+
+    expect(find.text('경로 상태를 아직 알 수 없어요'), findsWidgets);
+    expect(find.text('확인 후 이동'), findsOneWidget);
+    expect(find.text('추천 경로'), findsNothing);
+    expect(find.textContaining('이동할 수 있는 경로'), findsNothing);
+    expect(find.byKey(const Key('routeFavoriteSaveButton')), findsNothing);
+    expect(find.byKey(const Key('routeStartGuidanceButton')), findsNothing);
+  });
+
   testWidgets('즐겨찾기 경로 저장 실패는 도움말을 쉬운 문구로 안내한다', (tester) async {
     final semanticsHandle = tester.ensureSemantics();
     final stationRepository = FakeStationSearchRepository(


### PR DESCRIPTION
## 관련 이슈

Refs #1394

## 작업 배경

- #1394는 UNKNOWN 시설/경로 상태가 Android route result 화면에서 이동 가능처럼 보이지 않는 증거를 요구합니다.
- 기존 모델 테스트와 저장/안내 버튼 숨김 테스트는 있었지만, route result 상세 요약 카드가 UNKNOWN 결과에도 소요시간을 제목으로 보여 화면상 추천 경로처럼 읽힐 수 있었습니다.

## 작업 내용

- route result 상세 요약 카드가 추천 가능한 `FOUND` 결과에만 소요시간을 제목으로 표시하도록 수정했습니다.
- `UNKNOWN` 결과 상세는 `경로 상태를 아직 알 수 없어요`와 `확인 후 이동`을 표시합니다.
- widget 테스트로 UNKNOWN 상세 화면에서 `추천 경로`, `이동할 수 있는 경로`, 저장/안내 시작 행동이 노출되지 않음을 고정했습니다.
- CodeRabbit 지적사항을 반영해 상세/단계별 summary card가 같은 helper를 사용하도록 통일했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "경로 검색 UNKNOWN 결과는 이동 가능 화면 문구로 보이지 않는다"`: pass
  - `flutter test test/route_search_test.dart --name "경로 검색 UNKNOWN"`: pass
  - `flutter test test/widget_test.dart --name "경로 검색 UNKNOWN 결과"`: pass
  - `dart format --set-exit-if-changed lib/route_search.dart test/widget_test.dart`: pass
  - `git diff --check`: pass
  - PR CI: https://github.com/AquilaXk/easysubway/actions/runs/28660793832 pass
  - PR Release Artifacts: https://github.com/AquilaXk/easysubway/actions/runs/28660793476 pass
  - PR SonarCloud: https://github.com/AquilaXk/easysubway/actions/runs/28660793517 pass
  - CodeRabbit actionable 1건: `2952823d`에서 수정, thread reply/resolve 확인
  - Codex CLI fallback review: https://github.com/AquilaXk/easysubway/pull/1610#pullrequestreview-4625810042

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| UNKNOWN route result 상세 문구 | Android/Flutter widget | `flutter test test/widget_test.dart --name "경로 검색 UNKNOWN 결과"` | 테스트 출력 | pass |
| route result UNKNOWN semantic 회귀 | Flutter unit | `flutter test test/route_search_test.dart --name "경로 검색 UNKNOWN"` | 테스트 출력 | pass |
| PR checks | GitHub Actions | CI/Release/SonarCloud | run 링크 | pass |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/route_search.dart`의 `_routeWorkflowSummaryTitle`/`_routeWorkflowSummarySubtitle` helper와 `apps/mobile/test/widget_test.dart`의 UNKNOWN route result 화면 테스트입니다.

## 리스크

- FOUND 결과의 기존 시간/메타 표시 조건은 유지했습니다.
- UNKNOWN/REVIEW_REQUIRED 같은 비추천 결과 상세만 상태 확인 문구를 우선 표시합니다.
- #1394의 pathway graph, field evidence, 사당 pilot 범위 결정은 이 PR에서 닫지 않습니다.
- 배포/CD 영향은 없습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 경로 요약 카드의 표시가 추천 경로 여부에 따라 더 정확하게 바뀌었습니다.
  * 추천 경로일 때는 소요 시간과 요약 정보를, 추천이 아닐 때는 상태와 안내 문구를 보여줍니다.
  * 경로 상태를 아직 알 수 없는 경우, 불필요한 추천/이동 관련 문구와 버튼이 표시되지 않도록 개선했습니다.

* **Tests**
  * 경로 검색 결과가 `UNKNOWN`일 때 화면 노출 문구와 버튼 표시 여부를 확인하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
