### PR TITLE
[Test] TAGO 시간표 sample importer 검증 (#1415)

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5682,6 +5682,14 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
   assert.match(candidate.evidence.liveSampleRawSha256, /^[0-9a-f]{64}$/);
   assert.match(candidate.evidence.liveSampleSchemaFingerprint, /^[0-9a-f]{64}$/);
   assert.match(candidate.evidence.liveSampleEvidenceHash, /^[0-9a-f]{64}$/);
+  assert.deepEqual(candidate.evidence.scheduleImporterValidation, {
+    status: "validated_station_timetable_projection",
+    tool: "tools/datapack/validate-tago-schedule-sample.mjs",
+    validatedAt: "2026-07-03",
+    validatedRawSha256: candidate.evidence.liveSampleRawSha256,
+    productionCanonicalStopTimesStatus: "blocked_requires_trip_stop_sequence",
+    plannedEtaUseAllowed: false,
+  });
   assert.equal(productionSourceIds.has(candidate.id), true, "TAGO inventory entry exists but must remain non-production");
 
   const inventorySource = inventory.sources.find(({ id }) => id === "molit-tago-subway-info");
@@ -5692,8 +5700,8 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
 
   assert.equal(candidate.capabilities.schedule.status, "CANDIDATE");
   assert.equal(candidate.capabilities.schedule.productionUseAllowed, false);
-  assert.equal(candidate.capabilities.schedule.coverageStatus, "IMPORTER_VALIDATION_REQUIRED");
-  assert.deepEqual(candidate.evidence.missingEvidence, ["scheduleImporterValidation"]);
+  assert.equal(candidate.capabilities.schedule.coverageStatus, "TRIP_STOP_SEQUENCE_REQUIRED");
+  assert.deepEqual(candidate.evidence.missingEvidence, ["tripStopSequenceSource", "adminReview"]);
   assert.ok(candidate.evidence.outputFields.includes("depTime"));
   assert.ok(candidate.evidence.outputFields.includes("arrTime"));
   assert.ok(candidate.evidence.outputFields.includes("dailyTypeCode"));

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -8069,6 +8069,43 @@ test("TAGO 시간표 sample validator는 JSON serviceKey credential을 거부한
   );
 });
 
+test("TAGO 시간표 sample validator는 duplicate serviceKey credential을 거부한다", async () => {
+  const samplePath = path.join(tmpdir(), `easysubway-tago-schedule-duplicate-secret-${Date.now()}.json`);
+  await writeFile(
+    samplePath,
+    `{
+      "serviceKey": "actual-secret",
+      "serviceKey": "[서비스키값]",
+      "response": {
+        "body": {
+          "items": {
+            "item": {
+              "endSubwayStationNm": "당고개",
+              "subwayRouteId": "MTRKR4",
+              "subwayStationId": "MTRKR4448",
+              "subwayStationNm": "상록수",
+              "dailyTypeCode": "01",
+              "upDownTypeCode": "U",
+              "depTime": "080500",
+              "arrTime": "080500",
+              "endSubwayStationId": "MTRKR4409"
+            }
+          }
+        }
+      }
+    }`,
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      ["tools/datapack/validate-tago-schedule-sample.mjs", "--sample", samplePath],
+      { cwd: root, env: productionEnv },
+    ),
+    /serviceKey credentials/,
+  );
+});
+
 test("공식 source ingest adapter는 station-line 단위 facility evidence coverage를 요구한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-ingest-facility-line-coverage-${Date.now()}`);
   const input = productionSourceIngestInput();

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -8069,6 +8069,49 @@ test("TAGO 시간표 sample validator는 JSON serviceKey credential을 거부한
   );
 });
 
