### PR TITLE
[Chore] TAGO 시간표 수집 plan CLI 추가 (#1415)

### DIFF
--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
+import { promisify } from "node:util";
 import { buildTagoScheduleCollectionPlan } from "./validate-tago-schedule-sample.mjs";
+
+const execFileAsync = promisify(execFile);
 
 test("TAGO 시간표 수집 plan은 daily limit과 checkpoint resume을 적용한다", () => {
   const plan = buildTagoScheduleCollectionPlan(
@@ -32,5 +39,41 @@ test("TAGO 시간표 수집 plan은 파일럿 매핑 대상이 아닌 lineId를 
         stationLineRows: [{ stationCode: "113", lineId: "busan-1" }],
       }),
     /Unsupported lineId for pilot mapping: busan-1/,
+  );
+});
+
+test("TAGO 시간표 수집 plan CLI는 checkpoint와 output을 적용한다", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "tago-plan-"));
+  const inputPath = path.join(dir, "input.json");
+  const checkpointPath = path.join(dir, "checkpoint.json");
+  const outputPath = path.join(dir, "plan.json");
+  await writeFile(
+    inputPath,
+    `${JSON.stringify({
+      stationLineRows: [{ stationCode: "448", lineId: "seoul-4" }],
+    })}\n`,
+  );
+  await writeFile(checkpointPath, `${JSON.stringify({ completedRequestKeys: ["MTRKR4448|01|U"] })}\n`);
+
+  await execFileAsync(process.execPath, [
+    "tools/datapack/validate-tago-schedule-sample.mjs",
+    "--plan",
+    "--input",
+    inputPath,
+    "--checkpoint",
+    checkpointPath,
+    "--daily-limit",
+    "2",
+    "--output",
+    outputPath,
+  ]);
+
+  const plan = JSON.parse(await readFile(outputPath, "utf8"));
+  assert.equal(plan.dailyLimit, 2);
+  assert.equal(plan.totalRequestCount, 6);
+  assert.equal(plan.completedRequestCount, 1);
+  assert.deepEqual(
+    plan.batches.map((batch) => batch.requests.length),
+    [2, 2, 1],
   );
 });

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -8,6 +8,7 @@ import { promisify } from "node:util";
 import { buildTagoScheduleCollectionPlan } from "./validate-tago-schedule-sample.mjs";
 
 const execFileAsync = promisify(execFile);
