### PR TITLE
[Chore] Exclude summary RIDE edges from production pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Production Routing Graph
 
-- Production LOCAL `RIDE` edge는 같은 노선의 인접 `lineSequence`만 연결합니다. 비인접 요약 edge는 regression fixture 또는 공식 정차 패턴이 있는 `EXPRESS` 근거로만 둡니다. pilot summary edge가 임시 pack에 남아 있으면 `route-graph-topology-report`의 release-blocking `nonAdjacentExpressRide` violation으로 기록하고 ETA 근거로 쓰지 않습니다. Production ingest는 이런 edge가 있을 때 `routeGraphTopologyPolicy.summaryRideEdges=release-blocking-regression-only`와 edge id 목록을 요구합니다.
+- Production LOCAL `RIDE` edge는 같은 노선의 인접 `lineSequence`만 연결합니다. 비인접 요약 edge는 regression fixture 전용이며 production pack에서 제외합니다. 공식 정차 패턴이 검증된 `EXPRESS` edge를 추가하기 전까지 pilot summary edge를 `route-graph-topology-report`의 release-blocking `nonAdjacentExpressRide` violation 또는 ETA 근거로 쓰지 않습니다.
 - 기본 route node는 station-line(`stationId:lineId`)입니다. platform node는 공식 platform/source가 admission되기 전까지 만들지 않고, 방향 문구는 `platformInfo`에만 둡니다.
 - 표시용 SVG asset은 앱 지도 표시용입니다. canonical route map position은 `routeMapPositions`의 source, license, `sourceSha256`, `reviewedAt`, `updatedAt`, label polygon으로만 판정합니다.
 - 앱의 `데이터 및 지도 출처` 화면은 source inventory와 manifest를 보여주는 사용자 연결점입니다. Level 4 또는 전국 claim은 #1397 source admission과 #1400 인접역 graph/position 확장 증거가 닫힐 때까지 NO-GO입니다.

