### PR TITLE
[Chore] #1397 TAGO source admission approval evidence

### DIFF
--- a/apps/mobile/assets/datapacks/source-inventory.json
+++ b/apps/mobile/assets/datapacks/source-inventory.json
@@ -433,7 +433,7 @@
         "rawSha256": "34af0c0e6750012070282b0b59f0226075bfbc8ee533f0bd934c78b130d297d4",
         "schemaFingerprint": "6e5d572290d2d5a8ea2d243a615b6f310417995944c140353a5606228016bd48",
         "sourceSnapshotSetHash": "f6a7dcb11a04a1993202fc5fbd3068eb5808f66a237f2b72c907700bbd660578",
-        "sourceInventorySha256": "b3c0aeb36990318484c2f368622366503e78e363956426cbdb6cc4ac9e093af7",
+        "sourceInventorySha256": "85a88db7f1c9f389adda7a8c1b9bc7c682ec1fe3762a4cb647ce332d52a916f1",
         "adminReviewRecordHash": "68de2df243b1b73b5eb5b50c786bbd43385c99338c29945d7fd38b2163640ef0",
         "licenseEvidenceHash": "1bece434e20038b0e5fc9fb7812b96fc088936905208ad1619317dda73e17c60",
         "aliasLedgerHash": "6915e06ab8432339b4c3b19ec2a7abeba0698b004234e85e5c1d19735a8b6f6f",

--- a/apps/mobile/assets/datapacks/source-inventory.json
+++ b/apps/mobile/assets/datapacks/source-inventory.json
@@ -419,6 +419,30 @@
           "updateFrequency": "realtime",
           "unsupportedNotes": "source does not provide accessibility facility records"
         }
+      },
+      "admissionEvidence": {
+        "artifactKind": "source-admission-pipeline-evidence-summary",
+        "issue": 1397,
+        "candidateId": "molit-tago-subway-info",
+        "sourceId": "molit-tago-subway-info",
+        "snapshotId": "molit-tago-subway-info-snapshot-20260704",
+        "decision": "APPROVED",
+        "approvedBy": "qa-admin",
+        "approvedAt": "2026-07-04T00:20:00Z",
+        "sampleEvidenceHash": "d5a60bcc1907d346a24fbf720a5d362268720e8fab68e35c42eace270e5fe9ae",
+        "rawSha256": "34af0c0e6750012070282b0b59f0226075bfbc8ee533f0bd934c78b130d297d4",
+        "schemaFingerprint": "6e5d572290d2d5a8ea2d243a615b6f310417995944c140353a5606228016bd48",
+        "sourceSnapshotSetHash": "f6a7dcb11a04a1993202fc5fbd3068eb5808f66a237f2b72c907700bbd660578",
+        "sourceInventorySha256": "b3c0aeb36990318484c2f368622366503e78e363956426cbdb6cc4ac9e093af7",
+        "adminReviewRecordHash": "68de2df243b1b73b5eb5b50c786bbd43385c99338c29945d7fd38b2163640ef0",
+        "licenseEvidenceHash": "1bece434e20038b0e5fc9fb7812b96fc088936905208ad1619317dda73e17c60",
+        "aliasLedgerHash": "6915e06ab8432339b4c3b19ec2a7abeba0698b004234e85e5c1d19735a8b6f6f",
+        "operatorMappingLedgerHash": "436598de70ed9d75b909010aa9fe8a283fe86d9ab9041fcb1ab8c1f54b43f9d0",
+        "facilityEvidenceLedgerHash": "2f9ddabfb6c983c428d2194ea88e65818b5ae951750f82078375ca883ace110c",
+        "routeEvidenceLedgerHash": "db2a0915adbf98eabc8f4ee52b4a9f27d25ebca95ecdfff3e3c8e4554ef768cc",
+        "overrideHash": "b5fb2c6fed271ff24e1c8ecd0d2334b257540e2032492f78b4d8417964215787",
+        "admissionDurationSeconds": 0,
+        "productionUseNoteKo": "admin review는 통과했지만 trip/stop sequence source가 없어 schedule_timetable production use는 아직 차단한다."
       }
     },
     {

--- a/apps/mobile/test/widget_test.dart
+++ b/apps/mobile/test/widget_test.dart
@@ -1148,8 +1148,15 @@ void main() {
         matching: find.byType(InkWell),
       ),
     );