+const tagoScheduleToolPath = path.resolve(import.meta.dirname, "validate-tago-schedule-sample.mjs");
 
 test("TAGO 시간표 수집 plan은 daily limit과 checkpoint resume을 적용한다", () => {
   const plan = buildTagoScheduleCollectionPlan(
@@ -42,8 +43,11 @@ test("TAGO 시간표 수집 plan은 파일럿 매핑 대상이 아닌 lineId를 
   );
 });
 
-test("TAGO 시간표 수집 plan CLI는 checkpoint와 output을 적용한다", async () => {
+test("TAGO 시간표 수집 plan CLI는 checkpoint와 output을 적용한다", async (t) => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "tago-plan-"));
+  t.after(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
   const inputPath = path.join(dir, "input.json");
   const checkpointPath = path.join(dir, "checkpoint.json");
   const outputPath = path.join(dir, "plan.json");
@@ -55,18 +59,22 @@ test("TAGO 시간표 수집 plan CLI는 checkpoint와 output을 적용한다", a
   );
   await writeFile(checkpointPath, `${JSON.stringify({ completedRequestKeys: ["MTRKR4448|01|U"] })}\n`);
 
-  await execFileAsync(process.execPath, [
-    "tools/datapack/validate-tago-schedule-sample.mjs",
-    "--plan",
-    "--input",
-    inputPath,
-    "--checkpoint",
-    checkpointPath,
-    "--daily-limit",
-    "2",
-    "--output",
-    outputPath,
-  ]);
+  await execFileAsync(
+    process.execPath,
+    [
+      tagoScheduleToolPath,
+      "--plan",
+      "--input",
+      inputPath,
+      "--checkpoint",
+      checkpointPath,
+      "--daily-limit",
+      "2",
+      "--output",
+      outputPath,
+    ],
+    { timeout: 10_000 },
+  );
 
   const plan = JSON.parse(await readFile(outputPath, "utf8"));
   assert.equal(plan.dailyLimit, 2);

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -30,6 +30,10 @@ function parseArgs(argv) {
     if (!flag.startsWith("--")) {
       throw new Error(`unexpected argument: ${flag}`);
     }
+    if (flag === "--plan") {
+      args.plan = true;
+      continue;
+    }
     if (!value || value.startsWith("--")) {
       throw new Error(`${flag} requires a value`);
     }
@@ -231,7 +235,13 @@ function sha256(value) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const inputPath = path.resolve(args.input);
-  const result = validateTagoScheduleSample(await readFile(inputPath, "utf8"));
+  const result = args.plan
+    ? buildTagoScheduleCollectionPlan(
+        JSON.parse(await readFile(inputPath, "utf8")),
+        args.checkpoint ? JSON.parse(await readFile(path.resolve(args.checkpoint), "utf8")) : {},
+        args["daily-limit"] ? Number(args["daily-limit"]) : 1000,
+      )
+    : validateTagoScheduleSample(await readFile(inputPath, "utf8"));
   if (args.output) {
     await writeFile(path.resolve(args.output), `${JSON.stringify(result, null, 2)}\n`);
   }

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -235,13 +235,14 @@ function sha256(value) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const inputPath = path.resolve(args.input);
-  const result = args.plan
-    ? buildTagoScheduleCollectionPlan(
-        JSON.parse(await readFile(inputPath, "utf8")),
-        args.checkpoint ? JSON.parse(await readFile(path.resolve(args.checkpoint), "utf8")) : {},
-        args["daily-limit"] ? Number(args["daily-limit"]) : 1000,
-      )
-    : validateTagoScheduleSample(await readFile(inputPath, "utf8"));
+  let result;
+  if (args.plan) {
+    const checkpoint = args.checkpoint ? JSON.parse(await readFile(path.resolve(args.checkpoint), "utf8")) : {};
+    const dailyLimit = args["daily-limit"] === undefined ? undefined : Number(args["daily-limit"]);
+    result = buildTagoScheduleCollectionPlan(JSON.parse(await readFile(inputPath, "utf8")), checkpoint, dailyLimit);
+  } else {
+    result = validateTagoScheduleSample(await readFile(inputPath, "utf8"));
+  }
   if (args.output) {
     await writeFile(path.resolve(args.output), `${JSON.stringify(result, null, 2)}\n`);
   }


### PR DESCRIPTION
## 관련 이슈

Refs #1415
Refs #1414

## 작업 배경

- TAGO 시간표 production 적재는 trip-stop sequence와 quota production 승인 전까지 막혀 있다.
- 다만 수집 준비에는 daily limit과 checkpoint resume이 적용되는 실행 가능한 plan CLI가 필요하다.

## 작업 내용

- `validate-tago-schedule-sample.mjs`에 `--plan` 모드를 추가해 기존 TAGO 시간표 수집 plan 함수를 CLI에서 실행할 수 있게 했다.
- `--checkpoint`, `--daily-limit`, `--output`을 지원해 공공데이터포털 quota 안에서 재개 가능한 batch plan을 만들 수 있게 했다.
- CLI 경로 테스트를 추가했다.

## 검증

- 실행한 명령과 결과:
  - `node --test tools/datapack/plan-tago-schedule-collection.test.mjs` 성공
  - `node --test tools/datapack/datapack-tools.test.mjs` 성공, 181 passed
  - `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| TAGO 수집 plan CLI | datapack tools | Node test | `node --test tools/datapack/plan-tago-schedule-collection.test.mjs` | 통과 |
| datapack tool regression | datapack tools | Node test | `node --test tools/datapack/datapack-tools.test.mjs` | 통과 |
| patch hygiene | repo | whitespace check | `git diff --check` | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/validate-tago-schedule-sample.mjs`의 `--plan` 분기와 `tools/datapack/plan-tago-schedule-collection.test.mjs`의 CLI test.

## 리스크

- Production stop_times 적재 자체는 여전히 기존 gate가 막는다. 이번 변경은 수집 plan 생성까지만 다룬다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
