### PR TITLE
[Fix] Require evidence for available facility operation

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -3211,6 +3211,46 @@ test("데이터팩 검증기는 현장·운영기관 확인 시설 AVAILABLE 근
   );
 });
 
+test("데이터팩 검증기는 근거 없는 시설 operationalStatus AVAILABLE을 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-production-facility-operational-evidence-${Date.now()}`);
+  const fixturePath = path.join(outputDir, "catalog-fixture.json");
+  const packOutputDir = path.join(outputDir, "pack");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  const fixture = await importOfficialSourceInput(outputDir, productionSourceIngestInput());
+  fixture.packs[0].facilities[0].status = "UNKNOWN";
+  fixture.packs[0].facilities[0].operationalStatus = "AVAILABLE";
+  fixture.packs[0].facilities[0].statusMeaning = "OFFICIAL_SOURCE";
+  await writeFile(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`);
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture",
+      fixturePath,
+      "--output",
+      packOutputDir,
+    ],
+    { cwd: root, env: productionEnv },
+  );
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-datapack.mjs",
+        "--manifest",
+        path.join(packOutputDir, "current.json"),
+        "--root",
+        packOutputDir,
+      ],
+      { cwd: root, env: productionEnv },
+    ),
+    /facilities positive status requires verified operation evidence/,
+  );
+});
+
 test("데이터팩 검증기는 UNKNOWN 운행상태 시설의 strict route eligibility를 거부한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-production-facility-strict-unknown-${Date.now()}`);
   const fixturePath = path.join(outputDir, "catalog-fixture.json");

--- a/tools/datapack/validate-datapack.mjs
+++ b/tools/datapack/validate-datapack.mjs
@@ -29,7 +29,7 @@ const facilityEvidenceProvenanceColumns = [
   "retrieved_at",
 ];
 const productionFacilityProvenanceKinds = ["OFFICIAL_SOURCE", "OPERATOR_CONFIRMED", "FIELD_SURVEY"];
-const positiveFacilityStatuses = ["NORMAL", "AVAILABLE", "IN_SERVICE", "OPERATING", "OPEN", "ADMIN_VERIFIED"];
+const positiveFacilityStatuses = new Set(["NORMAL", "AVAILABLE", "IN_SERVICE", "OPERATING", "OPEN", "ADMIN_VERIFIED"]);
 const allowedRealtimeDatapackTables = new Set([
   "realtime_provider_line_mappings",
   "realtime_provider_station_mappings",
@@ -1360,7 +1360,7 @@ function validateProductionFacilityEvidenceConfidence(confidence, pack, tableNam
 
 function validateProductionFacilityPositiveStatus(row, statusMeaning, pack) {
   const positiveStatus = [row.status, row.operational_status].some((status) =>
-    positiveFacilityStatuses.includes(String(status ?? "").toUpperCase()),
+    positiveFacilityStatuses.has(String(status ?? "").toUpperCase()),
   );
   if (positiveStatus && !["REALTIME_OPERATION", "OPERATOR_CONFIRMED", "FIELD_SURVEY"].includes(statusMeaning)) {
     throw new Error(`${pack.id}@${pack.version} facilities positive status requires verified operation evidence: ${row.id}`);

--- a/tools/datapack/validate-datapack.mjs
+++ b/tools/datapack/validate-datapack.mjs
@@ -29,6 +29,7 @@ const facilityEvidenceProvenanceColumns = [
   "retrieved_at",
 ];
 const productionFacilityProvenanceKinds = ["OFFICIAL_SOURCE", "OPERATOR_CONFIRMED", "FIELD_SURVEY"];
+const positiveFacilityStatuses = ["NORMAL", "AVAILABLE", "IN_SERVICE", "OPERATING", "OPEN", "ADMIN_VERIFIED"];
 const allowedRealtimeDatapackTables = new Set([
   "realtime_provider_line_mappings",
   "realtime_provider_station_mappings",
@@ -1358,7 +1359,6 @@ function validateProductionFacilityEvidenceConfidence(confidence, pack, tableNam
 }
 
 function validateProductionFacilityPositiveStatus(row, statusMeaning, pack) {
-  const positiveFacilityStatuses = ["NORMAL", "AVAILABLE", "IN_SERVICE", "OPERATING", "OPEN", "ADMIN_VERIFIED"];
   const positiveStatus = [row.status, row.operational_status].some((status) =>
     positiveFacilityStatuses.includes(String(status ?? "").toUpperCase()),
   );

--- a/tools/datapack/validate-datapack.mjs
+++ b/tools/datapack/validate-datapack.mjs
@@ -1358,10 +1358,9 @@ function validateProductionFacilityEvidenceConfidence(confidence, pack, tableNam
 }
 
 function validateProductionFacilityPositiveStatus(row, statusMeaning, pack) {
-  const positiveStatus = ["NORMAL", "AVAILABLE", "IN_SERVICE", "OPERATING", "OPEN", "ADMIN_VERIFIED"].includes(
-    String(row.status ?? "").toUpperCase(),
-  ) || ["NORMAL", "AVAILABLE", "IN_SERVICE", "OPERATING", "OPEN", "ADMIN_VERIFIED"].includes(
-    String(row.operational_status ?? "").toUpperCase(),
+  const positiveFacilityStatuses = ["NORMAL", "AVAILABLE", "IN_SERVICE", "OPERATING", "OPEN", "ADMIN_VERIFIED"];
+  const positiveStatus = [row.status, row.operational_status].some((status) =>
+    positiveFacilityStatuses.includes(String(status ?? "").toUpperCase()),
   );
   if (positiveStatus && !["REALTIME_OPERATION", "OPERATOR_CONFIRMED", "FIELD_SURVEY"].includes(statusMeaning)) {
     throw new Error(`${pack.id}@${pack.version} facilities positive status requires verified operation evidence: ${row.id}`);

--- a/tools/datapack/validate-datapack.mjs
+++ b/tools/datapack/validate-datapack.mjs
@@ -1360,6 +1360,8 @@ function validateProductionFacilityEvidenceConfidence(confidence, pack, tableNam
 function validateProductionFacilityPositiveStatus(row, statusMeaning, pack) {
   const positiveStatus = ["NORMAL", "AVAILABLE", "IN_SERVICE", "OPERATING", "OPEN", "ADMIN_VERIFIED"].includes(
     String(row.status ?? "").toUpperCase(),
+  ) || ["NORMAL", "AVAILABLE", "IN_SERVICE", "OPERATING", "OPEN", "ADMIN_VERIFIED"].includes(
+    String(row.operational_status ?? "").toUpperCase(),
   );
   if (positiveStatus && !["REALTIME_OPERATION", "OPERATOR_CONFIRMED", "FIELD_SURVEY"].includes(statusMeaning)) {
     throw new Error(`${pack.id}@${pack.version} facilities positive status requires verified operation evidence: ${row.id}`);


### PR DESCRIPTION
## 관련 이슈

Refs #1394

## 작업 배경

- #1394의 AVAILABLE 표시는 `REALTIME_OPERATION`, `OPERATOR_CONFIRMED`, `FIELD_SURVEY` 중 하나의 evidence kind가 있을 때만 허용되어야 합니다.
- 기존 production validator는 `facilities.status` positive 값은 막았지만 `operational_status=AVAILABLE`만 positive인 경우는 놓칠 수 있었습니다.

## 작업 내용

- production datapack validation에서 `status` 또는 `operational_status` 중 하나라도 AVAILABLE 계열이면 verified operation evidence를 요구하도록 고정했습니다.
- 근거 없는 `operationalStatus=AVAILABLE` fixture가 validation에서 실패하는 regression test를 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "근거 없는 시설 operationalStatus AVAILABLE" tools/datapack/datapack-tools.test.mjs` 통과
  - `node --test --test-name-pattern "현장·운영기관 확인 시설 AVAILABLE 근거|근거 없는 시설 operationalStatus AVAILABLE" tools/datapack/datapack-tools.test.mjs` 통과
  - `node --test tools/datapack/datapack-tools.test.mjs` 통과
  - `node --test tools/ci/repository-contract.test.mjs` 통과
  - `git diff --check` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| Datapack validator regression | local | `node --test tools/datapack/datapack-tools.test.mjs` | 터미널 출력 | 통과 |
| Repository contract | local | `node --test tools/ci/repository-contract.test.mjs` | 터미널 출력 | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: unchanged
- mobile versionCode: unchanged
- datapack version: unchanged
- route contract: facility operation evidence validator tightened
- realtime contract: unchanged
- backend identity: unchanged

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/validate-datapack.mjs`의 positive facility status 판정

## 리스크

- 기존 production pack에서 `operational_status`만 AVAILABLE이고 verified operation evidence가 없는 시설은 validation 실패로 바뀝니다. #1394 의도와 맞는 차단입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 시설의 운영 상태가 긍정 상태로 표시된 경우도 검증 대상에 포함되도록 확인 기준이 개선되었습니다.
  * 긍정 상태인데 운영 증빙이 없는 시설에 대한 오류 판단이 더 정확해졌습니다.

* **Tests**
  * 시설 검증 시나리오에 대한 새 테스트가 추가되어, 특정 상태 조합에서 검증이 실패하는지 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->