-    await tester.pump(const Duration(seconds: 1));
-    await tester.pump(const Duration(milliseconds: 300));
+    for (var attempt = 0; attempt < 30; attempt += 1) {
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 100)),
+      );
+      await tester.pump(const Duration(milliseconds: 100));
+      if (find.text('지도 표시용 asset').evaluate().isNotEmpty) {
+        break;
+      }
+    }
 
     expect(
       find.byKey(const Key('dataSourceAttributionScreen')),

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4596,14 +4596,18 @@ test("운영 데이터팩 공식 출처 inventory는 라이선스와 갱신 기�
   ]);
   const p0SourceCandidates = sourceCandidates.candidates.filter((candidate) => candidate.priority === "P0");
   assert.equal(targets.roadmapEvidenceLedger.sourceCandidateAdmission.p0CandidateCount, p0SourceCandidates.length);
-  assert.ok(
-    p0SourceCandidates.every(
-      (candidate) =>
-        candidate.admissionStatus === targets.roadmapEvidenceLedger.sourceCandidateAdmission.currentSharedAdmissionStatus,
-    ),
+  assert.deepEqual(
+    p0SourceCandidates
+      .filter(
+        (candidate) =>
+          candidate.admissionStatus === targets.roadmapEvidenceLedger.sourceCandidateAdmission.requiredAdmissionStatusBeforeProductionClaim,
+      )
+      .map((candidate) => candidate.id),
+    ["molit-tago-subway-info"],
   );
+  assert.equal(targets.roadmapEvidenceLedger.sourceCandidateAdmission.admittedCandidateCount, 1);
   assert.equal(
-    targets.roadmapEvidenceLedger.sourceCandidateAdmission.currentSharedAdmissionStatus,
+    targets.roadmapEvidenceLedger.sourceCandidateAdmission.currentOpenAdmissionStatus,
     "evidence_recorded_admin_review_required",
   );
   assert.match(targets.roadmapEvidenceLedger.gapEscalationRuleKo, /P0 release blocker/);
@@ -5679,7 +5683,7 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
   assert.equal(candidate.domain, "schedule_timetable");
   assert.equal(candidate.licenseEvidenceStatus, "confirmed_attribution");
   assert.equal(candidate.sampleEvidenceStatus, "validated_live_sample");
-  assert.equal(candidate.admissionStatus, "evidence_recorded_admin_review_required");
+  assert.equal(candidate.admissionStatus, "admitted_to_production_inventory");
   assert.equal(candidate.serviceKeyHandling, "offline_import_secret_only");
   assert.equal(candidate.mobileEmbeddingAllowed, false);
   assert.equal(candidate.productionInventoryReferenceId, "molit-tago-subway-info");
@@ -5703,6 +5707,14 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
     productionCanonicalStopTimesStatus: "blocked_requires_trip_stop_sequence",
     plannedEtaUseAllowed: false,
   });
+  assert.deepEqual(candidate.evidence.adminReview, {
+    artifactKind: "source-admission-admin-review-summary",
+    decision: "APPROVED",
+    approvedBy: "qa-admin",
+    approvedAt: "2026-07-04T00:20:00Z",
+    sampleEvidenceHash: candidate.evidence.liveSampleEvidenceHash,
+    admissionDurationSeconds: 0,
+  });
   assert.equal(productionSourceIds.has(candidate.id), true, "TAGO inventory entry exists but must remain non-production");
 
   const inventorySource = inventory.sources.find(({ id }) => id === "molit-tago-subway-info");
@@ -5710,11 +5722,17 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
   assert.equal(inventorySource.capabilities.schedule.status, "CANDIDATE");
   assert.equal(inventorySource.capabilities.schedule.productionUseAllowed, false);
   assert.equal(inventorySource.coverageScope.sourceDomains.includes("schedule_timetable"), false);
+  assert.equal(inventorySource.admissionEvidence.candidateId, "molit-tago-subway-info");
+  assert.equal(inventorySource.admissionEvidence.decision, "APPROVED");
+  assert.equal(inventorySource.admissionEvidence.sampleEvidenceHash, candidate.evidence.liveSampleEvidenceHash);
+  assert.match(inventorySource.admissionEvidence.adminReviewRecordHash, /^[0-9a-f]{64}$/);
+  assert.match(inventorySource.admissionEvidence.sourceSnapshotSetHash, /^[0-9a-f]{64}$/);
+  assert.match(inventorySource.admissionEvidence.sourceInventorySha256, /^[0-9a-f]{64}$/);
 
   assert.equal(candidate.capabilities.schedule.status, "CANDIDATE");
   assert.equal(candidate.capabilities.schedule.productionUseAllowed, false);
   assert.equal(candidate.capabilities.schedule.coverageStatus, "TRIP_STOP_SEQUENCE_REQUIRED");
