### PR TITLE
[Fix] require summary ride edge policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Production Routing Graph
 
-- Production LOCAL `RIDE` edge는 같은 노선의 인접 `lineSequence`만 연결합니다. 비인접 요약 edge는 regression fixture 또는 공식 정차 패턴이 있는 `EXPRESS` 근거로만 둡니다. pilot summary edge가 임시 pack에 남아 있으면 `route-graph-topology-report`의 release-blocking `nonAdjacentExpressRide` violation으로 기록하고 ETA 근거로 쓰지 않습니다.
+- Production LOCAL `RIDE` edge는 같은 노선의 인접 `lineSequence`만 연결합니다. 비인접 요약 edge는 regression fixture 또는 공식 정차 패턴이 있는 `EXPRESS` 근거로만 둡니다. pilot summary edge가 임시 pack에 남아 있으면 `route-graph-topology-report`의 release-blocking `nonAdjacentExpressRide` violation으로 기록하고 ETA 근거로 쓰지 않습니다. Production ingest는 이런 edge가 있을 때 `routeGraphTopologyPolicy.summaryRideEdges=release-blocking-regression-only`와 edge id 목록을 요구합니다.
 - 기본 route node는 station-line(`stationId:lineId`)입니다. platform node는 공식 platform/source가 admission되기 전까지 만들지 않고, 방향 문구는 `platformInfo`에만 둡니다.
 - 표시용 SVG asset은 앱 지도 표시용입니다. canonical route map position은 `routeMapPositions`의 source, license, `sourceSha256`, `reviewedAt`, `updatedAt`, label polygon으로만 판정합니다.
 - 앱의 `데이터 및 지도 출처` 화면은 source inventory와 manifest를 보여주는 사용자 연결점입니다. Level 4 또는 전국 claim은 #1397 source admission과 #1400 인접역 graph/position 확장 증거가 닫힐 때까지 NO-GO입니다.

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -8852,6 +8852,27 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
   const adjacencySafeInputPath = path.join(outputDir, "capital-pilot-production-adjacency-safe.json");
   await writeFile(adjacencySafeInputPath, `${JSON.stringify(adjacencySafeInput, null, 2)}\n`);
 