--- a/apps/mobile/lib/core/datapack/data_pack_manifest.dart
+++ b/apps/mobile/lib/core/datapack/data_pack_manifest.dart
@@ -884,9 +884,10 @@ _parseRepresentativeRouteRegressions(
   if (rawRoutes == null && artifactKind == DataPackArtifactKind.fixture) {
     return const [];
   }
-  if (rawRoutes is! List<Object?> || rawRoutes.isEmpty) {
+  if (rawRoutes is! List<Object?>) {
     throw const FormatException('Invalid representative route regressions.');
   }
+  if (rawRoutes.isEmpty) return const [];
   final routes = rawRoutes
       .map((route) {
         if (route is! Map<String, Object?>) {

--- a/apps/mobile/release/production-datapack-scope.json
+++ b/apps/mobile/release/production-datapack-scope.json
@@ -69,7 +69,7 @@
     "p0DefinitionKo": "지원한다고 표시한 역, 노선, 시설, ENTRY/EXIT/TRANSFER/route edge 누락 또는 앱/Play listing 지원 범위와 모순되는 P1/P2 gap",
     "p1p2PolicyKo": "P1/P2 gap은 evidence와 support copy에 기록하되 지원 claim을 깨면 P0로 승격한다.",
     "routeSafetyRequired": true,
-    "representativeRouteRegressionsRequired": true,
+    "representativeRouteRegressionsRequired": false,
     "strictMobilityProfile": {
       "staleUnknownGeneratedConnectorCannotProduceFound": true,
       "policyKo": "wheelchair/stroller strict profile에서 stale, unknown, generated connector edge는 FOUND 경로를 만들 수 없다."

--- a/apps/mobile/test/core/datapack/data_pack_manifest_test.dart
+++ b/apps/mobile/test/core/datapack/data_pack_manifest_test.dart
@@ -525,6 +525,24 @@ void main() {
     expect(pack.representativeRouteRegressionSignature.value, '0' * 64);
   });
 
+  test('manifest는 route regression claim이 없으면 빈 회귀 목록을 허용한다', () {
+    final packJson = _fixturePack();
+    packJson['representativeRouteRegressions'] = <Object?>[];
+    packJson['representativeRouteRegressionSignature'] = {
+      'algorithm': 'sha256-route-regression-v1',
+      'value': '0' * 64,
+    };
+
+    final manifest = DataPackManifest.fromJson({
+      'ttlSeconds': 3600,
+      'packs': [packJson],
+    });
+
+    final pack = manifest.packs.single;
+    expect(pack.artifactKind, DataPackArtifactKind.fixture);
+    expect(pack.representativeRouteRegressions, isEmpty);
+  });
+
   test('production key가 설정되면 fixture manifest를 거부한다', () {
     expect(
       () => DataPackManifest.fromJson({

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4763,21 +4763,10 @@ test("Android v1 production 데이터팩 scope는 수도권 pilot 승인 기준�
     productionInput.supportedV1Scope.facilityCoverageDenominator,
     scope.supportScope.facilityCoverageDenominator,
   );
-  assert.deepEqual(productionInput.routeRegressionScope, {
-    mode: "DIRECT_ONLY",
-    excludedPatterns: ["TRANSFER", "MULTI_TRANSFER", "LOOP_BRANCH", "EXPRESS_LOCAL"],
-    claim: productionInput.routeRegressionScope.claim,
-  });
-  assert.match(productionInput.routeRegressionScope.claim, /direct regression only/);
-  assert.deepEqual(productionInput.routeGraphTopologyPolicy, {
-    summaryRideEdges: "release-blocking-regression-only",
-    productionReadinessRequirement: "replace summary RIDE edges with adjacent-station LOCAL RIDE edges before ETA or release-readiness claim",
-    nonAdjacentExpressRideEdgeIds: [
-      "edge-sangnoksu-sadang-seoul-4",
-      "edge-sadang-sangnoksu-seoul-4",
-    ],
-  });
-  assert.deepEqual(productionInput.representativeRouteRegressions.map((route) => route.pattern), ["DIRECT"]);
+  assert.equal(productionInput.routeRegressionScope, undefined);
+  assert.equal(productionInput.routeGraphTopologyPolicy, undefined);
+  assert.deepEqual(productionInput.routeEdges.filter((routeEdge) => routeEdge.edgeType === "RIDE"), []);
+  assert.deepEqual(productionInput.representativeRouteRegressions, []);
   for (const edge of productionInput.routeEdges.filter((routeEdge) => routeEdge.edgeType === "RIDE")) {
     const speedKmh = (edge.distanceMeters / edge.durationSeconds) * 3.6;
     assert.ok(speedKmh >= 15 && speedKmh <= 110, `${edge.id} must stay within production ride speed bounds`);

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4464,6 +4464,10 @@ test("운영 환경 placeholder 계약은 production 데이터팩 URL에서 loca
   assert.match(manifestSchema.$id, /^https:\/\/easysubway\.local\/schema\//);
   assert.deepEqual(manifestSchema.properties.packs.items.properties.payloadKind.enum, ["sqlite_catalog"]);
   assert.equal(
+    manifestSchema.properties.packs.items.properties.representativeRouteRegressions.minItems,
+    0,
+  );
+  assert.equal(
     manifestSchema.properties.packs.items.properties.dependencies.items.$ref,
     "#/$defs/packIdentity",
   );

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -4888,6 +4888,7 @@ test("Android v1 production 데이터팩 scope는 수도권 pilot 승인 기준�
   assert.equal(scope.productionPromotionCriteria.p0CoverageGapPolicy, "fail-release");
   assert.equal(scope.productionPromotionCriteria.minimumProductionCoverageValuesMustBePositive, true);
   assert.equal(scope.productionPromotionCriteria.coverageEvidenceRequired, true);
+  assert.equal(scope.productionPromotionCriteria.representativeRouteRegressionsRequired, false);
   assert.equal(scope.productionPromotionCriteria.manifest.manifestVersion, 2);
   assert.equal(scope.productionPromotionCriteria.manifest.channel, "production");
   assert.equal(scope.productionPromotionCriteria.manifest.releaseSequenceMustIncrease, true);

--- a/tools/datapack/build-datapack.mjs
+++ b/tools/datapack/build-datapack.mjs
@@ -1676,10 +1676,13 @@ function validateTableName(value) {
 }
 
 function validateRepresentativeRouteRegressions(routes, scope = null) {
-  if (!Array.isArray(routes) || routes.length === 0) {
+  const requiredPatterns =
+    !scope && Array.isArray(routes) && routes.length === 0
+      ? new Set()
+      : requiredRepresentativeRoutePatterns(scope);
+  if (!Array.isArray(routes) || (requiredPatterns.size > 0 && routes.length === 0)) {
     throw new Error("pack.representativeRouteRegressions must be a non-empty array");
   }
-  const requiredPatterns = requiredRepresentativeRoutePatterns(scope);
   const seenPatterns = new Set();
   for (const route of routes) {
     requiredString(route.id, "representativeRouteRegressions.id");

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -8142,7 +8142,7 @@ test("공식 source ingest adapter는 production coverage 기준을 manifest 최
     lines: 1,
     stations: 2,
     station_lines: 2,
-    network_edges: 6,
+    network_edges: 4,
     facilities: 6,
     station_facility_evidence: 6,
   });
@@ -8397,7 +8397,7 @@ test("공식 source ingest adapter는 cross-line EXPRESS summary edge도 격리 
   });
   input.routeEdges = [
     {
-      ...input.routeEdges[0],
+      ...productionSummaryRideEdges()[0],
       id: "edge-cross-line-express-summary",
       sourceId: "molit-urban-rail-full-route",
       from: {
@@ -8886,19 +8886,15 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
   assert.equal(input.manifest.releaseSequence, undefined);
   assert.equal(input.manifest.publishedAt, undefined);
   assert.equal(input.manifest.expiresAt, undefined);
-  const adjacencySafeInput = {
-    ...input,
-    routeEdges: input.routeEdges.map((edge) =>
-      edge.edgeType === "RIDE" ? { ...edge, servicePattern: "EXPRESS" } : edge,
-    ),
-  };
+  assert.deepEqual(input.routeEdges.filter((edge) => edge.edgeType === "RIDE"), []);
+  assert.equal(input.routeGraphTopologyPolicy, undefined);
+  const adjacencySafeInput = input;
   const adjacencySafeInputPath = path.join(outputDir, "capital-pilot-production-adjacency-safe.json");
   await writeFile(adjacencySafeInputPath, `${JSON.stringify(adjacencySafeInput, null, 2)}\n`);
 
-  const missingSummaryRidePolicyInput = JSON.parse(JSON.stringify(adjacencySafeInput));
-  delete missingSummaryRidePolicyInput.routeGraphTopologyPolicy;
-  const missingSummaryRidePolicyInputPath = path.join(outputDir, "missing-summary-ride-policy.json");
-  await writeFile(missingSummaryRidePolicyInputPath, `${JSON.stringify(missingSummaryRidePolicyInput, null, 2)}\n`);
+  const summaryRideRegressionInput = withProductionSummaryRideEdges(input);
+  const summaryRideRegressionInputPath = path.join(outputDir, "summary-ride-regression-only.json");
+  await writeFile(summaryRideRegressionInputPath, `${JSON.stringify(summaryRideRegressionInput, null, 2)}\n`);
   await assert.rejects(
     execFileAsync(
       process.execPath,
@@ -8907,20 +8903,19 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
         "--inventory",
         "tools/datapack/source-inventory.json",
         "--input",
-        missingSummaryRidePolicyInputPath,
+        summaryRideRegressionInputPath,
         "--output",
-        path.join(outputDir, "missing-summary-ride-policy-fixture.json"),
+        path.join(outputDir, "summary-ride-regression-only-fixture.json"),
       ],
       { cwd: root },
     ),
-    /routeGraphTopologyPolicy\.summaryRideEdges must mark non-adjacent EXPRESS RIDE edges as release-blocking-regression-only/,
+    /production routeEdges non-adjacent EXPRESS summary edge is regression-only/,
   );
 
-  const lowercaseRideEdgeInput = JSON.parse(JSON.stringify(adjacencySafeInput));
+  const lowercaseRideEdgeInput = JSON.parse(JSON.stringify(withProductionSummaryRideEdges(input)));
   lowercaseRideEdgeInput.routeEdges = lowercaseRideEdgeInput.routeEdges.map((edge) =>
     edge.edgeType === "RIDE" ? { ...edge, edgeType: "ride" } : edge,
   );
-  delete lowercaseRideEdgeInput.routeGraphTopologyPolicy;
   const lowercaseRideEdgeInputPath = path.join(outputDir, "lowercase-ride-summary-policy.json");
   await writeFile(lowercaseRideEdgeInputPath, `${JSON.stringify(lowercaseRideEdgeInput, null, 2)}\n`);
   await assert.rejects(
@@ -8937,7 +8932,7 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
       ],
       { cwd: root },
     ),
-    /routeGraphTopologyPolicy\.summaryRideEdges must mark non-adjacent EXPRESS RIDE edges as release-blocking-regression-only/,
+    /production routeEdges non-adjacent EXPRESS summary edge is regression-only/,
   );
 
   await execFileAsync(
@@ -9025,8 +9020,33 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
   }
 
   const validatorBypassFixture = JSON.parse(JSON.stringify(importedFixture));
-  validatorBypassFixture.packs[0].networkEdges = validatorBypassFixture.packs[0].networkEdges.map((edge) =>
-    edge.edgeType === "RIDE" ? { ...edge, servicePattern: "LOCAL" } : edge,
+  validatorBypassFixture.packs[0].networkEdges.push(
+    ...productionSummaryRideEdges("LOCAL").map((edge) => ({
+      id: edge.id,
+      fromNodeId:
+        edge.from.sourceStationCode === "448"
+          ? "station-sangnoksu:seoul-4:LOCAL"
+          : "station-sadang:seoul-4:LOCAL",
+      toNodeId:
+        edge.to.sourceStationCode === "433"
+          ? "station-sadang:seoul-4:LOCAL"
+          : "station-sangnoksu:seoul-4:LOCAL",
+      durationSeconds: edge.durationSeconds,
+      distanceMeters: edge.distanceMeters,
+      edgeType: edge.edgeType,
+      servicePattern: edge.servicePattern,
+      includesStairs: edge.includesStairs,
+      stairAccessState: edge.stairAccessState,
+      accessibilityStatus: edge.accessibilityStatus,
+      reliabilityScore: edge.reliabilityScore,
+      sourceId: edge.sourceId,
+      sourceSnapshotId: edge.sourceSnapshotId,
+      providerRecordHash: edge.providerRecordHash,
+      provenanceKind: edge.provenanceKind,
+      verificationStatus: edge.verificationStatus,
+      lastVerifiedAt: edge.lastVerifiedAt,
+      evidenceHash: edge.evidenceHash,
+    })),
   );
   const validatorBypassFixturePath = path.join(outputDir, "validator-bypass-local-ride.json");
   const validatorBypassPackDir = path.join(outputDir, "validator-bypass-local-ride-pack");
@@ -9060,9 +9080,7 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
 
   const nonAdjacentInput = {
     ...input,
-    routeEdges: input.routeEdges.map((edge) =>
-      edge.edgeType === "RIDE" ? { ...edge, servicePattern: "LOCAL" } : edge,
-    ),
+    routeEdges: [...productionSummaryRideEdges("LOCAL"), ...input.routeEdges],
   };
   const nonAdjacentInputPath = path.join(outputDir, "non-adjacent-local-ride-input.json");
   const nonAdjacentFixturePath = path.join(outputDir, "non-adjacent-local-ride.json");
@@ -9145,37 +9163,16 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
     /production facility evidence missing: station-sadang:seoul-4:WHEELCHAIR_LIFT/,
   );
 
-  const unrealisticRideSpeedInputPath = path.join(outputDir, "capital-pilot-production-unrealistic-ride-speed.json");
-  await writeFile(
-    unrealisticRideSpeedInputPath,
-    `${JSON.stringify(
-      {
-        ...adjacencySafeInput,
-        routeEdges: adjacencySafeInput.routeEdges.map((edge) =>
-          edge.edgeType === "RIDE"
-            ? { ...edge, durationSeconds: 420 }
-            : edge,
-        ),
-      },
-      null,
-      2,
-    )}\n`,
+  const unrealisticRideSpeedFixture = JSON.parse(JSON.stringify(importedFixture));
+  unrealisticRideSpeedFixture.packs[0].networkEdges.push(
+    ...productionSummaryNetworkEdges("EXPRESS").map((edge) => ({
+      ...edge,
+      durationSeconds: 420,
+    })),
   );
   const unrealisticRideSpeedFixturePath = path.join(outputDir, "unrealistic-ride-speed.json");
   const unrealisticRideSpeedPackDir = path.join(outputDir, "unrealistic-ride-speed-pack");
-  await execFileAsync(
-    process.execPath,
-    [
-      "tools/datapack/import-official-sources.mjs",
-      "--inventory",
-      "tools/datapack/source-inventory.json",
-      "--input",
-      unrealisticRideSpeedInputPath,
-      "--output",
-      unrealisticRideSpeedFixturePath,
-    ],
-    { cwd: root },
-  );
+  await writeFile(unrealisticRideSpeedFixturePath, `${JSON.stringify(unrealisticRideSpeedFixture, null, 2)}\n`);
   await execFileAsync(
     process.execPath,
     [
@@ -9229,10 +9226,10 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
     { cwd: root },
   );
   const routeGraphTopologyReport = JSON.parse(await readFile(routeGraphTopologyReportPath, "utf8"));
-  assert.equal(routeGraphTopologyReport.summary.nonAdjacentExpressRideViolationCount, 2);
+  assert.equal(routeGraphTopologyReport.summary.nonAdjacentExpressRideViolationCount, 0);
   assert.deepEqual(
     routeGraphTopologyReport.packs[0].violations.nonAdjacentExpressRide.map((violation) => violation.edgeId),
-    ["edge-sadang-sangnoksu-seoul-4", "edge-sangnoksu-sadang-seoul-4"],
+    [],
   );
 
   let validationFailure;
@@ -9299,12 +9296,8 @@ test("수도권 pilot production source input은 UNKNOWN strict coverage gap을 
   assert.equal(manifest.signature.algorithm, "rsa-sha256-manifest-v2");
   assert.equal(manifest.packs[0].artifactKind, "production");
   assert.equal(manifest.packs[0].signature.algorithm, "rsa-sha256-pack-manifest-v2");
-  assert.deepEqual(manifest.packs[0].routeRegressionScope, {
-    mode: "DIRECT_ONLY",
-    excludedPatterns: ["TRANSFER", "MULTI_TRANSFER", "LOOP_BRANCH", "EXPRESS_LOCAL"],
-    claim: manifest.packs[0].routeRegressionScope.claim,
-  });
-  assert.deepEqual(manifest.packs[0].representativeRouteRegressions.map((route) => route.pattern), ["DIRECT"]);
+  assert.equal(manifest.packs[0].routeRegressionScope, undefined);
+  assert.deepEqual(manifest.packs[0].representativeRouteRegressions, []);
   const database = new DatabaseSync(path.join(packOutputDir, "catalog", "capital-v1.sqlite"), { readOnly: true });
   try {
     assert.deepEqual(
@@ -10952,15 +10945,6 @@ function productionSourceIngestInput() {
   const input = sourceIngestInput();
   input.pack.artifactKind = "production";
   input.pack.url = "https://datapack.example.com/easysubway/catalog/capital-v1.sqlite.gz";
-  input.routeGraphTopologyPolicy = {
-    summaryRideEdges: "release-blocking-regression-only",
-    productionReadinessRequirement:
-      "replace summary RIDE edges with adjacent-station LOCAL RIDE edges before ETA or release-readiness claim",
-    nonAdjacentExpressRideEdgeIds: [
-      "edge-sangnoksu-sadang-seoul-4",
-      "edge-sadang-sangnoksu-seoul-4",
-    ],
-  };
   input.sourceIds = [
     "molit-urban-rail-full-route",
     "seoulmetro-station-line-info",
@@ -11018,13 +11002,9 @@ function productionSourceIngestInput() {
   input.stationLineRows = input.stationLineRows.filter(
     (row) => row.sourceId !== "seoul-realtime-arrival-station-info",
   );
-  for (const edge of input.routeEdges) {
-    edge.provenanceKind = "OFFICIAL_SOURCE";
-    edge.verificationStatus = "VERIFIED";
-    edge.sourceSnapshotId = `${edge.sourceId}-snapshot-20260621`;
-    edge.providerRecordHash = sha256(`provider:${edge.id}:${edge.sourceId}`);
-    edge.evidenceHash = sha256(`evidence:${edge.id}:${edge.sourceId}:${edge.lastVerifiedAt}`);
-  }
+  input.routeEdges = [];
+  input.representativeRouteRegressions = [];
+  delete input.routeRegressionScope;
   input.facilityRows = [
     [
       "kric-station-elevator",
@@ -11130,7 +11110,7 @@ function productionSourceIngestInput() {
   input.minimumProductionCoverage = {
     stations: 2,
     stationLines: 2,
-    routeEdges: 6,
+    routeEdges: 4,
     facilities: 6,
   };
   input.routeEdges.push(
@@ -11294,6 +11274,63 @@ function productionSourceAccessRouteEdge({ id, sourceStationCode, edgeType, stat
     providerRecordHash: sha256(`provider:${id}:seoulmetro-station-line-info`),
     evidenceHash: sha256(`evidence:${id}:seoulmetro-station-line-info:2026-06-21T00:00:00.000Z`),
   };
+}
+
+function withProductionSummaryRideEdges(input, servicePattern = "EXPRESS") {
+  return {
+    ...input,
+    routeEdges: [...productionSummaryRideEdges(servicePattern), ...input.routeEdges],
+    routeGraphTopologyPolicy: {
+      summaryRideEdges: "release-blocking-regression-only",
+      productionReadinessRequirement:
+        "replace summary RIDE edges with adjacent-station LOCAL RIDE edges before ETA or release-readiness claim",
+      nonAdjacentExpressRideEdgeIds: [
+        "edge-sangnoksu-sadang-seoul-4",
+        "edge-sadang-sangnoksu-seoul-4",
+      ],
+    },
+  };
+}
+
+function productionSummaryRideEdges(servicePattern = "EXPRESS") {
+  return sourceIngestInput().routeEdges.map((edge) => ({
+    ...edge,
+    servicePattern,
+    provenanceKind: "OFFICIAL_SOURCE",
+    verificationStatus: "VERIFIED",
+    sourceSnapshotId: `${edge.sourceId}-snapshot-20260621`,
+    providerRecordHash: sha256(`provider:${edge.id}:${edge.sourceId}`),
+    evidenceHash: sha256(`evidence:${edge.id}:${edge.sourceId}:${edge.lastVerifiedAt}`),
+  }));
+}
+
+function productionSummaryNetworkEdges(servicePattern = "EXPRESS") {
+  return productionSummaryRideEdges(servicePattern).map((edge) => ({
+    id: edge.id,
+    fromNodeId:
+      edge.from.sourceStationCode === "448"
+        ? "station-sangnoksu:seoul-4:LOCAL"
+        : "station-sadang:seoul-4:LOCAL",
+    toNodeId:
+      edge.to.sourceStationCode === "433"
+        ? "station-sadang:seoul-4:LOCAL"
+        : "station-sangnoksu:seoul-4:LOCAL",
+    durationSeconds: edge.durationSeconds,
+    distanceMeters: edge.distanceMeters,
+    edgeType: edge.edgeType,
+    servicePattern: edge.servicePattern,
+    includesStairs: edge.includesStairs,
+    stairAccessState: edge.stairAccessState,
+    accessibilityStatus: edge.accessibilityStatus,
+    reliabilityScore: edge.reliabilityScore,
+    sourceId: edge.sourceId,
+    sourceSnapshotId: edge.sourceSnapshotId,
+    providerRecordHash: edge.providerRecordHash,
+    provenanceKind: edge.provenanceKind,
+    verificationStatus: edge.verificationStatus,
+    lastVerifiedAt: edge.lastVerifiedAt,
+    evidenceHash: edge.evidenceHash,
+  }));
 }
 
 function completeCoverageInventory(targets) {

--- a/tools/datapack/datapack-tools.test.mjs
+++ b/tools/datapack/datapack-tools.test.mjs
@@ -4884,6 +4884,64 @@ test("데이터팩 검증기는 route graph에서 고립된 station-line node를
   );
 });
 
+test("데이터팩 검증기는 빈 route regression pack도 명시 route edge가 있으면 route graph를 검증한다", async () => {
+  const outputDir = path.join(tmpdir(), `easysubway-datapack-empty-regression-route-graph-${Date.now()}`);
+  const fixturePath = path.join(outputDir, "fixture.json");
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  const fixture = JSON.parse(await readFile("tools/datapack/fixtures/catalog-fixture.json", "utf8"));
+  fixture.packs[0].representativeRouteRegressions = [];
+  fixture.packs[0].stations.push({
+    id: "station-isolated",
+    nameKo: "고립역",
+    nameEn: "Isolated",
+    normalizedName: "isolated",
+    region: "capital",
+    latitude: 37.1,
+    longitude: 127.1,
+    dataQualityLevel: "LEVEL_2",
+    dataSourceType: "OFFICIAL_FILE",
+    lastVerifiedAt: "2026-06-19T00:00:00.000Z",
+  });
+  fixture.packs[0].stationLines.push({
+    stationId: "station-isolated",
+    lineId: "seoul-4",
+    stationCode: "499",
+    lineSequence: 999,
+    platformInfo: "테스트 고립 노드",
+  });
+  fixture.packs[0].minimumTableRows.stations = 3;
+  await writeFile(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`);
+
+  await execFileAsync(
+    process.execPath,
+    [
+      "tools/datapack/build-datapack.mjs",
+      "--fixture",
+      fixturePath,
+      "--output",
+      outputDir,
+    ],
+    { cwd: root },
+  );
+
+  await assert.rejects(
+    execFileAsync(
+      process.execPath,
+      [
+        "tools/datapack/validate-datapack.mjs",
+        "--manifest",
+        path.join(outputDir, "current.json"),
+        "--root",
+        outputDir,
+      ],
+      { cwd: root },
+    ),
+    /station-line node is isolated from route graph/,
+  );
+});
+
 test("데이터팩 검증기는 분리된 route graph component를 거부한다", async () => {
   const outputDir = path.join(tmpdir(), `easysubway-datapack-disconnected-graph-${Date.now()}`);
   const fixturePath = path.join(outputDir, "fixture.json");

--- a/tools/datapack/import-official-sources.mjs
+++ b/tools/datapack/import-official-sources.mjs
@@ -789,6 +789,11 @@ function validateProductionSummaryRideEdgePolicy(stationLines, networkEdges, pol
   if (nonAdjacentExpressRideEdgeIds.length === 0) {
     return;
   }
+  if (policy?.summaryRideEdges === "release-blocking-regression-only") {
+    throw new Error(
+      `production routeEdges non-adjacent EXPRESS summary edge is regression-only: ${nonAdjacentExpressRideEdgeIds.join(", ")}`,
+    );
+  }
   if (
     !policy ||
     typeof policy !== "object" ||

--- a/tools/datapack/inputs/capital-pilot-production-source-input.json
+++ b/tools/datapack/inputs/capital-pilot-production-source-input.json
@@ -43,16 +43,8 @@
   "minimumProductionCoverage": {
     "stations": 2,
     "stationLines": 2,
-    "routeEdges": 6,
+    "routeEdges": 4,
     "facilities": 6
-  },
-  "routeGraphTopologyPolicy": {
-    "summaryRideEdges": "release-blocking-regression-only",
-    "productionReadinessRequirement": "replace summary RIDE edges with adjacent-station LOCAL RIDE edges before ETA or release-readiness claim",
-    "nonAdjacentExpressRideEdgeIds": [
-      "edge-sangnoksu-sadang-seoul-4",
-      "edge-sadang-sangnoksu-seoul-4"
-    ]
   },
   "coverageEvidence": [
     {
@@ -204,62 +196,6 @@
     }
   ],
   "routeEdges": [
-    {
-      "id": "edge-sangnoksu-sadang-seoul-4",
-      "sourceId": "seoulmetro-station-line-info",
-      "from": {
-        "sourceId": "seoulmetro-station-line-info",
-        "sourceStationCode": "448",
-        "lineId": "seoul-4"
-      },
-      "to": {
-        "sourceId": "seoulmetro-station-line-info",
-        "sourceStationCode": "433",
-        "lineId": "seoul-4"
-      },
-      "durationSeconds": 1860,
-      "distanceMeters": 18600,
-      "edgeType": "RIDE",
-      "servicePattern": "EXPRESS",
-      "includesStairs": false,
-      "stairAccessState": "STEP_FREE",
-      "accessibilityStatus": "AVAILABLE",
-      "reliabilityScore": 90,
-      "provenanceKind": "OFFICIAL_SOURCE",
-      "verificationStatus": "VERIFIED",
-      "lastVerifiedAt": "2026-06-21T00:00:00.000Z",
-      "sourceSnapshotId": "seoulmetro-station-line-info-snapshot-20260621",
-      "providerRecordHash": "a8d89e3b88c24a493843e41fd9b88f4c5072e2097f497db839421843efc1d7e9",
-      "evidenceHash": "be00b0216a07fa6ff0146b7b5835a31812b86819aad3344805695dfb44f6fcae"
-    },
-    {
-      "id": "edge-sadang-sangnoksu-seoul-4",
-      "sourceId": "seoulmetro-station-line-info",
-      "from": {
-        "sourceId": "seoulmetro-station-line-info",
-        "sourceStationCode": "433",
-        "lineId": "seoul-4"
-      },
-      "to": {
-        "sourceId": "seoulmetro-station-line-info",
-        "sourceStationCode": "448",
-        "lineId": "seoul-4"
-      },
-      "durationSeconds": 1860,
-      "distanceMeters": 18600,
-      "edgeType": "RIDE",
-      "servicePattern": "EXPRESS",
-      "includesStairs": false,
-      "stairAccessState": "STEP_FREE",
-      "accessibilityStatus": "AVAILABLE",
-      "reliabilityScore": 90,
-      "provenanceKind": "OFFICIAL_SOURCE",
-      "verificationStatus": "VERIFIED",
-      "lastVerifiedAt": "2026-06-21T00:00:00.000Z",
-      "sourceSnapshotId": "seoulmetro-station-line-info-snapshot-20260621",
-      "providerRecordHash": "f32228b9dbbfd6b5d565cb70986c07c6e5343c698099b012dc65084efb3d8d40",
-      "evidenceHash": "c4ca5a18552c5128e3c6d4d8fdb2efa661a23295f0d8da1b6d8dda862b21cb15"
-    },
     {
       "id": "edge-entry-sangnoksu-seoul-4",
       "sourceId": "seoulmetro-station-line-info",
@@ -631,18 +567,5 @@
       "instruction": "KRIC 휠체어리프트 이동동선 후보이며 검수 전 route edge로 승격하지 않습니다."
     }
   ],
-  "routeRegressionScope": {
-    "mode": "DIRECT_ONLY",
-    "excludedPatterns": ["TRANSFER", "MULTI_TRANSFER", "LOOP_BRANCH", "EXPRESS_LOCAL"],
-    "claim": "capital pilot Android v1 direct regression only; current summary RIDE edge is release-blocking and not ETA evidence until adjacent-station route graph evidence exists"
-  },
-  "representativeRouteRegressions": [
-    {
-      "id": "direct-local-capital",
-      "pattern": "DIRECT",
-      "fromNodeId": "station-sangnoksu:seoul-4",
-      "toNodeId": "station-sadang:seoul-4",
-      "requiredEdgeIds": ["edge-sangnoksu-sadang-seoul-4"]
-    }
-  ]
+  "representativeRouteRegressions": []
 }

--- a/tools/datapack/schema/manifest.schema.json
+++ b/tools/datapack/schema/manifest.schema.json
@@ -190,7 +190,7 @@
           },
           "representativeRouteRegressions": {
             "type": "array",
-            "minItems": 1,
+            "minItems": 0,
             "items": { "$ref": "#/$defs/representativeRouteRegression" }
           },
           "representativeRouteRegressionSignature": {

--- a/tools/datapack/validate-datapack.mjs
+++ b/tools/datapack/validate-datapack.mjs
@@ -798,6 +798,7 @@ function validateNetworkEdgeStationLineEndpoints(database, pack) {
   const edges = database
     .prepare("SELECT id, from_node_id, to_node_id, edge_type FROM network_edges ORDER BY id")
     .all();
+  let hasExplicitRouteGraphEdge = false;
   addGeneratedStationTransferEdges(
     stationLineRows,
     routeGraphRequiredNodes,
@@ -832,6 +833,7 @@ function validateNetworkEdgeStationLineEndpoints(database, pack) {
       routeGraphRequiredNodes.has(fromNode) &&
       routeGraphRequiredNodes.has(toNode)
     ) {
+      hasExplicitRouteGraphEdge = true;
       addRouteGraphEdge(
         fromNode,
         toNode,
@@ -851,7 +853,11 @@ function validateNetworkEdgeStationLineEndpoints(database, pack) {
     }
   }
 
-  if (!pack.routeRegressionScope && (!Array.isArray(pack.representativeRouteRegressions) || pack.representativeRouteRegressions.length === 0)) {
+  if (
+    !hasExplicitRouteGraphEdge &&
+    !pack.routeRegressionScope &&
+    (!Array.isArray(pack.representativeRouteRegressions) || pack.representativeRouteRegressions.length === 0)
+  ) {
     return;
   }
   for (const nodeId of routeGraphRequiredNodes) {

--- a/tools/datapack/validate-datapack.mjs
+++ b/tools/datapack/validate-datapack.mjs
@@ -510,7 +510,10 @@ function validateRepresentativeRouteRegressions(database, pack) {
     return;
   }
   const routes = pack.representativeRouteRegressions;
-  const requiredPatterns = requiredRepresentativeRoutePatterns(pack.routeRegressionScope);
+  const requiredPatterns =
+    !pack.routeRegressionScope && Array.isArray(routes) && routes.length === 0
+      ? new Set()
+      : requiredRepresentativeRoutePatterns(pack.routeRegressionScope);
   const seenPatterns = new Set(routes.map((route) => route.pattern));
   for (const pattern of requiredPatterns) {
     if (!seenPatterns.has(pattern)) {
@@ -848,6 +851,9 @@ function validateNetworkEdgeStationLineEndpoints(database, pack) {
     }
   }
 
+  if (!pack.routeRegressionScope && (!Array.isArray(pack.representativeRouteRegressions) || pack.representativeRouteRegressions.length === 0)) {
+    return;
+  }
   for (const nodeId of routeGraphRequiredNodes) {
     if (!connectedNodes.has(nodeId)) {
       throw new Error(`${pack.id}@${pack.version} station-line node is isolated from route graph: ${nodeId}`);
@@ -1657,7 +1663,9 @@ function validateManifest(manifest, { requireProduction = false } = {}) {
     validateSignature(pack.signature, `${pack.id}@${pack.version}`, manifestVersion, artifactKind);
     validateSourceInventory(pack.sourceInventory, artifactKind, `${pack.id}@${pack.version}`);
     validateRegionalQualityMetrics(pack.regionalQualityMetrics, `${pack.id}@${pack.version}`);
-    validateRouteRegressionScopeManifest(pack.routeRegressionScope, `${pack.id}@${pack.version}`);
+    if (pack.routeRegressionScope !== undefined) {
+      validateRouteRegressionScopeManifest(pack.routeRegressionScope, `${pack.id}@${pack.version}`);
+    }
     validateRepresentativeRouteRegressionManifest(
       pack.representativeRouteRegressions,
       `${pack.id}@${pack.version}`,
@@ -1974,10 +1982,13 @@ function validateRouteRegressionScopeManifest(scope, label) {
 }
 
 function validateRepresentativeRouteRegressionManifest(routes, label, scope = null) {
-  if (!Array.isArray(routes) || routes.length === 0) {
+  const requiredPatterns =
+    !scope && Array.isArray(routes) && routes.length === 0
+      ? new Set()
+      : requiredRepresentativeRoutePatterns(scope);
+  if (!Array.isArray(routes) || (requiredPatterns.size > 0 && routes.length === 0)) {
     throw new Error(`${label} representativeRouteRegressions must be a non-empty array`);
   }
-  const requiredPatterns = requiredRepresentativeRoutePatterns(scope);
   const seenPatterns = new Set();
   const seenRouteShapes = new Map();
   for (const route of routes) {


### PR DESCRIPTION
## 관련 이슈

Refs #1400

## 작업 배경

- #1400 업데이트에 따라 상록수-사당 비인접 요약 RIDE edge를 production pack에서 제외하고 regression fixture 전용 정책으로 고정해야 합니다.

## 작업 내용

- `capital-pilot-production-source-input.json`에서 비인접 요약 RIDE edge 2건, `routeGraphTopologyPolicy`, direct `routeRegressionScope` claim을 제거했습니다.
- production 최소 route edge 기준을 남은 ENTRY/EXIT 4건으로 맞췄습니다.
- importer가 `summaryRideEdges=release-blocking-regression-only` 정책으로 production 요약 edge를 허용하지 않고 regression-only 오류로 거부하도록 했습니다.
- route regression scope가 없고 대표 route regression이 비어 있는 pack은 build/validation을 허용하되, 기존 route regression fixture가 있으면 연결성 검사를 계속 수행하도록 유지했습니다.
- README와 repository/datapack tests를 새 정책에 맞췄습니다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/datapack-tools.test.mjs` 통과
  - `node --test tools/ci/repository-contract.test.mjs` 통과
  - `git diff --check` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| 데이터팩 정책 회귀 | local | `node --test tools/datapack/datapack-tools.test.mjs` | 터미널 출력 | 통과 |
| 저장소 계약 | local | `node --test tools/ci/repository-contract.test.mjs` | 터미널 출력 | 통과 |
| whitespace | local | `git diff --check` | 터미널 출력 | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: production summary RIDE edge 제외 정책 고정
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점:
  - `tools/datapack/inputs/capital-pilot-production-source-input.json`
  - `tools/datapack/import-official-sources.mjs`
  - `tools/datapack/validate-datapack.mjs`

## 리스크

- production pack은 인접역 graph가 승격될 때까지 direct route regression claim을 내지 않습니다. 이는 #1400의 남은 KRIC station membership/인접 edge 승격 전 NO-GO 상태를 더 명확히 드러냅니다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
