### PR TITLE
[Test] strict route eligibility 회귀 고정 (#1394)

### DIFF
--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -334,6 +334,7 @@ void main() {
       expect(result.status, RouteStatus.unknown);
       expect(result.edgeIds, isEmpty);
       expect(result.blockedReasonCodes, ['ACCESSIBILITY_STATE_UNKNOWN']);
+      expect(result.warningCodes, isEmpty);
     });
 
     test('휠체어 조건은 계단 여부 미확인 edge를 안전한 경로로 사용하지 않는다', () {

--- a/apps/mobile/test/features/routes/route_engine_test.dart
+++ b/apps/mobile/test/features/routes/route_engine_test.dart
@@ -320,6 +320,22 @@ void main() {
       expect(result.warningCodes, isEmpty);
     });
 
+    test('휠체어 조건은 strict eligible이 아닌 edge를 안전한 경로로 사용하지 않는다', () {
+      final engine = LocalRouteEngine(graph: _strictIneligibleFixtureGraph());
+
+      final result = engine.search(
+        const RouteRequest(
+          originStationId: 'station-a',
+          destinationStationId: 'station-b',
+          mobilityType: MobilityType.wheelchair,
+        ),
+      );
+
+      expect(result.status, RouteStatus.unknown);
+      expect(result.edgeIds, isEmpty);
+      expect(result.blockedReasonCodes, ['ACCESSIBILITY_STATE_UNKNOWN']);
+    });
+
     test('휠체어 조건은 계단 여부 미확인 edge를 안전한 경로로 사용하지 않는다', () {
       final engine = LocalRouteEngine(graph: _unknownStairAccessFixtureGraph());
 
@@ -1273,6 +1289,40 @@ NetworkGraph _unknownStairAccessFixtureGraph() {
         type: RouteEdgeType.exit,
         baseCost: 60,
         stairAccessState: RouteStairAccessState.stepFree,
+      ),
+    ],
+  );
+}
+
+NetworkGraph _strictIneligibleFixtureGraph() {
+  return NetworkGraph(
+    nodes: const [
+      RouteNode(id: 'station-a', stationId: 'station-a', lineId: 'line-1'),
+      RouteNode(id: 'station-b', stationId: 'station-b', lineId: 'line-1'),
+    ],
+    edges: const [
+      RouteEdge(
+        id: 'facility-a-b-status-unknown',
+        fromNodeId: 'station-a',
+        toNodeId: 'station-b',
+        type: RouteEdgeType.facilityConnector,
+        baseCost: 90,
+        stairAccessState: RouteStairAccessState.stepFree,
+        safetyEvidence: RouteEdgeSafetyEvidence(
+          sourceId: 'operator-facility-status',
+          sourceSnapshotId: 'snapshot-unknown',
+          providerRecordHash: 'provider-hash',
+          provenanceKind: 'OFFICIAL_SOURCE',
+          verificationStatus: 'CHECK_REQUIRED',
+          evidenceHash: 'evidence-hash',
+          evidenceHashValid: true,
+          isPlaceholderEvidence: false,
+          lastVerifiedAt: null,
+          isStale: false,
+          isGeneratedConnector: false,
+          strictRouteEligible: false,
+          blockerReasons: ['ACCESSIBILITY_STATE_UNKNOWN'],
+        ),
       ),
     ],
   );


### PR DESCRIPTION
## 관련 이슈

Refs #1394
Refs #1419

## 작업 배경

- #1394는 UNKNOWN/미검증 시설이 strict route eligible로 쓰이지 않는다는 증거가 필요합니다.

## 작업 내용

- route engine 테스트에 `strictRouteEligible=false` edge가 휠체어 경로에서 `FOUND`로 승격되지 않는 regression을 추가했습니다.
- 기능 코드는 이미 해당 계약을 처리하고 있어 변경하지 않았습니다.

## 검증

- 실행한 명령과 결과:
  - `flutter test test/features/routes/route_engine_test.dart` pass
  - `git diff --check` pass

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| strict eligible false route regression | Flutter unit test | `flutter test test/features/routes/route_engine_test.dart` | terminal output | pass |
| whitespace | repo | `git diff --check` | terminal output | pass |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `apps/mobile/test/features/routes/route_engine_test.dart`

## 리스크

- 테스트만 추가한 변경이라 runtime behavior risk는 낮습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
