### PR TITLE
[Mobile] SVG 라벨 충돌 정책 적용

### DIFF
--- a/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/RouteMapViewportWebView.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/RouteMapViewportWebView.kt
@@ -190,7 +190,7 @@ private class RouteMapViewportPlatformView(
         val frameRevision = revision
         val script = String.format(
             Locale.US,
-            "(function(){const svg=document.querySelector('svg');if(!svg){return false;}svg.setAttribute('viewBox','%.4f %.4f %.4f %.4f');svg.setAttribute('width','100%%');svg.setAttribute('height','100%%');svg.setAttribute('preserveAspectRatio','xMidYMid meet');if(window.easysubwayApplyRouteMapLabelPolicy){window.easysubwayApplyRouteMapLabelPolicy();}return true;})();",
+            "(function(){const svg=document.querySelector('svg');if(!svg){return false;}svg.setAttribute('viewBox','%.4f %.4f %.4f %.4f');svg.setAttribute('width','100%%');svg.setAttribute('height','100%%');svg.setAttribute('preserveAspectRatio','xMidYMid meet');try{if(window.easysubwayApplyRouteMapLabelPolicy){window.easysubwayApplyRouteMapLabelPolicy();}}catch(e){}return true;})();",
             values[0],
             values[1],
             values[2],

--- a/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/RouteMapViewportWebView.kt
+++ b/apps/mobile/android/app/src/main/kotlin/com/easysubway/easysubway_mobile/RouteMapViewportWebView.kt
@@ -34,6 +34,7 @@ class RouteMapViewportWebViewFactory(
             sourceHeight = params["sourceHeight"].asDouble(),
             viewBox = params["viewBox"].asDoubleList(),
             revision = params["revision"].asInt(),
+            labelCollisionScript = params["labelCollisionScript"] as? String ?: "",
         )
     }
 }
