### PR TITLE
[Chore] add route timetable load port

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteTimetablePort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteTimetablePort.java
@@ -14,6 +14,9 @@ public interface LoadRouteTimetablePort {
 		List<TransitStopTime> transitStopTimes,
 		List<TransitFrequency> transitFrequencies
 	) {
+		public static RouteTimetable empty() {
+			return new RouteTimetable(List.of(), List.of(), List.of(), List.of(), List.of(), List.of());
+		}
 	}
 
 	record ServiceCalendar(

--- a/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteTimetablePort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteTimetablePort.java
@@ -1,8 +1,11 @@
 package com.easysubway.route.application.port.out;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface LoadRouteTimetablePort {
+
+	int SERVICE_DAY_SECONDS_LIMIT_EXCLUSIVE = 108000;
 
 	RouteTimetable loadRouteTimetable();
 
@@ -14,6 +17,15 @@ public interface LoadRouteTimetablePort {
 		List<TransitStopTime> transitStopTimes,
 		List<TransitFrequency> transitFrequencies
 	) {
+		public RouteTimetable {
+			serviceCalendars = List.copyOf(serviceCalendars);
+			serviceCalendarDates = List.copyOf(serviceCalendarDates);
+			transitRoutes = List.copyOf(transitRoutes);
+			transitTrips = List.copyOf(transitTrips);
+			transitStopTimes = List.copyOf(transitStopTimes);
+			transitFrequencies = List.copyOf(transitFrequencies);
+		}
+
 		public static RouteTimetable empty() {
 			return new RouteTimetable(List.of(), List.of(), List.of(), List.of(), List.of(), List.of());
 		}
@@ -28,13 +40,26 @@ public interface LoadRouteTimetablePort {
 		boolean friday,
 		boolean saturday,
 		boolean sunday,
-		String startDate,
-		String endDate,
+		LocalDate startDate,
+		LocalDate endDate,
 		String timezone
 	) {
+		public ServiceCalendar {
+			requireDate(startDate, "service_calendars.start_date");
+			requireDate(endDate, "service_calendars.end_date");
+			if (startDate.isAfter(endDate)) {
+				throw new IllegalArgumentException("service_calendars.start_date must be <= end_date");
+			}
+		}
 	}
 
-	record ServiceCalendarDate(String serviceId, String date, int exceptionType) {
+	record ServiceCalendarDate(String serviceId, LocalDate date, int exceptionType) {
+		public ServiceCalendarDate {
+			requireDate(date, "service_calendar_dates.date");
+			if (exceptionType != 1 && exceptionType != 2) {
+				throw new IllegalArgumentException("service_calendar_dates.exception_type must be 1 or 2");
+			}
+		}
 	}
 
 	record TransitRoute(
@@ -56,6 +81,9 @@ public interface LoadRouteTimetablePort {
 		String servicePattern,
 		int serviceDayStartSeconds
 	) {
+		public TransitTrip {
+			requireServiceDaySeconds(serviceDayStartSeconds, "transit_trips.service_day_start_seconds");
+		}
 	}
 
 	record TransitStopTime(
@@ -68,6 +96,16 @@ public interface LoadRouteTimetablePort {
 		int pickupType,
 		int dropOffType
 	) {
+		public TransitStopTime {
+			if (stopSequence <= 0) {
+				throw new IllegalArgumentException("transit_stop_times.stop_sequence must be positive");
+			}
+			requireServiceDaySeconds(arrivalSeconds, "transit_stop_times.arrival_seconds");
+			requireServiceDaySeconds(departureSeconds, "transit_stop_times.departure_seconds");
+			if (arrivalSeconds > departureSeconds) {
+				throw new IllegalArgumentException("transit_stop_times.arrival_seconds must be <= departure_seconds");
+			}
+		}
 	}
 
 	record TransitFrequency(
@@ -77,5 +115,27 @@ public interface LoadRouteTimetablePort {
 		int headwaySeconds,
 		boolean exactTimes
 	) {
+		public TransitFrequency {
+			requireServiceDaySeconds(startTimeSeconds, "transit_frequencies.start_time_seconds");
+			requireServiceDaySeconds(endTimeSeconds, "transit_frequencies.end_time_seconds");
+			if (endTimeSeconds <= startTimeSeconds) {
+				throw new IllegalArgumentException("transit_frequencies.end_time_seconds must be > start_time_seconds");
+			}
+			if (headwaySeconds <= 0) {
+				throw new IllegalArgumentException("transit_frequencies.headway_seconds must be positive");
+			}
+		}
+	}
+
+	private static void requireDate(LocalDate date, String fieldName) {
+		if (date == null) {
+			throw new IllegalArgumentException(fieldName + " is required");
+		}
+	}
+
+	private static void requireServiceDaySeconds(int seconds, String fieldName) {
+		if (seconds < 0 || seconds >= SERVICE_DAY_SECONDS_LIMIT_EXCLUSIVE) {
+			throw new IllegalArgumentException(fieldName + " must be >= 0 and < 108000");
+		}
 	}
 }

--- a/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteTimetablePort.java
+++ b/backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteTimetablePort.java
@@ -1,0 +1,78 @@
+package com.easysubway.route.application.port.out;
+
+import java.util.List;
+
+public interface LoadRouteTimetablePort {
+
+	RouteTimetable loadRouteTimetable();
+
+	record RouteTimetable(
+		List<ServiceCalendar> serviceCalendars,
+		List<ServiceCalendarDate> serviceCalendarDates,
+		List<TransitRoute> transitRoutes,
+		List<TransitTrip> transitTrips,
+		List<TransitStopTime> transitStopTimes,
+		List<TransitFrequency> transitFrequencies
+	) {
+	}
+
+	record ServiceCalendar(
+		String serviceId,
+		boolean monday,
+		boolean tuesday,
+		boolean wednesday,
+		boolean thursday,
+		boolean friday,
+		boolean saturday,
+		boolean sunday,
+		String startDate,
+		String endDate,
+		String timezone
+	) {
+	}
+
+	record ServiceCalendarDate(String serviceId, String date, int exceptionType) {
+	}
+
+	record TransitRoute(
+		String id,
+		String lineId,
+		String routeShortName,
+		String routeLongName,
+		String directionName,
+		String timezone
+	) {
+	}
+
+	record TransitTrip(
+		String id,
+		String routeId,
+		String serviceId,
+		String tripHeadsign,
+		String directionId,
+		String servicePattern,
+		int serviceDayStartSeconds
+	) {
+	}
+
+	record TransitStopTime(
+		String tripId,
+		int stopSequence,
+		String stationId,
+		String lineId,
+		int arrivalSeconds,
+		int departureSeconds,
+		int pickupType,
+		int dropOffType
+	) {
+	}
+
+	record TransitFrequency(
+		String tripId,
+		int startTimeSeconds,
+		int endTimeSeconds,
+		int headwaySeconds,
+		boolean exactTimes
+	) {
+	}
+}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -14,6 +14,7 @@ import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,6 +25,7 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 	private final RouteSearchUseCase routeSearchUseCase;
 	private final LoadRouteTimetablePort routeTimetablePort;
 
+	@Autowired
 	public RouteV2Planner(RouteSearchUseCase routeSearchUseCase) {
 		this(routeSearchUseCase, RouteTimetable::empty);
 	}

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -6,6 +6,8 @@ import com.easysubway.route.application.port.in.RouteV2SearchUseCase;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase.SearchRouteV2Command;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Plan;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Status;
+import com.easysubway.route.application.port.out.LoadRouteTimetablePort;
+import com.easysubway.route.application.port.out.LoadRouteTimetablePort.RouteTimetable;
 import com.easysubway.route.domain.EtaSource;
 import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteSearchResult;
@@ -20,14 +22,21 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 	private static final String PLANNER_ADR = "tools/routes/route-algorithm-v2-adr.json";
 
 	private final RouteSearchUseCase routeSearchUseCase;
+	private final LoadRouteTimetablePort routeTimetablePort;
 
 	public RouteV2Planner(RouteSearchUseCase routeSearchUseCase) {
+		this(routeSearchUseCase, RouteTimetable::empty);
+	}
+
+	RouteV2Planner(RouteSearchUseCase routeSearchUseCase, LoadRouteTimetablePort routeTimetablePort) {
 		this.routeSearchUseCase = routeSearchUseCase;
+		this.routeTimetablePort = routeTimetablePort;
 	}
 
 	@Override
 	public RouteV2Plan search(SearchRouteV2Command command) {
 		try {
+			routeTimetablePort.loadRouteTimetable();
 			SearchRouteCommand searchRouteCommand = toSearchRouteCommand(command);
 			List<RouteSearchResult> itineraries = routeSearchUseCase.searchRouteAlternatives(
 				searchRouteCommand,

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -15,6 +15,7 @@ import com.easysubway.route.domain.RouteSearchStatus;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -25,9 +26,16 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 	private final RouteSearchUseCase routeSearchUseCase;
 	private final LoadRouteTimetablePort routeTimetablePort;
 
-	@Autowired
 	public RouteV2Planner(RouteSearchUseCase routeSearchUseCase) {
 		this(routeSearchUseCase, RouteTimetable::empty);
+	}
+
+	@Autowired
+	public RouteV2Planner(
+		RouteSearchUseCase routeSearchUseCase,
+		ObjectProvider<LoadRouteTimetablePort> routeTimetablePortProvider
+	) {
+		this(routeSearchUseCase, routeTimetablePortProvider.getIfAvailable(() -> RouteTimetable::empty));
 	}
 
 	RouteV2Planner(RouteSearchUseCase routeSearchUseCase, LoadRouteTimetablePort routeTimetablePort) {

--- a/backend/src/test/java/com/easysubway/route/application/port/out/LoadRouteTimetablePortTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/port/out/LoadRouteTimetablePortTest.java
@@ -1,0 +1,59 @@
+package com.easysubway.route.application.port.out;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LoadRouteTimetablePortTest {
+
+	@Test
+	@DisplayName("시간표 port는 LocalDate와 schema 초 범위를 강제한다")
+	void routeTimetableRecordsValidateDatesAndSeconds() {
+		new LoadRouteTimetablePort.ServiceCalendar(
+			"weekday",
+			true,
+			true,
+			true,
+			true,
+			true,
+			false,
+			false,
+			LocalDate.parse("2026-07-01"),
+			LocalDate.parse("2026-12-31"),
+			"Asia/Seoul"
+		);
+
+		assertThatThrownBy(() -> new LoadRouteTimetablePort.ServiceCalendar(
+			"weekday",
+			true,
+			true,
+			true,
+			true,
+			true,
+			false,
+			false,
+			LocalDate.parse("2026-12-31"),
+			LocalDate.parse("2026-07-01"),
+			"Asia/Seoul"
+		)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> new LoadRouteTimetablePort.TransitStopTime(
+			"trip-1",
+			1,
+			"station-a",
+			"seoul-4",
+			-1,
+			60,
+			0,
+			0
+		)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> new LoadRouteTimetablePort.TransitFrequency(
+			"trip-1",
+			60,
+			30,
+			0,
+			false
+		)).isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -9439,6 +9439,8 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(controller, /plan\.statuses\(\)/);
   assert.doesNotMatch(controller, /List\.of\(\s*"FOUND"[\s\S]*"ROUTE_GRAPH_UNKNOWN"/);
   assert.match(planner, /class RouteV2Planner implements RouteV2SearchUseCase/);
+  assert.match(planner, /LoadRouteTimetablePort/);
+  assert.match(planner, /loadRouteTimetable\(\)/);
   assert.match(planner, /searchRouteAlternatives/);
   assert.match(planner, /statusesOf/);
   assert.match(useCase, /record SearchRouteV2Command/);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -9418,12 +9418,15 @@ test("백엔드 경로 검색은 헥사고날 API 경계를 따른다", () => {
 test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 전달한다", () => {
   const controller = read("backend/src/main/java/com/easysubway/route/adapter/in/web/RouteSearchController.java");
   const useCasePath = "backend/src/main/java/com/easysubway/route/application/port/in/RouteV2SearchUseCase.java";
+  const timetablePortPath = "backend/src/main/java/com/easysubway/route/application/port/out/LoadRouteTimetablePort.java";
   const plannerPath = "backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java";
 
   assert.equal(existsSync(path.join(root, useCasePath)), true, "RouteV2SearchUseCase must expose the V2 planning port");
+  assert.equal(existsSync(path.join(root, timetablePortPath)), true, "RouteV2Planner must get timetable data through a port");
   assert.equal(existsSync(path.join(root, plannerPath)), true, "RouteV2Planner must own V2 production search planning");
 
   const useCase = read(useCasePath);
+  const timetablePort = read(timetablePortPath);
   const planner = read(plannerPath);
   const v2Endpoint = controller.match(
     /@PostMapping\("\/api\/v2\/routes\/search"\)[\s\S]*?ApiResponse<RouteSearchV2Response> searchRouteV2[\s\S]*?\n\t}/,
@@ -9448,6 +9451,19 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(useCase, /alternativeCount < 1/);
   assert.match(useCase, /enum RouteV2Status/);
   assert.match(useCase, /List<RouteV2Status> statuses/);
+  assert.match(timetablePort, /interface LoadRouteTimetablePort/);
+  assert.match(timetablePort, /loadRouteTimetable/);
+  assert.match(timetablePort, /record RouteTimetable/);
+  for (const schemaRecord of [
+    "ServiceCalendar",
+    "ServiceCalendarDate",
+    "TransitRoute",
+    "TransitTrip",
+    "TransitStopTime",
+    "TransitFrequency",
+  ]) {
+    assert.match(timetablePort, new RegExp(`record ${schemaRecord}`));
+  }
   assert.match(planner, /route-algorithm-v2-adr\.json|Range RAPTOR/);
 });
 

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -9440,6 +9440,8 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.doesNotMatch(controller, /List\.of\(\s*"FOUND"[\s\S]*"ROUTE_GRAPH_UNKNOWN"/);
   assert.match(planner, /class RouteV2Planner implements RouteV2SearchUseCase/);
   assert.match(planner, /LoadRouteTimetablePort/);
+  assert.match(planner, /ObjectProvider<LoadRouteTimetablePort>/);
+  assert.match(planner, /getIfAvailable\(\(\) -> RouteTimetable::empty\)/);
   assert.match(planner, /loadRouteTimetable\(\)/);
   assert.match(planner, /searchRouteAlternatives/);
   assert.match(planner, /statusesOf/);


### PR DESCRIPTION
## 관련 이슈

Refs #1620
Refs #1414

## 작업 배경

- #1620의 Range RAPTOR production 승격을 위해 backend가 데이터팩 시간표 schema를 읽을 out port가 먼저 필요합니다.
- 전체 RAPTOR 이식 전, 데이터 경계와 Spring 주입 경계를 먼저 고정하는 작은 slice입니다.

## 작업 내용

- `LoadRouteTimetablePort`를 추가해 `service_calendars`, `service_calendar_dates`, `transit_routes`, `transit_trips`, `transit_stop_times`, `transit_frequencies` 형태를 backend port로 고정했습니다.
- timetable record가 `LocalDate`와 데이터팩 schema의 seconds 범위를 생성 시점에 검증하도록 했습니다.
- `RouteV2Planner`가 timetable port를 호출하고, Spring 주입 생성자는 `ObjectProvider<LoadRouteTimetablePort>`로 실제 adapter bean이 있으면 우선 사용하도록 했습니다.
- repository contract가 V2 planner의 timetable port 의존성, provider 주입, schema record를 확인하게 했습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "V2 경로 검색" tools/ci/repository-contract.test.mjs` → RED 확인 후 pass 1 / fail 0
  - `./gradlew test --tests com.easysubway.route.application.port.out.LoadRouteTimetablePortTest --tests com.easysubway.route.application.service.RouteSearchServiceTest.routeV2Planner*` (backend cwd) → BUILD SUCCESSFUL
  - `./gradlew test --tests com.easysubway.EasySubwayBackendApplicationTests` (backend cwd) → BUILD SUCCESSFUL
  - `node --test tools/ci/repository-contract.test.mjs` → pass 158 / fail 0
  - `./gradlew test` (backend cwd) → BUILD SUCCESSFUL
  - `git diff --check` → exit 0
  - `codex review --disable plugins --base origin/main` → latest head `a4f4f970`, actionable 0

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| timetable load port contract | backend/tooling | node contract + backend focused/full tests | local terminal output | pass |
| Spring context startup | backend | `EasySubwayBackendApplicationTests`, `./gradlew test` | local terminal output | pass |
| code review | GitHub PR | CodeRabbit actual review + Codex CLI fallback reviews | PR review objects | pass |
| UI/접근성 증거 | n/a | backend port/contract만 변경 | 불필요 | n/a |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: backend timetable load port boundary만 추가, public route API 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteV2Planner`의 `ObjectProvider<LoadRouteTimetablePort>` 주입과 `LoadRouteTimetablePort` record 검증이 데이터팩 시간표 schema를 보존하는지.

## 리스크

- 아직 RAPTOR 스캔 구현은 아닙니다. 다음 slice에서 concrete adapter와 planner scan을 이어야 합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. 배포 영향 없음.
