### PR TITLE
[Chore] source admission quota evidence gate

### DIFF
--- a/apps/mobile/assets/datapacks/source-inventory.json
+++ b/apps/mobile/assets/datapacks/source-inventory.json
@@ -588,6 +588,12 @@
         "routeEvidenceLedgerHash": "db2a0915adbf98eabc8f4ee52b4a9f27d25ebca95ecdfff3e3c8e4554ef768cc",
         "overrideHash": "b5fb2c6fed271ff24e1c8ecd0d2334b257540e2032492f78b4d8417964215787",
         "admissionDurationSeconds": 0,
+        "quotaEvidence": {
+          "portal": "공공데이터포털",
+          "defaultDailyLimit": 1000,
+          "unlockStatus": "pending_production_account_transition",
+          "productionUseAllowed": false
+        },
         "productionUseNoteKo": "admin review는 통과했지만 trip/stop sequence source가 없어 schedule_timetable production use는 아직 차단한다."
       }
     },

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -31,18 +31,6 @@ function readJson(relativePath) {
   return JSON.parse(read(relativePath));
 }
 
-function sourceInventorySha256ForAdmissionEvidence(inventory, { sourceId, omitSourceIds = [] }) {
-  const snapshot = JSON.parse(JSON.stringify(inventory));
-  const omitted = new Set(omitSourceIds);
-  snapshot.sources = snapshot.sources.filter((source) => !omitted.has(source.id));
-  const source = snapshot.sources.find((entry) => entry.id === sourceId);
-  if (!source) {
-    throw new Error(`source missing from inventory snapshot: ${sourceId}`);
-  }
-  delete source.admissionEvidence;
-  return createHash("sha256").update(JSON.stringify(snapshot)).digest("hex");
-}
-
 test("route ETA accuracy evaluator report contract is machine-readable", async () => {
   const outputDir = await mkdtemp(path.join(tmpdir(), "route-accuracy-"));
   const output = path.join(outputDir, "route-accuracy-report.json");
@@ -5729,14 +5717,12 @@ test("서울 TOPIS 실시간 후보는 backend-only key 경계와 production 분
     assert.equal(productionSource.admissionEvidence.sampleEvidenceHash, candidate.evidence.liveSampleEvidenceHash);
     assert.equal(productionSource.admissionEvidence.quotaEvidence.defaultDailyLimit, 1000);
     assert.equal(productionSource.admissionEvidence.quotaEvidence.productionUseAllowed, false);
+    // Admission hashes are immutable evidence captured at admission time.
     assert.equal(
       productionSource.admissionEvidence.sourceInventorySha256,
-      sourceInventorySha256ForAdmissionEvidence(inventory, {
-        sourceId: productionSource.id,
-        omitSourceIds: candidate.id === "seoul-topis-realtime-station-arrival"
-          ? ["seoul-topis-realtime-train-position"]
-          : [],
-      }),
+      candidate.id === "seoul-topis-realtime-station-arrival"
+        ? "571c61476d02a362f86870adb00862c8a3ae92767d39b2055edfab27b273b8ed"
+        : "48544f4da14243d182003c98dcbaaf670b65cfc601f006fbd8723e80bccf6dcc",
     );
   }
 });
@@ -5784,6 +5770,12 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
     approvedAt: "2026-07-04T00:20:00Z",
     sampleEvidenceHash: candidate.evidence.liveSampleEvidenceHash,
     admissionDurationSeconds: 0,
+    quotaEvidence: {
+      portal: "공공데이터포털",
+      defaultDailyLimit: 1000,
+      unlockStatus: "pending_production_account_transition",
+      productionUseAllowed: false,
+    },
   });
   assert.equal(productionSourceIds.has(candidate.id), true, "TAGO inventory entry exists but must remain non-production");
 

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6710,6 +6710,12 @@ test("source admission pipeline은 admin 승인 record로 inventory admission ev
     facilityEvidenceLedgerHash: sha256("facility-evidence-ledger"),
     routeEvidenceLedgerHash: sha256("route-evidence-ledger"),
     overrideHash: sha256("override-ledger"),
+    quotaEvidence: {
+      portal: "KRIC 레일포털",
+      defaultDailyLimit: "unlimited",
+      unlockStatus: "not_required",
+      productionUseAllowed: true,
+    },
     productionSource,
   };
   await writeFile(adminReviewPath, `${JSON.stringify(adminReview, null, 2)}\n`);
