### PR TITLE
[Chore] TOPIS live sample evidence 기록 (#1397)

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5619,7 +5619,7 @@ test("서울 TOPIS 실시간 후보는 backend-only key 경계와 production 분
   for (const candidate of topisCandidates) {
     assert.equal(candidate.priority, "P0");
     assert.equal(candidate.licenseEvidenceStatus, "confirmed_attribution");
-    assert.equal(candidate.sampleEvidenceStatus, "sample_url_documented_key_required");
+    assert.equal(candidate.sampleEvidenceStatus, "validated_live_sample");
     assert.equal(candidate.admissionStatus, "evidence_recorded_admin_review_required");
     assert.equal(candidate.serviceKeyHandling, "backend_secret_only");
     assert.equal(candidate.mobileEmbeddingAllowed, false);
@@ -5642,9 +5642,15 @@ test("서울 TOPIS 실시간 후보는 backend-only key 경계와 production 분
     assert.equal(candidate.evidence.usePermissionRange, "공공누리 1유형");
     assert.deepEqual(candidate.evidence.formats, ["JSON"]);
     assert.match(candidate.evidence.sampleUrl, /\[서비스키값\]/);
+    assert.match(candidate.evidence.liveSampleRetrievedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    assert.equal(candidate.evidence.liveSampleRowCount, 5);
+    assert.match(candidate.evidence.liveSampleRawSha256, /^[0-9a-f]{64}$/);
+    assert.match(candidate.evidence.liveSampleSchemaFingerprint, /^[0-9a-f]{64}$/);
+    assert.match(candidate.evidence.liveSampleEvidenceHash, /^[0-9a-f]{64}$/);
     assert.ok(candidate.evidence.coverageLimitations.length >= 2);
     assert.ok(candidate.evidence.outputFields.includes("recptnDt"));
-    assert.deepEqual(candidate.evidence.missingEvidence, ["sampleResponse"]);
+    assert.deepEqual(candidate.evidence.missingEvidence, ["providerTermsOrQuotaApproval", "adminReview"]);
+    assert.equal(candidate.capabilities.realtime.coverageStatus, "PROVIDER_TERMS_OR_QUOTA_REQUIRED");
     assert.ok(candidate.nextAction);
 
     const productionSource = productionSourceByDatasetUrl.get(candidate.detailUrl);

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -741,7 +741,7 @@
       "detailUrl": "https://data.seoul.go.kr/dataList/OA-12764/F/1/datasetView.do",
       "requestUrl": "http://swopenapi.seoul.go.kr/api/subway/{serviceKey}/json/realtimeStationArrival",
       "licenseEvidenceStatus": "confirmed_attribution",
-      "sampleEvidenceStatus": "sample_url_documented_key_required",
+      "sampleEvidenceStatus": "validated_live_sample",
       "admissionStatus": "evidence_recorded_admin_review_required",
       "productionInventoryReferenceId": "seoul-realtime-arrival-station-info",
       "productionInventoryRelationship": "same_dataset_station_reference_is_production_live_provider_contract_remains_candidate",
@@ -777,10 +777,16 @@
           "updnLine"
         ],
         "missingEvidence": [
-          "sampleResponse"
-        ]
+          "providerTermsOrQuotaApproval",
+          "adminReview"
+        ],
+        "liveSampleRetrievedAt": "2026-07-03T15:37:21Z",
+        "liveSampleRowCount": 5,
+        "liveSampleRawSha256": "d07597c4936e4a5af61f465abf25851a6e4881c09781b034bed2696d4fd396a8",
+        "liveSampleSchemaFingerprint": "868d78c39e620f62a464cd547760de538e71cb7e863bf962cd14a25b30b3ff47",
+        "liveSampleEvidenceHash": "86c6fede4ddef9e5038142ef1ae1ceb700fe15d1f2d2eca2aa6e57bc6a27862b"
       },
-      "nextAction": "capture sanitized live sample with backend-only Seoul API key and confirm quota before production provider adapter",
+      "nextAction": "complete TOPIS provider terms/quota approval and admin review before production realtime ETA admission",
       "capabilities": {
         "schedule": {
           "status": "UNSUPPORTED",
@@ -794,9 +800,9 @@
           "productionUseAllowed": false,
           "liveEtaEligible": false,
           "rateLimitStatus": "BLOCKED_PENDING_PROVIDER_TERMS_OR_QUOTA",
-          "coverageStatus": "SAMPLE_EVIDENCE_REQUIRED",
+          "coverageStatus": "PROVIDER_TERMS_OR_QUOTA_REQUIRED",
           "updateFrequency": "provider realtime API; production quota not admitted",
-          "unsupportedNotes": "backend-only service key, provider terms, rate limits, and live sample evidence must be approved before live ETA"
+          "unsupportedNotes": "live sample evidence is validated, but backend-only key terms, provider quota, and admin review are still required before live ETA"
         },
         "facility": {
           "status": "UNSUPPORTED",
@@ -815,7 +821,7 @@
       "detailUrl": "https://data.seoul.go.kr/dataList/OA-12601/A/1/datasetView.do",
       "requestUrl": "http://swopenapi.seoul.go.kr/api/subway/{serviceKey}/json/realtimePosition",
       "licenseEvidenceStatus": "confirmed_attribution",
-      "sampleEvidenceStatus": "sample_url_documented_key_required",
+      "sampleEvidenceStatus": "validated_live_sample",
       "admissionStatus": "evidence_recorded_admin_review_required",
       "serviceKeyHandling": "backend_secret_only",
       "mobileEmbeddingAllowed": false,
@@ -849,10 +855,16 @@
           "updnLine"
         ],
         "missingEvidence": [
-          "sampleResponse"
-        ]
+          "providerTermsOrQuotaApproval",
+          "adminReview"
+        ],
+        "liveSampleRetrievedAt": "2026-07-03T15:37:21Z",
+        "liveSampleRowCount": 5,
+        "liveSampleRawSha256": "c48be5d948394ff8af18617feee43c902a09e4a6237da76e6003b442aa6445b3",
+        "liveSampleSchemaFingerprint": "94d22dd5b64ad968f1347d94c3cce657e0f539c5a0e6bf2c2570245715479209",
+        "liveSampleEvidenceHash": "33734c425b0896ca26cf1f5eae718b9516f43fd4caa92fa14fbbb6b8bf58f6f6"
       },
-      "nextAction": "capture sanitized live sample with backend-only Seoul API key and keep train position separate from precise GPS claims",
+      "nextAction": "complete TOPIS provider terms/quota approval and admin review before using train position as realtime overlay evidence",
       "capabilities": {
         "schedule": {
           "status": "UNSUPPORTED",
@@ -866,9 +878,9 @@
           "productionUseAllowed": false,
           "liveEtaEligible": false,
           "rateLimitStatus": "BLOCKED_PENDING_PROVIDER_TERMS_OR_QUOTA",
-          "coverageStatus": "SAMPLE_EVIDENCE_REQUIRED",
+          "coverageStatus": "PROVIDER_TERMS_OR_QUOTA_REQUIRED",
           "updateFrequency": "provider realtime API; production quota not admitted",
-          "unsupportedNotes": "backend-only service key, provider terms, rate limits, and live sample evidence must be approved before live ETA"
+          "unsupportedNotes": "live sample evidence is validated, but backend-only key terms, provider quota, and admin review are still required before live ETA"
         },
         "facility": {
           "status": "UNSUPPORTED",


### PR DESCRIPTION
## 관련 이슈

Refs #1397
Refs #1419

## 작업 배경

- #1397의 provider key 기반 live sample blocker 중 TOPIS realtime station arrival / train position 후보 2건을 실제 호출 hash evidence로 좁힙니다.
- raw provider response는 local-only `.codex/evidence/1397/topis-live/`에만 보관하고, tracked 파일에는 hash/schema/row count만 남깁니다.

## 작업 내용

- `seoul-topis-realtime-station-arrival`, `seoul-topis-realtime-train-position`을 `validated_live_sample`로 갱신했습니다.
- 각 후보에 `liveSampleRetrievedAt`, `liveSampleRowCount`, `liveSampleRawSha256`, `liveSampleSchemaFingerprint`, `liveSampleEvidenceHash`를 기록했습니다.
- production realtime ETA 승격은 계속 차단하고, 남은 evidence를 `providerTermsOrQuotaApproval`, `adminReview`로 명시했습니다.

## 검증

- 실행한 명령과 결과:
- `scripts/github/sync-actions-env-secret.sh /private/tmp/easysubway-env-sync.env` 통과, `EASYSUBWAY_ENV` secret 갱신
- TOPIS live sample 호출 2회: station arrival 200 / 3657 bytes, train position 200 / 2027 bytes
- `node tools/datapack/validate-source-candidate-sample.mjs --candidate seoul-topis-realtime-station-arrival --sample .codex/evidence/1397/topis-live/seoul-topis-realtime-station-arrival.sample-evidence.json` 통과
- `node tools/datapack/validate-source-candidate-sample.mjs --candidate seoul-topis-realtime-train-position --sample .codex/evidence/1397/topis-live/seoul-topis-realtime-train-position.sample-evidence.json` 통과
- `node --test --test-name-pattern "서울 TOPIS 실시간 후보|source candidate sample" tools/ci/repository-contract.test.mjs tools/datapack/datapack-tools.test.mjs` 통과, 13 pass
- `rg --pcre2 -n 'serviceKey=(?!\[서비스키값\])|/api/subway/(?!\{serviceKey\}|\[서비스키값\])|EASYSUBWAY_SEOUL_TOPIS_SERVICE_KEY' .codex/evidence/1397/topis-live` match 없음
- `git diff --check` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| TOPIS live sample raw archive | local-only | provider call 2회, raw credential leak scan | `.codex/evidence/1397/topis-live/` | PASS |
| candidate sample evidence | local-only | validator 2건 | `.codex/evidence/1397/topis-live/*.sample-evidence.json` | PASS |
| UI/접근성 | 해당 없음 | 데이터 후보 메타데이터만 변경 | 증거 불필요 | PASS |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: source candidate evidence만 갱신, production realtime contract 승격 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: TOPIS 후보가 live sample hash는 갖지만 `productionUseAllowed=false`, `liveEtaEligible=false`, `rateLimitStatus=BLOCKED_PENDING_PROVIDER_TERMS_OR_QUOTA`를 유지하는지 확인해주세요.

## 리스크

- provider terms/quota approval과 admin review는 아직 남아 있어 #1397을 닫지 않습니다.
- raw response는 GitHub에 올리지 않았습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
