### PR TITLE
[Chore] 구조화 노선도 스키마 계약 고정

### DIFF
--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -36,6 +36,10 @@ test("structured route map contract pins nationwide vector-rendered layers", asy
     contract.layers.map((layer) => layer.id),
     ["line_geometry", "station_nodes", "transfer_groups", "station_labels"],
   );
+  assert.deepEqual(
+    contract.layers.find((layer) => layer.id === "line_geometry").requiredFields,
+    ["station_id", "line_id", "region", "x", "y", "up_path", "down_path"],
+  );
   assert.equal(
     contract.layers.find((layer) => layer.id === "station_nodes").featureId,
     "{region}:{station_id}:{line_id}",
@@ -43,6 +47,10 @@ test("structured route map contract pins nationwide vector-rendered layers", asy
   assert.deepEqual(
     contract.layers.find((layer) => layer.id === "station_labels").priority,
     ["transfer", "major", "regular"],
+  );
+  assert.equal(
+    contract.layers.find((layer) => layer.id === "station_labels").majorRule,
+    "환승역이 아니어도 지역별 공식 노선도에서 주요 거점으로 별도 검수된 역을 major로 둔다. 별도 검수값이 없으면 regular다.",
   );
   assert.equal(
     contract.layers.find((layer) => layer.id === "station_labels").renderRule,
@@ -53,8 +61,13 @@ test("structured route map contract pins nationwide vector-rendered layers", asy
     "지역별 datapack의 route_map_positions를 우선한다.",
   );
 
+  const routeMapPositionsTable = schema.match(
+    /CREATE TABLE route_map_positions \(([\s\S]*?)\);/,
+  );
+  assert.ok(routeMapPositionsTable, "route_map_positions table definition not found");
+  const routeMapPositionsDdl = routeMapPositionsTable[1];
   for (const column of contract.routeMapPositionsColumns) {
-    assert.match(schema, new RegExp(`\\b${column}\\b`));
+    assert.match(routeMapPositionsDdl, new RegExp(`\\b${column}\\b`));
   }
   assert.ok(fixture.packs[0].requiredTables.includes("route_map_positions"));
   assert.ok(fixture.packs[0].minimumTableRows.route_map_positions > 0);

--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -10,6 +10,56 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 const root = path.resolve(import.meta.dirname, "../..");
 
+test("structured route map contract pins nationwide vector-rendered layers", async () => {
+  const contract = JSON.parse(
+    await readFile(
+      path.join(root, "tools/route-map/structured-route-map-contract.json"),
+      "utf8",
+    ),
+  );
+  const schema = await readFile(
+    path.join(root, "tools/datapack/schema/catalog-schema.sql"),
+    "utf8",
+  );
+  const fixture = JSON.parse(
+    await readFile(
+      path.join(root, "tools/datapack/fixtures/catalog-fixture.json"),
+      "utf8",
+    ),
+  );
+
+  assert.equal(contract.schemaVersion, 1);
+  assert.equal(contract.artifactKind, "structured-route-map-contract");
+  assert.deepEqual(contract.regions, ["수도권", "부산", "대구", "광주", "대전"]);
+  assert.equal(contract.releaseGate.wholePdfOrSvgZoomRendererAllowed, false);
+  assert.deepEqual(
+    contract.layers.map((layer) => layer.id),
+    ["line_geometry", "station_nodes", "transfer_groups", "station_labels"],
+  );
+  assert.equal(
+    contract.layers.find((layer) => layer.id === "station_nodes").featureId,
+    "{region}:{station_id}:{line_id}",
+  );
+  assert.deepEqual(
+    contract.layers.find((layer) => layer.id === "station_labels").priority,
+    ["transfer", "major", "regular"],
+  );
+  assert.equal(
+    contract.layers.find((layer) => layer.id === "station_labels").renderRule,
+    "데이터에는 역명을 보관하되 화면에는 zoom과 collision 결과로 필요한 라벨만 그린다.",
+  );
+  assert.equal(
+    contract.packSourceOfTruth.routeMapRegionPack,
+    "지역별 datapack의 route_map_positions를 우선한다.",
+  );
+
+  for (const column of contract.routeMapPositionsColumns) {
+    assert.match(schema, new RegExp(`\\b${column}\\b`));
+  }
+  assert.ok(fixture.packs[0].requiredTables.includes("route_map_positions"));
+  assert.ok(fixture.packs[0].minimumTableRows.route_map_positions > 0);
+});
+
 test("SVG geometry extractor returns transformed visible text polygons", async () => {
   const fixture = "tools/route-map/fixtures/geometry-fixture.svg";
   const { stdout } = await execFileAsync(

--- a/tools/route-map/structured-route-map-contract.json
+++ b/tools/route-map/structured-route-map-contract.json
@@ -7,7 +7,7 @@
     {
       "id": "line_geometry",
       "source": ["network_edges", "route_map_positions.up_path", "route_map_positions.down_path"],
-      "requiredFields": ["station_id", "line_id", "region", "x", "y"],
+      "requiredFields": ["station_id", "line_id", "region", "x", "y", "up_path", "down_path"],
       "lod": [
         { "minZoom": 0, "visible": true, "labelPolicy": "hide_station_labels" },
         { "minZoom": 1, "visible": true, "labelPolicy": "major_transfer_labels" },
@@ -32,6 +32,7 @@
       "source": ["stations", "route_map_positions.label_dx", "route_map_positions.label_dy", "route_map_positions.label_polygon"],
       "requiredFields": ["station_id", "line_id", "region", "label_dx", "label_dy"],
       "priority": ["transfer", "major", "regular"],
+      "majorRule": "환승역이 아니어도 지역별 공식 노선도에서 주요 거점으로 별도 검수된 역을 major로 둔다. 별도 검수값이 없으면 regular다.",
       "collisionField": "label_polygon",
       "renderRule": "데이터에는 역명을 보관하되 화면에는 zoom과 collision 결과로 필요한 라벨만 그린다."
     }

--- a/tools/route-map/structured-route-map-contract.json
+++ b/tools/route-map/structured-route-map-contract.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "artifactKind": "structured-route-map-contract",
+  "goal": "전국 도시철도 노선도를 PDF/SVG 전체 확대가 아니라 구조화 데이터와 클라이언트 렌더링으로 표시한다.",
+  "regions": ["수도권", "부산", "대구", "광주", "대전"],
+  "layers": [
+    {
+      "id": "line_geometry",
+      "source": ["network_edges", "route_map_positions.up_path", "route_map_positions.down_path"],
+      "requiredFields": ["station_id", "line_id", "region", "x", "y"],
+      "lod": [
+        { "minZoom": 0, "visible": true, "labelPolicy": "hide_station_labels" },
+        { "minZoom": 1, "visible": true, "labelPolicy": "major_transfer_labels" },
+        { "minZoom": 2, "visible": true, "labelPolicy": "collision_checked_station_labels" }
+      ]
+    },
+    {
+      "id": "station_nodes",
+      "source": ["route_map_positions", "station_lines", "stations", "lines"],
+      "requiredFields": ["station_id", "line_id", "region", "x", "y"],
+      "featureId": "{region}:{station_id}:{line_id}",
+      "nodeKinds": ["regular", "transfer"]
+    },
+    {
+      "id": "transfer_groups",
+      "source": ["stations", "station_lines", "route_map_positions"],
+      "featureId": "{region}:{station_id}",
+      "deriveRule": "같은 station_id에 여러 line_id가 있으면 환승 그룹으로 묶고, 표시 좌표는 해당 station_id의 route_map_positions 중심값을 쓴다."
+    },
+    {
+      "id": "station_labels",
+      "source": ["stations", "route_map_positions.label_dx", "route_map_positions.label_dy", "route_map_positions.label_polygon"],
+      "requiredFields": ["station_id", "line_id", "region", "label_dx", "label_dy"],
+      "priority": ["transfer", "major", "regular"],
+      "collisionField": "label_polygon",
+      "renderRule": "데이터에는 역명을 보관하되 화면에는 zoom과 collision 결과로 필요한 라벨만 그린다."
+    }
+  ],
+  "packSourceOfTruth": {
+    "routeMapRegionPack": "지역별 datapack의 route_map_positions를 우선한다.",
+    "corePack": "core pack은 앱 부팅용 최소 데이터만 보유하고, 지역 노선도 좌표의 source of truth가 아니다."
+  },
+  "routeMapPositionsColumns": [
+    "station_id",
+    "line_id",
+    "region",
+    "x",
+    "y",
+    "label_dx",
+    "label_dy",
+    "label_polygon",
+    "up_path",
+    "down_path",
+    "source_id",
+    "source_name",
+    "source_url",
+    "license",
+    "license_status",
+    "commercial_use_allowed",
+    "attribution_required",
+    "reviewed_at",
+    "updated_at"
+  ],
+  "releaseGate": {
+    "allRegionsRequired": true,
+    "officialOrReviewedSourceRequired": true,
+    "commercialUseMustBeResolvedBeforeProduction": true,
+    "wholePdfOrSvgZoomRendererAllowed": false
+  }
+}


### PR DESCRIPTION
## Summary
- 전국 노선도 구조화 렌더링 계약을 JSON으로 고정했습니다.
- line/station/transfer/label layer, LOD 라벨 정책, feature id, 지역별 datapack source-of-truth 규칙을 명시했습니다.
- 계약이 SQL schema와 fixture에서 벗어나면 실패하는 route-map 도구 테스트를 추가했습니다.

## Test Plan
- [x] node --test tools/route-map/route-map-tools.test.mjs

Refs #1636
Parent #1635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 도시철도 노선도 제공 방식에 대한 구조화된 계약이 추가되어, 지역별 노선도 렌더링 기준과 지원 범위가 명확해졌습니다.
  * 노선, 정거장, 환승, 라벨 표시 규칙과 출시 조건이 함께 정의되어 일관된 노선도 표시를 지원합니다.

* **Tests**
  * 계약 파일, 데이터 컬럼, 필수 행 수 등 노선도 관련 핵심 조건을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->