### PR TITLE
[Chore] TAGO live timetable sample evidence 기록 (#1415)

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5676,7 +5676,7 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
   assert.match(candidate.evidence.sampleUrl, /subwayStationId=MTRKR4448/);
   assert.match(candidate.evidence.stationDiscoveryUrl, /GetKwrdFndSubwaySttnList/);
   assert.match(candidate.evidence.stationDiscoveryUrl, /subwayStationName=상록수/);
-  assert.equal(candidate.evidence.liveSampleRetrievedAt, "2026-07-03T14:22:16Z");
+  assert.match(candidate.evidence.liveSampleRetrievedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
   assert.equal(candidate.evidence.liveSampleRowCount, 10);
   assert.match(candidate.evidence.liveSampleRawSha256, /^[0-9a-f]{64}$/);
   assert.match(candidate.evidence.liveSampleSchemaFingerprint, /^[0-9a-f]{64}$/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5665,7 +5665,7 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
   assert.equal(candidate.priority, "P0");
   assert.equal(candidate.domain, "schedule_timetable");
   assert.equal(candidate.licenseEvidenceStatus, "confirmed_attribution");
-  assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
+  assert.equal(candidate.sampleEvidenceStatus, "validated_live_sample");
   assert.equal(candidate.admissionStatus, "evidence_recorded_admin_review_required");
   assert.equal(candidate.serviceKeyHandling, "offline_import_secret_only");
   assert.equal(candidate.mobileEmbeddingAllowed, false);
@@ -5673,7 +5673,14 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
   assert.equal(candidate.requestUrl, "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList");
   assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
   assert.match(candidate.evidence.sampleUrl, /serviceKey=\[서비스키값\]/);
-  assert.match(candidate.evidence.sampleUrl, /subwayStationId=448/);
+  assert.match(candidate.evidence.sampleUrl, /subwayStationId=MTRKR4448/);
+  assert.match(candidate.evidence.stationDiscoveryUrl, /GetKwrdFndSubwaySttnList/);
+  assert.match(candidate.evidence.stationDiscoveryUrl, /subwayStationName=상록수/);
+  assert.equal(candidate.evidence.liveSampleRetrievedAt, "2026-07-03T14:22:16Z");
+  assert.equal(candidate.evidence.liveSampleRowCount, 10);
+  assert.match(candidate.evidence.liveSampleRawSha256, /^[0-9a-f]{64}$/);
+  assert.match(candidate.evidence.liveSampleSchemaFingerprint, /^[0-9a-f]{64}$/);
+  assert.match(candidate.evidence.liveSampleEvidenceHash, /^[0-9a-f]{64}$/);
   assert.equal(productionSourceIds.has(candidate.id), true, "TAGO inventory entry exists but must remain non-production");
 
   const inventorySource = inventory.sources.find(({ id }) => id === "molit-tago-subway-info");
@@ -5684,8 +5691,8 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
 
   assert.equal(candidate.capabilities.schedule.status, "CANDIDATE");
   assert.equal(candidate.capabilities.schedule.productionUseAllowed, false);
-  assert.equal(candidate.capabilities.schedule.coverageStatus, "SAMPLE_EVIDENCE_REQUIRED");
-  assert.deepEqual(candidate.evidence.missingEvidence, ["sampleResponse", "scheduleImporterValidation"]);
+  assert.equal(candidate.capabilities.schedule.coverageStatus, "IMPORTER_VALIDATION_REQUIRED");
+  assert.deepEqual(candidate.evidence.missingEvidence, ["scheduleImporterValidation"]);
   assert.ok(candidate.evidence.outputFields.includes("depTime"));
   assert.ok(candidate.evidence.outputFields.includes("arrTime"));
   assert.ok(candidate.evidence.outputFields.includes("dailyTypeCode"));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5670,6 +5670,7 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
   assert.equal(candidate.serviceKeyHandling, "offline_import_secret_only");
   assert.equal(candidate.mobileEmbeddingAllowed, false);
   assert.equal(candidate.productionInventoryReferenceId, "molit-tago-subway-info");
+  assert.equal(candidate.productionInventoryRelationship, "same_dataset_inventory_entry_remains_schedule_candidate_until_importer_validation");
   assert.equal(candidate.requestUrl, "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList");
   assert.equal(candidate.evidence.endpoint, candidate.requestUrl);
   assert.match(candidate.evidence.sampleUrl, /serviceKey=\[서비스키값\]/);

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -656,17 +656,23 @@
       "detailUrl": "https://www.data.go.kr/data/15098554/openapi.do",
       "requestUrl": "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList",
       "licenseEvidenceStatus": "confirmed_attribution",
-      "sampleEvidenceStatus": "sample_url_documented_key_required",
+      "sampleEvidenceStatus": "validated_live_sample",
       "admissionStatus": "evidence_recorded_admin_review_required",
       "productionInventoryReferenceId": "molit-tago-subway-info",
-      "productionInventoryRelationship": "same_dataset_inventory_entry_remains_schedule_candidate_until_sample_and_importer_validation",
+      "productionInventoryRelationship": "same_dataset_inventory_entry_remains_schedule_candidate_until_importer_validation",
       "serviceKeyHandling": "offline_import_secret_only",
       "mobileEmbeddingAllowed": false,
       "evidence": {
         "detailPageUrl": "https://www.data.go.kr/data/15098554/openapi.do",
         "retrievedAt": "2026-06-22",
         "endpoint": "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList",
-        "sampleUrl": "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList?serviceKey=[서비스키값]&pageNo=1&numOfRows=10&_type=json&subwayStationId=448&dailyTypeCode=01&upDownTypeCode=U",
+        "sampleUrl": "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList?serviceKey=[서비스키값]&pageNo=1&numOfRows=10&_type=json&subwayStationId=MTRKR4448&dailyTypeCode=01&upDownTypeCode=U",
+        "stationDiscoveryUrl": "https://apis.data.go.kr/1613000/SubwayInfo/GetKwrdFndSubwaySttnList?serviceKey=[서비스키값]&pageNo=1&numOfRows=10&_type=json&subwayStationName=상록수",
+        "liveSampleRetrievedAt": "2026-07-03T14:22:16Z",
+        "liveSampleRowCount": 10,
+        "liveSampleRawSha256": "34af0c0e6750012070282b0b59f0226075bfbc8ee533f0bd934c78b130d297d4",
+        "liveSampleSchemaFingerprint": "6e5d572290d2d5a8ea2d243a615b6f310417995944c140353a5606228016bd48",
+        "liveSampleEvidenceHash": "d5a60bcc1907d346a24fbf720a5d362268720e8fab68e35c42eace270e5fe9ae",
         "usePermissionRange": "공공데이터포털 이용허락범위 제한 없음",
         "formats": [
           "XML",
@@ -688,16 +694,15 @@
           "endSubwayStationId"
         ],
         "missingEvidence": [
-          "sampleResponse",
           "scheduleImporterValidation"
         ]
       },
-      "nextAction": "capture sanitized TAGO live sample and validate schedule importer before production timetable admission",
+      "nextAction": "validate schedule importer against sanitized TAGO live sample before production timetable admission",
       "capabilities": {
         "schedule": {
           "status": "CANDIDATE",
           "productionUseAllowed": false,
-          "coverageStatus": "SAMPLE_EVIDENCE_REQUIRED",
+          "coverageStatus": "IMPORTER_VALIDATION_REQUIRED",
           "updateFrequency": "provider documented; production cadence not admitted",
           "unsupportedNotes": "commercial schedule import remains blocked until production schedule importer and provider sample validation are complete"
         },


### PR DESCRIPTION
## 관련 이슈

Refs #1414
Refs #1415
Refs #1397

## 작업 배경

- #1415의 TAGO timetable/calendar source admission에서 실제 live sample evidence가 없어 PLANNED ETA 검증이 막혀 있었다.
- 기존 sample URL은 정상 응답이지만 빈 item만 반환하는 `subwayStationId=448`을 사용했다.

## 작업 내용

- TAGO 역명 검색 API로 상록수 station id `MTRKR4448`을 확인하고 timetable API live sample metadata를 기록했다.
- sanitized sample evidence의 `rawSha256`, `schemaFingerprint`, `evidenceHash`, row count를 source candidate에 저장했다.
- TAGO는 live sample만 검증된 상태로 올리고, production PLANNED ETA 근거 승격은 `scheduleImporterValidation` 완료 전까지 계속 차단한다.
- CodeRabbit 지적에 따라 TAGO `productionInventoryRelationship`도 repository contract test로 고정했다.

## 검증

- 실행한 명령과 결과:
  - `node tools/datapack/validate-source-candidate-sample.mjs --candidate molit-tago-subway-info --sample .codex/evidence/1415/molit-tago-subway-info/timetable-sample-evidence.json` 성공
  - `node --test --test-name-pattern "TAGO|source candidate|source admission|schedule" tools/ci/repository-contract.test.mjs` 성공
  - `node --test --test-name-pattern "source candidate|source admission|TAGO|schedule" tools/datapack/datapack-tools.test.mjs` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공
  - `node --test tools/datapack/datapack-tools.test.mjs` 성공
  - `git diff --check` 성공
  - Codex fallback review: https://github.com/AquilaXk/easysubway/pull/1614#pullrequestreview-4626582339

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| TAGO station discovery | local | live TAGO API 1회 호출, credential marker 검사 | `.codex/evidence/1415/molit-tago-subway-info/station-discovery.raw` 로컬 전용 | 상록수 `MTRKR4448` 확인 |
| TAGO timetable sample | local | live TAGO API 1회 호출, sanitized evidence 생성 및 validator 실행 | `.codex/evidence/1415/molit-tago-subway-info/timetable-sample-evidence.json` 로컬 전용, tracked hash metadata | 10 rows, validator 성공 |
| production PLANNED ETA 차단 | repo contract | repository contract/datapack tests | 로컬 test output, PR CI | importer validation 전 승격 차단 유지 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: TAGO source candidate live sample metadata만 갱신
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/source-candidates.json`의 TAGO candidate가 `validated_live_sample`로만 바뀌고, production use는 계속 false인지 확인해 주세요.

## 리스크

- live sample raw는 로컬 전용이며 tracked file에는 hash metadata만 들어간다.
- importer validation과 production admission은 아직 남아 있으므로 #1415/#1414를 이 PR로 닫지 않는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
