### PR TITLE
[Chore] TAGO 시간표 수집 plan 추가

### DIFF
--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { buildTagoScheduleCollectionPlan } from "./validate-tago-schedule-sample.mjs";
 
-test("TAGO 시간표 수집 plan은 daily limit과 checkpoint resume을 적용한다", async () => {
+test("TAGO 시간표 수집 plan은 daily limit과 checkpoint resume을 적용한다", () => {
   const plan = buildTagoScheduleCollectionPlan(
     {
       stationLineRows: [
@@ -23,4 +23,14 @@ test("TAGO 시간표 수집 plan은 daily limit과 checkpoint resume을 적용�
   );
   assert.equal(plan.batches[0].requests[0].requestKey, "MTRKR4448|01|D");
   assert.ok(plan.batches.every((batch) => batch.requests.length <= 3));
+});
+
+test("TAGO 시간표 수집 plan은 파일럿 매핑 대상이 아닌 lineId를 거부한다", () => {
+  assert.throws(
+    () =>
+      buildTagoScheduleCollectionPlan({
+        stationLineRows: [{ stationCode: "113", lineId: "busan-1" }],
+      }),
+    /Unsupported lineId for pilot mapping: busan-1/,
+  );
 });

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { buildTagoScheduleCollectionPlan } from "./validate-tago-schedule-sample.mjs";
+
+test("TAGO 시간표 수집 plan은 daily limit과 checkpoint resume을 적용한다", async () => {
+  const plan = buildTagoScheduleCollectionPlan(
+    {
+      stationLineRows: [
+        { stationCode: "448", lineId: "seoul-4" },
+        { stationCode: "433", lineId: "seoul-4" },
+      ],
+    },
+    { completedRequestKeys: ["MTRKR4448|01|U"] },
+    3,
+  );
+  assert.equal(plan.artifactKind, "tago-schedule-collection-plan");
+  assert.equal(plan.dailyLimit, 3);
+  assert.equal(plan.totalRequestCount, 12);
+  assert.equal(plan.completedRequestCount, 1);
+  assert.deepEqual(
+    plan.batches.map((batch) => batch.requests.length),
+    [3, 3, 3, 2],
+  );
+  assert.equal(plan.batches[0].requests[0].requestKey, "MTRKR4448|01|D");
+  assert.ok(plan.batches.every((batch) => batch.requests.length <= 3));
+});

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -20,6 +20,7 @@ const OBSERVED_FIELDS = [
 ];
 const DAILY_TYPE_CODES = new Set(["01", "02", "03"]);
 const UP_DOWN_CODES = new Set(["U", "D"]);
+const TAGO_SCHEDULE_ENDPOINT = "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList";
 
 function parseArgs(argv) {
   const args = {};
@@ -98,7 +99,7 @@ function validateTagoScheduleSample(rawText) {
   return {
     artifactKind: "tago-schedule-sample-importer-validation",
     candidateId: "molit-tago-subway-info",
-    endpoint: "https://apis.data.go.kr/1613000/SubwayInfo/GetSubwaySttnAcctoSchdulList",
+    endpoint: TAGO_SCHEDULE_ENDPOINT,
     rowCount: rows.length,
     providerRecordHashes,
     rawSha256: sha256(rawText),
@@ -110,6 +111,59 @@ function validateTagoScheduleSample(rawText) {
     productionCanonicalStopTimesStatus: "blocked_requires_trip_stop_sequence",
     plannedEtaUseAllowed: false,
   };
+}
+
+function buildTagoScheduleCollectionPlan(input, checkpoint = {}, dailyLimit = 1000) {
+  if (!Number.isInteger(dailyLimit) || dailyLimit <= 0) {
+    throw new Error("dailyLimit must be a positive integer");
+  }
+  const completed = new Set(checkpoint.completedRequestKeys ?? []);
+  const allRequests = tagoStationIds(input).flatMap((stationId) =>
+    [...DAILY_TYPE_CODES].flatMap((dailyTypeCode) =>
+      [...UP_DOWN_CODES].map((upDownTypeCode) => {
+        const requestKey = `${stationId}|${dailyTypeCode}|${upDownTypeCode}`;
+        return {
+          requestKey,
+          stationId,
+          dailyTypeCode,
+          upDownTypeCode,
+          url: `${TAGO_SCHEDULE_ENDPOINT}?serviceKey=[서비스키값]&pageNo=1&numOfRows=1000&_type=json&subwayStationId=${stationId}&dailyTypeCode=${dailyTypeCode}&upDownTypeCode=${upDownTypeCode}`,
+        };
+      }),
+    ),
+  );
+  const pending = allRequests.filter((request) => !completed.has(request.requestKey));
+  return {
+    artifactKind: "tago-schedule-collection-plan",
+    sourceId: "molit-tago-subway-info",
+    endpoint: TAGO_SCHEDULE_ENDPOINT,
+    dailyLimit,
+    totalRequestCount: allRequests.length,
+    completedRequestCount: allRequests.length - pending.length,
+    pendingRequestCount: pending.length,
+    batches: chunk(pending, dailyLimit).map((requests, index) => ({ batchNumber: index + 1, requests })),
+  };
+}
+
+function tagoStationIds(input) {
+  const stationIds = new Set();
+  for (const row of input.stationLineRows ?? []) {
+    if (!row.stationCode) continue;
+    // ponytail: pilot line 4 mapping; use explicit provider station ids before nationwide collection.
+    stationIds.add(row.stationCode.startsWith("MTRKR") ? row.stationCode : `MTRKR4${row.stationCode}`);
+  }
+  if (stationIds.size === 0) {
+    throw new Error("stationLineRows must contain at least one stationCode");
+  }
+  return [...stationIds];
+}
+
+function chunk(items, size) {
+  const chunks = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
 }
 
 function normalizeRows(value) {
@@ -177,7 +231,7 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-export { validateTagoScheduleSample };
+export { buildTagoScheduleCollectionPlan, validateTagoScheduleSample };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error) => {

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -149,8 +149,15 @@ function tagoStationIds(input) {
   const stationIds = new Set();
   for (const row of input.stationLineRows ?? []) {
     if (!row.stationCode) continue;
-    // ponytail: pilot line 4 mapping; use explicit provider station ids before nationwide collection.
-    stationIds.add(row.stationCode.startsWith("MTRKR") ? row.stationCode : `MTRKR4${row.stationCode}`);
+    // TODO: pilot line 4 mapping only; replace with explicit provider station ids before nationwide collection.
+    if (row.stationCode.startsWith("MTRKR")) {
+      stationIds.add(row.stationCode);
+      continue;
+    }
+    if (row.lineId !== "seoul-4") {
+      throw new Error(`Unsupported lineId for pilot mapping: ${row.lineId}`);
+    }
+    stationIds.add(`MTRKR4${row.stationCode}`);
   }
   if (stationIds.size === 0) {
     throw new Error("stationLineRows must contain at least one stationCode");


### PR DESCRIPTION
## 관련 이슈

Refs #1415

## 작업 배경

- TAGO 시간표 production 적재 전 `DATA_GO_KR_SERVICE_KEY` 운영계정 전환과 일 한도 내 분할 수집 계획이 필요합니다.
- 현재 source admission은 quota가 `productionUseAllowed: false`라서 stop_times production 적재를 우회하지 않고, 수집 plan부터 검증 가능하게 고정합니다.

## 작업 내용

- 기존 TAGO sample validator에 역별 시간표 수집 요청 plan 생성 함수를 추가했습니다.
- `dailyLimit` 기준 batch 분할과 `completedRequestKeys` checkpoint resume을 검증합니다.
- pilot line 4 station code mapping은 `lineId === "seoul-4"`일 때만 허용하고, 그 외 노선은 잘못된 provider ID를 만들지 않도록 실패시킵니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/plan-tago-schedule-collection.test.mjs` 성공
  - `node --input-type=module -e "import { readFile, writeFile } from 'node:fs/promises'; import { buildTagoScheduleCollectionPlan } from './tools/datapack/validate-tago-schedule-sample.mjs'; const input=JSON.parse(await readFile('tools/datapack/inputs/capital-pilot-production-source-input.json','utf8')); await writeFile('/tmp/easysubway-tago-plan.json', JSON.stringify(buildTagoScheduleCollectionPlan(input, {}, 1000), null, 2)+'\n');"` 성공
  - `node --test tools/datapack/*.test.mjs` 성공 (186 tests)
  - `node --test tools/ci/repository-contract.test.mjs` 성공 (158 tests)
  - `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| TAGO 수집 plan | local | pilot input으로 plan 생성 | `/tmp/easysubway-tago-plan.json` | PASS |
| 자동화 테스트 | local | datapack/repository contract test | 터미널 출력 | PASS |
| PR CI | GitHub Actions | latest head `ad09fdc4` checks 확인 | PR #1633 checks | PASS |
| CodeRabbit review | GitHub PR Review | latest head `ad09fdc4` PR Review 객체와 resolved thread 확인 | CodeRabbit review thread `PRRT_kwDOS4Iqac6OTR5R` | PASS |
| UI/접근성 | 해당 없음 | CLI 도구만 변경 | 증거 불필요: 화면 변경 없음 | N/A |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `tools/datapack/validate-tago-schedule-sample.mjs`
  - `tools/datapack/plan-tago-schedule-collection.test.mjs`

## 리스크

- 실제 provider fetcher가 아니라 plan 생성 도구입니다. 운영계정 전환 후 live fetcher/adapter에서 이 request plan을 소비해야 합니다.
- pilot line 4 station code mapping만 지원합니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다. (해당 없음: latest head `ad09fdc4`에 CodeRabbit PR Review 객체 있음)
- [x] 배포 영향이 있는 경우 CD 상태를 확인했다. (해당 없음: CLI plan/test 변경, 배포 영향 없음)