+  const missingSummaryRidePolicyInput = JSON.parse(JSON.stringify(adjacencySafeInput));
+  delete missingSummaryRidePolicyInput.routeGraphTopologyPolicy;
+  const missingSummaryRidePolicyInputPath = path.join(outputDir, "missing-summary-ride-policy.json");
+  await writeFile(missingSummaryRidePolicyInputPath, `${JSON.stringify(missingSummaryRidePolicyInput, null, 2)}\n`);
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/import-official-sources.mjs",
+        "--inventory",
+        "tools/datapack/source-inventory.json",
+        "--input",
+        missingSummaryRidePolicyInputPath,
+        "--output",
+        path.join(outputDir, "missing-summary-ride-policy-fixture.json"),
+      ],
+      { cwd: root },
+    ),
+    /routeGraphTopologyPolicy\.summaryRideEdges must mark non-adjacent EXPRESS RIDE edges as release-blocking-regression-only/,
+  );
+
   await execFileAsync(
     process.execPath,
     [
@@ -10864,6 +10885,15 @@ function productionSourceIngestInput() {
   const input = sourceIngestInput();
   input.pack.artifactKind = "production";
   input.pack.url = "https://datapack.example.com/easysubway/catalog/capital-v1.sqlite.gz";
+  input.routeGraphTopologyPolicy = {
+    summaryRideEdges: "release-blocking-regression-only",
+    productionReadinessRequirement:
+      "replace summary RIDE edges with adjacent-station LOCAL RIDE edges before ETA or release-readiness claim",
+    nonAdjacentExpressRideEdgeIds: [
+      "edge-sangnoksu-sadang-seoul-4",
+      "edge-sadang-sangnoksu-seoul-4",
+    ],
+  };
   input.sourceIds = [
     "molit-urban-rail-full-route",
     "seoulmetro-station-line-info",

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -8916,6 +8916,30 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
     /routeGraphTopologyPolicy\.summaryRideEdges must mark non-adjacent EXPRESS RIDE edges as release-blocking-regression-only/,
   );
 
+  const lowercaseRideEdgeInput = JSON.parse(JSON.stringify(adjacencySafeInput));
+  lowercaseRideEdgeInput.routeEdges = lowercaseRideEdgeInput.routeEdges.map((edge) =>
+    edge.edgeType === "RIDE" ? { ...edge, edgeType: "ride" } : edge,
+  );
+  delete lowercaseRideEdgeInput.routeGraphTopologyPolicy;
+  const lowercaseRideEdgeInputPath = path.join(outputDir, "lowercase-ride-summary-policy.json");
+  await writeFile(lowercaseRideEdgeInputPath, `${JSON.stringify(lowercaseRideEdgeInput, null, 2)}\n`);
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/import-official-sources.mjs",
+        "--inventory",
+        "tools/datapack/source-inventory.json",
+        "--input",
+        lowercaseRideEdgeInputPath,
+        "--output",
+        path.join(outputDir, "lowercase-ride-summary-policy-fixture.json"),
+      ],
+      { cwd: root },
+    ),
+    /routeGraphTopologyPolicy\.summaryRideEdges must mark non-adjacent EXPRESS RIDE edges as release-blocking-regression-only/,
+  );
+
   await execFileAsync(
     process.execPath,
     [

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -8381,6 +8381,49 @@ test("공식 source ingest adapter는 명시한 lineSequence 경계 wrap만 허�
   assert.equal(generated.packs[0].minimumTableRows.transit_stop_times, 3);
 });
 
+test("공식 source ingest adapter는 cross-line EXPRESS summary edge도 격리 정책을 요구한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-source-ingest-cross-line-express-policy-${Date.now()}`);
+  const input = productionSourceIngestInput();
+  addSeoul2ProductionScope(input);
+  addMolitStationMapping(input, {
+    sourceStationCode: "MOLIT-SEOUL-2-226",
+    stationId: "station-sadang",
+  });
+  addStationLineRow(input, {
+    baseSourceStationCode: "MOLIT-SEOUL-4-433",
+    sourceStationCode: "MOLIT-SEOUL-2-226",
+    stationCode: "226",
+    lineSequence: 29,
+  });
+  input.routeEdges = [
+    {
+      ...input.routeEdges[0],
+      id: "edge-cross-line-express-summary",
+      sourceId: "molit-urban-rail-full-route",
+      from: {
+        sourceId: "molit-urban-rail-full-route",
+        sourceStationCode: "MOLIT-SEOUL-4-448",
+        lineId: "seoul-4",
+      },
+      to: {
+        sourceId: "molit-urban-rail-full-route",
+        sourceStationCode: "MOLIT-SEOUL-2-226",
+        lineId: "seoul-2",
+      },
+      servicePattern: "EXPRESS",
+      sourceSnapshotId: "molit-urban-rail-full-route-snapshot-20260621",
+      providerRecordHash: sha256("provider:edge-cross-line-express-summary:molit-urban-rail-full-route"),
+      evidenceHash: sha256("evidence:edge-cross-line-express-summary:molit-urban-rail-full-route:2026-06-21T00:00:00.000Z"),
+    },
+  ];
+  delete input.routeGraphTopologyPolicy;
+
+  await assert.rejects(
+    importOfficialSourceInput(outputDir, input),
+    /routeGraphTopologyPolicy\.summaryRideEdges must mark non-adjacent EXPRESS RIDE edges as release-blocking-regression-only/,
+  );
+});
+
 test("공식 source ingest adapter는 stop_times 순서가 lineSequence와 뒤섞이면 거부한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-source-ingest-stop-times-sequence-${Date.now()}`);
   const input = sourceIngestInput();

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -34,6 +34,7 @@ function buildFixture(inventory, input) {
   const stationLines = normalizedStationLines(stationRows);
   const networkEdges = routeEdges(input.routeEdges ?? [], allowedSourceIds, mappingBySourceKey, isProductionPack);
   validateProductionRideEdgeAdmission(stationLines, networkEdges, isProductionPack);
+  validateProductionSummaryRideEdgePolicy(stationLines, networkEdges, input.routeGraphTopologyPolicy, isProductionPack);
   const facilities = facilityRows(input.facilityRows ?? [], allowedSourceIds, mappingBySourceKey, isProductionPack);
   const stationFacilityEvidence = stationFacilityEvidenceRows(input, stationRows, facilities, isProductionPack);
   const movementCandidates = movementPathCandidates(
@@ -761,6 +762,51 @@ function validateProductionRideEdgeAdmission(stationLines, networkEdges, isProdu
       throw new Error(`production routeEdges LOCAL RIDE edge must connect adjacent station-line sequences: ${edge.id}`);
     }
   }
+}
+
+function validateProductionSummaryRideEdgePolicy(stationLines, networkEdges, policy, isProductionPack) {
+  if (!isProductionPack) {
+    return;
+  }
+  const stationLineByNode = new Map(
+    stationLines.map((row) => [
+      `${row.stationId}:${row.lineId}`,
+      { lineId: row.lineId, lineSequence: row.lineSequence },
+    ]),
+  );
+  const nonAdjacentExpressRideEdgeIds = networkEdges
+    .filter((edge) => edge.edgeType === "RIDE" && String(edge.servicePattern || "LOCAL").toUpperCase() === "EXPRESS")
+    .filter((edge) => {
+      const from = stationLineByNode.get(stationLineNodeFromRouteNode(edge.fromNodeId));
+      const to = stationLineByNode.get(stationLineNodeFromRouteNode(edge.toNodeId));
+      return from && to && from.lineId === to.lineId && Math.abs(from.lineSequence - to.lineSequence) !== 1;
+    })
+    .map((edge) => edge.id)
+    .sort((left, right) => left.localeCompare(right));
+  if (nonAdjacentExpressRideEdgeIds.length === 0) {
+    return;
+  }
+  if (
+    !policy ||
+    typeof policy !== "object" ||
+    Array.isArray(policy) ||
+    policy.summaryRideEdges !== "release-blocking-regression-only"
+  ) {
+    throw new Error(
+      "routeGraphTopologyPolicy.summaryRideEdges must mark non-adjacent EXPRESS RIDE edges as release-blocking-regression-only",
+    );
+  }
+  const declaredEdgeIds = requiredStringArray(
+    policy.nonAdjacentExpressRideEdgeIds,
+    "routeGraphTopologyPolicy.nonAdjacentExpressRideEdgeIds",
+  );
+  const declaredEdgeIdSet = new Set(declaredEdgeIds);
+  for (const edgeId of nonAdjacentExpressRideEdgeIds) {
+    if (!declaredEdgeIdSet.has(edgeId)) {
+      throw new Error(`routeGraphTopologyPolicy.nonAdjacentExpressRideEdgeIds missing: ${edgeId}`);
+    }
+  }
+  requiredString(policy.productionReadinessRequirement, "routeGraphTopologyPolicy.productionReadinessRequirement");
 }
 
 function stationLineNodeFromRouteNode(nodeId) {

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -779,7 +779,7 @@ function validateProductionSummaryRideEdgePolicy(stationLines, networkEdges, pol
     .filter((edge) => {
       const from = stationLineByNode.get(stationLineNodeFromRouteNode(edge.fromNodeId));
       const to = stationLineByNode.get(stationLineNodeFromRouteNode(edge.toNodeId));
-      return from && to && from.lineId === to.lineId && Math.abs(from.lineSequence - to.lineSequence) !== 1;
+      return from && to && (from.lineId !== to.lineId || Math.abs(from.lineSequence - to.lineSequence) !== 1);
     })
     .map((edge) => edge.id)
     .sort((left, right) => left.localeCompare(right));

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -775,7 +775,10 @@ function validateProductionSummaryRideEdgePolicy(stationLines, networkEdges, pol
     ]),
   );
   const nonAdjacentExpressRideEdgeIds = networkEdges
-    .filter((edge) => edge.edgeType === "RIDE" && String(edge.servicePattern || "LOCAL").toUpperCase() === "EXPRESS")
+    .filter((edge) =>
+      String(edge.edgeType ?? "").toUpperCase() === "RIDE" &&
+      String(edge.servicePattern || "LOCAL").toUpperCase() === "EXPRESS"
+    )
     .filter((edge) => {
       const from = stationLineByNode.get(stationLineNodeFromRouteNode(edge.fromNodeId));
       const to = stationLineByNode.get(stationLineNodeFromRouteNode(edge.toNodeId));


### PR DESCRIPTION
## 관련 이슈

Refs #1400
Refs #1414

## 작업 배경

- #1400의 잔여 작업 중 KRIC key 없이 진행 가능한 slice입니다.
- 현재 pilot summary RIDE edge는 인접역 production ETA 근거가 아니라 release-blocking regression-only 상태여야 합니다.
- 기존 production importer는 비인접 EXPRESS RIDE edge가 있어도 `routeGraphTopologyPolicy` 누락을 거부하지 않았습니다.

## 작업 내용

- production source ingest에서 비인접 EXPRESS RIDE edge를 감지하면 `routeGraphTopologyPolicy.summaryRideEdges=release-blocking-regression-only`와 해당 edge id 목록을 요구합니다.
- cross-line EXPRESS summary edge와 lower-case `ride` edgeType 우회 regression test를 추가했습니다.
- README Production Routing Graph 정책에 importer gate를 명시했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "UNKNOWN strict coverage gap" tools/datapack/datapack-tools.test.mjs` → RED 확인 후 pass 1 / fail 0
  - `node --test --test-name-pattern "cross-line EXPRESS summary edge|UNKNOWN strict coverage gap" tools/datapack/datapack-tools.test.mjs` → pass 2 / fail 0
  - `node tools/datapack/import-official-sources.mjs --inventory tools/datapack/source-inventory.json --input tools/datapack/inputs/capital-pilot-production-source-input.json --output /tmp/easysubway-1400-policy-import.json` → exit 0
  - `node --test tools/datapack/datapack-tools.test.mjs` → pass 180 / fail 0
  - `node --test tools/ci/repository-contract.test.mjs` → pass 158 / fail 0
  - `git diff --check` → exit 0
  - PR CI / Release Artifacts / SonarCloud → pass
  - Codex CLI fallback review → Actionable comments posted: 0

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| summary RIDE policy gate | tooling | node test + importer smoke | local terminal output | pass |
| PR CI | GitHub Actions | `gh pr checks 1631` | https://github.com/AquilaXk/easysubway/pull/1631/checks | pass |
| PR review | GitHub PR Review | Codex CLI fallback review | https://github.com/AquilaXk/easysubway/pull/1631#pullrequestreview-4628537434 | pass |
| UI/접근성 증거 | n/a | importer/README/test만 변경 | 불필요 | n/a |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `validateProductionSummaryRideEdgePolicy`가 비인접 EXPRESS RIDE만 정책 대상으로 잡고, edgeType/servicePattern을 topology report와 같은 기준으로 정규화하는 부분.

## 리스크

- 실제 4호선 인접역 edge 승격은 아직 KRIC source admission/key 확보에 의존합니다. 이 PR은 summary edge의 release-blocking 격리를 강화하는 slice입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. 배포 영향 없음.