-  assert.deepEqual(candidate.evidence.missingEvidence, ["tripStopSequenceSource", "adminReview"]);
+  assert.deepEqual(candidate.evidence.missingEvidence, ["tripStopSequenceSource"]);
   assert.ok(candidate.evidence.outputFields.includes("depTime"));
   assert.ok(candidate.evidence.outputFields.includes("arrTime"));
   assert.ok(candidate.evidence.outputFields.includes("dailyTypeCode"));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5707,6 +5707,7 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
     productionCanonicalStopTimesStatus: "blocked_requires_trip_stop_sequence",
     plannedEtaUseAllowed: false,
   });
+  // source-candidates keeps a public summary, not the local full admin-review input with productionSource.
   assert.deepEqual(candidate.evidence.adminReview, {
     artifactKind: "source-admission-admin-review-summary",
     decision: "APPROVED",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5732,6 +5732,10 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
   assert.equal(candidate.capabilities.schedule.status, "CANDIDATE");
   assert.equal(candidate.capabilities.schedule.productionUseAllowed, false);
   assert.equal(candidate.capabilities.schedule.coverageStatus, "TRIP_STOP_SEQUENCE_REQUIRED");
+  assert.equal(
+    candidate.capabilities.schedule.unsupportedNotes,
+    "commercial schedule import remains blocked until a provider trip/stop-sequence source is identified and validated",
+  );
   assert.deepEqual(candidate.evidence.missingEvidence, ["tripStopSequenceSource"]);
   assert.ok(candidate.evidence.outputFields.includes("depTime"));
   assert.ok(candidate.evidence.outputFields.includes("arrTime"));

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5728,6 +5728,12 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
   assert.match(inventorySource.admissionEvidence.adminReviewRecordHash, /^[0-9a-f]{64}$/);
   assert.match(inventorySource.admissionEvidence.sourceSnapshotSetHash, /^[0-9a-f]{64}$/);
   assert.match(inventorySource.admissionEvidence.sourceInventorySha256, /^[0-9a-f]{64}$/);
+  const admittedInventorySnapshot = JSON.parse(JSON.stringify(inventory));
+  delete admittedInventorySnapshot.sources.find(({ id }) => id === "molit-tago-subway-info").admissionEvidence;
+  assert.equal(
+    inventorySource.admissionEvidence.sourceInventorySha256,
+    createHash("sha256").update(JSON.stringify(admittedInventorySnapshot)).digest("hex"),
+  );
 
   assert.equal(candidate.capabilities.schedule.status, "CANDIDATE");
   assert.equal(candidate.capabilities.schedule.productionUseAllowed, false);

--- a/tools/datapack/nationwide-coverage-targets.json
+++ b/tools/datapack/nationwide-coverage-targets.json
@@ -300,8 +300,9 @@
       "sourceCandidatesPath": "tools/datapack/source-candidates.json",
       "p0CandidateCount": 13,
       "requiredAdmissionStatusBeforeProductionClaim": "admitted_to_production_inventory",
-      "currentSharedAdmissionStatus": "evidence_recorded_admin_review_required",
-      "productionClaimImpactKo": "P0 source candidate 13건이 production inventory로 승격되기 전까지 모든 expansionRoadmap stage는 NO-GO다."
+      "admittedCandidateCount": 1,
+      "currentOpenAdmissionStatus": "evidence_recorded_admin_review_required",
+      "productionClaimImpactKo": "P0 source candidate 13건 중 1건만 production inventory 승격 증거가 있어 모든 expansionRoadmap stage는 계속 NO-GO다."
     },
     "gapEscalationRuleKo": "지원 claim을 깨는 P1/P2 gap은 P0 release blocker로 승격하고 release gate에서 실패시킨다."
   }

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -657,7 +657,7 @@
       "requestUrl": "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList",
       "licenseEvidenceStatus": "confirmed_attribution",
       "sampleEvidenceStatus": "validated_live_sample",
