### PR TITLE
[Test] #1397 admission evidence validator

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6022,6 +6022,32 @@ test("source inventory 검증기는 admitted candidate sample evidence hash 불�
   );
 });
 
+test("source inventory 검증기는 admitted candidate live sample evidence hash 누락을 거부한다", async () => {
+  const sourceCandidates = JSON.parse(await readFile(path.join(root, "tools/datapack/source-candidates.json"), "utf8"));
+  const invalidCandidates = structuredClone(sourceCandidates);
+  const candidate = invalidCandidates.candidates.find((entry) => entry.id === "molit-tago-subway-info");
+  delete candidate.evidence.liveSampleEvidenceHash;
+
+  const outputDir = path.join(tmpdir(), `easysubway-source-inventory-candidate-admission-hash-${Date.now()}`);
+  const candidatesPath = path.join(outputDir, "source-candidates.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(candidatesPath, `${JSON.stringify(invalidCandidates, null, 2)}\n`);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-inventory.mjs",
+        "--candidates",
+        candidatesPath,
+      ],
+      { cwd: root },
+    ),
+    /molit-tago-subway-info\.evidence\.liveSampleEvidenceHash is required/,
+  );
+});
+
 test("source inventory 검증기는 v1 optional source가 production 필수로 남는 것을 거부한다", async () => {
   const sourceInventory = JSON.parse(await readFile(path.join(root, "tools/datapack/source-inventory.json"), "utf8"));
   const invalidInventory = structuredClone(sourceInventory);

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -5970,6 +5970,58 @@ test("source inventory 검증기는 candidate capability의 production 사용 �
   );
 });
 
