### PR TITLE
[Chore] TAGO 시간표 수집 summary 계약 추가 (#1415)

### DIFF
--- a/tools/ci/repository-contract.test.mjs
+++ b/tools/ci/repository-contract.test.mjs
@@ -5760,6 +5760,8 @@ test("TAGO 시간표 후보는 production PLANNED ETA 근거로 자동 승격되
     status: "planned_pilot_collection",
     tool: "tools/datapack/validate-tago-schedule-sample.mjs",
     command: "node tools/datapack/validate-tago-schedule-sample.mjs --plan --input tools/datapack/inputs/capital-pilot-production-source-input.json --daily-limit 1000 --checkpoint <checkpoint.json> --output <plan.json>",
+    summaryCommand: "node tools/datapack/validate-tago-schedule-sample.mjs --summary --input <collection.json> --output <summary.json>",
+    summaryArtifactKind: "tago-schedule-collection-summary",
     input: "tools/datapack/inputs/capital-pilot-production-source-input.json",
     defaultDailyLimit: 1000,
     pilotRequestCount: 12,

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -5,7 +5,10 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import { promisify } from "node:util";
-import { buildTagoScheduleCollectionPlan } from "./validate-tago-schedule-sample.mjs";
+import {
+  buildTagoScheduleCollectionPlan,
+  buildTagoScheduleCollectionSummary,
+} from "./validate-tago-schedule-sample.mjs";
 
 const execFileAsync = promisify(execFile);
 const tagoScheduleToolPath = path.resolve(import.meta.dirname, "validate-tago-schedule-sample.mjs");
@@ -85,3 +88,95 @@ test("TAGO 시간표 수집 plan CLI는 checkpoint와 output을 적용한다", a
     [2, 2, 1],
   );
 });
+
+test("TAGO 시간표 수집 summary는 완료 checkpoint와 evidence hash를 남긴다", () => {
+  const summary = buildTagoScheduleCollectionSummary({
+    responses: [
+      {
+        requestKey: "MTRKR4448|01|U",
+        rawText: tagoResponse("MTRKR4448", "01", "U"),
+      },
+    ],
+  });
+
+  assert.equal(summary.artifactKind, "tago-schedule-collection-summary");
+  assert.deepEqual(summary.completedRequestKeys, ["MTRKR4448|01|U"]);
+  assert.deepEqual(summary.checkpoint, { completedRequestKeys: ["MTRKR4448|01|U"] });
+  assert.equal(summary.rowCount, 2);
+  assert.equal(summary.providerRecordHashes.length, 2);
+  assert.match(summary.rawSha256ByRequest["MTRKR4448|01|U"], /^[0-9a-f]{64}$/);
+  assert.match(summary.evidenceHash, /^[0-9a-f]{64}$/);
+  assert.equal(summary.productionUseAllowed, false);
+});
+
+test("TAGO 시간표 수집 summary는 requestKey와 raw 응답 불일치를 거부한다", () => {
+  assert.throws(
+    () =>
+      buildTagoScheduleCollectionSummary({
+        responses: [
+          {
+            requestKey: "MTRKR4448|01|D",
+            rawText: tagoResponse("MTRKR4448", "01", "U"),
+          },
+        ],
+      }),
+    /response does not match requestKey: MTRKR4448\|01\|D/,
+  );
+});
+
+test("TAGO 시간표 수집 summary CLI는 rawPath 목록에서 checkpoint summary를 생성한다", async (t) => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "tago-summary-"));
+  t.after(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+  const rawPath = path.join(dir, "response.json");
+  const inputPath = path.join(dir, "collection.json");
+  const outputPath = path.join(dir, "summary.json");
+  await writeFile(rawPath, `${tagoResponse("MTRKR4448", "01", "U")}\n`);
+  await writeFile(
+    inputPath,
+    `${JSON.stringify({
+      responses: [{ requestKey: "MTRKR4448|01|U", rawPath }],
+    })}\n`,
+  );
+
+  await execFileAsync(
+    process.execPath,
+    [tagoScheduleToolPath, "--summary", "--input", inputPath, "--output", outputPath],
+    { timeout: 10_000 },
+  );
+
+  const summary = JSON.parse(await readFile(outputPath, "utf8"));
+  assert.deepEqual(summary.checkpoint, { completedRequestKeys: ["MTRKR4448|01|U"] });
+  assert.equal(summary.rowCount, 2);
+});
+
+function tagoResponse(stationId, dailyTypeCode, upDownTypeCode) {
+  return JSON.stringify({
+    response: {
+      header: { resultCode: "00" },
+      body: {
+        items: {
+          item: [
+            tagoRow(stationId, dailyTypeCode, upDownTypeCode, "051000", "051500"),
+            tagoRow(stationId, dailyTypeCode, upDownTypeCode, "052000", "052500"),
+          ],
+        },
+      },
+    },
+  });
+}
+
+function tagoRow(stationId, dailyTypeCode, upDownTypeCode, arrTime, depTime) {
+  return {
+    subwayRouteId: "MTRKR4",
+    subwayStationId: stationId,
+    subwayStationNm: "상록수",
+    dailyTypeCode,
+    upDownTypeCode,
+    arrTime,
+    depTime,
+    endSubwayStationNm: "당고개",
+    endSubwayStationId: "MTRKR409",
+  };
+}

