### PR TITLE
[Chore] #1415 stop_times lineSequence gate

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -7918,7 +7918,7 @@ test("공식 source ingest adapter는 production schedule pass-through를 거부
   );
 });
 
-test("공식 source ingest adapter는 stop_times가 lineSequence 경계를 감싸는 순환 운행을 허용한다", async () => {
+test("공식 source ingest adapter는 명시한 lineSequence 경계 wrap만 허용한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-ingest-stop-times-wrap-${Date.now()}`);
   const input = sourceIngestInput();
   addSourceIngestStation(input, {
@@ -7962,6 +7962,12 @@ test("공식 source ingest adapter는 stop_times가 lineSequence 경계를 감�
     },
   ];
 
+  await assert.rejects(
+    importOfficialSourceInput(path.join(outputDir, "blocked"), input),
+    /transit_stop_times stop_sequence must follow station lineSequence order: trip-seoul-4-loop-wrap/,
+  );
+
+  input.lines[0].lineSequenceWrapAllowed = true;
   const generated = await importOfficialSourceInput(outputDir, input);
   assert.equal(generated.packs[0].minimumTableRows.transit_stop_times, 3);
 });

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -7918,6 +7918,102 @@ test("공식 source ingest adapter는 production schedule pass-through를 거부
   );
 });
 
+test("공식 source ingest adapter는 stop_times 순서가 lineSequence와 뒤섞이면 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-ingest-stop-times-sequence-${Date.now()}`);
+  const input = sourceIngestInput();
+  input.stationMappings.push({
+    sourceId: "seoulmetro-station-line-info",
+    sourceStationCode: "450",
+    lineId: "seoul-4",
+    stationId: "station-jungang",
+    stationLineId: "station-jungang:seoul-4",
+    mappingStatus: "active",
+  });
+  input.stationLineRows.push({
+    sourceId: "seoulmetro-station-line-info",
+    sourceStationCode: "450",
+    lineId: "seoul-4",
+    stationNameKo: "중앙",
+    stationNameEn: "Jungang",
+    normalizedName: "중앙",
+    region: "수도권",
+    latitude: 37.3159,
+    longitude: 126.8385,
+    stationCode: "450",
+    lineSequence: 50,
+    platformInfo: "당고개 방면 / 오이도 방면",
+    lastVerifiedAt: "2026-06-21T00:00:00.000Z",
+  });
+  input.serviceCalendars = [
+    {
+      serviceId: "weekday-2026",
+      monday: true,
+      tuesday: true,
+      wednesday: true,
+      thursday: true,
+      friday: true,
+      saturday: false,
+      sunday: false,
+      startDate: "20260701",
+      endDate: "20261231",
+    },
+  ];
+  input.transitRoutes = [
+    {
+      routeId: "route-seoul-4",
+      lineId: "seoul-4",
+      agencyId: "seoul-metro",
+      routeShortName: "4",
+      routeLongName: "수도권 4호선",
+      routeColor: "00A5DE",
+      routeTextColor: "FFFFFF",
+      routeSortOrder: 4,
+    },
+  ];
+  input.transitTrips = [
+    {
+      tripId: "trip-seoul-4-zigzag",
+      routeId: "route-seoul-4",
+      serviceId: "weekday-2026",
+      directionId: "down",
+      tripHeadsign: "오이도",
+      blockId: "block-seoul-4-zigzag",
+      wheelchairAccessible: true,
+    },
+  ];
+  input.transitStopTimes = [
+    {
+      tripId: "trip-seoul-4-zigzag",
+      stopSequence: 1,
+      stationId: "station-sangnoksu",
+      lineId: "seoul-4",
+      arrivalSeconds: 28800,
+      departureSeconds: 28800,
+    },
+    {
+      tripId: "trip-seoul-4-zigzag",
+      stopSequence: 2,
+      stationId: "station-sadang",
+      lineId: "seoul-4",
+      arrivalSeconds: 29400,
+      departureSeconds: 29400,
+    },
+    {
+      tripId: "trip-seoul-4-zigzag",
+      stopSequence: 3,
+      stationId: "station-jungang",
+      lineId: "seoul-4",
+      arrivalSeconds: 30000,
+      departureSeconds: 30000,
+    },
+  ];
+
+  await assert.rejects(
+    importOfficialSourceInput(outputDir, input),
+    /transit_stop_times stop_sequence must follow station lineSequence order: trip-seoul-4-zigzag/,
+  );
+});
+
 test("공식 source ingest adapter는 admission 전 schedule provenance도 production 적재하지 않는다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-ingest-production-schedule-candidate-${Date.now()}`);
   const input = productionSourceIngestInput();

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -7918,69 +7918,71 @@ test("공식 source ingest adapter는 production schedule pass-through를 거부
   );
 });
 