@@ -48,6 +49,7 @@ private class RouteMapViewportPlatformView(
     private val sourceHeight: Double,
     private var viewBox: List<Double>,
     private var revision: Int,
+    private val labelCollisionScript: String,
 ) : PlatformView {
     private val container = FrameLayout(context).apply {
         setBackgroundColor(Color.WHITE)
@@ -174,6 +176,7 @@ private class RouteMapViewportPlatformView(
                     html, body { margin: 0; width: 100%; height: 100%; overflow: hidden; background: #ffffff; }
                     svg { display: block; width: 100%; height: 100%; }
                 </style>
+                <script>$labelCollisionScript</script>
             </head>
             <body>$svg</body>
             </html>
@@ -187,7 +190,7 @@ private class RouteMapViewportPlatformView(
         val frameRevision = revision
         val script = String.format(
             Locale.US,
-            "(function(){const svg=document.querySelector('svg');if(!svg){return false;}svg.setAttribute('viewBox','%.4f %.4f %.4f %.4f');svg.setAttribute('width','100%%');svg.setAttribute('height','100%%');svg.setAttribute('preserveAspectRatio','xMidYMid meet');return true;})();",
+            "(function(){const svg=document.querySelector('svg');if(!svg){return false;}svg.setAttribute('viewBox','%.4f %.4f %.4f %.4f');svg.setAttribute('width','100%%');svg.setAttribute('height','100%%');svg.setAttribute('preserveAspectRatio','xMidYMid meet');if(window.easysubwayApplyRouteMapLabelPolicy){window.easysubwayApplyRouteMapLabelPolicy();}return true;})();",
             values[0],
             values[1],
             values[2],

--- a/apps/mobile/ios/Runner/AppDelegate.swift
+++ b/apps/mobile/ios/Runner/AppDelegate.swift
@@ -311,7 +311,8 @@ private final class RouteMapViewportWebViewFactory: NSObject, FlutterPlatformVie
       sourceWidth: params["sourceWidth"].asDouble(),
       sourceHeight: params["sourceHeight"].asDouble(),
       viewBox: params["viewBox"].asDoubleList(),
-      revision: params["revision"].asInt()
+      revision: params["revision"].asInt(),
+      labelCollisionScript: params["labelCollisionScript"] as? String ?? ""
     )
   }
 }
@@ -325,6 +326,7 @@ private final class RouteMapViewportPlatformView: NSObject, FlutterPlatformView,
   private let sourceHeight: Double
   private var viewBox: [Double]
   private var revision: Int
+  private let labelCollisionScript: String
   private var webView: WKWebView?
 
   init(
@@ -336,7 +338,8 @@ private final class RouteMapViewportPlatformView: NSObject, FlutterPlatformView,
     sourceWidth: Double,
     sourceHeight: Double,
     viewBox: [Double],
-    revision: Int
+    revision: Int,
+    labelCollisionScript: String
   ) {
     container = UIView(frame: frame)
     channel = FlutterMethodChannel(
@@ -349,6 +352,7 @@ private final class RouteMapViewportPlatformView: NSObject, FlutterPlatformView,
     self.sourceHeight = sourceHeight
     self.viewBox = viewBox
     self.revision = revision
+    self.labelCollisionScript = labelCollisionScript
     super.init()
 
     container.backgroundColor = .white
@@ -430,6 +434,7 @@ private final class RouteMapViewportPlatformView: NSObject, FlutterPlatformView,
           html, body { margin: 0; width: 100%; height: 100%; overflow: hidden; background: #ffffff; }
           svg { display: block; width: 100%; height: 100%; }
         </style>
+        <script>\(labelCollisionScript)</script>
       </head>
       <body>\(svg)</body>
       </html>
@@ -448,7 +453,7 @@ private final class RouteMapViewportPlatformView: NSObject, FlutterPlatformView,
     let frameRevision = revision
     let script = String(
       format:
-        "(function(){const svg=document.querySelector('svg');if(!svg){return false;}svg.setAttribute('viewBox','%.4f %.4f %.4f %.4f');svg.setAttribute('width','100%%');svg.setAttribute('height','100%%');svg.setAttribute('preserveAspectRatio','xMidYMid meet');return true;})();",
+        "(function(){const svg=document.querySelector('svg');if(!svg){return false;}svg.setAttribute('viewBox','%.4f %.4f %.4f %.4f');svg.setAttribute('width','100%%');svg.setAttribute('height','100%%');svg.setAttribute('preserveAspectRatio','xMidYMid meet');if(window.easysubwayApplyRouteMapLabelPolicy){window.easysubwayApplyRouteMapLabelPolicy();}return true;})();",
       locale: Locale(identifier: "en_US_POSIX"),
       values[0],
       values[1],

--- a/apps/mobile/ios/Runner/AppDelegate.swift
+++ b/apps/mobile/ios/Runner/AppDelegate.swift
@@ -453,7 +453,7 @@ private final class RouteMapViewportPlatformView: NSObject, FlutterPlatformView,
     let frameRevision = revision
     let script = String(
       format:
-        "(function(){const svg=document.querySelector('svg');if(!svg){return false;}svg.setAttribute('viewBox','%.4f %.4f %.4f %.4f');svg.setAttribute('width','100%%');svg.setAttribute('height','100%%');svg.setAttribute('preserveAspectRatio','xMidYMid meet');if(window.easysubwayApplyRouteMapLabelPolicy){window.easysubwayApplyRouteMapLabelPolicy();}return true;})();",
+        "(function(){const svg=document.querySelector('svg');if(!svg){return false;}svg.setAttribute('viewBox','%.4f %.4f %.4f %.4f');svg.setAttribute('width','100%%');svg.setAttribute('height','100%%');svg.setAttribute('preserveAspectRatio','xMidYMid meet');try{if(window.easysubwayApplyRouteMapLabelPolicy){window.easysubwayApplyRouteMapLabelPolicy();}}catch(e){}return true;})();",
       locale: Locale(identifier: "en_US_POSIX"),
       values[0],
       values[1],

--- a/apps/mobile/lib/features/network_map/infrastructure/android_route_map_viewport_webview.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/android_route_map_viewport_webview.dart
@@ -23,6 +23,7 @@ Map<String, Object?> androidRouteMapViewportCreationParams({
     'sourceHeight': camera.sourceBounds.height,
     'viewBox': _viewBoxFor(camera),
     'revision': camera.revision,
+    'labelCollisionScript': routeMapViewportLabelCollisionScript,
   };
 }
 

--- a/apps/mobile/lib/features/network_map/infrastructure/ios_route_map_viewport_webview.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/ios_route_map_viewport_webview.dart
@@ -23,6 +23,7 @@ Map<String, Object?> iosRouteMapViewportCreationParams({
     'sourceHeight': camera.sourceBounds.height,
     'viewBox': _viewBoxFor(camera),
     'revision': camera.revision,
+    'labelCollisionScript': routeMapViewportLabelCollisionScript,
   };
 }
 

--- a/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
@@ -33,14 +33,14 @@ window.easysubwayApplyRouteMapLabelPolicy = function () {
   const readBounds = (label) => {
     try {
       return label.getBBox();
-    } catch (error) {
+    } catch {
       return null;
     }
   };
   const invertMatrix = (matrix) => {
     try {
       return matrix.inverse();
-    } catch (error) {
+    } catch {
       return null;
     }
   };

--- a/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
@@ -31,19 +31,17 @@ window.easysubwayApplyRouteMapLabelPolicy = function () {
     bottom: viewBox.y + viewBox.height
   };
   const readBounds = (label) => {
-    let bounds = null;
     try {
-      bounds = label.getBBox();
-    } finally {
-      return bounds;
+      return label.getBBox();
+    } catch (error) {
+      return null;
     }
   };
   const invertMatrix = (matrix) => {
-    let inverted = null;
     try {
-      inverted = matrix.inverse();
-    } finally {
-      return inverted;
+      return matrix.inverse();
+    } catch (error) {
+      return null;
     }
   };
   const accepted = [];

--- a/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
@@ -15,6 +15,22 @@ window.easysubwayApplyRouteMapLabelPolicy = function () {
     right: viewBox.x + viewBox.width,
     bottom: viewBox.y + viewBox.height
   };
+  const readBounds = (label) => {
+    let bounds = null;
+    try {
+      bounds = label.getBBox();
+    } finally {
+      return bounds;
+    }
+  };
+  const invertMatrix = (matrix) => {
+    let inverted = null;
+    try {
+      inverted = matrix.inverse();
+    } finally {
+      return inverted;
+    }
+  };
   const accepted = [];
   const labels = Array.from(svg.querySelectorAll('text'));
   for (const label of labels) {
@@ -34,10 +50,8 @@ window.easysubwayApplyRouteMapLabelPolicy = function () {
         bottom: Number(label.dataset.easysubwayLabelBottom)
       };
     } else {
-      let bounds;
-      try {
-        bounds = label.getBBox();
-      } catch (_) {
+      const bounds = readBounds(label);
+      if (!bounds) {
         continue;
       }
       const labelMatrix = label.getScreenCTM();
@@ -45,10 +59,8 @@ window.easysubwayApplyRouteMapLabelPolicy = function () {
       if (!labelMatrix || !svgMatrix) {
         continue;
       }
-      let toSvg;
-      try {
-        toSvg = svgMatrix.inverse();
-      } catch (_) {
+      const toSvg = invertMatrix(svgMatrix);
+      if (!toSvg) {
         continue;
       }
       const point = svg.createSVGPoint();

--- a/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
@@ -8,6 +8,21 @@ window.easysubwayApplyRouteMapLabelPolicy = function () {
   if (!svg || !svg.viewBox || !svg.viewBox.baseVal) {
     return false;
   }
+  const minIntervalMs = 120;
+  const now = Date.now();
+  const lastRun = Number(svg.dataset.easysubwayLabelPolicyAt || 0);
+  const remainingMs = minIntervalMs - (now - lastRun);
+  if (remainingMs > 0) {
+    if (!svg.dataset.easysubwayLabelPolicyPending) {
+      svg.dataset.easysubwayLabelPolicyPending = 'true';
+      setTimeout(() => {
+        delete svg.dataset.easysubwayLabelPolicyPending;
+        window.easysubwayApplyRouteMapLabelPolicy();
+      }, remainingMs);
+    }
+    return true;
+  }
+  svg.dataset.easysubwayLabelPolicyAt = String(now);
   const viewBox = svg.viewBox.baseVal;
   const viewport = {
     left: viewBox.x,

--- a/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
@@ -2,6 +2,82 @@ import 'dart:async';
 
 import '../domain/map_camera.dart';
 
+const routeMapViewportLabelCollisionScript = r'''
+window.easysubwayApplyRouteMapLabelPolicy = function () {
+  const svg = document.querySelector('svg');
+  if (!svg || !svg.viewBox || !svg.viewBox.baseVal) {
+    return false;
+  }
+  const viewBox = svg.viewBox.baseVal;
+  const viewport = {
+    left: viewBox.x,
+    top: viewBox.y,
+    right: viewBox.x + viewBox.width,
+    bottom: viewBox.y + viewBox.height
+  };
+  const accepted = [];
+  const labels = Array.from(svg.querySelectorAll('text'));
+  for (const label of labels) {
+    label.style.display = '';
+    label.removeAttribute('data-easysubway-hidden-label');
+    let box;
+    if (
+      label.dataset.easysubwayLabelLeft &&
+      label.dataset.easysubwayLabelTop &&
+      label.dataset.easysubwayLabelRight &&
+      label.dataset.easysubwayLabelBottom
+    ) {
+      box = {
+        left: Number(label.dataset.easysubwayLabelLeft),
+        top: Number(label.dataset.easysubwayLabelTop),
+        right: Number(label.dataset.easysubwayLabelRight),
+        bottom: Number(label.dataset.easysubwayLabelBottom)
+      };
+    } else {
+      let bounds;
+      try {
+        bounds = label.getBBox();
+      } catch (_) {
+        continue;
+      }
+      box = {
+        left: bounds.x,
+        top: bounds.y,
+        right: bounds.x + bounds.width,
+        bottom: bounds.y + bounds.height
+      };
+      label.dataset.easysubwayLabelLeft = String(box.left);
+      label.dataset.easysubwayLabelTop = String(box.top);
+      label.dataset.easysubwayLabelRight = String(box.right);
+      label.dataset.easysubwayLabelBottom = String(box.bottom);
+    }
+    if (
+      box.right < viewport.left ||
+      box.left > viewport.right ||
+      box.bottom < viewport.top ||
+      box.top > viewport.bottom
+    ) {
+      label.style.display = 'none';
+      label.setAttribute('data-easysubway-hidden-label', 'offscreen');
+      continue;
+    }
+    const overlaps = accepted.some((other) =>
+      box.left < other.right &&
+      box.right > other.left &&
+      box.top < other.bottom &&
+      box.bottom > other.top
+    );
+    if (overlaps) {
+      label.style.display = 'none';
+      label.setAttribute('data-easysubway-hidden-label', 'collision');
+    } else {
+      accepted.push(box);
+    }
+  }
+  return true;
+};
+''';
+
 abstract interface class RouteMapRendererController {
   Stream<RouteMapRendererEvent> get events;
 

--- a/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
@@ -40,11 +40,35 @@ window.easysubwayApplyRouteMapLabelPolicy = function () {
       } catch (_) {
         continue;
       }
+      const labelMatrix = label.getScreenCTM();
+      const svgMatrix = svg.getScreenCTM();
+      if (!labelMatrix || !svgMatrix) {
+        continue;
+      }
+      let toSvg;
+      try {
+        toSvg = svgMatrix.inverse();
+      } catch (_) {
+        continue;
+      }
+      const point = svg.createSVGPoint();
+      const transformPoint = (x, y) => {
+        point.x = x;
+        point.y = y;
+        return point.matrixTransform(labelMatrix).matrixTransform(toSvg);
+      };
+      const topLeft = transformPoint(bounds.x, bounds.y);
+      const topRight = transformPoint(bounds.x + bounds.width, bounds.y);
+      const bottomLeft = transformPoint(bounds.x, bounds.y + bounds.height);
+      const bottomRight = transformPoint(
+        bounds.x + bounds.width,
+        bounds.y + bounds.height
+      );
       box = {
-        left: bounds.x,
-        top: bounds.y,
-        right: bounds.x + bounds.width,
-        bottom: bounds.y + bounds.height
+        left: Math.min(topLeft.x, topRight.x, bottomLeft.x, bottomRight.x),
+        top: Math.min(topLeft.y, topRight.y, bottomLeft.y, bottomRight.y),
+        right: Math.max(topLeft.x, topRight.x, bottomLeft.x, bottomRight.x),
+        bottom: Math.max(topLeft.y, topRight.y, bottomLeft.y, bottomRight.y)
       };
       label.dataset.easysubwayLabelLeft = String(box.left);
       label.dataset.easysubwayLabelTop = String(box.top);

--- a/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
+++ b/apps/mobile/lib/features/network_map/infrastructure/route_map_renderer.dart
@@ -44,11 +44,28 @@ window.easysubwayApplyRouteMapLabelPolicy = function () {
       return null;
     }
   };
+  const isFiniteBox = (box) =>
+    box &&
+    Number.isFinite(box.left) &&
+    Number.isFinite(box.top) &&
+    Number.isFinite(box.right) &&
+    Number.isFinite(box.bottom);
   const accepted = [];
+  // svg 좌표 변환은 한 패스 내내 불변이므로 루프 밖에서 한 번만 계산한다.
+  const svgMatrix = svg.getScreenCTM();
+  const toSvg = svgMatrix ? invertMatrix(svgMatrix) : null;
+  const point = svg.createSVGPoint ? svg.createSVGPoint() : null;
   const labels = Array.from(svg.querySelectorAll('text'));
   for (const label of labels) {
-    label.style.display = '';
-    label.removeAttribute('data-easysubway-hidden-label');
+    const hiddenByUs = label.hasAttribute('data-easysubway-hidden-label');
+    if (!hiddenByUs && label.style.display === 'none') {
+      // 원본 SVG가 숨긴 라벨: 그대로 숨겨 두고 라벨 공간도 차지하지 않게 한다.
+      continue;
+    }
+    if (hiddenByUs) {
+      label.style.display = '';
+      label.removeAttribute('data-easysubway-hidden-label');
+    }
     let box;
     if (
       label.dataset.easysubwayLabelLeft &&
@@ -62,21 +79,19 @@ window.easysubwayApplyRouteMapLabelPolicy = function () {
         right: Number(label.dataset.easysubwayLabelRight),
         bottom: Number(label.dataset.easysubwayLabelBottom)
       };
-    } else {
+    }
+    if (!isFiniteBox(box)) {
+      if (!toSvg || !point) {
+        continue;
+      }
       const bounds = readBounds(label);
       if (!bounds) {
         continue;
       }
       const labelMatrix = label.getScreenCTM();
-      const svgMatrix = svg.getScreenCTM();
-      if (!labelMatrix || !svgMatrix) {
+      if (!labelMatrix) {
         continue;
       }
-      const toSvg = invertMatrix(svgMatrix);
-      if (!toSvg) {
-        continue;
-      }
-      const point = svg.createSVGPoint();
       const transformPoint = (x, y) => {
         point.x = x;
         point.y = y;
@@ -95,6 +110,11 @@ window.easysubwayApplyRouteMapLabelPolicy = function () {
         right: Math.max(topLeft.x, topRight.x, bottomLeft.x, bottomRight.x),
         bottom: Math.max(topLeft.y, topRight.y, bottomLeft.y, bottomRight.y)
       };
+      if (!isFiniteBox(box)) {
+        // 비정상 측정값(뷰가 아직 레이아웃되지 않은 상태): 잘못된 박스를 영구
+        // 캐시하지 않도록 캐시를 건너뛰어 다음 실행에서 다시 측정하게 한다.
+        continue;
+      }
       label.dataset.easysubwayLabelLeft = String(box.left);
       label.dataset.easysubwayLabelTop = String(box.top);
       label.dataset.easysubwayLabelRight = String(box.right);

--- a/apps/mobile/test/features/network_map/infrastructure/android_route_map_viewport_webview_test.dart
+++ b/apps/mobile/test/features/network_map/infrastructure/android_route_map_viewport_webview_test.dart
@@ -35,7 +35,23 @@ void main() {
         'sourceHeight': 500.0,
         'viewBox': <double>[250.0, 125.0, 500.0, 250.0],
         'revision': 3,
+        'labelCollisionScript': routeMapViewportLabelCollisionScript,
       },
+    );
+  });
+
+  test('creation params include label collision policy script', () {
+    final params = androidRouteMapViewportCreationParams(
+      assetPath: 'assets/datapacks/maps/seoul-official-route-map.svg',
+      mimeType: 'image/svg+xml',
+      camera: camera,
+    );
+
+    expect(params['labelCollisionScript'], isA<String>());
+    expect(params['labelCollisionScript'], contains('getBBox'));
+    expect(
+      params['labelCollisionScript'],
+      contains('data-easysubway-hidden-label'),
     );
   });
 

--- a/apps/mobile/test/features/network_map/infrastructure/android_route_map_viewport_webview_test.dart
+++ b/apps/mobile/test/features/network_map/infrastructure/android_route_map_viewport_webview_test.dart
@@ -50,6 +50,7 @@ void main() {
     expect(params['labelCollisionScript'], isA<String>());
     expect(params['labelCollisionScript'], contains('getBBox'));
     expect(params['labelCollisionScript'], contains('getScreenCTM'));
+    expect(params['labelCollisionScript'], contains('setTimeout'));
     expect(
       params['labelCollisionScript'],
       contains('data-easysubway-hidden-label'),

--- a/apps/mobile/test/features/network_map/infrastructure/android_route_map_viewport_webview_test.dart
+++ b/apps/mobile/test/features/network_map/infrastructure/android_route_map_viewport_webview_test.dart
@@ -49,6 +49,7 @@ void main() {
 
     expect(params['labelCollisionScript'], isA<String>());
     expect(params['labelCollisionScript'], contains('getBBox'));
+    expect(params['labelCollisionScript'], contains('getScreenCTM'));
     expect(
       params['labelCollisionScript'],
       contains('data-easysubway-hidden-label'),

--- a/apps/mobile/test/features/network_map/infrastructure/ios_route_map_viewport_webview_test.dart
+++ b/apps/mobile/test/features/network_map/infrastructure/ios_route_map_viewport_webview_test.dart
@@ -50,6 +50,7 @@ void main() {
     expect(params['labelCollisionScript'], isA<String>());
     expect(params['labelCollisionScript'], contains('getBBox'));
     expect(params['labelCollisionScript'], contains('getScreenCTM'));
+    expect(params['labelCollisionScript'], contains('setTimeout'));
     expect(
       params['labelCollisionScript'],
       contains('data-easysubway-hidden-label'),

--- a/apps/mobile/test/features/network_map/infrastructure/ios_route_map_viewport_webview_test.dart
+++ b/apps/mobile/test/features/network_map/infrastructure/ios_route_map_viewport_webview_test.dart
@@ -49,6 +49,7 @@ void main() {
 
     expect(params['labelCollisionScript'], isA<String>());
     expect(params['labelCollisionScript'], contains('getBBox'));
+    expect(params['labelCollisionScript'], contains('getScreenCTM'));
     expect(
       params['labelCollisionScript'],
       contains('data-easysubway-hidden-label'),

--- a/apps/mobile/test/features/network_map/infrastructure/ios_route_map_viewport_webview_test.dart
+++ b/apps/mobile/test/features/network_map/infrastructure/ios_route_map_viewport_webview_test.dart
@@ -35,7 +35,23 @@ void main() {
         'sourceHeight': 500.0,
         'viewBox': <double>[250.0, 125.0, 500.0, 250.0],
         'revision': 3,
+        'labelCollisionScript': routeMapViewportLabelCollisionScript,
       },
+    );
+  });
+
+  test('creation params include label collision policy script', () {
+    final params = iosRouteMapViewportCreationParams(
+      assetPath: 'assets/datapacks/maps/seoul-official-route-map.svg',
+      mimeType: 'image/svg+xml',
+      camera: camera,
+    );
+
+    expect(params['labelCollisionScript'], isA<String>());
+    expect(params['labelCollisionScript'], contains('getBBox'));
+    expect(
+      params['labelCollisionScript'],
+      contains('data-easysubway-hidden-label'),
     );
   });
 


### PR DESCRIPTION
## Summary
- 기존 SVG WebView 렌더러에 화면 밖 라벨 숨김과 겹침 라벨 숨김 정책을 추가했습니다.
- Android/iOS 네이티브 WebView HTML에 라벨 정책 스크립트를 주입하고 viewBox 갱신 때 다시 적용합니다.
- Android/iOS creation params 테스트로 스크립트 전달 계약을 고정했습니다.

## Test Plan
- flutter test test/features/network_map/infrastructure/android_route_map_viewport_webview_test.dart test/features/network_map/infrastructure/ios_route_map_viewport_webview_test.dart test/features/network_map/infrastructure/route_map_renderer_test.dart
- flutter build apk --debug
- flutter build ios --debug --no-codesign
- git diff --check

Refs #1642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 지도를 표시할 때 라벨 겹침과 화면 밖 라벨을 자동으로 숨기는 정책이 적용됩니다.
  * Android와 iOS에서 동일한 라벨 처리 스크립트가 전달되어 지도 표시가 더 일관되게 동작합니다.

* **Bug Fixes**
  * SVG 라벨이 서로 겹치거나 보이지 않는 위치에 있을 때 잘못 표시되는 문제가 개선되었습니다.

* **Tests**
  * Android/iOS 생성 파라미터에 라벨 처리 스크립트가 포함되는지 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->