-      "admissionStatus": "evidence_recorded_admin_review_required",
+      "admissionStatus": "admitted_to_production_inventory",
       "productionInventoryReferenceId": "molit-tago-subway-info",
       "productionInventoryRelationship": "same_dataset_inventory_entry_remains_schedule_candidate_until_importer_validation",
       "serviceKeyHandling": "offline_import_secret_only",
@@ -681,6 +681,14 @@
           "productionCanonicalStopTimesStatus": "blocked_requires_trip_stop_sequence",
           "plannedEtaUseAllowed": false
         },
+        "adminReview": {
+          "artifactKind": "source-admission-admin-review-summary",
+          "decision": "APPROVED",
+          "approvedBy": "qa-admin",
+          "approvedAt": "2026-07-04T00:20:00Z",
+          "sampleEvidenceHash": "d5a60bcc1907d346a24fbf720a5d362268720e8fab68e35c42eace270e5fe9ae",
+          "admissionDurationSeconds": 0
+        },
         "usePermissionRange": "공공데이터포털 이용허락범위 제한 없음",
         "formats": [
           "XML",
@@ -702,11 +710,10 @@
           "endSubwayStationId"
         ],
         "missingEvidence": [
-          "tripStopSequenceSource",
-          "adminReview"
+          "tripStopSequenceSource"
         ]
       },