--- a/tools/datapack/plan-tago-schedule-collection.test.mjs
+++ b/tools/datapack/plan-tago-schedule-collection.test.mjs
@@ -124,6 +124,31 @@ test("TAGO 시간표 수집 summary는 requestKey와 raw 응답 불일치를 거
   );
 });
 
+test("TAGO 시간표 수집 summary는 중복 또는 malformed requestKey를 거부한다", () => {
+  assert.throws(
+    () =>
+      buildTagoScheduleCollectionSummary({
+        responses: [
+          { requestKey: "MTRKR4448|01|U", rawText: tagoResponse("MTRKR4448", "01", "U") },
+          { requestKey: "MTRKR4448|01|U", rawText: tagoResponse("MTRKR4448", "01", "U") },
+        ],
+      }),
+    /duplicate requestKey: MTRKR4448\|01\|U/,
+  );
+  assert.throws(
+    () =>
+      buildTagoScheduleCollectionSummary({
+        responses: [
+          {
+            requestKey: "MTRKR4448|01|U|retry",
+            rawText: tagoResponse("MTRKR4448", "01", "U"),
+          },
+        ],
+      }),
+    /response does not match requestKey: MTRKR4448\|01\|U\|retry/,
+  );
+});
+
 test("TAGO 시간표 수집 summary CLI는 rawPath 목록에서 checkpoint summary를 생성한다", async (t) => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "tago-summary-"));
   t.after(async () => {
@@ -136,7 +161,7 @@ test("TAGO 시간표 수집 summary CLI는 rawPath 목록에서 checkpoint summa
   await writeFile(
     inputPath,
     `${JSON.stringify({
-      responses: [{ requestKey: "MTRKR4448|01|U", rawPath }],
+      responses: [{ requestKey: "MTRKR4448|01|U", rawPath: path.basename(rawPath) }],
     })}\n`,
   );
 

--- a/tools/datapack/source-candidates.json
+++ b/tools/datapack/source-candidates.json
@@ -685,6 +685,8 @@
           "status": "planned_pilot_collection",
           "tool": "tools/datapack/validate-tago-schedule-sample.mjs",
           "command": "node tools/datapack/validate-tago-schedule-sample.mjs --plan --input tools/datapack/inputs/capital-pilot-production-source-input.json --daily-limit 1000 --checkpoint <checkpoint.json> --output <plan.json>",
+          "summaryCommand": "node tools/datapack/validate-tago-schedule-sample.mjs --summary --input <collection.json> --output <summary.json>",
+          "summaryArtifactKind": "tago-schedule-collection-summary",
           "input": "tools/datapack/inputs/capital-pilot-production-source-input.json",
           "defaultDailyLimit": 1000,
           "pilotRequestCount": 12,

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -159,10 +159,10 @@ function buildTagoScheduleCollectionSummary(collection) {
   const providerRecordHashes = [];
   let rowCount = 0;
 
+  for (const response of responses) {
+    requestKeyParts(response.requestKey);
+  }
   for (const response of [...responses].sort((left, right) => left.requestKey.localeCompare(right.requestKey))) {
-    if (typeof response.requestKey !== "string" || response.requestKey.length === 0) {
-      throw new Error("responses.requestKey is required");
-    }
     if (completedRequestKeys.includes(response.requestKey)) {
       throw new Error(`duplicate requestKey: ${response.requestKey}`);
     }
@@ -202,11 +202,8 @@ function buildTagoScheduleCollectionSummary(collection) {
 }
 
 function assertResponseMatchesRequestKey(validation, requestKey) {
-  const [stationId, dailyTypeCode, upDownTypeCode] = requestKey.split("|");
+  const [stationId, dailyTypeCode, upDownTypeCode] = requestKeyParts(requestKey);
   if (
-    !stationId ||
-    !dailyTypeCode ||
-    !upDownTypeCode ||
     validation.departures.some(
       (row) =>
         row.subwayStationId !== stationId ||
@@ -216,6 +213,17 @@ function assertResponseMatchesRequestKey(validation, requestKey) {
   ) {
     throw new Error(`response does not match requestKey: ${requestKey}`);
   }
+}
+
+function requestKeyParts(requestKey) {
+  if (typeof requestKey !== "string" || requestKey.length === 0) {
+    throw new Error("responses.requestKey is required");
+  }
+  const parts = requestKey.split("|");
+  if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+    throw new Error(`response does not match requestKey: ${requestKey}`);
+  }
+  return parts;
 }
 
 function tagoStationIds(input) {

--- a/tools/datapack/validate-tago-schedule-sample.mjs
+++ b/tools/datapack/validate-tago-schedule-sample.mjs
@@ -30,8 +30,8 @@ function parseArgs(argv) {
     if (!flag.startsWith("--")) {
       throw new Error(`unexpected argument: ${flag}`);
     }
-    if (flag === "--plan") {
-      args.plan = true;
+    if (flag === "--plan" || flag === "--summary") {
+      args[flag.slice(2)] = true;
       continue;
     }
     if (!value || value.startsWith("--")) {
@@ -149,6 +149,75 @@ function buildTagoScheduleCollectionPlan(input, checkpoint = {}, dailyLimit = 10
   };
 }
 
+function buildTagoScheduleCollectionSummary(collection) {
+  const responses = collection?.responses;
+  if (!Array.isArray(responses) || responses.length === 0) {
+    throw new Error("responses must be a non-empty array");
+  }
+  const completedRequestKeys = [];
+  const rawSha256ByRequest = {};
+  const providerRecordHashes = [];
+  let rowCount = 0;
+
+  for (const response of [...responses].sort((left, right) => left.requestKey.localeCompare(right.requestKey))) {
+    if (typeof response.requestKey !== "string" || response.requestKey.length === 0) {
+      throw new Error("responses.requestKey is required");
+    }
+    if (completedRequestKeys.includes(response.requestKey)) {
+      throw new Error(`duplicate requestKey: ${response.requestKey}`);
+    }
+    if (typeof response.rawText !== "string" || response.rawText.length === 0) {
+      throw new Error(`responses.rawText is required: ${response.requestKey}`);
+    }
+    const validation = validateTagoScheduleSample(response.rawText);
+    assertResponseMatchesRequestKey(validation, response.requestKey);
+    completedRequestKeys.push(response.requestKey);
+    rawSha256ByRequest[response.requestKey] = validation.rawSha256;
+    providerRecordHashes.push(...validation.providerRecordHashes);
+    rowCount += validation.rowCount;
+  }
+
+  const evidencePayload = {
+    sourceId: "molit-tago-subway-info",
+    endpoint: TAGO_SCHEDULE_ENDPOINT,
+    completedRequestKeys,
+    rawSha256ByRequest,
+    providerRecordHashes,
+  };
+  return {
+    artifactKind: "tago-schedule-collection-summary",
+    sourceId: evidencePayload.sourceId,
+    endpoint: evidencePayload.endpoint,
+    completedRequestKeys,
+    checkpoint: { completedRequestKeys },
+    responseCount: completedRequestKeys.length,
+    rowCount,
+    rawSha256ByRequest,
+    providerRecordHashes,
+    evidenceHash: sha256(JSON.stringify(evidencePayload)),
+    stationLevelOnly: true,
+    productionUseAllowed: false,
+    remainingAdmissionBlocker: "line_wide_trip_stop_sequence_validation_required",
+  };
+}
+
+function assertResponseMatchesRequestKey(validation, requestKey) {
+  const [stationId, dailyTypeCode, upDownTypeCode] = requestKey.split("|");
+  if (
+    !stationId ||
+    !dailyTypeCode ||
+    !upDownTypeCode ||
+    validation.departures.some(
+      (row) =>
+        row.subwayStationId !== stationId ||
+        row.dailyTypeCode !== dailyTypeCode ||
+        row.upDownTypeCode !== upDownTypeCode,
+    )
+  ) {
+    throw new Error(`response does not match requestKey: ${requestKey}`);
+  }
+}
+
 function tagoStationIds(input) {
   const stationIds = new Set();
   for (const row of input.stationLineRows ?? []) {
@@ -240,6 +309,20 @@ async function main() {
     const checkpoint = args.checkpoint ? JSON.parse(await readFile(path.resolve(args.checkpoint), "utf8")) : {};
     const dailyLimit = args["daily-limit"] === undefined ? undefined : Number(args["daily-limit"]);
     result = buildTagoScheduleCollectionPlan(JSON.parse(await readFile(inputPath, "utf8")), checkpoint, dailyLimit);
+  } else if (args.summary) {
+    const input = JSON.parse(await readFile(inputPath, "utf8"));
+    const inputDir = path.dirname(inputPath);
+    result = buildTagoScheduleCollectionSummary({
+      ...input,
+      responses: await Promise.all(
+        (input.responses ?? []).map(async (response) => ({
+          ...response,
+          rawText:
+            response.rawText ??
+            (await readFile(path.resolve(inputDir, requiredString(response.rawPath, "responses.rawPath")), "utf8")),
+        })),
+      ),
+    });
   } else {
     result = validateTagoScheduleSample(await readFile(inputPath, "utf8"));
   }
@@ -249,7 +332,14 @@ async function main() {
   console.log(JSON.stringify(result, null, 2));
 }
 
-export { buildTagoScheduleCollectionPlan, validateTagoScheduleSample };
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} is required`);
+  }
+  return value;
+}
+
+export { buildTagoScheduleCollectionPlan, buildTagoScheduleCollectionSummary, validateTagoScheduleSample };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error) => {


### PR DESCRIPTION
## 관련 이슈

Refs #1415
Refs #1414

## 작업 배경

- TAGO 시간표 pilot 수집은 plan/checkpoint 계약은 있지만, provider raw 응답들을 완료 checkpoint와 hash summary로 묶는 산출물 계약이 없었다.

## 작업 내용

- `validate-tago-schedule-sample.mjs`에 TAGO 수집 summary builder와 `--summary` CLI를 추가했다.
- summary는 raw 응답을 싣지 않고 `completedRequestKeys`, raw SHA-256, provider record hashes, evidence hash만 남긴다.
- `molit-tago-subway-info` candidate metadata에 summary 생성 명령과 artifact kind를 고정했다.

## 검증

- 실행한 명령과 결과:
  - `node --test --test-name-pattern "TAGO 시간표 후보" tools/ci/repository-contract.test.mjs` 통과
  - `node --test tools/datapack/plan-tago-schedule-collection.test.mjs` 통과, 6 passed
  - `node --test tools/ci/repository-contract.test.mjs` 통과, 158 passed
  - `node --test tools/datapack/datapack-tools.test.mjs` 통과, 181 passed
  - `git diff --check` 통과

## 검증 증거

UI, 접근성, 수동 QA, 배포 확인이 필요한 항목은 증거 첨부, 링크, 또는 로컬 evidence 경로를 적습니다. 증거가 필요 없는 항목은 사유를 적습니다.

| 항목 | 플랫폼 | 확인 방법 | 증거 | 결과 |
| --- | --- | --- | --- | --- |
| TAGO 수집 summary 계약 | repository | node test | 터미널 출력 | 통과 |
| UI/접근성 | 해당 없음 | 도구/metadata 변경만 있음 | 증거 불필요: 화면 변경 없음 | 해당 없음 |

## Version impact

- [x] no version change
- [ ] mobile patch
- [ ] mobile minor
- [ ] mobile major
- [ ] backend deploy only
- [ ] datapack release only
- [x] route/realtime contract change
- [ ] DB migration change

## Route commercialization gate impact

- [x] route-commercialization-gate.json 영향 없음
- [ ] route ETA accuracy, realtime coverage, accessibility regression, route v2 contract report를 갱신했다.
- [x] 상용 경로/ETA claim을 추가하거나 변경하지 않는다.

## Route release readiness tracker impact

- [ ] route-release-readiness-tracker.json 영향 없음
- [x] #1414 하위 release blocker issue 또는 production evidence 완료 조건을 갱신했다.
- [x] 실시간/교통약자 길찾기 출시 준비 완료 claim을 추가하거나 변경하지 않는다.

### Version decision

- mobile versionName: 변경 없음
- mobile versionCode: 변경 없음
- datapack version: 변경 없음
- route contract: TAGO 수집 summary artifact 계약 추가
- realtime contract: 변경 없음
- backend identity: 변경 없음

## 리뷰어 메모

- 리뷰어가 먼저 봐야 할 지점: `tools/datapack/validate-tago-schedule-sample.mjs`의 `--summary` 분기와 raw 응답 미포함 여부

## 리스크

- 실제 provider 호출은 수행하지 않는다. 운영계정 전환 전까지 production schedule use는 계속 차단된다.

## 체크리스트

- [x] PR 본문은 이 템플릿 섹션을 삭제하지 않고 모두 채웠다.
- [ ] CI 결과를 확인했다.
- [ ] CodeRabbit 리뷰를 확인했다.
- [ ] GitHub PR Review 객체가 있는지 확인했다. CodeRabbit status check만으로는 리뷰 완료로 보지 않는다.
- [ ] CodeRabbit 실행이 불가능하거나 PR Review 객체가 없으면 Codex CLI code review를 단일 PR review로 게시했다.
- [ ] 배포 영향이 있는 경우 CD 상태를 확인했다.
