### PR TITLE
[Chore] V2 planner 시간표 guard 보강

### DIFF
--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -25,9 +25,10 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 
 	private final RouteSearchUseCase routeSearchUseCase;
 	private final LoadRouteTimetablePort routeTimetablePort;
+	private final boolean timetableRequired;
 
 	public RouteV2Planner(RouteSearchUseCase routeSearchUseCase) {
-		this(routeSearchUseCase, RouteTimetable::empty);
+		this(routeSearchUseCase, RouteTimetable::empty, false);
 	}
 
 	@Autowired
@@ -35,19 +36,28 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 		RouteSearchUseCase routeSearchUseCase,
 		ObjectProvider<LoadRouteTimetablePort> routeTimetablePortProvider
 	) {
-		this(routeSearchUseCase, routeTimetablePortProvider.getIfAvailable(() -> RouteTimetable::empty));
+		this(routeSearchUseCase, routeTimetablePortProvider.getIfAvailable(), true);
 	}
 
 	RouteV2Planner(RouteSearchUseCase routeSearchUseCase, LoadRouteTimetablePort routeTimetablePort) {
+		this(routeSearchUseCase, routeTimetablePort, true);
+	}
+
+	private RouteV2Planner(
+		RouteSearchUseCase routeSearchUseCase,
+		LoadRouteTimetablePort routeTimetablePort,
+		boolean timetableRequired
+	) {
 		this.routeSearchUseCase = routeSearchUseCase;
-		this.routeTimetablePort = routeTimetablePort;
+		this.routeTimetablePort = routeTimetablePort == null ? RouteTimetable::empty : routeTimetablePort;
+		this.timetableRequired = timetableRequired && routeTimetablePort != null;
 	}
 
 	@Override
 	public RouteV2Plan search(SearchRouteV2Command command) {
 		try {
 			RouteTimetable timetable = routeTimetablePort.loadRouteTimetable();
-			if (timetable.transitTrips().isEmpty() || timetable.transitStopTimes().isEmpty()) {
+			if (timetableRequired && (timetable.transitTrips().isEmpty() || timetable.transitStopTimes().isEmpty())) {
 				return new RouteV2Plan(List.of(), List.of(RouteV2Status.NO_TIMETABLE_SERVICE), PLANNER_ADR);
 			}
 			SearchRouteCommand searchRouteCommand = toSearchRouteCommand(command);

--- a/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
+++ b/backend/src/main/java/com/easysubway/route/application/service/RouteV2Planner.java
@@ -46,7 +46,10 @@ public class RouteV2Planner implements RouteV2SearchUseCase {
 	@Override
 	public RouteV2Plan search(SearchRouteV2Command command) {
 		try {
-			routeTimetablePort.loadRouteTimetable();
+			RouteTimetable timetable = routeTimetablePort.loadRouteTimetable();
+			if (timetable.transitTrips().isEmpty() || timetable.transitStopTimes().isEmpty()) {
+				return new RouteV2Plan(List.of(), List.of(RouteV2Status.NO_TIMETABLE_SERVICE), PLANNER_ADR);
+			}
 			SearchRouteCommand searchRouteCommand = toSearchRouteCommand(command);
 			List<RouteSearchResult> itineraries = routeSearchUseCase.searchRouteAlternatives(
 				searchRouteCommand,

--- a/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
+++ b/backend/src/test/java/com/easysubway/route/adapter/in/web/RouteSearchV2ControllerTest.java
@@ -11,24 +11,28 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.easysubway.profile.domain.MobilityType;
 import com.easysubway.route.application.port.in.RouteSearchUseCase;
+import com.easysubway.route.application.port.out.LoadRouteTimetablePort;
 import com.easysubway.route.domain.EtaConfidence;
 import com.easysubway.route.domain.EtaSource;
+import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.RouteRefreshResult;
 import com.easysubway.route.domain.RouteRefreshStatus;
-import com.easysubway.route.domain.ConstraintMode;
 import com.easysubway.route.domain.RouteNotFoundException;
 import com.easysubway.route.domain.RouteSearchResult;
 import com.easysubway.route.domain.RouteSearchStatus;
 import com.easysubway.route.domain.RouteStep;
 import com.easysubway.route.domain.RouteWarning;
 import com.easysubway.route.domain.RouteWarningCode;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -46,6 +50,70 @@ class RouteSearchV2ControllerTest {
 
 	@MockitoBean
 	private RouteSearchUseCase routeSearchUseCase;
+
+	@TestConfiguration
+	static class RouteTimetableTestConfiguration {
+
+		@Bean
+		LoadRouteTimetablePort routeTimetablePort() {
+			return () -> new LoadRouteTimetablePort.RouteTimetable(
+				List.of(new LoadRouteTimetablePort.ServiceCalendar(
+					"weekday-2026",
+					true,
+					true,
+					true,
+					true,
+					true,
+					false,
+					false,
+					LocalDate.parse("2026-07-01"),
+					LocalDate.parse("2026-12-31"),
+					"Asia/Seoul"
+				)),
+				List.of(),
+				List.of(new LoadRouteTimetablePort.TransitRoute(
+					"route-seoul-4",
+					"seoul-4",
+					"4",
+					"수도권 4호선",
+					"사당 방면",
+					"Asia/Seoul"
+				)),
+				List.of(new LoadRouteTimetablePort.TransitTrip(
+					"trip-seoul-4-0900",
+					"route-seoul-4",
+					"weekday-2026",
+					"사당",
+					"0",
+					"LOCAL",
+					0
+				)),
+				List.of(
+					new LoadRouteTimetablePort.TransitStopTime(
+						"trip-seoul-4-0900",
+						1,
+						"station-sangnoksu",
+						"seoul-4",
+						32400,
+						32400,
+						0,
+						0
+					),
+					new LoadRouteTimetablePort.TransitStopTime(
+						"trip-seoul-4-0900",
+						2,
+						"station-sadang",
+						"seoul-4",
+						33000,
+						33000,
+						0,
+						0
+					)
+				),
+				List.of()
+			);
+		}
+	}
 
 	@Test
 	@DisplayName("모바일 V2 계약으로 itinerary와 leg 단위 ETA 필드를 반환한다")

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -782,6 +782,19 @@ class RouteSearchServiceTest {
 	}
 
 	@Test
+	@DisplayName("V2 planner는 시간표 adapter 미연결 fallback에서는 기존 경로 검색을 유지한다")
+	void routeV2PlannerKeepsLegacySearchWhenTimetableAdapterMissing() {
+		var repository = new InMemoryRouteSearchRepository();
+		var routeSearchService = new RouteSearchService(repository, repository, new RampAccessibleTransitMasterPort(), CLOCK);
+		var planner = new RouteV2Planner(routeSearchService);
+
+		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
+
+		assertThat(plan.statuses()).containsExactly(RouteV2Status.FOUND);
+		assertThat(plan.itineraries()).hasSize(1);
+	}
+
+	@Test
 	@DisplayName("V2 planner는 접근성 차단 경로를 BLOCKED_ACCESSIBILITY status로 반환한다")
 	void routeV2PlannerReturnsBlockedAccessibilityStatus() {
 		var planner = routeV2Planner(new StairOnlyTransitMasterPort());

--- a/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
+++ b/backend/src/test/java/com/easysubway/route/application/service/RouteSearchServiceTest.java
@@ -11,6 +11,7 @@ import com.easysubway.route.application.port.in.SearchRouteCommand;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase;
 import com.easysubway.route.application.port.in.RouteV2SearchUseCase.RouteV2Status;
 import com.easysubway.route.application.port.in.SubmitRouteFeedbackCommand;
+import com.easysubway.route.application.port.out.LoadRouteTimetablePort;
 import com.easysubway.route.application.port.out.RealtimeArrivalResolver;
 import com.easysubway.route.domain.ArrivalCandidate;
 import com.easysubway.route.domain.ArrivalFreshness;
@@ -770,7 +771,9 @@ class RouteSearchServiceTest {
 	@Test
 	@DisplayName("V2 planner는 시간표 서비스가 없으면 NO_TIMETABLE_SERVICE status를 반환한다")
 	void routeV2PlannerReturnsNoTimetableServiceStatus() {
-		var planner = routeV2Planner(new TwoTransferTransitMasterPort());
+		var repository = new InMemoryRouteSearchRepository();
+		var routeSearchService = new RouteSearchService(repository, repository, new RampAccessibleTransitMasterPort(), CLOCK);
+		var planner = new RouteV2Planner(routeSearchService, LoadRouteTimetablePort.RouteTimetable::empty);
 
 		var plan = planner.search(routeV2Command(ConstraintMode.PREFER_STEP_FREE, MobilityType.SENIOR, 1, 3));
 
@@ -802,7 +805,7 @@ class RouteSearchServiceTest {
 			CLOCK,
 			resolver
 		);
-		var planner = new RouteV2Planner(routeSearchService);
+		var planner = new RouteV2Planner(routeSearchService, routeTimetablePort());
 
 		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
 			"station-a",
@@ -848,7 +851,7 @@ class RouteSearchServiceTest {
 			CLOCK,
 			resolver
 		);
-		var planner = new RouteV2Planner(routeSearchService);
+		var planner = new RouteV2Planner(routeSearchService, routeTimetablePort());
 
 		var plan = planner.search(new RouteV2Planner.SearchRouteV2Command(
 			"station-a",
@@ -890,7 +893,7 @@ class RouteSearchServiceTest {
 			CLOCK,
 			resolver
 		);
-		var planner = new RouteV2Planner(routeSearchService);
+		var planner = new RouteV2Planner(routeSearchService, routeTimetablePort());
 
 		var plan = planner.search(new RouteV2Planner.SearchRouteV2Command(
 			"station-a",
@@ -932,7 +935,7 @@ class RouteSearchServiceTest {
 			CLOCK,
 			resolver
 		);
-		var planner = new RouteV2Planner(routeSearchService);
+		var planner = new RouteV2Planner(routeSearchService, routeTimetablePort());
 
 		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
 			"station-a",
@@ -967,7 +970,7 @@ class RouteSearchServiceTest {
 				List.of()
 			)
 		);
-		var planner = new RouteV2Planner(routeSearchService);
+		var planner = new RouteV2Planner(routeSearchService, routeTimetablePort());
 
 		var plan = planner.search(new RouteV2SearchUseCase.SearchRouteV2Command(
 			"station-a",
@@ -1692,7 +1695,48 @@ class RouteSearchServiceTest {
 
 	private static RouteV2Planner routeV2Planner(LoadTransitMasterPort transitMasterPort) {
 		var repository = new InMemoryRouteSearchRepository();
-		return new RouteV2Planner(new RouteSearchService(repository, repository, transitMasterPort, CLOCK));
+		return new RouteV2Planner(new RouteSearchService(repository, repository, transitMasterPort, CLOCK), routeTimetablePort());
+	}
+
+	private static LoadRouteTimetablePort routeTimetablePort() {
+		return () -> new LoadRouteTimetablePort.RouteTimetable(
+			List.of(new LoadRouteTimetablePort.ServiceCalendar(
+				"weekday-2026",
+				true,
+				true,
+				true,
+				true,
+				true,
+				false,
+				false,
+				LocalDate.parse("2026-07-01"),
+				LocalDate.parse("2026-12-31"),
+				"Asia/Seoul"
+			)),
+			List.of(),
+			List.of(new LoadRouteTimetablePort.TransitRoute(
+				"route-seoul-4",
+				"seoul-4",
+				"4",
+				"수도권 4호선",
+				"사당 방면",
+				"Asia/Seoul"
+			)),
+			List.of(new LoadRouteTimetablePort.TransitTrip(
+				"trip-seoul-4-0900",
+				"route-seoul-4",
+				"weekday-2026",
+				"사당",
+				"0",
+				"LOCAL",
+				0
+			)),
+			List.of(
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0900", 1, "station-a", "seoul-4", 32400, 32400, 0, 0),
+				new LoadRouteTimetablePort.TransitStopTime("trip-seoul-4-0900", 2, "station-b", "seoul-4", 33000, 33000, 0, 0)
+			),
+			List.of()
+		);
 	}
 
 	private static RouteV2SearchUseCase.SearchRouteV2Command routeV2Command(

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -9441,7 +9441,9 @@ test("V2 경로 검색은 production planner 경계를 통해 요청 조건을 �
   assert.match(planner, /class RouteV2Planner implements RouteV2SearchUseCase/);
   assert.match(planner, /LoadRouteTimetablePort/);
   assert.match(planner, /ObjectProvider<LoadRouteTimetablePort>/);
-  assert.match(planner, /getIfAvailable\(\(\) -> RouteTimetable::empty\)/);
+  assert.match(planner, /getIfAvailable\(\)/);
+  assert.match(planner, /timetableRequired && routeTimetablePort != null/);
+  assert.match(planner, /timetableRequired && \(timetable\.transitTrips\(\)\.isEmpty\(\) \|\| timetable\.transitStopTimes\(\)\.isEmpty\(\)\)/);
   assert.match(planner, /loadRouteTimetable\(\)/);
   assert.match(planner, /searchRouteAlternatives/);
   assert.match(planner, /statusesOf/);


### PR DESCRIPTION
## 관련 이슈

Refs #1620

## 작업 배경

- #1620의 전체 RAPTOR production 승격 전, 실제 timetable adapter가 주입된 환경에서는 시간표 row 없이 기존 graph 기반 추정으로 우회하지 않도록 닫습니다.
- 현재 main source에는 `LoadRouteTimetablePort` 구현 bean이 없으므로, no-adapter fallback은 기존 V2 route search 위임을 유지합니다.
- #1415의 production 시간표 적재는 TAGO 운영 quota가 `productionUseAllowed: false`인 외부 blocker라 이번 PR에서 우회하지 않습니다.

## 작업 내용

- `RouteV2Planner`가 실제 timetable port를 주입받은 경우 `transit_trips` 또는 `transit_stop_times`가 비어 있으면 `NO_TIMETABLE_SERVICE`와 빈 itinerary를 반환하도록 guard를 추가했습니다.
- timetable adapter 미연결 fallback에서는 기존 `RouteSearchUseCase` 위임을 유지하도록 분리했습니다.
- 기존 V2 planner/controller 테스트가 의도한 경로 검색까지 도달하도록 테스트용 timetable port를 명시했습니다.
- repository contract가 optional timetable port와 no-adapter fallback 경계를 고정하도록 갱신했습니다.

## 검증

- 실행한 명령과 결과:
  - `./gradlew test --tests 'com.easysubway.route.application.service.RouteSearchServiceTest.routeV2PlannerReturnsNoTimetableServiceStatus'` 실패 확인 후 구현
  - `./gradlew test --tests 'com.easysubway.route.application.service.RouteSearchServiceTest.routeV2Planner*' --tests 'com.easysubway.route.adapter.in.web.RouteSearchV2ControllerTest'` 성공
  - `./gradlew test` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공, 158 passed
  - `git diff --check` 성공
  - PR #1634 CI/Release Artifacts/SonarCloud/CodeRabbit status 성공
  - Codex CLI fallback review: 현재 head `c23f794982d147c302ae1ebb7e3e6dd85bcc4368` 기준 actionable 0건

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| V2 planner 시간표 guard | backend | Gradle targeted/full tests | 로컬 터미널 출력, PR checks | 성공 |
| repository contract | repository | node test | 로컬 터미널 출력, PR checks | 성공 |
| code review | GitHub PR | Codex CLI fallback review | PR review 객체 | actionable 0건 |
| UI/접근성 수동 QA | 해당 없음 | backend planner guard 변경이라 화면 변경 없음 | 증거 불필요 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [x] route-release-readiness-tracker.json 영향 없음
- [ ] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 실제 timetable port 주입 환경에서 시간표 row 부재 시 `NO_TIMETABLE_SERVICE` fail-closed 동작 보강
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `RouteV2Planner.search()`의 `timetableRequired` guard와 no-adapter fallback 회귀 테스트

## 리스크

- 실제 timetable adapter가 주입된 환경에서 production 시간표 row가 아직 적재되지 않으면 V2 search가 빈 itinerary로 닫힙니다. 이는 #1620/#1415 범위의 의도된 fail-closed 동작입니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [x] CI 결과를 확인했다.
- [x] CodeRabbit 리뷰를 확인했다.
- [x] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [x] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
