### PR TITLE
[Chore] TAGO 시간표 수집 plan 계약 고정 (#1415)

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5721,7 +5721,7 @@ test("서울 TOPIS 실시간 후보는 backend-only key 경계와 production 분
   }
 });
 
-test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되지 않는다", () => {
+test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되지 않는다", async () => {
   const inventory = readJson("tools/datapack/source-inventory.json");
   const candidates = readJson("tools/datapack/source-candidates.json");
   const productionSourceIds = new Set(inventory.sources.map((source) => source.id));
@@ -5756,7 +5756,7 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
     productionCanonicalStopTimesStatus: "blocked_requires_trip_stop_sequence",
     plannedEtaUseAllowed: false,
   });
-  assert.deepEqual(candidate.evidence.scheduleCollectionPlan, {
+  assert.deepStrictEqual(candidate.evidence.scheduleCollectionPlan, {
     status: "planned_pilot_collection",
     tool: "tools/datapack/validate-tago-schedule-sample.mjs",
     command: "node tools/datapack/validate-tago-schedule-sample.mjs --plan --input tools/datapack/inputs/capital-pilot-production-source-input.json --daily-limit 1000 --checkpoint <checkpoint.json> --output <plan.json>",
@@ -5766,6 +5766,23 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
     checkpointField: "completedRequestKeys",
     productionUseAllowed: false,
   });
+  const { stdout: collectionPlanStdout } = await execFileAsync(
+    process.execPath,
+    [
+      candidate.evidence.scheduleCollectionPlan.tool,
+      "--plan",
+      "--input",
+      candidate.evidence.scheduleCollectionPlan.input,
+      "--daily-limit",
+      String(candidate.evidence.scheduleCollectionPlan.defaultDailyLimit),
+    ],
+    { cwd: root },
+  );
+  const collectionPlan = JSON.parse(collectionPlanStdout);
+  assert.equal(collectionPlan.sourceId, candidate.id);
+  assert.equal(collectionPlan.dailyLimit, candidate.evidence.scheduleCollectionPlan.defaultDailyLimit);
+  assert.equal(collectionPlan.totalRequestCount, candidate.evidence.scheduleCollectionPlan.pilotRequestCount);
+  assert.equal(collectionPlan.pendingRequestCount, candidate.evidence.scheduleCollectionPlan.pilotRequestCount);
   // source-candidates keeps a public summary, not the local full admin-review input with productionSource.
   assert.deepEqual(candidate.evidence.adminReview, {
     artifactKind: "source-admission-admin-review-summary",

--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5756,6 +5756,16 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
     productionCanonicalStopTimesStatus: "blocked_requires_trip_stop_sequence",
     plannedEtaUseAllowed: false,
   });
+  assert.deepEqual(candidate.evidence.scheduleCollectionPlan, {
+    status: "planned_pilot_collection",
+    tool: "tools/datapack/validate-tago-schedule-sample.mjs",
+    command: "node tools/datapack/validate-tago-schedule-sample.mjs --plan --input tools/datapack/inputs/capital-pilot-production-source-input.json --daily-limit 1000 --checkpoint <checkpoint.json> --output <plan.json>",
+    input: "tools/datapack/inputs/capital-pilot-production-source-input.json",
+    defaultDailyLimit: 1000,
+    pilotRequestCount: 12,
+    checkpointField: "completedRequestKeys",
+    productionUseAllowed: false,
+  });
   // source-candidates keeps a public summary, not the local full admin-review input with productionSource.
   assert.deepEqual(candidate.evidence.adminReview, {
     artifactKind: "source-admission-admin-review-summary",

--- a/tools/datapack/source-admission-runbook.json
+++ b/tools/datapack/source-admission-runbook.json
@@ -10,6 +10,7 @@
     "validate sample evidence against source-candidates.json",
     "build a LOCKED source snapshot with credential-free rawObjectUri and freshness expiry",
     "require admin review APPROVED record before production inventory admission",
+    "for TAGO schedule collection, generate a checkpoint/resume plan before provider calls",
     "write candidate source inventory and validate it",
     "write admission summary with sourceSnapshotSetHash, sourceInventorySha256, ledger hashes, and adminReviewRecordHash"
   ],

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -681,6 +681,16 @@
           "productionCanonicalStopTimesStatus": "blocked_requires_trip_stop_sequence",
           "plannedEtaUseAllowed": false
         },
+        "scheduleCollectionPlan": {
+          "status": "planned_pilot_collection",
+          "tool": "tools/datapack/validate-tago-schedule-sample.mjs",
+          "command": "node tools/datapack/validate-tago-schedule-sample.mjs --plan --input tools/datapack/inputs/capital-pilot-production-source-input.json --daily-limit 1000 --checkpoint <checkpoint.json> --output <plan.json>",
+          "input": "tools/datapack/inputs/capital-pilot-production-source-input.json",
+          "defaultDailyLimit": 1000,
+          "pilotRequestCount": 12,
+          "checkpointField": "completedRequestKeys",
+          "productionUseAllowed": false
+        },
         "adminReview": {
           "artifactKind": "source-admission-admin-review-summary",
           "decision": "APPROVED",


### PR DESCRIPTION
## 관련 이슈

Refs #1415
Refs #1414

## 작업 배경

- TAGO 시간표 수집은 production 적재 전에도 quota 안에서 재개 가능한 plan 증거가 필요하다.
- PR #1658에서 CLI는 추가됐지만 candidate evidence와 admission runbook에는 아직 연결되지 않았다.

## 작업 내용

- `molit-tago-subway-info` candidate evidence에 pilot schedule collection plan 계약을 추가했다.
- TAGO 수집 전 checkpoint/resume plan 생성 단계를 source admission runbook에 추가했다.
- repository contract test에서 plan command, daily limit, pilot request count, checkpoint field, production block 상태를 고정했다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "TAGO 시간표 후보" tools/ci/repository-contract.test.mjs` 성공
  - `node --test tools/datapack/plan-tago-schedule-collection.test.mjs` 성공
  - `node --test tools/ci/repository-contract.test.mjs` 성공, 158 passed
  - `node --test tools/datapack/datapack-tools.test.mjs` 성공, 181 passed
  - `git diff --check` 성공

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| TAGO plan contract | datapack tools | Node test | `node --test --test-name-pattern "TAGO 시간표 후보" tools/ci/repository-contract.test.mjs` | 통과 |
| datapack regression | datapack tools | Node test | `node --test tools/datapack/datapack-tools.test.mjs` | 통과 |
| repo contract | repository | Node test | `node --test tools/ci/repository-contract.test.mjs` | 통과 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [ ] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [ ] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [ ] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: 변경 없음
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/source-candidates.json`의 `scheduleCollectionPlan`과 `tools/ci/repository-contract.test.mjs` assertion.

## 리스크

- Production PLANNED ETA 사용은 계속 `productionUseAllowed: false`와 quota/trip-sequence gate가 막는다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