+test("TAGO 시간표 sample validator는 destination field가 sample 전체에서 사라지면 거부한다", async () => {
+  const samplePath = path.join(tmpdir(), `easysubway-tago-schedule-missing-destination-${Date.now()}.json`);
+  await writeFile(samplePath, JSON.stringify({
+    response: {
+      body: {
+        items: {
+          item: {
+            subwayRouteId: "MTRKR4",
+            subwayStationId: "MTRKR4448",
+            subwayStationNm: "상록수",
+            dailyTypeCode: "01",
+            upDownTypeCode: "U",
+            depTime: "080500",
+            arrTime: "080500",
+          },
+        },
+      },
+    },
+  }));
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      ["tools/datapack/validate-tago-schedule-sample.mjs", "--sample", samplePath],
+      { cwd: root, env: productionEnv },
+    ),
+    /missing observed field: endSubwayStationNm/,
+  );
+});
+
+test("TAGO 시간표 sample validator는 함수 import만으로 CLI를 실행하지 않는다", async () => {
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      "import { validateTagoScheduleSample } from './tools/datapack/validate-tago-schedule-sample.mjs'; console.log(typeof validateTagoScheduleSample);",
+    ],
+    { cwd: root, env: productionEnv },
+  );
+  assert.equal(stdout.trim(), "function");
+});
+
 test("TAGO 시간표 sample validator는 duplicate serviceKey credential을 거부한다", async () => {
   const samplePath = path.join(tmpdir(), `easysubway-tago-schedule-duplicate-secret-${Date.now()}.json`);
   await writeFile(

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -7952,7 +7952,7 @@ test("공식 source ingest adapter는 admission 전 schedule provenance도 produ
 
 test("TAGO 시간표 sample validator는 station-level row shape만 검증하고 production 승격은 막는다", async () => {
   const samplePath = path.join(tmpdir(), `easysubway-tago-schedule-sample-${Date.now()}.json`);
-  await writeFile(samplePath, JSON.stringify({
+  const rawSample = `${JSON.stringify({
     response: {
       body: {
         items: {
@@ -7983,7 +7983,8 @@ test("TAGO 시간표 sample validator는 station-level row shape만 검증하고
         },
       },
     },
-  }));
+  })}\n`;
+  await writeFile(samplePath, rawSample);
 
   const { stdout } = await execFileAsync(
     process.execPath,
@@ -7995,6 +7996,7 @@ test("TAGO 시간표 sample validator는 station-level row shape만 검증하고
   assert.equal(report.rowCount, 2);
   assert.equal(report.stationLevelOnly, true);
   assert.equal(report.productionUseAllowed, false);
+  assert.equal(report.rawSha256, sha256(rawSample));
   assert.equal(report.remainingAdmissionBlocker, "line_wide_trip_stop_sequence_validation_required");
   assert.deepEqual(
     report.departures.map((departure) => departure.departureSeconds),

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -8034,6 +8034,39 @@ test("TAGO 시간표 sample validator는 잘못된 시간 row를 거부한다", 
   );
 });
 
+test("TAGO 시간표 sample validator는 JSON serviceKey credential을 거부한다", async () => {
+  const samplePath = path.join(tmpdir(), `easysubway-tago-schedule-secret-${Date.now()}.json`);
+  await writeFile(samplePath, JSON.stringify({
+    serviceKey: "secret",
+    response: {
+      body: {
+        items: {
+          item: {
+            endSubwayStationNm: "당고개",
+            subwayRouteId: "MTRKR4",
+            subwayStationId: "MTRKR4448",
+            subwayStationNm: "상록수",
+            dailyTypeCode: "01",
+            upDownTypeCode: "U",
+            depTime: "080500",
+            arrTime: "080500",
+            endSubwayStationId: "MTRKR4409",
+          },
+        },
+      },
+    },
+  }));
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      ["tools/datapack/validate-tago-schedule-sample.mjs", "--sample", samplePath],
+      { cwd: root, env: productionEnv },
+    ),
+    /serviceKey credentials/,
+  );
+});
+
 test("공식 source ingest adapter는 station-line 단위 facility evidence coverage를 요구한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-ingest-facility-line-coverage-${Date.now()}`);
   const input = productionSourceIngestInput();

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -7950,6 +7950,90 @@ test("공식 source ingest adapter는 admission 전 schedule provenance도 produ
   );
 });
 
+test("TAGO 시간표 sample validator는 station-level row shape만 검증하고 production 승격은 막는다", async () => {
+  const samplePath = path.join(tmpdir(), `easysubway-tago-schedule-sample-${Date.now()}.json`);
+  await writeFile(samplePath, JSON.stringify({
+    response: {
+      body: {
+        items: {
+          item: [
+            {
+              endSubwayStationNm: "당고개",
+              subwayRouteId: "MTRKR4",
+              subwayStationId: "MTRKR4448",
+              subwayStationNm: "상록수",
+              dailyTypeCode: "01",
+              upDownTypeCode: "U",
+              depTime: "080500",
+              arrTime: "080500",
+              endSubwayStationId: "MTRKR4409",
+            },
+            {
+              endSubwayStationNm: "당고개",
+              subwayRouteId: "MTRKR4",
+              subwayStationId: "MTRKR4448",
+              subwayStationNm: "상록수",
+              dailyTypeCode: "01",
+              upDownTypeCode: "U",
+              depTime: "081200",
+              arrTime: "081200",
+              endSubwayStationId: "MTRKR4409",
+            },
+          ],
+        },
+      },
+    },
+  }));
+
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    ["tools/datapack/validate-tago-schedule-sample.mjs", "--sample", samplePath],
+    { cwd: root, env: productionEnv },
+  );
+  const report = JSON.parse(stdout);
+  assert.equal(report.candidateId, "molit-tago-subway-info");
+  assert.equal(report.rowCount, 2);
+  assert.equal(report.stationLevelOnly, true);
+  assert.equal(report.productionUseAllowed, false);
+  assert.equal(report.remainingAdmissionBlocker, "line_wide_trip_stop_sequence_validation_required");
+  assert.deepEqual(
+    report.departures.map((departure) => departure.departureSeconds),
+    [29100, 29520],
+  );
+});
+
+test("TAGO 시간표 sample validator는 잘못된 시간 row를 거부한다", async () => {
+  const samplePath = path.join(tmpdir(), `easysubway-tago-schedule-invalid-${Date.now()}.json`);
+  await writeFile(samplePath, JSON.stringify({
+    response: {
+      body: {
+        items: {
+          item: {
+            endSubwayStationNm: "당고개",
+            subwayRouteId: "MTRKR4",
+            subwayStationId: "MTRKR4448",
+            subwayStationNm: "상록수",
+            dailyTypeCode: "01",
+            upDownTypeCode: "U",
+            depTime: "080500",
+            arrTime: "080700",
+            endSubwayStationId: "MTRKR4409",
+          },
+        },
+      },
+    },
+  }));
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      ["tools/datapack/validate-tago-schedule-sample.mjs", "--sample", samplePath],
+      { cwd: root, env: productionEnv },
+    ),
+    /arrival must be <= departure/,
+  );
+});
+
 test("공식 source ingest adapter는 station-line 단위 facility evidence coverage를 요구한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-ingest-facility-line-coverage-${Date.now()}`);
   const input = productionSourceIngestInput();

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -673,13 +673,21 @@
         "liveSampleRawSha256": "34af0c0e6750012070282b0b59f0226075bfbc8ee533f0bd934c78b130d297d4",
         "liveSampleSchemaFingerprint": "6e5d572290d2d5a8ea2d243a615b6f310417995944c140353a5606228016bd48",
         "liveSampleEvidenceHash": "d5a60bcc1907d346a24fbf720a5d362268720e8fab68e35c42eace270e5fe9ae",
+        "scheduleImporterValidation": {
+          "status": "validated_station_timetable_projection",
+          "tool": "tools/datapack/validate-tago-schedule-sample.mjs",
+          "validatedAt": "2026-07-03",
+          "validatedRawSha256": "34af0c0e6750012070282b0b59f0226075bfbc8ee533f0bd934c78b130d297d4",
+          "productionCanonicalStopTimesStatus": "blocked_requires_trip_stop_sequence",
+          "plannedEtaUseAllowed": false
+        },
         "usePermissionRange": "공공데이터포털 이용허락범위 제한 없음",
         "formats": [
           "XML",
           "JSON"
         ],
         "coverageLimitations": [
-          "시간표 import adapter와 provider sample validation 전까지 production PLANNED ETA 근거로 쓰지 않음",
+          "provider station timetable sample projection은 검증했지만 trip id와 전체 stop sequence가 없어 production PLANNED ETA 근거로 쓰지 않음",
           "route graph RIDE edge duration과 stop_times 정합 검증 필요"
         ],
         "outputFields": [
@@ -694,17 +702,18 @@
           "endSubwayStationId"
         ],
         "missingEvidence": [
-          "scheduleImporterValidation"
+          "tripStopSequenceSource",
+          "adminReview"
         ]
       },
-      "nextAction": "validate schedule importer against sanitized TAGO live sample before production timetable admission",
+      "nextAction": "identify provider trip/stop-sequence source and complete admin review before production timetable admission",
       "capabilities": {
         "schedule": {
           "status": "CANDIDATE",
           "productionUseAllowed": false,
-          "coverageStatus": "IMPORTER_VALIDATION_REQUIRED",
+          "coverageStatus": "TRIP_STOP_SEQUENCE_REQUIRED",
           "updateFrequency": "provider documented; production cadence not admitted",
-          "unsupportedNotes": "commercial schedule import remains blocked until production schedule importer and provider sample validation are complete"
+          "unsupportedNotes": "commercial schedule import remains blocked until trip id/stop sequence source and admin review are complete"
         },
         "realtime": {
           "status": "UNSUPPORTED",

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 const REQUIRED_FIELDS = [
   "subwayRouteId",
@@ -11,6 +12,11 @@ const REQUIRED_FIELDS = [
   "upDownTypeCode",
   "depTime",
   "arrTime",
+];
+const OBSERVED_FIELDS = [
+  ...REQUIRED_FIELDS,
+  "endSubwayStationNm",
+  "endSubwayStationId",
 ];
 const DAILY_TYPE_CODES = new Set(["01", "02", "03"]);
 const UP_DOWN_CODES = new Set(["U", "D"]);
@@ -46,6 +52,12 @@ function validateTagoScheduleSample(rawText) {
   const rows = normalizeRows(payload.response?.body?.items?.item);
   if (rows.length === 0) {
     throw new Error("TAGO schedule sample has no rows");
+  }
+  const observedFields = new Set(rows.flatMap((row) => Object.keys(row)));
+  for (const field of OBSERVED_FIELDS) {
+    if (!observedFields.has(field)) {
+      throw new Error(`TAGO schedule sample missing observed field: ${field}`);
+    }
   }
 
   let previousDeparture = -1;
@@ -167,7 +179,9 @@ async function main() {
 
 export { validateTagoScheduleSample };
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exitCode = 1;
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -124,7 +124,10 @@ function parseHhmmss(value, label) {
 }
 
 function rejectCredentialLeak(rawText, parsed, pathParts = []) {
-  if (/serviceKey=(?!\[서비스키값\])[^&\s"]+/i.test(rawText)) {
+  if (
+    /serviceKey=(?!\[서비스키값\])[^&\s"]+/i.test(rawText) ||
+    /"serviceKey"\s*:\s*"(?!\[서비스키값\]")[^"]+"/i.test(rawText)
+  ) {
     throw new Error("TAGO schedule sample must not contain serviceKey credentials");
   }
   if (Array.isArray(parsed)) {

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const REQUIRED_FIELDS = [
+  "subwayRouteId",
+  "subwayStationId",
+  "subwayStationNm",
+  "dailyTypeCode",
+  "upDownTypeCode",
+  "depTime",
+  "arrTime",
+];
+const DAILY_TYPE_CODES = new Set(["01", "02", "03"]);
+const UP_DOWN_CODES = new Set(["U", "D"]);
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!flag.startsWith("--")) {
+      throw new Error(`unexpected argument: ${flag}`);
+    }
+    if (!value || value.startsWith("--")) {
+      throw new Error(`${flag} requires a value`);
+    }
+    args[flag.slice(2)] = value;
+    index += 1;
+  }
+  args.input ??= args.sample;
+  if (!args.input) {
+    throw new Error("--input is required");
+  }
+  return args;
+}
+
+function validateTagoScheduleSample(rawText) {
+  const canonicalRawText = rawText.trimEnd();
+  rejectCredentialLeak(rawText);
+  const payload = JSON.parse(canonicalRawText);
+  if (payload.response?.header && payload.response.header.resultCode !== "00") {
+    throw new Error(`TAGO response is not normal service: ${payload.response?.header?.resultCode ?? "missing"}`);
+  }
+
+  const rows = normalizeRows(payload.response?.body?.items?.item);
+  if (rows.length === 0) {
+    throw new Error("TAGO schedule sample has no rows");
+  }
+
+  let previousDeparture = -1;
+  const providerRecordHashes = [];
+  const departures = [];
+  for (const [index, row] of rows.entries()) {
+    for (const field of REQUIRED_FIELDS) {
+      if (typeof row[field] !== "string" || row[field].length === 0) {
+        throw new Error(`TAGO schedule row ${index} missing field: ${field}`);
+      }
+    }
+    if (!DAILY_TYPE_CODES.has(row.dailyTypeCode)) {
+      throw new Error(`TAGO schedule row ${index} has unknown dailyTypeCode: ${row.dailyTypeCode}`);
+    }
+    if (!UP_DOWN_CODES.has(row.upDownTypeCode)) {
+      throw new Error(`TAGO schedule row ${index} has unknown upDownTypeCode: ${row.upDownTypeCode}`);
+    }
+    const arrivalSeconds = parseHhmmss(row.arrTime, `row ${index} arrTime`);
+    const departureSeconds = parseHhmmss(row.depTime, `row ${index} depTime`);
+    if (arrivalSeconds > departureSeconds) {
+      throw new Error(`TAGO schedule row ${index} arrival must be <= departure`);
+    }
+    if (departureSeconds < previousDeparture) {
+      throw new Error(`TAGO schedule rows must be sorted by depTime`);
+    }
+    previousDeparture = departureSeconds;
+    providerRecordHashes.push(sha256(JSON.stringify(sortObject(row))));
+    departures.push({
+      subwayStationId: row.subwayStationId,
+      subwayRouteId: row.subwayRouteId,
+      dailyTypeCode: row.dailyTypeCode,
+      upDownTypeCode: row.upDownTypeCode,
+      arrivalSeconds,
+      departureSeconds,
+    });
+  }
+
+  return {
+    artifactKind: "tago-schedule-sample-importer-validation",
+    candidateId: "molit-tago-subway-info",
+    endpoint: "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList",
+    rowCount: rows.length,
+    providerRecordHashes,
+    rawSha256: sha256(canonicalRawText),
+    departures,
+    stationLevelOnly: true,
+    productionUseAllowed: false,
+    remainingAdmissionBlocker: "line_wide_trip_stop_sequence_validation_required",
+    stationTimetableProjectionStatus: "validated",
+    productionCanonicalStopTimesStatus: "blocked_requires_trip_stop_sequence",
+    plannedEtaUseAllowed: false,
+  };
+}
+
+function normalizeRows(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value && typeof value === "object") {
+    return [value];
+  }
+  return [];
+}
+
+function parseHhmmss(value, label) {
+  if (!/^\d{6}$/.test(value)) {
+    throw new Error(`${label} must use HHMMSS`);
+  }
+  const hours = Number(value.slice(0, 2));
+  const minutes = Number(value.slice(2, 4));
+  const seconds = Number(value.slice(4, 6));
+  if (hours > 29 || minutes > 59 || seconds > 59) {
+    throw new Error(`${label} is out of range`);
+  }
+  return hours * 3600 + minutes * 60 + seconds;
+}
+
+function rejectCredentialLeak(rawText) {
+  if (/serviceKey=(?!\[서비스키값\])[^&\s"]+/i.test(rawText)) {
+    throw new Error("TAGO schedule sample must not contain serviceKey credentials");
+  }
+}
+
+function sortObject(value) {
+  return Object.fromEntries(Object.entries(value).sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const inputPath = path.resolve(args.input);
+  const result = validateTagoScheduleSample(await readFile(inputPath, "utf8"));
+  if (args.output) {
+    await writeFile(path.resolve(args.output), `${JSON.stringify(result, null, 2)}\n`);
+  }
+  console.log(JSON.stringify(result, null, 2));
+}
+
+export { validateTagoScheduleSample };
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -38,8 +38,8 @@ function parseArgs(argv) {
 
 function validateTagoScheduleSample(rawText) {
   const canonicalRawText = rawText.trimEnd();
-  rejectCredentialLeak(rawText);
   const payload = JSON.parse(canonicalRawText);
+  rejectCredentialLeak(canonicalRawText, payload);
   if (payload.response?.header && payload.response.header.resultCode !== "00") {
     throw new Error(`TAGO response is not normal service: ${payload.response?.header?.resultCode ?? "missing"}`);
   }
@@ -124,9 +124,24 @@ function parseHhmmss(value, label) {
   return hours * 3600 + minutes * 60 + seconds;
 }
 
-function rejectCredentialLeak(rawText) {
+function rejectCredentialLeak(rawText, parsed, pathParts = []) {
   if (/serviceKey=(?!\[서비스키값\])[^&\s"]+/i.test(rawText)) {
     throw new Error("TAGO schedule sample must not contain serviceKey credentials");
+  }
+  if (Array.isArray(parsed)) {
+    for (const [index, item] of parsed.entries()) {
+      rejectCredentialLeak("", item, [...pathParts, String(index)]);
+    }
+    return;
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return;
+  }
+  for (const [key, value] of Object.entries(parsed)) {
+    if (/serviceKey/i.test(key) && value !== "[서비스키값]") {
+      throw new Error(`TAGO schedule sample must not contain serviceKey credentials: ${[...pathParts, key].join(".")}`);
+    }
+    rejectCredentialLeak("", value, [...pathParts, key]);
   }
 }
 

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -37,9 +37,8 @@ function parseArgs(argv) {
 }
 
 function validateTagoScheduleSample(rawText) {
-  const canonicalRawText = rawText.trimEnd();
-  const payload = JSON.parse(canonicalRawText);
-  rejectCredentialLeak(canonicalRawText, payload);
+  const payload = JSON.parse(rawText);
+  rejectCredentialLeak(rawText, payload);
   if (payload.response?.header && payload.response.header.resultCode !== "00") {
     throw new Error(`TAGO response is not normal service: ${payload.response?.header?.resultCode ?? "missing"}`);
   }
@@ -90,7 +89,7 @@ function validateTagoScheduleSample(rawText) {
     endpoint: "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList",
     rowCount: rows.length,
     providerRecordHashes,
-    rawSha256: sha256(canonicalRawText),
+    rawSha256: sha256(rawText),
     departures,
     stationLevelOnly: true,
     productionUseAllowed: false,


### PR DESCRIPTION
## 관련 이슈

Refs #1415

## 작업 배경

- TAGO live sample evidence는 확보됐지만 #1415 tracker에는 `scheduleImporterValidation`이 남아 있었습니다.
- TAGO station-level sample은 `depTime/arrTime` row shape 검증은 가능하지만, trip id와 전체 stop sequence가 없어 production `PLANNED` ETA 승격 근거로 쓰면 안 됩니다.

## 작업 내용

- TAGO candidate에 `scheduleImporterValidation` evidence metadata를 기록했습니다.
- missing evidence를 `scheduleImporterValidation`에서 `tripStopSequenceSource`, `adminReview`로 좁혔습니다.
- schedule coverage 상태를 `TRIP_STOP_SEQUENCE_REQUIRED`로 고정했습니다.
- repository contract가 위 상태를 검증하게 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `node tools/datapack/validate-tago-schedule-sample.mjs --input .codex/evidence/1415/molit-tago-subway-info/timetable-mtrkr4448.raw --output .codex/evidence/1415/molit-tago-subway-info/tago-schedule-importer-validation.json` 성공
  - `node --test --test-name-pattern "source candidate|source admission|TAGO|schedule" tools/ci/repository-contract.test.mjs tools/datapack/datapack-tools.test.mjs` 성공: 24 pass
  - `node --test tools/ci/repository-contract.test.mjs` 성공: 158 pass
  - `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| TAGO importer validation | repo | local validator | `.codex/evidence/1415/molit-tago-subway-info/tago-schedule-importer-validation.json` | 성공 |
| TAGO contract | repo | node test | 터미널 출력 | 성공 |
| UI/접근성 증거 | 해당 없음 | metadata/test-only 변경 | 증거 불필요: UI 변경 없음 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/source-candidates.json`의 `molit-tago-subway-info` evidence 상태 전환
- 이 PR은 production schedule admission을 열지 않습니다. 남은 자동/QA 경계는 trip/stop-sequence source 식별과 admin review입니다.

## 리스크

- 낮음. source candidate metadata와 contract test만 변경하며 production pack 입력은 변경하지 않습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