+test("공식 source ingest adapter는 stop_times가 lineSequence 경계를 감싸는 순환 운행을 허용한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-ingest-stop-times-wrap-${Date.now()}`);
+  const input = sourceIngestInput();
+  addSourceIngestStation(input, {
+    sourceStationCode: "410",
+    stationId: "station-loop-min",
+    stationNameKo: "순환최소",
+    stationCode: "410",
+    lineSequence: 10,
+  });
+  addSourceIngestStation(input, {
+    sourceStationCode: "420",
+    stationId: "station-loop-next",
+    stationNameKo: "순환다음",
+    stationCode: "420",
+    lineSequence: 20,
+  });
+  input.transitStopTimes = [
+    {
+      tripId: "trip-seoul-4-loop-wrap",
+      stopSequence: 1,
+      stationId: "station-sangnoksu",
+      lineId: "seoul-4",
+      arrivalSeconds: 28800,
+      departureSeconds: 28800,
+    },
+    {
+      tripId: "trip-seoul-4-loop-wrap",
+      stopSequence: 2,
+      stationId: "station-loop-min",
+      lineId: "seoul-4",
+      arrivalSeconds: 29400,
+      departureSeconds: 29400,
+    },
+    {
+      tripId: "trip-seoul-4-loop-wrap",
+      stopSequence: 3,
+      stationId: "station-loop-next",
+      lineId: "seoul-4",
+      arrivalSeconds: 30000,
+      departureSeconds: 30000,
+    },
+  ];
+
+  const generated = await importOfficialSourceInput(outputDir, input);
+  assert.equal(generated.packs[0].minimumTableRows.transit_stop_times, 3);
+});
+
 test("공식 source ingest adapter는 stop_times 순서가 lineSequence와 뒤섞이면 거부한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-ingest-stop-times-sequence-${Date.now()}`);
   const input = sourceIngestInput();
-  input.stationMappings.push({
-    sourceId: "seoulmetro-station-line-info",
+  addSourceIngestStation(input, {
     sourceStationCode: "450",
-    lineId: "seoul-4",
     stationId: "station-jungang",
-    stationLineId: "station-jungang:seoul-4",
-    mappingStatus: "active",
-  });
-  input.stationLineRows.push({
-    sourceId: "seoulmetro-station-line-info",
-    sourceStationCode: "450",
-    lineId: "seoul-4",
     stationNameKo: "중앙",
-    stationNameEn: "Jungang",
-    normalizedName: "중앙",
-    region: "수도권",
-    latitude: 37.3159,
-    longitude: 126.8385,
     stationCode: "450",
     lineSequence: 50,
-    platformInfo: "당고개 방면 / 오이도 방면",
-    lastVerifiedAt: "2026-06-21T00:00:00.000Z",
   });
-  input.serviceCalendars = [
-    {
-      serviceId: "weekday-2026",
-      monday: true,
-      tuesday: true,
-      wednesday: true,
-      thursday: true,
-      friday: true,
-      saturday: false,
-      sunday: false,
-      startDate: "20260701",
-      endDate: "20261231",
-    },
-  ];
-  input.transitRoutes = [
-    {
-      routeId: "route-seoul-4",
-      lineId: "seoul-4",
-      agencyId: "seoul-metro",
-      routeShortName: "4",
-      routeLongName: "수도권 4호선",
-      routeColor: "00A5DE",
-      routeTextColor: "FFFFFF",
-      routeSortOrder: 4,
-    },
-  ];
-  input.transitTrips = [
-    {
-      tripId: "trip-seoul-4-zigzag",
-      routeId: "route-seoul-4",
-      serviceId: "weekday-2026",
-      directionId: "down",
-      tripHeadsign: "오이도",
-      blockId: "block-seoul-4-zigzag",
-      wheelchairAccessible: true,
-    },
-  ];
+  addSourceIngestStation(input, {
+    sourceStationCode: "451",
+    stationId: "station-extra",
+    stationNameKo: "추가",
+    stationCode: "451",
+    lineSequence: 60,
+  });
   input.transitStopTimes = [
     {
       tripId: "trip-seoul-4-zigzag",
@@ -10101,6 +10103,32 @@ function sourceIngestInput() {
       },
     ],
   };
+}
+
+function addSourceIngestStation(input, { sourceStationCode, stationId, stationNameKo, stationCode, lineSequence }) {
+  input.stationMappings.push({
+    sourceId: "seoulmetro-station-line-info",
+    sourceStationCode,
+    lineId: "seoul-4",
+    stationId,
+    stationLineId: `${stationId}:seoul-4`,
+    mappingStatus: "active",
+  });
+  input.stationLineRows.push({
+    sourceId: "seoulmetro-station-line-info",
+    sourceStationCode,
+    lineId: "seoul-4",
+    stationNameKo,
+    stationNameEn: stationNameKo,
+    normalizedName: stationNameKo,
+    region: "수도권",
+    latitude: 37.3159,
+    longitude: 126.8385,
+    stationCode,
+    lineSequence,
+    platformInfo: "당고개 방면 / 오이도 방면",
+    lastVerifiedAt: "2026-06-21T00:00:00.000Z",
+  });
 }
 
 function nationwideMasterSourceIngestInput() {

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -44,7 +44,7 @@ function buildFixture(inventory, input) {
   );
   const routeMapPositions = routeMapPositionRows(input.routeMapPositions ?? [], allowedSourceIds, mappingBySourceKey);
   const transitSchedule = transitScheduleRows(input);
-  validateTransitStopTimesFollowLineSequence(transitSchedule.transitStopTimes, stationLines);
+  validateTransitStopTimesFollowLineSequence(transitSchedule.transitStopTimes, stationLines, input.lines ?? []);
   const transitScheduleTableRows = transitScheduleMinimumTableRows(transitSchedule);
   if (isProductionPack && Object.keys(transitScheduleTableRows).length > 0) {
     validateProductionScheduleProvenance(input.scheduleProvenance, selectedSources, allowedSourceIds);
@@ -995,12 +995,12 @@ function transitScheduleRows(input) {
   };
 }
 
-function validateTransitStopTimesFollowLineSequence(stopTimes, stationLines) {
+function validateTransitStopTimesFollowLineSequence(stopTimes, stationLines, lines) {
   if (stopTimes.length === 0) {
     return;
   }
   const lineSequences = new Map(stationLines.map((row) => [`${row.stationId}:${row.lineId}`, row.lineSequence]));
-  const lineSequenceRanges = lineSequenceRangesByLine(stationLines);
+  const lineSequenceRanges = lineSequenceRangesByLine(stationLines, lineSequenceWrapAllowedLineIds(lines));
   const byTrip = new Map();
 
   for (const stopTime of stopTimes) {
@@ -1051,10 +1051,23 @@ function validateTransitStopTimesFollowLineSequence(stopTimes, stationLines) {
   }
 }
 
-function lineSequenceRangesByLine(stationLines) {
+function lineSequenceWrapAllowedLineIds(lines) {
+  return new Set(
+    lines
+      .filter((line) => line.lineSequenceWrapAllowed === true)
+      .map((line) => requiredString(line.id, "lines.id")),
+  );
+}
+
+function lineSequenceRangesByLine(stationLines, wrapAllowedLineIds) {
   const ranges = new Map();
   for (const row of stationLines) {
-    const current = ranges.get(row.lineId) ?? { min: row.lineSequence, max: row.lineSequence, count: 0 };
+    const current = ranges.get(row.lineId) ?? {
+      min: row.lineSequence,
+      max: row.lineSequence,
+      count: 0,
+      wrapAllowed: wrapAllowedLineIds.has(row.lineId),
+    };
     current.min = Math.min(current.min, row.lineSequence);
     current.max = Math.max(current.max, row.lineSequence);
     current.count += 1;
@@ -1069,6 +1082,7 @@ function isLineSequenceBoundaryWrap(previous, current, ranges) {
   }
   const range = ranges.get(previous.lineId);
   return (
+    range?.wrapAllowed === true &&
     range?.count >= 4 &&
     Math.min(previous.lineSequence, current.lineSequence) === range.min &&
     Math.max(previous.lineSequence, current.lineSequence) === range.max

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -1000,6 +1000,7 @@ function validateTransitStopTimesFollowLineSequence(stopTimes, stationLines) {
     return;
   }
   const lineSequences = new Map(stationLines.map((row) => [`${row.stationId}:${row.lineId}`, row.lineSequence]));
+  const lineSequenceRanges = lineSequenceRangesByLine(stationLines);
   const byTrip = new Map();
 
   for (const stopTime of stopTimes) {
@@ -1014,6 +1015,7 @@ function validateTransitStopTimesFollowLineSequence(stopTimes, stationLines) {
     rows.push({
       stopSequence: requiredInteger(stopTime.stopSequence, "transitStopTimes.stopSequence"),
       lineSequence: lineSequences.get(stationLineKey),
+      lineId,
     });
     byTrip.set(tripId, rows);
   }
@@ -1021,14 +1023,25 @@ function validateTransitStopTimesFollowLineSequence(stopTimes, stationLines) {
   for (const [tripId, rows] of byTrip) {
     rows.sort((left, right) => left.stopSequence - right.stopSequence);
     let direction = 0;
+    let wrapped = false;
     for (let index = 1; index < rows.length; index += 1) {
+      const previous = rows[index - 1];
+      const current = rows[index];
       const delta = rows[index].lineSequence - rows[index - 1].lineSequence;
       if (delta === 0) {
         throw new Error(`transit_stop_times lineSequence must change between stops: ${tripId}`);
       }
       const stepDirection = Math.sign(delta);
+      if (direction === 0 && isLineSequenceBoundaryWrap(previous, current, lineSequenceRanges)) {
+        wrapped = true;
+        continue;
+      }
       if (direction === 0) {
         direction = stepDirection;
+        continue;
+      }
+      if (!wrapped && stepDirection !== direction && isLineSequenceBoundaryWrap(previous, current, lineSequenceRanges)) {
+        wrapped = true;
         continue;
       }
       if (stepDirection !== direction) {
@@ -1036,6 +1049,30 @@ function validateTransitStopTimesFollowLineSequence(stopTimes, stationLines) {
       }
     }
   }
+}
+
+function lineSequenceRangesByLine(stationLines) {
+  const ranges = new Map();
+  for (const row of stationLines) {
+    const current = ranges.get(row.lineId) ?? { min: row.lineSequence, max: row.lineSequence, count: 0 };
+    current.min = Math.min(current.min, row.lineSequence);
+    current.max = Math.max(current.max, row.lineSequence);
+    current.count += 1;
+    ranges.set(row.lineId, current);
+  }
+  return ranges;
+}
+
+function isLineSequenceBoundaryWrap(previous, current, ranges) {
+  if (previous.lineId !== current.lineId) {
+    return false;
+  }
+  const range = ranges.get(previous.lineId);
+  return (
+    range?.count >= 4 &&
+    Math.min(previous.lineSequence, current.lineSequence) === range.min &&
+    Math.max(previous.lineSequence, current.lineSequence) === range.max
+  );
 }
 
 function transitScheduleMinimumTableRows(rows) {

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -44,6 +44,7 @@ function buildFixture(inventory, input) {
   );
   const routeMapPositions = routeMapPositionRows(input.routeMapPositions ?? [], allowedSourceIds, mappingBySourceKey);
   const transitSchedule = transitScheduleRows(input);
+  validateTransitStopTimesFollowLineSequence(transitSchedule.transitStopTimes, stationLines);
   const transitScheduleTableRows = transitScheduleMinimumTableRows(transitSchedule);
   if (isProductionPack && Object.keys(transitScheduleTableRows).length > 0) {
     validateProductionScheduleProvenance(input.scheduleProvenance, selectedSources, allowedSourceIds);
@@ -992,6 +993,49 @@ function transitScheduleRows(input) {
     transitStopTimes: optionalRows(input.transitStopTimes, "transitStopTimes"),
     transitFrequencies: optionalRows(input.transitFrequencies, "transitFrequencies"),
   };
+}
+
+function validateTransitStopTimesFollowLineSequence(stopTimes, stationLines) {
+  if (stopTimes.length === 0) {
+    return;
+  }
+  const lineSequences = new Map(stationLines.map((row) => [`${row.stationId}:${row.lineId}`, row.lineSequence]));
+  const byTrip = new Map();
+
+  for (const stopTime of stopTimes) {
+    const tripId = requiredString(stopTime.tripId, "transitStopTimes.tripId");
+    const stationId = requiredString(stopTime.stationId, "transitStopTimes.stationId");
+    const lineId = requiredString(stopTime.lineId, "transitStopTimes.lineId");
+    const stationLineKey = `${stationId}:${lineId}`;
+    if (!lineSequences.has(stationLineKey)) {
+      throw new Error(`transit_stop_times station-line is missing from station_lines: ${tripId}:${stationLineKey}`);
+    }
+    const rows = byTrip.get(tripId) ?? [];
+    rows.push({
+      stopSequence: requiredInteger(stopTime.stopSequence, "transitStopTimes.stopSequence"),
+      lineSequence: lineSequences.get(stationLineKey),
+    });
+    byTrip.set(tripId, rows);
+  }
+
+  for (const [tripId, rows] of byTrip) {
+    rows.sort((left, right) => left.stopSequence - right.stopSequence);
+    let direction = 0;
+    for (let index = 1; index < rows.length; index += 1) {
+      const delta = rows[index].lineSequence - rows[index - 1].lineSequence;
+      if (delta === 0) {
+        throw new Error(`transit_stop_times lineSequence must change between stops: ${tripId}`);
+      }
+      const stepDirection = Math.sign(delta);
+      if (direction === 0) {
+        direction = stepDirection;
+        continue;
+      }
+      if (stepDirection !== direction) {
+        throw new Error(`transit_stop_times stop_sequence must follow station lineSequence order: ${tripId}`);
+      }
+    }
+  }
 }
 
 function transitScheduleMinimumTableRows(rows) {


### PR DESCRIPTION
## 관련 이슈

Refs #1415

## 작업 배경

- #1415는 생산 시간표 적재 전 stop_times 정차역 순서가 station lineSequence와 일치해야 한다고 요구한다.
- 현재 TAGO 생산 시간표 입력은 trip/stop sequence source가 아직 없어 fake production rows를 넣지 않고 importer 검증 계약만 먼저 고정한다.

## 작업 내용

- official source importer가 transit_stop_times를 trip별 stopSequence로 정렬한 뒤 station_lines lineSequence 방향이 중간에 뒤섞이면 거부하게 했다.
- 상행/하행은 데이터의 첫 lineSequence delta로 방향을 추론해 둘 다 허용한다.
- stop_times가 lineSequence를 역행했다가 되돌아가는 fixture를 추가해 negative gate를 고정했다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "stop_times 순서|production schedule|admission 전 schedule|source ingest adapter" tools/datapack/datapack-tools.test.mjs` 성공
  - `node --test tools/datapack/datapack-tools.test.mjs` 성공: 171 passed
  - `node --test tools/ci/repository-contract.test.mjs` 성공: 158 passed
  - `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| datapack importer validator | local Node.js | node --test tools/datapack/datapack-tools.test.mjs | 터미널 출력: 171 passed | 통과 |
| repository contract | local Node.js | node --test tools/ci/repository-contract.test.mjs | 터미널 출력: 158 passed | 통과 |
| UI/접근성/배포 | 해당 없음 | importer 검증 계약만 변경 | 화면/배포 변경 없음 | 증거 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/import-official-sources.mjs`의 `validateTransitStopTimesFollowLineSequence`와 negative test.

## 리스크

- 기존 fixture에는 stop_times가 거의 없어서 적용면은 좁다.
- 실제 production schedule 적재는 여전히 TAGO trip/stop sequence source 확보와 #1397 admission 잔여 작업에 막혀 있다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
