### PR TITLE
[Route Map] 스키마 계약에 실시간 선형 파라미터 고정 (#1636)

### DIFF
--- a/tools/route-map/route-map-tools.test.mjs
+++ b/tools/route-map/route-map-tools.test.mjs
@@ -61,6 +61,53 @@ test("structured route map contract pins nationwide vector-rendered layers", asy
     "지역별 datapack의 route_map_positions를 우선한다.",
   );
 
+  const lineGeometry = contract.layers.find((layer) => layer.id === "line_geometry");
+  assert.deepEqual(lineGeometry.linearParameter.range, [0, 1]);
+  assert.deepEqual(lineGeometry.linearParameter.directions, ["up", "down"]);
+  assert.equal(lineGeometry.linearParameter.field, "t");
+  assert.ok(
+    /shape_dist_traveled/.test(lineGeometry.linearParameter.basis),
+    "linearParameter must anchor to GTFS shape_dist_traveled 방식",
+  );
+
+  assert.deepEqual(
+    contract.lineStationProgression.requiredFields,
+    ["region", "line_id", "station_id", "direction", "t"],
+  );
+  assert.equal(
+    contract.lineStationProgression.featureId,
+    "{region}:{line_id}:{direction}:{station_id}",
+  );
+  assert.ok(
+    /line path 선형 파라미터만으로 좌표 계산 가능/.test(
+      contract.lineStationProgression.rendererContract,
+    ),
+    "renderer가 line path + 역별 t만으로 좌표를 계산할 수 있어야 함",
+  );
+
+  assert.match(
+    contract.realtimeOverlayHook.joinPath.line,
+    /realtime_provider_line_mappings/,
+  );
+  assert.match(
+    contract.realtimeOverlayHook.joinPath.station,
+    /realtime_provider_station_mappings/,
+  );
+  assert.ok(
+    /datapack 밖/.test(contract.realtimeOverlayHook.payloadLocation),
+    "실시간 payload는 datapack 밖이어야 함",
+  );
+  for (const providerTable of [
+    "realtime_provider_line_mappings",
+    "realtime_provider_station_mappings",
+  ]) {
+    assert.match(
+      schema,
+      new RegExp(`CREATE TABLE ${providerTable} \\(`),
+      `${providerTable} join 대상 테이블이 스키마에 존재해야 함`,
+    );
+  }
+
   const routeMapPositionsTable = schema.match(
     /CREATE TABLE route_map_positions \(([\s\S]*?)\);/,
   );

--- a/tools/route-map/structured-route-map-contract.json
+++ b/tools/route-map/structured-route-map-contract.json
@@ -12,7 +12,14 @@
         { "minZoom": 0, "visible": true, "labelPolicy": "hide_station_labels" },
         { "minZoom": 1, "visible": true, "labelPolicy": "major_transfer_labels" },
         { "minZoom": 2, "visible": true, "labelPolicy": "collision_checked_station_labels" }
-      ]
+      ],
+      "linearParameter": {
+        "field": "t",
+        "range": [0, 1],
+        "basis": "schematic polyline 누적 거리 정규화 (GTFS shape_dist_traveled 방식)",
+        "directions": ["up", "down"],
+        "deriveRule": "방향별 polyline(up_path/down_path)의 시작점 t=0, 끝점 t=1로 두고, 각 정점까지의 누적 거리를 전체 길이로 나눠 t를 계산한다. 렌더러는 t만으로 polyline 위 좌표를 보간한다."
+      }
     },
     {
       "id": "station_nodes",
@@ -62,6 +69,24 @@
     "reviewed_at",
     "updated_at"
   ],
+  "lineStationProgression": {
+    "id": "line_station_progression",
+    "source": ["route_map_positions.up_path", "route_map_positions.down_path", "station_lines"],
+    "featureId": "{region}:{line_id}:{direction}:{station_id}",
+    "requiredFields": ["region", "line_id", "station_id", "direction", "t"],
+    "tRule": "역이 line_geometry polyline 위에서 차지하는 위치를 linearParameter.t(0..1)로 둔다. 방향별(up/down)로 t는 단조 증가한다.",
+    "rendererContract": "열차 overlay는 line path 선형 파라미터만으로 좌표 계산 가능: #1649 렌더러는 line_geometry geometry와 역별 t만으로 노선도 좌표를 계산하며, 별도 좌표 조회 없이 t 보간으로 열차 위치를 그린다."
+  },
+  "realtimeOverlayHook": {
+    "purpose": "실시간 열차 위치 overlay(#1649)를 정적 노선도 위에 온라인 전용 layer로 그린다.",
+    "joinPath": {
+      "line": "realtime_provider_line_mappings(provider_id, provider_line_id) ↔ line_id",
+      "station": "realtime_provider_station_mappings(provider_id, provider_station_id) ↔ (station_id, line_id)"
+    },
+    "coordinateRule": "provider payload 위치를 line_station_progression.t 또는 인접 두 역 사이 t 보간으로 노선도 좌표에 매핑한다. 열차 overlay는 line path 선형 파라미터만으로 좌표 계산이 가능하다.",
+    "payloadLocation": "datapack 밖. pack은 정적 geometry/mapping 계약만 보유하고 실시간 payload 자체는 온라인 provider에서 받는다.",
+    "separationPrinciple": "#1416 분리 원칙: 정적 노선도(pack)와 실시간 overlay(online)를 분리한다."
+  },
   "releaseGate": {
     "allRegionsRequired": true,
     "officialOrReviewedSourceRequired": true,


### PR DESCRIPTION
## Summary
- `#1636`의 남은 미충족 조건인 **1차 스키마 산출물에 실시간 선형 파라미터 포함**을 contract-only 범위로 반영합니다.
- `line_geometry` 레이어에 `linearParameter`(schematic polyline 누적 거리 정규화 `t∈[0,1]`, `up`/`down` 방향, GTFS `shape_dist_traveled` 방식)를 정의합니다.
- `lineStationProgression` 계약을 신설해 역별 `t` 규칙과 "열차 overlay는 line path 선형 파라미터만으로 좌표 계산 가능"이라는 렌더러 계약(#1649)을 명시합니다.
- `realtimeOverlayHook`으로 `realtime_provider_line_mappings`/`realtime_provider_station_mappings` join 경로를 명시하고, 실시간 payload 자체는 datapack 밖(#1416 분리 원칙)임을 고정합니다.
- **`catalog-schema.sql`은 변경하지 않습니다.** 선형 파라미터는 기존 `up_path`/`down_path`에서 파생되는 계약 정의이며, DB 저장 구조 확정은 실제 renderer/datapack ingestion에서 persistence가 필요해지는 별도 이슈로 분리합니다.

## Test Plan
- `node --test tools/route-map/route-map-tools.test.mjs` (25 tests pass)
- 계약 테스트에 `linearParameter` range/directions/field/basis, `lineStationProgression` requiredFields/featureId/rendererContract, `realtimeOverlayHook` join 경로 및 payload 위치, join 대상 테이블 존재 검증 추가
- JSON 유효성 확인

Closes #1636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 노선도에서 선형 진행 위치와 역 위치를 더 정밀하게 표현하도록 계약이 확장되었습니다.
  * 실시간 오버레이의 좌표 매핑 규칙이 추가되어, 노선도 표현이 더 일관되게 동작합니다.

* **버그 수정**
  * 라인 및 역 매핑 정보에 대한 검증이 강화되어, 잘못된 데이터가 더 빨리 감지됩니다.
  * 실시간 페이로드 위치와 렌더링 규칙의 제약이 명확해져 표시 오류 가능성이 줄었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->