+test("source inventory 검증기는 admitted candidate의 admission evidence 누락을 거부한다", async () => {
+  const sourceInventory = JSON.parse(await readFile(path.join(root, "tools/datapack/source-inventory.json"), "utf8"));
+  const invalidInventory = structuredClone(sourceInventory);
+  const source = invalidInventory.sources.find((entry) => entry.id === "molit-tago-subway-info");
+  delete source.admissionEvidence;
+
+  const outputDir = path.join(tmpdir(), `easysubway-source-inventory-admission-evidence-${Date.now()}`);
+  const inventoryPath = path.join(outputDir, "source-inventory.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(inventoryPath, `${JSON.stringify(invalidInventory, null, 2)}\n`);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-inventory.mjs",
+        "--inventory",
+        inventoryPath,
+      ],
+      { cwd: root },
+    ),
+    /molit-tago-subway-info\.admissionEvidence must be an object/,
+  );
+});
+
+test("source inventory 검증기는 admitted candidate sample evidence hash 불일치를 거부한다", async () => {
+  const sourceInventory = JSON.parse(await readFile(path.join(root, "tools/datapack/source-inventory.json"), "utf8"));
+  const invalidInventory = structuredClone(sourceInventory);
+  const source = invalidInventory.sources.find((entry) => entry.id === "molit-tago-subway-info");
+  source.admissionEvidence.sampleEvidenceHash = sha256("wrong-sample-evidence");
+
+  const outputDir = path.join(tmpdir(), `easysubway-source-inventory-admission-hash-${Date.now()}`);
+  const inventoryPath = path.join(outputDir, "source-inventory.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(inventoryPath, `${JSON.stringify(invalidInventory, null, 2)}\n`);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-inventory.mjs",
+        "--inventory",
+        inventoryPath,
+      ],
+      { cwd: root },
+    ),
+    /molit-tago-subway-info\.admissionEvidence\.sampleEvidenceHash must be/,
+  );
+});
+
 test("source inventory 검증기는 v1 optional source가 production 필수로 남는 것을 거부한다", async () => {
   const sourceInventory = JSON.parse(await readFile(path.join(root, "tools/datapack/source-inventory.json"), "utf8"));
   const invalidInventory = structuredClone(sourceInventory);

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6721,6 +6721,149 @@ test("source admission pipeline은 admin 승인 record로 inventory admission ev
   assert.ok(outputInventory.sources.some((source) => source.id === "kric-train-operation-organ"));
 });
 
+test("source admission pipeline은 custom candidates를 최종 inventory 검증에 전달한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-admission-candidates-${Date.now()}`);
+  const rawPath = path.join(outputDir, "kric-train-operation-organ.raw.json");
+  const seedSamplePath = path.join(outputDir, "seed-sample.json");
+  const candidatesPath = path.join(outputDir, "source-candidates.json");
+  const adminReviewPath = path.join(outputDir, "admin-review.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(rawPath, `${JSON.stringify([{ railOprIsttCd: "S1", railOprIsttNm: "서울교통공사" }])}\n`);
+
+  const { stdout: sampleStdout } = await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-source-candidate-sample-evidence.mjs",
+      "--candidate",
+      "kric-train-operation-organ",
+      "--response",
+      rawPath,
+    ],
+    { cwd: root },
+  );
+  await writeFile(seedSamplePath, sampleStdout);
+  const sample = JSON.parse(sampleStdout);
+
+  const stagedCandidates = JSON.parse(await readFile(path.join(root, "tools/datapack/source-candidates.json"), "utf8"));
+  const tagoCandidate = stagedCandidates.candidates.find((entry) => entry.id === "molit-tago-subway-info");
+  tagoCandidate.evidence.liveSampleEvidenceHash = sha256("staged-candidate-hash-mismatch");
+  await writeFile(candidatesPath, `${JSON.stringify(stagedCandidates, null, 2)}\n`);
+
+  const productionSource = {
+    id: "kric-train-operation-organ",
+    displayName: "열차운영기관정보",
+    owner: "국가철도공단",
+    provider: "국가철도공단",
+    sourceSystem: "KRIC OpenAPI",
+    datasetUrl: "https://data.kric.go.kr/rips/M_01_02/detail.do?id=266&service=convenientInfo&operation=trainOperationOrgan&page=3",
+    requiredForProductionPack: false,
+    updateFrequency: "provider-documented",
+    observedDataUpdatedAt: "2026-07-02",
+    retrievedAt: "2026-07-02",
+    license: {
+      type: "KOGL-1",
+      name: "공공누리 1유형",
+      attribution: "공공누리 제1유형: 출처표시",
+      commercialUseAllowed: true,
+      derivativeWorkAllowed: true,
+      redistributionAllowed: true,
+      evidenceUrl: "https://data.kric.go.kr/rips/M_01_02/detail.do?id=266&service=convenientInfo&operation=trainOperationOrgan&page=3",
+    },
+    coverageScope: {
+      regionIds: ["capital"],
+      operatorIds: ["seoul-metro"],
+      sourceDomains: ["station_line_membership"],
+    },
+    fieldsProvided: ["railOprIsttCd", "railOprIsttNm"],
+    capabilities: {
+      schedule: {
+        status: "UNSUPPORTED",
+        productionUseAllowed: false,
+        coverageStatus: "NOT_PROVIDED_BY_SOURCE",
+        updateFrequency: "provider-documented",
+        unsupportedNotes: "candidate does not provide scheduled timetable data",
+      },
+      realtime: {
+        status: "UNSUPPORTED",
+        productionUseAllowed: false,
+        liveEtaEligible: false,
+        rateLimitStatus: "NOT_APPLICABLE",
+        coverageStatus: "NOT_PROVIDED_BY_SOURCE",
+        updateFrequency: "provider-documented",
+        unsupportedNotes: "candidate does not provide realtime arrival data",
+      },
+      facility: {
+        status: "UNSUPPORTED",
+        productionUseAllowed: false,
+        coverageStatus: "NOT_PROVIDED_BY_SOURCE",
+        updateFrequency: "provider-documented",
+        unsupportedNotes: "candidate does not provide accessibility facility records",
+      },
+    },
+  };
+  const adminReview = {
+    schemaVersion: 1,
+    artifactKind: "source-admission-admin-review",
+    candidateId: "kric-train-operation-organ",
+    sourceId: "kric-train-operation-organ",
+    snapshotId: "kric-train-operation-organ-snapshot-20260702",
+    sampleEvidenceHash: sample.evidenceHash,
+    decision: "APPROVED",
+    approvedBy: "qa-admin",
+    approvedAt: "2026-07-02T00:10:00Z",
+    licenseEvidenceHash: sha256("license-evidence"),
+    aliasLedgerHash: sha256("alias-ledger"),
+    operatorMappingLedgerHash: sha256("operator-mapping-ledger"),
+    facilityEvidenceLedgerHash: sha256("facility-evidence-ledger"),
+    routeEvidenceLedgerHash: sha256("route-evidence-ledger"),
+    overrideHash: sha256("override-ledger"),
+    productionSource,
+  };
+  await writeFile(adminReviewPath, `${JSON.stringify(adminReview, null, 2)}\n`);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/run-source-admission-pipeline.mjs",
+        "--candidates",
+        candidatesPath,
+        "--candidate",
+        "kric-train-operation-organ",
+        "--raw-input",
+        rawPath,
+        "--evidence-dir",
+        outputDir,
+        "--snapshot-id",
+        "kric-train-operation-organ-snapshot-20260702",
+        "--source-id",
+        "kric-train-operation-organ",
+        "--provider",
+        "국가철도공단",
+        "--retrieved-at",
+        "2026-07-02T00:00:00Z",
+        "--source-updated-at",
+        "2026-07-02T00:00:00Z",
+        "--raw-object-uri",
+        "s3://easysubway-datapack-sources/kric-train-operation-organ/20260702.json",
+        "--freshness-expires-at",
+        "2026-08-01T00:00:00Z",
+        "--raw-retention-expires-at",
+        "2026-10-01T00:00:00Z",
+        "--admin-review",
+        adminReviewPath,
+        "--output-inventory",
+        path.join(outputDir, "source-inventory.admitted.json"),
+        "--output",
+        path.join(outputDir, "admission-summary.json"),
+      ],
+      { cwd: root },
+    ),
+    /molit-tago-subway-info\.admissionEvidence\.sampleEvidenceHash must be/,
+  );
+});
+
 test("source admission pipeline은 JSON credential raw response를 저장 전에 거부한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-admission-secret-${Date.now()}`);
   const rawPath = path.join(outputDir, "kric-train-operation-organ.raw.json");

--- a/tools/datapack/run-source-admission-pipeline.mjs
+++ b/tools/datapack/run-source-admission-pipeline.mjs
@@ -33,7 +33,13 @@ async function main() {
   const inventory = await readJson(path.resolve(root, requireArg(args, "inventory")));
   const outputInventory = admitSource({ inventory, productionSource: adminReview.productionSource });
   await writeFile(outputInventoryPath, `${JSON.stringify(outputInventory, null, 2)}\n`);
-  await execNode(["tools/datapack/validate-source-inventory.mjs", "--inventory", outputInventoryPath]);
+  await execNode([
+    "tools/datapack/validate-source-inventory.mjs",
+    "--inventory",
+    outputInventoryPath,
+    "--candidates",
+    args.candidates,
+  ]);
 
   const summary = {
     schemaVersion: 1,

--- a/tools/datapack/validate-source-inventory.mjs
+++ b/tools/datapack/validate-source-inventory.mjs
@@ -246,14 +246,15 @@ function validateAdmissionEvidence(evidence, candidate, sourceId) {
     assertSha256(evidence[field], `${sourceId}.admissionEvidence.${field}`);
   }
 
-  const liveSampleEvidenceHash = candidate.evidence?.liveSampleEvidenceHash;
-  if (liveSampleEvidenceHash) {
-    assertEqual(
-      evidence.sampleEvidenceHash,
-      liveSampleEvidenceHash,
-      `${sourceId}.admissionEvidence.sampleEvidenceHash`,
-    );
-  }
+  const liveSampleEvidenceHash = assertString(
+    candidate.evidence?.liveSampleEvidenceHash,
+    `${candidate.id}.evidence.liveSampleEvidenceHash`,
+  );
+  assertEqual(
+    evidence.sampleEvidenceHash,
+    liveSampleEvidenceHash,
+    `${sourceId}.admissionEvidence.sampleEvidenceHash`,
+  );
   if (!Number.isInteger(evidence.admissionDurationSeconds) || evidence.admissionDurationSeconds < 0) {
     throw new Error(`${sourceId}.admissionEvidence.admissionDurationSeconds must be a non-negative integer`);
   }

--- a/tools/datapack/validate-source-inventory.mjs
+++ b/tools/datapack/validate-source-inventory.mjs
@@ -3,13 +3,16 @@ import { readFile } from "node:fs/promises";
 
 const args = process.argv.slice(2);
 const inventoryPath = optionValue("--inventory") ?? "tools/datapack/source-inventory.json";
+const candidatesPath = optionValue("--candidates") ?? "tools/datapack/source-candidates.json";
 const scopePath = optionValue("--scope");
 const compareStrings = (left, right) => left.localeCompare(right);
 
 try {
   const inventory = JSON.parse(await readFile(inventoryPath, "utf8"));
+  const candidates = JSON.parse(await readFile(candidatesPath, "utf8"));
   const scope = scopePath ? JSON.parse(await readFile(scopePath, "utf8")) : null;
   validateInventory(inventory);
+  validateAdmittedCandidateEvidence(inventory, candidates);
   if (scope) {
     validateProductionScope(inventory, scope);
   }
@@ -187,6 +190,75 @@ function validateProductionScope(inventory, scope) {
   }
 }
 
+function validateAdmittedCandidateEvidence(inventory, candidates) {
+  if (!candidates || typeof candidates !== "object" || Array.isArray(candidates)) {
+    throw new Error("source candidates must be an object");
+  }
+  assertEqual(candidates.schemaVersion, 1, "source candidates schemaVersion");
+  assertEqual(candidates.artifactKind, "production-source-candidates", "source candidates artifactKind");
+  if (!Array.isArray(candidates.candidates)) {
+    throw new Error("source candidates must include candidates array");
+  }
+
+  const sources = new Map(inventory.sources.map((source) => [source.id, source]));
+  for (const candidate of candidates.candidates) {
+    if (candidate?.admissionStatus !== "admitted_to_production_inventory") {
+      continue;
+    }
+    const sourceId = assertString(
+      candidate.productionInventoryReferenceId ?? candidate.id,
+      `${candidate.id}.productionInventoryReferenceId`,
+    );
+    const source = sources.get(sourceId);
+    if (!source) {
+      throw new Error(`${candidate.id} admitted candidate missing production inventory source: ${sourceId}`);
+    }
+    validateAdmissionEvidence(source.admissionEvidence, candidate, sourceId);
+  }
+}
+
+function validateAdmissionEvidence(evidence, candidate, sourceId) {
+  if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) {
+    throw new Error(`${sourceId}.admissionEvidence must be an object for admitted candidate ${candidate.id}`);
+  }
+  assertEqual(evidence.artifactKind, "source-admission-pipeline-evidence-summary", `${sourceId}.admissionEvidence.artifactKind`);
+  assertEqual(evidence.candidateId, candidate.id, `${sourceId}.admissionEvidence.candidateId`);
+  assertEqual(evidence.sourceId, sourceId, `${sourceId}.admissionEvidence.sourceId`);
+  assertString(evidence.snapshotId, `${sourceId}.admissionEvidence.snapshotId`);
+  assertEqual(evidence.decision, "APPROVED", `${sourceId}.admissionEvidence.decision`);
+  assertString(evidence.approvedBy, `${sourceId}.admissionEvidence.approvedBy`);
+  assertString(evidence.approvedAt, `${sourceId}.admissionEvidence.approvedAt`);
+
+  for (const field of [
+    "sampleEvidenceHash",
+    "rawSha256",
+    "schemaFingerprint",
+    "sourceSnapshotSetHash",
+    "sourceInventorySha256",
+    "adminReviewRecordHash",
+    "licenseEvidenceHash",
+    "aliasLedgerHash",
+    "operatorMappingLedgerHash",
+    "facilityEvidenceLedgerHash",
+    "routeEvidenceLedgerHash",
+    "overrideHash",
+  ]) {
+    assertSha256(evidence[field], `${sourceId}.admissionEvidence.${field}`);
+  }
+
+  const liveSampleEvidenceHash = candidate.evidence?.liveSampleEvidenceHash;
+  if (liveSampleEvidenceHash) {
+    assertEqual(
+      evidence.sampleEvidenceHash,
+      liveSampleEvidenceHash,
+      `${sourceId}.admissionEvidence.sampleEvidenceHash`,
+    );
+  }
+  if (!Number.isInteger(evidence.admissionDurationSeconds) || evidence.admissionDurationSeconds < 0) {
+    throw new Error(`${sourceId}.admissionEvidence.admissionDurationSeconds must be a non-negative integer`);
+  }
+}
+
 function requireInventorySource(sources, sourceId) {
   const source = sources.get(sourceId);
   if (!source) {
@@ -258,6 +330,12 @@ function assertDate(value, label) {
   assertString(value, label);
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value) || Number.isNaN(Date.parse(`${value}T00:00:00.000Z`))) {
     throw new Error(`${label} must be YYYY-MM-DD`);
+  }
+}
+
+function assertSha256(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/.test(value)) {
+    throw new Error(`${label} must be a sha256 hex string`);
   }
 }
 


### PR DESCRIPTION
## 관련 이슈

Refs #1397

## 작업 배경

- #1397에서 admitted source candidate가 production inventory에 들어갈 때 admission evidence summary가 빠지거나 candidate live sample hash와 어긋나도 CLI validator가 직접 막지 못하는 구간을 보강합니다.

## 작업 내용

- `validate-source-inventory.mjs`가 `source-candidates.json`의 `admitted_to_production_inventory` 후보를 읽고 inventory source의 admission evidence summary를 검증하도록 추가했습니다.
- admitted candidate의 `sampleEvidenceHash`가 후보 live sample evidence hash와 일치해야 하며, admin review/source snapshot/license/ledger hash 필드를 sha256으로 요구합니다.
- admitted candidate의 `candidate.evidence.liveSampleEvidenceHash`를 필수화하고, 파이프라인 최종 inventory 검증에서도 caller의 `--candidates` 파일을 그대로 전달하도록 보강했습니다.
- admission evidence 누락, sample evidence hash 불일치, live sample evidence hash 누락, staged custom candidates 검증 누락 negative/regression test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
- `node --test --test-name-pattern "source inventory 검증기" tools/datapack/datapack-tools.test.mjs` 통과
- `node --test --test-name-pattern "source admission pipeline" tools/datapack/datapack-tools.test.mjs` 통과, 5 pass
- `node tools/datapack/validate-source-inventory.mjs` 통과
- `node --test tools/ci/repository-contract.test.mjs` 통과, 158 pass
- `node --test tools/datapack/datapack-tools.test.mjs` 통과, 176 pass
- `git diff --check` 통과
- PR CI `28683714674` 통과
- Release Artifacts `28683714536` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| source inventory admission evidence validator | local | node test/validator | terminal output | pass |
| PR CI | GitHub Actions | CI run | https://github.com/AquilaXk/easysubway/actions/runs/28683714674 | pass |
| Release Artifacts | GitHub Actions | artifact workflow | https://github.com/AquilaXk/easysubway/actions/runs/28683714536 | pass |
| UI/접근성/배포 | 해당 없음 | validator/test only | 코드 변경 없음 | not required |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: unchanged
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/validate-source-inventory.mjs`의 admitted candidate evidence 검증과 `tools/datapack/run-source-admission-pipeline.mjs`의 custom candidates 전달입니다.

## 리스크

- source inventory validator가 기본으로 `source-candidates.json`도 읽습니다. CI와 workflow에서는 repo 기본 파일이 함께 존재하므로 기존 실행 경로와 맞습니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다.
