### PR TITLE
[Fix] schedule import quota approval gate

### DIFF
--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -8463,6 +8463,68 @@ test("공식 source ingest adapter는 admission 전 schedule provenance도 produ
   );
 });
 
+test("공식 source ingest adapter는 quota 미승인 schedule source를 production 적재하지 않는다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-ingest-production-schedule-quota-${Date.now()}`);
+  const input = productionSourceIngestInput();
+  input.sourceIds.push("molit-tago-subway-info");
+  input.stationMappings.push({
+    sourceId: "molit-tago-subway-info",
+    sourceStationCode: "448",
+    lineId: "seoul-4",
+    stationId: "station-sangnoksu",
+    stationLineId: "station-sangnoksu:seoul-4",
+    mappingStatus: "active",
+  });
+  input.stationLineRows.push({
+    ...input.stationLineRows[0],
+    sourceId: "molit-tago-subway-info",
+    sourceStationCode: "448",
+  });
+  input.coverageEvidence.push({
+    regionId: "capital",
+    operatorId: "seoul-metro",
+    sourceDomain: "schedule_timetable",
+    sourceIds: ["molit-tago-subway-info"],
+    evidence: "TAGO schedule admission quota gate regression",
+  });
+  input.scheduleProvenance = {
+    sourceId: "molit-tago-subway-info",
+    sourceSnapshotId: "molit-tago-subway-info-snapshot-20260704",
+    providerRecordHash: sha256("provider:molit-tago-subway-info:schedule:20260704"),
+    evidenceHash: sha256("evidence:molit-tago-subway-info:schedule:20260704"),
+    retrievedAt: "2026-07-04T00:00:00.000Z",
+  };
+  input.serviceCalendars = [
+    {
+      serviceId: "weekday-2026",
+      monday: true,
+      tuesday: true,
+      wednesday: true,
+      thursday: true,
+      friday: true,
+      saturday: false,
+      sunday: false,
+      startDate: "20260701",
+      endDate: "20261231",
+    },
+  ];
+
+  const inventoryPath = path.join(tmpdir(), `easysubway-source-inventory-schedule-quota-${Date.now()}.json`);
+  const inventory = JSON.parse(await readFile(path.join(root, "tools/datapack/source-inventory.json"), "utf8"));
+  const tago = inventory.sources.find((source) => source.id === "molit-tago-subway-info");
+  tago.coverageScope.sourceDomains.push("schedule_timetable");
+  tago.capabilities.schedule.status = "SUPPORTED";
+  tago.capabilities.schedule.productionUseAllowed = true;
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(inventoryPath, `${JSON.stringify(inventory, null, 2)}\n`);
+
+  await assert.rejects(
+    importOfficialSourceInput(outputDir, input, inventoryPath),
+    /scheduleProvenance source quota does not allow production schedule use: molit-tago-subway-info/,
+  );
+});
+
 test("TAGO 시간표 sample validator는 station-level row shape만 검증하고 production 승격은 막는다", async () => {
   const samplePath = path.join(tmpdir(), `easysubway-tago-schedule-sample-${Date.now()}.json`);
   const rawSample = `${JSON.stringify({
@@ -11025,7 +11087,7 @@ function productionSourceIngestInput() {
   return input;
 }
 
-async function importOfficialSourceInput(outputDir, input) {
+async function importOfficialSourceInput(outputDir, input, inventoryPath = "tools/datapack/source-inventory.json") {
   const inputPath = path.join(outputDir, "official-source-input.json");
   const outputPath = path.join(outputDir, "catalog-fixture.json");
   await rm(outputDir, { recursive: true, force: true });
@@ -11036,7 +11098,7 @@ async function importOfficialSourceInput(outputDir, input) {
     [
       "tools/datapack/import-official-sources.mjs",
       "--inventory",
-      "tools/datapack/source-inventory.json",
+      inventoryPath,
       "--input",
       inputPath,
       "--output",

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -1114,6 +1114,9 @@ function validateProductionScheduleProvenance(provenance, selectedSources, allow
   if (source.capabilities?.schedule?.productionUseAllowed !== true) {
     throw new Error(`scheduleProvenance source is not admitted for production schedule use: ${sourceId}`);
   }
+  if (source.admissionEvidence?.quotaEvidence?.productionUseAllowed !== true) {
+    throw new Error(`scheduleProvenance source quota does not allow production schedule use: ${sourceId}`);
+  }
   requiredString(provenance.sourceSnapshotId, "scheduleProvenance.sourceSnapshotId");
   productionEvidenceHash(provenance.providerRecordHash, true, sourceId, "scheduleProvenance.providerRecordHash");
   productionEvidenceHash(provenance.evidenceHash, true, sourceId, "scheduleProvenance.evidenceHash");


### PR DESCRIPTION
## 관련 이슈

Refs #1415
Refs #1414

## 작업 배경

- TAGO source는 admin admission evidence가 생겼지만 `quotaEvidence.productionUseAllowed=false`라 아직 production PLANNED ETA 적재 근거로 쓰면 안 됩니다.
- 기존 importer는 schedule capability만 보면 통과할 수 있어 quota 승인 전 scheduleProvenance 우회를 막아야 합니다.

## 작업 내용

- production schedule provenance 검증에서 source admission quota evidence의 production use 승인 여부를 함께 확인합니다.
- TAGO를 임시로 schedule supported/sourceDomain 포함 상태로 만들어도 quota evidence가 false면 importer가 실패하는 regression을 추가했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "quota 미승인 schedule source" tools/datapack/datapack-tools.test.mjs` → pass 1 / fail 0
  - `node --test --test-name-pattern "production schedule|schedule provenance|quota 미승인 schedule source" tools/datapack/datapack-tools.test.mjs` → pass 3 / fail 0
  - `node --test tools/datapack/datapack-tools.test.mjs` → pass 179 / fail 0
  - `node --test tools/ci/repository-contract.test.mjs` → pass 158 / fail 0
  - `node tools/datapack/validate-source-inventory.mjs` → exit 0
  - `git diff --check` → exit 0

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| schedule quota gate | tooling | node test | local terminal output | pass |
| UI/접근성 증거 | n/a | importer gate만 변경 | 불필요 | n/a |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `validateProductionScheduleProvenance`의 quota evidence cross-check.

## 리스크

- 운영계정 전환 전에는 TAGO schedule source를 production schedule 적재에 사용할 수 없습니다. 의도한 fail-closed 동작입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. 배포 영향 없음.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 프로덕션 일정(source) 적재 시 추가 검증이 적용되어, quota 승인 증거가 없는 경우 업로드가 거부됩니다.
  * 공식 소스 가져오기 흐름에서 인벤토리 경로를 선택적으로 지정할 수 있어, 다양한 환경에서 더 유연하게 실행할 수 있습니다.
  * 관련 테스트가 추가되어, quota 미승인 일정 소스가 프로덕션에 반영되지 않는 동작을 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->