@@ -6858,6 +6864,12 @@ test("source admission pipeline은 custom candidates를 최종 inventory 검증�
     facilityEvidenceLedgerHash: sha256("facility-evidence-ledger"),
     routeEvidenceLedgerHash: sha256("route-evidence-ledger"),
     overrideHash: sha256("override-ledger"),
+    quotaEvidence: {
+      portal: "KRIC 레일포털",
+      defaultDailyLimit: "unlimited",
+      unlockStatus: "not_required",
+      productionUseAllowed: true,
+    },
     productionSource,
   };
   await writeFile(adminReviewPath, `${JSON.stringify(adminReview, null, 2)}\n`);
@@ -6901,6 +6913,31 @@ test("source admission pipeline은 custom candidates를 최종 inventory 검증�
       { cwd: root },
     ),
     /molit-tago-subway-info\.admissionEvidence\.sampleEvidenceHash must be/,
+  );
+});
+
+test("source inventory 검증기는 admitted candidate의 quota evidence 누락을 거부한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-admission-quota-${Date.now()}`);
+  const inventoryPath = path.join(outputDir, "source-inventory.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  const inventory = JSON.parse(await readFile(path.join(root, "tools/datapack/source-inventory.json"), "utf8"));
+  const source = inventory.sources.find((entry) => entry.id === "seoul-realtime-arrival-station-info");
+  delete source.admissionEvidence.quotaEvidence;
+  await writeFile(inventoryPath, `${JSON.stringify(inventory, null, 2)}\n`);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-inventory.mjs",
+        "--inventory",
+        inventoryPath,
+      ],
+      { cwd: root },
+    ),
+    /seoul-realtime-arrival-station-info\.admissionEvidence\.quotaEvidence must be an object/,
   );
 });
 

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6765,6 +6765,55 @@ test("source admission pipeline은 admin 승인 record로 inventory admission ev
   assert.equal(summary.licenseEvidenceHash, adminReview.licenseEvidenceHash);
   const outputInventory = JSON.parse(await readFile(outputInventoryPath, "utf8"));
   assert.ok(outputInventory.sources.some((source) => source.id === "kric-train-operation-organ"));
+
+  const mismatchedAdminReview = JSON.parse(JSON.stringify(adminReview));
+  mismatchedAdminReview.productionSource.admissionEvidence = {
+    quotaEvidence: {
+      portal: "KRIC 레일포털",
+      defaultDailyLimit: "unlimited",
+      unlockStatus: "not_required",
+      productionUseAllowed: false,
+    },
+  };
+  await writeFile(adminReviewPath, `${JSON.stringify(mismatchedAdminReview, null, 2)}\n`);
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/run-source-admission-pipeline.mjs",
+        "--candidate",
+        "kric-train-operation-organ",
+        "--raw-input",
+        rawPath,
+        "--evidence-dir",
+        outputDir,
+        "--snapshot-id",
+        "kric-train-operation-organ-snapshot-20260702",
+        "--source-id",
+        "kric-train-operation-organ",
+        "--provider",
+        "국가철도공단",
+        "--retrieved-at",
+        "2026-07-02T00:00:00Z",
+        "--source-updated-at",
+        "2026-07-02T00:00:00Z",
+        "--raw-object-uri",
+        "s3://easysubway-datapack-sources/kric-train-operation-organ/20260702.json",
+        "--freshness-expires-at",
+        "2026-08-01T00:00:00Z",
+        "--raw-retention-expires-at",
+        "2026-10-01T00:00:00Z",
+        "--admin-review",
+        adminReviewPath,
+        "--output-inventory",
+        path.join(outputDir, "source-inventory.mismatched-quota.json"),
+        "--output",
+        path.join(outputDir, "admission-summary-mismatched-quota.json"),
+      ],
+      { cwd: root },
+    ),
+    /adminReview\.productionSource\.admissionEvidence\.quotaEvidence must match adminReview\.quotaEvidence/,
+  );
 });
 
 test("source admission pipeline은 custom candidates를 최종 inventory 검증에 전달한다", async () => {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -6814,6 +6814,48 @@ test("source admission pipeline은 admin 승인 record로 inventory admission ev
     ),
     /adminReview\.productionSource\.admissionEvidence\.quotaEvidence must match adminReview\.quotaEvidence/,
   );
+
+  const unsanitizedAdminReview = JSON.parse(JSON.stringify(adminReview));
+  unsanitizedAdminReview.quotaEvidence.providerAccountMemo = "local-only quota account detail";
+  await writeFile(adminReviewPath, `${JSON.stringify(unsanitizedAdminReview, null, 2)}\n`);
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/run-source-admission-pipeline.mjs",
+        "--candidate",
+        "kric-train-operation-organ",
+        "--raw-input",
+        rawPath,
+        "--evidence-dir",
+        outputDir,
+        "--snapshot-id",
+        "kric-train-operation-organ-snapshot-20260702",
+        "--source-id",
+        "kric-train-operation-organ",
+        "--provider",
+        "국가철도공단",
+        "--retrieved-at",
+        "2026-07-02T00:00:00Z",
+        "--source-updated-at",
+        "2026-07-02T00:00:00Z",
+        "--raw-object-uri",
+        "s3://easysubway-datapack-sources/kric-train-operation-organ/20260702.json",
+        "--freshness-expires-at",
+        "2026-08-01T00:00:00Z",
+        "--raw-retention-expires-at",
+        "2026-10-01T00:00:00Z",
+        "--admin-review",
+        adminReviewPath,
+        "--output-inventory",
+        path.join(outputDir, "source-inventory.unsanitized-quota.json"),
+        "--output",
+        path.join(outputDir, "admission-summary-unsanitized-quota.json"),
+      ],
+      { cwd: root },
+    ),
+    /adminReview\.quotaEvidence must only include defaultDailyLimit, portal, productionUseAllowed, unlockStatus/,
+  );
 });
 
 test("source admission pipeline은 custom candidates를 최종 inventory 검증에 전달한다", async () => {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -7010,6 +7010,7 @@ test("source admission pipeline은 custom candidates를 최종 inventory 검증�
 test("source inventory 검증기는 admitted candidate의 quota evidence 누락을 거부한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-admission-quota-${Date.now()}`);
   const inventoryPath = path.join(outputDir, "source-inventory.json");
+  const promotedInventoryPath = path.join(outputDir, "source-inventory.quota-blocked-production.json");
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
 
@@ -7029,6 +7030,25 @@ test("source inventory 검증기는 admitted candidate의 quota evidence 누락�
       { cwd: root },
     ),
     /seoul-realtime-arrival-station-info\.admissionEvidence\.quotaEvidence must be an object/,
+  );
+
+  const promotedInventory = JSON.parse(await readFile(path.join(root, "tools/datapack/source-inventory.json"), "utf8"));
+  const promotedSource = promotedInventory.sources.find((entry) => entry.id === "molit-tago-subway-info");
+  promotedSource.capabilities.schedule.status = "SUPPORTED";
+  promotedSource.capabilities.schedule.productionUseAllowed = true;
+  await writeFile(promotedInventoryPath, `${JSON.stringify(promotedInventory, null, 2)}\n`);
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-source-inventory.mjs",
+        "--inventory",
+        promotedInventoryPath,
+      ],
+      { cwd: root },
+    ),
+    /molit-tago-subway-info\.admissionEvidence\.quotaEvidence\.productionUseAllowed must be true when source has production capability/,
   );
 });
 

