### PR TITLE
[Test] 데이터 품질 Level 화면 증거 추가 (#1400)

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4878,7 +4878,17 @@ class _PrivacyDataUseLine extends StatelessWidget {
 }
 
 class DataSourceAttributionScreen extends StatefulWidget {
-  const DataSourceAttributionScreen({super.key});
+  const DataSourceAttributionScreen({
+    super.key,
+    this.initialManifest,
+    this.initialInventory,
+  }) : assert(
+         (initialManifest == null) == (initialInventory == null),
+         'initialManifest and initialInventory must be provided together.',
+       );
+
+  final Map<String, Object?>? initialManifest;
+  final Map<String, Object?>? initialInventory;
 
   @override
   State<DataSourceAttributionScreen> createState() =>
@@ -4898,6 +4908,11 @@ class _DataSourceAttributionScreenState
 
   Future<({Map<String, Object?> manifest, Map<String, Object?> inventory})>
   _load() async {
+    final initialManifest = widget.initialManifest;
+    final initialInventory = widget.initialInventory;
+    if (initialManifest != null && initialInventory != null) {
+      return (manifest: initialManifest, inventory: initialInventory);
+    }
     final [manifestText, inventoryText] = await Future.wait([
       rootBundle.loadString(_mapManifestAsset),
       rootBundle.loadString(_sourceInventoryAsset),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4967,7 +4967,7 @@ class _DataSourceAttributionScreenState
                         iconColor: EasySubwayAccessibleColors.mintDark,
                         title: 'Level 1-4 품질 기준',
                         subtitle:
-                            'Level 1은 역·노선 분모, Level 2는 시설 근거, Level 3은 운행상태와 freshness, Level 4는 현장 또는 운영기관 검증 pathway를 확인해요.',
+                            'Level 1은 역·노선 수, Level 2는 필수 시설 근거, Level 3은 운행상태와 최신 여부, Level 4는 현장 또는 운영기관이 확인한 쉬운 길을 봐요.',
                       ),
                     ),
                     const _AppCard(
@@ -4976,7 +4976,7 @@ class _DataSourceAttributionScreenState
                         iconColor: EasySubwayAccessibleColors.amber,
                         title: '품질 지표',
                         subtitle:
-                            'requiredFacilityEvidenceCoverageRatio, operationalKnownRatio, freshnessValidRatio, strictRouteEligibleFacilityRatio, fieldVerifiedPathwayRatio로 확인해요.',
+                            '필수 시설 근거 비율, 운행상태 확인 비율, 최신 정보 비율, 검증된 쉬운 길 비율, 현장 확인 경로 비율을 함께 확인해요.',
                       ),
                     ),
                     const _AppSectionTitle(title: '경로·시설 판단용 data pack'),

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4960,6 +4960,25 @@ class _DataSourceAttributionScreenState
                     ),
                     const _AppSectionTitle(title: '지도 표시용 asset'),
                     for (final map in maps) _AttributionCard.map(map, manifest),
+                    const _AppSectionTitle(title: '데이터 품질 Level'),
+                    const _AppCard(
+                      child: _AppInfoRow(
+                        icon: Icons.verified_outlined,
+                        iconColor: EasySubwayAccessibleColors.mintDark,
+                        title: 'Level 1-4 품질 기준',
+                        subtitle:
+                            'Level 1은 역·노선 분모, Level 2는 시설 근거, Level 3은 운행상태와 freshness, Level 4는 현장 또는 운영기관 검증 pathway를 확인해요.',
+                      ),
+                    ),
+                    const _AppCard(
+                      child: _AppInfoRow(
+                        icon: Icons.analytics_outlined,
+                        iconColor: EasySubwayAccessibleColors.amber,
+                        title: '품질 지표',
+                        subtitle:
+                            'requiredFacilityEvidenceCoverageRatio, operationalKnownRatio, freshnessValidRatio, strictRouteEligibleFacilityRatio, fieldVerifiedPathwayRatio로 확인해요.',
+                      ),
+                    ),
                     const _AppSectionTitle(title: '경로·시설 판단용 data pack'),
                     for (final source in sources)
                       _AttributionCard.source(source),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3888,15 +3888,12 @@ void main() {
     expect(find.text('데이터 품질 Level'), findsOneWidget);
     expect(find.text('Level 1-4 품질 기준'), findsOneWidget);
     expect(
-      find.textContaining('Level 4는 현장 또는 운영기관 검증 pathway'),
+      find.textContaining('Level 4는 현장 또는 운영기관이 확인한 쉬운 길'),
       findsOneWidget,
     );
     expect(find.text('품질 지표'), findsOneWidget);
-    expect(
-      find.textContaining('requiredFacilityEvidenceCoverageRatio'),
-      findsOneWidget,
-    );
-    expect(find.textContaining('fieldVerifiedPathwayRatio'), findsOneWidget);
+    expect(find.textContaining('필수 시설 근거 비율'), findsOneWidget);
+    expect(find.textContaining('현장 확인 경로 비율'), findsOneWidget);
 
     final manifest =
         jsonDecode(

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3871,30 +3871,6 @@ void main() {
   testWidgets('데이터 및 지도 출처 화면은 manifest와 source inventory를 보여준다', (
     tester,
   ) async {
-    await tester.pumpWidget(
-      const MaterialApp(home: DataSourceAttributionScreen()),
-    );
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
-    await tester.pump();
-
-    expect(
-      find.byKey(const Key('dataSourceAttributionScreen')),
-      findsOneWidget,
-    );
-    expect(find.text('데이터 및 지도 출처'), findsOneWidget);
-    await tester.scrollUntilVisible(find.text('데이터 품질 Level'), 160);
-    await tester.pumpAndSettle();
-    expect(find.text('데이터 품질 Level'), findsOneWidget);
-    expect(find.text('Level 1-4 품질 기준'), findsOneWidget);
-    expect(
-      find.textContaining('Level 4는 현장 또는 운영기관이 확인한 쉬운 길'),
-      findsOneWidget,
-    );
-    expect(find.text('품질 지표'), findsOneWidget);
-    expect(find.textContaining('필수 시설 근거 비율'), findsOneWidget);
-    expect(find.textContaining('현장 확인 경로 비율'), findsOneWidget);
-
     final manifest =
         jsonDecode(
               File(
@@ -3907,6 +3883,35 @@ void main() {
               File('assets/datapacks/source-inventory.json').readAsStringSync(),
             )
             as Map<String, Object?>;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DataSourceAttributionScreen(
+          initialManifest: manifest,
+          initialInventory: inventory,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(
+      find.byKey(const Key('dataSourceAttributionScreen')),
+      findsOneWidget,
+    );
+    expect(find.text('데이터 및 지도 출처'), findsOneWidget);
+    expect(find.byType(Scrollable), findsOneWidget);
+    await tester.scrollUntilVisible(find.text('데이터 품질 Level'), 160);
+    await tester.pumpAndSettle();
+    expect(find.text('데이터 품질 Level'), findsOneWidget);
+    expect(find.text('Level 1-4 품질 기준'), findsOneWidget);
+    expect(
+      find.textContaining('Level 4는 현장 또는 운영기관이 확인한 쉬운 길'),
+      findsOneWidget,
+    );
+    expect(find.text('품질 지표'), findsOneWidget);
+    expect(find.textContaining('필수 시설 근거 비율'), findsOneWidget);
+    expect(find.textContaining('현장 확인 경로 비율'), findsOneWidget);
+
     final maps = (manifest['maps'] as List).cast<Map<String, Object?>>();
     final sources = (inventory['sources'] as List).cast<Map<String, Object?>>();
 

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3883,6 +3883,20 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('데이터 및 지도 출처'), findsOneWidget);
+    await tester.scrollUntilVisible(find.text('데이터 품질 Level'), 160);
+    await tester.pumpAndSettle();
+    expect(find.text('데이터 품질 Level'), findsOneWidget);
+    expect(find.text('Level 1-4 품질 기준'), findsOneWidget);
+    expect(
+      find.textContaining('Level 4는 현장 또는 운영기관 검증 pathway'),
+      findsOneWidget,
+    );
+    expect(find.text('품질 지표'), findsOneWidget);
+    expect(
+      find.textContaining('requiredFacilityEvidenceCoverageRatio'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('fieldVerifiedPathwayRatio'), findsOneWidget);
 
     final manifest =
         jsonDecode(


### PR DESCRIPTION
## 관련 이슈

Refs #1400

## 작업 배경

- #1400은 README의 Level 1-4 데이터 품질 약속과 앱 데이터 품질 표시/도움말 화면 evidence 연결을 요구합니다.
- `데이터 및 지도 출처` 화면은 manifest/source inventory는 보여줬지만 Level 1-4와 품질 지표 설명은 사용자 화면에 직접 노출하지 않았습니다.

## 작업 내용

- `데이터 및 지도 출처` 화면에 `데이터 품질 Level` 안내를 추가했습니다.
- Level 1-4 기준과 품질 지표를 사용자가 이해할 수 있는 쉬운 한국어 label로 안내합니다.
- 기존 widget test에 화면 evidence를 고정했습니다.
- full widget test에서 asset Future timing에 흔들리지 않도록 attribution 화면 test에 manifest/source inventory 주입 경로를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/widget_test.dart --name "데이터 및 지도 출처 화면은 manifest와 source inventory를 보여준다"`: pass
  - `flutter test test/widget_test.dart`: pass
  - `node --test --test-name-pattern "데이터 및 지도 출처|백엔드 데이터 품질 요약" tools/ci/repository-contract.test.mjs`: pass
  - `dart format --set-exit-if-changed lib/main.dart test/widget_test.dart`: pass
  - `git diff --check`: pass

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 데이터 품질 Level 화면 문구 | Android/Flutter widget | `flutter test test/widget_test.dart --name "데이터 및 지도 출처 화면은 manifest와 source inventory를 보여준다"` | 테스트 출력 | pass |
| Mobile widget suite | Flutter widget | `flutter test test/widget_test.dart` | 테스트 출력 | pass |
| README/백엔드 품질 label 계약 | Repository contract | `node --test --test-name-pattern "데이터 및 지도 출처|백엔드 데이터 품질 요약" tools/ci/repository-contract.test.mjs` | 테스트 출력 | pass |
| PR CI | GitHub Actions | CI / Release Artifacts / SonarCloud | https://github.com/AquilaXk/easysubway/actions/runs/28663103502, https://github.com/AquilaXk/easysubway/actions/runs/28663103246, https://github.com/AquilaXk/easysubway/actions/runs/28663103260 | merge 전 최신 run 확인 |
| Code review | GitHub PR Review | Codex CLI fallback review | https://github.com/AquilaXk/easysubway/pull/1612#pullrequestreview-4625948845, https://github.com/AquilaXk/easysubway/pull/1612#pullrequestreview-4625965723, https://github.com/AquilaXk/easysubway/pull/1612#pullrequestreview-4626056189 | actionable 1건 게시 후 수정, 최신 head 0건 |
| Review thread | GitHub review thread | 원 inline thread reply 및 resolve | https://github.com/AquilaXk/easysubway/pull/1612#discussion_r3520011183 | resolved |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/lib/main.dart`의 `DataSourceAttributionScreen` static 안내 카드와 `apps/mobile/test/widget_test.dart`의 기존 출처 화면 테스트 보강입니다.
- CodeRabbit은 status check만 확인되어 최신 head의 GitHub PR Review 객체로 보지 않았고, Codex CLI fallback review를 게시했습니다.

## 리스크

- 정적 안내 문구와 widget test만 추가했습니다.
- #1400의 4호선 인접역 graph, 전체 route map position, source admission 연동은 이 PR에서 닫지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