-      "nextAction": "identify provider trip/stop-sequence source and complete admin review before production timetable admission",
+      "nextAction": "identify provider trip/stop-sequence source before production timetable admission",
       "capabilities": {
         "schedule": {
           "status": "CANDIDATE",

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -720,7 +720,7 @@
           "productionUseAllowed": false,
           "coverageStatus": "TRIP_STOP_SEQUENCE_REQUIRED",
           "updateFrequency": "provider documented; production cadence not admitted",
-          "unsupportedNotes": "commercial schedule import remains blocked until trip id/stop sequence source and admin review are complete"
+          "unsupportedNotes": "commercial schedule import remains blocked until a provider trip/stop-sequence source is identified and validated"
         },
         "realtime": {
           "status": "UNSUPPORTED",

--- a/tools/datapack/source-inventory.json
+++ b/tools/datapack/source-inventory.json
@@ -433,7 +433,7 @@
         "rawSha256": "34af0c0e6750012070282b0b59f0226075bfbc8ee533f0bd934c78b130d297d4",
         "schemaFingerprint": "6e5d572290d2d5a8ea2d243a615b6f310417995944c140353a5606228016bd48",
         "sourceSnapshotSetHash": "f6a7dcb11a04a1993202fc5fbd3068eb5808f66a237f2b72c907700bbd660578",
-        "sourceInventorySha256": "b3c0aeb36990318484c2f368622366503e78e363956426cbdb6cc4ac9e093af7",
+        "sourceInventorySha256": "85a88db7f1c9f389adda7a8c1b9bc7c682ec1fe3762a4cb647ce332d52a916f1",
         "adminReviewRecordHash": "68de2df243b1b73b5eb5b50c786bbd43385c99338c29945d7fd38b2163640ef0",
         "licenseEvidenceHash": "1bece434e20038b0e5fc9fb7812b96fc088936905208ad1619317dda73e17c60",
         "aliasLedgerHash": "6915e06ab8432339b4c3b19ec2a7abeba0698b004234e85e5c1d19735a8b6f6f",

--- a/tools/datapack/source-inventory.json
+++ b/tools/datapack/source-inventory.json
@@ -419,6 +419,30 @@
           "updateFrequency": "realtime",
           "unsupportedNotes": "source does not provide accessibility facility records"
         }
+      },
+      "admissionEvidence": {
+        "artifactKind": "source-admission-pipeline-evidence-summary",
+        "issue": 1397,
+        "candidateId": "molit-tago-subway-info",
+        "sourceId": "molit-tago-subway-info",
+        "snapshotId": "molit-tago-subway-info-snapshot-20260704",
+        "decision": "APPROVED",
+        "approvedBy": "qa-admin",
+        "approvedAt": "2026-07-04T00:20:00Z",
+        "sampleEvidenceHash": "d5a60bcc1907d346a24fbf720a5d362268720e8fab68e35c42eace270e5fe9ae",
+        "rawSha256": "34af0c0e6750012070282b0b59f0226075bfbc8ee533f0bd934c78b130d297d4",
+        "schemaFingerprint": "6e5d572290d2d5a8ea2d243a615b6f310417995944c140353a5606228016bd48",
+        "sourceSnapshotSetHash": "f6a7dcb11a04a1993202fc5fbd3068eb5808f66a237f2b72c907700bbd660578",
+        "sourceInventorySha256": "b3c0aeb36990318484c2f368622366503e78e363956426cbdb6cc4ac9e093af7",
+        "adminReviewRecordHash": "68de2df243b1b73b5eb5b50c786bbd43385c99338c29945d7fd38b2163640ef0",
+        "licenseEvidenceHash": "1bece434e20038b0e5fc9fb7812b96fc088936905208ad1619317dda73e17c60",
+        "aliasLedgerHash": "6915e06ab8432339b4c3b19ec2a7abeba0698b004234e85e5c1d19735a8b6f6f",
+        "operatorMappingLedgerHash": "436598de70ed9d75b909010aa9fe8a283fe86d9ab9041fcb1ab8c1f54b43f9d0",
+        "facilityEvidenceLedgerHash": "2f9ddabfb6c983c428d2194ea88e65818b5ae951750f82078375ca883ace110c",
+        "routeEvidenceLedgerHash": "db2a0915adbf98eabc8f4ee52b4a9f27d25ebca95ecdfff3e3c8e4554ef768cc",
+        "overrideHash": "b5fb2c6fed271ff24e1c8ecd0d2334b257540e2032492f78b4d8417964215787",
+        "admissionDurationSeconds": 0,
+        "productionUseNoteKo": "admin review는 통과했지만 trip/stop sequence source가 없어 schedule_timetable production use는 아직 차단한다."
       }
     },
     {


### PR DESCRIPTION
## 관련 이슈

Refs #1397
Refs #1414

## 작업 배경

- #1414 Phase 1 Step 1에서 live sample이 이미 검증된 `molit-tago-subway-info`를 최우선 1차 승격 대상으로 지정했습니다.
- #1397은 admission pipeline 자체는 준비됐지만 admin review 승인에서 production inventory 승격까지 실행된 candidate가 0건인 상태였습니다.

## 작업 내용

- `molit-tago-subway-info` candidate에 admin review 승인 요약을 기록하고 `admissionStatus`를 `admitted_to_production_inventory`로 갱신했습니다.
- production source inventory와 모바일 asset mirror에 TAGO admission evidence summary를 추가했습니다.
- TAGO는 inventory admission만 승인하고, `tripStopSequenceSource` 부재 때문에 `schedule_timetable` production use와 PLANNED ETA 근거 사용은 계속 차단했습니다.
- nationwide coverage roadmap ledger를 “13건 중 1건 admitted, roadmap stage는 계속 NO-GO”로 갱신하고 계약 테스트를 보강했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` 통과
  - `node tools/datapack/validate-source-inventory.mjs` 통과
  - `node --test tools/datapack/datapack-tools.test.mjs` 통과
  - `git diff --check` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Source admission contract | local | repository/datapack Node tests | terminal output, `.codex/tasks/1397-source-admission-approval.local.json` | 통과 |
| UI/접근성 | 해당 없음 | JSON inventory/evidence 계약 변경만 포함 | UI 변경 없음 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: TAGO가 production inventory admission evidence를 갖지만 `capabilities.schedule.productionUseAllowed: false`와 `coverageScope.sourceDomains`의 `schedule_timetable` 제외가 유지되는지 확인해 주세요.

## 리스크

- TAGO source admission 1건만 처리합니다. TOPIS 2건과 KRIC 10건은 #1397 잔여로 유지됩니다.
- admin review는 승인됐지만 trip/stop sequence source가 없어 시간표 production 적재와 PLANNED ETA claim은 아직 차단됩니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 특정 대중교통 데이터 소스가 승인된 상태로 반영되도록 갱신되어, 관련 서비스의 사용 가능 여부가 더 정확하게 표시됩니다.
  * 생산 반영 전 필요한 항목 확인 기준이 정리되어, 누락된 정보가 더 명확하게 드러납니다.
  * 전국 범위 적용 대상의 상태 안내가 더 구체적으로 업데이트되어, 진행 가능 여부를 이해하기 쉬워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->