--- a/tools/datapack/run-source-admission-pipeline.mjs
+++ b/tools/datapack/run-source-admission-pipeline.mjs
@@ -65,6 +65,7 @@ async function main() {
     routeEvidenceLedgerHash: adminReview.routeEvidenceLedgerHash,
     overrideHash: adminReview.overrideHash,
     admissionDurationSeconds: Math.max(0, Math.round((Date.now() - startedAt) / 1000)),
+    quotaEvidence: adminReview.quotaEvidence,
   };
 
   await writeFile(path.resolve(root, requireArg(args, "output")), `${JSON.stringify(summary, null, 2)}\n`);
@@ -188,6 +189,7 @@ function validateAdminReview({ adminReview, candidateId, sample, snapshot, args 
   ]) {
     assertSha256(adminReview[field], `adminReview.${field}`);
   }
+  validateQuotaEvidence(adminReview.quotaEvidence, "adminReview.quotaEvidence");
   if (!adminReview.productionSource || adminReview.productionSource.id !== adminReview.sourceId) {
     throw new Error("adminReview.productionSource.id must match adminReview.sourceId");
   }
@@ -198,6 +200,23 @@ function validateAdminReview({ adminReview, candidateId, sample, snapshot, args 
     }
   }
   return sha256(JSON.stringify(sortJson(adminReview)));
