### PR TITLE
[Chore] 앱 데이터 품질 표시 증거 추가 (#1400)

### DIFF
--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -4973,6 +4973,15 @@ class _DataSourceAttributionScreenState
                         subtitle: ProductionScopeCopy.supportedClaimKo,
                       ),
                     ),
+                    const _AppCard(
+                      child: _AppInfoRow(
+                        icon: Icons.fact_check_outlined,
+                        iconColor: EasySubwayAccessibleColors.amber,
+                        title: '현재 앱 표시',
+                        subtitle:
+                            '상록수·사당 pilot만 확인해요. 현장 또는 운영기관 확인 전에는 전국 쉬운 길이나 실시간 도착을 보장한다고 말하지 않아요.',
+                      ),
+                    ),
                     const _AppSectionTitle(title: '지도 표시용 asset'),
                     for (final map in maps) _AttributionCard.map(map, manifest),
                     const _AppSectionTitle(title: '데이터 품질 Level'),

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -3900,6 +3900,11 @@ void main() {
     );
     expect(find.text('데이터 및 지도 출처'), findsOneWidget);
     expect(find.byType(Scrollable), findsOneWidget);
+    expect(find.text('현재 앱 표시'), findsOneWidget);
+    expect(
+      find.textContaining('전국 쉬운 길이나 실시간 도착을 보장한다고 말하지 않아요'),
+      findsOneWidget,
+    );
     await tester.scrollUntilVisible(find.text('데이터 품질 Level'), 160);
     await tester.pumpAndSettle();
     expect(find.text('데이터 품질 Level'), findsOneWidget);


### PR DESCRIPTION
## 관련 이슈

Refs #1400
Refs #1419

## 작업 배경

- #1400의 남은 blocker 중 앱 데이터 품질 표시/도움말 evidence 항목을 코드와 widget test로 좁혀 닫습니다.
- 실제 4호선 인접역 graph 승격, production artifact 검증, field/operator 확인은 이 PR에서 claim하지 않습니다.

## 작업 내용

- `데이터 및 지도 출처` 화면에 현재 앱 표시 범위를 추가했습니다.
- 상록수·사당 pilot만 확인하며, 현장 또는 운영기관 확인 전에는 전국 쉬운 길/실시간 도착 보장 claim을 하지 않는 문구를 노출합니다.
- 해당 문구를 기존 출처 화면 widget test에 고정했습니다.

## 검증

- 실행한 명령과 결과:
- `dart format apps/mobile/lib/main.dart apps/mobile/test/widget_test.dart` 통과
- `flutter test test/widget_test.dart --plain-name '데이터 및 지도 출처 화면은 manifest와 source inventory를 보여준다'` 통과\n- `flutter test test/user_copy_guard.dart`는 단독 test 파일이 아니라 `main` 없음으로 실행 불가했습니다. 실제 copy guard는 widget test 경로에서 import되어 검증됩니다.\n- `git diff --check` 통과\n\n## 검증 증거\n\nUI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.\n\n| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |\n| --- | --- | --- | --- | --- |\n| 데이터 및 지도 출처 품질 표시 | Flutter widget | widget test에서 문구 렌더링 확인 | `apps/mobile/test/widget_test.dart` | PASS |\n| Android screenshot/UI tree | Android | 실제 RC/QA evidence 필요 | 이 PR은 widget evidence만 추가, RC QA에서 수집 | DEFERRED |\n\n## Version impact\n\n- [x] no version change\n- [ ] mobile patch\n- [ ] mobile minor\n- [ ] mobile major\n- [ ] backend deploy only\n- [ ] datapack release only\n- [ ] route/realtime contract change\n- [ ] DB migration change\n\n## Route commercialization gate impact\n\n- [x] route-commercialization-gate.json 영향 없음\n- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.\n- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.\n\n## Route release readiness tracker impact\n\n- [ ] route-release-readiness-tracker.json 영향 없음\n- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.\n- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.\n\n### Version decision\n\n- mobile versionName: 변경 없음\n- mobile versionCode: 변경 없음\n- datapack version: 변경 없음\n- route contract: 변경 없음\n- realtime contract: 변경 없음\n- backend identity: 변경 없음\n\n## 리뷰어 메모\n\n- 리뷰어가 먼저 봐야 할 지점: 새 문구가 #1400의 앱 품질 표시 evidence 요구를 충족하되, Level 4/전국/실시간 ETA claim으로 읽히지 않는지 확인해주세요.\n\n## 리스크\n\n- Android screenshot/UI tree 증거는 실제 RC QA에서 별도 수집해야 합니다.\n- #1400의 graph/source admission, route map 4호선 확장, production artifact evidence는 아직 남아 있어 이 PR로 #1400을 닫지 않습니다.\n\n## 체크리스트\n\n- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.\n- [x] CI 결과를 확인했다.\n- [x] CodeRabbit 리뷰를 확인했다.\n- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.\n- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.\n- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.