### PR TITLE
[Chore] Lock route graph summary edge blocker

### DIFF
--- a/.github/workflows/datapack-release.yml
+++ b/.github/workflows/datapack-release.yml
@@ -450,6 +450,7 @@ jobs:
           const headwayReport = JSON.parse(fs.readFileSync(process.env.EASYSUBWAY_HEADWAY_REPORT, "utf8"));
           const routeGraphTopologyViolationCount = [
             "localRideAdjacencyViolationCount",
+            "nonAdjacentExpressRideViolationCount",
             "rideSpeedViolationCount",
             "disconnectedNodeCount",
             "unreachableDirectedPairCount",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Production Routing Graph
 
-- Production LOCAL `RIDE` edge는 같은 노선의 인접 `lineSequence`만 연결합니다. 비인접 요약 edge는 regression fixture 또는 공식 정차 패턴이 있는 `EXPRESS` 근거로만 둡니다.
+- Production LOCAL `RIDE` edge는 같은 노선의 인접 `lineSequence`만 연결합니다. 비인접 요약 edge는 regression fixture 또는 공식 정차 패턴이 있는 `EXPRESS` 근거로만 둡니다. pilot summary edge가 임시 pack에 남아 있으면 `route-graph-topology-report`의 release-blocking `nonAdjacentExpressRide` violation으로 기록하고 ETA 근거로 쓰지 않습니다.
 - 기본 route node는 station-line(`stationId:lineId`)입니다. platform node는 공식 platform/source가 admission되기 전까지 만들지 않고, 방향 문구는 `platformInfo`에만 둡니다.
 - 표시용 SVG asset은 앱 지도 표시용입니다. canonical route map position은 `routeMapPositions`의 source, license, `sourceSha256`, `reviewedAt`, `updatedAt`, label polygon으로만 판정합니다.
 - 앱의 `데이터 및 지도 출처` 화면은 source inventory와 manifest를 보여주는 사용자 연결점입니다. Level 4 또는 전국 claim은 #1397 source admission과 #1400 인접역 graph/position 확장 증거가 닫힐 때까지 NO-GO입니다.

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -261,6 +261,8 @@ test("README fixes production routing graph admission policy", () => {
     "인접 `lineSequence`",
     "regression fixture",
     "`EXPRESS`",
+    "release-blocking",
+    "nonAdjacentExpressRide",
     "station-line(`stationId:lineId`)",
     "`platformInfo`",
     "canonical route map position",
@@ -4777,7 +4779,15 @@ test("Android v1 production 데이터팩 scope는 수도권 pilot 승인 기준�
     excludedPatterns: ["TRANSFER", "MULTI_TRANSFER", "LOOP_BRANCH", "EXPRESS_LOCAL"],
     claim: productionInput.routeRegressionScope.claim,
   });
-  assert.match(productionInput.routeRegressionScope.claim, /direct ride only/);
+  assert.match(productionInput.routeRegressionScope.claim, /direct regression only/);
+  assert.deepEqual(productionInput.routeGraphTopologyPolicy, {
+    summaryRideEdges: "release-blocking-regression-only",
+    productionReadinessRequirement: "replace summary RIDE edges with adjacent-station LOCAL RIDE edges before ETA or release-readiness claim",
+    nonAdjacentExpressRideEdgeIds: [
+      "edge-sangnoksu-sadang-seoul-4",
+      "edge-sadang-sangnoksu-seoul-4",
+    ],
+  });
   assert.deepEqual(productionInput.representativeRouteRegressions.map((route) => route.pattern), ["DIRECT"]);
   for (const edge of productionInput.routeEdges.filter((routeEdge) => routeEdge.edgeType === "RIDE")) {
     const speedKmh = (edge.distanceMeters / edge.durationSeconds) * 3.6;

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -3994,6 +3994,7 @@ test("데이터팩 release workflow는 production publish hard gate를 강제한
   assert.match(workflow, /routeGraphTopologySha256: hashFile\(process\.env\.EASYSUBWAY_ROUTE_GRAPH_TOPOLOGY_REPORT\)/);
   assert.match(workflow, /headwayReportSha256: hashFile\(process\.env\.EASYSUBWAY_HEADWAY_REPORT\)/);
   assert.match(workflow, /const routeGraphTopologyViolationCount = \[/);
+  assert.match(workflow, /"nonAdjacentExpressRideViolationCount"/);
   assert.match(workflow, /const routeGraphTopologyStatus = routeGraphTopologyViolationCount === 0/);
   assert.match(workflow, /const headwayEvidenceCount =/);
   assert.match(workflow, /const headwayReportStatus = headwayEvidenceCount > 0/);

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -8876,6 +8876,27 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
     ],
     { cwd: root, env: productionEnv },
   );
+  const routeGraphTopologyReportPath = path.join(outputDir, "route-graph-topology-report.json");
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-route-graph-topology-report.mjs",
+      "--manifest",
+      path.join(packOutputDir, "current.json"),
+      "--root",
+      packOutputDir,
+      "--output",
+      routeGraphTopologyReportPath,
+    ],
+    { cwd: root },
+  );
+  const routeGraphTopologyReport = JSON.parse(await readFile(routeGraphTopologyReportPath, "utf8"));
+  assert.equal(routeGraphTopologyReport.summary.nonAdjacentExpressRideViolationCount, 2);
+  assert.deepEqual(
+    routeGraphTopologyReport.packs[0].violations.nonAdjacentExpressRide.map((violation) => violation.edgeId),
+    ["edge-sadang-sangnoksu-seoul-4", "edge-sangnoksu-sadang-seoul-4"],
+  );
+
   let validationFailure;
   try {
     await execFileAsync(
@@ -10318,7 +10339,7 @@ function sourceIngestInput() {
     routeRegressionScope: {
       mode: "DIRECT_ONLY",
       excludedPatterns: ["TRANSFER", "MULTI_TRANSFER", "LOOP_BRANCH", "EXPRESS_LOCAL"],
-      claim: "capital pilot Android v1 direct ride only; transfer, multi-transfer, branch/loop, and express/local claims are excluded until route graph evidence exists",
+      claim: "capital pilot Android v1 direct regression only; current summary RIDE edge is release-blocking and not ETA evidence until adjacent-station route graph evidence exists",
     },
     representativeRouteRegressions: [
       {

--- a/tools/datapack/inputs/capital-pilot-production-source-input.json
+++ b/tools/datapack/inputs/capital-pilot-production-source-input.json
@@ -46,6 +46,14 @@
     "routeEdges": 6,
     "facilities": 6
   },
+  "routeGraphTopologyPolicy": {
+    "summaryRideEdges": "release-blocking-regression-only",
+    "productionReadinessRequirement": "replace summary RIDE edges with adjacent-station LOCAL RIDE edges before ETA or release-readiness claim",
+    "nonAdjacentExpressRideEdgeIds": [
+      "edge-sangnoksu-sadang-seoul-4",
+      "edge-sadang-sangnoksu-seoul-4"
+    ]
+  },
   "coverageEvidence": [
     {
       "regionId": "capital",
@@ -626,7 +634,7 @@
   "routeRegressionScope": {
     "mode": "DIRECT_ONLY",
     "excludedPatterns": ["TRANSFER", "MULTI_TRANSFER", "LOOP_BRANCH", "EXPRESS_LOCAL"],
-    "claim": "capital pilot Android v1 direct ride only; transfer, multi-transfer, branch/loop, and express/local claims are excluded until route graph evidence exists"
+    "claim": "capital pilot Android v1 direct regression only; current summary RIDE edge is release-blocking and not ETA evidence until adjacent-station route graph evidence exists"
   },
   "representativeRouteRegressions": [
     {


### PR DESCRIPTION
## 관련 이슈

Refs #1400
Refs #1414

## 작업 배경

- #1400의 4호선 인접역 edge 실제 승격은 KRIC station membership/source admission 이후 진행해야 하므로, 현재 pilot summary RIDE edge가 release-ready ETA 근거로 오인되지 않게 먼저 차단 증거를 고정합니다.

## 작업 내용

- production source input에 `routeGraphTopologyPolicy`를 추가해 상록수↔사당 summary RIDE edge를 `release-blocking-regression-only`로 명시했습니다.
- route regression claim을 direct ride claim에서 direct regression claim으로 낮추고, adjacent-station route graph evidence 전까지 ETA 근거가 아님을 고정했습니다.
- datapack regression test에서 production pack의 non-adjacent EXPRESS summary edge 2건이 `route-graph-topology-report` violation으로 기록되는지 검증합니다.
- README와 repository contract에 release-blocking `nonAdjacentExpressRide` 정책 문구를 고정했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "README fixes production routing graph admission policy|Android v1 production 데이터팩 scope" tools/ci/repository-contract.test.mjs` 통과
  - `node --test --test-name-pattern "수도권 pilot production source input" tools/datapack/datapack-tools.test.mjs` 통과
  - `node --test tools/datapack/build-route-graph-topology-report.test.mjs` 통과
  - `node --test tools/datapack/*.test.mjs tools/ci/repository-contract.test.mjs` 통과, 338 tests
  - PR CI 통과: CI, SonarCloud, Release Artifacts

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| route graph summary edge blocker | local | Node test | `node --test tools/datapack/*.test.mjs tools/ci/repository-contract.test.mjs` | 통과 |
| UI/접근성 수동 QA | N/A | 데이터/계약 테스트 변경만 있음 | UI 변경 없음 | 증거 불필요 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: summary RIDE edge is regression-only and release-blocking until adjacent-station evidence exists
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/inputs/capital-pilot-production-source-input.json`의 `routeGraphTopologyPolicy`와 `tools/datapack/datapack-tools.test.mjs`의 topology report assertion
- Codex CLI fallback review에서 P1 1건을 먼저 inline 게시했고, fix commit `73ba49cb`로 해결 후 원 thread에 답글을 남겼습니다.

## 리스크

- 실제 4호선 인접역 edge 승격은 아직 남아 있습니다. 이 PR은 기존 summary edge를 release blocker로 명확히 고정하는 중간 단계입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