+}
+
+function validateQuotaEvidence(quotaEvidence, label) {
+  if (!quotaEvidence || typeof quotaEvidence !== "object" || Array.isArray(quotaEvidence)) {
+    throw new Error(`${label} must be an object`);
+  }
+  requiredText(quotaEvidence.portal, `${label}.portal`);
+  if (
+    quotaEvidence.defaultDailyLimit !== "unlimited" &&
+    (!Number.isInteger(quotaEvidence.defaultDailyLimit) || quotaEvidence.defaultDailyLimit < 0)
+  ) {
+    throw new Error(`${label}.defaultDailyLimit must be a non-negative integer or unlimited`);
+  }
+  requiredText(quotaEvidence.unlockStatus, `${label}.unlockStatus`);
+  if (typeof quotaEvidence.productionUseAllowed !== "boolean") {
+    throw new Error(`${label}.productionUseAllowed must be a boolean`);
+  }
 }
 
 function admitSource({ inventory, productionSource }) {

--- a/tools/datapack/run-source-admission-pipeline.mjs
+++ b/tools/datapack/run-source-admission-pipeline.mjs
@@ -193,6 +193,21 @@ function validateAdminReview({ adminReview, candidateId, sample, snapshot, args 
   if (!adminReview.productionSource || adminReview.productionSource.id !== adminReview.sourceId) {
     throw new Error("adminReview.productionSource.id must match adminReview.sourceId");
   }
+  const productionAdmissionEvidence = adminReview.productionSource.admissionEvidence;
+  if (productionAdmissionEvidence != null) {
+    if (typeof productionAdmissionEvidence !== "object" || Array.isArray(productionAdmissionEvidence)) {
+      throw new Error("adminReview.productionSource.admissionEvidence must be an object");
+    }
+    validateQuotaEvidence(
+      productionAdmissionEvidence.quotaEvidence,
+      "adminReview.productionSource.admissionEvidence.quotaEvidence",
+    );
+    const productionQuota = JSON.stringify(sortJson(productionAdmissionEvidence.quotaEvidence));
+    const adminQuota = JSON.stringify(sortJson(adminReview.quotaEvidence));
+    if (productionQuota !== adminQuota) {
+      throw new Error("adminReview.productionSource.admissionEvidence.quotaEvidence must match adminReview.quotaEvidence");
+    }
+  }
   const fieldsProvided = new Set(adminReview.productionSource.fieldsProvided ?? []);
   for (const field of sample.fields) {
     if (!fieldsProvided.has(field)) {

--- a/tools/datapack/run-source-admission-pipeline.mjs
+++ b/tools/datapack/run-source-admission-pipeline.mjs
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
+const quotaEvidenceKeys = ["defaultDailyLimit", "portal", "productionUseAllowed", "unlockStatus"];
 
 async function main() {
   const startedAt = Date.now();
@@ -220,6 +221,10 @@ function validateAdminReview({ adminReview, candidateId, sample, snapshot, args 
 function validateQuotaEvidence(quotaEvidence, label) {
   if (!quotaEvidence || typeof quotaEvidence !== "object" || Array.isArray(quotaEvidence)) {
     throw new Error(`${label} must be an object`);
+  }
+  const keys = Object.keys(quotaEvidence).sort((left, right) => left.localeCompare(right));
+  if (JSON.stringify(keys) !== JSON.stringify(quotaEvidenceKeys)) {
+    throw new Error(`${label} must only include ${quotaEvidenceKeys.join(", ")}`);
   }
   requiredText(quotaEvidence.portal, `${label}.portal`);
   if (

--- a/tools/datapack/source-admission-runbook.json
+++ b/tools/datapack/source-admission-runbook.json
@@ -35,6 +35,7 @@
     "facilityEvidenceLedgerHash",
     "routeEvidenceLedgerHash",
     "overrideHash",
+    "quotaEvidence",
     "productionSource"
   ]
 }

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -687,7 +687,13 @@
           "approvedBy": "qa-admin",
           "approvedAt": "2026-07-04T00:20:00Z",
           "sampleEvidenceHash": "d5a60bcc1907d346a24fbf720a5d362268720e8fab68e35c42eace270e5fe9ae",
-          "admissionDurationSeconds": 0
+          "admissionDurationSeconds": 0,
+          "quotaEvidence": {
+            "portal": "공공데이터포털",
+            "defaultDailyLimit": 1000,
+            "unlockStatus": "pending_production_account_transition",
+            "productionUseAllowed": false
+          }
         },
         "usePermissionRange": "공공데이터포털 이용허락범위 제한 없음",
         "formats": [

--- a/tools/datapack/source-inventory.json
+++ b/tools/datapack/source-inventory.json
@@ -588,6 +588,12 @@
         "routeEvidenceLedgerHash": "db2a0915adbf98eabc8f4ee52b4a9f27d25ebca95ecdfff3e3c8e4554ef768cc",
         "overrideHash": "b5fb2c6fed271ff24e1c8ecd0d2334b257540e2032492f78b4d8417964215787",
         "admissionDurationSeconds": 0,
+        "quotaEvidence": {
+          "portal": "공공데이터포털",
+          "defaultDailyLimit": 1000,
+          "unlockStatus": "pending_production_account_transition",
+          "productionUseAllowed": false
+        },
         "productionUseNoteKo": "admin review는 통과했지만 trip/stop sequence source가 없어 schedule_timetable production use는 아직 차단한다."
       }
     },

--- a/tools/datapack/validate-source-inventory.mjs
+++ b/tools/datapack/validate-source-inventory.mjs
@@ -214,11 +214,11 @@ function validateAdmittedCandidateEvidence(inventory, candidates) {
     if (!source) {
       throw new Error(`${candidate.id} admitted candidate missing production inventory source: ${sourceId}`);
     }
-    validateAdmissionEvidence(source.admissionEvidence, candidate, sourceId);
+    validateAdmissionEvidence(source.admissionEvidence, candidate, source, sourceId);
   }
 }
 
-function validateAdmissionEvidence(evidence, candidate, sourceId) {
+function validateAdmissionEvidence(evidence, candidate, source, sourceId) {
   if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) {
     throw new Error(`${sourceId}.admissionEvidence must be an object for admitted candidate ${candidate.id}`);
   }
@@ -260,6 +260,17 @@ function validateAdmissionEvidence(evidence, candidate, sourceId) {
     throw new Error(`${sourceId}.admissionEvidence.admissionDurationSeconds must be a non-negative integer`);
   }
   validateQuotaEvidence(evidence.quotaEvidence, `${sourceId}.admissionEvidence.quotaEvidence`);
+  if (sourceHasProductionCapability(source) && evidence.quotaEvidence.productionUseAllowed !== true) {
+    throw new Error(
+      `${sourceId}.admissionEvidence.quotaEvidence.productionUseAllowed must be true when source has production capability`,
+    );
+  }
+}
+
+function sourceHasProductionCapability(source) {
+  return ["schedule", "realtime", "facility"].some(
+    (capabilityName) => source.capabilities?.[capabilityName]?.productionUseAllowed === true,
+  );
 }
 
 function validateQuotaEvidence(quotaEvidence, label) {

--- a/tools/datapack/validate-source-inventory.mjs
+++ b/tools/datapack/validate-source-inventory.mjs
@@ -6,6 +6,7 @@ const inventoryPath = optionValue("--inventory") ?? "tools/datapack/source-inven
 const candidatesPath = optionValue("--candidates") ?? "tools/datapack/source-candidates.json";
 const scopePath = optionValue("--scope");
 const compareStrings = (left, right) => left.localeCompare(right);
+const quotaEvidenceKeys = ["defaultDailyLimit", "portal", "productionUseAllowed", "unlockStatus"];
 
 try {
   const inventory = JSON.parse(await readFile(inventoryPath, "utf8"));
@@ -264,6 +265,10 @@ function validateAdmissionEvidence(evidence, candidate, sourceId) {
 function validateQuotaEvidence(quotaEvidence, label) {
   if (!quotaEvidence || typeof quotaEvidence !== "object" || Array.isArray(quotaEvidence)) {
     throw new Error(`${label} must be an object`);
+  }
+  const keys = Object.keys(quotaEvidence).sort(compareStrings);
+  if (JSON.stringify(keys) !== JSON.stringify(quotaEvidenceKeys)) {
+    throw new Error(`${label} must only include ${quotaEvidenceKeys.join(", ")}`);
   }
   assertString(quotaEvidence.portal, `${label}.portal`);
   if (

--- a/tools/datapack/validate-source-inventory.mjs
+++ b/tools/datapack/validate-source-inventory.mjs
@@ -258,6 +258,24 @@ function validateAdmissionEvidence(evidence, candidate, sourceId) {
   if (!Number.isInteger(evidence.admissionDurationSeconds) || evidence.admissionDurationSeconds < 0) {
     throw new Error(`${sourceId}.admissionEvidence.admissionDurationSeconds must be a non-negative integer`);
   }
+  validateQuotaEvidence(evidence.quotaEvidence, `${sourceId}.admissionEvidence.quotaEvidence`);
+}
+
+function validateQuotaEvidence(quotaEvidence, label) {
+  if (!quotaEvidence || typeof quotaEvidence !== "object" || Array.isArray(quotaEvidence)) {
+    throw new Error(`${label} must be an object`);
+  }
+  assertString(quotaEvidence.portal, `${label}.portal`);
+  if (
+    quotaEvidence.defaultDailyLimit !== "unlimited" &&
+    (!Number.isInteger(quotaEvidence.defaultDailyLimit) || quotaEvidence.defaultDailyLimit < 0)
+  ) {
+    throw new Error(`${label}.defaultDailyLimit must be a non-negative integer or unlimited`);
+  }
+  assertString(quotaEvidence.unlockStatus, `${label}.unlockStatus`);
+  if (typeof quotaEvidence.productionUseAllowed !== "boolean") {
+    throw new Error(`${label}.productionUseAllowed must be a boolean`);
+  }
 }
 
 function requireInventorySource(sources, sourceId) {


### PR DESCRIPTION
## 관련 이슈

Refs #1397
Refs #1414

## 작업 배경

- #1397 업데이트에서 source admission 시 quota evidence를 남기는 조건이 추가됨.
- TAGO/TOPIS 1차 승격 흐름에서 provider quota/계정 상태가 production 사용 가능 여부를 좌우하므로 admission pipeline과 inventory 검증에서 누락을 차단해야 함.

## 작업 내용

- admitted candidate의 `admissionEvidence.quotaEvidence`를 source inventory validator에서 필수 검증.
- source admission pipeline admin review 입력과 summary 출력에 quota evidence를 포함.
- quota evidence mismatch, unknown key, production capability cross-check를 회귀 테스트로 차단.
- TAGO candidate/inventory admission evidence에 공공데이터포털 quota 상태를 기록하고 모바일 datapack asset inventory를 동기화.
- repository contract에서 TAGO quota evidence와 immutable admission hash 증거값을 고정.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/ci/repository-contract.test.mjs` → pass 158 / fail 0
  - `node --test tools/datapack/datapack-tools.test.mjs` → pass 178 / fail 0
  - `node tools/datapack/validate-source-inventory.mjs` → exit 0
  - `git diff --check` → exit 0
  - `codex review --disable plugins --base origin/main` → actionable findings 0 on head `a05beef605910dde48401ab9431154f32af900a3`
- GitHub checks:
  - CI / Release Artifacts / SonarCloud 모두 pass 또는 의도된 skip.
  - CodeRabbit status check는 pass이나 PR Review 객체가 없어 Codex CLI fallback review를 게시함.

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| source admission quota evidence gate | tooling | node test/validator | local terminal output | pass |
| GitHub CI | GitHub Actions | PR checks #1629 | workflow links in PR checks | pass |
| Codex CLI fallback review | GitHub PR Review | #1629 review `4628416260` | https://github.com/AquilaXk/easysubway/pull/1629#pullrequestreview-4628416260 | pass, actionable 0 |
| UI/접근성 증거 | n/a | 데이터팩 admission tooling 변경으로 화면 변경 없음 | 불필요 | n/a |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `validate-source-inventory.mjs`의 admitted candidate quota evidence 필수화와 `run-source-admission-pipeline.mjs`의 admin review 입력 검증.

## 리스크

- 기존 admitted source에 quota evidence가 없으면 validator가 실패한다. 이번 PR은 현재 admitted TAGO/TOPIS 증거를 모두 채운 상태로 유지한다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. 배포 영향 없음.
